### PR TITLE
Split large DuckDB amalgamated file - part 2

### DIFF
--- a/velox/external/duckdb/duckdb-1.cpp
+++ b/velox/external/duckdb/duckdb-1.cpp
@@ -1,0 +1,16259 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+string SimilarCatalogEntry::GetQualifiedName() const {
+	D_ASSERT(Found());
+
+	return schema->name + "." + name;
+}
+
+Catalog::Catalog(DatabaseInstance &db)
+    : db(db), schemas(make_unique<CatalogSet>(*this, make_unique<DefaultSchemaGenerator>(*this))),
+      dependency_manager(make_unique<DependencyManager>(*this)) {
+	catalog_version = 0;
+}
+Catalog::~Catalog() {
+}
+
+Catalog &Catalog::GetCatalog(ClientContext &context) {
+	return context.db->GetCatalog();
+}
+
+CatalogEntry *Catalog::CreateTable(ClientContext &context, BoundCreateTableInfo *info) {
+	auto schema = GetSchema(context, info->base->schema);
+	return CreateTable(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateTable(ClientContext &context, unique_ptr<CreateTableInfo> info) {
+	auto binder = Binder::CreateBinder(context);
+	auto bound_info = binder->BindCreateTableInfo(move(info));
+	return CreateTable(context, bound_info.get());
+}
+
+CatalogEntry *Catalog::CreateTable(ClientContext &context, SchemaCatalogEntry *schema, BoundCreateTableInfo *info) {
+	return schema->CreateTable(context, info);
+}
+
+CatalogEntry *Catalog::CreateView(ClientContext &context, CreateViewInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateView(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateView(ClientContext &context, SchemaCatalogEntry *schema, CreateViewInfo *info) {
+	return schema->CreateView(context, info);
+}
+
+CatalogEntry *Catalog::CreateSequence(ClientContext &context, CreateSequenceInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateSequence(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateType(ClientContext &context, CreateTypeInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateType(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateSequence(ClientContext &context, SchemaCatalogEntry *schema, CreateSequenceInfo *info) {
+	return schema->CreateSequence(context, info);
+}
+
+CatalogEntry *Catalog::CreateType(ClientContext &context, SchemaCatalogEntry *schema, CreateTypeInfo *info) {
+	return schema->CreateType(context, info);
+}
+
+CatalogEntry *Catalog::CreateTableFunction(ClientContext &context, CreateTableFunctionInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateTableFunction(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateTableFunction(ClientContext &context, SchemaCatalogEntry *schema,
+                                           CreateTableFunctionInfo *info) {
+	return schema->CreateTableFunction(context, info);
+}
+
+CatalogEntry *Catalog::CreateCopyFunction(ClientContext &context, CreateCopyFunctionInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateCopyFunction(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateCopyFunction(ClientContext &context, SchemaCatalogEntry *schema,
+                                          CreateCopyFunctionInfo *info) {
+	return schema->CreateCopyFunction(context, info);
+}
+
+CatalogEntry *Catalog::CreatePragmaFunction(ClientContext &context, CreatePragmaFunctionInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreatePragmaFunction(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreatePragmaFunction(ClientContext &context, SchemaCatalogEntry *schema,
+                                            CreatePragmaFunctionInfo *info) {
+	return schema->CreatePragmaFunction(context, info);
+}
+
+CatalogEntry *Catalog::CreateFunction(ClientContext &context, CreateFunctionInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateFunction(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateFunction(ClientContext &context, SchemaCatalogEntry *schema, CreateFunctionInfo *info) {
+	return schema->CreateFunction(context, info);
+}
+
+CatalogEntry *Catalog::CreateCollation(ClientContext &context, CreateCollationInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return CreateCollation(context, schema, info);
+}
+
+CatalogEntry *Catalog::CreateCollation(ClientContext &context, SchemaCatalogEntry *schema, CreateCollationInfo *info) {
+	return schema->CreateCollation(context, info);
+}
+
+CatalogEntry *Catalog::CreateSchema(ClientContext &context, CreateSchemaInfo *info) {
+	D_ASSERT(!info->schema.empty());
+	if (info->schema == TEMP_SCHEMA) {
+		throw CatalogException("Cannot create built-in schema \"%s\"", info->schema);
+	}
+
+	unordered_set<CatalogEntry *> dependencies;
+	auto entry = make_unique<SchemaCatalogEntry>(this, info->schema, info->internal);
+	auto result = entry.get();
+	if (!schemas->CreateEntry(context, info->schema, move(entry), dependencies)) {
+		if (info->on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
+			throw CatalogException("Schema with name %s already exists!", info->schema);
+		} else {
+			D_ASSERT(info->on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT);
+		}
+		return nullptr;
+	}
+	return result;
+}
+
+void Catalog::DropSchema(ClientContext &context, DropInfo *info) {
+	D_ASSERT(!info->name.empty());
+	ModifyCatalog();
+	if (!schemas->DropEntry(context, info->name, info->cascade)) {
+		if (!info->if_exists) {
+			throw CatalogException("Schema with name \"%s\" does not exist!", info->name);
+		}
+	}
+}
+
+void Catalog::DropEntry(ClientContext &context, DropInfo *info) {
+	ModifyCatalog();
+	if (info->type == CatalogType::SCHEMA_ENTRY) {
+		// DROP SCHEMA
+		DropSchema(context, info);
+		return;
+	}
+
+	auto lookup = LookupEntry(context, info->type, info->schema, info->name, info->if_exists);
+	if (!lookup.Found()) {
+		return;
+	}
+
+	lookup.schema->DropEntry(context, info);
+}
+
+CatalogEntry *Catalog::AddFunction(ClientContext &context, CreateFunctionInfo *info) {
+	auto schema = GetSchema(context, info->schema);
+	return AddFunction(context, schema, info);
+}
+
+CatalogEntry *Catalog::AddFunction(ClientContext &context, SchemaCatalogEntry *schema, CreateFunctionInfo *info) {
+	return schema->AddFunction(context, info);
+}
+
+SchemaCatalogEntry *Catalog::GetSchema(ClientContext &context, const string &schema_name, bool if_exists,
+                                       QueryErrorContext error_context) {
+	D_ASSERT(!schema_name.empty());
+	if (schema_name == TEMP_SCHEMA) {
+		return ClientData::Get(context).temporary_objects.get();
+	}
+	auto entry = schemas->GetEntry(context, schema_name);
+	if (!entry && !if_exists) {
+		throw CatalogException(error_context.FormatError("Schema with name %s does not exist!", schema_name));
+	}
+	return (SchemaCatalogEntry *)entry;
+}
+
+void Catalog::ScanSchemas(ClientContext &context, std::function<void(CatalogEntry *)> callback) {
+	// create all default schemas first
+	schemas->Scan(context, [&](CatalogEntry *entry) { callback(entry); });
+}
+
+SimilarCatalogEntry Catalog::SimilarEntryInSchemas(ClientContext &context, const string &entry_name, CatalogType type,
+                                                   const vector<SchemaCatalogEntry *> &schemas) {
+
+	vector<CatalogSet *> sets;
+	std::transform(schemas.begin(), schemas.end(), std::back_inserter(sets),
+	               [type](SchemaCatalogEntry *s) -> CatalogSet * { return &s->GetCatalogSet(type); });
+	pair<string, idx_t> most_similar {"", (idx_t)-1};
+	SchemaCatalogEntry *schema_of_most_similar = nullptr;
+	for (auto schema : schemas) {
+		auto entry = schema->GetCatalogSet(type).SimilarEntry(context, entry_name);
+		if (!entry.first.empty() && (most_similar.first.empty() || most_similar.second > entry.second)) {
+			most_similar = entry;
+			schema_of_most_similar = schema;
+		}
+	}
+
+	return {most_similar.first, most_similar.second, schema_of_most_similar};
+}
+
+CatalogException Catalog::CreateMissingEntryException(ClientContext &context, const string &entry_name,
+                                                      CatalogType type, const vector<SchemaCatalogEntry *> &schemas,
+                                                      QueryErrorContext error_context) {
+	auto entry = SimilarEntryInSchemas(context, entry_name, type, schemas);
+
+	vector<SchemaCatalogEntry *> unseen_schemas;
+	this->schemas->Scan([&schemas, &unseen_schemas](CatalogEntry *entry) {
+		auto schema_entry = (SchemaCatalogEntry *)entry;
+		if (std::find(schemas.begin(), schemas.end(), schema_entry) == schemas.end()) {
+			unseen_schemas.emplace_back(schema_entry);
+		}
+	});
+	auto unseen_entry = SimilarEntryInSchemas(context, entry_name, type, unseen_schemas);
+
+	string did_you_mean;
+	if (unseen_entry.Found() && unseen_entry.distance < entry.distance) {
+		did_you_mean = "\nDid you mean \"" + unseen_entry.GetQualifiedName() + "\"?";
+	} else if (entry.Found()) {
+		did_you_mean = "\nDid you mean \"" + entry.name + "\"?";
+	}
+
+	return CatalogException(error_context.FormatError("%s with name %s does not exist!%s", CatalogTypeToString(type),
+	                                                  entry_name, did_you_mean));
+}
+
+CatalogEntryLookup Catalog::LookupEntry(ClientContext &context, CatalogType type, const string &schema_name,
+                                        const string &name, bool if_exists, QueryErrorContext error_context) {
+	if (!schema_name.empty()) {
+		auto schema = GetSchema(context, schema_name, if_exists, error_context);
+		if (!schema) {
+			D_ASSERT(if_exists);
+			return {nullptr, nullptr};
+		}
+
+		auto entry = schema->GetCatalogSet(type).GetEntry(context, name);
+		if (!entry && !if_exists) {
+			throw CreateMissingEntryException(context, name, type, {schema}, error_context);
+		}
+
+		return {schema, entry};
+	}
+
+	const auto &paths = ClientData::Get(context).catalog_search_path->Get();
+	for (const auto &path : paths) {
+		auto lookup = LookupEntry(context, type, path, name, true, error_context);
+		if (lookup.Found()) {
+			return lookup;
+		}
+	}
+
+	if (!if_exists) {
+		vector<SchemaCatalogEntry *> schemas;
+		for (const auto &path : paths) {
+			auto schema = GetSchema(context, path, true);
+			if (schema) {
+				schemas.emplace_back(schema);
+			}
+		}
+
+		throw CreateMissingEntryException(context, name, type, schemas, error_context);
+	}
+
+	return {nullptr, nullptr};
+}
+
+CatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema, const string &name) {
+	vector<CatalogType> entry_types {CatalogType::TABLE_ENTRY, CatalogType::SEQUENCE_ENTRY};
+
+	for (auto entry_type : entry_types) {
+		CatalogEntry *result = GetEntry(context, entry_type, schema, name, true);
+		if (result != nullptr) {
+			return result;
+		}
+	}
+
+	throw CatalogException("CatalogElement \"%s.%s\" does not exist!", schema, name);
+}
+
+CatalogEntry *Catalog::GetEntry(ClientContext &context, CatalogType type, const string &schema_name, const string &name,
+                                bool if_exists, QueryErrorContext error_context) {
+	return LookupEntry(context, type, schema_name, name, if_exists, error_context).entry;
+}
+
+template <>
+TableCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                     bool if_exists, QueryErrorContext error_context) {
+	auto entry = GetEntry(context, CatalogType::TABLE_ENTRY, schema_name, name, if_exists);
+	if (!entry) {
+		return nullptr;
+	}
+	if (entry->type != CatalogType::TABLE_ENTRY) {
+		throw CatalogException(error_context.FormatError("%s is not a table", name));
+	}
+	return (TableCatalogEntry *)entry;
+}
+
+template <>
+SequenceCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                        bool if_exists, QueryErrorContext error_context) {
+	return (SequenceCatalogEntry *)GetEntry(context, CatalogType::SEQUENCE_ENTRY, schema_name, name, if_exists,
+	                                        error_context);
+}
+
+template <>
+TableFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                             bool if_exists, QueryErrorContext error_context) {
+	return (TableFunctionCatalogEntry *)GetEntry(context, CatalogType::TABLE_FUNCTION_ENTRY, schema_name, name,
+	                                             if_exists, error_context);
+}
+
+template <>
+CopyFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                            bool if_exists, QueryErrorContext error_context) {
+	return (CopyFunctionCatalogEntry *)GetEntry(context, CatalogType::COPY_FUNCTION_ENTRY, schema_name, name, if_exists,
+	                                            error_context);
+}
+
+template <>
+PragmaFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                              bool if_exists, QueryErrorContext error_context) {
+	return (PragmaFunctionCatalogEntry *)GetEntry(context, CatalogType::PRAGMA_FUNCTION_ENTRY, schema_name, name,
+	                                              if_exists, error_context);
+}
+
+template <>
+AggregateFunctionCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                                 bool if_exists, QueryErrorContext error_context) {
+	auto entry = GetEntry(context, CatalogType::AGGREGATE_FUNCTION_ENTRY, schema_name, name, if_exists, error_context);
+	if (entry->type != CatalogType::AGGREGATE_FUNCTION_ENTRY) {
+		throw CatalogException(error_context.FormatError("%s is not an aggregate function", name));
+	}
+	return (AggregateFunctionCatalogEntry *)entry;
+}
+
+template <>
+CollateCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                       bool if_exists, QueryErrorContext error_context) {
+	return (CollateCatalogEntry *)GetEntry(context, CatalogType::COLLATION_ENTRY, schema_name, name, if_exists,
+	                                       error_context);
+}
+
+template <>
+TypeCatalogEntry *Catalog::GetEntry(ClientContext &context, const string &schema_name, const string &name,
+                                    bool if_exists, QueryErrorContext error_context) {
+	return (TypeCatalogEntry *)GetEntry(context, CatalogType::TYPE_ENTRY, schema_name, name, if_exists, error_context);
+}
+
+LogicalType Catalog::GetType(ClientContext &context, const string &schema, const string &name) {
+	auto user_type_catalog = GetEntry<TypeCatalogEntry>(context, schema, name);
+	auto result_type = user_type_catalog->user_type;
+	LogicalType::SetCatalog(result_type, user_type_catalog);
+	return result_type;
+}
+
+void Catalog::Alter(ClientContext &context, AlterInfo *info) {
+	ModifyCatalog();
+	auto lookup = LookupEntry(context, info->GetCatalogType(), info->schema, info->name);
+	D_ASSERT(lookup.Found()); // It must have thrown otherwise.
+	return lookup.schema->Alter(context, info);
+}
+
+idx_t Catalog::GetCatalogVersion() {
+	return catalog_version;
+}
+
+idx_t Catalog::ModifyCatalog() {
+	return catalog_version++;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+ColumnDependencyManager::ColumnDependencyManager() {
+}
+
+ColumnDependencyManager::~ColumnDependencyManager() {
+}
+
+void ColumnDependencyManager::AddGeneratedColumn(const ColumnDefinition &column,
+                                                 const case_insensitive_map_t<column_t> &name_map) {
+	D_ASSERT(column.Generated());
+	vector<string> referenced_columns;
+	column.GetListOfDependencies(referenced_columns);
+	vector<column_t> indices;
+	for (auto &col : referenced_columns) {
+		auto entry = name_map.find(col);
+		if (entry == name_map.end()) {
+			throw InvalidInputException("Referenced column \"%s\" was not found in the table", col);
+		}
+		indices.push_back(entry->second);
+	}
+	return AddGeneratedColumn(column.Oid(), indices);
+}
+
+void ColumnDependencyManager::AddGeneratedColumn(column_t index, const vector<column_t> &indices, bool root) {
+	if (indices.empty()) {
+		return;
+	}
+	auto &list = dependents_map[index];
+	// Create a link between the dependencies
+	for (auto &dep : indices) {
+		// Add this column as a dependency of the new column
+		list.insert(dep);
+		// Add the new column as a dependent of the column
+		dependencies_map[dep].insert(index);
+		// Inherit the dependencies
+		if (HasDependencies(dep)) {
+			auto &inherited_deps = dependents_map[dep];
+			D_ASSERT(!inherited_deps.empty());
+			for (auto &inherited_dep : inherited_deps) {
+				list.insert(inherited_dep);
+				dependencies_map[inherited_dep].insert(index);
+			}
+		}
+		if (!root) {
+			continue;
+		}
+		direct_dependencies[index].insert(dep);
+	}
+	if (!HasDependents(index)) {
+		return;
+	}
+	auto &dependents = dependencies_map[index];
+	if (dependents.count(index)) {
+		throw InvalidInputException("Circular dependency encountered when resolving generated column expressions");
+	}
+	// Also let the dependents of this generated column inherit the dependencies
+	for (auto &dependent : dependents) {
+		AddGeneratedColumn(dependent, indices, false);
+	}
+}
+
+vector<column_t> ColumnDependencyManager::RemoveColumn(column_t index, column_t column_amount) {
+	// Always add the initial column
+	deleted_columns.insert(index);
+
+	RemoveGeneratedColumn(index);
+	RemoveStandardColumn(index);
+
+	// Clean up the internal list
+	vector<column_t> new_indices = CleanupInternals(column_amount);
+	D_ASSERT(deleted_columns.empty());
+	return new_indices;
+}
+
+bool ColumnDependencyManager::IsDependencyOf(column_t gcol, column_t col) const {
+	auto entry = dependents_map.find(gcol);
+	if (entry == dependents_map.end()) {
+		return false;
+	}
+	auto &list = entry->second;
+	return list.count(col);
+}
+
+bool ColumnDependencyManager::HasDependencies(column_t index) const {
+	auto entry = dependents_map.find(index);
+	if (entry == dependents_map.end()) {
+		return false;
+	}
+	return true;
+}
+
+const unordered_set<column_t> &ColumnDependencyManager::GetDependencies(column_t index) const {
+	auto entry = dependents_map.find(index);
+	D_ASSERT(entry != dependents_map.end());
+	return entry->second;
+}
+
+bool ColumnDependencyManager::HasDependents(column_t index) const {
+	auto entry = dependencies_map.find(index);
+	if (entry == dependencies_map.end()) {
+		return false;
+	}
+	return true;
+}
+
+const unordered_set<column_t> &ColumnDependencyManager::GetDependents(column_t index) const {
+	auto entry = dependencies_map.find(index);
+	D_ASSERT(entry != dependencies_map.end());
+	return entry->second;
+}
+
+void ColumnDependencyManager::RemoveStandardColumn(column_t index) {
+	if (!HasDependents(index)) {
+		return;
+	}
+	auto dependents = dependencies_map[index];
+	for (auto &gcol : dependents) {
+		// If index is a direct dependency of gcol, remove it from the list
+		if (direct_dependencies.find(gcol) != direct_dependencies.end()) {
+			direct_dependencies[gcol].erase(index);
+		}
+		RemoveGeneratedColumn(gcol);
+	}
+	// Remove this column from the dependencies map
+	dependencies_map.erase(index);
+}
+
+void ColumnDependencyManager::RemoveGeneratedColumn(column_t index) {
+	deleted_columns.insert(index);
+	if (!HasDependencies(index)) {
+		return;
+	}
+	auto &dependencies = dependents_map[index];
+	for (auto &col : dependencies) {
+		// Remove this generated column from the list of this column
+		auto &col_dependents = dependencies_map[col];
+		D_ASSERT(col_dependents.count(index));
+		col_dependents.erase(index);
+		// If the resulting list is empty, remove the column from the dependencies map altogether
+		if (col_dependents.empty()) {
+			dependencies_map.erase(col);
+		}
+	}
+	// Remove this column from the dependents_map map
+	dependents_map.erase(index);
+}
+
+void ColumnDependencyManager::AdjustSingle(column_t idx, idx_t offset) {
+	D_ASSERT(idx >= offset);
+	column_t new_idx = idx - offset;
+	// Adjust this index in the dependents of this column
+	bool has_dependents = HasDependents(idx);
+	bool has_dependencies = HasDependencies(idx);
+
+	if (has_dependents) {
+		auto &dependents = GetDependents(idx);
+		for (auto &dep : dependents) {
+			auto &dep_dependencies = dependents_map[dep];
+			dep_dependencies.erase(idx);
+			D_ASSERT(!dep_dependencies.count(new_idx));
+			dep_dependencies.insert(new_idx);
+		}
+	}
+	if (has_dependencies) {
+		auto &dependencies = GetDependencies(idx);
+		for (auto &dep : dependencies) {
+			auto &dep_dependents = dependencies_map[dep];
+			dep_dependents.erase(idx);
+			D_ASSERT(!dep_dependents.count(new_idx));
+			dep_dependents.insert(new_idx);
+		}
+	}
+	if (has_dependents) {
+		D_ASSERT(!dependencies_map.count(new_idx));
+		dependencies_map[new_idx] = move(dependencies_map[idx]);
+		dependencies_map.erase(idx);
+	}
+	if (has_dependencies) {
+		D_ASSERT(!dependents_map.count(new_idx));
+		dependents_map[new_idx] = move(dependents_map[idx]);
+		dependents_map.erase(idx);
+	}
+}
+
+vector<column_t> ColumnDependencyManager::CleanupInternals(column_t column_amount) {
+	vector<column_t> to_adjust;
+	D_ASSERT(!deleted_columns.empty());
+	// Get the lowest index that was deleted
+	vector<column_t> new_indices(column_amount, DConstants::INVALID_INDEX);
+	column_t threshold = *deleted_columns.begin();
+
+	idx_t offset = 0;
+	for (column_t i = 0; i < column_amount; i++) {
+		new_indices[i] = i - offset;
+		if (deleted_columns.count(i)) {
+			offset++;
+			continue;
+		}
+		if (i > threshold && (HasDependencies(i) || HasDependents(i))) {
+			to_adjust.push_back(i);
+		}
+	}
+
+	// Adjust all indices inside the dependency managers internal mappings
+	for (auto &col : to_adjust) {
+		offset = col - new_indices[col];
+		AdjustSingle(col, offset);
+	}
+	deleted_columns.clear();
+	return new_indices;
+}
+
+stack<column_t> ColumnDependencyManager::GetBindOrder(const vector<ColumnDefinition> &columns) {
+	stack<column_t> bind_order;
+	queue<column_t> to_visit;
+	unordered_set<column_t> visited;
+
+	for (auto &entry : direct_dependencies) {
+		auto dependent = entry.first;
+		//! Skip the dependents that are also dependencies
+		if (dependencies_map.find(dependent) != dependencies_map.end()) {
+			continue;
+		}
+		bind_order.push(dependent);
+		visited.insert(dependent);
+		for (auto &dependency : direct_dependencies[dependent]) {
+			to_visit.push(dependency);
+		}
+	}
+
+	while (!to_visit.empty()) {
+		auto column = to_visit.front();
+		to_visit.pop();
+
+		//! If this column does not have dependencies, the queue stops getting filled
+		if (direct_dependencies.find(column) == direct_dependencies.end()) {
+			continue;
+		}
+		bind_order.push(column);
+		visited.insert(column);
+
+		for (auto &dependency : direct_dependencies[column]) {
+			to_visit.push(dependency);
+		}
+	}
+
+	// Add generated columns that have no dependencies, but still might need to have their type resolved
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto &col = columns[i];
+		// Not a generated column
+		if (!col.Generated()) {
+			continue;
+		}
+		// Already added to the bind_order stack
+		if (visited.count(i)) {
+			continue;
+		}
+		bind_order.push(i);
+	}
+
+	return bind_order;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+CopyFunctionCatalogEntry::CopyFunctionCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema,
+                                                   CreateCopyFunctionInfo *info)
+    : StandardEntry(CatalogType::COPY_FUNCTION_ENTRY, schema, catalog, info->name), function(info->function) {
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+IndexCatalogEntry::IndexCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateIndexInfo *info)
+    : StandardEntry(CatalogType::INDEX_ENTRY, schema, catalog, info->index_name), index(nullptr), sql(info->sql) {
+}
+
+IndexCatalogEntry::~IndexCatalogEntry() {
+	// remove the associated index from the info
+	if (!info || !index) {
+		return;
+	}
+	info->indexes.RemoveIndex(index);
+}
+
+string IndexCatalogEntry::ToSQL() {
+	if (sql.empty()) {
+		throw InternalException("Cannot convert INDEX to SQL because it was not created with a SQL statement");
+	}
+	if (sql[sql.size() - 1] != ';') {
+		sql += ";";
+	}
+	return sql;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PragmaFunctionCatalogEntry::PragmaFunctionCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema,
+                                                       CreatePragmaFunctionInfo *info)
+    : StandardEntry(CatalogType::PRAGMA_FUNCTION_ENTRY, schema, catalog, info->name), functions(move(info->functions)) {
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+MacroCatalogEntry::MacroCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateMacroInfo *info)
+    : StandardEntry(
+          (info->function->type == MacroType::SCALAR_MACRO ? CatalogType::MACRO_ENTRY : CatalogType::TABLE_MACRO_ENTRY),
+          schema, catalog, info->name),
+      function(move(info->function)) {
+	this->temporary = info->temporary;
+	this->internal = info->internal;
+}
+
+ScalarMacroCatalogEntry::ScalarMacroCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateMacroInfo *info)
+    : MacroCatalogEntry(catalog, schema, info) {
+}
+
+void ScalarMacroCatalogEntry::Serialize(Serializer &main_serializer) {
+	D_ASSERT(!internal);
+	auto &scalar_function = (ScalarMacroFunction &)*function;
+	FieldWriter writer(main_serializer);
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteSerializable(*scalar_function.expression);
+	// writer.WriteSerializableList(function->parameters);
+	writer.WriteSerializableList(function->parameters);
+	writer.WriteField<uint32_t>((uint32_t)function->default_parameters.size());
+	auto &serializer = writer.GetSerializer();
+	for (auto &kv : function->default_parameters) {
+		serializer.WriteString(kv.first);
+		kv.second->Serialize(serializer);
+	}
+	writer.Finalize();
+}
+
+unique_ptr<CreateMacroInfo> ScalarMacroCatalogEntry::Deserialize(Deserializer &main_source) {
+	auto info = make_unique<CreateMacroInfo>(CatalogType::MACRO_ENTRY);
+	FieldReader reader(main_source);
+	info->schema = reader.ReadRequired<string>();
+	info->name = reader.ReadRequired<string>();
+	auto expression = reader.ReadRequiredSerializable<ParsedExpression>();
+	auto func = make_unique<ScalarMacroFunction>(move(expression));
+	info->function = move(func);
+	info->function->parameters = reader.ReadRequiredSerializableList<ParsedExpression>();
+	auto default_param_count = reader.ReadRequired<uint32_t>();
+	auto &source = reader.GetSource();
+	for (idx_t i = 0; i < default_param_count; i++) {
+		auto name = source.Read<string>();
+		info->function->default_parameters[name] = ParsedExpression::Deserialize(source);
+	}
+	// dont like this
+	// info->type=CatalogType::MACRO_ENTRY;
+	reader.Finalize();
+	return info;
+}
+
+TableMacroCatalogEntry::TableMacroCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateMacroInfo *info)
+    : MacroCatalogEntry(catalog, schema, info) {
+}
+
+void TableMacroCatalogEntry::Serialize(Serializer &main_serializer) {
+	D_ASSERT(!internal);
+	FieldWriter writer(main_serializer);
+
+	auto &table_function = (TableMacroFunction &)*function;
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteSerializable(*table_function.query_node);
+	writer.WriteSerializableList(function->parameters);
+	writer.WriteField<uint32_t>((uint32_t)function->default_parameters.size());
+	auto &serializer = writer.GetSerializer();
+	for (auto &kv : function->default_parameters) {
+		serializer.WriteString(kv.first);
+		kv.second->Serialize(serializer);
+	}
+	writer.Finalize();
+}
+
+unique_ptr<CreateMacroInfo> TableMacroCatalogEntry::Deserialize(Deserializer &main_source) {
+	auto info = make_unique<CreateMacroInfo>(CatalogType::TABLE_MACRO_ENTRY);
+	FieldReader reader(main_source);
+	info->schema = reader.ReadRequired<string>();
+	info->name = reader.ReadRequired<string>();
+	auto query_node = reader.ReadRequiredSerializable<QueryNode>();
+	auto table_function = make_unique<TableMacroFunction>(move(query_node));
+	info->function = move(table_function);
+	info->function->parameters = reader.ReadRequiredSerializableList<ParsedExpression>();
+	auto default_param_count = reader.ReadRequired<uint32_t>();
+	auto &source = reader.GetSource();
+	for (idx_t i = 0; i < default_param_count; i++) {
+		auto name = source.Read<string>();
+		info->function->default_parameters[name] = ParsedExpression::Deserialize(source);
+	}
+
+	reader.Finalize();
+
+	return info;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <sstream>
+
+namespace duckdb {
+
+void FindForeignKeyInformation(CatalogEntry *entry, AlterForeignKeyType alter_fk_type,
+                               vector<unique_ptr<AlterForeignKeyInfo>> &fk_arrays) {
+	if (entry->type != CatalogType::TABLE_ENTRY) {
+		return;
+	}
+	auto *table_entry = (TableCatalogEntry *)entry;
+	for (idx_t i = 0; i < table_entry->constraints.size(); i++) {
+		auto &cond = table_entry->constraints[i];
+		if (cond->type != ConstraintType::FOREIGN_KEY) {
+			continue;
+		}
+		auto &fk = (ForeignKeyConstraint &)*cond;
+		if (fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+			fk_arrays.push_back(make_unique<AlterForeignKeyInfo>(fk.info.schema, fk.info.table, entry->name,
+			                                                     fk.pk_columns, fk.fk_columns, fk.info.pk_keys,
+			                                                     fk.info.fk_keys, alter_fk_type));
+		} else if (fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE &&
+		           alter_fk_type == AlterForeignKeyType::AFT_DELETE) {
+			throw CatalogException("Could not drop the table because this table is main key table of the table \"%s\"",
+			                       fk.info.table);
+		}
+	}
+}
+
+SchemaCatalogEntry::SchemaCatalogEntry(Catalog *catalog, string name_p, bool internal)
+    : CatalogEntry(CatalogType::SCHEMA_ENTRY, catalog, move(name_p)),
+      tables(*catalog, make_unique<DefaultViewGenerator>(*catalog, this)), indexes(*catalog), table_functions(*catalog),
+      copy_functions(*catalog), pragma_functions(*catalog),
+      functions(*catalog, make_unique<DefaultFunctionGenerator>(*catalog, this)), sequences(*catalog),
+      collations(*catalog), types(*catalog, make_unique<DefaultTypeGenerator>(*catalog, this)) {
+	this->internal = internal;
+}
+
+CatalogEntry *SchemaCatalogEntry::AddEntry(ClientContext &context, unique_ptr<StandardEntry> entry,
+                                           OnCreateConflict on_conflict, unordered_set<CatalogEntry *> dependencies) {
+	auto entry_name = entry->name;
+	auto entry_type = entry->type;
+	auto result = entry.get();
+
+	// first find the set for this entry
+	auto &set = GetCatalogSet(entry_type);
+
+	if (name != TEMP_SCHEMA) {
+		dependencies.insert(this);
+	} else {
+		entry->temporary = true;
+	}
+	if (on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+		// CREATE OR REPLACE: first try to drop the entry
+		auto old_entry = set.GetEntry(context, entry_name);
+		if (old_entry) {
+			if (old_entry->type != entry_type) {
+				throw CatalogException("Existing object %s is of type %s, trying to replace with type %s", entry_name,
+				                       CatalogTypeToString(old_entry->type), CatalogTypeToString(entry_type));
+			}
+			(void)set.DropEntry(context, entry_name, false);
+		}
+	}
+	// now try to add the entry
+	if (!set.CreateEntry(context, entry_name, move(entry), dependencies)) {
+		// entry already exists!
+		if (on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
+			throw CatalogException("%s with name \"%s\" already exists!", CatalogTypeToString(entry_type), entry_name);
+		} else {
+			return nullptr;
+		}
+	}
+	return result;
+}
+
+CatalogEntry *SchemaCatalogEntry::AddEntry(ClientContext &context, unique_ptr<StandardEntry> entry,
+                                           OnCreateConflict on_conflict) {
+	unordered_set<CatalogEntry *> dependencies;
+	return AddEntry(context, move(entry), on_conflict, dependencies);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateSequence(ClientContext &context, CreateSequenceInfo *info) {
+	auto sequence = make_unique<SequenceCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(sequence), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateType(ClientContext &context, CreateTypeInfo *info) {
+	auto type_entry = make_unique<TypeCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(type_entry), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateTable(ClientContext &context, BoundCreateTableInfo *info) {
+	auto table = make_unique<TableCatalogEntry>(catalog, this, info);
+	table->storage->info->cardinality = table->storage->GetTotalRows();
+
+	CatalogEntry *entry = AddEntry(context, move(table), info->Base().on_conflict, info->dependencies);
+	if (!entry) {
+		return nullptr;
+	}
+
+	// add a foreign key constraint in main key table if there is a foreign key constraint
+	vector<unique_ptr<AlterForeignKeyInfo>> fk_arrays;
+	FindForeignKeyInformation(entry, AlterForeignKeyType::AFT_ADD, fk_arrays);
+	for (idx_t i = 0; i < fk_arrays.size(); i++) {
+		// alter primary key table
+		AlterForeignKeyInfo *fk_info = fk_arrays[i].get();
+		catalog->Alter(context, fk_info);
+
+		// make a dependency between this table and referenced table
+		auto &set = GetCatalogSet(CatalogType::TABLE_ENTRY);
+		info->dependencies.insert(set.GetEntry(context, fk_info->name));
+	}
+	return entry;
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateView(ClientContext &context, CreateViewInfo *info) {
+	auto view = make_unique<ViewCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(view), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateIndex(ClientContext &context, CreateIndexInfo *info, TableCatalogEntry *table) {
+	unordered_set<CatalogEntry *> dependencies;
+	dependencies.insert(table);
+	auto index = make_unique<IndexCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(index), info->on_conflict, dependencies);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateCollation(ClientContext &context, CreateCollationInfo *info) {
+	auto collation = make_unique<CollateCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(collation), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateTableFunction(ClientContext &context, CreateTableFunctionInfo *info) {
+	auto table_function = make_unique<TableFunctionCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(table_function), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateCopyFunction(ClientContext &context, CreateCopyFunctionInfo *info) {
+	auto copy_function = make_unique<CopyFunctionCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(copy_function), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreatePragmaFunction(ClientContext &context, CreatePragmaFunctionInfo *info) {
+	auto pragma_function = make_unique<PragmaFunctionCatalogEntry>(catalog, this, info);
+	return AddEntry(context, move(pragma_function), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::CreateFunction(ClientContext &context, CreateFunctionInfo *info) {
+	unique_ptr<StandardEntry> function;
+	switch (info->type) {
+	case CatalogType::SCALAR_FUNCTION_ENTRY:
+		function = make_unique_base<StandardEntry, ScalarFunctionCatalogEntry>(catalog, this,
+		                                                                       (CreateScalarFunctionInfo *)info);
+		break;
+	case CatalogType::MACRO_ENTRY:
+		// create a macro function
+		function = make_unique_base<StandardEntry, ScalarMacroCatalogEntry>(catalog, this, (CreateMacroInfo *)info);
+		break;
+
+	case CatalogType::TABLE_MACRO_ENTRY:
+		// create a macro function
+		function = make_unique_base<StandardEntry, TableMacroCatalogEntry>(catalog, this, (CreateMacroInfo *)info);
+		break;
+	case CatalogType::AGGREGATE_FUNCTION_ENTRY:
+		D_ASSERT(info->type == CatalogType::AGGREGATE_FUNCTION_ENTRY);
+		// create an aggregate function
+		function = make_unique_base<StandardEntry, AggregateFunctionCatalogEntry>(catalog, this,
+		                                                                          (CreateAggregateFunctionInfo *)info);
+		break;
+	default:
+		throw InternalException("Unknown function type \"%s\"", CatalogTypeToString(info->type));
+	}
+	return AddEntry(context, move(function), info->on_conflict);
+}
+
+CatalogEntry *SchemaCatalogEntry::AddFunction(ClientContext &context, CreateFunctionInfo *info) {
+	auto entry = GetCatalogSet(info->type).GetEntry(context, info->name);
+	if (!entry) {
+		return CreateFunction(context, info);
+	}
+
+	info->on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
+	switch (info->type) {
+	case CatalogType::SCALAR_FUNCTION_ENTRY: {
+		auto scalar_info = (CreateScalarFunctionInfo *)info;
+		auto &scalars = *(ScalarFunctionCatalogEntry *)entry;
+		for (const auto &scalar : scalars.functions) {
+			scalar_info->functions.emplace_back(scalar);
+		}
+		break;
+	}
+	case CatalogType::AGGREGATE_FUNCTION_ENTRY: {
+		auto agg_info = (CreateAggregateFunctionInfo *)info;
+		auto &aggs = *(AggregateFunctionCatalogEntry *)entry;
+		for (const auto &agg : aggs.functions) {
+			agg_info->functions.AddFunction(agg);
+		}
+		break;
+	}
+	default:
+		// Macros can only be replaced because there is only one of each name.
+		throw InternalException("Unsupported function type \"%s\" for adding", CatalogTypeToString(info->type));
+	}
+	return CreateFunction(context, info);
+}
+
+void SchemaCatalogEntry::DropEntry(ClientContext &context, DropInfo *info) {
+	auto &set = GetCatalogSet(info->type);
+
+	// first find the entry
+	auto existing_entry = set.GetEntry(context, info->name);
+	if (!existing_entry) {
+		if (!info->if_exists) {
+			throw CatalogException("%s with name \"%s\" does not exist!", CatalogTypeToString(info->type), info->name);
+		}
+		return;
+	}
+	if (existing_entry->type != info->type) {
+		throw CatalogException("Existing object %s is of type %s, trying to replace with type %s", info->name,
+		                       CatalogTypeToString(existing_entry->type), CatalogTypeToString(info->type));
+	}
+
+	// if there is a foreign key constraint, get that information
+	vector<unique_ptr<AlterForeignKeyInfo>> fk_arrays;
+	FindForeignKeyInformation(existing_entry, AlterForeignKeyType::AFT_DELETE, fk_arrays);
+
+	if (!set.DropEntry(context, info->name, info->cascade)) {
+		throw InternalException("Could not drop element because of an internal error");
+	}
+
+	// remove the foreign key constraint in main key table if main key table's name is valid
+	for (idx_t i = 0; i < fk_arrays.size(); i++) {
+		// alter primary key tablee
+		Catalog::GetCatalog(context).Alter(context, fk_arrays[i].get());
+	}
+}
+
+void SchemaCatalogEntry::Alter(ClientContext &context, AlterInfo *info) {
+	CatalogType type = info->GetCatalogType();
+	auto &set = GetCatalogSet(type);
+	if (info->type == AlterType::CHANGE_OWNERSHIP) {
+		if (!set.AlterOwnership(context, (ChangeOwnershipInfo *)info)) {
+			throw CatalogException("Couldn't change ownership!");
+		}
+	} else {
+		string name = info->name;
+		if (!set.AlterEntry(context, name, info)) {
+			throw CatalogException("Entry with name \"%s\" does not exist!", name);
+		}
+	}
+}
+
+void SchemaCatalogEntry::Scan(ClientContext &context, CatalogType type,
+                              const std::function<void(CatalogEntry *)> &callback) {
+	auto &set = GetCatalogSet(type);
+	set.Scan(context, callback);
+}
+
+void SchemaCatalogEntry::Scan(CatalogType type, const std::function<void(CatalogEntry *)> &callback) {
+	auto &set = GetCatalogSet(type);
+	set.Scan(callback);
+}
+
+void SchemaCatalogEntry::Serialize(Serializer &serializer) {
+	FieldWriter writer(serializer);
+	writer.WriteString(name);
+	writer.Finalize();
+}
+
+unique_ptr<CreateSchemaInfo> SchemaCatalogEntry::Deserialize(Deserializer &source) {
+	auto info = make_unique<CreateSchemaInfo>();
+
+	FieldReader reader(source);
+	info->schema = reader.ReadRequired<string>();
+	reader.Finalize();
+
+	return info;
+}
+
+string SchemaCatalogEntry::ToSQL() {
+	std::stringstream ss;
+	ss << "CREATE SCHEMA " << name << ";";
+	return ss.str();
+}
+
+CatalogSet &SchemaCatalogEntry::GetCatalogSet(CatalogType type) {
+	switch (type) {
+	case CatalogType::VIEW_ENTRY:
+	case CatalogType::TABLE_ENTRY:
+		return tables;
+	case CatalogType::INDEX_ENTRY:
+		return indexes;
+	case CatalogType::TABLE_FUNCTION_ENTRY:
+	case CatalogType::TABLE_MACRO_ENTRY:
+		return table_functions;
+	case CatalogType::COPY_FUNCTION_ENTRY:
+		return copy_functions;
+	case CatalogType::PRAGMA_FUNCTION_ENTRY:
+		return pragma_functions;
+	case CatalogType::AGGREGATE_FUNCTION_ENTRY:
+	case CatalogType::SCALAR_FUNCTION_ENTRY:
+	case CatalogType::MACRO_ENTRY:
+		return functions;
+	case CatalogType::SEQUENCE_ENTRY:
+		return sequences;
+	case CatalogType::COLLATION_ENTRY:
+		return collations;
+	case CatalogType::TYPE_ENTRY:
+		return types;
+	default:
+		throw InternalException("Unsupported catalog type in schema");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <sstream>
+
+namespace duckdb {
+
+SequenceCatalogEntry::SequenceCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateSequenceInfo *info)
+    : StandardEntry(CatalogType::SEQUENCE_ENTRY, schema, catalog, info->name), usage_count(info->usage_count),
+      counter(info->start_value), increment(info->increment), start_value(info->start_value),
+      min_value(info->min_value), max_value(info->max_value), cycle(info->cycle) {
+	this->temporary = info->temporary;
+}
+
+void SequenceCatalogEntry::Serialize(Serializer &serializer) {
+	FieldWriter writer(serializer);
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteField<uint64_t>(usage_count);
+	writer.WriteField<int64_t>(increment);
+	writer.WriteField<int64_t>(min_value);
+	writer.WriteField<int64_t>(max_value);
+	writer.WriteField<int64_t>(counter);
+	writer.WriteField<bool>(cycle);
+	writer.Finalize();
+}
+
+unique_ptr<CreateSequenceInfo> SequenceCatalogEntry::Deserialize(Deserializer &source) {
+	auto info = make_unique<CreateSequenceInfo>();
+
+	FieldReader reader(source);
+	info->schema = reader.ReadRequired<string>();
+	info->name = reader.ReadRequired<string>();
+	info->usage_count = reader.ReadRequired<uint64_t>();
+	info->increment = reader.ReadRequired<int64_t>();
+	info->min_value = reader.ReadRequired<int64_t>();
+	info->max_value = reader.ReadRequired<int64_t>();
+	info->start_value = reader.ReadRequired<int64_t>();
+	info->cycle = reader.ReadRequired<bool>();
+	reader.Finalize();
+
+	return info;
+}
+
+string SequenceCatalogEntry::ToSQL() {
+	std::stringstream ss;
+	ss << "CREATE SEQUENCE ";
+	ss << name;
+	ss << " INCREMENT BY " << increment;
+	ss << " MINVALUE " << min_value;
+	ss << " MAXVALUE " << max_value;
+	ss << " START " << counter;
+	ss << " " << (cycle ? "CYCLE" : "NO CYCLE") << ";";
+	return ss.str();
+}
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <sstream>
+
+namespace duckdb {
+
+const string &TableCatalogEntry::GetColumnName(column_t index) {
+	return columns[index].Name();
+}
+
+column_t TableCatalogEntry::GetColumnIndex(string &column_name, bool if_exists) {
+	auto entry = name_map.find(column_name);
+	if (entry == name_map.end()) {
+		// entry not found: try lower-casing the name
+		entry = name_map.find(StringUtil::Lower(column_name));
+		if (entry == name_map.end()) {
+			if (if_exists) {
+				return DConstants::INVALID_INDEX;
+			}
+			throw BinderException("Table \"%s\" does not have a column with name \"%s\"", name, column_name);
+		}
+	}
+	column_name = GetColumnName(entry->second);
+	return entry->second;
+}
+
+void AddDataTableIndex(DataTable *storage, vector<ColumnDefinition> &columns, vector<idx_t> &keys,
+                       IndexConstraintType constraint_type) {
+	// fetch types and create expressions for the index from the columns
+	vector<column_t> column_ids;
+	vector<unique_ptr<Expression>> unbound_expressions;
+	vector<unique_ptr<Expression>> bound_expressions;
+	idx_t key_nr = 0;
+	for (auto &key : keys) {
+		D_ASSERT(key < columns.size());
+		auto &column = columns[key];
+		if (column.Generated()) {
+			throw InvalidInputException("Creating index on generated column is not supported");
+		}
+
+		unbound_expressions.push_back(make_unique<BoundColumnRefExpression>(columns[key].Name(), columns[key].Type(),
+		                                                                    ColumnBinding(0, column_ids.size())));
+
+		bound_expressions.push_back(make_unique<BoundReferenceExpression>(columns[key].Type(), key_nr++));
+		column_ids.push_back(column.StorageOid());
+	}
+	// create an adaptive radix tree around the expressions
+	auto art = make_unique<ART>(column_ids, move(unbound_expressions), constraint_type);
+	storage->AddIndex(move(art), bound_expressions);
+}
+
+TableCatalogEntry::TableCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, BoundCreateTableInfo *info,
+                                     std::shared_ptr<DataTable> inherited_storage)
+    : StandardEntry(CatalogType::TABLE_ENTRY, schema, catalog, info->Base().table), storage(move(inherited_storage)),
+      columns(move(info->Base().columns)), constraints(move(info->Base().constraints)),
+      bound_constraints(move(info->bound_constraints)),
+      column_dependency_manager(move(info->column_dependency_manager)) {
+	this->temporary = info->Base().temporary;
+	// add lower case aliases
+	this->name_map = move(info->name_map);
+#ifdef DEBUG
+	D_ASSERT(name_map.size() == columns.size());
+	for (idx_t i = 0; i < columns.size(); i++) {
+		D_ASSERT(name_map[columns[i].Name()] == i);
+	}
+#endif
+	// add the "rowid" alias, if there is no rowid column specified in the table
+	if (name_map.find("rowid") == name_map.end()) {
+		name_map["rowid"] = COLUMN_IDENTIFIER_ROW_ID;
+	}
+	if (!storage) {
+		// create the physical storage
+		vector<ColumnDefinition> storage_columns;
+		vector<ColumnDefinition> get_columns;
+		for (auto &col_def : columns) {
+			get_columns.push_back(col_def.Copy());
+			if (col_def.Generated()) {
+				continue;
+			}
+			storage_columns.push_back(col_def.Copy());
+		}
+		storage = make_shared<DataTable>(catalog->db, schema->name, name, move(storage_columns), move(info->data));
+
+		// create the unique indexes for the UNIQUE and PRIMARY KEY and FOREIGN KEY constraints
+		for (idx_t i = 0; i < bound_constraints.size(); i++) {
+			auto &constraint = bound_constraints[i];
+			if (constraint->type == ConstraintType::UNIQUE) {
+				// unique constraint: create a unique index
+				auto &unique = (BoundUniqueConstraint &)*constraint;
+				IndexConstraintType constraint_type = IndexConstraintType::UNIQUE;
+				if (unique.is_primary_key) {
+					constraint_type = IndexConstraintType::PRIMARY;
+				}
+				AddDataTableIndex(storage.get(), get_columns, unique.keys, constraint_type);
+			} else if (constraint->type == ConstraintType::FOREIGN_KEY) {
+				// foreign key constraint: create a foreign key index
+				auto &bfk = (BoundForeignKeyConstraint &)*constraint;
+				if (bfk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE ||
+				    bfk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+					AddDataTableIndex(storage.get(), get_columns, bfk.info.fk_keys, IndexConstraintType::FOREIGN);
+				}
+			}
+		}
+	}
+}
+
+bool TableCatalogEntry::ColumnExists(const string &name) {
+	auto iterator = name_map.find(name);
+	if (iterator == name_map.end()) {
+		return false;
+	}
+	return true;
+}
+
+idx_t TableCatalogEntry::StandardColumnCount() const {
+	idx_t count = 0;
+	for (auto &col : columns) {
+		if (col.Category() == TableColumnType::STANDARD) {
+			count++;
+		}
+	}
+	return count;
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::AlterEntry(ClientContext &context, AlterInfo *info) {
+	D_ASSERT(!internal);
+	if (info->type != AlterType::ALTER_TABLE) {
+		throw CatalogException("Can only modify table with ALTER TABLE statement");
+	}
+	auto table_info = (AlterTableInfo *)info;
+	switch (table_info->alter_table_type) {
+	case AlterTableType::RENAME_COLUMN: {
+		auto rename_info = (RenameColumnInfo *)table_info;
+		return RenameColumn(context, *rename_info);
+	}
+	case AlterTableType::RENAME_TABLE: {
+		auto rename_info = (RenameTableInfo *)table_info;
+		auto copied_table = Copy(context);
+		copied_table->name = rename_info->new_table_name;
+		return copied_table;
+	}
+	case AlterTableType::ADD_COLUMN: {
+		auto add_info = (AddColumnInfo *)table_info;
+		return AddColumn(context, *add_info);
+	}
+	case AlterTableType::REMOVE_COLUMN: {
+		auto remove_info = (RemoveColumnInfo *)table_info;
+		return RemoveColumn(context, *remove_info);
+	}
+	case AlterTableType::SET_DEFAULT: {
+		auto set_default_info = (SetDefaultInfo *)table_info;
+		return SetDefault(context, *set_default_info);
+	}
+	case AlterTableType::ALTER_COLUMN_TYPE: {
+		auto change_type_info = (ChangeColumnTypeInfo *)table_info;
+		return ChangeColumnType(context, *change_type_info);
+	}
+	case AlterTableType::FOREIGN_KEY_CONSTRAINT: {
+		auto foreign_key_constraint_info = (AlterForeignKeyInfo *)table_info;
+		return SetForeignKeyConstraint(context, *foreign_key_constraint_info);
+	}
+	default:
+		throw InternalException("Unrecognized alter table type!");
+	}
+}
+
+static void RenameExpression(ParsedExpression &expr, RenameColumnInfo &info) {
+	if (expr.type == ExpressionType::COLUMN_REF) {
+		auto &colref = (ColumnRefExpression &)expr;
+		if (colref.column_names.back() == info.old_name) {
+			colref.column_names.back() = info.new_name;
+		}
+	}
+	ParsedExpressionIterator::EnumerateChildren(
+	    expr, [&](const ParsedExpression &child) { RenameExpression((ParsedExpression &)child, info); });
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::RenameColumn(ClientContext &context, RenameColumnInfo &info) {
+	auto rename_idx = GetColumnIndex(info.old_name);
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto copy = columns[i].Copy();
+
+		if (rename_idx == i) {
+			copy.SetName(info.new_name);
+		}
+		create_info->columns.push_back(move(copy));
+		auto &col = create_info->columns[i];
+		if (col.Generated() && column_dependency_manager.IsDependencyOf(i, rename_idx)) {
+			RenameExpression(col.GeneratedExpressionMutable(), info);
+		}
+	}
+	for (idx_t c_idx = 0; c_idx < constraints.size(); c_idx++) {
+		auto copy = constraints[c_idx]->Copy();
+		switch (copy->type) {
+		case ConstraintType::NOT_NULL:
+			// NOT NULL constraint: no adjustments necessary
+			break;
+		case ConstraintType::CHECK: {
+			// CHECK constraint: need to rename column references that refer to the renamed column
+			auto &check = (CheckConstraint &)*copy;
+			RenameExpression(*check.expression, info);
+			break;
+		}
+		case ConstraintType::UNIQUE: {
+			// UNIQUE constraint: possibly need to rename columns
+			auto &unique = (UniqueConstraint &)*copy;
+			for (idx_t i = 0; i < unique.columns.size(); i++) {
+				if (unique.columns[i] == info.old_name) {
+					unique.columns[i] = info.new_name;
+				}
+			}
+			break;
+		}
+		case ConstraintType::FOREIGN_KEY: {
+			// FOREIGN KEY constraint: possibly need to rename columns
+			auto &fk = (ForeignKeyConstraint &)*copy;
+			vector<string> columns = fk.pk_columns;
+			if (fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+				columns = fk.fk_columns;
+			} else if (fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+				for (idx_t i = 0; i < fk.fk_columns.size(); i++) {
+					columns.push_back(fk.fk_columns[i]);
+				}
+			}
+			for (idx_t i = 0; i < columns.size(); i++) {
+				if (columns[i] == info.old_name) {
+					throw CatalogException(
+					    "Cannot rename column \"%s\" because this is involved in the foreign key constraint",
+					    info.old_name);
+				}
+			}
+			break;
+		}
+		default:
+			throw InternalException("Unsupported constraint for entry!");
+		}
+		create_info->constraints.push_back(move(copy));
+	}
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(), storage);
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::AddColumn(ClientContext &context, AddColumnInfo &info) {
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
+
+	for (idx_t i = 0; i < columns.size(); i++) {
+		create_info->columns.push_back(columns[i].Copy());
+	}
+	for (auto &constraint : constraints) {
+		create_info->constraints.push_back(constraint->Copy());
+	}
+	Binder::BindLogicalType(context, info.new_column.TypeMutable(), schema->name);
+	info.new_column.SetOid(columns.size());
+	info.new_column.SetStorageOid(storage->column_definitions.size());
+
+	auto col = info.new_column.Copy();
+
+	create_info->columns.push_back(move(col));
+
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	auto new_storage =
+	    make_shared<DataTable>(context, *storage, info.new_column, bound_create_info->bound_defaults.back().get());
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(),
+	                                      new_storage);
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::RemoveColumn(ClientContext &context, RemoveColumnInfo &info) {
+	auto removed_index = GetColumnIndex(info.removed_column, info.if_exists);
+	if (removed_index == DConstants::INVALID_INDEX) {
+		return nullptr;
+	}
+
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
+
+	unordered_set<column_t> removed_columns;
+	if (column_dependency_manager.HasDependents(removed_index)) {
+		removed_columns = column_dependency_manager.GetDependents(removed_index);
+	}
+	if (!removed_columns.empty() && !info.cascade) {
+		throw CatalogException("Cannot drop column: column is a dependency of 1 or more generated column(s)");
+	}
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto &col = columns[i];
+		if (i == removed_index || removed_columns.count(i)) {
+			continue;
+		}
+		create_info->columns.push_back(col.Copy());
+	}
+	if (create_info->columns.empty()) {
+		throw CatalogException("Cannot drop column: table only has one column remaining!");
+	}
+	vector<column_t> adjusted_indices = column_dependency_manager.RemoveColumn(removed_index, columns.size());
+	// handle constraints for the new table
+	D_ASSERT(constraints.size() == bound_constraints.size());
+	for (idx_t constr_idx = 0; constr_idx < constraints.size(); constr_idx++) {
+		auto &constraint = constraints[constr_idx];
+		auto &bound_constraint = bound_constraints[constr_idx];
+		switch (constraint->type) {
+		case ConstraintType::NOT_NULL: {
+			auto &not_null_constraint = (BoundNotNullConstraint &)*bound_constraint;
+			if (not_null_constraint.index != removed_index) {
+				// the constraint is not about this column: we need to copy it
+				// we might need to shift the index back by one though, to account for the removed column
+				idx_t new_index = not_null_constraint.index;
+				new_index = adjusted_indices[new_index];
+				create_info->constraints.push_back(make_unique<NotNullConstraint>(new_index));
+			}
+			break;
+		}
+		case ConstraintType::CHECK: {
+			// CHECK constraint
+			auto &bound_check = (BoundCheckConstraint &)*bound_constraint;
+			// check if the removed column is part of the check constraint
+			if (bound_check.bound_columns.find(removed_index) != bound_check.bound_columns.end()) {
+				if (bound_check.bound_columns.size() > 1) {
+					// CHECK constraint that concerns mult
+					throw CatalogException(
+					    "Cannot drop column \"%s\" because there is a CHECK constraint that depends on it",
+					    info.removed_column);
+				} else {
+					// CHECK constraint that ONLY concerns this column, strip the constraint
+				}
+			} else {
+				// check constraint does not concern the removed column: simply re-add it
+				create_info->constraints.push_back(constraint->Copy());
+			}
+			break;
+		}
+		case ConstraintType::UNIQUE: {
+			auto copy = constraint->Copy();
+			auto &unique = (UniqueConstraint &)*copy;
+			if (unique.index != DConstants::INVALID_INDEX) {
+				if (unique.index == removed_index) {
+					throw CatalogException(
+					    "Cannot drop column \"%s\" because there is a UNIQUE constraint that depends on it",
+					    info.removed_column);
+				}
+				unique.index = adjusted_indices[unique.index];
+			}
+			create_info->constraints.push_back(move(copy));
+			break;
+		}
+		case ConstraintType::FOREIGN_KEY: {
+			auto copy = constraint->Copy();
+			auto &fk = (ForeignKeyConstraint &)*copy;
+			vector<string> columns = fk.pk_columns;
+			if (fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+				columns = fk.fk_columns;
+			} else if (fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+				for (idx_t i = 0; i < fk.fk_columns.size(); i++) {
+					columns.push_back(fk.fk_columns[i]);
+				}
+			}
+			for (idx_t i = 0; i < columns.size(); i++) {
+				if (columns[i] == info.removed_column) {
+					throw CatalogException(
+					    "Cannot drop column \"%s\" because there is a FOREIGN KEY constraint that depends on it",
+					    info.removed_column);
+				}
+			}
+			create_info->constraints.push_back(move(copy));
+			break;
+		}
+		default:
+			throw InternalException("Unsupported constraint for entry!");
+		}
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	if (columns[removed_index].Generated()) {
+		return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(),
+		                                      storage);
+	}
+	auto new_storage = make_shared<DataTable>(context, *storage, removed_index);
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(),
+	                                      new_storage);
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::SetDefault(ClientContext &context, SetDefaultInfo &info) {
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	auto default_idx = GetColumnIndex(info.column_name);
+
+	// Copy all the columns, changing the value of the one that was specified by 'column_name'
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto copy = columns[i].Copy();
+		if (default_idx == i) {
+			// set the default value of this column
+			D_ASSERT(!copy.Generated()); // Shouldnt reach here - DEFAULT value isn't supported for Generated Columns
+			copy.SetDefaultValue(info.expression ? info.expression->Copy() : nullptr);
+		}
+		create_info->columns.push_back(move(copy));
+	}
+	// Copy all the constraints
+	for (idx_t i = 0; i < constraints.size(); i++) {
+		auto constraint = constraints[i]->Copy();
+		create_info->constraints.push_back(move(constraint));
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(), storage);
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::ChangeColumnType(ClientContext &context, ChangeColumnTypeInfo &info) {
+	if (info.target_type.id() == LogicalTypeId::USER) {
+		auto &catalog = Catalog::GetCatalog(context);
+		info.target_type = catalog.GetType(context, schema->name, UserType::GetTypeName(info.target_type));
+	}
+	auto change_idx = GetColumnIndex(info.column_name);
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
+
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto copy = columns[i].Copy();
+		if (change_idx == i) {
+			// set the type of this column
+			if (copy.Generated()) {
+				throw NotImplementedException("Changing types of generated columns is not supported yet");
+				// copy.ChangeGeneratedExpressionType(info.target_type);
+			}
+			copy.SetType(info.target_type);
+		}
+		// TODO: check if the generated_expression breaks, only delete it if it does
+		if (copy.Generated() && column_dependency_manager.IsDependencyOf(i, change_idx)) {
+			throw BinderException(
+			    "This column is referenced by the generated column \"%s\", so its type can not be changed",
+			    copy.Name());
+		}
+		create_info->columns.push_back(move(copy));
+	}
+
+	for (idx_t i = 0; i < constraints.size(); i++) {
+		auto constraint = constraints[i]->Copy();
+		switch (constraint->type) {
+		case ConstraintType::CHECK: {
+			auto &bound_check = (BoundCheckConstraint &)*bound_constraints[i];
+			if (bound_check.bound_columns.find(change_idx) != bound_check.bound_columns.end()) {
+				throw BinderException("Cannot change the type of a column that has a CHECK constraint specified");
+			}
+			break;
+		}
+		case ConstraintType::NOT_NULL:
+			break;
+		case ConstraintType::UNIQUE: {
+			auto &bound_unique = (BoundUniqueConstraint &)*bound_constraints[i];
+			if (bound_unique.key_set.find(change_idx) != bound_unique.key_set.end()) {
+				throw BinderException(
+				    "Cannot change the type of a column that has a UNIQUE or PRIMARY KEY constraint specified");
+			}
+			break;
+		}
+		case ConstraintType::FOREIGN_KEY: {
+			auto &bfk = (BoundForeignKeyConstraint &)*bound_constraints[i];
+			unordered_set<idx_t> key_set = bfk.pk_key_set;
+			if (bfk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+				key_set = bfk.fk_key_set;
+			} else if (bfk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+				for (idx_t i = 0; i < bfk.info.fk_keys.size(); i++) {
+					key_set.insert(bfk.info.fk_keys[i]);
+				}
+			}
+			if (key_set.find(change_idx) != key_set.end()) {
+				throw BinderException("Cannot change the type of a column that has a FOREIGN KEY constraint specified");
+			}
+			break;
+		}
+		default:
+			throw InternalException("Unsupported constraint for entry!");
+		}
+		create_info->constraints.push_back(move(constraint));
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	// bind the specified expression
+	vector<column_t> bound_columns;
+	AlterBinder expr_binder(*binder, context, *this, bound_columns, info.target_type);
+	auto expression = info.expression->Copy();
+	auto bound_expression = expr_binder.Bind(expression);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	if (bound_columns.empty()) {
+		bound_columns.push_back(COLUMN_IDENTIFIER_ROW_ID);
+	}
+
+	auto new_storage =
+	    make_shared<DataTable>(context, *storage, change_idx, info.target_type, move(bound_columns), *bound_expression);
+	auto result =
+	    make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(), new_storage);
+	return move(result);
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::SetForeignKeyConstraint(ClientContext &context, AlterForeignKeyInfo &info) {
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	create_info->temporary = temporary;
+
+	for (idx_t i = 0; i < columns.size(); i++) {
+		create_info->columns.push_back(columns[i].Copy());
+	}
+	for (idx_t i = 0; i < constraints.size(); i++) {
+		auto constraint = constraints[i]->Copy();
+		if (constraint->type == ConstraintType::FOREIGN_KEY) {
+			ForeignKeyConstraint &fk = (ForeignKeyConstraint &)*constraint;
+			if (fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE && fk.info.table == info.fk_table) {
+				continue;
+			}
+		}
+		create_info->constraints.push_back(move(constraint));
+	}
+	if (info.type == AlterForeignKeyType::AFT_ADD) {
+		ForeignKeyInfo fk_info;
+		fk_info.type = ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE;
+		fk_info.schema = info.schema;
+		fk_info.table = info.fk_table;
+		fk_info.pk_keys = info.pk_keys;
+		fk_info.fk_keys = info.fk_keys;
+		create_info->constraints.push_back(
+		    make_unique<ForeignKeyConstraint>(info.pk_columns, info.fk_columns, move(fk_info)));
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(), storage);
+}
+
+ColumnDefinition &TableCatalogEntry::GetColumn(const string &name) {
+	auto entry = name_map.find(name);
+	if (entry == name_map.end() || entry->second == COLUMN_IDENTIFIER_ROW_ID) {
+		throw CatalogException("Column with name %s does not exist!", name);
+	}
+	auto column_index = entry->second;
+	return columns[column_index];
+}
+
+vector<LogicalType> TableCatalogEntry::GetTypes() {
+	vector<LogicalType> types;
+	for (auto &it : columns) {
+		if (it.Generated()) {
+			continue;
+		}
+		types.push_back(it.Type());
+	}
+	return types;
+}
+
+void TableCatalogEntry::Serialize(Serializer &serializer) {
+	D_ASSERT(!internal);
+
+	FieldWriter writer(serializer);
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteRegularSerializableList(columns);
+	writer.WriteSerializableList(constraints);
+	writer.Finalize();
+}
+
+unique_ptr<CreateTableInfo> TableCatalogEntry::Deserialize(Deserializer &source) {
+	auto info = make_unique<CreateTableInfo>();
+
+	FieldReader reader(source);
+	info->schema = reader.ReadRequired<string>();
+	info->table = reader.ReadRequired<string>();
+	info->columns = reader.ReadRequiredSerializableList<ColumnDefinition, ColumnDefinition>();
+	info->constraints = reader.ReadRequiredSerializableList<Constraint>();
+	reader.Finalize();
+
+	return info;
+}
+
+string TableCatalogEntry::ToSQL() {
+	std::stringstream ss;
+
+	ss << "CREATE TABLE ";
+
+	if (schema->name != DEFAULT_SCHEMA) {
+		ss << KeywordHelper::WriteOptionallyQuoted(schema->name) << ".";
+	}
+
+	ss << KeywordHelper::WriteOptionallyQuoted(name) << "(";
+
+	// find all columns that have NOT NULL specified, but are NOT primary key columns
+	unordered_set<idx_t> not_null_columns;
+	unordered_set<idx_t> unique_columns;
+	unordered_set<idx_t> pk_columns;
+	unordered_set<string> multi_key_pks;
+	vector<string> extra_constraints;
+	for (auto &constraint : constraints) {
+		if (constraint->type == ConstraintType::NOT_NULL) {
+			auto &not_null = (NotNullConstraint &)*constraint;
+			not_null_columns.insert(not_null.index);
+		} else if (constraint->type == ConstraintType::UNIQUE) {
+			auto &pk = (UniqueConstraint &)*constraint;
+			vector<string> constraint_columns = pk.columns;
+			if (pk.index != DConstants::INVALID_INDEX) {
+				// no columns specified: single column constraint
+				if (pk.is_primary_key) {
+					pk_columns.insert(pk.index);
+				} else {
+					unique_columns.insert(pk.index);
+				}
+			} else {
+				// multi-column constraint, this constraint needs to go at the end after all columns
+				if (pk.is_primary_key) {
+					// multi key pk column: insert set of columns into multi_key_pks
+					for (auto &col : pk.columns) {
+						multi_key_pks.insert(col);
+					}
+				}
+				extra_constraints.push_back(constraint->ToString());
+			}
+		} else if (constraint->type == ConstraintType::FOREIGN_KEY) {
+			auto &fk = (ForeignKeyConstraint &)*constraint;
+			if (fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE ||
+			    fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+				extra_constraints.push_back(constraint->ToString());
+			}
+		} else {
+			extra_constraints.push_back(constraint->ToString());
+		}
+	}
+
+	for (idx_t i = 0; i < columns.size(); i++) {
+		if (i > 0) {
+			ss << ", ";
+		}
+		auto &column = columns[i];
+		ss << KeywordHelper::WriteOptionallyQuoted(column.Name()) << " ";
+		ss << column.Type().ToString();
+		bool not_null = not_null_columns.find(column.Oid()) != not_null_columns.end();
+		bool is_single_key_pk = pk_columns.find(column.Oid()) != pk_columns.end();
+		bool is_multi_key_pk = multi_key_pks.find(column.Name()) != multi_key_pks.end();
+		bool is_unique = unique_columns.find(column.Oid()) != unique_columns.end();
+		if (not_null && !is_single_key_pk && !is_multi_key_pk) {
+			// NOT NULL but not a primary key column
+			ss << " NOT NULL";
+		}
+		if (is_single_key_pk) {
+			// single column pk: insert constraint here
+			ss << " PRIMARY KEY";
+		}
+		if (is_unique) {
+			// single column unique: insert constraint here
+			ss << " UNIQUE";
+		}
+		if (column.DefaultValue()) {
+			ss << " DEFAULT(" << column.DefaultValue()->ToString() << ")";
+		}
+		if (column.Generated()) {
+			ss << " GENERATED ALWAYS AS(" << column.GeneratedExpression().ToString() << ")";
+		}
+	}
+	// print any extra constraints that still need to be printed
+	for (auto &extra_constraint : extra_constraints) {
+		ss << ", ";
+		ss << extra_constraint;
+	}
+
+	ss << ");";
+	return ss.str();
+}
+
+unique_ptr<CatalogEntry> TableCatalogEntry::Copy(ClientContext &context) {
+	auto create_info = make_unique<CreateTableInfo>(schema->name, name);
+	for (idx_t i = 0; i < columns.size(); i++) {
+		create_info->columns.push_back(columns[i].Copy());
+	}
+
+	for (idx_t i = 0; i < constraints.size(); i++) {
+		auto constraint = constraints[i]->Copy();
+		create_info->constraints.push_back(move(constraint));
+	}
+
+	auto binder = Binder::CreateBinder(context);
+	auto bound_create_info = binder->BindCreateTableInfo(move(create_info));
+	return make_unique<TableCatalogEntry>(catalog, schema, (BoundCreateTableInfo *)bound_create_info.get(), storage);
+}
+
+void TableCatalogEntry::SetAsRoot() {
+	storage->SetAsRoot();
+}
+
+void TableCatalogEntry::CommitAlter(AlterInfo &info) {
+	D_ASSERT(info.type == AlterType::ALTER_TABLE);
+	auto &alter_table = (AlterTableInfo &)info;
+	string column_name;
+	switch (alter_table.alter_table_type) {
+	case AlterTableType::REMOVE_COLUMN: {
+		auto &remove_info = (RemoveColumnInfo &)alter_table;
+		column_name = remove_info.removed_column;
+		break;
+	}
+	case AlterTableType::ALTER_COLUMN_TYPE: {
+		auto &change_info = (ChangeColumnTypeInfo &)alter_table;
+		column_name = change_info.column_name;
+		break;
+	}
+	default:
+		break;
+	}
+	if (column_name.empty()) {
+		return;
+	}
+	idx_t removed_index = DConstants::INVALID_INDEX;
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto &col = columns[i];
+		if (col.Name() == column_name) {
+			// No need to alter storage, removed column is generated column
+			if (col.Generated()) {
+				return;
+			}
+			removed_index = i;
+			break;
+		}
+	}
+	D_ASSERT(removed_index != DConstants::INVALID_INDEX);
+	storage->CommitDropColumn(removed_index);
+}
+
+void TableCatalogEntry::CommitDrop() {
+	storage->CommitDropTable();
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+TableFunctionCatalogEntry::TableFunctionCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema,
+                                                     CreateTableFunctionInfo *info)
+    : StandardEntry(CatalogType::TABLE_FUNCTION_ENTRY, schema, catalog, info->name), functions(move(info->functions)) {
+	D_ASSERT(this->functions.size() > 0);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <sstream>
+
+namespace duckdb {
+
+TypeCatalogEntry::TypeCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateTypeInfo *info)
+    : StandardEntry(CatalogType::TYPE_ENTRY, schema, catalog, info->name), user_type(info->type) {
+	this->temporary = info->temporary;
+	this->internal = info->internal;
+}
+
+void TypeCatalogEntry::Serialize(Serializer &serializer) {
+	D_ASSERT(!internal);
+	FieldWriter writer(serializer);
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteSerializable(user_type);
+	writer.Finalize();
+}
+
+unique_ptr<CreateTypeInfo> TypeCatalogEntry::Deserialize(Deserializer &source) {
+	auto info = make_unique<CreateTypeInfo>();
+
+	FieldReader reader(source);
+	info->schema = reader.ReadRequired<string>();
+	info->name = reader.ReadRequired<string>();
+	info->type = reader.ReadRequiredSerializable<LogicalType, LogicalType>();
+	reader.Finalize();
+
+	return info;
+}
+
+string TypeCatalogEntry::ToSQL() {
+	std::stringstream ss;
+	switch (user_type.id()) {
+	case (LogicalTypeId::ENUM): {
+		Vector values_insert_order(EnumType::GetValuesInsertOrder(user_type));
+		idx_t size = EnumType::GetSize(user_type);
+		ss << "CREATE TYPE ";
+		ss << KeywordHelper::WriteOptionallyQuoted(name);
+		ss << " AS ENUM ( ";
+
+		for (idx_t i = 0; i < size; i++) {
+			ss << "'" << values_insert_order.GetValue(i).ToString() << "'";
+			if (i != size - 1) {
+				ss << ", ";
+			}
+		}
+		ss << ");";
+		break;
+	}
+	default:
+		throw InternalException("Logical Type can't be used as a User Defined Type");
+	}
+
+	return ss.str();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+void ViewCatalogEntry::Initialize(CreateViewInfo *info) {
+	query = move(info->query);
+	this->aliases = info->aliases;
+	this->types = info->types;
+	this->temporary = info->temporary;
+	this->sql = info->sql;
+	this->internal = info->internal;
+}
+
+ViewCatalogEntry::ViewCatalogEntry(Catalog *catalog, SchemaCatalogEntry *schema, CreateViewInfo *info)
+    : StandardEntry(CatalogType::VIEW_ENTRY, schema, catalog, info->view_name) {
+	Initialize(info);
+}
+
+unique_ptr<CatalogEntry> ViewCatalogEntry::AlterEntry(ClientContext &context, AlterInfo *info) {
+	D_ASSERT(!internal);
+	if (info->type != AlterType::ALTER_VIEW) {
+		throw CatalogException("Can only modify view with ALTER VIEW statement");
+	}
+	auto view_info = (AlterViewInfo *)info;
+	switch (view_info->alter_view_type) {
+	case AlterViewType::RENAME_VIEW: {
+		auto rename_info = (RenameViewInfo *)view_info;
+		auto copied_view = Copy(context);
+		copied_view->name = rename_info->new_view_name;
+		return copied_view;
+	}
+	default:
+		throw InternalException("Unrecognized alter view type!");
+	}
+}
+
+void ViewCatalogEntry::Serialize(Serializer &serializer) {
+	D_ASSERT(!internal);
+	FieldWriter writer(serializer);
+	writer.WriteString(schema->name);
+	writer.WriteString(name);
+	writer.WriteString(sql);
+	writer.WriteSerializable(*query);
+	writer.WriteList<string>(aliases);
+	writer.WriteRegularSerializableList<LogicalType>(types);
+	writer.Finalize();
+}
+
+unique_ptr<CreateViewInfo> ViewCatalogEntry::Deserialize(Deserializer &source) {
+	auto info = make_unique<CreateViewInfo>();
+
+	FieldReader reader(source);
+	info->schema = reader.ReadRequired<string>();
+	info->view_name = reader.ReadRequired<string>();
+	info->sql = reader.ReadRequired<string>();
+	info->query = reader.ReadRequiredSerializable<SelectStatement>();
+	info->aliases = reader.ReadRequiredList<string>();
+	info->types = reader.ReadRequiredSerializableList<LogicalType, LogicalType>();
+	reader.Finalize();
+
+	return info;
+}
+
+string ViewCatalogEntry::ToSQL() {
+	if (sql.empty()) {
+		//! Return empty sql with view name so pragma view_tables don't complain
+		return sql;
+	}
+	return sql + "\n;";
+}
+
+unique_ptr<CatalogEntry> ViewCatalogEntry::Copy(ClientContext &context) {
+	D_ASSERT(!internal);
+	auto create_info = make_unique<CreateViewInfo>(schema->name, name);
+	create_info->query = unique_ptr_cast<SQLStatement, SelectStatement>(query->Copy());
+	for (idx_t i = 0; i < aliases.size(); i++) {
+		create_info->aliases.push_back(aliases[i]);
+	}
+	for (idx_t i = 0; i < types.size(); i++) {
+		create_info->types.push_back(types[i]);
+	}
+	create_info->temporary = temporary;
+	create_info->sql = sql;
+
+	return make_unique<ViewCatalogEntry>(catalog, schema, create_info.get());
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+CatalogEntry::CatalogEntry(CatalogType type, Catalog *catalog_p, string name_p)
+    : oid(catalog_p->ModifyCatalog()), type(type), catalog(catalog_p), set(nullptr), name(move(name_p)), deleted(false),
+      temporary(false), internal(false), parent(nullptr) {
+}
+
+CatalogEntry::~CatalogEntry() {
+}
+
+void CatalogEntry::SetAsRoot() {
+}
+
+// LCOV_EXCL_START
+unique_ptr<CatalogEntry> CatalogEntry::AlterEntry(ClientContext &context, AlterInfo *info) {
+	throw InternalException("Unsupported alter type for catalog entry!");
+}
+
+unique_ptr<CatalogEntry> CatalogEntry::Copy(ClientContext &context) {
+	throw InternalException("Unsupported copy type for catalog entry!");
+}
+
+string CatalogEntry::ToSQL() {
+	throw InternalException("Unsupported catalog type for ToSQL()");
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+CatalogSearchPath::CatalogSearchPath(ClientContext &context_p) : context(context_p) {
+	SetPaths(ParsePaths(""));
+}
+
+void CatalogSearchPath::Set(const string &new_value, bool is_set_schema) {
+	auto new_paths = ParsePaths(new_value);
+	if (is_set_schema && new_paths.size() != 1) {
+		throw CatalogException("SET schema can set only 1 schema. This has %d", new_paths.size());
+	}
+	auto &catalog = Catalog::GetCatalog(context);
+	for (const auto &path : new_paths) {
+		if (!catalog.GetSchema(context, StringUtil::Lower(path), true)) {
+			throw CatalogException("SET %s: No schema named %s found.", is_set_schema ? "schema" : "search_path", path);
+		}
+	}
+	this->set_paths = move(new_paths);
+	SetPaths(set_paths);
+}
+
+const vector<string> &CatalogSearchPath::Get() {
+	return paths;
+}
+
+const string &CatalogSearchPath::GetOrDefault(const string &name) {
+	return name == INVALID_SCHEMA ? GetDefault() : name; // NOLINT
+}
+
+const string &CatalogSearchPath::GetDefault() {
+	const auto &paths = Get();
+	D_ASSERT(paths.size() >= 2);
+	D_ASSERT(paths[0] == TEMP_SCHEMA);
+	return paths[1];
+}
+
+void CatalogSearchPath::SetPaths(vector<string> new_paths) {
+	paths.clear();
+	paths.reserve(new_paths.size() + 3);
+	paths.emplace_back(TEMP_SCHEMA);
+	for (auto &path : new_paths) {
+		paths.push_back(move(path));
+	}
+	paths.emplace_back(DEFAULT_SCHEMA);
+	paths.emplace_back("pg_catalog");
+}
+
+vector<string> CatalogSearchPath::ParsePaths(const string &value) {
+	return StringUtil::SplitWithQuote(StringUtil::Lower(value));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//! Class responsible to keep track of state when removing entries from the catalog.
+//! When deleting, many types of errors can be thrown, since we want to avoid try/catch blocks
+//! this class makes sure that whatever elements were modified are returned to a correct state
+//! when exceptions are thrown.
+//! The idea here is to use RAII (Resource acquisition is initialization) to mimic a try/catch/finally block.
+//! If any exception is raised when this object exists, then its destructor will be called
+//! and the entry will return to its previous state during deconstruction.
+class EntryDropper {
+public:
+	//! Both constructor and destructor are privates because they should only be called by DropEntryDependencies
+	explicit EntryDropper(CatalogSet &catalog_set, idx_t entry_index)
+	    : catalog_set(catalog_set), entry_index(entry_index) {
+		old_deleted = catalog_set.entries[entry_index].get()->deleted;
+	}
+
+	~EntryDropper() {
+		catalog_set.entries[entry_index].get()->deleted = old_deleted;
+	}
+
+private:
+	//! The current catalog_set
+	CatalogSet &catalog_set;
+	//! Keeps track of the state of the entry before starting the delete
+	bool old_deleted;
+	//! Index of entry to be deleted
+	idx_t entry_index;
+};
+
+CatalogSet::CatalogSet(Catalog &catalog, unique_ptr<DefaultGenerator> defaults)
+    : catalog(catalog), defaults(move(defaults)) {
+}
+
+bool CatalogSet::CreateEntry(ClientContext &context, const string &name, unique_ptr<CatalogEntry> value,
+                             unordered_set<CatalogEntry *> &dependencies) {
+	auto &transaction = Transaction::GetTransaction(context);
+	// lock the catalog for writing
+	lock_guard<mutex> write_lock(catalog.write_lock);
+	// lock this catalog set to disallow reading
+	unique_lock<mutex> read_lock(catalog_lock);
+
+	// first check if the entry exists in the unordered set
+	idx_t entry_index;
+	auto mapping_value = GetMapping(context, name);
+	if (mapping_value == nullptr || mapping_value->deleted) {
+		// if it does not: entry has never been created
+
+		// check if there is a default entry
+		auto entry = CreateDefaultEntry(context, name, read_lock);
+		if (entry) {
+			return false;
+		}
+
+		// first create a dummy deleted entry for this entry
+		// so transactions started before the commit of this transaction don't
+		// see it yet
+		entry_index = current_entry++;
+		auto dummy_node = make_unique<CatalogEntry>(CatalogType::INVALID, value->catalog, name);
+		dummy_node->timestamp = 0;
+		dummy_node->deleted = true;
+		dummy_node->set = this;
+
+		entries[entry_index] = move(dummy_node);
+		PutMapping(context, name, entry_index);
+	} else {
+		entry_index = mapping_value->index;
+		auto &current = *entries[entry_index];
+		// if it does, we have to check version numbers
+		if (HasConflict(context, current.timestamp)) {
+			// current version has been written to by a currently active
+			// transaction
+			throw TransactionException("Catalog write-write conflict on create with \"%s\"", current.name);
+		}
+		// there is a current version that has been committed
+		// if it has not been deleted there is a conflict
+		if (!current.deleted) {
+			return false;
+		}
+	}
+	// create a new entry and replace the currently stored one
+	// set the timestamp to the timestamp of the current transaction
+	// and point it at the dummy node
+	value->timestamp = transaction.transaction_id;
+	value->set = this;
+
+	// now add the dependency set of this object to the dependency manager
+	catalog.dependency_manager->AddObject(context, value.get(), dependencies);
+
+	value->child = move(entries[entry_index]);
+	value->child->parent = value.get();
+	// push the old entry in the undo buffer for this transaction
+	transaction.PushCatalogEntry(value->child.get());
+	entries[entry_index] = move(value);
+	return true;
+}
+
+bool CatalogSet::GetEntryInternal(ClientContext &context, idx_t entry_index, CatalogEntry *&catalog_entry) {
+	catalog_entry = entries[entry_index].get();
+	// if it does: we have to retrieve the entry and to check version numbers
+	if (HasConflict(context, catalog_entry->timestamp)) {
+		// current version has been written to by a currently active
+		// transaction
+		throw TransactionException("Catalog write-write conflict on alter with \"%s\"", catalog_entry->name);
+	}
+	// there is a current version that has been committed by this transaction
+	if (catalog_entry->deleted) {
+		// if the entry was already deleted, it now does not exist anymore
+		// so we return that we could not find it
+		return false;
+	}
+	return true;
+}
+
+bool CatalogSet::GetEntryInternal(ClientContext &context, const string &name, idx_t &entry_index,
+                                  CatalogEntry *&catalog_entry) {
+	auto mapping_value = GetMapping(context, name);
+	if (mapping_value == nullptr || mapping_value->deleted) {
+		// the entry does not exist, check if we can create a default entry
+		return false;
+	}
+	entry_index = mapping_value->index;
+	return GetEntryInternal(context, entry_index, catalog_entry);
+}
+
+bool CatalogSet::AlterOwnership(ClientContext &context, ChangeOwnershipInfo *info) {
+	idx_t entry_index;
+	CatalogEntry *entry;
+	if (!GetEntryInternal(context, info->name, entry_index, entry)) {
+		return false;
+	}
+
+	auto owner_entry = catalog.GetEntry(context, info->owner_schema, info->owner_name);
+	if (!owner_entry) {
+		return false;
+	}
+
+	catalog.dependency_manager->AddOwnership(context, owner_entry, entry);
+
+	return true;
+}
+
+bool CatalogSet::AlterEntry(ClientContext &context, const string &name, AlterInfo *alter_info) {
+	auto &transaction = Transaction::GetTransaction(context);
+	// lock the catalog for writing
+	lock_guard<mutex> write_lock(catalog.write_lock);
+
+	// first check if the entry exists in the unordered set
+	idx_t entry_index;
+	CatalogEntry *entry;
+	if (!GetEntryInternal(context, name, entry_index, entry)) {
+		return false;
+	}
+	if (entry->internal) {
+		throw CatalogException("Cannot alter entry \"%s\" because it is an internal system entry", entry->name);
+	}
+
+	// lock this catalog set to disallow reading
+	lock_guard<mutex> read_lock(catalog_lock);
+
+	// create a new entry and replace the currently stored one
+	// set the timestamp to the timestamp of the current transaction
+	// and point it to the updated table node
+	string original_name = entry->name;
+	auto value = entry->AlterEntry(context, alter_info);
+	if (!value) {
+		// alter failed, but did not result in an error
+		return true;
+	}
+
+	if (value->name != original_name) {
+		auto mapping_value = GetMapping(context, value->name);
+		if (mapping_value && !mapping_value->deleted) {
+			auto entry = GetEntryForTransaction(context, entries[mapping_value->index].get());
+			if (!entry->deleted) {
+				string rename_err_msg =
+				    "Could not rename \"%s\" to \"%s\": another entry with this name already exists!";
+				throw CatalogException(rename_err_msg, original_name, value->name);
+			}
+		}
+		PutMapping(context, value->name, entry_index);
+		DeleteMapping(context, original_name);
+	}
+	//! Check the dependency manager to verify that there are no conflicting dependencies with this alter
+	catalog.dependency_manager->AlterObject(context, entry, value.get());
+
+	value->timestamp = transaction.transaction_id;
+	value->child = move(entries[entry_index]);
+	value->child->parent = value.get();
+	value->set = this;
+
+	// serialize the AlterInfo into a temporary buffer
+	BufferedSerializer serializer;
+	alter_info->Serialize(serializer);
+	BinaryData serialized_alter = serializer.GetData();
+
+	// push the old entry in the undo buffer for this transaction
+	transaction.PushCatalogEntry(value->child.get(), serialized_alter.data.get(), serialized_alter.size);
+	entries[entry_index] = move(value);
+
+	return true;
+}
+
+void CatalogSet::DropEntryDependencies(ClientContext &context, idx_t entry_index, CatalogEntry &entry, bool cascade) {
+
+	// Stores the deleted value of the entry before starting the process
+	EntryDropper dropper(*this, entry_index);
+
+	// To correctly delete the object and its dependencies, it temporarily is set to deleted.
+	entries[entry_index].get()->deleted = true;
+
+	// check any dependencies of this object
+	entry.catalog->dependency_manager->DropObject(context, &entry, cascade);
+
+	// dropper destructor is called here
+	// the destructor makes sure to return the value to the previous state
+	// dropper.~EntryDropper()
+}
+
+void CatalogSet::DropEntryInternal(ClientContext &context, idx_t entry_index, CatalogEntry &entry, bool cascade) {
+	auto &transaction = Transaction::GetTransaction(context);
+
+	DropEntryDependencies(context, entry_index, entry, cascade);
+
+	// create a new entry and replace the currently stored one
+	// set the timestamp to the timestamp of the current transaction
+	// and point it at the dummy node
+	auto value = make_unique<CatalogEntry>(CatalogType::DELETED_ENTRY, entry.catalog, entry.name);
+	value->timestamp = transaction.transaction_id;
+	value->child = move(entries[entry_index]);
+	value->child->parent = value.get();
+	value->set = this;
+	value->deleted = true;
+
+	// push the old entry in the undo buffer for this transaction
+	transaction.PushCatalogEntry(value->child.get());
+
+	entries[entry_index] = move(value);
+}
+
+bool CatalogSet::DropEntry(ClientContext &context, const string &name, bool cascade) {
+	// lock the catalog for writing
+	lock_guard<mutex> write_lock(catalog.write_lock);
+	// we can only delete an entry that exists
+	idx_t entry_index;
+	CatalogEntry *entry;
+	if (!GetEntryInternal(context, name, entry_index, entry)) {
+		return false;
+	}
+	if (entry->internal) {
+		throw CatalogException("Cannot drop entry \"%s\" because it is an internal system entry", entry->name);
+	}
+
+	DropEntryInternal(context, entry_index, *entry, cascade);
+	return true;
+}
+
+void CatalogSet::CleanupEntry(CatalogEntry *catalog_entry) {
+	// destroy the backed up entry: it is no longer required
+	D_ASSERT(catalog_entry->parent);
+	if (catalog_entry->parent->type != CatalogType::UPDATED_ENTRY) {
+		lock_guard<mutex> lock(catalog_lock);
+		if (!catalog_entry->deleted) {
+			// delete the entry from the dependency manager, if it is not deleted yet
+			catalog_entry->catalog->dependency_manager->EraseObject(catalog_entry);
+		}
+		auto parent = catalog_entry->parent;
+		parent->child = move(catalog_entry->child);
+		if (parent->deleted && !parent->child && !parent->parent) {
+			auto mapping_entry = mapping.find(parent->name);
+			D_ASSERT(mapping_entry != mapping.end());
+			auto index = mapping_entry->second->index;
+			auto entry = entries.find(index);
+			D_ASSERT(entry != entries.end());
+			if (entry->second.get() == parent) {
+				mapping.erase(mapping_entry);
+				entries.erase(entry);
+			}
+		}
+	}
+}
+
+bool CatalogSet::HasConflict(ClientContext &context, transaction_t timestamp) {
+	auto &transaction = Transaction::GetTransaction(context);
+	return (timestamp >= TRANSACTION_ID_START && timestamp != transaction.transaction_id) ||
+	       (timestamp < TRANSACTION_ID_START && timestamp > transaction.start_time);
+}
+
+MappingValue *CatalogSet::GetMapping(ClientContext &context, const string &name, bool get_latest) {
+	MappingValue *mapping_value;
+	auto entry = mapping.find(name);
+	if (entry != mapping.end()) {
+		mapping_value = entry->second.get();
+	} else {
+
+		return nullptr;
+	}
+	if (get_latest) {
+		return mapping_value;
+	}
+	while (mapping_value->child) {
+		if (UseTimestamp(context, mapping_value->timestamp)) {
+			break;
+		}
+		mapping_value = mapping_value->child.get();
+		D_ASSERT(mapping_value);
+	}
+	return mapping_value;
+}
+
+void CatalogSet::PutMapping(ClientContext &context, const string &name, idx_t entry_index) {
+	auto entry = mapping.find(name);
+	auto new_value = make_unique<MappingValue>(entry_index);
+	new_value->timestamp = Transaction::GetTransaction(context).transaction_id;
+	if (entry != mapping.end()) {
+		if (HasConflict(context, entry->second->timestamp)) {
+			throw TransactionException("Catalog write-write conflict on name \"%s\"", name);
+		}
+		new_value->child = move(entry->second);
+		new_value->child->parent = new_value.get();
+	}
+	mapping[name] = move(new_value);
+}
+
+void CatalogSet::DeleteMapping(ClientContext &context, const string &name) {
+	auto entry = mapping.find(name);
+	D_ASSERT(entry != mapping.end());
+	auto delete_marker = make_unique<MappingValue>(entry->second->index);
+	delete_marker->deleted = true;
+	delete_marker->timestamp = Transaction::GetTransaction(context).transaction_id;
+	delete_marker->child = move(entry->second);
+	delete_marker->child->parent = delete_marker.get();
+	mapping[name] = move(delete_marker);
+}
+
+bool CatalogSet::UseTimestamp(ClientContext &context, transaction_t timestamp) {
+	auto &transaction = Transaction::GetTransaction(context);
+	if (timestamp == transaction.transaction_id) {
+		// we created this version
+		return true;
+	}
+	if (timestamp < transaction.start_time) {
+		// this version was commited before we started the transaction
+		return true;
+	}
+	return false;
+}
+
+CatalogEntry *CatalogSet::GetEntryForTransaction(ClientContext &context, CatalogEntry *current) {
+	while (current->child) {
+		if (UseTimestamp(context, current->timestamp)) {
+			break;
+		}
+		current = current->child.get();
+		D_ASSERT(current);
+	}
+	return current;
+}
+
+CatalogEntry *CatalogSet::GetCommittedEntry(CatalogEntry *current) {
+	while (current->child) {
+		if (current->timestamp < TRANSACTION_ID_START) {
+			// this entry is committed: use it
+			break;
+		}
+		current = current->child.get();
+		D_ASSERT(current);
+	}
+	return current;
+}
+
+pair<string, idx_t> CatalogSet::SimilarEntry(ClientContext &context, const string &name) {
+	unique_lock<mutex> lock(catalog_lock);
+	CreateDefaultEntries(context, lock);
+
+	string result;
+	idx_t current_score = (idx_t)-1;
+	for (auto &kv : mapping) {
+		auto mapping_value = GetMapping(context, kv.first);
+		if (mapping_value && !mapping_value->deleted) {
+			auto ldist = StringUtil::LevenshteinDistance(kv.first, name);
+			if (ldist < current_score) {
+				current_score = ldist;
+				result = kv.first;
+			}
+		}
+	}
+	return {result, current_score};
+}
+
+CatalogEntry *CatalogSet::CreateEntryInternal(ClientContext &context, unique_ptr<CatalogEntry> entry) {
+	if (mapping.find(entry->name) != mapping.end()) {
+		return nullptr;
+	}
+	auto &name = entry->name;
+	auto entry_index = current_entry++;
+	auto catalog_entry = entry.get();
+
+	entry->set = this;
+	entry->timestamp = 0;
+
+	PutMapping(context, name, entry_index);
+	mapping[name]->timestamp = 0;
+	entries[entry_index] = move(entry);
+	return catalog_entry;
+}
+
+CatalogEntry *CatalogSet::CreateDefaultEntry(ClientContext &context, const string &name, unique_lock<mutex> &lock) {
+	// no entry found with this name, check for defaults
+	if (!defaults || defaults->created_all_entries) {
+		// no defaults either: return null
+		return nullptr;
+	}
+	// this catalog set has a default map defined
+	// check if there is a default entry that we can create with this name
+	lock.unlock();
+	auto entry = defaults->CreateDefaultEntry(context, name);
+
+	lock.lock();
+	if (!entry) {
+		// no default entry
+		return nullptr;
+	}
+	// there is a default entry! create it
+	auto result = CreateEntryInternal(context, move(entry));
+	if (result) {
+		return result;
+	}
+	// we found a default entry, but failed
+	// this means somebody else created the entry first
+	// just retry?
+	lock.unlock();
+	return GetEntry(context, name);
+}
+
+CatalogEntry *CatalogSet::GetEntry(ClientContext &context, const string &name) {
+	unique_lock<mutex> lock(catalog_lock);
+	auto mapping_value = GetMapping(context, name);
+	if (mapping_value != nullptr && !mapping_value->deleted) {
+		// we found an entry for this name
+		// check the version numbers
+
+		auto catalog_entry = entries[mapping_value->index].get();
+		CatalogEntry *current = GetEntryForTransaction(context, catalog_entry);
+		if (current->deleted || (current->name != name && !UseTimestamp(context, mapping_value->timestamp))) {
+			return nullptr;
+		}
+		return current;
+	}
+	return CreateDefaultEntry(context, name, lock);
+}
+
+void CatalogSet::UpdateTimestamp(CatalogEntry *entry, transaction_t timestamp) {
+	entry->timestamp = timestamp;
+	mapping[entry->name]->timestamp = timestamp;
+}
+
+void CatalogSet::AdjustUserDependency(CatalogEntry *entry, ColumnDefinition &column, bool remove) {
+	CatalogEntry *user_type_catalog = (CatalogEntry *)LogicalType::GetCatalog(column.Type());
+	if (user_type_catalog) {
+		if (remove) {
+			catalog.dependency_manager->dependents_map[user_type_catalog].erase(entry->parent);
+			catalog.dependency_manager->dependencies_map[entry->parent].erase(user_type_catalog);
+		} else {
+			catalog.dependency_manager->dependents_map[user_type_catalog].insert(entry);
+			catalog.dependency_manager->dependencies_map[entry].insert(user_type_catalog);
+		}
+	}
+}
+
+void CatalogSet::AdjustDependency(CatalogEntry *entry, TableCatalogEntry *table, ColumnDefinition &column,
+                                  bool remove) {
+	bool found = false;
+	if (column.Type().id() == LogicalTypeId::ENUM) {
+		for (auto &old_column : table->columns) {
+			if (old_column.Name() == column.Name() && old_column.Type().id() != LogicalTypeId::ENUM) {
+				AdjustUserDependency(entry, column, remove);
+				found = true;
+			}
+		}
+		if (!found) {
+			AdjustUserDependency(entry, column, remove);
+		}
+	} else if (!(column.Type().GetAlias().empty())) {
+		auto alias = column.Type().GetAlias();
+		for (auto &old_column : table->columns) {
+			auto old_alias = old_column.Type().GetAlias();
+			if (old_column.Name() == column.Name() && old_alias != alias) {
+				AdjustUserDependency(entry, column, remove);
+				found = true;
+			}
+		}
+		if (!found) {
+			AdjustUserDependency(entry, column, remove);
+		}
+	}
+}
+
+void CatalogSet::AdjustTableDependencies(CatalogEntry *entry) {
+	if (entry->type == CatalogType::TABLE_ENTRY && entry->parent->type == CatalogType::TABLE_ENTRY) {
+		// If it's a table entry we have to check for possibly removing or adding user type dependencies
+		auto old_table = (TableCatalogEntry *)entry->parent;
+		auto new_table = (TableCatalogEntry *)entry;
+
+		for (auto &new_column : new_table->columns) {
+			AdjustDependency(entry, old_table, new_column, false);
+		}
+		for (auto &old_column : old_table->columns) {
+			AdjustDependency(entry, new_table, old_column, true);
+		}
+	}
+}
+
+void CatalogSet::Undo(CatalogEntry *entry) {
+	lock_guard<mutex> write_lock(catalog.write_lock);
+
+	lock_guard<mutex> lock(catalog_lock);
+
+	// entry has to be restored
+	// and entry->parent has to be removed ("rolled back")
+
+	// i.e. we have to place (entry) as (entry->parent) again
+	auto &to_be_removed_node = entry->parent;
+
+	AdjustTableDependencies(entry);
+
+	if (!to_be_removed_node->deleted) {
+		// delete the entry from the dependency manager as well
+		catalog.dependency_manager->EraseObject(to_be_removed_node);
+	}
+	if (entry->name != to_be_removed_node->name) {
+		// rename: clean up the new name when the rename is rolled back
+		auto removed_entry = mapping.find(to_be_removed_node->name);
+		if (removed_entry->second->child) {
+			removed_entry->second->child->parent = nullptr;
+			mapping[to_be_removed_node->name] = move(removed_entry->second->child);
+		} else {
+			mapping.erase(removed_entry);
+		}
+	}
+	if (to_be_removed_node->parent) {
+		// if the to be removed node has a parent, set the child pointer to the
+		// to be restored node
+		to_be_removed_node->parent->child = move(to_be_removed_node->child);
+		entry->parent = to_be_removed_node->parent;
+	} else {
+		// otherwise we need to update the base entry tables
+		auto &name = entry->name;
+		to_be_removed_node->child->SetAsRoot();
+		entries[mapping[name]->index] = move(to_be_removed_node->child);
+		entry->parent = nullptr;
+	}
+
+	// restore the name if it was deleted
+	auto restored_entry = mapping.find(entry->name);
+	if (restored_entry->second->deleted || entry->type == CatalogType::INVALID) {
+		if (restored_entry->second->child) {
+			restored_entry->second->child->parent = nullptr;
+			mapping[entry->name] = move(restored_entry->second->child);
+		} else {
+			mapping.erase(restored_entry);
+		}
+	}
+	// we mark the catalog as being modified, since this action can lead to e.g. tables being dropped
+	entry->catalog->ModifyCatalog();
+}
+
+void CatalogSet::CreateDefaultEntries(ClientContext &context, unique_lock<mutex> &lock) {
+	if (!defaults || defaults->created_all_entries) {
+		return;
+	}
+	// this catalog set has a default set defined:
+	auto default_entries = defaults->GetDefaultEntries();
+	for (auto &default_entry : default_entries) {
+		auto map_entry = mapping.find(default_entry);
+		if (map_entry == mapping.end()) {
+			// we unlock during the CreateEntry, since it might reference other catalog sets...
+			// specifically for views this can happen since the view will be bound
+			lock.unlock();
+			auto entry = defaults->CreateDefaultEntry(context, default_entry);
+			if (!entry) {
+				throw InternalException("Failed to create default entry for %s", default_entry);
+			}
+
+			lock.lock();
+			CreateEntryInternal(context, move(entry));
+		}
+	}
+	defaults->created_all_entries = true;
+}
+
+void CatalogSet::Scan(ClientContext &context, const std::function<void(CatalogEntry *)> &callback) {
+	// lock the catalog set
+	unique_lock<mutex> lock(catalog_lock);
+	CreateDefaultEntries(context, lock);
+
+	for (auto &kv : entries) {
+		auto entry = kv.second.get();
+		entry = GetEntryForTransaction(context, entry);
+		if (!entry->deleted) {
+			callback(entry);
+		}
+	}
+}
+
+void CatalogSet::Scan(const std::function<void(CatalogEntry *)> &callback) {
+	// lock the catalog set
+	lock_guard<mutex> lock(catalog_lock);
+	for (auto &kv : entries) {
+		auto entry = kv.second.get();
+		entry = GetCommittedEntry(entry);
+		if (!entry->deleted) {
+			callback(entry);
+		}
+	}
+}
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static DefaultMacro internal_macros[] = {
+	{DEFAULT_SCHEMA, "current_user", {nullptr}, "'duckdb'"},                       // user name of current execution context
+	{DEFAULT_SCHEMA, "current_catalog", {nullptr}, "'duckdb'"},                    // name of current database (called "catalog" in the SQL standard)
+	{DEFAULT_SCHEMA, "current_database", {nullptr}, "'duckdb'"},                   // name of current database
+	{DEFAULT_SCHEMA, "user", {nullptr}, "current_user"},                           // equivalent to current_user
+	{DEFAULT_SCHEMA, "session_user", {nullptr}, "'duckdb'"},                       // session user name
+	{"pg_catalog", "inet_client_addr", {nullptr}, "NULL"},                       // address of the remote connection
+	{"pg_catalog", "inet_client_port", {nullptr}, "NULL"},                       // port of the remote connection
+	{"pg_catalog", "inet_server_addr", {nullptr}, "NULL"},                       // address of the local connection
+	{"pg_catalog", "inet_server_port", {nullptr}, "NULL"},                       // port of the local connection
+	{"pg_catalog", "pg_my_temp_schema", {nullptr}, "0"},                         // OID of session's temporary schema, or 0 if none
+	{"pg_catalog", "pg_is_other_temp_schema", {"schema_id", nullptr}, "false"},  // is schema another session's temporary schema?
+
+	{"pg_catalog", "pg_conf_load_time", {nullptr}, "current_timestamp"},         // configuration load time
+	{"pg_catalog", "pg_postmaster_start_time", {nullptr}, "current_timestamp"},  // server start time
+
+	{"pg_catalog", "pg_typeof", {"expression", nullptr}, "lower(typeof(expression))"},  // get the data type of any value
+
+	// privilege functions
+	// {"has_any_column_privilege", {"user", "table", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for any column of table
+	{"pg_catalog", "has_any_column_privilege", {"table", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for any column of table
+	// {"has_column_privilege", {"user", "table", "column", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for column
+	{"pg_catalog", "has_column_privilege", {"table", "column", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for column
+	// {"has_database_privilege", {"user", "database", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for database
+	{"pg_catalog", "has_database_privilege", {"database", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for database
+	// {"has_foreign_data_wrapper_privilege", {"user", "fdw", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for foreign-data wrapper
+	{"pg_catalog", "has_foreign_data_wrapper_privilege", {"fdw", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for foreign-data wrapper
+	// {"has_function_privilege", {"user", "function", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for function
+	{"pg_catalog", "has_function_privilege", {"function", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for function
+	// {"has_language_privilege", {"user", "language", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for language
+	{"pg_catalog", "has_language_privilege", {"language", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for language
+	// {"has_schema_privilege", {"user", "schema, privilege", nullptr}, "true"},  //boolean  //does user have privilege for schema
+	{"pg_catalog", "has_schema_privilege", {"schema", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for schema
+	// {"has_sequence_privilege", {"user", "sequence", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for sequence
+	{"pg_catalog", "has_sequence_privilege", {"sequence", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for sequence
+	// {"has_server_privilege", {"user", "server", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for foreign server
+	{"pg_catalog", "has_server_privilege", {"server", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for foreign server
+	// {"has_table_privilege", {"user", "table", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for table
+	{"pg_catalog", "has_table_privilege", {"table", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for table
+	// {"has_tablespace_privilege", {"user", "tablespace", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for tablespace
+	{"pg_catalog", "has_tablespace_privilege", {"tablespace", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for tablespace
+
+	// various postgres system functions
+	{"pg_catalog", "pg_get_viewdef", {"oid", nullptr}, "(select sql from duckdb_views() v where v.view_oid=oid)"},
+	{"pg_catalog", "pg_get_constraintdef", {"constraint_oid", "pretty_bool", nullptr}, "(select constraint_text from duckdb_constraints() d_constraint where d_constraint.table_oid=constraint_oid/1000000 and d_constraint.constraint_index=constraint_oid%1000000)"},
+	{"pg_catalog", "pg_get_expr", {"pg_node_tree", "relation_oid", nullptr}, "pg_node_tree"},
+	{"pg_catalog", "format_pg_type", {"type_name", nullptr}, "case when logical_type='FLOAT' then 'real' when logical_type='DOUBLE' then 'double precision' when logical_type='DECIMAL' then 'numeric' when logical_type='VARCHAR' then 'character varying' when logical_type='BLOB' then 'bytea' when logical_type='TIMESTAMP' then 'timestamp without time zone' when logical_type='TIME' then 'time without time zone' else lower(logical_type) end"},
+	{"pg_catalog", "format_type", {"type_oid", "typemod", nullptr}, "(select format_pg_type(type_name) from duckdb_types() t where t.type_oid=type_oid) || case when typemod>0 then concat('(', typemod/1000, ',', typemod%1000, ')') else '' end"},
+
+	{"pg_catalog", "pg_has_role", {"user", "role", "privilege", nullptr}, "true"},  //boolean  //does user have privilege for role
+	{"pg_catalog", "pg_has_role", {"role", "privilege", nullptr}, "true"},  //boolean  //does current user have privilege for role
+
+	{"pg_catalog", "col_description", {"table_oid", "column_number", nullptr}, "NULL"},   // get comment for a table column
+	{"pg_catalog", "obj_description", {"object_oid", "catalog_name", nullptr}, "NULL"},   // get comment for a database object
+	{"pg_catalog", "shobj_description", {"object_oid", "catalog_name", nullptr}, "NULL"}, // get comment for a shared database object
+
+	// visibility functions
+	{"pg_catalog", "pg_collation_is_visible", {"collation_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_conversion_is_visible", {"conversion_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_function_is_visible", {"function_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_opclass_is_visible", {"opclass_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_operator_is_visible", {"operator_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_opfamily_is_visible", {"opclass_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_table_is_visible", {"table_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_ts_config_is_visible", {"config_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_ts_dict_is_visible", {"dict_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_ts_parser_is_visible", {"parser_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_ts_template_is_visible", {"template_oid", nullptr}, "true"},
+	{"pg_catalog", "pg_type_is_visible", {"type_oid", nullptr}, "true"},
+
+	{DEFAULT_SCHEMA, "round_even", {"x", "n", nullptr}, "CASE ((abs(x) * power(10, n+1)) % 10) WHEN 5 THEN round(x/2, n) * 2 ELSE round(x, n) END"},
+	{DEFAULT_SCHEMA, "roundbankers", {"x", "n", nullptr}, "round_even(x, n)"},
+	{DEFAULT_SCHEMA, "nullif", {"a", "b", nullptr}, "CASE WHEN a=b THEN NULL ELSE a END"},
+	{DEFAULT_SCHEMA, "list_append", {"l", "e", nullptr}, "list_concat(l, list_value(e))"},
+	{DEFAULT_SCHEMA, "array_append", {"arr", "el", nullptr}, "list_append(arr, el)"},
+	{DEFAULT_SCHEMA, "list_prepend", {"e", "l", nullptr}, "list_concat(list_value(e), l)"},
+	{DEFAULT_SCHEMA, "array_prepend", {"el", "arr", nullptr}, "list_prepend(el, arr)"},
+	{DEFAULT_SCHEMA, "array_pop_back", {"arr", nullptr}, "arr[:LEN(arr)-1]"},
+	{DEFAULT_SCHEMA, "array_pop_front", {"arr", nullptr}, "arr[2:]"},
+	{DEFAULT_SCHEMA, "array_push_back", {"arr", "e", nullptr}, "list_concat(arr, list_value(e))"},
+	{DEFAULT_SCHEMA, "array_push_front", {"arr", "e", nullptr}, "list_concat(list_value(e), arr)"},
+	{DEFAULT_SCHEMA, "generate_subscripts", {"arr", "dim", nullptr}, "unnest(generate_series(1, array_length(arr, dim)))"},
+	{DEFAULT_SCHEMA, "fdiv", {"x", "y", nullptr}, "floor(x/y)"},
+	{DEFAULT_SCHEMA, "fmod", {"x", "y", nullptr}, "(x-y*floor(x/y))"},
+
+	// algebraic list aggregates
+	{DEFAULT_SCHEMA, "list_avg", {"l", nullptr}, "list_aggr(l, 'avg')"},
+	{DEFAULT_SCHEMA, "list_var_samp", {"l", nullptr}, "list_aggr(l, 'var_samp')"},
+	{DEFAULT_SCHEMA, "list_var_pop", {"l", nullptr}, "list_aggr(l, 'var_pop')"},
+	{DEFAULT_SCHEMA, "list_stddev_pop", {"l", nullptr}, "list_aggr(l, 'stddev_pop')"},
+	{DEFAULT_SCHEMA, "list_stddev_samp", {"l", nullptr}, "list_aggr(l, 'stddev_samp')"},
+	{DEFAULT_SCHEMA, "list_sem", {"l", nullptr}, "list_aggr(l, 'sem')"},
+
+	// distributive list aggregates
+	{DEFAULT_SCHEMA, "list_approx_count_distinct", {"l", nullptr}, "list_aggr(l, 'approx_count_distinct')"},
+	{DEFAULT_SCHEMA, "list_bit_xor", {"l", nullptr}, "list_aggr(l, 'bit_xor')"},
+	{DEFAULT_SCHEMA, "list_bit_or", {"l", nullptr}, "list_aggr(l, 'bit_or')"},
+	{DEFAULT_SCHEMA, "list_bit_and", {"l", nullptr}, "list_aggr(l, 'bit_and')"},
+	{DEFAULT_SCHEMA, "list_bool_and", {"l", nullptr}, "list_aggr(l, 'bool_and')"},
+	{DEFAULT_SCHEMA, "list_bool_or", {"l", nullptr}, "list_aggr(l, 'bool_or')"},
+	{DEFAULT_SCHEMA, "list_count", {"l", nullptr}, "list_aggr(l, 'count')"},
+	{DEFAULT_SCHEMA, "list_entropy", {"l", nullptr}, "list_aggr(l, 'entropy')"},
+	{DEFAULT_SCHEMA, "list_last", {"l", nullptr}, "list_aggr(l, 'last')"},
+	{DEFAULT_SCHEMA, "list_first", {"l", nullptr}, "list_aggr(l, 'first')"},
+	{DEFAULT_SCHEMA, "list_kurtosis", {"l", nullptr}, "list_aggr(l, 'kurtosis')"},
+	{DEFAULT_SCHEMA, "list_min", {"l", nullptr}, "list_aggr(l, 'min')"},
+	{DEFAULT_SCHEMA, "list_max", {"l", nullptr}, "list_aggr(l, 'max')"},
+	{DEFAULT_SCHEMA, "list_product", {"l", nullptr}, "list_aggr(l, 'product')"},
+	{DEFAULT_SCHEMA, "list_skewness", {"l", nullptr}, "list_aggr(l, 'skewness')"},
+	{DEFAULT_SCHEMA, "list_sum", {"l", nullptr}, "list_aggr(l, 'sum')"},
+	{DEFAULT_SCHEMA, "list_string_agg", {"l", nullptr}, "list_aggr(l, 'string_agg')"},
+
+	// holistic list aggregates
+	{DEFAULT_SCHEMA, "list_mode", {"l", nullptr}, "list_aggr(l, 'mode')"},
+	{DEFAULT_SCHEMA, "list_median", {"l", nullptr}, "list_aggr(l, 'median')"},
+	{DEFAULT_SCHEMA, "list_mad", {"l", nullptr}, "list_aggr(l, 'mad')"},
+
+	// nested list aggregates
+	{DEFAULT_SCHEMA, "list_histogram", {"l", nullptr}, "list_aggr(l, 'histogram')"},
+
+	{nullptr, nullptr, {nullptr}, nullptr}
+	};
+
+unique_ptr<CreateMacroInfo> DefaultFunctionGenerator::CreateInternalTableMacroInfo(DefaultMacro &default_macro, unique_ptr<MacroFunction> function) {
+	for (idx_t param_idx = 0; default_macro.parameters[param_idx] != nullptr; param_idx++) {
+		function->parameters.push_back(
+		    make_unique<ColumnRefExpression>(default_macro.parameters[param_idx]));
+	}
+
+	auto bind_info = make_unique<CreateMacroInfo>();
+	bind_info->schema = default_macro.schema;
+	bind_info->name = default_macro.name;
+	bind_info->temporary = true;
+	bind_info->internal = true;
+	bind_info->type = function->type == MacroType::TABLE_MACRO ? CatalogType::TABLE_MACRO_ENTRY : CatalogType::MACRO_ENTRY;
+	bind_info->function = move(function);
+	return bind_info;
+
+}
+
+unique_ptr<CreateMacroInfo> DefaultFunctionGenerator::CreateInternalMacroInfo(DefaultMacro &default_macro) {
+	// parse the expression
+	auto expressions = Parser::ParseExpressionList(default_macro.macro);
+	D_ASSERT(expressions.size() == 1);
+
+	auto result = make_unique<ScalarMacroFunction>(move(expressions[0]));
+	return CreateInternalTableMacroInfo(default_macro, move(result));
+}
+
+unique_ptr<CreateMacroInfo> DefaultFunctionGenerator::CreateInternalTableMacroInfo(DefaultMacro &default_macro) {
+	Parser parser;
+	parser.ParseQuery(default_macro.macro);
+	D_ASSERT(parser.statements.size() == 1);
+	D_ASSERT(parser.statements[0]->type == StatementType::SELECT_STATEMENT);
+
+	auto &select = (SelectStatement &) *parser.statements[0];
+	auto result = make_unique<TableMacroFunction>(move(select.node));
+	return CreateInternalTableMacroInfo(default_macro, move(result));
+}
+
+static unique_ptr<CreateFunctionInfo> GetDefaultFunction(const string &input_schema, const string &input_name) {
+	auto schema = StringUtil::Lower(input_schema);
+	auto name = StringUtil::Lower(input_name);
+	for (idx_t index = 0; internal_macros[index].name != nullptr; index++) {
+		if (internal_macros[index].schema == schema && internal_macros[index].name == name) {
+			return DefaultFunctionGenerator::CreateInternalMacroInfo(internal_macros[index]);
+		}
+	}
+	return nullptr;
+}
+
+DefaultFunctionGenerator::DefaultFunctionGenerator(Catalog &catalog, SchemaCatalogEntry *schema)
+    : DefaultGenerator(catalog), schema(schema) {
+}
+
+unique_ptr<CatalogEntry> DefaultFunctionGenerator::CreateDefaultEntry(ClientContext &context,
+                                                                      const string &entry_name) {
+	auto info = GetDefaultFunction(schema->name, entry_name);
+	if (info) {
+		return make_unique_base<CatalogEntry, ScalarMacroCatalogEntry>(&catalog, schema, (CreateMacroInfo *)info.get());
+	}
+	return nullptr;
+}
+
+vector<string> DefaultFunctionGenerator::GetDefaultEntries() {
+	vector<string> result;
+	for (idx_t index = 0; internal_macros[index].name != nullptr; index++) {
+		if (internal_macros[index].schema == schema->name) {
+			result.emplace_back(internal_macros[index].name);
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+struct DefaultSchema {
+	const char *name;
+};
+
+static DefaultSchema internal_schemas[] = {{"information_schema"}, {"pg_catalog"}, {nullptr}};
+
+static bool GetDefaultSchema(const string &input_schema) {
+	auto schema = StringUtil::Lower(input_schema);
+	for (idx_t index = 0; internal_schemas[index].name != nullptr; index++) {
+		if (internal_schemas[index].name == schema) {
+			return true;
+		}
+	}
+	return false;
+}
+
+DefaultSchemaGenerator::DefaultSchemaGenerator(Catalog &catalog) : DefaultGenerator(catalog) {
+}
+
+unique_ptr<CatalogEntry> DefaultSchemaGenerator::CreateDefaultEntry(ClientContext &context, const string &entry_name) {
+	if (GetDefaultSchema(entry_name)) {
+		return make_unique_base<CatalogEntry, SchemaCatalogEntry>(&catalog, StringUtil::Lower(entry_name), true);
+	}
+	return nullptr;
+}
+
+vector<string> DefaultSchemaGenerator::GetDefaultEntries() {
+	vector<string> result;
+	for (idx_t index = 0; internal_schemas[index].name != nullptr; index++) {
+		result.emplace_back(internal_schemas[index].name);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DefaultType {
+	const char *name;
+	LogicalTypeId type;
+};
+
+static DefaultType internal_types[] = {{"int", LogicalTypeId::INTEGER},
+                                       {"int4", LogicalTypeId::INTEGER},
+                                       {"signed", LogicalTypeId::INTEGER},
+                                       {"integer", LogicalTypeId::INTEGER},
+                                       {"integral", LogicalTypeId::INTEGER},
+                                       {"int32", LogicalTypeId::INTEGER},
+                                       {"varchar", LogicalTypeId::VARCHAR},
+                                       {"bpchar", LogicalTypeId::VARCHAR},
+                                       {"text", LogicalTypeId::VARCHAR},
+                                       {"string", LogicalTypeId::VARCHAR},
+                                       {"char", LogicalTypeId::VARCHAR},
+                                       {"nvarchar", LogicalTypeId::VARCHAR},
+                                       {"bytea", LogicalTypeId::BLOB},
+                                       {"blob", LogicalTypeId::BLOB},
+                                       {"varbinary", LogicalTypeId::BLOB},
+                                       {"binary", LogicalTypeId::BLOB},
+                                       {"int8", LogicalTypeId::BIGINT},
+                                       {"bigint", LogicalTypeId::BIGINT},
+                                       {"int64", LogicalTypeId::BIGINT},
+                                       {"long", LogicalTypeId::BIGINT},
+                                       {"oid", LogicalTypeId::BIGINT},
+                                       {"int2", LogicalTypeId::SMALLINT},
+                                       {"smallint", LogicalTypeId::SMALLINT},
+                                       {"short", LogicalTypeId::SMALLINT},
+                                       {"int16", LogicalTypeId::SMALLINT},
+                                       {"timestamp", LogicalTypeId::TIMESTAMP},
+                                       {"datetime", LogicalTypeId::TIMESTAMP},
+                                       {"timestamp_us", LogicalTypeId::TIMESTAMP},
+                                       {"timestamp_ms", LogicalTypeId::TIMESTAMP_MS},
+                                       {"timestamp_ns", LogicalTypeId::TIMESTAMP_NS},
+                                       {"timestamp_s", LogicalTypeId::TIMESTAMP_SEC},
+                                       {"bool", LogicalTypeId::BOOLEAN},
+                                       {"boolean", LogicalTypeId::BOOLEAN},
+                                       {"logical", LogicalTypeId::BOOLEAN},
+                                       {"decimal", LogicalTypeId::DECIMAL},
+                                       {"dec", LogicalTypeId::DECIMAL},
+                                       {"numeric", LogicalTypeId::DECIMAL},
+                                       {"real", LogicalTypeId::FLOAT},
+                                       {"float4", LogicalTypeId::FLOAT},
+                                       {"float", LogicalTypeId::FLOAT},
+                                       {"double", LogicalTypeId::DOUBLE},
+                                       {"float8", LogicalTypeId::DOUBLE},
+                                       {"tinyint", LogicalTypeId::TINYINT},
+                                       {"int1", LogicalTypeId::TINYINT},
+                                       {"date", LogicalTypeId::DATE},
+                                       {"time", LogicalTypeId::TIME},
+                                       {"interval", LogicalTypeId::INTERVAL},
+                                       {"hugeint", LogicalTypeId::HUGEINT},
+                                       {"int128", LogicalTypeId::HUGEINT},
+                                       {"uuid", LogicalTypeId::UUID},
+                                       {"guid", LogicalTypeId::UUID},
+                                       {"struct", LogicalTypeId::STRUCT},
+                                       {"row", LogicalTypeId::STRUCT},
+                                       {"list", LogicalTypeId::LIST},
+                                       {"map", LogicalTypeId::MAP},
+                                       {"utinyint", LogicalTypeId::UTINYINT},
+                                       {"uint8", LogicalTypeId::UTINYINT},
+                                       {"usmallint", LogicalTypeId::USMALLINT},
+                                       {"uint16", LogicalTypeId::USMALLINT},
+                                       {"uinteger", LogicalTypeId::UINTEGER},
+                                       {"uint32", LogicalTypeId::UINTEGER},
+                                       {"ubigint", LogicalTypeId::UBIGINT},
+                                       {"uint64", LogicalTypeId::UBIGINT},
+                                       {"timestamptz", LogicalTypeId::TIMESTAMP_TZ},
+                                       {"timetz", LogicalTypeId::TIME_TZ},
+                                       {"json", LogicalTypeId::JSON},
+                                       {"null", LogicalTypeId::SQLNULL},
+                                       {nullptr, LogicalTypeId::INVALID}};
+
+LogicalTypeId DefaultTypeGenerator::GetDefaultType(const string &name) {
+	auto lower_str = StringUtil::Lower(name);
+	for (idx_t index = 0; internal_types[index].name != nullptr; index++) {
+		if (internal_types[index].name == lower_str) {
+			return internal_types[index].type;
+		}
+	}
+	return LogicalTypeId::INVALID;
+}
+
+DefaultTypeGenerator::DefaultTypeGenerator(Catalog &catalog, SchemaCatalogEntry *schema)
+    : DefaultGenerator(catalog), schema(schema) {
+}
+
+unique_ptr<CatalogEntry> DefaultTypeGenerator::CreateDefaultEntry(ClientContext &context, const string &entry_name) {
+	if (schema->name != DEFAULT_SCHEMA) {
+		return nullptr;
+	}
+	auto type_id = GetDefaultType(entry_name);
+	if (type_id == LogicalTypeId::INVALID) {
+		return nullptr;
+	}
+	CreateTypeInfo info;
+	info.name = entry_name;
+	info.type = LogicalType(type_id);
+	info.internal = true;
+	info.temporary = true;
+	return make_unique_base<CatalogEntry, TypeCatalogEntry>(&catalog, schema, &info);
+}
+
+vector<string> DefaultTypeGenerator::GetDefaultEntries() {
+	vector<string> result;
+	if (schema->name != DEFAULT_SCHEMA) {
+		return result;
+	}
+	for (idx_t index = 0; internal_types[index].name != nullptr; index++) {
+		result.emplace_back(internal_types[index].name);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DefaultView {
+	const char *schema;
+	const char *name;
+	const char *sql;
+};
+
+static DefaultView internal_views[] = {
+    {DEFAULT_SCHEMA, "pragma_database_list", "SELECT * FROM pragma_database_list()"},
+    {DEFAULT_SCHEMA, "sqlite_master", "select 'table' \"type\", table_name \"name\", table_name \"tbl_name\", 0 rootpage, sql from duckdb_tables union all select 'view' \"type\", view_name \"name\", view_name \"tbl_name\", 0 rootpage, sql from duckdb_views union all select 'index' \"type\", index_name \"name\", table_name \"tbl_name\", 0 rootpage, sql from duckdb_indexes;"},
+    {DEFAULT_SCHEMA, "sqlite_schema", "SELECT * FROM sqlite_master"},
+    {DEFAULT_SCHEMA, "sqlite_temp_master", "SELECT * FROM sqlite_master"},
+    {DEFAULT_SCHEMA, "sqlite_temp_schema", "SELECT * FROM sqlite_master"},
+    {DEFAULT_SCHEMA, "duckdb_constraints", "SELECT * FROM duckdb_constraints()"},
+    {DEFAULT_SCHEMA, "duckdb_columns", "SELECT * FROM duckdb_columns() WHERE NOT internal"},
+    {DEFAULT_SCHEMA, "duckdb_indexes", "SELECT * FROM duckdb_indexes()"},
+    {DEFAULT_SCHEMA, "duckdb_schemas", "SELECT * FROM duckdb_schemas() WHERE NOT internal"},
+    {DEFAULT_SCHEMA, "duckdb_tables", "SELECT * FROM duckdb_tables() WHERE NOT internal"},
+    {DEFAULT_SCHEMA, "duckdb_types", "SELECT * FROM duckdb_types()"},
+    {DEFAULT_SCHEMA, "duckdb_views", "SELECT * FROM duckdb_views() WHERE NOT internal"},
+    {"pg_catalog", "pg_am", "SELECT 0 oid, 'art' amname, NULL amhandler, 'i' amtype"},
+    {"pg_catalog", "pg_attribute", "SELECT table_oid attrelid, column_name attname, data_type_id atttypid, 0 attstattarget, NULL attlen, column_index attnum, 0 attndims, -1 attcacheoff, case when data_type ilike '%decimal%' then numeric_precision*1000+numeric_scale else -1 end atttypmod, false attbyval, NULL attstorage, NULL attalign, NOT is_nullable attnotnull, column_default IS NOT NULL atthasdef, false atthasmissing, '' attidentity, '' attgenerated, false attisdropped, true attislocal, 0 attinhcount, 0 attcollation, NULL attcompression, NULL attacl, NULL attoptions, NULL attfdwoptions, NULL attmissingval FROM duckdb_columns()"},
+    {"pg_catalog", "pg_attrdef", "SELECT column_index oid, table_oid adrelid, column_index adnum, column_default adbin from duckdb_columns() where column_default is not null;"},
+    {"pg_catalog", "pg_class", "SELECT table_oid oid, table_name relname, schema_oid relnamespace, 0 reltype, 0 reloftype, 0 relowner, 0 relam, 0 relfilenode, 0 reltablespace, 0 relpages, estimated_size::real reltuples, 0 relallvisible, 0 reltoastrelid, 0 reltoastidxid, index_count > 0 relhasindex, false relisshared, case when temporary then 't' else 'p' end relpersistence, 'r' relkind, column_count relnatts, check_constraint_count relchecks, false relhasoids, has_primary_key relhaspkey, false relhasrules, false relhastriggers, false relhassubclass, false relrowsecurity, true relispopulated, NULL relreplident, false relispartition, 0 relrewrite, 0 relfrozenxid, NULL relminmxid, NULL relacl, NULL reloptions, NULL relpartbound FROM duckdb_tables() UNION ALL SELECT view_oid oid, view_name relname, schema_oid relnamespace, 0 reltype, 0 reloftype, 0 relowner, 0 relam, 0 relfilenode, 0 reltablespace, 0 relpages, 0 reltuples, 0 relallvisible, 0 reltoastrelid, 0 reltoastidxid, false relhasindex, false relisshared, case when temporary then 't' else 'p' end relpersistence, 'v' relkind, column_count relnatts, 0 relchecks, false relhasoids, false relhaspkey, false relhasrules, false relhastriggers, false relhassubclass, false relrowsecurity, true relispopulated, NULL relreplident, false relispartition, 0 relrewrite, 0 relfrozenxid, NULL relminmxid, NULL relacl, NULL reloptions, NULL relpartbound FROM duckdb_views() UNION ALL SELECT sequence_oid oid, sequence_name relname, schema_oid relnamespace, 0 reltype, 0 reloftype, 0 relowner, 0 relam, 0 relfilenode, 0 reltablespace, 0 relpages, 0 reltuples, 0 relallvisible, 0 reltoastrelid, 0 reltoastidxid, false relhasindex, false relisshared, case when temporary then 't' else 'p' end relpersistence, 'S' relkind, 0 relnatts, 0 relchecks, false relhasoids, false relhaspkey, false relhasrules, false relhastriggers, false relhassubclass, false relrowsecurity, true relispopulated, NULL relreplident, false relispartition, 0 relrewrite, 0 relfrozenxid, NULL relminmxid, NULL relacl, NULL reloptions, NULL relpartbound FROM duckdb_sequences() UNION ALL SELECT index_oid oid, index_name relname, schema_oid relnamespace, 0 reltype, 0 reloftype, 0 relowner, 0 relam, 0 relfilenode, 0 reltablespace, 0 relpages, 0 reltuples, 0 relallvisible, 0 reltoastrelid, 0 reltoastidxid, false relhasindex, false relisshared, 't' relpersistence, 'i' relkind, NULL relnatts, 0 relchecks, false relhasoids, false relhaspkey, false relhasrules, false relhastriggers, false relhassubclass, false relrowsecurity, true relispopulated, NULL relreplident, false relispartition, 0 relrewrite, 0 relfrozenxid, NULL relminmxid, NULL relacl, NULL reloptions, NULL relpartbound FROM duckdb_indexes()"},
+    {"pg_catalog", "pg_constraint", "SELECT table_oid*1000000+constraint_index oid, constraint_text conname, schema_oid connamespace, CASE WHEN constraint_type='CHECK' then 'c' WHEN constraint_type='UNIQUE' then 'u' WHEN constraint_type='PRIMARY KEY' THEN 'p' ELSE 'x' END contype, false condeferrable, false condeferred, true convalidated, table_oid conrelid, 0 contypid, 0 conindid, 0 conparentid, 0 confrelid, NULL confupdtype, NULL confdeltype, NULL confmatchtype, true conislocal, 0 coninhcount, false connoinherit, constraint_column_indexes conkey, NULL confkey, NULL conpfeqop, NULL conppeqop, NULL conffeqop, NULL conexclop, expression conbin FROM duckdb_constraints()"},
+    {"pg_catalog", "pg_depend", "SELECT * FROM duckdb_dependencies()"},
+	{"pg_catalog", "pg_description", "SELECT NULL objoid, NULL classoid, NULL objsubid, NULL description WHERE 1=0"},
+    {"pg_catalog", "pg_enum", "SELECT NULL oid, NULL enumtypid, NULL enumsortorder, NULL enumlabel WHERE 1=0"},
+    {"pg_catalog", "pg_index", "SELECT index_oid indexrelid, table_oid indrelid, 0 indnatts, 0 indnkeyatts, is_unique indisunique, is_primary indisprimary, false indisexclusion, true indimmediate, false indisclustered, true indisvalid, false indcheckxmin, true indisready, true indislive, false indisreplident, NULL::INT[] indkey, NULL::OID[] indcollation, NULL::OID[] indclass, NULL::INT[] indoption, expressions indexprs, NULL indpred FROM duckdb_indexes()"},
+    {"pg_catalog", "pg_indexes", "SELECT schema_name schemaname, table_name tablename, index_name indexname, NULL \"tablespace\", sql indexdef FROM duckdb_indexes()"},
+    {"pg_catalog", "pg_namespace", "SELECT oid, schema_name nspname, 0 nspowner, NULL nspacl FROM duckdb_schemas()"},
+    {"pg_catalog", "pg_sequence", "SELECT sequence_oid seqrelid, 0 seqtypid, start_value seqstart, increment_by seqincrement, max_value seqmax, min_value seqmin, 0 seqcache, cycle seqcycle FROM duckdb_sequences()"},
+	{"pg_catalog", "pg_sequences", "SELECT schema_name schemaname, sequence_name sequencename, 'duckdb' sequenceowner, 0 data_type, start_value, min_value, max_value, increment_by, cycle, 0 cache_size, last_value FROM duckdb_sequences()"},
+    {"pg_catalog", "pg_tables", "SELECT schema_name schemaname, table_name tablename, 'duckdb' tableowner, NULL \"tablespace\", index_count > 0 hasindexes, false hasrules, false hastriggers FROM duckdb_tables()"},
+    {"pg_catalog", "pg_tablespace", "SELECT 0 oid, 'pg_default' spcname, 0 spcowner, NULL spcacl, NULL spcoptions"},
+    {"pg_catalog", "pg_type", "SELECT type_oid oid, format_pg_type(type_name) typname, schema_oid typnamespace, 0 typowner, type_size typlen, false typbyval, 'b' typtype, CASE WHEN type_category='NUMERIC' THEN 'N' WHEN type_category='STRING' THEN 'S' WHEN type_category='DATETIME' THEN 'D' WHEN type_category='BOOLEAN' THEN 'B' WHEN type_category='COMPOSITE' THEN 'C' WHEN type_category='USER' THEN 'U' ELSE 'X' END typcategory, false typispreferred, true typisdefined, NULL typdelim, NULL typrelid, NULL typsubscript, NULL typelem, NULL typarray, NULL typinput, NULL typoutput, NULL typreceive, NULL typsend, NULL typmodin, NULL typmodout, NULL typanalyze, 'd' typalign, 'p' typstorage, NULL typnotnull, NULL typbasetype, NULL typtypmod, NULL typndims, NULL typcollation, NULL typdefaultbin, NULL typdefault, NULL typacl FROM duckdb_types();"},
+    {"pg_catalog", "pg_views", "SELECT schema_name schemaname, view_name viewname, 'duckdb' viewowner, sql definition FROM duckdb_views()"},
+    {"information_schema", "columns", "SELECT NULL table_catalog, schema_name table_schema, table_name, column_name, column_index ordinal_position, column_default, CASE WHEN is_nullable THEN 'YES' ELSE 'NO' END is_nullable, data_type, character_maximum_length, NULL character_octet_length, numeric_precision, numeric_precision_radix, numeric_scale, NULL datetime_precision, NULL interval_type, NULL interval_precision, NULL character_set_catalog, NULL character_set_schema, NULL character_set_name, NULL collation_catalog, NULL collation_schema, NULL collation_name, NULL domain_catalog, NULL domain_schema, NULL domain_name, NULL udt_catalog, NULL udt_schema, NULL udt_name, NULL scope_catalog, NULL scope_schema, NULL scope_name, NULL maximum_cardinality, NULL dtd_identifier, NULL is_self_referencing, NULL is_identity, NULL identity_generation, NULL identity_start, NULL identity_increment, NULL identity_maximum, NULL identity_minimum, NULL identity_cycle, NULL is_generated, NULL generation_expression, NULL is_updatable FROM duckdb_columns;"},
+    {"information_schema", "schemata", "SELECT NULL catalog_name, schema_name, 'duckdb' schema_owner, NULL default_character_set_catalog, NULL default_character_set_schema, NULL default_character_set_name, sql sql_path FROM duckdb_schemas()"},
+    {"information_schema", "tables", "SELECT NULL table_catalog, schema_name table_schema, table_name, CASE WHEN temporary THEN 'LOCAL TEMPORARY' ELSE 'BASE TABLE' END table_type, NULL self_referencing_column_name, NULL reference_generation, NULL user_defined_type_catalog, NULL user_defined_type_schema, NULL user_defined_type_name, 'YES' is_insertable_into, 'NO' is_typed, CASE WHEN temporary THEN 'PRESERVE' ELSE NULL END commit_action FROM duckdb_tables() UNION ALL SELECT NULL table_catalog, schema_name table_schema, view_name table_name, 'VIEW' table_type, NULL self_referencing_column_name, NULL reference_generation, NULL user_defined_type_catalog, NULL user_defined_type_schema, NULL user_defined_type_name, 'NO' is_insertable_into, 'NO' is_typed, NULL commit_action FROM duckdb_views;"},
+    {nullptr, nullptr, nullptr}};
+
+static unique_ptr<CreateViewInfo> GetDefaultView(const string &input_schema, const string &input_name) {
+	auto schema = StringUtil::Lower(input_schema);
+	auto name = StringUtil::Lower(input_name);
+	for (idx_t index = 0; internal_views[index].name != nullptr; index++) {
+		if (internal_views[index].schema == schema && internal_views[index].name == name) {
+			auto result = make_unique<CreateViewInfo>();
+			result->schema = schema;
+			result->sql = internal_views[index].sql;
+
+			Parser parser;
+			parser.ParseQuery(internal_views[index].sql);
+			D_ASSERT(parser.statements.size() == 1 && parser.statements[0]->type == StatementType::SELECT_STATEMENT);
+			result->query = unique_ptr_cast<SQLStatement, SelectStatement>(move(parser.statements[0]));
+			result->temporary = true;
+			result->internal = true;
+			result->view_name = name;
+			return result;
+		}
+	}
+	return nullptr;
+}
+
+DefaultViewGenerator::DefaultViewGenerator(Catalog &catalog, SchemaCatalogEntry *schema)
+    : DefaultGenerator(catalog), schema(schema) {
+}
+
+unique_ptr<CatalogEntry> DefaultViewGenerator::CreateDefaultEntry(ClientContext &context, const string &entry_name) {
+	auto info = GetDefaultView(schema->name, entry_name);
+	if (info) {
+		auto binder = Binder::CreateBinder(context);
+		binder->BindCreateViewInfo(*info);
+
+		return make_unique_base<CatalogEntry, ViewCatalogEntry>(&catalog, schema, info.get());
+	}
+	return nullptr;
+}
+
+vector<string> DefaultViewGenerator::GetDefaultEntries() {
+	vector<string> result;
+	for (idx_t index = 0; internal_views[index].name != nullptr; index++) {
+		if (internal_views[index].schema == schema->name) {
+			result.emplace_back(internal_views[index].name);
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+DependencyManager::DependencyManager(Catalog &catalog) : catalog(catalog) {
+}
+
+void DependencyManager::AddObject(ClientContext &context, CatalogEntry *object,
+                                  unordered_set<CatalogEntry *> &dependencies) {
+	// check for each object in the sources if they were not deleted yet
+	for (auto &dependency : dependencies) {
+		idx_t entry_index;
+		CatalogEntry *catalog_entry;
+		if (!dependency->set) {
+			throw InternalException("Dependency has no set");
+		}
+		if (!dependency->set->GetEntryInternal(context, dependency->name, entry_index, catalog_entry)) {
+			throw InternalException("Dependency has already been deleted?");
+		}
+	}
+	// indexes do not require CASCADE to be dropped, they are simply always dropped along with the table
+	auto dependency_type = object->type == CatalogType::INDEX_ENTRY ? DependencyType::DEPENDENCY_AUTOMATIC
+	                                                                : DependencyType::DEPENDENCY_REGULAR;
+	// add the object to the dependents_map of each object that it depends on
+	for (auto &dependency : dependencies) {
+		dependents_map[dependency].insert(Dependency(object, dependency_type));
+	}
+	// create the dependents map for this object: it starts out empty
+	dependents_map[object] = dependency_set_t();
+	dependencies_map[object] = dependencies;
+}
+
+void DependencyManager::DropObject(ClientContext &context, CatalogEntry *object, bool cascade) {
+	D_ASSERT(dependents_map.find(object) != dependents_map.end());
+
+	// first check the objects that depend on this object
+	auto &dependent_objects = dependents_map[object];
+	for (auto &dep : dependent_objects) {
+		// look up the entry in the catalog set
+		auto &catalog_set = *dep.entry->set;
+		auto mapping_value = catalog_set.GetMapping(context, dep.entry->name, true /* get_latest */);
+		if (mapping_value == nullptr) {
+			continue;
+		}
+		idx_t entry_index = mapping_value->index;
+		CatalogEntry *dependency_entry;
+
+		if (!catalog_set.GetEntryInternal(context, entry_index, dependency_entry)) {
+			// the dependent object was already deleted, no conflict
+			continue;
+		}
+		// conflict: attempting to delete this object but the dependent object still exists
+		if (cascade || dep.dependency_type == DependencyType::DEPENDENCY_AUTOMATIC ||
+		    dep.dependency_type == DependencyType::DEPENDENCY_OWNS) {
+			// cascade: drop the dependent object
+			catalog_set.DropEntryInternal(context, entry_index, *dependency_entry, cascade);
+		} else {
+			// no cascade and there are objects that depend on this object: throw error
+			throw CatalogException("Cannot drop entry \"%s\" because there are entries that "
+			                       "depend on it. Use DROP...CASCADE to drop all dependents.",
+			                       object->name);
+		}
+	}
+}
+
+void DependencyManager::AlterObject(ClientContext &context, CatalogEntry *old_obj, CatalogEntry *new_obj) {
+	D_ASSERT(dependents_map.find(old_obj) != dependents_map.end());
+	D_ASSERT(dependencies_map.find(old_obj) != dependencies_map.end());
+
+	// first check the objects that depend on this object
+	vector<CatalogEntry *> owned_objects_to_add;
+	auto &dependent_objects = dependents_map[old_obj];
+	for (auto &dep : dependent_objects) {
+		// look up the entry in the catalog set
+		auto &catalog_set = *dep.entry->set;
+		idx_t entry_index;
+		CatalogEntry *dependency_entry;
+		if (!catalog_set.GetEntryInternal(context, dep.entry->name, entry_index, dependency_entry)) {
+			// the dependent object was already deleted, no conflict
+			continue;
+		}
+		if (dep.dependency_type == DependencyType::DEPENDENCY_OWNS) {
+			// the dependent object is owned by the current object
+			owned_objects_to_add.push_back(dep.entry);
+			continue;
+		}
+		// conflict: attempting to alter this object but the dependent object still exists
+		// no cascade and there are objects that depend on this object: throw error
+		throw CatalogException("Cannot alter entry \"%s\" because there are entries that "
+		                       "depend on it.",
+		                       old_obj->name);
+	}
+	// add the new object to the dependents_map of each object that it depends on
+	auto &old_dependencies = dependencies_map[old_obj];
+	vector<CatalogEntry *> to_delete;
+	for (auto &dependency : old_dependencies) {
+		if (dependency->type == CatalogType::TYPE_ENTRY) {
+			auto user_type = (TypeCatalogEntry *)dependency;
+			auto table = (TableCatalogEntry *)new_obj;
+			bool deleted_dependency = true;
+			for (auto &column : table->columns) {
+				if (column.Type() == user_type->user_type) {
+					deleted_dependency = false;
+					break;
+				}
+			}
+			if (deleted_dependency) {
+				to_delete.push_back(dependency);
+				continue;
+			}
+		}
+		dependents_map[dependency].insert(new_obj);
+	}
+	for (auto &dependency : to_delete) {
+		old_dependencies.erase(dependency);
+		dependents_map[dependency].erase(old_obj);
+	}
+
+	// We might have to add a type dependency
+	vector<CatalogEntry *> to_add;
+	if (new_obj->type == CatalogType::TABLE_ENTRY) {
+		auto table = (TableCatalogEntry *)new_obj;
+		for (auto &column : table->columns) {
+			auto user_type_catalog = LogicalType::GetCatalog(column.Type());
+			if (user_type_catalog) {
+				to_add.push_back(user_type_catalog);
+			}
+		}
+	}
+	// add the new object to the dependency manager
+	dependents_map[new_obj] = dependency_set_t();
+	dependencies_map[new_obj] = old_dependencies;
+
+	for (auto &dependency : to_add) {
+		dependencies_map[new_obj].insert(dependency);
+		dependents_map[dependency].insert(new_obj);
+	}
+
+	for (auto &dependency : owned_objects_to_add) {
+		dependents_map[new_obj].insert(Dependency(dependency, DependencyType::DEPENDENCY_OWNS));
+		dependents_map[dependency].insert(Dependency(new_obj, DependencyType::DEPENDENCY_OWNED_BY));
+		dependencies_map[new_obj].insert(dependency);
+	}
+}
+
+void DependencyManager::EraseObject(CatalogEntry *object) {
+	// obtain the writing lock
+	EraseObjectInternal(object);
+}
+
+void DependencyManager::EraseObjectInternal(CatalogEntry *object) {
+	if (dependents_map.find(object) == dependents_map.end()) {
+		// dependencies already removed
+		return;
+	}
+	D_ASSERT(dependents_map.find(object) != dependents_map.end());
+	D_ASSERT(dependencies_map.find(object) != dependencies_map.end());
+	// now for each of the dependencies, erase the entries from the dependents_map
+	for (auto &dependency : dependencies_map[object]) {
+		auto entry = dependents_map.find(dependency);
+		if (entry != dependents_map.end()) {
+			D_ASSERT(entry->second.find(object) != entry->second.end());
+			entry->second.erase(object);
+		}
+	}
+	// erase the dependents and dependencies for this object
+	dependents_map.erase(object);
+	dependencies_map.erase(object);
+}
+
+void DependencyManager::Scan(const std::function<void(CatalogEntry *, CatalogEntry *, DependencyType)> &callback) {
+	lock_guard<mutex> write_lock(catalog.write_lock);
+	for (auto &entry : dependents_map) {
+		for (auto &dependent : entry.second) {
+			callback(entry.first, dependent.entry, dependent.dependency_type);
+		}
+	}
+}
+
+void DependencyManager::AddOwnership(ClientContext &context, CatalogEntry *owner, CatalogEntry *entry) {
+	// lock the catalog for writing
+	lock_guard<mutex> write_lock(catalog.write_lock);
+
+	// If the owner is already owned by something else, throw an error
+	for (auto &dep : dependents_map[owner]) {
+		if (dep.dependency_type == DependencyType::DEPENDENCY_OWNED_BY) {
+			throw CatalogException(owner->name + " already owned by " + dep.entry->name);
+		}
+	}
+
+	// If the entry is already owned, throw an error
+	for (auto &dep : dependents_map[entry]) {
+		// if the entry is already owned, throw error
+		if (dep.entry != owner) {
+			throw CatalogException(entry->name + " already depends on " + dep.entry->name);
+		}
+		// if the entry owns the owner, throw error
+		if (dep.entry == owner && dep.dependency_type == DependencyType::DEPENDENCY_OWNS) {
+			throw CatalogException(entry->name + " already owns " + owner->name +
+			                       ". Cannot have circular dependencies");
+		}
+	}
+
+	// Emplace guarantees that the same object cannot be inserted twice in the unordered_set
+	// In the case AddOwnership is called twice, because of emplace, the object will not be repeated in the set.
+	// We use an automatic dependency because if the Owner gets deleted, then the owned objects are also deleted
+	dependents_map[owner].emplace(Dependency(entry, DependencyType::DEPENDENCY_OWNS));
+	dependents_map[entry].emplace(Dependency(owner, DependencyType::DEPENDENCY_OWNED_BY));
+	dependencies_map[owner].emplace(entry);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+AllocatedData::AllocatedData(Allocator &allocator, data_ptr_t pointer, idx_t allocated_size)
+    : allocator(allocator), pointer(pointer), allocated_size(allocated_size) {
+}
+AllocatedData::~AllocatedData() {
+	Reset();
+}
+
+void AllocatedData::Reset() {
+	if (!pointer) {
+		return;
+	}
+	allocator.FreeData(pointer, allocated_size);
+	pointer = nullptr;
+}
+
+Allocator::Allocator()
+    : allocate_function(Allocator::DefaultAllocate), free_function(Allocator::DefaultFree),
+      reallocate_function(Allocator::DefaultReallocate) {
+}
+
+Allocator::Allocator(allocate_function_ptr_t allocate_function_p, free_function_ptr_t free_function_p,
+                     reallocate_function_ptr_t reallocate_function_p, unique_ptr<PrivateAllocatorData> private_data)
+    : allocate_function(allocate_function_p), free_function(free_function_p),
+      reallocate_function(reallocate_function_p), private_data(move(private_data)) {
+}
+
+data_ptr_t Allocator::AllocateData(idx_t size) {
+	return allocate_function(private_data.get(), size);
+}
+
+void Allocator::FreeData(data_ptr_t pointer, idx_t size) {
+	if (!pointer) {
+		return;
+	}
+	return free_function(private_data.get(), pointer, size);
+}
+
+data_ptr_t Allocator::ReallocateData(data_ptr_t pointer, idx_t size) {
+	if (!pointer) {
+		return pointer;
+	}
+	return reallocate_function(private_data.get(), pointer, size);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+ArrowSchemaWrapper::~ArrowSchemaWrapper() {
+	if (arrow_schema.release) {
+		for (int64_t child_idx = 0; child_idx < arrow_schema.n_children; child_idx++) {
+			auto &child = *arrow_schema.children[child_idx];
+			if (child.release) {
+				child.release(&child);
+			}
+		}
+		arrow_schema.release(&arrow_schema);
+		arrow_schema.release = nullptr;
+	}
+}
+
+ArrowArrayWrapper::~ArrowArrayWrapper() {
+	if (arrow_array.release) {
+		for (int64_t child_idx = 0; child_idx < arrow_array.n_children; child_idx++) {
+			auto &child = *arrow_array.children[child_idx];
+			if (child.release) {
+				child.release(&child);
+			}
+		}
+		arrow_array.release(&arrow_array);
+		arrow_array.release = nullptr;
+	}
+}
+
+ArrowArrayStreamWrapper::~ArrowArrayStreamWrapper() {
+	if (arrow_array_stream.release) {
+		arrow_array_stream.release(&arrow_array_stream);
+		arrow_array_stream.release = nullptr;
+	}
+}
+
+void ArrowArrayStreamWrapper::GetSchema(ArrowSchemaWrapper &schema) {
+	D_ASSERT(arrow_array_stream.get_schema);
+	// LCOV_EXCL_START
+	if (arrow_array_stream.get_schema(&arrow_array_stream, &schema.arrow_schema)) {
+		throw InvalidInputException("arrow_scan: get_schema failed(): %s", string(GetError()));
+	}
+	if (!schema.arrow_schema.release) {
+		throw InvalidInputException("arrow_scan: released schema passed");
+	}
+	if (schema.arrow_schema.n_children < 1) {
+		throw InvalidInputException("arrow_scan: empty schema passed");
+	}
+	// LCOV_EXCL_STOP
+}
+
+shared_ptr<ArrowArrayWrapper> ArrowArrayStreamWrapper::GetNextChunk() {
+	auto current_chunk = make_shared<ArrowArrayWrapper>();
+	if (arrow_array_stream.get_next(&arrow_array_stream, &current_chunk->arrow_array)) { // LCOV_EXCL_START
+		throw InvalidInputException("arrow_scan: get_next failed(): %s", string(GetError()));
+	} // LCOV_EXCL_STOP
+
+	return current_chunk;
+}
+
+const char *ArrowArrayStreamWrapper::GetError() { // LCOV_EXCL_START
+	return arrow_array_stream.get_last_error(&arrow_array_stream);
+} // LCOV_EXCL_STOP
+
+int ResultArrowArrayStreamWrapper::MyStreamGetSchema(struct ArrowArrayStream *stream, struct ArrowSchema *out) {
+	if (!stream->release) {
+		return -1;
+	}
+	auto my_stream = (ResultArrowArrayStreamWrapper *)stream->private_data;
+	if (!my_stream->column_types.empty()) {
+		QueryResult::ToArrowSchema(out, my_stream->column_types, my_stream->column_names, my_stream->timezone_config);
+		return 0;
+	}
+
+	auto &result = *my_stream->result;
+	if (!result.success) {
+		my_stream->last_error = "Query Failed";
+		return -1;
+	}
+	if (result.type == QueryResultType::STREAM_RESULT) {
+		auto &stream_result = (StreamQueryResult &)result;
+		if (!stream_result.IsOpen()) {
+			my_stream->last_error = "Query Stream is closed";
+			return -1;
+		}
+	}
+	if (my_stream->column_types.empty()) {
+		my_stream->column_types = result.types;
+		my_stream->column_names = result.names;
+	}
+	QueryResult::ToArrowSchema(out, my_stream->column_types, my_stream->column_names, my_stream->timezone_config);
+	return 0;
+}
+
+int ResultArrowArrayStreamWrapper::MyStreamGetNext(struct ArrowArrayStream *stream, struct ArrowArray *out) {
+	if (!stream->release) {
+		return -1;
+	}
+	auto my_stream = (ResultArrowArrayStreamWrapper *)stream->private_data;
+	auto &result = *my_stream->result;
+	if (!result.success) {
+		my_stream->last_error = "Query Failed";
+		return -1;
+	}
+	if (result.type == QueryResultType::STREAM_RESULT) {
+		auto &stream_result = (StreamQueryResult &)result;
+		if (!stream_result.IsOpen()) {
+			// Nothing to output
+			out->release = nullptr;
+			return 0;
+		}
+	}
+	if (my_stream->column_types.empty()) {
+		my_stream->column_types = result.types;
+		my_stream->column_names = result.names;
+	}
+	unique_ptr<DataChunk> chunk_result = result.Fetch();
+	if (!chunk_result) {
+		// Nothing to output
+		out->release = nullptr;
+		return 0;
+	}
+	unique_ptr<DataChunk> agg_chunk_result = make_unique<DataChunk>();
+	agg_chunk_result->Initialize(chunk_result->GetTypes());
+	agg_chunk_result->Append(*chunk_result, true);
+
+	while (agg_chunk_result->size() < my_stream->batch_size) {
+		auto new_chunk = result.Fetch();
+		if (!new_chunk) {
+			break;
+		} else {
+			agg_chunk_result->Append(*new_chunk, true);
+		}
+	}
+	agg_chunk_result->ToArrowArray(out);
+	return 0;
+}
+
+void ResultArrowArrayStreamWrapper::MyStreamRelease(struct ArrowArrayStream *stream) {
+	if (!stream->release) {
+		return;
+	}
+	stream->release = nullptr;
+	delete (ResultArrowArrayStreamWrapper *)stream->private_data;
+}
+
+const char *ResultArrowArrayStreamWrapper::MyStreamGetLastError(struct ArrowArrayStream *stream) {
+	if (!stream->release) {
+		return "stream was released";
+	}
+	D_ASSERT(stream->private_data);
+	auto my_stream = (ResultArrowArrayStreamWrapper *)stream->private_data;
+	return my_stream->last_error.c_str();
+}
+ResultArrowArrayStreamWrapper::ResultArrowArrayStreamWrapper(unique_ptr<QueryResult> result_p, idx_t batch_size_p)
+    : result(move(result_p)) {
+	//! We first initialize the private data of the stream
+	stream.private_data = this;
+	//! Ceil Approx_Batch_Size/STANDARD_VECTOR_SIZE
+	if (batch_size_p == 0) {
+		throw std::runtime_error("Approximate Batch Size of Record Batch MUST be higher than 0");
+	}
+	batch_size = batch_size_p;
+	//! We initialize the stream functions
+	stream.get_schema = ResultArrowArrayStreamWrapper::MyStreamGetSchema;
+	stream.get_next = ResultArrowArrayStreamWrapper::MyStreamGetNext;
+	stream.release = ResultArrowArrayStreamWrapper::MyStreamRelease;
+	stream.get_last_error = ResultArrowArrayStreamWrapper::MyStreamGetLastError;
+}
+
+unique_ptr<DataChunk> ArrowUtil::FetchNext(QueryResult &result) {
+	auto chunk = result.Fetch();
+	if (!result.success) {
+		throw std::runtime_error(result.error);
+	}
+	return chunk;
+}
+
+unique_ptr<DataChunk> ArrowUtil::FetchChunk(QueryResult *result, idx_t chunk_size) {
+
+	auto data_chunk = FetchNext(*result);
+	if (!data_chunk) {
+		return data_chunk;
+	}
+	while (data_chunk->size() < chunk_size) {
+		auto next_chunk = FetchNext(*result);
+		if (!next_chunk || next_chunk->size() == 0) {
+			break;
+		}
+		data_chunk->Append(*next_chunk, true);
+	}
+	return data_chunk;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void DuckDBAssertInternal(bool condition, const char *condition_name, const char *file, int linenr) {
+	if (condition) {
+		return;
+	}
+	throw InternalException("Assertion triggered in file \"%s\" on line %d: %s", file, linenr, condition_name);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+uint64_t Checksum(uint8_t *buffer, size_t size) {
+	uint64_t result = 5381;
+	uint64_t *ptr = (uint64_t *)buffer;
+	size_t i;
+	// for efficiency, we first hash uint64_t values
+	for (i = 0; i < size / 8; i++) {
+		result ^= Hash(ptr[i]);
+	}
+	if (size - i * 8 > 0) {
+		// the remaining 0-7 bytes we hash using a string hash
+		result ^= Hash(buffer + i * 8, size - i * 8);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+StreamWrapper::~StreamWrapper() {
+}
+
+CompressedFile::CompressedFile(CompressedFileSystem &fs, unique_ptr<FileHandle> child_handle_p, const string &path)
+    : FileHandle(fs, path), compressed_fs(fs), child_handle(move(child_handle_p)) {
+}
+
+CompressedFile::~CompressedFile() {
+	Close();
+}
+
+void CompressedFile::Initialize(bool write) {
+	Close();
+
+	this->write = write;
+	stream_data.in_buf_size = compressed_fs.InBufferSize();
+	stream_data.out_buf_size = compressed_fs.OutBufferSize();
+	stream_data.in_buff = unique_ptr<data_t[]>(new data_t[stream_data.in_buf_size]);
+	stream_data.in_buff_start = stream_data.in_buff.get();
+	stream_data.in_buff_end = stream_data.in_buff.get();
+	stream_data.out_buff = unique_ptr<data_t[]>(new data_t[stream_data.out_buf_size]);
+	stream_data.out_buff_start = stream_data.out_buff.get();
+	stream_data.out_buff_end = stream_data.out_buff.get();
+
+	stream_wrapper = compressed_fs.CreateStream();
+	stream_wrapper->Initialize(*this, write);
+}
+
+int64_t CompressedFile::ReadData(void *buffer, int64_t remaining) {
+	idx_t total_read = 0;
+	while (true) {
+		// first check if there are input bytes available in the output buffers
+		if (stream_data.out_buff_start != stream_data.out_buff_end) {
+			// there is! copy it into the output buffer
+			idx_t available = MinValue<idx_t>(remaining, stream_data.out_buff_end - stream_data.out_buff_start);
+			memcpy(data_ptr_t(buffer) + total_read, stream_data.out_buff_start, available);
+
+			// increment the total read variables as required
+			stream_data.out_buff_start += available;
+			total_read += available;
+			remaining -= available;
+			if (remaining == 0) {
+				// done! read enough
+				return total_read;
+			}
+		}
+		if (!stream_wrapper) {
+			return total_read;
+		}
+
+		// ran out of buffer: read more data from the child stream
+		stream_data.out_buff_start = stream_data.out_buff.get();
+		stream_data.out_buff_end = stream_data.out_buff.get();
+		D_ASSERT(stream_data.in_buff_start <= stream_data.in_buff_end);
+		D_ASSERT(stream_data.in_buff_end <= stream_data.in_buff_start + stream_data.in_buf_size);
+
+		// read more input if none available
+		if (stream_data.in_buff_start == stream_data.in_buff_end) {
+			// empty input buffer: refill from the start
+			stream_data.in_buff_start = stream_data.in_buff.get();
+			stream_data.in_buff_end = stream_data.in_buff_start;
+			auto sz = child_handle->Read(stream_data.in_buff.get(), stream_data.in_buf_size);
+			if (sz <= 0) {
+				stream_wrapper.reset();
+				break;
+			}
+			stream_data.in_buff_end = stream_data.in_buff_start + sz;
+		}
+
+		auto finished = stream_wrapper->Read(stream_data);
+		if (finished) {
+			stream_wrapper.reset();
+		}
+	}
+	return total_read;
+}
+
+int64_t CompressedFile::WriteData(data_ptr_t buffer, int64_t nr_bytes) {
+	stream_wrapper->Write(*this, stream_data, buffer, nr_bytes);
+	return nr_bytes;
+}
+
+void CompressedFile::Close() {
+	if (stream_wrapper) {
+		stream_wrapper->Close();
+		stream_wrapper.reset();
+	}
+	stream_data.in_buff.reset();
+	stream_data.out_buff.reset();
+	stream_data.out_buff_start = nullptr;
+	stream_data.out_buff_end = nullptr;
+	stream_data.in_buff_start = nullptr;
+	stream_data.in_buff_end = nullptr;
+	stream_data.in_buf_size = 0;
+	stream_data.out_buf_size = 0;
+}
+
+int64_t CompressedFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &compressed_file = (CompressedFile &)handle;
+	return compressed_file.ReadData(buffer, nr_bytes);
+}
+
+int64_t CompressedFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &compressed_file = (CompressedFile &)handle;
+	return compressed_file.WriteData((data_ptr_t)buffer, nr_bytes);
+}
+
+void CompressedFileSystem::Reset(FileHandle &handle) {
+	auto &compressed_file = (CompressedFile &)handle;
+	compressed_file.child_handle->Reset();
+	compressed_file.Initialize(compressed_file.write);
+}
+
+int64_t CompressedFileSystem::GetFileSize(FileHandle &handle) {
+	auto &compressed_file = (CompressedFile &)handle;
+	return compressed_file.child_handle->GetFileSize();
+}
+
+bool CompressedFileSystem::OnDiskFile(FileHandle &handle) {
+	auto &compressed_file = (CompressedFile &)handle;
+	return compressed_file.child_handle->OnDiskFile();
+}
+
+bool CompressedFileSystem::CanSeek() {
+	return false;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+constexpr const idx_t DConstants::INVALID_INDEX;
+const row_t MAX_ROW_ID = 4611686018427388000ULL; // 2^62
+const column_t COLUMN_IDENTIFIER_ROW_ID = (column_t)-1;
+const sel_t ZERO_VECTOR[STANDARD_VECTOR_SIZE] = {0};
+const double PI = 3.141592653589793;
+
+const transaction_t TRANSACTION_ID_START = 4611686018427388000ULL;                // 2^62
+const transaction_t MAX_TRANSACTION_ID = NumericLimits<transaction_t>::Maximum(); // 2^63
+const transaction_t NOT_DELETED_ID = NumericLimits<transaction_t>::Maximum() - 1; // 2^64 - 1
+const transaction_t MAXIMUM_QUERY_ID = NumericLimits<transaction_t>::Maximum();   // 2^64
+
+uint64_t NextPowerOfTwo(uint64_t v) {
+	v--;
+	v |= v >> 1;
+	v |= v >> 2;
+	v |= v >> 4;
+	v |= v >> 8;
+	v |= v >> 16;
+	v |= v >> 32;
+	v++;
+	return v;
+}
+
+} // namespace duckdb
+/*
+** This code taken from the SQLite test library.  Originally found on
+** the internet.  The original header comment follows this comment.
+** The code is largerly unchanged, but there have been some modifications.
+*/
+/*
+ * This code implements the MD5 message-digest algorithm.
+ * The algorithm is due to Ron Rivest.  This code was
+ * written by Colin Plumb in 1993, no copyright is claimed.
+ * This code is in the public domain; do with it what you wish.
+ *
+ * Equivalent code is available from RSA Data Security, Inc.
+ * This code has been tested against that, and is equivalent,
+ * except that you don't need to include two pages of legalese
+ * with every copy.
+ *
+ * To compute the message digest of a chunk of bytes, declare an
+ * MD5Context structure, pass it to MD5Init, call MD5Update as
+ * needed on buffers full of bytes, and then call MD5Final, which
+ * will fill a supplied 16-byte array with the digest.
+ */
+
+
+namespace duckdb {
+
+/*
+ * Note: this code is harmless on little-endian machines.
+ */
+static void ByteReverse(unsigned char *buf, unsigned longs) {
+	uint32_t t;
+	do {
+		t = (uint32_t)((unsigned)buf[3] << 8 | buf[2]) << 16 | ((unsigned)buf[1] << 8 | buf[0]);
+		*(uint32_t *)buf = t;
+		buf += 4;
+	} while (--longs);
+}
+/* The four core functions - F1 is optimized somewhat */
+
+/* #define F1(x, y, z) (x & y | ~x & z) */
+#define F1(x, y, z) ((z) ^ ((x) & ((y) ^ (z))))
+#define F2(x, y, z) F1(z, x, y)
+#define F3(x, y, z) ((x) ^ (y) ^ (z))
+#define F4(x, y, z) ((y) ^ ((x) | ~(z)))
+
+/* This is the central step in the MD5 algorithm. */
+#define MD5STEP(f, w, x, y, z, data, s) ((w) += f(x, y, z) + (data), (w) = (w) << (s) | (w) >> (32 - (s)), (w) += (x))
+
+/*
+ * The core of the MD5 algorithm, this alters an existing MD5 hash to
+ * reflect the addition of 16 longwords of new data.  MD5Update blocks
+ * the data and converts bytes into longwords for this routine.
+ */
+static void MD5Transform(uint32_t buf[4], const uint32_t in[16]) {
+	uint32_t a, b, c, d;
+
+	a = buf[0];
+	b = buf[1];
+	c = buf[2];
+	d = buf[3];
+
+	MD5STEP(F1, a, b, c, d, in[0] + 0xd76aa478, 7);
+	MD5STEP(F1, d, a, b, c, in[1] + 0xe8c7b756, 12);
+	MD5STEP(F1, c, d, a, b, in[2] + 0x242070db, 17);
+	MD5STEP(F1, b, c, d, a, in[3] + 0xc1bdceee, 22);
+	MD5STEP(F1, a, b, c, d, in[4] + 0xf57c0faf, 7);
+	MD5STEP(F1, d, a, b, c, in[5] + 0x4787c62a, 12);
+	MD5STEP(F1, c, d, a, b, in[6] + 0xa8304613, 17);
+	MD5STEP(F1, b, c, d, a, in[7] + 0xfd469501, 22);
+	MD5STEP(F1, a, b, c, d, in[8] + 0x698098d8, 7);
+	MD5STEP(F1, d, a, b, c, in[9] + 0x8b44f7af, 12);
+	MD5STEP(F1, c, d, a, b, in[10] + 0xffff5bb1, 17);
+	MD5STEP(F1, b, c, d, a, in[11] + 0x895cd7be, 22);
+	MD5STEP(F1, a, b, c, d, in[12] + 0x6b901122, 7);
+	MD5STEP(F1, d, a, b, c, in[13] + 0xfd987193, 12);
+	MD5STEP(F1, c, d, a, b, in[14] + 0xa679438e, 17);
+	MD5STEP(F1, b, c, d, a, in[15] + 0x49b40821, 22);
+
+	MD5STEP(F2, a, b, c, d, in[1] + 0xf61e2562, 5);
+	MD5STEP(F2, d, a, b, c, in[6] + 0xc040b340, 9);
+	MD5STEP(F2, c, d, a, b, in[11] + 0x265e5a51, 14);
+	MD5STEP(F2, b, c, d, a, in[0] + 0xe9b6c7aa, 20);
+	MD5STEP(F2, a, b, c, d, in[5] + 0xd62f105d, 5);
+	MD5STEP(F2, d, a, b, c, in[10] + 0x02441453, 9);
+	MD5STEP(F2, c, d, a, b, in[15] + 0xd8a1e681, 14);
+	MD5STEP(F2, b, c, d, a, in[4] + 0xe7d3fbc8, 20);
+	MD5STEP(F2, a, b, c, d, in[9] + 0x21e1cde6, 5);
+	MD5STEP(F2, d, a, b, c, in[14] + 0xc33707d6, 9);
+	MD5STEP(F2, c, d, a, b, in[3] + 0xf4d50d87, 14);
+	MD5STEP(F2, b, c, d, a, in[8] + 0x455a14ed, 20);
+	MD5STEP(F2, a, b, c, d, in[13] + 0xa9e3e905, 5);
+	MD5STEP(F2, d, a, b, c, in[2] + 0xfcefa3f8, 9);
+	MD5STEP(F2, c, d, a, b, in[7] + 0x676f02d9, 14);
+	MD5STEP(F2, b, c, d, a, in[12] + 0x8d2a4c8a, 20);
+
+	MD5STEP(F3, a, b, c, d, in[5] + 0xfffa3942, 4);
+	MD5STEP(F3, d, a, b, c, in[8] + 0x8771f681, 11);
+	MD5STEP(F3, c, d, a, b, in[11] + 0x6d9d6122, 16);
+	MD5STEP(F3, b, c, d, a, in[14] + 0xfde5380c, 23);
+	MD5STEP(F3, a, b, c, d, in[1] + 0xa4beea44, 4);
+	MD5STEP(F3, d, a, b, c, in[4] + 0x4bdecfa9, 11);
+	MD5STEP(F3, c, d, a, b, in[7] + 0xf6bb4b60, 16);
+	MD5STEP(F3, b, c, d, a, in[10] + 0xbebfbc70, 23);
+	MD5STEP(F3, a, b, c, d, in[13] + 0x289b7ec6, 4);
+	MD5STEP(F3, d, a, b, c, in[0] + 0xeaa127fa, 11);
+	MD5STEP(F3, c, d, a, b, in[3] + 0xd4ef3085, 16);
+	MD5STEP(F3, b, c, d, a, in[6] + 0x04881d05, 23);
+	MD5STEP(F3, a, b, c, d, in[9] + 0xd9d4d039, 4);
+	MD5STEP(F3, d, a, b, c, in[12] + 0xe6db99e5, 11);
+	MD5STEP(F3, c, d, a, b, in[15] + 0x1fa27cf8, 16);
+	MD5STEP(F3, b, c, d, a, in[2] + 0xc4ac5665, 23);
+
+	MD5STEP(F4, a, b, c, d, in[0] + 0xf4292244, 6);
+	MD5STEP(F4, d, a, b, c, in[7] + 0x432aff97, 10);
+	MD5STEP(F4, c, d, a, b, in[14] + 0xab9423a7, 15);
+	MD5STEP(F4, b, c, d, a, in[5] + 0xfc93a039, 21);
+	MD5STEP(F4, a, b, c, d, in[12] + 0x655b59c3, 6);
+	MD5STEP(F4, d, a, b, c, in[3] + 0x8f0ccc92, 10);
+	MD5STEP(F4, c, d, a, b, in[10] + 0xffeff47d, 15);
+	MD5STEP(F4, b, c, d, a, in[1] + 0x85845dd1, 21);
+	MD5STEP(F4, a, b, c, d, in[8] + 0x6fa87e4f, 6);
+	MD5STEP(F4, d, a, b, c, in[15] + 0xfe2ce6e0, 10);
+	MD5STEP(F4, c, d, a, b, in[6] + 0xa3014314, 15);
+	MD5STEP(F4, b, c, d, a, in[13] + 0x4e0811a1, 21);
+	MD5STEP(F4, a, b, c, d, in[4] + 0xf7537e82, 6);
+	MD5STEP(F4, d, a, b, c, in[11] + 0xbd3af235, 10);
+	MD5STEP(F4, c, d, a, b, in[2] + 0x2ad7d2bb, 15);
+	MD5STEP(F4, b, c, d, a, in[9] + 0xeb86d391, 21);
+
+	buf[0] += a;
+	buf[1] += b;
+	buf[2] += c;
+	buf[3] += d;
+}
+
+/*
+ * Start MD5 accumulation.  Set bit count to 0 and buffer to mysterious
+ * initialization constants.
+ */
+MD5Context::MD5Context() {
+	buf[0] = 0x67452301;
+	buf[1] = 0xefcdab89;
+	buf[2] = 0x98badcfe;
+	buf[3] = 0x10325476;
+	bits[0] = 0;
+	bits[1] = 0;
+}
+
+/*
+ * Update context to reflect the concatenation of another buffer full
+ * of bytes.
+ */
+void MD5Context::MD5Update(const_data_ptr_t input, idx_t len) {
+	uint32_t t;
+
+	/* Update bitcount */
+
+	t = bits[0];
+	if ((bits[0] = t + ((uint32_t)len << 3)) < t) {
+		bits[1]++; /* Carry from low to high */
+	}
+	bits[1] += len >> 29;
+
+	t = (t >> 3) & 0x3f; /* Bytes already in shsInfo->data */
+
+	/* Handle any leading odd-sized chunks */
+
+	if (t) {
+		unsigned char *p = (unsigned char *)in + t;
+
+		t = 64 - t;
+		if (len < t) {
+			memcpy(p, input, len);
+			return;
+		}
+		memcpy(p, input, t);
+		ByteReverse(in, 16);
+		MD5Transform(buf, (uint32_t *)in);
+		input += t;
+		len -= t;
+	}
+
+	/* Process data in 64-byte chunks */
+
+	while (len >= 64) {
+		memcpy(in, input, 64);
+		ByteReverse(in, 16);
+		MD5Transform(buf, (uint32_t *)in);
+		input += 64;
+		len -= 64;
+	}
+
+	/* Handle any remaining bytes of data. */
+	memcpy(in, input, len);
+}
+
+/*
+ * Final wrapup - pad to 64-byte boundary with the bit pattern
+ * 1 0* (64-bit count of bits processed, MSB-first)
+ */
+void MD5Context::Finish(data_ptr_t out_digest) {
+	unsigned count;
+	unsigned char *p;
+
+	/* Compute number of bytes mod 64 */
+	count = (bits[0] >> 3) & 0x3F;
+
+	/* Set the first char of padding to 0x80.  This is safe since there is
+	   always at least one byte free */
+	p = in + count;
+	*p++ = 0x80;
+
+	/* Bytes of padding needed to make 64 bytes */
+	count = 64 - 1 - count;
+
+	/* Pad out to 56 mod 64 */
+	if (count < 8) {
+		/* Two lots of padding:  Pad the first block to 64 bytes */
+		memset(p, 0, count);
+		ByteReverse(in, 16);
+		MD5Transform(buf, (uint32_t *)in);
+
+		/* Now fill the next block with 56 bytes */
+		memset(in, 0, 56);
+	} else {
+		/* Pad block to 56 bytes */
+		memset(p, 0, count - 8);
+	}
+	ByteReverse(in, 14);
+
+	/* Append length in bits and transform */
+	((uint32_t *)in)[14] = bits[0];
+	((uint32_t *)in)[15] = bits[1];
+
+	MD5Transform(buf, (uint32_t *)in);
+	ByteReverse((unsigned char *)buf, 4);
+	memcpy(out_digest, buf, 16);
+}
+
+void MD5Context::DigestToBase16(const_data_ptr_t digest, char *zbuf) {
+	static char const HEX_CODES[] = "0123456789abcdef";
+	int i, j;
+
+	for (j = i = 0; i < 16; i++) {
+		int a = digest[i];
+		zbuf[j++] = HEX_CODES[(a >> 4) & 0xf];
+		zbuf[j++] = HEX_CODES[a & 0xf];
+	}
+}
+
+void MD5Context::FinishHex(char *out_digest) {
+	data_t digest[MD5_HASH_LENGTH_BINARY];
+	Finish(digest);
+	DigestToBase16(digest, out_digest);
+}
+
+string MD5Context::FinishHex() {
+	char digest[MD5_HASH_LENGTH_TEXT];
+	FinishHex(digest);
+	return string(digest, MD5_HASH_LENGTH_TEXT);
+}
+
+void MD5Context::Add(const char *data) {
+	MD5Update((const_data_ptr_t)data, strlen(data));
+}
+
+} // namespace duckdb
+// This file is licensed under Apache License 2.0
+// Source code taken from https://github.com/google/benchmark
+// It is highly modified
+
+
+
+
+namespace duckdb {
+
+inline uint64_t ChronoNow() {
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(
+	           std::chrono::time_point_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now())
+	               .time_since_epoch())
+	    .count();
+}
+
+inline uint64_t Now() {
+#if defined(RDTSC)
+#if defined(__i386__)
+	uint64_t ret;
+	__asm__ volatile("rdtsc" : "=A"(ret));
+	return ret;
+#elif defined(__x86_64__) || defined(__amd64__)
+	uint64_t low, high;
+	__asm__ volatile("rdtsc" : "=a"(low), "=d"(high));
+	return (high << 32) | low;
+#elif defined(__powerpc__) || defined(__ppc__)
+	uint64_t tbl, tbu0, tbu1;
+	asm("mftbu %0" : "=r"(tbu0));
+	asm("mftb  %0" : "=r"(tbl));
+	asm("mftbu %0" : "=r"(tbu1));
+	tbl &= -static_cast<int64>(tbu0 == tbu1);
+	return (tbu1 << 32) | tbl;
+#elif defined(__sparc__)
+	uint64_t tick;
+	asm(".byte 0x83, 0x41, 0x00, 0x00");
+	asm("mov   %%g1, %0" : "=r"(tick));
+	return tick;
+#elif defined(__ia64__)
+	uint64_t itc;
+	asm("mov %0 = ar.itc" : "=r"(itc));
+	return itc;
+#elif defined(COMPILER_MSVC) && defined(_M_IX86)
+	_asm rdtsc
+#elif defined(COMPILER_MSVC)
+	return __rdtsc();
+#elif defined(__aarch64__)
+	uint64_t virtual_timer_value;
+	asm volatile("mrs %0, cntvct_el0" : "=r"(virtual_timer_value));
+	return virtual_timer_value;
+#elif defined(__ARM_ARCH)
+#if (__ARM_ARCH >= 6)
+	uint32_t pmccntr;
+	uint32_t pmuseren;
+	uint32_t pmcntenset;
+	asm volatile("mrc p15, 0, %0, c9, c14, 0" : "=r"(pmuseren));
+	if (pmuseren & 1) { // Allows reading perfmon counters for user mode code.
+		asm volatile("mrc p15, 0, %0, c9, c12, 1" : "=r"(pmcntenset));
+		if (pmcntenset & 0x80000000ul) { // Is it counting?
+			asm volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(pmccntr));
+			return static_cast<uint64_t>(pmccntr) * 64; // Should optimize to << 6
+		}
+	}
+#endif
+	return ChronoNow();
+#else
+	return ChronoNow();
+#endif
+#else
+	return ChronoNow();
+#endif // defined(RDTSC)
+}
+uint64_t CycleCounter::Tick() const {
+	return Now();
+}
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+string CatalogTypeToString(CatalogType type) {
+	switch (type) {
+	case CatalogType::COLLATION_ENTRY:
+		return "Collation";
+	case CatalogType::TYPE_ENTRY:
+		return "Type";
+	case CatalogType::TABLE_ENTRY:
+		return "Table";
+	case CatalogType::SCHEMA_ENTRY:
+		return "Schema";
+	case CatalogType::TABLE_FUNCTION_ENTRY:
+		return "Table Function";
+	case CatalogType::SCALAR_FUNCTION_ENTRY:
+		return "Scalar Function";
+	case CatalogType::AGGREGATE_FUNCTION_ENTRY:
+		return "Aggregate Function";
+	case CatalogType::COPY_FUNCTION_ENTRY:
+		return "Copy Function";
+	case CatalogType::PRAGMA_FUNCTION_ENTRY:
+		return "Pragma Function";
+	case CatalogType::MACRO_ENTRY:
+		return "Macro Function";
+	case CatalogType::TABLE_MACRO_ENTRY:
+		return "Table Macro Function";
+	case CatalogType::VIEW_ENTRY:
+		return "View";
+	case CatalogType::INDEX_ENTRY:
+		return "Index";
+	case CatalogType::PREPARED_STATEMENT:
+		return "Prepared Statement";
+	case CatalogType::SEQUENCE_ENTRY:
+		return "Sequence";
+	case CatalogType::INVALID:
+	case CatalogType::DELETED_ENTRY:
+	case CatalogType::UPDATED_ENTRY:
+		break;
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+CompressionType CompressionTypeFromString(const string &str) {
+	auto compression = StringUtil::Lower(str);
+	if (compression == "uncompressed") {
+		return CompressionType::COMPRESSION_UNCOMPRESSED;
+	} else if (compression == "rle") {
+		return CompressionType::COMPRESSION_RLE;
+	} else if (compression == "dictionary") {
+		return CompressionType::COMPRESSION_DICTIONARY;
+	} else if (compression == "pfor") {
+		return CompressionType::COMPRESSION_PFOR_DELTA;
+	} else if (compression == "bitpacking") {
+		return CompressionType::COMPRESSION_BITPACKING;
+	} else if (compression == "fsst") {
+		return CompressionType::COMPRESSION_FSST;
+	} else {
+		return CompressionType::COMPRESSION_AUTO;
+	}
+}
+
+string CompressionTypeToString(CompressionType type) {
+	switch (type) {
+	case CompressionType::COMPRESSION_UNCOMPRESSED:
+		return "Uncompressed";
+	case CompressionType::COMPRESSION_CONSTANT:
+		return "Constant";
+	case CompressionType::COMPRESSION_RLE:
+		return "RLE";
+	case CompressionType::COMPRESSION_DICTIONARY:
+		return "Dictionary";
+	case CompressionType::COMPRESSION_PFOR_DELTA:
+		return "PFOR";
+	case CompressionType::COMPRESSION_BITPACKING:
+		return "BitPacking";
+	case CompressionType::COMPRESSION_FSST:
+		return "FSST";
+	default:
+		throw InternalException("Unrecognized compression type!");
+	}
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+string ExpressionTypeToString(ExpressionType type) {
+	switch (type) {
+	case ExpressionType::OPERATOR_CAST:
+		return "CAST";
+	case ExpressionType::OPERATOR_NOT:
+		return "NOT";
+	case ExpressionType::OPERATOR_IS_NULL:
+		return "IS_NULL";
+	case ExpressionType::OPERATOR_IS_NOT_NULL:
+		return "IS_NOT_NULL";
+	case ExpressionType::COMPARE_EQUAL:
+		return "EQUAL";
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return "NOTEQUAL";
+	case ExpressionType::COMPARE_LESSTHAN:
+		return "LESSTHAN";
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return "GREATERTHAN";
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return "LESSTHANOREQUALTO";
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return "GREATERTHANOREQUALTO";
+	case ExpressionType::COMPARE_IN:
+		return "IN";
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return "DISTINCT_FROM";
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		return "NOT_DISTINCT_FROM";
+	case ExpressionType::CONJUNCTION_AND:
+		return "AND";
+	case ExpressionType::CONJUNCTION_OR:
+		return "OR";
+	case ExpressionType::VALUE_CONSTANT:
+		return "CONSTANT";
+	case ExpressionType::VALUE_PARAMETER:
+		return "PARAMETER";
+	case ExpressionType::VALUE_TUPLE:
+		return "TUPLE";
+	case ExpressionType::VALUE_TUPLE_ADDRESS:
+		return "TUPLE_ADDRESS";
+	case ExpressionType::VALUE_NULL:
+		return "NULL";
+	case ExpressionType::VALUE_VECTOR:
+		return "VECTOR";
+	case ExpressionType::VALUE_SCALAR:
+		return "SCALAR";
+	case ExpressionType::AGGREGATE:
+		return "AGGREGATE";
+	case ExpressionType::WINDOW_AGGREGATE:
+		return "WINDOW_AGGREGATE";
+	case ExpressionType::WINDOW_RANK:
+		return "RANK";
+	case ExpressionType::WINDOW_RANK_DENSE:
+		return "RANK_DENSE";
+	case ExpressionType::WINDOW_PERCENT_RANK:
+		return "PERCENT_RANK";
+	case ExpressionType::WINDOW_ROW_NUMBER:
+		return "ROW_NUMBER";
+	case ExpressionType::WINDOW_FIRST_VALUE:
+		return "FIRST_VALUE";
+	case ExpressionType::WINDOW_LAST_VALUE:
+		return "LAST_VALUE";
+	case ExpressionType::WINDOW_NTH_VALUE:
+		return "NTH_VALUE";
+	case ExpressionType::WINDOW_CUME_DIST:
+		return "CUME_DIST";
+	case ExpressionType::WINDOW_LEAD:
+		return "LEAD";
+	case ExpressionType::WINDOW_LAG:
+		return "LAG";
+	case ExpressionType::WINDOW_NTILE:
+		return "NTILE";
+	case ExpressionType::FUNCTION:
+		return "FUNCTION";
+	case ExpressionType::CASE_EXPR:
+		return "CASE";
+	case ExpressionType::OPERATOR_NULLIF:
+		return "NULLIF";
+	case ExpressionType::OPERATOR_COALESCE:
+		return "COALESCE";
+	case ExpressionType::ARRAY_EXTRACT:
+		return "ARRAY_EXTRACT";
+	case ExpressionType::ARRAY_SLICE:
+		return "ARRAY_SLICE";
+	case ExpressionType::STRUCT_EXTRACT:
+		return "STRUCT_EXTRACT";
+	case ExpressionType::SUBQUERY:
+		return "SUBQUERY";
+	case ExpressionType::STAR:
+		return "STAR";
+	case ExpressionType::PLACEHOLDER:
+		return "PLACEHOLDER";
+	case ExpressionType::COLUMN_REF:
+		return "COLUMN_REF";
+	case ExpressionType::FUNCTION_REF:
+		return "FUNCTION_REF";
+	case ExpressionType::TABLE_REF:
+		return "TABLE_REF";
+	case ExpressionType::CAST:
+		return "CAST";
+	case ExpressionType::COMPARE_NOT_IN:
+		return "COMPARE_NOT_IN";
+	case ExpressionType::COMPARE_BETWEEN:
+		return "COMPARE_BETWEEN";
+	case ExpressionType::COMPARE_NOT_BETWEEN:
+		return "COMPARE_NOT_BETWEEN";
+	case ExpressionType::VALUE_DEFAULT:
+		return "VALUE_DEFAULT";
+	case ExpressionType::BOUND_REF:
+		return "BOUND_REF";
+	case ExpressionType::BOUND_COLUMN_REF:
+		return "BOUND_COLUMN_REF";
+	case ExpressionType::BOUND_FUNCTION:
+		return "BOUND_FUNCTION";
+	case ExpressionType::BOUND_AGGREGATE:
+		return "BOUND_AGGREGATE";
+	case ExpressionType::GROUPING_FUNCTION:
+		return "GROUPING";
+	case ExpressionType::ARRAY_CONSTRUCTOR:
+		return "ARRAY_CONSTRUCTOR";
+	case ExpressionType::TABLE_STAR:
+		return "TABLE_STAR";
+	case ExpressionType::BOUND_UNNEST:
+		return "BOUND_UNNEST";
+	case ExpressionType::COLLATE:
+		return "COLLATE";
+	case ExpressionType::POSITIONAL_REFERENCE:
+		return "POSITIONAL_REFERENCE";
+	case ExpressionType::LAMBDA:
+		return "LAMBDA";
+	case ExpressionType::ARROW:
+		return "ARROW";
+	case ExpressionType::INVALID:
+		break;
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+string ExpressionTypeToOperator(ExpressionType type) {
+	switch (type) {
+	case ExpressionType::COMPARE_EQUAL:
+		return "=";
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return "!=";
+	case ExpressionType::COMPARE_LESSTHAN:
+		return "<";
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return ">";
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return "<=";
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return ">=";
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return "IS DISTINCT FROM";
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		return "IS NOT DISTINCT FROM";
+	case ExpressionType::CONJUNCTION_AND:
+		return "AND";
+	case ExpressionType::CONJUNCTION_OR:
+		return "OR";
+	default:
+		return "";
+	}
+}
+
+ExpressionType NegateComparisionExpression(ExpressionType type) {
+	ExpressionType negated_type = ExpressionType::INVALID;
+	switch (type) {
+	case ExpressionType::COMPARE_EQUAL:
+		negated_type = ExpressionType::COMPARE_NOTEQUAL;
+		break;
+	case ExpressionType::COMPARE_NOTEQUAL:
+		negated_type = ExpressionType::COMPARE_EQUAL;
+		break;
+	case ExpressionType::COMPARE_LESSTHAN:
+		negated_type = ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		negated_type = ExpressionType::COMPARE_LESSTHANOREQUALTO;
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		negated_type = ExpressionType::COMPARE_GREATERTHAN;
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		negated_type = ExpressionType::COMPARE_LESSTHAN;
+		break;
+	default:
+		throw InternalException("Unsupported comparison type in negation");
+	}
+	return negated_type;
+}
+
+ExpressionType FlipComparisionExpression(ExpressionType type) {
+	ExpressionType flipped_type = ExpressionType::INVALID;
+	switch (type) {
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+	case ExpressionType::COMPARE_NOTEQUAL:
+	case ExpressionType::COMPARE_EQUAL:
+		flipped_type = type;
+		break;
+	case ExpressionType::COMPARE_LESSTHAN:
+		flipped_type = ExpressionType::COMPARE_GREATERTHAN;
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		flipped_type = ExpressionType::COMPARE_LESSTHAN;
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		flipped_type = ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		flipped_type = ExpressionType::COMPARE_LESSTHANOREQUALTO;
+		break;
+	default:
+		throw InternalException("Unsupported comparison type in flip");
+	}
+	return flipped_type;
+}
+
+ExpressionType OperatorToExpressionType(const string &op) {
+	if (op == "=" || op == "==") {
+		return ExpressionType::COMPARE_EQUAL;
+	} else if (op == "!=" || op == "<>") {
+		return ExpressionType::COMPARE_NOTEQUAL;
+	} else if (op == "<") {
+		return ExpressionType::COMPARE_LESSTHAN;
+	} else if (op == ">") {
+		return ExpressionType::COMPARE_GREATERTHAN;
+	} else if (op == "<=") {
+		return ExpressionType::COMPARE_LESSTHANOREQUALTO;
+	} else if (op == ">=") {
+		return ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+	}
+	return ExpressionType::INVALID;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+FileCompressionType FileCompressionTypeFromString(const string &input) {
+	auto parameter = StringUtil::Lower(input);
+	if (parameter == "infer" || parameter == "auto") {
+		return FileCompressionType::AUTO_DETECT;
+	} else if (parameter == "gzip") {
+		return FileCompressionType::GZIP;
+	} else if (parameter == "zstd") {
+		return FileCompressionType::ZSTD;
+	} else if (parameter == "uncompressed" || parameter == "none" || parameter.empty()) {
+		return FileCompressionType::UNCOMPRESSED;
+	} else {
+		throw ParserException("Unrecognized file compression type \"%s\"", input);
+	}
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+string JoinTypeToString(JoinType type) {
+	switch (type) {
+	case JoinType::LEFT:
+		return "LEFT";
+	case JoinType::RIGHT:
+		return "RIGHT";
+	case JoinType::INNER:
+		return "INNER";
+	case JoinType::OUTER:
+		return "FULL";
+	case JoinType::SEMI:
+		return "SEMI";
+	case JoinType::ANTI:
+		return "ANTI";
+	case JoinType::SINGLE:
+		return "SINGLE";
+	case JoinType::MARK:
+		return "MARK";
+	case JoinType::INVALID: // LCOV_EXCL_START
+		break;
+	}
+	return "INVALID";
+} // LCOV_EXCL_STOP
+
+bool IsLeftOuterJoin(JoinType type) {
+	return type == JoinType::LEFT || type == JoinType::OUTER;
+}
+
+bool IsRightOuterJoin(JoinType type) {
+	return type == JoinType::OUTER || type == JoinType::RIGHT;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Value <--> String Utilities
+//===--------------------------------------------------------------------===//
+// LCOV_EXCL_START
+string LogicalOperatorToString(LogicalOperatorType type) {
+	switch (type) {
+	case LogicalOperatorType::LOGICAL_GET:
+		return "GET";
+	case LogicalOperatorType::LOGICAL_CHUNK_GET:
+		return "CHUNK_GET";
+	case LogicalOperatorType::LOGICAL_DELIM_GET:
+		return "DELIM_GET";
+	case LogicalOperatorType::LOGICAL_EMPTY_RESULT:
+		return "EMPTY_RESULT";
+	case LogicalOperatorType::LOGICAL_EXPRESSION_GET:
+		return "EXPRESSION_GET";
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+		return "ANY_JOIN";
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+		return "COMPARISON_JOIN";
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+		return "DELIM_JOIN";
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+		return "PROJECTION";
+	case LogicalOperatorType::LOGICAL_FILTER:
+		return "FILTER";
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		return "AGGREGATE";
+	case LogicalOperatorType::LOGICAL_WINDOW:
+		return "WINDOW";
+	case LogicalOperatorType::LOGICAL_UNNEST:
+		return "UNNEST";
+	case LogicalOperatorType::LOGICAL_LIMIT:
+		return "LIMIT";
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+		return "ORDER_BY";
+	case LogicalOperatorType::LOGICAL_TOP_N:
+		return "TOP_N";
+	case LogicalOperatorType::LOGICAL_SAMPLE:
+		return "SAMPLE";
+	case LogicalOperatorType::LOGICAL_LIMIT_PERCENT:
+		return "LIMIT_PERCENT";
+	case LogicalOperatorType::LOGICAL_COPY_TO_FILE:
+		return "COPY_TO_FILE";
+	case LogicalOperatorType::LOGICAL_JOIN:
+		return "JOIN";
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+		return "CROSS_PRODUCT";
+	case LogicalOperatorType::LOGICAL_UNION:
+		return "UNION";
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+		return "EXCEPT";
+	case LogicalOperatorType::LOGICAL_INTERSECT:
+		return "INTERSECT";
+	case LogicalOperatorType::LOGICAL_INSERT:
+		return "INSERT";
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+		return "DISTINCT";
+	case LogicalOperatorType::LOGICAL_DELETE:
+		return "DELETE";
+	case LogicalOperatorType::LOGICAL_UPDATE:
+		return "UPDATE";
+	case LogicalOperatorType::LOGICAL_PREPARE:
+		return "PREPARE";
+	case LogicalOperatorType::LOGICAL_DUMMY_SCAN:
+		return "DUMMY_SCAN";
+	case LogicalOperatorType::LOGICAL_CREATE_INDEX:
+		return "CREATE_INDEX";
+	case LogicalOperatorType::LOGICAL_CREATE_TABLE:
+		return "CREATE_TABLE";
+	case LogicalOperatorType::LOGICAL_CREATE_MACRO:
+		return "CREATE_MACRO";
+	case LogicalOperatorType::LOGICAL_EXPLAIN:
+		return "EXPLAIN";
+	case LogicalOperatorType::LOGICAL_EXECUTE:
+		return "EXECUTE";
+	case LogicalOperatorType::LOGICAL_VACUUM:
+		return "VACUUM";
+	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE:
+		return "REC_CTE";
+	case LogicalOperatorType::LOGICAL_CTE_REF:
+		return "CTE_SCAN";
+	case LogicalOperatorType::LOGICAL_SHOW:
+		return "SHOW";
+	case LogicalOperatorType::LOGICAL_ALTER:
+		return "ALTER";
+	case LogicalOperatorType::LOGICAL_CREATE_SEQUENCE:
+		return "CREATE_SEQUENCE";
+	case LogicalOperatorType::LOGICAL_CREATE_TYPE:
+		return "CREATE_TYPE";
+	case LogicalOperatorType::LOGICAL_CREATE_VIEW:
+		return "CREATE_VIEW";
+	case LogicalOperatorType::LOGICAL_CREATE_SCHEMA:
+		return "CREATE_SCHEMA";
+	case LogicalOperatorType::LOGICAL_DROP:
+		return "DROP";
+	case LogicalOperatorType::LOGICAL_PRAGMA:
+		return "PRAGMA";
+	case LogicalOperatorType::LOGICAL_TRANSACTION:
+		return "TRANSACTION";
+	case LogicalOperatorType::LOGICAL_EXPORT:
+		return "EXPORT";
+	case LogicalOperatorType::LOGICAL_SET:
+		return "SET";
+	case LogicalOperatorType::LOGICAL_LOAD:
+		return "LOAD";
+	case LogicalOperatorType::LOGICAL_INVALID:
+		break;
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct DefaultOptimizerType {
+	const char *name;
+	OptimizerType type;
+};
+
+static DefaultOptimizerType internal_optimizer_types[] = {
+    {"expression_rewriter", OptimizerType::EXPRESSION_REWRITER},
+    {"filter_pullup", OptimizerType::FILTER_PULLUP},
+    {"filter_pushdown", OptimizerType::FILTER_PUSHDOWN},
+    {"regex_range", OptimizerType::REGEX_RANGE},
+    {"in_clause", OptimizerType::IN_CLAUSE},
+    {"join_order", OptimizerType::JOIN_ORDER},
+    {"deliminator", OptimizerType::DELIMINATOR},
+    {"unused_columns", OptimizerType::UNUSED_COLUMNS},
+    {"statistics_propagation", OptimizerType::STATISTICS_PROPAGATION},
+    {"common_subexpressions", OptimizerType::COMMON_SUBEXPRESSIONS},
+    {"common_aggregate", OptimizerType::COMMON_AGGREGATE},
+    {"column_lifetime", OptimizerType::COLUMN_LIFETIME},
+    {"top_n", OptimizerType::TOP_N},
+    {"reorder_filter", OptimizerType::REORDER_FILTER},
+    {nullptr, OptimizerType::INVALID}};
+
+string OptimizerTypeToString(OptimizerType type) {
+	for (idx_t i = 0; internal_optimizer_types[i].name; i++) {
+		if (internal_optimizer_types[i].type == type) {
+			return internal_optimizer_types[i].name;
+		}
+	}
+	throw InternalException("Invalid optimizer type");
+}
+
+OptimizerType OptimizerTypeFromString(const string &str) {
+	for (idx_t i = 0; internal_optimizer_types[i].name; i++) {
+		if (internal_optimizer_types[i].name == str) {
+			return internal_optimizer_types[i].type;
+		}
+	}
+	// optimizer not found, construct candidate list
+	vector<string> optimizer_names;
+	for (idx_t i = 0; internal_optimizer_types[i].name; i++) {
+		optimizer_names.emplace_back(internal_optimizer_types[i].name);
+	}
+	throw ParserException("Optimizer type \"%s\" not recognized\n%s", str,
+	                      StringUtil::CandidatesErrorMessage(optimizer_names, str, "Candidate optimizers"));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+string PhysicalOperatorToString(PhysicalOperatorType type) {
+	switch (type) {
+	case PhysicalOperatorType::TABLE_SCAN:
+		return "TABLE_SCAN";
+	case PhysicalOperatorType::DUMMY_SCAN:
+		return "DUMMY_SCAN";
+	case PhysicalOperatorType::CHUNK_SCAN:
+		return "CHUNK_SCAN";
+	case PhysicalOperatorType::DELIM_SCAN:
+		return "DELIM_SCAN";
+	case PhysicalOperatorType::ORDER_BY:
+		return "ORDER_BY";
+	case PhysicalOperatorType::LIMIT:
+		return "LIMIT";
+	case PhysicalOperatorType::LIMIT_PERCENT:
+		return "LIMIT_PERCENT";
+	case PhysicalOperatorType::STREAMING_LIMIT:
+		return "STREAMING_LIMIT";
+	case PhysicalOperatorType::RESERVOIR_SAMPLE:
+		return "RESERVOIR_SAMPLE";
+	case PhysicalOperatorType::STREAMING_SAMPLE:
+		return "STREAMING_SAMPLE";
+	case PhysicalOperatorType::TOP_N:
+		return "TOP_N";
+	case PhysicalOperatorType::WINDOW:
+		return "WINDOW";
+	case PhysicalOperatorType::STREAMING_WINDOW:
+		return "STREAMING_WINDOW";
+	case PhysicalOperatorType::UNNEST:
+		return "UNNEST";
+	case PhysicalOperatorType::SIMPLE_AGGREGATE:
+		return "SIMPLE_AGGREGATE";
+	case PhysicalOperatorType::HASH_GROUP_BY:
+		return "HASH_GROUP_BY";
+	case PhysicalOperatorType::PERFECT_HASH_GROUP_BY:
+		return "PERFECT_HASH_GROUP_BY";
+	case PhysicalOperatorType::FILTER:
+		return "FILTER";
+	case PhysicalOperatorType::PROJECTION:
+		return "PROJECTION";
+	case PhysicalOperatorType::COPY_TO_FILE:
+		return "COPY_TO_FILE";
+	case PhysicalOperatorType::DELIM_JOIN:
+		return "DELIM_JOIN";
+	case PhysicalOperatorType::BLOCKWISE_NL_JOIN:
+		return "BLOCKWISE_NL_JOIN";
+	case PhysicalOperatorType::NESTED_LOOP_JOIN:
+		return "NESTED_LOOP_JOIN";
+	case PhysicalOperatorType::HASH_JOIN:
+		return "HASH_JOIN";
+	case PhysicalOperatorType::INDEX_JOIN:
+		return "INDEX_JOIN";
+	case PhysicalOperatorType::PIECEWISE_MERGE_JOIN:
+		return "PIECEWISE_MERGE_JOIN";
+	case PhysicalOperatorType::IE_JOIN:
+		return "IE_JOIN";
+	case PhysicalOperatorType::CROSS_PRODUCT:
+		return "CROSS_PRODUCT";
+	case PhysicalOperatorType::UNION:
+		return "UNION";
+	case PhysicalOperatorType::INSERT:
+		return "INSERT";
+	case PhysicalOperatorType::DELETE_OPERATOR:
+		return "DELETE";
+	case PhysicalOperatorType::UPDATE:
+		return "UPDATE";
+	case PhysicalOperatorType::EMPTY_RESULT:
+		return "EMPTY_RESULT";
+	case PhysicalOperatorType::CREATE_TABLE:
+		return "CREATE_TABLE";
+	case PhysicalOperatorType::CREATE_TABLE_AS:
+		return "CREATE_TABLE_AS";
+	case PhysicalOperatorType::CREATE_INDEX:
+		return "CREATE_INDEX";
+	case PhysicalOperatorType::EXPLAIN:
+		return "EXPLAIN";
+	case PhysicalOperatorType::EXPLAIN_ANALYZE:
+		return "EXPLAIN_ANALYZE";
+	case PhysicalOperatorType::EXECUTE:
+		return "EXECUTE";
+	case PhysicalOperatorType::VACUUM:
+		return "VACUUM";
+	case PhysicalOperatorType::RECURSIVE_CTE:
+		return "REC_CTE";
+	case PhysicalOperatorType::RECURSIVE_CTE_SCAN:
+		return "REC_CTE_SCAN";
+	case PhysicalOperatorType::EXPRESSION_SCAN:
+		return "EXPRESSION_SCAN";
+	case PhysicalOperatorType::ALTER:
+		return "ALTER";
+	case PhysicalOperatorType::CREATE_SEQUENCE:
+		return "CREATE_SEQUENCE";
+	case PhysicalOperatorType::CREATE_VIEW:
+		return "CREATE_VIEW";
+	case PhysicalOperatorType::CREATE_SCHEMA:
+		return "CREATE_SCHEMA";
+	case PhysicalOperatorType::CREATE_MACRO:
+		return "CREATE_MACRO";
+	case PhysicalOperatorType::DROP:
+		return "DROP";
+	case PhysicalOperatorType::PRAGMA:
+		return "PRAGMA";
+	case PhysicalOperatorType::TRANSACTION:
+		return "TRANSACTION";
+	case PhysicalOperatorType::PREPARE:
+		return "PREPARE";
+	case PhysicalOperatorType::EXPORT:
+		return "EXPORT";
+	case PhysicalOperatorType::SET:
+		return "SET";
+	case PhysicalOperatorType::LOAD:
+		return "LOAD";
+	case PhysicalOperatorType::INOUT_FUNCTION:
+		return "INOUT_FUNCTION";
+	case PhysicalOperatorType::CREATE_TYPE:
+		return "CREATE_TYPE";
+	case PhysicalOperatorType::RESULT_COLLECTOR:
+		return "RESULT_COLLECTOR";
+	case PhysicalOperatorType::INVALID:
+		break;
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+string RelationTypeToString(RelationType type) {
+	switch (type) {
+	case RelationType::TABLE_RELATION:
+		return "TABLE_RELATION";
+	case RelationType::PROJECTION_RELATION:
+		return "PROJECTION_RELATION";
+	case RelationType::FILTER_RELATION:
+		return "FILTER_RELATION";
+	case RelationType::EXPLAIN_RELATION:
+		return "EXPLAIN_RELATION";
+	case RelationType::CROSS_PRODUCT_RELATION:
+		return "CROSS_PRODUCT_RELATION";
+	case RelationType::JOIN_RELATION:
+		return "JOIN_RELATION";
+	case RelationType::AGGREGATE_RELATION:
+		return "AGGREGATE_RELATION";
+	case RelationType::SET_OPERATION_RELATION:
+		return "SET_OPERATION_RELATION";
+	case RelationType::DISTINCT_RELATION:
+		return "DISTINCT_RELATION";
+	case RelationType::LIMIT_RELATION:
+		return "LIMIT_RELATION";
+	case RelationType::ORDER_RELATION:
+		return "ORDER_RELATION";
+	case RelationType::CREATE_VIEW_RELATION:
+		return "CREATE_VIEW_RELATION";
+	case RelationType::CREATE_TABLE_RELATION:
+		return "CREATE_TABLE_RELATION";
+	case RelationType::INSERT_RELATION:
+		return "INSERT_RELATION";
+	case RelationType::VALUE_LIST_RELATION:
+		return "VALUE_LIST_RELATION";
+	case RelationType::DELETE_RELATION:
+		return "DELETE_RELATION";
+	case RelationType::UPDATE_RELATION:
+		return "UPDATE_RELATION";
+	case RelationType::WRITE_CSV_RELATION:
+		return "WRITE_CSV_RELATION";
+	case RelationType::READ_CSV_RELATION:
+		return "READ_CSV_RELATION";
+	case RelationType::SUBQUERY_RELATION:
+		return "SUBQUERY_RELATION";
+	case RelationType::TABLE_FUNCTION_RELATION:
+		return "TABLE_FUNCTION_RELATION";
+	case RelationType::VIEW_RELATION:
+		return "VIEW_RELATION";
+	case RelationType::QUERY_RELATION:
+		return "QUERY_RELATION";
+	case RelationType::INVALID_RELATION:
+		break;
+	}
+	return "INVALID_RELATION";
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+string StatementTypeToString(StatementType type) {
+	switch (type) {
+	case StatementType::SELECT_STATEMENT:
+		return "SELECT";
+	case StatementType::INSERT_STATEMENT:
+		return "INSERT";
+	case StatementType::UPDATE_STATEMENT:
+		return "UPDATE";
+	case StatementType::DELETE_STATEMENT:
+		return "DELETE";
+	case StatementType::PREPARE_STATEMENT:
+		return "PREPARE";
+	case StatementType::EXECUTE_STATEMENT:
+		return "EXECUTE";
+	case StatementType::ALTER_STATEMENT:
+		return "ALTER";
+	case StatementType::TRANSACTION_STATEMENT:
+		return "TRANSACTION";
+	case StatementType::COPY_STATEMENT:
+		return "COPY";
+	case StatementType::ANALYZE_STATEMENT:
+		return "ANALYZE";
+	case StatementType::VARIABLE_SET_STATEMENT:
+		return "VARIABLE_SET";
+	case StatementType::CREATE_FUNC_STATEMENT:
+		return "CREATE_FUNC";
+	case StatementType::EXPLAIN_STATEMENT:
+		return "EXPLAIN";
+	case StatementType::CREATE_STATEMENT:
+		return "CREATE";
+	case StatementType::DROP_STATEMENT:
+		return "DROP";
+	case StatementType::PRAGMA_STATEMENT:
+		return "PRAGMA";
+	case StatementType::SHOW_STATEMENT:
+		return "SHOW";
+	case StatementType::VACUUM_STATEMENT:
+		return "VACUUM";
+	case StatementType::RELATION_STATEMENT:
+		return "RELATION";
+	case StatementType::EXPORT_STATEMENT:
+		return "EXPORT";
+	case StatementType::CALL_STATEMENT:
+		return "CALL";
+	case StatementType::SET_STATEMENT:
+		return "SET";
+	case StatementType::LOAD_STATEMENT:
+		return "LOAD";
+	case StatementType::INVALID_STATEMENT:
+		break;
+	}
+	return "INVALID";
+}
+
+string StatementReturnTypeToString(StatementReturnType type) {
+	switch (type) {
+	case StatementReturnType::QUERY_RESULT:
+		return "QUERY_RESULT";
+	case StatementReturnType::CHANGED_ROWS:
+		return "CHANGED_ROWS";
+	case StatementReturnType::NOTHING:
+		return "NOTHING";
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+Exception::Exception(const string &msg) : std::exception(), type(ExceptionType::INVALID) {
+	exception_message_ = msg;
+}
+
+Exception::Exception(ExceptionType exception_type, const string &message) : std::exception(), type(exception_type) {
+	exception_message_ = ExceptionTypeToString(exception_type) + " Error: " + message;
+}
+
+const char *Exception::what() const noexcept {
+	return exception_message_.c_str();
+}
+
+bool Exception::UncaughtException() {
+#if __cplusplus >= 201703L
+	return std::uncaught_exceptions() > 0;
+#else
+	return std::uncaught_exception();
+#endif
+}
+
+string Exception::ConstructMessageRecursive(const string &msg, vector<ExceptionFormatValue> &values) {
+	return ExceptionFormatValue::Format(msg, values);
+}
+
+string Exception::ExceptionTypeToString(ExceptionType type) {
+	switch (type) {
+	case ExceptionType::INVALID:
+		return "Invalid";
+	case ExceptionType::OUT_OF_RANGE:
+		return "Out of Range";
+	case ExceptionType::CONVERSION:
+		return "Conversion";
+	case ExceptionType::UNKNOWN_TYPE:
+		return "Unknown Type";
+	case ExceptionType::DECIMAL:
+		return "Decimal";
+	case ExceptionType::MISMATCH_TYPE:
+		return "Mismatch Type";
+	case ExceptionType::DIVIDE_BY_ZERO:
+		return "Divide by Zero";
+	case ExceptionType::OBJECT_SIZE:
+		return "Object Size";
+	case ExceptionType::INVALID_TYPE:
+		return "Invalid type";
+	case ExceptionType::SERIALIZATION:
+		return "Serialization";
+	case ExceptionType::TRANSACTION:
+		return "TransactionContext";
+	case ExceptionType::NOT_IMPLEMENTED:
+		return "Not implemented";
+	case ExceptionType::EXPRESSION:
+		return "Expression";
+	case ExceptionType::CATALOG:
+		return "Catalog";
+	case ExceptionType::PARSER:
+		return "Parser";
+	case ExceptionType::BINDER:
+		return "Binder";
+	case ExceptionType::PLANNER:
+		return "Planner";
+	case ExceptionType::SCHEDULER:
+		return "Scheduler";
+	case ExceptionType::EXECUTOR:
+		return "Executor";
+	case ExceptionType::CONSTRAINT:
+		return "Constraint";
+	case ExceptionType::INDEX:
+		return "Index";
+	case ExceptionType::STAT:
+		return "Stat";
+	case ExceptionType::CONNECTION:
+		return "Connection";
+	case ExceptionType::SYNTAX:
+		return "Syntax";
+	case ExceptionType::SETTINGS:
+		return "Settings";
+	case ExceptionType::OPTIMIZER:
+		return "Optimizer";
+	case ExceptionType::NULL_POINTER:
+		return "NullPointer";
+	case ExceptionType::IO:
+		return "IO";
+	case ExceptionType::INTERRUPT:
+		return "INTERRUPT";
+	case ExceptionType::FATAL:
+		return "FATAL";
+	case ExceptionType::INTERNAL:
+		return "INTERNAL";
+	case ExceptionType::INVALID_INPUT:
+		return "Invalid Input";
+	case ExceptionType::OUT_OF_MEMORY:
+		return "Out of Memory";
+	case ExceptionType::PERMISSION:
+		return "Permission";
+	default:
+		return "Unknown";
+	}
+}
+
+StandardException::StandardException(ExceptionType exception_type, const string &message)
+    : Exception(exception_type, message) {
+}
+
+CastException::CastException(const PhysicalType orig_type, const PhysicalType new_type)
+    : Exception(ExceptionType::CONVERSION,
+                "Type " + TypeIdToString(orig_type) + " can't be cast as " + TypeIdToString(new_type)) {
+}
+
+CastException::CastException(const LogicalType &orig_type, const LogicalType &new_type)
+    : Exception(ExceptionType::CONVERSION,
+                "Type " + orig_type.ToString() + " can't be cast as " + new_type.ToString()) {
+}
+
+ValueOutOfRangeException::ValueOutOfRangeException(const int64_t value, const PhysicalType orig_type,
+                                                   const PhysicalType new_type)
+    : Exception(ExceptionType::CONVERSION, "Type " + TypeIdToString(orig_type) + " with value " +
+                                               to_string((intmax_t)value) +
+                                               " can't be cast because the value is out of range "
+                                               "for the destination type " +
+                                               TypeIdToString(new_type)) {
+}
+
+ValueOutOfRangeException::ValueOutOfRangeException(const double value, const PhysicalType orig_type,
+                                                   const PhysicalType new_type)
+    : Exception(ExceptionType::CONVERSION, "Type " + TypeIdToString(orig_type) + " with value " + to_string(value) +
+                                               " can't be cast because the value is out of range "
+                                               "for the destination type " +
+                                               TypeIdToString(new_type)) {
+}
+
+ValueOutOfRangeException::ValueOutOfRangeException(const hugeint_t value, const PhysicalType orig_type,
+                                                   const PhysicalType new_type)
+    : Exception(ExceptionType::CONVERSION, "Type " + TypeIdToString(orig_type) + " with value " + value.ToString() +
+                                               " can't be cast because the value is out of range "
+                                               "for the destination type " +
+                                               TypeIdToString(new_type)) {
+}
+
+ValueOutOfRangeException::ValueOutOfRangeException(const PhysicalType var_type, const idx_t length)
+    : Exception(ExceptionType::OUT_OF_RANGE,
+                "The value is too long to fit into type " + TypeIdToString(var_type) + "(" + to_string(length) + ")") {
+}
+
+ConversionException::ConversionException(const string &msg) : Exception(ExceptionType::CONVERSION, msg) {
+}
+
+InvalidTypeException::InvalidTypeException(PhysicalType type, const string &msg)
+    : Exception(ExceptionType::INVALID_TYPE, "Invalid Type [" + TypeIdToString(type) + "]: " + msg) {
+}
+
+InvalidTypeException::InvalidTypeException(const LogicalType &type, const string &msg)
+    : Exception(ExceptionType::INVALID_TYPE, "Invalid Type [" + type.ToString() + "]: " + msg) {
+}
+
+TypeMismatchException::TypeMismatchException(const PhysicalType type_1, const PhysicalType type_2, const string &msg)
+    : Exception(ExceptionType::MISMATCH_TYPE,
+                "Type " + TypeIdToString(type_1) + " does not match with " + TypeIdToString(type_2) + ". " + msg) {
+}
+
+TypeMismatchException::TypeMismatchException(const LogicalType &type_1, const LogicalType &type_2, const string &msg)
+    : Exception(ExceptionType::MISMATCH_TYPE,
+                "Type " + type_1.ToString() + " does not match with " + type_2.ToString() + ". " + msg) {
+}
+
+TransactionException::TransactionException(const string &msg) : Exception(ExceptionType::TRANSACTION, msg) {
+}
+
+NotImplementedException::NotImplementedException(const string &msg) : Exception(ExceptionType::NOT_IMPLEMENTED, msg) {
+}
+
+OutOfRangeException::OutOfRangeException(const string &msg) : Exception(ExceptionType::OUT_OF_RANGE, msg) {
+}
+
+CatalogException::CatalogException(const string &msg) : StandardException(ExceptionType::CATALOG, msg) {
+}
+
+ParserException::ParserException(const string &msg) : StandardException(ExceptionType::PARSER, msg) {
+}
+
+PermissionException::PermissionException(const string &msg) : StandardException(ExceptionType::PERMISSION, msg) {
+}
+
+SyntaxException::SyntaxException(const string &msg) : Exception(ExceptionType::SYNTAX, msg) {
+}
+
+ConstraintException::ConstraintException(const string &msg) : Exception(ExceptionType::CONSTRAINT, msg) {
+}
+
+BinderException::BinderException(const string &msg) : StandardException(ExceptionType::BINDER, msg) {
+}
+
+IOException::IOException(const string &msg) : Exception(ExceptionType::IO, msg) {
+}
+
+SerializationException::SerializationException(const string &msg) : Exception(ExceptionType::SERIALIZATION, msg) {
+}
+
+SequenceException::SequenceException(const string &msg) : Exception(ExceptionType::SERIALIZATION, msg) {
+}
+
+InterruptException::InterruptException() : Exception(ExceptionType::INTERRUPT, "Interrupted!") {
+}
+
+FatalException::FatalException(const string &msg) : Exception(ExceptionType::FATAL, msg) {
+}
+
+InternalException::InternalException(const string &msg) : Exception(ExceptionType::INTERNAL, msg) {
+}
+
+InvalidInputException::InvalidInputException(const string &msg) : Exception(ExceptionType::INVALID_INPUT, msg) {
+}
+
+OutOfMemoryException::OutOfMemoryException(const string &msg) : Exception(ExceptionType::OUT_OF_MEMORY, msg) {
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+ExceptionFormatValue::ExceptionFormatValue(double dbl_val)
+    : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_DOUBLE), dbl_val(dbl_val) {
+}
+ExceptionFormatValue::ExceptionFormatValue(int64_t int_val)
+    : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_INTEGER), int_val(int_val) {
+}
+ExceptionFormatValue::ExceptionFormatValue(hugeint_t huge_val)
+    : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING), str_val(Hugeint::ToString(huge_val)) {
+}
+ExceptionFormatValue::ExceptionFormatValue(string str_val)
+    : type(ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING), str_val(move(str_val)) {
+}
+
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(PhysicalType value) {
+	return ExceptionFormatValue(TypeIdToString(value));
+}
+template <>
+ExceptionFormatValue
+ExceptionFormatValue::CreateFormatValue(LogicalType value) { // NOLINT: templating requires us to copy value here
+	return ExceptionFormatValue(value.ToString());
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(float value) {
+	return ExceptionFormatValue(double(value));
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(double value) {
+	return ExceptionFormatValue(double(value));
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(string value) {
+	return ExceptionFormatValue(move(value));
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(const char *value) {
+	return ExceptionFormatValue(string(value));
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(char *value) {
+	return ExceptionFormatValue(string(value));
+}
+template <>
+ExceptionFormatValue ExceptionFormatValue::CreateFormatValue(hugeint_t value) {
+	return ExceptionFormatValue(value);
+}
+
+string ExceptionFormatValue::Format(const string &msg, vector<ExceptionFormatValue> &values) {
+	std::vector<duckdb_fmt::basic_format_arg<duckdb_fmt::printf_context>> format_args;
+	for (auto &val : values) {
+		switch (val.type) {
+		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_DOUBLE:
+			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.dbl_val));
+			break;
+		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_INTEGER:
+			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.int_val));
+			break;
+		case ExceptionFormatValueType::FORMAT_VALUE_TYPE_STRING:
+			format_args.push_back(duckdb_fmt::internal::make_arg<duckdb_fmt::printf_context>(val.str_val));
+			break;
+		}
+	}
+	return duckdb_fmt::vsprintf(msg, duckdb_fmt::basic_format_args<duckdb_fmt::printf_context>(
+	                                     format_args.data(), static_cast<int>(format_args.size())));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Field Writer
+//===--------------------------------------------------------------------===//
+FieldWriter::FieldWriter(Serializer &serializer_p)
+    : serializer(serializer_p), buffer(make_unique<BufferedSerializer>()), field_count(0), finalized(false) {
+}
+
+FieldWriter::~FieldWriter() {
+	if (Exception::UncaughtException()) {
+		return;
+	}
+	D_ASSERT(finalized);
+	// finalize should always have been called, unless this is destroyed as part of stack unwinding
+	D_ASSERT(!buffer);
+}
+
+void FieldWriter::WriteData(const_data_ptr_t buffer_ptr, idx_t write_size) {
+	D_ASSERT(buffer);
+	buffer->WriteData(buffer_ptr, write_size);
+}
+
+template <>
+void FieldWriter::Write(const string &val) {
+	Write<uint32_t>((uint32_t)val.size());
+	if (!val.empty()) {
+		WriteData((const_data_ptr_t)val.c_str(), val.size());
+	}
+}
+
+void FieldWriter::Finalize() {
+	D_ASSERT(buffer);
+	D_ASSERT(!finalized);
+	finalized = true;
+	serializer.Write<uint32_t>(field_count);
+	serializer.Write<uint64_t>(buffer->blob.size);
+	serializer.WriteData(buffer->blob.data.get(), buffer->blob.size);
+
+	buffer.reset();
+}
+
+//===--------------------------------------------------------------------===//
+// Field Deserializer
+//===--------------------------------------------------------------------===//
+FieldDeserializer::FieldDeserializer(Deserializer &root) : root(root), remaining_data(idx_t(-1)) {
+}
+
+void FieldDeserializer::ReadData(data_ptr_t buffer, idx_t read_size) {
+	D_ASSERT(remaining_data != idx_t(-1));
+	D_ASSERT(read_size <= remaining_data);
+	root.ReadData(buffer, read_size);
+	remaining_data -= read_size;
+}
+
+idx_t FieldDeserializer::RemainingData() {
+	return remaining_data;
+}
+
+void FieldDeserializer::SetRemainingData(idx_t remaining_data) {
+	this->remaining_data = remaining_data;
+}
+
+//===--------------------------------------------------------------------===//
+// Field Reader
+//===--------------------------------------------------------------------===//
+FieldReader::FieldReader(Deserializer &source_p) : source(source_p), field_count(0), finalized(false) {
+	max_field_count = source_p.Read<uint32_t>();
+	total_size = source_p.Read<uint64_t>();
+	D_ASSERT(max_field_count > 0);
+	source.SetRemainingData(total_size);
+}
+
+FieldReader::~FieldReader() {
+	if (Exception::UncaughtException()) {
+		return;
+	}
+	D_ASSERT(finalized);
+}
+
+void FieldReader::Finalize() {
+	D_ASSERT(!finalized);
+	finalized = true;
+	if (field_count < max_field_count) {
+		// we can handle this case by calling source.ReadData(buffer, source.RemainingData())
+		throw SerializationException("Not all fields were read. This file might have been written with a newer version "
+		                             "of DuckDB and is incompatible with this version of DuckDB.");
+	}
+	D_ASSERT(source.RemainingData() == 0);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+FileBuffer::FileBuffer(Allocator &allocator, FileBufferType type, uint64_t bufsiz)
+    : allocator(allocator), type(type), malloced_buffer(nullptr) {
+	SetMallocedSize(bufsiz);
+	malloced_buffer = allocator.AllocateData(malloced_size);
+	Construct(bufsiz);
+}
+
+FileBuffer::FileBuffer(FileBuffer &source, FileBufferType type_p) : allocator(source.allocator), type(type_p) {
+	// take over the structures of the source buffer
+	buffer = source.buffer;
+	size = source.size;
+	internal_buffer = source.internal_buffer;
+	internal_size = source.internal_size;
+	malloced_buffer = source.malloced_buffer;
+	malloced_size = source.malloced_size;
+
+	source.buffer = nullptr;
+	source.size = 0;
+	source.internal_buffer = nullptr;
+	source.internal_size = 0;
+	source.malloced_buffer = nullptr;
+	source.malloced_size = 0;
+}
+
+FileBuffer::~FileBuffer() {
+	allocator.FreeData(malloced_buffer, malloced_size);
+}
+
+void FileBuffer::SetMallocedSize(uint64_t &bufsiz) {
+	// make room for the block header (if this is not the db file header)
+	if (type == FileBufferType::MANAGED_BUFFER && bufsiz != Storage::FILE_HEADER_SIZE) {
+		bufsiz += Storage::BLOCK_HEADER_SIZE;
+	}
+	if (type == FileBufferType::BLOCK) {
+		const int sector_size = Storage::SECTOR_SIZE;
+		// round up to the nearest sector_size
+		if (bufsiz % sector_size != 0) {
+			bufsiz += sector_size - (bufsiz % sector_size);
+		}
+		D_ASSERT(bufsiz % sector_size == 0);
+		D_ASSERT(bufsiz >= sector_size);
+		// we add (sector_size - 1) to ensure that we can align the buffer to sector_size
+		malloced_size = bufsiz + (sector_size - 1);
+	} else {
+		malloced_size = bufsiz;
+	}
+}
+
+void FileBuffer::Construct(uint64_t bufsiz) {
+	if (!malloced_buffer) {
+		throw std::bad_alloc();
+	}
+	if (type == FileBufferType::BLOCK) {
+		const int sector_size = Storage::SECTOR_SIZE;
+		// round to multiple of sector_size
+		uint64_t num = (uint64_t)malloced_buffer;
+		uint64_t remainder = num % sector_size;
+		if (remainder != 0) {
+			num = num + sector_size - remainder;
+		}
+		D_ASSERT(num % sector_size == 0);
+		D_ASSERT(num + bufsiz <= ((uint64_t)malloced_buffer + bufsiz + (sector_size - 1)));
+		D_ASSERT(num >= (uint64_t)malloced_buffer);
+		// construct the FileBuffer object
+		internal_buffer = (data_ptr_t)num;
+		internal_size = bufsiz;
+	} else {
+		internal_buffer = malloced_buffer;
+		internal_size = malloced_size;
+	}
+	buffer = internal_buffer + Storage::BLOCK_HEADER_SIZE;
+	size = internal_size - Storage::BLOCK_HEADER_SIZE;
+}
+
+void FileBuffer::Resize(uint64_t bufsiz) {
+	D_ASSERT(type == FileBufferType::MANAGED_BUFFER);
+	SetMallocedSize(bufsiz);
+	malloced_buffer = allocator.ReallocateData(malloced_buffer, malloced_size);
+	Construct(bufsiz);
+}
+
+void FileBuffer::Read(FileHandle &handle, uint64_t location) {
+	handle.Read(internal_buffer, internal_size, location);
+}
+
+void FileBuffer::ReadAndChecksum(FileHandle &handle, uint64_t location) {
+	// read the buffer from disk
+	Read(handle, location);
+	// compute the checksum
+	auto stored_checksum = Load<uint64_t>(internal_buffer);
+	uint64_t computed_checksum = Checksum(buffer, size);
+	// verify the checksum
+	if (stored_checksum != computed_checksum) {
+		throw IOException("Corrupt database file: computed checksum %llu does not match stored checksum %llu in block",
+		                  computed_checksum, stored_checksum);
+	}
+}
+
+void FileBuffer::Write(FileHandle &handle, uint64_t location) {
+	handle.Write(internal_buffer, internal_size, location);
+}
+
+void FileBuffer::ChecksumAndWrite(FileHandle &handle, uint64_t location) {
+	// compute the checksum and write it to the start of the buffer (if not temp buffer)
+	uint64_t checksum = Checksum(buffer, size);
+	Store<uint64_t>(checksum, internal_buffer);
+	// now write the buffer
+	Write(handle, location);
+}
+
+void FileBuffer::Clear() {
+	memset(internal_buffer, 0, internal_size);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cstdint>
+#include <cstdio>
+
+#ifndef _WIN32
+#include <dirent.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#else
+#include <string>
+#include <sysinfoapi.h>
+
+#ifdef __MINGW32__
+// need to manually define this for mingw
+extern "C" WINBASEAPI BOOL WINAPI GetPhysicallyInstalledSystemMemory(PULONGLONG);
+#endif
+
+#undef FILE_CREATE // woo mingw
+#endif
+
+namespace duckdb {
+
+FileSystem::~FileSystem() {
+}
+
+FileSystem &FileSystem::GetFileSystem(ClientContext &context) {
+	return *context.db->config.file_system;
+}
+
+FileOpener *FileSystem::GetFileOpener(ClientContext &context) {
+	return ClientData::Get(context).file_opener.get();
+}
+
+#ifndef _WIN32
+string FileSystem::PathSeparator() {
+	return "/";
+}
+
+void FileSystem::SetWorkingDirectory(const string &path) {
+	if (chdir(path.c_str()) != 0) {
+		throw IOException("Could not change working directory!");
+	}
+}
+
+idx_t FileSystem::GetAvailableMemory() {
+	errno = 0;
+	idx_t max_memory = MinValue<idx_t>((idx_t)sysconf(_SC_PHYS_PAGES) * (idx_t)sysconf(_SC_PAGESIZE), UINTPTR_MAX);
+	if (errno != 0) {
+		return DConstants::INVALID_INDEX;
+	}
+	return max_memory;
+}
+
+string FileSystem::GetWorkingDirectory() {
+	auto buffer = unique_ptr<char[]>(new char[PATH_MAX]);
+	char *ret = getcwd(buffer.get(), PATH_MAX);
+	if (!ret) {
+		throw IOException("Could not get working directory!");
+	}
+	return string(buffer.get());
+}
+#else
+
+string FileSystem::PathSeparator() {
+	return "\\";
+}
+
+void FileSystem::SetWorkingDirectory(const string &path) {
+	if (!SetCurrentDirectory(path.c_str())) {
+		throw IOException("Could not change working directory!");
+	}
+}
+
+idx_t FileSystem::GetAvailableMemory() {
+	ULONGLONG available_memory_kb;
+	if (GetPhysicallyInstalledSystemMemory(&available_memory_kb)) {
+		return MinValue<idx_t>(available_memory_kb * 1024, UINTPTR_MAX);
+	}
+	// fallback: try GlobalMemoryStatusEx
+	MEMORYSTATUSEX mem_state;
+	mem_state.dwLength = sizeof(MEMORYSTATUSEX);
+
+	if (GlobalMemoryStatusEx(&mem_state)) {
+		return MinValue<idx_t>(mem_state.ullTotalPhys, UINTPTR_MAX);
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+string FileSystem::GetWorkingDirectory() {
+	idx_t count = GetCurrentDirectory(0, nullptr);
+	if (count == 0) {
+		throw IOException("Could not get working directory!");
+	}
+	auto buffer = unique_ptr<char[]>(new char[count]);
+	idx_t ret = GetCurrentDirectory(count, buffer.get());
+	if (count != ret + 1) {
+		throw IOException("Could not get working directory!");
+	}
+	return string(buffer.get(), ret);
+}
+
+#endif
+
+string FileSystem::JoinPath(const string &a, const string &b) {
+	// FIXME: sanitize paths
+	return a + PathSeparator() + b;
+}
+
+string FileSystem::ConvertSeparators(const string &path) {
+	auto separator_str = PathSeparator();
+	char separator = separator_str[0];
+	if (separator == '/') {
+		// on unix-based systems we only accept / as a separator
+		return path;
+	}
+	// on windows-based systems we accept both
+	string result = path;
+	for (idx_t i = 0; i < result.size(); i++) {
+		if (result[i] == '/') {
+			result[i] = separator;
+		}
+	}
+	return result;
+}
+
+string FileSystem::ExtractBaseName(const string &path) {
+	auto normalized_path = ConvertSeparators(path);
+	auto sep = PathSeparator();
+	auto vec = StringUtil::Split(StringUtil::Split(normalized_path, sep).back(), ".");
+	return vec[0];
+}
+
+string FileSystem::GetHomeDirectory() {
+#ifdef DUCKDB_WINDOWS
+	const char *homedir = getenv("USERPROFILE");
+#else
+	const char *homedir = getenv("HOME");
+#endif
+	if (homedir) {
+		return homedir;
+	}
+	return string();
+}
+
+// LCOV_EXCL_START
+unique_ptr<FileHandle> FileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock,
+                                            FileCompressionType compression, FileOpener *opener) {
+	throw NotImplementedException("%s: OpenFile is not implemented!", GetName());
+}
+
+void FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	throw NotImplementedException("%s: Read (with location) is not implemented!", GetName());
+}
+
+void FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	throw NotImplementedException("%s: Write (with location) is not implemented!", GetName());
+}
+
+int64_t FileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	throw NotImplementedException("%s: Read is not implemented!", GetName());
+}
+
+int64_t FileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	throw NotImplementedException("%s: Write is not implemented!", GetName());
+}
+
+int64_t FileSystem::GetFileSize(FileHandle &handle) {
+	throw NotImplementedException("%s: GetFileSize is not implemented!", GetName());
+}
+
+time_t FileSystem::GetLastModifiedTime(FileHandle &handle) {
+	throw NotImplementedException("%s: GetLastModifiedTime is not implemented!", GetName());
+}
+
+FileType FileSystem::GetFileType(FileHandle &handle) {
+	return FileType::FILE_TYPE_INVALID;
+}
+
+void FileSystem::Truncate(FileHandle &handle, int64_t new_size) {
+	throw NotImplementedException("%s: Truncate is not implemented!", GetName());
+}
+
+bool FileSystem::DirectoryExists(const string &directory) {
+	throw NotImplementedException("%s: DirectoryExists is not implemented!", GetName());
+}
+
+void FileSystem::CreateDirectory(const string &directory) {
+	throw NotImplementedException("%s: CreateDirectory is not implemented!", GetName());
+}
+
+void FileSystem::RemoveDirectory(const string &directory) {
+	throw NotImplementedException("%s: RemoveDirectory is not implemented!", GetName());
+}
+
+bool FileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback) {
+	throw NotImplementedException("%s: ListFiles is not implemented!", GetName());
+}
+
+void FileSystem::MoveFile(const string &source, const string &target) {
+	throw NotImplementedException("%s: MoveFile is not implemented!", GetName());
+}
+
+bool FileSystem::FileExists(const string &filename) {
+	throw NotImplementedException("%s: FileExists is not implemented!", GetName());
+}
+
+bool FileSystem::IsPipe(const string &filename) {
+	throw NotImplementedException("%s: IsPipe is not implemented!", GetName());
+}
+
+void FileSystem::RemoveFile(const string &filename) {
+	throw NotImplementedException("%s: RemoveFile is not implemented!", GetName());
+}
+
+void FileSystem::FileSync(FileHandle &handle) {
+	throw NotImplementedException("%s: FileSync is not implemented!", GetName());
+}
+
+vector<string> FileSystem::Glob(const string &path, FileOpener *opener) {
+	throw NotImplementedException("%s: Glob is not implemented!", GetName());
+}
+
+vector<string> FileSystem::Glob(const string &path, ClientContext &context) {
+	return Glob(path, GetFileOpener(context));
+}
+
+void FileSystem::RegisterSubSystem(unique_ptr<FileSystem> sub_fs) {
+	throw NotImplementedException("%s: Can't register a sub system on a non-virtual file system", GetName());
+}
+
+void FileSystem::RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> sub_fs) {
+	throw NotImplementedException("%s: Can't register a sub system on a non-virtual file system", GetName());
+}
+
+bool FileSystem::CanHandleFile(const string &fpath) {
+	throw NotImplementedException("%s: CanHandleFile is not implemented!", GetName());
+}
+
+void FileSystem::Seek(FileHandle &handle, idx_t location) {
+	throw NotImplementedException("%s: Seek is not implemented!", GetName());
+}
+
+void FileSystem::Reset(FileHandle &handle) {
+	handle.Seek(0);
+}
+
+idx_t FileSystem::SeekPosition(FileHandle &handle) {
+	throw NotImplementedException("%s: SeekPosition is not implemented!", GetName());
+}
+
+bool FileSystem::CanSeek() {
+	throw NotImplementedException("%s: CanSeek is not implemented!", GetName());
+}
+
+unique_ptr<FileHandle> FileSystem::OpenCompressedFile(unique_ptr<FileHandle> handle, bool write) {
+	throw NotImplementedException("%s: OpenCompressedFile is not implemented!", GetName());
+}
+
+bool FileSystem::OnDiskFile(FileHandle &handle) {
+	throw NotImplementedException("%s: OnDiskFile is not implemented!", GetName());
+}
+// LCOV_EXCL_STOP
+
+FileHandle::FileHandle(FileSystem &file_system, string path_p) : file_system(file_system), path(move(path_p)) {
+}
+
+FileHandle::~FileHandle() {
+}
+
+int64_t FileHandle::Read(void *buffer, idx_t nr_bytes) {
+	return file_system.Read(*this, buffer, nr_bytes);
+}
+
+int64_t FileHandle::Write(void *buffer, idx_t nr_bytes) {
+	return file_system.Write(*this, buffer, nr_bytes);
+}
+
+void FileHandle::Read(void *buffer, idx_t nr_bytes, idx_t location) {
+	file_system.Read(*this, buffer, nr_bytes, location);
+}
+
+void FileHandle::Write(void *buffer, idx_t nr_bytes, idx_t location) {
+	file_system.Write(*this, buffer, nr_bytes, location);
+}
+
+void FileHandle::Seek(idx_t location) {
+	file_system.Seek(*this, location);
+}
+
+void FileHandle::Reset() {
+	file_system.Reset(*this);
+}
+
+idx_t FileHandle::SeekPosition() {
+	return file_system.SeekPosition(*this);
+}
+
+bool FileHandle::CanSeek() {
+	return file_system.CanSeek();
+}
+
+string FileHandle::ReadLine() {
+	string result;
+	char buffer[1];
+	while (true) {
+		idx_t tuples_read = Read(buffer, 1);
+		if (tuples_read == 0 || buffer[0] == '\n') {
+			return result;
+		}
+		if (buffer[0] != '\r') {
+			result += buffer[0];
+		}
+	}
+}
+
+bool FileHandle::OnDiskFile() {
+	return file_system.OnDiskFile(*this);
+}
+
+idx_t FileHandle::GetFileSize() {
+	return file_system.GetFileSize(*this);
+}
+
+void FileHandle::Sync() {
+	file_system.FileSync(*this);
+}
+
+void FileHandle::Truncate(int64_t new_size) {
+	file_system.Truncate(*this, new_size);
+}
+
+FileType FileHandle::GetType() {
+	return file_system.GetFileType(*this);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+/*
+
+  0      2 bytes  magic header  0x1f, 0x8b (\037 \213)
+  2      1 byte   compression method
+                     0: store (copied)
+                     1: compress
+                     2: pack
+                     3: lzh
+                     4..7: reserved
+                     8: deflate
+  3      1 byte   flags
+                     bit 0 set: file probably ascii text
+                     bit 1 set: continuation of multi-part gzip file, part number present
+                     bit 2 set: extra field present
+                     bit 3 set: original file name present
+                     bit 4 set: file comment present
+                     bit 5 set: file is encrypted, encryption header present
+                     bit 6,7:   reserved
+  4      4 bytes  file modification time in Unix format
+  8      1 byte   extra flags (depend on compression method)
+  9      1 byte   OS type
+[
+         2 bytes  optional part number (second part=1)
+]?
+[
+         2 bytes  optional extra field length (e)
+        (e)bytes  optional extra field
+]?
+[
+           bytes  optional original file name, zero terminated
+]?
+[
+           bytes  optional file comment, zero terminated
+]?
+[
+        12 bytes  optional encryption header
+]?
+           bytes  compressed data
+         4 bytes  crc32
+         4 bytes  uncompressed input size modulo 2^32
+
+ */
+
+static idx_t GZipConsumeString(FileHandle &input) {
+	idx_t size = 1; // terminator
+	char buffer[1];
+	while (input.Read(buffer, 1) == 1) {
+		if (buffer[0] == '\0') {
+			break;
+		}
+		size++;
+	}
+	return size;
+}
+
+struct MiniZStreamWrapper : public StreamWrapper {
+	~MiniZStreamWrapper() override;
+
+	CompressedFile *file = nullptr;
+	duckdb_miniz::mz_stream *mz_stream_ptr = nullptr;
+	bool writing = false;
+	duckdb_miniz::mz_ulong crc;
+	idx_t total_size;
+
+public:
+	void Initialize(CompressedFile &file, bool write) override;
+
+	bool Read(StreamData &stream_data) override;
+	void Write(CompressedFile &file, StreamData &stream_data, data_ptr_t buffer, int64_t nr_bytes) override;
+
+	void Close() override;
+
+	void FlushStream();
+};
+
+MiniZStreamWrapper::~MiniZStreamWrapper() {
+	// avoid closing if destroyed during stack unwinding
+	if (Exception::UncaughtException()) {
+		return;
+	}
+	try {
+		Close();
+	} catch (...) {
+	}
+}
+
+void MiniZStreamWrapper::Initialize(CompressedFile &file, bool write) {
+	Close();
+	this->file = &file;
+	mz_stream_ptr = new duckdb_miniz::mz_stream();
+	memset(mz_stream_ptr, 0, sizeof(duckdb_miniz::mz_stream));
+	this->writing = write;
+
+	// TODO use custom alloc/free methods in miniz to throw exceptions on OOM
+	uint8_t gzip_hdr[GZIP_HEADER_MINSIZE];
+	if (write) {
+		crc = MZ_CRC32_INIT;
+		total_size = 0;
+
+		MiniZStream::InitializeGZIPHeader(gzip_hdr);
+		file.child_handle->Write(gzip_hdr, GZIP_HEADER_MINSIZE);
+
+		auto ret = mz_deflateInit2((duckdb_miniz::mz_streamp)mz_stream_ptr, duckdb_miniz::MZ_DEFAULT_LEVEL, MZ_DEFLATED,
+		                           -MZ_DEFAULT_WINDOW_BITS, 1, 0);
+		if (ret != duckdb_miniz::MZ_OK) {
+			throw InternalException("Failed to initialize miniz");
+		}
+	} else {
+		idx_t data_start = GZIP_HEADER_MINSIZE;
+		auto read_count = file.child_handle->Read(gzip_hdr, GZIP_HEADER_MINSIZE);
+		GZipFileSystem::VerifyGZIPHeader(gzip_hdr, read_count);
+
+		if (gzip_hdr[3] & GZIP_FLAG_NAME) {
+			file.child_handle->Seek(data_start);
+			data_start += GZipConsumeString(*file.child_handle);
+		}
+		file.child_handle->Seek(data_start);
+		// stream is now set to beginning of payload data
+		auto ret = duckdb_miniz::mz_inflateInit2((duckdb_miniz::mz_streamp)mz_stream_ptr, -MZ_DEFAULT_WINDOW_BITS);
+		if (ret != duckdb_miniz::MZ_OK) {
+			throw InternalException("Failed to initialize miniz");
+		}
+	}
+}
+
+bool MiniZStreamWrapper::Read(StreamData &sd) {
+	// actually decompress
+	mz_stream_ptr->next_in = (data_ptr_t)sd.in_buff_start;
+	D_ASSERT(sd.in_buff_end - sd.in_buff_start < NumericLimits<int32_t>::Maximum());
+	mz_stream_ptr->avail_in = (uint32_t)(sd.in_buff_end - sd.in_buff_start);
+	mz_stream_ptr->next_out = (data_ptr_t)sd.out_buff_end;
+	mz_stream_ptr->avail_out = (uint32_t)((sd.out_buff.get() + sd.out_buf_size) - sd.out_buff_end);
+	auto ret = duckdb_miniz::mz_inflate(mz_stream_ptr, duckdb_miniz::MZ_NO_FLUSH);
+	if (ret != duckdb_miniz::MZ_OK && ret != duckdb_miniz::MZ_STREAM_END) {
+		throw IOException("Failed to decode gzip stream: %s", duckdb_miniz::mz_error(ret));
+	}
+	// update pointers following inflate()
+	sd.in_buff_start = (data_ptr_t)mz_stream_ptr->next_in;
+	sd.in_buff_end = sd.in_buff_start + mz_stream_ptr->avail_in;
+	sd.out_buff_end = (data_ptr_t)mz_stream_ptr->next_out;
+	D_ASSERT(sd.out_buff_end + mz_stream_ptr->avail_out == sd.out_buff.get() + sd.out_buf_size);
+	// if stream ended, deallocate inflator
+	if (ret == duckdb_miniz::MZ_STREAM_END) {
+		Close();
+		return true;
+	}
+	return false;
+}
+
+void MiniZStreamWrapper::Write(CompressedFile &file, StreamData &sd, data_ptr_t uncompressed_data,
+                               int64_t uncompressed_size) {
+	// update the src and the total size
+	crc = duckdb_miniz::mz_crc32(crc, (const unsigned char *)uncompressed_data, uncompressed_size);
+	total_size += uncompressed_size;
+
+	auto remaining = uncompressed_size;
+	while (remaining > 0) {
+		idx_t output_remaining = (sd.out_buff.get() + sd.out_buf_size) - sd.out_buff_start;
+
+		mz_stream_ptr->next_in = (const unsigned char *)uncompressed_data;
+		mz_stream_ptr->avail_in = remaining;
+		mz_stream_ptr->next_out = sd.out_buff_start;
+		mz_stream_ptr->avail_out = output_remaining;
+
+		auto res = mz_deflate(mz_stream_ptr, duckdb_miniz::MZ_NO_FLUSH);
+		if (res != duckdb_miniz::MZ_OK) {
+			D_ASSERT(res != duckdb_miniz::MZ_STREAM_END);
+			throw InternalException("Failed to compress GZIP block");
+		}
+		sd.out_buff_start += output_remaining - mz_stream_ptr->avail_out;
+		if (mz_stream_ptr->avail_out == 0) {
+			// no more output buffer available: flush
+			file.child_handle->Write(sd.out_buff.get(), sd.out_buff_start - sd.out_buff.get());
+			sd.out_buff_start = sd.out_buff.get();
+		}
+		idx_t written = remaining - mz_stream_ptr->avail_in;
+		uncompressed_data += written;
+		remaining = mz_stream_ptr->avail_in;
+	}
+}
+
+void MiniZStreamWrapper::FlushStream() {
+	auto &sd = file->stream_data;
+	mz_stream_ptr->next_in = nullptr;
+	mz_stream_ptr->avail_in = 0;
+	while (true) {
+		auto output_remaining = (sd.out_buff.get() + sd.out_buf_size) - sd.out_buff_start;
+		mz_stream_ptr->next_out = sd.out_buff_start;
+		mz_stream_ptr->avail_out = output_remaining;
+
+		auto res = mz_deflate(mz_stream_ptr, duckdb_miniz::MZ_FINISH);
+		sd.out_buff_start += (output_remaining - mz_stream_ptr->avail_out);
+		if (sd.out_buff_start > sd.out_buff.get()) {
+			file->child_handle->Write(sd.out_buff.get(), sd.out_buff_start - sd.out_buff.get());
+			sd.out_buff_start = sd.out_buff.get();
+		}
+		if (res == duckdb_miniz::MZ_STREAM_END) {
+			break;
+		}
+		if (res != duckdb_miniz::MZ_OK) {
+			throw InternalException("Failed to compress GZIP block");
+		}
+	}
+}
+
+void MiniZStreamWrapper::Close() {
+	if (!mz_stream_ptr) {
+		return;
+	}
+	if (writing) {
+		// flush anything remaining in the stream
+		FlushStream();
+
+		// write the footer
+		unsigned char gzip_footer[MiniZStream::GZIP_FOOTER_SIZE];
+		MiniZStream::InitializeGZIPFooter(gzip_footer, crc, total_size);
+		file->child_handle->Write(gzip_footer, MiniZStream::GZIP_FOOTER_SIZE);
+
+		duckdb_miniz::mz_deflateEnd(mz_stream_ptr);
+	} else {
+		duckdb_miniz::mz_inflateEnd(mz_stream_ptr);
+	}
+	delete mz_stream_ptr;
+	mz_stream_ptr = nullptr;
+	file = nullptr;
+}
+
+class GZipFile : public CompressedFile {
+public:
+	GZipFile(unique_ptr<FileHandle> child_handle_p, const string &path, bool write)
+	    : CompressedFile(gzip_fs, move(child_handle_p), path) {
+		Initialize(write);
+	}
+
+	GZipFileSystem gzip_fs;
+};
+
+void GZipFileSystem::VerifyGZIPHeader(uint8_t gzip_hdr[], idx_t read_count) {
+	// check for incorrectly formatted files
+	if (read_count != GZIP_HEADER_MINSIZE) {
+		throw IOException("Input is not a GZIP stream");
+	}
+	if (gzip_hdr[0] != 0x1F || gzip_hdr[1] != 0x8B) { // magic header
+		throw IOException("Input is not a GZIP stream");
+	}
+	if (gzip_hdr[2] != GZIP_COMPRESSION_DEFLATE) { // compression method
+		throw IOException("Unsupported GZIP compression method");
+	}
+	if (gzip_hdr[3] & GZIP_FLAG_UNSUPPORTED) {
+		throw IOException("Unsupported GZIP archive");
+	}
+}
+
+string GZipFileSystem::UncompressGZIPString(const string &in) {
+	// decompress file
+	auto body_ptr = in.data();
+
+	auto mz_stream_ptr = new duckdb_miniz::mz_stream();
+	memset(mz_stream_ptr, 0, sizeof(duckdb_miniz::mz_stream));
+
+	uint8_t gzip_hdr[GZIP_HEADER_MINSIZE];
+
+	// check for incorrectly formatted files
+
+	// TODO this is mostly the same as gzip_file_system.cpp
+	if (in.size() < GZIP_HEADER_MINSIZE) {
+		throw IOException("Input is not a GZIP stream");
+	}
+	memcpy(gzip_hdr, body_ptr, GZIP_HEADER_MINSIZE);
+	body_ptr += GZIP_HEADER_MINSIZE;
+	GZipFileSystem::VerifyGZIPHeader(gzip_hdr, GZIP_HEADER_MINSIZE);
+
+	if (gzip_hdr[3] & GZIP_FLAG_NAME) {
+		char c;
+		do {
+			c = *body_ptr;
+			body_ptr++;
+		} while (c != '\0' && (idx_t)(body_ptr - in.data()) < in.size());
+	}
+
+	// stream is now set to beginning of payload data
+	auto status = duckdb_miniz::mz_inflateInit2(mz_stream_ptr, -MZ_DEFAULT_WINDOW_BITS);
+	if (status != duckdb_miniz::MZ_OK) {
+		throw InternalException("Failed to initialize miniz");
+	}
+
+	auto bytes_remaining = in.size() - (body_ptr - in.data());
+	mz_stream_ptr->next_in = (unsigned char *)body_ptr;
+	mz_stream_ptr->avail_in = bytes_remaining;
+
+	unsigned char decompress_buffer[BUFSIZ];
+	string decompressed;
+
+	while (status == duckdb_miniz::MZ_OK) {
+		mz_stream_ptr->next_out = decompress_buffer;
+		mz_stream_ptr->avail_out = sizeof(decompress_buffer);
+		status = mz_inflate(mz_stream_ptr, duckdb_miniz::MZ_NO_FLUSH);
+		if (status != duckdb_miniz::MZ_STREAM_END && status != duckdb_miniz::MZ_OK) {
+			throw IOException("Failed to uncompress");
+		}
+		decompressed.append((char *)decompress_buffer, mz_stream_ptr->total_out - decompressed.size());
+	}
+	duckdb_miniz::mz_inflateEnd(mz_stream_ptr);
+	if (decompressed.empty()) {
+		throw IOException("Failed to uncompress");
+	}
+	return decompressed;
+}
+
+unique_ptr<FileHandle> GZipFileSystem::OpenCompressedFile(unique_ptr<FileHandle> handle, bool write) {
+	auto path = handle->path;
+	return make_unique<GZipFile>(move(handle), path, write);
+}
+
+unique_ptr<StreamWrapper> GZipFileSystem::CreateStream() {
+	return make_unique<MiniZStreamWrapper>();
+}
+
+idx_t GZipFileSystem::InBufferSize() {
+	return BUFFER_SIZE;
+}
+
+idx_t GZipFileSystem::OutBufferSize() {
+	return BUFFER_SIZE;
+}
+
+} // namespace duckdb
+
+
+
+
+#include <limits>
+
+namespace duckdb {
+
+using std::numeric_limits;
+
+int8_t NumericLimits<int8_t>::Minimum() {
+	return numeric_limits<int8_t>::lowest();
+}
+
+int8_t NumericLimits<int8_t>::Maximum() {
+	return numeric_limits<int8_t>::max();
+}
+
+int16_t NumericLimits<int16_t>::Minimum() {
+	return numeric_limits<int16_t>::lowest();
+}
+
+int16_t NumericLimits<int16_t>::Maximum() {
+	return numeric_limits<int16_t>::max();
+}
+
+int32_t NumericLimits<int32_t>::Minimum() {
+	return numeric_limits<int32_t>::lowest();
+}
+
+int32_t NumericLimits<int32_t>::Maximum() {
+	return numeric_limits<int32_t>::max();
+}
+
+int64_t NumericLimits<int64_t>::Minimum() {
+	return numeric_limits<int64_t>::lowest();
+}
+
+int64_t NumericLimits<int64_t>::Maximum() {
+	return numeric_limits<int64_t>::max();
+}
+
+float NumericLimits<float>::Minimum() {
+	return numeric_limits<float>::lowest();
+}
+
+float NumericLimits<float>::Maximum() {
+	return numeric_limits<float>::max();
+}
+
+double NumericLimits<double>::Minimum() {
+	return numeric_limits<double>::lowest();
+}
+
+double NumericLimits<double>::Maximum() {
+	return numeric_limits<double>::max();
+}
+
+uint8_t NumericLimits<uint8_t>::Minimum() {
+	return numeric_limits<uint8_t>::lowest();
+}
+
+uint8_t NumericLimits<uint8_t>::Maximum() {
+	return numeric_limits<uint8_t>::max();
+}
+
+uint16_t NumericLimits<uint16_t>::Minimum() {
+	return numeric_limits<uint16_t>::lowest();
+}
+
+uint16_t NumericLimits<uint16_t>::Maximum() {
+	return numeric_limits<uint16_t>::max();
+}
+
+uint32_t NumericLimits<uint32_t>::Minimum() {
+	return numeric_limits<uint32_t>::lowest();
+}
+
+uint32_t NumericLimits<uint32_t>::Maximum() {
+	return numeric_limits<uint32_t>::max();
+}
+
+uint64_t NumericLimits<uint64_t>::Minimum() {
+	return numeric_limits<uint64_t>::lowest();
+}
+
+uint64_t NumericLimits<uint64_t>::Maximum() {
+	return numeric_limits<uint64_t>::max();
+}
+
+hugeint_t NumericLimits<hugeint_t>::Minimum() {
+	hugeint_t result;
+	result.lower = 1;
+	result.upper = numeric_limits<int64_t>::lowest();
+	return result;
+}
+
+hugeint_t NumericLimits<hugeint_t>::Maximum() {
+	hugeint_t result;
+	result.lower = numeric_limits<uint64_t>::max();
+	result.upper = numeric_limits<int64_t>::max();
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cstdint>
+#include <cstdio>
+#include <sys/stat.h>
+
+#ifndef _WIN32
+#include <dirent.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+#else
+
+
+#include <io.h>
+#include <string>
+
+#ifdef __MINGW32__
+// need to manually define this for mingw
+extern "C" WINBASEAPI BOOL WINAPI GetPhysicallyInstalledSystemMemory(PULONGLONG);
+#endif
+
+#undef FILE_CREATE // woo mingw
+#endif
+
+namespace duckdb {
+
+static void AssertValidFileFlags(uint8_t flags) {
+#ifdef DEBUG
+	bool is_read = flags & FileFlags::FILE_FLAGS_READ;
+	bool is_write = flags & FileFlags::FILE_FLAGS_WRITE;
+	// require either READ or WRITE (or both)
+	D_ASSERT(is_read || is_write);
+	// CREATE/Append flags require writing
+	D_ASSERT(is_write || !(flags & FileFlags::FILE_FLAGS_APPEND));
+	D_ASSERT(is_write || !(flags & FileFlags::FILE_FLAGS_FILE_CREATE));
+	D_ASSERT(is_write || !(flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW));
+	// cannot combine CREATE and CREATE_NEW flags
+	D_ASSERT(!(flags & FileFlags::FILE_FLAGS_FILE_CREATE && flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW));
+#endif
+}
+
+#ifndef _WIN32
+bool LocalFileSystem::FileExists(const string &filename) {
+	if (!filename.empty()) {
+		if (access(filename.c_str(), 0) == 0) {
+			struct stat status;
+			stat(filename.c_str(), &status);
+			if (S_ISREG(status.st_mode)) {
+				return true;
+			}
+		}
+	}
+	// if any condition fails
+	return false;
+}
+
+bool LocalFileSystem::IsPipe(const string &filename) {
+	if (!filename.empty()) {
+		if (access(filename.c_str(), 0) == 0) {
+			struct stat status;
+			stat(filename.c_str(), &status);
+			if (S_ISFIFO(status.st_mode)) {
+				return true;
+			}
+		}
+	}
+	// if any condition fails
+	return false;
+}
+
+#else
+bool LocalFileSystem::FileExists(const string &filename) {
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(filename.c_str());
+	const wchar_t *wpath = unicode_path.c_str();
+	if (_waccess(wpath, 0) == 0) {
+		struct _stati64 status;
+		_wstati64(wpath, &status);
+		if (status.st_mode & S_IFREG) {
+			return true;
+		}
+	}
+	return false;
+}
+bool LocalFileSystem::IsPipe(const string &filename) {
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(filename.c_str());
+	const wchar_t *wpath = unicode_path.c_str();
+	if (_waccess(wpath, 0) == 0) {
+		struct _stati64 status;
+		_wstati64(wpath, &status);
+		if (status.st_mode & _S_IFCHR) {
+			return true;
+		}
+	}
+	return false;
+}
+#endif
+
+#ifndef _WIN32
+// somehow sometimes this is missing
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+
+// Solaris
+#ifndef O_DIRECT
+#define O_DIRECT 0
+#endif
+
+struct UnixFileHandle : public FileHandle {
+public:
+	UnixFileHandle(FileSystem &file_system, string path, int fd) : FileHandle(file_system, move(path)), fd(fd) {
+	}
+	~UnixFileHandle() override {
+		Close();
+	}
+
+	int fd;
+
+public:
+	void Close() override {
+		if (fd != -1) {
+			close(fd);
+		}
+	};
+};
+
+static FileType GetFileTypeInternal(int fd) { // LCOV_EXCL_START
+	struct stat s;
+	if (fstat(fd, &s) == -1) {
+		return FileType::FILE_TYPE_INVALID;
+	}
+	switch (s.st_mode & S_IFMT) {
+	case S_IFBLK:
+		return FileType::FILE_TYPE_BLOCKDEV;
+	case S_IFCHR:
+		return FileType::FILE_TYPE_CHARDEV;
+	case S_IFIFO:
+		return FileType::FILE_TYPE_FIFO;
+	case S_IFDIR:
+		return FileType::FILE_TYPE_DIR;
+	case S_IFLNK:
+		return FileType::FILE_TYPE_LINK;
+	case S_IFREG:
+		return FileType::FILE_TYPE_REGULAR;
+	case S_IFSOCK:
+		return FileType::FILE_TYPE_SOCKET;
+	default:
+		return FileType::FILE_TYPE_INVALID;
+	}
+} // LCOV_EXCL_STOP
+
+unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock_type,
+                                                 FileCompressionType compression, FileOpener *opener) {
+	if (compression != FileCompressionType::UNCOMPRESSED) {
+		throw NotImplementedException("Unsupported compression type for default file system");
+	}
+
+	AssertValidFileFlags(flags);
+
+	int open_flags = 0;
+	int rc;
+	bool open_read = flags & FileFlags::FILE_FLAGS_READ;
+	bool open_write = flags & FileFlags::FILE_FLAGS_WRITE;
+	if (open_read && open_write) {
+		open_flags = O_RDWR;
+	} else if (open_read) {
+		open_flags = O_RDONLY;
+	} else if (open_write) {
+		open_flags = O_WRONLY;
+	} else {
+		throw InternalException("READ, WRITE or both should be specified when opening a file");
+	}
+	if (open_write) {
+		// need Read or Write
+		D_ASSERT(flags & FileFlags::FILE_FLAGS_WRITE);
+		open_flags |= O_CLOEXEC;
+		if (flags & FileFlags::FILE_FLAGS_FILE_CREATE) {
+			open_flags |= O_CREAT;
+		} else if (flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW) {
+			open_flags |= O_CREAT | O_TRUNC;
+		}
+		if (flags & FileFlags::FILE_FLAGS_APPEND) {
+			open_flags |= O_APPEND;
+		}
+	}
+	if (flags & FileFlags::FILE_FLAGS_DIRECT_IO) {
+#if defined(__sun) && defined(__SVR4)
+		throw Exception("DIRECT_IO not supported on Solaris");
+#endif
+#if defined(__DARWIN__) || defined(__APPLE__) || defined(__OpenBSD__)
+		// OSX does not have O_DIRECT, instead we need to use fcntl afterwards to support direct IO
+		open_flags |= O_SYNC;
+#else
+		open_flags |= O_DIRECT | O_SYNC;
+#endif
+	}
+	int fd = open(path.c_str(), open_flags, 0666);
+	if (fd == -1) {
+		throw IOException("Cannot open file \"%s\": %s", path, strerror(errno));
+	}
+	// #if defined(__DARWIN__) || defined(__APPLE__)
+	// 	if (flags & FileFlags::FILE_FLAGS_DIRECT_IO) {
+	// 		// OSX requires fcntl for Direct IO
+	// 		rc = fcntl(fd, F_NOCACHE, 1);
+	// 		if (fd == -1) {
+	// 			throw IOException("Could not enable direct IO for file \"%s\": %s", path, strerror(errno));
+	// 		}
+	// 	}
+	// #endif
+	if (lock_type != FileLockType::NO_LOCK) {
+		// set lock on file
+		// but only if it is not an input/output stream
+		auto file_type = GetFileTypeInternal(fd);
+		if (file_type != FileType::FILE_TYPE_FIFO && file_type != FileType::FILE_TYPE_SOCKET) {
+			struct flock fl;
+			memset(&fl, 0, sizeof fl);
+			fl.l_type = lock_type == FileLockType::READ_LOCK ? F_RDLCK : F_WRLCK;
+			fl.l_whence = SEEK_SET;
+			fl.l_start = 0;
+			fl.l_len = 0;
+			rc = fcntl(fd, F_SETLK, &fl);
+			if (rc == -1) {
+				throw IOException("Could not set lock on file \"%s\": %s", path, strerror(errno));
+			}
+		}
+	}
+	return make_unique<UnixFileHandle>(*this, path, fd);
+}
+
+void LocalFileSystem::SetFilePointer(FileHandle &handle, idx_t location) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	off_t offset = lseek(fd, location, SEEK_SET);
+	if (offset == (off_t)-1) {
+		throw IOException("Could not seek to location %lld for file \"%s\": %s", location, handle.path,
+		                  strerror(errno));
+	}
+}
+
+idx_t LocalFileSystem::GetFilePointer(FileHandle &handle) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	off_t position = lseek(fd, 0, SEEK_CUR);
+	if (position == (off_t)-1) {
+		throw IOException("Could not get file position file \"%s\": %s", handle.path, strerror(errno));
+	}
+	return position;
+}
+
+void LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	int64_t bytes_read = pread(fd, buffer, nr_bytes, location);
+	if (bytes_read == -1) {
+		throw IOException("Could not read from file \"%s\": %s", handle.path, strerror(errno));
+	}
+	if (bytes_read != nr_bytes) {
+		throw IOException("Could not read all bytes from file \"%s\": wanted=%lld read=%lld", handle.path, nr_bytes,
+		                  bytes_read);
+	}
+}
+
+int64_t LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	int64_t bytes_read = read(fd, buffer, nr_bytes);
+	if (bytes_read == -1) {
+		throw IOException("Could not read from file \"%s\": %s", handle.path, strerror(errno));
+	}
+	return bytes_read;
+}
+
+void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	int64_t bytes_written = pwrite(fd, buffer, nr_bytes, location);
+	if (bytes_written == -1) {
+		throw IOException("Could not write file \"%s\": %s", handle.path, strerror(errno));
+	}
+	if (bytes_written != nr_bytes) {
+		throw IOException("Could not write all bytes to file \"%s\": wanted=%lld wrote=%lld", handle.path, nr_bytes,
+		                  bytes_written);
+	}
+}
+
+int64_t LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	int64_t bytes_written = write(fd, buffer, nr_bytes);
+	if (bytes_written == -1) {
+		throw IOException("Could not write file \"%s\": %s", handle.path, strerror(errno));
+	}
+	return bytes_written;
+}
+
+int64_t LocalFileSystem::GetFileSize(FileHandle &handle) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	struct stat s;
+	if (fstat(fd, &s) == -1) {
+		return -1;
+	}
+	return s.st_size;
+}
+
+time_t LocalFileSystem::GetLastModifiedTime(FileHandle &handle) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	struct stat s;
+	if (fstat(fd, &s) == -1) {
+		return -1;
+	}
+	return s.st_mtime;
+}
+
+FileType LocalFileSystem::GetFileType(FileHandle &handle) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	return GetFileTypeInternal(fd);
+}
+
+void LocalFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	if (ftruncate(fd, new_size) != 0) {
+		throw IOException("Could not truncate file \"%s\": %s", handle.path, strerror(errno));
+	}
+}
+
+bool LocalFileSystem::DirectoryExists(const string &directory) {
+	if (!directory.empty()) {
+		if (access(directory.c_str(), 0) == 0) {
+			struct stat status;
+			stat(directory.c_str(), &status);
+			if (status.st_mode & S_IFDIR) {
+				return true;
+			}
+		}
+	}
+	// if any condition fails
+	return false;
+}
+
+void LocalFileSystem::CreateDirectory(const string &directory) {
+	struct stat st;
+
+	if (stat(directory.c_str(), &st) != 0) {
+		/* Directory does not exist. EEXIST for race condition */
+		if (mkdir(directory.c_str(), 0755) != 0 && errno != EEXIST) {
+			throw IOException("Failed to create directory \"%s\"!", directory);
+		}
+	} else if (!S_ISDIR(st.st_mode)) {
+		throw IOException("Failed to create directory \"%s\": path exists but is not a directory!", directory);
+	}
+}
+
+int RemoveDirectoryRecursive(const char *path) {
+	DIR *d = opendir(path);
+	idx_t path_len = (idx_t)strlen(path);
+	int r = -1;
+
+	if (d) {
+		struct dirent *p;
+		r = 0;
+		while (!r && (p = readdir(d))) {
+			int r2 = -1;
+			char *buf;
+			idx_t len;
+			/* Skip the names "." and ".." as we don't want to recurse on them. */
+			if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, "..")) {
+				continue;
+			}
+			len = path_len + (idx_t)strlen(p->d_name) + 2;
+			buf = new char[len];
+			if (buf) {
+				struct stat statbuf;
+				snprintf(buf, len, "%s/%s", path, p->d_name);
+				if (!stat(buf, &statbuf)) {
+					if (S_ISDIR(statbuf.st_mode)) {
+						r2 = RemoveDirectoryRecursive(buf);
+					} else {
+						r2 = unlink(buf);
+					}
+				}
+				delete[] buf;
+			}
+			r = r2;
+		}
+		closedir(d);
+	}
+	if (!r) {
+		r = rmdir(path);
+	}
+	return r;
+}
+
+void LocalFileSystem::RemoveDirectory(const string &directory) {
+	RemoveDirectoryRecursive(directory.c_str());
+}
+
+void LocalFileSystem::RemoveFile(const string &filename) {
+	if (std::remove(filename.c_str()) != 0) {
+		throw IOException("Could not remove file \"%s\": %s", filename, strerror(errno));
+	}
+}
+
+bool LocalFileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback) {
+	if (!DirectoryExists(directory)) {
+		return false;
+	}
+	DIR *dir = opendir(directory.c_str());
+	if (!dir) {
+		return false;
+	}
+	struct dirent *ent;
+	// loop over all files in the directory
+	while ((ent = readdir(dir)) != nullptr) {
+		string name = string(ent->d_name);
+		// skip . .. and empty files
+		if (name.empty() || name == "." || name == "..") {
+			continue;
+		}
+		// now stat the file to figure out if it is a regular file or directory
+		string full_path = JoinPath(directory, name);
+		if (access(full_path.c_str(), 0) != 0) {
+			continue;
+		}
+		struct stat status;
+		stat(full_path.c_str(), &status);
+		if (!(status.st_mode & S_IFREG) && !(status.st_mode & S_IFDIR)) {
+			// not a file or directory: skip
+			continue;
+		}
+		// invoke callback
+		callback(name, status.st_mode & S_IFDIR);
+	}
+	closedir(dir);
+	return true;
+}
+
+void LocalFileSystem::FileSync(FileHandle &handle) {
+	int fd = ((UnixFileHandle &)handle).fd;
+	if (fsync(fd) != 0) {
+		throw FatalException("fsync failed!");
+	}
+}
+
+void LocalFileSystem::MoveFile(const string &source, const string &target) {
+	//! FIXME: rename does not guarantee atomicity or overwriting target file if it exists
+	if (rename(source.c_str(), target.c_str()) != 0) {
+		throw IOException("Could not rename file!");
+	}
+}
+
+std::string LocalFileSystem::GetLastErrorAsString() {
+	return string();
+}
+
+#else
+
+constexpr char PIPE_PREFIX[] = "\\\\.\\pipe\\";
+
+// Returns the last Win32 error, in string format. Returns an empty string if there is no error.
+std::string LocalFileSystem::GetLastErrorAsString() {
+	// Get the error message, if any.
+	DWORD errorMessageID = GetLastError();
+	if (errorMessageID == 0)
+		return std::string(); // No error message has been recorded
+
+	LPSTR messageBuffer = nullptr;
+	idx_t size =
+	    FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+	                   NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+	std::string message(messageBuffer, size);
+
+	// Free the buffer.
+	LocalFree(messageBuffer);
+
+	return message;
+}
+
+struct WindowsFileHandle : public FileHandle {
+public:
+	WindowsFileHandle(FileSystem &file_system, string path, HANDLE fd)
+	    : FileHandle(file_system, path), position(0), fd(fd) {
+	}
+	virtual ~WindowsFileHandle() {
+		Close();
+	}
+
+	idx_t position;
+	HANDLE fd;
+
+public:
+	void Close() override {
+		CloseHandle(fd);
+	};
+};
+
+unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock_type,
+                                                 FileCompressionType compression, FileOpener *opener) {
+	if (compression != FileCompressionType::UNCOMPRESSED) {
+		throw NotImplementedException("Unsupported compression type for default file system");
+	}
+	AssertValidFileFlags(flags);
+
+	DWORD desired_access;
+	DWORD share_mode;
+	DWORD creation_disposition = OPEN_EXISTING;
+	DWORD flags_and_attributes = FILE_ATTRIBUTE_NORMAL;
+	bool open_read = flags & FileFlags::FILE_FLAGS_READ;
+	bool open_write = flags & FileFlags::FILE_FLAGS_WRITE;
+	if (open_read && open_write) {
+		desired_access = GENERIC_READ | GENERIC_WRITE;
+		share_mode = 0;
+	} else if (open_read) {
+		desired_access = GENERIC_READ;
+		share_mode = FILE_SHARE_READ;
+	} else if (open_write) {
+		desired_access = GENERIC_WRITE;
+		share_mode = 0;
+	} else {
+		throw InternalException("READ, WRITE or both should be specified when opening a file");
+	}
+	if (open_write) {
+		if (flags & FileFlags::FILE_FLAGS_FILE_CREATE) {
+			creation_disposition = OPEN_ALWAYS;
+		} else if (flags & FileFlags::FILE_FLAGS_FILE_CREATE_NEW) {
+			creation_disposition = CREATE_ALWAYS;
+		}
+	}
+	if (flags & FileFlags::FILE_FLAGS_DIRECT_IO) {
+		flags_and_attributes |= FILE_FLAG_NO_BUFFERING;
+	}
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(path.c_str());
+	HANDLE hFile = CreateFileW(unicode_path.c_str(), desired_access, share_mode, NULL, creation_disposition,
+	                           flags_and_attributes, NULL);
+	if (hFile == INVALID_HANDLE_VALUE) {
+		auto error = LocalFileSystem::GetLastErrorAsString();
+		throw IOException("Cannot open file \"%s\": %s", path.c_str(), error);
+	}
+	auto handle = make_unique<WindowsFileHandle>(*this, path.c_str(), hFile);
+	if (flags & FileFlags::FILE_FLAGS_APPEND) {
+		auto file_size = GetFileSize(*handle);
+		SetFilePointer(*handle, file_size);
+	}
+	return move(handle);
+}
+
+void LocalFileSystem::SetFilePointer(FileHandle &handle, idx_t location) {
+	((WindowsFileHandle &)handle).position = location;
+}
+
+idx_t LocalFileSystem::GetFilePointer(FileHandle &handle) {
+	return ((WindowsFileHandle &)handle).position;
+}
+
+static DWORD FSInternalRead(FileHandle &handle, HANDLE hFile, void *buffer, int64_t nr_bytes, idx_t location) {
+	DWORD bytes_read = 0;
+	OVERLAPPED ov = {};
+	ov.Internal = 0;
+	ov.InternalHigh = 0;
+	ov.Offset = location & 0xFFFFFFFF;
+	ov.OffsetHigh = location >> 32;
+	ov.hEvent = 0;
+	auto rc = ReadFile(hFile, buffer, (DWORD)nr_bytes, &bytes_read, &ov);
+	if (!rc) {
+		auto error = LocalFileSystem::GetLastErrorAsString();
+		throw IOException("Could not read file \"%s\" (error in ReadFile): %s", handle.path, error);
+	}
+	return bytes_read;
+}
+
+void LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	auto bytes_read = FSInternalRead(handle, hFile, buffer, nr_bytes, location);
+	if (bytes_read != nr_bytes) {
+		throw IOException("Could not read all bytes from file \"%s\": wanted=%lld read=%lld", handle.path, nr_bytes,
+		                  bytes_read);
+	}
+}
+
+int64_t LocalFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	auto &pos = ((WindowsFileHandle &)handle).position;
+	auto n = std::min<idx_t>(std::max<idx_t>(GetFileSize(handle), pos) - pos, nr_bytes);
+	auto bytes_read = FSInternalRead(handle, hFile, buffer, n, pos);
+	pos += bytes_read;
+	return bytes_read;
+}
+
+static DWORD FSInternalWrite(FileHandle &handle, HANDLE hFile, void *buffer, int64_t nr_bytes, idx_t location) {
+	DWORD bytes_written = 0;
+	OVERLAPPED ov = {};
+	ov.Internal = 0;
+	ov.InternalHigh = 0;
+	ov.Offset = location & 0xFFFFFFFF;
+	ov.OffsetHigh = location >> 32;
+	ov.hEvent = 0;
+	auto rc = WriteFile(hFile, buffer, (DWORD)nr_bytes, &bytes_written, &ov);
+	if (!rc) {
+		auto error = LocalFileSystem::GetLastErrorAsString();
+		throw IOException("Could not write file \"%s\" (error in WriteFile): %s", handle.path, error);
+	}
+	return bytes_written;
+}
+
+void LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	auto bytes_written = FSInternalWrite(handle, hFile, buffer, nr_bytes, location);
+	if (bytes_written != nr_bytes) {
+		throw IOException("Could not write all bytes from file \"%s\": wanted=%lld wrote=%lld", handle.path, nr_bytes,
+		                  bytes_written);
+	}
+}
+
+int64_t LocalFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	auto &pos = ((WindowsFileHandle &)handle).position;
+	auto bytes_written = FSInternalWrite(handle, hFile, buffer, nr_bytes, pos);
+	pos += bytes_written;
+	return bytes_written;
+}
+
+int64_t LocalFileSystem::GetFileSize(FileHandle &handle) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	LARGE_INTEGER result;
+	if (!GetFileSizeEx(hFile, &result)) {
+		return -1;
+	}
+	return result.QuadPart;
+}
+
+time_t LocalFileSystem::GetLastModifiedTime(FileHandle &handle) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+
+	// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfiletime
+	FILETIME last_write;
+	if (GetFileTime(hFile, nullptr, nullptr, &last_write) == 0) {
+		return -1;
+	}
+
+	// https://stackoverflow.com/questions/29266743/what-is-dwlowdatetime-and-dwhighdatetime
+	ULARGE_INTEGER ul;
+	ul.LowPart = last_write.dwLowDateTime;
+	ul.HighPart = last_write.dwHighDateTime;
+	int64_t fileTime64 = ul.QuadPart;
+
+	// fileTime64 contains a 64-bit value representing the number of
+	// 100-nanosecond intervals since January 1, 1601 (UTC).
+	// https://docs.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
+
+	// Adapted from: https://stackoverflow.com/questions/6161776/convert-windows-filetime-to-second-in-unix-linux
+	const auto WINDOWS_TICK = 10000000;
+	const auto SEC_TO_UNIX_EPOCH = 11644473600LL;
+	time_t result = (fileTime64 / WINDOWS_TICK - SEC_TO_UNIX_EPOCH);
+	return result;
+}
+
+void LocalFileSystem::Truncate(FileHandle &handle, int64_t new_size) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	// seek to the location
+	SetFilePointer(handle, new_size);
+	// now set the end of file position
+	if (!SetEndOfFile(hFile)) {
+		auto error = LocalFileSystem::GetLastErrorAsString();
+		throw IOException("Failure in SetEndOfFile call on file \"%s\": %s", handle.path, error);
+	}
+}
+
+static DWORD WindowsGetFileAttributes(const string &filename) {
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(filename.c_str());
+	return GetFileAttributesW(unicode_path.c_str());
+}
+
+bool LocalFileSystem::DirectoryExists(const string &directory) {
+	DWORD attrs = WindowsGetFileAttributes(directory);
+	return (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY));
+}
+
+void LocalFileSystem::CreateDirectory(const string &directory) {
+	if (DirectoryExists(directory)) {
+		return;
+	}
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(directory.c_str());
+	if (directory.empty() || !CreateDirectoryW(unicode_path.c_str(), NULL) || !DirectoryExists(directory)) {
+		throw IOException("Could not create directory!");
+	}
+}
+
+static void DeleteDirectoryRecursive(FileSystem &fs, string directory) {
+	fs.ListFiles(directory, [&](const string &fname, bool is_directory) {
+		if (is_directory) {
+			DeleteDirectoryRecursive(fs, fs.JoinPath(directory, fname));
+		} else {
+			fs.RemoveFile(fs.JoinPath(directory, fname));
+		}
+	});
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(directory.c_str());
+	if (!RemoveDirectoryW(unicode_path.c_str())) {
+		throw IOException("Failed to delete directory");
+	}
+}
+
+void LocalFileSystem::RemoveDirectory(const string &directory) {
+	if (FileExists(directory)) {
+		throw IOException("Attempting to delete directory \"%s\", but it is a file and not a directory!", directory);
+	}
+	if (!DirectoryExists(directory)) {
+		return;
+	}
+	DeleteDirectoryRecursive(*this, directory.c_str());
+}
+
+void LocalFileSystem::RemoveFile(const string &filename) {
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(filename.c_str());
+	DeleteFileW(unicode_path.c_str());
+}
+
+bool LocalFileSystem::ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback) {
+	string search_dir = JoinPath(directory, "*");
+
+	auto unicode_path = WindowsUtil::UTF8ToUnicode(search_dir.c_str());
+
+	WIN32_FIND_DATAW ffd;
+	HANDLE hFind = FindFirstFileW(unicode_path.c_str(), &ffd);
+	if (hFind == INVALID_HANDLE_VALUE) {
+		return false;
+	}
+	do {
+		string cFileName = WindowsUtil::UnicodeToUTF8(ffd.cFileName);
+		if (cFileName == "." || cFileName == "..") {
+			continue;
+		}
+		callback(cFileName, ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+	} while (FindNextFileW(hFind, &ffd) != 0);
+
+	DWORD dwError = GetLastError();
+	if (dwError != ERROR_NO_MORE_FILES) {
+		FindClose(hFind);
+		return false;
+	}
+
+	FindClose(hFind);
+	return true;
+}
+
+void LocalFileSystem::FileSync(FileHandle &handle) {
+	HANDLE hFile = ((WindowsFileHandle &)handle).fd;
+	if (FlushFileBuffers(hFile) == 0) {
+		throw IOException("Could not flush file handle to disk!");
+	}
+}
+
+void LocalFileSystem::MoveFile(const string &source, const string &target) {
+	auto source_unicode = WindowsUtil::UTF8ToUnicode(source.c_str());
+	auto target_unicode = WindowsUtil::UTF8ToUnicode(target.c_str());
+	if (!MoveFileW(source_unicode.c_str(), target_unicode.c_str())) {
+		throw IOException("Could not move file");
+	}
+}
+
+FileType LocalFileSystem::GetFileType(FileHandle &handle) {
+	auto path = ((WindowsFileHandle &)handle).path;
+	// pipes in windows are just files in '\\.\pipe\' folder
+	if (strncmp(path.c_str(), PIPE_PREFIX, strlen(PIPE_PREFIX)) == 0) {
+		return FileType::FILE_TYPE_FIFO;
+	}
+	DWORD attrs = WindowsGetFileAttributes(path.c_str());
+	if (attrs != INVALID_FILE_ATTRIBUTES) {
+		if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
+			return FileType::FILE_TYPE_DIR;
+		} else {
+			return FileType::FILE_TYPE_REGULAR;
+		}
+	}
+	return FileType::FILE_TYPE_INVALID;
+}
+#endif
+
+bool LocalFileSystem::CanSeek() {
+	return true;
+}
+
+bool LocalFileSystem::OnDiskFile(FileHandle &handle) {
+	return true;
+}
+
+void LocalFileSystem::Seek(FileHandle &handle, idx_t location) {
+	if (!CanSeek()) {
+		throw IOException("Cannot seek in files of this type");
+	}
+	SetFilePointer(handle, location);
+}
+
+idx_t LocalFileSystem::SeekPosition(FileHandle &handle) {
+	if (!CanSeek()) {
+		throw IOException("Cannot seek in files of this type");
+	}
+	return GetFilePointer(handle);
+}
+
+static bool HasGlob(const string &str) {
+	for (idx_t i = 0; i < str.size(); i++) {
+		switch (str[i]) {
+		case '*':
+		case '?':
+		case '[':
+			return true;
+		default:
+			break;
+		}
+	}
+	return false;
+}
+
+static void GlobFiles(FileSystem &fs, const string &path, const string &glob, bool match_directory,
+                      vector<string> &result, bool join_path) {
+	fs.ListFiles(path, [&](const string &fname, bool is_directory) {
+		if (is_directory != match_directory) {
+			return;
+		}
+		if (LikeFun::Glob(fname.c_str(), fname.size(), glob.c_str(), glob.size())) {
+			if (join_path) {
+				result.push_back(fs.JoinPath(path, fname));
+			} else {
+				result.push_back(fname);
+			}
+		}
+	});
+}
+
+vector<string> LocalFileSystem::Glob(const string &path, FileOpener *opener) {
+	if (path.empty()) {
+		return vector<string>();
+	}
+	// split up the path into separate chunks
+	vector<string> splits;
+	idx_t last_pos = 0;
+	for (idx_t i = 0; i < path.size(); i++) {
+		if (path[i] == '\\' || path[i] == '/') {
+			if (i == last_pos) {
+				// empty: skip this position
+				last_pos = i + 1;
+				continue;
+			}
+			if (splits.empty()) {
+				splits.push_back(path.substr(0, i));
+			} else {
+				splits.push_back(path.substr(last_pos, i - last_pos));
+			}
+			last_pos = i + 1;
+		}
+	}
+	splits.push_back(path.substr(last_pos, path.size() - last_pos));
+	// handle absolute paths
+	bool absolute_path = false;
+	if (path[0] == '/') {
+		// first character is a slash -  unix absolute path
+		absolute_path = true;
+	} else if (StringUtil::Contains(splits[0], ":")) {
+		// first split has a colon -  windows absolute path
+		absolute_path = true;
+	} else if (splits[0] == "~") {
+		// starts with home directory
+		auto home_directory = GetHomeDirectory();
+		if (!home_directory.empty()) {
+			absolute_path = true;
+			splits[0] = home_directory;
+		}
+	}
+	// Check if the path has a glob at all
+	if (!HasGlob(path)) {
+		// no glob: return only the file (if it exists or is a pipe)
+		vector<string> result;
+		if (FileExists(path) || IsPipe(path)) {
+			result.push_back(path);
+		} else if (!absolute_path) {
+			Value value;
+			if (opener->TryGetCurrentSetting("file_search_path", value)) {
+				auto search_paths_str = value.ToString();
+				std::vector<std::string> search_paths = StringUtil::Split(search_paths_str, ',');
+				for (const auto &search_path : search_paths) {
+					auto joined_path = JoinPath(search_path, path);
+					if (FileExists(joined_path) || IsPipe(joined_path)) {
+						result.push_back(joined_path);
+					}
+				}
+			}
+		}
+		return result;
+	}
+	vector<string> previous_directories;
+	if (absolute_path) {
+		// for absolute paths, we don't start by scanning the current directory
+		previous_directories.push_back(splits[0]);
+	}
+	for (idx_t i = absolute_path ? 1 : 0; i < splits.size(); i++) {
+		bool is_last_chunk = i + 1 == splits.size();
+		bool has_glob = HasGlob(splits[i]);
+		// if it's the last chunk we need to find files, otherwise we find directories
+		// not the last chunk: gather a list of all directories that match the glob pattern
+		vector<string> result;
+		if (!has_glob) {
+			// no glob, just append as-is
+			if (previous_directories.empty()) {
+				result.push_back(splits[i]);
+			} else {
+				for (auto &prev_directory : previous_directories) {
+					result.push_back(JoinPath(prev_directory, splits[i]));
+				}
+			}
+		} else {
+			if (previous_directories.empty()) {
+				// no previous directories: list in the current path
+				GlobFiles(*this, ".", splits[i], !is_last_chunk, result, false);
+			} else {
+				// previous directories
+				// we iterate over each of the previous directories, and apply the glob of the current directory
+				for (auto &prev_directory : previous_directories) {
+					GlobFiles(*this, prev_directory, splits[i], !is_last_chunk, result, true);
+				}
+			}
+		}
+		if (is_last_chunk || result.empty()) {
+			return result;
+		}
+		previous_directories = move(result);
+	}
+	return vector<string>();
+}
+
+unique_ptr<FileSystem> FileSystem::CreateLocal() {
+	return make_unique<LocalFileSystem>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Cast bool -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(bool input, bool &result, bool strict) {
+	return NumericTryCast::Operation<bool, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<bool, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, float &result, bool strict) {
+	return NumericTryCast::Operation<bool, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(bool input, double &result, bool strict) {
+	return NumericTryCast::Operation<bool, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int8_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(int8_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int8_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<int8_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int16_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(int16_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int16_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<int16_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int32_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(int32_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int32_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<int32_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int64_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(int64_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(int64_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<int64_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast hugeint_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(hugeint_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(hugeint_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<hugeint_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint8_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(uint8_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint8_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<uint8_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint16_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(uint16_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint16_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<uint16_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint32_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(uint32_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint32_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<uint32_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint64_t -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(uint64_t input, bool &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, float &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(uint64_t input, double &result, bool strict) {
+	return NumericTryCast::Operation<uint64_t, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast float -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(float input, bool &result, bool strict) {
+	return NumericTryCast::Operation<float, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<float, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<float, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<float, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<float, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<float, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<float, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<float, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<float, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<float, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, float &result, bool strict) {
+	return NumericTryCast::Operation<float, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(float input, double &result, bool strict) {
+	return NumericTryCast::Operation<float, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast double -> Numeric
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(double input, bool &result, bool strict) {
+	return NumericTryCast::Operation<double, bool>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, int8_t &result, bool strict) {
+	return NumericTryCast::Operation<double, int8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, int16_t &result, bool strict) {
+	return NumericTryCast::Operation<double, int16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, int32_t &result, bool strict) {
+	return NumericTryCast::Operation<double, int32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, int64_t &result, bool strict) {
+	return NumericTryCast::Operation<double, int64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, hugeint_t &result, bool strict) {
+	return NumericTryCast::Operation<double, hugeint_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, uint8_t &result, bool strict) {
+	return NumericTryCast::Operation<double, uint8_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, uint16_t &result, bool strict) {
+	return NumericTryCast::Operation<double, uint16_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, uint32_t &result, bool strict) {
+	return NumericTryCast::Operation<double, uint32_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, uint64_t &result, bool strict) {
+	return NumericTryCast::Operation<double, uint64_t>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, float &result, bool strict) {
+	return NumericTryCast::Operation<double, float>(input, result, strict);
+}
+
+template <>
+bool TryCast::Operation(double input, double &result, bool strict) {
+	return NumericTryCast::Operation<double, double>(input, result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast String -> Numeric
+//===--------------------------------------------------------------------===//
+template <typename T>
+struct IntegerCastData {
+	using Result = T;
+	Result result;
+	bool seen_decimal;
+};
+
+struct IntegerCastOperation {
+	template <class T, bool NEGATIVE>
+	static bool HandleDigit(T &state, uint8_t digit) {
+		using result_t = typename T::Result;
+		if (NEGATIVE) {
+			if (state.result < (NumericLimits<result_t>::Minimum() + digit) / 10) {
+				return false;
+			}
+			state.result = state.result * 10 - digit;
+		} else {
+			if (state.result > (NumericLimits<result_t>::Maximum() - digit) / 10) {
+				return false;
+			}
+			state.result = state.result * 10 + digit;
+		}
+		return true;
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleExponent(T &state, int32_t exponent) {
+		using result_t = typename T::Result;
+		double dbl_res = state.result * std::pow(10.0L, exponent);
+		if (dbl_res < NumericLimits<result_t>::Minimum() || dbl_res > NumericLimits<result_t>::Maximum()) {
+			return false;
+		}
+		state.result = (result_t)std::nearbyint(dbl_res);
+		return true;
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleDecimal(T &state, uint8_t digit) {
+		if (state.seen_decimal) {
+			return true;
+		}
+		state.seen_decimal = true;
+		// round the integer based on what is after the decimal point
+		// if digit >= 5, then we round up (or down in case of negative numbers)
+		auto increment = digit >= 5;
+		if (!increment) {
+			return true;
+		}
+		if (NEGATIVE) {
+			if (state.result == NumericLimits<typename T::Result>::Minimum()) {
+				return false;
+			}
+			state.result--;
+		} else {
+			if (state.result == NumericLimits<typename T::Result>::Maximum()) {
+				return false;
+			}
+			state.result++;
+		}
+		return true;
+	}
+
+	template <class T>
+	static bool Finalize(T &state) {
+		return true;
+	}
+};
+
+template <class T, bool NEGATIVE, bool ALLOW_EXPONENT, class OP = IntegerCastOperation>
+static bool IntegerCastLoop(const char *buf, idx_t len, T &result, bool strict) {
+	idx_t start_pos = NEGATIVE || *buf == '+' ? 1 : 0;
+	idx_t pos = start_pos;
+	while (pos < len) {
+		if (!StringUtil::CharacterIsDigit(buf[pos])) {
+			// not a digit!
+			if (buf[pos] == '.') {
+				if (strict) {
+					return false;
+				}
+				bool number_before_period = pos > start_pos;
+				// decimal point: we accept decimal values for integers as well
+				// we just truncate them
+				// make sure everything after the period is a number
+				pos++;
+				idx_t start_digit = pos;
+				while (pos < len) {
+					if (!StringUtil::CharacterIsDigit(buf[pos])) {
+						break;
+					}
+					if (!OP::template HandleDecimal<T, NEGATIVE>(result, buf[pos] - '0')) {
+						return false;
+					}
+					pos++;
+				}
+				// make sure there is either (1) one number after the period, or (2) one number before the period
+				// i.e. we accept "1." and ".1" as valid numbers, but not "."
+				if (!(number_before_period || pos > start_digit)) {
+					return false;
+				}
+				if (pos >= len) {
+					break;
+				}
+			}
+			if (StringUtil::CharacterIsSpace(buf[pos])) {
+				// skip any trailing spaces
+				while (++pos < len) {
+					if (!StringUtil::CharacterIsSpace(buf[pos])) {
+						return false;
+					}
+				}
+				break;
+			}
+			if (ALLOW_EXPONENT) {
+				if (buf[pos] == 'e' || buf[pos] == 'E') {
+					if (pos == start_pos) {
+						return false;
+					}
+					pos++;
+					if (pos >= len) {
+						return false;
+					}
+					using ExponentData = IntegerCastData<int32_t>;
+					ExponentData exponent {0, false};
+					int negative = buf[pos] == '-';
+					if (negative) {
+						if (!IntegerCastLoop<ExponentData, true, false>(buf + pos, len - pos, exponent, strict)) {
+							return false;
+						}
+					} else {
+						if (!IntegerCastLoop<ExponentData, false, false>(buf + pos, len - pos, exponent, strict)) {
+							return false;
+						}
+					}
+					return OP::template HandleExponent<T, NEGATIVE>(result, exponent.result);
+				}
+			}
+			return false;
+		}
+		uint8_t digit = buf[pos++] - '0';
+		if (!OP::template HandleDigit<T, NEGATIVE>(result, digit)) {
+			return false;
+		}
+	}
+	if (!OP::template Finalize<T>(result)) {
+		return false;
+	}
+	return pos > start_pos;
+}
+
+template <class T, bool IS_SIGNED = true, bool ALLOW_EXPONENT = true, class OP = IntegerCastOperation,
+          bool ZERO_INITIALIZE = true>
+static bool TryIntegerCast(const char *buf, idx_t len, T &result, bool strict) {
+	// skip any spaces at the start
+	while (len > 0 && StringUtil::CharacterIsSpace(*buf)) {
+		buf++;
+		len--;
+	}
+	if (len == 0) {
+		return false;
+	}
+	int negative = *buf == '-';
+
+	if (ZERO_INITIALIZE) {
+		memset(&result, 0, sizeof(T));
+	}
+	if (!negative) {
+		return IntegerCastLoop<T, false, ALLOW_EXPONENT, OP>(buf, len, result, strict);
+	} else {
+		if (!IS_SIGNED) {
+			// Need to check if its not -0
+			idx_t pos = 1;
+			while (pos < len) {
+				if (buf[pos++] != '0') {
+					return false;
+				}
+			}
+		}
+		return IntegerCastLoop<T, true, ALLOW_EXPONENT, OP>(buf, len, result, strict);
+	}
+}
+
+template <typename T, bool IS_SIGNED = true>
+static inline bool TrySimpleIntegerCast(const char *buf, idx_t len, T &result, bool strict) {
+	IntegerCastData<T> data;
+	if (TryIntegerCast<IntegerCastData<T>, IS_SIGNED>(buf, len, data, strict)) {
+		result = data.result;
+		return true;
+	}
+	return false;
+}
+
+template <>
+bool TryCast::Operation(string_t input, bool &result, bool strict) {
+	auto input_data = input.GetDataUnsafe();
+	auto input_size = input.GetSize();
+
+	switch (input_size) {
+	case 1: {
+		char c = std::tolower(*input_data);
+		if (c == 't' || (!strict && c == '1')) {
+			result = true;
+			return true;
+		} else if (c == 'f' || (!strict && c == '0')) {
+			result = false;
+			return true;
+		}
+		return false;
+	}
+	case 4: {
+		char t = std::tolower(input_data[0]);
+		char r = std::tolower(input_data[1]);
+		char u = std::tolower(input_data[2]);
+		char e = std::tolower(input_data[3]);
+		if (t == 't' && r == 'r' && u == 'u' && e == 'e') {
+			result = true;
+			return true;
+		}
+		return false;
+	}
+	case 5: {
+		char f = std::tolower(input_data[0]);
+		char a = std::tolower(input_data[1]);
+		char l = std::tolower(input_data[2]);
+		char s = std::tolower(input_data[3]);
+		char e = std::tolower(input_data[4]);
+		if (f == 'f' && a == 'a' && l == 'l' && s == 's' && e == 'e') {
+			result = false;
+			return true;
+		}
+		return false;
+	}
+	default:
+		return false;
+	}
+}
+template <>
+bool TryCast::Operation(string_t input, int8_t &result, bool strict) {
+	return TrySimpleIntegerCast<int8_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, int16_t &result, bool strict) {
+	return TrySimpleIntegerCast<int16_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, int32_t &result, bool strict) {
+	return TrySimpleIntegerCast<int32_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, int64_t &result, bool strict) {
+	return TrySimpleIntegerCast<int64_t>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+
+template <>
+bool TryCast::Operation(string_t input, uint8_t &result, bool strict) {
+	return TrySimpleIntegerCast<uint8_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, uint16_t &result, bool strict) {
+	return TrySimpleIntegerCast<uint16_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, uint32_t &result, bool strict) {
+	return TrySimpleIntegerCast<uint32_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+template <>
+bool TryCast::Operation(string_t input, uint64_t &result, bool strict) {
+	return TrySimpleIntegerCast<uint64_t, false>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+
+template <class T>
+static bool TryDoubleCast(const char *buf, idx_t len, T &result, bool strict) {
+	// skip any spaces at the start
+	while (len > 0 && StringUtil::CharacterIsSpace(*buf)) {
+		buf++;
+		len--;
+	}
+	if (len == 0) {
+		return false;
+	}
+	if (*buf == '+') {
+		buf++;
+		len--;
+	}
+	auto endptr = buf + len;
+	auto parse_result = duckdb_fast_float::from_chars(buf, buf + len, result);
+	if (parse_result.ec != std::errc()) {
+		return false;
+	}
+	auto current_end = parse_result.ptr;
+	if (!strict) {
+		while (current_end < endptr && StringUtil::CharacterIsSpace(*current_end)) {
+			current_end++;
+		}
+	}
+	return current_end == endptr;
+}
+
+template <>
+bool TryCast::Operation(string_t input, float &result, bool strict) {
+	return TryDoubleCast<float>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+
+template <>
+bool TryCast::Operation(string_t input, double &result, bool strict) {
+	return TryDoubleCast<double>(input.GetDataUnsafe(), input.GetSize(), result, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Date
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(date_t input, date_t &result, bool strict) {
+	result = input;
+	return true;
+}
+
+template <>
+bool TryCast::Operation(date_t input, timestamp_t &result, bool strict) {
+	if (input == date_t::infinity()) {
+		result = timestamp_t::infinity();
+		return true;
+	} else if (input == date_t::ninfinity()) {
+		result = timestamp_t::ninfinity();
+		return true;
+	}
+	return Timestamp::TryFromDatetime(input, Time::FromTime(0, 0, 0), result);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Time
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(dtime_t input, dtime_t &result, bool strict) {
+	result = input;
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Timestamps
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(timestamp_t input, date_t &result, bool strict) {
+	result = Timestamp::GetDate(input);
+	return true;
+}
+
+template <>
+bool TryCast::Operation(timestamp_t input, dtime_t &result, bool strict) {
+	if (!Timestamp::IsFinite(input)) {
+		return false;
+	}
+	result = Timestamp::GetTime(input);
+	return true;
+}
+
+template <>
+bool TryCast::Operation(timestamp_t input, timestamp_t &result, bool strict) {
+	result = input;
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast from Interval
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCast::Operation(interval_t input, interval_t &result, bool strict) {
+	result = input;
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Non-Standard Timestamps
+//===--------------------------------------------------------------------===//
+template <>
+duckdb::string_t CastFromTimestampNS::Operation(duckdb::timestamp_t input, Vector &result) {
+	return StringCast::Operation<timestamp_t>(Timestamp::FromEpochNanoSeconds(input.value), result);
+}
+template <>
+duckdb::string_t CastFromTimestampMS::Operation(duckdb::timestamp_t input, Vector &result) {
+	return StringCast::Operation<timestamp_t>(Timestamp::FromEpochMs(input.value), result);
+}
+template <>
+duckdb::string_t CastFromTimestampSec::Operation(duckdb::timestamp_t input, Vector &result) {
+	return StringCast::Operation<timestamp_t>(Timestamp::FromEpochSeconds(input.value), result);
+}
+
+template <>
+timestamp_t CastTimestampUsToMs::Operation(timestamp_t input) {
+	timestamp_t cast_timestamp(Timestamp::GetEpochMs(input));
+	return cast_timestamp;
+}
+
+template <>
+timestamp_t CastTimestampUsToNs::Operation(timestamp_t input) {
+	timestamp_t cast_timestamp(Timestamp::GetEpochNanoSeconds(input));
+	return cast_timestamp;
+}
+
+template <>
+timestamp_t CastTimestampUsToSec::Operation(timestamp_t input) {
+	timestamp_t cast_timestamp(Timestamp::GetEpochSeconds(input));
+	return cast_timestamp;
+}
+template <>
+timestamp_t CastTimestampMsToUs::Operation(timestamp_t input) {
+	return Timestamp::FromEpochMs(input.value);
+}
+
+template <>
+timestamp_t CastTimestampNsToUs::Operation(timestamp_t input) {
+	return Timestamp::FromEpochNanoSeconds(input.value);
+}
+
+template <>
+timestamp_t CastTimestampSecToUs::Operation(timestamp_t input) {
+	return Timestamp::FromEpochSeconds(input.value);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To Timestamp
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToTimestampNS::Operation(string_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<string_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	result = Timestamp::GetEpochNanoSeconds(result);
+	return true;
+}
+
+template <>
+bool TryCastToTimestampMS::Operation(string_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<string_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	result = Timestamp::GetEpochMs(result);
+	return true;
+}
+
+template <>
+bool TryCastToTimestampSec::Operation(string_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<string_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	result = Timestamp::GetEpochSeconds(result);
+	return true;
+}
+
+template <>
+bool TryCastToTimestampNS::Operation(date_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<date_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	if (!TryMultiplyOperator::Operation(result.value, Interval::NANOS_PER_MICRO, result.value)) {
+		return false;
+	}
+	return true;
+}
+
+template <>
+bool TryCastToTimestampMS::Operation(date_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<date_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	result.value /= Interval::MICROS_PER_MSEC;
+	return true;
+}
+
+template <>
+bool TryCastToTimestampSec::Operation(date_t input, timestamp_t &result, bool strict) {
+	if (!TryCast::Operation<date_t, timestamp_t>(input, result, strict)) {
+		return false;
+	}
+	result.value /= Interval::MICROS_PER_MSEC * Interval::MSECS_PER_SEC;
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Blob
+//===--------------------------------------------------------------------===//
+template <>
+string_t CastFromBlob::Operation(string_t input, Vector &vector) {
+	idx_t result_size = Blob::GetStringSize(input);
+
+	string_t result = StringVector::EmptyString(vector, result_size);
+	Blob::ToString(input, result.GetDataWriteable());
+	result.Finalize();
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To Blob
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToBlob::Operation(string_t input, string_t &result, Vector &result_vector, string *error_message,
+                              bool strict) {
+	idx_t result_size;
+	if (!Blob::TryGetBlobSize(input, result_size, error_message)) {
+		return false;
+	}
+
+	result = StringVector::EmptyString(result_vector, result_size);
+	Blob::ToBlob(input, (data_ptr_t)result.GetDataWriteable());
+	result.Finalize();
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From UUID
+//===--------------------------------------------------------------------===//
+template <>
+string_t CastFromUUID::Operation(hugeint_t input, Vector &vector) {
+	string_t result = StringVector::EmptyString(vector, 36);
+	UUID::ToString(input, result.GetDataWriteable());
+	result.Finalize();
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To UUID
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToUUID::Operation(string_t input, hugeint_t &result, Vector &result_vector, string *error_message,
+                              bool strict) {
+	return UUID::FromString(input.GetString(), result);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To Date
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastErrorMessage::Operation(string_t input, date_t &result, string *error_message, bool strict) {
+	if (!TryCast::Operation<string_t, date_t>(input, result, strict)) {
+		HandleCastError::AssignError(Date::ConversionError(input), error_message);
+		return false;
+	}
+	return true;
+}
+
+template <>
+bool TryCast::Operation(string_t input, date_t &result, bool strict) {
+	idx_t pos;
+	return Date::TryConvertDate(input.GetDataUnsafe(), input.GetSize(), pos, result, strict);
+}
+
+template <>
+date_t Cast::Operation(string_t input) {
+	return Date::FromCString(input.GetDataUnsafe(), input.GetSize());
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To Time
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastErrorMessage::Operation(string_t input, dtime_t &result, string *error_message, bool strict) {
+	if (!TryCast::Operation<string_t, dtime_t>(input, result, strict)) {
+		HandleCastError::AssignError(Time::ConversionError(input), error_message);
+		return false;
+	}
+	return true;
+}
+
+template <>
+bool TryCast::Operation(string_t input, dtime_t &result, bool strict) {
+	idx_t pos;
+	return Time::TryConvertTime(input.GetDataUnsafe(), input.GetSize(), pos, result, strict);
+}
+
+template <>
+dtime_t Cast::Operation(string_t input) {
+	return Time::FromCString(input.GetDataUnsafe(), input.GetSize());
+}
+
+//===--------------------------------------------------------------------===//
+// Cast To Timestamp
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastErrorMessage::Operation(string_t input, timestamp_t &result, string *error_message, bool strict) {
+	if (!TryCast::Operation<string_t, timestamp_t>(input, result, strict)) {
+		HandleCastError::AssignError(Timestamp::ConversionError(input), error_message);
+		return false;
+	}
+	return true;
+}
+
+template <>
+bool TryCast::Operation(string_t input, timestamp_t &result, bool strict) {
+	return Timestamp::TryConvertTimestamp(input.GetDataUnsafe(), input.GetSize(), result);
+}
+
+template <>
+timestamp_t Cast::Operation(string_t input) {
+	return Timestamp::FromCString(input.GetDataUnsafe(), input.GetSize());
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Interval
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastErrorMessage::Operation(string_t input, interval_t &result, string *error_message, bool strict) {
+	return Interval::FromCString(input.GetDataUnsafe(), input.GetSize(), result, error_message, strict);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast From Hugeint
+//===--------------------------------------------------------------------===//
+// parsing hugeint from string is done a bit differently for performance reasons
+// for other integer types we keep track of a single value
+// and multiply that value by 10 for every digit we read
+// however, for hugeints, multiplication is very expensive (>20X as expensive as for int64)
+// for that reason, we parse numbers first into an int64 value
+// when that value is full, we perform a HUGEINT multiplication to flush it into the hugeint
+// this takes the number of HUGEINT multiplications down from [0-38] to [0-2]
+struct HugeIntCastData {
+	hugeint_t hugeint;
+	int64_t intermediate;
+	uint8_t digits;
+	bool decimal;
+
+	bool Flush() {
+		if (digits == 0 && intermediate == 0) {
+			return true;
+		}
+		if (hugeint.lower != 0 || hugeint.upper != 0) {
+			if (digits > 38) {
+				return false;
+			}
+			if (!Hugeint::TryMultiply(hugeint, Hugeint::POWERS_OF_TEN[digits], hugeint)) {
+				return false;
+			}
+		}
+		if (!Hugeint::AddInPlace(hugeint, hugeint_t(intermediate))) {
+			return false;
+		}
+		digits = 0;
+		intermediate = 0;
+		return true;
+	}
+};
+
+struct HugeIntegerCastOperation {
+	template <class T, bool NEGATIVE>
+	static bool HandleDigit(T &result, uint8_t digit) {
+		if (NEGATIVE) {
+			if (result.intermediate < (NumericLimits<int64_t>::Minimum() + digit) / 10) {
+				// intermediate is full: need to flush it
+				if (!result.Flush()) {
+					return false;
+				}
+			}
+			result.intermediate = result.intermediate * 10 - digit;
+		} else {
+			if (result.intermediate > (NumericLimits<int64_t>::Maximum() - digit) / 10) {
+				if (!result.Flush()) {
+					return false;
+				}
+			}
+			result.intermediate = result.intermediate * 10 + digit;
+		}
+		result.digits++;
+		return true;
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleExponent(T &result, int32_t exponent) {
+		if (!result.Flush()) {
+			return false;
+		}
+		if (exponent < -38 || exponent > 38) {
+			// out of range for exact exponent: use double and convert
+			double dbl_res = Hugeint::Cast<double>(result.hugeint) * std::pow(10.0L, exponent);
+			if (dbl_res < Hugeint::Cast<double>(NumericLimits<hugeint_t>::Minimum()) ||
+			    dbl_res > Hugeint::Cast<double>(NumericLimits<hugeint_t>::Maximum())) {
+				return false;
+			}
+			result.hugeint = Hugeint::Convert(dbl_res);
+			return true;
+		}
+		if (exponent < 0) {
+			// negative exponent: divide by power of 10
+			result.hugeint = Hugeint::Divide(result.hugeint, Hugeint::POWERS_OF_TEN[-exponent]);
+			return true;
+		} else {
+			// positive exponent: multiply by power of 10
+			return Hugeint::TryMultiply(result.hugeint, Hugeint::POWERS_OF_TEN[exponent], result.hugeint);
+		}
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleDecimal(T &result, uint8_t digit) {
+		// Integer casts round
+		if (!result.decimal) {
+			if (!result.Flush()) {
+				return false;
+			}
+			if (NEGATIVE) {
+				result.intermediate = -(digit >= 5);
+			} else {
+				result.intermediate = (digit >= 5);
+			}
+		}
+		result.decimal = true;
+
+		return true;
+	}
+
+	template <class T>
+	static bool Finalize(T &result) {
+		return result.Flush();
+	}
+};
+
+template <>
+bool TryCast::Operation(string_t input, hugeint_t &result, bool strict) {
+	HugeIntCastData data;
+	if (!TryIntegerCast<HugeIntCastData, true, true, HugeIntegerCastOperation>(input.GetDataUnsafe(), input.GetSize(),
+	                                                                           data, strict)) {
+		return false;
+	}
+	result = data.hugeint;
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Decimal String Cast
+//===--------------------------------------------------------------------===//
+template <class T>
+struct DecimalCastData {
+	T result;
+	uint8_t width;
+	uint8_t scale;
+	uint8_t digit_count;
+	uint8_t decimal_count;
+};
+
+struct DecimalCastOperation {
+	template <class T, bool NEGATIVE>
+	static bool HandleDigit(T &state, uint8_t digit) {
+		if (state.result == 0 && digit == 0) {
+			// leading zero's don't count towards the digit count
+			return true;
+		}
+		if (state.digit_count == state.width - state.scale) {
+			// width of decimal type is exceeded!
+			return false;
+		}
+		state.digit_count++;
+		if (NEGATIVE) {
+			state.result = state.result * 10 - digit;
+		} else {
+			state.result = state.result * 10 + digit;
+		}
+		return true;
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleExponent(T &state, int32_t exponent) {
+		Finalize<T>(state);
+		if (exponent < 0) {
+			for (idx_t i = 0; i < idx_t(-int64_t(exponent)); i++) {
+				state.result /= 10;
+				if (state.result == 0) {
+					break;
+				}
+			}
+			return true;
+		} else {
+			// positive exponent: append 0's
+			for (idx_t i = 0; i < idx_t(exponent); i++) {
+				if (!HandleDigit<T, NEGATIVE>(state, 0)) {
+					return false;
+				}
+			}
+			return true;
+		}
+	}
+
+	template <class T, bool NEGATIVE>
+	static bool HandleDecimal(T &state, uint8_t digit) {
+		if (state.decimal_count == state.scale) {
+			// we exceeded the amount of supported decimals
+			// however, we don't throw an error here
+			// we just truncate the decimal
+			return true;
+		}
+		state.decimal_count++;
+		if (NEGATIVE) {
+			state.result = state.result * 10 - digit;
+		} else {
+			state.result = state.result * 10 + digit;
+		}
+		return true;
+	}
+
+	template <class T>
+	static bool Finalize(T &state) {
+		// if we have not gotten exactly "scale" decimals, we need to multiply the result
+		// e.g. if we have a string "1.0" that is cast to a DECIMAL(9,3), the value needs to be 1000
+		// but we have only gotten the value "10" so far, so we multiply by 1000
+		for (uint8_t i = state.decimal_count; i < state.scale; i++) {
+			state.result *= 10;
+		}
+		return true;
+	}
+};
+
+template <class T>
+bool TryDecimalStringCast(string_t input, T &result, string *error_message, uint8_t width, uint8_t scale) {
+	DecimalCastData<T> state;
+	state.result = 0;
+	state.width = width;
+	state.scale = scale;
+	state.digit_count = 0;
+	state.decimal_count = 0;
+	if (!TryIntegerCast<DecimalCastData<T>, true, true, DecimalCastOperation, false>(input.GetDataUnsafe(),
+	                                                                                 input.GetSize(), state, false)) {
+		string error = StringUtil::Format("Could not convert string \"%s\" to DECIMAL(%d,%d)", input.GetString(),
+		                                  (int)width, (int)scale);
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	result = state.result;
+	return true;
+}
+
+template <>
+bool TryCastToDecimal::Operation(string_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryDecimalStringCast<int16_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(string_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryDecimalStringCast<int32_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(string_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryDecimalStringCast<int64_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(string_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return TryDecimalStringCast<hugeint_t>(input, result, error_message, width, scale);
+}
+
+template <>
+string_t StringCastFromDecimal::Operation(int16_t input, uint8_t width, uint8_t scale, Vector &result) {
+	return DecimalToString::Format<int16_t, uint16_t>(input, scale, result);
+}
+
+template <>
+string_t StringCastFromDecimal::Operation(int32_t input, uint8_t width, uint8_t scale, Vector &result) {
+	return DecimalToString::Format<int32_t, uint32_t>(input, scale, result);
+}
+
+template <>
+string_t StringCastFromDecimal::Operation(int64_t input, uint8_t width, uint8_t scale, Vector &result) {
+	return DecimalToString::Format<int64_t, uint64_t>(input, scale, result);
+}
+
+template <>
+string_t StringCastFromDecimal::Operation(hugeint_t input, uint8_t width, uint8_t scale, Vector &result) {
+	return HugeintToStringCast::FormatDecimal(input, scale, result);
+}
+
+//===--------------------------------------------------------------------===//
+// Decimal Casts
+//===--------------------------------------------------------------------===//
+// Decimal <-> Bool
+//===--------------------------------------------------------------------===//
+template <class T, class OP = NumericHelper>
+bool TryCastBoolToDecimal(bool input, T &result, string *error_message, uint8_t width, uint8_t scale) {
+	if (width > scale) {
+		result = input ? OP::POWERS_OF_TEN[scale] : 0;
+		return true;
+	} else {
+		return TryCast::Operation<bool, T>(input, result);
+	}
+}
+
+template <>
+bool TryCastToDecimal::Operation(bool input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<int16_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(bool input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<int32_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(bool input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<int64_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(bool input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastBoolToDecimal<hugeint_t, Hugeint>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCast::Operation<int16_t, bool>(input, result);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCast::Operation<int32_t, bool>(input, result);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCast::Operation<int64_t, bool>(input, result);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, bool &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCast::Operation<hugeint_t, bool>(input, result);
+}
+
+//===--------------------------------------------------------------------===//
+// Numeric -> Decimal Cast
+//===--------------------------------------------------------------------===//
+struct SignedToDecimalOperator {
+	template <class SRC, class DST>
+	static bool Operation(SRC input, DST max_width) {
+		return int64_t(input) >= int64_t(max_width) || int64_t(input) <= int64_t(-max_width);
+	}
+};
+
+struct UnsignedToDecimalOperator {
+	template <class SRC, class DST>
+	static bool Operation(SRC input, DST max_width) {
+		return uint64_t(input) >= uint64_t(max_width);
+	}
+};
+
+template <class SRC, class DST, class OP = SignedToDecimalOperator>
+bool StandardNumericToDecimalCast(SRC input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+	// check for overflow
+	DST max_width = NumericHelper::POWERS_OF_TEN[width - scale];
+	if (OP::template Operation<SRC, DST>(input, max_width)) {
+		string error = StringUtil::Format("Could not cast value %d to DECIMAL(%d,%d)", input, width, scale);
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	result = DST(input) * NumericHelper::POWERS_OF_TEN[scale];
+	return true;
+}
+
+template <class SRC>
+bool NumericToHugeDecimalCast(SRC input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	// check for overflow
+	hugeint_t max_width = Hugeint::POWERS_OF_TEN[width - scale];
+	hugeint_t hinput = Hugeint::Convert(input);
+	if (hinput >= max_width || hinput <= -max_width) {
+		string error = StringUtil::Format("Could not cast value %s to DECIMAL(%d,%d)", hinput.ToString(), width, scale);
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	result = hinput * Hugeint::POWERS_OF_TEN[scale];
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int8_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(int8_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int8_t, int16_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int8_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int8_t, int32_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int8_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int8_t, int64_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int8_t input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return NumericToHugeDecimalCast<int8_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int16_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(int16_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int16_t, int16_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int16_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int16_t, int32_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int16_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int16_t, int64_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int16_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<int16_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int32_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(int32_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int32_t, int16_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int32_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int32_t, int32_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int32_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int32_t, int64_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int32_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<int32_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast int64_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(int64_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int64_t, int16_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int64_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int64_t, int32_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int64_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<int64_t, int64_t>(input, result, error_message, width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(int64_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<int64_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint8_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(uint8_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                 width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint8_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                 width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint8_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint8_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                 width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint8_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<uint8_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint16_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(uint16_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint16_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint16_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint16_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint16_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<uint16_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint32_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(uint32_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint32_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint32_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint32_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint32_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<uint32_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast uint64_t -> Decimal
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastToDecimal::Operation(uint64_t input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int16_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint64_t input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int32_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint64_t input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return StandardNumericToDecimalCast<uint64_t, int64_t, UnsignedToDecimalOperator>(input, result, error_message,
+	                                                                                  width, scale);
+}
+template <>
+bool TryCastToDecimal::Operation(uint64_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return NumericToHugeDecimalCast<uint64_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Hugeint -> Decimal Cast
+//===--------------------------------------------------------------------===//
+template <class DST>
+bool HugeintToDecimalCast(hugeint_t input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+	// check for overflow
+	hugeint_t max_width = Hugeint::POWERS_OF_TEN[width - scale];
+	if (input >= max_width || input <= -max_width) {
+		string error = StringUtil::Format("Could not cast value %s to DECIMAL(%d,%d)", input.ToString(), width, scale);
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	result = Hugeint::Cast<DST>(input * Hugeint::POWERS_OF_TEN[scale]);
+	return true;
+}
+
+template <>
+bool TryCastToDecimal::Operation(hugeint_t input, int16_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return HugeintToDecimalCast<int16_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(hugeint_t input, int32_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return HugeintToDecimalCast<int32_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(hugeint_t input, int64_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return HugeintToDecimalCast<int64_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(hugeint_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                 uint8_t scale) {
+	return HugeintToDecimalCast<hugeint_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Float/Double -> Decimal Cast
+//===--------------------------------------------------------------------===//
+template <class SRC, class DST>
+bool DoubleToDecimalCast(SRC input, DST &result, string *error_message, uint8_t width, uint8_t scale) {
+	double value = input * NumericHelper::DOUBLE_POWERS_OF_TEN[scale];
+	// Add the sign (-1, 0, 1) times a tiny value to fix floating point issues (issue 3091)
+	double sign = (double(0) < value) - (value < double(0));
+	value += 1e-9 * sign;
+	if (value <= -NumericHelper::DOUBLE_POWERS_OF_TEN[width] || value >= NumericHelper::DOUBLE_POWERS_OF_TEN[width]) {
+		string error = StringUtil::Format("Could not cast value %f to DECIMAL(%d,%d)", value, width, scale);
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	result = Cast::Operation<SRC, DST>(value);
+	return true;
+}
+
+template <>
+bool TryCastToDecimal::Operation(float input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, int16_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(float input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, int32_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(float input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, int64_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(float input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<float, hugeint_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(double input, int16_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, int16_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(double input, int32_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, int32_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(double input, int64_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, int64_t>(input, result, error_message, width, scale);
+}
+
+template <>
+bool TryCastToDecimal::Operation(double input, hugeint_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return DoubleToDecimalCast<double, hugeint_t>(input, result, error_message, width, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Decimal -> Numeric Cast
+//===--------------------------------------------------------------------===//
+template <class SRC, class DST>
+bool TryCastDecimalToNumeric(SRC input, DST &result, string *error_message, uint8_t scale) {
+	// Round away from 0.
+	const auto power = NumericHelper::POWERS_OF_TEN[scale];
+	// https://graphics.stanford.edu/~seander/bithacks.html#ConditionalNegate
+	const auto fNegate = int64_t(input < 0);
+	const auto rounding = ((power ^ -fNegate) + fNegate) / 2;
+	const auto scaled_value = (input + rounding) / power;
+	if (!TryCast::Operation<SRC, DST>(scaled_value, result)) {
+		string error = StringUtil::Format("Failed to cast decimal value %d to type %s", scaled_value, GetTypeId<DST>());
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	return true;
+}
+
+template <class DST>
+bool TryCastHugeDecimalToNumeric(hugeint_t input, DST &result, string *error_message, uint8_t scale) {
+	const auto power = Hugeint::POWERS_OF_TEN[scale];
+	const auto rounding = ((input < 0) ? -power : power) / 2;
+	auto scaled_value = (input + rounding) / power;
+	if (!TryCast::Operation<hugeint_t, DST>(scaled_value, result)) {
+		string error = StringUtil::Format("Failed to cast decimal value %s to type %s",
+		                                  ConvertToString::Operation(scaled_value), GetTypeId<DST>());
+		HandleCastError::AssignError(error, error_message);
+		return false;
+	}
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> int8_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, int8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, int8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, int8_t &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, int8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, int8_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<int8_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> int16_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, int16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, int16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, int16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, int16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, int16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, int16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, int16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<int16_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> int32_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, int32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, int32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, int32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, int32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, int32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, int32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, int32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<int32_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> int64_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, int64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, int64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, int64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, int64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, int64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, int64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, int64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<int64_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> uint8_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, uint8_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, uint8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, uint8_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, uint8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, uint8_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, uint8_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, uint8_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<uint8_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> uint16_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, uint16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, uint16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, uint16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, uint16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, uint16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, uint16_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, uint16_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<uint16_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> uint32_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, uint32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, uint32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, uint32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, uint32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, uint32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, uint32_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, uint32_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<uint32_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> uint64_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, uint64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, uint64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, uint64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, uint64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, uint64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, uint64_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, uint64_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<uint64_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Cast Decimal -> hugeint_t
+//===--------------------------------------------------------------------===//
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int16_t, hugeint_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int32_t, hugeint_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToNumeric<int64_t, hugeint_t>(input, result, error_message, scale);
+}
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, hugeint_t &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastHugeDecimalToNumeric<hugeint_t>(input, result, error_message, scale);
+}
+
+//===--------------------------------------------------------------------===//
+// Decimal -> Float/Double Cast
+//===--------------------------------------------------------------------===//
+template <class SRC, class DST>
+bool TryCastDecimalToFloatingPoint(SRC input, DST &result, uint8_t scale) {
+	result = Cast::Operation<SRC, DST>(input) / DST(NumericHelper::DOUBLE_POWERS_OF_TEN[scale]);
+	return true;
+}
+
+// DECIMAL -> FLOAT
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, float &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int16_t, float>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, float &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int32_t, float>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, float &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int64_t, float>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, float &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<hugeint_t, float>(input, result, scale);
+}
+
+// DECIMAL -> DOUBLE
+template <>
+bool TryCastFromDecimal::Operation(int16_t input, double &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int16_t, double>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int32_t input, double &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int32_t, double>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(int64_t input, double &result, string *error_message, uint8_t width, uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<int64_t, double>(input, result, scale);
+}
+
+template <>
+bool TryCastFromDecimal::Operation(hugeint_t input, double &result, string *error_message, uint8_t width,
+                                   uint8_t scale) {
+	return TryCastDecimalToFloatingPoint<hugeint_t, double>(input, result, scale);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+template <class T>
+string StandardStringCast(T input) {
+	Vector v(LogicalType::VARCHAR);
+	return StringCast::Operation(input, v).GetString();
+}
+
+template <>
+string ConvertToString::Operation(bool input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(int8_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(int16_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(int32_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(int64_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(uint8_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(uint16_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(uint32_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(uint64_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(hugeint_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(float input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(double input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(interval_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(date_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(dtime_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(timestamp_t input) {
+	return StandardStringCast(input);
+}
+template <>
+string ConvertToString::Operation(string_t input) {
+	return input.GetString();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Cast Numeric -> String
+//===--------------------------------------------------------------------===//
+template <>
+string_t StringCast::Operation(bool input, Vector &vector) {
+	if (input) {
+		return StringVector::AddString(vector, "true", 4);
+	} else {
+		return StringVector::AddString(vector, "false", 5);
+	}
+}
+
+template <>
+string_t StringCast::Operation(int8_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<int8_t, uint8_t>(input, vector);
+}
+
+template <>
+string_t StringCast::Operation(int16_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<int16_t, uint16_t>(input, vector);
+}
+template <>
+string_t StringCast::Operation(int32_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<int32_t, uint32_t>(input, vector);
+}
+
+template <>
+string_t StringCast::Operation(int64_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<int64_t, uint64_t>(input, vector);
+}
+template <>
+duckdb::string_t StringCast::Operation(uint8_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<uint8_t, uint64_t>(input, vector);
+}
+template <>
+duckdb::string_t StringCast::Operation(uint16_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<uint16_t, uint64_t>(input, vector);
+}
+template <>
+duckdb::string_t StringCast::Operation(uint32_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<uint32_t, uint64_t>(input, vector);
+}
+template <>
+duckdb::string_t StringCast::Operation(uint64_t input, Vector &vector) {
+	return NumericHelper::FormatSigned<uint64_t, uint64_t>(input, vector);
+}
+
+template <>
+string_t StringCast::Operation(float input, Vector &vector) {
+	std::string s = duckdb_fmt::format("{}", input);
+	return StringVector::AddString(vector, s);
+}
+
+template <>
+string_t StringCast::Operation(double input, Vector &vector) {
+	std::string s = duckdb_fmt::format("{}", input);
+	return StringVector::AddString(vector, s);
+}
+
+template <>
+string_t StringCast::Operation(interval_t input, Vector &vector) {
+	char buffer[70];
+	idx_t length = IntervalToStringCast::Format(input, buffer);
+	return StringVector::AddString(vector, buffer, length);
+}
+
+template <>
+duckdb::string_t StringCast::Operation(hugeint_t input, Vector &vector) {
+	return HugeintToStringCast::FormatSigned(input, vector);
+}
+
+template <>
+duckdb::string_t StringCast::Operation(date_t input, Vector &vector) {
+	if (input == date_t::infinity()) {
+		return StringVector::AddString(vector, Date::PINF);
+	} else if (input == date_t::ninfinity()) {
+		return StringVector::AddString(vector, Date::NINF);
+	}
+	int32_t date[3];
+	Date::Convert(input, date[0], date[1], date[2]);
+
+	idx_t year_length;
+	bool add_bc;
+	idx_t length = DateToStringCast::Length(date, year_length, add_bc);
+
+	string_t result = StringVector::EmptyString(vector, length);
+	auto data = result.GetDataWriteable();
+
+	DateToStringCast::Format(data, date, year_length, add_bc);
+
+	result.Finalize();
+	return result;
+}
+
+template <>
+duckdb::string_t StringCast::Operation(dtime_t input, Vector &vector) {
+	int32_t time[4];
+	Time::Convert(input, time[0], time[1], time[2], time[3]);
+
+	char micro_buffer[10];
+	idx_t length = TimeToStringCast::Length(time, micro_buffer);
+
+	string_t result = StringVector::EmptyString(vector, length);
+	auto data = result.GetDataWriteable();
+
+	TimeToStringCast::Format(data, length, time, micro_buffer);
+
+	result.Finalize();
+	return result;
+}
+
+template <>
+duckdb::string_t StringCast::Operation(timestamp_t input, Vector &vector) {
+	if (input == timestamp_t::infinity()) {
+		return StringVector::AddString(vector, Date::PINF);
+	} else if (input == timestamp_t::ninfinity()) {
+		return StringVector::AddString(vector, Date::NINF);
+	}
+	date_t date_entry;
+	dtime_t time_entry;
+	Timestamp::Convert(input, date_entry, time_entry);
+
+	int32_t date[3], time[4];
+	Date::Convert(date_entry, date[0], date[1], date[2]);
+	Time::Convert(time_entry, time[0], time[1], time[2], time[3]);
+
+	// format for timestamp is DATE TIME (separated by space)
+	idx_t year_length;
+	bool add_bc;
+	char micro_buffer[6];
+	idx_t date_length = DateToStringCast::Length(date, year_length, add_bc);
+	idx_t time_length = TimeToStringCast::Length(time, micro_buffer);
+	idx_t length = date_length + time_length + 1;
+
+	string_t result = StringVector::EmptyString(vector, length);
+	auto data = result.GetDataWriteable();
+
+	DateToStringCast::Format(data, date, year_length, add_bc);
+	data[date_length] = ' ';
+	TimeToStringCast::Format(data + date_length + 1, time_length, time, micro_buffer);
+
+	result.Finalize();
+	return result;
+}
+
+template <>
+duckdb::string_t StringCast::Operation(duckdb::string_t input, Vector &result) {
+	return StringVector::AddStringOrBlob(result, input);
+}
+
+template <>
+string_t StringCastTZ::Operation(dtime_t input, Vector &vector) {
+	int32_t time[4];
+	Time::Convert(input, time[0], time[1], time[2], time[3]);
+
+	// format for timetz is TIME+00
+	char micro_buffer[10];
+	const auto time_length = TimeToStringCast::Length(time, micro_buffer);
+	const idx_t length = time_length + 3;
+
+	string_t result = StringVector::EmptyString(vector, length);
+	auto data = result.GetDataWriteable();
+
+	idx_t pos = 0;
+	TimeToStringCast::Format(data + pos, length, time, micro_buffer);
+	pos += time_length;
+	data[pos++] = '+';
+	data[pos++] = '0';
+	data[pos++] = '0';
+
+	result.Finalize();
+	return result;
+}
+
+template <>
+string_t StringCastTZ::Operation(timestamp_t input, Vector &vector) {
+	if (input == timestamp_t::infinity()) {
+		return StringVector::AddString(vector, Date::PINF);
+	} else if (input == timestamp_t::ninfinity()) {
+		return StringVector::AddString(vector, Date::NINF);
+	}
+	date_t date_entry;
+	dtime_t time_entry;
+	Timestamp::Convert(input, date_entry, time_entry);
+
+	int32_t date[3], time[4];
+	Date::Convert(date_entry, date[0], date[1], date[2]);
+	Time::Convert(time_entry, time[0], time[1], time[2], time[3]);
+
+	// format for timestamptz is DATE TIME+00 (separated by space)
+	idx_t year_length;
+	bool add_bc;
+	char micro_buffer[6];
+	const idx_t date_length = DateToStringCast::Length(date, year_length, add_bc);
+	const idx_t time_length = TimeToStringCast::Length(time, micro_buffer);
+	const idx_t length = date_length + 1 + time_length + 3;
+
+	string_t result = StringVector::EmptyString(vector, length);
+	auto data = result.GetDataWriteable();
+
+	idx_t pos = 0;
+	DateToStringCast::Format(data + pos, date, year_length, add_bc);
+	pos += date_length;
+	data[pos++] = ' ';
+	TimeToStringCast::Format(data + pos, time_length, time, micro_buffer);
+	pos += time_length;
+	data[pos++] = '+';
+	data[pos++] = '0';
+	data[pos++] = '0';
+
+	result.Finalize();
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+class PipeFile : public FileHandle {
+public:
+	PipeFile(unique_ptr<FileHandle> child_handle_p, const string &path)
+	    : FileHandle(pipe_fs, path), child_handle(move(child_handle_p)) {
+	}
+
+	PipeFileSystem pipe_fs;
+	unique_ptr<FileHandle> child_handle;
+
+public:
+	int64_t ReadChunk(void *buffer, int64_t nr_bytes);
+	int64_t WriteChunk(void *buffer, int64_t nr_bytes);
+
+	void Close() override {
+	}
+};
+
+int64_t PipeFile::ReadChunk(void *buffer, int64_t nr_bytes) {
+	return child_handle->Read(buffer, nr_bytes);
+}
+int64_t PipeFile::WriteChunk(void *buffer, int64_t nr_bytes) {
+	return child_handle->Write(buffer, nr_bytes);
+}
+
+void PipeFileSystem::Reset(FileHandle &handle) {
+	throw InternalException("Cannot reset pipe file system");
+}
+
+int64_t PipeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &pipe = (PipeFile &)handle;
+	return pipe.ReadChunk(buffer, nr_bytes);
+}
+
+int64_t PipeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &pipe = (PipeFile &)handle;
+	return pipe.WriteChunk(buffer, nr_bytes);
+}
+
+int64_t PipeFileSystem::GetFileSize(FileHandle &handle) {
+	return 0;
+}
+
+void PipeFileSystem::FileSync(FileHandle &handle) {
+}
+
+unique_ptr<FileHandle> PipeFileSystem::OpenPipe(unique_ptr<FileHandle> handle) {
+	auto path = handle->path;
+	return make_unique<PipeFile>(move(handle), path);
+}
+
+} // namespace duckdb
+
+
+
+
+#include <stdio.h>
+
+#ifndef DUCKDB_DISABLE_PRINT
+#ifdef DUCKDB_WINDOWS
+#include <io.h>
+#endif
+#endif
+
+namespace duckdb {
+
+// LCOV_EXCL_START
+void Printer::Print(const string &str) {
+#ifndef DUCKDB_DISABLE_PRINT
+#ifdef DUCKDB_WINDOWS
+	if (IsTerminal()) {
+		// print utf8 to terminal
+		auto unicode = WindowsUtil::UTF8ToMBCS(str.c_str());
+		fprintf(stderr, "%s\n", unicode.c_str());
+		return;
+	}
+#endif
+	fprintf(stderr, "%s\n", str.c_str());
+#endif
+}
+
+void Printer::PrintProgress(int percentage, const char *pbstr, int pbwidth) {
+#ifndef DUCKDB_DISABLE_PRINT
+	int lpad = (int)(percentage / 100.0 * pbwidth);
+	int rpad = pbwidth - lpad;
+	printf("\r%3d%% [%.*s%*s]", percentage, lpad, pbstr, rpad, "");
+	fflush(stdout);
+#endif
+}
+
+void Printer::FinishProgressBarPrint(const char *pbstr, int pbwidth) {
+#ifndef DUCKDB_DISABLE_PRINT
+	PrintProgress(100, pbstr, pbwidth);
+	printf(" \n");
+	fflush(stdout);
+#endif
+}
+
+bool Printer::IsTerminal() {
+#ifndef DUCKDB_DISABLE_PRINT
+#ifdef DUCKDB_WINDOWS
+	return GetFileType(GetStdHandle(STD_ERROR_HANDLE)) == FILE_TYPE_CHAR;
+#else
+	throw InternalException("IsTerminal is only implemented for Windows");
+#endif
+#endif
+	return false;
+}
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+ProgressBar::ProgressBar(Executor &executor, idx_t show_progress_after, bool print_progress)
+    : executor(executor), show_progress_after(show_progress_after), current_percentage(-1),
+      print_progress(print_progress) {
+}
+
+double ProgressBar::GetCurrentPercentage() {
+	return current_percentage;
+}
+
+void ProgressBar::Start() {
+	profiler.Start();
+	current_percentage = 0;
+	supported = true;
+}
+
+void ProgressBar::Update(bool final) {
+	if (!supported) {
+		return;
+	}
+	double new_percentage;
+	supported = executor.GetPipelinesProgress(new_percentage);
+	if (!supported) {
+		return;
+	}
+	auto sufficient_time_elapsed = profiler.Elapsed() > show_progress_after / 1000.0;
+	if (new_percentage > current_percentage) {
+		current_percentage = new_percentage;
+	}
+	if (supported && print_progress && sufficient_time_elapsed && current_percentage > -1 && print_progress) {
+		if (final) {
+			Printer::FinishProgressBarPrint(PROGRESS_BAR_STRING.c_str(), PROGRESS_BAR_WIDTH);
+		} else {
+			Printer::PrintProgress(current_percentage, PROGRESS_BAR_STRING.c_str(), PROGRESS_BAR_WIDTH);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+#include <random>
+
+namespace duckdb {
+
+struct RandomState {
+	RandomState() {
+	}
+
+	pcg32 pcg;
+};
+
+RandomEngine::RandomEngine(int64_t seed) : random_state(make_unique<RandomState>()) {
+	if (seed < 0) {
+		random_state->pcg.seed(pcg_extras::seed_seq_from<std::random_device>());
+	} else {
+		random_state->pcg.seed(seed);
+	}
+}
+
+RandomEngine::~RandomEngine() {
+}
+
+double RandomEngine::NextRandom(double min, double max) {
+	D_ASSERT(max >= min);
+	return min + (NextRandom() * (max - min));
+}
+
+double RandomEngine::NextRandom() {
+	return random_state->pcg() / double(std::numeric_limits<uint32_t>::max());
+}
+uint32_t RandomEngine::NextRandomInteger() {
+	return random_state->pcg();
+}
+
+void RandomEngine::SetSeed(uint32_t seed) {
+	random_state->pcg.seed(seed);
+}
+
+} // namespace duckdb
+#include <vector>
+#include <memory>
+
+
+
+
+namespace duckdb_re2 {
+
+Regex::Regex(const std::string &pattern, RegexOptions options) {
+	RE2::Options o;
+	o.set_case_sensitive(options == RegexOptions::CASE_INSENSITIVE);
+	regex = std::make_shared<duckdb_re2::RE2>(StringPiece(pattern), o);
+}
+
+bool RegexSearchInternal(const char *input, Match &match, const Regex &r, RE2::Anchor anchor, size_t start,
+                         size_t end) {
+	auto &regex = r.GetRegex();
+	std::vector<StringPiece> target_groups;
+	auto group_count = regex.NumberOfCapturingGroups() + 1;
+	target_groups.resize(group_count);
+	match.groups.clear();
+	if (!regex.Match(StringPiece(input), start, end, anchor, target_groups.data(), group_count)) {
+		return false;
+	}
+	for (auto &group : target_groups) {
+		GroupMatch group_match;
+		group_match.text = group.ToString();
+		group_match.position = group.data() - input;
+		match.groups.emplace_back(group_match);
+	}
+	return true;
+}
+
+bool RegexSearch(const std::string &input, Match &match, const Regex &regex) {
+	return RegexSearchInternal(input.c_str(), match, regex, RE2::UNANCHORED, 0, input.size());
+}
+
+bool RegexMatch(const std::string &input, Match &match, const Regex &regex) {
+	return RegexSearchInternal(input.c_str(), match, regex, RE2::ANCHOR_BOTH, 0, input.size());
+}
+
+bool RegexMatch(const char *start, const char *end, Match &match, const Regex &regex) {
+	return RegexSearchInternal(start, match, regex, RE2::ANCHOR_BOTH, 0, end - start);
+}
+
+bool RegexMatch(const std::string &input, const Regex &regex) {
+	Match nop_match;
+	return RegexSearchInternal(input.c_str(), nop_match, regex, RE2::ANCHOR_BOTH, 0, input.size());
+}
+
+std::vector<Match> RegexFindAll(const std::string &input, const Regex &regex) {
+	std::vector<Match> matches;
+	size_t position = 0;
+	Match match;
+	while (RegexSearchInternal(input.c_str(), match, regex, RE2::UNANCHORED, position, input.size())) {
+		position += match.position(0) + match.length(0);
+		matches.emplace_back(std::move(match));
+	}
+	return matches;
+}
+
+} // namespace duckdb_re2
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/row_operations/row_aggregate.cpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+
+namespace duckdb {
+
+void RowOperations::InitializeStates(RowLayout &layout, Vector &addresses, const SelectionVector &sel, idx_t count) {
+	if (count == 0) {
+		return;
+	}
+	auto pointers = FlatVector::GetData<data_ptr_t>(addresses);
+	auto &offsets = layout.GetOffsets();
+	auto aggr_idx = layout.ColumnCount();
+
+	for (auto &aggr : layout.GetAggregates()) {
+		for (idx_t i = 0; i < count; ++i) {
+			auto row_idx = sel.get_index(i);
+			auto row = pointers[row_idx];
+			aggr.function.initialize(row + offsets[aggr_idx]);
+		}
+		++aggr_idx;
+	}
+}
+
+void RowOperations::DestroyStates(RowLayout &layout, Vector &addresses, idx_t count) {
+	if (count == 0) {
+		return;
+	}
+	//	Move to the first aggregate state
+	VectorOperations::AddInPlace(addresses, layout.GetAggrOffset(), count);
+	for (auto &aggr : layout.GetAggregates()) {
+		if (aggr.function.destructor) {
+			aggr.function.destructor(addresses, count);
+		}
+		// Move to the next aggregate state
+		VectorOperations::AddInPlace(addresses, aggr.payload_size, count);
+	}
+}
+
+void RowOperations::UpdateStates(AggregateObject &aggr, Vector &addresses, DataChunk &payload, idx_t arg_idx,
+                                 idx_t count) {
+	AggregateInputData aggr_input_data(aggr.bind_data);
+	aggr.function.update(aggr.child_count == 0 ? nullptr : &payload.data[arg_idx], aggr_input_data, aggr.child_count,
+	                     addresses, count);
+}
+
+void RowOperations::UpdateFilteredStates(AggregateObject &aggr, Vector &addresses, DataChunk &payload, idx_t arg_idx) {
+	ExpressionExecutor filter_execution(aggr.filter);
+	SelectionVector true_sel(STANDARD_VECTOR_SIZE);
+	auto count = filter_execution.SelectExpression(payload, true_sel);
+
+	DataChunk filtered_payload;
+	auto pay_types = payload.GetTypes();
+	filtered_payload.Initialize(pay_types);
+	filtered_payload.Slice(payload, true_sel, count);
+
+	Vector filtered_addresses(addresses, true_sel, count);
+	filtered_addresses.Normalify(count);
+
+	UpdateStates(aggr, filtered_addresses, filtered_payload, arg_idx, filtered_payload.size());
+}
+
+void RowOperations::CombineStates(RowLayout &layout, Vector &sources, Vector &targets, idx_t count) {
+	if (count == 0) {
+		return;
+	}
+
+	//	Move to the first aggregate states
+	VectorOperations::AddInPlace(sources, layout.GetAggrOffset(), count);
+	VectorOperations::AddInPlace(targets, layout.GetAggrOffset(), count);
+	for (auto &aggr : layout.GetAggregates()) {
+		D_ASSERT(aggr.function.combine);
+		AggregateInputData aggr_input_data(aggr.bind_data);
+		aggr.function.combine(sources, targets, aggr_input_data, count);
+
+		// Move to the next aggregate states
+		VectorOperations::AddInPlace(sources, aggr.payload_size, count);
+		VectorOperations::AddInPlace(targets, aggr.payload_size, count);
+	}
+}
+
+void RowOperations::FinalizeStates(RowLayout &layout, Vector &addresses, DataChunk &result, idx_t aggr_idx) {
+	//	Move to the first aggregate state
+	VectorOperations::AddInPlace(addresses, layout.GetAggrOffset(), result.size());
+
+	auto &aggregates = layout.GetAggregates();
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		auto &target = result.data[aggr_idx + i];
+		auto &aggr = aggregates[i];
+		AggregateInputData aggr_input_data(aggr.bind_data);
+		aggr.function.finalize(addresses, aggr_input_data, target, result.size(), 0);
+
+		// Move to the next aggregate state
+		VectorOperations::AddInPlace(addresses, aggr.payload_size, result.size());
+	}
+}
+
+} // namespace duckdb
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/row_operations/row_external.cpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+namespace duckdb {
+
+void RowOperations::SwizzleColumns(const RowLayout &layout, const data_ptr_t base_row_ptr, const idx_t count) {
+	const idx_t row_width = layout.GetRowWidth();
+	data_ptr_t heap_row_ptrs[STANDARD_VECTOR_SIZE];
+	idx_t done = 0;
+	while (done != count) {
+		const idx_t next = MinValue<idx_t>(count - done, STANDARD_VECTOR_SIZE);
+		const data_ptr_t row_ptr = base_row_ptr + done * row_width;
+		// Load heap row pointers
+		data_ptr_t heap_ptr_ptr = row_ptr + layout.GetHeapPointerOffset();
+		for (idx_t i = 0; i < next; i++) {
+			heap_row_ptrs[i] = Load<data_ptr_t>(heap_ptr_ptr);
+			heap_ptr_ptr += row_width;
+		}
+		// Loop through the blob columns
+		for (idx_t col_idx = 0; col_idx < layout.ColumnCount(); col_idx++) {
+			auto physical_type = layout.GetTypes()[col_idx].InternalType();
+			if (TypeIsConstantSize(physical_type)) {
+				continue;
+			}
+			data_ptr_t col_ptr = row_ptr + layout.GetOffsets()[col_idx];
+			if (physical_type == PhysicalType::VARCHAR) {
+				data_ptr_t string_ptr = col_ptr + sizeof(uint32_t) + string_t::PREFIX_LENGTH;
+				for (idx_t i = 0; i < next; i++) {
+					if (Load<uint32_t>(col_ptr) > string_t::INLINE_LENGTH) {
+						// Overwrite the string pointer with the within-row offset (if not inlined)
+						Store<idx_t>(Load<data_ptr_t>(string_ptr) - heap_row_ptrs[i], string_ptr);
+					}
+					col_ptr += row_width;
+					string_ptr += row_width;
+				}
+			} else {
+				// Non-varchar blob columns
+				for (idx_t i = 0; i < next; i++) {
+					// Overwrite the column data pointer with the within-row offset
+					Store<idx_t>(Load<data_ptr_t>(col_ptr) - heap_row_ptrs[i], col_ptr);
+					col_ptr += row_width;
+				}
+			}
+		}
+		done += next;
+	}
+}
+
+void RowOperations::SwizzleHeapPointer(const RowLayout &layout, data_ptr_t row_ptr, const data_ptr_t heap_base_ptr,
+                                       const idx_t count) {
+	const idx_t row_width = layout.GetRowWidth();
+	row_ptr += layout.GetHeapPointerOffset();
+	idx_t cumulative_offset = 0;
+	for (idx_t i = 0; i < count; i++) {
+		Store<idx_t>(cumulative_offset, row_ptr);
+		cumulative_offset += Load<uint32_t>(heap_base_ptr + cumulative_offset);
+		row_ptr += row_width;
+	}
+}
+
+void RowOperations::UnswizzlePointers(const RowLayout &layout, const data_ptr_t base_row_ptr,
+                                      const data_ptr_t base_heap_ptr, const idx_t count) {
+	const idx_t row_width = layout.GetRowWidth();
+	data_ptr_t heap_row_ptrs[STANDARD_VECTOR_SIZE];
+	idx_t done = 0;
+	while (done != count) {
+		const idx_t next = MinValue<idx_t>(count - done, STANDARD_VECTOR_SIZE);
+		const data_ptr_t row_ptr = base_row_ptr + done * row_width;
+		// Restore heap row pointers
+		data_ptr_t heap_ptr_ptr = row_ptr + layout.GetHeapPointerOffset();
+		for (idx_t i = 0; i < next; i++) {
+			heap_row_ptrs[i] = base_heap_ptr + Load<idx_t>(heap_ptr_ptr);
+			Store<data_ptr_t>(heap_row_ptrs[i], heap_ptr_ptr);
+			heap_ptr_ptr += row_width;
+		}
+		// Loop through the blob columns
+		for (idx_t col_idx = 0; col_idx < layout.ColumnCount(); col_idx++) {
+			auto physical_type = layout.GetTypes()[col_idx].InternalType();
+			if (TypeIsConstantSize(physical_type)) {
+				continue;
+			}
+			data_ptr_t col_ptr = row_ptr + layout.GetOffsets()[col_idx];
+			if (physical_type == PhysicalType::VARCHAR) {
+				data_ptr_t string_ptr = col_ptr + sizeof(uint32_t) + string_t::PREFIX_LENGTH;
+				for (idx_t i = 0; i < next; i++) {
+					if (Load<uint32_t>(col_ptr) > string_t::INLINE_LENGTH) {
+						// Overwrite the string offset with the pointer (if not inlined)
+						Store<data_ptr_t>(heap_row_ptrs[i] + Load<idx_t>(string_ptr), string_ptr);
+					}
+					col_ptr += row_width;
+					string_ptr += row_width;
+				}
+			} else {
+				// Non-varchar blob columns
+				for (idx_t i = 0; i < next; i++) {
+					// Overwrite the column data offset with the pointer
+					Store<data_ptr_t>(heap_row_ptrs[i] + Load<idx_t>(col_ptr), col_ptr);
+					col_ptr += row_width;
+				}
+			}
+		}
+		done += next;
+	}
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// row_gather.cpp
+// Description: This file contains the implementation of the gather operators
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = RowLayout::ValidityBytes;
+
+template <class T>
+static void TemplatedGatherLoop(Vector &rows, const SelectionVector &row_sel, Vector &col,
+                                const SelectionVector &col_sel, idx_t count, idx_t col_offset, idx_t col_no,
+                                idx_t build_size) {
+	// Precompute mask indexes
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
+
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	auto data = FlatVector::GetData<T>(col);
+	auto &col_mask = FlatVector::Validity(col);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto row_idx = row_sel.get_index(i);
+		auto row = ptrs[row_idx];
+		auto col_idx = col_sel.get_index(i);
+		data[col_idx] = Load<T>(row + col_offset);
+		ValidityBytes row_mask(row);
+		if (!row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry)) {
+			if (build_size > STANDARD_VECTOR_SIZE && col_mask.AllValid()) {
+				//! We need to initialize the mask with the vector size.
+				col_mask.Initialize(build_size);
+			}
+			col_mask.SetInvalid(col_idx);
+		}
+	}
+}
+
+static void GatherNestedVector(Vector &rows, const SelectionVector &row_sel, Vector &col,
+                               const SelectionVector &col_sel, idx_t count, idx_t col_offset, idx_t col_no) {
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+
+	// Build the gather locations
+	auto data_locations = unique_ptr<data_ptr_t[]>(new data_ptr_t[count]);
+	auto mask_locations = unique_ptr<data_ptr_t[]>(new data_ptr_t[count]);
+	for (idx_t i = 0; i < count; i++) {
+		auto row_idx = row_sel.get_index(i);
+		mask_locations[i] = ptrs[row_idx];
+		data_locations[i] = Load<data_ptr_t>(ptrs[row_idx] + col_offset);
+	}
+
+	// Deserialise into the selected locations
+	RowOperations::HeapGather(col, count, col_sel, col_no, data_locations.get(), mask_locations.get());
+}
+
+void RowOperations::Gather(Vector &rows, const SelectionVector &row_sel, Vector &col, const SelectionVector &col_sel,
+                           const idx_t count, const idx_t col_offset, const idx_t col_no, const idx_t build_size) {
+	D_ASSERT(rows.GetVectorType() == VectorType::FLAT_VECTOR);
+	D_ASSERT(rows.GetType().id() == LogicalTypeId::POINTER); // "Cannot gather from non-pointer type!"
+
+	col.SetVectorType(VectorType::FLAT_VECTOR);
+	switch (col.GetType().InternalType()) {
+	case PhysicalType::UINT8:
+		TemplatedGatherLoop<uint8_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedGatherLoop<uint16_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedGatherLoop<uint32_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedGatherLoop<uint64_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedGatherLoop<int8_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::INT16:
+		TemplatedGatherLoop<int16_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::INT32:
+		TemplatedGatherLoop<int32_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::INT64:
+		TemplatedGatherLoop<int64_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::INT128:
+		TemplatedGatherLoop<hugeint_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedGatherLoop<float>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedGatherLoop<double>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedGatherLoop<interval_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedGatherLoop<string_t>(rows, row_sel, col, col_sel, count, col_offset, col_no, build_size);
+		break;
+	case PhysicalType::LIST:
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		GatherNestedVector(rows, row_sel, col, col_sel, count, col_offset, col_no);
+		break;
+	default:
+		throw InternalException("Unimplemented type for RowOperations::Gather");
+	}
+}
+
+template <class T>
+static void TemplatedFullScanLoop(Vector &rows, Vector &col, idx_t count, idx_t col_offset, idx_t col_no) {
+	// Precompute mask indexes
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
+
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	auto data = FlatVector::GetData<T>(col);
+	//	auto &col_mask = FlatVector::Validity(col);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto row = ptrs[i];
+		data[i] = Load<T>(row + col_offset);
+		ValidityBytes row_mask(row);
+		if (!row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry)) {
+			throw InternalException("Null value comparisons not implemented for perfect hash table yet");
+			//			col_mask.SetInvalid(i);
+		}
+	}
+}
+
+void RowOperations::FullScanColumn(const RowLayout &layout, Vector &rows, Vector &col, idx_t count, idx_t col_no) {
+	const auto col_offset = layout.GetOffsets()[col_no];
+	col.SetVectorType(VectorType::FLAT_VECTOR);
+	switch (col.GetType().InternalType()) {
+	case PhysicalType::UINT8:
+		TemplatedFullScanLoop<uint8_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedFullScanLoop<uint16_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedFullScanLoop<uint32_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedFullScanLoop<uint64_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::INT8:
+		TemplatedFullScanLoop<int8_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::INT16:
+		TemplatedFullScanLoop<int16_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::INT32:
+		TemplatedFullScanLoop<int32_t>(rows, col, count, col_offset, col_no);
+		break;
+	case PhysicalType::INT64:
+		TemplatedFullScanLoop<int64_t>(rows, col, count, col_offset, col_no);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for RowOperations::FullScanColumn");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = TemplatedValidityMask<uint8_t>;
+
+template <class T>
+static void TemplatedHeapGather(Vector &v, const idx_t count, const SelectionVector &sel, data_ptr_t *key_locations) {
+	auto target = FlatVector::GetData<T>(v);
+
+	for (idx_t i = 0; i < count; ++i) {
+		const auto col_idx = sel.get_index(i);
+		target[col_idx] = Load<T>(key_locations[i]);
+		key_locations[i] += sizeof(T);
+	}
+}
+
+static void HeapGatherStringVector(Vector &v, const idx_t vcount, const SelectionVector &sel,
+                                   data_ptr_t *key_locations) {
+	const auto &validity = FlatVector::Validity(v);
+	auto target = FlatVector::GetData<string_t>(v);
+
+	for (idx_t i = 0; i < vcount; i++) {
+		const auto col_idx = sel.get_index(i);
+		if (!validity.RowIsValid(col_idx)) {
+			continue;
+		}
+		auto len = Load<uint32_t>(key_locations[i]);
+		key_locations[i] += sizeof(uint32_t);
+		target[col_idx] = StringVector::AddStringOrBlob(v, string_t((const char *)key_locations[i], len));
+		key_locations[i] += len;
+	}
+}
+
+static void HeapGatherStructVector(Vector &v, const idx_t vcount, const SelectionVector &sel,
+                                   data_ptr_t *key_locations) {
+	// struct must have a validitymask for its fields
+	auto &child_types = StructType::GetChildTypes(v.GetType());
+	const idx_t struct_validitymask_size = (child_types.size() + 7) / 8;
+	data_ptr_t struct_validitymask_locations[STANDARD_VECTOR_SIZE];
+	for (idx_t i = 0; i < vcount; i++) {
+		// use key_locations as the validitymask, and create struct_key_locations
+		struct_validitymask_locations[i] = key_locations[i];
+		key_locations[i] += struct_validitymask_size;
+	}
+
+	// now deserialize into the struct vectors
+	auto &children = StructVector::GetEntries(v);
+	for (idx_t i = 0; i < child_types.size(); i++) {
+		RowOperations::HeapGather(*children[i], vcount, sel, i, key_locations, struct_validitymask_locations);
+	}
+}
+
+static void HeapGatherListVector(Vector &v, const idx_t vcount, const SelectionVector &sel, data_ptr_t *key_locations) {
+	const auto &validity = FlatVector::Validity(v);
+
+	auto child_type = ListType::GetChildType(v.GetType());
+	auto list_data = ListVector::GetData(v);
+	data_ptr_t list_entry_locations[STANDARD_VECTOR_SIZE];
+
+	uint64_t entry_offset = ListVector::GetListSize(v);
+	for (idx_t i = 0; i < vcount; i++) {
+		const auto col_idx = sel.get_index(i);
+		if (!validity.RowIsValid(col_idx)) {
+			continue;
+		}
+		// read list length
+		auto entry_remaining = Load<uint64_t>(key_locations[i]);
+		key_locations[i] += sizeof(uint64_t);
+		// set list entry attributes
+		list_data[col_idx].length = entry_remaining;
+		list_data[col_idx].offset = entry_offset;
+		// skip over the validity mask
+		data_ptr_t validitymask_location = key_locations[i];
+		idx_t offset_in_byte = 0;
+		key_locations[i] += (entry_remaining + 7) / 8;
+		// entry sizes
+		data_ptr_t var_entry_size_ptr = nullptr;
+		if (!TypeIsConstantSize(child_type.InternalType())) {
+			var_entry_size_ptr = key_locations[i];
+			key_locations[i] += entry_remaining * sizeof(idx_t);
+		}
+
+		// now read the list data
+		while (entry_remaining > 0) {
+			auto next = MinValue(entry_remaining, (idx_t)STANDARD_VECTOR_SIZE);
+
+			// initialize a new vector to append
+			Vector append_vector(v.GetType());
+			append_vector.SetVectorType(v.GetVectorType());
+
+			auto &list_vec_to_append = ListVector::GetEntry(append_vector);
+
+			// set validity
+			//! Since we are constructing the vector, this will always be a flat vector.
+			auto &append_validity = FlatVector::Validity(list_vec_to_append);
+			for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+				append_validity.Set(entry_idx, *(validitymask_location) & (1 << offset_in_byte));
+				if (++offset_in_byte == 8) {
+					validitymask_location++;
+					offset_in_byte = 0;
+				}
+			}
+
+			// compute entry sizes and set locations where the list entries are
+			if (TypeIsConstantSize(child_type.InternalType())) {
+				// constant size list entries
+				const idx_t type_size = GetTypeIdSize(child_type.InternalType());
+				for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+					list_entry_locations[entry_idx] = key_locations[i];
+					key_locations[i] += type_size;
+				}
+			} else {
+				// variable size list entries
+				for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+					list_entry_locations[entry_idx] = key_locations[i];
+					key_locations[i] += Load<idx_t>(var_entry_size_ptr);
+					var_entry_size_ptr += sizeof(idx_t);
+				}
+			}
+
+			// now deserialize and add to listvector
+			RowOperations::HeapGather(list_vec_to_append, next, *FlatVector::IncrementalSelectionVector(), 0,
+			                          list_entry_locations, nullptr);
+			ListVector::Append(v, list_vec_to_append, next);
+
+			// update for next iteration
+			entry_remaining -= next;
+			entry_offset += next;
+		}
+	}
+}
+
+void RowOperations::HeapGather(Vector &v, const idx_t &vcount, const SelectionVector &sel, const idx_t &col_no,
+                               data_ptr_t *key_locations, data_ptr_t *validitymask_locations) {
+	v.SetVectorType(VectorType::FLAT_VECTOR);
+
+	auto &validity = FlatVector::Validity(v);
+	if (validitymask_locations) {
+		// Precompute mask indexes
+		idx_t entry_idx;
+		idx_t idx_in_entry;
+		ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
+
+		for (idx_t i = 0; i < vcount; i++) {
+			ValidityBytes row_mask(validitymask_locations[i]);
+			const auto valid = row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry);
+			const auto col_idx = sel.get_index(i);
+			validity.Set(col_idx, valid);
+		}
+	}
+
+	auto type = v.GetType().InternalType();
+	switch (type) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedHeapGather<int8_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::INT16:
+		TemplatedHeapGather<int16_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::INT32:
+		TemplatedHeapGather<int32_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::INT64:
+		TemplatedHeapGather<int64_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedHeapGather<uint8_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedHeapGather<uint16_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedHeapGather<uint32_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedHeapGather<uint64_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::INT128:
+		TemplatedHeapGather<hugeint_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedHeapGather<float>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedHeapGather<double>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedHeapGather<interval_t>(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::VARCHAR:
+		HeapGatherStringVector(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::STRUCT:
+		HeapGatherStructVector(v, vcount, sel, key_locations);
+		break;
+	case PhysicalType::LIST:
+		HeapGatherListVector(v, vcount, sel, key_locations);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented deserialize from row-format");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = TemplatedValidityMask<uint8_t>;
+
+static void ComputeStringEntrySizes(VectorData &vdata, idx_t entry_sizes[], const idx_t ser_count,
+                                    const SelectionVector &sel, const idx_t offset) {
+	auto strings = (string_t *)vdata.data;
+	for (idx_t i = 0; i < ser_count; i++) {
+		auto idx = sel.get_index(i);
+		auto str_idx = vdata.sel->get_index(idx) + offset;
+		if (vdata.validity.RowIsValid(str_idx)) {
+			entry_sizes[i] += sizeof(uint32_t) + strings[str_idx].GetSize();
+		}
+	}
+}
+
+static void ComputeStructEntrySizes(Vector &v, idx_t entry_sizes[], idx_t vcount, idx_t ser_count,
+                                    const SelectionVector &sel, idx_t offset) {
+	// obtain child vectors
+	idx_t num_children;
+	auto &children = StructVector::GetEntries(v);
+	num_children = children.size();
+	// add struct validitymask size
+	const idx_t struct_validitymask_size = (num_children + 7) / 8;
+	for (idx_t i = 0; i < ser_count; i++) {
+		entry_sizes[i] += struct_validitymask_size;
+	}
+	// compute size of child vectors
+	for (auto &struct_vector : children) {
+		RowOperations::ComputeEntrySizes(*struct_vector, entry_sizes, vcount, ser_count, sel, offset);
+	}
+}
+
+static void ComputeListEntrySizes(Vector &v, VectorData &vdata, idx_t entry_sizes[], idx_t ser_count,
+                                  const SelectionVector &sel, idx_t offset) {
+	auto list_data = ListVector::GetData(v);
+	auto &child_vector = ListVector::GetEntry(v);
+	idx_t list_entry_sizes[STANDARD_VECTOR_SIZE];
+	for (idx_t i = 0; i < ser_count; i++) {
+		auto idx = sel.get_index(i);
+		auto source_idx = vdata.sel->get_index(idx) + offset;
+		if (vdata.validity.RowIsValid(source_idx)) {
+			auto list_entry = list_data[source_idx];
+
+			// make room for list length, list validitymask
+			entry_sizes[i] += sizeof(list_entry.length);
+			entry_sizes[i] += (list_entry.length + 7) / 8;
+
+			// serialize size of each entry (if non-constant size)
+			if (!TypeIsConstantSize(ListType::GetChildType(v.GetType()).InternalType())) {
+				entry_sizes[i] += list_entry.length * sizeof(list_entry.length);
+			}
+
+			// compute size of each the elements in list_entry and sum them
+			auto entry_remaining = list_entry.length;
+			auto entry_offset = list_entry.offset;
+			while (entry_remaining > 0) {
+				// the list entry can span multiple vectors
+				auto next = MinValue((idx_t)STANDARD_VECTOR_SIZE, entry_remaining);
+
+				// compute and add to the total
+				std::fill_n(list_entry_sizes, next, 0);
+				RowOperations::ComputeEntrySizes(child_vector, list_entry_sizes, next, next,
+				                                 *FlatVector::IncrementalSelectionVector(), entry_offset);
+				for (idx_t list_idx = 0; list_idx < next; list_idx++) {
+					entry_sizes[i] += list_entry_sizes[list_idx];
+				}
+
+				// update for next iteration
+				entry_remaining -= next;
+				entry_offset += next;
+			}
+		}
+	}
+}
+
+void RowOperations::ComputeEntrySizes(Vector &v, VectorData &vdata, idx_t entry_sizes[], idx_t vcount, idx_t ser_count,
+                                      const SelectionVector &sel, idx_t offset) {
+	const auto physical_type = v.GetType().InternalType();
+	if (TypeIsConstantSize(physical_type)) {
+		const auto type_size = GetTypeIdSize(physical_type);
+		for (idx_t i = 0; i < ser_count; i++) {
+			entry_sizes[i] += type_size;
+		}
+	} else {
+		switch (physical_type) {
+		case PhysicalType::VARCHAR:
+			ComputeStringEntrySizes(vdata, entry_sizes, ser_count, sel, offset);
+			break;
+		case PhysicalType::STRUCT:
+			ComputeStructEntrySizes(v, entry_sizes, vcount, ser_count, sel, offset);
+			break;
+		case PhysicalType::LIST:
+			ComputeListEntrySizes(v, vdata, entry_sizes, ser_count, sel, offset);
+			break;
+		default:
+			// LCOV_EXCL_START
+			throw NotImplementedException("Column with variable size type %s cannot be serialized to row-format",
+			                              v.GetType().ToString());
+			// LCOV_EXCL_STOP
+		}
+	}
+}
+
+void RowOperations::ComputeEntrySizes(Vector &v, idx_t entry_sizes[], idx_t vcount, idx_t ser_count,
+                                      const SelectionVector &sel, idx_t offset) {
+	VectorData vdata;
+	v.Orrify(vcount, vdata);
+	ComputeEntrySizes(v, vdata, entry_sizes, vcount, ser_count, sel, offset);
+}
+
+template <class T>
+static void TemplatedHeapScatter(VectorData &vdata, const SelectionVector &sel, idx_t count, idx_t col_idx,
+                                 data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+	auto source = (T *)vdata.data;
+	if (!validitymask_locations) {
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+
+			auto target = (T *)key_locations[i];
+			Store<T>(source[source_idx], (data_ptr_t)target);
+			key_locations[i] += sizeof(T);
+		}
+	} else {
+		idx_t entry_idx;
+		idx_t idx_in_entry;
+		ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
+		const auto bit = ~(1UL << idx_in_entry);
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+
+			auto target = (T *)key_locations[i];
+			Store<T>(source[source_idx], (data_ptr_t)target);
+			key_locations[i] += sizeof(T);
+
+			// set the validitymask
+			if (!vdata.validity.RowIsValid(source_idx)) {
+				*(validitymask_locations[i] + entry_idx) &= bit;
+			}
+		}
+	}
+}
+
+static void HeapScatterStringVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_idx,
+                                    data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+	VectorData vdata;
+	v.Orrify(vcount, vdata);
+
+	auto strings = (string_t *)vdata.data;
+	if (!validitymask_locations) {
+		for (idx_t i = 0; i < ser_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			if (vdata.validity.RowIsValid(source_idx)) {
+				auto &string_entry = strings[source_idx];
+				// store string size
+				Store<uint32_t>(string_entry.GetSize(), key_locations[i]);
+				key_locations[i] += sizeof(uint32_t);
+				// store the string
+				memcpy(key_locations[i], string_entry.GetDataUnsafe(), string_entry.GetSize());
+				key_locations[i] += string_entry.GetSize();
+			}
+		}
+	} else {
+		idx_t entry_idx;
+		idx_t idx_in_entry;
+		ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
+		const auto bit = ~(1UL << idx_in_entry);
+		for (idx_t i = 0; i < ser_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			if (vdata.validity.RowIsValid(source_idx)) {
+				auto &string_entry = strings[source_idx];
+				// store string size
+				Store<uint32_t>(string_entry.GetSize(), key_locations[i]);
+				key_locations[i] += sizeof(uint32_t);
+				// store the string
+				memcpy(key_locations[i], string_entry.GetDataUnsafe(), string_entry.GetSize());
+				key_locations[i] += string_entry.GetSize();
+			} else {
+				// set the validitymask
+				*(validitymask_locations[i] + entry_idx) &= bit;
+			}
+		}
+	}
+}
+
+static void HeapScatterStructVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_idx,
+                                    data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+	VectorData vdata;
+	v.Orrify(vcount, vdata);
+
+	auto &children = StructVector::GetEntries(v);
+	idx_t num_children = children.size();
+
+	// the whole struct itself can be NULL
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
+	const auto bit = ~(1UL << idx_in_entry);
+
+	// struct must have a validitymask for its fields
+	const idx_t struct_validitymask_size = (num_children + 7) / 8;
+	data_ptr_t struct_validitymask_locations[STANDARD_VECTOR_SIZE];
+	for (idx_t i = 0; i < ser_count; i++) {
+		// initialize the struct validity mask
+		struct_validitymask_locations[i] = key_locations[i];
+		memset(struct_validitymask_locations[i], -1, struct_validitymask_size);
+		key_locations[i] += struct_validitymask_size;
+
+		// set whether the whole struct is null
+		auto idx = sel.get_index(i);
+		auto source_idx = vdata.sel->get_index(idx) + offset;
+		if (validitymask_locations && !vdata.validity.RowIsValid(source_idx)) {
+			*(validitymask_locations[i] + entry_idx) &= bit;
+		}
+	}
+
+	// now serialize the struct vectors
+	for (idx_t i = 0; i < children.size(); i++) {
+		auto &struct_vector = *children[i];
+		RowOperations::HeapScatter(struct_vector, vcount, sel, ser_count, i, key_locations,
+		                           struct_validitymask_locations, offset);
+	}
+}
+
+static void HeapScatterListVector(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_no,
+                                  data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+	VectorData vdata;
+	v.Orrify(vcount, vdata);
+
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
+
+	auto list_data = ListVector::GetData(v);
+
+	auto &child_vector = ListVector::GetEntry(v);
+
+	VectorData list_vdata;
+	child_vector.Orrify(ListVector::GetListSize(v), list_vdata);
+	auto child_type = ListType::GetChildType(v.GetType()).InternalType();
+
+	idx_t list_entry_sizes[STANDARD_VECTOR_SIZE];
+	data_ptr_t list_entry_locations[STANDARD_VECTOR_SIZE];
+
+	for (idx_t i = 0; i < ser_count; i++) {
+		auto idx = sel.get_index(i);
+		auto source_idx = vdata.sel->get_index(idx) + offset;
+		if (!vdata.validity.RowIsValid(source_idx)) {
+			if (validitymask_locations) {
+				// set the row validitymask for this column to invalid
+				ValidityBytes row_mask(validitymask_locations[i]);
+				row_mask.SetInvalidUnsafe(entry_idx, idx_in_entry);
+			}
+			continue;
+		}
+		auto list_entry = list_data[source_idx];
+
+		// store list length
+		Store<uint64_t>(list_entry.length, key_locations[i]);
+		key_locations[i] += sizeof(list_entry.length);
+
+		// make room for the validitymask
+		data_ptr_t list_validitymask_location = key_locations[i];
+		idx_t entry_offset_in_byte = 0;
+		idx_t validitymask_size = (list_entry.length + 7) / 8;
+		memset(list_validitymask_location, -1, validitymask_size);
+		key_locations[i] += validitymask_size;
+
+		// serialize size of each entry (if non-constant size)
+		data_ptr_t var_entry_size_ptr = nullptr;
+		if (!TypeIsConstantSize(child_type)) {
+			var_entry_size_ptr = key_locations[i];
+			key_locations[i] += list_entry.length * sizeof(idx_t);
+		}
+
+		auto entry_remaining = list_entry.length;
+		auto entry_offset = list_entry.offset;
+		while (entry_remaining > 0) {
+			// the list entry can span multiple vectors
+			auto next = MinValue((idx_t)STANDARD_VECTOR_SIZE, entry_remaining);
+
+			// serialize list validity
+			for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+				auto list_idx = list_vdata.sel->get_index(entry_idx) + entry_offset;
+				if (!list_vdata.validity.RowIsValid(list_idx)) {
+					*(list_validitymask_location) &= ~(1UL << entry_offset_in_byte);
+				}
+				if (++entry_offset_in_byte == 8) {
+					list_validitymask_location++;
+					entry_offset_in_byte = 0;
+				}
+			}
+
+			if (TypeIsConstantSize(child_type)) {
+				// constant size list entries: set list entry locations
+				const idx_t type_size = GetTypeIdSize(child_type);
+				for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+					list_entry_locations[entry_idx] = key_locations[i];
+					key_locations[i] += type_size;
+				}
+			} else {
+				// variable size list entries: compute entry sizes and set list entry locations
+				std::fill_n(list_entry_sizes, next, 0);
+				RowOperations::ComputeEntrySizes(child_vector, list_entry_sizes, next, next,
+				                                 *FlatVector::IncrementalSelectionVector(), entry_offset);
+				for (idx_t entry_idx = 0; entry_idx < next; entry_idx++) {
+					list_entry_locations[entry_idx] = key_locations[i];
+					key_locations[i] += list_entry_sizes[entry_idx];
+					Store<idx_t>(list_entry_sizes[entry_idx], var_entry_size_ptr);
+					var_entry_size_ptr += sizeof(idx_t);
+				}
+			}
+
+			// now serialize to the locations
+			RowOperations::HeapScatter(child_vector, ListVector::GetListSize(v),
+			                           *FlatVector::IncrementalSelectionVector(), next, 0, list_entry_locations,
+			                           nullptr, entry_offset);
+
+			// update for next iteration
+			entry_remaining -= next;
+			entry_offset += next;
+		}
+	}
+}
+
+void RowOperations::HeapScatter(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count, idx_t col_idx,
+                                data_ptr_t *key_locations, data_ptr_t *validitymask_locations, idx_t offset) {
+	if (TypeIsConstantSize(v.GetType().InternalType())) {
+		VectorData vdata;
+		v.Orrify(vcount, vdata);
+		RowOperations::HeapScatterVData(vdata, v.GetType().InternalType(), sel, ser_count, col_idx, key_locations,
+		                                validitymask_locations, offset);
+	} else {
+		switch (v.GetType().InternalType()) {
+		case PhysicalType::VARCHAR:
+			HeapScatterStringVector(v, vcount, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+			break;
+		case PhysicalType::STRUCT:
+			HeapScatterStructVector(v, vcount, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+			break;
+		case PhysicalType::LIST:
+			HeapScatterListVector(v, vcount, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+			break;
+		default:
+			// LCOV_EXCL_START
+			throw NotImplementedException("Serialization of variable length vector with type %s",
+			                              v.GetType().ToString());
+			// LCOV_EXCL_STOP
+		}
+	}
+}
+
+void RowOperations::HeapScatterVData(VectorData &vdata, PhysicalType type, const SelectionVector &sel, idx_t ser_count,
+                                     idx_t col_idx, data_ptr_t *key_locations, data_ptr_t *validitymask_locations,
+                                     idx_t offset) {
+	switch (type) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedHeapScatter<int8_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::INT16:
+		TemplatedHeapScatter<int16_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::INT32:
+		TemplatedHeapScatter<int32_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::INT64:
+		TemplatedHeapScatter<int64_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedHeapScatter<uint8_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedHeapScatter<uint16_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedHeapScatter<uint32_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedHeapScatter<uint64_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::INT128:
+		TemplatedHeapScatter<hugeint_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedHeapScatter<float>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedHeapScatter<double>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedHeapScatter<interval_t>(vdata, sel, ser_count, col_idx, key_locations, validitymask_locations, offset);
+		break;
+	default:
+		throw NotImplementedException("FIXME: Serialize to of constant type column to row-format");
+	}
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// row_match.cpp
+// Description: This file contains the implementation of the match operators
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = RowLayout::ValidityBytes;
+using Predicates = RowOperations::Predicates;
+
+template <typename OP>
+static idx_t SelectComparison(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                              SelectionVector *true_sel, SelectionVector *false_sel) {
+	throw NotImplementedException("Unsupported nested comparison operand for RowOperations::Match");
+}
+
+template <>
+idx_t SelectComparison<Equals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                               SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::NestedEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t SelectComparison<NotEquals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                  SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::NestedNotEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t SelectComparison<GreaterThan>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                    SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t SelectComparison<GreaterThanEquals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                          SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t SelectComparison<LessThan>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                 SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t SelectComparison<LessThanEquals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                       SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <class T, class OP, bool NO_MATCH_SEL>
+static void TemplatedMatchType(VectorData &col, Vector &rows, SelectionVector &sel, idx_t &count, idx_t col_offset,
+                               idx_t col_no, SelectionVector *no_match, idx_t &no_match_count) {
+	// Precompute row_mask indexes
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_no, entry_idx, idx_in_entry);
+
+	auto data = (T *)col.data;
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	idx_t match_count = 0;
+	if (!col.validity.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+
+			auto row = ptrs[idx];
+			ValidityBytes row_mask(row);
+			auto isnull = !row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry);
+
+			auto col_idx = col.sel->get_index(idx);
+			if (!col.validity.RowIsValid(col_idx)) {
+				if (isnull) {
+					// match: move to next value to compare
+					sel.set_index(match_count++, idx);
+				} else {
+					if (NO_MATCH_SEL) {
+						no_match->set_index(no_match_count++, idx);
+					}
+				}
+			} else {
+				auto value = Load<T>(row + col_offset);
+				if (!isnull && OP::template Operation<T>(data[col_idx], value)) {
+					sel.set_index(match_count++, idx);
+				} else {
+					if (NO_MATCH_SEL) {
+						no_match->set_index(no_match_count++, idx);
+					}
+				}
+			}
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+
+			auto row = ptrs[idx];
+			ValidityBytes row_mask(row);
+			auto isnull = !row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry);
+
+			auto col_idx = col.sel->get_index(idx);
+			auto value = Load<T>(row + col_offset);
+			if (!isnull && OP::template Operation<T>(data[col_idx], value)) {
+				sel.set_index(match_count++, idx);
+			} else {
+				if (NO_MATCH_SEL) {
+					no_match->set_index(no_match_count++, idx);
+				}
+			}
+		}
+	}
+	count = match_count;
+}
+
+template <class OP, bool NO_MATCH_SEL>
+static void TemplatedMatchNested(Vector &col, Vector &rows, SelectionVector &sel, idx_t &count, const idx_t col_offset,
+                                 const idx_t col_no, SelectionVector *no_match, idx_t &no_match_count) {
+	// Gather a dense Vector containing the column values being matched
+	Vector key(col.GetType());
+	RowOperations::Gather(rows, sel, key, *FlatVector::IncrementalSelectionVector(), count, col_offset, col_no);
+
+	// Densify the input column
+	Vector sliced(col, sel, count);
+
+	if (NO_MATCH_SEL) {
+		SelectionVector no_match_sel_offset(no_match->data() + no_match_count);
+		auto match_count = SelectComparison<OP>(sliced, key, sel, count, &sel, &no_match_sel_offset);
+		no_match_count += count - match_count;
+		count = match_count;
+	} else {
+		count = SelectComparison<OP>(sliced, key, sel, count, &sel, nullptr);
+	}
+}
+
+template <class OP, bool NO_MATCH_SEL>
+static void TemplatedMatchOp(Vector &vec, VectorData &col, const RowLayout &layout, Vector &rows, SelectionVector &sel,
+                             idx_t &count, idx_t col_no, SelectionVector *no_match, idx_t &no_match_count) {
+	if (count == 0) {
+		return;
+	}
+	auto col_offset = layout.GetOffsets()[col_no];
+	switch (layout.GetTypes()[col_no].InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedMatchType<int8_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                             no_match_count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedMatchType<int16_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                              no_match_count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedMatchType<int32_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                              no_match_count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedMatchType<int64_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                              no_match_count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedMatchType<uint8_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                              no_match_count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedMatchType<uint16_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                               no_match_count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedMatchType<uint32_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                               no_match_count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedMatchType<uint64_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                               no_match_count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedMatchType<hugeint_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                                no_match_count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedMatchType<float, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                            no_match_count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedMatchType<double, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                             no_match_count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedMatchType<interval_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                                 no_match_count);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedMatchType<string_t, OP, NO_MATCH_SEL>(col, rows, sel, count, col_offset, col_no, no_match,
+		                                               no_match_count);
+		break;
+	case PhysicalType::LIST:
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		TemplatedMatchNested<OP, NO_MATCH_SEL>(vec, rows, sel, count, col_offset, col_no, no_match, no_match_count);
+		break;
+	default:
+		throw InternalException("Unsupported column type for RowOperations::Match");
+	}
+}
+
+template <bool NO_MATCH_SEL>
+static void TemplatedMatch(DataChunk &columns, VectorData col_data[], const RowLayout &layout, Vector &rows,
+                           const Predicates &predicates, SelectionVector &sel, idx_t &count, SelectionVector *no_match,
+                           idx_t &no_match_count) {
+	for (idx_t col_no = 0; col_no < predicates.size(); ++col_no) {
+		auto &vec = columns.data[col_no];
+		auto &col = col_data[col_no];
+		switch (predicates[col_no]) {
+		case ExpressionType::COMPARE_EQUAL:
+		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			TemplatedMatchOp<Equals, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                       no_match_count);
+			break;
+		case ExpressionType::COMPARE_NOTEQUAL:
+			TemplatedMatchOp<NotEquals, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                          no_match_count);
+			break;
+		case ExpressionType::COMPARE_GREATERTHAN:
+			TemplatedMatchOp<GreaterThan, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                            no_match_count);
+			break;
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			TemplatedMatchOp<GreaterThanEquals, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                                  no_match_count);
+			break;
+		case ExpressionType::COMPARE_LESSTHAN:
+			TemplatedMatchOp<LessThan, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                         no_match_count);
+			break;
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			TemplatedMatchOp<LessThanEquals, NO_MATCH_SEL>(vec, col, layout, rows, sel, count, col_no, no_match,
+			                                               no_match_count);
+			break;
+		default:
+			throw InternalException("Unsupported comparison type for RowOperations::Match");
+		}
+	}
+}
+
+idx_t RowOperations::Match(DataChunk &columns, VectorData col_data[], const RowLayout &layout, Vector &rows,
+                           const Predicates &predicates, SelectionVector &sel, idx_t count, SelectionVector *no_match,
+                           idx_t &no_match_count) {
+	if (no_match) {
+		TemplatedMatch<true>(columns, col_data, layout, rows, predicates, sel, count, no_match, no_match_count);
+	} else {
+		TemplatedMatch<false>(columns, col_data, layout, rows, predicates, sel, count, no_match, no_match_count);
+	}
+
+	return count;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+void TemplatedRadixScatter(VectorData &vdata, const SelectionVector &sel, idx_t add_count, data_ptr_t *key_locations,
+                           const bool desc, const bool has_null, const bool nulls_first, const bool is_little_endian,
+                           const idx_t offset) {
+	auto source = (T *)vdata.data;
+	if (has_null) {
+		auto &validity = vdata.validity;
+		const data_t valid = nulls_first ? 1 : 0;
+		const data_t invalid = 1 - valid;
+
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			// write validity and according value
+			if (validity.RowIsValid(source_idx)) {
+				key_locations[i][0] = valid;
+				Radix::EncodeData<T>(key_locations[i] + 1, source[source_idx], is_little_endian);
+				// invert bits if desc
+				if (desc) {
+					for (idx_t s = 1; s < sizeof(T) + 1; s++) {
+						*(key_locations[i] + s) = ~*(key_locations[i] + s);
+					}
+				}
+			} else {
+				key_locations[i][0] = invalid;
+				memset(key_locations[i] + 1, '\0', sizeof(T));
+			}
+			key_locations[i] += sizeof(T) + 1;
+		}
+	} else {
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			// write value
+			Radix::EncodeData<T>(key_locations[i], source[source_idx], is_little_endian);
+			// invert bits if desc
+			if (desc) {
+				for (idx_t s = 0; s < sizeof(T); s++) {
+					*(key_locations[i] + s) = ~*(key_locations[i] + s);
+				}
+			}
+			key_locations[i] += sizeof(T);
+		}
+	}
+}
+
+void RadixScatterStringVector(VectorData &vdata, const SelectionVector &sel, idx_t add_count, data_ptr_t *key_locations,
+                              const bool desc, const bool has_null, const bool nulls_first, const idx_t prefix_len,
+                              idx_t offset) {
+	auto source = (string_t *)vdata.data;
+	if (has_null) {
+		auto &validity = vdata.validity;
+		const data_t valid = nulls_first ? 1 : 0;
+		const data_t invalid = 1 - valid;
+
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			// write validity and according value
+			if (validity.RowIsValid(source_idx)) {
+				key_locations[i][0] = valid;
+				Radix::EncodeStringDataPrefix(key_locations[i] + 1, source[source_idx], prefix_len);
+				// invert bits if desc
+				if (desc) {
+					for (idx_t s = 1; s < prefix_len + 1; s++) {
+						*(key_locations[i] + s) = ~*(key_locations[i] + s);
+					}
+				}
+			} else {
+				key_locations[i][0] = invalid;
+				memset(key_locations[i] + 1, '\0', prefix_len);
+			}
+			key_locations[i] += prefix_len + 1;
+		}
+	} else {
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			// write value
+			Radix::EncodeStringDataPrefix(key_locations[i], source[source_idx], prefix_len);
+			// invert bits if desc
+			if (desc) {
+				for (idx_t s = 0; s < prefix_len; s++) {
+					*(key_locations[i] + s) = ~*(key_locations[i] + s);
+				}
+			}
+			key_locations[i] += prefix_len;
+		}
+	}
+}
+
+void RadixScatterListVector(Vector &v, VectorData &vdata, const SelectionVector &sel, idx_t add_count,
+                            data_ptr_t *key_locations, const bool desc, const bool has_null, const bool nulls_first,
+                            const idx_t prefix_len, const idx_t width, const idx_t offset) {
+	auto list_data = ListVector::GetData(v);
+	auto &child_vector = ListVector::GetEntry(v);
+	auto list_size = ListVector::GetListSize(v);
+
+	// serialize null values
+	if (has_null) {
+		auto &validity = vdata.validity;
+		const data_t valid = nulls_first ? 1 : 0;
+		const data_t invalid = 1 - valid;
+
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			data_ptr_t key_location = key_locations[i] + 1;
+			// write validity and according value
+			if (validity.RowIsValid(source_idx)) {
+				key_locations[i][0] = valid;
+				key_locations[i]++;
+				auto &list_entry = list_data[source_idx];
+				if (list_entry.length > 0) {
+					// denote that the list is not empty with a 1
+					key_locations[i][0] = 1;
+					key_locations[i]++;
+					RowOperations::RadixScatter(child_vector, list_size, *FlatVector::IncrementalSelectionVector(), 1,
+					                            key_locations + i, false, true, false, prefix_len, width - 1,
+					                            list_entry.offset);
+				} else {
+					// denote that the list is empty with a 0
+					key_locations[i][0] = 0;
+					key_locations[i]++;
+					memset(key_locations[i], '\0', width - 2);
+				}
+				// invert bits if desc
+				if (desc) {
+					for (idx_t s = 0; s < width - 1; s++) {
+						*(key_location + s) = ~*(key_location + s);
+					}
+				}
+			} else {
+				key_locations[i][0] = invalid;
+				memset(key_locations[i] + 1, '\0', width - 1);
+				key_locations[i] += width;
+			}
+		}
+	} else {
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			auto &list_entry = list_data[source_idx];
+			data_ptr_t key_location = key_locations[i];
+			if (list_entry.length > 0) {
+				// denote that the list is not empty with a 1
+				key_locations[i][0] = 1;
+				key_locations[i]++;
+				RowOperations::RadixScatter(child_vector, list_size, *FlatVector::IncrementalSelectionVector(), 1,
+				                            key_locations + i, false, true, false, prefix_len, width - 1,
+				                            list_entry.offset);
+			} else {
+				// denote that the list is empty with a 0
+				key_locations[i][0] = 0;
+				key_locations[i]++;
+				memset(key_locations[i], '\0', width - 1);
+			}
+			// invert bits if desc
+			if (desc) {
+				for (idx_t s = 0; s < width; s++) {
+					*(key_location + s) = ~*(key_location + s);
+				}
+			}
+		}
+	}
+}
+
+void RadixScatterStructVector(Vector &v, VectorData &vdata, idx_t vcount, const SelectionVector &sel, idx_t add_count,
+                              data_ptr_t *key_locations, const bool desc, const bool has_null, const bool nulls_first,
+                              const idx_t prefix_len, idx_t width, const idx_t offset) {
+	// serialize null values
+	if (has_null) {
+		auto &validity = vdata.validity;
+		const data_t valid = nulls_first ? 1 : 0;
+		const data_t invalid = 1 - valid;
+
+		for (idx_t i = 0; i < add_count; i++) {
+			auto idx = sel.get_index(i);
+			auto source_idx = vdata.sel->get_index(idx) + offset;
+			// write validity and according value
+			if (validity.RowIsValid(source_idx)) {
+				key_locations[i][0] = valid;
+			} else {
+				key_locations[i][0] = invalid;
+			}
+			key_locations[i]++;
+		}
+		width--;
+	}
+	// serialize the struct
+	auto &child_vector = *StructVector::GetEntries(v)[0];
+	RowOperations::RadixScatter(child_vector, vcount, *FlatVector::IncrementalSelectionVector(), add_count,
+	                            key_locations, false, true, false, prefix_len, width, offset);
+	// invert bits if desc
+	if (desc) {
+		for (idx_t i = 0; i < add_count; i++) {
+			for (idx_t s = 0; s < width; s++) {
+				*(key_locations[i] - width + s) = ~*(key_locations[i] - width + s);
+			}
+		}
+	}
+}
+
+void RowOperations::RadixScatter(Vector &v, idx_t vcount, const SelectionVector &sel, idx_t ser_count,
+                                 data_ptr_t *key_locations, bool desc, bool has_null, bool nulls_first,
+                                 idx_t prefix_len, idx_t width, idx_t offset) {
+	auto is_little_endian = Radix::IsLittleEndian();
+
+	VectorData vdata;
+	v.Orrify(vcount, vdata);
+	switch (v.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedRadixScatter<int8_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                              is_little_endian, offset);
+		break;
+	case PhysicalType::INT16:
+		TemplatedRadixScatter<int16_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                               is_little_endian, offset);
+		break;
+	case PhysicalType::INT32:
+		TemplatedRadixScatter<int32_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                               is_little_endian, offset);
+		break;
+	case PhysicalType::INT64:
+		TemplatedRadixScatter<int64_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                               is_little_endian, offset);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedRadixScatter<uint8_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                               is_little_endian, offset);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedRadixScatter<uint16_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                                is_little_endian, offset);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedRadixScatter<uint32_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                                is_little_endian, offset);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedRadixScatter<uint64_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                                is_little_endian, offset);
+		break;
+	case PhysicalType::INT128:
+		TemplatedRadixScatter<hugeint_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                                 is_little_endian, offset);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedRadixScatter<float>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                             is_little_endian, offset);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedRadixScatter<double>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                              is_little_endian, offset);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedRadixScatter<interval_t>(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                                  is_little_endian, offset);
+		break;
+	case PhysicalType::VARCHAR:
+		RadixScatterStringVector(vdata, sel, ser_count, key_locations, desc, has_null, nulls_first, prefix_len, offset);
+		break;
+	case PhysicalType::LIST:
+		RadixScatterListVector(v, vdata, sel, ser_count, key_locations, desc, has_null, nulls_first, prefix_len, width,
+		                       offset);
+		break;
+	case PhysicalType::STRUCT:
+		RadixScatterStructVector(v, vdata, vcount, sel, ser_count, key_locations, desc, has_null, nulls_first,
+		                         prefix_len, width, offset);
+		break;
+	default:
+		throw NotImplementedException("Cannot ORDER BY column with type %s", v.GetType().ToString());
+	}
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// row_scatter.cpp
+// Description: This file contains the implementation of the row scattering
+//              operators
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = RowLayout::ValidityBytes;
+
+template <class T>
+static void TemplatedScatter(VectorData &col, Vector &rows, const SelectionVector &sel, const idx_t count,
+                             const idx_t col_offset, const idx_t col_no) {
+	auto data = (T *)col.data;
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+
+	if (!col.validity.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+			auto col_idx = col.sel->get_index(idx);
+			auto row = ptrs[idx];
+
+			auto isnull = !col.validity.RowIsValid(col_idx);
+			T store_value = isnull ? NullValue<T>() : data[col_idx];
+			Store<T>(store_value, row + col_offset);
+			if (isnull) {
+				ValidityBytes col_mask(ptrs[idx]);
+				col_mask.SetInvalidUnsafe(col_no);
+			}
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+			auto col_idx = col.sel->get_index(idx);
+			auto row = ptrs[idx];
+
+			Store<T>(data[col_idx], row + col_offset);
+		}
+	}
+}
+
+static void ComputeStringEntrySizes(const VectorData &col, idx_t entry_sizes[], const SelectionVector &sel,
+                                    const idx_t count, const idx_t offset = 0) {
+	auto data = (const string_t *)col.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto col_idx = col.sel->get_index(idx) + offset;
+		const auto &str = data[col_idx];
+		if (col.validity.RowIsValid(col_idx) && !str.IsInlined()) {
+			entry_sizes[i] += str.GetSize();
+		}
+	}
+}
+
+static void ScatterStringVector(VectorData &col, Vector &rows, data_ptr_t str_locations[], const SelectionVector &sel,
+                                const idx_t count, const idx_t col_offset, const idx_t col_no) {
+	auto string_data = (string_t *)col.data;
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto col_idx = col.sel->get_index(idx);
+		auto row = ptrs[idx];
+		if (!col.validity.RowIsValid(col_idx)) {
+			ValidityBytes col_mask(row);
+			col_mask.SetInvalidUnsafe(col_no);
+			Store<string_t>(NullValue<string_t>(), row + col_offset);
+		} else if (string_data[col_idx].IsInlined()) {
+			Store<string_t>(string_data[col_idx], row + col_offset);
+		} else {
+			const auto &str = string_data[col_idx];
+			string_t inserted((const char *)str_locations[i], str.GetSize());
+			memcpy(inserted.GetDataWriteable(), str.GetDataUnsafe(), str.GetSize());
+			str_locations[i] += str.GetSize();
+			inserted.Finalize();
+			Store<string_t>(inserted, row + col_offset);
+		}
+	}
+}
+
+static void ScatterNestedVector(Vector &vec, VectorData &col, Vector &rows, data_ptr_t data_locations[],
+                                const SelectionVector &sel, const idx_t count, const idx_t col_offset,
+                                const idx_t col_no, const idx_t vcount) {
+	// Store pointers to the data in the row
+	// Do this first because SerializeVector destroys the locations
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	data_ptr_t validitymask_locations[STANDARD_VECTOR_SIZE];
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto row = ptrs[idx];
+		validitymask_locations[i] = row;
+
+		Store<data_ptr_t>(data_locations[i], row + col_offset);
+	}
+
+	// Serialise the data
+	RowOperations::HeapScatter(vec, vcount, sel, count, col_no, data_locations, validitymask_locations);
+}
+
+void RowOperations::Scatter(DataChunk &columns, VectorData col_data[], const RowLayout &layout, Vector &rows,
+                            RowDataCollection &string_heap, const SelectionVector &sel, idx_t count) {
+	if (count == 0) {
+		return;
+	}
+
+	// Set the validity mask for each row before inserting data
+	auto ptrs = FlatVector::GetData<data_ptr_t>(rows);
+	for (idx_t i = 0; i < count; ++i) {
+		auto row_idx = sel.get_index(i);
+		auto row = ptrs[row_idx];
+		ValidityBytes(row).SetAllValid(layout.ColumnCount());
+	}
+
+	const auto vcount = columns.size();
+	auto &offsets = layout.GetOffsets();
+	auto &types = layout.GetTypes();
+
+	// Compute the entry size of the variable size columns
+	vector<unique_ptr<BufferHandle>> handles;
+	data_ptr_t data_locations[STANDARD_VECTOR_SIZE];
+	if (!layout.AllConstant()) {
+		idx_t entry_sizes[STANDARD_VECTOR_SIZE];
+		std::fill_n(entry_sizes, count, sizeof(uint32_t));
+		for (idx_t col_no = 0; col_no < types.size(); col_no++) {
+			if (TypeIsConstantSize(types[col_no].InternalType())) {
+				continue;
+			}
+
+			auto &vec = columns.data[col_no];
+			auto &col = col_data[col_no];
+			switch (types[col_no].InternalType()) {
+			case PhysicalType::VARCHAR:
+				ComputeStringEntrySizes(col, entry_sizes, sel, count);
+				break;
+			case PhysicalType::LIST:
+			case PhysicalType::MAP:
+			case PhysicalType::STRUCT:
+				RowOperations::ComputeEntrySizes(vec, col, entry_sizes, vcount, count, sel);
+				break;
+			default:
+				throw InternalException("Unsupported type for RowOperations::Scatter");
+			}
+		}
+
+		// Build out the buffer space
+		string_heap.Build(count, data_locations, entry_sizes);
+
+		// Serialize information that is needed for swizzling if the computation goes out-of-core
+		const idx_t heap_pointer_offset = layout.GetHeapPointerOffset();
+		for (idx_t i = 0; i < count; i++) {
+			auto row_idx = sel.get_index(i);
+			auto row = ptrs[row_idx];
+			// Pointer to this row in the heap block
+			Store<data_ptr_t>(data_locations[i], row + heap_pointer_offset);
+			// Row size is stored in the heap in front of each row
+			Store<uint32_t>(entry_sizes[i], data_locations[i]);
+			data_locations[i] += sizeof(uint32_t);
+		}
+	}
+
+	for (idx_t col_no = 0; col_no < types.size(); col_no++) {
+		auto &vec = columns.data[col_no];
+		auto &col = col_data[col_no];
+		auto col_offset = offsets[col_no];
+
+		switch (types[col_no].InternalType()) {
+		case PhysicalType::BOOL:
+		case PhysicalType::INT8:
+			TemplatedScatter<int8_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::INT16:
+			TemplatedScatter<int16_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::INT32:
+			TemplatedScatter<int32_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::INT64:
+			TemplatedScatter<int64_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::UINT8:
+			TemplatedScatter<uint8_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::UINT16:
+			TemplatedScatter<uint16_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::UINT32:
+			TemplatedScatter<uint32_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::UINT64:
+			TemplatedScatter<uint64_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::INT128:
+			TemplatedScatter<hugeint_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::FLOAT:
+			TemplatedScatter<float>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::DOUBLE:
+			TemplatedScatter<double>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::INTERVAL:
+			TemplatedScatter<interval_t>(col, rows, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::VARCHAR:
+			ScatterStringVector(col, rows, data_locations, sel, count, col_offset, col_no);
+			break;
+		case PhysicalType::LIST:
+		case PhysicalType::MAP:
+		case PhysicalType::STRUCT:
+			ScatterNestedVector(vec, col, rows, data_locations, sel, count, col_offset, col_no, vcount);
+			break;
+		default:
+			throw InternalException("Unsupported type for RowOperations::Scatter");
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+#include <cstring>
+
+namespace duckdb {
+
+BufferedDeserializer::BufferedDeserializer(data_ptr_t ptr, idx_t data_size) : ptr(ptr), endptr(ptr + data_size) {
+}
+
+BufferedDeserializer::BufferedDeserializer(BufferedSerializer &serializer)
+    : BufferedDeserializer(serializer.data, serializer.maximum_size) {
+}
+
+void BufferedDeserializer::ReadData(data_ptr_t buffer, idx_t read_size) {
+	if (ptr + read_size > endptr) {
+		throw SerializationException("Failed to deserialize: not enough data in buffer to fulfill read request");
+	}
+	memcpy(buffer, ptr, read_size);
+	ptr += read_size;
+}
+
+} // namespace duckdb
+
+
+
+
+#include <cstring>
+#include <algorithm>
+
+namespace duckdb {
+
+BufferedFileReader::BufferedFileReader(FileSystem &fs, const char *path, FileOpener *opener)
+    : fs(fs), data(unique_ptr<data_t[]>(new data_t[FILE_BUFFER_SIZE])), offset(0), read_data(0), total_read(0) {
+	handle =
+	    fs.OpenFile(path, FileFlags::FILE_FLAGS_READ, FileLockType::READ_LOCK, FileSystem::DEFAULT_COMPRESSION, opener);
+	file_size = fs.GetFileSize(*handle);
+}
+
+void BufferedFileReader::ReadData(data_ptr_t target_buffer, uint64_t read_size) {
+	// first copy anything we can from the buffer
+	data_ptr_t end_ptr = target_buffer + read_size;
+	while (true) {
+		idx_t to_read = MinValue<idx_t>(end_ptr - target_buffer, read_data - offset);
+		if (to_read > 0) {
+			memcpy(target_buffer, data.get() + offset, to_read);
+			offset += to_read;
+			target_buffer += to_read;
+		}
+		if (target_buffer < end_ptr) {
+			D_ASSERT(offset == read_data);
+			total_read += read_data;
+			// did not finish reading yet but exhausted buffer
+			// read data into buffer
+			offset = 0;
+			read_data = fs.Read(*handle, data.get(), FILE_BUFFER_SIZE);
+			if (read_data == 0) {
+				throw SerializationException("not enough data in file to deserialize result");
+			}
+		} else {
+			return;
+		}
+	}
+}
+
+bool BufferedFileReader::Finished() {
+	return total_read + offset == file_size;
+}
+
+} // namespace duckdb
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+// Remove this when we switch C++17: https://stackoverflow.com/a/53350948
+constexpr uint8_t BufferedFileWriter::DEFAULT_OPEN_FLAGS;
+
+BufferedFileWriter::BufferedFileWriter(FileSystem &fs, const string &path_p, uint8_t open_flags, FileOpener *opener)
+    : fs(fs), path(path_p), data(unique_ptr<data_t[]>(new data_t[FILE_BUFFER_SIZE])), offset(0), total_written(0) {
+	handle = fs.OpenFile(path, open_flags, FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION, opener);
+}
+
+int64_t BufferedFileWriter::GetFileSize() {
+	return fs.GetFileSize(*handle);
+}
+
+idx_t BufferedFileWriter::GetTotalWritten() {
+	return total_written + offset;
+}
+
+void BufferedFileWriter::WriteData(const_data_ptr_t buffer, uint64_t write_size) {
+	// first copy anything we can from the buffer
+	const_data_ptr_t end_ptr = buffer + write_size;
+	while (buffer < end_ptr) {
+		idx_t to_write = MinValue<idx_t>((end_ptr - buffer), FILE_BUFFER_SIZE - offset);
+		D_ASSERT(to_write > 0);
+		memcpy(data.get() + offset, buffer, to_write);
+		offset += to_write;
+		buffer += to_write;
+		if (offset == FILE_BUFFER_SIZE) {
+			Flush();
+		}
+	}
+}
+
+void BufferedFileWriter::Flush() {
+	if (offset == 0) {
+		return;
+	}
+	fs.Write(*handle, data.get(), offset);
+	total_written += offset;
+	offset = 0;
+}
+
+void BufferedFileWriter::Sync() {
+	Flush();
+	handle->Sync();
+}
+
+void BufferedFileWriter::Truncate(int64_t size) {
+	// truncate the physical file on disk
+	handle->Truncate(size);
+	// reset anything written in the buffer
+	offset = 0;
+}
+
+} // namespace duckdb
+
+
+#include <cstring>
+
+namespace duckdb {
+
+BufferedSerializer::BufferedSerializer(idx_t maximum_size)
+    : BufferedSerializer(unique_ptr<data_t[]>(new data_t[maximum_size]), maximum_size) {
+}
+
+BufferedSerializer::BufferedSerializer(unique_ptr<data_t[]> data, idx_t size) : maximum_size(size), data(data.get()) {
+	blob.size = 0;
+	blob.data = move(data);
+}
+
+BufferedSerializer::BufferedSerializer(data_ptr_t data, idx_t size) : maximum_size(size), data(data) {
+	blob.size = 0;
+}
+
+void BufferedSerializer::WriteData(const_data_ptr_t buffer, idx_t write_size) {
+	if (blob.size + write_size >= maximum_size) {
+		do {
+			maximum_size *= 2;
+		} while (blob.size + write_size > maximum_size);
+		auto new_data = new data_t[maximum_size];
+		memcpy(new_data, data, blob.size);
+		data = new_data;
+		blob.data = unique_ptr<data_t[]>(new_data);
+	}
+
+	memcpy(data + blob.size, buffer, write_size);
+	blob.size += write_size;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+template <>
+string Deserializer::Read() {
+	uint32_t size = Read<uint32_t>();
+	if (size == 0) {
+		return string();
+	}
+	auto buffer = unique_ptr<data_t[]>(new data_t[size]);
+	ReadData(buffer.get(), size);
+	return string((char *)buffer.get(), size);
+}
+
+void Deserializer::ReadStringVector(vector<string> &list) {
+	uint32_t sz = Read<uint32_t>();
+	list.resize(sz);
+	for (idx_t i = 0; i < sz; i++) {
+		list[i] = Read<string>();
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+bool Comparators::TieIsBreakable(const idx_t &col_idx, const data_ptr_t row_ptr, const RowLayout &row_layout) {
+	// Check if the blob is NULL
+	ValidityBytes row_mask(row_ptr);
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	ValidityBytes::GetEntryIndex(col_idx, entry_idx, idx_in_entry);
+	if (!row_mask.RowIsValid(row_mask.GetValidityEntry(entry_idx), idx_in_entry)) {
+		// Can't break a NULL tie
+		return false;
+	}
+	if (row_layout.GetTypes()[col_idx].InternalType() == PhysicalType::VARCHAR) {
+		const auto &tie_col_offset = row_layout.GetOffsets()[col_idx];
+		string_t tie_string = Load<string_t>(row_ptr + tie_col_offset);
+		if (tie_string.GetSize() < string_t::INLINE_LENGTH) {
+			// No need to break the tie - we already compared the full string
+			return false;
+		}
+	}
+	return true;
+}
+
+int Comparators::CompareTuple(const SBScanState &left, const SBScanState &right, const data_ptr_t &l_ptr,
+                              const data_ptr_t &r_ptr, const SortLayout &sort_layout, const bool &external_sort) {
+	// Compare the sorting columns one by one
+	int comp_res = 0;
+	data_ptr_t l_ptr_offset = l_ptr;
+	data_ptr_t r_ptr_offset = r_ptr;
+	for (idx_t col_idx = 0; col_idx < sort_layout.column_count; col_idx++) {
+		comp_res = FastMemcmp(l_ptr_offset, r_ptr_offset, sort_layout.column_sizes[col_idx]);
+		if (comp_res == 0 && !sort_layout.constant_size[col_idx]) {
+			comp_res = BreakBlobTie(col_idx, left, right, sort_layout, external_sort);
+		}
+		if (comp_res != 0) {
+			break;
+		}
+		l_ptr_offset += sort_layout.column_sizes[col_idx];
+		r_ptr_offset += sort_layout.column_sizes[col_idx];
+	}
+	return comp_res;
+}
+
+int Comparators::CompareVal(const data_ptr_t l_ptr, const data_ptr_t r_ptr, const LogicalType &type) {
+	switch (type.InternalType()) {
+	case PhysicalType::VARCHAR:
+		return TemplatedCompareVal<string_t>(l_ptr, r_ptr);
+	case PhysicalType::LIST:
+	case PhysicalType::STRUCT: {
+		auto l_nested_ptr = Load<data_ptr_t>(l_ptr);
+		auto r_nested_ptr = Load<data_ptr_t>(r_ptr);
+		return CompareValAndAdvance(l_nested_ptr, r_nested_ptr, type);
+	}
+	default:
+		throw NotImplementedException("Unimplemented CompareVal for type %s", type.ToString());
+	}
+}
+
+int Comparators::BreakBlobTie(const idx_t &tie_col, const SBScanState &left, const SBScanState &right,
+                              const SortLayout &sort_layout, const bool &external) {
+	const idx_t &col_idx = sort_layout.sorting_to_blob_col.at(tie_col);
+	data_ptr_t l_data_ptr = left.DataPtr(*left.sb->blob_sorting_data);
+	data_ptr_t r_data_ptr = right.DataPtr(*right.sb->blob_sorting_data);
+	if (!TieIsBreakable(col_idx, l_data_ptr, sort_layout.blob_layout)) {
+		// Quick check to see if ties can be broken
+		return 0;
+	}
+	// Align the pointers
+	const auto &tie_col_offset = sort_layout.blob_layout.GetOffsets()[col_idx];
+	l_data_ptr += tie_col_offset;
+	r_data_ptr += tie_col_offset;
+	// Do the comparison
+	const int order = sort_layout.order_types[tie_col] == OrderType::DESCENDING ? -1 : 1;
+	const auto &type = sort_layout.blob_layout.GetTypes()[col_idx];
+	int result;
+	if (external) {
+		// Store heap pointers
+		data_ptr_t l_heap_ptr = left.HeapPtr(*left.sb->blob_sorting_data);
+		data_ptr_t r_heap_ptr = right.HeapPtr(*right.sb->blob_sorting_data);
+		// Unswizzle offset to pointer
+		UnswizzleSingleValue(l_data_ptr, l_heap_ptr, type);
+		UnswizzleSingleValue(r_data_ptr, r_heap_ptr, type);
+		// Compare
+		result = CompareVal(l_data_ptr, r_data_ptr, type);
+		// Swizzle the pointers back to offsets
+		SwizzleSingleValue(l_data_ptr, l_heap_ptr, type);
+		SwizzleSingleValue(r_data_ptr, r_heap_ptr, type);
+	} else {
+		result = CompareVal(l_data_ptr, r_data_ptr, type);
+	}
+	return order * result;
+}
+
+template <class T>
+int Comparators::TemplatedCompareVal(const data_ptr_t &left_ptr, const data_ptr_t &right_ptr) {
+	const auto left_val = Load<T>(left_ptr);
+	const auto right_val = Load<T>(right_ptr);
+	if (Equals::Operation<T>(left_val, right_val)) {
+		return 0;
+	} else if (LessThan::Operation<T>(left_val, right_val)) {
+		return -1;
+	} else {
+		return 1;
+	}
+}
+
+int Comparators::CompareValAndAdvance(data_ptr_t &l_ptr, data_ptr_t &r_ptr, const LogicalType &type) {
+	switch (type.InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedCompareAndAdvance<int8_t>(l_ptr, r_ptr);
+	case PhysicalType::INT16:
+		return TemplatedCompareAndAdvance<int16_t>(l_ptr, r_ptr);
+	case PhysicalType::INT32:
+		return TemplatedCompareAndAdvance<int32_t>(l_ptr, r_ptr);
+	case PhysicalType::INT64:
+		return TemplatedCompareAndAdvance<int64_t>(l_ptr, r_ptr);
+	case PhysicalType::UINT8:
+		return TemplatedCompareAndAdvance<uint8_t>(l_ptr, r_ptr);
+	case PhysicalType::UINT16:
+		return TemplatedCompareAndAdvance<uint16_t>(l_ptr, r_ptr);
+	case PhysicalType::UINT32:
+		return TemplatedCompareAndAdvance<uint32_t>(l_ptr, r_ptr);
+	case PhysicalType::UINT64:
+		return TemplatedCompareAndAdvance<uint64_t>(l_ptr, r_ptr);
+	case PhysicalType::INT128:
+		return TemplatedCompareAndAdvance<hugeint_t>(l_ptr, r_ptr);
+	case PhysicalType::FLOAT:
+		return TemplatedCompareAndAdvance<float>(l_ptr, r_ptr);
+	case PhysicalType::DOUBLE:
+		return TemplatedCompareAndAdvance<double>(l_ptr, r_ptr);
+	case PhysicalType::INTERVAL:
+		return TemplatedCompareAndAdvance<interval_t>(l_ptr, r_ptr);
+	case PhysicalType::VARCHAR:
+		return CompareStringAndAdvance(l_ptr, r_ptr);
+	case PhysicalType::LIST:
+		return CompareListAndAdvance(l_ptr, r_ptr, ListType::GetChildType(type));
+	case PhysicalType::STRUCT:
+		return CompareStructAndAdvance(l_ptr, r_ptr, StructType::GetChildTypes(type));
+	default:
+		throw NotImplementedException("Unimplemented CompareValAndAdvance for type %s", type.ToString());
+	}
+}
+
+template <class T>
+int Comparators::TemplatedCompareAndAdvance(data_ptr_t &left_ptr, data_ptr_t &right_ptr) {
+	auto result = TemplatedCompareVal<T>(left_ptr, right_ptr);
+	left_ptr += sizeof(T);
+	right_ptr += sizeof(T);
+	return result;
+}
+
+int Comparators::CompareStringAndAdvance(data_ptr_t &left_ptr, data_ptr_t &right_ptr) {
+	// Construct the string_t
+	uint32_t left_string_size = Load<uint32_t>(left_ptr);
+	uint32_t right_string_size = Load<uint32_t>(right_ptr);
+	left_ptr += sizeof(uint32_t);
+	right_ptr += sizeof(uint32_t);
+	string_t left_val((const char *)left_ptr, left_string_size);
+	string_t right_val((const char *)right_ptr, right_string_size);
+	left_ptr += left_string_size;
+	right_ptr += right_string_size;
+	// Compare
+	return TemplatedCompareVal<string_t>((data_ptr_t)&left_val, (data_ptr_t)&right_val);
+}
+
+int Comparators::CompareStructAndAdvance(data_ptr_t &left_ptr, data_ptr_t &right_ptr,
+                                         const child_list_t<LogicalType> &types) {
+	idx_t count = types.size();
+	// Load validity masks
+	ValidityBytes left_validity(left_ptr);
+	ValidityBytes right_validity(right_ptr);
+	left_ptr += (count + 7) / 8;
+	right_ptr += (count + 7) / 8;
+	// Initialize variables
+	bool left_valid;
+	bool right_valid;
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	// Compare
+	int comp_res = 0;
+	for (idx_t i = 0; i < count; i++) {
+		ValidityBytes::GetEntryIndex(i, entry_idx, idx_in_entry);
+		left_valid = left_validity.RowIsValid(left_validity.GetValidityEntry(entry_idx), idx_in_entry);
+		right_valid = right_validity.RowIsValid(right_validity.GetValidityEntry(entry_idx), idx_in_entry);
+		auto &type = types[i].second;
+		if ((left_valid && right_valid) || TypeIsConstantSize(type.InternalType())) {
+			comp_res = CompareValAndAdvance(left_ptr, right_ptr, types[i].second);
+		}
+		if (!left_valid && !right_valid) {
+			comp_res = 0;
+		} else if (!left_valid) {
+			comp_res = 1;
+		} else if (!right_valid) {
+			comp_res = -1;
+		}
+		if (comp_res != 0) {
+			break;
+		}
+	}
+	return comp_res;
+}
+
+int Comparators::CompareListAndAdvance(data_ptr_t &left_ptr, data_ptr_t &right_ptr, const LogicalType &type) {
+	// Load list lengths
+	auto left_len = Load<idx_t>(left_ptr);
+	auto right_len = Load<idx_t>(right_ptr);
+	left_ptr += sizeof(idx_t);
+	right_ptr += sizeof(idx_t);
+	// Load list validity masks
+	ValidityBytes left_validity(left_ptr);
+	ValidityBytes right_validity(right_ptr);
+	left_ptr += (left_len + 7) / 8;
+	right_ptr += (right_len + 7) / 8;
+	// Compare
+	int comp_res = 0;
+	idx_t count = MinValue(left_len, right_len);
+	if (TypeIsConstantSize(type.InternalType())) {
+		// Templated code for fixed-size types
+		switch (type.InternalType()) {
+		case PhysicalType::BOOL:
+		case PhysicalType::INT8:
+			comp_res = TemplatedCompareListLoop<int8_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::INT16:
+			comp_res = TemplatedCompareListLoop<int16_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::INT32:
+			comp_res = TemplatedCompareListLoop<int32_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::INT64:
+			comp_res = TemplatedCompareListLoop<int64_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::UINT8:
+			comp_res = TemplatedCompareListLoop<uint8_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::UINT16:
+			comp_res = TemplatedCompareListLoop<uint16_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::UINT32:
+			comp_res = TemplatedCompareListLoop<uint32_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::UINT64:
+			comp_res = TemplatedCompareListLoop<uint64_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::INT128:
+			comp_res = TemplatedCompareListLoop<hugeint_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::FLOAT:
+			comp_res = TemplatedCompareListLoop<float>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::DOUBLE:
+			comp_res = TemplatedCompareListLoop<double>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		case PhysicalType::INTERVAL:
+			comp_res = TemplatedCompareListLoop<interval_t>(left_ptr, right_ptr, left_validity, right_validity, count);
+			break;
+		default:
+			throw NotImplementedException("CompareListAndAdvance for fixed-size type %s", type.ToString());
+		}
+	} else {
+		// Variable-sized list entries
+		bool left_valid;
+		bool right_valid;
+		idx_t entry_idx;
+		idx_t idx_in_entry;
+		// Size (in bytes) of all variable-sizes entries is stored before the entries begin,
+		// to make deserialization easier. We need to skip over them
+		left_ptr += left_len * sizeof(idx_t);
+		right_ptr += right_len * sizeof(idx_t);
+		for (idx_t i = 0; i < count; i++) {
+			ValidityBytes::GetEntryIndex(i, entry_idx, idx_in_entry);
+			left_valid = left_validity.RowIsValid(left_validity.GetValidityEntry(entry_idx), idx_in_entry);
+			right_valid = right_validity.RowIsValid(right_validity.GetValidityEntry(entry_idx), idx_in_entry);
+			if (left_valid && right_valid) {
+				switch (type.InternalType()) {
+				case PhysicalType::LIST:
+					comp_res = CompareListAndAdvance(left_ptr, right_ptr, ListType::GetChildType(type));
+					break;
+				case PhysicalType::VARCHAR:
+					comp_res = CompareStringAndAdvance(left_ptr, right_ptr);
+					break;
+				case PhysicalType::STRUCT:
+					comp_res = CompareStructAndAdvance(left_ptr, right_ptr, StructType::GetChildTypes(type));
+					break;
+				default:
+					throw NotImplementedException("CompareListAndAdvance for variable-size type %s", type.ToString());
+				}
+			} else if (!left_valid && !right_valid) {
+				comp_res = 0;
+			} else if (left_valid) {
+				comp_res = -1;
+			} else {
+				comp_res = 1;
+			}
+			if (comp_res != 0) {
+				break;
+			}
+		}
+	}
+	// All values that we looped over were equal
+	if (comp_res == 0 && left_len != right_len) {
+		// Smaller lists first
+		if (left_len < right_len) {
+			comp_res = -1;
+		} else {
+			comp_res = 1;
+		}
+	}
+	return comp_res;
+}
+
+template <class T>
+int Comparators::TemplatedCompareListLoop(data_ptr_t &left_ptr, data_ptr_t &right_ptr,
+                                          const ValidityBytes &left_validity, const ValidityBytes &right_validity,
+                                          const idx_t &count) {
+	int comp_res = 0;
+	bool left_valid;
+	bool right_valid;
+	idx_t entry_idx;
+	idx_t idx_in_entry;
+	for (idx_t i = 0; i < count; i++) {
+		ValidityBytes::GetEntryIndex(i, entry_idx, idx_in_entry);
+		left_valid = left_validity.RowIsValid(left_validity.GetValidityEntry(entry_idx), idx_in_entry);
+		right_valid = right_validity.RowIsValid(right_validity.GetValidityEntry(entry_idx), idx_in_entry);
+		comp_res = TemplatedCompareAndAdvance<T>(left_ptr, right_ptr);
+		if (!left_valid && !right_valid) {
+			comp_res = 0;
+		} else if (!left_valid) {
+			comp_res = 1;
+		} else if (!right_valid) {
+			comp_res = -1;
+		}
+		if (comp_res != 0) {
+			break;
+		}
+	}
+	return comp_res;
+}
+
+void Comparators::UnswizzleSingleValue(data_ptr_t data_ptr, const data_ptr_t &heap_ptr, const LogicalType &type) {
+	if (type.InternalType() == PhysicalType::VARCHAR) {
+		data_ptr += sizeof(uint32_t) + string_t::PREFIX_LENGTH;
+	}
+	Store<data_ptr_t>(heap_ptr + Load<idx_t>(data_ptr), data_ptr);
+}
+
+void Comparators::SwizzleSingleValue(data_ptr_t data_ptr, const data_ptr_t &heap_ptr, const LogicalType &type) {
+	if (type.InternalType() == PhysicalType::VARCHAR) {
+		data_ptr += sizeof(uint32_t) + string_t::PREFIX_LENGTH;
+	}
+	Store<idx_t>(Load<data_ptr_t>(data_ptr) - heap_ptr, data_ptr);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+MergeSorter::MergeSorter(GlobalSortState &state, BufferManager &buffer_manager)
+    : state(state), buffer_manager(buffer_manager), sort_layout(state.sort_layout) {
+}
+
+void MergeSorter::PerformInMergeRound() {
+	while (true) {
+		{
+			lock_guard<mutex> pair_guard(state.lock);
+			if (state.pair_idx == state.num_pairs) {
+				break;
+			}
+			GetNextPartition();
+		}
+		MergePartition();
+	}
+}
+
+void MergeSorter::MergePartition() {
+	auto &left_block = *left->sb;
+	auto &right_block = *right->sb;
+#ifdef DEBUG
+	D_ASSERT(left_block.radix_sorting_data.size() == left_block.payload_data->data_blocks.size());
+	D_ASSERT(right_block.radix_sorting_data.size() == right_block.payload_data->data_blocks.size());
+	if (!state.payload_layout.AllConstant() && state.external) {
+		D_ASSERT(left_block.payload_data->data_blocks.size() == left_block.payload_data->heap_blocks.size());
+		D_ASSERT(right_block.payload_data->data_blocks.size() == right_block.payload_data->heap_blocks.size());
+	}
+	if (!sort_layout.all_constant) {
+		D_ASSERT(left_block.radix_sorting_data.size() == left_block.blob_sorting_data->data_blocks.size());
+		D_ASSERT(right_block.radix_sorting_data.size() == right_block.blob_sorting_data->data_blocks.size());
+		if (state.external) {
+			D_ASSERT(left_block.blob_sorting_data->data_blocks.size() ==
+			         left_block.blob_sorting_data->heap_blocks.size());
+			D_ASSERT(right_block.blob_sorting_data->data_blocks.size() ==
+			         right_block.blob_sorting_data->heap_blocks.size());
+		}
+	}
+#endif
+	// Set up the write block
+	// Each merge task produces a SortedBlock with exactly state.block_capacity rows or less
+	result->InitializeWrite();
+	// Initialize arrays to store merge data
+	bool left_smaller[STANDARD_VECTOR_SIZE];
+	idx_t next_entry_sizes[STANDARD_VECTOR_SIZE];
+	// Merge loop
+#ifdef DEBUG
+	auto l_count = left->Remaining();
+	auto r_count = right->Remaining();
+#endif
+	while (true) {
+		auto l_remaining = left->Remaining();
+		auto r_remaining = right->Remaining();
+		if (l_remaining + r_remaining == 0) {
+			// Done
+			break;
+		}
+		const idx_t next = MinValue(l_remaining + r_remaining, (idx_t)STANDARD_VECTOR_SIZE);
+		if (l_remaining != 0 && r_remaining != 0) {
+			// Compute the merge (not needed if one side is exhausted)
+			ComputeMerge(next, left_smaller);
+		}
+		// Actually merge the data (radix, blob, and payload)
+		MergeRadix(next, left_smaller);
+		if (!sort_layout.all_constant) {
+			MergeData(*result->blob_sorting_data, *left_block.blob_sorting_data, *right_block.blob_sorting_data, next,
+			          left_smaller, next_entry_sizes, true);
+			D_ASSERT(result->radix_sorting_data.size() == result->blob_sorting_data->data_blocks.size());
+		}
+		MergeData(*result->payload_data, *left_block.payload_data, *right_block.payload_data, next, left_smaller,
+		          next_entry_sizes, false);
+		D_ASSERT(result->radix_sorting_data.size() == result->payload_data->data_blocks.size());
+	}
+#ifdef DEBUG
+	D_ASSERT(result->Count() == l_count + r_count);
+#endif
+}
+
+void MergeSorter::GetNextPartition() {
+	// Create result block
+	state.sorted_blocks_temp[state.pair_idx].push_back(make_unique<SortedBlock>(buffer_manager, state));
+	result = state.sorted_blocks_temp[state.pair_idx].back().get();
+	// Determine which blocks must be merged
+	auto &left_block = *state.sorted_blocks[state.pair_idx * 2];
+	auto &right_block = *state.sorted_blocks[state.pair_idx * 2 + 1];
+	const idx_t l_count = left_block.Count();
+	const idx_t r_count = right_block.Count();
+	// Initialize left and right reader
+	left = make_unique<SBScanState>(buffer_manager, state);
+	right = make_unique<SBScanState>(buffer_manager, state);
+	// Compute the work that this thread must do using Merge Path
+	idx_t l_end;
+	idx_t r_end;
+	if (state.l_start + state.r_start + state.block_capacity < l_count + r_count) {
+		left->sb = state.sorted_blocks[state.pair_idx * 2].get();
+		right->sb = state.sorted_blocks[state.pair_idx * 2 + 1].get();
+		const idx_t intersection = state.l_start + state.r_start + state.block_capacity;
+		GetIntersection(intersection, l_end, r_end);
+		D_ASSERT(l_end <= l_count);
+		D_ASSERT(r_end <= r_count);
+		D_ASSERT(intersection == l_end + r_end);
+	} else {
+		l_end = l_count;
+		r_end = r_count;
+	}
+	// Create slices of the data that this thread must merge
+	left->SetIndices(0, 0);
+	right->SetIndices(0, 0);
+	left_input = left_block.CreateSlice(state.l_start, l_end, left->entry_idx);
+	right_input = right_block.CreateSlice(state.r_start, r_end, right->entry_idx);
+	left->sb = left_input.get();
+	right->sb = right_input.get();
+	state.l_start = l_end;
+	state.r_start = r_end;
+	D_ASSERT(left->Remaining() + right->Remaining() == state.block_capacity || (l_end == l_count && r_end == r_count));
+	// Update global state
+	if (state.l_start == l_count && state.r_start == r_count) {
+		// Delete references to previous pair
+		state.sorted_blocks[state.pair_idx * 2] = nullptr;
+		state.sorted_blocks[state.pair_idx * 2 + 1] = nullptr;
+		// Advance pair
+		state.pair_idx++;
+		state.l_start = 0;
+		state.r_start = 0;
+	}
+}
+
+int MergeSorter::CompareUsingGlobalIndex(SBScanState &l, SBScanState &r, const idx_t l_idx, const idx_t r_idx) {
+	D_ASSERT(l_idx < l.sb->Count());
+	D_ASSERT(r_idx < r.sb->Count());
+
+	// Easy comparison using the previous result (intersections must increase monotonically)
+	if (l_idx < state.l_start) {
+		return -1;
+	}
+	if (r_idx < state.r_start) {
+		return 1;
+	}
+
+	l.sb->GlobalToLocalIndex(l_idx, l.block_idx, l.entry_idx);
+	r.sb->GlobalToLocalIndex(r_idx, r.block_idx, r.entry_idx);
+
+	l.PinRadix(l.block_idx);
+	r.PinRadix(r.block_idx);
+	data_ptr_t l_ptr = l.radix_handle->Ptr() + l.entry_idx * sort_layout.entry_size;
+	data_ptr_t r_ptr = r.radix_handle->Ptr() + r.entry_idx * sort_layout.entry_size;
+
+	int comp_res;
+	if (sort_layout.all_constant) {
+		comp_res = FastMemcmp(l_ptr, r_ptr, sort_layout.comparison_size);
+	} else {
+		l.PinData(*l.sb->blob_sorting_data);
+		r.PinData(*r.sb->blob_sorting_data);
+		comp_res = Comparators::CompareTuple(l, r, l_ptr, r_ptr, sort_layout, state.external);
+	}
+	return comp_res;
+}
+
+void MergeSorter::GetIntersection(const idx_t diagonal, idx_t &l_idx, idx_t &r_idx) {
+	const idx_t l_count = left->sb->Count();
+	const idx_t r_count = right->sb->Count();
+	// Cover some edge cases
+	// Code coverage off because these edge cases cannot happen unless other code changes
+	// Edge cases have been tested extensively while developing Merge Path in a script
+	// LCOV_EXCL_START
+	if (diagonal >= l_count + r_count) {
+		l_idx = l_count;
+		r_idx = r_count;
+		return;
+	} else if (diagonal == 0) {
+		l_idx = 0;
+		r_idx = 0;
+		return;
+	} else if (l_count == 0) {
+		l_idx = 0;
+		r_idx = diagonal;
+		return;
+	} else if (r_count == 0) {
+		r_idx = 0;
+		l_idx = diagonal;
+		return;
+	}
+	// LCOV_EXCL_STOP
+	// Determine offsets for the binary search
+	const idx_t l_offset = MinValue(l_count, diagonal);
+	const idx_t r_offset = diagonal > l_count ? diagonal - l_count : 0;
+	D_ASSERT(l_offset + r_offset == diagonal);
+	const idx_t search_space = diagonal > MaxValue(l_count, r_count) ? l_count + r_count - diagonal
+	                                                                 : MinValue(diagonal, MinValue(l_count, r_count));
+	// Double binary search
+	idx_t li = 0;
+	idx_t ri = search_space - 1;
+	idx_t middle;
+	int comp_res;
+	while (li <= ri) {
+		middle = (li + ri) / 2;
+		l_idx = l_offset - middle;
+		r_idx = r_offset + middle;
+		if (l_idx == l_count || r_idx == 0) {
+			comp_res = CompareUsingGlobalIndex(*left, *right, l_idx - 1, r_idx);
+			if (comp_res > 0) {
+				l_idx--;
+				r_idx++;
+			} else {
+				return;
+			}
+			if (l_idx == 0 || r_idx == r_count) {
+				// This case is incredibly difficult to cover as it is dependent on parallelism randomness
+				// But it has been tested extensively during development in a script
+				// LCOV_EXCL_START
+				return;
+				// LCOV_EXCL_STOP
+			} else {
+				break;
+			}
+		}
+		comp_res = CompareUsingGlobalIndex(*left, *right, l_idx, r_idx);
+		if (comp_res > 0) {
+			li = middle + 1;
+		} else {
+			ri = middle - 1;
+		}
+	}
+	int l_r_min1 = CompareUsingGlobalIndex(*left, *right, l_idx, r_idx - 1);
+	int l_min1_r = CompareUsingGlobalIndex(*left, *right, l_idx - 1, r_idx);
+	if (l_r_min1 > 0 && l_min1_r < 0) {
+		return;
+	} else if (l_r_min1 > 0) {
+		l_idx--;
+		r_idx++;
+	} else if (l_min1_r < 0) {
+		l_idx++;
+		r_idx--;
+	}
+}
+
+void MergeSorter::ComputeMerge(const idx_t &count, bool left_smaller[]) {
+	auto &l = *left;
+	auto &r = *right;
+	auto &l_sorted_block = *l.sb;
+	auto &r_sorted_block = *r.sb;
+	// Save indices to restore afterwards
+	idx_t l_block_idx_before = l.block_idx;
+	idx_t l_entry_idx_before = l.entry_idx;
+	idx_t r_block_idx_before = r.block_idx;
+	idx_t r_entry_idx_before = r.entry_idx;
+	// Data pointers for both sides
+	data_ptr_t l_radix_ptr;
+	data_ptr_t r_radix_ptr;
+	// Compute the merge of the next 'count' tuples
+	idx_t compared = 0;
+	while (compared < count) {
+		// Move to the next block (if needed)
+		if (l.block_idx < l_sorted_block.radix_sorting_data.size() &&
+		    l.entry_idx == l_sorted_block.radix_sorting_data[l.block_idx].count) {
+			l.block_idx++;
+			l.entry_idx = 0;
+		}
+		if (r.block_idx < r_sorted_block.radix_sorting_data.size() &&
+		    r.entry_idx == r_sorted_block.radix_sorting_data[r.block_idx].count) {
+			r.block_idx++;
+			r.entry_idx = 0;
+		}
+		const bool l_done = l.block_idx == l_sorted_block.radix_sorting_data.size();
+		const bool r_done = r.block_idx == r_sorted_block.radix_sorting_data.size();
+		if (l_done || r_done) {
+			// One of the sides is exhausted, no need to compare
+			break;
+		}
+		// Pin the radix sorting data
+		if (!l_done) {
+			left->PinRadix(l.block_idx);
+			l_radix_ptr = left->RadixPtr();
+		}
+		if (!r_done) {
+			right->PinRadix(r.block_idx);
+			r_radix_ptr = right->RadixPtr();
+		}
+		const idx_t &l_count = !l_done ? l_sorted_block.radix_sorting_data[l.block_idx].count : 0;
+		const idx_t &r_count = !r_done ? r_sorted_block.radix_sorting_data[r.block_idx].count : 0;
+		// Compute the merge
+		if (sort_layout.all_constant) {
+			// All sorting columns are constant size
+			for (; compared < count && l.entry_idx < l_count && r.entry_idx < r_count; compared++) {
+				left_smaller[compared] = FastMemcmp(l_radix_ptr, r_radix_ptr, sort_layout.comparison_size) < 0;
+				const bool &l_smaller = left_smaller[compared];
+				const bool r_smaller = !l_smaller;
+				// Use comparison bool (0 or 1) to increment entries and pointers
+				l.entry_idx += l_smaller;
+				r.entry_idx += r_smaller;
+				l_radix_ptr += l_smaller * sort_layout.entry_size;
+				r_radix_ptr += r_smaller * sort_layout.entry_size;
+			}
+		} else {
+			// Pin the blob data
+			if (!l_done) {
+				left->PinData(*l_sorted_block.blob_sorting_data);
+			}
+			if (!r_done) {
+				right->PinData(*r_sorted_block.blob_sorting_data);
+			}
+			// Merge with variable size sorting columns
+			for (; compared < count && l.entry_idx < l_count && r.entry_idx < r_count; compared++) {
+				left_smaller[compared] =
+				    Comparators::CompareTuple(*left, *right, l_radix_ptr, r_radix_ptr, sort_layout, state.external) < 0;
+				const bool &l_smaller = left_smaller[compared];
+				const bool r_smaller = !l_smaller;
+				// Use comparison bool (0 or 1) to increment entries and pointers
+				l.entry_idx += l_smaller;
+				r.entry_idx += r_smaller;
+				l_radix_ptr += l_smaller * sort_layout.entry_size;
+				r_radix_ptr += r_smaller * sort_layout.entry_size;
+			}
+		}
+	}
+	// Reset block indices
+	left->SetIndices(l_block_idx_before, l_entry_idx_before);
+	right->SetIndices(r_block_idx_before, r_entry_idx_before);
+}
+
+void MergeSorter::MergeRadix(const idx_t &count, const bool left_smaller[]) {
+	auto &l = *left;
+	auto &r = *right;
+	// Save indices to restore afterwards
+	idx_t l_block_idx_before = l.block_idx;
+	idx_t l_entry_idx_before = l.entry_idx;
+	idx_t r_block_idx_before = r.block_idx;
+	idx_t r_entry_idx_before = r.entry_idx;
+
+	auto &l_blocks = l.sb->radix_sorting_data;
+	auto &r_blocks = r.sb->radix_sorting_data;
+	RowDataBlock *l_block;
+	RowDataBlock *r_block;
+
+	data_ptr_t l_ptr;
+	data_ptr_t r_ptr;
+
+	RowDataBlock *result_block = &result->radix_sorting_data.back();
+	auto result_handle = buffer_manager.Pin(result_block->block);
+	data_ptr_t result_ptr = result_handle->Ptr() + result_block->count * sort_layout.entry_size;
+
+	idx_t copied = 0;
+	while (copied < count) {
+		// Move to the next block (if needed)
+		if (l.block_idx < l_blocks.size() && l.entry_idx == l_blocks[l.block_idx].count) {
+			// Delete reference to previous block
+			l_blocks[l.block_idx].block = nullptr;
+			// Advance block
+			l.block_idx++;
+			l.entry_idx = 0;
+		}
+		if (r.block_idx < r_blocks.size() && r.entry_idx == r_blocks[r.block_idx].count) {
+			// Delete reference to previous block
+			r_blocks[r.block_idx].block = nullptr;
+			// Advance block
+			r.block_idx++;
+			r.entry_idx = 0;
+		}
+		const bool l_done = l.block_idx == l_blocks.size();
+		const bool r_done = r.block_idx == r_blocks.size();
+		// Pin the radix sortable blocks
+		if (!l_done) {
+			l_block = &l_blocks[l.block_idx];
+			left->PinRadix(l.block_idx);
+			l_ptr = l.RadixPtr();
+		}
+		if (!r_done) {
+			r_block = &r_blocks[r.block_idx];
+			r.PinRadix(r.block_idx);
+			r_ptr = r.RadixPtr();
+		}
+		const idx_t &l_count = !l_done ? l_block->count : 0;
+		const idx_t &r_count = !r_done ? r_block->count : 0;
+		// Copy using computed merge
+		if (!l_done && !r_done) {
+			// Both sides have data - merge
+			MergeRows(l_ptr, l.entry_idx, l_count, r_ptr, r.entry_idx, r_count, result_block, result_ptr,
+			          sort_layout.entry_size, left_smaller, copied, count);
+		} else if (r_done) {
+			// Right side is exhausted
+			FlushRows(l_ptr, l.entry_idx, l_count, result_block, result_ptr, sort_layout.entry_size, copied, count);
+		} else {
+			// Left side is exhausted
+			FlushRows(r_ptr, r.entry_idx, r_count, result_block, result_ptr, sort_layout.entry_size, copied, count);
+		}
+	}
+	// Reset block indices
+	left->SetIndices(l_block_idx_before, l_entry_idx_before);
+	right->SetIndices(r_block_idx_before, r_entry_idx_before);
+}
+
+void MergeSorter::MergeData(SortedData &result_data, SortedData &l_data, SortedData &r_data, const idx_t &count,
+                            const bool left_smaller[], idx_t next_entry_sizes[], bool reset_indices) {
+	auto &l = *left;
+	auto &r = *right;
+	// Save indices to restore afterwards
+	idx_t l_block_idx_before = l.block_idx;
+	idx_t l_entry_idx_before = l.entry_idx;
+	idx_t r_block_idx_before = r.block_idx;
+	idx_t r_entry_idx_before = r.entry_idx;
+
+	const auto &layout = result_data.layout;
+	const idx_t row_width = layout.GetRowWidth();
+	const idx_t heap_pointer_offset = layout.GetHeapPointerOffset();
+
+	// Left and right row data to merge
+	data_ptr_t l_ptr;
+	data_ptr_t r_ptr;
+	// Accompanying left and right heap data (if needed)
+	data_ptr_t l_heap_ptr;
+	data_ptr_t r_heap_ptr;
+
+	// Result rows to write to
+	RowDataBlock *result_data_block = &result_data.data_blocks.back();
+	auto result_data_handle = buffer_manager.Pin(result_data_block->block);
+	data_ptr_t result_data_ptr = result_data_handle->Ptr() + result_data_block->count * row_width;
+	// Result heap to write to (if needed)
+	RowDataBlock *result_heap_block;
+	unique_ptr<BufferHandle> result_heap_handle;
+	data_ptr_t result_heap_ptr;
+	if (!layout.AllConstant() && state.external) {
+		result_heap_block = &result_data.heap_blocks.back();
+		result_heap_handle = buffer_manager.Pin(result_heap_block->block);
+		result_heap_ptr = result_heap_handle->Ptr() + result_heap_block->byte_offset;
+	}
+
+	idx_t copied = 0;
+	while (copied < count) {
+		// Move to new data blocks (if needed)
+		if (l.block_idx < l_data.data_blocks.size() && l.entry_idx == l_data.data_blocks[l.block_idx].count) {
+			// Delete reference to previous block
+			l_data.data_blocks[l.block_idx].block = nullptr;
+			if (!layout.AllConstant() && state.external) {
+				l_data.heap_blocks[l.block_idx].block = nullptr;
+			}
+			// Advance block
+			l.block_idx++;
+			l.entry_idx = 0;
+		}
+		if (r.block_idx < r_data.data_blocks.size() && r.entry_idx == r_data.data_blocks[r.block_idx].count) {
+			// Delete reference to previous block
+			r_data.data_blocks[r.block_idx].block = nullptr;
+			if (!layout.AllConstant() && state.external) {
+				r_data.heap_blocks[r.block_idx].block = nullptr;
+			}
+			// Advance block
+			r.block_idx++;
+			r.entry_idx = 0;
+		}
+		const bool l_done = l.block_idx == l_data.data_blocks.size();
+		const bool r_done = r.block_idx == r_data.data_blocks.size();
+		// Pin the row data blocks
+		if (!l_done) {
+			l.PinData(l_data);
+			l_ptr = l.DataPtr(l_data);
+		}
+		if (!r_done) {
+			r.PinData(r_data);
+			r_ptr = r.DataPtr(r_data);
+		}
+		const idx_t &l_count = !l_done ? l_data.data_blocks[l.block_idx].count : 0;
+		const idx_t &r_count = !r_done ? r_data.data_blocks[r.block_idx].count : 0;
+		// Perform the merge
+		if (layout.AllConstant() || !state.external) {
+			// If all constant size, or if we are doing an in-memory sort, we do not need to touch the heap
+			if (!l_done && !r_done) {
+				// Both sides have data - merge
+				MergeRows(l_ptr, l.entry_idx, l_count, r_ptr, r.entry_idx, r_count, result_data_block, result_data_ptr,
+				          row_width, left_smaller, copied, count);
+			} else if (r_done) {
+				// Right side is exhausted
+				FlushRows(l_ptr, l.entry_idx, l_count, result_data_block, result_data_ptr, row_width, copied, count);
+			} else {
+				// Left side is exhausted
+				FlushRows(r_ptr, r.entry_idx, r_count, result_data_block, result_data_ptr, row_width, copied, count);
+			}
+		} else {
+			// External sorting with variable size data. Pin the heap blocks too
+			if (!l_done) {
+				l_heap_ptr = l.BaseHeapPtr(l_data) + Load<idx_t>(l_ptr + heap_pointer_offset);
+				D_ASSERT(l_heap_ptr - l.BaseHeapPtr(l_data) >= 0);
+				D_ASSERT((idx_t)(l_heap_ptr - l.BaseHeapPtr(l_data)) < l_data.heap_blocks[l.block_idx].byte_offset);
+			}
+			if (!r_done) {
+				r_heap_ptr = r.BaseHeapPtr(r_data) + Load<idx_t>(r_ptr + heap_pointer_offset);
+				D_ASSERT(r_heap_ptr - r.BaseHeapPtr(r_data) >= 0);
+				D_ASSERT((idx_t)(r_heap_ptr - r.BaseHeapPtr(r_data)) < r_data.heap_blocks[r.block_idx].byte_offset);
+			}
+			// Both the row and heap data need to be dealt with
+			if (!l_done && !r_done) {
+				// Both sides have data - merge
+				idx_t l_idx_copy = l.entry_idx;
+				idx_t r_idx_copy = r.entry_idx;
+				data_ptr_t result_data_ptr_copy = result_data_ptr;
+				idx_t copied_copy = copied;
+				// Merge row data
+				MergeRows(l_ptr, l_idx_copy, l_count, r_ptr, r_idx_copy, r_count, result_data_block,
+				          result_data_ptr_copy, row_width, left_smaller, copied_copy, count);
+				const idx_t merged = copied_copy - copied;
+				// Compute the entry sizes and number of heap bytes that will be copied
+				idx_t copy_bytes = 0;
+				data_ptr_t l_heap_ptr_copy = l_heap_ptr;
+				data_ptr_t r_heap_ptr_copy = r_heap_ptr;
+				for (idx_t i = 0; i < merged; i++) {
+					// Store base heap offset in the row data
+					Store<idx_t>(result_heap_block->byte_offset + copy_bytes, result_data_ptr + heap_pointer_offset);
+					result_data_ptr += row_width;
+					// Compute entry size and add to total
+					const bool &l_smaller = left_smaller[copied + i];
+					const bool r_smaller = !l_smaller;
+					auto &entry_size = next_entry_sizes[copied + i];
+					entry_size =
+					    l_smaller * Load<uint32_t>(l_heap_ptr_copy) + r_smaller * Load<uint32_t>(r_heap_ptr_copy);
+					D_ASSERT(entry_size >= sizeof(uint32_t));
+					D_ASSERT(l_heap_ptr_copy - l.BaseHeapPtr(l_data) + l_smaller * entry_size <=
+					         l_data.heap_blocks[l.block_idx].byte_offset);
+					D_ASSERT(r_heap_ptr_copy - r.BaseHeapPtr(r_data) + r_smaller * entry_size <=
+					         r_data.heap_blocks[r.block_idx].byte_offset);
+					l_heap_ptr_copy += l_smaller * entry_size;
+					r_heap_ptr_copy += r_smaller * entry_size;
+					copy_bytes += entry_size;
+				}
+				// Reallocate result heap block size (if needed)
+				if (result_heap_block->byte_offset + copy_bytes > result_heap_block->capacity) {
+					idx_t new_capacity = result_heap_block->byte_offset + copy_bytes;
+					buffer_manager.ReAllocate(result_heap_block->block, new_capacity);
+					result_heap_block->capacity = new_capacity;
+					result_heap_ptr = result_heap_handle->Ptr() + result_heap_block->byte_offset;
+				}
+				D_ASSERT(result_heap_block->byte_offset + copy_bytes <= result_heap_block->capacity);
+				// Now copy the heap data
+				for (idx_t i = 0; i < merged; i++) {
+					const bool &l_smaller = left_smaller[copied + i];
+					const bool r_smaller = !l_smaller;
+					const auto &entry_size = next_entry_sizes[copied + i];
+					memcpy(result_heap_ptr, (data_ptr_t)(l_smaller * (idx_t)l_heap_ptr + r_smaller * (idx_t)r_heap_ptr),
+					       entry_size);
+					D_ASSERT(Load<uint32_t>(result_heap_ptr) == entry_size);
+					result_heap_ptr += entry_size;
+					l_heap_ptr += l_smaller * entry_size;
+					r_heap_ptr += r_smaller * entry_size;
+					l.entry_idx += l_smaller;
+					r.entry_idx += r_smaller;
+				}
+				// Update result indices and pointers
+				result_heap_block->count += merged;
+				result_heap_block->byte_offset += copy_bytes;
+				copied += merged;
+			} else if (r_done) {
+				// Right side is exhausted - flush left
+				FlushBlobs(layout, l_count, l_ptr, l.entry_idx, l_heap_ptr, result_data_block, result_data_ptr,
+				           result_heap_block, *result_heap_handle, result_heap_ptr, copied, count);
+			} else {
+				// Left side is exhausted - flush right
+				FlushBlobs(layout, r_count, r_ptr, r.entry_idx, r_heap_ptr, result_data_block, result_data_ptr,
+				           result_heap_block, *result_heap_handle, result_heap_ptr, copied, count);
+			}
+			D_ASSERT(result_data_block->count == result_heap_block->count);
+		}
+	}
+	if (reset_indices) {
+		left->SetIndices(l_block_idx_before, l_entry_idx_before);
+		right->SetIndices(r_block_idx_before, r_entry_idx_before);
+	}
+}
+
+void MergeSorter::MergeRows(data_ptr_t &l_ptr, idx_t &l_entry_idx, const idx_t &l_count, data_ptr_t &r_ptr,
+                            idx_t &r_entry_idx, const idx_t &r_count, RowDataBlock *target_block,
+                            data_ptr_t &target_ptr, const idx_t &entry_size, const bool left_smaller[], idx_t &copied,
+                            const idx_t &count) {
+	const idx_t next = MinValue(count - copied, target_block->capacity - target_block->count);
+	idx_t i;
+	for (i = 0; i < next && l_entry_idx < l_count && r_entry_idx < r_count; i++) {
+		const bool &l_smaller = left_smaller[copied + i];
+		const bool r_smaller = !l_smaller;
+		// Use comparison bool (0 or 1) to copy an entry from either side
+		FastMemcpy(target_ptr, (data_ptr_t)(l_smaller * (idx_t)l_ptr + r_smaller * (idx_t)r_ptr), entry_size);
+		target_ptr += entry_size;
+		// Use the comparison bool to increment entries and pointers
+		l_entry_idx += l_smaller;
+		r_entry_idx += r_smaller;
+		l_ptr += l_smaller * entry_size;
+		r_ptr += r_smaller * entry_size;
+	}
+	// Update counts
+	target_block->count += i;
+	copied += i;
+}
+
+void MergeSorter::FlushRows(data_ptr_t &source_ptr, idx_t &source_entry_idx, const idx_t &source_count,
+                            RowDataBlock *target_block, data_ptr_t &target_ptr, const idx_t &entry_size, idx_t &copied,
+                            const idx_t &count) {
+	// Compute how many entries we can fit
+	idx_t next = MinValue(count - copied, target_block->capacity - target_block->count);
+	next = MinValue(next, source_count - source_entry_idx);
+	// Copy them all in a single memcpy
+	const idx_t copy_bytes = next * entry_size;
+	memcpy(target_ptr, source_ptr, copy_bytes);
+	target_ptr += copy_bytes;
+	source_ptr += copy_bytes;
+	// Update counts
+	source_entry_idx += next;
+	target_block->count += next;
+	copied += next;
+}
+
+void MergeSorter::FlushBlobs(const RowLayout &layout, const idx_t &source_count, data_ptr_t &source_data_ptr,
+                             idx_t &source_entry_idx, data_ptr_t &source_heap_ptr, RowDataBlock *target_data_block,
+                             data_ptr_t &target_data_ptr, RowDataBlock *target_heap_block,
+                             BufferHandle &target_heap_handle, data_ptr_t &target_heap_ptr, idx_t &copied,
+                             const idx_t &count) {
+	const idx_t row_width = layout.GetRowWidth();
+	const idx_t heap_pointer_offset = layout.GetHeapPointerOffset();
+	idx_t source_entry_idx_copy = source_entry_idx;
+	data_ptr_t target_data_ptr_copy = target_data_ptr;
+	idx_t copied_copy = copied;
+	// Flush row data
+	FlushRows(source_data_ptr, source_entry_idx_copy, source_count, target_data_block, target_data_ptr_copy, row_width,
+	          copied_copy, count);
+	const idx_t flushed = copied_copy - copied;
+	// Compute the entry sizes and number of heap bytes that will be copied
+	idx_t copy_bytes = 0;
+	data_ptr_t source_heap_ptr_copy = source_heap_ptr;
+	for (idx_t i = 0; i < flushed; i++) {
+		// Store base heap offset in the row data
+		Store<idx_t>(target_heap_block->byte_offset + copy_bytes, target_data_ptr + heap_pointer_offset);
+		target_data_ptr += row_width;
+		// Compute entry size and add to total
+		auto entry_size = Load<uint32_t>(source_heap_ptr_copy);
+		D_ASSERT(entry_size >= sizeof(uint32_t));
+		source_heap_ptr_copy += entry_size;
+		copy_bytes += entry_size;
+	}
+	// Reallocate result heap block size (if needed)
+	if (target_heap_block->byte_offset + copy_bytes > target_heap_block->capacity) {
+		idx_t new_capacity = target_heap_block->byte_offset + copy_bytes;
+		buffer_manager.ReAllocate(target_heap_block->block, new_capacity);
+		target_heap_block->capacity = new_capacity;
+		target_heap_ptr = target_heap_handle.Ptr() + target_heap_block->byte_offset;
+	}
+	D_ASSERT(target_heap_block->byte_offset + copy_bytes <= target_heap_block->capacity);
+	// Copy the heap data in one go
+	memcpy(target_heap_ptr, source_heap_ptr, copy_bytes);
+	target_heap_ptr += copy_bytes;
+	source_heap_ptr += copy_bytes;
+	source_entry_idx += flushed;
+	copied += flushed;
+	// Update result indices and pointers
+	target_heap_block->count += flushed;
+	target_heap_block->byte_offset += copy_bytes;
+	D_ASSERT(target_heap_block->byte_offset <= target_heap_block->capacity);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+//! Calls std::sort on strings that are tied by their prefix after the radix sort
+static void SortTiedBlobs(BufferManager &buffer_manager, const data_ptr_t dataptr, const idx_t &start, const idx_t &end,
+                          const idx_t &tie_col, bool *ties, const data_ptr_t blob_ptr, const SortLayout &sort_layout) {
+	const auto row_width = sort_layout.blob_layout.GetRowWidth();
+	const idx_t &col_idx = sort_layout.sorting_to_blob_col.at(tie_col);
+	// Locate the first blob row in question
+	data_ptr_t row_ptr = dataptr + start * sort_layout.entry_size;
+	data_ptr_t blob_row_ptr = blob_ptr + Load<uint32_t>(row_ptr + sort_layout.comparison_size) * row_width;
+	if (!Comparators::TieIsBreakable(col_idx, blob_row_ptr, sort_layout.blob_layout)) {
+		// Quick check to see if ties can be broken
+		return;
+	}
+	// Fill pointer array for sorting
+	auto ptr_block = unique_ptr<data_ptr_t[]>(new data_ptr_t[end - start]);
+	auto entry_ptrs = (data_ptr_t *)ptr_block.get();
+	for (idx_t i = start; i < end; i++) {
+		entry_ptrs[i - start] = row_ptr;
+		row_ptr += sort_layout.entry_size;
+	}
+	// Slow pointer-based sorting
+	const int order = sort_layout.order_types[tie_col] == OrderType::DESCENDING ? -1 : 1;
+	const auto &tie_col_offset = sort_layout.blob_layout.GetOffsets()[col_idx];
+	auto logical_type = sort_layout.blob_layout.GetTypes()[col_idx];
+	std::sort(entry_ptrs, entry_ptrs + end - start,
+	          [&blob_ptr, &order, &sort_layout, &tie_col_offset, &row_width, &logical_type](const data_ptr_t l,
+	                                                                                        const data_ptr_t r) {
+		          idx_t left_idx = Load<uint32_t>(l + sort_layout.comparison_size);
+		          idx_t right_idx = Load<uint32_t>(r + sort_layout.comparison_size);
+		          data_ptr_t left_ptr = blob_ptr + left_idx * row_width + tie_col_offset;
+		          data_ptr_t right_ptr = blob_ptr + right_idx * row_width + tie_col_offset;
+		          return order * Comparators::CompareVal(left_ptr, right_ptr, logical_type) < 0;
+	          });
+	// Re-order
+	auto temp_block =
+	    buffer_manager.Allocate(MaxValue((end - start) * sort_layout.entry_size, (idx_t)Storage::BLOCK_SIZE));
+	data_ptr_t temp_ptr = temp_block->Ptr();
+	for (idx_t i = 0; i < end - start; i++) {
+		FastMemcpy(temp_ptr, entry_ptrs[i], sort_layout.entry_size);
+		temp_ptr += sort_layout.entry_size;
+	}
+	memcpy(dataptr + start * sort_layout.entry_size, temp_block->Ptr(), (end - start) * sort_layout.entry_size);
+	// Determine if there are still ties (if this is not the last column)
+	if (tie_col < sort_layout.column_count - 1) {
+		data_ptr_t idx_ptr = dataptr + start * sort_layout.entry_size + sort_layout.comparison_size;
+		// Load current entry
+		data_ptr_t current_ptr = blob_ptr + Load<uint32_t>(idx_ptr) * row_width + tie_col_offset;
+		for (idx_t i = 0; i < end - start - 1; i++) {
+			// Load next entry and compare
+			idx_ptr += sort_layout.entry_size;
+			data_ptr_t next_ptr = blob_ptr + Load<uint32_t>(idx_ptr) * row_width + tie_col_offset;
+			ties[start + i] = Comparators::CompareVal(current_ptr, next_ptr, logical_type) == 0;
+			current_ptr = next_ptr;
+		}
+	}
+}
+
+//! Identifies sequences of rows that are tied by the prefix of a blob column, and sorts them
+static void SortTiedBlobs(BufferManager &buffer_manager, SortedBlock &sb, bool *ties, data_ptr_t dataptr,
+                          const idx_t &count, const idx_t &tie_col, const SortLayout &sort_layout) {
+	D_ASSERT(!ties[count - 1]);
+	auto &blob_block = sb.blob_sorting_data->data_blocks.back();
+	auto blob_handle = buffer_manager.Pin(blob_block.block);
+	const data_ptr_t blob_ptr = blob_handle->Ptr();
+
+	for (idx_t i = 0; i < count; i++) {
+		if (!ties[i]) {
+			continue;
+		}
+		idx_t j;
+		for (j = i; j < count; j++) {
+			if (!ties[j]) {
+				break;
+			}
+		}
+		SortTiedBlobs(buffer_manager, dataptr, i, j + 1, tie_col, ties, blob_ptr, sort_layout);
+		i = j;
+	}
+}
+
+//! Returns whether there are any 'true' values in the ties[] array
+static bool AnyTies(bool ties[], const idx_t &count) {
+	D_ASSERT(!ties[count - 1]);
+	bool any_ties = false;
+	for (idx_t i = 0; i < count - 1; i++) {
+		any_ties = any_ties || ties[i];
+	}
+	return any_ties;
+}
+
+//! Compares subsequent rows to check for ties
+static void ComputeTies(data_ptr_t dataptr, const idx_t &count, const idx_t &col_offset, const idx_t &tie_size,
+                        bool ties[], const SortLayout &sort_layout) {
+	D_ASSERT(!ties[count - 1]);
+	D_ASSERT(col_offset + tie_size <= sort_layout.comparison_size);
+	// Align dataptr
+	dataptr += col_offset;
+	for (idx_t i = 0; i < count - 1; i++) {
+		ties[i] = ties[i] && FastMemcmp(dataptr, dataptr + sort_layout.entry_size, tie_size) == 0;
+		dataptr += sort_layout.entry_size;
+	}
+}
+
+//! Textbook LSD radix sort
+void RadixSortLSD(BufferManager &buffer_manager, const data_ptr_t &dataptr, const idx_t &count, const idx_t &col_offset,
+                  const idx_t &row_width, const idx_t &sorting_size) {
+	auto temp_block = buffer_manager.Allocate(MaxValue(count * row_width, (idx_t)Storage::BLOCK_SIZE));
+	bool swap = false;
+
+	idx_t counts[SortConstants::VALUES_PER_RADIX];
+	for (idx_t r = 1; r <= sorting_size; r++) {
+		// Init counts to 0
+		memset(counts, 0, sizeof(counts));
+		// Const some values for convenience
+		const data_ptr_t source_ptr = swap ? temp_block->Ptr() : dataptr;
+		const data_ptr_t target_ptr = swap ? dataptr : temp_block->Ptr();
+		const idx_t offset = col_offset + sorting_size - r;
+		// Collect counts
+		data_ptr_t offset_ptr = source_ptr + offset;
+		for (idx_t i = 0; i < count; i++) {
+			counts[*offset_ptr]++;
+			offset_ptr += row_width;
+		}
+		// Compute offsets from counts
+		idx_t max_count = counts[0];
+		for (idx_t val = 1; val < SortConstants::VALUES_PER_RADIX; val++) {
+			max_count = MaxValue<idx_t>(max_count, counts[val]);
+			counts[val] = counts[val] + counts[val - 1];
+		}
+		if (max_count == count) {
+			continue;
+		}
+		// Re-order the data in temporary array
+		data_ptr_t row_ptr = source_ptr + (count - 1) * row_width;
+		for (idx_t i = 0; i < count; i++) {
+			idx_t &radix_offset = --counts[*(row_ptr + offset)];
+			FastMemcpy(target_ptr + radix_offset * row_width, row_ptr, row_width);
+			row_ptr -= row_width;
+		}
+		swap = !swap;
+	}
+	// Move data back to original buffer (if it was swapped)
+	if (swap) {
+		memcpy(dataptr, temp_block->Ptr(), count * row_width);
+	}
+}
+
+//! Insertion sort, used when count of values is low
+inline void InsertionSort(const data_ptr_t orig_ptr, const data_ptr_t temp_ptr, const idx_t &count,
+                          const idx_t &col_offset, const idx_t &row_width, const idx_t &total_comp_width,
+                          const idx_t &offset, bool swap) {
+	const data_ptr_t source_ptr = swap ? temp_ptr : orig_ptr;
+	const data_ptr_t target_ptr = swap ? orig_ptr : temp_ptr;
+	if (count > 1) {
+		const idx_t total_offset = col_offset + offset;
+		auto temp_val = unique_ptr<data_t[]>(new data_t[row_width]);
+		const data_ptr_t val = temp_val.get();
+		const auto comp_width = total_comp_width - offset;
+		for (idx_t i = 1; i < count; i++) {
+			FastMemcpy(val, source_ptr + i * row_width, row_width);
+			idx_t j = i;
+			while (j > 0 &&
+			       FastMemcmp(source_ptr + (j - 1) * row_width + total_offset, val + total_offset, comp_width) > 0) {
+				FastMemcpy(source_ptr + j * row_width, source_ptr + (j - 1) * row_width, row_width);
+				j--;
+			}
+			FastMemcpy(source_ptr + j * row_width, val, row_width);
+		}
+	}
+	if (swap) {
+		memcpy(target_ptr, source_ptr, count * row_width);
+	}
+}
+
+//! MSD radix sort that switches to insertion sort with low bucket sizes
+void RadixSortMSD(const data_ptr_t orig_ptr, const data_ptr_t temp_ptr, const idx_t &count, const idx_t &col_offset,
+                  const idx_t &row_width, const idx_t &comp_width, const idx_t &offset, idx_t locations[], bool swap) {
+	const data_ptr_t source_ptr = swap ? temp_ptr : orig_ptr;
+	const data_ptr_t target_ptr = swap ? orig_ptr : temp_ptr;
+	// Init counts to 0
+	memset(locations, 0, SortConstants::MSD_RADIX_LOCATIONS * sizeof(idx_t));
+	idx_t *counts = locations + 1;
+	// Collect counts
+	const idx_t total_offset = col_offset + offset;
+	data_ptr_t offset_ptr = source_ptr + total_offset;
+	for (idx_t i = 0; i < count; i++) {
+		counts[*offset_ptr]++;
+		offset_ptr += row_width;
+	}
+	// Compute locations from counts
+	idx_t max_count = 0;
+	for (idx_t radix = 0; radix < SortConstants::VALUES_PER_RADIX; radix++) {
+		max_count = MaxValue<idx_t>(max_count, counts[radix]);
+		counts[radix] += locations[radix];
+	}
+	if (max_count != count) {
+		// Re-order the data in temporary array
+		data_ptr_t row_ptr = source_ptr;
+		for (idx_t i = 0; i < count; i++) {
+			const idx_t &radix_offset = locations[*(row_ptr + total_offset)]++;
+			FastMemcpy(target_ptr + radix_offset * row_width, row_ptr, row_width);
+			row_ptr += row_width;
+		}
+		swap = !swap;
+	}
+	// Check if done
+	if (offset == comp_width - 1) {
+		if (swap) {
+			memcpy(orig_ptr, temp_ptr, count * row_width);
+		}
+		return;
+	}
+	if (max_count == count) {
+		RadixSortMSD(orig_ptr, temp_ptr, count, col_offset, row_width, comp_width, offset + 1,
+		             locations + SortConstants::MSD_RADIX_LOCATIONS, swap);
+		return;
+	}
+	// Recurse
+	idx_t radix_count = locations[0];
+	for (idx_t radix = 0; radix < SortConstants::VALUES_PER_RADIX; radix++) {
+		const idx_t loc = (locations[radix] - radix_count) * row_width;
+		if (radix_count > SortConstants::INSERTION_SORT_THRESHOLD) {
+			RadixSortMSD(orig_ptr + loc, temp_ptr + loc, radix_count, col_offset, row_width, comp_width, offset + 1,
+			             locations + SortConstants::MSD_RADIX_LOCATIONS, swap);
+		} else if (radix_count != 0) {
+			InsertionSort(orig_ptr + loc, temp_ptr + loc, radix_count, col_offset, row_width, comp_width, offset + 1,
+			              swap);
+		}
+		radix_count = locations[radix + 1] - locations[radix];
+	}
+}
+
+//! Calls different sort functions, depending on the count and sorting sizes
+void RadixSort(BufferManager &buffer_manager, const data_ptr_t &dataptr, const idx_t &count, const idx_t &col_offset,
+               const idx_t &sorting_size, const SortLayout &sort_layout) {
+	if (count <= SortConstants::INSERTION_SORT_THRESHOLD) {
+		InsertionSort(dataptr, nullptr, count, 0, sort_layout.entry_size, sort_layout.comparison_size, 0, false);
+	} else if (sorting_size <= SortConstants::MSD_RADIX_SORT_SIZE_THRESHOLD) {
+		RadixSortLSD(buffer_manager, dataptr, count, col_offset, sort_layout.entry_size, sorting_size);
+	} else {
+		auto temp_block = buffer_manager.Allocate(MaxValue(count * sort_layout.entry_size, (idx_t)Storage::BLOCK_SIZE));
+		auto preallocated_array = unique_ptr<idx_t[]>(new idx_t[sorting_size * SortConstants::MSD_RADIX_LOCATIONS]);
+		RadixSortMSD(dataptr, temp_block->Ptr(), count, col_offset, sort_layout.entry_size, sorting_size, 0,
+		             preallocated_array.get(), false);
+	}
+}
+
+//! Identifies sequences of rows that are tied, and calls radix sort on these
+static void SubSortTiedTuples(BufferManager &buffer_manager, const data_ptr_t dataptr, const idx_t &count,
+                              const idx_t &col_offset, const idx_t &sorting_size, bool ties[],
+                              const SortLayout &sort_layout) {
+	D_ASSERT(!ties[count - 1]);
+	for (idx_t i = 0; i < count; i++) {
+		if (!ties[i]) {
+			continue;
+		}
+		idx_t j;
+		for (j = i + 1; j < count; j++) {
+			if (!ties[j]) {
+				break;
+			}
+		}
+		RadixSort(buffer_manager, dataptr + i * sort_layout.entry_size, j - i + 1, col_offset, sorting_size,
+		          sort_layout);
+		i = j;
+	}
+}
+
+void LocalSortState::SortInMemory() {
+	auto &sb = *sorted_blocks.back();
+	auto &block = sb.radix_sorting_data.back();
+	const auto &count = block.count;
+	auto handle = buffer_manager->Pin(block.block);
+	const auto dataptr = handle->Ptr();
+	// Assign an index to each row
+	data_ptr_t idx_dataptr = dataptr + sort_layout->comparison_size;
+	for (uint32_t i = 0; i < count; i++) {
+		Store<uint32_t>(i, idx_dataptr);
+		idx_dataptr += sort_layout->entry_size;
+	}
+	// Radix sort and break ties until no more ties, or until all columns are sorted
+	idx_t sorting_size = 0;
+	idx_t col_offset = 0;
+	unique_ptr<bool[]> ties_ptr;
+	bool *ties = nullptr;
+	for (idx_t i = 0; i < sort_layout->column_count; i++) {
+		sorting_size += sort_layout->column_sizes[i];
+		if (sort_layout->constant_size[i] && i < sort_layout->column_count - 1) {
+			// Add columns to the sorting size until we reach a variable size column, or the last column
+			continue;
+		}
+
+		if (!ties) {
+			// This is the first sort
+			RadixSort(*buffer_manager, dataptr, count, col_offset, sorting_size, *sort_layout);
+			ties_ptr = unique_ptr<bool[]>(new bool[count]);
+			ties = ties_ptr.get();
+			std::fill_n(ties, count - 1, true);
+			ties[count - 1] = false;
+		} else {
+			// For subsequent sorts, we only have to subsort the tied tuples
+			SubSortTiedTuples(*buffer_manager, dataptr, count, col_offset, sorting_size, ties, *sort_layout);
+		}
+
+		if (sort_layout->constant_size[i] && i == sort_layout->column_count - 1) {
+			// All columns are sorted, no ties to break because last column is constant size
+			break;
+		}
+
+		ComputeTies(dataptr, count, col_offset, sorting_size, ties, *sort_layout);
+		if (!AnyTies(ties, count)) {
+			// No ties, stop sorting
+			break;
+		}
+
+		if (!sort_layout->constant_size[i]) {
+			SortTiedBlobs(*buffer_manager, sb, ties, dataptr, count, i, *sort_layout);
+			if (!AnyTies(ties, count)) {
+				// No more ties after tie-breaking, stop
+				break;
+			}
+		}
+
+		col_offset += sorting_size;
+		sorting_size = 0;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <numeric>
+
+namespace duckdb {
+
+idx_t GetNestedSortingColSize(idx_t &col_size, const LogicalType &type) {
+	auto physical_type = type.InternalType();
+	if (TypeIsConstantSize(physical_type)) {
+		col_size += GetTypeIdSize(physical_type);
+		return 0;
+	} else {
+		switch (physical_type) {
+		case PhysicalType::VARCHAR: {
+			// Nested strings are between 4 and 11 chars long for alignment
+			auto size_before_str = col_size;
+			col_size += 11;
+			col_size -= (col_size - 12) % 8;
+			return col_size - size_before_str;
+		}
+		case PhysicalType::LIST:
+			// Lists get 2 bytes (null and empty list)
+			col_size += 2;
+			return GetNestedSortingColSize(col_size, ListType::GetChildType(type));
+		case PhysicalType::MAP:
+		case PhysicalType::STRUCT:
+			// Structs get 1 bytes (null)
+			col_size++;
+			return GetNestedSortingColSize(col_size, StructType::GetChildType(type, 0));
+		default:
+			throw NotImplementedException("Unable to order column with type %s", type.ToString());
+		}
+	}
+}
+
+SortLayout::SortLayout(const vector<BoundOrderByNode> &orders)
+    : column_count(orders.size()), all_constant(true), comparison_size(0), entry_size(0) {
+	vector<LogicalType> blob_layout_types;
+	for (idx_t i = 0; i < column_count; i++) {
+		const auto &order = orders[i];
+
+		order_types.push_back(order.type);
+		order_by_null_types.push_back(order.null_order);
+		auto &expr = *order.expression;
+		logical_types.push_back(expr.return_type);
+
+		auto physical_type = expr.return_type.InternalType();
+		constant_size.push_back(TypeIsConstantSize(physical_type));
+
+		if (order.stats) {
+			stats.push_back(order.stats.get());
+			has_null.push_back(stats.back()->CanHaveNull());
+		} else {
+			stats.push_back(nullptr);
+			has_null.push_back(true);
+		}
+
+		idx_t col_size = has_null.back() ? 1 : 0;
+		prefix_lengths.push_back(0);
+		if (!TypeIsConstantSize(physical_type) && physical_type != PhysicalType::VARCHAR) {
+			prefix_lengths.back() = GetNestedSortingColSize(col_size, expr.return_type);
+		} else if (physical_type == PhysicalType::VARCHAR) {
+			idx_t size_before = col_size;
+			if (stats.back()) {
+				auto &str_stats = (StringStatistics &)*stats.back();
+				col_size += str_stats.max_string_length;
+				if (col_size > 12) {
+					col_size = 12;
+				} else {
+					constant_size.back() = true;
+				}
+			} else {
+				col_size = 12;
+			}
+			prefix_lengths.back() = col_size - size_before;
+		} else {
+			col_size += GetTypeIdSize(physical_type);
+		}
+
+		comparison_size += col_size;
+		column_sizes.push_back(col_size);
+	}
+	entry_size = comparison_size + sizeof(uint32_t);
+
+	// 8-byte alignment
+	if (entry_size % 8 != 0) {
+		// First assign more bytes to strings instead of aligning
+		idx_t bytes_to_fill = 8 - (entry_size % 8);
+		for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+			if (bytes_to_fill == 0) {
+				break;
+			}
+			if (logical_types[col_idx].InternalType() == PhysicalType::VARCHAR && stats[col_idx]) {
+				auto &str_stats = (StringStatistics &)*stats[col_idx];
+				idx_t diff = str_stats.max_string_length - prefix_lengths[col_idx];
+				if (diff > 0) {
+					// Increase all sizes accordingly
+					idx_t increase = MinValue(bytes_to_fill, diff);
+					column_sizes[col_idx] += increase;
+					prefix_lengths[col_idx] += increase;
+					constant_size[col_idx] = increase == diff;
+					comparison_size += increase;
+					entry_size += increase;
+					bytes_to_fill -= increase;
+				}
+			}
+		}
+		entry_size = AlignValue(entry_size);
+	}
+
+	for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+		all_constant = all_constant && constant_size[col_idx];
+		if (!constant_size[col_idx]) {
+			sorting_to_blob_col[col_idx] = blob_layout_types.size();
+			blob_layout_types.push_back(logical_types[col_idx]);
+		}
+	}
+
+	blob_layout.Initialize(blob_layout_types);
+}
+
+LocalSortState::LocalSortState() : initialized(false) {
+}
+
+static idx_t EntriesPerBlock(idx_t width) {
+	return (Storage::BLOCK_SIZE + width * STANDARD_VECTOR_SIZE - 1) / width;
+}
+
+void LocalSortState::Initialize(GlobalSortState &global_sort_state, BufferManager &buffer_manager_p) {
+	sort_layout = &global_sort_state.sort_layout;
+	payload_layout = &global_sort_state.payload_layout;
+	buffer_manager = &buffer_manager_p;
+	// Radix sorting data
+	radix_sorting_data = make_unique<RowDataCollection>(*buffer_manager, EntriesPerBlock(sort_layout->entry_size),
+	                                                    sort_layout->entry_size);
+	// Blob sorting data
+	if (!sort_layout->all_constant) {
+		auto blob_row_width = sort_layout->blob_layout.GetRowWidth();
+		blob_sorting_data =
+		    make_unique<RowDataCollection>(*buffer_manager, EntriesPerBlock(blob_row_width), blob_row_width);
+		blob_sorting_heap = make_unique<RowDataCollection>(*buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1, true);
+	}
+	// Payload data
+	auto payload_row_width = payload_layout->GetRowWidth();
+	payload_data =
+	    make_unique<RowDataCollection>(*buffer_manager, EntriesPerBlock(payload_row_width), payload_row_width);
+	payload_heap = make_unique<RowDataCollection>(*buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1, true);
+	// Init done
+	initialized = true;
+}
+
+void LocalSortState::SinkChunk(DataChunk &sort, DataChunk &payload) {
+	D_ASSERT(sort.size() == payload.size());
+	// Build and serialize sorting data to radix sortable rows
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+	auto handles = radix_sorting_data->Build(sort.size(), data_pointers, nullptr);
+	for (idx_t sort_col = 0; sort_col < sort.ColumnCount(); sort_col++) {
+		bool has_null = sort_layout->has_null[sort_col];
+		bool nulls_first = sort_layout->order_by_null_types[sort_col] == OrderByNullType::NULLS_FIRST;
+		bool desc = sort_layout->order_types[sort_col] == OrderType::DESCENDING;
+		RowOperations::RadixScatter(sort.data[sort_col], sort.size(), sel_ptr, sort.size(), data_pointers, desc,
+		                            has_null, nulls_first, sort_layout->prefix_lengths[sort_col],
+		                            sort_layout->column_sizes[sort_col]);
+	}
+
+	// Also fully serialize blob sorting columns (to be able to break ties
+	if (!sort_layout->all_constant) {
+		DataChunk blob_chunk;
+		blob_chunk.SetCardinality(sort.size());
+		for (idx_t sort_col = 0; sort_col < sort.ColumnCount(); sort_col++) {
+			if (!sort_layout->constant_size[sort_col]) {
+				blob_chunk.data.emplace_back(sort.data[sort_col]);
+			}
+		}
+		handles = blob_sorting_data->Build(blob_chunk.size(), data_pointers, nullptr);
+		auto blob_data = blob_chunk.Orrify();
+		RowOperations::Scatter(blob_chunk, blob_data.get(), sort_layout->blob_layout, addresses, *blob_sorting_heap,
+		                       sel_ptr, blob_chunk.size());
+	}
+
+	// Finally, serialize payload data
+	handles = payload_data->Build(payload.size(), data_pointers, nullptr);
+	auto input_data = payload.Orrify();
+	RowOperations::Scatter(payload, input_data.get(), *payload_layout, addresses, *payload_heap, sel_ptr,
+	                       payload.size());
+}
+
+idx_t LocalSortState::SizeInBytes() const {
+	idx_t size_in_bytes = radix_sorting_data->SizeInBytes() + payload_data->SizeInBytes();
+	if (!sort_layout->all_constant) {
+		size_in_bytes += blob_sorting_data->SizeInBytes() + blob_sorting_heap->SizeInBytes();
+	}
+	if (!payload_layout->AllConstant()) {
+		size_in_bytes += payload_heap->SizeInBytes();
+	}
+	return size_in_bytes;
+}
+
+void LocalSortState::Sort(GlobalSortState &global_sort_state, bool reorder_heap) {
+	D_ASSERT(radix_sorting_data->count == payload_data->count);
+	if (radix_sorting_data->count == 0) {
+		return;
+	}
+	// Move all data to a single SortedBlock
+	sorted_blocks.emplace_back(make_unique<SortedBlock>(*buffer_manager, global_sort_state));
+	auto &sb = *sorted_blocks.back();
+	// Fixed-size sorting data
+	auto sorting_block = ConcatenateBlocks(*radix_sorting_data);
+	sb.radix_sorting_data.push_back(move(sorting_block));
+	// Variable-size sorting data
+	if (!sort_layout->all_constant) {
+		auto &blob_data = *blob_sorting_data;
+		auto new_block = ConcatenateBlocks(blob_data);
+		sb.blob_sorting_data->data_blocks.push_back(move(new_block));
+	}
+	// Payload data
+	auto payload_block = ConcatenateBlocks(*payload_data);
+	sb.payload_data->data_blocks.push_back(move(payload_block));
+	// Now perform the actual sort
+	SortInMemory();
+	// Re-order before the merge sort
+	ReOrder(global_sort_state, reorder_heap);
+}
+
+RowDataBlock LocalSortState::ConcatenateBlocks(RowDataCollection &row_data) {
+	// Create block with the correct capacity
+	const idx_t &entry_size = row_data.entry_size;
+	idx_t capacity = MaxValue(((idx_t)Storage::BLOCK_SIZE + entry_size - 1) / entry_size, row_data.count);
+	RowDataBlock new_block(*buffer_manager, capacity, entry_size);
+	new_block.count = row_data.count;
+	auto new_block_handle = buffer_manager->Pin(new_block.block);
+	data_ptr_t new_block_ptr = new_block_handle->Ptr();
+	// Copy the data of the blocks into a single block
+	for (auto &block : row_data.blocks) {
+		auto block_handle = buffer_manager->Pin(block.block);
+		memcpy(new_block_ptr, block_handle->Ptr(), block.count * entry_size);
+		new_block_ptr += block.count * entry_size;
+	}
+	row_data.blocks.clear();
+	row_data.count = 0;
+	return new_block;
+}
+
+void LocalSortState::ReOrder(SortedData &sd, data_ptr_t sorting_ptr, RowDataCollection &heap, GlobalSortState &gstate,
+                             bool reorder_heap) {
+	sd.swizzled = reorder_heap;
+	auto &unordered_data_block = sd.data_blocks.back();
+	const idx_t &count = unordered_data_block.count;
+	auto unordered_data_handle = buffer_manager->Pin(unordered_data_block.block);
+	const data_ptr_t unordered_data_ptr = unordered_data_handle->Ptr();
+	// Create new block that will hold re-ordered row data
+	RowDataBlock ordered_data_block(*buffer_manager, unordered_data_block.capacity, unordered_data_block.entry_size);
+	ordered_data_block.count = count;
+	auto ordered_data_handle = buffer_manager->Pin(ordered_data_block.block);
+	data_ptr_t ordered_data_ptr = ordered_data_handle->Ptr();
+	// Re-order fixed-size row layout
+	const idx_t row_width = sd.layout.GetRowWidth();
+	const idx_t sorting_entry_size = gstate.sort_layout.entry_size;
+	for (idx_t i = 0; i < count; i++) {
+		auto index = Load<uint32_t>(sorting_ptr);
+		FastMemcpy(ordered_data_ptr, unordered_data_ptr + index * row_width, row_width);
+		ordered_data_ptr += row_width;
+		sorting_ptr += sorting_entry_size;
+	}
+	// Replace the unordered data block with the re-ordered data block
+	sd.data_blocks.clear();
+	sd.data_blocks.push_back(move(ordered_data_block));
+	// Deal with the heap (if necessary)
+	if (!sd.layout.AllConstant() && reorder_heap) {
+		// Swizzle the column pointers to offsets
+		RowOperations::SwizzleColumns(sd.layout, ordered_data_handle->Ptr(), count);
+		// Create a single heap block to store the ordered heap
+		idx_t total_byte_offset = std::accumulate(heap.blocks.begin(), heap.blocks.end(), 0,
+		                                          [](idx_t a, const RowDataBlock &b) { return a + b.byte_offset; });
+		idx_t heap_block_size = MaxValue(total_byte_offset, (idx_t)Storage::BLOCK_SIZE);
+		RowDataBlock ordered_heap_block(*buffer_manager, heap_block_size, 1);
+		ordered_heap_block.count = count;
+		ordered_heap_block.byte_offset = total_byte_offset;
+		auto ordered_heap_handle = buffer_manager->Pin(ordered_heap_block.block);
+		data_ptr_t ordered_heap_ptr = ordered_heap_handle->Ptr();
+		// Fill the heap in order
+		ordered_data_ptr = ordered_data_handle->Ptr();
+		const idx_t heap_pointer_offset = sd.layout.GetHeapPointerOffset();
+		for (idx_t i = 0; i < count; i++) {
+			auto heap_row_ptr = Load<data_ptr_t>(ordered_data_ptr + heap_pointer_offset);
+			auto heap_row_size = Load<uint32_t>(heap_row_ptr);
+			memcpy(ordered_heap_ptr, heap_row_ptr, heap_row_size);
+			ordered_heap_ptr += heap_row_size;
+			ordered_data_ptr += row_width;
+		}
+		// Swizzle the base pointer to the offset of each row in the heap
+		RowOperations::SwizzleHeapPointer(sd.layout, ordered_data_handle->Ptr(), ordered_heap_handle->Ptr(), count);
+		// Move the re-ordered heap to the SortedData, and clear the local heap
+		sd.heap_blocks.push_back(move(ordered_heap_block));
+		heap.pinned_blocks.clear();
+		heap.blocks.clear();
+		heap.count = 0;
+	}
+}
+
+void LocalSortState::ReOrder(GlobalSortState &gstate, bool reorder_heap) {
+	auto &sb = *sorted_blocks.back();
+	auto sorting_handle = buffer_manager->Pin(sb.radix_sorting_data.back().block);
+	const data_ptr_t sorting_ptr = sorting_handle->Ptr() + gstate.sort_layout.comparison_size;
+	// Re-order variable size sorting columns
+	if (!gstate.sort_layout.all_constant) {
+		ReOrder(*sb.blob_sorting_data, sorting_ptr, *blob_sorting_heap, gstate, reorder_heap);
+	}
+	// And the payload
+	ReOrder(*sb.payload_data, sorting_ptr, *payload_heap, gstate, reorder_heap);
+}
+
+GlobalSortState::GlobalSortState(BufferManager &buffer_manager, const vector<BoundOrderByNode> &orders,
+                                 RowLayout &payload_layout)
+    : buffer_manager(buffer_manager), sort_layout(SortLayout(orders)), payload_layout(payload_layout),
+      block_capacity(0), external(false) {
+}
+
+void GlobalSortState::AddLocalState(LocalSortState &local_sort_state) {
+	if (!local_sort_state.radix_sorting_data) {
+		return;
+	}
+
+	// Sort accumulated data
+	// we only re-order the heap when the data is expected to not fit in memory
+	// re-ordering the heap avoids random access when reading/merging but incurs a significant cost of shuffling data
+	// when data fits in memory, doing random access on reads is cheaper than re-shuffling
+	local_sort_state.Sort(*this, external || !local_sort_state.sorted_blocks.empty());
+
+	// Append local state sorted data to this global state
+	lock_guard<mutex> append_guard(lock);
+	for (auto &sb : local_sort_state.sorted_blocks) {
+		sorted_blocks.push_back(move(sb));
+	}
+	auto &payload_heap = local_sort_state.payload_heap;
+	for (idx_t i = 0; i < payload_heap->blocks.size(); i++) {
+		heap_blocks.push_back(move(payload_heap->blocks[i]));
+		pinned_blocks.push_back(move(payload_heap->pinned_blocks[i]));
+	}
+	if (!sort_layout.all_constant) {
+		auto &blob_heap = local_sort_state.blob_sorting_heap;
+		for (idx_t i = 0; i < blob_heap->blocks.size(); i++) {
+			heap_blocks.push_back(move(blob_heap->blocks[i]));
+			pinned_blocks.push_back(move(blob_heap->pinned_blocks[i]));
+		}
+	}
+}
+
+void GlobalSortState::PrepareMergePhase() {
+	// Determine if we need to use do an external sort
+	idx_t total_heap_size =
+	    std::accumulate(sorted_blocks.begin(), sorted_blocks.end(), (idx_t)0,
+	                    [](idx_t a, const unique_ptr<SortedBlock> &b) { return a + b->HeapSize(); });
+	if (external || (pinned_blocks.empty() && total_heap_size > 0.25 * buffer_manager.GetMaxMemory())) {
+		external = true;
+	}
+	// Use the data that we have to determine which partition size to use during the merge
+	if (external && total_heap_size > 0) {
+		// If we have variable size data we need to be conservative, as there might be skew
+		idx_t max_block_size = 0;
+		for (auto &sb : sorted_blocks) {
+			idx_t size_in_bytes = sb->SizeInBytes();
+			if (size_in_bytes > max_block_size) {
+				max_block_size = size_in_bytes;
+				block_capacity = sb->Count();
+			}
+		}
+	} else {
+		for (auto &sb : sorted_blocks) {
+			block_capacity = MaxValue(block_capacity, sb->Count());
+		}
+	}
+	// Unswizzle and pin heap blocks if we can fit everything in memory
+	if (!external) {
+		for (auto &sb : sorted_blocks) {
+			sb->blob_sorting_data->Unswizzle();
+			sb->payload_data->Unswizzle();
+		}
+	}
+}
+
+void GlobalSortState::InitializeMergeRound() {
+	D_ASSERT(sorted_blocks_temp.empty());
+	// If we reverse this list, the blocks that were merged last will be merged first in the next round
+	// These are still in memory, therefore this reduces the amount of read/write to disk!
+	std::reverse(sorted_blocks.begin(), sorted_blocks.end());
+	// Uneven number of blocks - keep one on the side
+	if (sorted_blocks.size() % 2 == 1) {
+		odd_one_out = move(sorted_blocks.back());
+		sorted_blocks.pop_back();
+	}
+	// Init merge path path indices
+	pair_idx = 0;
+	num_pairs = sorted_blocks.size() / 2;
+	l_start = 0;
+	r_start = 0;
+	// Allocate room for merge results
+	for (idx_t p_idx = 0; p_idx < num_pairs; p_idx++) {
+		sorted_blocks_temp.emplace_back();
+	}
+}
+
+void GlobalSortState::CompleteMergeRound(bool keep_radix_data) {
+	sorted_blocks.clear();
+	for (auto &sorted_block_vector : sorted_blocks_temp) {
+		sorted_blocks.push_back(make_unique<SortedBlock>(buffer_manager, *this));
+		sorted_blocks.back()->AppendSortedBlocks(sorted_block_vector);
+	}
+	sorted_blocks_temp.clear();
+	if (odd_one_out) {
+		sorted_blocks.push_back(move(odd_one_out));
+		odd_one_out = nullptr;
+	}
+	// Only one block left: Done!
+	if (sorted_blocks.size() == 1 && !keep_radix_data) {
+		sorted_blocks[0]->radix_sorting_data.clear();
+		sorted_blocks[0]->blob_sorting_data = nullptr;
+	}
+}
+void GlobalSortState::Print() {
+	PayloadScanner scanner(*this, false);
+	DataChunk chunk;
+	chunk.Initialize(scanner.GetPayloadTypes());
+	for (;;) {
+		scanner.Scan(chunk);
+		const auto count = chunk.size();
+		if (!count) {
+			break;
+		}
+		chunk.Print();
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <numeric>
+
+namespace duckdb {
+
+SortedData::SortedData(SortedDataType type, const RowLayout &layout, BufferManager &buffer_manager,
+                       GlobalSortState &state)
+    : type(type), layout(layout), swizzled(false), buffer_manager(buffer_manager), state(state) {
+}
+
+idx_t SortedData::Count() {
+	idx_t count = std::accumulate(data_blocks.begin(), data_blocks.end(), (idx_t)0,
+	                              [](idx_t a, const RowDataBlock &b) { return a + b.count; });
+	if (!layout.AllConstant() && state.external) {
+		D_ASSERT(count == std::accumulate(heap_blocks.begin(), heap_blocks.end(), (idx_t)0,
+		                                  [](idx_t a, const RowDataBlock &b) { return a + b.count; }));
+	}
+	return count;
+}
+
+void SortedData::CreateBlock() {
+	auto capacity =
+	    MaxValue(((idx_t)Storage::BLOCK_SIZE + layout.GetRowWidth() - 1) / layout.GetRowWidth(), state.block_capacity);
+	data_blocks.emplace_back(buffer_manager, capacity, layout.GetRowWidth());
+	if (!layout.AllConstant() && state.external) {
+		heap_blocks.emplace_back(buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1);
+		D_ASSERT(data_blocks.size() == heap_blocks.size());
+	}
+}
+
+unique_ptr<SortedData> SortedData::CreateSlice(idx_t start_block_index, idx_t end_block_index, idx_t end_entry_index) {
+	// Add the corresponding blocks to the result
+	auto result = make_unique<SortedData>(type, layout, buffer_manager, state);
+	for (idx_t i = start_block_index; i <= end_block_index; i++) {
+		result->data_blocks.push_back(data_blocks[i]);
+		if (!layout.AllConstant() && state.external) {
+			result->heap_blocks.push_back(heap_blocks[i]);
+		}
+	}
+	// All of the blocks that come before block with idx = start_block_idx can be reset (other references exist)
+	for (idx_t i = 0; i < start_block_index; i++) {
+		data_blocks[i].block = nullptr;
+		if (!layout.AllConstant() && state.external) {
+			heap_blocks[i].block = nullptr;
+		}
+	}
+	// Use start and end entry indices to set the boundaries
+	D_ASSERT(end_entry_index <= result->data_blocks.back().count);
+	result->data_blocks.back().count = end_entry_index;
+	if (!layout.AllConstant() && state.external) {
+		result->heap_blocks.back().count = end_entry_index;
+	}
+	return result;
+}
+
+void SortedData::Unswizzle() {
+	if (layout.AllConstant() || !swizzled) {
+		return;
+	}
+	for (idx_t i = 0; i < data_blocks.size(); i++) {
+		auto &data_block = data_blocks[i];
+		auto &heap_block = heap_blocks[i];
+		auto data_handle_p = buffer_manager.Pin(data_block.block);
+		auto heap_handle_p = buffer_manager.Pin(heap_block.block);
+		RowOperations::UnswizzlePointers(layout, data_handle_p->Ptr(), heap_handle_p->Ptr(), data_block.count);
+		state.heap_blocks.push_back(move(heap_block));
+		state.pinned_blocks.push_back(move(heap_handle_p));
+	}
+	heap_blocks.clear();
+}
+
+SortedBlock::SortedBlock(BufferManager &buffer_manager, GlobalSortState &state)
+    : buffer_manager(buffer_manager), state(state), sort_layout(state.sort_layout),
+      payload_layout(state.payload_layout) {
+	blob_sorting_data = make_unique<SortedData>(SortedDataType::BLOB, sort_layout.blob_layout, buffer_manager, state);
+	payload_data = make_unique<SortedData>(SortedDataType::PAYLOAD, payload_layout, buffer_manager, state);
+}
+
+idx_t SortedBlock::Count() const {
+	idx_t count = std::accumulate(radix_sorting_data.begin(), radix_sorting_data.end(), 0,
+	                              [](idx_t a, const RowDataBlock &b) { return a + b.count; });
+	if (!sort_layout.all_constant) {
+		D_ASSERT(count == blob_sorting_data->Count());
+	}
+	D_ASSERT(count == payload_data->Count());
+	return count;
+}
+
+void SortedBlock::InitializeWrite() {
+	CreateBlock();
+	if (!sort_layout.all_constant) {
+		blob_sorting_data->CreateBlock();
+	}
+	payload_data->CreateBlock();
+}
+
+void SortedBlock::CreateBlock() {
+	auto capacity = MaxValue(((idx_t)Storage::BLOCK_SIZE + sort_layout.entry_size - 1) / sort_layout.entry_size,
+	                         state.block_capacity);
+	radix_sorting_data.emplace_back(buffer_manager, capacity, sort_layout.entry_size);
+}
+
+void SortedBlock::AppendSortedBlocks(vector<unique_ptr<SortedBlock>> &sorted_blocks) {
+	D_ASSERT(Count() == 0);
+	for (auto &sb : sorted_blocks) {
+		for (auto &radix_block : sb->radix_sorting_data) {
+			radix_sorting_data.push_back(move(radix_block));
+		}
+		if (!sort_layout.all_constant) {
+			for (auto &blob_block : sb->blob_sorting_data->data_blocks) {
+				blob_sorting_data->data_blocks.push_back(move(blob_block));
+			}
+			for (auto &heap_block : sb->blob_sorting_data->heap_blocks) {
+				blob_sorting_data->heap_blocks.push_back(move(heap_block));
+			}
+		}
+		for (auto &payload_data_block : sb->payload_data->data_blocks) {
+			payload_data->data_blocks.push_back(move(payload_data_block));
+		}
+		if (!payload_data->layout.AllConstant()) {
+			for (auto &payload_heap_block : sb->payload_data->heap_blocks) {
+				payload_data->heap_blocks.push_back(move(payload_heap_block));
+			}
+		}
+	}
+}
+
+void SortedBlock::GlobalToLocalIndex(const idx_t &global_idx, idx_t &local_block_index, idx_t &local_entry_index) {
+	if (global_idx == Count()) {
+		local_block_index = radix_sorting_data.size() - 1;
+		local_entry_index = radix_sorting_data.back().count;
+		return;
+	}
+	D_ASSERT(global_idx < Count());
+	local_entry_index = global_idx;
+	for (local_block_index = 0; local_block_index < radix_sorting_data.size(); local_block_index++) {
+		const idx_t &block_count = radix_sorting_data[local_block_index].count;
+		if (local_entry_index >= block_count) {
+			local_entry_index -= block_count;
+		} else {
+			break;
+		}
+	}
+	D_ASSERT(local_entry_index < radix_sorting_data[local_block_index].count);
+}
+
+unique_ptr<SortedBlock> SortedBlock::CreateSlice(const idx_t start, const idx_t end, idx_t &entry_idx) {
+	// Identify blocks/entry indices of this slice
+	idx_t start_block_index;
+	idx_t start_entry_index;
+	GlobalToLocalIndex(start, start_block_index, start_entry_index);
+	idx_t end_block_index;
+	idx_t end_entry_index;
+	GlobalToLocalIndex(end, end_block_index, end_entry_index);
+	// Add the corresponding blocks to the result
+	auto result = make_unique<SortedBlock>(buffer_manager, state);
+	for (idx_t i = start_block_index; i <= end_block_index; i++) {
+		result->radix_sorting_data.push_back(radix_sorting_data[i]);
+	}
+	// Reset all blocks that come before block with idx = start_block_idx (slice holds new reference)
+	for (idx_t i = 0; i < start_block_index; i++) {
+		radix_sorting_data[i].block = nullptr;
+	}
+	// Use start and end entry indices to set the boundaries
+	entry_idx = start_entry_index;
+	D_ASSERT(end_entry_index <= result->radix_sorting_data.back().count);
+	result->radix_sorting_data.back().count = end_entry_index;
+	// Same for the var size sorting data
+	if (!sort_layout.all_constant) {
+		result->blob_sorting_data = blob_sorting_data->CreateSlice(start_block_index, end_block_index, end_entry_index);
+	}
+	// And the payload data
+	result->payload_data = payload_data->CreateSlice(start_block_index, end_block_index, end_entry_index);
+	return result;
+}
+
+idx_t SortedBlock::HeapSize() const {
+	idx_t result = 0;
+	if (!sort_layout.all_constant) {
+		for (auto &block : blob_sorting_data->heap_blocks) {
+			result += block.capacity;
+		}
+	}
+	if (!payload_layout.AllConstant()) {
+		for (auto &block : payload_data->heap_blocks) {
+			result += block.capacity;
+		}
+	}
+	return result;
+}
+
+idx_t SortedBlock::SizeInBytes() const {
+	idx_t bytes = 0;
+	for (idx_t i = 0; i < radix_sorting_data.size(); i++) {
+		bytes += radix_sorting_data[i].capacity * sort_layout.entry_size;
+		if (!sort_layout.all_constant) {
+			bytes += blob_sorting_data->data_blocks[i].capacity * sort_layout.blob_layout.GetRowWidth();
+			bytes += blob_sorting_data->heap_blocks[i].capacity;
+		}
+		bytes += payload_data->data_blocks[i].capacity * payload_layout.GetRowWidth();
+		if (!payload_layout.AllConstant()) {
+			bytes += payload_data->heap_blocks[i].capacity;
+		}
+	}
+	return bytes;
+}
+
+SBScanState::SBScanState(BufferManager &buffer_manager, GlobalSortState &state)
+    : buffer_manager(buffer_manager), sort_layout(state.sort_layout), state(state), block_idx(0), entry_idx(0) {
+}
+
+void SBScanState::PinRadix(idx_t block_idx_to) {
+	auto &radix_sorting_data = sb->radix_sorting_data;
+	D_ASSERT(block_idx_to < radix_sorting_data.size());
+	auto &block = radix_sorting_data[block_idx_to];
+	if (!radix_handle || radix_handle->handle->BlockId() != block.block->BlockId()) {
+		radix_handle = buffer_manager.Pin(block.block);
+	}
+}
+
+void SBScanState::PinData(SortedData &sd) {
+	D_ASSERT(block_idx < sd.data_blocks.size());
+	auto &data_handle = sd.type == SortedDataType::BLOB ? blob_sorting_data_handle : payload_data_handle;
+	auto &heap_handle = sd.type == SortedDataType::BLOB ? blob_sorting_heap_handle : payload_heap_handle;
+
+	auto &data_block = sd.data_blocks[block_idx];
+	if (!data_handle || data_handle->handle->BlockId() != data_block.block->BlockId()) {
+		data_handle = buffer_manager.Pin(data_block.block);
+	}
+	if (sd.layout.AllConstant() || !state.external) {
+		return;
+	}
+	auto &heap_block = sd.heap_blocks[block_idx];
+	if (!heap_handle || heap_handle->handle->BlockId() != heap_block.block->BlockId()) {
+		heap_handle = buffer_manager.Pin(heap_block.block);
+	}
+}
+
+data_ptr_t SBScanState::RadixPtr() const {
+	return radix_handle->Ptr() + entry_idx * sort_layout.entry_size;
+}
+
+data_ptr_t SBScanState::DataPtr(SortedData &sd) const {
+	auto &data_handle = sd.type == SortedDataType::BLOB ? *blob_sorting_data_handle : *payload_data_handle;
+	D_ASSERT(sd.data_blocks[block_idx].block->Readers() != 0 &&
+	         data_handle.handle->BlockId() == sd.data_blocks[block_idx].block->BlockId());
+	return data_handle.Ptr() + entry_idx * sd.layout.GetRowWidth();
+}
+
+data_ptr_t SBScanState::HeapPtr(SortedData &sd) const {
+	return BaseHeapPtr(sd) + Load<idx_t>(DataPtr(sd) + sd.layout.GetHeapPointerOffset());
+}
+
+data_ptr_t SBScanState::BaseHeapPtr(SortedData &sd) const {
+	auto &heap_handle = sd.type == SortedDataType::BLOB ? *blob_sorting_heap_handle : *payload_heap_handle;
+	D_ASSERT(!sd.layout.AllConstant() && state.external);
+	D_ASSERT(sd.heap_blocks[block_idx].block->Readers() != 0 &&
+	         heap_handle.handle->BlockId() == sd.heap_blocks[block_idx].block->BlockId());
+	return heap_handle.Ptr();
+}
+
+idx_t SBScanState::Remaining() const {
+	const auto &blocks = sb->radix_sorting_data;
+	idx_t remaining = 0;
+	if (block_idx < blocks.size()) {
+		remaining += blocks[block_idx].count - entry_idx;
+		for (idx_t i = block_idx + 1; i < blocks.size(); i++) {
+			remaining += blocks[i].count;
+		}
+	}
+	return remaining;
+}
+
+void SBScanState::SetIndices(idx_t block_idx_to, idx_t entry_idx_to) {
+	block_idx = block_idx_to;
+	entry_idx = entry_idx_to;
+}
+
+PayloadScanner::PayloadScanner(SortedData &sorted_data, GlobalSortState &global_sort_state, bool flush_p)
+    : sorted_data(sorted_data), read_state(global_sort_state.buffer_manager, global_sort_state),
+      total_count(sorted_data.Count()), global_sort_state(global_sort_state), total_scanned(0), flush(flush_p) {
+}
+
+PayloadScanner::PayloadScanner(GlobalSortState &global_sort_state, bool flush_p)
+    : PayloadScanner(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state, flush_p) {
+}
+
+PayloadScanner::PayloadScanner(GlobalSortState &global_sort_state, idx_t block_idx)
+    : sorted_data(*global_sort_state.sorted_blocks[0]->payload_data),
+      read_state(global_sort_state.buffer_manager, global_sort_state),
+      total_count(sorted_data.data_blocks[block_idx].count), global_sort_state(global_sort_state), total_scanned(0),
+      flush(false) {
+	read_state.SetIndices(block_idx, 0);
+}
+
+void PayloadScanner::Scan(DataChunk &chunk) {
+	auto count = MinValue((idx_t)STANDARD_VECTOR_SIZE, total_count - total_scanned);
+	if (count == 0) {
+		chunk.SetCardinality(count);
+		return;
+	}
+	// Eagerly delete references to blocks that we've passed
+	if (flush) {
+		for (idx_t i = 0; i < read_state.block_idx; i++) {
+			sorted_data.data_blocks[i].block = nullptr;
+		}
+	}
+	const idx_t &row_width = sorted_data.layout.GetRowWidth();
+	// Set up a batch of pointers to scan data from
+	idx_t scanned = 0;
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+	while (scanned < count) {
+		read_state.PinData(sorted_data);
+		auto &data_block = sorted_data.data_blocks[read_state.block_idx];
+		idx_t next = MinValue(data_block.count - read_state.entry_idx, count - scanned);
+		const data_ptr_t data_ptr = read_state.payload_data_handle->Ptr() + read_state.entry_idx * row_width;
+		// Set up the next pointers
+		data_ptr_t row_ptr = data_ptr;
+		for (idx_t i = 0; i < next; i++) {
+			data_pointers[scanned + i] = row_ptr;
+			row_ptr += row_width;
+		}
+		// Unswizzle the offsets back to pointers (if needed)
+		if (!sorted_data.layout.AllConstant() && global_sort_state.external) {
+			RowOperations::UnswizzlePointers(sorted_data.layout, data_ptr, read_state.payload_heap_handle->Ptr(), next);
+		}
+		// Update state indices
+		read_state.entry_idx += next;
+		if (read_state.entry_idx == data_block.count) {
+			read_state.block_idx++;
+			read_state.entry_idx = 0;
+		}
+		scanned += next;
+	}
+	D_ASSERT(scanned == count);
+	// Deserialize the payload data
+	for (idx_t col_idx = 0; col_idx < sorted_data.layout.ColumnCount(); col_idx++) {
+		const auto col_offset = sorted_data.layout.GetOffsets()[col_idx];
+		RowOperations::Gather(addresses, *FlatVector::IncrementalSelectionVector(), chunk.data[col_idx],
+		                      *FlatVector::IncrementalSelectionVector(), count, col_offset, col_idx);
+	}
+	chunk.SetCardinality(count);
+	chunk.Verify();
+	total_scanned += scanned;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <algorithm>
+#include <cctype>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <stdarg.h>
+#include <string.h>
+
+namespace duckdb {
+
+bool StringUtil::Contains(const string &haystack, const string &needle) {
+	return (haystack.find(needle) != string::npos);
+}
+
+void StringUtil::LTrim(string &str) {
+	auto it = str.begin();
+	while (CharacterIsSpace(*it)) {
+		it++;
+	}
+	str.erase(str.begin(), it);
+}
+
+// Remove trailing ' ', '\f', '\n', '\r', '\t', '\v'
+void StringUtil::RTrim(string &str) {
+	str.erase(find_if(str.rbegin(), str.rend(), [](int ch) { return ch > 0 && !CharacterIsSpace(ch); }).base(),
+	          str.end());
+}
+
+void StringUtil::Trim(string &str) {
+	StringUtil::LTrim(str);
+	StringUtil::RTrim(str);
+}
+
+bool StringUtil::StartsWith(string str, string prefix) {
+	if (prefix.size() > str.size()) {
+		return false;
+	}
+	return equal(prefix.begin(), prefix.end(), str.begin());
+}
+
+bool StringUtil::EndsWith(const string &str, const string &suffix) {
+	if (suffix.size() > str.size()) {
+		return false;
+	}
+	return equal(suffix.rbegin(), suffix.rend(), str.rbegin());
+}
+
+string StringUtil::Repeat(const string &str, idx_t n) {
+	std::ostringstream os;
+	for (idx_t i = 0; i < n; i++) {
+		os << str;
+	}
+	return (os.str());
+}
+
+vector<string> StringUtil::Split(const string &str, char delimiter) {
+	std::stringstream ss(str);
+	vector<string> lines;
+	string temp;
+	while (getline(ss, temp, delimiter)) {
+		lines.push_back(temp);
+	}
+	return (lines);
+}
+
+namespace string_util_internal {
+
+inline void SkipSpaces(const string &str, idx_t &index) {
+	while (index < str.size() && std::isspace(str[index])) {
+		index++;
+	}
+}
+
+inline void ConsumeLetter(const string &str, idx_t &index, char expected) {
+	if (index >= str.size() || str[index] != expected) {
+		throw ParserException("Invalid quoted list: %s", str);
+	}
+
+	index++;
+}
+
+template <typename F>
+inline void TakeWhile(const string &str, idx_t &index, const F &cond, string &taker) {
+	while (index < str.size() && cond(str[index])) {
+		taker.push_back(str[index]);
+		index++;
+	}
+}
+
+inline string TakePossiblyQuotedItem(const string &str, idx_t &index, char delimiter, char quote) {
+	string entry;
+
+	if (str[index] == quote) {
+		index++;
+		TakeWhile(
+		    str, index, [quote](char c) { return c != quote; }, entry);
+		ConsumeLetter(str, index, quote);
+	} else {
+		TakeWhile(
+		    str, index, [delimiter, quote](char c) { return c != delimiter && c != quote && !std::isspace(c); }, entry);
+	}
+
+	return entry;
+}
+
+} // namespace string_util_internal
+
+vector<string> StringUtil::SplitWithQuote(const string &str, char delimiter, char quote) {
+	vector<string> entries;
+	idx_t i = 0;
+
+	string_util_internal::SkipSpaces(str, i);
+	while (i < str.size()) {
+		if (!entries.empty()) {
+			string_util_internal::ConsumeLetter(str, i, delimiter);
+		}
+
+		entries.emplace_back(string_util_internal::TakePossiblyQuotedItem(str, i, delimiter, quote));
+		string_util_internal::SkipSpaces(str, i);
+	}
+
+	return entries;
+}
+
+string StringUtil::Join(const vector<string> &input, const string &separator) {
+	return StringUtil::Join(input, input.size(), separator, [](const string &s) { return s; });
+}
+
+string StringUtil::BytesToHumanReadableString(idx_t bytes) {
+	string db_size;
+	auto kilobytes = bytes / 1000;
+	auto megabytes = kilobytes / 1000;
+	kilobytes -= megabytes * 1000;
+	auto gigabytes = megabytes / 1000;
+	megabytes -= gigabytes * 1000;
+	auto terabytes = gigabytes / 1000;
+	gigabytes -= terabytes * 1000;
+	if (terabytes > 0) {
+		return to_string(terabytes) + "." + to_string(gigabytes / 100) + "TB";
+	} else if (gigabytes > 0) {
+		return to_string(gigabytes) + "." + to_string(megabytes / 100) + "GB";
+	} else if (megabytes > 0) {
+		return to_string(megabytes) + "." + to_string(kilobytes / 100) + "MB";
+	} else if (kilobytes > 0) {
+		return to_string(kilobytes) + "KB";
+	} else {
+		return to_string(bytes) + " bytes";
+	}
+}
+
+string StringUtil::Upper(const string &str) {
+	string copy(str);
+	transform(copy.begin(), copy.end(), copy.begin(), [](unsigned char c) { return std::toupper(c); });
+	return (copy);
+}
+
+string StringUtil::Lower(const string &str) {
+	string copy(str);
+	transform(copy.begin(), copy.end(), copy.begin(), [](unsigned char c) { return std::tolower(c); });
+	return (copy);
+}
+
+vector<string> StringUtil::Split(const string &input, const string &split) {
+	vector<string> splits;
+
+	idx_t last = 0;
+	idx_t input_len = input.size();
+	idx_t split_len = split.size();
+	while (last <= input_len) {
+		idx_t next = input.find(split, last);
+		if (next == string::npos) {
+			next = input_len;
+		}
+
+		// Push the substring [last, next) on to splits
+		string substr = input.substr(last, next - last);
+		if (substr.empty() == false) {
+			splits.push_back(substr);
+		}
+		last = next + split_len;
+	}
+	return splits;
+}
+
+string StringUtil::Replace(string source, const string &from, const string &to) {
+	idx_t start_pos = 0;
+	while ((start_pos = source.find(from, start_pos)) != string::npos) {
+		source.replace(start_pos, from.length(), to);
+		start_pos += to.length(); // In case 'to' contains 'from', like
+		                          // replacing 'x' with 'yx'
+	}
+	return source;
+}
+
+vector<string> StringUtil::TopNStrings(vector<pair<string, idx_t>> scores, idx_t n, idx_t threshold) {
+	if (scores.empty()) {
+		return vector<string>();
+	}
+	sort(scores.begin(), scores.end(),
+	     [](const pair<string, idx_t> &a, const pair<string, idx_t> &b) -> bool { return a.second < b.second; });
+	vector<string> result;
+	result.push_back(scores[0].first);
+	for (idx_t i = 1; i < MinValue<idx_t>(scores.size(), n); i++) {
+		if (scores[i].second > threshold) {
+			break;
+		}
+		result.push_back(scores[i].first);
+	}
+	return result;
+}
+
+struct LevenshteinArray {
+	LevenshteinArray(idx_t len1, idx_t len2) : len1(len1) {
+		dist = unique_ptr<idx_t[]>(new idx_t[len1 * len2]);
+	}
+
+	idx_t &Score(idx_t i, idx_t j) {
+		return dist[GetIndex(i, j)];
+	}
+
+private:
+	idx_t len1;
+	unique_ptr<idx_t[]> dist;
+
+	idx_t GetIndex(idx_t i, idx_t j) {
+		return j * len1 + i;
+	}
+};
+
+// adapted from https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#C++
+idx_t StringUtil::LevenshteinDistance(const string &s1_p, const string &s2_p) {
+	auto s1 = StringUtil::Lower(s1_p);
+	auto s2 = StringUtil::Lower(s2_p);
+	idx_t len1 = s1.size();
+	idx_t len2 = s2.size();
+	if (len1 == 0) {
+		return len2;
+	}
+	if (len2 == 0) {
+		return len1;
+	}
+	LevenshteinArray array(len1 + 1, len2 + 1);
+	array.Score(0, 0) = 0;
+	for (idx_t i = 0; i <= len1; i++) {
+		array.Score(i, 0) = i;
+	}
+	for (idx_t j = 0; j <= len2; j++) {
+		array.Score(0, j) = j;
+	}
+	for (idx_t i = 1; i <= len1; i++) {
+		for (idx_t j = 1; j <= len2; j++) {
+			// d[i][j] = std::min({ d[i - 1][j] + 1,
+			//                      d[i][j - 1] + 1,
+			//                      d[i - 1][j - 1] + (s1[i - 1] == s2[j - 1] ? 0 : 1) });
+			int equal = s1[i - 1] == s2[j - 1] ? 0 : 1;
+			idx_t adjacent_score1 = array.Score(i - 1, j) + 1;
+			idx_t adjacent_score2 = array.Score(i, j - 1) + 1;
+			idx_t adjacent_score3 = array.Score(i - 1, j - 1) + equal;
+
+			idx_t t = MinValue<idx_t>(adjacent_score1, adjacent_score2);
+			array.Score(i, j) = MinValue<idx_t>(t, adjacent_score3);
+		}
+	}
+	return array.Score(len1, len2);
+}
+
+vector<string> StringUtil::TopNLevenshtein(const vector<string> &strings, const string &target, idx_t n,
+                                           idx_t threshold) {
+	vector<pair<string, idx_t>> scores;
+	scores.reserve(strings.size());
+	for (auto &str : strings) {
+		scores.emplace_back(str, LevenshteinDistance(str, target));
+	}
+	return TopNStrings(scores, n, threshold);
+}
+
+string StringUtil::CandidatesMessage(const vector<string> &candidates, const string &candidate) {
+	string result_str;
+	if (!candidates.empty()) {
+		result_str = "\n" + candidate + ": ";
+		for (idx_t i = 0; i < candidates.size(); i++) {
+			if (i > 0) {
+				result_str += ", ";
+			}
+			result_str += "\"" + candidates[i] + "\"";
+		}
+	}
+	return result_str;
+}
+
+string StringUtil::CandidatesErrorMessage(const vector<string> &strings, const string &target,
+                                          const string &message_prefix, idx_t n) {
+	auto closest_strings = StringUtil::TopNLevenshtein(strings, target, n);
+	return StringUtil::CandidatesMessage(closest_strings, message_prefix);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+#include <sstream>
+
+namespace duckdb {
+
+RenderTree::RenderTree(idx_t width_p, idx_t height_p) : width(width_p), height(height_p) {
+	nodes = unique_ptr<unique_ptr<RenderTreeNode>[]>(new unique_ptr<RenderTreeNode>[(width + 1) * (height + 1)]);
+}
+
+RenderTreeNode *RenderTree::GetNode(idx_t x, idx_t y) {
+	if (x >= width || y >= height) {
+		return nullptr;
+	}
+	return nodes[GetPosition(x, y)].get();
+}
+
+bool RenderTree::HasNode(idx_t x, idx_t y) {
+	if (x >= width || y >= height) {
+		return false;
+	}
+	return nodes[GetPosition(x, y)].get() != nullptr;
+}
+
+idx_t RenderTree::GetPosition(idx_t x, idx_t y) {
+	return y * width + x;
+}
+
+void RenderTree::SetNode(idx_t x, idx_t y, unique_ptr<RenderTreeNode> node) {
+	nodes[GetPosition(x, y)] = move(node);
+}
+
+void TreeRenderer::RenderTopLayer(RenderTree &root, std::ostream &ss, idx_t y) {
+	for (idx_t x = 0; x < root.width; x++) {
+		if (x * config.NODE_RENDER_WIDTH >= config.MAXIMUM_RENDER_WIDTH) {
+			break;
+		}
+		if (root.HasNode(x, y)) {
+			ss << config.LTCORNER;
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			if (y == 0) {
+				// top level node: no node above this one
+				ss << config.HORIZONTAL;
+			} else {
+				// render connection to node above this one
+				ss << config.DMIDDLE;
+			}
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			ss << config.RTCORNER;
+		} else {
+			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+		}
+	}
+	ss << std::endl;
+}
+
+void TreeRenderer::RenderBottomLayer(RenderTree &root, std::ostream &ss, idx_t y) {
+	for (idx_t x = 0; x <= root.width; x++) {
+		if (x * config.NODE_RENDER_WIDTH >= config.MAXIMUM_RENDER_WIDTH) {
+			break;
+		}
+		if (root.HasNode(x, y)) {
+			ss << config.LDCORNER;
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			if (root.HasNode(x, y + 1)) {
+				// node below this one: connect to that one
+				ss << config.TMIDDLE;
+			} else {
+				// no node below this one: end the box
+				ss << config.HORIZONTAL;
+			}
+			ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2 - 1);
+			ss << config.RDCORNER;
+		} else if (root.HasNode(x, y + 1)) {
+			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+			ss << config.VERTICAL;
+			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+		} else {
+			ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+		}
+	}
+	ss << std::endl;
+}
+
+string AdjustTextForRendering(string source, idx_t max_render_width) {
+	idx_t cpos = 0;
+	idx_t render_width = 0;
+	vector<pair<idx_t, idx_t>> render_widths;
+	while (cpos < source.size()) {
+		idx_t char_render_width = Utf8Proc::RenderWidth(source.c_str(), source.size(), cpos);
+		cpos = Utf8Proc::NextGraphemeCluster(source.c_str(), source.size(), cpos);
+		render_width += char_render_width;
+		render_widths.emplace_back(cpos, render_width);
+		if (render_width > max_render_width) {
+			break;
+		}
+	}
+	if (render_width > max_render_width) {
+		// need to find a position to truncate
+		for (idx_t pos = render_widths.size(); pos > 0; pos--) {
+			if (render_widths[pos - 1].second < max_render_width - 4) {
+				return source.substr(0, render_widths[pos - 1].first) + "..." +
+				       string(max_render_width - render_widths[pos - 1].second - 3, ' ');
+			}
+		}
+		source = "...";
+	}
+	// need to pad with spaces
+	idx_t total_spaces = max_render_width - render_width;
+	idx_t half_spaces = total_spaces / 2;
+	idx_t extra_left_space = total_spaces % 2 == 0 ? 0 : 1;
+	return string(half_spaces + extra_left_space, ' ') + source + string(half_spaces, ' ');
+}
+
+static bool NodeHasMultipleChildren(RenderTree &root, idx_t x, idx_t y) {
+	for (; x < root.width && !root.HasNode(x + 1, y); x++) {
+		if (root.HasNode(x + 1, y + 1)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void TreeRenderer::RenderBoxContent(RenderTree &root, std::ostream &ss, idx_t y) {
+	// we first need to figure out how high our boxes are going to be
+	vector<vector<string>> extra_info;
+	idx_t extra_height = 0;
+	extra_info.resize(root.width);
+	for (idx_t x = 0; x < root.width; x++) {
+		auto node = root.GetNode(x, y);
+		if (node) {
+			SplitUpExtraInfo(node->extra_text, extra_info[x]);
+			if (extra_info[x].size() > extra_height) {
+				extra_height = extra_info[x].size();
+			}
+		}
+	}
+	extra_height = MinValue<idx_t>(extra_height, config.MAX_EXTRA_LINES);
+	idx_t halfway_point = (extra_height + 1) / 2;
+	// now we render the actual node
+	for (idx_t render_y = 0; render_y <= extra_height; render_y++) {
+		for (idx_t x = 0; x < root.width; x++) {
+			if (x * config.NODE_RENDER_WIDTH >= config.MAXIMUM_RENDER_WIDTH) {
+				break;
+			}
+			auto node = root.GetNode(x, y);
+			if (!node) {
+				if (render_y == halfway_point) {
+					bool has_child_to_the_right = NodeHasMultipleChildren(root, x, y);
+					if (root.HasNode(x, y + 1)) {
+						// node right below this one
+						ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2);
+						ss << config.RTCORNER;
+						if (has_child_to_the_right) {
+							// but we have another child to the right! keep rendering the line
+							ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH / 2);
+						} else {
+							// only a child below this one: fill the rest with spaces
+							ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+						}
+					} else if (has_child_to_the_right) {
+						// child to the right, but no child right below this one: render a full line
+						ss << StringUtil::Repeat(config.HORIZONTAL, config.NODE_RENDER_WIDTH);
+					} else {
+						// empty spot: render spaces
+						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+					}
+				} else if (render_y >= halfway_point) {
+					if (root.HasNode(x, y + 1)) {
+						// we have a node below this empty spot: render a vertical line
+						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+						ss << config.VERTICAL;
+						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH / 2);
+					} else {
+						// empty spot: render spaces
+						ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+					}
+				} else {
+					// empty spot: render spaces
+					ss << StringUtil::Repeat(" ", config.NODE_RENDER_WIDTH);
+				}
+			} else {
+				ss << config.VERTICAL;
+				// figure out what to render
+				string render_text;
+				if (render_y == 0) {
+					render_text = node->name;
+				} else {
+					if (render_y <= extra_info[x].size()) {
+						render_text = extra_info[x][render_y - 1];
+					}
+				}
+				render_text = AdjustTextForRendering(render_text, config.NODE_RENDER_WIDTH - 2);
+				ss << render_text;
+
+				if (render_y == halfway_point && NodeHasMultipleChildren(root, x, y)) {
+					ss << config.LMIDDLE;
+				} else {
+					ss << config.VERTICAL;
+				}
+			}
+		}
+		ss << std::endl;
+	}
+}
+
+string TreeRenderer::ToString(const LogicalOperator &op) {
+	std::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+string TreeRenderer::ToString(const PhysicalOperator &op) {
+	std::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+string TreeRenderer::ToString(const QueryProfiler::TreeNode &op) {
+	std::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+string TreeRenderer::ToString(const Pipeline &op) {
+	std::stringstream ss;
+	Render(op, ss);
+	return ss.str();
+}
+
+void TreeRenderer::Render(const LogicalOperator &op, std::ostream &ss) {
+	auto tree = CreateTree(op);
+	ToStream(*tree, ss);
+}
+
+void TreeRenderer::Render(const PhysicalOperator &op, std::ostream &ss) {
+	auto tree = CreateTree(op);
+	ToStream(*tree, ss);
+}
+
+void TreeRenderer::Render(const QueryProfiler::TreeNode &op, std::ostream &ss) {
+	auto tree = CreateTree(op);
+	ToStream(*tree, ss);
+}
+
+void TreeRenderer::Render(const Pipeline &op, std::ostream &ss) {
+	auto tree = CreateTree(op);
+	ToStream(*tree, ss);
+}
+
+void TreeRenderer::ToStream(RenderTree &root, std::ostream &ss) {
+	while (root.width * config.NODE_RENDER_WIDTH > config.MAXIMUM_RENDER_WIDTH) {
+		if (config.NODE_RENDER_WIDTH - 2 < config.MINIMUM_RENDER_WIDTH) {
+			break;
+		}
+		config.NODE_RENDER_WIDTH -= 2;
+	}
+
+	for (idx_t y = 0; y < root.height; y++) {
+		// start by rendering the top layer
+		RenderTopLayer(root, ss, y);
+		// now we render the content of the boxes
+		RenderBoxContent(root, ss, y);
+		// render the bottom layer of each of the boxes
+		RenderBottomLayer(root, ss, y);
+	}
+}
+
+bool TreeRenderer::CanSplitOnThisChar(char l) {
+	return (l < '0' || (l > '9' && l < 'A') || (l > 'Z' && l < 'a')) && l != '_';
+}
+
+bool TreeRenderer::IsPadding(char l) {
+	return l == ' ' || l == '\t' || l == '\n' || l == '\r';
+}
+
+string TreeRenderer::RemovePadding(string l) {
+	idx_t start = 0, end = l.size();
+	while (start < l.size() && IsPadding(l[start])) {
+		start++;
+	}
+	while (end > 0 && IsPadding(l[end - 1])) {
+		end--;
+	}
+	return l.substr(start, end - start);
+}
+
+void TreeRenderer::SplitStringBuffer(const string &source, vector<string> &result) {
+	D_ASSERT(Utf8Proc::IsValid(source.c_str(), source.size()));
+	idx_t max_line_render_size = config.NODE_RENDER_WIDTH - 2;
+	// utf8 in prompt, get render width
+	idx_t cpos = 0;
+	idx_t start_pos = 0;
+	idx_t render_width = 0;
+	idx_t last_possible_split = 0;
+	while (cpos < source.size()) {
+		// check if we can split on this character
+		if (CanSplitOnThisChar(source[cpos])) {
+			last_possible_split = cpos;
+		}
+		size_t char_render_width = Utf8Proc::RenderWidth(source.c_str(), source.size(), cpos);
+		idx_t next_cpos = Utf8Proc::NextGraphemeCluster(source.c_str(), source.size(), cpos);
+		if (render_width + char_render_width > max_line_render_size) {
+			if (last_possible_split <= start_pos + 8) {
+				last_possible_split = cpos;
+			}
+			result.push_back(source.substr(start_pos, last_possible_split - start_pos));
+			start_pos = last_possible_split;
+			cpos = last_possible_split;
+			render_width = 0;
+		}
+		cpos = next_cpos;
+		render_width += char_render_width;
+	}
+	if (source.size() > start_pos) {
+		result.push_back(source.substr(start_pos, source.size() - start_pos));
+	}
+}
+
+void TreeRenderer::SplitUpExtraInfo(const string &extra_info, vector<string> &result) {
+	if (extra_info.empty()) {
+		return;
+	}
+	if (!Utf8Proc::IsValid(extra_info.c_str(), extra_info.size())) {
+		return;
+	}
+	auto splits = StringUtil::Split(extra_info, "\n");
+	if (!splits.empty() && splits[0] != "[INFOSEPARATOR]") {
+		result.push_back(ExtraInfoSeparator());
+	}
+	for (auto &split : splits) {
+		if (split == "[INFOSEPARATOR]") {
+			result.push_back(ExtraInfoSeparator());
+			continue;
+		}
+		string str = RemovePadding(split);
+		if (str.empty()) {
+			continue;
+		}
+		SplitStringBuffer(str, result);
+	}
+}
+
+string TreeRenderer::ExtraInfoSeparator() {
+	return StringUtil::Repeat(string(config.HORIZONTAL) + " ", (config.NODE_RENDER_WIDTH - 7) / 2);
+}
+
+unique_ptr<RenderTreeNode> TreeRenderer::CreateRenderNode(string name, string extra_info) {
+	auto result = make_unique<RenderTreeNode>();
+	result->name = move(name);
+	result->extra_text = move(extra_info);
+	return result;
+}
+
+class TreeChildrenIterator {
+public:
+	template <class T>
+	static bool HasChildren(const T &op) {
+		return !op.children.empty();
+	}
+	template <class T>
+	static void Iterate(const T &op, const std::function<void(const T &child)> &callback) {
+		for (auto &child : op.children) {
+			callback(*child);
+		}
+	}
+};
+
+template <>
+bool TreeChildrenIterator::HasChildren(const PhysicalOperator &op) {
+	if (op.type == PhysicalOperatorType::DELIM_JOIN) {
+		return true;
+	}
+	return !op.children.empty();
+}
+template <>
+void TreeChildrenIterator::Iterate(const PhysicalOperator &op,
+                                   const std::function<void(const PhysicalOperator &child)> &callback) {
+	for (auto &child : op.children) {
+		callback(*child);
+	}
+	if (op.type == PhysicalOperatorType::DELIM_JOIN) {
+		auto &delim = (PhysicalDelimJoin &)op;
+		callback(*delim.join);
+	}
+}
+
+struct PipelineRenderNode {
+	explicit PipelineRenderNode(PhysicalOperator &op) : op(op) {
+	}
+
+	PhysicalOperator &op;
+	unique_ptr<PipelineRenderNode> child;
+};
+
+template <>
+bool TreeChildrenIterator::HasChildren(const PipelineRenderNode &op) {
+	return op.child.get();
+}
+
+template <>
+void TreeChildrenIterator::Iterate(const PipelineRenderNode &op,
+                                   const std::function<void(const PipelineRenderNode &child)> &callback) {
+	if (op.child) {
+		callback(*op.child);
+	}
+}
+
+template <class T>
+static void GetTreeWidthHeight(const T &op, idx_t &width, idx_t &height) {
+	if (!TreeChildrenIterator::HasChildren(op)) {
+		width = 1;
+		height = 1;
+		return;
+	}
+	width = 0;
+	height = 0;
+
+	TreeChildrenIterator::Iterate<T>(op, [&](const T &child) {
+		idx_t child_width, child_height;
+		GetTreeWidthHeight<T>(child, child_width, child_height);
+		width += child_width;
+		height = MaxValue<idx_t>(height, child_height);
+	});
+	height++;
+}
+
+template <class T>
+idx_t TreeRenderer::CreateRenderTreeRecursive(RenderTree &result, const T &op, idx_t x, idx_t y) {
+	auto node = TreeRenderer::CreateNode(op);
+	result.SetNode(x, y, move(node));
+
+	if (!TreeChildrenIterator::HasChildren(op)) {
+		return 1;
+	}
+	idx_t width = 0;
+	// render the children of this node
+	TreeChildrenIterator::Iterate<T>(
+	    op, [&](const T &child) { width += CreateRenderTreeRecursive<T>(result, child, x + width, y + 1); });
+	return width;
+}
+
+template <class T>
+unique_ptr<RenderTree> TreeRenderer::CreateRenderTree(const T &op) {
+	idx_t width, height;
+	GetTreeWidthHeight<T>(op, width, height);
+
+	auto result = make_unique<RenderTree>(width, height);
+
+	// now fill in the tree
+	CreateRenderTreeRecursive<T>(*result, op, 0, 0);
+	return result;
+}
+
+unique_ptr<RenderTreeNode> TreeRenderer::CreateNode(const LogicalOperator &op) {
+	return CreateRenderNode(op.GetName(), op.ParamsToString());
+}
+
+unique_ptr<RenderTreeNode> TreeRenderer::CreateNode(const PhysicalOperator &op) {
+	return CreateRenderNode(op.GetName(), op.ParamsToString());
+}
+
+unique_ptr<RenderTreeNode> TreeRenderer::CreateNode(const PipelineRenderNode &op) {
+	return CreateNode(op.op);
+}
+
+string TreeRenderer::ExtractExpressionsRecursive(ExpressionInfo &state) {
+	string result = "\n[INFOSEPARATOR]";
+	result += "\n" + state.function_name;
+	result += "\n" + StringUtil::Format("%.9f", double(state.function_time));
+	if (state.children.empty()) {
+		return result;
+	}
+	// render the children of this node
+	for (auto &child : state.children) {
+		result += ExtractExpressionsRecursive(*child);
+	}
+	return result;
+}
+
+unique_ptr<RenderTreeNode> TreeRenderer::CreateNode(const QueryProfiler::TreeNode &op) {
+	auto result = TreeRenderer::CreateRenderNode(op.name, op.extra_info);
+	result->extra_text += "\n[INFOSEPARATOR]";
+	result->extra_text += "\n" + to_string(op.info.elements);
+	string timing = StringUtil::Format("%.2f", op.info.time);
+	result->extra_text += "\n(" + timing + "s)";
+	if (config.detailed) {
+		for (auto &info : op.info.executors_info) {
+			if (!info) {
+				continue;
+			}
+			for (auto &executor_info : info->roots) {
+				string sample_count = to_string(executor_info->sample_count);
+				result->extra_text += "\n[INFOSEPARATOR]";
+				result->extra_text += "\nsample_count: " + sample_count;
+				string sample_tuples_count = to_string(executor_info->sample_tuples_count);
+				result->extra_text += "\n[INFOSEPARATOR]";
+				result->extra_text += "\nsample_tuples_count: " + sample_tuples_count;
+				string total_count = to_string(executor_info->total_count);
+				result->extra_text += "\n[INFOSEPARATOR]";
+				result->extra_text += "\ntotal_count: " + total_count;
+				for (auto &state : executor_info->root->children) {
+					result->extra_text += ExtractExpressionsRecursive(*state);
+				}
+			}
+		}
+	}
+	return result;
+}
+
+unique_ptr<RenderTree> TreeRenderer::CreateTree(const LogicalOperator &op) {
+	return CreateRenderTree<LogicalOperator>(op);
+}
+
+unique_ptr<RenderTree> TreeRenderer::CreateTree(const PhysicalOperator &op) {
+	return CreateRenderTree<PhysicalOperator>(op);
+}
+
+unique_ptr<RenderTree> TreeRenderer::CreateTree(const QueryProfiler::TreeNode &op) {
+	return CreateRenderTree<QueryProfiler::TreeNode>(op);
+}
+
+unique_ptr<RenderTree> TreeRenderer::CreateTree(const Pipeline &op) {
+	auto operators = op.GetOperators();
+	D_ASSERT(!operators.empty());
+	unique_ptr<PipelineRenderNode> node;
+	for (auto &op : operators) {
+		auto new_node = make_unique<PipelineRenderNode>(*op);
+		new_node->child = move(node);
+		node = move(new_node);
+	}
+	return CreateRenderTree<PipelineRenderNode>(*node);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+BatchedChunkCollection::BatchedChunkCollection() {
+}
+
+void BatchedChunkCollection::Append(DataChunk &input, idx_t batch_index) {
+	D_ASSERT(batch_index != DConstants::INVALID_INDEX);
+	auto entry = data.find(batch_index);
+	ChunkCollection *collection;
+	if (entry == data.end()) {
+		auto new_collection = make_unique<ChunkCollection>();
+		collection = new_collection.get();
+		data.insert(make_pair(batch_index, move(new_collection)));
+	} else {
+		collection = entry->second.get();
+	}
+	collection->Append(input);
+}
+
+void BatchedChunkCollection::Merge(BatchedChunkCollection &other) {
+	for (auto &entry : other.data) {
+		if (data.find(entry.first) != data.end()) {
+			throw InternalException(
+			    "BatchChunkCollection::Merge error - batch index %d is present in both collections. This occurs when "
+			    "batch indexes are not uniquely distributed over threads",
+			    entry.first);
+		}
+		data[entry.first] = move(entry.second);
+	}
+	other.data.clear();
+}
+
+void BatchedChunkCollection::InitializeScan(BatchedChunkScanState &state) {
+	state.iterator = data.begin();
+	state.chunk_index = 0;
+}
+
+void BatchedChunkCollection::Scan(BatchedChunkScanState &state, DataChunk &output) {
+	while (state.iterator != data.end()) {
+		// check if there is a chunk remaining in this collection
+		auto collection = state.iterator->second.get();
+		if (state.chunk_index < collection->ChunkCount()) {
+			// there is! increment the chunk count
+			output.Reference(collection->GetChunk(state.chunk_index));
+			state.chunk_index++;
+			return;
+		}
+		// there isn't! move to the next collection
+		state.iterator++;
+		state.chunk_index = 0;
+	}
+}
+
+string BatchedChunkCollection::ToString() const {
+	string result;
+	result += "Batched Chunk Collection\n";
+	for (auto &entry : data) {
+		result += "Batch Index - " + to_string(entry.first) + "\n";
+		result += entry.second->ToString() + "\n\n";
+	}
+	return result;
+}
+
+void BatchedChunkCollection::Print() const {
+	Printer::Print(ToString());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+constexpr const char *Blob::HEX_TABLE;
+const int Blob::HEX_MAP[256] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+    -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+
+idx_t Blob::GetStringSize(string_t blob) {
+	auto data = (const_data_ptr_t)blob.GetDataUnsafe();
+	auto len = blob.GetSize();
+	idx_t str_len = 0;
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] >= 32 && data[i] <= 127 && data[i] != '\\') {
+			// ascii characters are rendered as-is
+			str_len++;
+		} else {
+			// non-ascii characters are rendered as hexadecimal (e.g. \x00)
+			str_len += 4;
+		}
+	}
+	return str_len;
+}
+
+void Blob::ToString(string_t blob, char *output) {
+	auto data = (const_data_ptr_t)blob.GetDataUnsafe();
+	auto len = blob.GetSize();
+	idx_t str_idx = 0;
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] >= 32 && data[i] <= 127 && data[i] != '\\') {
+			// ascii characters are rendered as-is
+			output[str_idx++] = data[i];
+		} else {
+			auto byte_a = data[i] >> 4;
+			auto byte_b = data[i] & 0x0F;
+			D_ASSERT(byte_a >= 0 && byte_a < 16);
+			D_ASSERT(byte_b >= 0 && byte_b < 16);
+			// non-ascii characters are rendered as hexadecimal (e.g. \x00)
+			output[str_idx++] = '\\';
+			output[str_idx++] = 'x';
+			output[str_idx++] = Blob::HEX_TABLE[byte_a];
+			output[str_idx++] = Blob::HEX_TABLE[byte_b];
+		}
+	}
+	D_ASSERT(str_idx == GetStringSize(blob));
+}
+
+string Blob::ToString(string_t blob) {
+	auto str_len = GetStringSize(blob);
+	auto buffer = std::unique_ptr<char[]>(new char[str_len]);
+	Blob::ToString(blob, buffer.get());
+	return string(buffer.get(), str_len);
+}
+
+bool Blob::TryGetBlobSize(string_t str, idx_t &str_len, string *error_message) {
+	auto data = (const_data_ptr_t)str.GetDataUnsafe();
+	auto len = str.GetSize();
+	str_len = 0;
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] == '\\') {
+			if (i + 3 >= len) {
+				string error = "Invalid hex escape code encountered in string -> blob conversion: "
+				               "unterminated escape code at end of blob";
+				HandleCastError::AssignError(error, error_message);
+				return false;
+			}
+			if (data[i + 1] != 'x' || Blob::HEX_MAP[data[i + 2]] < 0 || Blob::HEX_MAP[data[i + 3]] < 0) {
+				string error =
+				    StringUtil::Format("Invalid hex escape code encountered in string -> blob conversion: %s",
+				                       string((char *)data + i, 4));
+				HandleCastError::AssignError(error, error_message);
+				return false;
+			}
+			str_len++;
+			i += 3;
+		} else if (data[i] >= 32 && data[i] <= 127) {
+			str_len++;
+		} else {
+			string error = "Invalid byte encountered in STRING -> BLOB conversion. All non-ascii characters "
+			               "must be escaped with hex codes (e.g. \\xAA)";
+			HandleCastError::AssignError(error, error_message);
+			return false;
+		}
+	}
+	return true;
+}
+
+idx_t Blob::GetBlobSize(string_t str) {
+	string error_message;
+	idx_t str_len;
+	if (!Blob::TryGetBlobSize(str, str_len, &error_message)) {
+		throw ConversionException(error_message);
+	}
+	return str_len;
+}
+
+void Blob::ToBlob(string_t str, data_ptr_t output) {
+	auto data = (const_data_ptr_t)str.GetDataUnsafe();
+	auto len = str.GetSize();
+	idx_t blob_idx = 0;
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] == '\\') {
+			int byte_a = Blob::HEX_MAP[data[i + 2]];
+			int byte_b = Blob::HEX_MAP[data[i + 3]];
+			D_ASSERT(i + 3 < len);
+			D_ASSERT(byte_a >= 0 && byte_b >= 0);
+			D_ASSERT(data[i + 1] == 'x');
+			output[blob_idx++] = (byte_a << 4) + byte_b;
+			i += 3;
+		} else if (data[i] >= 32 && data[i] <= 127) {
+			output[blob_idx++] = data_t(data[i]);
+		} else {
+			throw ConversionException("Invalid byte encountered in STRING -> BLOB conversion. All non-ascii characters "
+			                          "must be escaped with hex codes (e.g. \\xAA)");
+		}
+	}
+	D_ASSERT(blob_idx == GetBlobSize(str));
+}
+
+string Blob::ToBlob(string_t str) {
+	auto blob_len = GetBlobSize(str);
+	auto buffer = std::unique_ptr<char[]>(new char[blob_len]);
+	Blob::ToBlob(str, (data_ptr_t)buffer.get());
+	return string(buffer.get(), blob_len);
+}
+
+// base64 functions are adapted from https://gist.github.com/tomykaira/f0fd86b6c73063283afe550bc5d77594
+idx_t Blob::ToBase64Size(string_t blob) {
+	// every 4 characters in base64 encode 3 bytes, plus (potential) padding at the end
+	auto input_size = blob.GetSize();
+	return ((input_size + 2) / 3) * 4;
+}
+
+void Blob::ToBase64(string_t blob, char *output) {
+	auto input_data = (const_data_ptr_t)blob.GetDataUnsafe();
+	auto input_size = blob.GetSize();
+	idx_t out_idx = 0;
+	idx_t i;
+	// convert the bulk of the string to base64
+	// this happens in steps of 3 bytes -> 4 output bytes
+	for (i = 0; i + 2 < input_size; i += 3) {
+		output[out_idx++] = Blob::BASE64_MAP[(input_data[i] >> 2) & 0x3F];
+		output[out_idx++] = Blob::BASE64_MAP[((input_data[i] & 0x3) << 4) | ((input_data[i + 1] & 0xF0) >> 4)];
+		output[out_idx++] = Blob::BASE64_MAP[((input_data[i + 1] & 0xF) << 2) | ((input_data[i + 2] & 0xC0) >> 6)];
+		output[out_idx++] = Blob::BASE64_MAP[input_data[i + 2] & 0x3F];
+	}
+
+	if (i < input_size) {
+		// there are one or two bytes left over: we have to insert padding
+		// first write the first 6 bits of the first byte
+		output[out_idx++] = Blob::BASE64_MAP[(input_data[i] >> 2) & 0x3F];
+		// now check the character count
+		if (i == input_size - 1) {
+			// single byte left over: convert the remainder of that byte and insert padding
+			output[out_idx++] = Blob::BASE64_MAP[((input_data[i] & 0x3) << 4)];
+			output[out_idx++] = Blob::BASE64_PADDING;
+		} else {
+			// two bytes left over: convert the second byte as well
+			output[out_idx++] = Blob::BASE64_MAP[((input_data[i] & 0x3) << 4) | ((input_data[i + 1] & 0xF0) >> 4)];
+			output[out_idx++] = Blob::BASE64_MAP[((input_data[i + 1] & 0xF) << 2)];
+		}
+		output[out_idx++] = Blob::BASE64_PADDING;
+	}
+}
+
+static constexpr int BASE64_DECODING_TABLE[256] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
+    -1, -1, -1, -1, -1, -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+    22, 23, 24, 25, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
+    45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+
+idx_t Blob::FromBase64Size(string_t str) {
+	auto input_data = str.GetDataUnsafe();
+	auto input_size = str.GetSize();
+	if (input_size % 4 != 0) {
+		// valid base64 needs to always be cleanly divisible by 4
+		throw ConversionException("Could not decode string \"%s\" as base64: length must be a multiple of 4",
+		                          str.GetString());
+	}
+	if (input_size < 4) {
+		// empty string
+		return 0;
+	}
+	auto base_size = input_size / 4 * 3;
+	// check for padding to figure out the length
+	if (input_data[input_size - 2] == Blob::BASE64_PADDING) {
+		// two bytes of padding
+		return base_size - 2;
+	}
+	if (input_data[input_size - 1] == Blob::BASE64_PADDING) {
+		// one byte of padding
+		return base_size - 1;
+	}
+	// no padding
+	return base_size;
+}
+
+template <bool ALLOW_PADDING>
+uint32_t DecodeBase64Bytes(const string_t &str, const_data_ptr_t input_data, idx_t base_idx) {
+	int decoded_bytes[4];
+	for (idx_t decode_idx = 0; decode_idx < 4; decode_idx++) {
+		if (ALLOW_PADDING && decode_idx >= 2 && input_data[base_idx + decode_idx] == Blob::BASE64_PADDING) {
+			// the last two bytes of a base64 string can have padding: in this case we set the byte to 0
+			decoded_bytes[decode_idx] = 0;
+		} else {
+			decoded_bytes[decode_idx] = BASE64_DECODING_TABLE[input_data[base_idx + decode_idx]];
+		}
+		if (decoded_bytes[decode_idx] < 0) {
+			throw ConversionException(
+			    "Could not decode string \"%s\" as base64: invalid byte value '%d' at position %d", str.GetString(),
+			    input_data[base_idx + decode_idx], base_idx + decode_idx);
+		}
+	}
+	return (decoded_bytes[0] << 3 * 6) + (decoded_bytes[1] << 2 * 6) + (decoded_bytes[2] << 1 * 6) +
+	       (decoded_bytes[3] << 0 * 6);
+}
+
+void Blob::FromBase64(string_t str, data_ptr_t output, idx_t output_size) {
+	D_ASSERT(output_size == FromBase64Size(str));
+	auto input_data = (const_data_ptr_t)str.GetDataUnsafe();
+	auto input_size = str.GetSize();
+	if (input_size == 0) {
+		return;
+	}
+	idx_t out_idx = 0;
+	idx_t i = 0;
+	for (i = 0; i + 4 < input_size; i += 4) {
+		auto combined = DecodeBase64Bytes<false>(str, input_data, i);
+		output[out_idx++] = (combined >> 2 * 8) & 0xFF;
+		output[out_idx++] = (combined >> 1 * 8) & 0xFF;
+		output[out_idx++] = (combined >> 0 * 8) & 0xFF;
+	}
+	// decode the final four bytes: padding is allowed here
+	auto combined = DecodeBase64Bytes<true>(str, input_data, i);
+	output[out_idx++] = (combined >> 2 * 8) & 0xFF;
+	if (out_idx < output_size) {
+		output[out_idx++] = (combined >> 1 * 8) & 0xFF;
+	}
+	if (out_idx < output_size) {
+		output[out_idx++] = (combined >> 0 * 8) & 0xFF;
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+const int64_t NumericHelper::POWERS_OF_TEN[] {1,
+                                              10,
+                                              100,
+                                              1000,
+                                              10000,
+                                              100000,
+                                              1000000,
+                                              10000000,
+                                              100000000,
+                                              1000000000,
+                                              10000000000,
+                                              100000000000,
+                                              1000000000000,
+                                              10000000000000,
+                                              100000000000000,
+                                              1000000000000000,
+                                              10000000000000000,
+                                              100000000000000000,
+                                              1000000000000000000};
+
+const double NumericHelper::DOUBLE_POWERS_OF_TEN[] {1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,  1e8,  1e9,
+                                                    1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19,
+                                                    1e20, 1e21, 1e22, 1e23, 1e24, 1e25, 1e26, 1e27, 1e28, 1e29,
+                                                    1e30, 1e31, 1e32, 1e33, 1e34, 1e35, 1e36, 1e37, 1e38, 1e39};
+
+template <>
+int NumericHelper::UnsignedLength(uint8_t value) {
+	int length = 1;
+	length += value >= 10;
+	length += value >= 100;
+	return length;
+}
+
+template <>
+int NumericHelper::UnsignedLength(uint16_t value) {
+	int length = 1;
+	length += value >= 10;
+	length += value >= 100;
+	length += value >= 1000;
+	length += value >= 10000;
+	return length;
+}
+
+template <>
+int NumericHelper::UnsignedLength(uint32_t value) {
+	if (value >= 10000) {
+		int length = 5;
+		length += value >= 100000;
+		length += value >= 1000000;
+		length += value >= 10000000;
+		length += value >= 100000000;
+		length += value >= 1000000000;
+		return length;
+	} else {
+		int length = 1;
+		length += value >= 10;
+		length += value >= 100;
+		length += value >= 1000;
+		return length;
+	}
+}
+
+template <>
+int NumericHelper::UnsignedLength(uint64_t value) {
+	if (value >= 10000000000ULL) {
+		if (value >= 1000000000000000ULL) {
+			int length = 16;
+			length += value >= 10000000000000000ULL;
+			length += value >= 100000000000000000ULL;
+			length += value >= 1000000000000000000ULL;
+			length += value >= 10000000000000000000ULL;
+			return length;
+		} else {
+			int length = 11;
+			length += value >= 100000000000ULL;
+			length += value >= 1000000000000ULL;
+			length += value >= 10000000000000ULL;
+			length += value >= 100000000000000ULL;
+			return length;
+		}
+	} else {
+		if (value >= 100000ULL) {
+			int length = 6;
+			length += value >= 1000000ULL;
+			length += value >= 10000000ULL;
+			length += value >= 100000000ULL;
+			length += value >= 1000000000ULL;
+			return length;
+		} else {
+			int length = 1;
+			length += value >= 10ULL;
+			length += value >= 100ULL;
+			length += value >= 1000ULL;
+			length += value >= 10000ULL;
+			return length;
+		}
+	}
+}
+
+template <>
+std::string NumericHelper::ToString(hugeint_t value) {
+	return Hugeint::ToString(value);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <cstring>
+
+namespace duckdb {
+
+void ChunkCollection::Verify() {
+#ifdef DEBUG
+	for (auto &chunk : chunks) {
+		chunk->Verify();
+	}
+#endif
+}
+
+void ChunkCollection::Append(ChunkCollection &other) {
+	for (auto &chunk : other.chunks) {
+		Append(*chunk);
+	}
+}
+
+void ChunkCollection::Merge(ChunkCollection &other) {
+	if (other.count == 0) {
+		return;
+	}
+	if (count == 0) {
+		chunks = move(other.chunks);
+		types = move(other.types);
+		count = other.count;
+		return;
+	}
+	unique_ptr<DataChunk> old_back;
+	if (!chunks.empty() && chunks.back()->size() != STANDARD_VECTOR_SIZE) {
+		old_back = move(chunks.back());
+		chunks.pop_back();
+		count -= old_back->size();
+	}
+	for (auto &chunk : other.chunks) {
+		chunks.push_back(move(chunk));
+	}
+	count += other.count;
+	if (old_back) {
+		Append(*old_back);
+	}
+	Verify();
+}
+
+void ChunkCollection::Append(DataChunk &new_chunk) {
+	if (new_chunk.size() == 0) {
+		return;
+	}
+	new_chunk.Verify();
+
+	// we have to ensure that every chunk in the ChunkCollection is completely
+	// filled, otherwise our O(1) lookup in GetValue and SetValue does not work
+	// first fill the latest chunk, if it exists
+	count += new_chunk.size();
+
+	idx_t remaining_data = new_chunk.size();
+	idx_t offset = 0;
+	if (chunks.empty()) {
+		// first chunk
+		types = new_chunk.GetTypes();
+	} else {
+		// the types of the new chunk should match the types of the previous one
+		D_ASSERT(types.size() == new_chunk.ColumnCount());
+		auto new_types = new_chunk.GetTypes();
+		for (idx_t i = 0; i < types.size(); i++) {
+			if (new_types[i] != types[i]) {
+				throw TypeMismatchException(new_types[i], types[i], "Type mismatch when combining rows");
+			}
+			if (types[i].InternalType() == PhysicalType::LIST) {
+				// need to check all the chunks because they can have only-null list entries
+				for (auto &chunk : chunks) {
+					auto &chunk_vec = chunk->data[i];
+					auto &new_vec = new_chunk.data[i];
+					auto &chunk_type = chunk_vec.GetType();
+					auto &new_type = new_vec.GetType();
+					if (chunk_type != new_type) {
+						throw TypeMismatchException(chunk_type, new_type, "Type mismatch when combining lists");
+					}
+				}
+			}
+			// TODO check structs, too
+		}
+
+		// first append data to the current chunk
+		DataChunk &last_chunk = *chunks.back();
+		idx_t added_data = MinValue<idx_t>(remaining_data, STANDARD_VECTOR_SIZE - last_chunk.size());
+		if (added_data > 0) {
+			// copy <added_data> elements to the last chunk
+			new_chunk.Normalify();
+			// have to be careful here: setting the cardinality without calling normalify can cause incorrect partial
+			// decompression
+			idx_t old_count = new_chunk.size();
+			new_chunk.SetCardinality(added_data);
+
+			last_chunk.Append(new_chunk);
+			remaining_data -= added_data;
+			// reset the chunk to the old data
+			new_chunk.SetCardinality(old_count);
+			offset = added_data;
+		}
+	}
+
+	if (remaining_data > 0) {
+		// create a new chunk and fill it with the remainder
+		auto chunk = make_unique<DataChunk>();
+		chunk->Initialize(types);
+		new_chunk.Copy(*chunk, offset);
+		chunks.push_back(move(chunk));
+	}
+}
+
+void ChunkCollection::Append(unique_ptr<DataChunk> new_chunk) {
+	if (types.empty()) {
+		types = new_chunk->GetTypes();
+	}
+	D_ASSERT(types == new_chunk->GetTypes());
+	count += new_chunk->size();
+	chunks.push_back(move(new_chunk));
+}
+
+void ChunkCollection::Fuse(ChunkCollection &other) {
+	if (count == 0) {
+		chunks.reserve(other.ChunkCount());
+		for (idx_t chunk_idx = 0; chunk_idx < other.ChunkCount(); ++chunk_idx) {
+			auto lhs = make_unique<DataChunk>();
+			auto &rhs = other.GetChunk(chunk_idx);
+			lhs->data.reserve(rhs.data.size());
+			for (auto &v : rhs.data) {
+				lhs->data.emplace_back(Vector(v));
+			}
+			lhs->SetCardinality(rhs.size());
+			chunks.push_back(move(lhs));
+		}
+		count = other.Count();
+	} else {
+		D_ASSERT(this->ChunkCount() == other.ChunkCount());
+		for (idx_t chunk_idx = 0; chunk_idx < ChunkCount(); ++chunk_idx) {
+			auto &lhs = this->GetChunk(chunk_idx);
+			auto &rhs = other.GetChunk(chunk_idx);
+			D_ASSERT(lhs.size() == rhs.size());
+			for (auto &v : rhs.data) {
+				lhs.data.emplace_back(Vector(v));
+			}
+		}
+	}
+	types.insert(types.end(), other.types.begin(), other.types.end());
+}
+
+// returns an int similar to a C comparator:
+// -1 if left < right
+// 0 if left == right
+// 1 if left > right
+
+template <class TYPE>
+static int8_t TemplatedCompareValue(Vector &left_vec, Vector &right_vec, idx_t left_idx, idx_t right_idx) {
+	D_ASSERT(left_vec.GetType() == right_vec.GetType());
+	auto left_val = FlatVector::GetData<TYPE>(left_vec)[left_idx];
+	auto right_val = FlatVector::GetData<TYPE>(right_vec)[right_idx];
+	if (Equals::Operation<TYPE>(left_val, right_val)) {
+		return 0;
+	}
+	if (LessThan::Operation<TYPE>(left_val, right_val)) {
+		return -1;
+	}
+	return 1;
+}
+
+// return type here is int32 because strcmp() on some platforms returns rather large values
+static int32_t CompareValue(Vector &left_vec, Vector &right_vec, idx_t vector_idx_left, idx_t vector_idx_right,
+                            OrderByNullType null_order) {
+	auto left_null = FlatVector::IsNull(left_vec, vector_idx_left);
+	auto right_null = FlatVector::IsNull(right_vec, vector_idx_right);
+
+	if (left_null && right_null) {
+		return 0;
+	} else if (right_null) {
+		return null_order == OrderByNullType::NULLS_FIRST ? 1 : -1;
+	} else if (left_null) {
+		return null_order == OrderByNullType::NULLS_FIRST ? -1 : 1;
+	}
+
+	switch (left_vec.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedCompareValue<int8_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::INT16:
+		return TemplatedCompareValue<int16_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::INT32:
+		return TemplatedCompareValue<int32_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::INT64:
+		return TemplatedCompareValue<int64_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::UINT8:
+		return TemplatedCompareValue<uint8_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::UINT16:
+		return TemplatedCompareValue<uint16_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::UINT32:
+		return TemplatedCompareValue<uint32_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::UINT64:
+		return TemplatedCompareValue<uint64_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::INT128:
+		return TemplatedCompareValue<hugeint_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::FLOAT:
+		return TemplatedCompareValue<float>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::DOUBLE:
+		return TemplatedCompareValue<double>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::VARCHAR:
+		return TemplatedCompareValue<string_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	case PhysicalType::INTERVAL:
+		return TemplatedCompareValue<interval_t>(left_vec, right_vec, vector_idx_left, vector_idx_right);
+	default:
+		throw NotImplementedException("Type for comparison");
+	}
+}
+
+static int CompareTuple(ChunkCollection *sort_by, vector<OrderType> &desc, vector<OrderByNullType> &null_order,
+                        idx_t left, idx_t right) {
+	D_ASSERT(sort_by);
+
+	idx_t chunk_idx_left = left / STANDARD_VECTOR_SIZE;
+	idx_t chunk_idx_right = right / STANDARD_VECTOR_SIZE;
+	idx_t vector_idx_left = left % STANDARD_VECTOR_SIZE;
+	idx_t vector_idx_right = right % STANDARD_VECTOR_SIZE;
+
+	auto &left_chunk = sort_by->GetChunk(chunk_idx_left);
+	auto &right_chunk = sort_by->GetChunk(chunk_idx_right);
+
+	for (idx_t col_idx = 0; col_idx < desc.size(); col_idx++) {
+		auto order_type = desc[col_idx];
+
+		auto &left_vec = left_chunk.data[col_idx];
+		auto &right_vec = right_chunk.data[col_idx];
+
+		D_ASSERT(left_vec.GetVectorType() == VectorType::FLAT_VECTOR);
+		D_ASSERT(right_vec.GetVectorType() == VectorType::FLAT_VECTOR);
+		D_ASSERT(left_vec.GetType() == right_vec.GetType());
+
+		auto comp_res = CompareValue(left_vec, right_vec, vector_idx_left, vector_idx_right, null_order[col_idx]);
+
+		if (comp_res == 0) {
+			continue;
+		}
+		return comp_res < 0 ? (order_type == OrderType::ASCENDING ? -1 : 1)
+		                    : (order_type == OrderType::ASCENDING ? 1 : -1);
+	}
+	return 0;
+}
+
+static int64_t QuicksortInitial(ChunkCollection *sort_by, vector<OrderType> &desc, vector<OrderByNullType> &null_order,
+                                idx_t *result) {
+	// select pivot
+	int64_t pivot = 0;
+	int64_t low = 0, high = sort_by->Count() - 1;
+	// now insert elements
+	for (idx_t i = 1; i < sort_by->Count(); i++) {
+		if (CompareTuple(sort_by, desc, null_order, i, pivot) <= 0) {
+			result[low++] = i;
+		} else {
+			result[high--] = i;
+		}
+	}
+	D_ASSERT(low == high);
+	result[low] = pivot;
+	return low;
+}
+
+struct QuicksortInfo {
+	QuicksortInfo(int64_t left_p, int64_t right_p) : left(left_p), right(right_p) {
+	}
+
+	int64_t left;
+	int64_t right;
+};
+
+struct QuicksortStack {
+	std::queue<QuicksortInfo> info_queue;
+
+	QuicksortInfo Pop() {
+		auto element = info_queue.front();
+		info_queue.pop();
+		return element;
+	}
+
+	bool IsEmpty() {
+		return info_queue.empty();
+	}
+
+	void Enqueue(int64_t left, int64_t right) {
+		if (left >= right) {
+			return;
+		}
+		info_queue.emplace(left, right);
+	}
+};
+
+static void QuicksortInPlace(ChunkCollection *sort_by, vector<OrderType> &desc, vector<OrderByNullType> &null_order,
+                             idx_t *result, QuicksortInfo info, QuicksortStack &stack) {
+	auto left = info.left;
+	auto right = info.right;
+
+	D_ASSERT(left < right);
+
+	int64_t middle = left + (right - left) / 2;
+	int64_t pivot = result[middle];
+	// move the mid point value to the front.
+	int64_t i = left + 1;
+	int64_t j = right;
+
+	std::swap(result[middle], result[left]);
+	bool all_equal = true;
+	while (i <= j) {
+		if (result) {
+			while (i <= j) {
+				int cmp = CompareTuple(sort_by, desc, null_order, result[i], pivot);
+				if (cmp < 0) {
+					all_equal = false;
+				} else if (cmp > 0) {
+					all_equal = false;
+					break;
+				}
+				i++;
+			}
+		}
+
+		while (i <= j && CompareTuple(sort_by, desc, null_order, result[j], pivot) > 0) {
+			j--;
+		}
+
+		if (i < j) {
+			std::swap(result[i], result[j]);
+		}
+	}
+	std::swap(result[i - 1], result[left]);
+	int64_t part = i - 1;
+
+	if (all_equal) {
+		return;
+	}
+
+	stack.Enqueue(left, part - 1);
+	stack.Enqueue(part + 1, right);
+}
+
+void ChunkCollection::Sort(vector<OrderType> &desc, vector<OrderByNullType> &null_order, idx_t result[]) {
+	if (count == 0) {
+		return;
+	}
+	D_ASSERT(result);
+
+	// start off with an initial quicksort
+	int64_t part = QuicksortInitial(this, desc, null_order, result);
+
+	// now continuously perform
+	QuicksortStack stack;
+	stack.Enqueue(0, part);
+	stack.Enqueue(part + 1, count - 1);
+	while (!stack.IsEmpty()) {
+		auto element = stack.Pop();
+		QuicksortInPlace(this, desc, null_order, result, element, stack);
+	}
+}
+
+// FIXME make this more efficient by not using the Value API
+// just use memcpy in the vectors
+// assert that there is no selection list
+void ChunkCollection::Reorder(idx_t order_org[]) {
+	auto order = unique_ptr<idx_t[]>(new idx_t[count]);
+	memcpy(order.get(), order_org, sizeof(idx_t) * count);
+
+	// adapted from https://stackoverflow.com/a/7366196/2652376
+
+	auto val_buf = vector<Value>();
+	val_buf.resize(ColumnCount());
+
+	idx_t j, k;
+	for (idx_t i = 0; i < count; i++) {
+		for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+			val_buf[col_idx] = GetValue(col_idx, i);
+		}
+		j = i;
+		while (true) {
+			k = order[j];
+			order[j] = j;
+			if (k == i) {
+				break;
+			}
+			for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+				SetValue(col_idx, j, GetValue(col_idx, k));
+			}
+			j = k;
+		}
+		for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+			SetValue(col_idx, j, val_buf[col_idx]);
+		}
+	}
+}
+
+Value ChunkCollection::GetValue(idx_t column, idx_t index) {
+	return chunks[LocateChunk(index)]->GetValue(column, index % STANDARD_VECTOR_SIZE);
+}
+
+void ChunkCollection::SetValue(idx_t column, idx_t index, const Value &value) {
+	chunks[LocateChunk(index)]->SetValue(column, index % STANDARD_VECTOR_SIZE, value);
+}
+
+void ChunkCollection::CopyCell(idx_t column, idx_t index, Vector &target, idx_t target_offset) {
+	auto &chunk = GetChunkForRow(index);
+	auto &source = chunk.data[column];
+	const auto source_offset = index % STANDARD_VECTOR_SIZE;
+	VectorOperations::Copy(source, target, source_offset + 1, source_offset, target_offset);
+}
+
+string ChunkCollection::ToString() const {
+	return chunks.empty() ? "ChunkCollection [ 0 ]"
+	                      : "ChunkCollection [ " + std::to_string(count) + " ]: \n" + chunks[0]->ToString();
+}
+
+void ChunkCollection::Print() const {
+	Printer::Print(ToString());
+}
+
+bool ChunkCollection::Equals(ChunkCollection &other) {
+	if (count != other.count) {
+		return false;
+	}
+	if (ColumnCount() != other.ColumnCount()) {
+		return false;
+	}
+	// first try to compare the results as-is
+	bool compare_equals = true;
+	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+		for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+			auto lvalue = GetValue(col_idx, row_idx);
+			auto rvalue = other.GetValue(col_idx, row_idx);
+			if (!Value::ValuesAreEqual(lvalue, rvalue)) {
+				compare_equals = false;
+				break;
+			}
+		}
+		if (!compare_equals) {
+			break;
+		}
+	}
+	if (compare_equals) {
+		return true;
+	}
+	// if the results are not equal,
+	// sort both chunk collections to ensure the comparison is not order insensitive
+	vector<OrderType> desc(ColumnCount(), OrderType::DESCENDING);
+	vector<OrderByNullType> null_order(ColumnCount(), OrderByNullType::NULLS_FIRST);
+	auto this_order = unique_ptr<idx_t[]>(new idx_t[count]);
+	auto other_order = unique_ptr<idx_t[]>(new idx_t[count]);
+	Sort(desc, null_order, this_order.get());
+	other.Sort(desc, null_order, other_order.get());
+
+	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+		auto lrow = this_order[row_idx];
+		auto rrow = other_order[row_idx];
+		for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+			auto lvalue = GetValue(col_idx, lrow);
+			auto rvalue = other.GetValue(col_idx, rrow);
+			if (!Value::ValuesAreEqual(lvalue, rvalue)) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+} // namespace duckdb

--- a/velox/external/duckdb/duckdb-2.cpp
+++ b/velox/external/duckdb/duckdb-2.cpp
@@ -1,0 +1,17425 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+DataChunk::DataChunk() : count(0), capacity(STANDARD_VECTOR_SIZE) {
+}
+
+DataChunk::~DataChunk() {
+}
+
+void DataChunk::InitializeEmpty(const vector<LogicalType> &types) {
+	capacity = STANDARD_VECTOR_SIZE;
+	D_ASSERT(data.empty());   // can only be initialized once
+	D_ASSERT(!types.empty()); // empty chunk not allowed
+	for (idx_t i = 0; i < types.size(); i++) {
+		data.emplace_back(Vector(types[i], nullptr));
+	}
+}
+
+void DataChunk::Initialize(const vector<LogicalType> &types) {
+	D_ASSERT(data.empty());   // can only be initialized once
+	D_ASSERT(!types.empty()); // empty chunk not allowed
+	capacity = STANDARD_VECTOR_SIZE;
+	for (idx_t i = 0; i < types.size(); i++) {
+		VectorCache cache(types[i]);
+		data.emplace_back(cache);
+		vector_caches.push_back(move(cache));
+	}
+}
+
+void DataChunk::Reset() {
+	if (data.empty()) {
+		return;
+	}
+	if (vector_caches.size() != data.size()) {
+		throw InternalException("VectorCache and column count mismatch in DataChunk::Reset");
+	}
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		data[i].ResetFromCache(vector_caches[i]);
+	}
+	capacity = STANDARD_VECTOR_SIZE;
+	SetCardinality(0);
+}
+
+void DataChunk::Destroy() {
+	data.clear();
+	vector_caches.clear();
+	capacity = 0;
+	SetCardinality(0);
+}
+
+Value DataChunk::GetValue(idx_t col_idx, idx_t index) const {
+	D_ASSERT(index < size());
+	return data[col_idx].GetValue(index);
+}
+
+void DataChunk::SetValue(idx_t col_idx, idx_t index, const Value &val) {
+	data[col_idx].SetValue(index, val);
+}
+
+void DataChunk::Reference(DataChunk &chunk) {
+	D_ASSERT(chunk.ColumnCount() <= ColumnCount());
+	SetCardinality(chunk);
+	SetCapacity(chunk);
+	for (idx_t i = 0; i < chunk.ColumnCount(); i++) {
+		data[i].Reference(chunk.data[i]);
+	}
+}
+
+void DataChunk::Move(DataChunk &chunk) {
+	SetCardinality(chunk);
+	SetCapacity(chunk);
+	data = move(chunk.data);
+	vector_caches = move(chunk.vector_caches);
+
+	chunk.Destroy();
+}
+
+void DataChunk::Copy(DataChunk &other, idx_t offset) const {
+	D_ASSERT(ColumnCount() == other.ColumnCount());
+	D_ASSERT(other.size() == 0);
+
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		D_ASSERT(other.data[i].GetVectorType() == VectorType::FLAT_VECTOR);
+		VectorOperations::Copy(data[i], other.data[i], size(), offset, 0);
+	}
+	other.SetCardinality(size() - offset);
+}
+
+void DataChunk::Copy(DataChunk &other, const SelectionVector &sel, const idx_t source_count, const idx_t offset) const {
+	D_ASSERT(ColumnCount() == other.ColumnCount());
+	D_ASSERT(other.size() == 0);
+	D_ASSERT((offset + source_count) <= size());
+
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		D_ASSERT(other.data[i].GetVectorType() == VectorType::FLAT_VECTOR);
+		VectorOperations::Copy(data[i], other.data[i], sel, source_count, offset, 0);
+	}
+	other.SetCardinality(source_count - offset);
+}
+
+void DataChunk::Split(DataChunk &other, idx_t split_idx) {
+	D_ASSERT(other.size() == 0);
+	D_ASSERT(other.data.empty());
+	D_ASSERT(split_idx < data.size());
+	const idx_t num_cols = data.size();
+	for (idx_t col_idx = split_idx; col_idx < num_cols; col_idx++) {
+		other.data.push_back(move(data[col_idx]));
+		other.vector_caches.push_back(move(vector_caches[col_idx]));
+	}
+	for (idx_t col_idx = split_idx; col_idx < num_cols; col_idx++) {
+		data.pop_back();
+		vector_caches.pop_back();
+	}
+	other.SetCardinality(*this);
+	other.SetCapacity(*this);
+}
+
+void DataChunk::Fuse(DataChunk &other) {
+	D_ASSERT(other.size() == size());
+	const idx_t num_cols = other.data.size();
+	for (idx_t col_idx = 0; col_idx < num_cols; ++col_idx) {
+		data.emplace_back(move(other.data[col_idx]));
+		vector_caches.emplace_back(move(other.vector_caches[col_idx]));
+	}
+	other.Destroy();
+}
+
+void DataChunk::Append(const DataChunk &other, bool resize, SelectionVector *sel, idx_t sel_count) {
+	idx_t new_size = sel ? size() + sel_count : size() + other.size();
+	if (other.size() == 0) {
+		return;
+	}
+	if (ColumnCount() != other.ColumnCount()) {
+		throw InternalException("Column counts of appending chunk doesn't match!");
+	}
+	if (new_size > capacity) {
+		if (resize) {
+			for (idx_t i = 0; i < ColumnCount(); i++) {
+				data[i].Resize(size(), new_size);
+			}
+			capacity = new_size;
+		} else {
+			throw InternalException("Can't append chunk to other chunk without resizing");
+		}
+	}
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		D_ASSERT(data[i].GetVectorType() == VectorType::FLAT_VECTOR);
+		if (sel) {
+			VectorOperations::Copy(other.data[i], data[i], *sel, sel_count, 0, size());
+		} else {
+			VectorOperations::Copy(other.data[i], data[i], other.size(), 0, size());
+		}
+	}
+	SetCardinality(new_size);
+}
+
+void DataChunk::Normalify() {
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		data[i].Normalify(size());
+	}
+}
+
+vector<LogicalType> DataChunk::GetTypes() {
+	vector<LogicalType> types;
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		types.push_back(data[i].GetType());
+	}
+	return types;
+}
+
+string DataChunk::ToString() const {
+	string retval = "Chunk - [" + to_string(ColumnCount()) + " Columns]\n";
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		retval += "- " + data[i].ToString(size()) + "\n";
+	}
+	return retval;
+}
+
+void DataChunk::Serialize(Serializer &serializer) {
+	// write the count
+	serializer.Write<sel_t>(size());
+	serializer.Write<idx_t>(ColumnCount());
+	for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+		// write the types
+		data[col_idx].GetType().Serialize(serializer);
+	}
+	// write the data
+	for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+		data[col_idx].Serialize(size(), serializer);
+	}
+}
+
+void DataChunk::Deserialize(Deserializer &source) {
+	auto rows = source.Read<sel_t>();
+	idx_t column_count = source.Read<idx_t>();
+
+	vector<LogicalType> types;
+	for (idx_t i = 0; i < column_count; i++) {
+		types.push_back(LogicalType::Deserialize(source));
+	}
+	Initialize(types);
+	// now load the column data
+	SetCardinality(rows);
+	for (idx_t i = 0; i < column_count; i++) {
+		data[i].Deserialize(rows, source);
+	}
+	Verify();
+}
+
+void DataChunk::Slice(const SelectionVector &sel_vector, idx_t count_p) {
+	this->count = count_p;
+	SelCache merge_cache;
+	for (idx_t c = 0; c < ColumnCount(); c++) {
+		data[c].Slice(sel_vector, count_p, merge_cache);
+	}
+}
+
+void DataChunk::Slice(DataChunk &other, const SelectionVector &sel, idx_t count_p, idx_t col_offset) {
+	D_ASSERT(other.ColumnCount() <= col_offset + ColumnCount());
+	this->count = count_p;
+	SelCache merge_cache;
+	for (idx_t c = 0; c < other.ColumnCount(); c++) {
+		if (other.data[c].GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+			// already a dictionary! merge the dictionaries
+			data[col_offset + c].Reference(other.data[c]);
+			data[col_offset + c].Slice(sel, count_p, merge_cache);
+		} else {
+			data[col_offset + c].Slice(other.data[c], sel, count_p);
+		}
+	}
+}
+
+unique_ptr<VectorData[]> DataChunk::Orrify() {
+	auto orrified_data = unique_ptr<VectorData[]>(new VectorData[ColumnCount()]);
+	for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+		data[col_idx].Orrify(size(), orrified_data[col_idx]);
+	}
+	return orrified_data;
+}
+
+void DataChunk::Hash(Vector &result) {
+	D_ASSERT(result.GetType().id() == LogicalType::HASH);
+	VectorOperations::Hash(data[0], result, size());
+	for (idx_t i = 1; i < ColumnCount(); i++) {
+		VectorOperations::CombineHash(result, data[i], size());
+	}
+}
+
+void DataChunk::Verify() {
+#ifdef DEBUG
+	D_ASSERT(size() <= capacity);
+	// verify that all vectors in this chunk have the chunk selection vector
+	for (idx_t i = 0; i < ColumnCount(); i++) {
+		data[i].Verify(size());
+	}
+#endif
+}
+
+void DataChunk::Print() {
+	Printer::Print(ToString());
+}
+
+struct DuckDBArrowArrayChildHolder {
+	ArrowArray array;
+	//! need max three pointers for strings
+	duckdb::array<const void *, 3> buffers = {{nullptr, nullptr, nullptr}};
+	unique_ptr<Vector> vector;
+	unique_ptr<data_t[]> offsets;
+	unique_ptr<data_t[]> data;
+	//! Children of nested structures
+	::duckdb::vector<DuckDBArrowArrayChildHolder> children;
+	::duckdb::vector<ArrowArray *> children_ptrs;
+};
+
+struct DuckDBArrowArrayHolder {
+	vector<DuckDBArrowArrayChildHolder> children = {};
+	vector<ArrowArray *> children_ptrs = {};
+	array<const void *, 1> buffers = {{nullptr}};
+	vector<shared_ptr<ArrowArrayWrapper>> arrow_original_array;
+};
+
+static void ReleaseDuckDBArrowArray(ArrowArray *array) {
+	if (!array || !array->release) {
+		return;
+	}
+	array->release = nullptr;
+	auto holder = static_cast<DuckDBArrowArrayHolder *>(array->private_data);
+	delete holder;
+}
+
+void InitializeChild(DuckDBArrowArrayChildHolder &child_holder, idx_t size) {
+	auto &child = child_holder.array;
+	child.private_data = nullptr;
+	child.release = ReleaseDuckDBArrowArray;
+	child.n_children = 0;
+	child.null_count = 0;
+	child.offset = 0;
+	child.dictionary = nullptr;
+	child.buffers = child_holder.buffers.data();
+
+	child.length = size;
+}
+
+void SetChildValidityMask(Vector &vector, ArrowArray &child) {
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR);
+	auto &mask = FlatVector::Validity(vector);
+	if (!mask.AllValid()) {
+		//! any bits are set: might have nulls
+		child.null_count = -1;
+	} else {
+		//! no bits are set; we know there are no nulls
+		child.null_count = 0;
+	}
+	child.buffers[0] = (void *)mask.GetData();
+}
+
+void SetArrowChild(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size);
+
+void SetList(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
+	auto &child = child_holder.array;
+	child_holder.vector = make_unique<Vector>(data);
+
+	//! Lists have two buffers
+	child.n_buffers = 2;
+	//! Second Buffer is the list offsets
+	child_holder.offsets = unique_ptr<data_t[]>(new data_t[sizeof(uint32_t) * (size + 1)]);
+	child.buffers[1] = child_holder.offsets.get();
+	auto offset_ptr = (uint32_t *)child.buffers[1];
+	auto list_data = FlatVector::GetData<list_entry_t>(data);
+	auto list_mask = FlatVector::Validity(data);
+	idx_t offset = 0;
+	offset_ptr[0] = 0;
+	for (idx_t i = 0; i < size; i++) {
+		auto &le = list_data[i];
+
+		if (list_mask.RowIsValid(i)) {
+			offset += le.length;
+		}
+
+		offset_ptr[i + 1] = offset;
+	}
+	auto list_size = ListVector::GetListSize(data);
+	child_holder.children.resize(1);
+	InitializeChild(child_holder.children[0], list_size);
+	child.n_children = 1;
+	child_holder.children_ptrs.push_back(&child_holder.children[0].array);
+	child.children = &child_holder.children_ptrs[0];
+	auto &child_vector = ListVector::GetEntry(data);
+	auto &child_type = ListType::GetChildType(type);
+	SetArrowChild(child_holder.children[0], child_type, child_vector, list_size);
+	SetChildValidityMask(child_vector, child_holder.children[0].array);
+}
+
+void SetStruct(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
+	auto &child = child_holder.array;
+	child_holder.vector = make_unique<Vector>(data);
+
+	//! Structs only have validity buffers
+	child.n_buffers = 1;
+	auto &children = StructVector::GetEntries(*child_holder.vector);
+	child.n_children = children.size();
+	child_holder.children.resize(child.n_children);
+	for (auto &struct_child : child_holder.children) {
+		InitializeChild(struct_child, size);
+		child_holder.children_ptrs.push_back(&struct_child.array);
+	}
+	child.children = &child_holder.children_ptrs[0];
+	for (idx_t child_idx = 0; child_idx < child_holder.children.size(); child_idx++) {
+		SetArrowChild(child_holder.children[child_idx], StructType::GetChildType(type, child_idx), *children[child_idx],
+		              size);
+		SetChildValidityMask(*children[child_idx], child_holder.children[child_idx].array);
+	}
+}
+
+void SetStructMap(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
+	auto &child = child_holder.array;
+	child_holder.vector = make_unique<Vector>(data);
+
+	//! Structs only have validity buffers
+	child.n_buffers = 1;
+	auto &children = StructVector::GetEntries(*child_holder.vector);
+	child.n_children = children.size();
+	child_holder.children.resize(child.n_children);
+	auto list_size = ListVector::GetListSize(*children[0]);
+	child.length = list_size;
+	for (auto &struct_child : child_holder.children) {
+		InitializeChild(struct_child, list_size);
+		child_holder.children_ptrs.push_back(&struct_child.array);
+	}
+	child.children = &child_holder.children_ptrs[0];
+	auto &child_types = StructType::GetChildTypes(type);
+	for (idx_t child_idx = 0; child_idx < child_holder.children.size(); child_idx++) {
+		auto &list_vector_child = ListVector::GetEntry(*children[child_idx]);
+		if (child_idx == 0) {
+			VectorData list_data;
+			children[child_idx]->Orrify(size, list_data);
+			auto list_child_validity = FlatVector::Validity(list_vector_child);
+			if (!list_child_validity.AllValid()) {
+				//! Get the offsets to check from the selection vector
+				auto list_offsets = FlatVector::GetData<list_entry_t>(*children[child_idx]);
+				for (idx_t list_idx = 0; list_idx < size; list_idx++) {
+					auto offset = list_offsets[list_data.sel->get_index(list_idx)];
+					if (!list_child_validity.CheckAllValid(offset.length + offset.offset, offset.offset)) {
+						throw std::runtime_error("Arrow doesnt accept NULL keys on Maps");
+					}
+				}
+			}
+		} else {
+			SetChildValidityMask(list_vector_child, child_holder.children[child_idx].array);
+		}
+		SetArrowChild(child_holder.children[child_idx], ListType::GetChildType(child_types[child_idx].second),
+		              list_vector_child, list_size);
+	}
+}
+
+struct ArrowUUIDConversion {
+	using internal_type_t = hugeint_t;
+
+	static unique_ptr<Vector> InitializeVector(Vector &data, idx_t size) {
+		return make_unique<Vector>(LogicalType::VARCHAR, size);
+	}
+
+	static idx_t GetStringLength(hugeint_t value) {
+		return UUID::STRING_SIZE;
+	}
+
+	static string_t ConvertValue(Vector &tgt_vec, string_t *tgt_ptr, internal_type_t *src_ptr, idx_t row) {
+		auto str_value = UUID::ToString(src_ptr[row]);
+		// Have to store this string
+		tgt_ptr[row] = StringVector::AddStringOrBlob(tgt_vec, str_value);
+		return tgt_ptr[row];
+	}
+};
+
+struct ArrowVarcharConversion {
+	using internal_type_t = string_t;
+
+	static unique_ptr<Vector> InitializeVector(Vector &data, idx_t size) {
+		return make_unique<Vector>(data);
+	}
+	static idx_t GetStringLength(string_t value) {
+		return value.GetSize();
+	}
+
+	static string_t ConvertValue(Vector &tgt_vec, string_t *tgt_ptr, internal_type_t *src_ptr, idx_t row) {
+		return src_ptr[row];
+	}
+};
+
+template <class CONVERT, class VECTOR_TYPE>
+void SetVarchar(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
+	auto &child = child_holder.array;
+	child_holder.vector = CONVERT::InitializeVector(data, size);
+	auto target_data_ptr = FlatVector::GetData<string_t>(data);
+	child.n_buffers = 3;
+	child_holder.offsets = unique_ptr<data_t[]>(new data_t[sizeof(uint32_t) * (size + 1)]);
+	child.buffers[1] = child_holder.offsets.get();
+	D_ASSERT(child.buffers[1]);
+	//! step 1: figure out total string length:
+	idx_t total_string_length = 0;
+	auto source_ptr = FlatVector::GetData<VECTOR_TYPE>(data);
+	auto &mask = FlatVector::Validity(data);
+	for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+		if (!mask.RowIsValid(row_idx)) {
+			continue;
+		}
+		total_string_length += CONVERT::GetStringLength(source_ptr[row_idx]);
+	}
+	//! step 2: allocate this much
+	child_holder.data = unique_ptr<data_t[]>(new data_t[total_string_length]);
+	child.buffers[2] = child_holder.data.get();
+	D_ASSERT(child.buffers[2]);
+	//! step 3: assign buffers
+	idx_t current_heap_offset = 0;
+	auto target_ptr = (uint32_t *)child.buffers[1];
+
+	for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+		target_ptr[row_idx] = current_heap_offset;
+		if (!mask.RowIsValid(row_idx)) {
+			continue;
+		}
+		string_t str = CONVERT::ConvertValue(*child_holder.vector, target_data_ptr, source_ptr, row_idx);
+		memcpy((void *)((uint8_t *)child.buffers[2] + current_heap_offset), str.GetDataUnsafe(), str.GetSize());
+		current_heap_offset += str.GetSize();
+	}
+	target_ptr[size] = current_heap_offset; //! need to terminate last string!
+}
+
+void SetArrowChild(DuckDBArrowArrayChildHolder &child_holder, const LogicalType &type, Vector &data, idx_t size) {
+	auto &child = child_holder.array;
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN: {
+		//! Gotta bitpack these booleans
+		child_holder.vector = make_unique<Vector>(data);
+		child.n_buffers = 2;
+		idx_t num_bytes = (size + 8 - 1) / 8;
+		child_holder.data = unique_ptr<data_t[]>(new data_t[sizeof(uint8_t) * num_bytes]);
+		child.buffers[1] = child_holder.data.get();
+		auto source_ptr = FlatVector::GetData<uint8_t>(*child_holder.vector);
+		auto target_ptr = (uint8_t *)child.buffers[1];
+		idx_t target_pos = 0;
+		idx_t cur_bit = 0;
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			if (cur_bit == 8) {
+				target_pos++;
+				cur_bit = 0;
+			}
+			if (source_ptr[row_idx] == 0) {
+				//! We set the bit to 0
+				target_ptr[target_pos] &= ~(1 << cur_bit);
+			} else {
+				//! We set the bit to 1
+				target_ptr[target_pos] |= 1 << cur_bit;
+			}
+			cur_bit++;
+		}
+		break;
+	}
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIME_TZ:
+		child_holder.vector = make_unique<Vector>(data);
+		child.n_buffers = 2;
+		child.buffers[1] = (void *)FlatVector::GetData(*child_holder.vector);
+		break;
+	case LogicalTypeId::SQLNULL:
+		child.n_buffers = 1;
+		break;
+	case LogicalTypeId::DECIMAL: {
+		child.n_buffers = 2;
+		child_holder.vector = make_unique<Vector>(data);
+
+		//! We have to convert to INT128
+		switch (type.InternalType()) {
+
+		case PhysicalType::INT16: {
+			child_holder.data = unique_ptr<data_t[]>(new data_t[sizeof(hugeint_t) * (size)]);
+			child.buffers[1] = child_holder.data.get();
+			auto source_ptr = FlatVector::GetData<int16_t>(*child_holder.vector);
+			auto target_ptr = (hugeint_t *)child.buffers[1];
+			for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+				target_ptr[row_idx] = source_ptr[row_idx];
+			}
+			break;
+		}
+		case PhysicalType::INT32: {
+			child_holder.data = unique_ptr<data_t[]>(new data_t[sizeof(hugeint_t) * (size)]);
+			child.buffers[1] = child_holder.data.get();
+			auto source_ptr = FlatVector::GetData<int32_t>(*child_holder.vector);
+			auto target_ptr = (hugeint_t *)child.buffers[1];
+			for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+				target_ptr[row_idx] = source_ptr[row_idx];
+			}
+			break;
+		}
+		case PhysicalType::INT64: {
+			child_holder.data = unique_ptr<data_t[]>(new data_t[sizeof(hugeint_t) * (size)]);
+			child.buffers[1] = child_holder.data.get();
+			auto source_ptr = FlatVector::GetData<int64_t>(*child_holder.vector);
+			auto target_ptr = (hugeint_t *)child.buffers[1];
+			for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+				target_ptr[row_idx] = source_ptr[row_idx];
+			}
+			break;
+		}
+		case PhysicalType::INT128: {
+			child.buffers[1] = (void *)FlatVector::GetData(*child_holder.vector);
+			break;
+		}
+		default:
+			throw std::runtime_error("Unsupported physical type for Decimal" + TypeIdToString(type.InternalType()));
+		}
+		break;
+	}
+	case LogicalTypeId::BLOB:
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR: {
+		SetVarchar<ArrowVarcharConversion, string_t>(child_holder, type, data, size);
+		break;
+	}
+	case LogicalTypeId::UUID: {
+		SetVarchar<ArrowUUIDConversion, hugeint_t>(child_holder, type, data, size);
+		break;
+	}
+	case LogicalTypeId::LIST: {
+		SetList(child_holder, type, data, size);
+		break;
+	}
+	case LogicalTypeId::STRUCT: {
+		SetStruct(child_holder, type, data, size);
+		break;
+	}
+	case LogicalTypeId::MAP: {
+		child_holder.vector = make_unique<Vector>(data);
+
+		auto &map_mask = FlatVector::Validity(*child_holder.vector);
+		child.n_buffers = 2;
+		//! Maps have one child
+		child.n_children = 1;
+		child_holder.children.resize(1);
+		InitializeChild(child_holder.children[0], size);
+		child_holder.children_ptrs.push_back(&child_holder.children[0].array);
+		//! Second Buffer is the offsets
+		child_holder.offsets = unique_ptr<data_t[]>(new data_t[sizeof(uint32_t) * (size + 1)]);
+		child.buffers[1] = child_holder.offsets.get();
+		auto &struct_children = StructVector::GetEntries(data);
+		auto offset_ptr = (uint32_t *)child.buffers[1];
+		auto list_data = FlatVector::GetData<list_entry_t>(*struct_children[0]);
+		idx_t offset = 0;
+		offset_ptr[0] = 0;
+		for (idx_t i = 0; i < size; i++) {
+			auto &le = list_data[i];
+			if (map_mask.RowIsValid(i)) {
+				offset += le.length;
+			}
+			offset_ptr[i + 1] = offset;
+		}
+		child.children = &child_holder.children_ptrs[0];
+		//! We need to set up a struct
+		auto struct_type = LogicalType::STRUCT(StructType::GetChildTypes(type));
+
+		SetStructMap(child_holder.children[0], struct_type, *child_holder.vector, size);
+		break;
+	}
+	case LogicalTypeId::INTERVAL: {
+		//! convert interval from month/days/ucs to milliseconds
+		child_holder.vector = make_unique<Vector>(data);
+		child.n_buffers = 2;
+		child_holder.data = unique_ptr<data_t[]>(new data_t[sizeof(int64_t) * (size)]);
+		child.buffers[1] = child_holder.data.get();
+		auto source_ptr = FlatVector::GetData<interval_t>(*child_holder.vector);
+		auto target_ptr = (int64_t *)child.buffers[1];
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			target_ptr[row_idx] = Interval::GetMilli(source_ptr[row_idx]);
+		}
+		break;
+	}
+	case LogicalTypeId::ENUM: {
+		// We need to initialize our dictionary
+		child_holder.children.resize(1);
+		idx_t dict_size = EnumType::GetSize(type);
+		InitializeChild(child_holder.children[0], dict_size);
+		Vector dictionary(EnumType::GetValuesInsertOrder(type));
+		SetArrowChild(child_holder.children[0], dictionary.GetType(), dictionary, dict_size);
+		child_holder.children_ptrs.push_back(&child_holder.children[0].array);
+
+		// now we set the data
+		child.dictionary = child_holder.children_ptrs[0];
+		child_holder.vector = make_unique<Vector>(data);
+		child.n_buffers = 2;
+		child.buffers[1] = (void *)FlatVector::GetData(*child_holder.vector);
+
+		break;
+	}
+	default:
+		throw std::runtime_error("Unsupported type " + type.ToString());
+	}
+}
+
+void DataChunk::ToArrowArray(ArrowArray *out_array) {
+	Normalify();
+	D_ASSERT(out_array);
+
+	// Allocate as unique_ptr first to cleanup properly on error
+	auto root_holder = make_unique<DuckDBArrowArrayHolder>();
+
+	// Allocate the children
+	root_holder->children.resize(ColumnCount());
+	root_holder->children_ptrs.resize(ColumnCount(), nullptr);
+	for (size_t i = 0; i < ColumnCount(); ++i) {
+		root_holder->children_ptrs[i] = &root_holder->children[i].array;
+	}
+	out_array->children = root_holder->children_ptrs.data();
+	out_array->n_children = ColumnCount();
+
+	// Configure root array
+	out_array->length = size();
+	out_array->n_children = ColumnCount();
+	out_array->n_buffers = 1;
+	out_array->buffers = root_holder->buffers.data(); // there is no actual buffer there since we don't have NULLs
+	out_array->offset = 0;
+	out_array->null_count = 0; // needs to be 0
+	out_array->dictionary = nullptr;
+
+	//! Configure child arrays
+	for (idx_t col_idx = 0; col_idx < ColumnCount(); col_idx++) {
+		auto &child_holder = root_holder->children[col_idx];
+		InitializeChild(child_holder, size());
+		auto &vector = child_holder.vector;
+		auto &child = child_holder.array;
+		auto vec_buffer = data[col_idx].GetBuffer();
+		if (vec_buffer->GetAuxiliaryData() &&
+		    vec_buffer->GetAuxiliaryDataType() == VectorAuxiliaryDataType::ARROW_AUXILIARY) {
+			auto arrow_aux_data = (ArrowAuxiliaryData *)vec_buffer->GetAuxiliaryData();
+			root_holder->arrow_original_array.push_back(arrow_aux_data->arrow_array);
+		}
+		//! We could, in theory, output other types of vectors here, currently only FLAT Vectors
+		SetArrowChild(child_holder, GetTypes()[col_idx], data[col_idx], size());
+		SetChildValidityMask(*vector, child);
+		out_array->children[col_idx] = &child;
+	}
+
+	// Release ownership to caller
+	out_array->private_data = root_holder.release();
+	out_array->release = ReleaseDuckDBArrowArray;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <cstring>
+#include <cctype>
+#include <algorithm>
+
+namespace duckdb {
+
+static_assert(sizeof(date_t) == sizeof(int32_t), "date_t was padded");
+
+const char *Date::PINF = "infinity";  // NOLINT
+const char *Date::NINF = "-infinity"; // NOLINT
+const char *Date::EPOCH = "epoch";    // NOLINT
+
+const string_t Date::MONTH_NAMES_ABBREVIATED[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                                  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+const string_t Date::MONTH_NAMES[] = {"January", "February", "March",     "April",   "May",      "June",
+                                      "July",    "August",   "September", "October", "November", "December"};
+const string_t Date::DAY_NAMES[] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
+const string_t Date::DAY_NAMES_ABBREVIATED[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+
+const int32_t Date::NORMAL_DAYS[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+const int32_t Date::CUMULATIVE_DAYS[] = {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365};
+const int32_t Date::LEAP_DAYS[] = {0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+const int32_t Date::CUMULATIVE_LEAP_DAYS[] = {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366};
+const int8_t Date::MONTH_PER_DAY_OF_YEAR[] = {
+    1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+    1,  1,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+    2,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,
+    3,  3,  3,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+    4,  4,  4,  4,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,
+    5,  5,  5,  5,  5,  5,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,
+    6,  6,  6,  6,  6,  6,  6,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,
+    7,  7,  7,  7,  7,  7,  7,  7,  7,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,
+    8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,
+    9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+    12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12};
+const int8_t Date::LEAP_MONTH_PER_DAY_OF_YEAR[] = {
+    1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+    1,  1,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+    2,  2,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,  3,
+    3,  3,  3,  3,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+    4,  4,  4,  4,  4,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,  5,
+    5,  5,  5,  5,  5,  5,  5,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,  6,
+    6,  6,  6,  6,  6,  6,  6,  6,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,
+    7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,
+    8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,
+    9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  9,  10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+    12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12};
+const int32_t Date::CUMULATIVE_YEAR_DAYS[] = {
+    0,      365,    730,    1096,   1461,   1826,   2191,   2557,   2922,   3287,   3652,   4018,   4383,   4748,
+    5113,   5479,   5844,   6209,   6574,   6940,   7305,   7670,   8035,   8401,   8766,   9131,   9496,   9862,
+    10227,  10592,  10957,  11323,  11688,  12053,  12418,  12784,  13149,  13514,  13879,  14245,  14610,  14975,
+    15340,  15706,  16071,  16436,  16801,  17167,  17532,  17897,  18262,  18628,  18993,  19358,  19723,  20089,
+    20454,  20819,  21184,  21550,  21915,  22280,  22645,  23011,  23376,  23741,  24106,  24472,  24837,  25202,
+    25567,  25933,  26298,  26663,  27028,  27394,  27759,  28124,  28489,  28855,  29220,  29585,  29950,  30316,
+    30681,  31046,  31411,  31777,  32142,  32507,  32872,  33238,  33603,  33968,  34333,  34699,  35064,  35429,
+    35794,  36160,  36525,  36890,  37255,  37621,  37986,  38351,  38716,  39082,  39447,  39812,  40177,  40543,
+    40908,  41273,  41638,  42004,  42369,  42734,  43099,  43465,  43830,  44195,  44560,  44926,  45291,  45656,
+    46021,  46387,  46752,  47117,  47482,  47847,  48212,  48577,  48942,  49308,  49673,  50038,  50403,  50769,
+    51134,  51499,  51864,  52230,  52595,  52960,  53325,  53691,  54056,  54421,  54786,  55152,  55517,  55882,
+    56247,  56613,  56978,  57343,  57708,  58074,  58439,  58804,  59169,  59535,  59900,  60265,  60630,  60996,
+    61361,  61726,  62091,  62457,  62822,  63187,  63552,  63918,  64283,  64648,  65013,  65379,  65744,  66109,
+    66474,  66840,  67205,  67570,  67935,  68301,  68666,  69031,  69396,  69762,  70127,  70492,  70857,  71223,
+    71588,  71953,  72318,  72684,  73049,  73414,  73779,  74145,  74510,  74875,  75240,  75606,  75971,  76336,
+    76701,  77067,  77432,  77797,  78162,  78528,  78893,  79258,  79623,  79989,  80354,  80719,  81084,  81450,
+    81815,  82180,  82545,  82911,  83276,  83641,  84006,  84371,  84736,  85101,  85466,  85832,  86197,  86562,
+    86927,  87293,  87658,  88023,  88388,  88754,  89119,  89484,  89849,  90215,  90580,  90945,  91310,  91676,
+    92041,  92406,  92771,  93137,  93502,  93867,  94232,  94598,  94963,  95328,  95693,  96059,  96424,  96789,
+    97154,  97520,  97885,  98250,  98615,  98981,  99346,  99711,  100076, 100442, 100807, 101172, 101537, 101903,
+    102268, 102633, 102998, 103364, 103729, 104094, 104459, 104825, 105190, 105555, 105920, 106286, 106651, 107016,
+    107381, 107747, 108112, 108477, 108842, 109208, 109573, 109938, 110303, 110669, 111034, 111399, 111764, 112130,
+    112495, 112860, 113225, 113591, 113956, 114321, 114686, 115052, 115417, 115782, 116147, 116513, 116878, 117243,
+    117608, 117974, 118339, 118704, 119069, 119435, 119800, 120165, 120530, 120895, 121260, 121625, 121990, 122356,
+    122721, 123086, 123451, 123817, 124182, 124547, 124912, 125278, 125643, 126008, 126373, 126739, 127104, 127469,
+    127834, 128200, 128565, 128930, 129295, 129661, 130026, 130391, 130756, 131122, 131487, 131852, 132217, 132583,
+    132948, 133313, 133678, 134044, 134409, 134774, 135139, 135505, 135870, 136235, 136600, 136966, 137331, 137696,
+    138061, 138427, 138792, 139157, 139522, 139888, 140253, 140618, 140983, 141349, 141714, 142079, 142444, 142810,
+    143175, 143540, 143905, 144271, 144636, 145001, 145366, 145732, 146097};
+
+void Date::ExtractYearOffset(int32_t &n, int32_t &year, int32_t &year_offset) {
+	year = Date::EPOCH_YEAR;
+	// first we normalize n to be in the year range [1970, 2370]
+	// since leap years repeat every 400 years, we can safely normalize just by "shifting" the CumulativeYearDays array
+	while (n < 0) {
+		n += Date::DAYS_PER_YEAR_INTERVAL;
+		year -= Date::YEAR_INTERVAL;
+	}
+	while (n >= Date::DAYS_PER_YEAR_INTERVAL) {
+		n -= Date::DAYS_PER_YEAR_INTERVAL;
+		year += Date::YEAR_INTERVAL;
+	}
+	// interpolation search
+	// we can find an upper bound of the year by assuming each year has 365 days
+	year_offset = n / 365;
+	// because of leap years we might be off by a little bit: compensate by decrementing the year offset until we find
+	// our year
+	while (n < Date::CUMULATIVE_YEAR_DAYS[year_offset]) {
+		year_offset--;
+		D_ASSERT(year_offset >= 0);
+	}
+	year += year_offset;
+	D_ASSERT(n >= Date::CUMULATIVE_YEAR_DAYS[year_offset]);
+}
+
+void Date::Convert(date_t d, int32_t &year, int32_t &month, int32_t &day) {
+	auto n = d.days;
+	int32_t year_offset;
+	Date::ExtractYearOffset(n, year, year_offset);
+
+	day = n - Date::CUMULATIVE_YEAR_DAYS[year_offset];
+	D_ASSERT(day >= 0 && day <= 365);
+
+	bool is_leap_year = (Date::CUMULATIVE_YEAR_DAYS[year_offset + 1] - Date::CUMULATIVE_YEAR_DAYS[year_offset]) == 366;
+	if (is_leap_year) {
+		month = Date::LEAP_MONTH_PER_DAY_OF_YEAR[day];
+		day -= Date::CUMULATIVE_LEAP_DAYS[month - 1];
+	} else {
+		month = Date::MONTH_PER_DAY_OF_YEAR[day];
+		day -= Date::CUMULATIVE_DAYS[month - 1];
+	}
+	day++;
+	D_ASSERT(day > 0 && day <= (is_leap_year ? Date::LEAP_DAYS[month] : Date::NORMAL_DAYS[month]));
+	D_ASSERT(month > 0 && month <= 12);
+}
+
+bool Date::TryFromDate(int32_t year, int32_t month, int32_t day, date_t &result) {
+	int32_t n = 0;
+	if (!Date::IsValid(year, month, day)) {
+		return false;
+	}
+	n += Date::IsLeapYear(year) ? Date::CUMULATIVE_LEAP_DAYS[month - 1] : Date::CUMULATIVE_DAYS[month - 1];
+	n += day - 1;
+	if (year < 1970) {
+		int32_t diff_from_base = 1970 - year;
+		int32_t year_index = 400 - (diff_from_base % 400);
+		int32_t fractions = diff_from_base / 400;
+		n += Date::CUMULATIVE_YEAR_DAYS[year_index];
+		n -= Date::DAYS_PER_YEAR_INTERVAL;
+		n -= fractions * Date::DAYS_PER_YEAR_INTERVAL;
+	} else if (year >= 2370) {
+		int32_t diff_from_base = year - 2370;
+		int32_t year_index = diff_from_base % 400;
+		int32_t fractions = diff_from_base / 400;
+		n += Date::CUMULATIVE_YEAR_DAYS[year_index];
+		n += Date::DAYS_PER_YEAR_INTERVAL;
+		n += fractions * Date::DAYS_PER_YEAR_INTERVAL;
+	} else {
+		n += Date::CUMULATIVE_YEAR_DAYS[year - 1970];
+	}
+#ifdef DEBUG
+	int32_t y, m, d;
+	Date::Convert(date_t(n), y, m, d);
+	D_ASSERT(year == y);
+	D_ASSERT(month == m);
+	D_ASSERT(day == d);
+#endif
+	result = date_t(n);
+	return true;
+}
+
+date_t Date::FromDate(int32_t year, int32_t month, int32_t day) {
+	date_t result;
+	if (!Date::TryFromDate(year, month, day, result)) {
+		throw ConversionException("Date out of range: %d-%d-%d", year, month, day);
+	}
+	return result;
+}
+
+bool Date::ParseDoubleDigit(const char *buf, idx_t len, idx_t &pos, int32_t &result) {
+	if (pos < len && StringUtil::CharacterIsDigit(buf[pos])) {
+		result = buf[pos++] - '0';
+		if (pos < len && StringUtil::CharacterIsDigit(buf[pos])) {
+			result = (buf[pos++] - '0') + result * 10;
+		}
+		return true;
+	}
+	return false;
+}
+
+static bool TryConvertDateSpecial(const char *buf, idx_t len, idx_t &pos, const char *special) {
+	auto p = pos;
+	for (; p < len && *special; ++p) {
+		const auto s = *special++;
+		if (!s || StringUtil::CharacterToLower(buf[p]) != s) {
+			return false;
+		}
+	}
+	pos = p;
+	return true;
+}
+
+bool Date::TryConvertDate(const char *buf, idx_t len, idx_t &pos, date_t &result, bool strict) {
+	pos = 0;
+	if (len == 0) {
+		return false;
+	}
+
+	int32_t day = 0;
+	int32_t month = -1;
+	int32_t year = 0;
+	bool yearneg = false;
+	int sep;
+
+	// skip leading spaces
+	while (pos < len && StringUtil::CharacterIsSpace(buf[pos])) {
+		pos++;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+	if (buf[pos] == '-') {
+		yearneg = true;
+		pos++;
+		if (pos >= len) {
+			return false;
+		}
+	}
+	if (!StringUtil::CharacterIsDigit(buf[pos])) {
+		// Check for special values
+		if (TryConvertDateSpecial(buf, len, pos, PINF)) {
+			result = yearneg ? date_t::ninfinity() : date_t::infinity();
+		} else if (TryConvertDateSpecial(buf, len, pos, EPOCH)) {
+			result = date_t::epoch();
+		} else {
+			return false;
+		}
+		// skip trailing spaces - parsing must be strict here
+		while (pos < len && StringUtil::CharacterIsSpace(buf[pos])) {
+			pos++;
+		}
+		return pos == len;
+	}
+	// first parse the year
+	for (; pos < len && StringUtil::CharacterIsDigit(buf[pos]); pos++) {
+		if (year >= 100000000) {
+			return false;
+		}
+		year = (buf[pos] - '0') + year * 10;
+	}
+	if (yearneg) {
+		year = -year;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	// fetch the separator
+	sep = buf[pos++];
+	if (sep != ' ' && sep != '-' && sep != '/' && sep != '\\') {
+		// invalid separator
+		return false;
+	}
+
+	// parse the month
+	if (!Date::ParseDoubleDigit(buf, len, pos, month)) {
+		return false;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	if (buf[pos++] != sep) {
+		return false;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	// now parse the day
+	if (!Date::ParseDoubleDigit(buf, len, pos, day)) {
+		return false;
+	}
+
+	// check for an optional trailing " (BC)""
+	if (len - pos >= 5 && StringUtil::CharacterIsSpace(buf[pos]) && buf[pos + 1] == '(' &&
+	    StringUtil::CharacterToLower(buf[pos + 2]) == 'b' && StringUtil::CharacterToLower(buf[pos + 3]) == 'c' &&
+	    buf[pos + 4] == ')') {
+		if (yearneg || year == 0) {
+			return false;
+		}
+		year = -year + 1;
+		pos += 5;
+	}
+
+	// in strict mode, check remaining string for non-space characters
+	if (strict) {
+		// skip trailing spaces
+		while (pos < len && StringUtil::CharacterIsSpace((unsigned char)buf[pos])) {
+			pos++;
+		}
+		// check position. if end was not reached, non-space chars remaining
+		if (pos < len) {
+			return false;
+		}
+	} else {
+		// in non-strict mode, check for any direct trailing digits
+		if (pos < len && StringUtil::CharacterIsDigit((unsigned char)buf[pos])) {
+			return false;
+		}
+	}
+
+	return Date::TryFromDate(year, month, day, result);
+}
+
+string Date::ConversionError(const string &str) {
+	return StringUtil::Format("date field value out of range: \"%s\", "
+	                          "expected format is (YYYY-MM-DD)",
+	                          str);
+}
+
+string Date::ConversionError(string_t str) {
+	return ConversionError(str.GetString());
+}
+
+date_t Date::FromCString(const char *buf, idx_t len, bool strict) {
+	date_t result;
+	idx_t pos;
+	if (!TryConvertDate(buf, len, pos, result, strict)) {
+		throw ConversionException(ConversionError(string(buf, len)));
+	}
+	return result;
+}
+
+date_t Date::FromString(const string &str, bool strict) {
+	return Date::FromCString(str.c_str(), str.size(), strict);
+}
+
+string Date::ToString(date_t date) {
+	// PG displays temporal infinities in lowercase,
+	// but numerics in Titlecase.
+	if (date == date_t::infinity()) {
+		return PINF;
+	} else if (date == date_t::ninfinity()) {
+		return NINF;
+	}
+	int32_t date_units[3];
+	idx_t year_length;
+	bool add_bc;
+	Date::Convert(date, date_units[0], date_units[1], date_units[2]);
+
+	auto length = DateToStringCast::Length(date_units, year_length, add_bc);
+	auto buffer = unique_ptr<char[]>(new char[length]);
+	DateToStringCast::Format(buffer.get(), date_units, year_length, add_bc);
+	return string(buffer.get(), length);
+}
+
+string Date::Format(int32_t year, int32_t month, int32_t day) {
+	return ToString(Date::FromDate(year, month, day));
+}
+
+bool Date::IsLeapYear(int32_t year) {
+	return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+}
+
+bool Date::IsValid(int32_t year, int32_t month, int32_t day) {
+	if (month < 1 || month > 12) {
+		return false;
+	}
+	if (day < 1) {
+		return false;
+	}
+	if (year <= DATE_MIN_YEAR) {
+		if (year < DATE_MIN_YEAR) {
+			return false;
+		} else if (year == DATE_MIN_YEAR) {
+			if (month < DATE_MIN_MONTH || (month == DATE_MIN_MONTH && day < DATE_MIN_DAY)) {
+				return false;
+			}
+		}
+	}
+	if (year >= DATE_MAX_YEAR) {
+		if (year > DATE_MAX_YEAR) {
+			return false;
+		} else if (year == DATE_MAX_YEAR) {
+			if (month > DATE_MAX_MONTH || (month == DATE_MAX_MONTH && day > DATE_MAX_DAY)) {
+				return false;
+			}
+		}
+	}
+	return Date::IsLeapYear(year) ? day <= Date::LEAP_DAYS[month] : day <= Date::NORMAL_DAYS[month];
+}
+
+int32_t Date::MonthDays(int32_t year, int32_t month) {
+	D_ASSERT(month >= 1 && month <= 12);
+	return Date::IsLeapYear(year) ? Date::LEAP_DAYS[month] : Date::NORMAL_DAYS[month];
+}
+
+date_t Date::EpochDaysToDate(int32_t epoch) {
+	return (date_t)epoch;
+}
+
+int32_t Date::EpochDays(date_t date) {
+	return date.days;
+}
+
+date_t Date::EpochToDate(int64_t epoch) {
+	return date_t(epoch / Interval::SECS_PER_DAY);
+}
+
+int64_t Date::Epoch(date_t date) {
+	return ((int64_t)date.days) * Interval::SECS_PER_DAY;
+}
+
+int64_t Date::EpochNanoseconds(date_t date) {
+	return ((int64_t)date.days) * (Interval::MICROS_PER_DAY * 1000);
+}
+
+int32_t Date::ExtractYear(date_t d, int32_t *last_year) {
+	auto n = d.days;
+	// cached look up: check if year of this date is the same as the last one we looked up
+	// note that this only works for years in the range [1970, 2370]
+	if (n >= Date::CUMULATIVE_YEAR_DAYS[*last_year] && n < Date::CUMULATIVE_YEAR_DAYS[*last_year + 1]) {
+		return Date::EPOCH_YEAR + *last_year;
+	}
+	int32_t year;
+	Date::ExtractYearOffset(n, year, *last_year);
+	return year;
+}
+
+int32_t Date::ExtractYear(timestamp_t ts, int32_t *last_year) {
+	return Date::ExtractYear(Timestamp::GetDate(ts), last_year);
+}
+
+int32_t Date::ExtractYear(date_t d) {
+	int32_t year, year_offset;
+	Date::ExtractYearOffset(d.days, year, year_offset);
+	return year;
+}
+
+int32_t Date::ExtractMonth(date_t date) {
+	int32_t out_year, out_month, out_day;
+	Date::Convert(date, out_year, out_month, out_day);
+	return out_month;
+}
+
+int32_t Date::ExtractDay(date_t date) {
+	int32_t out_year, out_month, out_day;
+	Date::Convert(date, out_year, out_month, out_day);
+	return out_day;
+}
+
+int32_t Date::ExtractDayOfTheYear(date_t date) {
+	int32_t year, year_offset;
+	Date::ExtractYearOffset(date.days, year, year_offset);
+	return date.days - Date::CUMULATIVE_YEAR_DAYS[year_offset] + 1;
+}
+
+int32_t Date::ExtractISODayOfTheWeek(date_t date) {
+	// date of 0 is 1970-01-01, which was a Thursday (4)
+	// -7 = 4
+	// -6 = 5
+	// -5 = 6
+	// -4 = 7
+	// -3 = 1
+	// -2 = 2
+	// -1 = 3
+	// 0  = 4
+	// 1  = 5
+	// 2  = 6
+	// 3  = 7
+	// 4  = 1
+	// 5  = 2
+	// 6  = 3
+	// 7  = 4
+	if (date.days < 0) {
+		// negative date: start off at 4 and cycle downwards
+		return (7 - ((-int64_t(date.days) + 3) % 7));
+	} else {
+		// positive date: start off at 4 and cycle upwards
+		return ((int64_t(date.days) + 3) % 7) + 1;
+	}
+}
+
+static int32_t GetISOYearWeek(int32_t &year, int32_t month, int32_t day) {
+	auto day_of_the_year =
+	    (Date::IsLeapYear(year) ? Date::CUMULATIVE_LEAP_DAYS[month] : Date::CUMULATIVE_DAYS[month]) + day;
+	// get the first day of the first week of the year
+	// the first week is the week that has the 4th of January in it
+	const auto weekday_of_the_fourth = Date::ExtractISODayOfTheWeek(Date::FromDate(year, 1, 4));
+	// if fourth is monday, then fourth is the first day
+	// if fourth is tuesday, third is the first day
+	// if fourth is wednesday, second is the first day
+	// if fourth is thursday, first is the first day
+	// if fourth is friday - sunday, day is in the previous year
+	// (day is 0-based, weekday is 1-based)
+	const auto first_day_of_the_first_isoweek = 4 - weekday_of_the_fourth;
+	if (day_of_the_year < first_day_of_the_first_isoweek) {
+		// day is part of last year (13th month)
+		--year;
+		return GetISOYearWeek(year, 12, day);
+	} else {
+		return ((day_of_the_year - first_day_of_the_first_isoweek) / 7) + 1;
+	}
+}
+
+void Date::ExtractISOYearWeek(date_t date, int32_t &year, int32_t &week) {
+	int32_t month, day;
+	Date::Convert(date, year, month, day);
+	week = GetISOYearWeek(year, month - 1, day - 1);
+}
+
+int32_t Date::ExtractISOWeekNumber(date_t date) {
+	int32_t year, week;
+	ExtractISOYearWeek(date, year, week);
+	return week;
+}
+
+int32_t Date::ExtractISOYearNumber(date_t date) {
+	int32_t year, week;
+	ExtractISOYearWeek(date, year, week);
+	return year;
+}
+
+int32_t Date::ExtractWeekNumberRegular(date_t date, bool monday_first) {
+	int32_t year, month, day;
+	Date::Convert(date, year, month, day);
+	month -= 1;
+	day -= 1;
+	// get the day of the year
+	auto day_of_the_year =
+	    (Date::IsLeapYear(year) ? Date::CUMULATIVE_LEAP_DAYS[month] : Date::CUMULATIVE_DAYS[month]) + day;
+	// now figure out the first monday or sunday of the year
+	// what day is January 1st?
+	auto day_of_jan_first = Date::ExtractISODayOfTheWeek(Date::FromDate(year, 1, 1));
+	// monday = 1, sunday = 7
+	int32_t first_week_start;
+	if (monday_first) {
+		// have to find next "1"
+		if (day_of_jan_first == 1) {
+			// jan 1 is monday: starts immediately
+			first_week_start = 0;
+		} else {
+			// jan 1 is not monday: count days until next monday
+			first_week_start = 8 - day_of_jan_first;
+		}
+	} else {
+		first_week_start = 7 - day_of_jan_first;
+	}
+	if (day_of_the_year < first_week_start) {
+		// day occurs before first week starts: week 0
+		return 0;
+	}
+	return ((day_of_the_year - first_week_start) / 7) + 1;
+}
+
+// Returns the date of the monday of the current week.
+date_t Date::GetMondayOfCurrentWeek(date_t date) {
+	int32_t dotw = Date::ExtractISODayOfTheWeek(date);
+	return date - (dotw - 1);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+template <class SIGNED, class UNSIGNED>
+string TemplatedDecimalToString(SIGNED value, uint8_t scale) {
+	auto len = DecimalToString::DecimalLength<SIGNED, UNSIGNED>(value, scale);
+	auto data = unique_ptr<char[]>(new char[len + 1]);
+	DecimalToString::FormatDecimal<SIGNED, UNSIGNED>(value, scale, data.get(), len);
+	return string(data.get(), len);
+}
+
+string Decimal::ToString(int16_t value, uint8_t scale) {
+	return TemplatedDecimalToString<int16_t, uint16_t>(value, scale);
+}
+
+string Decimal::ToString(int32_t value, uint8_t scale) {
+	return TemplatedDecimalToString<int32_t, uint32_t>(value, scale);
+}
+
+string Decimal::ToString(int64_t value, uint8_t scale) {
+	return TemplatedDecimalToString<int64_t, uint64_t>(value, scale);
+}
+
+string Decimal::ToString(hugeint_t value, uint8_t scale) {
+	auto len = HugeintToStringCast::DecimalLength(value, scale);
+	auto data = unique_ptr<char[]>(new char[len + 1]);
+	HugeintToStringCast::FormatDecimal(value, scale, data.get(), len);
+	return string(data.get(), len);
+}
+
+} // namespace duckdb
+
+
+
+
+
+#include <functional>
+
+namespace duckdb {
+
+template <>
+hash_t Hash(uint64_t val) {
+	return murmurhash64(val);
+}
+
+template <>
+hash_t Hash(int64_t val) {
+	return murmurhash64((uint64_t)val);
+}
+
+template <>
+hash_t Hash(hugeint_t val) {
+	return murmurhash64(val.lower) ^ murmurhash64(val.upper);
+}
+
+template <>
+hash_t Hash(float val) {
+	return std::hash<float> {}(val);
+}
+
+template <>
+hash_t Hash(double val) {
+	return std::hash<double> {}(val);
+}
+
+template <>
+hash_t Hash(interval_t val) {
+	return Hash(val.days) ^ Hash(val.months) ^ Hash(val.micros);
+}
+
+template <>
+hash_t Hash(const char *str) {
+	return Hash(str, strlen(str));
+}
+
+template <>
+hash_t Hash(string_t val) {
+	return Hash(val.GetDataUnsafe(), val.GetSize());
+}
+
+template <>
+hash_t Hash(char *val) {
+	return Hash<const char *>(val);
+}
+
+// MIT License
+// Copyright (c) 2018-2021 Martin Ankerl
+// https://github.com/martinus/robin-hood-hashing/blob/3.11.5/LICENSE
+hash_t HashBytes(void *ptr, size_t len) noexcept {
+	static constexpr uint64_t M = UINT64_C(0xc6a4a7935bd1e995);
+	static constexpr uint64_t SEED = UINT64_C(0xe17a1465);
+	static constexpr unsigned int R = 47;
+
+	auto const *const data64 = static_cast<uint64_t const *>(ptr);
+	uint64_t h = SEED ^ (len * M);
+
+	size_t const n_blocks = len / 8;
+	for (size_t i = 0; i < n_blocks; ++i) {
+		auto k = Load<uint64_t>(reinterpret_cast<const_data_ptr_t>(data64 + i));
+
+		k *= M;
+		k ^= k >> R;
+		k *= M;
+
+		h ^= k;
+		h *= M;
+	}
+
+	auto const *const data8 = reinterpret_cast<uint8_t const *>(data64 + n_blocks);
+	switch (len & 7U) {
+	case 7:
+		h ^= static_cast<uint64_t>(data8[6]) << 48U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 6:
+		h ^= static_cast<uint64_t>(data8[5]) << 40U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 5:
+		h ^= static_cast<uint64_t>(data8[4]) << 32U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 4:
+		h ^= static_cast<uint64_t>(data8[3]) << 24U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 3:
+		h ^= static_cast<uint64_t>(data8[2]) << 16U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 2:
+		h ^= static_cast<uint64_t>(data8[1]) << 8U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 1:
+		h ^= static_cast<uint64_t>(data8[0]);
+		h *= M;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	default:
+		break;
+	}
+	h ^= h >> R;
+	h *= M;
+	h ^= h >> R;
+	return static_cast<hash_t>(h);
+}
+
+hash_t Hash(const char *val, size_t size) {
+	return HashBytes((void *)val, size);
+}
+
+hash_t Hash(uint8_t *val, size_t size) {
+	return HashBytes((void *)val, size);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <cmath>
+#include <limits>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// String Conversion
+//===--------------------------------------------------------------------===//
+const hugeint_t Hugeint::POWERS_OF_TEN[] {
+    hugeint_t(1),
+    hugeint_t(10),
+    hugeint_t(100),
+    hugeint_t(1000),
+    hugeint_t(10000),
+    hugeint_t(100000),
+    hugeint_t(1000000),
+    hugeint_t(10000000),
+    hugeint_t(100000000),
+    hugeint_t(1000000000),
+    hugeint_t(10000000000),
+    hugeint_t(100000000000),
+    hugeint_t(1000000000000),
+    hugeint_t(10000000000000),
+    hugeint_t(100000000000000),
+    hugeint_t(1000000000000000),
+    hugeint_t(10000000000000000),
+    hugeint_t(100000000000000000),
+    hugeint_t(1000000000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(10),
+    hugeint_t(1000000000000000000) * hugeint_t(100),
+    hugeint_t(1000000000000000000) * hugeint_t(1000),
+    hugeint_t(1000000000000000000) * hugeint_t(10000),
+    hugeint_t(1000000000000000000) * hugeint_t(100000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000),
+    hugeint_t(1000000000000000000) * hugeint_t(10000000),
+    hugeint_t(1000000000000000000) * hugeint_t(100000000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(10000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(100000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(10000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(100000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(10000000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(100000000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000000000000),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000000000000) * hugeint_t(10),
+    hugeint_t(1000000000000000000) * hugeint_t(1000000000000000000) * hugeint_t(100)};
+
+static uint8_t PositiveHugeintHighestBit(hugeint_t bits) {
+	uint8_t out = 0;
+	if (bits.upper) {
+		out = 64;
+		uint64_t up = bits.upper;
+		while (up) {
+			up >>= 1;
+			out++;
+		}
+	} else {
+		uint64_t low = bits.lower;
+		while (low) {
+			low >>= 1;
+			out++;
+		}
+	}
+	return out;
+}
+
+static bool PositiveHugeintIsBitSet(hugeint_t lhs, uint8_t bit_position) {
+	if (bit_position < 64) {
+		return lhs.lower & (uint64_t(1) << uint64_t(bit_position));
+	} else {
+		return lhs.upper & (uint64_t(1) << uint64_t(bit_position - 64));
+	}
+}
+
+hugeint_t PositiveHugeintLeftShift(hugeint_t lhs, uint32_t amount) {
+	D_ASSERT(amount > 0 && amount < 64);
+	hugeint_t result;
+	result.lower = lhs.lower << amount;
+	result.upper = (lhs.upper << amount) + (lhs.lower >> (64 - amount));
+	return result;
+}
+
+hugeint_t Hugeint::DivModPositive(hugeint_t lhs, uint64_t rhs, uint64_t &remainder) {
+	D_ASSERT(lhs.upper >= 0);
+	// DivMod code adapted from:
+	// https://github.com/calccrypto/uint128_t/blob/master/uint128_t.cpp
+
+	// initialize the result and remainder to 0
+	hugeint_t div_result;
+	div_result.lower = 0;
+	div_result.upper = 0;
+	remainder = 0;
+
+	uint8_t highest_bit_set = PositiveHugeintHighestBit(lhs);
+	// now iterate over the amount of bits that are set in the LHS
+	for (uint8_t x = highest_bit_set; x > 0; x--) {
+		// left-shift the current result and remainder by 1
+		div_result = PositiveHugeintLeftShift(div_result, 1);
+		remainder <<= 1;
+		// we get the value of the bit at position X, where position 0 is the least-significant bit
+		if (PositiveHugeintIsBitSet(lhs, x - 1)) {
+			// increment the remainder
+			remainder++;
+		}
+		if (remainder >= rhs) {
+			// the remainder has passed the division multiplier: add one to the divide result
+			remainder -= rhs;
+			div_result.lower++;
+			if (div_result.lower == 0) {
+				// overflow
+				div_result.upper++;
+			}
+		}
+	}
+	return div_result;
+}
+
+string Hugeint::ToString(hugeint_t input) {
+	uint64_t remainder;
+	string result;
+	bool negative = input.upper < 0;
+	if (negative) {
+		NegateInPlace(input);
+	}
+	while (true) {
+		if (!input.lower && !input.upper) {
+			break;
+		}
+		input = Hugeint::DivModPositive(input, 10, remainder);
+		result = string(1, '0' + remainder) + result; // NOLINT
+	}
+	if (result.empty()) {
+		// value is zero
+		return "0";
+	}
+	return negative ? "-" + result : result;
+}
+
+//===--------------------------------------------------------------------===//
+// Multiply
+//===--------------------------------------------------------------------===//
+bool Hugeint::TryMultiply(hugeint_t lhs, hugeint_t rhs, hugeint_t &result) {
+	bool lhs_negative = lhs.upper < 0;
+	bool rhs_negative = rhs.upper < 0;
+	if (lhs_negative) {
+		NegateInPlace(lhs);
+	}
+	if (rhs_negative) {
+		NegateInPlace(rhs);
+	}
+#if ((__GNUC__ >= 5) || defined(__clang__)) && defined(__SIZEOF_INT128__)
+	__uint128_t left = __uint128_t(lhs.lower) + (__uint128_t(lhs.upper) << 64);
+	__uint128_t right = __uint128_t(rhs.lower) + (__uint128_t(rhs.upper) << 64);
+	__uint128_t result_i128;
+	if (__builtin_mul_overflow(left, right, &result_i128)) {
+		return false;
+	}
+	uint64_t upper = uint64_t(result_i128 >> 64);
+	if (upper & 0x8000000000000000) {
+		return false;
+	}
+	result.upper = int64_t(upper);
+	result.lower = uint64_t(result_i128 & 0xffffffffffffffff);
+#else
+	// Multiply code adapted from:
+	// https://github.com/calccrypto/uint128_t/blob/master/uint128_t.cpp
+
+	// split values into 4 32-bit parts
+	uint64_t top[4] = {uint64_t(lhs.upper) >> 32, uint64_t(lhs.upper) & 0xffffffff, lhs.lower >> 32,
+	                   lhs.lower & 0xffffffff};
+	uint64_t bottom[4] = {uint64_t(rhs.upper) >> 32, uint64_t(rhs.upper) & 0xffffffff, rhs.lower >> 32,
+	                      rhs.lower & 0xffffffff};
+	uint64_t products[4][4];
+
+	// multiply each component of the values
+	for (auto x = 0; x < 4; x++) {
+		for (auto y = 0; y < 4; y++) {
+			products[x][y] = top[x] * bottom[y];
+		}
+	}
+
+	// if any of these products are set to a non-zero value, there is always an overflow
+	if (products[0][0] || products[0][1] || products[0][2] || products[1][0] || products[2][0] || products[1][1]) {
+		return false;
+	}
+	// if the high bits of any of these are set, there is always an overflow
+	if ((products[0][3] & 0xffffffff80000000) || (products[1][2] & 0xffffffff80000000) ||
+	    (products[2][1] & 0xffffffff80000000) || (products[3][0] & 0xffffffff80000000)) {
+		return false;
+	}
+
+	// otherwise we merge the result of the different products together in-order
+
+	// first row
+	uint64_t fourth32 = (products[3][3] & 0xffffffff);
+	uint64_t third32 = (products[3][2] & 0xffffffff) + (products[3][3] >> 32);
+	uint64_t second32 = (products[3][1] & 0xffffffff) + (products[3][2] >> 32);
+	uint64_t first32 = (products[3][0] & 0xffffffff) + (products[3][1] >> 32);
+
+	// second row
+	third32 += (products[2][3] & 0xffffffff);
+	second32 += (products[2][2] & 0xffffffff) + (products[2][3] >> 32);
+	first32 += (products[2][1] & 0xffffffff) + (products[2][2] >> 32);
+
+	// third row
+	second32 += (products[1][3] & 0xffffffff);
+	first32 += (products[1][2] & 0xffffffff) + (products[1][3] >> 32);
+
+	// fourth row
+	first32 += (products[0][3] & 0xffffffff);
+
+	// move carry to next digit
+	third32 += fourth32 >> 32;
+	second32 += third32 >> 32;
+	first32 += second32 >> 32;
+
+	// check if the combination of the different products resulted in an overflow
+	if (first32 & 0xffffff80000000) {
+		return false;
+	}
+
+	// remove carry from current digit
+	fourth32 &= 0xffffffff;
+	third32 &= 0xffffffff;
+	second32 &= 0xffffffff;
+	first32 &= 0xffffffff;
+
+	// combine components
+	result.lower = (third32 << 32) | fourth32;
+	result.upper = (first32 << 32) | second32;
+#endif
+	if (lhs_negative ^ rhs_negative) {
+		NegateInPlace(result);
+	}
+	return true;
+}
+
+hugeint_t Hugeint::Multiply(hugeint_t lhs, hugeint_t rhs) {
+	hugeint_t result;
+	if (!TryMultiply(lhs, rhs, result)) {
+		throw OutOfRangeException("Overflow in HUGEINT multiplication!");
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Divide
+//===--------------------------------------------------------------------===//
+hugeint_t Hugeint::DivMod(hugeint_t lhs, hugeint_t rhs, hugeint_t &remainder) {
+	// division by zero not allowed
+	D_ASSERT(!(rhs.upper == 0 && rhs.lower == 0));
+
+	bool lhs_negative = lhs.upper < 0;
+	bool rhs_negative = rhs.upper < 0;
+	if (lhs_negative) {
+		Hugeint::NegateInPlace(lhs);
+	}
+	if (rhs_negative) {
+		Hugeint::NegateInPlace(rhs);
+	}
+	// DivMod code adapted from:
+	// https://github.com/calccrypto/uint128_t/blob/master/uint128_t.cpp
+
+	// initialize the result and remainder to 0
+	hugeint_t div_result;
+	div_result.lower = 0;
+	div_result.upper = 0;
+	remainder.lower = 0;
+	remainder.upper = 0;
+
+	uint8_t highest_bit_set = PositiveHugeintHighestBit(lhs);
+	// now iterate over the amount of bits that are set in the LHS
+	for (uint8_t x = highest_bit_set; x > 0; x--) {
+		// left-shift the current result and remainder by 1
+		div_result = PositiveHugeintLeftShift(div_result, 1);
+		remainder = PositiveHugeintLeftShift(remainder, 1);
+
+		// we get the value of the bit at position X, where position 0 is the least-significant bit
+		if (PositiveHugeintIsBitSet(lhs, x - 1)) {
+			// increment the remainder
+			Hugeint::AddInPlace(remainder, 1);
+		}
+		if (Hugeint::GreaterThanEquals(remainder, rhs)) {
+			// the remainder has passed the division multiplier: add one to the divide result
+			remainder = Hugeint::Subtract(remainder, rhs);
+			Hugeint::AddInPlace(div_result, 1);
+		}
+	}
+	if (lhs_negative ^ rhs_negative) {
+		Hugeint::NegateInPlace(div_result);
+	}
+	if (lhs_negative) {
+		Hugeint::NegateInPlace(remainder);
+	}
+	return div_result;
+}
+
+hugeint_t Hugeint::Divide(hugeint_t lhs, hugeint_t rhs) {
+	hugeint_t remainder;
+	return Hugeint::DivMod(lhs, rhs, remainder);
+}
+
+hugeint_t Hugeint::Modulo(hugeint_t lhs, hugeint_t rhs) {
+	hugeint_t remainder;
+	Hugeint::DivMod(lhs, rhs, remainder);
+	return remainder;
+}
+
+//===--------------------------------------------------------------------===//
+// Add/Subtract
+//===--------------------------------------------------------------------===//
+bool Hugeint::AddInPlace(hugeint_t &lhs, hugeint_t rhs) {
+	int overflow = lhs.lower + rhs.lower < lhs.lower;
+	if (rhs.upper >= 0) {
+		// RHS is positive: check for overflow
+		if (lhs.upper > (std::numeric_limits<int64_t>::max() - rhs.upper - overflow)) {
+			return false;
+		}
+		lhs.upper = lhs.upper + overflow + rhs.upper;
+	} else {
+		// RHS is negative: check for underflow
+		if (lhs.upper < std::numeric_limits<int64_t>::min() - rhs.upper - overflow) {
+			return false;
+		}
+		lhs.upper = lhs.upper + (overflow + rhs.upper);
+	}
+	lhs.lower += rhs.lower;
+	if (lhs.upper == std::numeric_limits<int64_t>::min() && lhs.lower == 0) {
+		return false;
+	}
+	return true;
+}
+
+bool Hugeint::SubtractInPlace(hugeint_t &lhs, hugeint_t rhs) {
+	// underflow
+	int underflow = lhs.lower - rhs.lower > lhs.lower;
+	if (rhs.upper >= 0) {
+		// RHS is positive: check for underflow
+		if (lhs.upper < (std::numeric_limits<int64_t>::min() + rhs.upper + underflow)) {
+			return false;
+		}
+		lhs.upper = (lhs.upper - rhs.upper) - underflow;
+	} else {
+		// RHS is negative: check for overflow
+		if (lhs.upper > std::numeric_limits<int64_t>::min() &&
+		    lhs.upper - 1 >= (std::numeric_limits<int64_t>::max() + rhs.upper + underflow)) {
+			return false;
+		}
+		lhs.upper = lhs.upper - (rhs.upper + underflow);
+	}
+	lhs.lower -= rhs.lower;
+	if (lhs.upper == std::numeric_limits<int64_t>::min() && lhs.lower == 0) {
+		return false;
+	}
+	return true;
+}
+
+hugeint_t Hugeint::Add(hugeint_t lhs, hugeint_t rhs) {
+	if (!AddInPlace(lhs, rhs)) {
+		throw OutOfRangeException("Overflow in HUGEINT addition");
+	}
+	return lhs;
+}
+
+hugeint_t Hugeint::Subtract(hugeint_t lhs, hugeint_t rhs) {
+	if (!SubtractInPlace(lhs, rhs)) {
+		throw OutOfRangeException("Underflow in HUGEINT addition");
+	}
+	return lhs;
+}
+
+//===--------------------------------------------------------------------===//
+// Hugeint Cast/Conversion
+//===--------------------------------------------------------------------===//
+template <class DST, bool SIGNED = true>
+bool HugeintTryCastInteger(hugeint_t input, DST &result) {
+	switch (input.upper) {
+	case 0:
+		// positive number: check if the positive number is in range
+		if (input.lower <= uint64_t(NumericLimits<DST>::Maximum())) {
+			result = DST(input.lower);
+			return true;
+		}
+		break;
+	case -1:
+		if (!SIGNED) {
+			return false;
+		}
+		// negative number: check if the negative number is in range
+		if (input.lower >= NumericLimits<uint64_t>::Maximum() - uint64_t(NumericLimits<DST>::Maximum())) {
+			result = -DST(NumericLimits<uint64_t>::Maximum() - input.lower) - 1;
+			return true;
+		}
+		break;
+	default:
+		break;
+	}
+	return false;
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, int8_t &result) {
+	return HugeintTryCastInteger<int8_t>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, int16_t &result) {
+	return HugeintTryCastInteger<int16_t>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, int32_t &result) {
+	return HugeintTryCastInteger<int32_t>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, int64_t &result) {
+	return HugeintTryCastInteger<int64_t>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, uint8_t &result) {
+	return HugeintTryCastInteger<uint8_t, false>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, uint16_t &result) {
+	return HugeintTryCastInteger<uint16_t, false>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, uint32_t &result) {
+	return HugeintTryCastInteger<uint32_t, false>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, uint64_t &result) {
+	return HugeintTryCastInteger<uint64_t, false>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, hugeint_t &result) {
+	result = input;
+	return true;
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, float &result) {
+	double dbl_result;
+	Hugeint::TryCast(input, dbl_result);
+	result = (float)dbl_result;
+	return true;
+}
+
+template <class REAL_T>
+bool CastBigintToFloating(hugeint_t input, REAL_T &result) {
+	switch (input.upper) {
+	case -1:
+		// special case for upper = -1 to avoid rounding issues in small negative numbers
+		result = -REAL_T(NumericLimits<uint64_t>::Maximum() - input.lower) - 1;
+		break;
+	default:
+		result = REAL_T(input.lower) + REAL_T(input.upper) * REAL_T(NumericLimits<uint64_t>::Maximum());
+		break;
+	}
+	return true;
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, double &result) {
+	return CastBigintToFloating<double>(input, result);
+}
+
+template <>
+bool Hugeint::TryCast(hugeint_t input, long double &result) {
+	return CastBigintToFloating<long double>(input, result);
+}
+
+template <class DST>
+hugeint_t HugeintConvertInteger(DST input) {
+	hugeint_t result;
+	result.lower = (uint64_t)input;
+	result.upper = (input < 0) * -1;
+	return result;
+}
+
+template <>
+bool Hugeint::TryConvert(int8_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<int8_t>(value);
+	return true;
+}
+
+template <>
+bool Hugeint::TryConvert(int16_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<int16_t>(value);
+	return true;
+}
+
+template <>
+bool Hugeint::TryConvert(int32_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<int32_t>(value);
+	return true;
+}
+
+template <>
+bool Hugeint::TryConvert(int64_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<int64_t>(value);
+	return true;
+}
+template <>
+bool Hugeint::TryConvert(uint8_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<uint8_t>(value);
+	return true;
+}
+template <>
+bool Hugeint::TryConvert(uint16_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<uint16_t>(value);
+	return true;
+}
+template <>
+bool Hugeint::TryConvert(uint32_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<uint32_t>(value);
+	return true;
+}
+template <>
+bool Hugeint::TryConvert(uint64_t value, hugeint_t &result) {
+	result = HugeintConvertInteger<uint64_t>(value);
+	return true;
+}
+
+template <>
+bool Hugeint::TryConvert(float value, hugeint_t &result) {
+	return Hugeint::TryConvert(double(value), result);
+}
+
+template <class REAL_T>
+bool ConvertFloatingToBigint(REAL_T value, hugeint_t &result) {
+	if (!Value::IsFinite<REAL_T>(value)) {
+		return false;
+	}
+	if (value <= -170141183460469231731687303715884105728.0 || value >= 170141183460469231731687303715884105727.0) {
+		return false;
+	}
+	bool negative = value < 0;
+	if (negative) {
+		value = -value;
+	}
+	result.lower = (uint64_t)fmod(value, REAL_T(NumericLimits<uint64_t>::Maximum()));
+	result.upper = (uint64_t)(value / REAL_T(NumericLimits<uint64_t>::Maximum()));
+	if (negative) {
+		Hugeint::NegateInPlace(result);
+	}
+	return true;
+}
+
+template <>
+bool Hugeint::TryConvert(double value, hugeint_t &result) {
+	return ConvertFloatingToBigint<double>(value, result);
+}
+
+template <>
+bool Hugeint::TryConvert(long double value, hugeint_t &result) {
+	return ConvertFloatingToBigint<long double>(value, result);
+}
+
+//===--------------------------------------------------------------------===//
+// hugeint_t operators
+//===--------------------------------------------------------------------===//
+hugeint_t::hugeint_t(int64_t value) {
+	auto result = Hugeint::Convert(value);
+	this->lower = result.lower;
+	this->upper = result.upper;
+}
+
+bool hugeint_t::operator==(const hugeint_t &rhs) const {
+	return Hugeint::Equals(*this, rhs);
+}
+
+bool hugeint_t::operator!=(const hugeint_t &rhs) const {
+	return Hugeint::NotEquals(*this, rhs);
+}
+
+bool hugeint_t::operator<(const hugeint_t &rhs) const {
+	return Hugeint::LessThan(*this, rhs);
+}
+
+bool hugeint_t::operator<=(const hugeint_t &rhs) const {
+	return Hugeint::LessThanEquals(*this, rhs);
+}
+
+bool hugeint_t::operator>(const hugeint_t &rhs) const {
+	return Hugeint::GreaterThan(*this, rhs);
+}
+
+bool hugeint_t::operator>=(const hugeint_t &rhs) const {
+	return Hugeint::GreaterThanEquals(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator+(const hugeint_t &rhs) const {
+	return Hugeint::Add(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator-(const hugeint_t &rhs) const {
+	return Hugeint::Subtract(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator*(const hugeint_t &rhs) const {
+	return Hugeint::Multiply(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator/(const hugeint_t &rhs) const {
+	return Hugeint::Divide(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator%(const hugeint_t &rhs) const {
+	return Hugeint::Modulo(*this, rhs);
+}
+
+hugeint_t hugeint_t::operator-() const {
+	return Hugeint::Negate(*this);
+}
+
+hugeint_t hugeint_t::operator>>(const hugeint_t &rhs) const {
+	hugeint_t result;
+	uint64_t shift = rhs.lower;
+	if (rhs.upper != 0 || shift >= 128) {
+		return hugeint_t(0);
+	} else if (shift == 0) {
+		return *this;
+	} else if (shift == 64) {
+		result.upper = (upper < 0) ? -1 : 0;
+		result.lower = upper;
+	} else if (shift < 64) {
+		// perform lower shift in unsigned integer, and mask away the most significant bit
+		result.lower = (uint64_t(upper) << (64 - shift)) | (lower >> shift);
+		result.upper = upper >> shift;
+	} else {
+		D_ASSERT(shift < 128);
+		result.lower = upper >> (shift - 64);
+		result.upper = (upper < 0) ? -1 : 0;
+	}
+	return result;
+}
+
+hugeint_t hugeint_t::operator<<(const hugeint_t &rhs) const {
+	if (upper < 0) {
+		return hugeint_t(0);
+	}
+	hugeint_t result;
+	uint64_t shift = rhs.lower;
+	if (rhs.upper != 0 || shift >= 128) {
+		return hugeint_t(0);
+	} else if (shift == 64) {
+		result.upper = lower;
+		result.lower = 0;
+	} else if (shift == 0) {
+		return *this;
+	} else if (shift < 64) {
+		// perform upper shift in unsigned integer, and mask away the most significant bit
+		uint64_t upper_shift = ((uint64_t(upper) << shift) + (lower >> (64 - shift))) & 0x7FFFFFFFFFFFFFFF;
+		result.lower = lower << shift;
+		result.upper = upper_shift;
+	} else {
+		D_ASSERT(shift < 128);
+		result.lower = 0;
+		result.upper = (lower << (shift - 64)) & 0x7FFFFFFFFFFFFFFF;
+	}
+	return result;
+}
+
+hugeint_t hugeint_t::operator&(const hugeint_t &rhs) const {
+	hugeint_t result;
+	result.lower = lower & rhs.lower;
+	result.upper = upper & rhs.upper;
+	return result;
+}
+
+hugeint_t hugeint_t::operator|(const hugeint_t &rhs) const {
+	hugeint_t result;
+	result.lower = lower | rhs.lower;
+	result.upper = upper | rhs.upper;
+	return result;
+}
+
+hugeint_t hugeint_t::operator^(const hugeint_t &rhs) const {
+	hugeint_t result;
+	result.lower = lower ^ rhs.lower;
+	result.upper = upper ^ rhs.upper;
+	return result;
+}
+
+hugeint_t hugeint_t::operator~() const {
+	hugeint_t result;
+	result.lower = ~lower;
+	result.upper = ~upper;
+	return result;
+}
+
+hugeint_t &hugeint_t::operator+=(const hugeint_t &rhs) {
+	Hugeint::AddInPlace(*this, rhs);
+	return *this;
+}
+hugeint_t &hugeint_t::operator-=(const hugeint_t &rhs) {
+	Hugeint::SubtractInPlace(*this, rhs);
+	return *this;
+}
+hugeint_t &hugeint_t::operator*=(const hugeint_t &rhs) {
+	*this = Hugeint::Multiply(*this, rhs);
+	return *this;
+}
+hugeint_t &hugeint_t::operator/=(const hugeint_t &rhs) {
+	*this = Hugeint::Divide(*this, rhs);
+	return *this;
+}
+hugeint_t &hugeint_t::operator%=(const hugeint_t &rhs) {
+	*this = Hugeint::Modulo(*this, rhs);
+	return *this;
+}
+hugeint_t &hugeint_t::operator>>=(const hugeint_t &rhs) {
+	*this = *this >> rhs;
+	return *this;
+}
+hugeint_t &hugeint_t::operator<<=(const hugeint_t &rhs) {
+	*this = *this << rhs;
+	return *this;
+}
+hugeint_t &hugeint_t::operator&=(const hugeint_t &rhs) {
+	lower &= rhs.lower;
+	upper &= rhs.upper;
+	return *this;
+}
+hugeint_t &hugeint_t::operator|=(const hugeint_t &rhs) {
+	lower |= rhs.lower;
+	upper |= rhs.upper;
+	return *this;
+}
+hugeint_t &hugeint_t::operator^=(const hugeint_t &rhs) {
+	lower ^= rhs.lower;
+	upper ^= rhs.upper;
+	return *this;
+}
+
+string hugeint_t::ToString() const {
+	return Hugeint::ToString(*this);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+HyperLogLog::HyperLogLog() : hll(nullptr) {
+	hll = duckdb_hll::hll_create();
+	// Insert into a dense hll can be vectorized, sparse cannot, so we immediately convert
+	duckdb_hll::hllSparseToDense((duckdb_hll::robj *)hll);
+}
+
+HyperLogLog::HyperLogLog(void *hll) : hll(hll) {
+}
+
+HyperLogLog::~HyperLogLog() {
+	duckdb_hll::hll_destroy((duckdb_hll::robj *)hll);
+}
+
+void HyperLogLog::Add(data_ptr_t element, idx_t size) {
+	if (duckdb_hll::hll_add((duckdb_hll::robj *)hll, element, size) == HLL_C_ERR) {
+		throw InternalException("Could not add to HLL?");
+	}
+}
+
+idx_t HyperLogLog::Count() const {
+	// exception from size_t ban
+	size_t result;
+
+	if (duckdb_hll::hll_count((duckdb_hll::robj *)hll, &result) != HLL_C_OK) {
+		throw InternalException("Could not count HLL?");
+	}
+	return result;
+}
+
+unique_ptr<HyperLogLog> HyperLogLog::Merge(HyperLogLog &other) {
+	duckdb_hll::robj *hlls[2];
+	hlls[0] = (duckdb_hll::robj *)hll;
+	hlls[1] = (duckdb_hll::robj *)other.hll;
+	auto new_hll = duckdb_hll::hll_merge(hlls, 2);
+	if (!new_hll) {
+		throw InternalException("Could not merge HLLs");
+	}
+	return unique_ptr<HyperLogLog>(new HyperLogLog((void *)new_hll));
+}
+
+HyperLogLog *HyperLogLog::MergePointer(HyperLogLog &other) {
+	duckdb_hll::robj *hlls[2];
+	hlls[0] = (duckdb_hll::robj *)hll;
+	hlls[1] = (duckdb_hll::robj *)other.hll;
+	auto new_hll = duckdb_hll::hll_merge(hlls, 2);
+	if (!new_hll) {
+		throw Exception("Could not merge HLLs");
+	}
+	return new HyperLogLog((void *)new_hll);
+}
+
+unique_ptr<HyperLogLog> HyperLogLog::Merge(HyperLogLog logs[], idx_t count) {
+	auto hlls_uptr = unique_ptr<duckdb_hll::robj *[]> {
+		new duckdb_hll::robj *[count]
+	};
+	auto hlls = hlls_uptr.get();
+	for (idx_t i = 0; i < count; i++) {
+		hlls[i] = (duckdb_hll::robj *)logs[i].hll;
+	}
+	auto new_hll = duckdb_hll::hll_merge(hlls, count);
+	if (!new_hll) {
+		throw InternalException("Could not merge HLLs");
+	}
+	return unique_ptr<HyperLogLog>(new HyperLogLog((void *)new_hll));
+}
+
+idx_t HyperLogLog::GetSize() {
+	return duckdb_hll::get_size();
+}
+
+data_ptr_t HyperLogLog::GetPtr() const {
+	return (data_ptr_t)((duckdb_hll::robj *)hll)->ptr;
+}
+
+unique_ptr<HyperLogLog> HyperLogLog::Copy() {
+	auto result = make_unique<HyperLogLog>();
+	lock_guard<mutex> guard(lock);
+	memcpy(result->GetPtr(), GetPtr(), GetSize());
+	D_ASSERT(result->Count() == Count());
+	return result;
+}
+
+void HyperLogLog::Serialize(FieldWriter &writer) const {
+	writer.WriteField<HLLStorageType>(HLLStorageType::UNCOMPRESSED);
+	writer.WriteBlob(GetPtr(), GetSize());
+}
+
+unique_ptr<HyperLogLog> HyperLogLog::Deserialize(FieldReader &reader) {
+	auto result = make_unique<HyperLogLog>();
+	auto storage_type = reader.ReadRequired<HLLStorageType>();
+	switch (storage_type) {
+	case HLLStorageType::UNCOMPRESSED:
+		reader.ReadBlob(result->GetPtr(), GetSize());
+		break;
+	default:
+		throw SerializationException("Unknown HyperLogLog storage type!");
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Vectorized HLL implementation
+//===--------------------------------------------------------------------===//
+//! Taken from https://nullprogram.com/blog/2018/07/31/
+template <class T>
+inline uint64_t TemplatedHash(const T &elem) {
+	uint64_t x = elem;
+	x ^= x >> 30;
+	x *= UINT64_C(0xbf58476d1ce4e5b9);
+	x ^= x >> 27;
+	x *= UINT64_C(0x94d049bb133111eb);
+	x ^= x >> 31;
+	return x;
+}
+
+template <>
+inline uint64_t TemplatedHash(const hugeint_t &elem) {
+	return TemplatedHash<uint64_t>(Load<uint64_t>((data_ptr_t)&elem.upper)) ^ TemplatedHash<uint64_t>(elem.lower);
+}
+
+template <idx_t rest>
+inline void CreateIntegerRecursive(const data_ptr_t &data, uint64_t &x) {
+	x ^= (uint64_t)data[rest - 1] << ((rest - 1) * 8);
+	return CreateIntegerRecursive<rest - 1>(data, x);
+}
+
+template <>
+inline void CreateIntegerRecursive<1>(const data_ptr_t &data, uint64_t &x) {
+	x ^= (uint64_t)data[0];
+}
+
+inline uint64_t HashOtherSize(const data_ptr_t &data, const idx_t &len) {
+	uint64_t x = 0;
+	switch (len & 7) {
+	case 7:
+		CreateIntegerRecursive<7>(data, x);
+		break;
+	case 6:
+		CreateIntegerRecursive<6>(data, x);
+		break;
+	case 5:
+		CreateIntegerRecursive<5>(data, x);
+		break;
+	case 4:
+		CreateIntegerRecursive<4>(data, x);
+		break;
+	case 3:
+		CreateIntegerRecursive<3>(data, x);
+		break;
+	case 2:
+		CreateIntegerRecursive<2>(data, x);
+		break;
+	case 1:
+		CreateIntegerRecursive<1>(data, x);
+		break;
+	case 0:
+		break;
+	}
+	return TemplatedHash<uint64_t>(x);
+}
+
+template <>
+inline uint64_t TemplatedHash(const string_t &elem) {
+	data_ptr_t data = (data_ptr_t)elem.GetDataUnsafe();
+	const auto &len = elem.GetSize();
+	uint64_t h = 0;
+	for (idx_t i = 0; i + sizeof(uint64_t) <= len; i += sizeof(uint64_t)) {
+		h ^= TemplatedHash<uint64_t>(Load<uint64_t>(data));
+		data += sizeof(uint64_t);
+	}
+	switch (len & (sizeof(uint64_t) - 1)) {
+	case 4:
+		h ^= TemplatedHash<uint32_t>(Load<uint32_t>(data));
+		break;
+	case 2:
+		h ^= TemplatedHash<uint16_t>(Load<uint16_t>(data));
+		break;
+	case 1:
+		h ^= TemplatedHash<uint8_t>(Load<uint8_t>(data));
+		break;
+	default:
+		h ^= HashOtherSize(data, len);
+	}
+	return h;
+}
+
+template <class T>
+void TemplatedComputeHashes(VectorData &vdata, const idx_t &count, uint64_t hashes[]) {
+	T *data = (T *)vdata.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = vdata.sel->get_index(i);
+		if (vdata.validity.RowIsValid(idx)) {
+			hashes[i] = TemplatedHash<T>(data[idx]);
+		} else {
+			hashes[i] = 0;
+		}
+	}
+}
+
+static void ComputeHashes(VectorData &vdata, const LogicalType &type, uint64_t hashes[], idx_t count) {
+	switch (type.InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+	case PhysicalType::UINT8:
+		return TemplatedComputeHashes<uint8_t>(vdata, count, hashes);
+	case PhysicalType::INT16:
+	case PhysicalType::UINT16:
+		return TemplatedComputeHashes<uint16_t>(vdata, count, hashes);
+	case PhysicalType::INT32:
+	case PhysicalType::UINT32:
+	case PhysicalType::FLOAT:
+		return TemplatedComputeHashes<uint32_t>(vdata, count, hashes);
+	case PhysicalType::INT64:
+	case PhysicalType::UINT64:
+	case PhysicalType::DOUBLE:
+		return TemplatedComputeHashes<uint64_t>(vdata, count, hashes);
+	case PhysicalType::INT128:
+	case PhysicalType::INTERVAL:
+		static_assert(sizeof(hugeint_t) == sizeof(interval_t), "ComputeHashes assumes these are the same size!");
+		return TemplatedComputeHashes<hugeint_t>(vdata, count, hashes);
+	case PhysicalType::VARCHAR:
+		return TemplatedComputeHashes<string_t>(vdata, count, hashes);
+	default:
+		throw InternalException("Unimplemented type for HyperLogLog::ComputeHashes");
+	}
+}
+
+//! Taken from https://stackoverflow.com/a/72088344
+static inline uint8_t CountTrailingZeros(uint64_t &x) {
+	static constexpr const uint64_t DEBRUIJN = 0x03f79d71b4cb0a89;
+	static constexpr const uint8_t LOOKUP[] = {0,  47, 1,  56, 48, 27, 2,  60, 57, 49, 41, 37, 28, 16, 3,  61,
+	                                           54, 58, 35, 52, 50, 42, 21, 44, 38, 32, 29, 23, 17, 11, 4,  62,
+	                                           46, 55, 26, 59, 40, 36, 15, 53, 34, 51, 20, 43, 31, 22, 10, 45,
+	                                           25, 39, 14, 33, 19, 30, 9,  24, 13, 18, 8,  12, 7,  6,  5,  63};
+	return LOOKUP[(DEBRUIJN * (x ^ (x - 1))) >> 58];
+}
+
+static inline void ComputeIndexAndCount(uint64_t &hash, uint8_t &prefix) {
+	uint64_t index = hash & ((1 << 12) - 1); /* Register index. */
+	hash >>= 12;                             /* Remove bits used to address the register. */
+	hash |= ((uint64_t)1 << (64 - 12));      /* Make sure the count will be <= Q+1. */
+
+	prefix = CountTrailingZeros(hash) + 1; /* Add 1 since we count the "00000...1" pattern. */
+	hash = index;
+}
+
+void HyperLogLog::ProcessEntries(VectorData &vdata, const LogicalType &type, uint64_t hashes[], uint8_t counts[],
+                                 idx_t count) {
+	ComputeHashes(vdata, type, hashes, count);
+	for (idx_t i = 0; i < count; i++) {
+		ComputeIndexAndCount(hashes[i], counts[i]);
+	}
+}
+
+void HyperLogLog::AddToLogs(VectorData &vdata, idx_t count, uint64_t indices[], uint8_t counts[], HyperLogLog **logs[],
+                            const SelectionVector *log_sel) {
+	AddToLogsInternal(vdata, count, indices, counts, (void ****)logs, log_sel);
+}
+
+void HyperLogLog::AddToLog(VectorData &vdata, idx_t count, uint64_t indices[], uint8_t counts[]) {
+	lock_guard<mutex> guard(lock);
+	AddToSingleLogInternal(vdata, count, indices, counts, hll);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+bool Interval::FromString(const string &str, interval_t &result) {
+	string error_message;
+	return Interval::FromCString(str.c_str(), str.size(), result, &error_message, false);
+}
+
+template <class T>
+void IntervalTryAddition(T &target, int64_t input, int64_t multiplier) {
+	int64_t addition;
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, multiplier, addition)) {
+		throw OutOfRangeException("interval value is out of range");
+	}
+	T addition_base = Cast::Operation<int64_t, T>(addition);
+	if (!TryAddOperator::Operation<T, T, T>(target, addition_base, target)) {
+		throw OutOfRangeException("interval value is out of range");
+	}
+}
+
+bool Interval::FromCString(const char *str, idx_t len, interval_t &result, string *error_message, bool strict) {
+	idx_t pos = 0;
+	idx_t start_pos;
+	bool negative;
+	bool found_any = false;
+	int64_t number;
+	DatePartSpecifier specifier;
+	string specifier_str;
+
+	result.days = 0;
+	result.micros = 0;
+	result.months = 0;
+
+	if (len == 0) {
+		return false;
+	}
+
+	switch (str[pos]) {
+	case '@':
+		pos++;
+		goto standard_interval;
+	case 'P':
+	case 'p':
+		pos++;
+		goto posix_interval;
+	default:
+		goto standard_interval;
+	}
+standard_interval:
+	// start parsing a standard interval (e.g. 2 years 3 months...)
+	for (; pos < len; pos++) {
+		char c = str[pos];
+		if (c == ' ' || c == '\t' || c == '\n') {
+			// skip spaces
+			continue;
+		} else if (c >= '0' && c <= '9') {
+			// start parsing a positive number
+			negative = false;
+			goto interval_parse_number;
+		} else if (c == '-') {
+			// negative number
+			negative = true;
+			pos++;
+			goto interval_parse_number;
+		} else if (c == 'a' || c == 'A') {
+			// parse the word "ago" as the final specifier
+			goto interval_parse_ago;
+		} else {
+			// unrecognized character, expected a number or end of string
+			return false;
+		}
+	}
+	goto end_of_string;
+interval_parse_number:
+	start_pos = pos;
+	for (; pos < len; pos++) {
+		char c = str[pos];
+		if (c >= '0' && c <= '9') {
+			// the number continues
+			continue;
+		} else if (c == ':') {
+			// colon: we are parsing a time
+			goto interval_parse_time;
+		} else {
+			if (pos == start_pos) {
+				return false;
+			}
+			// finished the number, parse it from the string
+			string_t nr_string(str + start_pos, pos - start_pos);
+			number = Cast::Operation<string_t, int64_t>(nr_string);
+			if (negative) {
+				number = -number;
+			}
+			goto interval_parse_identifier;
+		}
+	}
+	goto end_of_string;
+interval_parse_time : {
+	// parse the remainder of the time as a Time type
+	dtime_t time;
+	idx_t pos;
+	if (!Time::TryConvertTime(str + start_pos, len - start_pos, pos, time)) {
+		return false;
+	}
+	result.micros += time.micros;
+	found_any = true;
+	goto end_of_string;
+}
+interval_parse_identifier:
+	for (; pos < len; pos++) {
+		char c = str[pos];
+		if (c == ' ' || c == '\t' || c == '\n') {
+			// skip spaces at the start
+			continue;
+		} else {
+			break;
+		}
+	}
+	// now parse the identifier
+	start_pos = pos;
+	for (; pos < len; pos++) {
+		char c = str[pos];
+		if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+			// keep parsing the string
+			continue;
+		} else {
+			break;
+		}
+	}
+	specifier_str = string(str + start_pos, pos - start_pos);
+	if (!TryGetDatePartSpecifier(specifier_str, specifier)) {
+		HandleCastError::AssignError(StringUtil::Format("extract specifier \"%s\" not recognized", specifier_str),
+		                             error_message);
+		return false;
+	}
+	// add the specifier to the interval
+	switch (specifier) {
+	case DatePartSpecifier::MILLENNIUM:
+		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_MILLENIUM);
+		break;
+	case DatePartSpecifier::CENTURY:
+		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_CENTURY);
+		break;
+	case DatePartSpecifier::DECADE:
+		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_DECADE);
+		break;
+	case DatePartSpecifier::YEAR:
+		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_YEAR);
+		break;
+	case DatePartSpecifier::QUARTER:
+		IntervalTryAddition<int32_t>(result.months, number, MONTHS_PER_QUARTER);
+		break;
+	case DatePartSpecifier::MONTH:
+		IntervalTryAddition<int32_t>(result.months, number, 1);
+		break;
+	case DatePartSpecifier::DAY:
+		IntervalTryAddition<int32_t>(result.days, number, 1);
+		break;
+	case DatePartSpecifier::WEEK:
+		IntervalTryAddition<int32_t>(result.days, number, DAYS_PER_WEEK);
+		break;
+	case DatePartSpecifier::MICROSECONDS:
+		IntervalTryAddition<int64_t>(result.micros, number, 1);
+		break;
+	case DatePartSpecifier::MILLISECONDS:
+		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_MSEC);
+		break;
+	case DatePartSpecifier::SECOND:
+		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_SEC);
+		break;
+	case DatePartSpecifier::MINUTE:
+		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_MINUTE);
+		break;
+	case DatePartSpecifier::HOUR:
+		IntervalTryAddition<int64_t>(result.micros, number, MICROS_PER_HOUR);
+		break;
+	default:
+		HandleCastError::AssignError(
+		    StringUtil::Format("extract specifier \"%s\" not supported for interval", specifier_str), error_message);
+		return false;
+	}
+	found_any = true;
+	goto standard_interval;
+interval_parse_ago:
+	D_ASSERT(str[pos] == 'a' || str[pos] == 'A');
+	// parse the "ago" string at the end of the interval
+	if (len - pos < 3) {
+		return false;
+	}
+	pos++;
+	if (!(str[pos] == 'g' || str[pos] == 'G')) {
+		return false;
+	}
+	pos++;
+	if (!(str[pos] == 'o' || str[pos] == 'O')) {
+		return false;
+	}
+	pos++;
+	// parse any trailing whitespace
+	for (; pos < len; pos++) {
+		char c = str[pos];
+		if (c == ' ' || c == '\t' || c == '\n') {
+			continue;
+		} else {
+			return false;
+		}
+	}
+	// invert all the values
+	result.months = -result.months;
+	result.days = -result.days;
+	result.micros = -result.micros;
+	goto end_of_string;
+end_of_string:
+	if (!found_any) {
+		// end of string and no identifiers were found: cannot convert empty interval
+		return false;
+	}
+	return true;
+posix_interval:
+	return false;
+}
+
+string Interval::ToString(const interval_t &interval) {
+	char buffer[70];
+	idx_t length = IntervalToStringCast::Format(interval, buffer);
+	return string(buffer, length);
+}
+
+int64_t Interval::GetMilli(const interval_t &val) {
+	int64_t milli_month, milli_day, milli;
+	if (!TryMultiplyOperator::Operation((int64_t)val.months, Interval::MICROS_PER_MONTH / 1000, milli_month)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	if (!TryMultiplyOperator::Operation((int64_t)val.days, Interval::MICROS_PER_DAY / 1000, milli_day)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	milli = val.micros / 1000;
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(milli, milli_month, milli)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(milli, milli_day, milli)) {
+		throw ConversionException("Could not convert Interval to Milliseconds");
+	}
+	return milli;
+}
+
+int64_t Interval::GetMicro(const interval_t &val) {
+	int64_t micro_month, micro_day, micro_total;
+	micro_total = val.micros;
+	if (!TryMultiplyOperator::Operation((int64_t)val.months, MICROS_PER_MONTH, micro_month)) {
+		throw ConversionException("Could not convert Month to Microseconds");
+	}
+	if (!TryMultiplyOperator::Operation((int64_t)val.days, MICROS_PER_DAY, micro_day)) {
+		throw ConversionException("Could not convert Day to Microseconds");
+	}
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(micro_total, micro_month, micro_total)) {
+		throw ConversionException("Could not convert Interval to Microseconds");
+	}
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(micro_total, micro_day, micro_total)) {
+		throw ConversionException("Could not convert Interval to Microseconds");
+	}
+
+	return micro_total;
+}
+
+int64_t Interval::GetNanoseconds(const interval_t &val) {
+	int64_t nano;
+	const auto micro_total = GetMicro(val);
+	if (!TryMultiplyOperator::Operation(micro_total, NANOS_PER_MICRO, nano)) {
+		throw ConversionException("Could not convert Interval to Nanoseconds");
+	}
+
+	return nano;
+}
+
+interval_t Interval::GetAge(timestamp_t timestamp_1, timestamp_t timestamp_2) {
+	D_ASSERT(Timestamp::IsFinite(timestamp_1) && Timestamp::IsFinite(timestamp_2));
+	date_t date1, date2;
+	dtime_t time1, time2;
+
+	Timestamp::Convert(timestamp_1, date1, time1);
+	Timestamp::Convert(timestamp_2, date2, time2);
+
+	// and from date extract the years, months and days
+	int32_t year1, month1, day1;
+	int32_t year2, month2, day2;
+	Date::Convert(date1, year1, month1, day1);
+	Date::Convert(date2, year2, month2, day2);
+	// finally perform the differences
+	auto year_diff = year1 - year2;
+	auto month_diff = month1 - month2;
+	auto day_diff = day1 - day2;
+
+	// and from time extract hours, minutes, seconds and milliseconds
+	int32_t hour1, min1, sec1, micros1;
+	int32_t hour2, min2, sec2, micros2;
+	Time::Convert(time1, hour1, min1, sec1, micros1);
+	Time::Convert(time2, hour2, min2, sec2, micros2);
+	// finally perform the differences
+	auto hour_diff = hour1 - hour2;
+	auto min_diff = min1 - min2;
+	auto sec_diff = sec1 - sec2;
+	auto micros_diff = micros1 - micros2;
+
+	// flip sign if necessary
+	bool sign_flipped = false;
+	if (timestamp_1 < timestamp_2) {
+		year_diff = -year_diff;
+		month_diff = -month_diff;
+		day_diff = -day_diff;
+		hour_diff = -hour_diff;
+		min_diff = -min_diff;
+		sec_diff = -sec_diff;
+		micros_diff = -micros_diff;
+		sign_flipped = true;
+	}
+	// now propagate any negative field into the next higher field
+	while (micros_diff < 0) {
+		micros_diff += MICROS_PER_SEC;
+		sec_diff--;
+	}
+	while (sec_diff < 0) {
+		sec_diff += SECS_PER_MINUTE;
+		min_diff--;
+	}
+	while (min_diff < 0) {
+		min_diff += MINS_PER_HOUR;
+		hour_diff--;
+	}
+	while (hour_diff < 0) {
+		hour_diff += HOURS_PER_DAY;
+		day_diff--;
+	}
+	while (day_diff < 0) {
+		if (timestamp_1 < timestamp_2) {
+			day_diff += Date::IsLeapYear(year1) ? Date::LEAP_DAYS[month1] : Date::NORMAL_DAYS[month1];
+			month_diff--;
+		} else {
+			day_diff += Date::IsLeapYear(year2) ? Date::LEAP_DAYS[month2] : Date::NORMAL_DAYS[month2];
+			month_diff--;
+		}
+	}
+	while (month_diff < 0) {
+		month_diff += MONTHS_PER_YEAR;
+		year_diff--;
+	}
+
+	// recover sign if necessary
+	if (sign_flipped) {
+		year_diff = -year_diff;
+		month_diff = -month_diff;
+		day_diff = -day_diff;
+		hour_diff = -hour_diff;
+		min_diff = -min_diff;
+		sec_diff = -sec_diff;
+		micros_diff = -micros_diff;
+	}
+	interval_t interval;
+	interval.months = year_diff * MONTHS_PER_YEAR + month_diff;
+	interval.days = day_diff;
+	interval.micros = Time::FromTime(hour_diff, min_diff, sec_diff, micros_diff).micros;
+
+	return interval;
+}
+
+interval_t Interval::GetDifference(timestamp_t timestamp_1, timestamp_t timestamp_2) {
+	if (!Timestamp::IsFinite(timestamp_1) || !Timestamp::IsFinite(timestamp_2)) {
+		throw InvalidInputException("Cannot subtract infinite timestamps");
+	}
+	const auto us_1 = Timestamp::GetEpochMicroSeconds(timestamp_1);
+	const auto us_2 = Timestamp::GetEpochMicroSeconds(timestamp_2);
+	int64_t delta_us;
+	if (!TrySubtractOperator::Operation(us_1, us_2, delta_us)) {
+		throw ConversionException("Timestamp difference is out of bounds");
+	}
+	return FromMicro(delta_us);
+}
+
+interval_t Interval::FromMicro(int64_t delta_us) {
+	interval_t result;
+	result.months = 0;
+	result.days = delta_us / Interval::MICROS_PER_DAY;
+	result.micros = delta_us % Interval::MICROS_PER_DAY;
+
+	return result;
+}
+
+static void NormalizeIntervalEntries(interval_t input, int64_t &months, int64_t &days, int64_t &micros) {
+	int64_t extra_months_d = input.days / Interval::DAYS_PER_MONTH;
+	int64_t extra_months_micros = input.micros / Interval::MICROS_PER_MONTH;
+	input.days -= extra_months_d * Interval::DAYS_PER_MONTH;
+	input.micros -= extra_months_micros * Interval::MICROS_PER_MONTH;
+
+	int64_t extra_days_micros = input.micros / Interval::MICROS_PER_DAY;
+	input.micros -= extra_days_micros * Interval::MICROS_PER_DAY;
+
+	months = input.months + extra_months_d + extra_months_micros;
+	days = input.days + extra_days_micros;
+	micros = input.micros;
+}
+
+bool Interval::Equals(interval_t left, interval_t right) {
+	return left.months == right.months && left.days == right.days && left.micros == right.micros;
+}
+
+bool Interval::GreaterThan(interval_t left, interval_t right) {
+	int64_t lmonths, ldays, lmicros;
+	int64_t rmonths, rdays, rmicros;
+	NormalizeIntervalEntries(left, lmonths, ldays, lmicros);
+	NormalizeIntervalEntries(right, rmonths, rdays, rmicros);
+
+	if (lmonths > rmonths) {
+		return true;
+	} else if (lmonths < rmonths) {
+		return false;
+	}
+	if (ldays > rdays) {
+		return true;
+	} else if (ldays < rdays) {
+		return false;
+	}
+	return lmicros > rmicros;
+}
+
+bool Interval::GreaterThanEquals(interval_t left, interval_t right) {
+	return GreaterThan(left, right) || Equals(left, right);
+}
+
+date_t Interval::Add(date_t left, interval_t right) {
+	if (!Date::IsFinite(left)) {
+		return left;
+	}
+	date_t result;
+	if (right.months != 0) {
+		int32_t year, month, day;
+		Date::Convert(left, year, month, day);
+		int32_t year_diff = right.months / Interval::MONTHS_PER_YEAR;
+		year += year_diff;
+		month += right.months - year_diff * Interval::MONTHS_PER_YEAR;
+		if (month > Interval::MONTHS_PER_YEAR) {
+			year++;
+			month -= Interval::MONTHS_PER_YEAR;
+		} else if (month <= 0) {
+			year--;
+			month += Interval::MONTHS_PER_YEAR;
+		}
+		day = MinValue<int32_t>(day, Date::MonthDays(year, month));
+		result = Date::FromDate(year, month, day);
+	} else {
+		result = left;
+	}
+	if (right.days != 0) {
+		if (!TryAddOperator::Operation(result.days, right.days, result.days)) {
+			throw OutOfRangeException("Date out of range");
+		}
+	}
+	if (right.micros != 0) {
+		if (!TryAddOperator::Operation(result.days, int32_t(right.micros / Interval::MICROS_PER_DAY), result.days)) {
+			throw OutOfRangeException("Date out of range");
+		}
+	}
+	if (!Date::IsFinite(result)) {
+		throw OutOfRangeException("Date out of range");
+	}
+	return result;
+}
+
+dtime_t Interval::Add(dtime_t left, interval_t right, date_t &date) {
+	int64_t diff = right.micros - ((right.micros / Interval::MICROS_PER_DAY) * Interval::MICROS_PER_DAY);
+	left += diff;
+	if (left.micros >= Interval::MICROS_PER_DAY) {
+		left.micros -= Interval::MICROS_PER_DAY;
+		date.days++;
+	} else if (left.micros < 0) {
+		left.micros += Interval::MICROS_PER_DAY;
+		date.days--;
+	}
+	return left;
+}
+
+timestamp_t Interval::Add(timestamp_t left, interval_t right) {
+	if (!Timestamp::IsFinite(left)) {
+		return left;
+	}
+	date_t date;
+	dtime_t time;
+	Timestamp::Convert(left, date, time);
+	auto new_date = Interval::Add(date, right);
+	auto new_time = Interval::Add(time, right, new_date);
+	return Timestamp::FromDatetime(new_date, new_time);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+RowDataCollection::RowDataCollection(BufferManager &buffer_manager, idx_t block_capacity, idx_t entry_size,
+                                     bool keep_pinned)
+    : buffer_manager(buffer_manager), count(0), block_capacity(block_capacity), entry_size(entry_size),
+      keep_pinned(keep_pinned) {
+	D_ASSERT(block_capacity * entry_size >= Storage::BLOCK_SIZE);
+}
+
+idx_t RowDataCollection::AppendToBlock(RowDataBlock &block, BufferHandle &handle,
+                                       vector<BlockAppendEntry> &append_entries, idx_t remaining, idx_t entry_sizes[]) {
+	idx_t append_count = 0;
+	data_ptr_t dataptr;
+	if (entry_sizes) {
+		D_ASSERT(entry_size == 1);
+		// compute how many entries fit if entry size is variable
+		dataptr = handle.Ptr() + block.byte_offset;
+		for (idx_t i = 0; i < remaining; i++) {
+			if (block.byte_offset + entry_sizes[i] > block.capacity) {
+				if (block.count == 0 && append_count == 0 && entry_sizes[i] > block.capacity) {
+					// special case: single entry is bigger than block capacity
+					// resize current block to fit the entry, append it, and move to the next block
+					block.capacity = entry_sizes[i];
+					buffer_manager.ReAllocate(block.block, block.capacity);
+					dataptr = handle.Ptr();
+					append_count++;
+					block.byte_offset += entry_sizes[i];
+				}
+				break;
+			}
+			append_count++;
+			block.byte_offset += entry_sizes[i];
+		}
+	} else {
+		append_count = MinValue<idx_t>(remaining, block.capacity - block.count);
+		dataptr = handle.Ptr() + block.count * entry_size;
+	}
+	append_entries.emplace_back(dataptr, append_count);
+	block.count += append_count;
+	return append_count;
+}
+
+vector<unique_ptr<BufferHandle>> RowDataCollection::Build(idx_t added_count, data_ptr_t key_locations[],
+                                                          idx_t entry_sizes[], const SelectionVector *sel) {
+	vector<unique_ptr<BufferHandle>> handles;
+	vector<BlockAppendEntry> append_entries;
+
+	// first allocate space of where to serialize the keys and payload columns
+	idx_t remaining = added_count;
+	{
+		// first append to the last block (if any)
+		lock_guard<mutex> append_lock(rdc_lock);
+		count += added_count;
+
+		if (!blocks.empty()) {
+			auto &last_block = blocks.back();
+			if (last_block.count < last_block.capacity) {
+				// last block has space: pin the buffer of this block
+				auto handle = buffer_manager.Pin(last_block.block);
+				// now append to the block
+				idx_t append_count = AppendToBlock(last_block, *handle, append_entries, remaining, entry_sizes);
+				remaining -= append_count;
+				handles.push_back(move(handle));
+			}
+		}
+		while (remaining > 0) {
+			// now for the remaining data, allocate new buffers to store the data and append there
+			RowDataBlock new_block(buffer_manager, block_capacity, entry_size);
+			auto handle = buffer_manager.Pin(new_block.block);
+
+			// offset the entry sizes array if we have added entries already
+			idx_t *offset_entry_sizes = entry_sizes ? entry_sizes + added_count - remaining : nullptr;
+
+			idx_t append_count = AppendToBlock(new_block, *handle, append_entries, remaining, offset_entry_sizes);
+			D_ASSERT(new_block.count > 0);
+			remaining -= append_count;
+
+			blocks.push_back(move(new_block));
+			if (keep_pinned) {
+				pinned_blocks.push_back(move(handle));
+			} else {
+				handles.push_back(move(handle));
+			}
+		}
+	}
+	// now set up the key_locations based on the append entries
+	idx_t append_idx = 0;
+	for (auto &append_entry : append_entries) {
+		idx_t next = append_idx + append_entry.count;
+		if (entry_sizes) {
+			for (; append_idx < next; append_idx++) {
+				key_locations[append_idx] = append_entry.baseptr;
+				append_entry.baseptr += entry_sizes[append_idx];
+			}
+		} else {
+			for (; append_idx < next; append_idx++) {
+				auto idx = sel->get_index(append_idx);
+				key_locations[idx] = append_entry.baseptr;
+				append_entry.baseptr += entry_size;
+			}
+		}
+	}
+	// return the unique pointers to the handles because they must stay pinned
+	return handles;
+}
+
+void RowDataCollection::Merge(RowDataCollection &other) {
+	RowDataCollection temp(buffer_manager, Storage::BLOCK_SIZE, 1);
+	{
+		//	One lock at a time to avoid deadlocks
+		lock_guard<mutex> read_lock(other.rdc_lock);
+		temp.count = other.count;
+		temp.block_capacity = other.block_capacity;
+		temp.entry_size = other.entry_size;
+		temp.blocks = move(other.blocks);
+		other.count = 0;
+	}
+
+	lock_guard<mutex> write_lock(rdc_lock);
+	count += temp.count;
+	block_capacity = MaxValue(block_capacity, temp.block_capacity);
+	entry_size = MaxValue(entry_size, temp.entry_size);
+	for (auto &block : temp.blocks) {
+		blocks.emplace_back(move(block));
+	}
+	for (auto &handle : temp.pinned_blocks) {
+		pinned_blocks.emplace_back(move(handle));
+	}
+}
+
+} // namespace duckdb
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/types/row_layout.cpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+vector<AggregateObject> AggregateObject::CreateAggregateObjects(const vector<BoundAggregateExpression *> &bindings) {
+	vector<AggregateObject> aggregates;
+	for (auto &binding : bindings) {
+		auto payload_size = binding->function.state_size();
+#ifndef DUCKDB_ALLOW_UNDEFINED
+		payload_size = AlignValue(payload_size);
+#endif
+		aggregates.emplace_back(binding->function, binding->bind_info.get(), binding->children.size(), payload_size,
+		                        binding->distinct, binding->return_type.InternalType(), binding->filter.get());
+	}
+	return aggregates;
+}
+
+RowLayout::RowLayout()
+    : flag_width(0), data_width(0), aggr_width(0), row_width(0), all_constant(true), heap_pointer_offset(0) {
+}
+
+void RowLayout::Initialize(vector<LogicalType> types_p, Aggregates aggregates_p, bool align) {
+	offsets.clear();
+	types = move(types_p);
+
+	// Null mask at the front - 1 bit per value.
+	flag_width = ValidityBytes::ValidityMaskSize(types.size());
+	row_width = flag_width;
+
+	// Whether all columns are constant size.
+	for (const auto &type : types) {
+		all_constant = all_constant && TypeIsConstantSize(type.InternalType());
+	}
+
+	// This enables pointer swizzling for out-of-core computation.
+	if (!all_constant) {
+		// When unswizzled the pointer lives here.
+		// When swizzled, the pointer is replaced by an offset.
+		heap_pointer_offset = row_width;
+		// The 8 byte pointer will be replaced with an 8 byte idx_t when swizzled.
+		// However, this cannot be sizeof(data_ptr_t), since 32 bit builds use 4 byte pointers.
+		row_width += sizeof(idx_t);
+	}
+
+	// Data columns. No alignment required.
+	for (const auto &type : types) {
+		offsets.push_back(row_width);
+		const auto internal_type = type.InternalType();
+		if (TypeIsConstantSize(internal_type) || internal_type == PhysicalType::VARCHAR) {
+			row_width += GetTypeIdSize(type.InternalType());
+		} else {
+			// Variable size types use pointers to the actual data (can be swizzled).
+			// Again, we would use sizeof(data_ptr_t), but this is not guaranteed to be equal to sizeof(idx_t).
+			row_width += sizeof(idx_t);
+		}
+	}
+
+	// Alignment padding for aggregates
+#ifndef DUCKDB_ALLOW_UNDEFINED
+	if (align) {
+		row_width = AlignValue(row_width);
+	}
+#endif
+	data_width = row_width - flag_width;
+
+	// Aggregate fields.
+	aggregates = move(aggregates_p);
+	for (auto &aggregate : aggregates) {
+		offsets.push_back(row_width);
+		row_width += aggregate.payload_size;
+#ifndef DUCKDB_ALLOW_UNDEFINED
+		D_ASSERT(aggregate.payload_size == AlignValue(aggregate.payload_size));
+#endif
+	}
+	aggr_width = row_width - data_width - flag_width;
+
+	// Alignment padding for the next row
+#ifndef DUCKDB_ALLOW_UNDEFINED
+	if (align) {
+		row_width = AlignValue(row_width);
+	}
+#endif
+}
+
+void RowLayout::Initialize(vector<LogicalType> types_p, bool align) {
+	Initialize(move(types_p), Aggregates(), align);
+}
+
+void RowLayout::Initialize(Aggregates aggregates_p, bool align) {
+	Initialize(vector<LogicalType>(), move(aggregates_p), align);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+SelectionData::SelectionData(idx_t count) {
+	owned_data = unique_ptr<sel_t[]>(new sel_t[count]);
+#ifdef DEBUG
+	for (idx_t i = 0; i < count; i++) {
+		owned_data[i] = std::numeric_limits<sel_t>::max();
+	}
+#endif
+}
+
+// LCOV_EXCL_START
+string SelectionVector::ToString(idx_t count) const {
+	string result = "Selection Vector (" + to_string(count) + ") [";
+	for (idx_t i = 0; i < count; i++) {
+		if (i != 0) {
+			result += ", ";
+		}
+		result += to_string(get_index(i));
+	}
+	result += "]";
+	return result;
+}
+
+void SelectionVector::Print(idx_t count) const {
+	Printer::Print(ToString(count));
+}
+// LCOV_EXCL_STOP
+
+buffer_ptr<SelectionData> SelectionVector::Slice(const SelectionVector &sel, idx_t count) const {
+	auto data = make_buffer<SelectionData>(count);
+	auto result_ptr = data->owned_data.get();
+	// for every element, we perform result[i] = target[new[i]]
+	for (idx_t i = 0; i < count; i++) {
+		auto new_idx = sel.get_index(i);
+		auto idx = this->get_index(new_idx);
+		result_ptr[i] = idx;
+	}
+	return data;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+#define MINIMUM_HEAP_SIZE 4096
+
+StringHeap::StringHeap() : tail(nullptr) {
+}
+
+string_t StringHeap::AddString(const char *data, idx_t len) {
+	D_ASSERT(Utf8Proc::Analyze(data, len) != UnicodeType::INVALID);
+	return AddBlob(data, len);
+}
+
+string_t StringHeap::AddString(const char *data) {
+	return AddString(data, strlen(data));
+}
+
+string_t StringHeap::AddString(const string &data) {
+	return AddString(data.c_str(), data.size());
+}
+
+string_t StringHeap::AddString(const string_t &data) {
+	return AddString(data.GetDataUnsafe(), data.GetSize());
+}
+
+string_t StringHeap::AddBlob(const char *data, idx_t len) {
+	auto insert_string = EmptyString(len);
+	auto insert_pos = insert_string.GetDataWriteable();
+	memcpy(insert_pos, data, len);
+	insert_string.Finalize();
+	return insert_string;
+}
+
+string_t StringHeap::EmptyString(idx_t len) {
+	D_ASSERT(len >= string_t::INLINE_LENGTH);
+	if (!chunk || chunk->current_position + len >= chunk->maximum_size) {
+		// have to make a new entry
+		auto new_chunk = make_unique<StringChunk>(MaxValue<idx_t>(len, MINIMUM_HEAP_SIZE));
+		new_chunk->prev = move(chunk);
+		chunk = move(new_chunk);
+		if (!tail) {
+			tail = chunk.get();
+		}
+	}
+	auto insert_pos = chunk->data.get() + chunk->current_position;
+	chunk->current_position += len;
+	return string_t(insert_pos, len);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+void string_t::Verify() {
+	auto dataptr = GetDataUnsafe();
+	(void)dataptr;
+	D_ASSERT(dataptr);
+
+#ifdef DEBUG
+	auto utf_type = Utf8Proc::Analyze(dataptr, GetSize());
+	D_ASSERT(utf_type != UnicodeType::INVALID);
+#endif
+
+	// verify that the prefix contains the first four characters of the string
+	for (idx_t i = 0; i < MinValue<uint32_t>(PREFIX_LENGTH, GetSize()); i++) {
+		D_ASSERT(GetPrefix()[i] == dataptr[i]);
+	}
+	// verify that for strings with length < INLINE_LENGTH, the rest of the string is zero
+	for (idx_t i = GetSize(); i < INLINE_LENGTH; i++) {
+		D_ASSERT(GetDataUnsafe()[i] == '\0');
+	}
+}
+
+void string_t::VerifyNull() {
+	for (idx_t i = 0; i < GetSize(); i++) {
+		D_ASSERT(GetDataUnsafe()[i] != '\0');
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+#include <cstring>
+#include <sstream>
+#include <cctype>
+
+namespace duckdb {
+
+static_assert(sizeof(dtime_t) == sizeof(int64_t), "dtime_t was padded");
+
+// string format is hh:mm:ss.microsecondsZ
+// microseconds and Z are optional
+// ISO 8601
+
+bool Time::TryConvertInternal(const char *buf, idx_t len, idx_t &pos, dtime_t &result, bool strict) {
+	int32_t hour = -1, min = -1, sec = -1, micros = -1;
+	pos = 0;
+
+	if (len == 0) {
+		return false;
+	}
+
+	int sep;
+
+	// skip leading spaces
+	while (pos < len && StringUtil::CharacterIsSpace(buf[pos])) {
+		pos++;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	if (!StringUtil::CharacterIsDigit(buf[pos])) {
+		return false;
+	}
+
+	if (!Date::ParseDoubleDigit(buf, len, pos, hour)) {
+		return false;
+	}
+	if (hour < 0 || hour >= 24) {
+		return false;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	// fetch the separator
+	sep = buf[pos++];
+	if (sep != ':') {
+		// invalid separator
+		return false;
+	}
+
+	if (!Date::ParseDoubleDigit(buf, len, pos, min)) {
+		return false;
+	}
+	if (min < 0 || min >= 60) {
+		return false;
+	}
+
+	if (pos >= len) {
+		return false;
+	}
+
+	if (buf[pos++] != sep) {
+		return false;
+	}
+
+	if (!Date::ParseDoubleDigit(buf, len, pos, sec)) {
+		return false;
+	}
+	if (sec < 0 || sec >= 60) {
+		return false;
+	}
+
+	micros = 0;
+	if (pos < len && buf[pos] == '.') {
+		pos++;
+		// we expect some microseconds
+		int32_t mult = 100000;
+		for (; pos < len && StringUtil::CharacterIsDigit(buf[pos]); pos++, mult /= 10) {
+			if (mult > 0) {
+				micros += (buf[pos] - '0') * mult;
+			}
+		}
+	}
+
+	// in strict mode, check remaining string for non-space characters
+	if (strict) {
+		// skip trailing spaces
+		while (pos < len && StringUtil::CharacterIsSpace(buf[pos])) {
+			pos++;
+		}
+		// check position. if end was not reached, non-space chars remaining
+		if (pos < len) {
+			return false;
+		}
+	}
+
+	result = Time::FromTime(hour, min, sec, micros);
+	return true;
+}
+
+bool Time::TryConvertTime(const char *buf, idx_t len, idx_t &pos, dtime_t &result, bool strict) {
+	if (!Time::TryConvertInternal(buf, len, pos, result, strict)) {
+		if (!strict) {
+			// last chance, check if we can parse as timestamp
+			timestamp_t timestamp;
+			if (Timestamp::TryConvertTimestamp(buf, len, timestamp)) {
+				result = Timestamp::GetTime(timestamp);
+				return true;
+			}
+		}
+		return false;
+	}
+	return true;
+}
+
+string Time::ConversionError(const string &str) {
+	return StringUtil::Format("time field value out of range: \"%s\", "
+	                          "expected format is ([YYYY-MM-DD ]HH:MM:SS[.MS])",
+	                          str);
+}
+
+string Time::ConversionError(string_t str) {
+	return Time::ConversionError(str.GetString());
+}
+
+dtime_t Time::FromCString(const char *buf, idx_t len, bool strict) {
+	dtime_t result;
+	idx_t pos;
+	if (!Time::TryConvertTime(buf, len, pos, result, strict)) {
+		throw ConversionException(ConversionError(string(buf, len)));
+	}
+	return result;
+}
+
+dtime_t Time::FromString(const string &str, bool strict) {
+	return Time::FromCString(str.c_str(), str.size(), strict);
+}
+
+string Time::ToString(dtime_t time) {
+	int32_t time_units[4];
+	Time::Convert(time, time_units[0], time_units[1], time_units[2], time_units[3]);
+
+	char micro_buffer[6];
+	auto length = TimeToStringCast::Length(time_units, micro_buffer);
+	auto buffer = unique_ptr<char[]>(new char[length]);
+	TimeToStringCast::Format(buffer.get(), length, time_units, micro_buffer);
+	return string(buffer.get(), length);
+}
+
+string Time::ToUTCOffset(int hour_offset, int minute_offset) {
+	dtime_t time((hour_offset * Interval::MINS_PER_HOUR + minute_offset) * Interval::MICROS_PER_MINUTE);
+
+	char buffer[1 + 2 + 1 + 2];
+	idx_t length = 0;
+	buffer[length++] = (time.micros < 0 ? '-' : '+');
+	time.micros = std::abs(time.micros);
+
+	int32_t time_units[4];
+	Time::Convert(time, time_units[0], time_units[1], time_units[2], time_units[3]);
+
+	TimeToStringCast::FormatTwoDigits(buffer + length, time_units[0]);
+	length += 2;
+	if (time_units[1]) {
+		buffer[length++] = ':';
+		TimeToStringCast::FormatTwoDigits(buffer + length, time_units[1]);
+		length += 2;
+	}
+
+	return string(buffer, length);
+}
+
+dtime_t Time::FromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
+	int64_t result;
+	result = hour;                                             // hours
+	result = result * Interval::MINS_PER_HOUR + minute;        // hours -> minutes
+	result = result * Interval::SECS_PER_MINUTE + second;      // minutes -> seconds
+	result = result * Interval::MICROS_PER_SEC + microseconds; // seconds -> microseconds
+	return dtime_t(result);
+}
+
+// LCOV_EXCL_START
+#ifdef DEBUG
+static bool AssertValidTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
+	if (hour < 0 || hour >= 24) {
+		return false;
+	}
+	if (minute < 0 || minute >= 60) {
+		return false;
+	}
+	if (second < 0 || second > 60) {
+		return false;
+	}
+	if (microseconds < 0 || microseconds > 1000000) {
+		return false;
+	}
+	return true;
+}
+#endif
+// LCOV_EXCL_STOP
+
+void Time::Convert(dtime_t dtime, int32_t &hour, int32_t &min, int32_t &sec, int32_t &micros) {
+	int64_t time = dtime.micros;
+	hour = int32_t(time / Interval::MICROS_PER_HOUR);
+	time -= int64_t(hour) * Interval::MICROS_PER_HOUR;
+	min = int32_t(time / Interval::MICROS_PER_MINUTE);
+	time -= int64_t(min) * Interval::MICROS_PER_MINUTE;
+	sec = int32_t(time / Interval::MICROS_PER_SEC);
+	time -= int64_t(sec) * Interval::MICROS_PER_SEC;
+	micros = int32_t(time);
+#ifdef DEBUG
+	D_ASSERT(AssertValidTime(hour, min, sec, micros));
+#endif
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+#include <ctime>
+
+namespace duckdb {
+
+static_assert(sizeof(timestamp_t) == sizeof(int64_t), "timestamp_t was padded");
+
+// timestamp/datetime uses 64 bits, high 32 bits for date and low 32 bits for time
+// string format is YYYY-MM-DDThh:mm:ssZ
+// T may be a space
+// Z is optional
+// ISO 8601
+bool Timestamp::TryConvertTimestamp(const char *str, idx_t len, timestamp_t &result) {
+	idx_t pos;
+	date_t date;
+	dtime_t time;
+	if (!Date::TryConvertDate(str, len, pos, date)) {
+		return false;
+	}
+	if (pos == len) {
+		// no time: only a date or special
+		if (date == date_t::infinity()) {
+			result = timestamp_t::infinity();
+			return true;
+		} else if (date == date_t::ninfinity()) {
+			result = timestamp_t::ninfinity();
+			return true;
+		}
+		return Timestamp::TryFromDatetime(date, dtime_t(0), result);
+	}
+	// try to parse a time field
+	if (str[pos] == ' ' || str[pos] == 'T') {
+		pos++;
+	}
+	idx_t time_pos = 0;
+	if (!Time::TryConvertTime(str + pos, len - pos, time_pos, time)) {
+		return false;
+	}
+	pos += time_pos;
+	if (!Timestamp::TryFromDatetime(date, time, result)) {
+		return false;
+	}
+	if (pos < len) {
+		// skip a "Z" at the end (as per the ISO8601 specs)
+		if (str[pos] == 'Z') {
+			pos++;
+		}
+		int hour_offset, minute_offset;
+		if (Timestamp::TryParseUTCOffset(str, pos, len, hour_offset, minute_offset)) {
+			result -= hour_offset * Interval::MICROS_PER_HOUR + minute_offset * Interval::MICROS_PER_MINUTE;
+		}
+
+		// skip any spaces at the end
+		while (pos < len && StringUtil::CharacterIsSpace(str[pos])) {
+			pos++;
+		}
+		if (pos < len) {
+			return false;
+		}
+	}
+	return true;
+}
+
+string Timestamp::ConversionError(const string &str) {
+	return StringUtil::Format("timestamp field value out of range: \"%s\", "
+	                          "expected format is (YYYY-MM-DD HH:MM:SS[.MS])",
+	                          str);
+}
+
+string Timestamp::ConversionError(string_t str) {
+	return Timestamp::ConversionError(str.GetString());
+}
+
+timestamp_t Timestamp::FromCString(const char *str, idx_t len) {
+	timestamp_t result;
+	if (!Timestamp::TryConvertTimestamp(str, len, result)) {
+		throw ConversionException(Timestamp::ConversionError(string(str, len)));
+	}
+	return result;
+}
+
+bool Timestamp::TryParseUTCOffset(const char *str, idx_t &pos, idx_t len, int &hour_offset, int &minute_offset) {
+	minute_offset = 0;
+	idx_t curpos = pos;
+	// parse the next 3 characters
+	if (curpos + 3 > len) {
+		// no characters left to parse
+		return false;
+	}
+	char sign_char = str[curpos];
+	if (sign_char != '+' && sign_char != '-') {
+		// expected either + or -
+		return false;
+	}
+	curpos++;
+	if (!StringUtil::CharacterIsDigit(str[curpos]) || !StringUtil::CharacterIsDigit(str[curpos + 1])) {
+		// expected +HH or -HH
+		return false;
+	}
+	hour_offset = (str[curpos] - '0') * 10 + (str[curpos + 1] - '0');
+	if (sign_char == '-') {
+		hour_offset = -hour_offset;
+	}
+	curpos += 2;
+
+	// optional minute specifier: expected either "MM" or ":MM"
+	if (curpos >= len) {
+		// done, nothing left
+		pos = curpos;
+		return true;
+	}
+	if (str[curpos] == ':') {
+		curpos++;
+	}
+	if (curpos + 2 > len || !StringUtil::CharacterIsDigit(str[curpos]) ||
+	    !StringUtil::CharacterIsDigit(str[curpos + 1])) {
+		// no MM specifier
+		pos = curpos;
+		return true;
+	}
+	// we have an MM specifier: parse it
+	minute_offset = (str[curpos] - '0') * 10 + (str[curpos + 1] - '0');
+	if (sign_char == '-') {
+		minute_offset = -minute_offset;
+	}
+	pos = curpos + 2;
+	return true;
+}
+
+timestamp_t Timestamp::FromString(const string &str) {
+	return Timestamp::FromCString(str.c_str(), str.size());
+}
+
+string Timestamp::ToString(timestamp_t timestamp) {
+	if (timestamp == timestamp_t::infinity()) {
+		return Date::PINF;
+	} else if (timestamp == timestamp_t::ninfinity()) {
+		return Date::NINF;
+	}
+	date_t date;
+	dtime_t time;
+	Timestamp::Convert(timestamp, date, time);
+	return Date::ToString(date) + " " + Time::ToString(time);
+}
+
+date_t Timestamp::GetDate(timestamp_t timestamp) {
+	if (timestamp == timestamp_t::infinity()) {
+		return date_t::infinity();
+	} else if (timestamp == timestamp_t::ninfinity()) {
+		return date_t::ninfinity();
+	}
+	return date_t((timestamp.value + (timestamp.value < 0)) / Interval::MICROS_PER_DAY - (timestamp.value < 0));
+}
+
+dtime_t Timestamp::GetTime(timestamp_t timestamp) {
+	if (!IsFinite(timestamp)) {
+		throw ConversionException("Can't get TIME of infinite TIMESTAMP");
+	}
+	date_t date = Timestamp::GetDate(timestamp);
+	return dtime_t(timestamp.value - (int64_t(date.days) * int64_t(Interval::MICROS_PER_DAY)));
+}
+
+bool Timestamp::TryFromDatetime(date_t date, dtime_t time, timestamp_t &result) {
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(date.days, Interval::MICROS_PER_DAY, result.value)) {
+		return false;
+	}
+	if (!TryAddOperator::Operation<int64_t, int64_t, int64_t>(result.value, time.micros, result.value)) {
+		return false;
+	}
+	return Timestamp::IsFinite(result);
+}
+
+timestamp_t Timestamp::FromDatetime(date_t date, dtime_t time) {
+	timestamp_t result;
+	if (!TryFromDatetime(date, time, result)) {
+		throw Exception("Overflow exception in date/time -> timestamp conversion");
+	}
+	return result;
+}
+
+void Timestamp::Convert(timestamp_t timestamp, date_t &out_date, dtime_t &out_time) {
+	out_date = GetDate(timestamp);
+	int64_t days_micros;
+	if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(out_date.days, Interval::MICROS_PER_DAY,
+	                                                               days_micros)) {
+		throw ConversionException("Date out of range in timestamp conversion");
+	}
+	out_time = dtime_t(timestamp.value - days_micros);
+	D_ASSERT(timestamp == Timestamp::FromDatetime(out_date, out_time));
+}
+
+timestamp_t Timestamp::GetCurrentTimestamp() {
+	auto now = system_clock::now();
+	auto epoch_ms = duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+	return Timestamp::FromEpochMs(epoch_ms);
+}
+
+timestamp_t Timestamp::FromEpochSeconds(int64_t sec) {
+	int64_t result;
+	if (!TryMultiplyOperator::Operation(sec, Interval::MICROS_PER_SEC, result)) {
+		throw ConversionException("Could not convert Timestamp(S) to Timestamp(US)");
+	}
+	return timestamp_t(result);
+}
+
+timestamp_t Timestamp::FromEpochMs(int64_t ms) {
+	int64_t result;
+	if (!TryMultiplyOperator::Operation(ms, Interval::MICROS_PER_MSEC, result)) {
+		throw ConversionException("Could not convert Timestamp(MS) to Timestamp(US)");
+	}
+	return timestamp_t(result);
+}
+
+timestamp_t Timestamp::FromEpochMicroSeconds(int64_t micros) {
+	return timestamp_t(micros);
+}
+
+timestamp_t Timestamp::FromEpochNanoSeconds(int64_t ns) {
+	return timestamp_t(ns / 1000);
+}
+
+int64_t Timestamp::GetEpochSeconds(timestamp_t timestamp) {
+	return timestamp.value / Interval::MICROS_PER_SEC;
+}
+
+int64_t Timestamp::GetEpochMs(timestamp_t timestamp) {
+	return timestamp.value / Interval::MICROS_PER_MSEC;
+}
+
+int64_t Timestamp::GetEpochMicroSeconds(timestamp_t timestamp) {
+	return timestamp.value;
+}
+
+int64_t Timestamp::GetEpochNanoSeconds(timestamp_t timestamp) {
+	int64_t result;
+	int64_t ns_in_us = 1000;
+	if (!TryMultiplyOperator::Operation(timestamp.value, ns_in_us, result)) {
+		throw ConversionException("Could not convert Timestamp(US) to Timestamp(NS)");
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+bool UUID::FromString(string str, hugeint_t &result) {
+	auto hex2char = [](char ch) -> unsigned char {
+		if (ch >= '0' && ch <= '9') {
+			return ch - '0';
+		}
+		if (ch >= 'a' && ch <= 'f') {
+			return 10 + ch - 'a';
+		}
+		if (ch >= 'A' && ch <= 'F') {
+			return 10 + ch - 'A';
+		}
+		return 0;
+	};
+	auto is_hex = [](char ch) -> bool {
+		return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
+	};
+
+	if (str.empty()) {
+		return false;
+	}
+	int has_braces = 0;
+	if (str.front() == '{') {
+		has_braces = 1;
+	}
+	if (has_braces && str.back() != '}') {
+		return false;
+	}
+
+	result.lower = 0;
+	result.upper = 0;
+	size_t count = 0;
+	for (size_t i = has_braces; i < str.size() - has_braces; ++i) {
+		if (str[i] == '-') {
+			continue;
+		}
+		if (count >= 32 || !is_hex(str[i])) {
+			return false;
+		}
+		if (count >= 16) {
+			result.lower = (result.lower << 4) | hex2char(str[i]);
+		} else {
+			result.upper = (result.upper << 4) | hex2char(str[i]);
+		}
+		count++;
+	}
+	// Flip the first bit to make `order by uuid` same as `order by uuid::varchar`
+	result.upper ^= (int64_t(1) << 63);
+	return count == 32;
+}
+
+void UUID::ToString(hugeint_t input, char *buf) {
+	auto byte_to_hex = [](char byte_val, char *buf, idx_t &pos) {
+		static char const HEX_DIGITS[] = "0123456789abcdef";
+		buf[pos++] = HEX_DIGITS[(byte_val >> 4) & 0xf];
+		buf[pos++] = HEX_DIGITS[byte_val & 0xf];
+	};
+
+	// Flip back before convert to string
+	int64_t upper = input.upper ^ (int64_t(1) << 63);
+	idx_t pos = 0;
+	byte_to_hex(upper >> 56 & 0xFF, buf, pos);
+	byte_to_hex(upper >> 48 & 0xFF, buf, pos);
+	byte_to_hex(upper >> 40 & 0xFF, buf, pos);
+	byte_to_hex(upper >> 32 & 0xFF, buf, pos);
+	buf[pos++] = '-';
+	byte_to_hex(upper >> 24 & 0xFF, buf, pos);
+	byte_to_hex(upper >> 16 & 0xFF, buf, pos);
+	buf[pos++] = '-';
+	byte_to_hex(upper >> 8 & 0xFF, buf, pos);
+	byte_to_hex(upper & 0xFF, buf, pos);
+	buf[pos++] = '-';
+	byte_to_hex(input.lower >> 56 & 0xFF, buf, pos);
+	byte_to_hex(input.lower >> 48 & 0xFF, buf, pos);
+	buf[pos++] = '-';
+	byte_to_hex(input.lower >> 40 & 0xFF, buf, pos);
+	byte_to_hex(input.lower >> 32 & 0xFF, buf, pos);
+	byte_to_hex(input.lower >> 24 & 0xFF, buf, pos);
+	byte_to_hex(input.lower >> 16 & 0xFF, buf, pos);
+	byte_to_hex(input.lower >> 8 & 0xFF, buf, pos);
+	byte_to_hex(input.lower & 0xFF, buf, pos);
+}
+
+hugeint_t UUID::GenerateRandomUUID(RandomEngine &engine) {
+	uint8_t bytes[16];
+	for (int i = 0; i < 16; i += 4) {
+		*reinterpret_cast<uint32_t *>(bytes + i) = engine.NextRandomInteger();
+	}
+	// variant must be 10xxxxxx
+	bytes[8] &= 0xBF;
+	bytes[8] |= 0x80;
+	// version must be 0100xxxx
+	bytes[6] &= 0x4F;
+	bytes[6] |= 0x40;
+
+	hugeint_t result;
+	result.upper = 0;
+	result.upper |= ((int64_t)bytes[0] << 56);
+	result.upper |= ((int64_t)bytes[1] << 48);
+	result.upper |= ((int64_t)bytes[3] << 40);
+	result.upper |= ((int64_t)bytes[4] << 32);
+	result.upper |= ((int64_t)bytes[5] << 24);
+	result.upper |= ((int64_t)bytes[6] << 16);
+	result.upper |= ((int64_t)bytes[7] << 8);
+	result.upper |= bytes[8];
+	result.lower = 0;
+	result.lower |= ((uint64_t)bytes[8] << 56);
+	result.lower |= ((uint64_t)bytes[9] << 48);
+	result.lower |= ((uint64_t)bytes[10] << 40);
+	result.lower |= ((uint64_t)bytes[11] << 32);
+	result.lower |= ((uint64_t)bytes[12] << 24);
+	result.lower |= ((uint64_t)bytes[13] << 16);
+	result.lower |= ((uint64_t)bytes[14] << 8);
+	result.lower |= bytes[15];
+	return result;
+}
+
+hugeint_t UUID::GenerateRandomUUID() {
+	RandomEngine engine;
+	return GenerateRandomUUID(engine);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+ValidityData::ValidityData(idx_t count) : TemplatedValidityData(count) {
+}
+ValidityData::ValidityData(const ValidityMask &original, idx_t count)
+    : TemplatedValidityData(original.GetData(), count) {
+}
+
+void ValidityMask::Combine(const ValidityMask &other, idx_t count) {
+	if (other.AllValid()) {
+		// X & 1 = X
+		return;
+	}
+	if (AllValid()) {
+		// 1 & Y = Y
+		Initialize(other);
+		return;
+	}
+	if (validity_mask == other.validity_mask) {
+		// X & X == X
+		return;
+	}
+	// have to merge
+	// create a new validity mask that contains the combined mask
+	auto owned_data = move(validity_data);
+	auto data = GetData();
+	auto other_data = other.GetData();
+
+	Initialize(count);
+	auto result_data = GetData();
+
+	auto entry_count = ValidityData::EntryCount(count);
+	for (idx_t entry_idx = 0; entry_idx < entry_count; entry_idx++) {
+		result_data[entry_idx] = data[entry_idx] & other_data[entry_idx];
+	}
+}
+
+// LCOV_EXCL_START
+string ValidityMask::ToString(idx_t count) const {
+	string result = "Validity Mask (" + to_string(count) + ") [";
+	for (idx_t i = 0; i < count; i++) {
+		result += RowIsValid(i) ? "." : "X";
+	}
+	result += "]";
+	return result;
+}
+// LCOV_EXCL_STOP
+
+void ValidityMask::Resize(idx_t old_size, idx_t new_size) {
+	if (validity_mask) {
+		auto new_size_count = EntryCount(new_size);
+		auto old_size_count = EntryCount(old_size);
+		auto new_owned_data = unique_ptr<validity_t[]>(new validity_t[new_size_count]);
+		for (idx_t entry_idx = 0; entry_idx < old_size_count; entry_idx++) {
+			new_owned_data[entry_idx] = validity_mask[entry_idx];
+		}
+		for (idx_t entry_idx = old_size_count; entry_idx < new_size_count; entry_idx++) {
+			new_owned_data[entry_idx] = ValidityData::MAX_ENTRY;
+		}
+		validity_data->owned_data = move(new_owned_data);
+		validity_mask = validity_data->owned_data.get();
+	} else {
+		Initialize(new_size);
+	}
+}
+
+void ValidityMask::Slice(const ValidityMask &other, idx_t offset) {
+	if (other.AllValid()) {
+		validity_mask = nullptr;
+		validity_data.reset();
+		return;
+	}
+	if (offset == 0) {
+		Initialize(other);
+		return;
+	}
+	ValidityMask new_mask(STANDARD_VECTOR_SIZE);
+
+// FIXME THIS NEEDS FIXING!
+#if 1
+	for (idx_t i = offset; i < STANDARD_VECTOR_SIZE; i++) {
+		new_mask.Set(i - offset, other.RowIsValid(i));
+	}
+	Initialize(new_mask);
+#else
+	// first shift the "whole" units
+	idx_t entire_units = offset / BITS_PER_VALUE;
+	idx_t sub_units = offset - entire_units * BITS_PER_VALUE;
+	if (entire_units > 0) {
+		idx_t validity_idx;
+		for (validity_idx = 0; validity_idx + entire_units < STANDARD_ENTRY_COUNT; validity_idx++) {
+			new_mask.validity_mask[validity_idx] = other.validity_mask[validity_idx + entire_units];
+		}
+	}
+	// now we shift the remaining sub units
+	// this gets a bit more complicated because we have to shift over the borders of the entries
+	// e.g. suppose we have 2 entries of length 4 and we left-shift by two
+	// 0101|1010
+	// a regular left-shift of both gets us:
+	// 0100|1000
+	// we then OR the overflow (right-shifted by BITS_PER_VALUE - offset) together to get the correct result
+	// 0100|1000 ->
+	// 0110|1000
+	if (sub_units > 0) {
+		idx_t validity_idx;
+		for (validity_idx = 0; validity_idx + 1 < STANDARD_ENTRY_COUNT; validity_idx++) {
+			new_mask.validity_mask[validity_idx] =
+			    (other.validity_mask[validity_idx] >> sub_units) |
+			    (other.validity_mask[validity_idx + 1] << (BITS_PER_VALUE - sub_units));
+		}
+		new_mask.validity_mask[validity_idx] >>= sub_units;
+	}
+#ifdef DEBUG
+	for (idx_t i = offset; i < STANDARD_VECTOR_SIZE; i++) {
+		D_ASSERT(new_mask.RowIsValid(i - offset) == other.RowIsValid(i));
+	}
+	Initialize(new_mask);
+#endif
+#endif
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <utility>
+#include <cmath>
+
+namespace duckdb {
+
+Value::Value(LogicalType type) : type_(move(type)), is_null(true) {
+}
+
+Value::Value(int32_t val) : type_(LogicalType::INTEGER), is_null(false) {
+	value_.integer = val;
+}
+
+Value::Value(int64_t val) : type_(LogicalType::BIGINT), is_null(false) {
+	value_.bigint = val;
+}
+
+Value::Value(float val) : type_(LogicalType::FLOAT), is_null(false) {
+	value_.float_ = val;
+}
+
+Value::Value(double val) : type_(LogicalType::DOUBLE), is_null(false) {
+	value_.double_ = val;
+}
+
+Value::Value(const char *val) : Value(val ? string(val) : string()) {
+}
+
+Value::Value(std::nullptr_t val) : Value(LogicalType::VARCHAR) {
+}
+
+Value::Value(string_t val) : Value(string(val.GetDataUnsafe(), val.GetSize())) {
+}
+
+Value::Value(string val) : type_(LogicalType::VARCHAR), is_null(false), str_value(move(val)) {
+	if (!Value::StringIsValid(str_value.c_str(), str_value.size())) {
+		throw Exception("String value is not valid UTF8");
+	}
+}
+
+Value::~Value() {
+}
+
+Value::Value(const Value &other)
+    : type_(other.type_), is_null(other.is_null), value_(other.value_), str_value(other.str_value),
+      struct_value(other.struct_value), list_value(other.list_value) {
+}
+
+Value::Value(Value &&other) noexcept
+    : type_(move(other.type_)), is_null(other.is_null), value_(other.value_), str_value(move(other.str_value)),
+      struct_value(move(other.struct_value)), list_value(move(other.list_value)) {
+}
+
+Value &Value::operator=(const Value &other) {
+	type_ = other.type_;
+	is_null = other.is_null;
+	value_ = other.value_;
+	str_value = other.str_value;
+	struct_value = other.struct_value;
+	list_value = other.list_value;
+	return *this;
+}
+
+Value &Value::operator=(Value &&other) noexcept {
+	type_ = move(other.type_);
+	is_null = other.is_null;
+	value_ = other.value_;
+	str_value = move(other.str_value);
+	struct_value = move(other.struct_value);
+	list_value = move(other.list_value);
+	return *this;
+}
+
+Value Value::MinimumValue(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return Value::BOOLEAN(false);
+	case LogicalTypeId::TINYINT:
+		return Value::TINYINT(NumericLimits<int8_t>::Minimum());
+	case LogicalTypeId::SMALLINT:
+		return Value::SMALLINT(NumericLimits<int16_t>::Minimum());
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::SQLNULL:
+		return Value::INTEGER(NumericLimits<int32_t>::Minimum());
+	case LogicalTypeId::BIGINT:
+		return Value::BIGINT(NumericLimits<int64_t>::Minimum());
+	case LogicalTypeId::HUGEINT:
+		return Value::HUGEINT(NumericLimits<hugeint_t>::Minimum());
+	case LogicalTypeId::UUID:
+		return Value::UUID(NumericLimits<hugeint_t>::Minimum());
+	case LogicalTypeId::UTINYINT:
+		return Value::UTINYINT(NumericLimits<uint8_t>::Minimum());
+	case LogicalTypeId::USMALLINT:
+		return Value::USMALLINT(NumericLimits<uint16_t>::Minimum());
+	case LogicalTypeId::UINTEGER:
+		return Value::UINTEGER(NumericLimits<uint32_t>::Minimum());
+	case LogicalTypeId::UBIGINT:
+		return Value::UBIGINT(NumericLimits<uint64_t>::Minimum());
+	case LogicalTypeId::DATE:
+		return Value::DATE(Date::FromDate(Date::DATE_MIN_YEAR, Date::DATE_MIN_MONTH, Date::DATE_MIN_DAY));
+	case LogicalTypeId::TIME:
+		return Value::TIME(dtime_t(0));
+	case LogicalTypeId::TIMESTAMP:
+		return Value::TIMESTAMP(Date::FromDate(Timestamp::MIN_YEAR, Timestamp::MIN_MONTH, Timestamp::MIN_DAY),
+		                        dtime_t(0));
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return MinimumValue(LogicalType::TIMESTAMP).CastAs(LogicalType::TIMESTAMP_S);
+	case LogicalTypeId::TIMESTAMP_MS:
+		return MinimumValue(LogicalType::TIMESTAMP).CastAs(LogicalType::TIMESTAMP_MS);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return Value::TIMESTAMPNS(timestamp_t(NumericLimits<int64_t>::Minimum()));
+	case LogicalTypeId::TIME_TZ:
+		return Value::TIMETZ(dtime_t(0));
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return Value::TIMESTAMPTZ(Timestamp::FromDatetime(
+		    Date::FromDate(Timestamp::MIN_YEAR, Timestamp::MIN_MONTH, Timestamp::MIN_DAY), dtime_t(0)));
+	case LogicalTypeId::FLOAT:
+		return Value::FLOAT(NumericLimits<float>::Minimum());
+	case LogicalTypeId::DOUBLE:
+		return Value::DOUBLE(NumericLimits<double>::Minimum());
+	case LogicalTypeId::DECIMAL: {
+		auto width = DecimalType::GetWidth(type);
+		auto scale = DecimalType::GetScale(type);
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return Value::DECIMAL(int16_t(-NumericHelper::POWERS_OF_TEN[width] + 1), width, scale);
+		case PhysicalType::INT32:
+			return Value::DECIMAL(int32_t(-NumericHelper::POWERS_OF_TEN[width] + 1), width, scale);
+		case PhysicalType::INT64:
+			return Value::DECIMAL(int64_t(-NumericHelper::POWERS_OF_TEN[width] + 1), width, scale);
+		case PhysicalType::INT128:
+			return Value::DECIMAL(-Hugeint::POWERS_OF_TEN[width] + 1, width, scale);
+		default:
+			throw InternalException("Unknown decimal type");
+		}
+	}
+	case LogicalTypeId::ENUM:
+		return Value::ENUM(0, type);
+	default:
+		throw InvalidTypeException(type, "MinimumValue requires numeric type");
+	}
+}
+
+Value Value::MaximumValue(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return Value::BOOLEAN(true);
+	case LogicalTypeId::TINYINT:
+		return Value::TINYINT(NumericLimits<int8_t>::Maximum());
+	case LogicalTypeId::SMALLINT:
+		return Value::SMALLINT(NumericLimits<int16_t>::Maximum());
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::SQLNULL:
+		return Value::INTEGER(NumericLimits<int32_t>::Maximum());
+	case LogicalTypeId::BIGINT:
+		return Value::BIGINT(NumericLimits<int64_t>::Maximum());
+	case LogicalTypeId::HUGEINT:
+		return Value::HUGEINT(NumericLimits<hugeint_t>::Maximum());
+	case LogicalTypeId::UUID:
+		return Value::UUID(NumericLimits<hugeint_t>::Maximum());
+	case LogicalTypeId::UTINYINT:
+		return Value::UTINYINT(NumericLimits<uint8_t>::Maximum());
+	case LogicalTypeId::USMALLINT:
+		return Value::USMALLINT(NumericLimits<uint16_t>::Maximum());
+	case LogicalTypeId::UINTEGER:
+		return Value::UINTEGER(NumericLimits<uint32_t>::Maximum());
+	case LogicalTypeId::UBIGINT:
+		return Value::UBIGINT(NumericLimits<uint64_t>::Maximum());
+	case LogicalTypeId::DATE:
+		return Value::DATE(Date::FromDate(Date::DATE_MAX_YEAR, Date::DATE_MAX_MONTH, Date::DATE_MAX_DAY));
+	case LogicalTypeId::TIME:
+		return Value::TIME(dtime_t(Interval::SECS_PER_DAY * Interval::MICROS_PER_SEC - 1));
+	case LogicalTypeId::TIMESTAMP:
+		return Value::TIMESTAMP(timestamp_t(NumericLimits<int64_t>::Maximum() - 1));
+	case LogicalTypeId::TIMESTAMP_MS:
+		return MaximumValue(LogicalType::TIMESTAMP).CastAs(LogicalType::TIMESTAMP_MS);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return Value::TIMESTAMPNS(timestamp_t(NumericLimits<int64_t>::Maximum() - 1));
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return MaximumValue(LogicalType::TIMESTAMP).CastAs(LogicalType::TIMESTAMP_S);
+	case LogicalTypeId::TIME_TZ:
+		return Value::TIMETZ(dtime_t(Interval::SECS_PER_DAY * Interval::MICROS_PER_SEC - 1));
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return MaximumValue(LogicalType::TIMESTAMP);
+	case LogicalTypeId::FLOAT:
+		return Value::FLOAT(NumericLimits<float>::Maximum());
+	case LogicalTypeId::DOUBLE:
+		return Value::DOUBLE(NumericLimits<double>::Maximum());
+	case LogicalTypeId::DECIMAL: {
+		auto width = DecimalType::GetWidth(type);
+		auto scale = DecimalType::GetScale(type);
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return Value::DECIMAL(int16_t(NumericHelper::POWERS_OF_TEN[width] - 1), width, scale);
+		case PhysicalType::INT32:
+			return Value::DECIMAL(int32_t(NumericHelper::POWERS_OF_TEN[width] - 1), width, scale);
+		case PhysicalType::INT64:
+			return Value::DECIMAL(int64_t(NumericHelper::POWERS_OF_TEN[width] - 1), width, scale);
+		case PhysicalType::INT128:
+			return Value::DECIMAL(Hugeint::POWERS_OF_TEN[width] - 1, width, scale);
+		default:
+			throw InternalException("Unknown decimal type");
+		}
+	}
+	case LogicalTypeId::ENUM:
+		return Value::ENUM(EnumType::GetSize(type) - 1, type);
+	default:
+		throw InvalidTypeException(type, "MaximumValue requires numeric type");
+	}
+}
+
+Value Value::BOOLEAN(int8_t value) {
+	Value result(LogicalType::BOOLEAN);
+	result.value_.boolean = value ? true : false;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TINYINT(int8_t value) {
+	Value result(LogicalType::TINYINT);
+	result.value_.tinyint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::SMALLINT(int16_t value) {
+	Value result(LogicalType::SMALLINT);
+	result.value_.smallint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::INTEGER(int32_t value) {
+	Value result(LogicalType::INTEGER);
+	result.value_.integer = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::BIGINT(int64_t value) {
+	Value result(LogicalType::BIGINT);
+	result.value_.bigint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::HUGEINT(hugeint_t value) {
+	Value result(LogicalType::HUGEINT);
+	result.value_.hugeint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::UUID(hugeint_t value) {
+	Value result(LogicalType::UUID);
+	result.value_.hugeint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::UUID(const string &value) {
+	Value result(LogicalType::UUID);
+	result.value_.hugeint = UUID::FromString(value);
+	result.is_null = false;
+	return result;
+}
+
+Value Value::UTINYINT(uint8_t value) {
+	Value result(LogicalType::UTINYINT);
+	result.value_.utinyint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::USMALLINT(uint16_t value) {
+	Value result(LogicalType::USMALLINT);
+	result.value_.usmallint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::UINTEGER(uint32_t value) {
+	Value result(LogicalType::UINTEGER);
+	result.value_.uinteger = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::UBIGINT(uint64_t value) {
+	Value result(LogicalType::UBIGINT);
+	result.value_.ubigint = value;
+	result.is_null = false;
+	return result;
+}
+
+bool Value::FloatIsFinite(float value) {
+	return !(std::isnan(value) || std::isinf(value));
+}
+
+bool Value::DoubleIsFinite(double value) {
+	return !(std::isnan(value) || std::isinf(value));
+}
+
+template <>
+bool Value::IsNan(float input) {
+	return std::isnan(input);
+}
+
+template <>
+bool Value::IsNan(double input) {
+	return std::isnan(input);
+}
+
+template <>
+bool Value::IsFinite(float input) {
+	return Value::FloatIsFinite(input);
+}
+
+template <>
+bool Value::IsFinite(double input) {
+	return Value::DoubleIsFinite(input);
+}
+
+template <>
+bool Value::IsFinite(date_t input) {
+	return Date::IsFinite(input);
+}
+
+template <>
+bool Value::IsFinite(timestamp_t input) {
+	return Timestamp::IsFinite(input);
+}
+
+bool Value::StringIsValid(const char *str, idx_t length) {
+	auto utf_type = Utf8Proc::Analyze(str, length);
+	return utf_type != UnicodeType::INVALID;
+}
+
+Value Value::DECIMAL(int16_t value, uint8_t width, uint8_t scale) {
+	D_ASSERT(width <= Decimal::MAX_WIDTH_INT16);
+	Value result(LogicalType::DECIMAL(width, scale));
+	result.value_.smallint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DECIMAL(int32_t value, uint8_t width, uint8_t scale) {
+	D_ASSERT(width >= Decimal::MAX_WIDTH_INT16 && width <= Decimal::MAX_WIDTH_INT32);
+	Value result(LogicalType::DECIMAL(width, scale));
+	result.value_.integer = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DECIMAL(int64_t value, uint8_t width, uint8_t scale) {
+	auto decimal_type = LogicalType::DECIMAL(width, scale);
+	Value result(decimal_type);
+	switch (decimal_type.InternalType()) {
+	case PhysicalType::INT16:
+		result.value_.smallint = value;
+		break;
+	case PhysicalType::INT32:
+		result.value_.integer = value;
+		break;
+	case PhysicalType::INT64:
+		result.value_.bigint = value;
+		break;
+	default:
+		result.value_.hugeint = value;
+		break;
+	}
+	result.type_.Verify();
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DECIMAL(hugeint_t value, uint8_t width, uint8_t scale) {
+	D_ASSERT(width >= Decimal::MAX_WIDTH_INT64 && width <= Decimal::MAX_WIDTH_INT128);
+	Value result(LogicalType::DECIMAL(width, scale));
+	result.value_.hugeint = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::FLOAT(float value) {
+	Value result(LogicalType::FLOAT);
+	result.value_.float_ = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DOUBLE(double value) {
+	Value result(LogicalType::DOUBLE);
+	result.value_.double_ = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::HASH(hash_t value) {
+	Value result(LogicalType::HASH);
+	result.value_.hash = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::POINTER(uintptr_t value) {
+	Value result(LogicalType::POINTER);
+	result.value_.pointer = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DATE(date_t value) {
+	Value result(LogicalType::DATE);
+	result.value_.date = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::DATE(int32_t year, int32_t month, int32_t day) {
+	return Value::DATE(Date::FromDate(year, month, day));
+}
+
+Value Value::TIME(dtime_t value) {
+	Value result(LogicalType::TIME);
+	result.value_.time = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMETZ(dtime_t value) {
+	Value result(LogicalType::TIME_TZ);
+	result.value_.time = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIME(int32_t hour, int32_t min, int32_t sec, int32_t micros) {
+	return Value::TIME(Time::FromTime(hour, min, sec, micros));
+}
+
+Value Value::TIMESTAMP(timestamp_t value) {
+	Value result(LogicalType::TIMESTAMP);
+	result.value_.timestamp = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMESTAMPTZ(timestamp_t value) {
+	Value result(LogicalType::TIMESTAMP_TZ);
+	result.value_.timestamp = value;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMESTAMPNS(timestamp_t timestamp) {
+	Value result(LogicalType::TIMESTAMP_NS);
+	result.value_.timestamp = timestamp;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMESTAMPMS(timestamp_t timestamp) {
+	Value result(LogicalType::TIMESTAMP_MS);
+	result.value_.timestamp = timestamp;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMESTAMPSEC(timestamp_t timestamp) {
+	Value result(LogicalType::TIMESTAMP_S);
+	result.value_.timestamp = timestamp;
+	result.is_null = false;
+	return result;
+}
+
+Value Value::TIMESTAMP(date_t date, dtime_t time) {
+	return Value::TIMESTAMP(Timestamp::FromDatetime(date, time));
+}
+
+Value Value::TIMESTAMP(int32_t year, int32_t month, int32_t day, int32_t hour, int32_t min, int32_t sec,
+                       int32_t micros) {
+	auto val = Value::TIMESTAMP(Date::FromDate(year, month, day), Time::FromTime(hour, min, sec, micros));
+	val.type_ = LogicalType::TIMESTAMP;
+	return val;
+}
+
+Value Value::STRUCT(child_list_t<Value> values) {
+	Value result;
+	child_list_t<LogicalType> child_types;
+	for (auto &child : values) {
+		child_types.push_back(make_pair(move(child.first), child.second.type()));
+		result.struct_value.push_back(move(child.second));
+	}
+	result.type_ = LogicalType::STRUCT(move(child_types));
+
+	result.is_null = false;
+	return result;
+}
+
+Value Value::MAP(Value key, Value value) {
+	Value result;
+	child_list_t<LogicalType> child_types;
+	child_types.push_back({"key", key.type()});
+	child_types.push_back({"value", value.type()});
+
+	result.type_ = LogicalType::MAP(move(child_types));
+
+	result.struct_value.push_back(move(key));
+	result.struct_value.push_back(move(value));
+	result.is_null = false;
+	return result;
+}
+
+Value Value::LIST(vector<Value> values) {
+	if (values.empty()) {
+		throw InternalException("Value::LIST requires a non-empty list of values. Use Value::EMPTYLIST instead.");
+	}
+#ifdef DEBUG
+	for (idx_t i = 1; i < values.size(); i++) {
+		D_ASSERT(values[i].type() == values[0].type());
+	}
+#endif
+	Value result;
+	result.type_ = LogicalType::LIST(values[0].type());
+	result.list_value = move(values);
+	result.is_null = false;
+	return result;
+}
+
+Value Value::LIST(LogicalType child_type, vector<Value> values) {
+	if (values.empty()) {
+		return Value::EMPTYLIST(move(child_type));
+	}
+	for (auto &val : values) {
+		val = val.CastAs(child_type);
+	}
+	return Value::LIST(move(values));
+}
+
+Value Value::EMPTYLIST(LogicalType child_type) {
+	Value result;
+	result.type_ = LogicalType::LIST(move(child_type));
+	result.is_null = false;
+	return result;
+}
+
+Value Value::BLOB(const_data_ptr_t data, idx_t len) {
+	Value result(LogicalType::BLOB);
+	result.is_null = false;
+	result.str_value = string((const char *)data, len);
+	return result;
+}
+
+Value Value::BLOB(const string &data) {
+	Value result(LogicalType::BLOB);
+	result.is_null = false;
+	result.str_value = Blob::ToBlob(string_t(data));
+	return result;
+}
+
+Value Value::JSON(const char *val) {
+	auto result = Value(val);
+	result.type_ = LogicalTypeId::JSON;
+	return result;
+}
+
+Value Value::JSON(string_t val) {
+	auto result = Value(val);
+	result.type_ = LogicalTypeId::JSON;
+	return result;
+}
+
+Value Value::JSON(string val) {
+	auto result = Value(move(val));
+	result.type_ = LogicalTypeId::JSON;
+	return result;
+}
+
+Value Value::ENUM(uint64_t value, const LogicalType &original_type) {
+	D_ASSERT(original_type.id() == LogicalTypeId::ENUM);
+	Value result(original_type);
+	switch (original_type.InternalType()) {
+	case PhysicalType::UINT8:
+		result.value_.utinyint = value;
+		break;
+	case PhysicalType::UINT16:
+		result.value_.usmallint = value;
+		break;
+	case PhysicalType::UINT32:
+		result.value_.uinteger = value;
+		break;
+	case PhysicalType::UINT64: //  DEDUP_POINTER_ENUM
+		result.value_.ubigint = value;
+		break;
+	default:
+		throw InternalException("Incorrect Physical Type for ENUM");
+	}
+	result.is_null = false;
+	return result;
+}
+
+Value Value::INTERVAL(int32_t months, int32_t days, int64_t micros) {
+	Value result(LogicalType::INTERVAL);
+	result.is_null = false;
+	result.value_.interval.months = months;
+	result.value_.interval.days = days;
+	result.value_.interval.micros = micros;
+	return result;
+}
+
+Value Value::INTERVAL(interval_t interval) {
+	return Value::INTERVAL(interval.months, interval.days, interval.micros);
+}
+
+//===--------------------------------------------------------------------===//
+// CreateValue
+//===--------------------------------------------------------------------===//
+template <>
+Value Value::CreateValue(bool value) {
+	return Value::BOOLEAN(value);
+}
+
+template <>
+Value Value::CreateValue(int8_t value) {
+	return Value::TINYINT(value);
+}
+
+template <>
+Value Value::CreateValue(int16_t value) {
+	return Value::SMALLINT(value);
+}
+
+template <>
+Value Value::CreateValue(int32_t value) {
+	return Value::INTEGER(value);
+}
+
+template <>
+Value Value::CreateValue(int64_t value) {
+	return Value::BIGINT(value);
+}
+
+template <>
+Value Value::CreateValue(uint8_t value) {
+	return Value::UTINYINT(value);
+}
+
+template <>
+Value Value::CreateValue(uint16_t value) {
+	return Value::USMALLINT(value);
+}
+
+template <>
+Value Value::CreateValue(uint32_t value) {
+	return Value::UINTEGER(value);
+}
+
+template <>
+Value Value::CreateValue(uint64_t value) {
+	return Value::UBIGINT(value);
+}
+
+template <>
+Value Value::CreateValue(hugeint_t value) {
+	return Value::HUGEINT(value);
+}
+
+template <>
+Value Value::CreateValue(date_t value) {
+	return Value::DATE(value);
+}
+
+template <>
+Value Value::CreateValue(dtime_t value) {
+	return Value::TIME(value);
+}
+
+template <>
+Value Value::CreateValue(timestamp_t value) {
+	return Value::TIMESTAMP(value);
+}
+
+template <>
+Value Value::CreateValue(const char *value) {
+	return Value(string(value));
+}
+
+template <>
+Value Value::CreateValue(string value) { // NOLINT: required for templating
+	return Value::BLOB(value);
+}
+
+template <>
+Value Value::CreateValue(string_t value) {
+	return Value(value);
+}
+
+template <>
+Value Value::CreateValue(float value) {
+	return Value::FLOAT(value);
+}
+
+template <>
+Value Value::CreateValue(double value) {
+	return Value::DOUBLE(value);
+}
+
+template <>
+Value Value::CreateValue(interval_t value) {
+	return Value::INTERVAL(value);
+}
+
+template <>
+Value Value::CreateValue(Value value) {
+	return value;
+}
+
+//===--------------------------------------------------------------------===//
+// GetValue
+//===--------------------------------------------------------------------===//
+template <class T>
+T Value::GetValueInternal() const {
+	if (IsNull()) {
+		return NullValue<T>();
+	}
+	switch (type_.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return Cast::Operation<bool, T>(value_.boolean);
+	case LogicalTypeId::TINYINT:
+		return Cast::Operation<int8_t, T>(value_.tinyint);
+	case LogicalTypeId::SMALLINT:
+		return Cast::Operation<int16_t, T>(value_.smallint);
+	case LogicalTypeId::INTEGER:
+		return Cast::Operation<int32_t, T>(value_.integer);
+	case LogicalTypeId::BIGINT:
+		return Cast::Operation<int64_t, T>(value_.bigint);
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UUID:
+		return Cast::Operation<hugeint_t, T>(value_.hugeint);
+	case LogicalTypeId::DATE:
+		return Cast::Operation<date_t, T>(value_.date);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return Cast::Operation<dtime_t, T>(value_.time);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return Cast::Operation<timestamp_t, T>(value_.timestamp);
+	case LogicalTypeId::UTINYINT:
+		return Cast::Operation<uint8_t, T>(value_.utinyint);
+	case LogicalTypeId::USMALLINT:
+		return Cast::Operation<uint16_t, T>(value_.usmallint);
+	case LogicalTypeId::UINTEGER:
+		return Cast::Operation<uint32_t, T>(value_.uinteger);
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::UBIGINT:
+		return Cast::Operation<uint64_t, T>(value_.ubigint);
+	case LogicalTypeId::FLOAT:
+		return Cast::Operation<float, T>(value_.float_);
+	case LogicalTypeId::DOUBLE:
+		return Cast::Operation<double, T>(value_.double_);
+	case LogicalTypeId::VARCHAR:
+		return Cast::Operation<string_t, T>(str_value.c_str());
+	case LogicalTypeId::INTERVAL:
+		return Cast::Operation<interval_t, T>(value_.interval);
+	case LogicalTypeId::DECIMAL:
+		return CastAs(LogicalType::DOUBLE).GetValueInternal<T>();
+	case LogicalTypeId::ENUM: {
+		switch (type_.InternalType()) {
+		case PhysicalType::UINT8:
+			return Cast::Operation<uint8_t, T>(value_.utinyint);
+		case PhysicalType::UINT16:
+			return Cast::Operation<uint16_t, T>(value_.usmallint);
+		case PhysicalType::UINT32:
+			return Cast::Operation<uint32_t, T>(value_.uinteger);
+		default:
+			throw InternalException("Invalid Internal Type for ENUMs");
+		}
+	}
+
+	default:
+		throw NotImplementedException("Unimplemented type \"%s\" for GetValue()", type_.ToString());
+	}
+}
+
+template <>
+bool Value::GetValue() const {
+	return GetValueInternal<int8_t>();
+}
+template <>
+int8_t Value::GetValue() const {
+	return GetValueInternal<int8_t>();
+}
+template <>
+int16_t Value::GetValue() const {
+	return GetValueInternal<int16_t>();
+}
+template <>
+int32_t Value::GetValue() const {
+	if (type_.id() == LogicalTypeId::DATE) {
+		return value_.integer;
+	}
+	return GetValueInternal<int32_t>();
+}
+template <>
+int64_t Value::GetValue() const {
+	switch (type_.id()) {
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return value_.bigint;
+	default:
+		return GetValueInternal<int64_t>();
+	}
+}
+template <>
+hugeint_t Value::GetValue() const {
+	return GetValueInternal<hugeint_t>();
+}
+template <>
+uint8_t Value::GetValue() const {
+	return GetValueInternal<uint8_t>();
+}
+template <>
+uint16_t Value::GetValue() const {
+	return GetValueInternal<uint16_t>();
+}
+template <>
+uint32_t Value::GetValue() const {
+	return GetValueInternal<uint32_t>();
+}
+template <>
+uint64_t Value::GetValue() const {
+	return GetValueInternal<uint64_t>();
+}
+template <>
+string Value::GetValue() const {
+	return ToString();
+}
+template <>
+float Value::GetValue() const {
+	return GetValueInternal<float>();
+}
+template <>
+double Value::GetValue() const {
+	return GetValueInternal<double>();
+}
+template <>
+date_t Value::GetValue() const {
+	return GetValueInternal<date_t>();
+}
+template <>
+dtime_t Value::GetValue() const {
+	return GetValueInternal<dtime_t>();
+}
+template <>
+timestamp_t Value::GetValue() const {
+	return GetValueInternal<timestamp_t>();
+}
+
+template <>
+DUCKDB_API interval_t Value::GetValue() const {
+	return GetValueInternal<interval_t>();
+}
+
+template <>
+DUCKDB_API Value Value::GetValue() const {
+	return Value(*this);
+}
+
+uintptr_t Value::GetPointer() const {
+	D_ASSERT(type() == LogicalType::POINTER);
+	return value_.pointer;
+}
+
+Value Value::Numeric(const LogicalType &type, int64_t value) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		D_ASSERT(value == 0 || value == 1);
+		return Value::BOOLEAN(value ? 1 : 0);
+	case LogicalTypeId::TINYINT:
+		D_ASSERT(value >= NumericLimits<int8_t>::Minimum() && value <= NumericLimits<int8_t>::Maximum());
+		return Value::TINYINT((int8_t)value);
+	case LogicalTypeId::SMALLINT:
+		D_ASSERT(value >= NumericLimits<int16_t>::Minimum() && value <= NumericLimits<int16_t>::Maximum());
+		return Value::SMALLINT((int16_t)value);
+	case LogicalTypeId::INTEGER:
+		D_ASSERT(value >= NumericLimits<int32_t>::Minimum() && value <= NumericLimits<int32_t>::Maximum());
+		return Value::INTEGER((int32_t)value);
+	case LogicalTypeId::BIGINT:
+		return Value::BIGINT(value);
+	case LogicalTypeId::UTINYINT:
+		D_ASSERT(value >= NumericLimits<uint8_t>::Minimum() && value <= NumericLimits<uint8_t>::Maximum());
+		return Value::UTINYINT((uint8_t)value);
+	case LogicalTypeId::USMALLINT:
+		D_ASSERT(value >= NumericLimits<uint16_t>::Minimum() && value <= NumericLimits<uint16_t>::Maximum());
+		return Value::USMALLINT((uint16_t)value);
+	case LogicalTypeId::UINTEGER:
+		D_ASSERT(value >= NumericLimits<uint32_t>::Minimum() && value <= NumericLimits<uint32_t>::Maximum());
+		return Value::UINTEGER((uint32_t)value);
+	case LogicalTypeId::UBIGINT:
+		D_ASSERT(value >= 0);
+		return Value::UBIGINT(value);
+	case LogicalTypeId::HUGEINT:
+		return Value::HUGEINT(value);
+	case LogicalTypeId::DECIMAL:
+		return Value::DECIMAL(value, DecimalType::GetWidth(type), DecimalType::GetScale(type));
+	case LogicalTypeId::FLOAT:
+		return Value((float)value);
+	case LogicalTypeId::DOUBLE:
+		return Value((double)value);
+	case LogicalTypeId::POINTER:
+		return Value::POINTER(value);
+	case LogicalTypeId::DATE:
+		D_ASSERT(value >= NumericLimits<int32_t>::Minimum() && value <= NumericLimits<int32_t>::Maximum());
+		return Value::DATE(date_t(value));
+	case LogicalTypeId::TIME:
+		return Value::TIME(dtime_t(value));
+	case LogicalTypeId::TIMESTAMP:
+		return Value::TIMESTAMP(timestamp_t(value));
+	case LogicalTypeId::TIMESTAMP_NS:
+		return Value::TIMESTAMPNS(timestamp_t(value));
+	case LogicalTypeId::TIMESTAMP_MS:
+		return Value::TIMESTAMPMS(timestamp_t(value));
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return Value::TIMESTAMPSEC(timestamp_t(value));
+	case LogicalTypeId::TIME_TZ:
+		return Value::TIMETZ(dtime_t(value));
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return Value::TIMESTAMPTZ(timestamp_t(value));
+	case LogicalTypeId::ENUM:
+		switch (type.InternalType()) {
+		case PhysicalType::UINT8:
+			D_ASSERT(value >= NumericLimits<uint8_t>::Minimum() && value <= NumericLimits<uint8_t>::Maximum());
+			return Value::UTINYINT((uint8_t)value);
+		case PhysicalType::UINT16:
+			D_ASSERT(value >= NumericLimits<uint16_t>::Minimum() && value <= NumericLimits<uint16_t>::Maximum());
+			return Value::USMALLINT((uint16_t)value);
+		case PhysicalType::UINT32:
+			D_ASSERT(value >= NumericLimits<uint32_t>::Minimum() && value <= NumericLimits<uint32_t>::Maximum());
+			return Value::UINTEGER((uint32_t)value);
+		default:
+			throw InternalException("Enum doesn't accept this physical type");
+		}
+	default:
+		throw InvalidTypeException(type, "Numeric requires numeric type");
+	}
+}
+
+Value Value::Numeric(const LogicalType &type, hugeint_t value) {
+#ifdef DEBUG
+	// perform a throwing cast to verify that the type fits
+	Value::HUGEINT(value).CastAs(type);
+#endif
+	switch (type.id()) {
+	case LogicalTypeId::HUGEINT:
+		return Value::HUGEINT(value);
+	case LogicalTypeId::UBIGINT:
+		return Value::UBIGINT(Hugeint::Cast<uint64_t>(value));
+	default:
+		return Value::Numeric(type, Hugeint::Cast<int64_t>(value));
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// GetValueUnsafe
+//===--------------------------------------------------------------------===//
+template <>
+DUCKDB_API bool Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::BOOL);
+	return value_.boolean;
+}
+
+template <>
+int8_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT8 || type_.InternalType() == PhysicalType::BOOL);
+	return value_.tinyint;
+}
+
+template <>
+int16_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT16);
+	return value_.smallint;
+}
+
+template <>
+int32_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT32);
+	return value_.integer;
+}
+
+template <>
+int64_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.bigint;
+}
+
+template <>
+hugeint_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT128);
+	return value_.hugeint;
+}
+
+template <>
+uint8_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT8);
+	return value_.utinyint;
+}
+
+template <>
+uint16_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT16);
+	return value_.usmallint;
+}
+
+template <>
+uint32_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT32);
+	return value_.uinteger;
+}
+
+template <>
+uint64_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT64);
+	return value_.ubigint;
+}
+
+template <>
+string Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::VARCHAR);
+	return str_value;
+}
+
+template <>
+DUCKDB_API string_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::VARCHAR);
+	return string_t(str_value);
+}
+
+template <>
+float Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::FLOAT);
+	return value_.float_;
+}
+
+template <>
+double Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::DOUBLE);
+	return value_.double_;
+}
+
+template <>
+date_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT32);
+	return value_.date;
+}
+
+template <>
+dtime_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.time;
+}
+
+template <>
+timestamp_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.timestamp;
+}
+
+template <>
+interval_t Value::GetValueUnsafe() const {
+	D_ASSERT(type_.InternalType() == PhysicalType::INTERVAL);
+	return value_.interval;
+}
+
+//===--------------------------------------------------------------------===//
+// GetReferenceUnsafe
+//===--------------------------------------------------------------------===//
+template <>
+int8_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT8 || type_.InternalType() == PhysicalType::BOOL);
+	return value_.tinyint;
+}
+
+template <>
+int16_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT16);
+	return value_.smallint;
+}
+
+template <>
+int32_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT32);
+	return value_.integer;
+}
+
+template <>
+int64_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.bigint;
+}
+
+template <>
+hugeint_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT128);
+	return value_.hugeint;
+}
+
+template <>
+uint8_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT8);
+	return value_.utinyint;
+}
+
+template <>
+uint16_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT16);
+	return value_.usmallint;
+}
+
+template <>
+uint32_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT32);
+	return value_.uinteger;
+}
+
+template <>
+uint64_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::UINT64);
+	return value_.ubigint;
+}
+
+template <>
+float &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::FLOAT);
+	return value_.float_;
+}
+
+template <>
+double &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::DOUBLE);
+	return value_.double_;
+}
+
+template <>
+date_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT32);
+	return value_.date;
+}
+
+template <>
+dtime_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.time;
+}
+
+template <>
+timestamp_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT64);
+	return value_.timestamp;
+}
+
+template <>
+interval_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INTERVAL);
+	return value_.interval;
+}
+
+//===--------------------------------------------------------------------===//
+// Hash
+//===--------------------------------------------------------------------===//
+hash_t Value::Hash() const {
+	if (IsNull()) {
+		return 0;
+	}
+	switch (type_.InternalType()) {
+	case PhysicalType::BOOL:
+		return duckdb::Hash(value_.boolean);
+	case PhysicalType::INT8:
+		return duckdb::Hash(value_.tinyint);
+	case PhysicalType::INT16:
+		return duckdb::Hash(value_.smallint);
+	case PhysicalType::INT32:
+		return duckdb::Hash(value_.integer);
+	case PhysicalType::INT64:
+		return duckdb::Hash(value_.bigint);
+	case PhysicalType::UINT8:
+		return duckdb::Hash(value_.utinyint);
+	case PhysicalType::UINT16:
+		return duckdb::Hash(value_.usmallint);
+	case PhysicalType::UINT32:
+		return duckdb::Hash(value_.uinteger);
+	case PhysicalType::UINT64:
+		return duckdb::Hash(value_.ubigint);
+	case PhysicalType::INT128:
+		return duckdb::Hash(value_.hugeint);
+	case PhysicalType::FLOAT:
+		return duckdb::Hash(value_.float_);
+	case PhysicalType::DOUBLE:
+		return duckdb::Hash(value_.double_);
+	case PhysicalType::INTERVAL:
+		return duckdb::Hash(value_.interval);
+	case PhysicalType::VARCHAR:
+		return duckdb::Hash(string_t(StringValue::Get(*this)));
+	case PhysicalType::STRUCT: {
+		auto &struct_children = StructValue::GetChildren(*this);
+		hash_t hash = 0;
+		for (auto &entry : struct_children) {
+			hash ^= entry.Hash();
+		}
+		return hash;
+	}
+	case PhysicalType::LIST: {
+		auto &list_children = ListValue::GetChildren(*this);
+		hash_t hash = 0;
+		for (auto &entry : list_children) {
+			hash ^= entry.Hash();
+		}
+		return hash;
+	}
+	default:
+		throw InternalException("Unimplemented type for value hash");
+	}
+}
+
+string Value::ToString() const {
+	if (IsNull()) {
+		return "NULL";
+	}
+	switch (type_.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return value_.boolean ? "True" : "False";
+	case LogicalTypeId::TINYINT:
+		return to_string(value_.tinyint);
+	case LogicalTypeId::SMALLINT:
+		return to_string(value_.smallint);
+	case LogicalTypeId::INTEGER:
+		return to_string(value_.integer);
+	case LogicalTypeId::BIGINT:
+		return to_string(value_.bigint);
+	case LogicalTypeId::UTINYINT:
+		return to_string(value_.utinyint);
+	case LogicalTypeId::USMALLINT:
+		return to_string(value_.usmallint);
+	case LogicalTypeId::UINTEGER:
+		return to_string(value_.uinteger);
+	case LogicalTypeId::UBIGINT:
+		return to_string(value_.ubigint);
+	case LogicalTypeId::HUGEINT:
+		return Hugeint::ToString(value_.hugeint);
+	case LogicalTypeId::UUID:
+		return UUID::ToString(value_.hugeint);
+	case LogicalTypeId::FLOAT:
+		return duckdb_fmt::format("{}", value_.float_);
+	case LogicalTypeId::DOUBLE:
+		return duckdb_fmt::format("{}", value_.double_);
+	case LogicalTypeId::DECIMAL: {
+		auto internal_type = type_.InternalType();
+		auto scale = DecimalType::GetScale(type_);
+		if (internal_type == PhysicalType::INT16) {
+			return Decimal::ToString(value_.smallint, scale);
+		} else if (internal_type == PhysicalType::INT32) {
+			return Decimal::ToString(value_.integer, scale);
+		} else if (internal_type == PhysicalType::INT64) {
+			return Decimal::ToString(value_.bigint, scale);
+		} else {
+			D_ASSERT(internal_type == PhysicalType::INT128);
+			return Decimal::ToString(value_.hugeint, scale);
+		}
+	}
+	case LogicalTypeId::DATE:
+		return Date::ToString(value_.date);
+	case LogicalTypeId::TIME:
+		return Time::ToString(value_.time);
+	case LogicalTypeId::TIMESTAMP:
+		return Timestamp::ToString(value_.timestamp);
+	case LogicalTypeId::TIME_TZ:
+		return Time::ToString(value_.time) + Time::ToUTCOffset(0, 0);
+	case LogicalTypeId::TIMESTAMP_TZ: {
+		// Infinite TSTZ values do not display offsets in PG.
+		auto ret = Timestamp::ToString(value_.timestamp);
+		if (Timestamp::IsFinite(value_.timestamp)) {
+			ret += Time::ToUTCOffset(0, 0);
+		}
+		return ret;
+	}
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return Timestamp::ToString(Timestamp::FromEpochSeconds(value_.timestamp.value));
+	case LogicalTypeId::TIMESTAMP_MS:
+		return Timestamp::ToString(Timestamp::FromEpochMs(value_.timestamp.value));
+	case LogicalTypeId::TIMESTAMP_NS:
+		return Timestamp::ToString(Timestamp::FromEpochNanoSeconds(value_.timestamp.value));
+	case LogicalTypeId::INTERVAL:
+		return Interval::ToString(value_.interval);
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR:
+		return str_value;
+	case LogicalTypeId::BLOB:
+		return Blob::ToString(string_t(str_value));
+	case LogicalTypeId::POINTER:
+		return to_string(value_.pointer);
+	case LogicalTypeId::STRUCT: {
+		string ret = "{";
+		auto &child_types = StructType::GetChildTypes(type_);
+		for (size_t i = 0; i < struct_value.size(); i++) {
+			auto &name = child_types[i].first;
+			auto &child = struct_value[i];
+			ret += "'" + name + "': " + child.ToString();
+			if (i < struct_value.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += "}";
+		return ret;
+	}
+	case LogicalTypeId::LIST: {
+		string ret = "[";
+		for (size_t i = 0; i < list_value.size(); i++) {
+			auto &child = list_value[i];
+			ret += child.ToString();
+			if (i < list_value.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += "]";
+		return ret;
+	}
+	case LogicalTypeId::MAP: {
+		string ret = "{";
+		auto &key_list = struct_value[0].list_value;
+		auto &value_list = struct_value[1].list_value;
+		for (size_t i = 0; i < key_list.size(); i++) {
+			ret += key_list[i].ToString() + "=" + value_list[i].ToString();
+			if (i < key_list.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += "}";
+		return ret;
+	}
+	case LogicalTypeId::ENUM: {
+		auto &values_insert_order = EnumType::GetValuesInsertOrder(type_);
+		uint64_t enum_idx;
+		switch (type_.InternalType()) {
+		case PhysicalType::UINT8:
+			enum_idx = value_.utinyint;
+			break;
+		case PhysicalType::UINT16:
+			enum_idx = value_.usmallint;
+			break;
+		case PhysicalType::UINT32:
+			enum_idx = value_.uinteger;
+			break;
+		case PhysicalType::UINT64:
+			return string((const char *)value_.bigint);
+		default:
+			throw InternalException("ENUM can only have unsigned integers as physical types");
+		}
+		return values_insert_order.GetValue(enum_idx).ToString();
+	}
+	default:
+		throw NotImplementedException("Unimplemented type for printing: %s", type_.ToString());
+	}
+}
+
+string Value::ToSQLString() const {
+	if (IsNull()) {
+		return ToString();
+	}
+	switch (type_.id()) {
+	case LogicalTypeId::UUID:
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::INTERVAL:
+	case LogicalTypeId::BLOB:
+		return "'" + ToString() + "'::" + type_.ToString();
+	case LogicalTypeId::VARCHAR:
+		return "'" + StringUtil::Replace(ToString(), "'", "''") + "'";
+	case LogicalTypeId::STRUCT: {
+		string ret = "{";
+		auto &child_types = StructType::GetChildTypes(type_);
+		for (size_t i = 0; i < struct_value.size(); i++) {
+			auto &name = child_types[i].first;
+			auto &child = struct_value[i];
+			ret += "'" + name + "': " + child.ToSQLString();
+			if (i < struct_value.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += "}";
+		return ret;
+	}
+	case LogicalTypeId::FLOAT:
+		if (!FloatIsFinite(FloatValue::Get(*this))) {
+			return "'" + ToString() + "'::" + type_.ToString();
+		}
+		return ToString();
+	case LogicalTypeId::DOUBLE: {
+		double val = DoubleValue::Get(*this);
+		if (!DoubleIsFinite(val)) {
+			if (!Value::IsNan(val)) {
+				// to infinity and beyond
+				return val < 0 ? "-1e1000" : "1e1000";
+			}
+			return "'" + ToString() + "'::" + type_.ToString();
+		}
+		return ToString();
+	}
+	case LogicalTypeId::LIST: {
+		string ret = "[";
+		for (size_t i = 0; i < list_value.size(); i++) {
+			auto &child = list_value[i];
+			ret += child.ToSQLString();
+			if (i < list_value.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += "]";
+		return ret;
+	}
+	default:
+		return ToString();
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Type-specific getters
+//===--------------------------------------------------------------------===//
+bool BooleanValue::Get(const Value &value) {
+	return value.GetValueUnsafe<bool>();
+}
+
+int8_t TinyIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<int8_t>();
+}
+
+int16_t SmallIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<int16_t>();
+}
+
+int32_t IntegerValue::Get(const Value &value) {
+	return value.GetValueUnsafe<int32_t>();
+}
+
+int64_t BigIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<int64_t>();
+}
+
+hugeint_t HugeIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<hugeint_t>();
+}
+
+uint8_t UTinyIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<uint8_t>();
+}
+
+uint16_t USmallIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<uint16_t>();
+}
+
+uint32_t UIntegerValue::Get(const Value &value) {
+	return value.GetValueUnsafe<uint32_t>();
+}
+
+uint64_t UBigIntValue::Get(const Value &value) {
+	return value.GetValueUnsafe<uint64_t>();
+}
+
+float FloatValue::Get(const Value &value) {
+	return value.GetValueUnsafe<float>();
+}
+
+double DoubleValue::Get(const Value &value) {
+	return value.GetValueUnsafe<double>();
+}
+
+const string &StringValue::Get(const Value &value) {
+	D_ASSERT(value.type().InternalType() == PhysicalType::VARCHAR);
+	return value.str_value;
+}
+
+date_t DateValue::Get(const Value &value) {
+	return value.GetValueUnsafe<date_t>();
+}
+
+dtime_t TimeValue::Get(const Value &value) {
+	return value.GetValueUnsafe<dtime_t>();
+}
+
+timestamp_t TimestampValue::Get(const Value &value) {
+	return value.GetValueUnsafe<timestamp_t>();
+}
+
+interval_t IntervalValue::Get(const Value &value) {
+	return value.GetValueUnsafe<interval_t>();
+}
+
+const vector<Value> &StructValue::GetChildren(const Value &value) {
+	D_ASSERT(value.type().InternalType() == PhysicalType::STRUCT);
+	return value.struct_value;
+}
+
+const vector<Value> &ListValue::GetChildren(const Value &value) {
+	D_ASSERT(value.type().InternalType() == PhysicalType::LIST);
+	return value.list_value;
+}
+
+hugeint_t IntegralValue::Get(const Value &value) {
+	switch (value.type().InternalType()) {
+	case PhysicalType::INT8:
+		return TinyIntValue::Get(value);
+	case PhysicalType::INT16:
+		return SmallIntValue::Get(value);
+	case PhysicalType::INT32:
+		return IntegerValue::Get(value);
+	case PhysicalType::INT64:
+		return BigIntValue::Get(value);
+	case PhysicalType::INT128:
+		return HugeIntValue::Get(value);
+	case PhysicalType::UINT8:
+		return UTinyIntValue::Get(value);
+	case PhysicalType::UINT16:
+		return USmallIntValue::Get(value);
+	case PhysicalType::UINT32:
+		return UIntegerValue::Get(value);
+	case PhysicalType::UINT64:
+		return UBigIntValue::Get(value);
+	default:
+		throw InternalException("Invalid internal type \"%s\" for IntegralValue::Get", value.type().ToString());
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Comparison Operators
+//===--------------------------------------------------------------------===//
+bool Value::operator==(const Value &rhs) const {
+	return ValueOperations::Equals(*this, rhs);
+}
+
+bool Value::operator!=(const Value &rhs) const {
+	return ValueOperations::NotEquals(*this, rhs);
+}
+
+bool Value::operator<(const Value &rhs) const {
+	return ValueOperations::LessThan(*this, rhs);
+}
+
+bool Value::operator>(const Value &rhs) const {
+	return ValueOperations::GreaterThan(*this, rhs);
+}
+
+bool Value::operator<=(const Value &rhs) const {
+	return ValueOperations::LessThanEquals(*this, rhs);
+}
+
+bool Value::operator>=(const Value &rhs) const {
+	return ValueOperations::GreaterThanEquals(*this, rhs);
+}
+
+bool Value::operator==(const int64_t &rhs) const {
+	return *this == Value::Numeric(type_, rhs);
+}
+
+bool Value::operator!=(const int64_t &rhs) const {
+	return *this != Value::Numeric(type_, rhs);
+}
+
+bool Value::operator<(const int64_t &rhs) const {
+	return *this < Value::Numeric(type_, rhs);
+}
+
+bool Value::operator>(const int64_t &rhs) const {
+	return *this > Value::Numeric(type_, rhs);
+}
+
+bool Value::operator<=(const int64_t &rhs) const {
+	return *this <= Value::Numeric(type_, rhs);
+}
+
+bool Value::operator>=(const int64_t &rhs) const {
+	return *this >= Value::Numeric(type_, rhs);
+}
+
+bool Value::TryCastAs(const LogicalType &target_type, Value &new_value, string *error_message, bool strict) const {
+	if (type_ == target_type) {
+		new_value = Copy();
+		return true;
+	}
+	Vector input(*this);
+	Vector result(target_type);
+	if (!VectorOperations::TryCast(input, result, 1, error_message, strict)) {
+		return false;
+	}
+	new_value = result.GetValue(0);
+	return true;
+}
+
+Value Value::CastAs(const LogicalType &target_type, bool strict) const {
+	Value new_value;
+	string error_message;
+	if (!TryCastAs(target_type, new_value, &error_message, strict)) {
+		throw InvalidInputException("Failed to cast value: %s", error_message);
+	}
+	return new_value;
+}
+
+bool Value::TryCastAs(const LogicalType &target_type, bool strict) {
+	Value new_value;
+	string error_message;
+	if (!TryCastAs(target_type, new_value, &error_message, strict)) {
+		return false;
+	}
+	type_ = target_type;
+	is_null = new_value.is_null;
+	value_ = new_value.value_;
+	str_value = new_value.str_value;
+	struct_value = new_value.struct_value;
+	list_value = new_value.list_value;
+	return true;
+}
+
+void Value::Serialize(Serializer &main_serializer) const {
+	FieldWriter writer(main_serializer);
+	writer.WriteSerializable(type_);
+	writer.WriteField<bool>(IsNull());
+	if (!IsNull()) {
+		auto &serializer = writer.GetSerializer();
+		switch (type_.InternalType()) {
+		case PhysicalType::BOOL:
+			serializer.Write<int8_t>(value_.boolean);
+			break;
+		case PhysicalType::INT8:
+			serializer.Write<int8_t>(value_.tinyint);
+			break;
+		case PhysicalType::INT16:
+			serializer.Write<int16_t>(value_.smallint);
+			break;
+		case PhysicalType::INT32:
+			serializer.Write<int32_t>(value_.integer);
+			break;
+		case PhysicalType::INT64:
+			serializer.Write<int64_t>(value_.bigint);
+			break;
+		case PhysicalType::UINT8:
+			serializer.Write<uint8_t>(value_.utinyint);
+			break;
+		case PhysicalType::UINT16:
+			serializer.Write<uint16_t>(value_.usmallint);
+			break;
+		case PhysicalType::UINT32:
+			serializer.Write<uint32_t>(value_.uinteger);
+			break;
+		case PhysicalType::UINT64:
+			serializer.Write<uint64_t>(value_.ubigint);
+			break;
+		case PhysicalType::INT128:
+			serializer.Write<hugeint_t>(value_.hugeint);
+			break;
+		case PhysicalType::FLOAT:
+			serializer.Write<float>(value_.float_);
+			break;
+		case PhysicalType::DOUBLE:
+			serializer.Write<double>(value_.double_);
+			break;
+		case PhysicalType::INTERVAL:
+			serializer.Write<interval_t>(value_.interval);
+			break;
+		case PhysicalType::VARCHAR:
+			serializer.WriteString(str_value);
+			break;
+		default: {
+			Vector v(*this);
+			v.Serialize(1, serializer);
+			break;
+		}
+		}
+	}
+	writer.Finalize();
+}
+
+Value Value::Deserialize(Deserializer &main_source) {
+	FieldReader reader(main_source);
+	auto type = reader.ReadRequiredSerializable<LogicalType, LogicalType>();
+	auto is_null = reader.ReadRequired<bool>();
+	Value new_value = Value(type);
+	if (is_null) {
+		reader.Finalize();
+		return new_value;
+	}
+	new_value.is_null = false;
+	auto &source = reader.GetSource();
+	switch (type.InternalType()) {
+	case PhysicalType::BOOL:
+		new_value.value_.boolean = source.Read<int8_t>();
+		break;
+	case PhysicalType::INT8:
+		new_value.value_.tinyint = source.Read<int8_t>();
+		break;
+	case PhysicalType::INT16:
+		new_value.value_.smallint = source.Read<int16_t>();
+		break;
+	case PhysicalType::INT32:
+		new_value.value_.integer = source.Read<int32_t>();
+		break;
+	case PhysicalType::INT64:
+		new_value.value_.bigint = source.Read<int64_t>();
+		break;
+	case PhysicalType::UINT8:
+		new_value.value_.utinyint = source.Read<uint8_t>();
+		break;
+	case PhysicalType::UINT16:
+		new_value.value_.usmallint = source.Read<uint16_t>();
+		break;
+	case PhysicalType::UINT32:
+		new_value.value_.uinteger = source.Read<uint32_t>();
+		break;
+	case PhysicalType::UINT64:
+		new_value.value_.ubigint = source.Read<uint64_t>();
+		break;
+	case PhysicalType::INT128:
+		new_value.value_.hugeint = source.Read<hugeint_t>();
+		break;
+	case PhysicalType::FLOAT:
+		new_value.value_.float_ = source.Read<float>();
+		break;
+	case PhysicalType::DOUBLE:
+		new_value.value_.double_ = source.Read<double>();
+		break;
+	case PhysicalType::INTERVAL:
+		new_value.value_.interval = source.Read<interval_t>();
+		break;
+	case PhysicalType::VARCHAR:
+		new_value.str_value = source.Read<string>();
+		break;
+	default: {
+		Vector v(type);
+		v.Deserialize(1, source);
+		new_value = v.GetValue(0);
+		break;
+	}
+	}
+	reader.Finalize();
+	return new_value;
+}
+
+void Value::Print() const {
+	Printer::Print(ToString());
+}
+
+bool Value::NotDistinctFrom(const Value &lvalue, const Value &rvalue) {
+	return ValueOperations::NotDistinctFrom(lvalue, rvalue);
+}
+
+bool Value::ValuesAreEqual(const Value &result_value, const Value &value) {
+	if (result_value.IsNull() != value.IsNull()) {
+		return false;
+	}
+	if (result_value.IsNull() && value.IsNull()) {
+		// NULL = NULL in checking code
+		return true;
+	}
+	switch (value.type_.id()) {
+	case LogicalTypeId::FLOAT: {
+		auto other = result_value.CastAs(LogicalType::FLOAT);
+		float ldecimal = value.value_.float_;
+		float rdecimal = other.value_.float_;
+		return ApproxEqual(ldecimal, rdecimal);
+	}
+	case LogicalTypeId::DOUBLE: {
+		auto other = result_value.CastAs(LogicalType::DOUBLE);
+		double ldecimal = value.value_.double_;
+		double rdecimal = other.value_.double_;
+		return ApproxEqual(ldecimal, rdecimal);
+	}
+	case LogicalTypeId::VARCHAR: {
+		auto other = result_value.CastAs(LogicalType::VARCHAR);
+		// some results might contain padding spaces, e.g. when rendering
+		// VARCHAR(10) and the string only has 6 characters, they will be padded
+		// with spaces to 10 in the rendering. We don't do that here yet as we
+		// are looking at internal structures. So just ignore any extra spaces
+		// on the right
+		string left = other.str_value;
+		string right = value.str_value;
+		StringUtil::RTrim(left);
+		StringUtil::RTrim(right);
+		return left == right;
+	}
+	default:
+		if (result_value.type_.id() == LogicalTypeId::FLOAT || result_value.type_.id() == LogicalTypeId::DOUBLE) {
+			return Value::ValuesAreEqual(value, result_value);
+		}
+		return value == result_value;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cstring> // strlen() on Solaris
+
+namespace duckdb {
+
+Vector::Vector(LogicalType type_p, bool create_data, bool zero_data, idx_t capacity)
+    : vector_type(VectorType::FLAT_VECTOR), type(move(type_p)), data(nullptr) {
+	if (create_data) {
+		Initialize(zero_data, capacity);
+	}
+}
+
+Vector::Vector(LogicalType type_p, idx_t capacity) : Vector(move(type_p), true, false, capacity) {
+}
+
+Vector::Vector(LogicalType type_p, data_ptr_t dataptr)
+    : vector_type(VectorType::FLAT_VECTOR), type(move(type_p)), data(dataptr) {
+	if (dataptr && type.id() == LogicalTypeId::INVALID) {
+		throw InternalException("Cannot create a vector of type INVALID!");
+	}
+}
+
+Vector::Vector(const VectorCache &cache) : type(cache.GetType()) {
+	ResetFromCache(cache);
+}
+
+Vector::Vector(Vector &other) : type(other.type) {
+	Reference(other);
+}
+
+Vector::Vector(Vector &other, const SelectionVector &sel, idx_t count) : type(other.type) {
+	Slice(other, sel, count);
+}
+
+Vector::Vector(Vector &other, idx_t offset) : type(other.type) {
+	Slice(other, offset);
+}
+
+Vector::Vector(const Value &value) : type(value.type()) {
+	Reference(value);
+}
+
+Vector::Vector(Vector &&other) noexcept
+    : vector_type(other.vector_type), type(move(other.type)), data(other.data), validity(move(other.validity)),
+      buffer(move(other.buffer)), auxiliary(move(other.auxiliary)) {
+}
+
+void Vector::Reference(const Value &value) {
+	D_ASSERT(GetType().id() == value.type().id());
+	this->vector_type = VectorType::CONSTANT_VECTOR;
+	buffer = VectorBuffer::CreateConstantVector(value.type());
+	auto internal_type = value.type().InternalType();
+	if (internal_type == PhysicalType::STRUCT) {
+		auto struct_buffer = make_unique<VectorStructBuffer>();
+		auto &child_types = StructType::GetChildTypes(value.type());
+		auto &child_vectors = struct_buffer->GetChildren();
+		auto &value_children = StructValue::GetChildren(value);
+		for (idx_t i = 0; i < child_types.size(); i++) {
+			auto vector = make_unique<Vector>(value.IsNull() ? Value(child_types[i].second) : value_children[i]);
+			child_vectors.push_back(move(vector));
+		}
+		auxiliary = move(struct_buffer);
+		if (value.IsNull()) {
+			SetValue(0, value);
+		}
+	} else if (internal_type == PhysicalType::LIST) {
+		auto list_buffer = make_unique<VectorListBuffer>(value.type());
+		auxiliary = move(list_buffer);
+		data = buffer->GetData();
+		SetValue(0, value);
+	} else {
+		auxiliary.reset();
+		data = buffer->GetData();
+		SetValue(0, value);
+	}
+}
+
+void Vector::Reference(Vector &other) {
+	D_ASSERT(other.GetType() == GetType());
+	Reinterpret(other);
+}
+
+void Vector::ReferenceAndSetType(Vector &other) {
+	type = other.GetType();
+	Reference(other);
+}
+
+void Vector::Reinterpret(Vector &other) {
+	vector_type = other.vector_type;
+	AssignSharedPointer(buffer, other.buffer);
+	AssignSharedPointer(auxiliary, other.auxiliary);
+	data = other.data;
+	validity = other.validity;
+}
+
+void Vector::ResetFromCache(const VectorCache &cache) {
+	cache.ResetFromCache(*this);
+}
+
+void Vector::Slice(Vector &other, idx_t offset) {
+	if (other.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		Reference(other);
+		return;
+	}
+	D_ASSERT(other.GetVectorType() == VectorType::FLAT_VECTOR);
+
+	auto internal_type = GetType().InternalType();
+	if (internal_type == PhysicalType::STRUCT) {
+		Vector new_vector(GetType());
+		auto &entries = StructVector::GetEntries(new_vector);
+		auto &other_entries = StructVector::GetEntries(other);
+		D_ASSERT(entries.size() == other_entries.size());
+		for (idx_t i = 0; i < entries.size(); i++) {
+			entries[i]->Slice(*other_entries[i], offset);
+		}
+		if (offset > 0) {
+			new_vector.validity.Slice(other.validity, offset);
+		} else {
+			new_vector.validity = other.validity;
+		}
+		Reference(new_vector);
+	} else {
+		Reference(other);
+		if (offset > 0) {
+			data = data + GetTypeIdSize(internal_type) * offset;
+			validity.Slice(other.validity, offset);
+		}
+	}
+}
+
+void Vector::Slice(Vector &other, const SelectionVector &sel, idx_t count) {
+	Reference(other);
+	Slice(sel, count);
+}
+
+void Vector::Slice(const SelectionVector &sel, idx_t count) {
+	if (GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// dictionary on a constant is just a constant
+		return;
+	}
+	if (GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		// already a dictionary, slice the current dictionary
+		auto &current_sel = DictionaryVector::SelVector(*this);
+		auto sliced_dictionary = current_sel.Slice(sel, count);
+		buffer = make_buffer<DictionaryBuffer>(move(sliced_dictionary));
+		if (GetType().InternalType() == PhysicalType::STRUCT) {
+			auto &child_vector = DictionaryVector::Child(*this);
+
+			Vector new_child(child_vector);
+			new_child.auxiliary = make_buffer<VectorStructBuffer>(new_child, sel, count);
+			auxiliary = make_buffer<VectorChildBuffer>(move(new_child));
+		}
+		return;
+	}
+	Vector child_vector(*this);
+	auto internal_type = GetType().InternalType();
+	if (internal_type == PhysicalType::STRUCT) {
+		child_vector.auxiliary = make_buffer<VectorStructBuffer>(*this, sel, count);
+	}
+	auto child_ref = make_buffer<VectorChildBuffer>(move(child_vector));
+	auto dict_buffer = make_buffer<DictionaryBuffer>(sel);
+	vector_type = VectorType::DICTIONARY_VECTOR;
+	buffer = move(dict_buffer);
+	auxiliary = move(child_ref);
+}
+
+void Vector::Slice(const SelectionVector &sel, idx_t count, SelCache &cache) {
+	if (GetVectorType() == VectorType::DICTIONARY_VECTOR && GetType().InternalType() != PhysicalType::STRUCT) {
+		// dictionary vector: need to merge dictionaries
+		// check if we have a cached entry
+		auto &current_sel = DictionaryVector::SelVector(*this);
+		auto target_data = current_sel.data();
+		auto entry = cache.cache.find(target_data);
+		if (entry != cache.cache.end()) {
+			// cached entry exists: use that
+			this->buffer = make_buffer<DictionaryBuffer>(((DictionaryBuffer &)*entry->second).GetSelVector());
+			vector_type = VectorType::DICTIONARY_VECTOR;
+		} else {
+			Slice(sel, count);
+			cache.cache[target_data] = this->buffer;
+		}
+	} else {
+		Slice(sel, count);
+	}
+}
+
+void Vector::Initialize(bool zero_data, idx_t capacity) {
+	auxiliary.reset();
+	validity.Reset();
+	auto &type = GetType();
+	auto internal_type = type.InternalType();
+	if (internal_type == PhysicalType::STRUCT) {
+		auto struct_buffer = make_unique<VectorStructBuffer>(type, capacity);
+		auxiliary = move(struct_buffer);
+	} else if (internal_type == PhysicalType::LIST) {
+		auto list_buffer = make_unique<VectorListBuffer>(type, capacity);
+		auxiliary = move(list_buffer);
+	}
+	auto type_size = GetTypeIdSize(internal_type);
+	if (type_size > 0) {
+		buffer = VectorBuffer::CreateStandardVector(type, capacity);
+		data = buffer->GetData();
+		if (zero_data) {
+			memset(data, 0, capacity * type_size);
+		}
+	}
+}
+
+struct DataArrays {
+	Vector &vec;
+	data_ptr_t data;
+	VectorBuffer *buffer;
+	idx_t type_size;
+	bool is_nested;
+	DataArrays(Vector &vec, data_ptr_t data, VectorBuffer *buffer, idx_t type_size, bool is_nested)
+	    : vec(vec), data(data), buffer(buffer), type_size(type_size), is_nested(is_nested) {};
+};
+
+void FindChildren(std::vector<DataArrays> &to_resize, VectorBuffer &auxiliary) {
+	if (auxiliary.GetBufferType() == VectorBufferType::LIST_BUFFER) {
+		auto &buffer = (VectorListBuffer &)auxiliary;
+		auto &child = buffer.GetChild();
+		auto data = child.GetData();
+		if (!data) {
+			//! Nested type
+			DataArrays arrays(child, data, child.GetBuffer().get(), GetTypeIdSize(child.GetType().InternalType()),
+			                  true);
+			to_resize.emplace_back(arrays);
+			FindChildren(to_resize, *child.GetAuxiliary());
+		} else {
+			DataArrays arrays(child, data, child.GetBuffer().get(), GetTypeIdSize(child.GetType().InternalType()),
+			                  false);
+			to_resize.emplace_back(arrays);
+		}
+	} else if (auxiliary.GetBufferType() == VectorBufferType::STRUCT_BUFFER) {
+		auto &buffer = (VectorStructBuffer &)auxiliary;
+		auto &children = buffer.GetChildren();
+		for (auto &child : children) {
+			auto data = child->GetData();
+			if (!data) {
+				//! Nested type
+				DataArrays arrays(*child, data, child->GetBuffer().get(),
+				                  GetTypeIdSize(child->GetType().InternalType()), true);
+				to_resize.emplace_back(arrays);
+				FindChildren(to_resize, *child->GetAuxiliary());
+			} else {
+				DataArrays arrays(*child, data, child->GetBuffer().get(),
+				                  GetTypeIdSize(child->GetType().InternalType()), false);
+				to_resize.emplace_back(arrays);
+			}
+		}
+	}
+}
+void Vector::Resize(idx_t cur_size, idx_t new_size) {
+	std::vector<DataArrays> to_resize;
+	if (!buffer) {
+		buffer = make_unique<VectorBuffer>(0);
+	}
+	if (!data) {
+		//! this is a nested structure
+		DataArrays arrays(*this, data, buffer.get(), GetTypeIdSize(GetType().InternalType()), true);
+		to_resize.emplace_back(arrays);
+		FindChildren(to_resize, *auxiliary);
+	} else {
+		DataArrays arrays(*this, data, buffer.get(), GetTypeIdSize(GetType().InternalType()), false);
+		to_resize.emplace_back(arrays);
+	}
+	for (auto &data_to_resize : to_resize) {
+		if (!data_to_resize.is_nested) {
+			auto new_data = unique_ptr<data_t[]>(new data_t[new_size * data_to_resize.type_size]);
+			memcpy(new_data.get(), data_to_resize.data, cur_size * data_to_resize.type_size * sizeof(data_t));
+			data_to_resize.buffer->SetData(move(new_data));
+			data_to_resize.vec.data = data_to_resize.buffer->GetData();
+		}
+		data_to_resize.vec.validity.Resize(cur_size, new_size);
+	}
+}
+
+void Vector::SetValue(idx_t index, const Value &val) {
+	if (GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		// dictionary: apply dictionary and forward to child
+		auto &sel_vector = DictionaryVector::SelVector(*this);
+		auto &child = DictionaryVector::Child(*this);
+		return child.SetValue(sel_vector.get_index(index), val);
+	}
+	if (val.type().InternalType() != GetType().InternalType()) {
+		SetValue(index, val.CastAs(GetType()));
+		return;
+	}
+
+	validity.EnsureWritable();
+	validity.Set(index, !val.IsNull());
+	if (val.IsNull() && GetType().InternalType() != PhysicalType::STRUCT) {
+		// for structs we still need to set the child-entries to NULL
+		// so we do not bail out yet
+		return;
+	}
+
+	switch (GetType().InternalType()) {
+	case PhysicalType::BOOL:
+		((bool *)data)[index] = val.GetValueUnsafe<bool>();
+		break;
+	case PhysicalType::INT8:
+		((int8_t *)data)[index] = val.GetValueUnsafe<int8_t>();
+		break;
+	case PhysicalType::INT16:
+		((int16_t *)data)[index] = val.GetValueUnsafe<int16_t>();
+		break;
+	case PhysicalType::INT32:
+		((int32_t *)data)[index] = val.GetValueUnsafe<int32_t>();
+		break;
+	case PhysicalType::INT64:
+		((int64_t *)data)[index] = val.GetValueUnsafe<int64_t>();
+		break;
+	case PhysicalType::INT128:
+		((hugeint_t *)data)[index] = val.GetValueUnsafe<hugeint_t>();
+		break;
+	case PhysicalType::UINT8:
+		((uint8_t *)data)[index] = val.GetValueUnsafe<uint8_t>();
+		break;
+	case PhysicalType::UINT16:
+		((uint16_t *)data)[index] = val.GetValueUnsafe<uint16_t>();
+		break;
+	case PhysicalType::UINT32:
+		((uint32_t *)data)[index] = val.GetValueUnsafe<uint32_t>();
+		break;
+	case PhysicalType::UINT64:
+		((uint64_t *)data)[index] = val.GetValueUnsafe<uint64_t>();
+		break;
+	case PhysicalType::FLOAT:
+		((float *)data)[index] = val.GetValueUnsafe<float>();
+		break;
+	case PhysicalType::DOUBLE:
+		((double *)data)[index] = val.GetValueUnsafe<double>();
+		break;
+	case PhysicalType::INTERVAL:
+		((interval_t *)data)[index] = val.GetValueUnsafe<interval_t>();
+		break;
+	case PhysicalType::VARCHAR:
+		((string_t *)data)[index] = StringVector::AddStringOrBlob(*this, StringValue::Get(val));
+		break;
+	case PhysicalType::STRUCT: {
+		D_ASSERT(GetVectorType() == VectorType::CONSTANT_VECTOR || GetVectorType() == VectorType::FLAT_VECTOR);
+
+		auto &children = StructVector::GetEntries(*this);
+		auto &val_children = StructValue::GetChildren(val);
+		D_ASSERT(val.IsNull() || children.size() == val_children.size());
+		for (size_t i = 0; i < children.size(); i++) {
+			auto &vec_child = children[i];
+			if (!val.IsNull()) {
+				auto &struct_child = val_children[i];
+				vec_child->SetValue(index, struct_child);
+			} else {
+				vec_child->SetValue(index, Value());
+			}
+		}
+		break;
+	}
+	case PhysicalType::LIST: {
+		auto offset = ListVector::GetListSize(*this);
+		auto &val_children = ListValue::GetChildren(val);
+		if (!val_children.empty()) {
+			for (idx_t i = 0; i < val_children.size(); i++) {
+				ListVector::PushBack(*this, val_children[i]);
+			}
+		}
+		//! now set the pointer
+		auto &entry = ((list_entry_t *)data)[index];
+		entry.length = val_children.size();
+		entry.offset = offset;
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented type for Vector::SetValue");
+	}
+}
+
+Value Vector::GetValue(const Vector &v_p, idx_t index_p) {
+	const Vector *vector = &v_p;
+	idx_t index = index_p;
+	bool finished = false;
+	while (!finished) {
+		switch (vector->GetVectorType()) {
+		case VectorType::CONSTANT_VECTOR:
+			index = 0;
+			finished = true;
+			break;
+		case VectorType::FLAT_VECTOR:
+			finished = true;
+			break;
+			// dictionary: apply dictionary and forward to child
+		case VectorType::DICTIONARY_VECTOR: {
+			auto &sel_vector = DictionaryVector::SelVector(*vector);
+			auto &child = DictionaryVector::Child(*vector);
+			vector = &child;
+			index = sel_vector.get_index(index);
+			break;
+		}
+		case VectorType::SEQUENCE_VECTOR: {
+			int64_t start, increment;
+			SequenceVector::GetSequence(*vector, start, increment);
+			return Value::Numeric(vector->GetType(), start + increment * index);
+		}
+		default:
+			throw InternalException("Unimplemented vector type for Vector::GetValue");
+		}
+	}
+	auto data = vector->data;
+	auto &validity = vector->validity;
+	auto &type = vector->GetType();
+
+	if (!validity.RowIsValid(index)) {
+		return Value(vector->GetType());
+	}
+	switch (vector->GetType().id()) {
+	case LogicalTypeId::BOOLEAN:
+		return Value::BOOLEAN(((bool *)data)[index]);
+	case LogicalTypeId::TINYINT:
+		return Value::TINYINT(((int8_t *)data)[index]);
+	case LogicalTypeId::SMALLINT:
+		return Value::SMALLINT(((int16_t *)data)[index]);
+	case LogicalTypeId::INTEGER:
+		return Value::INTEGER(((int32_t *)data)[index]);
+	case LogicalTypeId::DATE:
+		return Value::DATE(((date_t *)data)[index]);
+	case LogicalTypeId::TIME:
+		return Value::TIME(((dtime_t *)data)[index]);
+	case LogicalTypeId::TIME_TZ:
+		return Value::TIMETZ(((dtime_t *)data)[index]);
+	case LogicalTypeId::BIGINT:
+		return Value::BIGINT(((int64_t *)data)[index]);
+	case LogicalTypeId::UTINYINT:
+		return Value::UTINYINT(((uint8_t *)data)[index]);
+	case LogicalTypeId::USMALLINT:
+		return Value::USMALLINT(((uint16_t *)data)[index]);
+	case LogicalTypeId::UINTEGER:
+		return Value::UINTEGER(((uint32_t *)data)[index]);
+	case LogicalTypeId::UBIGINT:
+		return Value::UBIGINT(((uint64_t *)data)[index]);
+	case LogicalTypeId::TIMESTAMP:
+		return Value::TIMESTAMP(((timestamp_t *)data)[index]);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return Value::TIMESTAMPNS(((timestamp_t *)data)[index]);
+	case LogicalTypeId::TIMESTAMP_MS:
+		return Value::TIMESTAMPMS(((timestamp_t *)data)[index]);
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return Value::TIMESTAMPSEC(((timestamp_t *)data)[index]);
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return Value::TIMESTAMPTZ(((timestamp_t *)data)[index]);
+	case LogicalTypeId::HUGEINT:
+		return Value::HUGEINT(((hugeint_t *)data)[index]);
+	case LogicalTypeId::UUID:
+		return Value::UUID(((hugeint_t *)data)[index]);
+	case LogicalTypeId::DECIMAL: {
+		auto width = DecimalType::GetWidth(type);
+		auto scale = DecimalType::GetScale(type);
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return Value::DECIMAL(((int16_t *)data)[index], width, scale);
+		case PhysicalType::INT32:
+			return Value::DECIMAL(((int32_t *)data)[index], width, scale);
+		case PhysicalType::INT64:
+			return Value::DECIMAL(((int64_t *)data)[index], width, scale);
+		case PhysicalType::INT128:
+			return Value::DECIMAL(((hugeint_t *)data)[index], width, scale);
+		default:
+			throw InternalException("Widths bigger than 38 are not supported");
+		}
+	}
+	case LogicalTypeId::ENUM: {
+		switch (type.InternalType()) {
+		case PhysicalType::UINT8:
+			return Value::ENUM(((uint8_t *)data)[index], type);
+		case PhysicalType::UINT16:
+			return Value::ENUM(((uint16_t *)data)[index], type);
+		case PhysicalType::UINT32:
+			return Value::ENUM(((uint32_t *)data)[index], type);
+		case PhysicalType::UINT64: //  DEDUP_POINTER_ENUM
+			return Value::ENUM(((uint64_t *)data)[index], type);
+		default:
+			throw InternalException("ENUM can only have unsigned integers as physical types");
+		}
+	}
+	case LogicalTypeId::POINTER:
+		return Value::POINTER(((uintptr_t *)data)[index]);
+	case LogicalTypeId::FLOAT:
+		return Value::FLOAT(((float *)data)[index]);
+	case LogicalTypeId::DOUBLE:
+		return Value::DOUBLE(((double *)data)[index]);
+	case LogicalTypeId::INTERVAL:
+		return Value::INTERVAL(((interval_t *)data)[index]);
+	case LogicalTypeId::VARCHAR: {
+		auto str = ((string_t *)data)[index];
+		return Value(str.GetString());
+	}
+	case LogicalTypeId::JSON: {
+		auto str = ((string_t *)data)[index];
+		return Value::JSON(str.GetString());
+	}
+	case LogicalTypeId::AGGREGATE_STATE:
+	case LogicalTypeId::BLOB: {
+		auto str = ((string_t *)data)[index];
+		return Value::BLOB((const_data_ptr_t)str.GetDataUnsafe(), str.GetSize());
+	}
+	case LogicalTypeId::MAP: {
+		auto &child_entries = StructVector::GetEntries(*vector);
+		Value key = child_entries[0]->GetValue(index);
+		Value value = child_entries[1]->GetValue(index);
+		return Value::MAP(move(key), move(value));
+	}
+	case LogicalTypeId::STRUCT: {
+		// we can derive the value schema from the vector schema
+		auto &child_entries = StructVector::GetEntries(*vector);
+		child_list_t<Value> children;
+		for (idx_t child_idx = 0; child_idx < child_entries.size(); child_idx++) {
+			auto &struct_child = child_entries[child_idx];
+			children.push_back(make_pair(StructType::GetChildName(type, child_idx), struct_child->GetValue(index_p)));
+		}
+		return Value::STRUCT(move(children));
+	}
+	case LogicalTypeId::LIST: {
+		auto offlen = ((list_entry_t *)data)[index];
+		auto &child_vec = ListVector::GetEntry(*vector);
+		std::vector<Value> children;
+		for (idx_t i = offlen.offset; i < offlen.offset + offlen.length; i++) {
+			children.push_back(child_vec.GetValue(i));
+		}
+		return Value::LIST(ListType::GetChildType(type), move(children));
+	}
+	default:
+		throw InternalException("Unimplemented type for value access");
+	}
+}
+
+Value Vector::GetValue(idx_t index) const {
+	return GetValue(*this, index);
+}
+
+// LCOV_EXCL_START
+string VectorTypeToString(VectorType type) {
+	switch (type) {
+	case VectorType::FLAT_VECTOR:
+		return "FLAT";
+	case VectorType::SEQUENCE_VECTOR:
+		return "SEQUENCE";
+	case VectorType::DICTIONARY_VECTOR:
+		return "DICTIONARY";
+	case VectorType::CONSTANT_VECTOR:
+		return "CONSTANT";
+	default:
+		return "UNKNOWN";
+	}
+}
+
+string Vector::ToString(idx_t count) const {
+	string retval =
+	    VectorTypeToString(GetVectorType()) + " " + GetType().ToString() + ": " + to_string(count) + " = [ ";
+	switch (GetVectorType()) {
+	case VectorType::FLAT_VECTOR:
+	case VectorType::DICTIONARY_VECTOR:
+		for (idx_t i = 0; i < count; i++) {
+			retval += GetValue(i).ToString() + (i == count - 1 ? "" : ", ");
+		}
+		break;
+	case VectorType::CONSTANT_VECTOR:
+		retval += GetValue(0).ToString();
+		break;
+	case VectorType::SEQUENCE_VECTOR: {
+		int64_t start, increment;
+		SequenceVector::GetSequence(*this, start, increment);
+		for (idx_t i = 0; i < count; i++) {
+			retval += to_string(start + increment * i) + (i == count - 1 ? "" : ", ");
+		}
+		break;
+	}
+	default:
+		retval += "UNKNOWN VECTOR TYPE";
+		break;
+	}
+	retval += "]";
+	return retval;
+}
+
+void Vector::Print(idx_t count) {
+	Printer::Print(ToString(count));
+}
+
+string Vector::ToString() const {
+	string retval = VectorTypeToString(GetVectorType()) + " " + GetType().ToString() + ": (UNKNOWN COUNT) [ ";
+	switch (GetVectorType()) {
+	case VectorType::FLAT_VECTOR:
+	case VectorType::DICTIONARY_VECTOR:
+		break;
+	case VectorType::CONSTANT_VECTOR:
+		retval += GetValue(0).ToString();
+		break;
+	case VectorType::SEQUENCE_VECTOR: {
+		break;
+	}
+	default:
+		retval += "UNKNOWN VECTOR TYPE";
+		break;
+	}
+	retval += "]";
+	return retval;
+}
+
+void Vector::Print() {
+	Printer::Print(ToString());
+}
+// LCOV_EXCL_STOP
+
+template <class T>
+static void TemplatedFlattenConstantVector(data_ptr_t data, data_ptr_t old_data, idx_t count) {
+	auto constant = Load<T>(old_data);
+	auto output = (T *)data;
+	for (idx_t i = 0; i < count; i++) {
+		output[i] = constant;
+	}
+}
+
+void Vector::Normalify(idx_t count) {
+	switch (GetVectorType()) {
+	case VectorType::FLAT_VECTOR:
+		// already a flat vector
+		break;
+	case VectorType::DICTIONARY_VECTOR: {
+		// create a new flat vector of this type
+		Vector other(GetType(), count);
+		// now copy the data of this vector to the other vector, removing the selection vector in the process
+		VectorOperations::Copy(*this, other, count, 0, 0);
+		// create a reference to the data in the other vector
+		this->Reference(other);
+		break;
+	}
+	case VectorType::CONSTANT_VECTOR: {
+		bool is_null = ConstantVector::IsNull(*this);
+		// allocate a new buffer for the vector
+		auto old_buffer = move(buffer);
+		auto old_data = data;
+		buffer = VectorBuffer::CreateStandardVector(type, MaxValue<idx_t>(STANDARD_VECTOR_SIZE, count));
+		data = buffer->GetData();
+		vector_type = VectorType::FLAT_VECTOR;
+		if (is_null) {
+			// constant NULL, set nullmask
+			validity.EnsureWritable();
+			validity.SetAllInvalid(count);
+			return;
+		}
+		// non-null constant: have to repeat the constant
+		switch (GetType().InternalType()) {
+		case PhysicalType::BOOL:
+			TemplatedFlattenConstantVector<bool>(data, old_data, count);
+			break;
+		case PhysicalType::INT8:
+			TemplatedFlattenConstantVector<int8_t>(data, old_data, count);
+			break;
+		case PhysicalType::INT16:
+			TemplatedFlattenConstantVector<int16_t>(data, old_data, count);
+			break;
+		case PhysicalType::INT32:
+			TemplatedFlattenConstantVector<int32_t>(data, old_data, count);
+			break;
+		case PhysicalType::INT64:
+			TemplatedFlattenConstantVector<int64_t>(data, old_data, count);
+			break;
+		case PhysicalType::UINT8:
+			TemplatedFlattenConstantVector<uint8_t>(data, old_data, count);
+			break;
+		case PhysicalType::UINT16:
+			TemplatedFlattenConstantVector<uint16_t>(data, old_data, count);
+			break;
+		case PhysicalType::UINT32:
+			TemplatedFlattenConstantVector<uint32_t>(data, old_data, count);
+			break;
+		case PhysicalType::UINT64:
+			TemplatedFlattenConstantVector<uint64_t>(data, old_data, count);
+			break;
+		case PhysicalType::INT128:
+			TemplatedFlattenConstantVector<hugeint_t>(data, old_data, count);
+			break;
+		case PhysicalType::FLOAT:
+			TemplatedFlattenConstantVector<float>(data, old_data, count);
+			break;
+		case PhysicalType::DOUBLE:
+			TemplatedFlattenConstantVector<double>(data, old_data, count);
+			break;
+		case PhysicalType::INTERVAL:
+			TemplatedFlattenConstantVector<interval_t>(data, old_data, count);
+			break;
+		case PhysicalType::VARCHAR:
+			TemplatedFlattenConstantVector<string_t>(data, old_data, count);
+			break;
+		case PhysicalType::LIST: {
+			TemplatedFlattenConstantVector<list_entry_t>(data, old_data, count);
+			break;
+		}
+		case PhysicalType::STRUCT: {
+			auto normalified_buffer = make_unique<VectorStructBuffer>();
+
+			auto &new_children = normalified_buffer->GetChildren();
+
+			auto &child_entries = StructVector::GetEntries(*this);
+			for (auto &child : child_entries) {
+				D_ASSERT(child->GetVectorType() == VectorType::CONSTANT_VECTOR);
+				auto vector = make_unique<Vector>(*child);
+				vector->Normalify(count);
+				new_children.push_back(move(vector));
+			}
+			auxiliary = move(normalified_buffer);
+		} break;
+		default:
+			throw InternalException("Unimplemented type for VectorOperations::Normalify");
+		}
+		break;
+	}
+	case VectorType::SEQUENCE_VECTOR: {
+		int64_t start, increment;
+		SequenceVector::GetSequence(*this, start, increment);
+
+		buffer = VectorBuffer::CreateStandardVector(GetType());
+		data = buffer->GetData();
+		VectorOperations::GenerateSequence(*this, count, start, increment);
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented type for normalify");
+	}
+}
+
+void Vector::Normalify(const SelectionVector &sel, idx_t count) {
+	switch (GetVectorType()) {
+	case VectorType::FLAT_VECTOR:
+		// already a flat vector
+		break;
+	case VectorType::SEQUENCE_VECTOR: {
+		int64_t start, increment;
+		SequenceVector::GetSequence(*this, start, increment);
+
+		buffer = VectorBuffer::CreateStandardVector(GetType());
+		data = buffer->GetData();
+		VectorOperations::GenerateSequence(*this, count, sel, start, increment);
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented type for normalify with selection vector");
+	}
+}
+
+void Vector::Orrify(idx_t count, VectorData &data) {
+	switch (GetVectorType()) {
+	case VectorType::DICTIONARY_VECTOR: {
+		auto &sel = DictionaryVector::SelVector(*this);
+		auto &child = DictionaryVector::Child(*this);
+		if (child.GetVectorType() == VectorType::FLAT_VECTOR) {
+			data.sel = &sel;
+			data.data = FlatVector::GetData(child);
+			data.validity = FlatVector::Validity(child);
+		} else {
+			// dictionary with non-flat child: create a new reference to the child and normalify it
+			Vector child_vector(child);
+			child_vector.Normalify(sel, count);
+			auto new_aux = make_buffer<VectorChildBuffer>(move(child_vector));
+
+			data.sel = &sel;
+			data.data = FlatVector::GetData(new_aux->data);
+			data.validity = FlatVector::Validity(new_aux->data);
+			this->auxiliary = move(new_aux);
+		}
+		break;
+	}
+	case VectorType::CONSTANT_VECTOR:
+		data.sel = ConstantVector::ZeroSelectionVector(count, data.owned_sel);
+		data.data = ConstantVector::GetData(*this);
+		data.validity = ConstantVector::Validity(*this);
+		break;
+	default:
+		Normalify(count);
+		data.sel = FlatVector::IncrementalSelectionVector();
+		data.data = FlatVector::GetData(*this);
+		data.validity = FlatVector::Validity(*this);
+		break;
+	}
+}
+
+void Vector::Sequence(int64_t start, int64_t increment) {
+	this->vector_type = VectorType::SEQUENCE_VECTOR;
+	this->buffer = make_buffer<VectorBuffer>(sizeof(int64_t) * 2);
+	auto data = (int64_t *)buffer->GetData();
+	data[0] = start;
+	data[1] = increment;
+	validity.Reset();
+	auxiliary.reset();
+}
+
+void Vector::Serialize(idx_t count, Serializer &serializer) {
+	auto &type = GetType();
+
+	VectorData vdata;
+	Orrify(count, vdata);
+
+	const auto write_validity = (count > 0) && !vdata.validity.AllValid();
+	serializer.Write<bool>(write_validity);
+	if (write_validity) {
+		ValidityMask flat_mask(count);
+		for (idx_t i = 0; i < count; ++i) {
+			auto row_idx = vdata.sel->get_index(i);
+			flat_mask.Set(i, vdata.validity.RowIsValid(row_idx));
+		}
+		serializer.WriteData((const_data_ptr_t)flat_mask.GetData(), flat_mask.ValidityMaskSize(count));
+	}
+	if (TypeIsConstantSize(type.InternalType())) {
+		// constant size type: simple copy
+		idx_t write_size = GetTypeIdSize(type.InternalType()) * count;
+		auto ptr = unique_ptr<data_t[]>(new data_t[write_size]);
+		VectorOperations::WriteToStorage(*this, count, ptr.get());
+		serializer.WriteData(ptr.get(), write_size);
+	} else {
+		switch (type.InternalType()) {
+		case PhysicalType::VARCHAR: {
+			auto strings = (string_t *)vdata.data;
+			for (idx_t i = 0; i < count; i++) {
+				auto idx = vdata.sel->get_index(i);
+				auto source = !vdata.validity.RowIsValid(idx) ? NullValue<string_t>() : strings[idx];
+				serializer.WriteStringLen((const_data_ptr_t)source.GetDataUnsafe(), source.GetSize());
+			}
+			break;
+		}
+		case PhysicalType::STRUCT: {
+			Normalify(count);
+			auto &entries = StructVector::GetEntries(*this);
+			for (auto &entry : entries) {
+				entry->Serialize(count, serializer);
+			}
+			break;
+		}
+		case PhysicalType::LIST: {
+			auto &child = ListVector::GetEntry(*this);
+			auto list_size = ListVector::GetListSize(*this);
+
+			// serialize the list entries in a flat array
+			auto data = unique_ptr<list_entry_t[]>(new list_entry_t[count]);
+			auto source_array = (list_entry_t *)vdata.data;
+			for (idx_t i = 0; i < count; i++) {
+				auto idx = vdata.sel->get_index(i);
+				auto source = source_array[idx];
+				data[i].offset = source.offset;
+				data[i].length = source.length;
+			}
+
+			// write the list size
+			serializer.Write<idx_t>(list_size);
+			serializer.WriteData((data_ptr_t)data.get(), count * sizeof(list_entry_t));
+
+			child.Serialize(list_size, serializer);
+			break;
+		}
+		default:
+			throw InternalException("Unimplemented variable width type for Vector::Serialize!");
+		}
+	}
+}
+
+void Vector::Deserialize(idx_t count, Deserializer &source) {
+	auto &type = GetType();
+
+	auto &validity = FlatVector::Validity(*this);
+	validity.Reset();
+	const auto has_validity = source.Read<bool>();
+	if (has_validity) {
+		validity.Initialize(count);
+		source.ReadData((data_ptr_t)validity.GetData(), validity.ValidityMaskSize(count));
+	}
+
+	if (TypeIsConstantSize(type.InternalType())) {
+		// constant size type: read fixed amount of data from
+		auto column_size = GetTypeIdSize(type.InternalType()) * count;
+		auto ptr = unique_ptr<data_t[]>(new data_t[column_size]);
+		source.ReadData(ptr.get(), column_size);
+
+		VectorOperations::ReadFromStorage(ptr.get(), count, *this);
+	} else {
+		switch (type.InternalType()) {
+		case PhysicalType::VARCHAR: {
+			auto strings = FlatVector::GetData<string_t>(*this);
+			for (idx_t i = 0; i < count; i++) {
+				// read the strings
+				auto str = source.Read<string>();
+				// now add the string to the StringHeap of the vector
+				// and write the pointer into the vector
+				if (validity.RowIsValid(i)) {
+					strings[i] = StringVector::AddStringOrBlob(*this, str);
+				}
+			}
+			break;
+		}
+		case PhysicalType::STRUCT: {
+			auto &entries = StructVector::GetEntries(*this);
+			for (auto &entry : entries) {
+				entry->Deserialize(count, source);
+			}
+			break;
+		}
+		case PhysicalType::LIST: {
+			// read the list size
+			auto list_size = source.Read<idx_t>();
+			ListVector::Reserve(*this, list_size);
+			ListVector::SetListSize(*this, list_size);
+
+			// read the list entry
+			auto list_entries = FlatVector::GetData(*this);
+			source.ReadData(list_entries, count * sizeof(list_entry_t));
+
+			// deserialize the child vector
+			auto &child = ListVector::GetEntry(*this);
+			child.Deserialize(list_size, source);
+
+			break;
+		}
+		default:
+			throw InternalException("Unimplemented variable width type for Vector::Deserialize!");
+		}
+	}
+}
+
+void Vector::SetVectorType(VectorType vector_type_p) {
+	this->vector_type = vector_type_p;
+	if (TypeIsConstantSize(GetType().InternalType()) &&
+	    (GetVectorType() == VectorType::CONSTANT_VECTOR || GetVectorType() == VectorType::FLAT_VECTOR)) {
+		auxiliary.reset();
+	}
+	if (vector_type == VectorType::CONSTANT_VECTOR && GetType().InternalType() == PhysicalType::STRUCT) {
+		auto &entries = StructVector::GetEntries(*this);
+		for (auto &entry : entries) {
+			entry->SetVectorType(vector_type);
+		}
+	}
+}
+
+void Vector::UTFVerify(const SelectionVector &sel, idx_t count) {
+#ifdef DEBUG
+	if (count == 0) {
+		return;
+	}
+	if (GetType().InternalType() == PhysicalType::VARCHAR) {
+		// we just touch all the strings and let the sanitizer figure out if any
+		// of them are deallocated/corrupt
+		switch (GetVectorType()) {
+		case VectorType::CONSTANT_VECTOR: {
+			auto string = ConstantVector::GetData<string_t>(*this);
+			if (!ConstantVector::IsNull(*this)) {
+				string->Verify();
+			}
+			break;
+		}
+		case VectorType::FLAT_VECTOR: {
+			auto strings = FlatVector::GetData<string_t>(*this);
+			for (idx_t i = 0; i < count; i++) {
+				auto oidx = sel.get_index(i);
+				if (validity.RowIsValid(oidx)) {
+					strings[oidx].Verify();
+				}
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+#endif
+}
+
+void Vector::UTFVerify(idx_t count) {
+	auto flat_sel = FlatVector::IncrementalSelectionVector();
+
+	UTFVerify(*flat_sel, count);
+}
+
+void Vector::VerifyMap(Vector &vector_p, const SelectionVector &sel_p, idx_t count) {
+#ifdef DEBUG
+	D_ASSERT(vector_p.GetType().id() == LogicalTypeId::MAP);
+	auto valid_check = CheckMapValidity(vector_p, count, sel_p);
+	D_ASSERT(valid_check == MapInvalidReason::VALID);
+#endif // DEBUG
+}
+
+void Vector::Verify(Vector &vector_p, const SelectionVector &sel_p, idx_t count) {
+#ifdef DEBUG
+	if (count == 0) {
+		return;
+	}
+	Vector *vector = &vector_p;
+	const SelectionVector *sel = &sel_p;
+	SelectionVector owned_sel;
+	auto &type = vector->GetType();
+	auto vtype = vector->GetVectorType();
+	if (vector->GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &child = DictionaryVector::Child(*vector);
+		D_ASSERT(child.GetVectorType() != VectorType::DICTIONARY_VECTOR);
+		auto &dict_sel = DictionaryVector::SelVector(*vector);
+		// merge the selection vectors and verify the child
+		auto new_buffer = dict_sel.Slice(*sel, count);
+		owned_sel.Initialize(new_buffer);
+		sel = &owned_sel;
+		vector = &child;
+		vtype = vector->GetVectorType();
+	}
+	if (TypeIsConstantSize(type.InternalType()) &&
+	    (vtype == VectorType::CONSTANT_VECTOR || vtype == VectorType::FLAT_VECTOR)) {
+		D_ASSERT(!vector->auxiliary);
+	}
+	if (type.id() == LogicalTypeId::VARCHAR || type.id() == LogicalTypeId::JSON) {
+		// verify that there are no '\0' bytes in string values
+		switch (vtype) {
+		case VectorType::FLAT_VECTOR: {
+			auto &validity = FlatVector::Validity(*vector);
+			auto strings = FlatVector::GetData<string_t>(*vector);
+			for (idx_t i = 0; i < count; i++) {
+				auto oidx = sel->get_index(i);
+				if (validity.RowIsValid(oidx)) {
+					strings[oidx].VerifyNull();
+				}
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	if (type.InternalType() == PhysicalType::STRUCT) {
+		auto &child_types = StructType::GetChildTypes(type);
+		D_ASSERT(!child_types.empty());
+		// create a selection vector of the non-null entries of the struct vector
+		auto &children = StructVector::GetEntries(*vector);
+		D_ASSERT(child_types.size() == children.size());
+		for (idx_t child_idx = 0; child_idx < children.size(); child_idx++) {
+			D_ASSERT(children[child_idx]->GetType() == child_types[child_idx].second);
+			Vector::Verify(*children[child_idx], sel_p, count);
+			if (vtype == VectorType::CONSTANT_VECTOR) {
+				D_ASSERT(children[child_idx]->GetVectorType() == VectorType::CONSTANT_VECTOR);
+				if (ConstantVector::IsNull(*vector)) {
+					D_ASSERT(ConstantVector::IsNull(*children[child_idx]));
+				}
+			}
+			if (vtype != VectorType::FLAT_VECTOR) {
+				continue;
+			}
+			ValidityMask *child_validity;
+			SelectionVector owned_child_sel;
+			const SelectionVector *child_sel = &owned_child_sel;
+			if (children[child_idx]->GetVectorType() == VectorType::FLAT_VECTOR) {
+				child_sel = FlatVector::IncrementalSelectionVector();
+				child_validity = &FlatVector::Validity(*children[child_idx]);
+			} else if (children[child_idx]->GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+				auto &child = DictionaryVector::Child(*children[child_idx]);
+				if (child.GetVectorType() != VectorType::FLAT_VECTOR) {
+					continue;
+				}
+				child_validity = &FlatVector::Validity(child);
+				child_sel = &DictionaryVector::SelVector(*children[child_idx]);
+			} else if (children[child_idx]->GetVectorType() == VectorType::CONSTANT_VECTOR) {
+				child_sel = ConstantVector::ZeroSelectionVector(count, owned_child_sel);
+				child_validity = &ConstantVector::Validity(*children[child_idx]);
+			} else {
+				continue;
+			}
+			// for any NULL entry in the struct, the child should be NULL as well
+			auto &validity = FlatVector::Validity(*vector);
+			for (idx_t i = 0; i < count; i++) {
+				auto index = sel->get_index(i);
+				if (!validity.RowIsValid(index)) {
+					auto child_index = child_sel->get_index(sel_p.get_index(i));
+					D_ASSERT(!child_validity->RowIsValid(child_index));
+				}
+			}
+		}
+		if (vector->GetType().id() == LogicalTypeId::MAP) {
+			VerifyMap(*vector, *sel, count);
+		}
+	}
+
+	if (type.InternalType() == PhysicalType::LIST) {
+		if (vtype == VectorType::CONSTANT_VECTOR) {
+			if (!ConstantVector::IsNull(*vector)) {
+				auto &child = ListVector::GetEntry(*vector);
+				SelectionVector child_sel(ListVector::GetListSize(*vector));
+				idx_t child_count = 0;
+				auto le = ConstantVector::GetData<list_entry_t>(*vector);
+				D_ASSERT(le->offset + le->length <= ListVector::GetListSize(*vector));
+				for (idx_t k = 0; k < le->length; k++) {
+					child_sel.set_index(child_count++, le->offset + k);
+				}
+				Vector::Verify(child, child_sel, child_count);
+			}
+		} else if (vtype == VectorType::FLAT_VECTOR) {
+			auto &validity = FlatVector::Validity(*vector);
+			auto &child = ListVector::GetEntry(*vector);
+			auto child_size = ListVector::GetListSize(*vector);
+			auto list_data = FlatVector::GetData<list_entry_t>(*vector);
+			idx_t total_size = 0;
+			for (idx_t i = 0; i < count; i++) {
+				auto idx = sel->get_index(i);
+				auto &le = list_data[idx];
+				if (validity.RowIsValid(idx)) {
+					D_ASSERT(le.offset + le.length <= child_size);
+					total_size += le.length;
+				}
+			}
+			SelectionVector child_sel(total_size);
+			idx_t child_count = 0;
+			for (idx_t i = 0; i < count; i++) {
+				auto idx = sel->get_index(i);
+				auto &le = list_data[idx];
+				if (validity.RowIsValid(idx)) {
+					D_ASSERT(le.offset + le.length <= child_size);
+					for (idx_t k = 0; k < le.length; k++) {
+						child_sel.set_index(child_count++, le.offset + k);
+					}
+				}
+			}
+			Vector::Verify(child, child_sel, child_count);
+		}
+	}
+#endif
+}
+
+void Vector::Verify(idx_t count) {
+	auto flat_sel = FlatVector::IncrementalSelectionVector();
+	Verify(*this, *flat_sel, count);
+}
+
+void FlatVector::SetNull(Vector &vector, idx_t idx, bool is_null) {
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR);
+	vector.validity.Set(idx, !is_null);
+	if (is_null && vector.GetType().InternalType() == PhysicalType::STRUCT) {
+		// set all child entries to null as well
+		auto &entries = StructVector::GetEntries(vector);
+		for (auto &entry : entries) {
+			FlatVector::SetNull(*entry, idx, is_null);
+		}
+	}
+}
+
+void ConstantVector::SetNull(Vector &vector, bool is_null) {
+	D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	vector.validity.Set(0, !is_null);
+	if (is_null && vector.GetType().InternalType() == PhysicalType::STRUCT) {
+		// set all child entries to null as well
+		auto &entries = StructVector::GetEntries(vector);
+		for (auto &entry : entries) {
+			entry->SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(*entry, is_null);
+		}
+	}
+}
+
+const SelectionVector *ConstantVector::ZeroSelectionVector(idx_t count, SelectionVector &owned_sel) {
+	if (count <= STANDARD_VECTOR_SIZE) {
+		return ConstantVector::ZeroSelectionVector();
+	}
+	owned_sel.Initialize(count);
+	for (idx_t i = 0; i < count; i++) {
+		owned_sel.set_index(i, 0);
+	}
+	return &owned_sel;
+}
+
+void ConstantVector::Reference(Vector &vector, Vector &source, idx_t position, idx_t count) {
+	auto &source_type = source.GetType();
+	switch (source_type.InternalType()) {
+	case PhysicalType::LIST: {
+		// retrieve the list entry from the source vector
+		VectorData vdata;
+		source.Orrify(count, vdata);
+
+		auto list_index = vdata.sel->get_index(position);
+		if (!vdata.validity.RowIsValid(list_index)) {
+			// list is null: create null value
+			Value null_value(source_type);
+			vector.Reference(null_value);
+			break;
+		}
+
+		auto list_data = (list_entry_t *)vdata.data;
+		auto list_entry = list_data[list_index];
+
+		// add the list entry as the first element of "vector"
+		// FIXME: we only need to allocate space for 1 tuple here
+		auto target_data = FlatVector::GetData<list_entry_t>(vector);
+		target_data[0] = list_entry;
+
+		// create a reference to the child list of the source vector
+		auto &child = ListVector::GetEntry(vector);
+		child.Reference(ListVector::GetEntry(source));
+
+		ListVector::SetListSize(vector, ListVector::GetListSize(source));
+		vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+		break;
+	}
+	case PhysicalType::STRUCT: {
+		VectorData vdata;
+		source.Orrify(count, vdata);
+
+		auto struct_index = vdata.sel->get_index(position);
+		if (!vdata.validity.RowIsValid(struct_index)) {
+			// null struct: create null value
+			Value null_value(source_type);
+			vector.Reference(null_value);
+			break;
+		}
+
+		// struct: pass constant reference into child entries
+		auto &source_entries = StructVector::GetEntries(source);
+		auto &target_entries = StructVector::GetEntries(vector);
+		for (idx_t i = 0; i < source_entries.size(); i++) {
+			ConstantVector::Reference(*target_entries[i], *source_entries[i], position, count);
+		}
+		vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+		break;
+	}
+	default:
+		// default behavior: get a value from the vector and reference it
+		// this is not that expensive for scalar types
+		auto value = source.GetValue(position);
+		vector.Reference(value);
+		D_ASSERT(vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+		break;
+	}
+}
+
+string_t StringVector::AddString(Vector &vector, const char *data, idx_t len) {
+	return StringVector::AddString(vector, string_t(data, len));
+}
+
+string_t StringVector::AddStringOrBlob(Vector &vector, const char *data, idx_t len) {
+	return StringVector::AddStringOrBlob(vector, string_t(data, len));
+}
+
+string_t StringVector::AddString(Vector &vector, const char *data) {
+	return StringVector::AddString(vector, string_t(data, strlen(data)));
+}
+
+string_t StringVector::AddString(Vector &vector, const string &data) {
+	return StringVector::AddString(vector, string_t(data.c_str(), data.size()));
+}
+
+string_t StringVector::AddString(Vector &vector, string_t data) {
+	D_ASSERT(vector.GetType().id() == LogicalTypeId::VARCHAR || vector.GetType().id() == LogicalTypeId::JSON);
+	if (data.IsInlined()) {
+		// string will be inlined: no need to store in string heap
+		return data;
+	}
+	if (!vector.auxiliary) {
+		vector.auxiliary = make_buffer<VectorStringBuffer>();
+	}
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::STRING_BUFFER);
+	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
+	return string_buffer.AddString(data);
+}
+
+string_t StringVector::AddStringOrBlob(Vector &vector, string_t data) {
+	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
+	if (data.IsInlined()) {
+		// string will be inlined: no need to store in string heap
+		return data;
+	}
+	if (!vector.auxiliary) {
+		vector.auxiliary = make_buffer<VectorStringBuffer>();
+	}
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::STRING_BUFFER);
+	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
+	return string_buffer.AddBlob(data);
+}
+
+string_t StringVector::EmptyString(Vector &vector, idx_t len) {
+	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
+	if (len < string_t::INLINE_LENGTH) {
+		return string_t(len);
+	}
+	if (!vector.auxiliary) {
+		vector.auxiliary = make_buffer<VectorStringBuffer>();
+	}
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::STRING_BUFFER);
+	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
+	return string_buffer.EmptyString(len);
+}
+
+void StringVector::AddHandle(Vector &vector, unique_ptr<BufferHandle> handle) {
+	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
+	if (!vector.auxiliary) {
+		vector.auxiliary = make_buffer<VectorStringBuffer>();
+	}
+	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
+	string_buffer.AddHeapReference(make_buffer<ManagedVectorBuffer>(move(handle)));
+}
+
+void StringVector::AddBuffer(Vector &vector, buffer_ptr<VectorBuffer> buffer) {
+	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
+	D_ASSERT(buffer.get() != vector.auxiliary.get());
+	if (!vector.auxiliary) {
+		vector.auxiliary = make_buffer<VectorStringBuffer>();
+	}
+	auto &string_buffer = (VectorStringBuffer &)*vector.auxiliary;
+	string_buffer.AddHeapReference(move(buffer));
+}
+
+void StringVector::AddHeapReference(Vector &vector, Vector &other) {
+	D_ASSERT(vector.GetType().InternalType() == PhysicalType::VARCHAR);
+	D_ASSERT(other.GetType().InternalType() == PhysicalType::VARCHAR);
+
+	if (other.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		StringVector::AddHeapReference(vector, DictionaryVector::Child(other));
+		return;
+	}
+	if (!other.auxiliary) {
+		return;
+	}
+	StringVector::AddBuffer(vector, other.auxiliary);
+}
+
+vector<unique_ptr<Vector>> &StructVector::GetEntries(Vector &vector) {
+	D_ASSERT(vector.GetType().id() == LogicalTypeId::STRUCT || vector.GetType().id() == LogicalTypeId::MAP);
+	if (vector.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &child = DictionaryVector::Child(vector);
+		return StructVector::GetEntries(child);
+	}
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
+	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.auxiliary);
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::STRUCT_BUFFER);
+	return ((VectorStructBuffer *)vector.auxiliary.get())->GetChildren();
+}
+
+const vector<unique_ptr<Vector>> &StructVector::GetEntries(const Vector &vector) {
+	return GetEntries((Vector &)vector);
+}
+
+const Vector &ListVector::GetEntry(const Vector &vector) {
+	D_ASSERT(vector.GetType().id() == LogicalTypeId::LIST);
+	if (vector.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &child = DictionaryVector::Child(vector);
+		return ListVector::GetEntry(child);
+	}
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
+	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.auxiliary);
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::LIST_BUFFER);
+	return ((VectorListBuffer *)vector.auxiliary.get())->GetChild();
+}
+
+Vector &ListVector::GetEntry(Vector &vector) {
+	const Vector &cvector = vector;
+	return const_cast<Vector &>(ListVector::GetEntry(cvector));
+}
+
+void ListVector::Reserve(Vector &vector, idx_t required_capacity) {
+	D_ASSERT(vector.GetType().id() == LogicalTypeId::LIST);
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
+	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(vector.auxiliary);
+	D_ASSERT(vector.auxiliary->GetBufferType() == VectorBufferType::LIST_BUFFER);
+	auto &child_buffer = *((VectorListBuffer *)vector.auxiliary.get());
+	child_buffer.Reserve(required_capacity);
+}
+
+template <class T>
+void TemplatedSearchInMap(Vector &list, T key, vector<idx_t> &offsets, bool is_key_null, idx_t offset, idx_t length) {
+	auto &list_vector = ListVector::GetEntry(list);
+	VectorData vector_data;
+	list_vector.Orrify(ListVector::GetListSize(list), vector_data);
+	auto data = (T *)vector_data.data;
+	auto validity_mask = vector_data.validity;
+
+	if (is_key_null) {
+		for (idx_t i = offset; i < offset + length; i++) {
+			if (!validity_mask.RowIsValid(i)) {
+				offsets.push_back(i);
+			}
+		}
+	} else {
+		for (idx_t i = offset; i < offset + length; i++) {
+			if (!validity_mask.RowIsValid(i)) {
+				continue;
+			}
+			if (key == data[i]) {
+				offsets.push_back(i);
+			}
+		}
+	}
+}
+
+template <class T>
+void TemplatedSearchInMap(Vector &list, const Value &key, vector<idx_t> &offsets, bool is_key_null, idx_t offset,
+                          idx_t length) {
+	TemplatedSearchInMap<T>(list, key.template GetValueUnsafe<T>(), offsets, is_key_null, offset, length);
+}
+
+void SearchStringInMap(Vector &list, const string &key, vector<idx_t> &offsets, bool is_key_null, idx_t offset,
+                       idx_t length) {
+	auto &list_vector = ListVector::GetEntry(list);
+	VectorData vector_data;
+	list_vector.Orrify(ListVector::GetListSize(list), vector_data);
+	auto data = (string_t *)vector_data.data;
+	auto validity_mask = vector_data.validity;
+	if (is_key_null) {
+		for (idx_t i = offset; i < offset + length; i++) {
+			if (!validity_mask.RowIsValid(i)) {
+				offsets.push_back(i);
+			}
+		}
+	} else {
+		string_t key_str_t(key);
+		for (idx_t i = offset; i < offset + length; i++) {
+			if (!validity_mask.RowIsValid(i)) {
+				continue;
+			}
+			if (Equals::Operation<string_t>(data[i], key_str_t)) {
+				offsets.push_back(i);
+			}
+		}
+	}
+}
+
+vector<idx_t> ListVector::Search(Vector &list, const Value &key, idx_t row) {
+	vector<idx_t> offsets;
+
+	auto &list_vector = ListVector::GetEntry(list);
+	auto &entry = ((list_entry_t *)list.GetData())[row];
+
+	switch (list_vector.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedSearchInMap<int8_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::INT16:
+		TemplatedSearchInMap<int16_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::INT32:
+		TemplatedSearchInMap<int32_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::INT64:
+		TemplatedSearchInMap<int64_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::INT128:
+		TemplatedSearchInMap<hugeint_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedSearchInMap<uint8_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedSearchInMap<uint16_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedSearchInMap<uint32_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedSearchInMap<uint64_t>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedSearchInMap<float>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedSearchInMap<double>(list, key, offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	case PhysicalType::VARCHAR:
+		SearchStringInMap(list, StringValue::Get(key), offsets, key.IsNull(), entry.offset, entry.length);
+		break;
+	default:
+		throw InvalidTypeException(list.GetType().id(), "Invalid type for List Vector Search");
+	}
+	return offsets;
+}
+
+Value ListVector::GetValuesFromOffsets(Vector &list, vector<idx_t> &offsets) {
+	auto &child_vec = ListVector::GetEntry(list);
+	vector<Value> list_values;
+	list_values.reserve(offsets.size());
+	for (auto &offset : offsets) {
+		list_values.push_back(child_vec.GetValue(offset));
+	}
+	return Value::LIST(ListType::GetChildType(list.GetType()), move(list_values));
+}
+
+idx_t ListVector::GetListSize(const Vector &vec) {
+	if (vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &child = DictionaryVector::Child(vec);
+		return ListVector::GetListSize(child);
+	}
+	D_ASSERT(vec.auxiliary);
+	return ((VectorListBuffer &)*vec.auxiliary).size;
+}
+
+void ListVector::ReferenceEntry(Vector &vector, Vector &other) {
+	D_ASSERT(vector.GetType().id() == LogicalTypeId::LIST);
+	D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR ||
+	         vector.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	D_ASSERT(other.GetType().id() == LogicalTypeId::LIST);
+	D_ASSERT(other.GetVectorType() == VectorType::FLAT_VECTOR || other.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	vector.auxiliary = other.auxiliary;
+}
+
+void ListVector::SetListSize(Vector &vec, idx_t size) {
+	if (vec.GetVectorType() == VectorType::DICTIONARY_VECTOR) {
+		auto &child = DictionaryVector::Child(vec);
+		ListVector::SetListSize(child, size);
+	}
+	((VectorListBuffer &)*vec.auxiliary).size = size;
+}
+
+void ListVector::Append(Vector &target, const Vector &source, idx_t source_size, idx_t source_offset) {
+	if (source_size - source_offset == 0) {
+		//! Nothing to add
+		return;
+	}
+	auto &target_buffer = (VectorListBuffer &)*target.auxiliary;
+	target_buffer.Append(source, source_size, source_offset);
+}
+
+void ListVector::Append(Vector &target, const Vector &source, const SelectionVector &sel, idx_t source_size,
+                        idx_t source_offset) {
+	if (source_size - source_offset == 0) {
+		//! Nothing to add
+		return;
+	}
+	auto &target_buffer = (VectorListBuffer &)*target.auxiliary;
+	target_buffer.Append(source, sel, source_size, source_offset);
+}
+
+void ListVector::PushBack(Vector &target, const Value &insert) {
+	auto &target_buffer = (VectorListBuffer &)*target.auxiliary;
+	target_buffer.PushBack(insert);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(PhysicalType type, idx_t capacity) {
+	return make_buffer<VectorBuffer>(capacity * GetTypeIdSize(type));
+}
+
+buffer_ptr<VectorBuffer> VectorBuffer::CreateConstantVector(PhysicalType type) {
+	return make_buffer<VectorBuffer>(GetTypeIdSize(type));
+}
+
+buffer_ptr<VectorBuffer> VectorBuffer::CreateConstantVector(const LogicalType &type) {
+	return VectorBuffer::CreateConstantVector(type.InternalType());
+}
+
+buffer_ptr<VectorBuffer> VectorBuffer::CreateStandardVector(const LogicalType &type, idx_t capacity) {
+	return VectorBuffer::CreateStandardVector(type.InternalType(), capacity);
+}
+
+VectorStringBuffer::VectorStringBuffer() : VectorBuffer(VectorBufferType::STRING_BUFFER) {
+}
+
+VectorStructBuffer::VectorStructBuffer() : VectorBuffer(VectorBufferType::STRUCT_BUFFER) {
+}
+
+VectorStructBuffer::VectorStructBuffer(const LogicalType &type, idx_t capacity)
+    : VectorBuffer(VectorBufferType::STRUCT_BUFFER) {
+	auto &child_types = StructType::GetChildTypes(type);
+	for (auto &child_type : child_types) {
+		auto vector = make_unique<Vector>(child_type.second, capacity);
+		children.push_back(move(vector));
+	}
+}
+
+VectorStructBuffer::VectorStructBuffer(Vector &other, const SelectionVector &sel, idx_t count)
+    : VectorBuffer(VectorBufferType::STRUCT_BUFFER) {
+	auto &other_vector = StructVector::GetEntries(other);
+	for (auto &child_vector : other_vector) {
+		auto vector = make_unique<Vector>(*child_vector, sel, count);
+		children.push_back(move(vector));
+	}
+}
+
+VectorStructBuffer::~VectorStructBuffer() {
+}
+
+VectorListBuffer::VectorListBuffer(unique_ptr<Vector> vector, idx_t initial_capacity)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), capacity(initial_capacity), child(move(vector)) {
+}
+
+VectorListBuffer::VectorListBuffer(const LogicalType &list_type, idx_t initial_capacity)
+    : VectorBuffer(VectorBufferType::LIST_BUFFER), capacity(initial_capacity),
+      child(make_unique<Vector>(ListType::GetChildType(list_type), initial_capacity)) {
+}
+
+void VectorListBuffer::Reserve(idx_t to_reserve) {
+	if (to_reserve > capacity) {
+		idx_t new_capacity = NextPowerOfTwo(to_reserve);
+		D_ASSERT(new_capacity >= to_reserve);
+		child->Resize(capacity, new_capacity);
+		capacity = new_capacity;
+	}
+}
+
+void VectorListBuffer::Append(const Vector &to_append, idx_t to_append_size, idx_t source_offset) {
+	Reserve(size + to_append_size - source_offset);
+	VectorOperations::Copy(to_append, *child, to_append_size, source_offset, size);
+	size += to_append_size - source_offset;
+}
+
+void VectorListBuffer::Append(const Vector &to_append, const SelectionVector &sel, idx_t to_append_size,
+                              idx_t source_offset) {
+	Reserve(size + to_append_size - source_offset);
+	VectorOperations::Copy(to_append, *child, sel, to_append_size, source_offset, size);
+	size += to_append_size - source_offset;
+}
+
+void VectorListBuffer::PushBack(const Value &insert) {
+	if (size + 1 > capacity) {
+		child->Resize(capacity, capacity * 2);
+		capacity *= 2;
+	}
+	child->SetValue(size++, insert);
+}
+
+VectorListBuffer::~VectorListBuffer() {
+}
+
+ManagedVectorBuffer::ManagedVectorBuffer(unique_ptr<BufferHandle> handle)
+    : VectorBuffer(VectorBufferType::MANAGED_BUFFER), handle(move(handle)) {
+}
+
+ManagedVectorBuffer::~ManagedVectorBuffer() {
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+class VectorCacheBuffer : public VectorBuffer {
+public:
+	explicit VectorCacheBuffer(const LogicalType &type_p)
+	    : VectorBuffer(VectorBufferType::OPAQUE_BUFFER), type(type_p) {
+		auto internal_type = type.InternalType();
+		switch (internal_type) {
+		case PhysicalType::LIST: {
+			// memory for the list offsets
+			owned_data = unique_ptr<data_t[]>(new data_t[STANDARD_VECTOR_SIZE * GetTypeIdSize(internal_type)]);
+			// child data of the list
+			auto &child_type = ListType::GetChildType(type);
+			child_caches.push_back(make_buffer<VectorCacheBuffer>(child_type));
+			auto child_vector = make_unique<Vector>(child_type, false, false);
+			auxiliary = make_unique<VectorListBuffer>(move(child_vector));
+			break;
+		}
+		case PhysicalType::STRUCT: {
+			auto &child_types = StructType::GetChildTypes(type);
+			for (auto &child_type : child_types) {
+				child_caches.push_back(make_buffer<VectorCacheBuffer>(child_type.second));
+			}
+			auto struct_buffer = make_unique<VectorStructBuffer>(type);
+			auxiliary = move(struct_buffer);
+			break;
+		}
+		default:
+			owned_data = unique_ptr<data_t[]>(new data_t[STANDARD_VECTOR_SIZE * GetTypeIdSize(internal_type)]);
+			break;
+		}
+	}
+
+	void ResetFromCache(Vector &result, const buffer_ptr<VectorBuffer> &buffer) {
+		D_ASSERT(type == result.GetType());
+		auto internal_type = type.InternalType();
+		result.vector_type = VectorType::FLAT_VECTOR;
+		AssignSharedPointer(result.buffer, buffer);
+		result.validity.Reset();
+		switch (internal_type) {
+		case PhysicalType::LIST: {
+			result.data = owned_data.get();
+			// reinitialize the VectorListBuffer
+			AssignSharedPointer(result.auxiliary, auxiliary);
+			// propagate through child
+			auto &list_buffer = (VectorListBuffer &)*result.auxiliary;
+			list_buffer.capacity = STANDARD_VECTOR_SIZE;
+			list_buffer.size = 0;
+
+			auto &list_child = list_buffer.GetChild();
+			auto &child_cache = (VectorCacheBuffer &)*child_caches[0];
+			child_cache.ResetFromCache(list_child, child_caches[0]);
+			break;
+		}
+		case PhysicalType::STRUCT: {
+			// struct does not have data
+			result.data = nullptr;
+			// reinitialize the VectorStructBuffer
+			AssignSharedPointer(result.auxiliary, auxiliary);
+			// propagate through children
+			auto &children = ((VectorStructBuffer &)*result.auxiliary).GetChildren();
+			for (idx_t i = 0; i < children.size(); i++) {
+				auto &child_cache = (VectorCacheBuffer &)*child_caches[i];
+				child_cache.ResetFromCache(*children[i], child_caches[i]);
+			}
+			break;
+		}
+		default:
+			// regular type: no aux data and reset data to cached data
+			result.data = owned_data.get();
+			result.auxiliary.reset();
+			break;
+		}
+	}
+
+	const LogicalType &GetType() {
+		return type;
+	}
+
+private:
+	//! The type of the vector cache
+	LogicalType type;
+	//! Owned data
+	unique_ptr<data_t[]> owned_data;
+	//! Child caches (if any). Used for nested types.
+	vector<buffer_ptr<VectorBuffer>> child_caches;
+	//! Aux data for the vector (if any)
+	buffer_ptr<VectorBuffer> auxiliary;
+};
+
+VectorCache::VectorCache(const LogicalType &type_p) {
+	buffer = make_unique<VectorCacheBuffer>(type_p);
+}
+
+void VectorCache::ResetFromCache(Vector &result) const {
+	D_ASSERT(buffer);
+	auto &vcache = (VectorCacheBuffer &)*buffer;
+	vcache.ResetFromCache(result, buffer);
+}
+
+const LogicalType &VectorCache::GetType() const {
+	auto &vcache = (VectorCacheBuffer &)*buffer;
+	return vcache.GetType();
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+const SelectionVector *ConstantVector::ZeroSelectionVector() {
+	static const SelectionVector ZERO_SELECTION_VECTOR = SelectionVector((sel_t *)ConstantVector::ZERO_VECTOR);
+	return &ZERO_SELECTION_VECTOR;
+}
+
+const SelectionVector *FlatVector::IncrementalSelectionVector() {
+	static const SelectionVector INCREMENTAL_SELECTION_VECTOR;
+	return &INCREMENTAL_SELECTION_VECTOR;
+}
+
+const sel_t ConstantVector::ZERO_VECTOR[STANDARD_VECTOR_SIZE] = {0};
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cmath>
+
+namespace duckdb {
+
+LogicalType::LogicalType() : LogicalType(LogicalTypeId::INVALID) {
+}
+
+LogicalType::LogicalType(LogicalTypeId id) : id_(id) {
+	physical_type_ = GetInternalType();
+}
+LogicalType::LogicalType(LogicalTypeId id, shared_ptr<ExtraTypeInfo> type_info_p)
+    : id_(id), type_info_(move(type_info_p)) {
+	physical_type_ = GetInternalType();
+}
+
+LogicalType::LogicalType(const LogicalType &other)
+    : id_(other.id_), physical_type_(other.physical_type_), type_info_(other.type_info_) {
+}
+
+LogicalType::LogicalType(LogicalType &&other) noexcept
+    : id_(other.id_), physical_type_(other.physical_type_), type_info_(move(other.type_info_)) {
+}
+
+hash_t LogicalType::Hash() const {
+	return duckdb::Hash<uint8_t>((uint8_t)id_);
+}
+
+PhysicalType LogicalType::GetInternalType() {
+	switch (id_) {
+	case LogicalTypeId::BOOLEAN:
+		return PhysicalType::BOOL;
+	case LogicalTypeId::TINYINT:
+		return PhysicalType::INT8;
+	case LogicalTypeId::UTINYINT:
+		return PhysicalType::UINT8;
+	case LogicalTypeId::SMALLINT:
+		return PhysicalType::INT16;
+	case LogicalTypeId::USMALLINT:
+		return PhysicalType::UINT16;
+	case LogicalTypeId::SQLNULL:
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::INTEGER:
+		return PhysicalType::INT32;
+	case LogicalTypeId::UINTEGER:
+		return PhysicalType::UINT32;
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return PhysicalType::INT64;
+	case LogicalTypeId::UBIGINT:
+		return PhysicalType::UINT64;
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UUID:
+		return PhysicalType::INT128;
+	case LogicalTypeId::FLOAT:
+		return PhysicalType::FLOAT;
+	case LogicalTypeId::DOUBLE:
+		return PhysicalType::DOUBLE;
+	case LogicalTypeId::DECIMAL: {
+		if (!type_info_) {
+			return PhysicalType::INVALID;
+		}
+		auto width = DecimalType::GetWidth(*this);
+		if (width <= Decimal::MAX_WIDTH_INT16) {
+			return PhysicalType::INT16;
+		} else if (width <= Decimal::MAX_WIDTH_INT32) {
+			return PhysicalType::INT32;
+		} else if (width <= Decimal::MAX_WIDTH_INT64) {
+			return PhysicalType::INT64;
+		} else if (width <= Decimal::MAX_WIDTH_INT128) {
+			return PhysicalType::INT128;
+		} else {
+			throw InternalException("Widths bigger than %d are not supported", DecimalType::MaxWidth());
+		}
+	}
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::CHAR:
+	case LogicalTypeId::BLOB:
+	case LogicalTypeId::JSON:
+		return PhysicalType::VARCHAR;
+	case LogicalTypeId::INTERVAL:
+		return PhysicalType::INTERVAL;
+	case LogicalTypeId::MAP:
+	case LogicalTypeId::STRUCT:
+		return PhysicalType::STRUCT;
+	case LogicalTypeId::LIST:
+		return PhysicalType::LIST;
+	case LogicalTypeId::POINTER:
+		// LCOV_EXCL_START
+		if (sizeof(uintptr_t) == sizeof(uint32_t)) {
+			return PhysicalType::UINT32;
+		} else if (sizeof(uintptr_t) == sizeof(uint64_t)) {
+			return PhysicalType::UINT64;
+		} else {
+			throw InternalException("Unsupported pointer size");
+		}
+		// LCOV_EXCL_STOP
+	case LogicalTypeId::VALIDITY:
+		return PhysicalType::BIT;
+	case LogicalTypeId::ENUM: {
+		D_ASSERT(type_info_);
+		return EnumType::GetPhysicalType(*this);
+	}
+	case LogicalTypeId::TABLE:
+	case LogicalTypeId::ANY:
+	case LogicalTypeId::INVALID:
+	case LogicalTypeId::UNKNOWN:
+		return PhysicalType::INVALID;
+	case LogicalTypeId::USER:
+		return PhysicalType::UNKNOWN;
+	case LogicalTypeId::AGGREGATE_STATE:
+		return PhysicalType::VARCHAR;
+	default:
+		throw InternalException("Invalid LogicalType %s", ToString());
+	}
+}
+
+constexpr const LogicalTypeId LogicalType::INVALID;
+constexpr const LogicalTypeId LogicalType::SQLNULL;
+constexpr const LogicalTypeId LogicalType::BOOLEAN;
+constexpr const LogicalTypeId LogicalType::TINYINT;
+constexpr const LogicalTypeId LogicalType::UTINYINT;
+constexpr const LogicalTypeId LogicalType::SMALLINT;
+constexpr const LogicalTypeId LogicalType::USMALLINT;
+constexpr const LogicalTypeId LogicalType::INTEGER;
+constexpr const LogicalTypeId LogicalType::UINTEGER;
+constexpr const LogicalTypeId LogicalType::BIGINT;
+constexpr const LogicalTypeId LogicalType::UBIGINT;
+constexpr const LogicalTypeId LogicalType::HUGEINT;
+constexpr const LogicalTypeId LogicalType::UUID;
+constexpr const LogicalTypeId LogicalType::FLOAT;
+constexpr const LogicalTypeId LogicalType::DOUBLE;
+constexpr const LogicalTypeId LogicalType::DATE;
+
+constexpr const LogicalTypeId LogicalType::TIMESTAMP;
+constexpr const LogicalTypeId LogicalType::TIMESTAMP_MS;
+constexpr const LogicalTypeId LogicalType::TIMESTAMP_NS;
+constexpr const LogicalTypeId LogicalType::TIMESTAMP_S;
+
+constexpr const LogicalTypeId LogicalType::TIME;
+
+constexpr const LogicalTypeId LogicalType::TIME_TZ;
+constexpr const LogicalTypeId LogicalType::TIMESTAMP_TZ;
+
+constexpr const LogicalTypeId LogicalType::HASH;
+constexpr const LogicalTypeId LogicalType::POINTER;
+
+constexpr const LogicalTypeId LogicalType::VARCHAR;
+constexpr const LogicalTypeId LogicalType::JSON;
+
+constexpr const LogicalTypeId LogicalType::BLOB;
+constexpr const LogicalTypeId LogicalType::INTERVAL;
+constexpr const LogicalTypeId LogicalType::ROW_TYPE;
+
+// TODO these are incomplete and should maybe not exist as such
+constexpr const LogicalTypeId LogicalType::TABLE;
+
+constexpr const LogicalTypeId LogicalType::ANY;
+
+const vector<LogicalType> LogicalType::Numeric() {
+	vector<LogicalType> types = {LogicalType::TINYINT,   LogicalType::SMALLINT,  LogicalType::INTEGER,
+	                             LogicalType::BIGINT,    LogicalType::HUGEINT,   LogicalType::FLOAT,
+	                             LogicalType::DOUBLE,    LogicalTypeId::DECIMAL, LogicalType::UTINYINT,
+	                             LogicalType::USMALLINT, LogicalType::UINTEGER,  LogicalType::UBIGINT};
+	return types;
+}
+
+const vector<LogicalType> LogicalType::Integral() {
+	vector<LogicalType> types = {LogicalType::TINYINT,   LogicalType::SMALLINT, LogicalType::INTEGER,
+	                             LogicalType::BIGINT,    LogicalType::HUGEINT,  LogicalType::UTINYINT,
+	                             LogicalType::USMALLINT, LogicalType::UINTEGER, LogicalType::UBIGINT};
+	return types;
+}
+
+const vector<LogicalType> LogicalType::AllTypes() {
+	vector<LogicalType> types = {
+	    LogicalType::BOOLEAN,  LogicalType::TINYINT,   LogicalType::SMALLINT,     LogicalType::INTEGER,
+	    LogicalType::BIGINT,   LogicalType::DATE,      LogicalType::TIMESTAMP,    LogicalType::DOUBLE,
+	    LogicalType::FLOAT,    LogicalType::VARCHAR,   LogicalType::BLOB,         LogicalType::INTERVAL,
+	    LogicalType::HUGEINT,  LogicalTypeId::DECIMAL, LogicalType::UTINYINT,     LogicalType::USMALLINT,
+	    LogicalType::UINTEGER, LogicalType::UBIGINT,   LogicalType::TIME,         LogicalTypeId::LIST,
+	    LogicalTypeId::STRUCT, LogicalType::TIME_TZ,   LogicalType::TIMESTAMP_TZ, LogicalTypeId::MAP,
+	    LogicalType::UUID,     LogicalType::JSON};
+	return types;
+}
+
+const PhysicalType ROW_TYPE = PhysicalType::INT64;
+
+// LCOV_EXCL_START
+string TypeIdToString(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BOOL:
+		return "BOOL";
+	case PhysicalType::INT8:
+		return "INT8";
+	case PhysicalType::INT16:
+		return "INT16";
+	case PhysicalType::INT32:
+		return "INT32";
+	case PhysicalType::INT64:
+		return "INT64";
+	case PhysicalType::UINT8:
+		return "UINT8";
+	case PhysicalType::UINT16:
+		return "UINT16";
+	case PhysicalType::UINT32:
+		return "UINT32";
+	case PhysicalType::UINT64:
+		return "UINT64";
+	case PhysicalType::INT128:
+		return "INT128";
+	case PhysicalType::FLOAT:
+		return "FLOAT";
+	case PhysicalType::DOUBLE:
+		return "DOUBLE";
+	case PhysicalType::VARCHAR:
+		return "VARCHAR";
+	case PhysicalType::INTERVAL:
+		return "INTERVAL";
+	case PhysicalType::STRUCT:
+		return "STRUCT";
+	case PhysicalType::LIST:
+		return "LIST";
+	case PhysicalType::INVALID:
+		return "INVALID";
+	case PhysicalType::BIT:
+		return "BIT";
+	case PhysicalType::NA:
+		return "NA";
+	case PhysicalType::HALF_FLOAT:
+		return "HALF_FLOAT";
+	case PhysicalType::STRING:
+		return "ARROW_STRING";
+	case PhysicalType::BINARY:
+		return "BINARY";
+	case PhysicalType::FIXED_SIZE_BINARY:
+		return "FIXED_SIZE_BINARY";
+	case PhysicalType::DATE32:
+		return "DATE32";
+	case PhysicalType::DATE64:
+		return "DATE64";
+	case PhysicalType::TIMESTAMP:
+		return "TIMESTAMP";
+	case PhysicalType::TIME32:
+		return "TIME32";
+	case PhysicalType::TIME64:
+		return "TIME64";
+	case PhysicalType::UNION:
+		return "UNION";
+	case PhysicalType::DICTIONARY:
+		return "DICTIONARY";
+	case PhysicalType::MAP:
+		return "MAP";
+	case PhysicalType::EXTENSION:
+		return "EXTENSION";
+	case PhysicalType::FIXED_SIZE_LIST:
+		return "FIXED_SIZE_LIST";
+	case PhysicalType::DURATION:
+		return "DURATION";
+	case PhysicalType::LARGE_STRING:
+		return "LARGE_STRING";
+	case PhysicalType::LARGE_BINARY:
+		return "LARGE_BINARY";
+	case PhysicalType::LARGE_LIST:
+		return "LARGE_LIST";
+	case PhysicalType::UNKNOWN:
+		return "UNKNOWN";
+	}
+	return "INVALID";
+}
+// LCOV_EXCL_STOP
+
+idx_t GetTypeIdSize(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+	case PhysicalType::BOOL:
+		return sizeof(bool);
+	case PhysicalType::INT8:
+		return sizeof(int8_t);
+	case PhysicalType::INT16:
+		return sizeof(int16_t);
+	case PhysicalType::INT32:
+		return sizeof(int32_t);
+	case PhysicalType::INT64:
+		return sizeof(int64_t);
+	case PhysicalType::UINT8:
+		return sizeof(uint8_t);
+	case PhysicalType::UINT16:
+		return sizeof(uint16_t);
+	case PhysicalType::UINT32:
+		return sizeof(uint32_t);
+	case PhysicalType::UINT64:
+		return sizeof(uint64_t);
+	case PhysicalType::INT128:
+		return sizeof(hugeint_t);
+	case PhysicalType::FLOAT:
+		return sizeof(float);
+	case PhysicalType::DOUBLE:
+		return sizeof(double);
+	case PhysicalType::VARCHAR:
+		return sizeof(string_t);
+	case PhysicalType::INTERVAL:
+		return sizeof(interval_t);
+	case PhysicalType::STRUCT:
+	case PhysicalType::UNKNOWN:
+		return 0; // no own payload
+	case PhysicalType::LIST:
+		return sizeof(list_entry_t); // offset + len
+	default:
+		throw InternalException("Invalid PhysicalType for GetTypeIdSize");
+	}
+}
+
+bool TypeIsConstantSize(PhysicalType type) {
+	return (type >= PhysicalType::BOOL && type <= PhysicalType::DOUBLE) ||
+	       (type >= PhysicalType::FIXED_SIZE_BINARY && type <= PhysicalType::INTERVAL) ||
+	       type == PhysicalType::INTERVAL || type == PhysicalType::INT128;
+}
+bool TypeIsIntegral(PhysicalType type) {
+	return (type >= PhysicalType::UINT8 && type <= PhysicalType::INT64) || type == PhysicalType::INT128;
+}
+bool TypeIsNumeric(PhysicalType type) {
+	return (type >= PhysicalType::UINT8 && type <= PhysicalType::DOUBLE) || type == PhysicalType::INT128;
+}
+bool TypeIsInteger(PhysicalType type) {
+	return (type >= PhysicalType::UINT8 && type <= PhysicalType::INT64) || type == PhysicalType::INT128;
+}
+
+// LCOV_EXCL_START
+string LogicalTypeIdToString(LogicalTypeId id) {
+	switch (id) {
+	case LogicalTypeId::BOOLEAN:
+		return "BOOLEAN";
+	case LogicalTypeId::TINYINT:
+		return "TINYINT";
+	case LogicalTypeId::SMALLINT:
+		return "SMALLINT";
+	case LogicalTypeId::INTEGER:
+		return "INTEGER";
+	case LogicalTypeId::BIGINT:
+		return "BIGINT";
+	case LogicalTypeId::HUGEINT:
+		return "HUGEINT";
+	case LogicalTypeId::UUID:
+		return "UUID";
+	case LogicalTypeId::UTINYINT:
+		return "UTINYINT";
+	case LogicalTypeId::USMALLINT:
+		return "USMALLINT";
+	case LogicalTypeId::UINTEGER:
+		return "UINTEGER";
+	case LogicalTypeId::UBIGINT:
+		return "UBIGINT";
+	case LogicalTypeId::DATE:
+		return "DATE";
+	case LogicalTypeId::TIME:
+		return "TIME";
+	case LogicalTypeId::TIMESTAMP:
+		return "TIMESTAMP";
+	case LogicalTypeId::TIMESTAMP_MS:
+		return "TIMESTAMP_MS";
+	case LogicalTypeId::TIMESTAMP_NS:
+		return "TIMESTAMP_NS";
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return "TIMESTAMP_S";
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return "TIMESTAMP WITH TIME ZONE";
+	case LogicalTypeId::TIME_TZ:
+		return "TIME WITH TIME ZONE";
+	case LogicalTypeId::FLOAT:
+		return "FLOAT";
+	case LogicalTypeId::DOUBLE:
+		return "DOUBLE";
+	case LogicalTypeId::DECIMAL:
+		return "DECIMAL";
+	case LogicalTypeId::VARCHAR:
+		return "VARCHAR";
+	case LogicalTypeId::BLOB:
+		return "BLOB";
+	case LogicalTypeId::CHAR:
+		return "CHAR";
+	case LogicalTypeId::INTERVAL:
+		return "INTERVAL";
+	case LogicalTypeId::SQLNULL:
+		return "NULL";
+	case LogicalTypeId::ANY:
+		return "ANY";
+	case LogicalTypeId::VALIDITY:
+		return "VALIDITY";
+	case LogicalTypeId::STRUCT:
+		return "STRUCT";
+	case LogicalTypeId::LIST:
+		return "LIST";
+	case LogicalTypeId::MAP:
+		return "MAP";
+	case LogicalTypeId::POINTER:
+		return "POINTER";
+	case LogicalTypeId::TABLE:
+		return "TABLE";
+	case LogicalTypeId::INVALID:
+		return "INVALID";
+	case LogicalTypeId::UNKNOWN:
+		return "UNKNOWN";
+	case LogicalTypeId::ENUM:
+		return "ENUM";
+	case LogicalTypeId::AGGREGATE_STATE:
+		return "AGGREGATE_STATE";
+	case LogicalTypeId::USER:
+		return "USER";
+	case LogicalTypeId::JSON:
+		return "JSON";
+	}
+	return "UNDEFINED";
+}
+
+string LogicalType::ToString() const {
+	auto alias = GetAlias();
+	if (!alias.empty()) {
+		return alias;
+	}
+	switch (id_) {
+	case LogicalTypeId::STRUCT: {
+		if (!type_info_) {
+			return "STRUCT";
+		}
+		auto &child_types = StructType::GetChildTypes(*this);
+		string ret = "STRUCT(";
+		for (size_t i = 0; i < child_types.size(); i++) {
+			ret += child_types[i].first + " " + child_types[i].second.ToString();
+			if (i < child_types.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += ")";
+		return ret;
+	}
+	case LogicalTypeId::LIST: {
+		if (!type_info_) {
+			return "LIST";
+		}
+		return ListType::GetChildType(*this).ToString() + "[]";
+	}
+	case LogicalTypeId::MAP: {
+		if (!type_info_) {
+			return "MAP";
+		}
+		auto &child_types = StructType::GetChildTypes(*this);
+		if (child_types.empty()) {
+			return "MAP(?)";
+		}
+		if (child_types.size() != 2) {
+			throw InternalException("Map needs exactly two child elements");
+		}
+		return "MAP(" + ListType::GetChildType(child_types[0].second).ToString() + ", " +
+		       ListType::GetChildType(child_types[1].second).ToString() + ")";
+	}
+	case LogicalTypeId::DECIMAL: {
+		if (!type_info_) {
+			return "DECIMAL";
+		}
+		auto width = DecimalType::GetWidth(*this);
+		auto scale = DecimalType::GetScale(*this);
+		if (width == 0) {
+			return "DECIMAL";
+		}
+		return StringUtil::Format("DECIMAL(%d,%d)", width, scale);
+	}
+	case LogicalTypeId::ENUM: {
+		return KeywordHelper::WriteOptionallyQuoted(EnumType::GetTypeName(*this));
+	}
+	case LogicalTypeId::USER: {
+		return KeywordHelper::WriteOptionallyQuoted(UserType::GetTypeName(*this));
+	}
+	case LogicalTypeId::AGGREGATE_STATE: {
+		return AggregateStateType::GetTypeName(*this);
+	}
+	default:
+		return LogicalTypeIdToString(id_);
+	}
+}
+// LCOV_EXCL_STOP
+
+LogicalTypeId TransformStringToLogicalTypeId(const string &str) {
+	auto type = DefaultTypeGenerator::GetDefaultType(str);
+	if (type == LogicalTypeId::INVALID) {
+		// This is a User Type, at this point we don't know if its one of the User Defined Types or an error
+		// It is checked in the binder
+		type = LogicalTypeId::USER;
+	}
+	return type;
+}
+
+LogicalType TransformStringToLogicalType(const string &str) {
+	if (StringUtil::Lower(str) == "null") {
+		return LogicalType::SQLNULL;
+	}
+	return Parser::ParseColumnList("dummy " + str)[0].Type();
+}
+
+bool LogicalType::IsIntegral() const {
+	switch (id_) {
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::HUGEINT:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool LogicalType::IsNumeric() const {
+	switch (id_) {
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool LogicalType::GetDecimalProperties(uint8_t &width, uint8_t &scale) const {
+	switch (id_) {
+	case LogicalTypeId::SQLNULL:
+		width = 0;
+		scale = 0;
+		break;
+	case LogicalTypeId::BOOLEAN:
+		width = 1;
+		scale = 0;
+		break;
+	case LogicalTypeId::TINYINT:
+		// tinyint: [-127, 127] = DECIMAL(3,0)
+		width = 3;
+		scale = 0;
+		break;
+	case LogicalTypeId::SMALLINT:
+		// smallint: [-32767, 32767] = DECIMAL(5,0)
+		width = 5;
+		scale = 0;
+		break;
+	case LogicalTypeId::INTEGER:
+		// integer: [-2147483647, 2147483647] = DECIMAL(10,0)
+		width = 10;
+		scale = 0;
+		break;
+	case LogicalTypeId::BIGINT:
+		// bigint: [-9223372036854775807, 9223372036854775807] = DECIMAL(19,0)
+		width = 19;
+		scale = 0;
+		break;
+	case LogicalTypeId::UTINYINT:
+		// UInt8 — [0 : 255]
+		width = 3;
+		scale = 0;
+		break;
+	case LogicalTypeId::USMALLINT:
+		// UInt16 — [0 : 65535]
+		width = 5;
+		scale = 0;
+		break;
+	case LogicalTypeId::UINTEGER:
+		// UInt32 — [0 : 4294967295]
+		width = 10;
+		scale = 0;
+		break;
+	case LogicalTypeId::UBIGINT:
+		// UInt64 — [0 : 18446744073709551615]
+		width = 20;
+		scale = 0;
+		break;
+	case LogicalTypeId::HUGEINT:
+		// hugeint: max size decimal (38, 0)
+		// note that a hugeint is not guaranteed to fit in this
+		width = 38;
+		scale = 0;
+		break;
+	case LogicalTypeId::DECIMAL:
+		width = DecimalType::GetWidth(*this);
+		scale = DecimalType::GetScale(*this);
+		break;
+	default:
+		return false;
+	}
+	return true;
+}
+
+LogicalType LogicalType::MaxLogicalType(const LogicalType &left, const LogicalType &right) {
+	if (left.id() < right.id()) {
+		return right;
+	} else if (right.id() < left.id()) {
+		return left;
+	} else {
+		// Since both left and right are equal we get the left type as our type_id for checks
+		auto type_id = left.id();
+		if (type_id == LogicalTypeId::ENUM) {
+			// If both types are different ENUMs we do a string comparison.
+			return left == right ? left : LogicalType::VARCHAR;
+		}
+		if (type_id == LogicalTypeId::VARCHAR) {
+			// varchar: use type that has collation (if any)
+			if (StringType::GetCollation(right).empty()) {
+				return left;
+			} else {
+				return right;
+			}
+		} else if (type_id == LogicalTypeId::DECIMAL) {
+			// unify the width/scale so that the resulting decimal always fits
+			// "width - scale" gives us the number of digits on the left side of the decimal point
+			// "scale" gives us the number of digits allowed on the right of the deciaml point
+			// using the max of these of the two types gives us the new decimal size
+			auto extra_width_left = DecimalType::GetWidth(left) - DecimalType::GetScale(left);
+			auto extra_width_right = DecimalType::GetWidth(right) - DecimalType::GetScale(right);
+			auto extra_width = MaxValue<uint8_t>(extra_width_left, extra_width_right);
+			auto scale = MaxValue<uint8_t>(DecimalType::GetScale(left), DecimalType::GetScale(right));
+			auto width = extra_width + scale;
+			if (width > DecimalType::MaxWidth()) {
+				// if the resulting decimal does not fit, we truncate the scale
+				width = DecimalType::MaxWidth();
+				scale = width - extra_width;
+			}
+			return LogicalType::DECIMAL(width, scale);
+		} else if (type_id == LogicalTypeId::LIST) {
+			// list: perform max recursively on child type
+			auto new_child = MaxLogicalType(ListType::GetChildType(left), ListType::GetChildType(right));
+			return LogicalType::LIST(move(new_child));
+		} else if (type_id == LogicalTypeId::STRUCT) {
+			// struct: perform recursively
+			auto &left_child_types = StructType::GetChildTypes(left);
+			auto &right_child_types = StructType::GetChildTypes(right);
+			if (left_child_types.size() != right_child_types.size()) {
+				// child types are not of equal size, we can't cast anyway
+				// just return the left child
+				return left;
+			}
+			child_list_t<LogicalType> child_types;
+			for (idx_t i = 0; i < left_child_types.size(); i++) {
+				auto child_type = MaxLogicalType(left_child_types[i].second, right_child_types[i].second);
+				child_types.push_back(make_pair(left_child_types[i].first, move(child_type)));
+			}
+			return LogicalType::STRUCT(move(child_types));
+		} else {
+			// types are equal but no extra specifier: just return the type
+			return left;
+		}
+	}
+}
+
+void LogicalType::Verify() const {
+#ifdef DEBUG
+	if (id_ == LogicalTypeId::DECIMAL) {
+		D_ASSERT(DecimalType::GetWidth(*this) >= 1 && DecimalType::GetWidth(*this) <= Decimal::MAX_WIDTH_DECIMAL);
+		D_ASSERT(DecimalType::GetScale(*this) >= 0 && DecimalType::GetScale(*this) <= DecimalType::GetWidth(*this));
+	}
+#endif
+}
+
+bool ApproxEqual(float ldecimal, float rdecimal) {
+	if (Value::IsNan(ldecimal) && Value::IsNan(rdecimal)) {
+		return true;
+	}
+	if (!Value::FloatIsFinite(ldecimal) || !Value::FloatIsFinite(rdecimal)) {
+		return ldecimal == rdecimal;
+	}
+	float epsilon = std::fabs(rdecimal) * 0.01 + 0.00000001;
+	return std::fabs(ldecimal - rdecimal) <= epsilon;
+}
+
+bool ApproxEqual(double ldecimal, double rdecimal) {
+	if (Value::IsNan(ldecimal) && Value::IsNan(rdecimal)) {
+		return true;
+	}
+	if (!Value::DoubleIsFinite(ldecimal) || !Value::DoubleIsFinite(rdecimal)) {
+		return ldecimal == rdecimal;
+	}
+	double epsilon = std::fabs(rdecimal) * 0.01 + 0.00000001;
+	return std::fabs(ldecimal - rdecimal) <= epsilon;
+}
+
+//===--------------------------------------------------------------------===//
+// Extra Type Info
+//===--------------------------------------------------------------------===//
+enum class ExtraTypeInfoType : uint8_t {
+	INVALID_TYPE_INFO = 0,
+	GENERIC_TYPE_INFO = 1,
+	DECIMAL_TYPE_INFO = 2,
+	STRING_TYPE_INFO = 3,
+	LIST_TYPE_INFO = 4,
+	STRUCT_TYPE_INFO = 5,
+	ENUM_TYPE_INFO = 6,
+	USER_TYPE_INFO = 7,
+	AGGREGATE_STATE_TYPE_INFO = 8
+};
+
+struct ExtraTypeInfo {
+	explicit ExtraTypeInfo(ExtraTypeInfoType type) : type(type) {
+	}
+	explicit ExtraTypeInfo(ExtraTypeInfoType type, string alias) : type(type), alias(move(alias)) {
+	}
+	virtual ~ExtraTypeInfo() {
+	}
+
+	ExtraTypeInfoType type;
+	string alias;
+	TypeCatalogEntry *catalog_entry = nullptr;
+
+public:
+	bool Equals(ExtraTypeInfo *other_p) const {
+		if (type == ExtraTypeInfoType::INVALID_TYPE_INFO || type == ExtraTypeInfoType::STRING_TYPE_INFO ||
+		    type == ExtraTypeInfoType::GENERIC_TYPE_INFO) {
+			if (!other_p) {
+				if (!alias.empty()) {
+					return false;
+				}
+				return true;
+			}
+			if (alias != other_p->alias) {
+				return false;
+			}
+			return true;
+		}
+		if (!other_p) {
+			return false;
+		}
+		if (type != other_p->type) {
+			return false;
+		}
+		auto &other = (ExtraTypeInfo &)*other_p;
+		return alias == other.alias && EqualsInternal(other_p);
+	}
+	//! Serializes a ExtraTypeInfo to a stand-alone binary blob
+	virtual void Serialize(FieldWriter &writer) const {};
+	//! Serializes a ExtraTypeInfo to a stand-alone binary blob
+	static void Serialize(ExtraTypeInfo *info, FieldWriter &writer);
+	//! Deserializes a blob back into an ExtraTypeInfo
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader);
+
+protected:
+	virtual bool EqualsInternal(ExtraTypeInfo *other_p) const {
+		// Do nothing
+		return true;
+	}
+};
+
+void LogicalType::SetAlias(string &alias) {
+	if (!type_info_) {
+		type_info_ = make_shared<ExtraTypeInfo>(ExtraTypeInfoType::GENERIC_TYPE_INFO, alias);
+	} else {
+		type_info_->alias = alias;
+	}
+}
+
+string LogicalType::GetAlias() const {
+	if (!type_info_) {
+		return string();
+	} else {
+		return type_info_->alias;
+	}
+}
+
+void LogicalType::SetCatalog(LogicalType &type, TypeCatalogEntry *catalog_entry) {
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	((ExtraTypeInfo &)*info).catalog_entry = catalog_entry;
+}
+TypeCatalogEntry *LogicalType::GetCatalog(const LogicalType &type) {
+	auto info = type.AuxInfo();
+	if (!info) {
+		return nullptr;
+	}
+	return ((ExtraTypeInfo &)*info).catalog_entry;
+}
+
+//===--------------------------------------------------------------------===//
+// Decimal Type
+//===--------------------------------------------------------------------===//
+struct DecimalTypeInfo : public ExtraTypeInfo {
+	DecimalTypeInfo(uint8_t width_p, uint8_t scale_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::DECIMAL_TYPE_INFO), width(width_p), scale(scale_p) {
+	}
+
+	uint8_t width;
+	uint8_t scale;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		writer.WriteField<uint8_t>(width);
+		writer.WriteField<uint8_t>(scale);
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		auto width = reader.ReadRequired<uint8_t>();
+		auto scale = reader.ReadRequired<uint8_t>();
+		return make_shared<DecimalTypeInfo>(width, scale);
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (DecimalTypeInfo &)*other_p;
+		return width == other.width && scale == other.scale;
+	}
+};
+
+uint8_t DecimalType::GetWidth(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::DECIMAL);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((DecimalTypeInfo &)*info).width;
+}
+
+uint8_t DecimalType::GetScale(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::DECIMAL);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((DecimalTypeInfo &)*info).scale;
+}
+
+uint8_t DecimalType::MaxWidth() {
+	return 38;
+}
+
+LogicalType LogicalType::DECIMAL(int width, int scale) {
+	auto type_info = make_shared<DecimalTypeInfo>(width, scale);
+	return LogicalType(LogicalTypeId::DECIMAL, move(type_info));
+}
+
+//===--------------------------------------------------------------------===//
+// String Type
+//===--------------------------------------------------------------------===//
+struct StringTypeInfo : public ExtraTypeInfo {
+	explicit StringTypeInfo(string collation_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::STRING_TYPE_INFO), collation(move(collation_p)) {
+	}
+
+	string collation;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		writer.WriteString(collation);
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		auto collation = reader.ReadRequired<string>();
+		return make_shared<StringTypeInfo>(move(collation));
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		// collation info has no impact on equality
+		return true;
+	}
+};
+
+string StringType::GetCollation(const LogicalType &type) {
+	if (type.id() != LogicalTypeId::VARCHAR) {
+		return string();
+	}
+	auto info = type.AuxInfo();
+	if (!info) {
+		return string();
+	}
+	if (info->type == ExtraTypeInfoType::GENERIC_TYPE_INFO) {
+		return string();
+	}
+	return ((StringTypeInfo &)*info).collation;
+}
+
+LogicalType LogicalType::VARCHAR_COLLATION(string collation) { // NOLINT
+	auto string_info = make_shared<StringTypeInfo>(move(collation));
+	return LogicalType(LogicalTypeId::VARCHAR, move(string_info));
+}
+
+//===--------------------------------------------------------------------===//
+// List Type
+//===--------------------------------------------------------------------===//
+struct ListTypeInfo : public ExtraTypeInfo {
+	explicit ListTypeInfo(LogicalType child_type_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::LIST_TYPE_INFO), child_type(move(child_type_p)) {
+	}
+
+	LogicalType child_type;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		writer.WriteSerializable(child_type);
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		auto child_type = reader.ReadRequiredSerializable<LogicalType, LogicalType>();
+		return make_shared<ListTypeInfo>(move(child_type));
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (ListTypeInfo &)*other_p;
+		return child_type == other.child_type;
+	}
+};
+
+const LogicalType &ListType::GetChildType(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::LIST);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((ListTypeInfo &)*info).child_type;
+}
+
+LogicalType LogicalType::LIST(LogicalType child) {
+	auto info = make_shared<ListTypeInfo>(move(child));
+	return LogicalType(LogicalTypeId::LIST, move(info));
+}
+
+//===--------------------------------------------------------------------===//
+// Struct Type
+//===--------------------------------------------------------------------===//
+struct StructTypeInfo : public ExtraTypeInfo {
+	explicit StructTypeInfo(child_list_t<LogicalType> child_types_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::STRUCT_TYPE_INFO), child_types(move(child_types_p)) {
+	}
+
+	child_list_t<LogicalType> child_types;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		writer.WriteField<uint32_t>(child_types.size());
+		auto &serializer = writer.GetSerializer();
+		for (idx_t i = 0; i < child_types.size(); i++) {
+			serializer.WriteString(child_types[i].first);
+			child_types[i].second.Serialize(serializer);
+		}
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		child_list_t<LogicalType> child_list;
+		auto child_types_size = reader.ReadRequired<uint32_t>();
+		auto &source = reader.GetSource();
+		for (uint32_t i = 0; i < child_types_size; i++) {
+			auto name = source.Read<string>();
+			auto type = LogicalType::Deserialize(source);
+			child_list.push_back(make_pair(move(name), move(type)));
+		}
+		return make_shared<StructTypeInfo>(move(child_list));
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (StructTypeInfo &)*other_p;
+		return child_types == other.child_types;
+	}
+};
+
+struct AggregateStateTypeInfo : public ExtraTypeInfo {
+	explicit AggregateStateTypeInfo(aggregate_state_t state_type_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::AGGREGATE_STATE_TYPE_INFO), state_type(move(state_type_p)) {
+	}
+
+	aggregate_state_t state_type;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		auto &serializer = writer.GetSerializer();
+		writer.WriteString(state_type.function_name);
+		state_type.return_type.Serialize(serializer);
+		writer.WriteField<uint32_t>(state_type.bound_argument_types.size());
+		for (idx_t i = 0; i < state_type.bound_argument_types.size(); i++) {
+			state_type.bound_argument_types[i].Serialize(serializer);
+		}
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		auto &source = reader.GetSource();
+
+		auto function_name = reader.ReadRequired<string>();
+		auto return_type = LogicalType::Deserialize(source);
+		auto bound_argument_types_size = reader.ReadRequired<uint32_t>();
+		vector<LogicalType> bound_argument_types;
+
+		for (uint32_t i = 0; i < bound_argument_types_size; i++) {
+			auto type = LogicalType::Deserialize(source);
+			bound_argument_types.push_back(move(type));
+		}
+		return make_shared<AggregateStateTypeInfo>(
+		    aggregate_state_t(move(function_name), move(return_type), move(bound_argument_types)));
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (AggregateStateTypeInfo &)*other_p;
+		return state_type.function_name == other.state_type.function_name &&
+		       state_type.return_type == other.state_type.return_type &&
+		       state_type.bound_argument_types == other.state_type.bound_argument_types;
+	}
+};
+
+const aggregate_state_t &AggregateStateType::GetStateType(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::AGGREGATE_STATE);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((AggregateStateTypeInfo &)*info).state_type;
+}
+
+const string AggregateStateType::GetTypeName(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::AGGREGATE_STATE);
+	auto info = type.AuxInfo();
+	if (!info) {
+		return "AGGREGATE_STATE<?>";
+	}
+	auto aggr_state = ((AggregateStateTypeInfo &)*info).state_type;
+	return "AGGREGATE_STATE<" + aggr_state.function_name + "(" +
+	       StringUtil::Join(aggr_state.bound_argument_types, aggr_state.bound_argument_types.size(), ", ",
+	                        [](const LogicalType &arg_type) { return arg_type.ToString(); }) +
+	       ")" + "::" + aggr_state.return_type.ToString() + ">";
+}
+
+const child_list_t<LogicalType> &StructType::GetChildTypes(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::STRUCT || type.id() == LogicalTypeId::MAP);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((StructTypeInfo &)*info).child_types;
+}
+
+const LogicalType &StructType::GetChildType(const LogicalType &type, idx_t index) {
+	auto &child_types = StructType::GetChildTypes(type);
+	D_ASSERT(index < child_types.size());
+	return child_types[index].second;
+}
+
+const string &StructType::GetChildName(const LogicalType &type, idx_t index) {
+	auto &child_types = StructType::GetChildTypes(type);
+	D_ASSERT(index < child_types.size());
+	return child_types[index].first;
+}
+
+idx_t StructType::GetChildCount(const LogicalType &type) {
+	return StructType::GetChildTypes(type).size();
+}
+
+LogicalType LogicalType::STRUCT(child_list_t<LogicalType> children) {
+	auto info = make_shared<StructTypeInfo>(move(children));
+	return LogicalType(LogicalTypeId::STRUCT, move(info));
+}
+
+LogicalType LogicalType::AGGREGATE_STATE(aggregate_state_t state_type) { // NOLINT
+	auto info = make_shared<AggregateStateTypeInfo>(move(state_type));
+	return LogicalType(LogicalTypeId::AGGREGATE_STATE, move(info));
+}
+
+//===--------------------------------------------------------------------===//
+// Map Type
+//===--------------------------------------------------------------------===//
+LogicalType LogicalType::MAP(child_list_t<LogicalType> children) {
+	auto info = make_shared<StructTypeInfo>(move(children));
+	return LogicalType(LogicalTypeId::MAP, move(info));
+}
+
+LogicalType LogicalType::MAP(LogicalType key, LogicalType value) {
+	child_list_t<LogicalType> child_types;
+	child_types.push_back({"key", LogicalType::LIST(move(key))});
+	child_types.push_back({"value", LogicalType::LIST(move(value))});
+	return LogicalType::MAP(move(child_types));
+}
+
+const LogicalType &MapType::KeyType(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::MAP);
+	return ListType::GetChildType(StructType::GetChildTypes(type)[0].second);
+}
+
+const LogicalType &MapType::ValueType(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::MAP);
+	return ListType::GetChildType(StructType::GetChildTypes(type)[1].second);
+}
+
+//===--------------------------------------------------------------------===//
+// User Type
+//===--------------------------------------------------------------------===//
+struct UserTypeInfo : public ExtraTypeInfo {
+	explicit UserTypeInfo(string name_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::USER_TYPE_INFO), user_type_name(move(name_p)) {
+	}
+
+	string user_type_name;
+
+public:
+	void Serialize(FieldWriter &writer) const override {
+		writer.WriteString(user_type_name);
+	}
+
+	static shared_ptr<ExtraTypeInfo> Deserialize(FieldReader &reader) {
+		auto enum_name = reader.ReadRequired<string>();
+		return make_shared<UserTypeInfo>(move(enum_name));
+	}
+
+protected:
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (UserTypeInfo &)*other_p;
+		return other.user_type_name == user_type_name;
+	}
+};
+
+const string &UserType::GetTypeName(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::USER);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((UserTypeInfo &)*info).user_type_name;
+}
+
+LogicalType LogicalType::USER(const string &user_type_name) {
+	auto info = make_shared<UserTypeInfo>(user_type_name);
+	return LogicalType(LogicalTypeId::USER, move(info));
+}
+
+//===--------------------------------------------------------------------===//
+// Enum Type
+//===--------------------------------------------------------------------===//
+
+enum EnumDictType : uint8_t { INVALID = 0, VECTOR_DICT = 1, DEDUP_POINTER = 2 };
+
+struct EnumTypeInfo : public ExtraTypeInfo {
+	explicit EnumTypeInfo(string enum_name_p, Vector &values_insert_order_p, idx_t dict_size_p)
+	    : ExtraTypeInfo(ExtraTypeInfoType::ENUM_TYPE_INFO), dict_type(EnumDictType::VECTOR_DICT),
+	      enum_name(move(enum_name_p)), values_insert_order(values_insert_order_p), dict_size(dict_size_p) {
+	}
+	explicit EnumTypeInfo()
+	    : ExtraTypeInfo(ExtraTypeInfoType::ENUM_TYPE_INFO), dict_type(EnumDictType::DEDUP_POINTER),
+	      enum_name("dedup_pointer"), values_insert_order(Vector(LogicalType::VARCHAR)), dict_size(0) {
+	}
+	EnumDictType dict_type;
+	string enum_name;
+	Vector values_insert_order;
+	idx_t dict_size;
+
+protected:
+	// Equalities are only used in enums with different catalog entries
+	bool EqualsInternal(ExtraTypeInfo *other_p) const override {
+		auto &other = (EnumTypeInfo &)*other_p;
+		if (dict_type != other.dict_type) {
+			return false;
+		}
+		if (dict_type == EnumDictType::DEDUP_POINTER) {
+			return true;
+		}
+		D_ASSERT(dict_type == EnumDictType::VECTOR_DICT);
+		// We must check if both enums have the same size
+		if (other.dict_size != dict_size) {
+			return false;
+		}
+		auto other_vector_ptr = FlatVector::GetData<string_t>(other.values_insert_order);
+		auto this_vector_ptr = FlatVector::GetData<string_t>(values_insert_order);
+
+		// Now we must check if all strings are the same
+		for (idx_t i = 0; i < dict_size; i++) {
+			if (!Equals::Operation(other_vector_ptr[i], this_vector_ptr[i])) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	void Serialize(FieldWriter &writer) const override {
+		if (dict_type != EnumDictType::VECTOR_DICT) {
+			throw InternalException("Cannot serialize non-vector dictionary ENUM types");
+		}
+		writer.WriteField<uint32_t>(dict_size);
+		writer.WriteString(enum_name);
+		((Vector &)values_insert_order).Serialize(dict_size, writer.GetSerializer());
+	}
+};
+
+template <class T>
+struct EnumTypeInfoTemplated : public EnumTypeInfo {
+	explicit EnumTypeInfoTemplated(const string &enum_name_p, Vector &values_insert_order_p, idx_t size_p)
+	    : EnumTypeInfo(enum_name_p, values_insert_order_p, size_p) {
+		for (idx_t count = 0; count < size_p; count++) {
+			values[values_insert_order_p.GetValue(count).ToString()] = count;
+		}
+	}
+
+	static shared_ptr<EnumTypeInfoTemplated> Deserialize(FieldReader &reader, uint32_t size) {
+		auto enum_name = reader.ReadRequired<string>();
+		Vector values_insert_order(LogicalType::VARCHAR, size);
+		values_insert_order.Deserialize(size, reader.GetSource());
+		return make_shared<EnumTypeInfoTemplated>(move(enum_name), values_insert_order, size);
+	}
+	unordered_map<string, T> values;
+};
+
+const string &EnumType::GetTypeName(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((EnumTypeInfo &)*info).enum_name;
+}
+
+static PhysicalType EnumVectorDictType(idx_t size) {
+	if (size <= NumericLimits<uint8_t>::Maximum()) {
+		return PhysicalType::UINT8;
+	} else if (size <= NumericLimits<uint16_t>::Maximum()) {
+		return PhysicalType::UINT16;
+	} else if (size <= NumericLimits<uint32_t>::Maximum()) {
+		return PhysicalType::UINT32;
+	} else {
+		throw InternalException("Enum size must be lower than " + std::to_string(NumericLimits<uint32_t>::Maximum()));
+	}
+}
+
+LogicalType LogicalType::ENUM(const string &enum_name, Vector &ordered_data, idx_t size) {
+	// Generate EnumTypeInfo
+	shared_ptr<ExtraTypeInfo> info;
+	auto enum_internal_type = EnumVectorDictType(size);
+	switch (enum_internal_type) {
+	case PhysicalType::UINT8:
+		info = make_shared<EnumTypeInfoTemplated<uint8_t>>(enum_name, ordered_data, size);
+		break;
+	case PhysicalType::UINT16:
+		info = make_shared<EnumTypeInfoTemplated<uint16_t>>(enum_name, ordered_data, size);
+		break;
+	case PhysicalType::UINT32:
+		info = make_shared<EnumTypeInfoTemplated<uint32_t>>(enum_name, ordered_data, size);
+		break;
+	default:
+		throw InternalException("Invalid Physical Type for ENUMs");
+	}
+	// Generate Actual Enum Type
+	return LogicalType(LogicalTypeId::ENUM, info);
+}
+
+LogicalType LogicalType::DEDUP_POINTER_ENUM() { // NOLINT
+	auto info = make_shared<EnumTypeInfo>();
+	D_ASSERT(info->dict_type == EnumDictType::DEDUP_POINTER);
+	return LogicalType(LogicalTypeId::ENUM, info);
+}
+
+template <class T>
+int64_t TemplatedGetPos(unordered_map<string, T> &map, const string &key) {
+	auto it = map.find(key);
+	if (it == map.end()) {
+		return -1;
+	}
+	return it->second;
+}
+int64_t EnumType::GetPos(const LogicalType &type, const string &key) {
+	auto info = type.AuxInfo();
+	switch (type.InternalType()) {
+	case PhysicalType::UINT8:
+		return TemplatedGetPos(((EnumTypeInfoTemplated<uint8_t> &)*info).values, key);
+	case PhysicalType::UINT16:
+		return TemplatedGetPos(((EnumTypeInfoTemplated<uint16_t> &)*info).values, key);
+	case PhysicalType::UINT32:
+		return TemplatedGetPos(((EnumTypeInfoTemplated<uint32_t> &)*info).values, key);
+	default:
+		throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
+	}
+}
+
+const string EnumType::GetValue(const Value &val) {
+	auto info = val.type().AuxInfo();
+	auto &enum_info = ((EnumTypeInfo &)*info);
+	if (enum_info.dict_type == EnumDictType::DEDUP_POINTER) {
+		return (const char *)val.GetValue<uint64_t>();
+	}
+	auto &values_insert_order = ((EnumTypeInfo &)*info).values_insert_order;
+	return StringValue::Get(values_insert_order.GetValue(val.GetValue<uint32_t>()));
+}
+
+Vector &EnumType::GetValuesInsertOrder(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((EnumTypeInfo &)*info).values_insert_order;
+}
+
+idx_t EnumType::GetSize(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((EnumTypeInfo &)*info).dict_size;
+}
+
+void EnumType::SetCatalog(LogicalType &type, TypeCatalogEntry *catalog_entry) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	((EnumTypeInfo &)*info).catalog_entry = catalog_entry;
+}
+TypeCatalogEntry *EnumType::GetCatalog(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto info = type.AuxInfo();
+	D_ASSERT(info);
+	return ((EnumTypeInfo &)*info).catalog_entry;
+}
+
+PhysicalType EnumType::GetPhysicalType(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::ENUM);
+	auto aux_info = type.AuxInfo();
+	D_ASSERT(aux_info);
+	auto &info = (EnumTypeInfo &)*aux_info;
+
+	if (info.dict_type == EnumDictType::DEDUP_POINTER) {
+		return PhysicalType::UINT64; // for pointer enum types
+	}
+	D_ASSERT(info.dict_type == EnumDictType::VECTOR_DICT);
+	return EnumVectorDictType(info.dict_size);
+}
+
+//===--------------------------------------------------------------------===//
+// Extra Type Info
+//===--------------------------------------------------------------------===//
+void ExtraTypeInfo::Serialize(ExtraTypeInfo *info, FieldWriter &writer) {
+	if (!info) {
+		writer.WriteField<ExtraTypeInfoType>(ExtraTypeInfoType::INVALID_TYPE_INFO);
+		writer.WriteString(string());
+	} else {
+		writer.WriteField<ExtraTypeInfoType>(info->type);
+		info->Serialize(writer);
+		writer.WriteString(info->alias);
+	}
+}
+shared_ptr<ExtraTypeInfo> ExtraTypeInfo::Deserialize(FieldReader &reader) {
+	auto type = reader.ReadRequired<ExtraTypeInfoType>();
+	shared_ptr<ExtraTypeInfo> extra_info;
+	switch (type) {
+	case ExtraTypeInfoType::INVALID_TYPE_INFO: {
+		auto alias = reader.ReadField<string>(string());
+		if (!alias.empty()) {
+			return make_shared<ExtraTypeInfo>(type, alias);
+		}
+		return nullptr;
+	} break;
+	case ExtraTypeInfoType::GENERIC_TYPE_INFO: {
+		extra_info = make_shared<ExtraTypeInfo>(type);
+	} break;
+	case ExtraTypeInfoType::DECIMAL_TYPE_INFO:
+		extra_info = DecimalTypeInfo::Deserialize(reader);
+		break;
+	case ExtraTypeInfoType::STRING_TYPE_INFO:
+		extra_info = StringTypeInfo::Deserialize(reader);
+		break;
+	case ExtraTypeInfoType::LIST_TYPE_INFO:
+		extra_info = ListTypeInfo::Deserialize(reader);
+		break;
+	case ExtraTypeInfoType::STRUCT_TYPE_INFO:
+		extra_info = StructTypeInfo::Deserialize(reader);
+		break;
+	case ExtraTypeInfoType::USER_TYPE_INFO:
+		extra_info = UserTypeInfo::Deserialize(reader);
+		break;
+	case ExtraTypeInfoType::ENUM_TYPE_INFO: {
+		auto enum_size = reader.ReadRequired<uint32_t>();
+		auto enum_internal_type = EnumVectorDictType(enum_size);
+		switch (enum_internal_type) {
+		case PhysicalType::UINT8:
+			extra_info = EnumTypeInfoTemplated<uint8_t>::Deserialize(reader, enum_size);
+			break;
+		case PhysicalType::UINT16:
+			extra_info = EnumTypeInfoTemplated<uint16_t>::Deserialize(reader, enum_size);
+			break;
+		case PhysicalType::UINT32:
+			extra_info = EnumTypeInfoTemplated<uint32_t>::Deserialize(reader, enum_size);
+			break;
+		default:
+			throw InternalException("Invalid Physical Type for ENUMs");
+		}
+	} break;
+	case ExtraTypeInfoType::AGGREGATE_STATE_TYPE_INFO:
+		extra_info = AggregateStateTypeInfo::Deserialize(reader);
+		break;
+
+	default:
+		throw InternalException("Unimplemented type info in ExtraTypeInfo::Deserialize");
+	}
+	auto alias = reader.ReadField<string>(string());
+	extra_info->alias = alias;
+	return extra_info;
+}
+
+//===--------------------------------------------------------------------===//
+// Logical Type
+//===--------------------------------------------------------------------===//
+
+// the destructor needs to know about the extra type info
+LogicalType::~LogicalType() {
+}
+
+void LogicalType::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	writer.WriteField<LogicalTypeId>(id_);
+	ExtraTypeInfo::Serialize(type_info_.get(), writer);
+	writer.Finalize();
+}
+
+LogicalType LogicalType::Deserialize(Deserializer &source) {
+	FieldReader reader(source);
+	auto id = reader.ReadRequired<LogicalTypeId>();
+	auto info = ExtraTypeInfo::Deserialize(reader);
+	reader.Finalize();
+
+	return LogicalType(id, move(info));
+}
+
+bool LogicalType::operator==(const LogicalType &rhs) const {
+	if (id_ != rhs.id_) {
+		return false;
+	}
+	if (type_info_.get() == rhs.type_info_.get()) {
+		return true;
+	}
+	if (type_info_) {
+		return type_info_->Equals(rhs.type_info_.get());
+	} else {
+		D_ASSERT(rhs.type_info_);
+		return rhs.type_info_->Equals(type_info_.get());
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Comparison Operations
+//===--------------------------------------------------------------------===//
+
+struct ValuePositionComparator {
+	// Return true if the positional Values definitely match.
+	// Default to the same as the final value
+	template <typename OP>
+	static inline bool Definite(const Value &lhs, const Value &rhs) {
+		return Final<OP>(lhs, rhs);
+	}
+
+	// Select the positional Values that need further testing.
+	// Usually this means Is Not Distinct, as those are the semantics used by Postges
+	template <typename OP>
+	static inline bool Possible(const Value &lhs, const Value &rhs) {
+		return ValueOperations::NotDistinctFrom(lhs, rhs);
+	}
+
+	// Return true if the positional Values definitely match in the final position
+	// This needs to be specialised.
+	template <typename OP>
+	static inline bool Final(const Value &lhs, const Value &rhs) {
+		return false;
+	}
+
+	// Tie-break based on length when one of the sides has been exhausted, returning true if the LHS matches.
+	// This essentially means that the existing positions compare equal.
+	// Default to the same semantics as the OP for idx_t. This works in most cases.
+	template <typename OP>
+	static inline bool TieBreak(const idx_t lpos, const idx_t rpos) {
+		return OP::Operation(lpos, rpos);
+	}
+};
+
+// Equals must always check every column
+template <>
+inline bool ValuePositionComparator::Definite<duckdb::Equals>(const Value &lhs, const Value &rhs) {
+	return false;
+}
+
+template <>
+inline bool ValuePositionComparator::Final<duckdb::Equals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::NotDistinctFrom(lhs, rhs);
+}
+
+// NotEquals must check everything that matched
+template <>
+inline bool ValuePositionComparator::Possible<duckdb::NotEquals>(const Value &lhs, const Value &rhs) {
+	return true;
+}
+
+template <>
+inline bool ValuePositionComparator::Final<duckdb::NotEquals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::NotDistinctFrom(lhs, rhs);
+}
+
+// Non-strict inequalities must use strict comparisons for Definite
+template <>
+bool ValuePositionComparator::Definite<duckdb::LessThanEquals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctLessThan(lhs, rhs);
+}
+
+template <>
+bool ValuePositionComparator::Final<duckdb::LessThanEquals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctLessThanEquals(lhs, rhs);
+}
+
+template <>
+bool ValuePositionComparator::Definite<duckdb::GreaterThanEquals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctGreaterThan(lhs, rhs);
+}
+
+template <>
+bool ValuePositionComparator::Final<duckdb::GreaterThanEquals>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctGreaterThanEquals(lhs, rhs);
+}
+
+// Strict inequalities just use strict for both Definite and Final
+template <>
+bool ValuePositionComparator::Final<duckdb::LessThan>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctLessThan(lhs, rhs);
+}
+
+template <>
+bool ValuePositionComparator::Final<duckdb::GreaterThan>(const Value &lhs, const Value &rhs) {
+	return ValueOperations::DistinctGreaterThan(lhs, rhs);
+}
+
+template <class OP>
+static bool TemplatedBooleanOperation(const Value &left, const Value &right) {
+	const auto &left_type = left.type();
+	const auto &right_type = right.type();
+	if (left_type != right_type) {
+		Value left_copy = left;
+		Value right_copy = right;
+
+		LogicalType comparison_type = BoundComparisonExpression::BindComparison(left_type, right_type);
+		if (!left_copy.TryCastAs(comparison_type) || !right_copy.TryCastAs(comparison_type)) {
+			return false;
+		}
+		D_ASSERT(left_copy.type() == right_copy.type());
+		return TemplatedBooleanOperation<OP>(left_copy, right_copy);
+	}
+	switch (left_type.InternalType()) {
+	case PhysicalType::BOOL:
+		return OP::Operation(left.GetValueUnsafe<bool>(), right.GetValueUnsafe<bool>());
+	case PhysicalType::INT8:
+		return OP::Operation(left.GetValueUnsafe<int8_t>(), right.GetValueUnsafe<int8_t>());
+	case PhysicalType::INT16:
+		return OP::Operation(left.GetValueUnsafe<int16_t>(), right.GetValueUnsafe<int16_t>());
+	case PhysicalType::INT32:
+		return OP::Operation(left.GetValueUnsafe<int32_t>(), right.GetValueUnsafe<int32_t>());
+	case PhysicalType::INT64:
+		return OP::Operation(left.GetValueUnsafe<int64_t>(), right.GetValueUnsafe<int64_t>());
+	case PhysicalType::UINT8:
+		return OP::Operation(left.GetValueUnsafe<uint8_t>(), right.GetValueUnsafe<uint8_t>());
+	case PhysicalType::UINT16:
+		return OP::Operation(left.GetValueUnsafe<uint16_t>(), right.GetValueUnsafe<uint16_t>());
+	case PhysicalType::UINT32:
+		return OP::Operation(left.GetValueUnsafe<uint32_t>(), right.GetValueUnsafe<uint32_t>());
+	case PhysicalType::UINT64:
+		return OP::Operation(left.GetValueUnsafe<uint64_t>(), right.GetValueUnsafe<uint64_t>());
+	case PhysicalType::INT128:
+		return OP::Operation(left.GetValueUnsafe<hugeint_t>(), right.GetValueUnsafe<hugeint_t>());
+	case PhysicalType::FLOAT:
+		return OP::Operation(left.GetValueUnsafe<float>(), right.GetValueUnsafe<float>());
+	case PhysicalType::DOUBLE:
+		return OP::Operation(left.GetValueUnsafe<double>(), right.GetValueUnsafe<double>());
+	case PhysicalType::INTERVAL:
+		return OP::Operation(left.GetValueUnsafe<interval_t>(), right.GetValueUnsafe<interval_t>());
+	case PhysicalType::VARCHAR:
+		return OP::Operation(StringValue::Get(left), StringValue::Get(right));
+	case PhysicalType::STRUCT: {
+		auto &left_children = StructValue::GetChildren(left);
+		auto &right_children = StructValue::GetChildren(right);
+		// this should be enforced by the type
+		D_ASSERT(left_children.size() == right_children.size());
+		idx_t i = 0;
+		for (; i < left_children.size() - 1; ++i) {
+			if (ValuePositionComparator::Definite<OP>(left_children[i], right_children[i])) {
+				return true;
+			}
+			if (!ValuePositionComparator::Possible<OP>(left_children[i], right_children[i])) {
+				return false;
+			}
+		}
+		return ValuePositionComparator::Final<OP>(left_children[i], right_children[i]);
+	}
+	case PhysicalType::LIST: {
+		auto &left_children = ListValue::GetChildren(left);
+		auto &right_children = ListValue::GetChildren(right);
+		for (idx_t pos = 0;; ++pos) {
+			if (pos == left_children.size() || pos == right_children.size()) {
+				return ValuePositionComparator::TieBreak<OP>(left_children.size(), right_children.size());
+			}
+			if (ValuePositionComparator::Definite<OP>(left_children[pos], right_children[pos])) {
+				return true;
+			}
+			if (!ValuePositionComparator::Possible<OP>(left_children[pos], right_children[pos])) {
+				return false;
+			}
+		}
+		return false;
+	}
+	default:
+		throw InternalException("Unimplemented type for value comparison");
+	}
+}
+
+bool ValueOperations::Equals(const Value &left, const Value &right) {
+	if (left.IsNull() || right.IsNull()) {
+		throw InternalException("Comparison on NULL values");
+	}
+	return TemplatedBooleanOperation<duckdb::Equals>(left, right);
+}
+
+bool ValueOperations::NotEquals(const Value &left, const Value &right) {
+	return !ValueOperations::Equals(left, right);
+}
+
+bool ValueOperations::GreaterThan(const Value &left, const Value &right) {
+	if (left.IsNull() || right.IsNull()) {
+		throw InternalException("Comparison on NULL values");
+	}
+	return TemplatedBooleanOperation<duckdb::GreaterThan>(left, right);
+}
+
+bool ValueOperations::GreaterThanEquals(const Value &left, const Value &right) {
+	if (left.IsNull() || right.IsNull()) {
+		throw InternalException("Comparison on NULL values");
+	}
+	return TemplatedBooleanOperation<duckdb::GreaterThanEquals>(left, right);
+}
+
+bool ValueOperations::LessThan(const Value &left, const Value &right) {
+	return ValueOperations::GreaterThan(right, left);
+}
+
+bool ValueOperations::LessThanEquals(const Value &left, const Value &right) {
+	return ValueOperations::GreaterThanEquals(right, left);
+}
+
+bool ValueOperations::NotDistinctFrom(const Value &left, const Value &right) {
+	if (left.IsNull() && right.IsNull()) {
+		return true;
+	}
+	if (left.IsNull() != right.IsNull()) {
+		return false;
+	}
+	return TemplatedBooleanOperation<duckdb::Equals>(left, right);
+}
+
+bool ValueOperations::DistinctFrom(const Value &left, const Value &right) {
+	return !ValueOperations::NotDistinctFrom(left, right);
+}
+
+bool ValueOperations::DistinctGreaterThan(const Value &left, const Value &right) {
+	if (left.IsNull() && right.IsNull()) {
+		return false;
+	} else if (right.IsNull()) {
+		return false;
+	} else if (left.IsNull()) {
+		return true;
+	}
+	return TemplatedBooleanOperation<duckdb::GreaterThan>(left, right);
+}
+
+bool ValueOperations::DistinctGreaterThanEquals(const Value &left, const Value &right) {
+	if (left.IsNull()) {
+		return true;
+	} else if (right.IsNull()) {
+		return false;
+	}
+	return TemplatedBooleanOperation<duckdb::GreaterThanEquals>(left, right);
+}
+
+bool ValueOperations::DistinctLessThan(const Value &left, const Value &right) {
+	return ValueOperations::DistinctGreaterThan(right, left);
+}
+
+bool ValueOperations::DistinctLessThanEquals(const Value &left, const Value &right) {
+	return ValueOperations::DistinctGreaterThanEquals(right, left);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// boolean_operators.cpp
+// Description: This file contains the implementation of the boolean
+// operations AND OR !
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// AND/OR
+//===--------------------------------------------------------------------===//
+template <class OP>
+static void TemplatedBooleanNullmask(Vector &left, Vector &right, Vector &result, idx_t count) {
+	D_ASSERT(left.GetType().id() == LogicalTypeId::BOOLEAN && right.GetType().id() == LogicalTypeId::BOOLEAN &&
+	         result.GetType().id() == LogicalTypeId::BOOLEAN);
+
+	if (left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// operation on two constants, result is constant vector
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto ldata = ConstantVector::GetData<uint8_t>(left);
+		auto rdata = ConstantVector::GetData<uint8_t>(right);
+		auto result_data = ConstantVector::GetData<bool>(result);
+
+		bool is_null = OP::Operation(*ldata > 0, *rdata > 0, ConstantVector::IsNull(left),
+		                             ConstantVector::IsNull(right), *result_data);
+		ConstantVector::SetNull(result, is_null);
+	} else {
+		// perform generic loop
+		VectorData ldata, rdata;
+		left.Orrify(count, ldata);
+		right.Orrify(count, rdata);
+
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		auto left_data = (uint8_t *)ldata.data; // we use uint8 to avoid load of gunk bools
+		auto right_data = (uint8_t *)rdata.data;
+		auto result_data = FlatVector::GetData<bool>(result);
+		auto &result_mask = FlatVector::Validity(result);
+		if (!ldata.validity.AllValid() || !rdata.validity.AllValid()) {
+			for (idx_t i = 0; i < count; i++) {
+				auto lidx = ldata.sel->get_index(i);
+				auto ridx = rdata.sel->get_index(i);
+				bool is_null =
+				    OP::Operation(left_data[lidx] > 0, right_data[ridx] > 0, !ldata.validity.RowIsValid(lidx),
+				                  !rdata.validity.RowIsValid(ridx), result_data[i]);
+				result_mask.Set(i, !is_null);
+			}
+		} else {
+			for (idx_t i = 0; i < count; i++) {
+				auto lidx = ldata.sel->get_index(i);
+				auto ridx = rdata.sel->get_index(i);
+				result_data[i] = OP::SimpleOperation(left_data[lidx], right_data[ridx]);
+			}
+		}
+	}
+}
+
+/*
+SQL AND Rules:
+
+TRUE  AND TRUE   = TRUE
+TRUE  AND FALSE  = FALSE
+TRUE  AND NULL   = NULL
+FALSE AND TRUE   = FALSE
+FALSE AND FALSE  = FALSE
+FALSE AND NULL   = FALSE
+NULL  AND TRUE   = NULL
+NULL  AND FALSE  = FALSE
+NULL  AND NULL   = NULL
+
+Basically:
+- Only true if both are true
+- False if either is false (regardless of NULLs)
+- NULL otherwise
+*/
+struct TernaryAnd {
+	static bool SimpleOperation(bool left, bool right) {
+		return left && right;
+	}
+	static bool Operation(bool left, bool right, bool left_null, bool right_null, bool &result) {
+		if (left_null && right_null) {
+			// both NULL:
+			// result is NULL
+			return true;
+		} else if (left_null) {
+			// left is NULL:
+			// result is FALSE if right is false
+			// result is NULL if right is true
+			result = right;
+			return right;
+		} else if (right_null) {
+			// right is NULL:
+			// result is FALSE if left is false
+			// result is NULL if left is true
+			result = left;
+			return left;
+		} else {
+			// no NULL: perform the AND
+			result = left && right;
+			return false;
+		}
+	}
+};
+
+void VectorOperations::And(Vector &left, Vector &right, Vector &result, idx_t count) {
+	TemplatedBooleanNullmask<TernaryAnd>(left, right, result, count);
+}
+
+/*
+SQL OR Rules:
+
+OR
+TRUE  OR TRUE  = TRUE
+TRUE  OR FALSE = TRUE
+TRUE  OR NULL  = TRUE
+FALSE OR TRUE  = TRUE
+FALSE OR FALSE = FALSE
+FALSE OR NULL  = NULL
+NULL  OR TRUE  = TRUE
+NULL  OR FALSE = NULL
+NULL  OR NULL  = NULL
+
+Basically:
+- Only false if both are false
+- True if either is true (regardless of NULLs)
+- NULL otherwise
+*/
+
+struct TernaryOr {
+	static bool SimpleOperation(bool left, bool right) {
+		return left || right;
+	}
+	static bool Operation(bool left, bool right, bool left_null, bool right_null, bool &result) {
+		if (left_null && right_null) {
+			// both NULL:
+			// result is NULL
+			return true;
+		} else if (left_null) {
+			// left is NULL:
+			// result is TRUE if right is true
+			// result is NULL if right is false
+			result = right;
+			return !right;
+		} else if (right_null) {
+			// right is NULL:
+			// result is TRUE if left is true
+			// result is NULL if left is false
+			result = left;
+			return !left;
+		} else {
+			// no NULL: perform the OR
+			result = left || right;
+			return false;
+		}
+	}
+};
+
+void VectorOperations::Or(Vector &left, Vector &right, Vector &result, idx_t count) {
+	TemplatedBooleanNullmask<TernaryOr>(left, right, result, count);
+}
+
+struct NotOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return !left;
+	}
+};
+
+void VectorOperations::Not(Vector &input, Vector &result, idx_t count) {
+	D_ASSERT(input.GetType() == LogicalType::BOOLEAN && result.GetType() == LogicalType::BOOLEAN);
+	UnaryExecutor::Execute<bool, bool, NotOperator>(input, result, count);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// comparison_operators.cpp
+// Description: This file contains the implementation of the comparison
+// operations == != >= <= > <
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+bool EqualsFloat(T left, T right) {
+	if (DUCKDB_UNLIKELY(Value::IsNan(left) && Value::IsNan(right))) {
+		return true;
+	}
+	return left == right;
+}
+
+template <>
+bool Equals::Operation(float left, float right) {
+	return EqualsFloat<float>(left, right);
+}
+
+template <>
+bool Equals::Operation(double left, double right) {
+	return EqualsFloat<double>(left, right);
+}
+
+template <class T>
+bool GreaterThanFloat(T left, T right) {
+	// handle nans
+	// nan is always bigger than everything else
+	bool left_is_nan = Value::IsNan(left);
+	bool right_is_nan = Value::IsNan(right);
+	// if right is nan, there is no number that is bigger than right
+	if (DUCKDB_UNLIKELY(right_is_nan)) {
+		return false;
+	}
+	// if left is nan, but right is not, left is always bigger
+	if (DUCKDB_UNLIKELY(left_is_nan)) {
+		return true;
+	}
+	return left > right;
+}
+
+template <>
+bool GreaterThan::Operation(float left, float right) {
+	return GreaterThanFloat<float>(left, right);
+}
+
+template <>
+bool GreaterThan::Operation(double left, double right) {
+	return GreaterThanFloat<double>(left, right);
+}
+
+template <class T>
+bool GreaterThanEqualsFloat(T left, T right) {
+	// handle nans
+	// nan is always bigger than everything else
+	bool left_is_nan = Value::IsNan(left);
+	bool right_is_nan = Value::IsNan(right);
+	// if right is nan, there is no bigger number
+	// we only return true if left is also nan (in which case the numbers are equal)
+	if (DUCKDB_UNLIKELY(right_is_nan)) {
+		return left_is_nan;
+	}
+	// if left is nan, but right is not, left is always bigger
+	if (DUCKDB_UNLIKELY(left_is_nan)) {
+		return true;
+	}
+	return left >= right;
+}
+
+template <>
+bool GreaterThanEquals::Operation(float left, float right) {
+	return GreaterThanEqualsFloat<float>(left, right);
+}
+
+template <>
+bool GreaterThanEquals::Operation(double left, double right) {
+	return GreaterThanEqualsFloat<double>(left, right);
+}
+
+struct ComparisonSelector {
+	template <typename OP>
+	static idx_t Select(Vector &left, Vector &right, const SelectionVector *sel, idx_t count, SelectionVector *true_sel,
+	                    SelectionVector *false_sel) {
+		throw NotImplementedException("Unknown comparison operation!");
+	}
+};
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::Equals>(Vector &left, Vector &right, const SelectionVector *sel,
+                                                        idx_t count, SelectionVector *true_sel,
+                                                        SelectionVector *false_sel) {
+	return VectorOperations::Equals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::NotEquals>(Vector &left, Vector &right, const SelectionVector *sel,
+                                                           idx_t count, SelectionVector *true_sel,
+                                                           SelectionVector *false_sel) {
+	return VectorOperations::NotEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::GreaterThan>(Vector &left, Vector &right, const SelectionVector *sel,
+                                                             idx_t count, SelectionVector *true_sel,
+                                                             SelectionVector *false_sel) {
+	return VectorOperations::GreaterThan(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::GreaterThanEquals>(Vector &left, Vector &right,
+                                                                   const SelectionVector *sel, idx_t count,
+                                                                   SelectionVector *true_sel,
+                                                                   SelectionVector *false_sel) {
+	return VectorOperations::GreaterThanEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::LessThan>(Vector &left, Vector &right, const SelectionVector *sel,
+                                                          idx_t count, SelectionVector *true_sel,
+                                                          SelectionVector *false_sel) {
+	return VectorOperations::LessThan(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+inline idx_t ComparisonSelector::Select<duckdb::LessThanEquals>(Vector &left, Vector &right, const SelectionVector *sel,
+                                                                idx_t count, SelectionVector *true_sel,
+                                                                SelectionVector *false_sel) {
+	return VectorOperations::LessThanEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+static void ComparesNotNull(VectorData &ldata, VectorData &rdata, ValidityMask &vresult, idx_t count) {
+	for (idx_t i = 0; i < count; ++i) {
+		auto lidx = ldata.sel->get_index(i);
+		auto ridx = rdata.sel->get_index(i);
+		if (!ldata.validity.RowIsValid(lidx) || !rdata.validity.RowIsValid(ridx)) {
+			vresult.SetInvalid(i);
+		}
+	}
+}
+
+template <typename OP>
+static void NestedComparisonExecutor(Vector &left, Vector &right, Vector &result, idx_t count) {
+	const auto left_constant = left.GetVectorType() == VectorType::CONSTANT_VECTOR;
+	const auto right_constant = right.GetVectorType() == VectorType::CONSTANT_VECTOR;
+
+	if ((left_constant && ConstantVector::IsNull(left)) || (right_constant && ConstantVector::IsNull(right))) {
+		// either left or right is constant NULL: result is constant NULL
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		return;
+	}
+
+	if (left_constant && right_constant) {
+		// both sides are constant, and neither is NULL so just compare one element.
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		SelectionVector true_sel(1);
+		auto match_count = ComparisonSelector::Select<OP>(left, right, nullptr, 1, &true_sel, nullptr);
+		auto result_data = ConstantVector::GetData<bool>(result);
+		result_data[0] = match_count > 0;
+		return;
+	}
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<bool>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	VectorData leftv, rightv;
+	left.Orrify(count, leftv);
+	right.Orrify(count, rightv);
+	if (!leftv.validity.AllValid() || !rightv.validity.AllValid()) {
+		ComparesNotNull(leftv, rightv, result_validity, count);
+	}
+	SelectionVector true_sel(count);
+	SelectionVector false_sel(count);
+	idx_t match_count = ComparisonSelector::Select<OP>(left, right, nullptr, count, &true_sel, &false_sel);
+
+	for (idx_t i = 0; i < match_count; ++i) {
+		const auto idx = true_sel.get_index(i);
+		result_data[idx] = true;
+	}
+
+	const idx_t no_match_count = count - match_count;
+	for (idx_t i = 0; i < no_match_count; ++i) {
+		const auto idx = false_sel.get_index(i);
+		result_data[idx] = false;
+	}
+}
+
+struct ComparisonExecutor {
+private:
+	template <class T, class OP>
+	static inline void TemplatedExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+		BinaryExecutor::Execute<T, T, bool, OP>(left, right, result, count);
+	}
+
+public:
+	template <class OP>
+	static inline void Execute(Vector &left, Vector &right, Vector &result, idx_t count) {
+		D_ASSERT(left.GetType() == right.GetType() && result.GetType() == LogicalType::BOOLEAN);
+		// the inplace loops take the result as the last parameter
+		switch (left.GetType().InternalType()) {
+		case PhysicalType::BOOL:
+		case PhysicalType::INT8:
+			TemplatedExecute<int8_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::INT16:
+			TemplatedExecute<int16_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::INT32:
+			TemplatedExecute<int32_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::INT64:
+			TemplatedExecute<int64_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::UINT8:
+			TemplatedExecute<uint8_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::UINT16:
+			TemplatedExecute<uint16_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::UINT32:
+			TemplatedExecute<uint32_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::UINT64:
+			TemplatedExecute<uint64_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::INT128:
+			TemplatedExecute<hugeint_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::FLOAT:
+			TemplatedExecute<float, OP>(left, right, result, count);
+			break;
+		case PhysicalType::DOUBLE:
+			TemplatedExecute<double, OP>(left, right, result, count);
+			break;
+		case PhysicalType::INTERVAL:
+			TemplatedExecute<interval_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::VARCHAR:
+			TemplatedExecute<string_t, OP>(left, right, result, count);
+			break;
+		case PhysicalType::LIST:
+		case PhysicalType::MAP:
+		case PhysicalType::STRUCT:
+			NestedComparisonExecutor<OP>(left, right, result, count);
+			break;
+		default:
+			throw InternalException("Invalid type for comparison");
+		}
+	}
+};
+
+void VectorOperations::Equals(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::Equals>(left, right, result, count);
+}
+
+void VectorOperations::NotEquals(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::NotEquals>(left, right, result, count);
+}
+
+void VectorOperations::GreaterThanEquals(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::GreaterThanEquals>(left, right, result, count);
+}
+
+void VectorOperations::LessThanEquals(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::LessThanEquals>(left, right, result, count);
+}
+
+void VectorOperations::GreaterThan(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::GreaterThan>(left, right, result, count);
+}
+
+void VectorOperations::LessThan(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ComparisonExecutor::Execute<duckdb::LessThan>(left, right, result, count);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// generators.cpp
+// Description: This file contains the implementation of different generators
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+void TemplatedGenerateSequence(Vector &result, idx_t count, int64_t start, int64_t increment) {
+	D_ASSERT(result.GetType().IsNumeric());
+	if (start > NumericLimits<T>::Maximum() || increment > NumericLimits<T>::Maximum()) {
+		throw Exception("Sequence start or increment out of type range");
+	}
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<T>(result);
+	auto value = (T)start;
+	for (idx_t i = 0; i < count; i++) {
+		if (i > 0) {
+			value += increment;
+		}
+		result_data[i] = value;
+	}
+}
+
+void VectorOperations::GenerateSequence(Vector &result, idx_t count, int64_t start, int64_t increment) {
+	if (!result.GetType().IsNumeric()) {
+		throw InvalidTypeException(result.GetType(), "Can only generate sequences for numeric values!");
+	}
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		TemplatedGenerateSequence<int8_t>(result, count, start, increment);
+		break;
+	case PhysicalType::INT16:
+		TemplatedGenerateSequence<int16_t>(result, count, start, increment);
+		break;
+	case PhysicalType::INT32:
+		TemplatedGenerateSequence<int32_t>(result, count, start, increment);
+		break;
+	case PhysicalType::INT64:
+		TemplatedGenerateSequence<int64_t>(result, count, start, increment);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedGenerateSequence<float>(result, count, start, increment);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedGenerateSequence<double>(result, count, start, increment);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for generate sequence");
+	}
+}
+
+template <class T>
+void TemplatedGenerateSequence(Vector &result, idx_t count, const SelectionVector &sel, int64_t start,
+                               int64_t increment) {
+	D_ASSERT(result.GetType().IsNumeric());
+	if (start > NumericLimits<T>::Maximum() || increment > NumericLimits<T>::Maximum()) {
+		throw Exception("Sequence start or increment out of type range");
+	}
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<T>(result);
+	auto value = (T)start;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		result_data[idx] = value + increment * idx;
+	}
+}
+
+void VectorOperations::GenerateSequence(Vector &result, idx_t count, const SelectionVector &sel, int64_t start,
+                                        int64_t increment) {
+	if (!result.GetType().IsNumeric()) {
+		throw InvalidTypeException(result.GetType(), "Can only generate sequences for numeric values!");
+	}
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		TemplatedGenerateSequence<int8_t>(result, count, sel, start, increment);
+		break;
+	case PhysicalType::INT16:
+		TemplatedGenerateSequence<int16_t>(result, count, sel, start, increment);
+		break;
+	case PhysicalType::INT32:
+		TemplatedGenerateSequence<int32_t>(result, count, sel, start, increment);
+		break;
+	case PhysicalType::INT64:
+		TemplatedGenerateSequence<int64_t>(result, count, sel, start, increment);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedGenerateSequence<float>(result, count, sel, start, increment);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedGenerateSequence<double>(result, count, sel, start, increment);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for generate sequence");
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+struct DistinctBinaryLambdaWrapper {
+	template <class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
+	static inline RESULT_TYPE Operation(LEFT_TYPE left, RIGHT_TYPE right, bool is_left_null, bool is_right_null) {
+		return OP::template Operation<LEFT_TYPE>(left, right, is_left_null, is_right_null);
+	}
+};
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
+static void DistinctExecuteGenericLoop(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                       RESULT_TYPE *__restrict result_data, const SelectionVector *__restrict lsel,
+                                       const SelectionVector *__restrict rsel, idx_t count, ValidityMask &lmask,
+                                       ValidityMask &rmask, ValidityMask &result_mask) {
+	for (idx_t i = 0; i < count; i++) {
+		auto lindex = lsel->get_index(i);
+		auto rindex = rsel->get_index(i);
+		auto lentry = ldata[lindex];
+		auto rentry = rdata[rindex];
+		result_data[i] =
+		    OP::template Operation<LEFT_TYPE>(lentry, rentry, !lmask.RowIsValid(lindex), !rmask.RowIsValid(rindex));
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
+static void DistinctExecuteConstant(Vector &left, Vector &right, Vector &result) {
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+
+	auto ldata = ConstantVector::GetData<LEFT_TYPE>(left);
+	auto rdata = ConstantVector::GetData<RIGHT_TYPE>(right);
+	auto result_data = ConstantVector::GetData<RESULT_TYPE>(result);
+	*result_data =
+	    OP::template Operation<LEFT_TYPE>(*ldata, *rdata, ConstantVector::IsNull(left), ConstantVector::IsNull(right));
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
+static void DistinctExecuteGeneric(Vector &left, Vector &right, Vector &result, idx_t count) {
+	if (left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		DistinctExecuteConstant<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(left, right, result);
+	} else {
+		VectorData ldata, rdata;
+
+		left.Orrify(count, ldata);
+		right.Orrify(count, rdata);
+
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		auto result_data = FlatVector::GetData<RESULT_TYPE>(result);
+		DistinctExecuteGenericLoop<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(
+		    (LEFT_TYPE *)ldata.data, (RIGHT_TYPE *)rdata.data, result_data, ldata.sel, rdata.sel, count, ldata.validity,
+		    rdata.validity, FlatVector::Validity(result));
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
+static void DistinctExecuteSwitch(Vector &left, Vector &right, Vector &result, idx_t count) {
+	DistinctExecuteGeneric<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(left, right, result, count);
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class OP>
+static void DistinctExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+	DistinctExecuteSwitch<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, OP>(left, right, result, count);
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool NO_NULL, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
+static inline idx_t
+DistinctSelectGenericLoop(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                          const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
+                          const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lmask,
+                          ValidityMask &rmask, SelectionVector *true_sel, SelectionVector *false_sel) {
+	idx_t true_count = 0, false_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto result_idx = result_sel->get_index(i);
+		auto lindex = lsel->get_index(i);
+		auto rindex = rsel->get_index(i);
+		if (NO_NULL) {
+			if (OP::Operation(ldata[lindex], rdata[rindex], false, false)) {
+				if (HAS_TRUE_SEL) {
+					true_sel->set_index(true_count++, result_idx);
+				}
+			} else {
+				if (HAS_FALSE_SEL) {
+					false_sel->set_index(false_count++, result_idx);
+				}
+			}
+		} else {
+			if (OP::Operation(ldata[lindex], rdata[rindex], !lmask.RowIsValid(lindex), !rmask.RowIsValid(rindex))) {
+				if (HAS_TRUE_SEL) {
+					true_sel->set_index(true_count++, result_idx);
+				}
+			} else {
+				if (HAS_FALSE_SEL) {
+					false_sel->set_index(false_count++, result_idx);
+				}
+			}
+		}
+	}
+	if (HAS_TRUE_SEL) {
+		return true_count;
+	} else {
+		return count - false_count;
+	}
+}
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool NO_NULL>
+static inline idx_t
+DistinctSelectGenericLoopSelSwitch(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                   const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
+                                   const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lmask,
+                                   ValidityMask &rmask, SelectionVector *true_sel, SelectionVector *false_sel) {
+	if (true_sel && false_sel) {
+		return DistinctSelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, true, true>(
+		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+	} else if (true_sel) {
+		return DistinctSelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, true, false>(
+		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+	} else {
+		D_ASSERT(false_sel);
+		return DistinctSelectGenericLoop<LEFT_TYPE, RIGHT_TYPE, OP, NO_NULL, false, true>(
+		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+static inline idx_t
+DistinctSelectGenericLoopSwitch(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                const SelectionVector *__restrict lsel, const SelectionVector *__restrict rsel,
+                                const SelectionVector *__restrict result_sel, idx_t count, ValidityMask &lmask,
+                                ValidityMask &rmask, SelectionVector *true_sel, SelectionVector *false_sel) {
+	if (!lmask.AllValid() || !rmask.AllValid()) {
+		return DistinctSelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, false>(
+		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+	} else {
+		return DistinctSelectGenericLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, true>(
+		    ldata, rdata, lsel, rsel, result_sel, count, lmask, rmask, true_sel, false_sel);
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+static idx_t DistinctSelectGeneric(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                   SelectionVector *true_sel, SelectionVector *false_sel) {
+	VectorData ldata, rdata;
+
+	left.Orrify(count, ldata);
+	right.Orrify(count, rdata);
+
+	return DistinctSelectGenericLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP>((LEFT_TYPE *)ldata.data, (RIGHT_TYPE *)rdata.data,
+	                                                                  ldata.sel, rdata.sel, sel, count, ldata.validity,
+	                                                                  rdata.validity, true_sel, false_sel);
+}
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT, bool NO_NULL,
+          bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
+static inline idx_t DistinctSelectFlatLoop(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                           const SelectionVector *sel, idx_t count, ValidityMask &lmask,
+                                           ValidityMask &rmask, SelectionVector *true_sel, SelectionVector *false_sel) {
+	idx_t true_count = 0, false_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		idx_t result_idx = sel->get_index(i);
+		idx_t lidx = LEFT_CONSTANT ? 0 : i;
+		idx_t ridx = RIGHT_CONSTANT ? 0 : i;
+		const bool lnull = !lmask.RowIsValid(lidx);
+		const bool rnull = !rmask.RowIsValid(ridx);
+		bool comparison_result = OP::Operation(ldata[lidx], rdata[ridx], lnull, rnull);
+		if (HAS_TRUE_SEL) {
+			true_sel->set_index(true_count, result_idx);
+			true_count += comparison_result;
+		}
+		if (HAS_FALSE_SEL) {
+			false_sel->set_index(false_count, result_idx);
+			false_count += !comparison_result;
+		}
+	}
+	if (HAS_TRUE_SEL) {
+		return true_count;
+	} else {
+		return count - false_count;
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT, bool NO_NULL>
+static inline idx_t DistinctSelectFlatLoopSelSwitch(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                                    const SelectionVector *sel, idx_t count, ValidityMask &lmask,
+                                                    ValidityMask &rmask, SelectionVector *true_sel,
+                                                    SelectionVector *false_sel) {
+	if (true_sel && false_sel) {
+		return DistinctSelectFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, NO_NULL, true, true>(
+		    ldata, rdata, sel, count, lmask, rmask, true_sel, false_sel);
+	} else if (true_sel) {
+		return DistinctSelectFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, NO_NULL, true, false>(
+		    ldata, rdata, sel, count, lmask, rmask, true_sel, false_sel);
+	} else {
+		D_ASSERT(false_sel);
+		return DistinctSelectFlatLoop<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, NO_NULL, false, true>(
+		    ldata, rdata, sel, count, lmask, rmask, true_sel, false_sel);
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
+static inline idx_t DistinctSelectFlatLoopSwitch(LEFT_TYPE *__restrict ldata, RIGHT_TYPE *__restrict rdata,
+                                                 const SelectionVector *sel, idx_t count, ValidityMask &lmask,
+                                                 ValidityMask &rmask, SelectionVector *true_sel,
+                                                 SelectionVector *false_sel) {
+	return DistinctSelectFlatLoopSelSwitch<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT, true>(
+	    ldata, rdata, sel, count, lmask, rmask, true_sel, false_sel);
+}
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP, bool LEFT_CONSTANT, bool RIGHT_CONSTANT>
+static idx_t DistinctSelectFlat(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                SelectionVector *true_sel, SelectionVector *false_sel) {
+	auto ldata = FlatVector::GetData<LEFT_TYPE>(left);
+	auto rdata = FlatVector::GetData<RIGHT_TYPE>(right);
+	if (LEFT_CONSTANT) {
+		ValidityMask validity;
+		if (ConstantVector::IsNull(left)) {
+			validity.SetAllInvalid(1);
+		}
+		return DistinctSelectFlatLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
+		    ldata, rdata, sel, count, validity, FlatVector::Validity(right), true_sel, false_sel);
+	} else if (RIGHT_CONSTANT) {
+		ValidityMask validity;
+		if (ConstantVector::IsNull(right)) {
+			validity.SetAllInvalid(1);
+		}
+		return DistinctSelectFlatLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
+		    ldata, rdata, sel, count, FlatVector::Validity(left), validity, true_sel, false_sel);
+	} else {
+		return DistinctSelectFlatLoopSwitch<LEFT_TYPE, RIGHT_TYPE, OP, LEFT_CONSTANT, RIGHT_CONSTANT>(
+		    ldata, rdata, sel, count, FlatVector::Validity(left), FlatVector::Validity(right), true_sel, false_sel);
+	}
+}
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+static idx_t DistinctSelectConstant(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                    SelectionVector *true_sel, SelectionVector *false_sel) {
+	auto ldata = ConstantVector::GetData<LEFT_TYPE>(left);
+	auto rdata = ConstantVector::GetData<RIGHT_TYPE>(right);
+
+	// both sides are constant, return either 0 or the count
+	// in this case we do not fill in the result selection vector at all
+	if (!OP::Operation(*ldata, *rdata, ConstantVector::IsNull(left), ConstantVector::IsNull(right))) {
+		if (false_sel) {
+			for (idx_t i = 0; i < count; i++) {
+				false_sel->set_index(i, sel->get_index(i));
+			}
+		}
+		return 0;
+	} else {
+		if (true_sel) {
+			for (idx_t i = 0; i < count; i++) {
+				true_sel->set_index(i, sel->get_index(i));
+			}
+		}
+		return count;
+	}
+}
+
+template <class LEFT_TYPE, class RIGHT_TYPE, class OP>
+static idx_t DistinctSelect(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                            SelectionVector *true_sel, SelectionVector *false_sel) {
+	if (!sel) {
+		sel = FlatVector::IncrementalSelectionVector();
+	}
+	if (left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		return DistinctSelectConstant<LEFT_TYPE, RIGHT_TYPE, OP>(left, right, sel, count, true_sel, false_sel);
+	} else if (left.GetVectorType() == VectorType::CONSTANT_VECTOR &&
+	           right.GetVectorType() == VectorType::FLAT_VECTOR) {
+		return DistinctSelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, true, false>(left, right, sel, count, true_sel, false_sel);
+	} else if (left.GetVectorType() == VectorType::FLAT_VECTOR &&
+	           right.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		return DistinctSelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, true>(left, right, sel, count, true_sel, false_sel);
+	} else if (left.GetVectorType() == VectorType::FLAT_VECTOR && right.GetVectorType() == VectorType::FLAT_VECTOR) {
+		return DistinctSelectFlat<LEFT_TYPE, RIGHT_TYPE, OP, false, false>(left, right, sel, count, true_sel,
+		                                                                   false_sel);
+	} else {
+		return DistinctSelectGeneric<LEFT_TYPE, RIGHT_TYPE, OP>(left, right, sel, count, true_sel, false_sel);
+	}
+}
+
+template <class OP>
+static idx_t DistinctSelectNotNull(Vector &left, Vector &right, const idx_t count, idx_t &true_count,
+                                   const SelectionVector &sel, SelectionVector &maybe_vec, OptionalSelection &true_opt,
+                                   OptionalSelection &false_opt) {
+	VectorData lvdata, rvdata;
+	left.Orrify(count, lvdata);
+	right.Orrify(count, rvdata);
+
+	auto &lmask = lvdata.validity;
+	auto &rmask = rvdata.validity;
+
+	idx_t remaining = 0;
+	if (lmask.AllValid() && rmask.AllValid()) {
+		//	None are NULL, distinguish values.
+		for (idx_t i = 0; i < count; ++i) {
+			const auto idx = sel.get_index(i);
+			maybe_vec.set_index(remaining++, idx);
+		}
+		return remaining;
+	}
+
+	// Slice the Vectors down to the rows that are not determined (i.e., neither is NULL)
+	SelectionVector slicer(count);
+	true_count = 0;
+	idx_t false_count = 0;
+	for (idx_t i = 0; i < count; ++i) {
+		const auto result_idx = sel.get_index(i);
+		const auto lidx = lvdata.sel->get_index(i);
+		const auto ridx = rvdata.sel->get_index(i);
+		const auto lnull = !lmask.RowIsValid(lidx);
+		const auto rnull = !rmask.RowIsValid(ridx);
+		if (lnull || rnull) {
+			// If either is NULL then we can major distinguish them
+			if (!OP::Operation(false, false, lnull, rnull)) {
+				false_opt.Append(false_count, result_idx);
+			} else {
+				true_opt.Append(true_count, result_idx);
+			}
+		} else {
+			//	Neither is NULL, distinguish values.
+			slicer.set_index(remaining, i);
+			maybe_vec.set_index(remaining++, result_idx);
+		}
+	}
+
+	true_opt.Advance(true_count);
+	false_opt.Advance(false_count);
+
+	if (remaining && remaining < count) {
+		left.Slice(slicer, remaining);
+		right.Slice(slicer, remaining);
+	}
+
+	return remaining;
+}
+
+struct PositionComparator {
+	// Select the rows that definitely match.
+	// Default to the same as the final row
+	template <typename OP>
+	static idx_t Definite(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+	                      SelectionVector *true_sel, SelectionVector &false_sel) {
+		return Final<OP>(left, right, sel, count, true_sel, &false_sel);
+	}
+
+	// Select the possible rows that need further testing.
+	// Usually this means Is Not Distinct, as those are the semantics used by Postges
+	template <typename OP>
+	static idx_t Possible(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+	                      SelectionVector &true_sel, SelectionVector *false_sel) {
+		return VectorOperations::NestedEquals(left, right, sel, count, &true_sel, false_sel);
+	}
+
+	// Select the matching rows for the final position.
+	// This needs to be specialised.
+	template <typename OP>
+	static idx_t Final(Vector &left, Vector &right, const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
+	                   SelectionVector *false_sel) {
+		return 0;
+	}
+
+	// Tie-break based on length when one of the sides has been exhausted, returning true if the LHS matches.
+	// This essentially means that the existing positions compare equal.
+	// Default to the same semantics as the OP for idx_t. This works in most cases.
+	template <typename OP>
+	static bool TieBreak(const idx_t lpos, const idx_t rpos) {
+		return OP::Operation(lpos, rpos, false, false);
+	}
+};
+
+// NotDistinctFrom must always check every column
+template <>
+idx_t PositionComparator::Definite<duckdb::NotDistinctFrom>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                            idx_t count, SelectionVector *true_sel,
+                                                            SelectionVector &false_sel) {
+	return 0;
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::NotDistinctFrom>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                         idx_t count, SelectionVector *true_sel,
+                                                         SelectionVector *false_sel) {
+	return VectorOperations::NestedEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+// DistinctFrom must check everything that matched
+template <>
+idx_t PositionComparator::Possible<duckdb::DistinctFrom>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                         idx_t count, SelectionVector &true_sel,
+                                                         SelectionVector *false_sel) {
+	return count;
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctFrom>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                      idx_t count, SelectionVector *true_sel,
+                                                      SelectionVector *false_sel) {
+	return VectorOperations::NestedNotEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+// Non-strict inequalities must use strict comparisons for Definite
+template <>
+idx_t PositionComparator::Definite<duckdb::DistinctLessThanEquals>(Vector &left, Vector &right,
+                                                                   const SelectionVector &sel, idx_t count,
+                                                                   SelectionVector *true_sel,
+                                                                   SelectionVector &false_sel) {
+	return VectorOperations::DistinctLessThan(left, right, &sel, count, true_sel, &false_sel);
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctLessThanEquals>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                                idx_t count, SelectionVector *true_sel,
+                                                                SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t PositionComparator::Definite<duckdb::DistinctGreaterThanEquals>(Vector &left, Vector &right,
+                                                                      const SelectionVector &sel, idx_t count,
+                                                                      SelectionVector *true_sel,
+                                                                      SelectionVector &false_sel) {
+	return VectorOperations::DistinctGreaterThan(left, right, &sel, count, true_sel, &false_sel);
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctGreaterThanEquals>(Vector &left, Vector &right,
+                                                                   const SelectionVector &sel, idx_t count,
+                                                                   SelectionVector *true_sel,
+                                                                   SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+// Strict inequalities just use strict for both Definite and Final
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctLessThan>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                          idx_t count, SelectionVector *true_sel,
+                                                          SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t PositionComparator::Final<duckdb::DistinctGreaterThan>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                             idx_t count, SelectionVector *true_sel,
+                                                             SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+using StructEntries = vector<unique_ptr<Vector>>;
+
+static void ExtractNestedSelection(const SelectionVector &slice_sel, const idx_t count, const SelectionVector &sel,
+                                   OptionalSelection &opt) {
+
+	for (idx_t i = 0; i < count;) {
+		const auto slice_idx = slice_sel.get_index(i);
+		const auto result_idx = sel.get_index(slice_idx);
+		opt.Append(i, result_idx);
+	}
+	opt.Advance(count);
+}
+
+static void DensifyNestedSelection(const SelectionVector &dense_sel, const idx_t count, SelectionVector &slice_sel) {
+	for (idx_t i = 0; i < count; ++i) {
+		slice_sel.set_index(i, dense_sel.get_index(i));
+	}
+}
+
+template <class OP>
+static idx_t DistinctSelectStruct(Vector &left, Vector &right, idx_t count, const SelectionVector &sel,
+                                  OptionalSelection &true_opt, OptionalSelection &false_opt) {
+	if (count == 0) {
+		return 0;
+	}
+
+	// Avoid allocating in the 99% of the cases where we don't need to.
+	StructEntries lsliced, rsliced;
+	auto &lchildren = StructVector::GetEntries(left);
+	auto &rchildren = StructVector::GetEntries(right);
+	D_ASSERT(lchildren.size() == rchildren.size());
+
+	// In order to reuse the comparators, we have to track what passed and failed internally.
+	// To do that, we need local SVs that we then merge back into the real ones after every pass.
+	const auto vcount = count;
+	SelectionVector slice_sel(count);
+	for (idx_t i = 0; i < count; ++i) {
+		slice_sel.set_index(i, i);
+	}
+
+	SelectionVector true_sel(count);
+	SelectionVector false_sel(count);
+
+	idx_t match_count = 0;
+	for (idx_t col_no = 0; col_no < lchildren.size(); ++col_no) {
+		// Slice the children to maintain density
+		Vector lchild(*lchildren[col_no]);
+		lchild.Normalify(vcount);
+		lchild.Slice(slice_sel, count);
+
+		Vector rchild(*rchildren[col_no]);
+		rchild.Normalify(vcount);
+		rchild.Slice(slice_sel, count);
+
+		// Find everything that definitely matches
+		auto true_count = PositionComparator::Definite<OP>(lchild, rchild, slice_sel, count, &true_sel, false_sel);
+		if (true_count > 0) {
+			auto false_count = count - true_count;
+
+			// Extract the definite matches into the true result
+			ExtractNestedSelection(false_count ? true_sel : slice_sel, true_count, sel, true_opt);
+
+			// Remove the definite matches from the slicing vector
+			DensifyNestedSelection(false_sel, false_count, slice_sel);
+
+			match_count += true_count;
+			count -= true_count;
+		}
+
+		if (col_no != lchildren.size() - 1) {
+			// Find what might match on the next position
+			true_count = PositionComparator::Possible<OP>(lchild, rchild, slice_sel, count, true_sel, &false_sel);
+			auto false_count = count - true_count;
+
+			// Extract the definite failures into the false result
+			ExtractNestedSelection(true_count ? false_sel : slice_sel, false_count, sel, false_opt);
+
+			// Remove any definite failures from the slicing vector
+			if (false_count) {
+				DensifyNestedSelection(true_sel, true_count, slice_sel);
+			}
+
+			count = true_count;
+		} else {
+			true_count = PositionComparator::Final<OP>(lchild, rchild, slice_sel, count, &true_sel, &false_sel);
+			auto false_count = count - true_count;
+
+			// Extract the definite matches into the true result
+			ExtractNestedSelection(false_count ? true_sel : slice_sel, true_count, sel, true_opt);
+
+			// Extract the definite failures into the false result
+			ExtractNestedSelection(true_count ? false_sel : slice_sel, false_count, sel, false_opt);
+
+			match_count += true_count;
+		}
+	}
+	return match_count;
+}
+
+static void PositionListCursor(SelectionVector &cursor, VectorData &vdata, const idx_t pos,
+                               const SelectionVector &slice_sel, const idx_t count) {
+	const auto data = (const list_entry_t *)vdata.data;
+	for (idx_t i = 0; i < count; ++i) {
+		const auto slice_idx = slice_sel.get_index(i);
+
+		const auto lidx = vdata.sel->get_index(slice_idx);
+		const auto &entry = data[lidx];
+		cursor.set_index(i, entry.offset + pos);
+	}
+}
+
+template <class OP>
+static idx_t DistinctSelectList(Vector &left, Vector &right, idx_t count, const SelectionVector &sel,
+                                OptionalSelection &true_opt, OptionalSelection &false_opt) {
+	if (count == 0) {
+		return count;
+	}
+
+	// Create dictionary views of the children so we can vectorise the positional comparisons.
+	SelectionVector lcursor(count);
+	SelectionVector rcursor(count);
+
+	ListVector::GetEntry(left).Normalify(count);
+	ListVector::GetEntry(right).Normalify(count);
+	Vector lchild(ListVector::GetEntry(left), lcursor, count);
+	Vector rchild(ListVector::GetEntry(right), rcursor, count);
+
+	// To perform the positional comparison, we use a vectorisation of the following algorithm:
+	// bool CompareLists(T *left, idx_t nleft, T *right, nright) {
+	// 	for (idx_t pos = 0; ; ++pos) {
+	// 		if (nleft == pos || nright == pos)
+	// 			return OP::TieBreak(nleft, nright);
+	// 		if (OP::Definite(*left, *right))
+	// 			return true;
+	// 		if (!OP::Maybe(*left, *right))
+	// 			return false;
+	// 		}
+	//	 	++left, ++right;
+	// 	}
+	// }
+
+	// Get pointers to the list entries
+	VectorData lvdata;
+	left.Orrify(count, lvdata);
+	const auto ldata = (const list_entry_t *)lvdata.data;
+
+	VectorData rvdata;
+	right.Orrify(count, rvdata);
+	const auto rdata = (const list_entry_t *)rvdata.data;
+
+	// In order to reuse the comparators, we have to track what passed and failed internally.
+	// To do that, we need local SVs that we then merge back into the real ones after every pass.
+	SelectionVector slice_sel(count);
+	for (idx_t i = 0; i < count; ++i) {
+		slice_sel.set_index(i, i);
+	}
+
+	SelectionVector true_sel(count);
+	SelectionVector false_sel(count);
+
+	idx_t match_count = 0;
+	for (idx_t pos = 0; count > 0; ++pos) {
+		// Set up the cursors for the current position
+		PositionListCursor(lcursor, lvdata, pos, slice_sel, count);
+		PositionListCursor(rcursor, rvdata, pos, slice_sel, count);
+
+		// Tie-break the pairs where one of the LISTs is exhausted.
+		idx_t true_count = 0;
+		idx_t false_count = 0;
+		idx_t maybe_count = 0;
+		for (idx_t i = 0; i < count; ++i) {
+			const auto slice_idx = slice_sel.get_index(i);
+			const auto lidx = lvdata.sel->get_index(slice_idx);
+			const auto &lentry = ldata[lidx];
+			const auto ridx = rvdata.sel->get_index(slice_idx);
+			const auto &rentry = rdata[ridx];
+			if (lentry.length == pos || rentry.length == pos) {
+				const auto idx = sel.get_index(slice_idx);
+				if (PositionComparator::TieBreak<OP>(lentry.length, rentry.length)) {
+					true_opt.Append(true_count, idx);
+				} else {
+					false_opt.Append(false_count, idx);
+				}
+			} else {
+				true_sel.set_index(maybe_count++, slice_idx);
+			}
+		}
+		true_opt.Advance(true_count);
+		false_opt.Advance(false_count);
+		match_count += true_count;
+
+		// Redensify the list cursors
+		if (maybe_count < count) {
+			count = maybe_count;
+			DensifyNestedSelection(true_sel, count, slice_sel);
+			PositionListCursor(lcursor, lvdata, pos, slice_sel, count);
+			PositionListCursor(rcursor, rvdata, pos, slice_sel, count);
+		}
+
+		// Find everything that definitely matches
+		true_count = PositionComparator::Definite<OP>(lchild, rchild, slice_sel, count, &true_sel, false_sel);
+		if (true_count) {
+			false_count = count - true_count;
+			ExtractNestedSelection(false_count ? true_sel : slice_sel, true_count, sel, true_opt);
+			match_count += true_count;
+
+			// Redensify the list cursors
+			count -= true_count;
+			DensifyNestedSelection(false_sel, count, slice_sel);
+			PositionListCursor(lcursor, lvdata, pos, slice_sel, count);
+			PositionListCursor(rcursor, rvdata, pos, slice_sel, count);
+		}
+
+		// Find what might match on the next position
+		true_count = PositionComparator::Possible<OP>(lchild, rchild, slice_sel, count, true_sel, &false_sel);
+		false_count = count - true_count;
+		ExtractNestedSelection(true_count ? false_sel : slice_sel, false_count, sel, false_opt);
+
+		if (false_count) {
+			DensifyNestedSelection(true_sel, true_count, slice_sel);
+		}
+		count = true_count;
+	}
+
+	return match_count;
+}
+
+template <class OP, class OPNESTED>
+static idx_t DistinctSelectNested(Vector &left, Vector &right, const SelectionVector *sel, const idx_t count,
+                                  SelectionVector *true_sel, SelectionVector *false_sel) {
+	// The Select operations all use a dense pair of input vectors to partition
+	// a selection vector in a single pass. But to implement progressive comparisons,
+	// we have to make multiple passes, so we need to keep track of the original input positions
+	// and then scatter the output selections when we are done.
+	if (!sel) {
+		sel = FlatVector::IncrementalSelectionVector();
+	}
+
+	// Make buffered selections for progressive comparisons
+	// TODO: Remove unnecessary allocations
+	SelectionVector true_vec(count);
+	OptionalSelection true_opt(&true_vec);
+
+	SelectionVector false_vec(count);
+	OptionalSelection false_opt(&false_vec);
+
+	SelectionVector maybe_vec(count);
+
+	// Handle NULL nested values
+	Vector l_not_null(left);
+	Vector r_not_null(right);
+
+	idx_t match_count = 0;
+	auto unknown =
+	    DistinctSelectNotNull<OP>(l_not_null, r_not_null, count, match_count, *sel, maybe_vec, true_opt, false_opt);
+
+	if (PhysicalType::LIST == left.GetType().InternalType()) {
+		match_count += DistinctSelectList<OPNESTED>(l_not_null, r_not_null, unknown, maybe_vec, true_opt, false_opt);
+	} else {
+		match_count += DistinctSelectStruct<OPNESTED>(l_not_null, r_not_null, unknown, maybe_vec, true_opt, false_opt);
+	}
+
+	// Copy the buffered selections to the output selections
+	if (true_sel) {
+		DensifyNestedSelection(true_vec, match_count, *true_sel);
+	}
+
+	if (false_sel) {
+		DensifyNestedSelection(false_vec, count - match_count, *false_sel);
+	}
+
+	return match_count;
+}
+
+template <typename OP>
+static void NestedDistinctExecute(Vector &left, Vector &right, Vector &result, idx_t count);
+
+template <class T, class OP>
+static inline void TemplatedDistinctExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+	DistinctExecute<T, T, bool, OP>(left, right, result, count);
+}
+template <class OP>
+static void ExecuteDistinct(Vector &left, Vector &right, Vector &result, idx_t count) {
+	D_ASSERT(left.GetType() == right.GetType() && result.GetType() == LogicalType::BOOLEAN);
+	// the inplace loops take the result as the last parameter
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedDistinctExecute<int8_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedDistinctExecute<int16_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedDistinctExecute<int32_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedDistinctExecute<int64_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedDistinctExecute<uint8_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedDistinctExecute<uint16_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedDistinctExecute<uint32_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedDistinctExecute<uint64_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedDistinctExecute<hugeint_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedDistinctExecute<float, OP>(left, right, result, count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedDistinctExecute<double, OP>(left, right, result, count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedDistinctExecute<interval_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedDistinctExecute<string_t, OP>(left, right, result, count);
+		break;
+	case PhysicalType::LIST:
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		NestedDistinctExecute<OP>(left, right, result, count);
+		break;
+	default:
+		throw InternalException("Invalid type for distinct comparison");
+	}
+}
+
+template <class OP, class OPNESTED = OP>
+static idx_t TemplatedDistinctSelectOperation(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                              SelectionVector *true_sel, SelectionVector *false_sel) {
+	// the inplace loops take the result as the last parameter
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return DistinctSelect<int8_t, int8_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT16:
+		return DistinctSelect<int16_t, int16_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT32:
+		return DistinctSelect<int32_t, int32_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT64:
+		return DistinctSelect<int64_t, int64_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT8:
+		return DistinctSelect<uint8_t, uint8_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT16:
+		return DistinctSelect<uint16_t, uint16_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT32:
+		return DistinctSelect<uint32_t, uint32_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT64:
+		return DistinctSelect<uint64_t, uint64_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT128:
+		return DistinctSelect<hugeint_t, hugeint_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::FLOAT:
+		return DistinctSelect<float, float, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::DOUBLE:
+		return DistinctSelect<double, double, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INTERVAL:
+		return DistinctSelect<interval_t, interval_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::VARCHAR:
+		return DistinctSelect<string_t, string_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+	case PhysicalType::LIST:
+		return DistinctSelectNested<OP, OPNESTED>(left, right, sel, count, true_sel, false_sel);
+	default:
+		throw InternalException("Invalid type for distinct selection");
+	}
+}
+
+template <typename OP>
+static void NestedDistinctExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+	const auto left_constant = left.GetVectorType() == VectorType::CONSTANT_VECTOR;
+	const auto right_constant = right.GetVectorType() == VectorType::CONSTANT_VECTOR;
+
+	if (left_constant && right_constant) {
+		// both sides are constant, so just compare one element.
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto result_data = ConstantVector::GetData<bool>(result);
+		SelectionVector true_sel(1);
+		auto match_count = TemplatedDistinctSelectOperation<OP>(left, right, nullptr, 1, &true_sel, nullptr);
+		result_data[0] = match_count > 0;
+		return;
+	}
+
+	SelectionVector true_sel(count);
+	SelectionVector false_sel(count);
+
+	// DISTINCT is either true or false
+	idx_t match_count = TemplatedDistinctSelectOperation<OP>(left, right, nullptr, count, &true_sel, &false_sel);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<bool>(result);
+
+	for (idx_t i = 0; i < match_count; ++i) {
+		const auto idx = true_sel.get_index(i);
+		result_data[idx] = true;
+	}
+
+	const idx_t no_match_count = count - match_count;
+	for (idx_t i = 0; i < no_match_count; ++i) {
+		const auto idx = false_sel.get_index(i);
+		result_data[idx] = false;
+	}
+}
+
+void VectorOperations::DistinctFrom(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ExecuteDistinct<duckdb::DistinctFrom>(left, right, result, count);
+}
+
+void VectorOperations::NotDistinctFrom(Vector &left, Vector &right, Vector &result, idx_t count) {
+	ExecuteDistinct<duckdb::NotDistinctFrom>(left, right, result, count);
+}
+
+// true := A != B with nulls being equal
+idx_t VectorOperations::DistinctFrom(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                     SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctFrom>(left, right, sel, count, true_sel, false_sel);
+}
+// true := A == B with nulls being equal
+idx_t VectorOperations::NotDistinctFrom(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                        SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::NotDistinctFrom>(left, right, sel, count, true_sel, false_sel);
+}
+
+// true := A > B with nulls being maximal
+idx_t VectorOperations::DistinctGreaterThan(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                            SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThan>(left, right, sel, count, true_sel, false_sel);
+}
+
+// true := A > B with nulls being minimal
+idx_t VectorOperations::DistinctGreaterThanNullsFirst(Vector &left, Vector &right, const SelectionVector *sel,
+                                                      idx_t count, SelectionVector *true_sel,
+                                                      SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThanNullsFirst, duckdb::DistinctGreaterThan>(
+	    left, right, sel, count, true_sel, false_sel);
+}
+// true := A >= B with nulls being maximal
+idx_t VectorOperations::DistinctGreaterThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                                  SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctGreaterThanEquals>(left, right, sel, count, true_sel,
+	                                                                           false_sel);
+}
+// true := A < B with nulls being maximal
+idx_t VectorOperations::DistinctLessThan(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                         SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctLessThan>(left, right, sel, count, true_sel, false_sel);
+}
+
+// true := A < B with nulls being minimal
+idx_t VectorOperations::DistinctLessThanNullsFirst(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                                   SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctLessThanNullsFirst, duckdb::DistinctLessThan>(
+	    left, right, sel, count, true_sel, false_sel);
+}
+
+// true := A <= B with nulls being maximal
+idx_t VectorOperations::DistinctLessThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                               SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctLessThanEquals>(left, right, sel, count, true_sel,
+	                                                                        false_sel);
+}
+
+// true := A != B with nulls being equal, inputs selected
+idx_t VectorOperations::NestedNotEquals(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                        SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::DistinctFrom>(left, right, &sel, count, true_sel, false_sel);
+}
+// true := A == B with nulls being equal, inputs selected
+idx_t VectorOperations::NestedEquals(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                     SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedDistinctSelectOperation<duckdb::NotDistinctFrom>(left, right, &sel, count, true_sel, false_sel);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// null_operators.cpp
+// Description: This file contains the implementation of the
+// IS NULL/NOT IS NULL operators
+//===--------------------------------------------------------------------===//
+
+
+
+
+namespace duckdb {
+
+template <bool INVERSE>
+void IsNullLoop(Vector &input, Vector &result, idx_t count) {
+	D_ASSERT(result.GetType() == LogicalType::BOOLEAN);
+
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto result_data = ConstantVector::GetData<bool>(result);
+		*result_data = INVERSE ? !ConstantVector::IsNull(input) : ConstantVector::IsNull(input);
+	} else {
+		VectorData data;
+		input.Orrify(count, data);
+
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		auto result_data = FlatVector::GetData<bool>(result);
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = data.sel->get_index(i);
+			result_data[i] = INVERSE ? data.validity.RowIsValid(idx) : !data.validity.RowIsValid(idx);
+		}
+	}
+}
+
+void VectorOperations::IsNotNull(Vector &input, Vector &result, idx_t count) {
+	IsNullLoop<true>(input, result, count);
+}
+
+void VectorOperations::IsNull(Vector &input, Vector &result, idx_t count) {
+	IsNullLoop<false>(input, result, count);
+}
+
+bool VectorOperations::HasNotNull(Vector &input, idx_t count) {
+	if (count == 0) {
+		return false;
+	}
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		return !ConstantVector::IsNull(input);
+	} else {
+		VectorData data;
+		input.Orrify(count, data);
+
+		if (data.validity.AllValid()) {
+			return true;
+		}
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = data.sel->get_index(i);
+			if (data.validity.RowIsValid(idx)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+bool VectorOperations::HasNull(Vector &input, idx_t count) {
+	if (count == 0) {
+		return false;
+	}
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		return ConstantVector::IsNull(input);
+	} else {
+		VectorData data;
+		input.Orrify(count, data);
+
+		if (data.validity.AllValid()) {
+			return false;
+		}
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = data.sel->get_index(i);
+			if (!data.validity.RowIsValid(idx)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+idx_t VectorOperations::CountNotNull(Vector &input, const idx_t count) {
+	idx_t valid = 0;
+
+	VectorData vdata;
+	input.Orrify(count, vdata);
+	if (vdata.validity.AllValid()) {
+		return count;
+	}
+	switch (input.GetVectorType()) {
+	case VectorType::FLAT_VECTOR:
+		valid += vdata.validity.CountValid(count);
+		break;
+	case VectorType::CONSTANT_VECTOR:
+		valid += vdata.validity.CountValid(1) * count;
+		break;
+	default:
+		for (idx_t i = 0; i < count; ++i) {
+			const auto row_idx = vdata.sel->get_index(i);
+			valid += int(vdata.validity.RowIsValid(row_idx));
+		}
+		break;
+	}
+
+	return valid;
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// numeric_inplace_operators.cpp
+// Description: This file contains the implementation of numeric inplace ops
+// += *= /= -= %=
+//===--------------------------------------------------------------------===//
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// In-Place Addition
+//===--------------------------------------------------------------------===//
+
+void VectorOperations::AddInPlace(Vector &input, int64_t right, idx_t count) {
+	D_ASSERT(input.GetType().id() == LogicalTypeId::POINTER);
+	if (right == 0) {
+		return;
+	}
+	switch (input.GetVectorType()) {
+	case VectorType::CONSTANT_VECTOR: {
+		D_ASSERT(!ConstantVector::IsNull(input));
+		auto data = ConstantVector::GetData<uintptr_t>(input);
+		*data += right;
+		break;
+	}
+	default: {
+		D_ASSERT(input.GetVectorType() == VectorType::FLAT_VECTOR);
+		auto data = FlatVector::GetData<uintptr_t>(input);
+		for (idx_t i = 0; i < count; i++) {
+			data[i] += right;
+		}
+		break;
+	}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class OP>
+struct VectorStringCastOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
+		auto result = (Vector *)dataptr;
+		return OP::template Operation<INPUT_TYPE>(input, *result);
+	}
+};
+
+struct VectorTryCastData {
+	VectorTryCastData(Vector &result_p, string *error_message_p, bool strict_p)
+	    : result(result_p), error_message(error_message_p), strict(strict_p) {
+	}
+
+	Vector &result;
+	string *error_message;
+	bool strict;
+	bool all_converted = true;
+};
+
+template <class OP>
+struct VectorTryCastOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
+		RESULT_TYPE output;
+		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output))) {
+			return output;
+		}
+		auto data = (VectorTryCastData *)dataptr;
+		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
+		                                                     idx, data->error_message, data->all_converted);
+	}
+};
+
+template <class OP>
+struct VectorTryCastStrictOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
+		auto data = (VectorTryCastData *)dataptr;
+		RESULT_TYPE output;
+		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->strict))) {
+			return output;
+		}
+		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
+		                                                     idx, data->error_message, data->all_converted);
+	}
+};
+
+template <class OP>
+struct VectorTryCastErrorOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
+		auto data = (VectorTryCastData *)dataptr;
+		RESULT_TYPE output;
+		if (DUCKDB_LIKELY(
+		        OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->error_message, data->strict))) {
+			return output;
+		}
+		bool has_error = data->error_message && !data->error_message->empty();
+		return HandleVectorCastError::Operation<RESULT_TYPE>(
+		    has_error ? *data->error_message : CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask, idx,
+		    data->error_message, data->all_converted);
+	}
+};
+
+template <class OP>
+struct VectorTryCastStringOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, ValidityMask &mask, idx_t idx, void *dataptr) {
+		auto data = (VectorTryCastData *)dataptr;
+		RESULT_TYPE output;
+		if (DUCKDB_LIKELY(OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input, output, data->result,
+		                                                                  data->error_message, data->strict))) {
+			return output;
+		}
+		return HandleVectorCastError::Operation<RESULT_TYPE>(CastExceptionText<INPUT_TYPE, RESULT_TYPE>(input), mask,
+		                                                     idx, data->error_message, data->all_converted);
+	}
+};
+
+template <class SRC, class DST, class OP>
+static bool TemplatedVectorTryCastLoop(Vector &source, Vector &result, idx_t count, bool strict,
+                                       string *error_message) {
+	VectorTryCastData input(result, error_message, strict);
+	UnaryExecutor::GenericExecute<SRC, DST, OP>(source, result, count, &input, error_message);
+	return input.all_converted;
+}
+
+template <class SRC, class DST, class OP>
+static bool VectorTryCastLoop(Vector &source, Vector &result, idx_t count, string *error_message) {
+	return TemplatedVectorTryCastLoop<SRC, DST, VectorTryCastOperator<OP>>(source, result, count, false, error_message);
+}
+
+template <class SRC, class DST, class OP>
+static bool VectorTryCastStrictLoop(Vector &source, Vector &result, idx_t count, bool strict, string *error_message) {
+	return TemplatedVectorTryCastLoop<SRC, DST, VectorTryCastStrictOperator<OP>>(source, result, count, strict,
+	                                                                             error_message);
+}
+
+template <class SRC, class DST, class OP>
+static bool VectorTryCastErrorLoop(Vector &source, Vector &result, idx_t count, bool strict, string *error_message) {
+	return TemplatedVectorTryCastLoop<SRC, DST, VectorTryCastErrorOperator<OP>>(source, result, count, strict,
+	                                                                            error_message);
+}
+
+template <class SRC, class DST, class OP>
+static bool VectorTryCastStringLoop(Vector &source, Vector &result, idx_t count, bool strict, string *error_message) {
+	return TemplatedVectorTryCastLoop<SRC, DST, VectorTryCastStringOperator<OP>>(source, result, count, strict,
+	                                                                             error_message);
+}
+
+template <class SRC, class OP>
+static void VectorStringCast(Vector &source, Vector &result, idx_t count) {
+	D_ASSERT(result.GetType().InternalType() == PhysicalType::VARCHAR);
+	UnaryExecutor::GenericExecute<SRC, string_t, VectorStringCastOperator<OP>>(source, result, count, (void *)&result);
+}
+
+template <class SRC>
+static bool NumericCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::BOOLEAN:
+		return VectorTryCastLoop<SRC, bool, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::TINYINT:
+		return VectorTryCastLoop<SRC, int8_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::SMALLINT:
+		return VectorTryCastLoop<SRC, int16_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::INTEGER:
+		return VectorTryCastLoop<SRC, int32_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::BIGINT:
+		return VectorTryCastLoop<SRC, int64_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::UTINYINT:
+		return VectorTryCastLoop<SRC, uint8_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::USMALLINT:
+		return VectorTryCastLoop<SRC, uint16_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::UINTEGER:
+		return VectorTryCastLoop<SRC, uint32_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::UBIGINT:
+		return VectorTryCastLoop<SRC, uint64_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::HUGEINT:
+		return VectorTryCastLoop<SRC, hugeint_t, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::FLOAT:
+		return VectorTryCastLoop<SRC, float, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::DOUBLE:
+		return VectorTryCastLoop<SRC, double, duckdb::NumericTryCast>(source, result, count, error_message);
+	case LogicalTypeId::DECIMAL:
+		return ToDecimalCast<SRC>(source, result, count, error_message);
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR: {
+		VectorStringCast<SRC, duckdb::StringCast>(source, result, count);
+		return true;
+	}
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+template <class T>
+bool FillEnum(string_t *source_data, ValidityMask &source_mask, const LogicalType &source_type, T *result_data,
+              ValidityMask &result_mask, const LogicalType &result_type, idx_t count, string *error_message,
+              const SelectionVector *sel) {
+	bool all_converted = true;
+	for (idx_t i = 0; i < count; i++) {
+		idx_t source_idx = i;
+		if (sel) {
+			source_idx = sel->get_index(i);
+		}
+		if (source_mask.RowIsValid(source_idx)) {
+			auto string_value = source_data[source_idx].GetString();
+			auto pos = EnumType::GetPos(result_type, string_value);
+			if (pos == -1) {
+				result_data[i] =
+				    HandleVectorCastError::Operation<T>(CastExceptionText<string_t, T>(source_data[source_idx]),
+				                                        result_mask, i, error_message, all_converted);
+			} else {
+				result_data[i] = pos;
+			}
+		} else {
+			result_mask.SetInvalid(i);
+		}
+	}
+	return all_converted;
+}
+
+template <class T>
+bool TransformEnum(Vector &source, Vector &result, idx_t count, string *error_message) {
+	D_ASSERT(source.GetType().id() == LogicalTypeId::VARCHAR);
+	auto enum_name = EnumType::GetTypeName(result.GetType());
+	switch (source.GetVectorType()) {
+	case VectorType::CONSTANT_VECTOR: {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+
+		auto source_data = ConstantVector::GetData<string_t>(source);
+		auto source_mask = ConstantVector::Validity(source);
+		auto result_data = ConstantVector::GetData<T>(result);
+		auto &result_mask = ConstantVector::Validity(result);
+
+		return FillEnum(source_data, source_mask, source.GetType(), result_data, result_mask, result.GetType(), 1,
+		                error_message, nullptr);
+	}
+	default: {
+		VectorData vdata;
+		source.Orrify(count, vdata);
+
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+
+		auto source_data = (string_t *)vdata.data;
+		auto source_sel = vdata.sel;
+		auto source_mask = vdata.validity;
+		auto result_data = FlatVector::GetData<T>(result);
+		auto &result_mask = FlatVector::Validity(result);
+
+		return FillEnum(source_data, source_mask, source.GetType(), result_data, result_mask, result.GetType(), count,
+		                error_message, source_sel);
+	}
+	}
+}
+static bool VectorStringCastNumericSwitch(Vector &source, Vector &result, idx_t count, bool strict,
+                                          string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::ENUM: {
+		switch (result.GetType().InternalType()) {
+		case PhysicalType::UINT8:
+			return TransformEnum<uint8_t>(source, result, count, error_message);
+		case PhysicalType::UINT16:
+			return TransformEnum<uint16_t>(source, result, count, error_message);
+		case PhysicalType::UINT32:
+			return TransformEnum<uint32_t>(source, result, count, error_message);
+		default:
+			throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
+		}
+	}
+	case LogicalTypeId::BOOLEAN:
+		return VectorTryCastStrictLoop<string_t, bool, duckdb::TryCast>(source, result, count, strict, error_message);
+	case LogicalTypeId::TINYINT:
+		return VectorTryCastStrictLoop<string_t, int8_t, duckdb::TryCast>(source, result, count, strict, error_message);
+	case LogicalTypeId::SMALLINT:
+		return VectorTryCastStrictLoop<string_t, int16_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                   error_message);
+	case LogicalTypeId::INTEGER:
+		return VectorTryCastStrictLoop<string_t, int32_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                   error_message);
+	case LogicalTypeId::BIGINT:
+		return VectorTryCastStrictLoop<string_t, int64_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                   error_message);
+	case LogicalTypeId::UTINYINT:
+		return VectorTryCastStrictLoop<string_t, uint8_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                   error_message);
+	case LogicalTypeId::USMALLINT:
+		return VectorTryCastStrictLoop<string_t, uint16_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                    error_message);
+	case LogicalTypeId::UINTEGER:
+		return VectorTryCastStrictLoop<string_t, uint32_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                    error_message);
+	case LogicalTypeId::UBIGINT:
+		return VectorTryCastStrictLoop<string_t, uint64_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                    error_message);
+	case LogicalTypeId::HUGEINT:
+		return VectorTryCastStrictLoop<string_t, hugeint_t, duckdb::TryCast>(source, result, count, strict,
+		                                                                     error_message);
+	case LogicalTypeId::FLOAT:
+		return VectorTryCastStrictLoop<string_t, float, duckdb::TryCast>(source, result, count, strict, error_message);
+	case LogicalTypeId::DOUBLE:
+		return VectorTryCastStrictLoop<string_t, double, duckdb::TryCast>(source, result, count, strict, error_message);
+	case LogicalTypeId::INTERVAL:
+		return VectorTryCastErrorLoop<string_t, interval_t, duckdb::TryCastErrorMessage>(source, result, count, strict,
+		                                                                                 error_message);
+	case LogicalTypeId::DECIMAL:
+		return ToDecimalCast<string_t>(source, result, count, error_message);
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+static bool StringCastSwitch(Vector &source, Vector &result, idx_t count, bool strict, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::DATE:
+		return VectorTryCastErrorLoop<string_t, date_t, duckdb::TryCastErrorMessage>(source, result, count, strict,
+		                                                                             error_message);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return VectorTryCastErrorLoop<string_t, dtime_t, duckdb::TryCastErrorMessage>(source, result, count, strict,
+		                                                                              error_message);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return VectorTryCastErrorLoop<string_t, timestamp_t, duckdb::TryCastErrorMessage>(source, result, count, strict,
+		                                                                                  error_message);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return VectorTryCastStrictLoop<string_t, timestamp_t, duckdb::TryCastToTimestampNS>(source, result, count,
+		                                                                                    strict, error_message);
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return VectorTryCastStrictLoop<string_t, timestamp_t, duckdb::TryCastToTimestampSec>(source, result, count,
+		                                                                                     strict, error_message);
+	case LogicalTypeId::TIMESTAMP_MS:
+		return VectorTryCastStrictLoop<string_t, timestamp_t, duckdb::TryCastToTimestampMS>(source, result, count,
+		                                                                                    strict, error_message);
+	case LogicalTypeId::BLOB:
+		return VectorTryCastStringLoop<string_t, string_t, duckdb::TryCastToBlob>(source, result, count, strict,
+		                                                                          error_message);
+	case LogicalTypeId::UUID:
+		return VectorTryCastStringLoop<string_t, hugeint_t, duckdb::TryCastToUUID>(source, result, count, strict,
+		                                                                           error_message);
+	case LogicalTypeId::SQLNULL:
+		return TryVectorNullCast(source, result, count, error_message);
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		result.Reinterpret(source);
+		return true;
+	default:
+		return VectorStringCastNumericSwitch(source, result, count, strict, error_message);
+	}
+}
+
+static bool DateCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// date to varchar
+		VectorStringCast<date_t, duckdb::StringCast>(source, result, count);
+		return true;
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		// date to timestamp
+		return VectorTryCastLoop<date_t, timestamp_t, duckdb::TryCast>(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return VectorTryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampNS>(source, result, count,
+		                                                                            error_message);
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return VectorTryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampSec>(source, result, count,
+		                                                                             error_message);
+	case LogicalTypeId::TIMESTAMP_MS:
+		return VectorTryCastLoop<date_t, timestamp_t, duckdb::TryCastToTimestampMS>(source, result, count,
+		                                                                            error_message);
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+static bool TimeCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// time to varchar
+		VectorStringCast<dtime_t, duckdb::StringCast>(source, result, count);
+		return true;
+	case LogicalTypeId::TIME_TZ:
+		// time to time with time zone
+		UnaryExecutor::Execute<dtime_t, dtime_t, duckdb::Cast>(source, result, count);
+		return true;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+static bool TimeTzCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// time with time zone to varchar
+		VectorStringCast<dtime_t, duckdb::StringCastTZ>(source, result, count);
+		return true;
+	case LogicalTypeId::TIME:
+		// time with time zone to time
+		UnaryExecutor::Execute<dtime_t, dtime_t, duckdb::Cast>(source, result, count);
+		return true;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+static bool TimestampCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// timestamp to varchar
+		VectorStringCast<timestamp_t, duckdb::StringCast>(source, result, count);
+		break;
+	case LogicalTypeId::DATE:
+		// timestamp to date
+		UnaryExecutor::Execute<timestamp_t, date_t, duckdb::Cast>(source, result, count);
+		break;
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		// timestamp to time
+		UnaryExecutor::Execute<timestamp_t, dtime_t, duckdb::Cast>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP_TZ:
+		// timestamp (us) to timestamp with time zone
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::Cast>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP_NS:
+		// timestamp (us) to timestamp (ns)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampUsToNs>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP_MS:
+		// timestamp (us) to timestamp (ms)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampUsToMs>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP_SEC:
+		// timestamp (us) to timestamp (s)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampUsToSec>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool TimestampTzCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// timestamp with time zone to varchar
+		VectorStringCast<timestamp_t, duckdb::StringCastTZ>(source, result, count);
+		break;
+	case LogicalTypeId::TIME_TZ:
+		// timestamp with time zone to time with time zone.
+		// TODO: set the offset to +00
+		UnaryExecutor::Execute<timestamp_t, dtime_t, duckdb::Cast>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		// timestamp with time zone to timestamp (us)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::Cast>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool TimestampNsCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// timestamp (ns) to varchar
+		VectorStringCast<timestamp_t, duckdb::CastFromTimestampNS>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		// timestamp (ns) to timestamp (us)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampNsToUs>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool TimestampMsCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// timestamp (ms) to varchar
+		VectorStringCast<timestamp_t, duckdb::CastFromTimestampMS>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		// timestamp (ms) to timestamp (us)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampMsToUs>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool TimestampSecCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// timestamp (sec) to varchar
+		VectorStringCast<timestamp_t, duckdb::CastFromTimestampSec>(source, result, count);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		// timestamp (s) to timestamp (us)
+		UnaryExecutor::Execute<timestamp_t, timestamp_t, duckdb::CastTimestampSecToUs>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool IntervalCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// time to varchar
+		VectorStringCast<interval_t, duckdb::StringCast>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool UUIDCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// uuid to varchar
+		VectorStringCast<hugeint_t, duckdb::CastFromUUID>(source, result, count);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool BlobCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	// now switch on the result type
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		// blob to varchar
+		VectorStringCast<string_t, duckdb::CastFromBlob>(source, result, count);
+		break;
+	case LogicalTypeId::AGGREGATE_STATE:
+		result.Reinterpret(source);
+		break;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+	return true;
+}
+
+static bool ValueStringCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	switch (result.GetType().id()) {
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::JSON:
+		if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(source.GetVectorType());
+		} else {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+		}
+		for (idx_t i = 0; i < count; i++) {
+			auto src_val = source.GetValue(i);
+			if (src_val.IsNull()) {
+				result.SetValue(i, Value(result.GetType()));
+			} else {
+				auto str_val = src_val.ToString();
+				result.SetValue(i, Value(str_val));
+			}
+		}
+		return true;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+static bool ListCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	switch (result.GetType().id()) {
+	case LogicalTypeId::LIST: {
+		// only handle constant and flat vectors here for now
+		if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(source.GetVectorType());
+			ConstantVector::SetNull(result, ConstantVector::IsNull(source));
+
+			auto ldata = ConstantVector::GetData<list_entry_t>(source);
+			auto tdata = ConstantVector::GetData<list_entry_t>(result);
+			*tdata = *ldata;
+		} else {
+			source.Normalify(count);
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			FlatVector::SetValidity(result, FlatVector::Validity(source));
+
+			auto ldata = FlatVector::GetData<list_entry_t>(source);
+			auto tdata = FlatVector::GetData<list_entry_t>(result);
+			for (idx_t i = 0; i < count; i++) {
+				tdata[i] = ldata[i];
+			}
+		}
+		auto &source_cc = ListVector::GetEntry(source);
+		auto source_size = ListVector::GetListSize(source);
+
+		ListVector::Reserve(result, source_size);
+		auto &append_vector = ListVector::GetEntry(result);
+
+		VectorOperations::Cast(source_cc, append_vector, source_size);
+		ListVector::SetListSize(result, source_size);
+		D_ASSERT(ListVector::GetListSize(result) == source_size);
+		return true;
+	}
+	default:
+		return ValueStringCastSwitch(source, result, count, error_message);
+	}
+}
+
+template <class SRC_TYPE, class RES_TYPE>
+bool FillEnum(Vector &source, Vector &result, idx_t count, string *error_message) {
+	bool all_converted = true;
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+
+	auto &str_vec = EnumType::GetValuesInsertOrder(source.GetType());
+	auto str_vec_ptr = FlatVector::GetData<string_t>(str_vec);
+
+	auto res_enum_type = result.GetType();
+
+	VectorData vdata;
+	source.Orrify(count, vdata);
+
+	auto source_data = (SRC_TYPE *)vdata.data;
+	auto source_sel = vdata.sel;
+	auto source_mask = vdata.validity;
+
+	auto result_data = FlatVector::GetData<RES_TYPE>(result);
+	auto &result_mask = FlatVector::Validity(result);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto src_idx = source_sel->get_index(i);
+		if (!source_mask.RowIsValid(src_idx)) {
+			result_mask.SetInvalid(i);
+			continue;
+		}
+		auto str = str_vec_ptr[source_data[src_idx]].GetString();
+		auto key = EnumType::GetPos(res_enum_type, str);
+		if (key == -1) {
+			// key doesn't exist on result enum
+			if (!error_message) {
+				result_data[i] = HandleVectorCastError::Operation<RES_TYPE>(
+				    CastExceptionText<SRC_TYPE, RES_TYPE>(source_data[src_idx]), result_mask, i, error_message,
+				    all_converted);
+			} else {
+				result_mask.SetInvalid(i);
+			}
+			continue;
+		}
+		result_data[i] = key;
+	}
+	return all_converted;
+}
+
+template <class SRC_TYPE>
+bool FillEnumResultTemplate(Vector &source, Vector &result, idx_t count, string *error_message) {
+	switch (source.GetType().InternalType()) {
+	case PhysicalType::UINT8:
+		return FillEnum<SRC_TYPE, uint8_t>(source, result, count, error_message);
+	case PhysicalType::UINT16:
+		return FillEnum<SRC_TYPE, uint16_t>(source, result, count, error_message);
+	case PhysicalType::UINT32:
+		return FillEnum<SRC_TYPE, uint32_t>(source, result, count, error_message);
+	default:
+		throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
+	}
+}
+
+void EnumToVarchar(Vector &source, Vector &result, idx_t count, PhysicalType enum_physical_type) {
+	if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(source.GetVectorType());
+	} else {
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+	}
+	auto &str_vec = EnumType::GetValuesInsertOrder(source.GetType());
+	auto str_vec_ptr = FlatVector::GetData<string_t>(str_vec);
+	auto res_vec_ptr = FlatVector::GetData<string_t>(result);
+
+	// TODO remove value api from this loop
+	for (idx_t i = 0; i < count; i++) {
+		auto src_val = source.GetValue(i);
+		if (src_val.IsNull()) {
+			result.SetValue(i, Value());
+			continue;
+		}
+
+		uint64_t enum_idx;
+		switch (enum_physical_type) {
+		case PhysicalType::UINT8:
+			enum_idx = UTinyIntValue::Get(src_val);
+			break;
+		case PhysicalType::UINT16:
+			enum_idx = USmallIntValue::Get(src_val);
+			break;
+		case PhysicalType::UINT32:
+			enum_idx = UIntegerValue::Get(src_val);
+			break;
+		case PhysicalType::UINT64: //  DEDUP_POINTER_ENUM
+		{
+			res_vec_ptr[i] = (const char *)UBigIntValue::Get(src_val);
+			continue;
+		}
+
+		default:
+			throw InternalException("ENUM can only have unsigned integers as physical types");
+		}
+		res_vec_ptr[i] = str_vec_ptr[enum_idx];
+	}
+}
+
+static bool EnumCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message, bool strict) {
+	auto enum_physical_type = source.GetType().InternalType();
+	switch (result.GetType().id()) {
+	case LogicalTypeId::ENUM: {
+		// This means they are both ENUMs, but of different types.
+		switch (enum_physical_type) {
+		case PhysicalType::UINT8:
+			return FillEnumResultTemplate<uint8_t>(source, result, count, error_message);
+		case PhysicalType::UINT16:
+			return FillEnumResultTemplate<uint16_t>(source, result, count, error_message);
+		case PhysicalType::UINT32:
+			return FillEnumResultTemplate<uint32_t>(source, result, count, error_message);
+		default:
+			throw InternalException("ENUM can only have unsigned integers (except UINT64) as physical types");
+		}
+	}
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR: {
+		EnumToVarchar(source, result, count, enum_physical_type);
+		break;
+	}
+	default: {
+		// Cast to varchar
+		Vector varchar_cast(LogicalType::VARCHAR, count);
+		EnumToVarchar(source, varchar_cast, count, enum_physical_type);
+		// Try to cast from varchar to whatever we wanted before
+		VectorOperations::TryCast(varchar_cast, result, count, error_message, strict);
+		break;
+	}
+	}
+	return true;
+}
+
+static bool AggregateStateToBlobCast(Vector &source, Vector &result, idx_t count, string *error_message, bool strict) {
+	if (result.GetType().id() != LogicalTypeId::BLOB) {
+		throw TypeMismatchException(source.GetType(), result.GetType(),
+		                            "Cannot cast AGGREGATE_STATE to anything but BLOB");
+	}
+	result.Reinterpret(source);
+	return true;
+}
+
+static bool StructCastSwitch(Vector &source, Vector &result, idx_t count, string *error_message) {
+	switch (result.GetType().id()) {
+	case LogicalTypeId::STRUCT:
+	case LogicalTypeId::MAP: {
+		auto &source_child_types = StructType::GetChildTypes(source.GetType());
+		auto &result_child_types = StructType::GetChildTypes(result.GetType());
+		if (source_child_types.size() != result_child_types.size()) {
+			throw TypeMismatchException(source.GetType(), result.GetType(), "Cannot cast STRUCTs of different size");
+		}
+		auto &source_children = StructVector::GetEntries(source);
+		D_ASSERT(source_children.size() == source_child_types.size());
+
+		auto &result_children = StructVector::GetEntries(result);
+		for (idx_t c_idx = 0; c_idx < result_child_types.size(); c_idx++) {
+			auto &result_child_vector = result_children[c_idx];
+			auto &source_child_vector = *source_children[c_idx];
+			if (result_child_vector->GetType() != source_child_vector.GetType()) {
+				VectorOperations::Cast(source_child_vector, *result_child_vector, count, false);
+			} else {
+				result_child_vector->Reference(source_child_vector);
+			}
+		}
+		if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result, ConstantVector::IsNull(source));
+		} else {
+			source.Normalify(count);
+			FlatVector::Validity(result) = FlatVector::Validity(source);
+		}
+		return true;
+	}
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR:
+		if (source.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(source.GetVectorType());
+		} else {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+		}
+		for (idx_t i = 0; i < count; i++) {
+			auto src_val = source.GetValue(i);
+			auto str_val = src_val.ToString();
+			result.SetValue(i, Value(str_val));
+		}
+		return true;
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+bool VectorOperations::TryCast(Vector &source, Vector &result, idx_t count, string *error_message, bool strict) {
+	D_ASSERT(source.GetType() != result.GetType());
+	// first switch on source type
+	switch (source.GetType().id()) {
+	case LogicalTypeId::BOOLEAN:
+		return NumericCastSwitch<bool>(source, result, count, error_message);
+	case LogicalTypeId::TINYINT:
+		return NumericCastSwitch<int8_t>(source, result, count, error_message);
+	case LogicalTypeId::SMALLINT:
+		return NumericCastSwitch<int16_t>(source, result, count, error_message);
+	case LogicalTypeId::INTEGER:
+		return NumericCastSwitch<int32_t>(source, result, count, error_message);
+	case LogicalTypeId::BIGINT:
+		return NumericCastSwitch<int64_t>(source, result, count, error_message);
+	case LogicalTypeId::UTINYINT:
+		return NumericCastSwitch<uint8_t>(source, result, count, error_message);
+	case LogicalTypeId::USMALLINT:
+		return NumericCastSwitch<uint16_t>(source, result, count, error_message);
+	case LogicalTypeId::UINTEGER:
+		return NumericCastSwitch<uint32_t>(source, result, count, error_message);
+	case LogicalTypeId::UBIGINT:
+		return NumericCastSwitch<uint64_t>(source, result, count, error_message);
+	case LogicalTypeId::HUGEINT:
+		return NumericCastSwitch<hugeint_t>(source, result, count, error_message);
+	case LogicalTypeId::UUID:
+		return UUIDCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::DECIMAL:
+		return DecimalCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::FLOAT:
+		return NumericCastSwitch<float>(source, result, count, error_message);
+	case LogicalTypeId::DOUBLE:
+		return NumericCastSwitch<double>(source, result, count, error_message);
+	case LogicalTypeId::DATE:
+		return DateCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIME:
+		return TimeCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIME_TZ:
+		return TimeTzCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP:
+		return TimestampCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return TimestampTzCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP_NS:
+		return TimestampNsCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP_MS:
+		return TimestampMsCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return TimestampSecCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::INTERVAL:
+		return IntervalCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR:
+		return StringCastSwitch(source, result, count, strict, error_message);
+	case LogicalTypeId::BLOB:
+		return BlobCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::SQLNULL: {
+		// cast a NULL to another type, just copy the properties and change the type
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		return true;
+	}
+	case LogicalTypeId::MAP:
+	case LogicalTypeId::STRUCT:
+		return StructCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::LIST:
+		return ListCastSwitch(source, result, count, error_message);
+	case LogicalTypeId::ENUM:
+		return EnumCastSwitch(source, result, count, error_message, strict);
+	case LogicalTypeId::AGGREGATE_STATE:
+		return AggregateStateToBlobCast(source, result, count, error_message, strict);
+	default:
+		return TryVectorNullCast(source, result, count, error_message);
+	}
+}
+
+void VectorOperations::Cast(Vector &source, Vector &result, idx_t count, bool strict) {
+	VectorOperations::TryCast(source, result, count, nullptr, strict);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// copy.cpp
+// Description: This file contains the implementation of the different copy
+// functions
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+static void TemplatedCopy(const Vector &source, const SelectionVector &sel, Vector &target, idx_t source_offset,
+                          idx_t target_offset, idx_t copy_count) {
+	auto ldata = FlatVector::GetData<T>(source);
+	auto tdata = FlatVector::GetData<T>(target);
+	for (idx_t i = 0; i < copy_count; i++) {
+		auto source_idx = sel.get_index(source_offset + i);
+		tdata[target_offset + i] = ldata[source_idx];
+	}
+}
+
+void VectorOperations::Copy(const Vector &source_p, Vector &target, const SelectionVector &sel_p, idx_t source_count,
+                            idx_t source_offset, idx_t target_offset) {
+	D_ASSERT(source_offset <= source_count);
+	D_ASSERT(source_p.GetType() == target.GetType());
+	idx_t copy_count = source_count - source_offset;
+
+	SelectionVector owned_sel;
+	const SelectionVector *sel = &sel_p;
+
+	const Vector *source = &source_p;
+	bool finished = false;
+	while (!finished) {
+		switch (source->GetVectorType()) {
+		case VectorType::DICTIONARY_VECTOR: {
+			// dictionary vector: merge selection vectors
+			auto &child = DictionaryVector::Child(*source);
+			auto &dict_sel = DictionaryVector::SelVector(*source);
+			// merge the selection vectors and verify the child
+			auto new_buffer = dict_sel.Slice(*sel, source_count);
+			owned_sel.Initialize(new_buffer);
+			sel = &owned_sel;
+			source = &child;
+			break;
+		}
+		case VectorType::SEQUENCE_VECTOR: {
+			int64_t start, increment;
+			Vector seq(source->GetType());
+			SequenceVector::GetSequence(*source, start, increment);
+			VectorOperations::GenerateSequence(seq, source_count, *sel, start, increment);
+			VectorOperations::Copy(seq, target, *sel, source_count, source_offset, target_offset);
+			return;
+		}
+		case VectorType::CONSTANT_VECTOR:
+			sel = ConstantVector::ZeroSelectionVector(copy_count, owned_sel);
+			finished = true;
+			break;
+		case VectorType::FLAT_VECTOR:
+			finished = true;
+			break;
+		default:
+			throw NotImplementedException("FIXME unimplemented vector type for VectorOperations::Copy");
+		}
+	}
+
+	if (copy_count == 0) {
+		return;
+	}
+
+	// Allow copying of a single value to constant vectors
+	const auto target_vector_type = target.GetVectorType();
+	if (copy_count == 1 && target_vector_type == VectorType::CONSTANT_VECTOR) {
+		target_offset = 0;
+		target.SetVectorType(VectorType::FLAT_VECTOR);
+	}
+	D_ASSERT(target.GetVectorType() == VectorType::FLAT_VECTOR);
+
+	// first copy the nullmask
+	auto &tmask = FlatVector::Validity(target);
+	if (source->GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		const bool valid = !ConstantVector::IsNull(*source);
+		for (idx_t i = 0; i < copy_count; i++) {
+			tmask.Set(target_offset + i, valid);
+		}
+	} else {
+		auto &smask = FlatVector::Validity(*source);
+		if (smask.IsMaskSet()) {
+			for (idx_t i = 0; i < copy_count; i++) {
+				auto idx = sel->get_index(source_offset + i);
+
+				if (smask.RowIsValid(idx)) {
+					// set valid
+					if (!tmask.AllValid()) {
+						tmask.SetValidUnsafe(target_offset + i);
+					}
+				} else {
+					// set invalid
+					if (tmask.AllValid()) {
+						auto init_size = MaxValue<idx_t>(STANDARD_VECTOR_SIZE, target_offset + copy_count);
+						tmask.Initialize(init_size);
+					}
+					tmask.SetInvalidUnsafe(target_offset + i);
+				}
+			}
+		}
+	}
+
+	D_ASSERT(sel);
+
+	// now copy over the data
+	switch (source->GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedCopy<int8_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedCopy<int16_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedCopy<int32_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedCopy<int64_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedCopy<uint8_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedCopy<uint16_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedCopy<uint32_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedCopy<uint64_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedCopy<hugeint_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedCopy<float>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedCopy<double>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedCopy<interval_t>(*source, *sel, target, source_offset, target_offset, copy_count);
+		break;
+	case PhysicalType::VARCHAR: {
+		auto ldata = FlatVector::GetData<string_t>(*source);
+		auto tdata = FlatVector::GetData<string_t>(target);
+		for (idx_t i = 0; i < copy_count; i++) {
+			auto source_idx = sel->get_index(source_offset + i);
+			auto target_idx = target_offset + i;
+			if (tmask.RowIsValid(target_idx)) {
+				tdata[target_idx] = StringVector::AddStringOrBlob(target, ldata[source_idx]);
+			}
+		}
+		break;
+	}
+	case PhysicalType::STRUCT: {
+		auto &source_children = StructVector::GetEntries(*source);
+		auto &target_children = StructVector::GetEntries(target);
+		D_ASSERT(source_children.size() == target_children.size());
+		for (idx_t i = 0; i < source_children.size(); i++) {
+			VectorOperations::Copy(*source_children[i], *target_children[i], sel_p, source_count, source_offset,
+			                       target_offset);
+		}
+		break;
+	}
+	case PhysicalType::LIST: {
+		D_ASSERT(target.GetType().InternalType() == PhysicalType::LIST);
+
+		auto &source_child = ListVector::GetEntry(*source);
+		auto sdata = FlatVector::GetData<list_entry_t>(*source);
+		auto tdata = FlatVector::GetData<list_entry_t>(target);
+
+		if (target_vector_type == VectorType::CONSTANT_VECTOR) {
+			// If we are only writing one value, then the copied values (if any) are contiguous
+			// and we can just Append from the offset position
+			if (!tmask.RowIsValid(target_offset)) {
+				break;
+			}
+			auto source_idx = sel->get_index(source_offset);
+			auto &source_entry = sdata[source_idx];
+			const idx_t source_child_size = source_entry.length + source_entry.offset;
+
+			//! overwrite constant target vectors.
+			ListVector::SetListSize(target, 0);
+			ListVector::Append(target, source_child, source_child_size, source_entry.offset);
+
+			auto &target_entry = tdata[target_offset];
+			target_entry.length = source_entry.length;
+			target_entry.offset = 0;
+		} else {
+			//! if the source has list offsets, we need to append them to the target
+			//! build a selection vector for the copied child elements
+			vector<sel_t> child_rows;
+			for (idx_t i = 0; i < copy_count; ++i) {
+				if (tmask.RowIsValid(target_offset + i)) {
+					auto source_idx = sel->get_index(source_offset + i);
+					auto &source_entry = sdata[source_idx];
+					for (idx_t j = 0; j < source_entry.length; ++j) {
+						child_rows.emplace_back(source_entry.offset + j);
+					}
+				}
+			}
+			idx_t source_child_size = child_rows.size();
+			SelectionVector child_sel(child_rows.data());
+
+			idx_t old_target_child_len = ListVector::GetListSize(target);
+
+			//! append to list itself
+			ListVector::Append(target, source_child, child_sel, source_child_size);
+
+			//! now write the list offsets
+			for (idx_t i = 0; i < copy_count; i++) {
+				auto source_idx = sel->get_index(source_offset + i);
+				auto &source_entry = sdata[source_idx];
+				auto &target_entry = tdata[target_offset + i];
+
+				target_entry.length = source_entry.length;
+				target_entry.offset = old_target_child_len;
+				if (tmask.RowIsValid(target_offset + i)) {
+					old_target_child_len += target_entry.length;
+				}
+			}
+		}
+		break;
+	}
+	default:
+		throw NotImplementedException("Unimplemented type '%s' for copy!",
+		                              TypeIdToString(source->GetType().InternalType()));
+	}
+
+	if (target_vector_type != VectorType::FLAT_VECTOR) {
+		target.SetVectorType(target_vector_type);
+	}
+}
+
+void VectorOperations::Copy(const Vector &source, Vector &target, idx_t source_count, idx_t source_offset,
+                            idx_t target_offset) {
+	VectorOperations::Copy(source, target, *FlatVector::IncrementalSelectionVector(), source_count, source_offset,
+	                       target_offset);
+}
+
+} // namespace duckdb
+//===--------------------------------------------------------------------===//
+// hash.cpp
+// Description: This file contains the vectorized hash implementations
+//===--------------------------------------------------------------------===//
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct HashOp {
+	static const hash_t NULL_HASH = 0xbf58476d1ce4e5b9;
+
+	template <class T>
+	static inline hash_t Operation(T input, bool is_null) {
+		return is_null ? NULL_HASH : duckdb::Hash<T>(input);
+	}
+};
+
+static inline hash_t CombineHashScalar(hash_t a, hash_t b) {
+	return (a * UINT64_C(0xbf58476d1ce4e5b9)) ^ b;
+}
+
+template <bool HAS_RSEL, class T>
+static inline void TightLoopHash(T *__restrict ldata, hash_t *__restrict result_data, const SelectionVector *rsel,
+                                 idx_t count, const SelectionVector *__restrict sel_vector, ValidityMask &mask) {
+	if (!mask.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			result_data[ridx] = HashOp::Operation(ldata[idx], !mask.RowIsValid(idx));
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			result_data[ridx] = duckdb::Hash<T>(ldata[idx]);
+		}
+	}
+}
+
+template <bool HAS_RSEL, class T>
+static inline void TemplatedLoopHash(Vector &input, Vector &result, const SelectionVector *rsel, idx_t count) {
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+
+		auto ldata = ConstantVector::GetData<T>(input);
+		auto result_data = ConstantVector::GetData<hash_t>(result);
+		*result_data = HashOp::Operation(*ldata, ConstantVector::IsNull(input));
+	} else {
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+
+		VectorData idata;
+		input.Orrify(count, idata);
+
+		TightLoopHash<HAS_RSEL, T>((T *)idata.data, FlatVector::GetData<hash_t>(result), rsel, count, idata.sel,
+		                           idata.validity);
+	}
+}
+
+template <bool HAS_RSEL, bool FIRST_HASH>
+static inline void StructLoopHash(Vector &input, Vector &hashes, const SelectionVector *rsel, idx_t count) {
+	auto &children = StructVector::GetEntries(input);
+
+	D_ASSERT(!children.empty());
+	idx_t col_no = 0;
+	if (HAS_RSEL) {
+		if (FIRST_HASH) {
+			VectorOperations::Hash(*children[col_no++], hashes, *rsel, count);
+		} else {
+			VectorOperations::CombineHash(hashes, *children[col_no++], *rsel, count);
+		}
+		while (col_no < children.size()) {
+			VectorOperations::CombineHash(hashes, *children[col_no++], *rsel, count);
+		}
+	} else {
+		if (FIRST_HASH) {
+			VectorOperations::Hash(*children[col_no++], hashes, count);
+		} else {
+			VectorOperations::CombineHash(hashes, *children[col_no++], count);
+		}
+		while (col_no < children.size()) {
+			VectorOperations::CombineHash(hashes, *children[col_no++], count);
+		}
+	}
+}
+
+template <bool HAS_RSEL, bool FIRST_HASH>
+static inline void ListLoopHash(Vector &input, Vector &hashes, const SelectionVector *rsel, idx_t count) {
+	auto hdata = FlatVector::GetData<hash_t>(hashes);
+
+	VectorData idata;
+	input.Orrify(count, idata);
+	const auto ldata = (const list_entry_t *)idata.data;
+
+	// Hash the children into a temporary
+	auto &child = ListVector::GetEntry(input);
+	const auto child_count = ListVector::GetListSize(input);
+
+	Vector child_hashes(LogicalType::HASH, child_count);
+	VectorOperations::Hash(child, child_hashes, child_count);
+	auto chdata = FlatVector::GetData<hash_t>(child_hashes);
+
+	// Reduce the number of entries to check to the non-empty ones
+	SelectionVector unprocessed(count);
+	SelectionVector cursor(HAS_RSEL ? STANDARD_VECTOR_SIZE : count);
+	idx_t remaining = 0;
+	for (idx_t i = 0; i < count; ++i) {
+		const idx_t ridx = HAS_RSEL ? rsel->get_index(i) : i;
+		const auto lidx = idata.sel->get_index(ridx);
+		const auto &entry = ldata[lidx];
+		if (idata.validity.RowIsValid(lidx) && entry.length > 0) {
+			unprocessed.set_index(remaining++, ridx);
+			cursor.set_index(ridx, entry.offset);
+		} else if (FIRST_HASH) {
+			hdata[ridx] = HashOp::NULL_HASH;
+		}
+		// Empty or NULL non-first elements have no effect.
+	}
+
+	count = remaining;
+	if (count == 0) {
+		return;
+	}
+
+	// Merge the first position hash into the main hash
+	idx_t position = 1;
+	if (FIRST_HASH) {
+		remaining = 0;
+		for (idx_t i = 0; i < count; ++i) {
+			const auto ridx = unprocessed.get_index(i);
+			const auto cidx = cursor.get_index(ridx);
+			hdata[ridx] = chdata[cidx];
+
+			const auto lidx = idata.sel->get_index(ridx);
+			const auto &entry = ldata[lidx];
+			if (entry.length > position) {
+				// Entry still has values to hash
+				unprocessed.set_index(remaining++, ridx);
+				cursor.set_index(ridx, cidx + 1);
+			}
+		}
+		count = remaining;
+		if (count == 0) {
+			return;
+		}
+		++position;
+	}
+
+	// Combine the hashes for the remaining positions until there are none left
+	for (;; ++position) {
+		remaining = 0;
+		for (idx_t i = 0; i < count; ++i) {
+			const auto ridx = unprocessed.get_index(i);
+			const auto cidx = cursor.get_index(ridx);
+			hdata[ridx] = CombineHashScalar(hdata[ridx], chdata[cidx]);
+
+			const auto lidx = idata.sel->get_index(ridx);
+			const auto &entry = ldata[lidx];
+			if (entry.length > position) {
+				// Entry still has values to hash
+				unprocessed.set_index(remaining++, ridx);
+				cursor.set_index(ridx, cidx + 1);
+			}
+		}
+
+		count = remaining;
+		if (count == 0) {
+			break;
+		}
+	}
+}
+
+template <bool HAS_RSEL>
+static inline void HashTypeSwitch(Vector &input, Vector &result, const SelectionVector *rsel, idx_t count) {
+	D_ASSERT(result.GetType().id() == LogicalType::HASH);
+	switch (input.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedLoopHash<HAS_RSEL, int8_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedLoopHash<HAS_RSEL, int16_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedLoopHash<HAS_RSEL, int32_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedLoopHash<HAS_RSEL, int64_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedLoopHash<HAS_RSEL, uint8_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedLoopHash<HAS_RSEL, uint16_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedLoopHash<HAS_RSEL, uint32_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedLoopHash<HAS_RSEL, uint64_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedLoopHash<HAS_RSEL, hugeint_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedLoopHash<HAS_RSEL, float>(input, result, rsel, count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedLoopHash<HAS_RSEL, double>(input, result, rsel, count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedLoopHash<HAS_RSEL, interval_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedLoopHash<HAS_RSEL, string_t>(input, result, rsel, count);
+		break;
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		StructLoopHash<HAS_RSEL, true>(input, result, rsel, count);
+		break;
+	case PhysicalType::LIST:
+		ListLoopHash<HAS_RSEL, true>(input, result, rsel, count);
+		break;
+	default:
+		throw InvalidTypeException(input.GetType(), "Invalid type for hash");
+	}
+}
+
+void VectorOperations::Hash(Vector &input, Vector &result, idx_t count) {
+	HashTypeSwitch<false>(input, result, nullptr, count);
+}
+
+void VectorOperations::Hash(Vector &input, Vector &result, const SelectionVector &sel, idx_t count) {
+	HashTypeSwitch<true>(input, result, &sel, count);
+}
+
+template <bool HAS_RSEL, class T>
+static inline void TightLoopCombineHashConstant(T *__restrict ldata, hash_t constant_hash, hash_t *__restrict hash_data,
+                                                const SelectionVector *rsel, idx_t count,
+                                                const SelectionVector *__restrict sel_vector, ValidityMask &mask) {
+	if (!mask.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			auto other_hash = HashOp::Operation(ldata[idx], !mask.RowIsValid(idx));
+			hash_data[ridx] = CombineHashScalar(constant_hash, other_hash);
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			auto other_hash = duckdb::Hash<T>(ldata[idx]);
+			hash_data[ridx] = CombineHashScalar(constant_hash, other_hash);
+		}
+	}
+}
+
+template <bool HAS_RSEL, class T>
+static inline void TightLoopCombineHash(T *__restrict ldata, hash_t *__restrict hash_data, const SelectionVector *rsel,
+                                        idx_t count, const SelectionVector *__restrict sel_vector, ValidityMask &mask) {
+	if (!mask.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			auto other_hash = HashOp::Operation(ldata[idx], !mask.RowIsValid(idx));
+			hash_data[ridx] = CombineHashScalar(hash_data[ridx], other_hash);
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = HAS_RSEL ? rsel->get_index(i) : i;
+			auto idx = sel_vector->get_index(ridx);
+			auto other_hash = duckdb::Hash<T>(ldata[idx]);
+			hash_data[ridx] = CombineHashScalar(hash_data[ridx], other_hash);
+		}
+	}
+}
+
+template <bool HAS_RSEL, class T>
+void TemplatedLoopCombineHash(Vector &input, Vector &hashes, const SelectionVector *rsel, idx_t count) {
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR && hashes.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		auto ldata = ConstantVector::GetData<T>(input);
+		auto hash_data = ConstantVector::GetData<hash_t>(hashes);
+
+		auto other_hash = HashOp::Operation(*ldata, ConstantVector::IsNull(input));
+		*hash_data = CombineHashScalar(*hash_data, other_hash);
+	} else {
+		VectorData idata;
+		input.Orrify(count, idata);
+		if (hashes.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			// mix constant with non-constant, first get the constant value
+			auto constant_hash = *ConstantVector::GetData<hash_t>(hashes);
+			// now re-initialize the hashes vector to an empty flat vector
+			hashes.SetVectorType(VectorType::FLAT_VECTOR);
+			TightLoopCombineHashConstant<HAS_RSEL, T>((T *)idata.data, constant_hash,
+			                                          FlatVector::GetData<hash_t>(hashes), rsel, count, idata.sel,
+			                                          idata.validity);
+		} else {
+			D_ASSERT(hashes.GetVectorType() == VectorType::FLAT_VECTOR);
+			TightLoopCombineHash<HAS_RSEL, T>((T *)idata.data, FlatVector::GetData<hash_t>(hashes), rsel, count,
+			                                  idata.sel, idata.validity);
+		}
+	}
+}
+
+template <bool HAS_RSEL>
+static inline void CombineHashTypeSwitch(Vector &hashes, Vector &input, const SelectionVector *rsel, idx_t count) {
+	D_ASSERT(hashes.GetType().id() == LogicalType::HASH);
+	switch (input.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedLoopCombineHash<HAS_RSEL, int8_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedLoopCombineHash<HAS_RSEL, int16_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedLoopCombineHash<HAS_RSEL, int32_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedLoopCombineHash<HAS_RSEL, int64_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedLoopCombineHash<HAS_RSEL, uint8_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedLoopCombineHash<HAS_RSEL, uint16_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedLoopCombineHash<HAS_RSEL, uint32_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedLoopCombineHash<HAS_RSEL, uint64_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedLoopCombineHash<HAS_RSEL, hugeint_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedLoopCombineHash<HAS_RSEL, float>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedLoopCombineHash<HAS_RSEL, double>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedLoopCombineHash<HAS_RSEL, interval_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedLoopCombineHash<HAS_RSEL, string_t>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		StructLoopHash<HAS_RSEL, false>(input, hashes, rsel, count);
+		break;
+	case PhysicalType::LIST:
+		ListLoopHash<HAS_RSEL, false>(input, hashes, rsel, count);
+		break;
+	default:
+		throw InvalidTypeException(input.GetType(), "Invalid type for hash");
+	}
+}
+
+void VectorOperations::CombineHash(Vector &hashes, Vector &input, idx_t count) {
+	CombineHashTypeSwitch<false>(hashes, input, nullptr, count);
+}
+
+void VectorOperations::CombineHash(Vector &hashes, Vector &input, const SelectionVector &rsel, idx_t count) {
+	CombineHashTypeSwitch<true>(hashes, input, &rsel, count);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+template <class T>
+static void CopyToStorageLoop(VectorData &vdata, idx_t count, data_ptr_t target) {
+	auto ldata = (T *)vdata.data;
+	auto result_data = (T *)target;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = vdata.sel->get_index(i);
+		if (!vdata.validity.RowIsValid(idx)) {
+			result_data[i] = NullValue<T>();
+		} else {
+			result_data[i] = ldata[idx];
+		}
+	}
+}
+
+void VectorOperations::WriteToStorage(Vector &source, idx_t count, data_ptr_t target) {
+	if (count == 0) {
+		return;
+	}
+	VectorData vdata;
+	source.Orrify(count, vdata);
+
+	switch (source.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		CopyToStorageLoop<int8_t>(vdata, count, target);
+		break;
+	case PhysicalType::INT16:
+		CopyToStorageLoop<int16_t>(vdata, count, target);
+		break;
+	case PhysicalType::INT32:
+		CopyToStorageLoop<int32_t>(vdata, count, target);
+		break;
+	case PhysicalType::INT64:
+		CopyToStorageLoop<int64_t>(vdata, count, target);
+		break;
+	case PhysicalType::UINT8:
+		CopyToStorageLoop<uint8_t>(vdata, count, target);
+		break;
+	case PhysicalType::UINT16:
+		CopyToStorageLoop<uint16_t>(vdata, count, target);
+		break;
+	case PhysicalType::UINT32:
+		CopyToStorageLoop<uint32_t>(vdata, count, target);
+		break;
+	case PhysicalType::UINT64:
+		CopyToStorageLoop<uint64_t>(vdata, count, target);
+		break;
+	case PhysicalType::INT128:
+		CopyToStorageLoop<hugeint_t>(vdata, count, target);
+		break;
+	case PhysicalType::FLOAT:
+		CopyToStorageLoop<float>(vdata, count, target);
+		break;
+	case PhysicalType::DOUBLE:
+		CopyToStorageLoop<double>(vdata, count, target);
+		break;
+	case PhysicalType::INTERVAL:
+		CopyToStorageLoop<interval_t>(vdata, count, target);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for WriteToStorage");
+	}
+}
+
+template <class T>
+static void ReadFromStorageLoop(data_ptr_t source, idx_t count, Vector &result) {
+	auto ldata = (T *)source;
+	auto result_data = FlatVector::GetData<T>(result);
+	for (idx_t i = 0; i < count; i++) {
+		result_data[i] = ldata[i];
+	}
+}
+
+void VectorOperations::ReadFromStorage(data_ptr_t source, idx_t count, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		ReadFromStorageLoop<int8_t>(source, count, result);
+		break;
+	case PhysicalType::INT16:
+		ReadFromStorageLoop<int16_t>(source, count, result);
+		break;
+	case PhysicalType::INT32:
+		ReadFromStorageLoop<int32_t>(source, count, result);
+		break;
+	case PhysicalType::INT64:
+		ReadFromStorageLoop<int64_t>(source, count, result);
+		break;
+	case PhysicalType::UINT8:
+		ReadFromStorageLoop<uint8_t>(source, count, result);
+		break;
+	case PhysicalType::UINT16:
+		ReadFromStorageLoop<uint16_t>(source, count, result);
+		break;
+	case PhysicalType::UINT32:
+		ReadFromStorageLoop<uint32_t>(source, count, result);
+		break;
+	case PhysicalType::UINT64:
+		ReadFromStorageLoop<uint64_t>(source, count, result);
+		break;
+	case PhysicalType::INT128:
+		ReadFromStorageLoop<hugeint_t>(source, count, result);
+		break;
+	case PhysicalType::FLOAT:
+		ReadFromStorageLoop<float>(source, count, result);
+		break;
+	case PhysicalType::DOUBLE:
+		ReadFromStorageLoop<double>(source, count, result);
+		break;
+	case PhysicalType::INTERVAL:
+		ReadFromStorageLoop<interval_t>(source, count, result);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for ReadFromStorage");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+VirtualFileSystem::VirtualFileSystem() : default_fs(FileSystem::CreateLocal()) {
+	RegisterSubSystem(FileCompressionType::GZIP, make_unique<GZipFileSystem>());
+}
+
+unique_ptr<FileHandle> VirtualFileSystem::OpenFile(const string &path, uint8_t flags, FileLockType lock,
+                                                   FileCompressionType compression, FileOpener *opener) {
+	if (compression == FileCompressionType::AUTO_DETECT) {
+		// auto detect compression settings based on file name
+		auto lower_path = StringUtil::Lower(path);
+		if (StringUtil::EndsWith(lower_path, ".gz")) {
+			compression = FileCompressionType::GZIP;
+		} else if (StringUtil::EndsWith(lower_path, ".zst")) {
+			compression = FileCompressionType::ZSTD;
+		} else {
+			compression = FileCompressionType::UNCOMPRESSED;
+		}
+	}
+	// open the base file handle
+	auto file_handle = FindFileSystem(path)->OpenFile(path, flags, lock, FileCompressionType::UNCOMPRESSED, opener);
+	if (file_handle->GetType() == FileType::FILE_TYPE_FIFO) {
+		file_handle = PipeFileSystem::OpenPipe(move(file_handle));
+	} else if (compression != FileCompressionType::UNCOMPRESSED) {
+		auto entry = compressed_fs.find(compression);
+		if (entry == compressed_fs.end()) {
+			throw NotImplementedException(
+			    "Attempting to open a compressed file, but the compression type is not supported");
+		}
+		file_handle = entry->second->OpenCompressedFile(move(file_handle), flags & FileFlags::FILE_FLAGS_WRITE);
+	}
+	return file_handle;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+#ifdef DUCKDB_WINDOWS
+
+std::wstring WindowsUtil::UTF8ToUnicode(const char *input) {
+	idx_t result_size;
+
+	result_size = MultiByteToWideChar(CP_UTF8, 0, input, -1, nullptr, 0);
+	if (result_size == 0) {
+		throw IOException("Failure in MultiByteToWideChar");
+	}
+	auto buffer = unique_ptr<wchar_t[]>(new wchar_t[result_size]);
+	result_size = MultiByteToWideChar(CP_UTF8, 0, input, -1, buffer.get(), result_size);
+	if (result_size == 0) {
+		throw IOException("Failure in MultiByteToWideChar");
+	}
+	return std::wstring(buffer.get(), result_size);
+}
+
+static string WideCharToMultiByteWrapper(LPCWSTR input, uint32_t code_page) {
+	idx_t result_size;
+
+	result_size = WideCharToMultiByte(code_page, 0, input, -1, 0, 0, 0, 0);
+	if (result_size == 0) {
+		throw IOException("Failure in WideCharToMultiByte");
+	}
+	auto buffer = unique_ptr<char[]>(new char[result_size]);
+	result_size = WideCharToMultiByte(code_page, 0, input, -1, buffer.get(), result_size, 0, 0);
+	if (result_size == 0) {
+		throw IOException("Failure in WideCharToMultiByte");
+	}
+	return string(buffer.get(), result_size - 1);
+}
+
+string WindowsUtil::UnicodeToUTF8(LPCWSTR input) {
+	return WideCharToMultiByteWrapper(input, CP_UTF8);
+}
+
+static string WindowsUnicodeToMBCS(LPCWSTR unicode_text, int use_ansi) {
+	uint32_t code_page = use_ansi ? CP_ACP : CP_OEMCP;
+	return WideCharToMultiByteWrapper(unicode_text, code_page);
+}
+
+string WindowsUtil::UTF8ToMBCS(const char *input, bool use_ansi) {
+	auto unicode = WindowsUtil::UTF8ToUnicode(input);
+	return WindowsUnicodeToMBCS(unicode.c_str(), use_ansi);
+}
+
+#endif
+
+} // namespace duckdb
+
+
+
+#include <vector>
+
+namespace duckdb {
+
+AdaptiveFilter::AdaptiveFilter(const Expression &expr)
+    : iteration_count(0), observe_interval(10), execute_interval(20), warmup(true) {
+	auto &conj_expr = (const BoundConjunctionExpression &)expr;
+	D_ASSERT(conj_expr.children.size() > 1);
+	for (idx_t idx = 0; idx < conj_expr.children.size(); idx++) {
+		permutation.push_back(idx);
+		if (idx != conj_expr.children.size() - 1) {
+			swap_likeliness.push_back(100);
+		}
+	}
+	right_random_border = 100 * (conj_expr.children.size() - 1);
+}
+
+AdaptiveFilter::AdaptiveFilter(TableFilterSet *table_filters)
+    : iteration_count(0), observe_interval(10), execute_interval(20), warmup(true) {
+	for (auto &table_filter : table_filters->filters) {
+		permutation.push_back(table_filter.first);
+		swap_likeliness.push_back(100);
+	}
+	swap_likeliness.pop_back();
+	right_random_border = 100 * (table_filters->filters.size() - 1);
+}
+void AdaptiveFilter::AdaptRuntimeStatistics(double duration) {
+	iteration_count++;
+	runtime_sum += duration;
+
+	if (!warmup) {
+		// the last swap was observed
+		if (observe && iteration_count == observe_interval) {
+			// keep swap if runtime decreased, else reverse swap
+			if (prev_mean - (runtime_sum / iteration_count) <= 0) {
+				// reverse swap because runtime didn't decrease
+				std::swap(permutation[swap_idx], permutation[swap_idx + 1]);
+
+				// decrease swap likeliness, but make sure there is always a small likeliness left
+				if (swap_likeliness[swap_idx] > 1) {
+					swap_likeliness[swap_idx] /= 2;
+				}
+			} else {
+				// keep swap because runtime decreased, reset likeliness
+				swap_likeliness[swap_idx] = 100;
+			}
+			observe = false;
+
+			// reset values
+			iteration_count = 0;
+			runtime_sum = 0.0;
+		} else if (!observe && iteration_count == execute_interval) {
+			// save old mean to evaluate swap
+			prev_mean = runtime_sum / iteration_count;
+
+			// get swap index and swap likeliness
+			std::uniform_int_distribution<int> distribution(1, right_random_border); // a <= i <= b
+			idx_t random_number = distribution(generator) - 1;
+
+			swap_idx = random_number / 100;                    // index to be swapped
+			idx_t likeliness = random_number - 100 * swap_idx; // random number between [0, 100)
+
+			// check if swap is going to happen
+			if (swap_likeliness[swap_idx] > likeliness) { // always true for the first swap of an index
+				// swap
+				std::swap(permutation[swap_idx], permutation[swap_idx + 1]);
+
+				// observe whether swap will be applied
+				observe = true;
+			}
+
+			// reset values
+			iteration_count = 0;
+			runtime_sum = 0.0;
+		}
+	} else {
+		if (iteration_count == 5) {
+			// initially set all values
+			iteration_count = 0;
+			runtime_sum = 0.0;
+			observe = false;
+			warmup = false;
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cmath>
+
+namespace duckdb {
+
+using ValidityBytes = RowLayout::ValidityBytes;
+
+GroupedAggregateHashTable::GroupedAggregateHashTable(BufferManager &buffer_manager, vector<LogicalType> group_types,
+                                                     vector<LogicalType> payload_types,
+                                                     const vector<BoundAggregateExpression *> &bindings,
+                                                     HtEntryType entry_type)
+    : GroupedAggregateHashTable(buffer_manager, move(group_types), move(payload_types),
+                                AggregateObject::CreateAggregateObjects(bindings), entry_type) {
+}
+
+GroupedAggregateHashTable::GroupedAggregateHashTable(BufferManager &buffer_manager, vector<LogicalType> group_types)
+    : GroupedAggregateHashTable(buffer_manager, move(group_types), {}, vector<AggregateObject>()) {
+}
+
+GroupedAggregateHashTable::GroupedAggregateHashTable(BufferManager &buffer_manager, vector<LogicalType> group_types_p,
+                                                     vector<LogicalType> payload_types_p,
+                                                     vector<AggregateObject> aggregate_objects_p,
+                                                     HtEntryType entry_type)
+    : BaseAggregateHashTable(buffer_manager, move(payload_types_p)), entry_type(entry_type), capacity(0), entries(0),
+      payload_page_offset(0), is_finalized(false), ht_offsets(LogicalTypeId::BIGINT),
+      hash_salts(LogicalTypeId::SMALLINT), group_compare_vector(STANDARD_VECTOR_SIZE),
+      no_match_vector(STANDARD_VECTOR_SIZE), empty_vector(STANDARD_VECTOR_SIZE) {
+
+	// Append hash column to the end and initialise the row layout
+	group_types_p.emplace_back(LogicalType::HASH);
+	layout.Initialize(move(group_types_p), move(aggregate_objects_p));
+
+	// HT layout
+	hash_offset = layout.GetOffsets()[layout.ColumnCount() - 1];
+
+	tuple_size = layout.GetRowWidth();
+
+	D_ASSERT(tuple_size <= Storage::BLOCK_SIZE);
+	tuples_per_block = Storage::BLOCK_SIZE / tuple_size;
+	hashes_hdl = buffer_manager.Allocate(Storage::BLOCK_SIZE);
+	hashes_hdl_ptr = hashes_hdl->Ptr();
+
+	switch (entry_type) {
+	case HtEntryType::HT_WIDTH_64: {
+		hash_prefix_shift = (HASH_WIDTH - sizeof(aggr_ht_entry_64::salt)) * 8;
+		Resize<aggr_ht_entry_64>(STANDARD_VECTOR_SIZE * 2);
+		break;
+	}
+	case HtEntryType::HT_WIDTH_32: {
+		hash_prefix_shift = (HASH_WIDTH - sizeof(aggr_ht_entry_32::salt)) * 8;
+		Resize<aggr_ht_entry_32>(STANDARD_VECTOR_SIZE * 2);
+		break;
+	}
+	default:
+		throw InternalException("Unknown HT entry width");
+	}
+
+	// create additional hash tables for distinct aggrs
+	auto &aggregates = layout.GetAggregates();
+	distinct_hashes.resize(aggregates.size());
+
+	idx_t payload_idx = 0;
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		auto &aggr = aggregates[i];
+		if (aggr.distinct) {
+			// layout types minus hash column plus aggr return type
+			vector<LogicalType> distinct_group_types(layout.GetTypes());
+			(void)distinct_group_types.pop_back();
+			for (idx_t child_idx = 0; child_idx < aggr.child_count; child_idx++) {
+				distinct_group_types.push_back(payload_types[payload_idx + child_idx]);
+			}
+			distinct_hashes[i] = make_unique<GroupedAggregateHashTable>(buffer_manager, distinct_group_types);
+		}
+		payload_idx += aggr.child_count;
+	}
+	predicates.resize(layout.ColumnCount() - 1, ExpressionType::COMPARE_EQUAL);
+	string_heap = make_unique<RowDataCollection>(buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1, true);
+}
+
+GroupedAggregateHashTable::~GroupedAggregateHashTable() {
+	Destroy();
+}
+
+template <class FUNC>
+void GroupedAggregateHashTable::PayloadApply(FUNC fun) {
+	if (entries == 0) {
+		return;
+	}
+	idx_t apply_entries = entries;
+	idx_t page_nr = 0;
+	idx_t page_offset = 0;
+
+	for (auto &payload_chunk_ptr : payload_hds_ptrs) {
+		auto this_entries = MinValue(tuples_per_block, apply_entries);
+		page_offset = 0;
+		for (data_ptr_t ptr = payload_chunk_ptr, end = payload_chunk_ptr + this_entries * tuple_size; ptr < end;
+		     ptr += tuple_size) {
+			fun(page_nr, page_offset++, ptr);
+		}
+		apply_entries -= this_entries;
+		page_nr++;
+	}
+	D_ASSERT(apply_entries == 0);
+}
+
+void GroupedAggregateHashTable::NewBlock() {
+	auto pin = buffer_manager.Allocate(Storage::BLOCK_SIZE);
+	payload_hds.push_back(move(pin));
+	payload_hds_ptrs.push_back(payload_hds.back()->Ptr());
+	payload_page_offset = 0;
+}
+
+void GroupedAggregateHashTable::Destroy() {
+	// check if there is a destructor
+	bool has_destructor = false;
+	for (auto &aggr : layout.GetAggregates()) {
+		if (aggr.function.destructor) {
+			has_destructor = true;
+		}
+	}
+	if (!has_destructor) {
+		return;
+	}
+	// there are aggregates with destructors: loop over the hash table
+	// and call the destructor method for each of the aggregates
+	data_ptr_t data_pointers[STANDARD_VECTOR_SIZE];
+	Vector state_vector(LogicalType::POINTER, (data_ptr_t)data_pointers);
+	idx_t count = 0;
+
+	PayloadApply([&](idx_t page_nr, idx_t page_offset, data_ptr_t ptr) {
+		data_pointers[count++] = ptr;
+		if (count == STANDARD_VECTOR_SIZE) {
+			RowOperations::DestroyStates(layout, state_vector, count);
+			count = 0;
+		}
+	});
+	RowOperations::DestroyStates(layout, state_vector, count);
+}
+
+template <class ENTRY>
+void GroupedAggregateHashTable::VerifyInternal() {
+	auto hashes_ptr = (ENTRY *)hashes_hdl_ptr;
+	D_ASSERT(payload_hds.size() == payload_hds_ptrs.size());
+	idx_t count = 0;
+	for (idx_t i = 0; i < capacity; i++) {
+		if (hashes_ptr[i].page_nr > 0) {
+			D_ASSERT(hashes_ptr[i].page_offset < tuples_per_block);
+			D_ASSERT(hashes_ptr[i].page_nr <= payload_hds.size());
+			auto ptr = payload_hds_ptrs[hashes_ptr[i].page_nr - 1] + ((hashes_ptr[i].page_offset) * tuple_size);
+			auto hash = Load<hash_t>(ptr + hash_offset);
+			D_ASSERT((hashes_ptr[i].salt) == (hash >> hash_prefix_shift));
+
+			count++;
+		}
+	}
+	D_ASSERT(count == entries);
+}
+
+idx_t GroupedAggregateHashTable::MaxCapacity() {
+	idx_t max_pages = 0;
+	idx_t max_tuples = 0;
+
+	switch (entry_type) {
+	case HtEntryType::HT_WIDTH_32:
+		max_pages = NumericLimits<uint8_t>::Maximum();
+		max_tuples = NumericLimits<uint16_t>::Maximum();
+		break;
+	default:
+		D_ASSERT(entry_type == HtEntryType::HT_WIDTH_64);
+		max_pages = NumericLimits<uint32_t>::Maximum();
+		max_tuples = NumericLimits<uint16_t>::Maximum();
+		break;
+	}
+
+	return max_pages * MinValue(max_tuples, (idx_t)Storage::BLOCK_SIZE / tuple_size);
+}
+
+void GroupedAggregateHashTable::Verify() {
+#ifdef DEBUG
+	switch (entry_type) {
+	case HtEntryType::HT_WIDTH_32:
+		VerifyInternal<aggr_ht_entry_32>();
+		break;
+	case HtEntryType::HT_WIDTH_64:
+		VerifyInternal<aggr_ht_entry_64>();
+		break;
+	}
+#endif
+}
+
+template <class ENTRY>
+void GroupedAggregateHashTable::Resize(idx_t size) {
+	Verify();
+
+	D_ASSERT(!is_finalized);
+
+	if (size <= capacity) {
+		throw InternalException("Cannot downsize a hash table!");
+	}
+	D_ASSERT(size >= STANDARD_VECTOR_SIZE);
+
+	// size needs to be a power of 2
+	D_ASSERT((size & (size - 1)) == 0);
+	bitmask = size - 1;
+
+	auto byte_size = size * sizeof(ENTRY);
+	if (byte_size > (idx_t)Storage::BLOCK_SIZE) {
+		hashes_hdl = buffer_manager.Allocate(byte_size);
+		hashes_hdl_ptr = hashes_hdl->Ptr();
+	}
+	memset(hashes_hdl_ptr, 0, byte_size);
+	hashes_end_ptr = hashes_hdl_ptr + byte_size;
+	capacity = size;
+
+	auto hashes_arr = (ENTRY *)hashes_hdl_ptr;
+
+	PayloadApply([&](idx_t page_nr, idx_t page_offset, data_ptr_t ptr) {
+		auto hash = Load<hash_t>(ptr + hash_offset);
+		D_ASSERT((hash & bitmask) == (hash % capacity));
+		auto entry_idx = (idx_t)hash & bitmask;
+		while (hashes_arr[entry_idx].page_nr > 0) {
+			entry_idx++;
+			if (entry_idx >= capacity) {
+				entry_idx = 0;
+			}
+		}
+
+		D_ASSERT(!hashes_arr[entry_idx].page_nr);
+		D_ASSERT(hash >> hash_prefix_shift <= NumericLimits<uint16_t>::Maximum());
+
+		hashes_arr[entry_idx].salt = hash >> hash_prefix_shift;
+		hashes_arr[entry_idx].page_nr = page_nr + 1;
+		hashes_arr[entry_idx].page_offset = page_offset;
+	});
+
+	Verify();
+}
+
+idx_t GroupedAggregateHashTable::AddChunk(DataChunk &groups, DataChunk &payload) {
+	Vector hashes(LogicalType::HASH);
+	groups.Hash(hashes);
+
+	return AddChunk(groups, hashes, payload);
+}
+
+idx_t GroupedAggregateHashTable::AddChunk(DataChunk &groups, Vector &group_hashes, DataChunk &payload) {
+	D_ASSERT(!is_finalized);
+
+	if (groups.size() == 0) {
+		return 0;
+	}
+	// dummy
+	SelectionVector new_groups(STANDARD_VECTOR_SIZE);
+
+	D_ASSERT(groups.ColumnCount() + 1 == layout.ColumnCount());
+	for (idx_t i = 0; i < groups.ColumnCount(); i++) {
+		D_ASSERT(groups.GetTypes()[i] == layout.GetTypes()[i]);
+	}
+
+	Vector addresses(LogicalType::POINTER);
+	auto new_group_count = FindOrCreateGroups(groups, group_hashes, addresses, new_groups);
+	VectorOperations::AddInPlace(addresses, layout.GetAggrOffset(), payload.size());
+
+	// now every cell has an entry
+	// update the aggregates
+	idx_t payload_idx = 0;
+
+	auto &aggregates = layout.GetAggregates();
+	for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
+		// for any entries for which a group was found, update the aggregate
+		auto &aggr = aggregates[aggr_idx];
+		if (aggr.distinct) {
+			// construct chunk for secondary hash table probing
+			vector<LogicalType> probe_types(groups.GetTypes());
+			for (idx_t i = 0; i < aggr.child_count; i++) {
+				probe_types.push_back(payload_types[payload_idx + i]);
+			}
+			DataChunk probe_chunk;
+			probe_chunk.Initialize(probe_types);
+			for (idx_t group_idx = 0; group_idx < groups.ColumnCount(); group_idx++) {
+				probe_chunk.data[group_idx].Reference(groups.data[group_idx]);
+			}
+			for (idx_t i = 0; i < aggr.child_count; i++) {
+				probe_chunk.data[groups.ColumnCount() + i].Reference(payload.data[payload_idx + i]);
+			}
+			probe_chunk.SetCardinality(groups);
+			probe_chunk.Verify();
+
+			Vector dummy_addresses(LogicalType::POINTER);
+			// this is the actual meat, find out which groups plus payload
+			// value have not been seen yet
+			idx_t new_group_count =
+			    distinct_hashes[aggr_idx]->FindOrCreateGroups(probe_chunk, dummy_addresses, new_groups);
+			if (new_group_count > 0) {
+				// now fix up the payload and addresses accordingly by creating
+				// a selection vector
+				DataChunk distinct_payload;
+				distinct_payload.Initialize(payload.GetTypes());
+				distinct_payload.Slice(payload, new_groups, new_group_count);
+				distinct_payload.Verify();
+
+				Vector distinct_addresses(addresses, new_groups, new_group_count);
+				distinct_addresses.Verify(new_group_count);
+
+				if (aggr.filter) {
+					distinct_addresses.Normalify(new_group_count);
+					RowOperations::UpdateFilteredStates(aggr, distinct_addresses, distinct_payload, payload_idx);
+				} else {
+					RowOperations::UpdateStates(aggr, distinct_addresses, distinct_payload, payload_idx,
+					                            new_group_count);
+				}
+			}
+		} else if (aggr.filter) {
+			RowOperations::UpdateFilteredStates(aggr, addresses, payload, payload_idx);
+		} else {
+			RowOperations::UpdateStates(aggr, addresses, payload, payload_idx, payload.size());
+		}
+
+		// move to the next aggregate
+		payload_idx += aggr.child_count;
+		VectorOperations::AddInPlace(addresses, aggr.payload_size, payload.size());
+	}
+
+	Verify();
+	return new_group_count;
+}
+
+void GroupedAggregateHashTable::FetchAggregates(DataChunk &groups, DataChunk &result) {
+	groups.Verify();
+	D_ASSERT(groups.ColumnCount() + 1 == layout.ColumnCount());
+	for (idx_t i = 0; i < result.ColumnCount(); i++) {
+		D_ASSERT(result.data[i].GetType() == payload_types[i]);
+	}
+	result.SetCardinality(groups);
+	if (groups.size() == 0) {
+		return;
+	}
+	// find the groups associated with the addresses
+	// FIXME: this should not use the FindOrCreateGroups, creating them is unnecessary
+	Vector addresses(LogicalType::POINTER);
+	FindOrCreateGroups(groups, addresses);
+	// now fetch the aggregates
+	RowOperations::FinalizeStates(layout, addresses, result, 0);
+}
+
+template <class ENTRY>
+idx_t GroupedAggregateHashTable::FindOrCreateGroupsInternal(DataChunk &groups, Vector &group_hashes, Vector &addresses,
+                                                            SelectionVector &new_groups_out) {
+	D_ASSERT(!is_finalized);
+
+	if (entries + groups.size() > MaxCapacity()) {
+		throw InternalException("Hash table capacity reached");
+	}
+
+	// resize at 50% capacity, also need to fit the entire vector
+	if (capacity - entries <= groups.size() || entries > capacity / LOAD_FACTOR) {
+		Resize<ENTRY>(capacity * 2);
+	}
+
+	D_ASSERT(capacity - entries >= groups.size());
+	D_ASSERT(groups.ColumnCount() + 1 == layout.ColumnCount());
+	// we need to be able to fit at least one vector of data
+	D_ASSERT(capacity - entries >= groups.size());
+	D_ASSERT(group_hashes.GetType() == LogicalType::HASH);
+
+	group_hashes.Normalify(groups.size());
+	auto group_hashes_ptr = FlatVector::GetData<hash_t>(group_hashes);
+
+	D_ASSERT(ht_offsets.GetVectorType() == VectorType::FLAT_VECTOR);
+	D_ASSERT(ht_offsets.GetType() == LogicalType::BIGINT);
+
+	D_ASSERT(addresses.GetType() == LogicalType::POINTER);
+	addresses.Normalify(groups.size());
+	auto addresses_ptr = FlatVector::GetData<data_ptr_t>(addresses);
+
+	// now compute the entry in the table based on the hash using a modulo
+	UnaryExecutor::Execute<hash_t, uint64_t>(group_hashes, ht_offsets, groups.size(), [&](hash_t element) {
+		D_ASSERT((element & bitmask) == (element % capacity));
+		return (element & bitmask);
+	});
+	auto ht_offsets_ptr = FlatVector::GetData<uint64_t>(ht_offsets);
+
+	// precompute the hash salts for faster comparison below
+	D_ASSERT(hash_salts.GetType() == LogicalType::SMALLINT);
+	UnaryExecutor::Execute<hash_t, uint16_t>(group_hashes, hash_salts, groups.size(),
+	                                         [&](hash_t element) { return (element >> hash_prefix_shift); });
+	auto hash_salts_ptr = FlatVector::GetData<uint16_t>(hash_salts);
+
+	// we start out with all entries [0, 1, 2, ..., groups.size()]
+	const SelectionVector *sel_vector = FlatVector::IncrementalSelectionVector();
+
+	idx_t remaining_entries = groups.size();
+
+	// make a chunk that references the groups and the hashes
+	DataChunk group_chunk;
+	group_chunk.InitializeEmpty(layout.GetTypes());
+	for (idx_t grp_idx = 0; grp_idx < groups.ColumnCount(); grp_idx++) {
+		group_chunk.data[grp_idx].Reference(groups.data[grp_idx]);
+	}
+	group_chunk.data[groups.ColumnCount()].Reference(group_hashes);
+	group_chunk.SetCardinality(groups);
+
+	// orrify all the groups
+	auto group_data = group_chunk.Orrify();
+
+	idx_t new_group_count = 0;
+	while (remaining_entries > 0) {
+		idx_t new_entry_count = 0;
+		idx_t need_compare_count = 0;
+		idx_t no_match_count = 0;
+
+		// first figure out for each remaining whether or not it belongs to a full or empty group
+		for (idx_t i = 0; i < remaining_entries; i++) {
+			const idx_t index = sel_vector->get_index(i);
+			const auto ht_entry_ptr = ((ENTRY *)this->hashes_hdl_ptr) + ht_offsets_ptr[index];
+			if (ht_entry_ptr->page_nr == 0) { // we use page number 0 as a "unused marker"
+				// cell is empty; setup the new entry
+				if (payload_page_offset == tuples_per_block || payload_hds.empty()) {
+					NewBlock();
+				}
+
+				auto entry_payload_ptr = payload_hds_ptrs.back() + (payload_page_offset * tuple_size);
+
+				D_ASSERT(group_hashes_ptr[index] >> hash_prefix_shift <= NumericLimits<uint16_t>::Maximum());
+				D_ASSERT(payload_page_offset < tuples_per_block);
+				D_ASSERT(payload_hds.size() < NumericLimits<uint32_t>::Maximum());
+				D_ASSERT(payload_page_offset + 1 < NumericLimits<uint16_t>::Maximum());
+
+				ht_entry_ptr->salt = group_hashes_ptr[index] >> hash_prefix_shift;
+
+				// page numbers start at one so we can use 0 as empty flag
+				// GetPtr undoes this
+				ht_entry_ptr->page_nr = payload_hds.size();
+				ht_entry_ptr->page_offset = payload_page_offset++;
+
+				// update selection lists for outer loops
+				empty_vector.set_index(new_entry_count++, index);
+				new_groups_out.set_index(new_group_count++, index);
+				entries++;
+
+				addresses_ptr[index] = entry_payload_ptr;
+
+			} else {
+				// cell is occupied: add to check list
+				// only need to check if hash salt in ptr == prefix of hash in payload
+				if (ht_entry_ptr->salt == hash_salts_ptr[index]) {
+					group_compare_vector.set_index(need_compare_count++, index);
+
+					auto page_ptr = payload_hds_ptrs[ht_entry_ptr->page_nr - 1];
+					auto page_offset = ht_entry_ptr->page_offset * tuple_size;
+					addresses_ptr[index] = page_ptr + page_offset;
+
+				} else {
+					no_match_vector.set_index(no_match_count++, index);
+				}
+			}
+		}
+
+		// for each of the locations that are empty, serialize the group columns to the locations
+		RowOperations::Scatter(group_chunk, group_data.get(), layout, addresses, *string_heap, empty_vector,
+		                       new_entry_count);
+		RowOperations::InitializeStates(layout, addresses, empty_vector, new_entry_count);
+
+		// now we have only the tuples remaining that might match to an existing group
+		// start performing comparisons with each of the groups
+		RowOperations::Match(group_chunk, group_data.get(), layout, addresses, predicates, group_compare_vector,
+		                     need_compare_count, &no_match_vector, no_match_count);
+
+		// each of the entries that do not match we move them to the next entry in the HT
+		for (idx_t i = 0; i < no_match_count; i++) {
+			idx_t index = no_match_vector.get_index(i);
+			ht_offsets_ptr[index]++;
+			if (ht_offsets_ptr[index] >= capacity) {
+				ht_offsets_ptr[index] = 0;
+			}
+		}
+		sel_vector = &no_match_vector;
+		remaining_entries = no_match_count;
+	}
+
+	return new_group_count;
+}
+
+// this is to support distinct aggregations where we need to record whether we
+// have already seen a value for a group
+idx_t GroupedAggregateHashTable::FindOrCreateGroups(DataChunk &groups, Vector &group_hashes, Vector &addresses_out,
+                                                    SelectionVector &new_groups_out) {
+	switch (entry_type) {
+	case HtEntryType::HT_WIDTH_64:
+		return FindOrCreateGroupsInternal<aggr_ht_entry_64>(groups, group_hashes, addresses_out, new_groups_out);
+	case HtEntryType::HT_WIDTH_32:
+		return FindOrCreateGroupsInternal<aggr_ht_entry_32>(groups, group_hashes, addresses_out, new_groups_out);
+	default:
+		throw InternalException("Unknown HT entry width");
+	}
+}
+
+void GroupedAggregateHashTable::FindOrCreateGroups(DataChunk &groups, Vector &addresses) {
+	// create a dummy new_groups sel vector
+	SelectionVector new_groups(STANDARD_VECTOR_SIZE);
+	FindOrCreateGroups(groups, addresses, new_groups);
+}
+
+idx_t GroupedAggregateHashTable::FindOrCreateGroups(DataChunk &groups, Vector &addresses_out,
+                                                    SelectionVector &new_groups_out) {
+	Vector hashes(LogicalType::HASH);
+	groups.Hash(hashes);
+	return FindOrCreateGroups(groups, hashes, addresses_out, new_groups_out);
+}
+
+void GroupedAggregateHashTable::FlushMove(Vector &source_addresses, Vector &source_hashes, idx_t count) {
+	D_ASSERT(source_addresses.GetType() == LogicalType::POINTER);
+	D_ASSERT(source_hashes.GetType() == LogicalType::HASH);
+
+	DataChunk groups;
+	groups.Initialize(vector<LogicalType>(layout.GetTypes().begin(), layout.GetTypes().end() - 1));
+	groups.SetCardinality(count);
+	for (idx_t i = 0; i < groups.ColumnCount(); i++) {
+		auto &column = groups.data[i];
+		const auto col_offset = layout.GetOffsets()[i];
+		RowOperations::Gather(source_addresses, *FlatVector::IncrementalSelectionVector(), column,
+		                      *FlatVector::IncrementalSelectionVector(), count, col_offset, i);
+	}
+
+	SelectionVector new_groups(STANDARD_VECTOR_SIZE);
+	Vector group_addresses(LogicalType::POINTER);
+	SelectionVector new_groups_sel(STANDARD_VECTOR_SIZE);
+
+	FindOrCreateGroups(groups, source_hashes, group_addresses, new_groups_sel);
+
+	RowOperations::CombineStates(layout, source_addresses, group_addresses, count);
+}
+
+void GroupedAggregateHashTable::Combine(GroupedAggregateHashTable &other) {
+
+	D_ASSERT(!is_finalized);
+
+	D_ASSERT(other.layout.GetAggrWidth() == layout.GetAggrWidth());
+	D_ASSERT(other.layout.GetDataWidth() == layout.GetDataWidth());
+	D_ASSERT(other.layout.GetRowWidth() == layout.GetRowWidth());
+	D_ASSERT(other.tuples_per_block == tuples_per_block);
+
+	if (other.entries == 0) {
+		return;
+	}
+
+	Vector addresses(LogicalType::POINTER);
+	auto addresses_ptr = FlatVector::GetData<data_ptr_t>(addresses);
+
+	Vector hashes(LogicalType::HASH);
+	auto hashes_ptr = FlatVector::GetData<hash_t>(hashes);
+
+	idx_t group_idx = 0;
+
+	other.PayloadApply([&](idx_t page_nr, idx_t page_offset, data_ptr_t ptr) {
+		auto hash = Load<hash_t>(ptr + hash_offset);
+
+		hashes_ptr[group_idx] = hash;
+		addresses_ptr[group_idx] = ptr;
+		group_idx++;
+		if (group_idx == STANDARD_VECTOR_SIZE) {
+			FlushMove(addresses, hashes, group_idx);
+			group_idx = 0;
+		}
+	});
+	FlushMove(addresses, hashes, group_idx);
+	string_heap->Merge(*other.string_heap);
+	Verify();
+}
+
+struct PartitionInfo {
+	PartitionInfo() : addresses(LogicalType::POINTER), hashes(LogicalType::HASH), group_count(0) {
+		addresses_ptr = FlatVector::GetData<data_ptr_t>(addresses);
+		hashes_ptr = FlatVector::GetData<hash_t>(hashes);
+	};
+	Vector addresses;
+	Vector hashes;
+	idx_t group_count;
+	data_ptr_t *addresses_ptr;
+	hash_t *hashes_ptr;
+};
+
+void GroupedAggregateHashTable::Partition(vector<GroupedAggregateHashTable *> &partition_hts, hash_t mask,
+                                          idx_t shift) {
+	D_ASSERT(partition_hts.size() > 1);
+	vector<PartitionInfo> partition_info(partition_hts.size());
+
+	PayloadApply([&](idx_t page_nr, idx_t page_offset, data_ptr_t ptr) {
+		auto hash = Load<hash_t>(ptr + hash_offset);
+
+		idx_t partition = (hash & mask) >> shift;
+		D_ASSERT(partition < partition_hts.size());
+
+		auto &info = partition_info[partition];
+
+		info.hashes_ptr[info.group_count] = hash;
+		info.addresses_ptr[info.group_count] = ptr;
+		info.group_count++;
+		if (info.group_count == STANDARD_VECTOR_SIZE) {
+			D_ASSERT(partition_hts[partition]);
+			partition_hts[partition]->FlushMove(info.addresses, info.hashes, info.group_count);
+			info.group_count = 0;
+		}
+	});
+
+	idx_t info_idx = 0;
+	idx_t total_count = 0;
+	for (auto &partition_entry : partition_hts) {
+		auto &info = partition_info[info_idx++];
+		partition_entry->FlushMove(info.addresses, info.hashes, info.group_count);
+
+		partition_entry->string_heap->Merge(*string_heap);
+		partition_entry->Verify();
+		total_count += partition_entry->Size();
+	}
+	D_ASSERT(total_count == entries);
+}
+
+idx_t GroupedAggregateHashTable::Scan(idx_t &scan_position, DataChunk &result) {
+	Vector addresses(LogicalType::POINTER);
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+
+	auto remaining = entries - scan_position;
+	if (remaining == 0) {
+		return 0;
+	}
+	auto this_n = MinValue((idx_t)STANDARD_VECTOR_SIZE, remaining);
+
+	auto chunk_idx = scan_position / tuples_per_block;
+	auto chunk_offset = (scan_position % tuples_per_block) * tuple_size;
+	D_ASSERT(chunk_offset + tuple_size <= Storage::BLOCK_SIZE);
+
+	auto read_ptr = payload_hds_ptrs[chunk_idx++];
+	for (idx_t i = 0; i < this_n; i++) {
+		data_pointers[i] = read_ptr + chunk_offset;
+		chunk_offset += tuple_size;
+		if (chunk_offset >= tuples_per_block * tuple_size) {
+			read_ptr = payload_hds_ptrs[chunk_idx++];
+			chunk_offset = 0;
+		}
+	}
+
+	result.SetCardinality(this_n);
+	// fetch the group columns (ignoring the final hash column
+	const auto group_cols = layout.ColumnCount() - 1;
+	for (idx_t i = 0; i < group_cols; i++) {
+		auto &column = result.data[i];
+		const auto col_offset = layout.GetOffsets()[i];
+		RowOperations::Gather(addresses, *FlatVector::IncrementalSelectionVector(), column,
+		                      *FlatVector::IncrementalSelectionVector(), result.size(), col_offset, i);
+	}
+
+	RowOperations::FinalizeStates(layout, addresses, result, group_cols);
+
+	scan_position += this_n;
+	return this_n;
+}
+
+void GroupedAggregateHashTable::Finalize() {
+	if (is_finalized) {
+		return;
+	}
+
+	// early release hashes, not needed for partition/scan
+	hashes_hdl.reset();
+	is_finalized = true;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+BaseAggregateHashTable::BaseAggregateHashTable(BufferManager &buffer_manager, vector<LogicalType> payload_types_p)
+    : buffer_manager(buffer_manager), payload_types(move(payload_types_p)) {
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+ColumnBindingResolver::ColumnBindingResolver() {
+}
+
+void ColumnBindingResolver::VisitOperator(LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN || op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		// special case: comparison join
+		auto &comp_join = (LogicalComparisonJoin &)op;
+		// first get the bindings of the LHS and resolve the LHS expressions
+		VisitOperator(*comp_join.children[0]);
+		for (auto &cond : comp_join.conditions) {
+			VisitExpression(&cond.left);
+		}
+		if (op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+			// visit the duplicate eliminated columns on the LHS, if any
+			auto &delim_join = (LogicalDelimJoin &)op;
+			for (auto &expr : delim_join.duplicate_eliminated_columns) {
+				VisitExpression(&expr);
+			}
+		}
+		// then get the bindings of the RHS and resolve the RHS expressions
+		VisitOperator(*comp_join.children[1]);
+		for (auto &cond : comp_join.conditions) {
+			VisitExpression(&cond.right);
+		}
+		// finally update the bindings with the result bindings of the join
+		bindings = op.GetColumnBindings();
+		return;
+	} else if (op.type == LogicalOperatorType::LOGICAL_ANY_JOIN) {
+		// ANY join, this join is different because we evaluate the expression on the bindings of BOTH join sides at
+		// once i.e. we set the bindings first to the bindings of the entire join, and then resolve the expressions of
+		// this operator
+		VisitOperatorChildren(op);
+		bindings = op.GetColumnBindings();
+		VisitOperatorExpressions(op);
+		return;
+	} else if (op.type == LogicalOperatorType::LOGICAL_CREATE_INDEX) {
+		// CREATE INDEX statement, add the columns of the table with table index 0 to the binding set
+		// afterwards bind the expressions of the CREATE INDEX statement
+		auto &create_index = (LogicalCreateIndex &)op;
+		bindings = LogicalOperator::GenerateColumnBindings(0, create_index.table.columns.size());
+		VisitOperatorExpressions(op);
+		return;
+	} else if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		//! We first need to update the current set of bindings and then visit operator expressions
+		bindings = op.GetColumnBindings();
+		VisitOperatorExpressions(op);
+		return;
+	}
+	// general case
+	// first visit the children of this operator
+	VisitOperatorChildren(op);
+	// now visit the expressions of this operator to resolve any bound column references
+	VisitOperatorExpressions(op);
+	// finally update the current set of bindings to the current set of column bindings
+	bindings = op.GetColumnBindings();
+}
+
+unique_ptr<Expression> ColumnBindingResolver::VisitReplace(BoundColumnRefExpression &expr,
+                                                           unique_ptr<Expression> *expr_ptr) {
+	D_ASSERT(expr.depth == 0);
+	// check the current set of column bindings to see which index corresponds to the column reference
+	for (idx_t i = 0; i < bindings.size(); i++) {
+		if (expr.binding == bindings[i]) {
+			return make_unique<BoundReferenceExpression>(expr.alias, expr.return_type, i);
+		}
+	}
+	// LCOV_EXCL_START
+	// could not bind the column reference, this should never happen and indicates a bug in the code
+	// generate an error message
+	string bound_columns = "[";
+	for (idx_t i = 0; i < bindings.size(); i++) {
+		if (i != 0) {
+			bound_columns += " ";
+		}
+		bound_columns += to_string(bindings[i].table_index) + "." + to_string(bindings[i].column_index);
+	}
+	bound_columns += "]";
+
+	throw InternalException("Failed to bind column reference \"%s\" [%d.%d] (bindings: %s)", expr.alias,
+	                        expr.binding.table_index, expr.binding.column_index, bound_columns);
+	// LCOV_EXCL_STOP
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct BothInclusiveBetweenOperator {
+	template <class T>
+	static inline bool Operation(T input, T lower, T upper) {
+		return GreaterThanEquals::Operation<T>(input, lower) && LessThanEquals::Operation<T>(input, upper);
+	}
+};
+
+struct LowerInclusiveBetweenOperator {
+	template <class T>
+	static inline bool Operation(T input, T lower, T upper) {
+		return GreaterThanEquals::Operation<T>(input, lower) && LessThan::Operation<T>(input, upper);
+	}
+};
+
+struct UpperInclusiveBetweenOperator {
+	template <class T>
+	static inline bool Operation(T input, T lower, T upper) {
+		return GreaterThan::Operation<T>(input, lower) && LessThanEquals::Operation<T>(input, upper);
+	}
+};
+
+struct ExclusiveBetweenOperator {
+	template <class T>
+	static inline bool Operation(T input, T lower, T upper) {
+		return GreaterThan::Operation<T>(input, lower) && LessThan::Operation<T>(input, upper);
+	}
+};
+
+template <class OP>
+static idx_t BetweenLoopTypeSwitch(Vector &input, Vector &lower, Vector &upper, const SelectionVector *sel, idx_t count,
+                                   SelectionVector *true_sel, SelectionVector *false_sel) {
+	switch (input.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TernaryExecutor::Select<int8_t, int8_t, int8_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                           false_sel);
+	case PhysicalType::INT16:
+		return TernaryExecutor::Select<int16_t, int16_t, int16_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                              false_sel);
+	case PhysicalType::INT32:
+		return TernaryExecutor::Select<int32_t, int32_t, int32_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                              false_sel);
+	case PhysicalType::INT64:
+		return TernaryExecutor::Select<int64_t, int64_t, int64_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                              false_sel);
+	case PhysicalType::INT128:
+		return TernaryExecutor::Select<hugeint_t, hugeint_t, hugeint_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                                    false_sel);
+	case PhysicalType::UINT8:
+		return TernaryExecutor::Select<uint8_t, uint8_t, uint8_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                              false_sel);
+	case PhysicalType::UINT16:
+		return TernaryExecutor::Select<uint16_t, uint16_t, uint16_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                                 false_sel);
+	case PhysicalType::UINT32:
+		return TernaryExecutor::Select<uint32_t, uint32_t, uint32_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                                 false_sel);
+	case PhysicalType::UINT64:
+		return TernaryExecutor::Select<uint64_t, uint64_t, uint64_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                                 false_sel);
+	case PhysicalType::FLOAT:
+		return TernaryExecutor::Select<float, float, float, OP>(input, lower, upper, sel, count, true_sel, false_sel);
+	case PhysicalType::DOUBLE:
+		return TernaryExecutor::Select<double, double, double, OP>(input, lower, upper, sel, count, true_sel,
+		                                                           false_sel);
+	case PhysicalType::VARCHAR:
+		return TernaryExecutor::Select<string_t, string_t, string_t, OP>(input, lower, upper, sel, count, true_sel,
+		                                                                 false_sel);
+	default:
+		throw InvalidTypeException(input.GetType(), "Invalid type for BETWEEN");
+	}
+}
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundBetweenExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->AddChild(expr.input.get());
+	result->AddChild(expr.lower.get());
+	result->AddChild(expr.upper.get());
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundBetweenExpression &expr, ExpressionState *state, const SelectionVector *sel,
+                                 idx_t count, Vector &result) {
+	// resolve the children
+	state->intermediate_chunk.Reset();
+
+	auto &input = state->intermediate_chunk.data[0];
+	auto &lower = state->intermediate_chunk.data[1];
+	auto &upper = state->intermediate_chunk.data[2];
+
+	Execute(*expr.input, state->child_states[0].get(), sel, count, input);
+	Execute(*expr.lower, state->child_states[1].get(), sel, count, lower);
+	Execute(*expr.upper, state->child_states[2].get(), sel, count, upper);
+
+	Vector intermediate1(LogicalType::BOOLEAN);
+	Vector intermediate2(LogicalType::BOOLEAN);
+
+	if (expr.upper_inclusive && expr.lower_inclusive) {
+		VectorOperations::GreaterThanEquals(input, lower, intermediate1, count);
+		VectorOperations::LessThanEquals(input, upper, intermediate2, count);
+	} else if (expr.lower_inclusive) {
+		VectorOperations::GreaterThanEquals(input, lower, intermediate1, count);
+		VectorOperations::LessThan(input, upper, intermediate2, count);
+	} else if (expr.upper_inclusive) {
+		VectorOperations::GreaterThan(input, lower, intermediate1, count);
+		VectorOperations::LessThanEquals(input, upper, intermediate2, count);
+	} else {
+		VectorOperations::GreaterThan(input, lower, intermediate1, count);
+		VectorOperations::LessThan(input, upper, intermediate2, count);
+	}
+	VectorOperations::And(intermediate1, intermediate2, result, count);
+}
+
+idx_t ExpressionExecutor::Select(const BoundBetweenExpression &expr, ExpressionState *state, const SelectionVector *sel,
+                                 idx_t count, SelectionVector *true_sel, SelectionVector *false_sel) {
+	// resolve the children
+	Vector input(state->intermediate_chunk.data[0]);
+	Vector lower(state->intermediate_chunk.data[1]);
+	Vector upper(state->intermediate_chunk.data[2]);
+
+	Execute(*expr.input, state->child_states[0].get(), sel, count, input);
+	Execute(*expr.lower, state->child_states[1].get(), sel, count, lower);
+	Execute(*expr.upper, state->child_states[2].get(), sel, count, upper);
+
+	if (expr.upper_inclusive && expr.lower_inclusive) {
+		return BetweenLoopTypeSwitch<BothInclusiveBetweenOperator>(input, lower, upper, sel, count, true_sel,
+		                                                           false_sel);
+	} else if (expr.lower_inclusive) {
+		return BetweenLoopTypeSwitch<LowerInclusiveBetweenOperator>(input, lower, upper, sel, count, true_sel,
+		                                                            false_sel);
+	} else if (expr.upper_inclusive) {
+		return BetweenLoopTypeSwitch<UpperInclusiveBetweenOperator>(input, lower, upper, sel, count, true_sel,
+		                                                            false_sel);
+	} else {
+		return BetweenLoopTypeSwitch<ExclusiveBetweenOperator>(input, lower, upper, sel, count, true_sel, false_sel);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+struct CaseExpressionState : public ExpressionState {
+	CaseExpressionState(const Expression &expr, ExpressionExecutorState &root)
+	    : ExpressionState(expr, root), true_sel(STANDARD_VECTOR_SIZE), false_sel(STANDARD_VECTOR_SIZE) {
+	}
+
+	SelectionVector true_sel;
+	SelectionVector false_sel;
+};
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundCaseExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<CaseExpressionState>(expr, root);
+	for (auto &case_check : expr.case_checks) {
+		result->AddChild(case_check.when_expr.get());
+		result->AddChild(case_check.then_expr.get());
+	}
+	result->AddChild(expr.else_expr.get());
+	result->Finalize();
+	return move(result);
+}
+
+void ExpressionExecutor::Execute(const BoundCaseExpression &expr, ExpressionState *state_p, const SelectionVector *sel,
+                                 idx_t count, Vector &result) {
+	auto state = (CaseExpressionState *)state_p;
+
+	state->intermediate_chunk.Reset();
+
+	// first execute the check expression
+	auto current_true_sel = &state->true_sel;
+	auto current_false_sel = &state->false_sel;
+	auto current_sel = sel;
+	idx_t current_count = count;
+	for (idx_t i = 0; i < expr.case_checks.size(); i++) {
+		auto &case_check = expr.case_checks[i];
+		auto &intermediate_result = state->intermediate_chunk.data[i * 2 + 1];
+		auto check_state = state->child_states[i * 2].get();
+		auto then_state = state->child_states[i * 2 + 1].get();
+
+		idx_t tcount =
+		    Select(*case_check.when_expr, check_state, current_sel, current_count, current_true_sel, current_false_sel);
+		if (tcount == 0) {
+			// everything is false: do nothing
+			continue;
+		}
+		idx_t fcount = current_count - tcount;
+		if (fcount == 0 && current_count == count) {
+			// everything is true in the first CHECK statement
+			// we can skip the entire case and only execute the TRUE side
+			Execute(*case_check.then_expr, then_state, sel, count, result);
+			return;
+		} else {
+			// we need to execute and then fill in the desired tuples in the result
+			Execute(*case_check.then_expr, then_state, current_true_sel, tcount, intermediate_result);
+			FillSwitch(intermediate_result, result, *current_true_sel, tcount);
+		}
+		// continue with the false tuples
+		current_sel = current_false_sel;
+		current_count = fcount;
+		if (fcount == 0) {
+			// everything is true: we are done
+			break;
+		}
+	}
+	if (current_count > 0) {
+		auto else_state = state->child_states.back().get();
+		if (current_count == count) {
+			// everything was false, we can just evaluate the else expression directly
+			Execute(*expr.else_expr, else_state, sel, count, result);
+			return;
+		} else {
+			auto &intermediate_result = state->intermediate_chunk.data[expr.case_checks.size() * 2];
+
+			D_ASSERT(current_sel);
+			Execute(*expr.else_expr, else_state, current_sel, current_count, intermediate_result);
+			FillSwitch(intermediate_result, result, *current_sel, current_count);
+		}
+	}
+	if (sel) {
+		result.Slice(*sel, count);
+	}
+}
+
+template <class T>
+void TemplatedFillLoop(Vector &vector, Vector &result, const SelectionVector &sel, sel_t count) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto res = FlatVector::GetData<T>(result);
+	auto &result_mask = FlatVector::Validity(result);
+	if (vector.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		auto data = ConstantVector::GetData<T>(vector);
+		if (ConstantVector::IsNull(vector)) {
+			for (idx_t i = 0; i < count; i++) {
+				result_mask.SetInvalid(sel.get_index(i));
+			}
+		} else {
+			for (idx_t i = 0; i < count; i++) {
+				res[sel.get_index(i)] = *data;
+			}
+		}
+	} else {
+		VectorData vdata;
+		vector.Orrify(count, vdata);
+		auto data = (T *)vdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			auto source_idx = vdata.sel->get_index(i);
+			auto res_idx = sel.get_index(i);
+
+			res[res_idx] = data[source_idx];
+			result_mask.Set(res_idx, vdata.validity.RowIsValid(source_idx));
+		}
+	}
+}
+
+void ValidityFillLoop(Vector &vector, Vector &result, const SelectionVector &sel, sel_t count) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &result_mask = FlatVector::Validity(result);
+	if (vector.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		if (ConstantVector::IsNull(vector)) {
+			for (idx_t i = 0; i < count; i++) {
+				result_mask.SetInvalid(sel.get_index(i));
+			}
+		}
+	} else {
+		VectorData vdata;
+		vector.Orrify(count, vdata);
+		if (vdata.validity.AllValid()) {
+			return;
+		}
+		for (idx_t i = 0; i < count; i++) {
+			auto source_idx = vdata.sel->get_index(i);
+			if (!vdata.validity.RowIsValid(source_idx)) {
+				result_mask.SetInvalid(sel.get_index(i));
+			}
+		}
+	}
+}
+
+void ExpressionExecutor::FillSwitch(Vector &vector, Vector &result, const SelectionVector &sel, sel_t count) {
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedFillLoop<int8_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedFillLoop<int16_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedFillLoop<int32_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedFillLoop<int64_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedFillLoop<uint8_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedFillLoop<uint16_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedFillLoop<uint32_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedFillLoop<uint64_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedFillLoop<hugeint_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedFillLoop<float>(vector, result, sel, count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedFillLoop<double>(vector, result, sel, count);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedFillLoop<interval_t>(vector, result, sel, count);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedFillLoop<string_t>(vector, result, sel, count);
+		StringVector::AddHeapReference(result, vector);
+		break;
+	case PhysicalType::STRUCT: {
+		auto &vector_entries = StructVector::GetEntries(vector);
+		auto &result_entries = StructVector::GetEntries(result);
+		ValidityFillLoop(vector, result, sel, count);
+		D_ASSERT(vector_entries.size() == result_entries.size());
+		for (idx_t i = 0; i < vector_entries.size(); i++) {
+			FillSwitch(*vector_entries[i], *result_entries[i], sel, count);
+		}
+		break;
+	}
+	case PhysicalType::LIST: {
+		idx_t offset = ListVector::GetListSize(result);
+		auto &list_child = ListVector::GetEntry(vector);
+		ListVector::Append(result, list_child, ListVector::GetListSize(vector));
+
+		// all the false offsets need to be incremented by true_child.count
+		TemplatedFillLoop<list_entry_t>(vector, result, sel, count);
+		if (offset == 0) {
+			break;
+		}
+
+		auto result_data = FlatVector::GetData<list_entry_t>(result);
+		for (idx_t i = 0; i < count; i++) {
+			auto result_idx = sel.get_index(i);
+			result_data[result_idx].offset += offset;
+		}
+
+		Vector::Verify(result, sel, count);
+		break;
+	}
+	default:
+		throw NotImplementedException("Unimplemented type for case expression: %s", result.GetType().ToString());
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundCastExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->AddChild(expr.child.get());
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundCastExpression &expr, ExpressionState *state, const SelectionVector *sel,
+                                 idx_t count, Vector &result) {
+	// resolve the child
+	state->intermediate_chunk.Reset();
+
+	auto &child = state->intermediate_chunk.data[0];
+	auto child_state = state->child_states[0].get();
+
+	Execute(*expr.child, child_state, sel, count, child);
+	if (expr.try_cast) {
+		string error_message;
+		VectorOperations::TryCast(child, result, count, &error_message);
+	} else {
+		// cast it to the type specified by the cast expression
+		D_ASSERT(result.GetType() == expr.return_type);
+		VectorOperations::Cast(child, result, count);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundComparisonExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->AddChild(expr.left.get());
+	result->AddChild(expr.right.get());
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundComparisonExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	// resolve the children
+	state->intermediate_chunk.Reset();
+	auto &left = state->intermediate_chunk.data[0];
+	auto &right = state->intermediate_chunk.data[1];
+
+	Execute(*expr.left, state->child_states[0].get(), sel, count, left);
+	Execute(*expr.right, state->child_states[1].get(), sel, count, right);
+
+	switch (expr.type) {
+	case ExpressionType::COMPARE_EQUAL:
+		VectorOperations::Equals(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_NOTEQUAL:
+		VectorOperations::NotEquals(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_LESSTHAN:
+		VectorOperations::LessThan(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+		VectorOperations::GreaterThan(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		VectorOperations::LessThanEquals(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		VectorOperations::GreaterThanEquals(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		VectorOperations::DistinctFrom(left, right, result, count);
+		break;
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		VectorOperations::NotDistinctFrom(left, right, result, count);
+		break;
+	default:
+		throw InternalException("Unknown comparison type!");
+	}
+}
+
+template <typename OP>
+static idx_t NestedSelectOperation(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                   SelectionVector *true_sel, SelectionVector *false_sel);
+
+template <class OP>
+static idx_t TemplatedSelectOperation(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                      SelectionVector *true_sel, SelectionVector *false_sel) {
+	// the inplace loops take the result as the last parameter
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return BinaryExecutor::Select<int8_t, int8_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT16:
+		return BinaryExecutor::Select<int16_t, int16_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT32:
+		return BinaryExecutor::Select<int32_t, int32_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT64:
+		return BinaryExecutor::Select<int64_t, int64_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT8:
+		return BinaryExecutor::Select<uint8_t, uint8_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT16:
+		return BinaryExecutor::Select<uint16_t, uint16_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT32:
+		return BinaryExecutor::Select<uint32_t, uint32_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::UINT64:
+		return BinaryExecutor::Select<uint64_t, uint64_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INT128:
+		return BinaryExecutor::Select<hugeint_t, hugeint_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::FLOAT:
+		return BinaryExecutor::Select<float, float, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::DOUBLE:
+		return BinaryExecutor::Select<double, double, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::INTERVAL:
+		return BinaryExecutor::Select<interval_t, interval_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::VARCHAR:
+		return BinaryExecutor::Select<string_t, string_t, OP>(left, right, sel, count, true_sel, false_sel);
+	case PhysicalType::LIST:
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		return NestedSelectOperation<OP>(left, right, sel, count, true_sel, false_sel);
+	default:
+		throw InternalException("Invalid type for comparison");
+	}
+}
+
+struct NestedSelector {
+	// Select the matching rows for the values of a nested type that are not both NULL.
+	// Those semantics are the same as the corresponding non-distinct comparator
+	template <typename OP>
+	static idx_t Select(Vector &left, Vector &right, const SelectionVector &sel, idx_t count, SelectionVector *true_sel,
+	                    SelectionVector *false_sel) {
+		throw InvalidTypeException(left.GetType(), "Invalid operation for nested SELECT");
+	}
+};
+
+template <>
+idx_t NestedSelector::Select<duckdb::Equals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                             SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::NestedEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t NestedSelector::Select<duckdb::NotEquals>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                                SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::NestedNotEquals(left, right, sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t NestedSelector::Select<duckdb::LessThan>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                               SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t NestedSelector::Select<duckdb::LessThanEquals>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                     idx_t count, SelectionVector *true_sel,
+                                                     SelectionVector *false_sel) {
+	return VectorOperations::DistinctLessThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t NestedSelector::Select<duckdb::GreaterThan>(Vector &left, Vector &right, const SelectionVector &sel, idx_t count,
+                                                  SelectionVector *true_sel, SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThan(left, right, &sel, count, true_sel, false_sel);
+}
+
+template <>
+idx_t NestedSelector::Select<duckdb::GreaterThanEquals>(Vector &left, Vector &right, const SelectionVector &sel,
+                                                        idx_t count, SelectionVector *true_sel,
+                                                        SelectionVector *false_sel) {
+	return VectorOperations::DistinctGreaterThanEquals(left, right, &sel, count, true_sel, false_sel);
+}
+
+static inline idx_t SelectNotNull(Vector &left, Vector &right, const idx_t count, const SelectionVector &sel,
+                                  SelectionVector &maybe_vec, OptionalSelection &false_opt) {
+
+	VectorData lvdata, rvdata;
+	left.Orrify(count, lvdata);
+	right.Orrify(count, rvdata);
+
+	auto &lmask = lvdata.validity;
+	auto &rmask = rvdata.validity;
+
+	// For top-level comparisons, NULL semantics are in effect,
+	// so filter out any NULLs
+	idx_t remaining = 0;
+	if (lmask.AllValid() && rmask.AllValid()) {
+		//	None are NULL, distinguish values.
+		for (idx_t i = 0; i < count; ++i) {
+			const auto idx = sel.get_index(i);
+			maybe_vec.set_index(remaining++, idx);
+		}
+		return remaining;
+	}
+
+	// Slice the Vectors down to the rows that are not determined (i.e., neither is NULL)
+	SelectionVector slicer(count);
+	idx_t false_count = 0;
+	for (idx_t i = 0; i < count; ++i) {
+		const auto result_idx = sel.get_index(i);
+		const auto lidx = lvdata.sel->get_index(i);
+		const auto ridx = rvdata.sel->get_index(i);
+		if (!lmask.RowIsValid(lidx) || !rmask.RowIsValid(ridx)) {
+			false_opt.Append(false_count, result_idx);
+		} else {
+			//	Neither is NULL, distinguish values.
+			slicer.set_index(remaining, i);
+			maybe_vec.set_index(remaining++, result_idx);
+		}
+	}
+	false_opt.Advance(false_count);
+
+	if (remaining && remaining < count) {
+		left.Slice(slicer, remaining);
+		right.Slice(slicer, remaining);
+	}
+
+	return remaining;
+}
+
+static void ScatterSelection(SelectionVector *target, const idx_t count, const SelectionVector &dense_vec) {
+	if (target) {
+		for (idx_t i = 0; i < count; ++i) {
+			target->set_index(i, dense_vec.get_index(i));
+		}
+	}
+}
+
+template <typename OP>
+static idx_t NestedSelectOperation(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                   SelectionVector *true_sel, SelectionVector *false_sel) {
+	// The Select operations all use a dense pair of input vectors to partition
+	// a selection vector in a single pass. But to implement progressive comparisons,
+	// we have to make multiple passes, so we need to keep track of the original input positions
+	// and then scatter the output selections when we are done.
+	if (!sel) {
+		sel = FlatVector::IncrementalSelectionVector();
+	}
+
+	// Make buffered selections for progressive comparisons
+	// TODO: Remove unnecessary allocations
+	SelectionVector true_vec(count);
+	OptionalSelection true_opt(&true_vec);
+
+	SelectionVector false_vec(count);
+	OptionalSelection false_opt(&false_vec);
+
+	SelectionVector maybe_vec(count);
+
+	// Handle NULL nested values
+	Vector l_not_null(left);
+	Vector r_not_null(right);
+
+	auto match_count = SelectNotNull(l_not_null, r_not_null, count, *sel, maybe_vec, false_opt);
+	auto no_match_count = count - match_count;
+	count = match_count;
+
+	//	Now that we have handled the NULLs, we can use the recursive nested comparator for the rest.
+	match_count = NestedSelector::Select<OP>(l_not_null, r_not_null, maybe_vec, count, true_opt, false_opt);
+	no_match_count += (count - match_count);
+
+	// Copy the buffered selections to the output selections
+	ScatterSelection(true_sel, match_count, true_vec);
+	ScatterSelection(false_sel, no_match_count, false_vec);
+
+	return match_count;
+}
+
+idx_t VectorOperations::Equals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                               SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::Equals>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t VectorOperations::NotEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                  SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::NotEquals>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t VectorOperations::GreaterThan(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                    SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::GreaterThan>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t VectorOperations::GreaterThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                          SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::GreaterThanEquals>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t VectorOperations::LessThan(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                 SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::LessThan>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t VectorOperations::LessThanEquals(Vector &left, Vector &right, const SelectionVector *sel, idx_t count,
+                                       SelectionVector *true_sel, SelectionVector *false_sel) {
+	return TemplatedSelectOperation<duckdb::LessThanEquals>(left, right, sel, count, true_sel, false_sel);
+}
+
+idx_t ExpressionExecutor::Select(const BoundComparisonExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, SelectionVector *true_sel,
+                                 SelectionVector *false_sel) {
+	// resolve the children
+	state->intermediate_chunk.Reset();
+	auto &left = state->intermediate_chunk.data[0];
+	auto &right = state->intermediate_chunk.data[1];
+
+	Execute(*expr.left, state->child_states[0].get(), sel, count, left);
+	Execute(*expr.right, state->child_states[1].get(), sel, count, right);
+
+	switch (expr.type) {
+	case ExpressionType::COMPARE_EQUAL:
+		return VectorOperations::Equals(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return VectorOperations::NotEquals(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_LESSTHAN:
+		return VectorOperations::LessThan(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return VectorOperations::GreaterThan(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return VectorOperations::LessThanEquals(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return VectorOperations::GreaterThanEquals(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return VectorOperations::DistinctFrom(left, right, sel, count, true_sel, false_sel);
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		return VectorOperations::NotDistinctFrom(left, right, sel, count, true_sel, false_sel);
+	default:
+		throw InternalException("Unknown comparison type!");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <random>
+
+namespace duckdb {
+
+struct ConjunctionState : public ExpressionState {
+	ConjunctionState(const Expression &expr, ExpressionExecutorState &root) : ExpressionState(expr, root) {
+		adaptive_filter = make_unique<AdaptiveFilter>(expr);
+	}
+	unique_ptr<AdaptiveFilter> adaptive_filter;
+};
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundConjunctionExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ConjunctionState>(expr, root);
+	for (auto &child : expr.children) {
+		result->AddChild(child.get());
+	}
+	result->Finalize();
+	return move(result);
+}
+
+void ExpressionExecutor::Execute(const BoundConjunctionExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	// execute the children
+	state->intermediate_chunk.Reset();
+	for (idx_t i = 0; i < expr.children.size(); i++) {
+		auto &current_result = state->intermediate_chunk.data[i];
+		Execute(*expr.children[i], state->child_states[i].get(), sel, count, current_result);
+		if (i == 0) {
+			// move the result
+			result.Reference(current_result);
+		} else {
+			Vector intermediate(LogicalType::BOOLEAN);
+			// AND/OR together
+			switch (expr.type) {
+			case ExpressionType::CONJUNCTION_AND:
+				VectorOperations::And(current_result, result, intermediate, count);
+				break;
+			case ExpressionType::CONJUNCTION_OR:
+				VectorOperations::Or(current_result, result, intermediate, count);
+				break;
+			default:
+				throw InternalException("Unknown conjunction type!");
+			}
+			result.Reference(intermediate);
+		}
+	}
+}
+
+idx_t ExpressionExecutor::Select(const BoundConjunctionExpression &expr, ExpressionState *state_p,
+                                 const SelectionVector *sel, idx_t count, SelectionVector *true_sel,
+                                 SelectionVector *false_sel) {
+	auto state = (ConjunctionState *)state_p;
+
+	if (expr.type == ExpressionType::CONJUNCTION_AND) {
+		// get runtime statistics
+		auto start_time = high_resolution_clock::now();
+
+		const SelectionVector *current_sel = sel;
+		idx_t current_count = count;
+		idx_t false_count = 0;
+
+		unique_ptr<SelectionVector> temp_true, temp_false;
+		if (false_sel) {
+			temp_false = make_unique<SelectionVector>(STANDARD_VECTOR_SIZE);
+		}
+		if (!true_sel) {
+			temp_true = make_unique<SelectionVector>(STANDARD_VECTOR_SIZE);
+			true_sel = temp_true.get();
+		}
+		for (idx_t i = 0; i < expr.children.size(); i++) {
+			idx_t tcount = Select(*expr.children[state->adaptive_filter->permutation[i]],
+			                      state->child_states[state->adaptive_filter->permutation[i]].get(), current_sel,
+			                      current_count, true_sel, temp_false.get());
+			idx_t fcount = current_count - tcount;
+			if (fcount > 0 && false_sel) {
+				// move failing tuples into the false_sel
+				// tuples passed, move them into the actual result vector
+				for (idx_t i = 0; i < fcount; i++) {
+					false_sel->set_index(false_count++, temp_false->get_index(i));
+				}
+			}
+			current_count = tcount;
+			if (current_count == 0) {
+				break;
+			}
+			if (current_count < count) {
+				// tuples were filtered out: move on to using the true_sel to only evaluate passing tuples in subsequent
+				// iterations
+				current_sel = true_sel;
+			}
+		}
+
+		// adapt runtime statistics
+		auto end_time = high_resolution_clock::now();
+		state->adaptive_filter->AdaptRuntimeStatistics(duration_cast<duration<double>>(end_time - start_time).count());
+		return current_count;
+	} else {
+		// get runtime statistics
+		auto start_time = high_resolution_clock::now();
+
+		const SelectionVector *current_sel = sel;
+		idx_t current_count = count;
+		idx_t result_count = 0;
+
+		unique_ptr<SelectionVector> temp_true, temp_false;
+		if (true_sel) {
+			temp_true = make_unique<SelectionVector>(STANDARD_VECTOR_SIZE);
+		}
+		if (!false_sel) {
+			temp_false = make_unique<SelectionVector>(STANDARD_VECTOR_SIZE);
+			false_sel = temp_false.get();
+		}
+		for (idx_t i = 0; i < expr.children.size(); i++) {
+			idx_t tcount = Select(*expr.children[state->adaptive_filter->permutation[i]],
+			                      state->child_states[state->adaptive_filter->permutation[i]].get(), current_sel,
+			                      current_count, temp_true.get(), false_sel);
+			if (tcount > 0) {
+				if (true_sel) {
+					// tuples passed, move them into the actual result vector
+					for (idx_t i = 0; i < tcount; i++) {
+						true_sel->set_index(result_count++, temp_true->get_index(i));
+					}
+				}
+				// now move on to check only the non-passing tuples
+				current_count -= tcount;
+				current_sel = false_sel;
+			}
+		}
+
+		// adapt runtime statistics
+		auto end_time = high_resolution_clock::now();
+		state->adaptive_filter->AdaptRuntimeStatistics(duration_cast<duration<double>>(end_time - start_time).count());
+		return result_count;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundConstantExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundConstantExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	D_ASSERT(expr.value.type() == expr.return_type);
+	result.Reference(expr.value);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+ExecuteFunctionState::ExecuteFunctionState(const Expression &expr, ExpressionExecutorState &root)
+    : ExpressionState(expr, root) {
+}
+
+ExecuteFunctionState::~ExecuteFunctionState() {
+}
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundFunctionExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExecuteFunctionState>(expr, root);
+	for (auto &child : expr.children) {
+		result->AddChild(child.get());
+	}
+	result->Finalize();
+	if (expr.function.init_local_state) {
+		result->local_state = expr.function.init_local_state(expr, expr.bind_info.get());
+	}
+	return move(result);
+}
+
+void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	state->intermediate_chunk.Reset();
+	auto &arguments = state->intermediate_chunk;
+	if (!state->types.empty()) {
+		for (idx_t i = 0; i < expr.children.size(); i++) {
+			D_ASSERT(state->types[i] == expr.children[i]->return_type);
+			Execute(*expr.children[i], state->child_states[i].get(), sel, count, arguments.data[i]);
+#ifdef DEBUG
+			if (expr.children[i]->return_type.id() == LogicalTypeId::VARCHAR) {
+				arguments.data[i].UTFVerify(count);
+			}
+#endif
+		}
+		arguments.Verify();
+	}
+	arguments.SetCardinality(count);
+	state->profiler.BeginSample();
+	expr.function.function(arguments, *state, result);
+	state->profiler.EndSample(count);
+	D_ASSERT(result.GetType() == expr.return_type);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundOperatorExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	for (auto &child : expr.children) {
+		result->AddChild(child.get());
+	}
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundOperatorExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	// special handling for special snowflake 'IN'
+	// IN has n children
+	if (expr.type == ExpressionType::COMPARE_IN || expr.type == ExpressionType::COMPARE_NOT_IN) {
+		if (expr.children.size() < 2) {
+			throw Exception("IN needs at least two children");
+		}
+
+		Vector left(expr.children[0]->return_type);
+		// eval left side
+		Execute(*expr.children[0], state->child_states[0].get(), sel, count, left);
+
+		// init result to false
+		Vector intermediate(LogicalType::BOOLEAN);
+		Value false_val = Value::BOOLEAN(false);
+		intermediate.Reference(false_val);
+
+		// in rhs is a list of constants
+		// for every child, OR the result of the comparision with the left
+		// to get the overall result.
+		for (idx_t child = 1; child < expr.children.size(); child++) {
+			Vector vector_to_check(expr.children[child]->return_type);
+			Vector comp_res(LogicalType::BOOLEAN);
+
+			Execute(*expr.children[child], state->child_states[child].get(), sel, count, vector_to_check);
+			VectorOperations::Equals(left, vector_to_check, comp_res, count);
+
+			if (child == 1) {
+				// first child: move to result
+				intermediate.Reference(comp_res);
+			} else {
+				// otherwise OR together
+				Vector new_result(LogicalType::BOOLEAN, true, false);
+				VectorOperations::Or(intermediate, comp_res, new_result, count);
+				intermediate.Reference(new_result);
+			}
+		}
+		if (expr.type == ExpressionType::COMPARE_NOT_IN) {
+			// NOT IN: invert result
+			VectorOperations::Not(intermediate, result, count);
+		} else {
+			// directly use the result
+			result.Reference(intermediate);
+		}
+	} else if (expr.type == ExpressionType::OPERATOR_COALESCE) {
+		SelectionVector sel_a(count);
+		SelectionVector sel_b(count);
+		SelectionVector slice_sel(count);
+		SelectionVector result_sel(count);
+		SelectionVector *next_sel = &sel_a;
+		const SelectionVector *current_sel = sel;
+		idx_t remaining_count = count;
+		idx_t next_count;
+		for (idx_t child = 0; child < expr.children.size(); child++) {
+			Vector vector_to_check(expr.children[child]->return_type);
+			Execute(*expr.children[child], state->child_states[child].get(), current_sel, remaining_count,
+			        vector_to_check);
+
+			VectorData vdata;
+			vector_to_check.Orrify(remaining_count, vdata);
+
+			idx_t result_count = 0;
+			next_count = 0;
+			for (idx_t i = 0; i < remaining_count; i++) {
+				auto base_idx = current_sel ? current_sel->get_index(i) : i;
+				auto idx = vdata.sel->get_index(i);
+				if (vdata.validity.RowIsValid(idx)) {
+					slice_sel.set_index(result_count, i);
+					result_sel.set_index(result_count++, base_idx);
+				} else {
+					next_sel->set_index(next_count++, base_idx);
+				}
+			}
+			if (result_count > 0) {
+				vector_to_check.Slice(slice_sel, result_count);
+				FillSwitch(vector_to_check, result, result_sel, result_count);
+			}
+			current_sel = next_sel;
+			next_sel = next_sel == &sel_a ? &sel_b : &sel_a;
+			remaining_count = next_count;
+			if (next_count == 0) {
+				break;
+			}
+		}
+		if (remaining_count > 0) {
+			for (idx_t i = 0; i < remaining_count; i++) {
+				FlatVector::SetNull(result, current_sel->get_index(i), true);
+			}
+		}
+		if (sel) {
+			result.Slice(*sel, count);
+		} else if (count == 1) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		}
+	} else if (expr.children.size() == 1) {
+		state->intermediate_chunk.Reset();
+		auto &child = state->intermediate_chunk.data[0];
+
+		Execute(*expr.children[0], state->child_states[0].get(), sel, count, child);
+		switch (expr.type) {
+		case ExpressionType::OPERATOR_NOT: {
+			VectorOperations::Not(child, result, count);
+			break;
+		}
+		case ExpressionType::OPERATOR_IS_NULL: {
+			VectorOperations::IsNull(child, result, count);
+			break;
+		}
+		case ExpressionType::OPERATOR_IS_NOT_NULL: {
+			VectorOperations::IsNotNull(child, result, count);
+			break;
+		}
+		default:
+			throw NotImplementedException("Unsupported operator type with 1 child!");
+		}
+	} else {
+		throw NotImplementedException("operator");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundParameterExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundParameterExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	D_ASSERT(expr.value);
+	D_ASSERT(expr.value->type() == expr.return_type);
+	result.Reference(*expr.value);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundReferenceExpression &expr,
+                                                                ExpressionExecutorState &root) {
+	auto result = make_unique<ExpressionState>(expr, root);
+	result->Finalize();
+	return result;
+}
+
+void ExpressionExecutor::Execute(const BoundReferenceExpression &expr, ExpressionState *state,
+                                 const SelectionVector *sel, idx_t count, Vector &result) {
+	D_ASSERT(expr.index != DConstants::INVALID_INDEX);
+	D_ASSERT(expr.index < chunk->ColumnCount());
+	if (sel) {
+		result.Slice(chunk->data[expr.index], *sel, count);
+	} else {
+		result.Reference(chunk->data[expr.index]);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+ExpressionExecutor::ExpressionExecutor() {
+}
+
+ExpressionExecutor::ExpressionExecutor(const Expression *expression) : ExpressionExecutor() {
+	D_ASSERT(expression);
+	AddExpression(*expression);
+}
+
+ExpressionExecutor::ExpressionExecutor(const Expression &expression) : ExpressionExecutor() {
+	AddExpression(expression);
+}
+
+ExpressionExecutor::ExpressionExecutor(const vector<unique_ptr<Expression>> &exprs) : ExpressionExecutor() {
+	D_ASSERT(exprs.size() > 0);
+	for (auto &expr : exprs) {
+		AddExpression(*expr);
+	}
+}
+
+void ExpressionExecutor::AddExpression(const Expression &expr) {
+	expressions.push_back(&expr);
+	auto state = make_unique<ExpressionExecutorState>(expr.ToString());
+	Initialize(expr, *state);
+	states.push_back(move(state));
+}
+
+void ExpressionExecutor::Initialize(const Expression &expression, ExpressionExecutorState &state) {
+	state.root_state = InitializeState(expression, state);
+	state.executor = this;
+}
+
+void ExpressionExecutor::Execute(DataChunk *input, DataChunk &result) {
+	SetChunk(input);
+	D_ASSERT(expressions.size() == result.ColumnCount());
+	D_ASSERT(!expressions.empty());
+
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		ExecuteExpression(i, result.data[i]);
+	}
+	result.SetCardinality(input ? input->size() : 1);
+	result.Verify();
+}
+
+void ExpressionExecutor::ExecuteExpression(DataChunk &input, Vector &result) {
+	SetChunk(&input);
+	ExecuteExpression(result);
+}
+
+idx_t ExpressionExecutor::SelectExpression(DataChunk &input, SelectionVector &sel) {
+	D_ASSERT(expressions.size() == 1);
+	SetChunk(&input);
+	states[0]->profiler.BeginSample();
+	idx_t selected_tuples = Select(*expressions[0], states[0]->root_state.get(), nullptr, input.size(), &sel, nullptr);
+	states[0]->profiler.EndSample(chunk ? chunk->size() : 0);
+	return selected_tuples;
+}
+
+void ExpressionExecutor::ExecuteExpression(Vector &result) {
+	D_ASSERT(expressions.size() == 1);
+	ExecuteExpression(0, result);
+}
+
+void ExpressionExecutor::ExecuteExpression(idx_t expr_idx, Vector &result) {
+	D_ASSERT(expr_idx < expressions.size());
+	D_ASSERT(result.GetType().id() == expressions[expr_idx]->return_type.id());
+	states[expr_idx]->profiler.BeginSample();
+	Execute(*expressions[expr_idx], states[expr_idx]->root_state.get(), nullptr, chunk ? chunk->size() : 1, result);
+	states[expr_idx]->profiler.EndSample(chunk ? chunk->size() : 0);
+}
+
+Value ExpressionExecutor::EvaluateScalar(const Expression &expr) {
+	D_ASSERT(expr.IsFoldable());
+	D_ASSERT(expr.IsScalar());
+	// use an ExpressionExecutor to execute the expression
+	ExpressionExecutor executor(expr);
+
+	Vector result(expr.return_type);
+	executor.ExecuteExpression(result);
+
+	D_ASSERT(result.GetVectorType() == VectorType::CONSTANT_VECTOR);
+	auto result_value = result.GetValue(0);
+	D_ASSERT(result_value.type().InternalType() == expr.return_type.InternalType());
+	return result_value;
+}
+
+bool ExpressionExecutor::TryEvaluateScalar(const Expression &expr, Value &result) {
+	try {
+		result = EvaluateScalar(expr);
+		return true;
+	} catch (...) {
+		return false;
+	}
+}
+
+void ExpressionExecutor::Verify(const Expression &expr, Vector &vector, idx_t count) {
+	D_ASSERT(expr.return_type.id() == vector.GetType().id());
+	vector.Verify(count);
+	if (expr.verification_stats) {
+		expr.verification_stats->Verify(vector, count);
+	}
+}
+
+unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const Expression &expr,
+                                                                ExpressionExecutorState &state) {
+	switch (expr.expression_class) {
+	case ExpressionClass::BOUND_REF:
+		return InitializeState((const BoundReferenceExpression &)expr, state);
+	case ExpressionClass::BOUND_BETWEEN:
+		return InitializeState((const BoundBetweenExpression &)expr, state);
+	case ExpressionClass::BOUND_CASE:
+		return InitializeState((const BoundCaseExpression &)expr, state);
+	case ExpressionClass::BOUND_CAST:
+		return InitializeState((const BoundCastExpression &)expr, state);
+	case ExpressionClass::BOUND_COMPARISON:
+		return InitializeState((const BoundComparisonExpression &)expr, state);
+	case ExpressionClass::BOUND_CONJUNCTION:
+		return InitializeState((const BoundConjunctionExpression &)expr, state);
+	case ExpressionClass::BOUND_CONSTANT:
+		return InitializeState((const BoundConstantExpression &)expr, state);
+	case ExpressionClass::BOUND_FUNCTION:
+		return InitializeState((const BoundFunctionExpression &)expr, state);
+	case ExpressionClass::BOUND_OPERATOR:
+		return InitializeState((const BoundOperatorExpression &)expr, state);
+	case ExpressionClass::BOUND_PARAMETER:
+		return InitializeState((const BoundParameterExpression &)expr, state);
+	default:
+		throw InternalException("Attempting to initialize state of expression of unknown type!");
+	}
+}
+
+void ExpressionExecutor::Execute(const Expression &expr, ExpressionState *state, const SelectionVector *sel,
+                                 idx_t count, Vector &result) {
+#ifdef DEBUG
+	if (result.GetVectorType() == VectorType::FLAT_VECTOR) {
+		D_ASSERT(FlatVector::Validity(result).CheckAllValid(count));
+	}
+#endif
+
+	if (count == 0) {
+		return;
+	}
+	switch (expr.expression_class) {
+	case ExpressionClass::BOUND_BETWEEN:
+		Execute((const BoundBetweenExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_REF:
+		Execute((const BoundReferenceExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_CASE:
+		Execute((const BoundCaseExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_CAST:
+		Execute((const BoundCastExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_COMPARISON:
+		Execute((const BoundComparisonExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_CONJUNCTION:
+		Execute((const BoundConjunctionExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_CONSTANT:
+		Execute((const BoundConstantExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_FUNCTION:
+		Execute((const BoundFunctionExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_OPERATOR:
+		Execute((const BoundOperatorExpression &)expr, state, sel, count, result);
+		break;
+	case ExpressionClass::BOUND_PARAMETER:
+		Execute((const BoundParameterExpression &)expr, state, sel, count, result);
+		break;
+	default:
+		throw InternalException("Attempting to execute expression of unknown type!");
+	}
+	Verify(expr, result, count);
+}
+
+idx_t ExpressionExecutor::Select(const Expression &expr, ExpressionState *state, const SelectionVector *sel,
+                                 idx_t count, SelectionVector *true_sel, SelectionVector *false_sel) {
+	if (count == 0) {
+		return 0;
+	}
+	D_ASSERT(true_sel || false_sel);
+	D_ASSERT(expr.return_type.id() == LogicalTypeId::BOOLEAN);
+	switch (expr.expression_class) {
+	case ExpressionClass::BOUND_BETWEEN:
+		return Select((BoundBetweenExpression &)expr, state, sel, count, true_sel, false_sel);
+	case ExpressionClass::BOUND_COMPARISON:
+		return Select((BoundComparisonExpression &)expr, state, sel, count, true_sel, false_sel);
+	case ExpressionClass::BOUND_CONJUNCTION:
+		return Select((BoundConjunctionExpression &)expr, state, sel, count, true_sel, false_sel);
+	default:
+		return DefaultSelect(expr, state, sel, count, true_sel, false_sel);
+	}
+}
+
+template <bool NO_NULL, bool HAS_TRUE_SEL, bool HAS_FALSE_SEL>
+static inline idx_t DefaultSelectLoop(const SelectionVector *bsel, uint8_t *__restrict bdata, ValidityMask &mask,
+                                      const SelectionVector *sel, idx_t count, SelectionVector *true_sel,
+                                      SelectionVector *false_sel) {
+	idx_t true_count = 0, false_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto bidx = bsel->get_index(i);
+		auto result_idx = sel->get_index(i);
+		if (bdata[bidx] > 0 && (NO_NULL || mask.RowIsValid(bidx))) {
+			if (HAS_TRUE_SEL) {
+				true_sel->set_index(true_count++, result_idx);
+			}
+		} else {
+			if (HAS_FALSE_SEL) {
+				false_sel->set_index(false_count++, result_idx);
+			}
+		}
+	}
+	if (HAS_TRUE_SEL) {
+		return true_count;
+	} else {
+		return count - false_count;
+	}
+}
+
+template <bool NO_NULL>
+static inline idx_t DefaultSelectSwitch(VectorData &idata, const SelectionVector *sel, idx_t count,
+                                        SelectionVector *true_sel, SelectionVector *false_sel) {
+	if (true_sel && false_sel) {
+		return DefaultSelectLoop<NO_NULL, true, true>(idata.sel, (uint8_t *)idata.data, idata.validity, sel, count,
+		                                              true_sel, false_sel);
+	} else if (true_sel) {
+		return DefaultSelectLoop<NO_NULL, true, false>(idata.sel, (uint8_t *)idata.data, idata.validity, sel, count,
+		                                               true_sel, false_sel);
+	} else {
+		D_ASSERT(false_sel);
+		return DefaultSelectLoop<NO_NULL, false, true>(idata.sel, (uint8_t *)idata.data, idata.validity, sel, count,
+		                                               true_sel, false_sel);
+	}
+}
+
+idx_t ExpressionExecutor::DefaultSelect(const Expression &expr, ExpressionState *state, const SelectionVector *sel,
+                                        idx_t count, SelectionVector *true_sel, SelectionVector *false_sel) {
+	// generic selection of boolean expression:
+	// resolve the true/false expression first
+	// then use that to generate the selection vector
+	bool intermediate_bools[STANDARD_VECTOR_SIZE];
+	Vector intermediate(LogicalType::BOOLEAN, (data_ptr_t)intermediate_bools);
+	Execute(expr, state, sel, count, intermediate);
+
+	VectorData idata;
+	intermediate.Orrify(count, idata);
+
+	if (!sel) {
+		sel = FlatVector::IncrementalSelectionVector();
+	}
+	if (!idata.validity.AllValid()) {
+		return DefaultSelectSwitch<false>(idata, sel, count, true_sel, false_sel);
+	} else {
+		return DefaultSelectSwitch<true>(idata, sel, count, true_sel, false_sel);
+	}
+}
+
+vector<unique_ptr<ExpressionExecutorState>> &ExpressionExecutor::GetStates() {
+	return states;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+void ExpressionState::AddChild(Expression *expr) {
+	types.push_back(expr->return_type);
+	child_states.push_back(ExpressionExecutor::InitializeState(*expr, root));
+}
+
+void ExpressionState::Finalize() {
+	if (!types.empty()) {
+		intermediate_chunk.Initialize(types);
+	}
+}
+ExpressionState::ExpressionState(const Expression &expr, ExpressionExecutorState &root)
+    : expr(expr), root(root), name(expr.ToString()) {
+}
+
+ExpressionExecutorState::ExpressionExecutorState(const string &name) : profiler(), name(name) {
+}
+} // namespace duckdb
+
+
+
+
+
+
+#include <algorithm>
+#include <cstring>
+#include <ctgmath>
+
+namespace duckdb {
+
+ART::ART(const vector<column_t> &column_ids, const vector<unique_ptr<Expression>> &unbound_expressions,
+         IndexConstraintType constraint_type)
+    : Index(IndexType::ART, column_ids, unbound_expressions, constraint_type) {
+	tree = nullptr;
+	expression_result.Initialize(logical_types);
+	is_little_endian = Radix::IsLittleEndian();
+	for (idx_t i = 0; i < types.size(); i++) {
+		switch (types[i]) {
+		case PhysicalType::BOOL:
+		case PhysicalType::INT8:
+		case PhysicalType::INT16:
+		case PhysicalType::INT32:
+		case PhysicalType::INT64:
+		case PhysicalType::INT128:
+		case PhysicalType::UINT8:
+		case PhysicalType::UINT16:
+		case PhysicalType::UINT32:
+		case PhysicalType::UINT64:
+		case PhysicalType::FLOAT:
+		case PhysicalType::DOUBLE:
+		case PhysicalType::VARCHAR:
+			break;
+		default:
+			throw InvalidTypeException(logical_types[i], "Invalid type for index");
+		}
+	}
+}
+
+ART::~ART() {
+}
+
+bool ART::LeafMatches(Node *node, Key &key, unsigned depth) {
+	auto leaf = static_cast<Leaf *>(node);
+	Key &leaf_key = *leaf->value;
+	for (idx_t i = depth; i < leaf_key.len; i++) {
+		if (leaf_key[i] != key[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+unique_ptr<IndexScanState> ART::InitializeScanSinglePredicate(Transaction &transaction, Value value,
+                                                              ExpressionType expression_type) {
+	auto result = make_unique<ARTIndexScanState>();
+	result->values[0] = value;
+	result->expressions[0] = expression_type;
+	return move(result);
+}
+
+unique_ptr<IndexScanState> ART::InitializeScanTwoPredicates(Transaction &transaction, Value low_value,
+                                                            ExpressionType low_expression_type, Value high_value,
+                                                            ExpressionType high_expression_type) {
+	auto result = make_unique<ARTIndexScanState>();
+	result->values[0] = low_value;
+	result->expressions[0] = low_expression_type;
+	result->values[1] = high_value;
+	result->expressions[1] = high_expression_type;
+	return move(result);
+}
+
+//===--------------------------------------------------------------------===//
+// Insert
+//===--------------------------------------------------------------------===//
+template <class T>
+static void TemplatedGenerateKeys(Vector &input, idx_t count, vector<unique_ptr<Key>> &keys, bool is_little_endian) {
+	VectorData idata;
+	input.Orrify(count, idata);
+
+	auto input_data = (T *)idata.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = idata.sel->get_index(i);
+		if (idata.validity.RowIsValid(idx)) {
+			keys.push_back(Key::CreateKey<T>(input_data[idx], is_little_endian));
+		} else {
+			keys.push_back(nullptr);
+		}
+	}
+}
+
+template <class T>
+static void ConcatenateKeys(Vector &input, idx_t count, vector<unique_ptr<Key>> &keys, bool is_little_endian) {
+	VectorData idata;
+	input.Orrify(count, idata);
+
+	auto input_data = (T *)idata.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = idata.sel->get_index(i);
+		if (!idata.validity.RowIsValid(idx) || !keys[i]) {
+			// either this column is NULL, or the previous column is NULL!
+			keys[i] = nullptr;
+		} else {
+			// concatenate the keys
+			auto old_key = move(keys[i]);
+			auto new_key = Key::CreateKey<T>(input_data[idx], is_little_endian);
+			auto key_len = old_key->len + new_key->len;
+			auto compound_data = unique_ptr<data_t[]>(new data_t[key_len]);
+			memcpy(compound_data.get(), old_key->data.get(), old_key->len);
+			memcpy(compound_data.get() + old_key->len, new_key->data.get(), new_key->len);
+			keys[i] = make_unique<Key>(move(compound_data), key_len);
+		}
+	}
+}
+
+void ART::GenerateKeys(DataChunk &input, vector<unique_ptr<Key>> &keys) {
+	keys.reserve(STANDARD_VECTOR_SIZE);
+	// generate keys for the first input column
+	switch (input.data[0].GetType().InternalType()) {
+	case PhysicalType::BOOL:
+		TemplatedGenerateKeys<bool>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::INT8:
+		TemplatedGenerateKeys<int8_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::INT16:
+		TemplatedGenerateKeys<int16_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::INT32:
+		TemplatedGenerateKeys<int32_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::INT64:
+		TemplatedGenerateKeys<int64_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::INT128:
+		TemplatedGenerateKeys<hugeint_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedGenerateKeys<uint8_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedGenerateKeys<uint16_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedGenerateKeys<uint32_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedGenerateKeys<uint64_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedGenerateKeys<float>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedGenerateKeys<double>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedGenerateKeys<string_t>(input.data[0], input.size(), keys, is_little_endian);
+		break;
+	default:
+		throw InternalException("Invalid type for index");
+	}
+
+	for (idx_t i = 1; i < input.ColumnCount(); i++) {
+		// for each of the remaining columns, concatenate
+		switch (input.data[i].GetType().InternalType()) {
+		case PhysicalType::BOOL:
+			ConcatenateKeys<bool>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::INT8:
+			ConcatenateKeys<int8_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::INT16:
+			ConcatenateKeys<int16_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::INT32:
+			ConcatenateKeys<int32_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::INT64:
+			ConcatenateKeys<int64_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::INT128:
+			ConcatenateKeys<hugeint_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::UINT8:
+			ConcatenateKeys<uint8_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::UINT16:
+			ConcatenateKeys<uint16_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::UINT32:
+			ConcatenateKeys<uint32_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::UINT64:
+			ConcatenateKeys<uint64_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::FLOAT:
+			ConcatenateKeys<float>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::DOUBLE:
+			ConcatenateKeys<double>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		case PhysicalType::VARCHAR:
+			ConcatenateKeys<string_t>(input.data[i], input.size(), keys, is_little_endian);
+			break;
+		default:
+			throw InternalException("Invalid type for index");
+		}
+	}
+}
+
+bool ART::Insert(IndexLock &lock, DataChunk &input, Vector &row_ids) {
+	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
+	D_ASSERT(logical_types[0] == input.data[0].GetType());
+
+	// generate the keys for the given input
+	vector<unique_ptr<Key>> keys;
+	GenerateKeys(input, keys);
+
+	// now insert the elements into the index
+	row_ids.Normalify(input.size());
+	auto row_identifiers = FlatVector::GetData<row_t>(row_ids);
+	idx_t failed_index = DConstants::INVALID_INDEX;
+	for (idx_t i = 0; i < input.size(); i++) {
+		if (!keys[i]) {
+			continue;
+		}
+
+		row_t row_id = row_identifiers[i];
+		if (!Insert(tree, move(keys[i]), 0, row_id)) {
+			// failed to insert because of constraint violation
+			failed_index = i;
+			break;
+		}
+	}
+	if (failed_index != DConstants::INVALID_INDEX) {
+		// failed to insert because of constraint violation: remove previously inserted entries
+		// generate keys again
+		keys.clear();
+		GenerateKeys(input, keys);
+		unique_ptr<Key> key;
+
+		// now erase the entries
+		for (idx_t i = 0; i < failed_index; i++) {
+			if (!keys[i]) {
+				continue;
+			}
+			row_t row_id = row_identifiers[i];
+			Erase(tree, *keys[i], 0, row_id);
+		}
+		return false;
+	}
+	return true;
+}
+
+bool ART::Append(IndexLock &lock, DataChunk &appended_data, Vector &row_identifiers) {
+	DataChunk expression_result;
+	expression_result.Initialize(logical_types);
+
+	// first resolve the expressions for the index
+	ExecuteExpressions(appended_data, expression_result);
+
+	// now insert into the index
+	return Insert(lock, expression_result, row_identifiers);
+}
+
+void ART::VerifyAppend(DataChunk &chunk) {
+	VerifyExistence(chunk, VerifyExistenceType::APPEND);
+}
+
+void ART::VerifyAppendForeignKey(DataChunk &chunk, string *err_msg_ptr) {
+	VerifyExistence(chunk, VerifyExistenceType::APPEND_FK, err_msg_ptr);
+}
+
+void ART::VerifyDeleteForeignKey(DataChunk &chunk, string *err_msg_ptr) {
+	VerifyExistence(chunk, VerifyExistenceType::DELETE_FK, err_msg_ptr);
+}
+
+bool ART::InsertToLeaf(Leaf &leaf, row_t row_id) {
+	if (IsUnique() && leaf.num_elements != 0) {
+		return false;
+	}
+	leaf.Insert(row_id);
+	return true;
+}
+
+bool ART::Insert(unique_ptr<Node> &node, unique_ptr<Key> value, unsigned depth, row_t row_id) {
+	Key &key = *value;
+	if (!node) {
+		// node is currently empty, create a leaf here with the key
+		node = make_unique<Leaf>(*this, move(value), row_id);
+		return true;
+	}
+
+	if (node->type == NodeType::NLeaf) {
+		// Replace leaf with Node4 and store both leaves in it
+		auto leaf = static_cast<Leaf *>(node.get());
+
+		Key &existing_key = *leaf->value;
+		uint32_t new_prefix_length = 0;
+		// Leaf node is already there, update row_id vector
+		if (depth + new_prefix_length == existing_key.len && existing_key.len == key.len) {
+			return InsertToLeaf(*leaf, row_id);
+		}
+		while (existing_key[depth + new_prefix_length] == key[depth + new_prefix_length]) {
+			new_prefix_length++;
+			// Leaf node is already there, update row_id vector
+			if (depth + new_prefix_length == existing_key.len && existing_key.len == key.len) {
+				return InsertToLeaf(*leaf, row_id);
+			}
+		}
+
+		unique_ptr<Node> new_node = make_unique<Node4>(*this, new_prefix_length);
+		new_node->prefix_length = new_prefix_length;
+		memcpy(new_node->prefix.get(), &key[depth], new_prefix_length);
+		Node4::Insert(*this, new_node, existing_key[depth + new_prefix_length], node);
+		unique_ptr<Node> leaf_node = make_unique<Leaf>(*this, move(value), row_id);
+		Node4::Insert(*this, new_node, key[depth + new_prefix_length], leaf_node);
+		node = move(new_node);
+		return true;
+	}
+
+	// Handle prefix of inner node
+	if (node->prefix_length) {
+		uint32_t mismatch_pos = Node::PrefixMismatch(*this, node.get(), key, depth);
+		if (mismatch_pos != node->prefix_length) {
+			// Prefix differs, create new node
+			unique_ptr<Node> new_node = make_unique<Node4>(*this, mismatch_pos);
+			new_node->prefix_length = mismatch_pos;
+			memcpy(new_node->prefix.get(), node->prefix.get(), mismatch_pos);
+			// Break up prefix
+			auto node_ptr = node.get();
+			Node4::Insert(*this, new_node, node->prefix[mismatch_pos], node);
+			node_ptr->prefix_length -= (mismatch_pos + 1);
+			memmove(node_ptr->prefix.get(), node_ptr->prefix.get() + mismatch_pos + 1, node_ptr->prefix_length);
+			unique_ptr<Node> leaf_node = make_unique<Leaf>(*this, move(value), row_id);
+			Node4::Insert(*this, new_node, key[depth + mismatch_pos], leaf_node);
+			node = move(new_node);
+			return true;
+		}
+		depth += node->prefix_length;
+	}
+
+	// Recurse
+	idx_t pos = node->GetChildPos(key[depth]);
+	if (pos != DConstants::INVALID_INDEX) {
+		auto child = node->GetChild(pos);
+		return Insert(*child, move(value), depth + 1, row_id);
+	}
+	unique_ptr<Node> new_node = make_unique<Leaf>(*this, move(value), row_id);
+	Node::InsertLeaf(*this, node, key[depth], new_node);
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Delete
+//===--------------------------------------------------------------------===//
+void ART::Delete(IndexLock &state, DataChunk &input, Vector &row_ids) {
+	DataChunk expression_result;
+	expression_result.Initialize(logical_types);
+
+	// first resolve the expressions
+	ExecuteExpressions(input, expression_result);
+
+	// then generate the keys for the given input
+	vector<unique_ptr<Key>> keys;
+	GenerateKeys(expression_result, keys);
+
+	// now erase the elements from the database
+	row_ids.Normalify(input.size());
+	auto row_identifiers = FlatVector::GetData<row_t>(row_ids);
+
+	for (idx_t i = 0; i < input.size(); i++) {
+		if (!keys[i]) {
+			continue;
+		}
+		Erase(tree, *keys[i], 0, row_identifiers[i]);
+#ifdef DEBUG
+		auto node = Lookup(tree, *keys[i], 0);
+		if (node) {
+			auto leaf = static_cast<Leaf *>(node);
+			for (idx_t k = 0; k < leaf->num_elements; k++) {
+				D_ASSERT(leaf->GetRowId(k) != row_identifiers[i]);
+			}
+		}
+#endif
+	}
+}
+
+void ART::Erase(unique_ptr<Node> &node, Key &key, unsigned depth, row_t row_id) {
+	if (!node) {
+		return;
+	}
+	// Delete a leaf from a tree
+	if (node->type == NodeType::NLeaf) {
+		// Make sure we have the right leaf
+		if (ART::LeafMatches(node.get(), key, depth)) {
+			auto leaf = static_cast<Leaf *>(node.get());
+			leaf->Remove(row_id);
+			if (leaf->num_elements == 0) {
+				node.reset();
+			}
+		}
+		return;
+	}
+
+	// Handle prefix
+	if (node->prefix_length) {
+		if (Node::PrefixMismatch(*this, node.get(), key, depth) != node->prefix_length) {
+			return;
+		}
+		depth += node->prefix_length;
+	}
+	idx_t pos = node->GetChildPos(key[depth]);
+	if (pos != DConstants::INVALID_INDEX) {
+		auto child = node->GetChild(pos);
+		D_ASSERT(child);
+
+		unique_ptr<Node> &child_ref = *child;
+		if (child_ref->type == NodeType::NLeaf && LeafMatches(child_ref.get(), key, depth)) {
+			// Leaf found, remove entry
+			auto leaf = static_cast<Leaf *>(child_ref.get());
+			leaf->Remove(row_id);
+			if (leaf->num_elements == 0) {
+				// Leaf is empty, delete leaf, decrement node counter and maybe shrink node
+				Node::Erase(*this, node, pos);
+			}
+		} else {
+			// Recurse
+			Erase(*child, key, depth + 1, row_id);
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Point Query
+//===--------------------------------------------------------------------===//
+static unique_ptr<Key> CreateKey(ART &art, PhysicalType type, Value &value) {
+	D_ASSERT(type == value.type().InternalType());
+	switch (type) {
+	case PhysicalType::BOOL:
+		return Key::CreateKey<bool>(value, art.is_little_endian);
+	case PhysicalType::INT8:
+		return Key::CreateKey<int8_t>(value, art.is_little_endian);
+	case PhysicalType::INT16:
+		return Key::CreateKey<int16_t>(value, art.is_little_endian);
+	case PhysicalType::INT32:
+		return Key::CreateKey<int32_t>(value, art.is_little_endian);
+	case PhysicalType::INT64:
+		return Key::CreateKey<int64_t>(value, art.is_little_endian);
+	case PhysicalType::UINT8:
+		return Key::CreateKey<uint8_t>(value, art.is_little_endian);
+	case PhysicalType::UINT16:
+		return Key::CreateKey<uint16_t>(value, art.is_little_endian);
+	case PhysicalType::UINT32:
+		return Key::CreateKey<uint32_t>(value, art.is_little_endian);
+	case PhysicalType::UINT64:
+		return Key::CreateKey<uint64_t>(value, art.is_little_endian);
+	case PhysicalType::INT128:
+		return Key::CreateKey<hugeint_t>(value, art.is_little_endian);
+	case PhysicalType::FLOAT:
+		return Key::CreateKey<float>(value, art.is_little_endian);
+	case PhysicalType::DOUBLE:
+		return Key::CreateKey<double>(value, art.is_little_endian);
+	case PhysicalType::VARCHAR:
+		return Key::CreateKey<string_t>(value, art.is_little_endian);
+	default:
+		throw InternalException("Invalid type for index");
+	}
+}
+
+bool ART::SearchEqual(ARTIndexScanState *state, idx_t max_count, vector<row_t> &result_ids) {
+	auto key = CreateKey(*this, types[0], state->values[0]);
+	auto leaf = static_cast<Leaf *>(Lookup(tree, *key, 0));
+	if (!leaf) {
+		return true;
+	}
+	if (leaf->num_elements > max_count) {
+		return false;
+	}
+	for (idx_t i = 0; i < leaf->num_elements; i++) {
+		row_t row_id = leaf->GetRowId(i);
+		result_ids.push_back(row_id);
+	}
+	return true;
+}
+
+void ART::SearchEqualJoinNoFetch(Value &equal_value, idx_t &result_size) {
+	//! We need to look for a leaf
+	auto key = CreateKey(*this, types[0], equal_value);
+	auto leaf = static_cast<Leaf *>(Lookup(tree, *key, 0));
+	if (!leaf) {
+		return;
+	}
+	result_size = leaf->num_elements;
+}
+
+Node *ART::Lookup(unique_ptr<Node> &node, Key &key, unsigned depth) {
+	auto node_val = node.get();
+
+	while (node_val) {
+		if (node_val->type == NodeType::NLeaf) {
+			auto leaf = static_cast<Leaf *>(node_val);
+			Key &leaf_key = *leaf->value;
+			//! Check leaf
+			for (idx_t i = depth; i < leaf_key.len; i++) {
+				if (leaf_key[i] != key[i]) {
+					return nullptr;
+				}
+			}
+			return node_val;
+		}
+		if (node_val->prefix_length) {
+			for (idx_t pos = 0; pos < node_val->prefix_length; pos++) {
+				if (key[depth + pos] != node_val->prefix[pos]) {
+					return nullptr;
+				}
+			}
+			depth += node_val->prefix_length;
+		}
+		idx_t pos = node_val->GetChildPos(key[depth]);
+		if (pos == DConstants::INVALID_INDEX) {
+			return nullptr;
+		}
+		node_val = node_val->GetChild(pos)->get();
+		D_ASSERT(node_val);
+
+		depth++;
+	}
+
+	return nullptr;
+}
+
+//===--------------------------------------------------------------------===//
+// Iterator scans
+//===--------------------------------------------------------------------===//
+template <bool HAS_BOUND, bool INCLUSIVE>
+bool ART::IteratorScan(ARTIndexScanState *state, Iterator *it, Key *bound, idx_t max_count, vector<row_t> &result_ids) {
+	bool has_next;
+	do {
+		if (HAS_BOUND) {
+			D_ASSERT(bound);
+			if (INCLUSIVE) {
+				if (*it->node->value > *bound) {
+					break;
+				}
+			} else {
+				if (*it->node->value >= *bound) {
+					break;
+				}
+			}
+		}
+		if (result_ids.size() + it->node->num_elements > max_count) {
+			// adding these elements would exceed the max count
+			return false;
+		}
+		for (idx_t i = 0; i < it->node->num_elements; i++) {
+			row_t row_id = it->node->GetRowId(i);
+			result_ids.push_back(row_id);
+		}
+		has_next = ART::IteratorNext(*it);
+	} while (has_next);
+	return true;
+}
+
+void Iterator::SetEntry(idx_t entry_depth, IteratorEntry entry) {
+	if (stack.size() < entry_depth + 1) {
+		stack.resize(MaxValue<idx_t>(8, MaxValue<idx_t>(entry_depth + 1, stack.size() * 2)));
+	}
+	stack[entry_depth] = entry;
+}
+
+bool ART::IteratorNext(Iterator &it) {
+	// Skip leaf
+	if ((it.depth) && ((it.stack[it.depth - 1].node)->type == NodeType::NLeaf)) {
+		it.depth--;
+	}
+
+	// Look for the next leaf
+	while (it.depth > 0) {
+		auto &top = it.stack[it.depth - 1];
+		Node *node = top.node;
+
+		if (node->type == NodeType::NLeaf) {
+			// found a leaf: move to next node
+			it.node = (Leaf *)node;
+			return true;
+		}
+
+		// Find next node
+		top.pos = node->GetNextPos(top.pos);
+		if (top.pos != DConstants::INVALID_INDEX) {
+			// next node found: go there
+			it.SetEntry(it.depth, IteratorEntry(node->GetChild(top.pos)->get(), DConstants::INVALID_INDEX));
+			it.depth++;
+		} else {
+			// no node found: move up the tree
+			it.depth--;
+		}
+	}
+	return false;
+}
+
+//===--------------------------------------------------------------------===//
+// Greater Than
+// Returns: True (If found leaf >= key)
+//          False (Otherwise)
+//===--------------------------------------------------------------------===//
+bool ART::Bound(unique_ptr<Node> &n, Key &key, Iterator &it, bool inclusive) {
+	it.depth = 0;
+	bool equal = false;
+	if (!n) {
+		return false;
+	}
+	Node *node = n.get();
+
+	idx_t depth = 0;
+	while (true) {
+		it.SetEntry(it.depth, IteratorEntry(node, 0));
+		auto &top = it.stack[it.depth];
+		it.depth++;
+		if (!equal) {
+			while (node->type != NodeType::NLeaf) {
+				node = node->GetChild(node->GetMin())->get();
+				auto &c_top = it.stack[it.depth];
+				c_top.node = node;
+				it.depth++;
+			}
+		}
+		if (node->type == NodeType::NLeaf) {
+			// found a leaf node: check if it is bigger or equal than the current key
+			auto leaf = static_cast<Leaf *>(node);
+			it.node = leaf;
+			// if the search is not inclusive the leaf node could still be equal to the current value
+			// check if leaf is equal to the current key
+			if (*leaf->value == key) {
+				// if its not inclusive check if there is a next leaf
+				if (!inclusive && !IteratorNext(it)) {
+					return false;
+				} else {
+					return true;
+				}
+			}
+
+			if (*leaf->value > key) {
+				return true;
+			}
+			// Leaf is lower than key
+			// Check if next leaf is still lower than key
+			while (IteratorNext(it)) {
+				if (*it.node->value == key) {
+					// if its not inclusive check if there is a next leaf
+					if (!inclusive && !IteratorNext(it)) {
+						return false;
+					} else {
+						return true;
+					}
+				} else if (*it.node->value > key) {
+					// if its not inclusive check if there is a next leaf
+					return true;
+				}
+			}
+			return false;
+		}
+		uint32_t mismatch_pos = Node::PrefixMismatch(*this, node, key, depth);
+		if (mismatch_pos != node->prefix_length) {
+			if (node->prefix[mismatch_pos] < key[depth + mismatch_pos]) {
+				// Less
+				it.depth--;
+				return IteratorNext(it);
+			} else {
+				// Greater
+				top.pos = DConstants::INVALID_INDEX;
+				return IteratorNext(it);
+			}
+		}
+		// prefix matches, search inside the child for the key
+		depth += node->prefix_length;
+
+		top.pos = node->GetChildGreaterEqual(key[depth], equal);
+		if (top.pos == DConstants::INVALID_INDEX) {
+			// Find min leaf
+			top.pos = node->GetMin();
+		}
+		node = node->GetChild(top.pos)->get();
+		//! This means all children of this node qualify as geq
+
+		depth++;
+	}
+}
+
+bool ART::SearchGreater(ARTIndexScanState *state, bool inclusive, idx_t max_count, vector<row_t> &result_ids) {
+	Iterator *it = &state->iterator;
+	auto key = CreateKey(*this, types[0], state->values[0]);
+
+	// greater than scan: first set the iterator to the node at which we will start our scan by finding the lowest node
+	// that satisfies our requirement
+	if (!it->start) {
+		bool found = ART::Bound(tree, *key, *it, inclusive);
+		if (!found) {
+			return true;
+		}
+		it->start = true;
+	}
+	// after that we continue the scan; we don't need to check the bounds as any value following this value is
+	// automatically bigger and hence satisfies our predicate
+	return IteratorScan<false, false>(state, it, nullptr, max_count, result_ids);
+}
+
+//===--------------------------------------------------------------------===//
+// Less Than
+//===--------------------------------------------------------------------===//
+static Leaf &FindMinimum(Iterator &it, Node &node) {
+	Node *next = nullptr;
+	idx_t pos = 0;
+	switch (node.type) {
+	case NodeType::NLeaf:
+		it.node = (Leaf *)&node;
+		return (Leaf &)node;
+	case NodeType::N4:
+		next = ((Node4 &)node).child[0].get();
+		break;
+	case NodeType::N16:
+		next = ((Node16 &)node).child[0].get();
+		break;
+	case NodeType::N48: {
+		auto &n48 = (Node48 &)node;
+		while (n48.child_index[pos] == Node::EMPTY_MARKER) {
+			pos++;
+		}
+		next = n48.child[n48.child_index[pos]].get();
+		break;
+	}
+	case NodeType::N256: {
+		auto &n256 = (Node256 &)node;
+		while (!n256.child[pos]) {
+			pos++;
+		}
+		next = n256.child[pos].get();
+		break;
+	}
+	}
+	it.SetEntry(it.depth, IteratorEntry(&node, pos));
+	it.depth++;
+	return FindMinimum(it, *next);
+}
+
+bool ART::SearchLess(ARTIndexScanState *state, bool inclusive, idx_t max_count, vector<row_t> &result_ids) {
+	if (!tree) {
+		return true;
+	}
+
+	Iterator *it = &state->iterator;
+	auto upper_bound = CreateKey(*this, types[0], state->values[0]);
+
+	if (!it->start) {
+		// first find the minimum value in the ART: we start scanning from this value
+		auto &minimum = FindMinimum(state->iterator, *tree);
+		// early out min value higher than upper bound query
+		if (*minimum.value > *upper_bound) {
+			return true;
+		}
+		it->start = true;
+	}
+	// now continue the scan until we reach the upper bound
+	if (inclusive) {
+		return IteratorScan<true, true>(state, it, upper_bound.get(), max_count, result_ids);
+	} else {
+		return IteratorScan<true, false>(state, it, upper_bound.get(), max_count, result_ids);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Closed Range Query
+//===--------------------------------------------------------------------===//
+bool ART::SearchCloseRange(ARTIndexScanState *state, bool left_inclusive, bool right_inclusive, idx_t max_count,
+                           vector<row_t> &result_ids) {
+	auto lower_bound = CreateKey(*this, types[0], state->values[0]);
+	auto upper_bound = CreateKey(*this, types[0], state->values[1]);
+	Iterator *it = &state->iterator;
+	// first find the first node that satisfies the left predicate
+	if (!it->start) {
+		bool found = ART::Bound(tree, *lower_bound, *it, left_inclusive);
+		if (!found) {
+			return true;
+		}
+		it->start = true;
+	}
+	// now continue the scan until we reach the upper bound
+	if (right_inclusive) {
+		return IteratorScan<true, true>(state, it, upper_bound.get(), max_count, result_ids);
+	} else {
+		return IteratorScan<true, false>(state, it, upper_bound.get(), max_count, result_ids);
+	}
+}
+
+bool ART::Scan(Transaction &transaction, DataTable &table, IndexScanState &table_state, idx_t max_count,
+               vector<row_t> &result_ids) {
+	auto state = (ARTIndexScanState *)&table_state;
+
+	D_ASSERT(state->values[0].type().InternalType() == types[0]);
+
+	vector<row_t> row_ids;
+	bool success = true;
+	if (state->values[1].IsNull()) {
+		lock_guard<mutex> l(lock);
+		// single predicate
+		switch (state->expressions[0]) {
+		case ExpressionType::COMPARE_EQUAL:
+			success = SearchEqual(state, max_count, row_ids);
+			break;
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			success = SearchGreater(state, true, max_count, row_ids);
+			break;
+		case ExpressionType::COMPARE_GREATERTHAN:
+			success = SearchGreater(state, false, max_count, row_ids);
+			break;
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			success = SearchLess(state, true, max_count, row_ids);
+			break;
+		case ExpressionType::COMPARE_LESSTHAN:
+			success = SearchLess(state, false, max_count, row_ids);
+			break;
+		default:
+			throw InternalException("Operation not implemented");
+		}
+	} else {
+		lock_guard<mutex> l(lock);
+		// two predicates
+		D_ASSERT(state->values[1].type().InternalType() == types[0]);
+		bool left_inclusive = state->expressions[0] == ExpressionType ::COMPARE_GREATERTHANOREQUALTO;
+		bool right_inclusive = state->expressions[1] == ExpressionType ::COMPARE_LESSTHANOREQUALTO;
+		success = SearchCloseRange(state, left_inclusive, right_inclusive, max_count, row_ids);
+	}
+	if (!success) {
+		return false;
+	}
+	if (row_ids.empty()) {
+		return true;
+	}
+	// sort the row ids
+	sort(row_ids.begin(), row_ids.end());
+	// duplicate eliminate the row ids and append them to the row ids of the state
+	result_ids.reserve(row_ids.size());
+
+	result_ids.push_back(row_ids[0]);
+	for (idx_t i = 1; i < row_ids.size(); i++) {
+		if (row_ids[i] != row_ids[i - 1]) {
+			result_ids.push_back(row_ids[i]);
+		}
+	}
+	return true;
+}
+
+void ART::VerifyExistence(DataChunk &chunk, VerifyExistenceType verify_type, string *err_msg_ptr) {
+	if (verify_type != VerifyExistenceType::DELETE_FK && !IsUnique()) {
+		return;
+	}
+
+	DataChunk expression_result;
+	expression_result.Initialize(logical_types);
+
+	// unique index, check
+	lock_guard<mutex> l(lock);
+	// first resolve the expressions for the index
+	ExecuteExpressions(chunk, expression_result);
+
+	// generate the keys for the given input
+	vector<unique_ptr<Key>> keys;
+	GenerateKeys(expression_result, keys);
+
+	for (idx_t i = 0; i < chunk.size(); i++) {
+		if (!keys[i]) {
+			continue;
+		}
+		Node *node_ptr = Lookup(tree, *keys[i], 0);
+		bool throw_exception =
+		    verify_type == VerifyExistenceType::APPEND_FK ? node_ptr == nullptr : node_ptr != nullptr;
+		if (!throw_exception) {
+			continue;
+		}
+		string key_name;
+		for (idx_t k = 0; k < expression_result.ColumnCount(); k++) {
+			if (k > 0) {
+				key_name += ", ";
+			}
+			key_name += unbound_expressions[k]->GetName() + ": " + expression_result.data[k].GetValue(i).ToString();
+		}
+		string exception_msg;
+		switch (verify_type) {
+		case VerifyExistenceType::APPEND: {
+			// node already exists in tree
+			string type = IsPrimary() ? "primary key" : "unique";
+			exception_msg = "duplicate key \"" + key_name + "\" violates ";
+			exception_msg += type + " constraint";
+			break;
+		}
+		case VerifyExistenceType::APPEND_FK: {
+			// found node no exists in tree
+			exception_msg =
+			    "violates foreign key constraint because key \"" + key_name + "\" does not exist in referenced table";
+			break;
+		}
+		case VerifyExistenceType::DELETE_FK: {
+			// found node exists in tree
+			exception_msg =
+			    "violates foreign key constraint because key \"" + key_name + "\" exist in table has foreign key";
+			break;
+		}
+		}
+		if (err_msg_ptr) {
+			err_msg_ptr[i] = exception_msg;
+		} else {
+			throw ConstraintException(exception_msg);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+Key::Key(unique_ptr<data_t[]> data, idx_t len) : len(len), data(move(data)) {
+}
+
+template <>
+unique_ptr<Key> Key::CreateKey(string_t value, bool is_little_endian) {
+	idx_t len = value.GetSize() + 1;
+	auto data = unique_ptr<data_t[]>(new data_t[len]);
+	memcpy(data.get(), value.GetDataUnsafe(), len - 1);
+	data[len - 1] = '\0';
+	return make_unique<Key>(move(data), len);
+}
+
+template <>
+unique_ptr<Key> Key::CreateKey(const char *value, bool is_little_endian) {
+	return Key::CreateKey(string_t(value, strlen(value)), is_little_endian);
+}
+
+bool Key::operator>(const Key &k) const {
+	for (idx_t i = 0; i < MinValue<idx_t>(len, k.len); i++) {
+		if (data[i] > k.data[i]) {
+			return true;
+		} else if (data[i] < k.data[i]) {
+			return false;
+		}
+	}
+	return len > k.len;
+}
+
+bool Key::operator<(const Key &k) const {
+	for (idx_t i = 0; i < MinValue<idx_t>(len, k.len); i++) {
+		if (data[i] < k.data[i]) {
+			return true;
+		} else if (data[i] > k.data[i]) {
+			return false;
+		}
+	}
+	return len < k.len;
+}
+
+bool Key::operator>=(const Key &k) const {
+	for (idx_t i = 0; i < MinValue<idx_t>(len, k.len); i++) {
+		if (data[i] > k.data[i]) {
+			return true;
+		} else if (data[i] < k.data[i]) {
+			return false;
+		}
+	}
+	return len >= k.len;
+}
+
+bool Key::operator==(const Key &k) const {
+	if (len != k.len) {
+		return false;
+	}
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] != k.data[i]) {
+			return false;
+		}
+	}
+	return true;
+}
+} // namespace duckdb
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+Leaf::Leaf(ART &art, unique_ptr<Key> value, row_t row_id) : Node(art, NodeType::NLeaf, 0) {
+	this->value = move(value);
+	this->capacity = 1;
+	this->row_ids = unique_ptr<row_t[]>(new row_t[this->capacity]);
+	this->row_ids[0] = row_id;
+	this->num_elements = 1;
+}
+
+void Leaf::Insert(row_t row_id) {
+	// Grow array
+	if (num_elements == capacity) {
+		auto new_row_id = unique_ptr<row_t[]>(new row_t[capacity * 2]);
+		memcpy(new_row_id.get(), row_ids.get(), capacity * sizeof(row_t));
+		capacity *= 2;
+		row_ids = move(new_row_id);
+	}
+	row_ids[num_elements++] = row_id;
+}
+
+void Leaf::Remove(row_t row_id) {
+	idx_t entry_offset = DConstants::INVALID_INDEX;
+	for (idx_t i = 0; i < num_elements; i++) {
+		if (row_ids[i] == row_id) {
+			entry_offset = i;
+			break;
+		}
+	}
+	if (entry_offset == DConstants::INVALID_INDEX) {
+		return;
+	}
+	num_elements--;
+	if (capacity > 2 && num_elements < capacity / 2) {
+		// Shrink array, if less than half full
+		auto new_row_id = unique_ptr<row_t[]>(new row_t[capacity / 2]);
+		memcpy(new_row_id.get(), row_ids.get(), entry_offset * sizeof(row_t));
+		memcpy(new_row_id.get() + entry_offset, row_ids.get() + entry_offset + 1,
+		       (num_elements - entry_offset) * sizeof(row_t));
+		capacity /= 2;
+		row_ids = move(new_row_id);
+	} else {
+		// Copy the rest
+		for (idx_t j = entry_offset; j < num_elements; j++) {
+			row_ids[j] = row_ids[j + 1];
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+Node::Node(ART &art, NodeType type, size_t compressed_prefix_size) : prefix_length(0), count(0), type(type) {
+	this->prefix = unique_ptr<uint8_t[]>(new uint8_t[compressed_prefix_size]);
+}
+
+void Node::CopyPrefix(ART &art, Node *src, Node *dst) {
+	dst->prefix_length = src->prefix_length;
+	memcpy(dst->prefix.get(), src->prefix.get(), src->prefix_length);
+}
+
+// LCOV_EXCL_START
+unique_ptr<Node> *Node::GetChild(idx_t pos) {
+	D_ASSERT(0);
+	return nullptr;
+}
+
+idx_t Node::GetMin() {
+	D_ASSERT(0);
+	return 0;
+}
+// LCOV_EXCL_STOP
+
+uint32_t Node::PrefixMismatch(ART &art, Node *node, Key &key, uint64_t depth) {
+	uint64_t pos;
+	for (pos = 0; pos < node->prefix_length; pos++) {
+		if (key[depth + pos] != node->prefix[pos]) {
+			return pos;
+		}
+	}
+	return pos;
+}
+
+void Node::InsertLeaf(ART &art, unique_ptr<Node> &node, uint8_t key, unique_ptr<Node> &new_node) {
+	switch (node->type) {
+	case NodeType::N4:
+		Node4::Insert(art, node, key, new_node);
+		break;
+	case NodeType::N16:
+		Node16::Insert(art, node, key, new_node);
+		break;
+	case NodeType::N48:
+		Node48::Insert(art, node, key, new_node);
+		break;
+	case NodeType::N256:
+		Node256::Insert(art, node, key, new_node);
+		break;
+	default:
+		throw InternalException("Unrecognized leaf type for insert");
+	}
+}
+
+void Node::Erase(ART &art, unique_ptr<Node> &node, idx_t pos) {
+	switch (node->type) {
+	case NodeType::N4: {
+		Node4::Erase(art, node, pos);
+		break;
+	}
+	case NodeType::N16: {
+		Node16::Erase(art, node, pos);
+		break;
+	}
+	case NodeType::N48: {
+		Node48::Erase(art, node, pos);
+		break;
+	}
+	case NodeType::N256:
+		Node256::Erase(art, node, pos);
+		break;
+	default:
+		throw InternalException("Unrecognized leaf type for erase");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+Node16::Node16(ART &art, size_t compression_length) : Node(art, NodeType::N16, compression_length) {
+	memset(key, 16, sizeof(key));
+}
+
+idx_t Node16::GetChildPos(uint8_t k) {
+	for (idx_t pos = 0; pos < count; pos++) {
+		if (key[pos] == k) {
+			return pos;
+		}
+	}
+	return Node::GetChildPos(k);
+}
+
+idx_t Node16::GetChildGreaterEqual(uint8_t k, bool &equal) {
+	for (idx_t pos = 0; pos < count; pos++) {
+		if (key[pos] >= k) {
+			if (key[pos] == k) {
+				equal = true;
+			} else {
+				equal = false;
+			}
+
+			return pos;
+		}
+	}
+	return Node::GetChildGreaterEqual(k, equal);
+}
+
+idx_t Node16::GetNextPos(idx_t pos) {
+	if (pos == DConstants::INVALID_INDEX) {
+		return 0;
+	}
+	pos++;
+	return pos < count ? pos : DConstants::INVALID_INDEX;
+}
+
+unique_ptr<Node> *Node16::GetChild(idx_t pos) {
+	D_ASSERT(pos < count);
+	return &child[pos];
+}
+
+idx_t Node16::GetMin() {
+	return 0;
+}
+
+void Node16::Insert(ART &art, unique_ptr<Node> &node, uint8_t key_byte, unique_ptr<Node> &child) {
+	Node16 *n = static_cast<Node16 *>(node.get());
+
+	if (n->count < 16) {
+		// Insert element
+		idx_t pos = 0;
+		while (pos < node->count && n->key[pos] < key_byte) {
+			pos++;
+		}
+		if (n->child[pos] != nullptr) {
+			for (idx_t i = n->count; i > pos; i--) {
+				n->key[i] = n->key[i - 1];
+				n->child[i] = move(n->child[i - 1]);
+			}
+		}
+		n->key[pos] = key_byte;
+		n->child[pos] = move(child);
+		n->count++;
+	} else {
+		// Grow to Node48
+		auto new_node = make_unique<Node48>(art, n->prefix_length);
+		for (idx_t i = 0; i < node->count; i++) {
+			new_node->child_index[n->key[i]] = i;
+			new_node->child[i] = move(n->child[i]);
+		}
+		CopyPrefix(art, n, new_node.get());
+		new_node->count = node->count;
+		node = move(new_node);
+
+		Node48::Insert(art, node, key_byte, child);
+	}
+}
+
+void Node16::Erase(ART &art, unique_ptr<Node> &node, int pos) {
+	Node16 *n = static_cast<Node16 *>(node.get());
+	// erase the child and decrease the count
+	n->child[pos].reset();
+	n->count--;
+	// potentially move any children backwards
+	for (; pos < n->count; pos++) {
+		n->key[pos] = n->key[pos + 1];
+		n->child[pos] = move(n->child[pos + 1]);
+	}
+	if (node->count <= 3) {
+		// Shrink node
+		auto new_node = make_unique<Node4>(art, n->prefix_length);
+		for (unsigned i = 0; i < n->count; i++) {
+			new_node->key[new_node->count] = n->key[i];
+			new_node->child[new_node->count++] = move(n->child[i]);
+		}
+		CopyPrefix(art, n, new_node.get());
+		node = move(new_node);
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+Node256::Node256(ART &art, size_t compression_length) : Node(art, NodeType::N256, compression_length) {
+}
+
+idx_t Node256::GetChildPos(uint8_t k) {
+	if (child[k]) {
+		return k;
+	} else {
+		return DConstants::INVALID_INDEX;
+	}
+}
+
+idx_t Node256::GetChildGreaterEqual(uint8_t k, bool &equal) {
+	for (idx_t pos = k; pos < 256; pos++) {
+		if (child[pos]) {
+			if (pos == k) {
+				equal = true;
+			} else {
+				equal = false;
+			}
+			return pos;
+		}
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+idx_t Node256::GetMin() {
+	for (idx_t i = 0; i < 256; i++) {
+		if (child[i]) {
+			return i;
+		}
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+idx_t Node256::GetNextPos(idx_t pos) {
+	for (pos == DConstants::INVALID_INDEX ? pos = 0 : pos++; pos < 256; pos++) {
+		if (child[pos]) {
+			return pos;
+		}
+	}
+	return Node::GetNextPos(pos);
+}
+
+unique_ptr<Node> *Node256::GetChild(idx_t pos) {
+	D_ASSERT(child[pos]);
+	return &child[pos];
+}
+
+void Node256::Insert(ART &art, unique_ptr<Node> &node, uint8_t key_byte, unique_ptr<Node> &child) {
+	Node256 *n = static_cast<Node256 *>(node.get());
+
+	n->count++;
+	n->child[key_byte] = move(child);
+}
+
+void Node256::Erase(ART &art, unique_ptr<Node> &node, int pos) {
+	Node256 *n = static_cast<Node256 *>(node.get());
+
+	n->child[pos].reset();
+	n->count--;
+	if (node->count <= 36) {
+		auto new_node = make_unique<Node48>(art, n->prefix_length);
+		CopyPrefix(art, n, new_node.get());
+		for (idx_t i = 0; i < 256; i++) {
+			if (n->child[i]) {
+				new_node->child_index[i] = new_node->count;
+				new_node->child[new_node->count] = move(n->child[i]);
+				new_node->count++;
+			}
+		}
+		node = move(new_node);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+Node4::Node4(ART &art, size_t compression_length) : Node(art, NodeType::N4, compression_length) {
+	memset(key, 0, sizeof(key));
+}
+
+idx_t Node4::GetChildPos(uint8_t k) {
+	for (idx_t pos = 0; pos < count; pos++) {
+		if (key[pos] == k) {
+			return pos;
+		}
+	}
+	return Node::GetChildPos(k);
+}
+
+idx_t Node4::GetChildGreaterEqual(uint8_t k, bool &equal) {
+	for (idx_t pos = 0; pos < count; pos++) {
+		if (key[pos] >= k) {
+			if (key[pos] == k) {
+				equal = true;
+			} else {
+				equal = false;
+			}
+			return pos;
+		}
+	}
+	return Node::GetChildGreaterEqual(k, equal);
+}
+
+idx_t Node4::GetMin() {
+	return 0;
+}
+
+idx_t Node4::GetNextPos(idx_t pos) {
+	if (pos == DConstants::INVALID_INDEX) {
+		return 0;
+	}
+	pos++;
+	return pos < count ? pos : DConstants::INVALID_INDEX;
+}
+
+unique_ptr<Node> *Node4::GetChild(idx_t pos) {
+	D_ASSERT(pos < count);
+	return &child[pos];
+}
+
+void Node4::Insert(ART &art, unique_ptr<Node> &node, uint8_t key_byte, unique_ptr<Node> &child) {
+	Node4 *n = static_cast<Node4 *>(node.get());
+
+	// Insert leaf into inner node
+	if (node->count < 4) {
+		// Insert element
+		idx_t pos = 0;
+		while ((pos < node->count) && (n->key[pos] < key_byte)) {
+			pos++;
+		}
+		if (n->child[pos] != nullptr) {
+			for (idx_t i = n->count; i > pos; i--) {
+				n->key[i] = n->key[i - 1];
+				n->child[i] = move(n->child[i - 1]);
+			}
+		}
+		n->key[pos] = key_byte;
+		n->child[pos] = move(child);
+		n->count++;
+	} else {
+		// Grow to Node16
+		auto new_node = make_unique<Node16>(art, n->prefix_length);
+		new_node->count = 4;
+		CopyPrefix(art, node.get(), new_node.get());
+		for (idx_t i = 0; i < 4; i++) {
+			new_node->key[i] = n->key[i];
+			new_node->child[i] = move(n->child[i]);
+		}
+		node = move(new_node);
+		Node16::Insert(art, node, key_byte, child);
+	}
+}
+
+void Node4::Erase(ART &art, unique_ptr<Node> &node, int pos) {
+	Node4 *n = static_cast<Node4 *>(node.get());
+	D_ASSERT(pos < n->count);
+
+	// erase the child and decrease the count
+	n->child[pos].reset();
+	n->count--;
+	// potentially move any children backwards
+	for (; pos < n->count; pos++) {
+		n->key[pos] = n->key[pos + 1];
+		n->child[pos] = move(n->child[pos + 1]);
+	}
+
+	// This is a one way node
+	if (n->count == 1) {
+		auto childref = n->child[0].get();
+		//! concatenate prefixes
+		auto new_length = node->prefix_length + childref->prefix_length + 1;
+		//! have to allocate space in our prefix array
+		unique_ptr<uint8_t[]> new_prefix = unique_ptr<uint8_t[]>(new uint8_t[new_length]);
+
+		//! first move the existing prefix (if any)
+		for (uint32_t i = 0; i < childref->prefix_length; i++) {
+			new_prefix[new_length - (i + 1)] = childref->prefix[childref->prefix_length - (i + 1)];
+		}
+		//! now move the current key as part of the prefix
+		new_prefix[node->prefix_length] = n->key[0];
+		//! finally add the old prefix
+		for (uint32_t i = 0; i < node->prefix_length; i++) {
+			new_prefix[i] = node->prefix[i];
+		}
+		//! set new prefix and move the child
+		childref->prefix = move(new_prefix);
+		childref->prefix_length = new_length;
+		node = move(n->child[0]);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+Node48::Node48(ART &art, size_t compression_length) : Node(art, NodeType::N48, compression_length) {
+	for (idx_t i = 0; i < 256; i++) {
+		child_index[i] = Node::EMPTY_MARKER;
+	}
+}
+
+idx_t Node48::GetChildPos(uint8_t k) {
+	if (child_index[k] == Node::EMPTY_MARKER) {
+		return DConstants::INVALID_INDEX;
+	} else {
+		return k;
+	}
+}
+
+idx_t Node48::GetChildGreaterEqual(uint8_t k, bool &equal) {
+	for (idx_t pos = k; pos < 256; pos++) {
+		if (child_index[pos] != Node::EMPTY_MARKER) {
+			if (pos == k) {
+				equal = true;
+			} else {
+				equal = false;
+			}
+			return pos;
+		}
+	}
+	return Node::GetChildGreaterEqual(k, equal);
+}
+
+idx_t Node48::GetNextPos(idx_t pos) {
+	for (pos == DConstants::INVALID_INDEX ? pos = 0 : pos++; pos < 256; pos++) {
+		if (child_index[pos] != Node::EMPTY_MARKER) {
+			return pos;
+		}
+	}
+	return Node::GetNextPos(pos);
+}
+
+unique_ptr<Node> *Node48::GetChild(idx_t pos) {
+	D_ASSERT(child_index[pos] != Node::EMPTY_MARKER);
+	return &child[child_index[pos]];
+}
+
+idx_t Node48::GetMin() {
+	for (idx_t i = 0; i < 256; i++) {
+		if (child_index[i] != Node::EMPTY_MARKER) {
+			return i;
+		}
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+void Node48::Insert(ART &art, unique_ptr<Node> &node, uint8_t key_byte, unique_ptr<Node> &child) {
+	Node48 *n = static_cast<Node48 *>(node.get());
+
+	// Insert leaf into inner node
+	if (node->count < 48) {
+		// Insert element
+		idx_t pos = n->count;
+		if (n->child[pos]) {
+			// find an empty position in the node list if the current position is occupied
+			pos = 0;
+			while (n->child[pos]) {
+				pos++;
+			}
+		}
+		n->child[pos] = move(child);
+		n->child_index[key_byte] = pos;
+		n->count++;
+	} else {
+		// Grow to Node256
+		auto new_node = make_unique<Node256>(art, n->prefix_length);
+		for (idx_t i = 0; i < 256; i++) {
+			if (n->child_index[i] != Node::EMPTY_MARKER) {
+				new_node->child[i] = move(n->child[n->child_index[i]]);
+			}
+		}
+		new_node->count = n->count;
+		CopyPrefix(art, n, new_node.get());
+		node = move(new_node);
+		Node256::Insert(art, node, key_byte, child);
+	}
+}
+
+void Node48::Erase(ART &art, unique_ptr<Node> &node, int pos) {
+	Node48 *n = static_cast<Node48 *>(node.get());
+
+	n->child[n->child_index[pos]].reset();
+	n->child_index[pos] = Node::EMPTY_MARKER;
+	n->count--;
+	if (node->count <= 12) {
+		auto new_node = make_unique<Node16>(art, n->prefix_length);
+		CopyPrefix(art, n, new_node.get());
+		for (idx_t i = 0; i < 256; i++) {
+			if (n->child_index[i] != Node::EMPTY_MARKER) {
+				new_node->key[new_node->count] = i;
+				new_node->child[new_node->count++] = move(n->child[n->child_index[i]]);
+			}
+		}
+		node = move(new_node);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+using ValidityBytes = JoinHashTable::ValidityBytes;
+using ScanStructure = JoinHashTable::ScanStructure;
+
+JoinHashTable::JoinHashTable(BufferManager &buffer_manager, const vector<JoinCondition> &conditions,
+                             vector<LogicalType> btypes, JoinType type)
+    : buffer_manager(buffer_manager), build_types(move(btypes)), entry_size(0), tuple_size(0),
+      vfound(Value::BOOLEAN(false)), join_type(type), finalized(false), has_null(false) {
+	for (auto &condition : conditions) {
+		D_ASSERT(condition.left->return_type == condition.right->return_type);
+		auto type = condition.left->return_type;
+		if (condition.comparison == ExpressionType::COMPARE_EQUAL ||
+		    condition.comparison == ExpressionType::COMPARE_NOT_DISTINCT_FROM ||
+		    condition.comparison == ExpressionType::COMPARE_DISTINCT_FROM) {
+			// all equality conditions should be at the front
+			// all other conditions at the back
+			// this assert checks that
+			D_ASSERT(equality_types.size() == condition_types.size());
+			equality_types.push_back(type);
+		}
+
+		predicates.push_back(condition.comparison);
+		null_values_are_equal.push_back(condition.comparison == ExpressionType::COMPARE_DISTINCT_FROM ||
+		                                condition.comparison == ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+
+		condition_types.push_back(type);
+	}
+	// at least one equality is necessary
+	D_ASSERT(!equality_types.empty());
+
+	// Types for the layout
+	vector<LogicalType> layout_types(condition_types);
+	layout_types.insert(layout_types.end(), build_types.begin(), build_types.end());
+	if (IsRightOuterJoin(join_type)) {
+		// full/right outer joins need an extra bool to keep track of whether or not a tuple has found a matching entry
+		// we place the bool before the NEXT pointer
+		layout_types.emplace_back(LogicalType::BOOLEAN);
+	}
+	layout_types.emplace_back(LogicalType::HASH);
+	layout.Initialize(layout_types, false);
+
+	const auto &offsets = layout.GetOffsets();
+	tuple_size = offsets[condition_types.size() + build_types.size()];
+	pointer_offset = offsets.back();
+	entry_size = layout.GetRowWidth();
+
+	// compute the per-block capacity of this HT
+	idx_t block_capacity = MaxValue<idx_t>(STANDARD_VECTOR_SIZE, (Storage::BLOCK_SIZE / entry_size) + 1);
+	block_collection = make_unique<RowDataCollection>(buffer_manager, block_capacity, entry_size);
+	string_heap = make_unique<RowDataCollection>(buffer_manager, (idx_t)Storage::BLOCK_SIZE, 1, true);
+}
+
+JoinHashTable::~JoinHashTable() {
+}
+
+void JoinHashTable::ApplyBitmask(Vector &hashes, idx_t count) {
+	if (hashes.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		D_ASSERT(!ConstantVector::IsNull(hashes));
+		auto indices = ConstantVector::GetData<hash_t>(hashes);
+		*indices = *indices & bitmask;
+	} else {
+		hashes.Normalify(count);
+		auto indices = FlatVector::GetData<hash_t>(hashes);
+		for (idx_t i = 0; i < count; i++) {
+			indices[i] &= bitmask;
+		}
+	}
+}
+
+void JoinHashTable::ApplyBitmask(Vector &hashes, const SelectionVector &sel, idx_t count, Vector &pointers) {
+	VectorData hdata;
+	hashes.Orrify(count, hdata);
+
+	auto hash_data = (hash_t *)hdata.data;
+	auto result_data = FlatVector::GetData<data_ptr_t *>(pointers);
+	auto main_ht = (data_ptr_t *)hash_map->node->buffer;
+	for (idx_t i = 0; i < count; i++) {
+		auto rindex = sel.get_index(i);
+		auto hindex = hdata.sel->get_index(rindex);
+		auto hash = hash_data[hindex];
+		result_data[rindex] = main_ht + (hash & bitmask);
+	}
+}
+
+void JoinHashTable::Hash(DataChunk &keys, const SelectionVector &sel, idx_t count, Vector &hashes) {
+	if (count == keys.size()) {
+		// no null values are filtered: use regular hash functions
+		VectorOperations::Hash(keys.data[0], hashes, keys.size());
+		for (idx_t i = 1; i < equality_types.size(); i++) {
+			VectorOperations::CombineHash(hashes, keys.data[i], keys.size());
+		}
+	} else {
+		// null values were filtered: use selection vector
+		VectorOperations::Hash(keys.data[0], hashes, sel, count);
+		for (idx_t i = 1; i < equality_types.size(); i++) {
+			VectorOperations::CombineHash(hashes, keys.data[i], sel, count);
+		}
+	}
+}
+
+static idx_t FilterNullValues(VectorData &vdata, const SelectionVector &sel, idx_t count, SelectionVector &result) {
+	idx_t result_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto key_idx = vdata.sel->get_index(idx);
+		if (vdata.validity.RowIsValid(key_idx)) {
+			result.set_index(result_count++, idx);
+		}
+	}
+	return result_count;
+}
+
+idx_t JoinHashTable::PrepareKeys(DataChunk &keys, unique_ptr<VectorData[]> &key_data,
+                                 const SelectionVector *&current_sel, SelectionVector &sel, bool build_side) {
+	key_data = keys.Orrify();
+
+	// figure out which keys are NULL, and create a selection vector out of them
+	current_sel = FlatVector::IncrementalSelectionVector();
+	idx_t added_count = keys.size();
+	if (build_side && IsRightOuterJoin(join_type)) {
+		// in case of a right or full outer join, we cannot remove NULL keys from the build side
+		return added_count;
+	}
+	for (idx_t i = 0; i < keys.ColumnCount(); i++) {
+		if (!null_values_are_equal[i]) {
+			if (key_data[i].validity.AllValid()) {
+				continue;
+			}
+			added_count = FilterNullValues(key_data[i], *current_sel, added_count, sel);
+			// null values are NOT equal for this column, filter them out
+			current_sel = &sel;
+		}
+	}
+	return added_count;
+}
+
+void JoinHashTable::Build(DataChunk &keys, DataChunk &payload) {
+	D_ASSERT(!finalized);
+	D_ASSERT(keys.size() == payload.size());
+	if (keys.size() == 0) {
+		return;
+	}
+	// special case: correlated mark join
+	if (join_type == JoinType::MARK && !correlated_mark_join_info.correlated_types.empty()) {
+		auto &info = correlated_mark_join_info;
+		lock_guard<mutex> mj_lock(info.mj_lock);
+		// Correlated MARK join
+		// for the correlated mark join we need to keep track of COUNT(*) and COUNT(COLUMN) for each of the correlated
+		// columns push into the aggregate hash table
+		D_ASSERT(info.correlated_counts);
+		info.group_chunk.SetCardinality(keys);
+		for (idx_t i = 0; i < info.correlated_types.size(); i++) {
+			info.group_chunk.data[i].Reference(keys.data[i]);
+		}
+		if (info.correlated_payload.data.empty()) {
+			vector<LogicalType> types;
+			types.push_back(keys.data[info.correlated_types.size()].GetType());
+			info.correlated_payload.InitializeEmpty(types);
+		}
+		info.correlated_payload.SetCardinality(keys);
+		info.correlated_payload.data[0].Reference(keys.data[info.correlated_types.size()]);
+		info.correlated_counts->AddChunk(info.group_chunk, info.correlated_payload);
+	}
+
+	// prepare the keys for processing
+	unique_ptr<VectorData[]> key_data;
+	const SelectionVector *current_sel;
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	idx_t added_count = PrepareKeys(keys, key_data, current_sel, sel, true);
+	if (added_count < keys.size()) {
+		has_null = true;
+	}
+	if (added_count == 0) {
+		return;
+	}
+
+	// build out the buffer space
+	Vector addresses(LogicalType::POINTER);
+	auto key_locations = FlatVector::GetData<data_ptr_t>(addresses);
+	auto handles = block_collection->Build(added_count, key_locations, nullptr, current_sel);
+
+	// hash the keys and obtain an entry in the list
+	// note that we only hash the keys used in the equality comparison
+	Vector hash_values(LogicalType::HASH);
+	Hash(keys, *current_sel, added_count, hash_values);
+
+	// build a chunk so we can handle nested types that need more than Orrification
+	DataChunk source_chunk;
+	source_chunk.InitializeEmpty(layout.GetTypes());
+
+	vector<VectorData> source_data;
+	source_data.reserve(layout.ColumnCount());
+
+	// serialize the keys to the key locations
+	for (idx_t i = 0; i < keys.ColumnCount(); i++) {
+		source_chunk.data[i].Reference(keys.data[i]);
+		source_data.emplace_back(move(key_data[i]));
+	}
+	// now serialize the payload
+	D_ASSERT(build_types.size() == payload.ColumnCount());
+	for (idx_t i = 0; i < payload.ColumnCount(); i++) {
+		source_chunk.data[source_data.size()].Reference(payload.data[i]);
+		VectorData pdata;
+		payload.data[i].Orrify(payload.size(), pdata);
+		source_data.emplace_back(move(pdata));
+	}
+	if (IsRightOuterJoin(join_type)) {
+		// for FULL/RIGHT OUTER joins initialize the "found" boolean to false
+		source_chunk.data[source_data.size()].Reference(vfound);
+		VectorData fdata;
+		vfound.Orrify(keys.size(), fdata);
+		source_data.emplace_back(move(fdata));
+	}
+
+	// serialise the hashes at the end
+	source_chunk.data[source_data.size()].Reference(hash_values);
+	VectorData hdata;
+	hash_values.Orrify(keys.size(), hdata);
+	source_data.emplace_back(move(hdata));
+
+	source_chunk.SetCardinality(keys);
+
+	RowOperations::Scatter(source_chunk, source_data.data(), layout, addresses, *string_heap, *current_sel,
+	                       added_count);
+}
+
+void JoinHashTable::InsertHashes(Vector &hashes, idx_t count, data_ptr_t key_locations[]) {
+	D_ASSERT(hashes.GetType().id() == LogicalType::HASH);
+
+	// use bitmask to get position in array
+	ApplyBitmask(hashes, count);
+
+	hashes.Normalify(count);
+
+	D_ASSERT(hashes.GetVectorType() == VectorType::FLAT_VECTOR);
+	auto pointers = (data_ptr_t *)hash_map->node->buffer;
+	auto indices = FlatVector::GetData<hash_t>(hashes);
+	for (idx_t i = 0; i < count; i++) {
+		auto index = indices[i];
+		// set prev in current key to the value (NOTE: this will be nullptr if
+		// there is none)
+		Store<data_ptr_t>(pointers[index], key_locations[i] + pointer_offset);
+
+		// set pointer to current tuple
+		pointers[index] = key_locations[i];
+	}
+}
+
+void JoinHashTable::Finalize() {
+	// the build has finished, now iterate over all the nodes and construct the final hash table
+	// select a HT that has at least 50% empty space
+	idx_t capacity = NextPowerOfTwo(MaxValue<idx_t>(Count() * 2, (Storage::BLOCK_SIZE / sizeof(data_ptr_t)) + 1));
+	// size needs to be a power of 2
+	D_ASSERT((capacity & (capacity - 1)) == 0);
+	bitmask = capacity - 1;
+
+	// allocate the HT and initialize it with all-zero entries
+	hash_map = buffer_manager.Allocate(capacity * sizeof(data_ptr_t));
+	memset(hash_map->node->buffer, 0, capacity * sizeof(data_ptr_t));
+
+	Vector hashes(LogicalType::HASH);
+	auto hash_data = FlatVector::GetData<hash_t>(hashes);
+	data_ptr_t key_locations[STANDARD_VECTOR_SIZE];
+	// now construct the actual hash table; scan the nodes
+	// as we can the nodes we pin all the blocks of the HT and keep them pinned until the HT is destroyed
+	// this is so that we can keep pointers around to the blocks
+	// FIXME: if we cannot keep everything pinned in memory, we could switch to an out-of-memory merge join or so
+	for (auto &block : block_collection->blocks) {
+		auto handle = buffer_manager.Pin(block.block);
+		data_ptr_t dataptr = handle->node->buffer;
+		idx_t entry = 0;
+		while (entry < block.count) {
+			// fetch the next vector of entries from the blocks
+			idx_t next = MinValue<idx_t>(STANDARD_VECTOR_SIZE, block.count - entry);
+			for (idx_t i = 0; i < next; i++) {
+				hash_data[i] = Load<hash_t>((data_ptr_t)(dataptr + pointer_offset));
+				key_locations[i] = dataptr;
+				dataptr += entry_size;
+			}
+			// now insert into the hash table
+			InsertHashes(hashes, next, key_locations);
+
+			entry += next;
+		}
+		pinned_handles.push_back(move(handle));
+	}
+
+	finalized = true;
+}
+
+unique_ptr<ScanStructure> JoinHashTable::Probe(DataChunk &keys) {
+	D_ASSERT(Count() > 0); // should be handled before
+	D_ASSERT(finalized);
+
+	// set up the scan structure
+	auto ss = make_unique<ScanStructure>(*this);
+
+	if (join_type != JoinType::INNER) {
+		ss->found_match = unique_ptr<bool[]>(new bool[STANDARD_VECTOR_SIZE]);
+		memset(ss->found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+	}
+
+	// first prepare the keys for probing
+	const SelectionVector *current_sel;
+	ss->count = PrepareKeys(keys, ss->key_data, current_sel, ss->sel_vector, false);
+	if (ss->count == 0) {
+		return ss;
+	}
+
+	// hash all the keys
+	Vector hashes(LogicalType::HASH);
+	Hash(keys, *current_sel, ss->count, hashes);
+
+	// now initialize the pointers of the scan structure based on the hashes
+	ApplyBitmask(hashes, *current_sel, ss->count, ss->pointers);
+
+	// create the selection vector linking to only non-empty entries
+	idx_t count = 0;
+	auto pointers = FlatVector::GetData<data_ptr_t>(ss->pointers);
+	for (idx_t i = 0; i < ss->count; i++) {
+		auto idx = current_sel->get_index(i);
+		pointers[idx] = Load<data_ptr_t>(pointers[idx]);
+		if (pointers[idx]) {
+			ss->sel_vector.set_index(count++, idx);
+		}
+	}
+	ss->count = count;
+	return ss;
+}
+
+ScanStructure::ScanStructure(JoinHashTable &ht)
+    : pointers(LogicalType::POINTER), sel_vector(STANDARD_VECTOR_SIZE), ht(ht), finished(false) {
+}
+
+void ScanStructure::Next(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	if (finished) {
+		return;
+	}
+
+	switch (ht.join_type) {
+	case JoinType::INNER:
+	case JoinType::RIGHT:
+		NextInnerJoin(keys, left, result);
+		break;
+	case JoinType::SEMI:
+		NextSemiJoin(keys, left, result);
+		break;
+	case JoinType::MARK:
+		NextMarkJoin(keys, left, result);
+		break;
+	case JoinType::ANTI:
+		NextAntiJoin(keys, left, result);
+		break;
+	case JoinType::OUTER:
+	case JoinType::LEFT:
+		NextLeftJoin(keys, left, result);
+		break;
+	case JoinType::SINGLE:
+		NextSingleJoin(keys, left, result);
+		break;
+	default:
+		throw InternalException("Unhandled join type in JoinHashTable");
+	}
+}
+
+idx_t ScanStructure::ResolvePredicates(DataChunk &keys, SelectionVector &match_sel, SelectionVector *no_match_sel) {
+	// Start with the scan selection
+	for (idx_t i = 0; i < this->count; ++i) {
+		match_sel.set_index(i, this->sel_vector.get_index(i));
+	}
+	idx_t no_match_count = 0;
+
+	return RowOperations::Match(keys, key_data.get(), ht.layout, pointers, ht.predicates, match_sel, this->count,
+	                            no_match_sel, no_match_count);
+}
+
+idx_t ScanStructure::ScanInnerJoin(DataChunk &keys, SelectionVector &result_vector) {
+	while (true) {
+		// resolve the predicates for this set of keys
+		idx_t result_count = ResolvePredicates(keys, result_vector, nullptr);
+
+		// after doing all the comparisons set the found_match vector
+		if (found_match) {
+			for (idx_t i = 0; i < result_count; i++) {
+				auto idx = result_vector.get_index(i);
+				found_match[idx] = true;
+			}
+		}
+		if (result_count > 0) {
+			return result_count;
+		}
+		// no matches found: check the next set of pointers
+		AdvancePointers();
+		if (this->count == 0) {
+			return 0;
+		}
+	}
+}
+
+void ScanStructure::AdvancePointers(const SelectionVector &sel, idx_t sel_count) {
+	// now for all the pointers, we move on to the next set of pointers
+	idx_t new_count = 0;
+	auto ptrs = FlatVector::GetData<data_ptr_t>(this->pointers);
+	for (idx_t i = 0; i < sel_count; i++) {
+		auto idx = sel.get_index(i);
+		ptrs[idx] = Load<data_ptr_t>(ptrs[idx] + ht.pointer_offset);
+		if (ptrs[idx]) {
+			this->sel_vector.set_index(new_count++, idx);
+		}
+	}
+	this->count = new_count;
+}
+
+void ScanStructure::AdvancePointers() {
+	AdvancePointers(this->sel_vector, this->count);
+}
+
+void ScanStructure::GatherResult(Vector &result, const SelectionVector &result_vector,
+                                 const SelectionVector &sel_vector, const idx_t count, const idx_t col_no) {
+	const auto col_offset = ht.layout.GetOffsets()[col_no];
+	RowOperations::Gather(pointers, sel_vector, result, result_vector, count, col_offset, col_no);
+}
+
+void ScanStructure::GatherResult(Vector &result, const SelectionVector &sel_vector, const idx_t count,
+                                 const idx_t col_idx) {
+	GatherResult(result, *FlatVector::IncrementalSelectionVector(), sel_vector, count, col_idx);
+}
+
+void ScanStructure::NextInnerJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	D_ASSERT(result.ColumnCount() == left.ColumnCount() + ht.build_types.size());
+	if (this->count == 0) {
+		// no pointers left to chase
+		return;
+	}
+
+	SelectionVector result_vector(STANDARD_VECTOR_SIZE);
+
+	idx_t result_count = ScanInnerJoin(keys, result_vector);
+	if (result_count > 0) {
+		if (IsRightOuterJoin(ht.join_type)) {
+			// full/right outer join: mark join matches as FOUND in the HT
+			auto ptrs = FlatVector::GetData<data_ptr_t>(pointers);
+			for (idx_t i = 0; i < result_count; i++) {
+				auto idx = result_vector.get_index(i);
+				// NOTE: threadsan reports this as a data race because this can be set concurrently by separate threads
+				// Technically it is, but it does not matter, since the only value that can be written is "true"
+				Store<bool>(true, ptrs[idx] + ht.tuple_size);
+			}
+		}
+		// matches were found
+		// construct the result
+		// on the LHS, we create a slice using the result vector
+		result.Slice(left, result_vector, result_count);
+
+		// on the RHS, we need to fetch the data from the hash table
+		for (idx_t i = 0; i < ht.build_types.size(); i++) {
+			auto &vector = result.data[left.ColumnCount() + i];
+			D_ASSERT(vector.GetType() == ht.build_types[i]);
+			GatherResult(vector, result_vector, result_count, i + ht.condition_types.size());
+		}
+		AdvancePointers();
+	}
+}
+
+void ScanStructure::ScanKeyMatches(DataChunk &keys) {
+	// the semi-join, anti-join and mark-join we handle a differently from the inner join
+	// since there can be at most STANDARD_VECTOR_SIZE results
+	// we handle the entire chunk in one call to Next().
+	// for every pointer, we keep chasing pointers and doing comparisons.
+	// this results in a boolean array indicating whether or not the tuple has a match
+	SelectionVector match_sel(STANDARD_VECTOR_SIZE), no_match_sel(STANDARD_VECTOR_SIZE);
+	while (this->count > 0) {
+		// resolve the predicates for the current set of pointers
+		idx_t match_count = ResolvePredicates(keys, match_sel, &no_match_sel);
+		idx_t no_match_count = this->count - match_count;
+
+		// mark each of the matches as found
+		for (idx_t i = 0; i < match_count; i++) {
+			found_match[match_sel.get_index(i)] = true;
+		}
+		// continue searching for the ones where we did not find a match yet
+		AdvancePointers(no_match_sel, no_match_count);
+	}
+}
+
+template <bool MATCH>
+void ScanStructure::NextSemiOrAntiJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	D_ASSERT(left.ColumnCount() == result.ColumnCount());
+	D_ASSERT(keys.size() == left.size());
+	// create the selection vector from the matches that were found
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	idx_t result_count = 0;
+	for (idx_t i = 0; i < keys.size(); i++) {
+		if (found_match[i] == MATCH) {
+			// part of the result
+			sel.set_index(result_count++, i);
+		}
+	}
+	// construct the final result
+	if (result_count > 0) {
+		// we only return the columns on the left side
+		// reference the columns of the left side from the result
+		result.Slice(left, sel, result_count);
+	} else {
+		D_ASSERT(result.size() == 0);
+	}
+}
+
+void ScanStructure::NextSemiJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	// first scan for key matches
+	ScanKeyMatches(keys);
+	// then construct the result from all tuples with a match
+	NextSemiOrAntiJoin<true>(keys, left, result);
+
+	finished = true;
+}
+
+void ScanStructure::NextAntiJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	// first scan for key matches
+	ScanKeyMatches(keys);
+	// then construct the result from all tuples that did not find a match
+	NextSemiOrAntiJoin<false>(keys, left, result);
+
+	finished = true;
+}
+
+void ScanStructure::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &child, DataChunk &result) {
+	// for the initial set of columns we just reference the left side
+	result.SetCardinality(child);
+	for (idx_t i = 0; i < child.ColumnCount(); i++) {
+		result.data[i].Reference(child.data[i]);
+	}
+	auto &mark_vector = result.data.back();
+	mark_vector.SetVectorType(VectorType::FLAT_VECTOR);
+	// first we set the NULL values from the join keys
+	// if there is any NULL in the keys, the result is NULL
+	auto bool_result = FlatVector::GetData<bool>(mark_vector);
+	auto &mask = FlatVector::Validity(mark_vector);
+	for (idx_t col_idx = 0; col_idx < join_keys.ColumnCount(); col_idx++) {
+		if (ht.null_values_are_equal[col_idx]) {
+			continue;
+		}
+		VectorData jdata;
+		join_keys.data[col_idx].Orrify(join_keys.size(), jdata);
+		if (!jdata.validity.AllValid()) {
+			for (idx_t i = 0; i < join_keys.size(); i++) {
+				auto jidx = jdata.sel->get_index(i);
+				mask.Set(i, jdata.validity.RowIsValidUnsafe(jidx));
+			}
+		}
+	}
+	// now set the remaining entries to either true or false based on whether a match was found
+	if (found_match) {
+		for (idx_t i = 0; i < child.size(); i++) {
+			bool_result[i] = found_match[i];
+		}
+	} else {
+		memset(bool_result, 0, sizeof(bool) * child.size());
+	}
+	// if the right side contains NULL values, the result of any FALSE becomes NULL
+	if (ht.has_null) {
+		for (idx_t i = 0; i < child.size(); i++) {
+			if (!bool_result[i]) {
+				mask.SetInvalid(i);
+			}
+		}
+	}
+}
+
+void ScanStructure::NextMarkJoin(DataChunk &keys, DataChunk &input, DataChunk &result) {
+	D_ASSERT(result.ColumnCount() == input.ColumnCount() + 1);
+	D_ASSERT(result.data.back().GetType() == LogicalType::BOOLEAN);
+	// this method should only be called for a non-empty HT
+	D_ASSERT(ht.Count() > 0);
+
+	ScanKeyMatches(keys);
+	if (ht.correlated_mark_join_info.correlated_types.empty()) {
+		ConstructMarkJoinResult(keys, input, result);
+	} else {
+		auto &info = ht.correlated_mark_join_info;
+		// there are correlated columns
+		// first we fetch the counts from the aggregate hashtable corresponding to these entries
+		D_ASSERT(keys.ColumnCount() == info.group_chunk.ColumnCount() + 1);
+		info.group_chunk.SetCardinality(keys);
+		for (idx_t i = 0; i < info.group_chunk.ColumnCount(); i++) {
+			info.group_chunk.data[i].Reference(keys.data[i]);
+		}
+		info.correlated_counts->FetchAggregates(info.group_chunk, info.result_chunk);
+
+		// for the initial set of columns we just reference the left side
+		result.SetCardinality(input);
+		for (idx_t i = 0; i < input.ColumnCount(); i++) {
+			result.data[i].Reference(input.data[i]);
+		}
+		// create the result matching vector
+		auto &last_key = keys.data.back();
+		auto &result_vector = result.data.back();
+		// first set the nullmask based on whether or not there were NULL values in the join key
+		result_vector.SetVectorType(VectorType::FLAT_VECTOR);
+		auto bool_result = FlatVector::GetData<bool>(result_vector);
+		auto &mask = FlatVector::Validity(result_vector);
+		switch (last_key.GetVectorType()) {
+		case VectorType::CONSTANT_VECTOR:
+			if (ConstantVector::IsNull(last_key)) {
+				mask.SetAllInvalid(input.size());
+			}
+			break;
+		case VectorType::FLAT_VECTOR:
+			mask.Copy(FlatVector::Validity(last_key), input.size());
+			break;
+		default: {
+			VectorData kdata;
+			last_key.Orrify(keys.size(), kdata);
+			for (idx_t i = 0; i < input.size(); i++) {
+				auto kidx = kdata.sel->get_index(i);
+				mask.Set(i, kdata.validity.RowIsValid(kidx));
+			}
+			break;
+		}
+		}
+
+		auto count_star = FlatVector::GetData<int64_t>(info.result_chunk.data[0]);
+		auto count = FlatVector::GetData<int64_t>(info.result_chunk.data[1]);
+		// set the entries to either true or false based on whether a match was found
+		for (idx_t i = 0; i < input.size(); i++) {
+			D_ASSERT(count_star[i] >= count[i]);
+			bool_result[i] = found_match ? found_match[i] : false;
+			if (!bool_result[i] && count_star[i] > count[i]) {
+				// RHS has NULL value and result is false: set to null
+				mask.SetInvalid(i);
+			}
+			if (count_star[i] == 0) {
+				// count == 0, set nullmask to false (we know the result is false now)
+				mask.SetValid(i);
+			}
+		}
+	}
+	finished = true;
+}
+
+void ScanStructure::NextLeftJoin(DataChunk &keys, DataChunk &left, DataChunk &result) {
+	// a LEFT OUTER JOIN is identical to an INNER JOIN except all tuples that do
+	// not have a match must return at least one tuple (with the right side set
+	// to NULL in every column)
+	NextInnerJoin(keys, left, result);
+	if (result.size() == 0) {
+		// no entries left from the normal join
+		// fill in the result of the remaining left tuples
+		// together with NULL values on the right-hand side
+		idx_t remaining_count = 0;
+		SelectionVector sel(STANDARD_VECTOR_SIZE);
+		for (idx_t i = 0; i < left.size(); i++) {
+			if (!found_match[i]) {
+				sel.set_index(remaining_count++, i);
+			}
+		}
+		if (remaining_count > 0) {
+			// have remaining tuples
+			// slice the left side with tuples that did not find a match
+			result.Slice(left, sel, remaining_count);
+
+			// now set the right side to NULL
+			for (idx_t i = left.ColumnCount(); i < result.ColumnCount(); i++) {
+				Vector &vec = result.data[i];
+				vec.SetVectorType(VectorType::CONSTANT_VECTOR);
+				ConstantVector::SetNull(vec, true);
+			}
+		}
+		finished = true;
+	}
+}
+
+void ScanStructure::NextSingleJoin(DataChunk &keys, DataChunk &input, DataChunk &result) {
+	// single join
+	// this join is similar to the semi join except that
+	// (1) we actually return data from the RHS and
+	// (2) we return NULL for that data if there is no match
+	idx_t result_count = 0;
+	SelectionVector result_sel(STANDARD_VECTOR_SIZE);
+	SelectionVector match_sel(STANDARD_VECTOR_SIZE), no_match_sel(STANDARD_VECTOR_SIZE);
+	while (this->count > 0) {
+		// resolve the predicates for the current set of pointers
+		idx_t match_count = ResolvePredicates(keys, match_sel, &no_match_sel);
+		idx_t no_match_count = this->count - match_count;
+
+		// mark each of the matches as found
+		for (idx_t i = 0; i < match_count; i++) {
+			// found a match for this index
+			auto index = match_sel.get_index(i);
+			found_match[index] = true;
+			result_sel.set_index(result_count++, index);
+		}
+		// continue searching for the ones where we did not find a match yet
+		AdvancePointers(no_match_sel, no_match_count);
+	}
+	// reference the columns of the left side from the result
+	D_ASSERT(input.ColumnCount() > 0);
+	for (idx_t i = 0; i < input.ColumnCount(); i++) {
+		result.data[i].Reference(input.data[i]);
+	}
+	// now fetch the data from the RHS
+	for (idx_t i = 0; i < ht.build_types.size(); i++) {
+		auto &vector = result.data[input.ColumnCount() + i];
+		// set NULL entries for every entry that was not found
+		auto &mask = FlatVector::Validity(vector);
+		mask.SetAllInvalid(input.size());
+		for (idx_t j = 0; j < result_count; j++) {
+			mask.SetValid(result_sel.get_index(j));
+		}
+		// for the remaining values we fetch the values
+		GatherResult(vector, result_sel, result_sel, result_count, i + ht.condition_types.size());
+	}
+	result.SetCardinality(input.size());
+
+	// like the SEMI, ANTI and MARK join types, the SINGLE join only ever does one pass over the HT per input chunk
+	finished = true;
+}
+
+void JoinHashTable::ScanFullOuter(DataChunk &result, JoinHTScanState &state) {
+	// scan the HT starting from the current position and check which rows from the build side did not find a match
+	Vector addresses(LogicalType::POINTER);
+	auto key_locations = FlatVector::GetData<data_ptr_t>(addresses);
+	idx_t found_entries = 0;
+	{
+		lock_guard<mutex> state_lock(state.lock);
+		for (; state.block_position < block_collection->blocks.size(); state.block_position++, state.position = 0) {
+			auto &block = block_collection->blocks[state.block_position];
+			auto &handle = pinned_handles[state.block_position];
+			auto baseptr = handle->node->buffer;
+			for (; state.position < block.count; state.position++) {
+				auto tuple_base = baseptr + state.position * entry_size;
+				auto found_match = Load<bool>(tuple_base + tuple_size);
+				if (!found_match) {
+					key_locations[found_entries++] = tuple_base;
+					if (found_entries == STANDARD_VECTOR_SIZE) {
+						state.position++;
+						break;
+					}
+				}
+			}
+			if (found_entries == STANDARD_VECTOR_SIZE) {
+				break;
+			}
+		}
+	}
+	result.SetCardinality(found_entries);
+	if (found_entries > 0) {
+		idx_t left_column_count = result.ColumnCount() - build_types.size();
+		const auto &sel_vector = *FlatVector::IncrementalSelectionVector();
+		// set the left side as a constant NULL
+		for (idx_t i = 0; i < left_column_count; i++) {
+			Vector &vec = result.data[i];
+			vec.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(vec, true);
+		}
+		// gather the values from the RHS
+		for (idx_t i = 0; i < build_types.size(); i++) {
+			auto &vector = result.data[left_column_count + i];
+			D_ASSERT(vector.GetType() == build_types[i]);
+			const auto col_no = condition_types.size() + i;
+			const auto col_offset = layout.GetOffsets()[col_no];
+			RowOperations::Gather(addresses, sel_vector, vector, sel_vector, found_entries, col_offset, col_no);
+		}
+	}
+}
+
+idx_t JoinHashTable::FillWithHTOffsets(data_ptr_t *key_locations, JoinHTScanState &state) {
+
+	// iterate over blocks
+	idx_t key_count = 0;
+	while (state.block_position < block_collection->blocks.size()) {
+		auto &block = block_collection->blocks[state.block_position];
+		auto handle = buffer_manager.Pin(block.block);
+		auto base_ptr = handle->node->buffer;
+		// go through all the tuples within this block
+		while (state.position < block.count) {
+			auto tuple_base = base_ptr + state.position * entry_size;
+			// store its locations
+			key_locations[key_count++] = tuple_base;
+			state.position++;
+		}
+		state.block_position++;
+		state.position = 0;
+	}
+	return key_count;
+}
+} // namespace duckdb

--- a/velox/external/duckdb/duckdb-3.cpp
+++ b/velox/external/duckdb/duckdb-3.cpp
@@ -1,0 +1,16677 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+namespace duckdb {
+
+template <class OP>
+struct ComparisonOperationWrapper {
+	template <class T>
+	static inline bool Operation(T left, T right, bool left_is_null, bool right_is_null) {
+		if (left_is_null || right_is_null) {
+			return false;
+		}
+		return OP::Operation(left, right);
+	}
+};
+
+struct InitialNestedLoopJoin {
+	template <class T, class OP>
+	static idx_t Operation(Vector &left, Vector &right, idx_t left_size, idx_t right_size, idx_t &lpos, idx_t &rpos,
+	                       SelectionVector &lvector, SelectionVector &rvector, idx_t current_match_count) {
+		// initialize phase of nested loop join
+		// fill lvector and rvector with matches from the base vectors
+		VectorData left_data, right_data;
+		left.Orrify(left_size, left_data);
+		right.Orrify(right_size, right_data);
+
+		auto ldata = (T *)left_data.data;
+		auto rdata = (T *)right_data.data;
+		idx_t result_count = 0;
+		for (; rpos < right_size; rpos++) {
+			idx_t right_position = right_data.sel->get_index(rpos);
+			bool right_is_valid = right_data.validity.RowIsValid(right_position);
+			for (; lpos < left_size; lpos++) {
+				if (result_count == STANDARD_VECTOR_SIZE) {
+					// out of space!
+					return result_count;
+				}
+				idx_t left_position = left_data.sel->get_index(lpos);
+				bool left_is_valid = left_data.validity.RowIsValid(left_position);
+				if (OP::Operation(ldata[left_position], rdata[right_position], !left_is_valid, !right_is_valid)) {
+					// emit tuple
+					lvector.set_index(result_count, lpos);
+					rvector.set_index(result_count, rpos);
+					result_count++;
+				}
+			}
+			lpos = 0;
+		}
+		return result_count;
+	}
+};
+
+struct RefineNestedLoopJoin {
+	template <class T, class OP>
+	static idx_t Operation(Vector &left, Vector &right, idx_t left_size, idx_t right_size, idx_t &lpos, idx_t &rpos,
+	                       SelectionVector &lvector, SelectionVector &rvector, idx_t current_match_count) {
+		VectorData left_data, right_data;
+		left.Orrify(left_size, left_data);
+		right.Orrify(right_size, right_data);
+
+		// refine phase of the nested loop join
+		// refine lvector and rvector based on matches of subsequent conditions (in case there are multiple conditions
+		// in the join)
+		D_ASSERT(current_match_count > 0);
+		auto ldata = (T *)left_data.data;
+		auto rdata = (T *)right_data.data;
+		idx_t result_count = 0;
+		for (idx_t i = 0; i < current_match_count; i++) {
+			auto lidx = lvector.get_index(i);
+			auto ridx = rvector.get_index(i);
+			auto left_idx = left_data.sel->get_index(lidx);
+			auto right_idx = right_data.sel->get_index(ridx);
+			bool left_is_valid = left_data.validity.RowIsValid(left_idx);
+			bool right_is_valid = right_data.validity.RowIsValid(right_idx);
+			if (OP::Operation(ldata[left_idx], rdata[right_idx], !left_is_valid, !right_is_valid)) {
+				lvector.set_index(result_count, lidx);
+				rvector.set_index(result_count, ridx);
+				result_count++;
+			}
+		}
+		return result_count;
+	}
+};
+
+template <class NLTYPE, class OP>
+static idx_t NestedLoopJoinTypeSwitch(Vector &left, Vector &right, idx_t left_size, idx_t right_size, idx_t &lpos,
+                                      idx_t &rpos, SelectionVector &lvector, SelectionVector &rvector,
+                                      idx_t current_match_count) {
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return NLTYPE::template Operation<int8_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                              current_match_count);
+	case PhysicalType::INT16:
+		return NLTYPE::template Operation<int16_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                               current_match_count);
+	case PhysicalType::INT32:
+		return NLTYPE::template Operation<int32_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                               current_match_count);
+	case PhysicalType::INT64:
+		return NLTYPE::template Operation<int64_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                               current_match_count);
+	case PhysicalType::UINT8:
+		return NLTYPE::template Operation<uint8_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                               current_match_count);
+	case PhysicalType::UINT16:
+		return NLTYPE::template Operation<uint16_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                rvector, current_match_count);
+	case PhysicalType::UINT32:
+		return NLTYPE::template Operation<uint32_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                rvector, current_match_count);
+	case PhysicalType::UINT64:
+		return NLTYPE::template Operation<uint64_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                rvector, current_match_count);
+	case PhysicalType::INT128:
+		return NLTYPE::template Operation<hugeint_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                 rvector, current_match_count);
+	case PhysicalType::FLOAT:
+		return NLTYPE::template Operation<float, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                             current_match_count);
+	case PhysicalType::DOUBLE:
+		return NLTYPE::template Operation<double, OP>(left, right, left_size, right_size, lpos, rpos, lvector, rvector,
+		                                              current_match_count);
+	case PhysicalType::INTERVAL:
+		return NLTYPE::template Operation<interval_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                  rvector, current_match_count);
+	case PhysicalType::VARCHAR:
+		return NLTYPE::template Operation<string_t, OP>(left, right, left_size, right_size, lpos, rpos, lvector,
+		                                                rvector, current_match_count);
+	default:
+		throw InternalException("Unimplemented type for join!");
+	}
+}
+
+template <class NLTYPE>
+idx_t NestedLoopJoinComparisonSwitch(Vector &left, Vector &right, idx_t left_size, idx_t right_size, idx_t &lpos,
+                                     idx_t &rpos, SelectionVector &lvector, SelectionVector &rvector,
+                                     idx_t current_match_count, ExpressionType comparison_type) {
+	D_ASSERT(left.GetType() == right.GetType());
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_EQUAL:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::Equals>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::NotEquals>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_LESSTHAN:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::LessThan>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::GreaterThan>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::LessThanEquals>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return NestedLoopJoinTypeSwitch<NLTYPE, ComparisonOperationWrapper<duckdb::GreaterThanEquals>>(
+		    left, right, left_size, right_size, lpos, rpos, lvector, rvector, current_match_count);
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return NestedLoopJoinTypeSwitch<NLTYPE, duckdb::DistinctFrom>(left, right, left_size, right_size, lpos, rpos,
+		                                                              lvector, rvector, current_match_count);
+	default:
+		throw NotImplementedException("Unimplemented comparison type for join!");
+	}
+}
+
+idx_t NestedLoopJoinInner::Perform(idx_t &lpos, idx_t &rpos, DataChunk &left_conditions, DataChunk &right_conditions,
+                                   SelectionVector &lvector, SelectionVector &rvector,
+                                   const vector<JoinCondition> &conditions) {
+	D_ASSERT(left_conditions.ColumnCount() == right_conditions.ColumnCount());
+	if (lpos >= left_conditions.size() || rpos >= right_conditions.size()) {
+		return 0;
+	}
+	// for the first condition, lvector and rvector are not set yet
+	// we initialize them using the InitialNestedLoopJoin
+	idx_t match_count = NestedLoopJoinComparisonSwitch<InitialNestedLoopJoin>(
+	    left_conditions.data[0], right_conditions.data[0], left_conditions.size(), right_conditions.size(), lpos, rpos,
+	    lvector, rvector, 0, conditions[0].comparison);
+	// now resolve the rest of the conditions
+	for (idx_t i = 1; i < conditions.size(); i++) {
+		// check if we have run out of tuples to compare
+		if (match_count == 0) {
+			return 0;
+		}
+		// if not, get the vectors to compare
+		Vector &l = left_conditions.data[i];
+		Vector &r = right_conditions.data[i];
+		// then we refine the currently obtained results using the RefineNestedLoopJoin
+		match_count = NestedLoopJoinComparisonSwitch<RefineNestedLoopJoin>(
+		    l, r, left_conditions.size(), right_conditions.size(), lpos, rpos, lvector, rvector, match_count,
+		    conditions[i].comparison);
+	}
+	return match_count;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+template <class T, class OP>
+static void TemplatedMarkJoin(Vector &left, Vector &right, idx_t lcount, idx_t rcount, bool found_match[]) {
+	VectorData left_data, right_data;
+	left.Orrify(lcount, left_data);
+	right.Orrify(rcount, right_data);
+
+	auto ldata = (T *)left_data.data;
+	auto rdata = (T *)right_data.data;
+	for (idx_t i = 0; i < lcount; i++) {
+		if (found_match[i]) {
+			continue;
+		}
+		auto lidx = left_data.sel->get_index(i);
+		if (!left_data.validity.RowIsValid(lidx)) {
+			continue;
+		}
+		for (idx_t j = 0; j < rcount; j++) {
+			auto ridx = right_data.sel->get_index(j);
+			if (!right_data.validity.RowIsValid(ridx)) {
+				continue;
+			}
+			if (OP::Operation(ldata[lidx], rdata[ridx])) {
+				found_match[i] = true;
+				break;
+			}
+		}
+	}
+}
+
+template <class OP>
+static void MarkJoinSwitch(Vector &left, Vector &right, idx_t lcount, idx_t rcount, bool found_match[]) {
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedMarkJoin<int8_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::INT16:
+		return TemplatedMarkJoin<int16_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::INT32:
+		return TemplatedMarkJoin<int32_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::INT64:
+		return TemplatedMarkJoin<int64_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::INT128:
+		return TemplatedMarkJoin<hugeint_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::UINT8:
+		return TemplatedMarkJoin<uint8_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::UINT16:
+		return TemplatedMarkJoin<uint16_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::UINT32:
+		return TemplatedMarkJoin<uint32_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::UINT64:
+		return TemplatedMarkJoin<uint64_t, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::FLOAT:
+		return TemplatedMarkJoin<float, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::DOUBLE:
+		return TemplatedMarkJoin<double, OP>(left, right, lcount, rcount, found_match);
+	case PhysicalType::VARCHAR:
+		return TemplatedMarkJoin<string_t, OP>(left, right, lcount, rcount, found_match);
+	default:
+		throw NotImplementedException("Unimplemented type for mark join!");
+	}
+}
+
+static void MarkJoinComparisonSwitch(Vector &left, Vector &right, idx_t lcount, idx_t rcount, bool found_match[],
+                                     ExpressionType comparison_type) {
+	D_ASSERT(left.GetType() == right.GetType());
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_EQUAL:
+		return MarkJoinSwitch<duckdb::Equals>(left, right, lcount, rcount, found_match);
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return MarkJoinSwitch<duckdb::NotEquals>(left, right, lcount, rcount, found_match);
+	case ExpressionType::COMPARE_LESSTHAN:
+		return MarkJoinSwitch<duckdb::LessThan>(left, right, lcount, rcount, found_match);
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return MarkJoinSwitch<duckdb::GreaterThan>(left, right, lcount, rcount, found_match);
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return MarkJoinSwitch<duckdb::LessThanEquals>(left, right, lcount, rcount, found_match);
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return MarkJoinSwitch<duckdb::GreaterThanEquals>(left, right, lcount, rcount, found_match);
+	default:
+		throw NotImplementedException("Unimplemented comparison type for join!");
+	}
+}
+
+void NestedLoopJoinMark::Perform(DataChunk &left, ChunkCollection &right, bool found_match[],
+                                 const vector<JoinCondition> &conditions) {
+	// initialize a new temporary selection vector for the left chunk
+	// loop over all chunks in the RHS
+	for (idx_t chunk_idx = 0; chunk_idx < right.ChunkCount(); chunk_idx++) {
+		DataChunk &right_chunk = right.GetChunk(chunk_idx);
+		for (idx_t i = 0; i < conditions.size(); i++) {
+			MarkJoinComparisonSwitch(left.data[i], right_chunk.data[i], left.size(), right_chunk.size(), found_match,
+			                         conditions[i].comparison);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
+                                             vector<unique_ptr<Expression>> expressions, idx_t estimated_cardinality,
+                                             PhysicalOperatorType type)
+    : PhysicalHashAggregate(context, move(types), move(expressions), {}, estimated_cardinality, type) {
+}
+
+PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
+                                             vector<unique_ptr<Expression>> expressions,
+                                             vector<unique_ptr<Expression>> groups_p, idx_t estimated_cardinality,
+                                             PhysicalOperatorType type)
+    : PhysicalHashAggregate(context, move(types), move(expressions), move(groups_p), {}, {}, estimated_cardinality,
+                            type) {
+}
+
+PhysicalHashAggregate::PhysicalHashAggregate(ClientContext &context, vector<LogicalType> types,
+                                             vector<unique_ptr<Expression>> expressions,
+                                             vector<unique_ptr<Expression>> groups_p,
+                                             vector<GroupingSet> grouping_sets_p,
+                                             vector<vector<idx_t>> grouping_functions_p, idx_t estimated_cardinality,
+                                             PhysicalOperatorType type)
+    : PhysicalOperator(type, move(types), estimated_cardinality), groups(move(groups_p)),
+      grouping_sets(move(grouping_sets_p)), grouping_functions(move(grouping_functions_p)), any_distinct(false) {
+	// get a list of all aggregates to be computed
+	for (auto &expr : groups) {
+		group_types.push_back(expr->return_type);
+	}
+	if (grouping_sets.empty()) {
+		GroupingSet set;
+		for (idx_t i = 0; i < group_types.size(); i++) {
+			set.insert(i);
+		}
+		grouping_sets.push_back(move(set));
+	}
+	vector<LogicalType> payload_types_filters;
+	for (auto &expr : expressions) {
+		D_ASSERT(expr->expression_class == ExpressionClass::BOUND_AGGREGATE);
+		D_ASSERT(expr->IsAggregate());
+		auto &aggr = (BoundAggregateExpression &)*expr;
+		bindings.push_back(&aggr);
+
+		if (aggr.distinct) {
+			any_distinct = true;
+		}
+
+		aggregate_return_types.push_back(aggr.return_type);
+		for (auto &child : aggr.children) {
+			payload_types.push_back(child->return_type);
+		}
+		if (aggr.filter) {
+			payload_types_filters.push_back(aggr.filter->return_type);
+		}
+		if (!aggr.function.combine) {
+			throw InternalException("Aggregate function %s is missing a combine method", aggr.function.name);
+		}
+		aggregates.push_back(move(expr));
+	}
+
+	for (const auto &pay_filters : payload_types_filters) {
+		payload_types.push_back(pay_filters);
+	}
+
+	// filter_indexes must be pre-built, not lazily instantiated in parallel...
+	idx_t aggregate_input_idx = 0;
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		aggregate_input_idx += aggr.children.size();
+	}
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		if (aggr.filter) {
+			auto &bound_ref_expr = (BoundReferenceExpression &)*aggr.filter;
+			auto it = filter_indexes.find(aggr.filter.get());
+			if (it == filter_indexes.end()) {
+				filter_indexes[aggr.filter.get()] = bound_ref_expr.index;
+				bound_ref_expr.index = aggregate_input_idx++;
+			} else {
+				++aggregate_input_idx;
+			}
+		}
+	}
+
+	for (auto &grouping_set : grouping_sets) {
+		radix_tables.emplace_back(grouping_set, *this);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class HashAggregateGlobalState : public GlobalSinkState {
+public:
+	HashAggregateGlobalState(const PhysicalHashAggregate &op, ClientContext &context) {
+		radix_states.reserve(op.radix_tables.size());
+		for (auto &rt : op.radix_tables) {
+			radix_states.push_back(rt.GetGlobalSinkState(context));
+		}
+	}
+
+	vector<unique_ptr<GlobalSinkState>> radix_states;
+};
+
+class HashAggregateLocalState : public LocalSinkState {
+public:
+	HashAggregateLocalState(const PhysicalHashAggregate &op, ExecutionContext &context) {
+		if (!op.payload_types.empty()) {
+			aggregate_input_chunk.InitializeEmpty(op.payload_types);
+		}
+
+		radix_states.reserve(op.radix_tables.size());
+		for (auto &rt : op.radix_tables) {
+			radix_states.push_back(rt.GetLocalSinkState(context));
+		}
+	}
+
+	DataChunk aggregate_input_chunk;
+
+	vector<unique_ptr<LocalSinkState>> radix_states;
+};
+
+void PhysicalHashAggregate::SetMultiScan(GlobalSinkState &state) {
+	auto &gstate = (HashAggregateGlobalState &)state;
+	for (auto &radix_state : gstate.radix_states) {
+		RadixPartitionedHashTable::SetMultiScan(*radix_state);
+	}
+}
+
+unique_ptr<GlobalSinkState> PhysicalHashAggregate::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<HashAggregateGlobalState>(*this, context);
+}
+
+unique_ptr<LocalSinkState> PhysicalHashAggregate::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<HashAggregateLocalState>(*this, context);
+}
+
+SinkResultType PhysicalHashAggregate::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                           DataChunk &input) const {
+	auto &llstate = (HashAggregateLocalState &)lstate;
+	auto &gstate = (HashAggregateGlobalState &)state;
+
+	DataChunk &aggregate_input_chunk = llstate.aggregate_input_chunk;
+
+	idx_t aggregate_input_idx = 0;
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		for (auto &child_expr : aggr.children) {
+			D_ASSERT(child_expr->type == ExpressionType::BOUND_REF);
+			auto &bound_ref_expr = (BoundReferenceExpression &)*child_expr;
+			D_ASSERT(bound_ref_expr.index < input.data.size());
+			aggregate_input_chunk.data[aggregate_input_idx++].Reference(input.data[bound_ref_expr.index]);
+		}
+	}
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		if (aggr.filter) {
+			auto it = filter_indexes.find(aggr.filter.get());
+			D_ASSERT(it != filter_indexes.end());
+			D_ASSERT(it->second < input.data.size());
+			aggregate_input_chunk.data[aggregate_input_idx++].Reference(input.data[it->second]);
+		}
+	}
+
+	aggregate_input_chunk.SetCardinality(input.size());
+	aggregate_input_chunk.Verify();
+
+	for (idx_t i = 0; i < radix_tables.size(); i++) {
+		radix_tables[i].Sink(context, *gstate.radix_states[i], *llstate.radix_states[i], input, aggregate_input_chunk);
+	}
+
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalHashAggregate::Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate) const {
+	auto &gstate = (HashAggregateGlobalState &)state;
+	auto &llstate = (HashAggregateLocalState &)lstate;
+
+	for (idx_t i = 0; i < radix_tables.size(); i++) {
+		radix_tables[i].Combine(context, *gstate.radix_states[i], *llstate.radix_states[i]);
+	}
+}
+
+class HashAggregateFinalizeEvent : public Event {
+public:
+	HashAggregateFinalizeEvent(const PhysicalHashAggregate &op_p, HashAggregateGlobalState &gstate_p,
+	                           Pipeline *pipeline_p)
+	    : Event(pipeline_p->executor), op(op_p), gstate(gstate_p), pipeline(pipeline_p) {
+	}
+
+	const PhysicalHashAggregate &op;
+	HashAggregateGlobalState &gstate;
+	Pipeline *pipeline;
+
+public:
+	void Schedule() override {
+		vector<unique_ptr<Task>> tasks;
+		for (idx_t i = 0; i < op.radix_tables.size(); i++) {
+			op.radix_tables[i].ScheduleTasks(pipeline->executor, shared_from_this(), *gstate.radix_states[i], tasks);
+		}
+		D_ASSERT(!tasks.empty());
+		SetTasks(move(tasks));
+	}
+};
+
+SinkFinalizeType PhysicalHashAggregate::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                 GlobalSinkState &gstate_p) const {
+	auto &gstate = (HashAggregateGlobalState &)gstate_p;
+	bool any_partitioned = false;
+	for (idx_t i = 0; i < gstate.radix_states.size(); i++) {
+		bool is_partitioned = radix_tables[i].Finalize(context, *gstate.radix_states[i]);
+		if (is_partitioned) {
+			any_partitioned = true;
+		}
+	}
+	if (any_partitioned) {
+		auto new_event = make_shared<HashAggregateFinalizeEvent>(*this, gstate, &pipeline);
+		event.InsertEvent(move(new_event));
+	}
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class PhysicalHashAggregateState : public GlobalSourceState {
+public:
+	explicit PhysicalHashAggregateState(const PhysicalHashAggregate &op) : scan_index(0) {
+		for (auto &rt : op.radix_tables) {
+			radix_states.push_back(rt.GetGlobalSourceState());
+		}
+	}
+
+	idx_t scan_index;
+
+	vector<unique_ptr<GlobalSourceState>> radix_states;
+};
+
+unique_ptr<GlobalSourceState> PhysicalHashAggregate::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<PhysicalHashAggregateState>(*this);
+}
+
+void PhysicalHashAggregate::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                    LocalSourceState &lstate) const {
+	auto &gstate = (HashAggregateGlobalState &)*sink_state;
+	auto &state = (PhysicalHashAggregateState &)gstate_p;
+	while (state.scan_index < state.radix_states.size()) {
+		radix_tables[state.scan_index].GetData(context, chunk, *gstate.radix_states[state.scan_index],
+		                                       *state.radix_states[state.scan_index]);
+		if (chunk.size() != 0) {
+			return;
+		}
+
+		state.scan_index++;
+	}
+}
+
+string PhysicalHashAggregate::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < groups.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += groups[i]->GetName();
+	}
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[i];
+		if (i > 0 || !groups.empty()) {
+			result += "\n";
+		}
+		result += aggregates[i]->GetName();
+		if (aggregate.filter) {
+			result += " Filter: " + aggregate.filter->GetName();
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalPerfectHashAggregate::PhysicalPerfectHashAggregate(ClientContext &context, vector<LogicalType> types_p,
+                                                           vector<unique_ptr<Expression>> aggregates_p,
+                                                           vector<unique_ptr<Expression>> groups_p,
+                                                           vector<unique_ptr<BaseStatistics>> group_stats,
+                                                           vector<idx_t> required_bits_p, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::PERFECT_HASH_GROUP_BY, move(types_p), estimated_cardinality),
+      groups(move(groups_p)), aggregates(move(aggregates_p)), required_bits(move(required_bits_p)) {
+	D_ASSERT(groups.size() == group_stats.size());
+	group_minima.reserve(group_stats.size());
+	for (auto &stats : group_stats) {
+		D_ASSERT(stats);
+		auto &nstats = (NumericStatistics &)*stats;
+		D_ASSERT(!nstats.min.IsNull());
+		group_minima.push_back(move(nstats.min));
+	}
+	for (auto &expr : groups) {
+		group_types.push_back(expr->return_type);
+	}
+
+	vector<BoundAggregateExpression *> bindings;
+	vector<LogicalType> payload_types_filters;
+	for (auto &expr : aggregates) {
+		D_ASSERT(expr->expression_class == ExpressionClass::BOUND_AGGREGATE);
+		D_ASSERT(expr->IsAggregate());
+		auto &aggr = (BoundAggregateExpression &)*expr;
+		bindings.push_back(&aggr);
+
+		D_ASSERT(!aggr.distinct);
+		D_ASSERT(aggr.function.combine);
+		for (auto &child : aggr.children) {
+			payload_types.push_back(child->return_type);
+		}
+		if (aggr.filter) {
+			payload_types_filters.push_back(aggr.filter->return_type);
+		}
+	}
+	for (const auto &pay_filters : payload_types_filters) {
+		payload_types.push_back(pay_filters);
+	}
+	aggregate_objects = AggregateObject::CreateAggregateObjects(bindings);
+
+	// filter_indexes must be pre-built, not lazily instantiated in parallel...
+	idx_t aggregate_input_idx = 0;
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		aggregate_input_idx += aggr.children.size();
+	}
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		if (aggr.filter) {
+			auto &bound_ref_expr = (BoundReferenceExpression &)*aggr.filter;
+			auto it = filter_indexes.find(aggr.filter.get());
+			if (it == filter_indexes.end()) {
+				filter_indexes[aggr.filter.get()] = bound_ref_expr.index;
+				bound_ref_expr.index = aggregate_input_idx++;
+			} else {
+				++aggregate_input_idx;
+			}
+		}
+	}
+}
+
+unique_ptr<PerfectAggregateHashTable> PhysicalPerfectHashAggregate::CreateHT(ClientContext &context) const {
+	return make_unique<PerfectAggregateHashTable>(BufferManager::GetBufferManager(context), group_types, payload_types,
+	                                              aggregate_objects, group_minima, required_bits);
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class PerfectHashAggregateGlobalState : public GlobalSinkState {
+public:
+	PerfectHashAggregateGlobalState(const PhysicalPerfectHashAggregate &op, ClientContext &context)
+	    : ht(op.CreateHT(context)) {
+	}
+
+	//! The lock for updating the global aggregate state
+	mutex lock;
+	//! The global aggregate hash table
+	unique_ptr<PerfectAggregateHashTable> ht;
+};
+
+class PerfectHashAggregateLocalState : public LocalSinkState {
+public:
+	PerfectHashAggregateLocalState(const PhysicalPerfectHashAggregate &op, ClientContext &context)
+	    : ht(op.CreateHT(context)) {
+		group_chunk.InitializeEmpty(op.group_types);
+		if (!op.payload_types.empty()) {
+			aggregate_input_chunk.InitializeEmpty(op.payload_types);
+		}
+	}
+
+	//! The local aggregate hash table
+	unique_ptr<PerfectAggregateHashTable> ht;
+	DataChunk group_chunk;
+	DataChunk aggregate_input_chunk;
+};
+
+unique_ptr<GlobalSinkState> PhysicalPerfectHashAggregate::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<PerfectHashAggregateGlobalState>(*this, context);
+}
+
+unique_ptr<LocalSinkState> PhysicalPerfectHashAggregate::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<PerfectHashAggregateLocalState>(*this, context.client);
+}
+
+SinkResultType PhysicalPerfectHashAggregate::Sink(ExecutionContext &context, GlobalSinkState &state,
+                                                  LocalSinkState &lstate_p, DataChunk &input) const {
+	auto &lstate = (PerfectHashAggregateLocalState &)lstate_p;
+	DataChunk &group_chunk = lstate.group_chunk;
+	DataChunk &aggregate_input_chunk = lstate.aggregate_input_chunk;
+
+	for (idx_t group_idx = 0; group_idx < groups.size(); group_idx++) {
+		auto &group = groups[group_idx];
+		D_ASSERT(group->type == ExpressionType::BOUND_REF);
+		auto &bound_ref_expr = (BoundReferenceExpression &)*group;
+		group_chunk.data[group_idx].Reference(input.data[bound_ref_expr.index]);
+	}
+	idx_t aggregate_input_idx = 0;
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		for (auto &child_expr : aggr.children) {
+			D_ASSERT(child_expr->type == ExpressionType::BOUND_REF);
+			auto &bound_ref_expr = (BoundReferenceExpression &)*child_expr;
+			aggregate_input_chunk.data[aggregate_input_idx++].Reference(input.data[bound_ref_expr.index]);
+		}
+	}
+	for (auto &aggregate : aggregates) {
+		auto &aggr = (BoundAggregateExpression &)*aggregate;
+		if (aggr.filter) {
+			auto it = filter_indexes.find(aggr.filter.get());
+			D_ASSERT(it != filter_indexes.end());
+			aggregate_input_chunk.data[aggregate_input_idx++].Reference(input.data[it->second]);
+		}
+	}
+
+	group_chunk.SetCardinality(input.size());
+
+	aggregate_input_chunk.SetCardinality(input.size());
+
+	group_chunk.Verify();
+	aggregate_input_chunk.Verify();
+	D_ASSERT(aggregate_input_chunk.ColumnCount() == 0 || group_chunk.size() == aggregate_input_chunk.size());
+
+	lstate.ht->AddChunk(group_chunk, aggregate_input_chunk);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Combine
+//===--------------------------------------------------------------------===//
+void PhysicalPerfectHashAggregate::Combine(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                           LocalSinkState &lstate_p) const {
+	auto &lstate = (PerfectHashAggregateLocalState &)lstate_p;
+	auto &gstate = (PerfectHashAggregateGlobalState &)gstate_p;
+
+	lock_guard<mutex> l(gstate.lock);
+	gstate.ht->Combine(*lstate.ht);
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class PerfectHashAggregateState : public GlobalSourceState {
+public:
+	PerfectHashAggregateState() : ht_scan_position(0) {
+	}
+
+	//! The current position to scan the HT for output tuples
+	idx_t ht_scan_position;
+};
+
+unique_ptr<GlobalSourceState> PhysicalPerfectHashAggregate::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<PerfectHashAggregateState>();
+}
+
+void PhysicalPerfectHashAggregate::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                           LocalSourceState &lstate) const {
+	auto &state = (PerfectHashAggregateState &)gstate_p;
+	auto &gstate = (PerfectHashAggregateGlobalState &)*sink_state;
+
+	gstate.ht->Scan(state.ht_scan_position, chunk);
+}
+
+string PhysicalPerfectHashAggregate::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < groups.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += groups[i]->GetName();
+	}
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		if (i > 0 || !groups.empty()) {
+			result += "\n";
+		}
+		result += aggregates[i]->GetName();
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[i];
+		if (aggregate.filter) {
+			result += " Filter: " + aggregate.filter->GetName();
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalSimpleAggregate::PhysicalSimpleAggregate(vector<LogicalType> types, vector<unique_ptr<Expression>> expressions,
+                                                 idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::SIMPLE_AGGREGATE, move(types), estimated_cardinality),
+      aggregates(move(expressions)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+struct AggregateState {
+	explicit AggregateState(const vector<unique_ptr<Expression>> &aggregate_expressions) {
+		for (auto &aggregate : aggregate_expressions) {
+			D_ASSERT(aggregate->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
+			auto &aggr = (BoundAggregateExpression &)*aggregate;
+			auto state = unique_ptr<data_t[]>(new data_t[aggr.function.state_size()]);
+			aggr.function.initialize(state.get());
+			aggregates.push_back(move(state));
+			destructors.push_back(aggr.function.destructor);
+		}
+	}
+	~AggregateState() {
+		D_ASSERT(destructors.size() == aggregates.size());
+		for (idx_t i = 0; i < destructors.size(); i++) {
+			if (!destructors[i]) {
+				continue;
+			}
+			Vector state_vector(Value::POINTER((uintptr_t)aggregates[i].get()));
+			state_vector.SetVectorType(VectorType::FLAT_VECTOR);
+
+			destructors[i](state_vector, 1);
+		}
+	}
+
+	void Move(AggregateState &other) {
+		other.aggregates = move(aggregates);
+		other.destructors = move(destructors);
+	}
+
+	//! The aggregate values
+	vector<unique_ptr<data_t[]>> aggregates;
+	// The destructors
+	vector<aggregate_destructor_t> destructors;
+};
+
+class SimpleAggregateGlobalState : public GlobalSinkState {
+public:
+	explicit SimpleAggregateGlobalState(const vector<unique_ptr<Expression>> &aggregates)
+	    : state(aggregates), finished(false) {
+	}
+
+	//! The lock for updating the global aggregate state
+	mutex lock;
+	//! The global aggregate state
+	AggregateState state;
+	//! Whether or not the aggregate is finished
+	bool finished;
+};
+
+class SimpleAggregateLocalState : public LocalSinkState {
+public:
+	explicit SimpleAggregateLocalState(const vector<unique_ptr<Expression>> &aggregates) : state(aggregates) {
+		vector<LogicalType> payload_types;
+		for (auto &aggregate : aggregates) {
+			D_ASSERT(aggregate->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
+			auto &aggr = (BoundAggregateExpression &)*aggregate;
+			// initialize the payload chunk
+			if (!aggr.children.empty()) {
+				for (auto &child : aggr.children) {
+					payload_types.push_back(child->return_type);
+					child_executor.AddExpression(*child);
+				}
+			}
+		}
+		if (!payload_types.empty()) { // for select count(*) from t; there is no payload at all
+			payload_chunk.Initialize(payload_types);
+		}
+	}
+	void Reset() {
+		payload_chunk.Reset();
+	}
+
+	//! The local aggregate state
+	AggregateState state;
+	//! The executor
+	ExpressionExecutor child_executor;
+	//! The payload chunk
+	DataChunk payload_chunk;
+};
+
+unique_ptr<GlobalSinkState> PhysicalSimpleAggregate::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<SimpleAggregateGlobalState>(aggregates);
+}
+
+unique_ptr<LocalSinkState> PhysicalSimpleAggregate::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<SimpleAggregateLocalState>(aggregates);
+}
+
+SinkResultType PhysicalSimpleAggregate::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                             DataChunk &input) const {
+	auto &sink = (SimpleAggregateLocalState &)lstate;
+	// perform the aggregation inside the local state
+	idx_t payload_idx = 0, payload_expr_idx = 0;
+	sink.Reset();
+
+	DataChunk &payload_chunk = sink.payload_chunk;
+	for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
+		DataChunk filtered_input;
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[aggr_idx];
+		idx_t payload_cnt = 0;
+		// resolve the filter (if any)
+		if (aggregate.filter) {
+			ExpressionExecutor filter_execution(aggregate.filter.get());
+			SelectionVector true_sel(STANDARD_VECTOR_SIZE);
+			auto count = filter_execution.SelectExpression(input, true_sel);
+			auto input_types = input.GetTypes();
+			filtered_input.Initialize(input_types);
+			filtered_input.Slice(input, true_sel, count);
+			sink.child_executor.SetChunk(filtered_input);
+			payload_chunk.SetCardinality(count);
+		} else {
+			sink.child_executor.SetChunk(input);
+			payload_chunk.SetCardinality(input);
+		}
+		// resolve the child expressions of the aggregate (if any)
+		if (!aggregate.children.empty()) {
+			for (idx_t i = 0; i < aggregate.children.size(); ++i) {
+				sink.child_executor.ExecuteExpression(payload_expr_idx, payload_chunk.data[payload_idx + payload_cnt]);
+				payload_expr_idx++;
+				payload_cnt++;
+			}
+		}
+
+		AggregateInputData aggr_input_data(aggregate.bind_info.get());
+		aggregate.function.simple_update(payload_cnt == 0 ? nullptr : &payload_chunk.data[payload_idx], aggr_input_data,
+		                                 payload_cnt, sink.state.aggregates[aggr_idx].get(), payload_chunk.size());
+		payload_idx += payload_cnt;
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+void PhysicalSimpleAggregate::Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate) const {
+	auto &gstate = (SimpleAggregateGlobalState &)state;
+	auto &source = (SimpleAggregateLocalState &)lstate;
+	D_ASSERT(!gstate.finished);
+
+	// finalize: combine the local state into the global state
+	// all aggregates are combinable: we might be doing a parallel aggregate
+	// use the combine method to combine the partial aggregates
+	lock_guard<mutex> glock(gstate.lock);
+	for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[aggr_idx];
+		Vector source_state(Value::POINTER((uintptr_t)source.state.aggregates[aggr_idx].get()));
+		Vector dest_state(Value::POINTER((uintptr_t)gstate.state.aggregates[aggr_idx].get()));
+
+		AggregateInputData aggr_input_data(aggregate.bind_info.get());
+		aggregate.function.combine(source_state, dest_state, aggr_input_data, 1);
+	}
+
+	auto &client_profiler = QueryProfiler::Get(context.client);
+	context.thread.profiler.Flush(this, &source.child_executor, "child_executor", 0);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+SinkFinalizeType PhysicalSimpleAggregate::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                   GlobalSinkState &gstate_p) const {
+	auto &gstate = (SimpleAggregateGlobalState &)gstate_p;
+
+	D_ASSERT(!gstate.finished);
+	gstate.finished = true;
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class SimpleAggregateState : public GlobalSourceState {
+public:
+	SimpleAggregateState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalSimpleAggregate::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<SimpleAggregateState>();
+}
+
+void PhysicalSimpleAggregate::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                      LocalSourceState &lstate) const {
+	auto &gstate = (SimpleAggregateGlobalState &)*sink_state;
+	auto &state = (SimpleAggregateState &)gstate_p;
+	D_ASSERT(gstate.finished);
+	if (state.finished) {
+		return;
+	}
+
+	// initialize the result chunk with the aggregate values
+	chunk.SetCardinality(1);
+	for (idx_t aggr_idx = 0; aggr_idx < aggregates.size(); aggr_idx++) {
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[aggr_idx];
+
+		Vector state_vector(Value::POINTER((uintptr_t)gstate.state.aggregates[aggr_idx].get()));
+		AggregateInputData aggr_input_data(aggregate.bind_info.get());
+		aggregate.function.finalize(state_vector, aggr_input_data, chunk.data[aggr_idx], 1, 0);
+	}
+	state.finished = true;
+}
+
+string PhysicalSimpleAggregate::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < aggregates.size(); i++) {
+		auto &aggregate = (BoundAggregateExpression &)*aggregates[i];
+		if (i > 0) {
+			result += "\n";
+		}
+		result += aggregates[i]->GetName();
+		if (aggregate.filter) {
+			result += " Filter: " + aggregate.filter->GetName();
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalStreamingWindow::PhysicalStreamingWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                                                 idx_t estimated_cardinality, PhysicalOperatorType type)
+    : PhysicalOperator(type, move(types), estimated_cardinality), select_list(move(select_list)) {
+}
+
+class StreamingWindowGlobalState : public GlobalOperatorState {
+public:
+	StreamingWindowGlobalState() : row_number(1) {
+	}
+
+	//! The next row number.
+	std::atomic<int64_t> row_number;
+};
+
+class StreamingWindowState : public OperatorState {
+public:
+	StreamingWindowState() : initialized(false) {
+	}
+
+	void Initialize(DataChunk &input, const vector<unique_ptr<Expression>> &expressions) {
+		for (idx_t expr_idx = 0; expr_idx < expressions.size(); expr_idx++) {
+			auto &expr = *expressions[expr_idx];
+			switch (expr.GetExpressionType()) {
+			case ExpressionType::WINDOW_FIRST_VALUE: {
+				auto &wexpr = (BoundWindowExpression &)expr;
+				auto &ref = (BoundReferenceExpression &)*wexpr.children[0];
+				const_vectors.push_back(make_unique<Vector>(input.data[ref.index].GetValue(0)));
+				break;
+			}
+			case ExpressionType::WINDOW_PERCENT_RANK: {
+				const_vectors.push_back(make_unique<Vector>(Value((double)0)));
+				break;
+			}
+			case ExpressionType::WINDOW_RANK:
+			case ExpressionType::WINDOW_RANK_DENSE: {
+				const_vectors.push_back(make_unique<Vector>(Value((int64_t)1)));
+				break;
+			}
+			default:
+				const_vectors.push_back(nullptr);
+			}
+		}
+		initialized = true;
+	}
+
+public:
+	bool initialized;
+	vector<unique_ptr<Vector>> const_vectors;
+};
+
+unique_ptr<GlobalOperatorState> PhysicalStreamingWindow::GetGlobalOperatorState(ClientContext &context) const {
+	return make_unique<StreamingWindowGlobalState>();
+}
+
+unique_ptr<OperatorState> PhysicalStreamingWindow::GetOperatorState(ClientContext &context) const {
+	return make_unique<StreamingWindowState>();
+}
+
+OperatorResultType PhysicalStreamingWindow::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                    GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	auto &gstate = (StreamingWindowGlobalState &)gstate_p;
+	auto &state = (StreamingWindowState &)state_p;
+	if (!state.initialized) {
+		state.Initialize(input, select_list);
+	}
+	// Put payload columns in place
+	for (idx_t col_idx = 0; col_idx < input.data.size(); col_idx++) {
+		chunk.data[col_idx].Reference(input.data[col_idx]);
+	}
+	// Compute window function
+	const idx_t count = input.size();
+	for (idx_t expr_idx = 0; expr_idx < select_list.size(); expr_idx++) {
+		idx_t col_idx = input.data.size() + expr_idx;
+		auto &expr = *select_list[expr_idx];
+		switch (expr.GetExpressionType()) {
+		case ExpressionType::WINDOW_FIRST_VALUE:
+		case ExpressionType::WINDOW_PERCENT_RANK:
+		case ExpressionType::WINDOW_RANK:
+		case ExpressionType::WINDOW_RANK_DENSE: {
+			// Reference constant vector
+			chunk.data[col_idx].Reference(*state.const_vectors[expr_idx]);
+			break;
+		}
+		case ExpressionType::WINDOW_ROW_NUMBER: {
+			// Set row numbers
+			auto rdata = FlatVector::GetData<int64_t>(chunk.data[col_idx]);
+			for (idx_t i = 0; i < count; i++) {
+				rdata[i] = gstate.row_number + i;
+			}
+			break;
+		}
+		default:
+			throw NotImplementedException("%s for StreamingWindow", ExpressionTypeToString(expr.GetExpressionType()));
+		}
+	}
+	gstate.row_number += count;
+	chunk.SetCardinality(count);
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+string PhysicalStreamingWindow::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < select_list.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += select_list[i]->GetName();
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+
+namespace duckdb {
+
+using counts_t = std::vector<size_t>;
+
+//	Global sink state
+class WindowGlobalState : public GlobalSinkState {
+public:
+	WindowGlobalState(const PhysicalWindow &op_p, ClientContext &context)
+	    : op(op_p), buffer_manager(BufferManager::GetBufferManager(context)),
+	      mode(DBConfig::GetConfig(context).window_mode) {
+	}
+	const PhysicalWindow &op;
+	BufferManager &buffer_manager;
+	mutex lock;
+	ChunkCollection chunks;
+	ChunkCollection over_collection;
+	ChunkCollection hash_collection;
+	counts_t counts;
+	WindowAggregationMode mode;
+};
+
+//	Per-thread sink state
+class WindowLocalState : public LocalSinkState {
+public:
+	explicit WindowLocalState(const PhysicalWindow &op_p, const unsigned partition_bits = 10)
+	    : op(op_p), partition_count(size_t(1) << partition_bits) {
+	}
+
+	const PhysicalWindow &op;
+	ChunkCollection chunks;
+	ChunkCollection over_collection;
+	ChunkCollection hash_collection;
+	const size_t partition_count;
+	counts_t counts;
+};
+
+// Per-thread read state
+class WindowOperatorState : public LocalSourceState {
+public:
+	WindowOperatorState(const PhysicalWindow &op, ExecutionContext &context)
+	    : buffer_manager(BufferManager::GetBufferManager(context.client)) {
+		auto &gstate = (WindowGlobalState &)*op.sink_state;
+		// initialize thread-local operator state
+		partitions = gstate.counts.size();
+		next_part = 0;
+		position = 0;
+	}
+
+	//! The number of partitions to process (0 if there is no partitioning)
+	size_t partitions;
+	//! The output read position.
+	size_t next_part;
+	//! The generated input chunks
+	ChunkCollection chunks;
+	//! The generated output chunks
+	ChunkCollection window_results;
+	//! The read cursor
+	idx_t position;
+
+	BufferManager &buffer_manager;
+	unique_ptr<GlobalSortState> global_sort_state;
+};
+
+// this implements a sorted window functions variant
+PhysicalWindow::PhysicalWindow(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                               idx_t estimated_cardinality, PhysicalOperatorType type)
+    : PhysicalOperator(type, move(types), estimated_cardinality), select_list(move(select_list)) {
+}
+
+template <typename INPUT_TYPE>
+struct ChunkIterator {
+
+	ChunkIterator(ChunkCollection &collection, const idx_t col_idx)
+	    : collection(collection), col_idx(col_idx), chunk_begin(0), chunk_end(0), ch_idx(0), data(nullptr),
+	      validity(nullptr) {
+		Update(0);
+	}
+
+	inline void Update(idx_t r) {
+		if (r >= chunk_end) {
+			ch_idx = collection.LocateChunk(r);
+			auto &ch = collection.GetChunk(ch_idx);
+			chunk_begin = ch_idx * STANDARD_VECTOR_SIZE;
+			chunk_end = chunk_begin + ch.size();
+			auto &vector = ch.data[col_idx];
+			data = FlatVector::GetData<INPUT_TYPE>(vector);
+			validity = &FlatVector::Validity(vector);
+		}
+	}
+
+	inline bool IsValid(idx_t r) {
+		return validity->RowIsValid(r - chunk_begin);
+	}
+
+	inline INPUT_TYPE GetValue(idx_t r) {
+		return data[r - chunk_begin];
+	}
+
+private:
+	ChunkCollection &collection;
+	idx_t col_idx;
+	idx_t chunk_begin;
+	idx_t chunk_end;
+	idx_t ch_idx;
+	const INPUT_TYPE *data;
+	ValidityMask *validity;
+};
+
+template <typename INPUT_TYPE>
+static void MaskTypedColumn(ValidityMask &mask, ChunkCollection &over_collection, const idx_t c) {
+	ChunkIterator<INPUT_TYPE> ci(over_collection, c);
+
+	//	Record the first value
+	idx_t r = 0;
+	auto prev_valid = ci.IsValid(r);
+	auto prev = ci.GetValue(r);
+
+	//	Process complete blocks
+	const auto count = over_collection.Count();
+	const auto entry_count = mask.EntryCount(count);
+	for (idx_t entry_idx = 0; entry_idx < entry_count; ++entry_idx) {
+		auto validity_entry = mask.GetValidityEntry(entry_idx);
+
+		//	Skip the block if it is all boundaries.
+		idx_t next = MinValue<idx_t>(r + ValidityMask::BITS_PER_VALUE, count);
+		if (ValidityMask::AllValid(validity_entry)) {
+			r = next;
+			continue;
+		}
+
+		//	Scan the rows in the complete block
+		idx_t start = r;
+		for (; r < next; ++r) {
+			//	Update the chunk for this row
+			ci.Update(r);
+
+			auto curr_valid = ci.IsValid(r);
+			auto curr = ci.GetValue(r);
+			if (!ValidityMask::RowIsValid(validity_entry, r - start)) {
+				if (curr_valid != prev_valid || (curr_valid && !Equals::Operation(curr, prev))) {
+					mask.SetValidUnsafe(r);
+				}
+			}
+			prev_valid = curr_valid;
+			prev = curr;
+		}
+	}
+}
+
+static void MaskColumn(ValidityMask &mask, ChunkCollection &over_collection, const idx_t c) {
+	auto &vector = over_collection.GetChunk(0).data[c];
+	switch (vector.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		MaskTypedColumn<int8_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::INT16:
+		MaskTypedColumn<int16_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::INT32:
+		MaskTypedColumn<int32_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::INT64:
+		MaskTypedColumn<int64_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::UINT8:
+		MaskTypedColumn<uint8_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::UINT16:
+		MaskTypedColumn<uint16_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::UINT32:
+		MaskTypedColumn<uint32_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::UINT64:
+		MaskTypedColumn<uint64_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::INT128:
+		MaskTypedColumn<hugeint_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::FLOAT:
+		MaskTypedColumn<float>(mask, over_collection, c);
+		break;
+	case PhysicalType::DOUBLE:
+		MaskTypedColumn<double>(mask, over_collection, c);
+		break;
+	case PhysicalType::VARCHAR:
+		MaskTypedColumn<string_t>(mask, over_collection, c);
+		break;
+	case PhysicalType::INTERVAL:
+		MaskTypedColumn<interval_t>(mask, over_collection, c);
+		break;
+	default:
+		throw NotImplementedException("Type for comparison");
+		break;
+	}
+}
+
+static idx_t FindNextStart(const ValidityMask &mask, idx_t l, const idx_t r, idx_t &n) {
+	if (mask.AllValid()) {
+		auto start = MinValue(l + n - 1, r);
+		n -= MinValue(n, r - l);
+		return start;
+	}
+
+	while (l < r) {
+		//	If l is aligned with the start of a block, and the block is blank, then skip forward one block.
+		idx_t entry_idx;
+		idx_t shift;
+		mask.GetEntryIndex(l, entry_idx, shift);
+
+		const auto block = mask.GetValidityEntry(entry_idx);
+		if (mask.NoneValid(block) && !shift) {
+			l += ValidityMask::BITS_PER_VALUE;
+			continue;
+		}
+
+		// Loop over the block
+		for (; shift < ValidityMask::BITS_PER_VALUE && l < r; ++shift, ++l) {
+			if (mask.RowIsValid(block, shift) && --n == 0) {
+				return MinValue(l, r);
+			}
+		}
+	}
+
+	//	Didn't find a start so return the end of the range
+	return r;
+}
+
+static idx_t FindPrevStart(const ValidityMask &mask, const idx_t l, idx_t r, idx_t &n) {
+	if (mask.AllValid()) {
+		auto start = (r <= l + n) ? l : r - n;
+		n -= r - start;
+		return start;
+	}
+
+	while (l < r) {
+		// If r is aligned with the start of a block, and the previous block is blank,
+		// then skip backwards one block.
+		idx_t entry_idx;
+		idx_t shift;
+		mask.GetEntryIndex(r - 1, entry_idx, shift);
+
+		const auto block = mask.GetValidityEntry(entry_idx);
+		if (mask.NoneValid(block) && (shift + 1 == ValidityMask::BITS_PER_VALUE)) {
+			// r is nonzero (> l) and word aligned, so this will not underflow.
+			r -= ValidityMask::BITS_PER_VALUE;
+			continue;
+		}
+
+		// Loop backwards over the block
+		// shift is probing r-1 >= l >= 0
+		for (++shift; shift-- > 0; --r) {
+			if (mask.RowIsValid(block, shift) && --n == 0) {
+				return MaxValue(l, r - 1);
+			}
+		}
+	}
+
+	//	Didn't find a start so return the start of the range
+	return l;
+}
+
+static void MaterializeExpressions(Expression **exprs, idx_t expr_count, ChunkCollection &input,
+                                   ChunkCollection &output, bool scalar = false) {
+	if (expr_count == 0) {
+		return;
+	}
+
+	vector<LogicalType> types;
+	ExpressionExecutor executor;
+	for (idx_t expr_idx = 0; expr_idx < expr_count; ++expr_idx) {
+		types.push_back(exprs[expr_idx]->return_type);
+		executor.AddExpression(*exprs[expr_idx]);
+	}
+
+	for (idx_t i = 0; i < input.ChunkCount(); i++) {
+		DataChunk chunk;
+		chunk.Initialize(types);
+
+		executor.Execute(input.GetChunk(i), chunk);
+
+		chunk.Verify();
+		output.Append(chunk);
+
+		if (scalar) {
+			break;
+		}
+	}
+}
+
+static void MaterializeExpression(Expression *expr, ChunkCollection &input, ChunkCollection &output,
+                                  bool scalar = false) {
+	MaterializeExpressions(&expr, 1, input, output, scalar);
+}
+
+static void SortCollectionForPartition(WindowOperatorState &state, BoundWindowExpression *wexpr, ChunkCollection &input,
+                                       ChunkCollection &over, ChunkCollection *hashes, const hash_t hash_bin,
+                                       const hash_t hash_mask) {
+	if (input.Count() == 0) {
+		return;
+	}
+
+	vector<BoundOrderByNode> orders;
+	// we sort by both 1) partition by expression list and 2) order by expressions
+	for (idx_t prt_idx = 0; prt_idx < wexpr->partitions.size(); prt_idx++) {
+		if (wexpr->partitions_stats.empty() || !wexpr->partitions_stats[prt_idx]) {
+			orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST, wexpr->partitions[prt_idx]->Copy(),
+			                    nullptr);
+		} else {
+			orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_FIRST, wexpr->partitions[prt_idx]->Copy(),
+			                    wexpr->partitions_stats[prt_idx]->Copy());
+		}
+	}
+	for (const auto &order : wexpr->orders) {
+		orders.push_back(order.Copy());
+	}
+
+	// fuse input and sort collection into one
+	// (sorting columns are not decoded, and we need them later)
+	auto payload_types = input.Types();
+	payload_types.insert(payload_types.end(), over.Types().begin(), over.Types().end());
+	DataChunk payload_chunk;
+	payload_chunk.InitializeEmpty(payload_types);
+
+	// initialise partitioning memory
+	// to minimise copying, we fill up a chunk and then sink it.
+	SelectionVector sel;
+	DataChunk over_partition;
+	DataChunk payload_partition;
+	if (hashes) {
+		sel.Initialize(STANDARD_VECTOR_SIZE);
+		over_partition.Initialize(over.Types());
+		payload_partition.Initialize(payload_types);
+	}
+
+	// initialize row layout for sorting
+	RowLayout payload_layout;
+	payload_layout.Initialize(payload_types);
+
+	// initialize sorting states
+	state.global_sort_state = make_unique<GlobalSortState>(state.buffer_manager, orders, payload_layout);
+	auto &global_sort_state = *state.global_sort_state;
+	LocalSortState local_sort_state;
+	local_sort_state.Initialize(global_sort_state, state.buffer_manager);
+
+	// sink collection chunks into row format
+	const idx_t chunk_count = over.ChunkCount();
+	for (idx_t i = 0; i < chunk_count; i++) {
+		auto &input_chunk = *input.Chunks()[i];
+		for (idx_t col_idx = 0; col_idx < input_chunk.ColumnCount(); ++col_idx) {
+			payload_chunk.data[col_idx].Reference(input_chunk.data[col_idx]);
+		}
+		auto &over_chunk = *over.Chunks()[i];
+		for (idx_t col_idx = 0; col_idx < over_chunk.ColumnCount(); ++col_idx) {
+			payload_chunk.data[input_chunk.ColumnCount() + col_idx].Reference(over_chunk.data[col_idx]);
+		}
+		payload_chunk.SetCardinality(input_chunk);
+
+		// Extract the hash partition, if any
+		if (hashes) {
+			auto &hash_chunk = *hashes->Chunks()[i];
+			auto hash_size = hash_chunk.size();
+			auto hash_data = FlatVector::GetData<hash_t>(hash_chunk.data[0]);
+			idx_t bin_size = 0;
+			for (idx_t i = 0; i < hash_size; ++i) {
+				if ((hash_data[i] & hash_mask) == hash_bin) {
+					sel.set_index(bin_size++, i);
+				}
+			}
+
+			// Flush the partition chunks if we would overflow
+			if (over_partition.size() + bin_size > STANDARD_VECTOR_SIZE) {
+				local_sort_state.SinkChunk(over_partition, payload_partition);
+				over_partition.Reset();
+				payload_partition.Reset();
+			}
+
+			// Copy the data for each collection.
+			if (bin_size) {
+				over_partition.Append(over_chunk, false, &sel, bin_size);
+				payload_partition.Append(payload_chunk, false, &sel, bin_size);
+			}
+		} else {
+			local_sort_state.SinkChunk(over_chunk, payload_chunk);
+		}
+	}
+
+	// Flush any ragged partition chunks
+	if (over_partition.size() > 0) {
+		local_sort_state.SinkChunk(over_partition, payload_partition);
+		over_partition.Reset();
+		payload_partition.Reset();
+	}
+
+	// If there are no hashes, release the input to save memory.
+	if (!hashes) {
+		over.Reset();
+		input.Reset();
+	}
+
+	// add local state to global state, which sorts the data
+	global_sort_state.AddLocalState(local_sort_state);
+	// Prepare for merge phase (in this case we never have a merge phase, but this call is still needed)
+	global_sort_state.PrepareMergePhase();
+}
+
+static void ScanSortedPartition(WindowOperatorState &state, ChunkCollection &input,
+                                const vector<LogicalType> &input_types, ChunkCollection &over,
+                                const vector<LogicalType> &over_types) {
+	auto &global_sort_state = *state.global_sort_state;
+
+	auto payload_types = input_types;
+	payload_types.insert(payload_types.end(), over_types.begin(), over_types.end());
+
+	// scan the sorted row data
+	PayloadScanner scanner(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state);
+	for (;;) {
+		DataChunk payload_chunk;
+		payload_chunk.Initialize(payload_types);
+		payload_chunk.SetCardinality(0);
+		scanner.Scan(payload_chunk);
+		if (payload_chunk.size() == 0) {
+			break;
+		}
+
+		// split into two
+		DataChunk over_chunk;
+		payload_chunk.Split(over_chunk, input_types.size());
+
+		// append back to collection
+		input.Append(payload_chunk);
+		over.Append(over_chunk);
+	}
+}
+
+static void HashChunk(counts_t &counts, DataChunk &hash_chunk, DataChunk &sort_chunk, const idx_t partition_cols) {
+	const vector<LogicalType> hash_types(1, LogicalType::HASH);
+	hash_chunk.Initialize(hash_types);
+	hash_chunk.SetCardinality(sort_chunk);
+	auto &hash_vector = hash_chunk.data[0];
+
+	const auto count = sort_chunk.size();
+	VectorOperations::Hash(sort_chunk.data[0], hash_vector, count);
+	for (idx_t prt_idx = 1; prt_idx < partition_cols; ++prt_idx) {
+		VectorOperations::CombineHash(hash_vector, sort_chunk.data[prt_idx], count);
+	}
+
+	const auto partition_mask = hash_t(counts.size() - 1);
+	auto hashes = FlatVector::GetData<hash_t>(hash_vector);
+	if (hash_vector.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		const auto bin = (hashes[0] & partition_mask);
+		counts[bin] += count;
+	} else {
+		for (idx_t i = 0; i < count; ++i) {
+			const auto bin = (hashes[i] & partition_mask);
+			++counts[bin];
+		}
+	}
+}
+
+static void MaterializeOverForWindow(BoundWindowExpression *wexpr, DataChunk &input_chunk, DataChunk &over_chunk) {
+	vector<LogicalType> over_types;
+	ExpressionExecutor executor;
+
+	// we sort by both 1) partition by expression list and 2) order by expressions
+	for (idx_t prt_idx = 0; prt_idx < wexpr->partitions.size(); prt_idx++) {
+		auto &pexpr = wexpr->partitions[prt_idx];
+		over_types.push_back(pexpr->return_type);
+		executor.AddExpression(*pexpr);
+	}
+
+	for (idx_t ord_idx = 0; ord_idx < wexpr->orders.size(); ord_idx++) {
+		auto &oexpr = wexpr->orders[ord_idx].expression;
+		over_types.push_back(oexpr->return_type);
+		executor.AddExpression(*oexpr);
+	}
+
+	D_ASSERT(!over_types.empty());
+
+	over_chunk.Initialize(over_types);
+	executor.Execute(input_chunk, over_chunk);
+
+	over_chunk.Verify();
+}
+
+static inline bool BoundaryNeedsPeer(const WindowBoundary &boundary) {
+	switch (boundary) {
+	case WindowBoundary::CURRENT_ROW_RANGE:
+	case WindowBoundary::EXPR_PRECEDING_RANGE:
+	case WindowBoundary::EXPR_FOLLOWING_RANGE:
+		return true;
+	default:
+		return false;
+	}
+}
+
+struct WindowBoundariesState {
+	static inline bool IsScalar(const unique_ptr<Expression> &expr) {
+		return expr ? expr->IsScalar() : true;
+	}
+
+	explicit WindowBoundariesState(BoundWindowExpression *wexpr)
+	    : type(wexpr->type), start_boundary(wexpr->start), end_boundary(wexpr->end),
+	      partition_count(wexpr->partitions.size()), order_count(wexpr->orders.size()),
+	      range_sense(wexpr->orders.empty() ? OrderType::INVALID : wexpr->orders[0].type),
+	      scalar_start(IsScalar(wexpr->start_expr)), scalar_end(IsScalar(wexpr->end_expr)),
+	      has_preceding_range(wexpr->start == WindowBoundary::EXPR_PRECEDING_RANGE ||
+	                          wexpr->end == WindowBoundary::EXPR_PRECEDING_RANGE),
+	      has_following_range(wexpr->start == WindowBoundary::EXPR_FOLLOWING_RANGE ||
+	                          wexpr->end == WindowBoundary::EXPR_FOLLOWING_RANGE),
+	      needs_peer(BoundaryNeedsPeer(wexpr->end) || wexpr->type == ExpressionType::WINDOW_CUME_DIST) {
+	}
+
+	// Cached lookups
+	const ExpressionType type;
+	const WindowBoundary start_boundary;
+	const WindowBoundary end_boundary;
+	const idx_t partition_count;
+	const idx_t order_count;
+	const OrderType range_sense;
+	const bool scalar_start;
+	const bool scalar_end;
+	const bool has_preceding_range;
+	const bool has_following_range;
+	const bool needs_peer;
+
+	idx_t partition_start = 0;
+	idx_t partition_end = 0;
+	idx_t peer_start = 0;
+	idx_t peer_end = 0;
+	idx_t valid_start = 0;
+	idx_t valid_end = 0;
+	int64_t window_start = -1;
+	int64_t window_end = -1;
+	bool is_same_partition = false;
+	bool is_peer = false;
+};
+
+static bool WindowNeedsRank(BoundWindowExpression *wexpr) {
+	return wexpr->type == ExpressionType::WINDOW_PERCENT_RANK || wexpr->type == ExpressionType::WINDOW_RANK ||
+	       wexpr->type == ExpressionType::WINDOW_RANK_DENSE || wexpr->type == ExpressionType::WINDOW_CUME_DIST;
+}
+
+template <typename T>
+static T GetCell(ChunkCollection &collection, idx_t column, idx_t index) {
+	D_ASSERT(collection.ColumnCount() > column);
+	auto &chunk = collection.GetChunkForRow(index);
+	auto &source = chunk.data[column];
+	const auto source_offset = index % STANDARD_VECTOR_SIZE;
+	const auto data = FlatVector::GetData<T>(source);
+	return data[source_offset];
+}
+
+static bool CellIsNull(ChunkCollection &collection, idx_t column, idx_t index) {
+	D_ASSERT(collection.ColumnCount() > column);
+	auto &chunk = collection.GetChunkForRow(index);
+	auto &source = chunk.data[column];
+	const auto source_offset = index % STANDARD_VECTOR_SIZE;
+	return FlatVector::IsNull(source, source_offset);
+}
+
+template <typename T>
+struct ChunkCollectionIterator {
+	using iterator = ChunkCollectionIterator<T>;
+	using iterator_category = std::forward_iterator_tag;
+	using difference_type = std::ptrdiff_t;
+	using value_type = T;
+	using reference = T;
+	using pointer = idx_t;
+
+	ChunkCollectionIterator(ChunkCollection &coll_p, idx_t col_no_p, pointer pos_p = 0)
+	    : coll(&coll_p), col_no(col_no_p), pos(pos_p) {
+	}
+
+	inline reference operator*() const {
+		return GetCell<T>(*coll, col_no, pos);
+	}
+	inline explicit operator pointer() const {
+		return pos;
+	}
+
+	inline iterator &operator++() {
+		++pos;
+		return *this;
+	}
+	inline iterator operator++(int) {
+		auto result = *this;
+		++(*this);
+		return result;
+	}
+
+	friend inline bool operator==(const iterator &a, const iterator &b) {
+		return a.pos == b.pos;
+	}
+	friend inline bool operator!=(const iterator &a, const iterator &b) {
+		return a.pos != b.pos;
+	}
+
+private:
+	ChunkCollection *coll;
+	idx_t col_no;
+	pointer pos;
+};
+
+template <typename T, typename OP>
+struct OperationCompare : public std::function<bool(T, T)> {
+	inline bool operator()(const T &lhs, const T &val) const {
+		return OP::template Operation(lhs, val);
+	}
+};
+
+template <typename T, typename OP, bool FROM>
+static idx_t FindTypedRangeBound(ChunkCollection &over, const idx_t order_col, const idx_t order_begin,
+                                 const idx_t order_end, ChunkCollection &boundary, const idx_t boundary_row) {
+	D_ASSERT(!CellIsNull(boundary, 0, boundary_row));
+	const auto val = GetCell<T>(boundary, 0, boundary_row);
+
+	OperationCompare<T, OP> comp;
+	ChunkCollectionIterator<T> begin(over, order_col, order_begin);
+	ChunkCollectionIterator<T> end(over, order_col, order_end);
+	if (FROM) {
+		return idx_t(std::lower_bound(begin, end, val, comp));
+	} else {
+		return idx_t(std::upper_bound(begin, end, val, comp));
+	}
+}
+
+template <typename OP, bool FROM>
+static idx_t FindRangeBound(ChunkCollection &over, const idx_t order_col, const idx_t order_begin,
+                            const idx_t order_end, ChunkCollection &boundary, const idx_t expr_idx) {
+	const auto &over_types = over.Types();
+	D_ASSERT(over_types.size() > order_col);
+	D_ASSERT(boundary.Types().size() == 1);
+	D_ASSERT(boundary.Types()[0] == over_types[order_col]);
+
+	switch (over_types[order_col].InternalType()) {
+	case PhysicalType::INT8:
+		return FindTypedRangeBound<int8_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::INT16:
+		return FindTypedRangeBound<int16_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::INT32:
+		return FindTypedRangeBound<int32_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::INT64:
+		return FindTypedRangeBound<int64_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::UINT8:
+		return FindTypedRangeBound<uint8_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::UINT16:
+		return FindTypedRangeBound<uint16_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::UINT32:
+		return FindTypedRangeBound<uint32_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::UINT64:
+		return FindTypedRangeBound<uint64_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::INT128:
+		return FindTypedRangeBound<hugeint_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::FLOAT:
+		return FindTypedRangeBound<float, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::DOUBLE:
+		return FindTypedRangeBound<double, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case PhysicalType::INTERVAL:
+		return FindTypedRangeBound<interval_t, OP, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	default:
+		throw InternalException("Unsupported column type for RANGE");
+	}
+}
+
+template <bool FROM>
+static idx_t FindOrderedRangeBound(ChunkCollection &over, const idx_t order_col, const OrderType range_sense,
+                                   const idx_t order_begin, const idx_t order_end, ChunkCollection &boundary,
+                                   const idx_t expr_idx) {
+	switch (range_sense) {
+	case OrderType::ASCENDING:
+		return FindRangeBound<LessThan, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	case OrderType::DESCENDING:
+		return FindRangeBound<GreaterThan, FROM>(over, order_col, order_begin, order_end, boundary, expr_idx);
+	default:
+		throw InternalException("Unsupported ORDER BY sense for RANGE");
+	}
+}
+
+static void UpdateWindowBoundaries(WindowBoundariesState &bounds, const idx_t input_size, const idx_t row_idx,
+                                   ChunkCollection &over_collection, ChunkCollection &boundary_start_collection,
+                                   ChunkCollection &boundary_end_collection, const ValidityMask &partition_mask,
+                                   const ValidityMask &order_mask) {
+
+	// RANGE sorting parameters
+	const auto order_col = bounds.partition_count;
+
+	if (bounds.partition_count + bounds.order_count > 0) {
+
+		// determine partition and peer group boundaries to ultimately figure out window size
+		bounds.is_same_partition = !partition_mask.RowIsValidUnsafe(row_idx);
+		bounds.is_peer = !order_mask.RowIsValidUnsafe(row_idx);
+
+		// when the partition changes, recompute the boundaries
+		if (!bounds.is_same_partition) {
+			bounds.partition_start = row_idx;
+			bounds.peer_start = row_idx;
+
+			// find end of partition
+			bounds.partition_end = input_size;
+			if (bounds.partition_count) {
+				idx_t n = 1;
+				bounds.partition_end = FindNextStart(partition_mask, bounds.partition_start + 1, input_size, n);
+			}
+
+			// Find valid ordering values for the new partition
+			// so we can exclude NULLs from RANGE expression computations
+			bounds.valid_start = bounds.partition_start;
+			bounds.valid_end = bounds.partition_end;
+
+			if ((bounds.valid_start < bounds.valid_end) && bounds.has_preceding_range) {
+				// Exclude any leading NULLs
+				if (CellIsNull(over_collection, order_col, bounds.valid_start)) {
+					idx_t n = 1;
+					bounds.valid_start = FindNextStart(order_mask, bounds.valid_start + 1, bounds.valid_end, n);
+				}
+			}
+
+			if ((bounds.valid_start < bounds.valid_end) && bounds.has_following_range) {
+				// Exclude any trailing NULLs
+				if (CellIsNull(over_collection, order_col, bounds.valid_end - 1)) {
+					idx_t n = 1;
+					bounds.valid_end = FindPrevStart(order_mask, bounds.valid_start, bounds.valid_end, n);
+				}
+			}
+
+		} else if (!bounds.is_peer) {
+			bounds.peer_start = row_idx;
+		}
+
+		if (bounds.needs_peer) {
+			bounds.peer_end = bounds.partition_end;
+			if (bounds.order_count) {
+				idx_t n = 1;
+				bounds.peer_end = FindNextStart(order_mask, bounds.peer_start + 1, bounds.partition_end, n);
+			}
+		}
+
+	} else {
+		bounds.is_same_partition = false;
+		bounds.is_peer = true;
+		bounds.partition_end = input_size;
+		bounds.peer_end = bounds.partition_end;
+	}
+
+	// determine window boundaries depending on the type of expression
+	bounds.window_start = -1;
+	bounds.window_end = -1;
+
+	switch (bounds.start_boundary) {
+	case WindowBoundary::UNBOUNDED_PRECEDING:
+		bounds.window_start = bounds.partition_start;
+		break;
+	case WindowBoundary::CURRENT_ROW_ROWS:
+		bounds.window_start = row_idx;
+		break;
+	case WindowBoundary::CURRENT_ROW_RANGE:
+		bounds.window_start = bounds.peer_start;
+		break;
+	case WindowBoundary::EXPR_PRECEDING_ROWS: {
+		bounds.window_start =
+		    (int64_t)row_idx - GetCell<int64_t>(boundary_start_collection, 0, bounds.scalar_start ? 0 : row_idx);
+		break;
+	}
+	case WindowBoundary::EXPR_FOLLOWING_ROWS: {
+		bounds.window_start =
+		    row_idx + GetCell<int64_t>(boundary_start_collection, 0, bounds.scalar_start ? 0 : row_idx);
+		break;
+	}
+	case WindowBoundary::EXPR_PRECEDING_RANGE: {
+		const auto expr_idx = bounds.scalar_start ? 0 : row_idx;
+		if (CellIsNull(boundary_start_collection, 0, expr_idx)) {
+			bounds.window_start = bounds.peer_start;
+		} else {
+			bounds.window_start =
+			    FindOrderedRangeBound<true>(over_collection, order_col, bounds.range_sense, bounds.valid_start, row_idx,
+			                                boundary_start_collection, expr_idx);
+		}
+		break;
+	}
+	case WindowBoundary::EXPR_FOLLOWING_RANGE: {
+		const auto expr_idx = bounds.scalar_start ? 0 : row_idx;
+		if (CellIsNull(boundary_start_collection, 0, expr_idx)) {
+			bounds.window_start = bounds.peer_start;
+		} else {
+			bounds.window_start = FindOrderedRangeBound<true>(over_collection, order_col, bounds.range_sense, row_idx,
+			                                                  bounds.valid_end, boundary_start_collection, expr_idx);
+		}
+		break;
+	}
+	default:
+		throw InternalException("Unsupported window start boundary");
+	}
+
+	switch (bounds.end_boundary) {
+	case WindowBoundary::CURRENT_ROW_ROWS:
+		bounds.window_end = row_idx + 1;
+		break;
+	case WindowBoundary::CURRENT_ROW_RANGE:
+		bounds.window_end = bounds.peer_end;
+		break;
+	case WindowBoundary::UNBOUNDED_FOLLOWING:
+		bounds.window_end = bounds.partition_end;
+		break;
+	case WindowBoundary::EXPR_PRECEDING_ROWS:
+		bounds.window_end =
+		    (int64_t)row_idx - GetCell<int64_t>(boundary_end_collection, 0, bounds.scalar_end ? 0 : row_idx) + 1;
+		break;
+	case WindowBoundary::EXPR_FOLLOWING_ROWS:
+		bounds.window_end = row_idx + GetCell<int64_t>(boundary_end_collection, 0, bounds.scalar_end ? 0 : row_idx) + 1;
+		break;
+	case WindowBoundary::EXPR_PRECEDING_RANGE: {
+		const auto expr_idx = bounds.scalar_end ? 0 : row_idx;
+		if (CellIsNull(boundary_end_collection, 0, expr_idx)) {
+			bounds.window_end = bounds.peer_end;
+		} else {
+			bounds.window_end =
+			    FindOrderedRangeBound<false>(over_collection, order_col, bounds.range_sense, bounds.valid_start,
+			                                 row_idx, boundary_end_collection, expr_idx);
+		}
+		break;
+	}
+	case WindowBoundary::EXPR_FOLLOWING_RANGE: {
+		const auto expr_idx = bounds.scalar_end ? 0 : row_idx;
+		if (CellIsNull(boundary_end_collection, 0, expr_idx)) {
+			bounds.window_end = bounds.peer_end;
+		} else {
+			bounds.window_end = FindOrderedRangeBound<false>(over_collection, order_col, bounds.range_sense, row_idx,
+			                                                 bounds.valid_end, boundary_end_collection, expr_idx);
+		}
+		break;
+	}
+	default:
+		throw InternalException("Unsupported window end boundary");
+	}
+
+	// clamp windows to partitions if they should exceed
+	if (bounds.window_start < (int64_t)bounds.partition_start) {
+		bounds.window_start = bounds.partition_start;
+	}
+	if (bounds.window_start > (int64_t)bounds.partition_end) {
+		bounds.window_start = bounds.partition_end;
+	}
+	if (bounds.window_end < (int64_t)bounds.partition_start) {
+		bounds.window_end = bounds.partition_start;
+	}
+	if (bounds.window_end > (int64_t)bounds.partition_end) {
+		bounds.window_end = bounds.partition_end;
+	}
+
+	if (bounds.window_start < 0 || bounds.window_end < 0) {
+		throw InternalException("Failed to compute window boundaries");
+	}
+}
+
+static void ComputeWindowExpression(BoundWindowExpression *wexpr, ChunkCollection &input, ChunkCollection &output,
+                                    ChunkCollection &over, const ValidityMask &partition_mask,
+                                    const ValidityMask &order_mask, WindowAggregationMode mode) {
+
+	// TODO we could evaluate those expressions in parallel
+
+	// evaluate inner expressions of window functions, could be more complex
+	ChunkCollection payload_collection;
+	vector<Expression *> exprs;
+	for (auto &child : wexpr->children) {
+		exprs.push_back(child.get());
+	}
+	// TODO: child may be a scalar, don't need to materialize the whole collection then
+	MaterializeExpressions(exprs.data(), exprs.size(), input, payload_collection);
+
+	ChunkCollection leadlag_offset_collection;
+	ChunkCollection leadlag_default_collection;
+	if (wexpr->type == ExpressionType::WINDOW_LEAD || wexpr->type == ExpressionType::WINDOW_LAG) {
+		if (wexpr->offset_expr) {
+			MaterializeExpression(wexpr->offset_expr.get(), input, leadlag_offset_collection,
+			                      wexpr->offset_expr->IsScalar());
+		}
+		if (wexpr->default_expr) {
+			MaterializeExpression(wexpr->default_expr.get(), input, leadlag_default_collection,
+			                      wexpr->default_expr->IsScalar());
+		}
+	}
+
+	// evaluate the FILTER clause and stuff it into a large mask for compactness and reuse
+	ValidityMask filter_mask;
+	vector<validity_t> filter_bits;
+	if (wexpr->filter_expr) {
+		// 	Start with all invalid and set the ones that pass
+		filter_bits.resize(ValidityMask::ValidityMaskSize(input.Count()), 0);
+		filter_mask.Initialize(filter_bits.data());
+		ExpressionExecutor filter_execution(*wexpr->filter_expr);
+		SelectionVector true_sel(STANDARD_VECTOR_SIZE);
+		idx_t base_idx = 0;
+		for (auto &chunk : input.Chunks()) {
+			const auto filtered = filter_execution.SelectExpression(*chunk, true_sel);
+			for (idx_t f = 0; f < filtered; ++f) {
+				filter_mask.SetValid(base_idx + true_sel[f]);
+			}
+			base_idx += chunk->size();
+		}
+	}
+
+	// evaluate boundaries if present. Parser has checked boundary types.
+	ChunkCollection boundary_start_collection;
+	if (wexpr->start_expr) {
+		MaterializeExpression(wexpr->start_expr.get(), input, boundary_start_collection, wexpr->start_expr->IsScalar());
+	}
+
+	ChunkCollection boundary_end_collection;
+	if (wexpr->end_expr) {
+		MaterializeExpression(wexpr->end_expr.get(), input, boundary_end_collection, wexpr->end_expr->IsScalar());
+	}
+
+	// Set up a validity mask for IGNORE NULLS
+	ValidityMask ignore_nulls;
+	if (wexpr->ignore_nulls) {
+		switch (wexpr->type) {
+		case ExpressionType::WINDOW_LEAD:
+		case ExpressionType::WINDOW_LAG:
+		case ExpressionType::WINDOW_FIRST_VALUE:
+		case ExpressionType::WINDOW_LAST_VALUE:
+		case ExpressionType::WINDOW_NTH_VALUE: {
+			idx_t pos = 0;
+			for (auto &chunk : payload_collection.Chunks()) {
+				const auto count = chunk->size();
+				VectorData vdata;
+				chunk->data[0].Orrify(count, vdata);
+				if (!vdata.validity.AllValid()) {
+					//	Lazily materialise the contents when we find the first NULL
+					if (ignore_nulls.AllValid()) {
+						ignore_nulls.Initialize(payload_collection.Count());
+					}
+					// Write to the current position
+					// Chunks in a collection are full, so we don't have to worry about raggedness
+					auto dst = ignore_nulls.GetData() + ignore_nulls.EntryCount(pos);
+					auto src = vdata.validity.GetData();
+					for (auto entry_count = vdata.validity.EntryCount(count); entry_count-- > 0;) {
+						*dst++ = *src++;
+					}
+				}
+				pos += count;
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+
+	// build a segment tree for frame-adhering aggregates
+	// see http://www.vldb.org/pvldb/vol8/p1058-leis.pdf
+	unique_ptr<WindowSegmentTree> segment_tree = nullptr;
+
+	if (wexpr->aggregate) {
+		segment_tree = make_unique<WindowSegmentTree>(*(wexpr->aggregate), wexpr->bind_info.get(), wexpr->return_type,
+		                                              &payload_collection, filter_mask, mode);
+	}
+
+	WindowBoundariesState bounds(wexpr);
+	uint64_t dense_rank = 1, rank_equal = 0, rank = 1;
+
+	// this is the main loop, go through all sorted rows and compute window function result
+	const vector<LogicalType> output_types(1, wexpr->return_type);
+	DataChunk output_chunk;
+	output_chunk.Initialize(output_types);
+	for (idx_t row_idx = 0; row_idx < input.Count(); row_idx++) {
+		// Grow the chunk if necessary.
+		const auto output_offset = row_idx % STANDARD_VECTOR_SIZE;
+		if (output_offset == 0) {
+			output.Append(output_chunk);
+			output_chunk.Reset();
+			output_chunk.SetCardinality(MinValue(idx_t(STANDARD_VECTOR_SIZE), input.Count() - row_idx));
+		}
+		auto &result = output_chunk.data[0];
+
+		// special case, OVER (), aggregate over everything
+		UpdateWindowBoundaries(bounds, input.Count(), row_idx, over, boundary_start_collection, boundary_end_collection,
+		                       partition_mask, order_mask);
+		if (WindowNeedsRank(wexpr)) {
+			if (!bounds.is_same_partition || row_idx == 0) { // special case for first row, need to init
+				dense_rank = 1;
+				rank = 1;
+				rank_equal = 0;
+			} else if (!bounds.is_peer) {
+				dense_rank++;
+				rank += rank_equal;
+				rank_equal = 0;
+			}
+			rank_equal++;
+		}
+
+		// if no values are read for window, result is NULL
+		if (bounds.window_start >= bounds.window_end) {
+			FlatVector::SetNull(result, output_offset, true);
+			continue;
+		}
+
+		switch (wexpr->type) {
+		case ExpressionType::WINDOW_AGGREGATE: {
+			segment_tree->Compute(result, output_offset, bounds.window_start, bounds.window_end);
+			break;
+		}
+		case ExpressionType::WINDOW_ROW_NUMBER: {
+			auto rdata = FlatVector::GetData<int64_t>(result);
+			rdata[output_offset] = row_idx - bounds.partition_start + 1;
+			break;
+		}
+		case ExpressionType::WINDOW_RANK_DENSE: {
+			auto rdata = FlatVector::GetData<int64_t>(result);
+			rdata[output_offset] = dense_rank;
+			break;
+		}
+		case ExpressionType::WINDOW_RANK: {
+			auto rdata = FlatVector::GetData<int64_t>(result);
+			rdata[output_offset] = rank;
+			break;
+		}
+		case ExpressionType::WINDOW_PERCENT_RANK: {
+			int64_t denom = (int64_t)bounds.partition_end - bounds.partition_start - 1;
+			double percent_rank = denom > 0 ? ((double)rank - 1) / denom : 0;
+			auto rdata = FlatVector::GetData<double>(result);
+			rdata[output_offset] = percent_rank;
+			break;
+		}
+		case ExpressionType::WINDOW_CUME_DIST: {
+			int64_t denom = (int64_t)bounds.partition_end - bounds.partition_start;
+			double cume_dist = denom > 0 ? ((double)(bounds.peer_end - bounds.partition_start)) / denom : 0;
+			auto rdata = FlatVector::GetData<double>(result);
+			rdata[output_offset] = cume_dist;
+			break;
+		}
+		case ExpressionType::WINDOW_NTILE: {
+			D_ASSERT(payload_collection.ColumnCount() == 1);
+			auto n_param = GetCell<int64_t>(payload_collection, 0, row_idx);
+			// With thanks from SQLite's ntileValueFunc()
+			int64_t n_total = bounds.partition_end - bounds.partition_start;
+			if (n_param > n_total) {
+				// more groups allowed than we have values
+				// map every entry to a unique group
+				n_param = n_total;
+			}
+			int64_t n_size = (n_total / n_param);
+			// find the row idx within the group
+			D_ASSERT(row_idx >= bounds.partition_start);
+			int64_t adjusted_row_idx = row_idx - bounds.partition_start;
+			// now compute the ntile
+			int64_t n_large = n_total - n_param * n_size;
+			int64_t i_small = n_large * (n_size + 1);
+			int64_t result_ntile;
+
+			D_ASSERT((n_large * (n_size + 1) + (n_param - n_large) * n_size) == n_total);
+
+			if (adjusted_row_idx < i_small) {
+				result_ntile = 1 + adjusted_row_idx / (n_size + 1);
+			} else {
+				result_ntile = 1 + n_large + (adjusted_row_idx - i_small) / n_size;
+			}
+			// result has to be between [1, NTILE]
+			D_ASSERT(result_ntile >= 1 && result_ntile <= n_param);
+			auto rdata = FlatVector::GetData<int64_t>(result);
+			rdata[output_offset] = result_ntile;
+			break;
+		}
+		case ExpressionType::WINDOW_LEAD:
+		case ExpressionType::WINDOW_LAG: {
+			int64_t offset = 1;
+			if (wexpr->offset_expr) {
+				offset = GetCell<int64_t>(leadlag_offset_collection, 0, wexpr->offset_expr->IsScalar() ? 0 : row_idx);
+			}
+			int64_t val_idx = (int64_t)row_idx;
+			if (wexpr->type == ExpressionType::WINDOW_LEAD) {
+				val_idx += offset;
+			} else {
+				val_idx -= offset;
+			}
+
+			idx_t delta = 0;
+			if (val_idx < (int64_t)row_idx) {
+				// Count backwards
+				delta = idx_t(row_idx - val_idx);
+				val_idx = FindPrevStart(ignore_nulls, bounds.partition_start, row_idx, delta);
+			} else if (val_idx > (int64_t)row_idx) {
+				delta = idx_t(val_idx - row_idx);
+				val_idx = FindNextStart(ignore_nulls, row_idx + 1, bounds.partition_end, delta);
+			}
+			// else offset is zero, so don't move.
+
+			if (!delta) {
+				payload_collection.CopyCell(0, val_idx, result, output_offset);
+			} else if (wexpr->default_expr) {
+				const auto source_row = wexpr->default_expr->IsScalar() ? 0 : row_idx;
+				leadlag_default_collection.CopyCell(0, source_row, result, output_offset);
+			} else {
+				FlatVector::SetNull(result, output_offset, true);
+			}
+			break;
+		}
+		case ExpressionType::WINDOW_FIRST_VALUE: {
+			idx_t n = 1;
+			const auto first_idx = FindNextStart(ignore_nulls, bounds.window_start, bounds.window_end, n);
+			payload_collection.CopyCell(0, first_idx, result, output_offset);
+			break;
+		}
+		case ExpressionType::WINDOW_LAST_VALUE: {
+			idx_t n = 1;
+			payload_collection.CopyCell(0, FindPrevStart(ignore_nulls, bounds.window_start, bounds.window_end, n),
+			                            result, output_offset);
+			break;
+		}
+		case ExpressionType::WINDOW_NTH_VALUE: {
+			D_ASSERT(payload_collection.ColumnCount() == 2);
+			// Returns value evaluated at the row that is the n'th row of the window frame (counting from 1);
+			// returns NULL if there is no such row.
+			if (CellIsNull(payload_collection, 1, row_idx)) {
+				FlatVector::SetNull(result, output_offset, true);
+			} else {
+				auto n_param = GetCell<int64_t>(payload_collection, 1, row_idx);
+				if (n_param < 1) {
+					FlatVector::SetNull(result, output_offset, true);
+				} else {
+					auto n = idx_t(n_param);
+					const auto nth_index = FindNextStart(ignore_nulls, bounds.window_start, bounds.window_end, n);
+					if (!n) {
+						payload_collection.CopyCell(0, nth_index, result, output_offset);
+					} else {
+						FlatVector::SetNull(result, output_offset, true);
+					}
+				}
+			}
+			break;
+		}
+		default:
+			throw InternalException("Window aggregate type %s", ExpressionTypeToString(wexpr->type));
+		}
+	}
+
+	// Push the last chunk
+	output.Append(output_chunk);
+}
+
+using WindowExpressions = vector<BoundWindowExpression *>;
+
+static void ComputeWindowExpressions(WindowExpressions &window_exprs, ChunkCollection &input,
+                                     ChunkCollection &window_results, ChunkCollection &over,
+                                     WindowAggregationMode mode) {
+	//	Idempotency
+	if (input.Count() == 0) {
+		return;
+	}
+	//	Pick out a function for the OVER clause
+	auto over_expr = window_exprs[0];
+
+	//	Set bits for the start of each partition
+	vector<validity_t> partition_bits(ValidityMask::EntryCount(input.Count()), 0);
+	ValidityMask partition_mask(partition_bits.data());
+	partition_mask.SetValid(0);
+
+	for (idx_t c = 0; c < over_expr->partitions.size(); ++c) {
+		MaskColumn(partition_mask, over, c);
+	}
+
+	//	Set bits for the start of each peer group.
+	//	Partitions also break peer groups, so start with the partition bits.
+	const auto sort_col_count = over_expr->partitions.size() + over_expr->orders.size();
+	ValidityMask order_mask(partition_mask, input.Count());
+	for (idx_t c = over_expr->partitions.size(); c < sort_col_count; ++c) {
+		MaskColumn(order_mask, over, c);
+	}
+
+	//	Compute the functions columnwise
+	for (idx_t expr_idx = 0; expr_idx < window_exprs.size(); ++expr_idx) {
+		ChunkCollection output;
+		ComputeWindowExpression(window_exprs[expr_idx], input, output, over, partition_mask, order_mask, mode);
+		window_results.Fuse(output);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+static void GeneratePartition(WindowOperatorState &state, WindowGlobalState &gstate, const idx_t hash_bin) {
+	auto &op = (PhysicalWindow &)gstate.op;
+	WindowExpressions window_exprs;
+	for (idx_t expr_idx = 0; expr_idx < op.select_list.size(); ++expr_idx) {
+		D_ASSERT(op.select_list[expr_idx]->GetExpressionClass() == ExpressionClass::BOUND_WINDOW);
+		auto wexpr = reinterpret_cast<BoundWindowExpression *>(op.select_list[expr_idx].get());
+		window_exprs.emplace_back(wexpr);
+	}
+
+	//	Get rid of any stale data
+	state.chunks.Reset();
+	state.window_results.Reset();
+	state.position = 0;
+	state.global_sort_state = nullptr;
+
+	//	Pick out a function for the OVER clause
+	auto over_expr = window_exprs[0];
+
+	// There are three types of partitions:
+	// 1. No partition (no sorting)
+	// 2. One partition (sorting, but no hashing)
+	// 3. Multiple partitions (sorting and hashing)
+	const auto input_types = gstate.chunks.Types();
+	const auto over_types = gstate.over_collection.Types();
+
+	if (gstate.counts.empty() && hash_bin == 0) {
+		ChunkCollection &input = gstate.chunks;
+		ChunkCollection output;
+		ChunkCollection &over = gstate.over_collection;
+
+		const auto has_sorting = over_expr->partitions.size() + over_expr->orders.size();
+		if (has_sorting && input.Count() > 0) {
+			// 2. One partition
+			SortCollectionForPartition(state, over_expr, input, over, nullptr, 0, 0);
+
+			// Overwrite the collections with the sorted data
+			ScanSortedPartition(state, input, input_types, over, over_types);
+		}
+
+		ComputeWindowExpressions(window_exprs, input, output, over, gstate.mode);
+		state.chunks.Merge(input);
+		state.window_results.Merge(output);
+
+	} else if (hash_bin < gstate.counts.size() && gstate.counts[hash_bin] > 0) {
+		// 3. Multiple partitions
+		const auto hash_mask = hash_t(gstate.counts.size() - 1);
+		SortCollectionForPartition(state, over_expr, gstate.chunks, gstate.over_collection, &gstate.hash_collection,
+		                           hash_bin, hash_mask);
+
+		// Scan the sorted data into new Collections
+		ChunkCollection input;
+		ChunkCollection output;
+		ChunkCollection over;
+		ScanSortedPartition(state, input, input_types, over, over_types);
+
+		ComputeWindowExpressions(window_exprs, input, output, over, gstate.mode);
+		state.chunks.Merge(input);
+		state.window_results.Merge(output);
+	}
+}
+
+static void Scan(WindowOperatorState &state, DataChunk &chunk) {
+	ChunkCollection &big_data = state.chunks;
+	ChunkCollection &window_results = state.window_results;
+
+	if (state.position >= big_data.Count()) {
+		return;
+	}
+
+	// just return what was computed before, appending the result cols of the window expressions at the end
+	auto &proj_ch = big_data.GetChunkForRow(state.position);
+	auto &wind_ch = window_results.GetChunkForRow(state.position);
+
+	idx_t out_idx = 0;
+	D_ASSERT(proj_ch.size() == wind_ch.size());
+	chunk.SetCardinality(proj_ch);
+	for (idx_t col_idx = 0; col_idx < proj_ch.ColumnCount(); col_idx++) {
+		chunk.data[out_idx++].Reference(proj_ch.data[col_idx]);
+	}
+	for (idx_t col_idx = 0; col_idx < wind_ch.ColumnCount(); col_idx++) {
+		chunk.data[out_idx++].Reference(wind_ch.data[col_idx]);
+	}
+	chunk.Verify();
+
+	state.position += STANDARD_VECTOR_SIZE;
+}
+
+SinkResultType PhysicalWindow::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p,
+                                    DataChunk &input) const {
+	auto &lstate = (WindowLocalState &)lstate_p;
+	lstate.chunks.Append(input);
+
+	// Compute the over columns and the hash values for this block (if any)
+	const auto over_idx = 0;
+	auto over_expr = reinterpret_cast<BoundWindowExpression *>(select_list[over_idx].get());
+
+	const auto sort_col_count = over_expr->partitions.size() + over_expr->orders.size();
+	if (sort_col_count > 0) {
+		DataChunk over_chunk;
+		MaterializeOverForWindow(over_expr, input, over_chunk);
+
+		if (!over_expr->partitions.empty()) {
+			if (lstate.counts.empty()) {
+				lstate.counts.resize(lstate.partition_count, 0);
+			}
+
+			DataChunk hash_chunk;
+			HashChunk(lstate.counts, hash_chunk, over_chunk, over_expr->partitions.size());
+			lstate.hash_collection.Append(hash_chunk);
+			D_ASSERT(lstate.chunks.Count() == lstate.hash_collection.Count());
+		}
+
+		lstate.over_collection.Append(over_chunk);
+		D_ASSERT(lstate.chunks.Count() == lstate.over_collection.Count());
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalWindow::Combine(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p) const {
+	auto &lstate = (WindowLocalState &)lstate_p;
+	if (lstate.chunks.Count() == 0) {
+		return;
+	}
+	auto &gstate = (WindowGlobalState &)gstate_p;
+	lock_guard<mutex> glock(gstate.lock);
+	gstate.chunks.Merge(lstate.chunks);
+	gstate.over_collection.Merge(lstate.over_collection);
+	gstate.hash_collection.Merge(lstate.hash_collection);
+	if (gstate.counts.empty()) {
+		gstate.counts = lstate.counts;
+	} else {
+		D_ASSERT(gstate.counts.size() == lstate.counts.size());
+		for (idx_t i = 0; i < gstate.counts.size(); ++i) {
+			gstate.counts[i] += lstate.counts[i];
+		}
+	}
+}
+
+unique_ptr<LocalSinkState> PhysicalWindow::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<WindowLocalState>(*this);
+}
+
+unique_ptr<GlobalSinkState> PhysicalWindow::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<WindowGlobalState>(*this, context);
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class WindowGlobalSourceState : public GlobalSourceState {
+public:
+	explicit WindowGlobalSourceState(const PhysicalWindow &op) : op(op), next_part(0) {
+	}
+
+	const PhysicalWindow &op;
+	//! The output read position.
+	atomic<idx_t> next_part;
+
+public:
+	idx_t MaxThreads() override {
+		auto &state = (WindowGlobalState &)*op.sink_state;
+
+		// If there is only one partition, we have to process it on one thread.
+		if (state.counts.empty()) {
+			return 1;
+		}
+
+		idx_t max_threads = 0;
+		for (const auto count : state.counts) {
+			if (count > 0) {
+				max_threads++;
+			}
+		}
+
+		return max_threads;
+	}
+};
+
+unique_ptr<LocalSourceState> PhysicalWindow::GetLocalSourceState(ExecutionContext &context,
+                                                                 GlobalSourceState &gstate) const {
+	return make_unique<WindowOperatorState>(*this, context);
+}
+
+unique_ptr<GlobalSourceState> PhysicalWindow::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<WindowGlobalSourceState>(*this);
+}
+
+void PhysicalWindow::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                             LocalSourceState &lstate_p) const {
+	auto &state = (WindowOperatorState &)lstate_p;
+	auto &global_source = (WindowGlobalSourceState &)gstate_p;
+	auto &gstate = (WindowGlobalState &)*sink_state;
+
+	do {
+		if (state.position >= state.chunks.Count()) {
+			auto hash_bin = global_source.next_part++;
+			for (; hash_bin < state.partitions; hash_bin = global_source.next_part++) {
+				if (gstate.counts[hash_bin] > 0) {
+					break;
+				}
+			}
+			GeneratePartition(state, gstate, hash_bin);
+		}
+		Scan(state, chunk);
+		if (chunk.size() != 0) {
+			return;
+		} else {
+			break;
+		}
+	} while (true);
+	D_ASSERT(chunk.size() == 0);
+}
+
+string PhysicalWindow::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < select_list.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += select_list[i]->GetName();
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PhysicalFilter::PhysicalFilter(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                               idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::FILTER, move(types), estimated_cardinality) {
+	D_ASSERT(select_list.size() > 0);
+	if (select_list.size() > 1) {
+		// create a big AND out of the expressions
+		auto conjunction = make_unique<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+		for (auto &expr : select_list) {
+			conjunction->children.push_back(move(expr));
+		}
+		expression = move(conjunction);
+	} else {
+		expression = move(select_list[0]);
+	}
+}
+
+class FilterState : public OperatorState {
+public:
+	explicit FilterState(Expression &expr) : executor(expr), sel(STANDARD_VECTOR_SIZE) {
+	}
+
+	ExpressionExecutor executor;
+	SelectionVector sel;
+
+public:
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		context.thread.profiler.Flush(op, &executor, "filter", 0);
+	}
+};
+
+unique_ptr<OperatorState> PhysicalFilter::GetOperatorState(ClientContext &context) const {
+	return make_unique<FilterState>(*expression);
+}
+
+OperatorResultType PhysicalFilter::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                           GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (FilterState &)state_p;
+	idx_t result_count = state.executor.SelectExpression(input, state.sel);
+	if (result_count == input.size()) {
+		// nothing was filtered: skip adding any selection vectors
+		chunk.Reference(input);
+	} else {
+		chunk.Slice(input, state.sel, result_count);
+	}
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+string PhysicalFilter::ParamsToString() const {
+	return expression->GetName();
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+PhysicalBatchCollector::PhysicalBatchCollector(PreparedStatementData &data) : PhysicalResultCollector(data) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class BatchCollectorGlobalState : public GlobalSinkState {
+public:
+	mutex glock;
+	BatchedChunkCollection data;
+	unique_ptr<MaterializedQueryResult> result;
+};
+
+class BatchCollectorLocalState : public LocalSinkState {
+public:
+	BatchedChunkCollection data;
+};
+
+SinkResultType PhysicalBatchCollector::Sink(ExecutionContext &context, GlobalSinkState &gstate,
+                                            LocalSinkState &lstate_p, DataChunk &input) const {
+	auto &state = (BatchCollectorLocalState &)lstate_p;
+	state.data.Append(input, state.batch_index);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalBatchCollector::Combine(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                     LocalSinkState &lstate_p) const {
+	auto &gstate = (BatchCollectorGlobalState &)gstate_p;
+	auto &state = (BatchCollectorLocalState &)lstate_p;
+
+	lock_guard<mutex> lock(gstate.glock);
+	gstate.data.Merge(state.data);
+}
+
+SinkFinalizeType PhysicalBatchCollector::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                  GlobalSinkState &gstate_p) const {
+	auto &gstate = (BatchCollectorGlobalState &)gstate_p;
+	auto result =
+	    make_unique<MaterializedQueryResult>(statement_type, properties, types, names, context.shared_from_this());
+	DataChunk output;
+	output.Initialize(types);
+
+	BatchedChunkScanState state;
+	gstate.data.InitializeScan(state);
+	while (true) {
+		output.Reset();
+		gstate.data.Scan(state, output);
+		if (output.size() == 0) {
+			break;
+		}
+		result->collection.Append(output);
+	}
+
+	gstate.result = move(result);
+	return SinkFinalizeType::READY;
+}
+
+unique_ptr<LocalSinkState> PhysicalBatchCollector::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<BatchCollectorLocalState>();
+}
+
+unique_ptr<GlobalSinkState> PhysicalBatchCollector::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<BatchCollectorGlobalState>();
+}
+
+unique_ptr<QueryResult> PhysicalBatchCollector::GetResult(GlobalSinkState &state) {
+	auto &gstate = (BatchCollectorGlobalState &)state;
+	D_ASSERT(gstate.result);
+	return move(gstate.result);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+PhysicalExecute::PhysicalExecute(PhysicalOperator *plan)
+    : PhysicalOperator(PhysicalOperatorType::EXECUTE, plan->types, -1), plan(plan) {
+}
+
+vector<PhysicalOperator *> PhysicalExecute::GetChildren() const {
+	return {plan};
+}
+
+void PhysicalExecute::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	// EXECUTE statement: build pipeline on child
+	plan->BuildPipelines(executor, current, state);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class ExplainAnalyzeStateGlobalState : public GlobalSinkState {
+public:
+	string analyzed_plan;
+};
+
+SinkResultType PhysicalExplainAnalyze::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                            DataChunk &input) const {
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+SinkFinalizeType PhysicalExplainAnalyze::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                  GlobalSinkState &gstate_p) const {
+	auto &gstate = (ExplainAnalyzeStateGlobalState &)gstate_p;
+	auto &profiler = QueryProfiler::Get(context);
+	gstate.analyzed_plan = profiler.ToString();
+	return SinkFinalizeType::READY;
+}
+
+unique_ptr<GlobalSinkState> PhysicalExplainAnalyze::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<ExplainAnalyzeStateGlobalState>();
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class ExplainAnalyzeState : public GlobalSourceState {
+public:
+	ExplainAnalyzeState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalExplainAnalyze::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<ExplainAnalyzeState>();
+}
+
+void PhysicalExplainAnalyze::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &source_state,
+                                     LocalSourceState &lstate) const {
+	auto &state = (ExplainAnalyzeState &)source_state;
+	auto &gstate = (ExplainAnalyzeStateGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+	chunk.SetValue(0, 0, Value("analyzed_plan"));
+	chunk.SetValue(1, 0, Value(gstate.analyzed_plan));
+	chunk.SetCardinality(1);
+
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalLimit::PhysicalLimit(vector<LogicalType> types, idx_t limit, idx_t offset,
+                             unique_ptr<Expression> limit_expression, unique_ptr<Expression> offset_expression,
+                             idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::LIMIT, move(types), estimated_cardinality), limit_value(limit),
+      offset_value(offset), limit_expression(move(limit_expression)), offset_expression(move(offset_expression)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class LimitGlobalState : public GlobalSinkState {
+public:
+	explicit LimitGlobalState(const PhysicalLimit &op) {
+		limit = 0;
+		offset = 0;
+	}
+
+	mutex glock;
+	idx_t limit;
+	idx_t offset;
+	BatchedChunkCollection data;
+};
+
+class LimitLocalState : public LocalSinkState {
+public:
+	explicit LimitLocalState(const PhysicalLimit &op) : current_offset(0) {
+		this->limit = op.limit_expression ? DConstants::INVALID_INDEX : op.limit_value;
+		this->offset = op.offset_expression ? DConstants::INVALID_INDEX : op.offset_value;
+	}
+
+	idx_t current_offset;
+	idx_t limit;
+	idx_t offset;
+	BatchedChunkCollection data;
+};
+
+unique_ptr<GlobalSinkState> PhysicalLimit::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<LimitGlobalState>(*this);
+}
+
+unique_ptr<LocalSinkState> PhysicalLimit::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<LimitLocalState>(*this);
+}
+
+bool PhysicalLimit::ComputeOffset(DataChunk &input, idx_t &limit, idx_t &offset, idx_t current_offset,
+                                  idx_t &max_element, Expression *limit_expression, Expression *offset_expression) {
+	if (limit != DConstants::INVALID_INDEX && offset != DConstants::INVALID_INDEX) {
+		max_element = limit + offset;
+		if ((limit == 0 || current_offset >= max_element) && !(limit_expression || offset_expression)) {
+			return false;
+		}
+	}
+
+	// get the next chunk from the child
+	if (limit == DConstants::INVALID_INDEX) {
+		limit = 1ULL << 62ULL;
+		Value val = GetDelimiter(input, limit_expression);
+		if (!val.IsNull()) {
+			limit = val.GetValue<idx_t>();
+		}
+		if (limit > 1ULL << 62ULL) {
+			throw BinderException("Max value %lld for LIMIT/OFFSET is %lld", limit, 1ULL << 62ULL);
+		}
+	}
+	if (offset == DConstants::INVALID_INDEX) {
+		offset = 0;
+		Value val = GetDelimiter(input, offset_expression);
+		if (!val.IsNull()) {
+			offset = val.GetValue<idx_t>();
+		}
+		if (offset > 1ULL << 62ULL) {
+			throw BinderException("Max value %lld for LIMIT/OFFSET is %lld", offset, 1ULL << 62ULL);
+		}
+	}
+	max_element = limit + offset;
+	if (limit == 0 || current_offset >= max_element) {
+		return false;
+	}
+	return true;
+}
+
+SinkResultType PhysicalLimit::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
+                                   DataChunk &input) const {
+
+	D_ASSERT(input.size() > 0);
+	auto &state = (LimitLocalState &)lstate;
+	auto &limit = state.limit;
+	auto &offset = state.offset;
+
+	idx_t max_element;
+	if (!ComputeOffset(input, limit, offset, state.current_offset, max_element, limit_expression.get(),
+	                   offset_expression.get())) {
+		return SinkResultType::FINISHED;
+	}
+	state.data.Append(input, lstate.batch_index);
+	state.current_offset += input.size();
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalLimit::Combine(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p) const {
+	auto &gstate = (LimitGlobalState &)gstate_p;
+	auto &state = (LimitLocalState &)lstate_p;
+
+	lock_guard<mutex> lock(gstate.glock);
+	gstate.limit = state.limit;
+	gstate.offset = state.offset;
+	gstate.data.Merge(state.data);
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class LimitSourceState : public GlobalSourceState {
+public:
+	LimitSourceState() {
+		initialized = false;
+		current_offset = 0;
+	}
+
+	bool initialized;
+	idx_t current_offset;
+	BatchedChunkScanState scan_state;
+};
+
+unique_ptr<GlobalSourceState> PhysicalLimit::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<LimitSourceState>();
+}
+
+void PhysicalLimit::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                            LocalSourceState &lstate) const {
+	auto &gstate = (LimitGlobalState &)*sink_state;
+	auto &state = (LimitSourceState &)gstate_p;
+	while (state.current_offset < gstate.limit + gstate.offset) {
+		if (!state.initialized) {
+			gstate.data.InitializeScan(state.scan_state);
+			state.initialized = true;
+		}
+		gstate.data.Scan(state.scan_state, chunk);
+		if (chunk.size() == 0) {
+			break;
+		}
+		if (HandleOffset(chunk, state.current_offset, gstate.offset, gstate.limit)) {
+			break;
+		}
+	}
+}
+
+bool PhysicalLimit::HandleOffset(DataChunk &input, idx_t &current_offset, idx_t offset, idx_t limit) {
+	idx_t max_element = limit + offset;
+	if (limit == DConstants::INVALID_INDEX) {
+		max_element = DConstants::INVALID_INDEX;
+	}
+	idx_t input_size = input.size();
+	if (current_offset < offset) {
+		// we are not yet at the offset point
+		if (current_offset + input.size() > offset) {
+			// however we will reach it in this chunk
+			// we have to copy part of the chunk with an offset
+			idx_t start_position = offset - current_offset;
+			auto chunk_count = MinValue<idx_t>(limit, input.size() - start_position);
+			SelectionVector sel(STANDARD_VECTOR_SIZE);
+			for (idx_t i = 0; i < chunk_count; i++) {
+				sel.set_index(i, start_position + i);
+			}
+			// set up a slice of the input chunks
+			input.Slice(input, sel, chunk_count);
+		} else {
+			current_offset += input_size;
+			return false;
+		}
+	} else {
+		// have to copy either the entire chunk or part of it
+		idx_t chunk_count;
+		if (current_offset + input.size() >= max_element) {
+			// have to limit the count of the chunk
+			chunk_count = max_element - current_offset;
+		} else {
+			// we copy the entire chunk
+			chunk_count = input.size();
+		}
+		// instead of copying we just change the pointer in the current chunk
+		input.Reference(input);
+		input.SetCardinality(chunk_count);
+	}
+
+	current_offset += input_size;
+	return true;
+}
+
+Value PhysicalLimit::GetDelimiter(DataChunk &input, Expression *expr) {
+	DataChunk limit_chunk;
+	vector<LogicalType> types {expr->return_type};
+	limit_chunk.Initialize(types);
+	ExpressionExecutor limit_executor(expr);
+	auto input_size = input.size();
+	input.SetCardinality(1);
+	limit_executor.Execute(input, limit_chunk);
+	input.SetCardinality(input_size);
+	auto limit_value = limit_chunk.GetValue(0, 0);
+	return limit_value;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class LimitPercentGlobalState : public GlobalSinkState {
+public:
+	explicit LimitPercentGlobalState(const PhysicalLimitPercent &op) : current_offset(0) {
+		if (!op.limit_expression) {
+			this->limit_percent = op.limit_percent;
+			is_limit_percent_delimited = true;
+		} else {
+			this->limit_percent = 100.0;
+		}
+
+		if (!op.offset_expression) {
+			this->offset = op.offset_value;
+			is_offset_delimited = true;
+		} else {
+			this->offset = 0;
+		}
+	}
+
+	idx_t current_offset;
+	double limit_percent;
+	idx_t offset;
+	ChunkCollection data;
+
+	bool is_limit_percent_delimited = false;
+	bool is_offset_delimited = false;
+};
+
+unique_ptr<GlobalSinkState> PhysicalLimitPercent::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<LimitPercentGlobalState>(*this);
+}
+
+SinkResultType PhysicalLimitPercent::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
+                                          DataChunk &input) const {
+	D_ASSERT(input.size() > 0);
+	auto &state = (LimitPercentGlobalState &)gstate;
+	auto &limit_percent = state.limit_percent;
+	auto &offset = state.offset;
+
+	// get the next chunk from the child
+	if (!state.is_limit_percent_delimited) {
+		Value val = PhysicalLimit::GetDelimiter(input, limit_expression.get());
+		if (!val.IsNull()) {
+			limit_percent = val.GetValue<double>();
+		}
+		if (limit_percent < 0.0) {
+			throw BinderException("Percentage value(%f) can't be negative", limit_percent);
+		}
+		state.is_limit_percent_delimited = true;
+	}
+	if (!state.is_offset_delimited) {
+		Value val = PhysicalLimit::GetDelimiter(input, offset_expression.get());
+		if (!val.IsNull()) {
+			offset = val.GetValue<idx_t>();
+		}
+		if (offset > 1ULL << 62ULL) {
+			throw BinderException("Max value %lld for LIMIT/OFFSET is %lld", offset, 1ULL << 62ULL);
+		}
+		state.is_offset_delimited = true;
+	}
+
+	if (!PhysicalLimit::HandleOffset(input, state.current_offset, offset, DConstants::INVALID_INDEX)) {
+		return SinkResultType::NEED_MORE_INPUT;
+	}
+
+	state.data.Append(input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class LimitPercentOperatorState : public GlobalSourceState {
+public:
+	LimitPercentOperatorState() : chunk_idx(0), limit(DConstants::INVALID_INDEX), current_offset(0) {
+	}
+
+	idx_t chunk_idx;
+	idx_t limit;
+	idx_t current_offset;
+};
+
+unique_ptr<GlobalSourceState> PhysicalLimitPercent::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<LimitPercentOperatorState>();
+}
+
+void PhysicalLimitPercent::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                   LocalSourceState &lstate) const {
+	auto &gstate = (LimitPercentGlobalState &)*sink_state;
+	auto &state = (LimitPercentOperatorState &)gstate_p;
+	auto &limit_percent = gstate.limit_percent;
+	auto &offset = gstate.offset;
+	auto &limit = state.limit;
+	auto &current_offset = state.current_offset;
+
+	if (gstate.is_limit_percent_delimited && limit == DConstants::INVALID_INDEX) {
+		idx_t count = gstate.data.Count();
+		if (count > 0) {
+			count += offset;
+		}
+		limit = MinValue((idx_t)(limit_percent / 100 * count), count);
+		if (limit == 0) {
+			return;
+		}
+	}
+
+	if (current_offset >= limit || state.chunk_idx >= gstate.data.ChunkCount()) {
+		return;
+	}
+
+	DataChunk &input = gstate.data.GetChunk(state.chunk_idx);
+	state.chunk_idx++;
+	if (PhysicalLimit::HandleOffset(input, current_offset, 0, limit)) {
+		chunk.Reference(input);
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void PhysicalLoad::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                           LocalSourceState &lstate) const {
+	auto &db = DatabaseInstance::GetDatabase(context.client);
+	if (info->load_type == LoadType::INSTALL || info->load_type == LoadType::FORCE_INSTALL) {
+		ExtensionHelper::InstallExtension(db, info->filename, info->load_type == LoadType::FORCE_INSTALL);
+	} else {
+		ExtensionHelper::LoadExternalExtension(db, info->filename);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+PhysicalMaterializedCollector::PhysicalMaterializedCollector(PreparedStatementData &data, bool parallel)
+    : PhysicalResultCollector(data), parallel(parallel) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class MaterializedCollectorGlobalState : public GlobalSinkState {
+public:
+	mutex glock;
+	unique_ptr<MaterializedQueryResult> result;
+};
+
+SinkResultType PhysicalMaterializedCollector::Sink(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                                   LocalSinkState &lstate, DataChunk &input) const {
+	auto &gstate = (MaterializedCollectorGlobalState &)gstate_p;
+	lock_guard<mutex> lock(gstate.glock);
+	gstate.result->collection.Append(input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+unique_ptr<GlobalSinkState> PhysicalMaterializedCollector::GetGlobalSinkState(ClientContext &context) const {
+	auto state = make_unique<MaterializedCollectorGlobalState>();
+	state->result =
+	    make_unique<MaterializedQueryResult>(statement_type, properties, types, names, context.shared_from_this());
+	return move(state);
+}
+
+unique_ptr<QueryResult> PhysicalMaterializedCollector::GetResult(GlobalSinkState &state) {
+	auto &gstate = (MaterializedCollectorGlobalState &)state;
+	D_ASSERT(gstate.result);
+	return move(gstate.result);
+}
+
+bool PhysicalMaterializedCollector::ParallelSink() const {
+	return parallel;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void PhysicalPragma::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                             LocalSourceState &lstate) const {
+	auto &client = context.client;
+	FunctionParameters parameters {info.parameters, info.named_parameters};
+	function.function(client, parameters);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void PhysicalPrepare::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                              LocalSourceState &lstate) const {
+	auto &client = context.client;
+
+	// store the prepared statement in the context
+	ClientData::Get(client).prepared_statements[name] = prepared;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class SampleGlobalSinkState : public GlobalSinkState {
+public:
+	explicit SampleGlobalSinkState(SampleOptions &options) {
+		if (options.is_percentage) {
+			auto percentage = options.sample_size.GetValue<double>();
+			if (percentage == 0) {
+				return;
+			}
+			sample = make_unique<ReservoirSamplePercentage>(percentage, options.seed);
+		} else {
+			auto size = options.sample_size.GetValue<int64_t>();
+			if (size == 0) {
+				return;
+			}
+			sample = make_unique<ReservoirSample>(size, options.seed);
+		}
+	}
+
+	//! The lock for updating the global aggregate state
+	mutex lock;
+	//! The reservoir sample
+	unique_ptr<BlockingSample> sample;
+};
+
+unique_ptr<GlobalSinkState> PhysicalReservoirSample::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<SampleGlobalSinkState>(*options);
+}
+
+SinkResultType PhysicalReservoirSample::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                             DataChunk &input) const {
+	auto &gstate = (SampleGlobalSinkState &)state;
+	if (!gstate.sample) {
+		return SinkResultType::FINISHED;
+	}
+	// we implement reservoir sampling without replacement and exponential jumps here
+	// the algorithm is adopted from the paper Weighted random sampling with a reservoir by Pavlos S. Efraimidis et al.
+	// note that the original algorithm is about weighted sampling; this is a simplified approach for uniform sampling
+	lock_guard<mutex> glock(gstate.lock);
+	gstate.sample->AddToReservoir(input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+void PhysicalReservoirSample::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                      LocalSourceState &lstate) const {
+	auto &sink = (SampleGlobalSinkState &)*this->sink_state;
+	if (!sink.sample) {
+		return;
+	}
+	auto sample_chunk = sink.sample->GetChunk();
+	if (!sample_chunk) {
+		return;
+	}
+	chunk.Move(*sample_chunk);
+}
+
+string PhysicalReservoirSample::ParamsToString() const {
+	return options->sample_size.ToString() + (options->is_percentage ? "%" : " rows");
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalResultCollector::PhysicalResultCollector(PreparedStatementData &data)
+    : PhysicalOperator(PhysicalOperatorType::RESULT_COLLECTOR, {LogicalType::BOOLEAN}, 0),
+      statement_type(data.statement_type), properties(data.properties), plan(data.plan.get()), names(data.names) {
+	this->types = data.types;
+}
+
+unique_ptr<PhysicalResultCollector> PhysicalResultCollector::GetResultCollector(ClientContext &context,
+                                                                                PreparedStatementData &data) {
+	auto &config = DBConfig::GetConfig(context);
+	bool use_materialized_collector = !config.preserve_insertion_order || !data.plan->AllSourcesSupportBatchIndex();
+	if (use_materialized_collector) {
+		// parallel materialized collector only if we don't care about maintaining insertion order
+		return make_unique_base<PhysicalResultCollector, PhysicalMaterializedCollector>(
+		    data, !config.preserve_insertion_order);
+	} else {
+		// we care about maintaining insertion order and the sources all support batch indexes
+		// use a batch collector
+		return make_unique_base<PhysicalResultCollector, PhysicalBatchCollector>(data);
+	}
+}
+
+vector<PhysicalOperator *> PhysicalResultCollector::GetChildren() const {
+	return {plan};
+}
+
+void PhysicalResultCollector::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	// operator is a sink, build a pipeline
+	sink_state.reset();
+
+	// single operator:
+	// the operator becomes the data source of the current pipeline
+	state.SetPipelineSource(current, this);
+	// we create a new pipeline starting from the child
+	D_ASSERT(children.size() == 0);
+	D_ASSERT(plan);
+
+	BuildChildPipeline(executor, current, state, plan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+void PhysicalSet::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                          LocalSourceState &lstate) const {
+	auto option = DBConfig::GetOptionByName(name);
+	if (!option) {
+		// check if this is an extra extension variable
+		auto &config = DBConfig::GetConfig(context.client);
+		auto entry = config.extension_parameters.find(name);
+		if (entry == config.extension_parameters.end()) {
+			// it is not!
+			// get a list of all options
+			vector<string> potential_names;
+			for (idx_t i = 0, option_count = DBConfig::GetOptionCount(); i < option_count; i++) {
+				potential_names.emplace_back(DBConfig::GetOptionByIndex(i)->name);
+			}
+			for (auto &entry : config.extension_parameters) {
+				potential_names.push_back(entry.first);
+			}
+
+			throw CatalogException("unrecognized configuration parameter \"%s\"\n%s", name,
+			                       StringUtil::CandidatesErrorMessage(potential_names, name, "Did you mean"));
+		}
+		//! it is!
+		auto &extension_option = entry->second;
+		auto &target_type = extension_option.type;
+		Value target_value = value.CastAs(target_type);
+		if (extension_option.set_function) {
+			extension_option.set_function(context.client, scope, target_value);
+		}
+		if (scope == SetScope::GLOBAL) {
+			config.set_variables[name] = move(target_value);
+		} else {
+			auto &client_config = ClientConfig::GetConfig(context.client);
+			client_config.set_variables[name] = move(target_value);
+		}
+		return;
+	}
+	SetScope variable_scope = scope;
+	if (variable_scope == SetScope::AUTOMATIC) {
+		if (option->set_local) {
+			variable_scope = SetScope::SESSION;
+		} else {
+			D_ASSERT(option->set_global);
+			variable_scope = SetScope::GLOBAL;
+		}
+	}
+
+	Value input = value.CastAs(option->parameter_type);
+	switch (variable_scope) {
+	case SetScope::GLOBAL: {
+		if (!option->set_global) {
+			throw CatalogException("option \"%s\" cannot be set globally", name);
+		}
+		auto &db = DatabaseInstance::GetDatabase(context.client);
+		auto &config = DBConfig::GetConfig(context.client);
+		option->set_global(&db, config, input);
+		break;
+	}
+	case SetScope::SESSION:
+		if (!option->set_local) {
+			throw CatalogException("option \"%s\" cannot be set locally", name);
+		}
+		option->set_local(context.client, input);
+		break;
+	default:
+		throw InternalException("Unsupported SetScope for variable");
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PhysicalStreamingLimit::PhysicalStreamingLimit(vector<LogicalType> types, idx_t limit, idx_t offset,
+                                               unique_ptr<Expression> limit_expression,
+                                               unique_ptr<Expression> offset_expression, idx_t estimated_cardinality,
+                                               bool parallel)
+    : PhysicalOperator(PhysicalOperatorType::STREAMING_LIMIT, move(types), estimated_cardinality), limit_value(limit),
+      offset_value(offset), limit_expression(move(limit_expression)), offset_expression(move(offset_expression)),
+      parallel(parallel) {
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class StreamingLimitOperatorState : public OperatorState {
+public:
+	explicit StreamingLimitOperatorState(const PhysicalStreamingLimit &op) {
+		this->limit = op.limit_expression ? DConstants::INVALID_INDEX : op.limit_value;
+		this->offset = op.offset_expression ? DConstants::INVALID_INDEX : op.offset_value;
+	}
+
+	idx_t limit;
+	idx_t offset;
+};
+
+class StreamingLimitGlobalState : public GlobalOperatorState {
+public:
+	StreamingLimitGlobalState() : current_offset(0) {
+	}
+
+	std::atomic<idx_t> current_offset;
+};
+
+unique_ptr<OperatorState> PhysicalStreamingLimit::GetOperatorState(ClientContext &context) const {
+	return make_unique<StreamingLimitOperatorState>(*this);
+}
+
+unique_ptr<GlobalOperatorState> PhysicalStreamingLimit::GetGlobalOperatorState(ClientContext &context) const {
+	return make_unique<StreamingLimitGlobalState>();
+}
+
+OperatorResultType PhysicalStreamingLimit::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                   GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	auto &gstate = (StreamingLimitGlobalState &)gstate_p;
+	auto &state = (StreamingLimitOperatorState &)state_p;
+	auto &limit = state.limit;
+	auto &offset = state.offset;
+	idx_t current_offset = gstate.current_offset.fetch_add(input.size());
+	idx_t max_element;
+	if (!PhysicalLimit::ComputeOffset(input, limit, offset, current_offset, max_element, limit_expression.get(),
+	                                  offset_expression.get())) {
+		return OperatorResultType::FINISHED;
+	}
+	if (PhysicalLimit::HandleOffset(input, current_offset, offset, limit)) {
+		chunk.Reference(input);
+	}
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+bool PhysicalStreamingLimit::IsOrderDependent() const {
+	return !parallel;
+}
+
+bool PhysicalStreamingLimit::ParallelOperator() const {
+	return parallel;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PhysicalStreamingSample::PhysicalStreamingSample(vector<LogicalType> types, SampleMethod method, double percentage,
+                                                 int64_t seed, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::STREAMING_SAMPLE, move(types), estimated_cardinality), method(method),
+      percentage(percentage / 100), seed(seed) {
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class StreamingSampleOperatorState : public OperatorState {
+public:
+	explicit StreamingSampleOperatorState(int64_t seed) : random(seed) {
+	}
+
+	RandomEngine random;
+};
+
+void PhysicalStreamingSample::SystemSample(DataChunk &input, DataChunk &result, OperatorState &state_p) const {
+	// system sampling: we throw one dice per chunk
+	auto &state = (StreamingSampleOperatorState &)state_p;
+	double rand = state.random.NextRandom();
+	if (rand <= percentage) {
+		// rand is smaller than sample_size: output chunk
+		result.Reference(input);
+	}
+}
+
+void PhysicalStreamingSample::BernoulliSample(DataChunk &input, DataChunk &result, OperatorState &state_p) const {
+	// bernoulli sampling: we throw one dice per tuple
+	// then slice the result chunk
+	auto &state = (StreamingSampleOperatorState &)state_p;
+	idx_t result_count = 0;
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	for (idx_t i = 0; i < input.size(); i++) {
+		double rand = state.random.NextRandom();
+		if (rand <= percentage) {
+			sel.set_index(result_count++, i);
+		}
+	}
+	if (result_count > 0) {
+		result.Slice(input, sel, result_count);
+	}
+}
+
+unique_ptr<OperatorState> PhysicalStreamingSample::GetOperatorState(ClientContext &context) const {
+	return make_unique<StreamingSampleOperatorState>(seed);
+}
+
+OperatorResultType PhysicalStreamingSample::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                    GlobalOperatorState &gstate, OperatorState &state) const {
+	switch (method) {
+	case SampleMethod::BERNOULLI_SAMPLE:
+		BernoulliSample(input, chunk, state);
+		break;
+	case SampleMethod::SYSTEM_SAMPLE:
+		SystemSample(input, chunk, state);
+		break;
+	default:
+		throw InternalException("Unsupported sample method for streaming sample");
+	}
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+string PhysicalStreamingSample::ParamsToString() const {
+	return SampleMethodToString(method) + ": " + to_string(100 * percentage) + "%";
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void PhysicalTransaction::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                  LocalSourceState &lstate) const {
+	auto &client = context.client;
+
+	switch (info->type) {
+	case TransactionType::BEGIN_TRANSACTION: {
+		if (client.transaction.IsAutoCommit()) {
+			// start the active transaction
+			// if autocommit is active, we have already called
+			// BeginTransaction by setting autocommit to false we
+			// prevent it from being closed after this query, hence
+			// preserving the transaction context for the next query
+			client.transaction.SetAutoCommit(false);
+		} else {
+			throw TransactionException("cannot start a transaction within a transaction");
+		}
+		break;
+	}
+	case TransactionType::COMMIT: {
+		if (client.transaction.IsAutoCommit()) {
+			throw TransactionException("cannot commit - no transaction is active");
+		} else {
+			// explicitly commit the current transaction
+			client.transaction.Commit();
+		}
+		break;
+	}
+	case TransactionType::ROLLBACK: {
+		if (client.transaction.IsAutoCommit()) {
+			throw TransactionException("cannot rollback - no transaction is active");
+		} else {
+			// explicitly rollback the current transaction
+			client.transaction.Rollback();
+		}
+		break;
+	}
+	default:
+		throw NotImplementedException("Unrecognized transaction type!");
+	}
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void PhysicalVacuum::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	// NOP
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+PerfectHashJoinExecutor::PerfectHashJoinExecutor(const PhysicalHashJoin &join_p, JoinHashTable &ht_p,
+                                                 PerfectHashJoinStats perfect_join_stats)
+    : join(join_p), ht(ht_p), perfect_join_statistics(move(perfect_join_stats)) {
+}
+
+bool PerfectHashJoinExecutor::CanDoPerfectHashJoin() {
+	return perfect_join_statistics.is_build_small;
+}
+
+//===--------------------------------------------------------------------===//
+// Build
+//===--------------------------------------------------------------------===//
+bool PerfectHashJoinExecutor::BuildPerfectHashTable(LogicalType &key_type) {
+	// First, allocate memory for each build column
+	auto build_size = perfect_join_statistics.build_range + 1;
+	for (const auto &type : ht.build_types) {
+		perfect_hash_table.emplace_back(type, build_size);
+	}
+	// and for duplicate_checking
+	bitmap_build_idx = unique_ptr<bool[]>(new bool[build_size]);
+	memset(bitmap_build_idx.get(), 0, sizeof(bool) * build_size); // set false
+
+	// Now fill columns with build data
+	JoinHTScanState join_ht_state;
+	return FullScanHashTable(join_ht_state, key_type);
+}
+
+bool PerfectHashJoinExecutor::FullScanHashTable(JoinHTScanState &state, LogicalType &key_type) {
+	Vector tuples_addresses(LogicalType::POINTER, ht.Count());              // allocate space for all the tuples
+	auto key_locations = FlatVector::GetData<data_ptr_t>(tuples_addresses); // get a pointer to vector data
+	// TODO: In a parallel finalize: One should exclusively lock and each thread should do one part of the code below.
+	// Go through all the blocks and fill the keys addresses
+	auto keys_count = ht.FillWithHTOffsets(key_locations, state);
+	// Scan the build keys in the hash table
+	Vector build_vector(key_type, keys_count);
+	RowOperations::FullScanColumn(ht.layout, tuples_addresses, build_vector, keys_count, 0);
+	// Now fill the selection vector using the build keys and create a sequential vector
+	// todo: add check for fast pass when probe is part of build domain
+	SelectionVector sel_build(keys_count + 1);
+	SelectionVector sel_tuples(keys_count + 1);
+	bool success = FillSelectionVectorSwitchBuild(build_vector, sel_build, sel_tuples, keys_count);
+	// early out
+	if (!success) {
+		return false;
+	}
+	if (unique_keys == perfect_join_statistics.build_range + 1 && !ht.has_null) {
+		perfect_join_statistics.is_build_dense = true;
+	}
+	keys_count = unique_keys; // do not consider keys out of the range
+	// Full scan the remaining build columns and fill the perfect hash table
+	for (idx_t i = 0; i < ht.build_types.size(); i++) {
+		auto build_size = perfect_join_statistics.build_range + 1;
+		auto &vector = perfect_hash_table[i];
+		D_ASSERT(vector.GetType() == ht.build_types[i]);
+		const auto col_no = ht.condition_types.size() + i;
+		const auto col_offset = ht.layout.GetOffsets()[col_no];
+		RowOperations::Gather(tuples_addresses, sel_tuples, vector, sel_build, keys_count, col_offset, col_no,
+		                      build_size);
+	}
+	return true;
+}
+
+bool PerfectHashJoinExecutor::FillSelectionVectorSwitchBuild(Vector &source, SelectionVector &sel_vec,
+                                                             SelectionVector &seq_sel_vec, idx_t count) {
+	switch (source.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		return TemplatedFillSelectionVectorBuild<int8_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::INT16:
+		return TemplatedFillSelectionVectorBuild<int16_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::INT32:
+		return TemplatedFillSelectionVectorBuild<int32_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::INT64:
+		return TemplatedFillSelectionVectorBuild<int64_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::UINT8:
+		return TemplatedFillSelectionVectorBuild<uint8_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::UINT16:
+		return TemplatedFillSelectionVectorBuild<uint16_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::UINT32:
+		return TemplatedFillSelectionVectorBuild<uint32_t>(source, sel_vec, seq_sel_vec, count);
+	case PhysicalType::UINT64:
+		return TemplatedFillSelectionVectorBuild<uint64_t>(source, sel_vec, seq_sel_vec, count);
+	default:
+		throw NotImplementedException("Type not supported for perfect hash join");
+	}
+}
+
+template <typename T>
+bool PerfectHashJoinExecutor::TemplatedFillSelectionVectorBuild(Vector &source, SelectionVector &sel_vec,
+                                                                SelectionVector &seq_sel_vec, idx_t count) {
+	if (perfect_join_statistics.build_min.IsNull() || perfect_join_statistics.build_max.IsNull()) {
+		return false;
+	}
+	auto min_value = perfect_join_statistics.build_min.GetValueUnsafe<T>();
+	auto max_value = perfect_join_statistics.build_max.GetValueUnsafe<T>();
+	VectorData vector_data;
+	source.Orrify(count, vector_data);
+	auto data = reinterpret_cast<T *>(vector_data.data);
+	// generate the selection vector
+	for (idx_t i = 0, sel_idx = 0; i < count; ++i) {
+		auto data_idx = vector_data.sel->get_index(i);
+		auto input_value = data[data_idx];
+		// add index to selection vector if value in the range
+		if (min_value <= input_value && input_value <= max_value) {
+			auto idx = (idx_t)(input_value - min_value); // subtract min value to get the idx position
+			sel_vec.set_index(sel_idx, idx);
+			if (bitmap_build_idx[idx]) {
+				return false;
+			} else {
+				bitmap_build_idx[idx] = true;
+				unique_keys++;
+			}
+			seq_sel_vec.set_index(sel_idx++, i);
+		}
+	}
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Probe
+//===--------------------------------------------------------------------===//
+class PerfectHashJoinState : public OperatorState {
+public:
+	DataChunk join_keys;
+	ExpressionExecutor probe_executor;
+	SelectionVector build_sel_vec;
+	SelectionVector probe_sel_vec;
+	SelectionVector seq_sel_vec;
+};
+
+unique_ptr<OperatorState> PerfectHashJoinExecutor::GetOperatorState(ClientContext &context) {
+	auto state = make_unique<PerfectHashJoinState>();
+	state->join_keys.Initialize(join.condition_types);
+	for (auto &cond : join.conditions) {
+		state->probe_executor.AddExpression(*cond.left);
+	}
+	state->build_sel_vec.Initialize(STANDARD_VECTOR_SIZE);
+	state->probe_sel_vec.Initialize(STANDARD_VECTOR_SIZE);
+	state->seq_sel_vec.Initialize(STANDARD_VECTOR_SIZE);
+	return move(state);
+}
+
+OperatorResultType PerfectHashJoinExecutor::ProbePerfectHashTable(ExecutionContext &context, DataChunk &input,
+                                                                  DataChunk &result, OperatorState &state_p) {
+	auto &state = (PerfectHashJoinState &)state_p;
+	// keeps track of how many probe keys have a match
+	idx_t probe_sel_count = 0;
+
+	// fetch the join keys from the chunk
+	state.join_keys.Reset();
+	state.probe_executor.Execute(input, state.join_keys);
+	// select the keys that are in the min-max range
+	auto &keys_vec = state.join_keys.data[0];
+	auto keys_count = state.join_keys.size();
+	// todo: add check for fast pass when probe is part of build domain
+	FillSelectionVectorSwitchProbe(keys_vec, state.build_sel_vec, state.probe_sel_vec, keys_count, probe_sel_count);
+
+	// If build is dense and probe is in build's domain, just reference probe
+	if (perfect_join_statistics.is_build_dense && keys_count == probe_sel_count) {
+		result.Reference(input);
+	} else {
+		// otherwise, filter it out the values that do not match
+		result.Slice(input, state.probe_sel_vec, probe_sel_count, 0);
+	}
+	// on the build side, we need to fetch the data and build dictionary vectors with the sel_vec
+	for (idx_t i = 0; i < ht.build_types.size(); i++) {
+		auto &result_vector = result.data[input.ColumnCount() + i];
+		D_ASSERT(result_vector.GetType() == ht.build_types[i]);
+		auto &build_vec = perfect_hash_table[i];
+		result_vector.Reference(build_vec);
+		result_vector.Slice(state.build_sel_vec, probe_sel_count);
+	}
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+void PerfectHashJoinExecutor::FillSelectionVectorSwitchProbe(Vector &source, SelectionVector &build_sel_vec,
+                                                             SelectionVector &probe_sel_vec, idx_t count,
+                                                             idx_t &probe_sel_count) {
+	switch (source.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		TemplatedFillSelectionVectorProbe<int8_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedFillSelectionVectorProbe<int16_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedFillSelectionVectorProbe<int32_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedFillSelectionVectorProbe<int64_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedFillSelectionVectorProbe<uint8_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedFillSelectionVectorProbe<uint16_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedFillSelectionVectorProbe<uint32_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedFillSelectionVectorProbe<uint64_t>(source, build_sel_vec, probe_sel_vec, count, probe_sel_count);
+		break;
+	default:
+		throw NotImplementedException("Type not supported");
+	}
+}
+
+template <typename T>
+void PerfectHashJoinExecutor::TemplatedFillSelectionVectorProbe(Vector &source, SelectionVector &build_sel_vec,
+                                                                SelectionVector &probe_sel_vec, idx_t count,
+                                                                idx_t &probe_sel_count) {
+	auto min_value = perfect_join_statistics.build_min.GetValueUnsafe<T>();
+	auto max_value = perfect_join_statistics.build_max.GetValueUnsafe<T>();
+
+	VectorData vector_data;
+	source.Orrify(count, vector_data);
+	auto data = reinterpret_cast<T *>(vector_data.data);
+	auto validity_mask = &vector_data.validity;
+	// build selection vector for non-dense build
+	if (validity_mask->AllValid()) {
+		for (idx_t i = 0, sel_idx = 0; i < count; ++i) {
+			// retrieve value from vector
+			auto data_idx = vector_data.sel->get_index(i);
+			auto input_value = data[data_idx];
+			// add index to selection vector if value in the range
+			if (min_value <= input_value && input_value <= max_value) {
+				auto idx = (idx_t)(input_value - min_value); // subtract min value to get the idx position
+				                                             // check for matches in the build
+				if (bitmap_build_idx[idx]) {
+					build_sel_vec.set_index(sel_idx, idx);
+					probe_sel_vec.set_index(sel_idx++, i);
+					probe_sel_count++;
+				}
+			}
+		}
+	} else {
+		for (idx_t i = 0, sel_idx = 0; i < count; ++i) {
+			// retrieve value from vector
+			auto data_idx = vector_data.sel->get_index(i);
+			if (!validity_mask->RowIsValid(data_idx)) {
+				continue;
+			}
+			auto input_value = data[data_idx];
+			// add index to selection vector if value in the range
+			if (min_value <= input_value && input_value <= max_value) {
+				auto idx = (idx_t)(input_value - min_value); // subtract min value to get the idx position
+				                                             // check for matches in the build
+				if (bitmap_build_idx[idx]) {
+					build_sel_vec.set_index(sel_idx, idx);
+					probe_sel_vec.set_index(sel_idx++, i);
+					probe_sel_count++;
+				}
+			}
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalBlockwiseNLJoin::PhysicalBlockwiseNLJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                                 unique_ptr<PhysicalOperator> right, unique_ptr<Expression> condition,
+                                                 JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalJoin(op, PhysicalOperatorType::BLOCKWISE_NL_JOIN, join_type, estimated_cardinality),
+      condition(move(condition)) {
+	children.push_back(move(left));
+	children.push_back(move(right));
+	// MARK and SINGLE joins not handled
+	D_ASSERT(join_type != JoinType::MARK);
+	D_ASSERT(join_type != JoinType::SINGLE);
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class BlockwiseNLJoinLocalState : public LocalSinkState {
+public:
+	BlockwiseNLJoinLocalState() {
+	}
+};
+
+class BlockwiseNLJoinGlobalState : public GlobalSinkState {
+public:
+	mutex lock;
+	ChunkCollection right_chunks;
+	//! Whether or not a tuple on the RHS has found a match, only used for FULL OUTER joins
+	unique_ptr<bool[]> rhs_found_match;
+};
+
+unique_ptr<GlobalSinkState> PhysicalBlockwiseNLJoin::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<BlockwiseNLJoinGlobalState>();
+}
+
+unique_ptr<LocalSinkState> PhysicalBlockwiseNLJoin::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<BlockwiseNLJoinLocalState>();
+}
+
+SinkResultType PhysicalBlockwiseNLJoin::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                             DataChunk &input) const {
+	auto &gstate = (BlockwiseNLJoinGlobalState &)state;
+	lock_guard<mutex> nl_lock(gstate.lock);
+	gstate.right_chunks.Append(input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+SinkFinalizeType PhysicalBlockwiseNLJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                   GlobalSinkState &gstate_p) const {
+	auto &gstate = (BlockwiseNLJoinGlobalState &)gstate_p;
+	if (IsRightOuterJoin(join_type)) {
+		gstate.rhs_found_match = unique_ptr<bool[]>(new bool[gstate.right_chunks.Count()]);
+		memset(gstate.rhs_found_match.get(), 0, sizeof(bool) * gstate.right_chunks.Count());
+	}
+	if (gstate.right_chunks.Count() == 0 && EmptyResultIfRHSIsEmpty()) {
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class BlockwiseNLJoinState : public OperatorState {
+public:
+	explicit BlockwiseNLJoinState(const PhysicalBlockwiseNLJoin &op)
+	    : left_position(0), right_position(0), executor(*op.condition) {
+		if (IsLeftOuterJoin(op.join_type)) {
+			left_found_match = unique_ptr<bool[]>(new bool[STANDARD_VECTOR_SIZE]);
+			memset(left_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+		}
+	}
+
+	//! Whether or not a tuple on the LHS has found a match, only used for LEFT OUTER and FULL OUTER joins
+	unique_ptr<bool[]> left_found_match;
+	idx_t left_position;
+	idx_t right_position;
+	ExpressionExecutor executor;
+};
+
+unique_ptr<OperatorState> PhysicalBlockwiseNLJoin::GetOperatorState(ClientContext &context) const {
+	return make_unique<BlockwiseNLJoinState>(*this);
+}
+
+OperatorResultType PhysicalBlockwiseNLJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                    GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	D_ASSERT(input.size() > 0);
+	auto &state = (BlockwiseNLJoinState &)state_p;
+	auto &gstate = (BlockwiseNLJoinGlobalState &)*sink_state;
+
+	if (gstate.right_chunks.Count() == 0) {
+		// empty RHS
+		if (!EmptyResultIfRHSIsEmpty()) {
+			PhysicalComparisonJoin::ConstructEmptyJoinResult(join_type, false, input, chunk);
+			return OperatorResultType::NEED_MORE_INPUT;
+		} else {
+			return OperatorResultType::FINISHED;
+		}
+	}
+
+	// now perform the actual join
+	// we construct a combined DataChunk by referencing the LHS and the RHS
+	// every step that we do not have output results we shift the vectors of the RHS one up or down
+	// this creates a new "alignment" between the tuples, exhausting all possible O(n^2) combinations
+	// while allowing us to use vectorized execution for every step
+	idx_t result_count = 0;
+	do {
+		if (state.left_position >= input.size()) {
+			// exhausted LHS, have to pull new LHS chunk
+			if (state.left_found_match) {
+				// left join: before we move to the next chunk, see if we need to output any vectors that didn't
+				// have a match found
+				PhysicalJoin::ConstructLeftJoinResult(input, chunk, state.left_found_match.get());
+				memset(state.left_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+			}
+			state.left_position = 0;
+			state.right_position = 0;
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+		auto &lchunk = input;
+		auto &rchunk = gstate.right_chunks.GetChunk(state.right_position);
+
+		// fill in the current element of the LHS into the chunk
+		D_ASSERT(chunk.ColumnCount() == lchunk.ColumnCount() + rchunk.ColumnCount());
+		for (idx_t i = 0; i < lchunk.ColumnCount(); i++) {
+			ConstantVector::Reference(chunk.data[i], lchunk.data[i], state.left_position, lchunk.size());
+		}
+		// for the RHS we just reference the entire vector
+		for (idx_t i = 0; i < rchunk.ColumnCount(); i++) {
+			chunk.data[lchunk.ColumnCount() + i].Reference(rchunk.data[i]);
+		}
+		chunk.SetCardinality(rchunk.size());
+
+		// now perform the computation
+		SelectionVector match_sel(STANDARD_VECTOR_SIZE);
+		result_count = state.executor.SelectExpression(chunk, match_sel);
+		if (result_count > 0) {
+			// found a match!
+			// set the match flags in the LHS
+			if (state.left_found_match) {
+				state.left_found_match[state.left_position] = true;
+			}
+			// set the match flags in the RHS
+			if (gstate.rhs_found_match) {
+				for (idx_t i = 0; i < result_count; i++) {
+					auto idx = match_sel.get_index(i);
+					gstate.rhs_found_match[state.right_position * STANDARD_VECTOR_SIZE + idx] = true;
+				}
+			}
+			chunk.Slice(match_sel, result_count);
+		} else {
+			// no result: reset the chunk
+			chunk.Reset();
+		}
+		// move to the next tuple on the LHS
+		state.left_position++;
+		if (state.left_position >= input.size()) {
+			// exhausted the current chunk, move to the next RHS chunk
+			state.right_position++;
+			if (state.right_position < gstate.right_chunks.ChunkCount()) {
+				// we still have chunks left! start over on the LHS
+				state.left_position = 0;
+			}
+		}
+	} while (result_count == 0);
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+string PhysicalBlockwiseNLJoin::ParamsToString() const {
+	string extra_info = JoinTypeToString(join_type) + "\n";
+	extra_info += condition->GetName();
+	return extra_info;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class BlockwiseNLJoinScanState : public GlobalSourceState {
+public:
+	explicit BlockwiseNLJoinScanState(const PhysicalBlockwiseNLJoin &op) : op(op), right_outer_position(0) {
+	}
+
+	mutex lock;
+	const PhysicalBlockwiseNLJoin &op;
+	//! The position in the RHS in the final scan of the FULL OUTER JOIN
+	idx_t right_outer_position;
+
+public:
+	idx_t MaxThreads() override {
+		auto &sink = (BlockwiseNLJoinGlobalState &)*op.sink_state;
+		return sink.right_chunks.Count() / (STANDARD_VECTOR_SIZE * 10);
+	}
+};
+
+unique_ptr<GlobalSourceState> PhysicalBlockwiseNLJoin::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<BlockwiseNLJoinScanState>(*this);
+}
+
+void PhysicalBlockwiseNLJoin::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                      LocalSourceState &lstate) const {
+	D_ASSERT(IsRightOuterJoin(join_type));
+	// check if we need to scan any unmatched tuples from the RHS for the full/right outer join
+	auto &sink = (BlockwiseNLJoinGlobalState &)*sink_state;
+	auto &state = (BlockwiseNLJoinScanState &)gstate;
+
+	// if the LHS is exhausted in a FULL/RIGHT OUTER JOIN, we scan the found_match for any chunks we
+	// still need to output
+	lock_guard<mutex> l(state.lock);
+	PhysicalComparisonJoin::ConstructFullOuterJoinResult(sink.rhs_found_match.get(), sink.right_chunks, chunk,
+	                                                     state.right_outer_position);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PhysicalComparisonJoin::PhysicalComparisonJoin(LogicalOperator &op, PhysicalOperatorType type,
+                                               vector<JoinCondition> conditions_p, JoinType join_type,
+                                               idx_t estimated_cardinality)
+    : PhysicalJoin(op, type, join_type, estimated_cardinality) {
+	conditions.resize(conditions_p.size());
+	// we reorder conditions so the ones with COMPARE_EQUAL occur first
+	idx_t equal_position = 0;
+	idx_t other_position = conditions_p.size() - 1;
+	for (idx_t i = 0; i < conditions_p.size(); i++) {
+		if (conditions_p[i].comparison == ExpressionType::COMPARE_EQUAL ||
+		    conditions_p[i].comparison == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+			// COMPARE_EQUAL and COMPARE_NOT_DISTINCT_FROM, move to the start
+			conditions[equal_position++] = std::move(conditions_p[i]);
+		} else {
+			// other expression, move to the end
+			conditions[other_position--] = std::move(conditions_p[i]);
+		}
+	}
+}
+
+string PhysicalComparisonJoin::ParamsToString() const {
+	string extra_info = JoinTypeToString(join_type) + "\n";
+	for (auto &it : conditions) {
+		string op = ExpressionTypeToOperator(it.comparison);
+		extra_info += it.left->GetName() + " " + op + " " + it.right->GetName() + "\n";
+	}
+	return extra_info;
+}
+
+void PhysicalComparisonJoin::ConstructEmptyJoinResult(JoinType join_type, bool has_null, DataChunk &input,
+                                                      DataChunk &result) {
+	// empty hash table, special case
+	if (join_type == JoinType::ANTI) {
+		// anti join with empty hash table, NOP join
+		// return the input
+		D_ASSERT(input.ColumnCount() == result.ColumnCount());
+		result.Reference(input);
+	} else if (join_type == JoinType::MARK) {
+		// MARK join with empty hash table
+		D_ASSERT(join_type == JoinType::MARK);
+		D_ASSERT(result.ColumnCount() == input.ColumnCount() + 1);
+		auto &result_vector = result.data.back();
+		D_ASSERT(result_vector.GetType() == LogicalType::BOOLEAN);
+		// for every data vector, we just reference the child chunk
+		result.SetCardinality(input);
+		for (idx_t i = 0; i < input.ColumnCount(); i++) {
+			result.data[i].Reference(input.data[i]);
+		}
+		// for the MARK vector:
+		// if the HT has no NULL values (i.e. empty result set), return a vector that has false for every input
+		// entry if the HT has NULL values (i.e. result set had values, but all were NULL), return a vector that
+		// has NULL for every input entry
+		if (!has_null) {
+			auto bool_result = FlatVector::GetData<bool>(result_vector);
+			for (idx_t i = 0; i < result.size(); i++) {
+				bool_result[i] = false;
+			}
+		} else {
+			FlatVector::Validity(result_vector).SetAllInvalid(result.size());
+		}
+	} else if (join_type == JoinType::LEFT || join_type == JoinType::OUTER || join_type == JoinType::SINGLE) {
+		// LEFT/FULL OUTER/SINGLE join and build side is empty
+		// for the LHS we reference the data
+		result.SetCardinality(input.size());
+		for (idx_t i = 0; i < input.ColumnCount(); i++) {
+			result.data[i].Reference(input.data[i]);
+		}
+		// for the RHS
+		for (idx_t k = input.ColumnCount(); k < result.ColumnCount(); k++) {
+			result.data[k].SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result.data[k], true);
+		}
+	}
+}
+
+void PhysicalComparisonJoin::ConstructFullOuterJoinResult(bool *found_match, ChunkCollection &input, DataChunk &result,
+                                                          idx_t &scan_position) {
+	// fill in NULL values for the LHS
+	SelectionVector rsel(STANDARD_VECTOR_SIZE);
+	while (scan_position < input.Count()) {
+		auto &rhs_chunk = input.GetChunk(scan_position / STANDARD_VECTOR_SIZE);
+		idx_t result_count = 0;
+		// figure out which tuples didn't find a match in the RHS
+		for (idx_t i = 0; i < rhs_chunk.size(); i++) {
+			if (!found_match[scan_position + i]) {
+				rsel.set_index(result_count++, i);
+			}
+		}
+		scan_position += STANDARD_VECTOR_SIZE;
+		if (result_count > 0) {
+			// if there were any tuples that didn't find a match, output them
+			idx_t left_column_count = result.ColumnCount() - input.ColumnCount();
+			for (idx_t i = 0; i < left_column_count; i++) {
+				result.data[i].SetVectorType(VectorType::CONSTANT_VECTOR);
+				ConstantVector::SetNull(result.data[i], true);
+			}
+			for (idx_t col_idx = 0; col_idx < rhs_chunk.ColumnCount(); col_idx++) {
+				result.data[left_column_count + col_idx].Slice(rhs_chunk.data[col_idx], rsel, result_count);
+			}
+			result.SetCardinality(result_count);
+			return;
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+PhysicalCrossProduct::PhysicalCrossProduct(vector<LogicalType> types, unique_ptr<PhysicalOperator> left,
+                                           unique_ptr<PhysicalOperator> right, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::CROSS_PRODUCT, move(types), estimated_cardinality) {
+	children.push_back(move(left));
+	children.push_back(move(right));
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class CrossProductGlobalState : public GlobalSinkState {
+public:
+	CrossProductGlobalState() {
+	}
+
+	ChunkCollection rhs_materialized;
+	mutex rhs_lock;
+};
+
+unique_ptr<GlobalSinkState> PhysicalCrossProduct::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<CrossProductGlobalState>();
+}
+
+SinkResultType PhysicalCrossProduct::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p,
+                                          DataChunk &input) const {
+	auto &sink = (CrossProductGlobalState &)state;
+	lock_guard<mutex> client_guard(sink.rhs_lock);
+	sink.rhs_materialized.Append(input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class CrossProductOperatorState : public OperatorState {
+public:
+	CrossProductOperatorState() : right_position(0) {
+	}
+
+	idx_t right_position;
+};
+
+unique_ptr<OperatorState> PhysicalCrossProduct::GetOperatorState(ClientContext &context) const {
+	return make_unique<CrossProductOperatorState>();
+}
+
+OperatorResultType PhysicalCrossProduct::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                 GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (CrossProductOperatorState &)state_p;
+	auto &sink = (CrossProductGlobalState &)*sink_state;
+	auto &right_collection = sink.rhs_materialized;
+
+	if (sink.rhs_materialized.Count() == 0) {
+		// no RHS: empty result
+		return OperatorResultType::FINISHED;
+	}
+	if (state.right_position >= right_collection.Count()) {
+		// ran out of entries on the RHS
+		// reset the RHS and move to the next chunk on the LHS
+		state.right_position = 0;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	auto &left_chunk = input;
+	// now match the current vector of the left relation with the current row
+	// from the right relation
+	chunk.SetCardinality(left_chunk.size());
+	// create a reference to the vectors of the left column
+	for (idx_t i = 0; i < left_chunk.ColumnCount(); i++) {
+		chunk.data[i].Reference(left_chunk.data[i]);
+	}
+	// duplicate the values on the right side
+	auto &right_chunk = right_collection.GetChunkForRow(state.right_position);
+	auto row_in_chunk = state.right_position % STANDARD_VECTOR_SIZE;
+	for (idx_t i = 0; i < right_collection.ColumnCount(); i++) {
+		ConstantVector::Reference(chunk.data[left_chunk.ColumnCount() + i], right_chunk.data[i], row_in_chunk,
+		                          right_chunk.size());
+	}
+
+	// for the next iteration, move to the next position on the right side
+	state.right_position++;
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalCrossProduct::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	PhysicalJoin::BuildJoinPipelines(executor, current, state, *this);
+}
+
+vector<const PhysicalOperator *> PhysicalCrossProduct::GetSources() const {
+	return children[0]->GetSources();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalDelimJoin::PhysicalDelimJoin(vector<LogicalType> types, unique_ptr<PhysicalOperator> original_join,
+                                     vector<PhysicalOperator *> delim_scans, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::DELIM_JOIN, move(types), estimated_cardinality), join(move(original_join)),
+      delim_scans(move(delim_scans)) {
+	D_ASSERT(join->children.size() == 2);
+	// now for the original join
+	// we take its left child, this is the side that we will duplicate eliminate
+	children.push_back(move(join->children[0]));
+
+	// we replace it with a PhysicalChunkCollectionScan, that scans the ChunkCollection that we keep cached
+	// the actual chunk collection to scan will be created in the DelimJoinGlobalState
+	auto cached_chunk_scan = make_unique<PhysicalChunkScan>(children[0]->GetTypes(), PhysicalOperatorType::CHUNK_SCAN,
+	                                                        estimated_cardinality);
+	join->children[0] = move(cached_chunk_scan);
+}
+
+vector<PhysicalOperator *> PhysicalDelimJoin::GetChildren() const {
+	vector<PhysicalOperator *> result;
+	for (auto &child : children) {
+		result.push_back(child.get());
+	}
+	result.push_back(join.get());
+	result.push_back(distinct.get());
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class DelimJoinGlobalState : public GlobalSinkState {
+public:
+	explicit DelimJoinGlobalState(const PhysicalDelimJoin *delim_join) {
+		D_ASSERT(delim_join->delim_scans.size() > 0);
+		// set up the delim join chunk to scan in the original join
+		auto &cached_chunk_scan = (PhysicalChunkScan &)*delim_join->join->children[0];
+		cached_chunk_scan.collection = &lhs_data;
+	}
+
+	ChunkCollection lhs_data;
+	mutex lhs_lock;
+
+	void Merge(ChunkCollection &input) {
+		lock_guard<mutex> guard(lhs_lock);
+		lhs_data.Append(input);
+	}
+};
+
+class DelimJoinLocalState : public LocalSinkState {
+public:
+	unique_ptr<LocalSinkState> distinct_state;
+	ChunkCollection lhs_data;
+
+	void Append(DataChunk &input) {
+		lhs_data.Append(input);
+	}
+};
+
+unique_ptr<GlobalSinkState> PhysicalDelimJoin::GetGlobalSinkState(ClientContext &context) const {
+	auto state = make_unique<DelimJoinGlobalState>(this);
+	distinct->sink_state = distinct->GetGlobalSinkState(context);
+	if (delim_scans.size() > 1) {
+		PhysicalHashAggregate::SetMultiScan(*distinct->sink_state);
+	}
+	return move(state);
+}
+
+unique_ptr<LocalSinkState> PhysicalDelimJoin::GetLocalSinkState(ExecutionContext &context) const {
+	auto state = make_unique<DelimJoinLocalState>();
+	state->distinct_state = distinct->GetLocalSinkState(context);
+	return move(state);
+}
+
+SinkResultType PhysicalDelimJoin::Sink(ExecutionContext &context, GlobalSinkState &state_p, LocalSinkState &lstate_p,
+                                       DataChunk &input) const {
+	auto &lstate = (DelimJoinLocalState &)lstate_p;
+	lstate.lhs_data.Append(input);
+	distinct->Sink(context, *distinct->sink_state, *lstate.distinct_state, input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalDelimJoin::Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p) const {
+	auto &lstate = (DelimJoinLocalState &)lstate_p;
+	auto &gstate = (DelimJoinGlobalState &)state;
+	gstate.Merge(lstate.lhs_data);
+	distinct->Combine(context, *distinct->sink_state, *lstate.distinct_state);
+}
+
+SinkFinalizeType PhysicalDelimJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &client,
+                                             GlobalSinkState &gstate) const {
+	// finalize the distinct HT
+	D_ASSERT(distinct);
+	distinct->Finalize(pipeline, event, client, *distinct->sink_state);
+	return SinkFinalizeType::READY;
+}
+
+string PhysicalDelimJoin::ParamsToString() const {
+	return join->ParamsToString();
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalDelimJoin::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	op_state.reset();
+	sink_state.reset();
+
+	// duplicate eliminated join
+	auto pipeline = make_shared<Pipeline>(executor);
+	state.SetPipelineSink(*pipeline, this);
+	current.AddDependency(pipeline);
+
+	// recurse into the pipeline child
+	children[0]->BuildPipelines(executor, *pipeline, state);
+	if (type == PhysicalOperatorType::DELIM_JOIN) {
+		// recurse into the actual join
+		// any pipelines in there depend on the main pipeline
+		// any scan of the duplicate eliminated data on the RHS depends on this pipeline
+		// we add an entry to the mapping of (PhysicalOperator*) -> (Pipeline*)
+		for (auto &delim_scan : delim_scans) {
+			state.delim_join_dependencies[delim_scan] = pipeline.get();
+		}
+		join->BuildPipelines(executor, current, state);
+	}
+	if (!state.recursive_cte) {
+		// regular pipeline: schedule it
+		state.AddPipeline(executor, move(pipeline));
+	} else {
+		// CTE pipeline! add it to the CTE pipelines
+		auto &cte = (PhysicalRecursiveCTE &)*state.recursive_cte;
+		cte.pipelines.push_back(move(pipeline));
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                   unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+                                   const vector<idx_t> &left_projection_map,
+                                   const vector<idx_t> &right_projection_map_p, vector<LogicalType> delim_types,
+                                   idx_t estimated_cardinality, PerfectHashJoinStats perfect_join_stats)
+    : PhysicalComparisonJoin(op, PhysicalOperatorType::HASH_JOIN, move(cond), join_type, estimated_cardinality),
+      right_projection_map(right_projection_map_p), delim_types(move(delim_types)),
+      perfect_join_statistics(move(perfect_join_stats)) {
+
+	children.push_back(move(left));
+	children.push_back(move(right));
+
+	D_ASSERT(left_projection_map.empty());
+	for (auto &condition : conditions) {
+		condition_types.push_back(condition.left->return_type);
+	}
+
+	// for ANTI, SEMI and MARK join, we only need to store the keys, so for these the build types are empty
+	if (join_type != JoinType::ANTI && join_type != JoinType::SEMI && join_type != JoinType::MARK) {
+		build_types = LogicalOperator::MapTypes(children[1]->GetTypes(), right_projection_map);
+	}
+}
+
+PhysicalHashJoin::PhysicalHashJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                   unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+                                   idx_t estimated_cardinality, PerfectHashJoinStats perfect_join_state)
+    : PhysicalHashJoin(op, move(left), move(right), move(cond), join_type, {}, {}, {}, estimated_cardinality,
+                       std::move(perfect_join_state)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class HashJoinLocalState : public LocalSinkState {
+public:
+	DataChunk build_chunk;
+	DataChunk join_keys;
+	ExpressionExecutor build_executor;
+};
+
+class HashJoinGlobalState : public GlobalSinkState {
+public:
+	HashJoinGlobalState() {
+	}
+
+	//! The HT used by the join
+	unique_ptr<JoinHashTable> hash_table;
+	//! The perfect hash join executor (if any)
+	unique_ptr<PerfectHashJoinExecutor> perfect_join_executor;
+	//! Whether or not the hash table has been finalized
+	bool finalized = false;
+};
+
+unique_ptr<GlobalSinkState> PhysicalHashJoin::GetGlobalSinkState(ClientContext &context) const {
+	auto state = make_unique<HashJoinGlobalState>();
+	state->hash_table =
+	    make_unique<JoinHashTable>(BufferManager::GetBufferManager(context), conditions, build_types, join_type);
+	if (!delim_types.empty() && join_type == JoinType::MARK) {
+		// correlated MARK join
+		if (delim_types.size() + 1 == conditions.size()) {
+			// the correlated MARK join has one more condition than the amount of correlated columns
+			// this is the case in a correlated ANY() expression
+			// in this case we need to keep track of additional entries, namely:
+			// - (1) the total amount of elements per group
+			// - (2) the amount of non-null elements per group
+			// we need these to correctly deal with the cases of either:
+			// - (1) the group being empty [in which case the result is always false, even if the comparison is NULL]
+			// - (2) the group containing a NULL value [in which case FALSE becomes NULL]
+			auto &info = state->hash_table->correlated_mark_join_info;
+
+			vector<LogicalType> payload_types;
+			vector<BoundAggregateExpression *> correlated_aggregates;
+			unique_ptr<BoundAggregateExpression> aggr;
+
+			// jury-rigging the GroupedAggregateHashTable
+			// we need a count_star and a count to get counts with and without NULLs
+			aggr = AggregateFunction::BindAggregateFunction(context, CountStarFun::GetFunction(), {}, nullptr, false);
+			correlated_aggregates.push_back(&*aggr);
+			payload_types.push_back(aggr->return_type);
+			info.correlated_aggregates.push_back(move(aggr));
+
+			auto count_fun = CountFun::GetFunction();
+			vector<unique_ptr<Expression>> children;
+			// this is a dummy but we need it to make the hash table understand whats going on
+			children.push_back(make_unique_base<Expression, BoundReferenceExpression>(count_fun.return_type, 0));
+			aggr = AggregateFunction::BindAggregateFunction(context, count_fun, move(children), nullptr, false);
+			correlated_aggregates.push_back(&*aggr);
+			payload_types.push_back(aggr->return_type);
+			info.correlated_aggregates.push_back(move(aggr));
+
+			info.correlated_counts = make_unique<GroupedAggregateHashTable>(
+			    BufferManager::GetBufferManager(context), delim_types, payload_types, correlated_aggregates);
+			info.correlated_types = delim_types;
+			info.group_chunk.Initialize(delim_types);
+			info.result_chunk.Initialize(payload_types);
+		}
+	}
+	// for perfect hash join
+	state->perfect_join_executor =
+	    make_unique<PerfectHashJoinExecutor>(*this, *state->hash_table, perfect_join_statistics);
+	return move(state);
+}
+
+unique_ptr<LocalSinkState> PhysicalHashJoin::GetLocalSinkState(ExecutionContext &context) const {
+	auto state = make_unique<HashJoinLocalState>();
+	if (!right_projection_map.empty()) {
+		state->build_chunk.Initialize(build_types);
+	}
+	for (auto &cond : conditions) {
+		state->build_executor.AddExpression(*cond.right);
+	}
+	state->join_keys.Initialize(condition_types);
+	return move(state);
+}
+
+SinkResultType PhysicalHashJoin::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p,
+                                      DataChunk &input) const {
+	auto &sink = (HashJoinGlobalState &)state;
+	auto &lstate = (HashJoinLocalState &)lstate_p;
+	// resolve the join keys for the right chunk
+	lstate.join_keys.Reset();
+	lstate.build_executor.Execute(input, lstate.join_keys);
+	// TODO: add statement to check for possible per
+	// build the HT
+	if (!right_projection_map.empty()) {
+		// there is a projection map: fill the build chunk with the projected columns
+		lstate.build_chunk.Reset();
+		lstate.build_chunk.SetCardinality(input);
+		for (idx_t i = 0; i < right_projection_map.size(); i++) {
+			lstate.build_chunk.data[i].Reference(input.data[right_projection_map[i]]);
+		}
+		sink.hash_table->Build(lstate.join_keys, lstate.build_chunk);
+	} else if (!build_types.empty()) {
+		// there is not a projected map: place the entire right chunk in the HT
+		sink.hash_table->Build(lstate.join_keys, input);
+	} else {
+		// there are only keys: place an empty chunk in the payload
+		lstate.build_chunk.SetCardinality(input.size());
+		sink.hash_table->Build(lstate.join_keys, lstate.build_chunk);
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalHashJoin::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+	auto &state = (HashJoinLocalState &)lstate;
+	auto &client_profiler = QueryProfiler::Get(context.client);
+	context.thread.profiler.Flush(this, &state.build_executor, "build_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+SinkFinalizeType PhysicalHashJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                            GlobalSinkState &gstate) const {
+	auto &sink = (HashJoinGlobalState &)gstate;
+	// check for possible perfect hash table
+	auto use_perfect_hash = sink.perfect_join_executor->CanDoPerfectHashJoin();
+	if (use_perfect_hash) {
+		D_ASSERT(sink.hash_table->equality_types.size() == 1);
+		auto key_type = sink.hash_table->equality_types[0];
+		use_perfect_hash = sink.perfect_join_executor->BuildPerfectHashTable(key_type);
+	}
+	// In case of a large build side or duplicates, use regular hash join
+	if (!use_perfect_hash) {
+		sink.perfect_join_executor.reset();
+		sink.hash_table->Finalize();
+	}
+	sink.finalized = true;
+	if (sink.hash_table->Count() == 0 && EmptyResultIfRHSIsEmpty()) {
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class PhysicalHashJoinState : public OperatorState {
+public:
+	DataChunk join_keys;
+	ExpressionExecutor probe_executor;
+	unique_ptr<JoinHashTable::ScanStructure> scan_structure;
+	unique_ptr<OperatorState> perfect_hash_join_state;
+
+public:
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		context.thread.profiler.Flush(op, &probe_executor, "probe_executor", 0);
+	}
+};
+
+unique_ptr<OperatorState> PhysicalHashJoin::GetOperatorState(ClientContext &context) const {
+	auto state = make_unique<PhysicalHashJoinState>();
+	auto &sink = (HashJoinGlobalState &)*sink_state;
+	if (sink.perfect_join_executor) {
+		state->perfect_hash_join_state = sink.perfect_join_executor->GetOperatorState(context);
+	} else {
+		state->join_keys.Initialize(condition_types);
+		for (auto &cond : conditions) {
+			state->probe_executor.AddExpression(*cond.left);
+		}
+	}
+	return move(state);
+}
+
+OperatorResultType PhysicalHashJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                             GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (PhysicalHashJoinState &)state_p;
+	auto &sink = (HashJoinGlobalState &)*sink_state;
+	D_ASSERT(sink.finalized);
+
+	if (sink.hash_table->Count() == 0 && EmptyResultIfRHSIsEmpty()) {
+		return OperatorResultType::FINISHED;
+	}
+	if (sink.perfect_join_executor) {
+		return sink.perfect_join_executor->ProbePerfectHashTable(context, input, chunk, *state.perfect_hash_join_state);
+	}
+
+	if (state.scan_structure) {
+		// still have elements remaining from the previous probe (i.e. we got
+		// >1024 elements in the previous probe)
+		state.scan_structure->Next(state.join_keys, input, chunk);
+		if (chunk.size() > 0) {
+			return OperatorResultType::HAVE_MORE_OUTPUT;
+		}
+		state.scan_structure = nullptr;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	// probe the HT
+	if (sink.hash_table->Count() == 0) {
+		ConstructEmptyJoinResult(sink.hash_table->join_type, sink.hash_table->has_null, input, chunk);
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+	// resolve the join keys for the left chunk
+	state.join_keys.Reset();
+	state.probe_executor.Execute(input, state.join_keys);
+
+	// perform the actual probe
+	state.scan_structure = sink.hash_table->Probe(state.join_keys);
+	state.scan_structure->Next(state.join_keys, input, chunk);
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class HashJoinScanState : public GlobalSourceState {
+public:
+	explicit HashJoinScanState(const PhysicalHashJoin &op) : op(op) {
+	}
+
+	const PhysicalHashJoin &op;
+	//! Only used for FULL OUTER JOIN: scan state of the final scan to find unmatched tuples in the build-side
+	JoinHTScanState ht_scan_state;
+
+	idx_t MaxThreads() override {
+		auto &sink = (HashJoinGlobalState &)*op.sink_state;
+		return sink.hash_table->Count() / (STANDARD_VECTOR_SIZE * 10);
+	}
+};
+
+unique_ptr<GlobalSourceState> PhysicalHashJoin::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<HashJoinScanState>(*this);
+}
+
+void PhysicalHashJoin::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                               LocalSourceState &lstate) const {
+	D_ASSERT(IsRightOuterJoin(join_type));
+	// check if we need to scan any unmatched tuples from the RHS for the full/right outer join
+	auto &sink = (HashJoinGlobalState &)*sink_state;
+	auto &state = (HashJoinScanState &)gstate;
+	sink.hash_table->ScanFullOuter(chunk, state.ht_scan_state);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <thread>
+
+namespace duckdb {
+
+PhysicalIEJoin::PhysicalIEJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                               unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+                               idx_t estimated_cardinality)
+    : PhysicalRangeJoin(op, PhysicalOperatorType::IE_JOIN, move(left), move(right), move(cond), join_type,
+                        estimated_cardinality) {
+
+	// 1. let L1 (resp. L2) be the array of column X (resp. Y)
+	D_ASSERT(conditions.size() >= 2);
+	lhs_orders.resize(2);
+	rhs_orders.resize(2);
+	for (idx_t i = 0; i < 2; ++i) {
+		auto &cond = conditions[i];
+		D_ASSERT(cond.left->return_type == cond.right->return_type);
+		join_key_types.push_back(cond.left->return_type);
+
+		// Convert the conditions to sort orders
+		auto left = cond.left->Copy();
+		auto right = cond.right->Copy();
+		auto sense = OrderType::INVALID;
+
+		// 2. if (op1 ∈ {>, ≥}) sort L1 in descending order
+		// 3. else if (op1 ∈ {<, ≤}) sort L1 in ascending order
+		// 4. if (op2 ∈ {>, ≥}) sort L2 in ascending order
+		// 5. else if (op2 ∈ {<, ≤}) sort L2 in descending order
+		switch (cond.comparison) {
+		case ExpressionType::COMPARE_GREATERTHAN:
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			sense = i ? OrderType::ASCENDING : OrderType::DESCENDING;
+			break;
+		case ExpressionType::COMPARE_LESSTHAN:
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			sense = i ? OrderType::DESCENDING : OrderType::ASCENDING;
+			break;
+		default:
+			throw NotImplementedException("Unimplemented join type for IEJoin");
+		}
+		lhs_orders[i].emplace_back(BoundOrderByNode(sense, OrderByNullType::NULLS_LAST, move(left)));
+		rhs_orders[i].emplace_back(BoundOrderByNode(sense, OrderByNullType::NULLS_LAST, move(right)));
+	}
+
+	for (idx_t i = 2; i < conditions.size(); ++i) {
+		auto &cond = conditions[i];
+		D_ASSERT(cond.left->return_type == cond.right->return_type);
+		join_key_types.push_back(cond.left->return_type);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class IEJoinLocalState : public LocalSinkState {
+public:
+	using LocalSortedTable = PhysicalRangeJoin::LocalSortedTable;
+
+	IEJoinLocalState(const PhysicalRangeJoin &op, const idx_t child) : table(op, child) {
+	}
+
+	//! The local sort state
+	LocalSortedTable table;
+};
+
+class IEJoinGlobalState : public GlobalSinkState {
+public:
+	using GlobalSortedTable = PhysicalRangeJoin::GlobalSortedTable;
+
+public:
+	IEJoinGlobalState(ClientContext &context, const PhysicalIEJoin &op) : child(0) {
+		tables.resize(2);
+		RowLayout lhs_layout;
+		lhs_layout.Initialize(op.children[0]->types);
+		vector<BoundOrderByNode> lhs_order;
+		lhs_order.emplace_back(op.lhs_orders[0][0].Copy());
+		tables[0] = make_unique<GlobalSortedTable>(context, lhs_order, lhs_layout);
+
+		RowLayout rhs_layout;
+		rhs_layout.Initialize(op.children[1]->types);
+		vector<BoundOrderByNode> rhs_order;
+		rhs_order.emplace_back(op.rhs_orders[0][0].Copy());
+		tables[1] = make_unique<GlobalSortedTable>(context, rhs_order, rhs_layout);
+	}
+
+	IEJoinGlobalState(IEJoinGlobalState &prev)
+	    : GlobalSinkState(prev), tables(move(prev.tables)), child(prev.child + 1) {
+	}
+
+	void Sink(DataChunk &input, IEJoinLocalState &lstate) {
+		auto &table = *tables[child];
+		auto &global_sort_state = table.global_sort_state;
+		auto &local_sort_state = lstate.table.local_sort_state;
+
+		// Sink the data into the local sort state
+		lstate.table.Sink(input, global_sort_state);
+
+		// When sorting data reaches a certain size, we sort it
+		if (local_sort_state.SizeInBytes() >= table.memory_per_thread) {
+			local_sort_state.Sort(global_sort_state, true);
+		}
+	}
+
+	vector<unique_ptr<GlobalSortedTable>> tables;
+	size_t child;
+};
+
+unique_ptr<GlobalSinkState> PhysicalIEJoin::GetGlobalSinkState(ClientContext &context) const {
+	D_ASSERT(!sink_state);
+	return make_unique<IEJoinGlobalState>(context, *this);
+}
+
+unique_ptr<LocalSinkState> PhysicalIEJoin::GetLocalSinkState(ExecutionContext &context) const {
+	idx_t sink_child = 0;
+	if (sink_state) {
+		const auto &ie_sink = (IEJoinGlobalState &)*sink_state;
+		sink_child = ie_sink.child;
+	}
+	return make_unique<IEJoinLocalState>(*this, sink_child);
+}
+
+SinkResultType PhysicalIEJoin::Sink(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p,
+                                    DataChunk &input) const {
+	auto &gstate = (IEJoinGlobalState &)gstate_p;
+	auto &lstate = (IEJoinLocalState &)lstate_p;
+
+	gstate.Sink(input, lstate);
+
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalIEJoin::Combine(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p) const {
+	auto &gstate = (IEJoinGlobalState &)gstate_p;
+	auto &lstate = (IEJoinLocalState &)lstate_p;
+	gstate.tables[gstate.child]->Combine(lstate.table);
+	auto &client_profiler = QueryProfiler::Get(context.client);
+
+	context.thread.profiler.Flush(this, &lstate.table.executor, gstate.child ? "rhs_executor" : "lhs_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+SinkFinalizeType PhysicalIEJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                          GlobalSinkState &gstate_p) const {
+	auto &gstate = (IEJoinGlobalState &)gstate_p;
+	auto &table = *gstate.tables[gstate.child];
+	auto &global_sort_state = table.global_sort_state;
+
+	if ((gstate.child == 1 && IsRightOuterJoin(join_type)) || (gstate.child == 0 && IsLeftOuterJoin(join_type))) {
+		// for FULL/LEFT/RIGHT OUTER JOIN, initialize found_match to false for every tuple
+		table.IntializeMatches();
+	}
+	if (gstate.child == 1 && global_sort_state.sorted_blocks.empty() && EmptyResultIfRHSIsEmpty()) {
+		// Empty input!
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+
+	// Sort the current input child
+	table.Finalize(pipeline, event);
+
+	// Move to the next input child
+	++gstate.child;
+
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+OperatorResultType PhysicalIEJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                           GlobalOperatorState &gstate, OperatorState &state) const {
+	return OperatorResultType::FINISHED;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+struct SBIterator {
+	static int ComparisonValue(ExpressionType comparison) {
+		switch (comparison) {
+		case ExpressionType::COMPARE_LESSTHAN:
+		case ExpressionType::COMPARE_GREATERTHAN:
+			return -1;
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			return 0;
+		default:
+			throw InternalException("Unimplemented comparison type for IEJoin!");
+		}
+	}
+
+	explicit SBIterator(GlobalSortState &gss, ExpressionType comparison, idx_t entry_idx_p = 0)
+	    : sort_layout(gss.sort_layout), block_count(gss.sorted_blocks[0]->radix_sorting_data.size()),
+	      block_capacity(gss.block_capacity), cmp_size(sort_layout.comparison_size), entry_size(sort_layout.entry_size),
+	      all_constant(sort_layout.all_constant), external(gss.external), cmp(ComparisonValue(comparison)),
+	      scan(gss.buffer_manager, gss), block_ptr(nullptr), entry_ptr(nullptr) {
+
+		scan.sb = gss.sorted_blocks[0].get();
+		scan.block_idx = block_count;
+		SetIndex(entry_idx_p);
+	}
+
+	inline idx_t GetIndex() const {
+		return entry_idx;
+	}
+
+	inline void SetIndex(idx_t entry_idx_p) {
+		const auto new_block_idx = entry_idx_p / block_capacity;
+		if (new_block_idx != scan.block_idx) {
+			scan.SetIndices(new_block_idx, 0);
+			if (new_block_idx < block_count) {
+				scan.PinRadix(scan.block_idx);
+				block_ptr = scan.RadixPtr();
+				if (!all_constant) {
+					scan.PinData(*scan.sb->blob_sorting_data);
+				}
+			}
+		}
+
+		scan.entry_idx = entry_idx_p % block_capacity;
+		entry_ptr = block_ptr + scan.entry_idx * entry_size;
+		entry_idx = entry_idx_p;
+	}
+
+	inline SBIterator &operator++() {
+		if (++scan.entry_idx < block_capacity) {
+			entry_ptr += entry_size;
+			++entry_idx;
+		} else {
+			SetIndex(entry_idx + 1);
+		}
+
+		return *this;
+	}
+
+	inline SBIterator &operator--() {
+		if (scan.entry_idx) {
+			--scan.entry_idx;
+			--entry_idx;
+			entry_ptr -= entry_size;
+		} else {
+			SetIndex(entry_idx - 1);
+		}
+
+		return *this;
+	}
+
+	inline bool Compare(const SBIterator &other) const {
+		int comp_res;
+		if (all_constant) {
+			comp_res = FastMemcmp(entry_ptr, other.entry_ptr, cmp_size);
+		} else {
+			comp_res = Comparators::CompareTuple(scan, other.scan, entry_ptr, other.entry_ptr, sort_layout, external);
+		}
+
+		return comp_res <= cmp;
+	}
+
+	// Fixed comparison parameters
+	const SortLayout &sort_layout;
+	const idx_t block_count;
+	const idx_t block_capacity;
+	const size_t cmp_size;
+	const size_t entry_size;
+	const bool all_constant;
+	const bool external;
+	const int cmp;
+
+	// Iteration state
+	SBScanState scan;
+	idx_t entry_idx;
+	data_ptr_t block_ptr;
+	data_ptr_t entry_ptr;
+};
+
+struct IEJoinUnion {
+	using SortedTable = PhysicalRangeJoin::GlobalSortedTable;
+
+	static idx_t AppendKey(SortedTable &table, ExpressionExecutor &executor, SortedTable &marked, int64_t increment,
+	                       int64_t base, const idx_t block_idx);
+
+	static void Sort(SortedTable &table) {
+		auto &global_sort_state = table.global_sort_state;
+		global_sort_state.PrepareMergePhase();
+		while (global_sort_state.sorted_blocks.size() > 1) {
+			global_sort_state.InitializeMergeRound();
+			MergeSorter merge_sorter(global_sort_state, global_sort_state.buffer_manager);
+			merge_sorter.PerformInMergeRound();
+			global_sort_state.CompleteMergeRound(true);
+		}
+	}
+
+	template <typename T>
+	static vector<T> ExtractColumn(SortedTable &table, idx_t col_idx) {
+		vector<T> result;
+		result.reserve(table.count);
+
+		auto &gstate = table.global_sort_state;
+		auto &blocks = *gstate.sorted_blocks[0]->payload_data;
+		PayloadScanner scanner(blocks, gstate, false);
+
+		DataChunk payload;
+		payload.Initialize(gstate.payload_layout.GetTypes());
+		for (;;) {
+			scanner.Scan(payload);
+			const auto count = payload.size();
+			if (!count) {
+				break;
+			}
+
+			const auto data_ptr = FlatVector::GetData<T>(payload.data[col_idx]);
+			result.insert(result.end(), data_ptr, data_ptr + count);
+		}
+
+		return result;
+	}
+
+	IEJoinUnion(ClientContext &context, const PhysicalIEJoin &op, SortedTable &t1, const idx_t b1, SortedTable &t2,
+	            const idx_t b2);
+
+	idx_t SearchL1(idx_t pos);
+	bool NextRow();
+
+	//! Inverted loop
+	idx_t JoinComplexBlocks(SelectionVector &lsel, SelectionVector &rsel);
+
+	//! L1
+	unique_ptr<SortedTable> l1;
+	//! L2
+	unique_ptr<SortedTable> l2;
+
+	//! Li
+	vector<int64_t> li;
+	//! P
+	vector<idx_t> p;
+
+	//! B
+	vector<validity_t> bit_array;
+	ValidityMask bit_mask;
+
+	//! Bloom Filter
+	static constexpr idx_t BLOOM_CHUNK_BITS = 1024;
+	idx_t bloom_count;
+	vector<validity_t> bloom_array;
+	ValidityMask bloom_filter;
+
+	//! Iteration state
+	idx_t n;
+	idx_t i;
+	idx_t j;
+	unique_ptr<SBIterator> op1;
+	unique_ptr<SBIterator> off1;
+	unique_ptr<SBIterator> op2;
+	unique_ptr<SBIterator> off2;
+	int64_t lrid;
+};
+
+idx_t IEJoinUnion::AppendKey(SortedTable &table, ExpressionExecutor &executor, SortedTable &marked, int64_t increment,
+                             int64_t base, const idx_t block_idx) {
+	LocalSortState local_sort_state;
+	local_sort_state.Initialize(marked.global_sort_state, marked.global_sort_state.buffer_manager);
+
+	// Reading
+	const auto valid = table.count - table.has_null;
+	auto &gstate = table.global_sort_state;
+	PayloadScanner scanner(gstate, block_idx);
+	auto table_idx = block_idx * gstate.block_capacity;
+
+	DataChunk scanned;
+	scanned.Initialize(scanner.GetPayloadTypes());
+
+	// Writing
+	auto types = local_sort_state.sort_layout->logical_types;
+	const idx_t payload_idx = types.size();
+
+	const auto &payload_types = local_sort_state.payload_layout->GetTypes();
+	types.insert(types.end(), payload_types.begin(), payload_types.end());
+	const idx_t rid_idx = types.size() - 1;
+
+	DataChunk keys;
+	DataChunk payload;
+	keys.Initialize(types);
+
+	idx_t inserted = 0;
+	for (auto rid = base; table_idx < valid;) {
+		scanner.Scan(scanned);
+
+		// NULLs are at the end, so stop when we reach them
+		auto scan_count = scanned.size();
+		if (table_idx + scan_count > valid) {
+			scan_count = valid - table_idx;
+			scanned.SetCardinality(scan_count);
+		}
+		if (scan_count == 0) {
+			break;
+		}
+		table_idx += scan_count;
+
+		// Compute the input columns from the payload
+		keys.Reset();
+		keys.Split(payload, rid_idx);
+		executor.Execute(scanned, keys);
+
+		// Mark the rid column
+		payload.data[0].Sequence(rid, increment);
+		payload.SetCardinality(scan_count);
+		keys.Fuse(payload);
+		rid += increment * scan_count;
+
+		// Sort on the sort columns (which will no longer be needed)
+		keys.Split(payload, payload_idx);
+		local_sort_state.SinkChunk(keys, payload);
+		inserted += scan_count;
+		keys.Fuse(payload);
+
+		// Flush when we have enough data
+		if (local_sort_state.SizeInBytes() >= marked.memory_per_thread) {
+			local_sort_state.Sort(marked.global_sort_state, true);
+		}
+	}
+	marked.global_sort_state.AddLocalState(local_sort_state);
+	marked.count += inserted;
+
+	return inserted;
+}
+
+IEJoinUnion::IEJoinUnion(ClientContext &context, const PhysicalIEJoin &op, SortedTable &t1, const idx_t b1,
+                         SortedTable &t2, const idx_t b2)
+    : n(0), i(0) {
+	// input : query Q with 2 join predicates t1.X op1 t2.X' and t1.Y op2 t2.Y', tables T, T' of sizes m and n resp.
+	// output: a list of tuple pairs (ti , tj)
+	// Note that T/T' are already sorted on X/X' and contain the payload data
+	// We only join the two block numbers and use the sizes of the blocks as the counts
+
+	// 0. Filter out tables with no overlap
+	if (!t1.BlockSize(b1) || !t2.BlockSize(b2)) {
+		return;
+	}
+
+	const auto &cmp1 = op.conditions[0].comparison;
+	SBIterator bounds1(t1.global_sort_state, cmp1);
+	SBIterator bounds2(t2.global_sort_state, cmp1);
+
+	// t1.X[0] op1 t2.X'[-1]
+	bounds1.SetIndex(bounds1.block_capacity * b1);
+	bounds2.SetIndex(bounds2.block_capacity * b2 + t2.BlockSize(b2) - 1);
+	if (!bounds1.Compare(bounds2)) {
+		return;
+	}
+
+	// 1. let L1 (resp. L2) be the array of column X (resp. Y )
+	const auto &order1 = op.lhs_orders[0][0];
+	const auto &order2 = op.lhs_orders[1][0];
+
+	// 2. if (op1 ∈ {>, ≥}) sort L1 in descending order
+	// 3. else if (op1 ∈ {<, ≤}) sort L1 in ascending order
+
+	// For the union algorithm, we make a unified table with the keys and the rids as the payload:
+	//		X/X', Y/Y', R/R'/Li
+	// The first position is the sort key.
+	vector<LogicalType> types;
+	types.emplace_back(order2.expression->return_type);
+	types.emplace_back(LogicalType::BIGINT);
+	RowLayout payload_layout;
+	payload_layout.Initialize(types);
+
+	// Sort on the first expression
+	auto ref = make_unique<BoundReferenceExpression>(order1.expression->return_type, 0);
+	vector<BoundOrderByNode> orders;
+	orders.emplace_back(BoundOrderByNode(order1.type, order1.null_order, move(ref)));
+
+	l1 = make_unique<SortedTable>(context, orders, payload_layout);
+
+	// LHS has positive rids
+	ExpressionExecutor l_executor;
+	l_executor.AddExpression(*order1.expression);
+	l_executor.AddExpression(*order2.expression);
+	AppendKey(t1, l_executor, *l1, 1, 1, b1);
+
+	// RHS has negative rids
+	ExpressionExecutor r_executor;
+	r_executor.AddExpression(*op.rhs_orders[0][0].expression);
+	r_executor.AddExpression(*op.rhs_orders[1][0].expression);
+	AppendKey(t2, r_executor, *l1, -1, -1, b2);
+
+	Sort(*l1);
+
+	op1 = make_unique<SBIterator>(l1->global_sort_state, cmp1);
+	off1 = make_unique<SBIterator>(l1->global_sort_state, cmp1);
+
+	// We don't actually need the L1 column, just its sort key, which is in the sort blocks
+	li = ExtractColumn<int64_t>(*l1, types.size() - 1);
+
+	// 4. if (op2 ∈ {>, ≥}) sort L2 in ascending order
+	// 5. else if (op2 ∈ {<, ≤}) sort L2 in descending order
+
+	// We sort on Y/Y' to obtain the sort keys and the permutation array.
+	// For this we just need a two-column table of Y, P
+	types.clear();
+	types.emplace_back(LogicalType::BIGINT);
+	payload_layout.Initialize(types);
+
+	// Sort on the first expression
+	orders.clear();
+	ref = make_unique<BoundReferenceExpression>(order2.expression->return_type, 0);
+	orders.emplace_back(BoundOrderByNode(order2.type, order2.null_order, move(ref)));
+
+	ExpressionExecutor executor;
+	executor.AddExpression(*orders[0].expression);
+
+	l2 = make_unique<SortedTable>(context, orders, payload_layout);
+	for (idx_t base = 0, block_idx = 0; block_idx < l1->BlockCount(); ++block_idx) {
+		base += AppendKey(*l1, executor, *l2, 1, base, block_idx);
+	}
+
+	Sort(*l2);
+
+	// We don't actually need the L2 column, just its sort key, which is in the sort blocks
+
+	// 6. compute the permutation array P of L2 w.r.t. L1
+	p = ExtractColumn<idx_t>(*l2, types.size() - 1);
+
+	// 7. initialize bit-array B (|B| = n), and set all bits to 0
+	n = l2->count.load();
+	bit_array.resize(ValidityMask::EntryCount(n), 0);
+	bit_mask.Initialize(bit_array.data());
+
+	// Bloom filter
+	bloom_count = (n + (BLOOM_CHUNK_BITS - 1)) / BLOOM_CHUNK_BITS;
+	bloom_array.resize(ValidityMask::EntryCount(bloom_count), 0);
+	bloom_filter.Initialize(bloom_array.data());
+
+	// 11. for(i←1 to n) do
+	const auto &cmp2 = op.conditions[1].comparison;
+	op2 = make_unique<SBIterator>(l2->global_sort_state, cmp2);
+	off2 = make_unique<SBIterator>(l2->global_sort_state, cmp2);
+	i = 0;
+	j = 0;
+	(void)NextRow();
+}
+
+idx_t IEJoinUnion::SearchL1(idx_t pos) {
+	// Perform an exponential search in the appropriate direction
+	op1->SetIndex(pos);
+
+	idx_t step = 1;
+	auto hi = pos;
+	auto lo = pos;
+	if (!op1->cmp) {
+		// Scan left for loose inequality
+		lo -= MinValue(step, lo);
+		step *= 2;
+		off1->SetIndex(lo);
+		while (lo > 0 && op1->Compare(*off1)) {
+			hi = lo;
+			lo -= MinValue(step, lo);
+			step *= 2;
+			off1->SetIndex(lo);
+		}
+	} else {
+		// Scan right for strict inequality
+		hi += MinValue(step, n - hi);
+		step *= 2;
+		off1->SetIndex(hi);
+		while (hi < n && !op1->Compare(*off1)) {
+			lo = hi;
+			hi += MinValue(step, n - hi);
+			step *= 2;
+			off1->SetIndex(hi);
+		}
+	}
+
+	// Binary search the target area
+	while (lo < hi) {
+		const auto mid = lo + (hi - lo) / 2;
+		off1->SetIndex(mid);
+		if (op1->Compare(*off1)) {
+			hi = mid;
+		} else {
+			lo = mid + 1;
+		}
+	}
+
+	off1->SetIndex(lo);
+
+	return lo;
+}
+
+bool IEJoinUnion::NextRow() {
+	for (; i < n; ++i) {
+		// 12. pos ← P[i]
+		auto pos = p[i];
+		lrid = li[pos];
+		if (lrid < 0) {
+			continue;
+		}
+
+		// 16. B[pos] ← 1
+		op2->SetIndex(i);
+		for (; off2->GetIndex() < n; ++(*off2)) {
+			if (!off2->Compare(*op2)) {
+				break;
+			}
+			const auto p2 = p[off2->GetIndex()];
+			if (li[p2] < 0) {
+				// Only mark rhs matches.
+				bit_mask.SetValid(p2);
+				bloom_filter.SetValid(p2 / BLOOM_CHUNK_BITS);
+			}
+		}
+
+		// 9.  if (op1 ∈ {≤,≥} and op2 ∈ {≤,≥}) eqOff = 0
+		// 10. else eqOff = 1
+		// No, because there could be more than one equal value.
+		// Find the leftmost off1 where L1[pos] op1 L1[off1..n]
+		// These are the rows that satisfy the op1 condition
+		// and that is where we should start scanning B from
+		j = SearchL1(pos);
+
+		return true;
+	}
+	return false;
+}
+
+static idx_t NextValid(const ValidityMask &bits, idx_t j, const idx_t n) {
+	if (j >= n) {
+		return n;
+	}
+
+	// We can do a first approximation by checking entries one at a time
+	// which gives 64:1.
+	idx_t entry_idx, idx_in_entry;
+	bits.GetEntryIndex(j, entry_idx, idx_in_entry);
+	auto entry = bits.GetValidityEntry(entry_idx++);
+
+	// Trim the bits before the start position
+	entry &= (ValidityMask::ValidityBuffer::MAX_ENTRY << idx_in_entry);
+
+	// Check the non-ragged entries
+	for (const auto entry_count = bits.EntryCount(n); entry_idx < entry_count; ++entry_idx) {
+		if (entry) {
+			for (; idx_in_entry < bits.BITS_PER_VALUE; ++idx_in_entry, ++j) {
+				if (bits.RowIsValid(entry, idx_in_entry)) {
+					return j;
+				}
+			}
+		} else {
+			j += bits.BITS_PER_VALUE - idx_in_entry;
+		}
+
+		entry = bits.GetValidityEntry(entry_idx);
+		idx_in_entry = 0;
+	}
+
+	// Check the final entry
+	for (; j < n; ++idx_in_entry, ++j) {
+		if (bits.RowIsValid(entry, idx_in_entry)) {
+			return j;
+		}
+	}
+
+	return j;
+}
+
+idx_t IEJoinUnion::JoinComplexBlocks(SelectionVector &lsel, SelectionVector &rsel) {
+	// 8. initialize join result as an empty list for tuple pairs
+	idx_t result_count = 0;
+
+	// 11. for(i←1 to n) do
+	while (i < n) {
+		// 13. for (j ← pos+eqOff to n) do
+		for (;;) {
+			// 14. if B[j] = 1 then
+
+			//	Use the Bloom filter to find candidate blocks
+			while (j < n) {
+				auto bloom_begin = NextValid(bloom_filter, j / BLOOM_CHUNK_BITS, bloom_count) * BLOOM_CHUNK_BITS;
+				auto bloom_end = MinValue<idx_t>(n, bloom_begin + BLOOM_CHUNK_BITS);
+
+				j = MaxValue<idx_t>(j, bloom_begin);
+				j = NextValid(bit_mask, j, bloom_end);
+				if (j < bloom_end) {
+					break;
+				}
+			}
+
+			if (j >= n) {
+				break;
+			}
+
+			// Filter out tuples with the same sign (they come from the same table)
+			const auto rrid = li[j];
+			++j;
+
+			// 15. add tuples w.r.t. (L1[j], L1[i]) to join result
+			if (lrid > 0 && rrid < 0) {
+				lsel.set_index(result_count, sel_t(+lrid - 1));
+				rsel.set_index(result_count, sel_t(-rrid - 1));
+				++result_count;
+				if (result_count == STANDARD_VECTOR_SIZE) {
+					// out of space!
+					return result_count;
+				}
+			}
+		}
+		++i;
+
+		if (!NextRow()) {
+			break;
+		}
+	}
+
+	return result_count;
+}
+
+class IEJoinState : public OperatorState {
+public:
+	explicit IEJoinState(const PhysicalIEJoin &op) : local_left(op, 0) {};
+
+	IEJoinLocalState local_left;
+};
+
+class IEJoinLocalSourceState : public LocalSourceState {
+public:
+	explicit IEJoinLocalSourceState(const PhysicalIEJoin &op)
+	    : op(op), true_sel(STANDARD_VECTOR_SIZE), left_matches(nullptr), right_matches(nullptr) {
+
+		if (op.conditions.size() < 3) {
+			return;
+		}
+
+		vector<LogicalType> left_types;
+		vector<LogicalType> right_types;
+		for (idx_t i = 2; i < op.conditions.size(); ++i) {
+			const auto &cond = op.conditions[i];
+
+			left_types.push_back(cond.left->return_type);
+			left_executor.AddExpression(*cond.left);
+
+			right_types.push_back(cond.left->return_type);
+			right_executor.AddExpression(*cond.right);
+		}
+
+		left_keys.Initialize(left_types);
+		right_keys.Initialize(right_types);
+	}
+
+	idx_t SelectOuterRows(bool *matches) {
+		idx_t count = 0;
+		for (; outer_idx < outer_count; ++outer_idx) {
+			if (!matches[outer_idx]) {
+				true_sel.set_index(count++, outer_idx);
+				if (count >= STANDARD_VECTOR_SIZE) {
+					break;
+				}
+			}
+		}
+
+		return count;
+	}
+
+	const PhysicalIEJoin &op;
+
+	// Joining
+	unique_ptr<IEJoinUnion> joiner;
+
+	idx_t left_base;
+	idx_t left_block_index;
+
+	idx_t right_base;
+	idx_t right_block_index;
+
+	// Trailing predicates
+	SelectionVector true_sel;
+
+	ExpressionExecutor left_executor;
+	DataChunk left_keys;
+
+	ExpressionExecutor right_executor;
+	DataChunk right_keys;
+
+	// Outer joins
+	idx_t outer_idx;
+	idx_t outer_count;
+	bool *left_matches;
+	bool *right_matches;
+};
+
+void PhysicalIEJoin::ResolveComplexJoin(ExecutionContext &context, DataChunk &chunk, LocalSourceState &state_p) const {
+	auto &state = (IEJoinLocalSourceState &)state_p;
+	auto &ie_sink = (IEJoinGlobalState &)*sink_state;
+	auto &left_table = *ie_sink.tables[0];
+	auto &right_table = *ie_sink.tables[1];
+
+	const auto left_cols = children[0]->GetTypes().size();
+	do {
+		SelectionVector lsel(STANDARD_VECTOR_SIZE);
+		SelectionVector rsel(STANDARD_VECTOR_SIZE);
+		auto result_count = state.joiner->JoinComplexBlocks(lsel, rsel);
+		if (result_count == 0) {
+			// exhausted this pair
+			return;
+		}
+
+		// found matches: extract them
+		chunk.Reset();
+		SliceSortedPayload(chunk, left_table.global_sort_state, state.left_block_index, lsel, result_count, 0);
+		SliceSortedPayload(chunk, right_table.global_sort_state, state.right_block_index, rsel, result_count,
+		                   left_cols);
+		chunk.SetCardinality(result_count);
+
+		auto sel = FlatVector::IncrementalSelectionVector();
+		if (conditions.size() > 2) {
+			// If there are more expressions to compute,
+			// split the result chunk into the left and right halves
+			// so we can compute the values for comparison.
+			const auto tail_cols = conditions.size() - 2;
+
+			DataChunk right_chunk;
+			chunk.Split(right_chunk, left_cols);
+			state.left_executor.SetChunk(chunk);
+			state.right_executor.SetChunk(right_chunk);
+
+			auto tail_count = result_count;
+			auto true_sel = &state.true_sel;
+			for (size_t cmp_idx = 0; cmp_idx < tail_cols; ++cmp_idx) {
+				auto &left = state.left_keys.data[cmp_idx];
+				state.left_executor.ExecuteExpression(cmp_idx, left);
+
+				auto &right = state.right_keys.data[cmp_idx];
+				state.right_executor.ExecuteExpression(cmp_idx, right);
+
+				if (tail_count < result_count) {
+					left.Slice(*sel, tail_count);
+					right.Slice(*sel, tail_count);
+				}
+				tail_count = SelectJoinTail(conditions[cmp_idx + 2].comparison, left, right, sel, tail_count, true_sel);
+				sel = true_sel;
+			}
+			chunk.Fuse(right_chunk);
+
+			if (tail_count < result_count) {
+				result_count = tail_count;
+				chunk.Slice(*sel, result_count);
+			}
+		}
+
+		// found matches: mark the found matches if required
+		if (left_table.found_match) {
+			for (idx_t i = 0; i < result_count; i++) {
+				left_table.found_match[state.left_base + lsel[sel->get_index(i)]] = true;
+			}
+		}
+		if (right_table.found_match) {
+			for (idx_t i = 0; i < result_count; i++) {
+				right_table.found_match[state.right_base + rsel[sel->get_index(i)]] = true;
+			}
+		}
+		chunk.Verify();
+	} while (chunk.size() == 0);
+}
+
+class IEJoinGlobalSourceState : public GlobalSourceState {
+public:
+	explicit IEJoinGlobalSourceState(const PhysicalIEJoin &op)
+	    : op(op), initialized(false), next_pair(0), completed(0), left_outers(0), next_left(0), right_outers(0),
+	      next_right(0) {
+	}
+
+	void Initialize(IEJoinGlobalState &sink_state) {
+		lock_guard<mutex> initializing(lock);
+		if (initialized) {
+			return;
+		}
+
+		// Compute the starting row for reach block
+		// (In theory these are all the same size, but you never know...)
+		auto &left_table = *sink_state.tables[0];
+		const auto left_blocks = left_table.BlockCount();
+		idx_t left_base = 0;
+
+		for (size_t lhs = 0; lhs < left_blocks; ++lhs) {
+			left_bases.emplace_back(left_base);
+			left_base += left_table.BlockSize(lhs);
+		}
+
+		auto &right_table = *sink_state.tables[1];
+		const auto right_blocks = right_table.BlockCount();
+		idx_t right_base = 0;
+		for (size_t rhs = 0; rhs < right_blocks; ++rhs) {
+			right_bases.emplace_back(right_base);
+			right_base += right_table.BlockSize(rhs);
+		}
+
+		// Outer join block counts
+		if (left_table.found_match) {
+			left_outers = left_blocks;
+		}
+
+		if (right_table.found_match) {
+			right_outers = right_blocks;
+		}
+
+		// Ready for action
+		initialized = true;
+	}
+
+public:
+	idx_t MaxThreads() override {
+		// We can't leverage any more threads than block pairs.
+		const auto &sink_state = ((IEJoinGlobalState &)*op.sink_state);
+		return sink_state.tables[0]->BlockCount() * sink_state.tables[1]->BlockCount();
+	}
+
+	void GetNextPair(ClientContext &client, IEJoinGlobalState &gstate, IEJoinLocalSourceState &lstate) {
+		auto &left_table = *gstate.tables[0];
+		auto &right_table = *gstate.tables[1];
+
+		const auto left_blocks = left_table.BlockCount();
+		const auto right_blocks = right_table.BlockCount();
+		const auto pair_count = left_blocks * right_blocks;
+
+		// Regular block
+		const auto i = next_pair++;
+		if (i < pair_count) {
+			const auto b1 = i / right_blocks;
+			const auto b2 = i % right_blocks;
+
+			lstate.left_block_index = b1;
+			lstate.left_base = left_bases[b1];
+
+			lstate.right_block_index = b2;
+			lstate.right_base = right_bases[b2];
+
+			lstate.joiner = make_unique<IEJoinUnion>(client, op, left_table, b1, right_table, b2);
+			return;
+		} else {
+			--next_pair;
+		}
+
+		// Outer joins
+		if (!left_outers && !right_outers) {
+			return;
+		}
+
+		// Spin wait for regular blocks to finish(!)
+		while (completed < pair_count) {
+			std::this_thread::yield();
+		}
+
+		// Left outer blocks
+		const auto l = next_left++;
+		if (l < left_outers) {
+			lstate.left_block_index = l;
+			lstate.left_base = left_bases[l];
+
+			lstate.left_matches = left_table.found_match.get() + lstate.left_base;
+			lstate.outer_idx = 0;
+			lstate.outer_count = left_table.BlockSize(l);
+			return;
+		} else {
+			lstate.left_matches = nullptr;
+			--next_left;
+		}
+
+		// Right outer block
+		const auto r = next_right++;
+		if (r < right_outers) {
+			lstate.right_block_index = r;
+			lstate.right_base = right_bases[r];
+
+			lstate.right_matches = right_table.found_match.get() + lstate.right_base;
+			lstate.outer_idx = 0;
+			lstate.outer_count = right_table.BlockSize(r);
+			return;
+		} else {
+			lstate.right_matches = nullptr;
+			--next_right;
+		}
+	}
+
+	void PairCompleted(ClientContext &client, IEJoinGlobalState &gstate, IEJoinLocalSourceState &lstate) {
+		lstate.joiner.reset();
+		++completed;
+		GetNextPair(client, gstate, lstate);
+	}
+
+	const PhysicalIEJoin &op;
+
+	mutex lock;
+	bool initialized;
+
+	// Join queue state
+	std::atomic<size_t> next_pair;
+	std::atomic<size_t> completed;
+
+	// Block base row number
+	vector<idx_t> left_bases;
+	vector<idx_t> right_bases;
+
+	// Outer joins
+	idx_t left_outers;
+	std::atomic<idx_t> next_left;
+
+	idx_t right_outers;
+	std::atomic<idx_t> next_right;
+};
+
+unique_ptr<GlobalSourceState> PhysicalIEJoin::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<IEJoinGlobalSourceState>(*this);
+}
+
+unique_ptr<LocalSourceState> PhysicalIEJoin::GetLocalSourceState(ExecutionContext &context,
+                                                                 GlobalSourceState &gstate) const {
+	return make_unique<IEJoinLocalSourceState>(*this);
+}
+
+void PhysicalIEJoin::GetData(ExecutionContext &context, DataChunk &result, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	auto &ie_sink = (IEJoinGlobalState &)*sink_state;
+	auto &ie_gstate = (IEJoinGlobalSourceState &)gstate;
+	auto &ie_lstate = (IEJoinLocalSourceState &)lstate;
+
+	ie_gstate.Initialize(ie_sink);
+
+	if (!ie_lstate.joiner) {
+		ie_gstate.GetNextPair(context.client, ie_sink, ie_lstate);
+	}
+
+	// Process INNER results
+	while (ie_lstate.joiner) {
+		ResolveComplexJoin(context, result, ie_lstate);
+
+		if (result.size()) {
+			return;
+		}
+
+		ie_gstate.PairCompleted(context.client, ie_sink, ie_lstate);
+	}
+
+	// Process LEFT OUTER results
+	const auto left_cols = children[0]->GetTypes().size();
+	while (ie_lstate.left_matches) {
+		const idx_t count = ie_lstate.SelectOuterRows(ie_lstate.left_matches);
+		if (!count) {
+			ie_gstate.GetNextPair(context.client, ie_sink, ie_lstate);
+			continue;
+		}
+
+		SliceSortedPayload(result, ie_sink.tables[0]->global_sort_state, ie_lstate.left_base, ie_lstate.true_sel,
+		                   count);
+
+		// Fill in NULLs to the right
+		for (auto col_idx = left_cols; col_idx < result.ColumnCount(); ++col_idx) {
+			result.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result.data[col_idx], true);
+		}
+
+		result.SetCardinality(count);
+		result.Verify();
+
+		return;
+	}
+
+	// Process RIGHT OUTER results
+	while (ie_lstate.right_matches) {
+		const idx_t count = ie_lstate.SelectOuterRows(ie_lstate.right_matches);
+		if (!count) {
+			ie_gstate.GetNextPair(context.client, ie_sink, ie_lstate);
+			continue;
+		}
+
+		SliceSortedPayload(result, ie_sink.tables[1]->global_sort_state, ie_lstate.right_base, ie_lstate.true_sel,
+		                   count, left_cols);
+
+		// Fill in NULLs to the left
+		for (idx_t col_idx = 0; col_idx < left_cols; ++col_idx) {
+			result.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result.data[col_idx], true);
+		}
+
+		result.SetCardinality(count);
+		result.Verify();
+
+		return;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalIEJoin::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	D_ASSERT(children.size() == 2);
+	if (state.recursive_cte) {
+		throw NotImplementedException("IEJoins are not supported in recursive CTEs yet");
+	}
+
+	// Build the LHS
+	auto lhs_pipeline = make_shared<Pipeline>(executor);
+	state.SetPipelineSink(*lhs_pipeline, this);
+	D_ASSERT(children[0].get());
+	children[0]->BuildPipelines(executor, *lhs_pipeline, state);
+
+	// Build the RHS
+	auto rhs_pipeline = make_shared<Pipeline>(executor);
+	state.SetPipelineSink(*rhs_pipeline, this);
+	D_ASSERT(children[1].get());
+	children[1]->BuildPipelines(executor, *rhs_pipeline, state);
+
+	// RHS => LHS => current
+	current.AddDependency(rhs_pipeline);
+	rhs_pipeline->AddDependency(lhs_pipeline);
+
+	state.AddPipeline(executor, move(lhs_pipeline));
+	state.AddPipeline(executor, move(rhs_pipeline));
+
+	// Now build both and scan
+	state.SetPipelineSource(current, this);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class IndexJoinOperatorState : public OperatorState {
+public:
+	explicit IndexJoinOperatorState(const PhysicalIndexJoin &op) {
+		rhs_rows.resize(STANDARD_VECTOR_SIZE);
+		result_sizes.resize(STANDARD_VECTOR_SIZE);
+
+		join_keys.Initialize(op.condition_types);
+		for (auto &cond : op.conditions) {
+			probe_executor.AddExpression(*cond.left);
+		}
+		if (!op.fetch_types.empty()) {
+			rhs_chunk.Initialize(op.fetch_types);
+		}
+		rhs_sel.Initialize(STANDARD_VECTOR_SIZE);
+	}
+
+	bool first_fetch = true;
+	idx_t lhs_idx = 0;
+	idx_t rhs_idx = 0;
+	idx_t result_size = 0;
+	vector<idx_t> result_sizes;
+	DataChunk join_keys;
+	DataChunk rhs_chunk;
+	SelectionVector rhs_sel;
+	//! Vector of rows that mush be fetched for every LHS key
+	vector<vector<row_t>> rhs_rows;
+	ExpressionExecutor probe_executor;
+
+public:
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		context.thread.profiler.Flush(op, &probe_executor, "probe_executor", 0);
+	}
+};
+
+PhysicalIndexJoin::PhysicalIndexJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                     unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+                                     const vector<idx_t> &left_projection_map_p, vector<idx_t> right_projection_map_p,
+                                     vector<column_t> column_ids_p, Index *index_p, bool lhs_first,
+                                     idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::INDEX_JOIN, move(op.types), estimated_cardinality),
+      left_projection_map(left_projection_map_p), right_projection_map(move(right_projection_map_p)), index(index_p),
+      conditions(move(cond)), join_type(join_type), lhs_first(lhs_first) {
+	column_ids = move(column_ids_p);
+	children.push_back(move(left));
+	children.push_back(move(right));
+	for (auto &condition : conditions) {
+		condition_types.push_back(condition.left->return_type);
+	}
+	//! Only add to fetch_ids columns that are not indexed
+	for (auto &index_id : index->column_ids) {
+		index_ids.insert(index_id);
+	}
+	for (idx_t column_id = 0; column_id < column_ids.size(); column_id++) {
+		auto it = index_ids.find(column_ids[column_id]);
+		if (it == index_ids.end()) {
+			fetch_ids.push_back(column_ids[column_id]);
+			fetch_types.push_back(children[1]->types[column_id]);
+		}
+	}
+	if (right_projection_map.empty()) {
+		for (column_t i = 0; i < column_ids.size(); i++) {
+			right_projection_map.push_back(i);
+		}
+	}
+	if (left_projection_map.empty()) {
+		for (column_t i = 0; i < children[0]->types.size(); i++) {
+			left_projection_map.push_back(i);
+		}
+	}
+}
+
+unique_ptr<OperatorState> PhysicalIndexJoin::GetOperatorState(ClientContext &context) const {
+	return make_unique<IndexJoinOperatorState>(*this);
+}
+
+void PhysicalIndexJoin::Output(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                               OperatorState &state_p) const {
+	auto &transaction = Transaction::GetTransaction(context.client);
+	auto &phy_tbl_scan = (PhysicalTableScan &)*children[1];
+	auto &bind_tbl = (TableScanBindData &)*phy_tbl_scan.bind_data;
+	auto &state = (IndexJoinOperatorState &)state_p;
+
+	auto tbl = bind_tbl.table->storage.get();
+	idx_t output_sel_idx = 0;
+	vector<row_t> fetch_rows;
+
+	while (output_sel_idx < STANDARD_VECTOR_SIZE && state.lhs_idx < input.size()) {
+		if (state.rhs_idx < state.result_sizes[state.lhs_idx]) {
+			state.rhs_sel.set_index(output_sel_idx++, state.lhs_idx);
+			if (!fetch_types.empty()) {
+				//! We need to collect the rows we want to fetch
+				fetch_rows.push_back(state.rhs_rows[state.lhs_idx][state.rhs_idx]);
+			}
+			state.rhs_idx++;
+		} else {
+			//! We are done with the matches from this LHS Key
+			state.rhs_idx = 0;
+			state.lhs_idx++;
+		}
+	}
+	//! Now we fetch the RHS data
+	if (!fetch_types.empty()) {
+		if (fetch_rows.empty()) {
+			return;
+		}
+		state.rhs_chunk.Reset();
+		ColumnFetchState fetch_state;
+		Vector row_ids(LogicalType::ROW_TYPE, (data_ptr_t)&fetch_rows[0]);
+		tbl->Fetch(transaction, state.rhs_chunk, fetch_ids, row_ids, output_sel_idx, fetch_state);
+	}
+
+	//! Now we actually produce our result chunk
+	idx_t left_offset = lhs_first ? 0 : right_projection_map.size();
+	idx_t right_offset = lhs_first ? left_projection_map.size() : 0;
+	idx_t rhs_column_idx = 0;
+	for (idx_t i = 0; i < right_projection_map.size(); i++) {
+		auto it = index_ids.find(column_ids[right_projection_map[i]]);
+		if (it == index_ids.end()) {
+			chunk.data[right_offset + i].Reference(state.rhs_chunk.data[rhs_column_idx++]);
+		} else {
+			chunk.data[right_offset + i].Slice(state.join_keys.data[0], state.rhs_sel, output_sel_idx);
+		}
+	}
+	for (idx_t i = 0; i < left_projection_map.size(); i++) {
+		chunk.data[left_offset + i].Slice(input.data[left_projection_map[i]], state.rhs_sel, output_sel_idx);
+	}
+
+	state.result_size = output_sel_idx;
+	chunk.SetCardinality(state.result_size);
+}
+
+void PhysicalIndexJoin::GetRHSMatches(ExecutionContext &context, DataChunk &input, OperatorState &state_p) const {
+	auto &state = (IndexJoinOperatorState &)state_p;
+	auto &art = (ART &)*index;
+	auto &transaction = Transaction::GetTransaction(context.client);
+	for (idx_t i = 0; i < input.size(); i++) {
+		auto equal_value = state.join_keys.GetValue(0, i);
+		auto index_state = art.InitializeScanSinglePredicate(transaction, equal_value, ExpressionType::COMPARE_EQUAL);
+		state.rhs_rows[i].clear();
+		if (!equal_value.IsNull()) {
+			if (fetch_types.empty()) {
+				IndexLock lock;
+				index->InitializeLock(lock);
+				art.SearchEqualJoinNoFetch(equal_value, state.result_sizes[i]);
+			} else {
+				IndexLock lock;
+				index->InitializeLock(lock);
+				art.SearchEqual((ARTIndexScanState *)index_state.get(), (idx_t)-1, state.rhs_rows[i]);
+				state.result_sizes[i] = state.rhs_rows[i].size();
+			}
+		} else {
+			//! This is null so no matches
+			state.result_sizes[i] = 0;
+		}
+	}
+	for (idx_t i = input.size(); i < STANDARD_VECTOR_SIZE; i++) {
+		//! No LHS chunk value so result size is empty
+		state.result_sizes[i] = 0;
+	}
+}
+
+OperatorResultType PhysicalIndexJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                              GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (IndexJoinOperatorState &)state_p;
+
+	state.result_size = 0;
+	if (state.first_fetch) {
+		state.probe_executor.Execute(input, state.join_keys);
+
+		//! Fill Matches for the current LHS chunk
+		GetRHSMatches(context, input, state_p);
+		state.first_fetch = false;
+	}
+	//! Check if we need to get a new LHS chunk
+	if (state.lhs_idx >= input.size()) {
+		state.lhs_idx = 0;
+		state.rhs_idx = 0;
+		state.first_fetch = true;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+	//! Output vectors
+	if (state.lhs_idx < input.size()) {
+		Output(context, input, chunk, state_p);
+	}
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalIndexJoin::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	// index join: we only continue into the LHS
+	// the right side is probed by the index join
+	// so we don't need to do anything in the pipeline with this child
+	state.AddPipelineOperator(current, this);
+	children[0]->BuildPipelines(executor, current, state);
+}
+
+vector<const PhysicalOperator *> PhysicalIndexJoin::GetSources() const {
+	return children[0]->GetSources();
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PhysicalJoin::PhysicalJoin(LogicalOperator &op, PhysicalOperatorType type, JoinType join_type,
+                           idx_t estimated_cardinality)
+    : PhysicalOperator(type, op.types, estimated_cardinality), join_type(join_type) {
+}
+
+bool PhysicalJoin::EmptyResultIfRHSIsEmpty() const {
+	// empty RHS with INNER, RIGHT or SEMI join means empty result set
+	switch (join_type) {
+	case JoinType::INNER:
+	case JoinType::RIGHT:
+	case JoinType::SEMI:
+		return true;
+	default:
+		return false;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalJoin::BuildJoinPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state,
+                                      PhysicalOperator &op) {
+	op.op_state.reset();
+	op.sink_state.reset();
+
+	// on the LHS (probe child), the operator becomes a regular operator
+	state.AddPipelineOperator(current, &op);
+	if (op.IsSource()) {
+		// FULL or RIGHT outer join
+		// schedule a scan of the node as a child pipeline
+		// this scan has to be performed AFTER all the probing has happened
+		if (state.recursive_cte) {
+			throw NotImplementedException("FULL and RIGHT outer joins are not supported in recursive CTEs yet");
+		}
+		state.AddChildPipeline(executor, current);
+	}
+	// continue building the pipeline on this child
+	op.children[0]->BuildPipelines(executor, current, state);
+
+	// on the RHS (build side), we construct a new child pipeline with this pipeline as its source
+	op.BuildChildPipeline(executor, current, state, op.children[1].get());
+}
+
+void PhysicalJoin::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	PhysicalJoin::BuildJoinPipelines(executor, current, state, *this);
+}
+
+vector<const PhysicalOperator *> PhysicalJoin::GetSources() const {
+	auto result = children[0]->GetSources();
+	if (IsSource()) {
+		result.push_back(this);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalNestedLoopJoin::PhysicalNestedLoopJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                               unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond,
+                                               JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalComparisonJoin(op, PhysicalOperatorType::NESTED_LOOP_JOIN, move(cond), join_type, estimated_cardinality) {
+	children.push_back(move(left));
+	children.push_back(move(right));
+}
+
+static bool HasNullValues(DataChunk &chunk) {
+	for (idx_t col_idx = 0; col_idx < chunk.ColumnCount(); col_idx++) {
+		VectorData vdata;
+		chunk.data[col_idx].Orrify(chunk.size(), vdata);
+
+		if (vdata.validity.AllValid()) {
+			continue;
+		}
+		for (idx_t i = 0; i < chunk.size(); i++) {
+			auto idx = vdata.sel->get_index(i);
+			if (!vdata.validity.RowIsValid(idx)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+template <bool MATCH>
+static void ConstructSemiOrAntiJoinResult(DataChunk &left, DataChunk &result, bool found_match[]) {
+	D_ASSERT(left.ColumnCount() == result.ColumnCount());
+	// create the selection vector from the matches that were found
+	idx_t result_count = 0;
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	for (idx_t i = 0; i < left.size(); i++) {
+		if (found_match[i] == MATCH) {
+			sel.set_index(result_count++, i);
+		}
+	}
+	// construct the final result
+	if (result_count > 0) {
+		// we only return the columns on the left side
+		// project them using the result selection vector
+		// reference the columns of the left side from the result
+		result.Slice(left, sel, result_count);
+	} else {
+		result.SetCardinality(0);
+	}
+}
+
+void PhysicalJoin::ConstructSemiJoinResult(DataChunk &left, DataChunk &result, bool found_match[]) {
+	ConstructSemiOrAntiJoinResult<true>(left, result, found_match);
+}
+
+void PhysicalJoin::ConstructAntiJoinResult(DataChunk &left, DataChunk &result, bool found_match[]) {
+	ConstructSemiOrAntiJoinResult<false>(left, result, found_match);
+}
+
+void PhysicalJoin::ConstructMarkJoinResult(DataChunk &join_keys, DataChunk &left, DataChunk &result, bool found_match[],
+                                           bool has_null) {
+	// for the initial set of columns we just reference the left side
+	result.SetCardinality(left);
+	for (idx_t i = 0; i < left.ColumnCount(); i++) {
+		result.data[i].Reference(left.data[i]);
+	}
+	auto &mark_vector = result.data.back();
+	mark_vector.SetVectorType(VectorType::FLAT_VECTOR);
+	// first we set the NULL values from the join keys
+	// if there is any NULL in the keys, the result is NULL
+	auto bool_result = FlatVector::GetData<bool>(mark_vector);
+	auto &mask = FlatVector::Validity(mark_vector);
+	for (idx_t col_idx = 0; col_idx < join_keys.ColumnCount(); col_idx++) {
+		VectorData jdata;
+		join_keys.data[col_idx].Orrify(join_keys.size(), jdata);
+		if (!jdata.validity.AllValid()) {
+			for (idx_t i = 0; i < join_keys.size(); i++) {
+				auto jidx = jdata.sel->get_index(i);
+				mask.Set(i, jdata.validity.RowIsValid(jidx));
+			}
+		}
+	}
+	// now set the remaining entries to either true or false based on whether a match was found
+	if (found_match) {
+		for (idx_t i = 0; i < left.size(); i++) {
+			bool_result[i] = found_match[i];
+		}
+	} else {
+		memset(bool_result, 0, sizeof(bool) * left.size());
+	}
+	// if the right side contains NULL values, the result of any FALSE becomes NULL
+	if (has_null) {
+		for (idx_t i = 0; i < left.size(); i++) {
+			if (!bool_result[i]) {
+				mask.SetInvalid(i);
+			}
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class NestedLoopJoinLocalState : public LocalSinkState {
+public:
+	explicit NestedLoopJoinLocalState(const vector<JoinCondition> &conditions) {
+		vector<LogicalType> condition_types;
+		for (auto &cond : conditions) {
+			rhs_executor.AddExpression(*cond.right);
+			condition_types.push_back(cond.right->return_type);
+		}
+		right_condition.Initialize(condition_types);
+	}
+
+	//! The chunk holding the right condition
+	DataChunk right_condition;
+	//! The executor of the RHS condition
+	ExpressionExecutor rhs_executor;
+};
+
+class NestedLoopJoinGlobalState : public GlobalSinkState {
+public:
+	NestedLoopJoinGlobalState() : has_null(false) {
+	}
+
+	mutex nj_lock;
+	//! Materialized data of the RHS
+	ChunkCollection right_data;
+	//! Materialized join condition of the RHS
+	ChunkCollection right_chunks;
+	//! Whether or not the RHS of the nested loop join has NULL values
+	bool has_null;
+	//! A bool indicating for each tuple in the RHS if they found a match (only used in FULL OUTER JOIN)
+	unique_ptr<bool[]> right_found_match;
+};
+
+SinkResultType PhysicalNestedLoopJoin::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                            DataChunk &input) const {
+	auto &gstate = (NestedLoopJoinGlobalState &)state;
+	auto &nlj_state = (NestedLoopJoinLocalState &)lstate;
+
+	// resolve the join expression of the right side
+	nlj_state.right_condition.Reset();
+	nlj_state.rhs_executor.Execute(input, nlj_state.right_condition);
+
+	// if we have not seen any NULL values yet, and we are performing a MARK join, check if there are NULL values in
+	// this chunk
+	if (join_type == JoinType::MARK && !gstate.has_null) {
+		if (HasNullValues(nlj_state.right_condition)) {
+			gstate.has_null = true;
+		}
+	}
+
+	// append the data and the
+	lock_guard<mutex> nj_guard(gstate.nj_lock);
+	gstate.right_data.Append(input);
+	gstate.right_chunks.Append(nlj_state.right_condition);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalNestedLoopJoin::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+	auto &state = (NestedLoopJoinLocalState &)lstate;
+	auto &client_profiler = QueryProfiler::Get(context.client);
+
+	context.thread.profiler.Flush(this, &state.rhs_executor, "rhs_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+SinkFinalizeType PhysicalNestedLoopJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                  GlobalSinkState &gstate_p) const {
+	auto &gstate = (NestedLoopJoinGlobalState &)gstate_p;
+	if (join_type == JoinType::OUTER || join_type == JoinType::RIGHT) {
+		// for FULL/RIGHT OUTER JOIN, initialize found_match to false for every tuple
+		gstate.right_found_match = unique_ptr<bool[]>(new bool[gstate.right_data.Count()]);
+		memset(gstate.right_found_match.get(), 0, sizeof(bool) * gstate.right_data.Count());
+	}
+	if (gstate.right_chunks.Count() == 0 && EmptyResultIfRHSIsEmpty()) {
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+	return SinkFinalizeType::READY;
+}
+
+unique_ptr<GlobalSinkState> PhysicalNestedLoopJoin::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<NestedLoopJoinGlobalState>();
+}
+
+unique_ptr<LocalSinkState> PhysicalNestedLoopJoin::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<NestedLoopJoinLocalState>(conditions);
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class PhysicalNestedLoopJoinState : public OperatorState {
+public:
+	PhysicalNestedLoopJoinState(const PhysicalNestedLoopJoin &op, const vector<JoinCondition> &conditions)
+	    : fetch_next_left(true), fetch_next_right(false), right_chunk(0), left_tuple(0), right_tuple(0) {
+		vector<LogicalType> condition_types;
+		for (auto &cond : conditions) {
+			lhs_executor.AddExpression(*cond.left);
+			condition_types.push_back(cond.left->return_type);
+		}
+		left_condition.Initialize(condition_types);
+		if (IsLeftOuterJoin(op.join_type)) {
+			left_found_match = unique_ptr<bool[]>(new bool[STANDARD_VECTOR_SIZE]);
+			memset(left_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+		}
+	}
+
+	bool fetch_next_left;
+	bool fetch_next_right;
+	idx_t right_chunk;
+	DataChunk left_condition;
+	//! The executor of the LHS condition
+	ExpressionExecutor lhs_executor;
+
+	idx_t left_tuple;
+	idx_t right_tuple;
+
+	unique_ptr<bool[]> left_found_match;
+
+public:
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		context.thread.profiler.Flush(op, &lhs_executor, "lhs_executor", 0);
+	}
+};
+
+unique_ptr<OperatorState> PhysicalNestedLoopJoin::GetOperatorState(ClientContext &context) const {
+	return make_unique<PhysicalNestedLoopJoinState>(*this, conditions);
+}
+
+OperatorResultType PhysicalNestedLoopJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                   GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	auto &gstate = (NestedLoopJoinGlobalState &)*sink_state;
+
+	if (gstate.right_chunks.Count() == 0) {
+		// empty RHS
+		if (!EmptyResultIfRHSIsEmpty()) {
+			ConstructEmptyJoinResult(join_type, gstate.has_null, input, chunk);
+			return OperatorResultType::NEED_MORE_INPUT;
+		} else {
+			return OperatorResultType::FINISHED;
+		}
+	}
+
+	switch (join_type) {
+	case JoinType::SEMI:
+	case JoinType::ANTI:
+	case JoinType::MARK:
+		// simple joins can have max STANDARD_VECTOR_SIZE matches per chunk
+		ResolveSimpleJoin(context, input, chunk, state_p);
+		return OperatorResultType::NEED_MORE_INPUT;
+	case JoinType::LEFT:
+	case JoinType::INNER:
+	case JoinType::OUTER:
+	case JoinType::RIGHT:
+		return ResolveComplexJoin(context, input, chunk, state_p);
+	default:
+		throw NotImplementedException("Unimplemented type for nested loop join!");
+	}
+}
+
+void PhysicalNestedLoopJoin::ResolveSimpleJoin(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                               OperatorState &state_p) const {
+	auto &state = (PhysicalNestedLoopJoinState &)state_p;
+	auto &gstate = (NestedLoopJoinGlobalState &)*sink_state;
+
+	// resolve the left join condition for the current chunk
+	state.lhs_executor.Execute(input, state.left_condition);
+
+	bool found_match[STANDARD_VECTOR_SIZE] = {false};
+	NestedLoopJoinMark::Perform(state.left_condition, gstate.right_chunks, found_match, conditions);
+	switch (join_type) {
+	case JoinType::MARK:
+		// now construct the mark join result from the found matches
+		PhysicalJoin::ConstructMarkJoinResult(state.left_condition, input, chunk, found_match, gstate.has_null);
+		break;
+	case JoinType::SEMI:
+		// construct the semi join result from the found matches
+		PhysicalJoin::ConstructSemiJoinResult(input, chunk, found_match);
+		break;
+	case JoinType::ANTI:
+		// construct the anti join result from the found matches
+		PhysicalJoin::ConstructAntiJoinResult(input, chunk, found_match);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for simple nested loop join!");
+	}
+}
+
+void PhysicalJoin::ConstructLeftJoinResult(DataChunk &left, DataChunk &result, bool found_match[]) {
+	SelectionVector remaining_sel(STANDARD_VECTOR_SIZE);
+	idx_t remaining_count = 0;
+	for (idx_t i = 0; i < left.size(); i++) {
+		if (!found_match[i]) {
+			remaining_sel.set_index(remaining_count++, i);
+		}
+	}
+	if (remaining_count > 0) {
+		result.Slice(left, remaining_sel, remaining_count);
+		for (idx_t idx = left.ColumnCount(); idx < result.ColumnCount(); idx++) {
+			result.data[idx].SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result.data[idx], true);
+		}
+	}
+}
+
+OperatorResultType PhysicalNestedLoopJoin::ResolveComplexJoin(ExecutionContext &context, DataChunk &input,
+                                                              DataChunk &chunk, OperatorState &state_p) const {
+	auto &state = (PhysicalNestedLoopJoinState &)state_p;
+	auto &gstate = (NestedLoopJoinGlobalState &)*sink_state;
+
+	idx_t match_count;
+	do {
+		if (state.fetch_next_right) {
+			// we exhausted the chunk on the right: move to the next chunk on the right
+			state.right_chunk++;
+			state.left_tuple = 0;
+			state.right_tuple = 0;
+			state.fetch_next_right = false;
+			// check if we exhausted all chunks on the RHS
+			if (state.right_chunk >= gstate.right_chunks.ChunkCount()) {
+				state.fetch_next_left = true;
+				// we exhausted all chunks on the right: move to the next chunk on the left
+				if (IsLeftOuterJoin(join_type)) {
+					// left join: before we move to the next chunk, see if we need to output any vectors that didn't
+					// have a match found
+					PhysicalJoin::ConstructLeftJoinResult(input, chunk, state.left_found_match.get());
+					memset(state.left_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+				}
+				return OperatorResultType::NEED_MORE_INPUT;
+			}
+		}
+		if (state.fetch_next_left) {
+			// resolve the left join condition for the current chunk
+			state.left_condition.Reset();
+			state.lhs_executor.Execute(input, state.left_condition);
+
+			state.left_tuple = 0;
+			state.right_tuple = 0;
+			state.right_chunk = 0;
+			state.fetch_next_left = false;
+		}
+		// now we have a left and a right chunk that we can join together
+		// note that we only get here in the case of a LEFT, INNER or FULL join
+		auto &left_chunk = input;
+		auto &right_chunk = gstate.right_chunks.GetChunk(state.right_chunk);
+		auto &right_data = gstate.right_data.GetChunk(state.right_chunk);
+
+		// sanity check
+		left_chunk.Verify();
+		right_chunk.Verify();
+		right_data.Verify();
+
+		// now perform the join
+		SelectionVector lvector(STANDARD_VECTOR_SIZE), rvector(STANDARD_VECTOR_SIZE);
+		match_count = NestedLoopJoinInner::Perform(state.left_tuple, state.right_tuple, state.left_condition,
+		                                           right_chunk, lvector, rvector, conditions);
+		// we have finished resolving the join conditions
+		if (match_count > 0) {
+			// we have matching tuples!
+			// construct the result
+			if (state.left_found_match) {
+				for (idx_t i = 0; i < match_count; i++) {
+					state.left_found_match[lvector.get_index(i)] = true;
+				}
+			}
+			if (gstate.right_found_match) {
+				for (idx_t i = 0; i < match_count; i++) {
+					gstate.right_found_match[state.right_chunk * STANDARD_VECTOR_SIZE + rvector.get_index(i)] = true;
+				}
+			}
+			chunk.Slice(input, lvector, match_count);
+			chunk.Slice(right_data, rvector, match_count, input.ColumnCount());
+		}
+
+		// check if we exhausted the RHS, if we did we need to move to the next right chunk in the next iteration
+		if (state.right_tuple >= right_chunk.size()) {
+			state.fetch_next_right = true;
+		}
+	} while (match_count == 0);
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class NestedLoopJoinScanState : public GlobalSourceState {
+public:
+	explicit NestedLoopJoinScanState(const PhysicalNestedLoopJoin &op) : op(op), right_outer_position(0) {
+	}
+
+	mutex lock;
+	const PhysicalNestedLoopJoin &op;
+	idx_t right_outer_position;
+
+public:
+	idx_t MaxThreads() override {
+		auto &sink = (NestedLoopJoinGlobalState &)*op.sink_state;
+		return sink.right_chunks.Count() / (STANDARD_VECTOR_SIZE * 10);
+	}
+};
+
+unique_ptr<GlobalSourceState> PhysicalNestedLoopJoin::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<NestedLoopJoinScanState>(*this);
+}
+
+void PhysicalNestedLoopJoin::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                     LocalSourceState &lstate) const {
+	D_ASSERT(IsRightOuterJoin(join_type));
+	// check if we need to scan any unmatched tuples from the RHS for the full/right outer join
+	auto &sink = (NestedLoopJoinGlobalState &)*sink_state;
+	auto &state = (NestedLoopJoinScanState &)gstate;
+
+	// if the LHS is exhausted in a FULL/RIGHT OUTER JOIN, we scan the found_match for any chunks we
+	// still need to output
+	lock_guard<mutex> l(state.lock);
+	ConstructFullOuterJoinResult(sink.right_found_match.get(), sink.right_data, chunk, state.right_outer_position);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalPiecewiseMergeJoin::PhysicalPiecewiseMergeJoin(LogicalOperator &op, unique_ptr<PhysicalOperator> left,
+                                                       unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond,
+                                                       JoinType join_type, idx_t estimated_cardinality)
+    : PhysicalRangeJoin(op, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, move(left), move(right), move(cond), join_type,
+                        estimated_cardinality) {
+
+	for (auto &cond : conditions) {
+		D_ASSERT(cond.left->return_type == cond.right->return_type);
+		join_key_types.push_back(cond.left->return_type);
+
+		// Convert the conditions to sort orders
+		auto left = cond.left->Copy();
+		auto right = cond.right->Copy();
+		switch (cond.comparison) {
+		case ExpressionType::COMPARE_LESSTHAN:
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			lhs_orders.emplace_back(BoundOrderByNode(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, move(left)));
+			rhs_orders.emplace_back(BoundOrderByNode(OrderType::ASCENDING, OrderByNullType::NULLS_LAST, move(right)));
+			break;
+		case ExpressionType::COMPARE_GREATERTHAN:
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			lhs_orders.emplace_back(BoundOrderByNode(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, move(left)));
+			rhs_orders.emplace_back(BoundOrderByNode(OrderType::DESCENDING, OrderByNullType::NULLS_LAST, move(right)));
+			break;
+		case ExpressionType::COMPARE_NOTEQUAL:
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			// Allowed in multi-predicate joins, but can't be first/sort.
+			D_ASSERT(!lhs_orders.empty());
+			lhs_orders.emplace_back(BoundOrderByNode(OrderType::INVALID, OrderByNullType::NULLS_LAST, move(left)));
+			rhs_orders.emplace_back(BoundOrderByNode(OrderType::INVALID, OrderByNullType::NULLS_LAST, move(right)));
+			break;
+
+		default:
+			// COMPARE EQUAL not supported with merge join
+			throw NotImplementedException("Unimplemented join type for merge join");
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class MergeJoinLocalState : public LocalSinkState {
+public:
+	explicit MergeJoinLocalState(const PhysicalRangeJoin &op, const idx_t child) : table(op, child) {
+	}
+
+	//! The local sort state
+	PhysicalRangeJoin::LocalSortedTable table;
+};
+
+class MergeJoinGlobalState : public GlobalSinkState {
+public:
+	using GlobalSortedTable = PhysicalRangeJoin::GlobalSortedTable;
+
+public:
+	MergeJoinGlobalState(ClientContext &context, const PhysicalPiecewiseMergeJoin &op) {
+		RowLayout rhs_layout;
+		rhs_layout.Initialize(op.children[1]->types);
+		vector<BoundOrderByNode> rhs_order;
+		rhs_order.emplace_back(op.rhs_orders[0].Copy());
+		table = make_unique<GlobalSortedTable>(context, rhs_order, rhs_layout);
+	}
+
+	inline idx_t Count() const {
+		return table->count;
+	}
+
+	void Sink(DataChunk &input, MergeJoinLocalState &lstate) {
+		auto &global_sort_state = table->global_sort_state;
+		auto &local_sort_state = lstate.table.local_sort_state;
+
+		// Sink the data into the local sort state
+		lstate.table.Sink(input, global_sort_state);
+
+		// When sorting data reaches a certain size, we sort it
+		if (local_sort_state.SizeInBytes() >= table->memory_per_thread) {
+			local_sort_state.Sort(global_sort_state, true);
+		}
+	}
+
+	unique_ptr<GlobalSortedTable> table;
+};
+
+unique_ptr<GlobalSinkState> PhysicalPiecewiseMergeJoin::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<MergeJoinGlobalState>(context, *this);
+}
+
+unique_ptr<LocalSinkState> PhysicalPiecewiseMergeJoin::GetLocalSinkState(ExecutionContext &context) const {
+	// We only sink the RHS
+	return make_unique<MergeJoinLocalState>(*this, 1);
+}
+
+SinkResultType PhysicalPiecewiseMergeJoin::Sink(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                                LocalSinkState &lstate_p, DataChunk &input) const {
+	auto &gstate = (MergeJoinGlobalState &)gstate_p;
+	auto &lstate = (MergeJoinLocalState &)lstate_p;
+
+	gstate.Sink(input, lstate);
+
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalPiecewiseMergeJoin::Combine(ExecutionContext &context, GlobalSinkState &gstate_p,
+                                         LocalSinkState &lstate_p) const {
+	auto &gstate = (MergeJoinGlobalState &)gstate_p;
+	auto &lstate = (MergeJoinLocalState &)lstate_p;
+	gstate.table->Combine(lstate.table);
+	auto &client_profiler = QueryProfiler::Get(context.client);
+
+	context.thread.profiler.Flush(this, &lstate.table.executor, "rhs_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+SinkFinalizeType PhysicalPiecewiseMergeJoin::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                      GlobalSinkState &gstate_p) const {
+	auto &gstate = (MergeJoinGlobalState &)gstate_p;
+	auto &global_sort_state = gstate.table->global_sort_state;
+
+	if (IsRightOuterJoin(join_type)) {
+		// for FULL/RIGHT OUTER JOIN, initialize found_match to false for every tuple
+		gstate.table->IntializeMatches();
+	}
+	if (global_sort_state.sorted_blocks.empty() && EmptyResultIfRHSIsEmpty()) {
+		// Empty input!
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+
+	// Sort the current input child
+	gstate.table->Finalize(pipeline, event);
+
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+class PiecewiseMergeJoinState : public OperatorState {
+public:
+	using LocalSortedTable = PhysicalRangeJoin::LocalSortedTable;
+
+	explicit PiecewiseMergeJoinState(const PhysicalPiecewiseMergeJoin &op, BufferManager &buffer_manager,
+	                                 bool force_external)
+	    : op(op), buffer_manager(buffer_manager), force_external(force_external), left_position(0), first_fetch(true),
+	      finished(true), right_position(0), right_chunk_index(0) {
+		vector<LogicalType> condition_types;
+		for (auto &order : op.lhs_orders) {
+			condition_types.push_back(order.expression->return_type);
+		}
+		if (IsLeftOuterJoin(op.join_type)) {
+			lhs_found_match = unique_ptr<bool[]>(new bool[STANDARD_VECTOR_SIZE]);
+			memset(lhs_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+		}
+		lhs_layout.Initialize(op.children[0]->types);
+		lhs_payload.Initialize(op.children[0]->types);
+
+		lhs_order.emplace_back(op.lhs_orders[0].Copy());
+
+		// Set up shared data for multiple predicates
+		sel.Initialize(STANDARD_VECTOR_SIZE);
+		condition_types.clear();
+		for (auto &order : op.rhs_orders) {
+			rhs_executor.AddExpression(*order.expression);
+			condition_types.push_back(order.expression->return_type);
+		}
+		rhs_keys.Initialize(condition_types);
+	}
+
+	const PhysicalPiecewiseMergeJoin &op;
+	BufferManager &buffer_manager;
+	bool force_external;
+
+	// Block sorting
+	DataChunk lhs_payload;
+	unique_ptr<bool[]> lhs_found_match;
+	vector<BoundOrderByNode> lhs_order;
+	RowLayout lhs_layout;
+	unique_ptr<LocalSortedTable> lhs_local_table;
+	unique_ptr<GlobalSortState> lhs_global_state;
+
+	// Simple scans
+	idx_t left_position;
+
+	// Complex scans
+	bool first_fetch;
+	bool finished;
+	idx_t right_position;
+	idx_t right_chunk_index;
+	idx_t right_base;
+
+	// Secondary predicate shared data
+	SelectionVector sel;
+	DataChunk rhs_keys;
+	DataChunk rhs_input;
+	ExpressionExecutor rhs_executor;
+
+public:
+	void ResolveJoinKeys(DataChunk &input) {
+		// sort by join key
+		lhs_global_state = make_unique<GlobalSortState>(buffer_manager, lhs_order, lhs_layout);
+		lhs_local_table = make_unique<LocalSortedTable>(op, 0);
+		lhs_local_table->Sink(input, *lhs_global_state);
+
+		// Set external (can be forced with the PRAGMA)
+		lhs_global_state->external = force_external;
+		lhs_global_state->AddLocalState(lhs_local_table->local_sort_state);
+		lhs_global_state->PrepareMergePhase();
+		while (lhs_global_state->sorted_blocks.size() > 1) {
+			MergeSorter merge_sorter(*lhs_global_state, buffer_manager);
+			merge_sorter.PerformInMergeRound();
+			lhs_global_state->CompleteMergeRound();
+		}
+
+		// Scan the sorted payload
+		D_ASSERT(lhs_global_state->sorted_blocks.size() == 1);
+
+		PayloadScanner scanner(*lhs_global_state->sorted_blocks[0]->payload_data, *lhs_global_state);
+		lhs_payload.Reset();
+		scanner.Scan(lhs_payload);
+
+		// Recompute the sorted keys from the sorted input
+		lhs_local_table->keys.Reset();
+		lhs_local_table->executor.Execute(lhs_payload, lhs_local_table->keys);
+	}
+
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		if (lhs_local_table) {
+			context.thread.profiler.Flush(op, &lhs_local_table->executor, "lhs_executor", 0);
+		}
+	}
+};
+
+unique_ptr<OperatorState> PhysicalPiecewiseMergeJoin::GetOperatorState(ClientContext &context) const {
+	auto &buffer_manager = BufferManager::GetBufferManager(context);
+	auto &config = ClientConfig::GetConfig(context);
+	return make_unique<PiecewiseMergeJoinState>(*this, buffer_manager, config.force_external);
+}
+
+static inline idx_t SortedBlockNotNull(const idx_t base, const idx_t count, const idx_t not_null) {
+	return MinValue(base + count, MaxValue(base, not_null)) - base;
+}
+
+static int MergeJoinComparisonValue(ExpressionType comparison) {
+	switch (comparison) {
+	case ExpressionType::COMPARE_LESSTHAN:
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return -1;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return 0;
+	default:
+		throw InternalException("Unimplemented comparison type for merge join!");
+	}
+}
+
+struct BlockMergeInfo {
+	GlobalSortState &state;
+	//! The block being scanned
+	const idx_t block_idx;
+	//! The number of not-NULL values in the block (they are at the end)
+	const idx_t not_null;
+	//! The current offset in the block
+	idx_t &entry_idx;
+	SelectionVector result;
+
+	BlockMergeInfo(GlobalSortState &state, idx_t block_idx, idx_t &entry_idx, idx_t not_null)
+	    : state(state), block_idx(block_idx), not_null(not_null), entry_idx(entry_idx), result(STANDARD_VECTOR_SIZE) {
+	}
+};
+
+static void MergeJoinPinSortingBlock(SBScanState &scan, const idx_t block_idx) {
+	scan.SetIndices(block_idx, 0);
+	scan.PinRadix(block_idx);
+
+	auto &sd = *scan.sb->blob_sorting_data;
+	if (block_idx < sd.data_blocks.size()) {
+		scan.PinData(sd);
+	}
+}
+
+static data_ptr_t MergeJoinRadixPtr(SBScanState &scan, const idx_t entry_idx) {
+	scan.entry_idx = entry_idx;
+	return scan.RadixPtr();
+}
+
+static idx_t MergeJoinSimpleBlocks(PiecewiseMergeJoinState &lstate, MergeJoinGlobalState &rstate, bool *found_match,
+                                   const ExpressionType comparison) {
+	const auto cmp = MergeJoinComparisonValue(comparison);
+
+	// The sort parameters should all be the same
+	auto &lsort = *lstate.lhs_global_state;
+	auto &rsort = rstate.table->global_sort_state;
+	D_ASSERT(lsort.sort_layout.all_constant == rsort.sort_layout.all_constant);
+	const auto all_constant = lsort.sort_layout.all_constant;
+	D_ASSERT(lsort.external == rsort.external);
+	const auto external = lsort.external;
+
+	// There should only be one sorted block if they have been sorted
+	D_ASSERT(lsort.sorted_blocks.size() == 1);
+	SBScanState lread(lsort.buffer_manager, lsort);
+	lread.sb = lsort.sorted_blocks[0].get();
+
+	const idx_t l_block_idx = 0;
+	idx_t l_entry_idx = 0;
+	const auto lhs_not_null = lstate.lhs_local_table->count - lstate.lhs_local_table->has_null;
+	MergeJoinPinSortingBlock(lread, l_block_idx);
+	auto l_ptr = MergeJoinRadixPtr(lread, l_entry_idx);
+
+	D_ASSERT(rsort.sorted_blocks.size() == 1);
+	SBScanState rread(rsort.buffer_manager, rsort);
+	rread.sb = rsort.sorted_blocks[0].get();
+
+	const auto cmp_size = lsort.sort_layout.comparison_size;
+	const auto entry_size = lsort.sort_layout.entry_size;
+
+	idx_t right_base = 0;
+	for (idx_t r_block_idx = 0; r_block_idx < rread.sb->radix_sorting_data.size(); r_block_idx++) {
+		// we only care about the BIGGEST value in each of the RHS data blocks
+		// because we want to figure out if the LHS values are less than [or equal] to ANY value
+		// get the biggest value from the RHS chunk
+		MergeJoinPinSortingBlock(rread, r_block_idx);
+
+		auto &rblock = rread.sb->radix_sorting_data[r_block_idx];
+		const auto r_not_null =
+		    SortedBlockNotNull(right_base, rblock.count, rstate.table->count - rstate.table->has_null);
+		if (r_not_null == 0) {
+			break;
+		}
+		const auto r_entry_idx = r_not_null - 1;
+		right_base += rblock.count;
+
+		auto r_ptr = MergeJoinRadixPtr(rread, r_entry_idx);
+
+		// now we start from the current lpos value and check if we found a new value that is [<= OR <] the max RHS
+		// value
+		while (true) {
+			int comp_res;
+			if (all_constant) {
+				comp_res = FastMemcmp(l_ptr, r_ptr, cmp_size);
+			} else {
+				lread.entry_idx = l_entry_idx;
+				rread.entry_idx = r_entry_idx;
+				comp_res = Comparators::CompareTuple(lread, rread, l_ptr, r_ptr, lsort.sort_layout, external);
+			}
+
+			if (comp_res <= cmp) {
+				// found a match for lpos, set it in the found_match vector
+				found_match[l_entry_idx] = true;
+				l_entry_idx++;
+				l_ptr += entry_size;
+				if (l_entry_idx >= lhs_not_null) {
+					// early out: we exhausted the entire LHS and they all match
+					return 0;
+				}
+			} else {
+				// we found no match: any subsequent value from the LHS we scan now will be bigger and thus also not
+				// match move to the next RHS chunk
+				break;
+			}
+		}
+	}
+	return 0;
+}
+
+void PhysicalPiecewiseMergeJoin::ResolveSimpleJoin(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                   OperatorState &state_p) const {
+	auto &state = (PiecewiseMergeJoinState &)state_p;
+	auto &gstate = (MergeJoinGlobalState &)*sink_state;
+
+	state.ResolveJoinKeys(input);
+	auto &lhs_table = *state.lhs_local_table;
+
+	// perform the actual join
+	bool found_match[STANDARD_VECTOR_SIZE];
+	memset(found_match, 0, sizeof(found_match));
+	MergeJoinSimpleBlocks(state, gstate, found_match, conditions[0].comparison);
+
+	// use the sorted payload
+	const auto lhs_not_null = lhs_table.count - lhs_table.has_null;
+	auto &payload = state.lhs_payload;
+
+	// now construct the result based on the join result
+	switch (join_type) {
+	case JoinType::MARK: {
+		// The only part of the join keys that is actually used is the validity mask.
+		// Since the payload is sorted, we can just set the tail end of the validity masks to invalid.
+		for (auto &key : lhs_table.keys.data) {
+			key.Normalify(lhs_table.keys.size());
+			auto &mask = FlatVector::Validity(key);
+			if (mask.AllValid()) {
+				continue;
+			}
+			mask.SetAllValid(lhs_not_null);
+			for (idx_t i = lhs_not_null; i < lhs_table.count; ++i) {
+				mask.SetInvalid(i);
+			}
+		}
+		// So we make a set of keys that have the validity mask set for the
+		PhysicalJoin::ConstructMarkJoinResult(lhs_table.keys, payload, chunk, found_match, gstate.table->has_null);
+		break;
+	}
+	case JoinType::SEMI:
+		PhysicalJoin::ConstructSemiJoinResult(payload, chunk, found_match);
+		break;
+	case JoinType::ANTI:
+		PhysicalJoin::ConstructAntiJoinResult(payload, chunk, found_match);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented join type for merge join");
+	}
+}
+
+static idx_t MergeJoinComplexBlocks(BlockMergeInfo &l, BlockMergeInfo &r, const ExpressionType comparison) {
+	const auto cmp = MergeJoinComparisonValue(comparison);
+
+	// The sort parameters should all be the same
+	D_ASSERT(l.state.sort_layout.all_constant == r.state.sort_layout.all_constant);
+	const auto all_constant = r.state.sort_layout.all_constant;
+	D_ASSERT(l.state.external == r.state.external);
+	const auto external = l.state.external;
+
+	// There should only be one sorted block if they have been sorted
+	D_ASSERT(l.state.sorted_blocks.size() == 1);
+	SBScanState lread(l.state.buffer_manager, l.state);
+	lread.sb = l.state.sorted_blocks[0].get();
+	D_ASSERT(lread.sb->radix_sorting_data.size() == 1);
+	MergeJoinPinSortingBlock(lread, l.block_idx);
+	auto l_start = MergeJoinRadixPtr(lread, 0);
+	auto l_ptr = MergeJoinRadixPtr(lread, l.entry_idx);
+
+	D_ASSERT(r.state.sorted_blocks.size() == 1);
+	SBScanState rread(r.state.buffer_manager, r.state);
+	rread.sb = r.state.sorted_blocks[0].get();
+
+	if (r.entry_idx >= r.not_null) {
+		return 0;
+	}
+
+	MergeJoinPinSortingBlock(rread, r.block_idx);
+	auto r_ptr = MergeJoinRadixPtr(rread, r.entry_idx);
+
+	const auto cmp_size = l.state.sort_layout.comparison_size;
+	const auto entry_size = l.state.sort_layout.entry_size;
+
+	idx_t result_count = 0;
+	while (true) {
+		if (l.entry_idx < l.not_null) {
+			int comp_res;
+			if (all_constant) {
+				comp_res = FastMemcmp(l_ptr, r_ptr, cmp_size);
+			} else {
+				lread.entry_idx = l.entry_idx;
+				rread.entry_idx = r.entry_idx;
+				comp_res = Comparators::CompareTuple(lread, rread, l_ptr, r_ptr, l.state.sort_layout, external);
+			}
+
+			if (comp_res <= cmp) {
+				// left side smaller: found match
+				l.result.set_index(result_count, sel_t(l.entry_idx));
+				r.result.set_index(result_count, sel_t(r.entry_idx));
+				result_count++;
+				// move left side forward
+				l.entry_idx++;
+				l_ptr += entry_size;
+				if (result_count == STANDARD_VECTOR_SIZE) {
+					// out of space!
+					break;
+				}
+				continue;
+			}
+		}
+		// right side smaller or equal, or left side exhausted: move
+		// right pointer forward reset left side to start
+		r.entry_idx++;
+		if (r.entry_idx >= r.not_null) {
+			break;
+		}
+		r_ptr += entry_size;
+
+		l_ptr = l_start;
+		l.entry_idx = 0;
+	}
+
+	return result_count;
+}
+
+OperatorResultType PhysicalPiecewiseMergeJoin::ResolveComplexJoin(ExecutionContext &context, DataChunk &input,
+                                                                  DataChunk &chunk, OperatorState &state_p) const {
+	auto &state = (PiecewiseMergeJoinState &)state_p;
+	auto &gstate = (MergeJoinGlobalState &)*sink_state;
+	auto &rsorted = *gstate.table->global_sort_state.sorted_blocks[0];
+	const auto left_cols = input.ColumnCount();
+	const auto tail_cols = conditions.size() - 1;
+	do {
+		if (state.first_fetch) {
+			state.ResolveJoinKeys(input);
+
+			state.right_chunk_index = 0;
+			state.right_base = 0;
+			state.left_position = 0;
+			state.right_position = 0;
+			state.first_fetch = false;
+			state.finished = false;
+		}
+		if (state.finished) {
+			if (IsLeftOuterJoin(join_type)) {
+				// left join: before we move to the next chunk, see if we need to output any vectors that didn't
+				// have a match found
+				PhysicalJoin::ConstructLeftJoinResult(state.lhs_payload, chunk, state.lhs_found_match.get());
+				memset(state.lhs_found_match.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+			}
+			state.first_fetch = true;
+			state.finished = false;
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+
+		auto &lhs_table = *state.lhs_local_table;
+		const auto lhs_not_null = lhs_table.count - lhs_table.has_null;
+		BlockMergeInfo left_info(*state.lhs_global_state, 0, state.left_position, lhs_not_null);
+
+		const auto &rblock = rsorted.radix_sorting_data[state.right_chunk_index];
+		const auto rhs_not_null =
+		    SortedBlockNotNull(state.right_base, rblock.count, gstate.table->count - gstate.table->has_null);
+		BlockMergeInfo right_info(gstate.table->global_sort_state, state.right_chunk_index, state.right_position,
+		                          rhs_not_null);
+
+		idx_t result_count = MergeJoinComplexBlocks(left_info, right_info, conditions[0].comparison);
+		if (result_count == 0) {
+			// exhausted this chunk on the right side
+			// move to the next right chunk
+			state.left_position = 0;
+			state.right_position = 0;
+			state.right_base += rsorted.radix_sorting_data[state.right_chunk_index].count;
+			state.right_chunk_index++;
+			if (state.right_chunk_index >= rsorted.radix_sorting_data.size()) {
+				state.finished = true;
+			}
+		} else {
+			// found matches: extract them
+			chunk.Reset();
+			for (idx_t c = 0; c < state.lhs_payload.ColumnCount(); ++c) {
+				chunk.data[c].Slice(state.lhs_payload.data[c], left_info.result, result_count);
+			}
+			SliceSortedPayload(chunk, right_info.state, right_info.block_idx, right_info.result, result_count,
+			                   left_cols);
+			chunk.SetCardinality(result_count);
+
+			auto sel = FlatVector::IncrementalSelectionVector();
+			if (tail_cols) {
+				// If there are more expressions to compute,
+				// split the result chunk into the left and right halves
+				// so we can compute the values for comparison.
+				chunk.Split(state.rhs_input, left_cols);
+				state.rhs_executor.SetChunk(state.rhs_input);
+				state.rhs_keys.Reset();
+
+				auto tail_count = result_count;
+				for (size_t cmp_idx = 1; cmp_idx < conditions.size(); ++cmp_idx) {
+					Vector left(lhs_table.keys.data[cmp_idx]);
+					left.Slice(left_info.result, result_count);
+
+					auto &right = state.rhs_keys.data[cmp_idx];
+					state.rhs_executor.ExecuteExpression(cmp_idx, right);
+
+					if (tail_count < result_count) {
+						left.Slice(*sel, tail_count);
+						right.Slice(*sel, tail_count);
+					}
+					tail_count =
+					    SelectJoinTail(conditions[cmp_idx].comparison, left, right, sel, tail_count, &state.sel);
+					sel = &state.sel;
+				}
+				chunk.Fuse(state.rhs_input);
+
+				if (tail_count < result_count) {
+					result_count = tail_count;
+					chunk.Slice(*sel, result_count);
+				}
+			}
+
+			// found matches: mark the found matches if required
+			if (state.lhs_found_match) {
+				for (idx_t i = 0; i < result_count; i++) {
+					state.lhs_found_match[left_info.result[sel->get_index(i)]] = true;
+				}
+			}
+			if (gstate.table->found_match) {
+				//	Absolute position of the block + start position inside that block
+				for (idx_t i = 0; i < result_count; i++) {
+					gstate.table->found_match[state.right_base + right_info.result[sel->get_index(i)]] = true;
+				}
+			}
+			chunk.SetCardinality(result_count);
+			chunk.Verify();
+		}
+	} while (chunk.size() == 0);
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+OperatorResultType PhysicalPiecewiseMergeJoin::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                       GlobalOperatorState &gstate_p, OperatorState &state) const {
+	auto &gstate = (MergeJoinGlobalState &)*sink_state;
+
+	if (gstate.Count() == 0) {
+		// empty RHS
+		if (!EmptyResultIfRHSIsEmpty()) {
+			ConstructEmptyJoinResult(join_type, gstate.table->has_null, input, chunk);
+			return OperatorResultType::NEED_MORE_INPUT;
+		} else {
+			return OperatorResultType::FINISHED;
+		}
+	}
+
+	input.Verify();
+	switch (join_type) {
+	case JoinType::SEMI:
+	case JoinType::ANTI:
+	case JoinType::MARK:
+		// simple joins can have max STANDARD_VECTOR_SIZE matches per chunk
+		ResolveSimpleJoin(context, input, chunk, state);
+		return OperatorResultType::NEED_MORE_INPUT;
+	case JoinType::LEFT:
+	case JoinType::INNER:
+	case JoinType::RIGHT:
+	case JoinType::OUTER:
+		return ResolveComplexJoin(context, input, chunk, state);
+	default:
+		throw NotImplementedException("Unimplemented type for piecewise merge loop join!");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class PiecewiseJoinScanState : public GlobalSourceState {
+public:
+	explicit PiecewiseJoinScanState(const PhysicalPiecewiseMergeJoin &op) : op(op), right_outer_position(0) {
+	}
+
+	mutex lock;
+	const PhysicalPiecewiseMergeJoin &op;
+	unique_ptr<PayloadScanner> scanner;
+	idx_t right_outer_position;
+
+public:
+	idx_t MaxThreads() override {
+		auto &sink = (MergeJoinGlobalState &)*op.sink_state;
+		return sink.Count() / (STANDARD_VECTOR_SIZE * idx_t(10));
+	}
+};
+
+unique_ptr<GlobalSourceState> PhysicalPiecewiseMergeJoin::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<PiecewiseJoinScanState>(*this);
+}
+
+void PhysicalPiecewiseMergeJoin::GetData(ExecutionContext &context, DataChunk &result, GlobalSourceState &gstate,
+                                         LocalSourceState &lstate) const {
+	D_ASSERT(IsRightOuterJoin(join_type));
+	// check if we need to scan any unmatched tuples from the RHS for the full/right outer join
+	auto &sink = (MergeJoinGlobalState &)*sink_state;
+	auto &state = (PiecewiseJoinScanState &)gstate;
+
+	lock_guard<mutex> l(state.lock);
+	if (!state.scanner) {
+		// Initialize scanner (if not yet initialized)
+		auto &sort_state = sink.table->global_sort_state;
+		if (sort_state.sorted_blocks.empty()) {
+			return;
+		}
+		state.scanner = make_unique<PayloadScanner>(*sort_state.sorted_blocks[0]->payload_data, sort_state);
+	}
+
+	// if the LHS is exhausted in a FULL/RIGHT OUTER JOIN, we scan the found_match for any chunks we
+	// still need to output
+	const auto found_match = sink.table->found_match.get();
+
+	// ConstructFullOuterJoinResult(sink.table->found_match.get(), sink.right_chunks, chunk,
+	// state.right_outer_position);
+	DataChunk rhs_chunk;
+	rhs_chunk.Initialize(sink.table->global_sort_state.payload_layout.GetTypes());
+	SelectionVector rsel(STANDARD_VECTOR_SIZE);
+	for (;;) {
+		// Read the next sorted chunk
+		state.scanner->Scan(rhs_chunk);
+
+		const auto count = rhs_chunk.size();
+		if (count == 0) {
+			return;
+		}
+
+		idx_t result_count = 0;
+		// figure out which tuples didn't find a match in the RHS
+		for (idx_t i = 0; i < count; i++) {
+			if (!found_match[state.right_outer_position + i]) {
+				rsel.set_index(result_count++, i);
+			}
+		}
+		state.right_outer_position += count;
+
+		if (result_count > 0) {
+			// if there were any tuples that didn't find a match, output them
+			const idx_t left_column_count = children[0]->types.size();
+			for (idx_t col_idx = 0; col_idx < left_column_count; ++col_idx) {
+				result.data[col_idx].SetVectorType(VectorType::CONSTANT_VECTOR);
+				ConstantVector::SetNull(result.data[col_idx], true);
+			}
+			const idx_t right_column_count = children[1]->types.size();
+			;
+			for (idx_t col_idx = 0; col_idx < right_column_count; ++col_idx) {
+				result.data[left_column_count + col_idx].Slice(rhs_chunk.data[col_idx], rsel, result_count);
+			}
+			result.SetCardinality(result_count);
+			return;
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <thread>
+
+namespace duckdb {
+
+PhysicalRangeJoin::LocalSortedTable::LocalSortedTable(const PhysicalRangeJoin &op, const idx_t child)
+    : op(op), has_null(0), count(0) {
+	// Initialize order clause expression executor and key DataChunk
+	vector<LogicalType> types;
+	for (const auto &cond : op.conditions) {
+		const auto &expr = child ? cond.right : cond.left;
+		executor.AddExpression(*expr);
+
+		types.push_back(expr->return_type);
+	}
+	keys.Initialize(types);
+}
+
+void PhysicalRangeJoin::LocalSortedTable::Sink(DataChunk &input, GlobalSortState &global_sort_state) {
+	// Initialize local state (if necessary)
+	if (!local_sort_state.initialized) {
+		local_sort_state.Initialize(global_sort_state, global_sort_state.buffer_manager);
+	}
+
+	// Obtain sorting columns
+	keys.Reset();
+	executor.Execute(input, keys);
+
+	// Count the NULLs so we can exclude them later
+	has_null += MergeNulls(op.conditions);
+	count += keys.size();
+
+	//	Only sort the primary key
+	DataChunk join_head;
+	join_head.data.emplace_back(Vector(keys.data[0]));
+	join_head.SetCardinality(keys.size());
+
+	// Sink the data into the local sort state
+	local_sort_state.SinkChunk(join_head, input);
+}
+
+PhysicalRangeJoin::GlobalSortedTable::GlobalSortedTable(ClientContext &context, const vector<BoundOrderByNode> &orders,
+                                                        RowLayout &payload_layout)
+    : global_sort_state(BufferManager::GetBufferManager(context), orders, payload_layout), has_null(0), count(0),
+      memory_per_thread(0) {
+	D_ASSERT(orders.size() == 1);
+
+	// Set external (can be force with the PRAGMA)
+	auto &config = ClientConfig::GetConfig(context);
+	global_sort_state.external = config.force_external;
+	// Memory usage per thread should scale with max mem / num threads
+	// We take 1/4th of this, to be conservative
+	idx_t max_memory = global_sort_state.buffer_manager.GetMaxMemory();
+	idx_t num_threads = TaskScheduler::GetScheduler(context).NumberOfThreads();
+	memory_per_thread = (max_memory / num_threads) / 4;
+}
+
+void PhysicalRangeJoin::GlobalSortedTable::Combine(LocalSortedTable &ltable) {
+	global_sort_state.AddLocalState(ltable.local_sort_state);
+	has_null += ltable.has_null;
+	count += ltable.count;
+}
+
+void PhysicalRangeJoin::GlobalSortedTable::IntializeMatches() {
+	found_match = unique_ptr<bool[]>(new bool[Count()]);
+	memset(found_match.get(), 0, sizeof(bool) * Count());
+}
+
+void PhysicalRangeJoin::GlobalSortedTable::Print() {
+	global_sort_state.Print();
+}
+
+class RangeJoinMergeTask : public ExecutorTask {
+public:
+	using GlobalSortedTable = PhysicalRangeJoin::GlobalSortedTable;
+
+public:
+	RangeJoinMergeTask(shared_ptr<Event> event_p, ClientContext &context, GlobalSortedTable &table)
+	    : ExecutorTask(context), event(move(event_p)), context(context), table(table) {
+	}
+
+	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
+		// Initialize iejoin sorted and iterate until done
+		auto &global_sort_state = table.global_sort_state;
+		MergeSorter merge_sorter(global_sort_state, BufferManager::GetBufferManager(context));
+		merge_sorter.PerformInMergeRound();
+		event->FinishTask();
+
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+private:
+	shared_ptr<Event> event;
+	ClientContext &context;
+	GlobalSortedTable &table;
+};
+
+class RangeJoinMergeEvent : public Event {
+public:
+	using GlobalSortedTable = PhysicalRangeJoin::GlobalSortedTable;
+
+public:
+	RangeJoinMergeEvent(GlobalSortedTable &table_p, Pipeline &pipeline_p)
+	    : Event(pipeline_p.executor), table(table_p), pipeline(pipeline_p) {
+	}
+
+	GlobalSortedTable &table;
+	Pipeline &pipeline;
+
+public:
+	void Schedule() override {
+		auto &context = pipeline.GetClientContext();
+
+		// Schedule tasks equal to the number of threads, which will each merge multiple partitions
+		auto &ts = TaskScheduler::GetScheduler(context);
+		idx_t num_threads = ts.NumberOfThreads();
+
+		vector<unique_ptr<Task>> iejoin_tasks;
+		for (idx_t tnum = 0; tnum < num_threads; tnum++) {
+			iejoin_tasks.push_back(make_unique<RangeJoinMergeTask>(shared_from_this(), context, table));
+		}
+		SetTasks(move(iejoin_tasks));
+	}
+
+	void FinishEvent() override {
+		auto &global_sort_state = table.global_sort_state;
+
+		global_sort_state.CompleteMergeRound(true);
+		if (global_sort_state.sorted_blocks.size() > 1) {
+			// Multiple blocks remaining: Schedule the next round
+			table.ScheduleMergeTasks(pipeline, *this);
+		}
+	}
+};
+
+void PhysicalRangeJoin::GlobalSortedTable::ScheduleMergeTasks(Pipeline &pipeline, Event &event) {
+	// Initialize global sort state for a round of merging
+	global_sort_state.InitializeMergeRound();
+	auto new_event = make_shared<RangeJoinMergeEvent>(*this, pipeline);
+	event.InsertEvent(move(new_event));
+}
+
+void PhysicalRangeJoin::GlobalSortedTable::Finalize(Pipeline &pipeline, Event &event) {
+	// Prepare for merge sort phase
+	global_sort_state.PrepareMergePhase();
+
+	// Start the merge phase or finish if a merge is not necessary
+	if (global_sort_state.sorted_blocks.size() > 1) {
+		ScheduleMergeTasks(pipeline, event);
+	}
+}
+
+PhysicalRangeJoin::PhysicalRangeJoin(LogicalOperator &op, PhysicalOperatorType type, unique_ptr<PhysicalOperator> left,
+                                     unique_ptr<PhysicalOperator> right, vector<JoinCondition> cond, JoinType join_type,
+                                     idx_t estimated_cardinality)
+    : PhysicalComparisonJoin(op, type, move(cond), join_type, estimated_cardinality) {
+	// Reorder the conditions so that ranges are at the front.
+	// TODO: use stats to improve the choice?
+	// TODO: Prefer fixed length types?
+	if (conditions.size() > 1) {
+		auto conditions_p = std::move(conditions);
+		conditions.resize(conditions_p.size());
+		idx_t range_position = 0;
+		idx_t other_position = conditions_p.size();
+		for (idx_t i = 0; i < conditions_p.size(); ++i) {
+			switch (conditions_p[i].comparison) {
+			case ExpressionType::COMPARE_LESSTHAN:
+			case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			case ExpressionType::COMPARE_GREATERTHAN:
+			case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+				conditions[range_position++] = std::move(conditions_p[i]);
+				break;
+			default:
+				conditions[--other_position] = std::move(conditions_p[i]);
+				break;
+			}
+		}
+	}
+
+	children.push_back(move(left));
+	children.push_back(move(right));
+}
+
+idx_t PhysicalRangeJoin::LocalSortedTable::MergeNulls(const vector<JoinCondition> &conditions) {
+	// Merge the validity masks of the comparison keys into the primary
+	// Return the number of NULLs in the resulting chunk
+	D_ASSERT(keys.ColumnCount() > 0);
+	const auto count = keys.size();
+
+	size_t all_constant = 0;
+	for (auto &v : keys.data) {
+		if (v.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			++all_constant;
+		}
+	}
+
+	auto &primary = keys.data[0];
+	if (all_constant == keys.data.size()) {
+		//	Either all NULL or no NULLs
+		for (auto &v : keys.data) {
+			if (ConstantVector::IsNull(v)) {
+				ConstantVector::SetNull(primary, true);
+				return count;
+			}
+		}
+		return 0;
+	} else if (keys.ColumnCount() > 1) {
+		//	Normalify the primary, as it will need to merge arbitrary validity masks
+		primary.Normalify(count);
+		auto &pvalidity = FlatVector::Validity(primary);
+		D_ASSERT(keys.ColumnCount() == conditions.size());
+		for (size_t c = 1; c < keys.data.size(); ++c) {
+			// Skip comparisons that accept NULLs
+			if (conditions[c].comparison == ExpressionType::COMPARE_DISTINCT_FROM) {
+				continue;
+			}
+			//	Orrify the rest, as the sort code will do this anyway.
+			auto &v = keys.data[c];
+			VectorData vdata;
+			v.Orrify(count, vdata);
+			auto &vvalidity = vdata.validity;
+			if (vvalidity.AllValid()) {
+				continue;
+			}
+			pvalidity.EnsureWritable();
+			switch (v.GetVectorType()) {
+			case VectorType::FLAT_VECTOR: {
+				// Merge entire entries
+				auto pmask = pvalidity.GetData();
+				const auto entry_count = pvalidity.EntryCount(count);
+				for (idx_t entry_idx = 0; entry_idx < entry_count; ++entry_idx) {
+					pmask[entry_idx] &= vvalidity.GetValidityEntry(entry_idx);
+				}
+				break;
+			}
+			case VectorType::CONSTANT_VECTOR:
+				// All or nothing
+				if (ConstantVector::IsNull(v)) {
+					pvalidity.SetAllInvalid(count);
+					return count;
+				}
+				break;
+			default:
+				// One by one
+				for (idx_t i = 0; i < count; ++i) {
+					const auto idx = vdata.sel->get_index(i);
+					if (!vvalidity.RowIsValidUnsafe(idx)) {
+						pvalidity.SetInvalidUnsafe(i);
+					}
+				}
+				break;
+			}
+		}
+		return count - pvalidity.CountValid(count);
+	} else {
+		return count - VectorOperations::CountNotNull(primary, count);
+	}
+}
+
+void PhysicalRangeJoin::SliceSortedPayload(DataChunk &payload, GlobalSortState &state, const idx_t block_idx,
+                                           const SelectionVector &result, const idx_t result_count,
+                                           const idx_t left_cols) {
+	// There should only be one sorted block if they have been sorted
+	D_ASSERT(state.sorted_blocks.size() == 1);
+	SBScanState read_state(state.buffer_manager, state);
+	read_state.sb = state.sorted_blocks[0].get();
+	auto &sorted_data = *read_state.sb->payload_data;
+
+	read_state.SetIndices(block_idx, 0);
+	read_state.PinData(sorted_data);
+	const auto data_ptr = read_state.DataPtr(sorted_data);
+
+	// Set up a batch of pointers to scan data from
+	Vector addresses(LogicalType::POINTER, result_count);
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+
+	// Set up the data pointers for the values that are actually referenced
+	const idx_t &row_width = sorted_data.layout.GetRowWidth();
+
+	auto prev_idx = result.get_index(0);
+	SelectionVector gsel(result_count);
+	idx_t addr_count = 0;
+	gsel.set_index(0, addr_count);
+	data_pointers[addr_count] = data_ptr + prev_idx * row_width;
+	for (idx_t i = 1; i < result_count; ++i) {
+		const auto row_idx = result.get_index(i);
+		if (row_idx != prev_idx) {
+			data_pointers[++addr_count] = data_ptr + row_idx * row_width;
+			prev_idx = row_idx;
+		}
+		gsel.set_index(i, addr_count);
+	}
+	++addr_count;
+
+	// Unswizzle the offsets back to pointers (if needed)
+	if (!sorted_data.layout.AllConstant() && state.external) {
+		RowOperations::UnswizzlePointers(sorted_data.layout, data_ptr, read_state.payload_heap_handle->Ptr(),
+		                                 addr_count);
+	}
+
+	// Deserialize the payload data
+	auto sel = FlatVector::IncrementalSelectionVector();
+	for (idx_t col_idx = 0; col_idx < sorted_data.layout.ColumnCount(); col_idx++) {
+		const auto col_offset = sorted_data.layout.GetOffsets()[col_idx];
+		auto &col = payload.data[left_cols + col_idx];
+		RowOperations::Gather(addresses, *sel, col, *sel, addr_count, col_offset, col_idx);
+		col.Slice(gsel, result_count);
+	}
+}
+
+idx_t PhysicalRangeJoin::SelectJoinTail(const ExpressionType &condition, Vector &left, Vector &right,
+                                        const SelectionVector *sel, idx_t count, SelectionVector *true_sel) {
+	switch (condition) {
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return VectorOperations::NotEquals(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_LESSTHAN:
+		return VectorOperations::LessThan(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return VectorOperations::GreaterThan(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return VectorOperations::LessThanEquals(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return VectorOperations::GreaterThanEquals(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return VectorOperations::DistinctFrom(left, right, sel, count, true_sel, nullptr);
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+	case ExpressionType::COMPARE_EQUAL:
+	default:
+		throw InternalException("Unsupported comparison type for PhysicalRangeJoin");
+	}
+
+	return count;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalOrder::PhysicalOrder(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::ORDER_BY, move(types), estimated_cardinality), orders(move(orders)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class OrderGlobalState : public GlobalSinkState {
+public:
+	OrderGlobalState(BufferManager &buffer_manager, const PhysicalOrder &order, RowLayout &payload_layout)
+	    : global_sort_state(buffer_manager, order.orders, payload_layout) {
+	}
+
+	//! Global sort state
+	GlobalSortState global_sort_state;
+	//! Memory usage per thread
+	idx_t memory_per_thread;
+};
+
+class OrderLocalState : public LocalSinkState {
+public:
+	OrderLocalState() {
+	}
+
+public:
+	//! The local sort state
+	LocalSortState local_sort_state;
+	//! Local copy of the sorting expression executor
+	ExpressionExecutor executor;
+	//! Holds a vector of incoming sorting columns
+	DataChunk sort;
+};
+
+unique_ptr<GlobalSinkState> PhysicalOrder::GetGlobalSinkState(ClientContext &context) const {
+	// Get the payload layout from the return types
+	RowLayout payload_layout;
+	payload_layout.Initialize(types);
+	auto state = make_unique<OrderGlobalState>(BufferManager::GetBufferManager(context), *this, payload_layout);
+	// Set external (can be force with the PRAGMA)
+	state->global_sort_state.external = ClientConfig::GetConfig(context).force_external;
+	// Memory usage per thread should scale with max mem / num threads
+	// We take 1/4th of this, to be conservative
+	idx_t max_memory = BufferManager::GetBufferManager(context).GetMaxMemory();
+	idx_t num_threads = TaskScheduler::GetScheduler(context).NumberOfThreads();
+	state->memory_per_thread = (max_memory / num_threads) / 4;
+	return move(state);
+}
+
+unique_ptr<LocalSinkState> PhysicalOrder::GetLocalSinkState(ExecutionContext &context) const {
+	auto result = make_unique<OrderLocalState>();
+	// Initialize order clause expression executor and DataChunk
+	vector<LogicalType> types;
+	for (auto &order : orders) {
+		types.push_back(order.expression->return_type);
+		result->executor.AddExpression(*order.expression);
+	}
+	result->sort.Initialize(types);
+	return move(result);
+}
+
+SinkResultType PhysicalOrder::Sink(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p,
+                                   DataChunk &input) const {
+	auto &gstate = (OrderGlobalState &)gstate_p;
+	auto &lstate = (OrderLocalState &)lstate_p;
+
+	auto &global_sort_state = gstate.global_sort_state;
+	auto &local_sort_state = lstate.local_sort_state;
+
+	// Initialize local state (if necessary)
+	if (!local_sort_state.initialized) {
+		local_sort_state.Initialize(global_sort_state, BufferManager::GetBufferManager(context.client));
+	}
+
+	// Obtain sorting columns
+	auto &sort = lstate.sort;
+	sort.Reset();
+	lstate.executor.Execute(input, sort);
+
+	// Sink the data into the local sort state
+	sort.Verify();
+	input.Verify();
+	local_sort_state.SinkChunk(sort, input);
+
+	// When sorting data reaches a certain size, we sort it
+	if (local_sort_state.SizeInBytes() >= gstate.memory_per_thread) {
+		local_sort_state.Sort(global_sort_state, true);
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalOrder::Combine(ExecutionContext &context, GlobalSinkState &gstate_p, LocalSinkState &lstate_p) const {
+	auto &gstate = (OrderGlobalState &)gstate_p;
+	auto &lstate = (OrderLocalState &)lstate_p;
+	gstate.global_sort_state.AddLocalState(lstate.local_sort_state);
+}
+
+class PhysicalOrderMergeTask : public ExecutorTask {
+public:
+	PhysicalOrderMergeTask(shared_ptr<Event> event_p, ClientContext &context, OrderGlobalState &state)
+	    : ExecutorTask(context), event(move(event_p)), context(context), state(state) {
+	}
+
+	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
+		// Initialize merge sorted and iterate until done
+		auto &global_sort_state = state.global_sort_state;
+		MergeSorter merge_sorter(global_sort_state, BufferManager::GetBufferManager(context));
+		merge_sorter.PerformInMergeRound();
+		event->FinishTask();
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+private:
+	shared_ptr<Event> event;
+	ClientContext &context;
+	OrderGlobalState &state;
+};
+
+class OrderMergeEvent : public Event {
+public:
+	OrderMergeEvent(OrderGlobalState &gstate_p, Pipeline &pipeline_p)
+	    : Event(pipeline_p.executor), gstate(gstate_p), pipeline(pipeline_p) {
+	}
+
+	OrderGlobalState &gstate;
+	Pipeline &pipeline;
+
+public:
+	void Schedule() override {
+		auto &context = pipeline.GetClientContext();
+
+		// Schedule tasks equal to the number of threads, which will each merge multiple partitions
+		auto &ts = TaskScheduler::GetScheduler(context);
+		idx_t num_threads = ts.NumberOfThreads();
+
+		vector<unique_ptr<Task>> merge_tasks;
+		for (idx_t tnum = 0; tnum < num_threads; tnum++) {
+			merge_tasks.push_back(make_unique<PhysicalOrderMergeTask>(shared_from_this(), context, gstate));
+		}
+		SetTasks(move(merge_tasks));
+	}
+
+	void FinishEvent() override {
+		auto &global_sort_state = gstate.global_sort_state;
+
+		global_sort_state.CompleteMergeRound();
+		if (global_sort_state.sorted_blocks.size() > 1) {
+			// Multiple blocks remaining: Schedule the next round
+			PhysicalOrder::ScheduleMergeTasks(pipeline, *this, gstate);
+		}
+	}
+};
+
+SinkFinalizeType PhysicalOrder::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                         GlobalSinkState &gstate_p) const {
+	auto &state = (OrderGlobalState &)gstate_p;
+	auto &global_sort_state = state.global_sort_state;
+
+	if (global_sort_state.sorted_blocks.empty()) {
+		// Empty input!
+		return SinkFinalizeType::NO_OUTPUT_POSSIBLE;
+	}
+
+	// Prepare for merge sort phase
+	global_sort_state.PrepareMergePhase();
+
+	// Start the merge phase or finish if a merge is not necessary
+	if (global_sort_state.sorted_blocks.size() > 1) {
+		PhysicalOrder::ScheduleMergeTasks(pipeline, event, state);
+	}
+	return SinkFinalizeType::READY;
+}
+
+void PhysicalOrder::ScheduleMergeTasks(Pipeline &pipeline, Event &event, OrderGlobalState &state) {
+	// Initialize global sort state for a round of merging
+	state.global_sort_state.InitializeMergeRound();
+	auto new_event = make_shared<OrderMergeEvent>(state, pipeline);
+	event.InsertEvent(move(new_event));
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class PhysicalOrderOperatorState : public GlobalSourceState {
+public:
+	//! Payload scanner
+	unique_ptr<PayloadScanner> scanner;
+};
+
+unique_ptr<GlobalSourceState> PhysicalOrder::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<PhysicalOrderOperatorState>();
+}
+
+void PhysicalOrder::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                            LocalSourceState &lstate) const {
+	auto &state = (PhysicalOrderOperatorState &)gstate;
+
+	if (!state.scanner) {
+		// Initialize scanner (if not yet initialized)
+		auto &gstate = (OrderGlobalState &)*this->sink_state;
+		auto &global_sort_state = gstate.global_sort_state;
+		if (global_sort_state.sorted_blocks.empty()) {
+			return;
+		}
+		state.scanner =
+		    make_unique<PayloadScanner>(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state);
+	}
+
+	// Scan the next data chunk
+	state.scanner->Scan(chunk);
+}
+
+string PhysicalOrder::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < orders.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += orders[i].expression->ToString() + " ";
+		result += orders[i].type == OrderType::DESCENDING ? "DESC" : "ASC";
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalTopN::PhysicalTopN(vector<LogicalType> types, vector<BoundOrderByNode> orders, idx_t limit, idx_t offset,
+                           idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::TOP_N, move(types), estimated_cardinality), orders(move(orders)),
+      limit(limit), offset(offset) {
+}
+
+//===--------------------------------------------------------------------===//
+// Heaps
+//===--------------------------------------------------------------------===//
+class TopNHeap;
+
+struct TopNScanState {
+	unique_ptr<PayloadScanner> scanner;
+	idx_t pos;
+	bool exclude_offset;
+};
+
+class TopNSortState {
+public:
+	explicit TopNSortState(TopNHeap &heap);
+
+	TopNHeap &heap;
+	unique_ptr<LocalSortState> local_state;
+	unique_ptr<GlobalSortState> global_state;
+	idx_t count;
+	bool is_sorted;
+
+public:
+	void Initialize();
+	void Append(DataChunk &sort_chunk, DataChunk &payload);
+
+	void Sink(DataChunk &input);
+	void Finalize();
+
+	void Move(TopNSortState &other);
+
+	void InitializeScan(TopNScanState &state, bool exclude_offset);
+	void Scan(TopNScanState &state, DataChunk &chunk);
+};
+
+class TopNHeap {
+public:
+	TopNHeap(ClientContext &context, const vector<LogicalType> &payload_types, const vector<BoundOrderByNode> &orders,
+	         idx_t limit, idx_t offset);
+
+	ClientContext &context;
+	const vector<LogicalType> &payload_types;
+	const vector<BoundOrderByNode> &orders;
+	idx_t limit;
+	idx_t offset;
+	TopNSortState sort_state;
+	ExpressionExecutor executor;
+	DataChunk sort_chunk;
+	DataChunk compare_chunk;
+	DataChunk payload_chunk;
+	//! A set of boundary values that determine either the minimum or the maximum value we have to consider for our
+	//! top-n
+	DataChunk boundary_values;
+	//! Whether or not the boundary_values has been set. The boundary_values are only set after a reduce step
+	bool has_boundary_values;
+
+	SelectionVector final_sel;
+	SelectionVector true_sel;
+	SelectionVector false_sel;
+	SelectionVector new_remaining_sel;
+
+public:
+	void Sink(DataChunk &input);
+	void Combine(TopNHeap &other);
+	void Reduce();
+	void Finalize();
+
+	void ExtractBoundaryValues(DataChunk &current_chunk, DataChunk &prev_chunk);
+
+	void InitializeScan(TopNScanState &state, bool exclude_offset);
+	void Scan(TopNScanState &state, DataChunk &chunk);
+
+	bool CheckBoundaryValues(DataChunk &sort_chunk, DataChunk &payload);
+};
+
+//===--------------------------------------------------------------------===//
+// TopNSortState
+//===--------------------------------------------------------------------===//
+TopNSortState::TopNSortState(TopNHeap &heap) : heap(heap), count(0), is_sorted(false) {
+}
+
+void TopNSortState::Initialize() {
+	RowLayout layout;
+	layout.Initialize(heap.payload_types);
+	auto &buffer_manager = BufferManager::GetBufferManager(heap.context);
+	global_state = make_unique<GlobalSortState>(buffer_manager, heap.orders, layout);
+	local_state = make_unique<LocalSortState>();
+	local_state->Initialize(*global_state, buffer_manager);
+}
+
+void TopNSortState::Append(DataChunk &sort_chunk, DataChunk &payload) {
+	D_ASSERT(!is_sorted);
+	if (heap.has_boundary_values) {
+		if (!heap.CheckBoundaryValues(sort_chunk, payload)) {
+			return;
+		}
+	}
+
+	local_state->SinkChunk(sort_chunk, payload);
+	count += payload.size();
+}
+
+void TopNSortState::Sink(DataChunk &input) {
+	// compute the ordering values for the new chunk
+	heap.sort_chunk.Reset();
+	heap.executor.Execute(input, heap.sort_chunk);
+
+	// append the new chunk to what we have already
+	Append(heap.sort_chunk, input);
+}
+
+void TopNSortState::Move(TopNSortState &other) {
+	local_state = move(other.local_state);
+	global_state = move(other.global_state);
+	count = other.count;
+	is_sorted = other.is_sorted;
+}
+
+void TopNSortState::Finalize() {
+	D_ASSERT(!is_sorted);
+	global_state->AddLocalState(*local_state);
+
+	global_state->PrepareMergePhase();
+	while (global_state->sorted_blocks.size() > 1) {
+		MergeSorter merge_sorter(*global_state, BufferManager::GetBufferManager(heap.context));
+		merge_sorter.PerformInMergeRound();
+		global_state->CompleteMergeRound();
+	}
+	is_sorted = true;
+}
+
+void TopNSortState::InitializeScan(TopNScanState &state, bool exclude_offset) {
+	D_ASSERT(is_sorted);
+	if (global_state->sorted_blocks.empty()) {
+		state.scanner = nullptr;
+	} else {
+		D_ASSERT(global_state->sorted_blocks.size() == 1);
+		state.scanner = make_unique<PayloadScanner>(*global_state->sorted_blocks[0]->payload_data, *global_state);
+	}
+	state.pos = 0;
+	state.exclude_offset = exclude_offset && heap.offset > 0;
+}
+
+void TopNSortState::Scan(TopNScanState &state, DataChunk &chunk) {
+	if (!state.scanner) {
+		return;
+	}
+	auto offset = heap.offset;
+	auto limit = heap.limit;
+	D_ASSERT(is_sorted);
+	while (chunk.size() == 0) {
+		state.scanner->Scan(chunk);
+		if (chunk.size() == 0) {
+			break;
+		}
+		idx_t start = state.pos;
+		idx_t end = state.pos + chunk.size();
+		state.pos = end;
+
+		idx_t chunk_start = 0;
+		idx_t chunk_end = chunk.size();
+		if (state.exclude_offset) {
+			// we need to exclude all tuples before the OFFSET
+			// check if we should include anything
+			if (end <= offset) {
+				// end is smaller than offset: include nothing!
+				chunk.Reset();
+				continue;
+			} else if (start < offset) {
+				// we need to slice
+				chunk_start = offset - start;
+			}
+		}
+		// check if we need to truncate at the offset + limit mark
+		if (start >= offset + limit) {
+			// we are finished
+			chunk_end = 0;
+		} else if (end > offset + limit) {
+			// the end extends past the offset + limit
+			// truncate the current chunk
+			chunk_end = offset + limit - start;
+		}
+		D_ASSERT(chunk_end - chunk_start <= STANDARD_VECTOR_SIZE);
+		if (chunk_end == chunk_start) {
+			chunk.Reset();
+			break;
+		} else if (chunk_start > 0) {
+			SelectionVector sel(STANDARD_VECTOR_SIZE);
+			for (idx_t i = chunk_start; i < chunk_end; i++) {
+				sel.set_index(i - chunk_start, i);
+			}
+			chunk.Slice(sel, chunk_end - chunk_start);
+		} else if (chunk_end != chunk.size()) {
+			chunk.SetCardinality(chunk_end);
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// TopNHeap
+//===--------------------------------------------------------------------===//
+TopNHeap::TopNHeap(ClientContext &context_p, const vector<LogicalType> &payload_types_p,
+                   const vector<BoundOrderByNode> &orders_p, idx_t limit, idx_t offset)
+    : context(context_p), payload_types(payload_types_p), orders(orders_p), limit(limit), offset(offset),
+      sort_state(*this), has_boundary_values(false), final_sel(STANDARD_VECTOR_SIZE), true_sel(STANDARD_VECTOR_SIZE),
+      false_sel(STANDARD_VECTOR_SIZE), new_remaining_sel(STANDARD_VECTOR_SIZE) {
+	// initialize the executor and the sort_chunk
+	vector<LogicalType> sort_types;
+	for (auto &order : orders) {
+		auto &expr = order.expression;
+		sort_types.push_back(expr->return_type);
+		executor.AddExpression(*expr);
+	}
+	payload_chunk.Initialize(payload_types);
+	sort_chunk.Initialize(sort_types);
+	compare_chunk.Initialize(sort_types);
+	boundary_values.Initialize(sort_types);
+	sort_state.Initialize();
+}
+
+void TopNHeap::Sink(DataChunk &input) {
+	sort_state.Sink(input);
+}
+
+void TopNHeap::Combine(TopNHeap &other) {
+	other.Finalize();
+
+	TopNScanState state;
+	other.InitializeScan(state, false);
+	while (true) {
+		payload_chunk.Reset();
+		other.Scan(state, payload_chunk);
+		if (payload_chunk.size() == 0) {
+			break;
+		}
+		Sink(payload_chunk);
+	}
+	Reduce();
+}
+
+void TopNHeap::Finalize() {
+	sort_state.Finalize();
+}
+
+void TopNHeap::Reduce() {
+	idx_t min_sort_threshold = MaxValue<idx_t>(STANDARD_VECTOR_SIZE * 5, 2 * (limit + offset));
+	if (sort_state.count < min_sort_threshold) {
+		// only reduce when we pass two times the limit + offset, or 5 vectors (whichever comes first)
+		return;
+	}
+	sort_state.Finalize();
+	TopNSortState new_state(*this);
+	new_state.Initialize();
+
+	TopNScanState state;
+	sort_state.InitializeScan(state, false);
+
+	DataChunk new_chunk;
+	new_chunk.Initialize(payload_types);
+
+	DataChunk *current_chunk = &new_chunk;
+	DataChunk *prev_chunk = &payload_chunk;
+	has_boundary_values = false;
+	while (true) {
+		current_chunk->Reset();
+		Scan(state, *current_chunk);
+		if (current_chunk->size() == 0) {
+			ExtractBoundaryValues(*current_chunk, *prev_chunk);
+			break;
+		}
+		new_state.Sink(*current_chunk);
+		std::swap(current_chunk, prev_chunk);
+	}
+
+	sort_state.Move(new_state);
+}
+
+void TopNHeap::ExtractBoundaryValues(DataChunk &current_chunk, DataChunk &prev_chunk) {
+	// extract the last entry of the prev_chunk and set as minimum value
+	D_ASSERT(prev_chunk.size() > 0);
+	for (idx_t col_idx = 0; col_idx < current_chunk.ColumnCount(); col_idx++) {
+		ConstantVector::Reference(current_chunk.data[col_idx], prev_chunk.data[col_idx], prev_chunk.size() - 1,
+		                          prev_chunk.size());
+	}
+	current_chunk.SetCardinality(1);
+	sort_chunk.Reset();
+	executor.Execute(&current_chunk, sort_chunk);
+
+	boundary_values.Reset();
+	boundary_values.Append(sort_chunk);
+	boundary_values.SetCardinality(1);
+	for (idx_t i = 0; i < boundary_values.ColumnCount(); i++) {
+		boundary_values.data[i].SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+	has_boundary_values = true;
+}
+
+bool TopNHeap::CheckBoundaryValues(DataChunk &sort_chunk, DataChunk &payload) {
+	// we have boundary values
+	// from these boundary values, determine which values we should insert (if any)
+	idx_t final_count = 0;
+
+	SelectionVector remaining_sel(nullptr);
+	idx_t remaining_count = sort_chunk.size();
+	for (idx_t i = 0; i < orders.size(); i++) {
+		if (remaining_sel.data()) {
+			compare_chunk.data[i].Slice(sort_chunk.data[i], remaining_sel, remaining_count);
+		} else {
+			compare_chunk.data[i].Reference(sort_chunk.data[i]);
+		}
+		bool is_last = i + 1 == orders.size();
+		idx_t true_count;
+		if (orders[i].null_order == OrderByNullType::NULLS_LAST) {
+			if (orders[i].type == OrderType::ASCENDING) {
+				true_count = VectorOperations::DistinctLessThan(compare_chunk.data[i], boundary_values.data[i],
+				                                                &remaining_sel, remaining_count, &true_sel, &false_sel);
+			} else {
+				true_count = VectorOperations::DistinctGreaterThanNullsFirst(compare_chunk.data[i],
+				                                                             boundary_values.data[i], &remaining_sel,
+				                                                             remaining_count, &true_sel, &false_sel);
+			}
+		} else {
+			D_ASSERT(orders[i].null_order == OrderByNullType::NULLS_FIRST);
+			if (orders[i].type == OrderType::ASCENDING) {
+				true_count = VectorOperations::DistinctLessThanNullsFirst(compare_chunk.data[i],
+				                                                          boundary_values.data[i], &remaining_sel,
+				                                                          remaining_count, &true_sel, &false_sel);
+			} else {
+				true_count =
+				    VectorOperations::DistinctGreaterThan(compare_chunk.data[i], boundary_values.data[i],
+				                                          &remaining_sel, remaining_count, &true_sel, &false_sel);
+			}
+		}
+
+		if (true_count > 0) {
+			memcpy(final_sel.data() + final_count, true_sel.data(), true_count * sizeof(sel_t));
+			final_count += true_count;
+		}
+		idx_t false_count = remaining_count - true_count;
+		if (false_count > 0) {
+			// check what we should continue to check
+			compare_chunk.data[i].Slice(sort_chunk.data[i], false_sel, false_count);
+			remaining_count = VectorOperations::NotDistinctFrom(compare_chunk.data[i], boundary_values.data[i],
+			                                                    &false_sel, false_count, &new_remaining_sel, nullptr);
+			if (is_last) {
+				memcpy(final_sel.data() + final_count, new_remaining_sel.data(), remaining_count * sizeof(sel_t));
+				final_count += remaining_count;
+			} else {
+				remaining_sel.Initialize(new_remaining_sel);
+			}
+		} else {
+			break;
+		}
+	}
+	if (final_count == 0) {
+		return false;
+	}
+	if (final_count < sort_chunk.size()) {
+		sort_chunk.Slice(final_sel, final_count);
+		payload.Slice(final_sel, final_count);
+	}
+	return true;
+}
+
+void TopNHeap::InitializeScan(TopNScanState &state, bool exclude_offset) {
+	sort_state.InitializeScan(state, exclude_offset);
+}
+
+void TopNHeap::Scan(TopNScanState &state, DataChunk &chunk) {
+	sort_state.Scan(state, chunk);
+}
+
+class TopNGlobalState : public GlobalSinkState {
+public:
+	TopNGlobalState(ClientContext &context, const vector<LogicalType> &payload_types,
+	                const vector<BoundOrderByNode> &orders, idx_t limit, idx_t offset)
+	    : heap(context, payload_types, orders, limit, offset) {
+	}
+
+	mutex lock;
+	TopNHeap heap;
+};
+
+class TopNLocalState : public LocalSinkState {
+public:
+	TopNLocalState(ClientContext &context, const vector<LogicalType> &payload_types,
+	               const vector<BoundOrderByNode> &orders, idx_t limit, idx_t offset)
+	    : heap(context, payload_types, orders, limit, offset) {
+	}
+
+	TopNHeap heap;
+};
+
+unique_ptr<LocalSinkState> PhysicalTopN::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<TopNLocalState>(context.client, types, orders, limit, offset);
+}
+
+unique_ptr<GlobalSinkState> PhysicalTopN::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<TopNGlobalState>(context, types, orders, limit, offset);
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+SinkResultType PhysicalTopN::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                  DataChunk &input) const {
+	// append to the local sink state
+	auto &sink = (TopNLocalState &)lstate;
+	sink.heap.Sink(input);
+	sink.heap.Reduce();
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Combine
+//===--------------------------------------------------------------------===//
+void PhysicalTopN::Combine(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p) const {
+	auto &gstate = (TopNGlobalState &)state;
+	auto &lstate = (TopNLocalState &)lstate_p;
+
+	// scan the local top N and append it to the global heap
+	lock_guard<mutex> glock(gstate.lock);
+	gstate.heap.Combine(lstate.heap);
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+SinkFinalizeType PhysicalTopN::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                        GlobalSinkState &gstate_p) const {
+	auto &gstate = (TopNGlobalState &)gstate_p;
+	// global finalize: compute the final top N
+	gstate.heap.Finalize();
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class TopNOperatorState : public GlobalSourceState {
+public:
+	TopNScanState state;
+	bool initialized = false;
+};
+
+unique_ptr<GlobalSourceState> PhysicalTopN::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<TopNOperatorState>();
+}
+
+void PhysicalTopN::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                           LocalSourceState &lstate) const {
+	if (limit == 0) {
+		return;
+	}
+	auto &state = (TopNOperatorState &)gstate_p;
+	auto &gstate = (TopNGlobalState &)*sink_state;
+
+	if (!state.initialized) {
+		gstate.heap.InitializeScan(state.state, true);
+		state.initialized = true;
+	}
+	gstate.heap.Scan(state.state, chunk);
+}
+
+string PhysicalTopN::ParamsToString() const {
+	string result;
+	result += "Top " + to_string(limit);
+	if (offset > 0) {
+		result += "\n";
+		result += "Offset " + to_string(offset);
+	}
+	result += "\n[INFOSEPARATOR]";
+	for (idx_t i = 0; i < orders.size(); i++) {
+		result += "\n";
+		result += orders[i].expression->ToString() + " ";
+		result += orders[i].type == OrderType::DESCENDING ? "DESC" : "ASC";
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <fstream>
+
+namespace duckdb {
+
+static bool ParseBoolean(const Value &value, const string &loption);
+
+static bool ParseBoolean(const vector<Value> &set, const string &loption) {
+	if (set.empty()) {
+		// no option specified: default to true
+		return true;
+	}
+	if (set.size() > 1) {
+		throw BinderException("\"%s\" expects a single argument as a boolean value (e.g. TRUE or 1)", loption);
+	}
+	return ParseBoolean(set[0], loption);
+}
+
+static bool ParseBoolean(const Value &value, const string &loption) {
+
+	if (value.type().id() == LogicalTypeId::LIST) {
+		auto &children = ListValue::GetChildren(value);
+		return ParseBoolean(children, loption);
+	}
+	if (value.type() == LogicalType::FLOAT || value.type() == LogicalType::DOUBLE ||
+	    value.type().id() == LogicalTypeId::DECIMAL) {
+		throw BinderException("\"%s\" expects a boolean value (e.g. TRUE or 1)", loption);
+	}
+	return BooleanValue::Get(value.CastAs(LogicalType::BOOLEAN));
+}
+
+static string ParseString(const Value &value, const string &loption) {
+	if (value.type().id() == LogicalTypeId::LIST) {
+		auto &children = ListValue::GetChildren(value);
+		if (children.size() != 1) {
+			throw BinderException("\"%s\" expects a single argument as a string value", loption);
+		}
+		return ParseString(children[0], loption);
+	}
+	if (value.type().id() != LogicalTypeId::VARCHAR) {
+		throw BinderException("\"%s\" expects a string argument!", loption);
+	}
+	return value.GetValue<string>();
+}
+
+static int64_t ParseInteger(const Value &value, const string &loption) {
+	if (value.type().id() == LogicalTypeId::LIST) {
+		auto &children = ListValue::GetChildren(value);
+		if (children.size() != 1) {
+			// no option specified or multiple options specified
+			throw BinderException("\"%s\" expects a single argument as an integer value", loption);
+		}
+		return ParseInteger(children[0], loption);
+	}
+	return value.GetValue<int64_t>();
+}
+
+static vector<bool> ParseColumnList(const vector<Value> &set, vector<string> &names, const string &loption) {
+	vector<bool> result;
+
+	if (set.empty()) {
+		throw BinderException("\"%s\" expects a column list or * as parameter", loption);
+	}
+	// list of options: parse the list
+	unordered_map<string, bool> option_map;
+	for (idx_t i = 0; i < set.size(); i++) {
+		option_map[set[i].ToString()] = false;
+	}
+	result.resize(names.size(), false);
+	for (idx_t i = 0; i < names.size(); i++) {
+		auto entry = option_map.find(names[i]);
+		if (entry != option_map.end()) {
+			result[i] = true;
+			entry->second = true;
+		}
+	}
+	for (auto &entry : option_map) {
+		if (!entry.second) {
+			throw BinderException("\"%s\" expected to find %s, but it was not found in the table", loption,
+			                      entry.first.c_str());
+		}
+	}
+	return result;
+}
+
+static vector<bool> ParseColumnList(const Value &value, vector<string> &names, const string &loption) {
+	vector<bool> result;
+
+	// Only accept a list of arguments
+	if (value.type().id() != LogicalTypeId::LIST) {
+		// Support a single argument if it's '*'
+		if (value.type().id() == LogicalTypeId::VARCHAR && value.GetValue<string>() == "*") {
+			result.resize(names.size(), true);
+			return result;
+		}
+		throw BinderException("\"%s\" expects a column list or * as parameter", loption);
+	}
+	auto &children = ListValue::GetChildren(value);
+	// accept '*' as single argument
+	if (children.size() == 1 && children[0].type().id() == LogicalTypeId::VARCHAR &&
+	    children[0].GetValue<string>() == "*") {
+		result.resize(names.size(), true);
+		return result;
+	}
+	return ParseColumnList(children, names, loption);
+}
+
+struct CSVFileHandle {
+public:
+	explicit CSVFileHandle(unique_ptr<FileHandle> file_handle_p) : file_handle(move(file_handle_p)) {
+		can_seek = file_handle->CanSeek();
+		plain_file_source = file_handle->OnDiskFile() && can_seek;
+		file_size = file_handle->GetFileSize();
+	}
+
+	bool CanSeek() {
+		return can_seek;
+	}
+	void Seek(idx_t position) {
+		if (!can_seek) {
+			throw InternalException("Cannot seek in this file");
+		}
+		file_handle->Seek(position);
+	}
+	idx_t SeekPosition() {
+		if (!can_seek) {
+			throw InternalException("Cannot seek in this file");
+		}
+		return file_handle->SeekPosition();
+	}
+	void Reset() {
+		if (plain_file_source) {
+			file_handle->Reset();
+		} else {
+			if (!reset_enabled) {
+				throw InternalException("Reset called but reset is not enabled for this CSV Handle");
+			}
+			read_position = 0;
+		}
+	}
+	bool PlainFileSource() {
+		return plain_file_source;
+	}
+
+	bool OnDiskFile() {
+		return file_handle->OnDiskFile();
+	}
+
+	idx_t FileSize() {
+		return file_size;
+	}
+
+	idx_t Read(void *buffer, idx_t nr_bytes) {
+		if (!plain_file_source) {
+			// not a plain file source: we need to do some bookkeeping around the reset functionality
+			idx_t result_offset = 0;
+			if (read_position < buffer_size) {
+				// we need to read from our cached buffer
+				auto buffer_read_count = MinValue<idx_t>(nr_bytes, buffer_size - read_position);
+				memcpy(buffer, cached_buffer.get() + read_position, buffer_read_count);
+				result_offset += buffer_read_count;
+				read_position += buffer_read_count;
+				if (result_offset == nr_bytes) {
+					return nr_bytes;
+				}
+			} else if (!reset_enabled && cached_buffer) {
+				// reset is disabled but we still have cached data
+				// we can remove any cached data
+				cached_buffer.reset();
+				buffer_size = 0;
+				buffer_capacity = 0;
+				read_position = 0;
+			}
+			// we have data left to read from the file
+			// read directly into the buffer
+			auto bytes_read = file_handle->Read((char *)buffer + result_offset, nr_bytes - result_offset);
+			read_position += bytes_read;
+			if (reset_enabled) {
+				// if reset caching is enabled, we need to cache the bytes that we have read
+				if (buffer_size + bytes_read >= buffer_capacity) {
+					// no space; first enlarge the buffer
+					buffer_capacity = MaxValue<idx_t>(NextPowerOfTwo(buffer_size + bytes_read), buffer_capacity * 2);
+
+					auto new_buffer = unique_ptr<data_t[]>(new data_t[buffer_capacity]);
+					if (buffer_size > 0) {
+						memcpy(new_buffer.get(), cached_buffer.get(), buffer_size);
+					}
+					cached_buffer = move(new_buffer);
+				}
+				memcpy(cached_buffer.get() + buffer_size, (char *)buffer + result_offset, bytes_read);
+				buffer_size += bytes_read;
+			}
+
+			return result_offset + bytes_read;
+		} else {
+			return file_handle->Read(buffer, nr_bytes);
+		}
+	}
+
+	string ReadLine() {
+		string result;
+		char buffer[1];
+		while (true) {
+			idx_t tuples_read = Read(buffer, 1);
+			if (tuples_read == 0 || buffer[0] == '\n') {
+				return result;
+			}
+			if (buffer[0] != '\r') {
+				result += buffer[0];
+			}
+		}
+	}
+
+	void DisableReset() {
+		this->reset_enabled = false;
+	}
+
+private:
+	unique_ptr<FileHandle> file_handle;
+	bool reset_enabled = true;
+	bool can_seek = false;
+	bool plain_file_source = false;
+	idx_t file_size = 0;
+	// reset support
+	unique_ptr<data_t[]> cached_buffer;
+	idx_t read_position = 0;
+	idx_t buffer_size = 0;
+	idx_t buffer_capacity = 0;
+};
+
+void BufferedCSVReaderOptions::SetDelimiter(const string &input) {
+	this->delimiter = StringUtil::Replace(input, "\\t", "\t");
+	this->has_delimiter = true;
+	if (input.empty()) {
+		this->delimiter = string("\0", 1);
+	}
+}
+
+void BufferedCSVReaderOptions::SetDateFormat(LogicalTypeId type, const string &format, bool read_format) {
+	string error;
+	if (read_format) {
+		auto &date_format = this->date_format[type];
+		error = StrTimeFormat::ParseFormatSpecifier(format, date_format);
+		date_format.format_specifier = format;
+	} else {
+		auto &date_format = this->write_date_format[type];
+		error = StrTimeFormat::ParseFormatSpecifier(format, date_format);
+	}
+	if (!error.empty()) {
+		throw InvalidInputException("Could not parse DATEFORMAT: %s", error.c_str());
+	}
+	has_format[type] = true;
+}
+
+void BufferedCSVReaderOptions::SetReadOption(const string &loption, const Value &value,
+                                             vector<string> &expected_names) {
+	if (SetBaseOption(loption, value)) {
+		return;
+	}
+	if (loption == "auto_detect") {
+		auto_detect = ParseBoolean(value, loption);
+	} else if (loption == "sample_size") {
+		int64_t sample_size = ParseInteger(value, loption);
+		if (sample_size < 1 && sample_size != -1) {
+			throw BinderException("Unsupported parameter for SAMPLE_SIZE: cannot be smaller than 1");
+		}
+		if (sample_size == -1) {
+			sample_chunks = std::numeric_limits<uint64_t>::max();
+			sample_chunk_size = STANDARD_VECTOR_SIZE;
+		} else if (sample_size <= STANDARD_VECTOR_SIZE) {
+			sample_chunk_size = sample_size;
+			sample_chunks = 1;
+		} else {
+			sample_chunk_size = STANDARD_VECTOR_SIZE;
+			sample_chunks = sample_size / STANDARD_VECTOR_SIZE;
+		}
+	} else if (loption == "skip") {
+		skip_rows = ParseInteger(value, loption);
+	} else if (loption == "max_line_size" || loption == "maximum_line_size") {
+		maximum_line_size = ParseInteger(value, loption);
+	} else if (loption == "sample_chunk_size") {
+		sample_chunk_size = ParseInteger(value, loption);
+		if (sample_chunk_size > STANDARD_VECTOR_SIZE) {
+			throw BinderException(
+			    "Unsupported parameter for SAMPLE_CHUNK_SIZE: cannot be bigger than STANDARD_VECTOR_SIZE %d",
+			    STANDARD_VECTOR_SIZE);
+		} else if (sample_chunk_size < 1) {
+			throw BinderException("Unsupported parameter for SAMPLE_CHUNK_SIZE: cannot be smaller than 1");
+		}
+	} else if (loption == "sample_chunks") {
+		sample_chunks = ParseInteger(value, loption);
+		if (sample_chunks < 1) {
+			throw BinderException("Unsupported parameter for SAMPLE_CHUNKS: cannot be smaller than 1");
+		}
+	} else if (loption == "force_not_null") {
+		force_not_null = ParseColumnList(value, expected_names, loption);
+	} else if (loption == "date_format" || loption == "dateformat") {
+		string format = ParseString(value, loption);
+		SetDateFormat(LogicalTypeId::DATE, format, true);
+	} else if (loption == "timestamp_format" || loption == "timestampformat") {
+		string format = ParseString(value, loption);
+		SetDateFormat(LogicalTypeId::TIMESTAMP, format, true);
+	} else if (loption == "escape") {
+		escape = ParseString(value, loption);
+		has_escape = true;
+	} else if (loption == "ignore_errors") {
+		ignore_errors = ParseBoolean(value, loption);
+	} else {
+		throw BinderException("Unrecognized option for CSV reader \"%s\"", loption);
+	}
+}
+
+void BufferedCSVReaderOptions::SetWriteOption(const string &loption, const Value &value) {
+	if (SetBaseOption(loption, value)) {
+		return;
+	}
+
+	if (loption == "force_quote") {
+		force_quote = ParseColumnList(value, names, loption);
+	} else if (loption == "date_format" || loption == "dateformat") {
+		string format = ParseString(value, loption);
+		SetDateFormat(LogicalTypeId::DATE, format, false);
+	} else if (loption == "timestamp_format" || loption == "timestampformat") {
+		string format = ParseString(value, loption);
+		if (StringUtil::Lower(format) == "iso") {
+			format = "%Y-%m-%dT%H:%M:%S.%fZ";
+		}
+		SetDateFormat(LogicalTypeId::TIMESTAMP, format, false);
+	} else {
+		throw BinderException("Unrecognized option CSV writer \"%s\"", loption);
+	}
+}
+
+bool BufferedCSVReaderOptions::SetBaseOption(const string &loption, const Value &value) {
+	// Make sure this function was only called after the option was turned into lowercase
+	D_ASSERT(!std::any_of(loption.begin(), loption.end(), ::isupper));
+
+	if (StringUtil::StartsWith(loption, "delim") || StringUtil::StartsWith(loption, "sep")) {
+		SetDelimiter(ParseString(value, loption));
+	} else if (loption == "quote") {
+		quote = ParseString(value, loption);
+		has_quote = true;
+	} else if (loption == "escape") {
+		escape = ParseString(value, loption);
+		has_escape = true;
+	} else if (loption == "header") {
+		header = ParseBoolean(value, loption);
+		has_header = true;
+	} else if (loption == "null" || loption == "nullstr") {
+		null_str = ParseString(value, loption);
+	} else if (loption == "encoding") {
+		auto encoding = StringUtil::Lower(ParseString(value, loption));
+		if (encoding != "utf8" && encoding != "utf-8") {
+			throw BinderException("Copy is only supported for UTF-8 encoded files, ENCODING 'UTF-8'");
+		}
+	} else if (loption == "compression") {
+		compression = FileCompressionTypeFromString(ParseString(value, loption));
+	} else {
+		// unrecognized option in base CSV
+		return false;
+	}
+	return true;
+}
+
+std::string BufferedCSVReaderOptions::ToString() const {
+	return "DELIMITER='" + delimiter + (has_delimiter ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
+	       ", QUOTE='" + quote + (has_quote ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
+	       ", ESCAPE='" + escape + (has_escape ? "'" : (auto_detect ? "' (auto detected)" : "' (default)")) +
+	       ", HEADER=" + std::to_string(header) +
+	       (has_header ? "" : (auto_detect ? " (auto detected)" : "' (default)")) +
+	       ", SAMPLE_SIZE=" + std::to_string(sample_chunk_size * sample_chunks) +
+	       ", IGNORE_ERRORS=" + std::to_string(ignore_errors) + ", ALL_VARCHAR=" + std::to_string(all_varchar);
+}
+
+static string GetLineNumberStr(idx_t linenr, bool linenr_estimated) {
+	string estimated = (linenr_estimated ? string(" (estimated)") : string(""));
+	return to_string(linenr + 1) + estimated;
+}
+
+static bool StartsWithNumericDate(string &separator, const string &value) {
+	auto begin = value.c_str();
+	auto end = begin + value.size();
+
+	//	StrpTimeFormat::Parse will skip whitespace, so we can too
+	auto field1 = std::find_if_not(begin, end, StringUtil::CharacterIsSpace);
+	if (field1 == end) {
+		return false;
+	}
+
+	//	first numeric field must start immediately
+	if (!StringUtil::CharacterIsDigit(*field1)) {
+		return false;
+	}
+	auto literal1 = std::find_if_not(field1, end, StringUtil::CharacterIsDigit);
+	if (literal1 == end) {
+		return false;
+	}
+
+	//	second numeric field must exist
+	auto field2 = std::find_if(literal1, end, StringUtil::CharacterIsDigit);
+	if (field2 == end) {
+		return false;
+	}
+	auto literal2 = std::find_if_not(field2, end, StringUtil::CharacterIsDigit);
+	if (literal2 == end) {
+		return false;
+	}
+
+	//	third numeric field must exist
+	auto field3 = std::find_if(literal2, end, StringUtil::CharacterIsDigit);
+	if (field3 == end) {
+		return false;
+	}
+
+	//	second literal must match first
+	if (((field3 - literal2) != (field2 - literal1)) || strncmp(literal1, literal2, (field2 - literal1)) != 0) {
+		return false;
+	}
+
+	//	copy the literal as the separator, escaping percent signs
+	separator.clear();
+	while (literal1 < field2) {
+		const auto literal_char = *literal1++;
+		if (literal_char == '%') {
+			separator.push_back(literal_char);
+		}
+		separator.push_back(literal_char);
+	}
+
+	return true;
+}
+
+string GenerateDateFormat(const string &separator, const char *format_template) {
+	string format_specifier = format_template;
+
+	//	replace all dashes with the separator
+	for (auto pos = std::find(format_specifier.begin(), format_specifier.end(), '-'); pos != format_specifier.end();
+	     pos = std::find(pos + separator.size(), format_specifier.end(), '-')) {
+		format_specifier.replace(pos, pos + 1, separator);
+	}
+
+	return format_specifier;
+}
+
+TextSearchShiftArray::TextSearchShiftArray() {
+}
+
+TextSearchShiftArray::TextSearchShiftArray(string search_term) : length(search_term.size()) {
+	if (length > 255) {
+		throw Exception("Size of delimiter/quote/escape in CSV reader is limited to 255 bytes");
+	}
+	// initialize the shifts array
+	shifts = unique_ptr<uint8_t[]>(new uint8_t[length * 255]);
+	memset(shifts.get(), 0, length * 255 * sizeof(uint8_t));
+	// iterate over each of the characters in the array
+	for (idx_t main_idx = 0; main_idx < length; main_idx++) {
+		uint8_t current_char = (uint8_t)search_term[main_idx];
+		// now move over all the remaining positions
+		for (idx_t i = main_idx; i < length; i++) {
+			bool is_match = true;
+			// check if the prefix matches at this position
+			// if it does, we move to this position after encountering the current character
+			for (idx_t j = 0; j < main_idx; j++) {
+				if (search_term[i - main_idx + j] != search_term[j]) {
+					is_match = false;
+				}
+			}
+			if (!is_match) {
+				continue;
+			}
+			shifts[i * 255 + current_char] = main_idx + 1;
+		}
+	}
+}
+
+BufferedCSVReader::BufferedCSVReader(FileSystem &fs_p, FileOpener *opener_p, BufferedCSVReaderOptions options_p,
+                                     const vector<LogicalType> &requested_types)
+    : fs(fs_p), opener(opener_p), options(move(options_p)), buffer_size(0), position(0), start(0) {
+	file_handle = OpenCSV(options);
+	Initialize(requested_types);
+}
+
+BufferedCSVReader::BufferedCSVReader(ClientContext &context, BufferedCSVReaderOptions options_p,
+                                     const vector<LogicalType> &requested_types)
+    : BufferedCSVReader(FileSystem::GetFileSystem(context), FileSystem::GetFileOpener(context), move(options_p),
+                        requested_types) {
+}
+
+BufferedCSVReader::~BufferedCSVReader() {
+}
+
+idx_t BufferedCSVReader::GetFileSize() {
+	return file_handle ? file_handle->FileSize() : 0;
+}
+
+void BufferedCSVReader::Initialize(const vector<LogicalType> &requested_types) {
+	PrepareComplexParser();
+	if (options.auto_detect) {
+		sql_types = SniffCSV(requested_types);
+		if (sql_types.empty()) {
+			throw Exception("Failed to detect column types from CSV: is the file a valid CSV file?");
+		}
+		if (cached_chunks.empty()) {
+			JumpToBeginning(options.skip_rows, options.header);
+		}
+	} else {
+		sql_types = requested_types;
+		ResetBuffer();
+		SkipRowsAndReadHeader(options.skip_rows, options.header);
+	}
+	InitParseChunk(sql_types.size());
+	// we only need reset support during the automatic CSV type detection
+	// since reset support might require caching (in the case of streams), we disable it for the remainder
+	file_handle->DisableReset();
+}
+
+void BufferedCSVReader::PrepareComplexParser() {
+	delimiter_search = TextSearchShiftArray(options.delimiter);
+	escape_search = TextSearchShiftArray(options.escape);
+	quote_search = TextSearchShiftArray(options.quote);
+}
+
+unique_ptr<CSVFileHandle> BufferedCSVReader::OpenCSV(const BufferedCSVReaderOptions &options) {
+	auto file_handle = fs.OpenFile(options.file_path.c_str(), FileFlags::FILE_FLAGS_READ, FileLockType::NO_LOCK,
+	                               options.compression, this->opener);
+	return make_unique<CSVFileHandle>(move(file_handle));
+}
+
+// Helper function to generate column names
+static string GenerateColumnName(const idx_t total_cols, const idx_t col_number, const string &prefix = "column") {
+	int max_digits = NumericHelper::UnsignedLength(total_cols - 1);
+	int digits = NumericHelper::UnsignedLength(col_number);
+	string leading_zeros = string(max_digits - digits, '0');
+	string value = to_string(col_number);
+	return string(prefix + leading_zeros + value);
+}
+
+// Helper function for UTF-8 aware space trimming
+static string TrimWhitespace(const string &col_name) {
+	utf8proc_int32_t codepoint;
+	auto str = reinterpret_cast<const utf8proc_uint8_t *>(col_name.c_str());
+	idx_t size = col_name.size();
+	// Find the first character that is not left trimmed
+	idx_t begin = 0;
+	while (begin < size) {
+		auto bytes = utf8proc_iterate(str + begin, size - begin, &codepoint);
+		D_ASSERT(bytes > 0);
+		if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
+			break;
+		}
+		begin += bytes;
+	}
+
+	// Find the last character that is not right trimmed
+	idx_t end;
+	end = begin;
+	for (auto next = begin; next < col_name.size();) {
+		auto bytes = utf8proc_iterate(str + next, size - next, &codepoint);
+		D_ASSERT(bytes > 0);
+		next += bytes;
+		if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
+			end = next;
+		}
+	}
+
+	// return the trimmed string
+	return col_name.substr(begin, end - begin);
+}
+
+static string NormalizeColumnName(const string &col_name) {
+	// normalize UTF8 characters to NFKD
+	auto nfkd = utf8proc_NFKD((const utf8proc_uint8_t *)col_name.c_str(), col_name.size());
+	const string col_name_nfkd = string((const char *)nfkd, strlen((const char *)nfkd));
+	free(nfkd);
+
+	// only keep ASCII characters 0-9 a-z A-Z and replace spaces with regular whitespace
+	string col_name_ascii = "";
+	for (idx_t i = 0; i < col_name_nfkd.size(); i++) {
+		if (col_name_nfkd[i] == '_' || (col_name_nfkd[i] >= '0' && col_name_nfkd[i] <= '9') ||
+		    (col_name_nfkd[i] >= 'A' && col_name_nfkd[i] <= 'Z') ||
+		    (col_name_nfkd[i] >= 'a' && col_name_nfkd[i] <= 'z')) {
+			col_name_ascii += col_name_nfkd[i];
+		} else if (StringUtil::CharacterIsSpace(col_name_nfkd[i])) {
+			col_name_ascii += " ";
+		}
+	}
+
+	// trim whitespace and replace remaining whitespace by _
+	string col_name_trimmed = TrimWhitespace(col_name_ascii);
+	string col_name_cleaned = "";
+	bool in_whitespace = false;
+	for (idx_t i = 0; i < col_name_trimmed.size(); i++) {
+		if (col_name_trimmed[i] == ' ') {
+			if (!in_whitespace) {
+				col_name_cleaned += "_";
+				in_whitespace = true;
+			}
+		} else {
+			col_name_cleaned += col_name_trimmed[i];
+			in_whitespace = false;
+		}
+	}
+
+	// don't leave string empty; if not empty, make lowercase
+	if (col_name_cleaned.empty()) {
+		col_name_cleaned = "_";
+	} else {
+		col_name_cleaned = StringUtil::Lower(col_name_cleaned);
+	}
+
+	// prepend _ if name starts with a digit or is a reserved keyword
+	if (KeywordHelper::IsKeyword(col_name_cleaned) || (col_name_cleaned[0] >= '0' && col_name_cleaned[0] <= '9')) {
+		col_name_cleaned = "_" + col_name_cleaned;
+	}
+	return col_name_cleaned;
+}
+
+void BufferedCSVReader::ResetBuffer() {
+	buffer.reset();
+	buffer_size = 0;
+	position = 0;
+	start = 0;
+	cached_buffers.clear();
+}
+
+void BufferedCSVReader::ResetStream() {
+	if (!file_handle->CanSeek()) {
+		// seeking to the beginning appears to not be supported in all compiler/os-scenarios,
+		// so we have to create a new stream source here for now
+		file_handle->Reset();
+	} else {
+		file_handle->Seek(0);
+	}
+	linenr = 0;
+	linenr_estimated = false;
+	bytes_per_line_avg = 0;
+	sample_chunk_idx = 0;
+	jumping_samples = false;
+}
+
+void BufferedCSVReader::InitParseChunk(idx_t num_cols) {
+	// adapt not null info
+	if (options.force_not_null.size() != num_cols) {
+		options.force_not_null.resize(num_cols, false);
+	}
+	if (num_cols == parse_chunk.ColumnCount()) {
+		parse_chunk.Reset();
+	} else {
+		parse_chunk.Destroy();
+
+		// initialize the parse_chunk with a set of VARCHAR types
+		vector<LogicalType> varchar_types(num_cols, LogicalType::VARCHAR);
+		parse_chunk.Initialize(varchar_types);
+	}
+}
+
+void BufferedCSVReader::JumpToBeginning(idx_t skip_rows = 0, bool skip_header = false) {
+	ResetBuffer();
+	ResetStream();
+	sample_chunk_idx = 0;
+	bytes_in_chunk = 0;
+	end_of_file_reached = false;
+	bom_checked = false;
+	SkipRowsAndReadHeader(skip_rows, skip_header);
+}
+
+void BufferedCSVReader::SkipRowsAndReadHeader(idx_t skip_rows, bool skip_header) {
+	for (idx_t i = 0; i < skip_rows; i++) {
+		// ignore skip rows
+		string read_line = file_handle->ReadLine();
+		linenr++;
+	}
+
+	if (skip_header) {
+		// ignore the first line as a header line
+		InitParseChunk(sql_types.size());
+		ParseCSV(ParserMode::PARSING_HEADER);
+	}
+}
+
+bool BufferedCSVReader::JumpToNextSample() {
+	// get bytes contained in the previously read chunk
+	idx_t remaining_bytes_in_buffer = buffer_size - start;
+	bytes_in_chunk -= remaining_bytes_in_buffer;
+	if (remaining_bytes_in_buffer == 0) {
+		return false;
+	}
+
+	// assess if it makes sense to jump, based on size of the first chunk relative to size of the entire file
+	if (sample_chunk_idx == 0) {
+		idx_t bytes_first_chunk = bytes_in_chunk;
+		double chunks_fit = (file_handle->FileSize() / (double)bytes_first_chunk);
+		jumping_samples = chunks_fit >= options.sample_chunks;
+
+		// jump back to the beginning
+		JumpToBeginning(options.skip_rows, options.header);
+		sample_chunk_idx++;
+		return true;
+	}
+
+	if (end_of_file_reached || sample_chunk_idx >= options.sample_chunks) {
+		return false;
+	}
+
+	// if we deal with any other sources than plaintext files, jumping_samples can be tricky. In that case
+	// we just read x continuous chunks from the stream TODO: make jumps possible for zipfiles.
+	if (!file_handle->PlainFileSource() || !jumping_samples) {
+		sample_chunk_idx++;
+		return true;
+	}
+
+	// update average bytes per line
+	double bytes_per_line = bytes_in_chunk / (double)options.sample_chunk_size;
+	bytes_per_line_avg = ((bytes_per_line_avg * (sample_chunk_idx)) + bytes_per_line) / (sample_chunk_idx + 1);
+
+	// if none of the previous conditions were met, we can jump
+	idx_t partition_size = (idx_t)round(file_handle->FileSize() / (double)options.sample_chunks);
+
+	// calculate offset to end of the current partition
+	int64_t offset = partition_size - bytes_in_chunk - remaining_bytes_in_buffer;
+	auto current_pos = file_handle->SeekPosition();
+
+	if (current_pos + offset < file_handle->FileSize()) {
+		// set position in stream and clear failure bits
+		file_handle->Seek(current_pos + offset);
+
+		// estimate linenr
+		linenr += (idx_t)round((offset + remaining_bytes_in_buffer) / bytes_per_line_avg);
+		linenr_estimated = true;
+	} else {
+		// seek backwards from the end in last chunk and hope to catch the end of the file
+		// TODO: actually it would be good to make sure that the end of file is being reached, because
+		// messy end-lines are quite common. For this case, however, we first need a skip_end detection anyways.
+		file_handle->Seek(file_handle->FileSize() - bytes_in_chunk);
+
+		// estimate linenr
+		linenr = (idx_t)round((file_handle->FileSize() - bytes_in_chunk) / bytes_per_line_avg);
+		linenr_estimated = true;
+	}
+
+	// reset buffers and parse chunk
+	ResetBuffer();
+
+	// seek beginning of next line
+	// FIXME: if this jump ends up in a quoted linebreak, we will have a problem
+	string read_line = file_handle->ReadLine();
+	linenr++;
+
+	sample_chunk_idx++;
+
+	return true;
+}
+
+void BufferedCSVReader::SetDateFormat(const string &format_specifier, const LogicalTypeId &sql_type) {
+	options.has_format[sql_type] = true;
+	auto &date_format = options.date_format[sql_type];
+	date_format.format_specifier = format_specifier;
+	StrTimeFormat::ParseFormatSpecifier(date_format.format_specifier, date_format);
+}
+
+bool BufferedCSVReader::TryCastValue(const Value &value, const LogicalType &sql_type) {
+	if (options.has_format[LogicalTypeId::DATE] && sql_type.id() == LogicalTypeId::DATE) {
+		date_t result;
+		string error_message;
+		return options.date_format[LogicalTypeId::DATE].TryParseDate(string_t(StringValue::Get(value)), result,
+		                                                             error_message);
+	} else if (options.has_format[LogicalTypeId::TIMESTAMP] && sql_type.id() == LogicalTypeId::TIMESTAMP) {
+		timestamp_t result;
+		string error_message;
+		return options.date_format[LogicalTypeId::TIMESTAMP].TryParseTimestamp(string_t(StringValue::Get(value)),
+		                                                                       result, error_message);
+	} else {
+		Value new_value;
+		string error_message;
+		return value.TryCastAs(sql_type, new_value, &error_message, true);
+	}
+}
+
+struct TryCastDateOperator {
+	static bool Operation(BufferedCSVReaderOptions &options, string_t input, date_t &result, string &error_message) {
+		return options.date_format[LogicalTypeId::DATE].TryParseDate(input, result, error_message);
+	}
+};
+
+struct TryCastTimestampOperator {
+	static bool Operation(BufferedCSVReaderOptions &options, string_t input, timestamp_t &result,
+	                      string &error_message) {
+		return options.date_format[LogicalTypeId::TIMESTAMP].TryParseTimestamp(input, result, error_message);
+	}
+};
+
+template <class OP, class T>
+static bool TemplatedTryCastDateVector(BufferedCSVReaderOptions &options, Vector &input_vector, Vector &result_vector,
+                                       idx_t count, string &error_message) {
+	D_ASSERT(input_vector.GetType().id() == LogicalTypeId::VARCHAR);
+	bool all_converted = true;
+	UnaryExecutor::Execute<string_t, T>(input_vector, result_vector, count, [&](string_t input) {
+		T result;
+		if (!OP::Operation(options, input, result, error_message)) {
+			all_converted = false;
+		}
+		return result;
+	});
+	return all_converted;
+}
+
+bool TryCastDateVector(BufferedCSVReaderOptions &options, Vector &input_vector, Vector &result_vector, idx_t count,
+                       string &error_message) {
+	return TemplatedTryCastDateVector<TryCastDateOperator, date_t>(options, input_vector, result_vector, count,
+	                                                               error_message);
+}
+
+bool TryCastTimestampVector(BufferedCSVReaderOptions &options, Vector &input_vector, Vector &result_vector, idx_t count,
+                            string &error_message) {
+	return TemplatedTryCastDateVector<TryCastTimestampOperator, timestamp_t>(options, input_vector, result_vector,
+	                                                                         count, error_message);
+}
+
+bool BufferedCSVReader::TryCastVector(Vector &parse_chunk_col, idx_t size, const LogicalType &sql_type) {
+	// try vector-cast from string to sql_type
+	Vector dummy_result(sql_type);
+	if (options.has_format[LogicalTypeId::DATE] && sql_type == LogicalTypeId::DATE) {
+		// use the date format to cast the chunk
+		string error_message;
+		return TryCastDateVector(options, parse_chunk_col, dummy_result, size, error_message);
+	} else if (options.has_format[LogicalTypeId::TIMESTAMP] && sql_type == LogicalTypeId::TIMESTAMP) {
+		// use the timestamp format to cast the chunk
+		string error_message;
+		return TryCastTimestampVector(options, parse_chunk_col, dummy_result, size, error_message);
+	} else {
+		// target type is not varchar: perform a cast
+		string error_message;
+		return VectorOperations::TryCast(parse_chunk_col, dummy_result, size, &error_message, true);
+	}
+}
+
+enum class QuoteRule : uint8_t { QUOTES_RFC = 0, QUOTES_OTHER = 1, NO_QUOTES = 2 };
+
+void BufferedCSVReader::DetectDialect(const vector<LogicalType> &requested_types,
+                                      BufferedCSVReaderOptions &original_options,
+                                      vector<BufferedCSVReaderOptions> &info_candidates, idx_t &best_num_cols) {
+	// set up the candidates we consider for delimiter and quote rules based on user input
+	vector<string> delim_candidates;
+	vector<QuoteRule> quoterule_candidates;
+	vector<vector<string>> quote_candidates_map;
+	vector<vector<string>> escape_candidates_map = {{""}, {"\\"}, {""}};
+
+	if (options.has_delimiter) {
+		// user provided a delimiter: use that delimiter
+		delim_candidates = {options.delimiter};
+	} else {
+		// no delimiter provided: try standard/common delimiters
+		delim_candidates = {",", "|", ";", "\t"};
+	}
+	if (options.has_quote) {
+		// user provided quote: use that quote rule
+		quote_candidates_map = {{options.quote}, {options.quote}, {options.quote}};
+	} else {
+		// no quote rule provided: use standard/common quotes
+		quote_candidates_map = {{"\""}, {"\"", "'"}, {""}};
+	}
+	if (options.has_escape) {
+		// user provided escape: use that escape rule
+		if (options.escape.empty()) {
+			quoterule_candidates = {QuoteRule::QUOTES_RFC};
+		} else {
+			quoterule_candidates = {QuoteRule::QUOTES_OTHER};
+		}
+		escape_candidates_map[static_cast<uint8_t>(quoterule_candidates[0])] = {options.escape};
+	} else {
+		// no escape provided: try standard/common escapes
+		quoterule_candidates = {QuoteRule::QUOTES_RFC, QuoteRule::QUOTES_OTHER, QuoteRule::NO_QUOTES};
+	}
+
+	idx_t best_consistent_rows = 0;
+	for (auto quoterule : quoterule_candidates) {
+		const auto &quote_candidates = quote_candidates_map[static_cast<uint8_t>(quoterule)];
+		for (const auto &quote : quote_candidates) {
+			for (const auto &delim : delim_candidates) {
+				const auto &escape_candidates = escape_candidates_map[static_cast<uint8_t>(quoterule)];
+				for (const auto &escape : escape_candidates) {
+					BufferedCSVReaderOptions sniff_info = original_options;
+					sniff_info.delimiter = delim;
+					sniff_info.quote = quote;
+					sniff_info.escape = escape;
+
+					options = sniff_info;
+					PrepareComplexParser();
+
+					JumpToBeginning(original_options.skip_rows);
+					sniffed_column_counts.clear();
+
+					if (!TryParseCSV(ParserMode::SNIFFING_DIALECT)) {
+						continue;
+					}
+
+					idx_t start_row = original_options.skip_rows;
+					idx_t consistent_rows = 0;
+					idx_t num_cols = 0;
+
+					for (idx_t row = 0; row < sniffed_column_counts.size(); row++) {
+						if (sniffed_column_counts[row] == num_cols) {
+							consistent_rows++;
+						} else {
+							num_cols = sniffed_column_counts[row];
+							start_row = row + original_options.skip_rows;
+							consistent_rows = 1;
+						}
+					}
+
+					// some logic
+					bool more_values = (consistent_rows > best_consistent_rows && num_cols >= best_num_cols);
+					bool single_column_before = best_num_cols < 2 && num_cols > best_num_cols;
+					bool rows_consistent =
+					    start_row + consistent_rows - original_options.skip_rows == sniffed_column_counts.size();
+					bool more_than_one_row = (consistent_rows > 1);
+					bool more_than_one_column = (num_cols > 1);
+					bool start_good = !info_candidates.empty() && (start_row <= info_candidates.front().skip_rows);
+
+					if (!requested_types.empty() && requested_types.size() != num_cols) {
+						continue;
+					} else if ((more_values || single_column_before) && rows_consistent) {
+						sniff_info.skip_rows = start_row;
+						sniff_info.num_cols = num_cols;
+						best_consistent_rows = consistent_rows;
+						best_num_cols = num_cols;
+
+						info_candidates.clear();
+						info_candidates.push_back(sniff_info);
+					} else if (more_than_one_row && more_than_one_column && start_good && rows_consistent) {
+						bool same_quote_is_candidate = false;
+						for (auto &info_candidate : info_candidates) {
+							if (quote.compare(info_candidate.quote) == 0) {
+								same_quote_is_candidate = true;
+							}
+						}
+						if (!same_quote_is_candidate) {
+							sniff_info.skip_rows = start_row;
+							sniff_info.num_cols = num_cols;
+							info_candidates.push_back(sniff_info);
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+void BufferedCSVReader::DetectCandidateTypes(const vector<LogicalType> &type_candidates,
+                                             const map<LogicalTypeId, vector<const char *>> &format_template_candidates,
+                                             const vector<BufferedCSVReaderOptions> &info_candidates,
+                                             BufferedCSVReaderOptions &original_options, idx_t best_num_cols,
+                                             vector<vector<LogicalType>> &best_sql_types_candidates,
+                                             std::map<LogicalTypeId, vector<string>> &best_format_candidates,
+                                             DataChunk &best_header_row) {
+	BufferedCSVReaderOptions best_options;
+	idx_t min_varchar_cols = best_num_cols + 1;
+
+	// check which info candidate leads to minimum amount of non-varchar columns...
+	for (const auto &t : format_template_candidates) {
+		best_format_candidates[t.first].clear();
+	}
+	for (auto &info_candidate : info_candidates) {
+		options = info_candidate;
+		vector<vector<LogicalType>> info_sql_types_candidates(options.num_cols, type_candidates);
+		std::map<LogicalTypeId, bool> has_format_candidates;
+		std::map<LogicalTypeId, vector<string>> format_candidates;
+		for (const auto &t : format_template_candidates) {
+			has_format_candidates[t.first] = false;
+			format_candidates[t.first].clear();
+		}
+
+		// set all sql_types to VARCHAR so we can do datatype detection based on VARCHAR values
+		sql_types.clear();
+		sql_types.assign(options.num_cols, LogicalType::VARCHAR);
+
+		// jump to beginning and skip potential header
+		JumpToBeginning(options.skip_rows, true);
+		DataChunk header_row;
+		header_row.Initialize(sql_types);
+		parse_chunk.Copy(header_row);
+
+		if (header_row.size() == 0) {
+			continue;
+		}
+
+		// init parse chunk and read csv with info candidate
+		InitParseChunk(sql_types.size());
+		ParseCSV(ParserMode::SNIFFING_DATATYPES);
+		for (idx_t row_idx = 0; row_idx <= parse_chunk.size(); row_idx++) {
+			bool is_header_row = row_idx == 0;
+			idx_t row = row_idx - 1;
+			for (idx_t col = 0; col < parse_chunk.ColumnCount(); col++) {
+				auto &col_type_candidates = info_sql_types_candidates[col];
+				while (col_type_candidates.size() > 1) {
+					const auto &sql_type = col_type_candidates.back();
+					// try cast from string to sql_type
+					Value dummy_val;
+					if (is_header_row) {
+						dummy_val = header_row.GetValue(col, 0);
+					} else {
+						dummy_val = parse_chunk.GetValue(col, row);
+					}
+					// try formatting for date types if the user did not specify one and it starts with numeric values.
+					string separator;
+					if (has_format_candidates.count(sql_type.id()) && !original_options.has_format[sql_type.id()] &&
+					    StartsWithNumericDate(separator, StringValue::Get(dummy_val))) {
+						// generate date format candidates the first time through
+						auto &type_format_candidates = format_candidates[sql_type.id()];
+						const auto had_format_candidates = has_format_candidates[sql_type.id()];
+						if (!has_format_candidates[sql_type.id()]) {
+							has_format_candidates[sql_type.id()] = true;
+							// order by preference
+							auto entry = format_template_candidates.find(sql_type.id());
+							if (entry != format_template_candidates.end()) {
+								const auto &format_template_list = entry->second;
+								for (const auto &t : format_template_list) {
+									const auto format_string = GenerateDateFormat(separator, t);
+									// don't parse ISO 8601
+									if (format_string.find("%Y-%m-%d") == string::npos) {
+										type_format_candidates.emplace_back(format_string);
+									}
+								}
+							}
+							//	initialise the first candidate
+							options.has_format[sql_type.id()] = true;
+							//	all formats are constructed to be valid
+							SetDateFormat(type_format_candidates.back(), sql_type.id());
+						}
+						// check all formats and keep the first one that works
+						StrpTimeFormat::ParseResult result;
+						auto save_format_candidates = type_format_candidates;
+						while (!type_format_candidates.empty()) {
+							//	avoid using exceptions for flow control...
+							auto &current_format = options.date_format[sql_type.id()];
+							if (current_format.Parse(StringValue::Get(dummy_val), result)) {
+								break;
+							}
+							//	doesn't work - move to the next one
+							type_format_candidates.pop_back();
+							options.has_format[sql_type.id()] = (!type_format_candidates.empty());
+							if (!type_format_candidates.empty()) {
+								SetDateFormat(type_format_candidates.back(), sql_type.id());
+							}
+						}
+						//	if none match, then this is not a value of type sql_type,
+						if (type_format_candidates.empty()) {
+							//	so restore the candidates that did work.
+							//	or throw them out if they were generated by this value.
+							if (had_format_candidates) {
+								type_format_candidates.swap(save_format_candidates);
+								if (!type_format_candidates.empty()) {
+									SetDateFormat(type_format_candidates.back(), sql_type.id());
+								}
+							} else {
+								has_format_candidates[sql_type.id()] = false;
+							}
+						}
+					}
+					// try cast from string to sql_type
+					if (TryCastValue(dummy_val, sql_type)) {
+						break;
+					} else {
+						col_type_candidates.pop_back();
+					}
+				}
+			}
+			// reset type detection, because first row could be header,
+			// but only do it if csv has more than one line (including header)
+			if (parse_chunk.size() > 0 && is_header_row) {
+				info_sql_types_candidates = vector<vector<LogicalType>>(options.num_cols, type_candidates);
+				for (auto &f : format_candidates) {
+					f.second.clear();
+				}
+				for (auto &h : has_format_candidates) {
+					h.second = false;
+				}
+			}
+		}
+
+		idx_t varchar_cols = 0;
+		for (idx_t col = 0; col < parse_chunk.ColumnCount(); col++) {
+			auto &col_type_candidates = info_sql_types_candidates[col];
+			// check number of varchar columns
+			const auto &col_type = col_type_candidates.back();
+			if (col_type == LogicalType::VARCHAR) {
+				varchar_cols++;
+			}
+		}
+
+		// it's good if the dialect creates more non-varchar columns, but only if we sacrifice < 30% of best_num_cols.
+		if (varchar_cols < min_varchar_cols && parse_chunk.ColumnCount() > (best_num_cols * 0.7)) {
+			// we have a new best_options candidate
+			best_options = info_candidate;
+			min_varchar_cols = varchar_cols;
+			best_sql_types_candidates = info_sql_types_candidates;
+			best_format_candidates = format_candidates;
+			best_header_row.Destroy();
+			auto header_row_types = header_row.GetTypes();
+			best_header_row.Initialize(header_row_types);
+			header_row.Copy(best_header_row);
+		}
+	}
+
+	options = best_options;
+	for (const auto &best : best_format_candidates) {
+		if (!best.second.empty()) {
+			SetDateFormat(best.second.back(), best.first);
+		}
+	}
+}
+
+void BufferedCSVReader::DetectHeader(const vector<vector<LogicalType>> &best_sql_types_candidates,
+                                     const DataChunk &best_header_row) {
+	// information for header detection
+	bool first_row_consistent = true;
+	bool first_row_nulls = false;
+
+	// check if header row is all null and/or consistent with detected column data types
+	first_row_nulls = true;
+	for (idx_t col = 0; col < best_sql_types_candidates.size(); col++) {
+		auto dummy_val = best_header_row.GetValue(col, 0);
+		if (!dummy_val.IsNull()) {
+			first_row_nulls = false;
+		}
+
+		// try cast to sql_type of column
+		const auto &sql_type = best_sql_types_candidates[col].back();
+		if (!TryCastValue(dummy_val, sql_type)) {
+			first_row_consistent = false;
+		}
+	}
+
+	// update parser info, and read, generate & set col_names based on previous findings
+	if (((!first_row_consistent || first_row_nulls) && !options.has_header) || (options.has_header && options.header)) {
+		options.header = true;
+		case_insensitive_map_t<idx_t> name_collision_count;
+		// get header names from CSV
+		for (idx_t col = 0; col < options.num_cols; col++) {
+			const auto &val = best_header_row.GetValue(col, 0);
+			string col_name = val.ToString();
+
+			// generate name if field is empty
+			if (col_name.empty() || val.IsNull()) {
+				col_name = GenerateColumnName(options.num_cols, col);
+			}
+
+			// normalize names or at least trim whitespace
+			if (options.normalize_names) {
+				col_name = NormalizeColumnName(col_name);
+			} else {
+				col_name = TrimWhitespace(col_name);
+			}
+
+			// avoid duplicate header names
+			const string col_name_raw = col_name;
+			while (name_collision_count.find(col_name) != name_collision_count.end()) {
+				name_collision_count[col_name] += 1;
+				col_name = col_name + "_" + to_string(name_collision_count[col_name]);
+			}
+
+			col_names.push_back(col_name);
+			name_collision_count[col_name] = 0;
+		}
+
+	} else {
+		options.header = false;
+		for (idx_t col = 0; col < options.num_cols; col++) {
+			string column_name = GenerateColumnName(options.num_cols, col);
+			col_names.push_back(column_name);
+		}
+	}
+}
+
+vector<LogicalType> BufferedCSVReader::RefineTypeDetection(const vector<LogicalType> &type_candidates,
+                                                           const vector<LogicalType> &requested_types,
+                                                           vector<vector<LogicalType>> &best_sql_types_candidates,
+                                                           map<LogicalTypeId, vector<string>> &best_format_candidates) {
+	// for the type refine we set the SQL types to VARCHAR for all columns
+	sql_types.clear();
+	sql_types.assign(options.num_cols, LogicalType::VARCHAR);
+
+	vector<LogicalType> detected_types;
+
+	// if data types were provided, exit here if number of columns does not match
+	if (!requested_types.empty()) {
+		if (requested_types.size() != options.num_cols) {
+			throw InvalidInputException(
+			    "Error while determining column types: found %lld columns but expected %d. (%s)", options.num_cols,
+			    requested_types.size(), options.ToString());
+		} else {
+			detected_types = requested_types;
+		}
+	} else if (options.all_varchar) {
+		// return all types varchar
+		detected_types = sql_types;
+	} else {
+		// jump through the rest of the file and continue to refine the sql type guess
+		while (JumpToNextSample()) {
+			InitParseChunk(sql_types.size());
+			// if jump ends up a bad line, we just skip this chunk
+			if (!TryParseCSV(ParserMode::SNIFFING_DATATYPES)) {
+				continue;
+			}
+			for (idx_t col = 0; col < parse_chunk.ColumnCount(); col++) {
+				vector<LogicalType> &col_type_candidates = best_sql_types_candidates[col];
+				while (col_type_candidates.size() > 1) {
+					const auto &sql_type = col_type_candidates.back();
+					//	narrow down the date formats
+					if (best_format_candidates.count(sql_type.id())) {
+						auto &best_type_format_candidates = best_format_candidates[sql_type.id()];
+						auto save_format_candidates = best_type_format_candidates;
+						while (!best_type_format_candidates.empty()) {
+							if (TryCastVector(parse_chunk.data[col], parse_chunk.size(), sql_type)) {
+								break;
+							}
+							//	doesn't work - move to the next one
+							best_type_format_candidates.pop_back();
+							options.has_format[sql_type.id()] = (!best_type_format_candidates.empty());
+							if (!best_type_format_candidates.empty()) {
+								SetDateFormat(best_type_format_candidates.back(), sql_type.id());
+							}
+						}
+						//	if none match, then this is not a column of type sql_type,
+						if (best_type_format_candidates.empty()) {
+							//	so restore the candidates that did work.
+							best_type_format_candidates.swap(save_format_candidates);
+							if (!best_type_format_candidates.empty()) {
+								SetDateFormat(best_type_format_candidates.back(), sql_type.id());
+							}
+						}
+					}
+
+					if (TryCastVector(parse_chunk.data[col], parse_chunk.size(), sql_type)) {
+						break;
+					} else {
+						col_type_candidates.pop_back();
+					}
+				}
+			}
+
+			if (!jumping_samples) {
+				if ((sample_chunk_idx)*options.sample_chunk_size <= options.buffer_size) {
+					// cache parse chunk
+					// create a new chunk and fill it with the remainder
+					auto chunk = make_unique<DataChunk>();
+					auto parse_chunk_types = parse_chunk.GetTypes();
+					chunk->Move(parse_chunk);
+					cached_chunks.push(move(chunk));
+				} else {
+					while (!cached_chunks.empty()) {
+						cached_chunks.pop();
+					}
+				}
+			}
+		}
+
+		// set sql types
+		for (auto &best_sql_types_candidate : best_sql_types_candidates) {
+			LogicalType d_type = best_sql_types_candidate.back();
+			if (best_sql_types_candidate.size() == type_candidates.size()) {
+				d_type = LogicalType::VARCHAR;
+			}
+			detected_types.push_back(d_type);
+		}
+	}
+
+	return detected_types;
+}
+
+vector<LogicalType> BufferedCSVReader::SniffCSV(const vector<LogicalType> &requested_types) {
+	for (auto &type : requested_types) {
+		// auto detect for blobs not supported: there may be invalid UTF-8 in the file
+		if (type.id() == LogicalTypeId::BLOB) {
+			return requested_types;
+		}
+	}
+
+	// #######
+	// ### dialect detection
+	// #######
+	BufferedCSVReaderOptions original_options = options;
+	vector<BufferedCSVReaderOptions> info_candidates;
+	idx_t best_num_cols = 0;
+
+	DetectDialect(requested_types, original_options, info_candidates, best_num_cols);
+
+	// if no dialect candidate was found, then file was most likely empty and we throw an exception
+	if (info_candidates.empty()) {
+		throw InvalidInputException(
+		    "Error in file \"%s\": CSV options could not be auto-detected. Consider setting parser options manually.",
+		    options.file_path);
+	}
+
+	// #######
+	// ### type detection (initial)
+	// #######
+	// type candidates, ordered by descending specificity (~ from high to low)
+	vector<LogicalType> type_candidates = {
+	    LogicalType::VARCHAR, LogicalType::TIMESTAMP,
+	    LogicalType::DATE,    LogicalType::TIME,
+	    LogicalType::DOUBLE,  /* LogicalType::FLOAT,*/ LogicalType::BIGINT,
+	    LogicalType::INTEGER, /*LogicalType::SMALLINT, LogicalType::TINYINT,*/ LogicalType::BOOLEAN,
+	    LogicalType::SQLNULL};
+	// format template candidates, ordered by descending specificity (~ from high to low)
+	std::map<LogicalTypeId, vector<const char *>> format_template_candidates = {
+	    {LogicalTypeId::DATE, {"%m-%d-%Y", "%m-%d-%y", "%d-%m-%Y", "%d-%m-%y", "%Y-%m-%d", "%y-%m-%d"}},
+	    {LogicalTypeId::TIMESTAMP,
+	     {"%Y-%m-%d %H:%M:%S.%f", "%m-%d-%Y %I:%M:%S %p", "%m-%d-%y %I:%M:%S %p", "%d-%m-%Y %H:%M:%S",
+	      "%d-%m-%y %H:%M:%S", "%Y-%m-%d %H:%M:%S", "%y-%m-%d %H:%M:%S"}},
+	};
+	vector<vector<LogicalType>> best_sql_types_candidates;
+	map<LogicalTypeId, vector<string>> best_format_candidates;
+	DataChunk best_header_row;
+	DetectCandidateTypes(type_candidates, format_template_candidates, info_candidates, original_options, best_num_cols,
+	                     best_sql_types_candidates, best_format_candidates, best_header_row);
+
+	// #######
+	// ### header detection
+	// #######
+	options.num_cols = best_num_cols;
+	DetectHeader(best_sql_types_candidates, best_header_row);
+
+	// #######
+	// ### type detection (refining)
+	// #######
+	return RefineTypeDetection(type_candidates, requested_types, best_sql_types_candidates, best_format_candidates);
+}
+
+bool BufferedCSVReader::TryParseComplexCSV(DataChunk &insert_chunk, string &error_message) {
+	// used for parsing algorithm
+	bool finished_chunk = false;
+	idx_t column = 0;
+	vector<idx_t> escape_positions;
+	uint8_t delimiter_pos = 0, escape_pos = 0, quote_pos = 0;
+	idx_t offset = 0;
+
+	// read values into the buffer (if any)
+	if (position >= buffer_size) {
+		if (!ReadBuffer(start)) {
+			return true;
+		}
+	}
+	// start parsing the first value
+	start = position;
+	goto value_start;
+value_start:
+	/* state: value_start */
+	// this state parses the first characters of a value
+	offset = 0;
+	delimiter_pos = 0;
+	quote_pos = 0;
+	do {
+		idx_t count = 0;
+		for (; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			delimiter_search.Match(delimiter_pos, buffer[position]);
+			count++;
+			if (delimiter_pos == options.delimiter.size()) {
+				// found a delimiter, add the value
+				offset = options.delimiter.size() - 1;
+				goto add_value;
+			} else if (StringUtil::CharacterIsNewline(buffer[position])) {
+				// found a newline, add the row
+				goto add_row;
+			}
+			if (count > quote_pos) {
+				// did not find a quote directly at the start of the value, stop looking for the quote now
+				goto normal;
+			}
+			if (quote_pos == options.quote.size()) {
+				// found a quote, go to quoted loop and skip the initial quote
+				start += options.quote.size();
+				goto in_quotes;
+			}
+		}
+	} while (ReadBuffer(start));
+	// file ends while scanning for quote/delimiter, go to final state
+	goto final_state;
+normal:
+	/* state: normal parsing state */
+	// this state parses the remainder of a non-quoted value until we reach a delimiter or newline
+	position++;
+	do {
+		for (; position < buffer_size; position++) {
+			delimiter_search.Match(delimiter_pos, buffer[position]);
+			if (delimiter_pos == options.delimiter.size()) {
+				offset = options.delimiter.size() - 1;
+				goto add_value;
+			} else if (StringUtil::CharacterIsNewline(buffer[position])) {
+				goto add_row;
+			}
+		}
+	} while (ReadBuffer(start));
+	goto final_state;
+add_value:
+	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+	// increase position by 1 and move start to the new position
+	offset = 0;
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after delimiter, go to final state
+		goto final_state;
+	}
+	goto value_start;
+add_row : {
+	// check type of newline (\r or \n)
+	bool carriage_return = buffer[position] == '\r';
+	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+	finished_chunk = AddRow(insert_chunk, column);
+	// increase position by 1 and move start to the new position
+	offset = 0;
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after newline, go to final state
+		goto final_state;
+	}
+	if (carriage_return) {
+		// \r newline, go to special state that parses an optional \n afterwards
+		goto carriage_return;
+	} else {
+		// \n newline, move to value start
+		if (finished_chunk) {
+			return true;
+		}
+		goto value_start;
+	}
+}
+in_quotes:
+	/* state: in_quotes */
+	// this state parses the remainder of a quoted value
+	quote_pos = 0;
+	escape_pos = 0;
+	position++;
+	do {
+		for (; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			escape_search.Match(escape_pos, buffer[position]);
+			if (quote_pos == options.quote.size()) {
+				goto unquote;
+			} else if (escape_pos == options.escape.size()) {
+				escape_positions.push_back(position - start - (options.escape.size() - 1));
+				goto handle_escape;
+			}
+		}
+	} while (ReadBuffer(start));
+	// still in quoted state at the end of the file, error:
+	error_message = StringUtil::Format("Error in file \"%s\" on line %s: unterminated quotes. (%s)", options.file_path,
+	                                   GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+	return false;
+unquote:
+	/* state: unquote */
+	// this state handles the state directly after we unquote
+	// in this state we expect either another quote (entering the quoted state again, and escaping the quote)
+	// or a delimiter/newline, ending the current value and moving on to the next value
+	delimiter_pos = 0;
+	quote_pos = 0;
+	position++;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after unquote, go to final state
+		offset = options.quote.size();
+		goto final_state;
+	}
+	if (StringUtil::CharacterIsNewline(buffer[position])) {
+		// quote followed by newline, add row
+		offset = options.quote.size();
+		goto add_row;
+	}
+	do {
+		idx_t count = 0;
+		for (; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			delimiter_search.Match(delimiter_pos, buffer[position]);
+			count++;
+			if (count > delimiter_pos && count > quote_pos) {
+				error_message = StringUtil::Format(
+				    "Error in file \"%s\" on line %s: quote should be followed by end of value, end "
+				    "of row or another quote. (%s)",
+				    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+				return false;
+			}
+			if (delimiter_pos == options.delimiter.size()) {
+				// quote followed by delimiter, add value
+				offset = options.quote.size() + options.delimiter.size() - 1;
+				goto add_value;
+			} else if (quote_pos == options.quote.size() &&
+			           (options.escape.empty() || options.escape == options.quote)) {
+				// quote followed by quote, go back to quoted state and add to escape
+				escape_positions.push_back(position - start - (options.quote.size() - 1));
+				goto in_quotes;
+			}
+		}
+	} while (ReadBuffer(start));
+	error_message = StringUtil::Format(
+	    "Error in file \"%s\" on line %s: quote should be followed by end of value, end of row or another quote. (%s)",
+	    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+	return false;
+handle_escape:
+	escape_pos = 0;
+	quote_pos = 0;
+	position++;
+	do {
+		idx_t count = 0;
+		for (; position < buffer_size; position++) {
+			quote_search.Match(quote_pos, buffer[position]);
+			escape_search.Match(escape_pos, buffer[position]);
+			count++;
+			if (count > escape_pos && count > quote_pos) {
+				error_message = StringUtil::Format(
+				    "Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)",
+				    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+				return false;
+			}
+			if (quote_pos == options.quote.size() || escape_pos == options.escape.size()) {
+				// found quote or escape: move back to quoted state
+				goto in_quotes;
+			}
+		}
+	} while (ReadBuffer(start));
+	error_message =
+	    StringUtil::Format("Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)",
+	                       options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+	return false;
+carriage_return:
+	/* state: carriage_return */
+	// this stage optionally skips a newline (\n) character, which allows \r\n to be interpreted as a single line
+	if (buffer[position] == '\n') {
+		// newline after carriage return: skip
+		start = ++position;
+		if (position >= buffer_size && !ReadBuffer(start)) {
+			// file ends right after newline, go to final state
+			goto final_state;
+		}
+	}
+	if (finished_chunk) {
+		return true;
+	}
+	goto value_start;
+final_state:
+	if (finished_chunk) {
+		return true;
+	}
+	if (column > 0 || position > start) {
+		// remaining values to be added to the chunk
+		AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+		finished_chunk = AddRow(insert_chunk, column);
+	}
+	// final stage, only reached after parsing the file is finished
+	// flush the parsed chunk and finalize parsing
+	if (mode == ParserMode::PARSING) {
+		Flush(insert_chunk);
+	}
+
+	end_of_file_reached = true;
+	return true;
+}
+
+bool BufferedCSVReader::TryParseSimpleCSV(DataChunk &insert_chunk, string &error_message) {
+	// used for parsing algorithm
+	bool finished_chunk = false;
+	idx_t column = 0;
+	idx_t offset = 0;
+	vector<idx_t> escape_positions;
+
+	// read values into the buffer (if any)
+	if (position >= buffer_size) {
+		if (!ReadBuffer(start)) {
+			return true;
+		}
+	}
+	// start parsing the first value
+	goto value_start;
+value_start:
+	offset = 0;
+	/* state: value_start */
+	// this state parses the first character of a value
+	if (buffer[position] == options.quote[0]) {
+		// quote: actual value starts in the next position
+		// move to in_quotes state
+		start = position + 1;
+		goto in_quotes;
+	} else {
+		// no quote, move to normal parsing state
+		start = position;
+		goto normal;
+	}
+normal:
+	/* state: normal parsing state */
+	// this state parses the remainder of a non-quoted value until we reach a delimiter or newline
+	do {
+		for (; position < buffer_size; position++) {
+			if (buffer[position] == options.delimiter[0]) {
+				// delimiter: end the value and add it to the chunk
+				goto add_value;
+			} else if (StringUtil::CharacterIsNewline(buffer[position])) {
+				// newline: add row
+				goto add_row;
+			}
+		}
+	} while (ReadBuffer(start));
+	// file ends during normal scan: go to end state
+	goto final_state;
+add_value:
+	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+	// increase position by 1 and move start to the new position
+	offset = 0;
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after delimiter, go to final state
+		goto final_state;
+	}
+	goto value_start;
+add_row : {
+	// check type of newline (\r or \n)
+	bool carriage_return = buffer[position] == '\r';
+	AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+	finished_chunk = AddRow(insert_chunk, column);
+	// increase position by 1 and move start to the new position
+	offset = 0;
+	start = ++position;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after delimiter, go to final state
+		goto final_state;
+	}
+	if (carriage_return) {
+		// \r newline, go to special state that parses an optional \n afterwards
+		goto carriage_return;
+	} else {
+		// \n newline, move to value start
+		if (finished_chunk) {
+			return true;
+		}
+		goto value_start;
+	}
+}
+in_quotes:
+	/* state: in_quotes */
+	// this state parses the remainder of a quoted value
+	position++;
+	do {
+		for (; position < buffer_size; position++) {
+			if (buffer[position] == options.quote[0]) {
+				// quote: move to unquoted state
+				goto unquote;
+			} else if (buffer[position] == options.escape[0]) {
+				// escape: store the escaped position and move to handle_escape state
+				escape_positions.push_back(position - start);
+				goto handle_escape;
+			}
+		}
+	} while (ReadBuffer(start));
+	// still in quoted state at the end of the file, error:
+	throw InvalidInputException("Error in file \"%s\" on line %s: unterminated quotes. (%s)", options.file_path,
+	                            GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+unquote:
+	/* state: unquote */
+	// this state handles the state directly after we unquote
+	// in this state we expect either another quote (entering the quoted state again, and escaping the quote)
+	// or a delimiter/newline, ending the current value and moving on to the next value
+	position++;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		// file ends right after unquote, go to final state
+		offset = 1;
+		goto final_state;
+	}
+	if (buffer[position] == options.quote[0] && (options.escape.empty() || options.escape[0] == options.quote[0])) {
+		// escaped quote, return to quoted state and store escape position
+		escape_positions.push_back(position - start);
+		goto in_quotes;
+	} else if (buffer[position] == options.delimiter[0]) {
+		// delimiter, add value
+		offset = 1;
+		goto add_value;
+	} else if (StringUtil::CharacterIsNewline(buffer[position])) {
+		offset = 1;
+		goto add_row;
+	} else {
+		error_message = StringUtil::Format(
+		    "Error in file \"%s\" on line %s: quote should be followed by end of value, end of "
+		    "row or another quote. (%s)",
+		    options.file_path, GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+		return false;
+	}
+handle_escape:
+	/* state: handle_escape */
+	// escape should be followed by a quote or another escape character
+	position++;
+	if (position >= buffer_size && !ReadBuffer(start)) {
+		error_message = StringUtil::Format(
+		    "Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)", options.file_path,
+		    GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+		return false;
+	}
+	if (buffer[position] != options.quote[0] && buffer[position] != options.escape[0]) {
+		error_message = StringUtil::Format(
+		    "Error in file \"%s\" on line %s: neither QUOTE nor ESCAPE is proceeded by ESCAPE. (%s)", options.file_path,
+		    GetLineNumberStr(linenr, linenr_estimated).c_str(), options.ToString());
+		return false;
+	}
+	// escape was followed by quote or escape, go back to quoted state
+	goto in_quotes;
+carriage_return:
+	/* state: carriage_return */
+	// this stage optionally skips a newline (\n) character, which allows \r\n to be interpreted as a single line
+	if (buffer[position] == '\n') {
+		// newline after carriage return: skip
+		// increase position by 1 and move start to the new position
+		start = ++position;
+		if (position >= buffer_size && !ReadBuffer(start)) {
+			// file ends right after delimiter, go to final state
+			goto final_state;
+		}
+	}
+	if (finished_chunk) {
+		return true;
+	}
+	goto value_start;
+final_state:
+	if (finished_chunk) {
+		return true;
+	}
+
+	if (column > 0 || position > start) {
+		// remaining values to be added to the chunk
+		AddValue(buffer.get() + start, position - start - offset, column, escape_positions);
+		finished_chunk = AddRow(insert_chunk, column);
+	}
+
+	// final stage, only reached after parsing the file is finished
+	// flush the parsed chunk and finalize parsing
+	if (mode == ParserMode::PARSING) {
+		Flush(insert_chunk);
+	}
+
+	end_of_file_reached = true;
+	return true;
+}
+
+bool BufferedCSVReader::ReadBuffer(idx_t &start) {
+	auto old_buffer = move(buffer);
+
+	// the remaining part of the last buffer
+	idx_t remaining = buffer_size - start;
+
+	bool large_buffers = mode == ParserMode::PARSING && !file_handle->OnDiskFile() && file_handle->CanSeek();
+	idx_t buffer_read_size = large_buffers ? INITIAL_BUFFER_SIZE_LARGE : INITIAL_BUFFER_SIZE;
+
+	while (remaining > buffer_read_size) {
+		buffer_read_size *= 2;
+	}
+
+	// Check line length
+	if (remaining > options.maximum_line_size) {
+		throw InvalidInputException("Maximum line size of %llu bytes exceeded!", options.maximum_line_size);
+	}
+
+	buffer = unique_ptr<char[]>(new char[buffer_read_size + remaining + 1]);
+	buffer_size = remaining + buffer_read_size;
+	if (remaining > 0) {
+		// remaining from last buffer: copy it here
+		memcpy(buffer.get(), old_buffer.get() + start, remaining);
+	}
+	idx_t read_count = file_handle->Read(buffer.get() + remaining, buffer_read_size);
+
+	bytes_in_chunk += read_count;
+	buffer_size = remaining + read_count;
+	buffer[buffer_size] = '\0';
+	if (old_buffer) {
+		cached_buffers.push_back(move(old_buffer));
+	}
+	start = 0;
+	position = remaining;
+	if (!bom_checked) {
+		bom_checked = true;
+		if (read_count >= 3 && buffer[0] == '\xEF' && buffer[1] == '\xBB' && buffer[2] == '\xBF') {
+			position += 3;
+		}
+	}
+
+	return read_count > 0;
+}
+
+void BufferedCSVReader::ParseCSV(DataChunk &insert_chunk) {
+	// if no auto-detect or auto-detect with jumping samples, we have nothing cached and start from the beginning
+	if (cached_chunks.empty()) {
+		cached_buffers.clear();
+	} else {
+		auto &chunk = cached_chunks.front();
+		parse_chunk.Move(*chunk);
+		cached_chunks.pop();
+		Flush(insert_chunk);
+		return;
+	}
+
+	string error_message;
+	if (!TryParseCSV(ParserMode::PARSING, insert_chunk, error_message)) {
+		throw InvalidInputException(error_message);
+	}
+}
+
+bool BufferedCSVReader::TryParseCSV(ParserMode mode) {
+	DataChunk dummy_chunk;
+	string error_message;
+	return TryParseCSV(mode, dummy_chunk, error_message);
+}
+
+void BufferedCSVReader::ParseCSV(ParserMode mode) {
+	DataChunk dummy_chunk;
+	string error_message;
+	if (!TryParseCSV(mode, dummy_chunk, error_message)) {
+		throw InvalidInputException(error_message);
+	}
+}
+
+bool BufferedCSVReader::TryParseCSV(ParserMode parser_mode, DataChunk &insert_chunk, string &error_message) {
+	mode = parser_mode;
+
+	if (options.quote.size() <= 1 && options.escape.size() <= 1 && options.delimiter.size() == 1) {
+		return TryParseSimpleCSV(insert_chunk, error_message);
+	} else {
+		return TryParseComplexCSV(insert_chunk, error_message);
+	}
+}
+
+void BufferedCSVReader::AddValue(char *str_val, idx_t length, idx_t &column, vector<idx_t> &escape_positions) {
+	if (length == 0 && column == 0) {
+		row_empty = true;
+	} else {
+		row_empty = false;
+	}
+
+	if (!sql_types.empty() && column == sql_types.size() && length == 0) {
+		// skip a single trailing delimiter in last column
+		return;
+	}
+	if (mode == ParserMode::SNIFFING_DIALECT) {
+		column++;
+		return;
+	}
+	if (column >= sql_types.size()) {
+		if (options.ignore_errors) {
+			error_column_overflow = true;
+			return;
+		} else {
+			throw InvalidInputException("Error on line %s: expected %lld values per row, but got more. (%s)",
+			                            GetLineNumberStr(linenr, linenr_estimated).c_str(), sql_types.size(),
+			                            options.ToString());
+		}
+	}
+
+	// insert the line number into the chunk
+	idx_t row_entry = parse_chunk.size();
+
+	str_val[length] = '\0';
+
+	// test against null string
+	if (!options.force_not_null[column] && strcmp(options.null_str.c_str(), str_val) == 0) {
+		FlatVector::SetNull(parse_chunk.data[column], row_entry, true);
+	} else {
+		auto &v = parse_chunk.data[column];
+		auto parse_data = FlatVector::GetData<string_t>(v);
+		if (!escape_positions.empty()) {
+			// remove escape characters (if any)
+			string old_val = str_val;
+			string new_val = "";
+			idx_t prev_pos = 0;
+			for (idx_t i = 0; i < escape_positions.size(); i++) {
+				idx_t next_pos = escape_positions[i];
+				new_val += old_val.substr(prev_pos, next_pos - prev_pos);
+
+				if (options.escape.empty() || options.escape == options.quote) {
+					prev_pos = next_pos + options.quote.size();
+				} else {
+					prev_pos = next_pos + options.escape.size();
+				}
+			}
+			new_val += old_val.substr(prev_pos, old_val.size() - prev_pos);
+			escape_positions.clear();
+			parse_data[row_entry] = StringVector::AddStringOrBlob(v, string_t(new_val));
+		} else {
+			parse_data[row_entry] = string_t(str_val, length);
+		}
+	}
+
+	// move to the next column
+	column++;
+}
+
+bool BufferedCSVReader::AddRow(DataChunk &insert_chunk, idx_t &column) {
+	linenr++;
+
+	if (row_empty) {
+		row_empty = false;
+		if (sql_types.size() != 1) {
+			column = 0;
+			return false;
+		}
+	}
+
+	// Error forwarded by 'ignore_errors' - originally encountered in 'AddValue'
+	if (error_column_overflow) {
+		D_ASSERT(options.ignore_errors);
+		error_column_overflow = false;
+		column = 0;
+		return false;
+	}
+
+	if (column < sql_types.size() && mode != ParserMode::SNIFFING_DIALECT) {
+		if (options.ignore_errors) {
+			column = 0;
+			return false;
+		} else {
+			throw InvalidInputException("Error on line %s: expected %lld values per row, but got %d. (%s)",
+			                            GetLineNumberStr(linenr, linenr_estimated).c_str(), sql_types.size(), column,
+			                            options.ToString());
+		}
+	}
+
+	if (mode == ParserMode::SNIFFING_DIALECT) {
+		sniffed_column_counts.push_back(column);
+
+		if (sniffed_column_counts.size() == options.sample_chunk_size) {
+			return true;
+		}
+	} else {
+		parse_chunk.SetCardinality(parse_chunk.size() + 1);
+	}
+
+	if (mode == ParserMode::PARSING_HEADER) {
+		return true;
+	}
+
+	if (mode == ParserMode::SNIFFING_DATATYPES && parse_chunk.size() == options.sample_chunk_size) {
+		return true;
+	}
+
+	if (mode == ParserMode::PARSING && parse_chunk.size() == STANDARD_VECTOR_SIZE) {
+		Flush(insert_chunk);
+		return true;
+	}
+
+	column = 0;
+	return false;
+}
+
+void BufferedCSVReader::Flush(DataChunk &insert_chunk) {
+	if (parse_chunk.size() == 0) {
+		return;
+	}
+
+	bool conversion_error_ignored = false;
+
+	// convert the columns in the parsed chunk to the types of the table
+	insert_chunk.SetCardinality(parse_chunk);
+	for (idx_t col_idx = 0; col_idx < sql_types.size(); col_idx++) {
+		if (sql_types[col_idx].id() == LogicalTypeId::VARCHAR) {
+			// target type is varchar: no need to convert
+			// just test that all strings are valid utf-8 strings
+			auto parse_data = FlatVector::GetData<string_t>(parse_chunk.data[col_idx]);
+			for (idx_t i = 0; i < parse_chunk.size(); i++) {
+				if (!FlatVector::IsNull(parse_chunk.data[col_idx], i)) {
+					auto s = parse_data[i];
+					auto utf_type = Utf8Proc::Analyze(s.GetDataUnsafe(), s.GetSize());
+					if (utf_type == UnicodeType::INVALID) {
+						string col_name = to_string(col_idx);
+						if (col_idx < col_names.size()) {
+							col_name = "\"" + col_names[col_idx] + "\"";
+						}
+						throw InvalidInputException("Error in file \"%s\" between line %llu and %llu in column \"%s\": "
+						                            "file is not valid UTF8. Parser options: %s",
+						                            options.file_path, linenr - parse_chunk.size(), linenr, col_name,
+						                            options.ToString());
+					}
+				}
+			}
+			insert_chunk.data[col_idx].Reference(parse_chunk.data[col_idx]);
+		} else {
+			string error_message;
+			bool success;
+			if (options.has_format[LogicalTypeId::DATE] && sql_types[col_idx].id() == LogicalTypeId::DATE) {
+				// use the date format to cast the chunk
+				success = TryCastDateVector(options, parse_chunk.data[col_idx], insert_chunk.data[col_idx],
+				                            parse_chunk.size(), error_message);
+			} else if (options.has_format[LogicalTypeId::TIMESTAMP] &&
+			           sql_types[col_idx].id() == LogicalTypeId::TIMESTAMP) {
+				// use the date format to cast the chunk
+				success = TryCastTimestampVector(options, parse_chunk.data[col_idx], insert_chunk.data[col_idx],
+				                                 parse_chunk.size(), error_message);
+			} else {
+				// target type is not varchar: perform a cast
+				success = VectorOperations::TryCast(parse_chunk.data[col_idx], insert_chunk.data[col_idx],
+				                                    parse_chunk.size(), &error_message);
+			}
+			if (success) {
+				continue;
+			}
+			if (options.ignore_errors) {
+				conversion_error_ignored = true;
+				continue;
+			}
+			string col_name = to_string(col_idx);
+			if (col_idx < col_names.size()) {
+				col_name = "\"" + col_names[col_idx] + "\"";
+			}
+
+			if (options.auto_detect) {
+				throw InvalidInputException("%s in column %s, between line %llu and %llu. Parser "
+				                            "options: %s. Consider either increasing the sample size "
+				                            "(SAMPLE_SIZE=X [X rows] or SAMPLE_SIZE=-1 [all rows]), "
+				                            "or skipping column conversion (ALL_VARCHAR=1)",
+				                            error_message, col_name, linenr - parse_chunk.size() + 1, linenr,
+				                            options.ToString());
+			} else {
+				throw InvalidInputException("%s between line %llu and %llu in column %s. Parser options: %s ",
+				                            error_message, linenr - parse_chunk.size(), linenr, col_name,
+				                            options.ToString());
+			}
+		}
+	}
+	if (conversion_error_ignored) {
+		D_ASSERT(options.ignore_errors);
+		SelectionVector succesful_rows;
+		succesful_rows.Initialize(parse_chunk.size());
+		idx_t sel_size = 0;
+
+		for (idx_t row_idx = 0; row_idx < parse_chunk.size(); row_idx++) {
+			bool failed = false;
+			for (idx_t column_idx = 0; column_idx < sql_types.size(); column_idx++) {
+
+				auto &inserted_column = insert_chunk.data[column_idx];
+				auto &parsed_column = parse_chunk.data[column_idx];
+
+				bool was_already_null = FlatVector::IsNull(parsed_column, row_idx);
+				if (!was_already_null && FlatVector::IsNull(inserted_column, row_idx)) {
+					failed = true;
+					break;
+				}
+			}
+			if (!failed) {
+				succesful_rows.set_index(sel_size++, row_idx);
+			}
+		}
+		insert_chunk.Slice(succesful_rows, sel_size);
+	}
+	parse_chunk.Reset();
+}
+} // namespace duckdb
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+class CopyToFunctionGlobalState : public GlobalSinkState {
+public:
+	explicit CopyToFunctionGlobalState(unique_ptr<GlobalFunctionData> global_state)
+	    : rows_copied(0), global_state(move(global_state)) {
+	}
+
+	idx_t rows_copied;
+	unique_ptr<GlobalFunctionData> global_state;
+};
+
+class CopyToFunctionLocalState : public LocalSinkState {
+public:
+	explicit CopyToFunctionLocalState(unique_ptr<LocalFunctionData> local_state) : local_state(move(local_state)) {
+	}
+	unique_ptr<LocalFunctionData> local_state;
+};
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+void MoveTmpFile(ClientContext &context, const string &tmp_file_path) {
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto file_path = tmp_file_path.substr(0, tmp_file_path.length() - 4);
+	if (fs.FileExists(file_path)) {
+		fs.RemoveFile(file_path);
+	}
+	fs.MoveFile(tmp_file_path, file_path);
+}
+
+PhysicalCopyToFile::PhysicalCopyToFile(vector<LogicalType> types, CopyFunction function_p,
+                                       unique_ptr<FunctionData> bind_data, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::COPY_TO_FILE, move(types), estimated_cardinality),
+      function(move(function_p)), bind_data(move(bind_data)) {
+}
+
+SinkResultType PhysicalCopyToFile::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
+                                        DataChunk &input) const {
+	auto &g = (CopyToFunctionGlobalState &)gstate;
+	auto &l = (CopyToFunctionLocalState &)lstate;
+
+	g.rows_copied += input.size();
+	function.copy_to_sink(context.client, *bind_data, *g.global_state, *l.local_state, input);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+void PhysicalCopyToFile::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+	auto &g = (CopyToFunctionGlobalState &)gstate;
+	auto &l = (CopyToFunctionLocalState &)lstate;
+
+	if (function.copy_to_combine) {
+		function.copy_to_combine(context.client, *bind_data, *g.global_state, *l.local_state);
+	}
+}
+
+SinkFinalizeType PhysicalCopyToFile::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                              GlobalSinkState &gstate_p) const {
+	auto &gstate = (CopyToFunctionGlobalState &)gstate_p;
+	if (function.copy_to_finalize) {
+		function.copy_to_finalize(context, *bind_data, *gstate.global_state);
+
+		if (use_tmp_file) {
+			MoveTmpFile(context, file_path);
+		}
+	}
+	return SinkFinalizeType::READY;
+}
+
+unique_ptr<LocalSinkState> PhysicalCopyToFile::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<CopyToFunctionLocalState>(function.copy_to_initialize_local(context.client, *bind_data));
+}
+unique_ptr<GlobalSinkState> PhysicalCopyToFile::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<CopyToFunctionGlobalState>(function.copy_to_initialize_global(context, *bind_data, file_path));
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CopyToFileState : public GlobalSourceState {
+public:
+	CopyToFileState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCopyToFile::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CopyToFileState>();
+}
+
+void PhysicalCopyToFile::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                 LocalSourceState &lstate) const {
+	auto &state = (CopyToFileState &)gstate;
+	auto &g = (CopyToFunctionGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+
+	chunk.SetCardinality(1);
+	chunk.SetValue(0, 0, Value::BIGINT(g.rows_copied));
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class DeleteGlobalState : public GlobalSinkState {
+public:
+	DeleteGlobalState() : deleted_count(0), returned_chunk_count(0) {
+	}
+
+	mutex delete_lock;
+	idx_t deleted_count;
+	ChunkCollection return_chunk_collection;
+	idx_t returned_chunk_count;
+};
+
+class DeleteLocalState : public LocalSinkState {
+public:
+	explicit DeleteLocalState(const vector<LogicalType> &table_types) {
+		delete_chunk.Initialize(table_types);
+	}
+	DataChunk delete_chunk;
+};
+
+SinkResultType PhysicalDelete::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                    DataChunk &input) const {
+	auto &gstate = (DeleteGlobalState &)state;
+	auto &ustate = (DeleteLocalState &)lstate;
+
+	// get rows and
+	auto &transaction = Transaction::GetTransaction(context.client);
+	auto &row_identifiers = input.data[row_id_index];
+
+	vector<column_t> column_ids;
+	for (idx_t i = 0; i < table.column_definitions.size(); i++) {
+		column_ids.emplace_back(i);
+	};
+	auto cfs = ColumnFetchState();
+
+	lock_guard<mutex> delete_guard(gstate.delete_lock);
+	if (return_chunk) {
+		row_identifiers.Normalify(input.size());
+		table.Fetch(transaction, ustate.delete_chunk, column_ids, row_identifiers, input.size(), cfs);
+		gstate.return_chunk_collection.Append(ustate.delete_chunk);
+	}
+	gstate.deleted_count += table.Delete(tableref, context.client, row_identifiers, input.size());
+
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+unique_ptr<GlobalSinkState> PhysicalDelete::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<DeleteGlobalState>();
+}
+
+unique_ptr<LocalSinkState> PhysicalDelete::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<DeleteLocalState>(table.GetTypes());
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class DeleteSourceState : public GlobalSourceState {
+public:
+	DeleteSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalDelete::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<DeleteSourceState>();
+}
+
+void PhysicalDelete::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	auto &state = (DeleteSourceState &)gstate;
+	auto &g = (DeleteGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+
+	if (!return_chunk) {
+		chunk.SetCardinality(1);
+		chunk.SetValue(0, 0, Value::BIGINT(g.deleted_count));
+		state.finished = true;
+	}
+
+	idx_t chunk_return = g.returned_chunk_count;
+	if (chunk_return >= g.return_chunk_collection.Chunks().size()) {
+		return;
+	}
+	chunk.Reference(g.return_chunk_collection.GetChunk(chunk_return));
+	chunk.SetCardinality((g.return_chunk_collection.GetChunk(chunk_return)).size());
+	g.returned_chunk_count += 1;
+	if (g.returned_chunk_count >= g.return_chunk_collection.Chunks().size()) {
+		state.finished = true;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <sstream>
+
+namespace duckdb {
+
+using std::stringstream;
+
+static void WriteCatalogEntries(stringstream &ss, vector<CatalogEntry *> &entries) {
+	for (auto &entry : entries) {
+		if (entry->internal) {
+			continue;
+		}
+		ss << entry->ToSQL() << std::endl;
+	}
+	ss << std::endl;
+}
+
+static void WriteStringStreamToFile(FileSystem &fs, FileOpener *opener, stringstream &ss, const string &path) {
+	auto ss_string = ss.str();
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW,
+	                          FileLockType::WRITE_LOCK, FileSystem::DEFAULT_COMPRESSION, opener);
+	fs.Write(*handle, (void *)ss_string.c_str(), ss_string.size());
+	handle.reset();
+}
+
+static void WriteValueAsSQL(stringstream &ss, Value &val) {
+	if (val.type().IsNumeric()) {
+		ss << val.ToString();
+	} else {
+		ss << "'" << val.ToString() << "'";
+	}
+}
+
+static void WriteCopyStatement(FileSystem &fs, stringstream &ss, TableCatalogEntry *table, CopyInfo &info,
+                               ExportedTableData &exported_table, CopyFunction const &function) {
+	ss << "COPY ";
+
+	if (exported_table.schema_name != DEFAULT_SCHEMA) {
+		ss << KeywordHelper::WriteOptionallyQuoted(exported_table.schema_name) << ".";
+	}
+
+	ss << KeywordHelper::WriteOptionallyQuoted(exported_table.table_name) << " FROM '" << exported_table.file_path
+	   << "' (";
+
+	// write the copy options
+	ss << "FORMAT '" << info.format << "'";
+	if (info.format == "csv") {
+		// insert default csv options, if not specified
+		if (info.options.find("header") == info.options.end()) {
+			info.options["header"].push_back(Value::INTEGER(0));
+		}
+		if (info.options.find("delimiter") == info.options.end() && info.options.find("sep") == info.options.end() &&
+		    info.options.find("delim") == info.options.end()) {
+			info.options["delimiter"].push_back(Value(","));
+		}
+		if (info.options.find("quote") == info.options.end()) {
+			info.options["quote"].push_back(Value("\""));
+		}
+	}
+	for (auto &copy_option : info.options) {
+		ss << ", " << copy_option.first << " ";
+		if (copy_option.second.size() == 1) {
+			WriteValueAsSQL(ss, copy_option.second[0]);
+		} else {
+			// FIXME handle multiple options
+			throw NotImplementedException("FIXME: serialize list of options");
+		}
+	}
+	ss << ");" << std::endl;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class ExportSourceState : public GlobalSourceState {
+public:
+	ExportSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalExport::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<ExportSourceState>();
+}
+
+void PhysicalExport::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	auto &state = (ExportSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+
+	auto &ccontext = context.client;
+	auto &fs = FileSystem::GetFileSystem(ccontext);
+	auto *opener = FileSystem::GetFileOpener(ccontext);
+
+	// gather all catalog types to export
+	vector<CatalogEntry *> schemas;
+	vector<CatalogEntry *> custom_types;
+	vector<CatalogEntry *> sequences;
+	vector<CatalogEntry *> tables;
+	vector<CatalogEntry *> views;
+	vector<CatalogEntry *> indexes;
+
+	auto schema_list = Catalog::GetCatalog(ccontext).schemas->GetEntries<SchemaCatalogEntry>(context.client);
+	for (auto &schema : schema_list) {
+		if (!schema->internal) {
+			schemas.push_back(schema);
+		}
+		schema->Scan(context.client, CatalogType::TABLE_ENTRY, [&](CatalogEntry *entry) {
+			if (entry->internal) {
+				return;
+			}
+			if (entry->type != CatalogType::TABLE_ENTRY) {
+				views.push_back(entry);
+			}
+		});
+		schema->Scan(context.client, CatalogType::SEQUENCE_ENTRY,
+		             [&](CatalogEntry *entry) { sequences.push_back(entry); });
+		schema->Scan(context.client, CatalogType::TYPE_ENTRY,
+		             [&](CatalogEntry *entry) { custom_types.push_back(entry); });
+		schema->Scan(context.client, CatalogType::INDEX_ENTRY, [&](CatalogEntry *entry) { indexes.push_back(entry); });
+	}
+
+	// consider the order of tables because of foreign key constraint
+	for (idx_t i = 0; i < exported_tables.data.size(); i++) {
+		tables.push_back((CatalogEntry *)exported_tables.data[i].entry);
+	}
+
+	// write the schema.sql file
+	// export order is SCHEMA -> SEQUENCE -> TABLE -> VIEW -> INDEX
+
+	stringstream ss;
+	WriteCatalogEntries(ss, schemas);
+	WriteCatalogEntries(ss, custom_types);
+	WriteCatalogEntries(ss, sequences);
+	WriteCatalogEntries(ss, tables);
+	WriteCatalogEntries(ss, views);
+	WriteCatalogEntries(ss, indexes);
+
+	WriteStringStreamToFile(fs, opener, ss, fs.JoinPath(info->file_path, "schema.sql"));
+
+	// write the load.sql file
+	// for every table, we write COPY INTO statement with the specified options
+	stringstream load_ss;
+	for (idx_t i = 0; i < exported_tables.data.size(); i++) {
+		auto &table = exported_tables.data[i].entry;
+		auto exported_table_info = exported_tables.data[i].table_data;
+		WriteCopyStatement(fs, load_ss, table, *info, exported_table_info, function);
+	}
+	WriteStringStreamToFile(fs, opener, load_ss, fs.JoinPath(info->file_path, "load.sql"));
+	state.finished = true;
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+SinkResultType PhysicalExport::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
+                                    DataChunk &input) const {
+	// nop
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalExport::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	// EXPORT has an optional child
+	// we only need to schedule child pipelines if there is a child
+	state.SetPipelineSource(current, this);
+	if (children.empty()) {
+		return;
+	}
+	PhysicalOperator::BuildPipelines(executor, current, state);
+}
+
+vector<const PhysicalOperator *> PhysicalExport::GetSources() const {
+	return {this};
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class InsertGlobalState : public GlobalSinkState {
+public:
+	InsertGlobalState() : insert_count(0), returned_chunk_count(0) {
+	}
+
+	mutex lock;
+	idx_t insert_count;
+	ChunkCollection return_chunk_collection;
+	idx_t returned_chunk_count;
+};
+
+class InsertLocalState : public LocalSinkState {
+public:
+	InsertLocalState(const vector<LogicalType> &types, const vector<unique_ptr<Expression>> &bound_defaults)
+	    : default_executor(bound_defaults) {
+		insert_chunk.Initialize(types);
+	}
+
+	DataChunk insert_chunk;
+	ExpressionExecutor default_executor;
+};
+
+PhysicalInsert::PhysicalInsert(vector<LogicalType> types, TableCatalogEntry *table, vector<idx_t> column_index_map,
+                               vector<unique_ptr<Expression>> bound_defaults, idx_t estimated_cardinality,
+                               bool return_chunk)
+    : PhysicalOperator(PhysicalOperatorType::INSERT, move(types), estimated_cardinality),
+      column_index_map(std::move(column_index_map)), table(table), bound_defaults(move(bound_defaults)),
+      return_chunk(return_chunk) {
+}
+
+SinkResultType PhysicalInsert::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                    DataChunk &chunk) const {
+	auto &gstate = (InsertGlobalState &)state;
+	auto &istate = (InsertLocalState &)lstate;
+
+	chunk.Normalify();
+	istate.default_executor.SetChunk(chunk);
+
+	istate.insert_chunk.Reset();
+	istate.insert_chunk.SetCardinality(chunk);
+
+	if (!column_index_map.empty()) {
+		// columns specified by the user, use column_index_map
+		for (idx_t i = 0; i < table->columns.size(); i++) {
+			auto &col = table->columns[i];
+			if (col.Generated()) {
+				continue;
+			}
+			auto storage_idx = col.StorageOid();
+			if (column_index_map[i] == DConstants::INVALID_INDEX) {
+				// insert default value
+				istate.default_executor.ExecuteExpression(i, istate.insert_chunk.data[storage_idx]);
+			} else {
+				// get value from child chunk
+				D_ASSERT((idx_t)column_index_map[i] < chunk.ColumnCount());
+				D_ASSERT(istate.insert_chunk.data[storage_idx].GetType() == chunk.data[column_index_map[i]].GetType());
+				istate.insert_chunk.data[storage_idx].Reference(chunk.data[column_index_map[i]]);
+			}
+		}
+	} else {
+		// no columns specified, just append directly
+		for (idx_t i = 0; i < istate.insert_chunk.ColumnCount(); i++) {
+			D_ASSERT(istate.insert_chunk.data[i].GetType() == chunk.data[i].GetType());
+			istate.insert_chunk.data[i].Reference(chunk.data[i]);
+		}
+	}
+
+	lock_guard<mutex> glock(gstate.lock);
+	table->storage->Append(*table, context.client, istate.insert_chunk);
+
+	if (return_chunk) {
+		gstate.return_chunk_collection.Append(istate.insert_chunk);
+	}
+
+	gstate.insert_count += chunk.size();
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+unique_ptr<GlobalSinkState> PhysicalInsert::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<InsertGlobalState>();
+}
+
+unique_ptr<LocalSinkState> PhysicalInsert::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<InsertLocalState>(table->GetTypes(), bound_defaults);
+}
+
+void PhysicalInsert::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+	auto &state = (InsertLocalState &)lstate;
+	auto &client_profiler = QueryProfiler::Get(context.client);
+	context.thread.profiler.Flush(this, &state.default_executor, "default_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class InsertSourceState : public GlobalSourceState {
+public:
+	InsertSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalInsert::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<InsertSourceState>();
+}
+
+void PhysicalInsert::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	auto &state = (InsertSourceState &)gstate;
+	auto &insert_gstate = (InsertGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+	if (!return_chunk) {
+		chunk.SetCardinality(1);
+		chunk.SetValue(0, 0, Value::BIGINT(insert_gstate.insert_count));
+		state.finished = true;
+	}
+
+	idx_t chunk_return = insert_gstate.returned_chunk_count;
+	if (chunk_return >= insert_gstate.return_chunk_collection.Chunks().size()) {
+		return;
+	}
+
+	chunk.Reference(insert_gstate.return_chunk_collection.GetChunk(chunk_return));
+	chunk.SetCardinality((insert_gstate.return_chunk_collection.GetChunk(chunk_return)).size());
+	insert_gstate.returned_chunk_count += 1;
+	if (insert_gstate.returned_chunk_count >= insert_gstate.return_chunk_collection.Chunks().size()) {
+		state.finished = true;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class UpdateGlobalState : public GlobalSinkState {
+public:
+	UpdateGlobalState() : updated_count(0), returned_chunk_count(0) {
+	}
+
+	mutex lock;
+	idx_t updated_count;
+	unordered_set<row_t> updated_columns;
+	ChunkCollection return_chunk_collection;
+	idx_t returned_chunk_count;
+};
+
+class UpdateLocalState : public LocalSinkState {
+public:
+	UpdateLocalState(const vector<unique_ptr<Expression>> &expressions, const vector<LogicalType> &table_types,
+	                 const vector<unique_ptr<Expression>> &bound_defaults)
+	    : default_executor(bound_defaults) {
+		// initialize the update chunk
+		vector<LogicalType> update_types;
+		update_types.reserve(expressions.size());
+		for (auto &expr : expressions) {
+			update_types.push_back(expr->return_type);
+		}
+		update_chunk.Initialize(update_types);
+		// initialize the mock chunk
+		mock_chunk.Initialize(table_types);
+	}
+
+	DataChunk update_chunk;
+	DataChunk mock_chunk;
+	ExpressionExecutor default_executor;
+};
+
+SinkResultType PhysicalUpdate::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                    DataChunk &chunk) const {
+	auto &gstate = (UpdateGlobalState &)state;
+	auto &ustate = (UpdateLocalState &)lstate;
+
+	DataChunk &update_chunk = ustate.update_chunk;
+	DataChunk &mock_chunk = ustate.mock_chunk;
+
+	chunk.Normalify();
+	ustate.default_executor.SetChunk(chunk);
+
+	// update data in the base table
+	// the row ids are given to us as the last column of the child chunk
+	auto &row_ids = chunk.data[chunk.ColumnCount() - 1];
+	update_chunk.SetCardinality(chunk);
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		if (expressions[i]->type == ExpressionType::VALUE_DEFAULT) {
+			// default expression, set to the default value of the column
+			ustate.default_executor.ExecuteExpression(columns[i], update_chunk.data[i]);
+		} else {
+			D_ASSERT(expressions[i]->type == ExpressionType::BOUND_REF);
+			// index into child chunk
+			auto &binding = (BoundReferenceExpression &)*expressions[i];
+			update_chunk.data[i].Reference(chunk.data[binding.index]);
+		}
+	}
+
+	lock_guard<mutex> glock(gstate.lock);
+	if (update_is_del_and_insert) {
+		// index update or update on complex type, perform a delete and an append instead
+
+		// figure out which rows have not yet been deleted in this update
+		// this is required since we might see the same row_id multiple times
+		// in the case of an UPDATE query that e.g. has joins
+		auto row_id_data = FlatVector::GetData<row_t>(row_ids);
+		SelectionVector sel(STANDARD_VECTOR_SIZE);
+		idx_t update_count = 0;
+		for (idx_t i = 0; i < update_chunk.size(); i++) {
+			auto row_id = row_id_data[i];
+			if (gstate.updated_columns.find(row_id) == gstate.updated_columns.end()) {
+				gstate.updated_columns.insert(row_id);
+				sel.set_index(update_count++, i);
+			}
+		}
+		if (update_count != update_chunk.size()) {
+			// we need to slice here
+			update_chunk.Slice(sel, update_count);
+		}
+		table.Delete(tableref, context.client, row_ids, update_chunk.size());
+		// for the append we need to arrange the columns in a specific manner (namely the "standard table order")
+		mock_chunk.SetCardinality(update_chunk);
+		for (idx_t i = 0; i < columns.size(); i++) {
+			mock_chunk.data[columns[i]].Reference(update_chunk.data[i]);
+		}
+		table.Append(tableref, context.client, mock_chunk);
+	} else {
+		if (return_chunk) {
+			mock_chunk.SetCardinality(update_chunk);
+			for (idx_t i = 0; i < columns.size(); i++) {
+				mock_chunk.data[columns[i]].Reference(update_chunk.data[i]);
+			}
+		}
+		table.Update(tableref, context.client, row_ids, columns, update_chunk);
+	}
+
+	if (return_chunk) {
+		gstate.return_chunk_collection.Append(mock_chunk);
+	}
+
+	gstate.updated_count += chunk.size();
+
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+unique_ptr<GlobalSinkState> PhysicalUpdate::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<UpdateGlobalState>();
+}
+
+unique_ptr<LocalSinkState> PhysicalUpdate::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<UpdateLocalState>(expressions, table.GetTypes(), bound_defaults);
+}
+
+void PhysicalUpdate::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+	auto &state = (UpdateLocalState &)lstate;
+	auto &client_profiler = QueryProfiler::Get(context.client);
+	context.thread.profiler.Flush(this, &state.default_executor, "default_executor", 1);
+	client_profiler.Flush(context.thread.profiler);
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class UpdateSourceState : public GlobalSourceState {
+public:
+	UpdateSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalUpdate::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<UpdateSourceState>();
+}
+
+void PhysicalUpdate::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                             LocalSourceState &lstate) const {
+	auto &state = (UpdateSourceState &)gstate;
+	auto &g = (UpdateGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+	if (!return_chunk) {
+		chunk.SetCardinality(1);
+		chunk.SetValue(0, 0, Value::BIGINT(g.updated_count));
+		state.finished = true;
+	}
+
+	idx_t chunk_return = g.returned_chunk_count;
+	if (chunk_return >= g.return_chunk_collection.Chunks().size()) {
+		return;
+	}
+	chunk.Reference(g.return_chunk_collection.GetChunk(chunk_return));
+	chunk.SetCardinality((g.return_chunk_collection.GetChunk(chunk_return)).size());
+	g.returned_chunk_count += 1;
+	if (g.returned_chunk_count >= g.return_chunk_collection.Chunks().size()) {
+		state.finished = true;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+class ProjectionState : public OperatorState {
+public:
+	explicit ProjectionState(const vector<unique_ptr<Expression>> &expressions) : executor(expressions) {
+	}
+
+	ExpressionExecutor executor;
+
+public:
+	void Finalize(PhysicalOperator *op, ExecutionContext &context) override {
+		context.thread.profiler.Flush(op, &executor, "projection", 0);
+	}
+};
+
+PhysicalProjection::PhysicalProjection(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                                       idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::PROJECTION, move(types), estimated_cardinality),
+      select_list(move(select_list)) {
+}
+
+OperatorResultType PhysicalProjection::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                               GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (ProjectionState &)state_p;
+	state.executor.Execute(input, chunk);
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+unique_ptr<OperatorState> PhysicalProjection::GetOperatorState(ClientContext &context) const {
+	return make_unique<ProjectionState>(select_list);
+}
+
+string PhysicalProjection::ParamsToString() const {
+	string extra_info;
+	for (auto &expr : select_list) {
+		extra_info += expr->GetName() + "\n";
+	}
+	return extra_info;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+class TableInOutLocalState : public OperatorState {
+public:
+	TableInOutLocalState() {
+	}
+
+	unique_ptr<LocalTableFunctionState> local_state;
+};
+
+class TableInOutGlobalState : public GlobalOperatorState {
+public:
+	TableInOutGlobalState() {
+	}
+
+	unique_ptr<GlobalTableFunctionState> global_state;
+};
+
+PhysicalTableInOutFunction::PhysicalTableInOutFunction(vector<LogicalType> types, TableFunction function_p,
+                                                       unique_ptr<FunctionData> bind_data_p,
+                                                       vector<column_t> column_ids_p, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::INOUT_FUNCTION, move(types), estimated_cardinality),
+      function(move(function_p)), bind_data(move(bind_data_p)), column_ids(move(column_ids_p)) {
+}
+
+unique_ptr<OperatorState> PhysicalTableInOutFunction::GetOperatorState(ClientContext &context) const {
+	auto result = make_unique<TableInOutLocalState>();
+	if (function.init_local) {
+		TableFunctionInitInput input(bind_data.get(), column_ids, nullptr);
+		result->local_state = function.init_local(context, input, nullptr);
+	}
+	return move(result);
+}
+
+unique_ptr<GlobalOperatorState> PhysicalTableInOutFunction::GetGlobalOperatorState(ClientContext &context) const {
+	auto result = make_unique<TableInOutGlobalState>();
+	if (function.init_global) {
+		TableFunctionInitInput input(bind_data.get(), column_ids, nullptr);
+		result->global_state = function.init_global(context, input);
+	}
+	return move(result);
+}
+
+OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                       GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	auto &gstate = (TableInOutGlobalState &)gstate_p;
+	auto &state = (TableInOutLocalState &)state_p;
+	TableFunctionInput data(bind_data.get(), state.local_state.get(), gstate.global_state.get());
+	return function.in_out_function(context.client, data, input, chunk);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class UnnestOperatorState : public OperatorState {
+public:
+	UnnestOperatorState() : parent_position(0), list_position(0), list_length(-1), first_fetch(true) {
+	}
+
+	idx_t parent_position;
+	idx_t list_position;
+	int64_t list_length;
+	bool first_fetch;
+
+	DataChunk list_data;
+	vector<VectorData> list_vector_data;
+	vector<VectorData> list_child_data;
+};
+
+// this implements a sorted window functions variant
+PhysicalUnnest::PhysicalUnnest(vector<LogicalType> types, vector<unique_ptr<Expression>> select_list,
+                               idx_t estimated_cardinality, PhysicalOperatorType type)
+    : PhysicalOperator(type, move(types), estimated_cardinality), select_list(std::move(select_list)) {
+	D_ASSERT(!this->select_list.empty());
+}
+
+static void UnnestNull(idx_t start, idx_t end, Vector &result) {
+	if (result.GetType().InternalType() == PhysicalType::STRUCT) {
+		auto &children = StructVector::GetEntries(result);
+		for (auto &child : children) {
+			UnnestNull(start, end, *child);
+		}
+	}
+	auto &validity = FlatVector::Validity(result);
+	for (idx_t i = start; i < end; i++) {
+		validity.SetInvalid(i);
+	}
+	if (result.GetType().InternalType() == PhysicalType::STRUCT) {
+		auto &struct_children = StructVector::GetEntries(result);
+		for (auto &child : struct_children) {
+			UnnestNull(start, end, *child);
+		}
+	}
+}
+
+template <class T>
+static void TemplatedUnnest(VectorData &vdata, idx_t start, idx_t end, Vector &result) {
+	auto source_data = (T *)vdata.data;
+	auto &source_mask = vdata.validity;
+	auto result_data = FlatVector::GetData<T>(result);
+	auto &result_mask = FlatVector::Validity(result);
+
+	for (idx_t i = start; i < end; i++) {
+		auto source_idx = vdata.sel->get_index(i);
+		auto target_idx = i - start;
+		if (source_mask.RowIsValid(source_idx)) {
+			result_data[target_idx] = source_data[source_idx];
+			result_mask.SetValid(target_idx);
+		} else {
+			result_mask.SetInvalid(target_idx);
+		}
+	}
+}
+
+static void UnnestValidity(VectorData &vdata, idx_t start, idx_t end, Vector &result) {
+	auto &source_mask = vdata.validity;
+	auto &result_mask = FlatVector::Validity(result);
+
+	for (idx_t i = start; i < end; i++) {
+		auto source_idx = vdata.sel->get_index(i);
+		auto target_idx = i - start;
+		result_mask.Set(target_idx, source_mask.RowIsValid(source_idx));
+	}
+}
+
+static void UnnestVector(VectorData &vdata, Vector &source, idx_t list_size, idx_t start, idx_t end, Vector &result) {
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedUnnest<int8_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::INT16:
+		TemplatedUnnest<int16_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::INT32:
+		TemplatedUnnest<int32_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::INT64:
+		TemplatedUnnest<int64_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::INT128:
+		TemplatedUnnest<hugeint_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedUnnest<uint8_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedUnnest<uint16_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedUnnest<uint32_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedUnnest<uint64_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedUnnest<float>(vdata, start, end, result);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedUnnest<double>(vdata, start, end, result);
+		break;
+	case PhysicalType::INTERVAL:
+		TemplatedUnnest<interval_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedUnnest<string_t>(vdata, start, end, result);
+		break;
+	case PhysicalType::LIST: {
+		auto &target = ListVector::GetEntry(result);
+		target.Reference(ListVector::GetEntry(source));
+		ListVector::SetListSize(result, ListVector::GetListSize(source));
+		TemplatedUnnest<list_entry_t>(vdata, start, end, result);
+		break;
+	}
+	case PhysicalType::STRUCT: {
+		auto &source_entries = StructVector::GetEntries(source);
+		auto &target_entries = StructVector::GetEntries(result);
+		UnnestValidity(vdata, start, end, result);
+		for (idx_t i = 0; i < source_entries.size(); i++) {
+			VectorData sdata;
+			source_entries[i]->Orrify(list_size, sdata);
+			UnnestVector(sdata, *source_entries[i], list_size, start, end, *target_entries[i]);
+		}
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented type for UNNEST");
+	}
+}
+
+unique_ptr<OperatorState> PhysicalUnnest::GetOperatorState(ClientContext &context) const {
+	return PhysicalUnnest::GetState(context);
+}
+
+unique_ptr<OperatorState> PhysicalUnnest::GetState(ClientContext &context) {
+	return make_unique<UnnestOperatorState>();
+}
+
+OperatorResultType PhysicalUnnest::ExecuteInternal(ClientContext &context, DataChunk &input, DataChunk &chunk,
+                                                   OperatorState &state_p,
+                                                   const vector<unique_ptr<Expression>> &select_list,
+                                                   bool include_input) {
+	auto &state = (UnnestOperatorState &)state_p;
+	do {
+		if (state.first_fetch) {
+			// get the list data to unnest
+			ExpressionExecutor executor;
+			vector<LogicalType> list_data_types;
+			for (auto &exp : select_list) {
+				D_ASSERT(exp->type == ExpressionType::BOUND_UNNEST);
+				auto bue = (BoundUnnestExpression *)exp.get();
+				list_data_types.push_back(bue->child->return_type);
+				executor.AddExpression(*bue->child.get());
+			}
+			state.list_data.Destroy();
+			state.list_data.Initialize(list_data_types);
+			executor.Execute(input, state.list_data);
+
+			// paranoia aplenty
+			state.list_data.Verify();
+			D_ASSERT(input.size() == state.list_data.size());
+			D_ASSERT(state.list_data.ColumnCount() == select_list.size());
+
+			// initialize VectorData object so the nullmask can accessed
+			state.list_vector_data.resize(state.list_data.ColumnCount());
+			state.list_child_data.resize(state.list_data.ColumnCount());
+			for (idx_t col_idx = 0; col_idx < state.list_data.ColumnCount(); col_idx++) {
+				auto &list_vector = state.list_data.data[col_idx];
+				list_vector.Orrify(state.list_data.size(), state.list_vector_data[col_idx]);
+
+				if (list_vector.GetType() == LogicalType::SQLNULL) {
+					// UNNEST(NULL)
+					auto &child_vector = list_vector;
+					child_vector.Orrify(0, state.list_child_data[col_idx]);
+				} else {
+					auto list_size = ListVector::GetListSize(list_vector);
+					auto &child_vector = ListVector::GetEntry(list_vector);
+					child_vector.Orrify(list_size, state.list_child_data[col_idx]);
+				}
+			}
+			state.first_fetch = false;
+		}
+		if (state.parent_position >= input.size()) {
+			// finished with this input chunk
+			state.parent_position = 0;
+			state.list_position = 0;
+			state.list_length = -1;
+			state.first_fetch = true;
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+
+		// need to figure out how many times we need to repeat for current row
+		if (state.list_length < 0) {
+			for (idx_t col_idx = 0; col_idx < state.list_data.ColumnCount(); col_idx++) {
+				auto &vdata = state.list_vector_data[col_idx];
+				auto current_idx = vdata.sel->get_index(state.parent_position);
+
+				int64_t list_length;
+				// deal with NULL values
+				if (!vdata.validity.RowIsValid(current_idx)) {
+					list_length = 0;
+				} else {
+					auto list_data = (list_entry_t *)vdata.data;
+					auto list_entry = list_data[current_idx];
+					list_length = (int64_t)list_entry.length;
+				}
+
+				if (list_length > state.list_length) {
+					state.list_length = list_length;
+				}
+			}
+		}
+
+		D_ASSERT(state.list_length >= 0);
+
+		auto this_chunk_len = MinValue<idx_t>(STANDARD_VECTOR_SIZE, state.list_length - state.list_position);
+
+		// first cols are from child, last n cols from unnest
+		chunk.SetCardinality(this_chunk_len);
+
+		idx_t output_offset = 0;
+		if (include_input) {
+			for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
+				ConstantVector::Reference(chunk.data[col_idx], input.data[col_idx], state.parent_position,
+				                          input.size());
+			}
+			output_offset = input.ColumnCount();
+		}
+
+		for (idx_t col_idx = 0; col_idx < state.list_data.ColumnCount(); col_idx++) {
+			auto &result_vector = chunk.data[col_idx + output_offset];
+
+			if (state.list_data.data[col_idx].GetType() == LogicalType::SQLNULL) {
+				// UNNEST(NULL)
+				chunk.SetCardinality(0);
+			} else {
+				auto &vdata = state.list_vector_data[col_idx];
+				auto &child_data = state.list_child_data[col_idx];
+				auto current_idx = vdata.sel->get_index(state.parent_position);
+
+				auto list_data = (list_entry_t *)vdata.data;
+				auto list_entry = list_data[current_idx];
+
+				idx_t list_count;
+				if (state.list_position >= list_entry.length) {
+					list_count = 0;
+				} else {
+					list_count = MinValue<idx_t>(this_chunk_len, list_entry.length - state.list_position);
+				}
+
+				if (list_entry.length > state.list_position) {
+					if (!vdata.validity.RowIsValid(current_idx)) {
+						UnnestNull(0, list_count, result_vector);
+					} else {
+						auto &list_vector = state.list_data.data[col_idx];
+						auto &child_vector = ListVector::GetEntry(list_vector);
+						auto list_size = ListVector::GetListSize(list_vector);
+
+						auto base_offset = list_entry.offset + state.list_position;
+						UnnestVector(child_data, child_vector, list_size, base_offset, base_offset + list_count,
+						             result_vector);
+					}
+				}
+
+				UnnestNull(list_count, this_chunk_len, result_vector);
+			}
+		}
+
+		state.list_position += this_chunk_len;
+		if ((int64_t)state.list_position == state.list_length) {
+			state.parent_position++;
+			state.list_length = -1;
+			state.list_position = 0;
+		}
+
+		chunk.Verify();
+	} while (chunk.size() == 0);
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+OperatorResultType PhysicalUnnest::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                           GlobalOperatorState &gstate, OperatorState &state) const {
+	return ExecuteInternal(context.client, input, chunk, state, select_list);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+class PhysicalChunkScanState : public GlobalSourceState {
+public:
+	explicit PhysicalChunkScanState() : chunk_index(0) {
+	}
+
+	//! The current position in the scan
+	idx_t chunk_index;
+};
+
+unique_ptr<GlobalSourceState> PhysicalChunkScan::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<PhysicalChunkScanState>();
+}
+
+void PhysicalChunkScan::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                LocalSourceState &lstate) const {
+	auto &state = (PhysicalChunkScanState &)gstate;
+	D_ASSERT(collection);
+	if (collection->Count() == 0) {
+		return;
+	}
+	D_ASSERT(chunk.GetTypes() == collection->Types());
+	if (state.chunk_index >= collection->ChunkCount()) {
+		return;
+	}
+	auto &collection_chunk = collection->GetChunk(state.chunk_index);
+	chunk.Reference(collection_chunk);
+	state.chunk_index++;
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalChunkScan::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	// check if there is any additional action we need to do depending on the type
+	switch (type) {
+	case PhysicalOperatorType::DELIM_SCAN: {
+		auto entry = state.delim_join_dependencies.find(this);
+		D_ASSERT(entry != state.delim_join_dependencies.end());
+		// this chunk scan introduces a dependency to the current pipeline
+		// namely a dependency on the duplicate elimination pipeline to finish
+		auto delim_dependency = entry->second->shared_from_this();
+		auto delim_sink = state.GetPipelineSink(*delim_dependency);
+		D_ASSERT(delim_sink);
+		D_ASSERT(delim_sink->type == PhysicalOperatorType::DELIM_JOIN);
+		auto &delim_join = (PhysicalDelimJoin &)*delim_sink;
+		current.AddDependency(delim_dependency);
+		state.SetPipelineSource(current, (PhysicalOperator *)delim_join.distinct.get());
+		return;
+	}
+	case PhysicalOperatorType::RECURSIVE_CTE_SCAN:
+		if (!state.recursive_cte) {
+			throw InternalException("Recursive CTE scan found without recursive CTE node");
+		}
+		break;
+	default:
+		break;
+	}
+	D_ASSERT(children.empty());
+	state.SetPipelineSource(current, this);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+class DummyScanState : public GlobalSourceState {
+public:
+	DummyScanState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalDummyScan::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<DummyScanState>();
+}
+
+void PhysicalDummyScan::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                LocalSourceState &lstate) const {
+	auto &state = (DummyScanState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	// return a single row on the first call to the dummy scan
+	chunk.SetCardinality(1);
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void PhysicalEmptyResult::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                  LocalSourceState &lstate) const {
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+class ExpressionScanState : public OperatorState {
+public:
+	explicit ExpressionScanState(const PhysicalExpressionScan &op) : expression_index(0) {
+		temp_chunk.Initialize(op.GetTypes());
+	}
+
+	//! The current position in the scan
+	idx_t expression_index;
+	//! Temporary chunk for evaluating expressions
+	DataChunk temp_chunk;
+};
+
+unique_ptr<OperatorState> PhysicalExpressionScan::GetOperatorState(ClientContext &context) const {
+	return make_unique<ExpressionScanState>(*this);
+}
+
+OperatorResultType PhysicalExpressionScan::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                                   GlobalOperatorState &gstate, OperatorState &state_p) const {
+	auto &state = (ExpressionScanState &)state_p;
+
+	for (; chunk.size() + input.size() <= STANDARD_VECTOR_SIZE && state.expression_index < expressions.size();
+	     state.expression_index++) {
+		state.temp_chunk.Reset();
+		EvaluateExpression(state.expression_index, &input, state.temp_chunk);
+		chunk.Append(state.temp_chunk);
+	}
+	if (state.expression_index < expressions.size()) {
+		return OperatorResultType::HAVE_MORE_OUTPUT;
+	} else {
+		state.expression_index = 0;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+}
+
+void PhysicalExpressionScan::EvaluateExpression(idx_t expression_idx, DataChunk *child_chunk, DataChunk &result) const {
+	ExpressionExecutor executor(expressions[expression_idx]);
+	if (child_chunk) {
+		child_chunk->Verify();
+		executor.Execute(*child_chunk, result);
+	} else {
+		executor.Execute(result);
+	}
+}
+
+bool PhysicalExpressionScan::IsFoldable() const {
+	for (auto &expr_list : expressions) {
+		for (auto &expr : expr_list) {
+			if (!expr->IsFoldable()) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <utility>
+
+namespace duckdb {
+
+PhysicalTableScan::PhysicalTableScan(vector<LogicalType> types, TableFunction function_p,
+                                     unique_ptr<FunctionData> bind_data_p, vector<column_t> column_ids_p,
+                                     vector<string> names_p, unique_ptr<TableFilterSet> table_filters_p,
+                                     idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::TABLE_SCAN, move(types), estimated_cardinality),
+      function(move(function_p)), bind_data(move(bind_data_p)), column_ids(move(column_ids_p)), names(move(names_p)),
+      table_filters(move(table_filters_p)) {
+}
+
+class TableScanGlobalSourceState : public GlobalSourceState {
+public:
+	TableScanGlobalSourceState(ClientContext &context, const PhysicalTableScan &op) {
+		if (op.function.init_global) {
+			TableFunctionInitInput input(op.bind_data.get(), op.column_ids, op.table_filters.get());
+			global_state = op.function.init_global(context, input);
+			if (global_state) {
+				max_threads = global_state->MaxThreads();
+			}
+		} else {
+			max_threads = 1;
+		}
+	}
+
+	idx_t max_threads = 0;
+	unique_ptr<GlobalTableFunctionState> global_state;
+
+	idx_t MaxThreads() override {
+		return max_threads;
+	}
+};
+
+class TableScanLocalSourceState : public LocalSourceState {
+public:
+	TableScanLocalSourceState(ExecutionContext &context, TableScanGlobalSourceState &gstate,
+	                          const PhysicalTableScan &op) {
+		if (op.function.init_local) {
+			TableFunctionInitInput input(op.bind_data.get(), op.column_ids, op.table_filters.get());
+			local_state = op.function.init_local(context.client, input, gstate.global_state.get());
+		}
+	}
+
+	unique_ptr<LocalTableFunctionState> local_state;
+};
+
+unique_ptr<LocalSourceState> PhysicalTableScan::GetLocalSourceState(ExecutionContext &context,
+                                                                    GlobalSourceState &gstate) const {
+	return make_unique<TableScanLocalSourceState>(context, (TableScanGlobalSourceState &)gstate, *this);
+}
+
+unique_ptr<GlobalSourceState> PhysicalTableScan::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<TableScanGlobalSourceState>(context, *this);
+}
+
+void PhysicalTableScan::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                LocalSourceState &lstate) const {
+	D_ASSERT(!column_ids.empty());
+	auto &gstate = (TableScanGlobalSourceState &)gstate_p;
+	auto &state = (TableScanLocalSourceState &)lstate;
+
+	TableFunctionInput data(bind_data.get(), state.local_state.get(), gstate.global_state.get());
+	function.function(context.client, data, chunk);
+}
+
+double PhysicalTableScan::GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const {
+	auto &gstate = (TableScanGlobalSourceState &)gstate_p;
+	if (function.table_scan_progress) {
+		return function.table_scan_progress(context, bind_data.get(), gstate.global_state.get());
+	}
+	// if table_scan_progress is not implemented we don't support this function yet in the progress bar
+	return -1;
+}
+
+idx_t PhysicalTableScan::GetBatchIndex(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                       LocalSourceState &lstate) const {
+	D_ASSERT(SupportsBatchIndex());
+	D_ASSERT(function.get_batch_index);
+	auto &gstate = (TableScanGlobalSourceState &)gstate_p;
+	auto &state = (TableScanLocalSourceState &)lstate;
+	return function.get_batch_index(context.client, bind_data.get(), state.local_state.get(),
+	                                gstate.global_state.get());
+}
+
+string PhysicalTableScan::GetName() const {
+	return StringUtil::Upper(function.name);
+}
+
+string PhysicalTableScan::ParamsToString() const {
+	string result;
+	if (function.to_string) {
+		result = function.to_string(bind_data.get());
+		result += "\n[INFOSEPARATOR]\n";
+	}
+	if (function.projection_pushdown) {
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			if (column_ids[i] < names.size()) {
+				if (i > 0) {
+					result += "\n";
+				}
+				result += names[column_ids[i]];
+			}
+		}
+	}
+	if (function.filter_pushdown && table_filters) {
+		result += "\n[INFOSEPARATOR]\n";
+		result += "Filters: ";
+		for (auto &f : table_filters->filters) {
+			auto &column_index = f.first;
+			auto &filter = f.second;
+			if (column_index < names.size()) {
+				result += filter->ToString(names[column_ids[column_index]]);
+				result += "\n";
+			}
+		}
+	}
+	return result;
+}
+
+bool PhysicalTableScan::Equals(const PhysicalOperator &other_p) const {
+	if (type != other_p.type) {
+		return false;
+	}
+	auto &other = (PhysicalTableScan &)other_p;
+	if (function.function != other.function.function) {
+		return false;
+	}
+	if (column_ids != other.column_ids) {
+		return false;
+	}
+	if (!FunctionData::Equals(bind_data.get(), other.bind_data.get())) {
+		return false;
+	}
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class AlterSourceState : public GlobalSourceState {
+public:
+	AlterSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalAlter::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<AlterSourceState>();
+}
+
+void PhysicalAlter::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                            LocalSourceState &lstate) const {
+	auto &state = (AlterSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	auto &catalog = Catalog::GetCatalog(context.client);
+	catalog.Alter(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateFunctionSourceState : public GlobalSourceState {
+public:
+	CreateFunctionSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateFunction::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateFunctionSourceState>();
+}
+
+void PhysicalCreateFunction::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                     LocalSourceState &lstate) const {
+	auto &state = (CreateFunctionSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	Catalog::GetCatalog(context.client).CreateFunction(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateIndexSourceState : public GlobalSourceState {
+public:
+	CreateIndexSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateIndex::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateIndexSourceState>();
+}
+
+void PhysicalCreateIndex::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                  LocalSourceState &lstate) const {
+	auto &state = (CreateIndexSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	if (column_ids.empty()) {
+		throw BinderException("CREATE INDEX does not refer to any columns in the base table!");
+	}
+
+	auto &schema = *table.schema;
+	auto index_entry = (IndexCatalogEntry *)schema.CreateIndex(context.client, info.get(), &table);
+	if (!index_entry) {
+		// index already exists, but error ignored because of IF NOT EXISTS
+		return;
+	}
+
+	unique_ptr<Index> index;
+	switch (info->index_type) {
+	case IndexType::ART: {
+		index = make_unique<ART>(column_ids, unbound_expressions,
+		                         info->unique ? IndexConstraintType::UNIQUE : IndexConstraintType::NONE);
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented index type");
+	}
+	index_entry->index = index.get();
+	index_entry->info = table.storage->info;
+	table.storage->AddIndex(move(index), expressions);
+
+	chunk.SetCardinality(0);
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateSchemaSourceState : public GlobalSourceState {
+public:
+	CreateSchemaSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateSchema::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateSchemaSourceState>();
+}
+
+void PhysicalCreateSchema::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                   LocalSourceState &lstate) const {
+	auto &state = (CreateSchemaSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	Catalog::GetCatalog(context.client).CreateSchema(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateSequenceSourceState : public GlobalSourceState {
+public:
+	CreateSequenceSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateSequence::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateSequenceSourceState>();
+}
+
+void PhysicalCreateSequence::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                     LocalSourceState &lstate) const {
+	auto &state = (CreateSequenceSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	Catalog::GetCatalog(context.client).CreateSequence(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalCreateTable::PhysicalCreateTable(LogicalOperator &op, SchemaCatalogEntry *schema,
+                                         unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::CREATE_TABLE, op.types, estimated_cardinality), schema(schema),
+      info(move(info)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateTableSourceState : public GlobalSourceState {
+public:
+	CreateTableSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateTable::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateTableSourceState>();
+}
+
+void PhysicalCreateTable::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                  LocalSourceState &lstate) const {
+	auto &state = (CreateTableSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	auto &catalog = Catalog::GetCatalog(context.client);
+	catalog.CreateTable(context.client, schema, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalCreateTableAs::PhysicalCreateTableAs(LogicalOperator &op, SchemaCatalogEntry *schema,
+                                             unique_ptr<BoundCreateTableInfo> info, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::CREATE_TABLE_AS, op.types, estimated_cardinality), schema(schema),
+      info(move(info)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class CreateTableAsGlobalState : public GlobalSinkState {
+public:
+	CreateTableAsGlobalState() {
+		inserted_count = 0;
+	}
+
+	mutex append_lock;
+	TableCatalogEntry *table;
+	int64_t inserted_count;
+};
+
+unique_ptr<GlobalSinkState> PhysicalCreateTableAs::GetGlobalSinkState(ClientContext &context) const {
+	auto sink = make_unique<CreateTableAsGlobalState>();
+	auto &catalog = Catalog::GetCatalog(context);
+	sink->table = (TableCatalogEntry *)catalog.CreateTable(context, schema, info.get());
+	return move(sink);
+}
+
+SinkResultType PhysicalCreateTableAs::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate_p,
+                                           DataChunk &input) const {
+	auto &sink = (CreateTableAsGlobalState &)state;
+	if (sink.table) {
+		lock_guard<mutex> client_guard(sink.append_lock);
+		sink.table->storage->Append(*sink.table, context.client, input);
+		sink.inserted_count += input.size();
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateTableAsSourceState : public GlobalSourceState {
+public:
+	CreateTableAsSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateTableAs::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateTableAsSourceState>();
+}
+
+void PhysicalCreateTableAs::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                    LocalSourceState &lstate) const {
+	auto &state = (CreateTableAsSourceState &)gstate;
+	auto &sink = (CreateTableAsGlobalState &)*sink_state;
+	if (state.finished) {
+		return;
+	}
+	if (sink.table) {
+		chunk.SetCardinality(1);
+		chunk.SetValue(0, 0, Value::BIGINT(sink.inserted_count));
+	}
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PhysicalCreateType::PhysicalCreateType(unique_ptr<CreateTypeInfo> info, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::CREATE_TYPE, {LogicalType::BIGINT}, estimated_cardinality),
+      info(move(info)) {
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateTypeSourceState : public GlobalSourceState {
+public:
+	CreateTypeSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateType::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateTypeSourceState>();
+}
+
+void PhysicalCreateType::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                 LocalSourceState &lstate) const {
+	auto &state = (CreateTypeSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	auto &catalog = Catalog::GetCatalog(context.client);
+	catalog.CreateType(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class CreateViewSourceState : public GlobalSourceState {
+public:
+	CreateViewSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalCreateView::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<CreateViewSourceState>();
+}
+
+void PhysicalCreateView::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                 LocalSourceState &lstate) const {
+	auto &state = (CreateViewSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	Catalog::GetCatalog(context.client).CreateView(context.client, info.get());
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class DropSourceState : public GlobalSourceState {
+public:
+	DropSourceState() : finished(false) {
+	}
+
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> PhysicalDrop::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<DropSourceState>();
+}
+
+void PhysicalDrop::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                           LocalSourceState &lstate) const {
+	auto &state = (DropSourceState &)gstate;
+	if (state.finished) {
+		return;
+	}
+	switch (info->type) {
+	case CatalogType::PREPARED_STATEMENT: {
+		// DEALLOCATE silently ignores errors
+		auto &statements = ClientData::Get(context.client).prepared_statements;
+		if (statements.find(info->name) != statements.end()) {
+			statements.erase(info->name);
+		}
+		break;
+	}
+	default:
+		Catalog::GetCatalog(context.client).DropEntry(context.client, info.get());
+		break;
+	}
+	state.finished = true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PhysicalRecursiveCTE::PhysicalRecursiveCTE(vector<LogicalType> types, bool union_all, unique_ptr<PhysicalOperator> top,
+                                           unique_ptr<PhysicalOperator> bottom, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::RECURSIVE_CTE, move(types), estimated_cardinality), union_all(union_all) {
+	children.push_back(move(top));
+	children.push_back(move(bottom));
+}
+
+PhysicalRecursiveCTE::~PhysicalRecursiveCTE() {
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class RecursiveCTEState : public GlobalSinkState {
+public:
+	explicit RecursiveCTEState(ClientContext &context, const PhysicalRecursiveCTE &op)
+	    : new_groups(STANDARD_VECTOR_SIZE) {
+		ht = make_unique<GroupedAggregateHashTable>(BufferManager::GetBufferManager(context), op.types,
+		                                            vector<LogicalType>(), vector<BoundAggregateExpression *>());
+	}
+
+	unique_ptr<GroupedAggregateHashTable> ht;
+
+	bool intermediate_empty = true;
+	ChunkCollection intermediate_table;
+	idx_t chunk_idx = 0;
+	SelectionVector new_groups;
+};
+
+unique_ptr<GlobalSinkState> PhysicalRecursiveCTE::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<RecursiveCTEState>(context, *this);
+}
+
+idx_t PhysicalRecursiveCTE::ProbeHT(DataChunk &chunk, RecursiveCTEState &state) const {
+	Vector dummy_addresses(LogicalType::POINTER);
+
+	// Use the HT to eliminate duplicate rows
+	idx_t new_group_count = state.ht->FindOrCreateGroups(chunk, dummy_addresses, state.new_groups);
+
+	// we only return entries we have not seen before (i.e. new groups)
+	chunk.Slice(state.new_groups, new_group_count);
+
+	return new_group_count;
+}
+
+SinkResultType PhysicalRecursiveCTE::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                          DataChunk &input) const {
+	auto &gstate = (RecursiveCTEState &)state;
+	if (!union_all) {
+		idx_t match_count = ProbeHT(input, gstate);
+		if (match_count > 0) {
+			gstate.intermediate_table.Append(input);
+		}
+	} else {
+		gstate.intermediate_table.Append(input);
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+void PhysicalRecursiveCTE::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate_p,
+                                   LocalSourceState &lstate) const {
+	auto &gstate = (RecursiveCTEState &)*sink_state;
+	while (chunk.size() == 0) {
+		if (gstate.chunk_idx < gstate.intermediate_table.ChunkCount()) {
+			// scan any chunks we have collected so far
+			chunk.Reference(gstate.intermediate_table.GetChunk(gstate.chunk_idx));
+			gstate.chunk_idx++;
+			break;
+		} else {
+			// we have run out of chunks
+			// now we need to recurse
+			// we set up the working table as the data we gathered in this iteration of the recursion
+			working_table->Reset();
+			working_table->Merge(gstate.intermediate_table);
+			// and we clear the intermediate table
+			gstate.intermediate_table.Reset();
+			gstate.chunk_idx = 0;
+			// now we need to re-execute all of the pipelines that depend on the recursion
+			ExecuteRecursivePipelines(context);
+
+			// check if we obtained any results
+			// if not, we are done
+			if (gstate.intermediate_table.Count() == 0) {
+				break;
+			}
+		}
+	}
+}
+
+void PhysicalRecursiveCTE::ExecuteRecursivePipelines(ExecutionContext &context) const {
+	if (pipelines.empty()) {
+		throw InternalException("Missing pipelines for recursive CTE");
+	}
+
+	for (auto &pipeline : pipelines) {
+		auto sink = pipeline->GetSink();
+		if (sink != this) {
+			// reset the sink state for any intermediate sinks
+			sink->sink_state = sink->GetGlobalSinkState(context.client);
+		}
+		for (auto &op : pipeline->GetOperators()) {
+			if (op) {
+				op->op_state = op->GetGlobalOperatorState(context.client);
+			}
+		}
+		pipeline->Reset();
+	}
+	auto &executor = pipelines[0]->executor;
+
+	vector<shared_ptr<Event>> events;
+	executor.ReschedulePipelines(pipelines, events);
+
+	while (true) {
+		executor.WorkOnTasks();
+		if (executor.HasError()) {
+			executor.ThrowException();
+		}
+		bool finished = true;
+		for (auto &event : events) {
+			if (!event->IsFinished()) {
+				finished = false;
+				break;
+			}
+		}
+		if (finished) {
+			// all pipelines finished: done!
+			break;
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalRecursiveCTE::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	op_state.reset();
+	sink_state.reset();
+
+	// recursive CTE
+	state.SetPipelineSource(current, this);
+	// the LHS of the recursive CTE is our initial state
+	// we build this pipeline as normal
+	auto pipeline_child = children[0].get();
+	// for the RHS, we gather all pipelines that depend on the recursive cte
+	// these pipelines need to be rerun
+	if (state.recursive_cte) {
+		throw InternalException("Recursive CTE detected WITHIN a recursive CTE node");
+	}
+	state.recursive_cte = this;
+
+	auto recursive_pipeline = make_shared<Pipeline>(executor);
+	state.SetPipelineSink(*recursive_pipeline, this);
+	children[1]->BuildPipelines(executor, *recursive_pipeline, state);
+
+	pipelines.push_back(move(recursive_pipeline));
+
+	state.recursive_cte = nullptr;
+
+	BuildChildPipeline(executor, current, state, pipeline_child);
+}
+
+vector<const PhysicalOperator *> PhysicalRecursiveCTE::GetSources() const {
+	return {this};
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PhysicalUnion::PhysicalUnion(vector<LogicalType> types, unique_ptr<PhysicalOperator> top,
+                             unique_ptr<PhysicalOperator> bottom, idx_t estimated_cardinality)
+    : PhysicalOperator(PhysicalOperatorType::UNION, move(types), estimated_cardinality) {
+	children.push_back(move(top));
+	children.push_back(move(bottom));
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalUnion::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	if (state.recursive_cte) {
+		throw NotImplementedException("UNIONS are not supported in recursive CTEs yet");
+	}
+	op_state.reset();
+	sink_state.reset();
+
+	auto union_pipeline = make_shared<Pipeline>(executor);
+	auto pipeline_ptr = union_pipeline.get();
+	auto &child_pipelines = state.GetChildPipelines(executor);
+	auto &child_dependencies = state.GetChildDependencies(executor);
+	auto &union_pipelines = state.GetUnionPipelines(executor);
+	// set up dependencies for any child pipelines to this union pipeline
+	auto child_entry = child_pipelines.find(&current);
+	if (child_entry != child_pipelines.end()) {
+		for (auto &current_child : child_entry->second) {
+			D_ASSERT(child_dependencies.find(current_child.get()) != child_dependencies.end());
+			child_dependencies[current_child.get()].push_back(pipeline_ptr);
+		}
+	}
+	// for the current pipeline, continue building on the LHS
+	state.SetPipelineOperators(*union_pipeline, state.GetPipelineOperators(current));
+	children[0]->BuildPipelines(executor, current, state);
+	// insert the union pipeline as a union pipeline of the current node
+	union_pipelines[&current].push_back(move(union_pipeline));
+
+	// for the union pipeline, build on the RHS
+	state.SetPipelineSink(*pipeline_ptr, state.GetPipelineSink(current));
+	children[1]->BuildPipelines(executor, *pipeline_ptr, state);
+}
+
+vector<const PhysicalOperator *> PhysicalUnion::GetSources() const {
+	vector<const PhysicalOperator *> result;
+	for (auto &child : children) {
+		auto child_sources = child->GetSources();
+		result.insert(result.end(), child_sources.begin(), child_sources.end());
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+static idx_t PartitionInfoNPartitions(const idx_t n_partitions_upper_bound) {
+	idx_t n_partitions = 1;
+	while (n_partitions <= n_partitions_upper_bound / 2) {
+		n_partitions *= 2;
+		if (n_partitions >= 256) {
+			break;
+		}
+	}
+	return n_partitions;
+}
+
+static idx_t PartitionInfoRadixBits(const idx_t n_partitions) {
+	idx_t radix_bits = 0;
+	auto radix_partitions_copy = n_partitions;
+	while (radix_partitions_copy - 1) {
+		radix_bits++;
+		radix_partitions_copy >>= 1;
+	}
+	return radix_bits;
+}
+
+static hash_t PartitionInfoRadixMask(const idx_t radix_bits, const idx_t radix_shift) {
+	hash_t radix_mask = 0;
+	// we use the fifth byte of the 64 bit hash as radix source
+	for (idx_t i = 0; i < radix_bits; i++) {
+		radix_mask = (radix_mask << 1) | 1;
+	}
+	radix_mask <<= radix_shift;
+	return radix_mask;
+}
+
+RadixPartitionInfo::RadixPartitionInfo(const idx_t n_partitions_upper_bound)
+    : n_partitions(PartitionInfoNPartitions(n_partitions_upper_bound)),
+      radix_bits(PartitionInfoRadixBits(n_partitions)), radix_mask(PartitionInfoRadixMask(radix_bits, RADIX_SHIFT)) {
+
+	// finalize_threads needs to be a power of 2
+	D_ASSERT(n_partitions > 0);
+	D_ASSERT(n_partitions <= 256);
+	D_ASSERT((n_partitions & (n_partitions - 1)) == 0);
+	D_ASSERT(radix_bits <= 8);
+}
+
+PartitionableHashTable::PartitionableHashTable(BufferManager &buffer_manager_p, RadixPartitionInfo &partition_info_p,
+                                               vector<LogicalType> group_types_p, vector<LogicalType> payload_types_p,
+                                               vector<BoundAggregateExpression *> bindings_p)
+    : buffer_manager(buffer_manager_p), group_types(move(group_types_p)), payload_types(move(payload_types_p)),
+      bindings(move(bindings_p)), is_partitioned(false), partition_info(partition_info_p), hashes(LogicalType::HASH),
+      hashes_subset(LogicalType::HASH) {
+
+	sel_vectors.resize(partition_info.n_partitions);
+	sel_vector_sizes.resize(partition_info.n_partitions);
+	group_subset.Initialize(group_types);
+	if (!payload_types.empty()) {
+		payload_subset.Initialize(payload_types);
+	}
+
+	for (hash_t r = 0; r < partition_info.n_partitions; r++) {
+		sel_vectors[r].Initialize();
+	}
+}
+
+idx_t PartitionableHashTable::ListAddChunk(HashTableList &list, DataChunk &groups, Vector &group_hashes,
+                                           DataChunk &payload) {
+	if (list.empty() || list.back()->Size() + groups.size() > list.back()->MaxCapacity()) {
+		if (!list.empty()) {
+			// early release first part of ht and prevent adding of more data
+			list.back()->Finalize();
+		}
+		list.push_back(make_unique<GroupedAggregateHashTable>(buffer_manager, group_types, payload_types, bindings,
+		                                                      HtEntryType::HT_WIDTH_32));
+	}
+	return list.back()->AddChunk(groups, group_hashes, payload);
+}
+
+idx_t PartitionableHashTable::AddChunk(DataChunk &groups, DataChunk &payload, bool do_partition) {
+	groups.Hash(hashes);
+
+	// we partition when we are asked to or when the unpartitioned ht runs out of space
+	if (!IsPartitioned() && do_partition) {
+		Partition();
+	}
+
+	if (!IsPartitioned()) {
+		return ListAddChunk(unpartitioned_hts, groups, hashes, payload);
+	}
+
+	// makes no sense to do this with 1 partition
+	D_ASSERT(partition_info.n_partitions > 0);
+
+	for (hash_t r = 0; r < partition_info.n_partitions; r++) {
+		sel_vector_sizes[r] = 0;
+	}
+
+	hashes.Normalify(groups.size());
+	auto hashes_ptr = FlatVector::GetData<hash_t>(hashes);
+
+	for (idx_t i = 0; i < groups.size(); i++) {
+		auto partition = (hashes_ptr[i] & partition_info.radix_mask) >> partition_info.RADIX_SHIFT;
+		D_ASSERT(partition < partition_info.n_partitions);
+		sel_vectors[partition].set_index(sel_vector_sizes[partition]++, i);
+	}
+
+#ifdef DEBUG
+	// make sure we have lost no rows
+	idx_t total_count = 0;
+	for (idx_t r = 0; r < partition_info.n_partitions; r++) {
+		total_count += sel_vector_sizes[r];
+	}
+	D_ASSERT(total_count == groups.size());
+#endif
+	idx_t group_count = 0;
+	for (hash_t r = 0; r < partition_info.n_partitions; r++) {
+		group_subset.Slice(groups, sel_vectors[r], sel_vector_sizes[r]);
+		payload_subset.Slice(payload, sel_vectors[r], sel_vector_sizes[r]);
+		hashes_subset.Slice(hashes, sel_vectors[r], sel_vector_sizes[r]);
+
+		group_count += ListAddChunk(radix_partitioned_hts[r], group_subset, hashes_subset, payload_subset);
+	}
+	return group_count;
+}
+
+void PartitionableHashTable::Partition() {
+	D_ASSERT(!IsPartitioned());
+	D_ASSERT(radix_partitioned_hts.size() == 0);
+	D_ASSERT(partition_info.n_partitions > 1);
+
+	vector<GroupedAggregateHashTable *> partition_hts(partition_info.n_partitions);
+	for (auto &unpartitioned_ht : unpartitioned_hts) {
+		for (idx_t r = 0; r < partition_info.n_partitions; r++) {
+			radix_partitioned_hts[r].push_back(make_unique<GroupedAggregateHashTable>(
+			    buffer_manager, group_types, payload_types, bindings, HtEntryType::HT_WIDTH_32));
+			partition_hts[r] = radix_partitioned_hts[r].back().get();
+		}
+		unpartitioned_ht->Partition(partition_hts, partition_info.radix_mask, partition_info.RADIX_SHIFT);
+		unpartitioned_ht.reset();
+	}
+	unpartitioned_hts.clear();
+	is_partitioned = true;
+}
+
+bool PartitionableHashTable::IsPartitioned() {
+	return is_partitioned;
+}
+
+HashTableList PartitionableHashTable::GetPartition(idx_t partition) {
+	D_ASSERT(IsPartitioned());
+	D_ASSERT(partition < partition_info.n_partitions);
+	D_ASSERT(radix_partitioned_hts.size() > partition);
+	return move(radix_partitioned_hts[partition]);
+}
+HashTableList PartitionableHashTable::GetUnpartitioned() {
+	D_ASSERT(!IsPartitioned());
+	return move(unpartitioned_hts);
+}
+
+void PartitionableHashTable::Finalize() {
+	if (IsPartitioned()) {
+		for (auto &ht_list : radix_partitioned_hts) {
+			for (auto &ht : ht_list.second) {
+				D_ASSERT(ht);
+				ht->Finalize();
+			}
+		}
+	} else {
+		for (auto &ht : unpartitioned_hts) {
+			D_ASSERT(ht);
+			ht->Finalize();
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PerfectAggregateHashTable::PerfectAggregateHashTable(BufferManager &buffer_manager,
+                                                     const vector<LogicalType> &group_types_p,
+                                                     vector<LogicalType> payload_types_p,
+                                                     vector<AggregateObject> aggregate_objects_p,
+                                                     vector<Value> group_minima_p, vector<idx_t> required_bits_p)
+    : BaseAggregateHashTable(buffer_manager, move(payload_types_p)), addresses(LogicalType::POINTER),
+      required_bits(move(required_bits_p)), total_required_bits(0), group_minima(move(group_minima_p)),
+      sel(STANDARD_VECTOR_SIZE) {
+	for (auto &group_bits : required_bits) {
+		total_required_bits += group_bits;
+	}
+	// the total amount of groups we allocate space for is 2^required_bits
+	total_groups = 1 << total_required_bits;
+	// we don't need to store the groups in a perfect hash table, since the group keys can be deduced by their location
+	grouping_columns = group_types_p.size();
+	layout.Initialize(move(aggregate_objects_p));
+	tuple_size = layout.GetRowWidth();
+
+	// allocate and null initialize the data
+	owned_data = unique_ptr<data_t[]>(new data_t[tuple_size * total_groups]);
+	data = owned_data.get();
+
+	// set up the empty payloads for every tuple, and initialize the "occupied" flag to false
+	group_is_set = unique_ptr<bool[]>(new bool[total_groups]);
+	memset(group_is_set.get(), 0, total_groups * sizeof(bool));
+}
+
+PerfectAggregateHashTable::~PerfectAggregateHashTable() {
+	Destroy();
+}
+
+template <class T>
+static void ComputeGroupLocationTemplated(VectorData &group_data, Value &min, uintptr_t *address_data,
+                                          idx_t current_shift, idx_t count) {
+	auto data = (T *)group_data.data;
+	auto min_val = min.GetValueUnsafe<T>();
+	if (!group_data.validity.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto index = group_data.sel->get_index(i);
+			// check if the value is NULL
+			// NULL groups are considered as "0" in the hash table
+			// that is to say, they have no effect on the position of the element (because 0 << shift is 0)
+			// we only need to handle non-null values here
+			if (group_data.validity.RowIsValid(index)) {
+				D_ASSERT(data[index] >= min_val);
+				uintptr_t adjusted_value = (data[index] - min_val) + 1;
+				address_data[i] += adjusted_value << current_shift;
+			}
+		}
+	} else {
+		// no null values: we can directly compute the addresses
+		for (idx_t i = 0; i < count; i++) {
+			auto index = group_data.sel->get_index(i);
+			uintptr_t adjusted_value = (data[index] - min_val) + 1;
+			address_data[i] += adjusted_value << current_shift;
+		}
+	}
+}
+
+static void ComputeGroupLocation(Vector &group, Value &min, uintptr_t *address_data, idx_t current_shift, idx_t count) {
+	VectorData vdata;
+	group.Orrify(count, vdata);
+
+	switch (group.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		ComputeGroupLocationTemplated<int8_t>(vdata, min, address_data, current_shift, count);
+		break;
+	case PhysicalType::INT16:
+		ComputeGroupLocationTemplated<int16_t>(vdata, min, address_data, current_shift, count);
+		break;
+	case PhysicalType::INT32:
+		ComputeGroupLocationTemplated<int32_t>(vdata, min, address_data, current_shift, count);
+		break;
+	case PhysicalType::INT64:
+		ComputeGroupLocationTemplated<int64_t>(vdata, min, address_data, current_shift, count);
+		break;
+	default:
+		throw InternalException("Unsupported group type for perfect aggregate hash table");
+	}
+}
+
+void PerfectAggregateHashTable::AddChunk(DataChunk &groups, DataChunk &payload) {
+	// first we need to find the location in the HT of each of the groups
+	auto address_data = FlatVector::GetData<uintptr_t>(addresses);
+	// zero-initialize the address data
+	memset(address_data, 0, groups.size() * sizeof(uintptr_t));
+	D_ASSERT(groups.ColumnCount() == group_minima.size());
+
+	// then compute the actual group location by iterating over each of the groups
+	idx_t current_shift = total_required_bits;
+	for (idx_t i = 0; i < groups.ColumnCount(); i++) {
+		current_shift -= required_bits[i];
+		ComputeGroupLocation(groups.data[i], group_minima[i], address_data, current_shift, groups.size());
+	}
+	// now we have the HT entry number for every tuple
+	// compute the actual pointer to the data by adding it to the base HT pointer and multiplying by the tuple size
+	idx_t needs_init = 0;
+	for (idx_t i = 0; i < groups.size(); i++) {
+		D_ASSERT(address_data[i] < total_groups);
+		const auto group = address_data[i];
+		address_data[i] = uintptr_t(data) + address_data[i] * tuple_size;
+		if (!group_is_set[group]) {
+			group_is_set[group] = true;
+			sel.set_index(needs_init++, i);
+			if (needs_init == STANDARD_VECTOR_SIZE) {
+				RowOperations::InitializeStates(layout, addresses, sel, needs_init);
+				needs_init = 0;
+			}
+		}
+	}
+	RowOperations::InitializeStates(layout, addresses, sel, needs_init);
+
+	// after finding the group location we update the aggregates
+	idx_t payload_idx = 0;
+	auto &aggregates = layout.GetAggregates();
+	for (auto &aggregate : aggregates) {
+		auto input_count = (idx_t)aggregate.child_count;
+		if (aggregate.filter) {
+			RowOperations::UpdateFilteredStates(aggregate, addresses, payload, payload_idx);
+		} else {
+			RowOperations::UpdateStates(aggregate, addresses, payload, payload_idx, payload.size());
+		}
+		// move to the next aggregate
+		payload_idx += input_count;
+		VectorOperations::AddInPlace(addresses, aggregate.payload_size, payload.size());
+	}
+}
+
+void PerfectAggregateHashTable::Combine(PerfectAggregateHashTable &other) {
+	D_ASSERT(total_groups == other.total_groups);
+	D_ASSERT(tuple_size == other.tuple_size);
+
+	Vector source_addresses(LogicalType::POINTER);
+	Vector target_addresses(LogicalType::POINTER);
+	auto source_addresses_ptr = FlatVector::GetData<data_ptr_t>(source_addresses);
+	auto target_addresses_ptr = FlatVector::GetData<data_ptr_t>(target_addresses);
+
+	// iterate over all entries of both hash tables and call combine for all entries that can be combined
+	data_ptr_t source_ptr = other.data;
+	data_ptr_t target_ptr = data;
+	idx_t combine_count = 0;
+	idx_t reinit_count = 0;
+	const auto &reinit_sel = *FlatVector::IncrementalSelectionVector();
+	for (idx_t i = 0; i < total_groups; i++) {
+		auto has_entry_source = other.group_is_set[i];
+		// we only have any work to do if the source has an entry for this group
+		if (has_entry_source) {
+			auto has_entry_target = group_is_set[i];
+			if (has_entry_target) {
+				// both source and target have an entry: need to combine
+				source_addresses_ptr[combine_count] = source_ptr;
+				target_addresses_ptr[combine_count] = target_ptr;
+				combine_count++;
+				if (combine_count == STANDARD_VECTOR_SIZE) {
+					RowOperations::CombineStates(layout, source_addresses, target_addresses, combine_count);
+					combine_count = 0;
+				}
+			} else {
+				group_is_set[i] = true;
+				// only source has an entry for this group: we can just memcpy it over
+				memcpy(target_ptr, source_ptr, tuple_size);
+				// we clear this entry in the other HT as we "consume" the entry here
+				other.group_is_set[i] = false;
+			}
+		}
+		source_ptr += tuple_size;
+		target_ptr += tuple_size;
+	}
+	RowOperations::CombineStates(layout, source_addresses, target_addresses, combine_count);
+	RowOperations::InitializeStates(layout, addresses, reinit_sel, reinit_count);
+}
+
+template <class T>
+static void ReconstructGroupVectorTemplated(uint32_t group_values[], Value &min, idx_t mask, idx_t shift,
+                                            idx_t entry_count, Vector &result) {
+	auto data = FlatVector::GetData<T>(result);
+	auto &validity_mask = FlatVector::Validity(result);
+	auto min_data = min.GetValueUnsafe<T>();
+	for (idx_t i = 0; i < entry_count; i++) {
+		// extract the value of this group from the total group index
+		auto group_index = (group_values[i] >> shift) & mask;
+		if (group_index == 0) {
+			// if it is 0, the value is NULL
+			validity_mask.SetInvalid(i);
+		} else {
+			// otherwise we add the value (minus 1) to the min value
+			data[i] = min_data + group_index - 1;
+		}
+	}
+}
+
+static void ReconstructGroupVector(uint32_t group_values[], Value &min, idx_t required_bits, idx_t shift,
+                                   idx_t entry_count, Vector &result) {
+	// construct the mask for this entry
+	idx_t mask = (1 << required_bits) - 1;
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		ReconstructGroupVectorTemplated<int8_t>(group_values, min, mask, shift, entry_count, result);
+		break;
+	case PhysicalType::INT16:
+		ReconstructGroupVectorTemplated<int16_t>(group_values, min, mask, shift, entry_count, result);
+		break;
+	case PhysicalType::INT32:
+		ReconstructGroupVectorTemplated<int32_t>(group_values, min, mask, shift, entry_count, result);
+		break;
+	case PhysicalType::INT64:
+		ReconstructGroupVectorTemplated<int64_t>(group_values, min, mask, shift, entry_count, result);
+		break;
+	default:
+		throw InternalException("Invalid type for perfect aggregate HT group");
+	}
+}
+
+void PerfectAggregateHashTable::Scan(idx_t &scan_position, DataChunk &result) {
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+	uint32_t group_values[STANDARD_VECTOR_SIZE];
+
+	// iterate over the HT until we either have exhausted the entire HT, or
+	idx_t entry_count = 0;
+	for (; scan_position < total_groups; scan_position++) {
+		if (group_is_set[scan_position]) {
+			// this group is set: add it to the set of groups to extract
+			data_pointers[entry_count] = data + tuple_size * scan_position;
+			group_values[entry_count] = scan_position;
+			entry_count++;
+			if (entry_count == STANDARD_VECTOR_SIZE) {
+				scan_position++;
+				break;
+			}
+		}
+	}
+	if (entry_count == 0) {
+		// no entries found
+		return;
+	}
+	// first reconstruct the groups from the group index
+	idx_t shift = total_required_bits;
+	for (idx_t i = 0; i < grouping_columns; i++) {
+		shift -= required_bits[i];
+		ReconstructGroupVector(group_values, group_minima[i], required_bits[i], shift, entry_count, result.data[i]);
+	}
+	// then construct the payloads
+	result.SetCardinality(entry_count);
+	RowOperations::FinalizeStates(layout, addresses, result, grouping_columns);
+}
+
+void PerfectAggregateHashTable::Destroy() {
+	// check if there is any destructor to call
+	bool has_destructor = false;
+	for (auto &aggr : layout.GetAggregates()) {
+		if (aggr.function.destructor) {
+			has_destructor = true;
+		}
+	}
+	if (!has_destructor) {
+		return;
+	}
+	// there are aggregates with destructors: loop over the hash table
+	// and call the destructor method for each of the aggregates
+	auto data_pointers = FlatVector::GetData<data_ptr_t>(addresses);
+	idx_t count = 0;
+
+	// iterate over all initialised slots of the hash table
+	data_ptr_t payload_ptr = data;
+	for (idx_t i = 0; i < total_groups; i++) {
+		if (group_is_set[i]) {
+			data_pointers[count++] = payload_ptr;
+			if (count == STANDARD_VECTOR_SIZE) {
+				RowOperations::DestroyStates(layout, addresses, count);
+				count = 0;
+			}
+		}
+		payload_ptr += tuple_size;
+	}
+	RowOperations::DestroyStates(layout, addresses, count);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+string PhysicalOperator::GetName() const {
+	return PhysicalOperatorToString(type);
+}
+
+string PhysicalOperator::ToString() const {
+	TreeRenderer renderer;
+	return renderer.ToString(*this);
+}
+
+// LCOV_EXCL_START
+void PhysicalOperator::Print() const {
+	Printer::Print(ToString());
+}
+// LCOV_EXCL_STOP
+
+vector<PhysicalOperator *> PhysicalOperator::GetChildren() const {
+	vector<PhysicalOperator *> result;
+	for (auto &child : children) {
+		result.push_back(child.get());
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Operator
+//===--------------------------------------------------------------------===//
+// LCOV_EXCL_START
+unique_ptr<OperatorState> PhysicalOperator::GetOperatorState(ClientContext &context) const {
+	return make_unique<OperatorState>();
+}
+
+unique_ptr<GlobalOperatorState> PhysicalOperator::GetGlobalOperatorState(ClientContext &context) const {
+	return make_unique<GlobalOperatorState>();
+}
+
+OperatorResultType PhysicalOperator::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                             GlobalOperatorState &gstate, OperatorState &state) const {
+	throw InternalException("Calling Execute on a node that is not an operator!");
+}
+// LCOV_EXCL_STOP
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+unique_ptr<LocalSourceState> PhysicalOperator::GetLocalSourceState(ExecutionContext &context,
+                                                                   GlobalSourceState &gstate) const {
+	return make_unique<LocalSourceState>();
+}
+
+unique_ptr<GlobalSourceState> PhysicalOperator::GetGlobalSourceState(ClientContext &context) const {
+	return make_unique<GlobalSourceState>();
+}
+
+// LCOV_EXCL_START
+void PhysicalOperator::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                               LocalSourceState &lstate) const {
+	throw InternalException("Calling GetData on a node that is not a source!");
+}
+
+idx_t PhysicalOperator::GetBatchIndex(ExecutionContext &context, DataChunk &chunk, GlobalSourceState &gstate,
+                                      LocalSourceState &lstate) const {
+	throw InternalException("Calling GetBatchIndex on a node that does not support it");
+}
+
+double PhysicalOperator::GetProgress(ClientContext &context, GlobalSourceState &gstate) const {
+	return -1;
+}
+// LCOV_EXCL_STOP
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+// LCOV_EXCL_START
+SinkResultType PhysicalOperator::Sink(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate,
+                                      DataChunk &input) const {
+	throw InternalException("Calling Sink on a node that is not a sink!");
+}
+// LCOV_EXCL_STOP
+
+void PhysicalOperator::Combine(ExecutionContext &context, GlobalSinkState &gstate, LocalSinkState &lstate) const {
+}
+
+SinkFinalizeType PhysicalOperator::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                            GlobalSinkState &gstate) const {
+	return SinkFinalizeType::READY;
+}
+
+unique_ptr<LocalSinkState> PhysicalOperator::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<LocalSinkState>();
+}
+
+unique_ptr<GlobalSinkState> PhysicalOperator::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<GlobalSinkState>();
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Construction
+//===--------------------------------------------------------------------===//
+void PhysicalOperator::AddPipeline(Executor &executor, shared_ptr<Pipeline> pipeline, PipelineBuildState &state) {
+	if (!state.recursive_cte) {
+		// regular pipeline: schedule it
+		state.AddPipeline(executor, move(pipeline));
+	} else {
+		// CTE pipeline! add it to the CTE pipelines
+		auto &cte = (PhysicalRecursiveCTE &)*state.recursive_cte;
+		cte.pipelines.push_back(move(pipeline));
+	}
+}
+
+void PhysicalOperator::BuildChildPipeline(Executor &executor, Pipeline &current, PipelineBuildState &state,
+                                          PhysicalOperator *pipeline_child) {
+	auto pipeline = make_shared<Pipeline>(executor);
+	state.SetPipelineSink(*pipeline, this);
+	// the current is dependent on this pipeline to complete
+	current.AddDependency(pipeline);
+	// recurse into the pipeline child
+	pipeline_child->BuildPipelines(executor, *pipeline, state);
+	AddPipeline(executor, move(pipeline), state);
+}
+
+void PhysicalOperator::BuildPipelines(Executor &executor, Pipeline &current, PipelineBuildState &state) {
+	op_state.reset();
+	if (IsSink()) {
+		// operator is a sink, build a pipeline
+		sink_state.reset();
+
+		// single operator:
+		// the operator becomes the data source of the current pipeline
+		state.SetPipelineSource(current, this);
+		// we create a new pipeline starting from the child
+		D_ASSERT(children.size() == 1);
+
+		BuildChildPipeline(executor, current, state, children[0].get());
+	} else {
+		// operator is not a sink! recurse in children
+		if (children.empty()) {
+			// source
+			state.SetPipelineSource(current, this);
+		} else {
+			if (children.size() != 1) {
+				throw InternalException("Operator not supported in BuildPipelines");
+			}
+			state.AddPipelineOperator(current, this);
+			children[0]->BuildPipelines(executor, current, state);
+		}
+	}
+}
+
+vector<const PhysicalOperator *> PhysicalOperator::GetSources() const {
+	vector<const PhysicalOperator *> result;
+	if (IsSink()) {
+		D_ASSERT(children.size() == 1);
+		result.push_back(this);
+		return result;
+	} else {
+		if (children.empty()) {
+			// source
+			result.push_back(this);
+			return result;
+		} else {
+			if (children.size() != 1) {
+				throw InternalException("Operator not supported in GetSource");
+			}
+			return children[0]->GetSources();
+		}
+	}
+}
+
+bool PhysicalOperator::AllSourcesSupportBatchIndex() const {
+	auto sources = GetSources();
+	for (auto &source : sources) {
+		if (!source->SupportsBatchIndex()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void PhysicalOperator::Verify() {
+#ifdef DEBUG
+	auto sources = GetSources();
+	D_ASSERT(!sources.empty());
+	for (auto &child : children) {
+		child->Verify();
+	}
+#endif
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static uint32_t RequiredBitsForValue(uint32_t n) {
+	idx_t required_bits = 0;
+	while (n > 0) {
+		n >>= 1;
+		required_bits++;
+	}
+	return required_bits;
+}
+
+static bool CanUsePerfectHashAggregate(ClientContext &context, LogicalAggregate &op, vector<idx_t> &bits_per_group) {
+	if (op.grouping_sets.size() > 1 || !op.grouping_functions.empty()) {
+		return false;
+	}
+	idx_t perfect_hash_bits = 0;
+	if (op.group_stats.empty()) {
+		op.group_stats.resize(op.groups.size());
+	}
+	for (idx_t group_idx = 0; group_idx < op.groups.size(); group_idx++) {
+		auto &group = op.groups[group_idx];
+		auto &stats = op.group_stats[group_idx];
+
+		switch (group->return_type.InternalType()) {
+		case PhysicalType::INT8:
+		case PhysicalType::INT16:
+		case PhysicalType::INT32:
+		case PhysicalType::INT64:
+			break;
+		default:
+			// we only support simple integer types for perfect hashing
+			return false;
+		}
+		// check if the group has stats available
+		auto &group_type = group->return_type;
+		if (!stats) {
+			// no stats, but we might still be able to use perfect hashing if the type is small enough
+			// for small types we can just set the stats to [type_min, type_max]
+			switch (group_type.InternalType()) {
+			case PhysicalType::INT8:
+				stats = make_unique<NumericStatistics>(group_type, Value::MinimumValue(group_type),
+				                                       Value::MaximumValue(group_type), StatisticsType::LOCAL_STATS);
+				break;
+			case PhysicalType::INT16:
+				stats = make_unique<NumericStatistics>(group_type, Value::MinimumValue(group_type),
+				                                       Value::MaximumValue(group_type), StatisticsType::LOCAL_STATS);
+				break;
+			default:
+				// type is too large and there are no stats: skip perfect hashing
+				return false;
+			}
+			// we had no stats before, so we have no clue if there are null values or not
+			stats->validity_stats = make_unique<ValidityStatistics>(true);
+		}
+		auto &nstats = (NumericStatistics &)*stats;
+
+		if (nstats.min.IsNull() || nstats.max.IsNull()) {
+			return false;
+		}
+		// we have a min and a max value for the stats: use that to figure out how many bits we have
+		// we add two here, one for the NULL value, and one to make the computation one-indexed
+		// (e.g. if min and max are the same, we still need one entry in total)
+		int64_t range;
+		switch (group_type.InternalType()) {
+		case PhysicalType::INT8:
+			range = int64_t(nstats.max.GetValueUnsafe<int8_t>()) - int64_t(nstats.min.GetValueUnsafe<int8_t>());
+			break;
+		case PhysicalType::INT16:
+			range = int64_t(nstats.max.GetValueUnsafe<int16_t>()) - int64_t(nstats.min.GetValueUnsafe<int16_t>());
+			break;
+		case PhysicalType::INT32:
+			range = int64_t(nstats.max.GetValueUnsafe<int32_t>()) - int64_t(nstats.min.GetValueUnsafe<int32_t>());
+			break;
+		case PhysicalType::INT64:
+			if (!TrySubtractOperator::Operation(nstats.max.GetValueUnsafe<int64_t>(),
+			                                    nstats.min.GetValueUnsafe<int64_t>(), range)) {
+				return false;
+			}
+			break;
+		default:
+			throw InternalException("Unsupported type for perfect hash (should be caught before)");
+		}
+		// bail out on any range bigger than 2^32
+		if (range >= NumericLimits<int32_t>::Maximum()) {
+			return false;
+		}
+		range += 2;
+		// figure out how many bits we need
+		idx_t required_bits = RequiredBitsForValue(range);
+		bits_per_group.push_back(required_bits);
+		perfect_hash_bits += required_bits;
+		// check if we have exceeded the bits for the hash
+		if (perfect_hash_bits > ClientConfig::GetConfig(context).perfect_ht_threshold) {
+			// too many bits for perfect hash
+			return false;
+		}
+	}
+	for (auto &expression : op.expressions) {
+		auto &aggregate = (BoundAggregateExpression &)*expression;
+		if (aggregate.distinct || !aggregate.function.combine) {
+			// distinct aggregates are not supported in perfect hash aggregates
+			return false;
+		}
+	}
+	return true;
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAggregate &op) {
+	unique_ptr<PhysicalOperator> groupby;
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	plan = ExtractAggregateExpressions(move(plan), op.expressions, op.groups);
+
+	if (op.groups.empty()) {
+		// no groups, check if we can use a simple aggregation
+		// special case: aggregate entire columns together
+		bool use_simple_aggregation = true;
+		for (auto &expression : op.expressions) {
+			auto &aggregate = (BoundAggregateExpression &)*expression;
+			if (!aggregate.function.simple_update || aggregate.distinct) {
+				// unsupported aggregate for simple aggregation: use hash aggregation
+				use_simple_aggregation = false;
+				break;
+			}
+		}
+		if (use_simple_aggregation) {
+			groupby = make_unique_base<PhysicalOperator, PhysicalSimpleAggregate>(op.types, move(op.expressions),
+			                                                                      op.estimated_cardinality);
+		} else {
+			groupby = make_unique_base<PhysicalOperator, PhysicalHashAggregate>(context, op.types, move(op.expressions),
+			                                                                    op.estimated_cardinality);
+		}
+	} else {
+		// groups! create a GROUP BY aggregator
+		// use a perfect hash aggregate if possible
+		vector<idx_t> required_bits;
+		if (CanUsePerfectHashAggregate(context, op, required_bits)) {
+			groupby = make_unique_base<PhysicalOperator, PhysicalPerfectHashAggregate>(
+			    context, op.types, move(op.expressions), move(op.groups), move(op.group_stats), move(required_bits),
+			    op.estimated_cardinality);
+		} else {
+			groupby = make_unique_base<PhysicalOperator, PhysicalHashAggregate>(
+			    context, op.types, move(op.expressions), move(op.groups), move(op.grouping_sets),
+			    move(op.grouping_functions), op.estimated_cardinality);
+		}
+	}
+	groupby->children.push_back(move(plan));
+	return groupby;
+}
+
+unique_ptr<PhysicalOperator>
+PhysicalPlanGenerator::ExtractAggregateExpressions(unique_ptr<PhysicalOperator> child,
+                                                   vector<unique_ptr<Expression>> &aggregates,
+                                                   vector<unique_ptr<Expression>> &groups) {
+	vector<unique_ptr<Expression>> expressions;
+	vector<LogicalType> types;
+
+	for (auto &group : groups) {
+		auto ref = make_unique<BoundReferenceExpression>(group->return_type, expressions.size());
+		types.push_back(group->return_type);
+		expressions.push_back(move(group));
+		group = move(ref);
+	}
+
+	for (auto &aggr : aggregates) {
+		auto &bound_aggr = (BoundAggregateExpression &)*aggr;
+		for (auto &child : bound_aggr.children) {
+			auto ref = make_unique<BoundReferenceExpression>(child->return_type, expressions.size());
+			types.push_back(child->return_type);
+			expressions.push_back(move(child));
+			child = move(ref);
+		}
+		if (bound_aggr.filter) {
+			auto &filter = bound_aggr.filter;
+			auto ref = make_unique<BoundReferenceExpression>(filter->return_type, expressions.size());
+			types.push_back(filter->return_type);
+			expressions.push_back(move(filter));
+			bound_aggr.filter = move(ref);
+		}
+	}
+	if (expressions.empty()) {
+		return child;
+	}
+	auto projection = make_unique<PhysicalProjection>(move(types), move(expressions), child->estimated_cardinality);
+	projection->children.push_back(move(child));
+	return move(projection);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalAnyJoin &op) {
+	// first visit the child nodes
+	D_ASSERT(op.children.size() == 2);
+	D_ASSERT(op.condition);
+
+	auto left = CreatePlan(*op.children[0]);
+	auto right = CreatePlan(*op.children[1]);
+
+	// create the blockwise NL join
+	return make_unique<PhysicalBlockwiseNLJoin>(op, move(left), move(right), move(op.condition), op.join_type,
+	                                            op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalChunkGet &op) {
+	D_ASSERT(op.children.size() == 0);
+	D_ASSERT(op.collection);
+
+	// create a PhysicalChunkScan pointing towards the owned collection
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
+	chunk_scan->owned_collection = move(op.collection);
+	chunk_scan->collection = chunk_scan->owned_collection.get();
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static bool CanPlanIndexJoin(Transaction &transaction, TableScanBindData *bind_data, PhysicalTableScan &scan) {
+	if (!bind_data) {
+		// not a table scan
+		return false;
+	}
+	auto table = bind_data->table;
+	if (transaction.storage.Find(table->storage.get())) {
+		// transaction local appends: skip index join
+		return false;
+	}
+	if (scan.table_filters && !scan.table_filters->filters.empty()) {
+		// table scan filters
+		return false;
+	}
+	return true;
+}
+
+bool ExtractNumericValue(Value val, int64_t &result) {
+	if (!val.type().IsIntegral()) {
+		switch (val.type().InternalType()) {
+		case PhysicalType::INT16:
+			result = val.GetValueUnsafe<int16_t>();
+			break;
+		case PhysicalType::INT32:
+			result = val.GetValueUnsafe<int32_t>();
+			break;
+		case PhysicalType::INT64:
+			result = val.GetValueUnsafe<int64_t>();
+			break;
+		default:
+			return false;
+		}
+	} else {
+		if (!val.TryCastAs(LogicalType::BIGINT)) {
+			return false;
+		}
+		result = val.GetValue<int64_t>();
+	}
+	return true;
+}
+
+void CheckForPerfectJoinOpt(LogicalComparisonJoin &op, PerfectHashJoinStats &join_state) {
+	// we only do this optimization for inner joins
+	if (op.join_type != JoinType::INNER) {
+		return;
+	}
+	// with one condition
+	if (op.conditions.size() != 1) {
+		return;
+	}
+	// with propagated statistics
+	if (op.join_stats.empty()) {
+		return;
+	}
+	// with equality condition and null values not equal
+	for (auto &&condition : op.conditions) {
+		if (condition.comparison != ExpressionType::COMPARE_EQUAL) {
+			return;
+		}
+	}
+	// with integral internal types
+	for (auto &&join_stat : op.join_stats) {
+		if (!TypeIsInteger(join_stat->type.InternalType()) || join_stat->type.InternalType() == PhysicalType::INT128) {
+			// perfect join not possible for non-integral types or hugeint
+			return;
+		}
+	}
+
+	// and when the build range is smaller than the threshold
+	auto stats_build = reinterpret_cast<NumericStatistics *>(op.join_stats[0].get()); // lhs stats
+	if (stats_build->min.IsNull() || stats_build->max.IsNull()) {
+		return;
+	}
+	int64_t min_value, max_value;
+	if (!ExtractNumericValue(stats_build->min, min_value) || !ExtractNumericValue(stats_build->max, max_value)) {
+		return;
+	}
+	int64_t build_range;
+	if (!TrySubtractOperator::Operation(max_value, min_value, build_range)) {
+		return;
+	}
+
+	// Fill join_stats for invisible join
+	auto stats_probe = reinterpret_cast<NumericStatistics *>(op.join_stats[1].get()); // rhs stats
+
+	// The max size our build must have to run the perfect HJ
+	const idx_t MAX_BUILD_SIZE = 1000000;
+	join_state.probe_min = stats_probe->min;
+	join_state.probe_max = stats_probe->max;
+	join_state.build_min = stats_build->min;
+	join_state.build_max = stats_build->max;
+	join_state.estimated_cardinality = op.estimated_cardinality;
+	join_state.build_range = build_range;
+	if (join_state.build_range > MAX_BUILD_SIZE || stats_probe->max.IsNull() || stats_probe->min.IsNull()) {
+		return;
+	}
+	if (stats_build->min <= stats_probe->min && stats_probe->max <= stats_build->max) {
+		join_state.is_probe_in_domain = true;
+	}
+	join_state.is_build_small = true;
+	return;
+}
+
+static void CanUseIndexJoin(TableScanBindData *tbl, Expression &expr, Index **result_index) {
+	tbl->table->storage->info->indexes.Scan([&](Index &index) {
+		if (index.unbound_expressions.size() != 1) {
+			return false;
+		}
+		if (expr.alias == index.unbound_expressions[0]->alias) {
+			*result_index = &index;
+			return true;
+		}
+		return false;
+	});
+}
+
+void TransformIndexJoin(ClientContext &context, LogicalComparisonJoin &op, Index **left_index, Index **right_index,
+                        PhysicalOperator *left, PhysicalOperator *right) {
+	auto &transaction = Transaction::GetTransaction(context);
+	// check if one of the tables has an index on column
+	if (op.join_type == JoinType::INNER && op.conditions.size() == 1) {
+		// check if one of the children are table scans and if they have an index in the join attribute
+		// (op.condition)
+		if (left->type == PhysicalOperatorType::TABLE_SCAN) {
+			auto &tbl_scan = (PhysicalTableScan &)*left;
+			auto tbl = dynamic_cast<TableScanBindData *>(tbl_scan.bind_data.get());
+			if (CanPlanIndexJoin(transaction, tbl, tbl_scan)) {
+				CanUseIndexJoin(tbl, *op.conditions[0].left, left_index);
+			}
+		}
+		if (right->type == PhysicalOperatorType::TABLE_SCAN) {
+			auto &tbl_scan = (PhysicalTableScan &)*right;
+			auto tbl = dynamic_cast<TableScanBindData *>(tbl_scan.bind_data.get());
+			if (CanPlanIndexJoin(transaction, tbl, tbl_scan)) {
+				CanUseIndexJoin(tbl, *op.conditions[0].right, right_index);
+			}
+		}
+	}
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalComparisonJoin &op) {
+	// now visit the children
+	D_ASSERT(op.children.size() == 2);
+	idx_t lhs_cardinality = op.children[0]->EstimateCardinality(context);
+	idx_t rhs_cardinality = op.children[1]->EstimateCardinality(context);
+	auto left = CreatePlan(*op.children[0]);
+	auto right = CreatePlan(*op.children[1]);
+	D_ASSERT(left && right);
+
+	if (op.conditions.empty()) {
+		// no conditions: insert a cross product
+		return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right), op.estimated_cardinality);
+	}
+
+	bool has_equality = false;
+	// bool has_inequality = false;
+	size_t has_range = 0;
+	for (size_t c = 0; c < op.conditions.size(); ++c) {
+		auto &cond = op.conditions[c];
+		switch (cond.comparison) {
+		case ExpressionType::COMPARE_EQUAL:
+		case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+			has_equality = true;
+			break;
+		case ExpressionType::COMPARE_LESSTHAN:
+		case ExpressionType::COMPARE_GREATERTHAN:
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			++has_range;
+			break;
+		case ExpressionType::COMPARE_NOTEQUAL:
+		case ExpressionType::COMPARE_DISTINCT_FROM:
+			// has_inequality = true;
+			break;
+		default:
+			throw NotImplementedException("Unimplemented comparison join");
+		}
+	}
+
+	unique_ptr<PhysicalOperator> plan;
+	if (has_equality) {
+		Index *left_index {}, *right_index {};
+		TransformIndexJoin(context, op, &left_index, &right_index, left.get(), right.get());
+		if (left_index &&
+		    (ClientConfig::GetConfig(context).force_index_join || rhs_cardinality < 0.01 * lhs_cardinality)) {
+			auto &tbl_scan = (PhysicalTableScan &)*left;
+			swap(op.conditions[0].left, op.conditions[0].right);
+			return make_unique<PhysicalIndexJoin>(op, move(right), move(left), move(op.conditions), op.join_type,
+			                                      op.right_projection_map, op.left_projection_map, tbl_scan.column_ids,
+			                                      left_index, false, op.estimated_cardinality);
+		}
+		if (right_index &&
+		    (ClientConfig::GetConfig(context).force_index_join || lhs_cardinality < 0.01 * rhs_cardinality)) {
+			auto &tbl_scan = (PhysicalTableScan &)*right;
+			return make_unique<PhysicalIndexJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
+			                                      op.left_projection_map, op.right_projection_map, tbl_scan.column_ids,
+			                                      right_index, true, op.estimated_cardinality);
+		}
+		// Equality join with small number of keys : possible perfect join optimization
+		PerfectHashJoinStats perfect_join_stats;
+		CheckForPerfectJoinOpt(op, perfect_join_stats);
+		plan = make_unique<PhysicalHashJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
+		                                     op.left_projection_map, op.right_projection_map, move(op.delim_types),
+		                                     op.estimated_cardinality, perfect_join_stats);
+
+	} else {
+		bool can_merge = has_range > 0;
+		bool can_iejoin = has_range >= 2 && rec_ctes.empty();
+		switch (op.join_type) {
+		case JoinType::SEMI:
+		case JoinType::ANTI:
+		case JoinType::MARK:
+			can_merge = can_merge && op.conditions.size() == 1;
+			can_iejoin = false;
+			break;
+		default:
+			break;
+		}
+		if (can_iejoin) {
+			plan = make_unique<PhysicalIEJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
+			                                   op.estimated_cardinality);
+		} else if (can_merge) {
+			// range join: use piecewise merge join
+			plan = make_unique<PhysicalPiecewiseMergeJoin>(op, move(left), move(right), move(op.conditions),
+			                                               op.join_type, op.estimated_cardinality);
+		} else {
+			// inequality join: use nested loop
+			plan = make_unique<PhysicalNestedLoopJoin>(op, move(left), move(right), move(op.conditions), op.join_type,
+			                                           op.estimated_cardinality);
+		}
+	}
+	return plan;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCopyToFile &op) {
+	auto plan = CreatePlan(*op.children[0]);
+	bool use_tmp_file = op.is_file_and_exists && op.use_tmp_file;
+	if (use_tmp_file) {
+		op.file_path += ".tmp";
+	}
+	// COPY from select statement to file
+	auto copy = make_unique<PhysicalCopyToFile>(op.types, op.function, move(op.bind_data), op.estimated_cardinality);
+	copy->file_path = op.file_path;
+	copy->use_tmp_file = use_tmp_file;
+
+	copy->children.push_back(move(plan));
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreate &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_CREATE_SEQUENCE:
+		return make_unique<PhysicalCreateSequence>(unique_ptr_cast<CreateInfo, CreateSequenceInfo>(move(op.info)),
+		                                           op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_CREATE_VIEW:
+		return make_unique<PhysicalCreateView>(unique_ptr_cast<CreateInfo, CreateViewInfo>(move(op.info)),
+		                                       op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_CREATE_SCHEMA:
+		return make_unique<PhysicalCreateSchema>(unique_ptr_cast<CreateInfo, CreateSchemaInfo>(move(op.info)),
+		                                         op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_CREATE_MACRO:
+		return make_unique<PhysicalCreateFunction>(unique_ptr_cast<CreateInfo, CreateMacroInfo>(move(op.info)),
+		                                           op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_CREATE_TYPE:
+		return make_unique<PhysicalCreateType>(unique_ptr_cast<CreateInfo, CreateTypeInfo>(move(op.info)),
+		                                       op.estimated_cardinality);
+	default:
+		throw NotImplementedException("Unimplemented type for logical simple create");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateIndex &op) {
+	D_ASSERT(op.children.empty());
+	dependencies.insert(&op.table);
+	return make_unique<PhysicalCreateIndex>(op, op.table, op.column_ids, move(op.expressions), move(op.info),
+	                                        move(op.unbound_expressions), op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void ExtractDependencies(Expression &expr, unordered_set<CatalogEntry *> &dependencies) {
+	if (expr.type == ExpressionType::BOUND_FUNCTION) {
+		auto &function = (BoundFunctionExpression &)expr;
+		if (function.function.dependency) {
+			function.function.dependency(function, dependencies);
+		}
+	}
+	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { ExtractDependencies(child, dependencies); });
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCreateTable &op) {
+	// extract dependencies from any default values
+	for (auto &default_value : op.info->bound_defaults) {
+		if (default_value) {
+			ExtractDependencies(*default_value, op.info->dependencies);
+		}
+	}
+	auto &create_info = (CreateTableInfo &)*op.info->base;
+	auto &catalog = Catalog::GetCatalog(context);
+	auto existing_entry =
+	    catalog.GetEntry(context, CatalogType::TABLE_ENTRY, create_info.schema, create_info.table, true);
+	bool replace = op.info->Base().on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT;
+	if ((!existing_entry || replace) && !op.children.empty()) {
+		D_ASSERT(op.children.size() == 1);
+		auto create = make_unique<PhysicalCreateTableAs>(op, op.schema, move(op.info), op.estimated_cardinality);
+		auto plan = CreatePlan(*op.children[0]);
+		create->children.push_back(move(plan));
+		return move(create);
+	} else {
+		return make_unique<PhysicalCreateTable>(op, op.schema, move(op.info), op.estimated_cardinality);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCrossProduct &op) {
+	D_ASSERT(op.children.size() == 2);
+
+	auto left = CreatePlan(*op.children[0]);
+	auto right = CreatePlan(*op.children[1]);
+	return make_unique<PhysicalCrossProduct>(op.types, move(left), move(right), op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelete &op) {
+	D_ASSERT(op.children.size() == 1);
+	D_ASSERT(op.expressions.size() == 1);
+	D_ASSERT(op.expressions[0]->type == ExpressionType::BOUND_REF);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	// get the index of the row_id column
+	auto &bound_ref = (BoundReferenceExpression &)*op.expressions[0];
+
+	dependencies.insert(op.table);
+	auto del = make_unique<PhysicalDelete>(op.types, *op.table, *op.table->storage, bound_ref.index,
+	                                       op.estimated_cardinality, op.return_chunk);
+	del->children.push_back(move(plan));
+	return move(del);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimGet &op) {
+	D_ASSERT(op.children.empty());
+
+	// create a PhysicalChunkScan without an owned_collection, the collection will be added later
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::DELIM_SCAN, op.estimated_cardinality);
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void GatherDelimScans(PhysicalOperator *op, vector<PhysicalOperator *> &delim_scans) {
+	D_ASSERT(op);
+	if (op->type == PhysicalOperatorType::DELIM_SCAN) {
+		delim_scans.push_back(op);
+	}
+	for (auto &child : op->children) {
+		GatherDelimScans(child.get(), delim_scans);
+	}
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDelimJoin &op) {
+	// first create the underlying join
+	auto plan = CreatePlan((LogicalComparisonJoin &)op);
+	// this should create a join, not a cross product
+	D_ASSERT(plan && plan->type != PhysicalOperatorType::CROSS_PRODUCT);
+	// duplicate eliminated join
+	// first gather the scans on the duplicate eliminated data set from the RHS
+	vector<PhysicalOperator *> delim_scans;
+	GatherDelimScans(plan->children[1].get(), delim_scans);
+	if (delim_scans.empty()) {
+		// no duplicate eliminated scans in the RHS!
+		// in this case we don't need to create a delim join
+		// just push the normal join
+		return plan;
+	}
+	vector<LogicalType> delim_types;
+	vector<unique_ptr<Expression>> distinct_groups, distinct_expressions;
+	for (auto &delim_expr : op.duplicate_eliminated_columns) {
+		D_ASSERT(delim_expr->type == ExpressionType::BOUND_REF);
+		auto &bound_ref = (BoundReferenceExpression &)*delim_expr;
+		delim_types.push_back(bound_ref.return_type);
+		distinct_groups.push_back(make_unique<BoundReferenceExpression>(bound_ref.return_type, bound_ref.index));
+	}
+	// now create the duplicate eliminated join
+	auto delim_join = make_unique<PhysicalDelimJoin>(op.types, move(plan), delim_scans, op.estimated_cardinality);
+	// we still have to create the DISTINCT clause that is used to generate the duplicate eliminated chunk
+	delim_join->distinct = make_unique<PhysicalHashAggregate>(context, delim_types, move(distinct_expressions),
+	                                                          move(distinct_groups), op.estimated_cardinality);
+	return move(delim_join);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreateDistinctOn(unique_ptr<PhysicalOperator> child,
+                                                                     vector<unique_ptr<Expression>> distinct_targets) {
+	D_ASSERT(child);
+	D_ASSERT(!distinct_targets.empty());
+
+	auto &types = child->GetTypes();
+	vector<unique_ptr<Expression>> groups, aggregates, projections;
+	idx_t group_count = distinct_targets.size();
+	unordered_map<idx_t, idx_t> group_by_references;
+	vector<LogicalType> aggregate_types;
+	// creates one group per distinct_target
+	for (idx_t i = 0; i < distinct_targets.size(); i++) {
+		auto &target = distinct_targets[i];
+		if (target->type == ExpressionType::BOUND_REF) {
+			auto &bound_ref = (BoundReferenceExpression &)*target;
+			group_by_references[bound_ref.index] = i;
+		}
+		aggregate_types.push_back(target->return_type);
+		groups.push_back(move(target));
+	}
+	bool requires_projection = false;
+	if (types.size() != group_count) {
+		requires_projection = true;
+	}
+	// we need to create one aggregate per column in the select_list
+	for (idx_t i = 0; i < types.size(); ++i) {
+		auto logical_type = types[i];
+		// check if we can directly refer to a group, or if we need to push an aggregate with FIRST
+		auto entry = group_by_references.find(i);
+		if (entry != group_by_references.end()) {
+			auto group_index = entry->second;
+			// entry is found: can directly refer to a group
+			projections.push_back(make_unique<BoundReferenceExpression>(logical_type, group_index));
+			if (group_index != i) {
+				// we require a projection only if this group element is out of order
+				requires_projection = true;
+			}
+		} else {
+			// entry is not one of the groups: need to push a FIRST aggregate
+			auto bound = make_unique<BoundReferenceExpression>(logical_type, i);
+			vector<unique_ptr<Expression>> first_children;
+			first_children.push_back(move(bound));
+			auto first_aggregate = AggregateFunction::BindAggregateFunction(
+			    context, FirstFun::GetFunction(logical_type), move(first_children), nullptr, false);
+			// add the projection
+			projections.push_back(make_unique<BoundReferenceExpression>(logical_type, group_count + aggregates.size()));
+			// push it to the list of aggregates
+			aggregate_types.push_back(logical_type);
+			aggregates.push_back(move(first_aggregate));
+			requires_projection = true;
+		}
+	}
+
+	child = ExtractAggregateExpressions(move(child), aggregates, groups);
+
+	// we add a physical hash aggregation in the plan to select the distinct groups
+	auto groupby = make_unique<PhysicalHashAggregate>(context, aggregate_types, move(aggregates), move(groups),
+	                                                  child->estimated_cardinality);
+	groupby->children.push_back(move(child));
+	if (!requires_projection) {
+		return move(groupby);
+	}
+
+	// we add a physical projection on top of the aggregation to project all members in the select list
+	auto aggr_projection = make_unique<PhysicalProjection>(types, move(projections), groupby->estimated_cardinality);
+	aggr_projection->children.push_back(move(groupby));
+	return move(aggr_projection);
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDistinct &op) {
+	D_ASSERT(op.children.size() == 1);
+	auto plan = CreatePlan(*op.children[0]);
+	return CreateDistinctOn(move(plan), move(op.distinct_targets));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalDummyScan &op) {
+	D_ASSERT(op.children.size() == 0);
+	return make_unique<PhysicalDummyScan>(op.types, op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalEmptyResult &op) {
+	D_ASSERT(op.children.size() == 0);
+	return make_unique<PhysicalEmptyResult>(op.types, op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExecute &op) {
+	if (!op.prepared->plan) {
+		D_ASSERT(op.children.size() == 1);
+		auto owned_plan = CreatePlan(*op.children[0]);
+		auto execute = make_unique<PhysicalExecute>(owned_plan.get());
+		execute->owned_plan = move(owned_plan);
+		execute->prepared = move(op.prepared);
+		return move(execute);
+	} else {
+		D_ASSERT(op.children.size() == 0);
+		return make_unique<PhysicalExecute>(op.prepared->plan.get());
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExplain &op) {
+	D_ASSERT(op.children.size() == 1);
+	auto logical_plan_opt = op.children[0]->ToString();
+	auto plan = CreatePlan(*op.children[0]);
+	if (op.explain_type == ExplainType::EXPLAIN_ANALYZE) {
+		auto result = make_unique<PhysicalExplainAnalyze>(op.types);
+		result->children.push_back(move(plan));
+		return move(result);
+	}
+
+	op.physical_plan = plan->ToString();
+	// the output of the explain
+	vector<string> keys, values;
+	switch (ClientConfig::GetConfig(context).explain_output_type) {
+	case ExplainOutputType::OPTIMIZED_ONLY:
+		keys = {"logical_opt"};
+		values = {logical_plan_opt};
+		break;
+	case ExplainOutputType::PHYSICAL_ONLY:
+		keys = {"physical_plan"};
+		values = {op.physical_plan};
+		break;
+	default:
+		keys = {"logical_plan", "logical_opt", "physical_plan"};
+		values = {op.logical_plan_unopt, logical_plan_opt, op.physical_plan};
+	}
+
+	// create a ChunkCollection from the output
+	auto collection = make_unique<ChunkCollection>();
+
+	DataChunk chunk;
+	chunk.Initialize(op.types);
+	for (idx_t i = 0; i < keys.size(); i++) {
+		chunk.SetValue(0, chunk.size(), Value(keys[i]));
+		chunk.SetValue(1, chunk.size(), Value(values[i]));
+		chunk.SetCardinality(chunk.size() + 1);
+		if (chunk.size() == STANDARD_VECTOR_SIZE) {
+			collection->Append(chunk);
+			chunk.Reset();
+		}
+	}
+	collection->Append(chunk);
+
+	// create a chunk scan to output the result
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
+	chunk_scan->owned_collection = move(collection);
+	chunk_scan->collection = chunk_scan->owned_collection.get();
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExport &op) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("Export is disabled through configuration");
+	}
+	auto export_node = make_unique<PhysicalExport>(op.types, op.function, move(op.copy_info), op.estimated_cardinality,
+	                                               op.exported_tables);
+	// plan the underlying copy statements, if any
+	if (!op.children.empty()) {
+		auto plan = CreatePlan(*op.children[0]);
+		export_node->children.push_back(move(plan));
+	}
+	return move(export_node);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalExpressionGet &op) {
+	D_ASSERT(op.children.size() == 1);
+	auto plan = CreatePlan(*op.children[0]);
+
+	auto expr_scan = make_unique<PhysicalExpressionScan>(op.types, move(op.expressions), op.estimated_cardinality);
+	expr_scan->children.push_back(move(plan));
+	if (!expr_scan->IsFoldable()) {
+		return move(expr_scan);
+	}
+	// simple expression scan (i.e. no subqueries to evaluate and no prepared statement parameters)
+	// we can evaluate all the expressions right now and turn this into a chunk collection scan
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, expr_scan->expressions.size());
+	chunk_scan->owned_collection = make_unique<ChunkCollection>();
+	chunk_scan->collection = chunk_scan->owned_collection.get();
+
+	DataChunk chunk;
+	chunk.Initialize(op.types);
+	for (idx_t expression_idx = 0; expression_idx < expr_scan->expressions.size(); expression_idx++) {
+		chunk.Reset();
+		expr_scan->EvaluateExpression(expression_idx, nullptr, chunk);
+		chunk_scan->owned_collection->Append(chunk);
+	}
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalFilter &op) {
+	D_ASSERT(op.children.size() == 1);
+	unique_ptr<PhysicalOperator> plan = CreatePlan(*op.children[0]);
+	if (!op.expressions.empty()) {
+		D_ASSERT(plan->types.size() > 0);
+		// create a filter if there is anything to filter
+		auto filter = make_unique<PhysicalFilter>(plan->types, move(op.expressions), op.estimated_cardinality);
+		filter->children.push_back(move(plan));
+		plan = move(filter);
+	}
+	if (!op.projection_map.empty()) {
+		// there is a projection map, generate a physical projection
+		vector<unique_ptr<Expression>> select_list;
+		for (idx_t i = 0; i < op.projection_map.size(); i++) {
+			select_list.push_back(make_unique<BoundReferenceExpression>(op.types[i], op.projection_map[i]));
+		}
+		auto proj = make_unique<PhysicalProjection>(op.types, move(select_list), op.estimated_cardinality);
+		proj->children.push_back(move(plan));
+		plan = move(proj);
+	}
+	return plan;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<TableFilterSet> CreateTableFilterSet(TableFilterSet &table_filters, vector<column_t> &column_ids) {
+	// create the table filter map
+	auto table_filter_set = make_unique<TableFilterSet>();
+	for (auto &table_filter : table_filters.filters) {
+		// find the relative column index from the absolute column index into the table
+		idx_t column_index = DConstants::INVALID_INDEX;
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			if (table_filter.first == column_ids[i]) {
+				column_index = i;
+				break;
+			}
+		}
+		if (column_index == DConstants::INVALID_INDEX) {
+			throw InternalException("Could not find column index for table filter");
+		}
+		table_filter_set->filters[column_index] = move(table_filter.second);
+	}
+	return table_filter_set;
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalGet &op) {
+	if (!op.children.empty()) {
+		// this is for table producing functions that consume subquery results
+		D_ASSERT(op.children.size() == 1);
+		auto node = make_unique<PhysicalTableInOutFunction>(op.returned_types, op.function, move(op.bind_data),
+		                                                    op.column_ids, op.estimated_cardinality);
+		node->children.push_back(CreatePlan(move(op.children[0])));
+		return move(node);
+	}
+
+	unique_ptr<TableFilterSet> table_filters;
+	if (!op.table_filters.filters.empty()) {
+		table_filters = CreateTableFilterSet(op.table_filters, op.column_ids);
+	}
+
+	if (op.function.dependency) {
+		op.function.dependency(dependencies, op.bind_data.get());
+	}
+	// create the table scan node
+	if (!op.function.projection_pushdown) {
+		// function does not support projection pushdown
+		auto node = make_unique<PhysicalTableScan>(op.returned_types, op.function, move(op.bind_data), op.column_ids,
+		                                           op.names, move(table_filters), op.estimated_cardinality);
+		// first check if an additional projection is necessary
+		if (op.column_ids.size() == op.returned_types.size()) {
+			bool projection_necessary = false;
+			for (idx_t i = 0; i < op.column_ids.size(); i++) {
+				if (op.column_ids[i] != i) {
+					projection_necessary = true;
+					break;
+				}
+			}
+			if (!projection_necessary) {
+				// a projection is not necessary if all columns have been requested in-order
+				// in that case we just return the node
+
+				return move(node);
+			}
+		}
+		// push a projection on top that does the projection
+		vector<LogicalType> types;
+		vector<unique_ptr<Expression>> expressions;
+		for (auto &column_id : op.column_ids) {
+			if (column_id == COLUMN_IDENTIFIER_ROW_ID) {
+				types.emplace_back(LogicalType::BIGINT);
+				expressions.push_back(make_unique<BoundConstantExpression>(Value::BIGINT(0)));
+			} else {
+				auto type = op.returned_types[column_id];
+				types.push_back(type);
+				expressions.push_back(make_unique<BoundReferenceExpression>(type, column_id));
+			}
+		}
+
+		auto projection = make_unique<PhysicalProjection>(move(types), move(expressions), op.estimated_cardinality);
+		projection->children.push_back(move(node));
+		return move(projection);
+	} else {
+		return make_unique<PhysicalTableScan>(op.types, op.function, move(op.bind_data), op.column_ids, op.names,
+		                                      move(table_filters), op.estimated_cardinality);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalInsert &op) {
+	unique_ptr<PhysicalOperator> plan;
+	if (!op.children.empty()) {
+		D_ASSERT(op.children.size() == 1);
+		plan = CreatePlan(*op.children[0]);
+	}
+
+	dependencies.insert(op.table);
+	auto insert = make_unique<PhysicalInsert>(op.types, op.table, op.column_index_map, move(op.bound_defaults),
+	                                          op.estimated_cardinality, op.return_chunk);
+	if (plan) {
+		insert->children.push_back(move(plan));
+	}
+	return move(insert);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalLimit &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+	auto &config = DBConfig::GetConfig(context);
+	unique_ptr<PhysicalOperator> limit;
+	if (!config.preserve_insertion_order) {
+		// use parallel streaming limit if insertion order is not important
+		limit = make_unique<PhysicalStreamingLimit>(op.types, (idx_t)op.limit_val, op.offset_val, move(op.limit),
+		                                            move(op.offset), op.estimated_cardinality, true);
+	} else {
+		// maintaining insertion order is important
+		bool all_sources_support_batch_index = plan->AllSourcesSupportBatchIndex();
+
+		if (all_sources_support_batch_index) {
+			// source supports batch index: use parallel batch limit
+			limit = make_unique<PhysicalLimit>(op.types, (idx_t)op.limit_val, op.offset_val, move(op.limit),
+			                                   move(op.offset), op.estimated_cardinality);
+		} else {
+			// source does not support batch index: use a non-parallel streaming limit
+			limit = make_unique<PhysicalStreamingLimit>(op.types, (idx_t)op.limit_val, op.offset_val, move(op.limit),
+			                                            move(op.offset), op.estimated_cardinality, false);
+		}
+	}
+
+	limit->children.push_back(move(plan));
+	return limit;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalLimitPercent &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	auto limit = make_unique<PhysicalLimitPercent>(op.types, op.limit_percent, op.offset_val, move(op.limit),
+	                                               move(op.offset), op.estimated_cardinality);
+	limit->children.push_back(move(plan));
+	return move(limit);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOrder &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+	if (!op.orders.empty()) {
+		auto order = make_unique<PhysicalOrder>(op.types, move(op.orders), op.estimated_cardinality);
+		order->children.push_back(move(plan));
+		plan = move(order);
+	}
+	return plan;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPragma &op) {
+	return make_unique<PhysicalPragma>(op.function, op.info, op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalPrepare &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	// generate physical plan
+	auto plan = CreatePlan(*op.children[0]);
+	op.prepared->types = plan->types;
+	op.prepared->plan = move(plan);
+
+	return make_unique<PhysicalPrepare>(op.name, move(op.prepared), op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalProjection &op) {
+	D_ASSERT(op.children.size() == 1);
+	auto plan = CreatePlan(*op.children[0]);
+
+#ifdef DEBUG
+	for (auto &expr : op.expressions) {
+		D_ASSERT(!expr->IsWindow());
+		D_ASSERT(!expr->IsAggregate());
+	}
+#endif
+	if (plan->types.size() == op.types.size()) {
+		// check if this projection can be omitted entirely
+		// this happens if a projection simply emits the columns in the same order
+		// e.g. PROJECTION(#0, #1, #2, #3, ...)
+		bool omit_projection = true;
+		for (idx_t i = 0; i < op.types.size(); i++) {
+			if (op.expressions[i]->type == ExpressionType::BOUND_REF) {
+				auto &bound_ref = (BoundReferenceExpression &)*op.expressions[i];
+				if (bound_ref.index == i) {
+					continue;
+				}
+			}
+			omit_projection = false;
+			break;
+		}
+		if (omit_projection) {
+			// the projection only directly projects the child' columns: omit it entirely
+			return plan;
+		}
+	}
+
+	auto projection = make_unique<PhysicalProjection>(op.types, move(op.expressions), op.estimated_cardinality);
+	projection->children.push_back(move(plan));
+	return move(projection);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalRecursiveCTE &op) {
+	D_ASSERT(op.children.size() == 2);
+
+	// Create the working_table that the PhysicalRecursiveCTE will use for evaluation.
+	auto working_table = std::make_shared<ChunkCollection>();
+
+	// Add the ChunkCollection to the context of this PhysicalPlanGenerator
+	rec_ctes[op.table_index] = working_table;
+
+	auto left = CreatePlan(*op.children[0]);
+	auto right = CreatePlan(*op.children[1]);
+
+	auto cte =
+	    make_unique<PhysicalRecursiveCTE>(op.types, op.union_all, move(left), move(right), op.estimated_cardinality);
+	cte->working_table = working_table;
+
+	return move(cte);
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalCTERef &op) {
+	D_ASSERT(op.children.empty());
+
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::RECURSIVE_CTE_SCAN, op.estimated_cardinality);
+
+	// CreatePlan of a LogicalRecursiveCTE must have happened before.
+	auto cte = rec_ctes.find(op.cte_index);
+	if (cte == rec_ctes.end()) {
+		throw Exception("Referenced recursive CTE does not exist.");
+	}
+	chunk_scan->collection = cte->second.get();
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSample &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	unique_ptr<PhysicalOperator> sample;
+	switch (op.sample_options->method) {
+	case SampleMethod::RESERVOIR_SAMPLE:
+		sample = make_unique<PhysicalReservoirSample>(op.types, move(op.sample_options), op.estimated_cardinality);
+		break;
+	case SampleMethod::SYSTEM_SAMPLE:
+	case SampleMethod::BERNOULLI_SAMPLE:
+		if (!op.sample_options->is_percentage) {
+			throw ParserException("Sample method %s cannot be used with a discrete sample count, either switch to "
+			                      "reservoir sampling or use a sample_size",
+			                      SampleMethodToString(op.sample_options->method));
+		}
+		sample = make_unique<PhysicalStreamingSample>(op.types, op.sample_options->method,
+		                                              op.sample_options->sample_size.GetValue<double>(),
+		                                              op.sample_options->seed, op.estimated_cardinality);
+		break;
+	default:
+		throw InternalException("Unimplemented sample method");
+	}
+	sample->children.push_back(move(plan));
+	return sample;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSet &op) {
+	return make_unique<PhysicalSet>(op.name, op.value, op.scope, op.estimated_cardinality);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSetOperation &op) {
+	D_ASSERT(op.children.size() == 2);
+
+	auto left = CreatePlan(*op.children[0]);
+	auto right = CreatePlan(*op.children[1]);
+
+	if (left->GetTypes() != right->GetTypes()) {
+		throw Exception("Type mismatch for SET OPERATION");
+	}
+
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_UNION:
+		// UNION
+		return make_unique<PhysicalUnion>(op.types, move(left), move(right), op.estimated_cardinality);
+	default: {
+		// EXCEPT/INTERSECT
+		D_ASSERT(op.type == LogicalOperatorType::LOGICAL_EXCEPT || op.type == LogicalOperatorType::LOGICAL_INTERSECT);
+		auto &types = left->GetTypes();
+		vector<JoinCondition> conditions;
+		// create equality condition for all columns
+		for (idx_t i = 0; i < types.size(); i++) {
+			JoinCondition cond;
+			cond.left = make_unique<BoundReferenceExpression>(types[i], i);
+			cond.right = make_unique<BoundReferenceExpression>(types[i], i);
+			cond.comparison = ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+			conditions.push_back(move(cond));
+		}
+		// EXCEPT is ANTI join
+		// INTERSECT is SEMI join
+		PerfectHashJoinStats join_stats; // used in inner joins only
+		JoinType join_type = op.type == LogicalOperatorType::LOGICAL_EXCEPT ? JoinType::ANTI : JoinType::SEMI;
+		return make_unique<PhysicalHashJoin>(op, move(left), move(right), move(conditions), join_type,
+		                                     op.estimated_cardinality, join_stats);
+	}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalShow &op) {
+	DataChunk output;
+	output.Initialize(op.types);
+
+	auto collection = make_unique<ChunkCollection>();
+	for (idx_t column_idx = 0; column_idx < op.types_select.size(); column_idx++) {
+		auto type = op.types_select[column_idx];
+		auto &name = op.aliases[column_idx];
+
+		// "name", TypeId::VARCHAR
+		output.SetValue(0, output.size(), Value(name));
+		// "type", TypeId::VARCHAR
+		output.SetValue(1, output.size(), Value(type.ToString()));
+		// "null", TypeId::VARCHAR
+		output.SetValue(2, output.size(), Value("YES"));
+		// "pk", TypeId::BOOL
+		output.SetValue(3, output.size(), Value());
+		// "dflt_value", TypeId::VARCHAR
+		output.SetValue(4, output.size(), Value());
+		// "extra", TypeId::VARCHAR
+		output.SetValue(5, output.size(), Value());
+
+		output.SetCardinality(output.size() + 1);
+		if (output.size() == STANDARD_VECTOR_SIZE) {
+			collection->Append(output);
+			output.Reset();
+		}
+	}
+
+	collection->Append(output);
+
+	// create a chunk scan to output the result
+	auto chunk_scan =
+	    make_unique<PhysicalChunkScan>(op.types, PhysicalOperatorType::CHUNK_SCAN, op.estimated_cardinality);
+	chunk_scan->owned_collection = move(collection);
+	chunk_scan->collection = chunk_scan->owned_collection.get();
+	return move(chunk_scan);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalSimple &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_ALTER:
+		return make_unique<PhysicalAlter>(unique_ptr_cast<ParseInfo, AlterInfo>(move(op.info)),
+		                                  op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_DROP:
+		return make_unique<PhysicalDrop>(unique_ptr_cast<ParseInfo, DropInfo>(move(op.info)), op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_TRANSACTION:
+		return make_unique<PhysicalTransaction>(unique_ptr_cast<ParseInfo, TransactionInfo>(move(op.info)),
+		                                        op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_VACUUM:
+		return make_unique<PhysicalVacuum>(unique_ptr_cast<ParseInfo, VacuumInfo>(move(op.info)),
+		                                   op.estimated_cardinality);
+	case LogicalOperatorType::LOGICAL_LOAD:
+		return make_unique<PhysicalLoad>(unique_ptr_cast<ParseInfo, LoadInfo>(move(op.info)), op.estimated_cardinality);
+	default:
+		throw NotImplementedException("Unimplemented type for logical simple operator");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalTopN &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	auto top_n =
+	    make_unique<PhysicalTopN>(op.types, move(op.orders), (idx_t)op.limit, op.offset, op.estimated_cardinality);
+	top_n->children.push_back(move(plan));
+	return move(top_n);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUnnest &op) {
+	D_ASSERT(op.children.size() == 1);
+	auto plan = CreatePlan(*op.children[0]);
+	auto unnest = make_unique<PhysicalUnnest>(op.types, move(op.expressions), op.estimated_cardinality);
+	unnest->children.push_back(move(plan));
+	return move(unnest);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalUpdate &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+
+	dependencies.insert(op.table);
+	auto update = make_unique<PhysicalUpdate>(op.types, *op.table, *op.table->storage, op.columns, move(op.expressions),
+	                                          move(op.bound_defaults), op.estimated_cardinality, op.return_chunk);
+
+	update->update_is_del_and_insert = op.update_is_del_and_insert;
+	update->children.push_back(move(plan));
+	return move(update);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+#include <numeric>
+
+namespace duckdb {
+
+static bool IsStreamingWindow(unique_ptr<Expression> &expr) {
+	auto wexpr = reinterpret_cast<BoundWindowExpression *>(expr.get());
+	if (!wexpr->partitions.empty() || !wexpr->orders.empty() || wexpr->ignore_nulls) {
+		return false;
+	}
+	switch (wexpr->type) {
+	// TODO: add more expression types here?
+	case ExpressionType::WINDOW_FIRST_VALUE:
+	case ExpressionType::WINDOW_PERCENT_RANK:
+	case ExpressionType::WINDOW_RANK:
+	case ExpressionType::WINDOW_RANK_DENSE:
+	case ExpressionType::WINDOW_ROW_NUMBER:
+		return true;
+	default:
+		return false;
+	}
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalWindow &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	auto plan = CreatePlan(*op.children[0]);
+#ifdef DEBUG
+	for (auto &expr : op.expressions) {
+		D_ASSERT(expr->IsWindow());
+	}
+#endif
+
+	// Slice types
+	auto types = op.types;
+	const auto output_idx = types.size() - op.expressions.size();
+	types.resize(output_idx);
+
+	// Identify streaming windows
+	vector<idx_t> blocking_windows;
+	vector<idx_t> streaming_windows;
+	for (idx_t expr_idx = 0; expr_idx < op.expressions.size(); expr_idx++) {
+		if (IsStreamingWindow(op.expressions[expr_idx])) {
+			streaming_windows.push_back(expr_idx);
+		} else {
+			blocking_windows.push_back(expr_idx);
+		}
+	}
+
+	// Process the window functions by sharing the partition/order definitions
+	vector<idx_t> evaluation_order;
+	while (!blocking_windows.empty() || !streaming_windows.empty()) {
+		const bool process_streaming = blocking_windows.empty();
+		auto &remaining = process_streaming ? streaming_windows : blocking_windows;
+
+		// Find all functions that share the partitioning of the first remaining expression
+		const auto over_idx = remaining[0];
+		auto over_expr = reinterpret_cast<BoundWindowExpression *>(op.expressions[over_idx].get());
+
+		vector<idx_t> matching;
+		vector<idx_t> unprocessed;
+		for (const auto &expr_idx : remaining) {
+			D_ASSERT(op.expressions[expr_idx]->GetExpressionClass() == ExpressionClass::BOUND_WINDOW);
+			auto wexpr = reinterpret_cast<BoundWindowExpression *>(op.expressions[expr_idx].get());
+			if (over_expr->KeysAreCompatible(wexpr)) {
+				matching.emplace_back(expr_idx);
+			} else {
+				unprocessed.emplace_back(expr_idx);
+			}
+		}
+		remaining.swap(unprocessed);
+
+		// Extract the matching expressions
+		vector<unique_ptr<Expression>> select_list;
+		for (const auto &expr_idx : matching) {
+			select_list.emplace_back(move(op.expressions[expr_idx]));
+			types.emplace_back(op.types[output_idx + expr_idx]);
+		}
+
+		// Chain the new window operator on top of the plan
+		unique_ptr<PhysicalOperator> window;
+		if (process_streaming) {
+			window = make_unique<PhysicalStreamingWindow>(types, move(select_list), op.estimated_cardinality);
+		} else {
+			window = make_unique<PhysicalWindow>(types, move(select_list), op.estimated_cardinality);
+		}
+		window->children.push_back(move(plan));
+		plan = move(window);
+
+		// Remember the projection order if we changed it
+		if (!remaining.empty() || !evaluation_order.empty()) {
+			evaluation_order.insert(evaluation_order.end(), matching.begin(), matching.end());
+		}
+	}
+
+	// Put everything back into place if it moved
+	if (!evaluation_order.empty()) {
+		vector<unique_ptr<Expression>> select_list(op.types.size());
+		// The inputs don't move
+		for (idx_t i = 0; i < output_idx; ++i) {
+			select_list[i] = make_unique<BoundReferenceExpression>(op.types[i], i);
+		}
+		// The outputs have been rearranged
+		for (idx_t i = 0; i < evaluation_order.size(); ++i) {
+			const auto expr_idx = evaluation_order[i] + output_idx;
+			select_list[expr_idx] = make_unique<BoundReferenceExpression>(op.types[expr_idx], i + output_idx);
+		}
+		auto proj = make_unique<PhysicalProjection>(op.types, move(select_list), op.estimated_cardinality);
+		proj->children.push_back(move(plan));
+		plan = move(proj);
+	}
+
+	return plan;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+class DependencyExtractor : public LogicalOperatorVisitor {
+public:
+	explicit DependencyExtractor(unordered_set<CatalogEntry *> &dependencies) : dependencies(dependencies) {
+	}
+
+protected:
+	unique_ptr<Expression> VisitReplace(BoundFunctionExpression &expr, unique_ptr<Expression> *expr_ptr) override {
+		// extract dependencies from the bound function expression
+		if (expr.function.dependency) {
+			expr.function.dependency(expr, dependencies);
+		}
+		return nullptr;
+	}
+
+private:
+	unordered_set<CatalogEntry *> &dependencies;
+};
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(unique_ptr<LogicalOperator> op) {
+	auto &profiler = QueryProfiler::Get(context);
+
+	// first resolve column references
+	profiler.StartPhase("column_binding");
+	ColumnBindingResolver resolver;
+	resolver.VisitOperator(*op);
+	profiler.EndPhase();
+
+	// now resolve types of all the operators
+	profiler.StartPhase("resolve_types");
+	op->ResolveOperatorTypes();
+	profiler.EndPhase();
+
+	// extract dependencies from the logical plan
+	DependencyExtractor extractor(dependencies);
+	extractor.VisitOperator(*op);
+
+	// then create the main physical plan
+	profiler.StartPhase("create_plan");
+	auto plan = CreatePlan(*op);
+	profiler.EndPhase();
+
+	plan->Verify();
+	return plan;
+}
+
+unique_ptr<PhysicalOperator> PhysicalPlanGenerator::CreatePlan(LogicalOperator &op) {
+	op.estimated_cardinality = op.EstimateCardinality(context);
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_GET:
+		return CreatePlan((LogicalGet &)op);
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+		return CreatePlan((LogicalProjection &)op);
+	case LogicalOperatorType::LOGICAL_EMPTY_RESULT:
+		return CreatePlan((LogicalEmptyResult &)op);
+	case LogicalOperatorType::LOGICAL_FILTER:
+		return CreatePlan((LogicalFilter &)op);
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		return CreatePlan((LogicalAggregate &)op);
+	case LogicalOperatorType::LOGICAL_WINDOW:
+		return CreatePlan((LogicalWindow &)op);
+	case LogicalOperatorType::LOGICAL_UNNEST:
+		return CreatePlan((LogicalUnnest &)op);
+	case LogicalOperatorType::LOGICAL_LIMIT:
+		return CreatePlan((LogicalLimit &)op);
+	case LogicalOperatorType::LOGICAL_LIMIT_PERCENT:
+		return CreatePlan((LogicalLimitPercent &)op);
+	case LogicalOperatorType::LOGICAL_SAMPLE:
+		return CreatePlan((LogicalSample &)op);
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+		return CreatePlan((LogicalOrder &)op);
+	case LogicalOperatorType::LOGICAL_TOP_N:
+		return CreatePlan((LogicalTopN &)op);
+	case LogicalOperatorType::LOGICAL_COPY_TO_FILE:
+		return CreatePlan((LogicalCopyToFile &)op);
+	case LogicalOperatorType::LOGICAL_DUMMY_SCAN:
+		return CreatePlan((LogicalDummyScan &)op);
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+		return CreatePlan((LogicalAnyJoin &)op);
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+		return CreatePlan((LogicalDelimJoin &)op);
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+		return CreatePlan((LogicalComparisonJoin &)op);
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+		return CreatePlan((LogicalCrossProduct &)op);
+	case LogicalOperatorType::LOGICAL_UNION:
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+	case LogicalOperatorType::LOGICAL_INTERSECT:
+		return CreatePlan((LogicalSetOperation &)op);
+	case LogicalOperatorType::LOGICAL_INSERT:
+		return CreatePlan((LogicalInsert &)op);
+	case LogicalOperatorType::LOGICAL_DELETE:
+		return CreatePlan((LogicalDelete &)op);
+	case LogicalOperatorType::LOGICAL_CHUNK_GET:
+		return CreatePlan((LogicalChunkGet &)op);
+	case LogicalOperatorType::LOGICAL_DELIM_GET:
+		return CreatePlan((LogicalDelimGet &)op);
+	case LogicalOperatorType::LOGICAL_EXPRESSION_GET:
+		return CreatePlan((LogicalExpressionGet &)op);
+	case LogicalOperatorType::LOGICAL_UPDATE:
+		return CreatePlan((LogicalUpdate &)op);
+	case LogicalOperatorType::LOGICAL_CREATE_TABLE:
+		return CreatePlan((LogicalCreateTable &)op);
+	case LogicalOperatorType::LOGICAL_CREATE_INDEX:
+		return CreatePlan((LogicalCreateIndex &)op);
+	case LogicalOperatorType::LOGICAL_EXPLAIN:
+		return CreatePlan((LogicalExplain &)op);
+	case LogicalOperatorType::LOGICAL_SHOW:
+		return CreatePlan((LogicalShow &)op);
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+		return CreatePlan((LogicalDistinct &)op);
+	case LogicalOperatorType::LOGICAL_PREPARE:
+		return CreatePlan((LogicalPrepare &)op);
+	case LogicalOperatorType::LOGICAL_EXECUTE:
+		return CreatePlan((LogicalExecute &)op);
+	case LogicalOperatorType::LOGICAL_CREATE_VIEW:
+	case LogicalOperatorType::LOGICAL_CREATE_SEQUENCE:
+	case LogicalOperatorType::LOGICAL_CREATE_SCHEMA:
+	case LogicalOperatorType::LOGICAL_CREATE_MACRO:
+	case LogicalOperatorType::LOGICAL_CREATE_TYPE:
+		return CreatePlan((LogicalCreate &)op);
+	case LogicalOperatorType::LOGICAL_PRAGMA:
+		return CreatePlan((LogicalPragma &)op);
+	case LogicalOperatorType::LOGICAL_TRANSACTION:
+	case LogicalOperatorType::LOGICAL_ALTER:
+	case LogicalOperatorType::LOGICAL_DROP:
+	case LogicalOperatorType::LOGICAL_VACUUM:
+	case LogicalOperatorType::LOGICAL_LOAD:
+		return CreatePlan((LogicalSimple &)op);
+	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE:
+		return CreatePlan((LogicalRecursiveCTE &)op);
+	case LogicalOperatorType::LOGICAL_CTE_REF:
+		return CreatePlan((LogicalCTERef &)op);
+	case LogicalOperatorType::LOGICAL_EXPORT:
+		return CreatePlan((LogicalExport &)op);
+	case LogicalOperatorType::LOGICAL_SET:
+		return CreatePlan((LogicalSet &)op);
+	default:
+		throw NotImplementedException("Unimplemented logical operator type!");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+RadixPartitionedHashTable::RadixPartitionedHashTable(GroupingSet &grouping_set_p, const PhysicalHashAggregate &op_p)
+    : grouping_set(grouping_set_p), op(op_p) {
+
+	for (idx_t i = 0; i < op.groups.size(); i++) {
+		if (grouping_set.find(i) == grouping_set.end()) {
+			null_groups.push_back(i);
+		}
+	}
+
+	// 10000 seems like a good compromise here
+	radix_limit = 10000;
+
+	if (grouping_set.empty()) {
+		// fake a single group with a constant value for aggregation without groups
+		group_types.emplace_back(LogicalType::TINYINT);
+	}
+	for (auto &entry : grouping_set) {
+		D_ASSERT(entry < op.group_types.size());
+		group_types.push_back(op.group_types[entry]);
+	}
+	// compute the GROUPING values
+	// for each parameter to the GROUPING clause, we check if the hash table groups on this particular group
+	// if it does, we return 0, otherwise we return 1
+	// we then use bitshifts to combine these values
+	for (auto &grouping : op.grouping_functions) {
+		int64_t grouping_value = 0;
+		for (idx_t i = 0; i < grouping.size(); i++) {
+			if (grouping_set.find(grouping[i]) == grouping_set.end()) {
+				// we don't group on this value!
+				grouping_value += 1 << (grouping.size() - (i + 1));
+			}
+		}
+		grouping_values.push_back(Value::BIGINT(grouping_value));
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+class RadixHTGlobalState : public GlobalSinkState {
+public:
+	explicit RadixHTGlobalState(ClientContext &context)
+	    : is_empty(true), multi_scan(true), total_groups(0),
+	      partition_info((idx_t)TaskScheduler::GetScheduler(context).NumberOfThreads()) {
+	}
+
+	vector<unique_ptr<PartitionableHashTable>> intermediate_hts;
+	vector<unique_ptr<GroupedAggregateHashTable>> finalized_hts;
+
+	//! Whether or not any tuples were added to the HT
+	bool is_empty;
+	//! Whether or not the hash table should be scannable multiple times
+	bool multi_scan;
+	//! The lock for updating the global aggregate state
+	mutex lock;
+	//! a counter to determine if we should switch over to p
+	atomic<idx_t> total_groups;
+
+	bool is_finalized = false;
+	bool is_partitioned = false;
+
+	RadixPartitionInfo partition_info;
+};
+
+class RadixHTLocalState : public LocalSinkState {
+public:
+	explicit RadixHTLocalState(const RadixPartitionedHashTable &ht) : is_empty(true) {
+		// if there are no groups we create a fake group so everything has the same group
+		group_chunk.InitializeEmpty(ht.group_types);
+		if (ht.grouping_set.empty()) {
+			group_chunk.data[0].Reference(Value::TINYINT(42));
+		}
+	}
+
+	DataChunk group_chunk;
+	//! The aggregate HT
+	unique_ptr<PartitionableHashTable> ht;
+
+	//! Whether or not any tuples were added to the HT
+	bool is_empty;
+};
+
+void RadixPartitionedHashTable::SetMultiScan(GlobalSinkState &state) {
+	auto &gstate = (RadixHTGlobalState &)state;
+	gstate.multi_scan = true;
+}
+
+unique_ptr<GlobalSinkState> RadixPartitionedHashTable::GetGlobalSinkState(ClientContext &context) const {
+	return make_unique<RadixHTGlobalState>(context);
+}
+
+unique_ptr<LocalSinkState> RadixPartitionedHashTable::GetLocalSinkState(ExecutionContext &context) const {
+	return make_unique<RadixHTLocalState>(*this);
+}
+
+void RadixPartitionedHashTable::Sink(ExecutionContext &context, GlobalSinkState &state, LocalSinkState &lstate,
+                                     DataChunk &input, DataChunk &aggregate_input_chunk) const {
+	auto &llstate = (RadixHTLocalState &)lstate;
+	auto &gstate = (RadixHTGlobalState &)state;
+	D_ASSERT(!gstate.is_finalized);
+
+	DataChunk &group_chunk = llstate.group_chunk;
+	idx_t chunk_index = 0;
+	for (auto &group_idx : grouping_set) {
+		auto &group = op.groups[group_idx];
+		D_ASSERT(group->type == ExpressionType::BOUND_REF);
+		auto &bound_ref_expr = (BoundReferenceExpression &)*group;
+		group_chunk.data[chunk_index++].Reference(input.data[bound_ref_expr.index]);
+	}
+	group_chunk.SetCardinality(input.size());
+	group_chunk.Verify();
+
+	// if we have non-combinable aggregates (e.g. string_agg) or any distinct aggregates we cannot keep parallel hash
+	// tables
+	if (ForceSingleHT(state)) {
+		lock_guard<mutex> glock(gstate.lock);
+		gstate.is_empty = gstate.is_empty && group_chunk.size() == 0;
+		if (gstate.finalized_hts.empty()) {
+			gstate.finalized_hts.push_back(
+			    make_unique<GroupedAggregateHashTable>(BufferManager::GetBufferManager(context.client), group_types,
+			                                           op.payload_types, op.bindings, HtEntryType::HT_WIDTH_64));
+		}
+		D_ASSERT(gstate.finalized_hts.size() == 1);
+		D_ASSERT(gstate.finalized_hts[0]);
+		gstate.total_groups += gstate.finalized_hts[0]->AddChunk(group_chunk, aggregate_input_chunk);
+		return;
+	}
+
+	D_ASSERT(!op.any_distinct);
+
+	if (group_chunk.size() > 0) {
+		llstate.is_empty = false;
+	}
+
+	if (!llstate.ht) {
+		llstate.ht =
+		    make_unique<PartitionableHashTable>(BufferManager::GetBufferManager(context.client), gstate.partition_info,
+		                                        group_types, op.payload_types, op.bindings);
+	}
+
+	gstate.total_groups +=
+	    llstate.ht->AddChunk(group_chunk, aggregate_input_chunk,
+	                         gstate.total_groups > radix_limit && gstate.partition_info.n_partitions > 1);
+}
+
+void RadixPartitionedHashTable::Combine(ExecutionContext &context, GlobalSinkState &state,
+                                        LocalSinkState &lstate) const {
+	auto &llstate = (RadixHTLocalState &)lstate;
+	auto &gstate = (RadixHTGlobalState &)state;
+	D_ASSERT(!gstate.is_finalized);
+
+	// this actually does not do a lot but just pushes the local HTs into the global state so we can later combine them
+	// in parallel
+
+	if (ForceSingleHT(state)) {
+		D_ASSERT(gstate.finalized_hts.size() <= 1);
+		return;
+	}
+
+	if (!llstate.ht) {
+		return; // no data
+	}
+
+	if (!llstate.ht->IsPartitioned() && gstate.partition_info.n_partitions > 1 && gstate.total_groups > radix_limit) {
+		llstate.ht->Partition();
+	}
+
+	lock_guard<mutex> glock(gstate.lock);
+	D_ASSERT(!op.any_distinct);
+
+	if (!llstate.is_empty) {
+		gstate.is_empty = false;
+	}
+
+	// we will never add new values to these HTs so we can drop the first part of the HT
+	llstate.ht->Finalize();
+
+	// at this point we just collect them the PhysicalHashAggregateFinalizeTask (below) will merge them in parallel
+	gstate.intermediate_hts.push_back(move(llstate.ht));
+}
+
+bool RadixPartitionedHashTable::Finalize(ClientContext &context, GlobalSinkState &gstate_p) const {
+	auto &gstate = (RadixHTGlobalState &)gstate_p;
+	D_ASSERT(!gstate.is_finalized);
+	gstate.is_finalized = true;
+
+	// special case if we have non-combinable aggregates
+	// we have already aggreagted into a global shared HT that does not require any additional finalization steps
+	if (ForceSingleHT(gstate)) {
+		D_ASSERT(gstate.finalized_hts.size() <= 1);
+		D_ASSERT(gstate.finalized_hts.empty() || gstate.finalized_hts[0]);
+		return false;
+	}
+
+	// we can have two cases now, non-partitioned for few groups and radix-partitioned for very many groups.
+	// go through all of the child hts and see if we ever called partition() on any of them
+	// if we did, its the latter case.
+	bool any_partitioned = false;
+	for (auto &pht : gstate.intermediate_hts) {
+		if (pht->IsPartitioned()) {
+			any_partitioned = true;
+			break;
+		}
+	}
+
+	if (any_partitioned) {
+		// if one is partitioned, all have to be
+		// this should mostly have already happened in Combine, but if not we do it here
+		for (auto &pht : gstate.intermediate_hts) {
+			if (!pht->IsPartitioned()) {
+				pht->Partition();
+			}
+		}
+		// schedule additional tasks to combine the partial HTs
+		gstate.finalized_hts.resize(gstate.partition_info.n_partitions);
+		for (idx_t r = 0; r < gstate.partition_info.n_partitions; r++) {
+			gstate.finalized_hts[r] =
+			    make_unique<GroupedAggregateHashTable>(BufferManager::GetBufferManager(context), group_types,
+			                                           op.payload_types, op.bindings, HtEntryType::HT_WIDTH_64);
+		}
+		gstate.is_partitioned = true;
+		return true;
+	} else { // in the non-partitioned case we immediately combine all the unpartitioned hts created by the threads.
+		     // TODO possible optimization, if total count < limit for 32 bit ht, use that one
+		     // create this ht here so finalize needs no lock on gstate
+
+		gstate.finalized_hts.push_back(make_unique<GroupedAggregateHashTable>(BufferManager::GetBufferManager(context),
+		                                                                      group_types, op.payload_types,
+		                                                                      op.bindings, HtEntryType::HT_WIDTH_64));
+		for (auto &pht : gstate.intermediate_hts) {
+			auto unpartitioned = pht->GetUnpartitioned();
+			for (auto &unpartitioned_ht : unpartitioned) {
+				D_ASSERT(unpartitioned_ht);
+				gstate.finalized_hts[0]->Combine(*unpartitioned_ht);
+				unpartitioned_ht.reset();
+			}
+			unpartitioned.clear();
+		}
+		D_ASSERT(gstate.finalized_hts[0]);
+		gstate.finalized_hts[0]->Finalize();
+		return false;
+	}
+}
+
+// this task is run in multiple threads and combines the radix-partitioned hash tables into a single onen and then
+// folds them into the global ht finally.
+class RadixAggregateFinalizeTask : public ExecutorTask {
+public:
+	RadixAggregateFinalizeTask(Executor &executor, shared_ptr<Event> event_p, RadixHTGlobalState &state_p,
+	                           idx_t radix_p)
+	    : ExecutorTask(executor), event(move(event_p)), state(state_p), radix(radix_p) {
+	}
+
+	static void FinalizeHT(RadixHTGlobalState &gstate, idx_t radix) {
+		D_ASSERT(gstate.partition_info.n_partitions <= gstate.finalized_hts.size());
+		D_ASSERT(gstate.finalized_hts[radix]);
+		for (auto &pht : gstate.intermediate_hts) {
+			for (auto &ht : pht->GetPartition(radix)) {
+				gstate.finalized_hts[radix]->Combine(*ht);
+				ht.reset();
+			}
+		}
+		gstate.finalized_hts[radix]->Finalize();
+	}
+
+	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
+		FinalizeHT(state, radix);
+		event->FinishTask();
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+
+private:
+	shared_ptr<Event> event;
+	RadixHTGlobalState &state;
+	idx_t radix;
+};
+
+void RadixPartitionedHashTable::ScheduleTasks(Executor &executor, const shared_ptr<Event> &event,
+                                              GlobalSinkState &state, vector<unique_ptr<Task>> &tasks) const {
+	auto &gstate = (RadixHTGlobalState &)state;
+	if (!gstate.is_partitioned) {
+		return;
+	}
+	for (idx_t r = 0; r < gstate.partition_info.n_partitions; r++) {
+		D_ASSERT(gstate.partition_info.n_partitions <= gstate.finalized_hts.size());
+		D_ASSERT(gstate.finalized_hts[r]);
+		tasks.push_back(make_unique<RadixAggregateFinalizeTask>(executor, event, gstate, r));
+	}
+}
+
+bool RadixPartitionedHashTable::ForceSingleHT(GlobalSinkState &state) const {
+	auto &gstate = (RadixHTGlobalState &)state;
+	return op.any_distinct || gstate.partition_info.n_partitions < 2;
+}
+
+//===--------------------------------------------------------------------===//
+// Source
+//===--------------------------------------------------------------------===//
+class RadixHTGlobalSourceState : public GlobalSourceState {
+public:
+	explicit RadixHTGlobalSourceState(const RadixPartitionedHashTable &ht)
+	    : ht_index(0), ht_scan_position(0), finished(false) {
+		auto scan_chunk_types = ht.group_types;
+		for (auto &aggr_type : ht.op.aggregate_return_types) {
+			scan_chunk_types.push_back(aggr_type);
+		}
+		scan_chunk.Initialize(scan_chunk_types);
+	}
+
+	//! Materialized GROUP BY expressions & aggregates
+	DataChunk scan_chunk;
+	//! The current position to scan the HT for output tuples
+	idx_t ht_index;
+	idx_t ht_scan_position;
+	bool finished;
+};
+
+unique_ptr<GlobalSourceState> RadixPartitionedHashTable::GetGlobalSourceState() const {
+	return make_unique<RadixHTGlobalSourceState>(*this);
+}
+
+void RadixPartitionedHashTable::GetData(ExecutionContext &context, DataChunk &chunk, GlobalSinkState &sink_state,
+                                        GlobalSourceState &source_state) const {
+	auto &gstate = (RadixHTGlobalState &)sink_state;
+	auto &state = (RadixHTGlobalSourceState &)source_state;
+	D_ASSERT(gstate.is_finalized);
+	if (state.finished) {
+		return;
+	}
+
+	state.scan_chunk.Reset();
+	// special case hack to sort out aggregating from empty intermediates
+	// for aggregations without groups
+	if (gstate.is_empty && grouping_set.empty()) {
+		D_ASSERT(chunk.ColumnCount() == null_groups.size() + op.aggregates.size());
+		// for each column in the aggregates, set to initial state
+		chunk.SetCardinality(1);
+		for (auto null_group : null_groups) {
+			chunk.data[null_group].SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(chunk.data[null_group], true);
+		}
+		for (idx_t i = 0; i < op.aggregates.size(); i++) {
+			D_ASSERT(op.aggregates[i]->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
+			auto &aggr = (BoundAggregateExpression &)*op.aggregates[i];
+			auto aggr_state = unique_ptr<data_t[]>(new data_t[aggr.function.state_size()]);
+			aggr.function.initialize(aggr_state.get());
+
+			AggregateInputData aggr_input_data(aggr.bind_info.get());
+			Vector state_vector(Value::POINTER((uintptr_t)aggr_state.get()));
+			aggr.function.finalize(state_vector, aggr_input_data, chunk.data[null_groups.size() + i], 1, 0);
+			if (aggr.function.destructor) {
+				aggr.function.destructor(state_vector, 1);
+			}
+		}
+		state.finished = true;
+		return;
+	}
+	if (gstate.is_empty && !state.finished) {
+		state.finished = true;
+		return;
+	}
+	idx_t elements_found = 0;
+
+	while (true) {
+		if (state.ht_index == gstate.finalized_hts.size()) {
+			state.finished = true;
+			return;
+		}
+		D_ASSERT(gstate.finalized_hts[state.ht_index]);
+		elements_found = gstate.finalized_hts[state.ht_index]->Scan(state.ht_scan_position, state.scan_chunk);
+
+		if (elements_found > 0) {
+			break;
+		}
+		if (!gstate.multi_scan) {
+			gstate.finalized_hts[state.ht_index].reset();
+		}
+		state.ht_index++;
+		state.ht_scan_position = 0;
+	}
+
+	// compute the final projection list
+	chunk.SetCardinality(elements_found);
+
+	idx_t chunk_index = 0;
+	for (auto &entry : grouping_set) {
+		chunk.data[entry].Reference(state.scan_chunk.data[chunk_index++]);
+	}
+	for (auto null_group : null_groups) {
+		chunk.data[null_group].SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(chunk.data[null_group], true);
+	}
+	for (idx_t col_idx = 0; col_idx < op.aggregates.size(); col_idx++) {
+		chunk.data[op.groups.size() + col_idx].Reference(state.scan_chunk.data[group_types.size() + col_idx]);
+	}
+	D_ASSERT(op.grouping_functions.size() == grouping_values.size());
+	for (idx_t i = 0; i < op.grouping_functions.size(); i++) {
+		chunk.data[op.groups.size() + op.aggregates.size() + i].Reference(grouping_values[i]);
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void ReservoirSample::AddToReservoir(DataChunk &input) {
+	if (sample_count == 0) {
+		return;
+	}
+	// Input: A population V of n weighted items
+	// Output: A reservoir R with a size m
+	// 1: The first m items of V are inserted into R
+	// first we need to check if the reservoir already has "m" elements
+	if (reservoir.Count() < sample_count) {
+		if (FillReservoir(input) == 0) {
+			// entire chunk was consumed by reservoir
+			return;
+		}
+	}
+	// find the position of next_index relative to current_count
+	idx_t remaining = input.size();
+	idx_t base_offset = 0;
+	while (true) {
+		idx_t offset = base_reservoir_sample.next_index - base_reservoir_sample.current_count;
+		if (offset >= remaining) {
+			// not in this chunk! increment current count and go to the next chunk
+			base_reservoir_sample.current_count += remaining;
+			return;
+		}
+		// in this chunk! replace the element
+		ReplaceElement(input, base_offset + offset);
+		// shift the chunk forward
+		remaining -= offset;
+		base_offset += offset;
+	}
+}
+
+unique_ptr<DataChunk> ReservoirSample::GetChunk() {
+	return reservoir.Fetch();
+}
+
+void ReservoirSample::ReplaceElement(DataChunk &input, idx_t index_in_chunk) {
+	// replace the entry in the reservoir
+	// 8. The item in R with the minimum key is replaced by item vi
+	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
+		reservoir.SetValue(col_idx, base_reservoir_sample.min_entry, input.GetValue(col_idx, index_in_chunk));
+	}
+	base_reservoir_sample.ReplaceElement();
+}
+
+idx_t ReservoirSample::FillReservoir(DataChunk &input) {
+	idx_t chunk_count = input.size();
+	input.Normalify();
+
+	// we have not: append to the reservoir
+	idx_t required_count;
+	if (reservoir.Count() + chunk_count >= sample_count) {
+		// have to limit the count of the chunk
+		required_count = sample_count - reservoir.Count();
+	} else {
+		// we copy the entire chunk
+		required_count = chunk_count;
+	}
+	// instead of copying we just change the pointer in the current chunk
+	input.SetCardinality(required_count);
+	reservoir.Append(input);
+
+	base_reservoir_sample.InitializeReservoir(reservoir.Count(), sample_count);
+
+	// check if there are still elements remaining
+	// this happens if we are on a boundary
+	// for example, input.size() is 1024, but our sample size is 10
+	if (required_count == chunk_count) {
+		// we are done here
+		return 0;
+	}
+	// we still need to process a part of the chunk
+	// create a selection vector of the remaining elements
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	for (idx_t i = required_count; i < chunk_count; i++) {
+		sel.set_index(i - required_count, i);
+	}
+	// slice the input vector and continue
+	input.Slice(sel, chunk_count - required_count);
+	return input.size();
+}
+
+ReservoirSamplePercentage::ReservoirSamplePercentage(double percentage, int64_t seed)
+    : BlockingSample(seed), sample_percentage(percentage / 100.0), current_count(0), is_finalized(false) {
+	reservoir_sample_size = idx_t(sample_percentage * RESERVOIR_THRESHOLD);
+	current_sample = make_unique<ReservoirSample>(reservoir_sample_size, random.NextRandomInteger());
+}
+
+void ReservoirSamplePercentage::AddToReservoir(DataChunk &input) {
+	if (current_count + input.size() > RESERVOIR_THRESHOLD) {
+		// we don't have enough space in our current reservoir
+		// first check what we still need to append to the current sample
+		idx_t append_to_current_sample_count = RESERVOIR_THRESHOLD - current_count;
+		idx_t append_to_next_sample = input.size() - append_to_current_sample_count;
+		if (append_to_current_sample_count > 0) {
+			// we have elements remaining, first add them to the current sample
+			input.Normalify();
+
+			input.SetCardinality(append_to_current_sample_count);
+			current_sample->AddToReservoir(input);
+		}
+		if (append_to_next_sample > 0) {
+			// slice the input for the remainder
+			SelectionVector sel(STANDARD_VECTOR_SIZE);
+			for (idx_t i = 0; i < append_to_next_sample; i++) {
+				sel.set_index(i, append_to_current_sample_count + i);
+			}
+			input.Slice(sel, append_to_next_sample);
+		}
+		// now our first sample is filled: append it to the set of finished samples
+		finished_samples.push_back(move(current_sample));
+
+		// allocate a new sample, and potentially add the remainder of the current input to that sample
+		current_sample = make_unique<ReservoirSample>(reservoir_sample_size, random.NextRandomInteger());
+		if (append_to_next_sample > 0) {
+			current_sample->AddToReservoir(input);
+		}
+		current_count = append_to_next_sample;
+	} else {
+		// we can just append to the current sample
+		current_count += input.size();
+		current_sample->AddToReservoir(input);
+	}
+}
+
+unique_ptr<DataChunk> ReservoirSamplePercentage::GetChunk() {
+	if (!is_finalized) {
+		Finalize();
+	}
+	while (!finished_samples.empty()) {
+		auto &front = finished_samples.front();
+		auto chunk = front->GetChunk();
+		if (chunk && chunk->size() > 0) {
+			return chunk;
+		}
+		// move to the next sample
+		finished_samples.erase(finished_samples.begin());
+	}
+	return nullptr;
+}
+
+void ReservoirSamplePercentage::Finalize() {
+	// need to finalize the current sample, if any
+	if (current_count > 0) {
+		// create a new sample
+		auto new_sample_size = idx_t(round(sample_percentage * current_count));
+		auto new_sample = make_unique<ReservoirSample>(new_sample_size, random.NextRandomInteger());
+		while (true) {
+			auto chunk = current_sample->GetChunk();
+			if (!chunk || chunk->size() == 0) {
+				break;
+			}
+			new_sample->AddToReservoir(*chunk);
+		}
+		finished_samples.push_back(move(new_sample));
+	}
+	is_finalized = true;
+}
+
+BaseReservoirSampling::BaseReservoirSampling(int64_t seed) : random(seed) {
+	next_index = 0;
+	min_threshold = 0;
+	min_entry = 0;
+	current_count = 0;
+}
+
+BaseReservoirSampling::BaseReservoirSampling() : BaseReservoirSampling(-1) {
+}
+
+void BaseReservoirSampling::InitializeReservoir(idx_t cur_size, idx_t sample_size) {
+	//! 1: The first m items of V are inserted into R
+	//! first we need to check if the reservoir already has "m" elements
+	if (cur_size == sample_size) {
+		//! 2. For each item vi ∈ R: Calculate a key ki = random(0, 1)
+		//! we then define the threshold to enter the reservoir T_w as the minimum key of R
+		//! we use a priority queue to extract the minimum key in O(1) time
+		for (idx_t i = 0; i < sample_size; i++) {
+			double k_i = random.NextRandom();
+			reservoir_weights.push(std::make_pair(-k_i, i));
+		}
+		SetNextEntry();
+	}
+}
+
+void BaseReservoirSampling::SetNextEntry() {
+	//! 4. Let r = random(0, 1) and Xw = log(r) / log(T_w)
+	auto &min_key = reservoir_weights.top();
+	double t_w = -min_key.first;
+	double r = random.NextRandom();
+	double x_w = log(r) / log(t_w);
+	//! 5. From the current item vc skip items until item vi , such that:
+	//! 6. wc +wc+1 +···+wi−1 < Xw <= wc +wc+1 +···+wi−1 +wi
+	//! since all our weights are 1 (uniform sampling), we can just determine the amount of elements to skip
+	min_threshold = t_w;
+	min_entry = min_key.second;
+	next_index = MaxValue<idx_t>(1, idx_t(round(x_w)));
+	current_count = 0;
+}
+
+void BaseReservoirSampling::ReplaceElement() {
+	//! replace the entry in the reservoir
+	//! pop the minimum entry
+	reservoir_weights.pop();
+	//! now update the reservoir
+	//! 8. Let tw = Tw i , r2 = random(tw,1) and vi’s key: ki = (r2)1/wi
+	//! 9. The new threshold Tw is the new minimum key of R
+	//! we generate a random number between (min_threshold, 1)
+	double r2 = random.NextRandom(min_threshold, 1);
+	//! now we insert the new weight into the reservoir
+	reservoir_weights.push(std::make_pair(-r2, min_entry));
+	//! we update the min entry with the new min entry in the reservoir
+	SetNextEntry();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+WindowSegmentTree::WindowSegmentTree(AggregateFunction &aggregate, FunctionData *bind_info,
+                                     const LogicalType &result_type_p, ChunkCollection *input,
+                                     const ValidityMask &filter_mask_p, WindowAggregationMode mode_p)
+    : aggregate(aggregate), bind_info(bind_info), result_type(result_type_p), state(aggregate.state_size()),
+      statep(Value::POINTER((idx_t)state.data())), frame(0, 0), active(0, 1),
+      statev(Value::POINTER((idx_t)state.data())), internal_nodes(0), input_ref(input), filter_mask(filter_mask_p),
+      mode(mode_p) {
+#if STANDARD_VECTOR_SIZE < 512
+	throw NotImplementedException("Window functions are not supported for vector sizes < 512");
+#endif
+	statep.Normalify(STANDARD_VECTOR_SIZE);
+	statev.SetVectorType(VectorType::FLAT_VECTOR); // Prevent conversion of results to constants
+
+	if (input_ref && input_ref->ColumnCount() > 0) {
+		filter_sel.Initialize(STANDARD_VECTOR_SIZE);
+		inputs.Initialize(input_ref->Types());
+		// if we have a frame-by-frame method, share the single state
+		if (aggregate.window && UseWindowAPI()) {
+			AggregateInit();
+			inputs.Reference(input_ref->GetChunk(0));
+		} else if (aggregate.combine && UseCombineAPI()) {
+			ConstructTree();
+		}
+	}
+}
+
+WindowSegmentTree::~WindowSegmentTree() {
+	if (!aggregate.destructor) {
+		// nothing to destroy
+		return;
+	}
+	// call the destructor for all the intermediate states
+	data_ptr_t address_data[STANDARD_VECTOR_SIZE];
+	Vector addresses(LogicalType::POINTER, (data_ptr_t)address_data);
+	idx_t count = 0;
+	for (idx_t i = 0; i < internal_nodes; i++) {
+		address_data[count++] = data_ptr_t(levels_flat_native.get() + i * state.size());
+		if (count == STANDARD_VECTOR_SIZE) {
+			aggregate.destructor(addresses, count);
+			count = 0;
+		}
+	}
+	if (count > 0) {
+		aggregate.destructor(addresses, count);
+	}
+
+	if (aggregate.window && UseWindowAPI()) {
+		aggregate.destructor(statev, 1);
+	}
+}
+
+void WindowSegmentTree::AggregateInit() {
+	aggregate.initialize(state.data());
+}
+
+void WindowSegmentTree::AggegateFinal(Vector &result, idx_t rid) {
+	AggregateInputData aggr_input_data(bind_info);
+	aggregate.finalize(statev, aggr_input_data, result, 1, rid);
+
+	if (aggregate.destructor) {
+		aggregate.destructor(statev, 1);
+	}
+}
+
+void WindowSegmentTree::ExtractFrame(idx_t begin, idx_t end) {
+	const auto size = end - begin;
+	if (size >= STANDARD_VECTOR_SIZE) {
+		throw InternalException("Cannot compute window aggregation: bounds are too large");
+	}
+
+	const idx_t start_in_vector = begin % STANDARD_VECTOR_SIZE;
+	const auto input_count = input_ref->ColumnCount();
+	if (start_in_vector + size <= STANDARD_VECTOR_SIZE) {
+		inputs.SetCardinality(size);
+		auto &chunk = input_ref->GetChunkForRow(begin);
+		for (idx_t i = 0; i < input_count; ++i) {
+			auto &v = inputs.data[i];
+			auto &vec = chunk.data[i];
+			v.Slice(vec, start_in_vector);
+			v.Verify(size);
+		}
+	} else {
+		inputs.Reset();
+		inputs.SetCardinality(size);
+
+		// we cannot just slice the individual vector!
+		auto &chunk_a = input_ref->GetChunkForRow(begin);
+		auto &chunk_b = input_ref->GetChunkForRow(end);
+		idx_t chunk_a_count = chunk_a.size() - start_in_vector;
+		idx_t chunk_b_count = inputs.size() - chunk_a_count;
+		for (idx_t i = 0; i < input_count; ++i) {
+			auto &v = inputs.data[i];
+			VectorOperations::Copy(chunk_a.data[i], v, chunk_a.size(), start_in_vector, 0);
+			VectorOperations::Copy(chunk_b.data[i], v, chunk_b_count, 0, chunk_a_count);
+		}
+	}
+
+	// Slice to any filtered rows
+	if (!filter_mask.AllValid()) {
+		idx_t filtered = 0;
+		for (idx_t i = begin; i < end; ++i) {
+			if (filter_mask.RowIsValid(i)) {
+				filter_sel.set_index(filtered++, i - begin);
+			}
+		}
+		if (filtered != inputs.size()) {
+			inputs.Slice(filter_sel, filtered);
+		}
+	}
+}
+
+void WindowSegmentTree::WindowSegmentValue(idx_t l_idx, idx_t begin, idx_t end) {
+	D_ASSERT(begin <= end);
+	if (begin == end) {
+		return;
+	}
+
+	if (end - begin >= STANDARD_VECTOR_SIZE) {
+		throw InternalException("Cannot compute window aggregation: bounds are too large");
+	}
+
+	Vector s(statep, 0);
+	if (l_idx == 0) {
+		ExtractFrame(begin, end);
+		AggregateInputData aggr_input_data(bind_info);
+		aggregate.update(&inputs.data[0], aggr_input_data, input_ref->ColumnCount(), s, inputs.size());
+	} else {
+		inputs.Reset();
+		inputs.SetCardinality(end - begin);
+		// find out where the states begin
+		data_ptr_t begin_ptr = levels_flat_native.get() + state.size() * (begin + levels_flat_start[l_idx - 1]);
+		// set up a vector of pointers that point towards the set of states
+		Vector v(LogicalType::POINTER);
+		auto pdata = FlatVector::GetData<data_ptr_t>(v);
+		for (idx_t i = 0; i < inputs.size(); i++) {
+			pdata[i] = begin_ptr + i * state.size();
+		}
+		v.Verify(inputs.size());
+		AggregateInputData aggr_input_data(bind_info);
+		aggregate.combine(v, s, aggr_input_data, inputs.size());
+	}
+}
+
+void WindowSegmentTree::ConstructTree() {
+	D_ASSERT(input_ref);
+	D_ASSERT(inputs.ColumnCount() > 0);
+
+	// compute space required to store internal nodes of segment tree
+	internal_nodes = 0;
+	idx_t level_nodes = input_ref->Count();
+	do {
+		level_nodes = (level_nodes + (TREE_FANOUT - 1)) / TREE_FANOUT;
+		internal_nodes += level_nodes;
+	} while (level_nodes > 1);
+	levels_flat_native = unique_ptr<data_t[]>(new data_t[internal_nodes * state.size()]);
+	levels_flat_start.push_back(0);
+
+	idx_t levels_flat_offset = 0;
+	idx_t level_current = 0;
+	// level 0 is data itself
+	idx_t level_size;
+	// iterate over the levels of the segment tree
+	while ((level_size = (level_current == 0 ? input_ref->Count()
+	                                         : levels_flat_offset - levels_flat_start[level_current - 1])) > 1) {
+		for (idx_t pos = 0; pos < level_size; pos += TREE_FANOUT) {
+			// compute the aggregate for this entry in the segment tree
+			AggregateInit();
+			WindowSegmentValue(level_current, pos, MinValue(level_size, pos + TREE_FANOUT));
+
+			memcpy(levels_flat_native.get() + (levels_flat_offset * state.size()), state.data(), state.size());
+
+			levels_flat_offset++;
+		}
+
+		levels_flat_start.push_back(levels_flat_offset);
+		level_current++;
+	}
+
+	// Corner case: single element in the window
+	if (levels_flat_offset == 0) {
+		aggregate.initialize(levels_flat_native.get());
+	}
+}
+
+void WindowSegmentTree::Compute(Vector &result, idx_t rid, idx_t begin, idx_t end) {
+	D_ASSERT(input_ref);
+
+	// No arguments, so just count
+	if (inputs.ColumnCount() == 0) {
+		D_ASSERT(GetTypeIdSize(result_type.InternalType()) == sizeof(idx_t));
+		auto data = FlatVector::GetData<idx_t>(result);
+		// Slice to any filtered rows
+		if (!filter_mask.AllValid()) {
+			idx_t filtered = 0;
+			for (idx_t i = begin; i < end; ++i) {
+				filtered += filter_mask.RowIsValid(i);
+			}
+			data[rid] = filtered;
+		} else {
+			data[rid] = end - begin;
+		}
+		return;
+	}
+
+	// If we have a window function, use that
+	if (aggregate.window && UseWindowAPI()) {
+		// Frame boundaries
+		auto prev = frame;
+		frame = FrameBounds(begin, end);
+
+		// Extract the range
+		auto &coll = *input_ref;
+		const auto prev_active = active;
+		const FrameBounds combined(MinValue(frame.first, prev.first), MaxValue(frame.second, prev.second));
+
+		// The chunk bounds are the range that includes the begin and end - 1
+		const FrameBounds prev_chunks(coll.LocateChunk(prev_active.first), coll.LocateChunk(prev_active.second - 1));
+		const FrameBounds active_chunks(coll.LocateChunk(combined.first), coll.LocateChunk(combined.second - 1));
+
+		// Extract the range
+		if (active_chunks.first == active_chunks.second) {
+			// If all the data is in a single chunk, then just reference it
+			if (prev_chunks != active_chunks || (!prev.first && !prev.second)) {
+				inputs.Reference(coll.GetChunk(active_chunks.first));
+			}
+		} else if (active_chunks.first == prev_chunks.first && prev_chunks.first != prev_chunks.second) {
+			// If the start chunk did not change, and we are not just a reference, then extend if necessary
+			for (auto chunk_idx = prev_chunks.second + 1; chunk_idx <= active_chunks.second; ++chunk_idx) {
+				inputs.Append(coll.GetChunk(chunk_idx), true);
+			}
+		} else {
+			// If the first chunk changed, start over
+			inputs.Reset();
+			for (auto chunk_idx = active_chunks.first; chunk_idx <= active_chunks.second; ++chunk_idx) {
+				inputs.Append(coll.GetChunk(chunk_idx), true);
+			}
+		}
+
+		active = FrameBounds(active_chunks.first * STANDARD_VECTOR_SIZE,
+		                     MinValue((active_chunks.second + 1) * STANDARD_VECTOR_SIZE, coll.Count()));
+
+		AggregateInputData aggr_input_data(bind_info);
+		aggregate.window(inputs.data.data(), filter_mask, aggr_input_data, inputs.ColumnCount(), state.data(), frame,
+		                 prev, result, rid, active.first);
+		return;
+	}
+
+	AggregateInit();
+
+	// Aggregate everything at once if we can't combine states
+	if (!aggregate.combine || !UseCombineAPI()) {
+		WindowSegmentValue(0, begin, end);
+		AggegateFinal(result, rid);
+		return;
+	}
+
+	for (idx_t l_idx = 0; l_idx < levels_flat_start.size() + 1; l_idx++) {
+		idx_t parent_begin = begin / TREE_FANOUT;
+		idx_t parent_end = end / TREE_FANOUT;
+		if (parent_begin == parent_end) {
+			WindowSegmentValue(l_idx, begin, end);
+			break;
+		}
+		idx_t group_begin = parent_begin * TREE_FANOUT;
+		if (begin != group_begin) {
+			WindowSegmentValue(l_idx, begin, group_begin + TREE_FANOUT);
+			parent_begin++;
+		}
+		idx_t group_end = parent_end * TREE_FANOUT;
+		if (end != group_end) {
+			WindowSegmentValue(l_idx, group_end, end);
+		}
+		begin = parent_begin;
+		end = parent_end;
+	}
+
+	AggegateFinal(result, rid);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+struct AvgState {
+	uint64_t count;
+	T value;
+
+	void Initialize() {
+		this->count = 0;
+	}
+
+	void Combine(const AvgState<T> &other) {
+		this->count += other.count;
+		this->value += other.value;
+	}
+};
+
+struct KahanAvgState {
+	uint64_t count;
+	double value;
+	double err;
+
+	void Initialize() {
+		this->count = 0;
+		this->err = 0.0;
+	}
+
+	void Combine(const KahanAvgState &other) {
+		this->count += other.count;
+		KahanAddInternal(other.value, this->value, this->err);
+		KahanAddInternal(other.err, this->value, this->err);
+	}
+};
+
+struct AverageDecimalBindData : public FunctionData {
+	explicit AverageDecimalBindData(double scale) : scale(scale) {
+	}
+
+	double scale;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<AverageDecimalBindData>(scale);
+	};
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (AverageDecimalBindData &)other_p;
+		return scale == other.scale;
+	}
+};
+
+struct AverageSetOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->Initialize();
+	}
+	template <class STATE>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->Combine(source);
+	}
+	template <class STATE>
+	static void AddValues(STATE *state, idx_t count) {
+		state->count += count;
+	}
+};
+
+template <class T>
+static T GetAverageDivident(uint64_t count, FunctionData *bind_data) {
+	T divident = T(count);
+	if (bind_data) {
+		auto &avg_bind_data = (AverageDecimalBindData &)*bind_data;
+		divident *= avg_bind_data.scale;
+	}
+	return divident;
+}
+
+struct IntegerAverageOperation : public BaseSumOperation<AverageSetOperation, RegularAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			double divident = GetAverageDivident<double>(state->count, aggr_input_data.bind_data);
+			target[idx] = double(state->value) / divident;
+		}
+	}
+};
+
+struct IntegerAverageOperationHugeint : public BaseSumOperation<AverageSetOperation, HugeintAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			long double divident = GetAverageDivident<long double>(state->count, aggr_input_data.bind_data);
+			target[idx] = Hugeint::Cast<long double>(state->value) / divident;
+		}
+	}
+};
+
+struct HugeintAverageOperation : public BaseSumOperation<AverageSetOperation, RegularAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			long double divident = GetAverageDivident<long double>(state->count, aggr_input_data.bind_data);
+			target[idx] = Hugeint::Cast<long double>(state->value) / divident;
+		}
+	}
+};
+
+struct NumericAverageOperation : public BaseSumOperation<AverageSetOperation, RegularAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			if (!Value::DoubleIsFinite(state->value)) {
+				throw OutOfRangeException("AVG is out of range!");
+			}
+			target[idx] = (state->value / state->count);
+		}
+	}
+};
+
+struct KahanAverageOperation : public BaseSumOperation<AverageSetOperation, KahanAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			if (!Value::DoubleIsFinite(state->value)) {
+				throw OutOfRangeException("AVG is out of range!");
+			}
+			target[idx] = (state->value / state->count) + (state->err / state->count);
+		}
+	}
+};
+
+AggregateFunction GetAverageAggregate(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::INT16:
+		return AggregateFunction::UnaryAggregate<AvgState<int64_t>, int16_t, double, IntegerAverageOperation>(
+		    LogicalType::SMALLINT, LogicalType::DOUBLE, true);
+	case PhysicalType::INT32: {
+		auto function =
+		    AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int32_t, double, IntegerAverageOperationHugeint>(
+		        LogicalType::INTEGER, LogicalType::DOUBLE, true);
+		return function;
+	}
+	case PhysicalType::INT64: {
+		auto function =
+		    AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, int64_t, double, IntegerAverageOperationHugeint>(
+		        LogicalType::BIGINT, LogicalType::DOUBLE, true);
+		return function;
+	}
+	case PhysicalType::INT128:
+		return AggregateFunction::UnaryAggregate<AvgState<hugeint_t>, hugeint_t, double, HugeintAverageOperation>(
+		    LogicalType::HUGEINT, LogicalType::DOUBLE, true);
+	default:
+		throw InternalException("Unimplemented average aggregate");
+	}
+}
+
+unique_ptr<FunctionData> BindDecimalAvg(ClientContext &context, AggregateFunction &function,
+                                        vector<unique_ptr<Expression>> &arguments) {
+	auto decimal_type = arguments[0]->return_type;
+	function = GetAverageAggregate(decimal_type.InternalType());
+	function.name = "avg";
+	function.arguments[0] = decimal_type;
+	function.return_type = LogicalType::DOUBLE;
+	return make_unique<AverageDecimalBindData>(
+	    Hugeint::Cast<double>(Hugeint::POWERS_OF_TEN[DecimalType::GetScale(decimal_type)]));
+}
+
+void AvgFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet avg("avg");
+	avg.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
+	                                  nullptr, nullptr, true, nullptr, BindDecimalAvg));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT16));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT32));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT64));
+	avg.AddFunction(GetAverageAggregate(PhysicalType::INT128));
+	avg.AddFunction(AggregateFunction::UnaryAggregate<AvgState<double>, double, double, NumericAverageOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, true));
+	set.AddFunction(avg);
+
+	avg.name = "mean";
+	set.AddFunction(avg);
+
+	AggregateFunctionSet favg("favg");
+	favg.AddFunction(AggregateFunction::UnaryAggregate<KahanAvgState, double, double, KahanAverageOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, true));
+	set.AddFunction(favg);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+void Corr::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet corr("corr");
+	corr.AddFunction(AggregateFunction::BinaryAggregate<CorrState, double, double, double, CorrOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(corr);
+}
+} // namespace duckdb
+
+
+
+
+
+
+#include <cmath>
+
+namespace duckdb {
+
+void CovarPopFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet covar_pop("covar_pop");
+	covar_pop.AddFunction(AggregateFunction::BinaryAggregate<CovarState, double, double, double, CovarPopOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(covar_pop);
+}
+
+void CovarSampFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet covar_samp("covar_samp");
+	covar_samp.AddFunction(AggregateFunction::BinaryAggregate<CovarState, double, double, double, CovarSampOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(covar_samp);
+}
+
+} // namespace duckdb
+
+
+
+
+#include <cmath>
+
+namespace duckdb {
+
+void StdDevSampFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet stddev_samp("stddev_samp");
+	stddev_samp.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, STDDevSampOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(stddev_samp);
+	AggregateFunctionSet stddev("stddev");
+	stddev.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, STDDevSampOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(stddev);
+}
+
+void StdDevPopFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet stddev_pop("stddev_pop");
+	stddev_pop.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, STDDevPopOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(stddev_pop);
+}
+
+void VarPopFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet var_pop("var_pop");
+	var_pop.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, VarPopOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(var_pop);
+}
+
+void VarSampFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet var_samp("var_samp");
+	var_samp.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, VarSampOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(var_samp);
+}
+void VarianceFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet var_samp("variance");
+	var_samp.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, VarSampOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(var_samp);
+}
+
+void StandardErrorOfTheMeanFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet sem("sem");
+	sem.AddFunction(AggregateFunction::UnaryAggregate<StddevState, double, double, StandardErrorOfTheMeanOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(sem);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterAlgebraicAggregates() {
+	Register<AvgFun>();
+
+	Register<CovarSampFun>();
+	Register<CovarPopFun>();
+
+	Register<StdDevSampFun>();
+	Register<StdDevPopFun>();
+	Register<VarPopFun>();
+	Register<VarSampFun>();
+	Register<VarianceFun>();
+	Register<StandardErrorOfTheMeanFun>();
+	Register<Corr>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct ApproxDistinctCountState {
+	HyperLogLog *log;
+};
+
+struct ApproxCountDistinctFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->log = nullptr;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.log) {
+			return;
+		}
+		if (!target->log) {
+			target->log = new HyperLogLog();
+		}
+		D_ASSERT(target->log);
+		D_ASSERT(source.log);
+		auto new_log = target->log->MergePointer(*source.log);
+		delete target->log;
+		target->log = new_log;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->log) {
+			target[idx] = state->log->Count();
+		} else {
+			target[idx] = 0;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->log) {
+			delete state->log;
+		}
+	}
+};
+
+static void ApproxCountDistinctSimpleUpdateFunction(Vector inputs[], AggregateInputData &, idx_t input_count,
+                                                    data_ptr_t state, idx_t count) {
+	D_ASSERT(input_count == 1);
+
+	auto agg_state = (ApproxDistinctCountState *)state;
+	if (!agg_state->log) {
+		agg_state->log = new HyperLogLog();
+	}
+
+	VectorData vdata;
+	inputs[0].Orrify(count, vdata);
+
+	uint64_t indices[STANDARD_VECTOR_SIZE];
+	uint8_t counts[STANDARD_VECTOR_SIZE];
+
+	HyperLogLog::ProcessEntries(vdata, inputs[0].GetType(), indices, counts, count);
+	agg_state->log->AddToLog(vdata, count, indices, counts);
+}
+
+static void ApproxCountDistinctUpdateFunction(Vector inputs[], AggregateInputData &, idx_t input_count,
+                                              Vector &state_vector, idx_t count) {
+	D_ASSERT(input_count == 1);
+
+	VectorData sdata;
+	state_vector.Orrify(count, sdata);
+	auto states = (ApproxDistinctCountState **)sdata.data;
+
+	for (idx_t i = 0; i < count; i++) {
+		auto agg_state = states[sdata.sel->get_index(i)];
+		if (!agg_state->log) {
+			agg_state->log = new HyperLogLog();
+		}
+	}
+
+	VectorData vdata;
+	inputs[0].Orrify(count, vdata);
+
+	uint64_t indices[STANDARD_VECTOR_SIZE];
+	uint8_t counts[STANDARD_VECTOR_SIZE];
+
+	HyperLogLog::ProcessEntries(vdata, inputs[0].GetType(), indices, counts, count);
+	HyperLogLog::AddToLogs(vdata, count, indices, counts, (HyperLogLog ***)states, sdata.sel);
+}
+
+AggregateFunction GetApproxCountDistinctFunction(const LogicalType &input_type) {
+	return AggregateFunction(
+	    {input_type}, LogicalTypeId::BIGINT, AggregateFunction::StateSize<ApproxDistinctCountState>,
+	    AggregateFunction::StateInitialize<ApproxDistinctCountState, ApproxCountDistinctFunction>,
+	    ApproxCountDistinctUpdateFunction,
+	    AggregateFunction::StateCombine<ApproxDistinctCountState, ApproxCountDistinctFunction>,
+	    AggregateFunction::StateFinalize<ApproxDistinctCountState, int64_t, ApproxCountDistinctFunction>,
+	    ApproxCountDistinctSimpleUpdateFunction, nullptr,
+	    AggregateFunction::StateDestroy<ApproxDistinctCountState, ApproxCountDistinctFunction>);
+}
+
+void ApproxCountDistinctFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet approx_count("approx_count_distinct");
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::UTINYINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::USMALLINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::UINTEGER));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::UBIGINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::TINYINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::SMALLINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::BIGINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::HUGEINT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::FLOAT));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::DOUBLE));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::VARCHAR));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::TIMESTAMP));
+	approx_count.AddFunction(GetApproxCountDistinctFunction(LogicalType::TIMESTAMP_TZ));
+	set.AddFunction(approx_count);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T, class T2>
+struct ArgMinMaxState {
+	T arg;
+	T2 value;
+	bool is_initialized;
+};
+
+template <class T>
+static void ArgMinMaxDestroyValue(T value) {
+}
+
+template <>
+void ArgMinMaxDestroyValue(string_t value) {
+	if (!value.IsInlined()) {
+		delete[] value.GetDataUnsafe();
+	}
+}
+
+template <class T>
+static void ArgMinMaxAssignValue(T &target, T new_value, bool is_initialized) {
+	target = new_value;
+}
+
+template <>
+void ArgMinMaxAssignValue(string_t &target, string_t new_value, bool is_initialized) {
+	if (is_initialized) {
+		ArgMinMaxDestroyValue(target);
+	}
+	if (new_value.IsInlined()) {
+		target = new_value;
+	} else {
+		// non-inlined string, need to allocate space for it
+		auto len = new_value.GetSize();
+		auto ptr = new char[len];
+		memcpy(ptr, new_value.GetDataUnsafe(), len);
+
+		target = string_t(ptr, len);
+	}
+}
+
+template <class COMPARATOR>
+struct ArgMinMaxBase {
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->is_initialized) {
+			ArgMinMaxDestroyValue(state->arg);
+			ArgMinMaxDestroyValue(state->value);
+		}
+	}
+
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->is_initialized = false;
+	}
+
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, A_TYPE *x_data, B_TYPE *y_data, ValidityMask &amask,
+	                      ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		if (!state->is_initialized) {
+			ArgMinMaxAssignValue<A_TYPE>(state->arg, x_data[xidx], false);
+			ArgMinMaxAssignValue<B_TYPE>(state->value, y_data[yidx], false);
+			state->is_initialized = true;
+		} else {
+			OP::template Execute<A_TYPE, B_TYPE, STATE>(state, x_data[xidx], y_data[yidx]);
+		}
+	}
+
+	template <class A_TYPE, class B_TYPE, class STATE>
+	static void Execute(STATE *state, A_TYPE x_data, B_TYPE y_data) {
+		if (COMPARATOR::Operation(y_data, state->value)) {
+			ArgMinMaxAssignValue<A_TYPE>(state->arg, x_data, true);
+			ArgMinMaxAssignValue<B_TYPE>(state->value, y_data, true);
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.is_initialized) {
+			return;
+		}
+		if (!target->is_initialized || COMPARATOR::Operation(source.value, target->value)) {
+			ArgMinMaxAssignValue(target->arg, source.arg, target->is_initialized);
+			ArgMinMaxAssignValue(target->value, source.value, target->is_initialized);
+			target->is_initialized = true;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+template <class COMPARATOR>
+struct StringArgMinMax : public ArgMinMaxBase<COMPARATOR> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_initialized) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = StringVector::AddStringOrBlob(result, state->arg);
+		}
+	}
+};
+
+template <class COMPARATOR>
+struct NumericArgMinMax : public ArgMinMaxBase<COMPARATOR> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_initialized) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->arg;
+		}
+	}
+};
+
+using NumericArgMinOperation = NumericArgMinMax<LessThan>;
+using NumericArgMaxOperation = NumericArgMinMax<GreaterThan>;
+using StringArgMinOperation = StringArgMinMax<LessThan>;
+using StringArgMaxOperation = StringArgMinMax<GreaterThan>;
+
+template <class OP, class T, class T2>
+AggregateFunction GetArgMinMaxFunctionInternal(const LogicalType &arg_2, const LogicalType &arg) {
+	auto function = AggregateFunction::BinaryAggregate<ArgMinMaxState<T, T2>, T, T2, T, OP>(arg, arg_2, arg);
+	if (arg.InternalType() == PhysicalType::VARCHAR || arg_2.InternalType() == PhysicalType::VARCHAR) {
+		function.destructor = AggregateFunction::StateDestroy<ArgMinMaxState<T, T2>, OP>;
+	}
+	return function;
+}
+template <class OP, class T>
+AggregateFunction GetArgMinMaxFunctionArg2(const LogicalType &arg_2, const LogicalType &arg) {
+	switch (arg_2.InternalType()) {
+	case PhysicalType::INT32:
+		return GetArgMinMaxFunctionInternal<OP, T, int32_t>(arg_2, arg);
+	case PhysicalType::INT64:
+		return GetArgMinMaxFunctionInternal<OP, T, int64_t>(arg_2, arg);
+	case PhysicalType::DOUBLE:
+		return GetArgMinMaxFunctionInternal<OP, T, double>(arg_2, arg);
+	case PhysicalType::VARCHAR:
+		return GetArgMinMaxFunctionInternal<OP, T, string_t>(arg_2, arg);
+	default:
+		throw InternalException("Unimplemented arg_min/arg_max aggregate");
+	}
+}
+
+template <class OP, class T>
+void AddArgMinMaxFunctionArg2(AggregateFunctionSet &fun, const LogicalType &arg) {
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::INTEGER, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::BIGINT, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::DOUBLE, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::VARCHAR, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::DATE, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::TIMESTAMP, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::TIMESTAMP_TZ, arg));
+	fun.AddFunction(GetArgMinMaxFunctionArg2<OP, T>(LogicalType::BLOB, arg));
+}
+
+template <class OP, class STRING_OP>
+static void AddArgMinMaxFunctions(AggregateFunctionSet &fun) {
+	AddArgMinMaxFunctionArg2<OP, int32_t>(fun, LogicalType::INTEGER);
+	AddArgMinMaxFunctionArg2<OP, int64_t>(fun, LogicalType::BIGINT);
+	AddArgMinMaxFunctionArg2<OP, double>(fun, LogicalType::DOUBLE);
+	AddArgMinMaxFunctionArg2<STRING_OP, string_t>(fun, LogicalType::VARCHAR);
+	AddArgMinMaxFunctionArg2<OP, date_t>(fun, LogicalType::DATE);
+	AddArgMinMaxFunctionArg2<OP, timestamp_t>(fun, LogicalType::TIMESTAMP);
+	AddArgMinMaxFunctionArg2<OP, timestamp_t>(fun, LogicalType::TIMESTAMP_TZ);
+	AddArgMinMaxFunctionArg2<STRING_OP, string_t>(fun, LogicalType::BLOB);
+}
+
+void ArgMinFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("argmin");
+	AddArgMinMaxFunctions<NumericArgMinOperation, StringArgMinOperation>(fun);
+	set.AddFunction(fun);
+
+	//! Add min_by alias
+	fun.name = "min_by";
+	set.AddFunction(fun);
+
+	//! Add arg_min alias
+	fun.name = "arg_min";
+	set.AddFunction(fun);
+}
+
+void ArgMaxFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("argmax");
+	AddArgMinMaxFunctions<NumericArgMaxOperation, StringArgMaxOperation>(fun);
+	set.AddFunction(fun);
+
+	//! Add max_by alias
+	fun.name = "max_by";
+	set.AddFunction(fun);
+
+	//! Add arg_max alias
+	fun.name = "arg_max";
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb

--- a/velox/external/duckdb/duckdb-4.cpp
+++ b/velox/external/duckdb/duckdb-4.cpp
@@ -1,0 +1,16456 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+struct BitState {
+	bool is_set;
+	T value;
+};
+
+template <class OP>
+static AggregateFunction GetBitfieldUnaryAggregate(LogicalType type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, int8_t, int8_t, OP>(type, type);
+	case LogicalTypeId::SMALLINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, int16_t, int16_t, OP>(type, type);
+	case LogicalTypeId::INTEGER:
+		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, int32_t, int32_t, OP>(type, type);
+	case LogicalTypeId::BIGINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, int64_t, int64_t, OP>(type, type);
+	case LogicalTypeId::HUGEINT:
+		return AggregateFunction::UnaryAggregate<BitState<hugeint_t>, hugeint_t, hugeint_t, OP>(type, type);
+	case LogicalTypeId::UTINYINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint8_t>, uint8_t, uint8_t, OP>(type, type);
+	case LogicalTypeId::USMALLINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint16_t>, uint16_t, uint16_t, OP>(type, type);
+	case LogicalTypeId::UINTEGER:
+		return AggregateFunction::UnaryAggregate<BitState<uint32_t>, uint32_t, uint32_t, OP>(type, type);
+	case LogicalTypeId::UBIGINT:
+		return AggregateFunction::UnaryAggregate<BitState<uint64_t>, uint64_t, uint64_t, OP>(type, type);
+	default:
+		throw InternalException("Unimplemented bitfield type for unary aggregate");
+	}
+}
+
+struct BitAndOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		//  If there are no matching rows, BIT_AND() returns a null value.
+		state->is_set = false;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			state->is_set = true;
+			state->value = input[idx];
+		} else {
+			state->value &= input[idx];
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		//  count is irrelevant
+		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.is_set) {
+			// source is NULL, nothing to do.
+			return;
+		}
+		if (!target->is_set) {
+			// target is NULL, use source value directly.
+			*target = source;
+		} else {
+			target->value &= source.value;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void BitAndFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet bit_and("bit_and");
+	for (auto &type : LogicalType::Integral()) {
+		bit_and.AddFunction(GetBitfieldUnaryAggregate<BitAndOperation>(type));
+	}
+	set.AddFunction(bit_and);
+}
+
+struct BitOrOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		//  If there are no matching rows, BIT_OR() returns a null value.
+		state->is_set = false;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			state->is_set = true;
+			state->value = input[idx];
+		} else {
+			state->value |= input[idx];
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		//  count is irrelevant
+		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.is_set) {
+			// source is NULL, nothing to do.
+			return;
+		}
+		if (!target->is_set) {
+			// target is NULL, use source value directly.
+			*target = source;
+		} else {
+			target->value |= source.value;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void BitOrFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet bit_or("bit_or");
+	for (auto &type : LogicalType::Integral()) {
+		bit_or.AddFunction(GetBitfieldUnaryAggregate<BitOrOperation>(type));
+	}
+	set.AddFunction(bit_or);
+}
+
+struct BitXorOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		//  If there are no matching rows, BIT_XOR() returns a null value.
+		state->is_set = false;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			state->is_set = true;
+			state->value = input[idx];
+		} else {
+			state->value ^= input[idx];
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		//  count is irrelevant
+		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.is_set) {
+			// source is NULL, nothing to do.
+			return;
+		}
+		if (!target->is_set) {
+			// target is NULL, use source value directly.
+			*target = source;
+		} else {
+			target->value ^= source.value;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void BitXorFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet bit_xor("bit_xor");
+	for (auto &type : LogicalType::Integral()) {
+		bit_xor.AddFunction(GetBitfieldUnaryAggregate<BitXorOperation>(type));
+	}
+	set.AddFunction(bit_xor);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct BoolState {
+	bool empty;
+	bool val;
+};
+
+struct BoolAndFunFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->val = true;
+		state->empty = true;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->val = target->val && source.val;
+		target->empty = target->empty && source.empty;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->empty) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		target[idx] = state->val;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		state->empty = false;
+		state->val = input[idx] && state->val;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+struct BoolOrFunFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->val = false;
+		state->empty = true;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->val = target->val || source.val;
+		target->empty = target->empty && source.empty;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->empty) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		target[idx] = state->val;
+	}
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		state->empty = false;
+		state->val = input[idx] || state->val;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+AggregateFunction BoolOrFun::GetFunction() {
+	auto fun = AggregateFunction::UnaryAggregate<BoolState, bool, bool, BoolOrFunFunction>(
+	    LogicalType(LogicalTypeId::BOOLEAN), LogicalType::BOOLEAN);
+	fun.name = "bool_or";
+	return fun;
+}
+
+AggregateFunction BoolAndFun::GetFunction() {
+	auto fun = AggregateFunction::UnaryAggregate<BoolState, bool, bool, BoolAndFunFunction>(
+	    LogicalType(LogicalTypeId::BOOLEAN), LogicalType::BOOLEAN);
+	fun.name = "bool_and";
+	return fun;
+}
+
+void BoolOrFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunction bool_or_function = BoolOrFun::GetFunction();
+	AggregateFunctionSet bool_or("bool_or");
+	bool_or.AddFunction(bool_or_function);
+	set.AddFunction(bool_or);
+}
+
+void BoolAndFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunction bool_and_function = BoolAndFun::GetFunction();
+	AggregateFunctionSet bool_and("bool_and");
+	bool_and.AddFunction(bool_and_function);
+	set.AddFunction(bool_and);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct BaseCountFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		*state = 0;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		*target += source;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		target[idx] = *state;
+	}
+};
+
+struct CountStarFunction : public BaseCountFunction {
+	template <class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, idx_t idx) {
+		*state += 1;
+	}
+
+	template <class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &, idx_t count) {
+		*state += count;
+	}
+};
+
+struct CountFunction : public BaseCountFunction {
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		*state += 1;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask,
+	                              idx_t count) {
+		*state += count;
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+AggregateFunction CountFun::GetFunction() {
+	auto fun = AggregateFunction::UnaryAggregate<int64_t, int64_t, int64_t, CountFunction>(
+	    LogicalType(LogicalTypeId::ANY), LogicalType::BIGINT);
+	fun.name = "count";
+	return fun;
+}
+
+AggregateFunction CountStarFun::GetFunction() {
+	auto fun = AggregateFunction::NullaryAggregate<int64_t, int64_t, CountStarFunction>(LogicalType::BIGINT);
+	fun.name = "count_star";
+	return fun;
+}
+
+unique_ptr<BaseStatistics> CountPropagateStats(ClientContext &context, BoundAggregateExpression &expr,
+                                               FunctionData *bind_data, vector<unique_ptr<BaseStatistics>> &child_stats,
+                                               NodeStatistics *node_stats) {
+	if (!expr.distinct && child_stats[0] && !child_stats[0]->CanHaveNull()) {
+		// count on a column without null values: use count star
+		expr.function = CountStarFun::GetFunction();
+		expr.function.name = "count_star";
+		expr.children.clear();
+	}
+	return nullptr;
+}
+
+void CountFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunction count_function = CountFun::GetFunction();
+	count_function.statistics = CountPropagateStats;
+	AggregateFunctionSet count("count");
+	count.AddFunction(count_function);
+	// the count function can also be called without arguments
+	count_function.arguments.clear();
+	count_function.statistics = nullptr;
+	count.AddFunction(count_function);
+	set.AddFunction(count);
+}
+
+void CountStarFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet count("count_star");
+	count.AddFunction(CountStarFun::GetFunction());
+	set.AddFunction(count);
+}
+
+} // namespace duckdb
+
+
+
+
+
+#include <unordered_map>
+
+namespace duckdb {
+
+template <class T>
+struct EntropyState {
+	using DistinctMap = unordered_map<T, idx_t>;
+
+	idx_t count;
+	DistinctMap *distinct;
+
+	EntropyState &operator=(const EntropyState &other) = delete;
+
+	EntropyState &Assign(const EntropyState &other) {
+		D_ASSERT(!distinct);
+		distinct = new DistinctMap(*other.distinct);
+		count = other.count;
+		return *this;
+	}
+};
+
+struct EntropyFunctionBase {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->distinct = nullptr;
+		state->count = 0;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.distinct) {
+			return;
+		}
+		if (!target->distinct) {
+			target->Assign(source);
+			return;
+		}
+		for (auto &val : *source.distinct) {
+			auto value = val.first;
+			(*target->distinct)[value] += val.second;
+		}
+		target->count += source.count;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		double count = state->count;
+		if (state->distinct) {
+			double entropy = 0;
+			for (auto &val : *state->distinct) {
+				entropy += (val.second / count) * log2(count / val.second);
+			}
+			target[idx] = entropy;
+		} else {
+			target[idx] = 0;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->distinct) {
+			delete state->distinct;
+		}
+	}
+};
+
+struct EntropyFunction : EntropyFunctionBase {
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->distinct) {
+			state->distinct = new unordered_map<INPUT_TYPE, idx_t>();
+		}
+		(*state->distinct)[input[idx]]++;
+		state->count++;
+	}
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+};
+
+struct EntropyFunctionString : EntropyFunctionBase {
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->distinct) {
+			state->distinct = new unordered_map<string, idx_t>();
+		}
+		auto value = input[idx].GetString();
+		(*state->distinct)[value]++;
+		state->count++;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+};
+
+template <typename INPUT_TYPE, typename RESULT_TYPE>
+AggregateFunction GetEntropyFunction(const LogicalType &input_type, const LogicalType &result_type) {
+	return AggregateFunction::UnaryAggregateDestructor<EntropyState<INPUT_TYPE>, INPUT_TYPE, RESULT_TYPE,
+	                                                   EntropyFunction>(input_type, result_type);
+}
+
+AggregateFunction GetEntropyFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::UINT16:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<uint16_t>, uint16_t, double, EntropyFunction>(
+		    LogicalType::USMALLINT, LogicalType::DOUBLE);
+	case PhysicalType::UINT32:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<uint32_t>, uint32_t, double, EntropyFunction>(
+		    LogicalType::UINTEGER, LogicalType::DOUBLE);
+	case PhysicalType::UINT64:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<uint64_t>, uint64_t, double, EntropyFunction>(
+		    LogicalType::UBIGINT, LogicalType::DOUBLE);
+	case PhysicalType::INT16:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<int16_t>, int16_t, double, EntropyFunction>(
+		    LogicalType::SMALLINT, LogicalType::DOUBLE);
+	case PhysicalType::INT32:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<int32_t>, int32_t, double, EntropyFunction>(
+		    LogicalType::INTEGER, LogicalType::DOUBLE);
+	case PhysicalType::INT64:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<int64_t>, int64_t, double, EntropyFunction>(
+		    LogicalType::BIGINT, LogicalType::DOUBLE);
+	case PhysicalType::FLOAT:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<float>, float, double, EntropyFunction>(
+		    LogicalType::FLOAT, LogicalType::DOUBLE);
+	case PhysicalType::DOUBLE:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<double>, double, double, EntropyFunction>(
+		    LogicalType::DOUBLE, LogicalType::DOUBLE);
+	case PhysicalType::VARCHAR:
+		return AggregateFunction::UnaryAggregateDestructor<EntropyState<string>, string_t, double,
+		                                                   EntropyFunctionString>(LogicalType::VARCHAR,
+		                                                                          LogicalType::DOUBLE);
+
+	default:
+		throw InternalException("Unimplemented approximate_count aggregate");
+	}
+}
+
+void EntropyFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet entropy("entropy");
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::UINT16));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::UINT32));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::UINT64));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::FLOAT));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::INT16));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::INT32));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::INT64));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::DOUBLE));
+	entropy.AddFunction(GetEntropyFunction(PhysicalType::VARCHAR));
+	entropy.AddFunction(GetEntropyFunction<int64_t, double>(LogicalType::TIMESTAMP, LogicalType::DOUBLE));
+	entropy.AddFunction(GetEntropyFunction<int64_t, double>(LogicalType::TIMESTAMP_TZ, LogicalType::DOUBLE));
+	set.AddFunction(entropy);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+struct FirstState {
+	T value;
+	bool is_set;
+	bool is_null;
+};
+
+struct FirstFunctionBase {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->is_set = false;
+		state->is_null = false;
+	}
+
+	static bool IgnoreNull() {
+		return false;
+	}
+};
+
+template <bool LAST>
+struct FirstFunction : public FirstFunctionBase {
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (LAST || !state->is_set) {
+			state->is_set = true;
+			if (!mask.RowIsValid(idx)) {
+				state->is_null = true;
+			} else {
+				state->is_null = false;
+				state->value = input[idx];
+			}
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!target->is_set) {
+			*target = source;
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set || state->is_null) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+};
+
+template <bool LAST>
+struct FirstFunctionString : public FirstFunctionBase {
+	template <class STATE>
+	static void SetValue(STATE *state, string_t value, bool is_null) {
+		state->is_set = true;
+		if (is_null) {
+			state->is_null = true;
+		} else {
+			if (value.IsInlined()) {
+				state->value = value;
+			} else {
+				// non-inlined string, need to allocate space for it
+				auto len = value.GetSize();
+				auto ptr = new char[len];
+				memcpy(ptr, value.GetDataUnsafe(), len);
+
+				state->value = string_t(ptr, len);
+			}
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (LAST || !state->is_set) {
+			SetValue(state, input[idx], !mask.RowIsValid(idx));
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.is_set && (LAST || !target->is_set)) {
+			SetValue(target, source.value, source.is_null);
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->is_set || state->is_null) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = StringVector::AddStringOrBlob(result, state->value);
+		}
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->is_set && !state->is_null && !state->value.IsInlined()) {
+			delete[] state->value.GetDataUnsafe();
+		}
+	}
+};
+
+struct FirstStateVector {
+	Vector *value;
+};
+
+template <bool LAST>
+struct FirstVectorFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->value = nullptr;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->value) {
+			delete state->value;
+		}
+	}
+	static bool IgnoreNull() {
+		return false;
+	}
+
+	template <class STATE>
+	static void SetValue(STATE *state, Vector &input, const idx_t idx) {
+		if (!state->value) {
+			state->value = new Vector(input.GetType());
+			state->value->SetVectorType(VectorType::CONSTANT_VECTOR);
+		}
+		sel_t selv = idx;
+		SelectionVector sel(&selv);
+		VectorOperations::Copy(input, *state->value, sel, 1, 0, 0);
+	}
+
+	static void Update(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector, idx_t count) {
+		auto &input = inputs[0];
+		VectorData sdata;
+		state_vector.Orrify(count, sdata);
+
+		auto states = (FirstStateVector **)sdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			auto state = states[sdata.sel->get_index(i)];
+			if (LAST || !state->value) {
+				SetValue(state, input, i);
+			}
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.value && (LAST || !target->value)) {
+			SetValue(target, *source.value, 0);
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->value) {
+			// we need to use FlatVector::SetNull here
+			// since for STRUCT columns only setting the validity mask of the struct is incorrect
+			// as for a struct column, we need to also set ALL child columns to NULL
+			if (result.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+				ConstantVector::SetNull(result, true);
+			} else {
+				FlatVector::SetNull(result, idx, true);
+			}
+		} else {
+			VectorOperations::Copy(*state->value, result, 1, 0, idx);
+		}
+	}
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
+	                                     vector<unique_ptr<Expression>> &arguments) {
+		function.arguments[0] = arguments[0]->return_type;
+		function.return_type = arguments[0]->return_type;
+		return nullptr;
+	}
+};
+
+template <class T, bool LAST>
+static AggregateFunction GetFirstAggregateTemplated(LogicalType type) {
+	auto agg = AggregateFunction::UnaryAggregate<FirstState<T>, T, T, FirstFunction<LAST>>(type, type);
+	return agg;
+}
+
+template <bool LAST>
+static AggregateFunction GetFirstFunction(const LogicalType &type);
+
+template <bool LAST>
+AggregateFunction GetDecimalFirstFunction(const LogicalType &type) {
+	D_ASSERT(type.id() == LogicalTypeId::DECIMAL);
+	switch (type.InternalType()) {
+	case PhysicalType::INT16:
+		return GetFirstFunction<LAST>(LogicalType::SMALLINT);
+	case PhysicalType::INT32:
+		return GetFirstFunction<LAST>(LogicalType::INTEGER);
+	case PhysicalType::INT64:
+		return GetFirstFunction<LAST>(LogicalType::BIGINT);
+	default:
+		return GetFirstFunction<LAST>(LogicalType::HUGEINT);
+	}
+}
+
+template <bool LAST>
+static AggregateFunction GetFirstFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return GetFirstAggregateTemplated<int8_t, LAST>(type);
+	case LogicalTypeId::TINYINT:
+		return GetFirstAggregateTemplated<int8_t, LAST>(type);
+	case LogicalTypeId::SMALLINT:
+		return GetFirstAggregateTemplated<int16_t, LAST>(type);
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::DATE:
+		return GetFirstAggregateTemplated<int32_t, LAST>(type);
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetFirstAggregateTemplated<int64_t, LAST>(type);
+	case LogicalTypeId::UTINYINT:
+		return GetFirstAggregateTemplated<uint8_t, LAST>(type);
+	case LogicalTypeId::USMALLINT:
+		return GetFirstAggregateTemplated<uint16_t, LAST>(type);
+	case LogicalTypeId::UINTEGER:
+		return GetFirstAggregateTemplated<uint32_t, LAST>(type);
+	case LogicalTypeId::UBIGINT:
+		return GetFirstAggregateTemplated<uint64_t, LAST>(type);
+	case LogicalTypeId::HUGEINT:
+		return GetFirstAggregateTemplated<hugeint_t, LAST>(type);
+	case LogicalTypeId::FLOAT:
+		return GetFirstAggregateTemplated<float, LAST>(type);
+	case LogicalTypeId::DOUBLE:
+		return GetFirstAggregateTemplated<double, LAST>(type);
+	case LogicalTypeId::INTERVAL:
+		return GetFirstAggregateTemplated<interval_t, LAST>(type);
+	case LogicalTypeId::VARCHAR:
+	case LogicalTypeId::BLOB: {
+		auto agg = AggregateFunction::UnaryAggregateDestructor<FirstState<string_t>, string_t, string_t,
+		                                                       FirstFunctionString<LAST>>(type, type);
+		return agg;
+	}
+	case LogicalTypeId::DECIMAL: {
+		type.Verify();
+		AggregateFunction function = GetDecimalFirstFunction<LAST>(type);
+		function.arguments[0] = type;
+		function.return_type = type;
+		return function;
+	}
+	default: {
+		using OP = FirstVectorFunction<LAST>;
+		return AggregateFunction({type}, type, AggregateFunction::StateSize<FirstStateVector>,
+		                         AggregateFunction::StateInitialize<FirstStateVector, OP>, OP::Update,
+		                         AggregateFunction::StateCombine<FirstStateVector, OP>,
+		                         AggregateFunction::StateFinalize<FirstStateVector, void, OP>, nullptr, OP::Bind,
+		                         AggregateFunction::StateDestroy<FirstStateVector, OP>, nullptr, nullptr);
+	}
+	}
+}
+
+AggregateFunction FirstFun::GetFunction(const LogicalType &type) {
+	auto fun = GetFirstFunction<false>(type);
+	fun.name = "first";
+	return fun;
+}
+
+template <bool LAST>
+unique_ptr<FunctionData> BindDecimalFirst(ClientContext &context, AggregateFunction &function,
+                                          vector<unique_ptr<Expression>> &arguments) {
+	auto decimal_type = arguments[0]->return_type;
+	function = GetFirstFunction<LAST>(decimal_type);
+	function.name = "first";
+	function.return_type = decimal_type;
+	return nullptr;
+}
+
+void FirstFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet first("first");
+	AggregateFunctionSet last("last");
+	for (auto &type : LogicalType::AllTypes()) {
+		if (type.id() == LogicalTypeId::DECIMAL) {
+			first.AddFunction(AggregateFunction({type}, type, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+			                                    BindDecimalFirst<false>, nullptr, nullptr, nullptr));
+			last.AddFunction(AggregateFunction({type}, type, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+			                                   BindDecimalFirst<true>, nullptr, nullptr, nullptr));
+		} else {
+			first.AddFunction(GetFirstFunction<false>(type));
+			last.AddFunction(GetFirstFunction<true>(type));
+		}
+	}
+	set.AddFunction(first);
+	first.name = "arbitrary";
+	set.AddFunction(first);
+
+	set.AddFunction(last);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct KurtosisState {
+	idx_t n;
+	double sum;
+	double sum_sqr;
+	double sum_cub;
+	double sum_four;
+};
+
+struct KurtosisOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->n = 0;
+		state->sum = state->sum_sqr = state->sum_cub = state->sum_four = 0.0;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+		state->n++;
+		state->sum += data[idx];
+		state->sum_sqr += pow(data[idx], 2);
+		state->sum_cub += pow(data[idx], 3);
+		state->sum_four += pow(data[idx], 4);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.n == 0) {
+			return;
+		}
+		target->n += source.n;
+		target->sum += source.sum;
+		target->sum_sqr += source.sum_sqr;
+		target->sum_cub += source.sum_cub;
+		target->sum_four += source.sum_four;
+	}
+
+	template <class TARGET_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, TARGET_TYPE *target, ValidityMask &mask,
+	                     idx_t idx) {
+		auto n = (double)state->n;
+		if (n <= 3) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		double temp = 1 / n;
+		//! This is necessary due to linux 32 bits
+		long double temp_aux = 1 / n;
+		if (state->sum_sqr - state->sum * state->sum * temp == 0 ||
+		    state->sum_sqr - state->sum * state->sum * temp_aux == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		double m4 =
+		    temp * (state->sum_four - 4 * state->sum_cub * state->sum * temp +
+		            6 * state->sum_sqr * state->sum * state->sum * temp * temp - 3 * pow(state->sum, 4) * pow(temp, 3));
+
+		double m2 = temp * (state->sum_sqr - state->sum * state->sum * temp);
+		if (((m2 * m2) - 3 * (n - 1)) == 0 || ((n - 2) * (n - 3)) == 0) { // LCOV_EXCL_START
+			mask.SetInvalid(idx);
+		} // LCOV_EXCL_STOP
+		target[idx] = (n - 1) * ((n + 1) * m4 / (m2 * m2) - 3 * (n - 1)) / ((n - 2) * (n - 3));
+		if (!Value::DoubleIsFinite(target[idx])) {
+			throw OutOfRangeException("Kurtosis is out of range!");
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void KurtosisFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet function_set("kurtosis");
+	function_set.AddFunction(AggregateFunction::UnaryAggregate<KurtosisState, double, double, KurtosisOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(function_set);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+struct MinMaxState {
+	T value;
+	bool isset;
+};
+
+template <class OP>
+static AggregateFunction GetUnaryAggregate(LogicalType type) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return AggregateFunction::UnaryAggregate<MinMaxState<int8_t>, int8_t, int8_t, OP>(type, type);
+	case LogicalTypeId::TINYINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<int8_t>, int8_t, int8_t, OP>(type, type);
+	case LogicalTypeId::SMALLINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<int16_t>, int16_t, int16_t, OP>(type, type);
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::INTEGER:
+		return AggregateFunction::UnaryAggregate<MinMaxState<int32_t>, int32_t, int32_t, OP>(type, type);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIME_TZ:
+	case LogicalTypeId::BIGINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<int64_t>, int64_t, int64_t, OP>(type, type, true);
+	case LogicalTypeId::UTINYINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<uint8_t>, uint8_t, uint8_t, OP>(type, type, true);
+	case LogicalTypeId::USMALLINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<uint16_t>, uint16_t, uint16_t, OP>(type, type, true);
+	case LogicalTypeId::UINTEGER:
+		return AggregateFunction::UnaryAggregate<MinMaxState<uint32_t>, uint32_t, uint32_t, OP>(type, type, true);
+	case LogicalTypeId::UBIGINT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<uint64_t>, uint64_t, uint64_t, OP>(type, type, true);
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UUID:
+		return AggregateFunction::UnaryAggregate<MinMaxState<hugeint_t>, hugeint_t, hugeint_t, OP>(type, type, true);
+	case LogicalTypeId::FLOAT:
+		return AggregateFunction::UnaryAggregate<MinMaxState<float>, float, float, OP>(type, type, true);
+	case LogicalTypeId::DOUBLE:
+		return AggregateFunction::UnaryAggregate<MinMaxState<double>, double, double, OP>(type, type, true);
+	case LogicalTypeId::INTERVAL:
+		return AggregateFunction::UnaryAggregate<MinMaxState<interval_t>, interval_t, interval_t, OP>(type, type, true);
+	default:
+		throw InternalException("Unimplemented type for min/max aggregate");
+	}
+}
+
+struct MinMaxBase {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->isset = false;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask,
+	                              idx_t count) {
+		D_ASSERT(mask.RowIsValid(0));
+		if (!state->isset) {
+			OP::template Assign<INPUT_TYPE, STATE>(state, input[0]);
+			state->isset = true;
+		} else {
+			OP::template Execute<INPUT_TYPE, STATE>(state, input[0]);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			OP::template Assign<INPUT_TYPE, STATE>(state, input[idx]);
+			state->isset = true;
+		} else {
+			OP::template Execute<INPUT_TYPE, STATE>(state, input[idx]);
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+struct NumericMinMaxBase : public MinMaxBase {
+	template <class INPUT_TYPE, class STATE>
+	static void Assign(STATE *state, INPUT_TYPE input) {
+		state->value = input;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		mask.Set(idx, state->isset);
+		target[idx] = state->value;
+	}
+};
+
+struct MinOperation : public NumericMinMaxBase {
+	template <class INPUT_TYPE, class STATE>
+	static void Execute(STATE *state, INPUT_TYPE input) {
+		if (LessThan::Operation<INPUT_TYPE>(input, state->value)) {
+			state->value = input;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.isset) {
+			// source is NULL, nothing to do
+			return;
+		}
+		if (!target->isset) {
+			// target is NULL, use source value directly
+			*target = source;
+		} else if (GreaterThan::Operation(target->value, source.value)) {
+			target->value = source.value;
+		}
+	}
+};
+
+struct MaxOperation : public NumericMinMaxBase {
+	template <class INPUT_TYPE, class STATE>
+	static void Execute(STATE *state, INPUT_TYPE input) {
+		if (GreaterThan::Operation<INPUT_TYPE>(input, state->value)) {
+			state->value = input;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.isset) {
+			// source is NULL, nothing to do
+			return;
+		}
+		if (!target->isset) {
+			// target is NULL, use source value directly
+			*target = source;
+		} else if (LessThan::Operation(target->value, source.value)) {
+			target->value = source.value;
+		}
+	}
+};
+
+struct StringMinMaxBase : public MinMaxBase {
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->isset && !state->value.IsInlined()) {
+			delete[] state->value.GetDataUnsafe();
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE>
+	static void Assign(STATE *state, INPUT_TYPE input) {
+		Destroy(state);
+		if (input.IsInlined()) {
+			state->value = input;
+		} else {
+			// non-inlined string, need to allocate space for it
+			auto len = input.GetSize();
+			auto ptr = new char[len];
+			memcpy(ptr, input.GetDataUnsafe(), len);
+
+			state->value = string_t(ptr, len);
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = StringVector::AddStringOrBlob(result, state->value);
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.isset) {
+			// source is NULL, nothing to do
+			return;
+		}
+		if (!target->isset) {
+			// target is NULL, use source value directly
+			Assign(target, source.value);
+			target->isset = true;
+		} else {
+			OP::template Execute<string_t, STATE>(target, source.value);
+		}
+	}
+};
+
+struct MinOperationString : public StringMinMaxBase {
+	template <class INPUT_TYPE, class STATE>
+	static void Execute(STATE *state, INPUT_TYPE input) {
+		if (LessThan::Operation<INPUT_TYPE>(input, state->value)) {
+			Assign(state, input);
+		}
+	}
+};
+
+struct MaxOperationString : public StringMinMaxBase {
+	template <class INPUT_TYPE, class STATE>
+	static void Execute(STATE *state, INPUT_TYPE input) {
+		if (GreaterThan::Operation<INPUT_TYPE>(input, state->value)) {
+			Assign(state, input);
+		}
+	}
+};
+
+template <typename T, class OP>
+static bool TemplatedOptimumType(Vector &left, idx_t lidx, idx_t lcount, Vector &right, idx_t ridx, idx_t rcount) {
+	VectorData lvdata, rvdata;
+	left.Orrify(lcount, lvdata);
+	right.Orrify(rcount, rvdata);
+
+	lidx = lvdata.sel->get_index(lidx);
+	ridx = rvdata.sel->get_index(ridx);
+
+	auto ldata = (const T *)lvdata.data;
+	auto rdata = (const T *)rvdata.data;
+
+	auto &lval = ldata[lidx];
+	auto &rval = rdata[ridx];
+
+	auto lnull = !lvdata.validity.RowIsValid(lidx);
+	auto rnull = !rvdata.validity.RowIsValid(ridx);
+
+	return OP::Operation(lval, rval, lnull, rnull);
+}
+
+template <class OP>
+static bool TemplatedOptimumList(Vector &left, idx_t lidx, idx_t lcount, Vector &right, idx_t ridx, idx_t rcount);
+
+template <class OP>
+static bool TemplatedOptimumStruct(Vector &left, idx_t lidx, idx_t lcount, Vector &right, idx_t ridx, idx_t rcount);
+
+template <class OP>
+static bool TemplatedOptimumValue(Vector &left, idx_t lidx, idx_t lcount, Vector &right, idx_t ridx, idx_t rcount) {
+	D_ASSERT(left.GetType() == right.GetType());
+	switch (left.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedOptimumType<int8_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::INT16:
+		return TemplatedOptimumType<int16_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::INT32:
+		return TemplatedOptimumType<int32_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::INT64:
+		return TemplatedOptimumType<int64_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::UINT8:
+		return TemplatedOptimumType<uint8_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::UINT16:
+		return TemplatedOptimumType<uint16_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::UINT32:
+		return TemplatedOptimumType<uint32_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::UINT64:
+		return TemplatedOptimumType<uint64_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::INT128:
+		return TemplatedOptimumType<hugeint_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::FLOAT:
+		return TemplatedOptimumType<float, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::DOUBLE:
+		return TemplatedOptimumType<double, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::INTERVAL:
+		return TemplatedOptimumType<interval_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::VARCHAR:
+		return TemplatedOptimumType<string_t, OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::LIST:
+		return TemplatedOptimumList<OP>(left, lidx, lcount, right, ridx, rcount);
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+		return TemplatedOptimumStruct<OP>(left, lidx, lcount, right, ridx, rcount);
+	default:
+		throw InternalException("Invalid type for distinct comparison");
+	}
+}
+
+template <class OP>
+static bool TemplatedOptimumStruct(Vector &left, idx_t lidx_p, idx_t lcount, Vector &right, idx_t ridx_p,
+                                   idx_t rcount) {
+	// STRUCT dictionaries apply to all the children
+	// so map the indexes first
+	VectorData lvdata, rvdata;
+	left.Orrify(lcount, lvdata);
+	right.Orrify(rcount, rvdata);
+
+	idx_t lidx = lvdata.sel->get_index(lidx_p);
+	idx_t ridx = rvdata.sel->get_index(ridx_p);
+
+	// DISTINCT semantics are in effect for nested types
+	auto lnull = !lvdata.validity.RowIsValid(lidx);
+	auto rnull = !rvdata.validity.RowIsValid(ridx);
+	if (lnull || rnull) {
+		return OP::Operation(0, 0, lnull, rnull);
+	}
+
+	auto &lchildren = StructVector::GetEntries(left);
+	auto &rchildren = StructVector::GetEntries(right);
+
+	D_ASSERT(lchildren.size() == rchildren.size());
+	for (idx_t col_no = 0; col_no < lchildren.size(); ++col_no) {
+		auto &lchild = *lchildren[col_no];
+		auto &rchild = *rchildren[col_no];
+
+		// Strict comparisons use the OP for definite
+		if (TemplatedOptimumValue<OP>(lchild, lidx_p, lcount, rchild, ridx_p, rcount)) {
+			return true;
+		}
+
+		if (col_no == lchildren.size() - 1) {
+			break;
+		}
+
+		// Strict comparisons use IS NOT DISTINCT for possible
+		if (!TemplatedOptimumValue<NotDistinctFrom>(lchild, lidx_p, lcount, rchild, ridx_p, rcount)) {
+			return false;
+		}
+	}
+
+	return false;
+}
+
+template <class OP>
+static bool TemplatedOptimumList(Vector &left, idx_t lidx, idx_t lcount, Vector &right, idx_t ridx, idx_t rcount) {
+	VectorData lvdata, rvdata;
+	left.Orrify(lcount, lvdata);
+	right.Orrify(rcount, rvdata);
+
+	// Update the indexes and vector sizes for recursion.
+	lidx = lvdata.sel->get_index(lidx);
+	ridx = rvdata.sel->get_index(ridx);
+
+	lcount = ListVector::GetListSize(left);
+	rcount = ListVector::GetListSize(right);
+
+	// DISTINCT semantics are in effect for nested types
+	auto lnull = !lvdata.validity.RowIsValid(lidx);
+	auto rnull = !rvdata.validity.RowIsValid(ridx);
+	if (lnull || rnull) {
+		return OP::Operation(0, 0, lnull, rnull);
+	}
+
+	auto &lchild = ListVector::GetEntry(left);
+	auto &rchild = ListVector::GetEntry(right);
+
+	auto ldata = (const list_entry_t *)lvdata.data;
+	auto rdata = (const list_entry_t *)rvdata.data;
+
+	auto &lval = ldata[lidx];
+	auto &rval = rdata[ridx];
+
+	for (idx_t pos = 0;; ++pos) {
+		// Tie-breaking uses the OP
+		if (pos == lval.length || pos == rval.length) {
+			return OP::Operation(lval.length, rval.length, false, false);
+		}
+
+		// Strict comparisons use the OP for definite
+		lidx = lval.offset + pos;
+		ridx = rval.offset + pos;
+		if (TemplatedOptimumValue<OP>(lchild, lidx, lcount, rchild, ridx, rcount)) {
+			return true;
+		}
+
+		// Strict comparisons use IS NOT DISTINCT for possible
+		if (!TemplatedOptimumValue<NotDistinctFrom>(lchild, lidx, lcount, rchild, ridx, rcount)) {
+			return false;
+		}
+	}
+
+	return false;
+}
+
+struct VectorMinMaxState {
+	Vector *value;
+};
+
+struct VectorMinMaxBase {
+	static bool IgnoreNull() {
+		return true;
+	}
+
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->value = nullptr;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->value) {
+			delete state->value;
+		}
+		state->value = nullptr;
+	}
+
+	template <class STATE>
+	static void Assign(STATE *state, Vector &input, const idx_t idx) {
+		if (!state->value) {
+			state->value = new Vector(input.GetType());
+			state->value->SetVectorType(VectorType::CONSTANT_VECTOR);
+		}
+		sel_t selv = idx;
+		SelectionVector sel(&selv);
+		VectorOperations::Copy(input, *state->value, sel, 1, 0, 0);
+	}
+
+	template <class STATE>
+	static void Execute(STATE *state, Vector &input, const idx_t idx, const idx_t count) {
+		Assign(state, input, idx);
+	}
+
+	template <class STATE, class OP>
+	static void Update(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector, idx_t count) {
+		auto &input = inputs[0];
+		VectorData idata;
+		input.Orrify(count, idata);
+
+		VectorData sdata;
+		state_vector.Orrify(count, sdata);
+
+		auto states = (STATE **)sdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			const auto idx = idata.sel->get_index(i);
+			if (!idata.validity.RowIsValid(idx)) {
+				continue;
+			}
+			const auto sidx = sdata.sel->get_index(i);
+			auto state = states[sidx];
+			if (!state->value) {
+				Assign(state, input, i);
+			} else {
+				OP::template Execute(state, input, i, count);
+			}
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.value) {
+			return;
+		} else if (!target->value) {
+			Assign(target, *source.value, 0);
+		} else {
+			OP::template Execute(target, *source.value, 0, 1);
+		}
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->value) {
+			// we need to use SetNull here
+			// since for STRUCT columns only setting the validity mask of the struct is incorrect
+			// as for a struct column, we need to also set ALL child columns to NULL
+			switch (result.GetVectorType()) {
+			case VectorType::FLAT_VECTOR:
+				FlatVector::SetNull(result, idx, true);
+				break;
+			case VectorType::CONSTANT_VECTOR:
+				ConstantVector::SetNull(result, true);
+				break;
+			default:
+				throw InternalException("Invalid result vector type for nested min/max");
+			}
+		} else {
+			VectorOperations::Copy(*state->value, result, 1, 0, idx);
+		}
+	}
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
+	                                     vector<unique_ptr<Expression>> &arguments) {
+		function.arguments[0] = arguments[0]->return_type;
+		function.return_type = arguments[0]->return_type;
+		return nullptr;
+	}
+};
+
+struct MinOperationVector : public VectorMinMaxBase {
+	template <class STATE>
+	static void Execute(STATE *state, Vector &input, const idx_t idx, const idx_t count) {
+		if (TemplatedOptimumValue<DistinctLessThan>(input, idx, count, *state->value, 0, 1)) {
+			Assign(state, input, idx);
+		}
+	}
+};
+
+struct MaxOperationVector : public VectorMinMaxBase {
+	template <class STATE>
+	static void Execute(STATE *state, Vector &input, const idx_t idx, const idx_t count) {
+		if (TemplatedOptimumValue<DistinctGreaterThan>(input, idx, count, *state->value, 0, 1)) {
+			Assign(state, input, idx);
+		}
+	}
+};
+
+template <class OP>
+unique_ptr<FunctionData> BindDecimalMinMax(ClientContext &context, AggregateFunction &function,
+                                           vector<unique_ptr<Expression>> &arguments) {
+	auto decimal_type = arguments[0]->return_type;
+	auto name = function.name;
+	switch (decimal_type.InternalType()) {
+	case PhysicalType::INT16:
+		function = GetUnaryAggregate<OP>(LogicalType::SMALLINT);
+		break;
+	case PhysicalType::INT32:
+		function = GetUnaryAggregate<OP>(LogicalType::INTEGER);
+		break;
+	case PhysicalType::INT64:
+		function = GetUnaryAggregate<OP>(LogicalType::BIGINT);
+		break;
+	default:
+		function = GetUnaryAggregate<OP>(LogicalType::HUGEINT);
+		break;
+	}
+	function.name = move(name);
+	function.arguments[0] = decimal_type;
+	function.return_type = decimal_type;
+	return nullptr;
+}
+
+template <typename OP, typename STATE>
+static AggregateFunction GetMinMaxFunction(const LogicalType &type) {
+	return AggregateFunction({type}, type, AggregateFunction::StateSize<STATE>,
+	                         AggregateFunction::StateInitialize<STATE, OP>, OP::template Update<STATE, OP>,
+	                         AggregateFunction::StateCombine<STATE, OP>,
+	                         AggregateFunction::StateFinalize<STATE, void, OP>, nullptr, OP::Bind,
+	                         AggregateFunction::StateDestroy<STATE, OP>);
+}
+
+template <class OP, class OP_STRING, class OP_VECTOR>
+static void AddMinMaxOperator(AggregateFunctionSet &set) {
+	for (auto &type : LogicalType::AllTypes()) {
+		if (type.id() == LogicalTypeId::VARCHAR || type.id() == LogicalTypeId::BLOB || type.id() == LogicalType::JSON) {
+			set.AddFunction(
+			    AggregateFunction::UnaryAggregateDestructor<MinMaxState<string_t>, string_t, string_t, OP_STRING>(
+			        type.id(), type.id()));
+		} else if (type.id() == LogicalTypeId::DECIMAL) {
+			set.AddFunction(AggregateFunction({type}, type, nullptr, nullptr, nullptr, nullptr, nullptr, false, nullptr,
+			                                  BindDecimalMinMax<OP>));
+		} else if (type.id() == LogicalTypeId::LIST || type.id() == LogicalTypeId::MAP ||
+		           type.id() == LogicalTypeId::STRUCT) {
+			set.AddFunction(GetMinMaxFunction<OP_VECTOR, VectorMinMaxState>(type));
+
+		} else {
+			set.AddFunction(GetUnaryAggregate<OP>(type));
+		}
+	}
+}
+
+void MinFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet min("min");
+	AddMinMaxOperator<MinOperation, MinOperationString, MinOperationVector>(min);
+	set.AddFunction(min);
+}
+
+void MaxFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet max("max");
+	AddMinMaxOperator<MaxOperation, MaxOperationString, MaxOperationVector>(max);
+	set.AddFunction(max);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct ProductState {
+	bool empty;
+	double val;
+};
+
+struct ProductFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->val = 1;
+		state->empty = true;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->val *= source.val;
+		target->empty = target->empty && source.empty;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->empty) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		target[idx] = state->val;
+	}
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (state->empty) {
+			state->empty = false;
+		}
+		state->val *= input[idx];
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+AggregateFunction ProductFun::GetFunction() {
+	auto fun = AggregateFunction::UnaryAggregate<ProductState, double, double, ProductFunction>(
+	    LogicalType(LogicalTypeId::DOUBLE), LogicalType::DOUBLE);
+	fun.name = "product";
+	return fun;
+}
+
+void ProductFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunction product_function = ProductFun::GetFunction();
+	AggregateFunctionSet product("product");
+	product.AddFunction(product_function);
+	set.AddFunction(product);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct SkewState {
+	size_t n;
+	double sum;
+	double sum_sqr;
+	double sum_cub;
+};
+
+struct SkewnessOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->n = 0;
+		state->sum = state->sum_sqr = state->sum_cub = 0;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+		state->n++;
+		state->sum += data[idx];
+		state->sum_sqr += pow(data[idx], 2);
+		state->sum_cub += pow(data[idx], 3);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.n == 0) {
+			return;
+		}
+
+		target->n += source.n;
+		target->sum += source.sum;
+		target->sum_sqr += source.sum_sqr;
+		target->sum_cub += source.sum_cub;
+	}
+
+	template <class TARGET_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, TARGET_TYPE *target, ValidityMask &mask,
+	                     idx_t idx) {
+		if (state->n <= 2) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		double n = state->n;
+		double temp = 1 / n;
+		double div = (std::sqrt(std::pow(temp * (state->sum_sqr - state->sum * state->sum * temp), 3)));
+		if (div == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		double temp1 = std::sqrt(n * (n - 1)) / (n - 2);
+		target[idx] = temp1 * temp *
+		              (state->sum_cub - 3 * state->sum_sqr * state->sum * temp + 2 * pow(state->sum, 3) * temp * temp) /
+		              div;
+		if (!Value::DoubleIsFinite(target[idx])) {
+			throw OutOfRangeException("SKEW is out of range!");
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void SkewFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet function_set("skewness");
+	function_set.AddFunction(AggregateFunction::UnaryAggregate<SkewState, double, double, SkewnessOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(function_set);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct StringAggState {
+	idx_t size;
+	idx_t alloc_size;
+	char *dataptr;
+};
+
+struct StringAggBindData : public FunctionData {
+	explicit StringAggBindData(string sep_p) : sep(move(sep_p)) {
+	}
+
+	string sep;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<StringAggBindData>(sep);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (StringAggBindData &)other_p;
+		return sep == other.sep;
+	}
+};
+
+struct StringAggFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->dataptr = nullptr;
+		state->alloc_size = 0;
+		state->size = 0;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->dataptr) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = StringVector::AddString(result, state->dataptr, state->size);
+		}
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->dataptr) {
+			delete[] state->dataptr;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+
+	static inline void PerformOperation(StringAggState *state, const char *str, const char *sep, idx_t str_size,
+	                                    idx_t sep_size) {
+		if (!state->dataptr) {
+			// first iteration: allocate space for the string and copy it into the state
+			state->alloc_size = MaxValue<idx_t>(8, NextPowerOfTwo(str_size));
+			state->dataptr = new char[state->alloc_size];
+			state->size = str_size;
+			memcpy(state->dataptr, str, str_size);
+		} else {
+			// subsequent iteration: first check if we have space to place the string and separator
+			idx_t required_size = state->size + str_size + sep_size;
+			if (required_size > state->alloc_size) {
+				// no space! allocate extra space
+				while (state->alloc_size < required_size) {
+					state->alloc_size *= 2;
+				}
+				auto new_data = new char[state->alloc_size];
+				memcpy(new_data, state->dataptr, state->size);
+				delete[] state->dataptr;
+				state->dataptr = new_data;
+			}
+			// copy the separator
+			memcpy(state->dataptr + state->size, sep, sep_size);
+			state->size += sep_size;
+			// copy the string
+			memcpy(state->dataptr + state->size, str, str_size);
+			state->size += str_size;
+		}
+	}
+
+	static inline void PerformOperation(StringAggState *state, string_t str, FunctionData *data_p) {
+		auto &data = (StringAggBindData &)*data_p;
+		PerformOperation(state, str.GetDataUnsafe(), data.sep.c_str(), str.GetSize(), data.sep.size());
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *str_data,
+	                      ValidityMask &str_mask, idx_t str_idx) {
+		PerformOperation(state, str_data[str_idx], aggr_input_data.bind_data);
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+		if (!source.dataptr) {
+			// source is not set: skip combining
+			return;
+		}
+		PerformOperation(target, string_t(source.dataptr, source.size), aggr_input_data.bind_data);
+	}
+};
+
+unique_ptr<FunctionData> StringAggBind(ClientContext &context, AggregateFunction &function,
+                                       vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() == 1) {
+		// single argument: default to comma
+		return make_unique<StringAggBindData>(",");
+	}
+	D_ASSERT(arguments.size() == 2);
+	if (!arguments[1]->IsFoldable()) {
+		throw BinderException("Separator argument to StringAgg must be a constant");
+	}
+	auto separator_val = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+	if (separator_val.IsNull()) {
+		arguments[0] = make_unique<BoundConstantExpression>(Value(LogicalType::VARCHAR));
+	}
+	function.arguments.erase(function.arguments.begin() + 1);
+	return make_unique<StringAggBindData>(separator_val.ToString());
+}
+
+void StringAggFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet string_agg("string_agg");
+	string_agg.AddFunction(
+	    AggregateFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                      AggregateFunction::StateSize<StringAggState>,
+	                      AggregateFunction::StateInitialize<StringAggState, StringAggFunction>,
+	                      AggregateFunction::UnaryScatterUpdate<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::StateCombine<StringAggState, StringAggFunction>,
+	                      AggregateFunction::StateFinalize<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::UnaryUpdate<StringAggState, string_t, StringAggFunction>, StringAggBind,
+	                      AggregateFunction::StateDestroy<StringAggState, StringAggFunction>));
+	string_agg.AddFunction(
+	    AggregateFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, AggregateFunction::StateSize<StringAggState>,
+	                      AggregateFunction::StateInitialize<StringAggState, StringAggFunction>,
+	                      AggregateFunction::UnaryScatterUpdate<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::StateCombine<StringAggState, StringAggFunction>,
+	                      AggregateFunction::StateFinalize<StringAggState, string_t, StringAggFunction>,
+	                      AggregateFunction::UnaryUpdate<StringAggState, string_t, StringAggFunction>, StringAggBind,
+	                      AggregateFunction::StateDestroy<StringAggState, StringAggFunction>));
+	set.AddFunction(string_agg);
+	string_agg.name = "group_concat";
+	set.AddFunction(string_agg);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct SumSetOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->Initialize();
+	}
+	template <class STATE>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->Combine(source);
+	}
+	template <class STATE>
+	static void AddValues(STATE *state, idx_t count) {
+		state->isset = true;
+	}
+};
+
+struct IntegerSumOperation : public BaseSumOperation<SumSetOperation, RegularAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = Hugeint::Convert(state->value);
+		}
+	}
+};
+
+struct SumToHugeintOperation : public BaseSumOperation<SumSetOperation, HugeintAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+};
+
+template <class ADD_OPERATOR>
+struct DoubleSumOperation : public BaseSumOperation<SumSetOperation, ADD_OPERATOR> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			mask.SetInvalid(idx);
+		} else {
+			if (!Value::DoubleIsFinite(state->value)) {
+				throw OutOfRangeException("SUM is out of range!");
+			}
+			target[idx] = state->value;
+		}
+	}
+};
+
+using NumericSumOperation = DoubleSumOperation<RegularAdd>;
+using KahanSumOperation = DoubleSumOperation<KahanAdd>;
+
+struct HugeintSumOperation : public BaseSumOperation<SumSetOperation, RegularAdd> {
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (!state->isset) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->value;
+		}
+	}
+};
+
+unique_ptr<BaseStatistics> SumPropagateStats(ClientContext &context, BoundAggregateExpression &expr,
+                                             FunctionData *bind_data, vector<unique_ptr<BaseStatistics>> &child_stats,
+                                             NodeStatistics *node_stats) {
+	if (child_stats[0] && node_stats && node_stats->has_max_cardinality) {
+		auto &numeric_stats = (NumericStatistics &)*child_stats[0];
+		if (numeric_stats.min.IsNull() || numeric_stats.max.IsNull()) {
+			return nullptr;
+		}
+		auto internal_type = numeric_stats.min.type().InternalType();
+		hugeint_t max_negative;
+		hugeint_t max_positive;
+		switch (internal_type) {
+		case PhysicalType::INT32:
+			max_negative = numeric_stats.min.GetValueUnsafe<int32_t>();
+			max_positive = numeric_stats.max.GetValueUnsafe<int32_t>();
+			break;
+		case PhysicalType::INT64:
+			max_negative = numeric_stats.min.GetValueUnsafe<int64_t>();
+			max_positive = numeric_stats.max.GetValueUnsafe<int64_t>();
+			break;
+		default:
+			throw InternalException("Unsupported type for propagate sum stats");
+		}
+		auto max_sum_negative = max_negative * hugeint_t(node_stats->max_cardinality);
+		auto max_sum_positive = max_positive * hugeint_t(node_stats->max_cardinality);
+		if (max_sum_positive >= NumericLimits<int64_t>::Maximum() ||
+		    max_sum_negative <= NumericLimits<int64_t>::Minimum()) {
+			// sum can potentially exceed int64_t bounds: use hugeint sum
+			return nullptr;
+		}
+		// total sum is guaranteed to fit in a single int64: use int64 sum instead of hugeint sum
+		switch (internal_type) {
+		case PhysicalType::INT32:
+			expr.function =
+			    AggregateFunction::UnaryAggregate<SumState<int64_t>, int32_t, hugeint_t, IntegerSumOperation>(
+			        LogicalType::INTEGER, LogicalType::HUGEINT, true);
+			expr.function.name = "sum";
+			break;
+		case PhysicalType::INT64:
+			expr.function =
+			    AggregateFunction::UnaryAggregate<SumState<int64_t>, int64_t, hugeint_t, IntegerSumOperation>(
+			        LogicalType::BIGINT, LogicalType::HUGEINT, true);
+			expr.function.name = "sum";
+			break;
+		default:
+			throw InternalException("Unsupported type for propagate sum stats");
+		}
+	}
+	return nullptr;
+}
+
+AggregateFunction SumFun::GetSumAggregate(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::INT16:
+		return AggregateFunction::UnaryAggregate<SumState<int64_t>, int16_t, hugeint_t, IntegerSumOperation>(
+		    LogicalType::SMALLINT, LogicalType::HUGEINT, true);
+	case PhysicalType::INT32: {
+		auto function =
+		    AggregateFunction::UnaryAggregate<SumState<hugeint_t>, int32_t, hugeint_t, SumToHugeintOperation>(
+		        LogicalType::INTEGER, LogicalType::HUGEINT, true);
+		function.statistics = SumPropagateStats;
+		return function;
+	}
+	case PhysicalType::INT64: {
+		auto function =
+		    AggregateFunction::UnaryAggregate<SumState<hugeint_t>, int64_t, hugeint_t, SumToHugeintOperation>(
+		        LogicalType::BIGINT, LogicalType::HUGEINT, true);
+		function.statistics = SumPropagateStats;
+		return function;
+	}
+	case PhysicalType::INT128:
+		return AggregateFunction::UnaryAggregate<SumState<hugeint_t>, hugeint_t, hugeint_t, HugeintSumOperation>(
+		    LogicalType::HUGEINT, LogicalType::HUGEINT, true);
+	default:
+		throw InternalException("Unimplemented sum aggregate");
+	}
+}
+
+unique_ptr<FunctionData> BindDecimalSum(ClientContext &context, AggregateFunction &function,
+                                        vector<unique_ptr<Expression>> &arguments) {
+	auto decimal_type = arguments[0]->return_type;
+	function = SumFun::GetSumAggregate(decimal_type.InternalType());
+	function.name = "sum";
+	function.arguments[0] = decimal_type;
+	function.return_type = LogicalType::DECIMAL(Decimal::MAX_WIDTH_DECIMAL, DecimalType::GetScale(decimal_type));
+	return nullptr;
+}
+
+void SumFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet sum("sum");
+	// decimal
+	sum.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
+	                                  nullptr, nullptr, true, nullptr, BindDecimalSum));
+	sum.AddFunction(GetSumAggregate(PhysicalType::INT16));
+	sum.AddFunction(GetSumAggregate(PhysicalType::INT32));
+	sum.AddFunction(GetSumAggregate(PhysicalType::INT64));
+	sum.AddFunction(GetSumAggregate(PhysicalType::INT128));
+	sum.AddFunction(AggregateFunction::UnaryAggregate<SumState<double>, double, double, NumericSumOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, true));
+
+	set.AddFunction(sum);
+
+	// fsum
+	AggregateFunctionSet fsum("fsum");
+	fsum.AddFunction(AggregateFunction::UnaryAggregate<KahanSumState, double, double, KahanSumOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, true));
+
+	set.AddFunction(fsum);
+
+	fsum.name = "kahan_sum";
+	set.AddFunction(fsum);
+
+	fsum.name = "sumKahan";
+	set.AddFunction(fsum);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterDistributiveAggregates() {
+	Register<BitAndFun>();
+	Register<BitOrFun>();
+	Register<BitXorFun>();
+	Register<CountStarFun>();
+	Register<CountFun>();
+	Register<FirstFun>();
+	Register<MaxFun>();
+	Register<MinFun>();
+	Register<SumFun>();
+	Register<StringAggFun>();
+	Register<ApproxCountDistinctFun>();
+	Register<ProductFun>();
+	Register<BoolOrFun>();
+	Register<BoolAndFun>();
+	Register<ArgMinFun>();
+	Register<ArgMaxFun>();
+	Register<SkewFun>();
+	Register<KurtosisFun>();
+	Register<EntropyFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <algorithm>
+#include <cmath>
+#include <stdlib.h>
+
+namespace duckdb {
+
+struct ApproxQuantileState {
+	duckdb_tdigest::TDigest *h;
+	idx_t pos;
+};
+
+struct ApproximateQuantileBindData : public FunctionData {
+	explicit ApproximateQuantileBindData(float quantile_p) : quantiles(1, quantile_p) {
+	}
+
+	explicit ApproximateQuantileBindData(const vector<float> &quantiles_p) : quantiles(quantiles_p) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<ApproximateQuantileBindData>(quantiles);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (ApproximateQuantileBindData &)other_p;
+		return quantiles == other.quantiles;
+	}
+
+	vector<float> quantiles;
+};
+
+struct ApproxQuantileOperation {
+	using SAVE_TYPE = duckdb_tdigest::Value;
+
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->pos = 0;
+		state->h = nullptr;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+		if (!state->h) {
+			state->h = new duckdb_tdigest::TDigest(100);
+		}
+
+		state->h->add(Cast::template Operation<INPUT_TYPE, SAVE_TYPE>(data[idx]));
+		state->pos++;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.pos == 0) {
+			return;
+		}
+		D_ASSERT(source.h);
+		if (!target->h) {
+			target->h = new duckdb_tdigest::TDigest(100);
+		}
+		target->h->merge(source.h);
+		target->pos += source.pos;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->h) {
+			delete state->h;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+struct ApproxQuantileScalarOperation : public ApproxQuantileOperation {
+
+	template <class TARGET_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, TARGET_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+
+		if (state->pos == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		D_ASSERT(state->h);
+		D_ASSERT(aggr_input_data.bind_data);
+		state->h->compress();
+		auto bind_data = (ApproximateQuantileBindData *)aggr_input_data.bind_data;
+		D_ASSERT(bind_data->quantiles.size() == 1);
+		target[idx] = Cast::template Operation<SAVE_TYPE, TARGET_TYPE>(state->h->quantile(bind_data->quantiles[0]));
+	}
+};
+
+AggregateFunction GetApproximateQuantileAggregateFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::INT16:
+		return AggregateFunction::UnaryAggregateDestructor<ApproxQuantileState, int16_t, int16_t,
+		                                                   ApproxQuantileScalarOperation>(LogicalType::SMALLINT,
+		                                                                                  LogicalType::SMALLINT);
+
+	case PhysicalType::INT32:
+		return AggregateFunction::UnaryAggregateDestructor<ApproxQuantileState, int32_t, int32_t,
+		                                                   ApproxQuantileScalarOperation>(LogicalType::INTEGER,
+		                                                                                  LogicalType::INTEGER);
+
+	case PhysicalType::INT64:
+		return AggregateFunction::UnaryAggregateDestructor<ApproxQuantileState, int64_t, int64_t,
+		                                                   ApproxQuantileScalarOperation>(LogicalType::BIGINT,
+		                                                                                  LogicalType::BIGINT);
+	case PhysicalType::DOUBLE:
+		return AggregateFunction::UnaryAggregateDestructor<ApproxQuantileState, double, double,
+		                                                   ApproxQuantileScalarOperation>(LogicalType::DOUBLE,
+		                                                                                  LogicalType::DOUBLE);
+
+	default:
+		throw InternalException("Unimplemented quantile aggregate");
+	}
+}
+
+static float CheckApproxQuantile(const Value &quantile_val) {
+	auto quantile = quantile_val.GetValue<float>();
+
+	if (quantile_val.IsNull() || quantile < 0 || quantile > 1) {
+		throw BinderException("APPROXIMATE QUANTILE can only take parameters in range [0, 1]");
+	}
+
+	return quantile;
+}
+
+unique_ptr<FunctionData> BindApproxQuantile(ClientContext &context, AggregateFunction &function,
+                                            vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[1]->IsScalar()) {
+		throw BinderException("APPROXIMATE QUANTILE can only take constant quantile parameters");
+	}
+	Value quantile_val = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+
+	vector<float> quantiles;
+	if (quantile_val.type().id() != LogicalTypeId::LIST) {
+		quantiles.push_back(CheckApproxQuantile(quantile_val));
+	} else {
+		for (const auto &element_val : ListValue::GetChildren(quantile_val)) {
+			quantiles.push_back(CheckApproxQuantile(element_val));
+		}
+	}
+
+	// remove the quantile argument so we can use the unary aggregate
+	arguments.pop_back();
+	return make_unique<ApproximateQuantileBindData>(quantiles);
+}
+
+unique_ptr<FunctionData> BindApproxQuantileDecimal(ClientContext &context, AggregateFunction &function,
+                                                   vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindApproxQuantile(context, function, arguments);
+	function = GetApproximateQuantileAggregateFunction(arguments[0]->return_type.InternalType());
+	function.name = "approx_quantile";
+	return bind_data;
+}
+
+AggregateFunction GetApproximateQuantileAggregate(PhysicalType type) {
+	auto fun = GetApproximateQuantileAggregateFunction(type);
+	fun.bind = BindApproxQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	fun.arguments.emplace_back(LogicalType::FLOAT);
+	return fun;
+}
+
+template <class CHILD_TYPE>
+struct ApproxQuantileListOperation : public ApproxQuantileOperation {
+
+	template <class RESULT_TYPE, class STATE>
+	static void Finalize(Vector &result_list, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->pos == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (ApproximateQuantileBindData *)aggr_input_data.bind_data;
+
+		auto &result = ListVector::GetEntry(result_list);
+		auto ridx = ListVector::GetListSize(result_list);
+		ListVector::Reserve(result_list, ridx + bind_data->quantiles.size());
+		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
+
+		D_ASSERT(state->h);
+		state->h->compress();
+
+		auto &entry = target[idx];
+		entry.offset = ridx;
+		entry.length = bind_data->quantiles.size();
+		for (size_t q = 0; q < entry.length; ++q) {
+			const auto &quantile = bind_data->quantiles[q];
+			rdata[ridx + q] = Cast::template Operation<SAVE_TYPE, CHILD_TYPE>(state->h->quantile(quantile));
+		}
+
+		ListVector::SetListSize(result_list, entry.offset + entry.length);
+	}
+
+	template <class STATE_TYPE, class RESULT_TYPE>
+	static void FinalizeList(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count, // NOLINT
+	                         idx_t offset) {
+		D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (ApproximateQuantileBindData *)aggr_input_data.bind_data;
+
+		if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ListVector::Reserve(result, bind_data->quantiles.size());
+
+			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
+			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
+			auto &mask = ConstantVector::Validity(result);
+			Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
+		} else {
+			D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			ListVector::Reserve(result, (offset + count) * bind_data->quantiles.size());
+
+			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
+			auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+			auto &mask = FlatVector::Validity(result);
+			for (idx_t i = 0; i < count; i++) {
+				Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
+			}
+		}
+
+		result.Verify(count);
+	}
+};
+
+template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>
+static AggregateFunction ApproxQuantileListAggregate(const LogicalType &input_type, const LogicalType &child_type) {
+	LogicalType result_type = LogicalType::LIST(child_type);
+	return AggregateFunction(
+	    {input_type}, result_type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
+	    AggregateFunction::UnaryScatterUpdate<STATE, INPUT_TYPE, OP>, AggregateFunction::StateCombine<STATE, OP>,
+	    OP::template FinalizeList<STATE, RESULT_TYPE>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>, nullptr,
+	    AggregateFunction::StateDestroy<STATE, OP>);
+}
+
+template <typename INPUT_TYPE, typename SAVE_TYPE>
+AggregateFunction GetTypedApproxQuantileListAggregateFunction(const LogicalType &type) {
+	using STATE = ApproxQuantileState;
+	using OP = ApproxQuantileListOperation<INPUT_TYPE>;
+	auto fun = ApproxQuantileListAggregate<STATE, INPUT_TYPE, list_entry_t, OP>(type, type);
+	return fun;
+}
+
+AggregateFunction GetApproxQuantileListAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedApproxQuantileListAggregateFunction<int8_t, int8_t>(type);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedApproxQuantileListAggregateFunction<int16_t, int16_t>(type);
+	case LogicalTypeId::INTEGER:
+		return GetTypedApproxQuantileListAggregateFunction<int32_t, int32_t>(type);
+	case LogicalTypeId::BIGINT:
+		return GetTypedApproxQuantileListAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedApproxQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedApproxQuantileListAggregateFunction<float, float>(type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedApproxQuantileListAggregateFunction<double, double>(type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedApproxQuantileListAggregateFunction<int16_t, int16_t>(type);
+		case PhysicalType::INT32:
+			return GetTypedApproxQuantileListAggregateFunction<int32_t, int32_t>(type);
+		case PhysicalType::INT64:
+			return GetTypedApproxQuantileListAggregateFunction<int64_t, int64_t>(type);
+		case PhysicalType::INT128:
+			return GetTypedApproxQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+		default:
+			throw NotImplementedException("Unimplemented approximate quantile list aggregate");
+		}
+		break;
+
+	default:
+		// TODO: Add quantitative temporal types
+		throw NotImplementedException("Unimplemented approximate quantile list aggregate");
+	}
+}
+
+unique_ptr<FunctionData> BindApproxQuantileDecimalList(ClientContext &context, AggregateFunction &function,
+                                                       vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindApproxQuantile(context, function, arguments);
+	function = GetApproxQuantileListAggregateFunction(arguments[0]->return_type);
+	function.name = "approx_quantile";
+	return bind_data;
+}
+
+AggregateFunction GetApproxQuantileListAggregate(const LogicalType &type) {
+	auto fun = GetApproxQuantileListAggregateFunction(type);
+	fun.bind = BindApproxQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	auto list_of_float = LogicalType::LIST(LogicalType::FLOAT);
+	fun.arguments.push_back(list_of_float);
+	return fun;
+}
+
+void ApproximateQuantileFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet approx_quantile("approx_quantile");
+	approx_quantile.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::FLOAT}, LogicalTypeId::DECIMAL,
+	                                              nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+	                                              BindApproxQuantileDecimal));
+
+	approx_quantile.AddFunction(GetApproximateQuantileAggregate(PhysicalType::INT16));
+	approx_quantile.AddFunction(GetApproximateQuantileAggregate(PhysicalType::INT32));
+	approx_quantile.AddFunction(GetApproximateQuantileAggregate(PhysicalType::INT64));
+	approx_quantile.AddFunction(GetApproximateQuantileAggregate(PhysicalType::DOUBLE));
+
+	// List variants
+	approx_quantile.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::FLOAT)},
+	                                              LogicalType::LIST(LogicalTypeId::DECIMAL), nullptr, nullptr, nullptr,
+	                                              nullptr, nullptr, nullptr, BindApproxQuantileDecimalList));
+
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::TINYINT));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::SMALLINT));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::INTEGER));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::BIGINT));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::HUGEINT));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::FLOAT));
+	approx_quantile.AddFunction(GetApproxQuantileListAggregate(LogicalTypeId::DOUBLE));
+
+	set.AddFunction(approx_quantile);
+}
+
+} // namespace duckdb
+// MODE( <expr1> )
+// Returns the most frequent value for the values within expr1.
+// NULL values are ignored. If all the values are NULL, or there are 0 rows, then the function returns NULL.
+
+
+
+
+
+
+
+
+#include <functional>
+
+namespace std {
+
+template <>
+struct hash<duckdb::interval_t> {
+	inline size_t operator()(const duckdb::interval_t &val) const {
+		return hash<int32_t> {}(val.days) ^ hash<int32_t> {}(val.months) ^ hash<int64_t> {}(val.micros);
+	}
+};
+
+template <>
+struct hash<duckdb::hugeint_t> {
+	inline size_t operator()(const duckdb::hugeint_t &val) const {
+		return hash<int64_t> {}(val.upper) ^ hash<int64_t> {}(val.lower);
+	}
+};
+
+} // namespace std
+
+namespace duckdb {
+
+using FrameBounds = std::pair<idx_t, idx_t>;
+
+template <class KEY_TYPE>
+struct ModeState {
+	using Counts = unordered_map<KEY_TYPE, size_t>;
+
+	Counts *frequency_map;
+	KEY_TYPE *mode;
+	size_t nonzero;
+	bool valid;
+	size_t count;
+
+	void Initialize() {
+		frequency_map = nullptr;
+		mode = nullptr;
+		nonzero = 0;
+		valid = false;
+		count = 0;
+	}
+
+	void Destroy() {
+		if (frequency_map) {
+			delete frequency_map;
+		}
+		if (mode) {
+			delete mode;
+		}
+	}
+
+	void Reset() {
+		Counts empty;
+		frequency_map->swap(empty);
+		nonzero = 0;
+		count = 0;
+		valid = false;
+	}
+
+	void ModeAdd(const KEY_TYPE &key) {
+		auto new_count = ((*frequency_map)[key] += 1);
+		if (new_count == 1) {
+			++nonzero;
+		}
+		if (new_count > count) {
+			valid = true;
+			count = new_count;
+			if (mode) {
+				*mode = key;
+			} else {
+				mode = new KEY_TYPE(key);
+			}
+		}
+	}
+
+	void ModeRm(const KEY_TYPE &key) {
+		auto i = frequency_map->find(key);
+		auto old_count = i->second;
+		nonzero -= int(old_count == 1);
+
+		i->second -= 1;
+		if (count == old_count && key == *mode) {
+			valid = false;
+		}
+	}
+
+	typename Counts::const_iterator Scan() const {
+		//! Initialize control variables to first variable of the frequency map
+		auto highest_frequency = frequency_map->begin();
+		for (auto i = highest_frequency; i != frequency_map->end(); ++i) {
+			// Tie break with the lowest
+			if (i->second > highest_frequency->second ||
+			    (i->second == highest_frequency->second && i->first < highest_frequency->first)) {
+				highest_frequency = i;
+			}
+		}
+		return highest_frequency;
+	}
+};
+
+struct ModeIncluded {
+	inline explicit ModeIncluded(const ValidityMask &fmask_p, const ValidityMask &dmask_p, idx_t bias_p)
+	    : fmask(fmask_p), dmask(dmask_p), bias(bias_p) {
+	}
+
+	inline bool operator()(const idx_t &idx) const {
+		return fmask.RowIsValid(idx) && dmask.RowIsValid(idx - bias);
+	}
+	const ValidityMask &fmask;
+	const ValidityMask &dmask;
+	const idx_t bias;
+};
+
+template <typename KEY_TYPE>
+struct ModeFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->Initialize();
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask, idx_t idx) {
+		if (!state->frequency_map) {
+			state->frequency_map = new unordered_map<KEY_TYPE, size_t>();
+		}
+		auto key = KEY_TYPE(input[idx]);
+		(*state->frequency_map)[key]++;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (!source.frequency_map) {
+			return;
+		}
+		if (!target->frequency_map) {
+			// Copy - don't destroy! Otherwise windowing will break.
+			target->frequency_map = new unordered_map<KEY_TYPE, size_t>(*source.frequency_map);
+			return;
+		}
+		for (auto &val : *source.frequency_map) {
+			(*target->frequency_map)[val.first] += val.second;
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, INPUT_TYPE *target, ValidityMask &mask,
+	                     idx_t idx) {
+		if (!state->frequency_map) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		auto highest_frequency = state->Scan();
+		if (highest_frequency != state->frequency_map->end()) {
+			target[idx] = INPUT_TYPE(highest_frequency->first);
+		} else {
+			mask.SetInvalid(idx);
+		}
+	}
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &, INPUT_TYPE *input, ValidityMask &mask,
+	                              idx_t count) {
+		if (!state->frequency_map) {
+			state->frequency_map = new unordered_map<KEY_TYPE, size_t>();
+		}
+		auto key = KEY_TYPE(input[0]);
+		(*state->frequency_map)[key] += count;
+	}
+
+	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
+	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
+	                   AggregateInputData &, STATE *state, const FrameBounds &frame, const FrameBounds &prev,
+	                   Vector &result, idx_t rid, idx_t bias) {
+		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+		auto &rmask = FlatVector::Validity(result);
+
+		ModeIncluded included(fmask, dmask, bias);
+
+		if (!state->frequency_map) {
+			state->frequency_map = new unordered_map<KEY_TYPE, size_t>();
+		}
+		const double tau = .25;
+		if (state->nonzero <= tau * state->frequency_map->size()) {
+			state->Reset();
+			// for f ∈ F do
+			for (auto f = frame.first; f < frame.second; ++f) {
+				if (included(f)) {
+					state->ModeAdd(KEY_TYPE(data[f]));
+				}
+			}
+		} else {
+			// for f ∈ P \ F do
+			for (auto p = prev.first; p < frame.first; ++p) {
+				if (included(p)) {
+					state->ModeRm(KEY_TYPE(data[p]));
+				}
+			}
+			for (auto p = frame.second; p < prev.second; ++p) {
+				if (included(p)) {
+					state->ModeRm(KEY_TYPE(data[p]));
+				}
+			}
+
+			// for f ∈ F \ P do
+			for (auto f = frame.first; f < prev.first; ++f) {
+				if (included(f)) {
+					state->ModeAdd(KEY_TYPE(data[f]));
+				}
+			}
+			for (auto f = prev.second; f < frame.second; ++f) {
+				if (included(f)) {
+					state->ModeAdd(KEY_TYPE(data[f]));
+				}
+			}
+		}
+
+		if (!state->valid) {
+			// Rescan
+			auto highest_frequency = state->Scan();
+			if (highest_frequency != state->frequency_map->end()) {
+				*(state->mode) = highest_frequency->first;
+				state->count = highest_frequency->second;
+				state->valid = (state->count > 0);
+			}
+		}
+
+		if (state->valid) {
+			rdata[rid] = RESULT_TYPE(*state->mode);
+		} else {
+			rmask.Set(rid, false);
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		state->Destroy();
+	}
+};
+
+template <typename INPUT_TYPE, typename KEY_TYPE>
+AggregateFunction GetTypedModeFunction(const LogicalType &type) {
+	using STATE = ModeState<KEY_TYPE>;
+	using OP = ModeFunction<KEY_TYPE>;
+	auto func = AggregateFunction::UnaryAggregateDestructor<STATE, INPUT_TYPE, INPUT_TYPE, OP>(type, type);
+	func.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, INPUT_TYPE, OP>;
+	return func;
+}
+
+AggregateFunction GetModeAggregate(const LogicalType &type) {
+	switch (type.InternalType()) {
+	case PhysicalType::INT8:
+		return GetTypedModeFunction<int8_t, int8_t>(type);
+	case PhysicalType::UINT8:
+		return GetTypedModeFunction<uint8_t, uint8_t>(type);
+	case PhysicalType::INT16:
+		return GetTypedModeFunction<int16_t, int16_t>(type);
+	case PhysicalType::UINT16:
+		return GetTypedModeFunction<uint16_t, uint16_t>(type);
+	case PhysicalType::INT32:
+		return GetTypedModeFunction<int32_t, int32_t>(type);
+	case PhysicalType::UINT32:
+		return GetTypedModeFunction<uint32_t, uint32_t>(type);
+	case PhysicalType::INT64:
+		return GetTypedModeFunction<int64_t, int64_t>(type);
+	case PhysicalType::UINT64:
+		return GetTypedModeFunction<uint64_t, uint64_t>(type);
+	case PhysicalType::INT128:
+		return GetTypedModeFunction<hugeint_t, hugeint_t>(type);
+
+	case PhysicalType::FLOAT:
+		return GetTypedModeFunction<float, float>(type);
+	case PhysicalType::DOUBLE:
+		return GetTypedModeFunction<double, double>(type);
+
+	case PhysicalType::INTERVAL:
+		return GetTypedModeFunction<interval_t, interval_t>(type);
+
+	case PhysicalType::VARCHAR:
+		return GetTypedModeFunction<string_t, string>(type);
+
+	default:
+		throw NotImplementedException("Unimplemented mode aggregate");
+	}
+}
+
+unique_ptr<FunctionData> BindModeDecimal(ClientContext &context, AggregateFunction &function,
+                                         vector<unique_ptr<Expression>> &arguments) {
+	function = GetModeAggregate(arguments[0]->return_type);
+	function.name = "mode";
+	return nullptr;
+}
+
+void ModeFun::RegisterFunction(BuiltinFunctions &set) {
+	const vector<LogicalType> TEMPORAL = {LogicalType::DATE,         LogicalType::TIMESTAMP, LogicalType::TIME,
+	                                      LogicalType::TIMESTAMP_TZ, LogicalType::TIME_TZ,   LogicalType::INTERVAL};
+
+	AggregateFunctionSet mode("mode");
+	mode.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
+	                                   nullptr, nullptr, nullptr, BindModeDecimal));
+
+	for (const auto &type : LogicalType::Numeric()) {
+		if (type.id() != LogicalTypeId::DECIMAL) {
+			mode.AddFunction(GetModeAggregate(type));
+		}
+	}
+
+	for (const auto &type : TEMPORAL) {
+		mode.AddFunction(GetModeAggregate(type));
+	}
+
+	mode.AddFunction(GetModeAggregate(LogicalType::VARCHAR));
+
+	set.AddFunction(mode);
+}
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <stdlib.h>
+#include <utility>
+
+namespace duckdb {
+
+// Hugeint arithmetic
+hugeint_t operator*(const hugeint_t &h, const double &d) {
+	D_ASSERT(d >= 0 && d <= 1);
+	return Hugeint::Convert(Hugeint::Cast<double>(h) * d);
+}
+
+// Interval arithmetic
+interval_t operator*(const interval_t &i, const double &d) {
+	D_ASSERT(d >= 0 && d <= 1);
+	return Interval::FromMicro(std::llround(Interval::GetMicro(i) * d));
+}
+
+inline interval_t operator+(const interval_t &lhs, const interval_t &rhs) {
+	return Interval::FromMicro(Interval::GetMicro(lhs) + Interval::GetMicro(rhs));
+}
+
+inline interval_t operator-(const interval_t &lhs, const interval_t &rhs) {
+	return Interval::FromMicro(Interval::GetMicro(lhs) - Interval::GetMicro(rhs));
+}
+
+using FrameBounds = std::pair<idx_t, idx_t>;
+
+template <typename SAVE_TYPE>
+struct QuantileState {
+	using SaveType = SAVE_TYPE;
+
+	// Regular aggregation
+	std::vector<SaveType> v;
+
+	// Windowed Quantile indirection
+	std::vector<idx_t> w;
+	idx_t pos;
+
+	// Windowed MAD indirection
+	std::vector<idx_t> m;
+
+	QuantileState() : pos(0) {
+	}
+
+	~QuantileState() {
+	}
+
+	inline void SetPos(size_t pos_p) {
+		pos = pos_p;
+		if (pos >= w.size()) {
+			w.resize(pos);
+		}
+	}
+};
+
+struct QuantileIncluded {
+	inline explicit QuantileIncluded(const ValidityMask &fmask_p, const ValidityMask &dmask_p, idx_t bias_p)
+	    : fmask(fmask_p), dmask(dmask_p), bias(bias_p) {
+	}
+
+	inline bool operator()(const idx_t &idx) const {
+		return fmask.RowIsValid(idx) && dmask.RowIsValid(idx - bias);
+	}
+
+	inline bool AllValid() const {
+		return fmask.AllValid() && dmask.AllValid();
+	}
+
+	const ValidityMask &fmask;
+	const ValidityMask &dmask;
+	const idx_t bias;
+};
+
+void ReuseIndexes(idx_t *index, const FrameBounds &frame, const FrameBounds &prev) {
+	idx_t j = 0;
+
+	//  Copy overlapping indices
+	for (idx_t p = 0; p < (prev.second - prev.first); ++p) {
+		auto idx = index[p];
+
+		//  Shift down into any hole
+		if (j != p) {
+			index[j] = idx;
+		}
+
+		//  Skip overlapping values
+		if (frame.first <= idx && idx < frame.second) {
+			++j;
+		}
+	}
+
+	//  Insert new indices
+	if (j > 0) {
+		// Overlap: append the new ends
+		for (auto f = frame.first; f < prev.first; ++f, ++j) {
+			index[j] = f;
+		}
+		for (auto f = prev.second; f < frame.second; ++f, ++j) {
+			index[j] = f;
+		}
+	} else {
+		//  No overlap: overwrite with new values
+		for (auto f = frame.first; f < frame.second; ++f, ++j) {
+			index[j] = f;
+		}
+	}
+}
+
+static idx_t ReplaceIndex(idx_t *index, const FrameBounds &frame, const FrameBounds &prev) { // NOLINT
+	D_ASSERT(index);
+
+	idx_t j = 0;
+	for (idx_t p = 0; p < (prev.second - prev.first); ++p) {
+		auto idx = index[p];
+		if (j != p) {
+			break;
+		}
+
+		if (frame.first <= idx && idx < frame.second) {
+			++j;
+		}
+	}
+	index[j] = frame.second - 1;
+
+	return j;
+}
+
+template <class INPUT_TYPE>
+static inline int CanReplace(const idx_t *index, const INPUT_TYPE *fdata, const idx_t j, const idx_t k0, const idx_t k1,
+                             const QuantileIncluded &validity) {
+	D_ASSERT(index);
+
+	// NULLs sort to the end, so if we have inserted a NULL,
+	// it must be past the end of the quantile to be replaceable.
+	// Note that the quantile values are never NULL.
+	const auto ij = index[j];
+	if (!validity(ij)) {
+		return k1 < j ? 1 : 0;
+	}
+
+	auto curr = fdata[ij];
+	if (k1 < j) {
+		auto hi = fdata[index[k0]];
+		return hi < curr ? 1 : 0;
+	} else if (j < k0) {
+		auto lo = fdata[index[k1]];
+		return curr < lo ? -1 : 0;
+	}
+
+	return 0;
+}
+
+template <class INPUT_TYPE>
+struct IndirectLess {
+	inline explicit IndirectLess(const INPUT_TYPE *inputs_p) : inputs(inputs_p) {
+	}
+
+	inline bool operator()(const idx_t &lhi, const idx_t &rhi) const {
+		return inputs[lhi] < inputs[rhi];
+	}
+
+	const INPUT_TYPE *inputs;
+};
+
+struct CastInterpolation {
+
+	template <class INPUT_TYPE, class TARGET_TYPE>
+	static inline TARGET_TYPE Cast(const INPUT_TYPE &src, Vector &result) {
+		return Cast::Operation<INPUT_TYPE, TARGET_TYPE>(src);
+	}
+	template <typename TARGET_TYPE>
+	static inline TARGET_TYPE Interpolate(const TARGET_TYPE &lo, const double d, const TARGET_TYPE &hi) {
+		const auto delta = hi - lo;
+		return lo + delta * d;
+	}
+};
+
+template <>
+interval_t CastInterpolation::Cast(const dtime_t &src, Vector &result) {
+	return {0, 0, src.micros};
+}
+
+template <>
+double CastInterpolation::Interpolate(const double &lo, const double d, const double &hi) {
+	return lo * (1.0 - d) + hi * d;
+}
+
+template <>
+dtime_t CastInterpolation::Interpolate(const dtime_t &lo, const double d, const dtime_t &hi) {
+	return dtime_t(std::llround(lo.micros * (1.0 - d) + hi.micros * d));
+}
+
+template <>
+timestamp_t CastInterpolation::Interpolate(const timestamp_t &lo, const double d, const timestamp_t &hi) {
+	return timestamp_t(std::llround(lo.value * (1.0 - d) + hi.value * d));
+}
+
+template <>
+string_t CastInterpolation::Cast(const std::string &src, Vector &result) {
+	return StringVector::AddString(result, src);
+}
+
+template <>
+string_t CastInterpolation::Cast(const string_t &src, Vector &result) {
+	return StringVector::AddString(result, src);
+}
+
+// Direct access
+template <typename T>
+struct QuantileDirect {
+	using INPUT_TYPE = T;
+	using RESULT_TYPE = T;
+
+	inline const INPUT_TYPE &operator()(const INPUT_TYPE &x) const {
+		return x;
+	}
+};
+
+// Indirect access
+template <typename T>
+struct QuantileIndirect {
+	using INPUT_TYPE = idx_t;
+	using RESULT_TYPE = T;
+	const RESULT_TYPE *data;
+
+	explicit QuantileIndirect(const RESULT_TYPE *data_p) : data(data_p) {
+	}
+
+	inline RESULT_TYPE operator()(const idx_t &input) const {
+		return data[input];
+	}
+};
+
+// Composed access
+template <typename OUTER, typename INNER>
+struct QuantileComposed {
+	using INPUT_TYPE = typename INNER::INPUT_TYPE;
+	using RESULT_TYPE = typename OUTER::RESULT_TYPE;
+
+	const OUTER &outer;
+	const INNER &inner;
+
+	explicit QuantileComposed(const OUTER &outer_p, const INNER &inner_p) : outer(outer_p), inner(inner_p) {
+	}
+
+	inline RESULT_TYPE operator()(const idx_t &input) const {
+		return outer(inner(input));
+	}
+};
+
+// Accessed comparison
+template <typename ACCESSOR>
+struct QuantileLess {
+	using INPUT_TYPE = typename ACCESSOR::INPUT_TYPE;
+	const ACCESSOR &accessor;
+	explicit QuantileLess(const ACCESSOR &accessor_p) : accessor(accessor_p) {
+	}
+
+	inline bool operator()(const INPUT_TYPE &lhs, const INPUT_TYPE &rhs) const {
+		return accessor(lhs) < accessor(rhs);
+	}
+};
+
+// Continuous interpolation
+template <bool DISCRETE>
+struct Interpolator {
+	Interpolator(const double q, const idx_t n_p)
+	    : n(n_p), RN((double)(n_p - 1) * q), FRN(floor(RN)), CRN(ceil(RN)), begin(0), end(n_p) {
+	}
+
+	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
+	TARGET_TYPE Operation(INPUT_TYPE *v_t, Vector &result, const ACCESSOR &accessor = ACCESSOR()) const {
+		using ACCESS_TYPE = typename ACCESSOR::RESULT_TYPE;
+		QuantileLess<ACCESSOR> comp(accessor);
+		if (CRN == FRN) {
+			std::nth_element(v_t + begin, v_t + FRN, v_t + end, comp);
+			return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+		} else {
+			std::nth_element(v_t + begin, v_t + FRN, v_t + end, comp);
+			std::nth_element(v_t + FRN, v_t + CRN, v_t + end, comp);
+			auto lo = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+			auto hi = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[CRN]), result);
+			return CastInterpolation::Interpolate<TARGET_TYPE>(lo, RN - FRN, hi);
+		}
+	}
+
+	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
+	TARGET_TYPE Replace(const INPUT_TYPE *v_t, Vector &result, const ACCESSOR &accessor = ACCESSOR()) const {
+		using ACCESS_TYPE = typename ACCESSOR::RESULT_TYPE;
+		if (CRN == FRN) {
+			return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+		} else {
+			auto lo = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+			auto hi = CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[CRN]), result);
+			return CastInterpolation::Interpolate<TARGET_TYPE>(lo, RN - FRN, hi);
+		}
+	}
+
+	const idx_t n;
+	const double RN;
+	const idx_t FRN;
+	const idx_t CRN;
+
+	idx_t begin;
+	idx_t end;
+};
+
+// Discrete "interpolation"
+template <>
+struct Interpolator<true> {
+	Interpolator(const double q, const idx_t n_p)
+	    : n(n_p), RN((double)(n_p - 1) * q), FRN(floor(RN)), CRN(FRN), begin(0), end(n_p) {
+	}
+
+	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
+	TARGET_TYPE Operation(INPUT_TYPE *v_t, Vector &result, const ACCESSOR &accessor = ACCESSOR()) const {
+		using ACCESS_TYPE = typename ACCESSOR::RESULT_TYPE;
+		QuantileLess<ACCESSOR> comp(accessor);
+		std::nth_element(v_t + begin, v_t + FRN, v_t + end, comp);
+		return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+	}
+
+	template <class INPUT_TYPE, class TARGET_TYPE, typename ACCESSOR = QuantileDirect<INPUT_TYPE>>
+	TARGET_TYPE Replace(const INPUT_TYPE *v_t, Vector &result, const ACCESSOR &accessor = ACCESSOR()) const {
+		using ACCESS_TYPE = typename ACCESSOR::RESULT_TYPE;
+		return CastInterpolation::Cast<ACCESS_TYPE, TARGET_TYPE>(accessor(v_t[FRN]), result);
+	}
+
+	const idx_t n;
+	const double RN;
+	const idx_t FRN;
+	const idx_t CRN;
+
+	idx_t begin;
+	idx_t end;
+};
+
+struct QuantileBindData : public FunctionData {
+	explicit QuantileBindData(double quantile_p) : quantiles(1, quantile_p), order(1, 0) {
+	}
+
+	explicit QuantileBindData(const vector<double> &quantiles_p) : quantiles(quantiles_p) {
+		for (idx_t i = 0; i < quantiles.size(); ++i) {
+			order.push_back(i);
+		}
+
+		IndirectLess<double> lt(quantiles.data());
+		std::sort(order.begin(), order.end(), lt);
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<QuantileBindData>(quantiles);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (QuantileBindData &)other_p;
+		return quantiles == other.quantiles && order == other.order;
+	}
+
+	vector<double> quantiles;
+	vector<idx_t> order;
+};
+
+struct QuantileOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		new (state) STATE;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, INPUT_TYPE *data, ValidityMask &mask, idx_t idx) {
+		state->v.emplace_back(data[idx]);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.v.empty()) {
+			return;
+		}
+		target->v.insert(target->v.end(), source.v.begin(), source.v.end());
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		state->~STATE();
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+template <class STATE_TYPE, class RESULT_TYPE, class OP>
+static void ExecuteListFinalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result,
+                                idx_t count, // NOLINT
+                                idx_t offset) {
+	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+	D_ASSERT(aggr_input_data.bind_data);
+	auto bind_data = (QuantileBindData *)aggr_input_data.bind_data;
+
+	if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ListVector::Reserve(result, bind_data->quantiles.size());
+
+		auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
+		auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
+		auto &mask = ConstantVector::Validity(result);
+		OP::template Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
+	} else {
+		D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		ListVector::Reserve(result, (offset + count) * bind_data->quantiles.size());
+
+		auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
+		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+		auto &mask = FlatVector::Validity(result);
+		for (idx_t i = 0; i < count; i++) {
+			OP::template Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
+		}
+	}
+
+	result.Verify(count);
+}
+
+template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>
+static AggregateFunction QuantileListAggregate(const LogicalType &input_type, const LogicalType &child_type) { // NOLINT
+	LogicalType result_type = LogicalType::LIST(child_type);
+	return AggregateFunction(
+	    {input_type}, result_type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
+	    AggregateFunction::UnaryScatterUpdate<STATE, INPUT_TYPE, OP>, AggregateFunction::StateCombine<STATE, OP>,
+	    ExecuteListFinalize<STATE, RESULT_TYPE, OP>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>, nullptr,
+	    AggregateFunction::StateDestroy<STATE, OP>);
+}
+
+template <bool DISCRETE>
+struct QuantileScalarOperation : public QuantileOperation {
+
+	template <class RESULT_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->v.empty()) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (QuantileBindData *)aggr_input_data.bind_data;
+		D_ASSERT(bind_data->quantiles.size() == 1);
+		Interpolator<DISCRETE> interp(bind_data->quantiles[0], state->v.size());
+		target[idx] = interp.template Operation<typename STATE::SaveType, RESULT_TYPE>(state->v.data(), result);
+	}
+
+	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
+	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
+	                   AggregateInputData &aggr_input_data, STATE *state, const FrameBounds &frame,
+	                   const FrameBounds &prev, Vector &result, idx_t ridx, idx_t bias) {
+		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+		auto &rmask = FlatVector::Validity(result);
+
+		QuantileIncluded included(fmask, dmask, bias);
+
+		//  Lazily initialise frame state
+		auto prev_pos = state->pos;
+		state->SetPos(frame.second - frame.first);
+
+		auto index = state->w.data();
+		D_ASSERT(index);
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (QuantileBindData *)aggr_input_data.bind_data;
+
+		// Find the two positions needed
+		const auto q = bind_data->quantiles[0];
+
+		bool replace = false;
+		if (frame.first == prev.first + 1 && frame.second == prev.second + 1) {
+			//  Fixed frame size
+			const auto j = ReplaceIndex(index, frame, prev);
+			//	We can only replace if the number of NULLs has not changed
+			if (included.AllValid() || included(prev.first) == included(prev.second)) {
+				Interpolator<DISCRETE> interp(q, prev_pos);
+				replace = CanReplace(index, data, j, interp.FRN, interp.CRN, included);
+				if (replace) {
+					state->pos = prev_pos;
+				}
+			}
+		} else {
+			ReuseIndexes(index, frame, prev);
+		}
+
+		if (!replace && !included.AllValid()) {
+			// Remove the NULLs
+			state->pos = std::partition(index, index + state->pos, included) - index;
+		}
+		if (state->pos) {
+			Interpolator<DISCRETE> interp(q, state->pos);
+
+			using ID = QuantileIndirect<INPUT_TYPE>;
+			ID indirect(data);
+			rdata[ridx] = replace ? interp.template Replace<idx_t, RESULT_TYPE, ID>(index, result, indirect)
+			                      : interp.template Operation<idx_t, RESULT_TYPE, ID>(index, result, indirect);
+		} else {
+			rmask.Set(ridx, false);
+		}
+	}
+};
+
+template <typename INPUT_TYPE, typename SAVED_TYPE>
+AggregateFunction GetTypedDiscreteQuantileAggregateFunction(const LogicalType &type) {
+	using STATE = QuantileState<SAVED_TYPE>;
+	using OP = QuantileScalarOperation<true>;
+	auto fun = AggregateFunction::UnaryAggregateDestructor<STATE, INPUT_TYPE, INPUT_TYPE, OP>(type, type);
+	fun.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, INPUT_TYPE, OP>;
+	return fun;
+}
+
+AggregateFunction GetDiscreteQuantileAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedDiscreteQuantileAggregateFunction<int8_t, int8_t>(type);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedDiscreteQuantileAggregateFunction<int16_t, int16_t>(type);
+	case LogicalTypeId::INTEGER:
+		return GetTypedDiscreteQuantileAggregateFunction<int32_t, int32_t>(type);
+	case LogicalTypeId::BIGINT:
+		return GetTypedDiscreteQuantileAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedDiscreteQuantileAggregateFunction<hugeint_t, hugeint_t>(type);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedDiscreteQuantileAggregateFunction<float, float>(type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedDiscreteQuantileAggregateFunction<double, double>(type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedDiscreteQuantileAggregateFunction<int16_t, int16_t>(type);
+		case PhysicalType::INT32:
+			return GetTypedDiscreteQuantileAggregateFunction<int32_t, int32_t>(type);
+		case PhysicalType::INT64:
+			return GetTypedDiscreteQuantileAggregateFunction<int64_t, int64_t>(type);
+		case PhysicalType::INT128:
+			return GetTypedDiscreteQuantileAggregateFunction<hugeint_t, hugeint_t>(type);
+		default:
+			throw NotImplementedException("Unimplemented discrete quantile aggregate");
+		}
+		break;
+
+	case LogicalTypeId::DATE:
+		return GetTypedDiscreteQuantileAggregateFunction<int32_t, int32_t>(type);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetTypedDiscreteQuantileAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return GetTypedDiscreteQuantileAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::INTERVAL:
+		return GetTypedDiscreteQuantileAggregateFunction<interval_t, interval_t>(type);
+
+	case LogicalTypeId::VARCHAR:
+		return GetTypedDiscreteQuantileAggregateFunction<string_t, std::string>(type);
+
+	default:
+		throw NotImplementedException("Unimplemented discrete quantile aggregate");
+	}
+}
+
+template <class CHILD_TYPE, bool DISCRETE>
+struct QuantileListOperation : public QuantileOperation {
+
+	template <class RESULT_TYPE, class STATE>
+	static void Finalize(Vector &result_list, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->v.empty()) {
+			mask.SetInvalid(idx);
+			return;
+		}
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (QuantileBindData *)aggr_input_data.bind_data;
+
+		auto &result = ListVector::GetEntry(result_list);
+		auto ridx = ListVector::GetListSize(result_list);
+		ListVector::Reserve(result_list, ridx + bind_data->quantiles.size());
+		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
+
+		auto v_t = state->v.data();
+		D_ASSERT(v_t);
+
+		auto &entry = target[idx];
+		entry.offset = ridx;
+		idx_t lower = 0;
+		for (const auto &q : bind_data->order) {
+			const auto &quantile = bind_data->quantiles[q];
+			Interpolator<DISCRETE> interp(quantile, state->v.size());
+			interp.begin = lower;
+			rdata[ridx + q] = interp.template Operation<typename STATE::SaveType, CHILD_TYPE>(v_t, result);
+			lower = interp.FRN;
+		}
+		entry.length = bind_data->quantiles.size();
+
+		ListVector::SetListSize(result_list, entry.offset + entry.length);
+	}
+
+	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
+	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
+	                   AggregateInputData &aggr_input_data, STATE *state, const FrameBounds &frame,
+	                   const FrameBounds &prev, Vector &list, idx_t lidx, idx_t bias) {
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (QuantileBindData *)aggr_input_data.bind_data;
+
+		QuantileIncluded included(fmask, dmask, bias);
+
+		// Result is a constant LIST<RESULT_TYPE> with a fixed length
+		auto ldata = FlatVector::GetData<RESULT_TYPE>(list);
+		auto &lmask = FlatVector::Validity(list);
+		auto &lentry = ldata[lidx];
+		lentry.offset = ListVector::GetListSize(list);
+		lentry.length = bind_data->quantiles.size();
+
+		ListVector::Reserve(list, lentry.offset + lentry.length);
+		ListVector::SetListSize(list, lentry.offset + lentry.length);
+		auto &result = ListVector::GetEntry(list);
+		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
+
+		//  Lazily initialise frame state
+		auto prev_pos = state->pos;
+		state->SetPos(frame.second - frame.first);
+
+		auto index = state->w.data();
+
+		// We can generalise replacement for quantile lists by observing that when a replacement is
+		// valid for a single quantile, it is valid for all quantiles greater/less than that quantile
+		// based on whether the insertion is below/above the quantile location.
+		// So if a replaced index in an IQR is located between Q25 and Q50, but has a value below Q25,
+		// then Q25 must be recomputed, but Q50 and Q75 are unaffected.
+		// For a single element list, this reduces to the scalar case.
+		std::pair<idx_t, idx_t> replaceable {state->pos, 0};
+		if (frame.first == prev.first + 1 && frame.second == prev.second + 1) {
+			//  Fixed frame size
+			const auto j = ReplaceIndex(index, frame, prev);
+			//	We can only replace if the number of NULLs has not changed
+			if (included.AllValid() || included(prev.first) == included(prev.second)) {
+				for (const auto &q : bind_data->order) {
+					const auto &quantile = bind_data->quantiles[q];
+					Interpolator<DISCRETE> interp(quantile, prev_pos);
+					const auto replace = CanReplace(index, data, j, interp.FRN, interp.CRN, included);
+					if (replace < 0) {
+						//	Replacement is before this quantile, so the rest will be replaceable too.
+						replaceable.first = MinValue(replaceable.first, interp.FRN);
+						replaceable.second = prev_pos;
+						break;
+					} else if (replace > 0) {
+						//	Replacement is after this quantile, so everything before it is replaceable too.
+						replaceable.first = 0;
+						replaceable.second = MaxValue(replaceable.second, interp.CRN);
+					}
+				}
+				if (replaceable.first < replaceable.second) {
+					state->pos = prev_pos;
+				}
+			}
+		} else {
+			ReuseIndexes(index, frame, prev);
+		}
+
+		if (replaceable.first >= replaceable.second && !included.AllValid()) {
+			// Remove the NULLs
+			state->pos = std::partition(index, index + state->pos, included) - index;
+		}
+
+		if (state->pos) {
+			using ID = QuantileIndirect<INPUT_TYPE>;
+			ID indirect(data);
+			for (const auto &q : bind_data->order) {
+				const auto &quantile = bind_data->quantiles[q];
+				Interpolator<DISCRETE> interp(quantile, state->pos);
+				if (replaceable.first <= interp.FRN && interp.CRN <= replaceable.second) {
+					rdata[lentry.offset + q] = interp.template Replace<idx_t, CHILD_TYPE, ID>(index, result, indirect);
+				} else {
+					// Make sure we don't disturb any replacements
+					if (replaceable.first < replaceable.second) {
+						if (interp.FRN < replaceable.first) {
+							interp.end = replaceable.first;
+						}
+						if (replaceable.second < interp.CRN) {
+							interp.begin = replaceable.second;
+						}
+					}
+					rdata[lentry.offset + q] =
+					    interp.template Operation<idx_t, CHILD_TYPE, ID>(index, result, indirect);
+				}
+			}
+		} else {
+			lmask.Set(lidx, false);
+		}
+	}
+};
+
+template <typename INPUT_TYPE, typename SAVE_TYPE>
+AggregateFunction GetTypedDiscreteQuantileListAggregateFunction(const LogicalType &type) {
+	using STATE = QuantileState<SAVE_TYPE>;
+	using OP = QuantileListOperation<INPUT_TYPE, true>;
+	auto fun = QuantileListAggregate<STATE, INPUT_TYPE, list_entry_t, OP>(type, type);
+	fun.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, list_entry_t, OP>;
+	return fun;
+}
+
+AggregateFunction GetDiscreteQuantileListAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedDiscreteQuantileListAggregateFunction<int8_t, int8_t>(type);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedDiscreteQuantileListAggregateFunction<int16_t, int16_t>(type);
+	case LogicalTypeId::INTEGER:
+		return GetTypedDiscreteQuantileListAggregateFunction<int32_t, int32_t>(type);
+	case LogicalTypeId::BIGINT:
+		return GetTypedDiscreteQuantileListAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedDiscreteQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedDiscreteQuantileListAggregateFunction<float, float>(type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedDiscreteQuantileListAggregateFunction<double, double>(type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedDiscreteQuantileListAggregateFunction<int16_t, int16_t>(type);
+		case PhysicalType::INT32:
+			return GetTypedDiscreteQuantileListAggregateFunction<int32_t, int32_t>(type);
+		case PhysicalType::INT64:
+			return GetTypedDiscreteQuantileListAggregateFunction<int64_t, int64_t>(type);
+		case PhysicalType::INT128:
+			return GetTypedDiscreteQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+		default:
+			throw NotImplementedException("Unimplemented discrete quantile list aggregate");
+		}
+		break;
+
+	case LogicalTypeId::DATE:
+		return GetTypedDiscreteQuantileListAggregateFunction<date_t, date_t>(type);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetTypedDiscreteQuantileListAggregateFunction<timestamp_t, timestamp_t>(type);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return GetTypedDiscreteQuantileListAggregateFunction<dtime_t, dtime_t>(type);
+	case LogicalTypeId::INTERVAL:
+		return GetTypedDiscreteQuantileListAggregateFunction<interval_t, interval_t>(type);
+
+	case LogicalTypeId::VARCHAR:
+		return GetTypedDiscreteQuantileListAggregateFunction<string_t, std::string>(type);
+
+	default:
+		throw NotImplementedException("Unimplemented discrete quantile list aggregate");
+	}
+}
+
+template <typename INPUT_TYPE, typename TARGET_TYPE>
+AggregateFunction GetTypedContinuousQuantileAggregateFunction(const LogicalType &input_type,
+                                                              const LogicalType &target_type) {
+	using STATE = QuantileState<INPUT_TYPE>;
+	using OP = QuantileScalarOperation<false>;
+	auto fun = AggregateFunction::UnaryAggregateDestructor<STATE, INPUT_TYPE, TARGET_TYPE, OP>(input_type, target_type);
+	fun.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, TARGET_TYPE, OP>;
+	return fun;
+}
+
+AggregateFunction GetContinuousQuantileAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedContinuousQuantileAggregateFunction<int8_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedContinuousQuantileAggregateFunction<int16_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::INTEGER:
+		return GetTypedContinuousQuantileAggregateFunction<int32_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::BIGINT:
+		return GetTypedContinuousQuantileAggregateFunction<int64_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedContinuousQuantileAggregateFunction<hugeint_t, double>(type, LogicalType::DOUBLE);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedContinuousQuantileAggregateFunction<float, float>(type, type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedContinuousQuantileAggregateFunction<double, double>(type, type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedContinuousQuantileAggregateFunction<int16_t, int16_t>(type, type);
+		case PhysicalType::INT32:
+			return GetTypedContinuousQuantileAggregateFunction<int32_t, int32_t>(type, type);
+		case PhysicalType::INT64:
+			return GetTypedContinuousQuantileAggregateFunction<int64_t, int64_t>(type, type);
+		case PhysicalType::INT128:
+			return GetTypedContinuousQuantileAggregateFunction<hugeint_t, hugeint_t>(type, type);
+		default:
+			throw NotImplementedException("Unimplemented continuous quantile DECIMAL aggregate");
+		}
+		break;
+
+	case LogicalTypeId::DATE:
+		return GetTypedContinuousQuantileAggregateFunction<date_t, timestamp_t>(type, LogicalType::TIMESTAMP);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetTypedContinuousQuantileAggregateFunction<timestamp_t, timestamp_t>(type, type);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return GetTypedContinuousQuantileAggregateFunction<dtime_t, dtime_t>(type, type);
+
+	default:
+		throw NotImplementedException("Unimplemented continuous quantile aggregate");
+	}
+}
+
+template <typename INPUT_TYPE, typename CHILD_TYPE>
+AggregateFunction GetTypedContinuousQuantileListAggregateFunction(const LogicalType &input_type,
+                                                                  const LogicalType &result_type) {
+	using STATE = QuantileState<INPUT_TYPE>;
+	using OP = QuantileListOperation<CHILD_TYPE, false>;
+	auto fun = QuantileListAggregate<STATE, INPUT_TYPE, list_entry_t, OP>(input_type, result_type);
+	fun.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, list_entry_t, OP>;
+	return fun;
+}
+
+AggregateFunction GetContinuousQuantileListAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedContinuousQuantileListAggregateFunction<int8_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedContinuousQuantileListAggregateFunction<int16_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::INTEGER:
+		return GetTypedContinuousQuantileListAggregateFunction<int32_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::BIGINT:
+		return GetTypedContinuousQuantileListAggregateFunction<int64_t, double>(type, LogicalType::DOUBLE);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedContinuousQuantileListAggregateFunction<hugeint_t, double>(type, LogicalType::DOUBLE);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedContinuousQuantileListAggregateFunction<float, float>(type, type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedContinuousQuantileListAggregateFunction<double, double>(type, type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedContinuousQuantileListAggregateFunction<int16_t, int16_t>(type, type);
+		case PhysicalType::INT32:
+			return GetTypedContinuousQuantileListAggregateFunction<int32_t, int32_t>(type, type);
+		case PhysicalType::INT64:
+			return GetTypedContinuousQuantileListAggregateFunction<int64_t, int64_t>(type, type);
+		case PhysicalType::INT128:
+			return GetTypedContinuousQuantileListAggregateFunction<hugeint_t, hugeint_t>(type, type);
+		default:
+			throw NotImplementedException("Unimplemented discrete quantile DECIMAL list aggregate");
+		}
+		break;
+
+	case LogicalTypeId::DATE:
+		return GetTypedContinuousQuantileListAggregateFunction<date_t, timestamp_t>(type, LogicalType::TIMESTAMP);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetTypedContinuousQuantileListAggregateFunction<timestamp_t, timestamp_t>(type, type);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return GetTypedContinuousQuantileListAggregateFunction<dtime_t, dtime_t>(type, type);
+
+	default:
+		throw NotImplementedException("Unimplemented discrete quantile list aggregate");
+	}
+}
+
+template <typename T, typename R, typename MEDIAN_TYPE>
+struct MadAccessor {
+	using INPUT_TYPE = T;
+	using RESULT_TYPE = R;
+	const MEDIAN_TYPE &median;
+	explicit MadAccessor(const MEDIAN_TYPE &median_p) : median(median_p) {
+	}
+
+	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
+		const auto delta = input - median;
+		return TryAbsOperator::Operation<RESULT_TYPE, RESULT_TYPE>(delta);
+	}
+};
+
+// hugeint_t - double => undefined
+template <>
+struct MadAccessor<hugeint_t, double, double> {
+	using INPUT_TYPE = hugeint_t;
+	using RESULT_TYPE = double;
+	using MEDIAN_TYPE = double;
+	const MEDIAN_TYPE &median;
+	explicit MadAccessor(const MEDIAN_TYPE &median_p) : median(median_p) {
+	}
+	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
+		const auto delta = Hugeint::Cast<double>(input) - median;
+		return TryAbsOperator::Operation<double, double>(delta);
+	}
+};
+
+// date_t - timestamp_t => interval_t
+template <>
+struct MadAccessor<date_t, interval_t, timestamp_t> {
+	using INPUT_TYPE = date_t;
+	using RESULT_TYPE = interval_t;
+	using MEDIAN_TYPE = timestamp_t;
+	const MEDIAN_TYPE &median;
+	explicit MadAccessor(const MEDIAN_TYPE &median_p) : median(median_p) {
+	}
+	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
+		const auto dt = Cast::Operation<date_t, timestamp_t>(input);
+		const auto delta = dt - median;
+		return Interval::FromMicro(TryAbsOperator::Operation<int64_t, int64_t>(delta));
+	}
+};
+
+// timestamp_t - timestamp_t => int64_t
+template <>
+struct MadAccessor<timestamp_t, interval_t, timestamp_t> {
+	using INPUT_TYPE = timestamp_t;
+	using RESULT_TYPE = interval_t;
+	using MEDIAN_TYPE = timestamp_t;
+	const MEDIAN_TYPE &median;
+	explicit MadAccessor(const MEDIAN_TYPE &median_p) : median(median_p) {
+	}
+	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
+		const auto delta = input - median;
+		return Interval::FromMicro(TryAbsOperator::Operation<int64_t, int64_t>(delta));
+	}
+};
+
+// dtime_t - dtime_t => int64_t
+template <>
+struct MadAccessor<dtime_t, interval_t, dtime_t> {
+	using INPUT_TYPE = dtime_t;
+	using RESULT_TYPE = interval_t;
+	using MEDIAN_TYPE = dtime_t;
+	const MEDIAN_TYPE &median;
+	explicit MadAccessor(const MEDIAN_TYPE &median_p) : median(median_p) {
+	}
+	inline RESULT_TYPE operator()(const INPUT_TYPE &input) const {
+		const auto delta = input - median;
+		return Interval::FromMicro(TryAbsOperator::Operation<int64_t, int64_t>(delta));
+	}
+};
+
+template <typename MEDIAN_TYPE>
+struct MedianAbsoluteDeviationOperation : public QuantileOperation {
+
+	template <class RESULT_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, RESULT_TYPE *target, ValidityMask &mask,
+	                     idx_t idx) {
+		if (state->v.empty()) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		using SAVE_TYPE = typename STATE::SaveType;
+		Interpolator<false> interp(0.5, state->v.size());
+		const auto med = interp.template Operation<SAVE_TYPE, MEDIAN_TYPE>(state->v.data(), result);
+
+		MadAccessor<SAVE_TYPE, RESULT_TYPE, MEDIAN_TYPE> accessor(med);
+		target[idx] = interp.template Operation<SAVE_TYPE, RESULT_TYPE>(state->v.data(), result, accessor);
+	}
+
+	template <class STATE, class INPUT_TYPE, class RESULT_TYPE>
+	static void Window(const INPUT_TYPE *data, const ValidityMask &fmask, const ValidityMask &dmask,
+	                   AggregateInputData &, STATE *state, const FrameBounds &frame, const FrameBounds &prev,
+	                   Vector &result, idx_t ridx, idx_t bias) {
+		auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+		auto &rmask = FlatVector::Validity(result);
+
+		QuantileIncluded included(fmask, dmask, bias);
+
+		//  Lazily initialise frame state
+		auto prev_pos = state->pos;
+		state->SetPos(frame.second - frame.first);
+
+		auto index = state->w.data();
+		D_ASSERT(index);
+
+		// We need a second index for the second pass.
+		if (state->pos > state->m.size()) {
+			state->m.resize(state->pos);
+		}
+
+		auto index2 = state->m.data();
+		D_ASSERT(index2);
+
+		// The replacement trick does not work on the second index because if
+		// the median has changed, the previous order is not correct.
+		// It is probably close, however, and so reuse is helpful.
+		ReuseIndexes(index2, frame, prev);
+		std::partition(index2, index2 + state->pos, included);
+
+		// Find the two positions needed for the median
+		const float q = 0.5;
+
+		bool replace = false;
+		if (frame.first == prev.first + 1 && frame.second == prev.second + 1) {
+			//  Fixed frame size
+			const auto j = ReplaceIndex(index, frame, prev);
+			//	We can only replace if the number of NULLs has not changed
+			if (included.AllValid() || included(prev.first) == included(prev.second)) {
+				Interpolator<false> interp(q, prev_pos);
+				replace = CanReplace(index, data, j, interp.FRN, interp.CRN, included);
+				if (replace) {
+					state->pos = prev_pos;
+				}
+			}
+		} else {
+			ReuseIndexes(index, frame, prev);
+		}
+
+		if (!replace && !included.AllValid()) {
+			// Remove the NULLs
+			state->pos = std::partition(index, index + state->pos, included) - index;
+		}
+
+		if (state->pos) {
+			Interpolator<false> interp(q, state->pos);
+
+			// Compute or replace median from the first index
+			using ID = QuantileIndirect<INPUT_TYPE>;
+			ID indirect(data);
+			const auto med = replace ? interp.template Replace<idx_t, MEDIAN_TYPE, ID>(index, result, indirect)
+			                         : interp.template Operation<idx_t, MEDIAN_TYPE, ID>(index, result, indirect);
+
+			// Compute mad from the second index
+			using MAD = MadAccessor<INPUT_TYPE, RESULT_TYPE, MEDIAN_TYPE>;
+			MAD mad(med);
+
+			using MadIndirect = QuantileComposed<MAD, ID>;
+			MadIndirect mad_indirect(mad, indirect);
+			rdata[ridx] = interp.template Operation<idx_t, RESULT_TYPE, MadIndirect>(index2, result, mad_indirect);
+		} else {
+			rmask.Set(ridx, false);
+		}
+	}
+};
+
+template <typename INPUT_TYPE, typename MEDIAN_TYPE, typename TARGET_TYPE>
+AggregateFunction GetTypedMedianAbsoluteDeviationAggregateFunction(const LogicalType &input_type,
+                                                                   const LogicalType &target_type) {
+	using STATE = QuantileState<INPUT_TYPE>;
+	using OP = MedianAbsoluteDeviationOperation<MEDIAN_TYPE>;
+	auto fun = AggregateFunction::UnaryAggregateDestructor<STATE, INPUT_TYPE, TARGET_TYPE, OP>(input_type, target_type);
+	fun.window = AggregateFunction::UnaryWindow<STATE, INPUT_TYPE, TARGET_TYPE, OP>;
+	return fun;
+}
+
+AggregateFunction GetMedianAbsoluteDeviationAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::FLOAT:
+		return GetTypedMedianAbsoluteDeviationAggregateFunction<float, float, float>(type, type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedMedianAbsoluteDeviationAggregateFunction<double, double, double>(type, type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedMedianAbsoluteDeviationAggregateFunction<int16_t, int16_t, int16_t>(type, type);
+		case PhysicalType::INT32:
+			return GetTypedMedianAbsoluteDeviationAggregateFunction<int32_t, int32_t, int32_t>(type, type);
+		case PhysicalType::INT64:
+			return GetTypedMedianAbsoluteDeviationAggregateFunction<int64_t, int64_t, int64_t>(type, type);
+		case PhysicalType::INT128:
+			return GetTypedMedianAbsoluteDeviationAggregateFunction<hugeint_t, hugeint_t, hugeint_t>(type, type);
+		default:
+			throw NotImplementedException("Unimplemented Median Absolute Deviation DECIMAL aggregate");
+		}
+		break;
+
+	case LogicalTypeId::DATE:
+		return GetTypedMedianAbsoluteDeviationAggregateFunction<date_t, timestamp_t, interval_t>(type,
+		                                                                                         LogicalType::INTERVAL);
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return GetTypedMedianAbsoluteDeviationAggregateFunction<timestamp_t, timestamp_t, interval_t>(
+		    type, LogicalType::INTERVAL);
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return GetTypedMedianAbsoluteDeviationAggregateFunction<dtime_t, dtime_t, interval_t>(type,
+		                                                                                      LogicalType::INTERVAL);
+
+	default:
+		throw NotImplementedException("Unimplemented Median Absolute Deviation aggregate");
+	}
+}
+
+unique_ptr<FunctionData> BindMedian(ClientContext &context, AggregateFunction &function,
+                                    vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<QuantileBindData>(0.5);
+}
+
+unique_ptr<FunctionData> BindMedianDecimal(ClientContext &context, AggregateFunction &function,
+                                           vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindMedian(context, function, arguments);
+
+	function = GetDiscreteQuantileAggregateFunction(arguments[0]->return_type);
+	function.name = "median";
+	return bind_data;
+}
+
+unique_ptr<FunctionData> BindMedianAbsoluteDeviationDecimal(ClientContext &context, AggregateFunction &function,
+                                                            vector<unique_ptr<Expression>> &arguments) {
+	function = GetMedianAbsoluteDeviationAggregateFunction(arguments[0]->return_type);
+	function.name = "mad";
+	return nullptr;
+}
+
+static double CheckQuantile(const Value &quantile_val) {
+	auto quantile = quantile_val.GetValue<double>();
+
+	if (quantile_val.IsNull() || quantile < 0 || quantile > 1) {
+		throw BinderException("QUANTILE can only take parameters in the range [0, 1]");
+	}
+
+	return quantile;
+}
+
+unique_ptr<FunctionData> BindQuantile(ClientContext &context, AggregateFunction &function,
+                                      vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[1]->IsFoldable()) {
+		throw BinderException("QUANTILE can only take constant parameters");
+	}
+	Value quantile_val = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+	vector<double> quantiles;
+	if (quantile_val.type().id() != LogicalTypeId::LIST) {
+		quantiles.push_back(CheckQuantile(quantile_val));
+	} else {
+		for (const auto &element_val : ListValue::GetChildren(quantile_val)) {
+			quantiles.push_back(CheckQuantile(element_val));
+		}
+	}
+
+	arguments.pop_back();
+	return make_unique<QuantileBindData>(quantiles);
+}
+
+unique_ptr<FunctionData> BindDiscreteQuantileDecimal(ClientContext &context, AggregateFunction &function,
+                                                     vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindQuantile(context, function, arguments);
+	function = GetDiscreteQuantileAggregateFunction(arguments[0]->return_type);
+	function.name = "quantile_disc";
+	return bind_data;
+}
+
+unique_ptr<FunctionData> BindDiscreteQuantileDecimalList(ClientContext &context, AggregateFunction &function,
+                                                         vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindQuantile(context, function, arguments);
+	function = GetDiscreteQuantileListAggregateFunction(arguments[0]->return_type);
+	function.name = "quantile_disc";
+	return bind_data;
+}
+
+unique_ptr<FunctionData> BindContinuousQuantileDecimal(ClientContext &context, AggregateFunction &function,
+                                                       vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindQuantile(context, function, arguments);
+	function = GetContinuousQuantileAggregateFunction(arguments[0]->return_type);
+	function.name = "quantile_cont";
+	return bind_data;
+}
+
+unique_ptr<FunctionData> BindContinuousQuantileDecimalList(ClientContext &context, AggregateFunction &function,
+                                                           vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindQuantile(context, function, arguments);
+	function = GetContinuousQuantileListAggregateFunction(arguments[0]->return_type);
+	function.name = "quantile_cont";
+	return bind_data;
+}
+
+static bool CanInterpolate(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::INTERVAL:
+	case LogicalTypeId::VARCHAR:
+		return false;
+	default:
+		return true;
+	}
+}
+
+AggregateFunction GetMedianAggregate(const LogicalType &type) {
+	auto fun = CanInterpolate(type) ? GetContinuousQuantileAggregateFunction(type)
+	                                : GetDiscreteQuantileAggregateFunction(type);
+	fun.bind = BindMedian;
+	return fun;
+}
+
+AggregateFunction GetDiscreteQuantileAggregate(const LogicalType &type) {
+	auto fun = GetDiscreteQuantileAggregateFunction(type);
+	fun.bind = BindQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	fun.arguments.emplace_back(LogicalType::DOUBLE);
+	return fun;
+}
+
+AggregateFunction GetDiscreteQuantileListAggregate(const LogicalType &type) {
+	auto fun = GetDiscreteQuantileListAggregateFunction(type);
+	fun.bind = BindQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	auto list_of_double = LogicalType::LIST(LogicalType::DOUBLE);
+	fun.arguments.push_back(list_of_double);
+	return fun;
+}
+
+AggregateFunction GetContinuousQuantileAggregate(const LogicalType &type) {
+	auto fun = GetContinuousQuantileAggregateFunction(type);
+	fun.bind = BindQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	fun.arguments.emplace_back(LogicalType::DOUBLE);
+	return fun;
+}
+
+AggregateFunction GetContinuousQuantileListAggregate(const LogicalType &type) {
+	auto fun = GetContinuousQuantileListAggregateFunction(type);
+	fun.bind = BindQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	auto list_of_double = LogicalType::LIST(LogicalType::DOUBLE);
+	fun.arguments.push_back(list_of_double);
+	return fun;
+}
+
+void QuantileFun::RegisterFunction(BuiltinFunctions &set) {
+	const vector<LogicalType> QUANTILES = {LogicalType::TINYINT,  LogicalType::SMALLINT,     LogicalType::INTEGER,
+	                                       LogicalType::BIGINT,   LogicalType::HUGEINT,      LogicalType::FLOAT,
+	                                       LogicalType::DOUBLE,   LogicalType::DATE,         LogicalType::TIMESTAMP,
+	                                       LogicalType::TIME,     LogicalType::TIMESTAMP_TZ, LogicalType::TIME_TZ,
+	                                       LogicalType::INTERVAL, LogicalType::VARCHAR};
+
+	AggregateFunctionSet median("median");
+	median.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
+	                                     nullptr, nullptr, nullptr, BindMedianDecimal));
+
+	AggregateFunctionSet quantile_disc("quantile_disc");
+	quantile_disc.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::DOUBLE}, LogicalTypeId::DECIMAL,
+	                                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+	                                            BindDiscreteQuantileDecimal));
+	quantile_disc.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::DOUBLE)},
+	                                            LogicalType::LIST(LogicalTypeId::DECIMAL), nullptr, nullptr, nullptr,
+	                                            nullptr, nullptr, nullptr, BindDiscreteQuantileDecimalList));
+
+	AggregateFunctionSet quantile_cont("quantile_cont");
+	quantile_cont.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::DOUBLE}, LogicalTypeId::DECIMAL,
+	                                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+	                                            BindContinuousQuantileDecimal));
+	quantile_cont.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::DOUBLE)},
+	                                            LogicalType::LIST(LogicalTypeId::DECIMAL), nullptr, nullptr, nullptr,
+	                                            nullptr, nullptr, nullptr, BindContinuousQuantileDecimalList));
+
+	for (const auto &type : QUANTILES) {
+		median.AddFunction(GetMedianAggregate(type));
+		quantile_disc.AddFunction(GetDiscreteQuantileAggregate(type));
+		quantile_disc.AddFunction(GetDiscreteQuantileListAggregate(type));
+		if (CanInterpolate(type)) {
+			quantile_cont.AddFunction(GetContinuousQuantileAggregate(type));
+			quantile_cont.AddFunction(GetContinuousQuantileListAggregate(type));
+		}
+	}
+
+	set.AddFunction(median);
+	set.AddFunction(quantile_disc);
+	set.AddFunction(quantile_cont);
+
+	quantile_disc.name = "quantile";
+	set.AddFunction(quantile_disc);
+
+	AggregateFunctionSet mad("mad");
+	mad.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL}, LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr,
+	                                  nullptr, nullptr, nullptr, BindMedianAbsoluteDeviationDecimal));
+
+	const vector<LogicalType> MADS = {LogicalType::FLOAT,     LogicalType::DOUBLE, LogicalType::DATE,
+	                                  LogicalType::TIMESTAMP, LogicalType::TIME,   LogicalType::TIMESTAMP_TZ,
+	                                  LogicalType::TIME_TZ};
+	for (const auto &type : MADS) {
+		mad.AddFunction(GetMedianAbsoluteDeviationAggregateFunction(type));
+	}
+	set.AddFunction(mad);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <algorithm>
+#include <stdlib.h>
+
+namespace duckdb {
+
+template <typename T>
+struct ReservoirQuantileState {
+	T *v;
+	idx_t len;
+	idx_t pos;
+	BaseReservoirSampling *r_samp;
+
+	void Resize(idx_t new_len) {
+		if (new_len <= len) {
+			return;
+		}
+		v = (T *)realloc(v, new_len * sizeof(T));
+		if (!v) {
+			throw InternalException("Memory allocation failure");
+		}
+		len = new_len;
+	}
+
+	void ReplaceElement(T &input) {
+		v[r_samp->min_entry] = input;
+		r_samp->ReplaceElement();
+	}
+
+	void FillReservoir(idx_t sample_size, T element) {
+		if (pos < sample_size) {
+			v[pos++] = element;
+			r_samp->InitializeReservoir(pos, len);
+		} else {
+			D_ASSERT(r_samp->next_index >= r_samp->current_count);
+			if (r_samp->next_index == r_samp->current_count) {
+				ReplaceElement(element);
+			}
+		}
+	}
+};
+
+struct ReservoirQuantileBindData : public FunctionData {
+	ReservoirQuantileBindData(double quantile_p, int32_t sample_size_p)
+	    : quantiles(1, quantile_p), sample_size(sample_size_p) {
+	}
+
+	ReservoirQuantileBindData(const vector<double> &quantiles_p, int32_t sample_size_p)
+	    : quantiles(quantiles_p), sample_size(sample_size_p) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<ReservoirQuantileBindData>(quantiles, sample_size);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (ReservoirQuantileBindData &)other_p;
+		return quantiles == other.quantiles && sample_size == other.sample_size;
+	}
+
+	vector<double> quantiles;
+	int32_t sample_size;
+};
+
+struct ReservoirQuantileOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->v = nullptr;
+		state->len = 0;
+		state->pos = 0;
+		state->r_samp = nullptr;
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void ConstantOperation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *input,
+	                              ValidityMask &mask, idx_t count) {
+		for (idx_t i = 0; i < count; i++) {
+			Operation<INPUT_TYPE, STATE, OP>(state, aggr_input_data, input, mask, 0);
+		}
+	}
+
+	template <class INPUT_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, INPUT_TYPE *data, ValidityMask &mask,
+	                      idx_t idx) {
+		auto bind_data = (ReservoirQuantileBindData *)aggr_input_data.bind_data;
+		D_ASSERT(bind_data);
+		if (state->pos == 0) {
+			state->Resize(bind_data->sample_size);
+		}
+		if (!state->r_samp) {
+			state->r_samp = new BaseReservoirSampling();
+		}
+		D_ASSERT(state->v);
+		state->FillReservoir(bind_data->sample_size, data[idx]);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.pos == 0) {
+			return;
+		}
+		if (target->pos == 0) {
+			target->Resize(source.len);
+		}
+		if (!target->r_samp) {
+			target->r_samp = new BaseReservoirSampling();
+		}
+		for (idx_t src_idx = 0; src_idx < source.pos; src_idx++) {
+			target->FillReservoir(target->len, source.v[src_idx]);
+		}
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->v) {
+			free(state->v);
+			state->v = nullptr;
+		}
+		if (state->r_samp) {
+			delete state->r_samp;
+			state->r_samp = nullptr;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+struct ReservoirQuantileScalarOperation : public ReservoirQuantileOperation {
+	template <class TARGET_TYPE, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, TARGET_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->pos == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		D_ASSERT(state->v);
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (ReservoirQuantileBindData *)aggr_input_data.bind_data;
+		auto v_t = state->v;
+		D_ASSERT(bind_data->quantiles.size() == 1);
+		auto offset = (idx_t)((double)(state->pos - 1) * bind_data->quantiles[0]);
+		std::nth_element(v_t, v_t + offset, v_t + state->pos);
+		target[idx] = v_t[offset];
+	}
+};
+
+AggregateFunction GetReservoirQuantileAggregateFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::INT8:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<int8_t>, int8_t, int8_t,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::TINYINT,
+		                                                                                     LogicalType::TINYINT);
+
+	case PhysicalType::INT16:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<int16_t>, int16_t, int16_t,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::SMALLINT,
+		                                                                                     LogicalType::SMALLINT);
+
+	case PhysicalType::INT32:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<int32_t>, int32_t, int32_t,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::INTEGER,
+		                                                                                     LogicalType::INTEGER);
+
+	case PhysicalType::INT64:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<int64_t>, int64_t, int64_t,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::BIGINT,
+		                                                                                     LogicalType::BIGINT);
+
+	case PhysicalType::INT128:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<hugeint_t>, hugeint_t, hugeint_t,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::HUGEINT,
+		                                                                                     LogicalType::HUGEINT);
+	case PhysicalType::FLOAT:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<float>, float, float,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::FLOAT,
+		                                                                                     LogicalType::FLOAT);
+	case PhysicalType::DOUBLE:
+		return AggregateFunction::UnaryAggregateDestructor<ReservoirQuantileState<double>, double, double,
+		                                                   ReservoirQuantileScalarOperation>(LogicalType::DOUBLE,
+		                                                                                     LogicalType::DOUBLE);
+	default:
+		throw InternalException("Unimplemented reservoir quantile aggregate");
+	}
+}
+
+template <class CHILD_TYPE>
+struct ReservoirQuantileListOperation : public ReservoirQuantileOperation {
+
+	template <class RESULT_TYPE, class STATE>
+	static void Finalize(Vector &result_list, AggregateInputData &aggr_input_data, STATE *state, RESULT_TYPE *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->pos == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (ReservoirQuantileBindData *)aggr_input_data.bind_data;
+
+		auto &result = ListVector::GetEntry(result_list);
+		auto ridx = ListVector::GetListSize(result_list);
+		ListVector::Reserve(result_list, ridx + bind_data->quantiles.size());
+		auto rdata = FlatVector::GetData<CHILD_TYPE>(result);
+
+		auto v_t = state->v;
+		D_ASSERT(v_t);
+
+		auto &entry = target[idx];
+		entry.offset = ridx;
+		entry.length = bind_data->quantiles.size();
+		for (size_t q = 0; q < entry.length; ++q) {
+			const auto &quantile = bind_data->quantiles[q];
+			auto offset = (idx_t)((double)(state->pos - 1) * quantile);
+			std::nth_element(v_t, v_t + offset, v_t + state->pos);
+			rdata[ridx + q] = v_t[offset];
+		}
+
+		ListVector::SetListSize(result_list, entry.offset + entry.length);
+	}
+
+	template <class STATE_TYPE, class RESULT_TYPE>
+	static void FinalizeList(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count, // NOLINT
+	                         idx_t offset) {
+		D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+		D_ASSERT(aggr_input_data.bind_data);
+		auto bind_data = (ReservoirQuantileBindData *)aggr_input_data.bind_data;
+
+		if (states.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ListVector::Reserve(result, bind_data->quantiles.size());
+
+			auto sdata = ConstantVector::GetData<STATE_TYPE *>(states);
+			auto rdata = ConstantVector::GetData<RESULT_TYPE>(result);
+			auto &mask = ConstantVector::Validity(result);
+			Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[0], rdata, mask, 0);
+		} else {
+			D_ASSERT(states.GetVectorType() == VectorType::FLAT_VECTOR);
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			ListVector::Reserve(result, (offset + count) * bind_data->quantiles.size());
+
+			auto sdata = FlatVector::GetData<STATE_TYPE *>(states);
+			auto rdata = FlatVector::GetData<RESULT_TYPE>(result);
+			auto &mask = FlatVector::Validity(result);
+			for (idx_t i = 0; i < count; i++) {
+				Finalize<RESULT_TYPE, STATE_TYPE>(result, aggr_input_data, sdata[i], rdata, mask, i + offset);
+			}
+		}
+
+		result.Verify(count);
+	}
+};
+
+template <class STATE, class INPUT_TYPE, class RESULT_TYPE, class OP>
+static AggregateFunction ReservoirQuantileListAggregate(const LogicalType &input_type, const LogicalType &child_type) {
+	LogicalType result_type = LogicalType::LIST(child_type);
+	return AggregateFunction(
+	    {input_type}, result_type, AggregateFunction::StateSize<STATE>, AggregateFunction::StateInitialize<STATE, OP>,
+	    AggregateFunction::UnaryScatterUpdate<STATE, INPUT_TYPE, OP>, AggregateFunction::StateCombine<STATE, OP>,
+	    OP::template FinalizeList<STATE, RESULT_TYPE>, AggregateFunction::UnaryUpdate<STATE, INPUT_TYPE, OP>, nullptr,
+	    AggregateFunction::StateDestroy<STATE, OP>);
+}
+
+template <typename INPUT_TYPE, typename SAVE_TYPE>
+AggregateFunction GetTypedReservoirQuantileListAggregateFunction(const LogicalType &type) {
+	using STATE = ReservoirQuantileState<SAVE_TYPE>;
+	using OP = ReservoirQuantileListOperation<INPUT_TYPE>;
+	auto fun = ReservoirQuantileListAggregate<STATE, INPUT_TYPE, list_entry_t, OP>(type, type);
+	return fun;
+}
+
+AggregateFunction GetReservoirQuantileListAggregateFunction(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return GetTypedReservoirQuantileListAggregateFunction<int8_t, int8_t>(type);
+	case LogicalTypeId::SMALLINT:
+		return GetTypedReservoirQuantileListAggregateFunction<int16_t, int16_t>(type);
+	case LogicalTypeId::INTEGER:
+		return GetTypedReservoirQuantileListAggregateFunction<int32_t, int32_t>(type);
+	case LogicalTypeId::BIGINT:
+		return GetTypedReservoirQuantileListAggregateFunction<int64_t, int64_t>(type);
+	case LogicalTypeId::HUGEINT:
+		return GetTypedReservoirQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+
+	case LogicalTypeId::FLOAT:
+		return GetTypedReservoirQuantileListAggregateFunction<float, float>(type);
+	case LogicalTypeId::DOUBLE:
+		return GetTypedReservoirQuantileListAggregateFunction<double, double>(type);
+	case LogicalTypeId::DECIMAL:
+		switch (type.InternalType()) {
+		case PhysicalType::INT16:
+			return GetTypedReservoirQuantileListAggregateFunction<int16_t, int16_t>(type);
+		case PhysicalType::INT32:
+			return GetTypedReservoirQuantileListAggregateFunction<int32_t, int32_t>(type);
+		case PhysicalType::INT64:
+			return GetTypedReservoirQuantileListAggregateFunction<int64_t, int64_t>(type);
+		case PhysicalType::INT128:
+			return GetTypedReservoirQuantileListAggregateFunction<hugeint_t, hugeint_t>(type);
+		default:
+			throw NotImplementedException("Unimplemented reservoir quantile list aggregate");
+		}
+		break;
+
+	default:
+		// TODO: Add quantitative temporal types
+		throw NotImplementedException("Unimplemented reservoir quantile list aggregate");
+	}
+}
+
+static double CheckReservoirQuantile(const Value &quantile_val) {
+	auto quantile = quantile_val.GetValue<double>();
+
+	if (quantile_val.IsNull() || quantile < 0 || quantile > 1) {
+		throw BinderException("RESERVOIR_QUANTILE can only take parameters in the range [0, 1]");
+	}
+
+	return quantile;
+}
+
+unique_ptr<FunctionData> BindReservoirQuantile(ClientContext &context, AggregateFunction &function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[1]->IsFoldable()) {
+		throw BinderException("RESERVOIR_QUANTILE can only take constant quantile parameters");
+	}
+	Value quantile_val = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+	vector<double> quantiles;
+	if (quantile_val.type().id() != LogicalTypeId::LIST) {
+		quantiles.push_back(CheckReservoirQuantile(quantile_val));
+	} else {
+		for (const auto &element_val : ListValue::GetChildren(quantile_val)) {
+			quantiles.push_back(CheckReservoirQuantile(element_val));
+		}
+	}
+
+	if (arguments.size() <= 2) {
+		arguments.pop_back();
+		return make_unique<ReservoirQuantileBindData>(quantiles, 8192);
+	}
+	if (!arguments[2]->IsFoldable()) {
+		throw BinderException("RESERVOIR_QUANTILE can only take constant sample size parameters");
+	}
+	Value sample_size_val = ExpressionExecutor::EvaluateScalar(*arguments[2]);
+	auto sample_size = sample_size_val.GetValue<int32_t>();
+
+	if (sample_size_val.IsNull() || sample_size <= 0) {
+		throw BinderException("Size of the RESERVOIR_QUANTILE sample must be bigger than 0");
+	}
+
+	// remove the quantile argument so we can use the unary aggregate
+	arguments.pop_back();
+	arguments.pop_back();
+	return make_unique<ReservoirQuantileBindData>(quantiles, sample_size);
+}
+
+unique_ptr<FunctionData> BindReservoirQuantileDecimal(ClientContext &context, AggregateFunction &function,
+                                                      vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindReservoirQuantile(context, function, arguments);
+	function = GetReservoirQuantileAggregateFunction(arguments[0]->return_type.InternalType());
+	function.name = "reservoir_quantile";
+	return bind_data;
+}
+
+AggregateFunction GetReservoirQuantileAggregate(PhysicalType type) {
+	auto fun = GetReservoirQuantileAggregateFunction(type);
+	fun.bind = BindReservoirQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	fun.arguments.emplace_back(LogicalType::DOUBLE);
+	return fun;
+}
+
+unique_ptr<FunctionData> BindReservoirQuantileDecimalList(ClientContext &context, AggregateFunction &function,
+                                                          vector<unique_ptr<Expression>> &arguments) {
+	auto bind_data = BindReservoirQuantile(context, function, arguments);
+	function = GetReservoirQuantileListAggregateFunction(arguments[0]->return_type);
+	function.name = "reservoir_quantile";
+	return bind_data;
+}
+
+AggregateFunction GetReservoirQuantileListAggregate(const LogicalType &type) {
+	auto fun = GetReservoirQuantileListAggregateFunction(type);
+	fun.bind = BindReservoirQuantile;
+	// temporarily push an argument so we can bind the actual quantile
+	auto list_of_double = LogicalType::LIST(LogicalType::DOUBLE);
+	fun.arguments.push_back(list_of_double);
+	return fun;
+}
+
+static void DefineReservoirQuantile(AggregateFunctionSet &set, const LogicalType &type) {
+	//	Four versions: type, scalar/list[, count]
+	auto fun = GetReservoirQuantileAggregate(type.InternalType());
+	fun.bind = BindReservoirQuantile;
+	set.AddFunction(fun);
+
+	fun.arguments.emplace_back(LogicalType::INTEGER);
+	set.AddFunction(fun);
+
+	// List variants
+	fun = GetReservoirQuantileListAggregate(type);
+	set.AddFunction(fun);
+
+	fun.arguments.emplace_back(LogicalType::INTEGER);
+	set.AddFunction(fun);
+}
+
+void ReservoirQuantileFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet reservoir_quantile("reservoir_quantile");
+
+	// DECIMAL
+	reservoir_quantile.AddFunction(
+	    AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::DOUBLE, LogicalType::INTEGER}, LogicalTypeId::DECIMAL,
+	                      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, BindReservoirQuantileDecimal));
+	reservoir_quantile.AddFunction(AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::DOUBLE},
+	                                                 LogicalTypeId::DECIMAL, nullptr, nullptr, nullptr, nullptr,
+	                                                 nullptr, nullptr, BindReservoirQuantileDecimal));
+	reservoir_quantile.AddFunction(
+	    AggregateFunction({LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::INTEGER},
+	                      LogicalType::LIST(LogicalTypeId::DECIMAL), nullptr, nullptr, nullptr, nullptr, nullptr,
+	                      nullptr, BindReservoirQuantileDecimalList));
+
+	reservoir_quantile.AddFunction(AggregateFunction(
+	    {LogicalTypeId::DECIMAL, LogicalType::LIST(LogicalType::DOUBLE)}, LogicalType::LIST(LogicalTypeId::DECIMAL),
+	    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, BindReservoirQuantileDecimalList));
+
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::TINYINT);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::SMALLINT);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::INTEGER);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::BIGINT);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::HUGEINT);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::FLOAT);
+	DefineReservoirQuantile(reservoir_quantile, LogicalTypeId::DOUBLE);
+
+	set.AddFunction(reservoir_quantile);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterHolisticAggregates() {
+	Register<QuantileFun>();
+	Register<ModeFun>();
+	Register<ApproximateQuantileFun>();
+	Register<ReservoirQuantileFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct HistogramFunctor {
+	template <class T, class MAP_TYPE = map<T, idx_t>>
+	static void HistogramUpdate(VectorData &sdata, VectorData &input_data, idx_t count) {
+
+		auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			if (input_data.validity.RowIsValid(input_data.sel->get_index(i))) {
+				auto state = states[sdata.sel->get_index(i)];
+				if (!state->hist) {
+					state->hist = new MAP_TYPE();
+				}
+				auto value = (T *)input_data.data;
+				(*state->hist)[value[input_data.sel->get_index(i)]]++;
+			}
+		}
+	}
+
+	template <class T>
+	static Value HistogramFinalize(T first) {
+		return Value::CreateValue(first);
+	}
+};
+
+struct HistogramStringFunctor {
+	template <class T, class MAP_TYPE = map<T, idx_t>>
+	static void HistogramUpdate(VectorData &sdata, VectorData &input_data, idx_t count) {
+
+		auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			if (input_data.validity.RowIsValid(input_data.sel->get_index(i))) {
+				auto state = states[sdata.sel->get_index(i)];
+				if (!state->hist) {
+					state->hist = new MAP_TYPE();
+				}
+				auto value = (string_t *)input_data.data;
+				(*state->hist)[value[input_data.sel->get_index(i)].GetString()]++;
+			}
+		}
+	}
+
+	template <class T>
+	static Value HistogramFinalize(T first) {
+		string_t value = first;
+		return Value::CreateValue(value);
+	}
+};
+
+struct HistogramFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->hist = nullptr;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->hist) {
+			delete state->hist;
+		}
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+template <class OP, class T, class MAP_TYPE>
+static void HistogramUpdateFunction(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector,
+                                    idx_t count) {
+
+	D_ASSERT(input_count == 1);
+
+	auto &input = inputs[0];
+	VectorData sdata;
+	state_vector.Orrify(count, sdata);
+	VectorData input_data;
+	input.Orrify(count, input_data);
+
+	OP::template HistogramUpdate<T, MAP_TYPE>(sdata, input_data, count);
+}
+
+template <class T, class MAP_TYPE>
+static void HistogramCombineFunction(Vector &state, Vector &combined, AggregateInputData &, idx_t count) {
+
+	VectorData sdata;
+	state.Orrify(count, sdata);
+	auto states_ptr = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+
+	auto combined_ptr = FlatVector::GetData<HistogramAggState<T, MAP_TYPE> *>(combined);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto state = states_ptr[sdata.sel->get_index(i)];
+		if (!state->hist) {
+			continue;
+		}
+		if (!combined_ptr[i]->hist) {
+			combined_ptr[i]->hist = new MAP_TYPE();
+		}
+		D_ASSERT(combined_ptr[i]->hist);
+		D_ASSERT(state->hist);
+		for (auto &entry : *state->hist) {
+			(*combined_ptr[i]->hist)[entry.first] += entry.second;
+		}
+	}
+}
+
+template <class OP, class T, class MAP_TYPE>
+static void HistogramFinalizeFunction(Vector &state_vector, AggregateInputData &, Vector &result, idx_t count,
+                                      idx_t offset) {
+
+	VectorData sdata;
+	state_vector.Orrify(count, sdata);
+	auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+
+	auto &mask = FlatVector::Validity(result);
+
+	auto &child_entries = StructVector::GetEntries(result);
+	auto &bucket_list = child_entries[0];
+	auto &count_list = child_entries[1];
+
+	auto old_len = ListVector::GetListSize(*bucket_list);
+
+	auto &bucket_validity = FlatVector::Validity(*bucket_list);
+	auto &count_validity = FlatVector::Validity(*count_list);
+
+	for (idx_t i = 0; i < count; i++) {
+
+		const auto rid = i + offset;
+		auto state = states[sdata.sel->get_index(i)];
+		if (!state->hist) {
+			mask.SetInvalid(rid);
+			bucket_validity.SetInvalid(rid);
+			count_validity.SetInvalid(rid);
+			continue;
+		}
+
+		for (auto &entry : *state->hist) {
+			Value bucket_value = OP::template HistogramFinalize<T>(entry.first);
+			ListVector::PushBack(*bucket_list, bucket_value);
+			auto count_value = Value::CreateValue(entry.second);
+			ListVector::PushBack(*count_list, count_value);
+		}
+
+		auto list_struct_data = FlatVector::GetData<list_entry_t>(*bucket_list);
+		list_struct_data[rid].length = ListVector::GetListSize(*bucket_list) - old_len;
+		list_struct_data[rid].offset = old_len;
+
+		list_struct_data = FlatVector::GetData<list_entry_t>(*count_list);
+		list_struct_data[rid].length = ListVector::GetListSize(*count_list) - old_len;
+		list_struct_data[rid].offset = old_len;
+		old_len += list_struct_data[rid].length;
+	}
+}
+
+unique_ptr<FunctionData> HistogramBindFunction(ClientContext &context, AggregateFunction &function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+
+	D_ASSERT(arguments.size() == 1);
+	child_list_t<LogicalType> struct_children;
+	struct_children.push_back({"bucket", LogicalType::LIST(arguments[0]->return_type)});
+	struct_children.push_back({"count", LogicalType::LIST(LogicalType::UBIGINT)});
+	auto struct_type = LogicalType::MAP(move(struct_children));
+
+	function.return_type = struct_type;
+	return make_unique<VariableReturnBindData>(function.return_type);
+}
+
+template <class OP, class T, class MAP_TYPE = map<T, idx_t>>
+static AggregateFunction GetHistogramFunction(const LogicalType &type) {
+
+	using STATE_TYPE = HistogramAggState<T, MAP_TYPE>;
+
+	return AggregateFunction("histogram", {type}, LogicalTypeId::MAP, AggregateFunction::StateSize<STATE_TYPE>,
+	                         AggregateFunction::StateInitialize<STATE_TYPE, HistogramFunction>,
+	                         HistogramUpdateFunction<OP, T, MAP_TYPE>, HistogramCombineFunction<T, MAP_TYPE>,
+	                         HistogramFinalizeFunction<OP, T, MAP_TYPE>, nullptr, HistogramBindFunction,
+	                         AggregateFunction::StateDestroy<STATE_TYPE, HistogramFunction>);
+}
+
+template <class OP, class T, bool IS_ORDERED>
+AggregateFunction GetMapType(const LogicalType &type) {
+
+	if (IS_ORDERED) {
+		return GetHistogramFunction<OP, T>(type);
+	}
+	return GetHistogramFunction<OP, T, unordered_map<T, idx_t>>(type);
+}
+
+template <bool IS_ORDERED = true>
+AggregateFunction GetHistogramFunction(const LogicalType &type) {
+
+	switch (type.id()) {
+	case LogicalType::BOOLEAN:
+		return GetMapType<HistogramFunctor, bool, IS_ORDERED>(type);
+	case LogicalType::UTINYINT:
+		return GetMapType<HistogramFunctor, uint8_t, IS_ORDERED>(type);
+	case LogicalType::USMALLINT:
+		return GetMapType<HistogramFunctor, uint16_t, IS_ORDERED>(type);
+	case LogicalType::UINTEGER:
+		return GetMapType<HistogramFunctor, uint32_t, IS_ORDERED>(type);
+	case LogicalType::UBIGINT:
+		return GetMapType<HistogramFunctor, uint64_t, IS_ORDERED>(type);
+	case LogicalType::TINYINT:
+		return GetMapType<HistogramFunctor, int8_t, IS_ORDERED>(type);
+	case LogicalType::SMALLINT:
+		return GetMapType<HistogramFunctor, int16_t, IS_ORDERED>(type);
+	case LogicalType::INTEGER:
+		return GetMapType<HistogramFunctor, int32_t, IS_ORDERED>(type);
+	case LogicalType::BIGINT:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::FLOAT:
+		return GetMapType<HistogramFunctor, float, IS_ORDERED>(type);
+	case LogicalType::DOUBLE:
+		return GetMapType<HistogramFunctor, double, IS_ORDERED>(type);
+	case LogicalType::VARCHAR:
+		return GetMapType<HistogramStringFunctor, string, IS_ORDERED>(type);
+	case LogicalType::TIMESTAMP:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIMESTAMP_TZ:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIMESTAMP_S:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIMESTAMP_MS:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIMESTAMP_NS:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIME:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::TIME_TZ:
+		return GetMapType<HistogramFunctor, int64_t, IS_ORDERED>(type);
+	case LogicalType::DATE:
+		return GetMapType<HistogramFunctor, int32_t, IS_ORDERED>(type);
+	default:
+		throw InternalException("Unimplemented histogram aggregate");
+	}
+}
+
+void HistogramFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("histogram");
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::BOOLEAN));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::UTINYINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::USMALLINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::UINTEGER));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::UBIGINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TINYINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::SMALLINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::INTEGER));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::BIGINT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::FLOAT));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::DOUBLE));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::VARCHAR));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIMESTAMP));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIMESTAMP_TZ));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIMESTAMP_S));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIMESTAMP_MS));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIMESTAMP_NS));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIME));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::TIME_TZ));
+	fun.AddFunction(GetHistogramFunction<>(LogicalType::DATE));
+	set.AddFunction(fun);
+}
+
+AggregateFunction HistogramFun::GetHistogramUnorderedMap(LogicalType &type) {
+	const auto &const_type = type;
+	return GetHistogramFunction<false>(const_type);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct ListAggState {
+	Vector *list_vector;
+};
+
+struct ListFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->list_vector = nullptr;
+	}
+
+	template <class STATE>
+	static void Destroy(STATE *state) {
+		if (state->list_vector) {
+			delete state->list_vector;
+		}
+	}
+	static bool IgnoreNull() {
+		return false;
+	}
+};
+
+static void ListUpdateFunction(Vector inputs[], AggregateInputData &, idx_t input_count, Vector &state_vector,
+                               idx_t count) {
+	D_ASSERT(input_count == 1);
+
+	auto &input = inputs[0];
+	VectorData sdata;
+	state_vector.Orrify(count, sdata);
+
+	auto list_vector_type = LogicalType::LIST(input.GetType());
+
+	auto states = (ListAggState **)sdata.data;
+	if (input.GetVectorType() == VectorType::SEQUENCE_VECTOR) {
+		input.Normalify(count);
+	}
+	for (idx_t i = 0; i < count; i++) {
+		auto state = states[sdata.sel->get_index(i)];
+		if (!state->list_vector) {
+			// NOTE: any number bigger than 1 can cause DuckDB to run out of memory for specific queries
+			// consisting of millions of groups in the group by and complex (nested) vectors
+			state->list_vector = new Vector(list_vector_type, 1);
+		}
+		ListVector::Append(*state->list_vector, input, i + 1, i);
+	}
+}
+
+static void ListCombineFunction(Vector &state, Vector &combined, AggregateInputData &, idx_t count) {
+	VectorData sdata;
+	state.Orrify(count, sdata);
+	auto states_ptr = (ListAggState **)sdata.data;
+
+	auto combined_ptr = FlatVector::GetData<ListAggState *>(combined);
+	for (idx_t i = 0; i < count; i++) {
+		auto state = states_ptr[sdata.sel->get_index(i)];
+		if (!state->list_vector) {
+			// NULL, no need to append.
+			continue;
+		}
+		if (!combined_ptr[i]->list_vector) {
+			// NOTE: initializing this with a capacity of ListVector::GetListSize(*state->list_vector) causes
+			// DuckDB to run out of memory for multiple threads with millions of groups in the group by and complex
+			// (nested) vectors
+			combined_ptr[i]->list_vector = new Vector(state->list_vector->GetType(), 1);
+		}
+		ListVector::Append(*combined_ptr[i]->list_vector, ListVector::GetEntry(*state->list_vector),
+		                   ListVector::GetListSize(*state->list_vector));
+	}
+}
+
+static void ListFinalize(Vector &state_vector, AggregateInputData &, Vector &result, idx_t count, idx_t offset) {
+	VectorData sdata;
+	state_vector.Orrify(count, sdata);
+	auto states = (ListAggState **)sdata.data;
+
+	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+	auto &mask = FlatVector::Validity(result);
+	auto list_struct_data = FlatVector::GetData<list_entry_t>(result);
+	size_t total_len = ListVector::GetListSize(result);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto state = states[sdata.sel->get_index(i)];
+		const auto rid = i + offset;
+		if (!state->list_vector) {
+			mask.SetInvalid(rid);
+			continue;
+		}
+
+		auto &state_lv = *state->list_vector;
+		auto state_lv_count = ListVector::GetListSize(state_lv);
+		list_struct_data[rid].length = state_lv_count;
+		list_struct_data[rid].offset = total_len;
+		total_len += state_lv_count;
+
+		auto &list_vec_to_append = ListVector::GetEntry(state_lv);
+		ListVector::Append(result, list_vec_to_append, state_lv_count);
+	}
+}
+
+unique_ptr<FunctionData> ListBindFunction(ClientContext &context, AggregateFunction &function,
+                                          vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(arguments.size() == 1);
+	function.return_type = LogicalType::LIST(arguments[0]->return_type);
+	return nullptr;
+}
+
+void ListFun::RegisterFunction(BuiltinFunctions &set) {
+	auto agg =
+	    AggregateFunction("list", {LogicalType::ANY}, LogicalTypeId::LIST, AggregateFunction::StateSize<ListAggState>,
+	                      AggregateFunction::StateInitialize<ListAggState, ListFunction>, ListUpdateFunction,
+	                      ListCombineFunction, ListFinalize, nullptr, ListBindFunction,
+	                      AggregateFunction::StateDestroy<ListAggState, ListFunction>, nullptr, nullptr);
+	set.AddFunction(agg);
+	agg.name = "array_agg";
+	set.AddFunction(agg);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterNestedAggregates() {
+	Register<ListFun>();
+	Register<HistogramFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+struct RegrState {
+	double sum;
+	size_t count;
+};
+
+struct RegrAvgFunction {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->sum = 0;
+		state->count = 0;
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		target->sum += source.sum;
+		target->count += source.count;
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &, STATE *state, T *target, ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+		} else {
+			target[idx] = state->sum / (double)state->count;
+		}
+	}
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+struct RegrAvgXFunction : RegrAvgFunction {
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, A_TYPE *x_data, B_TYPE *y_data, ValidityMask &amask,
+	                      ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		state->sum += y_data[yidx];
+		state->count++;
+	}
+};
+
+struct RegrAvgYFunction : RegrAvgFunction {
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &, A_TYPE *x_data, B_TYPE *y_data, ValidityMask &amask,
+	                      ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		state->sum += x_data[xidx];
+		state->count++;
+	}
+};
+
+void RegrAvgxFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet corr("regr_avgx");
+	corr.AddFunction(AggregateFunction::BinaryAggregate<RegrState, double, double, double, RegrAvgXFunction>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(corr);
+}
+
+void RegrAvgyFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet corr("regr_avgy");
+	corr.AddFunction(AggregateFunction::BinaryAggregate<RegrState, double, double, double, RegrAvgYFunction>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(corr);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+void RegrCountFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet corr("regr_count");
+	corr.AddFunction(AggregateFunction::BinaryAggregate<size_t, double, double, uint32_t, RegrCountFunction>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::UINTEGER));
+	set.AddFunction(corr);
+}
+
+} // namespace duckdb
+//! AVG(y)-REGR_SLOPE(y,x)*AVG(x)
+
+
+
+
+
+namespace duckdb {
+
+struct RegrInterceptState {
+	size_t count;
+	double sum_x;
+	double sum_y;
+	RegrSlopeState slope;
+};
+
+struct RegrInterceptOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		state->count = 0;
+		state->sum_x = 0;
+		state->sum_y = 0;
+		RegrSlopeOperation::Initialize<RegrSlopeState>(&state->slope);
+	}
+
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, A_TYPE *x_data, B_TYPE *y_data,
+	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		state->count++;
+		state->sum_x += y_data[yidx];
+		state->sum_y += x_data[xidx];
+		RegrSlopeOperation::Operation<A_TYPE, B_TYPE, RegrSlopeState, OP>(&state->slope, aggr_input_data, x_data,
+		                                                                  y_data, amask, bmask, xidx, yidx);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+		target->count += source.count;
+		target->sum_x += source.sum_x;
+		target->sum_y += source.sum_y;
+		RegrSlopeOperation::Combine<RegrSlopeState, OP>(source.slope, &target->slope, aggr_input_data);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->count == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		RegrSlopeOperation::Finalize<T, RegrSlopeState>(result, aggr_input_data, &state->slope, target, mask, idx);
+		auto x_avg = state->sum_x / state->count;
+		auto y_avg = state->sum_y / state->count;
+		target[idx] = y_avg - target[idx] * x_avg;
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void RegrInterceptFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_intercept");
+	fun.AddFunction(
+	    AggregateFunction::BinaryAggregate<RegrInterceptState, double, double, double, RegrInterceptOperation>(
+	        LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+// Returns the coefficient of determination for non-null pairs in a group.
+// It is computed for non-null pairs using the following formula:
+// null                 if var_pop(x) = 0, else
+// 1                    if var_pop(y) = 0 and var_pop(x) <> 0, else
+// power(corr(y,x), 2)
+
+
+
+
+
+namespace duckdb {
+struct RegrR2State {
+	CorrState corr;
+	StddevState var_pop_x;
+	StddevState var_pop_y;
+};
+
+struct RegrR2Operation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		CorrOperation::Initialize<CorrState>(&state->corr);
+		STDDevBaseOperation::Initialize<StddevState>(&state->var_pop_x);
+		STDDevBaseOperation::Initialize<StddevState>(&state->var_pop_y);
+	}
+
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, A_TYPE *x_data, B_TYPE *y_data,
+	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		CorrOperation::Operation<A_TYPE, B_TYPE, CorrState, OP>(&state->corr, aggr_input_data, y_data, x_data, bmask,
+		                                                        amask, yidx, xidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop_x, aggr_input_data, y_data, bmask,
+		                                                        yidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop_y, aggr_input_data, x_data, amask,
+		                                                        xidx);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+		CorrOperation::Combine<CorrState, OP>(source.corr, &target->corr, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_x, &target->var_pop_x, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop_y, &target->var_pop_y, aggr_input_data);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		auto var_pop_x = state->var_pop_x.count > 1 ? (state->var_pop_x.dsquared / state->var_pop_x.count) : 0;
+		if (!Value::DoubleIsFinite(var_pop_x)) {
+			throw OutOfRangeException("VARPOP(X) is out of range!");
+		}
+		if (var_pop_x == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		auto var_pop_y = state->var_pop_y.count > 1 ? (state->var_pop_y.dsquared / state->var_pop_y.count) : 0;
+		if (!Value::DoubleIsFinite(var_pop_y)) {
+			throw OutOfRangeException("VARPOP(Y) is out of range!");
+		}
+		if (var_pop_y == 0) {
+			target[idx] = 1;
+			return;
+		}
+		CorrOperation::Finalize<T, CorrState>(result, aggr_input_data, &state->corr, target, mask, idx);
+		target[idx] = pow(target[idx], 2);
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void RegrR2Fun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_r2");
+	fun.AddFunction(AggregateFunction::BinaryAggregate<RegrR2State, double, double, double, RegrR2Operation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+} // namespace duckdb
+// REGR_SLOPE(y, x)
+// Returns the slope of the linear regression line for non-null pairs in a group.
+// It is computed for non-null pairs using the following formula:
+// COVAR_POP(x,y) / VAR_POP(x)
+
+//! Input : Any numeric type
+//! Output : Double
+
+
+
+
+
+namespace duckdb {
+
+void RegrSlopeFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_slope");
+	fun.AddFunction(AggregateFunction::BinaryAggregate<RegrSlopeState, double, double, double, RegrSlopeOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+// regr_sxx
+// Returns REGR_COUNT(y, x) * VAR_POP(x) for non-null pairs.
+// regrsyy
+// Returns REGR_COUNT(y, x) * VAR_POP(y) for non-null pairs.
+
+
+
+
+
+namespace duckdb {
+
+struct RegrSState {
+	size_t count;
+	StddevState var_pop;
+};
+
+struct RegrBaseOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		RegrCountFunction::Initialize<size_t>(&state->count);
+		STDDevBaseOperation::Initialize<StddevState>(&state->var_pop);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+		RegrCountFunction::Combine<size_t, OP>(source.count, &target->count, aggr_input_data);
+		STDDevBaseOperation::Combine<StddevState, OP>(source.var_pop, &target->var_pop, aggr_input_data);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		if (state->var_pop.count == 0) {
+			mask.SetInvalid(idx);
+			return;
+		}
+		auto var_pop = state->var_pop.count > 1 ? (state->var_pop.dsquared / state->var_pop.count) : 0;
+		if (!Value::DoubleIsFinite(var_pop)) {
+			throw OutOfRangeException("VARPOP is out of range!");
+		}
+		RegrCountFunction::Finalize<T, size_t>(result, aggr_input_data, &state->count, target, mask, idx);
+		target[idx] *= var_pop;
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+struct RegrSXXOperation : RegrBaseOperation {
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, A_TYPE *x_data, B_TYPE *y_data,
+	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(&state->count, aggr_input_data, y_data, x_data, bmask,
+		                                                         amask, yidx, xidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop, aggr_input_data, y_data, bmask, yidx);
+	}
+};
+
+struct RegrSYYOperation : RegrBaseOperation {
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, A_TYPE *x_data, B_TYPE *y_data,
+	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(&state->count, aggr_input_data, y_data, x_data, bmask,
+		                                                         amask, yidx, xidx);
+		STDDevBaseOperation::Operation<A_TYPE, StddevState, OP>(&state->var_pop, aggr_input_data, x_data, bmask, xidx);
+	}
+};
+
+void RegrSXXFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_sxx");
+	fun.AddFunction(AggregateFunction::BinaryAggregate<RegrSState, double, double, double, RegrSXXOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+
+void RegrSYYFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_syy");
+	fun.AddFunction(AggregateFunction::BinaryAggregate<RegrSState, double, double, double, RegrSYYOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+// Returns REGR_COUNT(expr1, expr2) * COVAR_POP(expr1, expr2) for non-null pairs.
+
+
+
+
+
+
+namespace duckdb {
+
+struct RegrSXyState {
+	size_t count;
+	CovarState cov_pop;
+};
+
+struct RegrSXYOperation {
+	template <class STATE>
+	static void Initialize(STATE *state) {
+		RegrCountFunction::Initialize<size_t>(&state->count);
+		CovarOperation::Initialize<CovarState>(&state->cov_pop);
+	}
+
+	template <class A_TYPE, class B_TYPE, class STATE, class OP>
+	static void Operation(STATE *state, AggregateInputData &aggr_input_data, A_TYPE *x_data, B_TYPE *y_data,
+	                      ValidityMask &amask, ValidityMask &bmask, idx_t xidx, idx_t yidx) {
+		RegrCountFunction::Operation<A_TYPE, B_TYPE, size_t, OP>(&state->count, aggr_input_data, y_data, x_data, bmask,
+		                                                         amask, yidx, xidx);
+		CovarOperation::Operation<A_TYPE, B_TYPE, CovarState, OP>(&state->cov_pop, aggr_input_data, x_data, y_data,
+		                                                          amask, bmask, xidx, yidx);
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &aggr_input_data) {
+		CovarOperation::Combine<CovarState, OP>(source.cov_pop, &target->cov_pop, aggr_input_data);
+		RegrCountFunction::Combine<size_t, OP>(source.count, &target->count, aggr_input_data);
+	}
+
+	template <class T, class STATE>
+	static void Finalize(Vector &result, AggregateInputData &aggr_input_data, STATE *state, T *target,
+	                     ValidityMask &mask, idx_t idx) {
+		CovarPopOperation::Finalize<T, CovarState>(result, aggr_input_data, &state->cov_pop, target, mask, idx);
+		auto cov_pop = target[idx];
+		RegrCountFunction::Finalize<T, size_t>(result, aggr_input_data, &state->count, target, mask, idx);
+		target[idx] *= cov_pop;
+	}
+
+	static bool IgnoreNull() {
+		return true;
+	}
+};
+
+void RegrSXYFun::RegisterFunction(BuiltinFunctions &set) {
+	AggregateFunctionSet fun("regr_sxy");
+	fun.AddFunction(AggregateFunction::BinaryAggregate<RegrSXyState, double, double, double, RegrSXYOperation>(
+	    LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE));
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterRegressiveAggregates() {
+	Register<RegrAvgxFun>();
+	Register<RegrAvgyFun>();
+	Register<RegrCountFun>();
+	Register<RegrSlopeFun>();
+	Register<RegrR2Fun>();
+	Register<RegrSYYFun>();
+	Register<RegrSXXFun>();
+	Register<RegrSXYFun>();
+	Register<RegrInterceptFun>();
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+struct SortedAggregateBindData : public FunctionData {
+
+	// TODO: Collection sorting does not handle OrderByNullType correctly
+	// so this is the third hack around it...
+	static OrderByNullType NormaliseNullOrder(OrderType sense, OrderByNullType null_order) {
+		if (sense != OrderType::DESCENDING) {
+			return null_order;
+		}
+
+		switch (null_order) {
+		case OrderByNullType::NULLS_FIRST:
+			return OrderByNullType::NULLS_LAST;
+		case OrderByNullType::NULLS_LAST:
+			return OrderByNullType::NULLS_FIRST;
+		default:
+			throw InternalException("Unknown NULL order sense");
+		}
+	}
+
+	SortedAggregateBindData(const AggregateFunction &function_p, vector<unique_ptr<Expression>> &children,
+	                        unique_ptr<FunctionData> bind_info_p, const BoundOrderModifier &order_bys)
+	    : function(function_p), bind_info(move(bind_info_p)) {
+		arg_types.reserve(children.size());
+		for (const auto &child : children) {
+			arg_types.emplace_back(child->return_type);
+		}
+		for (auto &order : order_bys.orders) {
+			order_sense.emplace_back(order.type);
+			null_order.emplace_back(NormaliseNullOrder(order.type, order.null_order));
+			sort_types.emplace_back(order.expression->return_type);
+		}
+	}
+
+	SortedAggregateBindData(const SortedAggregateBindData &other)
+	    : function(other.function), arg_types(other.arg_types), order_sense(other.order_sense),
+	      null_order(other.null_order), sort_types(other.sort_types) {
+		if (other.bind_info) {
+			bind_info = other.bind_info->Copy();
+		}
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<SortedAggregateBindData>(*this);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const SortedAggregateBindData &)other_p;
+		if (bind_info && other.bind_info) {
+			if (!bind_info->Equals(*other.bind_info)) {
+				return false;
+			}
+		} else if (bind_info || other.bind_info) {
+			return false;
+		}
+		return function == other.function && order_sense == other.order_sense && null_order == other.null_order &&
+		       sort_types == other.sort_types;
+	}
+
+	AggregateFunction function;
+	vector<LogicalType> arg_types;
+	unique_ptr<FunctionData> bind_info;
+
+	vector<OrderType> order_sense;
+	vector<OrderByNullType> null_order;
+	vector<LogicalType> sort_types;
+};
+
+struct SortedAggregateState {
+	SortedAggregateState() : nsel(0) {
+	}
+
+	ChunkCollection arguments;
+	ChunkCollection ordering;
+
+	// Selection for scattering
+	SelectionVector sel;
+	idx_t nsel;
+};
+
+struct SortedAggregateFunction {
+	template <typename STATE>
+	static void Initialize(STATE *state) {
+		new (state) STATE();
+	}
+
+	template <typename STATE>
+	static void Destroy(STATE *state) {
+		state->~STATE();
+	}
+
+	static void ProjectInputs(Vector inputs[], SortedAggregateBindData *order_bind, idx_t input_count, idx_t count,
+	                          DataChunk &arg_chunk, DataChunk &sort_chunk) {
+		idx_t col = 0;
+
+		arg_chunk.InitializeEmpty(order_bind->arg_types);
+		for (auto &dst : arg_chunk.data) {
+			dst.Reference(inputs[col++]);
+		}
+		arg_chunk.SetCardinality(count);
+
+		sort_chunk.InitializeEmpty(order_bind->sort_types);
+		for (auto &dst : sort_chunk.data) {
+			dst.Reference(inputs[col++]);
+		}
+		sort_chunk.SetCardinality(count);
+	}
+
+	static void SimpleUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count, data_ptr_t state,
+	                         idx_t count) {
+		const auto order_bind = (SortedAggregateBindData *)aggr_input_data.bind_data;
+		DataChunk arg_chunk;
+		DataChunk sort_chunk;
+		ProjectInputs(inputs, order_bind, input_count, count, arg_chunk, sort_chunk);
+
+		const auto order_state = (SortedAggregateState *)state;
+		order_state->arguments.Append(arg_chunk);
+		order_state->ordering.Append(sort_chunk);
+	}
+
+	static void ScatterUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count, Vector &states,
+	                          idx_t count) {
+		if (!count) {
+			return;
+		}
+
+		// Append the arguments to the two sub-collections
+		const auto order_bind = (SortedAggregateBindData *)aggr_input_data.bind_data;
+		DataChunk arg_inputs;
+		DataChunk sort_inputs;
+		ProjectInputs(inputs, order_bind, input_count, count, arg_inputs, sort_inputs);
+
+		// We have to scatter the chunks one at a time
+		// so build a selection vector for each one.
+		VectorData svdata;
+		states.Orrify(count, svdata);
+
+		// Build the selection vector for each state.
+		auto sdata = (SortedAggregateState **)svdata.data;
+		for (idx_t i = 0; i < count; ++i) {
+			auto sidx = svdata.sel->get_index(i);
+			auto order_state = sdata[sidx];
+			if (!order_state->sel.data()) {
+				order_state->sel.Initialize();
+			}
+			order_state->sel.set_index(order_state->nsel++, i);
+		}
+
+		// Append nonempty slices to the arguments
+		for (idx_t i = 0; i < count; ++i) {
+			auto sidx = svdata.sel->get_index(i);
+			auto order_state = sdata[sidx];
+			if (!order_state->nsel) {
+				continue;
+			}
+
+			DataChunk arg_chunk;
+			arg_chunk.InitializeEmpty(arg_inputs.GetTypes());
+			arg_chunk.Slice(arg_inputs, order_state->sel, order_state->nsel);
+			order_state->arguments.Append(arg_chunk);
+
+			DataChunk sort_chunk;
+			sort_chunk.InitializeEmpty(sort_inputs.GetTypes());
+			sort_chunk.Slice(sort_inputs, order_state->sel, order_state->nsel);
+			order_state->ordering.Append(sort_chunk);
+
+			// Mark the slice as empty now we have consumed it.
+			order_state->nsel = 0;
+		}
+	}
+
+	template <class STATE, class OP>
+	static void Combine(const STATE &source, STATE *target, AggregateInputData &) {
+		if (source.arguments.Count() == 0) {
+			return;
+		}
+		target->arguments.Append(const_cast<ChunkCollection &>(source.arguments));
+		target->ordering.Append(const_cast<ChunkCollection &>(source.ordering));
+	}
+
+	static void Finalize(Vector &states, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
+	                     idx_t offset) {
+		const auto order_bind = (SortedAggregateBindData *)aggr_input_data.bind_data;
+
+		//	 Reusable inner state
+		vector<data_t> agg_state(order_bind->function.state_size());
+		Vector agg_state_vec(Value::POINTER((idx_t)agg_state.data()));
+
+		// Sorting buffer
+		vector<idx_t> reordering;
+
+		// State variables
+		const auto input_count = order_bind->function.arguments.size();
+		auto bind_info = order_bind->bind_info.get();
+		AggregateInputData aggr_bind_info(bind_info);
+
+		// Inner aggregate APIs
+		auto initialize = order_bind->function.initialize;
+		auto destructor = order_bind->function.destructor;
+		auto simple_update = order_bind->function.simple_update;
+		auto update = order_bind->function.update;
+		auto finalize = order_bind->function.finalize;
+
+		auto sdata = FlatVector::GetData<SortedAggregateState *>(states);
+		for (idx_t i = 0; i < count; ++i) {
+			initialize(agg_state.data());
+			auto state = sdata[i];
+
+			// Apply the sort before delegating the chunks
+			const auto agg_count = state->ordering.Count();
+			if (agg_count > 0) {
+				reordering.resize(agg_count);
+				state->ordering.Sort(order_bind->order_sense, order_bind->null_order, reordering.data());
+				state->arguments.Reorder(reordering.data());
+			}
+
+			for (auto &chunk : state->arguments.Chunks()) {
+				// These are all simple updates, so use it if available
+				if (simple_update) {
+					simple_update(chunk->data.data(), aggr_bind_info, input_count, agg_state.data(), chunk->size());
+				} else {
+					// We are only updating a constant state
+					agg_state_vec.SetVectorType(VectorType::CONSTANT_VECTOR);
+					update(chunk->data.data(), aggr_bind_info, input_count, agg_state_vec, chunk->size());
+				}
+			}
+
+			// Finalize a single value at the next offset
+			agg_state_vec.SetVectorType(states.GetVectorType());
+			finalize(agg_state_vec, aggr_bind_info, result, 1, i + offset);
+
+			if (destructor) {
+				destructor(agg_state_vec, 1);
+			}
+		}
+	}
+};
+
+unique_ptr<FunctionData> AggregateFunction::BindSortedAggregate(AggregateFunction &bound_function,
+                                                                vector<unique_ptr<Expression>> &children,
+                                                                unique_ptr<FunctionData> bind_info,
+                                                                unique_ptr<BoundOrderModifier> order_bys) {
+
+	auto sorted_bind = make_unique<SortedAggregateBindData>(bound_function, children, move(bind_info), *order_bys);
+
+	// The arguments are the children plus the sort columns.
+	for (auto &order : order_bys->orders) {
+		children.emplace_back(move(order.expression));
+	}
+
+	vector<LogicalType> arguments;
+	arguments.reserve(children.size());
+	for (const auto &child : children) {
+		arguments.emplace_back(child->return_type);
+	}
+
+	// Replace the aggregate with the wrapper
+	bound_function = AggregateFunction(
+	    bound_function.name, arguments, bound_function.return_type, AggregateFunction::StateSize<SortedAggregateState>,
+	    AggregateFunction::StateInitialize<SortedAggregateState, SortedAggregateFunction>,
+	    SortedAggregateFunction::ScatterUpdate,
+	    AggregateFunction::StateCombine<SortedAggregateState, SortedAggregateFunction>,
+	    SortedAggregateFunction::Finalize, SortedAggregateFunction::SimpleUpdate, nullptr,
+	    AggregateFunction::StateDestroy<SortedAggregateState, SortedAggregateFunction>);
+
+	return move(sorted_bind);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+//! The target type determines the preferred implicit casts
+static int64_t TargetTypeCost(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::INTEGER:
+		return 103;
+	case LogicalTypeId::BIGINT:
+		return 101;
+	case LogicalTypeId::DOUBLE:
+		return 102;
+	case LogicalTypeId::HUGEINT:
+		return 120;
+	case LogicalTypeId::TIMESTAMP:
+		return 120;
+	case LogicalTypeId::VARCHAR:
+		return 149;
+	case LogicalTypeId::DECIMAL:
+		return 104;
+	case LogicalTypeId::STRUCT:
+	case LogicalTypeId::MAP:
+	case LogicalTypeId::LIST:
+		return 160;
+	default:
+		return 110;
+	}
+}
+
+static int64_t ImplicitCastTinyint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastSmallint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastInteger(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastBigint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastUTinyint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastUSmallint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastUInteger(const LogicalType &to) {
+	switch (to.id()) {
+
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastUBigint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastFloat(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::DOUBLE:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastDouble(const LogicalType &to) {
+	switch (to.id()) {
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastDecimal(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastHugeint(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+static int64_t ImplicitCastDate(const LogicalType &to) {
+	switch (to.id()) {
+	case LogicalTypeId::TIMESTAMP:
+		return TargetTypeCost(to);
+	default:
+		return -1;
+	}
+}
+
+int64_t CastRules::ImplicitCast(const LogicalType &from, const LogicalType &to) {
+	if (to.id() == LogicalTypeId::ANY) {
+		// anything can be cast to ANY type for no cost
+		return 0;
+	}
+	if (from.id() == LogicalTypeId::SQLNULL) {
+		// NULL expression can be cast to anything
+		return TargetTypeCost(to);
+	}
+	if (from.id() == LogicalTypeId::UNKNOWN) {
+		// parameter expression can be cast to anything for no cost
+		return 0;
+	}
+	if (from.id() == LogicalTypeId::BLOB && to.id() == LogicalTypeId::VARCHAR) {
+		// Implicit cast not allowed from BLOB to VARCHAR
+		return -1;
+	}
+	if ((from.id() == LogicalTypeId::VARCHAR && to.id() == LogicalTypeId::JSON) ||
+	    (from.id() == LogicalTypeId::JSON && to.id() == LogicalTypeId::VARCHAR)) {
+		// Virtually no cost, just a different tag
+		return 1;
+	}
+	if (to.id() == LogicalTypeId::VARCHAR || to.id() == LogicalTypeId::JSON) {
+		// everything can be cast to VARCHAR/JSON, but this cast has a high cost
+		return TargetTypeCost(to);
+	}
+	if (from.id() == LogicalTypeId::LIST && to.id() == LogicalTypeId::LIST) {
+		// Lists can be cast if their child types can be cast
+		return ImplicitCast(ListType::GetChildType(from), ListType::GetChildType(to));
+	}
+	if ((from.id() == LogicalTypeId::TIMESTAMP_SEC || from.id() == LogicalTypeId::TIMESTAMP_MS ||
+	     from.id() == LogicalTypeId::TIMESTAMP_NS) &&
+	    to.id() == LogicalTypeId::TIMESTAMP) {
+		//! Any timestamp type can be converted to the default (us) type at low cost
+		return 101;
+	}
+	if ((to.id() == LogicalTypeId::TIMESTAMP_SEC || to.id() == LogicalTypeId::TIMESTAMP_MS ||
+	     to.id() == LogicalTypeId::TIMESTAMP_NS) &&
+	    from.id() == LogicalTypeId::TIMESTAMP) {
+		//! Any timestamp type can be converted to the default (us) type at low cost
+		return 100;
+	}
+	switch (from.id()) {
+	case LogicalTypeId::TINYINT:
+		return ImplicitCastTinyint(to);
+	case LogicalTypeId::SMALLINT:
+		return ImplicitCastSmallint(to);
+	case LogicalTypeId::INTEGER:
+		return ImplicitCastInteger(to);
+	case LogicalTypeId::BIGINT:
+		return ImplicitCastBigint(to);
+	case LogicalTypeId::UTINYINT:
+		return ImplicitCastUTinyint(to);
+	case LogicalTypeId::USMALLINT:
+		return ImplicitCastUSmallint(to);
+	case LogicalTypeId::UINTEGER:
+		return ImplicitCastUInteger(to);
+	case LogicalTypeId::UBIGINT:
+		return ImplicitCastUBigint(to);
+	case LogicalTypeId::HUGEINT:
+		return ImplicitCastHugeint(to);
+	case LogicalTypeId::FLOAT:
+		return ImplicitCastFloat(to);
+	case LogicalTypeId::DOUBLE:
+		return ImplicitCastDouble(to);
+	case LogicalTypeId::DATE:
+		return ImplicitCastDate(to);
+	case LogicalTypeId::DECIMAL:
+		return ImplicitCastDecimal(to);
+	default:
+		return -1;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+typedef CompressionFunction (*get_compression_function_t)(PhysicalType type);
+typedef bool (*compression_supports_type_t)(PhysicalType type);
+
+struct DefaultCompressionMethod {
+	CompressionType type;
+	get_compression_function_t get_function;
+	compression_supports_type_t supports_type;
+};
+
+static DefaultCompressionMethod internal_compression_methods[] = {
+    {CompressionType::COMPRESSION_CONSTANT, ConstantFun::GetFunction, ConstantFun::TypeIsSupported},
+    {CompressionType::COMPRESSION_UNCOMPRESSED, UncompressedFun::GetFunction, UncompressedFun::TypeIsSupported},
+    {CompressionType::COMPRESSION_RLE, RLEFun::GetFunction, RLEFun::TypeIsSupported},
+    {CompressionType::COMPRESSION_BITPACKING, BitpackingFun::GetFunction, BitpackingFun::TypeIsSupported},
+    {CompressionType::COMPRESSION_DICTIONARY, DictionaryCompressionFun::GetFunction,
+     DictionaryCompressionFun::TypeIsSupported},
+    {CompressionType::COMPRESSION_AUTO, nullptr, nullptr}};
+
+static CompressionFunction *FindCompressionFunction(CompressionFunctionSet &set, CompressionType type,
+                                                    PhysicalType data_type) {
+	auto &functions = set.functions;
+	auto comp_entry = functions.find(type);
+	if (comp_entry != functions.end()) {
+		auto &type_functions = comp_entry->second;
+		auto type_entry = type_functions.find(data_type);
+		if (type_entry != type_functions.end()) {
+			return &type_entry->second;
+		}
+	}
+	return nullptr;
+}
+
+static CompressionFunction *LoadCompressionFunction(CompressionFunctionSet &set, CompressionType type,
+                                                    PhysicalType data_type) {
+	for (idx_t index = 0; internal_compression_methods[index].get_function; index++) {
+		const auto &method = internal_compression_methods[index];
+		if (method.type == type) {
+			// found the correct compression type
+			if (!method.supports_type(data_type)) {
+				// but it does not support this data type: bail out
+				return nullptr;
+			}
+			// the type is supported: create the function and insert it into the set
+			auto function = method.get_function(data_type);
+			set.functions[type].insert(make_pair(data_type, function));
+			return FindCompressionFunction(set, type, data_type);
+		}
+	}
+	throw InternalException("Unsupported compression function type");
+}
+
+static void TryLoadCompression(DBConfig &config, vector<CompressionFunction *> &result, CompressionType type,
+                               PhysicalType data_type) {
+	auto function = config.GetCompressionFunction(type, data_type);
+	if (!function) {
+		return;
+	}
+	result.push_back(function);
+}
+
+vector<CompressionFunction *> DBConfig::GetCompressionFunctions(PhysicalType data_type) {
+	vector<CompressionFunction *> result;
+	TryLoadCompression(*this, result, CompressionType::COMPRESSION_UNCOMPRESSED, data_type);
+	TryLoadCompression(*this, result, CompressionType::COMPRESSION_RLE, data_type);
+	TryLoadCompression(*this, result, CompressionType::COMPRESSION_BITPACKING, data_type);
+	TryLoadCompression(*this, result, CompressionType::COMPRESSION_DICTIONARY, data_type);
+	return result;
+}
+
+CompressionFunction *DBConfig::GetCompressionFunction(CompressionType type, PhysicalType data_type) {
+	// check if the function is already loaded
+	auto function = FindCompressionFunction(*compression_functions, type, data_type);
+	if (function) {
+		return function;
+	}
+	// else load the function
+	return LoadCompressionFunction(*compression_functions, type, data_type);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+FunctionData::~FunctionData() {
+}
+
+bool FunctionData::Equals(const FunctionData *left, const FunctionData *right) {
+	if (left == right) {
+		return true;
+	}
+	if (!left || !right) {
+		return false;
+	}
+	return left->Equals(*right);
+}
+
+TableFunctionData::~TableFunctionData() {
+}
+
+unique_ptr<FunctionData> TableFunctionData::Copy() const {
+	throw InternalException("Copy not supported for TableFunctionData");
+}
+
+bool TableFunctionData::Equals(const FunctionData &other) const {
+	return false;
+}
+
+Function::Function(string name_p) : name(move(name_p)) {
+}
+Function::~Function() {
+}
+
+SimpleFunction::SimpleFunction(string name_p, vector<LogicalType> arguments_p, LogicalType varargs_p)
+    : Function(move(name_p)), arguments(move(arguments_p)), varargs(move(varargs_p)) {
+}
+
+SimpleFunction::~SimpleFunction() {
+}
+
+string SimpleFunction::ToString() {
+	return Function::CallToString(name, arguments);
+}
+
+bool SimpleFunction::HasVarArgs() const {
+	return varargs.id() != LogicalTypeId::INVALID;
+}
+
+SimpleNamedParameterFunction::SimpleNamedParameterFunction(string name_p, vector<LogicalType> arguments_p,
+                                                           LogicalType varargs_p)
+    : SimpleFunction(move(name_p), move(arguments_p), move(varargs_p)) {
+}
+
+SimpleNamedParameterFunction::~SimpleNamedParameterFunction() {
+}
+
+string SimpleNamedParameterFunction::ToString() {
+	return Function::CallToString(name, arguments, named_parameters);
+}
+
+bool SimpleNamedParameterFunction::HasNamedParameters() {
+	return !named_parameters.empty();
+}
+
+BaseScalarFunction::BaseScalarFunction(string name_p, vector<LogicalType> arguments_p, LogicalType return_type_p,
+                                       bool has_side_effects, LogicalType varargs_p, bool propagates_null_values_p)
+    : SimpleFunction(move(name_p), move(arguments_p), move(varargs_p)), return_type(move(return_type_p)),
+      has_side_effects(has_side_effects), propagates_null_values(propagates_null_values_p) {
+}
+
+BaseScalarFunction::~BaseScalarFunction() {
+}
+
+string BaseScalarFunction::ToString() {
+	return Function::CallToString(name, arguments, return_type);
+}
+
+// add your initializer for new functions here
+void BuiltinFunctions::Initialize() {
+	RegisterSQLiteFunctions();
+	RegisterReadFunctions();
+	RegisterTableFunctions();
+	RegisterArrowFunctions();
+
+	RegisterAlgebraicAggregates();
+	RegisterDistributiveAggregates();
+	RegisterNestedAggregates();
+	RegisterHolisticAggregates();
+	RegisterRegressiveAggregates();
+
+	RegisterDateFunctions();
+	RegisterEnumFunctions();
+	RegisterGenericFunctions();
+	RegisterMathFunctions();
+	RegisterOperators();
+	RegisterSequenceFunctions();
+	RegisterStringFunctions();
+	RegisterNestedFunctions();
+	RegisterTrigonometricsFunctions();
+
+	RegisterPragmaFunctions();
+
+	// initialize collations
+	AddCollation("nocase", LowerFun::GetFunction(), true);
+	AddCollation("noaccent", StripAccentsFun::GetFunction());
+	AddCollation("nfc", NFCNormalizeFun::GetFunction());
+}
+
+BuiltinFunctions::BuiltinFunctions(ClientContext &context, Catalog &catalog) : context(context), catalog(catalog) {
+}
+
+void BuiltinFunctions::AddCollation(string name, ScalarFunction function, bool combinable,
+                                    bool not_required_for_equality) {
+	CreateCollationInfo info(move(name), move(function), combinable, not_required_for_equality);
+	catalog.CreateCollation(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(AggregateFunctionSet set) {
+	CreateAggregateFunctionInfo info(move(set));
+	catalog.CreateFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(AggregateFunction function) {
+	CreateAggregateFunctionInfo info(move(function));
+	catalog.CreateFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(PragmaFunction function) {
+	CreatePragmaFunctionInfo info(move(function));
+	catalog.CreatePragmaFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(const string &name, vector<PragmaFunction> functions) {
+	CreatePragmaFunctionInfo info(name, move(functions));
+	catalog.CreatePragmaFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(ScalarFunction function) {
+	CreateScalarFunctionInfo info(move(function));
+	catalog.CreateFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(const vector<string> &names, ScalarFunction function) { // NOLINT: false positive
+	for (auto &name : names) {
+		function.name = name;
+		AddFunction(function);
+	}
+}
+
+void BuiltinFunctions::AddFunction(ScalarFunctionSet set) {
+	CreateScalarFunctionInfo info(move(set));
+	catalog.CreateFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(TableFunction function) {
+	CreateTableFunctionInfo info(move(function));
+	catalog.CreateTableFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(TableFunctionSet set) {
+	CreateTableFunctionInfo info(move(set));
+	catalog.CreateTableFunction(context, &info);
+}
+
+void BuiltinFunctions::AddFunction(CopyFunction function) {
+	CreateCopyFunctionInfo info(move(function));
+	catalog.CreateCopyFunction(context, &info);
+}
+
+hash_t BaseScalarFunction::Hash() const {
+	hash_t hash = return_type.Hash();
+	for (auto &arg : arguments) {
+		duckdb::CombineHash(hash, arg.Hash());
+	}
+	return hash;
+}
+
+string Function::CallToString(const string &name, const vector<LogicalType> &arguments) {
+	string result = name + "(";
+	result += StringUtil::Join(arguments, arguments.size(), ", ",
+	                           [](const LogicalType &argument) { return argument.ToString(); });
+	return result + ")";
+}
+
+string Function::CallToString(const string &name, const vector<LogicalType> &arguments,
+                              const LogicalType &return_type) {
+	string result = CallToString(name, arguments);
+	result += " -> " + return_type.ToString();
+	return result;
+}
+
+string Function::CallToString(const string &name, const vector<LogicalType> &arguments,
+                              const named_parameter_type_map_t &named_parameters) {
+	vector<string> input_arguments;
+	input_arguments.reserve(arguments.size() + named_parameters.size());
+	for (auto &arg : arguments) {
+		input_arguments.push_back(arg.ToString());
+	}
+	for (auto &kv : named_parameters) {
+		input_arguments.push_back(StringUtil::Format("%s : %s", kv.first, kv.second.ToString()));
+	}
+	return StringUtil::Format("%s(%s)", name, StringUtil::Join(input_arguments, ", "));
+}
+
+static int64_t BindVarArgsFunctionCost(SimpleFunction &func, vector<LogicalType> &arguments) {
+	if (arguments.size() < func.arguments.size()) {
+		// not enough arguments to fulfill the non-vararg part of the function
+		return -1;
+	}
+	int64_t cost = 0;
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		LogicalType arg_type = i < func.arguments.size() ? func.arguments[i] : func.varargs;
+		if (arguments[i] == arg_type) {
+			// arguments match: do nothing
+			continue;
+		}
+		int64_t cast_cost = CastRules::ImplicitCast(arguments[i], arg_type);
+		if (cast_cost >= 0) {
+			// we can implicitly cast, add the cost to the total cost
+			cost += cast_cost;
+		} else {
+			// we can't implicitly cast: throw an error
+			return -1;
+		}
+	}
+	return cost;
+}
+
+static int64_t BindFunctionCost(SimpleFunction &func, vector<LogicalType> &arguments) {
+	if (func.HasVarArgs()) {
+		// special case varargs function
+		return BindVarArgsFunctionCost(func, arguments);
+	}
+	if (func.arguments.size() != arguments.size()) {
+		// invalid argument count: check the next function
+		return -1;
+	}
+	int64_t cost = 0;
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		if (arguments[i].id() == func.arguments[i].id()) {
+			// arguments match: do nothing
+			continue;
+		}
+		int64_t cast_cost = CastRules::ImplicitCast(arguments[i], func.arguments[i]);
+		if (cast_cost >= 0) {
+			// we can implicitly cast, add the cost to the total cost
+			cost += cast_cost;
+		} else {
+			// we can't implicitly cast: throw an error
+			return -1;
+		}
+	}
+	return cost;
+}
+
+template <class T>
+static vector<idx_t> BindFunctionsFromArguments(const string &name, vector<T> &functions,
+                                                vector<LogicalType> &arguments, string &error) {
+	idx_t best_function = DConstants::INVALID_INDEX;
+	int64_t lowest_cost = NumericLimits<int64_t>::Maximum();
+	vector<idx_t> candidate_functions;
+	for (idx_t f_idx = 0; f_idx < functions.size(); f_idx++) {
+		auto &func = functions[f_idx];
+		// check the arguments of the function
+		int64_t cost = BindFunctionCost(func, arguments);
+		if (cost < 0) {
+			// auto casting was not possible
+			continue;
+		}
+		if (cost == lowest_cost) {
+			candidate_functions.push_back(f_idx);
+			continue;
+		}
+		if (cost > lowest_cost) {
+			continue;
+		}
+		candidate_functions.clear();
+		lowest_cost = cost;
+		best_function = f_idx;
+	}
+	if (best_function == DConstants::INVALID_INDEX) {
+		// no matching function was found, throw an error
+		string call_str = Function::CallToString(name, arguments);
+		string candidate_str = "";
+		for (auto &f : functions) {
+			candidate_str += "\t" + f.ToString() + "\n";
+		}
+		error = StringUtil::Format("No function matches the given name and argument types '%s'. You might need to add "
+		                           "explicit type casts.\n\tCandidate functions:\n%s",
+		                           call_str, candidate_str);
+		return candidate_functions;
+	}
+	candidate_functions.push_back(best_function);
+	return candidate_functions;
+}
+
+template <class T>
+static idx_t MultipleCandidateException(const string &name, vector<T> &functions, vector<idx_t> &candidate_functions,
+                                        vector<LogicalType> &arguments, string &error) {
+	D_ASSERT(functions.size() > 1);
+	// there are multiple possible function definitions
+	// throw an exception explaining which overloads are there
+	string call_str = Function::CallToString(name, arguments);
+	string candidate_str = "";
+	for (auto &conf : candidate_functions) {
+		auto &f = functions[conf];
+		candidate_str += "\t" + f.ToString() + "\n";
+	}
+	error = StringUtil::Format("Could not choose a best candidate function for the function call \"%s\". In order to "
+	                           "select one, please add explicit type casts.\n\tCandidate functions:\n%s",
+	                           call_str, candidate_str);
+	return DConstants::INVALID_INDEX;
+}
+
+template <class T>
+static idx_t BindFunctionFromArguments(const string &name, vector<T> &functions, vector<LogicalType> &arguments,
+                                       string &error, bool &cast_parameters) {
+	auto candidate_functions = BindFunctionsFromArguments<T>(name, functions, arguments, error);
+	if (candidate_functions.empty()) {
+		// no candidates
+		return DConstants::INVALID_INDEX;
+	}
+	cast_parameters = true;
+	if (candidate_functions.size() > 1) {
+		// multiple candidates, check if there are any unknown arguments
+		bool has_parameters = false;
+		for (auto &arg_type : arguments) {
+			if (arg_type.id() == LogicalTypeId::UNKNOWN) {
+				//! there are! disable casting of parameters, but do not throw an error
+				cast_parameters = false;
+				has_parameters = true;
+				break;
+			}
+		}
+		if (!has_parameters) {
+			return MultipleCandidateException(name, functions, candidate_functions, arguments, error);
+		}
+	}
+	return candidate_functions[0];
+}
+
+idx_t Function::BindFunction(const string &name, vector<ScalarFunction> &functions, vector<LogicalType> &arguments,
+                             string &error, bool &cast_parameters) {
+	return BindFunctionFromArguments(name, functions, arguments, error, cast_parameters);
+}
+
+idx_t Function::BindFunction(const string &name, vector<AggregateFunction> &functions, vector<LogicalType> &arguments,
+                             string &error, bool &cast_parameters) {
+	return BindFunctionFromArguments(name, functions, arguments, error, cast_parameters);
+}
+
+idx_t Function::BindFunction(const string &name, vector<AggregateFunction> &functions, vector<LogicalType> &arguments,
+                             string &error) {
+	bool cast_parameters;
+	return BindFunction(name, functions, arguments, error, cast_parameters);
+}
+
+idx_t Function::BindFunction(const string &name, vector<TableFunction> &functions, vector<LogicalType> &arguments,
+                             string &error) {
+	bool cast_parameters;
+	return BindFunctionFromArguments(name, functions, arguments, error, cast_parameters);
+}
+
+idx_t Function::BindFunction(const string &name, vector<PragmaFunction> &functions, PragmaInfo &info, string &error) {
+	vector<LogicalType> types;
+	for (auto &value : info.parameters) {
+		types.push_back(value.type());
+	}
+	bool cast_parameters;
+	idx_t entry = BindFunctionFromArguments(name, functions, types, error, cast_parameters);
+	if (entry == DConstants::INVALID_INDEX) {
+		throw BinderException(error);
+	}
+	auto &candidate_function = functions[entry];
+	// cast the input parameters
+	for (idx_t i = 0; i < info.parameters.size(); i++) {
+		auto target_type =
+		    i < candidate_function.arguments.size() ? candidate_function.arguments[i] : candidate_function.varargs;
+		info.parameters[i] = info.parameters[i].CastAs(target_type);
+	}
+	return entry;
+}
+
+vector<LogicalType> GetLogicalTypesFromExpressions(vector<unique_ptr<Expression>> &arguments) {
+	vector<LogicalType> types;
+	types.reserve(arguments.size());
+	for (auto &argument : arguments) {
+		types.push_back(argument->return_type);
+	}
+	return types;
+}
+
+idx_t Function::BindFunction(const string &name, vector<ScalarFunction> &functions,
+                             vector<unique_ptr<Expression>> &arguments, string &error, bool &cast_parameters) {
+	auto types = GetLogicalTypesFromExpressions(arguments);
+	return Function::BindFunction(name, functions, types, error, cast_parameters);
+}
+
+idx_t Function::BindFunction(const string &name, vector<AggregateFunction> &functions,
+                             vector<unique_ptr<Expression>> &arguments, string &error) {
+	auto types = GetLogicalTypesFromExpressions(arguments);
+	return Function::BindFunction(name, functions, types, error);
+}
+
+idx_t Function::BindFunction(const string &name, vector<TableFunction> &functions,
+                             vector<unique_ptr<Expression>> &arguments, string &error) {
+	auto types = GetLogicalTypesFromExpressions(arguments);
+	return Function::BindFunction(name, functions, types, error);
+}
+
+enum class LogicalTypeComparisonResult { IDENTICAL_TYPE, TARGET_IS_ANY, DIFFERENT_TYPES };
+
+LogicalTypeComparisonResult RequiresCast(const LogicalType &source_type, const LogicalType &target_type) {
+	if (target_type.id() == LogicalTypeId::ANY) {
+		return LogicalTypeComparisonResult::TARGET_IS_ANY;
+	}
+	if (source_type == target_type) {
+		return LogicalTypeComparisonResult::IDENTICAL_TYPE;
+	}
+	if (source_type.id() == LogicalTypeId::LIST && target_type.id() == LogicalTypeId::LIST) {
+		return RequiresCast(ListType::GetChildType(source_type), ListType::GetChildType(target_type));
+	}
+	return LogicalTypeComparisonResult::DIFFERENT_TYPES;
+}
+
+void BaseScalarFunction::CastToFunctionArguments(vector<unique_ptr<Expression>> &children,
+                                                 bool cast_parameter_expressions) {
+	for (idx_t i = 0; i < children.size(); i++) {
+		auto target_type = i < this->arguments.size() ? this->arguments[i] : this->varargs;
+		target_type.Verify();
+		// check if the source type is a paramter, and we have disabled casting of parameters
+		if (children[i]->return_type.id() == LogicalTypeId::UNKNOWN && !cast_parameter_expressions) {
+			continue;
+		}
+		// check if the type of child matches the type of function argument
+		// if not we need to add a cast
+		auto cast_result = RequiresCast(children[i]->return_type, target_type);
+		// except for one special case: if the function accepts ANY argument
+		// in that case we don't add a cast
+		if (cast_result == LogicalTypeComparisonResult::DIFFERENT_TYPES) {
+			children[i] = BoundCastExpression::AddCastToType(move(children[i]), target_type);
+		}
+	}
+}
+
+unique_ptr<BoundFunctionExpression> ScalarFunction::BindScalarFunction(ClientContext &context, const string &schema,
+                                                                       const string &name,
+                                                                       vector<unique_ptr<Expression>> children,
+                                                                       string &error, bool is_operator) {
+	// bind the function
+	auto function = Catalog::GetCatalog(context).GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, schema, name);
+	D_ASSERT(function && function->type == CatalogType::SCALAR_FUNCTION_ENTRY);
+	return ScalarFunction::BindScalarFunction(context, (ScalarFunctionCatalogEntry &)*function, move(children), error,
+	                                          is_operator);
+}
+
+unique_ptr<BoundFunctionExpression> ScalarFunction::BindScalarFunction(ClientContext &context,
+                                                                       ScalarFunctionCatalogEntry &func,
+                                                                       vector<unique_ptr<Expression>> children,
+                                                                       string &error, bool is_operator) {
+	// bind the function
+	bool cast_parameters;
+	idx_t best_function = Function::BindFunction(func.name, func.functions, children, error, cast_parameters);
+	if (best_function == DConstants::INVALID_INDEX) {
+		return nullptr;
+	}
+
+	// found a matching function!
+	auto &bound_function = func.functions[best_function];
+	return ScalarFunction::BindScalarFunction(context, bound_function, move(children), is_operator, cast_parameters);
+}
+
+unique_ptr<BoundFunctionExpression> ScalarFunction::BindScalarFunction(ClientContext &context,
+                                                                       ScalarFunction bound_function,
+                                                                       vector<unique_ptr<Expression>> children,
+                                                                       bool is_operator, bool cast_parameters) {
+	unique_ptr<FunctionData> bind_info;
+	if (bound_function.bind) {
+		bind_info = bound_function.bind(context, bound_function, children);
+	}
+	// check if we need to add casts to the children
+	bound_function.CastToFunctionArguments(children, cast_parameters);
+
+	// now create the function
+	auto return_type = bound_function.return_type;
+	return make_unique<BoundFunctionExpression>(move(return_type), move(bound_function), move(children),
+	                                            move(bind_info), is_operator);
+}
+
+unique_ptr<BoundAggregateExpression> AggregateFunction::BindAggregateFunction(
+    ClientContext &context, AggregateFunction bound_function, vector<unique_ptr<Expression>> children,
+    unique_ptr<Expression> filter, bool is_distinct, unique_ptr<BoundOrderModifier> order_bys, bool cast_parameters) {
+	unique_ptr<FunctionData> bind_info;
+	if (bound_function.bind) {
+		bind_info = bound_function.bind(context, bound_function, children);
+		// we may have lost some arguments in the bind
+		children.resize(MinValue(bound_function.arguments.size(), children.size()));
+	}
+
+	// check if we need to add casts to the children
+	bound_function.CastToFunctionArguments(children, cast_parameters);
+
+	// Special case: for ORDER BY aggregates, we wrap the aggregate function in a SortedAggregateFunction
+	// The children are the sort clauses and the binding contains the ordering data.
+	if (order_bys && !order_bys->orders.empty()) {
+		bind_info = BindSortedAggregate(bound_function, children, move(bind_info), move(order_bys));
+	}
+
+	return make_unique<BoundAggregateExpression>(move(bound_function), move(children), move(filter), move(bind_info),
+	                                             is_distinct);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+// MacroFunction::MacroFunction(unique_ptr<ParsedExpression> expression) : expression(move(expression)) {}
+
+MacroFunction::MacroFunction(MacroType type) : type(type) {
+}
+
+string MacroFunction::ValidateArguments(MacroFunction &macro_def, const string &name, FunctionExpression &function_expr,
+                                        vector<unique_ptr<ParsedExpression>> &positionals,
+                                        unordered_map<string, unique_ptr<ParsedExpression>> &defaults) {
+
+	// separate positional and default arguments
+	for (auto &arg : function_expr.children) {
+		if (arg->type == ExpressionType::VALUE_CONSTANT && !arg->alias.empty()) {
+			// default argument
+			if (macro_def.default_parameters.find(arg->alias) == macro_def.default_parameters.end()) {
+				return StringUtil::Format("Macro %s does not have default parameter %s!", name, arg->alias);
+			} else if (defaults.find(arg->alias) != defaults.end()) {
+				return StringUtil::Format("Duplicate default parameters %s!", arg->alias);
+			}
+			defaults[arg->alias] = move(arg);
+		} else if (!defaults.empty()) {
+			return "Positional parameters cannot come after parameters with a default value!";
+		} else {
+			// positional argument
+			positionals.push_back(move(arg));
+		}
+	}
+
+	// validate if the right number of arguments was supplied
+	string error;
+	auto &parameters = macro_def.parameters;
+	if (parameters.size() != positionals.size()) {
+		error = StringUtil::Format(
+		    "Macro function '%s(%s)' requires ", name,
+		    StringUtil::Join(parameters, parameters.size(), ", ", [](const unique_ptr<ParsedExpression> &p) {
+			    return ((ColumnRefExpression &)*p).column_names[0];
+		    }));
+		error += parameters.size() == 1 ? "a single positional argument"
+		                                : StringUtil::Format("%i positional arguments", parameters.size());
+		error += ", but ";
+		error += positionals.size() == 1 ? "a single positional argument was"
+		                                 : StringUtil::Format("%i positional arguments were", positionals.size());
+		error += " provided.";
+		return error;
+	}
+
+	// fill in default value where this was not supplied
+	for (auto it = macro_def.default_parameters.begin(); it != macro_def.default_parameters.end(); it++) {
+		if (defaults.find(it->first) == defaults.end()) {
+			defaults[it->first] = it->second->Copy();
+		}
+	}
+
+	return error;
+}
+
+void MacroFunction::CopyProperties(MacroFunction &other) {
+	other.type = type;
+	for (auto &param : parameters) {
+		other.parameters.push_back(param->Copy());
+	}
+	for (auto &kv : default_parameters) {
+		other.default_parameters[kv.first] = kv.second->Copy();
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cctype>
+
+namespace duckdb {
+
+static void PragmaEnableProfilingStatement(ClientContext &context, const FunctionParameters &parameters) {
+	auto &config = ClientConfig::GetConfig(context);
+	config.profiler_print_format = ProfilerPrintFormat::QUERY_TREE;
+	config.enable_profiler = true;
+}
+
+void RegisterEnableProfiling(BuiltinFunctions &set) {
+	vector<PragmaFunction> functions;
+	functions.push_back(PragmaFunction::PragmaStatement(string(), PragmaEnableProfilingStatement));
+
+	set.AddFunction("enable_profile", functions);
+	set.AddFunction("enable_profiling", functions);
+}
+
+static void PragmaDisableProfiling(ClientContext &context, const FunctionParameters &parameters) {
+	auto &config = ClientConfig::GetConfig(context);
+	config.enable_profiler = false;
+	config.profiler_print_format = ProfilerPrintFormat::NONE;
+}
+
+static void PragmaEnableProgressBar(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).enable_progress_bar = true;
+}
+
+static void PragmaDisableProgressBar(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).enable_progress_bar = false;
+}
+
+static void PragmaEnablePrintProgressBar(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).print_progress_bar = true;
+}
+
+static void PragmaDisablePrintProgressBar(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).print_progress_bar = false;
+}
+
+static void PragmaEnableVerification(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).query_verification_enabled = true;
+}
+
+static void PragmaDisableVerification(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).query_verification_enabled = false;
+}
+
+static void PragmaEnableForceParallelism(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).verify_parallelism = true;
+}
+
+static void PragmaEnableForceIndexJoin(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).force_index_join = true;
+}
+
+static void PragmaForceCheckpoint(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).force_checkpoint = true;
+}
+
+static void PragmaDisableForceParallelism(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).verify_parallelism = false;
+}
+
+static void PragmaEnableObjectCache(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).object_cache_enable = true;
+}
+
+static void PragmaDisableObjectCache(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).object_cache_enable = false;
+}
+
+static void PragmaEnableCheckpointOnShutdown(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).checkpoint_on_shutdown = true;
+}
+
+static void PragmaDisableCheckpointOnShutdown(ClientContext &context, const FunctionParameters &parameters) {
+	DBConfig::GetConfig(context).checkpoint_on_shutdown = false;
+}
+
+static void PragmaEnableOptimizer(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).enable_optimizer = true;
+}
+
+static void PragmaDisableOptimizer(ClientContext &context, const FunctionParameters &parameters) {
+	ClientConfig::GetConfig(context).enable_optimizer = false;
+}
+
+void PragmaFunctions::RegisterFunction(BuiltinFunctions &set) {
+	RegisterEnableProfiling(set);
+
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_profile", PragmaDisableProfiling));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_profiling", PragmaDisableProfiling));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_verification", PragmaEnableVerification));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_verification", PragmaDisableVerification));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("verify_parallelism", PragmaEnableForceParallelism));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_verify_parallelism", PragmaDisableForceParallelism));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_object_cache", PragmaEnableObjectCache));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_object_cache", PragmaDisableObjectCache));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_optimizer", PragmaEnableOptimizer));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_optimizer", PragmaDisableOptimizer));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("force_index_join", PragmaEnableForceIndexJoin));
+	set.AddFunction(PragmaFunction::PragmaStatement("force_checkpoint", PragmaForceCheckpoint));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_progress_bar", PragmaEnableProgressBar));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_progress_bar", PragmaDisableProgressBar));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_print_progress_bar", PragmaEnablePrintProgressBar));
+	set.AddFunction(PragmaFunction::PragmaStatement("disable_print_progress_bar", PragmaDisablePrintProgressBar));
+
+	set.AddFunction(PragmaFunction::PragmaStatement("enable_checkpoint_on_shutdown", PragmaEnableCheckpointOnShutdown));
+	set.AddFunction(
+	    PragmaFunction::PragmaStatement("disable_checkpoint_on_shutdown", PragmaDisableCheckpointOnShutdown));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+string PragmaTableInfo(ClientContext &context, const FunctionParameters &parameters) {
+	return StringUtil::Format("SELECT * FROM pragma_table_info('%s');", parameters.values[0].ToString());
+}
+
+string PragmaShowTables(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT name FROM sqlite_master ORDER BY name;";
+}
+
+string PragmaShowTablesExpanded(ClientContext &context, const FunctionParameters &parameters) {
+	return R"(
+			SELECT
+				t.table_name,
+				LIST(c.column_name order by c.column_name) AS column_names,
+				LIST(c.data_type order by c.column_name) AS column_types,
+				FIRST(t.temporary) AS temporary
+			FROM duckdb_tables t
+			JOIN duckdb_columns c
+			USING (table_oid)
+			GROUP BY t.table_name
+			ORDER BY t.table_name;
+	)";
+}
+
+string PragmaAllProfiling(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_last_profiling_output() JOIN pragma_detailed_profiling_output() ON "
+	       "(pragma_last_profiling_output.operator_id);";
+}
+
+string PragmaDatabaseList(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_database_list() ORDER BY 1;";
+}
+
+string PragmaCollations(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_collations() ORDER BY 1;";
+}
+
+string PragmaFunctionsQuery(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_functions() ORDER BY 1;";
+}
+
+string PragmaShow(ClientContext &context, const FunctionParameters &parameters) {
+	// PRAGMA table_info but with some aliases
+	return StringUtil::Format(
+	    "SELECT name AS \"column_name\", type as \"column_type\", CASE WHEN \"notnull\" THEN 'NO' ELSE 'YES' "
+	    "END AS \"null\", NULL AS \"key\", dflt_value AS \"default\", NULL AS \"extra\" FROM pragma_table_info('%s');",
+	    parameters.values[0].ToString());
+}
+
+string PragmaVersion(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_version();";
+}
+
+string PragmaImportDatabase(ClientContext &context, const FunctionParameters &parameters) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("Import is disabled through configuration");
+	}
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto *opener = FileSystem::GetFileOpener(context);
+
+	string query;
+	// read the "shema.sql" and "load.sql" files
+	vector<string> files = {"schema.sql", "load.sql"};
+	for (auto &file : files) {
+		auto file_path = fs.JoinPath(parameters.values[0].ToString(), file);
+		auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ, FileSystem::DEFAULT_LOCK,
+		                          FileSystem::DEFAULT_COMPRESSION, opener);
+		auto fsize = fs.GetFileSize(*handle);
+		auto buffer = unique_ptr<char[]>(new char[fsize]);
+		fs.Read(*handle, buffer.get(), fsize);
+
+		query += string(buffer.get(), fsize);
+	}
+	return query;
+}
+
+string PragmaDatabaseSize(ClientContext &context, const FunctionParameters &parameters) {
+	return "SELECT * FROM pragma_database_size();";
+}
+
+string PragmaStorageInfo(ClientContext &context, const FunctionParameters &parameters) {
+	return StringUtil::Format("SELECT * FROM pragma_storage_info('%s');", parameters.values[0].ToString());
+}
+
+void PragmaQueries::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(PragmaFunction::PragmaCall("table_info", PragmaTableInfo, {LogicalType::VARCHAR}));
+	set.AddFunction(PragmaFunction::PragmaCall("storage_info", PragmaStorageInfo, {LogicalType::VARCHAR}));
+	set.AddFunction(PragmaFunction::PragmaStatement("show_tables", PragmaShowTables));
+	set.AddFunction(PragmaFunction::PragmaStatement("show_tables_expanded", PragmaShowTablesExpanded));
+	set.AddFunction(PragmaFunction::PragmaStatement("database_list", PragmaDatabaseList));
+	set.AddFunction(PragmaFunction::PragmaStatement("collations", PragmaCollations));
+	set.AddFunction(PragmaFunction::PragmaCall("show", PragmaShow, {LogicalType::VARCHAR}));
+	set.AddFunction(PragmaFunction::PragmaStatement("version", PragmaVersion));
+	set.AddFunction(PragmaFunction::PragmaStatement("database_size", PragmaDatabaseSize));
+	set.AddFunction(PragmaFunction::PragmaStatement("functions", PragmaFunctionsQuery));
+	set.AddFunction(PragmaFunction::PragmaCall("import_database", PragmaImportDatabase, {LogicalType::VARCHAR}));
+	set.AddFunction(PragmaFunction::PragmaStatement("all_profiling_output", PragmaAllProfiling));
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PragmaFunction::PragmaFunction(string name, PragmaType pragma_type, pragma_query_t query, pragma_function_t function,
+                               vector<LogicalType> arguments, LogicalType varargs)
+    : SimpleNamedParameterFunction(move(name), move(arguments), move(varargs)), type(pragma_type), query(query),
+      function(function) {
+}
+
+PragmaFunction PragmaFunction::PragmaCall(const string &name, pragma_query_t query, vector<LogicalType> arguments,
+                                          LogicalType varargs) {
+	return PragmaFunction(name, PragmaType::PRAGMA_CALL, query, nullptr, move(arguments), move(varargs));
+}
+
+PragmaFunction PragmaFunction::PragmaCall(const string &name, pragma_function_t function, vector<LogicalType> arguments,
+                                          LogicalType varargs) {
+	return PragmaFunction(name, PragmaType::PRAGMA_CALL, nullptr, function, move(arguments), move(varargs));
+}
+
+PragmaFunction PragmaFunction::PragmaStatement(const string &name, pragma_query_t query) {
+	vector<LogicalType> types;
+	return PragmaFunction(name, PragmaType::PRAGMA_STATEMENT, query, nullptr, move(types), LogicalType::INVALID);
+}
+
+PragmaFunction PragmaFunction::PragmaStatement(const string &name, pragma_function_t function) {
+	vector<LogicalType> types;
+	return PragmaFunction(name, PragmaType::PRAGMA_STATEMENT, nullptr, function, move(types), LogicalType::INVALID);
+}
+
+string PragmaFunction::ToString() {
+	switch (type) {
+	case PragmaType::PRAGMA_STATEMENT:
+		return StringUtil::Format("PRAGMA %s", name);
+	case PragmaType::PRAGMA_CALL: {
+		return StringUtil::Format("PRAGMA %s", SimpleNamedParameterFunction::ToString());
+	}
+	default:
+		return "UNKNOWN";
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+struct Base64EncodeOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
+		auto result_str = StringVector::EmptyString(result, Blob::ToBase64Size(input));
+		Blob::ToBase64(input, result_str.GetDataWriteable());
+		result_str.Finalize();
+		return result_str;
+	}
+};
+
+struct Base64DecodeOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
+		auto result_size = Blob::FromBase64Size(input);
+		auto result_blob = StringVector::EmptyString(result, result_size);
+		Blob::FromBase64(input, (data_ptr_t)result_blob.GetDataWriteable(), result_size);
+		result_blob.Finalize();
+		return result_blob;
+	}
+};
+
+static void Base64EncodeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	// decode is also a nop cast, but requires verification if the provided string is actually
+	UnaryExecutor::ExecuteString<string_t, string_t, Base64EncodeOperator>(args.data[0], result, args.size());
+}
+
+static void Base64DecodeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	// decode is also a nop cast, but requires verification if the provided string is actually
+	UnaryExecutor::ExecuteString<string_t, string_t, Base64DecodeOperator>(args.data[0], result, args.size());
+}
+
+void Base64Fun::RegisterFunction(BuiltinFunctions &set) {
+	// base64 encode
+	ScalarFunction to_base64({LogicalType::BLOB}, LogicalType::VARCHAR, Base64EncodeFunction);
+	set.AddFunction({"base64", "to_base64"}, to_base64); // to_base64 is a mysql alias
+
+	set.AddFunction(ScalarFunction("from_base64", {LogicalType::VARCHAR}, LogicalType::BLOB, Base64DecodeFunction));
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+static void EncodeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	// encode is essentially a nop cast from varchar to blob
+	// we only need to reinterpret the data using the blob type
+	result.Reinterpret(args.data[0]);
+}
+
+struct BlobDecodeOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input) {
+		auto input_data = input.GetDataUnsafe();
+		auto input_length = input.GetSize();
+		if (Utf8Proc::Analyze(input_data, input_length) == UnicodeType::INVALID) {
+			throw ConversionException(
+			    "Failure in decode: could not convert blob to UTF8 string, the blob contained invalid UTF8 characters");
+		}
+		return input;
+	}
+};
+
+static void DecodeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	// decode is also a nop cast, but requires verification if the provided string is actually
+	UnaryExecutor::Execute<string_t, string_t, BlobDecodeOperator>(args.data[0], result, args.size());
+	StringVector::AddHeapReference(result, args.data[0]);
+}
+
+void EncodeFun::RegisterFunction(BuiltinFunctions &set) {
+	// encode goes from varchar -> blob, this never fails
+	set.AddFunction(ScalarFunction("encode", {LogicalType::VARCHAR}, LogicalType::BLOB, EncodeFunction));
+	// decode goes from blob -> varchar, this fails if the varchar is not valid utf8
+	set.AddFunction(ScalarFunction("decode", {LogicalType::BLOB}, LogicalType::VARCHAR, DecodeFunction));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void AgeFunctionStandard(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 1);
+	auto current_timestamp = Timestamp::GetCurrentTimestamp();
+
+	UnaryExecutor::ExecuteWithNulls<timestamp_t, interval_t>(input.data[0], result, input.size(),
+	                                                         [&](timestamp_t input, ValidityMask &mask, idx_t idx) {
+		                                                         if (Timestamp::IsFinite(input)) {
+			                                                         return Interval::GetAge(current_timestamp, input);
+		                                                         } else {
+			                                                         mask.SetInvalid(idx);
+			                                                         return interval_t();
+		                                                         }
+	                                                         });
+}
+
+static void AgeFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 2);
+
+	BinaryExecutor::ExecuteWithNulls<timestamp_t, timestamp_t, interval_t>(
+	    input.data[0], input.data[1], result, input.size(),
+	    [&](timestamp_t input1, timestamp_t input2, ValidityMask &mask, idx_t idx) {
+		    if (Timestamp::IsFinite(input1) && Timestamp::IsFinite(input2)) {
+			    return Interval::GetAge(input1, input2);
+		    } else {
+			    mask.SetInvalid(idx);
+			    return interval_t();
+		    }
+	    });
+}
+
+void AgeFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet age("age");
+	age.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::INTERVAL, AgeFunctionStandard));
+	age.AddFunction(
+	    ScalarFunction({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP}, LogicalType::INTERVAL, AgeFunction));
+	set.AddFunction(age);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct CurrentBindData : public FunctionData {
+	ClientContext &context;
+
+	explicit CurrentBindData(ClientContext &context) : context(context) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<CurrentBindData>(context);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		return true;
+	}
+};
+
+static timestamp_t GetTransactionTimestamp(ExpressionState &state) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (CurrentBindData &)*func_expr.bind_info;
+	return info.context.ActiveTransaction().start_timestamp;
+}
+
+static void CurrentTimeFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 0);
+
+	auto val = Value::TIME(Timestamp::GetTime(GetTransactionTimestamp(state)));
+	result.Reference(val);
+}
+
+static void CurrentDateFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 0);
+
+	auto val = Value::DATE(Timestamp::GetDate(GetTransactionTimestamp(state)));
+	result.Reference(val);
+}
+
+static void CurrentTimestampFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 0);
+
+	auto val = Value::TIMESTAMP(GetTransactionTimestamp(state));
+	result.Reference(val);
+}
+
+unique_ptr<FunctionData> BindCurrentTime(ClientContext &context, ScalarFunction &bound_function,
+                                         vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<CurrentBindData>(context);
+}
+
+void CurrentTimeFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("get_current_time", {}, LogicalType::TIME, CurrentTimeFunction, false, BindCurrentTime));
+}
+
+void CurrentDateFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("current_date", {}, LogicalType::DATE, CurrentDateFunction, false, BindCurrentTime));
+}
+
+void CurrentTimestampFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    {"now", "get_current_timestamp"},
+	    ScalarFunction({}, LogicalType::TIMESTAMP, CurrentTimestampFunction, false, false, BindCurrentTime));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+// This function is an implementation of the "period-crossing" date difference function from T-SQL
+// https://docs.microsoft.com/en-us/sql/t-sql/functions/datediff-transact-sql?view=sql-server-ver15
+struct DateDiff {
+	template <class TA, class TB, class TR, class OP>
+	static inline void BinaryExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+		BinaryExecutor::ExecuteWithNulls<TA, TB, TR>(
+		    left, right, result, count, [&](TA startdate, TB enddate, ValidityMask &mask, idx_t idx) {
+			    if (Value::IsFinite(startdate) && Value::IsFinite(enddate)) {
+				    return OP::template Operation<TA, TB, TR>(startdate, enddate);
+			    } else {
+				    mask.SetInvalid(idx);
+				    return TR();
+			    }
+		    });
+	}
+
+	struct YearOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::ExtractYear(enddate) - Date::ExtractYear(startdate);
+		}
+	};
+
+	struct MonthOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			int32_t start_year, start_month, start_day;
+			Date::Convert(startdate, start_year, start_month, start_day);
+			int32_t end_year, end_month, end_day;
+			Date::Convert(enddate, end_year, end_month, end_day);
+
+			return (end_year * 12 + end_month - 1) - (start_year * 12 + start_month - 1);
+		}
+	};
+
+	struct DayOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::EpochDays(enddate) - Date::EpochDays(startdate);
+		}
+	};
+
+	struct DecadeOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::ExtractYear(enddate) / 10 - Date::ExtractYear(startdate) / 10;
+		}
+	};
+
+	struct CenturyOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::ExtractYear(enddate) / 100 - Date::ExtractYear(startdate) / 100;
+		}
+	};
+
+	struct MilleniumOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::ExtractYear(enddate) / 1000 - Date::ExtractYear(startdate) / 1000;
+		}
+	};
+
+	struct QuarterOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			int32_t start_year, start_month, start_day;
+			Date::Convert(startdate, start_year, start_month, start_day);
+			int32_t end_year, end_month, end_day;
+			Date::Convert(enddate, end_year, end_month, end_day);
+
+			return (end_year * 12 + end_month - 1) / Interval::MONTHS_PER_QUARTER -
+			       (start_year * 12 + start_month - 1) / Interval::MONTHS_PER_QUARTER;
+		}
+	};
+
+	struct WeekOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::Epoch(enddate) / Interval::SECS_PER_WEEK - Date::Epoch(startdate) / Interval::SECS_PER_WEEK;
+		}
+	};
+
+	struct ISOYearOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::ExtractISOYearNumber(enddate) - Date::ExtractISOYearNumber(startdate);
+		}
+	};
+
+	struct MicrosecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::EpochNanoseconds(enddate) / Interval::NANOS_PER_MICRO -
+			       Date::EpochNanoseconds(startdate) / Interval::NANOS_PER_MICRO;
+		}
+	};
+
+	struct MillisecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::EpochNanoseconds(enddate) / Interval::NANOS_PER_MSEC -
+			       Date::EpochNanoseconds(startdate) / Interval::NANOS_PER_MSEC;
+		}
+	};
+
+	struct SecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::Epoch(enddate) - Date::Epoch(startdate);
+		}
+	};
+
+	struct MinutesOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::Epoch(enddate) / Interval::SECS_PER_MINUTE -
+			       Date::Epoch(startdate) / Interval::SECS_PER_MINUTE;
+		}
+	};
+
+	struct HoursOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return Date::Epoch(enddate) / Interval::SECS_PER_HOUR - Date::Epoch(startdate) / Interval::SECS_PER_HOUR;
+		}
+	};
+};
+
+// TIMESTAMP specialisations
+template <>
+int64_t DateDiff::YearOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return YearOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate), Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::MonthOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return MonthOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                         Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::DayOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return DayOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate), Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::DecadeOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return DecadeOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                          Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::CenturyOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return CenturyOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                           Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::MilleniumOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return MilleniumOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                             Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::QuarterOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return QuarterOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                           Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::WeekOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return WeekOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate), Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::ISOYearOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return ISOYearOperator::Operation<date_t, date_t, int64_t>(Timestamp::GetDate(startdate),
+	                                                           Timestamp::GetDate(enddate));
+}
+
+template <>
+int64_t DateDiff::MicrosecondsOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate);
+}
+
+template <>
+int64_t DateDiff::MillisecondsOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return Timestamp::GetEpochMs(enddate) - Timestamp::GetEpochMs(startdate);
+}
+
+template <>
+int64_t DateDiff::SecondsOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return Timestamp::GetEpochSeconds(enddate) - Timestamp::GetEpochSeconds(startdate);
+}
+
+template <>
+int64_t DateDiff::MinutesOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return Timestamp::GetEpochSeconds(enddate) / Interval::SECS_PER_MINUTE -
+	       Timestamp::GetEpochSeconds(startdate) / Interval::SECS_PER_MINUTE;
+}
+
+template <>
+int64_t DateDiff::HoursOperator::Operation(timestamp_t startdate, timestamp_t enddate) {
+	return Timestamp::GetEpochSeconds(enddate) / Interval::SECS_PER_HOUR -
+	       Timestamp::GetEpochSeconds(startdate) / Interval::SECS_PER_HOUR;
+}
+
+// TIME specialisations
+template <>
+int64_t DateDiff::YearOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"year\" not recognized");
+}
+
+template <>
+int64_t DateDiff::MonthOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"month\" not recognized");
+}
+
+template <>
+int64_t DateDiff::DayOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"day\" not recognized");
+}
+
+template <>
+int64_t DateDiff::DecadeOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"decade\" not recognized");
+}
+
+template <>
+int64_t DateDiff::CenturyOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"century\" not recognized");
+}
+
+template <>
+int64_t DateDiff::MilleniumOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"millennium\" not recognized");
+}
+
+template <>
+int64_t DateDiff::QuarterOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"quarter\" not recognized");
+}
+
+template <>
+int64_t DateDiff::WeekOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"week\" not recognized");
+}
+
+template <>
+int64_t DateDiff::ISOYearOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"isoyear\" not recognized");
+}
+
+template <>
+int64_t DateDiff::MicrosecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros - startdate.micros;
+}
+
+template <>
+int64_t DateDiff::MillisecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros / Interval::MICROS_PER_MSEC - startdate.micros / Interval::MICROS_PER_MSEC;
+}
+
+template <>
+int64_t DateDiff::SecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros / Interval::MICROS_PER_SEC - startdate.micros / Interval::MICROS_PER_SEC;
+}
+
+template <>
+int64_t DateDiff::MinutesOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros / Interval::MICROS_PER_MINUTE - startdate.micros / Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DateDiff::HoursOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros / Interval::MICROS_PER_HOUR - startdate.micros / Interval::MICROS_PER_HOUR;
+}
+
+template <typename TA, typename TB, typename TR>
+static int64_t DifferenceDates(DatePartSpecifier type, TA startdate, TB enddate) {
+	switch (type) {
+	case DatePartSpecifier::YEAR:
+		return DateDiff::YearOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MONTH:
+		return DateDiff::MonthOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		return DateDiff::DayOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::DECADE:
+		return DateDiff::DecadeOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::CENTURY:
+		return DateDiff::CenturyOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MILLENNIUM:
+		return DateDiff::MilleniumOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::QUARTER:
+		return DateDiff::QuarterOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		return DateDiff::WeekOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::ISOYEAR:
+		return DateDiff::ISOYearOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MICROSECONDS:
+		return DateDiff::MicrosecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MILLISECONDS:
+		return DateDiff::MillisecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		return DateDiff::SecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MINUTE:
+		return DateDiff::MinutesOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::HOUR:
+		return DateDiff::HoursOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATEDIFF");
+	}
+}
+
+struct DateDiffTernaryOperator {
+	template <typename TS, typename TA, typename TB, typename TR>
+	static inline TR Operation(TS part, TA startdate, TB enddate, ValidityMask &mask, idx_t idx) {
+		if (Value::IsFinite(startdate) && Value::IsFinite(enddate)) {
+			return DifferenceDates<TA, TB, TR>(GetDatePartSpecifier(part.GetString()), startdate, enddate);
+		} else {
+			mask.SetInvalid(idx);
+			return TR();
+		}
+	}
+};
+
+template <typename TA, typename TB, typename TR>
+static void DateDiffBinaryExecutor(DatePartSpecifier type, Vector &left, Vector &right, Vector &result, idx_t count) {
+	switch (type) {
+	case DatePartSpecifier::YEAR:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::YearOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MONTH:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::MonthOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::DayOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::DECADE:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::DecadeOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::CENTURY:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::CenturyOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MILLENNIUM:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::MilleniumOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::QUARTER:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::QuarterOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::WeekOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::ISOYEAR:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::ISOYearOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MICROSECONDS:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::MicrosecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MILLISECONDS:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::MillisecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::SecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MINUTE:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::MinutesOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::HOUR:
+		DateDiff::BinaryExecute<TA, TB, TR, DateDiff::HoursOperator>(left, right, result, count);
+		break;
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATEDIFF");
+	}
+}
+
+template <typename T>
+static void DateDiffFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 3);
+	auto &part_arg = args.data[0];
+	auto &start_arg = args.data[1];
+	auto &end_arg = args.data[2];
+
+	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// Common case of constant part.
+		if (ConstantVector::IsNull(part_arg)) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result, true);
+		} else {
+			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
+			DateDiffBinaryExecutor<T, T, int64_t>(type, start_arg, end_arg, result, args.size());
+		}
+	} else {
+		TernaryExecutor::ExecuteWithNulls<string_t, T, T, int64_t>(
+		    part_arg, start_arg, end_arg, result, args.size(),
+		    DateDiffTernaryOperator::Operation<string_t, T, T, int64_t>);
+	}
+}
+
+void DateDiffFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet date_diff("date_diff");
+	date_diff.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE},
+	                                     LogicalType::BIGINT, DateDiffFunction<date_t>));
+	date_diff.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP, LogicalType::TIMESTAMP},
+	                                     LogicalType::BIGINT, DateDiffFunction<timestamp_t>));
+	date_diff.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME, LogicalType::TIME},
+	                                     LogicalType::BIGINT, DateDiffFunction<dtime_t>));
+	set.AddFunction(date_diff);
+
+	date_diff.name = "datediff";
+	set.AddFunction(date_diff);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+bool TryGetDatePartSpecifier(const string &specifier_p, DatePartSpecifier &result) {
+	auto specifier = StringUtil::Lower(specifier_p);
+	if (specifier == "year" || specifier == "y" || specifier == "years") {
+		result = DatePartSpecifier::YEAR;
+	} else if (specifier == "month" || specifier == "mon" || specifier == "months" || specifier == "mons") {
+		result = DatePartSpecifier::MONTH;
+	} else if (specifier == "day" || specifier == "days" || specifier == "d" || specifier == "dayofmonth") {
+		result = DatePartSpecifier::DAY;
+	} else if (specifier == "decade" || specifier == "decades") {
+		result = DatePartSpecifier::DECADE;
+	} else if (specifier == "century" || specifier == "centuries") {
+		result = DatePartSpecifier::CENTURY;
+	} else if (specifier == "millennium" || specifier == "millennia" || specifier == "millenium") {
+		result = DatePartSpecifier::MILLENNIUM;
+	} else if (specifier == "microseconds" || specifier == "microsecond") {
+		result = DatePartSpecifier::MICROSECONDS;
+	} else if (specifier == "milliseconds" || specifier == "millisecond" || specifier == "ms" || specifier == "msec" ||
+	           specifier == "msecs") {
+		result = DatePartSpecifier::MILLISECONDS;
+	} else if (specifier == "second" || specifier == "seconds" || specifier == "s") {
+		result = DatePartSpecifier::SECOND;
+	} else if (specifier == "minute" || specifier == "minutes" || specifier == "m") {
+		result = DatePartSpecifier::MINUTE;
+	} else if (specifier == "hour" || specifier == "hours" || specifier == "h") {
+		result = DatePartSpecifier::HOUR;
+	} else if (specifier == "epoch") {
+		// seconds since 1970-01-01
+		result = DatePartSpecifier::EPOCH;
+	} else if (specifier == "dow" || specifier == "dayofweek" || specifier == "weekday") {
+		// day of the week (Sunday = 0, Saturday = 6)
+		result = DatePartSpecifier::DOW;
+	} else if (specifier == "isodow") {
+		// isodow (Monday = 1, Sunday = 7)
+		result = DatePartSpecifier::ISODOW;
+	} else if (specifier == "week" || specifier == "weeks" || specifier == "w" || specifier == "weekofyear") {
+		// ISO week number
+		result = DatePartSpecifier::WEEK;
+	} else if (specifier == "doy" || specifier == "dayofyear") {
+		// day of the year (1-365/366)
+		result = DatePartSpecifier::DOY;
+	} else if (specifier == "quarter" || specifier == "quarters") {
+		// quarter of the year (1-4)
+		result = DatePartSpecifier::QUARTER;
+	} else if (specifier == "yearweek") {
+		// Combined isoyear and isoweek YYYYWW
+		result = DatePartSpecifier::YEARWEEK;
+	} else if (specifier == "isoyear") {
+		// ISO year (first week of the year may be in previous year)
+		result = DatePartSpecifier::ISOYEAR;
+	} else if (specifier == "era") {
+		result = DatePartSpecifier::ERA;
+	} else if (specifier == "timezone") {
+		result = DatePartSpecifier::TIMEZONE;
+	} else if (specifier == "timezone_hour") {
+		result = DatePartSpecifier::TIMEZONE_HOUR;
+	} else if (specifier == "timezone_minute") {
+		result = DatePartSpecifier::TIMEZONE_MINUTE;
+	} else {
+		return false;
+	}
+	return true;
+}
+
+DatePartSpecifier GetDatePartSpecifier(const string &specifier) {
+	DatePartSpecifier result;
+	if (!TryGetDatePartSpecifier(specifier, result)) {
+		throw ConversionException("extract specifier \"%s\" not recognized", specifier);
+	}
+	return result;
+}
+
+DatePartSpecifier GetDateTypePartSpecifier(const string &specifier, LogicalType &type) {
+	const auto part = GetDatePartSpecifier(specifier);
+	switch (type.id()) {
+	case LogicalType::TIMESTAMP:
+	case LogicalType::TIMESTAMP_TZ:
+		return part;
+	case LogicalType::DATE:
+		switch (part) {
+		case DatePartSpecifier::YEAR:
+		case DatePartSpecifier::MONTH:
+		case DatePartSpecifier::DAY:
+		case DatePartSpecifier::DECADE:
+		case DatePartSpecifier::CENTURY:
+		case DatePartSpecifier::MILLENNIUM:
+		case DatePartSpecifier::DOW:
+		case DatePartSpecifier::ISODOW:
+		case DatePartSpecifier::ISOYEAR:
+		case DatePartSpecifier::WEEK:
+		case DatePartSpecifier::QUARTER:
+		case DatePartSpecifier::DOY:
+		case DatePartSpecifier::YEARWEEK:
+		case DatePartSpecifier::ERA:
+			return part;
+		default:
+			break;
+		}
+		break;
+	case LogicalType::TIME:
+		switch (part) {
+		case DatePartSpecifier::MICROSECONDS:
+		case DatePartSpecifier::MILLISECONDS:
+		case DatePartSpecifier::SECOND:
+		case DatePartSpecifier::MINUTE:
+		case DatePartSpecifier::HOUR:
+		case DatePartSpecifier::EPOCH:
+		case DatePartSpecifier::TIMEZONE:
+		case DatePartSpecifier::TIMEZONE_HOUR:
+		case DatePartSpecifier::TIMEZONE_MINUTE:
+			return part;
+		default:
+			break;
+		}
+		break;
+	case LogicalType::INTERVAL:
+		switch (part) {
+		case DatePartSpecifier::YEAR:
+		case DatePartSpecifier::MONTH:
+		case DatePartSpecifier::DAY:
+		case DatePartSpecifier::DECADE:
+		case DatePartSpecifier::CENTURY:
+		case DatePartSpecifier::QUARTER:
+		case DatePartSpecifier::MILLENNIUM:
+		case DatePartSpecifier::MICROSECONDS:
+		case DatePartSpecifier::MILLISECONDS:
+		case DatePartSpecifier::SECOND:
+		case DatePartSpecifier::MINUTE:
+		case DatePartSpecifier::HOUR:
+		case DatePartSpecifier::EPOCH:
+			return part;
+		default:
+			break;
+		}
+		break;
+	default:
+		break;
+	}
+
+	throw NotImplementedException("\"%s\" units \"%s\" not recognized", LogicalTypeIdToString(type.id()), specifier);
+}
+
+template <int64_t MIN, int64_t MAX>
+static unique_ptr<BaseStatistics> PropagateSimpleDatePartStatistics(vector<unique_ptr<BaseStatistics>> &child_stats) {
+	// we can always propagate simple date part statistics
+	// since the min and max can never exceed these bounds
+	auto result = make_unique<NumericStatistics>(LogicalType::BIGINT, Value::BIGINT(MIN), Value::BIGINT(MAX),
+	                                             StatisticsType::LOCAL_STATS);
+	if (!child_stats[0]) {
+		// if there are no child stats, we don't know
+		result->validity_stats = make_unique<ValidityStatistics>(true);
+	} else if (child_stats[0]->validity_stats) {
+		result->validity_stats = child_stats[0]->validity_stats->Copy();
+	}
+	return move(result);
+}
+
+struct DatePart {
+	template <class T, class OP>
+	static unique_ptr<BaseStatistics> PropagateDatePartStatistics(vector<unique_ptr<BaseStatistics>> &child_stats) {
+		// we can only propagate complex date part stats if the child has stats
+		if (!child_stats[0]) {
+			return nullptr;
+		}
+		auto &nstats = (NumericStatistics &)*child_stats[0];
+		if (nstats.min.IsNull() || nstats.max.IsNull()) {
+			return nullptr;
+		}
+		// run the operator on both the min and the max, this gives us the [min, max] bound
+		auto min = nstats.min.GetValueUnsafe<T>();
+		auto max = nstats.max.GetValueUnsafe<T>();
+		if (min > max) {
+			return nullptr;
+		}
+		// Infinities prevent us from computing generic ranges
+		if (!Value::IsFinite(min) || !Value::IsFinite(max)) {
+			return nullptr;
+		}
+		auto min_part = OP::template Operation<T, int64_t>(min);
+		auto max_part = OP::template Operation<T, int64_t>(max);
+		auto result = make_unique<NumericStatistics>(LogicalType::BIGINT, Value::BIGINT(min_part),
+		                                             Value::BIGINT(max_part), StatisticsType::LOCAL_STATS);
+		if (child_stats[0]->validity_stats) {
+			result->validity_stats = child_stats[0]->validity_stats->Copy();
+		}
+		return move(result);
+	}
+
+	template <typename OP>
+	struct PartOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input, ValidityMask &mask, idx_t idx, void *dataptr) {
+			if (Value::IsFinite(input)) {
+				return OP::template Operation<TA, TR>(input);
+			} else {
+				mask.SetInvalid(idx);
+				return TR();
+			}
+		}
+	};
+
+	template <class TA, class TR, class OP>
+	static void UnaryFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+		D_ASSERT(input.ColumnCount() >= 1);
+		using IOP = PartOperator<OP>;
+		UnaryExecutor::GenericExecute<TA, TR, IOP>(input.data[0], result, input.size(), nullptr, true);
+	}
+
+	struct YearOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractYear(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, YearOperator>(input.child_stats);
+		}
+	};
+
+	struct MonthOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractMonth(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			// min/max of month operator is [1, 12]
+			return PropagateSimpleDatePartStatistics<1, 12>(input.child_stats);
+		}
+	};
+
+	struct DayOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractDay(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			// min/max of day operator is [1, 31]
+			return PropagateSimpleDatePartStatistics<1, 31>(input.child_stats);
+		}
+	};
+
+	struct DecadeOperator {
+		// From the PG docs: "The year field divided by 10"
+		template <typename TR>
+		static inline TR DecadeFromYear(TR yyyy) {
+			return yyyy / 10;
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return DecadeFromYear(YearOperator::Operation<TA, TR>(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, DecadeOperator>(input.child_stats);
+		}
+	};
+
+	struct CenturyOperator {
+		// From the PG docs:
+		// "The first century starts at 0001-01-01 00:00:00 AD, although they did not know it at the time.
+		// This definition applies to all Gregorian calendar countries.
+		// There is no century number 0, you go from -1 century to 1 century.
+		// If you disagree with this, please write your complaint to: Pope, Cathedral Saint-Peter of Roma, Vatican."
+		// (To be fair, His Holiness had nothing to do with this -
+		// it was the lack of zero in the counting systems of the time...)
+		template <typename TR>
+		static inline TR CenturyFromYear(TR yyyy) {
+			if (yyyy > 0) {
+				return ((yyyy - 1) / 100) + 1;
+			} else {
+				return (yyyy / 100) - 1;
+			}
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return CenturyFromYear(YearOperator::Operation<TA, TR>(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, CenturyOperator>(input.child_stats);
+		}
+	};
+
+	struct MillenniumOperator {
+		// See the century comment
+		template <typename TR>
+		static inline TR MillenniumFromYear(TR yyyy) {
+			if (yyyy > 0) {
+				return ((yyyy - 1) / 1000) + 1;
+			} else {
+				return (yyyy / 1000) - 1;
+			}
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return MillenniumFromYear<TR>(YearOperator::Operation<TA, TR>(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, MillenniumOperator>(input.child_stats);
+		}
+	};
+
+	struct QuarterOperator {
+		template <class TR>
+		static inline TR QuarterFromMonth(TR mm) {
+			return (mm - 1) / Interval::MONTHS_PER_QUARTER + 1;
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return QuarterFromMonth(Date::ExtractMonth(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			// min/max of quarter operator is [1, 4]
+			return PropagateSimpleDatePartStatistics<1, 4>(input.child_stats);
+		}
+	};
+
+	struct DayOfWeekOperator {
+		template <class TR>
+		static inline TR DayOfWeekFromISO(TR isodow) {
+			// day of the week (Sunday = 0, Saturday = 6)
+			// turn sunday into 0 by doing mod 7
+			return isodow % 7;
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return DayOfWeekFromISO(Date::ExtractISODayOfTheWeek(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 6>(input.child_stats);
+		}
+	};
+
+	struct ISODayOfWeekOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			// isodow (Monday = 1, Sunday = 7)
+			return Date::ExtractISODayOfTheWeek(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<1, 7>(input.child_stats);
+		}
+	};
+
+	struct DayOfYearOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractDayOfTheYear(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<1, 366>(input.child_stats);
+		}
+	};
+
+	struct WeekOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractISOWeekNumber(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<1, 54>(input.child_stats);
+		}
+	};
+
+	struct ISOYearOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::ExtractISOYearNumber(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, ISOYearOperator>(input.child_stats);
+		}
+	};
+
+	struct YearWeekOperator {
+		template <class TR>
+		static inline TR YearWeekFromParts(TR yyyy, TR ww) {
+			return yyyy * 100 + ((yyyy > 0) ? ww : -ww);
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t yyyy, ww;
+			Date::ExtractISOYearWeek(input, yyyy, ww);
+			return YearWeekFromParts(yyyy, ww);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, YearWeekOperator>(input.child_stats);
+		}
+	};
+
+	struct MicrosecondsOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60000000>(input.child_stats);
+		}
+	};
+
+	struct MillisecondsOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60000>(input.child_stats);
+		}
+	};
+
+	struct SecondsOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
+		}
+	};
+
+	struct MinutesOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 60>(input.child_stats);
+		}
+	};
+
+	struct HoursOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 24>(input.child_stats);
+		}
+	};
+
+	struct EpochOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::Epoch(input);
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateDatePartStatistics<T, EpochOperator>(input.child_stats);
+		}
+	};
+
+	struct EraOperator {
+		template <class TR>
+		static inline TR EraFromYear(TR yyyy) {
+			return yyyy > 0 ? 1 : 0;
+		}
+
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return EraFromYear(Date::ExtractYear(input));
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 1>(input.child_stats);
+		}
+	};
+
+	struct TimezoneOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			// Regular timestamps are UTC.
+			return 0;
+		}
+
+		template <class T>
+		static unique_ptr<BaseStatistics> PropagateStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+			return PropagateSimpleDatePartStatistics<0, 0>(input.child_stats);
+		}
+	};
+
+	// These are all zero and have the same restrictions
+	using TimezoneHourOperator = TimezoneOperator;
+	using TimezoneMinuteOperator = TimezoneOperator;
+
+	struct StructOperator {
+		using part_codes_t = vector<DatePartSpecifier>;
+		using part_mask_t = uint64_t;
+
+		enum MaskBits : uint8_t {
+			YMD = 1 << 0,
+			DOW = 1 << 1,
+			DOY = 1 << 2,
+			EPOCH = 1 << 3,
+			TIME = 1 << 4,
+			ZONE = 1 << 5,
+			ISO = 1 << 6
+		};
+
+		static part_mask_t GetMask(const part_codes_t &part_codes) {
+			part_mask_t mask = 0;
+			for (const auto &part_code : part_codes) {
+				switch (part_code) {
+				case DatePartSpecifier::YEAR:
+				case DatePartSpecifier::MONTH:
+				case DatePartSpecifier::DAY:
+				case DatePartSpecifier::DECADE:
+				case DatePartSpecifier::CENTURY:
+				case DatePartSpecifier::MILLENNIUM:
+				case DatePartSpecifier::QUARTER:
+				case DatePartSpecifier::ERA:
+					mask |= YMD;
+					break;
+				case DatePartSpecifier::YEARWEEK:
+				case DatePartSpecifier::WEEK:
+				case DatePartSpecifier::ISOYEAR:
+					mask |= ISO;
+					break;
+				case DatePartSpecifier::DOW:
+				case DatePartSpecifier::ISODOW:
+					mask |= DOW;
+					break;
+				case DatePartSpecifier::DOY:
+					mask |= DOY;
+					break;
+				case DatePartSpecifier::EPOCH:
+					mask |= EPOCH;
+					break;
+				case DatePartSpecifier::MICROSECONDS:
+				case DatePartSpecifier::MILLISECONDS:
+				case DatePartSpecifier::SECOND:
+				case DatePartSpecifier::MINUTE:
+				case DatePartSpecifier::HOUR:
+					mask |= TIME;
+					break;
+				case DatePartSpecifier::TIMEZONE:
+				case DatePartSpecifier::TIMEZONE_HOUR:
+				case DatePartSpecifier::TIMEZONE_MINUTE:
+					mask |= ZONE;
+					break;
+				}
+			}
+			return mask;
+		}
+
+		template <typename P>
+		static inline P HasPartValue(P *part_values, DatePartSpecifier part) {
+			return part_values[int(part)];
+		}
+
+		template <class TA, class TR>
+		static inline void Operation(TR **part_values, const TA &input, const idx_t idx, const part_mask_t mask) {
+			TR *part_data;
+			// YMD calculations
+			int32_t yyyy = 1970;
+			int32_t mm = 0;
+			int32_t dd = 1;
+			if (mask & YMD) {
+				Date::Convert(input, yyyy, mm, dd);
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::YEAR))) {
+					part_data[idx] = yyyy;
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::MONTH))) {
+					part_data[idx] = mm;
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::DAY))) {
+					part_data[idx] = dd;
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::DECADE))) {
+					part_data[idx] = DecadeOperator::DecadeFromYear(yyyy);
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::CENTURY))) {
+					part_data[idx] = CenturyOperator::CenturyFromYear(yyyy);
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::MILLENNIUM))) {
+					part_data[idx] = MillenniumOperator::MillenniumFromYear(yyyy);
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::QUARTER))) {
+					part_data[idx] = QuarterOperator::QuarterFromMonth(mm);
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::ERA))) {
+					part_data[idx] = EraOperator::EraFromYear(yyyy);
+				}
+			}
+
+			// Week calculations
+			if (mask & DOW) {
+				auto isodow = Date::ExtractISODayOfTheWeek(input);
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::DOW))) {
+					part_data[idx] = DayOfWeekOperator::DayOfWeekFromISO(isodow);
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::ISODOW))) {
+					part_data[idx] = isodow;
+				}
+			}
+
+			// ISO calculations
+			if (mask & ISO) {
+				int32_t ww = 0;
+				int32_t iyyy = 0;
+				Date::ExtractISOYearWeek(input, iyyy, ww);
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::WEEK))) {
+					part_data[idx] = ww;
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::ISOYEAR))) {
+					part_data[idx] = iyyy;
+				}
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::YEARWEEK))) {
+					part_data[idx] = YearWeekOperator::YearWeekFromParts(iyyy, ww);
+				}
+			}
+
+			if (mask & EPOCH) {
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::EPOCH))) {
+					part_data[idx] = Date::Epoch(input);
+				}
+			}
+			if (mask & DOY) {
+				if ((part_data = HasPartValue(part_values, DatePartSpecifier::DOY))) {
+					part_data[idx] = Date::ExtractDayOfTheYear(input);
+				}
+			}
+		}
+	};
+};
+
+template <class T>
+static void LastYearFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	int32_t last_year = 0;
+	UnaryExecutor::ExecuteWithNulls<T, int64_t>(args.data[0], result, args.size(),
+	                                            [&](T input, ValidityMask &mask, idx_t idx) {
+		                                            if (Value::IsFinite(input)) {
+			                                            return Date::ExtractYear(input, &last_year);
+		                                            } else {
+			                                            mask.SetInvalid(idx);
+			                                            return 0;
+		                                            }
+	                                            });
+}
+
+template <>
+int64_t DatePart::YearOperator::Operation(timestamp_t input) {
+	return YearOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::YearOperator::Operation(interval_t input) {
+	return input.months / Interval::MONTHS_PER_YEAR;
+}
+
+template <>
+int64_t DatePart::YearOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"year\" not recognized");
+}
+
+template <>
+int64_t DatePart::MonthOperator::Operation(timestamp_t input) {
+	return MonthOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::MonthOperator::Operation(interval_t input) {
+	return input.months % Interval::MONTHS_PER_YEAR;
+}
+
+template <>
+int64_t DatePart::MonthOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"month\" not recognized");
+}
+
+template <>
+int64_t DatePart::DayOperator::Operation(timestamp_t input) {
+	return DayOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::DayOperator::Operation(interval_t input) {
+	return input.days;
+}
+
+template <>
+int64_t DatePart::DayOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"day\" not recognized");
+}
+
+template <>
+int64_t DatePart::DecadeOperator::Operation(interval_t input) {
+	return input.months / Interval::MONTHS_PER_DECADE;
+}
+
+template <>
+int64_t DatePart::DecadeOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"decade\" not recognized");
+}
+
+template <>
+int64_t DatePart::CenturyOperator::Operation(interval_t input) {
+	return input.months / Interval::MONTHS_PER_CENTURY;
+}
+
+template <>
+int64_t DatePart::CenturyOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"century\" not recognized");
+}
+
+template <>
+int64_t DatePart::MillenniumOperator::Operation(interval_t input) {
+	return input.months / Interval::MONTHS_PER_MILLENIUM;
+}
+
+template <>
+int64_t DatePart::MillenniumOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"millennium\" not recognized");
+}
+
+template <>
+int64_t DatePart::QuarterOperator::Operation(timestamp_t input) {
+	return QuarterOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::QuarterOperator::Operation(interval_t input) {
+	return MonthOperator::Operation<interval_t, int64_t>(input) / Interval::MONTHS_PER_QUARTER + 1;
+}
+
+template <>
+int64_t DatePart::QuarterOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"quarter\" not recognized");
+}
+
+template <>
+int64_t DatePart::DayOfWeekOperator::Operation(timestamp_t input) {
+	return DayOfWeekOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::DayOfWeekOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"dow\" not recognized");
+}
+
+template <>
+int64_t DatePart::DayOfWeekOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"dow\" not recognized");
+}
+
+template <>
+int64_t DatePart::ISODayOfWeekOperator::Operation(timestamp_t input) {
+	return ISODayOfWeekOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::ISODayOfWeekOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"isodow\" not recognized");
+}
+
+template <>
+int64_t DatePart::ISODayOfWeekOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"isodow\" not recognized");
+}
+
+template <>
+int64_t DatePart::DayOfYearOperator::Operation(timestamp_t input) {
+	return DayOfYearOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::DayOfYearOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"doy\" not recognized");
+}
+
+template <>
+int64_t DatePart::DayOfYearOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"doy\" not recognized");
+}
+
+template <>
+int64_t DatePart::WeekOperator::Operation(timestamp_t input) {
+	return WeekOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::WeekOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"week\" not recognized");
+}
+
+template <>
+int64_t DatePart::WeekOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"week\" not recognized");
+}
+
+template <>
+int64_t DatePart::ISOYearOperator::Operation(timestamp_t input) {
+	return ISOYearOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::ISOYearOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"isoyear\" not recognized");
+}
+
+template <>
+int64_t DatePart::ISOYearOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"isoyear\" not recognized");
+}
+
+template <>
+int64_t DatePart::YearWeekOperator::Operation(timestamp_t input) {
+	return YearWeekOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::YearWeekOperator::Operation(interval_t input) {
+	const auto yyyy = YearOperator::Operation<interval_t, int64_t>(input);
+	const auto ww = WeekOperator::Operation<interval_t, int64_t>(input);
+	return YearWeekOperator::YearWeekFromParts<int64_t>(yyyy, ww);
+}
+
+template <>
+int64_t DatePart::YearWeekOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"yearweek\" not recognized");
+}
+
+template <>
+int64_t DatePart::MicrosecondsOperator::Operation(timestamp_t input) {
+	auto time = Timestamp::GetTime(input);
+	// remove everything but the second & microsecond part
+	return time.micros % Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::MicrosecondsOperator::Operation(interval_t input) {
+	// remove everything but the second & microsecond part
+	return input.micros % Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::MicrosecondsOperator::Operation(dtime_t input) {
+	// remove everything but the second & microsecond part
+	return input.micros % Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::MillisecondsOperator::Operation(timestamp_t input) {
+	return MicrosecondsOperator::Operation<timestamp_t, int64_t>(input) / Interval::MICROS_PER_MSEC;
+}
+
+template <>
+int64_t DatePart::MillisecondsOperator::Operation(interval_t input) {
+	return MicrosecondsOperator::Operation<interval_t, int64_t>(input) / Interval::MICROS_PER_MSEC;
+}
+
+template <>
+int64_t DatePart::MillisecondsOperator::Operation(dtime_t input) {
+	return MicrosecondsOperator::Operation<dtime_t, int64_t>(input) / Interval::MICROS_PER_MSEC;
+}
+
+template <>
+int64_t DatePart::SecondsOperator::Operation(timestamp_t input) {
+	return MicrosecondsOperator::Operation<timestamp_t, int64_t>(input) / Interval::MICROS_PER_SEC;
+}
+
+template <>
+int64_t DatePart::SecondsOperator::Operation(interval_t input) {
+	return MicrosecondsOperator::Operation<interval_t, int64_t>(input) / Interval::MICROS_PER_SEC;
+}
+
+template <>
+int64_t DatePart::SecondsOperator::Operation(dtime_t input) {
+	return MicrosecondsOperator::Operation<dtime_t, int64_t>(input) / Interval::MICROS_PER_SEC;
+}
+
+template <>
+int64_t DatePart::MinutesOperator::Operation(timestamp_t input) {
+	auto time = Timestamp::GetTime(input);
+	// remove the hour part, and truncate to minutes
+	return (time.micros % Interval::MICROS_PER_HOUR) / Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::MinutesOperator::Operation(interval_t input) {
+	// remove the hour part, and truncate to minutes
+	return (input.micros % Interval::MICROS_PER_HOUR) / Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::MinutesOperator::Operation(dtime_t input) {
+	// remove the hour part, and truncate to minutes
+	return (input.micros % Interval::MICROS_PER_HOUR) / Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DatePart::HoursOperator::Operation(timestamp_t input) {
+	return Timestamp::GetTime(input).micros / Interval::MICROS_PER_HOUR;
+}
+
+template <>
+int64_t DatePart::HoursOperator::Operation(interval_t input) {
+	return input.micros / Interval::MICROS_PER_HOUR;
+}
+
+template <>
+int64_t DatePart::HoursOperator::Operation(dtime_t input) {
+	return input.micros / Interval::MICROS_PER_HOUR;
+}
+
+template <>
+int64_t DatePart::EpochOperator::Operation(timestamp_t input) {
+	return Timestamp::GetEpochSeconds(input);
+}
+
+template <>
+int64_t DatePart::EpochOperator::Operation(interval_t input) {
+	int64_t interval_years = input.months / Interval::MONTHS_PER_YEAR;
+	int64_t interval_days;
+	interval_days = Interval::DAYS_PER_YEAR * interval_years;
+	interval_days += Interval::DAYS_PER_MONTH * (input.months % Interval::MONTHS_PER_YEAR);
+	interval_days += input.days;
+	int64_t interval_epoch;
+	interval_epoch = interval_days * Interval::SECS_PER_DAY;
+	// we add 0.25 days per year to sort of account for leap days
+	interval_epoch += interval_years * (Interval::SECS_PER_DAY / 4);
+	interval_epoch += input.micros / Interval::MICROS_PER_SEC;
+	return interval_epoch;
+}
+
+template <>
+int64_t DatePart::EpochOperator::Operation(dtime_t input) {
+	return input.micros / Interval::MICROS_PER_SEC;
+}
+
+template <>
+unique_ptr<BaseStatistics> DatePart::EpochOperator::PropagateStatistics<dtime_t>(ClientContext &context,
+                                                                                 FunctionStatisticsInput &input) {
+	// time seconds range over a single day
+	return PropagateSimpleDatePartStatistics<0, 86400>(input.child_stats);
+}
+
+template <>
+int64_t DatePart::EraOperator::Operation(timestamp_t input) {
+	return EraOperator::Operation<date_t, int64_t>(Timestamp::GetDate(input));
+}
+
+template <>
+int64_t DatePart::EraOperator::Operation(interval_t input) {
+	throw NotImplementedException("interval units \"era\" not recognized");
+}
+
+template <>
+int64_t DatePart::EraOperator::Operation(dtime_t input) {
+	throw NotImplementedException("\"time\" units \"era\" not recognized");
+}
+
+template <>
+int64_t DatePart::TimezoneOperator::Operation(date_t input) {
+	throw NotImplementedException("\"date\" units \"timezone\" not recognized");
+}
+
+template <>
+int64_t DatePart::TimezoneOperator::Operation(interval_t input) {
+	throw NotImplementedException("\"interval\" units \"timezone\" not recognized");
+}
+
+template <>
+int64_t DatePart::TimezoneOperator::Operation(dtime_t input) {
+	return 0;
+}
+
+template <>
+void DatePart::StructOperator::Operation(int64_t **part_values, const dtime_t &input, const idx_t idx,
+                                         const part_mask_t mask) {
+	int64_t *part_data;
+	if (mask & TIME) {
+		const auto micros = MicrosecondsOperator::Operation<dtime_t, int64_t>(input);
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MICROSECONDS))) {
+			part_data[idx] = micros;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MILLISECONDS))) {
+			part_data[idx] = micros / Interval::MICROS_PER_MSEC;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::SECOND))) {
+			part_data[idx] = micros / Interval::MICROS_PER_SEC;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MINUTE))) {
+			part_data[idx] = MinutesOperator::Operation<dtime_t, int64_t>(input);
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::HOUR))) {
+			part_data[idx] = HoursOperator::Operation<dtime_t, int64_t>(input);
+		}
+	}
+
+	if (mask & EPOCH) {
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::EPOCH))) {
+			part_data[idx] = EpochOperator::Operation<dtime_t, int64_t>(input);
+			;
+		}
+	}
+
+	if (mask & ZONE) {
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::TIMEZONE))) {
+			part_data[idx] = 0;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::TIMEZONE_HOUR))) {
+			part_data[idx] = 0;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::TIMEZONE_MINUTE))) {
+			part_data[idx] = 0;
+		}
+	}
+}
+
+template <>
+void DatePart::StructOperator::Operation(int64_t **part_values, const timestamp_t &input, const idx_t idx,
+                                         const part_mask_t mask) {
+	date_t d;
+	dtime_t t;
+	Timestamp::Convert(input, d, t);
+
+	// Both define epoch, and the correct value is the sum.
+	// So mask it out and compute it separately.
+	Operation(part_values, d, idx, mask & ~EPOCH);
+	Operation(part_values, t, idx, mask & ~EPOCH);
+
+	if (mask & EPOCH) {
+		auto part_data = HasPartValue(part_values, DatePartSpecifier::EPOCH);
+		if (part_data) {
+			part_data[idx] = EpochOperator::Operation<timestamp_t, int64_t>(input);
+		}
+	}
+}
+
+template <>
+void DatePart::StructOperator::Operation(int64_t **part_values, const interval_t &input, const idx_t idx,
+                                         const part_mask_t mask) {
+	int64_t *part_data;
+	if (mask & YMD) {
+		const auto mm = input.months % Interval::MONTHS_PER_YEAR;
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::YEAR))) {
+			part_data[idx] = input.months / Interval::MONTHS_PER_YEAR;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MONTH))) {
+			part_data[idx] = mm;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::DAY))) {
+			part_data[idx] = input.days;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::DECADE))) {
+			part_data[idx] = input.months / Interval::MONTHS_PER_DECADE;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::CENTURY))) {
+			part_data[idx] = input.months / Interval::MONTHS_PER_CENTURY;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MILLENNIUM))) {
+			part_data[idx] = input.months / Interval::MONTHS_PER_MILLENIUM;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::QUARTER))) {
+			part_data[idx] = mm / Interval::MONTHS_PER_QUARTER + 1;
+		}
+	}
+
+	if (mask & TIME) {
+		const auto micros = MicrosecondsOperator::Operation<interval_t, int64_t>(input);
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MICROSECONDS))) {
+			part_data[idx] = micros;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MILLISECONDS))) {
+			part_data[idx] = micros / Interval::MICROS_PER_MSEC;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::SECOND))) {
+			part_data[idx] = micros / Interval::MICROS_PER_SEC;
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::MINUTE))) {
+			part_data[idx] = MinutesOperator::Operation<interval_t, int64_t>(input);
+		}
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::HOUR))) {
+			part_data[idx] = HoursOperator::Operation<interval_t, int64_t>(input);
+		}
+	}
+
+	if (mask & EPOCH) {
+		if ((part_data = HasPartValue(part_values, DatePartSpecifier::EPOCH))) {
+			part_data[idx] = EpochOperator::Operation<interval_t, int64_t>(input);
+		}
+	}
+}
+
+template <typename T>
+static int64_t ExtractElement(DatePartSpecifier type, T element) {
+	switch (type) {
+	case DatePartSpecifier::YEAR:
+		return DatePart::YearOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::MONTH:
+		return DatePart::MonthOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::DAY:
+		return DatePart::DayOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::DECADE:
+		return DatePart::DecadeOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::CENTURY:
+		return DatePart::CenturyOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::MILLENNIUM:
+		return DatePart::MillenniumOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::QUARTER:
+		return DatePart::QuarterOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::DOW:
+		return DatePart::DayOfWeekOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::ISODOW:
+		return DatePart::ISODayOfWeekOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::DOY:
+		return DatePart::DayOfYearOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::WEEK:
+		return DatePart::WeekOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::ISOYEAR:
+		return DatePart::ISOYearOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::YEARWEEK:
+		return DatePart::YearWeekOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::EPOCH:
+		return DatePart::EpochOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::MICROSECONDS:
+		return DatePart::MicrosecondsOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::MILLISECONDS:
+		return DatePart::MillisecondsOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::SECOND:
+		return DatePart::SecondsOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::MINUTE:
+		return DatePart::MinutesOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::HOUR:
+		return DatePart::HoursOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::ERA:
+		return DatePart::EraOperator::template Operation<T, int64_t>(element);
+	case DatePartSpecifier::TIMEZONE:
+	case DatePartSpecifier::TIMEZONE_HOUR:
+	case DatePartSpecifier::TIMEZONE_MINUTE:
+		return DatePart::TimezoneOperator::template Operation<T, int64_t>(element);
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATEPART");
+	}
+}
+
+template <typename T>
+static void DatePartFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto &spec_arg = args.data[0];
+	auto &date_arg = args.data[1];
+
+	BinaryExecutor::ExecuteWithNulls<string_t, T, int64_t>(
+	    spec_arg, date_arg, result, args.size(), [&](string_t specifier, T date, ValidityMask &mask, idx_t idx) {
+		    if (Value::IsFinite(date)) {
+			    return ExtractElement<T>(GetDatePartSpecifier(specifier.GetString()), date);
+		    } else {
+			    mask.SetInvalid(idx);
+			    return int64_t(0);
+		    }
+	    });
+}
+
+void AddGenericDatePartOperator(BuiltinFunctions &set, const string &name, scalar_function_t date_func,
+                                scalar_function_t ts_func, scalar_function_t interval_func,
+                                function_statistics_t date_stats, function_statistics_t ts_stats) {
+	ScalarFunctionSet operator_set(name);
+	operator_set.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::BIGINT, move(date_func), false, false,
+	                                        nullptr, nullptr, date_stats));
+	operator_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::BIGINT, move(ts_func), false, false,
+	                                        nullptr, nullptr, ts_stats));
+	operator_set.AddFunction(ScalarFunction({LogicalType::INTERVAL}, LogicalType::BIGINT, move(interval_func)));
+	set.AddFunction(operator_set);
+}
+
+template <class OP>
+static void AddDatePartOperator(BuiltinFunctions &set, string name) {
+	AddGenericDatePartOperator(set, name, DatePart::UnaryFunction<date_t, int64_t, OP>,
+	                           DatePart::UnaryFunction<timestamp_t, int64_t, OP>,
+	                           ScalarFunction::UnaryFunction<interval_t, int64_t, OP>,
+	                           OP::template PropagateStatistics<date_t>, OP::template PropagateStatistics<timestamp_t>);
+}
+
+void AddGenericTimePartOperator(BuiltinFunctions &set, const string &name, scalar_function_t date_func,
+                                scalar_function_t ts_func, scalar_function_t interval_func, scalar_function_t time_func,
+                                function_statistics_t date_stats, function_statistics_t ts_stats,
+                                function_statistics_t time_stats) {
+	ScalarFunctionSet operator_set(name);
+	operator_set.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::BIGINT, move(date_func), false, false,
+	                                        nullptr, nullptr, date_stats));
+	operator_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::BIGINT, move(ts_func), false, false,
+	                                        nullptr, nullptr, ts_stats));
+	operator_set.AddFunction(ScalarFunction({LogicalType::INTERVAL}, LogicalType::BIGINT, move(interval_func)));
+	operator_set.AddFunction(ScalarFunction({LogicalType::TIME}, LogicalType::BIGINT, move(time_func), false, false,
+	                                        nullptr, nullptr, time_stats));
+	set.AddFunction(operator_set);
+}
+
+template <class OP>
+static void AddTimePartOperator(BuiltinFunctions &set, string name) {
+	AddGenericTimePartOperator(
+	    set, name, DatePart::UnaryFunction<date_t, int64_t, OP>, DatePart::UnaryFunction<timestamp_t, int64_t, OP>,
+	    ScalarFunction::UnaryFunction<interval_t, int64_t, OP>, ScalarFunction::UnaryFunction<dtime_t, int64_t, OP>,
+	    OP::template PropagateStatistics<date_t>, OP::template PropagateStatistics<timestamp_t>,
+	    OP::template PropagateStatistics<dtime_t>);
+}
+
+struct LastDayOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		int32_t yyyy, mm, dd;
+		Date::Convert(input, yyyy, mm, dd);
+		yyyy += (mm / 12);
+		mm %= 12;
+		++mm;
+		return Date::FromDate(yyyy, mm, 1) - 1;
+	}
+};
+
+template <>
+date_t LastDayOperator::Operation(timestamp_t input) {
+	return LastDayOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+struct MonthNameOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return Date::MONTH_NAMES[DatePart::MonthOperator::Operation<TA, int64_t>(input) - 1];
+	}
+};
+
+struct DayNameOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return Date::DAY_NAMES[DatePart::DayOfWeekOperator::Operation<TA, int64_t>(input)];
+	}
+};
+
+struct StructDatePart {
+	using part_codes_t = vector<DatePartSpecifier>;
+
+	struct BindData : public VariableReturnBindData {
+		part_codes_t part_codes;
+
+		explicit BindData(const LogicalType &stype, const part_codes_t &part_codes_p)
+		    : VariableReturnBindData(stype), part_codes(part_codes_p) {
+		}
+
+		unique_ptr<FunctionData> Copy() const override {
+			return make_unique<BindData>(stype, part_codes);
+		}
+	};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, ScalarFunction &bound_function,
+	                                     vector<unique_ptr<Expression>> &arguments) {
+		// collect names and deconflict, construct return type
+		if (!arguments[0]->IsFoldable()) {
+			throw BinderException("%s can only take constant lists of part names", bound_function.name);
+		}
+
+		case_insensitive_set_t name_collision_set;
+		child_list_t<LogicalType> struct_children;
+		part_codes_t part_codes;
+
+		Value parts_list = ExpressionExecutor::EvaluateScalar(*arguments[0]);
+		if (parts_list.type().id() == LogicalTypeId::LIST) {
+			auto &list_children = ListValue::GetChildren(parts_list);
+			if (list_children.empty()) {
+				throw BinderException("%s requires non-empty lists of part names", bound_function.name);
+			}
+			for (const auto &part_value : list_children) {
+				if (part_value.IsNull()) {
+					throw BinderException("NULL struct entry name in %s", bound_function.name);
+				}
+				const auto part_name = part_value.ToString();
+				const auto part_code = GetDateTypePartSpecifier(part_name, arguments[1]->return_type);
+				if (name_collision_set.find(part_name) != name_collision_set.end()) {
+					throw BinderException("Duplicate struct entry name \"%s\" in %s", part_name, bound_function.name);
+				}
+				name_collision_set.insert(part_name);
+				part_codes.emplace_back(part_code);
+				struct_children.emplace_back(make_pair(part_name, LogicalType::BIGINT));
+			}
+		} else {
+			throw BinderException("%s can only take constant lists of part names", bound_function.name);
+		}
+
+		arguments.erase(arguments.begin());
+		bound_function.arguments.erase(bound_function.arguments.begin());
+		bound_function.return_type = LogicalType::STRUCT(move(struct_children));
+		return make_unique<BindData>(bound_function.return_type, part_codes);
+	}
+
+	template <typename INPUT_TYPE>
+	static void Function(DataChunk &args, ExpressionState &state, Vector &result) {
+		auto &func_expr = (BoundFunctionExpression &)state.expr;
+		auto &info = (BindData &)*func_expr.bind_info;
+		D_ASSERT(args.ColumnCount() == 1);
+
+		const auto count = args.size();
+		Vector &input = args.data[0];
+		vector<int64_t *> part_values(int(DatePartSpecifier::TIMEZONE_MINUTE) + 1, nullptr);
+		const auto part_mask = DatePart::StructOperator::GetMask(info.part_codes);
+
+		auto &child_entries = StructVector::GetEntries(result);
+
+		// The first computer of a part "owns" it
+		// and other requestors just reference the owner
+		vector<size_t> owners(int(DatePartSpecifier::TIMEZONE_MINUTE) + 1, child_entries.size());
+		for (size_t col = 0; col < child_entries.size(); ++col) {
+			const auto part_index = size_t(info.part_codes[col]);
+			if (owners[part_index] == child_entries.size()) {
+				owners[part_index] = col;
+			}
+		}
+
+		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+
+			if (ConstantVector::IsNull(input)) {
+				ConstantVector::SetNull(result, true);
+			} else {
+				ConstantVector::SetNull(result, false);
+				for (size_t col = 0; col < child_entries.size(); ++col) {
+					auto &child_entry = child_entries[col];
+					ConstantVector::SetNull(*child_entry, false);
+					const auto part_index = size_t(info.part_codes[col]);
+					if (owners[part_index] == col) {
+						part_values[part_index] = ConstantVector::GetData<int64_t>(*child_entry);
+					}
+				}
+				auto tdata = ConstantVector::GetData<INPUT_TYPE>(input);
+				if (Value::IsFinite(tdata[0])) {
+					DatePart::StructOperator::Operation(part_values.data(), tdata[0], 0, part_mask);
+				} else {
+					for (auto &child_entry : child_entries) {
+						ConstantVector::SetNull(*child_entry, true);
+					}
+				}
+			}
+		} else {
+			VectorData rdata;
+			input.Orrify(count, rdata);
+
+			const auto &arg_valid = rdata.validity;
+			auto tdata = (const INPUT_TYPE *)rdata.data;
+
+			// Start with a valid flat vector
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			auto &res_valid = FlatVector::Validity(result);
+			if (res_valid.GetData()) {
+				res_valid.SetAllValid(count);
+			}
+
+			// Start with valid children
+			for (size_t col = 0; col < child_entries.size(); ++col) {
+				auto &child_entry = child_entries[col];
+				child_entry->SetVectorType(VectorType::FLAT_VECTOR);
+				auto &child_validity = FlatVector::Validity(*child_entry);
+				if (child_validity.GetData()) {
+					child_validity.SetAllValid(count);
+				}
+
+				// Pre-multiplex
+				const auto part_index = size_t(info.part_codes[col]);
+				if (owners[part_index] == col) {
+					part_values[part_index] = FlatVector::GetData<int64_t>(*child_entry);
+				}
+			}
+
+			for (idx_t i = 0; i < count; ++i) {
+				const auto idx = rdata.sel->get_index(i);
+				if (arg_valid.RowIsValid(idx)) {
+					if (Value::IsFinite(tdata[idx])) {
+						DatePart::StructOperator::Operation(part_values.data(), tdata[idx], idx, part_mask);
+					} else {
+						for (auto &child_entry : child_entries) {
+							FlatVector::Validity(*child_entry).SetInvalid(idx);
+						}
+					}
+				} else {
+					res_valid.SetInvalid(idx);
+					for (auto &child_entry : child_entries) {
+						FlatVector::Validity(*child_entry).SetInvalid(idx);
+					}
+				}
+			}
+		}
+
+		// Reference any duplicate parts
+		for (size_t col = 0; col < child_entries.size(); ++col) {
+			const auto part_index = size_t(info.part_codes[col]);
+			const auto owner = owners[part_index];
+			if (owner != col) {
+				child_entries[col]->Reference(*child_entries[owner]);
+			}
+		}
+
+		result.Verify(count);
+	}
+
+	template <typename INPUT_TYPE>
+	static ScalarFunction GetFunction(const LogicalType &temporal_type) {
+		auto part_type = LogicalType::LIST(LogicalType::VARCHAR);
+		auto result_type = LogicalType::STRUCT({});
+		return ScalarFunction({part_type, temporal_type}, result_type, Function<INPUT_TYPE>, false, false, Bind);
+	}
+};
+
+void DatePartFun::RegisterFunction(BuiltinFunctions &set) {
+	// register the individual operators
+	AddGenericDatePartOperator(set, "year", LastYearFunction<date_t>, LastYearFunction<timestamp_t>,
+	                           ScalarFunction::UnaryFunction<interval_t, int64_t, DatePart::YearOperator>,
+	                           DatePart::YearOperator::PropagateStatistics<date_t>,
+	                           DatePart::YearOperator::PropagateStatistics<timestamp_t>);
+	AddDatePartOperator<DatePart::MonthOperator>(set, "month");
+	AddDatePartOperator<DatePart::DayOperator>(set, "day");
+	AddDatePartOperator<DatePart::DecadeOperator>(set, "decade");
+	AddDatePartOperator<DatePart::CenturyOperator>(set, "century");
+	AddDatePartOperator<DatePart::MillenniumOperator>(set, "millennium");
+	AddDatePartOperator<DatePart::QuarterOperator>(set, "quarter");
+	AddDatePartOperator<DatePart::DayOfWeekOperator>(set, "dayofweek");
+	AddDatePartOperator<DatePart::ISODayOfWeekOperator>(set, "isodow");
+	AddDatePartOperator<DatePart::DayOfYearOperator>(set, "dayofyear");
+	AddDatePartOperator<DatePart::WeekOperator>(set, "week");
+	AddDatePartOperator<DatePart::ISOYearOperator>(set, "isoyear");
+	AddDatePartOperator<DatePart::EraOperator>(set, "era");
+	AddDatePartOperator<DatePart::TimezoneOperator>(set, "timezone");
+	AddDatePartOperator<DatePart::TimezoneHourOperator>(set, "timezone_hour");
+	AddDatePartOperator<DatePart::TimezoneMinuteOperator>(set, "timezone_minute");
+	AddTimePartOperator<DatePart::EpochOperator>(set, "epoch");
+	AddTimePartOperator<DatePart::MicrosecondsOperator>(set, "microsecond");
+	AddTimePartOperator<DatePart::MillisecondsOperator>(set, "millisecond");
+	AddTimePartOperator<DatePart::SecondsOperator>(set, "second");
+	AddTimePartOperator<DatePart::MinutesOperator>(set, "minute");
+	AddTimePartOperator<DatePart::HoursOperator>(set, "hour");
+
+	//  register combinations
+	AddDatePartOperator<DatePart::YearWeekOperator>(set, "yearweek");
+
+	//  register various aliases
+	AddDatePartOperator<DatePart::DayOperator>(set, "dayofmonth");
+	AddDatePartOperator<DatePart::DayOfWeekOperator>(set, "weekday");
+	AddDatePartOperator<DatePart::WeekOperator>(set, "weekofyear"); //  Note that WeekOperator is ISO-8601, not US
+
+	//  register the last_day function
+	ScalarFunctionSet last_day("last_day");
+	last_day.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::DATE,
+	                                    DatePart::UnaryFunction<date_t, date_t, LastDayOperator>));
+	last_day.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::DATE,
+	                                    DatePart::UnaryFunction<timestamp_t, date_t, LastDayOperator>));
+	set.AddFunction(last_day);
+
+	//  register the monthname function
+	ScalarFunctionSet monthname("monthname");
+	monthname.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::VARCHAR,
+	                                     DatePart::UnaryFunction<date_t, string_t, MonthNameOperator>));
+	monthname.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::VARCHAR,
+	                                     DatePart::UnaryFunction<timestamp_t, string_t, MonthNameOperator>));
+	set.AddFunction(monthname);
+
+	//  register the dayname function
+	ScalarFunctionSet dayname("dayname");
+	dayname.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::VARCHAR,
+	                                   DatePart::UnaryFunction<date_t, string_t, DayNameOperator>));
+	dayname.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::VARCHAR,
+	                                   DatePart::UnaryFunction<timestamp_t, string_t, DayNameOperator>));
+	set.AddFunction(dayname);
+
+	// finally the actual date_part function
+	ScalarFunctionSet date_part("date_part");
+	date_part.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::DATE}, LogicalType::BIGINT, DatePartFunction<date_t>));
+	date_part.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP}, LogicalType::BIGINT,
+	                                     DatePartFunction<timestamp_t>));
+	date_part.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME}, LogicalType::BIGINT, DatePartFunction<dtime_t>));
+	date_part.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTERVAL}, LogicalType::BIGINT,
+	                                     DatePartFunction<interval_t>));
+
+	// struct variants
+	date_part.AddFunction(StructDatePart::GetFunction<date_t>(LogicalType::DATE));
+	date_part.AddFunction(StructDatePart::GetFunction<timestamp_t>(LogicalType::TIMESTAMP));
+	date_part.AddFunction(StructDatePart::GetFunction<dtime_t>(LogicalType::TIME));
+	date_part.AddFunction(StructDatePart::GetFunction<interval_t>(LogicalType::INTERVAL));
+
+	set.AddFunction(date_part);
+	date_part.name = "datepart";
+	set.AddFunction(date_part);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DateSub {
+	template <class TA, class TB, class TR, class OP>
+	static inline void BinaryExecute(Vector &left, Vector &right, Vector &result, idx_t count) {
+		BinaryExecutor::ExecuteWithNulls<TA, TB, TR>(
+		    left, right, result, count, [&](TA startdate, TB enddate, ValidityMask &mask, idx_t idx) {
+			    if (Value::IsFinite(startdate) && Value::IsFinite(enddate)) {
+				    return OP::template Operation<TA, TB, TR>(startdate, enddate);
+			    } else {
+				    mask.SetInvalid(idx);
+				    return TR();
+			    }
+		    });
+	}
+
+	struct MonthOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+
+			if (start_ts > end_ts) {
+				return -MonthOperator::Operation<TA, TB, TR>(end_ts, start_ts);
+			}
+			// The number of complete months depends on whether end_ts is on the last day of the month.
+			date_t end_date;
+			dtime_t end_time;
+			Timestamp::Convert(end_ts, end_date, end_time);
+
+			int32_t yyyy, mm, dd;
+			Date::Convert(end_date, yyyy, mm, dd);
+			const auto end_days = Date::MonthDays(yyyy, mm);
+			if (end_days == dd) {
+				// Now check whether the start day is after the end day
+				date_t start_date;
+				dtime_t start_time;
+				Timestamp::Convert(start_ts, start_date, start_time);
+				Date::Convert(start_date, yyyy, mm, dd);
+				if (dd > end_days || (dd == end_days && start_time < end_time)) {
+					// Move back to the same time on the last day of the (shorter) end month
+					start_date = Date::FromDate(yyyy, mm, end_days);
+					start_ts = Timestamp::FromDatetime(start_date, start_time);
+				}
+			}
+
+			// Our interval difference will now give the correct result.
+			// Note that PG gives different interval subtraction results,
+			// so if we change this we will have to reimplement.
+			return Interval::GetAge(end_ts, start_ts).months;
+		}
+	};
+
+	struct QuarterOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_QUARTER;
+		}
+	};
+
+	struct YearOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_YEAR;
+		}
+	};
+
+	struct DecadeOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_DECADE;
+		}
+	};
+
+	struct CenturyOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_CENTURY;
+		}
+	};
+
+	struct MilleniumOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA start_ts, TB end_ts) {
+			return MonthOperator::Operation<TA, TB, TR>(start_ts, end_ts) / Interval::MONTHS_PER_MILLENIUM;
+		}
+	};
+
+	struct DayOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_DAY;
+		}
+	};
+
+	struct WeekOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_WEEK;
+		}
+	};
+
+	struct MicrosecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate));
+		}
+	};
+
+	struct MillisecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_MSEC;
+		}
+	};
+
+	struct SecondsOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_SEC;
+		}
+	};
+
+	struct MinutesOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_MINUTE;
+		}
+	};
+
+	struct HoursOperator {
+		template <class TA, class TB, class TR>
+		static inline TR Operation(TA startdate, TB enddate) {
+			return (Timestamp::GetEpochMicroSeconds(enddate) - Timestamp::GetEpochMicroSeconds(startdate)) /
+			       Interval::MICROS_PER_HOUR;
+		}
+	};
+};
+
+// DATE specialisations
+template <>
+int64_t DateSub::YearOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return YearOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                  Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::MonthOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return MonthOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                   Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::DayOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return DayOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                 Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::DecadeOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return DecadeOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                    Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::CenturyOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return CenturyOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                     Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::MilleniumOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return MilleniumOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                       Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::QuarterOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return QuarterOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                     Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::WeekOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return WeekOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                  Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::MicrosecondsOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return MicrosecondsOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                          Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::MillisecondsOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return MillisecondsOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                          Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::SecondsOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return SecondsOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                     Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::MinutesOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return MinutesOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                     Timestamp::FromDatetime(enddate, t0));
+}
+
+template <>
+int64_t DateSub::HoursOperator::Operation(date_t startdate, date_t enddate) {
+	dtime_t t0(0);
+	return HoursOperator::Operation<timestamp_t, timestamp_t, int64_t>(Timestamp::FromDatetime(startdate, t0),
+	                                                                   Timestamp::FromDatetime(enddate, t0));
+}
+
+// TIME specialisations
+template <>
+int64_t DateSub::YearOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"year\" not recognized");
+}
+
+template <>
+int64_t DateSub::MonthOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"month\" not recognized");
+}
+
+template <>
+int64_t DateSub::DayOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"day\" not recognized");
+}
+
+template <>
+int64_t DateSub::DecadeOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"decade\" not recognized");
+}
+
+template <>
+int64_t DateSub::CenturyOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"century\" not recognized");
+}
+
+template <>
+int64_t DateSub::MilleniumOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"millennium\" not recognized");
+}
+
+template <>
+int64_t DateSub::QuarterOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"quarter\" not recognized");
+}
+
+template <>
+int64_t DateSub::WeekOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	throw NotImplementedException("\"time\" units \"week\" not recognized");
+}
+
+template <>
+int64_t DateSub::MicrosecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return enddate.micros - startdate.micros;
+}
+
+template <>
+int64_t DateSub::MillisecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_MSEC;
+}
+
+template <>
+int64_t DateSub::SecondsOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_SEC;
+}
+
+template <>
+int64_t DateSub::MinutesOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_MINUTE;
+}
+
+template <>
+int64_t DateSub::HoursOperator::Operation(dtime_t startdate, dtime_t enddate) {
+	return (enddate.micros - startdate.micros) / Interval::MICROS_PER_HOUR;
+}
+
+template <typename TA, typename TB, typename TR>
+static int64_t SubtractDateParts(DatePartSpecifier type, TA startdate, TB enddate) {
+	switch (type) {
+	case DatePartSpecifier::YEAR:
+	case DatePartSpecifier::ISOYEAR:
+		return DateSub::YearOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MONTH:
+		return DateSub::MonthOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		return DateSub::DayOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::DECADE:
+		return DateSub::DecadeOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::CENTURY:
+		return DateSub::CenturyOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MILLENNIUM:
+		return DateSub::MilleniumOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::QUARTER:
+		return DateSub::QuarterOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		return DateSub::WeekOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MICROSECONDS:
+		return DateSub::MicrosecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MILLISECONDS:
+		return DateSub::MillisecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		return DateSub::SecondsOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::MINUTE:
+		return DateSub::MinutesOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	case DatePartSpecifier::HOUR:
+		return DateSub::HoursOperator::template Operation<TA, TB, TR>(startdate, enddate);
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATESUB");
+	}
+}
+
+struct DateSubTernaryOperator {
+	template <typename TS, typename TA, typename TB, typename TR>
+	static inline TR Operation(TS part, TA startdate, TB enddate, ValidityMask &mask, idx_t idx) {
+		if (Value::IsFinite(startdate) && Value::IsFinite(enddate)) {
+			return SubtractDateParts<TA, TB, TR>(GetDatePartSpecifier(part.GetString()), startdate, enddate);
+		} else {
+			mask.SetInvalid(idx);
+			return TR();
+		}
+	}
+};
+
+template <typename TA, typename TB, typename TR>
+static void DateSubBinaryExecutor(DatePartSpecifier type, Vector &left, Vector &right, Vector &result, idx_t count) {
+	switch (type) {
+	case DatePartSpecifier::YEAR:
+	case DatePartSpecifier::ISOYEAR:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::YearOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MONTH:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::MonthOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::DayOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::DECADE:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::DecadeOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::CENTURY:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::CenturyOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MILLENNIUM:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::MilleniumOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::QUARTER:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::QuarterOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::WeekOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MICROSECONDS:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::MicrosecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MILLISECONDS:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::MillisecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::SecondsOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::MINUTE:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::MinutesOperator>(left, right, result, count);
+		break;
+	case DatePartSpecifier::HOUR:
+		DateSub::BinaryExecute<TA, TB, TR, DateSub::HoursOperator>(left, right, result, count);
+		break;
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATESUB");
+	}
+}
+
+template <typename T>
+static void DateSubFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 3);
+	auto &part_arg = args.data[0];
+	auto &start_arg = args.data[1];
+	auto &end_arg = args.data[2];
+
+	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// Common case of constant part.
+		if (ConstantVector::IsNull(part_arg)) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result, true);
+		} else {
+			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
+			DateSubBinaryExecutor<T, T, int64_t>(type, start_arg, end_arg, result, args.size());
+		}
+	} else {
+		TernaryExecutor::ExecuteWithNulls<string_t, T, T, int64_t>(
+		    part_arg, start_arg, end_arg, result, args.size(),
+		    DateSubTernaryOperator::Operation<string_t, T, T, int64_t>);
+	}
+}
+
+void DateSubFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet date_sub("date_sub");
+	date_sub.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::DATE, LogicalType::DATE},
+	                                    LogicalType::BIGINT, DateSubFunction<date_t>));
+	date_sub.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP, LogicalType::TIMESTAMP},
+	                                    LogicalType::BIGINT, DateSubFunction<timestamp_t>));
+	date_sub.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIME, LogicalType::TIME},
+	                                    LogicalType::BIGINT, DateSubFunction<dtime_t>));
+	set.AddFunction(date_sub);
+
+	date_sub.name = "datesub";
+	set.AddFunction(date_sub);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DateTrunc {
+	template <class TA, class TR, class OP>
+	static inline TR UnaryFunction(TA input) {
+		if (Value::IsFinite(input)) {
+			return OP::template Operation<TA, TR>(input);
+		} else {
+			return Cast::template Operation<TA, TR>(input);
+		}
+	}
+
+	template <class TA, class TR, class OP>
+	static inline void UnaryExecute(Vector &left, Vector &result, idx_t count) {
+		UnaryExecutor::Execute<TA, TR>(left, result, count, UnaryFunction<TA, TR, OP>);
+	}
+
+	struct MillenniumOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::FromDate((Date::ExtractYear(input) / 1000) * 1000, 1, 1);
+		}
+	};
+
+	struct CenturyOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::FromDate((Date::ExtractYear(input) / 100) * 100, 1, 1);
+		}
+	};
+
+	struct DecadeOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::FromDate((Date::ExtractYear(input) / 10) * 10, 1, 1);
+		}
+	};
+
+	struct YearOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::FromDate(Date::ExtractYear(input), 1, 1);
+		}
+	};
+
+	struct QuarterOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t yyyy, mm, dd;
+			Date::Convert(input, yyyy, mm, dd);
+			mm = 1 + (((mm - 1) / 3) * 3);
+			return Date::FromDate(yyyy, mm, 1);
+		}
+	};
+
+	struct MonthOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::FromDate(Date::ExtractYear(input), Date::ExtractMonth(input), 1);
+		}
+	};
+
+	struct WeekOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return Date::GetMondayOfCurrentWeek(input);
+		}
+	};
+
+	struct ISOYearOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			date_t date = Date::GetMondayOfCurrentWeek(input);
+			date.days -= (Date::ExtractISOWeekNumber(date) - 1) * Interval::DAYS_PER_WEEK;
+
+			return date;
+		}
+	};
+
+	struct DayOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return input;
+		}
+	};
+
+	struct HourOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t hour, min, sec, micros;
+			date_t date;
+			dtime_t time;
+			Timestamp::Convert(input, date, time);
+			Time::Convert(time, hour, min, sec, micros);
+			return Timestamp::FromDatetime(date, Time::FromTime(hour, 0, 0, 0));
+		}
+	};
+
+	struct MinuteOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t hour, min, sec, micros;
+			date_t date;
+			dtime_t time;
+			Timestamp::Convert(input, date, time);
+			Time::Convert(time, hour, min, sec, micros);
+			return Timestamp::FromDatetime(date, Time::FromTime(hour, min, 0, 0));
+		}
+	};
+
+	struct SecondOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t hour, min, sec, micros;
+			date_t date;
+			dtime_t time;
+			Timestamp::Convert(input, date, time);
+			Time::Convert(time, hour, min, sec, micros);
+			return Timestamp::FromDatetime(date, Time::FromTime(hour, min, sec, 0));
+		}
+	};
+
+	struct MillisecondOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			int32_t hour, min, sec, micros;
+			date_t date;
+			dtime_t time;
+			Timestamp::Convert(input, date, time);
+			Time::Convert(time, hour, min, sec, micros);
+			micros -= micros % Interval::MICROS_PER_MSEC;
+			return Timestamp::FromDatetime(date, Time::FromTime(hour, min, sec, micros));
+		}
+	};
+
+	struct MicrosecondOperator {
+		template <class TA, class TR>
+		static inline TR Operation(TA input) {
+			return input;
+		}
+	};
+};
+
+// DATE specialisations
+template <>
+date_t DateTrunc::MillenniumOperator::Operation(timestamp_t input) {
+	return MillenniumOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::MillenniumOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(MillenniumOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::MillenniumOperator::Operation(timestamp_t input) {
+	return MillenniumOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::CenturyOperator::Operation(timestamp_t input) {
+	return CenturyOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::CenturyOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(CenturyOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::CenturyOperator::Operation(timestamp_t input) {
+	return CenturyOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::DecadeOperator::Operation(timestamp_t input) {
+	return DecadeOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::DecadeOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(DecadeOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::DecadeOperator::Operation(timestamp_t input) {
+	return DecadeOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::YearOperator::Operation(timestamp_t input) {
+	return YearOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::YearOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(YearOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::YearOperator::Operation(timestamp_t input) {
+	return YearOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::QuarterOperator::Operation(timestamp_t input) {
+	return QuarterOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::QuarterOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(QuarterOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::QuarterOperator::Operation(timestamp_t input) {
+	return QuarterOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::MonthOperator::Operation(timestamp_t input) {
+	return MonthOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::MonthOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(MonthOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::MonthOperator::Operation(timestamp_t input) {
+	return MonthOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::WeekOperator::Operation(timestamp_t input) {
+	return WeekOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::WeekOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(WeekOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::WeekOperator::Operation(timestamp_t input) {
+	return WeekOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::ISOYearOperator::Operation(timestamp_t input) {
+	return ISOYearOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::ISOYearOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(ISOYearOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::ISOYearOperator::Operation(timestamp_t input) {
+	return ISOYearOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::DayOperator::Operation(timestamp_t input) {
+	return DayOperator::Operation<date_t, date_t>(Timestamp::GetDate(input));
+}
+
+template <>
+timestamp_t DateTrunc::DayOperator::Operation(date_t input) {
+	return Timestamp::FromDatetime(DayOperator::Operation<date_t, date_t>(input), dtime_t(0));
+}
+
+template <>
+timestamp_t DateTrunc::DayOperator::Operation(timestamp_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(Timestamp::GetDate(input));
+}
+
+template <>
+date_t DateTrunc::HourOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, date_t>(input);
+}
+
+template <>
+timestamp_t DateTrunc::HourOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(input);
+}
+
+template <>
+date_t DateTrunc::HourOperator::Operation(timestamp_t input) {
+	return Timestamp::GetDate(HourOperator::Operation<timestamp_t, timestamp_t>(input));
+}
+
+template <>
+date_t DateTrunc::MinuteOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, date_t>(input);
+}
+
+template <>
+timestamp_t DateTrunc::MinuteOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(input);
+}
+
+template <>
+date_t DateTrunc::MinuteOperator::Operation(timestamp_t input) {
+	return Timestamp::GetDate(HourOperator::Operation<timestamp_t, timestamp_t>(input));
+}
+
+template <>
+date_t DateTrunc::SecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, date_t>(input);
+}
+
+template <>
+timestamp_t DateTrunc::SecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(input);
+}
+
+template <>
+date_t DateTrunc::SecondOperator::Operation(timestamp_t input) {
+	return Timestamp::GetDate(DayOperator::Operation<timestamp_t, timestamp_t>(input));
+}
+
+template <>
+date_t DateTrunc::MillisecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, date_t>(input);
+}
+
+template <>
+timestamp_t DateTrunc::MillisecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(input);
+}
+
+template <>
+date_t DateTrunc::MillisecondOperator::Operation(timestamp_t input) {
+	return Timestamp::GetDate(MillisecondOperator::Operation<timestamp_t, timestamp_t>(input));
+}
+
+template <>
+date_t DateTrunc::MicrosecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, date_t>(input);
+}
+
+template <>
+timestamp_t DateTrunc::MicrosecondOperator::Operation(date_t input) {
+	return DayOperator::Operation<date_t, timestamp_t>(input);
+}
+
+template <>
+date_t DateTrunc::MicrosecondOperator::Operation(timestamp_t input) {
+	return Timestamp::GetDate(MicrosecondOperator::Operation<timestamp_t, timestamp_t>(input));
+}
+
+// INTERVAL specialisations
+template <>
+interval_t DateTrunc::MillenniumOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	input.months = (input.months / Interval::MONTHS_PER_MILLENIUM) * Interval::MONTHS_PER_MILLENIUM;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::CenturyOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	input.months = (input.months / Interval::MONTHS_PER_CENTURY) * Interval::MONTHS_PER_CENTURY;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::DecadeOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	input.months = (input.months / Interval::MONTHS_PER_DECADE) * Interval::MONTHS_PER_DECADE;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::YearOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	input.months = (input.months / Interval::MONTHS_PER_YEAR) * Interval::MONTHS_PER_YEAR;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::QuarterOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	input.months = (input.months / Interval::MONTHS_PER_QUARTER) * Interval::MONTHS_PER_QUARTER;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::MonthOperator::Operation(interval_t input) {
+	input.days = 0;
+	input.micros = 0;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::WeekOperator::Operation(interval_t input) {
+	input.micros = 0;
+	input.days = (input.days / Interval::DAYS_PER_WEEK) * Interval::DAYS_PER_WEEK;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::ISOYearOperator::Operation(interval_t input) {
+	return YearOperator::Operation<interval_t, interval_t>(input);
+}
+
+template <>
+interval_t DateTrunc::DayOperator::Operation(interval_t input) {
+	input.micros = 0;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::HourOperator::Operation(interval_t input) {
+	input.micros = (input.micros / Interval::MICROS_PER_HOUR) * Interval::MICROS_PER_HOUR;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::MinuteOperator::Operation(interval_t input) {
+	input.micros = (input.micros / Interval::MICROS_PER_MINUTE) * Interval::MICROS_PER_MINUTE;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::SecondOperator::Operation(interval_t input) {
+	input.micros = (input.micros / Interval::MICROS_PER_SEC) * Interval::MICROS_PER_SEC;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::MillisecondOperator::Operation(interval_t input) {
+	input.micros = (input.micros / Interval::MICROS_PER_MSEC) * Interval::MICROS_PER_MSEC;
+	return input;
+}
+
+template <>
+interval_t DateTrunc::MicrosecondOperator::Operation(interval_t input) {
+	return input;
+}
+
+template <class TA, class TR>
+static TR TruncateElement(DatePartSpecifier type, TA element) {
+	if (!Value::IsFinite(element)) {
+		return Cast::template Operation<TA, TR>(element);
+	}
+
+	switch (type) {
+	case DatePartSpecifier::MILLENNIUM:
+		return DateTrunc::MillenniumOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::CENTURY:
+		return DateTrunc::CenturyOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::DECADE:
+		return DateTrunc::DecadeOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::YEAR:
+		return DateTrunc::YearOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::QUARTER:
+		return DateTrunc::QuarterOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::MONTH:
+		return DateTrunc::MonthOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		return DateTrunc::WeekOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::ISOYEAR:
+		return DateTrunc::ISOYearOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		return DateTrunc::DayOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::HOUR:
+		return DateTrunc::HourOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::MINUTE:
+		return DateTrunc::MinuteOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		return DateTrunc::SecondOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::MILLISECONDS:
+		return DateTrunc::MillisecondOperator::Operation<TA, TR>(element);
+	case DatePartSpecifier::MICROSECONDS:
+		return DateTrunc::MicrosecondOperator::Operation<TA, TR>(element);
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATETRUNC");
+	}
+}
+
+struct DateTruncBinaryOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA specifier, TB date) {
+		return TruncateElement<TB, TR>(GetDatePartSpecifier(specifier.GetString()), date);
+	}
+};
+
+template <typename TA, typename TR>
+static void DateTruncUnaryExecutor(DatePartSpecifier type, Vector &left, Vector &result, idx_t count) {
+	switch (type) {
+	case DatePartSpecifier::MILLENNIUM:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::MillenniumOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::CENTURY:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::CenturyOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::DECADE:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::DecadeOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::YEAR:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::YearOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::QUARTER:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::QuarterOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::MONTH:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::MonthOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::WeekOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::ISOYEAR:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::ISOYearOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::DayOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::HOUR:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::HourOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::MINUTE:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::MinuteOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::SecondOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::MILLISECONDS:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::MillisecondOperator>(left, result, count);
+		break;
+	case DatePartSpecifier::MICROSECONDS:
+		DateTrunc::UnaryExecute<TA, TR, DateTrunc::MicrosecondOperator>(left, result, count);
+		break;
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATETRUNC");
+	}
+}
+
+template <typename TA, typename TR>
+static void DateTruncFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto &part_arg = args.data[0];
+	auto &date_arg = args.data[1];
+
+	if (part_arg.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		// Common case of constant part.
+		if (ConstantVector::IsNull(part_arg)) {
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result, true);
+		} else {
+			const auto type = GetDatePartSpecifier(ConstantVector::GetData<string_t>(part_arg)->GetString());
+			DateTruncUnaryExecutor<TA, TR>(type, date_arg, result, args.size());
+		}
+	} else {
+		BinaryExecutor::ExecuteStandard<string_t, TA, TR, DateTruncBinaryOperator>(part_arg, date_arg, result,
+		                                                                           args.size());
+	}
+}
+
+template <class TA, class TR, class OP>
+static unique_ptr<BaseStatistics> DateTruncStatistics(vector<unique_ptr<BaseStatistics>> &child_stats) {
+	// we can only propagate date stats if the child has stats
+	if (!child_stats[1]) {
+		return nullptr;
+	}
+	auto &nstats = (NumericStatistics &)*child_stats[1];
+	if (nstats.min.IsNull() || nstats.max.IsNull()) {
+		return nullptr;
+	}
+	// run the operator on both the min and the max, this gives us the [min, max] bound
+	auto min = nstats.min.GetValueUnsafe<TA>();
+	auto max = nstats.max.GetValueUnsafe<TA>();
+	if (min > max) {
+		throw InternalException("Invalid DATETRUNC child statistics");
+	}
+
+	// Infinite values are unmodified
+	auto min_part = DateTrunc::UnaryFunction<TA, TR, OP>(min);
+	auto max_part = DateTrunc::UnaryFunction<TA, TR, OP>(max);
+
+	auto min_value = Value::CreateValue(min_part);
+	auto max_value = Value::CreateValue(max_part);
+	auto result = make_unique<NumericStatistics>(min_value.type(), min_value, max_value, StatisticsType::LOCAL_STATS);
+	if (child_stats[0]->validity_stats) {
+		result->validity_stats = child_stats[1]->validity_stats->Copy();
+	}
+	return move(result);
+}
+
+template <class TA, class TR, class OP>
+static unique_ptr<BaseStatistics> PropagateDateTruncStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+	return DateTruncStatistics<TA, TR, OP>(input.child_stats);
+}
+
+template <typename TA, typename TR>
+static function_statistics_t DateTruncStats(DatePartSpecifier type) {
+	switch (type) {
+	case DatePartSpecifier::MILLENNIUM:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::MillenniumOperator>;
+	case DatePartSpecifier::CENTURY:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::CenturyOperator>;
+	case DatePartSpecifier::DECADE:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::DecadeOperator>;
+	case DatePartSpecifier::YEAR:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::YearOperator>;
+	case DatePartSpecifier::QUARTER:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::QuarterOperator>;
+	case DatePartSpecifier::MONTH:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::MonthOperator>;
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::WeekOperator>;
+	case DatePartSpecifier::ISOYEAR:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::ISOYearOperator>;
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::DayOperator>;
+	case DatePartSpecifier::HOUR:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::HourOperator>;
+	case DatePartSpecifier::MINUTE:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::MinuteOperator>;
+	case DatePartSpecifier::SECOND:
+	case DatePartSpecifier::EPOCH:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::SecondOperator>;
+	case DatePartSpecifier::MILLISECONDS:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::MillisecondOperator>;
+	case DatePartSpecifier::MICROSECONDS:
+		return PropagateDateTruncStatistics<TA, TR, DateTrunc::MicrosecondOperator>;
+	default:
+		throw NotImplementedException("Specifier type not implemented for DATETRUNC statistics");
+	}
+}
+
+static unique_ptr<FunctionData> DateTruncBind(ClientContext &context, ScalarFunction &bound_function,
+                                              vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[0]->IsFoldable()) {
+		return nullptr;
+	}
+
+	// Rebind to return a date if we are truncating that far
+	Value part_value = ExpressionExecutor::EvaluateScalar(*arguments[0]);
+	if (part_value.IsNull()) {
+		return nullptr;
+	}
+	const auto part_name = part_value.ToString();
+	const auto part_code = GetDatePartSpecifier(part_name);
+	switch (part_code) {
+	case DatePartSpecifier::MILLENNIUM:
+	case DatePartSpecifier::CENTURY:
+	case DatePartSpecifier::DECADE:
+	case DatePartSpecifier::YEAR:
+	case DatePartSpecifier::QUARTER:
+	case DatePartSpecifier::MONTH:
+	case DatePartSpecifier::WEEK:
+	case DatePartSpecifier::YEARWEEK:
+	case DatePartSpecifier::ISOYEAR:
+	case DatePartSpecifier::DAY:
+	case DatePartSpecifier::DOW:
+	case DatePartSpecifier::ISODOW:
+	case DatePartSpecifier::DOY:
+		switch (arguments[1]->return_type.id()) {
+		case LogicalType::TIMESTAMP:
+			bound_function.function = DateTruncFunction<timestamp_t, date_t>;
+			bound_function.statistics = DateTruncStats<timestamp_t, date_t>(part_code);
+			break;
+		case LogicalType::DATE:
+			bound_function.function = DateTruncFunction<date_t, date_t>;
+			bound_function.statistics = DateTruncStats<date_t, date_t>(part_code);
+			break;
+		default:
+			break;
+		}
+		bound_function.return_type = LogicalType::DATE;
+		break;
+	default:
+		switch (arguments[1]->return_type.id()) {
+		case LogicalType::TIMESTAMP:
+			bound_function.statistics = DateTruncStats<timestamp_t, timestamp_t>(part_code);
+			break;
+		case LogicalType::DATE:
+			bound_function.statistics = DateTruncStats<timestamp_t, date_t>(part_code);
+			break;
+		default:
+			break;
+		}
+		break;
+	}
+
+	return nullptr;
+}
+
+void DateTruncFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet date_trunc("date_trunc");
+	date_trunc.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP}, LogicalType::TIMESTAMP,
+	                                      DateTruncFunction<timestamp_t, timestamp_t>, false, false, DateTruncBind));
+	date_trunc.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::DATE}, LogicalType::TIMESTAMP,
+	                                      DateTruncFunction<date_t, timestamp_t>, false, false, DateTruncBind));
+	date_trunc.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTERVAL}, LogicalType::INTERVAL,
+	                                      DateTruncFunction<interval_t, interval_t>));
+	set.AddFunction(date_trunc);
+	date_trunc.name = "datetrunc";
+	set.AddFunction(date_trunc);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct EpochSecOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input) {
+		return Timestamp::FromEpochSeconds(input);
+	}
+};
+
+static void EpochSecFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 1);
+
+	UnaryExecutor::Execute<int64_t, timestamp_t, EpochSecOperator>(input.data[0], result, input.size());
+}
+
+struct EpochMillisOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input) {
+		return Timestamp::FromEpochMs(input);
+	}
+};
+
+static void EpochMillisFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 1);
+
+	UnaryExecutor::Execute<int64_t, timestamp_t, EpochMillisOperator>(input.data[0], result, input.size());
+}
+
+void EpochFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet epoch("epoch_ms");
+	epoch.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, EpochMillisFunction));
+	set.AddFunction(epoch);
+	// to_timestamp is an alias from Postgres that converts the time in seconds to a timestamp
+	ScalarFunctionSet to_timestamp("to_timestamp");
+	to_timestamp.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::TIMESTAMP, EpochSecFunction));
+	set.AddFunction(to_timestamp);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <cmath>
+
+namespace duckdb {
+
+struct MakeDateOperator {
+	template <typename YYYY, typename MM, typename DD, typename RESULT_TYPE>
+	static RESULT_TYPE Operation(YYYY yyyy, MM mm, DD dd) {
+		return Date::FromDate(yyyy, mm, dd);
+	}
+};
+
+template <typename T>
+static void ExecuteMakeDate(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 3);
+	auto &yyyy = input.data[0];
+	auto &mm = input.data[1];
+	auto &dd = input.data[2];
+
+	TernaryExecutor::Execute<T, T, T, date_t>(yyyy, mm, dd, result, input.size(),
+	                                          MakeDateOperator::Operation<T, T, T, date_t>);
+}
+
+template <typename T>
+static void ExecuteStructMakeDate(DataChunk &input, ExpressionState &state, Vector &result) {
+	// this should be guaranteed by the binder
+	D_ASSERT(input.ColumnCount() == 1);
+	auto &vec = input.data[0];
+
+	auto &children = StructVector::GetEntries(vec);
+	D_ASSERT(children.size() == 3);
+	auto &yyyy = *children[0];
+	auto &mm = *children[1];
+	auto &dd = *children[2];
+
+	TernaryExecutor::Execute<T, T, T, date_t>(yyyy, mm, dd, result, input.size(), Date::FromDate);
+}
+
+struct MakeTimeOperator {
+	template <typename HH, typename MM, typename SS, typename RESULT_TYPE>
+	static RESULT_TYPE Operation(HH hh, MM mm, SS ss) {
+		int64_t secs = ss;
+		int64_t micros = std::round((ss - secs) * Interval::MICROS_PER_SEC);
+		return Time::FromTime(hh, mm, secs, micros);
+	}
+};
+
+template <typename T>
+static void ExecuteMakeTime(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 3);
+	auto &yyyy = input.data[0];
+	auto &mm = input.data[1];
+	auto &dd = input.data[2];
+
+	TernaryExecutor::Execute<T, T, double, dtime_t>(yyyy, mm, dd, result, input.size(),
+	                                                MakeTimeOperator::Operation<T, T, double, dtime_t>);
+}
+
+struct MakeTimestampOperator {
+	template <typename YYYY, typename MM, typename DD, typename HR, typename MN, typename SS, typename RESULT_TYPE>
+	static RESULT_TYPE Operation(YYYY yyyy, MM mm, DD dd, HR hr, MN mn, SS ss) {
+		const auto d = MakeDateOperator::Operation<YYYY, MM, DD, date_t>(yyyy, mm, dd);
+		const auto t = MakeTimeOperator::Operation<HR, MN, SS, dtime_t>(hr, mn, ss);
+		return Timestamp::FromDatetime(d, t);
+	}
+};
+
+template <typename T>
+static void ExecuteMakeTimestamp(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() == 6);
+
+	auto func = MakeTimestampOperator::Operation<T, T, T, T, T, double, timestamp_t>;
+	SenaryExecutor::Execute<T, T, T, T, T, double, timestamp_t>(input, result, func);
+}
+
+void MakeDateFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet make_date("make_date");
+	make_date.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
+	                                     LogicalType::DATE, ExecuteMakeDate<int64_t>));
+
+	child_list_t<LogicalType> make_date_children {
+	    {"year", LogicalType::BIGINT}, {"month", LogicalType::BIGINT}, {"day", LogicalType::BIGINT}};
+	make_date.AddFunction(
+	    ScalarFunction({LogicalType::STRUCT(make_date_children)}, LogicalType::DATE, ExecuteStructMakeDate<int64_t>));
+	set.AddFunction(make_date);
+
+	ScalarFunctionSet make_time("make_time");
+	make_time.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::DOUBLE},
+	                                     LogicalType::TIME, ExecuteMakeTime<int64_t>));
+	set.AddFunction(make_time);
+
+	ScalarFunctionSet make_timestamp("make_timestamp");
+	make_timestamp.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT,
+	                                           LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::DOUBLE},
+	                                          LogicalType::TIMESTAMP, ExecuteMakeTimestamp<int64_t>));
+	set.AddFunction(make_timestamp);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cctype>
+
+namespace duckdb {
+
+idx_t StrfTimepecifierSize(StrTimeSpecifier specifier) {
+	switch (specifier) {
+	case StrTimeSpecifier::ABBREVIATED_WEEKDAY_NAME:
+	case StrTimeSpecifier::ABBREVIATED_MONTH_NAME:
+		return 3;
+	case StrTimeSpecifier::WEEKDAY_DECIMAL:
+		return 1;
+	case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+	case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY_PADDED:
+	case StrTimeSpecifier::HOUR_24_PADDED:
+	case StrTimeSpecifier::HOUR_12_PADDED:
+	case StrTimeSpecifier::MINUTE_PADDED:
+	case StrTimeSpecifier::SECOND_PADDED:
+	case StrTimeSpecifier::AM_PM:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST:
+		return 2;
+	case StrTimeSpecifier::MICROSECOND_PADDED:
+		return 6;
+	case StrTimeSpecifier::MILLISECOND_PADDED:
+		return 3;
+	case StrTimeSpecifier::DAY_OF_YEAR_PADDED:
+		return 3;
+	default:
+		return 0;
+	}
+}
+
+void StrTimeFormat::AddLiteral(string literal) {
+	constant_size += literal.size();
+	literals.push_back(move(literal));
+}
+
+void StrTimeFormat::AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier) {
+	AddLiteral(move(preceding_literal));
+	specifiers.push_back(specifier);
+}
+
+void StrfTimeFormat::AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier) {
+	is_date_specifier.push_back(IsDateSpecifier(specifier));
+	idx_t specifier_size = StrfTimepecifierSize(specifier);
+	if (specifier_size == 0) {
+		// variable length specifier
+		var_length_specifiers.push_back(specifier);
+	} else {
+		// constant size specifier
+		constant_size += specifier_size;
+	}
+	StrTimeFormat::AddFormatSpecifier(move(preceding_literal), specifier);
+}
+
+idx_t StrfTimeFormat::GetSpecifierLength(StrTimeSpecifier specifier, date_t date, dtime_t time, int32_t utc_offset,
+                                         const char *tz_name) {
+	switch (specifier) {
+	case StrTimeSpecifier::FULL_WEEKDAY_NAME:
+		return Date::DAY_NAMES[Date::ExtractISODayOfTheWeek(date) % 7].GetSize();
+	case StrTimeSpecifier::FULL_MONTH_NAME:
+		return Date::MONTH_NAMES[Date::ExtractMonth(date) - 1].GetSize();
+	case StrTimeSpecifier::YEAR_DECIMAL: {
+		auto year = Date::ExtractYear(date);
+		return NumericHelper::SignedLength<int32_t, uint32_t>(year);
+	}
+	case StrTimeSpecifier::MONTH_DECIMAL: {
+		idx_t len = 1;
+		auto month = Date::ExtractMonth(date);
+		len += month >= 10;
+		return len;
+	}
+	case StrTimeSpecifier::UTC_OFFSET:
+		// ±HH or ±HH:MM
+		return (utc_offset % 60) ? 6 : 3;
+	case StrTimeSpecifier::TZ_NAME:
+		if (tz_name) {
+			return strlen(tz_name);
+		}
+		// empty for now
+		return 0;
+	case StrTimeSpecifier::HOUR_24_DECIMAL:
+	case StrTimeSpecifier::HOUR_12_DECIMAL:
+	case StrTimeSpecifier::MINUTE_DECIMAL:
+	case StrTimeSpecifier::SECOND_DECIMAL: {
+		// time specifiers
+		idx_t len = 1;
+		int32_t hour, min, sec, msec;
+		Time::Convert(time, hour, min, sec, msec);
+		switch (specifier) {
+		case StrTimeSpecifier::HOUR_24_DECIMAL:
+			len += hour >= 10;
+			break;
+		case StrTimeSpecifier::HOUR_12_DECIMAL:
+			hour = hour % 12;
+			if (hour == 0) {
+				hour = 12;
+			}
+			len += hour >= 10;
+			break;
+		case StrTimeSpecifier::MINUTE_DECIMAL:
+			len += min >= 10;
+			break;
+		case StrTimeSpecifier::SECOND_DECIMAL:
+			len += sec >= 10;
+			break;
+		default:
+			throw InternalException("Time specifier mismatch");
+		}
+		return len;
+	}
+	case StrTimeSpecifier::DAY_OF_MONTH:
+		return NumericHelper::UnsignedLength<uint32_t>(Date::ExtractDay(date));
+	case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL:
+		return NumericHelper::UnsignedLength<uint32_t>(Date::ExtractDayOfTheYear(date));
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY:
+		return NumericHelper::UnsignedLength<uint32_t>(Date::ExtractYear(date) % 100);
+	default:
+		throw InternalException("Unimplemented specifier for GetSpecifierLength");
+	}
+}
+
+//! Returns the total length of the date formatted by this format specifier
+idx_t StrfTimeFormat::GetLength(date_t date, dtime_t time, int32_t utc_offset, const char *tz_name) {
+	idx_t size = constant_size;
+	if (!var_length_specifiers.empty()) {
+		for (auto &specifier : var_length_specifiers) {
+			size += GetSpecifierLength(specifier, date, time, utc_offset, tz_name);
+		}
+	}
+	return size;
+}
+
+char *StrfTimeFormat::WriteString(char *target, const string_t &str) {
+	idx_t size = str.GetSize();
+	memcpy(target, str.GetDataUnsafe(), size);
+	return target + size;
+}
+
+// write a value in the range of 0..99 unpadded (e.g. "1", "2", ... "98", "99")
+char *StrfTimeFormat::Write2(char *target, uint8_t value) {
+	D_ASSERT(value < 100);
+	if (value >= 10) {
+		return WritePadded2(target, value);
+	} else {
+		*target = char(uint8_t('0') + value);
+		return target + 1;
+	}
+}
+
+// write a value in the range of 0..99 padded to 2 digits
+char *StrfTimeFormat::WritePadded2(char *target, uint32_t value) {
+	D_ASSERT(value < 100);
+	auto index = static_cast<unsigned>(value * 2);
+	*target++ = duckdb_fmt::internal::data::digits[index];
+	*target++ = duckdb_fmt::internal::data::digits[index + 1];
+	return target;
+}
+
+// write a value in the range of 0..999 padded
+char *StrfTimeFormat::WritePadded3(char *target, uint32_t value) {
+	D_ASSERT(value < 1000);
+	if (value >= 100) {
+		WritePadded2(target + 1, value % 100);
+		*target = char(uint8_t('0') + value / 100);
+		return target + 3;
+	} else {
+		*target = '0';
+		target++;
+		return WritePadded2(target, value);
+	}
+}
+
+// write a value in the range of 0..999999 padded to 6 digits
+char *StrfTimeFormat::WritePadded(char *target, uint32_t value, size_t padding) {
+	D_ASSERT(padding % 2 == 0);
+	for (size_t i = 0; i < padding / 2; i++) {
+		int decimals = value % 100;
+		WritePadded2(target + padding - 2 * (i + 1), decimals);
+		value /= 100;
+	}
+	return target + padding;
+}
+
+bool StrfTimeFormat::IsDateSpecifier(StrTimeSpecifier specifier) {
+	switch (specifier) {
+	case StrTimeSpecifier::ABBREVIATED_WEEKDAY_NAME:
+	case StrTimeSpecifier::FULL_WEEKDAY_NAME:
+	case StrTimeSpecifier::DAY_OF_YEAR_PADDED:
+	case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+	case StrTimeSpecifier::WEEKDAY_DECIMAL:
+		return true;
+	default:
+		return false;
+	}
+}
+
+char *StrfTimeFormat::WriteDateSpecifier(StrTimeSpecifier specifier, date_t date, char *target) {
+	switch (specifier) {
+	case StrTimeSpecifier::ABBREVIATED_WEEKDAY_NAME: {
+		auto dow = Date::ExtractISODayOfTheWeek(date);
+		target = WriteString(target, Date::DAY_NAMES_ABBREVIATED[dow % 7]);
+		break;
+	}
+	case StrTimeSpecifier::FULL_WEEKDAY_NAME: {
+		auto dow = Date::ExtractISODayOfTheWeek(date);
+		target = WriteString(target, Date::DAY_NAMES[dow % 7]);
+		break;
+	}
+	case StrTimeSpecifier::WEEKDAY_DECIMAL: {
+		auto dow = Date::ExtractISODayOfTheWeek(date);
+		*target = char('0' + uint8_t(dow % 7));
+		target++;
+		break;
+	}
+	case StrTimeSpecifier::DAY_OF_YEAR_PADDED: {
+		int32_t doy = Date::ExtractDayOfTheYear(date);
+		target = WritePadded3(target, doy);
+		break;
+	}
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST:
+		target = WritePadded2(target, Date::ExtractWeekNumberRegular(date, true));
+		break;
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+		target = WritePadded2(target, Date::ExtractWeekNumberRegular(date, false));
+		break;
+	case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL: {
+		uint32_t doy = Date::ExtractDayOfTheYear(date);
+		target += NumericHelper::UnsignedLength<uint32_t>(doy);
+		NumericHelper::FormatUnsigned(doy, target);
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented date specifier for strftime");
+	}
+	return target;
+}
+
+char *StrfTimeFormat::WriteStandardSpecifier(StrTimeSpecifier specifier, int32_t data[], const char *tz_name,
+                                             char *target) {
+	// data contains [0] year, [1] month, [2] day, [3] hour, [4] minute, [5] second, [6] msec, [7] utc
+	switch (specifier) {
+	case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+		target = WritePadded2(target, data[2]);
+		break;
+	case StrTimeSpecifier::ABBREVIATED_MONTH_NAME: {
+		auto &month_name = Date::MONTH_NAMES_ABBREVIATED[data[1] - 1];
+		return WriteString(target, month_name);
+	}
+	case StrTimeSpecifier::FULL_MONTH_NAME: {
+		auto &month_name = Date::MONTH_NAMES[data[1] - 1];
+		return WriteString(target, month_name);
+	}
+	case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+		target = WritePadded2(target, data[1]);
+		break;
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY_PADDED:
+		target = WritePadded2(target, AbsValue(data[0]) % 100);
+		break;
+	case StrTimeSpecifier::YEAR_DECIMAL:
+		if (data[0] >= 0 && data[0] <= 9999) {
+			target = WritePadded(target, data[0], 4);
+		} else {
+			int32_t year = data[0];
+			if (data[0] < 0) {
+				*target = '-';
+				year = -year;
+				target++;
+			}
+			auto len = NumericHelper::UnsignedLength<uint32_t>(year);
+			NumericHelper::FormatUnsigned(year, target + len);
+			target += len;
+		}
+		break;
+	case StrTimeSpecifier::HOUR_24_PADDED: {
+		target = WritePadded2(target, data[3]);
+		break;
+	}
+	case StrTimeSpecifier::HOUR_12_PADDED: {
+		int hour = data[3] % 12;
+		if (hour == 0) {
+			hour = 12;
+		}
+		target = WritePadded2(target, hour);
+		break;
+	}
+	case StrTimeSpecifier::AM_PM:
+		*target++ = data[3] >= 12 ? 'P' : 'A';
+		*target++ = 'M';
+		break;
+	case StrTimeSpecifier::MINUTE_PADDED: {
+		target = WritePadded2(target, data[4]);
+		break;
+	}
+	case StrTimeSpecifier::SECOND_PADDED:
+		target = WritePadded2(target, data[5]);
+		break;
+	case StrTimeSpecifier::MICROSECOND_PADDED:
+		target = WritePadded(target, data[6], 6);
+		break;
+	case StrTimeSpecifier::MILLISECOND_PADDED:
+		target = WritePadded3(target, data[6] / 1000);
+		break;
+	case StrTimeSpecifier::UTC_OFFSET: {
+		*target++ = (data[7] < 0) ? '-' : '+';
+
+		auto offset = abs(data[7]);
+		auto offset_hours = offset / Interval::MINS_PER_HOUR;
+		auto offset_minutes = offset % Interval::MINS_PER_HOUR;
+		target = WritePadded2(target, offset_hours);
+		if (offset_minutes) {
+			*target++ = ':';
+			target = WritePadded2(target, offset_minutes);
+		}
+		break;
+	}
+	case StrTimeSpecifier::TZ_NAME:
+		if (tz_name) {
+			strcpy(target, tz_name);
+			target += strlen(tz_name);
+		}
+		break;
+	case StrTimeSpecifier::DAY_OF_MONTH: {
+		target = Write2(target, data[2] % 100);
+		break;
+	}
+	case StrTimeSpecifier::MONTH_DECIMAL: {
+		target = Write2(target, data[1]);
+		break;
+	}
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY: {
+		target = Write2(target, data[0] % 100);
+		break;
+	}
+	case StrTimeSpecifier::HOUR_24_DECIMAL: {
+		target = Write2(target, data[3]);
+		break;
+	}
+	case StrTimeSpecifier::HOUR_12_DECIMAL: {
+		int hour = data[3] % 12;
+		if (hour == 0) {
+			hour = 12;
+		}
+		target = Write2(target, hour);
+		break;
+	}
+	case StrTimeSpecifier::MINUTE_DECIMAL: {
+		target = Write2(target, data[4]);
+		break;
+	}
+	case StrTimeSpecifier::SECOND_DECIMAL: {
+		target = Write2(target, data[5]);
+		break;
+	}
+	default:
+		throw InternalException("Unimplemented specifier for WriteStandardSpecifier in strftime");
+	}
+	return target;
+}
+
+void StrfTimeFormat::FormatString(date_t date, int32_t data[8], const char *tz_name, char *target) {
+	D_ASSERT(specifiers.size() + 1 == literals.size());
+	idx_t i;
+	for (i = 0; i < specifiers.size(); i++) {
+		// first copy the current literal
+		memcpy(target, literals[i].c_str(), literals[i].size());
+		target += literals[i].size();
+		// now copy the specifier
+		if (is_date_specifier[i]) {
+			target = WriteDateSpecifier(specifiers[i], date, target);
+		} else {
+			target = WriteStandardSpecifier(specifiers[i], data, tz_name, target);
+		}
+	}
+	// copy the final literal into the target
+	memcpy(target, literals[i].c_str(), literals[i].size());
+}
+
+void StrfTimeFormat::FormatString(date_t date, dtime_t time, char *target) {
+	int32_t data[8]; // year, month, day, hour, min, sec, µs, offset
+	Date::Convert(date, data[0], data[1], data[2]);
+	Time::Convert(time, data[3], data[4], data[5], data[6]);
+	data[7] = 0;
+
+	FormatString(date, data, nullptr, target);
+}
+
+string StrfTimeFormat::Format(timestamp_t timestamp, const string &format_str) {
+	StrfTimeFormat format;
+	format.ParseFormatSpecifier(format_str, format);
+
+	auto date = Timestamp::GetDate(timestamp);
+	auto time = Timestamp::GetTime(timestamp);
+
+	auto len = format.GetLength(date, time, 0, nullptr);
+	auto result = unique_ptr<char[]>(new char[len]);
+	format.FormatString(date, time, result.get());
+	return string(result.get(), len);
+}
+
+string StrTimeFormat::ParseFormatSpecifier(const string &format_string, StrTimeFormat &format) {
+	if (format_string.empty()) {
+		return "Empty format string";
+	}
+	format.specifiers.clear();
+	format.literals.clear();
+	format.numeric_width.clear();
+	format.constant_size = 0;
+	idx_t pos = 0;
+	string current_literal;
+	for (idx_t i = 0; i < format_string.size(); i++) {
+		if (format_string[i] == '%') {
+			if (i + 1 == format_string.size()) {
+				return "Trailing format character %";
+			}
+			if (i > pos) {
+				// push the previous string to the current literal
+				current_literal += format_string.substr(pos, i - pos);
+			}
+			char format_char = format_string[++i];
+			if (format_char == '%') {
+				// special case: %%
+				// set the pos for the next literal and continue
+				pos = i;
+				continue;
+			}
+			StrTimeSpecifier specifier;
+			if (format_char == '-' && i + 1 < format_string.size()) {
+				format_char = format_string[++i];
+				switch (format_char) {
+				case 'd':
+					specifier = StrTimeSpecifier::DAY_OF_MONTH;
+					break;
+				case 'm':
+					specifier = StrTimeSpecifier::MONTH_DECIMAL;
+					break;
+				case 'y':
+					specifier = StrTimeSpecifier::YEAR_WITHOUT_CENTURY;
+					break;
+				case 'H':
+					specifier = StrTimeSpecifier::HOUR_24_DECIMAL;
+					break;
+				case 'I':
+					specifier = StrTimeSpecifier::HOUR_12_DECIMAL;
+					break;
+				case 'M':
+					specifier = StrTimeSpecifier::MINUTE_DECIMAL;
+					break;
+				case 'S':
+					specifier = StrTimeSpecifier::SECOND_DECIMAL;
+					break;
+				case 'j':
+					specifier = StrTimeSpecifier::DAY_OF_YEAR_DECIMAL;
+					break;
+				default:
+					return "Unrecognized format for strftime/strptime: %-" + string(1, format_char);
+				}
+			} else {
+				switch (format_char) {
+				case 'a':
+					specifier = StrTimeSpecifier::ABBREVIATED_WEEKDAY_NAME;
+					break;
+				case 'A':
+					specifier = StrTimeSpecifier::FULL_WEEKDAY_NAME;
+					break;
+				case 'w':
+					specifier = StrTimeSpecifier::WEEKDAY_DECIMAL;
+					break;
+				case 'd':
+					specifier = StrTimeSpecifier::DAY_OF_MONTH_PADDED;
+					break;
+				case 'h':
+				case 'b':
+					specifier = StrTimeSpecifier::ABBREVIATED_MONTH_NAME;
+					break;
+				case 'B':
+					specifier = StrTimeSpecifier::FULL_MONTH_NAME;
+					break;
+				case 'm':
+					specifier = StrTimeSpecifier::MONTH_DECIMAL_PADDED;
+					break;
+				case 'y':
+					specifier = StrTimeSpecifier::YEAR_WITHOUT_CENTURY_PADDED;
+					break;
+				case 'Y':
+					specifier = StrTimeSpecifier::YEAR_DECIMAL;
+					break;
+				case 'H':
+					specifier = StrTimeSpecifier::HOUR_24_PADDED;
+					break;
+				case 'I':
+					specifier = StrTimeSpecifier::HOUR_12_PADDED;
+					break;
+				case 'p':
+					specifier = StrTimeSpecifier::AM_PM;
+					break;
+				case 'M':
+					specifier = StrTimeSpecifier::MINUTE_PADDED;
+					break;
+				case 'S':
+					specifier = StrTimeSpecifier::SECOND_PADDED;
+					break;
+				case 'f':
+					specifier = StrTimeSpecifier::MICROSECOND_PADDED;
+					break;
+				case 'g':
+					specifier = StrTimeSpecifier::MILLISECOND_PADDED;
+					break;
+				case 'z':
+					specifier = StrTimeSpecifier::UTC_OFFSET;
+					break;
+				case 'Z':
+					specifier = StrTimeSpecifier::TZ_NAME;
+					break;
+				case 'j':
+					specifier = StrTimeSpecifier::DAY_OF_YEAR_PADDED;
+					break;
+				case 'U':
+					specifier = StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST;
+					break;
+				case 'W':
+					specifier = StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST;
+					break;
+				case 'c':
+				case 'x':
+				case 'X':
+				case 'T': {
+					string subformat;
+					if (format_char == 'c') {
+						// %c: Locale’s appropriate date and time representation.
+						// we push the ISO timestamp representation here
+						subformat = "%Y-%m-%d %H:%M:%S";
+					} else if (format_char == 'x') {
+						// %x - Locale’s appropriate date representation.
+						// we push the ISO date format here
+						subformat = "%Y-%m-%d";
+					} else if (format_char == 'X' || format_char == 'T') {
+						// %X - Locale’s appropriate time representation.
+						// we push the ISO time format here
+						subformat = "%H:%M:%S";
+					}
+					// parse the subformat in a separate format specifier
+					StrfTimeFormat locale_format;
+					string error = StrTimeFormat::ParseFormatSpecifier(subformat, locale_format);
+					D_ASSERT(error.empty());
+					// add the previous literal to the first literal of the subformat
+					locale_format.literals[0] = move(current_literal) + locale_format.literals[0];
+					current_literal = "";
+					// now push the subformat into the current format specifier
+					for (idx_t i = 0; i < locale_format.specifiers.size(); i++) {
+						format.AddFormatSpecifier(move(locale_format.literals[i]), locale_format.specifiers[i]);
+					}
+					pos = i + 1;
+					continue;
+				}
+				default:
+					return "Unrecognized format for strftime/strptime: %" + string(1, format_char);
+				}
+			}
+			format.AddFormatSpecifier(move(current_literal), specifier);
+			current_literal = "";
+			pos = i + 1;
+		}
+	}
+	// add the final literal
+	if (pos < format_string.size()) {
+		current_literal += format_string.substr(pos, format_string.size() - pos);
+	}
+	format.AddLiteral(move(current_literal));
+	return string();
+}
+
+struct StrfTimeBindData : public FunctionData {
+	explicit StrfTimeBindData(StrfTimeFormat format_p, string format_string_p)
+	    : format(move(format_p)), format_string(move(format_string_p)) {
+	}
+
+	StrfTimeFormat format;
+	string format_string;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<StrfTimeBindData>(format, format_string);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const StrfTimeBindData &)other_p;
+		return format_string == other.format_string;
+	}
+};
+
+template <bool REVERSED>
+static unique_ptr<FunctionData> StrfTimeBindFunction(ClientContext &context, ScalarFunction &bound_function,
+                                                     vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[REVERSED ? 0 : 1]->IsFoldable()) {
+		throw InvalidInputException("strftime format must be a constant");
+	}
+	Value options_str = ExpressionExecutor::EvaluateScalar(*arguments[REVERSED ? 0 : 1]);
+	auto format_string = options_str.GetValue<string>();
+	StrfTimeFormat format;
+	if (!options_str.IsNull()) {
+		string error = StrTimeFormat::ParseFormatSpecifier(format_string, format);
+		if (!error.empty()) {
+			throw InvalidInputException("Failed to parse format specifier %s: %s", format_string, error);
+		}
+	}
+	return make_unique<StrfTimeBindData>(format, format_string);
+}
+
+void StrfTimeFormat::ConvertDateVector(Vector &input, Vector &result, idx_t count) {
+	D_ASSERT(input.GetType().id() == LogicalTypeId::DATE);
+	D_ASSERT(result.GetType().id() == LogicalTypeId::VARCHAR);
+	UnaryExecutor::ExecuteWithNulls<date_t, string_t>(input, result, count,
+	                                                  [&](date_t input, ValidityMask &mask, idx_t idx) {
+		                                                  if (Date::IsFinite(input)) {
+			                                                  dtime_t time(0);
+			                                                  idx_t len = GetLength(input, time, 0, nullptr);
+			                                                  string_t target = StringVector::EmptyString(result, len);
+			                                                  FormatString(input, time, target.GetDataWriteable());
+			                                                  target.Finalize();
+			                                                  return target;
+		                                                  } else {
+			                                                  mask.SetInvalid(idx);
+			                                                  return string_t();
+		                                                  }
+	                                                  });
+}
+
+template <bool REVERSED>
+static void StrfTimeFunctionDate(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (StrfTimeBindData &)*func_expr.bind_info;
+
+	if (ConstantVector::IsNull(args.data[REVERSED ? 0 : 1])) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		return;
+	}
+	info.format.ConvertDateVector(args.data[REVERSED ? 1 : 0], result, args.size());
+}
+
+void StrfTimeFormat::ConvertTimestampVector(Vector &input, Vector &result, idx_t count) {
+	D_ASSERT(input.GetType().id() == LogicalTypeId::TIMESTAMP);
+	D_ASSERT(result.GetType().id() == LogicalTypeId::VARCHAR);
+	UnaryExecutor::ExecuteWithNulls<timestamp_t, string_t>(
+	    input, result, count, [&](timestamp_t input, ValidityMask &mask, idx_t idx) {
+		    if (Timestamp::IsFinite(input)) {
+			    date_t date;
+			    dtime_t time;
+			    Timestamp::Convert(input, date, time);
+			    idx_t len = GetLength(date, time, 0, nullptr);
+			    string_t target = StringVector::EmptyString(result, len);
+			    FormatString(date, time, target.GetDataWriteable());
+			    target.Finalize();
+			    return target;
+		    } else {
+			    mask.SetInvalid(idx);
+			    return string_t();
+		    }
+	    });
+}
+
+template <bool REVERSED>
+static void StrfTimeFunctionTimestamp(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (StrfTimeBindData &)*func_expr.bind_info;
+
+	if (ConstantVector::IsNull(args.data[REVERSED ? 0 : 1])) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		return;
+	}
+	info.format.ConvertTimestampVector(args.data[REVERSED ? 1 : 0], result, args.size());
+}
+
+void StrfTimeFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet strftime("strftime");
+
+	strftime.AddFunction(ScalarFunction({LogicalType::DATE, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                    StrfTimeFunctionDate<false>, false, false, StrfTimeBindFunction<false>));
+
+	strftime.AddFunction(ScalarFunction({LogicalType::TIMESTAMP, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                    StrfTimeFunctionTimestamp<false>, false, false, StrfTimeBindFunction<false>));
+
+	strftime.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::DATE}, LogicalType::VARCHAR,
+	                                    StrfTimeFunctionDate<true>, false, false, StrfTimeBindFunction<true>));
+
+	strftime.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::TIMESTAMP}, LogicalType::VARCHAR,
+	                                    StrfTimeFunctionTimestamp<true>, false, false, StrfTimeBindFunction<true>));
+
+	set.AddFunction(strftime);
+}
+
+void StrpTimeFormat::AddFormatSpecifier(string preceding_literal, StrTimeSpecifier specifier) {
+	numeric_width.push_back(NumericSpecifierWidth(specifier));
+	StrTimeFormat::AddFormatSpecifier(move(preceding_literal), specifier);
+}
+
+int StrpTimeFormat::NumericSpecifierWidth(StrTimeSpecifier specifier) {
+	switch (specifier) {
+	case StrTimeSpecifier::WEEKDAY_DECIMAL:
+		return 1;
+	case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+	case StrTimeSpecifier::DAY_OF_MONTH:
+	case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+	case StrTimeSpecifier::MONTH_DECIMAL:
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY_PADDED:
+	case StrTimeSpecifier::YEAR_WITHOUT_CENTURY:
+	case StrTimeSpecifier::HOUR_24_PADDED:
+	case StrTimeSpecifier::HOUR_24_DECIMAL:
+	case StrTimeSpecifier::HOUR_12_PADDED:
+	case StrTimeSpecifier::HOUR_12_DECIMAL:
+	case StrTimeSpecifier::MINUTE_PADDED:
+	case StrTimeSpecifier::MINUTE_DECIMAL:
+	case StrTimeSpecifier::SECOND_PADDED:
+	case StrTimeSpecifier::SECOND_DECIMAL:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST:
+		return 2;
+	case StrTimeSpecifier::MILLISECOND_PADDED:
+	case StrTimeSpecifier::DAY_OF_YEAR_PADDED:
+	case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL:
+		return 3;
+	case StrTimeSpecifier::YEAR_DECIMAL:
+		return 4;
+	case StrTimeSpecifier::MICROSECOND_PADDED:
+		return 6;
+	default:
+		return -1;
+	}
+}
+
+enum class TimeSpecifierAMOrPM : uint8_t { TIME_SPECIFIER_NONE = 0, TIME_SPECIFIER_AM = 1, TIME_SPECIFIER_PM = 2 };
+
+int32_t StrpTimeFormat::TryParseCollection(const char *data, idx_t &pos, idx_t size, const string_t collection[],
+                                           idx_t collection_count) {
+	for (idx_t c = 0; c < collection_count; c++) {
+		auto &entry = collection[c];
+		auto entry_data = entry.GetDataUnsafe();
+		auto entry_size = entry.GetSize();
+		// check if this entry matches
+		if (pos + entry_size > size) {
+			// too big: can't match
+			continue;
+		}
+		// compare the characters
+		idx_t i;
+		for (i = 0; i < entry_size; i++) {
+			if (std::tolower(entry_data[i]) != std::tolower(data[pos + i])) {
+				break;
+			}
+		}
+		if (i == entry_size) {
+			// full match
+			pos += entry_size;
+			return c;
+		}
+	}
+	return -1;
+}
+
+//! Parses a timestamp using the given specifier
+bool StrpTimeFormat::Parse(string_t str, ParseResult &result) {
+	auto &result_data = result.data;
+	auto &error_message = result.error_message;
+	auto &error_position = result.error_position;
+
+	// initialize the result
+	result_data[0] = 1900;
+	result_data[1] = 1;
+	result_data[2] = 1;
+	result_data[3] = 0;
+	result_data[4] = 0;
+	result_data[5] = 0;
+	result_data[6] = 0;
+	result_data[7] = 0;
+
+	auto data = str.GetDataUnsafe();
+	idx_t size = str.GetSize();
+	// skip leading spaces
+	while (StringUtil::CharacterIsSpace(*data)) {
+		data++;
+		size--;
+	}
+	idx_t pos = 0;
+	TimeSpecifierAMOrPM ampm = TimeSpecifierAMOrPM::TIME_SPECIFIER_NONE;
+
+	// Year offset state (Year+W/j)
+	auto offset_specifier = StrTimeSpecifier::WEEKDAY_DECIMAL;
+	uint64_t weekno = 0;
+	uint64_t weekday = 0;
+	uint64_t yearday = 0;
+
+	for (idx_t i = 0;; i++) {
+		D_ASSERT(i < literals.size());
+		// first compare the literal
+		const auto &literal = literals[i];
+		for (size_t l = 0; l < literal.size();) {
+			// Match runs of spaces to runs of spaces.
+			if (StringUtil::CharacterIsSpace(literal[l])) {
+				if (!StringUtil::CharacterIsSpace(data[pos])) {
+					error_message = "Space does not match, expected " + literals[i];
+					error_position = pos;
+					return false;
+				}
+				for (++pos; pos < size && StringUtil::CharacterIsSpace(data[pos]); ++pos) {
+					continue;
+				}
+				for (++l; l < literal.size() && StringUtil::CharacterIsSpace(literal[l]); ++l) {
+					continue;
+				}
+				continue;
+			}
+			// literal does not match
+			if (data[pos++] != literal[l++]) {
+				error_message = "Literal does not match, expected " + literal;
+				error_position = pos;
+				return false;
+			}
+		}
+		if (i == specifiers.size()) {
+			break;
+		}
+		// now parse the specifier
+		if (numeric_width[i] > 0) {
+			// numeric specifier: parse a number
+			uint64_t number = 0;
+			size_t start_pos = pos;
+			size_t end_pos = start_pos + numeric_width[i];
+			while (pos < size && pos < end_pos && StringUtil::CharacterIsDigit(data[pos])) {
+				number = number * 10 + data[pos] - '0';
+				pos++;
+			}
+			if (pos == start_pos) {
+				// expected a number here
+				error_message = "Expected a number";
+				error_position = start_pos;
+				return false;
+			}
+			switch (specifiers[i]) {
+			case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+			case StrTimeSpecifier::DAY_OF_MONTH:
+				if (number < 1 || number > 31) {
+					error_message = "Day out of range, expected a value between 1 and 31";
+					error_position = start_pos;
+					return false;
+				}
+				// day of the month
+				result_data[2] = number;
+				offset_specifier = specifiers[i];
+				break;
+			case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+			case StrTimeSpecifier::MONTH_DECIMAL:
+				if (number < 1 || number > 12) {
+					error_message = "Month out of range, expected a value between 1 and 12";
+					error_position = start_pos;
+					return false;
+				}
+				// month number
+				result_data[1] = number;
+				offset_specifier = specifiers[i];
+				break;
+			case StrTimeSpecifier::YEAR_WITHOUT_CENTURY_PADDED:
+			case StrTimeSpecifier::YEAR_WITHOUT_CENTURY:
+				// year without century..
+				// Python uses 69 as a crossover point (i.e. >= 69 is 19.., < 69 is 20..)
+				if (number >= 100) {
+					// %y only supports numbers between [0..99]
+					error_message = "Year without century out of range, expected a value between 0 and 99";
+					error_position = start_pos;
+					return false;
+				}
+				if (number >= 69) {
+					result_data[0] = int32_t(1900 + number);
+				} else {
+					result_data[0] = int32_t(2000 + number);
+				}
+				break;
+			case StrTimeSpecifier::YEAR_DECIMAL:
+				// year as full number
+				result_data[0] = number;
+				break;
+			case StrTimeSpecifier::HOUR_24_PADDED:
+			case StrTimeSpecifier::HOUR_24_DECIMAL:
+				if (number >= 24) {
+					error_message = "Hour out of range, expected a value between 0 and 23";
+					error_position = start_pos;
+					return false;
+				}
+				// hour as full number
+				result_data[3] = number;
+				break;
+			case StrTimeSpecifier::HOUR_12_PADDED:
+			case StrTimeSpecifier::HOUR_12_DECIMAL:
+				if (number < 1 || number > 12) {
+					error_message = "Hour12 out of range, expected a value between 1 and 12";
+					error_position = start_pos;
+					return false;
+				}
+				// 12-hour number: start off by just storing the number
+				result_data[3] = number;
+				break;
+			case StrTimeSpecifier::MINUTE_PADDED:
+			case StrTimeSpecifier::MINUTE_DECIMAL:
+				if (number >= 60) {
+					error_message = "Minutes out of range, expected a value between 0 and 59";
+					error_position = start_pos;
+					return false;
+				}
+				// minutes
+				result_data[4] = number;
+				break;
+			case StrTimeSpecifier::SECOND_PADDED:
+			case StrTimeSpecifier::SECOND_DECIMAL:
+				if (number >= 60) {
+					error_message = "Seconds out of range, expected a value between 0 and 59";
+					error_position = start_pos;
+					return false;
+				}
+				// seconds
+				result_data[5] = number;
+				break;
+			case StrTimeSpecifier::MICROSECOND_PADDED:
+				D_ASSERT(number < 1000000ULL); // enforced by the length of the number
+				// milliseconds
+				result_data[6] = number;
+				break;
+			case StrTimeSpecifier::MILLISECOND_PADDED:
+				D_ASSERT(number < 1000ULL); // enforced by the length of the number
+				// milliseconds
+				result_data[6] = number * 1000;
+				break;
+			case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+			case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST:
+				// m/d overrides WU/w but does not conflict
+				switch (offset_specifier) {
+				case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+				case StrTimeSpecifier::DAY_OF_MONTH:
+				case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+				case StrTimeSpecifier::MONTH_DECIMAL:
+					// Just validate, don't use
+					break;
+				case StrTimeSpecifier::WEEKDAY_DECIMAL:
+					// First offset specifier
+					offset_specifier = specifiers[i];
+					break;
+				default:
+					error_message = "Multiple year offsets specified";
+					error_position = start_pos;
+					return false;
+				}
+				if (number > 53) {
+					error_message = "Week out of range, expected a value between 0 and 53";
+					error_position = start_pos;
+					return false;
+				}
+				weekno = number;
+				break;
+			case StrTimeSpecifier::WEEKDAY_DECIMAL:
+				if (number > 6) {
+					error_message = "Weekday out of range, expected a value between 0 and 6";
+					error_position = start_pos;
+					return false;
+				}
+				weekday = number;
+				break;
+			case StrTimeSpecifier::DAY_OF_YEAR_PADDED:
+			case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL:
+				// m/d overrides j but does not conflict
+				switch (offset_specifier) {
+				case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+				case StrTimeSpecifier::DAY_OF_MONTH:
+				case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+				case StrTimeSpecifier::MONTH_DECIMAL:
+					// Just validate, don't use
+					break;
+				case StrTimeSpecifier::WEEKDAY_DECIMAL:
+					// First offset specifier
+					offset_specifier = specifiers[i];
+					break;
+				default:
+					error_message = "Multiple year offsets specified";
+					error_position = start_pos;
+					return false;
+				}
+				if (number < 1 || number > 366) {
+					error_message = "Year day out of range, expected a value between 1 and 366";
+					error_position = start_pos;
+					return false;
+				}
+				yearday = number;
+				break;
+			default:
+				throw NotImplementedException("Unsupported specifier for strptime");
+			}
+		} else {
+			switch (specifiers[i]) {
+			case StrTimeSpecifier::AM_PM: {
+				// parse the next 2 characters
+				if (pos + 2 > size) {
+					// no characters left to parse
+					error_message = "Expected AM/PM";
+					error_position = pos;
+					return false;
+				}
+				char pa_char = char(std::tolower(data[pos]));
+				char m_char = char(std::tolower(data[pos + 1]));
+				if (m_char != 'm') {
+					error_message = "Expected AM/PM";
+					error_position = pos;
+					return false;
+				}
+				if (pa_char == 'p') {
+					ampm = TimeSpecifierAMOrPM::TIME_SPECIFIER_PM;
+				} else if (pa_char == 'a') {
+					ampm = TimeSpecifierAMOrPM::TIME_SPECIFIER_AM;
+				} else {
+					error_message = "Expected AM/PM";
+					error_position = pos;
+					return false;
+				}
+				pos += 2;
+				break;
+			}
+			// we parse weekday names, but we don't use them as information
+			case StrTimeSpecifier::ABBREVIATED_WEEKDAY_NAME:
+				if (TryParseCollection(data, pos, size, Date::DAY_NAMES_ABBREVIATED, 7) < 0) {
+					error_message = "Expected an abbreviated day name (Mon, Tue, Wed, Thu, Fri, Sat, Sun)";
+					error_position = pos;
+					return false;
+				}
+				break;
+			case StrTimeSpecifier::FULL_WEEKDAY_NAME:
+				if (TryParseCollection(data, pos, size, Date::DAY_NAMES, 7) < 0) {
+					error_message = "Expected a full day name (Monday, Tuesday, etc...)";
+					error_position = pos;
+					return false;
+				}
+				break;
+			case StrTimeSpecifier::ABBREVIATED_MONTH_NAME: {
+				int32_t month = TryParseCollection(data, pos, size, Date::MONTH_NAMES_ABBREVIATED, 12);
+				if (month < 0) {
+					error_message = "Expected an abbreviated month name (Jan, Feb, Mar, etc..)";
+					error_position = pos;
+					return false;
+				}
+				result_data[1] = month + 1;
+				break;
+			}
+			case StrTimeSpecifier::FULL_MONTH_NAME: {
+				int32_t month = TryParseCollection(data, pos, size, Date::MONTH_NAMES, 12);
+				if (month < 0) {
+					error_message = "Expected a full month name (January, February, etc...)";
+					error_position = pos;
+					return false;
+				}
+				result_data[1] = month + 1;
+				break;
+			}
+			case StrTimeSpecifier::UTC_OFFSET: {
+				int hour_offset, minute_offset;
+				if (!Timestamp::TryParseUTCOffset(data, pos, size, hour_offset, minute_offset)) {
+					error_message = "Expected +HH[MM] or -HH[MM]";
+					error_position = pos;
+					return false;
+				}
+				result_data[7] = hour_offset * Interval::MINS_PER_HOUR + minute_offset;
+				break;
+			}
+			case StrTimeSpecifier::TZ_NAME: {
+				// skip leading spaces
+				while (pos < size && StringUtil::CharacterIsSpace(data[pos])) {
+					pos++;
+				}
+				const auto tz_begin = data + pos;
+				// stop when we encounter a space or the end of the string
+				while (pos < size && !StringUtil::CharacterIsSpace(data[pos])) {
+					pos++;
+				}
+				const auto tz_end = data + pos;
+				// Can't fully validate without a list - caller's responsibility.
+				// But tz must not be empty.
+				if (tz_end == tz_begin) {
+					error_message = "Empty Time Zone name";
+					error_position = tz_begin - data;
+					return false;
+				}
+				result.tz.assign(tz_begin, tz_end);
+				break;
+			}
+			default:
+				throw NotImplementedException("Unsupported specifier for strptime");
+			}
+		}
+	}
+	// skip trailing spaces
+	while (pos < size && StringUtil::CharacterIsSpace(data[pos])) {
+		pos++;
+	}
+	if (pos != size) {
+		error_message = "Full specifier did not match: trailing characters";
+		error_position = pos;
+		return false;
+	}
+	if (ampm != TimeSpecifierAMOrPM::TIME_SPECIFIER_NONE) {
+		if (result_data[3] > 12) {
+			error_message =
+			    "Invalid hour: " + to_string(result_data[3]) + " AM/PM, expected an hour within the range [0..12]";
+			return false;
+		}
+		// adjust the hours based on the AM or PM specifier
+		if (ampm == TimeSpecifierAMOrPM::TIME_SPECIFIER_AM) {
+			// AM: 12AM=0, 1AM=1, 2AM=2, ..., 11AM=11
+			if (result_data[3] == 12) {
+				result_data[3] = 0;
+			}
+		} else {
+			// PM: 12PM=12, 1PM=13, 2PM=14, ..., 11PM=23
+			if (result_data[3] != 12) {
+				result_data[3] += 12;
+			}
+		}
+	}
+	switch (offset_specifier) {
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST:
+	case StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST: {
+		// Adjust weekday to be 0-based for the week type
+		weekday = (weekday + 7 - int(offset_specifier == StrTimeSpecifier::WEEK_NUMBER_PADDED_MON_FIRST)) % 7;
+		// Get the start of week 1, move back 7 days and then weekno * 7 + weekday gives the date
+		const auto jan1 = Date::FromDate(result_data[0], 1, 1);
+		auto yeardate = Date::GetMondayOfCurrentWeek(jan1);
+		yeardate -= int(offset_specifier == StrTimeSpecifier::WEEK_NUMBER_PADDED_SUN_FIRST);
+		// Is there a week 0?
+		yeardate -= 7 * int(yeardate >= jan1);
+		yeardate += weekno * 7 + weekday;
+		Date::Convert(yeardate, result_data[0], result_data[1], result_data[2]);
+		break;
+	}
+	case StrTimeSpecifier::DAY_OF_YEAR_PADDED:
+	case StrTimeSpecifier::DAY_OF_YEAR_DECIMAL: {
+		auto yeardate = Date::FromDate(result_data[0], 1, 1);
+		yeardate += yearday - 1;
+		Date::Convert(yeardate, result_data[0], result_data[1], result_data[2]);
+		break;
+	}
+	case StrTimeSpecifier::DAY_OF_MONTH_PADDED:
+	case StrTimeSpecifier::DAY_OF_MONTH:
+	case StrTimeSpecifier::MONTH_DECIMAL_PADDED:
+	case StrTimeSpecifier::MONTH_DECIMAL:
+		// m/d overrides UWw/j
+		break;
+	default:
+		D_ASSERT(offset_specifier == StrTimeSpecifier::WEEKDAY_DECIMAL);
+		break;
+	}
+
+	return true;
+}
+
+struct StrpTimeBindData : public FunctionData {
+	explicit StrpTimeBindData(StrpTimeFormat format_p, string format_string_p)
+	    : format(move(format_p)), format_string(move(format_string_p)) {
+	}
+
+	StrpTimeFormat format;
+	string format_string;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<StrpTimeBindData>(format, format_string);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const StrpTimeBindData &)other_p;
+		return format_string == other.format_string;
+	}
+};
+
+static unique_ptr<FunctionData> StrpTimeBindFunction(ClientContext &context, ScalarFunction &bound_function,
+                                                     vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments[1]->IsFoldable()) {
+		throw InvalidInputException("strptime format must be a constant");
+	}
+	Value options_str = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+	string format_string = options_str.ToString();
+	StrpTimeFormat format;
+	if (!options_str.IsNull()) {
+		if (options_str.type().id() != LogicalTypeId::VARCHAR) {
+			throw InvalidInputException("strptime format must be a string");
+		}
+		format.format_specifier = format_string;
+		string error = StrTimeFormat::ParseFormatSpecifier(format_string, format);
+		if (!error.empty()) {
+			throw InvalidInputException("Failed to parse format specifier %s: %s", format_string, error);
+		}
+		if (format.HasFormatSpecifier(StrTimeSpecifier::UTC_OFFSET)) {
+			bound_function.return_type = LogicalType::TIMESTAMP_TZ;
+		}
+	}
+	return make_unique<StrpTimeBindData>(format, format_string);
+}
+
+StrpTimeFormat::ParseResult StrpTimeFormat::Parse(const string &format_string, const string &text) {
+	StrpTimeFormat format;
+	format.format_specifier = format_string;
+	string error = StrTimeFormat::ParseFormatSpecifier(format_string, format);
+	if (!error.empty()) {
+		throw InvalidInputException("Failed to parse format specifier %s: %s", format_string, error);
+	}
+	StrpTimeFormat::ParseResult result;
+	if (!format.Parse(text, result)) {
+		throw InvalidInputException("Failed to parse string \"%s\" with format specifier \"%s\"", text, format_string);
+	}
+	return result;
+}
+
+string StrpTimeFormat::FormatStrpTimeError(const string &input, idx_t position) {
+	if (position == DConstants::INVALID_INDEX) {
+		return string();
+	}
+	return input + "\n" + string(position, ' ') + "^";
+}
+
+date_t StrpTimeFormat::ParseResult::ToDate() {
+	return Date::FromDate(data[0], data[1], data[2]);
+}
+
+timestamp_t StrpTimeFormat::ParseResult::ToTimestamp() {
+	date_t date = Date::FromDate(data[0], data[1], data[2]);
+	const auto hour_offset = data[7] / Interval::MINS_PER_HOUR;
+	const auto mins_offset = data[7] % Interval::MINS_PER_HOUR;
+	dtime_t time = Time::FromTime(data[3] - hour_offset, data[4] - mins_offset, data[5], data[6]);
+	return Timestamp::FromDatetime(date, time);
+}
+
+string StrpTimeFormat::ParseResult::FormatError(string_t input, const string &format_specifier) {
+	return StringUtil::Format("Could not parse string \"%s\" according to format specifier \"%s\"\n%s\nError: %s",
+	                          input.GetString(), format_specifier,
+	                          FormatStrpTimeError(input.GetString(), error_position), error_message);
+}
+
+bool StrpTimeFormat::TryParseDate(string_t input, date_t &result, string &error_message) {
+	ParseResult parse_result;
+	if (!Parse(input, parse_result)) {
+		error_message = parse_result.FormatError(input, format_specifier);
+		return false;
+	}
+	result = parse_result.ToDate();
+	return true;
+}
+
+bool StrpTimeFormat::TryParseTimestamp(string_t input, timestamp_t &result, string &error_message) {
+	ParseResult parse_result;
+	if (!Parse(input, parse_result)) {
+		error_message = parse_result.FormatError(input, format_specifier);
+		return false;
+	}
+	result = parse_result.ToTimestamp();
+	return true;
+}
+
+date_t StrpTimeFormat::ParseDate(string_t input) {
+	ParseResult result;
+	if (!Parse(input, result)) {
+		throw InvalidInputException(result.FormatError(input, format_specifier));
+	}
+	return result.ToDate();
+}
+
+timestamp_t StrpTimeFormat::ParseTimestamp(string_t input) {
+	ParseResult result;
+	if (!Parse(input, result)) {
+		throw InvalidInputException(result.FormatError(input, format_specifier));
+	}
+	return result.ToTimestamp();
+}
+
+static void StrpTimeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (StrpTimeBindData &)*func_expr.bind_info;
+
+	if (ConstantVector::IsNull(args.data[1])) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		return;
+	}
+	UnaryExecutor::Execute<string_t, timestamp_t>(args.data[0], result, args.size(),
+	                                              [&](string_t input) { return info.format.ParseTimestamp(input); });
+}
+
+void StrpTimeFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet strptime("strptime");
+
+	strptime.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::TIMESTAMP,
+	                                    StrpTimeFunction, false, false, StrpTimeBindFunction));
+
+	set.AddFunction(strptime);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+struct ToYearsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.days = 0;
+		result.micros = 0;
+		if (!TryMultiplyOperator::Operation<int32_t, int32_t, int32_t>(input, Interval::MONTHS_PER_YEAR,
+		                                                               result.months)) {
+			throw OutOfRangeException("Interval value %d years out of range", input);
+		}
+		return result;
+	}
+};
+
+struct ToMonthsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = input;
+		result.days = 0;
+		result.micros = 0;
+		return result;
+	}
+};
+
+struct ToDaysOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = input;
+		result.micros = 0;
+		return result;
+	}
+};
+
+struct ToHoursOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = 0;
+		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_HOUR,
+		                                                               result.micros)) {
+			throw OutOfRangeException("Interval value %d hours out of range", input);
+		}
+		return result;
+	}
+};
+
+struct ToMinutesOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = 0;
+		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_MINUTE,
+		                                                               result.micros)) {
+			throw OutOfRangeException("Interval value %d minutes out of range", input);
+		}
+		return result;
+	}
+};
+
+struct ToSecondsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = 0;
+		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_SEC,
+		                                                               result.micros)) {
+			throw OutOfRangeException("Interval value %d seconds out of range", input);
+		}
+		return result;
+	}
+};
+
+struct ToMilliSecondsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = 0;
+		if (!TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(input, Interval::MICROS_PER_MSEC,
+		                                                               result.micros)) {
+			throw OutOfRangeException("Interval value %d milliseconds out of range", input);
+		}
+		return result;
+	}
+};
+
+struct ToMicroSecondsOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		interval_t result;
+		result.months = 0;
+		result.days = 0;
+		result.micros = input;
+		return result;
+	}
+};
+
+void ToIntervalFun::RegisterFunction(BuiltinFunctions &set) {
+	// register the individual operators
+	set.AddFunction(ScalarFunction("to_years", {LogicalType::INTEGER}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int32_t, interval_t, ToYearsOperator>));
+	set.AddFunction(ScalarFunction("to_months", {LogicalType::INTEGER}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int32_t, interval_t, ToMonthsOperator>));
+	set.AddFunction(ScalarFunction("to_days", {LogicalType::INTEGER}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int32_t, interval_t, ToDaysOperator>));
+	set.AddFunction(ScalarFunction("to_hours", {LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int64_t, interval_t, ToHoursOperator>));
+	set.AddFunction(ScalarFunction("to_minutes", {LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int64_t, interval_t, ToMinutesOperator>));
+	set.AddFunction(ScalarFunction("to_seconds", {LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int64_t, interval_t, ToSecondsOperator>));
+	set.AddFunction(ScalarFunction("to_milliseconds", {LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int64_t, interval_t, ToMilliSecondsOperator>));
+	set.AddFunction(ScalarFunction("to_microseconds", {LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                               ScalarFunction::UnaryFunction<int64_t, interval_t, ToMicroSecondsOperator>));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterDateFunctions() {
+	Register<AgeFun>();
+	Register<DateDiffFun>();
+	Register<DatePartFun>();
+	Register<DateSubFun>();
+	Register<DateTruncFun>();
+	Register<CurrentTimeFun>();
+	Register<CurrentDateFun>();
+	Register<CurrentTimestampFun>();
+	Register<EpochFun>();
+	Register<MakeDateFun>();
+	Register<StrfTimeFun>();
+	Register<StrpTimeFun>();
+	Register<ToIntervalFun>();
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+static void EnumFirstFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.GetTypes().size() == 1);
+	auto &enum_vector = EnumType::GetValuesInsertOrder(input.GetTypes()[0]);
+	auto val = Value(enum_vector.GetValue(0));
+	result.Reference(val);
+}
+
+static void EnumLastFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.GetTypes().size() == 1);
+	auto enum_size = EnumType::GetSize(input.GetTypes()[0]);
+	auto &enum_vector = EnumType::GetValuesInsertOrder(input.GetTypes()[0]);
+	auto val = Value(enum_vector.GetValue(enum_size - 1));
+	result.Reference(val);
+}
+
+static void EnumRangeFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.GetTypes().size() == 1);
+	auto enum_size = EnumType::GetSize(input.GetTypes()[0]);
+	auto &enum_vector = EnumType::GetValuesInsertOrder(input.GetTypes()[0]);
+	vector<Value> enum_values;
+	for (idx_t i = 0; i < enum_size; i++) {
+		enum_values.emplace_back(enum_vector.GetValue(i));
+	}
+	auto val = Value::LIST(enum_values);
+	result.Reference(val);
+}
+
+static void EnumRangeBoundaryFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.GetTypes().size() == 2);
+	idx_t start, end;
+	auto first_param = input.GetValue(0, 0);
+	auto second_param = input.GetValue(1, 0);
+
+	auto &enum_vector = first_param.IsNull() ? EnumType::GetValuesInsertOrder(input.GetTypes()[1])
+	                                         : EnumType::GetValuesInsertOrder(input.GetTypes()[0]);
+
+	if (first_param.IsNull()) {
+		start = 0;
+	} else {
+		start = first_param.GetValue<uint32_t>();
+	}
+	if (second_param.IsNull()) {
+		end = EnumType::GetSize(input.GetTypes()[0]);
+	} else {
+		end = second_param.GetValue<uint32_t>() + 1;
+	}
+	vector<Value> enum_values;
+	for (idx_t i = start; i < end; i++) {
+		enum_values.emplace_back(enum_vector.GetValue(i));
+	}
+	Value val;
+	if (enum_values.empty()) {
+		val = Value::EMPTYLIST(LogicalType::VARCHAR);
+	} else {
+		val = Value::LIST(enum_values);
+	}
+	result.Reference(val);
+}
+
+unique_ptr<FunctionData> BindEnumFunction(ClientContext &context, ScalarFunction &bound_function,
+                                          vector<unique_ptr<Expression>> &arguments) {
+	if (arguments[0]->return_type.id() != LogicalTypeId::ENUM) {
+		throw BinderException("This function needs an ENUM as an argument");
+	}
+	return nullptr;
+}
+
+unique_ptr<FunctionData> BindEnumRangeBoundaryFunction(ClientContext &context, ScalarFunction &bound_function,
+                                                       vector<unique_ptr<Expression>> &arguments) {
+	if (arguments[0]->return_type.id() != LogicalTypeId::ENUM && arguments[0]->return_type != LogicalType::SQLNULL) {
+		throw BinderException("This function needs an ENUM as an argument");
+	}
+	if (arguments[1]->return_type.id() != LogicalTypeId::ENUM && arguments[1]->return_type != LogicalType::SQLNULL) {
+		throw BinderException("This function needs an ENUM as an argument");
+	}
+	if (arguments[0]->return_type == LogicalType::SQLNULL && arguments[1]->return_type == LogicalType::SQLNULL) {
+		throw BinderException("This function needs an ENUM as an argument");
+	}
+	if (arguments[0]->return_type.id() == LogicalTypeId::ENUM &&
+	    arguments[1]->return_type.id() == LogicalTypeId::ENUM &&
+	    arguments[0]->return_type != arguments[1]->return_type) {
+
+		throw BinderException("The parameters need to link to ONLY one enum OR be NULL ");
+	}
+	return nullptr;
+}
+
+void EnumFirst::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("enum_first", {LogicalType::ANY}, LogicalType::VARCHAR, EnumFirstFunction, false,
+	                               BindEnumFunction));
+}
+
+void EnumLast::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("enum_last", {LogicalType::ANY}, LogicalType::VARCHAR, EnumLastFunction, false,
+	                               BindEnumFunction));
+}
+
+void EnumRange::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("enum_range", {LogicalType::ANY}, LogicalType::LIST(LogicalType::VARCHAR),
+	                               EnumRangeFunction, false, BindEnumFunction));
+}
+
+void EnumRangeBoundary::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("enum_range_boundary", {LogicalType::ANY, LogicalType::ANY},
+	                               LogicalType::LIST(LogicalType::VARCHAR), EnumRangeBoundaryFunction, false,
+	                               BindEnumRangeBoundaryFunction));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterEnumFunctions() {
+	Register<EnumFirst>();
+	Register<EnumLast>();
+	Register<EnumRange>();
+	Register<EnumRangeBoundary>();
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+static void AliasFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	Value v(state.expr.alias.empty() ? func_expr.children[0]->GetName() : state.expr.alias);
+	result.Reference(v);
+}
+
+void AliasFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("alias", {LogicalType::ANY}, LogicalType::VARCHAR, AliasFunction));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct ConstantOrNullBindData : public FunctionData {
+	explicit ConstantOrNullBindData(Value val) : value(move(val)) {
+	}
+
+	Value value;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<ConstantOrNullBindData>(value);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const ConstantOrNullBindData &)other_p;
+		return value == other.value;
+	}
+};
+
+static void ConstantOrNullFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (ConstantOrNullBindData &)*func_expr.bind_info;
+	result.Reference(info.value);
+	for (idx_t idx = 0; idx < args.ColumnCount(); idx++) {
+		switch (args.data[idx].GetVectorType()) {
+		case VectorType::FLAT_VECTOR: {
+			auto &input_mask = FlatVector::Validity(args.data[idx]);
+			if (!input_mask.AllValid()) {
+				// there are null values: need to merge them into the result
+				result.Normalify(args.size());
+				auto &result_mask = FlatVector::Validity(result);
+				result_mask.Combine(input_mask, args.size());
+			}
+			break;
+		}
+		case VectorType::CONSTANT_VECTOR: {
+			if (ConstantVector::IsNull(args.data[idx])) {
+				// input is constant null, return constant null
+				result.Reference(info.value);
+				ConstantVector::SetNull(result, true);
+				return;
+			}
+			break;
+		}
+		default: {
+			VectorData vdata;
+			args.data[idx].Orrify(args.size(), vdata);
+			if (!vdata.validity.AllValid()) {
+				result.Normalify(args.size());
+				auto &result_mask = FlatVector::Validity(result);
+				for (idx_t i = 0; i < args.size(); i++) {
+					if (!vdata.validity.RowIsValid(vdata.sel->get_index(i))) {
+						result_mask.SetInvalid(i);
+					}
+				}
+			}
+			break;
+		}
+		}
+	}
+}
+
+ScalarFunction ConstantOrNull::GetFunction(LogicalType return_type) {
+	return ScalarFunction("constant_or_null", {}, move(return_type), ConstantOrNullFunction);
+}
+
+unique_ptr<FunctionData> ConstantOrNull::Bind(Value value) {
+	return make_unique<ConstantOrNullBindData>(move(value));
+}
+
+bool ConstantOrNull::IsConstantOrNull(BoundFunctionExpression &expr, const Value &val) {
+	if (expr.function.name != "constant_or_null") {
+		return false;
+	}
+	D_ASSERT(expr.bind_info);
+	auto &bind_data = (ConstantOrNullBindData &)*expr.bind_info;
+	D_ASSERT(bind_data.value.type() == val.type());
+	return bind_data.value == val;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct CurrentSettingBindData : public FunctionData {
+	explicit CurrentSettingBindData(Value value_p) : value(move(value_p)) {
+	}
+
+	Value value;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<CurrentSettingBindData>(value);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const CurrentSettingBindData &)other_p;
+		return Value::NotDistinctFrom(value, other.value);
+	}
+};
+
+static void CurrentSettingFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (CurrentSettingBindData &)*func_expr.bind_info;
+	result.Reference(info.value);
+}
+
+unique_ptr<FunctionData> CurrentSettingBind(ClientContext &context, ScalarFunction &bound_function,
+                                            vector<unique_ptr<Expression>> &arguments) {
+
+	auto &key_child = arguments[0];
+
+	if (key_child->return_type.id() != LogicalTypeId::VARCHAR ||
+	    key_child->return_type.id() != LogicalTypeId::VARCHAR || !key_child->IsFoldable()) {
+		throw ParserException("Key name for current_setting needs to be a constant string");
+	}
+	Value key_val = ExpressionExecutor::EvaluateScalar(*key_child.get());
+	D_ASSERT(key_val.type().id() == LogicalTypeId::VARCHAR);
+	auto &key_str = StringValue::Get(key_val);
+	if (key_val.IsNull() || key_str.empty()) {
+		throw ParserException("Key name for current_setting needs to be neither NULL nor empty");
+	}
+
+	auto key = StringUtil::Lower(key_str);
+	Value val;
+	if (!context.TryGetCurrentSetting(key, val)) {
+		throw InvalidInputException("unrecognized configuration parameter \"%s\"", key_str);
+	}
+
+	bound_function.return_type = val.type();
+	return make_unique<CurrentSettingBindData>(val);
+}
+
+void CurrentSettingFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("current_setting", {LogicalType::VARCHAR}, LogicalType::ANY, CurrentSettingFunction,
+	                               false, CurrentSettingBind));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+static void HashFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	args.Hash(result);
+}
+
+void HashFun::RegisterFunction(BuiltinFunctions &set) {
+	auto hash_fun = ScalarFunction("hash", {LogicalType::ANY}, LogicalType::HASH, HashFunction);
+	hash_fun.varargs = LogicalType::ANY;
+	set.AddFunction(hash_fun);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+template <class OP>
+struct LeastOperator {
+	template <class T>
+	static T Operation(T left, T right) {
+		return OP::Operation(left, right) ? left : right;
+	}
+};
+
+template <class T, class OP, bool IS_STRING = false>
+static void LeastGreatestFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	if (args.ColumnCount() == 1) {
+		// single input: nop
+		result.Reference(args.data[0]);
+		return;
+	}
+	auto result_type = VectorType::CONSTANT_VECTOR;
+	for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
+		if (args.data[col_idx].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			// non-constant input: result is not a constant vector
+			result_type = VectorType::FLAT_VECTOR;
+		}
+		if (IS_STRING) {
+			// for string vectors we add a reference to the heap of the children
+			StringVector::AddHeapReference(result, args.data[col_idx]);
+		}
+	}
+
+	auto result_data = FlatVector::GetData<T>(result);
+	auto &result_mask = FlatVector::Validity(result);
+	// copy over the first column
+	bool result_has_value[STANDARD_VECTOR_SIZE];
+	{
+		VectorData vdata;
+		args.data[0].Orrify(args.size(), vdata);
+		auto input_data = (T *)vdata.data;
+		for (idx_t i = 0; i < args.size(); i++) {
+			auto vindex = vdata.sel->get_index(i);
+			if (vdata.validity.RowIsValid(vindex)) {
+				result_data[i] = input_data[vindex];
+				result_has_value[i] = true;
+			} else {
+				result_has_value[i] = false;
+			}
+		}
+	}
+	// now handle the remainder of the columns
+	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
+		if (args.data[col_idx].GetVectorType() == VectorType::CONSTANT_VECTOR &&
+		    ConstantVector::IsNull(args.data[col_idx])) {
+			// ignore null vector
+			continue;
+		}
+
+		VectorData vdata;
+		args.data[col_idx].Orrify(args.size(), vdata);
+
+		auto input_data = (T *)vdata.data;
+		if (!vdata.validity.AllValid()) {
+			// potential new null entries: have to check the null mask
+			for (idx_t i = 0; i < args.size(); i++) {
+				auto vindex = vdata.sel->get_index(i);
+				if (vdata.validity.RowIsValid(vindex)) {
+					// not a null entry: perform the operation and add to new set
+					auto ivalue = input_data[vindex];
+					if (!result_has_value[i] || OP::template Operation<T>(ivalue, result_data[i])) {
+						result_has_value[i] = true;
+						result_data[i] = ivalue;
+					}
+				}
+			}
+		} else {
+			// no new null entries: only need to perform the operation
+			for (idx_t i = 0; i < args.size(); i++) {
+				auto vindex = vdata.sel->get_index(i);
+
+				auto ivalue = input_data[vindex];
+				if (!result_has_value[i] || OP::template Operation<T>(ivalue, result_data[i])) {
+					result_has_value[i] = true;
+					result_data[i] = ivalue;
+				}
+			}
+		}
+	}
+	for (idx_t i = 0; i < args.size(); i++) {
+		if (!result_has_value[i]) {
+			result_mask.SetInvalid(i);
+		}
+	}
+	result.SetVectorType(result_type);
+}
+
+template <typename T, class OP>
+ScalarFunction GetLeastGreatestFunction(const LogicalType &type) {
+	return ScalarFunction({type}, type, LeastGreatestFunction<T, OP>, true, false, nullptr, nullptr, nullptr, nullptr,
+	                      type);
+}
+
+template <class OP>
+static void RegisterLeastGreatest(BuiltinFunctions &set, const string &fun_name) {
+	ScalarFunctionSet fun_set(fun_name);
+	fun_set.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::BIGINT, LeastGreatestFunction<int64_t, OP>,
+	                                   true, false, nullptr, nullptr, nullptr, nullptr, LogicalType::BIGINT));
+	fun_set.AddFunction(ScalarFunction({LogicalType::HUGEINT}, LogicalType::HUGEINT,
+	                                   LeastGreatestFunction<hugeint_t, OP>, true, false, nullptr, nullptr, nullptr,
+	                                   nullptr, LogicalType::HUGEINT));
+	fun_set.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE, LeastGreatestFunction<double, OP>,
+	                                   true, false, nullptr, nullptr, nullptr, nullptr, LogicalType::DOUBLE));
+	fun_set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                   LeastGreatestFunction<string_t, OP, true>, true, false, nullptr, nullptr,
+	                                   nullptr, nullptr, LogicalType::VARCHAR));
+
+	fun_set.AddFunction(GetLeastGreatestFunction<timestamp_t, OP>(LogicalType::TIMESTAMP));
+	fun_set.AddFunction(GetLeastGreatestFunction<time_t, OP>(LogicalType::TIME));
+	fun_set.AddFunction(GetLeastGreatestFunction<date_t, OP>(LogicalType::DATE));
+
+	fun_set.AddFunction(GetLeastGreatestFunction<timestamp_t, OP>(LogicalType::TIMESTAMP_TZ));
+	fun_set.AddFunction(GetLeastGreatestFunction<time_t, OP>(LogicalType::TIME_TZ));
+
+	set.AddFunction(fun_set);
+}
+
+void LeastFun::RegisterFunction(BuiltinFunctions &set) {
+	RegisterLeastGreatest<duckdb::LessThan>(set, "least");
+}
+
+void GreatestFun::RegisterFunction(BuiltinFunctions &set) {
+	RegisterLeastGreatest<duckdb::GreaterThan>(set, "greatest");
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+struct StatsBindData : public FunctionData {
+	explicit StatsBindData(string stats_p = string()) : stats(move(stats_p)) {
+	}
+
+	string stats;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<StatsBindData>(stats);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const StatsBindData &)other_p;
+		return stats == other.stats;
+	}
+};
+
+static void StatsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (StatsBindData &)*func_expr.bind_info;
+	if (info.stats.empty()) {
+		info.stats = "No statistics";
+	}
+	Value v(info.stats);
+	result.Reference(v);
+}
+
+unique_ptr<FunctionData> StatsBind(ClientContext &context, ScalarFunction &bound_function,
+                                   vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<StatsBindData>();
+}
+
+static unique_ptr<BaseStatistics> StatsPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &bind_data = input.bind_data;
+	if (child_stats[0]) {
+		auto &info = (StatsBindData &)*bind_data;
+		info.stats = child_stats[0]->ToString();
+	}
+	return nullptr;
+}
+
+void StatsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("stats", {LogicalType::ANY}, LogicalType::VARCHAR, StatsFunction, true, StatsBind,
+	                               nullptr, StatsPropagateStats));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+static void TypeOfFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	Value v(args.data[0].GetType().ToString());
+	result.Reference(v);
+}
+
+void TypeOfFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("typeof", {LogicalType::ANY}, LogicalType::VARCHAR, TypeOfFunction));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterGenericFunctions() {
+	Register<AliasFun>();
+	Register<HashFun>();
+	Register<LeastFun>();
+	Register<GreatestFun>();
+	Register<StatsFun>();
+	Register<TypeOfFun>();
+	Register<CurrentSettingFun>();
+	Register<SystemFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+INDEX_TYPE ValueOffset(const INPUT_TYPE &value) {
+	return 0;
+}
+
+template <>
+int64_t ValueOffset(const list_entry_t &value) {
+	return value.offset;
+}
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+INDEX_TYPE ValueLength(const INPUT_TYPE &value) {
+	return 0;
+}
+
+template <>
+int64_t ValueLength(const list_entry_t &value) {
+	return value.length;
+}
+
+template <>
+int32_t ValueLength(const string_t &value) {
+	return LengthFun::Length<string_t, int32_t>(value);
+}
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+bool ClampIndex(INDEX_TYPE &index, const INPUT_TYPE &value) {
+	const auto length = ValueLength<INPUT_TYPE, INDEX_TYPE>(value);
+	if (index < 0) {
+		if (-index > length) {
+			return false;
+		}
+		index = length + index;
+	} else if (index > length) {
+		index = length;
+	}
+	return true;
+}
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+static bool ClampSlice(const INPUT_TYPE &value, INDEX_TYPE &begin, INDEX_TYPE &end, bool begin_valid, bool end_valid) {
+	// Clamp offsets
+	begin = begin_valid ? begin : 0;
+	end = end_valid ? end : ValueLength<INPUT_TYPE, INDEX_TYPE>(value);
+	if (!ClampIndex(begin, value) || !ClampIndex(end, value)) {
+		return false;
+	}
+	end = MaxValue<INDEX_TYPE>(begin, end);
+
+	return true;
+}
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+INPUT_TYPE SliceValue(Vector &result, INPUT_TYPE input, INDEX_TYPE begin, INDEX_TYPE end) {
+	return input;
+}
+
+template <>
+list_entry_t SliceValue(Vector &result, list_entry_t input, int64_t begin, int64_t end) {
+	input.offset += begin;
+	input.length = end - begin;
+	return input;
+}
+
+template <>
+string_t SliceValue(Vector &result, string_t input, int32_t begin, int32_t end) {
+	// one-based - zero has strange semantics
+	return SubstringFun::SubstringScalarFunction(result, input, begin + 1, end - begin);
+}
+
+template <typename INPUT_TYPE, typename INDEX_TYPE>
+static void ExecuteSlice(Vector &result, Vector &s, Vector &b, Vector &e, const idx_t count) {
+	if (result.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		auto rdata = ConstantVector::GetData<INPUT_TYPE>(result);
+		auto sdata = ConstantVector::GetData<INPUT_TYPE>(s);
+		auto bdata = ConstantVector::GetData<INDEX_TYPE>(b);
+		auto edata = ConstantVector::GetData<INDEX_TYPE>(e);
+
+		auto sliced = sdata[0];
+		auto begin = (bdata[0] > 0) ? bdata[0] - 1 : bdata[0];
+		auto end = edata[0];
+
+		auto svalid = !ConstantVector::IsNull(s);
+		auto bvalid = !ConstantVector::IsNull(b);
+		auto evalid = !ConstantVector::IsNull(e);
+
+		// Try to slice
+		if (!svalid || !ClampSlice(sliced, begin, end, bvalid, evalid)) {
+			ConstantVector::SetNull(result, true);
+		} else {
+			rdata[0] = SliceValue<INPUT_TYPE, INDEX_TYPE>(result, sliced, begin, end);
+		}
+	} else {
+		VectorData sdata, bdata, edata;
+
+		s.Orrify(count, sdata);
+		b.Orrify(count, bdata);
+		e.Orrify(count, edata);
+
+		auto rdata = FlatVector::GetData<INPUT_TYPE>(result);
+		auto &rmask = FlatVector::Validity(result);
+
+		for (idx_t i = 0; i < count; ++i) {
+			auto sidx = sdata.sel->get_index(i);
+			auto bidx = bdata.sel->get_index(i);
+			auto eidx = edata.sel->get_index(i);
+
+			auto sliced = ((INPUT_TYPE *)sdata.data)[sidx];
+			auto begin = ((INDEX_TYPE *)bdata.data)[bidx];
+			auto end = ((INDEX_TYPE *)edata.data)[eidx];
+
+			begin = (begin > 0) ? begin - 1 : begin;
+
+			auto svalid = sdata.validity.RowIsValid(sidx);
+			auto bvalid = bdata.validity.RowIsValid(bidx);
+			auto evalid = edata.validity.RowIsValid(eidx);
+
+			// Try to slice
+			if (!svalid || !ClampSlice(sliced, begin, end, bvalid, evalid)) {
+				rmask.SetInvalid(i);
+			} else {
+				rdata[i] = SliceValue<INPUT_TYPE, INDEX_TYPE>(result, sliced, begin, end);
+			}
+		}
+	}
+
+	result.Verify(count);
+}
+
+static void ArraySliceFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 3);
+	D_ASSERT(args.data.size() == 3);
+	auto count = args.size();
+
+	Vector &s = args.data[0];
+	Vector &b = args.data[1];
+	Vector &e = args.data[2];
+
+	s.Normalify(count);
+	switch (result.GetType().id()) {
+	case LogicalTypeId::LIST:
+		// Share the value dictionary as we are just going to slice it
+		ListVector::ReferenceEntry(result, s);
+		ExecuteSlice<list_entry_t, int64_t>(result, s, b, e, count);
+		break;
+	case LogicalTypeId::VARCHAR:
+		ExecuteSlice<string_t, int32_t>(result, s, b, e, count);
+		break;
+	default:
+		throw NotImplementedException("Specifier type not implemented");
+	}
+
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
+		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			break;
+		}
+	}
+}
+
+static unique_ptr<FunctionData> ArraySliceBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 3);
+	switch (arguments[0]->return_type.id()) {
+	case LogicalTypeId::LIST:
+		// The result is the same type
+		bound_function.return_type = arguments[0]->return_type;
+		break;
+	case LogicalTypeId::VARCHAR:
+		// string slice returns a string, but can only accept 32 bit integers
+		bound_function.return_type = arguments[0]->return_type;
+		bound_function.arguments[1] = LogicalType::INTEGER;
+		bound_function.arguments[2] = LogicalType::INTEGER;
+		break;
+	case LogicalTypeId::UNKNOWN:
+		bound_function.arguments[0] = LogicalTypeId::UNKNOWN;
+		bound_function.return_type = LogicalType::SQLNULL;
+		break;
+	default:
+		throw BinderException("ARRAY_SLICE can only operate on LISTs and VARCHARs");
+	}
+
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+void ArraySliceFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	ScalarFunction fun({LogicalType::ANY, LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::ANY,
+	                   ArraySliceFunction, false, false, ArraySliceBind);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction({"array_slice", "list_slice"}, fun);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+template <class T>
+static inline bool ValueEqualsOrNot(const T &left, const T &right) {
+	return left == right;
+}
+
+template <>
+inline bool ValueEqualsOrNot(const string_t &left, const string_t &right) {
+	return StringComparisonOperators::EqualsOrNot<false>(left, right);
+}
+
+struct ContainsFunctor {
+	static inline bool Initialize() {
+		return false;
+	}
+	static inline bool UpdateResultEntries(idx_t child_idx) {
+		return true;
+	}
+};
+
+struct PositionFunctor {
+	static inline int32_t Initialize() {
+		return 0;
+	}
+	static inline int32_t UpdateResultEntries(idx_t child_idx) {
+		return child_idx + 1;
+	}
+};
+
+template <class CHILD_TYPE, class RETURN_TYPE, class OP>
+static void TemplatedContainsOrPosition(DataChunk &args, ExpressionState &state, Vector &result,
+                                        bool is_nested = false) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto count = args.size();
+	Vector &list = args.data[0];
+	Vector &value_vector = args.data[1];
+
+	// Create a result vector of type RETURN_TYPE
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_entries = FlatVector::GetData<RETURN_TYPE>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	if (list.GetType().id() == LogicalTypeId::SQLNULL) {
+		result_validity.SetInvalid(0);
+		return;
+	}
+
+	auto list_size = ListVector::GetListSize(list);
+	auto &child_vector = ListVector::GetEntry(list);
+
+	VectorData child_data;
+	child_vector.Orrify(list_size, child_data);
+
+	VectorData list_data;
+	list.Orrify(count, list_data);
+	auto list_entries = (list_entry_t *)list_data.data;
+
+	VectorData value_data;
+	value_vector.Orrify(count, value_data);
+
+	// not required for a comparison of nested types
+	auto child_value = FlatVector::GetData<CHILD_TYPE>(child_vector);
+	auto values = FlatVector::GetData<CHILD_TYPE>(value_vector);
+
+	for (idx_t i = 0; i < count; i++) {
+		auto list_index = list_data.sel->get_index(i);
+		auto value_index = value_data.sel->get_index(i);
+
+		if (!list_data.validity.RowIsValid(list_index) || !value_data.validity.RowIsValid(value_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		const auto &list_entry = list_entries[list_index];
+
+		result_entries[i] = OP::Initialize();
+		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
+
+			auto child_value_idx = child_data.sel->get_index(list_entry.offset + child_idx);
+			if (!child_data.validity.RowIsValid(child_value_idx)) {
+				continue;
+			}
+
+			if (!is_nested) {
+				if (ValueEqualsOrNot<CHILD_TYPE>(child_value[child_value_idx], values[value_index])) {
+					result_entries[i] = OP::UpdateResultEntries(child_idx);
+					break; // Found value in list, no need to look further
+				}
+			} else {
+				// FIXME: using Value is less efficient than modifying the vector comparison code
+				// to more efficiently compare nested types
+				if (ValueEqualsOrNot<Value>(child_vector.GetValue(child_value_idx),
+				                            value_vector.GetValue(value_index))) {
+					result_entries[i] = OP::UpdateResultEntries(child_idx);
+					break; // Found value in list, no need to look further
+				}
+			}
+		}
+	}
+}
+
+template <class T, class OP>
+static void ListContainsOrPosition(DataChunk &args, ExpressionState &state, Vector &result) {
+	switch (args.data[1].GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		TemplatedContainsOrPosition<int8_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::INT16:
+		TemplatedContainsOrPosition<int16_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::INT32:
+		TemplatedContainsOrPosition<int32_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::INT64:
+		TemplatedContainsOrPosition<int64_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::INT128:
+		TemplatedContainsOrPosition<hugeint_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedContainsOrPosition<uint8_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedContainsOrPosition<uint16_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedContainsOrPosition<uint32_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedContainsOrPosition<uint64_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedContainsOrPosition<float, T, OP>(args, state, result);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedContainsOrPosition<double, T, OP>(args, state, result);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedContainsOrPosition<string_t, T, OP>(args, state, result);
+		break;
+	case PhysicalType::MAP:
+	case PhysicalType::STRUCT:
+	case PhysicalType::LIST:
+		TemplatedContainsOrPosition<int8_t, T, OP>(args, state, result, true);
+		break;
+	default:
+		throw NotImplementedException("This function has not been implemented for this type");
+	}
+}
+
+static void ListContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	return ListContainsOrPosition<bool, ContainsFunctor>(args, state, result);
+}
+
+static void ListPositionFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	return ListContainsOrPosition<int32_t, PositionFunctor>(args, state, result);
+}
+
+template <LogicalTypeId RETURN_TYPE>
+static unique_ptr<FunctionData> ListContainsOrPositionBind(ClientContext &context, ScalarFunction &bound_function,
+                                                           vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 2);
+
+	const auto &list = arguments[0]->return_type; // change to list
+	const auto &value = arguments[1]->return_type;
+	if (list.id() == LogicalTypeId::SQLNULL && value.id() == LogicalTypeId::SQLNULL) {
+		bound_function.arguments[0] = LogicalType::SQLNULL;
+		bound_function.arguments[1] = LogicalType::SQLNULL;
+		bound_function.return_type = LogicalType::SQLNULL;
+	} else if (list.id() == LogicalTypeId::SQLNULL || value.id() == LogicalTypeId::SQLNULL) {
+		// In case either the list or the value is NULL, return NULL
+		// Similar to behaviour of prestoDB
+		bound_function.arguments[0] = list;
+		bound_function.arguments[1] = value;
+		bound_function.return_type = LogicalTypeId::SQLNULL;
+	} else if (list.id() == LogicalTypeId::UNKNOWN) {
+		bound_function.return_type = RETURN_TYPE;
+		if (value.id() != LogicalTypeId::UNKNOWN) {
+			// only list is a parameter, cast it to a list of value type
+			bound_function.arguments[0] = LogicalType::LIST(value);
+			bound_function.arguments[1] = value;
+		}
+	} else if (value.id() == LogicalTypeId::UNKNOWN) {
+		// only value is a parameter: we expect the child type of list
+		auto const &child_type = ListType::GetChildType(list);
+		bound_function.arguments[0] = list;
+		bound_function.arguments[1] = child_type;
+		bound_function.return_type = RETURN_TYPE;
+	} else {
+		auto const &child_type = ListType::GetChildType(list);
+		auto max_child_type = LogicalType::MaxLogicalType(child_type, value);
+		auto list_type = LogicalType::LIST(max_child_type);
+
+		bound_function.arguments[0] = list_type;
+		bound_function.arguments[1] = value == max_child_type ? value : max_child_type;
+
+		// list_contains and list_position only differ in their return type
+		bound_function.return_type = RETURN_TYPE;
+	}
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+static unique_ptr<FunctionData> ListContainsBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	return ListContainsOrPositionBind<LogicalType::BOOLEAN>(context, bound_function, arguments);
+}
+
+static unique_ptr<FunctionData> ListPositionBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	return ListContainsOrPositionBind<LogicalType::INTEGER>(context, bound_function, arguments);
+}
+
+ScalarFunction ListContainsFun::GetFunction() {
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::ANY}, // argument list
+	                      LogicalType::BOOLEAN,                                    // return type
+	                      ListContainsFunction, false, false, ListContainsBind, nullptr);
+}
+
+ScalarFunction ListPositionFun::GetFunction() {
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::ANY}, // argument list
+	                      LogicalType::INTEGER,                                    // return type
+	                      ListPositionFunction, false, false, ListPositionBind, nullptr);
+}
+
+void ListContainsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_contains", "array_contains", "list_has", "array_has"}, GetFunction());
+}
+
+void ListPositionFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_position", "list_indexof", "array_position", "array_indexof"}, GetFunction());
+}
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+void ListFlattenFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 1);
+
+	Vector &input = args.data[0];
+	if (input.GetType().id() == LogicalTypeId::SQLNULL) {
+		result.Reference(input);
+		return;
+	}
+
+	idx_t count = args.size();
+
+	VectorData list_data;
+	input.Orrify(count, list_data);
+	auto list_entries = (list_entry_t *)list_data.data;
+
+	auto &child_vector = ListVector::GetEntry(input);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_entries = FlatVector::GetData<list_entry_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	if (child_vector.GetType().id() == LogicalTypeId::SQLNULL) {
+		auto result_entries = FlatVector::GetData<list_entry_t>(result);
+		for (idx_t i = 0; i < count; i++) {
+			auto list_index = list_data.sel->get_index(i);
+			if (!list_data.validity.RowIsValid(list_index)) {
+				result_validity.SetInvalid(i);
+				continue;
+			}
+			result_entries[i].offset = 0;
+			result_entries[i].length = 0;
+		}
+		return;
+	}
+
+	auto child_size = ListVector::GetListSize(input);
+	VectorData child_data;
+	child_vector.Orrify(child_size, child_data);
+	auto child_entries = (list_entry_t *)child_data.data;
+	auto &data_vector = ListVector::GetEntry(child_vector);
+
+	idx_t offset = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto list_index = list_data.sel->get_index(i);
+		if (!list_data.validity.RowIsValid(list_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+		auto list_entry = list_entries[list_index];
+
+		idx_t source_offset = 0;
+		// Find first valid child list entry to get offset
+		for (idx_t j = 0; j < list_entry.length; j++) {
+			auto child_list_index = child_data.sel->get_index(list_entry.offset + j);
+			if (child_data.validity.RowIsValid(child_list_index)) {
+				source_offset = child_entries[child_list_index].offset;
+				break;
+			}
+		}
+
+		idx_t length = 0;
+		// Find last valid child list entry to get length
+		for (idx_t j = list_entry.length - 1; j != (idx_t)-1; j--) {
+			auto child_list_index = child_data.sel->get_index(list_entry.offset + j);
+			if (child_data.validity.RowIsValid(child_list_index)) {
+				auto child_entry = child_entries[child_list_index];
+				length = child_entry.offset + child_entry.length - source_offset;
+				break;
+			}
+		}
+		ListVector::Append(result, data_vector, source_offset + length, source_offset);
+
+		result_entries[i].offset = offset;
+		result_entries[i].length = length;
+		offset += length;
+	}
+
+	if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+static unique_ptr<FunctionData> ListFlattenBind(ClientContext &context, ScalarFunction &bound_function,
+                                                vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 1);
+
+	auto &input_type = arguments[0]->return_type;
+	bound_function.arguments[0] = input_type;
+	if (input_type.id() == LogicalTypeId::SQLNULL) {
+		bound_function.return_type = LogicalType(LogicalTypeId::SQLNULL);
+		return make_unique<VariableReturnBindData>(bound_function.return_type);
+	}
+	if (input_type.id() == LogicalTypeId::UNKNOWN) {
+		bound_function.arguments[0] = LogicalType(LogicalTypeId::UNKNOWN);
+		bound_function.return_type = LogicalType(LogicalTypeId::SQLNULL);
+		return nullptr;
+	}
+	D_ASSERT(input_type.id() == LogicalTypeId::LIST);
+
+	auto child_type = ListType::GetChildType(input_type);
+	if (child_type.id() == LogicalType::SQLNULL) {
+		bound_function.return_type = input_type;
+		return make_unique<VariableReturnBindData>(bound_function.return_type);
+	}
+	D_ASSERT(child_type.id() == LogicalTypeId::LIST);
+
+	bound_function.return_type = child_type;
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+static unique_ptr<BaseStatistics> ListFlattenStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &list_stats = (ListStatistics &)*child_stats[0];
+	if (!list_stats.child_stats || list_stats.child_stats->type == LogicalTypeId::SQLNULL) {
+		return nullptr;
+	}
+
+	auto child_copy = list_stats.child_stats->Copy();
+	child_copy->validity_stats = make_unique<ValidityStatistics>(true);
+	return child_copy;
+}
+
+void ListFlattenFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction fun({LogicalType::LIST(LogicalType::LIST(LogicalType::ANY))}, LogicalType::LIST(LogicalType::ANY),
+	                   ListFlattenFunction, false, false, ListFlattenBind, nullptr, ListFlattenStats);
+	set.AddFunction({"flatten"}, fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+// FIXME: use a local state for each thread to increase performance?
+// FIXME: benchmark the use of simple_update against using update (if applicable)
+
+struct ListAggregatesBindData : public FunctionData {
+	ListAggregatesBindData(const LogicalType &stype_p, unique_ptr<Expression> aggr_expr_p);
+	~ListAggregatesBindData() override;
+
+	LogicalType stype;
+	unique_ptr<Expression> aggr_expr;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<ListAggregatesBindData>(stype, aggr_expr->Copy());
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const ListAggregatesBindData &)other_p;
+		return stype == other.stype && aggr_expr->Equals(other.aggr_expr.get());
+	}
+};
+
+ListAggregatesBindData::ListAggregatesBindData(const LogicalType &stype_p, unique_ptr<Expression> aggr_expr_p)
+    : stype(stype_p), aggr_expr(move(aggr_expr_p)) {
+}
+
+ListAggregatesBindData::~ListAggregatesBindData() {
+}
+
+struct StateVector {
+	StateVector(idx_t count_p, unique_ptr<Expression> aggr_expr_p)
+	    : count(count_p), aggr_expr(move(aggr_expr_p)), state_vector(Vector(LogicalType::POINTER, count_p)) {
+	}
+
+	~StateVector() {
+		// destroy objects within the aggregate states
+		auto &aggr = (BoundAggregateExpression &)*aggr_expr;
+		if (aggr.function.destructor) {
+			aggr.function.destructor(state_vector, count);
+		}
+	}
+
+	idx_t count;
+	unique_ptr<Expression> aggr_expr;
+	Vector state_vector;
+};
+
+struct FinalizeValueFunctor {
+	template <class T>
+	static Value FinalizeValue(T first) {
+		return Value::CreateValue(first);
+	}
+};
+
+struct FinalizeStringValueFunctor {
+	template <class T>
+	static Value FinalizeValue(T first) {
+		string_t value = first;
+		return Value::CreateValue(value);
+	}
+};
+
+struct AggregateFunctor {
+	template <class OP, class T, class MAP_TYPE = unordered_map<T, idx_t>>
+	static void ListExecuteFunction(Vector &result, Vector &state_vector, idx_t count) {
+	}
+};
+
+struct DistinctFunctor {
+	template <class OP, class T, class MAP_TYPE = unordered_map<T, idx_t>>
+	static void ListExecuteFunction(Vector &result, Vector &state_vector, idx_t count) {
+
+		VectorData sdata;
+		state_vector.Orrify(count, sdata);
+		auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+
+		auto result_data = FlatVector::GetData<list_entry_t>(result);
+
+		idx_t offset = 0;
+		for (idx_t i = 0; i < count; i++) {
+
+			auto state = states[sdata.sel->get_index(i)];
+			result_data[i].offset = offset;
+
+			if (!state->hist) {
+				result_data[i].length = 0;
+				continue;
+			}
+
+			result_data[i].length = state->hist->size();
+			offset += state->hist->size();
+
+			for (auto &entry : *state->hist) {
+				Value bucket_value = OP::template FinalizeValue<T>(entry.first);
+				ListVector::PushBack(result, bucket_value);
+			}
+		}
+		result.Verify(count);
+	}
+};
+
+struct UniqueFunctor {
+	template <class OP, class T, class MAP_TYPE = unordered_map<T, idx_t>>
+	static void ListExecuteFunction(Vector &result, Vector &state_vector, idx_t count) {
+
+		VectorData sdata;
+		state_vector.Orrify(count, sdata);
+		auto states = (HistogramAggState<T, MAP_TYPE> **)sdata.data;
+
+		auto result_data = FlatVector::GetData<uint64_t>(result);
+
+		for (idx_t i = 0; i < count; i++) {
+
+			auto state = states[sdata.sel->get_index(i)];
+
+			if (!state->hist) {
+				result_data[i] = 0;
+				continue;
+			}
+
+			result_data[i] = state->hist->size();
+		}
+		result.Verify(count);
+	}
+};
+
+template <class FUNCTION_FUNCTOR, bool IS_AGGR = false>
+static void ListAggregatesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+
+	auto count = args.size();
+	Vector &lists = args.data[0];
+
+	// set the result vector
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &result_validity = FlatVector::Validity(result);
+
+	if (lists.GetType().id() == LogicalTypeId::SQLNULL) {
+		result_validity.SetInvalid(0);
+		return;
+	}
+
+	// get the aggregate function
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (ListAggregatesBindData &)*func_expr.bind_info;
+	auto &aggr = (BoundAggregateExpression &)*info.aggr_expr;
+	AggregateInputData aggr_input_data(aggr.bind_info.get());
+
+	D_ASSERT(aggr.function.update);
+
+	auto lists_size = ListVector::GetListSize(lists);
+	auto &child_vector = ListVector::GetEntry(lists);
+
+	VectorData child_data;
+	child_vector.Orrify(lists_size, child_data);
+
+	VectorData lists_data;
+	lists.Orrify(count, lists_data);
+	auto list_entries = (list_entry_t *)lists_data.data;
+
+	// state_buffer holds the state for each list of this chunk
+	idx_t size = aggr.function.state_size();
+	auto state_buffer = unique_ptr<data_t[]>(new data_t[size * count]);
+
+	// state vector for initialize and finalize
+	StateVector state_vector(count, info.aggr_expr->Copy());
+	auto states = FlatVector::GetData<data_ptr_t>(state_vector.state_vector);
+
+	// state vector of STANDARD_VECTOR_SIZE holds the pointers to the states
+	Vector state_vector_update = Vector(LogicalType::POINTER);
+	auto states_update = FlatVector::GetData<data_ptr_t>(state_vector_update);
+
+	// selection vector pointing to the data
+	SelectionVector sel_vector(STANDARD_VECTOR_SIZE);
+	idx_t states_idx = 0;
+
+	for (idx_t i = 0; i < count; i++) {
+
+		// initialize the state for this list
+		auto state_ptr = state_buffer.get() + size * i;
+		states[i] = state_ptr;
+		aggr.function.initialize(states[i]);
+
+		auto lists_index = lists_data.sel->get_index(i);
+		const auto &list_entry = list_entries[lists_index];
+
+		// nothing to do for this list
+		if (!lists_data.validity.RowIsValid(lists_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		// skip empty list
+		if (list_entry.length == 0) {
+			continue;
+		}
+
+		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
+
+			// states vector is full, update
+			if (states_idx == STANDARD_VECTOR_SIZE) {
+
+				// update the aggregate state(s)
+				Vector slice = Vector(child_vector, sel_vector, states_idx);
+				aggr.function.update(&slice, aggr_input_data, 1, state_vector_update, states_idx);
+
+				// reset values
+				states_idx = 0;
+			}
+
+			auto source_idx = child_data.sel->get_index(list_entry.offset + child_idx);
+			sel_vector.set_index(states_idx, source_idx);
+			states_update[states_idx] = state_ptr;
+			states_idx++;
+		}
+	}
+
+	// update the remaining elements of the last list(s)
+	if (states_idx != 0) {
+		Vector slice = Vector(child_vector, sel_vector, states_idx);
+		aggr.function.update(&slice, aggr_input_data, 1, state_vector_update, states_idx);
+	}
+
+	if (IS_AGGR) {
+		// finalize all the aggregate states
+		aggr.function.finalize(state_vector.state_vector, aggr_input_data, result, count, 0);
+
+	} else {
+		// finalize manually to use the map
+		D_ASSERT(aggr.function.arguments.size() == 1);
+		auto key_type = aggr.function.arguments[0];
+
+		switch (key_type.InternalType()) {
+		case PhysicalType::BOOL:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, bool>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::UINT8:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint8_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::UINT16:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint16_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::UINT32:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint32_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::UINT64:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, uint64_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::INT8:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int8_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::INT16:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int16_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::INT32:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int32_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::INT64:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::FLOAT:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, float>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::DOUBLE:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, double>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::DATE32:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int32_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::DATE64:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::TIMESTAMP:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::TIME32:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int32_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::TIME64:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeValueFunctor, int64_t>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::STRING:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeStringValueFunctor, string>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::LARGE_STRING:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeStringValueFunctor, string>(
+			    result, state_vector.state_vector, count);
+			break;
+		case PhysicalType::VARCHAR:
+			FUNCTION_FUNCTOR::template ListExecuteFunction<FinalizeStringValueFunctor, string>(
+			    result, state_vector.state_vector, count);
+			break;
+		default:
+			throw InternalException("Unimplemented histogram aggregate");
+		}
+	}
+}
+
+static void ListAggregateFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+
+	D_ASSERT(args.ColumnCount() == 2);
+	ListAggregatesFunction<AggregateFunctor, true>(args, state, result);
+}
+
+static void ListDistinctFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+
+	D_ASSERT(args.ColumnCount() == 1);
+	ListAggregatesFunction<DistinctFunctor>(args, state, result);
+}
+
+static void ListUniqueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+
+	D_ASSERT(args.ColumnCount() == 1);
+	ListAggregatesFunction<UniqueFunctor>(args, state, result);
+}
+
+template <bool IS_AGGR = false>
+static unique_ptr<FunctionData> ListAggregatesBindFunction(ClientContext &context, ScalarFunction &bound_function,
+                                                           const LogicalType &list_child_type,
+                                                           AggregateFunction &aggr_function) {
+
+	// create the child expression and its type
+	vector<unique_ptr<Expression>> children;
+	auto expr = make_unique<BoundConstantExpression>(Value(list_child_type));
+	children.push_back(move(expr));
+
+	auto bound_aggr_function = AggregateFunction::BindAggregateFunction(context, aggr_function, move(children));
+	bound_function.arguments[0] = LogicalType::LIST(bound_aggr_function->function.arguments[0]);
+
+	if (IS_AGGR) {
+		bound_function.return_type = bound_aggr_function->function.return_type;
+	}
+
+	return make_unique<ListAggregatesBindData>(bound_function.return_type, move(bound_aggr_function));
+}
+
+template <bool IS_AGGR = false>
+static unique_ptr<FunctionData> ListAggregatesBind(ClientContext &context, ScalarFunction &bound_function,
+                                                   vector<unique_ptr<Expression>> &arguments) {
+
+	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
+		bound_function.arguments[0] = LogicalType::SQLNULL;
+		bound_function.return_type = LogicalType::SQLNULL;
+		return make_unique<VariableReturnBindData>(bound_function.return_type);
+	}
+
+	bool is_parameter = arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN;
+	auto list_child_type = is_parameter ? LogicalTypeId::UNKNOWN : ListType::GetChildType(arguments[0]->return_type);
+
+	string function_name = "histogram";
+	if (IS_AGGR) { // get the name of the aggregate function
+
+		if (!arguments[1]->IsFoldable()) {
+			throw InvalidInputException("Aggregate function name must be a constant");
+		}
+		// get the function name
+		Value function_value = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+		function_name = function_value.ToString();
+	}
+
+	// look up the aggregate function in the catalog
+	QueryErrorContext error_context(nullptr, 0);
+	auto func = (AggregateFunctionCatalogEntry *)Catalog::GetCatalog(context).GetEntry<AggregateFunctionCatalogEntry>(
+	    context, DEFAULT_SCHEMA, function_name, false, error_context);
+	D_ASSERT(func->type == CatalogType::AGGREGATE_FUNCTION_ENTRY);
+
+	if (is_parameter) {
+		bound_function.arguments[0] = LogicalTypeId::UNKNOWN;
+		bound_function.return_type = LogicalType::SQLNULL;
+		return nullptr;
+	}
+
+	// find a matching aggregate function
+	string error;
+	vector<LogicalType> types;
+	types.push_back(list_child_type);
+	auto best_function_idx = Function::BindFunction(func->name, func->functions, types, error);
+	if (best_function_idx == DConstants::INVALID_INDEX) {
+		throw BinderException("No matching aggregate function");
+	}
+
+	// found a matching function, bind it as an aggregate
+	auto &best_function = func->functions[best_function_idx];
+
+	if (IS_AGGR) {
+		return ListAggregatesBindFunction<IS_AGGR>(context, bound_function, list_child_type, best_function);
+	}
+
+	// create the unordered map histogram function
+	D_ASSERT(best_function.arguments.size() == 1);
+	auto key_type = best_function.arguments[0];
+	auto aggr_function = HistogramFun::GetHistogramUnorderedMap(key_type);
+	return ListAggregatesBindFunction<IS_AGGR>(context, bound_function, list_child_type, aggr_function);
+}
+
+static unique_ptr<FunctionData> ListAggregateBind(ClientContext &context, ScalarFunction &bound_function,
+                                                  vector<unique_ptr<Expression>> &arguments) {
+
+	// the list column and the name of the aggregate function
+	D_ASSERT(bound_function.arguments.size() == 2);
+	D_ASSERT(arguments.size() == 2);
+
+	return ListAggregatesBind<true>(context, bound_function, arguments);
+}
+
+static unique_ptr<FunctionData> ListDistinctBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+
+	D_ASSERT(bound_function.arguments.size() == 1);
+	D_ASSERT(arguments.size() == 1);
+	bound_function.return_type = arguments[0]->return_type;
+
+	return ListAggregatesBind<>(context, bound_function, arguments);
+}
+
+static unique_ptr<FunctionData> ListUniqueBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+
+	D_ASSERT(bound_function.arguments.size() == 1);
+	D_ASSERT(arguments.size() == 1);
+	bound_function.return_type = LogicalType::UBIGINT;
+
+	return ListAggregatesBind<>(context, bound_function, arguments);
+}
+
+ScalarFunction ListAggregateFun::GetFunction() {
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::VARCHAR}, LogicalType::ANY,
+	                      ListAggregateFunction, false, false, ListAggregateBind);
+}
+
+ScalarFunction ListDistinctFun::GetFunction() {
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY)}, LogicalType::LIST(LogicalType::ANY),
+	                      ListDistinctFunction, false, false, ListDistinctBind);
+}
+
+ScalarFunction ListUniqueFun::GetFunction() {
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY)}, LogicalType::UBIGINT, ListUniqueFunction, false, false,
+	                      ListUniqueBind);
+}
+
+void ListAggregateFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_aggregate", "array_aggregate", "list_aggr", "array_aggr"}, GetFunction());
+}
+
+void ListDistinctFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_distinct", "array_distinct"}, GetFunction());
+}
+
+void ListUniqueFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_unique", "array_unique"}, GetFunction());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void ListConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto count = args.size();
+
+	Vector &lhs = args.data[0];
+	Vector &rhs = args.data[1];
+	if (lhs.GetType().id() == LogicalTypeId::SQLNULL) {
+		result.Reference(rhs);
+		return;
+	}
+	if (rhs.GetType().id() == LogicalTypeId::SQLNULL) {
+		result.Reference(lhs);
+		return;
+	}
+
+	VectorData lhs_data;
+	VectorData rhs_data;
+	lhs.Orrify(count, lhs_data);
+	rhs.Orrify(count, rhs_data);
+	auto lhs_entries = (list_entry_t *)lhs_data.data;
+	auto rhs_entries = (list_entry_t *)rhs_data.data;
+
+	auto lhs_list_size = ListVector::GetListSize(lhs);
+	auto rhs_list_size = ListVector::GetListSize(rhs);
+	auto &lhs_child = ListVector::GetEntry(lhs);
+	auto &rhs_child = ListVector::GetEntry(rhs);
+	VectorData lhs_child_data;
+	VectorData rhs_child_data;
+	lhs_child.Orrify(lhs_list_size, lhs_child_data);
+	rhs_child.Orrify(rhs_list_size, rhs_child_data);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_entries = FlatVector::GetData<list_entry_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	idx_t offset = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto lhs_list_index = lhs_data.sel->get_index(i);
+		auto rhs_list_index = rhs_data.sel->get_index(i);
+		if (!lhs_data.validity.RowIsValid(lhs_list_index) && !rhs_data.validity.RowIsValid(rhs_list_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+		result_entries[i].offset = offset;
+		result_entries[i].length = 0;
+		if (lhs_data.validity.RowIsValid(lhs_list_index)) {
+			const auto &lhs_entry = lhs_entries[lhs_list_index];
+			result_entries[i].length += lhs_entry.length;
+			ListVector::Append(result, lhs_child, *lhs_child_data.sel, lhs_entry.offset + lhs_entry.length,
+			                   lhs_entry.offset);
+		}
+		if (rhs_data.validity.RowIsValid(rhs_list_index)) {
+			const auto &rhs_entry = rhs_entries[rhs_list_index];
+			result_entries[i].length += rhs_entry.length;
+			ListVector::Append(result, rhs_child, *rhs_child_data.sel, rhs_entry.offset + rhs_entry.length,
+			                   rhs_entry.offset);
+		}
+		offset += result_entries[i].length;
+	}
+	D_ASSERT(ListVector::GetListSize(result) == offset);
+
+	if (lhs.GetVectorType() == VectorType::CONSTANT_VECTOR && rhs.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+static unique_ptr<FunctionData> ListConcatBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 2);
+
+	auto &lhs = arguments[0]->return_type;
+	auto &rhs = arguments[1]->return_type;
+	if (lhs.id() == LogicalTypeId::SQLNULL && rhs.id() == LogicalTypeId::SQLNULL) {
+		bound_function.return_type = LogicalType::SQLNULL;
+	} else if (lhs.id() == LogicalTypeId::SQLNULL || rhs.id() == LogicalTypeId::SQLNULL) {
+		// we mimic postgres behaviour: list_concat(NULL, my_list) = my_list
+		bound_function.arguments[0] = lhs;
+		bound_function.arguments[1] = rhs;
+		bound_function.return_type = rhs.id() == LogicalTypeId::SQLNULL ? lhs : rhs;
+	} else {
+		D_ASSERT(lhs.id() == LogicalTypeId::LIST);
+		D_ASSERT(rhs.id() == LogicalTypeId::LIST);
+
+		// Resolve list type
+		LogicalType child_type = LogicalType::SQLNULL;
+		for (const auto &argument : arguments) {
+			child_type = LogicalType::MaxLogicalType(child_type, ListType::GetChildType(argument->return_type));
+		}
+		auto list_type = LogicalType::LIST(move(child_type));
+
+		bound_function.arguments[0] = list_type;
+		bound_function.arguments[1] = list_type;
+		bound_function.return_type = list_type;
+	}
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+static unique_ptr<BaseStatistics> ListConcatStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	D_ASSERT(child_stats.size() == 2);
+	if (!child_stats[0] || !child_stats[1]) {
+		return nullptr;
+	}
+
+	auto &left_stats = (ListStatistics &)*child_stats[0];
+	auto &right_stats = (ListStatistics &)*child_stats[1];
+
+	auto stats = left_stats.Copy();
+	stats->Merge(right_stats);
+
+	return stats;
+}
+
+ScalarFunction ListConcatFun::GetFunction() {
+	// the arguments and return types are actually set in the binder function
+	return ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::LIST(LogicalType::ANY)},
+	                      LogicalType::LIST(LogicalType::ANY), ListConcatFunction, false, false, ListConcatBind,
+	                      nullptr, ListConcatStats);
+}
+
+void ListConcatFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"list_concat", "list_cat", "array_concat", "array_cat"}, GetFunction());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T, bool HEAP_REF = false, bool VALIDITY_ONLY = false>
+void ListExtractTemplate(idx_t count, VectorData &list_data, VectorData &offsets_data, Vector &child_vector,
+                         idx_t list_size, Vector &result) {
+	VectorData child_data;
+	child_vector.Orrify(list_size, child_data);
+
+	T *result_data;
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	if (!VALIDITY_ONLY) {
+		result_data = FlatVector::GetData<T>(result);
+	}
+	auto &result_mask = FlatVector::Validity(result);
+
+	// heap-ref once
+	if (HEAP_REF) {
+		StringVector::AddHeapReference(result, child_vector);
+	}
+
+	// this is lifted from ExecuteGenericLoop because we can't push the list child data into this otherwise
+	// should have gone with GetValue perhaps
+	for (idx_t i = 0; i < count; i++) {
+		auto list_index = list_data.sel->get_index(i);
+		auto offsets_index = offsets_data.sel->get_index(i);
+		if (list_data.validity.RowIsValid(list_index) && offsets_data.validity.RowIsValid(offsets_index)) {
+			auto list_entry = ((list_entry_t *)list_data.data)[list_index];
+			auto offsets_entry = ((int64_t *)offsets_data.data)[offsets_index];
+
+			// 1-based indexing
+			if (offsets_entry == 0) {
+				result_mask.SetInvalid(i);
+				continue;
+			}
+			offsets_entry = (offsets_entry > 0) ? offsets_entry - 1 : offsets_entry;
+
+			idx_t child_offset;
+			if (offsets_entry < 0) {
+				if ((idx_t)-offsets_entry > list_entry.length) {
+					result_mask.SetInvalid(i);
+					continue;
+				}
+				child_offset = list_entry.offset + list_entry.length + offsets_entry;
+			} else {
+				if ((idx_t)offsets_entry >= list_entry.length) {
+					result_mask.SetInvalid(i);
+					continue;
+				}
+				child_offset = list_entry.offset + offsets_entry;
+			}
+			if (child_data.validity.RowIsValid(child_offset)) {
+				if (!VALIDITY_ONLY) {
+					result_data[i] = ((T *)child_data.data)[child_offset];
+				}
+			} else {
+				result_mask.SetInvalid(i);
+			}
+		} else {
+			result_mask.SetInvalid(i);
+		}
+	}
+	if (count == 1) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+static void ExecuteListExtractInternal(const idx_t count, VectorData &list, VectorData &offsets, Vector &child_vector,
+                                       idx_t list_size, Vector &result) {
+	D_ASSERT(child_vector.GetType() == result.GetType());
+	switch (result.GetType().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		ListExtractTemplate<int8_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::INT16:
+		ListExtractTemplate<int16_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::INT32:
+		ListExtractTemplate<int32_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::INT64:
+		ListExtractTemplate<int64_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::INT128:
+		ListExtractTemplate<hugeint_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::UINT8:
+		ListExtractTemplate<uint8_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::UINT16:
+		ListExtractTemplate<uint16_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::UINT32:
+		ListExtractTemplate<uint32_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::UINT64:
+		ListExtractTemplate<uint64_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::FLOAT:
+		ListExtractTemplate<float>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::DOUBLE:
+		ListExtractTemplate<double>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::VARCHAR:
+		ListExtractTemplate<string_t, true>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::INTERVAL:
+		ListExtractTemplate<interval_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	case PhysicalType::STRUCT: {
+		auto &entries = StructVector::GetEntries(child_vector);
+		auto &result_entries = StructVector::GetEntries(result);
+		D_ASSERT(entries.size() == result_entries.size());
+		// extract the child entries of the struct
+		for (idx_t i = 0; i < entries.size(); i++) {
+			ExecuteListExtractInternal(count, list, offsets, *entries[i], list_size, *result_entries[i]);
+		}
+		// extract the validity mask
+		ListExtractTemplate<bool, false, true>(count, list, offsets, child_vector, list_size, result);
+		break;
+	}
+	case PhysicalType::LIST: {
+		// nested list: we have to reference the child
+		auto &child_child_list = ListVector::GetEntry(child_vector);
+
+		ListVector::GetEntry(result).Reference(child_child_list);
+		ListVector::SetListSize(result, ListVector::GetListSize(child_vector));
+		ListExtractTemplate<list_entry_t>(count, list, offsets, child_vector, list_size, result);
+		break;
+	}
+	default:
+		throw NotImplementedException("Unimplemented type for LIST_EXTRACT");
+	}
+}
+
+static void ExecuteListExtract(Vector &result, Vector &list, Vector &offsets, const idx_t count) {
+	D_ASSERT(list.GetType().id() == LogicalTypeId::LIST);
+	VectorData list_data;
+	VectorData offsets_data;
+
+	list.Orrify(count, list_data);
+	offsets.Orrify(count, offsets_data);
+	ExecuteListExtractInternal(count, list_data, offsets_data, ListVector::GetEntry(list),
+	                           ListVector::GetListSize(list), result);
+	result.Verify(count);
+}
+
+static void ExecuteStringExtract(Vector &result, Vector &input_vector, Vector &subscript_vector, const idx_t count) {
+	BinaryExecutor::Execute<string_t, int64_t, string_t>(
+	    input_vector, subscript_vector, result, count, [&](string_t input_string, int64_t subscript) {
+		    return SubstringFun::SubstringScalarFunction(result, input_string, subscript, 1);
+	    });
+}
+
+static void ListExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto count = args.size();
+
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
+		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+		}
+	}
+
+	Vector &base = args.data[0];
+	Vector &subscript = args.data[1];
+
+	switch (base.GetType().id()) {
+	case LogicalTypeId::LIST:
+		ExecuteListExtract(result, base, subscript, count);
+		break;
+	case LogicalTypeId::VARCHAR:
+		ExecuteStringExtract(result, base, subscript, count);
+		break;
+	case LogicalTypeId::SQLNULL:
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+		break;
+	default:
+		throw NotImplementedException("Specifier type not implemented");
+	}
+}
+
+static unique_ptr<FunctionData> ListExtractBind(ClientContext &context, ScalarFunction &bound_function,
+                                                vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 2);
+	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
+		bound_function.arguments[0] = LogicalType::SQLNULL;
+		bound_function.return_type = LogicalType::SQLNULL;
+	} else {
+		D_ASSERT(LogicalTypeId::LIST == arguments[0]->return_type.id());
+		// list extract returns the child type of the list as return type
+		bound_function.return_type = ListType::GetChildType(arguments[0]->return_type);
+	}
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+static unique_ptr<BaseStatistics> ListExtractStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &list_stats = (ListStatistics &)*child_stats[0];
+	if (!list_stats.child_stats) {
+		return nullptr;
+	}
+	auto child_copy = list_stats.child_stats->Copy();
+	// list_extract always pushes a NULL, since if the offset is out of range for a list it inserts a null
+	child_copy->validity_stats = make_unique<ValidityStatistics>(true);
+	return child_copy;
+}
+
+void ListExtractFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	ScalarFunction lfun({LogicalType::LIST(LogicalType::ANY), LogicalType::BIGINT}, LogicalType::ANY,
+	                    ListExtractFunction, false, false, ListExtractBind, nullptr, ListExtractStats);
+
+	ScalarFunction sfun({LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR, ListExtractFunction, false,
+	                    false, nullptr);
+
+	ScalarFunctionSet list_extract("list_extract");
+	list_extract.AddFunction(lfun);
+	list_extract.AddFunction(sfun);
+	set.AddFunction(list_extract);
+
+	ScalarFunctionSet list_element("list_element");
+	list_element.AddFunction(lfun);
+	list_element.AddFunction(sfun);
+	set.AddFunction(list_element);
+
+	ScalarFunctionSet array_extract("array_extract");
+	array_extract.AddFunction(lfun);
+	array_extract.AddFunction(sfun);
+	array_extract.AddFunction(StructExtractFun::GetFunction());
+	set.AddFunction(array_extract);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct ListSortBindData : public FunctionData {
+	ListSortBindData(OrderType order_type_p, OrderByNullType null_order_p, const LogicalType &return_type_p,
+	                 const LogicalType &child_type_p, ClientContext &context_p);
+	~ListSortBindData() override;
+
+	OrderType order_type;
+	OrderByNullType null_order;
+	LogicalType return_type;
+	LogicalType child_type;
+
+	vector<LogicalType> types;
+	vector<LogicalType> payload_types;
+
+	ClientContext &context;
+	unique_ptr<GlobalSortState> global_sort_state;
+	RowLayout payload_layout;
+	vector<BoundOrderByNode> orders;
+
+public:
+	bool Equals(const FunctionData &other_p) const override;
+	unique_ptr<FunctionData> Copy() const override;
+};
+
+ListSortBindData::ListSortBindData(OrderType order_type_p, OrderByNullType null_order_p,
+                                   const LogicalType &return_type_p, const LogicalType &child_type_p,
+                                   ClientContext &context_p)
+    : order_type(order_type_p), null_order(null_order_p), return_type(return_type_p), child_type(child_type_p),
+      context(context_p) {
+
+	// get the vector types
+	types.emplace_back(LogicalType::USMALLINT);
+	types.emplace_back(child_type);
+	D_ASSERT(types.size() == 2);
+
+	// get the payload types
+	payload_types.emplace_back(LogicalType::UINTEGER);
+	D_ASSERT(payload_types.size() == 1);
+
+	// initialize the payload layout
+	payload_layout.Initialize(payload_types);
+
+	// get the BoundOrderByNode
+	auto idx_col_expr = make_unique_base<Expression, BoundReferenceExpression>(LogicalType::USMALLINT, 0);
+	auto lists_col_expr = make_unique_base<Expression, BoundReferenceExpression>(child_type, 1);
+	orders.emplace_back(OrderType::ASCENDING, OrderByNullType::ORDER_DEFAULT, move(idx_col_expr));
+	orders.emplace_back(order_type, null_order, move(lists_col_expr));
+}
+
+unique_ptr<FunctionData> ListSortBindData::Copy() const {
+	return make_unique<ListSortBindData>(order_type, null_order, return_type, child_type, context);
+}
+
+bool ListSortBindData::Equals(const FunctionData &other_p) const {
+	auto &other = (ListSortBindData &)other_p;
+	return order_type == other.order_type && null_order == other.null_order;
+}
+
+ListSortBindData::~ListSortBindData() {
+}
+
+// create the key_chunk and the payload_chunk and sink them into the local_sort_state
+void SinkDataChunk(Vector *child_vector, SelectionVector &sel, idx_t offset_lists_indices, vector<LogicalType> &types,
+                   vector<LogicalType> &payload_types, Vector &payload_vector, LocalSortState &local_sort_state,
+                   bool &data_to_sort, Vector &lists_indices) {
+
+	// slice the child vector
+	Vector slice(*child_vector, sel, offset_lists_indices);
+
+	// initialize and fill key_chunk
+	DataChunk key_chunk;
+	key_chunk.InitializeEmpty(types);
+	key_chunk.data[0].Reference(lists_indices);
+	key_chunk.data[1].Reference(slice);
+	key_chunk.SetCardinality(offset_lists_indices);
+
+	// initialize and fill key_chunk and payload_chunk
+	DataChunk payload_chunk;
+	payload_chunk.InitializeEmpty(payload_types);
+	payload_chunk.data[0].Reference(payload_vector);
+	payload_chunk.SetCardinality(offset_lists_indices);
+
+	// sink
+	local_sort_state.SinkChunk(key_chunk, payload_chunk);
+	data_to_sort = true;
+}
+
+static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+
+	D_ASSERT(args.ColumnCount() >= 1 && args.ColumnCount() <= 3);
+	auto count = args.size();
+	Vector &lists = args.data[0];
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &result_validity = FlatVector::Validity(result);
+
+	if (lists.GetType().id() == LogicalTypeId::SQLNULL) {
+		result_validity.SetInvalid(0);
+		return;
+	}
+
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (ListSortBindData &)*func_expr.bind_info;
+
+	// initialize the global and local sorting state
+	auto &buffer_manager = BufferManager::GetBufferManager(info.context);
+	info.global_sort_state = make_unique<GlobalSortState>(buffer_manager, info.orders, info.payload_layout);
+	auto &global_sort_state = *info.global_sort_state;
+	LocalSortState local_sort_state;
+	local_sort_state.Initialize(global_sort_state, buffer_manager);
+
+	// get the child vector
+	auto lists_size = ListVector::GetListSize(lists);
+	auto &child_vector = ListVector::GetEntry(lists);
+	VectorData child_data;
+	child_vector.Orrify(lists_size, child_data);
+
+	// get the lists data
+	VectorData lists_data;
+	lists.Orrify(count, lists_data);
+	auto list_entries = (list_entry_t *)lists_data.data;
+
+	// create the lists_indices vector, this contains an element for each list's entry,
+	// the element corresponds to the list's index, e.g. for [1, 2, 4], [5, 4]
+	// lists_indices contains [0, 0, 0, 1, 1]
+	Vector lists_indices(LogicalType::USMALLINT);
+	auto lists_indices_data = FlatVector::GetData<uint16_t>(lists_indices);
+
+	// create the payload_vector, this is just a vector containing incrementing integers
+	// this will later be used as the 'new' selection vector of the child_vector, after
+	// rearranging the payload according to the sorting order
+	Vector payload_vector(LogicalType::UINTEGER);
+	auto payload_vector_data = FlatVector::GetData<uint32_t>(payload_vector);
+
+	// selection vector pointing to the data of the child vector,
+	// used for slicing the child_vector correctly
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+
+	idx_t offset_lists_indices = 0;
+	uint32_t incr_payload_count = 0;
+	bool data_to_sort = false;
+
+	for (idx_t i = 0; i < count; i++) {
+
+		auto lists_index = lists_data.sel->get_index(i);
+		const auto &list_entry = list_entries[lists_index];
+
+		// nothing to do for this list
+		if (!lists_data.validity.RowIsValid(lists_index)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		// empty list, no sorting required
+		if (list_entry.length == 0) {
+			continue;
+		}
+
+		for (idx_t child_idx = 0; child_idx < list_entry.length; child_idx++) {
+
+			// lists_indices vector is full, sink
+			if (offset_lists_indices == STANDARD_VECTOR_SIZE) {
+				SinkDataChunk(&child_vector, sel, offset_lists_indices, info.types, info.payload_types, payload_vector,
+				              local_sort_state, data_to_sort, lists_indices);
+				offset_lists_indices = 0;
+			}
+
+			auto source_idx = child_data.sel->get_index(list_entry.offset + child_idx);
+			sel.set_index(offset_lists_indices, source_idx);
+			lists_indices_data[offset_lists_indices] = (uint32_t)i;
+			payload_vector_data[offset_lists_indices] = incr_payload_count;
+			offset_lists_indices++;
+			incr_payload_count++;
+		}
+	}
+
+	if (offset_lists_indices != 0) {
+		SinkDataChunk(&child_vector, sel, offset_lists_indices, info.types, info.payload_types, payload_vector,
+		              local_sort_state, data_to_sort, lists_indices);
+	}
+
+	if (data_to_sort) {
+
+		// add local state to global state, which sorts the data
+		global_sort_state.AddLocalState(local_sort_state);
+		global_sort_state.PrepareMergePhase();
+
+		// selection vector that is to be filled with the 'sorted' payload
+		SelectionVector sel_sorted(incr_payload_count);
+		idx_t sel_sorted_idx = 0;
+
+		// scan the sorted row data
+		PayloadScanner scanner(*global_sort_state.sorted_blocks[0]->payload_data, global_sort_state);
+		for (;;) {
+			DataChunk result_chunk;
+			result_chunk.Initialize(info.payload_types);
+			result_chunk.SetCardinality(0);
+			scanner.Scan(result_chunk);
+			if (result_chunk.size() == 0) {
+				break;
+			}
+
+			// construct the selection vector with the new order from the result vectors
+			Vector result_vector(result_chunk.data[0]);
+			auto result_data = FlatVector::GetData<uint32_t>(result_vector);
+			auto row_count = result_chunk.size();
+
+			for (idx_t i = 0; i < row_count; i++) {
+				sel_sorted.set_index(sel_sorted_idx, result_data[i]);
+				sel_sorted_idx++;
+			}
+		}
+
+		D_ASSERT(sel_sorted_idx == incr_payload_count);
+		child_vector.Slice(sel_sorted, sel_sorted_idx);
+		child_vector.Normalify(sel_sorted_idx);
+	}
+
+	result.Reference(lists);
+}
+
+static unique_ptr<FunctionData> ListSortBind(ClientContext &context, ScalarFunction &bound_function,
+                                             vector<unique_ptr<Expression>> &arguments, OrderType &order,
+                                             OrderByNullType &null_order) {
+
+	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL) {
+		bound_function.arguments[0] = LogicalType::SQLNULL;
+		bound_function.return_type = LogicalType::SQLNULL;
+		return make_unique<VariableReturnBindData>(bound_function.return_type);
+	}
+
+	bound_function.arguments[0] = arguments[0]->return_type;
+	bound_function.return_type = arguments[0]->return_type;
+	auto child_type = ListType::GetChildType(arguments[0]->return_type);
+
+	return make_unique<ListSortBindData>(order, null_order, bound_function.return_type, child_type, context);
+}
+
+OrderByNullType GetNullOrder(vector<unique_ptr<Expression>> &arguments, idx_t idx) {
+
+	if (!arguments[idx]->IsFoldable()) {
+		throw InvalidInputException("Null sorting order must be a constant");
+	}
+	Value null_order_value = ExpressionExecutor::EvaluateScalar(*arguments[idx]);
+	auto null_order_name = null_order_value.ToString();
+	std::transform(null_order_name.begin(), null_order_name.end(), null_order_name.begin(), ::toupper);
+	if (null_order_name != "NULLS FIRST" && null_order_name != "NULLS LAST") {
+		throw InvalidInputException("Null sorting order must be either NULLS FIRST or NULLS LAST");
+	}
+
+	if (null_order_name == "NULLS LAST") {
+		return OrderByNullType::NULLS_LAST;
+	}
+	return OrderByNullType::NULLS_FIRST;
+}
+
+static unique_ptr<FunctionData> ListNormalSortBind(ClientContext &context, ScalarFunction &bound_function,
+                                                   vector<unique_ptr<Expression>> &arguments) {
+
+	D_ASSERT(bound_function.arguments.size() >= 1 && bound_function.arguments.size() <= 3);
+	D_ASSERT(arguments.size() >= 1 && arguments.size() <= 3);
+
+	// set default values
+	auto &config = DBConfig::GetConfig(context);
+	auto order = config.default_order_type;
+	auto null_order = config.default_null_order;
+
+	// get the sorting order
+	if (arguments.size() >= 2) {
+
+		if (!arguments[1]->IsFoldable()) {
+			throw InvalidInputException("Sorting order must be a constant");
+		}
+		Value order_value = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+		auto order_name = order_value.ToString();
+		std::transform(order_name.begin(), order_name.end(), order_name.begin(), ::toupper);
+		if (order_name != "DESC" && order_name != "ASC") {
+			throw InvalidInputException("Sorting order must be either ASC or DESC");
+		}
+		if (order_name == "DESC") {
+			order = OrderType::DESCENDING;
+		} else {
+			order = OrderType::ASCENDING;
+		}
+	}
+
+	// get the null sorting order
+	if (arguments.size() == 3) {
+		null_order = GetNullOrder(arguments, 2);
+	}
+
+	return ListSortBind(context, bound_function, arguments, order, null_order);
+}
+
+static unique_ptr<FunctionData> ListReverseSortBind(ClientContext &context, ScalarFunction &bound_function,
+                                                    vector<unique_ptr<Expression>> &arguments) {
+
+	D_ASSERT(bound_function.arguments.size() == 1 || bound_function.arguments.size() == 2);
+	D_ASSERT(arguments.size() == 1 || arguments.size() == 2);
+
+	// set (reverse) default values
+	auto &config = DBConfig::GetConfig(context);
+	auto order = (config.default_order_type == OrderType::ASCENDING) ? OrderType::DESCENDING : OrderType::ASCENDING;
+	auto null_order = config.default_null_order;
+
+	// get the null sorting order
+	if (arguments.size() == 2) {
+		null_order = GetNullOrder(arguments, 1);
+	}
+
+	return ListSortBind(context, bound_function, arguments, order, null_order);
+}
+
+void ListSortFun::RegisterFunction(BuiltinFunctions &set) {
+
+	// normal sort
+
+	// one parameter: list
+	ScalarFunction sort({LogicalType::LIST(LogicalType::ANY)}, LogicalType::LIST(LogicalType::ANY), ListSortFunction,
+	                    false, false, ListNormalSortBind);
+
+	// two parameters: list, order
+	ScalarFunction sort_order({LogicalType::LIST(LogicalType::ANY), LogicalType::VARCHAR},
+	                          LogicalType::LIST(LogicalType::ANY), ListSortFunction, false, false, ListNormalSortBind);
+
+	// three parameters: list, order, null order
+	ScalarFunction sort_orders({LogicalType::LIST(LogicalType::ANY), LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                           LogicalType::LIST(LogicalType::ANY), ListSortFunction, false, false, ListNormalSortBind);
+
+	ScalarFunctionSet list_sort("list_sort");
+	list_sort.AddFunction(sort);
+	list_sort.AddFunction(sort_order);
+	list_sort.AddFunction(sort_orders);
+	set.AddFunction(list_sort);
+
+	ScalarFunctionSet array_sort("array_sort");
+	array_sort.AddFunction(sort);
+	array_sort.AddFunction(sort_order);
+	array_sort.AddFunction(sort_orders);
+	set.AddFunction(array_sort);
+
+	// reverse sort
+
+	// one parameter: list
+	ScalarFunction sort_reverse({LogicalType::LIST(LogicalType::ANY)}, LogicalType::LIST(LogicalType::ANY),
+	                            ListSortFunction, false, false, ListReverseSortBind);
+
+	// two parameters: list, null order
+	ScalarFunction sort_reverse_null_order({LogicalType::LIST(LogicalType::ANY), LogicalType::VARCHAR},
+	                                       LogicalType::LIST(LogicalType::ANY), ListSortFunction, false, false,
+	                                       ListReverseSortBind);
+
+	ScalarFunctionSet list_reverse_sort("list_reverse_sort");
+	list_reverse_sort.AddFunction(sort_reverse);
+	list_reverse_sort.AddFunction(sort_reverse_null_order);
+	set.AddFunction(list_reverse_sort);
+
+	ScalarFunctionSet array_reverse_sort("array_reverse_sort");
+	array_reverse_sort.AddFunction(sort_reverse);
+	array_reverse_sort.AddFunction(sort_reverse_null_order);
+	set.AddFunction(array_reverse_sort);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void ListValueFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+	auto &child_type = ListType::GetChildType(result.GetType());
+
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
+		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+		}
+	}
+
+	auto result_data = FlatVector::GetData<list_entry_t>(result);
+	for (idx_t i = 0; i < args.size(); i++) {
+		result_data[i].offset = ListVector::GetListSize(result);
+		for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
+			auto val = args.GetValue(col_idx, i).CastAs(child_type);
+			ListVector::PushBack(result, val);
+		}
+		result_data[i].length = args.ColumnCount();
+	}
+	result.Verify(args.size());
+}
+
+static unique_ptr<FunctionData> ListValueBind(ClientContext &context, ScalarFunction &bound_function,
+                                              vector<unique_ptr<Expression>> &arguments) {
+	// collect names and deconflict, construct return type
+	LogicalType child_type = LogicalType::SQLNULL;
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		child_type = LogicalType::MaxLogicalType(child_type, arguments[i]->return_type);
+	}
+
+	// this is more for completeness reasons
+	bound_function.varargs = child_type;
+	bound_function.return_type = LogicalType::LIST(move(child_type));
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+unique_ptr<BaseStatistics> ListValueStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	auto list_stats = make_unique<ListStatistics>(expr.return_type);
+	for (idx_t i = 0; i < child_stats.size(); i++) {
+		if (child_stats[i]) {
+			list_stats->child_stats->Merge(*child_stats[i]);
+		} else {
+			list_stats->child_stats.reset();
+			return move(list_stats);
+		}
+	}
+	return move(list_stats);
+}
+
+void ListValueFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	ScalarFunction fun("list_value", {}, LogicalTypeId::LIST, ListValueFunction, false, ListValueBind, nullptr,
+	                   ListValueStats);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction(fun);
+	fun.name = "list_pack";
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct NumericRangeInfo {
+	using TYPE = int64_t;
+	using INCREMENT_TYPE = int64_t;
+
+	static int64_t DefaultStart() {
+		return 0;
+	}
+	static int64_t DefaultIncrement() {
+		return 1;
+	}
+
+	static uint64_t ListLength(int64_t start_value, int64_t end_value, int64_t increment_value, bool inclusive_bound) {
+		if (increment_value == 0) {
+			return 0;
+		}
+		if (start_value > end_value && increment_value > 0) {
+			return 0;
+		}
+		if (start_value < end_value && increment_value < 0) {
+			return 0;
+		}
+		hugeint_t total_diff = AbsValue(hugeint_t(end_value) - hugeint_t(start_value));
+		hugeint_t increment = AbsValue(hugeint_t(increment_value));
+		hugeint_t total_values = total_diff / increment;
+		if (total_diff % increment == 0) {
+			if (inclusive_bound) {
+				total_values += 1;
+			}
+		} else {
+			total_values += 1;
+		}
+		if (total_values > NumericLimits<uint32_t>::Maximum()) {
+			throw InvalidInputException("Lists larger than 2^32 elements are not supported");
+		}
+		return Hugeint::Cast<uint64_t>(total_values);
+	}
+
+	static void Increment(int64_t &input, int64_t increment) {
+		input += increment;
+	}
+};
+struct TimestampRangeInfo {
+	using TYPE = timestamp_t;
+	using INCREMENT_TYPE = interval_t;
+
+	static timestamp_t DefaultStart() {
+		throw InternalException("Default start not implemented for timestamp range");
+	}
+	static interval_t DefaultIncrement() {
+		throw InternalException("Default increment not implemented for timestamp range");
+	}
+	static uint64_t ListLength(timestamp_t start_value, timestamp_t end_value, interval_t increment_value,
+	                           bool inclusive_bound) {
+		bool is_positive = increment_value.months > 0 || increment_value.days > 0 || increment_value.micros > 0;
+		bool is_negative = increment_value.months < 0 || increment_value.days < 0 || increment_value.micros < 0;
+		if (!is_negative && !is_positive) {
+			// interval is 0: no result
+			return 0;
+		}
+		// We don't allow infinite bounds because they generate errors or infinite loops
+		if (!Timestamp::IsFinite(start_value) || !Timestamp::IsFinite(end_value)) {
+			throw InvalidInputException("Interval infinite bounds not supported");
+		}
+
+		if (is_negative && is_positive) {
+			// we don't allow a mix of
+			throw InvalidInputException("Interval with mix of negative/positive entries not supported");
+		}
+		if (start_value > end_value && is_positive) {
+			return 0;
+		}
+		if (start_value < end_value && is_negative) {
+			return 0;
+		}
+		int64_t total_values = 0;
+		if (is_negative) {
+			// negative interval, start_value is going down
+			while (inclusive_bound ? start_value >= end_value : start_value > end_value) {
+				start_value = Interval::Add(start_value, increment_value);
+				total_values++;
+				if (total_values > NumericLimits<uint32_t>::Maximum()) {
+					throw InvalidInputException("Lists larger than 2^32 elements are not supported");
+				}
+			}
+		} else {
+			// positive interval, start_value is going up
+			while (inclusive_bound ? start_value <= end_value : start_value < end_value) {
+				start_value = Interval::Add(start_value, increment_value);
+				total_values++;
+				if (total_values > NumericLimits<uint32_t>::Maximum()) {
+					throw InvalidInputException("Lists larger than 2^32 elements are not supported");
+				}
+			}
+		}
+		return total_values;
+	}
+
+	static void Increment(timestamp_t &input, interval_t increment) {
+		input = Interval::Add(input, increment);
+	}
+};
+
+template <class OP, bool INCLUSIVE_BOUND>
+class RangeInfoStruct {
+public:
+	explicit RangeInfoStruct(DataChunk &args_p) : args(args_p) {
+		switch (args.ColumnCount()) {
+		case 1:
+			args.data[0].Orrify(args.size(), vdata[0]);
+			break;
+		case 2:
+			args.data[0].Orrify(args.size(), vdata[0]);
+			args.data[1].Orrify(args.size(), vdata[1]);
+			break;
+		case 3:
+			args.data[0].Orrify(args.size(), vdata[0]);
+			args.data[1].Orrify(args.size(), vdata[1]);
+			args.data[2].Orrify(args.size(), vdata[2]);
+			break;
+		default:
+			throw InternalException("Unsupported number of parameters for range");
+		}
+	}
+
+	bool RowIsValid(idx_t row_idx) {
+		for (idx_t i = 0; i < args.ColumnCount(); i++) {
+			auto idx = vdata[i].sel->get_index(row_idx);
+			if (!vdata[i].validity.RowIsValid(idx)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	typename OP::TYPE StartListValue(idx_t row_idx) {
+		if (args.ColumnCount() == 1) {
+			return OP::DefaultStart();
+		} else {
+			auto data = (typename OP::TYPE *)vdata[0].data;
+			auto idx = vdata[0].sel->get_index(row_idx);
+			return data[idx];
+		}
+	}
+
+	typename OP::TYPE EndListValue(idx_t row_idx) {
+		idx_t vdata_idx = args.ColumnCount() == 1 ? 0 : 1;
+		auto data = (typename OP::TYPE *)vdata[vdata_idx].data;
+		auto idx = vdata[vdata_idx].sel->get_index(row_idx);
+		return data[idx];
+	}
+
+	typename OP::INCREMENT_TYPE ListIncrementValue(idx_t row_idx) {
+		if (args.ColumnCount() < 3) {
+			return OP::DefaultIncrement();
+		} else {
+			auto data = (typename OP::INCREMENT_TYPE *)vdata[2].data;
+			auto idx = vdata[2].sel->get_index(row_idx);
+			return data[idx];
+		}
+	}
+
+	void GetListValues(idx_t row_idx, typename OP::TYPE &start_value, typename OP::TYPE &end_value,
+	                   typename OP::INCREMENT_TYPE &increment_value) {
+		start_value = StartListValue(row_idx);
+		end_value = EndListValue(row_idx);
+		increment_value = ListIncrementValue(row_idx);
+	}
+
+	uint64_t ListLength(idx_t row_idx) {
+		typename OP::TYPE start_value;
+		typename OP::TYPE end_value;
+		typename OP::INCREMENT_TYPE increment_value;
+		GetListValues(row_idx, start_value, end_value, increment_value);
+		return OP::ListLength(start_value, end_value, increment_value, INCLUSIVE_BOUND);
+	}
+
+private:
+	DataChunk &args;
+	VectorData vdata[3];
+};
+
+template <class OP, bool INCLUSIVE_BOUND>
+static void ListRangeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+	RangeInfoStruct<OP, INCLUSIVE_BOUND> info(args);
+	idx_t args_size = 1;
+	auto result_type = VectorType::CONSTANT_VECTOR;
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
+		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			args_size = args.size();
+			result_type = VectorType::FLAT_VECTOR;
+			break;
+		}
+	}
+	auto list_data = FlatVector::GetData<list_entry_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+	int64_t total_size = 0;
+	for (idx_t i = 0; i < args_size; i++) {
+		if (!info.RowIsValid(i)) {
+			result_validity.SetInvalid(i);
+			list_data[i].offset = total_size;
+			list_data[i].length = 0;
+		} else {
+			list_data[i].offset = total_size;
+			list_data[i].length = info.ListLength(i);
+			total_size += list_data[i].length;
+		}
+	}
+
+	// now construct the child vector of the list
+	ListVector::Reserve(result, total_size);
+	auto range_data = FlatVector::GetData<typename OP::TYPE>(ListVector::GetEntry(result));
+	idx_t total_idx = 0;
+	for (idx_t i = 0; i < args_size; i++) {
+		typename OP::TYPE start_value = info.StartListValue(i);
+		typename OP::INCREMENT_TYPE increment = info.ListIncrementValue(i);
+
+		typename OP::TYPE range_value = start_value;
+		for (idx_t range_idx = 0; range_idx < list_data[i].length; range_idx++) {
+			if (range_idx > 0) {
+				OP::Increment(range_value, increment);
+			}
+			range_data[total_idx++] = range_value;
+		}
+	}
+
+	ListVector::SetListSize(result, total_size);
+	result.SetVectorType(result_type);
+
+	result.Verify(args.size());
+}
+
+void ListRangeFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	ScalarFunctionSet range_set("range");
+	range_set.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::LIST(LogicalType::BIGINT),
+	                                     ListRangeFunction<NumericRangeInfo, false>));
+	range_set.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT},
+	                                     LogicalType::LIST(LogicalType::BIGINT),
+	                                     ListRangeFunction<NumericRangeInfo, false>));
+	range_set.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
+	                                     LogicalType::LIST(LogicalType::BIGINT),
+	                                     ListRangeFunction<NumericRangeInfo, false>));
+	range_set.AddFunction(ScalarFunction({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
+	                                     LogicalType::LIST(LogicalType::TIMESTAMP),
+	                                     ListRangeFunction<TimestampRangeInfo, false>));
+	set.AddFunction(range_set);
+
+	ScalarFunctionSet generate_series("generate_series");
+	generate_series.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::LIST(LogicalType::BIGINT),
+	                                           ListRangeFunction<NumericRangeInfo, true>));
+	generate_series.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT},
+	                                           LogicalType::LIST(LogicalType::BIGINT),
+	                                           ListRangeFunction<NumericRangeInfo, true>));
+	generate_series.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT},
+	                                           LogicalType::LIST(LogicalType::BIGINT),
+	                                           ListRangeFunction<NumericRangeInfo, true>));
+	generate_series.AddFunction(ScalarFunction({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
+	                                           LogicalType::LIST(LogicalType::TIMESTAMP),
+	                                           ListRangeFunction<TimestampRangeInfo, true>));
+	set.AddFunction(generate_series);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+static void CardinalityFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &map = args.data[0];
+	VectorData list_data;
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<uint64_t>(result);
+
+	auto &children = StructVector::GetEntries(map);
+	children[0]->Orrify(args.size(), list_data);
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto list_entry = ((list_entry_t *)list_data.data)[list_data.sel->get_index(row)];
+		result_data[row] = list_entry.length;
+	}
+
+	if (args.size() == 1) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+static unique_ptr<FunctionData> CardinalityBind(ClientContext &context, ScalarFunction &bound_function,
+                                                vector<unique_ptr<Expression>> &arguments) {
+
+	if (arguments[0]->return_type.id() != LogicalTypeId::MAP) {
+		throw BinderException("Cardinality can only operate on MAPs");
+	}
+
+	bound_function.return_type = LogicalType::UBIGINT;
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+void CardinalityFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction fun("cardinality", {LogicalType::ANY}, LogicalType::UBIGINT, CardinalityFunction, false,
+	                   CardinalityBind);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+// TODO: this doesn't recursively verify maps if maps are nested
+MapInvalidReason CheckMapValidity(Vector &map, idx_t count, const SelectionVector &sel) {
+	D_ASSERT(map.GetType().id() == LogicalTypeId::MAP);
+	VectorData map_vdata;
+	map.Orrify(count, map_vdata);
+	auto &map_validity = map_vdata.validity;
+
+	auto &key_vector = *(StructVector::GetEntries(map)[0]);
+	VectorData key_vdata;
+	key_vector.Orrify(count, key_vdata);
+	auto key_data = (list_entry_t *)key_vdata.data;
+	auto &key_validity = key_vdata.validity;
+
+	auto &key_entries = ListVector::GetEntry(key_vector);
+	VectorData key_entry_vdata;
+	key_entries.Orrify(count, key_entry_vdata);
+	auto &entry_validity = key_entry_vdata.validity;
+
+	for (idx_t row = 0; row < count; row++) {
+		auto mapped_row = sel.get_index(row);
+		auto row_idx = map_vdata.sel->get_index(mapped_row);
+		// map is allowed to be NULL
+		if (!map_validity.RowIsValid(row_idx)) {
+			continue;
+		}
+		row_idx = key_vdata.sel->get_index(row);
+		if (!key_validity.RowIsValid(row_idx)) {
+			return MapInvalidReason::NULL_KEY_LIST;
+		}
+		value_set_t unique_keys;
+		for (idx_t i = 0; i < key_data[row_idx].length; i++) {
+			auto index = key_data[row_idx].offset + i;
+			index = key_entry_vdata.sel->get_index(index);
+			if (!entry_validity.RowIsValid(index)) {
+				return MapInvalidReason::NULL_KEY;
+			}
+			auto value = key_entries.GetValue(index);
+			auto result = unique_keys.insert(value);
+			if (!result.second) {
+				return MapInvalidReason::DUPLICATE_KEY;
+			}
+		}
+	}
+	return MapInvalidReason::VALID;
+}
+
+static void MapConversionVerify(Vector &vector, idx_t count) {
+	auto valid_check = CheckMapValidity(vector, count);
+	switch (valid_check) {
+	case MapInvalidReason::VALID:
+		break;
+	case MapInvalidReason::DUPLICATE_KEY: {
+		throw InvalidInputException("Map keys have to be unique");
+	}
+	case MapInvalidReason::NULL_KEY: {
+		throw InvalidInputException("Map keys can not be NULL");
+	}
+	case MapInvalidReason::NULL_KEY_LIST: {
+		throw InvalidInputException("The list of map keys is not allowed to be NULL");
+	}
+	default: {
+		throw InternalException("MapInvalidReason not implemented");
+	}
+	}
+}
+
+static void MapFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(result.GetType().id() == LogicalTypeId::MAP);
+
+	//! Otherwise if its not a constant vector, this breaks the optimizer
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
+		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+		}
+	}
+
+	auto &child_entries = StructVector::GetEntries(result);
+	D_ASSERT(child_entries.size() == 2);
+	auto &key_vector = *child_entries[0];
+	auto &value_vector = *child_entries[1];
+	if (args.data.empty()) {
+		// no arguments: construct an empty map
+		ListVector::SetListSize(key_vector, 0);
+		key_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+		auto list_data = ConstantVector::GetData<list_entry_t>(key_vector);
+		list_data->offset = 0;
+		list_data->length = 0;
+
+		ListVector::SetListSize(value_vector, 0);
+		value_vector.SetVectorType(VectorType::CONSTANT_VECTOR);
+		list_data = ConstantVector::GetData<list_entry_t>(value_vector);
+		list_data->offset = 0;
+		list_data->length = 0;
+
+		result.Verify(args.size());
+		return;
+	}
+
+	if (ListVector::GetListSize(args.data[0]) != ListVector::GetListSize(args.data[1])) {
+		throw Exception("Key list has a different size from Value list");
+	}
+
+	key_vector.Reference(args.data[0]);
+	value_vector.Reference(args.data[1]);
+	MapConversionVerify(result, args.size());
+
+	result.Verify(args.size());
+}
+
+static unique_ptr<FunctionData> MapBind(ClientContext &context, ScalarFunction &bound_function,
+                                        vector<unique_ptr<Expression>> &arguments) {
+	child_list_t<LogicalType> child_types;
+
+	if (arguments.size() != 2 && !arguments.empty()) {
+		throw Exception("We need exactly two lists for a map");
+	}
+	if (arguments.size() == 2) {
+		if (arguments[0]->return_type.id() != LogicalTypeId::LIST) {
+			throw Exception("First argument is not a list");
+		}
+		if (arguments[1]->return_type.id() != LogicalTypeId::LIST) {
+			throw Exception("Second argument is not a list");
+		}
+		child_types.push_back(make_pair("key", arguments[0]->return_type));
+		child_types.push_back(make_pair("value", arguments[1]->return_type));
+	}
+
+	if (arguments.empty()) {
+		auto empty = LogicalType::LIST(LogicalTypeId::SQLNULL);
+		child_types.push_back(make_pair("key", empty));
+		child_types.push_back(make_pair("value", empty));
+	}
+
+	//! this is more for completeness reasons
+	bound_function.return_type = LogicalType::MAP(move(child_types));
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+void MapFun::RegisterFunction(BuiltinFunctions &set) {
+	//! the arguments and return types are actually set in the binder function
+	ScalarFunction fun("map", {}, LogicalTypeId::MAP, MapFunction, false, MapBind);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+void FillResult(Value &values, Vector &result, idx_t row) {
+	//! First Initialize List Vector
+	idx_t current_offset = ListVector::GetListSize(result);
+	//! Push Values to List Vector
+	auto &list_values = ListValue::GetChildren(values);
+	for (idx_t i = 0; i < list_values.size(); i++) {
+		ListVector::PushBack(result, list_values[i]);
+	}
+
+	//! now set the pointer
+	auto &entry = ((list_entry_t *)result.GetData())[row];
+	entry.length = list_values.size();
+	entry.offset = current_offset;
+}
+
+static void MapExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.data.size() == 2);
+	D_ASSERT(args.data[0].GetType().id() == LogicalTypeId::MAP);
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+
+	auto &map = args.data[0];
+	auto &key = args.data[1];
+
+	auto key_value = key.GetValue(0);
+	VectorData offset_data;
+
+	auto &children = StructVector::GetEntries(map);
+	children[0]->Orrify(args.size(), offset_data);
+	auto &key_type = ListType::GetChildType(children[0]->GetType());
+	if (key_type != LogicalTypeId::SQLNULL) {
+		key_value = key_value.CastAs(key_type);
+	}
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto offsets = ListVector::Search(*children[0], key_value, offset_data.sel->get_index(row));
+		auto values = ListVector::GetValuesFromOffsets(*children[1], offsets);
+		FillResult(values, result, row);
+	}
+
+	if (args.size() == 1) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+
+	result.Verify(args.size());
+}
+
+static unique_ptr<FunctionData> MapExtractBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() != 2) {
+		throw BinderException("MAP_EXTRACT must have exactly two arguments");
+	}
+	if (arguments[0]->return_type.id() != LogicalTypeId::MAP) {
+		throw BinderException("MAP_EXTRACT can only operate on MAPs");
+	}
+	auto &child_types = StructType::GetChildTypes(arguments[0]->return_type);
+	auto &value_type = ListType::GetChildType(child_types[1].second);
+
+	//! Here we have to construct the List Type that will be returned
+	bound_function.return_type = LogicalType::LIST(value_type);
+	return make_unique<VariableReturnBindData>(value_type);
+}
+
+void MapExtractFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction fun("map_extract", {LogicalType::ANY, LogicalType::ANY}, LogicalType::ANY, MapExtractFunction, false,
+	                   MapExtractBind);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction(fun);
+	fun.name = "element_at";
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+#include <cmath>
+#include <errno.h>
+
+namespace duckdb {
+
+template <class TR, class OP>
+static scalar_function_t GetScalarIntegerUnaryFunctionFixedReturn(const LogicalType &type) {
+	scalar_function_t function;
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		function = &ScalarFunction::UnaryFunction<int8_t, TR, OP>;
+		break;
+	case LogicalTypeId::SMALLINT:
+		function = &ScalarFunction::UnaryFunction<int16_t, TR, OP>;
+		break;
+	case LogicalTypeId::INTEGER:
+		function = &ScalarFunction::UnaryFunction<int32_t, TR, OP>;
+		break;
+	case LogicalTypeId::BIGINT:
+		function = &ScalarFunction::UnaryFunction<int64_t, TR, OP>;
+		break;
+	case LogicalTypeId::HUGEINT:
+		function = &ScalarFunction::UnaryFunction<hugeint_t, TR, OP>;
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for GetScalarIntegerUnaryFunctionFixedReturn");
+	}
+	return function;
+}
+
+//===--------------------------------------------------------------------===//
+// nextafter
+//===--------------------------------------------------------------------===//
+struct NextAfterOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA base, TB exponent) {
+		throw NotImplementedException("Unimplemented type for NextAfter Function");
+	}
+
+	template <class TA, class TB, class TR>
+	static inline double Operation(double input, double approximate_to) {
+		return nextafter(input, approximate_to);
+	}
+	template <class TA, class TB, class TR>
+	static inline float Operation(float input, float approximate_to) {
+		return nextafterf(input, approximate_to);
+	}
+};
+
+void NextAfterFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet next_after_fun("nextafter");
+	next_after_fun.AddFunction(
+	    ScalarFunction("nextafter", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::BinaryFunction<double, double, double, NextAfterOperator>, false));
+	next_after_fun.AddFunction(ScalarFunction("nextafter", {LogicalType::FLOAT, LogicalType::FLOAT}, LogicalType::FLOAT,
+	                                          ScalarFunction::BinaryFunction<float, float, float, NextAfterOperator>,
+	                                          false));
+	set.AddFunction(next_after_fun);
+}
+
+//===--------------------------------------------------------------------===//
+// abs
+//===--------------------------------------------------------------------===//
+static unique_ptr<BaseStatistics> PropagateAbsStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	D_ASSERT(child_stats.size() == 1);
+	// can only propagate stats if the children have stats
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &lstats = (NumericStatistics &)*child_stats[0];
+	Value new_min, new_max;
+	bool potential_overflow = true;
+	if (!lstats.min.IsNull() && !lstats.max.IsNull()) {
+		switch (expr.return_type.InternalType()) {
+		case PhysicalType::INT8:
+			potential_overflow = lstats.min.GetValue<int8_t>() == NumericLimits<int8_t>::Minimum();
+			break;
+		case PhysicalType::INT16:
+			potential_overflow = lstats.min.GetValue<int16_t>() == NumericLimits<int16_t>::Minimum();
+			break;
+		case PhysicalType::INT32:
+			potential_overflow = lstats.min.GetValue<int32_t>() == NumericLimits<int32_t>::Minimum();
+			break;
+		case PhysicalType::INT64:
+			potential_overflow = lstats.min.GetValue<int64_t>() == NumericLimits<int64_t>::Minimum();
+			break;
+		default:
+			return nullptr;
+		}
+	}
+	if (potential_overflow) {
+		new_min = Value(expr.return_type);
+		new_max = Value(expr.return_type);
+	} else {
+		// no potential overflow
+
+		// compute stats
+		auto current_min = lstats.min.GetValue<int64_t>();
+		auto current_max = lstats.max.GetValue<int64_t>();
+
+		int64_t min_val, max_val;
+
+		if (current_min < 0 && current_max < 0) {
+			// if both min and max are below zero, then min=abs(cur_max) and max=abs(cur_min)
+			min_val = AbsValue(current_max);
+			max_val = AbsValue(current_min);
+		} else if (current_min < 0) {
+			D_ASSERT(current_max >= 0);
+			// if min is below zero and max is above 0, then min=0 and max=max(cur_max, abs(cur_min))
+			min_val = 0;
+			max_val = MaxValue(AbsValue(current_min), current_max);
+		} else {
+			// if both current_min and current_max are > 0, then the abs is a no-op and can be removed entirely
+			*input.expr_ptr = move(input.expr.children[0]);
+			return move(child_stats[0]);
+		}
+		new_min = Value::Numeric(expr.return_type, min_val);
+		new_max = Value::Numeric(expr.return_type, max_val);
+		expr.function.function = ScalarFunction::GetScalarUnaryFunction<AbsOperator>(expr.return_type);
+	}
+	auto stats =
+	    make_unique<NumericStatistics>(expr.return_type, move(new_min), move(new_max), StatisticsType::LOCAL_STATS);
+	stats->validity_stats = lstats.validity_stats->Copy();
+	return move(stats);
+}
+
+template <class OP>
+unique_ptr<FunctionData> DecimalUnaryOpBind(ClientContext &context, ScalarFunction &bound_function,
+                                            vector<unique_ptr<Expression>> &arguments) {
+	auto decimal_type = arguments[0]->return_type;
+	switch (decimal_type.InternalType()) {
+	case PhysicalType::INT16:
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<OP>(LogicalTypeId::SMALLINT);
+		break;
+	case PhysicalType::INT32:
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<OP>(LogicalTypeId::INTEGER);
+		break;
+	case PhysicalType::INT64:
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<OP>(LogicalTypeId::BIGINT);
+		break;
+	default:
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<OP>(LogicalTypeId::HUGEINT);
+		break;
+	}
+	bound_function.arguments[0] = decimal_type;
+	bound_function.return_type = decimal_type;
+	return nullptr;
+}
+
+void AbsFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet abs("abs");
+	for (auto &type : LogicalType::Numeric()) {
+		switch (type.id()) {
+		case LogicalTypeId::DECIMAL:
+			abs.AddFunction(ScalarFunction({type}, type, nullptr, false, false, DecimalUnaryOpBind<AbsOperator>));
+			break;
+		case LogicalTypeId::TINYINT:
+		case LogicalTypeId::SMALLINT:
+		case LogicalTypeId::INTEGER:
+		case LogicalTypeId::BIGINT: {
+			ScalarFunction func({type}, type, ScalarFunction::GetScalarUnaryFunction<TryAbsOperator>(type));
+			func.statistics = PropagateAbsStats;
+			abs.AddFunction(func);
+			break;
+		}
+		case LogicalTypeId::UTINYINT:
+		case LogicalTypeId::USMALLINT:
+		case LogicalTypeId::UINTEGER:
+		case LogicalTypeId::UBIGINT:
+			abs.AddFunction(ScalarFunction({type}, type, ScalarFunction::NopFunction));
+			break;
+		default:
+			abs.AddFunction(ScalarFunction({type}, type, ScalarFunction::GetScalarUnaryFunction<AbsOperator>(type)));
+			break;
+		}
+	}
+	set.AddFunction(abs);
+	abs.name = "@";
+	set.AddFunction(abs);
+}
+
+//===--------------------------------------------------------------------===//
+// bit_count
+//===--------------------------------------------------------------------===//
+struct BitCntOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		using TU = typename std::make_unsigned<TA>::type;
+		TR count = 0;
+		for (auto value = TU(input); value > 0; value >>= 1) {
+			count += TR(value & 1);
+		}
+		return count;
+	}
+};
+
+void BitCountFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("bit_count");
+	functions.AddFunction(ScalarFunction({LogicalType::TINYINT}, LogicalType::TINYINT,
+	                                     ScalarFunction::UnaryFunction<int8_t, int8_t, BitCntOperator>));
+	functions.AddFunction(ScalarFunction({LogicalType::SMALLINT}, LogicalType::TINYINT,
+	                                     ScalarFunction::UnaryFunction<int16_t, int8_t, BitCntOperator>));
+	functions.AddFunction(ScalarFunction({LogicalType::INTEGER}, LogicalType::TINYINT,
+	                                     ScalarFunction::UnaryFunction<int32_t, int8_t, BitCntOperator>));
+	functions.AddFunction(ScalarFunction({LogicalType::BIGINT}, LogicalType::TINYINT,
+	                                     ScalarFunction::UnaryFunction<int64_t, int8_t, BitCntOperator>));
+	set.AddFunction(functions);
+}
+
+//===--------------------------------------------------------------------===//
+// sign
+//===--------------------------------------------------------------------===//
+struct SignOperator {
+	template <class TA, class TR>
+	static TR Operation(TA input) {
+		if (input == TA(0)) {
+			return 0;
+		} else if (input > TA(0)) {
+			return 1;
+		} else {
+			return -1;
+		}
+	}
+};
+
+template <>
+int8_t SignOperator::Operation(float input) {
+	if (input == 0 || Value::IsNan(input)) {
+		return 0;
+	} else if (input > 0) {
+		return 1;
+	} else {
+		return -1;
+	}
+}
+
+template <>
+int8_t SignOperator::Operation(double input) {
+	if (input == 0 || Value::IsNan(input)) {
+		return 0;
+	} else if (input > 0) {
+		return 1;
+	} else {
+		return -1;
+	}
+}
+
+void SignFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet sign("sign");
+	for (auto &type : LogicalType::Numeric()) {
+		if (type.id() == LogicalTypeId::DECIMAL) {
+			continue;
+		} else {
+			sign.AddFunction(
+			    ScalarFunction({type}, LogicalType::TINYINT,
+			                   ScalarFunction::GetScalarUnaryFunctionFixedReturn<int8_t, SignOperator>(type)));
+		}
+	}
+	set.AddFunction(sign);
+}
+
+//===--------------------------------------------------------------------===//
+// ceil
+//===--------------------------------------------------------------------===//
+struct CeilOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return std::ceil(left);
+	}
+};
+
+template <class T, class POWERS_OF_TEN, class OP>
+static void GenericRoundFunctionDecimal(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	OP::template Operation<T, POWERS_OF_TEN>(input, DecimalType::GetScale(func_expr.children[0]->return_type), result);
+}
+
+template <class OP>
+unique_ptr<FunctionData> BindGenericRoundFunctionDecimal(ClientContext &context, ScalarFunction &bound_function,
+                                                         vector<unique_ptr<Expression>> &arguments) {
+	// ceil essentially removes the scale
+	auto &decimal_type = arguments[0]->return_type;
+	auto scale = DecimalType::GetScale(decimal_type);
+	auto width = DecimalType::GetWidth(decimal_type);
+	if (scale == 0) {
+		bound_function.function = ScalarFunction::NopFunction;
+	} else {
+		switch (decimal_type.InternalType()) {
+		case PhysicalType::INT16:
+			bound_function.function = GenericRoundFunctionDecimal<int16_t, NumericHelper, OP>;
+			break;
+		case PhysicalType::INT32:
+			bound_function.function = GenericRoundFunctionDecimal<int32_t, NumericHelper, OP>;
+			break;
+		case PhysicalType::INT64:
+			bound_function.function = GenericRoundFunctionDecimal<int64_t, NumericHelper, OP>;
+			break;
+		default:
+			bound_function.function = GenericRoundFunctionDecimal<hugeint_t, Hugeint, OP>;
+			break;
+		}
+	}
+	bound_function.arguments[0] = decimal_type;
+	bound_function.return_type = LogicalType::DECIMAL(width, 0);
+	return nullptr;
+}
+
+struct CeilDecimalOperator {
+	template <class T, class POWERS_OF_TEN_CLASS>
+	static void Operation(DataChunk &input, uint8_t scale, Vector &result) {
+		T power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[scale];
+		UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(), [&](T input) {
+			if (input < 0) {
+				// below 0 we floor the number (e.g. -10.5 -> -10)
+				return input / power_of_ten;
+			} else {
+				// above 0 we ceil the number
+				return ((input - 1) / power_of_ten) + 1;
+			}
+		});
+	}
+};
+
+void CeilFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet ceil("ceil");
+	for (auto &type : LogicalType::Numeric()) {
+		scalar_function_t func = nullptr;
+		bind_scalar_function_t bind_func = nullptr;
+		if (type.IsIntegral()) {
+			// no ceil for integral numbers
+			continue;
+		}
+		switch (type.id()) {
+		case LogicalTypeId::FLOAT:
+			func = ScalarFunction::UnaryFunction<float, float, CeilOperator>;
+			break;
+		case LogicalTypeId::DOUBLE:
+			func = ScalarFunction::UnaryFunction<double, double, CeilOperator>;
+			break;
+		case LogicalTypeId::DECIMAL:
+			bind_func = BindGenericRoundFunctionDecimal<CeilDecimalOperator>;
+			break;
+		default:
+			throw InternalException("Unimplemented numeric type for function \"ceil\"");
+		}
+		ceil.AddFunction(ScalarFunction({type}, type, func, false, false, bind_func));
+	}
+
+	set.AddFunction(ceil);
+	ceil.name = "ceiling";
+	set.AddFunction(ceil);
+}
+
+//===--------------------------------------------------------------------===//
+// floor
+//===--------------------------------------------------------------------===//
+struct FloorOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return std::floor(left);
+	}
+};
+
+struct FloorDecimalOperator {
+	template <class T, class POWERS_OF_TEN_CLASS>
+	static void Operation(DataChunk &input, uint8_t scale, Vector &result) {
+		T power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[scale];
+		UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(), [&](T input) {
+			if (input < 0) {
+				// below 0 we ceil the number (e.g. -10.5 -> -11)
+				return ((input + 1) / power_of_ten) - 1;
+			} else {
+				// above 0 we floor the number
+				return input / power_of_ten;
+			}
+		});
+	}
+};
+
+void FloorFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet floor("floor");
+	for (auto &type : LogicalType::Numeric()) {
+		scalar_function_t func = nullptr;
+		bind_scalar_function_t bind_func = nullptr;
+		if (type.IsIntegral()) {
+			// no floor for integral numbers
+			continue;
+		}
+		switch (type.id()) {
+		case LogicalTypeId::FLOAT:
+			func = ScalarFunction::UnaryFunction<float, float, FloorOperator>;
+			break;
+		case LogicalTypeId::DOUBLE:
+			func = ScalarFunction::UnaryFunction<double, double, FloorOperator>;
+			break;
+		case LogicalTypeId::DECIMAL:
+			bind_func = BindGenericRoundFunctionDecimal<FloorDecimalOperator>;
+			break;
+		default:
+			throw InternalException("Unimplemented numeric type for function \"floor\"");
+		}
+		floor.AddFunction(ScalarFunction({type}, type, func, false, false, bind_func));
+	}
+	set.AddFunction(floor);
+}
+
+//===--------------------------------------------------------------------===//
+// round
+//===--------------------------------------------------------------------===//
+struct RoundOperatorPrecision {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA input, TB precision) {
+		double rounded_value;
+		if (precision < 0) {
+			double modifier = std::pow(10, -precision);
+			rounded_value = (std::round(input / modifier)) * modifier;
+			if (std::isinf(rounded_value) || std::isnan(rounded_value)) {
+				return 0;
+			}
+		} else {
+			double modifier = std::pow(10, precision);
+			rounded_value = (std::round(input * modifier)) / modifier;
+			if (std::isinf(rounded_value) || std::isnan(rounded_value)) {
+				return input;
+			}
+		}
+		return rounded_value;
+	}
+};
+
+struct RoundOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		double rounded_value = round(input);
+		if (std::isinf(rounded_value) || std::isnan(rounded_value)) {
+			return input;
+		}
+		return rounded_value;
+	}
+};
+
+struct RoundDecimalOperator {
+	template <class T, class POWERS_OF_TEN_CLASS>
+	static void Operation(DataChunk &input, uint8_t scale, Vector &result) {
+		T power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[scale];
+		T addition = power_of_ten / 2;
+		// regular round rounds towards the nearest number
+		// in case of a tie we round away from zero
+		// i.e. -10.5 -> -11, 10.5 -> 11
+		// we implement this by adding (positive) or subtracting (negative) 0.5
+		// and then flooring the number
+		// e.g. 10.5 + 0.5 = 11, floor(11) = 11
+		//      10.4 + 0.5 = 10.9, floor(10.9) = 10
+		UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(), [&](T input) {
+			if (input < 0) {
+				input -= addition;
+			} else {
+				input += addition;
+			}
+			return input / power_of_ten;
+		});
+	}
+};
+
+struct RoundPrecisionFunctionData : public FunctionData {
+	explicit RoundPrecisionFunctionData(int32_t target_scale) : target_scale(target_scale) {
+	}
+
+	int32_t target_scale;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<RoundPrecisionFunctionData>(target_scale);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const RoundPrecisionFunctionData &)other_p;
+		return target_scale == other.target_scale;
+	}
+};
+
+template <class T, class POWERS_OF_TEN_CLASS>
+static void DecimalRoundNegativePrecisionFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (RoundPrecisionFunctionData &)*func_expr.bind_info;
+	auto source_scale = DecimalType::GetScale(func_expr.children[0]->return_type);
+	auto width = DecimalType::GetWidth(func_expr.children[0]->return_type);
+	if (-info.target_scale >= width) {
+		// scale too big for width
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		result.SetValue(0, Value::INTEGER(0));
+		return;
+	}
+	T divide_power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[-info.target_scale + source_scale];
+	T multiply_power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[-info.target_scale];
+	T addition = divide_power_of_ten / 2;
+
+	UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(), [&](T input) {
+		if (input < 0) {
+			input -= addition;
+		} else {
+			input += addition;
+		}
+		return input / divide_power_of_ten * multiply_power_of_ten;
+	});
+}
+
+template <class T, class POWERS_OF_TEN_CLASS>
+static void DecimalRoundPositivePrecisionFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (RoundPrecisionFunctionData &)*func_expr.bind_info;
+	auto source_scale = DecimalType::GetScale(func_expr.children[0]->return_type);
+	T power_of_ten = POWERS_OF_TEN_CLASS::POWERS_OF_TEN[source_scale - info.target_scale];
+	T addition = power_of_ten / 2;
+	UnaryExecutor::Execute<T, T>(input.data[0], result, input.size(), [&](T input) {
+		if (input < 0) {
+			input -= addition;
+		} else {
+			input += addition;
+		}
+		return input / power_of_ten;
+	});
+}
+
+unique_ptr<FunctionData> BindDecimalRoundPrecision(ClientContext &context, ScalarFunction &bound_function,
+                                                   vector<unique_ptr<Expression>> &arguments) {
+	auto &decimal_type = arguments[0]->return_type;
+	if (!arguments[1]->IsFoldable()) {
+		throw NotImplementedException("ROUND(DECIMAL, INTEGER) with non-constant precision is not supported");
+	}
+	Value val = ExpressionExecutor::EvaluateScalar(*arguments[1]).CastAs(LogicalType::INTEGER);
+	if (val.IsNull()) {
+		throw NotImplementedException("ROUND(DECIMAL, INTEGER) with non-constant precision is not supported");
+	}
+	// our new precision becomes the round value
+	// e.g. ROUND(DECIMAL(18,3), 1) -> DECIMAL(18,1)
+	// but ONLY if the round value is positive
+	// if it is negative the scale becomes zero
+	// i.e. ROUND(DECIMAL(18,3), -1) -> DECIMAL(18,0)
+	int32_t round_value = IntegerValue::Get(val);
+	uint8_t target_scale;
+	auto width = DecimalType::GetWidth(decimal_type);
+	auto scale = DecimalType::GetScale(decimal_type);
+	if (round_value < 0) {
+		target_scale = 0;
+		switch (decimal_type.InternalType()) {
+		case PhysicalType::INT16:
+			bound_function.function = DecimalRoundNegativePrecisionFunction<int16_t, NumericHelper>;
+			break;
+		case PhysicalType::INT32:
+			bound_function.function = DecimalRoundNegativePrecisionFunction<int32_t, NumericHelper>;
+			break;
+		case PhysicalType::INT64:
+			bound_function.function = DecimalRoundNegativePrecisionFunction<int64_t, NumericHelper>;
+			break;
+		default:
+			bound_function.function = DecimalRoundNegativePrecisionFunction<hugeint_t, Hugeint>;
+			break;
+		}
+	} else {
+		if (round_value >= (int32_t)scale) {
+			// if round_value is bigger than or equal to scale we do nothing
+			bound_function.function = ScalarFunction::NopFunction;
+			target_scale = scale;
+		} else {
+			target_scale = round_value;
+			switch (decimal_type.InternalType()) {
+			case PhysicalType::INT16:
+				bound_function.function = DecimalRoundPositivePrecisionFunction<int16_t, NumericHelper>;
+				break;
+			case PhysicalType::INT32:
+				bound_function.function = DecimalRoundPositivePrecisionFunction<int32_t, NumericHelper>;
+				break;
+			case PhysicalType::INT64:
+				bound_function.function = DecimalRoundPositivePrecisionFunction<int64_t, NumericHelper>;
+				break;
+			default:
+				bound_function.function = DecimalRoundPositivePrecisionFunction<hugeint_t, Hugeint>;
+				break;
+			}
+		}
+	}
+	bound_function.arguments[0] = decimal_type;
+	bound_function.return_type = LogicalType::DECIMAL(width, target_scale);
+	return make_unique<RoundPrecisionFunctionData>(round_value);
+}
+
+void RoundFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet round("round");
+	for (auto &type : LogicalType::Numeric()) {
+		scalar_function_t round_prec_func = nullptr;
+		scalar_function_t round_func = nullptr;
+		bind_scalar_function_t bind_func = nullptr;
+		bind_scalar_function_t bind_prec_func = nullptr;
+		if (type.IsIntegral()) {
+			// no round for integral numbers
+			continue;
+		}
+		switch (type.id()) {
+		case LogicalTypeId::FLOAT:
+			round_func = ScalarFunction::UnaryFunction<float, float, RoundOperator>;
+			round_prec_func = ScalarFunction::BinaryFunction<float, int32_t, float, RoundOperatorPrecision>;
+			break;
+		case LogicalTypeId::DOUBLE:
+			round_func = ScalarFunction::UnaryFunction<double, double, RoundOperator>;
+			round_prec_func = ScalarFunction::BinaryFunction<double, int32_t, double, RoundOperatorPrecision>;
+			break;
+		case LogicalTypeId::DECIMAL:
+			bind_func = BindGenericRoundFunctionDecimal<RoundDecimalOperator>;
+			bind_prec_func = BindDecimalRoundPrecision;
+			break;
+		default:
+			throw InternalException("Unimplemented numeric type for function \"floor\"");
+		}
+		round.AddFunction(ScalarFunction({type}, type, round_func, false, false, bind_func));
+		round.AddFunction(
+		    ScalarFunction({type, LogicalType::INTEGER}, type, round_prec_func, false, false, bind_prec_func));
+	}
+	set.AddFunction(round);
+}
+
+//===--------------------------------------------------------------------===//
+// exp
+//===--------------------------------------------------------------------===//
+struct ExpOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return std::exp(left);
+	}
+};
+
+void ExpFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("exp", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, ExpOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// pow
+//===--------------------------------------------------------------------===//
+struct PowOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA base, TB exponent) {
+		return std::pow(base, exponent);
+	}
+};
+
+void PowFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction power_function("pow", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                              ScalarFunction::BinaryFunction<double, double, double, PowOperator>);
+	set.AddFunction(power_function);
+	power_function.name = "power";
+	set.AddFunction(power_function);
+	power_function.name = "**";
+	set.AddFunction(power_function);
+	power_function.name = "^";
+	set.AddFunction(power_function);
+}
+
+//===--------------------------------------------------------------------===//
+// sqrt
+//===--------------------------------------------------------------------===//
+struct SqrtOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input < 0) {
+			throw OutOfRangeException("cannot take square root of a negative number");
+		}
+		return std::sqrt(input);
+	}
+};
+
+void SqrtFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("sqrt", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, SqrtOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// cbrt
+//===--------------------------------------------------------------------===//
+struct CbRtOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return std::cbrt(left);
+	}
+};
+
+void CbrtFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("cbrt", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, CbRtOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// ln
+//===--------------------------------------------------------------------===//
+
+struct LnOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input < 0) {
+			throw OutOfRangeException("cannot take logarithm of a negative number");
+		}
+		if (input == 0) {
+			throw OutOfRangeException("cannot take logarithm of zero");
+		}
+		return std::log(input);
+	}
+};
+
+void LnFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("ln", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, LnOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// log
+//===--------------------------------------------------------------------===//
+struct Log10Operator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input < 0) {
+			throw OutOfRangeException("cannot take logarithm of a negative number");
+		}
+		if (input == 0) {
+			throw OutOfRangeException("cannot take logarithm of zero");
+		}
+		return std::log10(input);
+	}
+};
+
+void Log10Fun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"log10", "log"}, ScalarFunction({LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                                                 ScalarFunction::UnaryFunction<double, double, Log10Operator>));
+}
+
+//===--------------------------------------------------------------------===//
+// log2
+//===--------------------------------------------------------------------===//
+struct Log2Operator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input < 0) {
+			throw OutOfRangeException("cannot take logarithm of a negative number");
+		}
+		if (input == 0) {
+			throw OutOfRangeException("cannot take logarithm of zero");
+		}
+		return std::log2(input);
+	}
+};
+
+void Log2Fun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("log2", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, Log2Operator>));
+}
+
+//===--------------------------------------------------------------------===//
+// pi
+//===--------------------------------------------------------------------===//
+static void PiFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 0);
+	Value pi_value = Value::DOUBLE(PI);
+	result.Reference(pi_value);
+}
+
+void PiFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("pi", {}, LogicalType::DOUBLE, PiFunction));
+}
+
+//===--------------------------------------------------------------------===//
+// degrees
+//===--------------------------------------------------------------------===//
+struct DegreesOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return left * (180 / PI);
+	}
+};
+
+void DegreesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("degrees", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, DegreesOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// radians
+//===--------------------------------------------------------------------===//
+struct RadiansOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		return left * (PI / 180);
+	}
+};
+
+void RadiansFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("radians", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, RadiansOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// isnan
+//===--------------------------------------------------------------------===//
+struct IsNanOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return Value::IsNan(input);
+	}
+};
+
+void IsNanFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet funcs("isnan");
+	funcs.AddFunction(ScalarFunction({LogicalType::FLOAT}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<float, bool, IsNanOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<double, bool, IsNanOperator>));
+	set.AddFunction(funcs);
+}
+
+//===--------------------------------------------------------------------===//
+// isinf
+//===--------------------------------------------------------------------===//
+struct IsInfiniteOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return !Value::IsNan(input) && !Value::IsFinite(input);
+	}
+};
+
+template <>
+bool IsInfiniteOperator::Operation(date_t input) {
+	return !Value::IsFinite(input);
+}
+
+template <>
+bool IsInfiniteOperator::Operation(timestamp_t input) {
+	return !Value::IsFinite(input);
+}
+
+void IsInfiniteFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet funcs("isinf");
+	funcs.AddFunction(ScalarFunction({LogicalType::FLOAT}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<float, bool, IsInfiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<double, bool, IsInfiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<date_t, bool, IsInfiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<timestamp_t, bool, IsInfiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<timestamp_t, bool, IsInfiniteOperator>));
+	set.AddFunction(funcs);
+}
+
+//===--------------------------------------------------------------------===//
+// isfinite
+//===--------------------------------------------------------------------===//
+struct IsFiniteOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return Value::IsFinite(input);
+	}
+};
+
+void IsFiniteFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet funcs("isfinite");
+	funcs.AddFunction(ScalarFunction({LogicalType::FLOAT}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<float, bool, IsFiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::DOUBLE}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<double, bool, IsFiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::DATE}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<date_t, bool, IsFiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<timestamp_t, bool, IsFiniteOperator>));
+	funcs.AddFunction(ScalarFunction({LogicalType::TIMESTAMP_TZ}, LogicalType::BOOLEAN,
+	                                 ScalarFunction::UnaryFunction<timestamp_t, bool, IsFiniteOperator>));
+	set.AddFunction(funcs);
+}
+
+//===--------------------------------------------------------------------===//
+// sin
+//===--------------------------------------------------------------------===//
+template <class OP>
+struct NoInfiniteDoubleWrapper {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input) {
+		if (DUCKDB_UNLIKELY(!Value::IsFinite(input))) {
+			if (Value::IsNan(input)) {
+				return input;
+			}
+			throw OutOfRangeException("input value %lf is out of range for numeric function", input);
+		}
+		return OP::template Operation<INPUT_TYPE, RESULT_TYPE>(input);
+	}
+};
+
+struct SinOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return std::sin(input);
+	}
+};
+
+void SinFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("sin", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<SinOperator>>));
+}
+
+//===--------------------------------------------------------------------===//
+// cos
+//===--------------------------------------------------------------------===//
+struct CosOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return (double)std::cos(input);
+	}
+};
+
+void CosFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("cos", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<CosOperator>>));
+}
+
+//===--------------------------------------------------------------------===//
+// tan
+//===--------------------------------------------------------------------===//
+struct TanOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return (double)std::tan(input);
+	}
+};
+
+void TanFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("tan", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<TanOperator>>));
+}
+
+//===--------------------------------------------------------------------===//
+// asin
+//===--------------------------------------------------------------------===//
+struct ASinOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input < -1 || input > 1) {
+			throw Exception("ASIN is undefined outside [-1,1]");
+		}
+		return (double)std::asin(input);
+	}
+};
+
+void AsinFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("asin", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<ASinOperator>>));
+}
+
+//===--------------------------------------------------------------------===//
+// atan
+//===--------------------------------------------------------------------===//
+struct ATanOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return (double)std::atan(input);
+	}
+};
+
+void AtanFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("atan", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, ATanOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// atan2
+//===--------------------------------------------------------------------===//
+struct ATan2 {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA left, TB right) {
+		return (double)std::atan2(left, right);
+	}
+};
+
+void Atan2Fun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("atan2", {LogicalType::DOUBLE, LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::BinaryFunction<double, double, double, ATan2>));
+}
+
+//===--------------------------------------------------------------------===//
+// acos
+//===--------------------------------------------------------------------===//
+struct ACos {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return (double)std::acos(input);
+	}
+};
+
+void AcosFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("acos", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<ACos>>));
+}
+
+//===--------------------------------------------------------------------===//
+// cot
+//===--------------------------------------------------------------------===//
+struct CotOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return 1.0 / (double)std::tan(input);
+	}
+};
+
+void CotFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("cot", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                   ScalarFunction::UnaryFunction<double, double, NoInfiniteDoubleWrapper<CotOperator>>));
+}
+
+//===--------------------------------------------------------------------===//
+// gamma
+//===--------------------------------------------------------------------===//
+struct GammaOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input == 0) {
+			throw OutOfRangeException("cannot take gamma of zero");
+		}
+		return std::tgamma(input);
+	}
+};
+
+void GammaFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("gamma", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, GammaOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// gamma
+//===--------------------------------------------------------------------===//
+struct LogGammaOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		if (input == 0) {
+			throw OutOfRangeException("cannot take log gamma of zero");
+		}
+		return std::lgamma(input);
+	}
+};
+
+void LogGammaFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("lgamma", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, LogGammaOperator>));
+}
+
+//===--------------------------------------------------------------------===//
+// factorial(), !
+//===--------------------------------------------------------------------===//
+
+struct FactorialOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		TR ret = 1;
+		for (TA i = 2; i <= left; i++) {
+			ret *= i;
+		}
+		return ret;
+	}
+};
+
+void FactorialFun::RegisterFunction(BuiltinFunctions &set) {
+	auto fun = ScalarFunction({LogicalType::INTEGER}, LogicalType::HUGEINT,
+	                          ScalarFunction::UnaryFunction<int32_t, hugeint_t, FactorialOperator>);
+
+	set.AddFunction({"factorial", "!__postfix"}, fun);
+}
+
+//===--------------------------------------------------------------------===//
+// even
+//===--------------------------------------------------------------------===//
+struct EvenOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA left) {
+		double value;
+		if (left >= 0) {
+			value = std::ceil(left);
+		} else {
+			value = std::ceil(-left);
+			value = -value;
+		}
+		if (std::floor(value / 2) * 2 != value) {
+			if (left >= 0) {
+				return value += 1;
+			}
+			return value -= 1;
+		}
+		return value;
+	}
+};
+
+void EvenFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("even", {LogicalType::DOUBLE}, LogicalType::DOUBLE,
+	                               ScalarFunction::UnaryFunction<double, double, EvenOperator>));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct RandomBindData : public FunctionData {
+	ClientContext &context;
+
+	explicit RandomBindData(ClientContext &context) : context(context) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<RandomBindData>(context);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		return true;
+	}
+};
+
+struct RandomLocalState : public FunctionLocalState {
+	explicit RandomLocalState(uint32_t seed) : random_engine(seed) {
+	}
+
+	RandomEngine random_engine;
+};
+
+static void RandomFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 0);
+	auto &lstate = (RandomLocalState &)*ExecuteFunctionState::GetFunctionState(state);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<double>(result);
+	for (idx_t i = 0; i < args.size(); i++) {
+		result_data[i] = lstate.random_engine.NextRandom();
+	}
+}
+
+unique_ptr<FunctionData> RandomBind(ClientContext &context, ScalarFunction &bound_function,
+                                    vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<RandomBindData>(context);
+}
+
+static unique_ptr<FunctionLocalState> RandomInitLocalState(const BoundFunctionExpression &expr,
+                                                           FunctionData *bind_data) {
+	auto &info = (RandomBindData &)*bind_data;
+	auto &random_engine = RandomEngine::Get(info.context);
+	return make_unique<RandomLocalState>(random_engine.NextRandomInteger());
+}
+
+void RandomFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("random", {}, LogicalType::DOUBLE, RandomFunction, true, RandomBind, nullptr,
+	                               nullptr, RandomInitLocalState));
+}
+
+static void GenerateUUIDFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 0);
+	auto &lstate = (RandomLocalState &)*ExecuteFunctionState::GetFunctionState(state);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<hugeint_t>(result);
+
+	for (idx_t i = 0; i < args.size(); i++) {
+		result_data[i] = UUID::GenerateRandomUUID(lstate.random_engine);
+	}
+}
+
+void UUIDFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction uuid_function({}, LogicalType::UUID, GenerateUUIDFunction, false, true, RandomBind, nullptr, nullptr,
+	                             RandomInitLocalState);
+	// generate a random uuid
+	set.AddFunction({"uuid", "gen_random_uuid"}, uuid_function);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct SetseedBindData : public FunctionData {
+	//! The client context for the function call
+	ClientContext &context;
+
+	explicit SetseedBindData(ClientContext &context) : context(context) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<SetseedBindData>(context);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		return true;
+	}
+};
+
+static void SetSeedFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (SetseedBindData &)*func_expr.bind_info;
+	auto &input = args.data[0];
+	input.Normalify(args.size());
+
+	auto input_seeds = FlatVector::GetData<double>(input);
+	uint32_t half_max = NumericLimits<uint32_t>::Maximum() / 2;
+
+	auto &random_engine = RandomEngine::Get(info.context);
+	for (idx_t i = 0; i < args.size(); i++) {
+		if (input_seeds[i] < -1.0 || input_seeds[i] > 1.0) {
+			throw Exception("SETSEED accepts seed values between -1.0 and 1.0, inclusive");
+		}
+		uint32_t norm_seed = (input_seeds[i] + 1.0) * half_max;
+		random_engine.SetSeed(norm_seed);
+	}
+
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	ConstantVector::SetNull(result, true);
+}
+
+unique_ptr<FunctionData> SetSeedBind(ClientContext &context, ScalarFunction &bound_function,
+                                     vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<SetseedBindData>(context);
+}
+
+void SetseedFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("setseed", {LogicalType::DOUBLE}, LogicalType::SQLNULL, SetSeedFunction, true, SetSeedBind));
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterMathFunctions() {
+	Register<AbsFun>();
+	Register<SignFun>();
+
+	Register<CeilFun>();
+	Register<FloorFun>();
+	Register<RoundFun>();
+
+	Register<DegreesFun>();
+	Register<RadiansFun>();
+
+	Register<CbrtFun>();
+	Register<ExpFun>();
+	Register<Log2Fun>();
+	Register<Log10Fun>();
+	Register<LnFun>();
+	Register<PowFun>();
+	Register<RandomFun>();
+	Register<SetseedFun>();
+	Register<SqrtFun>();
+
+	Register<PiFun>();
+
+	Register<BitCountFun>();
+
+	Register<GammaFun>();
+	Register<LogGammaFun>();
+
+	Register<FactorialFun>();
+
+	Register<NextAfterFun>();
+
+	Register<EvenFun>();
+
+	Register<IsNanFun>();
+	Register<IsInfiniteFun>();
+	Register<IsFiniteFun>();
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterNestedFunctions() {
+	Register<ArraySliceFun>();
+	Register<StructPackFun>();
+	Register<StructExtractFun>();
+	Register<StructInsertFun>();
+	Register<ListConcatFun>();
+	Register<ListContainsFun>();
+	Register<ListPositionFun>();
+	Register<ListAggregateFun>();
+	Register<ListDistinctFun>();
+	Register<ListUniqueFun>();
+	Register<ListValueFun>();
+	Register<ListExtractFun>();
+	Register<ListSortFun>();
+	Register<ListRangeFun>();
+	Register<ListFlattenFun>();
+	Register<MapFun>();
+	Register<MapExtractFun>();
+	Register<CardinalityFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+#include <limits>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// + [add]
+//===--------------------------------------------------------------------===//
+template <>
+float AddOperator::Operation(float left, float right) {
+	auto result = left + right;
+	if (!Value::FloatIsFinite(result)) {
+		throw OutOfRangeException("Overflow in addition of float!");
+	}
+	return result;
+}
+
+template <>
+double AddOperator::Operation(double left, double right) {
+	auto result = left + right;
+	if (!Value::DoubleIsFinite(result)) {
+		throw OutOfRangeException("Overflow in addition of double!");
+	}
+	return result;
+}
+
+template <>
+interval_t AddOperator::Operation(interval_t left, interval_t right) {
+	left.months = AddOperatorOverflowCheck::Operation<int32_t, int32_t, int32_t>(left.months, right.months);
+	left.days = AddOperatorOverflowCheck::Operation<int32_t, int32_t, int32_t>(left.days, right.days);
+	left.micros = AddOperatorOverflowCheck::Operation<int64_t, int64_t, int64_t>(left.micros, right.micros);
+	return left;
+}
+
+template <>
+date_t AddOperator::Operation(date_t left, int32_t right) {
+	if (!Value::IsFinite(left)) {
+		return left;
+	}
+	int32_t days;
+	if (!TryAddOperator::Operation(left.days, right, days)) {
+		throw OutOfRangeException("Date out of range");
+	}
+	date_t result(days);
+	if (!Value::IsFinite(result)) {
+		throw OutOfRangeException("Date out of range");
+	}
+	return result;
+}
+
+template <>
+date_t AddOperator::Operation(int32_t left, date_t right) {
+	return AddOperator::Operation<date_t, int32_t, date_t>(right, left);
+}
+
+template <>
+timestamp_t AddOperator::Operation(date_t left, dtime_t right) {
+	if (left == date_t::infinity()) {
+		return timestamp_t::infinity();
+	} else if (left == date_t::ninfinity()) {
+		return timestamp_t::ninfinity();
+	}
+	timestamp_t result;
+	if (!Timestamp::TryFromDatetime(left, right, result)) {
+		throw OutOfRangeException("Timestamp out of range");
+	}
+	return result;
+}
+
+template <>
+timestamp_t AddOperator::Operation(dtime_t left, date_t right) {
+	return AddOperator::Operation<date_t, dtime_t, timestamp_t>(right, left);
+}
+
+template <>
+date_t AddOperator::Operation(date_t left, interval_t right) {
+	return Interval::Add(left, right);
+}
+
+template <>
+date_t AddOperator::Operation(interval_t left, date_t right) {
+	return AddOperator::Operation<date_t, interval_t, date_t>(right, left);
+}
+
+template <>
+timestamp_t AddOperator::Operation(timestamp_t left, interval_t right) {
+	return Interval::Add(left, right);
+}
+
+template <>
+timestamp_t AddOperator::Operation(interval_t left, timestamp_t right) {
+	return AddOperator::Operation<timestamp_t, interval_t, timestamp_t>(right, left);
+}
+
+//===--------------------------------------------------------------------===//
+// + [add] with overflow check
+//===--------------------------------------------------------------------===//
+struct OverflowCheckedAddition {
+	template <class SRCTYPE, class UTYPE>
+	static inline bool Operation(SRCTYPE left, SRCTYPE right, SRCTYPE &result) {
+		UTYPE uresult = AddOperator::Operation<UTYPE, UTYPE, UTYPE>(UTYPE(left), UTYPE(right));
+		if (uresult < NumericLimits<SRCTYPE>::Minimum() || uresult > NumericLimits<SRCTYPE>::Maximum()) {
+			return false;
+		}
+		result = SRCTYPE(uresult);
+		return true;
+	}
+};
+
+template <>
+bool TryAddOperator::Operation(uint8_t left, uint8_t right, uint8_t &result) {
+	return OverflowCheckedAddition::Operation<uint8_t, uint16_t>(left, right, result);
+}
+template <>
+bool TryAddOperator::Operation(uint16_t left, uint16_t right, uint16_t &result) {
+	return OverflowCheckedAddition::Operation<uint16_t, uint32_t>(left, right, result);
+}
+template <>
+bool TryAddOperator::Operation(uint32_t left, uint32_t right, uint32_t &result) {
+	return OverflowCheckedAddition::Operation<uint32_t, uint64_t>(left, right, result);
+}
+
+template <>
+bool TryAddOperator::Operation(uint64_t left, uint64_t right, uint64_t &result) {
+	if (NumericLimits<uint64_t>::Maximum() - left < right) {
+		return false;
+	}
+	return OverflowCheckedAddition::Operation<uint64_t, uint64_t>(left, right, result);
+}
+
+template <>
+bool TryAddOperator::Operation(int8_t left, int8_t right, int8_t &result) {
+	return OverflowCheckedAddition::Operation<int8_t, int16_t>(left, right, result);
+}
+
+template <>
+bool TryAddOperator::Operation(int16_t left, int16_t right, int16_t &result) {
+	return OverflowCheckedAddition::Operation<int16_t, int32_t>(left, right, result);
+}
+
+template <>
+bool TryAddOperator::Operation(int32_t left, int32_t right, int32_t &result) {
+	return OverflowCheckedAddition::Operation<int32_t, int64_t>(left, right, result);
+}
+
+template <>
+bool TryAddOperator::Operation(int64_t left, int64_t right, int64_t &result) {
+#if (__GNUC__ >= 5) || defined(__clang__)
+	if (__builtin_add_overflow(left, right, &result)) {
+		return false;
+	}
+#else
+	// https://blog.regehr.org/archives/1139
+	result = int64_t((uint64_t)left + (uint64_t)right);
+	if ((left < 0 && right < 0 && result >= 0) || (left >= 0 && right >= 0 && result < 0)) {
+		return false;
+	}
+#endif
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// add decimal with overflow check
+//===--------------------------------------------------------------------===//
+template <class T, T min, T max>
+bool TryDecimalAddTemplated(T left, T right, T &result) {
+	if (right < 0) {
+		if (min - right > left) {
+			return false;
+		}
+	} else {
+		if (max - right < left) {
+			return false;
+		}
+	}
+	result = left + right;
+	return true;
+}
+
+template <>
+bool TryDecimalAdd::Operation(int16_t left, int16_t right, int16_t &result) {
+	return TryDecimalAddTemplated<int16_t, -9999, 9999>(left, right, result);
+}
+
+template <>
+bool TryDecimalAdd::Operation(int32_t left, int32_t right, int32_t &result) {
+	return TryDecimalAddTemplated<int32_t, -999999999, 999999999>(left, right, result);
+}
+
+template <>
+bool TryDecimalAdd::Operation(int64_t left, int64_t right, int64_t &result) {
+	return TryDecimalAddTemplated<int64_t, -999999999999999999, 999999999999999999>(left, right, result);
+}
+
+template <>
+bool TryDecimalAdd::Operation(hugeint_t left, hugeint_t right, hugeint_t &result) {
+	result = left + right;
+	if (result <= -Hugeint::POWERS_OF_TEN[38] || result >= Hugeint::POWERS_OF_TEN[38]) {
+		return false;
+	}
+	return true;
+}
+
+template <>
+hugeint_t DecimalAddOverflowCheck::Operation(hugeint_t left, hugeint_t right) {
+	hugeint_t result;
+	if (!TryDecimalAdd::Operation(left, right, result)) {
+		throw OutOfRangeException("Overflow in addition of DECIMAL(38) (%s + %s);", left.ToString(), right.ToString());
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// add time operator
+//===--------------------------------------------------------------------===//
+template <>
+dtime_t AddTimeOperator::Operation(dtime_t left, interval_t right) {
+	date_t date(0);
+	return Interval::Add(left, right, date);
+}
+
+template <>
+dtime_t AddTimeOperator::Operation(interval_t left, dtime_t right) {
+	return AddTimeOperator::Operation<dtime_t, interval_t, dtime_t>(right, left);
+}
+
+} // namespace duckdb

--- a/velox/external/duckdb/duckdb-5.cpp
+++ b/velox/external/duckdb/duckdb-5.cpp
@@ -1,0 +1,16840 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <limits>
+
+namespace duckdb {
+
+template <class OP>
+static scalar_function_t GetScalarIntegerFunction(PhysicalType type) {
+	scalar_function_t function;
+	switch (type) {
+	case PhysicalType::INT8:
+		function = &ScalarFunction::BinaryFunction<int8_t, int8_t, int8_t, OP>;
+		break;
+	case PhysicalType::INT16:
+		function = &ScalarFunction::BinaryFunction<int16_t, int16_t, int16_t, OP>;
+		break;
+	case PhysicalType::INT32:
+		function = &ScalarFunction::BinaryFunction<int32_t, int32_t, int32_t, OP>;
+		break;
+	case PhysicalType::INT64:
+		function = &ScalarFunction::BinaryFunction<int64_t, int64_t, int64_t, OP>;
+		break;
+	case PhysicalType::UINT8:
+		function = &ScalarFunction::BinaryFunction<uint8_t, uint8_t, uint8_t, OP>;
+		break;
+	case PhysicalType::UINT16:
+		function = &ScalarFunction::BinaryFunction<uint16_t, uint16_t, uint16_t, OP>;
+		break;
+	case PhysicalType::UINT32:
+		function = &ScalarFunction::BinaryFunction<uint32_t, uint32_t, uint32_t, OP>;
+		break;
+	case PhysicalType::UINT64:
+		function = &ScalarFunction::BinaryFunction<uint64_t, uint64_t, uint64_t, OP>;
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for GetScalarBinaryFunction");
+	}
+	return function;
+}
+
+template <class OP>
+static scalar_function_t GetScalarBinaryFunction(PhysicalType type) {
+	scalar_function_t function;
+	switch (type) {
+	case PhysicalType::INT128:
+		function = &ScalarFunction::BinaryFunction<hugeint_t, hugeint_t, hugeint_t, OP>;
+		break;
+	case PhysicalType::FLOAT:
+		function = &ScalarFunction::BinaryFunction<float, float, float, OP>;
+		break;
+	case PhysicalType::DOUBLE:
+		function = &ScalarFunction::BinaryFunction<double, double, double, OP>;
+		break;
+	default:
+		function = GetScalarIntegerFunction<OP>(type);
+		break;
+	}
+	return function;
+}
+
+//===--------------------------------------------------------------------===//
+// + [add]
+//===--------------------------------------------------------------------===//
+struct AddPropagateStatistics {
+	template <class T, class OP>
+	static bool Operation(LogicalType type, NumericStatistics &lstats, NumericStatistics &rstats, Value &new_min,
+	                      Value &new_max) {
+		T min, max;
+		// new min is min+min
+		if (!OP::Operation(lstats.min.GetValueUnsafe<T>(), rstats.min.GetValueUnsafe<T>(), min)) {
+			return true;
+		}
+		// new max is max+max
+		if (!OP::Operation(lstats.max.GetValueUnsafe<T>(), rstats.max.GetValueUnsafe<T>(), max)) {
+			return true;
+		}
+		new_min = Value::Numeric(type, min);
+		new_max = Value::Numeric(type, max);
+		return false;
+	}
+};
+
+struct SubtractPropagateStatistics {
+	template <class T, class OP>
+	static bool Operation(LogicalType type, NumericStatistics &lstats, NumericStatistics &rstats, Value &new_min,
+	                      Value &new_max) {
+		T min, max;
+		if (!OP::Operation(lstats.min.GetValueUnsafe<T>(), rstats.max.GetValueUnsafe<T>(), min)) {
+			return true;
+		}
+		if (!OP::Operation(lstats.max.GetValueUnsafe<T>(), rstats.min.GetValueUnsafe<T>(), max)) {
+			return true;
+		}
+		new_min = Value::Numeric(type, min);
+		new_max = Value::Numeric(type, max);
+		return false;
+	}
+};
+
+template <class OP, class PROPAGATE, class BASEOP>
+static unique_ptr<BaseStatistics> PropagateNumericStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	D_ASSERT(child_stats.size() == 2);
+	// can only propagate stats if the children have stats
+	if (!child_stats[0] || !child_stats[1]) {
+		return nullptr;
+	}
+	auto &lstats = (NumericStatistics &)*child_stats[0];
+	auto &rstats = (NumericStatistics &)*child_stats[1];
+	Value new_min, new_max;
+	bool potential_overflow = true;
+	if (!lstats.min.IsNull() && !lstats.max.IsNull() && !rstats.min.IsNull() && !rstats.max.IsNull()) {
+		switch (expr.return_type.InternalType()) {
+		case PhysicalType::INT8:
+			potential_overflow =
+			    PROPAGATE::template Operation<int8_t, OP>(expr.return_type, lstats, rstats, new_min, new_max);
+			break;
+		case PhysicalType::INT16:
+			potential_overflow =
+			    PROPAGATE::template Operation<int16_t, OP>(expr.return_type, lstats, rstats, new_min, new_max);
+			break;
+		case PhysicalType::INT32:
+			potential_overflow =
+			    PROPAGATE::template Operation<int32_t, OP>(expr.return_type, lstats, rstats, new_min, new_max);
+			break;
+		case PhysicalType::INT64:
+			potential_overflow =
+			    PROPAGATE::template Operation<int64_t, OP>(expr.return_type, lstats, rstats, new_min, new_max);
+			break;
+		default:
+			return nullptr;
+		}
+	}
+	if (potential_overflow) {
+		new_min = Value(expr.return_type);
+		new_max = Value(expr.return_type);
+	} else {
+		// no potential overflow: replace with non-overflowing operator
+		expr.function.function = GetScalarIntegerFunction<BASEOP>(expr.return_type.InternalType());
+	}
+	auto stats =
+	    make_unique<NumericStatistics>(expr.return_type, move(new_min), move(new_max), StatisticsType::LOCAL_STATS);
+	stats->validity_stats = ValidityStatistics::Combine(lstats.validity_stats, rstats.validity_stats);
+	return move(stats);
+}
+
+template <class OP, class OPOVERFLOWCHECK, bool IS_SUBTRACT = false>
+unique_ptr<FunctionData> BindDecimalAddSubtract(ClientContext &context, ScalarFunction &bound_function,
+                                                vector<unique_ptr<Expression>> &arguments) {
+	// get the max width and scale of the input arguments
+	uint8_t max_width = 0, max_scale = 0, max_width_over_scale = 0;
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		if (arguments[i]->return_type.id() == LogicalTypeId::UNKNOWN) {
+			continue;
+		}
+		uint8_t width, scale;
+		auto can_convert = arguments[i]->return_type.GetDecimalProperties(width, scale);
+		if (!can_convert) {
+			throw InternalException("Could not convert type %s to a decimal.", arguments[i]->return_type.ToString());
+		}
+		max_width = MaxValue<uint8_t>(width, max_width);
+		max_scale = MaxValue<uint8_t>(scale, max_scale);
+		max_width_over_scale = MaxValue<uint8_t>(width - scale, max_width_over_scale);
+	}
+	D_ASSERT(max_width > 0);
+	// for addition/subtraction, we add 1 to the width to ensure we don't overflow
+	bool check_overflow = false;
+	auto required_width = MaxValue<uint8_t>(max_scale + max_width_over_scale, max_width) + 1;
+	if (required_width > Decimal::MAX_WIDTH_INT64 && max_width <= Decimal::MAX_WIDTH_INT64) {
+		// we don't automatically promote past the hugeint boundary to avoid the large hugeint performance penalty
+		check_overflow = true;
+		required_width = Decimal::MAX_WIDTH_INT64;
+	}
+	if (required_width > Decimal::MAX_WIDTH_DECIMAL) {
+		// target width does not fit in decimal at all: truncate the scale and perform overflow detection
+		check_overflow = true;
+		required_width = Decimal::MAX_WIDTH_DECIMAL;
+	}
+	// arithmetic between two decimal arguments: check the types of the input arguments
+	LogicalType result_type = LogicalType::DECIMAL(required_width, max_scale);
+	// we cast all input types to the specified type
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		// first check if the cast is necessary
+		// if the argument has a matching scale and internal type as the output type, no casting is necessary
+		auto &argument_type = arguments[i]->return_type;
+		uint8_t width, scale;
+		argument_type.GetDecimalProperties(width, scale);
+		if (scale == DecimalType::GetScale(result_type) && argument_type.InternalType() == result_type.InternalType()) {
+			bound_function.arguments[i] = argument_type;
+		} else {
+			bound_function.arguments[i] = result_type;
+		}
+	}
+	bound_function.return_type = result_type;
+	// now select the physical function to execute
+	if (check_overflow) {
+		bound_function.function = GetScalarBinaryFunction<OPOVERFLOWCHECK>(result_type.InternalType());
+	} else {
+		bound_function.function = GetScalarBinaryFunction<OP>(result_type.InternalType());
+	}
+	if (result_type.InternalType() != PhysicalType::INT128) {
+		if (IS_SUBTRACT) {
+			bound_function.statistics =
+			    PropagateNumericStats<TryDecimalSubtract, SubtractPropagateStatistics, SubtractOperator>;
+		} else {
+			bound_function.statistics = PropagateNumericStats<TryDecimalAdd, AddPropagateStatistics, AddOperator>;
+		}
+	}
+	return nullptr;
+}
+
+unique_ptr<FunctionData> NopDecimalBind(ClientContext &context, ScalarFunction &bound_function,
+                                        vector<unique_ptr<Expression>> &arguments) {
+	bound_function.return_type = arguments[0]->return_type;
+	bound_function.arguments[0] = arguments[0]->return_type;
+	return nullptr;
+}
+
+ScalarFunction AddFun::GetFunction(const LogicalType &type) {
+	D_ASSERT(type.IsNumeric());
+	if (type.id() == LogicalTypeId::DECIMAL) {
+		return ScalarFunction("+", {type}, type, ScalarFunction::NopFunction, false, NopDecimalBind);
+	} else {
+		return ScalarFunction("+", {type}, type, ScalarFunction::NopFunction);
+	}
+}
+
+ScalarFunction AddFun::GetFunction(const LogicalType &left_type, const LogicalType &right_type) {
+	if (left_type.IsNumeric() && left_type.id() == right_type.id()) {
+		if (left_type.id() == LogicalTypeId::DECIMAL) {
+			return ScalarFunction("+", {left_type, right_type}, left_type, nullptr, false,
+			                      BindDecimalAddSubtract<AddOperator, DecimalAddOverflowCheck>);
+		} else if (left_type.IsIntegral() && left_type.id() != LogicalTypeId::HUGEINT) {
+			return ScalarFunction("+", {left_type, right_type}, left_type,
+			                      GetScalarIntegerFunction<AddOperatorOverflowCheck>(left_type.InternalType()), false,
+			                      nullptr, nullptr,
+			                      PropagateNumericStats<TryAddOperator, AddPropagateStatistics, AddOperator>);
+		} else {
+			return ScalarFunction("+", {left_type, right_type}, left_type,
+			                      GetScalarBinaryFunction<AddOperator>(left_type.InternalType()));
+		}
+	}
+
+	switch (left_type.id()) {
+	case LogicalTypeId::DATE:
+		if (right_type.id() == LogicalTypeId::INTEGER) {
+			return ScalarFunction("+", {left_type, right_type}, LogicalType::DATE,
+			                      ScalarFunction::BinaryFunction<date_t, int32_t, date_t, AddOperator>);
+		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
+			return ScalarFunction("+", {left_type, right_type}, LogicalType::DATE,
+			                      ScalarFunction::BinaryFunction<date_t, interval_t, date_t, AddOperator>);
+		} else if (right_type.id() == LogicalTypeId::TIME) {
+			return ScalarFunction("+", {left_type, right_type}, LogicalType::TIMESTAMP,
+			                      ScalarFunction::BinaryFunction<date_t, dtime_t, timestamp_t, AddOperator>);
+		}
+		break;
+	case LogicalTypeId::INTEGER:
+		if (right_type.id() == LogicalTypeId::DATE) {
+			return ScalarFunction("+", {left_type, right_type}, right_type,
+			                      ScalarFunction::BinaryFunction<int32_t, date_t, date_t, AddOperator>);
+		}
+		break;
+	case LogicalTypeId::INTERVAL:
+		if (right_type.id() == LogicalTypeId::INTERVAL) {
+			return ScalarFunction("+", {left_type, right_type}, LogicalType::INTERVAL,
+			                      ScalarFunction::BinaryFunction<interval_t, interval_t, interval_t, AddOperator>);
+		} else if (right_type.id() == LogicalTypeId::DATE) {
+			return ScalarFunction("+", {left_type, right_type}, LogicalType::DATE,
+			                      ScalarFunction::BinaryFunction<interval_t, date_t, date_t, AddOperator>);
+		} else if (right_type.id() == LogicalTypeId::TIME) {
+			return ScalarFunction("+", {left_type, right_type}, LogicalType::TIME,
+			                      ScalarFunction::BinaryFunction<interval_t, dtime_t, dtime_t, AddTimeOperator>);
+		} else if (right_type.id() == LogicalTypeId::TIMESTAMP) {
+			return ScalarFunction("+", {left_type, right_type}, LogicalType::TIMESTAMP,
+			                      ScalarFunction::BinaryFunction<interval_t, timestamp_t, timestamp_t, AddOperator>);
+		}
+		break;
+	case LogicalTypeId::TIME:
+		if (right_type.id() == LogicalTypeId::INTERVAL) {
+			return ScalarFunction("+", {left_type, right_type}, LogicalType::TIME,
+			                      ScalarFunction::BinaryFunction<dtime_t, interval_t, dtime_t, AddTimeOperator>);
+		} else if (right_type.id() == LogicalTypeId::DATE) {
+			return ScalarFunction("+", {left_type, right_type}, LogicalType::TIMESTAMP,
+			                      ScalarFunction::BinaryFunction<dtime_t, date_t, timestamp_t, AddOperator>);
+		}
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		if (right_type.id() == LogicalTypeId::INTERVAL) {
+			return ScalarFunction("+", {left_type, right_type}, LogicalType::TIMESTAMP,
+			                      ScalarFunction::BinaryFunction<timestamp_t, interval_t, timestamp_t, AddOperator>);
+		}
+		break;
+	default:
+		break;
+	}
+	// LCOV_EXCL_START
+	throw NotImplementedException("AddFun for types %s, %s", LogicalTypeIdToString(left_type.id()),
+	                              LogicalTypeIdToString(right_type.id()));
+	// LCOV_EXCL_STOP
+}
+
+void AddFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("+");
+	for (auto &type : LogicalType::Numeric()) {
+		// unary add function is a nop, but only exists for numeric types
+		functions.AddFunction(GetFunction(type));
+		// binary add function adds two numbers together
+		functions.AddFunction(GetFunction(type, type));
+	}
+	// we can add integers to dates
+	functions.AddFunction(GetFunction(LogicalType::DATE, LogicalType::INTEGER));
+	functions.AddFunction(GetFunction(LogicalType::INTEGER, LogicalType::DATE));
+	// we can add intervals together
+	functions.AddFunction(GetFunction(LogicalType::INTERVAL, LogicalType::INTERVAL));
+	// we can add intervals to dates/times/timestamps
+	functions.AddFunction(GetFunction(LogicalType::DATE, LogicalType::INTERVAL));
+	functions.AddFunction(GetFunction(LogicalType::INTERVAL, LogicalType::DATE));
+
+	functions.AddFunction(GetFunction(LogicalType::TIME, LogicalType::INTERVAL));
+	functions.AddFunction(GetFunction(LogicalType::INTERVAL, LogicalType::TIME));
+
+	functions.AddFunction(GetFunction(LogicalType::TIMESTAMP, LogicalType::INTERVAL));
+	functions.AddFunction(GetFunction(LogicalType::INTERVAL, LogicalType::TIMESTAMP));
+
+	// we can add times to dates
+	functions.AddFunction(GetFunction(LogicalType::TIME, LogicalType::DATE));
+	functions.AddFunction(GetFunction(LogicalType::DATE, LogicalType::TIME));
+
+	// we can add lists together
+	functions.AddFunction(ListConcatFun::GetFunction());
+
+	set.AddFunction(functions);
+
+	functions.name = "add";
+	set.AddFunction(functions);
+}
+
+//===--------------------------------------------------------------------===//
+// - [subtract]
+//===--------------------------------------------------------------------===//
+struct NegateOperator {
+	template <class T>
+	static bool CanNegate(T input) {
+		using Limits = std::numeric_limits<T>;
+		return !(Limits::is_integer && Limits::is_signed && Limits::lowest() == input);
+	}
+
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		auto cast = (TR)input;
+		if (!CanNegate<TR>(cast)) {
+			throw OutOfRangeException("Overflow in negation of integer!");
+		}
+		return -cast;
+	}
+};
+
+template <>
+bool NegateOperator::CanNegate(float input) {
+	return Value::FloatIsFinite(input);
+}
+
+template <>
+bool NegateOperator::CanNegate(double input) {
+	return Value::DoubleIsFinite(input);
+}
+
+template <>
+interval_t NegateOperator::Operation(interval_t input) {
+	interval_t result;
+	result.months = NegateOperator::Operation<int32_t, int32_t>(input.months);
+	result.days = NegateOperator::Operation<int32_t, int32_t>(input.days);
+	result.micros = NegateOperator::Operation<int64_t, int64_t>(input.micros);
+	return result;
+}
+
+unique_ptr<FunctionData> DecimalNegateBind(ClientContext &context, ScalarFunction &bound_function,
+                                           vector<unique_ptr<Expression>> &arguments) {
+	auto &decimal_type = arguments[0]->return_type;
+	auto width = DecimalType::GetWidth(decimal_type);
+	if (width <= Decimal::MAX_WIDTH_INT16) {
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<NegateOperator>(LogicalTypeId::SMALLINT);
+	} else if (width <= Decimal::MAX_WIDTH_INT32) {
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<NegateOperator>(LogicalTypeId::INTEGER);
+	} else if (width <= Decimal::MAX_WIDTH_INT64) {
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<NegateOperator>(LogicalTypeId::BIGINT);
+	} else {
+		D_ASSERT(width <= Decimal::MAX_WIDTH_INT128);
+		bound_function.function = ScalarFunction::GetScalarUnaryFunction<NegateOperator>(LogicalTypeId::HUGEINT);
+	}
+	decimal_type.Verify();
+	bound_function.arguments[0] = decimal_type;
+	bound_function.return_type = decimal_type;
+	return nullptr;
+}
+
+struct NegatePropagateStatistics {
+	template <class T>
+	static bool Operation(LogicalType type, NumericStatistics &istats, Value &new_min, Value &new_max) {
+		auto max_value = istats.max.GetValueUnsafe<T>();
+		auto min_value = istats.min.GetValueUnsafe<T>();
+		if (!NegateOperator::CanNegate<T>(min_value) || !NegateOperator::CanNegate<T>(max_value)) {
+			return true;
+		}
+		// new min is -max
+		new_min = Value::Numeric(type, NegateOperator::Operation<T, T>(max_value));
+		// new max is -min
+		new_max = Value::Numeric(type, NegateOperator::Operation<T, T>(min_value));
+		return false;
+	}
+};
+
+static unique_ptr<BaseStatistics> NegateBindStatistics(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	D_ASSERT(child_stats.size() == 1);
+	// can only propagate stats if the children have stats
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &istats = (NumericStatistics &)*child_stats[0];
+	Value new_min, new_max;
+	bool potential_overflow = true;
+	if (!istats.min.IsNull() && !istats.max.IsNull()) {
+		switch (expr.return_type.InternalType()) {
+		case PhysicalType::INT8:
+			potential_overflow =
+			    NegatePropagateStatistics::Operation<int8_t>(expr.return_type, istats, new_min, new_max);
+			break;
+		case PhysicalType::INT16:
+			potential_overflow =
+			    NegatePropagateStatistics::Operation<int16_t>(expr.return_type, istats, new_min, new_max);
+			break;
+		case PhysicalType::INT32:
+			potential_overflow =
+			    NegatePropagateStatistics::Operation<int32_t>(expr.return_type, istats, new_min, new_max);
+			break;
+		case PhysicalType::INT64:
+			potential_overflow =
+			    NegatePropagateStatistics::Operation<int64_t>(expr.return_type, istats, new_min, new_max);
+			break;
+		default:
+			return nullptr;
+		}
+	}
+	if (potential_overflow) {
+		new_min = Value(expr.return_type);
+		new_max = Value(expr.return_type);
+	}
+	auto stats =
+	    make_unique<NumericStatistics>(expr.return_type, move(new_min), move(new_max), StatisticsType::LOCAL_STATS);
+	if (istats.validity_stats) {
+		stats->validity_stats = istats.validity_stats->Copy();
+	}
+	return move(stats);
+}
+
+ScalarFunction SubtractFun::GetFunction(const LogicalType &type) {
+	if (type.id() == LogicalTypeId::INTERVAL) {
+		return ScalarFunction("-", {type}, type, ScalarFunction::UnaryFunction<interval_t, interval_t, NegateOperator>);
+	} else if (type.id() == LogicalTypeId::DECIMAL) {
+		return ScalarFunction("-", {type}, type, nullptr, false, DecimalNegateBind, nullptr, NegateBindStatistics);
+	} else {
+		D_ASSERT(type.IsNumeric());
+		return ScalarFunction("-", {type}, type, ScalarFunction::GetScalarUnaryFunction<NegateOperator>(type), false,
+		                      nullptr, nullptr, NegateBindStatistics);
+	}
+}
+
+ScalarFunction SubtractFun::GetFunction(const LogicalType &left_type, const LogicalType &right_type) {
+	if (left_type.IsNumeric() && left_type.id() == right_type.id()) {
+		if (left_type.id() == LogicalTypeId::DECIMAL) {
+			return ScalarFunction("-", {left_type, right_type}, left_type, nullptr, false,
+			                      BindDecimalAddSubtract<SubtractOperator, DecimalSubtractOverflowCheck, true>);
+		} else if (left_type.IsIntegral() && left_type.id() != LogicalTypeId::HUGEINT) {
+			return ScalarFunction(
+			    "-", {left_type, right_type}, left_type,
+			    GetScalarIntegerFunction<SubtractOperatorOverflowCheck>(left_type.InternalType()), false, nullptr,
+			    nullptr, PropagateNumericStats<TrySubtractOperator, SubtractPropagateStatistics, SubtractOperator>);
+		} else {
+			return ScalarFunction("-", {left_type, right_type}, left_type,
+			                      GetScalarBinaryFunction<SubtractOperator>(left_type.InternalType()));
+		}
+	}
+
+	switch (left_type.id()) {
+	case LogicalTypeId::DATE:
+		if (right_type.id() == LogicalTypeId::DATE) {
+			return ScalarFunction("-", {left_type, right_type}, LogicalType::BIGINT,
+			                      ScalarFunction::BinaryFunction<date_t, date_t, int64_t, SubtractOperator>);
+		} else if (right_type.id() == LogicalTypeId::INTEGER) {
+			return ScalarFunction("-", {left_type, right_type}, LogicalType::DATE,
+			                      ScalarFunction::BinaryFunction<date_t, int32_t, date_t, SubtractOperator>);
+		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
+			return ScalarFunction("-", {left_type, right_type}, LogicalType::DATE,
+			                      ScalarFunction::BinaryFunction<date_t, interval_t, date_t, SubtractOperator>);
+		}
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		if (right_type.id() == LogicalTypeId::TIMESTAMP) {
+			return ScalarFunction(
+			    "-", {left_type, right_type}, LogicalType::INTERVAL,
+			    ScalarFunction::BinaryFunction<timestamp_t, timestamp_t, interval_t, SubtractOperator>);
+		} else if (right_type.id() == LogicalTypeId::INTERVAL) {
+			return ScalarFunction(
+			    "-", {left_type, right_type}, LogicalType::TIMESTAMP,
+			    ScalarFunction::BinaryFunction<timestamp_t, interval_t, timestamp_t, SubtractOperator>);
+		}
+		break;
+	case LogicalTypeId::INTERVAL:
+		if (right_type.id() == LogicalTypeId::INTERVAL) {
+			return ScalarFunction("-", {left_type, right_type}, LogicalType::INTERVAL,
+			                      ScalarFunction::BinaryFunction<interval_t, interval_t, interval_t, SubtractOperator>);
+		}
+		break;
+	case LogicalTypeId::TIME:
+		if (right_type.id() == LogicalTypeId::INTERVAL) {
+			return ScalarFunction("-", {left_type, right_type}, LogicalType::TIME,
+			                      ScalarFunction::BinaryFunction<dtime_t, interval_t, dtime_t, SubtractTimeOperator>);
+		}
+		break;
+	default:
+		break;
+	}
+	// LCOV_EXCL_START
+	throw NotImplementedException("SubtractFun for types %s, %s", LogicalTypeIdToString(left_type.id()),
+	                              LogicalTypeIdToString(right_type.id()));
+	// LCOV_EXCL_STOP
+}
+
+void SubtractFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("-");
+	for (auto &type : LogicalType::Numeric()) {
+		// unary subtract function, negates the input (i.e. multiplies by -1)
+		functions.AddFunction(GetFunction(type));
+		// binary subtract function "a - b", subtracts b from a
+		functions.AddFunction(GetFunction(type, type));
+	}
+	// we can subtract dates from each other
+	functions.AddFunction(GetFunction(LogicalType::DATE, LogicalType::DATE));
+	// we can subtract integers from dates
+	functions.AddFunction(GetFunction(LogicalType::DATE, LogicalType::INTEGER));
+	// we can subtract timestamps from each other
+	functions.AddFunction(GetFunction(LogicalType::TIMESTAMP, LogicalType::TIMESTAMP));
+	// we can subtract intervals from each other
+	functions.AddFunction(GetFunction(LogicalType::INTERVAL, LogicalType::INTERVAL));
+	// we can subtract intervals from dates/times/timestamps, but not the other way around
+	functions.AddFunction(GetFunction(LogicalType::DATE, LogicalType::INTERVAL));
+	functions.AddFunction(GetFunction(LogicalType::TIME, LogicalType::INTERVAL));
+	functions.AddFunction(GetFunction(LogicalType::TIMESTAMP, LogicalType::INTERVAL));
+	// we can negate intervals
+	functions.AddFunction(GetFunction(LogicalType::INTERVAL));
+	set.AddFunction(functions);
+
+	functions.name = "subtract";
+	set.AddFunction(functions);
+}
+
+//===--------------------------------------------------------------------===//
+// * [multiply]
+//===--------------------------------------------------------------------===//
+struct MultiplyPropagateStatistics {
+	template <class T, class OP>
+	static bool Operation(LogicalType type, NumericStatistics &lstats, NumericStatistics &rstats, Value &new_min,
+	                      Value &new_max) {
+		// statistics propagation on the multiplication is slightly less straightforward because of negative numbers
+		// the new min/max depend on the signs of the input types
+		// if both are positive the result is [lmin * rmin][lmax * rmax]
+		// if lmin/lmax are negative the result is [lmin * rmax][lmax * rmin]
+		// etc
+		// rather than doing all this switcheroo we just multiply all combinations of lmin/lmax with rmin/rmax
+		// and check what the minimum/maximum value is
+		T lvals[] {lstats.min.GetValueUnsafe<T>(), lstats.max.GetValueUnsafe<T>()};
+		T rvals[] {rstats.min.GetValueUnsafe<T>(), rstats.max.GetValueUnsafe<T>()};
+		T min = NumericLimits<T>::Maximum();
+		T max = NumericLimits<T>::Minimum();
+		// multiplications
+		for (idx_t l = 0; l < 2; l++) {
+			for (idx_t r = 0; r < 2; r++) {
+				T result;
+				if (!OP::Operation(lvals[l], rvals[r], result)) {
+					// potential overflow
+					return true;
+				}
+				if (result < min) {
+					min = result;
+				}
+				if (result > max) {
+					max = result;
+				}
+			}
+		}
+		new_min = Value::Numeric(type, min);
+		new_max = Value::Numeric(type, max);
+		return false;
+	}
+};
+
+unique_ptr<FunctionData> BindDecimalMultiply(ClientContext &context, ScalarFunction &bound_function,
+                                             vector<unique_ptr<Expression>> &arguments) {
+	uint8_t result_width = 0, result_scale = 0;
+	uint8_t max_width = 0;
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		if (arguments[i]->return_type.id() == LogicalTypeId::UNKNOWN) {
+			continue;
+		}
+		uint8_t width, scale;
+		auto can_convert = arguments[i]->return_type.GetDecimalProperties(width, scale);
+		if (!can_convert) {
+			throw InternalException("Could not convert type %s to a decimal?", arguments[i]->return_type.ToString());
+		}
+		if (width > max_width) {
+			max_width = width;
+		}
+		result_width += width;
+		result_scale += scale;
+	}
+	D_ASSERT(max_width > 0);
+	if (result_scale > Decimal::MAX_WIDTH_DECIMAL) {
+		throw OutOfRangeException(
+		    "Needed scale %d to accurately represent the multiplication result, but this is out of range of the "
+		    "DECIMAL type. Max scale is %d; could not perform an accurate multiplication. Either add a cast to DOUBLE, "
+		    "or add an explicit cast to a decimal with a lower scale.",
+		    result_scale, Decimal::MAX_WIDTH_DECIMAL);
+	}
+	bool check_overflow = false;
+	if (result_width > Decimal::MAX_WIDTH_INT64 && max_width <= Decimal::MAX_WIDTH_INT64 &&
+	    result_scale < Decimal::MAX_WIDTH_INT64) {
+		check_overflow = true;
+		result_width = Decimal::MAX_WIDTH_INT64;
+	}
+	if (result_width > Decimal::MAX_WIDTH_DECIMAL) {
+		check_overflow = true;
+		result_width = Decimal::MAX_WIDTH_DECIMAL;
+	}
+	LogicalType result_type = LogicalType::DECIMAL(result_width, result_scale);
+	// since our scale is the summation of our input scales, we do not need to cast to the result scale
+	// however, we might need to cast to the correct internal type
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		auto &argument_type = arguments[i]->return_type;
+		if (argument_type.InternalType() == result_type.InternalType()) {
+			bound_function.arguments[i] = argument_type;
+		} else {
+			uint8_t width, scale;
+			if (!argument_type.GetDecimalProperties(width, scale)) {
+				scale = 0;
+			}
+
+			bound_function.arguments[i] = LogicalType::DECIMAL(result_width, scale);
+		}
+	}
+	result_type.Verify();
+	bound_function.return_type = result_type;
+	// now select the physical function to execute
+	if (check_overflow) {
+		bound_function.function = GetScalarBinaryFunction<DecimalMultiplyOverflowCheck>(result_type.InternalType());
+	} else {
+		bound_function.function = GetScalarBinaryFunction<MultiplyOperator>(result_type.InternalType());
+	}
+	if (result_type.InternalType() != PhysicalType::INT128) {
+		bound_function.statistics =
+		    PropagateNumericStats<TryDecimalMultiply, MultiplyPropagateStatistics, MultiplyOperator>;
+	}
+	return nullptr;
+}
+
+void MultiplyFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("*");
+	for (auto &type : LogicalType::Numeric()) {
+		if (type.id() == LogicalTypeId::DECIMAL) {
+			functions.AddFunction(ScalarFunction({type, type}, type, nullptr, true, false, BindDecimalMultiply));
+		} else if (TypeIsIntegral(type.InternalType()) && type.id() != LogicalTypeId::HUGEINT) {
+			functions.AddFunction(ScalarFunction(
+			    {type, type}, type, GetScalarIntegerFunction<MultiplyOperatorOverflowCheck>(type.InternalType()), true,
+			    false, nullptr, nullptr,
+			    PropagateNumericStats<TryMultiplyOperator, MultiplyPropagateStatistics, MultiplyOperator>));
+		} else {
+			functions.AddFunction(ScalarFunction({type, type}, type,
+			                                     GetScalarBinaryFunction<MultiplyOperator>(type.InternalType()), true));
+		}
+	}
+	functions.AddFunction(
+	    ScalarFunction({LogicalType::INTERVAL, LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                   ScalarFunction::BinaryFunction<interval_t, int64_t, interval_t, MultiplyOperator>, true));
+	functions.AddFunction(
+	    ScalarFunction({LogicalType::BIGINT, LogicalType::INTERVAL}, LogicalType::INTERVAL,
+	                   ScalarFunction::BinaryFunction<int64_t, interval_t, interval_t, MultiplyOperator>, true));
+	set.AddFunction(functions);
+
+	functions.name = "multiply";
+	set.AddFunction(functions);
+}
+
+//===--------------------------------------------------------------------===//
+// / [divide]
+//===--------------------------------------------------------------------===//
+template <>
+float DivideOperator::Operation(float left, float right) {
+	auto result = left / right;
+	if (!Value::FloatIsFinite(result)) {
+		throw OutOfRangeException("Overflow in division of float!");
+	}
+	return result;
+}
+
+template <>
+double DivideOperator::Operation(double left, double right) {
+	auto result = left / right;
+	if (!Value::DoubleIsFinite(result)) {
+		throw OutOfRangeException("Overflow in division of double!");
+	}
+	return result;
+}
+
+template <>
+hugeint_t DivideOperator::Operation(hugeint_t left, hugeint_t right) {
+	if (right.lower == 0 && right.upper == 0) {
+		throw InternalException("Hugeint division by zero!");
+	}
+	return left / right;
+}
+
+template <>
+interval_t DivideOperator::Operation(interval_t left, int64_t right) {
+	left.days /= right;
+	left.months /= right;
+	left.micros /= right;
+	return left;
+}
+
+struct BinaryZeroIsNullWrapper {
+	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
+	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
+		if (right == 0) {
+			mask.SetInvalid(idx);
+			return left;
+		} else {
+			return OP::template Operation<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(left, right);
+		}
+	}
+
+	static bool AddsNulls() {
+		return true;
+	}
+};
+
+struct BinaryZeroIsNullHugeintWrapper {
+	template <class FUNC, class OP, class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE>
+	static inline RESULT_TYPE Operation(FUNC fun, LEFT_TYPE left, RIGHT_TYPE right, ValidityMask &mask, idx_t idx) {
+		if (right.upper == 0 && right.lower == 0) {
+			mask.SetInvalid(idx);
+			return left;
+		} else {
+			return OP::template Operation<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(left, right);
+		}
+	}
+
+	static bool AddsNulls() {
+		return true;
+	}
+};
+
+template <class TA, class TB, class TC, class OP, class ZWRAPPER = BinaryZeroIsNullWrapper>
+static void BinaryScalarFunctionIgnoreZero(DataChunk &input, ExpressionState &state, Vector &result) {
+	BinaryExecutor::Execute<TA, TB, TC, OP, ZWRAPPER>(input.data[0], input.data[1], result, input.size());
+}
+
+template <class OP>
+static scalar_function_t GetBinaryFunctionIgnoreZero(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		return BinaryScalarFunctionIgnoreZero<int8_t, int8_t, int8_t, OP>;
+	case LogicalTypeId::SMALLINT:
+		return BinaryScalarFunctionIgnoreZero<int16_t, int16_t, int16_t, OP>;
+	case LogicalTypeId::INTEGER:
+		return BinaryScalarFunctionIgnoreZero<int32_t, int32_t, int32_t, OP>;
+	case LogicalTypeId::BIGINT:
+		return BinaryScalarFunctionIgnoreZero<int64_t, int64_t, int64_t, OP>;
+	case LogicalTypeId::UTINYINT:
+		return BinaryScalarFunctionIgnoreZero<uint8_t, uint8_t, uint8_t, OP>;
+	case LogicalTypeId::USMALLINT:
+		return BinaryScalarFunctionIgnoreZero<uint16_t, uint16_t, uint16_t, OP>;
+	case LogicalTypeId::UINTEGER:
+		return BinaryScalarFunctionIgnoreZero<uint32_t, uint32_t, uint32_t, OP>;
+	case LogicalTypeId::UBIGINT:
+		return BinaryScalarFunctionIgnoreZero<uint64_t, uint64_t, uint64_t, OP>;
+	case LogicalTypeId::HUGEINT:
+		return BinaryScalarFunctionIgnoreZero<hugeint_t, hugeint_t, hugeint_t, OP, BinaryZeroIsNullHugeintWrapper>;
+	case LogicalTypeId::FLOAT:
+		return BinaryScalarFunctionIgnoreZero<float, float, float, OP>;
+	case LogicalTypeId::DOUBLE:
+		return BinaryScalarFunctionIgnoreZero<double, double, double, OP>;
+	default:
+		throw NotImplementedException("Unimplemented type for GetScalarUnaryFunction");
+	}
+}
+
+void DivideFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("/");
+	for (auto &type : LogicalType::Numeric()) {
+		if (type.id() == LogicalTypeId::DECIMAL) {
+			continue;
+		} else {
+			functions.AddFunction(
+			    ScalarFunction({type, type}, type, GetBinaryFunctionIgnoreZero<DivideOperator>(type)));
+		}
+	}
+	functions.AddFunction(
+	    ScalarFunction({LogicalType::INTERVAL, LogicalType::BIGINT}, LogicalType::INTERVAL,
+	                   BinaryScalarFunctionIgnoreZero<interval_t, int64_t, interval_t, DivideOperator>));
+
+	set.AddFunction(functions);
+
+	functions.name = "divide";
+	set.AddFunction(functions);
+}
+
+//===--------------------------------------------------------------------===//
+// % [modulo]
+//===--------------------------------------------------------------------===//
+template <>
+float ModuloOperator::Operation(float left, float right) {
+	D_ASSERT(right != 0);
+	auto result = std::fmod(left, right);
+	if (!Value::FloatIsFinite(result)) {
+		throw OutOfRangeException("Overflow in modulo of float!");
+	}
+	return result;
+}
+
+template <>
+double ModuloOperator::Operation(double left, double right) {
+	D_ASSERT(right != 0);
+	auto result = std::fmod(left, right);
+	if (!Value::DoubleIsFinite(result)) {
+		throw OutOfRangeException("Overflow in modulo of double!");
+	}
+	return result;
+}
+
+template <>
+hugeint_t ModuloOperator::Operation(hugeint_t left, hugeint_t right) {
+	if (right.lower == 0 && right.upper == 0) {
+		throw InternalException("Hugeint division by zero!");
+	}
+	return left % right;
+}
+
+void ModFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("%");
+	for (auto &type : LogicalType::Numeric()) {
+		if (type.id() == LogicalTypeId::DECIMAL) {
+			continue;
+		} else {
+			functions.AddFunction(
+			    ScalarFunction({type, type}, type, GetBinaryFunctionIgnoreZero<ModuloOperator>(type)));
+		}
+	}
+	set.AddFunction(functions);
+	functions.name = "mod";
+	set.AddFunction(functions);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+template <class OP>
+static scalar_function_t GetScalarIntegerUnaryFunction(const LogicalType &type) {
+	scalar_function_t function;
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		function = &ScalarFunction::UnaryFunction<int8_t, int8_t, OP>;
+		break;
+	case LogicalTypeId::SMALLINT:
+		function = &ScalarFunction::UnaryFunction<int16_t, int16_t, OP>;
+		break;
+	case LogicalTypeId::INTEGER:
+		function = &ScalarFunction::UnaryFunction<int32_t, int32_t, OP>;
+		break;
+	case LogicalTypeId::BIGINT:
+		function = &ScalarFunction::UnaryFunction<int64_t, int64_t, OP>;
+		break;
+	case LogicalTypeId::UTINYINT:
+		function = &ScalarFunction::UnaryFunction<uint8_t, uint8_t, OP>;
+		break;
+	case LogicalTypeId::USMALLINT:
+		function = &ScalarFunction::UnaryFunction<uint16_t, uint16_t, OP>;
+		break;
+	case LogicalTypeId::UINTEGER:
+		function = &ScalarFunction::UnaryFunction<uint32_t, uint32_t, OP>;
+		break;
+	case LogicalTypeId::UBIGINT:
+		function = &ScalarFunction::UnaryFunction<uint64_t, uint64_t, OP>;
+		break;
+	case LogicalTypeId::HUGEINT:
+		function = &ScalarFunction::UnaryFunction<hugeint_t, hugeint_t, OP>;
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for GetScalarIntegerUnaryFunction");
+	}
+	return function;
+}
+
+template <class OP>
+static scalar_function_t GetScalarIntegerBinaryFunction(const LogicalType &type) {
+	scalar_function_t function;
+	switch (type.id()) {
+	case LogicalTypeId::TINYINT:
+		function = &ScalarFunction::BinaryFunction<int8_t, int8_t, int8_t, OP>;
+		break;
+	case LogicalTypeId::SMALLINT:
+		function = &ScalarFunction::BinaryFunction<int16_t, int16_t, int16_t, OP>;
+		break;
+	case LogicalTypeId::INTEGER:
+		function = &ScalarFunction::BinaryFunction<int32_t, int32_t, int32_t, OP>;
+		break;
+	case LogicalTypeId::BIGINT:
+		function = &ScalarFunction::BinaryFunction<int64_t, int64_t, int64_t, OP>;
+		break;
+	case LogicalTypeId::UTINYINT:
+		function = &ScalarFunction::BinaryFunction<uint8_t, uint8_t, uint8_t, OP>;
+		break;
+	case LogicalTypeId::USMALLINT:
+		function = &ScalarFunction::BinaryFunction<uint16_t, uint16_t, uint16_t, OP>;
+		break;
+	case LogicalTypeId::UINTEGER:
+		function = &ScalarFunction::BinaryFunction<uint32_t, uint32_t, uint32_t, OP>;
+		break;
+	case LogicalTypeId::UBIGINT:
+		function = &ScalarFunction::BinaryFunction<uint64_t, uint64_t, uint64_t, OP>;
+		break;
+	case LogicalTypeId::HUGEINT:
+		function = &ScalarFunction::BinaryFunction<hugeint_t, hugeint_t, hugeint_t, OP>;
+		break;
+	default:
+		throw NotImplementedException("Unimplemented type for GetScalarIntegerBinaryFunction");
+	}
+	return function;
+}
+
+//===--------------------------------------------------------------------===//
+// & [bitwise_and]
+//===--------------------------------------------------------------------===//
+struct BitwiseANDOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA left, TB right) {
+		return left & right;
+	}
+};
+
+void BitwiseAndFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("&");
+	for (auto &type : LogicalType::Integral()) {
+		functions.AddFunction(
+		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseANDOperator>(type)));
+	}
+	set.AddFunction(functions);
+}
+
+//===--------------------------------------------------------------------===//
+// | [bitwise_or]
+//===--------------------------------------------------------------------===//
+struct BitwiseOROperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA left, TB right) {
+		return left | right;
+	}
+};
+
+void BitwiseOrFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("|");
+	for (auto &type : LogicalType::Integral()) {
+		functions.AddFunction(
+		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseOROperator>(type)));
+	}
+	set.AddFunction(functions);
+}
+
+//===--------------------------------------------------------------------===//
+// # [bitwise_xor]
+//===--------------------------------------------------------------------===//
+struct BitwiseXOROperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA left, TB right) {
+		return left ^ right;
+	}
+};
+
+void BitwiseXorFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("xor");
+	for (auto &type : LogicalType::Integral()) {
+		functions.AddFunction(
+		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseXOROperator>(type)));
+	}
+	set.AddFunction(functions);
+}
+
+//===--------------------------------------------------------------------===//
+// << [bitwise_left_shift]
+//===--------------------------------------------------------------------===//
+
+struct BitwiseShiftLeftOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA input, TB shift) {
+		TA max_shift = TA(sizeof(TA) * 8);
+		if (input < 0) {
+			throw OutOfRangeException("Cannot left-shift negative number %s", NumericHelper::ToString(input));
+		}
+		if (shift < 0) {
+			throw OutOfRangeException("Cannot left-shift by negative number %s", NumericHelper::ToString(shift));
+		}
+		if (shift >= max_shift) {
+			if (input == 0) {
+				return 0;
+			}
+			throw OutOfRangeException("Left-shift value %s is out of range", NumericHelper::ToString(shift));
+		}
+		if (shift == 0) {
+			return input;
+		}
+		TA max_value = (TA(1) << (max_shift - shift - 1));
+		if (input >= max_value) {
+			throw OutOfRangeException("Overflow in left shift (%s << %s)", NumericHelper::ToString(input),
+			                          NumericHelper::ToString(shift));
+		}
+		return input << shift;
+	}
+};
+
+void LeftShiftFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("<<");
+	for (auto &type : LogicalType::Integral()) {
+		functions.AddFunction(
+		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseShiftLeftOperator>(type)));
+	}
+	set.AddFunction(functions);
+}
+
+//===--------------------------------------------------------------------===//
+// >> [bitwise_right_shift]
+//===--------------------------------------------------------------------===//
+template <class T>
+bool RightShiftInRange(T shift) {
+	return shift >= 0 && shift < T(sizeof(T) * 8);
+}
+
+struct BitwiseShiftRightOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA input, TB shift) {
+		return RightShiftInRange(shift) ? input >> shift : 0;
+	}
+};
+
+void RightShiftFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions(">>");
+	for (auto &type : LogicalType::Integral()) {
+		functions.AddFunction(
+		    ScalarFunction({type, type}, type, GetScalarIntegerBinaryFunction<BitwiseShiftRightOperator>(type)));
+	}
+	set.AddFunction(functions);
+}
+
+//===--------------------------------------------------------------------===//
+// ~ [bitwise_not]
+//===--------------------------------------------------------------------===//
+struct BitwiseNotOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return ~input;
+	}
+};
+
+void BitwiseNotFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet functions("~");
+	for (auto &type : LogicalType::Integral()) {
+		functions.AddFunction(ScalarFunction({type}, type, GetScalarIntegerUnaryFunction<BitwiseNotOperator>(type)));
+	}
+	set.AddFunction(functions);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <limits>
+#include <algorithm>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// * [multiply]
+//===--------------------------------------------------------------------===//
+template <>
+float MultiplyOperator::Operation(float left, float right) {
+	auto result = left * right;
+	if (!Value::FloatIsFinite(result)) {
+		throw OutOfRangeException("Overflow in multiplication of float!");
+	}
+	return result;
+}
+
+template <>
+double MultiplyOperator::Operation(double left, double right) {
+	auto result = left * right;
+	if (!Value::DoubleIsFinite(result)) {
+		throw OutOfRangeException("Overflow in multiplication of double!");
+	}
+	return result;
+}
+
+template <>
+interval_t MultiplyOperator::Operation(interval_t left, int64_t right) {
+	left.months = MultiplyOperatorOverflowCheck::Operation<int32_t, int32_t, int32_t>(left.months, right);
+	left.days = MultiplyOperatorOverflowCheck::Operation<int32_t, int32_t, int32_t>(left.days, right);
+	left.micros = MultiplyOperatorOverflowCheck::Operation<int64_t, int64_t, int64_t>(left.micros, right);
+	return left;
+}
+
+template <>
+interval_t MultiplyOperator::Operation(int64_t left, interval_t right) {
+	return MultiplyOperator::Operation<interval_t, int64_t, interval_t>(right, left);
+}
+
+//===--------------------------------------------------------------------===//
+// * [multiply] with overflow check
+//===--------------------------------------------------------------------===//
+struct OverflowCheckedMultiply {
+	template <class SRCTYPE, class UTYPE>
+	static inline bool Operation(SRCTYPE left, SRCTYPE right, SRCTYPE &result) {
+		UTYPE uresult = MultiplyOperator::Operation<UTYPE, UTYPE, UTYPE>(UTYPE(left), UTYPE(right));
+		if (uresult < NumericLimits<SRCTYPE>::Minimum() || uresult > NumericLimits<SRCTYPE>::Maximum()) {
+			return false;
+		}
+		result = SRCTYPE(uresult);
+		return true;
+	}
+};
+
+template <>
+bool TryMultiplyOperator::Operation(uint8_t left, uint8_t right, uint8_t &result) {
+	return OverflowCheckedMultiply::Operation<uint8_t, uint16_t>(left, right, result);
+}
+template <>
+bool TryMultiplyOperator::Operation(uint16_t left, uint16_t right, uint16_t &result) {
+	return OverflowCheckedMultiply::Operation<uint16_t, uint32_t>(left, right, result);
+}
+template <>
+bool TryMultiplyOperator::Operation(uint32_t left, uint32_t right, uint32_t &result) {
+	return OverflowCheckedMultiply::Operation<uint32_t, uint64_t>(left, right, result);
+}
+template <>
+bool TryMultiplyOperator::Operation(uint64_t left, uint64_t right, uint64_t &result) {
+	if (left > right) {
+		std::swap(left, right);
+	}
+	if (left > NumericLimits<uint32_t>::Maximum()) {
+		return false;
+	}
+	uint32_t c = right >> 32;
+	uint32_t d = NumericLimits<uint32_t>::Maximum() & right;
+	uint64_t r = left * c;
+	uint64_t s = left * d;
+	if (r > NumericLimits<uint32_t>::Maximum()) {
+		return false;
+	}
+	r <<= 32;
+	if (NumericLimits<uint64_t>::Maximum() - s < r) {
+		return false;
+	}
+	return OverflowCheckedMultiply::Operation<uint64_t, uint64_t>(left, right, result);
+}
+
+template <>
+bool TryMultiplyOperator::Operation(int8_t left, int8_t right, int8_t &result) {
+	return OverflowCheckedMultiply::Operation<int8_t, int16_t>(left, right, result);
+}
+
+template <>
+bool TryMultiplyOperator::Operation(int16_t left, int16_t right, int16_t &result) {
+	return OverflowCheckedMultiply::Operation<int16_t, int32_t>(left, right, result);
+}
+
+template <>
+bool TryMultiplyOperator::Operation(int32_t left, int32_t right, int32_t &result) {
+	return OverflowCheckedMultiply::Operation<int32_t, int64_t>(left, right, result);
+}
+
+template <>
+bool TryMultiplyOperator::Operation(int64_t left, int64_t right, int64_t &result) {
+#if (__GNUC__ >= 5) || defined(__clang__)
+	if (__builtin_mul_overflow(left, right, &result)) {
+		return false;
+	}
+#else
+	if (left == std::numeric_limits<int64_t>::min()) {
+		if (right == 0) {
+			result = 0;
+			return true;
+		}
+		if (right == 1) {
+			result = left;
+			return true;
+		}
+		return false;
+	}
+	if (right == std::numeric_limits<int64_t>::min()) {
+		if (left == 0) {
+			result = 0;
+			return true;
+		}
+		if (left == 1) {
+			result = right;
+			return true;
+		}
+		return false;
+	}
+	uint64_t left_non_negative = uint64_t(std::abs(left));
+	uint64_t right_non_negative = uint64_t(std::abs(right));
+	// split values into 2 32-bit parts
+	uint64_t left_high_bits = left_non_negative >> 32;
+	uint64_t left_low_bits = left_non_negative & 0xffffffff;
+	uint64_t right_high_bits = right_non_negative >> 32;
+	uint64_t right_low_bits = right_non_negative & 0xffffffff;
+
+	// check the high bits of both
+	// the high bits define the overflow
+	if (left_high_bits == 0) {
+		if (right_high_bits != 0) {
+			// only the right has high bits set
+			// multiply the high bits of right with the low bits of left
+			// multiply the low bits, and carry any overflow to the high bits
+			// then check for any overflow
+			auto low_low = left_low_bits * right_low_bits;
+			auto low_high = left_low_bits * right_high_bits;
+			auto high_bits = low_high + (low_low >> 32);
+			if (high_bits & 0xffffff80000000) {
+				// there is! abort
+				return false;
+			}
+		}
+	} else if (right_high_bits == 0) {
+		// only the left has high bits set
+		// multiply the high bits of left with the low bits of right
+		// multiply the low bits, and carry any overflow to the high bits
+		// then check for any overflow
+		auto low_low = left_low_bits * right_low_bits;
+		auto high_low = left_high_bits * right_low_bits;
+		auto high_bits = high_low + (low_low >> 32);
+		if (high_bits & 0xffffff80000000) {
+			// there is! abort
+			return false;
+		}
+	} else {
+		// both left and right have high bits set: guaranteed overflow
+		// abort!
+		return false;
+	}
+	// now we know that there is no overflow, we can just perform the multiplication
+	result = left * right;
+#endif
+	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// multiply  decimal with overflow check
+//===--------------------------------------------------------------------===//
+template <class T, T min, T max>
+bool TryDecimalMultiplyTemplated(T left, T right, T &result) {
+	if (!TryMultiplyOperator::Operation(left, right, result) || result < min || result > max) {
+		return false;
+	}
+	return true;
+}
+
+template <>
+bool TryDecimalMultiply::Operation(int16_t left, int16_t right, int16_t &result) {
+	return TryDecimalMultiplyTemplated<int16_t, -9999, 9999>(left, right, result);
+}
+
+template <>
+bool TryDecimalMultiply::Operation(int32_t left, int32_t right, int32_t &result) {
+	return TryDecimalMultiplyTemplated<int32_t, -999999999, 999999999>(left, right, result);
+}
+
+template <>
+bool TryDecimalMultiply::Operation(int64_t left, int64_t right, int64_t &result) {
+	return TryDecimalMultiplyTemplated<int64_t, -999999999999999999, 999999999999999999>(left, right, result);
+}
+
+template <>
+bool TryDecimalMultiply::Operation(hugeint_t left, hugeint_t right, hugeint_t &result) {
+	result = left * right;
+	if (result <= -Hugeint::POWERS_OF_TEN[38] || result >= Hugeint::POWERS_OF_TEN[38]) {
+		return false;
+	}
+	return true;
+}
+
+template <>
+hugeint_t DecimalMultiplyOverflowCheck::Operation(hugeint_t left, hugeint_t right) {
+	hugeint_t result;
+	if (!TryDecimalMultiply::Operation(left, right, result)) {
+		throw OutOfRangeException("Overflow in multiplication of DECIMAL(38) (%s * %s). You might want to add an "
+		                          "explicit cast to a decimal with a smaller scale.",
+		                          left.ToString(), right.ToString());
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <limits>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// - [subtract]
+//===--------------------------------------------------------------------===//
+template <>
+float SubtractOperator::Operation(float left, float right) {
+	auto result = left - right;
+	if (!Value::FloatIsFinite(result)) {
+		throw OutOfRangeException("Overflow in subtraction of float!");
+	}
+	return result;
+}
+
+template <>
+double SubtractOperator::Operation(double left, double right) {
+	auto result = left - right;
+	if (!Value::DoubleIsFinite(result)) {
+		throw OutOfRangeException("Overflow in subtraction of double!");
+	}
+	return result;
+}
+
+template <>
+int64_t SubtractOperator::Operation(date_t left, date_t right) {
+	return int64_t(left.days) - int64_t(right.days);
+}
+
+template <>
+date_t SubtractOperator::Operation(date_t left, int32_t right) {
+	if (!Date::IsFinite(left)) {
+		return left;
+	}
+	int32_t days;
+	if (!TrySubtractOperator::Operation(left.days, right, days)) {
+		throw OutOfRangeException("Date out of range");
+	}
+
+	date_t result(days);
+	if (!Date::IsFinite(result)) {
+		throw OutOfRangeException("Date out of range");
+	}
+	return result;
+}
+
+template <>
+interval_t SubtractOperator::Operation(interval_t left, interval_t right) {
+	interval_t result;
+	result.months = left.months - right.months;
+	result.days = left.days - right.days;
+	result.micros = left.micros - right.micros;
+	return result;
+}
+
+template <>
+date_t SubtractOperator::Operation(date_t left, interval_t right) {
+	right.months = -right.months;
+	right.days = -right.days;
+	right.micros = -right.micros;
+	return AddOperator::Operation<date_t, interval_t, date_t>(left, right);
+}
+
+template <>
+timestamp_t SubtractOperator::Operation(timestamp_t left, interval_t right) {
+	right.months = -right.months;
+	right.days = -right.days;
+	right.micros = -right.micros;
+	return AddOperator::Operation<timestamp_t, interval_t, timestamp_t>(left, right);
+}
+
+template <>
+interval_t SubtractOperator::Operation(timestamp_t left, timestamp_t right) {
+	return Interval::GetDifference(left, right);
+}
+
+//===--------------------------------------------------------------------===//
+// - [subtract] with overflow check
+//===--------------------------------------------------------------------===//
+struct OverflowCheckedSubtract {
+	template <class SRCTYPE, class UTYPE>
+	static inline bool Operation(SRCTYPE left, SRCTYPE right, SRCTYPE &result) {
+		UTYPE uresult = SubtractOperator::Operation<UTYPE, UTYPE, UTYPE>(UTYPE(left), UTYPE(right));
+		if (uresult < NumericLimits<SRCTYPE>::Minimum() || uresult > NumericLimits<SRCTYPE>::Maximum()) {
+			return false;
+		}
+		result = SRCTYPE(uresult);
+		return true;
+	}
+};
+
+template <>
+bool TrySubtractOperator::Operation(uint8_t left, uint8_t right, uint8_t &result) {
+	if (right > left) {
+		return false;
+	}
+	return OverflowCheckedSubtract::Operation<uint8_t, uint16_t>(left, right, result);
+}
+
+template <>
+bool TrySubtractOperator::Operation(uint16_t left, uint16_t right, uint16_t &result) {
+	if (right > left) {
+		return false;
+	}
+	return OverflowCheckedSubtract::Operation<uint16_t, uint32_t>(left, right, result);
+}
+
+template <>
+bool TrySubtractOperator::Operation(uint32_t left, uint32_t right, uint32_t &result) {
+	if (right > left) {
+		return false;
+	}
+	return OverflowCheckedSubtract::Operation<uint32_t, uint64_t>(left, right, result);
+}
+
+template <>
+bool TrySubtractOperator::Operation(uint64_t left, uint64_t right, uint64_t &result) {
+	if (right > left) {
+		return false;
+	}
+	return OverflowCheckedSubtract::Operation<uint64_t, uint64_t>(left, right, result);
+}
+
+template <>
+bool TrySubtractOperator::Operation(int8_t left, int8_t right, int8_t &result) {
+	return OverflowCheckedSubtract::Operation<int8_t, int16_t>(left, right, result);
+}
+
+template <>
+bool TrySubtractOperator::Operation(int16_t left, int16_t right, int16_t &result) {
+	return OverflowCheckedSubtract::Operation<int16_t, int32_t>(left, right, result);
+}
+
+template <>
+bool TrySubtractOperator::Operation(int32_t left, int32_t right, int32_t &result) {
+	return OverflowCheckedSubtract::Operation<int32_t, int64_t>(left, right, result);
+}
+
+template <>
+bool TrySubtractOperator::Operation(int64_t left, int64_t right, int64_t &result) {
+#if (__GNUC__ >= 5) || defined(__clang__)
+	if (__builtin_sub_overflow(left, right, &result)) {
+		return false;
+	}
+#else
+	if (right < 0) {
+		if (NumericLimits<int64_t>::Maximum() + right < left) {
+			return false;
+		}
+	} else {
+		if (NumericLimits<int64_t>::Minimum() + right > left) {
+			return false;
+		}
+	}
+	result = left - right;
+#endif
+	return true;
+}
+
+template <>
+bool TrySubtractOperator::Operation(hugeint_t left, hugeint_t right, hugeint_t &result) {
+	result = left;
+	return Hugeint::SubtractInPlace(result, right);
+}
+
+//===--------------------------------------------------------------------===//
+// subtract decimal with overflow check
+//===--------------------------------------------------------------------===//
+template <class T, T min, T max>
+bool TryDecimalSubtractTemplated(T left, T right, T &result) {
+	if (right < 0) {
+		if (max + right < left) {
+			return false;
+		}
+	} else {
+		if (min + right > left) {
+			return false;
+		}
+	}
+	result = left - right;
+	return true;
+}
+
+template <>
+bool TryDecimalSubtract::Operation(int16_t left, int16_t right, int16_t &result) {
+	return TryDecimalSubtractTemplated<int16_t, -9999, 9999>(left, right, result);
+}
+
+template <>
+bool TryDecimalSubtract::Operation(int32_t left, int32_t right, int32_t &result) {
+	return TryDecimalSubtractTemplated<int32_t, -999999999, 999999999>(left, right, result);
+}
+
+template <>
+bool TryDecimalSubtract::Operation(int64_t left, int64_t right, int64_t &result) {
+	return TryDecimalSubtractTemplated<int64_t, -999999999999999999, 999999999999999999>(left, right, result);
+}
+
+template <>
+bool TryDecimalSubtract::Operation(hugeint_t left, hugeint_t right, hugeint_t &result) {
+	result = left - right;
+	if (result <= -Hugeint::POWERS_OF_TEN[38] || result >= Hugeint::POWERS_OF_TEN[38]) {
+		return false;
+	}
+	return true;
+}
+
+template <>
+hugeint_t DecimalSubtractOverflowCheck::Operation(hugeint_t left, hugeint_t right) {
+	hugeint_t result;
+	if (!TryDecimalSubtract::Operation(left, right, result)) {
+		throw OutOfRangeException("Overflow in subtract of DECIMAL(38) (%s - %s);", left.ToString(), right.ToString());
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// subtract time operator
+//===--------------------------------------------------------------------===//
+template <>
+dtime_t SubtractTimeOperator::Operation(dtime_t left, interval_t right) {
+	right.micros = -right.micros;
+	return AddTimeOperator::Operation<dtime_t, interval_t, dtime_t>(left, right);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterOperators() {
+	Register<AddFun>();
+	Register<SubtractFun>();
+	Register<MultiplyFun>();
+	Register<DivideFun>();
+	Register<ModFun>();
+	Register<LeftShiftFun>();
+	Register<RightShiftFun>();
+	Register<BitwiseAndFun>();
+	Register<BitwiseOrFun>();
+	Register<BitwiseXorFun>();
+	Register<BitwiseNotFun>();
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterPragmaFunctions() {
+	Register<PragmaQueries>();
+	Register<PragmaFunctions>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct NextvalBindData : public FunctionData {
+	//! The client context for the function call
+	ClientContext &context;
+	//! The sequence to use for the nextval computation; only if
+	SequenceCatalogEntry *sequence;
+
+	NextvalBindData(ClientContext &context, SequenceCatalogEntry *sequence) : context(context), sequence(sequence) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<NextvalBindData>(context, sequence);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (NextvalBindData &)other_p;
+		return sequence == other.sequence;
+	}
+};
+
+struct CurrentSequenceValueOperator {
+	static int64_t Operation(Transaction &transaction, SequenceCatalogEntry *seq) {
+		lock_guard<mutex> seqlock(seq->lock);
+		int64_t result;
+		if (seq->usage_count == 0u) {
+			throw SequenceException("currval: sequence is not yet defined in this session");
+		}
+		result = seq->last_value;
+		return result;
+	}
+};
+
+struct NextSequenceValueOperator {
+	static int64_t Operation(Transaction &transaction, SequenceCatalogEntry *seq) {
+		lock_guard<mutex> seqlock(seq->lock);
+		int64_t result;
+		result = seq->counter;
+		bool overflow = !TryAddOperator::Operation(seq->counter, seq->increment, seq->counter);
+		if (seq->cycle) {
+			if (overflow) {
+				seq->counter = seq->increment < 0 ? seq->max_value : seq->min_value;
+			} else if (seq->counter < seq->min_value) {
+				seq->counter = seq->max_value;
+			} else if (seq->counter > seq->max_value) {
+				seq->counter = seq->min_value;
+			}
+		} else {
+			if (result < seq->min_value || (overflow && seq->increment < 0)) {
+				throw SequenceException("nextval: reached minimum value of sequence \"%s\" (%lld)", seq->name,
+				                        seq->min_value);
+			}
+			if (result > seq->max_value || overflow) {
+				throw SequenceException("nextval: reached maximum value of sequence \"%s\" (%lld)", seq->name,
+				                        seq->max_value);
+			}
+		}
+		seq->last_value = result;
+		seq->usage_count++;
+		transaction.sequence_usage[seq] = SequenceValue(seq->usage_count, seq->counter);
+		return result;
+	}
+};
+
+struct NextValData {
+	NextValData(NextvalBindData &bind_data_p, Transaction &transaction_p)
+	    : bind_data(bind_data_p), transaction(transaction_p) {
+	}
+
+	NextvalBindData &bind_data;
+	Transaction &transaction;
+};
+
+template <class OP>
+static void NextValFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (NextvalBindData &)*func_expr.bind_info;
+	auto &input = args.data[0];
+
+	auto &transaction = Transaction::GetTransaction(info.context);
+	if (info.sequence) {
+		// sequence to use is hard coded
+		// increment the sequence
+		result.SetVectorType(VectorType::FLAT_VECTOR);
+		auto result_data = FlatVector::GetData<int64_t>(result);
+		for (idx_t i = 0; i < args.size(); i++) {
+			// get the next value from the sequence
+			result_data[i] = OP::Operation(transaction, info.sequence);
+		}
+	} else {
+		NextValData next_val_input(info, transaction);
+		// sequence to use comes from the input
+		UnaryExecutor::Execute<string_t, int64_t>(input, result, args.size(), [&](string_t value) {
+			auto qname = QualifiedName::Parse(value.GetString());
+			// fetch the sequence from the catalog
+			auto sequence = Catalog::GetCatalog(info.context)
+			                    .GetEntry<SequenceCatalogEntry>(info.context, qname.schema, qname.name);
+			// finally get the next value from the sequence
+			return OP::Operation(transaction, sequence);
+		});
+	}
+}
+
+static unique_ptr<FunctionData> NextValBind(ClientContext &context, ScalarFunction &bound_function,
+                                            vector<unique_ptr<Expression>> &arguments) {
+	SequenceCatalogEntry *sequence = nullptr;
+	if (arguments[0]->IsFoldable()) {
+		// parameter to nextval function is a foldable constant
+		// evaluate the constant and perform the catalog lookup already
+		auto seqname = ExpressionExecutor::EvaluateScalar(*arguments[0]);
+		if (!seqname.IsNull()) {
+			D_ASSERT(seqname.type().id() == LogicalTypeId::VARCHAR);
+			auto qname = QualifiedName::Parse(StringValue::Get(seqname));
+			sequence = Catalog::GetCatalog(context).GetEntry<SequenceCatalogEntry>(context, qname.schema, qname.name);
+		}
+	}
+	return make_unique<NextvalBindData>(context, sequence);
+}
+
+static void NextValDependency(BoundFunctionExpression &expr, unordered_set<CatalogEntry *> &dependencies) {
+	auto &info = (NextvalBindData &)*expr.bind_info;
+	if (info.sequence) {
+		dependencies.insert(info.sequence);
+	}
+}
+
+void NextvalFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("nextval", {LogicalType::VARCHAR}, LogicalType::BIGINT,
+	                               NextValFunction<NextSequenceValueOperator>, true, NextValBind, NextValDependency));
+}
+
+void CurrvalFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("currval", {LogicalType::VARCHAR}, LogicalType::BIGINT,
+	                               NextValFunction<CurrentSequenceValueOperator>, true, NextValBind,
+	                               NextValDependency));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterSequenceFunctions() {
+	Register<NextvalFun>();
+	Register<CurrvalFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+struct AsciiOperator {
+	template <class TA, class TR>
+	static inline TR Operation(const TA &input) {
+		auto str = input.GetDataUnsafe();
+		if (Utf8Proc::Analyze(str, input.GetSize()) == UnicodeType::ASCII) {
+			return str[0];
+		}
+		int utf8_bytes = 4;
+		return Utf8Proc::UTF8ToCodepoint(str, utf8_bytes);
+	}
+};
+
+void ASCII::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction ascii("ascii", {LogicalType::VARCHAR}, LogicalType::INTEGER,
+	                     ScalarFunction::UnaryFunction<string_t, int32_t, AsciiOperator>);
+	set.AddFunction(ascii);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <string.h>
+
+namespace duckdb {
+
+uint8_t UpperFun::ascii_to_upper_map[] = {
+    0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,  15,  16,  17,  18,  19,  20,  21,
+    22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,
+    44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,  64,  65,
+    66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,  80,  81,  82,  83,  84,  85,  86,  87,
+    88,  89,  90,  91,  92,  93,  94,  95,  96,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,
+    78,  79,  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,  123, 124, 125, 126, 127, 128, 129, 130, 131,
+    132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153,
+    154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
+    176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197,
+    198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219,
+    220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241,
+    242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254};
+uint8_t LowerFun::ascii_to_lower_map[] = {
+    0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,  15,  16,  17,  18,  19,  20,  21,
+    22,  23,  24,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,
+    44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,  64,  97,
+    98,  99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+    120, 121, 122, 91,  92,  93,  94,  95,  96,  97,  98,  99,  100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
+    110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
+    132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153,
+    154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175,
+    176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197,
+    198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219,
+    220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241,
+    242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254};
+
+template <bool IS_UPPER>
+static string_t ASCIICaseConvert(Vector &result, const char *input_data, idx_t input_length) {
+	idx_t output_length = input_length;
+	auto result_str = StringVector::EmptyString(result, output_length);
+	auto result_data = result_str.GetDataWriteable();
+	for (idx_t i = 0; i < input_length; i++) {
+		result_data[i] = IS_UPPER ? UpperFun::ascii_to_upper_map[uint8_t(input_data[i])]
+		                          : LowerFun::ascii_to_lower_map[uint8_t(input_data[i])];
+	}
+	result_str.Finalize();
+	return result_str;
+}
+
+template <bool IS_UPPER>
+static idx_t GetResultLength(const char *input_data, idx_t input_length) {
+	idx_t output_length = 0;
+	for (idx_t i = 0; i < input_length;) {
+		if (input_data[i] & 0x80) {
+			// unicode
+			int sz = 0;
+			int codepoint = utf8proc_codepoint(input_data + i, sz);
+			int converted_codepoint = IS_UPPER ? utf8proc_toupper(codepoint) : utf8proc_tolower(codepoint);
+			int new_sz = utf8proc_codepoint_length(converted_codepoint);
+			D_ASSERT(new_sz >= 0);
+			output_length += new_sz;
+			i += sz;
+		} else {
+			// ascii
+			output_length++;
+			i++;
+		}
+	}
+	return output_length;
+}
+
+template <bool IS_UPPER>
+static void CaseConvert(const char *input_data, idx_t input_length, char *result_data) {
+	for (idx_t i = 0; i < input_length;) {
+		if (input_data[i] & 0x80) {
+			// non-ascii character
+			int sz = 0, new_sz = 0;
+			int codepoint = utf8proc_codepoint(input_data + i, sz);
+			int converted_codepoint = IS_UPPER ? utf8proc_toupper(codepoint) : utf8proc_tolower(codepoint);
+			auto success = utf8proc_codepoint_to_utf8(converted_codepoint, new_sz, result_data);
+			D_ASSERT(success);
+			(void)success;
+			result_data += new_sz;
+			i += sz;
+		} else {
+			// ascii
+			*result_data = IS_UPPER ? UpperFun::ascii_to_upper_map[uint8_t(input_data[i])]
+			                        : LowerFun::ascii_to_lower_map[uint8_t(input_data[i])];
+			result_data++;
+			i++;
+		}
+	}
+}
+
+idx_t LowerFun::LowerLength(const char *input_data, idx_t input_length) {
+	return GetResultLength<false>(input_data, input_length);
+}
+
+void LowerFun::LowerCase(const char *input_data, idx_t input_length, char *result_data) {
+	CaseConvert<false>(input_data, input_length, result_data);
+}
+
+template <bool IS_UPPER>
+static string_t UnicodeCaseConvert(Vector &result, const char *input_data, idx_t input_length) {
+	// first figure out the output length
+	idx_t output_length = GetResultLength<IS_UPPER>(input_data, input_length);
+	auto result_str = StringVector::EmptyString(result, output_length);
+	auto result_data = result_str.GetDataWriteable();
+
+	CaseConvert<IS_UPPER>(input_data, input_length, result_data);
+	result_str.Finalize();
+	return result_str;
+}
+
+template <bool IS_UPPER>
+struct CaseConvertOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
+		auto input_data = input.GetDataUnsafe();
+		auto input_length = input.GetSize();
+		return UnicodeCaseConvert<IS_UPPER>(result, input_data, input_length);
+	}
+};
+
+template <bool IS_UPPER>
+static void CaseConvertFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnaryExecutor::ExecuteString<string_t, string_t, CaseConvertOperator<IS_UPPER>>(args.data[0], result, args.size());
+}
+
+template <bool IS_UPPER>
+struct CaseConvertOperatorASCII {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
+		auto input_data = input.GetDataUnsafe();
+		auto input_length = input.GetSize();
+		return ASCIICaseConvert<IS_UPPER>(result, input_data, input_length);
+	}
+};
+
+template <bool IS_UPPER>
+static void CaseConvertFunctionASCII(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnaryExecutor::ExecuteString<string_t, string_t, CaseConvertOperatorASCII<IS_UPPER>>(args.data[0], result,
+	                                                                                     args.size());
+}
+
+template <bool IS_UPPER>
+static unique_ptr<BaseStatistics> CaseConvertPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	D_ASSERT(child_stats.size() == 1);
+	// can only propagate stats if the children have stats
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &sstats = (StringStatistics &)*child_stats[0];
+	if (!sstats.has_unicode) {
+		expr.function.function = CaseConvertFunctionASCII<IS_UPPER>;
+	}
+	return nullptr;
+}
+
+ScalarFunction LowerFun::GetFunction() {
+	return ScalarFunction("lower", {LogicalType::VARCHAR}, LogicalType::VARCHAR, CaseConvertFunction<false>, false,
+	                      nullptr, nullptr, CaseConvertPropagateStats<false>);
+}
+
+void LowerFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"lower", "lcase"}, LowerFun::GetFunction());
+}
+
+void UpperFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"upper", "ucase"},
+	                ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, CaseConvertFunction<true>, false,
+	                               false, nullptr, nullptr, CaseConvertPropagateStats<true>));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+struct ChrOperator {
+	template <class TA, class TR>
+	static inline TR Operation(const TA &input) {
+		char c[5] = {'\0', '\0', '\0', '\0', '\0'};
+		int utf8_bytes = 4;
+		if (input < 0 || !Utf8Proc::CodepointToUtf8(input, utf8_bytes, &c[0])) {
+			throw InvalidInputException("Invalid UTF8 Codepoint %d", input);
+		}
+		return string_t(&c[0]);
+	}
+};
+
+void CHR::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction chr("chr", {LogicalType::INTEGER}, LogicalType::VARCHAR,
+	                   ScalarFunction::UnaryFunction<int32_t, string_t, ChrOperator>);
+	set.AddFunction(chr);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+#include <string.h>
+
+namespace duckdb {
+
+static void ConcatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	// iterate over the vectors to count how large the final string will be
+	idx_t constant_lengths = 0;
+	vector<idx_t> result_lengths(args.size(), 0);
+	for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
+		auto &input = args.data[col_idx];
+		D_ASSERT(input.GetType().id() == LogicalTypeId::VARCHAR);
+		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			if (ConstantVector::IsNull(input)) {
+				// constant null, skip
+				continue;
+			}
+			auto input_data = ConstantVector::GetData<string_t>(input);
+			constant_lengths += input_data->GetSize();
+		} else {
+			// non-constant vector: set the result type to a flat vector
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			// now get the lengths of each of the input elements
+			VectorData vdata;
+			input.Orrify(args.size(), vdata);
+
+			auto input_data = (string_t *)vdata.data;
+			// now add the length of each vector to the result length
+			for (idx_t i = 0; i < args.size(); i++) {
+				auto idx = vdata.sel->get_index(i);
+				if (!vdata.validity.RowIsValid(idx)) {
+					continue;
+				}
+				result_lengths[i] += input_data[idx].GetSize();
+			}
+		}
+	}
+
+	// first we allocate the empty strings for each of the values
+	auto result_data = FlatVector::GetData<string_t>(result);
+	for (idx_t i = 0; i < args.size(); i++) {
+		// allocate an empty string of the required size
+		idx_t str_length = constant_lengths + result_lengths[i];
+		result_data[i] = StringVector::EmptyString(result, str_length);
+		// we reuse the result_lengths vector to store the currently appended size
+		result_lengths[i] = 0;
+	}
+
+	// now that the empty space for the strings has been allocated, perform the concatenation
+	for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
+		auto &input = args.data[col_idx];
+
+		// loop over the vector and concat to all results
+		if (input.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			// constant vector
+			if (ConstantVector::IsNull(input)) {
+				// constant null, skip
+				continue;
+			}
+			// append the constant vector to each of the strings
+			auto input_data = ConstantVector::GetData<string_t>(input);
+			auto input_ptr = input_data->GetDataUnsafe();
+			auto input_len = input_data->GetSize();
+			for (idx_t i = 0; i < args.size(); i++) {
+				memcpy(result_data[i].GetDataWriteable() + result_lengths[i], input_ptr, input_len);
+				result_lengths[i] += input_len;
+			}
+		} else {
+			// standard vector
+			VectorData idata;
+			input.Orrify(args.size(), idata);
+
+			auto input_data = (string_t *)idata.data;
+			for (idx_t i = 0; i < args.size(); i++) {
+				auto idx = idata.sel->get_index(i);
+				if (!idata.validity.RowIsValid(idx)) {
+					continue;
+				}
+				auto input_ptr = input_data[idx].GetDataUnsafe();
+				auto input_len = input_data[idx].GetSize();
+				memcpy(result_data[i].GetDataWriteable() + result_lengths[i], input_ptr, input_len);
+				result_lengths[i] += input_len;
+			}
+		}
+	}
+	for (idx_t i = 0; i < args.size(); i++) {
+		result_data[i].Finalize();
+	}
+}
+
+static void ConcatOperator(DataChunk &args, ExpressionState &state, Vector &result) {
+	BinaryExecutor::Execute<string_t, string_t, string_t>(
+	    args.data[0], args.data[1], result, args.size(), [&](string_t a, string_t b) {
+		    auto a_data = a.GetDataUnsafe();
+		    auto b_data = b.GetDataUnsafe();
+		    auto a_length = a.GetSize();
+		    auto b_length = b.GetSize();
+
+		    auto target_length = a_length + b_length;
+		    auto target = StringVector::EmptyString(result, target_length);
+		    auto target_data = target.GetDataWriteable();
+
+		    memcpy(target_data, a_data, a_length);
+		    memcpy(target_data + a_length, b_data, b_length);
+		    target.Finalize();
+		    return target;
+	    });
+}
+
+static void TemplatedConcatWS(DataChunk &args, string_t *sep_data, const SelectionVector &sep_sel,
+                              const SelectionVector &rsel, idx_t count, Vector &result) {
+	vector<idx_t> result_lengths(args.size(), 0);
+	vector<bool> has_results(args.size(), false);
+	auto orrified_data = unique_ptr<VectorData[]>(new VectorData[args.ColumnCount() - 1]);
+	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
+		args.data[col_idx].Orrify(args.size(), orrified_data[col_idx - 1]);
+	}
+
+	// first figure out the lengths
+	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
+		auto &idata = orrified_data[col_idx - 1];
+
+		auto input_data = (string_t *)idata.data;
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = rsel.get_index(i);
+			auto sep_idx = sep_sel.get_index(ridx);
+			auto idx = idata.sel->get_index(ridx);
+			if (!idata.validity.RowIsValid(idx)) {
+				continue;
+			}
+			if (has_results[ridx]) {
+				result_lengths[ridx] += sep_data[sep_idx].GetSize();
+			}
+			result_lengths[ridx] += input_data[idx].GetSize();
+			has_results[ridx] = true;
+		}
+	}
+
+	// first we allocate the empty strings for each of the values
+	auto result_data = FlatVector::GetData<string_t>(result);
+	for (idx_t i = 0; i < count; i++) {
+		auto ridx = rsel.get_index(i);
+		// allocate an empty string of the required size
+		result_data[ridx] = StringVector::EmptyString(result, result_lengths[ridx]);
+		// we reuse the result_lengths vector to store the currently appended size
+		result_lengths[ridx] = 0;
+		has_results[ridx] = false;
+	}
+
+	// now that the empty space for the strings has been allocated, perform the concatenation
+	for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
+		auto &idata = orrified_data[col_idx - 1];
+		auto input_data = (string_t *)idata.data;
+		for (idx_t i = 0; i < count; i++) {
+			auto ridx = rsel.get_index(i);
+			auto sep_idx = sep_sel.get_index(ridx);
+			auto idx = idata.sel->get_index(ridx);
+			if (!idata.validity.RowIsValid(idx)) {
+				continue;
+			}
+			if (has_results[ridx]) {
+				auto sep_size = sep_data[sep_idx].GetSize();
+				auto sep_ptr = sep_data[sep_idx].GetDataUnsafe();
+				memcpy(result_data[ridx].GetDataWriteable() + result_lengths[ridx], sep_ptr, sep_size);
+				result_lengths[ridx] += sep_size;
+			}
+			auto input_ptr = input_data[idx].GetDataUnsafe();
+			auto input_len = input_data[idx].GetSize();
+			memcpy(result_data[ridx].GetDataWriteable() + result_lengths[ridx], input_ptr, input_len);
+			result_lengths[ridx] += input_len;
+			has_results[ridx] = true;
+		}
+	}
+	for (idx_t i = 0; i < count; i++) {
+		auto ridx = rsel.get_index(i);
+		result_data[ridx].Finalize();
+	}
+}
+
+static void ConcatWSFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &separator = args.data[0];
+	VectorData vdata;
+	separator.Orrify(args.size(), vdata);
+
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	for (idx_t col_idx = 0; col_idx < args.ColumnCount(); col_idx++) {
+		if (args.data[col_idx].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			break;
+		}
+	}
+	switch (separator.GetVectorType()) {
+	case VectorType::CONSTANT_VECTOR: {
+		if (ConstantVector::IsNull(separator)) {
+			// constant NULL as separator: return constant NULL vector
+			result.SetVectorType(VectorType::CONSTANT_VECTOR);
+			ConstantVector::SetNull(result, true);
+			return;
+		}
+		// no null values
+		auto sel = FlatVector::IncrementalSelectionVector();
+		TemplatedConcatWS(args, (string_t *)vdata.data, *vdata.sel, *sel, args.size(), result);
+		return;
+	}
+	default: {
+		// default case: loop over nullmask and create a non-null selection vector
+		idx_t not_null_count = 0;
+		SelectionVector not_null_vector(STANDARD_VECTOR_SIZE);
+		auto &result_mask = FlatVector::Validity(result);
+		for (idx_t i = 0; i < args.size(); i++) {
+			if (!vdata.validity.RowIsValid(vdata.sel->get_index(i))) {
+				result_mask.SetInvalid(i);
+			} else {
+				not_null_vector.set_index(not_null_count++, i);
+			}
+		}
+		TemplatedConcatWS(args, (string_t *)vdata.data, *vdata.sel, not_null_vector, not_null_count, result);
+		return;
+	}
+	}
+}
+
+void ConcatFun::RegisterFunction(BuiltinFunctions &set) {
+	// the concat operator and concat function have different behavior regarding NULLs
+	// this is strange but seems consistent with postgresql and mysql
+	// (sqlite does not support the concat function, only the concat operator)
+
+	// the concat operator behaves as one would expect: any NULL value present results in a NULL
+	// i.e. NULL || 'hello' = NULL
+	// the concat function, however, treats NULL values as an empty string
+	// i.e. concat(NULL, 'hello') = 'hello'
+	// concat_ws functions similarly to the concat function, except the result is NULL if the separator is NULL
+	// if the separator is not NULL, however, NULL values are counted as empty string
+	// there is one separate rule: there are no separators added between NULL values
+	// so the NULL value and empty string are different!
+	// e.g.:
+	// concat_ws(',', NULL, NULL) = ""
+	// concat_ws(',', '', '') = ","
+	ScalarFunction concat = ScalarFunction("concat", {LogicalType::VARCHAR}, LogicalType::VARCHAR, ConcatFunction);
+	concat.varargs = LogicalType::VARCHAR;
+	set.AddFunction(concat);
+
+	ScalarFunctionSet concat_op("||");
+	concat_op.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, ConcatOperator));
+	concat_op.AddFunction(ScalarFunction({LogicalType::BLOB, LogicalType::BLOB}, LogicalType::BLOB, ConcatOperator));
+	concat_op.AddFunction(ListConcatFun::GetFunction());
+	set.AddFunction(concat_op);
+
+	ScalarFunction concat_ws = ScalarFunction("concat_ws", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                          LogicalType::VARCHAR, ConcatWSFunction);
+	concat_ws.varargs = LogicalType::VARCHAR;
+	set.AddFunction(concat_ws);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+template <class UNSIGNED, int NEEDLE_SIZE>
+static idx_t ContainsUnaligned(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
+                               idx_t base_offset) {
+	if (NEEDLE_SIZE > haystack_size) {
+		// needle is bigger than haystack: haystack cannot contain needle
+		return DConstants::INVALID_INDEX;
+	}
+	// contains for a small unaligned needle (3/5/6/7 bytes)
+	// we perform unsigned integer comparisons to check for equality of the entire needle in a single comparison
+	// this implementation is inspired by the memmem implementation of freebsd
+
+	// first we set up the needle and the first NEEDLE_SIZE characters of the haystack as UNSIGNED integers
+	UNSIGNED needle_entry = 0;
+	UNSIGNED haystack_entry = 0;
+	const UNSIGNED start = (sizeof(UNSIGNED) * 8) - 8;
+	const UNSIGNED shift = (sizeof(UNSIGNED) - NEEDLE_SIZE) * 8;
+	for (int i = 0; i < NEEDLE_SIZE; i++) {
+		needle_entry |= UNSIGNED(needle[i]) << UNSIGNED(start - i * 8);
+		haystack_entry |= UNSIGNED(haystack[i]) << UNSIGNED(start - i * 8);
+	}
+	// now we perform the actual search
+	for (idx_t offset = NEEDLE_SIZE; offset < haystack_size; offset++) {
+		// for this position we first compare the haystack with the needle
+		if (haystack_entry == needle_entry) {
+			return base_offset + offset - NEEDLE_SIZE;
+		}
+		// now we adjust the haystack entry by
+		// (1) removing the left-most character (shift by 8)
+		// (2) adding the next character (bitwise or, with potential shift)
+		// this shift is only necessary if the needle size is not aligned with the unsigned integer size
+		// (e.g. needle size 3, unsigned integer size 4, we need to shift by 1)
+		haystack_entry = (haystack_entry << 8) | ((UNSIGNED(haystack[offset])) << shift);
+	}
+	if (haystack_entry == needle_entry) {
+		return base_offset + haystack_size - NEEDLE_SIZE;
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+template <class UNSIGNED>
+static idx_t ContainsAligned(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
+                             idx_t base_offset) {
+	if (sizeof(UNSIGNED) > haystack_size) {
+		// needle is bigger than haystack: haystack cannot contain needle
+		return DConstants::INVALID_INDEX;
+	}
+	// contains for a small needle aligned with unsigned integer (2/4/8)
+	// similar to ContainsUnaligned, but simpler because we only need to do a reinterpret cast
+	auto needle_entry = Load<UNSIGNED>(needle);
+	for (idx_t offset = 0; offset <= haystack_size - sizeof(UNSIGNED); offset++) {
+		// for this position we first compare the haystack with the needle
+		auto haystack_entry = Load<UNSIGNED>(haystack + offset);
+		if (needle_entry == haystack_entry) {
+			return base_offset + offset;
+		}
+	}
+	return DConstants::INVALID_INDEX;
+}
+
+idx_t ContainsGeneric(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
+                      idx_t needle_size, idx_t base_offset) {
+	if (needle_size > haystack_size) {
+		// needle is bigger than haystack: haystack cannot contain needle
+		return DConstants::INVALID_INDEX;
+	}
+	// this implementation is inspired by Raphael Javaux's faststrstr (https://github.com/RaphaelJ/fast_strstr)
+	// generic contains; note that we can't use strstr because we don't have null-terminated strings anymore
+	// we keep track of a shifting window sum of all characters with window size equal to needle_size
+	// this shifting sum is used to avoid calling into memcmp;
+	// we only need to call into memcmp when the window sum is equal to the needle sum
+	// when that happens, the characters are potentially the same and we call into memcmp to check if they are
+	uint32_t sums_diff = 0;
+	for (idx_t i = 0; i < needle_size; i++) {
+		sums_diff += haystack[i];
+		sums_diff -= needle[i];
+	}
+	idx_t offset = 0;
+	while (true) {
+		if (sums_diff == 0 && haystack[offset] == needle[0]) {
+			if (memcmp(haystack + offset, needle, needle_size) == 0) {
+				return base_offset + offset;
+			}
+		}
+		if (offset >= haystack_size - needle_size) {
+			return DConstants::INVALID_INDEX;
+		}
+		sums_diff -= haystack[offset];
+		sums_diff += haystack[offset + needle_size];
+		offset++;
+	}
+}
+
+idx_t ContainsFun::Find(const unsigned char *haystack, idx_t haystack_size, const unsigned char *needle,
+                        idx_t needle_size) {
+	D_ASSERT(needle_size > 0);
+	// start off by performing a memchr to find the first character of the
+	auto location = memchr(haystack, needle[0], haystack_size);
+	if (location == nullptr) {
+		return DConstants::INVALID_INDEX;
+	}
+	idx_t base_offset = (const unsigned char *)location - haystack;
+	haystack_size -= base_offset;
+	haystack = (const unsigned char *)location;
+	// switch algorithm depending on needle size
+	switch (needle_size) {
+	case 1:
+		return base_offset;
+	case 2:
+		return ContainsAligned<uint16_t>(haystack, haystack_size, needle, base_offset);
+	case 3:
+		return ContainsUnaligned<uint32_t, 3>(haystack, haystack_size, needle, base_offset);
+	case 4:
+		return ContainsAligned<uint32_t>(haystack, haystack_size, needle, base_offset);
+	case 5:
+		return ContainsUnaligned<uint64_t, 5>(haystack, haystack_size, needle, base_offset);
+	case 6:
+		return ContainsUnaligned<uint64_t, 6>(haystack, haystack_size, needle, base_offset);
+	case 7:
+		return ContainsUnaligned<uint64_t, 7>(haystack, haystack_size, needle, base_offset);
+	case 8:
+		return ContainsAligned<uint64_t>(haystack, haystack_size, needle, base_offset);
+	default:
+		return ContainsGeneric(haystack, haystack_size, needle, needle_size, base_offset);
+	}
+}
+
+idx_t ContainsFun::Find(const string_t &haystack_s, const string_t &needle_s) {
+	auto haystack = (const unsigned char *)haystack_s.GetDataUnsafe();
+	auto haystack_size = haystack_s.GetSize();
+	auto needle = (const unsigned char *)needle_s.GetDataUnsafe();
+	auto needle_size = needle_s.GetSize();
+	if (needle_size == 0) {
+		// empty needle: always true
+		return 0;
+	}
+	return ContainsFun::Find(haystack, haystack_size, needle, needle_size);
+}
+
+struct ContainsOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA left, TB right) {
+		return ContainsFun::Find(left, right) != DConstants::INVALID_INDEX;
+	}
+};
+
+ScalarFunction ContainsFun::GetFunction() {
+	return ScalarFunction("contains",                                   // name of the function
+	                      {LogicalType::VARCHAR, LogicalType::VARCHAR}, // argument list
+	                      LogicalType::BOOLEAN,                         // return type
+	                      ScalarFunction::BinaryFunction<string_t, string_t, bool, ContainsOperator>);
+}
+
+void ContainsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(GetFunction());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct InstrOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA haystack, TB needle) {
+		int64_t string_position = 0;
+
+		auto location = ContainsFun::Find(haystack, needle);
+		if (location != DConstants::INVALID_INDEX) {
+			auto len = (utf8proc_ssize_t)location;
+			auto str = reinterpret_cast<const utf8proc_uint8_t *>(haystack.GetDataUnsafe());
+			D_ASSERT(len <= (utf8proc_ssize_t)haystack.GetSize());
+			for (++string_position; len > 0; ++string_position) {
+				utf8proc_int32_t codepoint;
+				auto bytes = utf8proc_iterate(str, len, &codepoint);
+				str += bytes;
+				len -= bytes;
+			}
+		}
+		return string_position;
+	}
+};
+
+struct InstrAsciiOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA haystack, TB needle) {
+		auto location = ContainsFun::Find(haystack, needle);
+		return location == DConstants::INVALID_INDEX ? 0 : location + 1;
+	}
+};
+
+static unique_ptr<BaseStatistics> InStrPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	D_ASSERT(child_stats.size() == 2);
+	// can only propagate stats if the children have stats
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	// for strpos, we only care if the FIRST string has unicode or not
+	auto &sstats = (StringStatistics &)*child_stats[0];
+	if (!sstats.has_unicode) {
+		expr.function.function = ScalarFunction::BinaryFunction<string_t, string_t, int64_t, InstrAsciiOperator>;
+	}
+	return nullptr;
+}
+
+void InstrFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction instr("instr",                                      // name of the function
+	                     {LogicalType::VARCHAR, LogicalType::VARCHAR}, // argument list
+	                     LogicalType::BIGINT,                          // return type
+	                     ScalarFunction::BinaryFunction<string_t, string_t, int64_t, InstrOperator>, false, nullptr,
+	                     nullptr, InStrPropagateStats);
+	set.AddFunction(instr);
+	instr.name = "strpos";
+	set.AddFunction(instr);
+	instr.name = "position";
+	set.AddFunction(instr);
+}
+
+} // namespace duckdb
+
+
+
+
+#include <ctype.h>
+
+namespace duckdb {
+
+static inline map<char, idx_t> GetSet(const string_t &str) {
+	auto map_of_chars = map<char, idx_t> {};
+	idx_t str_len = str.GetSize();
+	auto s = str.GetDataUnsafe();
+
+	for (idx_t pos = 0; pos < str_len; pos++) {
+		map_of_chars.insert(std::make_pair(s[pos], 1));
+	}
+	return map_of_chars;
+}
+
+static double JaccardSimilarity(const string_t &str, const string_t &txt) {
+	if (str.GetSize() < 1 || txt.GetSize() < 1) {
+		throw InvalidInputException("Jaccard Function: An argument too short!");
+	}
+	map<char, idx_t> m_str, m_txt;
+
+	m_str = GetSet(str);
+	m_txt = GetSet(txt);
+
+	if (m_str.size() > m_txt.size()) {
+		m_str.swap(m_txt);
+	}
+
+	for (auto const &achar : m_str) {
+		++m_txt[achar.first];
+	}
+	// m_txt.size is now size of union.
+
+	idx_t size_intersect = 0;
+	for (const auto &apair : m_txt) {
+		if (apair.second > 1) {
+			size_intersect++;
+		}
+	}
+
+	return (double)size_intersect / (double)m_txt.size();
+}
+
+static double JaccardScalarFunction(Vector &result, const string_t str, string_t tgt) {
+	return (double)JaccardSimilarity(str, tgt);
+}
+
+static void JaccardFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &str_vec = args.data[0];
+	auto &tgt_vec = args.data[1];
+
+	BinaryExecutor::Execute<string_t, string_t, double>(
+	    str_vec, tgt_vec, result, args.size(),
+	    [&](string_t str, string_t tgt) { return JaccardScalarFunction(result, str, tgt); });
+}
+
+void JaccardFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet jaccard("jaccard");
+	jaccard.AddFunction(ScalarFunction("jaccard", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::DOUBLE,
+	                                   JaccardFunction)); // Pointer to function implementation
+	set.AddFunction(jaccard);
+}
+
+} // namespace duckdb
+
+
+
+#include <ctype.h>
+#include <algorithm>
+
+namespace duckdb {
+
+static string_t LeftScalarFunction(Vector &result, const string_t str, int64_t pos) {
+	if (pos >= 0) {
+		return SubstringFun::SubstringScalarFunction(result, str, 1, pos);
+	}
+
+	int64_t num_characters = LengthFun::Length<string_t, int64_t>(str);
+	pos = MaxValue<int64_t>(0, num_characters + pos);
+	return SubstringFun::SubstringScalarFunction(result, str, 1, pos);
+}
+
+static void LeftFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &str_vec = args.data[0];
+	auto &pos_vec = args.data[1];
+
+	BinaryExecutor::Execute<string_t, int64_t, string_t>(
+	    str_vec, pos_vec, result, args.size(),
+	    [&](string_t str, int64_t pos) { return LeftScalarFunction(result, str, pos); });
+}
+
+void LeftFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("left", {LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR, LeftFunction));
+}
+
+static string_t RightScalarFunction(Vector &result, const string_t str, int64_t pos) {
+	int64_t num_characters = LengthFun::Length<string_t, int64_t>(str);
+	if (pos >= 0) {
+		int64_t len = MinValue<int64_t>(num_characters, pos);
+		int64_t start = num_characters - len + 1;
+		return SubstringFun::SubstringScalarFunction(result, str, start, len);
+	}
+
+	int64_t len = num_characters - MinValue<int64_t>(num_characters, -pos);
+	int64_t start = num_characters - len + 1;
+	return SubstringFun::SubstringScalarFunction(result, str, start, len);
+}
+
+static void RightFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &str_vec = args.data[0];
+	auto &pos_vec = args.data[1];
+	BinaryExecutor::Execute<string_t, int64_t, string_t>(
+	    str_vec, pos_vec, result, args.size(),
+	    [&](string_t str, int64_t pos) { return RightScalarFunction(result, str, pos); });
+}
+
+void RightFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    ScalarFunction("right", {LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR, RightFunction));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+// length returns the size in characters
+struct StringLengthOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return LengthFun::Length<TA, TR>(input);
+	}
+};
+
+struct ArrayLengthOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return input.length;
+	}
+};
+
+struct ArrayLengthBinaryOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA input, TB dimension) {
+		if (dimension != 1) {
+			throw NotImplementedException("array_length for dimensions other than 1 not implemented");
+		}
+		return input.length;
+	}
+};
+
+// strlen returns the size in bytes
+struct StrLenOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return input.GetSize();
+	}
+};
+
+// bitlen returns the size in bits
+struct BitLenOperator {
+	template <class TA, class TR>
+	static inline TR Operation(TA input) {
+		return 8 * input.GetSize();
+	}
+};
+
+static unique_ptr<BaseStatistics> LengthPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	D_ASSERT(child_stats.size() == 1);
+	// can only propagate stats if the children have stats
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &sstats = (StringStatistics &)*child_stats[0];
+	if (!sstats.has_unicode) {
+		expr.function.function = ScalarFunction::UnaryFunction<string_t, int64_t, StrLenOperator>;
+	}
+	return nullptr;
+}
+
+static unique_ptr<FunctionData> ListLengthBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	bound_function.arguments[0] = arguments[0]->return_type;
+	return nullptr;
+}
+
+void LengthFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction array_length_unary = ScalarFunction(
+	    {LogicalType::LIST(LogicalType::ANY)}, LogicalType::BIGINT,
+	    ScalarFunction::UnaryFunction<list_entry_t, int64_t, ArrayLengthOperator>, false, false, ListLengthBind);
+	ScalarFunctionSet length("length");
+	length.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::BIGINT,
+	                                  ScalarFunction::UnaryFunction<string_t, int64_t, StringLengthOperator>, false,
+	                                  false, nullptr, nullptr, LengthPropagateStats));
+	length.AddFunction(array_length_unary);
+	set.AddFunction(length);
+	length.name = "len";
+	set.AddFunction(length);
+
+	ScalarFunctionSet array_length("array_length");
+	array_length.AddFunction(array_length_unary);
+	array_length.AddFunction(
+	    ScalarFunction({LogicalType::LIST(LogicalType::ANY), LogicalType::BIGINT}, LogicalType::BIGINT,
+	                   ScalarFunction::BinaryFunction<list_entry_t, int64_t, int64_t, ArrayLengthBinaryOperator>, false,
+	                   false, ListLengthBind));
+	set.AddFunction(array_length);
+
+	set.AddFunction(ScalarFunction("strlen", {LogicalType::VARCHAR}, LogicalType::BIGINT,
+	                               ScalarFunction::UnaryFunction<string_t, int64_t, StrLenOperator>));
+	set.AddFunction(ScalarFunction("bit_length", {LogicalType::VARCHAR}, LogicalType::BIGINT,
+	                               ScalarFunction::UnaryFunction<string_t, int64_t, BitLenOperator>));
+	// length for BLOB type
+	set.AddFunction(ScalarFunction("octet_length", {LogicalType::BLOB}, LogicalType::BIGINT,
+	                               ScalarFunction::UnaryFunction<string_t, int64_t, StrLenOperator>));
+}
+
+struct UnicodeOperator {
+	template <class TA, class TR>
+	static inline TR Operation(const TA &input) {
+		auto str = reinterpret_cast<const utf8proc_uint8_t *>(input.GetDataUnsafe());
+		auto len = input.GetSize();
+		utf8proc_int32_t codepoint;
+		(void)utf8proc_iterate(str, len, &codepoint);
+		return codepoint;
+	}
+};
+
+void UnicodeFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunction unicode("unicode", {LogicalType::VARCHAR}, LogicalType::INTEGER,
+	                       ScalarFunction::UnaryFunction<string_t, int32_t, UnicodeOperator>);
+	set.AddFunction(unicode);
+	unicode.name = "ord";
+	set.AddFunction(unicode);
+}
+
+} // namespace duckdb
+
+
+
+
+#include <ctype.h>
+#include <algorithm>
+
+namespace duckdb {
+
+// See: https://www.kdnuggets.com/2020/10/optimizing-levenshtein-distance-measuring-text-similarity.html
+// And: Iterative 2-row algorithm: https://en.wikipedia.org/wiki/Levenshtein_distance
+// Note: A first implementation using the array algorithm version resulted in an error raised by duckdb
+// (too muach memory usage)
+
+static idx_t LevenshteinDistance(const string_t &txt, const string_t &tgt) {
+	auto txt_len = txt.GetSize();
+	auto tgt_len = tgt.GetSize();
+
+	if (txt_len < 1) {
+		throw InvalidInputException("Levenshtein Function: 1st argument too short");
+	}
+
+	if (tgt_len < 1) {
+		throw InvalidInputException("Levenshtein Function: 2nd argument too short");
+	}
+
+	auto txt_str = txt.GetDataUnsafe();
+	auto tgt_str = tgt.GetDataUnsafe();
+
+	// Create two working vectors
+	std::vector<idx_t> distances0(tgt_len + 1, 0);
+	std::vector<idx_t> distances1(tgt_len + 1, 0);
+
+	idx_t cost_substitution = 0;
+	idx_t cost_insertion = 0;
+	idx_t cost_deletion = 0;
+
+	// initialize distances0 vector
+	// edit distance for an empty txt string is just the number of characters to delete from tgt
+	for (idx_t pos_tgt = 0; pos_tgt <= tgt_len; pos_tgt++) {
+		distances0[pos_tgt] = pos_tgt;
+	}
+
+	for (idx_t pos_txt = 0; pos_txt < txt_len; pos_txt++) {
+		// calculate distances1 (current raw distances) from the previous row
+
+		distances1[0] = pos_txt + 1;
+
+		for (idx_t pos_tgt = 0; pos_tgt < tgt_len; pos_tgt++) {
+			cost_deletion = distances0[pos_tgt + 1] + 1;
+			cost_insertion = distances1[pos_tgt] + 1;
+			cost_substitution = distances0[pos_tgt];
+
+			if (txt_str[pos_txt] != tgt_str[pos_tgt]) {
+				cost_substitution += 1;
+			}
+
+			distances1[pos_tgt + 1] = MinValue(cost_deletion, MinValue(cost_substitution, cost_insertion));
+		}
+		// copy distances1 (current row) to distances0 (previous row) for next iteration
+		// since data in distances1 is always invalidated, a swap without copy is more efficient
+		distances0 = distances1;
+	}
+
+	return distances0[tgt_len];
+}
+
+static int64_t LevenshteinScalarFunction(Vector &result, const string_t str, string_t tgt) {
+	return (int64_t)LevenshteinDistance(str, tgt);
+}
+
+static void LevenshteinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &str_vec = args.data[0];
+	auto &tgt_vec = args.data[1];
+
+	BinaryExecutor::Execute<string_t, string_t, int64_t>(
+	    str_vec, tgt_vec, result, args.size(),
+	    [&](string_t str, string_t tgt) { return LevenshteinScalarFunction(result, str, tgt); });
+}
+
+void LevenshteinFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet levenshtein("levenshtein");
+	levenshtein.AddFunction(ScalarFunction("levenshtein", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                       LogicalType::BIGINT,
+	                                       LevenshteinFunction)); // Pointer to function implementation
+	set.AddFunction(levenshtein);
+
+	ScalarFunctionSet editdist3("editdist3");
+	editdist3.AddFunction(ScalarFunction("levenshtein", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                     LogicalType::BIGINT, LevenshteinFunction));
+	set.AddFunction(editdist3);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct StandardCharacterReader {
+	static char Operation(const char *data, idx_t pos) {
+		return data[pos];
+	}
+};
+
+struct ASCIILCaseReader {
+	static char Operation(const char *data, idx_t pos) {
+		return (char)LowerFun::ascii_to_lower_map[(uint8_t)data[pos]];
+	}
+};
+
+template <char PERCENTAGE, char UNDERSCORE, class READER = StandardCharacterReader>
+bool TemplatedLikeOperator(const char *sdata, idx_t slen, const char *pdata, idx_t plen, char escape) {
+	idx_t pidx = 0;
+	idx_t sidx = 0;
+	for (; pidx < plen && sidx < slen; pidx++) {
+		char pchar = READER::Operation(pdata, pidx);
+		char schar = READER::Operation(sdata, sidx);
+		if (pchar == escape) {
+			pidx++;
+			if (pidx == plen) {
+				throw SyntaxException("Like pattern must not end with escape character!");
+			}
+			if (pdata[pidx] != schar) {
+				return false;
+			}
+			sidx++;
+		} else if (pchar == UNDERSCORE) {
+			sidx++;
+		} else if (pchar == PERCENTAGE) {
+			pidx++;
+			while (pidx < plen && pdata[pidx] == PERCENTAGE) {
+				pidx++;
+			}
+			if (pidx == plen) {
+				return true; /* tail is acceptable */
+			}
+			for (; sidx < slen; sidx++) {
+				if (TemplatedLikeOperator<PERCENTAGE, UNDERSCORE, READER>(sdata + sidx, slen - sidx, pdata + pidx,
+				                                                          plen - pidx, escape)) {
+					return true;
+				}
+			}
+			return false;
+		} else if (pchar == schar) {
+			sidx++;
+		} else {
+			return false;
+		}
+	}
+	while (pidx < plen && pdata[pidx] == PERCENTAGE) {
+		pidx++;
+	}
+	return pidx == plen && sidx == slen;
+}
+
+struct LikeSegment {
+	explicit LikeSegment(string pattern) : pattern(move(pattern)) {
+	}
+
+	string pattern;
+};
+
+struct LikeMatcher : public FunctionData {
+	LikeMatcher(string like_pattern_p, vector<LikeSegment> segments, bool has_start_percentage, bool has_end_percentage)
+	    : like_pattern(move(like_pattern_p)), segments(move(segments)), has_start_percentage(has_start_percentage),
+	      has_end_percentage(has_end_percentage) {
+	}
+
+	bool Match(string_t &str) {
+		auto str_data = (const unsigned char *)str.GetDataUnsafe();
+		auto str_len = str.GetSize();
+		idx_t segment_idx = 0;
+		idx_t end_idx = segments.size() - 1;
+		if (!has_start_percentage) {
+			// no start sample_size: match the first part of the string directly
+			auto &segment = segments[0];
+			if (str_len < segment.pattern.size()) {
+				return false;
+			}
+			if (memcmp(str_data, segment.pattern.c_str(), segment.pattern.size()) != 0) {
+				return false;
+			}
+			str_data += segment.pattern.size();
+			str_len -= segment.pattern.size();
+			segment_idx++;
+			if (segments.size() == 1) {
+				// only one segment, and it matches
+				// we have a match if there is an end sample_size, OR if the memcmp was an exact match (remaining str is
+				// empty)
+				return has_end_percentage || str_len == 0;
+			}
+		}
+		// main match loop: for every segment in the middle, use Contains to find the needle in the haystack
+		for (; segment_idx < end_idx; segment_idx++) {
+			auto &segment = segments[segment_idx];
+			// find the pattern of the current segment
+			idx_t next_offset = ContainsFun::Find(str_data, str_len, (const unsigned char *)segment.pattern.c_str(),
+			                                      segment.pattern.size());
+			if (next_offset == DConstants::INVALID_INDEX) {
+				// could not find this pattern in the string: no match
+				return false;
+			}
+			idx_t offset = next_offset + segment.pattern.size();
+			str_data += offset;
+			str_len -= offset;
+		}
+		if (!has_end_percentage) {
+			end_idx--;
+			// no end sample_size: match the final segment now
+			auto &segment = segments.back();
+			if (str_len < segment.pattern.size()) {
+				return false;
+			}
+			if (memcmp(str_data + str_len - segment.pattern.size(), segment.pattern.c_str(), segment.pattern.size()) !=
+			    0) {
+				return false;
+			}
+			return true;
+		} else {
+			auto &segment = segments.back();
+			// find the pattern of the current segment
+			idx_t next_offset = ContainsFun::Find(str_data, str_len, (const unsigned char *)segment.pattern.c_str(),
+			                                      segment.pattern.size());
+			return next_offset != DConstants::INVALID_INDEX;
+		}
+	}
+
+	static unique_ptr<LikeMatcher> CreateLikeMatcher(string like_pattern, char escape = '\0') {
+		vector<LikeSegment> segments;
+		idx_t last_non_pattern = 0;
+		bool has_start_percentage = false;
+		bool has_end_percentage = false;
+		for (idx_t i = 0; i < like_pattern.size(); i++) {
+			auto ch = like_pattern[i];
+			if (ch == escape || ch == '%' || ch == '_') {
+				// special character, push a constant pattern
+				if (i > last_non_pattern) {
+					segments.emplace_back(like_pattern.substr(last_non_pattern, i - last_non_pattern));
+				}
+				last_non_pattern = i + 1;
+				if (ch == escape || ch == '_') {
+					// escape or underscore: could not create efficient like matcher
+					// FIXME: we could handle escaped percentages here
+					return nullptr;
+				} else {
+					// sample_size
+					if (i == 0) {
+						has_start_percentage = true;
+					}
+					if (i + 1 == like_pattern.size()) {
+						has_end_percentage = true;
+					}
+				}
+			}
+		}
+		if (last_non_pattern < like_pattern.size()) {
+			segments.emplace_back(like_pattern.substr(last_non_pattern, like_pattern.size() - last_non_pattern));
+		}
+		if (segments.empty()) {
+			return nullptr;
+		}
+		return make_unique<LikeMatcher>(move(like_pattern), move(segments), has_start_percentage, has_end_percentage);
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<LikeMatcher>(like_pattern, segments, has_start_percentage, has_end_percentage);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const LikeMatcher &)other_p;
+		return like_pattern == other.like_pattern;
+	}
+
+private:
+	string like_pattern;
+	vector<LikeSegment> segments;
+	bool has_start_percentage;
+	bool has_end_percentage;
+};
+
+static unique_ptr<FunctionData> LikeBindFunction(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	// pattern is the second argument. If its constant, we can already prepare the pattern and store it for later.
+	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
+	if (arguments[1]->IsFoldable()) {
+		Value pattern_str = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+		return LikeMatcher::CreateLikeMatcher(pattern_str.ToString());
+	}
+	return nullptr;
+}
+
+bool LikeOperatorFunction(const char *s, idx_t slen, const char *pattern, idx_t plen, char escape) {
+	return TemplatedLikeOperator<'%', '_'>(s, slen, pattern, plen, escape);
+}
+
+bool LikeOperatorFunction(string_t &s, string_t &pat, char escape = '\0') {
+	return LikeOperatorFunction(s.GetDataUnsafe(), s.GetSize(), pat.GetDataUnsafe(), pat.GetSize(), escape);
+}
+
+bool LikeFun::Glob(const char *string, idx_t slen, const char *pattern, idx_t plen) {
+	idx_t sidx = 0;
+	idx_t pidx = 0;
+main_loop : {
+	// main matching loop
+	while (sidx < slen && pidx < plen) {
+		char s = string[sidx];
+		char p = pattern[pidx];
+		switch (p) {
+		case '*': {
+			// asterisk: match any set of characters
+			// skip any subsequent asterisks
+			pidx++;
+			while (pidx < plen && pattern[pidx] == '*') {
+				pidx++;
+			}
+			// if the asterisk is the last character, the pattern always matches
+			if (pidx == plen) {
+				return true;
+			}
+			// recursively match the remainder of the pattern
+			for (; sidx < slen; sidx++) {
+				if (LikeFun::Glob(string + sidx, slen - sidx, pattern + pidx, plen - pidx)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		case '?':
+			// wildcard: matches anything but null
+			break;
+		case '[':
+			pidx++;
+			goto parse_bracket;
+		case '\\':
+			// escape character, next character needs to match literally
+			pidx++;
+			// check that we still have a character remaining
+			if (pidx == plen) {
+				return false;
+			}
+			p = pattern[pidx];
+			if (s != p) {
+				return false;
+			}
+			break;
+		default:
+			// not a control character: characters need to match literally
+			if (s != p) {
+				return false;
+			}
+			break;
+		}
+		sidx++;
+		pidx++;
+	}
+	while (pidx < plen && pattern[pidx] == '*') {
+		pidx++;
+	}
+	// we are finished only if we have consumed the full pattern
+	return pidx == plen && sidx == slen;
+}
+parse_bracket : {
+	// inside a bracket
+	if (pidx == plen) {
+		return false;
+	}
+	// check the first character
+	// if it is an exclamation mark we need to invert our logic
+	char p = pattern[pidx];
+	char s = string[sidx];
+	bool invert = false;
+	if (p == '!') {
+		invert = true;
+		pidx++;
+	}
+	bool found_match = invert;
+	idx_t start_pos = pidx;
+	bool found_closing_bracket = false;
+	// now check the remainder of the pattern
+	while (pidx < plen) {
+		p = pattern[pidx];
+		// if the first character is a closing bracket, we match it literally
+		// otherwise it indicates an end of bracket
+		if (p == ']' && pidx > start_pos) {
+			// end of bracket found: we are done
+			found_closing_bracket = true;
+			pidx++;
+			break;
+		}
+		// we either match a range (a-b) or a single character (a)
+		// check if the next character is a dash
+		if (pidx + 1 == plen) {
+			// no next character!
+			break;
+		}
+		bool matches;
+		if (pattern[pidx + 1] == '-') {
+			// range! find the next character in the range
+			if (pidx + 2 == plen) {
+				break;
+			}
+			char next_char = pattern[pidx + 2];
+			// check if the current character is within the range
+			matches = s >= p && s <= next_char;
+			// shift the pattern forward past the range
+			pidx += 3;
+		} else {
+			// no range! perform a direct match
+			matches = p == s;
+			// shift the pattern forward past the character
+			pidx++;
+		}
+		if (found_match == invert && matches) {
+			// found a match! set the found_matches flag
+			// we keep on pattern matching after this until we reach the end bracket
+			// however, we don't need to update the found_match flag anymore
+			found_match = !invert;
+		}
+	}
+	if (!found_closing_bracket) {
+		// no end of bracket: invalid pattern
+		return false;
+	}
+	if (!found_match) {
+		// did not match the bracket: return false;
+		return false;
+	}
+	// finished the bracket matching: move forward
+	sidx++;
+	goto main_loop;
+}
+}
+
+static char GetEscapeChar(string_t escape) {
+	// Only one escape character should be allowed
+	if (escape.GetSize() > 1) {
+		throw SyntaxException("Invalid escape string. Escape string must be empty or one character.");
+	}
+	return escape.GetSize() == 0 ? '\0' : *escape.GetDataUnsafe();
+}
+
+struct LikeEscapeOperator {
+	template <class TA, class TB, class TC>
+	static inline bool Operation(TA str, TB pattern, TC escape) {
+		char escape_char = GetEscapeChar(escape);
+		return LikeOperatorFunction(str.GetDataUnsafe(), str.GetSize(), pattern.GetDataUnsafe(), pattern.GetSize(),
+		                            escape_char);
+	}
+};
+
+struct NotLikeEscapeOperator {
+	template <class TA, class TB, class TC>
+	static inline bool Operation(TA str, TB pattern, TC escape) {
+		return !LikeEscapeOperator::Operation(str, pattern, escape);
+	}
+};
+
+struct LikeOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA str, TB pattern) {
+		return LikeOperatorFunction(str, pattern);
+	}
+};
+
+bool ILikeOperatorFunction(string_t &str, string_t &pattern, char escape = '\0') {
+	auto str_data = str.GetDataUnsafe();
+	auto str_size = str.GetSize();
+	auto pat_data = pattern.GetDataUnsafe();
+	auto pat_size = pattern.GetSize();
+
+	// lowercase both the str and the pattern
+	idx_t str_llength = LowerFun::LowerLength(str_data, str_size);
+	auto str_ldata = unique_ptr<char[]>(new char[str_llength]);
+	LowerFun::LowerCase(str_data, str_size, str_ldata.get());
+
+	idx_t pat_llength = LowerFun::LowerLength(pat_data, pat_size);
+	auto pat_ldata = unique_ptr<char[]>(new char[pat_llength]);
+	LowerFun::LowerCase(pat_data, pat_size, pat_ldata.get());
+	string_t str_lcase(str_ldata.get(), str_llength);
+	string_t pat_lcase(pat_ldata.get(), pat_llength);
+	return LikeOperatorFunction(str_lcase, pat_lcase, escape);
+}
+
+struct ILikeEscapeOperator {
+	template <class TA, class TB, class TC>
+	static inline bool Operation(TA str, TB pattern, TC escape) {
+		char escape_char = GetEscapeChar(escape);
+		return ILikeOperatorFunction(str, pattern, escape_char);
+	}
+};
+
+struct NotILikeEscapeOperator {
+	template <class TA, class TB, class TC>
+	static inline bool Operation(TA str, TB pattern, TC escape) {
+		return !ILikeEscapeOperator::Operation(str, pattern, escape);
+	}
+};
+
+struct ILikeOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA str, TB pattern) {
+		return ILikeOperatorFunction(str, pattern);
+	}
+};
+
+struct NotLikeOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA str, TB pattern) {
+		return !LikeOperatorFunction(str, pattern);
+	}
+};
+
+struct NotILikeOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA str, TB pattern) {
+		return !ILikeOperator::Operation<TA, TB, TR>(str, pattern);
+	}
+};
+
+struct ILikeOperatorASCII {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA str, TB pattern) {
+		return TemplatedLikeOperator<'%', '_', ASCIILCaseReader>(str.GetDataUnsafe(), str.GetSize(),
+		                                                         pattern.GetDataUnsafe(), pattern.GetSize(), '\0');
+	}
+};
+
+struct NotILikeOperatorASCII {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA str, TB pattern) {
+		return !ILikeOperatorASCII::Operation<TA, TB, TR>(str, pattern);
+	}
+};
+
+struct GlobOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA str, TB pattern) {
+		return LikeFun::Glob(str.GetDataUnsafe(), str.GetSize(), pattern.GetDataUnsafe(), pattern.GetSize());
+	}
+};
+
+// This can be moved to the scalar_function class
+template <typename FUNC>
+static void LikeEscapeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &str = args.data[0];
+	auto &pattern = args.data[1];
+	auto &escape = args.data[2];
+
+	TernaryExecutor::Execute<string_t, string_t, string_t, bool>(
+	    str, pattern, escape, result, args.size(), FUNC::template Operation<string_t, string_t, string_t>);
+}
+
+template <class ASCII_OP>
+static unique_ptr<BaseStatistics> ILikePropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	D_ASSERT(child_stats.size() >= 1);
+	// can only propagate stats if the children have stats
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &sstats = (StringStatistics &)*child_stats[0];
+	if (!sstats.has_unicode) {
+		expr.function.function = ScalarFunction::BinaryFunction<string_t, string_t, bool, ASCII_OP>;
+	}
+	return nullptr;
+}
+
+template <class OP, bool INVERT>
+static void RegularLikeFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	if (func_expr.bind_info) {
+		auto &matcher = (LikeMatcher &)*func_expr.bind_info;
+		// use fast like matcher
+		UnaryExecutor::Execute<string_t, bool>(input.data[0], result, input.size(), [&](string_t input) {
+			return INVERT ? !matcher.Match(input) : matcher.Match(input);
+		});
+	} else {
+		// use generic like matcher
+		BinaryExecutor::ExecuteStandard<string_t, string_t, bool, OP>(input.data[0], input.data[1], result,
+		                                                              input.size());
+	}
+}
+void LikeFun::RegisterFunction(BuiltinFunctions &set) {
+	// like
+	set.AddFunction(ScalarFunction("~~", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                               RegularLikeFunction<LikeOperator, false>, false, LikeBindFunction));
+	// not like
+	set.AddFunction(ScalarFunction("!~~", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                               RegularLikeFunction<NotLikeOperator, true>, false, LikeBindFunction));
+	// glob
+	set.AddFunction(ScalarFunction("~~~", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                               ScalarFunction::BinaryFunction<string_t, string_t, bool, GlobOperator>));
+	// ilike
+	set.AddFunction(ScalarFunction("~~*", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                               ScalarFunction::BinaryFunction<string_t, string_t, bool, ILikeOperator>, false,
+	                               nullptr, nullptr, ILikePropagateStats<ILikeOperatorASCII>));
+	// not ilike
+	set.AddFunction(ScalarFunction("!~~*", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                               ScalarFunction::BinaryFunction<string_t, string_t, bool, NotILikeOperator>, false,
+	                               nullptr, nullptr, ILikePropagateStats<NotILikeOperatorASCII>));
+}
+
+void LikeEscapeFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction({"like_escape"}, ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                                LogicalType::BOOLEAN, LikeEscapeFunction<LikeEscapeOperator>));
+	set.AddFunction({"not_like_escape"},
+	                ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                               LogicalType::BOOLEAN, LikeEscapeFunction<NotLikeEscapeOperator>));
+
+	set.AddFunction({"ilike_escape"}, ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                                 LogicalType::BOOLEAN, LikeEscapeFunction<ILikeEscapeOperator>));
+	set.AddFunction({"not_ilike_escape"},
+	                ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                               LogicalType::BOOLEAN, LikeEscapeFunction<NotILikeEscapeOperator>));
+}
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct MD5Operator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
+		auto hash = StringVector::EmptyString(result, MD5Context::MD5_HASH_LENGTH_TEXT);
+		MD5Context context;
+		context.Add(input);
+		context.FinishHex(hash.GetDataWriteable());
+		hash.Finalize();
+		return hash;
+	}
+};
+
+struct MD5Number128Operator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input) {
+		data_t digest[MD5Context::MD5_HASH_LENGTH_BINARY];
+
+		MD5Context context;
+		context.Add(input);
+		context.Finish(digest);
+		return *reinterpret_cast<hugeint_t *>(digest);
+	}
+};
+
+template <bool lower>
+struct MD5Number64Operator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input) {
+		data_t digest[MD5Context::MD5_HASH_LENGTH_BINARY];
+
+		MD5Context context;
+		context.Add(input);
+		context.Finish(digest);
+		return *reinterpret_cast<uint64_t *>(&digest[lower ? 8 : 0]);
+	}
+};
+
+static void MD5Function(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &input = args.data[0];
+
+	UnaryExecutor::ExecuteString<string_t, string_t, MD5Operator>(input, result, args.size());
+}
+
+static void MD5NumberFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &input = args.data[0];
+
+	UnaryExecutor::Execute<string_t, hugeint_t, MD5Number128Operator>(input, result, args.size());
+}
+
+static void MD5NumberUpperFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &input = args.data[0];
+
+	UnaryExecutor::Execute<string_t, uint64_t, MD5Number64Operator<false>>(input, result, args.size());
+}
+
+static void MD5NumberLowerFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &input = args.data[0];
+
+	UnaryExecutor::Execute<string_t, uint64_t, MD5Number64Operator<true>>(input, result, args.size());
+}
+
+void MD5Fun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("md5",                  // name of the function
+	                               {LogicalType::VARCHAR}, // argument list
+	                               LogicalType::VARCHAR,   // return type
+	                               MD5Function));          // pointer to function implementation
+
+	set.AddFunction(ScalarFunction("md5_number",           // name of the function
+	                               {LogicalType::VARCHAR}, // argument list
+	                               LogicalType::HUGEINT,   // return type
+	                               MD5NumberFunction));    // pointer to function implementation
+
+	set.AddFunction(ScalarFunction("md5_number_upper",       // name of the function
+	                               {LogicalType::VARCHAR},   // argument list
+	                               LogicalType::UBIGINT,     // return type
+	                               MD5NumberUpperFunction)); // pointer to function implementation
+
+	set.AddFunction(ScalarFunction("md5_number_lower",       // name of the function
+	                               {LogicalType::VARCHAR},   // argument list
+	                               LogicalType::UBIGINT,     // return type
+	                               MD5NumberLowerFunction)); // pointer to function implementation
+}
+
+} // namespace duckdb
+
+
+
+#include <ctype.h>
+#include <algorithm>
+
+namespace duckdb {
+
+static int64_t MismatchesScalarFunction(Vector &result, const string_t str, string_t tgt) {
+	idx_t str_len = str.GetSize();
+	idx_t tgt_len = tgt.GetSize();
+
+	if (str_len != tgt_len) {
+		throw InvalidInputException("Mismatch Function: Strings must be of equal length!");
+	}
+	if (str_len < 1) {
+		throw InvalidInputException("Mismatch Function: Strings must be of length > 0!");
+	}
+
+	idx_t mismatches = 0;
+	auto str_str = str.GetDataUnsafe();
+	auto tgt_str = tgt.GetDataUnsafe();
+
+	for (idx_t idx = 0; idx < str_len; ++idx) {
+		if (str_str[idx] != tgt_str[idx]) {
+			mismatches++;
+		}
+	}
+	return (int64_t)mismatches;
+}
+
+static void MismatchesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &str_vec = args.data[0];
+	auto &tgt_vec = args.data[1];
+
+	BinaryExecutor::Execute<string_t, string_t, int64_t>(
+	    str_vec, tgt_vec, result, args.size(),
+	    [&](string_t str, string_t tgt) { return MismatchesScalarFunction(result, str, tgt); });
+}
+
+void MismatchesFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet mismatches("mismatches");
+	mismatches.AddFunction(ScalarFunction("mismatches", {LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                      LogicalType::BIGINT,
+	                                      MismatchesFunction)); // Pointer to function implementation
+	set.AddFunction(mismatches);
+
+	ScalarFunctionSet hamming("hamming");
+	hamming.AddFunction(ScalarFunction("mismatches", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BIGINT,
+	                                   MismatchesFunction)); // Pointer to function implementation
+	set.AddFunction(hamming);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+struct NFCNormalizeOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
+		auto input_data = input.GetDataUnsafe();
+		auto input_length = input.GetSize();
+		if (StripAccentsFun::IsAscii(input_data, input_length)) {
+			return input;
+		}
+		auto normalized_str = Utf8Proc::Normalize(input_data, input_length);
+		D_ASSERT(normalized_str);
+		auto result_str = StringVector::AddString(result, normalized_str);
+		free(normalized_str);
+		return result_str;
+	}
+};
+
+static void NFCNormalizeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 1);
+
+	UnaryExecutor::ExecuteString<string_t, string_t, NFCNormalizeOperator>(args.data[0], result, args.size());
+	StringVector::AddHeapReference(result, args.data[0]);
+}
+
+ScalarFunction NFCNormalizeFun::GetFunction() {
+	return ScalarFunction("nfc_normalize", {LogicalType::VARCHAR}, LogicalType::VARCHAR, NFCNormalizeFunction);
+}
+
+void NFCNormalizeFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(NFCNormalizeFun::GetFunction());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static pair<idx_t, idx_t> PadCountChars(const idx_t len, const char *data, const idx_t size) {
+	//  Count how much of str will fit in the output
+	auto str = reinterpret_cast<const utf8proc_uint8_t *>(data);
+	idx_t nbytes = 0;
+	idx_t nchars = 0;
+	for (; nchars < len && nbytes < size; ++nchars) {
+		utf8proc_int32_t codepoint;
+		auto bytes = utf8proc_iterate(str + nbytes, size - nbytes, &codepoint);
+		D_ASSERT(bytes > 0);
+		nbytes += bytes;
+	}
+
+	return pair<idx_t, idx_t>(nbytes, nchars);
+}
+
+static bool InsertPadding(const idx_t len, const string_t &pad, vector<char> &result) {
+	//  Copy the padding until the output is long enough
+	auto data = pad.GetDataUnsafe();
+	auto size = pad.GetSize();
+
+	//  Check whether we need data that we don't have
+	if (len > 0 && size == 0) {
+		return false;
+	}
+
+	//  Insert characters until we have all we need.
+	auto str = reinterpret_cast<const utf8proc_uint8_t *>(data);
+	idx_t nbytes = 0;
+	for (idx_t nchars = 0; nchars < len; ++nchars) {
+		//  If we are at the end of the pad, flush all of it and loop back
+		if (nbytes >= size) {
+			result.insert(result.end(), data, data + size);
+			nbytes = 0;
+		}
+
+		//  Write the next character
+		utf8proc_int32_t codepoint;
+		auto bytes = utf8proc_iterate(str + nbytes, size - nbytes, &codepoint);
+		D_ASSERT(bytes > 0);
+		nbytes += bytes;
+	}
+
+	//  Flush the remaining pad
+	result.insert(result.end(), data, data + nbytes);
+
+	return true;
+}
+
+static string_t LeftPadFunction(const string_t &str, const int32_t len, const string_t &pad, vector<char> &result) {
+	//  Reuse the buffer
+	result.clear();
+
+	// Get information about the base string
+	auto data_str = str.GetDataUnsafe();
+	auto size_str = str.GetSize();
+
+	//  Count how much of str will fit in the output
+	auto written = PadCountChars(len, data_str, size_str);
+
+	//  Left pad by the number of characters still needed
+	if (!InsertPadding(len - written.second, pad, result)) {
+		throw Exception("Insufficient padding in LPAD.");
+	}
+
+	//  Append as much of the original string as fits
+	result.insert(result.end(), data_str, data_str + written.first);
+
+	return string_t(result.data(), result.size());
+}
+
+struct LeftPadOperator {
+	static inline string_t Operation(const string_t &str, const int32_t len, const string_t &pad,
+	                                 vector<char> &result) {
+		return LeftPadFunction(str, len, pad, result);
+	}
+};
+
+static string_t RightPadFunction(const string_t &str, const int32_t len, const string_t &pad, vector<char> &result) {
+	//  Reuse the buffer
+	result.clear();
+
+	// Get information about the base string
+	auto data_str = str.GetDataUnsafe();
+	auto size_str = str.GetSize();
+
+	// Count how much of str will fit in the output
+	auto written = PadCountChars(len, data_str, size_str);
+
+	//  Append as much of the original string as fits
+	result.insert(result.end(), data_str, data_str + written.first);
+
+	//  Right pad by the number of characters still needed
+	if (!InsertPadding(len - written.second, pad, result)) {
+		throw Exception("Insufficient padding in RPAD.");
+	};
+
+	return string_t(result.data(), result.size());
+}
+
+struct RightPadOperator {
+	static inline string_t Operation(const string_t &str, const int32_t len, const string_t &pad,
+	                                 vector<char> &result) {
+		return RightPadFunction(str, len, pad, result);
+	}
+};
+
+template <class OP>
+static void PadFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &str_vector = args.data[0];
+	auto &len_vector = args.data[1];
+	auto &pad_vector = args.data[2];
+
+	vector<char> buffer;
+	TernaryExecutor::Execute<string_t, int32_t, string_t, string_t>(
+	    str_vector, len_vector, pad_vector, result, args.size(), [&](string_t str, int32_t len, string_t pad) {
+		    len = MaxValue<int32_t>(len, 0);
+		    return StringVector::AddString(result, OP::Operation(str, len, pad, buffer));
+	    });
+}
+
+void LpadFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("lpad",                                      // name of the function
+	                               {LogicalType::VARCHAR, LogicalType::INTEGER, // argument list
+	                                LogicalType::VARCHAR},
+	                               LogicalType::VARCHAR,           // return type
+	                               PadFunction<LeftPadOperator>)); // pointer to function implementation
+}
+
+void RpadFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("rpad",                                      // name of the function
+	                               {LogicalType::VARCHAR, LogicalType::INTEGER, // argument list
+	                                LogicalType::VARCHAR},
+	                               LogicalType::VARCHAR,            // return type
+	                               PadFunction<RightPadOperator>)); // pointer to function implementation
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+static bool PrefixFunction(const string_t &str, const string_t &pattern);
+
+struct PrefixOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA left, TB right) {
+		return PrefixFunction(left, right);
+	}
+};
+static bool PrefixFunction(const string_t &str, const string_t &pattern) {
+	auto str_length = str.GetSize();
+	auto patt_length = pattern.GetSize();
+	if (patt_length > str_length) {
+		return false;
+	}
+	if (patt_length <= string_t::PREFIX_LENGTH) {
+		// short prefix
+		if (patt_length == 0) {
+			// length = 0, return true
+			return true;
+		}
+
+		// prefix early out
+		const char *str_pref = str.GetPrefix();
+		const char *patt_pref = pattern.GetPrefix();
+		for (idx_t i = 0; i < patt_length; ++i) {
+			if (str_pref[i] != patt_pref[i]) {
+				return false;
+			}
+		}
+		return true;
+	} else {
+		// prefix early out
+		const char *str_pref = str.GetPrefix();
+		const char *patt_pref = pattern.GetPrefix();
+		for (idx_t i = 0; i < string_t::PREFIX_LENGTH; ++i) {
+			if (str_pref[i] != patt_pref[i]) {
+				// early out
+				return false;
+			}
+		}
+		// compare the rest of the prefix
+		const char *str_data = str.GetDataUnsafe();
+		const char *patt_data = pattern.GetDataUnsafe();
+		D_ASSERT(patt_length <= str_length);
+		for (idx_t i = string_t::PREFIX_LENGTH; i < patt_length; ++i) {
+			if (str_data[i] != patt_data[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
+}
+
+ScalarFunction PrefixFun::GetFunction() {
+	return ScalarFunction("prefix",                                     // name of the function
+	                      {LogicalType::VARCHAR, LogicalType::VARCHAR}, // argument list
+	                      LogicalType::BOOLEAN,                         // return type
+	                      ScalarFunction::BinaryFunction<string_t, string_t, bool, PrefixOperator>);
+}
+
+void PrefixFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(GetFunction());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct FMTPrintf {
+	template <class CTX>
+	static string OP(const char *format_str, std::vector<duckdb_fmt::basic_format_arg<CTX>> &format_args) {
+		return duckdb_fmt::vsprintf(
+		    format_str, duckdb_fmt::basic_format_args<CTX>(format_args.data(), static_cast<int>(format_args.size())));
+	}
+};
+
+struct FMTFormat {
+	template <class CTX>
+	static string OP(const char *format_str, std::vector<duckdb_fmt::basic_format_arg<CTX>> &format_args) {
+		return duckdb_fmt::vformat(
+		    format_str, duckdb_fmt::basic_format_args<CTX>(format_args.data(), static_cast<int>(format_args.size())));
+	}
+};
+
+unique_ptr<FunctionData> BindPrintfFunction(ClientContext &context, ScalarFunction &bound_function,
+                                            vector<unique_ptr<Expression>> &arguments) {
+	for (idx_t i = 1; i < arguments.size(); i++) {
+		switch (arguments[i]->return_type.id()) {
+		case LogicalTypeId::BOOLEAN:
+		case LogicalTypeId::TINYINT:
+		case LogicalTypeId::SMALLINT:
+		case LogicalTypeId::INTEGER:
+		case LogicalTypeId::BIGINT:
+		case LogicalTypeId::FLOAT:
+		case LogicalTypeId::DOUBLE:
+		case LogicalTypeId::VARCHAR:
+			// these types are natively supported
+			bound_function.arguments.push_back(arguments[i]->return_type);
+			break;
+		case LogicalTypeId::DECIMAL:
+			// decimal type: add cast to double
+			bound_function.arguments.emplace_back(LogicalType::DOUBLE);
+			break;
+		case LogicalTypeId::UNKNOWN:
+			// parameter: accept any input and rebind later
+			bound_function.arguments.emplace_back(LogicalType::ANY);
+			break;
+		default:
+			// all other types: add cast to string
+			bound_function.arguments.emplace_back(LogicalType::VARCHAR);
+			break;
+		}
+	}
+	return nullptr;
+}
+
+template <class FORMAT_FUN, class CTX>
+static void PrintfFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &format_string = args.data[0];
+	auto &result_validity = FlatVector::Validity(result);
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	result_validity.Initialize(args.size());
+	for (idx_t i = 0; i < args.ColumnCount(); i++) {
+		switch (args.data[i].GetVectorType()) {
+		case VectorType::CONSTANT_VECTOR:
+			if (ConstantVector::IsNull(args.data[i])) {
+				// constant null! result is always NULL regardless of other input
+				result.SetVectorType(VectorType::CONSTANT_VECTOR);
+				ConstantVector::SetNull(result, true);
+				return;
+			}
+			break;
+		default:
+			// FLAT VECTOR, we can directly OR the nullmask
+			args.data[i].Normalify(args.size());
+			result.SetVectorType(VectorType::FLAT_VECTOR);
+			result_validity.Combine(FlatVector::Validity(args.data[i]), args.size());
+			break;
+		}
+	}
+	idx_t count = result.GetVectorType() == VectorType::CONSTANT_VECTOR ? 1 : args.size();
+
+	auto format_data = FlatVector::GetData<string_t>(format_string);
+	auto result_data = FlatVector::GetData<string_t>(result);
+	for (idx_t idx = 0; idx < count; idx++) {
+		if (result.GetVectorType() == VectorType::FLAT_VECTOR && FlatVector::IsNull(result, idx)) {
+			// this entry is NULL: skip it
+			continue;
+		}
+
+		// first fetch the format string
+		auto fmt_idx = format_string.GetVectorType() == VectorType::CONSTANT_VECTOR ? 0 : idx;
+		auto format_string = format_data[fmt_idx].GetString();
+
+		// now gather all the format arguments
+		std::vector<duckdb_fmt::basic_format_arg<CTX>> format_args;
+		std::vector<unique_ptr<data_t[]>> string_args;
+
+		for (idx_t col_idx = 1; col_idx < args.ColumnCount(); col_idx++) {
+			auto &col = args.data[col_idx];
+			idx_t arg_idx = col.GetVectorType() == VectorType::CONSTANT_VECTOR ? 0 : idx;
+			switch (col.GetType().id()) {
+			case LogicalTypeId::BOOLEAN: {
+				auto arg_data = FlatVector::GetData<bool>(col);
+				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
+				break;
+			}
+			case LogicalTypeId::TINYINT: {
+				auto arg_data = FlatVector::GetData<int8_t>(col);
+				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
+				break;
+			}
+			case LogicalTypeId::SMALLINT: {
+				auto arg_data = FlatVector::GetData<int8_t>(col);
+				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
+				break;
+			}
+			case LogicalTypeId::INTEGER: {
+				auto arg_data = FlatVector::GetData<int32_t>(col);
+				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
+				break;
+			}
+			case LogicalTypeId::BIGINT: {
+				auto arg_data = FlatVector::GetData<int64_t>(col);
+				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
+				break;
+			}
+			case LogicalTypeId::FLOAT: {
+				auto arg_data = FlatVector::GetData<float>(col);
+				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
+				break;
+			}
+			case LogicalTypeId::DOUBLE: {
+				auto arg_data = FlatVector::GetData<double>(col);
+				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(arg_data[arg_idx]));
+				break;
+			}
+			case LogicalTypeId::VARCHAR: {
+				auto arg_data = FlatVector::GetData<string_t>(col);
+				auto string_view =
+				    duckdb_fmt::basic_string_view<char>(arg_data[arg_idx].GetDataUnsafe(), arg_data[arg_idx].GetSize());
+				format_args.emplace_back(duckdb_fmt::internal::make_arg<CTX>(string_view));
+				break;
+			}
+			default:
+				throw InternalException("Unexpected type for printf format");
+			}
+		}
+		// finally actually perform the format
+		string dynamic_result = FORMAT_FUN::template OP<CTX>(format_string.c_str(), format_args);
+		result_data[idx] = StringVector::AddString(result, dynamic_result);
+	}
+}
+
+void PrintfFun::RegisterFunction(BuiltinFunctions &set) {
+	// duckdb_fmt::printf_context, duckdb_fmt::vsprintf
+	ScalarFunction printf_fun =
+	    ScalarFunction("printf", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                   PrintfFunction<FMTPrintf, duckdb_fmt::printf_context>, false, BindPrintfFunction);
+	printf_fun.varargs = LogicalType::ANY;
+	set.AddFunction(printf_fun);
+
+	// duckdb_fmt::format_context, duckdb_fmt::vformat
+	ScalarFunction format_fun =
+	    ScalarFunction("format", {LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                   PrintfFunction<FMTFormat, duckdb_fmt::format_context>, false, BindPrintfFunction);
+	format_fun.varargs = LogicalType::ANY;
+	set.AddFunction(format_fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+RegexpMatchesBindData::RegexpMatchesBindData(duckdb_re2::RE2::Options options, string constant_string_p)
+    : options(options), constant_string(move(constant_string_p)) {
+	constant_pattern = !constant_string.empty();
+	if (constant_pattern) {
+		auto pattern = make_unique<RE2>(constant_string, options);
+		if (!pattern->ok()) {
+			throw Exception(pattern->error());
+		}
+
+		range_success = pattern->PossibleMatchRange(&range_min, &range_max, 1000);
+	} else {
+		range_success = false;
+	}
+}
+
+static bool RegexOptionsEquals(const duckdb_re2::RE2::Options &opt_a, const duckdb_re2::RE2::Options &opt_b) {
+	return opt_a.case_sensitive() == opt_b.case_sensitive();
+}
+
+RegexpMatchesBindData::~RegexpMatchesBindData() {
+}
+
+unique_ptr<FunctionData> RegexpMatchesBindData::Copy() const {
+	return make_unique<RegexpMatchesBindData>(options, constant_string);
+}
+
+bool RegexpMatchesBindData::Equals(const FunctionData &other_p) const {
+	auto &other = (const RegexpMatchesBindData &)other_p;
+	return constant_string == other.constant_string && RegexOptionsEquals(options, other.options);
+}
+
+static inline duckdb_re2::StringPiece CreateStringPiece(string_t &input) {
+	return duckdb_re2::StringPiece(input.GetDataUnsafe(), input.GetSize());
+}
+
+static void ParseRegexOptions(const string &options, duckdb_re2::RE2::Options &result, bool *global_replace = nullptr) {
+	for (idx_t i = 0; i < options.size(); i++) {
+		switch (options[i]) {
+		case 'c':
+			// case-sensitive matching
+			result.set_case_sensitive(true);
+			break;
+		case 'i':
+			// case-insensitive matching
+			result.set_case_sensitive(false);
+			break;
+		case 'l':
+			// literal matching
+			result.set_literal(true);
+			break;
+		case 'm':
+		case 'n':
+		case 'p':
+			// newline-sensitive matching
+			result.set_dot_nl(false);
+			break;
+		case 's':
+			// non-newline-sensitive matching
+			result.set_dot_nl(true);
+			break;
+		case 'g':
+			// global replace, only available for regexp_replace
+			if (global_replace) {
+				*global_replace = true;
+			} else {
+				throw InvalidInputException("Option 'g' (global replace) is only valid for regexp_replace");
+			}
+			break;
+		case ' ':
+		case '\t':
+		case '\n':
+			// ignore whitespace
+			break;
+		default:
+			throw InvalidInputException("Unrecognized Regex option %c", options[i]);
+		}
+	}
+}
+
+struct RegexPartialMatch {
+	static inline bool Operation(const duckdb_re2::StringPiece &input, duckdb_re2::RE2 &re) {
+		return duckdb_re2::RE2::PartialMatch(input, re);
+	}
+};
+
+struct RegexFullMatch {
+	static inline bool Operation(const duckdb_re2::StringPiece &input, duckdb_re2::RE2 &re) {
+		return duckdb_re2::RE2::FullMatch(input, re);
+	}
+};
+
+struct RegexLocalState : public FunctionLocalState {
+	explicit RegexLocalState(RegexpMatchesBindData &info)
+	    : constant_pattern(duckdb_re2::StringPiece(info.constant_string.c_str(), info.constant_string.size()),
+	                       info.options) {
+		D_ASSERT(info.constant_pattern);
+	}
+
+	explicit RegexLocalState(RegexpExtractBindData &info)
+	    : constant_pattern(duckdb_re2::StringPiece(info.constant_string.c_str(), info.constant_string.size())) {
+		D_ASSERT(info.constant_pattern);
+	}
+
+	RE2 constant_pattern;
+};
+
+static unique_ptr<FunctionLocalState> RegexInitLocalState(const BoundFunctionExpression &expr,
+                                                          FunctionData *bind_data) {
+	auto &info = (RegexpMatchesBindData &)*bind_data;
+	if (info.constant_pattern) {
+		return make_unique<RegexLocalState>(info);
+	}
+	return nullptr;
+}
+
+template <class OP>
+static void RegexpMatchesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &strings = args.data[0];
+	auto &patterns = args.data[1];
+
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (RegexpMatchesBindData &)*func_expr.bind_info;
+
+	if (info.constant_pattern) {
+		auto &lstate = (RegexLocalState &)*ExecuteFunctionState::GetFunctionState(state);
+		UnaryExecutor::Execute<string_t, bool>(strings, result, args.size(), [&](string_t input) {
+			return OP::Operation(CreateStringPiece(input), lstate.constant_pattern);
+		});
+	} else {
+		BinaryExecutor::Execute<string_t, string_t, bool>(strings, patterns, result, args.size(),
+		                                                  [&](string_t input, string_t pattern) {
+			                                                  RE2 re(CreateStringPiece(pattern), info.options);
+			                                                  if (!re.ok()) {
+				                                                  throw Exception(re.error());
+			                                                  }
+			                                                  return OP::Operation(CreateStringPiece(input), re);
+		                                                  });
+	}
+}
+
+static unique_ptr<FunctionData> RegexpMatchesBind(ClientContext &context, ScalarFunction &bound_function,
+                                                  vector<unique_ptr<Expression>> &arguments) {
+	// pattern is the second argument. If its constant, we can already prepare the pattern and store it for later.
+	D_ASSERT(arguments.size() == 2 || arguments.size() == 3);
+	RE2::Options options;
+	options.set_log_errors(false);
+	if (arguments.size() == 3) {
+		if (!arguments[2]->IsFoldable()) {
+			throw InvalidInputException("Regex options field must be a constant");
+		}
+		Value options_str = ExpressionExecutor::EvaluateScalar(*arguments[2]);
+		if (!options_str.IsNull() && options_str.type().id() == LogicalTypeId::VARCHAR) {
+			ParseRegexOptions(StringValue::Get(options_str), options);
+		}
+	}
+
+	if (arguments[1]->IsFoldable()) {
+		Value pattern_str = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+		if (!pattern_str.IsNull() && pattern_str.type().id() == LogicalTypeId::VARCHAR) {
+			return make_unique<RegexpMatchesBindData>(options, StringValue::Get(pattern_str));
+		}
+	}
+	return make_unique<RegexpMatchesBindData>(options, "");
+}
+
+static void RegexReplaceFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (RegexpReplaceBindData &)*func_expr.bind_info;
+
+	auto &strings = args.data[0];
+	auto &patterns = args.data[1];
+	auto &replaces = args.data[2];
+
+	TernaryExecutor::Execute<string_t, string_t, string_t, string_t>(
+	    strings, patterns, replaces, result, args.size(), [&](string_t input, string_t pattern, string_t replace) {
+		    RE2 re(CreateStringPiece(pattern), info.options);
+		    std::string sstring = input.GetString();
+		    if (info.global_replace) {
+			    RE2::GlobalReplace(&sstring, re, CreateStringPiece(replace));
+		    } else {
+			    RE2::Replace(&sstring, re, CreateStringPiece(replace));
+		    }
+		    return StringVector::AddString(result, sstring);
+	    });
+}
+
+unique_ptr<FunctionData> RegexpReplaceBindData::Copy() const {
+	auto copy = make_unique<RegexpReplaceBindData>();
+	copy->options = options;
+	copy->global_replace = global_replace;
+	return move(copy);
+}
+
+bool RegexpReplaceBindData::Equals(const FunctionData &other_p) const {
+	auto &other = (const RegexpReplaceBindData &)other_p;
+	return global_replace == other.global_replace && RegexOptionsEquals(options, other.options);
+}
+
+static unique_ptr<FunctionData> RegexReplaceBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	auto data = make_unique<RegexpReplaceBindData>();
+	data->options.set_log_errors(false);
+	if (arguments.size() == 4) {
+		if (!arguments[3]->IsFoldable()) {
+			throw InvalidInputException("Regex options field must be a constant");
+		}
+		Value options_str = ExpressionExecutor::EvaluateScalar(*arguments[3]);
+		if (!options_str.IsNull() && options_str.type().id() == LogicalTypeId::VARCHAR) {
+			ParseRegexOptions(StringValue::Get(options_str), data->options, &data->global_replace);
+		}
+	}
+
+	return move(data);
+}
+
+inline static string_t Extract(const string_t &input, Vector &result, const RE2 &re,
+                               const duckdb_re2::StringPiece &rewrite) {
+	std::string extracted;
+	RE2::Extract(input.GetString(), re, rewrite, &extracted);
+	return StringVector::AddString(result, extracted.c_str(), extracted.size());
+}
+
+static void RegexExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	const auto &info = (RegexpExtractBindData &)*func_expr.bind_info;
+
+	auto &strings = args.data[0];
+	auto &patterns = args.data[1];
+	if (info.constant_pattern) {
+		auto &lstate = (RegexLocalState &)*ExecuteFunctionState::GetFunctionState(state);
+		UnaryExecutor::Execute<string_t, string_t>(strings, result, args.size(), [&](string_t input) {
+			return Extract(input, result, lstate.constant_pattern, info.rewrite);
+		});
+	} else {
+		BinaryExecutor::Execute<string_t, string_t, string_t>(strings, patterns, result, args.size(),
+		                                                      [&](string_t input, string_t pattern) {
+			                                                      RE2 re(CreateStringPiece(pattern));
+			                                                      return Extract(input, result, re, info.rewrite);
+		                                                      });
+	}
+}
+
+static unique_ptr<FunctionLocalState> RegexExtractInitLocalState(const BoundFunctionExpression &expr,
+                                                                 FunctionData *bind_data) {
+	auto &info = (RegexpExtractBindData &)*bind_data;
+	if (info.constant_pattern) {
+		return make_unique<RegexLocalState>(info);
+	}
+	return nullptr;
+}
+
+RegexpExtractBindData::RegexpExtractBindData(bool constant_pattern, const string &constant_string,
+                                             const string &group_string_p)
+    : constant_pattern(constant_pattern), constant_string(constant_string), group_string(group_string_p),
+      rewrite(group_string) {
+}
+
+unique_ptr<FunctionData> RegexpExtractBindData::Copy() const {
+	return make_unique<RegexpExtractBindData>(constant_pattern, constant_string, group_string);
+}
+
+bool RegexpExtractBindData::Equals(const FunctionData &other_p) const {
+	auto &other = (const RegexpExtractBindData &)other_p;
+	return constant_string == other.constant_string && group_string == other.group_string;
+}
+
+static unique_ptr<FunctionData> RegexExtractBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(arguments.size() >= 2);
+
+	bool constant_pattern = arguments[1]->IsFoldable();
+	string pattern = "";
+	if (constant_pattern) {
+		Value pattern_str = ExpressionExecutor::EvaluateScalar(*arguments[1]);
+		if (!pattern_str.IsNull() && pattern_str.type().id() == LogicalTypeId::VARCHAR) {
+			pattern = StringValue::Get(pattern_str);
+		}
+	}
+
+	string group_string = "";
+	if (arguments.size() == 3) {
+		if (!arguments[2]->IsFoldable()) {
+			throw InvalidInputException("Group index field field must be a constant!");
+		}
+		Value group = ExpressionExecutor::EvaluateScalar(*arguments[2]);
+		if (!group.IsNull()) {
+			auto group_idx = group.GetValue<int32_t>();
+			if (group_idx < 0 || group_idx > 9) {
+				throw InvalidInputException("Group index must be between 0 and 9!");
+			}
+			group_string = "\\" + to_string(group_idx);
+		}
+	} else {
+		group_string = "\\0";
+	}
+
+	return make_unique<RegexpExtractBindData>(constant_pattern, pattern, group_string);
+}
+
+void RegexpFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet regexp_full_match("regexp_full_match");
+	regexp_full_match.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                                             RegexpMatchesFunction<RegexFullMatch>, false, false, RegexpMatchesBind,
+	                                             nullptr, nullptr, RegexInitLocalState));
+	regexp_full_match.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                             LogicalType::BOOLEAN, RegexpMatchesFunction<RegexFullMatch>, false,
+	                                             false, RegexpMatchesBind, nullptr, nullptr, RegexInitLocalState));
+
+	ScalarFunctionSet regexp_partial_match("regexp_matches");
+	regexp_partial_match.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                                                RegexpMatchesFunction<RegexPartialMatch>, false, false,
+	                                                RegexpMatchesBind, nullptr, nullptr, RegexInitLocalState));
+	regexp_partial_match.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                                LogicalType::BOOLEAN, RegexpMatchesFunction<RegexPartialMatch>,
+	                                                false, false, RegexpMatchesBind, nullptr, nullptr,
+	                                                RegexInitLocalState));
+
+	ScalarFunctionSet regexp_replace("regexp_replace");
+	regexp_replace.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                          LogicalType::VARCHAR, RegexReplaceFunction, false, false,
+	                                          RegexReplaceBind));
+	regexp_replace.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                   LogicalType::VARCHAR, RegexReplaceFunction, false, false, RegexReplaceBind));
+
+	ScalarFunctionSet regexp_extract("regexp_extract");
+	regexp_extract.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                          RegexExtractFunction, false, false, RegexExtractBind, nullptr, nullptr,
+	                                          RegexExtractInitLocalState));
+	regexp_extract.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER},
+	                                          LogicalType::VARCHAR, RegexExtractFunction, false, false,
+	                                          RegexExtractBind, nullptr, nullptr, RegexExtractInitLocalState));
+
+	set.AddFunction(regexp_full_match);
+	set.AddFunction(regexp_partial_match);
+	set.AddFunction(regexp_replace);
+	set.AddFunction(regexp_extract);
+}
+
+} // namespace duckdb
+
+
+
+
+
+#include <string.h>
+#include <ctype.h>
+
+namespace duckdb {
+
+static string_t RepeatScalarFunction(const string_t &str, const int64_t cnt, vector<char> &result) {
+	// Get information about the repeated string
+	auto input_str = str.GetDataUnsafe();
+	auto size_str = str.GetSize();
+
+	//  Reuse the buffer
+	result.clear();
+	for (auto remaining = cnt; remaining-- > 0;) {
+		result.insert(result.end(), input_str, input_str + size_str);
+	}
+
+	return string_t(result.data(), result.size());
+}
+
+static void RepeatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &str_vector = args.data[0];
+	auto &cnt_vector = args.data[1];
+
+	vector<char> buffer;
+	BinaryExecutor::Execute<string_t, int64_t, string_t>(
+	    str_vector, cnt_vector, result, args.size(), [&](string_t str, int64_t cnt) {
+		    return StringVector::AddString(result, RepeatScalarFunction(str, cnt, buffer));
+	    });
+}
+
+void RepeatFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("repeat",                                    // name of the function
+	                               {LogicalType::VARCHAR, LogicalType::BIGINT}, // argument list
+	                               LogicalType::VARCHAR,                        // return type
+	                               RepeatFunction));                            // pointer to function implementation
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#include <string.h>
+#include <ctype.h>
+#include <unordered_map>
+
+namespace duckdb {
+
+static idx_t NextNeedle(const char *input_haystack, idx_t size_haystack, const char *input_needle,
+                        const idx_t size_needle) {
+	// Needle needs something to proceed
+	if (size_needle > 0) {
+		// Haystack should be bigger or equal size to the needle
+		for (idx_t string_position = 0; (size_haystack - string_position) >= size_needle; ++string_position) {
+			// Compare Needle to the Haystack
+			if ((memcmp(input_haystack + string_position, input_needle, size_needle) == 0)) {
+				return string_position;
+			}
+		}
+	}
+	// Did not find the needle
+	return size_haystack;
+}
+
+static string_t ReplaceScalarFunction(const string_t &haystack, const string_t &needle, const string_t &thread,
+                                      vector<char> &result) {
+	// Get information about the needle, the haystack and the "thread"
+	auto input_haystack = haystack.GetDataUnsafe();
+	auto size_haystack = haystack.GetSize();
+
+	auto input_needle = needle.GetDataUnsafe();
+	auto size_needle = needle.GetSize();
+
+	auto input_thread = thread.GetDataUnsafe();
+	auto size_thread = thread.GetSize();
+
+	//  Reuse the buffer
+	result.clear();
+
+	for (;;) {
+		//  Append the non-matching characters
+		auto string_position = NextNeedle(input_haystack, size_haystack, input_needle, size_needle);
+		result.insert(result.end(), input_haystack, input_haystack + string_position);
+		input_haystack += string_position;
+		size_haystack -= string_position;
+
+		//  Stop when we have read the entire haystack
+		if (size_haystack == 0) {
+			break;
+		}
+
+		//  Replace the matching characters
+		result.insert(result.end(), input_thread, input_thread + size_thread);
+		input_haystack += size_needle;
+		size_haystack -= size_needle;
+	}
+
+	return string_t(result.data(), result.size());
+}
+
+static void ReplaceFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &haystack_vector = args.data[0];
+	auto &needle_vector = args.data[1];
+	auto &thread_vector = args.data[2];
+
+	vector<char> buffer;
+	TernaryExecutor::Execute<string_t, string_t, string_t, string_t>(
+	    haystack_vector, needle_vector, thread_vector, result, args.size(),
+	    [&](string_t input_string, string_t needle_string, string_t thread_string) {
+		    return StringVector::AddString(result,
+		                                   ReplaceScalarFunction(input_string, needle_string, thread_string, buffer));
+	    });
+}
+
+void ReplaceFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("replace",             // name of the function
+	                               {LogicalType::VARCHAR, // argument list
+	                                LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                               LogicalType::VARCHAR, // return type
+	                               ReplaceFunction));    // pointer to function implementation
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <string.h>
+
+namespace duckdb {
+
+//! Fast ASCII string reverse, returns false if the input data is not ascii
+static bool StrReverseASCII(const char *input, idx_t n, char *output) {
+	for (idx_t i = 0; i < n; i++) {
+		if (input[i] & 0x80) {
+			// non-ascii character
+			return false;
+		}
+		output[n - i - 1] = input[i];
+	}
+	return true;
+}
+
+//! Unicode string reverse using grapheme breakers
+static void StrReverseUnicode(const char *input, idx_t n, char *output) {
+	utf8proc_grapheme_callback(input, n, [&](size_t start, size_t end) {
+		memcpy(output + n - end, input + start, end - start);
+		return true;
+	});
+}
+
+struct ReverseOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
+		auto input_data = input.GetDataUnsafe();
+		auto input_length = input.GetSize();
+
+		auto target = StringVector::EmptyString(result, input_length);
+		auto target_data = target.GetDataWriteable();
+		if (!StrReverseASCII(input_data, input_length, target_data)) {
+			StrReverseUnicode(input_data, input_length, target_data);
+		}
+		target.Finalize();
+		return target;
+	}
+};
+
+static void ReverseFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnaryExecutor::ExecuteString<string_t, string_t, ReverseOperator>(args.data[0], result, args.size());
+}
+
+void ReverseFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ScalarFunction("reverse", {LogicalType::VARCHAR}, LogicalType::VARCHAR, ReverseFunction));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct StringSplitIterator {
+public:
+	explicit StringSplitIterator(idx_t size) : size(size) {
+	}
+	virtual ~StringSplitIterator() {
+	}
+
+	idx_t size;
+
+public:
+	virtual idx_t Next(const char *input) = 0;
+	bool HasNext() {
+		return offset < size;
+	}
+	idx_t Start() {
+		return start;
+	}
+
+protected:
+	idx_t start = 0;  // end of last place a delim match was found
+	idx_t offset = 0; // current position
+};
+
+struct AsciiStringSplitIterator : virtual public StringSplitIterator {
+public:
+	AsciiStringSplitIterator(size_t size, const char *delim, const size_t delim_size)
+	    : StringSplitIterator(size), delim(delim), delim_size(delim_size) {
+	}
+	idx_t Next(const char *input) override {
+		// special case: separate by empty delimiter
+		if (delim_size == 0) {
+			offset++;
+			start = offset;
+			return offset;
+		}
+		for (offset = start; HasNext(); offset++) {
+			// potential delimiter match
+			if (input[offset] == delim[0] && offset + delim_size <= size) {
+				idx_t i;
+				for (i = 1; i < delim_size; i++) {
+					if (input[offset + i] != delim[i]) {
+						break;
+					}
+				}
+				// delimiter found: skip start over delimiter
+				if (i == delim_size) {
+					start = offset + delim_size;
+					return offset;
+				}
+			}
+		}
+		return offset;
+	}
+
+protected:
+	const char *delim;
+	size_t delim_size;
+};
+
+struct UnicodeStringSplitIterator : virtual public StringSplitIterator {
+public:
+	UnicodeStringSplitIterator(size_t input_size, const char *delim, const size_t delim_size)
+	    : StringSplitIterator(input_size), delim_size(delim_size) {
+		int cp_sz;
+		for (idx_t i = 0; i < delim_size; i += cp_sz) {
+			delim_cps.push_back(utf8proc_codepoint(delim, cp_sz));
+		}
+	}
+	idx_t Next(const char *input) override {
+		// special case: separate by empty delimiter
+		if (delim_size == 0) {
+			offset = utf8proc_next_grapheme(input, size, offset);
+			start = offset;
+			return offset;
+		}
+		int cp_sz;
+		for (offset = start; HasNext(); offset = utf8proc_next_grapheme(input, size, offset)) {
+			// potential delimiter match
+			if (utf8proc_codepoint(&input[offset], cp_sz) == delim_cps[0] && offset + delim_size <= size) {
+				idx_t delim_offset = cp_sz;
+				for (idx_t i = 1; i < delim_cps.size(); i++) {
+					if (utf8proc_codepoint(&input[offset + delim_offset], cp_sz) != delim_cps[i]) {
+						break;
+					}
+					delim_offset += cp_sz;
+				}
+				// delimiter found: skip start over delimiter
+				if (delim_offset == delim_size) {
+					start = offset + delim_size;
+					return offset;
+				}
+			}
+		}
+		return offset;
+	}
+
+protected:
+	vector<utf8proc_int32_t> delim_cps;
+	size_t delim_size;
+};
+
+struct RegexStringSplitIterator : virtual public StringSplitIterator {
+public:
+	RegexStringSplitIterator(size_t input_size, unique_ptr<RE2> re, const bool ascii_only)
+	    : StringSplitIterator(input_size), re(move(re)), ascii_only(ascii_only) {
+	}
+	idx_t Next(const char *input) override {
+		duckdb_re2::StringPiece input_sp(input, size);
+		duckdb_re2::StringPiece match;
+		if (re->Match(input_sp, start, size, RE2::UNANCHORED, &match, 1)) {
+			offset = match.data() - input;
+			// special case: 0 length match
+			if (match.empty() && start < size) {
+				if (ascii_only) {
+					offset++;
+				} else {
+					offset = utf8proc_next_grapheme(input, size, offset);
+				}
+				start = offset;
+			} else {
+				start = offset + match.size();
+			}
+		} else {
+			offset = size;
+		}
+		return offset;
+	}
+
+protected:
+	unique_ptr<RE2> re;
+	bool ascii_only;
+};
+
+void BaseStringSplitFunction(const char *input, StringSplitIterator &iter, Vector &result) {
+	// special case: empty string
+	if (iter.size == 0) {
+		Value val = StringVector::AddString(ListVector::GetEntry(result), &input[0], 0);
+		ListVector::PushBack(result, val);
+		return;
+	}
+	while (iter.HasNext()) {
+		idx_t start = iter.Start();
+		idx_t end = iter.Next(input);
+		size_t length = end - start;
+		Value to_insert(StringVector::AddString(ListVector::GetEntry(result), &input[start], length));
+		ListVector::PushBack(result, to_insert);
+	}
+}
+
+unique_ptr<Vector> BaseStringSplitFunction(string_t input, string_t delim, const bool regex) {
+	const char *input_data = input.GetDataUnsafe();
+	size_t input_size = input.GetSize();
+	const char *delim_data = delim.GetDataUnsafe();
+	size_t delim_size = delim.GetSize();
+
+	bool ascii_only = Utf8Proc::Analyze(input_data, input_size) == UnicodeType::ASCII;
+
+	auto list_type = LogicalType::LIST(LogicalType::VARCHAR);
+	auto output = make_unique<Vector>(list_type);
+	unique_ptr<StringSplitIterator> iter;
+	if (regex) {
+		auto re = make_unique<RE2>(duckdb_re2::StringPiece(delim_data, delim_size));
+		if (!re->ok()) {
+			throw Exception(re->error());
+		}
+		iter = make_unique_base<StringSplitIterator, RegexStringSplitIterator>(input_size, move(re), ascii_only);
+	} else if (ascii_only) {
+		iter = make_unique_base<StringSplitIterator, AsciiStringSplitIterator>(input_size, delim_data, delim_size);
+	} else {
+		iter = make_unique_base<StringSplitIterator, UnicodeStringSplitIterator>(input_size, delim_data, delim_size);
+	}
+	BaseStringSplitFunction(input_data, *iter, *output);
+
+	return output;
+}
+
+static void StringSplitExecutor(DataChunk &args, ExpressionState &state, Vector &result, const bool regex) {
+	VectorData input_data;
+	args.data[0].Orrify(args.size(), input_data);
+	auto inputs = (string_t *)input_data.data;
+
+	VectorData delim_data;
+	args.data[1].Orrify(args.size(), delim_data);
+	auto delims = (string_t *)delim_data.data;
+
+	D_ASSERT(result.GetType().id() == LogicalTypeId::LIST);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	ListVector::SetListSize(result, 0);
+
+	auto list_struct_data = FlatVector::GetData<list_entry_t>(result);
+	auto list_vector_type = LogicalType::LIST(LogicalType::VARCHAR);
+
+	idx_t total_len = 0;
+	auto &result_mask = FlatVector::Validity(result);
+	for (idx_t i = 0; i < args.size(); i++) {
+		auto input_idx = input_data.sel->get_index(i);
+		auto delim_idx = delim_data.sel->get_index(i);
+		if (!input_data.validity.RowIsValid(input_idx)) {
+			result_mask.SetInvalid(i);
+			continue;
+		}
+		string_t input = inputs[input_idx];
+
+		unique_ptr<Vector> split_input;
+		if (!delim_data.validity.RowIsValid(delim_idx)) {
+			// special case: delimiter is NULL
+			split_input = make_unique<Vector>(list_vector_type);
+			Value val(input);
+			ListVector::PushBack(*split_input, val);
+		} else {
+			string_t delim = delims[delim_idx];
+			split_input = BaseStringSplitFunction(input, delim, regex);
+		}
+		list_struct_data[i].length = ListVector::GetListSize(*split_input);
+		list_struct_data[i].offset = total_len;
+		total_len += ListVector::GetListSize(*split_input);
+		ListVector::Append(result, ListVector::GetEntry(*split_input), ListVector::GetListSize(*split_input));
+	}
+
+	D_ASSERT(ListVector::GetListSize(result) == total_len);
+	if (args.data[0].GetVectorType() == VectorType::CONSTANT_VECTOR &&
+	    args.data[1].GetVectorType() == VectorType::CONSTANT_VECTOR) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+static void StringSplitFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	StringSplitExecutor(args, state, result, false);
+}
+
+static void StringSplitRegexFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	StringSplitExecutor(args, state, result, true);
+}
+
+void StringSplitFun::RegisterFunction(BuiltinFunctions &set) {
+	auto varchar_list_type = LogicalType::LIST(LogicalType::VARCHAR);
+
+	set.AddFunction(
+	    {"string_split", "str_split", "string_to_array", "split"},
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, varchar_list_type, StringSplitFunction));
+	set.AddFunction(
+	    {"string_split_regex", "str_split_regex", "regexp_split_to_array"},
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, varchar_list_type, StringSplitRegexFunction));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+bool StripAccentsFun::IsAscii(const char *input, idx_t n) {
+	for (idx_t i = 0; i < n; i++) {
+		if (input[i] & 0x80) {
+			// non-ascii character
+			return false;
+		}
+	}
+	return true;
+}
+
+struct StripAccentsOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
+		if (StripAccentsFun::IsAscii(input.GetDataUnsafe(), input.GetSize())) {
+			return input;
+		}
+
+		// non-ascii, perform collation
+		auto stripped = utf8proc_remove_accents((const utf8proc_uint8_t *)input.GetDataUnsafe(), input.GetSize());
+		auto result_str = StringVector::AddString(result, (const char *)stripped);
+		free(stripped);
+		return result_str;
+	}
+};
+
+static void StripAccentsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 1);
+
+	UnaryExecutor::ExecuteString<string_t, string_t, StripAccentsOperator>(args.data[0], result, args.size());
+	StringVector::AddHeapReference(result, args.data[0]);
+}
+
+ScalarFunction StripAccentsFun::GetFunction() {
+	return ScalarFunction("strip_accents", {LogicalType::VARCHAR}, LogicalType::VARCHAR, StripAccentsFunction);
+}
+
+void StripAccentsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(StripAccentsFun::GetFunction());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+string_t SubstringEmptyString(Vector &result) {
+	auto result_string = StringVector::EmptyString(result, 0);
+	result_string.Finalize();
+	return result_string;
+}
+
+string_t SubstringSlice(Vector &result, const char *input_data, int64_t offset, int64_t length) {
+	auto result_string = StringVector::EmptyString(result, length);
+	auto result_data = result_string.GetDataWriteable();
+	memcpy(result_data, input_data + offset, length);
+	result_string.Finalize();
+	return result_string;
+}
+
+// compute start and end characters from the given input size and offset/length
+bool SubstringStartEnd(int64_t input_size, int64_t offset, int64_t length, int64_t &start, int64_t &end) {
+	if (length == 0) {
+		return false;
+	}
+	if (offset > 0) {
+		// positive offset: scan from start
+		start = MinValue<int64_t>(input_size, offset - 1);
+	} else if (offset < 0) {
+		// negative offset: scan from end (i.e. start = end + offset)
+		start = MaxValue<int64_t>(input_size + offset, 0);
+	} else {
+		// offset = 0: special case, we start 1 character BEHIND the first character
+		start = 0;
+		length--;
+		if (length <= 0) {
+			return false;
+		}
+	}
+	if (length > 0) {
+		// positive length: go forward (i.e. end = start + offset)
+		end = MinValue<int64_t>(input_size, start + length);
+	} else {
+		// negative length: go backwards (i.e. end = start, start = start + length)
+		end = start;
+		start = MaxValue<int64_t>(0, end + length);
+	}
+	if (start == end) {
+		return false;
+	}
+	D_ASSERT(start < end);
+	return true;
+}
+
+string_t SubstringASCII(Vector &result, string_t input, int64_t offset, int64_t length) {
+	auto input_data = input.GetDataUnsafe();
+	auto input_size = input.GetSize();
+
+	int64_t start, end;
+	if (!SubstringStartEnd(input_size, offset, length, start, end)) {
+		return SubstringEmptyString(result);
+	}
+	return SubstringSlice(result, input_data, start, end - start);
+}
+
+string_t SubstringFun::SubstringScalarFunction(Vector &result, string_t input, int64_t offset, int64_t length) {
+	auto input_data = input.GetDataUnsafe();
+	auto input_size = input.GetSize();
+
+	// we don't know yet if the substring is ascii, but we assume it is (for now)
+	// first get the start and end as if this was an ascii string
+	int64_t start, end;
+	if (!SubstringStartEnd(input_size, offset, length, start, end)) {
+		return SubstringEmptyString(result);
+	}
+
+	// now check if all the characters between 0 and end are ascii characters
+	// note that we scan one further to check for a potential combining diacritics (e.g. i + diacritic is ï)
+	bool is_ascii = true;
+	idx_t ascii_end = MinValue<idx_t>(end + 1, input_size);
+	for (idx_t i = 0; i < ascii_end; i++) {
+		if (input_data[i] & 0x80) {
+			// found a non-ascii character: eek
+			is_ascii = false;
+			break;
+		}
+	}
+	if (is_ascii) {
+		// all characters are ascii, we can just slice the substring
+		return SubstringSlice(result, input_data, start, end - start);
+	}
+	// if the characters are not ascii, we need to scan grapheme clusters
+	// first figure out which direction we need to scan
+	// offset = 0 case is taken care of in SubstringStartEnd
+	if (offset < 0) {
+		// negative offset, this case is more difficult
+		// we first need to count the number of characters in the string
+		idx_t num_characters = 0;
+		utf8proc_grapheme_callback(input_data, input_size, [&](size_t start, size_t end) {
+			num_characters++;
+			return true;
+		});
+		// now call substring start and end again, but with the number of unicode characters this time
+		SubstringStartEnd(num_characters, offset, length, start, end);
+	}
+
+	// now scan the graphemes of the string to find the positions of the start and end characters
+	int64_t current_character = 0;
+	idx_t start_pos = DConstants::INVALID_INDEX, end_pos = input_size;
+	utf8proc_grapheme_callback(input_data, input_size, [&](size_t gstart, size_t gend) {
+		if (current_character == start) {
+			start_pos = gstart;
+		} else if (current_character == end) {
+			end_pos = gstart;
+			return false;
+		}
+		current_character++;
+		return true;
+	});
+	if (start_pos == DConstants::INVALID_INDEX) {
+		return SubstringEmptyString(result);
+	}
+	// after we have found these, we can slice the substring
+	return SubstringSlice(result, input_data, start_pos, end_pos - start_pos);
+}
+
+static void SubstringFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &input_vector = args.data[0];
+	auto &offset_vector = args.data[1];
+	if (args.ColumnCount() == 3) {
+		auto &length_vector = args.data[2];
+
+		TernaryExecutor::Execute<string_t, int64_t, int64_t, string_t>(
+		    input_vector, offset_vector, length_vector, result, args.size(),
+		    [&](string_t input_string, int64_t offset, int64_t length) {
+			    return SubstringFun::SubstringScalarFunction(result, input_string, offset, length);
+		    });
+	} else {
+		BinaryExecutor::Execute<string_t, int64_t, string_t>(
+		    input_vector, offset_vector, result, args.size(), [&](string_t input_string, int64_t offset) {
+			    return SubstringFun::SubstringScalarFunction(result, input_string, offset,
+			                                                 NumericLimits<int64_t>::Maximum() - offset);
+		    });
+	}
+}
+
+static void SubstringFunctionASCII(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &input_vector = args.data[0];
+	auto &offset_vector = args.data[1];
+	if (args.ColumnCount() == 3) {
+		auto &length_vector = args.data[2];
+
+		TernaryExecutor::Execute<string_t, int64_t, int64_t, string_t>(
+		    input_vector, offset_vector, length_vector, result, args.size(),
+		    [&](string_t input_string, int64_t offset, int64_t length) {
+			    return SubstringASCII(result, input_string, offset, length);
+		    });
+	} else {
+		BinaryExecutor::Execute<string_t, int64_t, string_t>(
+		    input_vector, offset_vector, result, args.size(), [&](string_t input_string, int64_t offset) {
+			    return SubstringASCII(result, input_string, offset, NumericLimits<int64_t>::Maximum() - offset);
+		    });
+	}
+}
+
+static unique_ptr<BaseStatistics> SubstringPropagateStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	// can only propagate stats if the children have stats
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	// we only care about the stats of the first child (i.e. the string)
+	auto &sstats = (StringStatistics &)*child_stats[0];
+	if (!sstats.has_unicode) {
+		expr.function.function = SubstringFunctionASCII;
+	}
+	return nullptr;
+}
+
+void SubstringFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet substr("substring");
+	substr.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BIGINT, LogicalType::BIGINT},
+	                                  LogicalType::VARCHAR, SubstringFunction, false, false, nullptr, nullptr,
+	                                  SubstringPropagateStats));
+	substr.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::BIGINT}, LogicalType::VARCHAR,
+	                                  SubstringFunction, false, false, nullptr, nullptr, SubstringPropagateStats));
+	set.AddFunction(substr);
+	substr.name = "substr";
+	set.AddFunction(substr);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+static bool SuffixFunction(const string_t &str, const string_t &suffix);
+
+struct SuffixOperator {
+	template <class TA, class TB, class TR>
+	static inline TR Operation(TA left, TB right) {
+		return SuffixFunction(left, right);
+	}
+};
+
+static bool SuffixFunction(const string_t &str, const string_t &suffix) {
+	auto suffix_size = suffix.GetSize();
+	auto str_size = str.GetSize();
+	if (suffix_size > str_size) {
+		return false;
+	}
+
+	auto suffix_data = suffix.GetDataUnsafe();
+	auto str_data = str.GetDataUnsafe();
+	int32_t suf_idx = suffix_size - 1;
+	idx_t str_idx = str_size - 1;
+	for (; suf_idx >= 0; --suf_idx, --str_idx) {
+		if (suffix_data[suf_idx] != str_data[str_idx]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+ScalarFunction SuffixFun::GetFunction() {
+	return ScalarFunction("suffix",                                     // name of the function
+	                      {LogicalType::VARCHAR, LogicalType::VARCHAR}, // argument list
+	                      LogicalType::BOOLEAN,                         // return type
+	                      ScalarFunction::BinaryFunction<string_t, string_t, bool, SuffixOperator>);
+}
+
+void SuffixFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(GetFunction());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <string.h>
+
+namespace duckdb {
+
+template <bool LTRIM, bool RTRIM>
+struct TrimOperator {
+	template <class INPUT_TYPE, class RESULT_TYPE>
+	static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
+		auto data = input.GetDataUnsafe();
+		auto size = input.GetSize();
+
+		utf8proc_int32_t codepoint;
+		auto str = reinterpret_cast<const utf8proc_uint8_t *>(data);
+
+		// Find the first character that is not left trimmed
+		idx_t begin = 0;
+		if (LTRIM) {
+			while (begin < size) {
+				auto bytes = utf8proc_iterate(str + begin, size - begin, &codepoint);
+				D_ASSERT(bytes > 0);
+				if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
+					break;
+				}
+				begin += bytes;
+			}
+		}
+
+		// Find the last character that is not right trimmed
+		idx_t end;
+		if (RTRIM) {
+			end = begin;
+			for (auto next = begin; next < size;) {
+				auto bytes = utf8proc_iterate(str + next, size - next, &codepoint);
+				D_ASSERT(bytes > 0);
+				next += bytes;
+				if (utf8proc_category(codepoint) != UTF8PROC_CATEGORY_ZS) {
+					end = next;
+				}
+			}
+		} else {
+			end = size;
+		}
+
+		// Copy the trimmed string
+		auto target = StringVector::EmptyString(result, end - begin);
+		auto output = target.GetDataWriteable();
+		memcpy(output, data + begin, end - begin);
+
+		target.Finalize();
+		return target;
+	}
+};
+
+template <bool LTRIM, bool RTRIM>
+static void UnaryTrimFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnaryExecutor::ExecuteString<string_t, string_t, TrimOperator<LTRIM, RTRIM>>(args.data[0], result, args.size());
+}
+
+static void GetIgnoredCodepoints(string_t ignored, unordered_set<utf8proc_int32_t> &ignored_codepoints) {
+	auto dataptr = (utf8proc_uint8_t *)ignored.GetDataUnsafe();
+	auto size = ignored.GetSize();
+	idx_t pos = 0;
+	while (pos < size) {
+		utf8proc_int32_t codepoint;
+		pos += utf8proc_iterate(dataptr + pos, size - pos, &codepoint);
+		ignored_codepoints.insert(codepoint);
+	}
+}
+
+template <bool LTRIM, bool RTRIM>
+static void BinaryTrimFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	BinaryExecutor::Execute<string_t, string_t, string_t>(
+	    input.data[0], input.data[1], result, input.size(), [&](string_t input, string_t ignored) {
+		    auto data = input.GetDataUnsafe();
+		    auto size = input.GetSize();
+
+		    unordered_set<utf8proc_int32_t> ignored_codepoints;
+		    GetIgnoredCodepoints(ignored, ignored_codepoints);
+
+		    utf8proc_int32_t codepoint;
+		    auto str = reinterpret_cast<const utf8proc_uint8_t *>(data);
+
+		    // Find the first character that is not left trimmed
+		    idx_t begin = 0;
+		    if (LTRIM) {
+			    while (begin < size) {
+				    auto bytes = utf8proc_iterate(str + begin, size - begin, &codepoint);
+				    if (ignored_codepoints.find(codepoint) == ignored_codepoints.end()) {
+					    break;
+				    }
+				    begin += bytes;
+			    }
+		    }
+
+		    // Find the last character that is not right trimmed
+		    idx_t end;
+		    if (RTRIM) {
+			    end = begin;
+			    for (auto next = begin; next < size;) {
+				    auto bytes = utf8proc_iterate(str + next, size - next, &codepoint);
+				    D_ASSERT(bytes > 0);
+				    next += bytes;
+				    if (ignored_codepoints.find(codepoint) == ignored_codepoints.end()) {
+					    end = next;
+				    }
+			    }
+		    } else {
+			    end = size;
+		    }
+
+		    // Copy the trimmed string
+		    auto target = StringVector::EmptyString(result, end - begin);
+		    auto output = target.GetDataWriteable();
+		    memcpy(output, data + begin, end - begin);
+
+		    target.Finalize();
+		    return target;
+	    });
+}
+
+void TrimFun::RegisterFunction(BuiltinFunctions &set) {
+	ScalarFunctionSet ltrim("ltrim");
+	ScalarFunctionSet rtrim("rtrim");
+	ScalarFunctionSet trim("trim");
+
+	ltrim.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, UnaryTrimFunction<true, false>));
+	rtrim.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, UnaryTrimFunction<false, true>));
+	trim.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, UnaryTrimFunction<true, true>));
+
+	ltrim.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                 BinaryTrimFunction<true, false>));
+	rtrim.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                 BinaryTrimFunction<false, true>));
+	trim.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                BinaryTrimFunction<true, true>));
+
+	set.AddFunction(ltrim);
+	set.AddFunction(rtrim);
+	set.AddFunction(trim);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterStringFunctions() {
+	Register<ReverseFun>();
+	Register<LowerFun>();
+	Register<UpperFun>();
+	Register<StripAccentsFun>();
+	Register<ConcatFun>();
+	Register<ContainsFun>();
+	Register<LengthFun>();
+	Register<LikeFun>();
+	Register<LikeEscapeFun>();
+	Register<LpadFun>();
+	Register<LeftFun>();
+	Register<MD5Fun>();
+	Register<RightFun>();
+	Register<PrintfFun>();
+	Register<RegexpFun>();
+	Register<SubstringFun>();
+	Register<InstrFun>();
+	Register<PrefixFun>();
+	Register<RepeatFun>();
+	Register<ReplaceFun>();
+	Register<RpadFun>();
+	Register<SuffixFun>();
+	Register<TrimFun>();
+	Register<UnicodeFun>();
+	Register<NFCNormalizeFun>();
+	Register<StringSplitFun>();
+	Register<ASCII>();
+	Register<CHR>();
+	Register<MismatchesFun>();
+	Register<LevenshteinFun>();
+	Register<JaccardFun>();
+
+	// blob functions
+	Register<Base64Fun>();
+	Register<EncodeFun>();
+
+	// uuid functions
+	Register<UUIDFun>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct StructExtractBindData : public FunctionData {
+	StructExtractBindData(string key, idx_t index, LogicalType type) : key(move(key)), index(index), type(move(type)) {
+	}
+
+	string key;
+	idx_t index;
+	LogicalType type;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<StructExtractBindData>(key, index, type);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const StructExtractBindData &)other_p;
+		return key == other.key && index == other.index && type == other.type;
+	}
+};
+
+static void StructExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (StructExtractBindData &)*func_expr.bind_info;
+
+	// this should be guaranteed by the binder
+	auto &vec = args.data[0];
+
+	vec.Verify(args.size());
+	auto &children = StructVector::GetEntries(vec);
+	D_ASSERT(info.index < children.size());
+	auto &struct_child = children[info.index];
+	result.Reference(*struct_child);
+	result.Verify(args.size());
+}
+
+static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, ScalarFunction &bound_function,
+                                                  vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(bound_function.arguments.size() == 2);
+	if (arguments[0]->return_type.id() == LogicalTypeId::SQLNULL ||
+	    arguments[1]->return_type.id() == LogicalTypeId::SQLNULL) {
+		bound_function.return_type = LogicalType::SQLNULL;
+		bound_function.arguments[0] = LogicalType::SQLNULL;
+		return make_unique<StructExtractBindData>("", 0, LogicalType::SQLNULL);
+	}
+	D_ASSERT(LogicalTypeId::STRUCT == arguments[0]->return_type.id());
+	auto &struct_children = StructType::GetChildTypes(arguments[0]->return_type);
+	if (struct_children.empty()) {
+		throw InternalException("Can't extract something from an empty struct");
+	}
+
+	auto &key_child = arguments[1];
+
+	if (key_child->return_type.id() != LogicalTypeId::VARCHAR ||
+	    key_child->return_type.id() != LogicalTypeId::VARCHAR || !key_child->IsFoldable()) {
+		throw BinderException("Key name for struct_extract needs to be a constant string");
+	}
+	Value key_val = ExpressionExecutor::EvaluateScalar(*key_child.get());
+	D_ASSERT(key_val.type().id() == LogicalTypeId::VARCHAR);
+	auto &key_str = StringValue::Get(key_val);
+	if (key_val.IsNull() || key_str.empty()) {
+		throw BinderException("Key name for struct_extract needs to be neither NULL nor empty");
+	}
+	string key = StringUtil::Lower(key_str);
+
+	LogicalType return_type;
+	idx_t key_index = 0;
+	bool found_key = false;
+
+	for (size_t i = 0; i < struct_children.size(); i++) {
+		auto &child = struct_children[i];
+		if (StringUtil::Lower(child.first) == key) {
+			found_key = true;
+			key_index = i;
+			return_type = child.second;
+			break;
+		}
+	}
+
+	if (!found_key) {
+		vector<string> candidates;
+		candidates.reserve(struct_children.size());
+		for (auto &struct_child : struct_children) {
+			candidates.push_back(struct_child.first);
+		}
+		auto closest_settings = StringUtil::TopNLevenshtein(candidates, key);
+		auto message = StringUtil::CandidatesMessage(closest_settings, "Candidate Entries");
+		throw BinderException("Could not find key \"%s\" in struct\n%s", key, message);
+	}
+
+	bound_function.return_type = return_type;
+	bound_function.arguments[0] = arguments[0]->return_type;
+	return make_unique<StructExtractBindData>(key, key_index, return_type);
+}
+
+static unique_ptr<BaseStatistics> PropagateStructExtractStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &bind_data = input.bind_data;
+	if (!child_stats[0]) {
+		return nullptr;
+	}
+	auto &struct_stats = (StructStatistics &)*child_stats[0];
+	auto &info = (StructExtractBindData &)*bind_data;
+	if (info.index >= struct_stats.child_stats.size() || !struct_stats.child_stats[info.index]) {
+		return nullptr;
+	}
+	return struct_stats.child_stats[info.index]->Copy();
+}
+
+ScalarFunction StructExtractFun::GetFunction() {
+	return ScalarFunction("struct_extract", {LogicalTypeId::STRUCT, LogicalType::VARCHAR}, LogicalType::ANY,
+	                      StructExtractFunction, false, StructExtractBind, nullptr, PropagateStructExtractStats);
+}
+
+void StructExtractFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	auto fun = GetFunction();
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void StructInsertFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &starting_vec = args.data[0];
+
+	starting_vec.Verify(args.size());
+
+	auto &starting_child_entries = StructVector::GetEntries(starting_vec);
+
+	auto &result_child_entries = StructVector::GetEntries(result);
+
+	// Assign the starting vector entries to the result vector
+	for (size_t i = 0; i < starting_child_entries.size(); i++) {
+		auto &starting_child = starting_child_entries[i];
+		result_child_entries[i]->Reference(*starting_child);
+	}
+
+	// Assign the new entries to the result vector
+	for (size_t i = 1; i < args.ColumnCount(); i++) {
+		result_child_entries[starting_child_entries.size() + i - 1]->Reference(args.data[i]);
+	}
+
+	result.Verify(args.size());
+}
+
+static unique_ptr<FunctionData> StructInsertBind(ClientContext &context, ScalarFunction &bound_function,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	case_insensitive_set_t name_collision_set;
+
+	if (arguments.empty()) {
+		throw Exception("Missing required arguments for struct_insert function.");
+	}
+
+	if (LogicalTypeId::STRUCT != arguments[0]->return_type.id()) {
+		throw Exception("The first argument to struct_insert must be a STRUCT");
+	}
+
+	if (arguments.size() < 2) {
+		throw Exception("Can't insert nothing into a struct");
+	}
+
+	child_list_t<LogicalType> new_struct_children;
+
+	auto &existing_struct_children = StructType::GetChildTypes(arguments[0]->return_type);
+
+	for (size_t i = 0; i < existing_struct_children.size(); i++) {
+		auto &child = existing_struct_children[i];
+		name_collision_set.insert(child.first);
+		new_struct_children.push_back(make_pair(child.first, child.second));
+	}
+
+	// Loop through the additional arguments (name/value pairs)
+	for (idx_t i = 1; i < arguments.size(); i++) {
+		auto &child = arguments[i];
+		if (child->alias.empty() && bound_function.name == "struct_insert") {
+			throw BinderException("Need named argument for struct insert, e.g. STRUCT_PACK(a := b)");
+		}
+		if (name_collision_set.find(child->alias) != name_collision_set.end()) {
+			throw BinderException("Duplicate struct entry name \"%s\"", child->alias);
+		}
+		name_collision_set.insert(child->alias);
+		new_struct_children.push_back(make_pair(child->alias, arguments[i]->return_type));
+	}
+
+	// this is more for completeness reasons
+	bound_function.return_type = LogicalType::STRUCT(move(new_struct_children));
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+unique_ptr<BaseStatistics> StructInsertStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+
+	auto &existing_struct_stats = (StructStatistics &)*child_stats[0];
+	auto new_struct_stats = make_unique<StructStatistics>(expr.return_type);
+
+	for (idx_t i = 0; i < existing_struct_stats.child_stats.size(); i++) {
+		new_struct_stats->child_stats[i] =
+		    existing_struct_stats.child_stats[i] ? existing_struct_stats.child_stats[i]->Copy() : nullptr;
+	}
+
+	auto offset = new_struct_stats->child_stats.size() - child_stats.size();
+	for (idx_t i = 1; i < child_stats.size(); i++) {
+		new_struct_stats->child_stats[offset + i] = child_stats[i] ? child_stats[i]->Copy() : nullptr;
+	}
+	return move(new_struct_stats);
+}
+
+void StructInsertFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	ScalarFunction fun("struct_insert", {}, LogicalTypeId::STRUCT, StructInsertFunction, false, StructInsertBind,
+	                   nullptr, StructInsertStats);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void StructPackFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+#ifdef DEBUG
+	auto &func_expr = (BoundFunctionExpression &)state.expr;
+	auto &info = (VariableReturnBindData &)*func_expr.bind_info;
+	// this should never happen if the binder below is sane
+	D_ASSERT(args.ColumnCount() == StructType::GetChildTypes(info.stype).size());
+#endif
+	bool all_const = true;
+	auto &child_entries = StructVector::GetEntries(result);
+	for (size_t i = 0; i < args.ColumnCount(); i++) {
+		if (args.data[i].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			all_const = false;
+		}
+		// same holds for this
+		child_entries[i]->Reference(args.data[i]);
+	}
+	result.SetVectorType(all_const ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR);
+
+	result.Verify(args.size());
+}
+
+static unique_ptr<FunctionData> StructPackBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	case_insensitive_set_t name_collision_set;
+
+	// collect names and deconflict, construct return type
+	if (arguments.empty()) {
+		throw Exception("Can't pack nothing into a struct");
+	}
+	child_list_t<LogicalType> struct_children;
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		auto &child = arguments[i];
+		if (child->alias.empty() && bound_function.name == "struct_pack") {
+			throw BinderException("Need named argument for struct pack, e.g. STRUCT_PACK(a := b)");
+		}
+		if (child->alias.empty() && bound_function.name == "row") {
+			child->alias = "v" + std::to_string(i + 1);
+		}
+		if (name_collision_set.find(child->alias) != name_collision_set.end()) {
+			throw BinderException("Duplicate struct entry name \"%s\"", child->alias);
+		}
+		name_collision_set.insert(child->alias);
+		struct_children.push_back(make_pair(child->alias, arguments[i]->return_type));
+	}
+
+	// this is more for completeness reasons
+	bound_function.return_type = LogicalType::STRUCT(move(struct_children));
+	return make_unique<VariableReturnBindData>(bound_function.return_type);
+}
+
+unique_ptr<BaseStatistics> StructPackStats(ClientContext &context, FunctionStatisticsInput &input) {
+	auto &child_stats = input.child_stats;
+	auto &expr = input.expr;
+	auto struct_stats = make_unique<StructStatistics>(expr.return_type);
+	D_ASSERT(child_stats.size() == struct_stats->child_stats.size());
+	for (idx_t i = 0; i < struct_stats->child_stats.size(); i++) {
+		struct_stats->child_stats[i] = child_stats[i] ? child_stats[i]->Copy() : nullptr;
+	}
+	return move(struct_stats);
+}
+
+void StructPackFun::RegisterFunction(BuiltinFunctions &set) {
+	// the arguments and return types are actually set in the binder function
+	ScalarFunction fun("struct_pack", {}, LogicalTypeId::STRUCT, StructPackFunction, false, StructPackBind, nullptr,
+	                   StructPackStats);
+	fun.varargs = LogicalType::ANY;
+	set.AddFunction(fun);
+	fun.name = "row";
+	set.AddFunction(fun);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+// aggregate state export
+struct ExportAggregateBindData : public FunctionData {
+	AggregateFunction &aggr;
+	idx_t state_size;
+
+	explicit ExportAggregateBindData(AggregateFunction &aggr_p, idx_t state_size_p)
+	    : aggr(aggr_p), state_size(state_size_p) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<ExportAggregateBindData>(aggr, state_size);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const ExportAggregateBindData &)other_p;
+		return aggr == other.aggr && state_size == other.state_size;
+	}
+
+	static ExportAggregateBindData &GetFrom(ExpressionState &state) {
+		auto &func_expr = (BoundFunctionExpression &)state.expr;
+		return (ExportAggregateBindData &)*func_expr.bind_info;
+	}
+};
+
+struct CombineState : public FunctionLocalState {
+	idx_t state_size;
+
+	unique_ptr<data_t[]> state_buffer0, state_buffer1;
+	Vector state_vector0, state_vector1;
+
+	explicit CombineState(idx_t state_size_p)
+	    : state_size(state_size_p), state_buffer0(unique_ptr<data_t[]>(new data_t[state_size_p])),
+	      state_buffer1(unique_ptr<data_t[]>(new data_t[state_size_p])),
+	      state_vector0(Value::POINTER((uintptr_t)state_buffer0.get())),
+	      state_vector1(Value::POINTER((uintptr_t)state_buffer1.get())) {
+	}
+};
+
+static unique_ptr<FunctionLocalState> InitCombineState(const BoundFunctionExpression &expr, FunctionData *bind_data_p) {
+	auto &bind_data = *(ExportAggregateBindData *)bind_data_p;
+	return make_unique<CombineState>(bind_data.state_size);
+}
+
+struct FinalizeState : public FunctionLocalState {
+	idx_t state_size;
+	unique_ptr<data_t[]> state_buffer;
+	Vector addresses;
+
+	explicit FinalizeState(idx_t state_size_p)
+	    : state_size(state_size_p),
+	      state_buffer(unique_ptr<data_t[]>(new data_t[STANDARD_VECTOR_SIZE * AlignValue(state_size_p)])),
+	      addresses(LogicalType::POINTER) {
+	}
+};
+
+static unique_ptr<FunctionLocalState> InitFinalizeState(const BoundFunctionExpression &expr,
+                                                        FunctionData *bind_data_p) {
+	auto &bind_data = *(ExportAggregateBindData *)bind_data_p;
+	return make_unique<FinalizeState>(bind_data.state_size);
+}
+
+static void AggregateStateFinalize(DataChunk &input, ExpressionState &state_p, Vector &result) {
+	auto &bind_data = ExportAggregateBindData::GetFrom(state_p);
+	auto &local_state = (FinalizeState &)*((ExecuteFunctionState &)state_p).local_state;
+
+	D_ASSERT(bind_data.state_size == bind_data.aggr.state_size());
+	D_ASSERT(input.data.size() == 1);
+	D_ASSERT(input.data[0].GetType().id() == LogicalTypeId::AGGREGATE_STATE);
+	auto aligned_state_size = AlignValue(bind_data.state_size);
+
+	auto state_vec_ptr = FlatVector::GetData<data_ptr_t>(local_state.addresses);
+
+	VectorData state_data;
+	input.data[0].Orrify(input.size(), state_data);
+	for (idx_t i = 0; i < input.size(); i++) {
+		auto state_idx = state_data.sel->get_index(i);
+		auto state_entry = &((string_t *)state_data.data)[state_idx];
+		auto target_ptr = (const char *)local_state.state_buffer.get() + aligned_state_size * i;
+
+		if (state_data.validity.RowIsValid(state_idx)) {
+			D_ASSERT(state_entry->GetSize() == bind_data.state_size);
+			memcpy((void *)target_ptr, state_entry->GetDataUnsafe(), bind_data.state_size);
+		} else {
+			// create a dummy state because finalize does not understand NULLs in its input
+			// we put the NULL back in explicitly below
+			bind_data.aggr.initialize((data_ptr_t)target_ptr);
+		}
+		state_vec_ptr[i] = (data_ptr_t)target_ptr;
+	}
+
+	AggregateInputData aggr_input_data(nullptr);
+	bind_data.aggr.finalize(local_state.addresses, aggr_input_data, result, input.size(), 0);
+
+	for (idx_t i = 0; i < input.size(); i++) {
+		auto state_idx = state_data.sel->get_index(i);
+		if (!state_data.validity.RowIsValid(state_idx)) {
+			FlatVector::SetNull(result, i, true);
+		}
+	}
+}
+
+static void AggregateStateCombine(DataChunk &input, ExpressionState &state_p, Vector &result) {
+	auto &bind_data = ExportAggregateBindData::GetFrom(state_p);
+	auto &local_state = (CombineState &)*((ExecuteFunctionState &)state_p).local_state;
+
+	D_ASSERT(bind_data.state_size == bind_data.aggr.state_size());
+
+	D_ASSERT(input.data.size() == 2);
+	D_ASSERT(input.data[0].GetType().id() == LogicalTypeId::AGGREGATE_STATE);
+	D_ASSERT(input.data[0].GetType() == result.GetType());
+
+	if (input.data[0].GetType().InternalType() != input.data[1].GetType().InternalType()) {
+		throw IOException("Aggregate state combine type mismatch, expect %s, got %s",
+		                  input.data[0].GetType().ToString(), input.data[1].GetType().ToString());
+	}
+
+	VectorData state0_data, state1_data;
+	input.data[0].Orrify(input.size(), state0_data);
+	input.data[1].Orrify(input.size(), state1_data);
+
+	auto result_ptr = FlatVector::GetData<string_t>(result);
+
+	for (idx_t i = 0; i < input.size(); i++) {
+		auto state0_idx = state0_data.sel->get_index(i);
+		auto state1_idx = state1_data.sel->get_index(i);
+
+		auto &state0 = ((string_t *)state0_data.data)[state0_idx];
+		auto &state1 = ((string_t *)state1_data.data)[state1_idx];
+
+		// if both are NULL, we return NULL. If either of them is not, the result is that one
+		if (!state0_data.validity.RowIsValid(state0_idx) && !state1_data.validity.RowIsValid(state1_idx)) {
+			FlatVector::SetNull(result, i, true);
+			continue;
+		}
+		if (state0_data.validity.RowIsValid(state0_idx) && !state1_data.validity.RowIsValid(state1_idx)) {
+			result_ptr[i] =
+			    StringVector::AddStringOrBlob(result, (const char *)state0.GetDataUnsafe(), bind_data.state_size);
+			continue;
+		}
+		if (!state0_data.validity.RowIsValid(state0_idx) && state1_data.validity.RowIsValid(state1_idx)) {
+			result_ptr[i] =
+			    StringVector::AddStringOrBlob(result, (const char *)state1.GetDataUnsafe(), bind_data.state_size);
+			continue;
+		}
+
+		// we actually have to combine
+		if (state0.GetSize() != bind_data.state_size || state1.GetSize() != bind_data.state_size) {
+			throw IOException("Aggregate state size mismatch, expect %llu, got %llu and %llu", bind_data.state_size,
+			                  state0.GetSize(), state1.GetSize());
+		}
+
+		memcpy(local_state.state_buffer0.get(), state0.GetDataUnsafe(), bind_data.state_size);
+		memcpy(local_state.state_buffer1.get(), state1.GetDataUnsafe(), bind_data.state_size);
+
+		AggregateInputData aggr_input_data(nullptr);
+		bind_data.aggr.combine(local_state.state_vector0, local_state.state_vector1, aggr_input_data, 1);
+
+		result_ptr[i] =
+		    StringVector::AddStringOrBlob(result, (const char *)local_state.state_buffer1.get(), bind_data.state_size);
+	}
+}
+
+static unique_ptr<FunctionData> BindAggregateState(ClientContext &context, ScalarFunction &bound_function,
+                                                   vector<unique_ptr<Expression>> &arguments) {
+
+	// grab the aggregate type and bind the aggregate again
+
+	// the aggregate name and types are in the logical type of the aggregate state, make sure its sane
+	auto &arg_return_type = arguments[0]->return_type;
+	for (auto &arg_type : bound_function.arguments) {
+		arg_type = arg_return_type;
+	}
+
+	if (arg_return_type.id() != LogicalTypeId::AGGREGATE_STATE) {
+		throw BinderException("Can only FINALIZE aggregate state, not %s", arg_return_type.ToString());
+	}
+	// combine
+	if (arguments.size() == 2 && arguments[0]->return_type != arguments[1]->return_type &&
+	    arguments[1]->return_type.id() != LogicalTypeId::BLOB) {
+		throw BinderException("Cannot COMBINE aggregate states from different functions, %s <> %s",
+		                      arguments[0]->return_type.ToString(), arguments[1]->return_type.ToString());
+	}
+
+	// following error states are only reachable when someone messes up creating the state_type which is impossible from
+	// SQL
+
+	auto state_type = AggregateStateType::GetStateType(arg_return_type);
+
+	// now we can look up the function in the catalog again and bind it
+	auto func = Catalog::GetCatalog(context).GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, DEFAULT_SCHEMA,
+	                                                  state_type.function_name);
+	if (func->type != CatalogType::AGGREGATE_FUNCTION_ENTRY) {
+		throw InternalException("Could not find aggregate %s", state_type.function_name);
+	}
+	auto aggr = (AggregateFunctionCatalogEntry *)func;
+
+	string error;
+	idx_t best_function = Function::BindFunction(aggr->name, aggr->functions, state_type.bound_argument_types, error);
+	if (best_function == DConstants::INVALID_INDEX) {
+		throw InternalException("Could not re-bind exported aggregate %s: %s", state_type.function_name, error);
+	}
+	auto &bound_aggr = aggr->functions[best_function];
+	if (bound_aggr.return_type != state_type.return_type || bound_aggr.arguments != state_type.bound_argument_types) {
+		throw InternalException("Type mismatch for exported aggregate %s", state_type.function_name);
+	}
+
+	if (bound_function.name == "finalize") {
+		bound_function.return_type = bound_aggr.return_type;
+	} else {
+		D_ASSERT(bound_function.name == "combine");
+		bound_function.return_type = arg_return_type;
+	}
+
+	return make_unique<ExportAggregateBindData>(bound_aggr, bound_aggr.state_size());
+}
+
+static void ExportAggregateFinalize(Vector &state, AggregateInputData &aggr_input_data, Vector &result, idx_t count,
+                                    idx_t offset) {
+	D_ASSERT(offset == 0);
+	auto bind_data = (ExportAggregateFunctionBindData *)aggr_input_data.bind_data;
+	auto state_size = bind_data->aggregate->function.state_size();
+	auto blob_ptr = FlatVector::GetData<string_t>(result);
+	auto addresses_ptr = FlatVector::GetData<data_ptr_t>(state);
+	for (idx_t row_idx = 0; row_idx < count; row_idx++) {
+		auto data_ptr = addresses_ptr[row_idx];
+		blob_ptr[row_idx] = StringVector::AddStringOrBlob(result, (const char *)data_ptr, state_size);
+	}
+}
+
+ExportAggregateFunctionBindData::ExportAggregateFunctionBindData(unique_ptr<Expression> aggregate_p) {
+	D_ASSERT(aggregate_p->type == ExpressionType::BOUND_AGGREGATE);
+	aggregate = unique_ptr<BoundAggregateExpression>((BoundAggregateExpression *)aggregate_p.release());
+}
+
+unique_ptr<FunctionData> ExportAggregateFunctionBindData::Copy() const {
+	return make_unique<ExportAggregateFunctionBindData>(aggregate->Copy());
+}
+
+bool ExportAggregateFunctionBindData::Equals(const FunctionData &other_p) const {
+	auto &other = (const ExportAggregateFunctionBindData &)other_p;
+	return aggregate->Equals(other.aggregate.get());
+}
+
+unique_ptr<BoundAggregateExpression>
+ExportAggregateFunction::Bind(unique_ptr<BoundAggregateExpression> child_aggregate) {
+	auto &bound_function = child_aggregate->function;
+	if (!bound_function.combine) {
+		throw BinderException("Cannot use EXPORT_STATE for non-combinable function %s", bound_function.name);
+	}
+	if (bound_function.bind) {
+		throw BinderException("Cannot use EXPORT_STATE on aggregate functions with custom binders");
+	}
+	if (bound_function.destructor) {
+		throw BinderException("Cannot use EXPORT_STATE on aggregate functions with custom destructors");
+	}
+	// this should be required
+	D_ASSERT(bound_function.state_size);
+	D_ASSERT(bound_function.finalize);
+	D_ASSERT(!bound_function.window);
+
+	D_ASSERT(child_aggregate->function.return_type.id() != LogicalTypeId::INVALID);
+#ifdef DEBUG
+	for (auto &arg_type : child_aggregate->function.arguments) {
+		D_ASSERT(arg_type.id() != LogicalTypeId::INVALID);
+	}
+#endif
+	auto export_bind_data = make_unique<ExportAggregateFunctionBindData>(child_aggregate->Copy());
+	aggregate_state_t state_type(child_aggregate->function.name, child_aggregate->function.return_type,
+	                             child_aggregate->function.arguments);
+	auto return_type = LogicalType::AGGREGATE_STATE(move(state_type));
+
+	auto export_function =
+	    AggregateFunction("aggregate_state_export_" + bound_function.name, bound_function.arguments, return_type,
+	                      bound_function.state_size, bound_function.initialize, bound_function.update,
+	                      bound_function.combine, ExportAggregateFinalize, bound_function.simple_update,
+	                      /* can't bind this again */ nullptr, /* no dynamic state yet */ nullptr,
+	                      /* can't propagate statistics */ nullptr, nullptr);
+
+	return make_unique<BoundAggregateExpression>(export_function, move(child_aggregate->children),
+	                                             move(child_aggregate->filter), move(export_bind_data),
+	                                             child_aggregate->distinct);
+}
+
+ScalarFunction ExportAggregateFunction::GetFinalize() {
+	return ScalarFunction("finalize", {LogicalTypeId::AGGREGATE_STATE}, LogicalTypeId::INVALID, AggregateStateFinalize,
+	                      false, BindAggregateState, nullptr, nullptr, InitFinalizeState);
+}
+
+ScalarFunction ExportAggregateFunction::GetCombine() {
+	return ScalarFunction("combine", {LogicalTypeId::AGGREGATE_STATE, LogicalTypeId::ANY},
+	                      LogicalTypeId::AGGREGATE_STATE, AggregateStateCombine, false, BindAggregateState, nullptr,
+	                      nullptr, InitCombineState);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+// current_query
+struct SystemBindData : public FunctionData {
+	ClientContext &context;
+
+	explicit SystemBindData(ClientContext &context) : context(context) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<SystemBindData>(context);
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return true;
+	}
+
+	static SystemBindData &GetFrom(ExpressionState &state) {
+		auto &func_expr = (BoundFunctionExpression &)state.expr;
+		return (SystemBindData &)*func_expr.bind_info;
+	}
+};
+
+unique_ptr<FunctionData> BindSystemFunction(ClientContext &context, ScalarFunction &bound_function,
+                                            vector<unique_ptr<Expression>> &arguments) {
+	return make_unique<SystemBindData>(context);
+}
+
+static void CurrentQueryFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto &info = SystemBindData::GetFrom(state);
+	Value val(info.context.GetCurrentQuery());
+	result.Reference(val);
+}
+
+// current_schema
+static void CurrentSchemaFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	Value val(ClientData::Get(SystemBindData::GetFrom(state).context).catalog_search_path->GetDefault());
+	result.Reference(val);
+}
+
+// current_schemas
+static void CurrentSchemasFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	vector<Value> schema_list;
+	vector<string> search_path = ClientData::Get(SystemBindData::GetFrom(state).context).catalog_search_path->Get();
+	std::transform(search_path.begin(), search_path.end(), std::back_inserter(schema_list),
+	               [](const string &s) -> Value { return Value(s); });
+	auto val = Value::LIST(schema_list);
+	result.Reference(val);
+}
+
+// txid_current
+static void TransactionIdCurrent(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto &transaction = Transaction::GetTransaction(SystemBindData::GetFrom(state).context);
+	auto val = Value::BIGINT(transaction.start_time);
+	result.Reference(val);
+}
+
+// version
+static void VersionFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	auto val = Value(DuckDB::LibraryVersion());
+	result.Reference(val);
+}
+
+void SystemFun::RegisterFunction(BuiltinFunctions &set) {
+	auto varchar_list_type = LogicalType::LIST(LogicalType::VARCHAR);
+
+	set.AddFunction(
+	    ScalarFunction("current_query", {}, LogicalType::VARCHAR, CurrentQueryFunction, true, BindSystemFunction));
+	set.AddFunction(
+	    ScalarFunction("current_schema", {}, LogicalType::VARCHAR, CurrentSchemaFunction, false, BindSystemFunction));
+	set.AddFunction(ScalarFunction("current_schemas", {LogicalType::BOOLEAN}, varchar_list_type, CurrentSchemasFunction,
+	                               false, BindSystemFunction));
+	set.AddFunction(
+	    ScalarFunction("txid_current", {}, LogicalType::BIGINT, TransactionIdCurrent, false, BindSystemFunction));
+	set.AddFunction(ScalarFunction("version", {}, LogicalType::VARCHAR, VersionFunction));
+	set.AddFunction(ExportAggregateFunction::GetCombine());
+	set.AddFunction(ExportAggregateFunction::GetFinalize());
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterTrigonometricsFunctions() {
+	Register<SinFun>();
+	Register<CosFun>();
+	Register<TanFun>();
+	Register<AsinFun>();
+	Register<AcosFun>();
+	Register<AtanFun>();
+	Register<CotFun>();
+	Register<Atan2Fun>();
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+FunctionLocalState::~FunctionLocalState() {
+}
+
+ScalarFunction::ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
+                               scalar_function_t function, bool has_side_effects, bind_scalar_function_t bind,
+                               dependency_function_t dependency, function_statistics_t statistics,
+                               init_local_state_t init_local_state, LogicalType varargs, bool propagate_null_values)
+    : BaseScalarFunction(move(name), move(arguments), move(return_type), has_side_effects, move(varargs),
+                         propagate_null_values),
+      function(move(function)), bind(bind), init_local_state(init_local_state), dependency(dependency),
+      statistics(statistics) {
+}
+
+ScalarFunction::ScalarFunction(vector<LogicalType> arguments, LogicalType return_type, scalar_function_t function,
+                               bool propagate_null_values, bool has_side_effects, bind_scalar_function_t bind,
+                               dependency_function_t dependency, function_statistics_t statistics,
+                               init_local_state_t init_local_state, LogicalType varargs)
+    : ScalarFunction(string(), move(arguments), move(return_type), move(function), has_side_effects, bind, dependency,
+                     statistics, init_local_state, move(varargs), propagate_null_values) {
+}
+
+bool ScalarFunction::operator==(const ScalarFunction &rhs) const {
+	return CompareScalarFunctionT(rhs.function) && bind == rhs.bind && dependency == rhs.dependency &&
+	       statistics == rhs.statistics;
+}
+bool ScalarFunction::operator!=(const ScalarFunction &rhs) const {
+	return !(*this == rhs);
+}
+
+bool ScalarFunction::Equal(const ScalarFunction &rhs) const {
+	// number of types
+	if (this->arguments.size() != rhs.arguments.size()) {
+		return false;
+	}
+	// argument types
+	for (idx_t i = 0; i < this->arguments.size(); ++i) {
+		if (this->arguments[i] != rhs.arguments[i]) {
+			return false;
+		}
+	}
+	// return type
+	if (this->return_type != rhs.return_type) {
+		return false;
+	}
+	// varargs
+	if (this->varargs != rhs.varargs) {
+		return false;
+	}
+
+	return true; // they are equal
+}
+
+bool ScalarFunction::CompareScalarFunctionT(const scalar_function_t &other) const {
+	typedef void(scalar_function_ptr_t)(DataChunk &, ExpressionState &, Vector &);
+
+	auto func_ptr = (scalar_function_ptr_t **)function.template target<scalar_function_ptr_t *>();
+	auto other_ptr = (scalar_function_ptr_t **)other.template target<scalar_function_ptr_t *>();
+
+	// Case the functions were created from lambdas the target will return a nullptr
+	if (!func_ptr && !other_ptr) {
+		return true;
+	}
+	if (func_ptr == nullptr || other_ptr == nullptr) {
+		// scalar_function_t (std::functions) from lambdas cannot be compared
+		return false;
+	}
+	return ((size_t)*func_ptr == (size_t)*other_ptr);
+}
+
+void ScalarFunction::NopFunction(DataChunk &input, ExpressionState &state, Vector &result) {
+	D_ASSERT(input.ColumnCount() >= 1);
+	result.Reference(input.data[0]);
+}
+
+} // namespace duckdb
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/scalar_macro_function.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+
+
+
+
+namespace duckdb {
+
+ScalarMacroFunction::ScalarMacroFunction(unique_ptr<ParsedExpression> expression)
+    : MacroFunction(MacroType::SCALAR_MACRO), expression(move(expression)) {
+}
+
+ScalarMacroFunction::ScalarMacroFunction(void) : MacroFunction(MacroType::SCALAR_MACRO) {
+}
+
+unique_ptr<MacroFunction> ScalarMacroFunction::Copy() {
+	auto result = make_unique<ScalarMacroFunction>();
+	result->expression = expression->Copy();
+	CopyProperties(*result);
+
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+LogicalType GetArrowLogicalType(ArrowSchema &schema,
+                                std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data,
+                                idx_t col_idx) {
+	auto format = string(schema.format);
+	if (arrow_convert_data.find(col_idx) == arrow_convert_data.end()) {
+		arrow_convert_data[col_idx] = make_unique<ArrowConvertData>();
+	}
+	if (format == "n") {
+		return LogicalType::SQLNULL;
+	} else if (format == "b") {
+		return LogicalType::BOOLEAN;
+	} else if (format == "c") {
+		return LogicalType::TINYINT;
+	} else if (format == "s") {
+		return LogicalType::SMALLINT;
+	} else if (format == "i") {
+		return LogicalType::INTEGER;
+	} else if (format == "l") {
+		return LogicalType::BIGINT;
+	} else if (format == "C") {
+		return LogicalType::UTINYINT;
+	} else if (format == "S") {
+		return LogicalType::USMALLINT;
+	} else if (format == "I") {
+		return LogicalType::UINTEGER;
+	} else if (format == "L") {
+		return LogicalType::UBIGINT;
+	} else if (format == "f") {
+		return LogicalType::FLOAT;
+	} else if (format == "g") {
+		return LogicalType::DOUBLE;
+	} else if (format[0] == 'd') { //! this can be either decimal128 or decimal 256 (e.g., d:38,0)
+		std::string parameters = format.substr(format.find(':'));
+		uint8_t width = std::stoi(parameters.substr(1, parameters.find(',')));
+		uint8_t scale = std::stoi(parameters.substr(parameters.find(',') + 1));
+		if (width > 38) {
+			throw NotImplementedException("Unsupported Internal Arrow Type for Decimal %s", format);
+		}
+		return LogicalType::DECIMAL(width, scale);
+	} else if (format == "u") {
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::NORMAL, 0);
+		return LogicalType::VARCHAR;
+	} else if (format == "U") {
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::SUPER_SIZE, 0);
+		return LogicalType::VARCHAR;
+	} else if (format == "tsn:") {
+		return LogicalTypeId::TIMESTAMP_NS;
+	} else if (format == "tsu:") {
+		return LogicalTypeId::TIMESTAMP;
+	} else if (format == "tsm:") {
+		return LogicalTypeId::TIMESTAMP_MS;
+	} else if (format == "tss:") {
+		return LogicalTypeId::TIMESTAMP_SEC;
+	} else if (format == "tdD") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::DAYS);
+		return LogicalType::DATE;
+	} else if (format == "tdm") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::MILLISECONDS);
+		return LogicalType::DATE;
+	} else if (format == "tts") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::SECONDS);
+		return LogicalType::TIME;
+	} else if (format == "ttm") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::MILLISECONDS);
+		return LogicalType::TIME;
+	} else if (format == "ttu") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::MICROSECONDS);
+		return LogicalType::TIME;
+	} else if (format == "ttn") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::NANOSECONDS);
+		return LogicalType::TIME;
+	} else if (format == "tDs") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::SECONDS);
+		return LogicalType::INTERVAL;
+	} else if (format == "tDm") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::MILLISECONDS);
+		return LogicalType::INTERVAL;
+	} else if (format == "tDu") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::MICROSECONDS);
+		return LogicalType::INTERVAL;
+	} else if (format == "tDn") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::NANOSECONDS);
+		return LogicalType::INTERVAL;
+	} else if (format == "tiD") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::DAYS);
+		return LogicalType::INTERVAL;
+	} else if (format == "tiM") {
+		arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::MONTHS);
+		return LogicalType::INTERVAL;
+	} else if (format == "+l") {
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::NORMAL, 0);
+		auto child_type = GetArrowLogicalType(*schema.children[0], arrow_convert_data, col_idx);
+		return LogicalType::LIST(child_type);
+	} else if (format == "+L") {
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::SUPER_SIZE, 0);
+		auto child_type = GetArrowLogicalType(*schema.children[0], arrow_convert_data, col_idx);
+		return LogicalType::LIST(child_type);
+	} else if (format[0] == '+' && format[1] == 'w') {
+		std::string parameters = format.substr(format.find(':') + 1);
+		idx_t fixed_size = std::stoi(parameters);
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::FIXED_SIZE, fixed_size);
+		auto child_type = GetArrowLogicalType(*schema.children[0], arrow_convert_data, col_idx);
+		return LogicalType::LIST(move(child_type));
+	} else if (format == "+s") {
+		child_list_t<LogicalType> child_types;
+		for (idx_t type_idx = 0; type_idx < (idx_t)schema.n_children; type_idx++) {
+			auto child_type = GetArrowLogicalType(*schema.children[type_idx], arrow_convert_data, col_idx);
+			child_types.push_back({schema.children[type_idx]->name, child_type});
+		}
+		return LogicalType::STRUCT(move(child_types));
+
+	} else if (format == "+m") {
+		child_list_t<LogicalType> child_types;
+		//! First type will be struct, so we skip it
+		auto &struct_schema = *schema.children[0];
+		for (idx_t type_idx = 0; type_idx < (idx_t)struct_schema.n_children; type_idx++) {
+			//! The other types must be added on lists
+			auto child_type = GetArrowLogicalType(*struct_schema.children[type_idx], arrow_convert_data, col_idx);
+
+			auto list_type = LogicalType::LIST(child_type);
+			child_types.push_back({struct_schema.children[type_idx]->name, list_type});
+		}
+		return LogicalType::MAP(move(child_types));
+	} else if (format == "z") {
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::NORMAL, 0);
+		return LogicalType::BLOB;
+	} else if (format == "Z") {
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::SUPER_SIZE, 0);
+		return LogicalType::BLOB;
+	} else if (format[0] == 'w') {
+		std::string parameters = format.substr(format.find(':') + 1);
+		idx_t fixed_size = std::stoi(parameters);
+		arrow_convert_data[col_idx]->variable_sz_type.emplace_back(ArrowVariableSizeType::FIXED_SIZE, fixed_size);
+		return LogicalType::BLOB;
+	} else if (format[0] == 't' && format[1] == 's') {
+		// Timestamp with Timezone
+		if (format[2] == 'n') {
+			arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::NANOSECONDS);
+		} else if (format[2] == 'u') {
+			arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::MICROSECONDS);
+		} else if (format[2] == 'm') {
+			arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::MILLISECONDS);
+		} else if (format[2] == 's') {
+			arrow_convert_data[col_idx]->date_time_precision.emplace_back(ArrowDateTimeType::SECONDS);
+		} else {
+			throw NotImplementedException(" Timestamptz precision of not accepted");
+		}
+		// TODO right now we just get the UTC value. We probably want to support this properly in the future
+		return LogicalType::TIMESTAMP_TZ;
+	} else {
+		throw NotImplementedException("Unsupported Internal Arrow Type %s", format);
+	}
+}
+
+// Renames repeated columns and case sensitive columns
+void RenameArrowColumns(vector<string> &names) {
+	unordered_map<string, idx_t> name_map;
+	for (auto &column_name : names) {
+		// put it all lower_case
+		auto low_column_name = StringUtil::Lower(column_name);
+		if (name_map.find(low_column_name) == name_map.end()) {
+			// Name does not exist yet
+			name_map[low_column_name]++;
+		} else {
+			// Name already exists, we add _x where x is the repetition number
+			string new_column_name = column_name + "_" + std::to_string(name_map[low_column_name]);
+			auto new_column_name_low = StringUtil::Lower(new_column_name);
+			while (name_map.find(new_column_name_low) != name_map.end()) {
+				// This name is already here due to a previous definition
+				name_map[low_column_name]++;
+				new_column_name = column_name + "_" + std::to_string(name_map[low_column_name]);
+				new_column_name_low = StringUtil::Lower(new_column_name);
+			}
+			column_name = new_column_name;
+			name_map[new_column_name_low]++;
+		}
+	}
+}
+
+unique_ptr<FunctionData> ArrowTableFunction::ArrowScanBind(ClientContext &context, TableFunctionBindInput &input,
+                                                           vector<LogicalType> &return_types, vector<string> &names) {
+	auto stream_factory_ptr = input.inputs[0].GetPointer();
+	auto stream_factory_produce = (stream_factory_produce_t)input.inputs[1].GetPointer();
+	auto stream_factory_get_schema = (stream_factory_get_schema_t)input.inputs[2].GetPointer();
+	auto rows_per_thread = input.inputs[3].GetValue<uint64_t>();
+
+	pair<unordered_map<idx_t, string>, vector<string>> project_columns;
+	auto res = make_unique<ArrowScanFunctionData>(rows_per_thread, stream_factory_produce, stream_factory_ptr);
+
+	auto &data = *res;
+	stream_factory_get_schema(stream_factory_ptr, data.schema_root);
+	for (idx_t col_idx = 0; col_idx < (idx_t)data.schema_root.arrow_schema.n_children; col_idx++) {
+		auto &schema = *data.schema_root.arrow_schema.children[col_idx];
+		if (!schema.release) {
+			throw InvalidInputException("arrow_scan: released schema passed");
+		}
+		if (schema.dictionary) {
+			res->arrow_convert_data[col_idx] =
+			    make_unique<ArrowConvertData>(GetArrowLogicalType(schema, res->arrow_convert_data, col_idx));
+			return_types.emplace_back(GetArrowLogicalType(*schema.dictionary, res->arrow_convert_data, col_idx));
+		} else {
+			return_types.emplace_back(GetArrowLogicalType(schema, res->arrow_convert_data, col_idx));
+		}
+		auto format = string(schema.format);
+		auto name = string(schema.name);
+		if (name.empty()) {
+			name = string("v") + to_string(col_idx);
+		}
+		names.push_back(name);
+	}
+	RenameArrowColumns(names);
+	return move(res);
+}
+
+unique_ptr<ArrowArrayStreamWrapper> ProduceArrowScan(const ArrowScanFunctionData &function,
+                                                     const vector<column_t> &column_ids, TableFilterSet *filters) {
+	//! Generate Projection Pushdown Vector
+	pair<unordered_map<idx_t, string>, vector<string>> project_columns;
+	D_ASSERT(!column_ids.empty());
+	for (idx_t idx = 0; idx < column_ids.size(); idx++) {
+		auto col_idx = column_ids[idx];
+		if (col_idx != COLUMN_IDENTIFIER_ROW_ID) {
+			auto &schema = *function.schema_root.arrow_schema.children[col_idx];
+			project_columns.first[idx] = schema.name;
+			project_columns.second.emplace_back(schema.name);
+		}
+	}
+	return function.scanner_producer(function.stream_factory_ptr, project_columns, filters);
+}
+
+idx_t ArrowTableFunction::ArrowScanMaxThreads(ClientContext &context, const FunctionData *bind_data_p) {
+	auto &bind_data = (const ArrowScanFunctionData &)*bind_data_p;
+	if (bind_data.number_of_rows <= 0 || ClientConfig::GetConfig(context).verify_parallelism) {
+		return context.db->NumberOfThreads();
+	}
+	return ((bind_data.number_of_rows + bind_data.rows_per_thread - 1) / bind_data.rows_per_thread) + 1;
+}
+
+bool ArrowScanParallelStateNext(ClientContext &context, const FunctionData *bind_data_p, ArrowScanLocalState &state,
+                                ArrowScanGlobalState &parallel_state) {
+	lock_guard<mutex> parallel_lock(parallel_state.main_mutex);
+	state.chunk_offset = 0;
+
+	auto current_chunk = parallel_state.stream->GetNextChunk();
+	while (current_chunk->arrow_array.length == 0 && current_chunk->arrow_array.release) {
+		current_chunk = parallel_state.stream->GetNextChunk();
+	}
+	state.chunk = move(current_chunk);
+	//! have we run out of chunks? we are done
+	if (!state.chunk->arrow_array.release) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<GlobalTableFunctionState> ArrowTableFunction::ArrowScanInitGlobal(ClientContext &context,
+                                                                             TableFunctionInitInput &input) {
+	auto &bind_data = (const ArrowScanFunctionData &)*input.bind_data;
+	auto result = make_unique<ArrowScanGlobalState>();
+	result->stream = ProduceArrowScan(bind_data, input.column_ids, input.filters);
+	result->max_threads = ArrowScanMaxThreads(context, input.bind_data);
+	return move(result);
+}
+
+unique_ptr<LocalTableFunctionState> ArrowTableFunction::ArrowScanInitLocal(ClientContext &context,
+                                                                           TableFunctionInitInput &input,
+                                                                           GlobalTableFunctionState *global_state_p) {
+	auto &global_state = (ArrowScanGlobalState &)*global_state_p;
+	auto current_chunk = make_unique<ArrowArrayWrapper>();
+	auto result = make_unique<ArrowScanLocalState>(move(current_chunk));
+	result->column_ids = input.column_ids;
+	result->filters = input.filters;
+	if (!ArrowScanParallelStateNext(context, input.bind_data, *result, global_state)) {
+		return nullptr;
+	}
+	return move(result);
+}
+
+void ArrowTableFunction::ArrowScanFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	if (!data_p.local_state) {
+		return;
+	}
+	auto &data = (ArrowScanFunctionData &)*data_p.bind_data;
+	auto &state = (ArrowScanLocalState &)*data_p.local_state;
+	auto &global_state = (ArrowScanGlobalState &)*data_p.global_state;
+
+	//! Out of tuples in this chunk
+	if (state.chunk_offset >= (idx_t)state.chunk->arrow_array.length) {
+		if (!ArrowScanParallelStateNext(context, data_p.bind_data, state, global_state)) {
+			return;
+		}
+	}
+	int64_t output_size = MinValue<int64_t>(STANDARD_VECTOR_SIZE, state.chunk->arrow_array.length - state.chunk_offset);
+	data.lines_read += output_size;
+	output.SetCardinality(output_size);
+	ArrowToDuckDB(state, data.arrow_convert_data, output, data.lines_read - output_size);
+	output.Verify();
+	state.chunk_offset += output.size();
+}
+
+unique_ptr<NodeStatistics> ArrowTableFunction::ArrowScanCardinality(ClientContext &context, const FunctionData *data) {
+	auto &bind_data = (ArrowScanFunctionData &)*data;
+	return make_unique<NodeStatistics>(bind_data.number_of_rows, bind_data.number_of_rows);
+}
+
+double ArrowTableFunction::ArrowProgress(ClientContext &context, const FunctionData *bind_data_p,
+                                         const GlobalTableFunctionState *global_state) {
+	auto &bind_data = (const ArrowScanFunctionData &)*bind_data_p;
+	if (bind_data.number_of_rows == 0) {
+		return 100;
+	}
+	auto percentage = bind_data.lines_read * 100.0 / bind_data.number_of_rows;
+	return percentage;
+}
+
+void ArrowTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	TableFunction arrow("arrow_scan",
+	                    {LogicalType::POINTER, LogicalType::POINTER, LogicalType::POINTER, LogicalType::UBIGINT},
+	                    ArrowScanFunction, ArrowScanBind, ArrowScanInitGlobal, ArrowScanInitLocal);
+	arrow.cardinality = ArrowScanCardinality;
+	arrow.projection_pushdown = true;
+	arrow.filter_pushdown = true;
+	arrow.table_scan_progress = ArrowProgress;
+	set.AddFunction(arrow);
+}
+
+void BuiltinFunctions::RegisterArrowFunctions() {
+	ArrowTableFunction::RegisterFunction(*this);
+}
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+void ShiftRight(unsigned char *ar, int size, int shift) {
+	int carry = 0;
+	while (shift--) {
+		for (int i = size - 1; i >= 0; --i) {
+			int next = (ar[i] & 1) ? 0x80 : 0;
+			ar[i] = carry | (ar[i] >> 1);
+			carry = next;
+		}
+	}
+}
+
+void SetValidityMask(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, idx_t size,
+                     int64_t nested_offset, bool add_null = false) {
+	auto &mask = FlatVector::Validity(vector);
+	if (array.null_count != 0 && array.buffers[0]) {
+		D_ASSERT(vector.GetVectorType() == VectorType::FLAT_VECTOR);
+		auto bit_offset = scan_state.chunk_offset + array.offset;
+		if (nested_offset != -1) {
+			bit_offset = nested_offset;
+		}
+		auto n_bitmask_bytes = (size + 8 - 1) / 8;
+		mask.EnsureWritable();
+		if (bit_offset % 8 == 0) {
+			//! just memcpy nullmask
+			memcpy((void *)mask.GetData(), (uint8_t *)array.buffers[0] + bit_offset / 8, n_bitmask_bytes);
+		} else {
+			//! need to re-align nullmask
+			std::vector<uint8_t> temp_nullmask(n_bitmask_bytes + 1);
+			memcpy(temp_nullmask.data(), (uint8_t *)array.buffers[0] + bit_offset / 8, n_bitmask_bytes + 1);
+			ShiftRight(temp_nullmask.data(), n_bitmask_bytes + 1,
+			           bit_offset % 8); //! why this has to be a right shift is a mystery to me
+			memcpy((void *)mask.GetData(), (data_ptr_t)temp_nullmask.data(), n_bitmask_bytes);
+		}
+	}
+	if (add_null) {
+		//! We are setting a validity mask of the data part of dictionary vector
+		//! For some reason, Nulls are allowed to be indexes, hence we need to set the last element here to be null
+		//! We might have to resize the mask
+		mask.Resize(size, size + 1);
+		mask.SetInvalid(size);
+	}
+}
+
+void GetValidityMask(ValidityMask &mask, ArrowArray &array, ArrowScanLocalState &scan_state, idx_t size) {
+	if (array.null_count != 0 && array.buffers[0]) {
+		auto bit_offset = scan_state.chunk_offset + array.offset;
+		auto n_bitmask_bytes = (size + 8 - 1) / 8;
+		mask.EnsureWritable();
+		if (bit_offset % 8 == 0) {
+			//! just memcpy nullmask
+			memcpy((void *)mask.GetData(), (uint8_t *)array.buffers[0] + bit_offset / 8, n_bitmask_bytes);
+		} else {
+			//! need to re-align nullmask
+			std::vector<uint8_t> temp_nullmask(n_bitmask_bytes + 1);
+			memcpy(temp_nullmask.data(), (uint8_t *)array.buffers[0] + bit_offset / 8, n_bitmask_bytes + 1);
+			ShiftRight(temp_nullmask.data(), n_bitmask_bytes + 1,
+			           bit_offset % 8); //! why this has to be a right shift is a mystery to me
+			memcpy((void *)mask.GetData(), (data_ptr_t)temp_nullmask.data(), n_bitmask_bytes);
+		}
+	}
+}
+
+void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, idx_t size,
+                         std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data, idx_t col_idx,
+                         std::pair<idx_t, idx_t> &arrow_convert_idx, int64_t nested_offset = -1,
+                         ValidityMask *parent_mask = nullptr);
+
+void ArrowToDuckDBList(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, idx_t size,
+                       std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data, idx_t col_idx,
+                       std::pair<idx_t, idx_t> &arrow_convert_idx, int64_t nested_offset, ValidityMask *parent_mask) {
+	auto original_type = arrow_convert_data[col_idx]->variable_sz_type[arrow_convert_idx.first++];
+	idx_t list_size = 0;
+	SetValidityMask(vector, array, scan_state, size, nested_offset);
+	idx_t start_offset = 0;
+	idx_t cur_offset = 0;
+	if (original_type.first == ArrowVariableSizeType::FIXED_SIZE) {
+		//! Have to check validity mask before setting this up
+		idx_t offset = (scan_state.chunk_offset + array.offset) * original_type.second;
+		if (nested_offset != -1) {
+			offset = original_type.second * nested_offset;
+		}
+		start_offset = offset;
+		auto list_data = FlatVector::GetData<list_entry_t>(vector);
+		for (idx_t i = 0; i < size; i++) {
+			auto &le = list_data[i];
+			le.offset = cur_offset;
+			le.length = original_type.second;
+			cur_offset += original_type.second;
+		}
+		list_size = cur_offset;
+	} else if (original_type.first == ArrowVariableSizeType::NORMAL) {
+		auto offsets = (uint32_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
+		if (nested_offset != -1) {
+			offsets = (uint32_t *)array.buffers[1] + nested_offset;
+		}
+		start_offset = offsets[0];
+		auto list_data = FlatVector::GetData<list_entry_t>(vector);
+		for (idx_t i = 0; i < size; i++) {
+			auto &le = list_data[i];
+			le.offset = cur_offset;
+			le.length = offsets[i + 1] - offsets[i];
+			cur_offset += le.length;
+		}
+		list_size = offsets[size];
+	} else {
+		auto offsets = (uint64_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
+		if (nested_offset != -1) {
+			offsets = (uint64_t *)array.buffers[1] + nested_offset;
+		}
+		start_offset = offsets[0];
+		auto list_data = FlatVector::GetData<list_entry_t>(vector);
+		for (idx_t i = 0; i < size; i++) {
+			auto &le = list_data[i];
+			le.offset = cur_offset;
+			le.length = offsets[i + 1] - offsets[i];
+			cur_offset += le.length;
+		}
+		list_size = offsets[size];
+	}
+	list_size -= start_offset;
+	ListVector::Reserve(vector, list_size);
+	ListVector::SetListSize(vector, list_size);
+	auto &child_vector = ListVector::GetEntry(vector);
+	SetValidityMask(child_vector, *array.children[0], scan_state, list_size, start_offset);
+	auto &list_mask = FlatVector::Validity(vector);
+	if (parent_mask) {
+		//! Since this List is owned by a struct we must guarantee their validity map matches on Null
+		if (!parent_mask->AllValid()) {
+			for (idx_t i = 0; i < size; i++) {
+				if (!parent_mask->RowIsValid(i)) {
+					list_mask.SetInvalid(i);
+				}
+			}
+		}
+	}
+	if (list_size == 0 && start_offset == 0) {
+		ColumnArrowToDuckDB(child_vector, *array.children[0], scan_state, list_size, arrow_convert_data, col_idx,
+		                    arrow_convert_idx, -1);
+	} else {
+		ColumnArrowToDuckDB(child_vector, *array.children[0], scan_state, list_size, arrow_convert_data, col_idx,
+		                    arrow_convert_idx, start_offset);
+	}
+}
+
+void ArrowToDuckDBBlob(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, idx_t size,
+                       std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data, idx_t col_idx,
+                       std::pair<idx_t, idx_t> &arrow_convert_idx, int64_t nested_offset) {
+	auto original_type = arrow_convert_data[col_idx]->variable_sz_type[arrow_convert_idx.first++];
+	SetValidityMask(vector, array, scan_state, size, nested_offset);
+	if (original_type.first == ArrowVariableSizeType::FIXED_SIZE) {
+		//! Have to check validity mask before setting this up
+		idx_t offset = (scan_state.chunk_offset + array.offset) * original_type.second;
+		if (nested_offset != -1) {
+			offset = original_type.second * nested_offset;
+		}
+		auto cdata = (char *)array.buffers[1];
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			if (FlatVector::IsNull(vector, row_idx)) {
+				continue;
+			}
+			auto bptr = cdata + offset;
+			auto blob_len = original_type.second;
+			FlatVector::GetData<string_t>(vector)[row_idx] = StringVector::AddStringOrBlob(vector, bptr, blob_len);
+			offset += blob_len;
+		}
+	} else if (original_type.first == ArrowVariableSizeType::NORMAL) {
+		auto offsets = (uint32_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
+		if (nested_offset != -1) {
+			offsets = (uint32_t *)array.buffers[1] + array.offset + nested_offset;
+		}
+		auto cdata = (char *)array.buffers[2];
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			if (FlatVector::IsNull(vector, row_idx)) {
+				continue;
+			}
+			auto bptr = cdata + offsets[row_idx];
+			auto blob_len = offsets[row_idx + 1] - offsets[row_idx];
+			FlatVector::GetData<string_t>(vector)[row_idx] = StringVector::AddStringOrBlob(vector, bptr, blob_len);
+		}
+	} else {
+		//! Check if last offset is higher than max uint32
+		if (((uint64_t *)array.buffers[1])[array.length] > NumericLimits<uint32_t>::Maximum()) { // LCOV_EXCL_START
+			throw std::runtime_error("DuckDB does not support Blobs over 4GB");
+		} // LCOV_EXCL_STOP
+		auto offsets = (uint64_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
+		if (nested_offset != -1) {
+			offsets = (uint64_t *)array.buffers[1] + array.offset + nested_offset;
+		}
+		auto cdata = (char *)array.buffers[2];
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			if (FlatVector::IsNull(vector, row_idx)) {
+				continue;
+			}
+			auto bptr = cdata + offsets[row_idx];
+			auto blob_len = offsets[row_idx + 1] - offsets[row_idx];
+			FlatVector::GetData<string_t>(vector)[row_idx] = StringVector::AddStringOrBlob(vector, bptr, blob_len);
+		}
+	}
+}
+
+void ArrowToDuckDBMapVerify(Vector &vector, idx_t count) {
+	auto valid_check = CheckMapValidity(vector, count);
+	switch (valid_check) {
+	case MapInvalidReason::VALID:
+		break;
+	case MapInvalidReason::DUPLICATE_KEY: {
+		throw InvalidInputException("Arrow map contains duplicate key, which isn't supported by DuckDB map type");
+	}
+	case MapInvalidReason::NULL_KEY: {
+		throw InvalidInputException("Arrow map contains NULL as map key, which isn't supported by DuckDB map type");
+	}
+	case MapInvalidReason::NULL_KEY_LIST: {
+		throw InvalidInputException("Arrow map contains NULL as key list, which isn't supported by DuckDB map type");
+	}
+	default: {
+		throw InternalException("MapInvalidReason not implemented");
+	}
+	}
+}
+
+void ArrowToDuckDBMapList(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, idx_t size,
+                          unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data, idx_t col_idx,
+                          pair<idx_t, idx_t> &arrow_convert_idx, uint32_t *offsets, ValidityMask *parent_mask) {
+	idx_t list_size = offsets[size] - offsets[0];
+	ListVector::Reserve(vector, list_size);
+
+	auto &child_vector = ListVector::GetEntry(vector);
+	auto list_data = FlatVector::GetData<list_entry_t>(vector);
+	auto cur_offset = 0;
+	for (idx_t i = 0; i < size; i++) {
+		auto &le = list_data[i];
+		le.offset = cur_offset;
+		le.length = offsets[i + 1] - offsets[i];
+		cur_offset += le.length;
+	}
+	ListVector::SetListSize(vector, list_size);
+	if (list_size == 0 && offsets[0] == 0) {
+		SetValidityMask(child_vector, array, scan_state, list_size, -1);
+	} else {
+		SetValidityMask(child_vector, array, scan_state, list_size, offsets[0]);
+	}
+
+	auto &list_mask = FlatVector::Validity(vector);
+	if (parent_mask) {
+		//! Since this List is owned by a struct we must guarantee their validity map matches on Null
+		if (!parent_mask->AllValid()) {
+			for (idx_t i = 0; i < size; i++) {
+				if (!parent_mask->RowIsValid(i)) {
+					list_mask.SetInvalid(i);
+				}
+			}
+		}
+	}
+	if (list_size == 0 && offsets[0] == 0) {
+		ColumnArrowToDuckDB(child_vector, array, scan_state, list_size, arrow_convert_data, col_idx, arrow_convert_idx,
+		                    -1);
+	} else {
+		ColumnArrowToDuckDB(child_vector, array, scan_state, list_size, arrow_convert_data, col_idx, arrow_convert_idx,
+		                    offsets[0]);
+	}
+}
+template <class T>
+static void SetVectorString(Vector &vector, idx_t size, char *cdata, T *offsets) {
+	auto strings = FlatVector::GetData<string_t>(vector);
+	for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+		if (FlatVector::IsNull(vector, row_idx)) {
+			continue;
+		}
+		auto cptr = cdata + offsets[row_idx];
+		auto str_len = offsets[row_idx + 1] - offsets[row_idx];
+		strings[row_idx] = string_t(cptr, str_len);
+	}
+}
+
+void DirectConversion(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, int64_t nested_offset) {
+	auto internal_type = GetTypeIdSize(vector.GetType().InternalType());
+	auto data_ptr = (data_ptr_t)array.buffers[1] + internal_type * (scan_state.chunk_offset + array.offset);
+	if (nested_offset != -1) {
+		data_ptr = (data_ptr_t)array.buffers[1] + internal_type * (array.offset + nested_offset);
+	}
+	FlatVector::SetData(vector, data_ptr);
+}
+
+template <class T>
+void TimeConversion(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, int64_t nested_offset,
+                    idx_t size, int64_t conversion) {
+	auto tgt_ptr = (dtime_t *)FlatVector::GetData(vector);
+	auto &validity_mask = FlatVector::Validity(vector);
+	auto src_ptr = (T *)array.buffers[1] + scan_state.chunk_offset + array.offset;
+	if (nested_offset != -1) {
+		src_ptr = (T *)array.buffers[1] + nested_offset + array.offset;
+	}
+	for (idx_t row = 0; row < size; row++) {
+		if (!validity_mask.RowIsValid(row)) {
+			continue;
+		}
+		if (!TryMultiplyOperator::Operation((int64_t)src_ptr[row], conversion, tgt_ptr[row].micros)) {
+			throw ConversionException("Could not convert Time to Microsecond");
+		}
+	}
+}
+
+void TimestampTZConversion(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, int64_t nested_offset,
+                           idx_t size, int64_t conversion) {
+	auto tgt_ptr = (timestamp_t *)FlatVector::GetData(vector);
+	auto &validity_mask = FlatVector::Validity(vector);
+	auto src_ptr = (int64_t *)array.buffers[1] + scan_state.chunk_offset + array.offset;
+	if (nested_offset != -1) {
+		src_ptr = (int64_t *)array.buffers[1] + nested_offset + array.offset;
+	}
+	for (idx_t row = 0; row < size; row++) {
+		if (!validity_mask.RowIsValid(row)) {
+			continue;
+		}
+		if (!TryMultiplyOperator::Operation(src_ptr[row], conversion, tgt_ptr[row].value)) {
+			throw ConversionException("Could not convert TimestampTZ to Microsecond");
+		}
+	}
+}
+
+void IntervalConversionUs(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, int64_t nested_offset,
+                          idx_t size, int64_t conversion) {
+	auto tgt_ptr = (interval_t *)FlatVector::GetData(vector);
+	auto src_ptr = (int64_t *)array.buffers[1] + scan_state.chunk_offset + array.offset;
+	if (nested_offset != -1) {
+		src_ptr = (int64_t *)array.buffers[1] + nested_offset + array.offset;
+	}
+	for (idx_t row = 0; row < size; row++) {
+		tgt_ptr[row].days = 0;
+		tgt_ptr[row].months = 0;
+		if (!TryMultiplyOperator::Operation(src_ptr[row], conversion, tgt_ptr[row].micros)) {
+			throw ConversionException("Could not convert Interval to Microsecond");
+		}
+	}
+}
+
+void IntervalConversionMonths(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, int64_t nested_offset,
+                              idx_t size) {
+	auto tgt_ptr = (interval_t *)FlatVector::GetData(vector);
+	auto src_ptr = (int32_t *)array.buffers[1] + scan_state.chunk_offset + array.offset;
+	if (nested_offset != -1) {
+		src_ptr = (int32_t *)array.buffers[1] + nested_offset + array.offset;
+	}
+	for (idx_t row = 0; row < size; row++) {
+		tgt_ptr[row].days = 0;
+		tgt_ptr[row].micros = 0;
+		tgt_ptr[row].months = src_ptr[row];
+	}
+}
+
+void ColumnArrowToDuckDB(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, idx_t size,
+                         std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data, idx_t col_idx,
+                         std::pair<idx_t, idx_t> &arrow_convert_idx, int64_t nested_offset, ValidityMask *parent_mask) {
+	switch (vector.GetType().id()) {
+	case LogicalTypeId::SQLNULL:
+		vector.Reference(Value());
+		break;
+	case LogicalTypeId::BOOLEAN: {
+		//! Arrow bit-packs boolean values
+		//! Lets first figure out where we are in the source array
+		auto src_ptr = (uint8_t *)array.buffers[1] + (scan_state.chunk_offset + array.offset) / 8;
+
+		if (nested_offset != -1) {
+			src_ptr = (uint8_t *)array.buffers[1] + (nested_offset + array.offset) / 8;
+		}
+		auto tgt_ptr = (uint8_t *)FlatVector::GetData(vector);
+		int src_pos = 0;
+		idx_t cur_bit = scan_state.chunk_offset % 8;
+		if (nested_offset != -1) {
+			cur_bit = nested_offset % 8;
+		}
+		for (idx_t row = 0; row < size; row++) {
+			if ((src_ptr[src_pos] & (1 << cur_bit)) == 0) {
+				tgt_ptr[row] = 0;
+			} else {
+				tgt_ptr[row] = 1;
+			}
+			cur_bit++;
+			if (cur_bit == 8) {
+				src_pos++;
+				cur_bit = 0;
+			}
+		}
+		break;
+	}
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+	case LogicalTypeId::UINTEGER:
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS: {
+		DirectConversion(vector, array, scan_state, nested_offset);
+		break;
+	}
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR: {
+		auto original_type = arrow_convert_data[col_idx]->variable_sz_type[arrow_convert_idx.first++];
+		auto cdata = (char *)array.buffers[2];
+		if (original_type.first == ArrowVariableSizeType::SUPER_SIZE) {
+			if (((uint64_t *)array.buffers[1])[array.length] > NumericLimits<uint32_t>::Maximum()) { // LCOV_EXCL_START
+				throw std::runtime_error("DuckDB does not support Strings over 4GB");
+			} // LCOV_EXCL_STOP
+			auto offsets = (uint64_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
+			if (nested_offset != -1) {
+				offsets = (uint64_t *)array.buffers[1] + array.offset + nested_offset;
+			}
+			SetVectorString(vector, size, cdata, offsets);
+		} else {
+			auto offsets = (uint32_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
+			if (nested_offset != -1) {
+				offsets = (uint32_t *)array.buffers[1] + array.offset + nested_offset;
+			}
+			SetVectorString(vector, size, cdata, offsets);
+		}
+		break;
+	}
+	case LogicalTypeId::DATE: {
+		auto precision = arrow_convert_data[col_idx]->date_time_precision[arrow_convert_idx.second++];
+		switch (precision) {
+		case ArrowDateTimeType::DAYS: {
+			DirectConversion(vector, array, scan_state, nested_offset);
+			break;
+		}
+		case ArrowDateTimeType::MILLISECONDS: {
+			//! convert date from nanoseconds to days
+			auto src_ptr = (uint64_t *)array.buffers[1] + scan_state.chunk_offset + array.offset;
+			if (nested_offset != -1) {
+				src_ptr = (uint64_t *)array.buffers[1] + nested_offset + array.offset;
+			}
+			auto tgt_ptr = (date_t *)FlatVector::GetData(vector);
+			for (idx_t row = 0; row < size; row++) {
+				tgt_ptr[row] = date_t(int64_t(src_ptr[row]) / (1000 * 60 * 60 * 24));
+			}
+			break;
+		}
+		default:
+			throw std::runtime_error("Unsupported precision for Date Type ");
+		}
+		break;
+	}
+	case LogicalTypeId::TIME: {
+		auto precision = arrow_convert_data[col_idx]->date_time_precision[arrow_convert_idx.second++];
+		switch (precision) {
+		case ArrowDateTimeType::SECONDS: {
+			TimeConversion<int32_t>(vector, array, scan_state, nested_offset, size, 1000000);
+			break;
+		}
+		case ArrowDateTimeType::MILLISECONDS: {
+			TimeConversion<int32_t>(vector, array, scan_state, nested_offset, size, 1000);
+			break;
+		}
+		case ArrowDateTimeType::MICROSECONDS: {
+			TimeConversion<int64_t>(vector, array, scan_state, nested_offset, size, 1);
+			break;
+		}
+		case ArrowDateTimeType::NANOSECONDS: {
+			auto tgt_ptr = (dtime_t *)FlatVector::GetData(vector);
+			auto src_ptr = (int64_t *)array.buffers[1] + scan_state.chunk_offset + array.offset;
+			if (nested_offset != -1) {
+				src_ptr = (int64_t *)array.buffers[1] + nested_offset + array.offset;
+			}
+			for (idx_t row = 0; row < size; row++) {
+				tgt_ptr[row].micros = src_ptr[row] / 1000;
+			}
+			break;
+		}
+		default:
+			throw std::runtime_error("Unsupported precision for Time Type ");
+		}
+		break;
+	}
+	case LogicalTypeId::TIMESTAMP_TZ: {
+		auto precision = arrow_convert_data[col_idx]->date_time_precision[arrow_convert_idx.second++];
+		switch (precision) {
+		case ArrowDateTimeType::SECONDS: {
+			TimestampTZConversion(vector, array, scan_state, nested_offset, size, 1000000);
+			break;
+		}
+		case ArrowDateTimeType::MILLISECONDS: {
+			TimestampTZConversion(vector, array, scan_state, nested_offset, size, 1000);
+			break;
+		}
+		case ArrowDateTimeType::MICROSECONDS: {
+			DirectConversion(vector, array, scan_state, nested_offset);
+			break;
+		}
+		case ArrowDateTimeType::NANOSECONDS: {
+			auto tgt_ptr = (timestamp_t *)FlatVector::GetData(vector);
+			auto src_ptr = (int64_t *)array.buffers[1] + scan_state.chunk_offset + array.offset;
+			if (nested_offset != -1) {
+				src_ptr = (int64_t *)array.buffers[1] + nested_offset + array.offset;
+			}
+			for (idx_t row = 0; row < size; row++) {
+				tgt_ptr[row].value = src_ptr[row] / 1000;
+			}
+			break;
+		}
+		default:
+			throw std::runtime_error("Unsupported precision for TimestampTZ Type ");
+		}
+		break;
+	}
+	case LogicalTypeId::INTERVAL: {
+		auto precision = arrow_convert_data[col_idx]->date_time_precision[arrow_convert_idx.second++];
+		switch (precision) {
+		case ArrowDateTimeType::SECONDS: {
+			IntervalConversionUs(vector, array, scan_state, nested_offset, size, 1000000);
+			break;
+		}
+		case ArrowDateTimeType::DAYS:
+		case ArrowDateTimeType::MILLISECONDS: {
+			IntervalConversionUs(vector, array, scan_state, nested_offset, size, 1000);
+			break;
+		}
+		case ArrowDateTimeType::MICROSECONDS: {
+			IntervalConversionUs(vector, array, scan_state, nested_offset, size, 1);
+			break;
+		}
+		case ArrowDateTimeType::NANOSECONDS: {
+			auto tgt_ptr = (interval_t *)FlatVector::GetData(vector);
+			auto src_ptr = (int64_t *)array.buffers[1] + scan_state.chunk_offset + array.offset;
+			if (nested_offset != -1) {
+				src_ptr = (int64_t *)array.buffers[1] + nested_offset + array.offset;
+			}
+			for (idx_t row = 0; row < size; row++) {
+				tgt_ptr[row].micros = src_ptr[row] / 1000;
+				tgt_ptr[row].days = 0;
+				tgt_ptr[row].months = 0;
+			}
+			break;
+		}
+		case ArrowDateTimeType::MONTHS: {
+			IntervalConversionMonths(vector, array, scan_state, nested_offset, size);
+			break;
+		}
+		default:
+			throw std::runtime_error("Unsupported precision for Interval/Duration Type ");
+		}
+		break;
+	}
+	case LogicalTypeId::DECIMAL: {
+		auto val_mask = FlatVector::Validity(vector);
+		//! We have to convert from INT128
+		auto src_ptr = (hugeint_t *)array.buffers[1] + scan_state.chunk_offset + array.offset;
+		if (nested_offset != -1) {
+			src_ptr = (hugeint_t *)array.buffers[1] + nested_offset + array.offset;
+		}
+		switch (vector.GetType().InternalType()) {
+		case PhysicalType::INT16: {
+			auto tgt_ptr = (int16_t *)FlatVector::GetData(vector);
+			for (idx_t row = 0; row < size; row++) {
+				if (val_mask.RowIsValid(row)) {
+					auto result = Hugeint::TryCast(src_ptr[row], tgt_ptr[row]);
+					D_ASSERT(result);
+					(void)result;
+				}
+			}
+			break;
+		}
+		case PhysicalType::INT32: {
+			auto tgt_ptr = (int32_t *)FlatVector::GetData(vector);
+			for (idx_t row = 0; row < size; row++) {
+				if (val_mask.RowIsValid(row)) {
+					auto result = Hugeint::TryCast(src_ptr[row], tgt_ptr[row]);
+					D_ASSERT(result);
+					(void)result;
+				}
+			}
+			break;
+		}
+		case PhysicalType::INT64: {
+			auto tgt_ptr = (int64_t *)FlatVector::GetData(vector);
+			for (idx_t row = 0; row < size; row++) {
+				if (val_mask.RowIsValid(row)) {
+					auto result = Hugeint::TryCast(src_ptr[row], tgt_ptr[row]);
+					D_ASSERT(result);
+					(void)result;
+				}
+			}
+			break;
+		}
+		case PhysicalType::INT128: {
+			FlatVector::SetData(vector, (data_ptr_t)array.buffers[1] + GetTypeIdSize(vector.GetType().InternalType()) *
+			                                                               (scan_state.chunk_offset + array.offset));
+			break;
+		}
+		default:
+			throw std::runtime_error("Unsupported physical type for Decimal: " +
+			                         TypeIdToString(vector.GetType().InternalType()));
+		}
+		break;
+	}
+	case LogicalTypeId::BLOB: {
+		ArrowToDuckDBBlob(vector, array, scan_state, size, arrow_convert_data, col_idx, arrow_convert_idx,
+		                  nested_offset);
+		break;
+	}
+	case LogicalTypeId::LIST: {
+		ArrowToDuckDBList(vector, array, scan_state, size, arrow_convert_data, col_idx, arrow_convert_idx,
+		                  nested_offset, parent_mask);
+		break;
+	}
+	case LogicalTypeId::MAP: {
+		//! Since this is a map we skip first child, because its a struct
+		auto &struct_arrow = *array.children[0];
+		auto &child_entries = StructVector::GetEntries(vector);
+		D_ASSERT(child_entries.size() == 2);
+		auto offsets = (uint32_t *)array.buffers[1] + array.offset + scan_state.chunk_offset;
+		if (nested_offset != -1) {
+			offsets = (uint32_t *)array.buffers[1] + nested_offset;
+		}
+		auto &struct_validity_mask = FlatVector::Validity(vector);
+		//! Fill the children
+		for (idx_t type_idx = 0; type_idx < (idx_t)struct_arrow.n_children; type_idx++) {
+			ArrowToDuckDBMapList(*child_entries[type_idx], *struct_arrow.children[type_idx], scan_state, size,
+			                     arrow_convert_data, col_idx, arrow_convert_idx, offsets, &struct_validity_mask);
+		}
+		ArrowToDuckDBMapVerify(vector, size);
+		break;
+	}
+	case LogicalTypeId::STRUCT: {
+		//! Fill the children
+		auto &child_entries = StructVector::GetEntries(vector);
+		auto &struct_validity_mask = FlatVector::Validity(vector);
+		for (idx_t type_idx = 0; type_idx < (idx_t)array.n_children; type_idx++) {
+			SetValidityMask(*child_entries[type_idx], *array.children[type_idx], scan_state, size, nested_offset);
+			if (!struct_validity_mask.AllValid()) {
+				auto &child_validity_mark = FlatVector::Validity(*child_entries[type_idx]);
+				for (idx_t i = 0; i < size; i++) {
+					if (!struct_validity_mask.RowIsValid(i)) {
+						child_validity_mark.SetInvalid(i);
+					}
+				}
+			}
+			ColumnArrowToDuckDB(*child_entries[type_idx], *array.children[type_idx], scan_state, size,
+			                    arrow_convert_data, col_idx, arrow_convert_idx, nested_offset, &struct_validity_mask);
+		}
+		break;
+	}
+	default:
+		throw std::runtime_error("Unsupported type " + vector.GetType().ToString());
+	}
+}
+
+template <class T>
+static void SetSelectionVectorLoop(SelectionVector &sel, data_ptr_t indices_p, idx_t size) {
+	auto indices = (T *)indices_p;
+	for (idx_t row = 0; row < size; row++) {
+		sel.set_index(row, indices[row]);
+	}
+}
+
+template <class T>
+static void SetSelectionVectorLoopWithChecks(SelectionVector &sel, data_ptr_t indices_p, idx_t size) {
+
+	auto indices = (T *)indices_p;
+	for (idx_t row = 0; row < size; row++) {
+		if (indices[row] > NumericLimits<uint32_t>::Maximum()) {
+			throw std::runtime_error("DuckDB only supports indices that fit on an uint32");
+		}
+		sel.set_index(row, indices[row]);
+	}
+}
+
+template <class T>
+static void SetMaskedSelectionVectorLoop(SelectionVector &sel, data_ptr_t indices_p, idx_t size, ValidityMask &mask,
+                                         idx_t last_element_pos) {
+	auto indices = (T *)indices_p;
+	for (idx_t row = 0; row < size; row++) {
+		if (mask.RowIsValid(row)) {
+			sel.set_index(row, indices[row]);
+		} else {
+			//! Need to point out to last element
+			sel.set_index(row, last_element_pos);
+		}
+	}
+}
+
+void SetSelectionVector(SelectionVector &sel, data_ptr_t indices_p, LogicalType &logical_type, idx_t size,
+                        ValidityMask *mask = nullptr, idx_t last_element_pos = 0) {
+	sel.Initialize(size);
+
+	if (mask) {
+		switch (logical_type.id()) {
+		case LogicalTypeId::UTINYINT:
+			SetMaskedSelectionVectorLoop<uint8_t>(sel, indices_p, size, *mask, last_element_pos);
+			break;
+		case LogicalTypeId::TINYINT:
+			SetMaskedSelectionVectorLoop<int8_t>(sel, indices_p, size, *mask, last_element_pos);
+			break;
+		case LogicalTypeId::USMALLINT:
+			SetMaskedSelectionVectorLoop<uint16_t>(sel, indices_p, size, *mask, last_element_pos);
+			break;
+		case LogicalTypeId::SMALLINT:
+			SetMaskedSelectionVectorLoop<int16_t>(sel, indices_p, size, *mask, last_element_pos);
+			break;
+		case LogicalTypeId::UINTEGER:
+			if (last_element_pos > NumericLimits<uint32_t>::Maximum()) {
+				//! Its guaranteed that our indices will point to the last element, so just throw an error
+				throw std::runtime_error("DuckDB only supports indices that fit on an uint32");
+			}
+			SetMaskedSelectionVectorLoop<uint32_t>(sel, indices_p, size, *mask, last_element_pos);
+			break;
+		case LogicalTypeId::INTEGER:
+			SetMaskedSelectionVectorLoop<int32_t>(sel, indices_p, size, *mask, last_element_pos);
+			break;
+		case LogicalTypeId::UBIGINT:
+			if (last_element_pos > NumericLimits<uint32_t>::Maximum()) {
+				//! Its guaranteed that our indices will point to the last element, so just throw an error
+				throw std::runtime_error("DuckDB only supports indices that fit on an uint32");
+			}
+			SetMaskedSelectionVectorLoop<uint64_t>(sel, indices_p, size, *mask, last_element_pos);
+			break;
+		case LogicalTypeId::BIGINT:
+			if (last_element_pos > NumericLimits<uint32_t>::Maximum()) {
+				//! Its guaranteed that our indices will point to the last element, so just throw an error
+				throw std::runtime_error("DuckDB only supports indices that fit on an uint32");
+			}
+			SetMaskedSelectionVectorLoop<int64_t>(sel, indices_p, size, *mask, last_element_pos);
+			break;
+
+		default:
+			throw std::runtime_error("(Arrow) Unsupported type for selection vectors " + logical_type.ToString());
+		}
+
+	} else {
+		switch (logical_type.id()) {
+		case LogicalTypeId::UTINYINT:
+			SetSelectionVectorLoop<uint8_t>(sel, indices_p, size);
+			break;
+		case LogicalTypeId::TINYINT:
+			SetSelectionVectorLoop<int8_t>(sel, indices_p, size);
+			break;
+		case LogicalTypeId::USMALLINT:
+			SetSelectionVectorLoop<uint16_t>(sel, indices_p, size);
+			break;
+		case LogicalTypeId::SMALLINT:
+			SetSelectionVectorLoop<int16_t>(sel, indices_p, size);
+			break;
+		case LogicalTypeId::UINTEGER:
+			SetSelectionVectorLoop<uint32_t>(sel, indices_p, size);
+			break;
+		case LogicalTypeId::INTEGER:
+			SetSelectionVectorLoop<int32_t>(sel, indices_p, size);
+			break;
+		case LogicalTypeId::UBIGINT:
+			if (last_element_pos > NumericLimits<uint32_t>::Maximum()) {
+				//! We need to check if our indexes fit in a uint32_t
+				SetSelectionVectorLoopWithChecks<uint64_t>(sel, indices_p, size);
+			} else {
+				SetSelectionVectorLoop<uint64_t>(sel, indices_p, size);
+			}
+			break;
+		case LogicalTypeId::BIGINT:
+			if (last_element_pos > NumericLimits<uint32_t>::Maximum()) {
+				//! We need to check if our indexes fit in a uint32_t
+				SetSelectionVectorLoopWithChecks<int64_t>(sel, indices_p, size);
+			} else {
+				SetSelectionVectorLoop<int64_t>(sel, indices_p, size);
+			}
+			break;
+		default:
+			throw std::runtime_error("(Arrow) Unsupported type for selection vectors " + logical_type.ToString());
+		}
+	}
+}
+
+void ColumnArrowToDuckDBDictionary(Vector &vector, ArrowArray &array, ArrowScanLocalState &scan_state, idx_t size,
+                                   std::unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data,
+                                   idx_t col_idx, std::pair<idx_t, idx_t> &arrow_convert_idx) {
+	SelectionVector sel;
+	auto &dict_vectors = scan_state.arrow_dictionary_vectors;
+	if (dict_vectors.find(col_idx) == dict_vectors.end()) {
+		//! We need to set the dictionary data for this column
+		auto base_vector = make_unique<Vector>(vector.GetType(), array.dictionary->length);
+		SetValidityMask(*base_vector, *array.dictionary, scan_state, array.dictionary->length, 0, array.null_count > 0);
+		ColumnArrowToDuckDB(*base_vector, *array.dictionary, scan_state, array.dictionary->length, arrow_convert_data,
+		                    col_idx, arrow_convert_idx);
+		dict_vectors[col_idx] = move(base_vector);
+	}
+	auto dictionary_type = arrow_convert_data[col_idx]->dictionary_type;
+	//! Get Pointer to Indices of Dictionary
+	auto indices = (data_ptr_t)array.buffers[1] +
+	               GetTypeIdSize(dictionary_type.InternalType()) * (scan_state.chunk_offset + array.offset);
+	if (array.null_count > 0) {
+		ValidityMask indices_validity;
+		GetValidityMask(indices_validity, array, scan_state, size);
+		SetSelectionVector(sel, indices, dictionary_type, size, &indices_validity, array.dictionary->length);
+	} else {
+		SetSelectionVector(sel, indices, dictionary_type, size);
+	}
+	vector.Slice(*dict_vectors[col_idx], sel, size);
+}
+
+void ArrowTableFunction::ArrowToDuckDB(ArrowScanLocalState &scan_state,
+                                       unordered_map<idx_t, unique_ptr<ArrowConvertData>> &arrow_convert_data,
+                                       DataChunk &output, idx_t start) {
+	for (idx_t idx = 0; idx < output.ColumnCount(); idx++) {
+		auto col_idx = scan_state.column_ids[idx];
+		std::pair<idx_t, idx_t> arrow_convert_idx {0, 0};
+		auto &array = *scan_state.chunk->arrow_array.children[idx];
+		if (!array.release) {
+			throw InvalidInputException("arrow_scan: released array passed");
+		}
+		if (array.length != scan_state.chunk->arrow_array.length) {
+			throw InvalidInputException("arrow_scan: array length mismatch");
+		}
+		output.data[idx].GetBuffer()->SetAuxiliaryData(make_unique<ArrowAuxiliaryData>(scan_state.chunk));
+		if (array.dictionary) {
+			ColumnArrowToDuckDBDictionary(output.data[idx], array, scan_state, output.size(), arrow_convert_data,
+			                              col_idx, arrow_convert_idx);
+		} else {
+			SetValidityMask(output.data[idx], array, scan_state, output.size(), -1);
+			ColumnArrowToDuckDB(output.data[idx], array, scan_state, output.size(), arrow_convert_data, col_idx,
+			                    arrow_convert_idx);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+static unique_ptr<FunctionData> CheckpointBind(ClientContext &context, TableFunctionBindInput &input,
+                                               vector<LogicalType> &return_types, vector<string> &names) {
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("Success");
+	return nullptr;
+}
+
+template <bool FORCE>
+static void TemplatedCheckpointFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &transaction_manager = TransactionManager::Get(context);
+	transaction_manager.Checkpoint(context, FORCE);
+}
+
+void CheckpointFunction::RegisterFunction(BuiltinFunctions &set) {
+	TableFunction checkpoint("checkpoint", {}, TemplatedCheckpointFunction<false>, CheckpointBind);
+	set.AddFunction(checkpoint);
+	TableFunction force_checkpoint("force_checkpoint", {}, TemplatedCheckpointFunction<true>, CheckpointBind);
+	set.AddFunction(force_checkpoint);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+#include <limits>
+
+namespace duckdb {
+
+void SubstringDetection(string &str_1, string &str_2, const string &name_str_1, const string &name_str_2) {
+	if (str_1.empty() || str_2.empty()) {
+		return;
+	}
+	if (str_1.find(str_2) != string::npos || str_2.find(str_1) != std::string::npos) {
+		throw BinderException("%s must not appear in the %s specification and vice versa", name_str_1, name_str_2);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Bind
+//===--------------------------------------------------------------------===//
+
+void BaseCSVData::Finalize() {
+	// verify that the options are correct in the final pass
+	if (options.escape.empty()) {
+		options.escape = options.quote;
+	}
+	// escape and delimiter must not be substrings of each other
+	if (options.has_delimiter && options.has_escape) {
+		SubstringDetection(options.delimiter, options.escape, "DELIMITER", "ESCAPE");
+	}
+	// delimiter and quote must not be substrings of each other
+	if (options.has_quote && options.has_delimiter) {
+		SubstringDetection(options.quote, options.delimiter, "DELIMITER", "QUOTE");
+	}
+	// escape and quote must not be substrings of each other (but can be the same)
+	if (options.quote != options.escape && options.has_quote && options.has_escape) {
+		SubstringDetection(options.quote, options.escape, "QUOTE", "ESCAPE");
+	}
+	if (!options.null_str.empty()) {
+		// null string and delimiter must not be substrings of each other
+		if (options.has_delimiter) {
+			SubstringDetection(options.delimiter, options.null_str, "DELIMITER", "NULL");
+		}
+		// quote/escape and nullstr must not be substrings of each other
+		if (options.has_quote) {
+			SubstringDetection(options.quote, options.null_str, "QUOTE", "NULL");
+		}
+		if (options.has_escape) {
+			SubstringDetection(options.escape, options.null_str, "ESCAPE", "NULL");
+		}
+	}
+}
+
+static Value ConvertVectorToValue(vector<Value> set) {
+	if (set.empty()) {
+		return Value::EMPTYLIST(LogicalType::BOOLEAN);
+	}
+	return Value::LIST(move(set));
+}
+
+static unique_ptr<FunctionData> WriteCSVBind(ClientContext &context, CopyInfo &info, vector<string> &names,
+                                             vector<LogicalType> &sql_types) {
+	auto bind_data = make_unique<WriteCSVData>(info.file_path, sql_types, names);
+
+	// check all the options in the copy info
+	for (auto &option : info.options) {
+		auto loption = StringUtil::Lower(option.first);
+		auto &set = option.second;
+		bind_data->options.SetWriteOption(loption, ConvertVectorToValue(move(set)));
+	}
+	// verify the parsed options
+	if (bind_data->options.force_quote.empty()) {
+		// no FORCE_QUOTE specified: initialize to false
+		bind_data->options.force_quote.resize(names.size(), false);
+	}
+	bind_data->Finalize();
+	bind_data->is_simple = bind_data->options.delimiter.size() == 1 && bind_data->options.escape.size() == 1 &&
+	                       bind_data->options.quote.size() == 1;
+	return move(bind_data);
+}
+
+static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, CopyInfo &info, vector<string> &expected_names,
+                                            vector<LogicalType> &expected_types) {
+	auto bind_data = make_unique<ReadCSVData>();
+	bind_data->sql_types = expected_types;
+
+	string file_pattern = info.file_path;
+
+	auto &fs = FileSystem::GetFileSystem(context);
+	bind_data->files = fs.Glob(file_pattern, context);
+	if (bind_data->files.empty()) {
+		throw IOException("No files found that match the pattern \"%s\"", file_pattern);
+	}
+
+	auto &options = bind_data->options;
+
+	// check all the options in the copy info
+	for (auto &option : info.options) {
+		auto loption = StringUtil::Lower(option.first);
+		auto &set = option.second;
+		options.SetReadOption(loption, ConvertVectorToValue(move(set)), expected_names);
+	}
+	// verify the parsed options
+	if (options.force_not_null.empty()) {
+		// no FORCE_QUOTE specified: initialize to false
+		options.force_not_null.resize(expected_types.size(), false);
+	}
+	bind_data->Finalize();
+	return move(bind_data);
+}
+
+//===--------------------------------------------------------------------===//
+// Helper writing functions
+//===--------------------------------------------------------------------===//
+static string AddEscapes(string &to_be_escaped, const string &escape, const string &val) {
+	idx_t i = 0;
+	string new_val = "";
+	idx_t found = val.find(to_be_escaped);
+
+	while (found != string::npos) {
+		while (i < found) {
+			new_val += val[i];
+			i++;
+		}
+		new_val += escape;
+		found = val.find(to_be_escaped, found + escape.length());
+	}
+	while (i < val.length()) {
+		new_val += val[i];
+		i++;
+	}
+	return new_val;
+}
+
+static bool RequiresQuotes(WriteCSVData &csv_data, const char *str, idx_t len) {
+	auto &options = csv_data.options;
+	// check if the string is equal to the null string
+	if (len == options.null_str.size() && memcmp(str, options.null_str.c_str(), len) == 0) {
+		return true;
+	}
+	if (csv_data.is_simple) {
+		// simple CSV: check for newlines, quotes and delimiter all at once
+		for (idx_t i = 0; i < len; i++) {
+			if (str[i] == '\n' || str[i] == '\r' || str[i] == options.quote[0] || str[i] == options.delimiter[0]) {
+				// newline, write a quoted string
+				return true;
+			}
+		}
+		// no newline, quote or delimiter in the string
+		// no quoting or escaping necessary
+		return false;
+	} else {
+		// CSV with complex quotes/delimiter (multiple bytes)
+
+		// first check for \n, \r, \n\r in string
+		for (idx_t i = 0; i < len; i++) {
+			if (str[i] == '\n' || str[i] == '\r') {
+				// newline, write a quoted string
+				return true;
+			}
+		}
+
+		// check for delimiter
+		if (ContainsFun::Find((const unsigned char *)str, len, (const unsigned char *)options.delimiter.c_str(),
+		                      options.delimiter.size()) != DConstants::INVALID_INDEX) {
+			return true;
+		}
+		// check for quote
+		if (ContainsFun::Find((const unsigned char *)str, len, (const unsigned char *)options.quote.c_str(),
+		                      options.quote.size()) != DConstants::INVALID_INDEX) {
+			return true;
+		}
+		return false;
+	}
+}
+
+static void WriteQuotedString(Serializer &serializer, WriteCSVData &csv_data, const char *str, idx_t len,
+                              bool force_quote) {
+	auto &options = csv_data.options;
+	if (!force_quote) {
+		// force quote is disabled: check if we need to add quotes anyway
+		force_quote = RequiresQuotes(csv_data, str, len);
+	}
+	if (force_quote) {
+		// quoting is enabled: we might need to escape things in the string
+		bool requires_escape = false;
+		if (csv_data.is_simple) {
+			// simple CSV
+			// do a single loop to check for a quote or escape value
+			for (idx_t i = 0; i < len; i++) {
+				if (str[i] == options.quote[0] || str[i] == options.escape[0]) {
+					requires_escape = true;
+					break;
+				}
+			}
+		} else {
+			// complex CSV
+			// check for quote or escape separately
+			if (ContainsFun::Find((const unsigned char *)str, len, (const unsigned char *)options.quote.c_str(),
+			                      options.quote.size()) != DConstants::INVALID_INDEX) {
+				requires_escape = true;
+			} else if (ContainsFun::Find((const unsigned char *)str, len, (const unsigned char *)options.escape.c_str(),
+			                             options.escape.size()) != DConstants::INVALID_INDEX) {
+				requires_escape = true;
+			}
+		}
+		if (!requires_escape) {
+			// fast path: no need to escape anything
+			serializer.WriteBufferData(options.quote);
+			serializer.WriteData((const_data_ptr_t)str, len);
+			serializer.WriteBufferData(options.quote);
+			return;
+		}
+
+		// slow path: need to add escapes
+		string new_val(str, len);
+		new_val = AddEscapes(options.escape, options.escape, new_val);
+		if (options.escape != options.quote) {
+			// need to escape quotes separately
+			new_val = AddEscapes(options.quote, options.escape, new_val);
+		}
+		serializer.WriteBufferData(options.quote);
+		serializer.WriteBufferData(new_val);
+		serializer.WriteBufferData(options.quote);
+	} else {
+		serializer.WriteData((const_data_ptr_t)str, len);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+struct LocalReadCSVData : public LocalFunctionData {
+	//! The thread-local buffer to write data into
+	BufferedSerializer serializer;
+	//! A chunk with VARCHAR columns to cast intermediates into
+	DataChunk cast_chunk;
+};
+
+struct GlobalWriteCSVData : public GlobalFunctionData {
+	GlobalWriteCSVData(FileSystem &fs, const string &file_path, FileOpener *opener, FileCompressionType compression)
+	    : fs(fs) {
+		handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW,
+		                     FileLockType::WRITE_LOCK, compression, opener);
+	}
+
+	void WriteData(const_data_ptr_t data, idx_t size) {
+		lock_guard<mutex> flock(lock);
+		handle->Write((void *)data, size);
+	}
+
+	FileSystem &fs;
+	//! The mutex for writing to the physical file
+	mutex lock;
+	//! The file handle to write to
+	unique_ptr<FileHandle> handle;
+};
+
+static unique_ptr<LocalFunctionData> WriteCSVInitializeLocal(ClientContext &context, FunctionData &bind_data) {
+	auto &csv_data = (WriteCSVData &)bind_data;
+	auto local_data = make_unique<LocalReadCSVData>();
+
+	// create the chunk with VARCHAR types
+	vector<LogicalType> types;
+	types.resize(csv_data.options.names.size(), LogicalType::VARCHAR);
+
+	local_data->cast_chunk.Initialize(types);
+	return move(local_data);
+}
+
+static unique_ptr<GlobalFunctionData> WriteCSVInitializeGlobal(ClientContext &context, FunctionData &bind_data,
+                                                               const string &file_path) {
+	auto &csv_data = (WriteCSVData &)bind_data;
+	auto &options = csv_data.options;
+	auto global_data = make_unique<GlobalWriteCSVData>(FileSystem::GetFileSystem(context), file_path,
+	                                                   FileSystem::GetFileOpener(context), options.compression);
+
+	if (options.header) {
+		BufferedSerializer serializer;
+		// write the header line to the file
+		for (idx_t i = 0; i < csv_data.options.names.size(); i++) {
+			if (i != 0) {
+				serializer.WriteBufferData(options.delimiter);
+			}
+			WriteQuotedString(serializer, csv_data, csv_data.options.names[i].c_str(), csv_data.options.names[i].size(),
+			                  false);
+		}
+		serializer.WriteBufferData(csv_data.newline);
+
+		global_data->WriteData(serializer.blob.data.get(), serializer.blob.size);
+	}
+	return move(global_data);
+}
+
+static void WriteCSVSink(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                         LocalFunctionData &lstate, DataChunk &input) {
+	auto &csv_data = (WriteCSVData &)bind_data;
+	auto &options = csv_data.options;
+	auto &local_data = (LocalReadCSVData &)lstate;
+	auto &global_state = (GlobalWriteCSVData &)gstate;
+
+	// write data into the local buffer
+
+	// first cast the columns of the chunk to varchar
+	auto &cast_chunk = local_data.cast_chunk;
+	cast_chunk.SetCardinality(input);
+	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
+		if (csv_data.sql_types[col_idx].id() == LogicalTypeId::VARCHAR) {
+			// VARCHAR, just create a reference
+			cast_chunk.data[col_idx].Reference(input.data[col_idx]);
+		} else if (options.has_format[LogicalTypeId::DATE] && csv_data.sql_types[col_idx].id() == LogicalTypeId::DATE) {
+			// use the date format to cast the chunk
+			csv_data.options.write_date_format[LogicalTypeId::DATE].ConvertDateVector(
+			    input.data[col_idx], cast_chunk.data[col_idx], input.size());
+		} else if (options.has_format[LogicalTypeId::TIMESTAMP] &&
+		           csv_data.sql_types[col_idx].id() == LogicalTypeId::TIMESTAMP) {
+			// use the timestamp format to cast the chunk
+			csv_data.options.write_date_format[LogicalTypeId::TIMESTAMP].ConvertTimestampVector(
+			    input.data[col_idx], cast_chunk.data[col_idx], input.size());
+		} else {
+			// non varchar column, perform the cast
+			VectorOperations::Cast(input.data[col_idx], cast_chunk.data[col_idx], input.size());
+		}
+	}
+
+	cast_chunk.Normalify();
+	auto &writer = local_data.serializer;
+	// now loop over the vectors and output the values
+	for (idx_t row_idx = 0; row_idx < cast_chunk.size(); row_idx++) {
+		// write values
+		for (idx_t col_idx = 0; col_idx < cast_chunk.ColumnCount(); col_idx++) {
+			if (col_idx != 0) {
+				writer.WriteBufferData(options.delimiter);
+			}
+			if (FlatVector::IsNull(cast_chunk.data[col_idx], row_idx)) {
+				// write null value
+				writer.WriteBufferData(options.null_str);
+				continue;
+			}
+
+			// non-null value, fetch the string value from the cast chunk
+			auto str_data = FlatVector::GetData<string_t>(cast_chunk.data[col_idx]);
+			auto str_value = str_data[row_idx];
+			// FIXME: we could gain some performance here by checking for certain types if they ever require quotes
+			// (e.g. integers only require quotes if the delimiter is a number, decimals only require quotes if the
+			// delimiter is a number or "." character)
+			WriteQuotedString(writer, csv_data, str_value.GetDataUnsafe(), str_value.GetSize(),
+			                  csv_data.options.force_quote[col_idx]);
+		}
+		writer.WriteBufferData(csv_data.newline);
+	}
+	// check if we should flush what we have currently written
+	if (writer.blob.size >= csv_data.flush_size) {
+		global_state.WriteData(writer.blob.data.get(), writer.blob.size);
+		writer.Reset();
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Combine
+//===--------------------------------------------------------------------===//
+static void WriteCSVCombine(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                            LocalFunctionData &lstate) {
+	auto &local_data = (LocalReadCSVData &)lstate;
+	auto &global_state = (GlobalWriteCSVData &)gstate;
+	auto &writer = local_data.serializer;
+	// flush the local writer
+	if (writer.blob.size > 0) {
+		global_state.WriteData(writer.blob.data.get(), writer.blob.size);
+		writer.Reset();
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+void WriteCSVFinalize(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate) {
+	auto &global_state = (GlobalWriteCSVData &)gstate;
+
+	global_state.handle->Close();
+	global_state.handle.reset();
+}
+
+void CSVCopyFunction::RegisterFunction(BuiltinFunctions &set) {
+	CopyFunction info("csv");
+	info.copy_to_bind = WriteCSVBind;
+	info.copy_to_initialize_local = WriteCSVInitializeLocal;
+	info.copy_to_initialize_global = WriteCSVInitializeGlobal;
+	info.copy_to_sink = WriteCSVSink;
+	info.copy_to_combine = WriteCSVCombine;
+	info.copy_to_finalize = WriteCSVFinalize;
+
+	info.copy_from_bind = ReadCSVBind;
+	info.copy_from_function = ReadCSVTableFunction::GetFunction();
+
+	info.extension = "csv";
+
+	set.AddFunction(info);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct GlobFunctionBindData : public TableFunctionData {
+	vector<string> files;
+};
+
+static unique_ptr<FunctionData> GlobFunctionBind(ClientContext &context, TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("Globbing is disabled through configuration");
+	}
+	auto result = make_unique<GlobFunctionBindData>();
+	auto &fs = FileSystem::GetFileSystem(context);
+	result->files = fs.Glob(StringValue::Get(input.inputs[0]), context);
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("file");
+	return move(result);
+}
+
+struct GlobFunctionState : public GlobalTableFunctionState {
+	GlobFunctionState() : current_idx(0) {
+	}
+
+	idx_t current_idx;
+};
+
+static unique_ptr<GlobalTableFunctionState> GlobFunctionInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_unique<GlobFunctionState>();
+}
+
+static void GlobFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = (GlobFunctionBindData &)*data_p.bind_data;
+	auto &state = (GlobFunctionState &)*data_p.global_state;
+
+	idx_t count = 0;
+	idx_t next_idx = MinValue<idx_t>(state.current_idx + STANDARD_VECTOR_SIZE, bind_data.files.size());
+	for (; state.current_idx < next_idx; state.current_idx++) {
+		output.data[0].SetValue(count, bind_data.files[state.current_idx]);
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void GlobTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	TableFunctionSet glob("glob");
+	glob.AddFunction(TableFunction({LogicalType::VARCHAR}, GlobFunction, GlobFunctionBind, GlobFunctionInit));
+	set.AddFunction(glob);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct PragmaDetailedProfilingOutputOperatorData : public GlobalTableFunctionState {
+	explicit PragmaDetailedProfilingOutputOperatorData() : chunk_index(0), initialized(false) {
+	}
+	idx_t chunk_index;
+	bool initialized;
+};
+
+struct PragmaDetailedProfilingOutputData : public TableFunctionData {
+	explicit PragmaDetailedProfilingOutputData(vector<LogicalType> &types) : types(types) {
+	}
+	unique_ptr<ChunkCollection> collection;
+	vector<LogicalType> types;
+};
+
+static unique_ptr<FunctionData> PragmaDetailedProfilingOutputBind(ClientContext &context, TableFunctionBindInput &input,
+                                                                  vector<LogicalType> &return_types,
+                                                                  vector<string> &names) {
+	names.emplace_back("OPERATOR_ID");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("ANNOTATION");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("ID");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("NAME");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("TIME");
+	return_types.emplace_back(LogicalType::DOUBLE);
+
+	names.emplace_back("CYCLES_PER_TUPLE");
+	return_types.emplace_back(LogicalType::DOUBLE);
+
+	names.emplace_back("SAMPLE_SIZE");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("INPUT_SIZE");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("EXTRA_INFO");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return make_unique<PragmaDetailedProfilingOutputData>(return_types);
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaDetailedProfilingOutputInit(ClientContext &context,
+                                                                       TableFunctionInitInput &input) {
+	return make_unique<PragmaDetailedProfilingOutputOperatorData>();
+}
+
+// Insert a row into the given datachunk
+static void SetValue(DataChunk &output, int index, int op_id, string annotation, int id, string name, double time,
+                     int sample_counter, int tuple_counter, string extra_info) {
+	output.SetValue(0, index, op_id);
+	output.SetValue(1, index, move(annotation));
+	output.SetValue(2, index, id);
+	output.SetValue(3, index, move(name));
+#if defined(RDTSC)
+	output.SetValue(4, index, Value(nullptr));
+	output.SetValue(5, index, time);
+#else
+	output.SetValue(4, index, time);
+	output.SetValue(5, index, Value(nullptr));
+
+#endif
+	output.SetValue(6, index, sample_counter);
+	output.SetValue(7, index, tuple_counter);
+	output.SetValue(8, index, move(extra_info));
+}
+
+static void ExtractFunctions(ChunkCollection &collection, ExpressionInfo &info, DataChunk &chunk, int op_id,
+                             int &fun_id) {
+	if (info.hasfunction) {
+		D_ASSERT(info.sample_tuples_count != 0);
+		SetValue(chunk, chunk.size(), op_id, "Function", fun_id++, info.function_name,
+		         int(info.function_time) / double(info.sample_tuples_count), info.sample_tuples_count,
+		         info.tuples_count, "");
+
+		chunk.SetCardinality(chunk.size() + 1);
+		if (chunk.size() == STANDARD_VECTOR_SIZE) {
+			collection.Append(chunk);
+			chunk.Reset();
+		}
+	}
+	if (info.children.empty()) {
+		return;
+	}
+	// extract the children of this node
+	for (auto &child : info.children) {
+		ExtractFunctions(collection, *child, chunk, op_id, fun_id);
+	}
+}
+
+static void PragmaDetailedProfilingOutputFunction(ClientContext &context, TableFunctionInput &data_p,
+                                                  DataChunk &output) {
+	auto &state = (PragmaDetailedProfilingOutputOperatorData &)*data_p.global_state;
+	auto &data = (PragmaDetailedProfilingOutputData &)*data_p.bind_data;
+
+	if (!state.initialized) {
+		// create a ChunkCollection
+		auto collection = make_unique<ChunkCollection>();
+
+		// create a chunk
+		DataChunk chunk;
+		chunk.Initialize(data.types);
+
+		// Initialize ids
+		int operator_counter = 1;
+		int function_counter = 1;
+		int expression_counter = 1;
+		if (ClientData::Get(context).query_profiler_history->GetPrevProfilers().empty()) {
+			return;
+		}
+		// For each Operator
+		for (auto op :
+		     ClientData::Get(context).query_profiler_history->GetPrevProfilers().back().second->GetTreeMap()) {
+			// For each Expression Executor
+			for (auto &expr_executor : op.second->info.executors_info) {
+				// For each Expression tree
+				if (!expr_executor) {
+					continue;
+				}
+				for (auto &expr_timer : expr_executor->roots) {
+					D_ASSERT(expr_timer->sample_tuples_count != 0);
+					SetValue(chunk, chunk.size(), operator_counter, "ExpressionRoot", expression_counter++,
+					         // Sometimes, cycle counter is not accurate, too big or too small. return 0 for
+					         // those cases
+					         expr_timer->name, int(expr_timer->time) / double(expr_timer->sample_tuples_count),
+					         expr_timer->sample_tuples_count, expr_timer->tuples_count, expr_timer->extra_info);
+					// Increment cardinality
+					chunk.SetCardinality(chunk.size() + 1);
+					// Check whether data chunk is full or not
+					if (chunk.size() == STANDARD_VECTOR_SIZE) {
+						collection->Append(chunk);
+						chunk.Reset();
+					}
+					// Extract all functions inside the tree
+					ExtractFunctions(*collection, *expr_timer->root, chunk, operator_counter, function_counter);
+				}
+			}
+			operator_counter++;
+		}
+		collection->Append(chunk);
+		data.collection = move(collection);
+		state.initialized = true;
+	}
+
+	if (state.chunk_index >= data.collection->ChunkCount()) {
+		output.SetCardinality(0);
+		return;
+	}
+	output.Reference(data.collection->GetChunk(state.chunk_index++));
+}
+
+void PragmaDetailedProfilingOutput::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("pragma_detailed_profiling_output", {}, PragmaDetailedProfilingOutputFunction,
+	                              PragmaDetailedProfilingOutputBind, PragmaDetailedProfilingOutputInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct PragmaLastProfilingOutputOperatorData : public GlobalTableFunctionState {
+	PragmaLastProfilingOutputOperatorData() : chunk_index(0), initialized(false) {
+	}
+	idx_t chunk_index;
+	bool initialized;
+};
+
+struct PragmaLastProfilingOutputData : public TableFunctionData {
+	explicit PragmaLastProfilingOutputData(vector<LogicalType> &types) : types(types) {
+	}
+	unique_ptr<ChunkCollection> collection;
+	vector<LogicalType> types;
+};
+
+static unique_ptr<FunctionData> PragmaLastProfilingOutputBind(ClientContext &context, TableFunctionBindInput &input,
+                                                              vector<LogicalType> &return_types,
+                                                              vector<string> &names) {
+	names.emplace_back("OPERATOR_ID");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("NAME");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("TIME");
+	return_types.emplace_back(LogicalType::DOUBLE);
+
+	names.emplace_back("CARDINALITY");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("DESCRIPTION");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return make_unique<PragmaLastProfilingOutputData>(return_types);
+}
+
+static void SetValue(DataChunk &output, int index, int op_id, string name, double time, int64_t car,
+                     string description) {
+	output.SetValue(0, index, op_id);
+	output.SetValue(1, index, move(name));
+	output.SetValue(2, index, time);
+	output.SetValue(3, index, car);
+	output.SetValue(4, index, move(description));
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaLastProfilingOutputInit(ClientContext &context,
+                                                                   TableFunctionInitInput &input) {
+	return make_unique<PragmaLastProfilingOutputOperatorData>();
+}
+
+static void PragmaLastProfilingOutputFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &state = (PragmaLastProfilingOutputOperatorData &)*data_p.global_state;
+	auto &data = (PragmaLastProfilingOutputData &)*data_p.bind_data;
+	if (!state.initialized) {
+		// create a ChunkCollection
+		auto collection = make_unique<ChunkCollection>();
+
+		DataChunk chunk;
+		chunk.Initialize(data.types);
+		int operator_counter = 1;
+		if (!ClientData::Get(context).query_profiler_history->GetPrevProfilers().empty()) {
+			for (auto op :
+			     ClientData::Get(context).query_profiler_history->GetPrevProfilers().back().second->GetTreeMap()) {
+				SetValue(chunk, chunk.size(), operator_counter++, op.second->name, op.second->info.time,
+				         op.second->info.elements, " ");
+				chunk.SetCardinality(chunk.size() + 1);
+				if (chunk.size() == STANDARD_VECTOR_SIZE) {
+					collection->Append(chunk);
+					chunk.Reset();
+				}
+			}
+		}
+		collection->Append(chunk);
+		data.collection = move(collection);
+		state.initialized = true;
+	}
+
+	if (state.chunk_index >= data.collection->ChunkCount()) {
+		output.SetCardinality(0);
+		return;
+	}
+	output.Reference(data.collection->GetChunk(state.chunk_index++));
+}
+
+void PragmaLastProfilingOutput::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("pragma_last_profiling_output", {}, PragmaLastProfilingOutputFunction,
+	                              PragmaLastProfilingOutputBind, PragmaLastProfilingOutputInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Range (integers)
+//===--------------------------------------------------------------------===//
+struct RangeFunctionBindData : public TableFunctionData {
+	hugeint_t start;
+	hugeint_t end;
+	hugeint_t increment;
+
+public:
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const RangeFunctionBindData &)other_p;
+		return other.start == start && other.end == end && other.increment == increment;
+	}
+};
+
+template <bool GENERATE_SERIES>
+static unique_ptr<FunctionData> RangeFunctionBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_unique<RangeFunctionBindData>();
+	auto &inputs = input.inputs;
+	if (inputs.size() < 2) {
+		// single argument: only the end is specified
+		result->start = 0;
+		result->end = inputs[0].GetValue<int64_t>();
+	} else {
+		// two arguments: first two arguments are start and end
+		result->start = inputs[0].GetValue<int64_t>();
+		result->end = inputs[1].GetValue<int64_t>();
+	}
+	if (inputs.size() < 3) {
+		result->increment = 1;
+	} else {
+		result->increment = inputs[2].GetValue<int64_t>();
+	}
+	if (result->increment == 0) {
+		throw BinderException("interval cannot be 0!");
+	}
+	if (result->start > result->end && result->increment > 0) {
+		throw BinderException("start is bigger than end, but increment is positive: cannot generate infinite series");
+	} else if (result->start < result->end && result->increment < 0) {
+		throw BinderException("start is smaller than end, but increment is negative: cannot generate infinite series");
+	}
+	return_types.emplace_back(LogicalType::BIGINT);
+	if (GENERATE_SERIES) {
+		// generate_series has inclusive bounds on the RHS
+		if (result->increment < 0) {
+			result->end = result->end - 1;
+		} else {
+			result->end = result->end + 1;
+		}
+		names.emplace_back("generate_series");
+	} else {
+		names.emplace_back("range");
+	}
+	return move(result);
+}
+
+struct RangeFunctionState : public GlobalTableFunctionState {
+	RangeFunctionState() : current_idx(0) {
+	}
+
+	int64_t current_idx;
+};
+
+static unique_ptr<GlobalTableFunctionState> RangeFunctionInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_unique<RangeFunctionState>();
+}
+
+static void RangeFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = (RangeFunctionBindData &)*data_p.bind_data;
+	auto &state = (RangeFunctionState &)*data_p.global_state;
+
+	auto increment = bind_data.increment;
+	auto end = bind_data.end;
+	hugeint_t current_value = bind_data.start + increment * state.current_idx;
+	int64_t current_value_i64;
+	if (!Hugeint::TryCast<int64_t>(current_value, current_value_i64)) {
+		return;
+	}
+	// set the result vector as a sequence vector
+	output.data[0].Sequence(current_value_i64, Hugeint::Cast<int64_t>(increment));
+	int64_t offset = increment < 0 ? 1 : -1;
+	idx_t remaining = MinValue<idx_t>(Hugeint::Cast<idx_t>((end - current_value + (increment + offset)) / increment),
+	                                  STANDARD_VECTOR_SIZE);
+	// increment the index pointer by the remaining count
+	state.current_idx += remaining;
+	output.SetCardinality(remaining);
+}
+
+unique_ptr<NodeStatistics> RangeCardinality(ClientContext &context, const FunctionData *bind_data_p) {
+	auto &bind_data = (RangeFunctionBindData &)*bind_data_p;
+	idx_t cardinality = Hugeint::Cast<idx_t>((bind_data.end - bind_data.start) / bind_data.increment);
+	return make_unique<NodeStatistics>(cardinality, cardinality);
+}
+
+//===--------------------------------------------------------------------===//
+// Range (timestamp)
+//===--------------------------------------------------------------------===//
+struct RangeDateTimeBindData : public TableFunctionData {
+	timestamp_t start;
+	timestamp_t end;
+	interval_t increment;
+	bool inclusive_bound;
+	bool greater_than_check;
+
+public:
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const RangeDateTimeBindData &)other_p;
+		return other.start == start && other.end == end && other.increment == increment &&
+		       other.inclusive_bound == inclusive_bound && other.greater_than_check == greater_than_check;
+	}
+
+	bool Finished(timestamp_t current_value) {
+		if (greater_than_check) {
+			if (inclusive_bound) {
+				return current_value > end;
+			} else {
+				return current_value >= end;
+			}
+		} else {
+			if (inclusive_bound) {
+				return current_value < end;
+			} else {
+				return current_value <= end;
+			}
+		}
+	}
+};
+
+template <bool GENERATE_SERIES>
+static unique_ptr<FunctionData> RangeDateTimeBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_unique<RangeDateTimeBindData>();
+	auto &inputs = input.inputs;
+	D_ASSERT(inputs.size() == 3);
+	result->start = inputs[0].GetValue<timestamp_t>();
+	result->end = inputs[1].GetValue<timestamp_t>();
+	result->increment = inputs[2].GetValue<interval_t>();
+
+	// Infinities either cause errors or infinite loops, so just ban them
+	if (!Timestamp::IsFinite(result->start) || !Timestamp::IsFinite(result->end)) {
+		throw BinderException("RANGE with infinite bounds is not supported");
+	}
+
+	if (result->increment.months == 0 && result->increment.days == 0 && result->increment.micros == 0) {
+		throw BinderException("interval cannot be 0!");
+	}
+	// all elements should point in the same direction
+	if (result->increment.months > 0 || result->increment.days > 0 || result->increment.micros > 0) {
+		if (result->increment.months < 0 || result->increment.days < 0 || result->increment.micros < 0) {
+			throw BinderException("RANGE with composite interval that has mixed signs is not supported");
+		}
+		result->greater_than_check = true;
+		if (result->start > result->end) {
+			throw BinderException(
+			    "start is bigger than end, but increment is positive: cannot generate infinite series");
+		}
+	} else {
+		result->greater_than_check = false;
+		if (result->start < result->end) {
+			throw BinderException(
+			    "start is smaller than end, but increment is negative: cannot generate infinite series");
+		}
+	}
+	return_types.push_back(inputs[0].type());
+	if (GENERATE_SERIES) {
+		// generate_series has inclusive bounds on the RHS
+		result->inclusive_bound = true;
+		names.emplace_back("generate_series");
+	} else {
+		result->inclusive_bound = false;
+		names.emplace_back("range");
+	}
+	return move(result);
+}
+
+struct RangeDateTimeState : public GlobalTableFunctionState {
+	explicit RangeDateTimeState(timestamp_t start_p) : current_state(start_p) {
+	}
+
+	timestamp_t current_state;
+	bool finished = false;
+};
+
+static unique_ptr<GlobalTableFunctionState> RangeDateTimeInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto &bind_data = (RangeDateTimeBindData &)*input.bind_data;
+	return make_unique<RangeDateTimeState>(bind_data.start);
+}
+
+static void RangeDateTimeFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = (RangeDateTimeBindData &)*data_p.bind_data;
+	auto &state = (RangeDateTimeState &)*data_p.global_state;
+	if (state.finished) {
+		return;
+	}
+
+	idx_t size = 0;
+	auto data = FlatVector::GetData<timestamp_t>(output.data[0]);
+	while (true) {
+		data[size++] = state.current_state;
+		state.current_state =
+		    AddOperator::Operation<timestamp_t, interval_t, timestamp_t>(state.current_state, bind_data.increment);
+		if (bind_data.Finished(state.current_state)) {
+			state.finished = true;
+			break;
+		}
+		if (size >= STANDARD_VECTOR_SIZE) {
+			break;
+		}
+	}
+	output.SetCardinality(size);
+}
+
+void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	TableFunctionSet range("range");
+
+	TableFunction range_function({LogicalType::BIGINT}, RangeFunction, RangeFunctionBind<false>, RangeFunctionInit);
+	range_function.cardinality = RangeCardinality;
+
+	// single argument range: (end) - implicit start = 0 and increment = 1
+	range.AddFunction(range_function);
+	// two arguments range: (start, end) - implicit increment = 1
+	range_function.arguments = {LogicalType::BIGINT, LogicalType::BIGINT};
+	range.AddFunction(range_function);
+	// three arguments range: (start, end, increment)
+	range_function.arguments = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT};
+	range.AddFunction(range_function);
+	range.AddFunction(TableFunction({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
+	                                RangeDateTimeFunction, RangeDateTimeBind<false>, RangeDateTimeInit));
+	set.AddFunction(range);
+	// generate_series: similar to range, but inclusive instead of exclusive bounds on the RHS
+	TableFunctionSet generate_series("generate_series");
+	range_function.bind = RangeFunctionBind<true>;
+	range_function.arguments = {LogicalType::BIGINT};
+	generate_series.AddFunction(range_function);
+	range_function.arguments = {LogicalType::BIGINT, LogicalType::BIGINT};
+	generate_series.AddFunction(range_function);
+	range_function.arguments = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT};
+	generate_series.AddFunction(range_function);
+	generate_series.AddFunction(TableFunction({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
+	                                          RangeDateTimeFunction, RangeDateTimeBind<true>, RangeDateTimeInit));
+	set.AddFunction(generate_series);
+}
+
+void BuiltinFunctions::RegisterTableFunctions() {
+	CheckpointFunction::RegisterFunction(*this);
+	GlobTableFunction::RegisterFunction(*this);
+	RangeTableFunction::RegisterFunction(*this);
+	RepeatTableFunction::RegisterFunction(*this);
+	SummaryTableFunction::RegisterFunction(*this);
+	UnnestTableFunction::RegisterFunction(*this);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+#include <limits>
+
+namespace duckdb {
+
+static unique_ptr<FunctionData> ReadCSVBind(ClientContext &context, TableFunctionBindInput &input,
+                                            vector<LogicalType> &return_types, vector<string> &names) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("Scanning CSV files is disabled through configuration");
+	}
+	auto result = make_unique<ReadCSVData>();
+	auto &options = result->options;
+
+	auto &file_pattern = StringValue::Get(input.inputs[0]);
+
+	auto &fs = FileSystem::GetFileSystem(context);
+	result->files = fs.Glob(file_pattern, context);
+	if (result->files.empty()) {
+		throw IOException("No files found that match the pattern \"%s\"", file_pattern);
+	}
+
+	for (auto &kv : input.named_parameters) {
+		auto loption = StringUtil::Lower(kv.first);
+		if (loption == "columns") {
+			auto &child_type = kv.second.type();
+			if (child_type.id() != LogicalTypeId::STRUCT) {
+				throw BinderException("read_csv columns requires a struct as input");
+			}
+			auto &struct_children = StructValue::GetChildren(kv.second);
+			D_ASSERT(StructType::GetChildCount(child_type) == struct_children.size());
+			for (idx_t i = 0; i < struct_children.size(); i++) {
+				auto &name = StructType::GetChildName(child_type, i);
+				auto &val = struct_children[i];
+				names.push_back(name);
+				if (val.type().id() != LogicalTypeId::VARCHAR) {
+					throw BinderException("read_csv requires a type specification as string");
+				}
+				return_types.emplace_back(TransformStringToLogicalType(StringValue::Get(val)));
+			}
+			if (names.empty()) {
+				throw BinderException("read_csv requires at least a single column as input!");
+			}
+		} else if (loption == "all_varchar") {
+			options.all_varchar = BooleanValue::Get(kv.second);
+		} else if (loption == "normalize_names") {
+			options.normalize_names = BooleanValue::Get(kv.second);
+		} else if (loption == "filename") {
+			options.include_file_name = BooleanValue::Get(kv.second);
+		} else {
+			options.SetReadOption(loption, kv.second, names);
+		}
+	}
+	if (!options.auto_detect && return_types.empty()) {
+		throw BinderException("read_csv requires columns to be specified. Use read_csv_auto or set read_csv(..., "
+		                      "AUTO_DETECT=TRUE) to automatically guess columns.");
+	}
+	if (options.auto_detect) {
+		options.file_path = result->files[0];
+		auto initial_reader = make_unique<BufferedCSVReader>(context, options);
+
+		return_types.assign(initial_reader->sql_types.begin(), initial_reader->sql_types.end());
+		if (names.empty()) {
+			names.assign(initial_reader->col_names.begin(), initial_reader->col_names.end());
+		} else {
+			D_ASSERT(return_types.size() == names.size());
+		}
+		result->initial_reader = move(initial_reader);
+	} else {
+		result->sql_types = return_types;
+		D_ASSERT(return_types.size() == names.size());
+	}
+	if (result->options.include_file_name) {
+		return_types.emplace_back(LogicalType::VARCHAR);
+		names.emplace_back("filename");
+	}
+	return move(result);
+}
+
+struct ReadCSVOperatorData : public GlobalTableFunctionState {
+	//! The CSV reader
+	unique_ptr<BufferedCSVReader> csv_reader;
+	//! The index of the next file to read (i.e. current file + 1)
+	idx_t file_index;
+	//! Total File Size
+	idx_t file_size;
+	//! How many bytes were read up to this point
+	atomic<idx_t> bytes_read;
+};
+
+static unique_ptr<GlobalTableFunctionState> ReadCSVInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto &bind_data = (ReadCSVData &)*input.bind_data;
+	auto result = make_unique<ReadCSVOperatorData>();
+	if (bind_data.initial_reader) {
+		result->csv_reader = move(bind_data.initial_reader);
+	} else {
+		bind_data.options.file_path = bind_data.files[0];
+		result->csv_reader = make_unique<BufferedCSVReader>(context, bind_data.options, bind_data.sql_types);
+	}
+	result->file_size = result->csv_reader->GetFileSize();
+	result->file_index = 1;
+	return move(result);
+}
+
+static unique_ptr<FunctionData> ReadCSVAutoBind(ClientContext &context, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	input.named_parameters["auto_detect"] = Value::BOOLEAN(true);
+	return ReadCSVBind(context, input, return_types, names);
+}
+
+static void ReadCSVFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = (ReadCSVData &)*data_p.bind_data;
+	auto &data = (ReadCSVOperatorData &)*data_p.global_state;
+	do {
+		data.csv_reader->ParseCSV(output);
+		data.bytes_read = data.csv_reader->bytes_in_chunk;
+		if (output.size() == 0 && data.file_index < bind_data.files.size()) {
+			// exhausted this file, but we have more files we can read
+			// open the next file and increment the counter
+			bind_data.options.file_path = bind_data.files[data.file_index];
+			data.csv_reader = make_unique<BufferedCSVReader>(context, bind_data.options, data.csv_reader->sql_types);
+			data.file_index++;
+		} else {
+			break;
+		}
+	} while (true);
+	if (bind_data.options.include_file_name) {
+		auto &col = output.data.back();
+		col.SetValue(0, Value(data.csv_reader->options.file_path));
+		col.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+static void ReadCSVAddNamedParameters(TableFunction &table_function) {
+	table_function.named_parameters["sep"] = LogicalType::VARCHAR;
+	table_function.named_parameters["delim"] = LogicalType::VARCHAR;
+	table_function.named_parameters["quote"] = LogicalType::VARCHAR;
+	table_function.named_parameters["escape"] = LogicalType::VARCHAR;
+	table_function.named_parameters["nullstr"] = LogicalType::VARCHAR;
+	table_function.named_parameters["columns"] = LogicalType::ANY;
+	table_function.named_parameters["header"] = LogicalType::BOOLEAN;
+	table_function.named_parameters["auto_detect"] = LogicalType::BOOLEAN;
+	table_function.named_parameters["sample_size"] = LogicalType::BIGINT;
+	table_function.named_parameters["sample_chunk_size"] = LogicalType::BIGINT;
+	table_function.named_parameters["sample_chunks"] = LogicalType::BIGINT;
+	table_function.named_parameters["all_varchar"] = LogicalType::BOOLEAN;
+	table_function.named_parameters["dateformat"] = LogicalType::VARCHAR;
+	table_function.named_parameters["timestampformat"] = LogicalType::VARCHAR;
+	table_function.named_parameters["normalize_names"] = LogicalType::BOOLEAN;
+	table_function.named_parameters["compression"] = LogicalType::VARCHAR;
+	table_function.named_parameters["filename"] = LogicalType::BOOLEAN;
+	table_function.named_parameters["skip"] = LogicalType::BIGINT;
+	table_function.named_parameters["max_line_size"] = LogicalType::VARCHAR;
+	table_function.named_parameters["maximum_line_size"] = LogicalType::VARCHAR;
+}
+
+double CSVReaderProgress(ClientContext &context, const FunctionData *bind_data_p,
+                         const GlobalTableFunctionState *global_state) {
+	auto &data = (const ReadCSVOperatorData &)*global_state;
+	if (data.file_size == 0) {
+		return 100;
+	}
+	auto percentage = (data.bytes_read * 100.0) / data.file_size;
+	return percentage;
+}
+
+TableFunction ReadCSVTableFunction::GetFunction() {
+	TableFunction read_csv("read_csv", {LogicalType::VARCHAR}, ReadCSVFunction, ReadCSVBind, ReadCSVInit);
+	read_csv.table_scan_progress = CSVReaderProgress;
+	ReadCSVAddNamedParameters(read_csv);
+	return read_csv;
+}
+
+void ReadCSVTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(ReadCSVTableFunction::GetFunction());
+
+	TableFunction read_csv_auto("read_csv_auto", {LogicalType::VARCHAR}, ReadCSVFunction, ReadCSVAutoBind, ReadCSVInit);
+	read_csv_auto.table_scan_progress = CSVReaderProgress;
+	ReadCSVAddNamedParameters(read_csv_auto);
+	set.AddFunction(read_csv_auto);
+}
+
+unique_ptr<TableFunctionRef> ReadCSVReplacement(ClientContext &context, const string &table_name,
+                                                ReplacementScanData *data) {
+	auto lower_name = StringUtil::Lower(table_name);
+	// remove any compression
+	if (StringUtil::EndsWith(lower_name, ".gz")) {
+		lower_name = lower_name.substr(0, lower_name.size() - 3);
+	} else if (StringUtil::EndsWith(lower_name, ".zst")) {
+		lower_name = lower_name.substr(0, lower_name.size() - 4);
+	}
+	if (!StringUtil::EndsWith(lower_name, ".csv") && !StringUtil::EndsWith(lower_name, ".tsv")) {
+		return nullptr;
+	}
+	auto table_function = make_unique<TableFunctionRef>();
+	vector<unique_ptr<ParsedExpression>> children;
+	children.push_back(make_unique<ConstantExpression>(Value(table_name)));
+	table_function->function = make_unique<FunctionExpression>("read_csv_auto", move(children));
+	return table_function;
+}
+
+void BuiltinFunctions::RegisterReadFunctions() {
+	CSVCopyFunction::RegisterFunction(*this);
+	ReadCSVTableFunction::RegisterFunction(*this);
+
+	auto &config = DBConfig::GetConfig(context);
+	config.replacement_scans.emplace_back(ReadCSVReplacement);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+struct RepeatFunctionData : public TableFunctionData {
+	RepeatFunctionData(Value value, idx_t target_count) : value(move(value)), target_count(target_count) {
+	}
+
+	Value value;
+	idx_t target_count;
+};
+
+struct RepeatOperatorData : public GlobalTableFunctionState {
+	RepeatOperatorData() : current_count(0) {
+	}
+	idx_t current_count;
+};
+
+static unique_ptr<FunctionData> RepeatBind(ClientContext &context, TableFunctionBindInput &input,
+                                           vector<LogicalType> &return_types, vector<string> &names) {
+	// the repeat function returns the type of the first argument
+	auto &inputs = input.inputs;
+	return_types.push_back(inputs[0].type());
+	names.push_back(inputs[0].ToString());
+	return make_unique<RepeatFunctionData>(inputs[0], inputs[1].GetValue<int64_t>());
+}
+
+static unique_ptr<GlobalTableFunctionState> RepeatInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_unique<RepeatOperatorData>();
+}
+
+static void RepeatFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = (const RepeatFunctionData &)*data_p.bind_data;
+	auto &state = (RepeatOperatorData &)*data_p.global_state;
+
+	idx_t remaining = MinValue<idx_t>(bind_data.target_count - state.current_count, STANDARD_VECTOR_SIZE);
+	output.data[0].Reference(bind_data.value);
+	output.SetCardinality(remaining);
+	state.current_count += remaining;
+}
+
+static unique_ptr<NodeStatistics> RepeatCardinality(ClientContext &context, const FunctionData *bind_data_p) {
+	auto &bind_data = (const RepeatFunctionData &)*bind_data_p;
+	return make_unique<NodeStatistics>(bind_data.target_count, bind_data.target_count);
+}
+
+void RepeatTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	TableFunction repeat("repeat", {LogicalType::ANY, LogicalType::BIGINT}, RepeatFunction, RepeatBind, RepeatInit);
+	repeat.cardinality = RepeatCardinality;
+	set.AddFunction(repeat);
+}
+
+} // namespace duckdb
+
+
+
+
+
+// this function makes not that much sense on its own but is a demo for table-parameter table-producing functions
+
+namespace duckdb {
+
+static unique_ptr<FunctionData> SummaryFunctionBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("summary");
+
+	for (idx_t i = 0; i < input.input_table_types.size(); i++) {
+		return_types.push_back(input.input_table_types[i]);
+		names.emplace_back(input.input_table_names[i]);
+	}
+
+	return make_unique<TableFunctionData>();
+}
+
+static OperatorResultType SummaryFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &input,
+                                          DataChunk &output) {
+	output.SetCardinality(input.size());
+
+	for (idx_t row_idx = 0; row_idx < input.size(); row_idx++) {
+		string summary_val = "[";
+
+		for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
+			summary_val += input.GetValue(col_idx, row_idx).ToString();
+			if (col_idx < input.ColumnCount() - 1) {
+				summary_val += ", ";
+			}
+		}
+		summary_val += "]";
+		output.SetValue(0, row_idx, Value(summary_val));
+	}
+	for (idx_t col_idx = 0; col_idx < input.ColumnCount(); col_idx++) {
+		output.data[col_idx + 1].Reference(input.data[col_idx]);
+	}
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
+void SummaryTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	TableFunction summary_function("summary", {LogicalType::TABLE}, nullptr, SummaryFunctionBind);
+	summary_function.in_out_function = SummaryFunction;
+	set.AddFunction(summary_function);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+#include <set>
+
+namespace duckdb {
+
+struct DuckDBColumnsData : public GlobalTableFunctionState {
+	DuckDBColumnsData() : offset(0), column_offset(0) {
+	}
+
+	vector<CatalogEntry *> entries;
+	idx_t offset;
+	idx_t column_offset;
+};
+
+static unique_ptr<FunctionData> DuckDBColumnsBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("schema_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("schema_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("table_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("table_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("column_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("column_index");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("internal");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("column_default");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("is_nullable");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("data_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("data_type_id");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("character_maximum_length");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("numeric_precision");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("numeric_precision_radix");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("numeric_scale");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBColumnsInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBColumnsData>();
+
+	// scan all the schemas for tables and views and collect them
+	auto schemas = Catalog::GetCatalog(context).schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		schema->Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	}
+
+	// check the temp schema as well
+	ClientData::Get(context).temporary_objects->Scan(context, CatalogType::TABLE_ENTRY,
+	                                                 [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	return move(result);
+}
+
+class ColumnHelper {
+public:
+	static unique_ptr<ColumnHelper> Create(CatalogEntry *entry);
+
+	virtual ~ColumnHelper() {
+	}
+
+	virtual StandardEntry *Entry() = 0;
+	virtual idx_t NumColumns() = 0;
+	virtual const string &ColumnName(idx_t col) = 0;
+	virtual const LogicalType &ColumnType(idx_t col) = 0;
+	virtual const Value ColumnDefault(idx_t col) = 0;
+	virtual bool IsNullable(idx_t col) = 0;
+
+	void WriteColumns(idx_t index, idx_t start_col, idx_t end_col, DataChunk &output);
+};
+
+class TableColumnHelper : public ColumnHelper {
+public:
+	explicit TableColumnHelper(TableCatalogEntry *entry) : entry(entry) {
+		for (auto &constraint : entry->constraints) {
+			if (constraint->type == ConstraintType::NOT_NULL) {
+				auto &not_null = *reinterpret_cast<NotNullConstraint *>(constraint.get());
+				not_null_cols.insert(not_null.index);
+			}
+		}
+	}
+
+	StandardEntry *Entry() override {
+		return entry;
+	}
+	idx_t NumColumns() override {
+		return entry->columns.size();
+	}
+	const string &ColumnName(idx_t col) override {
+		return entry->columns[col].Name();
+	}
+	const LogicalType &ColumnType(idx_t col) override {
+		return entry->columns[col].Type();
+	}
+	const Value ColumnDefault(idx_t col) override {
+		if (entry->columns[col].DefaultValue()) {
+			return Value(entry->columns[col].DefaultValue()->ToString());
+		}
+		return Value();
+	}
+	bool IsNullable(idx_t col) override {
+		return not_null_cols.find(col) == not_null_cols.end();
+	}
+
+private:
+	TableCatalogEntry *entry;
+	std::set<idx_t> not_null_cols;
+};
+
+class ViewColumnHelper : public ColumnHelper {
+public:
+	explicit ViewColumnHelper(ViewCatalogEntry *entry) : entry(entry) {
+	}
+
+	StandardEntry *Entry() override {
+		return entry;
+	}
+	idx_t NumColumns() override {
+		return entry->types.size();
+	}
+	const string &ColumnName(idx_t col) override {
+		return entry->aliases[col];
+	}
+	const LogicalType &ColumnType(idx_t col) override {
+		return entry->types[col];
+	}
+	const Value ColumnDefault(idx_t col) override {
+		return Value();
+	}
+	bool IsNullable(idx_t col) override {
+		return true;
+	}
+
+private:
+	ViewCatalogEntry *entry;
+};
+
+unique_ptr<ColumnHelper> ColumnHelper::Create(CatalogEntry *entry) {
+	switch (entry->type) {
+	case CatalogType::TABLE_ENTRY:
+		return make_unique<TableColumnHelper>((TableCatalogEntry *)entry);
+	case CatalogType::VIEW_ENTRY:
+		return make_unique<ViewColumnHelper>((ViewCatalogEntry *)entry);
+	default:
+		throw NotImplementedException("Unsupported catalog type for duckdb_columns");
+	}
+}
+
+void ColumnHelper::WriteColumns(idx_t start_index, idx_t start_col, idx_t end_col, DataChunk &output) {
+	for (idx_t i = start_col; i < end_col; i++) {
+		auto index = start_index + (i - start_col);
+		auto &entry = *Entry();
+
+		// schema_oid, BIGINT
+		output.SetValue(0, index, Value::BIGINT(entry.schema->oid));
+		// schema_name, VARCHAR
+		output.SetValue(1, index, entry.schema->name);
+		// table_oid, BIGINT
+		output.SetValue(2, index, Value::BIGINT(entry.oid));
+		// table_name, VARCHAR
+		output.SetValue(3, index, entry.name);
+		// column_name, VARCHAR
+		output.SetValue(4, index, Value(ColumnName(i)));
+		// column_index, INTEGER
+		output.SetValue(5, index, Value::INTEGER(i + 1));
+		// internal, BOOLEAN
+		output.SetValue(6, index, Value::BOOLEAN(entry.internal));
+		// column_default, VARCHAR
+		output.SetValue(7, index, Value(ColumnDefault(i)));
+		// is_nullable, BOOLEAN
+		output.SetValue(8, index, Value::BOOLEAN(IsNullable(i)));
+		// data_type, VARCHAR
+		const LogicalType &type = ColumnType(i);
+		output.SetValue(9, index, Value(type.ToString()));
+		// data_type_id, BIGINT
+		output.SetValue(10, index, Value::BIGINT(int(type.id())));
+		if (type == LogicalType::VARCHAR) {
+			// FIXME: need check constraints in place to set this correctly
+			// character_maximum_length, INTEGER
+			output.SetValue(11, index, Value());
+		} else {
+			// "character_maximum_length", PhysicalType::INTEGER
+			output.SetValue(11, index, Value());
+		}
+
+		Value numeric_precision, numeric_scale, numeric_precision_radix;
+		switch (type.id()) {
+		case LogicalTypeId::DECIMAL:
+			numeric_precision = Value::INTEGER(DecimalType::GetWidth(type));
+			numeric_scale = Value::INTEGER(DecimalType::GetScale(type));
+			numeric_precision_radix = Value::INTEGER(10);
+			break;
+		case LogicalTypeId::HUGEINT:
+			numeric_precision = Value::INTEGER(128);
+			numeric_scale = Value::INTEGER(0);
+			numeric_precision_radix = Value::INTEGER(2);
+			break;
+		case LogicalTypeId::BIGINT:
+			numeric_precision = Value::INTEGER(64);
+			numeric_scale = Value::INTEGER(0);
+			numeric_precision_radix = Value::INTEGER(2);
+			break;
+		case LogicalTypeId::INTEGER:
+			numeric_precision = Value::INTEGER(32);
+			numeric_scale = Value::INTEGER(0);
+			numeric_precision_radix = Value::INTEGER(2);
+			break;
+		case LogicalTypeId::SMALLINT:
+			numeric_precision = Value::INTEGER(16);
+			numeric_scale = Value::INTEGER(0);
+			numeric_precision_radix = Value::INTEGER(2);
+			break;
+		case LogicalTypeId::TINYINT:
+			numeric_precision = Value::INTEGER(8);
+			numeric_scale = Value::INTEGER(0);
+			numeric_precision_radix = Value::INTEGER(2);
+			break;
+		case LogicalTypeId::FLOAT:
+			numeric_precision = Value::INTEGER(24);
+			numeric_scale = Value::INTEGER(0);
+			numeric_precision_radix = Value::INTEGER(2);
+			break;
+		case LogicalTypeId::DOUBLE:
+			numeric_precision = Value::INTEGER(53);
+			numeric_scale = Value::INTEGER(0);
+			numeric_precision_radix = Value::INTEGER(2);
+			break;
+		default:
+			numeric_precision = Value();
+			numeric_scale = Value();
+			numeric_precision_radix = Value();
+			break;
+		}
+
+		// numeric_precision, INTEGER
+		output.SetValue(12, index, numeric_precision);
+		// numeric_precision_radix, INTEGER
+		output.SetValue(13, index, numeric_precision_radix);
+		// numeric_scale, INTEGER
+		output.SetValue(14, index, numeric_scale);
+	}
+}
+
+void DuckDBColumnsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBColumnsData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+
+	// We need to track the offset of the relation we're writing as well as the last column
+	// we wrote from that relation (if any); it's possible that we can fill up the output
+	// with a partial list of columns from a relation and will need to pick up processing the
+	// next chunk at the same spot.
+	idx_t next = data.offset;
+	idx_t column_offset = data.column_offset;
+	idx_t index = 0;
+	while (next < data.entries.size() && index < STANDARD_VECTOR_SIZE) {
+		auto column_helper = ColumnHelper::Create(data.entries[next]);
+		idx_t columns = column_helper->NumColumns();
+
+		// Check to see if we are going to exceed the maximum index for a DataChunk
+		if (index + (columns - column_offset) > STANDARD_VECTOR_SIZE) {
+			idx_t column_limit = column_offset + (STANDARD_VECTOR_SIZE - index);
+			output.SetCardinality(STANDARD_VECTOR_SIZE);
+			column_helper->WriteColumns(index, column_offset, column_limit, output);
+
+			// Make the current column limit the column offset when we process the next chunk
+			column_offset = column_limit;
+			break;
+		} else {
+			// Otherwise, write all of the columns from the current relation and
+			// then move on to the next one.
+			output.SetCardinality(index + (columns - column_offset));
+			column_helper->WriteColumns(index, column_offset, columns, output);
+			index += columns - column_offset;
+			next++;
+			column_offset = 0;
+		}
+	}
+	data.offset = next;
+	data.column_offset = column_offset;
+}
+
+void DuckDBColumnsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_columns", {}, DuckDBColumnsFunction, DuckDBColumnsBind, DuckDBColumnsInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DuckDBConstraintsData : public GlobalTableFunctionState {
+	DuckDBConstraintsData() : offset(0), constraint_offset(0) {
+	}
+
+	vector<CatalogEntry *> entries;
+	idx_t offset;
+	idx_t constraint_offset;
+};
+
+static unique_ptr<FunctionData> DuckDBConstraintsBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("schema_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("schema_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("table_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("table_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("constraint_index");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	// CHECK, PRIMARY KEY or UNIQUE
+	names.emplace_back("constraint_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("constraint_text");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("expression");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("constraint_column_indexes");
+	;
+	return_types.push_back(LogicalType::LIST(LogicalType::BIGINT));
+
+	names.emplace_back("constraint_column_names");
+	return_types.push_back(LogicalType::LIST(LogicalType::VARCHAR));
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBConstraintsInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBConstraintsData>();
+
+	// scan all the schemas for tables and collect themand collect them
+	auto schemas = Catalog::GetCatalog(context).schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		schema->Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	};
+
+	// check the temp schema as well
+	ClientData::Get(context).temporary_objects->Scan(context, CatalogType::TABLE_ENTRY,
+	                                                 [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	return move(result);
+}
+
+void DuckDBConstraintsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBConstraintsData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset];
+
+		if (entry->type != CatalogType::TABLE_ENTRY) {
+			data.offset++;
+			continue;
+		}
+
+		auto &table = (TableCatalogEntry &)*entry;
+		for (; data.constraint_offset < table.constraints.size() && count < STANDARD_VECTOR_SIZE;
+		     data.constraint_offset++) {
+			auto &constraint = table.constraints[data.constraint_offset];
+			// return values:
+			// schema_name, LogicalType::VARCHAR
+			output.SetValue(0, count, Value(table.schema->name));
+			// schema_oid, LogicalType::BIGINT
+			output.SetValue(1, count, Value::BIGINT(table.schema->oid));
+			// table_name, LogicalType::VARCHAR
+			output.SetValue(2, count, Value(table.name));
+			// table_oid, LogicalType::BIGINT
+			output.SetValue(3, count, Value::BIGINT(table.oid));
+
+			// constraint_index, BIGINT
+			output.SetValue(4, count, Value::BIGINT(data.constraint_offset));
+
+			// constraint_type, VARCHAR
+			string constraint_type;
+			switch (constraint->type) {
+			case ConstraintType::CHECK:
+				constraint_type = "CHECK";
+				break;
+			case ConstraintType::UNIQUE: {
+				auto &unique = (UniqueConstraint &)*constraint;
+				constraint_type = unique.is_primary_key ? "PRIMARY KEY" : "UNIQUE";
+				break;
+			}
+			case ConstraintType::NOT_NULL:
+				constraint_type = "NOT NULL";
+				break;
+			case ConstraintType::FOREIGN_KEY:
+				constraint_type = "FOREIGN KEY";
+				break;
+			default:
+				throw NotImplementedException("Unimplemented constraint for duckdb_constraints");
+			}
+			output.SetValue(5, count, Value(constraint_type));
+
+			// constraint_text, VARCHAR
+			output.SetValue(6, count, Value(constraint->ToString()));
+
+			// expression, VARCHAR
+			Value expression_text;
+			if (constraint->type == ConstraintType::CHECK) {
+				auto &check = (CheckConstraint &)*constraint;
+				expression_text = Value(check.expression->ToString());
+			}
+			output.SetValue(7, count, expression_text);
+
+			auto &bound_constraint = (BoundConstraint &)*table.bound_constraints[data.constraint_offset];
+			vector<column_t> column_index_list;
+			switch (bound_constraint.type) {
+			case ConstraintType::CHECK: {
+				auto &bound_check = (BoundCheckConstraint &)bound_constraint;
+				for (auto &col_idx : bound_check.bound_columns) {
+					column_index_list.push_back(col_idx);
+				}
+				break;
+			}
+			case ConstraintType::UNIQUE: {
+				auto &bound_unique = (BoundUniqueConstraint &)bound_constraint;
+				for (auto &col_idx : bound_unique.keys) {
+					column_index_list.push_back(column_t(col_idx));
+				}
+				break;
+			}
+			case ConstraintType::NOT_NULL: {
+				auto &bound_not_null = (BoundNotNullConstraint &)bound_constraint;
+				column_index_list.push_back(bound_not_null.index);
+				break;
+			}
+			case ConstraintType::FOREIGN_KEY: {
+				auto &bound_foreign_key = (BoundForeignKeyConstraint &)bound_constraint;
+				for (auto &col_idx : bound_foreign_key.info.fk_keys) {
+					column_index_list.push_back(column_t(col_idx));
+				}
+				break;
+			}
+			default:
+				throw NotImplementedException("Unimplemented constraint for duckdb_constraints");
+			}
+
+			vector<Value> index_list;
+			vector<Value> column_name_list;
+			for (auto column_index : column_index_list) {
+				index_list.push_back(Value::BIGINT(column_index));
+				column_name_list.emplace_back(table.columns[column_index].Name());
+			}
+
+			// constraint_column_indexes, LIST
+			output.SetValue(8, count, Value::LIST(move(index_list)));
+
+			// constraint_column_names, LIST
+			output.SetValue(9, count, Value::LIST(move(column_name_list)));
+
+			count++;
+		}
+		if (data.constraint_offset >= table.constraints.size()) {
+			data.constraint_offset = 0;
+			data.offset++;
+		}
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBConstraintsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_constraints", {}, DuckDBConstraintsFunction, DuckDBConstraintsBind,
+	                              DuckDBConstraintsInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DependencyInformation {
+	CatalogEntry *object;
+	CatalogEntry *dependent;
+	DependencyType type;
+};
+
+struct DuckDBDependenciesData : public GlobalTableFunctionState {
+	DuckDBDependenciesData() : offset(0) {
+	}
+
+	vector<DependencyInformation> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBDependenciesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                       vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("classid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("objid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("objsubid");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("refclassid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("refobjid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("refobjsubid");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("deptype");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBDependenciesInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBDependenciesData>();
+
+	// scan all the schemas and collect them
+	auto &catalog = Catalog::GetCatalog(context);
+	auto &dependency_manager = catalog.GetDependencyManager();
+	dependency_manager.Scan([&](CatalogEntry *obj, CatalogEntry *dependent, DependencyType type) {
+		DependencyInformation info;
+		info.object = obj;
+		info.dependent = dependent;
+		info.type = type;
+		result->entries.push_back(info);
+	});
+
+	return move(result);
+}
+
+void DuckDBDependenciesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBDependenciesData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset];
+
+		// return values:
+		// classid, LogicalType::BIGINT
+		output.SetValue(0, count, Value::BIGINT(0));
+		// objid, LogicalType::BIGINT
+		output.SetValue(1, count, Value::BIGINT(entry.object->oid));
+		// objsubid, LogicalType::INTEGER
+		output.SetValue(2, count, Value::INTEGER(0));
+		// refclassid, LogicalType::BIGINT
+		output.SetValue(3, count, Value::BIGINT(0));
+		// refobjid, LogicalType::BIGINT
+		output.SetValue(4, count, Value::BIGINT(entry.dependent->oid));
+		// refobjsubid, LogicalType::INTEGER
+		output.SetValue(5, count, Value::INTEGER(0));
+		// deptype, LogicalType::VARCHAR
+		string dependency_type_str;
+		switch (entry.type) {
+		case DependencyType::DEPENDENCY_REGULAR:
+			dependency_type_str = "n";
+			break;
+		case DependencyType::DEPENDENCY_AUTOMATIC:
+			dependency_type_str = "a";
+			break;
+		default:
+			throw NotImplementedException("Unimplemented dependency type");
+		}
+		output.SetValue(6, count, Value(dependency_type_str));
+
+		data.offset++;
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBDependenciesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_dependencies", {}, DuckDBDependenciesFunction, DuckDBDependenciesBind,
+	                              DuckDBDependenciesInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct ExtensionInformation {
+	string name;
+	bool loaded = false;
+	bool installed = false;
+	string file_path;
+	string description;
+};
+
+struct DuckDBExtensionsData : public GlobalTableFunctionState {
+	DuckDBExtensionsData() : offset(0) {
+	}
+
+	vector<ExtensionInformation> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBExtensionsBind(ClientContext &context, TableFunctionBindInput &input,
+                                                     vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("extension_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("loaded");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("installed");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("install_path");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("description");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBExtensionsInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBExtensionsData>();
+
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto &db = DatabaseInstance::GetDatabase(context);
+
+	map<string, ExtensionInformation> installed_extensions;
+	auto extension_count = ExtensionHelper::DefaultExtensionCount();
+	for (idx_t i = 0; i < extension_count; i++) {
+		auto extension = ExtensionHelper::GetDefaultExtension(i);
+		ExtensionInformation info;
+		info.name = extension.name;
+		info.installed = extension.statically_loaded;
+		info.loaded = false;
+		info.file_path = extension.statically_loaded ? "(BUILT-IN)" : string();
+		info.description = extension.description;
+		installed_extensions[info.name] = move(info);
+	}
+
+	// scan the install directory for installed extensions
+	auto ext_directory = ExtensionHelper::ExtensionDirectory(fs);
+	fs.ListFiles(ext_directory, [&](const string &path, bool is_directory) {
+		if (!StringUtil::EndsWith(path, ".duckdb_extension")) {
+			return;
+		}
+		ExtensionInformation info;
+		info.name = fs.ExtractBaseName(path);
+		info.loaded = false;
+		info.file_path = fs.JoinPath(ext_directory, path);
+		auto entry = installed_extensions.find(info.name);
+		if (entry == installed_extensions.end()) {
+			installed_extensions[info.name] = move(info);
+		} else {
+			if (!entry->second.loaded) {
+				entry->second.file_path = info.file_path;
+			}
+			entry->second.installed = true;
+		}
+	});
+
+	// now check the list of currently loaded extensions
+	auto &loaded_extensions = db.LoadedExtensions();
+	for (auto &ext_name : loaded_extensions) {
+		auto entry = installed_extensions.find(ext_name);
+		if (entry == installed_extensions.end()) {
+			ExtensionInformation info;
+			info.name = ext_name;
+			info.loaded = true;
+			installed_extensions[ext_name] = move(info);
+		} else {
+			entry->second.loaded = true;
+		}
+	}
+
+	result->entries.reserve(installed_extensions.size());
+	for (auto &kv : installed_extensions) {
+		result->entries.push_back(move(kv.second));
+	}
+	return move(result);
+}
+
+void DuckDBExtensionsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBExtensionsData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset];
+
+		// return values:
+		// extension_name LogicalType::VARCHAR
+		output.SetValue(0, count, Value(entry.name));
+		// loaded LogicalType::BOOLEAN
+		output.SetValue(1, count, Value::BOOLEAN(entry.loaded));
+		// installed LogicalType::BOOLEAN
+		output.SetValue(2, count, !entry.installed && entry.loaded ? Value() : Value::BOOLEAN(entry.installed));
+		// install_path LogicalType::VARCHAR
+		output.SetValue(3, count, Value(entry.file_path));
+		// description LogicalType::VARCHAR
+		output.SetValue(4, count, Value(entry.description));
+
+		data.offset++;
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBExtensionsFun::RegisterFunction(BuiltinFunctions &set) {
+	TableFunctionSet functions("duckdb_extensions");
+	functions.AddFunction(TableFunction({}, DuckDBExtensionsFunction, DuckDBExtensionsBind, DuckDBExtensionsInit));
+	set.AddFunction(functions);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DuckDBFunctionsData : public GlobalTableFunctionState {
+	DuckDBFunctionsData() : offset(0), offset_in_entry(0) {
+	}
+
+	vector<CatalogEntry *> entries;
+	idx_t offset;
+	idx_t offset_in_entry;
+};
+
+static unique_ptr<FunctionData> DuckDBFunctionsBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("schema_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("function_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("function_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("description");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("return_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("parameters");
+	return_types.push_back(LogicalType::LIST(LogicalType::VARCHAR));
+
+	names.emplace_back("parameter_types");
+	return_types.push_back(LogicalType::LIST(LogicalType::VARCHAR));
+
+	names.emplace_back("varargs");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("macro_definition");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("has_side_effects");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	return nullptr;
+}
+
+static void ExtractFunctionsFromSchema(ClientContext &context, SchemaCatalogEntry &schema,
+                                       DuckDBFunctionsData &result) {
+	schema.Scan(context, CatalogType::SCALAR_FUNCTION_ENTRY,
+	            [&](CatalogEntry *entry) { result.entries.push_back(entry); });
+	schema.Scan(context, CatalogType::TABLE_FUNCTION_ENTRY,
+	            [&](CatalogEntry *entry) { result.entries.push_back(entry); });
+	schema.Scan(context, CatalogType::PRAGMA_FUNCTION_ENTRY,
+	            [&](CatalogEntry *entry) { result.entries.push_back(entry); });
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBFunctionsInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBFunctionsData>();
+
+	// scan all the schemas for tables and collect themand collect them
+	auto schemas = Catalog::GetCatalog(context).schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		ExtractFunctionsFromSchema(context, *schema, *result);
+	};
+	ExtractFunctionsFromSchema(context, *ClientData::Get(context).temporary_objects, *result);
+
+	std::sort(result->entries.begin(), result->entries.end(),
+	          [&](CatalogEntry *a, CatalogEntry *b) { return (int)a->type < (int)b->type; });
+	return move(result);
+}
+
+struct ScalarFunctionExtractor {
+	static idx_t FunctionCount(ScalarFunctionCatalogEntry &entry) {
+		return entry.functions.size();
+	}
+
+	static Value GetFunctionType() {
+		return Value("scalar");
+	}
+
+	static Value GetFunctionDescription(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetReturnType(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		return Value(entry.functions[offset].return_type.ToString());
+	}
+
+	static Value GetParameters(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.emplace_back("col" + to_string(i));
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetParameterTypes(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.emplace_back(entry.functions[offset].arguments[i].ToString());
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetVarArgs(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		return entry.functions[offset].varargs.id() == LogicalTypeId::INVALID
+		           ? Value()
+		           : Value(entry.functions[offset].varargs.ToString());
+	}
+
+	static Value GetMacroDefinition(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value HasSideEffects(ScalarFunctionCatalogEntry &entry, idx_t offset) {
+		return Value::BOOLEAN(entry.functions[offset].has_side_effects);
+	}
+};
+
+struct AggregateFunctionExtractor {
+	static idx_t FunctionCount(AggregateFunctionCatalogEntry &entry) {
+		return entry.functions.size();
+	}
+
+	static Value GetFunctionType() {
+		return Value("aggregate");
+	}
+
+	static Value GetFunctionDescription(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetReturnType(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		return Value(entry.functions[offset].return_type.ToString());
+	}
+
+	static Value GetParameters(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.emplace_back("col" + to_string(i));
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetParameterTypes(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.emplace_back(entry.functions[offset].arguments[i].ToString());
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetVarArgs(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		return entry.functions[offset].varargs.id() == LogicalTypeId::INVALID
+		           ? Value()
+		           : Value(entry.functions[offset].varargs.ToString());
+	}
+
+	static Value GetMacroDefinition(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value HasSideEffects(AggregateFunctionCatalogEntry &entry, idx_t offset) {
+		return Value::BOOLEAN(entry.functions[offset].has_side_effects);
+	}
+};
+
+struct MacroExtractor {
+	static idx_t FunctionCount(ScalarMacroCatalogEntry &entry) {
+		return 1;
+	}
+
+	static Value GetFunctionType() {
+		return Value("macro");
+	}
+
+	static Value GetFunctionDescription(ScalarMacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetReturnType(ScalarMacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetParameters(ScalarMacroCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (auto &param : entry.function->parameters) {
+			D_ASSERT(param->type == ExpressionType::COLUMN_REF);
+			auto &colref = (ColumnRefExpression &)*param;
+			results.emplace_back(colref.GetColumnName());
+		}
+		for (auto &param_entry : entry.function->default_parameters) {
+			results.emplace_back(param_entry.first);
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetParameterTypes(ScalarMacroCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.function->parameters.size(); i++) {
+			results.emplace_back(LogicalType::VARCHAR);
+		}
+		for (idx_t i = 0; i < entry.function->default_parameters.size(); i++) {
+			results.emplace_back(LogicalType::VARCHAR);
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetVarArgs(ScalarMacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetMacroDefinition(ScalarMacroCatalogEntry &entry, idx_t offset) {
+		D_ASSERT(entry.function->type == MacroType::SCALAR_MACRO);
+		auto &func = (ScalarMacroFunction &)*entry.function;
+		return func.expression->ToString();
+	}
+
+	static Value HasSideEffects(ScalarMacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+};
+
+struct TableMacroExtractor {
+	static idx_t FunctionCount(TableMacroCatalogEntry &entry) {
+		return 1;
+	}
+
+	static Value GetFunctionType() {
+		return Value("table_macro");
+	}
+
+	static Value GetFunctionDescription(TableMacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetReturnType(TableMacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetParameters(TableMacroCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (auto &param : entry.function->parameters) {
+			D_ASSERT(param->type == ExpressionType::COLUMN_REF);
+			auto &colref = (ColumnRefExpression &)*param;
+			results.emplace_back(colref.GetColumnName());
+		}
+		for (auto &param_entry : entry.function->default_parameters) {
+			results.emplace_back(param_entry.first);
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetParameterTypes(TableMacroCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.function->parameters.size(); i++) {
+			results.emplace_back(LogicalType::VARCHAR);
+		}
+		for (idx_t i = 0; i < entry.function->default_parameters.size(); i++) {
+			results.emplace_back(LogicalType::VARCHAR);
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetVarArgs(TableMacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetMacroDefinition(TableMacroCatalogEntry &entry, idx_t offset) {
+		if (entry.function->type == MacroType::SCALAR_MACRO) {
+			auto &func = (ScalarMacroFunction &)*entry.function;
+			return func.expression->ToString();
+		}
+		return Value();
+	}
+
+	static Value HasSideEffects(TableMacroCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+};
+
+struct TableFunctionExtractor {
+	static idx_t FunctionCount(TableFunctionCatalogEntry &entry) {
+		return entry.functions.size();
+	}
+
+	static Value GetFunctionType() {
+		return Value("table");
+	}
+
+	static Value GetFunctionDescription(TableFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetReturnType(TableFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetParameters(TableFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.emplace_back("col" + to_string(i));
+		}
+		for (auto &param : entry.functions[offset].named_parameters) {
+			results.emplace_back(param.first);
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetParameterTypes(TableFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.emplace_back(entry.functions[offset].arguments[i].ToString());
+		}
+		for (auto &param : entry.functions[offset].named_parameters) {
+			results.emplace_back(param.second.ToString());
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetVarArgs(TableFunctionCatalogEntry &entry, idx_t offset) {
+		return entry.functions[offset].varargs.id() == LogicalTypeId::INVALID
+		           ? Value()
+		           : Value(entry.functions[offset].varargs.ToString());
+	}
+
+	static Value GetMacroDefinition(TableFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value HasSideEffects(TableFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+};
+
+struct PragmaFunctionExtractor {
+	static idx_t FunctionCount(PragmaFunctionCatalogEntry &entry) {
+		return entry.functions.size();
+	}
+
+	static Value GetFunctionType() {
+		return Value("pragma");
+	}
+
+	static Value GetFunctionDescription(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetReturnType(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value GetParameters(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.emplace_back("col" + to_string(i));
+		}
+		for (auto &param : entry.functions[offset].named_parameters) {
+			results.emplace_back(param.first);
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetParameterTypes(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		vector<Value> results;
+		for (idx_t i = 0; i < entry.functions[offset].arguments.size(); i++) {
+			results.emplace_back(entry.functions[offset].arguments[i].ToString());
+		}
+		for (auto &param : entry.functions[offset].named_parameters) {
+			results.emplace_back(param.second.ToString());
+		}
+		return Value::LIST(LogicalType::VARCHAR, move(results));
+	}
+
+	static Value GetVarArgs(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		return entry.functions[offset].varargs.id() == LogicalTypeId::INVALID
+		           ? Value()
+		           : Value(entry.functions[offset].varargs.ToString());
+	}
+
+	static Value GetMacroDefinition(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+
+	static Value HasSideEffects(PragmaFunctionCatalogEntry &entry, idx_t offset) {
+		return Value();
+	}
+};
+
+template <class T, class OP>
+bool ExtractFunctionData(StandardEntry *entry, idx_t function_idx, DataChunk &output, idx_t output_offset) {
+	auto &function = (T &)*entry;
+	// schema_name, LogicalType::VARCHAR
+	output.SetValue(0, output_offset, Value(entry->schema->name));
+
+	// function_name, LogicalType::VARCHAR
+	output.SetValue(1, output_offset, Value(entry->name));
+
+	// function_type, LogicalType::VARCHAR
+	output.SetValue(2, output_offset, Value(OP::GetFunctionType()));
+
+	// function_description, LogicalType::VARCHAR
+	output.SetValue(3, output_offset, OP::GetFunctionDescription(function, function_idx));
+
+	// return_type, LogicalType::VARCHAR
+	output.SetValue(4, output_offset, OP::GetReturnType(function, function_idx));
+
+	// parameters, LogicalType::LIST(LogicalType::VARCHAR)
+	output.SetValue(5, output_offset, OP::GetParameters(function, function_idx));
+
+	// parameter_types, LogicalType::LIST(LogicalType::VARCHAR)
+	output.SetValue(6, output_offset, OP::GetParameterTypes(function, function_idx));
+
+	// varargs, LogicalType::VARCHAR
+	output.SetValue(7, output_offset, OP::GetVarArgs(function, function_idx));
+
+	// macro_definition, LogicalType::VARCHAR
+	output.SetValue(8, output_offset, OP::GetMacroDefinition(function, function_idx));
+
+	// has_side_effects, LogicalType::BOOLEAN
+	output.SetValue(9, output_offset, OP::HasSideEffects(function, function_idx));
+
+	return function_idx + 1 == OP::FunctionCount(function);
+}
+
+void DuckDBFunctionsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBFunctionsData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset];
+		auto standard_entry = (StandardEntry *)entry;
+		bool finished = false;
+
+		switch (entry->type) {
+		case CatalogType::SCALAR_FUNCTION_ENTRY:
+			finished = ExtractFunctionData<ScalarFunctionCatalogEntry, ScalarFunctionExtractor>(
+			    standard_entry, data.offset_in_entry, output, count);
+			break;
+		case CatalogType::AGGREGATE_FUNCTION_ENTRY:
+			finished = ExtractFunctionData<AggregateFunctionCatalogEntry, AggregateFunctionExtractor>(
+			    standard_entry, data.offset_in_entry, output, count);
+			break;
+		case CatalogType::TABLE_MACRO_ENTRY:
+			finished = ExtractFunctionData<TableMacroCatalogEntry, TableMacroExtractor>(
+			    standard_entry, data.offset_in_entry, output, count);
+			break;
+
+		case CatalogType::MACRO_ENTRY:
+			finished = ExtractFunctionData<ScalarMacroCatalogEntry, MacroExtractor>(
+			    standard_entry, data.offset_in_entry, output, count);
+			break;
+		case CatalogType::TABLE_FUNCTION_ENTRY:
+			finished = ExtractFunctionData<TableFunctionCatalogEntry, TableFunctionExtractor>(
+			    standard_entry, data.offset_in_entry, output, count);
+			break;
+		case CatalogType::PRAGMA_FUNCTION_ENTRY:
+			finished = ExtractFunctionData<PragmaFunctionCatalogEntry, PragmaFunctionExtractor>(
+			    standard_entry, data.offset_in_entry, output, count);
+			break;
+		default:
+			throw InternalException("FIXME: unrecognized function type in duckdb_functions");
+		}
+		if (finished) {
+			// finished with this function, move to the next function
+			data.offset++;
+			data.offset_in_entry = 0;
+		} else {
+			// more functions remain
+			data.offset_in_entry++;
+		}
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBFunctionsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("duckdb_functions", {}, DuckDBFunctionsFunction, DuckDBFunctionsBind, DuckDBFunctionsInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DuckDBIndexesData : public GlobalTableFunctionState {
+	DuckDBIndexesData() : offset(0) {
+	}
+
+	vector<CatalogEntry *> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBIndexesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("schema_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("schema_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("index_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("index_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("table_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("table_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("is_unique");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("is_primary");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("expressions");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("sql");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBIndexesInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBIndexesData>();
+
+	// scan all the schemas for tables and collect themand collect them
+	auto schemas = Catalog::GetCatalog(context).schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		schema->Scan(context, CatalogType::INDEX_ENTRY, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	};
+
+	// check the temp schema as well
+	ClientData::Get(context).temporary_objects->Scan(context, CatalogType::INDEX_ENTRY,
+	                                                 [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	return move(result);
+}
+
+void DuckDBIndexesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBIndexesData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset++];
+
+		auto &index = (IndexCatalogEntry &)*entry;
+		// return values:
+
+		// schema_name, VARCHAR
+		output.SetValue(0, count, Value(index.schema->name));
+		// schema_oid, BIGINT
+		output.SetValue(1, count, Value::BIGINT(index.schema->oid));
+		// index_name, VARCHAR
+		output.SetValue(2, count, Value(index.name));
+		// index_oid, BIGINT
+		output.SetValue(3, count, Value::BIGINT(index.oid));
+		// table_name, VARCHAR
+		output.SetValue(4, count, Value(index.info->table));
+		// table_oid, BIGINT
+		// find the table in the catalog
+		auto &catalog = Catalog::GetCatalog(context);
+		auto table_entry = catalog.GetEntry(context, CatalogType::TABLE_ENTRY, index.info->schema, index.info->table);
+		output.SetValue(5, count, Value::BIGINT(table_entry->oid));
+		// is_unique, BOOLEAN
+		output.SetValue(6, count, Value::BOOLEAN(index.index->IsUnique()));
+		// is_primary, BOOLEAN
+		output.SetValue(7, count, Value::BOOLEAN(index.index->IsPrimary()));
+		// expressions, VARCHAR
+		output.SetValue(8, count, Value());
+		// sql, VARCHAR
+		output.SetValue(9, count, Value(index.ToSQL()));
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBIndexesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_indexes", {}, DuckDBIndexesFunction, DuckDBIndexesBind, DuckDBIndexesInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct DuckDBKeywordsData : public GlobalTableFunctionState {
+	DuckDBKeywordsData() : offset(0) {
+	}
+
+	vector<ParserKeyword> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBKeywordsBind(ClientContext &context, TableFunctionBindInput &input,
+                                                   vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("keyword_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("keyword_category");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBKeywordsInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBKeywordsData>();
+	result->entries = Parser::KeywordList();
+	return move(result);
+}
+
+void DuckDBKeywordsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBKeywordsData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset++];
+
+		// keyword_name, VARCHAR
+		output.SetValue(0, count, Value(entry.name));
+		// keyword_category, VARCHAR
+		string category_name;
+		switch (entry.category) {
+		case KeywordCategory::KEYWORD_RESERVED:
+			category_name = "reserved";
+			break;
+		case KeywordCategory::KEYWORD_UNRESERVED:
+			category_name = "unreserved";
+			break;
+		case KeywordCategory::KEYWORD_TYPE_FUNC:
+			category_name = "type_function";
+			break;
+		case KeywordCategory::KEYWORD_COL_NAME:
+			category_name = "column_name";
+			break;
+		default:
+			throw InternalException("Unrecognized keyword category");
+		}
+		output.SetValue(1, count, Value(move(category_name)));
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBKeywordsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("duckdb_keywords", {}, DuckDBKeywordsFunction, DuckDBKeywordsBind, DuckDBKeywordsInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DuckDBSchemasData : public GlobalTableFunctionState {
+	DuckDBSchemasData() : offset(0) {
+	}
+
+	vector<SchemaCatalogEntry *> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBSchemasBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("schema_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("internal");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("sql");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBSchemasInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBSchemasData>();
+
+	// scan all the schemas and collect them
+	Catalog::GetCatalog(context).ScanSchemas(
+	    context, [&](CatalogEntry *entry) { result->entries.push_back((SchemaCatalogEntry *)entry); });
+	// get the temp schema as well
+	result->entries.push_back(ClientData::Get(context).temporary_objects.get());
+
+	return move(result);
+}
+
+void DuckDBSchemasFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBSchemasData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset];
+
+		// return values:
+		// "oid", PhysicalType::BIGINT
+		output.SetValue(0, count, Value::BIGINT(entry->oid));
+		// "schema_name", PhysicalType::VARCHAR
+		output.SetValue(1, count, Value(entry->name));
+		// "internal", PhysicalType::BOOLEAN
+		output.SetValue(2, count, Value::BOOLEAN(entry->internal));
+		// "sql", PhysicalType::VARCHAR
+		output.SetValue(3, count, Value());
+
+		data.offset++;
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBSchemasFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_schemas", {}, DuckDBSchemasFunction, DuckDBSchemasBind, DuckDBSchemasInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DuckDBSequencesData : public GlobalTableFunctionState {
+	DuckDBSequencesData() : offset(0) {
+	}
+
+	vector<CatalogEntry *> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBSequencesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("schema_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("schema_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("sequence_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("sequence_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("temporary");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("start_value");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("min_value");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("max_value");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("increment_by");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("cycle");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("last_value");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("sql");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBSequencesInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBSequencesData>();
+
+	// scan all the schemas for tables and collect themand collect them
+	auto schemas = Catalog::GetCatalog(context).schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		schema->Scan(context, CatalogType::SEQUENCE_ENTRY,
+		             [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	};
+
+	// check the temp schema as well
+	ClientData::Get(context).temporary_objects->Scan(context, CatalogType::SEQUENCE_ENTRY,
+	                                                 [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	return move(result);
+}
+
+void DuckDBSequencesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBSequencesData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset++];
+
+		auto &seq = (SequenceCatalogEntry &)*entry;
+		// return values:
+		// schema_name, VARCHAR
+		output.SetValue(0, count, Value(seq.schema->name));
+		// schema_oid, BIGINT
+		output.SetValue(1, count, Value::BIGINT(seq.schema->oid));
+		// sequence_name, VARCHAR
+		output.SetValue(2, count, Value(seq.name));
+		// sequence_oid, BIGINT
+		output.SetValue(3, count, Value::BIGINT(seq.oid));
+		// temporary, BOOLEAN
+		output.SetValue(4, count, Value::BOOLEAN(seq.temporary));
+		// start_value, BIGINT
+		output.SetValue(5, count, Value::BIGINT(seq.start_value));
+		// min_value, BIGINT
+		output.SetValue(6, count, Value::BIGINT(seq.min_value));
+		// max_value, BIGINT
+		output.SetValue(7, count, Value::BIGINT(seq.max_value));
+		// increment_by, BIGINT
+		output.SetValue(8, count, Value::BIGINT(seq.increment));
+		// cycle, BOOLEAN
+		output.SetValue(9, count, Value::BOOLEAN(seq.cycle));
+		// last_value, BIGINT
+		output.SetValue(10, count, seq.usage_count == 0 ? Value() : Value::BOOLEAN(seq.last_value));
+		// sql, LogicalType::VARCHAR
+		output.SetValue(11, count, Value(seq.ToSQL()));
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBSequencesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("duckdb_sequences", {}, DuckDBSequencesFunction, DuckDBSequencesBind, DuckDBSequencesInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+struct DuckDBSettingValue {
+	string name;
+	string value;
+	string description;
+	string input_type;
+};
+
+struct DuckDBSettingsData : public GlobalTableFunctionState {
+	DuckDBSettingsData() : offset(0) {
+	}
+
+	vector<DuckDBSettingValue> settings;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBSettingsBind(ClientContext &context, TableFunctionBindInput &input,
+                                                   vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("value");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("description");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("input_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBSettingsInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBSettingsData>();
+
+	auto &config = DBConfig::GetConfig(context);
+	auto options_count = DBConfig::GetOptionCount();
+	for (idx_t i = 0; i < options_count; i++) {
+		auto option = DBConfig::GetOptionByIndex(i);
+		D_ASSERT(option);
+		DuckDBSettingValue value;
+		value.name = option->name;
+		value.value = option->get_setting(context).ToString();
+		value.description = option->description;
+		value.input_type = LogicalTypeIdToString(option->parameter_type);
+
+		result->settings.push_back(move(value));
+	}
+	for (auto &ext_param : config.extension_parameters) {
+		Value setting_val;
+		string setting_str_val;
+		if (context.TryGetCurrentSetting(ext_param.first, setting_val)) {
+			setting_str_val = setting_val.ToString();
+		}
+		DuckDBSettingValue value;
+		value.name = ext_param.first;
+		value.value = move(setting_str_val);
+		value.description = ext_param.second.description;
+		value.input_type = ext_param.second.type.ToString();
+
+		result->settings.push_back(move(value));
+	}
+	return move(result);
+}
+
+void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBSettingsData &)*data_p.global_state;
+	if (data.offset >= data.settings.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.settings.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.settings[data.offset++];
+
+		// return values:
+		// name, LogicalType::VARCHAR
+		output.SetValue(0, count, Value(entry.name));
+		// value, LogicalType::VARCHAR
+		output.SetValue(1, count, Value(entry.value));
+		// description, LogicalType::VARCHAR
+		output.SetValue(2, count, Value(entry.description));
+		// input_type, LogicalType::VARCHAR
+		output.SetValue(3, count, Value(entry.input_type));
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBSettingsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("duckdb_settings", {}, DuckDBSettingsFunction, DuckDBSettingsBind, DuckDBSettingsInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DuckDBTablesData : public GlobalTableFunctionState {
+	DuckDBTablesData() : offset(0) {
+	}
+
+	vector<CatalogEntry *> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBTablesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("schema_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("schema_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("table_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("table_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("internal");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("temporary");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("has_primary_key");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("estimated_size");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("column_count");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("index_count");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("check_constraint_count");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("sql");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBTablesInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBTablesData>();
+
+	// scan all the schemas for tables and collect themand collect them
+	auto schemas = Catalog::GetCatalog(context).schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		schema->Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	};
+
+	// check the temp schema as well
+	ClientData::Get(context).temporary_objects->Scan(context, CatalogType::TABLE_ENTRY,
+	                                                 [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	return move(result);
+}
+
+static bool TableHasPrimaryKey(TableCatalogEntry &table) {
+	for (auto &constraint : table.constraints) {
+		if (constraint->type == ConstraintType::UNIQUE) {
+			auto &unique = (UniqueConstraint &)*constraint;
+			if (unique.is_primary_key) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+static idx_t CheckConstraintCount(TableCatalogEntry &table) {
+	idx_t check_count = 0;
+	for (auto &constraint : table.constraints) {
+		if (constraint->type == ConstraintType::CHECK) {
+			check_count++;
+		}
+	}
+	return check_count;
+}
+
+void DuckDBTablesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBTablesData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset++];
+
+		if (entry->type != CatalogType::TABLE_ENTRY) {
+			continue;
+		}
+		auto &table = (TableCatalogEntry &)*entry;
+		// return values:
+		// schema_name, LogicalType::VARCHAR
+		output.SetValue(0, count, Value(table.schema->name));
+		// schema_oid, LogicalType::BIGINT
+		output.SetValue(1, count, Value::BIGINT(table.schema->oid));
+		// table_name, LogicalType::VARCHAR
+		output.SetValue(2, count, Value(table.name));
+		// table_oid, LogicalType::BIGINT
+		output.SetValue(3, count, Value::BIGINT(table.oid));
+		// internal, LogicalType::BOOLEAN
+		output.SetValue(4, count, Value::BOOLEAN(table.internal));
+		// temporary, LogicalType::BOOLEAN
+		output.SetValue(5, count, Value::BOOLEAN(table.temporary));
+		// has_primary_key, LogicalType::BOOLEAN
+		output.SetValue(6, count, Value::BOOLEAN(TableHasPrimaryKey(table)));
+		// estimated_size, LogicalType::BIGINT
+		output.SetValue(7, count, Value::BIGINT(table.storage->info->cardinality.load()));
+		// column_count, LogicalType::BIGINT
+		output.SetValue(8, count, Value::BIGINT(table.columns.size()));
+		// index_count, LogicalType::BIGINT
+		output.SetValue(9, count, Value::BIGINT(table.storage->info->indexes.Count()));
+		// check_constraint_count, LogicalType::BIGINT
+		output.SetValue(10, count, Value::BIGINT(CheckConstraintCount(table)));
+		// sql, LogicalType::VARCHAR
+		output.SetValue(11, count, Value(table.ToSQL()));
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBTablesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_tables", {}, DuckDBTablesFunction, DuckDBTablesBind, DuckDBTablesInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DuckDBTypesData : public GlobalTableFunctionState {
+	DuckDBTypesData() : offset(0) {
+	}
+
+	vector<TypeCatalogEntry *> entries;
+	idx_t offset;
+	unordered_set<int64_t> oids;
+};
+
+static unique_ptr<FunctionData> DuckDBTypesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("schema_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("schema_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("type_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("type_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("type_size");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("logical_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	// NUMERIC, STRING, DATETIME, BOOLEAN, COMPOSITE, USER
+	names.emplace_back("type_category");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("internal");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBTypesInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBTypesData>();
+	auto schemas = Catalog::GetCatalog(context).schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		schema->Scan(context, CatalogType::TYPE_ENTRY,
+		             [&](CatalogEntry *entry) { result->entries.push_back((TypeCatalogEntry *)entry); });
+	};
+
+	// check the temp schema as well
+	ClientData::Get(context).temporary_objects->Scan(context, CatalogType::TYPE_ENTRY, [&](CatalogEntry *entry) {
+		result->entries.push_back((TypeCatalogEntry *)entry);
+	});
+	return move(result);
+}
+
+void DuckDBTypesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBTypesData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &type_entry = data.entries[data.offset++];
+		auto &type = type_entry->user_type;
+
+		// return values:
+		// schema_name, LogicalType::VARCHAR
+		output.SetValue(0, count, Value(type_entry->schema->name));
+		// schema_oid, LogicalType::BIGINT
+		output.SetValue(1, count, Value::BIGINT(type_entry->schema->oid));
+		// type_oid, BIGINT
+		int64_t oid;
+		if (type_entry->internal) {
+			oid = int64_t(type.id());
+		} else {
+			oid = type_entry->oid;
+		}
+		Value oid_val;
+		if (data.oids.find(oid) == data.oids.end()) {
+			data.oids.insert(oid);
+			oid_val = Value::BIGINT(oid);
+		} else {
+			oid_val = Value();
+		}
+		output.SetValue(2, count, oid_val);
+		// type_name, VARCHAR
+		output.SetValue(3, count, Value(type_entry->name));
+		// type_size, BIGINT
+		auto internal_type = type.InternalType();
+		output.SetValue(4, count,
+		                internal_type == PhysicalType::INVALID ? Value() : Value::BIGINT(GetTypeIdSize(internal_type)));
+		// logical_type, VARCHAR
+		output.SetValue(5, count, Value(LogicalTypeIdToString(type.id())));
+		// type_category, VARCHAR
+		string category;
+		switch (type.id()) {
+		case LogicalTypeId::TINYINT:
+		case LogicalTypeId::SMALLINT:
+		case LogicalTypeId::INTEGER:
+		case LogicalTypeId::BIGINT:
+		case LogicalTypeId::DECIMAL:
+		case LogicalTypeId::FLOAT:
+		case LogicalTypeId::DOUBLE:
+		case LogicalTypeId::UTINYINT:
+		case LogicalTypeId::USMALLINT:
+		case LogicalTypeId::UINTEGER:
+		case LogicalTypeId::UBIGINT:
+		case LogicalTypeId::HUGEINT:
+			category = "NUMERIC";
+			break;
+		case LogicalTypeId::DATE:
+		case LogicalTypeId::TIME:
+		case LogicalTypeId::TIMESTAMP_SEC:
+		case LogicalTypeId::TIMESTAMP_MS:
+		case LogicalTypeId::TIMESTAMP:
+		case LogicalTypeId::TIMESTAMP_NS:
+		case LogicalTypeId::INTERVAL:
+		case LogicalTypeId::TIME_TZ:
+		case LogicalTypeId::TIMESTAMP_TZ:
+			category = "DATETIME";
+			break;
+		case LogicalTypeId::CHAR:
+		case LogicalTypeId::VARCHAR:
+			category = "STRING";
+			break;
+		case LogicalTypeId::BOOLEAN:
+			category = "BOOLEAN";
+			break;
+		case LogicalTypeId::STRUCT:
+		case LogicalTypeId::LIST:
+		case LogicalTypeId::MAP:
+			category = "COMPOSITE";
+			break;
+		default:
+			break;
+		}
+		output.SetValue(6, count, category.empty() ? Value() : Value(category));
+		// internal, BOOLEAN
+		output.SetValue(7, count, Value::BOOLEAN(type_entry->internal));
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBTypesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_types", {}, DuckDBTypesFunction, DuckDBTypesBind, DuckDBTypesInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct DuckDBViewsData : public GlobalTableFunctionState {
+	DuckDBViewsData() : offset(0) {
+	}
+
+	vector<CatalogEntry *> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> DuckDBViewsBind(ClientContext &context, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("schema_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("schema_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("view_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("view_oid");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("internal");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("temporary");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("column_count");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("sql");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DuckDBViewsInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<DuckDBViewsData>();
+
+	// scan all the schemas for tables and collect themand collect them
+	auto schemas = Catalog::GetCatalog(context).schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		schema->Scan(context, CatalogType::VIEW_ENTRY, [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	};
+
+	// check the temp schema as well
+	ClientData::Get(context).temporary_objects->Scan(context, CatalogType::VIEW_ENTRY,
+	                                                 [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	return move(result);
+}
+
+void DuckDBViewsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (DuckDBViewsData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.entries[data.offset++];
+
+		if (entry->type != CatalogType::VIEW_ENTRY) {
+			continue;
+		}
+		auto &view = (ViewCatalogEntry &)*entry;
+
+		// return values:
+		// schema_name, LogicalType::VARCHAR
+		output.SetValue(0, count, Value(view.schema->name));
+		// schema_oid, LogicalType::BIGINT
+		output.SetValue(1, count, Value::BIGINT(view.schema->oid));
+		// view_name, LogicalType::VARCHAR
+		output.SetValue(2, count, Value(view.name));
+		// view_oid, LogicalType::BIGINT
+		output.SetValue(3, count, Value::BIGINT(view.oid));
+		// internal, LogicalType::BOOLEAN
+		output.SetValue(4, count, Value::BOOLEAN(view.internal));
+		// temporary, LogicalType::BOOLEAN
+		output.SetValue(5, count, Value::BOOLEAN(view.temporary));
+		// column_count, LogicalType::BIGINT
+		output.SetValue(6, count, Value::BIGINT(view.types.size()));
+		// sql, LogicalType::VARCHAR
+		output.SetValue(7, count, Value(view.ToSQL()));
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void DuckDBViewsFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("duckdb_views", {}, DuckDBViewsFunction, DuckDBViewsBind, DuckDBViewsInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct PragmaCollateData : public GlobalTableFunctionState {
+	PragmaCollateData() : offset(0) {
+	}
+
+	vector<string> entries;
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> PragmaCollateBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("collname");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaCollateInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<PragmaCollateData>();
+
+	Catalog::GetCatalog(context).schemas->Scan(context, [&](CatalogEntry *entry) {
+		auto schema = (SchemaCatalogEntry *)entry;
+		schema->Scan(context, CatalogType::COLLATION_ENTRY,
+		             [&](CatalogEntry *entry) { result->entries.push_back(entry->name); });
+	});
+
+	return move(result);
+}
+
+static void PragmaCollateFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (PragmaCollateData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	idx_t next = MinValue<idx_t>(data.offset + STANDARD_VECTOR_SIZE, data.entries.size());
+	output.SetCardinality(next - data.offset);
+	for (idx_t i = data.offset; i < next; i++) {
+		auto index = i - data.offset;
+		output.SetValue(0, index, Value(data.entries[i]));
+	}
+
+	data.offset = next;
+}
+
+void PragmaCollations::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("pragma_collations", {}, PragmaCollateFunction, PragmaCollateBind, PragmaCollateInit));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+struct PragmaDatabaseListData : public GlobalTableFunctionState {
+	PragmaDatabaseListData() : finished(false) {
+	}
+
+	bool finished;
+};
+
+static unique_ptr<FunctionData> PragmaDatabaseListBind(ClientContext &context, TableFunctionBindInput &input,
+                                                       vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("seq");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("file");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaDatabaseListInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_unique<PragmaDatabaseListData>();
+}
+
+void PragmaDatabaseListFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (PragmaDatabaseListData &)*data_p.global_state;
+	if (data.finished) {
+		return;
+	}
+
+	output.SetCardinality(1);
+	output.data[0].SetValue(0, Value::INTEGER(0));
+	output.data[1].SetValue(0, Value("main"));
+	output.data[2].SetValue(0, Value(StorageManager::GetStorageManager(context).GetDBPath()));
+
+	data.finished = true;
+}
+
+void PragmaDatabaseList::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("pragma_database_list", {}, PragmaDatabaseListFunction, PragmaDatabaseListBind,
+	                              PragmaDatabaseListInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct PragmaDatabaseSizeData : public GlobalTableFunctionState {
+	PragmaDatabaseSizeData() : finished(false) {
+	}
+
+	bool finished;
+};
+
+static unique_ptr<FunctionData> PragmaDatabaseSizeBind(ClientContext &context, TableFunctionBindInput &input,
+                                                       vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("database_size");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("block_size");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("total_blocks");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("used_blocks");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("free_blocks");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("wal_size");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("memory_usage");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("memory_limit");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaDatabaseSizeInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_unique<PragmaDatabaseSizeData>();
+}
+
+void PragmaDatabaseSizeFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (PragmaDatabaseSizeData &)*data_p.global_state;
+	if (data.finished) {
+		return;
+	}
+	auto &storage = StorageManager::GetStorageManager(context);
+	auto &block_manager = BlockManager::GetBlockManager(context);
+	auto &buffer_manager = BufferManager::GetBufferManager(context);
+
+	output.SetCardinality(1);
+	if (!storage.InMemory()) {
+		auto total_blocks = block_manager.TotalBlocks();
+		auto block_size = Storage::BLOCK_ALLOC_SIZE;
+		auto free_blocks = block_manager.FreeBlocks();
+		auto used_blocks = total_blocks - free_blocks;
+		auto bytes = (total_blocks * block_size);
+		auto wal = storage.GetWriteAheadLog();
+		auto wal_size = wal ? wal->GetWALSize() : 0;
+		output.data[0].SetValue(0, Value(StringUtil::BytesToHumanReadableString(bytes)));
+		output.data[1].SetValue(0, Value::BIGINT(block_size));
+		output.data[2].SetValue(0, Value::BIGINT(total_blocks));
+		output.data[3].SetValue(0, Value::BIGINT(used_blocks));
+		output.data[4].SetValue(0, Value::BIGINT(free_blocks));
+		output.data[5].SetValue(0, Value(StringUtil::BytesToHumanReadableString(wal_size)));
+	} else {
+		output.data[0].SetValue(0, Value());
+		output.data[1].SetValue(0, Value());
+		output.data[2].SetValue(0, Value());
+		output.data[3].SetValue(0, Value());
+		output.data[4].SetValue(0, Value());
+		output.data[5].SetValue(0, Value());
+	}
+	output.data[6].SetValue(0, Value(StringUtil::BytesToHumanReadableString(buffer_manager.GetUsedMemory())));
+	auto max_memory = buffer_manager.GetMaxMemory();
+	output.data[7].SetValue(0, max_memory == (idx_t)-1 ? Value("Unlimited")
+	                                                   : Value(StringUtil::BytesToHumanReadableString(max_memory)));
+
+	data.finished = true;
+}
+
+void PragmaDatabaseSize::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("pragma_database_size", {}, PragmaDatabaseSizeFunction, PragmaDatabaseSizeBind,
+	                              PragmaDatabaseSizeInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct PragmaFunctionsData : public GlobalTableFunctionState {
+	PragmaFunctionsData() : offset(0), offset_in_entry(0) {
+	}
+
+	vector<CatalogEntry *> entries;
+	idx_t offset;
+	idx_t offset_in_entry;
+};
+
+static unique_ptr<FunctionData> PragmaFunctionsBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("parameters");
+	return_types.push_back(LogicalType::LIST(LogicalType::VARCHAR));
+
+	names.emplace_back("varargs");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("return_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("side_effects");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaFunctionsInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<PragmaFunctionsData>();
+
+	Catalog::GetCatalog(context).schemas->Scan(context, [&](CatalogEntry *entry) {
+		auto schema = (SchemaCatalogEntry *)entry;
+		schema->Scan(context, CatalogType::SCALAR_FUNCTION_ENTRY,
+		             [&](CatalogEntry *entry) { result->entries.push_back(entry); });
+	});
+
+	return move(result);
+}
+
+void AddFunction(BaseScalarFunction &f, idx_t &count, DataChunk &output, bool is_aggregate) {
+	output.SetValue(0, count, Value(f.name));
+	output.SetValue(1, count, Value(is_aggregate ? "AGGREGATE" : "SCALAR"));
+	auto result_data = FlatVector::GetData<list_entry_t>(output.data[2]);
+	result_data[count].offset = ListVector::GetListSize(output.data[2]);
+	result_data[count].length = f.arguments.size();
+	string parameters;
+	for (idx_t i = 0; i < f.arguments.size(); i++) {
+		auto val = Value(f.arguments[i].ToString());
+		ListVector::PushBack(output.data[2], val);
+	}
+
+	output.SetValue(3, count, f.varargs.id() != LogicalTypeId::INVALID ? Value(f.varargs.ToString()) : Value());
+	output.SetValue(4, count, f.return_type.ToString());
+	output.SetValue(5, count, Value::BOOLEAN(f.has_side_effects));
+
+	count++;
+}
+
+static void PragmaFunctionsFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (PragmaFunctionsData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	idx_t count = 0;
+	while (count < STANDARD_VECTOR_SIZE && data.offset < data.entries.size()) {
+		auto &entry = data.entries[data.offset];
+		switch (entry->type) {
+		case CatalogType::SCALAR_FUNCTION_ENTRY: {
+			auto &func = (ScalarFunctionCatalogEntry &)*entry;
+			if (data.offset_in_entry >= func.functions.size()) {
+				data.offset++;
+				data.offset_in_entry = 0;
+				break;
+			}
+			AddFunction(func.functions[data.offset_in_entry++], count, output, false);
+			break;
+		}
+		case CatalogType::AGGREGATE_FUNCTION_ENTRY: {
+			auto &aggr = (AggregateFunctionCatalogEntry &)*entry;
+			if (data.offset_in_entry >= aggr.functions.size()) {
+				data.offset++;
+				data.offset_in_entry = 0;
+				break;
+			}
+			AddFunction(aggr.functions[data.offset_in_entry++], count, output, true);
+			break;
+		}
+		default:
+			data.offset++;
+			break;
+		}
+	}
+	output.SetCardinality(count);
+}
+
+void PragmaFunctionPragma::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(
+	    TableFunction("pragma_functions", {}, PragmaFunctionsFunction, PragmaFunctionsBind, PragmaFunctionsInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+struct PragmaStorageFunctionData : public TableFunctionData {
+	explicit PragmaStorageFunctionData(TableCatalogEntry *table_entry) : table_entry(table_entry) {
+	}
+
+	TableCatalogEntry *table_entry;
+	vector<vector<Value>> storage_info;
+};
+
+struct PragmaStorageOperatorData : public GlobalTableFunctionState {
+	PragmaStorageOperatorData() : offset(0) {
+	}
+
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> PragmaStorageInfoBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("row_group_id");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("column_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("column_id");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("column_path");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("segment_id");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("segment_type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("start");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("count");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("compression");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("stats");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("has_updates");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("persistent");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("block_id");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	names.emplace_back("block_offset");
+	return_types.emplace_back(LogicalType::BIGINT);
+
+	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
+
+	// look up the table name in the catalog
+	auto &catalog = Catalog::GetCatalog(context);
+	auto entry = catalog.GetEntry(context, CatalogType::TABLE_ENTRY, qname.schema, qname.name);
+	if (entry->type != CatalogType::TABLE_ENTRY) {
+		throw Exception("storage_info requires a table as parameter");
+	}
+	auto table_entry = (TableCatalogEntry *)entry;
+
+	auto result = make_unique<PragmaStorageFunctionData>(table_entry);
+	result->storage_info = table_entry->storage->GetStorageInfo();
+	return move(result);
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaStorageInfoInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_unique<PragmaStorageOperatorData>();
+}
+
+static void PragmaStorageInfoFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = (PragmaStorageFunctionData &)*data_p.bind_data;
+	auto &data = (PragmaStorageOperatorData &)*data_p.global_state;
+	idx_t count = 0;
+	while (data.offset < bind_data.storage_info.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = bind_data.storage_info[data.offset++];
+		D_ASSERT(entry.size() + 1 == output.ColumnCount());
+		idx_t result_idx = 0;
+		for (idx_t col_idx = 0; col_idx < entry.size(); col_idx++, result_idx++) {
+			if (col_idx == 1) {
+				// write the column name
+				auto column_index = entry[col_idx].GetValue<int64_t>();
+				output.SetValue(result_idx, count, Value(bind_data.table_entry->columns[column_index].Name()));
+				result_idx++;
+			}
+			output.SetValue(result_idx, count, entry[col_idx]);
+		}
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void PragmaStorageInfo::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("pragma_storage_info", {LogicalType::VARCHAR}, PragmaStorageInfoFunction,
+	                              PragmaStorageInfoBind, PragmaStorageInfoInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+struct PragmaTableFunctionData : public TableFunctionData {
+	explicit PragmaTableFunctionData(CatalogEntry *entry_p) : entry(entry_p) {
+	}
+
+	CatalogEntry *entry;
+};
+
+struct PragmaTableOperatorData : public GlobalTableFunctionState {
+	PragmaTableOperatorData() : offset(0) {
+	}
+	idx_t offset;
+};
+
+static unique_ptr<FunctionData> PragmaTableInfoBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("cid");
+	return_types.emplace_back(LogicalType::INTEGER);
+
+	names.emplace_back("name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("type");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("notnull");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	names.emplace_back("dflt_value");
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	names.emplace_back("pk");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+
+	auto qname = QualifiedName::Parse(input.inputs[0].GetValue<string>());
+
+	// look up the table name in the catalog
+	auto &catalog = Catalog::GetCatalog(context);
+	auto entry = catalog.GetEntry(context, CatalogType::TABLE_ENTRY, qname.schema, qname.name);
+	return make_unique<PragmaTableFunctionData>(entry);
+}
+
+unique_ptr<GlobalTableFunctionState> PragmaTableInfoInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_unique<PragmaTableOperatorData>();
+}
+
+static void CheckConstraints(TableCatalogEntry *table, idx_t oid, bool &out_not_null, bool &out_pk) {
+	out_not_null = false;
+	out_pk = false;
+	// check all constraints
+	// FIXME: this is pretty inefficient, it probably doesn't matter
+	for (auto &constraint : table->bound_constraints) {
+		switch (constraint->type) {
+		case ConstraintType::NOT_NULL: {
+			auto &not_null = (BoundNotNullConstraint &)*constraint;
+			if (not_null.index == oid) {
+				out_not_null = true;
+			}
+			break;
+		}
+		case ConstraintType::UNIQUE: {
+			auto &unique = (BoundUniqueConstraint &)*constraint;
+			if (unique.is_primary_key && unique.key_set.find(oid) != unique.key_set.end()) {
+				out_pk = true;
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+}
+
+static void PragmaTableInfoTable(PragmaTableOperatorData &data, TableCatalogEntry *table, DataChunk &output) {
+	if (data.offset >= table->columns.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t next = MinValue<idx_t>(data.offset + STANDARD_VECTOR_SIZE, table->columns.size());
+	output.SetCardinality(next - data.offset);
+
+	for (idx_t i = data.offset; i < next; i++) {
+		bool not_null, pk;
+		auto index = i - data.offset;
+		auto &column = table->columns[i];
+		D_ASSERT(column.Oid() < (idx_t)NumericLimits<int32_t>::Maximum());
+		CheckConstraints(table, column.Oid(), not_null, pk);
+
+		// return values:
+		// "cid", PhysicalType::INT32
+		output.SetValue(0, index, Value::INTEGER((int32_t)column.Oid()));
+		// "name", PhysicalType::VARCHAR
+		output.SetValue(1, index, Value(column.Name()));
+		// "type", PhysicalType::VARCHAR
+		output.SetValue(2, index, Value(column.Type().ToString()));
+		// "notnull", PhysicalType::BOOL
+		output.SetValue(3, index, Value::BOOLEAN(not_null));
+		// "dflt_value", PhysicalType::VARCHAR
+		Value def_value = column.DefaultValue() ? Value(column.DefaultValue()->ToString()) : Value();
+		output.SetValue(4, index, def_value);
+		// "pk", PhysicalType::BOOL
+		output.SetValue(5, index, Value::BOOLEAN(pk));
+	}
+	data.offset = next;
+}
+
+static void PragmaTableInfoView(PragmaTableOperatorData &data, ViewCatalogEntry *view, DataChunk &output) {
+	if (data.offset >= view->types.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t next = MinValue<idx_t>(data.offset + STANDARD_VECTOR_SIZE, view->types.size());
+	output.SetCardinality(next - data.offset);
+
+	for (idx_t i = data.offset; i < next; i++) {
+		auto index = i - data.offset;
+		auto type = view->types[index];
+		auto &name = view->aliases[index];
+		// return values:
+		// "cid", PhysicalType::INT32
+
+		output.SetValue(0, index, Value::INTEGER((int32_t)index));
+		// "name", PhysicalType::VARCHAR
+		output.SetValue(1, index, Value(name));
+		// "type", PhysicalType::VARCHAR
+		output.SetValue(2, index, Value(type.ToString()));
+		// "notnull", PhysicalType::BOOL
+		output.SetValue(3, index, Value::BOOLEAN(false));
+		// "dflt_value", PhysicalType::VARCHAR
+		output.SetValue(4, index, Value());
+		// "pk", PhysicalType::BOOL
+		output.SetValue(5, index, Value::BOOLEAN(false));
+	}
+	data.offset = next;
+}
+
+static void PragmaTableInfoFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = (PragmaTableFunctionData &)*data_p.bind_data;
+	auto &state = (PragmaTableOperatorData &)*data_p.global_state;
+	switch (bind_data.entry->type) {
+	case CatalogType::TABLE_ENTRY:
+		PragmaTableInfoTable(state, (TableCatalogEntry *)bind_data.entry, output);
+		break;
+	case CatalogType::VIEW_ENTRY:
+		PragmaTableInfoView(state, (ViewCatalogEntry *)bind_data.entry, output);
+		break;
+	default:
+		throw NotImplementedException("Unimplemented catalog type for pragma_table_info");
+	}
+}
+
+void PragmaTableInfo::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("pragma_table_info", {LogicalType::VARCHAR}, PragmaTableInfoFunction,
+	                              PragmaTableInfoBind, PragmaTableInfoInit));
+}
+
+} // namespace duckdb
+
+
+
+
+#include <cmath>
+#include <limits>
+
+namespace duckdb {
+
+struct TestAllTypesData : public GlobalTableFunctionState {
+	TestAllTypesData() : offset(0) {
+	}
+
+	vector<vector<Value>> entries;
+	idx_t offset;
+};
+
+vector<TestType> TestAllTypesFun::GetTestTypes() {
+	vector<TestType> result;
+	// scalar types/numerics
+	result.emplace_back(LogicalType::BOOLEAN, "bool");
+	result.emplace_back(LogicalType::TINYINT, "tinyint");
+	result.emplace_back(LogicalType::SMALLINT, "smallint");
+	result.emplace_back(LogicalType::INTEGER, "int");
+	result.emplace_back(LogicalType::BIGINT, "bigint");
+	result.emplace_back(LogicalType::HUGEINT, "hugeint");
+	result.emplace_back(LogicalType::UTINYINT, "utinyint");
+	result.emplace_back(LogicalType::USMALLINT, "usmallint");
+	result.emplace_back(LogicalType::UINTEGER, "uint");
+	result.emplace_back(LogicalType::UBIGINT, "ubigint");
+	result.emplace_back(LogicalType::DATE, "date");
+	result.emplace_back(LogicalType::TIME, "time");
+	result.emplace_back(LogicalType::TIMESTAMP, "timestamp");
+	result.emplace_back(LogicalType::TIMESTAMP_S, "timestamp_s");
+	result.emplace_back(LogicalType::TIMESTAMP_MS, "timestamp_ms");
+	result.emplace_back(LogicalType::TIMESTAMP_NS, "timestamp_ns");
+	result.emplace_back(LogicalType::TIME_TZ, "time_tz");
+	result.emplace_back(LogicalType::TIMESTAMP_TZ, "timestamp_tz");
+	result.emplace_back(LogicalType::FLOAT, "float");
+	result.emplace_back(LogicalType::DOUBLE, "double");
+	result.emplace_back(LogicalType::DECIMAL(4, 1), "dec_4_1");
+	result.emplace_back(LogicalType::DECIMAL(9, 4), "dec_9_4");
+	result.emplace_back(LogicalType::DECIMAL(18, 6), "dec_18_6");
+	result.emplace_back(LogicalType::DECIMAL(38, 10), "dec38_10");
+	result.emplace_back(LogicalType::UUID, "uuid");
+
+	// interval
+	interval_t min_interval;
+	min_interval.months = 0;
+	min_interval.days = 0;
+	min_interval.micros = 0;
+
+	interval_t max_interval;
+	max_interval.months = 999;
+	max_interval.days = 999;
+	max_interval.micros = 999999999;
+	result.emplace_back(LogicalType::INTERVAL, "interval", Value::INTERVAL(min_interval),
+	                    Value::INTERVAL(max_interval));
+	// strings/blobs
+	result.emplace_back(LogicalType::VARCHAR, "varchar", Value("🦆🦆🦆🦆🦆🦆"), Value("goose"));
+	result.emplace_back(LogicalType::JSON, "json", Value("🦆🦆🦆🦆🦆🦆"), Value("goose"));
+	result.emplace_back(LogicalType::BLOB, "blob", Value::BLOB("thisisalongblob\\x00withnullbytes"),
+	                    Value("\\x00\\x00\\x00a"));
+
+	// enums
+	Vector small_enum(LogicalType::VARCHAR, 2);
+	auto small_enum_ptr = FlatVector::GetData<string_t>(small_enum);
+	small_enum_ptr[0] = StringVector::AddStringOrBlob(small_enum, "DUCK_DUCK_ENUM");
+	small_enum_ptr[1] = StringVector::AddStringOrBlob(small_enum, "GOOSE");
+	result.emplace_back(LogicalType::ENUM("small_enum", small_enum, 2), "small_enum");
+
+	Vector medium_enum(LogicalType::VARCHAR, 300);
+	auto medium_enum_ptr = FlatVector::GetData<string_t>(medium_enum);
+	for (idx_t i = 0; i < 300; i++) {
+		medium_enum_ptr[i] = StringVector::AddStringOrBlob(medium_enum, string("enum_") + to_string(i));
+	}
+	result.emplace_back(LogicalType::ENUM("medium_enum", medium_enum, 300), "medium_enum");
+
+	// this is a big one... not sure if we should push this one here, but it's required for completeness
+	Vector large_enum(LogicalType::VARCHAR, 70000);
+	auto large_enum_ptr = FlatVector::GetData<string_t>(large_enum);
+	for (idx_t i = 0; i < 70000; i++) {
+		large_enum_ptr[i] = StringVector::AddStringOrBlob(large_enum, string("enum_") + to_string(i));
+	}
+	result.emplace_back(LogicalType::ENUM("large_enum", large_enum, 70000), "large_enum");
+
+	// arrays
+	auto int_list_type = LogicalType::LIST(LogicalType::INTEGER);
+	auto empty_int_list = Value::EMPTYLIST(LogicalType::INTEGER);
+	auto int_list = Value::LIST({Value::INTEGER(42), Value::INTEGER(999), Value(LogicalType::INTEGER),
+	                             Value(LogicalType::INTEGER), Value::INTEGER(-42)});
+	result.emplace_back(int_list_type, "int_array", empty_int_list, int_list);
+
+	auto double_list_type = LogicalType::LIST(LogicalType::DOUBLE);
+	auto empty_double_list = Value::EMPTYLIST(LogicalType::DOUBLE);
+	auto double_list = Value::LIST(
+	    {Value::DOUBLE(42), Value::DOUBLE(NAN), Value::DOUBLE(std::numeric_limits<double>::infinity()),
+	     Value::DOUBLE(-std::numeric_limits<double>::infinity()), Value(LogicalType::DOUBLE), Value::DOUBLE(-42)});
+	result.emplace_back(double_list_type, "double_array", empty_double_list, double_list);
+
+	auto date_list_type = LogicalType::LIST(LogicalType::DATE);
+	auto empty_date_list = Value::EMPTYLIST(LogicalType::DATE);
+	auto date_list =
+	    Value::LIST({Value::DATE(date_t()), Value::DATE(date_t::infinity()), Value::DATE(date_t::ninfinity()),
+	                 Value(LogicalType::DATE), Value::DATE(Date::FromString("2022-05-12"))});
+	result.emplace_back(date_list_type, "date_array", empty_date_list, date_list);
+
+	auto timestamp_list_type = LogicalType::LIST(LogicalType::TIMESTAMP);
+	auto empty_timestamp_list = Value::EMPTYLIST(LogicalType::TIMESTAMP);
+	auto timestamp_list = Value::LIST({Value::TIMESTAMP(timestamp_t()), Value::TIMESTAMP(timestamp_t::infinity()),
+	                                   Value::TIMESTAMP(timestamp_t::ninfinity()), Value(LogicalType::TIMESTAMP),
+	                                   Value::TIMESTAMP(Timestamp::FromString("2022-05-12 16:23:45"))});
+	result.emplace_back(timestamp_list_type, "timestamp_array", empty_timestamp_list, timestamp_list);
+
+	auto timestamptz_list_type = LogicalType::LIST(LogicalType::TIMESTAMP_TZ);
+	auto empty_timestamptz_list = Value::EMPTYLIST(LogicalType::TIMESTAMP_TZ);
+	auto timestamptz_list = Value::LIST({Value::TIMESTAMPTZ(timestamp_t()), Value::TIMESTAMPTZ(timestamp_t::infinity()),
+	                                     Value::TIMESTAMPTZ(timestamp_t::ninfinity()), Value(LogicalType::TIMESTAMP_TZ),
+	                                     Value::TIMESTAMPTZ(Timestamp::FromString("2022-05-12 16:23:45-07"))});
+	result.emplace_back(timestamptz_list_type, "timestamptz_array", empty_timestamptz_list, timestamptz_list);
+
+	auto varchar_list_type = LogicalType::LIST(LogicalType::VARCHAR);
+	auto empty_varchar_list = Value::EMPTYLIST(LogicalType::VARCHAR);
+	auto varchar_list =
+	    Value::LIST({Value("🦆🦆🦆🦆🦆🦆"), Value("goose"), Value(LogicalType::VARCHAR), Value("")});
+	result.emplace_back(varchar_list_type, "varchar_array", empty_varchar_list, varchar_list);
+
+	// nested arrays
+	auto nested_list_type = LogicalType::LIST(int_list_type);
+	auto empty_nested_list = Value::EMPTYLIST(int_list_type);
+	auto nested_int_list = Value::LIST({empty_int_list, int_list, Value(int_list_type), empty_int_list, int_list});
+	result.emplace_back(nested_list_type, "nested_int_array", empty_nested_list, nested_int_list);
+
+	// structs
+	child_list_t<LogicalType> struct_type_list;
+	struct_type_list.push_back(make_pair("a", LogicalType::INTEGER));
+	struct_type_list.push_back(make_pair("b", LogicalType::VARCHAR));
+	auto struct_type = LogicalType::STRUCT(move(struct_type_list));
+
+	child_list_t<Value> min_struct_list;
+	min_struct_list.push_back(make_pair("a", Value(LogicalType::INTEGER)));
+	min_struct_list.push_back(make_pair("b", Value(LogicalType::VARCHAR)));
+	auto min_struct_val = Value::STRUCT(move(min_struct_list));
+
+	child_list_t<Value> max_struct_list;
+	max_struct_list.push_back(make_pair("a", Value::INTEGER(42)));
+	max_struct_list.push_back(make_pair("b", Value("🦆🦆🦆🦆🦆🦆")));
+	auto max_struct_val = Value::STRUCT(move(max_struct_list));
+
+	result.emplace_back(struct_type, "struct", min_struct_val, max_struct_val);
+
+	// structs with lists
+	child_list_t<LogicalType> struct_list_type_list;
+	struct_list_type_list.push_back(make_pair("a", int_list_type));
+	struct_list_type_list.push_back(make_pair("b", varchar_list_type));
+	auto struct_list_type = LogicalType::STRUCT(move(struct_list_type_list));
+
+	child_list_t<Value> min_struct_vl_list;
+	min_struct_vl_list.push_back(make_pair("a", Value(int_list_type)));
+	min_struct_vl_list.push_back(make_pair("b", Value(varchar_list_type)));
+	auto min_struct_val_list = Value::STRUCT(move(min_struct_vl_list));
+
+	child_list_t<Value> max_struct_vl_list;
+	max_struct_vl_list.push_back(make_pair("a", int_list));
+	max_struct_vl_list.push_back(make_pair("b", varchar_list));
+	auto max_struct_val_list = Value::STRUCT(move(max_struct_vl_list));
+
+	result.emplace_back(struct_list_type, "struct_of_arrays", move(min_struct_val_list), move(max_struct_val_list));
+
+	// array of structs
+	auto array_of_structs_type = LogicalType::LIST(struct_type);
+	auto min_array_of_struct_val = Value::EMPTYLIST(struct_type);
+	auto max_array_of_struct_val = Value::LIST({min_struct_val, max_struct_val, Value(struct_type)});
+	result.emplace_back(array_of_structs_type, "array_of_structs", move(min_array_of_struct_val),
+	                    move(max_array_of_struct_val));
+
+	// map
+	auto map_type = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
+	auto min_map_value = Value::MAP(Value::EMPTYLIST(LogicalType::VARCHAR), Value::EMPTYLIST(LogicalType::VARCHAR));
+	auto max_map_value = Value::MAP(Value::LIST({Value("key1"), Value("key2")}),
+	                                Value::LIST({Value("🦆🦆🦆🦆🦆🦆"), Value("goose")}));
+	result.emplace_back(map_type, "map", move(min_map_value), move(max_map_value));
+
+	return result;
+}
+
+static unique_ptr<FunctionData> TestAllTypesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
+	auto test_types = TestAllTypesFun::GetTestTypes();
+	for (auto &test_type : test_types) {
+		return_types.push_back(move(test_type.type));
+		names.push_back(move(test_type.name));
+	}
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> TestAllTypesInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_unique<TestAllTypesData>();
+	auto test_types = TestAllTypesFun::GetTestTypes();
+	// 3 rows: min, max and NULL
+	result->entries.resize(3);
+	// initialize the values
+	for (auto &test_type : test_types) {
+		result->entries[0].push_back(move(test_type.min_value));
+		result->entries[1].push_back(move(test_type.max_value));
+		result->entries[2].emplace_back(move(test_type.type));
+	}
+	return move(result);
+}
+
+void TestAllTypesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (TestAllTypesData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	// start returning values
+	// either fill up the chunk or return all the remaining columns
+	idx_t count = 0;
+	while (data.offset < data.entries.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &vals = data.entries[data.offset++];
+		for (idx_t col_idx = 0; col_idx < vals.size(); col_idx++) {
+			output.SetValue(col_idx, count, vals[col_idx]);
+		}
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+void TestAllTypesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("test_all_types", {}, TestAllTypesFunction, TestAllTypesBind, TestAllTypesInit));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+// FLAT, CONSTANT, DICTIONARY, SEQUENCE
+struct TestVectorBindData : public TableFunctionData {
+	LogicalType type;
+	bool all_flat;
+};
+
+struct TestVectorTypesData : public GlobalTableFunctionState {
+	TestVectorTypesData() : offset(0) {
+	}
+
+	vector<unique_ptr<DataChunk>> entries;
+	idx_t offset;
+};
+
+struct TestVectorInfo {
+	TestVectorInfo(const LogicalType &type, const map<LogicalTypeId, TestType> &test_type_map,
+	               vector<unique_ptr<DataChunk>> &entries)
+	    : type(type), test_type_map(test_type_map), entries(entries) {
+	}
+
+	const LogicalType &type;
+	const map<LogicalTypeId, TestType> &test_type_map;
+	vector<unique_ptr<DataChunk>> &entries;
+};
+
+struct TestVectorFlat {
+	static constexpr const idx_t TEST_VECTOR_CARDINALITY = 3;
+
+	static vector<Value> GenerateValues(TestVectorInfo &info, const LogicalType &type) {
+		vector<Value> result;
+		switch (type.InternalType()) {
+		case PhysicalType::STRUCT: {
+			vector<child_list_t<Value>> struct_children;
+			auto &child_types = StructType::GetChildTypes(type);
+
+			struct_children.resize(TEST_VECTOR_CARDINALITY);
+			for (auto &child_type : child_types) {
+				auto child_values = GenerateValues(info, child_type.second);
+
+				for (idx_t i = 0; i < child_values.size(); i++) {
+					struct_children[i].push_back(make_pair(child_type.first, move(child_values[i])));
+				}
+			}
+			for (auto &struct_child : struct_children) {
+				result.push_back(Value::STRUCT(move(struct_child)));
+			}
+			break;
+		}
+		case PhysicalType::LIST: {
+			auto &child_type = ListType::GetChildType(type);
+			auto child_values = GenerateValues(info, child_type);
+
+			result.push_back(Value::LIST(child_type, {child_values[0], child_values[1]}));
+			result.push_back(Value::LIST(child_type, {}));
+			result.push_back(Value::LIST(child_type, {child_values[2]}));
+			break;
+		}
+		default: {
+			auto entry = info.test_type_map.find(type.id());
+			if (entry == info.test_type_map.end()) {
+				throw NotImplementedException("Unimplemented type for test_vector_types %s", type.ToString());
+			}
+			result.push_back(entry->second.min_value);
+			result.push_back(entry->second.max_value);
+			result.emplace_back(type);
+			break;
+		}
+		}
+		return result;
+	}
+
+	static void Generate(TestVectorInfo &info) {
+		vector<Value> result_values = GenerateValues(info, info.type);
+		for (idx_t cur_row = 0; cur_row < result_values.size(); cur_row += STANDARD_VECTOR_SIZE) {
+			auto result = make_unique<DataChunk>();
+			result->Initialize({info.type});
+			auto cardinality = MinValue<idx_t>(STANDARD_VECTOR_SIZE, result_values.size() - cur_row);
+			for (idx_t i = 0; i < cardinality; i++) {
+				result->data[0].SetValue(i, result_values[cur_row + i]);
+			}
+			result->SetCardinality(cardinality);
+			info.entries.push_back(move(result));
+		}
+	}
+};
+
+struct TestVectorConstant {
+	static void Generate(TestVectorInfo &info) {
+		auto values = TestVectorFlat::GenerateValues(info, info.type);
+		for (idx_t cur_row = 0; cur_row < TestVectorFlat::TEST_VECTOR_CARDINALITY; cur_row += STANDARD_VECTOR_SIZE) {
+			auto result = make_unique<DataChunk>();
+			result->Initialize({info.type});
+			auto cardinality = MinValue<idx_t>(STANDARD_VECTOR_SIZE, TestVectorFlat::TEST_VECTOR_CARDINALITY - cur_row);
+			result->data[0].SetValue(0, values[0]);
+			result->data[0].SetVectorType(VectorType::CONSTANT_VECTOR);
+			result->SetCardinality(cardinality);
+
+			info.entries.push_back(move(result));
+		}
+	}
+};
+
+struct TestVectorSequence {
+	static void GenerateVector(TestVectorInfo &info, const LogicalType &type, Vector &result) {
+		D_ASSERT(type == result.GetType());
+		switch (type.id()) {
+		case LogicalTypeId::TINYINT:
+		case LogicalTypeId::SMALLINT:
+		case LogicalTypeId::INTEGER:
+		case LogicalTypeId::BIGINT:
+		case LogicalTypeId::UTINYINT:
+		case LogicalTypeId::USMALLINT:
+		case LogicalTypeId::UINTEGER:
+		case LogicalTypeId::UBIGINT:
+			result.Sequence(3, 2);
+			return;
+		default:
+			break;
+		}
+		switch (type.InternalType()) {
+		case PhysicalType::STRUCT: {
+			auto &child_entries = StructVector::GetEntries(result);
+			for (auto &child_entry : child_entries) {
+				GenerateVector(info, child_entry->GetType(), *child_entry);
+			}
+			break;
+		}
+		case PhysicalType::LIST: {
+			auto data = FlatVector::GetData<list_entry_t>(result);
+			data[0].offset = 0;
+			data[0].length = 2;
+			data[1].offset = 2;
+			data[1].length = 0;
+			data[2].offset = 2;
+			data[2].length = 1;
+
+			GenerateVector(info, ListType::GetChildType(type), ListVector::GetEntry(result));
+			ListVector::SetListSize(result, 3);
+			break;
+		}
+		default: {
+			auto entry = info.test_type_map.find(type.id());
+			if (entry == info.test_type_map.end()) {
+				throw NotImplementedException("Unimplemented type for test_vector_types %s", type.ToString());
+			}
+			result.SetValue(0, entry->second.min_value);
+			result.SetValue(1, entry->second.max_value);
+			result.SetValue(2, Value(type));
+			break;
+		}
+		}
+	}
+
+	static void Generate(TestVectorInfo &info) {
+#if STANDARD_VECTOR_SIZE > 2
+		auto result = make_unique<DataChunk>();
+		result->Initialize({info.type});
+
+		GenerateVector(info, info.type, result->data[0]);
+		result->SetCardinality(3);
+		info.entries.push_back(move(result));
+#endif
+	}
+};
+
+struct TestVectorDictionary {
+	static void Generate(TestVectorInfo &info) {
+		idx_t current_chunk = info.entries.size();
+
+		unordered_set<idx_t> slice_entries {1, 2};
+
+		TestVectorFlat::Generate(info);
+		idx_t current_idx = 0;
+		for (idx_t i = current_chunk; i < info.entries.size(); i++) {
+			auto &chunk = *info.entries[i];
+			SelectionVector sel(STANDARD_VECTOR_SIZE);
+			idx_t sel_idx = 0;
+			for (idx_t k = 0; k < chunk.size(); k++) {
+				if (slice_entries.count(current_idx + k) > 0) {
+					sel.set_index(sel_idx++, k);
+				}
+			}
+			chunk.Slice(sel, sel_idx);
+			current_idx += chunk.size();
+		}
+	}
+};
+
+static unique_ptr<FunctionData> TestVectorTypesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_unique<TestVectorBindData>();
+	result->type = input.inputs[0].type();
+	result->all_flat = BooleanValue::Get(input.inputs[1]);
+
+	return_types.push_back(result->type);
+	names.emplace_back("test_vector");
+	return move(result);
+}
+
+unique_ptr<GlobalTableFunctionState> TestVectorTypesInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto &bind_data = (TestVectorBindData &)*input.bind_data;
+
+	auto result = make_unique<TestVectorTypesData>();
+
+	auto test_types = TestAllTypesFun::GetTestTypes();
+
+	map<LogicalTypeId, TestType> test_type_map;
+	for (auto &test_type : test_types) {
+		test_type_map.insert(make_pair(test_type.type.id(), move(test_type)));
+	}
+
+	TestVectorInfo info(bind_data.type, test_type_map, result->entries);
+	TestVectorFlat::Generate(info);
+	TestVectorConstant::Generate(info);
+	TestVectorDictionary::Generate(info);
+	TestVectorSequence::Generate(info);
+	for (auto &entry : result->entries) {
+		entry->Verify();
+	}
+	if (bind_data.all_flat) {
+		for (auto &entry : result->entries) {
+			entry->Normalify();
+			entry->Verify();
+		}
+	}
+	return move(result);
+}
+
+void TestVectorTypesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (TestVectorTypesData &)*data_p.global_state;
+	if (data.offset >= data.entries.size()) {
+		// finished returning values
+		return;
+	}
+	output.Reference(*data.entries[data.offset]);
+	data.offset++;
+}
+
+void TestVectorTypesFun::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(TableFunction("test_vector_types", {LogicalType::ANY, LogicalType::BOOLEAN},
+	                              TestVectorTypesFunction, TestVectorTypesBind, TestVectorTypesInit));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+void BuiltinFunctions::RegisterSQLiteFunctions() {
+	PragmaVersion::RegisterFunction(*this);
+	PragmaFunctionPragma::RegisterFunction(*this);
+	PragmaCollations::RegisterFunction(*this);
+	PragmaTableInfo::RegisterFunction(*this);
+	PragmaStorageInfo::RegisterFunction(*this);
+	PragmaDatabaseSize::RegisterFunction(*this);
+	PragmaDatabaseList::RegisterFunction(*this);
+	PragmaLastProfilingOutput::RegisterFunction(*this);
+	PragmaDetailedProfilingOutput::RegisterFunction(*this);
+
+	DuckDBColumnsFun::RegisterFunction(*this);
+	DuckDBConstraintsFun::RegisterFunction(*this);
+	DuckDBFunctionsFun::RegisterFunction(*this);
+	DuckDBKeywordsFun::RegisterFunction(*this);
+	DuckDBIndexesFun::RegisterFunction(*this);
+	DuckDBSchemasFun::RegisterFunction(*this);
+	DuckDBDependenciesFun::RegisterFunction(*this);
+	DuckDBExtensionsFun::RegisterFunction(*this);
+	DuckDBSequencesFun::RegisterFunction(*this);
+	DuckDBSettingsFun::RegisterFunction(*this);
+	DuckDBTablesFun::RegisterFunction(*this);
+	DuckDBTypesFun::RegisterFunction(*this);
+	DuckDBViewsFun::RegisterFunction(*this);
+	TestAllTypesFun::RegisterFunction(*this);
+	TestVectorTypesFun::RegisterFunction(*this);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Table Scan
+//===--------------------------------------------------------------------===//
+bool TableScanParallelStateNext(ClientContext &context, const FunctionData *bind_data_p,
+                                LocalTableFunctionState *local_state, GlobalTableFunctionState *gstate);
+
+struct TableScanLocalState : public LocalTableFunctionState {
+	//! The current position in the scan
+	TableScanState scan_state;
+	vector<column_t> column_ids;
+};
+
+static storage_t GetStorageIndex(TableCatalogEntry &table, column_t column_id) {
+	if (column_id == DConstants::INVALID_INDEX) {
+		return column_id;
+	}
+	auto &col = table.columns[column_id];
+	return col.StorageOid();
+}
+
+struct TableScanGlobalState : public GlobalTableFunctionState {
+	TableScanGlobalState(ClientContext &context, const FunctionData *bind_data_p) {
+		D_ASSERT(bind_data_p);
+		auto &bind_data = (const TableScanBindData &)*bind_data_p;
+		max_threads = bind_data.table->storage->MaxThreads(context);
+	}
+
+	ParallelTableScanState state;
+	mutex lock;
+	idx_t max_threads;
+
+	idx_t MaxThreads() const override {
+		return max_threads;
+	}
+};
+
+static unique_ptr<LocalTableFunctionState> TableScanInitLocal(ClientContext &context, TableFunctionInitInput &input,
+                                                              GlobalTableFunctionState *gstate) {
+	auto result = make_unique<TableScanLocalState>();
+	auto &bind_data = (TableScanBindData &)*input.bind_data;
+	result->column_ids = input.column_ids;
+	for (auto &col : result->column_ids) {
+		auto storage_idx = GetStorageIndex(*bind_data.table, col);
+		col = storage_idx;
+	}
+	result->scan_state.table_filters = input.filters;
+	TableScanParallelStateNext(context, input.bind_data, result.get(), gstate);
+	return move(result);
+}
+
+unique_ptr<GlobalTableFunctionState> TableScanInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
+	D_ASSERT(input.bind_data);
+	auto &bind_data = (const TableScanBindData &)*input.bind_data;
+	auto result = make_unique<TableScanGlobalState>(context, input.bind_data);
+	bind_data.table->storage->InitializeParallelScan(context, result->state);
+	return move(result);
+}
+
+static unique_ptr<BaseStatistics> TableScanStatistics(ClientContext &context, const FunctionData *bind_data_p,
+                                                      column_t column_id) {
+	auto &bind_data = (const TableScanBindData &)*bind_data_p;
+	auto &transaction = Transaction::GetTransaction(context);
+	if (transaction.storage.Find(bind_data.table->storage.get())) {
+		// we don't emit any statistics for tables that have outstanding transaction-local data
+		return nullptr;
+	}
+	auto storage_idx = GetStorageIndex(*bind_data.table, column_id);
+	return bind_data.table->storage->GetStatistics(context, storage_idx);
+}
+
+static void TableScanFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = (TableScanBindData &)*data_p.bind_data;
+	auto &state = (TableScanLocalState &)*data_p.local_state;
+	auto &transaction = Transaction::GetTransaction(context);
+	do {
+		bind_data.table->storage->Scan(transaction, output, state.scan_state, state.column_ids);
+		if (output.size() > 0) {
+			return;
+		}
+		if (!TableScanParallelStateNext(context, data_p.bind_data, data_p.local_state, data_p.global_state)) {
+			return;
+		}
+	} while (true);
+}
+
+bool TableScanParallelStateNext(ClientContext &context, const FunctionData *bind_data_p,
+                                LocalTableFunctionState *local_state, GlobalTableFunctionState *global_state) {
+	auto &bind_data = (const TableScanBindData &)*bind_data_p;
+	auto &parallel_state = (TableScanGlobalState &)*global_state;
+	auto &state = (TableScanLocalState &)*local_state;
+
+	lock_guard<mutex> parallel_lock(parallel_state.lock);
+	return bind_data.table->storage->NextParallelScan(context, parallel_state.state, state.scan_state,
+	                                                  state.column_ids);
+}
+
+double TableScanProgress(ClientContext &context, const FunctionData *bind_data_p,
+                         const GlobalTableFunctionState *gstate) {
+	auto &bind_data = (TableScanBindData &)*bind_data_p;
+	idx_t total_rows = bind_data.table->storage->GetTotalRows();
+	if (total_rows == 0 || total_rows < STANDARD_VECTOR_SIZE) {
+		//! Table is either empty or smaller than a vector size, so it is finished
+		return 100;
+	}
+	auto percentage = double(bind_data.chunk_count * STANDARD_VECTOR_SIZE * 100.0) / total_rows;
+	if (percentage > 100) {
+		//! In case the last chunk has less elements than STANDARD_VECTOR_SIZE, if our percentage is over 100
+		//! It means we finished this table.
+		return 100;
+	}
+	return percentage;
+}
+
+idx_t TableScanGetBatchIndex(ClientContext &context, const FunctionData *bind_data_p,
+                             LocalTableFunctionState *local_state, GlobalTableFunctionState *global_state) {
+	auto &bind_data = (const TableScanBindData &)*bind_data_p;
+	auto &state = (TableScanLocalState &)*local_state;
+	if (state.scan_state.row_group_scan_state.row_group) {
+		return state.scan_state.row_group_scan_state.row_group->start;
+	}
+	if (state.scan_state.local_state.max_index > 0) {
+		return bind_data.table->storage->GetTotalRows() + state.scan_state.local_state.chunk_index;
+	}
+	return 0;
+}
+
+void TableScanDependency(unordered_set<CatalogEntry *> &entries, const FunctionData *bind_data_p) {
+	auto &bind_data = (const TableScanBindData &)*bind_data_p;
+	entries.insert(bind_data.table);
+}
+
+unique_ptr<NodeStatistics> TableScanCardinality(ClientContext &context, const FunctionData *bind_data_p) {
+	auto &bind_data = (const TableScanBindData &)*bind_data_p;
+	auto &transaction = Transaction::GetTransaction(context);
+	idx_t estimated_cardinality =
+	    bind_data.table->storage->info->cardinality + transaction.storage.AddedRows(bind_data.table->storage.get());
+	return make_unique<NodeStatistics>(bind_data.table->storage->info->cardinality, estimated_cardinality);
+}
+
+//===--------------------------------------------------------------------===//
+// Index Scan
+//===--------------------------------------------------------------------===//
+struct IndexScanGlobalState : public GlobalTableFunctionState {
+	explicit IndexScanGlobalState(data_ptr_t row_id_data) : row_ids(LogicalType::ROW_TYPE, row_id_data) {
+	}
+
+	Vector row_ids;
+	ColumnFetchState fetch_state;
+	LocalScanState local_storage_state;
+	vector<column_t> column_ids;
+	bool finished;
+};
+
+static unique_ptr<GlobalTableFunctionState> IndexScanInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
+	auto &bind_data = (const TableScanBindData &)*input.bind_data;
+	data_ptr_t row_id_data = nullptr;
+	if (!bind_data.result_ids.empty()) {
+		row_id_data = (data_ptr_t)&bind_data.result_ids[0];
+	}
+	auto result = make_unique<IndexScanGlobalState>(row_id_data);
+	auto &transaction = Transaction::GetTransaction(context);
+	result->column_ids = input.column_ids;
+	transaction.storage.InitializeScan(bind_data.table->storage.get(), result->local_storage_state, input.filters);
+
+	result->finished = false;
+	return move(result);
+}
+
+static void IndexScanFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = (const TableScanBindData &)*data_p.bind_data;
+	auto &state = (IndexScanGlobalState &)*data_p.global_state;
+	auto &transaction = Transaction::GetTransaction(context);
+	if (!state.finished) {
+		bind_data.table->storage->Fetch(transaction, output, state.column_ids, state.row_ids,
+		                                bind_data.result_ids.size(), state.fetch_state);
+		state.finished = true;
+	}
+	if (output.size() == 0) {
+		transaction.storage.Scan(state.local_storage_state, state.column_ids, output);
+	}
+}
+
+static void RewriteIndexExpression(Index &index, LogicalGet &get, Expression &expr, bool &rewrite_possible) {
+	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &bound_colref = (BoundColumnRefExpression &)expr;
+		// bound column ref: rewrite to fit in the current set of bound column ids
+		bound_colref.binding.table_index = get.table_index;
+		column_t referenced_column = index.column_ids[bound_colref.binding.column_index];
+		// search for the referenced column in the set of column_ids
+		for (idx_t i = 0; i < get.column_ids.size(); i++) {
+			if (get.column_ids[i] == referenced_column) {
+				bound_colref.binding.column_index = i;
+				return;
+			}
+		}
+		// column id not found in bound columns in the LogicalGet: rewrite not possible
+		rewrite_possible = false;
+	}
+	ExpressionIterator::EnumerateChildren(
+	    expr, [&](Expression &child) { RewriteIndexExpression(index, get, child, rewrite_possible); });
+}
+
+void TableScanPushdownComplexFilter(ClientContext &context, LogicalGet &get, FunctionData *bind_data_p,
+                                    vector<unique_ptr<Expression>> &filters) {
+	auto &bind_data = (TableScanBindData &)*bind_data_p;
+	auto table = bind_data.table;
+	auto &storage = *table->storage;
+
+	if (bind_data.is_index_scan) {
+		return;
+	}
+	if (filters.empty()) {
+		// no indexes or no filters: skip the pushdown
+		return;
+	}
+	// behold
+	storage.info->indexes.Scan([&](Index &index) {
+		// first rewrite the index expression so the ColumnBindings align with the column bindings of the current table
+		if (index.unbound_expressions.size() > 1) {
+			return false;
+		}
+		auto index_expression = index.unbound_expressions[0]->Copy();
+		bool rewrite_possible = true;
+		RewriteIndexExpression(index, get, *index_expression, rewrite_possible);
+		if (!rewrite_possible) {
+			// could not rewrite!
+			return false;
+		}
+
+		Value low_value, high_value, equal_value;
+		ExpressionType low_comparison_type = ExpressionType::INVALID, high_comparison_type = ExpressionType::INVALID;
+		// try to find a matching index for any of the filter expressions
+		for (auto &filter : filters) {
+			auto expr = filter.get();
+
+			// create a matcher for a comparison with a constant
+			ComparisonExpressionMatcher matcher;
+			// match on a comparison type
+			matcher.expr_type = make_unique<ComparisonExpressionTypeMatcher>();
+			// match on a constant comparison with the indexed expression
+			matcher.matchers.push_back(make_unique<ExpressionEqualityMatcher>(index_expression.get()));
+			matcher.matchers.push_back(make_unique<ConstantExpressionMatcher>());
+
+			matcher.policy = SetMatcher::Policy::UNORDERED;
+
+			vector<Expression *> bindings;
+			if (matcher.Match(expr, bindings)) {
+				// range or equality comparison with constant value
+				// we can use our index here
+				// bindings[0] = the expression
+				// bindings[1] = the index expression
+				// bindings[2] = the constant
+				auto comparison = (BoundComparisonExpression *)bindings[0];
+				D_ASSERT(bindings[0]->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON);
+				D_ASSERT(bindings[2]->type == ExpressionType::VALUE_CONSTANT);
+
+				auto constant_value = ((BoundConstantExpression *)bindings[2])->value;
+				auto comparison_type = comparison->type;
+				if (comparison->left->type == ExpressionType::VALUE_CONSTANT) {
+					// the expression is on the right side, we flip them around
+					comparison_type = FlipComparisionExpression(comparison_type);
+				}
+				if (comparison_type == ExpressionType::COMPARE_EQUAL) {
+					// equality value
+					// equality overrides any other bounds so we just break here
+					equal_value = constant_value;
+					break;
+				} else if (comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO ||
+				           comparison_type == ExpressionType::COMPARE_GREATERTHAN) {
+					// greater than means this is a lower bound
+					low_value = constant_value;
+					low_comparison_type = comparison_type;
+				} else {
+					// smaller than means this is an upper bound
+					high_value = constant_value;
+					high_comparison_type = comparison_type;
+				}
+			} else if (expr->type == ExpressionType::COMPARE_BETWEEN) {
+				// BETWEEN expression
+				auto &between = (BoundBetweenExpression &)*expr;
+				if (!between.input->Equals(index_expression.get())) {
+					// expression doesn't match the current index expression
+					continue;
+				}
+				if (between.lower->type != ExpressionType::VALUE_CONSTANT ||
+				    between.upper->type != ExpressionType::VALUE_CONSTANT) {
+					// not a constant comparison
+					continue;
+				}
+				low_value = ((BoundConstantExpression &)*between.lower).value;
+				low_comparison_type = between.lower_inclusive ? ExpressionType::COMPARE_GREATERTHANOREQUALTO
+				                                              : ExpressionType::COMPARE_GREATERTHAN;
+				high_value = ((BoundConstantExpression &)*between.upper).value;
+				high_comparison_type = between.upper_inclusive ? ExpressionType::COMPARE_LESSTHANOREQUALTO
+				                                               : ExpressionType::COMPARE_LESSTHAN;
+				break;
+			}
+		}
+		if (!equal_value.IsNull() || !low_value.IsNull() || !high_value.IsNull()) {
+			// we can scan this index using this predicate: try a scan
+			auto &transaction = Transaction::GetTransaction(context);
+			unique_ptr<IndexScanState> index_state;
+			if (!equal_value.IsNull()) {
+				// equality predicate
+				index_state =
+				    index.InitializeScanSinglePredicate(transaction, equal_value, ExpressionType::COMPARE_EQUAL);
+			} else if (!low_value.IsNull() && !high_value.IsNull()) {
+				// two-sided predicate
+				index_state = index.InitializeScanTwoPredicates(transaction, low_value, low_comparison_type, high_value,
+				                                                high_comparison_type);
+			} else if (!low_value.IsNull()) {
+				// less than predicate
+				index_state = index.InitializeScanSinglePredicate(transaction, low_value, low_comparison_type);
+			} else {
+				D_ASSERT(!high_value.IsNull());
+				index_state = index.InitializeScanSinglePredicate(transaction, high_value, high_comparison_type);
+			}
+			if (index.Scan(transaction, storage, *index_state, STANDARD_VECTOR_SIZE, bind_data.result_ids)) {
+				// use an index scan!
+				bind_data.is_index_scan = true;
+				get.function.init_local = nullptr;
+				get.function.init_global = IndexScanInitGlobal;
+				get.function.function = IndexScanFunction;
+				get.function.table_scan_progress = nullptr;
+				get.function.get_batch_index = nullptr;
+				get.function.filter_pushdown = false;
+			} else {
+				bind_data.result_ids.clear();
+			}
+			return true;
+		}
+		return false;
+	});
+}
+
+string TableScanToString(const FunctionData *bind_data_p) {
+	auto &bind_data = (const TableScanBindData &)*bind_data_p;
+	string result = bind_data.table->name;
+	return result;
+}
+
+TableFunction TableScanFunction::GetFunction() {
+	TableFunction scan_function("seq_scan", {}, TableScanFunc);
+	scan_function.init_local = TableScanInitLocal;
+	scan_function.init_global = TableScanInitGlobal;
+	scan_function.statistics = TableScanStatistics;
+	scan_function.dependency = TableScanDependency;
+	scan_function.cardinality = TableScanCardinality;
+	scan_function.pushdown_complex_filter = TableScanPushdownComplexFilter;
+	scan_function.to_string = TableScanToString;
+	scan_function.table_scan_progress = TableScanProgress;
+	scan_function.get_batch_index = TableScanGetBatchIndex;
+	scan_function.projection_pushdown = true;
+	scan_function.filter_pushdown = true;
+	return scan_function;
+}
+
+TableCatalogEntry *TableScanFunction::GetTableEntry(const TableFunction &function, const FunctionData *bind_data_p) {
+	if (function.function != TableScanFunc || !bind_data_p) {
+		return nullptr;
+	}
+	auto &bind_data = (TableScanBindData &)*bind_data_p;
+	return bind_data.table;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+struct UnnestBindData : public FunctionData {
+	explicit UnnestBindData(LogicalType input_type_p) : input_type(move(input_type_p)) {
+	}
+
+	LogicalType input_type;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		return make_unique<UnnestBindData>(input_type);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto &other = (const UnnestBindData &)other_p;
+		return input_type == other.input_type;
+	}
+};
+
+struct UnnestOperatorData : public GlobalTableFunctionState {
+	UnnestOperatorData() {
+	}
+
+	unique_ptr<OperatorState> operator_state;
+	vector<unique_ptr<Expression>> select_list;
+
+	idx_t MaxThreads() const override {
+		return GlobalTableFunctionState::MAX_THREADS;
+	}
+};
+
+static unique_ptr<FunctionData> UnnestBind(ClientContext &context, TableFunctionBindInput &input,
+                                           vector<LogicalType> &return_types, vector<string> &names) {
+	if (input.input_table_types.size() != 1 || input.input_table_types[0].id() != LogicalTypeId::LIST) {
+		throw BinderException("UNNEST requires a single list as input");
+	}
+	return_types.push_back(ListType::GetChildType(input.input_table_types[0]));
+	names.push_back(input.input_table_names[0]);
+	return make_unique<UnnestBindData>(input.input_table_types[0]);
+}
+
+static unique_ptr<GlobalTableFunctionState> UnnestInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto &bind_data = (UnnestBindData &)*input.bind_data;
+	auto result = make_unique<UnnestOperatorData>();
+	result->operator_state = PhysicalUnnest::GetState(context);
+	auto ref = make_unique<BoundReferenceExpression>(bind_data.input_type, 0);
+	auto bound_unnest = make_unique<BoundUnnestExpression>(ListType::GetChildType(bind_data.input_type));
+	bound_unnest->child = move(ref);
+	result->select_list.push_back(move(bound_unnest));
+	return move(result);
+}
+
+static OperatorResultType UnnestFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &input,
+                                         DataChunk &output) {
+	auto &state = (UnnestOperatorData &)*data_p.global_state;
+	return PhysicalUnnest::ExecuteInternal(context, input, output, *state.operator_state, state.select_list, false);
+}
+
+void UnnestTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	TableFunction unnest_function("unnest", {LogicalTypeId::TABLE}, nullptr, UnnestBind, UnnestInit);
+	unnest_function.in_out_function = UnnestFunction;
+	set.AddFunction(unnest_function);
+}
+
+} // namespace duckdb
+
+
+
+#include <cstdint>
+
+namespace duckdb {
+
+struct PragmaVersionData : public GlobalTableFunctionState {
+	PragmaVersionData() : finished(false) {
+	}
+
+	bool finished;
+};
+
+static unique_ptr<FunctionData> PragmaVersionBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("library_version");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("source_id");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return nullptr;
+}
+
+static unique_ptr<GlobalTableFunctionState> PragmaVersionInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_unique<PragmaVersionData>();
+}
+
+static void PragmaVersionFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = (PragmaVersionData &)*data_p.global_state;
+	if (data.finished) {
+		// finished returning values
+		return;
+	}
+	output.SetCardinality(1);
+	output.SetValue(0, 0, DuckDB::LibraryVersion());
+	output.SetValue(1, 0, DuckDB::SourceID());
+	data.finished = true;
+}
+
+void PragmaVersion::RegisterFunction(BuiltinFunctions &set) {
+	TableFunction pragma_version("pragma_version", {}, PragmaVersionFunction);
+	pragma_version.bind = PragmaVersionBind;
+	pragma_version.init_global = PragmaVersionInit;
+	set.AddFunction(pragma_version);
+}
+
+const char *DuckDB::SourceID() {
+	return DUCKDB_SOURCE_ID;
+}
+
+const char *DuckDB::LibraryVersion() {
+	return DUCKDB_VERSION;
+}
+
+string DuckDB::Platform() {
+	string os = "linux";
+#if INTPTR_MAX == INT64_MAX
+	string arch = "amd64";
+#elif INTPTR_MAX == INT32_MAX
+	string arch = "i686";
+#else
+#error Unknown pointer size or missing size macros!
+#endif
+	string postfix = "";
+
+#ifdef _WIN32
+	os = "windows";
+#elif defined(__APPLE__)
+	os = "osx";
+#endif
+#if defined(__aarch64__) || defined(__ARM_ARCH_ISA_A64)
+	arch = "arm64";
+#endif
+
+#if !defined(_GLIBCXX_USE_CXX11_ABI) || _GLIBCXX_USE_CXX11_ABI == 0
+	if (os == "linux") {
+		postfix = "_gcc4";
+	}
+#endif
+
+	return os + "_" + arch + postfix;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+GlobalTableFunctionState::~GlobalTableFunctionState() {
+}
+
+LocalTableFunctionState::~LocalTableFunctionState() {
+}
+
+TableFunctionInfo::~TableFunctionInfo() {
+}
+
+TableFunction::TableFunction(string name, vector<LogicalType> arguments, table_function_t function,
+                             table_function_bind_t bind, table_function_init_global_t init_global,
+                             table_function_init_local_t init_local)
+    : SimpleNamedParameterFunction(move(name), move(arguments)), bind(bind), init_global(init_global),
+      init_local(init_local), function(function), in_out_function(nullptr), statistics(nullptr), dependency(nullptr),
+      cardinality(nullptr), pushdown_complex_filter(nullptr), to_string(nullptr), table_scan_progress(nullptr),
+      get_batch_index(nullptr), projection_pushdown(false), filter_pushdown(false) {
+}
+
+TableFunction::TableFunction(const vector<LogicalType> &arguments, table_function_t function,
+                             table_function_bind_t bind, table_function_init_global_t init_global,
+                             table_function_init_local_t init_local)
+    : TableFunction(string(), arguments, function, bind, init_global, init_local) {
+}
+TableFunction::TableFunction() : SimpleNamedParameterFunction("", {}) {
+}
+
+} // namespace duckdb
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/table_macro_function.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+//! The SelectStatement of the view
+
+
+
+
+namespace duckdb {
+
+TableMacroFunction::TableMacroFunction(unique_ptr<QueryNode> query_node)
+    : MacroFunction(MacroType::TABLE_MACRO), query_node(move(query_node)) {
+}
+
+TableMacroFunction::TableMacroFunction(void) : MacroFunction(MacroType::TABLE_MACRO) {
+}
+
+unique_ptr<MacroFunction> TableMacroFunction::Copy() {
+	auto result = make_unique<TableMacroFunction>();
+	result->query_node = query_node->Copy();
+	this->CopyProperties(*result);
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+void UDFWrapper::RegisterFunction(string name, vector<LogicalType> args, LogicalType ret_type,
+                                  scalar_function_t udf_function, ClientContext &context, LogicalType varargs) {
+
+	ScalarFunction scalar_function(move(name), move(args), move(ret_type), move(udf_function));
+	scalar_function.varargs = move(varargs);
+	CreateScalarFunctionInfo info(scalar_function);
+	info.schema = DEFAULT_SCHEMA;
+	context.RegisterFunction(&info);
+}
+
+void UDFWrapper::RegisterAggrFunction(AggregateFunction aggr_function, ClientContext &context, LogicalType varargs) {
+	aggr_function.varargs = move(varargs);
+	CreateAggregateFunctionInfo info(move(aggr_function));
+	context.RegisterFunction(&info);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+BaseAppender::BaseAppender() : column(0) {
+}
+
+BaseAppender::BaseAppender(vector<LogicalType> types_p) : types(move(types_p)), column(0) {
+	InitializeChunk();
+}
+
+BaseAppender::~BaseAppender() {
+}
+
+void BaseAppender::Destructor() {
+	if (Exception::UncaughtException()) {
+		return;
+	}
+	// flush any remaining chunks, but only if we are not cleaning up the appender as part of an exception stack unwind
+	// wrapped in a try/catch because Close() can throw if the table was dropped in the meantime
+	try {
+		Close();
+	} catch (...) {
+	}
+}
+
+InternalAppender::InternalAppender(ClientContext &context_p, TableCatalogEntry &table_p)
+    : BaseAppender(table_p.GetTypes()), context(context_p), table(table_p) {
+}
+
+InternalAppender::~InternalAppender() {
+	Destructor();
+}
+
+Appender::Appender(Connection &con, const string &schema_name, const string &table_name)
+    : BaseAppender(), context(con.context) {
+	description = con.TableInfo(schema_name, table_name);
+	if (!description) {
+		// table could not be found
+		throw CatalogException(StringUtil::Format("Table \"%s.%s\" could not be found", schema_name, table_name));
+	}
+	for (auto &column : description->columns) {
+		types.push_back(column.Type());
+	}
+	InitializeChunk();
+}
+
+Appender::Appender(Connection &con, const string &table_name) : Appender(con, DEFAULT_SCHEMA, table_name) {
+}
+
+Appender::~Appender() {
+	Destructor();
+}
+
+void BaseAppender::InitializeChunk() {
+	chunk = make_unique<DataChunk>();
+	chunk->Initialize(types);
+}
+
+void BaseAppender::BeginRow() {
+}
+
+void BaseAppender::EndRow() {
+	// check that all rows have been appended to
+	if (column != chunk->ColumnCount()) {
+		throw InvalidInputException("Call to EndRow before all rows have been appended to!");
+	}
+	column = 0;
+	chunk->SetCardinality(chunk->size() + 1);
+	if (chunk->size() >= STANDARD_VECTOR_SIZE) {
+		FlushChunk();
+	}
+}
+
+template <class SRC, class DST>
+void BaseAppender::AppendValueInternal(Vector &col, SRC input) {
+	FlatVector::GetData<DST>(col)[chunk->size()] = Cast::Operation<SRC, DST>(input);
+}
+
+template <class T>
+void BaseAppender::AppendValueInternal(T input) {
+	if (column >= types.size()) {
+		throw InvalidInputException("Too many appends for chunk!");
+	}
+	auto &col = chunk->data[column];
+	switch (col.GetType().id()) {
+	case LogicalTypeId::BOOLEAN:
+		AppendValueInternal<T, bool>(col, input);
+		break;
+	case LogicalTypeId::UTINYINT:
+		AppendValueInternal<T, uint8_t>(col, input);
+		break;
+	case LogicalTypeId::TINYINT:
+		AppendValueInternal<T, int8_t>(col, input);
+		break;
+	case LogicalTypeId::USMALLINT:
+		AppendValueInternal<T, uint16_t>(col, input);
+		break;
+	case LogicalTypeId::SMALLINT:
+		AppendValueInternal<T, int16_t>(col, input);
+		break;
+	case LogicalTypeId::UINTEGER:
+		AppendValueInternal<T, uint32_t>(col, input);
+		break;
+	case LogicalTypeId::INTEGER:
+		AppendValueInternal<T, int32_t>(col, input);
+		break;
+	case LogicalTypeId::UBIGINT:
+		AppendValueInternal<T, uint64_t>(col, input);
+		break;
+	case LogicalTypeId::BIGINT:
+		AppendValueInternal<T, int64_t>(col, input);
+		break;
+	case LogicalTypeId::HUGEINT:
+		AppendValueInternal<T, hugeint_t>(col, input);
+		break;
+	case LogicalTypeId::FLOAT:
+		AppendValueInternal<T, float>(col, input);
+		break;
+	case LogicalTypeId::DOUBLE:
+		AppendValueInternal<T, double>(col, input);
+		break;
+	case LogicalTypeId::DECIMAL:
+		switch (col.GetType().InternalType()) {
+		case PhysicalType::INT8:
+			AppendValueInternal<T, int8_t>(col, input);
+			break;
+		case PhysicalType::INT16:
+			AppendValueInternal<T, int16_t>(col, input);
+			break;
+		case PhysicalType::INT32:
+			AppendValueInternal<T, int32_t>(col, input);
+			break;
+		default:
+			AppendValueInternal<T, int64_t>(col, input);
+			break;
+		}
+		break;
+	case LogicalTypeId::DATE:
+		AppendValueInternal<T, date_t>(col, input);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		AppendValueInternal<T, timestamp_t>(col, input);
+		break;
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		AppendValueInternal<T, dtime_t>(col, input);
+		break;
+	case LogicalTypeId::INTERVAL:
+		AppendValueInternal<T, interval_t>(col, input);
+		break;
+	case LogicalTypeId::VARCHAR:
+		FlatVector::GetData<string_t>(col)[chunk->size()] = StringCast::Operation<T>(input, col);
+		break;
+	default:
+		AppendValue(Value::CreateValue<T>(input));
+		return;
+	}
+	column++;
+}
+
+template <>
+void BaseAppender::Append(bool value) {
+	AppendValueInternal<bool>(value);
+}
+
+template <>
+void BaseAppender::Append(int8_t value) {
+	AppendValueInternal<int8_t>(value);
+}
+
+template <>
+void BaseAppender::Append(int16_t value) {
+	AppendValueInternal<int16_t>(value);
+}
+
+template <>
+void BaseAppender::Append(int32_t value) {
+	AppendValueInternal<int32_t>(value);
+}
+
+template <>
+void BaseAppender::Append(int64_t value) {
+	AppendValueInternal<int64_t>(value);
+}
+
+template <>
+void BaseAppender::Append(hugeint_t value) {
+	AppendValueInternal<hugeint_t>(value);
+}
+
+template <>
+void BaseAppender::Append(uint8_t value) {
+	AppendValueInternal<uint8_t>(value);
+}
+
+template <>
+void BaseAppender::Append(uint16_t value) {
+	AppendValueInternal<uint16_t>(value);
+}
+
+template <>
+void BaseAppender::Append(uint32_t value) {
+	AppendValueInternal<uint32_t>(value);
+}
+
+template <>
+void BaseAppender::Append(uint64_t value) {
+	AppendValueInternal<uint64_t>(value);
+}
+
+template <>
+void BaseAppender::Append(const char *value) {
+	AppendValueInternal<string_t>(string_t(value));
+}
+
+void BaseAppender::Append(const char *value, uint32_t length) {
+	AppendValueInternal<string_t>(string_t(value, length));
+}
+
+template <>
+void BaseAppender::Append(string_t value) {
+	AppendValueInternal<string_t>(value);
+}
+
+template <>
+void BaseAppender::Append(float value) {
+	AppendValueInternal<float>(value);
+}
+
+template <>
+void BaseAppender::Append(double value) {
+	AppendValueInternal<double>(value);
+}
+
+template <>
+void BaseAppender::Append(date_t value) {
+	AppendValueInternal<date_t>(value);
+}
+
+template <>
+void BaseAppender::Append(dtime_t value) {
+	AppendValueInternal<dtime_t>(value);
+}
+
+template <>
+void BaseAppender::Append(timestamp_t value) {
+	AppendValueInternal<timestamp_t>(value);
+}
+
+template <>
+void BaseAppender::Append(interval_t value) {
+	AppendValueInternal<interval_t>(value);
+}
+
+template <>
+void BaseAppender::Append(Value value) { // NOLINT: template shtuff
+	if (column >= chunk->ColumnCount()) {
+		throw InvalidInputException("Too many appends for chunk!");
+	}
+	AppendValue(value);
+}
+
+template <>
+void BaseAppender::Append(std::nullptr_t value) {
+	if (column >= chunk->ColumnCount()) {
+		throw InvalidInputException("Too many appends for chunk!");
+	}
+	auto &col = chunk->data[column++];
+	FlatVector::SetNull(col, chunk->size(), true);
+}
+
+void BaseAppender::AppendValue(const Value &value) {
+	chunk->SetValue(column, chunk->size(), value);
+	column++;
+}
+
+void BaseAppender::AppendDataChunk(DataChunk &chunk) {
+	if (chunk.GetTypes() != types) {
+		throw InvalidInputException("Type mismatch in Append DataChunk and the types required for appender");
+	}
+	collection.Append(chunk);
+	if (collection.ChunkCount() >= FLUSH_COUNT) {
+		Flush();
+	}
+}
+
+void BaseAppender::FlushChunk() {
+	if (chunk->size() == 0) {
+		return;
+	}
+	collection.Append(move(chunk));
+	InitializeChunk();
+	if (collection.ChunkCount() >= FLUSH_COUNT) {
+		Flush();
+	}
+}
+
+void BaseAppender::Flush() {
+	// check that all vectors have the same length before appending
+	if (column != 0) {
+		throw InvalidInputException("Failed to Flush appender: incomplete append to row!");
+	}
+
+	FlushChunk();
+	if (collection.Count() == 0) {
+		return;
+	}
+	FlushInternal(collection);
+
+	collection.Reset();
+	column = 0;
+}
+
+void Appender::FlushInternal(ChunkCollection &collection) {
+	context->Append(*description, collection);
+}
+
+void InternalAppender::FlushInternal(ChunkCollection &collection) {
+	for (auto &chunk : collection.Chunks()) {
+		table.storage->Append(table, context, *chunk);
+	}
+}
+
+void BaseAppender::Close() {
+	if (column == 0 || column == types.size()) {
+		Flush();
+	}
+}
+
+} // namespace duckdb
+
+
+using duckdb::Appender;
+using duckdb::AppenderWrapper;
+using duckdb::Connection;
+using duckdb::date_t;
+using duckdb::dtime_t;
+using duckdb::hugeint_t;
+using duckdb::interval_t;
+using duckdb::string_t;
+using duckdb::timestamp_t;
+
+duckdb_state duckdb_appender_create(duckdb_connection connection, const char *schema, const char *table,
+                                    duckdb_appender *out_appender) {
+	Connection *conn = (Connection *)connection;
+
+	if (!connection || !table || !out_appender) {
+		return DuckDBError;
+	}
+	if (schema == nullptr) {
+		schema = DEFAULT_SCHEMA;
+	}
+	auto wrapper = new AppenderWrapper();
+	*out_appender = (duckdb_appender)wrapper;
+	try {
+		wrapper->appender = duckdb::make_unique<Appender>(*conn, schema, table);
+	} catch (std::exception &ex) {
+		wrapper->error = ex.what();
+		return DuckDBError;
+	} catch (...) { // LCOV_EXCL_START
+		wrapper->error = "Unknown create appender error";
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
+	return DuckDBSuccess;
+}
+
+duckdb_state duckdb_appender_destroy(duckdb_appender *appender) {
+	if (!appender || !*appender) {
+		return DuckDBError;
+	}
+	duckdb_appender_close(*appender);
+	auto wrapper = (AppenderWrapper *)*appender;
+	if (wrapper) {
+		delete wrapper;
+	}
+	*appender = nullptr;
+	return DuckDBSuccess;
+}
+
+template <class FUN>
+duckdb_state duckdb_appender_run_function(duckdb_appender appender, FUN &&function) {
+	if (!appender) {
+		return DuckDBError;
+	}
+	auto wrapper = (AppenderWrapper *)appender;
+	if (!wrapper->appender) {
+		return DuckDBError;
+	}
+	try {
+		function(*wrapper->appender);
+	} catch (std::exception &ex) {
+		wrapper->error = ex.what();
+		return DuckDBError;
+	} catch (...) { // LCOV_EXCL_START
+		wrapper->error = "Unknown error";
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
+	return DuckDBSuccess;
+}
+
+const char *duckdb_appender_error(duckdb_appender appender) {
+	if (!appender) {
+		return nullptr;
+	}
+	auto wrapper = (AppenderWrapper *)appender;
+	if (wrapper->error.empty()) {
+		return nullptr;
+	}
+	return wrapper->error.c_str();
+}
+
+duckdb_state duckdb_appender_begin_row(duckdb_appender appender) {
+	return DuckDBSuccess;
+}
+
+duckdb_state duckdb_appender_end_row(duckdb_appender appender) {
+	return duckdb_appender_run_function(appender, [&](Appender &appender) { appender.EndRow(); });
+}
+
+template <class T>
+duckdb_state duckdb_append_internal(duckdb_appender appender, T value) {
+	if (!appender) {
+		return DuckDBError;
+	}
+	auto *appender_instance = (AppenderWrapper *)appender;
+	try {
+		appender_instance->appender->Append<T>(value);
+	} catch (...) {
+		return DuckDBError;
+	}
+	return DuckDBSuccess;
+}
+
+duckdb_state duckdb_append_bool(duckdb_appender appender, bool value) {
+	return duckdb_append_internal<bool>(appender, value);
+}
+
+duckdb_state duckdb_append_int8(duckdb_appender appender, int8_t value) {
+	return duckdb_append_internal<int8_t>(appender, value);
+}
+
+duckdb_state duckdb_append_int16(duckdb_appender appender, int16_t value) {
+	return duckdb_append_internal<int16_t>(appender, value);
+}
+
+duckdb_state duckdb_append_int32(duckdb_appender appender, int32_t value) {
+	return duckdb_append_internal<int32_t>(appender, value);
+}
+
+duckdb_state duckdb_append_int64(duckdb_appender appender, int64_t value) {
+	return duckdb_append_internal<int64_t>(appender, value);
+}
+
+duckdb_state duckdb_append_hugeint(duckdb_appender appender, duckdb_hugeint value) {
+	hugeint_t internal;
+	internal.lower = value.lower;
+	internal.upper = value.upper;
+	return duckdb_append_internal<hugeint_t>(appender, internal);
+}
+
+duckdb_state duckdb_append_uint8(duckdb_appender appender, uint8_t value) {
+	return duckdb_append_internal<uint8_t>(appender, value);
+}
+
+duckdb_state duckdb_append_uint16(duckdb_appender appender, uint16_t value) {
+	return duckdb_append_internal<uint16_t>(appender, value);
+}
+
+duckdb_state duckdb_append_uint32(duckdb_appender appender, uint32_t value) {
+	return duckdb_append_internal<uint32_t>(appender, value);
+}
+
+duckdb_state duckdb_append_uint64(duckdb_appender appender, uint64_t value) {
+	return duckdb_append_internal<uint64_t>(appender, value);
+}
+
+duckdb_state duckdb_append_float(duckdb_appender appender, float value) {
+	return duckdb_append_internal<float>(appender, value);
+}
+
+duckdb_state duckdb_append_double(duckdb_appender appender, double value) {
+	return duckdb_append_internal<double>(appender, value);
+}
+
+duckdb_state duckdb_append_date(duckdb_appender appender, duckdb_date value) {
+	return duckdb_append_internal<date_t>(appender, date_t(value.days));
+}
+
+duckdb_state duckdb_append_time(duckdb_appender appender, duckdb_time value) {
+	return duckdb_append_internal<dtime_t>(appender, dtime_t(value.micros));
+}
+
+duckdb_state duckdb_append_timestamp(duckdb_appender appender, duckdb_timestamp value) {
+	return duckdb_append_internal<timestamp_t>(appender, timestamp_t(value.micros));
+}
+
+duckdb_state duckdb_append_interval(duckdb_appender appender, duckdb_interval value) {
+	interval_t interval;
+	interval.months = value.months;
+	interval.days = value.days;
+	interval.micros = value.micros;
+	return duckdb_append_internal<interval_t>(appender, interval);
+}
+
+duckdb_state duckdb_append_null(duckdb_appender appender) {
+	return duckdb_append_internal<std::nullptr_t>(appender, nullptr);
+}
+
+duckdb_state duckdb_append_varchar(duckdb_appender appender, const char *val) {
+	return duckdb_append_internal<const char *>(appender, val);
+}
+
+duckdb_state duckdb_append_varchar_length(duckdb_appender appender, const char *val, idx_t length) {
+	return duckdb_append_internal<string_t>(appender, string_t(val, length));
+}
+duckdb_state duckdb_append_blob(duckdb_appender appender, const void *data, idx_t length) {
+	auto value = duckdb::Value::BLOB((duckdb::const_data_ptr_t)data, length);
+	return duckdb_append_internal<duckdb::Value>(appender, value);
+}
+
+duckdb_state duckdb_appender_flush(duckdb_appender appender) {
+	return duckdb_appender_run_function(appender, [&](Appender &appender) { appender.Flush(); });
+}
+
+duckdb_state duckdb_appender_close(duckdb_appender appender) {
+	return duckdb_appender_run_function(appender, [&](Appender &appender) { appender.Close(); });
+}
+
+duckdb_state duckdb_append_data_chunk(duckdb_appender appender, duckdb_data_chunk chunk) {
+	if (!chunk) {
+		return DuckDBError;
+	}
+	auto data_chunk = (duckdb::DataChunk *)chunk;
+	return duckdb_appender_run_function(appender, [&](Appender &appender) { appender.AppendDataChunk(*data_chunk); });
+}
+
+
+using duckdb::ArrowResultWrapper;
+using duckdb::Connection;
+using duckdb::DataChunk;
+using duckdb::LogicalType;
+using duckdb::MaterializedQueryResult;
+using duckdb::PreparedStatementWrapper;
+using duckdb::QueryResult;
+using duckdb::QueryResultType;
+
+duckdb_state duckdb_query_arrow(duckdb_connection connection, const char *query, duckdb_arrow *out_result) {
+	Connection *conn = (Connection *)connection;
+	auto wrapper = new ArrowResultWrapper();
+	wrapper->result = conn->Query(query);
+	*out_result = (duckdb_arrow)wrapper;
+	return wrapper->result->success ? DuckDBSuccess : DuckDBError;
+}
+
+duckdb_state duckdb_query_arrow_schema(duckdb_arrow result, duckdb_arrow_schema *out_schema) {
+	if (!out_schema) {
+		return DuckDBSuccess;
+	}
+	auto wrapper = (ArrowResultWrapper *)result;
+	QueryResult::ToArrowSchema((ArrowSchema *)*out_schema, wrapper->result->types, wrapper->result->names,
+	                           wrapper->timezone_config);
+	return DuckDBSuccess;
+}
+
+duckdb_state duckdb_query_arrow_array(duckdb_arrow result, duckdb_arrow_array *out_array) {
+	if (!out_array) {
+		return DuckDBSuccess;
+	}
+	auto wrapper = (ArrowResultWrapper *)result;
+	auto success = wrapper->result->TryFetch(wrapper->current_chunk, wrapper->result->error);
+	if (!success) { // LCOV_EXCL_START
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
+	if (!wrapper->current_chunk || wrapper->current_chunk->size() == 0) {
+		return DuckDBSuccess;
+	}
+	wrapper->current_chunk->ToArrowArray((ArrowArray *)*out_array);
+	return DuckDBSuccess;
+}
+
+idx_t duckdb_arrow_row_count(duckdb_arrow result) {
+	auto wrapper = (ArrowResultWrapper *)result;
+	return wrapper->result->collection.Count();
+}
+
+idx_t duckdb_arrow_column_count(duckdb_arrow result) {
+	auto wrapper = (ArrowResultWrapper *)result;
+	return wrapper->result->types.size();
+}
+
+idx_t duckdb_arrow_rows_changed(duckdb_arrow result) {
+	auto wrapper = (ArrowResultWrapper *)result;
+	idx_t rows_changed = 0;
+	idx_t row_count = wrapper->result->collection.Count();
+	if (row_count > 0 && wrapper->result->properties.return_type == duckdb::StatementReturnType::CHANGED_ROWS) {
+		auto row_changes = wrapper->result->GetValue(0, 0);
+		if (!row_changes.IsNull() && row_changes.TryCastAs(LogicalType::BIGINT)) {
+			rows_changed = row_changes.GetValue<int64_t>();
+		}
+	}
+	return rows_changed;
+}
+
+const char *duckdb_query_arrow_error(duckdb_arrow result) {
+	auto wrapper = (ArrowResultWrapper *)result;
+	return wrapper->result->error.c_str();
+}
+
+void duckdb_destroy_arrow(duckdb_arrow *result) {
+	if (*result) {
+		auto wrapper = (ArrowResultWrapper *)*result;
+		delete wrapper;
+		*result = nullptr;
+	}
+}
+
+duckdb_state duckdb_execute_prepared_arrow(duckdb_prepared_statement prepared_statement, duckdb_arrow *out_result) {
+	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
+	if (!wrapper || !wrapper->statement || !wrapper->statement->success || !out_result) {
+		return DuckDBError;
+	}
+	auto arrow_wrapper = new ArrowResultWrapper();
+	if (wrapper->statement->context->config.set_variables.find("TimeZone") ==
+	    wrapper->statement->context->config.set_variables.end()) {
+		arrow_wrapper->timezone_config = "UTC";
+	} else {
+		arrow_wrapper->timezone_config =
+		    wrapper->statement->context->config.set_variables["TimeZone"].GetValue<std::string>();
+	}
+
+	auto result = wrapper->statement->Execute(wrapper->values, false);
+	D_ASSERT(result->type == QueryResultType::MATERIALIZED_RESULT);
+	arrow_wrapper->result = duckdb::unique_ptr_cast<QueryResult, MaterializedQueryResult>(move(result));
+	*out_result = (duckdb_arrow)arrow_wrapper;
+	return arrow_wrapper->result->success ? DuckDBSuccess : DuckDBError;
+}
+
+
+
+
+using duckdb::DBConfig;
+using duckdb::Value;
+
+// config
+duckdb_state duckdb_create_config(duckdb_config *out_config) {
+	if (!out_config) {
+		return DuckDBError;
+	}
+	DBConfig *config;
+	try {
+		config = new DBConfig();
+	} catch (...) { // LCOV_EXCL_START
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
+	*out_config = (duckdb_config)config;
+	return DuckDBSuccess;
+}
+
+size_t duckdb_config_count() {
+	return DBConfig::GetOptionCount();
+}
+
+duckdb_state duckdb_get_config_flag(size_t index, const char **out_name, const char **out_description) {
+	auto option = DBConfig::GetOptionByIndex(index);
+	if (!option) {
+		return DuckDBError;
+	}
+	if (out_name) {
+		*out_name = option->name;
+	}
+	if (out_description) {
+		*out_description = option->description;
+	}
+	return DuckDBSuccess;
+}
+
+duckdb_state duckdb_set_config(duckdb_config config, const char *name, const char *option) {
+	if (!config || !name || !option) {
+		return DuckDBError;
+	}
+	auto config_option = DBConfig::GetOptionByName(name);
+	if (!config_option) {
+		return DuckDBError;
+	}
+	try {
+		auto db_config = (DBConfig *)config;
+		db_config->SetOption(*config_option, Value(option));
+	} catch (...) {
+		return DuckDBError;
+	}
+	return DuckDBSuccess;
+}
+
+void duckdb_destroy_config(duckdb_config *config) {
+	if (!config) {
+		return;
+	}
+	if (*config) {
+		auto db_config = (DBConfig *)*config;
+		delete db_config;
+		*config = nullptr;
+	}
+}
+
+
+
+#include <string.h>
+
+duckdb_data_chunk duckdb_create_data_chunk(duckdb_logical_type *ctypes, idx_t column_count) {
+	if (!ctypes) {
+		return nullptr;
+	}
+	duckdb::vector<duckdb::LogicalType> types;
+	for (idx_t i = 0; i < column_count; i++) {
+		auto ltype = (duckdb::LogicalType *)ctypes[i];
+		types.push_back(*ltype);
+	}
+
+	auto result = new duckdb::DataChunk();
+	result->Initialize(types);
+	return result;
+}
+
+void duckdb_destroy_data_chunk(duckdb_data_chunk *chunk) {
+	if (chunk && *chunk) {
+		auto dchunk = (duckdb::DataChunk *)*chunk;
+		delete dchunk;
+		*chunk = nullptr;
+	}
+}
+
+void duckdb_data_chunk_reset(duckdb_data_chunk chunk) {
+	if (!chunk) {
+		return;
+	}
+	auto dchunk = (duckdb::DataChunk *)chunk;
+	dchunk->Reset();
+}
+
+idx_t duckdb_data_chunk_get_column_count(duckdb_data_chunk chunk) {
+	if (!chunk) {
+		return 0;
+	}
+	auto dchunk = (duckdb::DataChunk *)chunk;
+	return dchunk->ColumnCount();
+}
+
+duckdb_vector duckdb_data_chunk_get_vector(duckdb_data_chunk chunk, idx_t col_idx) {
+	if (!chunk || col_idx >= duckdb_data_chunk_get_column_count(chunk)) {
+		return nullptr;
+	}
+	auto dchunk = (duckdb::DataChunk *)chunk;
+	return &dchunk->data[col_idx];
+}
+
+idx_t duckdb_data_chunk_get_size(duckdb_data_chunk chunk) {
+	if (!chunk) {
+		return 0;
+	}
+	auto dchunk = (duckdb::DataChunk *)chunk;
+	return dchunk->size();
+}
+
+void duckdb_data_chunk_set_size(duckdb_data_chunk chunk, idx_t size) {
+	if (!chunk) {
+		return;
+	}
+	auto dchunk = (duckdb::DataChunk *)chunk;
+	dchunk->SetCardinality(size);
+}
+
+duckdb_logical_type duckdb_vector_get_column_type(duckdb_vector vector) {
+	if (!vector) {
+		return nullptr;
+	}
+	auto v = (duckdb::Vector *)vector;
+	return new duckdb::LogicalType(v->GetType());
+}
+
+void *duckdb_vector_get_data(duckdb_vector vector) {
+	if (!vector) {
+		return nullptr;
+	}
+	auto v = (duckdb::Vector *)vector;
+	return duckdb::FlatVector::GetData(*v);
+}
+
+uint64_t *duckdb_vector_get_validity(duckdb_vector vector) {
+	if (!vector) {
+		return nullptr;
+	}
+	auto v = (duckdb::Vector *)vector;
+	return duckdb::FlatVector::Validity(*v).GetData();
+}
+
+void duckdb_vector_ensure_validity_writable(duckdb_vector vector) {
+	if (!vector) {
+		return;
+	}
+	auto v = (duckdb::Vector *)vector;
+	auto &validity = duckdb::FlatVector::Validity(*v);
+	validity.EnsureWritable();
+}
+
+void duckdb_vector_assign_string_element(duckdb_vector vector, idx_t index, const char *str) {
+	duckdb_vector_assign_string_element_len(vector, index, str, strlen(str));
+}
+
+void duckdb_vector_assign_string_element_len(duckdb_vector vector, idx_t index, const char *str, idx_t str_len) {
+	if (!vector) {
+		return;
+	}
+	auto v = (duckdb::Vector *)vector;
+	auto data = duckdb::FlatVector::GetData<duckdb::string_t>(*v);
+	data[index] = duckdb::StringVector::AddString(*v, str, str_len);
+}
+
+duckdb_vector duckdb_list_vector_get_child(duckdb_vector vector) {
+	if (!vector) {
+		return nullptr;
+	}
+	auto v = (duckdb::Vector *)vector;
+	return &duckdb::ListVector::GetEntry(*v);
+}
+
+idx_t duckdb_list_vector_get_size(duckdb_vector vector) {
+	if (!vector) {
+		return 0;
+	}
+	auto v = (duckdb::Vector *)vector;
+	return duckdb::ListVector::GetListSize(*v);
+}
+
+duckdb_vector duckdb_struct_vector_get_child(duckdb_vector vector, idx_t index) {
+	if (!vector) {
+		return nullptr;
+	}
+	auto v = (duckdb::Vector *)vector;
+	return duckdb::StructVector::GetEntries(*v)[index].get();
+}
+
+bool duckdb_validity_row_is_valid(uint64_t *validity, idx_t row) {
+	if (!validity) {
+		return true;
+	}
+	idx_t entry_idx = row / 64;
+	idx_t idx_in_entry = row % 64;
+	return validity[entry_idx] & (1 << idx_in_entry);
+}
+
+void duckdb_validity_set_row_validity(uint64_t *validity, idx_t row, bool valid) {
+	if (valid) {
+		duckdb_validity_set_row_valid(validity, row);
+	} else {
+		duckdb_validity_set_row_invalid(validity, row);
+	}
+}
+
+void duckdb_validity_set_row_invalid(uint64_t *validity, idx_t row) {
+	if (!validity) {
+		return;
+	}
+	idx_t entry_idx = row / 64;
+	idx_t idx_in_entry = row % 64;
+	validity[entry_idx] &= ~(1 << idx_in_entry);
+}
+
+void duckdb_validity_set_row_valid(uint64_t *validity, idx_t row) {
+	if (!validity) {
+		return;
+	}
+	idx_t entry_idx = row / 64;
+	idx_t idx_in_entry = row % 64;
+	validity[entry_idx] |= 1 << idx_in_entry;
+}
+
+
+
+
+
+using duckdb::Date;
+using duckdb::Time;
+using duckdb::Timestamp;
+
+using duckdb::date_t;
+using duckdb::dtime_t;
+using duckdb::timestamp_t;
+
+duckdb_date_struct duckdb_from_date(duckdb_date date) {
+	int32_t year, month, day;
+	Date::Convert(date_t(date.days), year, month, day);
+
+	duckdb_date_struct result;
+	result.year = year;
+	result.month = month;
+	result.day = day;
+	return result;
+}
+
+duckdb_date duckdb_to_date(duckdb_date_struct date) {
+	duckdb_date result;
+	result.days = Date::FromDate(date.year, date.month, date.day).days;
+	return result;
+}
+
+duckdb_time_struct duckdb_from_time(duckdb_time time) {
+	int32_t hour, minute, second, micros;
+	Time::Convert(dtime_t(time.micros), hour, minute, second, micros);
+
+	duckdb_time_struct result;
+	result.hour = hour;
+	result.min = minute;
+	result.sec = second;
+	result.micros = micros;
+	return result;
+}
+
+duckdb_time duckdb_to_time(duckdb_time_struct time) {
+	duckdb_time result;
+	result.micros = Time::FromTime(time.hour, time.min, time.sec, time.micros).micros;
+	return result;
+}
+
+duckdb_timestamp_struct duckdb_from_timestamp(duckdb_timestamp ts) {
+	date_t date;
+	dtime_t time;
+	Timestamp::Convert(timestamp_t(ts.micros), date, time);
+
+	duckdb_date ddate;
+	ddate.days = date.days;
+
+	duckdb_time dtime;
+	dtime.micros = time.micros;
+
+	duckdb_timestamp_struct result;
+	result.date = duckdb_from_date(ddate);
+	result.time = duckdb_from_time(dtime);
+	return result;
+}
+
+duckdb_timestamp duckdb_to_timestamp(duckdb_timestamp_struct ts) {
+	date_t date = date_t(duckdb_to_date(ts.date).days);
+	dtime_t time = dtime_t(duckdb_to_time(ts.time).micros);
+
+	duckdb_timestamp result;
+	result.micros = Timestamp::FromDatetime(date, time).value;
+	return result;
+}
+
+
+using duckdb::Connection;
+using duckdb::DatabaseData;
+using duckdb::DBConfig;
+using duckdb::DuckDB;
+
+duckdb_state duckdb_open_ext(const char *path, duckdb_database *out, duckdb_config config, char **error) {
+	auto wrapper = new DatabaseData();
+	try {
+		auto db_config = (DBConfig *)config;
+		wrapper->database = duckdb::make_unique<DuckDB>(path, db_config);
+	} catch (std::exception &ex) {
+		if (error) {
+			*error = strdup(ex.what());
+		}
+		delete wrapper;
+		return DuckDBError;
+	} catch (...) { // LCOV_EXCL_START
+		if (error) {
+			*error = strdup("Unknown error");
+		}
+		delete wrapper;
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
+	*out = (duckdb_database)wrapper;
+	return DuckDBSuccess;
+}
+
+duckdb_state duckdb_open(const char *path, duckdb_database *out) {
+	return duckdb_open_ext(path, out, nullptr, nullptr);
+}
+
+void duckdb_close(duckdb_database *database) {
+	if (database && *database) {
+		auto wrapper = (DatabaseData *)*database;
+		delete wrapper;
+		*database = nullptr;
+	}
+}
+
+duckdb_state duckdb_connect(duckdb_database database, duckdb_connection *out) {
+	if (!database || !out) {
+		return DuckDBError;
+	}
+	auto wrapper = (DatabaseData *)database;
+	Connection *connection;
+	try {
+		connection = new Connection(*wrapper->database);
+	} catch (...) { // LCOV_EXCL_START
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
+	*out = (duckdb_connection)connection;
+	return DuckDBSuccess;
+}
+
+void duckdb_disconnect(duckdb_connection *connection) {
+	if (connection && *connection) {
+		Connection *conn = (Connection *)*connection;
+		delete conn;
+		*connection = nullptr;
+	}
+}
+
+duckdb_state duckdb_query(duckdb_connection connection, const char *query, duckdb_result *out) {
+	Connection *conn = (Connection *)connection;
+	auto result = conn->Query(query);
+	return duckdb_translate_result(move(result), out);
+}
+
+
+void duckdb_destroy_value(duckdb_value *value) {
+	if (value && *value) {
+		auto val = (duckdb::Value *)*value;
+		delete val;
+		*value = nullptr;
+	}
+}
+
+duckdb_value duckdb_create_varchar_length(const char *text, idx_t length) {
+	return (duckdb_value) new duckdb::Value(std::string(text, length));
+}
+
+duckdb_value duckdb_create_varchar(const char *text) {
+	return duckdb_create_varchar_length(text, strlen(text));
+}
+
+duckdb_value duckdb_create_int64(int64_t input) {
+	auto val = duckdb::Value::BIGINT(input);
+	return (duckdb_value) new duckdb::Value(val);
+}
+
+char *duckdb_get_varchar(duckdb_value value) {
+	auto val = (duckdb::Value *)value;
+	auto str_val = val->CastAs(duckdb::LogicalType::VARCHAR);
+	auto &str = duckdb::StringValue::Get(str_val);
+
+	auto result = (char *)malloc(sizeof(char *) * (str.size() + 1));
+	memcpy(result, str.c_str(), str.size());
+	result[str.size()] = '\0';
+	return result;
+}
+
+int64_t duckdb_get_int64(duckdb_value value) {
+	auto val = (duckdb::Value *)value;
+	if (!val->TryCastAs(duckdb::LogicalType::BIGINT)) {
+		return 0;
+	}
+	return duckdb::BigIntValue::Get(*val);
+}
+
+
+namespace duckdb {
+
+LogicalTypeId ConvertCTypeToCPP(duckdb_type c_type) {
+	switch (c_type) {
+	case DUCKDB_TYPE_BOOLEAN:
+		return LogicalTypeId::BOOLEAN;
+	case DUCKDB_TYPE_TINYINT:
+		return LogicalTypeId::TINYINT;
+	case DUCKDB_TYPE_SMALLINT:
+		return LogicalTypeId::SMALLINT;
+	case DUCKDB_TYPE_INTEGER:
+		return LogicalTypeId::INTEGER;
+	case DUCKDB_TYPE_BIGINT:
+		return LogicalTypeId::BIGINT;
+	case DUCKDB_TYPE_UTINYINT:
+		return LogicalTypeId::UTINYINT;
+	case DUCKDB_TYPE_USMALLINT:
+		return LogicalTypeId::USMALLINT;
+	case DUCKDB_TYPE_UINTEGER:
+		return LogicalTypeId::UINTEGER;
+	case DUCKDB_TYPE_UBIGINT:
+		return LogicalTypeId::UBIGINT;
+	case DUCKDB_TYPE_HUGEINT:
+		return LogicalTypeId::HUGEINT;
+	case DUCKDB_TYPE_FLOAT:
+		return LogicalTypeId::FLOAT;
+	case DUCKDB_TYPE_DOUBLE:
+		return LogicalTypeId::DOUBLE;
+	case DUCKDB_TYPE_TIMESTAMP:
+		return LogicalTypeId::TIMESTAMP;
+	case DUCKDB_TYPE_DATE:
+		return LogicalTypeId::DATE;
+	case DUCKDB_TYPE_TIME:
+		return LogicalTypeId::TIME;
+	case DUCKDB_TYPE_VARCHAR:
+		return LogicalTypeId::VARCHAR;
+	case DUCKDB_TYPE_JSON:
+		return LogicalTypeId::JSON;
+	case DUCKDB_TYPE_BLOB:
+		return LogicalTypeId::BLOB;
+	case DUCKDB_TYPE_INTERVAL:
+		return LogicalTypeId::INTERVAL;
+	case DUCKDB_TYPE_TIMESTAMP_S:
+		return LogicalTypeId::TIMESTAMP_SEC;
+	case DUCKDB_TYPE_TIMESTAMP_MS:
+		return LogicalTypeId::TIMESTAMP_MS;
+	case DUCKDB_TYPE_TIMESTAMP_NS:
+		return LogicalTypeId::TIMESTAMP_NS;
+	case DUCKDB_TYPE_UUID:
+		return LogicalTypeId::UUID;
+	default: // LCOV_EXCL_START
+		D_ASSERT(0);
+		return LogicalTypeId::INVALID;
+	} // LCOV_EXCL_STOP
+}
+
+duckdb_type ConvertCPPTypeToC(const LogicalType &sql_type) {
+	switch (sql_type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return DUCKDB_TYPE_BOOLEAN;
+	case LogicalTypeId::TINYINT:
+		return DUCKDB_TYPE_TINYINT;
+	case LogicalTypeId::SMALLINT:
+		return DUCKDB_TYPE_SMALLINT;
+	case LogicalTypeId::INTEGER:
+		return DUCKDB_TYPE_INTEGER;
+	case LogicalTypeId::BIGINT:
+		return DUCKDB_TYPE_BIGINT;
+	case LogicalTypeId::UTINYINT:
+		return DUCKDB_TYPE_UTINYINT;
+	case LogicalTypeId::USMALLINT:
+		return DUCKDB_TYPE_USMALLINT;
+	case LogicalTypeId::UINTEGER:
+		return DUCKDB_TYPE_UINTEGER;
+	case LogicalTypeId::UBIGINT:
+		return DUCKDB_TYPE_UBIGINT;
+	case LogicalTypeId::HUGEINT:
+		return DUCKDB_TYPE_HUGEINT;
+	case LogicalTypeId::FLOAT:
+		return DUCKDB_TYPE_FLOAT;
+	case LogicalTypeId::DOUBLE:
+		return DUCKDB_TYPE_DOUBLE;
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return DUCKDB_TYPE_TIMESTAMP;
+	case LogicalTypeId::TIMESTAMP_SEC:
+		return DUCKDB_TYPE_TIMESTAMP_S;
+	case LogicalTypeId::TIMESTAMP_MS:
+		return DUCKDB_TYPE_TIMESTAMP_MS;
+	case LogicalTypeId::TIMESTAMP_NS:
+		return DUCKDB_TYPE_TIMESTAMP_NS;
+	case LogicalTypeId::DATE:
+		return DUCKDB_TYPE_DATE;
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		return DUCKDB_TYPE_TIME;
+	case LogicalTypeId::VARCHAR:
+		return DUCKDB_TYPE_VARCHAR;
+	case LogicalTypeId::JSON:
+		return DUCKDB_TYPE_JSON;
+	case LogicalTypeId::BLOB:
+		return DUCKDB_TYPE_BLOB;
+	case LogicalTypeId::INTERVAL:
+		return DUCKDB_TYPE_INTERVAL;
+	case LogicalTypeId::DECIMAL:
+		return DUCKDB_TYPE_DECIMAL;
+	case LogicalTypeId::ENUM:
+		return DUCKDB_TYPE_ENUM;
+	case LogicalTypeId::LIST:
+		return DUCKDB_TYPE_LIST;
+	case LogicalTypeId::STRUCT:
+		return DUCKDB_TYPE_STRUCT;
+	case LogicalTypeId::MAP:
+		return DUCKDB_TYPE_MAP;
+	case LogicalTypeId::UUID:
+		return DUCKDB_TYPE_UUID;
+	default: // LCOV_EXCL_START
+		D_ASSERT(0);
+		return DUCKDB_TYPE_INVALID;
+	} // LCOV_EXCL_STOP
+}
+
+idx_t GetCTypeSize(duckdb_type type) {
+	switch (type) {
+	case DUCKDB_TYPE_BOOLEAN:
+		return sizeof(bool);
+	case DUCKDB_TYPE_TINYINT:
+		return sizeof(int8_t);
+	case DUCKDB_TYPE_SMALLINT:
+		return sizeof(int16_t);
+	case DUCKDB_TYPE_INTEGER:
+		return sizeof(int32_t);
+	case DUCKDB_TYPE_BIGINT:
+		return sizeof(int64_t);
+	case DUCKDB_TYPE_UTINYINT:
+		return sizeof(uint8_t);
+	case DUCKDB_TYPE_USMALLINT:
+		return sizeof(uint16_t);
+	case DUCKDB_TYPE_UINTEGER:
+		return sizeof(uint32_t);
+	case DUCKDB_TYPE_UBIGINT:
+		return sizeof(uint64_t);
+	case DUCKDB_TYPE_HUGEINT:
+	case DUCKDB_TYPE_UUID:
+		return sizeof(duckdb_hugeint);
+	case DUCKDB_TYPE_FLOAT:
+		return sizeof(float);
+	case DUCKDB_TYPE_DOUBLE:
+		return sizeof(double);
+	case DUCKDB_TYPE_DATE:
+		return sizeof(duckdb_date);
+	case DUCKDB_TYPE_TIME:
+		return sizeof(duckdb_time);
+	case DUCKDB_TYPE_TIMESTAMP:
+	case DUCKDB_TYPE_TIMESTAMP_S:
+	case DUCKDB_TYPE_TIMESTAMP_MS:
+	case DUCKDB_TYPE_TIMESTAMP_NS:
+		return sizeof(duckdb_timestamp);
+	case DUCKDB_TYPE_VARCHAR:
+		return sizeof(const char *);
+	case DUCKDB_TYPE_BLOB:
+		return sizeof(duckdb_blob);
+	case DUCKDB_TYPE_INTERVAL:
+		return sizeof(duckdb_interval);
+	case DUCKDB_TYPE_DECIMAL:
+		return sizeof(duckdb_hugeint);
+	default: // LCOV_EXCL_START
+		// unsupported type
+		D_ASSERT(0);
+		return sizeof(const char *);
+	} // LCOV_EXCL_STOP
+}
+
+} // namespace duckdb
+
+void *duckdb_malloc(size_t size) {
+	return malloc(size);
+}
+
+void duckdb_free(void *ptr) {
+	free(ptr);
+}
+
+idx_t duckdb_vector_size() {
+	return STANDARD_VECTOR_SIZE;
+}
+
+
+
+
+
+using duckdb::Hugeint;
+using duckdb::hugeint_t;
+using duckdb::Value;
+
+double duckdb_hugeint_to_double(duckdb_hugeint val) {
+	hugeint_t internal;
+	internal.lower = val.lower;
+	internal.upper = val.upper;
+	return Hugeint::Cast<double>(internal);
+}
+
+duckdb_hugeint duckdb_double_to_hugeint(double val) {
+	hugeint_t internal_result;
+	if (!Value::DoubleIsFinite(val) || !Hugeint::TryConvert<double>(val, internal_result)) {
+		internal_result.lower = 0;
+		internal_result.upper = 0;
+	}
+
+	duckdb_hugeint result;
+	result.lower = internal_result.lower;
+	result.upper = internal_result.upper;
+	return result;
+}
+
+double duckdb_decimal_to_double(duckdb_decimal val) {
+	double result;
+	hugeint_t value;
+	value.lower = val.value.lower;
+	value.upper = val.value.upper;
+	duckdb::TryCastFromDecimal::Operation<hugeint_t, double>(value, result, nullptr, val.width, val.scale);
+	return result;
+}
+
+
+duckdb_logical_type duckdb_create_logical_type(duckdb_type type) {
+	return new duckdb::LogicalType(duckdb::ConvertCTypeToCPP(type));
+}
+
+duckdb_logical_type duckdb_create_list_type(duckdb_logical_type type) {
+	if (!type) {
+		return nullptr;
+	}
+	duckdb::LogicalType *ltype = new duckdb::LogicalType;
+	*ltype = duckdb::LogicalType::LIST(*(duckdb::LogicalType *)type);
+	return ltype;
+}
+
+duckdb_logical_type duckdb_create_map_type(duckdb_logical_type key_type, duckdb_logical_type value_type) {
+	if (!key_type || !value_type) {
+		return nullptr;
+	}
+	duckdb::LogicalType *mtype = new duckdb::LogicalType;
+	*mtype = duckdb::LogicalType::MAP(*(duckdb::LogicalType *)key_type, *(duckdb::LogicalType *)value_type);
+	return mtype;
+}
+
+duckdb_logical_type duckdb_create_decimal_type(uint8_t width, uint8_t scale) {
+	return new duckdb::LogicalType(duckdb::LogicalType::DECIMAL(width, scale));
+}
+
+duckdb_type duckdb_get_type_id(duckdb_logical_type type) {
+	if (!type) {
+		return DUCKDB_TYPE_INVALID;
+	}
+	auto ltype = (duckdb::LogicalType *)type;
+	return duckdb::ConvertCPPTypeToC(*ltype);
+}
+
+void duckdb_destroy_logical_type(duckdb_logical_type *type) {
+	if (type && *type) {
+		auto ltype = (duckdb::LogicalType *)*type;
+		delete ltype;
+		*type = nullptr;
+	}
+}
+
+uint8_t duckdb_decimal_width(duckdb_logical_type type) {
+	if (!type) {
+		return 0;
+	}
+	auto &ltype = *((duckdb::LogicalType *)type);
+	if (ltype.id() != duckdb::LogicalTypeId::DECIMAL) {
+		return 0;
+	}
+	return duckdb::DecimalType::GetWidth(ltype);
+}
+
+uint8_t duckdb_decimal_scale(duckdb_logical_type type) {
+	if (!type) {
+		return 0;
+	}
+	auto &ltype = *((duckdb::LogicalType *)type);
+	if (ltype.id() != duckdb::LogicalTypeId::DECIMAL) {
+		return 0;
+	}
+	return duckdb::DecimalType::GetScale(ltype);
+}
+
+duckdb_type duckdb_decimal_internal_type(duckdb_logical_type type) {
+	if (!type) {
+		return DUCKDB_TYPE_INVALID;
+	}
+	auto &ltype = *((duckdb::LogicalType *)type);
+	if (ltype.id() != duckdb::LogicalTypeId::DECIMAL) {
+		return DUCKDB_TYPE_INVALID;
+	}
+	switch (ltype.InternalType()) {
+	case duckdb::PhysicalType::INT16:
+		return DUCKDB_TYPE_SMALLINT;
+	case duckdb::PhysicalType::INT32:
+		return DUCKDB_TYPE_INTEGER;
+	case duckdb::PhysicalType::INT64:
+		return DUCKDB_TYPE_BIGINT;
+	case duckdb::PhysicalType::INT128:
+		return DUCKDB_TYPE_HUGEINT;
+	default:
+		return DUCKDB_TYPE_INVALID;
+	}
+}
+
+duckdb_type duckdb_enum_internal_type(duckdb_logical_type type) {
+	if (!type) {
+		return DUCKDB_TYPE_INVALID;
+	}
+	auto &ltype = *((duckdb::LogicalType *)type);
+	if (ltype.id() != duckdb::LogicalTypeId::ENUM) {
+		return DUCKDB_TYPE_INVALID;
+	}
+	switch (ltype.InternalType()) {
+	case duckdb::PhysicalType::UINT8:
+		return DUCKDB_TYPE_UTINYINT;
+	case duckdb::PhysicalType::UINT16:
+		return DUCKDB_TYPE_USMALLINT;
+	case duckdb::PhysicalType::UINT32:
+		return DUCKDB_TYPE_UINTEGER;
+	default:
+		return DUCKDB_TYPE_INVALID;
+	}
+}
+
+uint32_t duckdb_enum_dictionary_size(duckdb_logical_type type) {
+	if (!type) {
+		return 0;
+	}
+	auto &ltype = *((duckdb::LogicalType *)type);
+	if (ltype.id() != duckdb::LogicalTypeId::ENUM) {
+		return 0;
+	}
+	return duckdb::EnumType::GetSize(ltype);
+}
+
+char *duckdb_enum_dictionary_value(duckdb_logical_type type, idx_t index) {
+	if (!type) {
+		return nullptr;
+	}
+	auto &ltype = *((duckdb::LogicalType *)type);
+	if (ltype.id() != duckdb::LogicalTypeId::ENUM) {
+		return nullptr;
+	}
+	auto &vector = duckdb::EnumType::GetValuesInsertOrder(ltype);
+	auto value = vector.GetValue(index);
+	return strdup(duckdb::StringValue::Get(value).c_str());
+}
+
+duckdb_logical_type duckdb_list_type_child_type(duckdb_logical_type type) {
+	if (!type) {
+		return nullptr;
+	}
+	auto &ltype = *((duckdb::LogicalType *)type);
+	if (ltype.id() != duckdb::LogicalTypeId::LIST) {
+		return nullptr;
+	}
+	return new duckdb::LogicalType(duckdb::ListType::GetChildType(ltype));
+}
+
+duckdb_logical_type duckdb_map_type_key_type(duckdb_logical_type type) {
+	if (!type) {
+		return nullptr;
+	}
+	auto &mtype = *((duckdb::LogicalType *)type);
+	if (mtype.id() != duckdb::LogicalTypeId::MAP) {
+		return nullptr;
+	}
+	return new duckdb::LogicalType(duckdb::MapType::KeyType(mtype));
+}
+
+duckdb_logical_type duckdb_map_type_value_type(duckdb_logical_type type) {
+	if (!type) {
+		return nullptr;
+	}
+	auto &mtype = *((duckdb::LogicalType *)type);
+	if (mtype.id() != duckdb::LogicalTypeId::MAP) {
+		return nullptr;
+	}
+	return new duckdb::LogicalType(duckdb::MapType::ValueType(mtype));
+}
+
+idx_t duckdb_struct_type_child_count(duckdb_logical_type type) {
+	if (!type) {
+		return 0;
+	}
+	auto &ltype = *((duckdb::LogicalType *)type);
+	if (ltype.InternalType() != duckdb::PhysicalType::STRUCT) {
+		return 0;
+	}
+	return duckdb::StructType::GetChildCount(ltype);
+}
+
+char *duckdb_struct_type_child_name(duckdb_logical_type type, idx_t index) {
+	if (!type) {
+		return nullptr;
+	}
+	auto &ltype = *((duckdb::LogicalType *)type);
+	if (ltype.InternalType() != duckdb::PhysicalType::STRUCT) {
+		return nullptr;
+	}
+	return strdup(duckdb::StructType::GetChildName(ltype, index).c_str());
+}
+
+duckdb_logical_type duckdb_struct_type_child_type(duckdb_logical_type type, idx_t index) {
+	if (!type) {
+		return nullptr;
+	}
+	auto &ltype = *((duckdb::LogicalType *)type);
+	if (ltype.InternalType() != duckdb::PhysicalType::STRUCT) {
+		return nullptr;
+	}
+	return new duckdb::LogicalType(duckdb::StructType::GetChildType(ltype, index));
+}
+
+
+
+
+using duckdb::Connection;
+using duckdb::date_t;
+using duckdb::dtime_t;
+using duckdb::hugeint_t;
+using duckdb::MaterializedQueryResult;
+using duckdb::PreparedStatementWrapper;
+using duckdb::QueryResultType;
+using duckdb::timestamp_t;
+using duckdb::Value;
+
+duckdb_state duckdb_prepare(duckdb_connection connection, const char *query,
+                            duckdb_prepared_statement *out_prepared_statement) {
+	if (!connection || !query || !out_prepared_statement) {
+		return DuckDBError;
+	}
+	auto wrapper = new PreparedStatementWrapper();
+	Connection *conn = (Connection *)connection;
+	wrapper->statement = conn->Prepare(query);
+	*out_prepared_statement = (duckdb_prepared_statement)wrapper;
+	return wrapper->statement->success ? DuckDBSuccess : DuckDBError;
+}
+
+const char *duckdb_prepare_error(duckdb_prepared_statement prepared_statement) {
+	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
+	if (!wrapper || !wrapper->statement || wrapper->statement->success) {
+		return nullptr;
+	}
+	return wrapper->statement->error.c_str();
+}
+
+idx_t duckdb_nparams(duckdb_prepared_statement prepared_statement) {
+	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
+	if (!wrapper || !wrapper->statement || !wrapper->statement->success) {
+		return 0;
+	}
+	return wrapper->statement->n_param;
+}
+
+duckdb_type duckdb_param_type(duckdb_prepared_statement prepared_statement, idx_t param_idx) {
+	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
+	if (!wrapper || !wrapper->statement || !wrapper->statement->success) {
+		return DUCKDB_TYPE_INVALID;
+	}
+	auto entry = wrapper->statement->data->value_map.find(param_idx);
+	if (entry == wrapper->statement->data->value_map.end()) {
+		return DUCKDB_TYPE_INVALID;
+	}
+	return ConvertCPPTypeToC(entry->second[0]->type());
+}
+
+static duckdb_state duckdb_bind_value(duckdb_prepared_statement prepared_statement, idx_t param_idx, Value val) {
+	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
+	if (!wrapper || !wrapper->statement || !wrapper->statement->success) {
+		return DuckDBError;
+	}
+	if (param_idx <= 0 || param_idx > wrapper->statement->n_param) {
+		return DuckDBError;
+	}
+	if (param_idx > wrapper->values.size()) {
+		wrapper->values.resize(param_idx);
+	}
+	wrapper->values[param_idx - 1] = val;
+	return DuckDBSuccess;
+}
+
+duckdb_state duckdb_bind_boolean(duckdb_prepared_statement prepared_statement, idx_t param_idx, bool val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::BOOLEAN(val));
+}
+
+duckdb_state duckdb_bind_int8(duckdb_prepared_statement prepared_statement, idx_t param_idx, int8_t val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::TINYINT(val));
+}
+
+duckdb_state duckdb_bind_int16(duckdb_prepared_statement prepared_statement, idx_t param_idx, int16_t val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::SMALLINT(val));
+}
+
+duckdb_state duckdb_bind_int32(duckdb_prepared_statement prepared_statement, idx_t param_idx, int32_t val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::INTEGER(val));
+}
+
+duckdb_state duckdb_bind_int64(duckdb_prepared_statement prepared_statement, idx_t param_idx, int64_t val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::BIGINT(val));
+}
+
+duckdb_state duckdb_bind_hugeint(duckdb_prepared_statement prepared_statement, idx_t param_idx, duckdb_hugeint val) {
+	hugeint_t internal;
+	internal.lower = val.lower;
+	internal.upper = val.upper;
+	return duckdb_bind_value(prepared_statement, param_idx, Value::HUGEINT(internal));
+}
+
+duckdb_state duckdb_bind_uint8(duckdb_prepared_statement prepared_statement, idx_t param_idx, uint8_t val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::UTINYINT(val));
+}
+
+duckdb_state duckdb_bind_uint16(duckdb_prepared_statement prepared_statement, idx_t param_idx, uint16_t val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::USMALLINT(val));
+}
+
+duckdb_state duckdb_bind_uint32(duckdb_prepared_statement prepared_statement, idx_t param_idx, uint32_t val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::UINTEGER(val));
+}
+
+duckdb_state duckdb_bind_uint64(duckdb_prepared_statement prepared_statement, idx_t param_idx, uint64_t val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::UBIGINT(val));
+}
+
+duckdb_state duckdb_bind_float(duckdb_prepared_statement prepared_statement, idx_t param_idx, float val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::FLOAT(val));
+}
+
+duckdb_state duckdb_bind_double(duckdb_prepared_statement prepared_statement, idx_t param_idx, double val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::DOUBLE(val));
+}
+
+duckdb_state duckdb_bind_date(duckdb_prepared_statement prepared_statement, idx_t param_idx, duckdb_date val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::DATE(date_t(val.days)));
+}
+
+duckdb_state duckdb_bind_time(duckdb_prepared_statement prepared_statement, idx_t param_idx, duckdb_time val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::TIME(dtime_t(val.micros)));
+}
+
+duckdb_state duckdb_bind_timestamp(duckdb_prepared_statement prepared_statement, idx_t param_idx,
+                                   duckdb_timestamp val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::TIMESTAMP(timestamp_t(val.micros)));
+}
+
+duckdb_state duckdb_bind_interval(duckdb_prepared_statement prepared_statement, idx_t param_idx, duckdb_interval val) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::INTERVAL(val.months, val.days, val.micros));
+}
+
+duckdb_state duckdb_bind_varchar(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val) {
+	try {
+		return duckdb_bind_value(prepared_statement, param_idx, Value(val));
+	} catch (...) {
+		return DuckDBError;
+	}
+}
+
+duckdb_state duckdb_bind_varchar_length(duckdb_prepared_statement prepared_statement, idx_t param_idx, const char *val,
+                                        idx_t length) {
+	try {
+		return duckdb_bind_value(prepared_statement, param_idx, Value(std::string(val, length)));
+	} catch (...) {
+		return DuckDBError;
+	}
+}
+
+duckdb_state duckdb_bind_blob(duckdb_prepared_statement prepared_statement, idx_t param_idx, const void *data,
+                              idx_t length) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value::BLOB((duckdb::const_data_ptr_t)data, length));
+}
+
+duckdb_state duckdb_bind_null(duckdb_prepared_statement prepared_statement, idx_t param_idx) {
+	return duckdb_bind_value(prepared_statement, param_idx, Value());
+}
+
+duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statement, duckdb_result *out_result) {
+	auto wrapper = (PreparedStatementWrapper *)prepared_statement;
+	if (!wrapper || !wrapper->statement || !wrapper->statement->success) {
+		return DuckDBError;
+	}
+	auto result = wrapper->statement->Execute(wrapper->values, false);
+	return duckdb_translate_result(move(result), out_result);
+}
+
+void duckdb_destroy_prepare(duckdb_prepared_statement *prepared_statement) {
+	if (!prepared_statement) {
+		return;
+	}
+	auto wrapper = (PreparedStatementWrapper *)*prepared_statement;
+	if (wrapper) {
+		delete wrapper;
+	}
+	*prepared_statement = nullptr;
+}
+
+
+
+
+
+
+namespace duckdb {
+
+struct CAPIReplacementScanData : public ReplacementScanData {
+	~CAPIReplacementScanData() {
+		if (delete_callback) {
+			delete_callback(extra_data);
+		}
+	}
+
+	duckdb_replacement_callback_t callback;
+	void *extra_data;
+	duckdb_delete_callback_t delete_callback;
+};
+
+struct CAPIReplacementScanInfo {
+	CAPIReplacementScanInfo(CAPIReplacementScanData *data) : data(data) {
+	}
+
+	CAPIReplacementScanData *data;
+	string function_name;
+	vector<Value> parameters;
+};
+
+unique_ptr<TableFunctionRef> duckdb_capi_replacement_callback(ClientContext &context, const string &table_name,
+                                                              ReplacementScanData *data) {
+	auto &scan_data = (CAPIReplacementScanData &)*data;
+
+	CAPIReplacementScanInfo info(&scan_data);
+	scan_data.callback((duckdb_replacement_scan_info)&info, table_name.c_str(), scan_data.extra_data);
+	if (info.function_name.empty()) {
+		// no function provided: bail-out
+		return nullptr;
+	}
+	auto table_function = make_unique<TableFunctionRef>();
+	vector<unique_ptr<ParsedExpression>> children;
+	for (auto &param : info.parameters) {
+		children.push_back(make_unique<ConstantExpression>(move(param)));
+	}
+	table_function->function = make_unique<FunctionExpression>(info.function_name, move(children));
+	return table_function;
+}
+
+} // namespace duckdb
+
+void duckdb_add_replacement_scan(duckdb_database db, duckdb_replacement_callback_t replacement, void *extra_data,
+                                 duckdb_delete_callback_t delete_callback) {
+	if (!db || !replacement) {
+		return;
+	}
+	auto wrapper = (duckdb::DatabaseData *)db;
+	auto scan_info = duckdb::make_unique<duckdb::CAPIReplacementScanData>();
+	scan_info->callback = replacement;
+	scan_info->extra_data = extra_data;
+	scan_info->delete_callback = delete_callback;
+
+	auto &config = duckdb::DBConfig::GetConfig(*wrapper->database->instance);
+	config.replacement_scans.push_back(
+	    duckdb::ReplacementScan(duckdb::duckdb_capi_replacement_callback, move(scan_info)));
+}
+
+void duckdb_replacement_scan_set_function_name(duckdb_replacement_scan_info info_p, const char *function_name) {
+	if (!info_p || !function_name) {
+		return;
+	}
+	auto info = (duckdb::CAPIReplacementScanInfo *)info_p;
+	info->function_name = function_name;
+}
+
+void duckdb_replacement_scan_add_parameter(duckdb_replacement_scan_info info_p, duckdb_value parameter) {
+	if (!info_p || !parameter) {
+		return;
+	}
+	auto info = (duckdb::CAPIReplacementScanInfo *)info_p;
+	auto val = (duckdb::Value *)parameter;
+	info->parameters.push_back(*val);
+}
+
+
+
+namespace duckdb {
+
+template <class T>
+void WriteData(duckdb_column *column, ChunkCollection &source, idx_t col) {
+	idx_t row = 0;
+	auto target = (T *)column->__deprecated_data;
+	for (auto &chunk : source.Chunks()) {
+		auto source = FlatVector::GetData<T>(chunk->data[col]);
+		auto &mask = FlatVector::Validity(chunk->data[col]);
+
+		for (idx_t k = 0; k < chunk->size(); k++, row++) {
+			if (!mask.RowIsValid(k)) {
+				continue;
+			}
+			target[row] = source[k];
+		}
+	}
+}
+
+duckdb_state deprecated_duckdb_translate_column(MaterializedQueryResult &result, duckdb_column *column, idx_t col) {
+	idx_t row_count = result.collection.Count();
+	column->__deprecated_nullmask = (bool *)duckdb_malloc(sizeof(bool) * result.collection.Count());
+	column->__deprecated_data = duckdb_malloc(GetCTypeSize(column->__deprecated_type) * row_count);
+	if (!column->__deprecated_nullmask || !column->__deprecated_data) { // LCOV_EXCL_START
+		// malloc failure
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
+
+	// first convert the nullmask
+	idx_t row = 0;
+	for (auto &chunk : result.collection.Chunks()) {
+		for (idx_t k = 0; k < chunk->size(); k++) {
+			column->__deprecated_nullmask[row++] = FlatVector::IsNull(chunk->data[col], k);
+		}
+	}
+	// then write the data
+	switch (result.types[col].id()) {
+	case LogicalTypeId::BOOLEAN:
+		WriteData<bool>(column, result.collection, col);
+		break;
+	case LogicalTypeId::TINYINT:
+		WriteData<int8_t>(column, result.collection, col);
+		break;
+	case LogicalTypeId::SMALLINT:
+		WriteData<int16_t>(column, result.collection, col);
+		break;
+	case LogicalTypeId::INTEGER:
+		WriteData<int32_t>(column, result.collection, col);
+		break;
+	case LogicalTypeId::BIGINT:
+		WriteData<int64_t>(column, result.collection, col);
+		break;
+	case LogicalTypeId::UTINYINT:
+		WriteData<uint8_t>(column, result.collection, col);
+		break;
+	case LogicalTypeId::USMALLINT:
+		WriteData<uint16_t>(column, result.collection, col);
+		break;
+	case LogicalTypeId::UINTEGER:
+		WriteData<uint32_t>(column, result.collection, col);
+		break;
+	case LogicalTypeId::UBIGINT:
+		WriteData<uint64_t>(column, result.collection, col);
+		break;
+	case LogicalTypeId::FLOAT:
+		WriteData<float>(column, result.collection, col);
+		break;
+	case LogicalTypeId::DOUBLE:
+		WriteData<double>(column, result.collection, col);
+		break;
+	case LogicalTypeId::DATE:
+		WriteData<date_t>(column, result.collection, col);
+		break;
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		WriteData<dtime_t>(column, result.collection, col);
+		break;
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		WriteData<timestamp_t>(column, result.collection, col);
+		break;
+	case LogicalTypeId::VARCHAR: {
+		idx_t row = 0;
+		auto target = (const char **)column->__deprecated_data;
+		for (auto &chunk : result.collection.Chunks()) {
+			auto source = FlatVector::GetData<string_t>(chunk->data[col]);
+			for (idx_t k = 0; k < chunk->size(); k++) {
+				if (!FlatVector::IsNull(chunk->data[col], k)) {
+					target[row] = (char *)duckdb_malloc(source[k].GetSize() + 1);
+					assert(target[row]);
+					memcpy((void *)target[row], source[k].GetDataUnsafe(), source[k].GetSize());
+					auto write_arr = (char *)target[row];
+					write_arr[source[k].GetSize()] = '\0';
+				} else {
+					target[row] = nullptr;
+				}
+				row++;
+			}
+		}
+		break;
+	}
+	case LogicalTypeId::BLOB: {
+		idx_t row = 0;
+		auto target = (duckdb_blob *)column->__deprecated_data;
+		for (auto &chunk : result.collection.Chunks()) {
+			auto source = FlatVector::GetData<string_t>(chunk->data[col]);
+			for (idx_t k = 0; k < chunk->size(); k++) {
+				if (!FlatVector::IsNull(chunk->data[col], k)) {
+					target[row].data = (char *)duckdb_malloc(source[k].GetSize());
+					target[row].size = source[k].GetSize();
+					assert(target[row].data);
+					memcpy((void *)target[row].data, source[k].GetDataUnsafe(), source[k].GetSize());
+				} else {
+					target[row].data = nullptr;
+					target[row].size = 0;
+				}
+				row++;
+			}
+		}
+		break;
+	}
+	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_SEC: {
+		idx_t row = 0;
+		auto target = (timestamp_t *)column->__deprecated_data;
+		for (auto &chunk : result.collection.Chunks()) {
+			auto source = FlatVector::GetData<timestamp_t>(chunk->data[col]);
+
+			for (idx_t k = 0; k < chunk->size(); k++) {
+				if (!FlatVector::IsNull(chunk->data[col], k)) {
+					if (result.types[col].id() == LogicalTypeId::TIMESTAMP_NS) {
+						target[row] = Timestamp::FromEpochNanoSeconds(source[k].value);
+					} else if (result.types[col].id() == LogicalTypeId::TIMESTAMP_MS) {
+						target[row] = Timestamp::FromEpochMs(source[k].value);
+					} else {
+						D_ASSERT(result.types[col].id() == LogicalTypeId::TIMESTAMP_SEC);
+						target[row] = Timestamp::FromEpochSeconds(source[k].value);
+					}
+				}
+				row++;
+			}
+		}
+		break;
+	}
+	case LogicalTypeId::HUGEINT: {
+		idx_t row = 0;
+		auto target = (duckdb_hugeint *)column->__deprecated_data;
+		for (auto &chunk : result.collection.Chunks()) {
+			auto source = FlatVector::GetData<hugeint_t>(chunk->data[col]);
+			for (idx_t k = 0; k < chunk->size(); k++) {
+				if (!FlatVector::IsNull(chunk->data[col], k)) {
+					target[row].lower = source[k].lower;
+					target[row].upper = source[k].upper;
+				}
+				row++;
+			}
+		}
+		break;
+	}
+	case LogicalTypeId::INTERVAL: {
+		idx_t row = 0;
+		auto target = (duckdb_interval *)column->__deprecated_data;
+		for (auto &chunk : result.collection.Chunks()) {
+			auto source = FlatVector::GetData<interval_t>(chunk->data[col]);
+			for (idx_t k = 0; k < chunk->size(); k++) {
+				if (!FlatVector::IsNull(chunk->data[col], k)) {
+					target[row].days = source[k].days;
+					target[row].months = source[k].months;
+					target[row].micros = source[k].micros;
+				}
+				row++;
+			}
+		}
+		break;
+	}
+	case LogicalTypeId::DECIMAL: {
+		// get data
+		idx_t row = 0;
+		auto target = (hugeint_t *)column->__deprecated_data;
+		switch (result.types[col].InternalType()) {
+		case PhysicalType::INT16: {
+			for (auto &chunk : result.collection.Chunks()) {
+				auto source = FlatVector::GetData<int16_t>(chunk->data[col]);
+				for (idx_t k = 0; k < chunk->size(); k++) {
+					if (!FlatVector::IsNull(chunk->data[col], k)) {
+						target[row].lower = source[k];
+						target[row].upper = 0;
+					}
+					row++;
+				}
+			}
+			break;
+		}
+		case PhysicalType::INT32: {
+			for (auto &chunk : result.collection.Chunks()) {
+				auto source = FlatVector::GetData<int32_t>(chunk->data[col]);
+				for (idx_t k = 0; k < chunk->size(); k++) {
+					if (!FlatVector::IsNull(chunk->data[col], k)) {
+						target[row].lower = source[k];
+						target[row].upper = 0;
+					}
+					row++;
+				}
+			}
+			break;
+		}
+		case PhysicalType::INT64: {
+			for (auto &chunk : result.collection.Chunks()) {
+				auto source = FlatVector::GetData<int64_t>(chunk->data[col]);
+				for (idx_t k = 0; k < chunk->size(); k++) {
+					if (!FlatVector::IsNull(chunk->data[col], k)) {
+						target[row].lower = source[k];
+						target[row].upper = 0;
+					}
+					row++;
+				}
+			}
+			break;
+		}
+		case PhysicalType::INT128: {
+			for (auto &chunk : result.collection.Chunks()) {
+				auto source = FlatVector::GetData<hugeint_t>(chunk->data[col]);
+				for (idx_t k = 0; k < chunk->size(); k++) {
+					if (!FlatVector::IsNull(chunk->data[col], k)) {
+						target[row].lower = source[k].lower;
+						target[row].upper = source[k].upper;
+					}
+					row++;
+				}
+			}
+			break;
+		}
+		default:
+			throw std::runtime_error("Unsupported physical type for Decimal" +
+			                         TypeIdToString(result.types[col].InternalType()));
+		}
+		break;
+	}
+	default: // LCOV_EXCL_START
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
+	return DuckDBSuccess;
+}
+
+duckdb_state duckdb_translate_result(unique_ptr<QueryResult> result_p, duckdb_result *out) {
+	auto &result = *result_p;
+	D_ASSERT(result_p);
+	if (!out) {
+		// no result to write to, only return the status
+		return result.success ? DuckDBSuccess : DuckDBError;
+	}
+
+	memset(out, 0, sizeof(duckdb_result));
+
+	// initialize the result_data object
+	auto result_data = new DuckDBResultData();
+	result_data->result = move(result_p);
+	result_data->result_set_type = CAPIResultSetType::CAPI_RESULT_TYPE_NONE;
+	out->internal_data = result_data;
+
+	if (!result.success) {
+		// write the error message
+		out->__deprecated_error_message = (char *)result.error.c_str();
+		return DuckDBError;
+	}
+	// copy the data
+	// first write the meta data
+	out->__deprecated_column_count = result.ColumnCount();
+	out->__deprecated_rows_changed = 0;
+	return DuckDBSuccess;
+}
+
+bool deprecated_materialize_result(duckdb_result *result) {
+	if (!result) {
+		return false;
+	}
+	auto result_data = (duckdb::DuckDBResultData *)result->internal_data;
+	if (!result_data->result->success) {
+		return false;
+	}
+	if (result_data->result_set_type == CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED) {
+		// already materialized into deprecated result format
+		return true;
+	}
+	if (result_data->result_set_type == CAPIResultSetType::CAPI_RESULT_TYPE_MATERIALIZED) {
+		// already used as a new result set
+		return false;
+	}
+	// materialize as deprecated result set
+	result_data->result_set_type = CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED;
+	auto column_count = result_data->result->ColumnCount();
+	result->__deprecated_columns = (duckdb_column *)duckdb_malloc(sizeof(duckdb_column) * column_count);
+	if (!result->__deprecated_columns) { // LCOV_EXCL_START
+		// malloc failure
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
+	if (result_data->result->type == QueryResultType::STREAM_RESULT) {
+		// if we are dealing with a stream result, convert it to a materialized result first
+		auto &stream_result = (StreamQueryResult &)*result_data->result;
+		result_data->result = stream_result.Materialize();
+	}
+	D_ASSERT(result_data->result->type == QueryResultType::MATERIALIZED_RESULT);
+	auto &materialized = (MaterializedQueryResult &)*result_data->result;
+
+	// convert the result to a materialized result
+	// zero initialize the columns (so we can cleanly delete it in case a malloc fails)
+	memset(result->__deprecated_columns, 0, sizeof(duckdb_column) * column_count);
+	for (idx_t i = 0; i < column_count; i++) {
+		result->__deprecated_columns[i].__deprecated_type = ConvertCPPTypeToC(result_data->result->types[i]);
+		result->__deprecated_columns[i].__deprecated_name = (char *)result_data->result->names[i].c_str();
+	}
+	result->__deprecated_row_count = materialized.collection.Count();
+	if (result->__deprecated_row_count > 0 &&
+	    materialized.properties.return_type == StatementReturnType::CHANGED_ROWS) {
+		// update total changes
+		auto row_changes = materialized.GetValue(0, 0);
+		if (!row_changes.IsNull() && row_changes.TryCastAs(LogicalType::BIGINT)) {
+			result->__deprecated_rows_changed = row_changes.GetValue<int64_t>();
+		}
+	}
+	// now write the data
+	for (idx_t col = 0; col < column_count; col++) {
+		auto state = deprecated_duckdb_translate_column(materialized, &result->__deprecated_columns[col], col);
+		if (state != DuckDBSuccess) {
+			return false;
+		}
+	}
+	return true;
+}
+
+} // namespace duckdb
+
+static void DuckdbDestroyColumn(duckdb_column column, idx_t count) {
+	if (column.__deprecated_data) {
+		if (column.__deprecated_type == DUCKDB_TYPE_VARCHAR) {
+			// varchar, delete individual strings
+			auto data = (char **)column.__deprecated_data;
+			for (idx_t i = 0; i < count; i++) {
+				if (data[i]) {
+					duckdb_free(data[i]);
+				}
+			}
+		} else if (column.__deprecated_type == DUCKDB_TYPE_BLOB) {
+			// blob, delete individual blobs
+			auto data = (duckdb_blob *)column.__deprecated_data;
+			for (idx_t i = 0; i < count; i++) {
+				if (data[i].data) {
+					duckdb_free((void *)data[i].data);
+				}
+			}
+		}
+		duckdb_free(column.__deprecated_data);
+	}
+	if (column.__deprecated_nullmask) {
+		duckdb_free(column.__deprecated_nullmask);
+	}
+}
+
+void duckdb_destroy_result(duckdb_result *result) {
+	if (result->__deprecated_columns) {
+		for (idx_t i = 0; i < result->__deprecated_column_count; i++) {
+			DuckdbDestroyColumn(result->__deprecated_columns[i], result->__deprecated_row_count);
+		}
+		duckdb_free(result->__deprecated_columns);
+	}
+	if (result->internal_data) {
+		auto result_data = (duckdb::DuckDBResultData *)result->internal_data;
+		delete result_data;
+	}
+	memset(result, 0, sizeof(duckdb_result));
+}
+
+const char *duckdb_column_name(duckdb_result *result, idx_t col) {
+	if (!result || col >= duckdb_column_count(result)) {
+		return nullptr;
+	}
+	auto &result_data = *((duckdb::DuckDBResultData *)result->internal_data);
+	return result_data.result->names[col].c_str();
+}
+
+duckdb_type duckdb_column_type(duckdb_result *result, idx_t col) {
+	if (!result || col >= duckdb_column_count(result)) {
+		return DUCKDB_TYPE_INVALID;
+	}
+	auto &result_data = *((duckdb::DuckDBResultData *)result->internal_data);
+	return duckdb::ConvertCPPTypeToC(result_data.result->types[col]);
+}
+
+duckdb_logical_type duckdb_column_logical_type(duckdb_result *result, idx_t col) {
+	if (!result || col >= duckdb_column_count(result)) {
+		return nullptr;
+	}
+	auto &result_data = *((duckdb::DuckDBResultData *)result->internal_data);
+	return new duckdb::LogicalType(result_data.result->types[col]);
+}
+
+idx_t duckdb_column_count(duckdb_result *result) {
+	if (!result) {
+		return 0;
+	}
+	auto &result_data = *((duckdb::DuckDBResultData *)result->internal_data);
+	return result_data.result->ColumnCount();
+}
+
+idx_t duckdb_row_count(duckdb_result *result) {
+	if (!result) {
+		return 0;
+	}
+	auto &result_data = *((duckdb::DuckDBResultData *)result->internal_data);
+	auto &materialized = (duckdb::MaterializedQueryResult &)*result_data.result;
+	return materialized.collection.Count();
+}
+
+idx_t duckdb_rows_changed(duckdb_result *result) {
+	if (!result) {
+		return 0;
+	}
+	if (!duckdb::deprecated_materialize_result(result)) {
+		return 0;
+	}
+	return result->__deprecated_rows_changed;
+}
+
+void *duckdb_column_data(duckdb_result *result, idx_t col) {
+	if (!result || col >= result->__deprecated_column_count) {
+		return nullptr;
+	}
+	if (!duckdb::deprecated_materialize_result(result)) {
+		return nullptr;
+	}
+	return result->__deprecated_columns[col].__deprecated_data;
+}
+
+bool *duckdb_nullmask_data(duckdb_result *result, idx_t col) {
+	if (!result || col >= result->__deprecated_column_count) {
+		return nullptr;
+	}
+	if (!duckdb::deprecated_materialize_result(result)) {
+		return nullptr;
+	}
+	return result->__deprecated_columns[col].__deprecated_nullmask;
+}
+
+const char *duckdb_result_error(duckdb_result *result) {
+	if (!result) {
+		return nullptr;
+	}
+	auto &result_data = *((duckdb::DuckDBResultData *)result->internal_data);
+	return result_data.result->success ? nullptr : result_data.result->error.c_str();
+}
+
+idx_t duckdb_result_chunk_count(duckdb_result result) {
+	if (!result.internal_data) {
+		return 0;
+	}
+	auto &result_data = *((duckdb::DuckDBResultData *)result.internal_data);
+	if (result_data.result_set_type == duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED) {
+		return 0;
+	}
+	D_ASSERT(result_data.result->type == duckdb::QueryResultType::MATERIALIZED_RESULT);
+	auto &materialized = (duckdb::MaterializedQueryResult &)*result_data.result;
+	return materialized.collection.ChunkCount();
+}
+
+duckdb_data_chunk duckdb_result_get_chunk(duckdb_result result, idx_t chunk_idx) {
+	if (!result.internal_data) {
+		return nullptr;
+	}
+	auto &result_data = *((duckdb::DuckDBResultData *)result.internal_data);
+	if (result_data.result_set_type == duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED) {
+		return nullptr;
+	}
+	result_data.result_set_type = duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_MATERIALIZED;
+	auto &materialized = (duckdb::MaterializedQueryResult &)*result_data.result;
+	if (chunk_idx >= materialized.collection.ChunkCount()) {
+		return nullptr;
+	}
+	auto chunk = duckdb::make_unique<duckdb::DataChunk>();
+	chunk->InitializeEmpty(materialized.collection.Types());
+	chunk->Reference(*materialized.collection.Chunks()[chunk_idx]);
+	return chunk.release();
+}
+
+
+
+
+
+
+namespace duckdb {
+
+struct CTableFunctionInfo : public TableFunctionInfo {
+	~CTableFunctionInfo() {
+		if (extra_info && delete_callback) {
+			delete_callback(extra_info);
+		}
+		extra_info = nullptr;
+		delete_callback = nullptr;
+	}
+
+	duckdb_table_function_bind_t bind = nullptr;
+	duckdb_table_function_init_t init = nullptr;
+	duckdb_table_function_init_t local_init = nullptr;
+	duckdb_table_function_t function = nullptr;
+	void *extra_info = nullptr;
+	duckdb_delete_callback_t delete_callback = nullptr;
+};
+
+struct CTableBindData : public TableFunctionData {
+	~CTableBindData() {
+		if (bind_data && delete_callback) {
+			delete_callback(bind_data);
+		}
+		bind_data = nullptr;
+		delete_callback = nullptr;
+	}
+
+	CTableFunctionInfo *info = nullptr;
+	void *bind_data = nullptr;
+	duckdb_delete_callback_t delete_callback = nullptr;
+};
+
+struct CTableInternalBindInfo {
+	CTableInternalBindInfo(ClientContext &context, TableFunctionBindInput &input, vector<LogicalType> &return_types,
+	                       vector<string> &names, CTableBindData &bind_data, CTableFunctionInfo &function_info)
+	    : context(context), input(input), return_types(return_types), names(names), bind_data(bind_data),
+	      function_info(function_info), success(true) {
+	}
+
+	ClientContext &context;
+	TableFunctionBindInput &input;
+	vector<LogicalType> &return_types;
+	vector<string> &names;
+	CTableBindData &bind_data;
+	CTableFunctionInfo &function_info;
+	bool success;
+	string error;
+};
+
+struct CTableInitData {
+	~CTableInitData() {
+		if (init_data && delete_callback) {
+			delete_callback(init_data);
+		}
+		init_data = nullptr;
+		delete_callback = nullptr;
+	}
+
+	void *init_data = nullptr;
+	duckdb_delete_callback_t delete_callback = nullptr;
+	idx_t max_threads = 1;
+};
+
+struct CTableGlobalInitData : public GlobalTableFunctionState {
+	CTableInitData init_data;
+
+	idx_t MaxThreads() const override {
+		return init_data.max_threads;
+	}
+};
+
+struct CTableLocalInitData : public LocalTableFunctionState {
+	CTableInitData init_data;
+};
+
+struct CTableInternalInitInfo {
+	CTableInternalInitInfo(CTableBindData &bind_data, CTableInitData &init_data, const vector<column_t> &column_ids,
+	                       TableFilterSet *filters)
+	    : bind_data(bind_data), init_data(init_data), column_ids(column_ids), filters(filters), success(true) {
+	}
+
+	CTableBindData &bind_data;
+	CTableInitData &init_data;
+	const vector<column_t> &column_ids;
+	TableFilterSet *filters;
+	bool success;
+	string error;
+};
+
+struct CTableInternalFunctionInfo {
+	CTableInternalFunctionInfo(CTableBindData &bind_data, CTableInitData &init_data, CTableInitData &local_data)
+	    : bind_data(bind_data), init_data(init_data), local_data(local_data), success(true) {
+	}
+
+	CTableBindData &bind_data;
+	CTableInitData &init_data;
+	CTableInitData &local_data;
+	bool success;
+	string error;
+};
+
+unique_ptr<FunctionData> CTableFunctionBind(ClientContext &context, TableFunctionBindInput &input,
+                                            vector<LogicalType> &return_types, vector<string> &names) {
+	auto info = (CTableFunctionInfo *)input.info;
+	D_ASSERT(info->bind && info->function && info->init);
+	auto result = make_unique<CTableBindData>();
+	CTableInternalBindInfo bind_info(context, input, return_types, names, *result, *info);
+	info->bind(&bind_info);
+	if (!bind_info.success) {
+		throw Exception(bind_info.error);
+	}
+
+	result->info = info;
+	return move(result);
+}
+
+unique_ptr<GlobalTableFunctionState> CTableFunctionInit(ClientContext &context, TableFunctionInitInput &data_p) {
+	auto &bind_data = (CTableBindData &)*data_p.bind_data;
+	auto result = make_unique<CTableGlobalInitData>();
+
+	CTableInternalInitInfo init_info(bind_data, result->init_data, data_p.column_ids, data_p.filters);
+	bind_data.info->init(&init_info);
+	if (!init_info.success) {
+		throw Exception(init_info.error);
+	}
+	return move(result);
+}
+
+unique_ptr<LocalTableFunctionState> CTableFunctionLocalInit(ClientContext &context, TableFunctionInitInput &data_p,
+                                                            GlobalTableFunctionState *gstate) {
+	auto &bind_data = (CTableBindData &)*data_p.bind_data;
+	auto result = make_unique<CTableLocalInitData>();
+	if (!bind_data.info->local_init) {
+		return move(result);
+	}
+
+	CTableInternalInitInfo init_info(bind_data, result->init_data, data_p.column_ids, data_p.filters);
+	bind_data.info->local_init(&init_info);
+	if (!init_info.success) {
+		throw Exception(init_info.error);
+	}
+	return move(result);
+}
+
+void CTableFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = (CTableBindData &)*data_p.bind_data;
+	auto &global_data = (CTableGlobalInitData &)*data_p.global_state;
+	auto &local_data = (CTableLocalInitData &)*data_p.local_state;
+	CTableInternalFunctionInfo function_info(bind_data, global_data.init_data, local_data.init_data);
+	bind_data.info->function(&function_info, &output);
+	if (!function_info.success) {
+		throw Exception(function_info.error);
+	}
+}
+
+} // namespace duckdb
+
+//===--------------------------------------------------------------------===//
+// Table Function
+//===--------------------------------------------------------------------===//
+duckdb_table_function duckdb_create_table_function() {
+	auto function = new duckdb::TableFunction("", {}, duckdb::CTableFunction, duckdb::CTableFunctionBind,
+	                                          duckdb::CTableFunctionInit, duckdb::CTableFunctionLocalInit);
+	function->function_info = duckdb::make_shared<duckdb::CTableFunctionInfo>();
+	return function;
+}
+
+void duckdb_destroy_table_function(duckdb_table_function *function) {
+	if (function && *function) {
+		auto tf = (duckdb::TableFunction *)*function;
+		delete tf;
+		*function = nullptr;
+	}
+}
+
+void duckdb_table_function_set_name(duckdb_table_function function, const char *name) {
+	if (!function || !name) {
+		return;
+	}
+	auto tf = (duckdb::TableFunction *)function;
+	tf->name = name;
+}
+
+void duckdb_table_function_add_parameter(duckdb_table_function function, duckdb_logical_type type) {
+	if (!function || !type) {
+		return;
+	}
+	auto tf = (duckdb::TableFunction *)function;
+	auto logical_type = (duckdb::LogicalType *)type;
+	tf->arguments.push_back(*logical_type);
+}
+
+void duckdb_table_function_set_extra_info(duckdb_table_function function, void *extra_info,
+                                          duckdb_delete_callback_t destroy) {
+	if (!function) {
+		return;
+	}
+	auto tf = (duckdb::TableFunction *)function;
+	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
+	info->extra_info = extra_info;
+	info->delete_callback = destroy;
+}
+
+void duckdb_table_function_set_bind(duckdb_table_function function, duckdb_table_function_bind_t bind) {
+	if (!function || !bind) {
+		return;
+	}
+	auto tf = (duckdb::TableFunction *)function;
+	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
+	info->bind = bind;
+}
+
+void duckdb_table_function_set_init(duckdb_table_function function, duckdb_table_function_init_t init) {
+	if (!function || !init) {
+		return;
+	}
+	auto tf = (duckdb::TableFunction *)function;
+	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
+	info->init = init;
+}
+
+void duckdb_table_function_set_local_init(duckdb_table_function function, duckdb_table_function_init_t init) {
+	if (!function || !init) {
+		return;
+	}
+	auto tf = (duckdb::TableFunction *)function;
+	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
+	info->local_init = init;
+}
+
+void duckdb_table_function_set_function(duckdb_table_function table_function, duckdb_table_function_t function) {
+	if (!table_function || !function) {
+		return;
+	}
+	auto tf = (duckdb::TableFunction *)table_function;
+	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
+	info->function = function;
+}
+
+void duckdb_table_function_supports_projection_pushdown(duckdb_table_function table_function, bool pushdown) {
+	if (!table_function) {
+		return;
+	}
+	auto tf = (duckdb::TableFunction *)table_function;
+	tf->projection_pushdown = pushdown;
+}
+
+duckdb_state duckdb_register_table_function(duckdb_connection connection, duckdb_table_function function) {
+	if (!connection || !function) {
+		return DuckDBError;
+	}
+	auto con = (duckdb::Connection *)connection;
+	auto tf = (duckdb::TableFunction *)function;
+	auto info = (duckdb::CTableFunctionInfo *)tf->function_info.get();
+	if (tf->name.empty() || !info->bind || !info->init || !info->function) {
+		return DuckDBError;
+	}
+	con->context->RunFunctionInTransaction([&]() {
+		auto &catalog = duckdb::Catalog::GetCatalog(*con->context);
+		duckdb::CreateTableFunctionInfo tf_info(*tf);
+
+		// create the function in the catalog
+		catalog.CreateTableFunction(*con->context, &tf_info);
+	});
+	return DuckDBSuccess;
+}
+
+//===--------------------------------------------------------------------===//
+// Bind Interface
+//===--------------------------------------------------------------------===//
+void *duckdb_bind_get_extra_info(duckdb_bind_info info) {
+	if (!info) {
+		return nullptr;
+	}
+	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
+	return bind_info->function_info.extra_info;
+}
+
+void duckdb_bind_add_result_column(duckdb_bind_info info, const char *name, duckdb_logical_type type) {
+	if (!info || !name || !type) {
+		return;
+	}
+	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
+	bind_info->names.push_back(name);
+	bind_info->return_types.push_back(*((duckdb::LogicalType *)type));
+}
+
+idx_t duckdb_bind_get_parameter_count(duckdb_bind_info info) {
+	if (!info) {
+		return 0;
+	}
+	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
+	return bind_info->input.inputs.size();
+}
+
+duckdb_value duckdb_bind_get_parameter(duckdb_bind_info info, idx_t index) {
+	if (!info || index >= duckdb_bind_get_parameter_count(info)) {
+		return nullptr;
+	}
+	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
+	return new duckdb::Value(bind_info->input.inputs[index]);
+}
+
+void duckdb_bind_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy) {
+	if (!info) {
+		return;
+	}
+	auto bind_info = (duckdb::CTableInternalBindInfo *)info;
+	bind_info->bind_data.bind_data = bind_data;
+	bind_info->bind_data.delete_callback = destroy;
+}
+
+void duckdb_bind_set_error(duckdb_bind_info info, const char *error) {
+	if (!info || !error) {
+		return;
+	}
+	auto function_info = (duckdb::CTableInternalBindInfo *)info;
+	function_info->error = error;
+	function_info->success = false;
+}
+
+//===--------------------------------------------------------------------===//
+// Init Interface
+//===--------------------------------------------------------------------===//
+void *duckdb_init_get_extra_info(duckdb_init_info info) {
+	if (!info) {
+		return nullptr;
+	}
+	auto init_info = (duckdb::CTableInternalInitInfo *)info;
+	return init_info->bind_data.info->extra_info;
+}
+
+void *duckdb_init_get_bind_data(duckdb_init_info info) {
+	if (!info) {
+		return nullptr;
+	}
+	auto init_info = (duckdb::CTableInternalInitInfo *)info;
+	return init_info->bind_data.bind_data;
+}
+
+void duckdb_init_set_init_data(duckdb_init_info info, void *init_data, duckdb_delete_callback_t destroy) {
+	if (!info) {
+		return;
+	}
+	auto init_info = (duckdb::CTableInternalInitInfo *)info;
+	init_info->init_data.init_data = init_data;
+	init_info->init_data.delete_callback = destroy;
+}
+
+void duckdb_init_set_error(duckdb_init_info info, const char *error) {
+	if (!info || !error) {
+		return;
+	}
+	auto function_info = (duckdb::CTableInternalInitInfo *)info;
+	function_info->error = error;
+	function_info->success = false;
+}
+
+idx_t duckdb_init_get_column_count(duckdb_init_info info) {
+	if (!info) {
+		return 0;
+	}
+	auto function_info = (duckdb::CTableInternalInitInfo *)info;
+	return function_info->column_ids.size();
+}
+
+idx_t duckdb_init_get_column_index(duckdb_init_info info, idx_t column_index) {
+	if (!info) {
+		return 0;
+	}
+	auto function_info = (duckdb::CTableInternalInitInfo *)info;
+	if (column_index >= function_info->column_ids.size()) {
+		return 0;
+	}
+	return function_info->column_ids[column_index];
+}
+
+void duckdb_init_set_max_threads(duckdb_init_info info, idx_t max_threads) {
+	if (!info) {
+		return;
+	}
+	auto function_info = (duckdb::CTableInternalInitInfo *)info;
+	function_info->init_data.max_threads = max_threads;
+}
+
+//===--------------------------------------------------------------------===//
+// Function Interface
+//===--------------------------------------------------------------------===//
+void *duckdb_function_get_extra_info(duckdb_function_info info) {
+	if (!info) {
+		return nullptr;
+	}
+	auto function_info = (duckdb::CTableInternalFunctionInfo *)info;
+	return function_info->bind_data.info->extra_info;
+}
+
+void *duckdb_function_get_bind_data(duckdb_function_info info) {
+	if (!info) {
+		return nullptr;
+	}
+	auto function_info = (duckdb::CTableInternalFunctionInfo *)info;
+	return function_info->bind_data.bind_data;
+}
+
+void *duckdb_function_get_init_data(duckdb_function_info info) {
+	if (!info) {
+		return nullptr;
+	}
+	auto function_info = (duckdb::CTableInternalFunctionInfo *)info;
+	return function_info->init_data.init_data;
+}
+
+void *duckdb_function_get_local_init_data(duckdb_function_info info) {
+	if (!info) {
+		return nullptr;
+	}
+	auto function_info = (duckdb::CTableInternalFunctionInfo *)info;
+	return function_info->local_data.init_data;
+}
+
+void duckdb_function_set_error(duckdb_function_info info, const char *error) {
+	if (!info || !error) {
+		return;
+	}
+	auto function_info = (duckdb::CTableInternalFunctionInfo *)info;
+	function_info->error = error;
+	function_info->success = false;
+}
+
+
+
+using duckdb::DatabaseData;
+
+void duckdb_execute_tasks(duckdb_database database, idx_t max_tasks) {
+	if (!database) {
+		return;
+	}
+	auto wrapper = (DatabaseData *)database;
+	auto &scheduler = duckdb::TaskScheduler::GetScheduler(*wrapper->database->instance);
+	scheduler.ExecuteTasks(max_tasks);
+}
+
+
+
+
+
+
+
+using duckdb::const_data_ptr_t;
+using duckdb::Date;
+using duckdb::date_t;
+using duckdb::dtime_t;
+using duckdb::hugeint_t;
+using duckdb::interval_t;
+using duckdb::LogicalType;
+using duckdb::string;
+using duckdb::string_t;
+using duckdb::Time;
+using duckdb::Timestamp;
+using duckdb::timestamp_t;
+using duckdb::Value;
+using duckdb::Vector;
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Unsafe Fetch (for internal use only)
+//===--------------------------------------------------------------------===//
+template <class T>
+T UnsafeFetch(duckdb_result *result, idx_t col, idx_t row) {
+	D_ASSERT(row < result->__deprecated_row_count);
+	return ((T *)result->__deprecated_columns[col].__deprecated_data)[row];
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch Default Value
+//===--------------------------------------------------------------------===//
+struct FetchDefaultValue {
+	template <class T>
+	static T Operation() {
+		return 0;
+	}
+};
+
+template <>
+date_t FetchDefaultValue::Operation() {
+	date_t result;
+	result.days = 0;
+	return result;
+}
+
+template <>
+dtime_t FetchDefaultValue::Operation() {
+	dtime_t result;
+	result.micros = 0;
+	return result;
+}
+
+template <>
+timestamp_t FetchDefaultValue::Operation() {
+	timestamp_t result;
+	result.value = 0;
+	return result;
+}
+
+template <>
+interval_t FetchDefaultValue::Operation() {
+	interval_t result;
+	result.months = 0;
+	result.days = 0;
+	result.micros = 0;
+	return result;
+}
+
+template <>
+char *FetchDefaultValue::Operation() {
+	return nullptr;
+}
+
+template <>
+duckdb_blob FetchDefaultValue::Operation() {
+	duckdb_blob result;
+	result.data = nullptr;
+	result.size = 0;
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// String Casts
+//===--------------------------------------------------------------------===//
+template <class OP>
+struct FromCStringCastWrapper {
+	template <class SOURCE_TYPE, class RESULT_TYPE>
+	static bool Operation(SOURCE_TYPE input_str, RESULT_TYPE &result) {
+		string_t input(input_str);
+		return OP::template Operation<string_t, RESULT_TYPE>(input, result);
+	}
+};
+
+template <class OP>
+struct ToCStringCastWrapper {
+	template <class SOURCE_TYPE, class RESULT_TYPE>
+	static bool Operation(SOURCE_TYPE input, RESULT_TYPE &result) {
+		Vector result_vector(LogicalType::VARCHAR, nullptr);
+		auto result_string = OP::template Operation<SOURCE_TYPE>(input, result_vector);
+		auto result_size = result_string.GetSize();
+		auto result_data = result_string.GetDataUnsafe();
+
+		result = (char *)duckdb_malloc(result_size + 1);
+		memcpy(result, result_data, result_size);
+		result[result_size] = '\0';
+		return true;
+	}
+};
+
+//===--------------------------------------------------------------------===//
+// Blob Casts
+//===--------------------------------------------------------------------===//
+struct FromCBlobCastWrapper {
+	template <class SOURCE_TYPE, class RESULT_TYPE>
+	static bool Operation(SOURCE_TYPE input_str, RESULT_TYPE &result) {
+		return false;
+	}
+};
+
+template <>
+bool FromCBlobCastWrapper::Operation(duckdb_blob input, char *&result) {
+	string_t input_str((const char *)input.data, input.size);
+	return ToCStringCastWrapper<duckdb::CastFromBlob>::template Operation<string_t, char *>(input_str, result);
+}
+
+} // namespace duckdb
+
+using duckdb::FetchDefaultValue;
+using duckdb::FromCBlobCastWrapper;
+using duckdb::FromCStringCastWrapper;
+using duckdb::ToCStringCastWrapper;
+using duckdb::UnsafeFetch;
+
+//===--------------------------------------------------------------------===//
+// Templated Casts
+//===--------------------------------------------------------------------===//
+template <class SOURCE_TYPE, class RESULT_TYPE, class OP>
+RESULT_TYPE TryCastCInternal(duckdb_result *result, idx_t col, idx_t row) {
+	RESULT_TYPE result_value;
+	try {
+		if (!OP::template Operation<SOURCE_TYPE, RESULT_TYPE>(UnsafeFetch<SOURCE_TYPE>(result, col, row),
+		                                                      result_value)) {
+			return FetchDefaultValue::Operation<RESULT_TYPE>();
+		}
+	} catch (...) {
+		return FetchDefaultValue::Operation<RESULT_TYPE>();
+	}
+	return result_value;
+}
+
+static bool CanUseDeprecatedFetch(duckdb_result *result, idx_t col, idx_t row) {
+	if (!result) {
+		return false;
+	}
+	if (!duckdb::deprecated_materialize_result(result)) {
+		return false;
+	}
+	if (col >= result->__deprecated_column_count || row >= result->__deprecated_row_count) {
+		return false;
+	}
+	return true;
+}
+
+static bool CanFetchValue(duckdb_result *result, idx_t col, idx_t row) {
+	if (!CanUseDeprecatedFetch(result, col, row)) {
+		return false;
+	}
+	if (result->__deprecated_columns[col].__deprecated_nullmask[row]) {
+		return false;
+	}
+	return true;
+}
+
+template <class RESULT_TYPE, class OP = duckdb::TryCast>
+static RESULT_TYPE GetInternalCValue(duckdb_result *result, idx_t col, idx_t row) {
+	if (!CanFetchValue(result, col, row)) {
+		return FetchDefaultValue::Operation<RESULT_TYPE>();
+	}
+	switch (result->__deprecated_columns[col].__deprecated_type) {
+	case DUCKDB_TYPE_BOOLEAN:
+		return TryCastCInternal<bool, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_TINYINT:
+		return TryCastCInternal<int8_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_SMALLINT:
+		return TryCastCInternal<int16_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_INTEGER:
+		return TryCastCInternal<int32_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_BIGINT:
+		return TryCastCInternal<int64_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_UTINYINT:
+		return TryCastCInternal<uint8_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_USMALLINT:
+		return TryCastCInternal<uint16_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_UINTEGER:
+		return TryCastCInternal<uint32_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_UBIGINT:
+		return TryCastCInternal<uint64_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_FLOAT:
+		return TryCastCInternal<float, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_DOUBLE:
+		return TryCastCInternal<double, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_DATE:
+		return TryCastCInternal<date_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_TIME:
+		return TryCastCInternal<dtime_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_TIMESTAMP:
+		return TryCastCInternal<timestamp_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_HUGEINT:
+		return TryCastCInternal<hugeint_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_DECIMAL:
+		return TryCastCInternal<hugeint_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_INTERVAL:
+		return TryCastCInternal<interval_t, RESULT_TYPE, OP>(result, col, row);
+	case DUCKDB_TYPE_VARCHAR:
+		return TryCastCInternal<char *, RESULT_TYPE, FromCStringCastWrapper<OP>>(result, col, row);
+	case DUCKDB_TYPE_BLOB:
+		return TryCastCInternal<duckdb_blob, RESULT_TYPE, FromCBlobCastWrapper>(result, col, row);
+	default: // LCOV_EXCL_START
+		// invalid type for C to C++ conversion
+		D_ASSERT(0);
+		return FetchDefaultValue::Operation<RESULT_TYPE>();
+	} // LCOV_EXCL_STOP
+}
+
+//===--------------------------------------------------------------------===//
+// duckdb_value_ functions
+//===--------------------------------------------------------------------===//
+bool duckdb_value_boolean(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<bool>(result, col, row);
+}
+
+int8_t duckdb_value_int8(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<int8_t>(result, col, row);
+}
+
+int16_t duckdb_value_int16(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<int16_t>(result, col, row);
+}
+
+int32_t duckdb_value_int32(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<int32_t>(result, col, row);
+}
+
+int64_t duckdb_value_int64(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<int64_t>(result, col, row);
+}
+
+duckdb_decimal duckdb_value_decimal(duckdb_result *result, idx_t col, idx_t row) {
+	duckdb_decimal result_value;
+
+	auto result_data = (duckdb::DuckDBResultData *)result->internal_data;
+	result_data->result->types[col].GetDecimalProperties(result_value.width, result_value.scale);
+
+	auto internal_value = GetInternalCValue<hugeint_t>(result, col, row);
+	result_value.value.lower = internal_value.lower;
+	result_value.value.upper = internal_value.upper;
+	return result_value;
+}
+
+duckdb_hugeint duckdb_value_hugeint(duckdb_result *result, idx_t col, idx_t row) {
+	duckdb_hugeint result_value;
+	auto internal_value = GetInternalCValue<hugeint_t>(result, col, row);
+	result_value.lower = internal_value.lower;
+	result_value.upper = internal_value.upper;
+	return result_value;
+}
+
+uint8_t duckdb_value_uint8(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<uint8_t>(result, col, row);
+}
+
+uint16_t duckdb_value_uint16(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<uint16_t>(result, col, row);
+}
+
+uint32_t duckdb_value_uint32(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<uint32_t>(result, col, row);
+}
+
+uint64_t duckdb_value_uint64(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<uint64_t>(result, col, row);
+}
+
+float duckdb_value_float(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<float>(result, col, row);
+}
+
+double duckdb_value_double(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<double>(result, col, row);
+}
+
+duckdb_date duckdb_value_date(duckdb_result *result, idx_t col, idx_t row) {
+	duckdb_date result_value;
+	result_value.days = GetInternalCValue<date_t>(result, col, row).days;
+	return result_value;
+}
+
+duckdb_time duckdb_value_time(duckdb_result *result, idx_t col, idx_t row) {
+	duckdb_time result_value;
+	result_value.micros = GetInternalCValue<dtime_t>(result, col, row).micros;
+	return result_value;
+}
+
+duckdb_timestamp duckdb_value_timestamp(duckdb_result *result, idx_t col, idx_t row) {
+	duckdb_timestamp result_value;
+	result_value.micros = GetInternalCValue<timestamp_t>(result, col, row).value;
+	return result_value;
+}
+
+duckdb_interval duckdb_value_interval(duckdb_result *result, idx_t col, idx_t row) {
+	duckdb_interval result_value;
+	auto ival = GetInternalCValue<interval_t>(result, col, row);
+	result_value.months = ival.months;
+	result_value.days = ival.days;
+	result_value.micros = ival.micros;
+	return result_value;
+}
+
+char *duckdb_value_varchar(duckdb_result *result, idx_t col, idx_t row) {
+	return GetInternalCValue<char *, ToCStringCastWrapper<duckdb::StringCast>>(result, col, row);
+}
+
+char *duckdb_value_varchar_internal(duckdb_result *result, idx_t col, idx_t row) {
+	if (!CanFetchValue(result, col, row)) {
+		return nullptr;
+	}
+	if (duckdb_column_type(result, col) != DUCKDB_TYPE_VARCHAR) {
+		return nullptr;
+	}
+	return UnsafeFetch<char *>(result, col, row);
+}
+
+duckdb_blob duckdb_value_blob(duckdb_result *result, idx_t col, idx_t row) {
+	if (CanFetchValue(result, col, row) && result->__deprecated_columns[col].__deprecated_type == DUCKDB_TYPE_BLOB) {
+		auto internal_result = UnsafeFetch<duckdb_blob>(result, col, row);
+
+		duckdb_blob result_blob;
+		result_blob.data = malloc(internal_result.size);
+		result_blob.size = internal_result.size;
+		memcpy(result_blob.data, internal_result.data, internal_result.size);
+		return result_blob;
+	}
+	return FetchDefaultValue::Operation<duckdb_blob>();
+}
+
+bool duckdb_value_is_null(duckdb_result *result, idx_t col, idx_t row) {
+	if (!CanUseDeprecatedFetch(result, col, row)) {
+		return false;
+	}
+	return result->__deprecated_columns[col].__deprecated_nullmask[row];
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct ActiveQueryContext {
+	//! The query that is currently being executed
+	string query;
+	//! The currently open result
+	BaseQueryResult *open_result = nullptr;
+	//! Prepared statement data
+	shared_ptr<PreparedStatementData> prepared;
+	//! The query executor
+	unique_ptr<Executor> executor;
+	//! The progress bar
+	unique_ptr<ProgressBar> progress_bar;
+};
+
+ClientContext::ClientContext(shared_ptr<DatabaseInstance> database)
+    : db(move(database)), transaction(db->GetTransactionManager(), *this), interrupted(false),
+      client_data(make_unique<ClientData>(*this)) {
+}
+
+ClientContext::~ClientContext() {
+	if (Exception::UncaughtException()) {
+		return;
+	}
+	// destroy the client context and rollback if there is an active transaction
+	// but only if we are not destroying this client context as part of an exception stack unwind
+	Destroy();
+}
+
+unique_ptr<ClientContextLock> ClientContext::LockContext() {
+	return make_unique<ClientContextLock>(context_lock);
+}
+
+void ClientContext::Destroy() {
+	auto lock = LockContext();
+	if (transaction.HasActiveTransaction()) {
+		ActiveTransaction().active_query = MAXIMUM_QUERY_ID;
+		if (!transaction.IsAutoCommit()) {
+			transaction.Rollback();
+		}
+	}
+	CleanupInternal(*lock);
+}
+
+unique_ptr<DataChunk> ClientContext::Fetch(ClientContextLock &lock, StreamQueryResult &result) {
+	D_ASSERT(IsActiveResult(lock, &result));
+	D_ASSERT(active_query->executor);
+	return FetchInternal(lock, *active_query->executor, result);
+}
+
+unique_ptr<DataChunk> ClientContext::FetchInternal(ClientContextLock &lock, Executor &executor,
+                                                   BaseQueryResult &result) {
+	bool invalidate_query = true;
+	try {
+		// fetch the chunk and return it
+		auto chunk = executor.FetchChunk();
+		if (!chunk || chunk->size() == 0) {
+			CleanupInternal(lock, &result);
+		}
+		return chunk;
+	} catch (StandardException &ex) {
+		// standard exceptions do not invalidate the current transaction
+		result.error = ex.what();
+		invalidate_query = false;
+	} catch (std::exception &ex) {
+		result.error = ex.what();
+	} catch (...) { // LCOV_EXCL_START
+		result.error = "Unhandled exception in FetchInternal";
+	} // LCOV_EXCL_STOP
+	result.success = false;
+	CleanupInternal(lock, &result, invalidate_query);
+	return nullptr;
+}
+
+void ClientContext::BeginTransactionInternal(ClientContextLock &lock, bool requires_valid_transaction) {
+	// check if we are on AutoCommit. In this case we should start a transaction
+	D_ASSERT(!active_query);
+	if (requires_valid_transaction && transaction.HasActiveTransaction() &&
+	    transaction.ActiveTransaction().IsInvalidated()) {
+		throw Exception("Failed: transaction has been invalidated!");
+	}
+	active_query = make_unique<ActiveQueryContext>();
+	if (transaction.IsAutoCommit()) {
+		transaction.BeginTransaction();
+	}
+}
+
+void ClientContext::BeginQueryInternal(ClientContextLock &lock, const string &query) {
+	BeginTransactionInternal(lock, false);
+	LogQueryInternal(lock, query);
+	active_query->query = query;
+	query_progress = -1;
+	ActiveTransaction().active_query = db->GetTransactionManager().GetQueryNumber();
+}
+
+string ClientContext::EndQueryInternal(ClientContextLock &lock, bool success, bool invalidate_transaction) {
+	client_data->profiler->EndQuery();
+
+	D_ASSERT(active_query.get());
+	string error;
+	try {
+		if (transaction.HasActiveTransaction()) {
+			// Move the query profiler into the history
+			auto &prev_profilers = client_data->query_profiler_history->GetPrevProfilers();
+			prev_profilers.emplace_back(transaction.ActiveTransaction().active_query, move(client_data->profiler));
+			// Reinitialize the query profiler
+			client_data->profiler = make_shared<QueryProfiler>(*this);
+			// Propagate settings of the saved query into the new profiler.
+			client_data->profiler->Propagate(*prev_profilers.back().second);
+			if (prev_profilers.size() >= client_data->query_profiler_history->GetPrevProfilersSize()) {
+				prev_profilers.pop_front();
+			}
+
+			ActiveTransaction().active_query = MAXIMUM_QUERY_ID;
+			if (transaction.IsAutoCommit()) {
+				if (success) {
+					transaction.Commit();
+				} else {
+					transaction.Rollback();
+				}
+			} else if (invalidate_transaction) {
+				D_ASSERT(!success);
+				ActiveTransaction().Invalidate();
+			}
+		}
+	} catch (std::exception &ex) {
+		error = ex.what();
+	} catch (...) { // LCOV_EXCL_START
+		error = "Unhandled exception!";
+	} // LCOV_EXCL_STOP
+	active_query.reset();
+	query_progress = -1;
+	return error;
+}
+
+void ClientContext::CleanupInternal(ClientContextLock &lock, BaseQueryResult *result, bool invalidate_transaction) {
+	if (!active_query) {
+		// no query currently active
+		return;
+	}
+	if (active_query->executor) {
+		active_query->executor->CancelTasks();
+	}
+	active_query->progress_bar.reset();
+
+	auto error = EndQueryInternal(lock, result ? result->success : false, invalidate_transaction);
+	if (result && result->success) {
+		// if an error occurred while committing report it in the result
+		result->error = error;
+		result->success = error.empty();
+	}
+	D_ASSERT(!active_query);
+}
+
+Executor &ClientContext::GetExecutor() {
+	D_ASSERT(active_query);
+	D_ASSERT(active_query->executor);
+	return *active_query->executor;
+}
+
+const string &ClientContext::GetCurrentQuery() {
+	D_ASSERT(active_query);
+	return active_query->query;
+}
+
+unique_ptr<QueryResult> ClientContext::FetchResultInternal(ClientContextLock &lock, PendingQueryResult &pending) {
+	D_ASSERT(active_query);
+	D_ASSERT(active_query->open_result == &pending);
+	D_ASSERT(active_query->prepared);
+	auto &executor = GetExecutor();
+	auto &prepared = *active_query->prepared;
+	bool create_stream_result = prepared.properties.allow_stream_result && pending.allow_stream_result;
+	if (create_stream_result) {
+		D_ASSERT(!executor.HasResultCollector());
+		active_query->progress_bar.reset();
+		query_progress = -1;
+
+		// successfully compiled SELECT clause, and it is the last statement
+		// return a StreamQueryResult so the client can call Fetch() on it and stream the result
+		auto stream_result = make_unique<StreamQueryResult>(pending.statement_type, pending.properties,
+		                                                    shared_from_this(), pending.types, pending.names);
+		active_query->open_result = stream_result.get();
+		return move(stream_result);
+	}
+	unique_ptr<QueryResult> result;
+	if (executor.HasResultCollector()) {
+		// we have a result collector - fetch the result directly from the result collector
+		result = executor.GetResult();
+		CleanupInternal(lock, result.get(), false);
+	} else {
+		// no result collector - create a materialized result by continuously fetching
+		auto materialized_result = make_unique<MaterializedQueryResult>(
+		    pending.statement_type, pending.properties, pending.types, pending.names, shared_from_this());
+		while (true) {
+			auto chunk = FetchInternal(lock, GetExecutor(), *materialized_result);
+			if (!chunk || chunk->size() == 0) {
+				break;
+			}
+#ifdef DEBUG
+			for (idx_t i = 0; i < chunk->ColumnCount(); i++) {
+				if (pending.types[i].id() == LogicalTypeId::VARCHAR) {
+					chunk->data[i].UTFVerify(chunk->size());
+				}
+			}
+#endif
+			materialized_result->collection.Append(*chunk);
+		}
+		result = move(materialized_result);
+	}
+	return result;
+}
+
+shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatement(ClientContextLock &lock, const string &query,
+                                                                         unique_ptr<SQLStatement> statement,
+                                                                         vector<Value> *values) {
+	StatementType statement_type = statement->type;
+	auto result = make_shared<PreparedStatementData>(statement_type);
+
+	auto &profiler = QueryProfiler::Get(*this);
+	profiler.StartPhase("planner");
+	Planner planner(*this);
+	if (values) {
+		for (auto &value : *values) {
+			planner.parameter_types.push_back(value.type());
+		}
+	}
+	planner.CreatePlan(move(statement));
+	D_ASSERT(planner.plan);
+	profiler.EndPhase();
+
+	auto plan = move(planner.plan);
+#ifdef DEBUG
+	plan->Verify();
+#endif
+	// extract the result column names from the plan
+	result->properties = planner.properties;
+	result->names = planner.names;
+	result->types = planner.types;
+	result->value_map = move(planner.value_map);
+	result->catalog_version = Transaction::GetTransaction(*this).catalog_version;
+
+	if (config.enable_optimizer) {
+		profiler.StartPhase("optimizer");
+		Optimizer optimizer(*planner.binder, *this);
+		plan = optimizer.Optimize(move(plan));
+		D_ASSERT(plan);
+		profiler.EndPhase();
+
+#ifdef DEBUG
+		plan->Verify();
+#endif
+	}
+
+	profiler.StartPhase("physical_planner");
+	// now convert logical query plan into a physical query plan
+	PhysicalPlanGenerator physical_planner(*this);
+	auto physical_plan = physical_planner.CreatePlan(move(plan));
+	profiler.EndPhase();
+
+#ifdef DEBUG
+	D_ASSERT(!physical_plan->ToString().empty());
+#endif
+	result->plan = move(physical_plan);
+	return result;
+}
+
+double ClientContext::GetProgress() {
+	return query_progress.load();
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingPreparedStatement(ClientContextLock &lock,
+                                                                       shared_ptr<PreparedStatementData> statement_p,
+                                                                       PendingQueryParameters parameters) {
+	D_ASSERT(active_query);
+	auto &statement = *statement_p;
+	if (ActiveTransaction().IsInvalidated() && statement.properties.requires_valid_transaction) {
+		throw Exception("Current transaction is aborted (please ROLLBACK)");
+	}
+	auto &db_config = DBConfig::GetConfig(*this);
+	if (db_config.access_mode == AccessMode::READ_ONLY && !statement.properties.read_only) {
+		throw Exception(StringUtil::Format("Cannot execute statement of type \"%s\" in read-only mode!",
+		                                   StatementTypeToString(statement.statement_type)));
+	}
+
+	// bind the bound values before execution
+	statement.Bind(parameters.parameters ? *parameters.parameters : vector<Value>());
+
+	active_query->executor = make_unique<Executor>(*this);
+	auto &executor = *active_query->executor;
+	if (config.enable_progress_bar) {
+		active_query->progress_bar = make_unique<ProgressBar>(executor, config.wait_time, config.print_progress_bar);
+		active_query->progress_bar->Start();
+		query_progress = 0;
+	}
+	auto stream_result = parameters.allow_stream_result && statement.properties.allow_stream_result;
+	if (!stream_result && statement.properties.return_type == StatementReturnType::QUERY_RESULT) {
+		unique_ptr<PhysicalResultCollector> collector;
+		auto &config = ClientConfig::GetConfig(*this);
+		auto get_method =
+		    config.result_collector ? config.result_collector : PhysicalResultCollector::GetResultCollector;
+		collector = get_method(*this, statement);
+		D_ASSERT(collector->type == PhysicalOperatorType::RESULT_COLLECTOR);
+		executor.Initialize(move(collector));
+	} else {
+		executor.Initialize(statement.plan.get());
+	}
+	auto types = executor.GetTypes();
+	D_ASSERT(types == statement.types);
+	D_ASSERT(!active_query->open_result);
+
+	auto pending_result = make_unique<PendingQueryResult>(shared_from_this(), *statement_p, move(types), stream_result);
+	active_query->prepared = move(statement_p);
+	active_query->open_result = pending_result.get();
+	return pending_result;
+}
+
+PendingExecutionResult ClientContext::ExecuteTaskInternal(ClientContextLock &lock, PendingQueryResult &result) {
+	D_ASSERT(active_query);
+	D_ASSERT(active_query->open_result == &result);
+	try {
+		auto result = active_query->executor->ExecuteTask();
+		if (active_query->progress_bar) {
+			active_query->progress_bar->Update(result == PendingExecutionResult::RESULT_READY);
+			query_progress = active_query->progress_bar->GetCurrentPercentage();
+		}
+		return result;
+	} catch (std::exception &ex) {
+		result.error = ex.what();
+	} catch (...) { // LCOV_EXCL_START
+		result.error = "Unhandled exception in ExecuteTaskInternal";
+	} // LCOV_EXCL_STOP
+	EndQueryInternal(lock, false, true);
+	result.success = false;
+	return PendingExecutionResult::EXECUTION_ERROR;
+}
+
+void ClientContext::InitialCleanup(ClientContextLock &lock) {
+	//! Cleanup any open results and reset the interrupted flag
+	CleanupInternal(lock);
+	interrupted = false;
+}
+
+vector<unique_ptr<SQLStatement>> ClientContext::ParseStatements(const string &query) {
+	auto lock = LockContext();
+	return ParseStatementsInternal(*lock, query);
+}
+
+vector<unique_ptr<SQLStatement>> ClientContext::ParseStatementsInternal(ClientContextLock &lock, const string &query) {
+	Parser parser(GetParserOptions());
+	parser.ParseQuery(query);
+
+	PragmaHandler handler(*this);
+	handler.HandlePragmaStatements(lock, parser.statements);
+
+	return move(parser.statements);
+}
+
+void ClientContext::HandlePragmaStatements(vector<unique_ptr<SQLStatement>> &statements) {
+	auto lock = LockContext();
+
+	PragmaHandler handler(*this);
+	handler.HandlePragmaStatements(*lock, statements);
+}
+
+unique_ptr<LogicalOperator> ClientContext::ExtractPlan(const string &query) {
+	auto lock = LockContext();
+
+	auto statements = ParseStatementsInternal(*lock, query);
+	if (statements.size() != 1) {
+		throw Exception("ExtractPlan can only prepare a single statement");
+	}
+
+	unique_ptr<LogicalOperator> plan;
+	RunFunctionInTransactionInternal(*lock, [&]() {
+		Planner planner(*this);
+		planner.CreatePlan(move(statements[0]));
+		D_ASSERT(planner.plan);
+
+		plan = move(planner.plan);
+
+		if (config.enable_optimizer) {
+			Optimizer optimizer(*planner.binder, *this);
+			plan = optimizer.Optimize(move(plan));
+		}
+
+		ColumnBindingResolver resolver;
+		resolver.VisitOperator(*plan);
+
+		plan->ResolveOperatorTypes();
+	});
+	return plan;
+}
+
+unique_ptr<PreparedStatement> ClientContext::PrepareInternal(ClientContextLock &lock,
+                                                             unique_ptr<SQLStatement> statement) {
+	auto n_param = statement->n_param;
+	auto statement_query = statement->query;
+	shared_ptr<PreparedStatementData> prepared_data;
+	auto unbound_statement = statement->Copy();
+	RunFunctionInTransactionInternal(
+	    lock, [&]() { prepared_data = CreatePreparedStatement(lock, statement_query, move(statement)); }, false);
+	prepared_data->unbound_statement = move(unbound_statement);
+	return make_unique<PreparedStatement>(shared_from_this(), move(prepared_data), move(statement_query), n_param);
+}
+
+unique_ptr<PreparedStatement> ClientContext::Prepare(unique_ptr<SQLStatement> statement) {
+	auto lock = LockContext();
+	// prepare the query
+	try {
+		InitialCleanup(*lock);
+		return PrepareInternal(*lock, move(statement));
+	} catch (std::exception &ex) {
+		return make_unique<PreparedStatement>(ex.what());
+	}
+}
+
+unique_ptr<PreparedStatement> ClientContext::Prepare(const string &query) {
+	auto lock = LockContext();
+	// prepare the query
+	try {
+		InitialCleanup(*lock);
+
+		// first parse the query
+		auto statements = ParseStatementsInternal(*lock, query);
+		if (statements.empty()) {
+			throw Exception("No statement to prepare!");
+		}
+		if (statements.size() > 1) {
+			throw Exception("Cannot prepare multiple statements at once!");
+		}
+		return PrepareInternal(*lock, move(statements[0]));
+	} catch (std::exception &ex) {
+		return make_unique<PreparedStatement>(ex.what());
+	}
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingQueryPreparedInternal(ClientContextLock &lock, const string &query,
+                                                                           shared_ptr<PreparedStatementData> &prepared,
+                                                                           PendingQueryParameters parameters) {
+	try {
+		InitialCleanup(lock);
+	} catch (std::exception &ex) {
+		return make_unique<PendingQueryResult>(ex.what());
+	}
+	return PendingStatementOrPreparedStatementInternal(lock, query, nullptr, prepared, parameters);
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query,
+                                                           shared_ptr<PreparedStatementData> &prepared,
+                                                           PendingQueryParameters parameters) {
+	auto lock = LockContext();
+	return PendingQueryPreparedInternal(*lock, query, prepared, parameters);
+}
+
+unique_ptr<QueryResult> ClientContext::Execute(const string &query, shared_ptr<PreparedStatementData> &prepared,
+                                               PendingQueryParameters parameters) {
+	auto lock = LockContext();
+	auto pending = PendingQueryPreparedInternal(*lock, query, prepared, parameters);
+	if (!pending->success) {
+		return make_unique<MaterializedQueryResult>(pending->error);
+	}
+	return pending->ExecuteInternal(*lock);
+}
+
+unique_ptr<QueryResult> ClientContext::Execute(const string &query, shared_ptr<PreparedStatementData> &prepared,
+                                               vector<Value> &values, bool allow_stream_result) {
+	PendingQueryParameters parameters;
+	parameters.parameters = &values;
+	parameters.allow_stream_result = allow_stream_result;
+	return Execute(query, prepared, parameters);
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingStatementInternal(ClientContextLock &lock, const string &query,
+                                                                       unique_ptr<SQLStatement> statement,
+                                                                       PendingQueryParameters parameters) {
+	// prepare the query for execution
+	auto prepared = CreatePreparedStatement(lock, query, move(statement));
+	// execute the prepared statement
+	return PendingPreparedStatement(lock, move(prepared), parameters);
+}
+
+unique_ptr<QueryResult> ClientContext::RunStatementInternal(ClientContextLock &lock, const string &query,
+                                                            unique_ptr<SQLStatement> statement,
+                                                            bool allow_stream_result, bool verify) {
+	PendingQueryParameters parameters;
+	parameters.allow_stream_result = allow_stream_result;
+	auto pending = PendingQueryInternal(lock, move(statement), parameters, verify);
+	if (!pending->success) {
+		return make_unique<MaterializedQueryResult>(move(pending->error));
+	}
+	return ExecutePendingQueryInternal(lock, *pending);
+}
+
+bool ClientContext::IsActiveResult(ClientContextLock &lock, BaseQueryResult *result) {
+	if (!active_query) {
+		return false;
+	}
+	return active_query->open_result == result;
+}
+
+static bool IsExplainAnalyze(SQLStatement *statement) {
+	if (!statement) {
+		return false;
+	}
+	if (statement->type != StatementType::EXPLAIN_STATEMENT) {
+		return false;
+	}
+	auto &explain = (ExplainStatement &)*statement;
+	return explain.explain_type == ExplainType::EXPLAIN_ANALYZE;
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingStatementOrPreparedStatementInternal(
+    ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
+    shared_ptr<PreparedStatementData> &prepared, PendingQueryParameters parameters) {
+	// check if we are on AutoCommit. In this case we should start a transaction.
+	if (statement && config.query_verification_enabled) {
+		// query verification is enabled
+		// create a copy of the statement, and use the copy
+		// this way we verify that the copy correctly copies all properties
+		auto copied_statement = statement->Copy();
+		switch (statement->type) {
+		case StatementType::SELECT_STATEMENT: {
+			// in case this is a select query, we verify the original statement
+			string error;
+			try {
+				error = VerifyQuery(lock, query, move(statement));
+			} catch (std::exception &ex) {
+				error = ex.what();
+			}
+			if (!error.empty()) {
+				// error in verifying query
+				return make_unique<PendingQueryResult>(error);
+			}
+			statement = move(copied_statement);
+			break;
+		}
+		case StatementType::INSERT_STATEMENT:
+		case StatementType::DELETE_STATEMENT:
+		case StatementType::UPDATE_STATEMENT: {
+			auto sql = statement->ToString();
+			Parser parser;
+			parser.ParseQuery(sql);
+			statement = move(parser.statements[0]);
+			break;
+		}
+		default:
+			statement = move(copied_statement);
+			break;
+		}
+	}
+	return PendingStatementOrPreparedStatement(lock, query, move(statement), prepared, parameters);
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingStatementOrPreparedStatement(
+    ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement,
+    shared_ptr<PreparedStatementData> &prepared, PendingQueryParameters parameters) {
+	unique_ptr<PendingQueryResult> result;
+
+	BeginQueryInternal(lock, query);
+	// start the profiler
+	auto &profiler = QueryProfiler::Get(*this);
+	profiler.StartQuery(query, IsExplainAnalyze(statement ? statement.get() : prepared->unbound_statement.get()));
+	bool invalidate_query = true;
+	try {
+		if (statement) {
+			result = PendingStatementInternal(lock, query, move(statement), parameters);
+		} else {
+			auto &catalog = Catalog::GetCatalog(*this);
+			if (prepared->unbound_statement && (catalog.GetCatalogVersion() != prepared->catalog_version ||
+			                                    !prepared->properties.bound_all_parameters)) {
+				// catalog was modified: rebind the statement before execution
+				auto new_prepared =
+				    CreatePreparedStatement(lock, query, prepared->unbound_statement->Copy(), parameters.parameters);
+				if (prepared->types != new_prepared->types && prepared->properties.bound_all_parameters) {
+					throw BinderException("Rebinding statement after catalog change resulted in change of types");
+				}
+				D_ASSERT(new_prepared->properties.bound_all_parameters);
+				new_prepared->unbound_statement = move(prepared->unbound_statement);
+				prepared = move(new_prepared);
+				prepared->properties.bound_all_parameters = false;
+			}
+			result = PendingPreparedStatement(lock, prepared, parameters);
+		}
+	} catch (StandardException &ex) {
+		// standard exceptions do not invalidate the current transaction
+		result = make_unique<PendingQueryResult>(ex.what());
+		invalidate_query = false;
+	} catch (std::exception &ex) {
+		// other types of exceptions do invalidate the current transaction
+		result = make_unique<PendingQueryResult>(ex.what());
+	}
+	if (!result->success) {
+		// query failed: abort now
+		EndQueryInternal(lock, false, invalidate_query);
+		return result;
+	}
+	D_ASSERT(active_query->open_result == result.get());
+	return result;
+}
+
+void ClientContext::LogQueryInternal(ClientContextLock &, const string &query) {
+	if (!client_data->log_query_writer) {
+#ifdef DUCKDB_FORCE_QUERY_LOG
+		try {
+			string log_path(DUCKDB_FORCE_QUERY_LOG);
+			client_data->log_query_writer =
+			    make_unique<BufferedFileWriter>(FileSystem::GetFileSystem(*this), log_path,
+			                                    BufferedFileWriter::DEFAULT_OPEN_FLAGS, client_data->file_opener.get());
+		} catch (...) {
+			return;
+		}
+#else
+		return;
+#endif
+	}
+	// log query path is set: log the query
+	client_data->log_query_writer->WriteData((const_data_ptr_t)query.c_str(), query.size());
+	client_data->log_query_writer->WriteData((const_data_ptr_t) "\n", 1);
+	client_data->log_query_writer->Flush();
+	client_data->log_query_writer->Sync();
+}
+
+unique_ptr<QueryResult> ClientContext::Query(unique_ptr<SQLStatement> statement, bool allow_stream_result) {
+	auto pending_query = PendingQuery(move(statement), allow_stream_result);
+	if (!pending_query->success) {
+		return make_unique<MaterializedQueryResult>(pending_query->error);
+	}
+	return pending_query->Execute();
+}
+
+unique_ptr<QueryResult> ClientContext::Query(const string &query, bool allow_stream_result) {
+	auto lock = LockContext();
+
+	string error;
+	vector<unique_ptr<SQLStatement>> statements;
+	if (!ParseStatements(*lock, query, statements, error)) {
+		return make_unique<MaterializedQueryResult>(move(error));
+	}
+	if (statements.empty()) {
+		// no statements, return empty successful result
+		StatementProperties properties;
+		vector<LogicalType> types;
+		vector<string> names;
+		return make_unique<MaterializedQueryResult>(StatementType::INVALID_STATEMENT, properties, move(types),
+		                                            move(names), shared_from_this());
+	}
+
+	unique_ptr<QueryResult> result;
+	QueryResult *last_result = nullptr;
+	for (idx_t i = 0; i < statements.size(); i++) {
+		auto &statement = statements[i];
+		bool is_last_statement = i + 1 == statements.size();
+		PendingQueryParameters parameters;
+		parameters.allow_stream_result = allow_stream_result && is_last_statement;
+		auto pending_query = PendingQueryInternal(*lock, move(statement), parameters);
+		unique_ptr<QueryResult> current_result;
+		if (!pending_query->success) {
+			current_result = make_unique<MaterializedQueryResult>(pending_query->error);
+		} else {
+			current_result = ExecutePendingQueryInternal(*lock, *pending_query);
+		}
+		// now append the result to the list of results
+		if (!last_result) {
+			// first result of the query
+			result = move(current_result);
+			last_result = result.get();
+		} else {
+			// later results; attach to the result chain
+			last_result->next = move(current_result);
+			last_result = last_result->next.get();
+		}
+	}
+	return result;
+}
+
+bool ClientContext::ParseStatements(ClientContextLock &lock, const string &query,
+                                    vector<unique_ptr<SQLStatement>> &result, string &error) {
+	try {
+		InitialCleanup(lock);
+		// parse the query and transform it into a set of statements
+		result = ParseStatementsInternal(lock, query);
+		return true;
+	} catch (std::exception &ex) {
+		error = ex.what();
+		return false;
+	}
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query, bool allow_stream_result) {
+	auto lock = LockContext();
+
+	string error;
+	vector<unique_ptr<SQLStatement>> statements;
+	if (!ParseStatements(*lock, query, statements, error)) {
+		return make_unique<PendingQueryResult>(move(error));
+	}
+	if (statements.size() != 1) {
+		return make_unique<PendingQueryResult>("PendingQuery can only take a single statement");
+	}
+	PendingQueryParameters parameters;
+	parameters.allow_stream_result = allow_stream_result;
+	return PendingQueryInternal(*lock, move(statements[0]), parameters);
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingQuery(unique_ptr<SQLStatement> statement,
+                                                           bool allow_stream_result) {
+	auto lock = LockContext();
+	PendingQueryParameters parameters;
+	parameters.allow_stream_result = allow_stream_result;
+	return PendingQueryInternal(*lock, move(statement), parameters);
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContextLock &lock,
+                                                                   unique_ptr<SQLStatement> statement,
+                                                                   PendingQueryParameters parameters, bool verify) {
+	auto query = statement->query;
+	shared_ptr<PreparedStatementData> prepared;
+	if (verify) {
+		return PendingStatementOrPreparedStatementInternal(lock, query, move(statement), prepared, parameters);
+	} else {
+		return PendingStatementOrPreparedStatement(lock, query, move(statement), prepared, parameters);
+	}
+}
+
+unique_ptr<QueryResult> ClientContext::ExecutePendingQueryInternal(ClientContextLock &lock, PendingQueryResult &query) {
+	return query.ExecuteInternal(lock);
+}
+
+void ClientContext::Interrupt() {
+	interrupted = true;
+}
+
+void ClientContext::EnableProfiling() {
+	auto lock = LockContext();
+	auto &config = ClientConfig::GetConfig(*this);
+	config.enable_profiler = true;
+}
+
+void ClientContext::DisableProfiling() {
+	auto lock = LockContext();
+	auto &config = ClientConfig::GetConfig(*this);
+	config.enable_profiler = false;
+}
+
+struct VerifyStatement {
+	VerifyStatement(unique_ptr<SelectStatement> statement_p, string statement_name_p, bool require_equality = true,
+	                bool disable_optimizer = false)
+	    : statement(move(statement_p)), statement_name(move(statement_name_p)), require_equality(require_equality),
+	      disable_optimizer(disable_optimizer), select_list(statement->node->GetSelectList()) {
+	}
+
+	unique_ptr<SelectStatement> statement;
+	string statement_name;
+	bool require_equality;
+	bool disable_optimizer;
+	const vector<unique_ptr<ParsedExpression>> &select_list;
+};
+
+string ClientContext::VerifyQuery(ClientContextLock &lock, const string &query, unique_ptr<SQLStatement> statement) {
+	D_ASSERT(statement->type == StatementType::SELECT_STATEMENT);
+	// aggressive query verification
+
+	// the purpose of this function is to test correctness of otherwise hard to test features:
+	// Copy() of statements and expressions
+	// Serialize()/Deserialize() of expressions
+	// Hash() of expressions
+	// Equality() of statements and expressions
+	// ToString() of statements and expressions
+	// Correctness of plans both with and without optimizers
+
+	vector<VerifyStatement> verify_statements;
+
+	// copy the statement
+	auto select_stmt = (SelectStatement *)statement.get();
+	auto copied_stmt = unique_ptr_cast<SQLStatement, SelectStatement>(select_stmt->Copy());
+	auto unoptimized_stmt = unique_ptr_cast<SQLStatement, SelectStatement>(select_stmt->Copy());
+
+	BufferedSerializer serializer;
+	select_stmt->Serialize(serializer);
+	BufferedDeserializer source(serializer);
+	auto deserialized_stmt = SelectStatement::Deserialize(source);
+
+	auto query_str = select_stmt->ToString();
+	Parser parser;
+	parser.ParseQuery(query_str);
+	D_ASSERT(parser.statements.size() == 1);
+	D_ASSERT(parser.statements[0]->type == StatementType::SELECT_STATEMENT);
+	auto parsed_statement = move(parser.statements[0]);
+
+	verify_statements.emplace_back(unique_ptr_cast<SQLStatement, SelectStatement>(move(statement)),
+	                               "Original statement");
+	verify_statements.emplace_back(move(copied_stmt), "Copied statement");
+	verify_statements.emplace_back(move(deserialized_stmt), "Deserialized statement");
+	verify_statements.emplace_back(unique_ptr_cast<SQLStatement, SelectStatement>(move(parsed_statement)),
+	                               "Parsed statement", false);
+	verify_statements.emplace_back(unique_ptr_cast<SQLStatement, SelectStatement>(move(unoptimized_stmt)),
+	                               "Unoptimized", true, true);
+
+	// all the statements should be equal
+	for (idx_t i = 1; i < verify_statements.size(); i++) {
+		if (!verify_statements[i].require_equality) {
+			continue;
+		}
+		D_ASSERT(verify_statements[i].statement->Equals(verify_statements[0].statement.get()));
+	}
+
+	// now perform checking on the expressions
+#ifdef DEBUG
+	for (idx_t i = 1; i < verify_statements.size(); i++) {
+		D_ASSERT(verify_statements[i].select_list.size() == verify_statements[0].select_list.size());
+	}
+	auto expr_count = verify_statements[0].select_list.size();
+	auto &orig_expr_list = verify_statements[0].select_list;
+	for (idx_t i = 0; i < expr_count; i++) {
+		// run the ToString, to verify that it doesn't crash
+		auto str = orig_expr_list[i]->ToString();
+		for (idx_t v_idx = 0; v_idx < verify_statements.size(); v_idx++) {
+			if (!verify_statements[v_idx].require_equality && orig_expr_list[i]->HasSubquery()) {
+				continue;
+			}
+			// check that the expressions are equivalent
+			D_ASSERT(orig_expr_list[i]->Equals(verify_statements[v_idx].select_list[i].get()));
+			// check that the hashes are equivalent too
+			D_ASSERT(orig_expr_list[i]->Hash() == verify_statements[v_idx].select_list[i]->Hash());
+
+			verify_statements[v_idx].select_list[i]->Verify();
+		}
+		D_ASSERT(!orig_expr_list[i]->Equals(nullptr));
+
+		if (orig_expr_list[i]->HasSubquery()) {
+			continue;
+		}
+		// ToString round trip
+		auto parsed_list = Parser::ParseExpressionList(str);
+		D_ASSERT(parsed_list.size() == 1);
+		D_ASSERT(parsed_list[0]->Equals(orig_expr_list[i].get()));
+	}
+	// perform additional checking within the expressions
+	for (idx_t outer_idx = 0; outer_idx < orig_expr_list.size(); outer_idx++) {
+		auto hash = orig_expr_list[outer_idx]->Hash();
+		for (idx_t inner_idx = 0; inner_idx < orig_expr_list.size(); inner_idx++) {
+			auto hash2 = orig_expr_list[inner_idx]->Hash();
+			if (hash != hash2) {
+				// if the hashes are not equivalent, the expressions should not be equivalent
+				D_ASSERT(!orig_expr_list[outer_idx]->Equals(orig_expr_list[inner_idx].get()));
+			}
+		}
+	}
+#endif
+
+	// disable profiling if it is enabled
+	auto &config = ClientConfig::GetConfig(*this);
+	bool profiling_is_enabled = config.enable_profiler;
+	if (profiling_is_enabled) {
+		config.enable_profiler = false;
+	}
+
+	// see below
+	auto statement_copy_for_explain = select_stmt->Copy();
+
+	// execute the original statement
+	auto optimizer_enabled = config.enable_optimizer;
+	vector<unique_ptr<MaterializedQueryResult>> results;
+	for (idx_t i = 0; i < verify_statements.size(); i++) {
+		interrupted = false;
+		config.enable_optimizer = !verify_statements[i].disable_optimizer;
+		try {
+			auto result = RunStatementInternal(lock, query, move(verify_statements[i].statement), false, false);
+			results.push_back(unique_ptr_cast<QueryResult, MaterializedQueryResult>(move(result)));
+		} catch (std::exception &ex) {
+			results.push_back(make_unique<MaterializedQueryResult>(ex.what()));
+		}
+		interrupted = false;
+	}
+	config.enable_optimizer = optimizer_enabled;
+
+	// check explain, only if q does not already contain EXPLAIN
+	if (results[0]->success) {
+		auto explain_q = "EXPLAIN " + query;
+		auto explain_stmt = make_unique<ExplainStatement>(move(statement_copy_for_explain));
+		try {
+			RunStatementInternal(lock, explain_q, move(explain_stmt), false, false);
+		} catch (std::exception &ex) { // LCOV_EXCL_START
+			interrupted = false;
+			return "EXPLAIN failed but query did not (" + string(ex.what()) + ")";
+		} // LCOV_EXCL_STOP
+	}
+
+	if (profiling_is_enabled) {
+		config.enable_profiler = true;
+	}
+
+	// now compare the results
+	// the results of all runs should be identical
+	for (idx_t i = 1; i < results.size(); i++) {
+		auto name = verify_statements[i].statement_name;
+		if (results[0]->success != results[i]->success) { // LCOV_EXCL_START
+			string result = name + " differs from original result!\n";
+			result += "Original Result:\n" + results[0]->ToString();
+			result += name + ":\n" + results[i]->ToString();
+			return result;
+		}                                                             // LCOV_EXCL_STOP
+		if (!results[0]->collection.Equals(results[i]->collection)) { // LCOV_EXCL_START
+			string result = name + " differs from original result!\n";
+			result += "Original Result:\n" + results[0]->ToString();
+			result += name + ":\n" + results[i]->ToString();
+			return result;
+		} // LCOV_EXCL_STOP
+	}
+
+	return "";
+}
+
+bool ClientContext::UpdateFunctionInfoFromEntry(ScalarFunctionCatalogEntry *existing_function,
+                                                CreateScalarFunctionInfo *new_info) {
+	if (new_info->functions.empty()) {
+		throw InternalException("Registering function without scalar function definitions!");
+	}
+	bool need_rewrite_entry = false;
+	idx_t size_new_func = new_info->functions.size();
+	for (idx_t exist_idx = 0; exist_idx < existing_function->functions.size(); ++exist_idx) {
+		bool can_add = true;
+		for (idx_t new_idx = 0; new_idx < size_new_func; ++new_idx) {
+			if (new_info->functions[new_idx].Equal(existing_function->functions[exist_idx])) {
+				can_add = false;
+				break;
+			}
+		}
+		if (can_add) {
+			new_info->functions.push_back(existing_function->functions[exist_idx]);
+			need_rewrite_entry = true;
+		}
+	}
+	return need_rewrite_entry;
+}
+
+void ClientContext::RegisterFunction(CreateFunctionInfo *info) {
+	RunFunctionInTransaction([&]() {
+		auto &catalog = Catalog::GetCatalog(*this);
+		auto existing_function = (ScalarFunctionCatalogEntry *)catalog.GetEntry(
+		    *this, CatalogType::SCALAR_FUNCTION_ENTRY, info->schema, info->name, true);
+		if (existing_function) {
+			if (UpdateFunctionInfoFromEntry(existing_function, (CreateScalarFunctionInfo *)info)) {
+				// function info was updated from catalog entry, rewrite is needed
+				info->on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
+			}
+		}
+		// create function
+		catalog.CreateFunction(*this, info);
+	});
+}
+
+void ClientContext::RunFunctionInTransactionInternal(ClientContextLock &lock, const std::function<void(void)> &fun,
+                                                     bool requires_valid_transaction) {
+	if (requires_valid_transaction && transaction.HasActiveTransaction() &&
+	    transaction.ActiveTransaction().IsInvalidated()) {
+		throw Exception("Failed: transaction has been invalidated!");
+	}
+	// check if we are on AutoCommit. In this case we should start a transaction
+	bool require_new_transaction = transaction.IsAutoCommit() && !transaction.HasActiveTransaction();
+	if (require_new_transaction) {
+		D_ASSERT(!active_query);
+		transaction.BeginTransaction();
+	}
+	try {
+		fun();
+	} catch (StandardException &ex) {
+		if (require_new_transaction) {
+			transaction.Rollback();
+		}
+		throw;
+	} catch (std::exception &ex) {
+		if (require_new_transaction) {
+			transaction.Rollback();
+		} else {
+			ActiveTransaction().Invalidate();
+		}
+		throw;
+	}
+	if (require_new_transaction) {
+		transaction.Commit();
+	}
+}
+
+void ClientContext::RunFunctionInTransaction(const std::function<void(void)> &fun, bool requires_valid_transaction) {
+	auto lock = LockContext();
+	RunFunctionInTransactionInternal(*lock, fun, requires_valid_transaction);
+}
+
+unique_ptr<TableDescription> ClientContext::TableInfo(const string &schema_name, const string &table_name) {
+	unique_ptr<TableDescription> result;
+	RunFunctionInTransaction([&]() {
+		// obtain the table info
+		auto &catalog = Catalog::GetCatalog(*this);
+		auto table = catalog.GetEntry<TableCatalogEntry>(*this, schema_name, table_name, true);
+		if (!table) {
+			return;
+		}
+		// write the table info to the result
+		result = make_unique<TableDescription>();
+		result->schema = schema_name;
+		result->table = table_name;
+		for (auto &column : table->columns) {
+			result->columns.emplace_back(column.Name(), column.Type());
+		}
+	});
+	return result;
+}
+
+void ClientContext::Append(TableDescription &description, ChunkCollection &collection) {
+	RunFunctionInTransaction([&]() {
+		auto &catalog = Catalog::GetCatalog(*this);
+		auto table_entry = catalog.GetEntry<TableCatalogEntry>(*this, description.schema, description.table);
+		// verify that the table columns and types match up
+		if (description.columns.size() != table_entry->columns.size()) {
+			throw Exception("Failed to append: table entry has different number of columns!");
+		}
+		for (idx_t i = 0; i < description.columns.size(); i++) {
+			if (description.columns[i].Type() != table_entry->columns[i].Type()) {
+				throw Exception("Failed to append: table entry has different number of columns!");
+			}
+		}
+		for (auto &chunk : collection.Chunks()) {
+			table_entry->storage->Append(*table_entry, *this, *chunk);
+		}
+	});
+}
+
+void ClientContext::TryBindRelation(Relation &relation, vector<ColumnDefinition> &result_columns) {
+#ifdef DEBUG
+	D_ASSERT(!relation.GetAlias().empty());
+	D_ASSERT(!relation.ToString().empty());
+#endif
+	RunFunctionInTransaction([&]() {
+		// bind the expressions
+		auto binder = Binder::CreateBinder(*this);
+		auto result = relation.Bind(*binder);
+		D_ASSERT(result.names.size() == result.types.size());
+		for (idx_t i = 0; i < result.names.size(); i++) {
+			result_columns.emplace_back(result.names[i], result.types[i]);
+		}
+	});
+}
+
+unordered_set<string> ClientContext::GetTableNames(const string &query) {
+	auto lock = LockContext();
+
+	auto statements = ParseStatementsInternal(*lock, query);
+	if (statements.size() != 1) {
+		throw InvalidInputException("Expected a single statement");
+	}
+
+	unordered_set<string> result;
+	RunFunctionInTransactionInternal(*lock, [&]() {
+		// bind the expressions
+		auto binder = Binder::CreateBinder(*this);
+		binder->SetBindingMode(BindingMode::EXTRACT_NAMES);
+		binder->Bind(*statements[0]);
+		result = binder->GetTableNames();
+	});
+	return result;
+}
+
+unique_ptr<QueryResult> ClientContext::Execute(const shared_ptr<Relation> &relation) {
+	auto lock = LockContext();
+	InitialCleanup(*lock);
+
+	string query;
+	if (config.query_verification_enabled) {
+		// run the ToString method of any relation we run, mostly to ensure it doesn't crash
+		relation->ToString();
+		relation->GetAlias();
+		if (relation->IsReadOnly()) {
+			// verify read only statements by running a select statement
+			auto select = make_unique<SelectStatement>();
+			select->node = relation->GetQueryNode();
+			RunStatementInternal(*lock, query, move(select), false);
+		}
+	}
+	auto &expected_columns = relation->Columns();
+	auto relation_stmt = make_unique<RelationStatement>(relation);
+
+	unique_ptr<QueryResult> result;
+	result = RunStatementInternal(*lock, query, move(relation_stmt), false);
+	if (!result->success) {
+		return result;
+	}
+	// verify that the result types and result names of the query match the expected result types/names
+	if (result->types.size() == expected_columns.size()) {
+		bool mismatch = false;
+		for (idx_t i = 0; i < result->types.size(); i++) {
+			if (result->types[i] != expected_columns[i].Type() || result->names[i] != expected_columns[i].Name()) {
+				mismatch = true;
+				break;
+			}
+		}
+		if (!mismatch) {
+			// all is as expected: return the result
+			return result;
+		}
+	}
+	// result mismatch
+	string err_str = "Result mismatch in query!\nExpected the following columns: [";
+	for (idx_t i = 0; i < expected_columns.size(); i++) {
+		if (i > 0) {
+			err_str += ", ";
+		}
+		err_str += expected_columns[i].Name() + " " + expected_columns[i].Type().ToString();
+	}
+	err_str += "]\nBut result contained the following: ";
+	for (idx_t i = 0; i < result->types.size(); i++) {
+		err_str += i == 0 ? "[" : ", ";
+		err_str += result->names[i] + " " + result->types[i].ToString();
+	}
+	err_str += "]";
+	return make_unique<MaterializedQueryResult>(err_str);
+}
+
+bool ClientContext::TryGetCurrentSetting(const std::string &key, Value &result) {
+	// first check the built-in settings
+	auto &db_config = DBConfig::GetConfig(*this);
+	auto option = db_config.GetOptionByName(key);
+	if (option) {
+		result = option->get_setting(*this);
+		return true;
+	}
+
+	// then check the session values
+	const auto &session_config_map = config.set_variables;
+	const auto &global_config_map = db_config.set_variables;
+
+	auto session_value = session_config_map.find(key);
+	bool found_session_value = session_value != session_config_map.end();
+	auto global_value = global_config_map.find(key);
+	bool found_global_value = global_value != global_config_map.end();
+	if (!found_session_value && !found_global_value) {
+		return false;
+	}
+
+	result = found_session_value ? session_value->second : global_value->second;
+	return true;
+}
+
+ParserOptions ClientContext::GetParserOptions() {
+	ParserOptions options;
+	options.preserve_identifier_case = ClientConfig::GetConfig(*this).preserve_identifier_case;
+	options.max_expression_depth = ClientConfig::GetConfig(*this).max_expression_depth;
+	return options;
+}
+
+} // namespace duckdb

--- a/velox/external/duckdb/duckdb-6.cpp
+++ b/velox/external/duckdb/duckdb-6.cpp
@@ -1,0 +1,16819 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+
+namespace duckdb {
+
+bool ClientContextFileOpener::TryGetCurrentSetting(const string &key, Value &result) {
+	return context.TryGetCurrentSetting(key, result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+ClientData::ClientData(ClientContext &context) : catalog_search_path(make_unique<CatalogSearchPath>(context)) {
+	profiler = make_shared<QueryProfiler>(context);
+	query_profiler_history = make_unique<QueryProfilerHistory>();
+	temporary_objects = make_unique<SchemaCatalogEntry>(&Catalog::GetCatalog(context), TEMP_SCHEMA, true);
+	random_engine = make_unique<RandomEngine>();
+	file_opener = make_unique<ClientContextFileOpener>(context);
+}
+ClientData::~ClientData() {
+}
+
+ClientData &ClientData::Get(ClientContext &context) {
+	return *context.client_data;
+}
+
+RandomEngine &RandomEngine::Get(ClientContext &context) {
+	return *ClientData::Get(context).random_engine;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+#define DUCKDB_GLOBAL(_PARAM)                                                                                          \
+	{ _PARAM::Name, _PARAM::Description, _PARAM::InputType, _PARAM::SetGlobal, nullptr, _PARAM::GetSetting }
+#define DUCKDB_GLOBAL_ALIAS(_ALIAS, _PARAM)                                                                            \
+	{ _ALIAS, _PARAM::Description, _PARAM::InputType, _PARAM::SetGlobal, nullptr, _PARAM::GetSetting }
+
+#define DUCKDB_LOCAL(_PARAM)                                                                                           \
+	{ _PARAM::Name, _PARAM::Description, _PARAM::InputType, nullptr, _PARAM::SetLocal, _PARAM::GetSetting }
+#define DUCKDB_LOCAL_ALIAS(_ALIAS, _PARAM)                                                                             \
+	{ _ALIAS, _PARAM::Description, _PARAM::InputType, nullptr, _PARAM::SetLocal, _PARAM::GetSetting }
+
+#define DUCKDB_GLOBAL_LOCAL(_PARAM)                                                                                    \
+	{ _PARAM::Name, _PARAM::Description, _PARAM::InputType, _PARAM::SetGlobal, _PARAM::SetLocal, _PARAM::GetSetting }
+#define DUCKDB_GLOBAL_LOCAL_ALIAS(_ALIAS, _PARAM)                                                                      \
+	{ _ALIAS, _PARAM::Description, _PARAM::InputType, _PARAM::SetGlobal, _PARAM::SetLocal, _PARAM::GetSetting }
+#define FINAL_SETTING                                                                                                  \
+	{ nullptr, nullptr, LogicalTypeId::INVALID, nullptr, nullptr, nullptr }
+
+static ConfigurationOption internal_options[] = {DUCKDB_GLOBAL(AccessModeSetting),
+                                                 DUCKDB_GLOBAL(CheckpointThresholdSetting),
+                                                 DUCKDB_GLOBAL(DebugCheckpointAbort),
+                                                 DUCKDB_LOCAL(DebugForceExternal),
+                                                 DUCKDB_LOCAL(DebugForceNoCrossProduct),
+                                                 DUCKDB_GLOBAL(DebugManyFreeListBlocks),
+                                                 DUCKDB_GLOBAL(DebugWindowMode),
+                                                 DUCKDB_GLOBAL_LOCAL(DefaultCollationSetting),
+                                                 DUCKDB_GLOBAL(DefaultOrderSetting),
+                                                 DUCKDB_GLOBAL(DefaultNullOrderSetting),
+                                                 DUCKDB_GLOBAL(DisabledOptimizersSetting),
+                                                 DUCKDB_GLOBAL(EnableExternalAccessSetting),
+                                                 DUCKDB_GLOBAL(EnableObjectCacheSetting),
+                                                 DUCKDB_LOCAL(EnableProfilingSetting),
+                                                 DUCKDB_LOCAL(EnableProgressBarSetting),
+                                                 DUCKDB_LOCAL(ExplainOutputSetting),
+                                                 DUCKDB_GLOBAL(ExternalThreadsSetting),
+                                                 DUCKDB_LOCAL(FileSearchPathSetting),
+                                                 DUCKDB_GLOBAL(ForceCompressionSetting),
+                                                 DUCKDB_LOCAL(LogQueryPathSetting),
+                                                 DUCKDB_LOCAL(MaximumExpressionDepthSetting),
+                                                 DUCKDB_GLOBAL(MaximumMemorySetting),
+                                                 DUCKDB_GLOBAL_ALIAS("memory_limit", MaximumMemorySetting),
+                                                 DUCKDB_GLOBAL_ALIAS("null_order", DefaultNullOrderSetting),
+                                                 DUCKDB_LOCAL(PerfectHashThresholdSetting),
+                                                 DUCKDB_LOCAL(PreserveIdentifierCase),
+                                                 DUCKDB_GLOBAL(PreserveInsertionOrder),
+                                                 DUCKDB_LOCAL(ProfilerHistorySize),
+                                                 DUCKDB_LOCAL(ProfileOutputSetting),
+                                                 DUCKDB_LOCAL(ProfilingModeSetting),
+                                                 DUCKDB_LOCAL_ALIAS("profiling_output", ProfileOutputSetting),
+                                                 DUCKDB_LOCAL(ProgressBarTimeSetting),
+                                                 DUCKDB_LOCAL(SchemaSetting),
+                                                 DUCKDB_LOCAL(SearchPathSetting),
+                                                 DUCKDB_GLOBAL(TempDirectorySetting),
+                                                 DUCKDB_GLOBAL(ThreadsSetting),
+                                                 DUCKDB_GLOBAL_ALIAS("wal_autocheckpoint", CheckpointThresholdSetting),
+                                                 DUCKDB_GLOBAL_ALIAS("worker_threads", ThreadsSetting),
+                                                 FINAL_SETTING};
+
+vector<ConfigurationOption> DBConfig::GetOptions() {
+	vector<ConfigurationOption> options;
+	for (idx_t index = 0; internal_options[index].name; index++) {
+		options.push_back(internal_options[index]);
+	}
+	return options;
+}
+
+idx_t DBConfig::GetOptionCount() {
+	idx_t count = 0;
+	for (idx_t index = 0; internal_options[index].name; index++) {
+		count++;
+	}
+	return count;
+}
+
+ConfigurationOption *DBConfig::GetOptionByIndex(idx_t target_index) {
+	for (idx_t index = 0; internal_options[index].name; index++) {
+		if (index == target_index) {
+			return internal_options + index;
+		}
+	}
+	return nullptr;
+}
+
+ConfigurationOption *DBConfig::GetOptionByName(const string &name) {
+	auto lname = StringUtil::Lower(name);
+	for (idx_t index = 0; internal_options[index].name; index++) {
+		D_ASSERT(StringUtil::Lower(internal_options[index].name) == string(internal_options[index].name));
+		if (internal_options[index].name == lname) {
+			return internal_options + index;
+		}
+	}
+	return nullptr;
+}
+
+void DBConfig::SetOption(const ConfigurationOption &option, const Value &value) {
+	if (!option.set_global) {
+		throw InternalException("Could not set option \"%s\" as a global option", option.name);
+	}
+	Value input = value.CastAs(option.parameter_type);
+	option.set_global(nullptr, *this, input);
+}
+
+void DBConfig::AddExtensionOption(string name, string description, LogicalType parameter,
+                                  set_option_callback_t function) {
+	extension_parameters.insert(make_pair(move(name), ExtensionOption(move(description), move(parameter), function)));
+}
+
+idx_t DBConfig::ParseMemoryLimit(const string &arg) {
+	if (arg[0] == '-' || arg == "null" || arg == "none") {
+		return DConstants::INVALID_INDEX;
+	}
+	// split based on the number/non-number
+	idx_t idx = 0;
+	while (StringUtil::CharacterIsSpace(arg[idx])) {
+		idx++;
+	}
+	idx_t num_start = idx;
+	while ((arg[idx] >= '0' && arg[idx] <= '9') || arg[idx] == '.' || arg[idx] == 'e' || arg[idx] == 'E' ||
+	       arg[idx] == '-') {
+		idx++;
+	}
+	if (idx == num_start) {
+		throw ParserException("Memory limit must have a number (e.g. SET memory_limit=1GB");
+	}
+	string number = arg.substr(num_start, idx - num_start);
+
+	// try to parse the number
+	double limit = Cast::Operation<string_t, double>(string_t(number));
+
+	// now parse the memory limit unit (e.g. bytes, gb, etc)
+	while (StringUtil::CharacterIsSpace(arg[idx])) {
+		idx++;
+	}
+	idx_t start = idx;
+	while (idx < arg.size() && !StringUtil::CharacterIsSpace(arg[idx])) {
+		idx++;
+	}
+	if (limit < 0) {
+		// limit < 0, set limit to infinite
+		return (idx_t)-1;
+	}
+	string unit = StringUtil::Lower(arg.substr(start, idx - start));
+	idx_t multiplier;
+	if (unit == "byte" || unit == "bytes" || unit == "b") {
+		multiplier = 1;
+	} else if (unit == "kilobyte" || unit == "kilobytes" || unit == "kb" || unit == "k") {
+		multiplier = 1000LL;
+	} else if (unit == "megabyte" || unit == "megabytes" || unit == "mb" || unit == "m") {
+		multiplier = 1000LL * 1000LL;
+	} else if (unit == "gigabyte" || unit == "gigabytes" || unit == "gb" || unit == "g") {
+		multiplier = 1000LL * 1000LL * 1000LL;
+	} else if (unit == "terabyte" || unit == "terabytes" || unit == "tb" || unit == "t") {
+		multiplier = 1000LL * 1000LL * 1000LL * 1000LL;
+	} else {
+		throw ParserException("Unknown unit for memory_limit: %s (expected: b, mb, gb or tb)", unit);
+	}
+	return (idx_t)multiplier * limit;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+Connection::Connection(DatabaseInstance &database) : context(make_shared<ClientContext>(database.shared_from_this())) {
+	ConnectionManager::Get(database).AddConnection(*context);
+#ifdef DEBUG
+	EnableProfiling();
+#endif
+}
+
+Connection::Connection(DuckDB &database) : Connection(*database.instance) {
+}
+
+Connection::~Connection() {
+	ConnectionManager::Get(*context->db).RemoveConnection(*context);
+}
+
+string Connection::GetProfilingInformation(ProfilerPrintFormat format) {
+	auto &profiler = QueryProfiler::Get(*context);
+	if (format == ProfilerPrintFormat::JSON) {
+		return profiler.ToJSON();
+	} else {
+		return profiler.ToString();
+	}
+}
+
+void Connection::Interrupt() {
+	context->Interrupt();
+}
+
+void Connection::EnableProfiling() {
+	context->EnableProfiling();
+}
+
+void Connection::DisableProfiling() {
+	context->DisableProfiling();
+}
+
+void Connection::EnableQueryVerification() {
+	ClientConfig::GetConfig(*context).query_verification_enabled = true;
+}
+
+void Connection::DisableQueryVerification() {
+	ClientConfig::GetConfig(*context).query_verification_enabled = false;
+}
+
+void Connection::ForceParallelism() {
+	ClientConfig::GetConfig(*context).verify_parallelism = true;
+}
+
+unique_ptr<QueryResult> Connection::SendQuery(const string &query) {
+	return context->Query(query, true);
+}
+
+unique_ptr<MaterializedQueryResult> Connection::Query(const string &query) {
+	auto result = context->Query(query, false);
+	D_ASSERT(result->type == QueryResultType::MATERIALIZED_RESULT);
+	return unique_ptr_cast<QueryResult, MaterializedQueryResult>(move(result));
+}
+
+unique_ptr<MaterializedQueryResult> Connection::Query(unique_ptr<SQLStatement> statement) {
+	auto result = context->Query(move(statement), false);
+	D_ASSERT(result->type == QueryResultType::MATERIALIZED_RESULT);
+	return unique_ptr_cast<QueryResult, MaterializedQueryResult>(move(result));
+}
+
+unique_ptr<PendingQueryResult> Connection::PendingQuery(const string &query, bool allow_stream_result) {
+	return context->PendingQuery(query, allow_stream_result);
+}
+
+unique_ptr<PendingQueryResult> Connection::PendingQuery(unique_ptr<SQLStatement> statement, bool allow_stream_result) {
+	return context->PendingQuery(move(statement), allow_stream_result);
+}
+
+unique_ptr<PreparedStatement> Connection::Prepare(const string &query) {
+	return context->Prepare(query);
+}
+
+unique_ptr<PreparedStatement> Connection::Prepare(unique_ptr<SQLStatement> statement) {
+	return context->Prepare(move(statement));
+}
+
+unique_ptr<QueryResult> Connection::QueryParamsRecursive(const string &query, vector<Value> &values) {
+	auto statement = Prepare(query);
+	if (!statement->success) {
+		return make_unique<MaterializedQueryResult>(statement->error);
+	}
+	return statement->Execute(values, false);
+}
+
+unique_ptr<TableDescription> Connection::TableInfo(const string &table_name) {
+	return TableInfo(DEFAULT_SCHEMA, table_name);
+}
+
+unique_ptr<TableDescription> Connection::TableInfo(const string &schema_name, const string &table_name) {
+	return context->TableInfo(schema_name, table_name);
+}
+
+vector<unique_ptr<SQLStatement>> Connection::ExtractStatements(const string &query) {
+	return context->ParseStatements(query);
+}
+
+unique_ptr<LogicalOperator> Connection::ExtractPlan(const string &query) {
+	return context->ExtractPlan(query);
+}
+
+void Connection::Append(TableDescription &description, DataChunk &chunk) {
+	ChunkCollection collection;
+	collection.Append(chunk);
+	Append(description, collection);
+}
+
+void Connection::Append(TableDescription &description, ChunkCollection &collection) {
+	context->Append(description, collection);
+}
+
+shared_ptr<Relation> Connection::Table(const string &table_name) {
+	return Table(DEFAULT_SCHEMA, table_name);
+}
+
+shared_ptr<Relation> Connection::Table(const string &schema_name, const string &table_name) {
+	auto table_info = TableInfo(schema_name, table_name);
+	if (!table_info) {
+		throw Exception("Table does not exist!");
+	}
+	return make_shared<TableRelation>(context, move(table_info));
+}
+
+shared_ptr<Relation> Connection::View(const string &tname) {
+	return View(DEFAULT_SCHEMA, tname);
+}
+
+shared_ptr<Relation> Connection::View(const string &schema_name, const string &table_name) {
+	return make_shared<ViewRelation>(context, schema_name, table_name);
+}
+
+shared_ptr<Relation> Connection::TableFunction(const string &fname) {
+	vector<Value> values;
+	named_parameter_map_t named_parameters;
+	return TableFunction(fname, values, named_parameters);
+}
+
+shared_ptr<Relation> Connection::TableFunction(const string &fname, const vector<Value> &values,
+                                               const named_parameter_map_t &named_parameters) {
+	return make_shared<TableFunctionRelation>(context, fname, values, named_parameters);
+}
+
+shared_ptr<Relation> Connection::TableFunction(const string &fname, const vector<Value> &values) {
+	return make_shared<TableFunctionRelation>(context, fname, values);
+}
+
+shared_ptr<Relation> Connection::Values(const vector<vector<Value>> &values) {
+	vector<string> column_names;
+	return Values(values, column_names);
+}
+
+shared_ptr<Relation> Connection::Values(const vector<vector<Value>> &values, const vector<string> &column_names,
+                                        const string &alias) {
+	return make_shared<ValueRelation>(context, values, column_names, alias);
+}
+
+shared_ptr<Relation> Connection::Values(const string &values) {
+	vector<string> column_names;
+	return Values(values, column_names);
+}
+
+shared_ptr<Relation> Connection::Values(const string &values, const vector<string> &column_names, const string &alias) {
+	return make_shared<ValueRelation>(context, values, column_names, alias);
+}
+
+shared_ptr<Relation> Connection::ReadCSV(const string &csv_file) {
+	BufferedCSVReaderOptions options;
+	options.file_path = csv_file;
+	options.auto_detect = true;
+	BufferedCSVReader reader(*context, options);
+	vector<ColumnDefinition> column_list;
+	for (idx_t i = 0; i < reader.sql_types.size(); i++) {
+		column_list.emplace_back(reader.col_names[i], reader.sql_types[i]);
+	}
+	return make_shared<ReadCSVRelation>(context, csv_file, move(column_list), true);
+}
+
+shared_ptr<Relation> Connection::ReadCSV(const string &csv_file, const vector<string> &columns) {
+	// parse columns
+	vector<ColumnDefinition> column_list;
+	for (auto &column : columns) {
+		auto col_list = Parser::ParseColumnList(column, context->GetParserOptions());
+		if (col_list.size() != 1) {
+			throw ParserException("Expected a single column definition");
+		}
+		column_list.push_back(move(col_list[0]));
+	}
+	return make_shared<ReadCSVRelation>(context, csv_file, move(column_list));
+}
+
+unordered_set<string> Connection::GetTableNames(const string &query) {
+	return context->GetTableNames(query);
+}
+
+shared_ptr<Relation> Connection::RelationFromQuery(const string &query, const string &alias, const string &error) {
+	return RelationFromQuery(QueryRelation::ParseStatement(*context, query, error), alias);
+}
+
+shared_ptr<Relation> Connection::RelationFromQuery(unique_ptr<SelectStatement> select_stmt, const string &alias) {
+	return make_shared<QueryRelation>(context, move(select_stmt), alias);
+}
+
+void Connection::BeginTransaction() {
+	auto result = Query("BEGIN TRANSACTION");
+	if (!result->success) {
+		throw Exception(result->error);
+	}
+}
+
+void Connection::Commit() {
+	auto result = Query("COMMIT");
+	if (!result->success) {
+		throw Exception(result->error);
+	}
+}
+
+void Connection::Rollback() {
+	auto result = Query("ROLLBACK");
+	if (!result->success) {
+		throw Exception(result->error);
+	}
+}
+
+void Connection::SetAutoCommit(bool auto_commit) {
+	context->transaction.SetAutoCommit(auto_commit);
+}
+
+bool Connection::IsAutoCommit() {
+	return context->transaction.IsAutoCommit();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+#ifndef DUCKDB_NO_THREADS
+
+#endif
+
+namespace duckdb {
+
+DBConfig::DBConfig() {
+	compression_functions = make_unique<CompressionFunctionSet>();
+}
+
+DBConfig::~DBConfig() {
+}
+
+DatabaseInstance::DatabaseInstance() {
+}
+
+DatabaseInstance::~DatabaseInstance() {
+	if (Exception::UncaughtException()) {
+		return;
+	}
+
+	// shutting down: attempt to checkpoint the database
+	// but only if we are not cleaning up as part of an exception unwind
+	try {
+		auto &storage = StorageManager::GetStorageManager(*this);
+		if (!storage.InMemory()) {
+			auto &config = storage.db.config;
+			if (!config.checkpoint_on_shutdown) {
+				return;
+			}
+			storage.CreateCheckpoint(true);
+		}
+	} catch (...) {
+	}
+}
+
+BufferManager &BufferManager::GetBufferManager(DatabaseInstance &db) {
+	return *db.GetStorageManager().buffer_manager;
+}
+
+BlockManager &BlockManager::GetBlockManager(DatabaseInstance &db) {
+	return *db.GetStorageManager().block_manager;
+}
+
+BlockManager &BlockManager::GetBlockManager(ClientContext &context) {
+	return BlockManager::GetBlockManager(DatabaseInstance::GetDatabase(context));
+}
+
+DatabaseInstance &DatabaseInstance::GetDatabase(ClientContext &context) {
+	return *context.db;
+}
+
+StorageManager &StorageManager::GetStorageManager(DatabaseInstance &db) {
+	return db.GetStorageManager();
+}
+
+Catalog &Catalog::GetCatalog(DatabaseInstance &db) {
+	return db.GetCatalog();
+}
+
+FileSystem &FileSystem::GetFileSystem(DatabaseInstance &db) {
+	return db.GetFileSystem();
+}
+
+DBConfig &DBConfig::GetConfig(DatabaseInstance &db) {
+	return db.config;
+}
+
+ClientConfig &ClientConfig::GetConfig(ClientContext &context) {
+	return context.config;
+}
+
+TransactionManager &TransactionManager::Get(ClientContext &context) {
+	return TransactionManager::Get(DatabaseInstance::GetDatabase(context));
+}
+
+TransactionManager &TransactionManager::Get(DatabaseInstance &db) {
+	return db.GetTransactionManager();
+}
+
+ConnectionManager &ConnectionManager::Get(DatabaseInstance &db) {
+	return db.GetConnectionManager();
+}
+
+ConnectionManager &ConnectionManager::Get(ClientContext &context) {
+	return ConnectionManager::Get(DatabaseInstance::GetDatabase(context));
+}
+
+void DatabaseInstance::Initialize(const char *path, DBConfig *new_config) {
+	if (new_config) {
+		// user-supplied configuration
+		Configure(*new_config);
+	} else {
+		// default configuration
+		DBConfig config;
+		Configure(config);
+	}
+	if (config.temporary_directory.empty() && path) {
+		// no directory specified: use default temp path
+		config.temporary_directory = string(path) + ".tmp";
+
+		// special treatment for in-memory mode
+		if (strcmp(path, ":memory:") == 0) {
+			config.temporary_directory = ".tmp";
+		}
+	}
+	if (new_config && !new_config->use_temporary_directory) {
+		// temporary directories explicitly disabled
+		config.temporary_directory = string();
+	}
+
+	storage =
+	    make_unique<StorageManager>(*this, path ? string(path) : string(), config.access_mode == AccessMode::READ_ONLY);
+	catalog = make_unique<Catalog>(*this);
+	transaction_manager = make_unique<TransactionManager>(*this);
+	scheduler = make_unique<TaskScheduler>(*this);
+	object_cache = make_unique<ObjectCache>();
+	connection_manager = make_unique<ConnectionManager>();
+
+	// initialize the database
+	storage->Initialize();
+
+	// only increase thread count after storage init because we get races on catalog otherwise
+	scheduler->SetThreads(config.maximum_threads);
+}
+
+DuckDB::DuckDB(const char *path, DBConfig *new_config) : instance(make_shared<DatabaseInstance>()) {
+	instance->Initialize(path, new_config);
+	if (instance->config.load_extensions) {
+		ExtensionHelper::LoadAllExtensions(*this);
+	}
+}
+
+DuckDB::DuckDB(const string &path, DBConfig *config) : DuckDB(path.c_str(), config) {
+}
+
+DuckDB::DuckDB(DatabaseInstance &instance_p) : instance(instance_p.shared_from_this()) {
+}
+
+DuckDB::~DuckDB() {
+}
+
+StorageManager &DatabaseInstance::GetStorageManager() {
+	return *storage;
+}
+
+Catalog &DatabaseInstance::GetCatalog() {
+	return *catalog;
+}
+
+TransactionManager &DatabaseInstance::GetTransactionManager() {
+	return *transaction_manager;
+}
+
+TaskScheduler &DatabaseInstance::GetScheduler() {
+	return *scheduler;
+}
+
+ObjectCache &DatabaseInstance::GetObjectCache() {
+	return *object_cache;
+}
+
+FileSystem &DatabaseInstance::GetFileSystem() {
+	return *config.file_system;
+}
+
+ConnectionManager &DatabaseInstance::GetConnectionManager() {
+	return *connection_manager;
+}
+
+FileSystem &DuckDB::GetFileSystem() {
+	return instance->GetFileSystem();
+}
+
+Allocator &Allocator::Get(ClientContext &context) {
+	return Allocator::Get(*context.db);
+}
+
+Allocator &Allocator::Get(DatabaseInstance &db) {
+	return db.config.allocator;
+}
+
+void DatabaseInstance::Configure(DBConfig &new_config) {
+	config.access_mode = AccessMode::READ_WRITE;
+	if (new_config.access_mode != AccessMode::UNDEFINED) {
+		config.access_mode = new_config.access_mode;
+	}
+	if (new_config.file_system) {
+		config.file_system = move(new_config.file_system);
+	} else {
+		config.file_system = make_unique<VirtualFileSystem>();
+	}
+	config.maximum_memory = new_config.maximum_memory;
+	if (config.maximum_memory == (idx_t)-1) {
+		auto memory = FileSystem::GetAvailableMemory();
+		if (memory != DConstants::INVALID_INDEX) {
+			config.maximum_memory = memory * 8 / 10;
+		}
+	}
+	if (new_config.maximum_threads == (idx_t)-1) {
+#ifndef DUCKDB_NO_THREADS
+		config.maximum_threads = std::thread::hardware_concurrency();
+#else
+		config.maximum_threads = 1;
+#endif
+	} else {
+		config.maximum_threads = new_config.maximum_threads;
+	}
+	config.external_threads = new_config.external_threads;
+	config.load_extensions = new_config.load_extensions;
+	config.force_compression = new_config.force_compression;
+	config.allocator = move(new_config.allocator);
+	config.checkpoint_wal_size = new_config.checkpoint_wal_size;
+	config.use_direct_io = new_config.use_direct_io;
+	config.temporary_directory = new_config.temporary_directory;
+	config.collation = new_config.collation;
+	config.default_order_type = new_config.default_order_type;
+	config.default_null_order = new_config.default_null_order;
+	config.enable_external_access = new_config.enable_external_access;
+	config.replacement_scans = move(new_config.replacement_scans);
+	config.initialize_default_database = new_config.initialize_default_database;
+	config.disabled_optimizers = move(new_config.disabled_optimizers);
+}
+
+DBConfig &DBConfig::GetConfig(ClientContext &context) {
+	return context.db->config;
+}
+
+idx_t DatabaseInstance::NumberOfThreads() {
+	return scheduler->NumberOfThreads();
+}
+
+const unordered_set<std::string> &DatabaseInstance::LoadedExtensions() {
+	return loaded_extensions;
+}
+
+idx_t DuckDB::NumberOfThreads() {
+	return instance->NumberOfThreads();
+}
+
+bool DuckDB::ExtensionIsLoaded(const std::string &name) {
+	return instance->loaded_extensions.find(name) != instance->loaded_extensions.end();
+}
+void DuckDB::SetExtensionLoaded(const std::string &name) {
+	instance->loaded_extensions.insert(name);
+}
+
+string ClientConfig::ExtractTimezoneFromConfig(ClientConfig &config) {
+	if (config.set_variables.find("TimeZone") == config.set_variables.end()) {
+		return "UTC";
+	} else {
+		return config.set_variables["TimeZone"].GetValue<std::string>();
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#if defined(BUILD_ICU_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define ICU_STATICALLY_LOADED true
+#include "icu-extension.hpp"
+#else
+#define ICU_STATICALLY_LOADED false
+#endif
+
+#if defined(BUILD_PARQUET_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define PARQUET_STATICALLY_LOADED true
+#include "parquet-extension.hpp"
+#else
+#define PARQUET_STATICALLY_LOADED false
+#endif
+
+#if defined(BUILD_TPCH_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define TPCH_STATICALLY_LOADED true
+#include "tpch-extension.hpp"
+#else
+#define TPCH_STATICALLY_LOADED false
+#endif
+
+#if defined(BUILD_TPCDS_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define TPCDS_STATICALLY_LOADED true
+#include "tpcds-extension.hpp"
+#else
+#define TPCDS_STATICALLY_LOADED false
+#endif
+
+#if defined(BUILD_SUBSTRAIT_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define SUBSTRAIT_STATICALLY_LOADED true
+#include "substrait-extension.hpp"
+#else
+#define SUBSTRAIT_STATICALLY_LOADED false
+#endif
+
+#if defined(BUILD_FTS_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define FTS_STATICALLY_LOADED true
+#include "fts-extension.hpp"
+#else
+#define FTS_STATICALLY_LOADED false
+#endif
+
+#if defined(BUILD_HTTPFS_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define HTTPFS_STATICALLY_LOADED true
+#include "httpfs-extension.hpp"
+#else
+#define HTTPFS_STATICALLY_LOADED false
+#endif
+
+#if defined(BUILD_VISUALIZER_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#include "visualizer-extension.hpp"
+#endif
+
+#if defined(BUILD_JSON_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#define JSON_STATICALLY_LOADED true
+#include "json-extension.hpp"
+#else
+#define JSON_STATICALLY_LOADED false
+#endif
+
+#if defined(BUILD_EXCEL_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#include "excel-extension.hpp"
+#endif
+
+#if defined(BUILD_SQLSMITH_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+#include "sqlsmith-extension.hpp"
+#endif
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Default Extensions
+//===--------------------------------------------------------------------===//
+static DefaultExtension internal_extensions[] = {
+    {"icu", "Adds support for time zones and collations using the ICU library", ICU_STATICALLY_LOADED},
+    {"parquet", "Adds support for reading and writing parquet files", PARQUET_STATICALLY_LOADED},
+    {"tpch", "Adds TPC-H data generation and query support", TPCH_STATICALLY_LOADED},
+    {"tpcds", "Adds TPC-DS data generation and query support", TPCDS_STATICALLY_LOADED},
+    {"substrait", "Adds support for the Substrait integration", SUBSTRAIT_STATICALLY_LOADED},
+    {"fts", "Adds support for Full-Text Search Indexes", FTS_STATICALLY_LOADED},
+    {"httpfs", "Adds support for reading and writing files over a HTTP(S) connection", HTTPFS_STATICALLY_LOADED},
+    {"json", "Adds support for JSON operations", JSON_STATICALLY_LOADED},
+    {"sqlite_scanner", "Adds support for reading SQLite database files", false},
+    {"postgres_scanner", "Adds support for reading from a Postgres database", false},
+    {nullptr, nullptr, false}};
+
+idx_t ExtensionHelper::DefaultExtensionCount() {
+	idx_t index;
+	for (index = 0; internal_extensions[index].name != nullptr; index++) {
+	}
+	return index;
+}
+
+DefaultExtension ExtensionHelper::GetDefaultExtension(idx_t index) {
+	D_ASSERT(index < DefaultExtensionCount());
+	return internal_extensions[index];
+}
+
+//===--------------------------------------------------------------------===//
+// Load Statically Compiled Extension
+//===--------------------------------------------------------------------===//
+void ExtensionHelper::LoadAllExtensions(DuckDB &db) {
+	unordered_set<string> extensions {"parquet",   "icu",        "tpch", "tpcds", "fts",     "httpfs",
+	                                  "substrait", "visualizer", "json", "excel", "sqlsmith"};
+	for (auto &ext : extensions) {
+		LoadExtensionInternal(db, ext, true);
+	}
+}
+
+ExtensionLoadResult ExtensionHelper::LoadExtension(DuckDB &db, const std::string &extension) {
+	return LoadExtensionInternal(db, extension, false);
+}
+
+ExtensionLoadResult ExtensionHelper::LoadExtensionInternal(DuckDB &db, const std::string &extension,
+                                                           bool initial_load) {
+#ifdef DUCKDB_TEST_REMOTE_INSTALL
+	if (!initial_load && StringUtil::Contains(DUCKDB_TEST_REMOTE_INSTALL, extension)) {
+		Connection con(db);
+		auto result = con.Query("INSTALL " + extension);
+		if (!result->success) {
+			result->Print();
+			return ExtensionLoadResult::EXTENSION_UNKNOWN;
+		}
+		result = con.Query("LOAD " + extension);
+		if (!result->success) {
+			result->Print();
+			return ExtensionLoadResult::EXTENSION_UNKNOWN;
+		}
+		return ExtensionLoadResult::LOADED_EXTENSION;
+	}
+#endif
+	if (extension == "parquet") {
+#if PARQUET_STATICALLY_LOADED
+		db.LoadExtension<ParquetExtension>();
+#else
+		// parquet extension required but not build: skip this test
+		return ExtensionLoadResult::NOT_LOADED;
+#endif
+	} else if (extension == "icu") {
+#if ICU_STATICALLY_LOADED
+		db.LoadExtension<ICUExtension>();
+#else
+		// icu extension required but not build: skip this test
+		return ExtensionLoadResult::NOT_LOADED;
+#endif
+	} else if (extension == "tpch") {
+#if TPCH_STATICALLY_LOADED
+		db.LoadExtension<TPCHExtension>();
+#else
+		// icu extension required but not build: skip this test
+		return ExtensionLoadResult::NOT_LOADED;
+#endif
+	} else if (extension == "substrait") {
+#if SUBSTRAIT_STATICALLY_LOADED
+
+		db.LoadExtension<SubstraitExtension>();
+#else
+		// substrait extension required but not build: skip this test
+		return ExtensionLoadResult::NOT_LOADED;
+#endif
+	} else if (extension == "tpcds") {
+#if TPCDS_STATICALLY_LOADED
+		db.LoadExtension<TPCDSExtension>();
+#else
+		// icu extension required but not build: skip this test
+		return ExtensionLoadResult::NOT_LOADED;
+#endif
+	} else if (extension == "fts") {
+#if FTS_STATICALLY_LOADED
+		db.LoadExtension<FTSExtension>();
+#else
+		// fts extension required but not build: skip this test
+		return ExtensionLoadResult::NOT_LOADED;
+#endif
+	} else if (extension == "httpfs") {
+#if HTTPFS_STATICALLY_LOADED
+		db.LoadExtension<HTTPFsExtension>();
+#else
+		return ExtensionLoadResult::NOT_LOADED;
+#endif
+	} else if (extension == "visualizer") {
+#if defined(BUILD_VISUALIZER_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+		db.LoadExtension<VisualizerExtension>();
+#else
+		// visualizer extension required but not build: skip this test
+		return ExtensionLoadResult::NOT_LOADED;
+#endif
+	} else if (extension == "json") {
+#if JSON_STATICALLY_LOADED
+		db.LoadExtension<JSONExtension>();
+#else
+		// json extension required but not build: skip this test
+		return ExtensionLoadResult::NOT_LOADED;
+#endif
+	} else if (extension == "excel") {
+#if defined(BUILD_EXCEL_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+		db.LoadExtension<EXCELExtension>();
+#else
+		// excel extension required but not build: skip this test
+		return ExtensionLoadResult::NOT_LOADED;
+#endif
+	} else if (extension == "sqlsmith") {
+#if defined(BUILD_SQLSMITH_EXTENSION) && !defined(DISABLE_BUILTIN_EXTENSIONS)
+		db.LoadExtension<SQLSmithExtension>();
+#else
+		// excel extension required but not build: skip this test
+		return ExtensionLoadResult::NOT_LOADED;
+#endif
+	} else {
+		// unknown extension
+		return ExtensionLoadResult::EXTENSION_UNKNOWN;
+	}
+	return ExtensionLoadResult::LOADED_EXTENSION;
+}
+
+} // namespace duckdb
+
+
+
+
+#ifndef DISABLE_DUCKDB_REMOTE_INSTALL
+
+#endif
+
+
+#include <fstream>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Install Extension
+//===--------------------------------------------------------------------===//
+const vector<string> ExtensionHelper::PathComponents() {
+	return vector<string> {".duckdb", "extensions", DuckDB::SourceID(), DuckDB::Platform()};
+}
+
+string ExtensionHelper::ExtensionDirectory(FileSystem &fs) {
+	string local_path = fs.GetHomeDirectory();
+	if (!fs.DirectoryExists(local_path)) {
+		throw InternalException("Can't find the home directory at " + local_path);
+	}
+	auto path_components = PathComponents();
+	for (auto &path_ele : path_components) {
+		local_path = fs.JoinPath(local_path, path_ele);
+		if (!fs.DirectoryExists(local_path)) {
+			fs.CreateDirectory(local_path);
+		}
+	}
+	return local_path;
+}
+
+void ExtensionHelper::InstallExtension(DatabaseInstance &db, const string &extension, bool force_install) {
+	auto &config = DBConfig::GetConfig(db);
+	if (!config.enable_external_access) {
+		throw PermissionException("Installing extensions is disabled through configuration");
+	}
+	auto &fs = FileSystem::GetFileSystem(db);
+
+	string local_path = ExtensionDirectory(fs);
+
+	auto extension_name = fs.ExtractBaseName(extension);
+
+	string local_extension_path = fs.JoinPath(local_path, extension_name + ".duckdb_extension");
+	if (fs.FileExists(local_extension_path) && !force_install) {
+		return;
+	}
+
+	auto uuid = UUID::ToString(UUID::GenerateRandomUUID());
+	string temp_path = local_extension_path + ".tmp-" + uuid;
+	if (fs.FileExists(temp_path)) {
+		fs.RemoveFile(temp_path);
+	}
+	auto is_http_url = StringUtil::Contains(extension, "http://");
+	if (fs.FileExists(extension)) {
+
+		std::ifstream in(extension, std::ios::binary);
+		if (in.bad()) {
+			throw IOException("Failed to read extension from \"%s\"", extension);
+		}
+		std::ofstream out(temp_path, std::ios::binary);
+		out << in.rdbuf();
+		if (out.bad()) {
+			throw IOException("Failed to write extension to \"%s\"", temp_path);
+		}
+		in.close();
+		out.close();
+
+		fs.MoveFile(temp_path, local_extension_path);
+		return;
+	} else if (StringUtil::Contains(extension, "/") && !is_http_url) {
+		throw IOException("Failed to read extension from \"%s\": no such file", extension);
+	}
+
+#ifdef DISABLE_DUCKDB_REMOTE_INSTALL
+	throw BinderException("Remote extension installation is disabled through configuration");
+#else
+	string url_template = "http://extensions.duckdb.org/${REVISION}/${PLATFORM}/${NAME}.duckdb_extension.gz";
+
+	if (is_http_url) {
+		url_template = extension;
+		extension_name = "";
+	}
+
+	auto url = StringUtil::Replace(url_template, "${REVISION}", DuckDB::SourceID());
+	url = StringUtil::Replace(url, "${PLATFORM}", DuckDB::Platform());
+	url = StringUtil::Replace(url, "${NAME}", extension_name);
+
+	string no_http = StringUtil::Replace(url, "http://", "");
+
+	idx_t next = no_http.find('/', 0);
+	if (next == string::npos) {
+		throw IOException("No slash in URL template");
+	}
+
+	// Push the substring [last, next) on to splits
+	auto hostname_without_http = no_http.substr(0, next);
+	auto url_local_part = no_http.substr(next);
+
+	auto url_base = "http://" + hostname_without_http;
+	duckdb_httplib::Client cli(url_base.c_str());
+
+	duckdb_httplib::Headers headers = {{"User-Agent", StringUtil::Format("DuckDB %s %s %s", DuckDB::LibraryVersion(),
+	                                                                     DuckDB::SourceID(), DuckDB::Platform())}};
+
+	auto res = cli.Get(url_local_part.c_str(), headers);
+	if (!res || res->status != 200) {
+		throw IOException("Failed to download extension %s%s", url_base, url_local_part);
+	}
+	auto decompressed_body = GZipFileSystem::UncompressGZIPString(res->body);
+	std::ofstream out(temp_path, std::ios::binary);
+	out.write(decompressed_body.data(), decompressed_body.size());
+	if (out.bad()) {
+		throw IOException("Failed to write extension to %s", temp_path);
+	}
+	out.close();
+	fs.MoveFile(temp_path, local_extension_path);
+#endif
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Load External Extension
+//===--------------------------------------------------------------------===//
+typedef void (*ext_init_fun_t)(DatabaseInstance &);
+typedef const char *(*ext_version_fun_t)(void);
+
+template <class T>
+static T LoadFunctionFromDLL(void *dll, const string &function_name, const string &filename) {
+	auto function = dlsym(dll, function_name.c_str());
+	if (!function) {
+		throw IOException("File \"%s\" did not contain function \"%s\": %s", filename, function_name, GetDLError());
+	}
+	return (T)function;
+}
+
+void ExtensionHelper::LoadExternalExtension(DatabaseInstance &db, const string &extension) {
+	auto &config = DBConfig::GetConfig(db);
+	if (!config.enable_external_access) {
+		throw PermissionException("Loading external extensions is disabled through configuration");
+	}
+	auto &fs = FileSystem::GetFileSystem(db);
+	auto filename = fs.ConvertSeparators(extension);
+
+	// shorthand case
+	if (!StringUtil::Contains(extension, ".") && !StringUtil::Contains(extension, fs.PathSeparator())) {
+		string local_path = fs.GetHomeDirectory();
+		auto path_components = PathComponents();
+		for (auto &path_ele : path_components) {
+			local_path = fs.JoinPath(local_path, path_ele);
+		}
+		filename = fs.JoinPath(local_path, extension + ".duckdb_extension");
+	}
+
+	if (!fs.FileExists(filename)) {
+		throw IOException("File \"%s\" not found", filename);
+	}
+	auto lib_hdl = dlopen(filename.c_str(), RTLD_NOW | RTLD_LOCAL);
+	if (!lib_hdl) {
+		throw IOException("File \"%s\" could not be loaded: %s", filename, GetDLError());
+	}
+
+	auto basename = fs.ExtractBaseName(filename);
+	auto init_fun_name = basename + "_init";
+	auto version_fun_name = basename + "_version";
+
+	ext_init_fun_t init_fun;
+	ext_version_fun_t version_fun;
+
+	init_fun = LoadFunctionFromDLL<ext_init_fun_t>(lib_hdl, init_fun_name, filename);
+	version_fun = LoadFunctionFromDLL<ext_version_fun_t>(lib_hdl, version_fun_name, filename);
+
+	std::string engine_version = std::string(DuckDB::LibraryVersion());
+
+	auto version_fun_result = (*version_fun)();
+	if (version_fun_result == nullptr) {
+		throw InvalidInputException("Extension \"%s\" returned a nullptr", filename);
+	}
+	std::string extension_version = std::string(version_fun_result);
+
+	// Trim v's if necessary
+	std::string extension_version_trimmed = extension_version;
+	std::string engine_version_trimmed = engine_version;
+	if (extension_version.length() > 0 && extension_version[0] == 'v') {
+		extension_version_trimmed = extension_version.substr(1);
+	}
+	if (engine_version.length() > 0 && engine_version[0] == 'v') {
+		engine_version_trimmed = engine_version.substr(1);
+	}
+
+	if (extension_version_trimmed != engine_version_trimmed) {
+		throw InvalidInputException("Extension \"%s\" version (%s) does not match DuckDB version (%s)", filename,
+		                            extension_version, engine_version);
+	}
+
+	try {
+		(*init_fun)(db);
+	} catch (std::exception &e) {
+		throw InvalidInputException("Initialization function \"%s\" from file \"%s\" threw an exception: \"%s\"",
+		                            init_fun_name, filename, e.what());
+	}
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+Extension::~Extension() {
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+MaterializedQueryResult::MaterializedQueryResult(StatementType statement_type, StatementProperties properties,
+                                                 vector<LogicalType> types, vector<string> names,
+                                                 const shared_ptr<ClientContext> &context)
+    : QueryResult(QueryResultType::MATERIALIZED_RESULT, statement_type, properties, move(types), move(names)),
+      context(context) {
+}
+
+MaterializedQueryResult::MaterializedQueryResult(string error)
+    : QueryResult(QueryResultType::MATERIALIZED_RESULT, move(error)) {
+}
+
+Value MaterializedQueryResult::GetValue(idx_t column, idx_t index) {
+	auto &data = collection.GetChunkForRow(index).data[column];
+	auto offset_in_chunk = index % STANDARD_VECTOR_SIZE;
+	return data.GetValue(offset_in_chunk);
+}
+
+string MaterializedQueryResult::ToString() {
+	string result;
+	if (success) {
+		result = HeaderToString();
+		result += "[ Rows: " + to_string(collection.Count()) + "]\n";
+		for (idx_t j = 0; j < collection.Count(); j++) {
+			for (idx_t i = 0; i < collection.ColumnCount(); i++) {
+				auto val = collection.GetValue(i, j);
+				result += val.IsNull() ? "NULL" : val.ToString();
+				result += "\t";
+			}
+			result += "\n";
+		}
+		result += "\n";
+	} else {
+		result = error + "\n";
+	}
+	return result;
+}
+
+unique_ptr<DataChunk> MaterializedQueryResult::Fetch() {
+	return FetchRaw();
+}
+
+unique_ptr<DataChunk> MaterializedQueryResult::FetchRaw() {
+	if (!success) {
+		throw InvalidInputException("Attempting to fetch from an unsuccessful query result\nError: %s", error);
+	}
+	return collection.Fetch();
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PendingQueryResult::PendingQueryResult(shared_ptr<ClientContext> context_p, PreparedStatementData &statement,
+                                       vector<LogicalType> types_p, bool allow_stream_result)
+    : BaseQueryResult(QueryResultType::PENDING_RESULT, statement.statement_type, statement.properties, move(types_p),
+                      statement.names),
+      context(move(context_p)), allow_stream_result(allow_stream_result) {
+}
+
+PendingQueryResult::PendingQueryResult(string error) : BaseQueryResult(QueryResultType::PENDING_RESULT, move(error)) {
+}
+
+PendingQueryResult::~PendingQueryResult() {
+}
+
+unique_ptr<ClientContextLock> PendingQueryResult::LockContext() {
+	if (!context) {
+		throw InvalidInputException("Attempting to execute an unsuccessful or closed pending query result\nError: %s",
+		                            error);
+	}
+	return context->LockContext();
+}
+
+void PendingQueryResult::CheckExecutableInternal(ClientContextLock &lock) {
+	bool invalidated = !success || !context;
+	if (!invalidated) {
+		invalidated = !context->IsActiveResult(lock, this);
+	}
+	if (invalidated) {
+		throw InvalidInputException("Attempting to execute an unsuccessful or closed pending query result\nError: %s",
+		                            error);
+	}
+}
+
+PendingExecutionResult PendingQueryResult::ExecuteTask() {
+	auto lock = LockContext();
+	return ExecuteTaskInternal(*lock);
+}
+
+PendingExecutionResult PendingQueryResult::ExecuteTaskInternal(ClientContextLock &lock) {
+	CheckExecutableInternal(lock);
+	return context->ExecuteTaskInternal(lock, *this);
+}
+
+unique_ptr<QueryResult> PendingQueryResult::ExecuteInternal(ClientContextLock &lock) {
+	CheckExecutableInternal(lock);
+	while (ExecuteTaskInternal(lock) == PendingExecutionResult::RESULT_NOT_READY) {
+	}
+	if (!success) {
+		return make_unique<MaterializedQueryResult>(error);
+	}
+	auto result = context->FetchResultInternal(lock, *this);
+	Close();
+	return result;
+}
+
+unique_ptr<QueryResult> PendingQueryResult::Execute() {
+	auto lock = LockContext();
+	return ExecuteInternal(*lock);
+}
+
+void PendingQueryResult::Close() {
+	context.reset();
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+PreparedStatement::PreparedStatement(shared_ptr<ClientContext> context, shared_ptr<PreparedStatementData> data_p,
+                                     string query, idx_t n_param)
+    : context(move(context)), data(move(data_p)), query(move(query)), success(true), n_param(n_param) {
+	D_ASSERT(data || !success);
+}
+
+PreparedStatement::PreparedStatement(string error) : context(nullptr), success(false), error(move(error)) {
+}
+
+PreparedStatement::~PreparedStatement() {
+}
+
+idx_t PreparedStatement::ColumnCount() {
+	D_ASSERT(data);
+	return data->types.size();
+}
+
+StatementType PreparedStatement::GetStatementType() {
+	D_ASSERT(data);
+	return data->statement_type;
+}
+
+StatementProperties PreparedStatement::GetStatementProperties() {
+	D_ASSERT(data);
+	return data->properties;
+}
+
+const vector<LogicalType> &PreparedStatement::GetTypes() {
+	D_ASSERT(data);
+	return data->types;
+}
+
+const vector<string> &PreparedStatement::GetNames() {
+	D_ASSERT(data);
+	return data->names;
+}
+
+unique_ptr<QueryResult> PreparedStatement::Execute(vector<Value> &values, bool allow_stream_result) {
+	auto pending = PendingQuery(values, allow_stream_result);
+	if (!pending->success) {
+		return make_unique<MaterializedQueryResult>(pending->error);
+	}
+	return pending->Execute();
+}
+
+unique_ptr<PendingQueryResult> PreparedStatement::PendingQuery(vector<Value> &values, bool allow_stream_result) {
+	if (!success) {
+		throw InvalidInputException("Attempting to execute an unsuccessfully prepared statement!");
+	}
+	D_ASSERT(data);
+	PendingQueryParameters parameters;
+	parameters.parameters = &values;
+	parameters.allow_stream_result = allow_stream_result && data->properties.allow_stream_result;
+	auto result = context->PendingQuery(query, data, parameters);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PreparedStatementData::PreparedStatementData(StatementType type) : statement_type(type) {
+}
+
+PreparedStatementData::~PreparedStatementData() {
+}
+
+void PreparedStatementData::Bind(vector<Value> values) {
+	// set parameters
+	const auto required = properties.parameter_count;
+	D_ASSERT(!unbound_statement || unbound_statement->n_param == properties.parameter_count);
+	if (values.size() != required) {
+		throw BinderException("Parameter/argument count mismatch for prepared statement. Expected %llu, got %llu",
+		                      required, values.size());
+	}
+
+	// bind the required values
+	for (auto &it : value_map) {
+		const idx_t i = it.first - 1;
+		if (i >= values.size()) {
+			throw BinderException("Could not find parameter with index %llu", i + 1);
+		}
+		D_ASSERT(!it.second.empty());
+		if (!values[i].TryCastAs(it.second[0]->type())) {
+			throw BinderException(
+			    "Type mismatch for binding parameter with index %llu, expected type %s but got type %s", i + 1,
+			    it.second[0]->type().ToString().c_str(), values[i].type().ToString().c_str());
+		}
+		for (auto &target : it.second) {
+			*target = values[i];
+		}
+	}
+}
+
+LogicalType PreparedStatementData::GetType(idx_t param_idx) {
+	auto it = value_map.find(param_idx);
+	if (it == value_map.end()) {
+		throw BinderException("Could not find parameter with index %llu", param_idx);
+	}
+	D_ASSERT(!it->second.empty());
+	return it->second[0]->type();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <utility>
+#include <algorithm>
+
+namespace duckdb {
+
+QueryProfiler::QueryProfiler(ClientContext &context_p)
+    : context(context_p), running(false), query_requires_profiling(false), is_explain_analyze(false) {
+}
+
+bool QueryProfiler::IsEnabled() const {
+	return is_explain_analyze ? true : ClientConfig::GetConfig(context).enable_profiler;
+}
+
+bool QueryProfiler::IsDetailedEnabled() const {
+	return is_explain_analyze ? false : ClientConfig::GetConfig(context).enable_detailed_profiling;
+}
+
+ProfilerPrintFormat QueryProfiler::GetPrintFormat() const {
+	return is_explain_analyze ? ProfilerPrintFormat::NONE : ClientConfig::GetConfig(context).profiler_print_format;
+}
+
+string QueryProfiler::GetSaveLocation() const {
+	return is_explain_analyze ? string() : ClientConfig::GetConfig(context).profiler_save_location;
+}
+
+QueryProfiler &QueryProfiler::Get(ClientContext &context) {
+	return *ClientData::Get(context).profiler;
+}
+
+void QueryProfiler::StartQuery(string query, bool is_explain_analyze) {
+	if (is_explain_analyze) {
+		StartExplainAnalyze();
+	}
+	if (!IsEnabled()) {
+		return;
+	}
+	this->running = true;
+	this->query = move(query);
+	tree_map.clear();
+	root = nullptr;
+	phase_timings.clear();
+	phase_stack.clear();
+
+	main_query.Start();
+}
+
+bool QueryProfiler::OperatorRequiresProfiling(PhysicalOperatorType op_type) {
+	switch (op_type) {
+	case PhysicalOperatorType::ORDER_BY:
+	case PhysicalOperatorType::RESERVOIR_SAMPLE:
+	case PhysicalOperatorType::STREAMING_SAMPLE:
+	case PhysicalOperatorType::LIMIT:
+	case PhysicalOperatorType::LIMIT_PERCENT:
+	case PhysicalOperatorType::STREAMING_LIMIT:
+	case PhysicalOperatorType::TOP_N:
+	case PhysicalOperatorType::WINDOW:
+	case PhysicalOperatorType::UNNEST:
+	case PhysicalOperatorType::SIMPLE_AGGREGATE:
+	case PhysicalOperatorType::HASH_GROUP_BY:
+	case PhysicalOperatorType::FILTER:
+	case PhysicalOperatorType::PROJECTION:
+	case PhysicalOperatorType::COPY_TO_FILE:
+	case PhysicalOperatorType::TABLE_SCAN:
+	case PhysicalOperatorType::CHUNK_SCAN:
+	case PhysicalOperatorType::DELIM_SCAN:
+	case PhysicalOperatorType::EXPRESSION_SCAN:
+	case PhysicalOperatorType::BLOCKWISE_NL_JOIN:
+	case PhysicalOperatorType::NESTED_LOOP_JOIN:
+	case PhysicalOperatorType::HASH_JOIN:
+	case PhysicalOperatorType::CROSS_PRODUCT:
+	case PhysicalOperatorType::PIECEWISE_MERGE_JOIN:
+	case PhysicalOperatorType::IE_JOIN:
+	case PhysicalOperatorType::DELIM_JOIN:
+	case PhysicalOperatorType::UNION:
+	case PhysicalOperatorType::RECURSIVE_CTE:
+	case PhysicalOperatorType::EMPTY_RESULT:
+		return true;
+	default:
+		return false;
+	}
+}
+
+void QueryProfiler::Finalize(TreeNode &node) {
+	for (auto &child : node.children) {
+		Finalize(*child);
+		if (node.type == PhysicalOperatorType::UNION) {
+			node.info.elements += child->info.elements;
+		}
+	}
+}
+
+void QueryProfiler::StartExplainAnalyze() {
+	this->is_explain_analyze = true;
+}
+
+void QueryProfiler::EndQuery() {
+	lock_guard<mutex> guard(flush_lock);
+	if (!IsEnabled() || !running) {
+		return;
+	}
+
+	main_query.End();
+	if (root) {
+		Finalize(*root);
+	}
+	this->running = false;
+	auto automatic_print_format = GetPrintFormat();
+	// print or output the query profiling after termination, if this is enabled
+	if (automatic_print_format != ProfilerPrintFormat::NONE) {
+		// check if this query should be output based on the operator types
+		string query_info;
+		if (automatic_print_format == ProfilerPrintFormat::JSON) {
+			query_info = ToJSON();
+		} else if (automatic_print_format == ProfilerPrintFormat::QUERY_TREE) {
+			query_info = ToString();
+		} else if (automatic_print_format == ProfilerPrintFormat::QUERY_TREE_OPTIMIZER) {
+			query_info = ToString(true);
+		}
+		auto save_location = GetSaveLocation();
+		if (save_location.empty()) {
+			Printer::Print(query_info);
+			Printer::Print("\n");
+		} else {
+			WriteToFile(save_location.c_str(), query_info);
+		}
+	}
+	this->is_explain_analyze = false;
+}
+
+void QueryProfiler::StartPhase(string new_phase) {
+	if (!IsEnabled() || !running) {
+		return;
+	}
+
+	if (!phase_stack.empty()) {
+		// there are active phases
+		phase_profiler.End();
+		// add the timing to all phases prior to this one
+		string prefix = "";
+		for (auto &phase : phase_stack) {
+			phase_timings[phase] += phase_profiler.Elapsed();
+			prefix += phase + " > ";
+		}
+		// when there are previous phases, we prefix the current phase with those phases
+		new_phase = prefix + new_phase;
+	}
+
+	// start a new phase
+	phase_stack.push_back(new_phase);
+	// restart the timer
+	phase_profiler.Start();
+}
+
+void QueryProfiler::EndPhase() {
+	if (!IsEnabled() || !running) {
+		return;
+	}
+	D_ASSERT(phase_stack.size() > 0);
+
+	// end the timer
+	phase_profiler.End();
+	// add the timing to all currently active phases
+	for (auto &phase : phase_stack) {
+		phase_timings[phase] += phase_profiler.Elapsed();
+	}
+	// now remove the last added phase
+	phase_stack.pop_back();
+
+	if (!phase_stack.empty()) {
+		phase_profiler.Start();
+	}
+}
+
+void QueryProfiler::Initialize(PhysicalOperator *root_op) {
+	if (!IsEnabled() || !running) {
+		return;
+	}
+	this->query_requires_profiling = false;
+	this->root = CreateTree(root_op);
+	if (!query_requires_profiling) {
+		// query does not require profiling: disable profiling for this query
+		this->running = false;
+		tree_map.clear();
+		root = nullptr;
+		phase_timings.clear();
+		phase_stack.clear();
+	}
+}
+
+OperatorProfiler::OperatorProfiler(bool enabled_p) : enabled(enabled_p), active_operator(nullptr) {
+}
+
+void OperatorProfiler::StartOperator(const PhysicalOperator *phys_op) {
+	if (!enabled) {
+		return;
+	}
+
+	if (active_operator) {
+		throw InternalException("OperatorProfiler: Attempting to call StartOperator while another operator is active");
+	}
+
+	active_operator = phys_op;
+
+	// start timing for current element
+	op.Start();
+}
+
+void OperatorProfiler::EndOperator(DataChunk *chunk) {
+	if (!enabled) {
+		return;
+	}
+
+	if (!active_operator) {
+		throw InternalException("OperatorProfiler: Attempting to call EndOperator while another operator is active");
+	}
+
+	// finish timing for the current element
+	op.End();
+
+	AddTiming(active_operator, op.Elapsed(), chunk ? chunk->size() : 0);
+	active_operator = nullptr;
+}
+
+void OperatorProfiler::AddTiming(const PhysicalOperator *op, double time, idx_t elements) {
+	if (!enabled) {
+		return;
+	}
+	if (!Value::DoubleIsFinite(time)) {
+		return;
+	}
+	auto entry = timings.find(op);
+	if (entry == timings.end()) {
+		// add new entry
+		timings[op] = OperatorInformation(time, elements);
+	} else {
+		// add to existing entry
+		entry->second.time += time;
+		entry->second.elements += elements;
+	}
+}
+void OperatorProfiler::Flush(const PhysicalOperator *phys_op, ExpressionExecutor *expression_executor,
+                             const string &name, int id) {
+	auto entry = timings.find(phys_op);
+	if (entry == timings.end()) {
+		return;
+	}
+	auto &operator_timing = timings.find(phys_op)->second;
+	if (int(operator_timing.executors_info.size()) <= id) {
+		operator_timing.executors_info.resize(id + 1);
+	}
+	operator_timing.executors_info[id] = make_unique<ExpressionExecutorInfo>(*expression_executor, name, id);
+	operator_timing.name = phys_op->GetName();
+}
+
+void QueryProfiler::Flush(OperatorProfiler &profiler) {
+	lock_guard<mutex> guard(flush_lock);
+	if (!IsEnabled() || !running) {
+		return;
+	}
+	for (auto &node : profiler.timings) {
+		auto entry = tree_map.find(node.first);
+		D_ASSERT(entry != tree_map.end());
+
+		entry->second->info.time += node.second.time;
+		entry->second->info.elements += node.second.elements;
+		if (!IsDetailedEnabled()) {
+			continue;
+		}
+		for (auto &info : node.second.executors_info) {
+			if (!info) {
+				continue;
+			}
+			auto info_id = info->id;
+			if (int(entry->second->info.executors_info.size()) <= info_id) {
+				entry->second->info.executors_info.resize(info_id + 1);
+			}
+			entry->second->info.executors_info[info_id] = move(info);
+		}
+	}
+	profiler.timings.clear();
+}
+
+static string DrawPadded(const string &str, idx_t width) {
+	if (str.size() > width) {
+		return str.substr(0, width);
+	} else {
+		width -= str.size();
+		int half_spaces = width / 2;
+		int extra_left_space = width % 2 != 0 ? 1 : 0;
+		return string(half_spaces + extra_left_space, ' ') + str + string(half_spaces, ' ');
+	}
+}
+
+static string RenderTitleCase(string str) {
+	str = StringUtil::Lower(str);
+	str[0] = toupper(str[0]);
+	for (idx_t i = 0; i < str.size(); i++) {
+		if (str[i] == '_') {
+			str[i] = ' ';
+			if (i + 1 < str.size()) {
+				str[i + 1] = toupper(str[i + 1]);
+			}
+		}
+	}
+	return str;
+}
+
+static string RenderTiming(double timing) {
+	string timing_s;
+	if (timing >= 1) {
+		timing_s = StringUtil::Format("%.2f", timing);
+	} else if (timing >= 0.1) {
+		timing_s = StringUtil::Format("%.3f", timing);
+	} else {
+		timing_s = StringUtil::Format("%.4f", timing);
+	}
+	return timing_s + "s";
+}
+
+string QueryProfiler::ToString(bool print_optimizer_output) const {
+	std::stringstream str;
+	ToStream(str, print_optimizer_output);
+	return str.str();
+}
+
+void QueryProfiler::ToStream(std::ostream &ss, bool print_optimizer_output) const {
+	if (!IsEnabled()) {
+		ss << "Query profiling is disabled. Call "
+		      "Connection::EnableProfiling() to enable profiling!";
+		return;
+	}
+	ss << "┌─────────────────────────────────────┐\n";
+	ss << "│┌───────────────────────────────────┐│\n";
+	ss << "││    Query Profiling Information    ││\n";
+	ss << "│└───────────────────────────────────┘│\n";
+	ss << "└─────────────────────────────────────┘\n";
+	ss << StringUtil::Replace(query, "\n", " ") + "\n";
+	if (query.empty()) {
+		return;
+	}
+
+	constexpr idx_t TOTAL_BOX_WIDTH = 39;
+	ss << "┌─────────────────────────────────────┐\n";
+	ss << "│┌───────────────────────────────────┐│\n";
+	string total_time = "Total Time: " + RenderTiming(main_query.Elapsed());
+	ss << "││" + DrawPadded(total_time, TOTAL_BOX_WIDTH - 4) + "││\n";
+	ss << "│└───────────────────────────────────┘│\n";
+	ss << "└─────────────────────────────────────┘\n";
+	// print phase timings
+	if (print_optimizer_output) {
+		bool has_previous_phase = false;
+		for (const auto &entry : GetOrderedPhaseTimings()) {
+			if (!StringUtil::Contains(entry.first, " > ")) {
+				// primary phase!
+				if (has_previous_phase) {
+					ss << "│└───────────────────────────────────┘│\n";
+					ss << "└─────────────────────────────────────┘\n";
+				}
+				ss << "┌─────────────────────────────────────┐\n";
+				ss << "│" +
+				          DrawPadded(RenderTitleCase(entry.first) + ": " + RenderTiming(entry.second),
+				                     TOTAL_BOX_WIDTH - 2) +
+				          "│\n";
+				ss << "│┌───────────────────────────────────┐│\n";
+				has_previous_phase = true;
+			} else {
+				string entry_name = StringUtil::Split(entry.first, " > ")[1];
+				ss << "││" +
+				          DrawPadded(RenderTitleCase(entry_name) + ": " + RenderTiming(entry.second),
+				                     TOTAL_BOX_WIDTH - 4) +
+				          "││\n";
+			}
+		}
+		if (has_previous_phase) {
+			ss << "│└───────────────────────────────────┘│\n";
+			ss << "└─────────────────────────────────────┘\n";
+		}
+	}
+	// render the main operator tree
+	if (root) {
+		Render(*root, ss);
+	}
+}
+
+static string JSONSanitize(const string &text) {
+	string result;
+	result.reserve(text.size());
+	for (idx_t i = 0; i < text.size(); i++) {
+		switch (text[i]) {
+		case '\b':
+			result += "\\b";
+			break;
+		case '\f':
+			result += "\\f";
+			break;
+		case '\n':
+			result += "\\n";
+			break;
+		case '\r':
+			result += "\\r";
+			break;
+		case '\t':
+			result += "\\t";
+			break;
+		case '"':
+			result += "\\\"";
+			break;
+		case '\\':
+			result += "\\\\";
+			break;
+		default:
+			result += text[i];
+			break;
+		}
+	}
+	return result;
+}
+
+// Print a row
+static void PrintRow(std::ostream &ss, const string &annotation, int id, const string &name, double time,
+                     int sample_counter, int tuple_counter, const string &extra_info, int depth) {
+	ss << string(depth * 3, ' ') << " {\n";
+	ss << string(depth * 3, ' ') << "   \"annotation\": \"" + JSONSanitize(annotation) + "\",\n";
+	ss << string(depth * 3, ' ') << "   \"id\": " + to_string(id) + ",\n";
+	ss << string(depth * 3, ' ') << "   \"name\": \"" + JSONSanitize(name) + "\",\n";
+#if defined(RDTSC)
+	ss << string(depth * 3, ' ') << "   \"timing\": \"NULL\" ,\n";
+	ss << string(depth * 3, ' ') << "   \"cycles_per_tuple\": " + StringUtil::Format("%.4f", time) + ",\n";
+#else
+	ss << string(depth * 3, ' ') << "   \"timing\":" + to_string(time) + ",\n";
+	ss << string(depth * 3, ' ') << "   \"cycles_per_tuple\": \"NULL\" ,\n";
+#endif
+	ss << string(depth * 3, ' ') << "   \"sample_size\": " << to_string(sample_counter) + ",\n";
+	ss << string(depth * 3, ' ') << "   \"input_size\": " << to_string(tuple_counter) + ",\n";
+	ss << string(depth * 3, ' ') << "   \"extra_info\": \"" << JSONSanitize(extra_info) + "\"\n";
+	ss << string(depth * 3, ' ') << " },\n";
+}
+
+static void ExtractFunctions(std::ostream &ss, ExpressionInfo &info, int &fun_id, int depth) {
+	if (info.hasfunction) {
+		D_ASSERT(info.sample_tuples_count != 0);
+		PrintRow(ss, "Function", fun_id++, info.function_name,
+		         int(info.function_time) / double(info.sample_tuples_count), info.sample_tuples_count,
+		         info.tuples_count, "", depth);
+	}
+	if (info.children.empty()) {
+		return;
+	}
+	// extract the children of this node
+	for (auto &child : info.children) {
+		ExtractFunctions(ss, *child, fun_id, depth);
+	}
+}
+
+static void ToJSONRecursive(QueryProfiler::TreeNode &node, std::ostream &ss, int depth = 1) {
+	ss << string(depth * 3, ' ') << " {\n";
+	ss << string(depth * 3, ' ') << "   \"name\": \"" + JSONSanitize(node.name) + "\",\n";
+	ss << string(depth * 3, ' ') << "   \"timing\":" + to_string(node.info.time) + ",\n";
+	ss << string(depth * 3, ' ') << "   \"cardinality\":" + to_string(node.info.elements) + ",\n";
+	ss << string(depth * 3, ' ') << "   \"extra_info\": \"" + JSONSanitize(node.extra_info) + "\",\n";
+	ss << string(depth * 3, ' ') << "   \"timings\": [";
+	int32_t function_counter = 1;
+	int32_t expression_counter = 1;
+	ss << "\n ";
+	for (auto &expr_executor : node.info.executors_info) {
+		// For each Expression tree
+		if (!expr_executor) {
+			continue;
+		}
+		for (auto &expr_timer : expr_executor->roots) {
+			D_ASSERT(expr_timer->sample_tuples_count != 0);
+			PrintRow(ss, "ExpressionRoot", expression_counter++, expr_timer->name,
+			         int(expr_timer->time) / double(expr_timer->sample_tuples_count), expr_timer->sample_tuples_count,
+			         expr_timer->tuples_count, expr_timer->extra_info, depth + 1);
+			// Extract all functions inside the tree
+			ExtractFunctions(ss, *expr_timer->root, function_counter, depth + 1);
+		}
+	}
+	ss.seekp(-2, ss.cur);
+	ss << "\n";
+	ss << string(depth * 3, ' ') << "   ],\n";
+	ss << string(depth * 3, ' ') << "   \"children\": [\n";
+	if (node.children.empty()) {
+		ss << string(depth * 3, ' ') << "   ]\n";
+	} else {
+		for (idx_t i = 0; i < node.children.size(); i++) {
+			if (i > 0) {
+				ss << ",\n";
+			}
+			ToJSONRecursive(*node.children[i], ss, depth + 1);
+		}
+		ss << string(depth * 3, ' ') << "   ]\n";
+	}
+	ss << string(depth * 3, ' ') << " }\n";
+}
+
+string QueryProfiler::ToJSON() const {
+	if (!IsEnabled()) {
+		return "{ \"result\": \"disabled\" }\n";
+	}
+	if (query.empty()) {
+		return "{ \"result\": \"empty\" }\n";
+	}
+	if (!root) {
+		return "{ \"result\": \"error\" }\n";
+	}
+	std::stringstream ss;
+	ss << "{\n";
+	ss << "   \"name\":  \"Query\", \n";
+	ss << "   \"result\": " + to_string(main_query.Elapsed()) + ",\n";
+	ss << "   \"timing\": " + to_string(main_query.Elapsed()) + ",\n";
+	ss << "   \"cardinality\": " + to_string(root->info.elements) + ",\n";
+	// JSON cannot have literal control characters in string literals
+	string extra_info = JSONSanitize(query);
+	ss << "   \"extra-info\": \"" + extra_info + "\", \n";
+	// print the phase timings
+	ss << "   \"timings\": [\n";
+	const auto &ordered_phase_timings = GetOrderedPhaseTimings();
+	for (idx_t i = 0; i < ordered_phase_timings.size(); i++) {
+		if (i > 0) {
+			ss << ",\n";
+		}
+		ss << "   {\n";
+		ss << "   \"annotation\": \"" + ordered_phase_timings[i].first + "\", \n";
+		ss << "   \"timing\": " + to_string(ordered_phase_timings[i].second) + "\n";
+		ss << "   }";
+	}
+	ss << "\n";
+	ss << "   ],\n";
+	// recursively print the physical operator tree
+	ss << "   \"children\": [\n";
+	ToJSONRecursive(*root, ss);
+	ss << "   ]\n";
+	ss << "}";
+	return ss.str();
+}
+
+void QueryProfiler::WriteToFile(const char *path, string &info) const {
+	ofstream out(path);
+	out << info;
+	out.close();
+	// throw an IO exception if it fails to write the file
+	if (out.fail()) {
+		throw IOException(strerror(errno));
+	}
+}
+
+unique_ptr<QueryProfiler::TreeNode> QueryProfiler::CreateTree(PhysicalOperator *root, idx_t depth) {
+	if (OperatorRequiresProfiling(root->type)) {
+		this->query_requires_profiling = true;
+	}
+	auto node = make_unique<QueryProfiler::TreeNode>();
+	node->type = root->type;
+	node->name = root->GetName();
+	node->extra_info = root->ParamsToString();
+	node->depth = depth;
+	tree_map[root] = node.get();
+	auto children = root->GetChildren();
+	for (auto &child : children) {
+		auto child_node = CreateTree(child, depth + 1);
+		node->children.push_back(move(child_node));
+	}
+	return node;
+}
+
+void QueryProfiler::Render(const QueryProfiler::TreeNode &node, std::ostream &ss) const {
+	TreeRenderer renderer;
+	if (IsDetailedEnabled()) {
+		renderer.EnableDetailed();
+	} else {
+		renderer.EnableStandard();
+	}
+	renderer.Render(node, ss);
+}
+
+void QueryProfiler::Print() {
+	Printer::Print(ToString());
+}
+
+vector<QueryProfiler::PhaseTimingItem> QueryProfiler::GetOrderedPhaseTimings() const {
+	vector<PhaseTimingItem> result;
+	// first sort the phases alphabetically
+	vector<string> phases;
+	for (auto &entry : phase_timings) {
+		phases.push_back(entry.first);
+	}
+	std::sort(phases.begin(), phases.end());
+	for (const auto &phase : phases) {
+		auto entry = phase_timings.find(phase);
+		D_ASSERT(entry != phase_timings.end());
+		result.emplace_back(entry->first, entry->second);
+	}
+	return result;
+}
+void QueryProfiler::Propagate(QueryProfiler &qp) {
+}
+
+void ExpressionInfo::ExtractExpressionsRecursive(unique_ptr<ExpressionState> &state) {
+	if (state->child_states.empty()) {
+		return;
+	}
+	// extract the children of this node
+	for (auto &child : state->child_states) {
+		auto expr_info = make_unique<ExpressionInfo>();
+		if (child->expr.expression_class == ExpressionClass::BOUND_FUNCTION) {
+			expr_info->hasfunction = true;
+			expr_info->function_name = ((BoundFunctionExpression &)child->expr).function.ToString();
+			expr_info->function_time = child->profiler.time;
+			expr_info->sample_tuples_count = child->profiler.sample_tuples_count;
+			expr_info->tuples_count = child->profiler.tuples_count;
+		}
+		expr_info->ExtractExpressionsRecursive(child);
+		children.push_back(move(expr_info));
+	}
+	return;
+}
+
+ExpressionExecutorInfo::ExpressionExecutorInfo(ExpressionExecutor &executor, const string &name, int id) : id(id) {
+	// Extract Expression Root Information from ExpressionExecutorStats
+	for (auto &state : executor.GetStates()) {
+		roots.push_back(make_unique<ExpressionRootInfo>(*state, name));
+	}
+}
+
+ExpressionRootInfo::ExpressionRootInfo(ExpressionExecutorState &state, string name)
+    : current_count(state.profiler.current_count), sample_count(state.profiler.sample_count),
+      sample_tuples_count(state.profiler.sample_tuples_count), tuples_count(state.profiler.tuples_count),
+      name(state.name), time(state.profiler.time) {
+	// Use the name of expression-tree as extra-info
+	extra_info = move(name);
+	auto expression_info_p = make_unique<ExpressionInfo>();
+	// Maybe root has a function
+	if (state.root_state->expr.expression_class == ExpressionClass::BOUND_FUNCTION) {
+		expression_info_p->hasfunction = true;
+		expression_info_p->function_name = ((BoundFunctionExpression &)state.root_state->expr).function.name;
+		expression_info_p->function_time = state.root_state->profiler.time;
+		expression_info_p->sample_tuples_count = state.root_state->profiler.sample_tuples_count;
+		expression_info_p->tuples_count = state.root_state->profiler.tuples_count;
+	}
+	expression_info_p->ExtractExpressionsRecursive(state.root_state);
+	root = move(expression_info_p);
+}
+} // namespace duckdb
+#include <list>
+
+
+
+
+
+
+namespace duckdb {
+
+BaseQueryResult::BaseQueryResult(QueryResultType type, StatementType statement_type, StatementProperties properties,
+                                 vector<LogicalType> types_p, vector<string> names_p)
+    : type(type), statement_type(statement_type), properties(properties), types(move(types_p)), names(move(names_p)),
+      success(true) {
+	D_ASSERT(types.size() == names.size());
+}
+
+BaseQueryResult::BaseQueryResult(QueryResultType type, string error) : type(type), success(false), error(move(error)) {
+}
+
+BaseQueryResult::~BaseQueryResult() {
+}
+
+bool BaseQueryResult::HasError() {
+	return !success;
+}
+const string &BaseQueryResult::GetError() {
+	return error;
+}
+idx_t BaseQueryResult::ColumnCount() {
+	return types.size();
+}
+
+QueryResult::QueryResult(QueryResultType type, StatementType statement_type, StatementProperties properties,
+                         vector<LogicalType> types_p, vector<string> names_p)
+    : BaseQueryResult(type, statement_type, properties, move(types_p), move(names_p)) {
+}
+
+QueryResult::QueryResult(QueryResultType type, string error) : BaseQueryResult(type, move(error)) {
+}
+
+QueryResult::~QueryResult() {
+}
+
+unique_ptr<DataChunk> QueryResult::Fetch() {
+	auto chunk = FetchRaw();
+	if (!chunk) {
+		return nullptr;
+	}
+	chunk->Normalify();
+	return chunk;
+}
+
+bool QueryResult::Equals(QueryResult &other) { // LCOV_EXCL_START
+	// first compare the success state of the results
+	if (success != other.success) {
+		return false;
+	}
+	if (!success) {
+		return error == other.error;
+	}
+	// compare names
+	if (names != other.names) {
+		return false;
+	}
+	// compare types
+	if (types != other.types) {
+		return false;
+	}
+	// now compare the actual values
+	// fetch chunks
+	while (true) {
+		auto lchunk = Fetch();
+		auto rchunk = other.Fetch();
+		if (!lchunk && !rchunk) {
+			return true;
+		}
+		if (!lchunk || !rchunk) {
+			return false;
+		}
+		if (lchunk->size() == 0 && rchunk->size() == 0) {
+			return true;
+		}
+		if (lchunk->size() != rchunk->size()) {
+			return false;
+		}
+		D_ASSERT(lchunk->ColumnCount() == rchunk->ColumnCount());
+		for (idx_t col = 0; col < rchunk->ColumnCount(); col++) {
+			for (idx_t row = 0; row < rchunk->size(); row++) {
+				auto lvalue = lchunk->GetValue(col, row);
+				auto rvalue = rchunk->GetValue(col, row);
+				if (lvalue.IsNull() && rvalue.IsNull()) {
+					continue;
+				}
+				if (lvalue != rvalue) {
+					return false;
+				}
+			}
+		}
+	}
+} // LCOV_EXCL_STOP
+
+void QueryResult::Print() {
+	Printer::Print(ToString());
+}
+
+string QueryResult::HeaderToString() {
+	string result;
+	for (auto &name : names) {
+		result += name + "\t";
+	}
+	result += "\n";
+	for (auto &type : types) {
+		result += type.ToString() + "\t";
+	}
+	result += "\n";
+	return result;
+}
+
+struct DuckDBArrowSchemaHolder {
+	// unused in children
+	vector<ArrowSchema> children;
+	// unused in children
+	vector<ArrowSchema *> children_ptrs;
+	//! used for nested structures
+	std::list<std::vector<ArrowSchema>> nested_children;
+	std::list<std::vector<ArrowSchema *>> nested_children_ptr;
+	//! This holds strings created to represent decimal types
+	vector<unique_ptr<char[]>> owned_type_names;
+};
+
+static void ReleaseDuckDBArrowSchema(ArrowSchema *schema) {
+	if (!schema || !schema->release) {
+		return;
+	}
+	schema->release = nullptr;
+	auto holder = static_cast<DuckDBArrowSchemaHolder *>(schema->private_data);
+	delete holder;
+}
+
+void InitializeChild(ArrowSchema &child, const string &name = "") {
+	//! Child is cleaned up by parent
+	child.private_data = nullptr;
+	child.release = ReleaseDuckDBArrowSchema;
+
+	//! Store the child schema
+	child.flags = ARROW_FLAG_NULLABLE;
+	child.name = name.c_str();
+	child.n_children = 0;
+	child.children = nullptr;
+	child.metadata = nullptr;
+	child.dictionary = nullptr;
+}
+void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
+                    string &config_timezone);
+
+void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
+                       string &config_timezone) {
+	child.format = "+m";
+	//! Map has one child which is a struct
+	child.n_children = 1;
+	root_holder.nested_children.emplace_back();
+	root_holder.nested_children.back().resize(1);
+	root_holder.nested_children_ptr.emplace_back();
+	root_holder.nested_children_ptr.back().push_back(&root_holder.nested_children.back()[0]);
+	InitializeChild(root_holder.nested_children.back()[0]);
+	child.children = &root_holder.nested_children_ptr.back()[0];
+	child.children[0]->name = "entries";
+	child_list_t<LogicalType> struct_child_types;
+	struct_child_types.push_back(std::make_pair("key", ListType::GetChildType(StructType::GetChildType(type, 0))));
+	struct_child_types.push_back(std::make_pair("value", ListType::GetChildType(StructType::GetChildType(type, 1))));
+	auto struct_type = LogicalType::STRUCT(move(struct_child_types));
+	SetArrowFormat(root_holder, *child.children[0], struct_type, config_timezone);
+}
+
+void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
+                    string &config_timezone) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		child.format = "b";
+		break;
+	case LogicalTypeId::TINYINT:
+		child.format = "c";
+		break;
+	case LogicalTypeId::SMALLINT:
+		child.format = "s";
+		break;
+	case LogicalTypeId::INTEGER:
+		child.format = "i";
+		break;
+	case LogicalTypeId::BIGINT:
+		child.format = "l";
+		break;
+	case LogicalTypeId::UTINYINT:
+		child.format = "C";
+		break;
+	case LogicalTypeId::USMALLINT:
+		child.format = "S";
+		break;
+	case LogicalTypeId::UINTEGER:
+		child.format = "I";
+		break;
+	case LogicalTypeId::UBIGINT:
+		child.format = "L";
+		break;
+	case LogicalTypeId::FLOAT:
+		child.format = "f";
+		break;
+	case LogicalTypeId::HUGEINT:
+		child.format = "d:38,0";
+		break;
+	case LogicalTypeId::DOUBLE:
+		child.format = "g";
+		break;
+	case LogicalTypeId::UUID:
+	case LogicalTypeId::JSON:
+	case LogicalTypeId::VARCHAR:
+		child.format = "u";
+		break;
+	case LogicalTypeId::DATE:
+		child.format = "tdD";
+		break;
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIME_TZ:
+		child.format = "ttu";
+		break;
+	case LogicalTypeId::TIMESTAMP:
+		child.format = "tsu:";
+		break;
+	case LogicalTypeId::TIMESTAMP_TZ: {
+		string format = "tsu:" + config_timezone;
+		unique_ptr<char[]> format_ptr = unique_ptr<char[]>(new char[format.size() + 1]);
+		for (size_t i = 0; i < format.size(); i++) {
+			format_ptr[i] = format[i];
+		}
+		format_ptr[format.size()] = '\0';
+		root_holder.owned_type_names.push_back(move(format_ptr));
+		child.format = root_holder.owned_type_names.back().get();
+		break;
+	}
+	case LogicalTypeId::TIMESTAMP_SEC:
+		child.format = "tss:";
+		break;
+	case LogicalTypeId::TIMESTAMP_NS:
+		child.format = "tsn:";
+		break;
+	case LogicalTypeId::TIMESTAMP_MS:
+		child.format = "tsm:";
+		break;
+	case LogicalTypeId::INTERVAL:
+		child.format = "tDm";
+		break;
+	case LogicalTypeId::DECIMAL: {
+		uint8_t width, scale;
+		type.GetDecimalProperties(width, scale);
+		string format = "d:" + to_string(width) + "," + to_string(scale);
+		unique_ptr<char[]> format_ptr = unique_ptr<char[]>(new char[format.size() + 1]);
+		for (size_t i = 0; i < format.size(); i++) {
+			format_ptr[i] = format[i];
+		}
+		format_ptr[format.size()] = '\0';
+		root_holder.owned_type_names.push_back(move(format_ptr));
+		child.format = root_holder.owned_type_names.back().get();
+		break;
+	}
+	case LogicalTypeId::SQLNULL: {
+		child.format = "n";
+		break;
+	}
+	case LogicalTypeId::BLOB: {
+		child.format = "z";
+		break;
+	}
+	case LogicalTypeId::LIST: {
+		child.format = "+l";
+		child.n_children = 1;
+		root_holder.nested_children.emplace_back();
+		root_holder.nested_children.back().resize(1);
+		root_holder.nested_children_ptr.emplace_back();
+		root_holder.nested_children_ptr.back().push_back(&root_holder.nested_children.back()[0]);
+		InitializeChild(root_holder.nested_children.back()[0]);
+		child.children = &root_holder.nested_children_ptr.back()[0];
+		child.children[0]->name = "l";
+		SetArrowFormat(root_holder, **child.children, ListType::GetChildType(type), config_timezone);
+		break;
+	}
+	case LogicalTypeId::STRUCT: {
+		child.format = "+s";
+		auto &child_types = StructType::GetChildTypes(type);
+		child.n_children = child_types.size();
+		root_holder.nested_children.emplace_back();
+		root_holder.nested_children.back().resize(child_types.size());
+		root_holder.nested_children_ptr.emplace_back();
+		root_holder.nested_children_ptr.back().resize(child_types.size());
+		for (idx_t type_idx = 0; type_idx < child_types.size(); type_idx++) {
+			root_holder.nested_children_ptr.back()[type_idx] = &root_holder.nested_children.back()[type_idx];
+		}
+		child.children = &root_holder.nested_children_ptr.back()[0];
+		for (size_t type_idx = 0; type_idx < child_types.size(); type_idx++) {
+
+			InitializeChild(*child.children[type_idx]);
+
+			auto &struct_col_name = child_types[type_idx].first;
+			unique_ptr<char[]> name_ptr = unique_ptr<char[]>(new char[struct_col_name.size() + 1]);
+			for (size_t i = 0; i < struct_col_name.size(); i++) {
+				name_ptr[i] = struct_col_name[i];
+			}
+			name_ptr[struct_col_name.size()] = '\0';
+			root_holder.owned_type_names.push_back(move(name_ptr));
+
+			child.children[type_idx]->name = root_holder.owned_type_names.back().get();
+			SetArrowFormat(root_holder, *child.children[type_idx], child_types[type_idx].second, config_timezone);
+		}
+		break;
+	}
+	case LogicalTypeId::MAP: {
+		SetArrowMapFormat(root_holder, child, type, config_timezone);
+		break;
+	}
+	case LogicalTypeId::ENUM: {
+		// TODO what do we do with pointer enums here?
+		switch (EnumType::GetPhysicalType(type)) {
+		case PhysicalType::UINT8:
+			child.format = "C";
+			break;
+		case PhysicalType::UINT16:
+			child.format = "S";
+			break;
+		case PhysicalType::UINT32:
+			child.format = "I";
+			break;
+		default:
+			throw InternalException("Unsupported Enum Internal Type");
+		}
+		root_holder.nested_children.emplace_back();
+		root_holder.nested_children.back().resize(1);
+		root_holder.nested_children_ptr.emplace_back();
+		root_holder.nested_children_ptr.back().push_back(&root_holder.nested_children.back()[0]);
+		InitializeChild(root_holder.nested_children.back()[0]);
+		child.dictionary = root_holder.nested_children_ptr.back()[0];
+		child.dictionary->format = "u";
+		break;
+	}
+	default:
+		throw InternalException("Unsupported Arrow type " + type.ToString());
+	}
+}
+
+void QueryResult::ToArrowSchema(ArrowSchema *out_schema, vector<LogicalType> &types, vector<string> &names,
+                                string &config_timezone) {
+	D_ASSERT(out_schema);
+	D_ASSERT(types.size() == names.size());
+	idx_t column_count = types.size();
+	// Allocate as unique_ptr first to cleanup properly on error
+	auto root_holder = make_unique<DuckDBArrowSchemaHolder>();
+
+	// Allocate the children
+	root_holder->children.resize(column_count);
+	root_holder->children_ptrs.resize(column_count, nullptr);
+	for (size_t i = 0; i < column_count; ++i) {
+		root_holder->children_ptrs[i] = &root_holder->children[i];
+	}
+	out_schema->children = root_holder->children_ptrs.data();
+	out_schema->n_children = column_count;
+
+	// Store the schema
+	out_schema->format = "+s"; // struct apparently
+	out_schema->flags = 0;
+	out_schema->metadata = nullptr;
+	out_schema->name = "duckdb_query_result";
+	out_schema->dictionary = nullptr;
+
+	// Configure all child schemas
+	for (idx_t col_idx = 0; col_idx < column_count; col_idx++) {
+
+		auto &child = root_holder->children[col_idx];
+		InitializeChild(child, names[col_idx]);
+		SetArrowFormat(*root_holder, child, types[col_idx], config_timezone);
+	}
+
+	// Release ownership to caller
+	out_schema->private_data = root_holder.release();
+	out_schema->release = ReleaseDuckDBArrowSchema;
+}
+
+string QueryResult::GetConfigTimezone(QueryResult &query_result) {
+	switch (query_result.type) {
+	case QueryResultType::MATERIALIZED_RESULT: {
+		auto actual_context = ((MaterializedQueryResult &)query_result).context.lock();
+		if (!actual_context) {
+			throw std::runtime_error("This connection is closed");
+		}
+		return ClientConfig::ExtractTimezoneFromConfig(actual_context->config);
+	}
+	case QueryResultType::STREAM_RESULT: {
+		return ClientConfig::ExtractTimezoneFromConfig(((StreamQueryResult &)query_result).context->config);
+	}
+	default:
+		throw std::runtime_error("Can't extract timezone configuration from query type ");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+AggregateRelation::AggregateRelation(shared_ptr<Relation> child_p,
+                                     vector<unique_ptr<ParsedExpression>> parsed_expressions)
+    : Relation(child_p->context, RelationType::AGGREGATE_RELATION), expressions(move(parsed_expressions)),
+      child(move(child_p)) {
+	// bind the expressions
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+AggregateRelation::AggregateRelation(shared_ptr<Relation> child_p,
+                                     vector<unique_ptr<ParsedExpression>> parsed_expressions,
+                                     vector<unique_ptr<ParsedExpression>> groups_p)
+    : Relation(child_p->context, RelationType::AGGREGATE_RELATION), expressions(move(parsed_expressions)),
+      groups(move(groups_p)), child(move(child_p)) {
+	// bind the expressions
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+unique_ptr<QueryNode> AggregateRelation::GetQueryNode() {
+	auto child_ptr = child.get();
+	while (child_ptr->InheritsColumnBindings()) {
+		child_ptr = child_ptr->ChildRelation();
+	}
+	unique_ptr<QueryNode> result;
+	if (child_ptr->type == RelationType::JOIN_RELATION) {
+		// child node is a join: push projection into the child query node
+		result = child->GetQueryNode();
+	} else {
+		// child node is not a join: create a new select node and push the child as a table reference
+		auto select = make_unique<SelectNode>();
+		select->from_table = child->GetTableRef();
+		result = move(select);
+	}
+	D_ASSERT(result->type == QueryNodeType::SELECT_NODE);
+	auto &select_node = (SelectNode &)*result;
+	if (!groups.empty()) {
+		// explicit groups provided: use standard handling
+		select_node.aggregate_handling = AggregateHandling::STANDARD_HANDLING;
+		select_node.groups.group_expressions.clear();
+		GroupingSet grouping_set;
+		for (idx_t i = 0; i < groups.size(); i++) {
+			select_node.groups.group_expressions.push_back(groups[i]->Copy());
+			grouping_set.insert(i);
+		}
+		select_node.groups.grouping_sets.push_back(move(grouping_set));
+	} else {
+		// no groups provided: automatically figure out groups (if any)
+		select_node.aggregate_handling = AggregateHandling::FORCE_AGGREGATES;
+	}
+	select_node.select_list.clear();
+	for (auto &expr : expressions) {
+		select_node.select_list.push_back(expr->Copy());
+	}
+	return result;
+}
+
+string AggregateRelation::GetAlias() {
+	return child->GetAlias();
+}
+
+const vector<ColumnDefinition> &AggregateRelation::Columns() {
+	return columns;
+}
+
+string AggregateRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Aggregate [";
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		if (i != 0) {
+			str += ", ";
+		}
+		str += expressions[i]->ToString();
+	}
+	str += "]\n";
+	return str + child->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+CreateTableRelation::CreateTableRelation(shared_ptr<Relation> child_p, string schema_name, string table_name)
+    : Relation(child_p->context, RelationType::CREATE_TABLE_RELATION), child(move(child_p)),
+      schema_name(move(schema_name)), table_name(move(table_name)) {
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+BoundStatement CreateTableRelation::Bind(Binder &binder) {
+	auto select = make_unique<SelectStatement>();
+	select->node = child->GetQueryNode();
+
+	CreateStatement stmt;
+	auto info = make_unique<CreateTableInfo>();
+	info->schema = schema_name;
+	info->table = table_name;
+	info->query = move(select);
+	info->on_conflict = OnCreateConflict::ERROR_ON_CONFLICT;
+	stmt.info = move(info);
+	return binder.Bind((SQLStatement &)stmt);
+}
+
+const vector<ColumnDefinition> &CreateTableRelation::Columns() {
+	return columns;
+}
+
+string CreateTableRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Create Table\n";
+	return str + child->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+CreateViewRelation::CreateViewRelation(shared_ptr<Relation> child_p, string view_name_p, bool replace_p,
+                                       bool temporary_p)
+    : Relation(child_p->context, RelationType::CREATE_VIEW_RELATION), child(move(child_p)),
+      view_name(move(view_name_p)), replace(replace_p), temporary(temporary_p) {
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+BoundStatement CreateViewRelation::Bind(Binder &binder) {
+	auto select = make_unique<SelectStatement>();
+	select->node = child->GetQueryNode();
+
+	CreateStatement stmt;
+	auto info = make_unique<CreateViewInfo>();
+	info->query = move(select);
+	info->view_name = view_name;
+	info->temporary = temporary;
+	info->schema = "";
+	info->on_conflict = replace ? OnCreateConflict::REPLACE_ON_CONFLICT : OnCreateConflict::ERROR_ON_CONFLICT;
+	stmt.info = move(info);
+	return binder.Bind((SQLStatement &)stmt);
+}
+
+const vector<ColumnDefinition> &CreateViewRelation::Columns() {
+	return columns;
+}
+
+string CreateViewRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Create View\n";
+	return str + child->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+CrossProductRelation::CrossProductRelation(shared_ptr<Relation> left_p, shared_ptr<Relation> right_p)
+    : Relation(left_p->context, RelationType::CROSS_PRODUCT_RELATION), left(move(left_p)), right(move(right_p)) {
+	if (left->context.GetContext() != right->context.GetContext()) {
+		throw Exception("Cannot combine LEFT and RIGHT relations of different connections!");
+	}
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+unique_ptr<QueryNode> CrossProductRelation::GetQueryNode() {
+	auto result = make_unique<SelectNode>();
+	result->select_list.push_back(make_unique<StarExpression>());
+	result->from_table = GetTableRef();
+	return move(result);
+}
+
+unique_ptr<TableRef> CrossProductRelation::GetTableRef() {
+	auto cross_product_ref = make_unique<CrossProductRef>();
+	cross_product_ref->left = left->GetTableRef();
+	cross_product_ref->right = right->GetTableRef();
+	return move(cross_product_ref);
+}
+
+const vector<ColumnDefinition> &CrossProductRelation::Columns() {
+	return this->columns;
+}
+
+string CrossProductRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth);
+	str = "Cross Product";
+	return str + "\n" + left->ToString(depth + 1) + right->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+DeleteRelation::DeleteRelation(ClientContextWrapper &context, unique_ptr<ParsedExpression> condition_p,
+                               string schema_name_p, string table_name_p)
+    : Relation(context, RelationType::DELETE_RELATION), condition(move(condition_p)), schema_name(move(schema_name_p)),
+      table_name(move(table_name_p)) {
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+BoundStatement DeleteRelation::Bind(Binder &binder) {
+	auto basetable = make_unique<BaseTableRef>();
+	basetable->schema_name = schema_name;
+	basetable->table_name = table_name;
+
+	DeleteStatement stmt;
+	stmt.condition = condition ? condition->Copy() : nullptr;
+	stmt.table = move(basetable);
+	return binder.Bind((SQLStatement &)stmt);
+}
+
+const vector<ColumnDefinition> &DeleteRelation::Columns() {
+	return columns;
+}
+
+string DeleteRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "DELETE FROM " + table_name;
+	if (condition) {
+		str += " WHERE " + condition->ToString();
+	}
+	return str;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+DistinctRelation::DistinctRelation(shared_ptr<Relation> child_p)
+    : Relation(child_p->context, RelationType::DISTINCT_RELATION), child(move(child_p)) {
+	vector<ColumnDefinition> dummy_columns;
+	context.GetContext()->TryBindRelation(*this, dummy_columns);
+}
+
+unique_ptr<QueryNode> DistinctRelation::GetQueryNode() {
+	auto child_node = child->GetQueryNode();
+	child_node->modifiers.push_back(make_unique<DistinctModifier>());
+	return child_node;
+}
+
+string DistinctRelation::GetAlias() {
+	return child->GetAlias();
+}
+
+const vector<ColumnDefinition> &DistinctRelation::Columns() {
+	return child->Columns();
+}
+
+string DistinctRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Distinct\n";
+	return str + child->ToString(depth + 1);
+	;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+ExplainRelation::ExplainRelation(shared_ptr<Relation> child_p)
+    : Relation(child_p->context, RelationType::EXPLAIN_RELATION), child(move(child_p)) {
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+BoundStatement ExplainRelation::Bind(Binder &binder) {
+	auto select = make_unique<SelectStatement>();
+	select->node = child->GetQueryNode();
+	ExplainStatement explain(move(select));
+	return binder.Bind((SQLStatement &)explain);
+}
+
+const vector<ColumnDefinition> &ExplainRelation::Columns() {
+	return columns;
+}
+
+string ExplainRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Explain\n";
+	return str + child->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+FilterRelation::FilterRelation(shared_ptr<Relation> child_p, unique_ptr<ParsedExpression> condition_p)
+    : Relation(child_p->context, RelationType::FILTER_RELATION), condition(move(condition_p)), child(move(child_p)) {
+	vector<ColumnDefinition> dummy_columns;
+	context.GetContext()->TryBindRelation(*this, dummy_columns);
+}
+
+unique_ptr<QueryNode> FilterRelation::GetQueryNode() {
+	auto child_ptr = child.get();
+	while (child_ptr->InheritsColumnBindings()) {
+		child_ptr = child_ptr->ChildRelation();
+	}
+	if (child_ptr->type == RelationType::JOIN_RELATION) {
+		// child node is a join: push filter into WHERE clause of select node
+		auto child_node = child->GetQueryNode();
+		D_ASSERT(child_node->type == QueryNodeType::SELECT_NODE);
+		auto &select_node = (SelectNode &)*child_node;
+		if (!select_node.where_clause) {
+			select_node.where_clause = condition->Copy();
+		} else {
+			select_node.where_clause = make_unique<ConjunctionExpression>(
+			    ExpressionType::CONJUNCTION_AND, move(select_node.where_clause), condition->Copy());
+		}
+		return child_node;
+	} else {
+		auto result = make_unique<SelectNode>();
+		result->select_list.push_back(make_unique<StarExpression>());
+		result->from_table = child->GetTableRef();
+		result->where_clause = condition->Copy();
+		return move(result);
+	}
+}
+
+string FilterRelation::GetAlias() {
+	return child->GetAlias();
+}
+
+const vector<ColumnDefinition> &FilterRelation::Columns() {
+	return child->Columns();
+}
+
+string FilterRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Filter [" + condition->ToString() + "]\n";
+	return str + child->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+InsertRelation::InsertRelation(shared_ptr<Relation> child_p, string schema_name, string table_name)
+    : Relation(child_p->context, RelationType::INSERT_RELATION), child(move(child_p)), schema_name(move(schema_name)),
+      table_name(move(table_name)) {
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+BoundStatement InsertRelation::Bind(Binder &binder) {
+	InsertStatement stmt;
+	auto select = make_unique<SelectStatement>();
+	select->node = child->GetQueryNode();
+
+	stmt.schema = schema_name;
+	stmt.table = table_name;
+	stmt.select_statement = move(select);
+	return binder.Bind((SQLStatement &)stmt);
+}
+
+const vector<ColumnDefinition> &InsertRelation::Columns() {
+	return columns;
+}
+
+string InsertRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Insert\n";
+	return str + child->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+JoinRelation::JoinRelation(shared_ptr<Relation> left_p, shared_ptr<Relation> right_p,
+                           unique_ptr<ParsedExpression> condition_p, JoinType type)
+    : Relation(left_p->context, RelationType::JOIN_RELATION), left(move(left_p)), right(move(right_p)),
+      condition(move(condition_p)), join_type(type) {
+	if (left->context.GetContext() != right->context.GetContext()) {
+		throw Exception("Cannot combine LEFT and RIGHT relations of different connections!");
+	}
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+JoinRelation::JoinRelation(shared_ptr<Relation> left_p, shared_ptr<Relation> right_p, vector<string> using_columns_p,
+                           JoinType type)
+    : Relation(left_p->context, RelationType::JOIN_RELATION), left(move(left_p)), right(move(right_p)),
+      using_columns(move(using_columns_p)), join_type(type) {
+	if (left->context.GetContext() != right->context.GetContext()) {
+		throw Exception("Cannot combine LEFT and RIGHT relations of different connections!");
+	}
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+unique_ptr<QueryNode> JoinRelation::GetQueryNode() {
+	auto result = make_unique<SelectNode>();
+	result->select_list.push_back(make_unique<StarExpression>());
+	result->from_table = GetTableRef();
+	return move(result);
+}
+
+unique_ptr<TableRef> JoinRelation::GetTableRef() {
+	auto join_ref = make_unique<JoinRef>();
+	join_ref->left = left->GetTableRef();
+	join_ref->right = right->GetTableRef();
+	if (condition) {
+		join_ref->condition = condition->Copy();
+	}
+	join_ref->using_columns = using_columns;
+	join_ref->type = join_type;
+	return move(join_ref);
+}
+
+const vector<ColumnDefinition> &JoinRelation::Columns() {
+	return this->columns;
+}
+
+string JoinRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth);
+	str += "Join " + JoinTypeToString(join_type);
+	if (condition) {
+		str += " " + condition->GetName();
+	}
+
+	return str + "\n" + left->ToString(depth + 1) + "\n" + right->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+LimitRelation::LimitRelation(shared_ptr<Relation> child_p, int64_t limit, int64_t offset)
+    : Relation(child_p->context, RelationType::PROJECTION_RELATION), limit(limit), offset(offset),
+      child(move(child_p)) {
+}
+
+unique_ptr<QueryNode> LimitRelation::GetQueryNode() {
+	auto child_node = child->GetQueryNode();
+	auto limit_node = make_unique<LimitModifier>();
+	if (limit >= 0) {
+		limit_node->limit = make_unique<ConstantExpression>(Value::BIGINT(limit));
+	}
+	if (offset > 0) {
+		limit_node->offset = make_unique<ConstantExpression>(Value::BIGINT(offset));
+	}
+
+	child_node->modifiers.push_back(move(limit_node));
+	return child_node;
+}
+
+string LimitRelation::GetAlias() {
+	return child->GetAlias();
+}
+
+const vector<ColumnDefinition> &LimitRelation::Columns() {
+	return child->Columns();
+}
+
+string LimitRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Limit " + to_string(limit);
+	if (offset > 0) {
+		str += " Offset " + to_string(offset);
+	}
+	str += "\n";
+	return str + child->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+OrderRelation::OrderRelation(shared_ptr<Relation> child_p, vector<OrderByNode> orders)
+    : Relation(child_p->context, RelationType::ORDER_RELATION), orders(move(orders)), child(move(child_p)) {
+	// bind the expressions
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+unique_ptr<QueryNode> OrderRelation::GetQueryNode() {
+	auto select = make_unique<SelectNode>();
+	select->from_table = child->GetTableRef();
+	select->select_list.push_back(make_unique<StarExpression>());
+	auto order_node = make_unique<OrderModifier>();
+	for (idx_t i = 0; i < orders.size(); i++) {
+		order_node->orders.emplace_back(orders[i].type, orders[i].null_order, orders[i].expression->Copy());
+	}
+	select->modifiers.push_back(move(order_node));
+	return move(select);
+}
+
+string OrderRelation::GetAlias() {
+	return child->GetAlias();
+}
+
+const vector<ColumnDefinition> &OrderRelation::Columns() {
+	return columns;
+}
+
+string OrderRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Order [";
+	for (idx_t i = 0; i < orders.size(); i++) {
+		if (i != 0) {
+			str += ", ";
+		}
+		str += orders[i].expression->ToString() + (orders[i].type == OrderType::ASCENDING ? " ASC" : " DESC");
+	}
+	str += "]\n";
+	return str + child->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+ProjectionRelation::ProjectionRelation(shared_ptr<Relation> child_p,
+                                       vector<unique_ptr<ParsedExpression>> parsed_expressions, vector<string> aliases)
+    : Relation(child_p->context, RelationType::PROJECTION_RELATION), expressions(move(parsed_expressions)),
+      child(move(child_p)) {
+	if (!aliases.empty()) {
+		if (aliases.size() != expressions.size()) {
+			throw ParserException("Aliases list length must match expression list length!");
+		}
+		for (idx_t i = 0; i < aliases.size(); i++) {
+			expressions[i]->alias = aliases[i];
+		}
+	}
+	// bind the expressions
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+unique_ptr<QueryNode> ProjectionRelation::GetQueryNode() {
+	auto child_ptr = child.get();
+	while (child_ptr->InheritsColumnBindings()) {
+		child_ptr = child_ptr->ChildRelation();
+	}
+	unique_ptr<QueryNode> result;
+	if (child_ptr->type == RelationType::JOIN_RELATION) {
+		// child node is a join: push projection into the child query node
+		result = child->GetQueryNode();
+	} else {
+		// child node is not a join: create a new select node and push the child as a table reference
+		auto select = make_unique<SelectNode>();
+		select->from_table = child->GetTableRef();
+		result = move(select);
+	}
+	D_ASSERT(result->type == QueryNodeType::SELECT_NODE);
+	auto &select_node = (SelectNode &)*result;
+	select_node.aggregate_handling = AggregateHandling::NO_AGGREGATES_ALLOWED;
+	select_node.select_list.clear();
+	for (auto &expr : expressions) {
+		select_node.select_list.push_back(expr->Copy());
+	}
+	return result;
+}
+
+string ProjectionRelation::GetAlias() {
+	return child->GetAlias();
+}
+
+const vector<ColumnDefinition> &ProjectionRelation::Columns() {
+	return columns;
+}
+
+string ProjectionRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Projection [";
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		if (i != 0) {
+			str += ", ";
+		}
+		str += expressions[i]->ToString() + " as " + expressions[i]->alias;
+	}
+	str += "]\n";
+	return str + child->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+QueryRelation::QueryRelation(const std::shared_ptr<ClientContext> &context, unique_ptr<SelectStatement> select_stmt_p,
+                             string alias_p)
+    : Relation(context, RelationType::QUERY_RELATION), select_stmt(move(select_stmt_p)), alias(move(alias_p)) {
+	context->TryBindRelation(*this, this->columns);
+}
+
+QueryRelation::~QueryRelation() {
+}
+
+unique_ptr<SelectStatement> QueryRelation::ParseStatement(ClientContext &context, const string &query,
+                                                          const string &error) {
+	Parser parser(context.GetParserOptions());
+	parser.ParseQuery(query);
+	if (parser.statements.size() != 1) {
+		throw ParserException(error);
+	}
+	if (parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
+		throw ParserException(error);
+	}
+	return unique_ptr_cast<SQLStatement, SelectStatement>(move(parser.statements[0]));
+}
+
+unique_ptr<SelectStatement> QueryRelation::GetSelectStatement() {
+	return unique_ptr_cast<SQLStatement, SelectStatement>(select_stmt->Copy());
+}
+
+unique_ptr<QueryNode> QueryRelation::GetQueryNode() {
+	auto select = GetSelectStatement();
+	return move(select->node);
+}
+
+unique_ptr<TableRef> QueryRelation::GetTableRef() {
+	auto subquery_ref = make_unique<SubqueryRef>(GetSelectStatement(), GetAlias());
+	return move(subquery_ref);
+}
+
+string QueryRelation::GetAlias() {
+	return alias;
+}
+
+const vector<ColumnDefinition> &QueryRelation::Columns() {
+	return columns;
+}
+
+string QueryRelation::ToString(idx_t depth) {
+	return RenderWhitespace(depth) + "Subquery";
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+ReadCSVRelation::ReadCSVRelation(const std::shared_ptr<ClientContext> &context, string csv_file_p,
+                                 vector<ColumnDefinition> columns_p, bool auto_detect, string alias_p)
+    : Relation(context, RelationType::READ_CSV_RELATION), csv_file(move(csv_file_p)), auto_detect(auto_detect),
+      alias(move(alias_p)), columns(move(columns_p)) {
+	if (alias.empty()) {
+		alias = StringUtil::Split(csv_file, ".")[0];
+	}
+}
+
+unique_ptr<QueryNode> ReadCSVRelation::GetQueryNode() {
+	auto result = make_unique<SelectNode>();
+	result->select_list.push_back(make_unique<StarExpression>());
+	result->from_table = GetTableRef();
+	return move(result);
+}
+
+unique_ptr<TableRef> ReadCSVRelation::GetTableRef() {
+	auto table_ref = make_unique<TableFunctionRef>();
+	table_ref->alias = alias;
+	vector<unique_ptr<ParsedExpression>> children;
+	// CSV file
+	children.push_back(make_unique<ConstantExpression>(Value(csv_file)));
+	if (!auto_detect) {
+		// parameters
+		child_list_t<Value> column_names;
+		for (idx_t i = 0; i < columns.size(); i++) {
+			column_names.push_back(make_pair(columns[i].Name(), Value(columns[i].Type().ToString())));
+		}
+		auto colnames = make_unique<ConstantExpression>(Value::STRUCT(move(column_names)));
+		children.push_back(make_unique<ComparisonExpression>(
+		    ExpressionType::COMPARE_EQUAL, make_unique<ColumnRefExpression>("columns"), move(colnames)));
+	} else {
+		children.push_back(make_unique<ComparisonExpression>(ExpressionType::COMPARE_EQUAL,
+		                                                     make_unique<ColumnRefExpression>("auto_detect"),
+		                                                     make_unique<ConstantExpression>(Value::BOOLEAN(true))));
+	}
+	table_ref->function = make_unique<FunctionExpression>("read_csv", move(children));
+	return move(table_ref);
+}
+
+string ReadCSVRelation::GetAlias() {
+	return alias;
+}
+
+const vector<ColumnDefinition> &ReadCSVRelation::Columns() {
+	return columns;
+}
+
+string ReadCSVRelation::ToString(idx_t depth) {
+	return RenderWhitespace(depth) + "Read CSV [" + csv_file + "]";
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+SetOpRelation::SetOpRelation(shared_ptr<Relation> left_p, shared_ptr<Relation> right_p, SetOperationType setop_type_p)
+    : Relation(left_p->context, RelationType::SET_OPERATION_RELATION), left(move(left_p)), right(move(right_p)),
+      setop_type(setop_type_p) {
+	if (left->context.GetContext() != right->context.GetContext()) {
+		throw Exception("Cannot combine LEFT and RIGHT relations of different connections!");
+	}
+	vector<ColumnDefinition> dummy_columns;
+	context.GetContext()->TryBindRelation(*this, dummy_columns);
+}
+
+unique_ptr<QueryNode> SetOpRelation::GetQueryNode() {
+	auto result = make_unique<SetOperationNode>();
+	result->left = left->GetQueryNode();
+	result->right = right->GetQueryNode();
+	result->setop_type = setop_type;
+	return move(result);
+}
+
+string SetOpRelation::GetAlias() {
+	return left->GetAlias();
+}
+
+const vector<ColumnDefinition> &SetOpRelation::Columns() {
+	return left->Columns();
+}
+
+string SetOpRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth);
+	switch (setop_type) {
+	case SetOperationType::UNION:
+		str += "Union";
+		break;
+	case SetOperationType::EXCEPT:
+		str += "Except";
+		break;
+	case SetOperationType::INTERSECT:
+		str += "Intersect";
+		break;
+	default:
+		throw InternalException("Unknown setop type");
+	}
+	return str + "\n" + left->ToString(depth + 1) + right->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+SubqueryRelation::SubqueryRelation(shared_ptr<Relation> child_p, string alias_p)
+    : Relation(child_p->context, RelationType::SUBQUERY_RELATION), child(move(child_p)), alias(move(alias_p)) {
+	vector<ColumnDefinition> dummy_columns;
+	context.GetContext()->TryBindRelation(*this, dummy_columns);
+}
+
+unique_ptr<QueryNode> SubqueryRelation::GetQueryNode() {
+	return child->GetQueryNode();
+}
+
+string SubqueryRelation::GetAlias() {
+	return alias;
+}
+
+const vector<ColumnDefinition> &SubqueryRelation::Columns() {
+	return child->Columns();
+}
+
+string SubqueryRelation::ToString(idx_t depth) {
+	return child->ToString(depth);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+TableFunctionRelation::TableFunctionRelation(const std::shared_ptr<ClientContext> &context, string name_p,
+                                             vector<Value> parameters_p, named_parameter_map_t named_parameters,
+                                             shared_ptr<Relation> input_relation_p)
+    : Relation(context, RelationType::TABLE_FUNCTION_RELATION), name(move(name_p)), parameters(move(parameters_p)),
+      named_parameters(move(named_parameters)), input_relation(move(input_relation_p)) {
+	context->TryBindRelation(*this, this->columns);
+}
+TableFunctionRelation::TableFunctionRelation(const std::shared_ptr<ClientContext> &context, string name_p,
+                                             vector<Value> parameters_p,
+
+                                             shared_ptr<Relation> input_relation_p)
+    : Relation(context, RelationType::TABLE_FUNCTION_RELATION), name(move(name_p)), parameters(move(parameters_p)),
+      input_relation(move(input_relation_p)) {
+	context->TryBindRelation(*this, this->columns);
+}
+
+unique_ptr<QueryNode> TableFunctionRelation::GetQueryNode() {
+	auto result = make_unique<SelectNode>();
+	result->select_list.push_back(make_unique<StarExpression>());
+	result->from_table = GetTableRef();
+	return move(result);
+}
+
+unique_ptr<TableRef> TableFunctionRelation::GetTableRef() {
+	vector<unique_ptr<ParsedExpression>> children;
+	if (input_relation) { // input relation becomes first parameter if present, always
+		auto subquery = make_unique<SubqueryExpression>();
+		subquery->subquery = make_unique<SelectStatement>();
+		subquery->subquery->node = input_relation->GetQueryNode();
+		subquery->subquery_type = SubqueryType::SCALAR;
+		children.push_back(move(subquery));
+	}
+	for (auto &parameter : parameters) {
+		children.push_back(make_unique<ConstantExpression>(parameter));
+	}
+
+	for (auto &parameter : named_parameters) {
+		// Hackity-hack some comparisons with column refs
+		// This is all but pretty, basically the named parameter is the column, the table is empty because that's what
+		// the function binder likes
+		auto column_ref = make_unique<ColumnRefExpression>(parameter.first);
+		auto constant_value = make_unique<ConstantExpression>(parameter.second);
+		auto comparison =
+		    make_unique<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, move(column_ref), move(constant_value));
+		children.push_back(move(comparison));
+	}
+
+	auto table_function = make_unique<TableFunctionRef>();
+	auto function = make_unique<FunctionExpression>(name, move(children));
+	table_function->function = move(function);
+	return move(table_function);
+}
+
+string TableFunctionRelation::GetAlias() {
+	return name;
+}
+
+const vector<ColumnDefinition> &TableFunctionRelation::Columns() {
+	return columns;
+}
+
+string TableFunctionRelation::ToString(idx_t depth) {
+	string function_call = name + "(";
+	for (idx_t i = 0; i < parameters.size(); i++) {
+		if (i > 0) {
+			function_call += ", ";
+		}
+		function_call += parameters[i].ToString();
+	}
+	function_call += ")";
+	return RenderWhitespace(depth) + function_call;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+TableRelation::TableRelation(const std::shared_ptr<ClientContext> &context, unique_ptr<TableDescription> description)
+    : Relation(context, RelationType::TABLE_RELATION), description(move(description)) {
+}
+
+unique_ptr<QueryNode> TableRelation::GetQueryNode() {
+	auto result = make_unique<SelectNode>();
+	result->select_list.push_back(make_unique<StarExpression>());
+	result->from_table = GetTableRef();
+	return move(result);
+}
+
+unique_ptr<TableRef> TableRelation::GetTableRef() {
+	auto table_ref = make_unique<BaseTableRef>();
+	table_ref->schema_name = description->schema;
+	table_ref->table_name = description->table;
+	return move(table_ref);
+}
+
+string TableRelation::GetAlias() {
+	return description->table;
+}
+
+const vector<ColumnDefinition> &TableRelation::Columns() {
+	return description->columns;
+}
+
+string TableRelation::ToString(idx_t depth) {
+	return RenderWhitespace(depth) + "Scan Table [" + description->table + "]";
+}
+
+static unique_ptr<ParsedExpression> ParseCondition(ClientContext &context, const string &condition) {
+	if (!condition.empty()) {
+		auto expression_list = Parser::ParseExpressionList(condition, context.GetParserOptions());
+		if (expression_list.size() != 1) {
+			throw ParserException("Expected a single expression as filter condition");
+		}
+		return move(expression_list[0]);
+	} else {
+		return nullptr;
+	}
+}
+
+void TableRelation::Update(const string &update_list, const string &condition) {
+	vector<string> update_columns;
+	vector<unique_ptr<ParsedExpression>> expressions;
+	auto cond = ParseCondition(*context.GetContext(), condition);
+	Parser::ParseUpdateList(update_list, update_columns, expressions, context.GetContext()->GetParserOptions());
+	auto update = make_shared<UpdateRelation>(context, move(cond), description->schema, description->table,
+	                                          move(update_columns), move(expressions));
+	update->Execute();
+}
+
+void TableRelation::Delete(const string &condition) {
+	auto cond = ParseCondition(*context.GetContext(), condition);
+	auto del = make_shared<DeleteRelation>(context, move(cond), description->schema, description->table);
+	del->Execute();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+UpdateRelation::UpdateRelation(ClientContextWrapper &context, unique_ptr<ParsedExpression> condition_p,
+                               string schema_name_p, string table_name_p, vector<string> update_columns_p,
+                               vector<unique_ptr<ParsedExpression>> expressions_p)
+    : Relation(context, RelationType::UPDATE_RELATION), condition(move(condition_p)), schema_name(move(schema_name_p)),
+      table_name(move(table_name_p)), update_columns(move(update_columns_p)), expressions(move(expressions_p)) {
+	D_ASSERT(update_columns.size() == expressions.size());
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+BoundStatement UpdateRelation::Bind(Binder &binder) {
+	auto basetable = make_unique<BaseTableRef>();
+	basetable->schema_name = schema_name;
+	basetable->table_name = table_name;
+
+	UpdateStatement stmt;
+	stmt.condition = condition ? condition->Copy() : nullptr;
+	stmt.table = move(basetable);
+	stmt.columns = update_columns;
+	for (auto &expr : expressions) {
+		stmt.expressions.push_back(expr->Copy());
+	}
+	return binder.Bind((SQLStatement &)stmt);
+}
+
+const vector<ColumnDefinition> &UpdateRelation::Columns() {
+	return columns;
+}
+
+string UpdateRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "UPDATE " + table_name + " SET\n";
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		str += update_columns[i] + " = " + expressions[i]->ToString() + "\n";
+	}
+	if (condition) {
+		str += "WHERE " + condition->ToString() + "\n";
+	}
+	return str;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+ValueRelation::ValueRelation(const std::shared_ptr<ClientContext> &context, const vector<vector<Value>> &values,
+                             vector<string> names_p, string alias_p)
+    : Relation(context, RelationType::VALUE_LIST_RELATION), names(move(names_p)), alias(move(alias_p)) {
+	// create constant expressions for the values
+	for (idx_t row_idx = 0; row_idx < values.size(); row_idx++) {
+		auto &list = values[row_idx];
+		vector<unique_ptr<ParsedExpression>> expressions;
+		for (idx_t col_idx = 0; col_idx < list.size(); col_idx++) {
+			expressions.push_back(make_unique<ConstantExpression>(list[col_idx]));
+		}
+		this->expressions.push_back(move(expressions));
+	}
+	context->TryBindRelation(*this, this->columns);
+}
+
+ValueRelation::ValueRelation(const std::shared_ptr<ClientContext> &context, const string &values_list,
+                             vector<string> names_p, string alias_p)
+    : Relation(context, RelationType::VALUE_LIST_RELATION), names(move(names_p)), alias(move(alias_p)) {
+	this->expressions = Parser::ParseValuesList(values_list, context->GetParserOptions());
+	context->TryBindRelation(*this, this->columns);
+}
+
+unique_ptr<QueryNode> ValueRelation::GetQueryNode() {
+	auto result = make_unique<SelectNode>();
+	result->select_list.push_back(make_unique<StarExpression>());
+	result->from_table = GetTableRef();
+	return move(result);
+}
+
+unique_ptr<TableRef> ValueRelation::GetTableRef() {
+	auto table_ref = make_unique<ExpressionListRef>();
+	// set the expected types/names
+	if (columns.empty()) {
+		// no columns yet: only set up names
+		for (idx_t i = 0; i < names.size(); i++) {
+			table_ref->expected_names.push_back(names[i]);
+		}
+	} else {
+		for (idx_t i = 0; i < columns.size(); i++) {
+			table_ref->expected_names.push_back(columns[i].Name());
+			table_ref->expected_types.push_back(columns[i].Type());
+			D_ASSERT(names.size() == 0 || columns[i].Name() == names[i]);
+		}
+	}
+	// copy the expressions
+	for (auto &expr_list : expressions) {
+		vector<unique_ptr<ParsedExpression>> copied_list;
+		copied_list.reserve(expr_list.size());
+		for (auto &expr : expr_list) {
+			copied_list.push_back(expr->Copy());
+		}
+		table_ref->values.push_back(move(copied_list));
+	}
+	table_ref->alias = GetAlias();
+	return move(table_ref);
+}
+
+string ValueRelation::GetAlias() {
+	return alias;
+}
+
+const vector<ColumnDefinition> &ValueRelation::Columns() {
+	return columns;
+}
+
+string ValueRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Values ";
+	for (idx_t row_idx = 0; row_idx < expressions.size(); row_idx++) {
+		auto &list = expressions[row_idx];
+		str += row_idx > 0 ? ", (" : "(";
+		for (idx_t col_idx = 0; col_idx < list.size(); col_idx++) {
+			str += col_idx > 0 ? ", " : "";
+			str += list[col_idx]->ToString();
+		}
+		str += ")";
+	}
+	str += "\n";
+	return str;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+ViewRelation::ViewRelation(const std::shared_ptr<ClientContext> &context, string schema_name_p, string view_name_p)
+    : Relation(context, RelationType::VIEW_RELATION), schema_name(move(schema_name_p)), view_name(move(view_name_p)) {
+	context->TryBindRelation(*this, this->columns);
+}
+
+unique_ptr<QueryNode> ViewRelation::GetQueryNode() {
+	auto result = make_unique<SelectNode>();
+	result->select_list.push_back(make_unique<StarExpression>());
+	result->from_table = GetTableRef();
+	return move(result);
+}
+
+unique_ptr<TableRef> ViewRelation::GetTableRef() {
+	auto table_ref = make_unique<BaseTableRef>();
+	table_ref->schema_name = schema_name;
+	table_ref->table_name = view_name;
+	return move(table_ref);
+}
+
+string ViewRelation::GetAlias() {
+	return view_name;
+}
+
+const vector<ColumnDefinition> &ViewRelation::Columns() {
+	return columns;
+}
+
+string ViewRelation::ToString(idx_t depth) {
+	return RenderWhitespace(depth) + "View [" + view_name + "]";
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+WriteCSVRelation::WriteCSVRelation(shared_ptr<Relation> child_p, string csv_file_p)
+    : Relation(child_p->context, RelationType::WRITE_CSV_RELATION), child(move(child_p)), csv_file(move(csv_file_p)) {
+	context.GetContext()->TryBindRelation(*this, this->columns);
+}
+
+BoundStatement WriteCSVRelation::Bind(Binder &binder) {
+	CopyStatement copy;
+	copy.select_statement = child->GetQueryNode();
+	auto info = make_unique<CopyInfo>();
+	info->is_from = false;
+	info->file_path = csv_file;
+	info->format = "csv";
+	copy.info = move(info);
+	return binder.Bind((SQLStatement &)copy);
+}
+
+const vector<ColumnDefinition> &WriteCSVRelation::Columns() {
+	return columns;
+}
+
+string WriteCSVRelation::ToString(idx_t depth) {
+	string str = RenderWhitespace(depth) + "Write To CSV [" + csv_file + "]\n";
+	return str + child->ToString(depth + 1);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+shared_ptr<Relation> Relation::Project(const string &select_list) {
+	return Project(select_list, vector<string>());
+}
+
+shared_ptr<Relation> Relation::Project(const string &expression, const string &alias) {
+	return Project(expression, vector<string>({alias}));
+}
+
+shared_ptr<Relation> Relation::Project(const string &select_list, const vector<string> &aliases) {
+	auto expressions = Parser::ParseExpressionList(select_list, context.GetContext()->GetParserOptions());
+	return make_shared<ProjectionRelation>(shared_from_this(), move(expressions), aliases);
+}
+
+shared_ptr<Relation> Relation::Project(const vector<string> &expressions) {
+	vector<string> aliases;
+	return Project(expressions, aliases);
+}
+
+static vector<unique_ptr<ParsedExpression>> StringListToExpressionList(ClientContext &context,
+                                                                       const vector<string> &expressions) {
+	if (expressions.empty()) {
+		throw ParserException("Zero expressions provided");
+	}
+	vector<unique_ptr<ParsedExpression>> result_list;
+	for (auto &expr : expressions) {
+		auto expression_list = Parser::ParseExpressionList(expr, context.GetParserOptions());
+		if (expression_list.size() != 1) {
+			throw ParserException("Expected a single expression in the expression list");
+		}
+		result_list.push_back(move(expression_list[0]));
+	}
+	return result_list;
+}
+
+shared_ptr<Relation> Relation::Project(const vector<string> &expressions, const vector<string> &aliases) {
+	auto result_list = StringListToExpressionList(*context.GetContext(), expressions);
+	return make_shared<ProjectionRelation>(shared_from_this(), move(result_list), aliases);
+}
+
+shared_ptr<Relation> Relation::Filter(const string &expression) {
+	auto expression_list = Parser::ParseExpressionList(expression, context.GetContext()->GetParserOptions());
+	if (expression_list.size() != 1) {
+		throw ParserException("Expected a single expression as filter condition");
+	}
+	return make_shared<FilterRelation>(shared_from_this(), move(expression_list[0]));
+}
+
+shared_ptr<Relation> Relation::Filter(const vector<string> &expressions) {
+	// if there are multiple expressions, we AND them together
+	auto expression_list = StringListToExpressionList(*context.GetContext(), expressions);
+	D_ASSERT(!expression_list.empty());
+
+	auto expr = move(expression_list[0]);
+	for (idx_t i = 1; i < expression_list.size(); i++) {
+		expr =
+		    make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_AND, move(expr), move(expression_list[i]));
+	}
+	return make_shared<FilterRelation>(shared_from_this(), move(expr));
+}
+
+shared_ptr<Relation> Relation::Limit(int64_t limit, int64_t offset) {
+	return make_shared<LimitRelation>(shared_from_this(), limit, offset);
+}
+
+shared_ptr<Relation> Relation::Order(const string &expression) {
+	auto order_list = Parser::ParseOrderList(expression, context.GetContext()->GetParserOptions());
+	return make_shared<OrderRelation>(shared_from_this(), move(order_list));
+}
+
+shared_ptr<Relation> Relation::Order(const vector<string> &expressions) {
+	if (expressions.empty()) {
+		throw ParserException("Zero ORDER BY expressions provided");
+	}
+	vector<OrderByNode> order_list;
+	for (auto &expression : expressions) {
+		auto inner_list = Parser::ParseOrderList(expression, context.GetContext()->GetParserOptions());
+		if (inner_list.size() != 1) {
+			throw ParserException("Expected a single ORDER BY expression in the expression list");
+		}
+		order_list.push_back(move(inner_list[0]));
+	}
+	return make_shared<OrderRelation>(shared_from_this(), move(order_list));
+}
+
+shared_ptr<Relation> Relation::Join(const shared_ptr<Relation> &other, const string &condition, JoinType type) {
+	auto expression_list = Parser::ParseExpressionList(condition, context.GetContext()->GetParserOptions());
+	D_ASSERT(!expression_list.empty());
+
+	if (expression_list.size() > 1 || expression_list[0]->type == ExpressionType::COLUMN_REF) {
+		// multiple columns or single column ref: the condition is a USING list
+		vector<string> using_columns;
+		for (auto &expr : expression_list) {
+			if (expr->type != ExpressionType::COLUMN_REF) {
+				throw ParserException("Expected a single expression as join condition");
+			}
+			auto &colref = (ColumnRefExpression &)*expr;
+			if (colref.IsQualified()) {
+				throw ParserException("Expected unqualified column for column in USING clause");
+			}
+			using_columns.push_back(colref.column_names[0]);
+		}
+		return make_shared<JoinRelation>(shared_from_this(), other, move(using_columns), type);
+	} else {
+		// single expression that is not a column reference: use the expression as a join condition
+		return make_shared<JoinRelation>(shared_from_this(), other, move(expression_list[0]), type);
+	}
+}
+
+shared_ptr<Relation> Relation::CrossProduct(const shared_ptr<Relation> &other) {
+	return make_shared<CrossProductRelation>(shared_from_this(), other);
+}
+
+shared_ptr<Relation> Relation::Union(const shared_ptr<Relation> &other) {
+	return make_shared<SetOpRelation>(shared_from_this(), other, SetOperationType::UNION);
+}
+
+shared_ptr<Relation> Relation::Except(const shared_ptr<Relation> &other) {
+	return make_shared<SetOpRelation>(shared_from_this(), other, SetOperationType::EXCEPT);
+}
+
+shared_ptr<Relation> Relation::Intersect(const shared_ptr<Relation> &other) {
+	return make_shared<SetOpRelation>(shared_from_this(), other, SetOperationType::INTERSECT);
+}
+
+shared_ptr<Relation> Relation::Distinct() {
+	return make_shared<DistinctRelation>(shared_from_this());
+}
+
+shared_ptr<Relation> Relation::Alias(const string &alias) {
+	return make_shared<SubqueryRelation>(shared_from_this(), alias);
+}
+
+shared_ptr<Relation> Relation::Aggregate(const string &aggregate_list) {
+	auto expression_list = Parser::ParseExpressionList(aggregate_list, context.GetContext()->GetParserOptions());
+	return make_shared<AggregateRelation>(shared_from_this(), move(expression_list));
+}
+
+shared_ptr<Relation> Relation::Aggregate(const string &aggregate_list, const string &group_list) {
+	auto expression_list = Parser::ParseExpressionList(aggregate_list, context.GetContext()->GetParserOptions());
+	auto groups = Parser::ParseExpressionList(group_list, context.GetContext()->GetParserOptions());
+	return make_shared<AggregateRelation>(shared_from_this(), move(expression_list), move(groups));
+}
+
+shared_ptr<Relation> Relation::Aggregate(const vector<string> &aggregates) {
+	auto aggregate_list = StringListToExpressionList(*context.GetContext(), aggregates);
+	return make_shared<AggregateRelation>(shared_from_this(), move(aggregate_list));
+}
+
+shared_ptr<Relation> Relation::Aggregate(const vector<string> &aggregates, const vector<string> &groups) {
+	auto aggregate_list = StringListToExpressionList(*context.GetContext(), aggregates);
+	auto group_list = StringListToExpressionList(*context.GetContext(), groups);
+	return make_shared<AggregateRelation>(shared_from_this(), move(aggregate_list), move(group_list));
+}
+
+string Relation::GetAlias() {
+	return "relation";
+}
+
+unique_ptr<TableRef> Relation::GetTableRef() {
+	auto select = make_unique<SelectStatement>();
+	select->node = GetQueryNode();
+	return make_unique<SubqueryRef>(move(select), GetAlias());
+}
+
+unique_ptr<QueryResult> Relation::Execute() {
+	return context.GetContext()->Execute(shared_from_this());
+}
+
+BoundStatement Relation::Bind(Binder &binder) {
+	SelectStatement stmt;
+	stmt.node = GetQueryNode();
+	return binder.Bind((SQLStatement &)stmt);
+}
+
+void Relation::Insert(const string &table_name) {
+	Insert(DEFAULT_SCHEMA, table_name);
+}
+
+void Relation::Insert(const string &schema_name, const string &table_name) {
+	auto insert = make_shared<InsertRelation>(shared_from_this(), schema_name, table_name);
+	auto res = insert->Execute();
+	if (!res->success) {
+		throw Exception("Failed to insert into table '" + table_name + "': " + res->error);
+	}
+}
+
+void Relation::Insert(const vector<vector<Value>> &values) {
+	vector<string> column_names;
+	auto rel = make_shared<ValueRelation>(context.GetContext(), values, move(column_names), "values");
+	rel->Insert(GetAlias());
+}
+
+void Relation::Create(const string &table_name) {
+	Create(DEFAULT_SCHEMA, table_name);
+}
+
+void Relation::Create(const string &schema_name, const string &table_name) {
+	auto create = make_shared<CreateTableRelation>(shared_from_this(), schema_name, table_name);
+	auto res = create->Execute();
+	if (!res->success) {
+		throw Exception("Failed to create table '" + table_name + "': " + res->error);
+	}
+}
+
+void Relation::WriteCSV(const string &csv_file) {
+	auto write_csv = make_shared<WriteCSVRelation>(shared_from_this(), csv_file);
+	auto res = write_csv->Execute();
+	if (!res->success) {
+		throw Exception("Failed to write '" + csv_file + "': " + res->error);
+	}
+}
+
+shared_ptr<Relation> Relation::CreateView(const string &name, bool replace, bool temporary) {
+	auto view = make_shared<CreateViewRelation>(shared_from_this(), name, replace, temporary);
+	auto res = view->Execute();
+	if (!res->success) {
+		throw Exception("Failed to create view '" + name + "': " + res->error);
+	}
+	return shared_from_this();
+}
+
+unique_ptr<QueryResult> Relation::Query(const string &sql) {
+	return context.GetContext()->Query(sql, false);
+}
+
+unique_ptr<QueryResult> Relation::Query(const string &name, const string &sql) {
+	CreateView(name);
+	return Query(sql);
+}
+
+unique_ptr<QueryResult> Relation::Explain() {
+	auto explain = make_shared<ExplainRelation>(shared_from_this());
+	return explain->Execute();
+}
+
+void Relation::Update(const string &update, const string &condition) {
+	throw Exception("UPDATE can only be used on base tables!");
+}
+
+void Relation::Delete(const string &condition) {
+	throw Exception("DELETE can only be used on base tables!");
+}
+
+shared_ptr<Relation> Relation::TableFunction(const std::string &fname, const vector<Value> &values,
+                                             const named_parameter_map_t &named_parameters) {
+	return make_shared<TableFunctionRelation>(context.GetContext(), fname, values, named_parameters,
+	                                          shared_from_this());
+}
+
+shared_ptr<Relation> Relation::TableFunction(const std::string &fname, const vector<Value> &values) {
+	return make_shared<TableFunctionRelation>(context.GetContext(), fname, values, shared_from_this());
+}
+
+string Relation::ToString() {
+	string str;
+	str += "---------------------\n";
+	str += "--- Relation Tree ---\n";
+	str += "---------------------\n";
+	str += ToString(0);
+	str += "\n\n";
+	str += "---------------------\n";
+	str += "-- Result Columns  --\n";
+	str += "---------------------\n";
+	auto &cols = Columns();
+	for (idx_t i = 0; i < cols.size(); i++) {
+		str += "- " + cols[i].Name() + " (" + cols[i].Type().ToString() + ")\n";
+	}
+	return str;
+}
+
+// LCOV_EXCL_START
+unique_ptr<QueryNode> Relation::GetQueryNode() {
+	throw InternalException("Cannot create a query node from this node type");
+}
+
+void Relation::Head(idx_t limit) {
+	auto limit_node = Limit(limit);
+	limit_node->Execute()->Print();
+}
+// LCOV_EXCL_STOP
+
+void Relation::Print() {
+	Printer::Print(ToString());
+}
+
+string Relation::RenderWhitespace(idx_t depth) {
+	return string(depth * 2, ' ');
+}
+
+vector<shared_ptr<ExternalDependency>> Relation::GetAllDependencies() {
+	vector<shared_ptr<ExternalDependency>> all_dependencies;
+	Relation *cur = this;
+	while (cur) {
+		if (cur->extra_dependencies) {
+			all_dependencies.push_back(cur->extra_dependencies);
+		}
+		cur = ChildRelation();
+	}
+	return all_dependencies;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Access Mode
+//===--------------------------------------------------------------------===//
+void AccessModeSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto parameter = StringUtil::Lower(input.ToString());
+	if (parameter == "automatic") {
+		config.access_mode = AccessMode::AUTOMATIC;
+	} else if (parameter == "read_only") {
+		config.access_mode = AccessMode::READ_ONLY;
+	} else if (parameter == "read_write") {
+		config.access_mode = AccessMode::READ_WRITE;
+	} else {
+		throw InvalidInputException(
+		    "Unrecognized parameter for option ACCESS_MODE \"%s\". Expected READ_ONLY or READ_WRITE.", parameter);
+	}
+}
+
+Value AccessModeSetting::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	switch (config.access_mode) {
+	case AccessMode::AUTOMATIC:
+		return "automatic";
+	case AccessMode::READ_ONLY:
+		return "read_only";
+	case AccessMode::READ_WRITE:
+		return "read_write";
+	default:
+		throw InternalException("Unknown access mode setting");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Checkpoint Threshold
+//===--------------------------------------------------------------------===//
+void CheckpointThresholdSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	idx_t new_limit = DBConfig::ParseMemoryLimit(input.ToString());
+	config.checkpoint_wal_size = new_limit;
+}
+
+Value CheckpointThresholdSetting::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value(StringUtil::BytesToHumanReadableString(config.checkpoint_wal_size));
+}
+
+//===--------------------------------------------------------------------===//
+// Debug Checkpoint Abort
+//===--------------------------------------------------------------------===//
+void DebugCheckpointAbort::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto checkpoint_abort = StringUtil::Lower(input.ToString());
+	if (checkpoint_abort == "none") {
+		config.checkpoint_abort = CheckpointAbort::NO_ABORT;
+	} else if (checkpoint_abort == "before_truncate") {
+		config.checkpoint_abort = CheckpointAbort::DEBUG_ABORT_BEFORE_TRUNCATE;
+	} else if (checkpoint_abort == "before_header") {
+		config.checkpoint_abort = CheckpointAbort::DEBUG_ABORT_BEFORE_HEADER;
+	} else if (checkpoint_abort == "after_free_list_write") {
+		config.checkpoint_abort = CheckpointAbort::DEBUG_ABORT_AFTER_FREE_LIST_WRITE;
+	} else {
+		throw ParserException(
+		    "Unrecognized option for PRAGMA debug_checkpoint_abort, expected none, before_truncate or before_header");
+	}
+}
+
+Value DebugCheckpointAbort::GetSetting(ClientContext &context) {
+	return Value();
+}
+
+//===--------------------------------------------------------------------===//
+// Debug Force External
+//===--------------------------------------------------------------------===//
+void DebugForceExternal::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).force_external = input.GetValue<bool>();
+}
+
+Value DebugForceExternal::GetSetting(ClientContext &context) {
+	return Value::BOOLEAN(ClientConfig::GetConfig(context).force_external);
+}
+
+//===--------------------------------------------------------------------===//
+// Debug Force NoCrossProduct
+//===--------------------------------------------------------------------===//
+void DebugForceNoCrossProduct::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).force_no_cross_product = input.GetValue<bool>();
+}
+
+Value DebugForceNoCrossProduct::GetSetting(ClientContext &context) {
+	return Value::BOOLEAN(ClientConfig::GetConfig(context).force_no_cross_product);
+}
+
+//===--------------------------------------------------------------------===//
+// Debug Many Free List blocks
+//===--------------------------------------------------------------------===//
+void DebugManyFreeListBlocks::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.debug_many_free_list_blocks = input.GetValue<bool>();
+}
+
+Value DebugManyFreeListBlocks::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.debug_many_free_list_blocks);
+}
+
+//===--------------------------------------------------------------------===//
+// Debug Window Mode
+//===--------------------------------------------------------------------===//
+void DebugWindowMode::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto param = StringUtil::Lower(input.ToString());
+	if (param == "window") {
+		config.window_mode = WindowAggregationMode::WINDOW;
+	} else if (param == "combine") {
+		config.window_mode = WindowAggregationMode::COMBINE;
+	} else if (param == "separate") {
+		config.window_mode = WindowAggregationMode::SEPARATE;
+	} else {
+		throw ParserException("Unrecognized option for PRAGMA debug_window_mode, expected window, combine or separate");
+	}
+}
+
+Value DebugWindowMode::GetSetting(ClientContext &context) {
+	return Value();
+}
+
+//===--------------------------------------------------------------------===//
+// Default Collation
+//===--------------------------------------------------------------------===//
+void DefaultCollationSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto parameter = StringUtil::Lower(input.ToString());
+	config.collation = parameter;
+}
+
+void DefaultCollationSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto parameter = input.ToString();
+	// bind the collation to verify that it exists
+	ExpressionBinder::TestCollation(context, parameter);
+	auto &config = DBConfig::GetConfig(context);
+	config.collation = parameter;
+}
+
+Value DefaultCollationSetting::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value(config.collation);
+}
+
+//===--------------------------------------------------------------------===//
+// Default Order
+//===--------------------------------------------------------------------===//
+void DefaultOrderSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto parameter = StringUtil::Lower(input.ToString());
+	if (parameter == "ascending" || parameter == "asc") {
+		config.default_order_type = OrderType::ASCENDING;
+	} else if (parameter == "descending" || parameter == "desc") {
+		config.default_order_type = OrderType::DESCENDING;
+	} else {
+		throw InvalidInputException("Unrecognized parameter for option DEFAULT_ORDER \"%s\". Expected ASC or DESC.",
+		                            parameter);
+	}
+}
+
+Value DefaultOrderSetting::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	switch (config.default_order_type) {
+	case OrderType::ASCENDING:
+		return "asc";
+	case OrderType::DESCENDING:
+		return "desc";
+	default:
+		throw InternalException("Unknown order type setting");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Default Null Order
+//===--------------------------------------------------------------------===//
+void DefaultNullOrderSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto parameter = StringUtil::Lower(input.ToString());
+
+	if (parameter == "nulls_first" || parameter == "nulls first" || parameter == "null first" || parameter == "first") {
+		config.default_null_order = OrderByNullType::NULLS_FIRST;
+	} else if (parameter == "nulls_last" || parameter == "nulls last" || parameter == "null last" ||
+	           parameter == "last") {
+		config.default_null_order = OrderByNullType::NULLS_LAST;
+	} else {
+		throw ParserException(
+		    "Unrecognized parameter for option NULL_ORDER \"%s\", expected either NULLS FIRST or NULLS LAST",
+		    parameter);
+	}
+}
+
+Value DefaultNullOrderSetting::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	switch (config.default_null_order) {
+	case OrderByNullType::NULLS_FIRST:
+		return "nulls_first";
+	case OrderByNullType::NULLS_LAST:
+		return "nulls_last";
+	default:
+		throw InternalException("Unknown null order setting");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Disabled Optimizer
+//===--------------------------------------------------------------------===//
+void DisabledOptimizersSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto list = StringUtil::Split(input.ToString(), ",");
+	set<OptimizerType> disabled_optimizers;
+	for (auto &entry : list) {
+		auto param = StringUtil::Lower(entry);
+		StringUtil::Trim(param);
+		if (param.empty()) {
+			continue;
+		}
+		disabled_optimizers.insert(OptimizerTypeFromString(param));
+	}
+	config.disabled_optimizers = move(disabled_optimizers);
+}
+
+Value DisabledOptimizersSetting::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	string result;
+	for (auto &optimizer : config.disabled_optimizers) {
+		if (!result.empty()) {
+			result += ",";
+		}
+		result += OptimizerTypeToString(optimizer);
+	}
+	return Value(result);
+}
+
+//===--------------------------------------------------------------------===//
+// Enable External Access
+//===--------------------------------------------------------------------===//
+void EnableExternalAccessSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto new_value = input.GetValue<bool>();
+	if (db && new_value) {
+		throw InvalidInputException("Cannot change enable_external_access setting while database is running");
+	}
+	config.enable_external_access = new_value;
+}
+
+Value EnableExternalAccessSetting::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.enable_external_access);
+}
+
+//===--------------------------------------------------------------------===//
+// Enable Object Cache
+//===--------------------------------------------------------------------===//
+void EnableObjectCacheSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.object_cache_enable = input.GetValue<bool>();
+}
+
+Value EnableObjectCacheSetting::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.object_cache_enable);
+}
+
+//===--------------------------------------------------------------------===//
+// Enable Profiling
+//===--------------------------------------------------------------------===//
+void EnableProfilingSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto parameter = StringUtil::Lower(input.ToString());
+
+	auto &config = ClientConfig::GetConfig(context);
+	if (parameter == "json") {
+		config.profiler_print_format = ProfilerPrintFormat::JSON;
+	} else if (parameter == "query_tree") {
+		config.profiler_print_format = ProfilerPrintFormat::QUERY_TREE;
+	} else if (parameter == "query_tree_optimizer") {
+		config.profiler_print_format = ProfilerPrintFormat::QUERY_TREE_OPTIMIZER;
+	} else {
+		throw ParserException(
+		    "Unrecognized print format %s, supported formats: [json, query_tree, query_tree_optimizer]", parameter);
+	}
+	config.enable_profiler = true;
+}
+
+Value EnableProfilingSetting::GetSetting(ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	if (!config.enable_profiler) {
+		return Value();
+	}
+	switch (config.profiler_print_format) {
+	case ProfilerPrintFormat::NONE:
+		return Value("none");
+	case ProfilerPrintFormat::JSON:
+		return Value("json");
+	case ProfilerPrintFormat::QUERY_TREE:
+		return Value("query_tree");
+	case ProfilerPrintFormat::QUERY_TREE_OPTIMIZER:
+		return Value("query_tree_optimizer");
+	default:
+		throw InternalException("Unsupported profiler print format");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Enable Progress Bar
+//===--------------------------------------------------------------------===//
+void EnableProgressBarSetting::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).enable_progress_bar = input.GetValue<bool>();
+}
+
+Value EnableProgressBarSetting::GetSetting(ClientContext &context) {
+	return Value::BOOLEAN(ClientConfig::GetConfig(context).enable_progress_bar);
+}
+
+//===--------------------------------------------------------------------===//
+// Explain Output
+//===--------------------------------------------------------------------===//
+void ExplainOutputSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto parameter = StringUtil::Lower(input.ToString());
+	if (parameter == "all") {
+		ClientConfig::GetConfig(context).explain_output_type = ExplainOutputType::ALL;
+	} else if (parameter == "optimized_only") {
+		ClientConfig::GetConfig(context).explain_output_type = ExplainOutputType::OPTIMIZED_ONLY;
+	} else if (parameter == "physical_only") {
+		ClientConfig::GetConfig(context).explain_output_type = ExplainOutputType::PHYSICAL_ONLY;
+	} else {
+		throw ParserException("Unrecognized output type \"%s\", expected either ALL, OPTIMIZED_ONLY or PHYSICAL_ONLY",
+		                      parameter);
+	}
+}
+
+Value ExplainOutputSetting::GetSetting(ClientContext &context) {
+	switch (ClientConfig::GetConfig(context).explain_output_type) {
+	case ExplainOutputType::ALL:
+		return "all";
+	case ExplainOutputType::OPTIMIZED_ONLY:
+		return "optimized_only";
+	case ExplainOutputType::PHYSICAL_ONLY:
+		return "physical_only";
+	default:
+		throw InternalException("Unrecognized explain output type");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// External Threads Setting
+//===--------------------------------------------------------------------===//
+void ExternalThreadsSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.external_threads = input.GetValue<int64_t>();
+}
+
+Value ExternalThreadsSetting::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BIGINT(config.external_threads);
+}
+
+//===--------------------------------------------------------------------===//
+// File Search Path
+//===--------------------------------------------------------------------===//
+void FileSearchPathSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto parameter = input.ToString();
+	auto &client_data = ClientData::Get(context);
+	client_data.file_search_path = parameter;
+}
+
+Value FileSearchPathSetting::GetSetting(ClientContext &context) {
+	auto &client_data = ClientData::Get(context);
+	return Value(client_data.file_search_path);
+}
+
+//===--------------------------------------------------------------------===//
+// Force Compression
+//===--------------------------------------------------------------------===//
+void ForceCompressionSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	auto compression = StringUtil::Lower(input.ToString());
+	if (compression == "none") {
+		config.force_compression = CompressionType::COMPRESSION_AUTO;
+	} else {
+		auto compression_type = CompressionTypeFromString(compression);
+		if (compression_type == CompressionType::COMPRESSION_AUTO) {
+			throw ParserException("Unrecognized option for PRAGMA force_compression, expected none, uncompressed, rle, "
+			                      "dictionary, pfor, bitpacking or fsst");
+		}
+		config.force_compression = compression_type;
+	}
+}
+
+Value ForceCompressionSetting::GetSetting(ClientContext &context) {
+	return Value();
+}
+
+//===--------------------------------------------------------------------===//
+// Log Query Path
+//===--------------------------------------------------------------------===//
+void LogQueryPathSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto &client_data = ClientData::Get(context);
+	auto path = input.ToString();
+	if (path.empty()) {
+		// empty path: clean up query writer
+		client_data.log_query_writer = nullptr;
+	} else {
+		client_data.log_query_writer =
+		    make_unique<BufferedFileWriter>(FileSystem::GetFileSystem(context), path,
+		                                    BufferedFileWriter::DEFAULT_OPEN_FLAGS, client_data.file_opener.get());
+	}
+}
+
+Value LogQueryPathSetting::GetSetting(ClientContext &context) {
+	auto &client_data = ClientData::Get(context);
+	return client_data.log_query_writer ? Value(client_data.log_query_writer->path) : Value();
+}
+
+//===--------------------------------------------------------------------===//
+// Maximum Expression Depth
+//===--------------------------------------------------------------------===//
+void MaximumExpressionDepthSetting::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).max_expression_depth = input.GetValue<uint64_t>();
+}
+
+Value MaximumExpressionDepthSetting::GetSetting(ClientContext &context) {
+	return Value::UBIGINT(ClientConfig::GetConfig(context).max_expression_depth);
+}
+
+//===--------------------------------------------------------------------===//
+// Maximum Memory
+//===--------------------------------------------------------------------===//
+void MaximumMemorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.maximum_memory = DBConfig::ParseMemoryLimit(input.ToString());
+	if (db) {
+		BufferManager::GetBufferManager(*db).SetLimit(config.maximum_memory);
+	}
+}
+
+Value MaximumMemorySetting::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value(StringUtil::BytesToHumanReadableString(config.maximum_memory));
+}
+
+//===--------------------------------------------------------------------===//
+// Perfect Hash Threshold
+//===--------------------------------------------------------------------===//
+void PerfectHashThresholdSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto bits = input.GetValue<int32_t>();
+	if (bits < 0 || bits > 32) {
+		throw ParserException("Perfect HT threshold out of range: should be within range 0 - 32");
+	}
+	ClientConfig::GetConfig(context).perfect_ht_threshold = bits;
+}
+
+Value PerfectHashThresholdSetting::GetSetting(ClientContext &context) {
+	return Value::BIGINT(ClientConfig::GetConfig(context).perfect_ht_threshold);
+}
+
+//===--------------------------------------------------------------------===//
+// PreserveIdentifierCase
+//===--------------------------------------------------------------------===//
+void PreserveIdentifierCase::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).preserve_identifier_case = input.GetValue<bool>();
+}
+
+Value PreserveIdentifierCase::GetSetting(ClientContext &context) {
+	return Value::BOOLEAN(ClientConfig::GetConfig(context).preserve_identifier_case);
+}
+
+//===--------------------------------------------------------------------===//
+// PreserveInsertionOrder
+//===--------------------------------------------------------------------===//
+void PreserveInsertionOrder::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.preserve_insertion_order = input.GetValue<bool>();
+}
+
+Value PreserveInsertionOrder::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BOOLEAN(config.preserve_insertion_order);
+}
+
+//===--------------------------------------------------------------------===//
+// Profiler History Size
+//===--------------------------------------------------------------------===//
+void ProfilerHistorySize::SetLocal(ClientContext &context, const Value &input) {
+	auto size = input.GetValue<int64_t>();
+	if (size <= 0) {
+		throw ParserException("Size should be >= 0");
+	}
+	auto &client_data = ClientData::Get(context);
+	client_data.query_profiler_history->SetProfilerHistorySize(size);
+}
+
+Value ProfilerHistorySize::GetSetting(ClientContext &context) {
+	return Value();
+}
+
+//===--------------------------------------------------------------------===//
+// Profile Output
+//===--------------------------------------------------------------------===//
+void ProfileOutputSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto &config = ClientConfig::GetConfig(context);
+	auto parameter = input.ToString();
+	config.profiler_save_location = parameter;
+}
+
+Value ProfileOutputSetting::GetSetting(ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	return Value(config.profiler_save_location);
+}
+
+//===--------------------------------------------------------------------===//
+// Profiling Mode
+//===--------------------------------------------------------------------===//
+void ProfilingModeSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto parameter = StringUtil::Lower(input.ToString());
+	auto &config = ClientConfig::GetConfig(context);
+	if (parameter == "standard") {
+		config.enable_profiler = true;
+		config.enable_detailed_profiling = false;
+	} else if (parameter == "detailed") {
+		config.enable_profiler = true;
+		config.enable_detailed_profiling = true;
+	} else {
+		throw ParserException("Unrecognized profiling mode \"%s\", supported formats: [standard, detailed]", parameter);
+	}
+}
+
+Value ProfilingModeSetting::GetSetting(ClientContext &context) {
+	auto &config = ClientConfig::GetConfig(context);
+	if (!config.enable_profiler) {
+		return Value();
+	}
+	return Value(config.enable_detailed_profiling ? "detailed" : "standard");
+}
+
+//===--------------------------------------------------------------------===//
+// Progress Bar Time
+//===--------------------------------------------------------------------===//
+void ProgressBarTimeSetting::SetLocal(ClientContext &context, const Value &input) {
+	ClientConfig::GetConfig(context).wait_time = input.GetValue<int32_t>();
+	ClientConfig::GetConfig(context).enable_progress_bar = true;
+}
+
+Value ProgressBarTimeSetting::GetSetting(ClientContext &context) {
+	return Value::BIGINT(ClientConfig::GetConfig(context).wait_time);
+}
+
+//===--------------------------------------------------------------------===//
+// Schema
+//===--------------------------------------------------------------------===//
+void SchemaSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto parameter = input.ToString();
+	auto &client_data = ClientData::Get(context);
+	client_data.catalog_search_path->Set(parameter, true);
+}
+
+Value SchemaSetting::GetSetting(ClientContext &context) {
+	return SearchPathSetting::GetSetting(context);
+}
+
+//===--------------------------------------------------------------------===//
+// Search Path
+//===--------------------------------------------------------------------===//
+void SearchPathSetting::SetLocal(ClientContext &context, const Value &input) {
+	auto parameter = input.ToString();
+	auto &client_data = ClientData::Get(context);
+	client_data.catalog_search_path->Set(parameter, false);
+}
+
+Value SearchPathSetting::GetSetting(ClientContext &context) {
+	auto &client_data = ClientData::Get(context);
+	return Value(StringUtil::Join(client_data.catalog_search_path->GetSetPaths(), ","));
+}
+
+//===--------------------------------------------------------------------===//
+// Temp Directory
+//===--------------------------------------------------------------------===//
+void TempDirectorySetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.temporary_directory = input.ToString();
+	config.use_temporary_directory = !config.temporary_directory.empty();
+	if (db) {
+		auto &buffer_manager = BufferManager::GetBufferManager(*db);
+		buffer_manager.SetTemporaryDirectory(config.temporary_directory);
+	}
+}
+
+Value TempDirectorySetting::GetSetting(ClientContext &context) {
+	auto &buffer_manager = BufferManager::GetBufferManager(context);
+	return Value(buffer_manager.GetTemporaryDirectory());
+}
+
+//===--------------------------------------------------------------------===//
+// Threads Setting
+//===--------------------------------------------------------------------===//
+void ThreadsSetting::SetGlobal(DatabaseInstance *db, DBConfig &config, const Value &input) {
+	config.maximum_threads = input.GetValue<int64_t>();
+	if (db) {
+		TaskScheduler::GetScheduler(*db).SetThreads(config.maximum_threads);
+	}
+}
+
+Value ThreadsSetting::GetSetting(ClientContext &context) {
+	auto &config = DBConfig::GetConfig(context);
+	return Value::BIGINT(config.maximum_threads);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+StreamQueryResult::StreamQueryResult(StatementType statement_type, StatementProperties properties,
+                                     shared_ptr<ClientContext> context, vector<LogicalType> types, vector<string> names)
+    : QueryResult(QueryResultType::STREAM_RESULT, statement_type, properties, move(types), move(names)),
+      context(move(context)) {
+}
+
+StreamQueryResult::~StreamQueryResult() {
+}
+
+string StreamQueryResult::ToString() {
+	string result;
+	if (success) {
+		result = HeaderToString();
+		result += "[[STREAM RESULT]]";
+	} else {
+		result = error + "\n";
+	}
+	return result;
+}
+
+unique_ptr<ClientContextLock> StreamQueryResult::LockContext() {
+	if (!context) {
+		throw InvalidInputException("Attempting to execute an unsuccessful or closed pending query result\nError: %s",
+		                            error);
+	}
+	return context->LockContext();
+}
+
+void StreamQueryResult::CheckExecutableInternal(ClientContextLock &lock) {
+	if (!IsOpenInternal(lock)) {
+		throw InvalidInputException("Attempting to execute an unsuccessful or closed pending query result\nError: %s",
+		                            error);
+	}
+}
+
+unique_ptr<DataChunk> StreamQueryResult::FetchRaw() {
+	unique_ptr<DataChunk> chunk;
+	{
+		auto lock = LockContext();
+		CheckExecutableInternal(*lock);
+		chunk = context->Fetch(*lock, *this);
+	}
+	if (!chunk || chunk->ColumnCount() == 0 || chunk->size() == 0) {
+		Close();
+		return nullptr;
+	}
+	return chunk;
+}
+
+unique_ptr<MaterializedQueryResult> StreamQueryResult::Materialize() {
+	if (!success) {
+		return make_unique<MaterializedQueryResult>(error);
+	}
+	auto result = make_unique<MaterializedQueryResult>(statement_type, properties, types, names, context);
+	while (true) {
+		auto chunk = Fetch();
+		if (!chunk || chunk->size() == 0) {
+			break;
+		}
+		result->collection.Append(*chunk);
+	}
+	if (!success) {
+		return make_unique<MaterializedQueryResult>(error);
+	}
+	return result;
+}
+
+bool StreamQueryResult::IsOpenInternal(ClientContextLock &lock) {
+	bool invalidated = !success || !context;
+	if (!invalidated) {
+		invalidated = !context->IsActiveResult(lock, this);
+	}
+	return !invalidated;
+}
+
+bool StreamQueryResult::IsOpen() {
+	if (!success || !context) {
+		return false;
+	}
+	auto lock = LockContext();
+	return IsOpenInternal(*lock);
+}
+
+void StreamQueryResult::Close() {
+	context.reset();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+void ColumnLifetimeAnalyzer::ExtractUnusedColumnBindings(vector<ColumnBinding> bindings,
+                                                         column_binding_set_t &unused_bindings) {
+	for (idx_t i = 0; i < bindings.size(); i++) {
+		if (column_references.find(bindings[i]) == column_references.end()) {
+			unused_bindings.insert(bindings[i]);
+		}
+	}
+}
+
+void ColumnLifetimeAnalyzer::GenerateProjectionMap(vector<ColumnBinding> bindings,
+                                                   column_binding_set_t &unused_bindings,
+                                                   vector<idx_t> &projection_map) {
+	if (unused_bindings.empty()) {
+		return;
+	}
+	// now iterate over the result bindings of the child
+	for (idx_t i = 0; i < bindings.size(); i++) {
+		// if this binding does not belong to the unused bindings, add it to the projection map
+		if (unused_bindings.find(bindings[i]) == unused_bindings.end()) {
+			projection_map.push_back(i);
+		}
+	}
+	if (projection_map.size() == bindings.size()) {
+		projection_map.clear();
+	}
+}
+
+void ColumnLifetimeAnalyzer::StandardVisitOperator(LogicalOperator &op) {
+	LogicalOperatorVisitor::VisitOperatorExpressions(op);
+	if (op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		// visit the duplicate eliminated columns on the LHS, if any
+		auto &delim_join = (LogicalDelimJoin &)op;
+		for (auto &expr : delim_join.duplicate_eliminated_columns) {
+			VisitExpression(&expr);
+		}
+	}
+	LogicalOperatorVisitor::VisitOperatorChildren(op);
+}
+
+void ColumnLifetimeAnalyzer::VisitOperator(LogicalOperator &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
+		// FIXME: groups that are not referenced can be removed from projection
+		// recurse into the children of the aggregate
+		ColumnLifetimeAnalyzer analyzer;
+		analyzer.VisitOperatorExpressions(op);
+		analyzer.VisitOperator(*op.children[0]);
+		return;
+	}
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
+		if (everything_referenced) {
+			break;
+		}
+		auto &comp_join = (LogicalComparisonJoin &)op;
+		if (comp_join.join_type == JoinType::MARK || comp_join.join_type == JoinType::SEMI ||
+		    comp_join.join_type == JoinType::ANTI) {
+			break;
+		}
+		// FIXME for now, we only push into the projection map for equality (hash) joins
+		// FIXME: add projection to LHS as well
+		bool has_equality = false;
+		for (auto &cond : comp_join.conditions) {
+			if (cond.comparison == ExpressionType::COMPARE_EQUAL) {
+				has_equality = true;
+			}
+		}
+		if (!has_equality) {
+			break;
+		}
+		// now, for each of the columns of the RHS, check which columns need to be projected
+		column_binding_set_t unused_bindings;
+		ExtractUnusedColumnBindings(op.children[1]->GetColumnBindings(), unused_bindings);
+
+		// now recurse into the filter and its children
+		StandardVisitOperator(op);
+
+		// then generate the projection map
+		GenerateProjectionMap(op.children[1]->GetColumnBindings(), unused_bindings, comp_join.right_projection_map);
+		return;
+	}
+	case LogicalOperatorType::LOGICAL_UNION:
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+	case LogicalOperatorType::LOGICAL_INTERSECT:
+		// for set operations we don't remove anything, just recursively visit the children
+		// FIXME: for UNION we can remove unreferenced columns as long as everything_referenced is false (i.e. we
+		// encounter a UNION node that is not preceded by a DISTINCT)
+		for (auto &child : op.children) {
+			ColumnLifetimeAnalyzer analyzer(true);
+			analyzer.VisitOperator(*child);
+		}
+		return;
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		// then recurse into the children of this projection
+		ColumnLifetimeAnalyzer analyzer;
+		analyzer.VisitOperatorExpressions(op);
+		analyzer.VisitOperator(*op.children[0]);
+		return;
+	}
+	case LogicalOperatorType::LOGICAL_DISTINCT: {
+		// distinct, all projected columns are used for the DISTINCT computation
+		// mark all columns as used and continue to the children
+		// FIXME: DISTINCT with expression list does not implicitly reference everything
+		everything_referenced = true;
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_FILTER: {
+		auto &filter = (LogicalFilter &)op;
+		if (everything_referenced) {
+			break;
+		}
+		// filter, figure out which columns are not needed after the filter
+		column_binding_set_t unused_bindings;
+		ExtractUnusedColumnBindings(op.children[0]->GetColumnBindings(), unused_bindings);
+
+		// now recurse into the filter and its children
+		StandardVisitOperator(op);
+
+		// then generate the projection map
+		GenerateProjectionMap(op.children[0]->GetColumnBindings(), unused_bindings, filter.projection_map);
+		return;
+	}
+	default:
+		break;
+	}
+	StandardVisitOperator(op);
+}
+
+unique_ptr<Expression> ColumnLifetimeAnalyzer::VisitReplace(BoundColumnRefExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	column_references.insert(expr.binding);
+	return nullptr;
+}
+
+unique_ptr<Expression> ColumnLifetimeAnalyzer::VisitReplace(BoundReferenceExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	// BoundReferenceExpression should not be used here yet, they only belong in the physical plan
+	throw InternalException("BoundReferenceExpression should not be used here yet!");
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+void CommonAggregateOptimizer::VisitOperator(LogicalOperator &op) {
+	LogicalOperatorVisitor::VisitOperator(op);
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		ExtractCommonAggregates((LogicalAggregate &)op);
+		break;
+	default:
+		break;
+	}
+}
+
+unique_ptr<Expression> CommonAggregateOptimizer::VisitReplace(BoundColumnRefExpression &expr,
+                                                              unique_ptr<Expression> *expr_ptr) {
+	// check if this column ref points to an aggregate that was remapped; if it does we remap it
+	auto entry = aggregate_map.find(expr.binding);
+	if (entry != aggregate_map.end()) {
+		expr.binding = entry->second;
+	}
+	return nullptr;
+}
+
+void CommonAggregateOptimizer::ExtractCommonAggregates(LogicalAggregate &aggr) {
+	expression_map_t<idx_t> aggregate_remap;
+	idx_t total_erased = 0;
+	for (idx_t i = 0; i < aggr.expressions.size(); i++) {
+		idx_t original_index = i + total_erased;
+		auto entry = aggregate_remap.find(aggr.expressions[i].get());
+		if (entry == aggregate_remap.end()) {
+			// aggregate does not exist yet: add it to the map
+			aggregate_remap[aggr.expressions[i].get()] = i;
+			if (i != original_index) {
+				// this aggregate is not erased, however an agregate BEFORE it has been erased
+				// so we need to remap this aggregaet
+				ColumnBinding original_binding(aggr.aggregate_index, original_index);
+				ColumnBinding new_binding(aggr.aggregate_index, i);
+				aggregate_map[original_binding] = new_binding;
+			}
+		} else {
+			// aggregate already exists! we can remove this entry
+			total_erased++;
+			aggr.expressions.erase(aggr.expressions.begin() + i);
+			i--;
+			// we need to remap any references to this aggregate so they point to the other aggregate
+			ColumnBinding original_binding(aggr.aggregate_index, original_index);
+			ColumnBinding new_binding(aggr.aggregate_index, entry->second);
+			aggregate_map[original_binding] = new_binding;
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//! The CSENode contains information about a common subexpression; how many times it occurs, and the column index in the
+//! underlying projection
+struct CSENode {
+	idx_t count;
+	idx_t column_index;
+
+	CSENode() : count(1), column_index(DConstants::INVALID_INDEX) {
+	}
+};
+
+//! The CSEReplacementState
+struct CSEReplacementState {
+	//! The projection index of the new projection
+	idx_t projection_index;
+	//! Map of expression -> CSENode
+	expression_map_t<CSENode> expression_count;
+	//! Map of column bindings to column indexes in the projection expression list
+	column_binding_map_t<idx_t> column_map;
+	//! The set of expressions of the resulting projection
+	vector<unique_ptr<Expression>> expressions;
+	//! Cached expressions that are kept around so the expression_map always contains valid expressions
+	vector<unique_ptr<Expression>> cached_expressions;
+};
+
+void CommonSubExpressionOptimizer::VisitOperator(LogicalOperator &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		ExtractCommonSubExpresions(op);
+		break;
+	default:
+		break;
+	}
+	LogicalOperatorVisitor::VisitOperator(op);
+}
+
+void CommonSubExpressionOptimizer::CountExpressions(Expression &expr, CSEReplacementState &state) {
+	// we only consider expressions with children for CSE elimination
+	switch (expr.expression_class) {
+	case ExpressionClass::BOUND_COLUMN_REF:
+	case ExpressionClass::BOUND_CONSTANT:
+	case ExpressionClass::BOUND_PARAMETER:
+	// skip conjunctions and case, since short-circuiting might be incorrectly disabled otherwise
+	case ExpressionClass::BOUND_CONJUNCTION:
+	case ExpressionClass::BOUND_CASE:
+		return;
+	default:
+		break;
+	}
+	if (expr.expression_class != ExpressionClass::BOUND_AGGREGATE && !expr.HasSideEffects()) {
+		// we can't move aggregates to a projection, so we only consider the children of the aggregate
+		auto node = state.expression_count.find(&expr);
+		if (node == state.expression_count.end()) {
+			// first time we encounter this expression, insert this node with [count = 1]
+			state.expression_count[&expr] = CSENode();
+		} else {
+			// we encountered this expression before, increment the occurrence count
+			node->second.count++;
+		}
+	}
+	// recursively count the children
+	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { CountExpressions(child, state); });
+}
+
+void CommonSubExpressionOptimizer::PerformCSEReplacement(unique_ptr<Expression> *expr_ptr, CSEReplacementState &state) {
+	Expression &expr = **expr_ptr;
+	if (expr.expression_class == ExpressionClass::BOUND_COLUMN_REF) {
+		auto &bound_column_ref = (BoundColumnRefExpression &)expr;
+		// bound column ref, check if this one has already been recorded in the expression list
+		auto column_entry = state.column_map.find(bound_column_ref.binding);
+		if (column_entry == state.column_map.end()) {
+			// not there yet: push the expression
+			idx_t new_column_index = state.expressions.size();
+			state.column_map[bound_column_ref.binding] = new_column_index;
+			state.expressions.push_back(make_unique<BoundColumnRefExpression>(
+			    bound_column_ref.alias, bound_column_ref.return_type, bound_column_ref.binding));
+			bound_column_ref.binding = ColumnBinding(state.projection_index, new_column_index);
+		} else {
+			// else: just update the column binding!
+			bound_column_ref.binding = ColumnBinding(state.projection_index, column_entry->second);
+		}
+		return;
+	}
+	// check if this child is eligible for CSE elimination
+	bool can_cse = expr.expression_class != ExpressionClass::BOUND_CONJUNCTION &&
+	               expr.expression_class != ExpressionClass::BOUND_CASE;
+	if (can_cse && state.expression_count.find(&expr) != state.expression_count.end()) {
+		auto &node = state.expression_count[&expr];
+		if (node.count > 1) {
+			// this expression occurs more than once! push it into the projection
+			// check if it has already been pushed into the projection
+			auto alias = expr.alias;
+			auto type = expr.return_type;
+			if (node.column_index == DConstants::INVALID_INDEX) {
+				// has not been pushed yet: push it
+				node.column_index = state.expressions.size();
+				state.expressions.push_back(move(*expr_ptr));
+			} else {
+				state.cached_expressions.push_back(move(*expr_ptr));
+			}
+			// replace the original expression with a bound column ref
+			*expr_ptr = make_unique<BoundColumnRefExpression>(alias, type,
+			                                                  ColumnBinding(state.projection_index, node.column_index));
+			return;
+		}
+	}
+	// this expression only occurs once, we can't perform CSE elimination
+	// look into the children to see if we can replace them
+	ExpressionIterator::EnumerateChildren(expr,
+	                                      [&](unique_ptr<Expression> &child) { PerformCSEReplacement(&child, state); });
+}
+
+void CommonSubExpressionOptimizer::ExtractCommonSubExpresions(LogicalOperator &op) {
+	D_ASSERT(op.children.size() == 1);
+
+	// first we count for each expression with children how many types it occurs
+	CSEReplacementState state;
+	LogicalOperatorVisitor::EnumerateExpressions(
+	    op, [&](unique_ptr<Expression> *child) { CountExpressions(**child, state); });
+	// check if there are any expressions to extract
+	bool perform_replacement = false;
+	for (auto &expr : state.expression_count) {
+		if (expr.second.count > 1) {
+			perform_replacement = true;
+			break;
+		}
+	}
+	if (!perform_replacement) {
+		// no CSEs to extract
+		return;
+	}
+	state.projection_index = binder.GenerateTableIndex();
+	// we found common subexpressions to extract
+	// now we iterate over all the expressions and perform the actual CSE elimination
+	LogicalOperatorVisitor::EnumerateExpressions(
+	    op, [&](unique_ptr<Expression> *child) { PerformCSEReplacement(child, state); });
+	D_ASSERT(state.expressions.size() > 0);
+	// create a projection node as the child of this node
+	auto projection = make_unique<LogicalProjection>(state.projection_index, move(state.expressions));
+	projection->children.push_back(move(op.children[0]));
+	op.children[0] = move(projection);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class DeliminatorPlanUpdater : LogicalOperatorVisitor {
+public:
+	DeliminatorPlanUpdater() {
+	}
+	//! Update the plan after a DelimGet has been removed
+	void VisitOperator(LogicalOperator &op) override;
+	void VisitExpression(unique_ptr<Expression> *expression) override;
+	//! Whether the operator has one or more children of type DELIM_GET
+	bool HasChildDelimGet(LogicalOperator &op);
+	expression_map_t<Expression *> expr_map;
+	column_binding_map_t<bool> projection_map;
+	unique_ptr<LogicalOperator> temp_ptr;
+};
+
+void DeliminatorPlanUpdater::VisitOperator(LogicalOperator &op) {
+	VisitOperatorChildren(op);
+	VisitOperatorExpressions(op);
+	if (op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN && !HasChildDelimGet(op)) {
+		auto &delim_join = (LogicalDelimJoin &)op;
+		auto decs = &delim_join.duplicate_eliminated_columns;
+		for (auto &cond : delim_join.conditions) {
+			if (cond.comparison != ExpressionType::COMPARE_EQUAL &&
+			    cond.comparison != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+				continue;
+			}
+			auto &colref = (BoundColumnRefExpression &)*cond.right;
+			if (projection_map.find(colref.binding) != projection_map.end()) {
+				// value on the right is a projection of removed DelimGet
+				for (idx_t i = 0; i < decs->size(); i++) {
+					if (decs->at(i)->Equals(cond.left.get())) {
+						// the value on the left no longer needs to be a duplicate-eliminated column
+						decs->erase(decs->begin() + i);
+						break;
+					}
+				}
+				// whether we applied an IS NOT NULL filter
+				cond.comparison = ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+			}
+		}
+		// change type if there are no more duplicate-eliminated columns
+		if (decs->empty()) {
+			delim_join.type = LogicalOperatorType::LOGICAL_COMPARISON_JOIN;
+		}
+	}
+}
+
+void DeliminatorPlanUpdater::VisitExpression(unique_ptr<Expression> *expression) {
+	if (expr_map.find(expression->get()) != expr_map.end()) {
+		*expression = expr_map[expression->get()]->Copy();
+	} else {
+		VisitExpressionChildren(**expression);
+	}
+}
+
+bool DeliminatorPlanUpdater::HasChildDelimGet(LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_DELIM_GET) {
+		return true;
+	}
+	for (auto &child : op.children) {
+		if (HasChildDelimGet(*child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+unique_ptr<LogicalOperator> Deliminator::Optimize(unique_ptr<LogicalOperator> op) {
+	vector<unique_ptr<LogicalOperator> *> candidates;
+	FindCandidates(&op, candidates);
+
+	for (auto candidate : candidates) {
+		DeliminatorPlanUpdater updater;
+		if (RemoveCandidate(candidate, updater)) {
+			updater.VisitOperator(*op);
+		}
+	}
+	return op;
+}
+
+void Deliminator::FindCandidates(unique_ptr<LogicalOperator> *op_ptr,
+                                 vector<unique_ptr<LogicalOperator> *> &candidates) {
+	auto op = op_ptr->get();
+	// search children before adding, so the deepest candidates get added first
+	for (auto &child : op->children) {
+		FindCandidates(&child, candidates);
+	}
+	// search for projection/aggregate
+	if (op->type != LogicalOperatorType::LOGICAL_PROJECTION &&
+	    op->type != LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY) {
+		return;
+	}
+	// followed by a join
+	if (op->children[0]->type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		return;
+	}
+	auto &join = *op->children[0];
+	// with a DelimGet as a direct child (left or right)
+	if (join.children[0]->type == LogicalOperatorType::LOGICAL_DELIM_GET ||
+	    join.children[1]->type == LogicalOperatorType::LOGICAL_DELIM_GET) {
+		candidates.push_back(op_ptr);
+		return;
+	}
+	// or a filter followed by a DelimGet (left)
+	if (join.children[0]->type == LogicalOperatorType::LOGICAL_FILTER &&
+	    join.children[0]->children[0]->type == LogicalOperatorType::LOGICAL_DELIM_GET) {
+		candidates.push_back(op_ptr);
+		return;
+	}
+	// filter followed by a DelimGet (right)
+	if (join.children[1]->type == LogicalOperatorType::LOGICAL_FILTER &&
+	    join.children[1]->children[0]->type == LogicalOperatorType::LOGICAL_DELIM_GET) {
+		candidates.push_back(op_ptr);
+		return;
+	}
+}
+
+static bool OperatorIsDelimGet(LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_DELIM_GET) {
+		return true;
+	}
+	if (op.type == LogicalOperatorType::LOGICAL_FILTER &&
+	    op.children[0]->type == LogicalOperatorType::LOGICAL_DELIM_GET) {
+		return true;
+	}
+	return false;
+}
+
+bool Deliminator::RemoveCandidate(unique_ptr<LogicalOperator> *op_ptr, DeliminatorPlanUpdater &updater) {
+	auto &proj_or_agg = **op_ptr;
+	auto &join = (LogicalComparisonJoin &)*proj_or_agg.children[0];
+	if (join.join_type != JoinType::INNER && join.join_type != JoinType::SEMI) {
+		return false;
+	}
+
+	// get the index (left or right) of the DelimGet side of the join
+	idx_t delim_idx = OperatorIsDelimGet(*join.children[0]) ? 0 : 1;
+	D_ASSERT(OperatorIsDelimGet(*join.children[delim_idx]));
+	// get the filter (if any)
+	LogicalFilter *filter = nullptr;
+	if (join.children[delim_idx]->type == LogicalOperatorType::LOGICAL_FILTER) {
+		filter = (LogicalFilter *)join.children[delim_idx].get();
+	}
+	auto &delim_get = (LogicalDelimGet &)*(filter ? filter->children[0].get() : join.children[delim_idx].get());
+	if (join.conditions.size() != delim_get.chunk_types.size()) {
+		// joining with DelimGet adds new information
+		return false;
+	}
+	// check if joining with the DelimGet is redundant, and collect relevant column information
+	vector<Expression *> nulls_are_not_equal_exprs;
+	for (auto &cond : join.conditions) {
+		if (cond.comparison != ExpressionType::COMPARE_EQUAL &&
+		    cond.comparison != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+			// non-equality join condition
+			return false;
+		}
+		auto delim_side = delim_idx == 0 ? cond.left.get() : cond.right.get();
+		auto other_side = delim_idx == 0 ? cond.right.get() : cond.left.get();
+		if (delim_side->type != ExpressionType::BOUND_COLUMN_REF) {
+			// non-colref e.g. expression -(4, 1) in 4-i=j where i is from DelimGet
+			// FIXME: might be possible to also eliminate these
+			return false;
+		}
+		updater.expr_map[delim_side] = other_side;
+		if (cond.comparison != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+			nulls_are_not_equal_exprs.push_back(other_side);
+		}
+	}
+	// removed DelimGet columns are assigned a new ColumnBinding by Projection/Aggregation, keep track here
+	if (proj_or_agg.type == LogicalOperatorType::LOGICAL_PROJECTION) {
+		for (auto &cb : proj_or_agg.GetColumnBindings()) {
+			updater.projection_map[cb] = true;
+			for (auto &expr : nulls_are_not_equal_exprs) {
+				if (proj_or_agg.expressions[cb.column_index]->Equals(expr)) {
+					updater.projection_map[cb] = false;
+					break;
+				}
+			}
+		}
+	} else {
+		auto &agg = (LogicalAggregate &)proj_or_agg;
+		for (auto &cb : agg.GetColumnBindings()) {
+			updater.projection_map[cb] = true;
+			for (auto &expr : nulls_are_not_equal_exprs) {
+				if ((cb.table_index == agg.group_index && agg.groups[cb.column_index]->Equals(expr)) ||
+				    (cb.table_index == agg.aggregate_index && agg.expressions[cb.column_index]->Equals(expr))) {
+					updater.projection_map[cb] = false;
+					break;
+				}
+			}
+		}
+	}
+	// make a filter if needed
+	if (!nulls_are_not_equal_exprs.empty() || filter != nullptr) {
+		auto filter_op = make_unique<LogicalFilter>();
+		if (!nulls_are_not_equal_exprs.empty()) {
+			// add an IS NOT NULL filter that was implicitly in JoinCondition::null_values_are_equal
+			for (auto &expr : nulls_are_not_equal_exprs) {
+				auto is_not_null_expr =
+				    make_unique<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NOT_NULL, LogicalType::BOOLEAN);
+				is_not_null_expr->children.push_back(expr->Copy());
+				filter_op->expressions.push_back(move(is_not_null_expr));
+			}
+		}
+		if (filter != nullptr) {
+			for (auto &expr : filter->expressions) {
+				filter_op->expressions.push_back(move(expr));
+			}
+		}
+		filter_op->children.push_back(move(join.children[1 - delim_idx]));
+		join.children[1 - delim_idx] = move(filter_op);
+	}
+	// temporarily save deleted operator so its expressions are still available
+	updater.temp_ptr = move(proj_or_agg.children[0]);
+	// replace the redundant join
+	proj_or_agg.children[0] = move(join.children[1 - delim_idx]);
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> ExpressionHeuristics::Rewrite(unique_ptr<LogicalOperator> op) {
+	VisitOperator(*op);
+	return op;
+}
+
+void ExpressionHeuristics::VisitOperator(LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_FILTER) {
+		// reorder all filter expressions
+		if (op.expressions.size() > 1) {
+			ReorderExpressions(op.expressions);
+		}
+	}
+
+	// traverse recursively through the operator tree
+	VisitOperatorChildren(op);
+	VisitOperatorExpressions(op);
+}
+
+unique_ptr<Expression> ExpressionHeuristics::VisitReplace(BoundConjunctionExpression &expr,
+                                                          unique_ptr<Expression> *expr_ptr) {
+	ReorderExpressions(expr.children);
+	return nullptr;
+}
+
+void ExpressionHeuristics::ReorderExpressions(vector<unique_ptr<Expression>> &expressions) {
+
+	struct ExpressionCosts {
+		unique_ptr<Expression> expr;
+		idx_t cost;
+
+		bool operator==(const ExpressionCosts &p) const {
+			return cost == p.cost;
+		}
+		bool operator<(const ExpressionCosts &p) const {
+			return cost < p.cost;
+		}
+	};
+
+	vector<ExpressionCosts> expression_costs;
+	// iterate expressions, get cost for each one
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		idx_t cost = Cost(*expressions[i]);
+		expression_costs.push_back({move(expressions[i]), cost});
+	}
+
+	// sort by cost and put back in place
+	sort(expression_costs.begin(), expression_costs.end());
+	for (idx_t i = 0; i < expression_costs.size(); i++) {
+		expressions[i] = move(expression_costs[i].expr);
+	}
+}
+
+idx_t ExpressionHeuristics::ExpressionCost(BoundBetweenExpression &expr) {
+	return Cost(*expr.input) + Cost(*expr.lower) + Cost(*expr.upper) + 10;
+}
+
+idx_t ExpressionHeuristics::ExpressionCost(BoundCaseExpression &expr) {
+	// CASE WHEN check THEN result_if_true ELSE result_if_false END
+	idx_t case_cost = 0;
+	for (auto &case_check : expr.case_checks) {
+		case_cost += Cost(*case_check.then_expr);
+		case_cost += Cost(*case_check.when_expr);
+	}
+	case_cost += Cost(*expr.else_expr);
+	return case_cost;
+}
+
+idx_t ExpressionHeuristics::ExpressionCost(BoundCastExpression &expr) {
+	// OPERATOR_CAST
+	// determine cast cost by comparing cast_expr.source_type and cast_expr_target_type
+	idx_t cast_cost = 0;
+	if (expr.return_type != expr.source_type()) {
+		// if cast from or to varchar
+		// TODO: we might want to add more cases
+		if (expr.return_type.id() == LogicalTypeId::VARCHAR || expr.source_type().id() == LogicalTypeId::VARCHAR ||
+		    expr.return_type.id() == LogicalTypeId::BLOB || expr.source_type().id() == LogicalTypeId::BLOB) {
+			cast_cost = 200;
+		} else {
+			cast_cost = 5;
+		}
+	}
+	return Cost(*expr.child) + cast_cost;
+}
+
+idx_t ExpressionHeuristics::ExpressionCost(BoundComparisonExpression &expr) {
+	// COMPARE_EQUAL, COMPARE_NOTEQUAL, COMPARE_GREATERTHAN, COMPARE_GREATERTHANOREQUALTO, COMPARE_LESSTHAN,
+	// COMPARE_LESSTHANOREQUALTO
+	return Cost(*expr.left) + 5 + Cost(*expr.right);
+}
+
+idx_t ExpressionHeuristics::ExpressionCost(BoundConjunctionExpression &expr) {
+	// CONJUNCTION_AND, CONJUNCTION_OR
+	idx_t cost = 5;
+	for (auto &child : expr.children) {
+		cost += Cost(*child);
+	}
+	return cost;
+}
+
+idx_t ExpressionHeuristics::ExpressionCost(BoundFunctionExpression &expr) {
+	idx_t cost_children = 0;
+	for (auto &child : expr.children) {
+		cost_children += Cost(*child);
+	}
+
+	auto cost_function = function_costs.find(expr.function.name);
+	if (cost_function != function_costs.end()) {
+		return cost_children + cost_function->second;
+	} else {
+		return cost_children + 1000;
+	}
+}
+
+idx_t ExpressionHeuristics::ExpressionCost(BoundOperatorExpression &expr, ExpressionType &expr_type) {
+	idx_t sum = 0;
+	for (auto &child : expr.children) {
+		sum += Cost(*child);
+	}
+
+	// OPERATOR_IS_NULL, OPERATOR_IS_NOT_NULL
+	if (expr_type == ExpressionType::OPERATOR_IS_NULL || expr_type == ExpressionType::OPERATOR_IS_NOT_NULL) {
+		return sum + 5;
+	} else if (expr_type == ExpressionType::COMPARE_IN || expr_type == ExpressionType::COMPARE_NOT_IN) {
+		// COMPARE_IN, COMPARE_NOT_IN
+		return sum + (expr.children.size() - 1) * 100;
+	} else if (expr_type == ExpressionType::OPERATOR_NOT) {
+		// OPERATOR_NOT
+		return sum + 10; // TODO: evaluate via measured runtimes
+	} else {
+		return sum + 1000;
+	}
+}
+
+idx_t ExpressionHeuristics::ExpressionCost(PhysicalType return_type, idx_t multiplier) {
+	// TODO: ajust values according to benchmark results
+	switch (return_type) {
+	case PhysicalType::VARCHAR:
+		return 5 * multiplier;
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+		return 2 * multiplier;
+	default:
+		return 1 * multiplier;
+	}
+}
+
+idx_t ExpressionHeuristics::Cost(Expression &expr) {
+	switch (expr.expression_class) {
+	case ExpressionClass::BOUND_CASE: {
+		auto &case_expr = (BoundCaseExpression &)expr;
+		return ExpressionCost(case_expr);
+	}
+	case ExpressionClass::BOUND_BETWEEN: {
+		auto &between_expr = (BoundBetweenExpression &)expr;
+		return ExpressionCost(between_expr);
+	}
+	case ExpressionClass::BOUND_CAST: {
+		auto &cast_expr = (BoundCastExpression &)expr;
+		return ExpressionCost(cast_expr);
+	}
+	case ExpressionClass::BOUND_COMPARISON: {
+		auto &comp_expr = (BoundComparisonExpression &)expr;
+		return ExpressionCost(comp_expr);
+	}
+	case ExpressionClass::BOUND_CONJUNCTION: {
+		auto &conj_expr = (BoundConjunctionExpression &)expr;
+		return ExpressionCost(conj_expr);
+	}
+	case ExpressionClass::BOUND_FUNCTION: {
+		auto &func_expr = (BoundFunctionExpression &)expr;
+		return ExpressionCost(func_expr);
+	}
+	case ExpressionClass::BOUND_OPERATOR: {
+		auto &op_expr = (BoundOperatorExpression &)expr;
+		return ExpressionCost(op_expr, expr.type);
+	}
+	case ExpressionClass::BOUND_COLUMN_REF: {
+		auto &col_expr = (BoundColumnRefExpression &)expr;
+		return ExpressionCost(col_expr.return_type.InternalType(), 8);
+	}
+	case ExpressionClass::BOUND_CONSTANT: {
+		auto &const_expr = (BoundConstantExpression &)expr;
+		return ExpressionCost(const_expr.return_type.InternalType(), 1);
+	}
+	case ExpressionClass::BOUND_PARAMETER: {
+		auto &const_expr = (BoundParameterExpression &)expr;
+		return ExpressionCost(const_expr.return_type.InternalType(), 1);
+	}
+	case ExpressionClass::BOUND_REF: {
+		auto &col_expr = (BoundColumnRefExpression &)expr;
+		return ExpressionCost(col_expr.return_type.InternalType(), 8);
+	}
+	default: {
+		break;
+	}
+	}
+
+	// return a very high value if nothing matches
+	return 1000;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<Expression> ExpressionRewriter::ApplyRules(LogicalOperator &op, const vector<Rule *> &rules,
+                                                      unique_ptr<Expression> expr, bool &changes_made, bool is_root) {
+	for (auto &rule : rules) {
+		vector<Expression *> bindings;
+		if (rule->root->Match(expr.get(), bindings)) {
+			// the rule matches! try to apply it
+			bool rule_made_change = false;
+			auto result = rule->Apply(op, bindings, rule_made_change, is_root);
+			if (result) {
+				changes_made = true;
+				// the base node changed: the rule applied changes
+				// rerun on the new node
+				return ExpressionRewriter::ApplyRules(op, rules, move(result), changes_made);
+			} else if (rule_made_change) {
+				changes_made = true;
+				// the base node didn't change, but changes were made, rerun
+				return expr;
+			}
+			// else nothing changed, continue to the next rule
+			continue;
+		}
+	}
+	// no changes could be made to this node
+	// recursively run on the children of this node
+	ExpressionIterator::EnumerateChildren(*expr, [&](unique_ptr<Expression> &child) {
+		child = ExpressionRewriter::ApplyRules(op, rules, move(child), changes_made);
+	});
+	return expr;
+}
+
+unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(unique_ptr<Expression> child, Value value) {
+	vector<unique_ptr<Expression>> children;
+	children.push_back(move(child));
+	return ConstantOrNull(move(children), move(value));
+}
+
+unique_ptr<Expression> ExpressionRewriter::ConstantOrNull(vector<unique_ptr<Expression>> children, Value value) {
+	auto type = value.type();
+	return make_unique<BoundFunctionExpression>(type, ConstantOrNull::GetFunction(type), move(children),
+	                                            ConstantOrNull::Bind(move(value)));
+}
+
+void ExpressionRewriter::VisitOperator(LogicalOperator &op) {
+	VisitOperatorChildren(op);
+	this->op = &op;
+
+	to_apply_rules.clear();
+	for (auto &rule : rules) {
+		if (rule->logical_root && !rule->logical_root->Match(op.type)) {
+			// this rule does not apply to this type of LogicalOperator
+			continue;
+		}
+		to_apply_rules.push_back(rule.get());
+	}
+	if (to_apply_rules.empty()) {
+		// no rules to apply on this node
+		return;
+	}
+
+	VisitOperatorExpressions(op);
+
+	// if it is a LogicalFilter, we split up filter conjunctions again
+	if (op.type == LogicalOperatorType::LOGICAL_FILTER) {
+		auto &filter = (LogicalFilter &)op;
+		filter.SplitPredicates();
+	}
+}
+
+void ExpressionRewriter::VisitExpression(unique_ptr<Expression> *expression) {
+	bool changes_made;
+	do {
+		changes_made = false;
+		*expression = ExpressionRewriter::ApplyRules(*op, to_apply_rules, move(*expression), changes_made, true);
+	} while (changes_made);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+using ExpressionValueInformation = FilterCombiner::ExpressionValueInformation;
+
+ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, ExpressionValueInformation &right);
+
+Expression *FilterCombiner::GetNode(Expression *expr) {
+	auto entry = stored_expressions.find(expr);
+	if (entry != stored_expressions.end()) {
+		// expression already exists: return a reference to the stored expression
+		return entry->second.get();
+	}
+	// expression does not exist yet: create a copy and store it
+	auto copy = expr->Copy();
+	auto pointer_copy = copy.get();
+	D_ASSERT(stored_expressions.find(pointer_copy) == stored_expressions.end());
+	stored_expressions.insert(make_pair(pointer_copy, move(copy)));
+	return pointer_copy;
+}
+
+idx_t FilterCombiner::GetEquivalenceSet(Expression *expr) {
+	D_ASSERT(stored_expressions.find(expr) != stored_expressions.end());
+	D_ASSERT(stored_expressions.find(expr)->second.get() == expr);
+	auto entry = equivalence_set_map.find(expr);
+	if (entry == equivalence_set_map.end()) {
+		idx_t index = set_index++;
+		equivalence_set_map[expr] = index;
+		equivalence_map[index].push_back(expr);
+		constant_values.insert(make_pair(index, vector<ExpressionValueInformation>()));
+		return index;
+	} else {
+		return entry->second;
+	}
+}
+
+FilterResult FilterCombiner::AddConstantComparison(vector<ExpressionValueInformation> &info_list,
+                                                   ExpressionValueInformation info) {
+	for (idx_t i = 0; i < info_list.size(); i++) {
+		auto comparison = CompareValueInformation(info_list[i], info);
+		switch (comparison) {
+		case ValueComparisonResult::PRUNE_LEFT:
+			// prune the entry from the info list
+			info_list.erase(info_list.begin() + i);
+			i--;
+			break;
+		case ValueComparisonResult::PRUNE_RIGHT:
+			// prune the current info
+			return FilterResult::SUCCESS;
+		case ValueComparisonResult::UNSATISFIABLE_CONDITION:
+			// combination of filters is unsatisfiable: prune the entire branch
+			return FilterResult::UNSATISFIABLE;
+		default:
+			// prune nothing, move to the next condition
+			break;
+		}
+	}
+	// finally add the entry to the list
+	info_list.push_back(info);
+	return FilterResult::SUCCESS;
+}
+
+FilterResult FilterCombiner::AddFilter(unique_ptr<Expression> expr) {
+	//	LookUpConjunctions(expr.get());
+	// try to push the filter into the combiner
+	auto result = AddFilter(expr.get());
+	if (result == FilterResult::UNSUPPORTED) {
+		// unsupported filter, push into remaining filters
+		remaining_filters.push_back(move(expr));
+		return FilterResult::SUCCESS;
+	}
+	return result;
+}
+
+void FilterCombiner::GenerateFilters(const std::function<void(unique_ptr<Expression> filter)> &callback) {
+	// first loop over the remaining filters
+	for (auto &filter : remaining_filters) {
+		callback(move(filter));
+	}
+	remaining_filters.clear();
+	// now loop over the equivalence sets
+	for (auto &entry : equivalence_map) {
+		auto equivalence_set = entry.first;
+		auto &entries = entry.second;
+		auto &constant_list = constant_values.find(equivalence_set)->second;
+		// for each entry generate an equality expression comparing to each other
+		for (idx_t i = 0; i < entries.size(); i++) {
+			for (idx_t k = i + 1; k < entries.size(); k++) {
+				auto comparison = make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_EQUAL,
+				                                                         entries[i]->Copy(), entries[k]->Copy());
+				callback(move(comparison));
+			}
+			// for each entry also create a comparison with each constant
+			int lower_index = -1, upper_index = -1;
+			bool lower_inclusive, upper_inclusive;
+			for (idx_t k = 0; k < constant_list.size(); k++) {
+				auto &info = constant_list[k];
+				if (info.comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
+				    info.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO) {
+					lower_index = k;
+					lower_inclusive = info.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+				} else if (info.comparison_type == ExpressionType::COMPARE_LESSTHAN ||
+				           info.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO) {
+					upper_index = k;
+					upper_inclusive = info.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
+				} else {
+					auto constant = make_unique<BoundConstantExpression>(info.constant);
+					auto comparison = make_unique<BoundComparisonExpression>(info.comparison_type, entries[i]->Copy(),
+					                                                         move(constant));
+					callback(move(comparison));
+				}
+			}
+			if (lower_index >= 0 && upper_index >= 0) {
+				// found both lower and upper index, create a BETWEEN expression
+				auto lower_constant = make_unique<BoundConstantExpression>(constant_list[lower_index].constant);
+				auto upper_constant = make_unique<BoundConstantExpression>(constant_list[upper_index].constant);
+				auto between = make_unique<BoundBetweenExpression>(
+				    entries[i]->Copy(), move(lower_constant), move(upper_constant), lower_inclusive, upper_inclusive);
+				callback(move(between));
+			} else if (lower_index >= 0) {
+				// only lower index found, create simple comparison expression
+				auto constant = make_unique<BoundConstantExpression>(constant_list[lower_index].constant);
+				auto comparison = make_unique<BoundComparisonExpression>(constant_list[lower_index].comparison_type,
+				                                                         entries[i]->Copy(), move(constant));
+				callback(move(comparison));
+			} else if (upper_index >= 0) {
+				// only upper index found, create simple comparison expression
+				auto constant = make_unique<BoundConstantExpression>(constant_list[upper_index].constant);
+				auto comparison = make_unique<BoundComparisonExpression>(constant_list[upper_index].comparison_type,
+				                                                         entries[i]->Copy(), move(constant));
+				callback(move(comparison));
+			}
+		}
+	}
+	stored_expressions.clear();
+	equivalence_set_map.clear();
+	constant_values.clear();
+	equivalence_map.clear();
+}
+
+bool FilterCombiner::HasFilters() {
+	bool has_filters = false;
+	GenerateFilters([&](unique_ptr<Expression> child) { has_filters = true; });
+	return has_filters;
+}
+
+// unordered_map<idx_t, std::pair<Value *, Value *>> MergeAnd(unordered_map<idx_t, std::pair<Value *, Value *>> &f_1,
+//                                                            unordered_map<idx_t, std::pair<Value *, Value *>> &f_2) {
+// 	unordered_map<idx_t, std::pair<Value *, Value *>> result;
+// 	for (auto &f : f_1) {
+// 		auto it = f_2.find(f.first);
+// 		if (it == f_2.end()) {
+// 			result[f.first] = f.second;
+// 		} else {
+// 			Value *min = nullptr, *max = nullptr;
+// 			if (it->second.first && f.second.first) {
+// 				if (*f.second.first > *it->second.first) {
+// 					min = f.second.first;
+// 				} else {
+// 					min = it->second.first;
+// 				}
+
+// 			} else if (it->second.first) {
+// 				min = it->second.first;
+// 			} else if (f.second.first) {
+// 				min = f.second.first;
+// 			} else {
+// 				min = nullptr;
+// 			}
+// 			if (it->second.second && f.second.second) {
+// 				if (*f.second.second < *it->second.second) {
+// 					max = f.second.second;
+// 				} else {
+// 					max = it->second.second;
+// 				}
+// 			} else if (it->second.second) {
+// 				max = it->second.second;
+// 			} else if (f.second.second) {
+// 				max = f.second.second;
+// 			} else {
+// 				max = nullptr;
+// 			}
+// 			result[f.first] = {min, max};
+// 			f_2.erase(f.first);
+// 		}
+// 	}
+// 	for (auto &f : f_2) {
+// 		result[f.first] = f.second;
+// 	}
+// 	return result;
+// }
+
+// unordered_map<idx_t, std::pair<Value *, Value *>> MergeOr(unordered_map<idx_t, std::pair<Value *, Value *>> &f_1,
+//                                                           unordered_map<idx_t, std::pair<Value *, Value *>> &f_2) {
+// 	unordered_map<idx_t, std::pair<Value *, Value *>> result;
+// 	for (auto &f : f_1) {
+// 		auto it = f_2.find(f.first);
+// 		if (it != f_2.end()) {
+// 			Value *min = nullptr, *max = nullptr;
+// 			if (it->second.first && f.second.first) {
+// 				if (*f.second.first < *it->second.first) {
+// 					min = f.second.first;
+// 				} else {
+// 					min = it->second.first;
+// 				}
+// 			}
+// 			if (it->second.second && f.second.second) {
+// 				if (*f.second.second > *it->second.second) {
+// 					max = f.second.second;
+// 				} else {
+// 					max = it->second.second;
+// 				}
+// 			}
+// 			result[f.first] = {min, max};
+// 			f_2.erase(f.first);
+// 		}
+// 	}
+// 	return result;
+// }
+
+// unordered_map<idx_t, std::pair<Value *, Value *>>
+// FilterCombiner::FindZonemapChecks(vector<idx_t> &column_ids, unordered_set<idx_t> &not_constants, Expression *filter)
+// { 	unordered_map<idx_t, std::pair<Value *, Value *>> checks; 	switch (filter->type) { 	case
+// ExpressionType::CONJUNCTION_OR: {
+// 		//! For a filter to
+// 		auto &or_exp = (BoundConjunctionExpression &)*filter;
+// 		checks = FindZonemapChecks(column_ids, not_constants, or_exp.children[0].get());
+// 		for (size_t i = 1; i < or_exp.children.size(); ++i) {
+// 			auto child_check = FindZonemapChecks(column_ids, not_constants, or_exp.children[i].get());
+// 			checks = MergeOr(checks, child_check);
+// 		}
+// 		return checks;
+// 	}
+// 	case ExpressionType::CONJUNCTION_AND: {
+// 		auto &and_exp = (BoundConjunctionExpression &)*filter;
+// 		checks = FindZonemapChecks(column_ids, not_constants, and_exp.children[0].get());
+// 		for (size_t i = 1; i < and_exp.children.size(); ++i) {
+// 			auto child_check = FindZonemapChecks(column_ids, not_constants, and_exp.children[i].get());
+// 			checks = MergeAnd(checks, child_check);
+// 		}
+// 		return checks;
+// 	}
+// 	case ExpressionType::COMPARE_IN: {
+// 		auto &comp_in_exp = (BoundOperatorExpression &)*filter;
+// 		if (comp_in_exp.children[0]->type == ExpressionType::BOUND_COLUMN_REF) {
+// 			Value *min = nullptr, *max = nullptr;
+// 			auto &column_ref = (BoundColumnRefExpression &)*comp_in_exp.children[0].get();
+// 			for (size_t i {1}; i < comp_in_exp.children.size(); i++) {
+// 				if (comp_in_exp.children[i]->type != ExpressionType::VALUE_CONSTANT) {
+// 					//! This indicates the column has a comparison that is not with a constant
+// 					not_constants.insert(column_ids[column_ref.binding.column_index]);
+// 					break;
+// 				} else {
+// 					auto &const_value_expr = (BoundConstantExpression &)*comp_in_exp.children[i].get();
+// 					if (const_value_expr.value.IsNull()) {
+// 						return checks;
+// 					}
+// 					if (!min && !max) {
+// 						min = &const_value_expr.value;
+// 						max = min;
+// 					} else {
+// 						if (*min > const_value_expr.value) {
+// 							min = &const_value_expr.value;
+// 						}
+// 						if (*max < const_value_expr.value) {
+// 							max = &const_value_expr.value;
+// 						}
+// 					}
+// 				}
+// 			}
+// 			checks[column_ids[column_ref.binding.column_index]] = {min, max};
+// 		}
+// 		return checks;
+// 	}
+// 	case ExpressionType::COMPARE_EQUAL: {
+// 		auto &comp_exp = (BoundComparisonExpression &)*filter;
+// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_COLUMN_REF &&
+// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_CONSTANT)) {
+// 			auto &column_ref = (BoundColumnRefExpression &)*comp_exp.left;
+// 			auto &constant_value_expr = (BoundConstantExpression &)*comp_exp.right;
+// 			checks[column_ids[column_ref.binding.column_index]] = {&constant_value_expr.value,
+// 			                                                       &constant_value_expr.value};
+// 		}
+// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_CONSTANT &&
+// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_COLUMN_REF)) {
+// 			auto &column_ref = (BoundColumnRefExpression &)*comp_exp.right;
+// 			auto &constant_value_expr = (BoundConstantExpression &)*comp_exp.left;
+// 			checks[column_ids[column_ref.binding.column_index]] = {&constant_value_expr.value,
+// 			                                                       &constant_value_expr.value};
+// 		}
+// 		return checks;
+// 	}
+// 	case ExpressionType::COMPARE_LESSTHAN:
+// 	case ExpressionType::COMPARE_LESSTHANOREQUALTO: {
+// 		auto &comp_exp = (BoundComparisonExpression &)*filter;
+// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_COLUMN_REF &&
+// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_CONSTANT)) {
+// 			auto &column_ref = (BoundColumnRefExpression &)*comp_exp.left;
+// 			auto &constant_value_expr = (BoundConstantExpression &)*comp_exp.right;
+// 			checks[column_ids[column_ref.binding.column_index]] = {nullptr, &constant_value_expr.value};
+// 		}
+// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_CONSTANT &&
+// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_COLUMN_REF)) {
+// 			auto &column_ref = (BoundColumnRefExpression &)*comp_exp.right;
+// 			auto &constant_value_expr = (BoundConstantExpression &)*comp_exp.left;
+// 			checks[column_ids[column_ref.binding.column_index]] = {&constant_value_expr.value, nullptr};
+// 		}
+// 		return checks;
+// 	}
+// 	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+// 	case ExpressionType::COMPARE_GREATERTHAN: {
+// 		auto &comp_exp = (BoundComparisonExpression &)*filter;
+// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_COLUMN_REF &&
+// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_CONSTANT)) {
+// 			auto &column_ref = (BoundColumnRefExpression &)*comp_exp.left;
+// 			auto &constant_value_expr = (BoundConstantExpression &)*comp_exp.right;
+// 			checks[column_ids[column_ref.binding.column_index]] = {&constant_value_expr.value, nullptr};
+// 		}
+// 		if ((comp_exp.left->expression_class == ExpressionClass::BOUND_CONSTANT &&
+// 		     comp_exp.right->expression_class == ExpressionClass::BOUND_COLUMN_REF)) {
+// 			auto &column_ref = (BoundColumnRefExpression &)*comp_exp.right;
+// 			auto &constant_value_expr = (BoundConstantExpression &)*comp_exp.left;
+// 			checks[column_ids[column_ref.binding.column_index]] = {nullptr, &constant_value_expr.value};
+// 		}
+// 		return checks;
+// 	}
+// 	default:
+// 		return checks;
+// 	}
+// }
+
+// vector<TableFilter> FilterCombiner::GenerateZonemapChecks(vector<idx_t> &column_ids,
+//                                                           vector<TableFilter> &pushed_filters) {
+// 	vector<TableFilter> zonemap_checks;
+// 	unordered_set<idx_t> not_constants;
+// 	//! We go through the remaining filters and capture their min max
+// 	if (remaining_filters.empty()) {
+// 		return zonemap_checks;
+// 	}
+
+// 	auto checks = FindZonemapChecks(column_ids, not_constants, remaining_filters[0].get());
+// 	for (size_t i = 1; i < remaining_filters.size(); ++i) {
+// 		auto child_check = FindZonemapChecks(column_ids, not_constants, remaining_filters[i].get());
+// 		checks = MergeAnd(checks, child_check);
+// 	}
+// 	//! We construct the equivalent filters
+// 	for (auto not_constant : not_constants) {
+// 		checks.erase(not_constant);
+// 	}
+// 	for (const auto &pushed_filter : pushed_filters) {
+// 		checks.erase(column_ids[pushed_filter.column_index]);
+// 	}
+// 	for (const auto &check : checks) {
+// 		if (check.second.first) {
+// 			zonemap_checks.emplace_back(check.second.first->Copy(), ExpressionType::COMPARE_GREATERTHANOREQUALTO,
+// 			                            check.first);
+// 		}
+// 		if (check.second.second) {
+// 			zonemap_checks.emplace_back(check.second.second->Copy(), ExpressionType::COMPARE_LESSTHANOREQUALTO,
+// 			                            check.first);
+// 		}
+// 	}
+// 	return zonemap_checks;
+// }
+
+TableFilterSet FilterCombiner::GenerateTableScanFilters(vector<idx_t> &column_ids) {
+	TableFilterSet table_filters;
+	//! First, we figure the filters that have constant expressions that we can push down to the table scan
+	for (auto &constant_value : constant_values) {
+		if (!constant_value.second.empty()) {
+			auto filter_exp = equivalence_map.end();
+			if ((constant_value.second[0].comparison_type == ExpressionType::COMPARE_EQUAL ||
+			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
+			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO ||
+			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_LESSTHAN ||
+			     constant_value.second[0].comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO) &&
+			    (TypeIsNumeric(constant_value.second[0].constant.type().InternalType()) ||
+			     constant_value.second[0].constant.type().InternalType() == PhysicalType::VARCHAR ||
+			     constant_value.second[0].constant.type().InternalType() == PhysicalType::BOOL)) {
+				//! Here we check if these filters are column references
+				filter_exp = equivalence_map.find(constant_value.first);
+				if (filter_exp->second.size() == 1 && filter_exp->second[0]->type == ExpressionType::BOUND_COLUMN_REF) {
+					auto filter_col_exp = static_cast<BoundColumnRefExpression *>(filter_exp->second[0]);
+					auto column_index = column_ids[filter_col_exp->binding.column_index];
+					if (column_index == COLUMN_IDENTIFIER_ROW_ID) {
+						break;
+					}
+					auto equivalence_set = filter_exp->first;
+					auto &entries = filter_exp->second;
+					auto &constant_list = constant_values.find(equivalence_set)->second;
+					// for each entry generate an equality expression comparing to each other
+					for (idx_t i = 0; i < entries.size(); i++) {
+						// for each entry also create a comparison with each constant
+						for (idx_t k = 0; k < constant_list.size(); k++) {
+							auto constant_filter = make_unique<ConstantFilter>(constant_value.second[k].comparison_type,
+							                                                   constant_value.second[k].constant);
+							table_filters.PushFilter(column_index, move(constant_filter));
+						}
+						table_filters.PushFilter(column_index, make_unique<IsNotNullFilter>());
+					}
+					equivalence_map.erase(filter_exp);
+				}
+			}
+		}
+	}
+	//! Here we look for LIKE or IN filters
+	for (idx_t rem_fil_idx = 0; rem_fil_idx < remaining_filters.size(); rem_fil_idx++) {
+		auto &remaining_filter = remaining_filters[rem_fil_idx];
+		if (remaining_filter->expression_class == ExpressionClass::BOUND_FUNCTION) {
+			auto &func = (BoundFunctionExpression &)*remaining_filter;
+			if (func.function.name == "prefix" &&
+			    func.children[0]->expression_class == ExpressionClass::BOUND_COLUMN_REF &&
+			    func.children[1]->type == ExpressionType::VALUE_CONSTANT) {
+				//! This is a like function.
+				auto &column_ref = (BoundColumnRefExpression &)*func.children[0].get();
+				auto &constant_value_expr = (BoundConstantExpression &)*func.children[1].get();
+				auto like_string = StringValue::Get(constant_value_expr.value);
+				if (like_string.empty()) {
+					continue;
+				}
+				auto column_index = column_ids[column_ref.binding.column_index];
+				//! Here the like must be transformed to a BOUND COMPARISON geq le
+				auto lower_bound =
+				    make_unique<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value(like_string));
+				like_string[like_string.size() - 1]++;
+				auto upper_bound = make_unique<ConstantFilter>(ExpressionType::COMPARE_LESSTHAN, Value(like_string));
+				table_filters.PushFilter(column_index, move(lower_bound));
+				table_filters.PushFilter(column_index, move(upper_bound));
+				table_filters.PushFilter(column_index, make_unique<IsNotNullFilter>());
+			}
+			if (func.function.name == "~~" && func.children[0]->expression_class == ExpressionClass::BOUND_COLUMN_REF &&
+			    func.children[1]->type == ExpressionType::VALUE_CONSTANT) {
+				//! This is a like function.
+				auto &column_ref = (BoundColumnRefExpression &)*func.children[0].get();
+				auto &constant_value_expr = (BoundConstantExpression &)*func.children[1].get();
+				auto &like_string = StringValue::Get(constant_value_expr.value);
+				if (like_string[0] == '%' || like_string[0] == '_') {
+					//! We have no prefix so nothing to pushdown
+					break;
+				}
+				string prefix;
+				bool equality = true;
+				for (char const &c : like_string) {
+					if (c == '%' || c == '_') {
+						equality = false;
+						break;
+					}
+					prefix += c;
+				}
+				auto column_index = column_ids[column_ref.binding.column_index];
+				if (equality) {
+					//! Here the like can be transformed to an equality query
+					auto equal_filter = make_unique<ConstantFilter>(ExpressionType::COMPARE_EQUAL, Value(prefix));
+					table_filters.PushFilter(column_index, move(equal_filter));
+					table_filters.PushFilter(column_index, make_unique<IsNotNullFilter>());
+				} else {
+					//! Here the like must be transformed to a BOUND COMPARISON geq le
+					auto lower_bound =
+					    make_unique<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, Value(prefix));
+					prefix[prefix.size() - 1]++;
+					auto upper_bound = make_unique<ConstantFilter>(ExpressionType::COMPARE_LESSTHAN, Value(prefix));
+					table_filters.PushFilter(column_index, move(lower_bound));
+					table_filters.PushFilter(column_index, move(upper_bound));
+					table_filters.PushFilter(column_index, make_unique<IsNotNullFilter>());
+				}
+			}
+		} else if (remaining_filter->type == ExpressionType::COMPARE_IN) {
+			auto &func = (BoundOperatorExpression &)*remaining_filter;
+			vector<hugeint_t> in_values;
+			D_ASSERT(func.children.size() > 1);
+			if (func.children[0]->expression_class != ExpressionClass::BOUND_COLUMN_REF) {
+				continue;
+			}
+			auto &column_ref = (BoundColumnRefExpression &)*func.children[0].get();
+			auto column_index = column_ids[column_ref.binding.column_index];
+			if (column_index == COLUMN_IDENTIFIER_ROW_ID) {
+				break;
+			}
+			//! check if all children are const expr
+			bool children_constant = true;
+			for (size_t i {1}; i < func.children.size(); i++) {
+				if (func.children[i]->type != ExpressionType::VALUE_CONSTANT) {
+					children_constant = false;
+				}
+			}
+			if (!children_constant) {
+				continue;
+			}
+			auto &fst_const_value_expr = (BoundConstantExpression &)*func.children[1].get();
+			auto &type = fst_const_value_expr.value.type();
+
+			//! Check if values are consecutive, if yes transform them to >= <= (only for integers)
+			// e.g. if we have x IN (1, 2, 3, 4, 5) we transform this into x >= 1 AND x <= 5
+			if (!type.IsIntegral()) {
+				continue;
+			}
+
+			bool can_simplify_in_clause = true;
+			for (idx_t i = 1; i < func.children.size(); i++) {
+				auto &const_value_expr = (BoundConstantExpression &)*func.children[i].get();
+				if (const_value_expr.value.IsNull()) {
+					can_simplify_in_clause = false;
+					break;
+				}
+				in_values.push_back(const_value_expr.value.GetValue<hugeint_t>());
+			}
+			if (!can_simplify_in_clause || in_values.empty()) {
+				continue;
+			}
+
+			sort(in_values.begin(), in_values.end());
+
+			for (idx_t in_val_idx = 1; in_val_idx < in_values.size(); in_val_idx++) {
+				if (in_values[in_val_idx] - in_values[in_val_idx - 1] > 1) {
+					can_simplify_in_clause = false;
+					break;
+				}
+			}
+			if (!can_simplify_in_clause) {
+				continue;
+			}
+			auto lower_bound = make_unique<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO,
+			                                               Value::Numeric(type, in_values.front()));
+			auto upper_bound = make_unique<ConstantFilter>(ExpressionType::COMPARE_LESSTHANOREQUALTO,
+			                                               Value::Numeric(type, in_values.back()));
+			table_filters.PushFilter(column_index, move(lower_bound));
+			table_filters.PushFilter(column_index, move(upper_bound));
+			table_filters.PushFilter(column_index, make_unique<IsNotNullFilter>());
+
+			remaining_filters.erase(remaining_filters.begin() + rem_fil_idx);
+		}
+	}
+
+	//	GenerateORFilters(table_filters, column_ids);
+
+	return table_filters;
+}
+
+static bool IsGreaterThan(ExpressionType type) {
+	return type == ExpressionType::COMPARE_GREATERTHAN || type == ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+}
+
+static bool IsLessThan(ExpressionType type) {
+	return type == ExpressionType::COMPARE_LESSTHAN || type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
+}
+
+FilterResult FilterCombiner::AddBoundComparisonFilter(Expression *expr) {
+	auto &comparison = (BoundComparisonExpression &)*expr;
+	if (comparison.type != ExpressionType::COMPARE_LESSTHAN &&
+	    comparison.type != ExpressionType::COMPARE_LESSTHANOREQUALTO &&
+	    comparison.type != ExpressionType::COMPARE_GREATERTHAN &&
+	    comparison.type != ExpressionType::COMPARE_GREATERTHANOREQUALTO &&
+	    comparison.type != ExpressionType::COMPARE_EQUAL && comparison.type != ExpressionType::COMPARE_NOTEQUAL) {
+		// only support [>, >=, <, <=, ==] expressions
+		return FilterResult::UNSUPPORTED;
+	}
+	// check if one of the sides is a scalar value
+	bool left_is_scalar = comparison.left->IsFoldable();
+	bool right_is_scalar = comparison.right->IsFoldable();
+	if (left_is_scalar || right_is_scalar) {
+		// comparison with scalar
+		auto node = GetNode(left_is_scalar ? comparison.right.get() : comparison.left.get());
+		idx_t equivalence_set = GetEquivalenceSet(node);
+		auto scalar = left_is_scalar ? comparison.left.get() : comparison.right.get();
+		auto constant_value = ExpressionExecutor::EvaluateScalar(*scalar);
+		if (constant_value.IsNull()) {
+			// comparisons with null are always null (i.e. will never result in rows)
+			return FilterResult::UNSATISFIABLE;
+		}
+
+		// create the ExpressionValueInformation
+		ExpressionValueInformation info;
+		info.comparison_type = left_is_scalar ? FlipComparisionExpression(comparison.type) : comparison.type;
+		info.constant = constant_value;
+
+		// get the current bucket of constant values
+		D_ASSERT(constant_values.find(equivalence_set) != constant_values.end());
+		auto &info_list = constant_values.find(equivalence_set)->second;
+		// check the existing constant comparisons to see if we can do any pruning
+		auto ret = AddConstantComparison(info_list, info);
+
+		auto non_scalar = left_is_scalar ? comparison.right.get() : comparison.left.get();
+		auto transitive_filter = FindTransitiveFilter(non_scalar);
+		if (transitive_filter != nullptr) {
+			// try to add transitive filters
+			if (AddTransitiveFilters((BoundComparisonExpression &)*transitive_filter) == FilterResult::UNSUPPORTED) {
+				// in case of unsuccessful re-add filter into remaining ones
+				remaining_filters.push_back(move(transitive_filter));
+			}
+		}
+		return ret;
+	} else {
+		// comparison between two non-scalars
+		// only handle comparisons for now
+		if (expr->type != ExpressionType::COMPARE_EQUAL) {
+			if (IsGreaterThan(expr->type) || IsLessThan(expr->type)) {
+				return AddTransitiveFilters(comparison);
+			}
+			return FilterResult::UNSUPPORTED;
+		}
+		// get the LHS and RHS nodes
+		auto left_node = GetNode(comparison.left.get());
+		auto right_node = GetNode(comparison.right.get());
+		if (BaseExpression::Equals(left_node, right_node)) {
+			return FilterResult::UNSUPPORTED;
+		}
+		// get the equivalence sets of the LHS and RHS
+		auto left_equivalence_set = GetEquivalenceSet(left_node);
+		auto right_equivalence_set = GetEquivalenceSet(right_node);
+		if (left_equivalence_set == right_equivalence_set) {
+			// this equality filter already exists, prune it
+			return FilterResult::SUCCESS;
+		}
+		// add the right bucket into the left bucket
+		D_ASSERT(equivalence_map.find(left_equivalence_set) != equivalence_map.end());
+		D_ASSERT(equivalence_map.find(right_equivalence_set) != equivalence_map.end());
+
+		auto &left_bucket = equivalence_map.find(left_equivalence_set)->second;
+		auto &right_bucket = equivalence_map.find(right_equivalence_set)->second;
+		for (auto &i : right_bucket) {
+			// rewrite the equivalence set mapping for this node
+			equivalence_set_map[i] = left_equivalence_set;
+			// add the node to the left bucket
+			left_bucket.push_back(i);
+		}
+		// now add all constant values from the right bucket to the left bucket
+		D_ASSERT(constant_values.find(left_equivalence_set) != constant_values.end());
+		D_ASSERT(constant_values.find(right_equivalence_set) != constant_values.end());
+		auto &left_constant_bucket = constant_values.find(left_equivalence_set)->second;
+		auto &right_constant_bucket = constant_values.find(right_equivalence_set)->second;
+		for (auto &i : right_constant_bucket) {
+			if (AddConstantComparison(left_constant_bucket, i) == FilterResult::UNSATISFIABLE) {
+				return FilterResult::UNSATISFIABLE;
+			}
+		}
+	}
+	return FilterResult::SUCCESS;
+}
+
+FilterResult FilterCombiner::AddFilter(Expression *expr) {
+	if (expr->HasParameter()) {
+		return FilterResult::UNSUPPORTED;
+	}
+	if (expr->IsFoldable()) {
+		// scalar condition, evaluate it
+		auto result = ExpressionExecutor::EvaluateScalar(*expr).CastAs(LogicalType::BOOLEAN);
+		// check if the filter passes
+		if (result.IsNull() || !BooleanValue::Get(result)) {
+			// the filter does not pass the scalar test, create an empty result
+			return FilterResult::UNSATISFIABLE;
+		} else {
+			// the filter passes the scalar test, just remove the condition
+			return FilterResult::SUCCESS;
+		}
+	}
+	D_ASSERT(!expr->IsFoldable());
+	if (expr->GetExpressionClass() == ExpressionClass::BOUND_BETWEEN) {
+		auto &comparison = (BoundBetweenExpression &)*expr;
+		//! check if one of the sides is a scalar value
+		bool lower_is_scalar = comparison.lower->IsFoldable();
+		bool upper_is_scalar = comparison.upper->IsFoldable();
+		if (lower_is_scalar || upper_is_scalar) {
+			//! comparison with scalar - break apart
+			auto node = GetNode(comparison.input.get());
+			idx_t equivalence_set = GetEquivalenceSet(node);
+			auto result = FilterResult::UNSATISFIABLE;
+
+			if (lower_is_scalar) {
+				auto scalar = comparison.lower.get();
+				auto constant_value = ExpressionExecutor::EvaluateScalar(*scalar);
+
+				// create the ExpressionValueInformation
+				ExpressionValueInformation info;
+				if (comparison.lower_inclusive) {
+					info.comparison_type = ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+				} else {
+					info.comparison_type = ExpressionType::COMPARE_GREATERTHAN;
+				}
+				info.constant = constant_value;
+
+				// get the current bucket of constant values
+				D_ASSERT(constant_values.find(equivalence_set) != constant_values.end());
+				auto &info_list = constant_values.find(equivalence_set)->second;
+				// check the existing constant comparisons to see if we can do any pruning
+				result = AddConstantComparison(info_list, info);
+			} else {
+				D_ASSERT(upper_is_scalar);
+				const auto type = comparison.upper_inclusive ? ExpressionType::COMPARE_LESSTHANOREQUALTO
+				                                             : ExpressionType::COMPARE_LESSTHAN;
+				auto left = comparison.lower->Copy();
+				auto right = comparison.input->Copy();
+				auto lower_comp = make_unique<BoundComparisonExpression>(type, move(left), move(right));
+				result = AddBoundComparisonFilter(lower_comp.get());
+			}
+
+			//	 Stop if we failed
+			if (result != FilterResult::SUCCESS) {
+				return result;
+			}
+
+			if (upper_is_scalar) {
+				auto scalar = comparison.upper.get();
+				auto constant_value = ExpressionExecutor::EvaluateScalar(*scalar);
+
+				// create the ExpressionValueInformation
+				ExpressionValueInformation info;
+				if (comparison.upper_inclusive) {
+					info.comparison_type = ExpressionType::COMPARE_LESSTHANOREQUALTO;
+				} else {
+					info.comparison_type = ExpressionType::COMPARE_LESSTHAN;
+				}
+				info.constant = constant_value;
+
+				// get the current bucket of constant values
+				D_ASSERT(constant_values.find(equivalence_set) != constant_values.end());
+				// check the existing constant comparisons to see if we can do any pruning
+				result = AddConstantComparison(constant_values.find(equivalence_set)->second, info);
+			} else {
+				D_ASSERT(lower_is_scalar);
+				const auto type = comparison.upper_inclusive ? ExpressionType::COMPARE_LESSTHANOREQUALTO
+				                                             : ExpressionType::COMPARE_LESSTHAN;
+				auto left = comparison.input->Copy();
+				auto right = comparison.upper->Copy();
+				auto upper_comp = make_unique<BoundComparisonExpression>(type, move(left), move(right));
+				result = AddBoundComparisonFilter(upper_comp.get());
+			}
+
+			return result;
+		}
+	} else if (expr->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
+		return AddBoundComparisonFilter(expr);
+	}
+	// only comparisons supported for now
+	return FilterResult::UNSUPPORTED;
+}
+
+/*
+ * Create and add new transitive filters from a two non-scalar filter such as j > i, j >= i, j < i, and j <= i
+ * It's missing to create another method to add transitive filters from scalar filters, e.g, i > 10
+ */
+FilterResult FilterCombiner::AddTransitiveFilters(BoundComparisonExpression &comparison) {
+	D_ASSERT(IsGreaterThan(comparison.type) || IsLessThan(comparison.type));
+	// get the LHS and RHS nodes
+	Expression *left_node = GetNode(comparison.left.get());
+	Expression *right_node = GetNode(comparison.right.get());
+	// In case with filters like CAST(i) = j and i = 5 we replace the COLUMN_REF i with the constant 5
+	if (right_node->type == ExpressionType::OPERATOR_CAST) {
+		auto &bound_cast_expr = (BoundCastExpression &)*right_node;
+		if (bound_cast_expr.child->type == ExpressionType::BOUND_COLUMN_REF) {
+			auto &col_ref = (BoundColumnRefExpression &)*bound_cast_expr.child;
+			for (auto &stored_exp : stored_expressions) {
+				if (stored_exp.first->type == ExpressionType::BOUND_COLUMN_REF) {
+					auto &st_col_ref = (BoundColumnRefExpression &)*stored_exp.second;
+					if (st_col_ref.binding == col_ref.binding) {
+						bound_cast_expr.child = stored_exp.second->Copy();
+						right_node = GetNode(bound_cast_expr.child.get());
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	if (BaseExpression::Equals(left_node, right_node)) {
+		return FilterResult::UNSUPPORTED;
+	}
+	// get the equivalence sets of the LHS and RHS
+	idx_t left_equivalence_set = GetEquivalenceSet(left_node);
+	idx_t right_equivalence_set = GetEquivalenceSet(right_node);
+	if (left_equivalence_set == right_equivalence_set) {
+		// this equality filter already exists, prune it
+		return FilterResult::SUCCESS;
+	}
+
+	vector<ExpressionValueInformation> &left_constants = constant_values.find(left_equivalence_set)->second;
+	vector<ExpressionValueInformation> &right_constants = constant_values.find(right_equivalence_set)->second;
+	bool is_successful = false;
+	bool is_inserted = false;
+	// read every constant filters already inserted for the right scalar variable
+	// and see if we can create new transitive filters, e.g., there is already a filter i > 10,
+	// suppose that we have now the j >= i, then we can infer a new filter j > 10
+	for (const auto &right_constant : right_constants) {
+		ExpressionValueInformation info;
+		info.constant = right_constant.constant;
+		// there is already an equality filter, e.g., i = 10
+		if (right_constant.comparison_type == ExpressionType::COMPARE_EQUAL) {
+			// create filter j [>, >=, <, <=] 10
+			// suppose the new comparison is j >= i and we have already a filter i = 10,
+			// then we create a new filter j >= 10
+			// and the filter j >= i can be pruned by not adding it into the remaining filters
+			info.comparison_type = comparison.type;
+		} else if ((comparison.type == ExpressionType::COMPARE_GREATERTHANOREQUALTO &&
+		            IsGreaterThan(right_constant.comparison_type)) ||
+		           (comparison.type == ExpressionType::COMPARE_LESSTHANOREQUALTO &&
+		            IsLessThan(right_constant.comparison_type))) {
+			// filters (j >= i AND i [>, >=] 10) OR (j <= i AND i [<, <=] 10)
+			// create filter j [>, >=] 10 and add the filter j [>=, <=] i into the remaining filters
+			info.comparison_type = right_constant.comparison_type; // create filter j [>, >=, <, <=] 10
+			if (!is_inserted) {
+				// Add the filter j >= i in the remaing filters
+				auto filter = make_unique<BoundComparisonExpression>(comparison.type, comparison.left->Copy(),
+				                                                     comparison.right->Copy());
+				remaining_filters.push_back(move(filter));
+				is_inserted = true;
+			}
+		} else if ((comparison.type == ExpressionType::COMPARE_GREATERTHAN &&
+		            IsGreaterThan(right_constant.comparison_type)) ||
+		           (comparison.type == ExpressionType::COMPARE_LESSTHAN &&
+		            IsLessThan(right_constant.comparison_type))) {
+			// filters (j > i AND i [>, >=] 10) OR j < i AND i [<, <=] 10
+			// create filter j [>, <] 10 and add the filter j [>, <] i into the remaining filters
+			// the comparisons j > i and j < i are more restrictive
+			info.comparison_type = comparison.type;
+			if (!is_inserted) {
+				// Add the filter j [>, <] i
+				auto filter = make_unique<BoundComparisonExpression>(comparison.type, comparison.left->Copy(),
+				                                                     comparison.right->Copy());
+				remaining_filters.push_back(move(filter));
+				is_inserted = true;
+			}
+		} else {
+			// we cannot add a new filter
+			continue;
+		}
+		// Add the new filer into the left set
+		if (AddConstantComparison(left_constants, info) == FilterResult::UNSATISFIABLE) {
+			return FilterResult::UNSATISFIABLE;
+		}
+		is_successful = true;
+	}
+	if (is_successful) {
+		// now check for remaining trasitive filters from the left column
+		auto transitive_filter = FindTransitiveFilter(comparison.left.get());
+		if (transitive_filter != nullptr) {
+			// try to add transitive filters
+			if (AddTransitiveFilters((BoundComparisonExpression &)*transitive_filter) == FilterResult::UNSUPPORTED) {
+				// in case of unsuccessful re-add filter into remaining ones
+				remaining_filters.push_back(move(transitive_filter));
+			}
+		}
+		return FilterResult::SUCCESS;
+	}
+
+	return FilterResult::UNSUPPORTED;
+}
+
+/*
+ * Find a transitive filter already inserted into the remaining filters
+ * Check for a match between the right column of bound comparisons and the expression,
+ * then removes the bound comparison from the remaining filters and returns it
+ */
+unique_ptr<Expression> FilterCombiner::FindTransitiveFilter(Expression *expr) {
+	// We only check for bound column ref
+	if (expr->type == ExpressionType::BOUND_COLUMN_REF) {
+		for (idx_t i = 0; i < remaining_filters.size(); i++) {
+			if (remaining_filters[i]->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
+				auto comparison = (BoundComparisonExpression *)remaining_filters[i].get();
+				if (expr->Equals(comparison->right.get()) && comparison->type != ExpressionType::COMPARE_NOTEQUAL) {
+					auto filter = move(remaining_filters[i]);
+					remaining_filters.erase(remaining_filters.begin() + i);
+					return filter;
+				}
+			}
+		}
+	}
+	return nullptr;
+}
+
+ValueComparisonResult InvertValueComparisonResult(ValueComparisonResult result) {
+	if (result == ValueComparisonResult::PRUNE_RIGHT) {
+		return ValueComparisonResult::PRUNE_LEFT;
+	}
+	if (result == ValueComparisonResult::PRUNE_LEFT) {
+		return ValueComparisonResult::PRUNE_RIGHT;
+	}
+	return result;
+}
+
+ValueComparisonResult CompareValueInformation(ExpressionValueInformation &left, ExpressionValueInformation &right) {
+	if (left.comparison_type == ExpressionType::COMPARE_EQUAL) {
+		// left is COMPARE_EQUAL, we can either
+		// (1) prune the right side or
+		// (2) return UNSATISFIABLE
+		bool prune_right_side = false;
+		switch (right.comparison_type) {
+		case ExpressionType::COMPARE_LESSTHAN:
+			prune_right_side = left.constant < right.constant;
+			break;
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			prune_right_side = left.constant <= right.constant;
+			break;
+		case ExpressionType::COMPARE_GREATERTHAN:
+			prune_right_side = left.constant > right.constant;
+			break;
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			prune_right_side = left.constant >= right.constant;
+			break;
+		case ExpressionType::COMPARE_NOTEQUAL:
+			prune_right_side = left.constant != right.constant;
+			break;
+		default:
+			D_ASSERT(right.comparison_type == ExpressionType::COMPARE_EQUAL);
+			prune_right_side = left.constant == right.constant;
+			break;
+		}
+		if (prune_right_side) {
+			return ValueComparisonResult::PRUNE_RIGHT;
+		} else {
+			return ValueComparisonResult::UNSATISFIABLE_CONDITION;
+		}
+	} else if (right.comparison_type == ExpressionType::COMPARE_EQUAL) {
+		// right is COMPARE_EQUAL
+		return InvertValueComparisonResult(CompareValueInformation(right, left));
+	} else if (left.comparison_type == ExpressionType::COMPARE_NOTEQUAL) {
+		// left is COMPARE_NOTEQUAL, we can either
+		// (1) prune the left side or
+		// (2) not prune anything
+		bool prune_left_side = false;
+		switch (right.comparison_type) {
+		case ExpressionType::COMPARE_LESSTHAN:
+			prune_left_side = left.constant >= right.constant;
+			break;
+		case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+			prune_left_side = left.constant > right.constant;
+			break;
+		case ExpressionType::COMPARE_GREATERTHAN:
+			prune_left_side = left.constant <= right.constant;
+			break;
+		case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+			prune_left_side = left.constant < right.constant;
+			break;
+		default:
+			D_ASSERT(right.comparison_type == ExpressionType::COMPARE_NOTEQUAL);
+			prune_left_side = left.constant == right.constant;
+			break;
+		}
+		if (prune_left_side) {
+			return ValueComparisonResult::PRUNE_LEFT;
+		} else {
+			return ValueComparisonResult::PRUNE_NOTHING;
+		}
+	} else if (right.comparison_type == ExpressionType::COMPARE_NOTEQUAL) {
+		return InvertValueComparisonResult(CompareValueInformation(right, left));
+	} else if (IsGreaterThan(left.comparison_type) && IsGreaterThan(right.comparison_type)) {
+		// both comparisons are [>], we can either
+		// (1) prune the left side or
+		// (2) prune the right side
+		if (left.constant > right.constant) {
+			// left constant is more selective, prune right
+			return ValueComparisonResult::PRUNE_RIGHT;
+		} else if (left.constant < right.constant) {
+			// right constant is more selective, prune left
+			return ValueComparisonResult::PRUNE_LEFT;
+		} else {
+			// constants are equivalent
+			// however we can still have the scenario where one is [>=] and the other is [>]
+			// we want to prune the [>=] because [>] is more selective
+			// if left is [>=] we prune the left, else we prune the right
+			if (left.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO) {
+				return ValueComparisonResult::PRUNE_LEFT;
+			} else {
+				return ValueComparisonResult::PRUNE_RIGHT;
+			}
+		}
+	} else if (IsLessThan(left.comparison_type) && IsLessThan(right.comparison_type)) {
+		// both comparisons are [<], we can either
+		// (1) prune the left side or
+		// (2) prune the right side
+		if (left.constant < right.constant) {
+			// left constant is more selective, prune right
+			return ValueComparisonResult::PRUNE_RIGHT;
+		} else if (left.constant > right.constant) {
+			// right constant is more selective, prune left
+			return ValueComparisonResult::PRUNE_LEFT;
+		} else {
+			// constants are equivalent
+			// however we can still have the scenario where one is [<=] and the other is [<]
+			// we want to prune the [<=] because [<] is more selective
+			// if left is [<=] we prune the left, else we prune the right
+			if (left.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO) {
+				return ValueComparisonResult::PRUNE_LEFT;
+			} else {
+				return ValueComparisonResult::PRUNE_RIGHT;
+			}
+		}
+	} else if (IsLessThan(left.comparison_type)) {
+		D_ASSERT(IsGreaterThan(right.comparison_type));
+		// left is [<] and right is [>], in this case we can either
+		// (1) prune nothing or
+		// (2) return UNSATISFIABLE
+		// the SMALLER THAN constant has to be greater than the BIGGER THAN constant
+		if (left.constant >= right.constant) {
+			return ValueComparisonResult::PRUNE_NOTHING;
+		} else {
+			return ValueComparisonResult::UNSATISFIABLE_CONDITION;
+		}
+	} else {
+		// left is [>] and right is [<] or [!=]
+		D_ASSERT(IsLessThan(right.comparison_type) && IsGreaterThan(left.comparison_type));
+		return InvertValueComparisonResult(CompareValueInformation(right, left));
+	}
+}
+//
+// void FilterCombiner::LookUpConjunctions(Expression *expr) {
+//	if (expr->GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
+//		auto root_or_expr = (BoundConjunctionExpression *)expr;
+//		for (const auto &entry : map_col_conjunctions) {
+//			for (const auto &conjs_to_push : entry.second) {
+//				if (conjs_to_push->root_or->Equals(root_or_expr)) {
+//					return;
+//				}
+//			}
+//		}
+//
+//		cur_root_or = root_or_expr;
+//		cur_conjunction = root_or_expr;
+//		cur_colref_to_push = nullptr;
+//		if (!BFSLookUpConjunctions(cur_root_or)) {
+//			if (cur_colref_to_push) {
+//				auto entry = map_col_conjunctions.find(cur_colref_to_push);
+//				auto &vec_conjs_to_push = entry->second;
+//				if (vec_conjs_to_push.size() == 1) {
+//					map_col_conjunctions.erase(entry);
+//					return;
+//				}
+//				vec_conjs_to_push.pop_back();
+//			}
+//		}
+//		return;
+//	}
+//
+//	// Verify if the expression has a column already pushed down by other OR expression
+//	VerifyOrsToPush(*expr);
+//}
+//
+// bool FilterCombiner::BFSLookUpConjunctions(BoundConjunctionExpression *conjunction) {
+//	vector<BoundConjunctionExpression *> conjunctions_to_visit;
+//
+//	for (auto &child : conjunction->children) {
+//		switch (child->GetExpressionClass()) {
+//		case ExpressionClass::BOUND_CONJUNCTION: {
+//			auto child_conjunction = (BoundConjunctionExpression *)child.get();
+//			conjunctions_to_visit.emplace_back(child_conjunction);
+//			break;
+//		}
+//		case ExpressionClass::BOUND_COMPARISON: {
+//			if (!UpdateConjunctionFilter((BoundComparisonExpression *)child.get())) {
+//				return false;
+//			}
+//			break;
+//		}
+//		default: {
+//			return false;
+//		}
+//		}
+//	}
+//
+//	for (auto child_conjunction : conjunctions_to_visit) {
+//		cur_conjunction = child_conjunction;
+//		// traverse child conjuction
+//		if (!BFSLookUpConjunctions(child_conjunction)) {
+//			return false;
+//		}
+//	}
+//	return true;
+//}
+//
+// void FilterCombiner::VerifyOrsToPush(Expression &expr) {
+//	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
+//		auto colref = (BoundColumnRefExpression *)&expr;
+//		auto entry = map_col_conjunctions.find(colref);
+//		if (entry == map_col_conjunctions.end()) {
+//			return;
+//		}
+//		map_col_conjunctions.erase(entry);
+//	}
+//	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { VerifyOrsToPush(child); });
+//}
+//
+// bool FilterCombiner::UpdateConjunctionFilter(BoundComparisonExpression *comparison_expr) {
+//	bool left_is_scalar = comparison_expr->left->IsFoldable();
+//	bool right_is_scalar = comparison_expr->right->IsFoldable();
+//
+//	Expression *non_scalar_expr;
+//	if (left_is_scalar || right_is_scalar) {
+//		// only support comparison with scalar
+//		non_scalar_expr = left_is_scalar ? comparison_expr->right.get() : comparison_expr->left.get();
+//
+//		if (non_scalar_expr->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+//			return UpdateFilterByColumn((BoundColumnRefExpression *)non_scalar_expr, comparison_expr);
+//		}
+//	}
+//
+//	return false;
+//}
+//
+// bool FilterCombiner::UpdateFilterByColumn(BoundColumnRefExpression *column_ref,
+//                                          BoundComparisonExpression *comparison_expr) {
+//	if (cur_colref_to_push == nullptr) {
+//		cur_colref_to_push = column_ref;
+//
+//		auto or_conjunction = make_unique<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
+//		or_conjunction->children.emplace_back(comparison_expr->Copy());
+//
+//		unique_ptr<ConjunctionsToPush> conjs_to_push = make_unique<ConjunctionsToPush>();
+//		conjs_to_push->conjunctions.emplace_back(move(or_conjunction));
+//		conjs_to_push->root_or = cur_root_or;
+//
+//		auto &&vec_col_conjs = map_col_conjunctions[column_ref];
+//		vec_col_conjs.emplace_back(move(conjs_to_push));
+//		vec_colref_insertion_order.emplace_back(column_ref);
+//		return true;
+//	}
+//
+//	auto entry = map_col_conjunctions.find(cur_colref_to_push);
+//	D_ASSERT(entry != map_col_conjunctions.end());
+//	auto &conjunctions_to_push = entry->second.back();
+//
+//	if (!cur_colref_to_push->Equals(column_ref)) {
+//		// check for multiple colunms in the same root OR node
+//		if (cur_root_or == cur_conjunction) {
+//			return false;
+//		}
+//		// found an AND using a different column, we should stop the look up
+//		if (cur_conjunction->GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
+//			return false;
+//		}
+//
+//		// found a different column, AND conditions cannot be preserved anymore
+//		conjunctions_to_push->preserve_and = false;
+//		return true;
+//	}
+//
+//	auto &last_conjunction = conjunctions_to_push->conjunctions.back();
+//	if (cur_conjunction->GetExpressionType() == last_conjunction->GetExpressionType()) {
+//		last_conjunction->children.emplace_back(comparison_expr->Copy());
+//	} else {
+//		auto new_conjunction = make_unique<BoundConjunctionExpression>(cur_conjunction->GetExpressionType());
+//		new_conjunction->children.emplace_back(comparison_expr->Copy());
+//		conjunctions_to_push->conjunctions.emplace_back(move(new_conjunction));
+//	}
+//	return true;
+//}
+//
+// void FilterCombiner::GenerateORFilters(TableFilterSet &table_filter, vector<idx_t> &column_ids) {
+//	for (const auto colref : vec_colref_insertion_order) {
+//		auto column_index = column_ids[colref->binding.column_index];
+//		if (column_index == COLUMN_IDENTIFIER_ROW_ID) {
+//			break;
+//		}
+//
+//		for (const auto &conjunctions_to_push : map_col_conjunctions[colref]) {
+//			// root OR filter to push into the TableFilter
+//			auto root_or_filter = make_unique<ConjunctionOrFilter>();
+//			// variable to hold the last conjuntion filter pointer
+//			// the next filter will be added into it, i.e., we create a chain of conjunction filters
+//			ConjunctionFilter *last_conj_filter = root_or_filter.get();
+//
+//			for (auto &conjunction : conjunctions_to_push->conjunctions) {
+//				if (conjunction->GetExpressionType() == ExpressionType::CONJUNCTION_AND &&
+//				    conjunctions_to_push->preserve_and) {
+//					GenerateConjunctionFilter<ConjunctionAndFilter>(conjunction.get(), last_conj_filter);
+//				} else {
+//					GenerateConjunctionFilter<ConjunctionOrFilter>(conjunction.get(), last_conj_filter);
+//				}
+//			}
+//			table_filter.PushFilter(column_index, move(root_or_filter));
+//		}
+//	}
+//	map_col_conjunctions.clear();
+//	vec_colref_insertion_order.clear();
+//}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> FilterPullup::Rewrite(unique_ptr<LogicalOperator> op) {
+	switch (op->type) {
+	case LogicalOperatorType::LOGICAL_FILTER:
+		return PullupFilter(move(op));
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+		return PullupProjection(move(op));
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+		return PullupCrossProduct(move(op));
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+		return PullupJoin(move(op));
+	case LogicalOperatorType::LOGICAL_INTERSECT:
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+		return PullupSetOperation(move(op));
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+	case LogicalOperatorType::LOGICAL_ORDER_BY: {
+		// we can just pull directly through these operations without any rewriting
+		op->children[0] = Rewrite(move(op->children[0]));
+		return op;
+	}
+	default:
+		return FinishPullup(move(op));
+	}
+}
+
+unique_ptr<LogicalOperator> FilterPullup::PullupJoin(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
+	         op->type == LogicalOperatorType::LOGICAL_ANY_JOIN || op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN);
+	auto &join = (LogicalJoin &)*op;
+
+	switch (join.join_type) {
+	case JoinType::INNER:
+		return PullupInnerJoin(move(op));
+	case JoinType::LEFT:
+	case JoinType::ANTI:
+	case JoinType::SEMI: {
+		can_add_column = true;
+		return PullupFromLeft(move(op));
+	}
+	default:
+		// unsupported join type: call children pull up
+		return FinishPullup(move(op));
+	}
+}
+
+unique_ptr<LogicalOperator> FilterPullup::PullupInnerJoin(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(((LogicalJoin &)*op).join_type == JoinType::INNER);
+	D_ASSERT(op->type != LogicalOperatorType::LOGICAL_DELIM_JOIN);
+	return PullupBothSide(move(op));
+}
+
+unique_ptr<LogicalOperator> FilterPullup::PullupCrossProduct(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_CROSS_PRODUCT);
+	return PullupBothSide(move(op));
+}
+
+unique_ptr<LogicalOperator> FilterPullup::GeneratePullupFilter(unique_ptr<LogicalOperator> child,
+                                                               vector<unique_ptr<Expression>> &expressions) {
+	unique_ptr<LogicalFilter> filter = make_unique<LogicalFilter>();
+	for (idx_t i = 0; i < expressions.size(); ++i) {
+		filter->expressions.push_back(move(expressions[i]));
+	}
+	expressions.clear();
+	filter->children.push_back(move(child));
+	return move(filter);
+}
+
+unique_ptr<LogicalOperator> FilterPullup::FinishPullup(unique_ptr<LogicalOperator> op) {
+	// unhandled type, first perform filter pushdown in its children
+	for (idx_t i = 0; i < op->children.size(); i++) {
+		FilterPullup pullup;
+		op->children[i] = pullup.Rewrite(move(op->children[i]));
+	}
+	// now pull up any existing filters
+	if (filters_expr_pullup.empty()) {
+		// no filters to pull up
+		return op;
+	}
+	return GeneratePullupFilter(move(op), filters_expr_pullup);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+using Filter = FilterPushdown::Filter;
+
+unique_ptr<LogicalOperator> FilterPushdown::Rewrite(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(!combiner.HasFilters());
+	switch (op->type) {
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		return PushdownAggregate(move(op));
+	case LogicalOperatorType::LOGICAL_FILTER:
+		return PushdownFilter(move(op));
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+		return PushdownCrossProduct(move(op));
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+		return PushdownJoin(move(op));
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+		return PushdownProjection(move(op));
+	case LogicalOperatorType::LOGICAL_INTERSECT:
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+	case LogicalOperatorType::LOGICAL_UNION:
+		return PushdownSetOperation(move(op));
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+	case LogicalOperatorType::LOGICAL_ORDER_BY: {
+		// we can just push directly through these operations without any rewriting
+		op->children[0] = Rewrite(move(op->children[0]));
+		return op;
+	}
+	case LogicalOperatorType::LOGICAL_GET:
+		return PushdownGet(move(op));
+	case LogicalOperatorType::LOGICAL_LIMIT:
+		return PushdownLimit(move(op));
+	default:
+		return FinishPushdown(move(op));
+	}
+}
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownJoin(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
+	         op->type == LogicalOperatorType::LOGICAL_ANY_JOIN || op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN);
+	auto &join = (LogicalJoin &)*op;
+	unordered_set<idx_t> left_bindings, right_bindings;
+	LogicalJoin::GetTableReferences(*op->children[0], left_bindings);
+	LogicalJoin::GetTableReferences(*op->children[1], right_bindings);
+
+	switch (join.join_type) {
+	case JoinType::INNER:
+		return PushdownInnerJoin(move(op), left_bindings, right_bindings);
+	case JoinType::LEFT:
+		return PushdownLeftJoin(move(op), left_bindings, right_bindings);
+	case JoinType::MARK:
+		return PushdownMarkJoin(move(op), left_bindings, right_bindings);
+	case JoinType::SINGLE:
+		return PushdownSingleJoin(move(op), left_bindings, right_bindings);
+	default:
+		// unsupported join type: stop pushing down
+		return FinishPushdown(move(op));
+	}
+}
+void FilterPushdown::PushFilters() {
+	for (auto &f : filters) {
+		auto result = combiner.AddFilter(move(f->filter));
+		D_ASSERT(result == FilterResult::SUCCESS);
+		(void)result;
+	}
+	filters.clear();
+}
+
+FilterResult FilterPushdown::AddFilter(unique_ptr<Expression> expr) {
+	PushFilters();
+	// split up the filters by AND predicate
+	vector<unique_ptr<Expression>> expressions;
+	expressions.push_back(move(expr));
+	LogicalFilter::SplitPredicates(expressions);
+	// push the filters into the combiner
+	for (auto &child_expr : expressions) {
+		if (combiner.AddFilter(move(child_expr)) == FilterResult::UNSATISFIABLE) {
+			return FilterResult::UNSATISFIABLE;
+		}
+	}
+	return FilterResult::SUCCESS;
+}
+
+void FilterPushdown::GenerateFilters() {
+	if (!filters.empty()) {
+		D_ASSERT(!combiner.HasFilters());
+		return;
+	}
+	combiner.GenerateFilters([&](unique_ptr<Expression> filter) {
+		auto f = make_unique<Filter>();
+		f->filter = move(filter);
+		f->ExtractBindings();
+		filters.push_back(move(f));
+	});
+}
+
+unique_ptr<LogicalOperator> FilterPushdown::FinishPushdown(unique_ptr<LogicalOperator> op) {
+	// unhandled type, first perform filter pushdown in its children
+	for (auto &child : op->children) {
+		FilterPushdown pushdown(optimizer);
+		child = pushdown.Rewrite(move(child));
+	}
+	// now push any existing filters
+	if (filters.empty()) {
+		// no filters to push
+		return op;
+	}
+	auto filter = make_unique<LogicalFilter>();
+	for (auto &f : filters) {
+		filter->expressions.push_back(move(f->filter));
+	}
+	filter->children.push_back(move(op));
+	return move(filter);
+}
+
+void FilterPushdown::Filter::ExtractBindings() {
+	bindings.clear();
+	LogicalJoin::GetExpressionBindings(*filter, bindings);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> InClauseRewriter::Rewrite(unique_ptr<LogicalOperator> op) {
+	if (op->children.size() == 1) {
+		root = move(op->children[0]);
+		VisitOperatorExpressions(*op);
+		op->children[0] = move(root);
+	}
+
+	for (auto &child : op->children) {
+		child = Rewrite(move(child));
+	}
+	return op;
+}
+
+unique_ptr<Expression> InClauseRewriter::VisitReplace(BoundOperatorExpression &expr, unique_ptr<Expression> *expr_ptr) {
+	if (expr.type != ExpressionType::COMPARE_IN && expr.type != ExpressionType::COMPARE_NOT_IN) {
+		return nullptr;
+	}
+	D_ASSERT(root);
+	auto in_type = expr.children[0]->return_type;
+	bool is_regular_in = expr.type == ExpressionType::COMPARE_IN;
+	bool all_scalar = true;
+	// IN clause with many children: try to generate a mark join that replaces this IN expression
+	// we can only do this if the expressions in the expression list are scalar
+	for (idx_t i = 1; i < expr.children.size(); i++) {
+		D_ASSERT(expr.children[i]->return_type == in_type);
+		if (!expr.children[i]->IsFoldable()) {
+			// non-scalar expression
+			all_scalar = false;
+		}
+	}
+	if (expr.children.size() == 2) {
+		// only one child
+		// IN: turn into X = 1
+		// NOT IN: turn into X <> 1
+		return make_unique<BoundComparisonExpression>(is_regular_in ? ExpressionType::COMPARE_EQUAL
+		                                                            : ExpressionType::COMPARE_NOTEQUAL,
+		                                              move(expr.children[0]), move(expr.children[1]));
+	}
+	if (expr.children.size() < 6 || !all_scalar) {
+		// low amount of children or not all scalar
+		// IN: turn into (X = 1 OR X = 2 OR X = 3...)
+		// NOT IN: turn into (X <> 1 AND X <> 2 AND X <> 3 ...)
+		auto conjunction = make_unique<BoundConjunctionExpression>(is_regular_in ? ExpressionType::CONJUNCTION_OR
+		                                                                         : ExpressionType::CONJUNCTION_AND);
+		for (idx_t i = 1; i < expr.children.size(); i++) {
+			conjunction->children.push_back(make_unique<BoundComparisonExpression>(
+			    is_regular_in ? ExpressionType::COMPARE_EQUAL : ExpressionType::COMPARE_NOTEQUAL,
+			    expr.children[0]->Copy(), move(expr.children[i])));
+		}
+		return move(conjunction);
+	}
+	// IN clause with many constant children
+	// generate a mark join that replaces this IN expression
+	// first generate a ChunkCollection from the set of expressions
+	vector<LogicalType> types = {in_type};
+	auto collection = make_unique<ChunkCollection>();
+	DataChunk chunk;
+	chunk.Initialize(types);
+	for (idx_t i = 1; i < expr.children.size(); i++) {
+		// resolve this expression to a constant
+		auto value = ExpressionExecutor::EvaluateScalar(*expr.children[i]);
+		idx_t index = chunk.size();
+		chunk.SetCardinality(chunk.size() + 1);
+		chunk.SetValue(0, index, value);
+		if (chunk.size() == STANDARD_VECTOR_SIZE || i + 1 == expr.children.size()) {
+			// chunk full: append to chunk collection
+			collection->Append(chunk);
+			chunk.Reset();
+		}
+	}
+	// now generate a ChunkGet that scans this collection
+	auto chunk_index = optimizer.binder.GenerateTableIndex();
+	auto chunk_scan = make_unique<LogicalChunkGet>(chunk_index, types, move(collection));
+
+	// then we generate the MARK join with the chunk scan on the RHS
+	auto join = make_unique<LogicalComparisonJoin>(JoinType::MARK);
+	join->mark_index = chunk_index;
+	join->AddChild(move(root));
+	join->AddChild(move(chunk_scan));
+	// create the JOIN condition
+	JoinCondition cond;
+	cond.left = move(expr.children[0]);
+
+	cond.right = make_unique<BoundColumnRefExpression>(in_type, ColumnBinding(chunk_index, 0));
+	cond.comparison = ExpressionType::COMPARE_EQUAL;
+	join->conditions.push_back(move(cond));
+	root = move(join);
+
+	// we replace the original subquery with a BoundColumnRefExpression referring to the mark column
+	unique_ptr<Expression> result =
+	    make_unique<BoundColumnRefExpression>("IN (...)", LogicalType::BOOLEAN, ColumnBinding(chunk_index, 0));
+	if (!is_regular_in) {
+		// NOT IN: invert
+		auto invert = make_unique<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT, LogicalType::BOOLEAN);
+		invert->children.push_back(move(result));
+		result = move(invert);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+using JoinRelationTreeNode = JoinRelationSetManager::JoinRelationTreeNode;
+
+// LCOV_EXCL_START
+string JoinRelationSet::ToString() const {
+	string result = "[";
+	result += StringUtil::Join(relations, count, ", ", [](const idx_t &relation) { return to_string(relation); });
+	result += "]";
+	return result;
+}
+// LCOV_EXCL_STOP
+
+//! Returns true if sub is a subset of super
+bool JoinRelationSet::IsSubset(JoinRelationSet *super, JoinRelationSet *sub) {
+	D_ASSERT(sub->count > 0);
+	if (sub->count > super->count) {
+		return false;
+	}
+	idx_t j = 0;
+	for (idx_t i = 0; i < super->count; i++) {
+		if (sub->relations[j] == super->relations[i]) {
+			j++;
+			if (j == sub->count) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+JoinRelationSet *JoinRelationSetManager::GetJoinRelation(unique_ptr<idx_t[]> relations, idx_t count) {
+	// now look it up in the tree
+	JoinRelationTreeNode *info = &root;
+	for (idx_t i = 0; i < count; i++) {
+		auto entry = info->children.find(relations[i]);
+		if (entry == info->children.end()) {
+			// node not found, create it
+			auto insert_it = info->children.insert(make_pair(relations[i], make_unique<JoinRelationTreeNode>()));
+			entry = insert_it.first;
+		}
+		// move to the next node
+		info = entry->second.get();
+	}
+	// now check if the JoinRelationSet has already been created
+	if (!info->relation) {
+		// if it hasn't we need to create it
+		info->relation = make_unique<JoinRelationSet>(move(relations), count);
+	}
+	return info->relation.get();
+}
+
+//! Create or get a JoinRelationSet from a single node with the given index
+JoinRelationSet *JoinRelationSetManager::GetJoinRelation(idx_t index) {
+	// create a sorted vector of the relations
+	auto relations = unique_ptr<idx_t[]>(new idx_t[1]);
+	relations[0] = index;
+	idx_t count = 1;
+	return GetJoinRelation(move(relations), count);
+}
+
+JoinRelationSet *JoinRelationSetManager::GetJoinRelation(unordered_set<idx_t> &bindings) {
+	// create a sorted vector of the relations
+	unique_ptr<idx_t[]> relations = bindings.empty() ? nullptr : unique_ptr<idx_t[]>(new idx_t[bindings.size()]);
+	idx_t count = 0;
+	for (auto &entry : bindings) {
+		relations[count++] = entry;
+	}
+	std::sort(relations.get(), relations.get() + count);
+	return GetJoinRelation(move(relations), count);
+}
+
+JoinRelationSet *JoinRelationSetManager::Union(JoinRelationSet *left, JoinRelationSet *right) {
+	auto relations = unique_ptr<idx_t[]>(new idx_t[left->count + right->count]);
+	idx_t count = 0;
+	// move through the left and right relations, eliminating duplicates
+	idx_t i = 0, j = 0;
+	while (true) {
+		if (i == left->count) {
+			// exhausted left relation, add remaining of right relation
+			for (; j < right->count; j++) {
+				relations[count++] = right->relations[j];
+			}
+			break;
+		} else if (j == right->count) {
+			// exhausted right relation, add remaining of left
+			for (; i < left->count; i++) {
+				relations[count++] = left->relations[i];
+			}
+			break;
+		} else if (left->relations[i] == right->relations[j]) {
+			// equivalent, add only one of the two pairs
+			relations[count++] = left->relations[i];
+			i++;
+			j++;
+		} else if (left->relations[i] < right->relations[j]) {
+			// left is smaller, progress left and add it to the set
+			relations[count++] = left->relations[i];
+			i++;
+		} else {
+			// right is smaller, progress right and add it to the set
+			relations[count++] = right->relations[j];
+			j++;
+		}
+	}
+	return GetJoinRelation(move(relations), count);
+}
+
+// JoinRelationSet *JoinRelationSetManager::Difference(JoinRelationSet *left, JoinRelationSet *right) {
+// 	auto relations = unique_ptr<idx_t[]>(new idx_t[left->count]);
+// 	idx_t count = 0;
+// 	// move through the left and right relations
+// 	idx_t i = 0, j = 0;
+// 	while (true) {
+// 		if (i == left->count) {
+// 			// exhausted left relation, we are done
+// 			break;
+// 		} else if (j == right->count) {
+// 			// exhausted right relation, add remaining of left
+// 			for (; i < left->count; i++) {
+// 				relations[count++] = left->relations[i];
+// 			}
+// 			break;
+// 		} else if (left->relations[i] == right->relations[j]) {
+// 			// equivalent, add nothing
+// 			i++;
+// 			j++;
+// 		} else if (left->relations[i] < right->relations[j]) {
+// 			// left is smaller, progress left and add it to the set
+// 			relations[count++] = left->relations[i];
+// 			i++;
+// 		} else {
+// 			// right is smaller, progress right
+// 			j++;
+// 		}
+// 	}
+// 	return GetJoinRelation(move(relations), count);
+// }
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+using QueryEdge = QueryGraph::QueryEdge;
+
+// LCOV_EXCL_START
+static string QueryEdgeToString(const QueryEdge *info, vector<idx_t> prefix) {
+	string result = "";
+	string source = "[";
+	for (idx_t i = 0; i < prefix.size(); i++) {
+		source += to_string(prefix[i]) + (i < prefix.size() - 1 ? ", " : "");
+	}
+	source += "]";
+	for (auto &entry : info->neighbors) {
+		result += StringUtil::Format("%s -> %s\n", source.c_str(), entry->neighbor->ToString().c_str());
+	}
+	for (auto &entry : info->children) {
+		vector<idx_t> new_prefix = prefix;
+		new_prefix.push_back(entry.first);
+		result += QueryEdgeToString(entry.second.get(), new_prefix);
+	}
+	return result;
+}
+
+string QueryGraph::ToString() const {
+	return QueryEdgeToString(&root, {});
+}
+
+void QueryGraph::Print() {
+	Printer::Print(ToString());
+}
+// LCOV_EXCL_STOP
+
+QueryEdge *QueryGraph::GetQueryEdge(JoinRelationSet *left) {
+	D_ASSERT(left && left->count > 0);
+	// find the EdgeInfo corresponding to the left set
+	QueryEdge *info = &root;
+	for (idx_t i = 0; i < left->count; i++) {
+		auto entry = info->children.find(left->relations[i]);
+		if (entry == info->children.end()) {
+			// node not found, create it
+			auto insert_it = info->children.insert(make_pair(left->relations[i], make_unique<QueryEdge>()));
+			entry = insert_it.first;
+		}
+		// move to the next node
+		info = entry->second.get();
+	}
+	return info;
+}
+
+void QueryGraph::CreateEdge(JoinRelationSet *left, JoinRelationSet *right, FilterInfo *filter_info) {
+	D_ASSERT(left && right && left->count > 0 && right->count > 0);
+	// find the EdgeInfo corresponding to the left set
+	auto info = GetQueryEdge(left);
+	// now insert the edge to the right relation, if it does not exist
+	for (idx_t i = 0; i < info->neighbors.size(); i++) {
+		if (info->neighbors[i]->neighbor == right) {
+			if (filter_info) {
+				// neighbor already exists just add the filter, if we have any
+				info->neighbors[i]->filters.push_back(filter_info);
+			}
+			return;
+		}
+	}
+	// neighbor does not exist, create it
+	auto n = make_unique<NeighborInfo>();
+	if (filter_info) {
+		n->filters.push_back(filter_info);
+	}
+	n->neighbor = right;
+	info->neighbors.push_back(move(n));
+}
+
+void QueryGraph::EnumerateNeighbors(JoinRelationSet *node, const std::function<bool(NeighborInfo *)> &callback) {
+	for (idx_t j = 0; j < node->count; j++) {
+		QueryEdge *info = &root;
+		for (idx_t i = j; i < node->count; i++) {
+			auto entry = info->children.find(node->relations[i]);
+			if (entry == info->children.end()) {
+				// node not found
+				break;
+			}
+			// check if any subset of the other set is in this sets neighbors
+			info = entry->second.get();
+			for (auto &neighbor : info->neighbors) {
+				if (callback(neighbor.get())) {
+					return;
+				}
+			}
+		}
+	}
+}
+
+//! Returns true if a JoinRelationSet is banned by the list of exclusion_set, false otherwise
+static bool JoinRelationSetIsExcluded(JoinRelationSet *node, unordered_set<idx_t> &exclusion_set) {
+	return exclusion_set.find(node->relations[0]) != exclusion_set.end();
+}
+
+vector<idx_t> QueryGraph::GetNeighbors(JoinRelationSet *node, unordered_set<idx_t> &exclusion_set) {
+	unordered_set<idx_t> result;
+	EnumerateNeighbors(node, [&](NeighborInfo *info) -> bool {
+		if (!JoinRelationSetIsExcluded(info->neighbor, exclusion_set)) {
+			// add the smallest node of the neighbor to the set
+			result.insert(info->neighbor->relations[0]);
+		}
+		return false;
+	});
+	vector<idx_t> neighbors;
+	neighbors.insert(neighbors.end(), result.begin(), result.end());
+	return neighbors;
+}
+
+NeighborInfo *QueryGraph::GetConnection(JoinRelationSet *node, JoinRelationSet *other) {
+	NeighborInfo *connection = nullptr;
+	EnumerateNeighbors(node, [&](NeighborInfo *info) -> bool {
+		if (JoinRelationSet::IsSubset(other, info->neighbor)) {
+			connection = info;
+			return true;
+		}
+		return false;
+	});
+	return connection;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+using JoinNode = JoinOrderOptimizer::JoinNode;
+
+//! Returns true if A and B are disjoint, false otherwise
+template <class T>
+static bool Disjoint(unordered_set<T> &a, unordered_set<T> &b) {
+	for (auto &entry : a) {
+		if (b.find(entry) != b.end()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+//! Extract the set of relations referred to inside an expression
+bool JoinOrderOptimizer::ExtractBindings(Expression &expression, unordered_set<idx_t> &bindings) {
+	if (expression.type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &colref = (BoundColumnRefExpression &)expression;
+		D_ASSERT(colref.depth == 0);
+		D_ASSERT(colref.binding.table_index != DConstants::INVALID_INDEX);
+		// map the base table index to the relation index used by the JoinOrderOptimizer
+		D_ASSERT(relation_mapping.find(colref.binding.table_index) != relation_mapping.end());
+		bindings.insert(relation_mapping[colref.binding.table_index]);
+	}
+	if (expression.type == ExpressionType::BOUND_REF) {
+		// bound expression
+		bindings.clear();
+		return false;
+	}
+	D_ASSERT(expression.type != ExpressionType::SUBQUERY);
+	bool can_reorder = true;
+	ExpressionIterator::EnumerateChildren(expression, [&](Expression &expr) {
+		if (!ExtractBindings(expr, bindings)) {
+			can_reorder = false;
+			return;
+		}
+	});
+	return can_reorder;
+}
+
+static unique_ptr<LogicalOperator> PushFilter(unique_ptr<LogicalOperator> node, unique_ptr<Expression> expr) {
+	// push an expression into a filter
+	// first check if we have any filter to push it into
+	if (node->type != LogicalOperatorType::LOGICAL_FILTER) {
+		// we don't, we need to create one
+		auto filter = make_unique<LogicalFilter>();
+		filter->children.push_back(move(node));
+		node = move(filter);
+	}
+	// push the filter into the LogicalFilter
+	D_ASSERT(node->type == LogicalOperatorType::LOGICAL_FILTER);
+	auto filter = (LogicalFilter *)node.get();
+	filter->expressions.push_back(move(expr));
+	return node;
+}
+
+bool JoinOrderOptimizer::ExtractJoinRelations(LogicalOperator &input_op, vector<LogicalOperator *> &filter_operators,
+                                              LogicalOperator *parent) {
+	LogicalOperator *op = &input_op;
+	while (op->children.size() == 1 && (op->type != LogicalOperatorType::LOGICAL_PROJECTION &&
+	                                    op->type != LogicalOperatorType::LOGICAL_EXPRESSION_GET)) {
+		if (op->type == LogicalOperatorType::LOGICAL_FILTER) {
+			// extract join conditions from filter
+			filter_operators.push_back(op);
+		}
+		if (op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY ||
+		    op->type == LogicalOperatorType::LOGICAL_WINDOW) {
+			// don't push filters through projection or aggregate and group by
+			JoinOrderOptimizer optimizer(context);
+			op->children[0] = optimizer.Optimize(move(op->children[0]));
+			return false;
+		}
+		op = op->children[0].get();
+	}
+	bool non_reorderable_operation = false;
+	if (op->type == LogicalOperatorType::LOGICAL_UNION || op->type == LogicalOperatorType::LOGICAL_EXCEPT ||
+	    op->type == LogicalOperatorType::LOGICAL_INTERSECT || op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN ||
+	    op->type == LogicalOperatorType::LOGICAL_ANY_JOIN) {
+		// set operation, optimize separately in children
+		non_reorderable_operation = true;
+	}
+
+	if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		auto &join = (LogicalComparisonJoin &)*op;
+		if (join.join_type == JoinType::INNER) {
+			// extract join conditions from inner join
+			filter_operators.push_back(op);
+		} else {
+			// non-inner join, not reorderable yet
+			non_reorderable_operation = true;
+			if (join.join_type == JoinType::LEFT && join.right_projection_map.empty()) {
+				// for left joins; if the RHS cardinality is significantly larger than the LHS (2x)
+				// we convert to doing a RIGHT OUTER JOIN
+				// FIXME: for now we don't swap if the right_projection_map is not empty
+				// this can be fixed once we implement the left_projection_map properly...
+				auto lhs_cardinality = join.children[0]->EstimateCardinality(context);
+				auto rhs_cardinality = join.children[1]->EstimateCardinality(context);
+				if (rhs_cardinality > lhs_cardinality * 2) {
+					join.join_type = JoinType::RIGHT;
+					std::swap(join.children[0], join.children[1]);
+					for (auto &cond : join.conditions) {
+						std::swap(cond.left, cond.right);
+						cond.comparison = FlipComparisionExpression(cond.comparison);
+					}
+				}
+			}
+		}
+	}
+	if (non_reorderable_operation) {
+		// we encountered a non-reordable operation (setop or non-inner join)
+		// we do not reorder non-inner joins yet, however we do want to expand the potential join graph around them
+		// non-inner joins are also tricky because we can't freely make conditions through them
+		// e.g. suppose we have (left LEFT OUTER JOIN right WHERE right IS NOT NULL), the join can generate
+		// new NULL values in the right side, so pushing this condition through the join leads to incorrect results
+		// for this reason, we just start a new JoinOptimizer pass in each of the children of the join
+		for (auto &child : op->children) {
+			JoinOrderOptimizer optimizer(context);
+			child = optimizer.Optimize(move(child));
+		}
+		// after this we want to treat this node as one  "end node" (like e.g. a base relation)
+		// however the join refers to multiple base relations
+		// enumerate all base relations obtained from this join and add them to the relation mapping
+		// also, we have to resolve the join conditions for the joins here
+		// get the left and right bindings
+		unordered_set<idx_t> bindings;
+		LogicalJoin::GetTableReferences(*op, bindings);
+		// now create the relation that refers to all these bindings
+		auto relation = make_unique<SingleJoinRelation>(&input_op, parent);
+		for (idx_t it : bindings) {
+			relation_mapping[it] = relations.size();
+		}
+		relations.push_back(move(relation));
+		return true;
+	}
+	if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
+	    op->type == LogicalOperatorType::LOGICAL_CROSS_PRODUCT) {
+		// inner join or cross product
+		bool can_reorder_left = ExtractJoinRelations(*op->children[0], filter_operators, op);
+		bool can_reorder_right = ExtractJoinRelations(*op->children[1], filter_operators, op);
+		return can_reorder_left && can_reorder_right;
+	} else if (op->type == LogicalOperatorType::LOGICAL_GET) {
+		// base table scan, add to set of relations
+		auto get = (LogicalGet *)op;
+		auto relation = make_unique<SingleJoinRelation>(&input_op, parent);
+		relation_mapping[get->table_index] = relations.size();
+		relations.push_back(move(relation));
+		return true;
+	} else if (op->type == LogicalOperatorType::LOGICAL_EXPRESSION_GET) {
+		// base table scan, add to set of relations
+		auto get = (LogicalExpressionGet *)op;
+		auto relation = make_unique<SingleJoinRelation>(&input_op, parent);
+		relation_mapping[get->table_index] = relations.size();
+		relations.push_back(move(relation));
+		return true;
+	} else if (op->type == LogicalOperatorType::LOGICAL_DUMMY_SCAN) {
+		// table function call, add to set of relations
+		auto dummy_scan = (LogicalDummyScan *)op;
+		auto relation = make_unique<SingleJoinRelation>(&input_op, parent);
+		relation_mapping[dummy_scan->table_index] = relations.size();
+		relations.push_back(move(relation));
+		return true;
+	} else if (op->type == LogicalOperatorType::LOGICAL_PROJECTION) {
+		auto proj = (LogicalProjection *)op;
+		// we run the join order optimizer witin the subquery as well
+		JoinOrderOptimizer optimizer(context);
+		op->children[0] = optimizer.Optimize(move(op->children[0]));
+		// projection, add to the set of relations
+		auto relation = make_unique<SingleJoinRelation>(&input_op, parent);
+		relation_mapping[proj->table_index] = relations.size();
+		relations.push_back(move(relation));
+		return true;
+	}
+	return false;
+}
+
+//! Update the exclusion set with all entries in the subgraph
+static void UpdateExclusionSet(JoinRelationSet *node, unordered_set<idx_t> &exclusion_set) {
+	for (idx_t i = 0; i < node->count; i++) {
+		exclusion_set.insert(node->relations[i]);
+	}
+}
+
+//! Create a new JoinTree node by joining together two previous JoinTree nodes
+static unique_ptr<JoinNode> CreateJoinTree(JoinRelationSet *set, NeighborInfo *info, JoinNode *left, JoinNode *right) {
+	// for the hash join we want the right side (build side) to have the smallest cardinality
+	// also just a heuristic but for now...
+	// FIXME: we should probably actually benchmark that as well
+	// FIXME: should consider different join algorithms, should we pick a join algorithm here as well? (probably)
+	if (left->cardinality < right->cardinality) {
+		return CreateJoinTree(set, info, right, left);
+	}
+	// the expected cardinality is the max of the child cardinalities
+	// FIXME: we should obviously use better cardinality estimation here
+	// but for now we just assume foreign key joins only
+	idx_t expected_cardinality;
+	if (info->filters.empty()) {
+		// cross product
+		expected_cardinality = left->cardinality * right->cardinality;
+	} else {
+		// normal join, expect foreign key join
+		expected_cardinality = MaxValue(left->cardinality, right->cardinality);
+	}
+	// cost is expected_cardinality plus the cost of the previous plans
+	idx_t cost = expected_cardinality;
+	return make_unique<JoinNode>(set, info, left, right, expected_cardinality, cost);
+}
+
+JoinNode *JoinOrderOptimizer::EmitPair(JoinRelationSet *left, JoinRelationSet *right, NeighborInfo *info) {
+	// get the left and right join plans
+	auto &left_plan = plans[left];
+	auto &right_plan = plans[right];
+	auto new_set = set_manager.Union(left, right);
+	// create the join tree based on combining the two plans
+	auto new_plan = CreateJoinTree(new_set, info, left_plan.get(), right_plan.get());
+	// check if this plan is the optimal plan we found for this set of relations
+	auto entry = plans.find(new_set);
+	if (entry == plans.end() || new_plan->cost < entry->second->cost) {
+		// the plan is the optimal plan, move it into the dynamic programming tree
+		auto result = new_plan.get();
+		plans[new_set] = move(new_plan);
+		return result;
+	}
+	return entry->second.get();
+}
+
+bool JoinOrderOptimizer::TryEmitPair(JoinRelationSet *left, JoinRelationSet *right, NeighborInfo *info) {
+	pairs++;
+	if (pairs >= 2000) {
+		// when the amount of pairs gets too large we exit the dynamic programming and resort to a greedy algorithm
+		// FIXME: simple heuristic currently
+		// at 10K pairs stop searching exactly and switch to heuristic
+		return false;
+	}
+	EmitPair(left, right, info);
+	return true;
+}
+
+bool JoinOrderOptimizer::EmitCSG(JoinRelationSet *node) {
+	if (node->count == relations.size()) {
+		return true;
+	}
+	// create the exclusion set as everything inside the subgraph AND anything with members BELOW it
+	unordered_set<idx_t> exclusion_set;
+	for (idx_t i = 0; i < node->relations[0]; i++) {
+		exclusion_set.insert(i);
+	}
+	UpdateExclusionSet(node, exclusion_set);
+	// find the neighbors given this exclusion set
+	auto neighbors = query_graph.GetNeighbors(node, exclusion_set);
+	if (neighbors.empty()) {
+		return true;
+	}
+	// we iterate over the neighbors ordered by their first node
+	sort(neighbors.begin(), neighbors.end());
+	for (auto neighbor : neighbors) {
+		// since the GetNeighbors only returns the smallest element in a list, the entry might not be connected to
+		// (only!) this neighbor,  hence we have to do a connectedness check before we can emit it
+		auto neighbor_relation = set_manager.GetJoinRelation(neighbor);
+		auto connection = query_graph.GetConnection(node, neighbor_relation);
+		if (connection) {
+			if (!TryEmitPair(node, neighbor_relation, connection)) {
+				return false;
+			}
+		}
+		if (!EnumerateCmpRecursive(node, neighbor_relation, exclusion_set)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool JoinOrderOptimizer::EnumerateCmpRecursive(JoinRelationSet *left, JoinRelationSet *right,
+                                               unordered_set<idx_t> exclusion_set) {
+	// get the neighbors of the second relation under the exclusion set
+	auto neighbors = query_graph.GetNeighbors(right, exclusion_set);
+	if (neighbors.empty()) {
+		return true;
+	}
+	vector<JoinRelationSet *> union_sets;
+	union_sets.resize(neighbors.size());
+	for (idx_t i = 0; i < neighbors.size(); i++) {
+		auto neighbor = set_manager.GetJoinRelation(neighbors[i]);
+		// emit the combinations of this node and its neighbors
+		auto combined_set = set_manager.Union(right, neighbor);
+		if (combined_set->count > right->count && plans.find(combined_set) != plans.end()) {
+			auto connection = query_graph.GetConnection(left, combined_set);
+			if (connection) {
+				if (!TryEmitPair(left, combined_set, connection)) {
+					return false;
+				}
+			}
+		}
+		union_sets[i] = combined_set;
+	}
+	// recursively enumerate the sets
+	unordered_set<idx_t> new_exclusion_set = exclusion_set;
+	for (idx_t i = 0; i < neighbors.size(); i++) {
+		// updated the set of excluded entries with this neighbor
+		new_exclusion_set.insert(neighbors[i]);
+		if (!EnumerateCmpRecursive(left, union_sets[i], new_exclusion_set)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool JoinOrderOptimizer::EnumerateCSGRecursive(JoinRelationSet *node, unordered_set<idx_t> &exclusion_set) {
+	// find neighbors of S under the exlusion set
+	auto neighbors = query_graph.GetNeighbors(node, exclusion_set);
+	if (neighbors.empty()) {
+		return true;
+	}
+	// now first emit the connected subgraphs of the neighbors
+	vector<JoinRelationSet *> union_sets;
+	union_sets.resize(neighbors.size());
+	for (idx_t i = 0; i < neighbors.size(); i++) {
+		auto neighbor = set_manager.GetJoinRelation(neighbors[i]);
+		// emit the combinations of this node and its neighbors
+		auto new_set = set_manager.Union(node, neighbor);
+		if (new_set->count > node->count && plans.find(new_set) != plans.end()) {
+			if (!EmitCSG(new_set)) {
+				return false;
+			}
+		}
+		union_sets[i] = new_set;
+	}
+	// recursively enumerate the sets
+	unordered_set<idx_t> new_exclusion_set = exclusion_set;
+	for (idx_t i = 0; i < neighbors.size(); i++) {
+		// updated the set of excluded entries with this neighbor
+		new_exclusion_set.insert(neighbors[i]);
+		if (!EnumerateCSGRecursive(union_sets[i], new_exclusion_set)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool JoinOrderOptimizer::SolveJoinOrderExactly() {
+	// now we perform the actual dynamic programming to compute the final result
+	// we enumerate over all the possible pairs in the neighborhood
+	for (idx_t i = relations.size(); i > 0; i--) {
+		// for every node in the set, we consider it as the start node once
+		auto start_node = set_manager.GetJoinRelation(i - 1);
+		// emit the start node
+		if (!EmitCSG(start_node)) {
+			return false;
+		}
+		// initialize the set of exclusion_set as all the nodes with a number below this
+		unordered_set<idx_t> exclusion_set;
+		for (idx_t j = 0; j < i - 1; j++) {
+			exclusion_set.insert(j);
+		}
+		// then we recursively search for neighbors that do not belong to the banned entries
+		if (!EnumerateCSGRecursive(start_node, exclusion_set)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void JoinOrderOptimizer::SolveJoinOrderApproximately() {
+	// at this point, we exited the dynamic programming but did not compute the final join order because it took too
+	// long instead, we use a greedy heuristic to obtain a join ordering now we use Greedy Operator Ordering to
+	// construct the result tree first we start out with all the base relations (the to-be-joined relations)
+	vector<JoinRelationSet *> join_relations; // T in the paper
+	for (idx_t i = 0; i < relations.size(); i++) {
+		join_relations.push_back(set_manager.GetJoinRelation(i));
+	}
+	while (join_relations.size() > 1) {
+		// now in every step of the algorithm, we greedily pick the join between the to-be-joined relations that has the
+		// smallest cost. This is O(r^2) per step, and every step will reduce the total amount of relations to-be-joined
+		// by 1, so the total cost is O(r^3) in the amount of relations
+		idx_t best_left = 0, best_right = 0;
+		JoinNode *best_connection = nullptr;
+		for (idx_t i = 0; i < join_relations.size(); i++) {
+			auto left = join_relations[i];
+			for (idx_t j = i + 1; j < join_relations.size(); j++) {
+				auto right = join_relations[j];
+				// check if we can connect these two relations
+				auto connection = query_graph.GetConnection(left, right);
+				if (connection) {
+					// we can! check the cost of this connection
+					auto node = EmitPair(left, right, connection);
+					if (!best_connection || node->cost < best_connection->cost) {
+						// best pair found so far
+						best_connection = node;
+						best_left = i;
+						best_right = j;
+					}
+				}
+			}
+		}
+		if (!best_connection) {
+			// could not find a connection, but we were not done with finding a completed plan
+			// we have to add a cross product; we add it between the two smallest relations
+			JoinNode *smallest_plans[2] = {nullptr};
+			idx_t smallest_index[2];
+			for (idx_t i = 0; i < join_relations.size(); i++) {
+				// get the plan for this relation
+				auto current_plan = plans[join_relations[i]].get();
+				// check if the cardinality is smaller than the smallest two found so far
+				for (idx_t j = 0; j < 2; j++) {
+					if (!smallest_plans[j] || smallest_plans[j]->cardinality > current_plan->cardinality) {
+						smallest_plans[j] = current_plan;
+						smallest_index[j] = i;
+						break;
+					}
+				}
+			}
+			if (!smallest_plans[0] || !smallest_plans[1]) {
+				throw InternalException("Internal error in join order optimizer");
+			}
+			D_ASSERT(smallest_plans[0] && smallest_plans[1]);
+			D_ASSERT(smallest_index[0] != smallest_index[1]);
+			auto left = smallest_plans[0]->set;
+			auto right = smallest_plans[1]->set;
+			// create a cross product edge (i.e. edge with empty filter) between these two sets in the query graph
+			query_graph.CreateEdge(left, right, nullptr);
+			// now emit the pair and continue with the algorithm
+			auto connection = query_graph.GetConnection(left, right);
+			D_ASSERT(connection);
+
+			best_connection = EmitPair(left, right, connection);
+			best_left = smallest_index[0];
+			best_right = smallest_index[1];
+			// the code below assumes best_right > best_left
+			if (best_left > best_right) {
+				std::swap(best_left, best_right);
+			}
+		}
+		// now update the to-be-checked pairs
+		// remove left and right, and add the combination
+
+		// important to erase the biggest element first
+		// if we erase the smallest element first the index of the biggest element changes
+		D_ASSERT(best_right > best_left);
+		join_relations.erase(join_relations.begin() + best_right);
+		join_relations.erase(join_relations.begin() + best_left);
+		join_relations.push_back(best_connection->set);
+	}
+}
+
+void JoinOrderOptimizer::SolveJoinOrder() {
+	// first try to solve the join order exactly
+	if (!SolveJoinOrderExactly()) {
+		// otherwise, if that times out we resort to a greedy algorithm
+		SolveJoinOrderApproximately();
+	}
+}
+
+void JoinOrderOptimizer::GenerateCrossProducts() {
+	// generate a set of cross products to combine the currently available plans into a full join plan
+	// we create edges between every relation with a high cost
+	for (idx_t i = 0; i < relations.size(); i++) {
+		auto left = set_manager.GetJoinRelation(i);
+		for (idx_t j = 0; j < relations.size(); j++) {
+			if (i != j) {
+				auto right = set_manager.GetJoinRelation(j);
+				query_graph.CreateEdge(left, right, nullptr);
+				query_graph.CreateEdge(right, left, nullptr);
+			}
+		}
+	}
+}
+
+static unique_ptr<LogicalOperator> ExtractJoinRelation(SingleJoinRelation &rel) {
+	auto &children = rel.parent->children;
+	for (idx_t i = 0; i < children.size(); i++) {
+		if (children[i].get() == rel.op) {
+			// found it! take ownership of it from the parent
+			auto result = move(children[i]);
+			children.erase(children.begin() + i);
+			return result;
+		}
+	}
+	throw Exception("Could not find relation in parent node (?)");
+}
+
+pair<JoinRelationSet *, unique_ptr<LogicalOperator>>
+JoinOrderOptimizer::GenerateJoins(vector<unique_ptr<LogicalOperator>> &extracted_relations, JoinNode *node) {
+	JoinRelationSet *left_node = nullptr, *right_node = nullptr;
+	JoinRelationSet *result_relation;
+	unique_ptr<LogicalOperator> result_operator;
+	if (node->left && node->right) {
+		// generate the left and right children
+		auto left = GenerateJoins(extracted_relations, node->left);
+		auto right = GenerateJoins(extracted_relations, node->right);
+
+		if (node->info->filters.empty()) {
+			// no filters, create a cross product
+			auto join = make_unique<LogicalCrossProduct>();
+			join->children.push_back(move(left.second));
+			join->children.push_back(move(right.second));
+			result_operator = move(join);
+		} else {
+			// we have filters, create a join node
+			auto join = make_unique<LogicalComparisonJoin>(JoinType::INNER);
+			join->children.push_back(move(left.second));
+			join->children.push_back(move(right.second));
+			// set the join conditions from the join node
+			for (auto &f : node->info->filters) {
+				// extract the filter from the operator it originally belonged to
+				D_ASSERT(filters[f->filter_index]);
+				auto condition = move(filters[f->filter_index]);
+				// now create the actual join condition
+				D_ASSERT((JoinRelationSet::IsSubset(left.first, f->left_set) &&
+				          JoinRelationSet::IsSubset(right.first, f->right_set)) ||
+				         (JoinRelationSet::IsSubset(left.first, f->right_set) &&
+				          JoinRelationSet::IsSubset(right.first, f->left_set)));
+				JoinCondition cond;
+				D_ASSERT(condition->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON);
+				auto &comparison = (BoundComparisonExpression &)*condition;
+				// we need to figure out which side is which by looking at the relations available to us
+				bool invert = !JoinRelationSet::IsSubset(left.first, f->left_set);
+				cond.left = !invert ? move(comparison.left) : move(comparison.right);
+				cond.right = !invert ? move(comparison.right) : move(comparison.left);
+				cond.comparison = condition->type;
+
+				if (invert) {
+					// reverse comparison expression if we reverse the order of the children
+					cond.comparison = FlipComparisionExpression(cond.comparison);
+				}
+				join->conditions.push_back(move(cond));
+			}
+			D_ASSERT(!join->conditions.empty());
+			result_operator = move(join);
+		}
+		left_node = left.first;
+		right_node = right.first;
+		result_relation = set_manager.Union(left_node, right_node);
+	} else {
+		// base node, get the entry from the list of extracted relations
+		D_ASSERT(node->set->count == 1);
+		D_ASSERT(extracted_relations[node->set->relations[0]]);
+		result_relation = node->set;
+		result_operator = move(extracted_relations[node->set->relations[0]]);
+	}
+	// check if we should do a pushdown on this node
+	// basically, any remaining filter that is a subset of the current relation will no longer be used in joins
+	// hence we should push it here
+	for (auto &filter_info : filter_infos) {
+		// check if the filter has already been extracted
+		auto info = filter_info.get();
+		if (filters[info->filter_index]) {
+			// now check if the filter is a subset of the current relation
+			// note that infos with an empty relation set are a special case and we do not push them down
+			if (info->set->count > 0 && JoinRelationSet::IsSubset(result_relation, info->set)) {
+				auto filter = move(filters[info->filter_index]);
+				// if it is, we can push the filter
+				// we can push it either into a join or as a filter
+				// check if we are in a join or in a base table
+				if (!left_node || !info->left_set) {
+					// base table or non-comparison expression, push it as a filter
+					result_operator = PushFilter(move(result_operator), move(filter));
+					continue;
+				}
+				// the node below us is a join or cross product and the expression is a comparison
+				// check if the nodes can be split up into left/right
+				bool found_subset = false;
+				bool invert = false;
+				if (JoinRelationSet::IsSubset(left_node, info->left_set) &&
+				    JoinRelationSet::IsSubset(right_node, info->right_set)) {
+					found_subset = true;
+				} else if (JoinRelationSet::IsSubset(right_node, info->left_set) &&
+				           JoinRelationSet::IsSubset(left_node, info->right_set)) {
+					invert = true;
+					found_subset = true;
+				}
+				if (!found_subset) {
+					// could not be split up into left/right
+					result_operator = PushFilter(move(result_operator), move(filter));
+					continue;
+				}
+				// create the join condition
+				JoinCondition cond;
+				D_ASSERT(filter->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON);
+				auto &comparison = (BoundComparisonExpression &)*filter;
+				// we need to figure out which side is which by looking at the relations available to us
+				cond.left = !invert ? move(comparison.left) : move(comparison.right);
+				cond.right = !invert ? move(comparison.right) : move(comparison.left);
+				cond.comparison = comparison.type;
+				if (invert) {
+					// reverse comparison expression if we reverse the order of the children
+					cond.comparison = FlipComparisionExpression(comparison.type);
+				}
+				// now find the join to push it into
+				auto node = result_operator.get();
+				if (node->type == LogicalOperatorType::LOGICAL_FILTER) {
+					node = node->children[0].get();
+				}
+				if (node->type == LogicalOperatorType::LOGICAL_CROSS_PRODUCT) {
+					// turn into comparison join
+					auto comp_join = make_unique<LogicalComparisonJoin>(JoinType::INNER);
+					comp_join->children.push_back(move(node->children[0]));
+					comp_join->children.push_back(move(node->children[1]));
+					comp_join->conditions.push_back(move(cond));
+					if (node == result_operator.get()) {
+						result_operator = move(comp_join);
+					} else {
+						D_ASSERT(result_operator->type == LogicalOperatorType::LOGICAL_FILTER);
+						result_operator->children[0] = move(comp_join);
+					}
+				} else {
+					D_ASSERT(node->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN);
+					auto &comp_join = (LogicalComparisonJoin &)*node;
+					comp_join.conditions.push_back(move(cond));
+				}
+			}
+		}
+	}
+	return make_pair(result_relation, move(result_operator));
+}
+
+unique_ptr<LogicalOperator> JoinOrderOptimizer::RewritePlan(unique_ptr<LogicalOperator> plan, JoinNode *node) {
+	// now we have to rewrite the plan
+	bool root_is_join = plan->children.size() > 1;
+
+	// first we will extract all relations from the main plan
+	vector<unique_ptr<LogicalOperator>> extracted_relations;
+	for (auto &relation : relations) {
+		extracted_relations.push_back(ExtractJoinRelation(*relation));
+	}
+	// now we generate the actual joins
+	auto join_tree = GenerateJoins(extracted_relations, node);
+	// perform the final pushdown of remaining filters
+	for (auto &filter : filters) {
+		// check if the filter has already been extracted
+		if (filter) {
+			// if not we need to push it
+			join_tree.second = PushFilter(move(join_tree.second), move(filter));
+		}
+	}
+
+	// find the first join in the relation to know where to place this node
+	if (root_is_join) {
+		// first node is the join, return it immediately
+		return move(join_tree.second);
+	}
+	D_ASSERT(plan->children.size() == 1);
+	// have to move up through the relations
+	auto op = plan.get();
+	auto parent = plan.get();
+	while (op->type != LogicalOperatorType::LOGICAL_CROSS_PRODUCT &&
+	       op->type != LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		D_ASSERT(op->children.size() == 1);
+		parent = op;
+		op = op->children[0].get();
+	}
+	// have to replace at this node
+	parent->children[0] = move(join_tree.second);
+	return plan;
+}
+
+// the join ordering is pretty much a straight implementation of the paper "Dynamic Programming Strikes Back" by Guido
+// Moerkotte and Thomas Neumannn, see that paper for additional info/documentation bonus slides:
+// https://db.in.tum.de/teaching/ws1415/queryopt/chapter3.pdf?lang=de
+// FIXME: incorporate cardinality estimation into the plans, possibly by pushing samples?
+unique_ptr<LogicalOperator> JoinOrderOptimizer::Optimize(unique_ptr<LogicalOperator> plan) {
+	D_ASSERT(filters.empty() && relations.empty()); // assert that the JoinOrderOptimizer has not been used before
+	LogicalOperator *op = plan.get();
+	// now we optimize the current plan
+	// we skip past until we find the first projection, we do this because the HAVING clause inserts a Filter AFTER the
+	// group by and this filter cannot be reordered
+	// extract a list of all relations that have to be joined together
+	// and a list of all conditions that is applied to them
+	vector<LogicalOperator *> filter_operators;
+	if (!ExtractJoinRelations(*op, filter_operators)) {
+		// do not support reordering this type of plan
+		return plan;
+	}
+	if (relations.size() <= 1) {
+		// at most one relation, nothing to reorder
+		return plan;
+	}
+	// now that we know we are going to perform join ordering we actually extract the filters, eliminating duplicate
+	// filters in the process
+	expression_set_t filter_set;
+	for (auto &op : filter_operators) {
+		if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+			auto &join = (LogicalComparisonJoin &)*op;
+			D_ASSERT(join.join_type == JoinType::INNER);
+			D_ASSERT(join.expressions.empty());
+			for (auto &cond : join.conditions) {
+				auto comparison =
+				    make_unique<BoundComparisonExpression>(cond.comparison, move(cond.left), move(cond.right));
+				if (filter_set.find(comparison.get()) == filter_set.end()) {
+					filter_set.insert(comparison.get());
+					filters.push_back(move(comparison));
+				}
+			}
+			join.conditions.clear();
+		} else {
+			for (auto &expression : op->expressions) {
+				if (filter_set.find(expression.get()) == filter_set.end()) {
+					filter_set.insert(expression.get());
+					filters.push_back(move(expression));
+				}
+			}
+			op->expressions.clear();
+		}
+	}
+	// create potential edges from the comparisons
+	for (idx_t i = 0; i < filters.size(); i++) {
+		auto &filter = filters[i];
+		auto info = make_unique<FilterInfo>();
+		auto filter_info = info.get();
+		filter_infos.push_back(move(info));
+		// first extract the relation set for the entire filter
+		unordered_set<idx_t> bindings;
+		ExtractBindings(*filter, bindings);
+		filter_info->set = set_manager.GetJoinRelation(bindings);
+		filter_info->filter_index = i;
+		// now check if it can be used as a join predicate
+		if (filter->GetExpressionClass() == ExpressionClass::BOUND_COMPARISON) {
+			auto comparison = (BoundComparisonExpression *)filter.get();
+			// extract the bindings that are required for the left and right side of the comparison
+			unordered_set<idx_t> left_bindings, right_bindings;
+			ExtractBindings(*comparison->left, left_bindings);
+			ExtractBindings(*comparison->right, right_bindings);
+			if (!left_bindings.empty() && !right_bindings.empty()) {
+				// both the left and the right side have bindings
+				// first create the relation sets, if they do not exist
+				filter_info->left_set = set_manager.GetJoinRelation(left_bindings);
+				filter_info->right_set = set_manager.GetJoinRelation(right_bindings);
+				// we can only create a meaningful edge if the sets are not exactly the same
+				if (filter_info->left_set != filter_info->right_set) {
+					// check if the sets are disjoint
+					if (Disjoint(left_bindings, right_bindings)) {
+						// they are disjoint, we only need to create one set of edges in the join graph
+						query_graph.CreateEdge(filter_info->left_set, filter_info->right_set, filter_info);
+						query_graph.CreateEdge(filter_info->right_set, filter_info->left_set, filter_info);
+					} else {
+						continue;
+					}
+					continue;
+				}
+			}
+		}
+	}
+	// now use dynamic programming to figure out the optimal join order
+	// First we initialize each of the single-node plans with themselves and with their cardinalities these are the leaf
+	// nodes of the join tree NOTE: we can just use pointers to JoinRelationSet* here because the GetJoinRelation
+	// function ensures that a unique combination of relations will have a unique JoinRelationSet object.
+	for (idx_t i = 0; i < relations.size(); i++) {
+		auto &rel = *relations[i];
+		auto node = set_manager.GetJoinRelation(i);
+		plans[node] = make_unique<JoinNode>(node, rel.op->EstimateCardinality(context));
+	}
+	// now we perform the actual dynamic programming to compute the final result
+	SolveJoinOrder();
+	// now the optimal join path should have been found
+	// get it from the node
+	unordered_set<idx_t> bindings;
+	for (idx_t i = 0; i < relations.size(); i++) {
+		bindings.insert(i);
+	}
+	auto total_relation = set_manager.GetJoinRelation(bindings);
+	auto final_plan = plans.find(total_relation);
+	if (final_plan == plans.end()) {
+		// could not find the final plan
+		// this should only happen in case the sets are actually disjunct
+		// in this case we need to generate cross product to connect the disjoint sets
+		if (context.config.force_no_cross_product) {
+			throw InternalException("HyperGraph isn't connected");
+		}
+		GenerateCrossProducts();
+		//! solve the join order again
+		SolveJoinOrder();
+		// now we can obtain the final plan!
+		final_plan = plans.find(total_relation);
+		D_ASSERT(final_plan != plans.end());
+	}
+	// now perform the actual reordering
+	return RewritePlan(move(plan), final_plan->second.get());
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+bool ExpressionMatcher::Match(Expression *expr, vector<Expression *> &bindings) {
+	if (type && !type->Match(expr->return_type)) {
+		return false;
+	}
+	if (expr_type && !expr_type->Match(expr->type)) {
+		return false;
+	}
+	if (expr_class != ExpressionClass::INVALID && expr_class != expr->GetExpressionClass()) {
+		return false;
+	}
+	bindings.push_back(expr);
+	return true;
+}
+
+bool ExpressionEqualityMatcher::Match(Expression *expr, vector<Expression *> &bindings) {
+	if (!Expression::Equals(expression, expr)) {
+		return false;
+	}
+	bindings.push_back(expr);
+	return true;
+}
+
+bool CaseExpressionMatcher::Match(Expression *expr_p, vector<Expression *> &bindings) {
+	if (!ExpressionMatcher::Match(expr_p, bindings)) {
+		return false;
+	}
+	return true;
+}
+
+bool ComparisonExpressionMatcher::Match(Expression *expr_p, vector<Expression *> &bindings) {
+	if (!ExpressionMatcher::Match(expr_p, bindings)) {
+		return false;
+	}
+	auto expr = (BoundComparisonExpression *)expr_p;
+	vector<Expression *> expressions = {expr->left.get(), expr->right.get()};
+	return SetMatcher::Match(matchers, expressions, bindings, policy);
+}
+
+bool CastExpressionMatcher::Match(Expression *expr_p, vector<Expression *> &bindings) {
+	if (!ExpressionMatcher::Match(expr_p, bindings)) {
+		return false;
+	}
+	if (!matcher) {
+		return true;
+	}
+	auto expr = (BoundCastExpression *)expr_p;
+	return matcher->Match(expr->child.get(), bindings);
+}
+
+bool InClauseExpressionMatcher::Match(Expression *expr_p, vector<Expression *> &bindings) {
+	if (!ExpressionMatcher::Match(expr_p, bindings)) {
+		return false;
+	}
+	auto expr = (BoundOperatorExpression *)expr_p;
+	if (expr->type != ExpressionType::COMPARE_IN || expr->type == ExpressionType::COMPARE_NOT_IN) {
+		return false;
+	}
+	return SetMatcher::Match(matchers, expr->children, bindings, policy);
+}
+
+bool ConjunctionExpressionMatcher::Match(Expression *expr_p, vector<Expression *> &bindings) {
+	if (!ExpressionMatcher::Match(expr_p, bindings)) {
+		return false;
+	}
+	auto expr = (BoundConjunctionExpression *)expr_p;
+	if (!SetMatcher::Match(matchers, expr->children, bindings, policy)) {
+		return false;
+	}
+	return true;
+}
+
+bool FunctionExpressionMatcher::Match(Expression *expr_p, vector<Expression *> &bindings) {
+	if (!ExpressionMatcher::Match(expr_p, bindings)) {
+		return false;
+	}
+	auto expr = (BoundFunctionExpression *)expr_p;
+	if (!FunctionMatcher::Match(function, expr->function.name)) {
+		return false;
+	}
+	if (!SetMatcher::Match(matchers, expr->children, bindings, policy)) {
+		return false;
+	}
+	return true;
+}
+
+bool FoldableConstantMatcher::Match(Expression *expr, vector<Expression *> &bindings) {
+	// we match on ANY expression that is a scalar expression
+	if (!expr->IsFoldable()) {
+		return false;
+	}
+	bindings.push_back(expr);
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+Optimizer::Optimizer(Binder &binder, ClientContext &context) : context(context), binder(binder), rewriter(context) {
+	rewriter.rules.push_back(make_unique<ConstantFoldingRule>(rewriter));
+	rewriter.rules.push_back(make_unique<DistributivityRule>(rewriter));
+	rewriter.rules.push_back(make_unique<ArithmeticSimplificationRule>(rewriter));
+	rewriter.rules.push_back(make_unique<CaseSimplificationRule>(rewriter));
+	rewriter.rules.push_back(make_unique<ConjunctionSimplificationRule>(rewriter));
+	rewriter.rules.push_back(make_unique<DatePartSimplificationRule>(rewriter));
+	rewriter.rules.push_back(make_unique<ComparisonSimplificationRule>(rewriter));
+	rewriter.rules.push_back(make_unique<InClauseSimplificationRule>(rewriter));
+	rewriter.rules.push_back(make_unique<EqualOrNullSimplification>(rewriter));
+	rewriter.rules.push_back(make_unique<MoveConstantsRule>(rewriter));
+	rewriter.rules.push_back(make_unique<LikeOptimizationRule>(rewriter));
+	rewriter.rules.push_back(make_unique<RegexOptimizationRule>(rewriter));
+	rewriter.rules.push_back(make_unique<EmptyNeedleRemovalRule>(rewriter));
+	rewriter.rules.push_back(make_unique<EnumComparisonRule>(rewriter));
+
+#ifdef DEBUG
+	for (auto &rule : rewriter.rules) {
+		// root not defined in rule
+		D_ASSERT(rule->root);
+	}
+#endif
+}
+
+void Optimizer::RunOptimizer(OptimizerType type, const std::function<void()> &callback) {
+	auto &config = DBConfig::GetConfig(context);
+	if (config.disabled_optimizers.find(type) != config.disabled_optimizers.end()) {
+		// optimizer is marked as disabled: skip
+		return;
+	}
+	auto &profiler = QueryProfiler::Get(context);
+	profiler.StartPhase(OptimizerTypeToString(type));
+	callback();
+	profiler.EndPhase();
+}
+
+unique_ptr<LogicalOperator> Optimizer::Optimize(unique_ptr<LogicalOperator> plan) {
+	// first we perform expression rewrites using the ExpressionRewriter
+	// this does not change the logical plan structure, but only simplifies the expression trees
+	RunOptimizer(OptimizerType::EXPRESSION_REWRITER, [&]() { rewriter.VisitOperator(*plan); });
+
+	// perform filter pullup
+	RunOptimizer(OptimizerType::FILTER_PULLUP, [&]() {
+		FilterPullup filter_pullup;
+		plan = filter_pullup.Rewrite(move(plan));
+	});
+
+	// perform filter pushdown
+	RunOptimizer(OptimizerType::FILTER_PUSHDOWN, [&]() {
+		FilterPushdown filter_pushdown(*this);
+		plan = filter_pushdown.Rewrite(move(plan));
+	});
+
+	RunOptimizer(OptimizerType::REGEX_RANGE, [&]() {
+		RegexRangeFilter regex_opt;
+		plan = regex_opt.Rewrite(move(plan));
+	});
+
+	RunOptimizer(OptimizerType::IN_CLAUSE, [&]() {
+		InClauseRewriter rewriter(*this);
+		plan = rewriter.Rewrite(move(plan));
+	});
+
+	// then we perform the join ordering optimization
+	// this also rewrites cross products + filters into joins and performs filter pushdowns
+	RunOptimizer(OptimizerType::JOIN_ORDER, [&]() {
+		JoinOrderOptimizer optimizer(context);
+		plan = optimizer.Optimize(move(plan));
+	});
+
+	// removes any redundant DelimGets/DelimJoins
+	RunOptimizer(OptimizerType::DELIMINATOR, [&]() {
+		Deliminator deliminator;
+		plan = deliminator.Optimize(move(plan));
+	});
+
+	RunOptimizer(OptimizerType::UNUSED_COLUMNS, [&]() {
+		RemoveUnusedColumns unused(binder, context, true);
+		unused.VisitOperator(*plan);
+	});
+
+	// perform statistics propagation
+	RunOptimizer(OptimizerType::STATISTICS_PROPAGATION, [&]() {
+		StatisticsPropagator propagator(context);
+		propagator.PropagateStatistics(plan);
+	});
+
+	// then we extract common subexpressions inside the different operators
+	RunOptimizer(OptimizerType::COMMON_SUBEXPRESSIONS, [&]() {
+		CommonSubExpressionOptimizer cse_optimizer(binder);
+		cse_optimizer.VisitOperator(*plan);
+	});
+
+	RunOptimizer(OptimizerType::COMMON_AGGREGATE, [&]() {
+		CommonAggregateOptimizer common_aggregate;
+		common_aggregate.VisitOperator(*plan);
+	});
+
+	RunOptimizer(OptimizerType::COLUMN_LIFETIME, [&]() {
+		ColumnLifetimeAnalyzer column_lifetime(true);
+		column_lifetime.VisitOperator(*plan);
+	});
+
+	// transform ORDER BY + LIMIT to TopN
+	RunOptimizer(OptimizerType::TOP_N, [&]() {
+		TopN topn;
+		plan = topn.Optimize(move(plan));
+	});
+
+	// apply simple expression heuristics to get an initial reordering
+	RunOptimizer(OptimizerType::REORDER_FILTER, [&]() {
+		ExpressionHeuristics expression_heuristics(*this);
+		plan = expression_heuristics.Rewrite(move(plan));
+	});
+
+	return plan;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> FilterPullup::PullupBothSide(unique_ptr<LogicalOperator> op) {
+	FilterPullup left_pullup(true, can_add_column);
+	FilterPullup right_pullup(true, can_add_column);
+	op->children[0] = left_pullup.Rewrite(move(op->children[0]));
+	op->children[1] = right_pullup.Rewrite(move(op->children[1]));
+
+	// merging filter expressions
+	for (idx_t i = 0; i < right_pullup.filters_expr_pullup.size(); ++i) {
+		left_pullup.filters_expr_pullup.push_back(move(right_pullup.filters_expr_pullup[i]));
+	}
+
+	if (!left_pullup.filters_expr_pullup.empty()) {
+		return GeneratePullupFilter(move(op), left_pullup.filters_expr_pullup);
+	}
+	return op;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> FilterPullup::PullupFilter(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_FILTER);
+
+	if (can_pullup) {
+		unique_ptr<LogicalOperator> child = move(op->children[0]);
+		child = Rewrite(move(child));
+		// moving filter's expressions
+		for (idx_t i = 0; i < op->expressions.size(); ++i) {
+			filters_expr_pullup.push_back(move(op->expressions[i]));
+		}
+		return child;
+	}
+	op->children[0] = Rewrite(move(op->children[0]));
+	return op;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> FilterPullup::PullupFromLeft(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
+	         op->type == LogicalOperatorType::LOGICAL_ANY_JOIN || op->type == LogicalOperatorType::LOGICAL_EXCEPT);
+
+	FilterPullup left_pullup(true, can_add_column);
+	FilterPullup right_pullup(false, can_add_column);
+
+	op->children[0] = left_pullup.Rewrite(move(op->children[0]));
+	op->children[1] = right_pullup.Rewrite(move(op->children[1]));
+
+	// check only for filters from the LHS
+	if (!left_pullup.filters_expr_pullup.empty() && right_pullup.filters_expr_pullup.empty()) {
+		return GeneratePullupFilter(move(op), left_pullup.filters_expr_pullup);
+	}
+	return op;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void RevertFilterPullup(LogicalProjection &proj, vector<unique_ptr<Expression>> &expressions) {
+	unique_ptr<LogicalFilter> filter = make_unique<LogicalFilter>();
+	for (idx_t i = 0; i < expressions.size(); ++i) {
+		filter->expressions.push_back(move(expressions[i]));
+	}
+	expressions.clear();
+	filter->children.push_back(move(proj.children[0]));
+	proj.children[0] = move(filter);
+}
+
+static void ReplaceExpressionBinding(vector<unique_ptr<Expression>> &proj_expressions, Expression &expr,
+                                     idx_t proj_table_idx) {
+	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
+		bool found_proj_col = false;
+		BoundColumnRefExpression &colref = (BoundColumnRefExpression &)expr;
+		// find the corresponding column index in the projection expressions
+		for (idx_t proj_idx = 0; proj_idx < proj_expressions.size(); proj_idx++) {
+			auto proj_expr = proj_expressions[proj_idx].get();
+			if (proj_expr->type == ExpressionType::BOUND_COLUMN_REF) {
+				if (colref.Equals(proj_expr)) {
+					colref.binding.table_index = proj_table_idx;
+					colref.binding.column_index = proj_idx;
+					found_proj_col = true;
+					break;
+				}
+			}
+		}
+		if (!found_proj_col) {
+			// Project a new column
+			auto new_colref = colref.Copy();
+			colref.binding.table_index = proj_table_idx;
+			colref.binding.column_index = proj_expressions.size();
+			proj_expressions.push_back(move(new_colref));
+		}
+	}
+	ExpressionIterator::EnumerateChildren(
+	    expr, [&](Expression &child) { return ReplaceExpressionBinding(proj_expressions, child, proj_table_idx); });
+}
+
+void FilterPullup::ProjectSetOperation(LogicalProjection &proj) {
+	vector<unique_ptr<Expression>> copy_proj_expressions;
+	// copying the project expressions, it's useful whether we should revert the filter pullup
+	for (idx_t i = 0; i < proj.expressions.size(); ++i) {
+		copy_proj_expressions.push_back(proj.expressions[i]->Copy());
+	}
+
+	// Replace filter expression bindings, when need we add new columns into the copied projection expression
+	vector<unique_ptr<Expression>> changed_filter_expressions;
+	for (idx_t i = 0; i < filters_expr_pullup.size(); ++i) {
+		auto copy_filter_expr = filters_expr_pullup[i]->Copy();
+		ReplaceExpressionBinding(copy_proj_expressions, (Expression &)*copy_filter_expr, proj.table_index);
+		changed_filter_expressions.push_back(move(copy_filter_expr));
+	}
+
+	/// Case new columns were added into the projection
+	// we must skip filter pullup because adding new columns to these operators will change the result
+	if (copy_proj_expressions.size() > proj.expressions.size()) {
+		RevertFilterPullup(proj, filters_expr_pullup);
+		return;
+	}
+
+	// now we must replace the filter bindings
+	D_ASSERT(filters_expr_pullup.size() == changed_filter_expressions.size());
+	for (idx_t i = 0; i < filters_expr_pullup.size(); ++i) {
+		filters_expr_pullup[i] = move(changed_filter_expressions[i]);
+	}
+}
+
+unique_ptr<LogicalOperator> FilterPullup::PullupProjection(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_PROJECTION);
+	op->children[0] = Rewrite(move(op->children[0]));
+	if (!filters_expr_pullup.empty()) {
+		auto &proj = (LogicalProjection &)*op;
+		// INTERSECT, EXCEPT, and DISTINCT
+		if (!can_add_column) {
+			// special treatment for operators that cannot add columns, e.g., INTERSECT, EXCEPT, and DISTINCT
+			ProjectSetOperation(proj);
+			return op;
+		}
+
+		for (idx_t i = 0; i < filters_expr_pullup.size(); ++i) {
+			auto &expr = (Expression &)*filters_expr_pullup[i];
+			ReplaceExpressionBinding(proj.expressions, expr, proj.table_index);
+		}
+	}
+	return op;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+static void ReplaceFilterTableIndex(Expression &expr, LogicalSetOperation &setop) {
+	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &colref = (BoundColumnRefExpression &)expr;
+		D_ASSERT(colref.depth == 0);
+
+		colref.binding.table_index = setop.table_index;
+		return;
+	}
+	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { ReplaceFilterTableIndex(child, setop); });
+}
+
+unique_ptr<LogicalOperator> FilterPullup::PullupSetOperation(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_INTERSECT || op->type == LogicalOperatorType::LOGICAL_EXCEPT);
+	can_add_column = false;
+	can_pullup = true;
+	if (op->type == LogicalOperatorType::LOGICAL_INTERSECT) {
+		op = PullupBothSide(move(op));
+	} else {
+		// EXCEPT only pull ups from LHS
+		op = PullupFromLeft(move(op));
+	}
+	if (op->type == LogicalOperatorType::LOGICAL_FILTER) {
+		auto &filter = (LogicalFilter &)*op;
+		auto &setop = (LogicalSetOperation &)*filter.children[0];
+		for (idx_t i = 0; i < filter.expressions.size(); ++i) {
+			ReplaceFilterTableIndex(*filter.expressions[i], setop);
+		}
+	}
+	return op;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+using Filter = FilterPushdown::Filter;
+
+static unique_ptr<Expression> ReplaceGroupBindings(LogicalAggregate &proj, unique_ptr<Expression> expr) {
+	if (expr->type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &colref = (BoundColumnRefExpression &)*expr;
+		D_ASSERT(colref.binding.table_index == proj.group_index);
+		D_ASSERT(colref.binding.column_index < proj.groups.size());
+		D_ASSERT(colref.depth == 0);
+		// replace the binding with a copy to the expression at the referenced index
+		return proj.groups[colref.binding.column_index]->Copy();
+	}
+	ExpressionIterator::EnumerateChildren(
+	    *expr, [&](unique_ptr<Expression> &child) { child = ReplaceGroupBindings(proj, move(child)); });
+	return expr;
+}
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownAggregate(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY);
+	auto &aggr = (LogicalAggregate &)*op;
+
+	// pushdown into AGGREGATE and GROUP BY
+	// we cannot push expressions that refer to the aggregate
+	FilterPushdown child_pushdown(optimizer);
+	for (idx_t i = 0; i < filters.size(); i++) {
+		auto &f = *filters[i];
+		// check if any aggregate or GROUPING functions are in the set
+		if (f.bindings.find(aggr.aggregate_index) == f.bindings.end() &&
+		    f.bindings.find(aggr.groupings_index) == f.bindings.end()) {
+			// no aggregate! we can push this down
+			// rewrite any group bindings within the filter
+			f.filter = ReplaceGroupBindings(aggr, move(f.filter));
+			// add the filter to the child node
+			if (child_pushdown.AddFilter(move(f.filter)) == FilterResult::UNSATISFIABLE) {
+				// filter statically evaluates to false, strip tree
+				return make_unique<LogicalEmptyResult>(move(op));
+			}
+			// erase the filter from here
+			filters.erase(filters.begin() + i);
+			i--;
+		}
+	}
+	child_pushdown.GenerateFilters();
+
+	op->children[0] = child_pushdown.Rewrite(move(op->children[0]));
+	return FinishPushdown(move(op));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+using Filter = FilterPushdown::Filter;
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownCrossProduct(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_CROSS_PRODUCT);
+	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
+	vector<unique_ptr<Expression>> join_conditions;
+	unordered_set<idx_t> left_bindings, right_bindings;
+	if (!filters.empty()) {
+		// check to see into which side we should push the filters
+		// first get the LHS and RHS bindings
+		LogicalJoin::GetTableReferences(*op->children[0], left_bindings);
+		LogicalJoin::GetTableReferences(*op->children[1], right_bindings);
+		// now check the set of filters
+		for (auto &f : filters) {
+			auto side = JoinSide::GetJoinSide(f->bindings, left_bindings, right_bindings);
+			if (side == JoinSide::LEFT) {
+				// bindings match left side: push into left
+				left_pushdown.filters.push_back(move(f));
+			} else if (side == JoinSide::RIGHT) {
+				// bindings match right side: push into right
+				right_pushdown.filters.push_back(move(f));
+			} else {
+				D_ASSERT(side == JoinSide::BOTH);
+				// bindings match both: turn into join condition
+				join_conditions.push_back(move(f->filter));
+			}
+		}
+	}
+
+	op->children[0] = left_pushdown.Rewrite(move(op->children[0]));
+	op->children[1] = right_pushdown.Rewrite(move(op->children[1]));
+
+	if (!join_conditions.empty()) {
+		// join conditions found: turn into inner join
+		return LogicalComparisonJoin::CreateJoin(JoinType::INNER, move(op->children[0]), move(op->children[1]),
+		                                         left_bindings, right_bindings, join_conditions);
+	} else {
+		// no join conditions found: keep as cross product
+		return op;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+using Filter = FilterPushdown::Filter;
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownFilter(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_FILTER);
+	auto &filter = (LogicalFilter &)*op;
+	// filter: gather the filters and remove the filter from the set of operations
+	for (auto &expression : filter.expressions) {
+		if (AddFilter(move(expression)) == FilterResult::UNSATISFIABLE) {
+			// filter statically evaluates to false, strip tree
+			return make_unique<LogicalEmptyResult>(move(op));
+		}
+	}
+	GenerateFilters();
+	return Rewrite(move(filter.children[0]));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownGet(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_GET);
+	auto &get = (LogicalGet &)*op;
+
+	if (get.function.pushdown_complex_filter) {
+		// for the remaining filters, check if we can push any of them into the scan as well
+		vector<unique_ptr<Expression>> expressions;
+		for (auto &filter : filters) {
+			expressions.push_back(move(filter->filter));
+		}
+		filters.clear();
+
+		get.function.pushdown_complex_filter(optimizer.context, get, get.bind_data.get(), expressions);
+
+		if (expressions.empty()) {
+			return op;
+		}
+		// re-generate the filters
+		for (auto &expr : expressions) {
+			auto f = make_unique<Filter>();
+			f->filter = move(expr);
+			f->ExtractBindings();
+			filters.push_back(move(f));
+		}
+	}
+
+	if (!get.table_filters.filters.empty() || !get.function.filter_pushdown) {
+		// the table function does not support filter pushdown: push a LogicalFilter on top
+		return FinishPushdown(move(op));
+	}
+	PushFilters();
+
+	//! We generate the table filters that will be executed during the table scan
+	//! Right now this only executes simple AND filters
+	get.table_filters = combiner.GenerateTableScanFilters(get.column_ids);
+
+	// //! For more complex filters if all filters to a column are constants we generate a min max boundary used to
+	// check
+	// //! the zonemaps.
+	// auto zonemap_checks = combiner.GenerateZonemapChecks(get.column_ids, get.table_filters);
+
+	// for (auto &f : get.table_filters) {
+	// 	f.column_index = get.column_ids[f.column_index];
+	// }
+
+	// //! Use zonemap checks as table filters for pre-processing
+	// for (auto &zonemap_check : zonemap_checks) {
+	// 	if (zonemap_check.column_index != COLUMN_IDENTIFIER_ROW_ID) {
+	// 		get.table_filters.push_back(zonemap_check);
+	// 	}
+	// }
+
+	GenerateFilters();
+
+	//! Now we try to pushdown the remaining filters to perform zonemap checking
+	return FinishPushdown(move(op));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+using Filter = FilterPushdown::Filter;
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownInnerJoin(unique_ptr<LogicalOperator> op,
+                                                              unordered_set<idx_t> &left_bindings,
+                                                              unordered_set<idx_t> &right_bindings) {
+	auto &join = (LogicalJoin &)*op;
+	D_ASSERT(join.join_type == JoinType::INNER);
+	D_ASSERT(op->type != LogicalOperatorType::LOGICAL_DELIM_JOIN);
+	// inner join: gather all the conditions of the inner join and add to the filter list
+	if (op->type == LogicalOperatorType::LOGICAL_ANY_JOIN) {
+		auto &any_join = (LogicalAnyJoin &)join;
+		// any join: only one filter to add
+		if (AddFilter(move(any_join.condition)) == FilterResult::UNSATISFIABLE) {
+			// filter statically evaluates to false, strip tree
+			return make_unique<LogicalEmptyResult>(move(op));
+		}
+	} else {
+		// comparison join
+		D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN);
+		auto &comp_join = (LogicalComparisonJoin &)join;
+		// turn the conditions into filters
+		for (auto &i : comp_join.conditions) {
+			auto condition = JoinCondition::CreateExpression(move(i));
+			if (AddFilter(move(condition)) == FilterResult::UNSATISFIABLE) {
+				// filter statically evaluates to false, strip tree
+				return make_unique<LogicalEmptyResult>(move(op));
+			}
+		}
+	}
+	GenerateFilters();
+
+	// turn the inner join into a cross product
+	auto cross_product = make_unique<LogicalCrossProduct>();
+	cross_product->children.push_back(move(op->children[0]));
+	cross_product->children.push_back(move(op->children[1]));
+	// then push down cross product
+	return PushdownCrossProduct(move(cross_product));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+using Filter = FilterPushdown::Filter;
+
+static unique_ptr<Expression> ReplaceColRefWithNull(unique_ptr<Expression> expr, unordered_set<idx_t> &right_bindings) {
+	if (expr->type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &bound_colref = (BoundColumnRefExpression &)*expr;
+		if (right_bindings.find(bound_colref.binding.table_index) != right_bindings.end()) {
+			// bound colref belongs to RHS
+			// replace it with a constant NULL
+			return make_unique<BoundConstantExpression>(Value(expr->return_type));
+		}
+		return expr;
+	}
+	ExpressionIterator::EnumerateChildren(
+	    *expr, [&](unique_ptr<Expression> &child) { child = ReplaceColRefWithNull(move(child), right_bindings); });
+	return expr;
+}
+
+static bool FilterRemovesNull(ExpressionRewriter &rewriter, Expression *expr, unordered_set<idx_t> &right_bindings) {
+	// make a copy of the expression
+	auto copy = expr->Copy();
+	// replace all BoundColumnRef expressions frmo the RHS with NULL constants in the copied expression
+	copy = ReplaceColRefWithNull(move(copy), right_bindings);
+
+	// attempt to flatten the expression by running the expression rewriter on it
+	auto filter = make_unique<LogicalFilter>();
+	filter->expressions.push_back(move(copy));
+	rewriter.VisitOperator(*filter);
+
+	// check if all expressions are foldable
+	for (idx_t i = 0; i < filter->expressions.size(); i++) {
+		if (!filter->expressions[i]->IsFoldable()) {
+			return false;
+		}
+		// we flattened the result into a scalar, check if it is FALSE or NULL
+		auto val = ExpressionExecutor::EvaluateScalar(*filter->expressions[i]).CastAs(LogicalType::BOOLEAN);
+		// if the result of the expression with all expressions replaced with NULL is "NULL" or "false"
+		// then any extra entries generated by the LEFT OUTER JOIN will be filtered out!
+		// hence the LEFT OUTER JOIN is equivalent to an inner join
+		if (val.IsNull() || !BooleanValue::Get(val)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownLeftJoin(unique_ptr<LogicalOperator> op,
+                                                             unordered_set<idx_t> &left_bindings,
+                                                             unordered_set<idx_t> &right_bindings) {
+	auto &join = (LogicalJoin &)*op;
+	D_ASSERT(join.join_type == JoinType::LEFT);
+	D_ASSERT(op->type != LogicalOperatorType::LOGICAL_DELIM_JOIN);
+	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
+	// for a comparison join we create a FilterCombiner that checks if we can push conditions on LHS join conditions
+	// into the RHS of the join
+	FilterCombiner filter_combiner;
+	if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		// add all comparison conditions
+		auto &comparison_join = (LogicalComparisonJoin &)*op;
+		for (auto &cond : comparison_join.conditions) {
+			filter_combiner.AddFilter(
+			    make_unique<BoundComparisonExpression>(cond.comparison, cond.left->Copy(), cond.right->Copy()));
+		}
+	}
+	// now check the set of filters
+	for (idx_t i = 0; i < filters.size(); i++) {
+		auto side = JoinSide::GetJoinSide(filters[i]->bindings, left_bindings, right_bindings);
+		if (side == JoinSide::LEFT) {
+			// bindings match left side
+			// we can push the filter into the left side
+			if (op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+				// we MIGHT be able to push it down the RHS as well, but only if it is a comparison that matches the
+				// join predicates we use the FilterCombiner to figure this out add the expression to the FilterCombiner
+				filter_combiner.AddFilter(filters[i]->filter->Copy());
+			}
+			left_pushdown.filters.push_back(move(filters[i]));
+			// erase the filter from the list of filters
+			filters.erase(filters.begin() + i);
+			i--;
+		} else {
+			// bindings match right side or both sides: we cannot directly push it into the right
+			// however, if the filter removes rows with null values from the RHS we can turn the left outer join
+			// in an inner join, and then push down as we would push down an inner join
+			if (FilterRemovesNull(optimizer.rewriter, filters[i]->filter.get(), right_bindings)) {
+				// the filter removes NULL values, turn it into an inner join
+				join.join_type = JoinType::INNER;
+				// now we can do more pushdown
+				// move all filters we added to the left_pushdown back into the filter list
+				for (auto &left_filter : left_pushdown.filters) {
+					filters.push_back(move(left_filter));
+				}
+				// now push down the inner join
+				return PushdownInnerJoin(move(op), left_bindings, right_bindings);
+			}
+		}
+	}
+	// finally we check the FilterCombiner to see if there are any predicates we can push into the RHS
+	// we only added (1) predicates that have JoinSide::BOTH from the conditions, and
+	// (2) predicates that have JoinSide::LEFT from the filters
+	// we check now if this combination generated any new filters that are only on JoinSide::RIGHT
+	// this happens if, e.g. a join condition is (i=a) and there is a filter (i=500), we can then push the filter
+	// (a=500) into the RHS
+	filter_combiner.GenerateFilters([&](unique_ptr<Expression> filter) {
+		if (JoinSide::GetJoinSide(*filter, left_bindings, right_bindings) == JoinSide::RIGHT) {
+			right_pushdown.AddFilter(move(filter));
+		}
+	});
+	right_pushdown.GenerateFilters();
+	op->children[0] = left_pushdown.Rewrite(move(op->children[0]));
+	op->children[1] = right_pushdown.Rewrite(move(op->children[1]));
+	return FinishPushdown(move(op));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownLimit(unique_ptr<LogicalOperator> op) {
+	auto &limit = (LogicalLimit &)*op;
+
+	if (!limit.limit && limit.limit_val == 0) {
+		return make_unique<LogicalEmptyResult>(move(op));
+	}
+
+	return FinishPushdown(move(op));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+using Filter = FilterPushdown::Filter;
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownMarkJoin(unique_ptr<LogicalOperator> op,
+                                                             unordered_set<idx_t> &left_bindings,
+                                                             unordered_set<idx_t> &right_bindings) {
+	auto &join = (LogicalJoin &)*op;
+	auto &comp_join = (LogicalComparisonJoin &)*op;
+	D_ASSERT(join.join_type == JoinType::MARK);
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN ||
+	         op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN);
+
+	right_bindings.insert(comp_join.mark_index);
+	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
+#ifndef NDEBUG
+	bool found_mark_reference = false;
+#endif
+	// now check the set of filters
+	for (idx_t i = 0; i < filters.size(); i++) {
+		auto side = JoinSide::GetJoinSide(filters[i]->bindings, left_bindings, right_bindings);
+		if (side == JoinSide::LEFT) {
+			// bindings match left side: push into left
+			left_pushdown.filters.push_back(move(filters[i]));
+			// erase the filter from the list of filters
+			filters.erase(filters.begin() + i);
+			i--;
+		} else if (side == JoinSide::RIGHT) {
+			// there can only be at most one filter referencing the marker
+#ifndef NDEBUG
+			D_ASSERT(!found_mark_reference);
+			found_mark_reference = true;
+#endif
+			// this filter references the marker
+			// we can turn this into a SEMI join if the filter is on only the marker
+			if (filters[i]->filter->type == ExpressionType::BOUND_COLUMN_REF) {
+				// filter just references the marker: turn into semi join
+				join.join_type = JoinType::SEMI;
+				filters.erase(filters.begin() + i);
+				i--;
+				continue;
+			}
+			// if the filter is on NOT(marker) AND the join conditions are all set to "null_values_are_equal" we can
+			// turn this into an ANTI join if all join conditions have null_values_are_equal=true, then the result of
+			// the MARK join is always TRUE or FALSE, and never NULL this happens in the case of a correlated EXISTS
+			// clause
+			if (filters[i]->filter->type == ExpressionType::OPERATOR_NOT) {
+				auto &op_expr = (BoundOperatorExpression &)*filters[i]->filter;
+				if (op_expr.children[0]->type == ExpressionType::BOUND_COLUMN_REF) {
+					// the filter is NOT(marker), check the join conditions
+					bool all_null_values_are_equal = true;
+					for (auto &cond : comp_join.conditions) {
+						if (cond.comparison != ExpressionType::COMPARE_DISTINCT_FROM &&
+						    cond.comparison != ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+							all_null_values_are_equal = false;
+							break;
+						}
+					}
+					if (all_null_values_are_equal) {
+						// all null values are equal, convert to ANTI join
+						join.join_type = JoinType::ANTI;
+						filters.erase(filters.begin() + i);
+						i--;
+						continue;
+					}
+				}
+			}
+		}
+	}
+	op->children[0] = left_pushdown.Rewrite(move(op->children[0]));
+	op->children[1] = right_pushdown.Rewrite(move(op->children[1]));
+	return FinishPushdown(move(op));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+static unique_ptr<Expression> ReplaceProjectionBindings(LogicalProjection &proj, unique_ptr<Expression> expr) {
+	if (expr->type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &colref = (BoundColumnRefExpression &)*expr;
+		D_ASSERT(colref.binding.table_index == proj.table_index);
+		D_ASSERT(colref.binding.column_index < proj.expressions.size());
+		D_ASSERT(colref.depth == 0);
+		// replace the binding with a copy to the expression at the referenced index
+		return proj.expressions[colref.binding.column_index]->Copy();
+	}
+	ExpressionIterator::EnumerateChildren(
+	    *expr, [&](unique_ptr<Expression> &child) { child = ReplaceProjectionBindings(proj, move(child)); });
+	return expr;
+}
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownProjection(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_PROJECTION);
+	auto &proj = (LogicalProjection &)*op;
+	// push filter through logical projection
+	// all the BoundColumnRefExpressions in the filter should refer to the LogicalProjection
+	// we can rewrite them by replacing those references with the expression of the LogicalProjection node
+	FilterPushdown child_pushdown(optimizer);
+	for (auto &filter : filters) {
+		auto &f = *filter;
+		D_ASSERT(f.bindings.size() <= 1);
+		// rewrite the bindings within this subquery
+		f.filter = ReplaceProjectionBindings(proj, move(f.filter));
+		// add the filter to the child pushdown
+		if (child_pushdown.AddFilter(move(f.filter)) == FilterResult::UNSATISFIABLE) {
+			// filter statically evaluates to false, strip tree
+			return make_unique<LogicalEmptyResult>(move(op));
+		}
+	}
+	child_pushdown.GenerateFilters();
+	// now push into children
+	op->children[0] = child_pushdown.Rewrite(move(op->children[0]));
+	if (op->children[0]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
+		// child returns an empty result: generate an empty result here too
+		return make_unique<LogicalEmptyResult>(move(op));
+	}
+	return op;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+using Filter = FilterPushdown::Filter;
+
+static void ReplaceSetOpBindings(vector<ColumnBinding> &bindings, Filter &filter, Expression &expr,
+                                 LogicalSetOperation &setop) {
+	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &colref = (BoundColumnRefExpression &)expr;
+		D_ASSERT(colref.binding.table_index == setop.table_index);
+		D_ASSERT(colref.depth == 0);
+
+		// rewrite the binding by looking into the bound_tables list of the subquery
+		colref.binding = bindings[colref.binding.column_index];
+		filter.bindings.insert(colref.binding.table_index);
+		return;
+	}
+	ExpressionIterator::EnumerateChildren(
+	    expr, [&](Expression &child) { ReplaceSetOpBindings(bindings, filter, child, setop); });
+}
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownSetOperation(unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op->type == LogicalOperatorType::LOGICAL_UNION || op->type == LogicalOperatorType::LOGICAL_EXCEPT ||
+	         op->type == LogicalOperatorType::LOGICAL_INTERSECT);
+	auto &setop = (LogicalSetOperation &)*op;
+
+	D_ASSERT(op->children.size() == 2);
+	auto left_bindings = op->children[0]->GetColumnBindings();
+	auto right_bindings = op->children[1]->GetColumnBindings();
+
+	// pushdown into set operation, we can duplicate the condition and pushdown the expressions into both sides
+	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
+	for (idx_t i = 0; i < filters.size(); i++) {
+		// first create a copy of the filter
+		auto right_filter = make_unique<Filter>();
+		right_filter->filter = filters[i]->filter->Copy();
+
+		// in the original filter, rewrite references to the result of the union into references to the left_index
+		ReplaceSetOpBindings(left_bindings, *filters[i], *filters[i]->filter, setop);
+		// in the copied filter, rewrite references to the result of the union into references to the right_index
+		ReplaceSetOpBindings(right_bindings, *right_filter, *right_filter->filter, setop);
+
+		// extract bindings again
+		filters[i]->ExtractBindings();
+		right_filter->ExtractBindings();
+
+		// move the filters into the child pushdown nodes
+		left_pushdown.filters.push_back(move(filters[i]));
+		right_pushdown.filters.push_back(move(right_filter));
+	}
+
+	op->children[0] = left_pushdown.Rewrite(move(op->children[0]));
+	op->children[1] = right_pushdown.Rewrite(move(op->children[1]));
+
+	bool left_empty = op->children[0]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT;
+	bool right_empty = op->children[1]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT;
+	if (left_empty && right_empty) {
+		// both empty: return empty result
+		return make_unique<LogicalEmptyResult>(move(op));
+	}
+	if (left_empty) {
+		// left child is empty result
+		switch (op->type) {
+		case LogicalOperatorType::LOGICAL_UNION:
+			if (op->children[1]->type == LogicalOperatorType::LOGICAL_PROJECTION) {
+				// union with empty left side: return right child
+				auto &projection = (LogicalProjection &)*op->children[1];
+				projection.table_index = setop.table_index;
+				return move(op->children[1]);
+			}
+			break;
+		case LogicalOperatorType::LOGICAL_EXCEPT:
+			// except: if left child is empty, return empty result
+		case LogicalOperatorType::LOGICAL_INTERSECT:
+			// intersect: if any child is empty, return empty result itself
+			return make_unique<LogicalEmptyResult>(move(op));
+		default:
+			throw InternalException("Unsupported set operation");
+		}
+	} else if (right_empty) {
+		// right child is empty result
+		switch (op->type) {
+		case LogicalOperatorType::LOGICAL_UNION:
+		case LogicalOperatorType::LOGICAL_EXCEPT:
+			if (op->children[0]->type == LogicalOperatorType::LOGICAL_PROJECTION) {
+				// union or except with empty right child: return left child
+				auto &projection = (LogicalProjection &)*op->children[0];
+				projection.table_index = setop.table_index;
+				return move(op->children[0]);
+			}
+			break;
+		case LogicalOperatorType::LOGICAL_INTERSECT:
+			// intersect: if any child is empty, return empty result itself
+			return make_unique<LogicalEmptyResult>(move(op));
+		default:
+			throw InternalException("Unsupported set operation");
+		}
+	}
+	return op;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+using Filter = FilterPushdown::Filter;
+
+unique_ptr<LogicalOperator> FilterPushdown::PushdownSingleJoin(unique_ptr<LogicalOperator> op,
+                                                               unordered_set<idx_t> &left_bindings,
+                                                               unordered_set<idx_t> &right_bindings) {
+	D_ASSERT(((LogicalJoin &)*op).join_type == JoinType::SINGLE);
+	FilterPushdown left_pushdown(optimizer), right_pushdown(optimizer);
+	// now check the set of filters
+	for (idx_t i = 0; i < filters.size(); i++) {
+		auto side = JoinSide::GetJoinSide(filters[i]->bindings, left_bindings, right_bindings);
+		if (side == JoinSide::LEFT) {
+			// bindings match left side: push into left
+			left_pushdown.filters.push_back(move(filters[i]));
+			// erase the filter from the list of filters
+			filters.erase(filters.begin() + i);
+			i--;
+		}
+	}
+	op->children[0] = left_pushdown.Rewrite(move(op->children[0]));
+	op->children[1] = right_pushdown.Rewrite(move(op->children[1]));
+	return FinishPushdown(move(op));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> RegexRangeFilter::Rewrite(unique_ptr<LogicalOperator> op) {
+
+	for (idx_t child_idx = 0; child_idx < op->children.size(); child_idx++) {
+		op->children[child_idx] = Rewrite(move(op->children[child_idx]));
+	}
+
+	if (op->type != LogicalOperatorType::LOGICAL_FILTER) {
+		return op;
+	}
+
+	auto new_filter = make_unique<LogicalFilter>();
+
+	for (auto &expr : op->expressions) {
+		if (expr->type == ExpressionType::BOUND_FUNCTION) {
+			auto &func = (BoundFunctionExpression &)*expr.get();
+			if (func.function.name != "regexp_full_match" || func.children.size() != 2) {
+				continue;
+			}
+			auto &info = (RegexpMatchesBindData &)*func.bind_info;
+			if (!info.range_success) {
+				continue;
+			}
+			auto filter_left = make_unique<BoundComparisonExpression>(
+			    ExpressionType::COMPARE_GREATERTHANOREQUALTO, func.children[0]->Copy(),
+			    make_unique<BoundConstantExpression>(
+			        Value::BLOB((const_data_ptr_t)info.range_min.c_str(), info.range_min.size())));
+			auto filter_right = make_unique<BoundComparisonExpression>(
+			    ExpressionType::COMPARE_LESSTHANOREQUALTO, func.children[0]->Copy(),
+			    make_unique<BoundConstantExpression>(
+			        Value::BLOB((const_data_ptr_t)info.range_max.c_str(), info.range_max.size())));
+			auto filter_expr = make_unique<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND,
+			                                                           move(filter_left), move(filter_right));
+
+			new_filter->expressions.push_back(move(filter_expr));
+		}
+	}
+
+	if (!new_filter->expressions.empty()) {
+		new_filter->children = move(op->children);
+		op->children.clear();
+		op->children.push_back(move(new_filter));
+	}
+
+	return op;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <map>
+
+namespace duckdb {
+
+void RemoveUnusedColumns::ReplaceBinding(ColumnBinding current_binding, ColumnBinding new_binding) {
+	auto colrefs = column_references.find(current_binding);
+	if (colrefs != column_references.end()) {
+		for (auto &colref : colrefs->second) {
+			D_ASSERT(colref->binding == current_binding);
+			colref->binding = new_binding;
+		}
+	}
+}
+
+template <class T>
+void RemoveUnusedColumns::ClearUnusedExpressions(vector<T> &list, idx_t table_idx) {
+	idx_t offset = 0;
+	for (idx_t col_idx = 0; col_idx < list.size(); col_idx++) {
+		auto current_binding = ColumnBinding(table_idx, col_idx + offset);
+		auto entry = column_references.find(current_binding);
+		if (entry == column_references.end()) {
+			// this entry is not referred to, erase it from the set of expressions
+			list.erase(list.begin() + col_idx);
+			offset++;
+			col_idx--;
+		} else if (offset > 0) {
+			// column is used but the ColumnBinding has changed because of removed columns
+			ReplaceBinding(current_binding, ColumnBinding(table_idx, col_idx));
+		}
+	}
+}
+
+void RemoveUnusedColumns::VisitOperator(LogicalOperator &op) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
+		// aggregate
+		if (!everything_referenced) {
+			// FIXME: groups that are not referenced need to stay -> but they don't need to be scanned and output!
+			auto &aggr = (LogicalAggregate &)op;
+			ClearUnusedExpressions(aggr.expressions, aggr.aggregate_index);
+			if (aggr.expressions.empty() && aggr.groups.empty()) {
+				// removed all expressions from the aggregate: push a COUNT(*)
+				auto count_star_fun = CountStarFun::GetFunction();
+				aggr.expressions.push_back(
+				    AggregateFunction::BindAggregateFunction(context, count_star_fun, {}, nullptr, false));
+			}
+		}
+
+		// then recurse into the children of the aggregate
+		RemoveUnusedColumns remove(binder, context);
+		remove.VisitOperatorExpressions(op);
+		remove.VisitOperator(*op.children[0]);
+		return;
+	}
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
+		if (!everything_referenced) {
+			auto &comp_join = (LogicalComparisonJoin &)op;
+
+			if (comp_join.join_type != JoinType::INNER) {
+				break;
+			}
+			// for inner joins with equality predicates in the form of (X=Y)
+			// we can replace any references to the RHS (Y) to references to the LHS (X)
+			// this reduces the amount of columns we need to extract from the join hash table
+			for (auto &cond : comp_join.conditions) {
+				if (cond.comparison == ExpressionType::COMPARE_EQUAL) {
+					if (cond.left->expression_class == ExpressionClass::BOUND_COLUMN_REF &&
+					    cond.right->expression_class == ExpressionClass::BOUND_COLUMN_REF) {
+						// comparison join between two bound column refs
+						// we can replace any reference to the RHS (build-side) with a reference to the LHS (probe-side)
+						auto &lhs_col = (BoundColumnRefExpression &)*cond.left;
+						auto &rhs_col = (BoundColumnRefExpression &)*cond.right;
+						// if there are any columns that refer to the RHS,
+						auto colrefs = column_references.find(rhs_col.binding);
+						if (colrefs != column_references.end()) {
+							for (auto &entry : colrefs->second) {
+								entry->binding = lhs_col.binding;
+								column_references[lhs_col.binding].push_back(entry);
+							}
+							column_references.erase(rhs_col.binding);
+						}
+					}
+				}
+			}
+		}
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+		break;
+	case LogicalOperatorType::LOGICAL_UNION:
+		if (!everything_referenced) {
+			// for UNION we can remove unreferenced columns as long as everything_referenced is false (i.e. we
+			// encounter a UNION node that is not preceded by a DISTINCT)
+			// this happens when UNION ALL is used
+			auto &setop = (LogicalSetOperation &)op;
+			vector<idx_t> entries;
+			for (idx_t i = 0; i < setop.column_count; i++) {
+				entries.push_back(i);
+			}
+			ClearUnusedExpressions(entries, setop.table_index);
+			if (entries.size() < setop.column_count) {
+				if (entries.empty()) {
+					// no columns referenced: this happens in the case of a COUNT(*)
+					// extract the first column
+					entries.push_back(0);
+				}
+				// columns were cleared
+				setop.column_count = entries.size();
+
+				for (idx_t child_idx = 0; child_idx < op.children.size(); child_idx++) {
+					RemoveUnusedColumns remove(binder, context, true);
+					auto &child = op.children[child_idx];
+
+					// we push a projection under this child that references the required columns of the union
+					child->ResolveOperatorTypes();
+					auto bindings = child->GetColumnBindings();
+					vector<unique_ptr<Expression>> expressions;
+					expressions.reserve(entries.size());
+					for (auto &column_idx : entries) {
+						expressions.push_back(
+						    make_unique<BoundColumnRefExpression>(child->types[column_idx], bindings[column_idx]));
+					}
+					auto new_projection =
+					    make_unique<LogicalProjection>(binder.GenerateTableIndex(), move(expressions));
+					new_projection->children.push_back(move(child));
+					op.children[child_idx] = move(new_projection);
+
+					remove.VisitOperator(*op.children[child_idx]);
+				}
+				return;
+			}
+		}
+		for (auto &child : op.children) {
+			RemoveUnusedColumns remove(binder, context, true);
+			remove.VisitOperator(*child);
+		}
+		return;
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+	case LogicalOperatorType::LOGICAL_INTERSECT:
+		// for INTERSECT/EXCEPT operations we can't remove anything, just recursively visit the children
+		for (auto &child : op.children) {
+			RemoveUnusedColumns remove(binder, context, true);
+			remove.VisitOperator(*child);
+		}
+		return;
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		if (!everything_referenced) {
+			auto &proj = (LogicalProjection &)op;
+			ClearUnusedExpressions(proj.expressions, proj.table_index);
+
+			if (proj.expressions.empty()) {
+				// nothing references the projected expressions
+				// this happens in the case of e.g. EXISTS(SELECT * FROM ...)
+				// in this case we only need to project a single constant
+				proj.expressions.push_back(make_unique<BoundConstantExpression>(Value::INTEGER(42)));
+			}
+		}
+		// then recurse into the children of this projection
+		RemoveUnusedColumns remove(binder, context);
+		remove.VisitOperatorExpressions(op);
+		remove.VisitOperator(*op.children[0]);
+		return;
+	}
+	case LogicalOperatorType::LOGICAL_INSERT:
+	case LogicalOperatorType::LOGICAL_UPDATE:
+	case LogicalOperatorType::LOGICAL_DELETE: {
+		//! When RETURNING is used, a PROJECTION is the top level operator for INSERTS, UPDATES, and DELETES
+		//! We still need to project all values from these operators so the projection
+		//! on top of them can select from only the table values being inserted.
+		//! TODO: Push down the projections from the returning statement
+		//! TODO: Be careful because you might be adding expressions when a user returns *
+		RemoveUnusedColumns remove(binder, context, true);
+		remove.VisitOperatorExpressions(op);
+		remove.VisitOperator(*op.children[0]);
+		return;
+	}
+	case LogicalOperatorType::LOGICAL_GET:
+		LogicalOperatorVisitor::VisitOperatorExpressions(op);
+		if (!everything_referenced) {
+			auto &get = (LogicalGet &)op;
+			// for every table filter, push a column binding into the column references map to prevent the column from
+			// being projected out
+			for (auto &filter : get.table_filters.filters) {
+				idx_t index = DConstants::INVALID_INDEX;
+				for (idx_t i = 0; i < get.column_ids.size(); i++) {
+					if (get.column_ids[i] == filter.first) {
+						index = i;
+						break;
+					}
+				}
+				if (index == DConstants::INVALID_INDEX) {
+					throw InternalException("Could not find column index for table filter");
+				}
+				ColumnBinding filter_binding(get.table_index, index);
+				if (column_references.find(filter_binding) == column_references.end()) {
+					column_references.insert(make_pair(filter_binding, vector<BoundColumnRefExpression *>()));
+				}
+			}
+			// table scan: figure out which columns are referenced
+			ClearUnusedExpressions(get.column_ids, get.table_index);
+
+			if (get.column_ids.empty()) {
+				// this generally means we are only interested in whether or not anything exists in the table (e.g.
+				// EXISTS(SELECT * FROM tbl)) in this case, we just scan the row identifier column as it means we do not
+				// need to read any of the columns
+				get.column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+			}
+		}
+		return;
+	case LogicalOperatorType::LOGICAL_DISTINCT: {
+		// distinct, all projected columns are used for the DISTINCT computation
+		// mark all columns as used and continue to the children
+		// FIXME: DISTINCT with expression list does not implicitly reference everything
+		everything_referenced = true;
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE: {
+		everything_referenced = true;
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_CTE_REF: {
+		everything_referenced = true;
+		break;
+	}
+	default:
+		break;
+	}
+	LogicalOperatorVisitor::VisitOperatorExpressions(op);
+	LogicalOperatorVisitor::VisitOperatorChildren(op);
+}
+
+unique_ptr<Expression> RemoveUnusedColumns::VisitReplace(BoundColumnRefExpression &expr,
+                                                         unique_ptr<Expression> *expr_ptr) {
+	// add a column reference
+	column_references[expr.binding].push_back(&expr);
+	return nullptr;
+}
+
+unique_ptr<Expression> RemoveUnusedColumns::VisitReplace(BoundReferenceExpression &expr,
+                                                         unique_ptr<Expression> *expr_ptr) {
+	// BoundReferenceExpression should not be used here yet, they only belong in the physical plan
+	throw InternalException("BoundReferenceExpression should not be used here yet!");
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+ArithmeticSimplificationRule::ArithmeticSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match on an OperatorExpression that has a ConstantExpression as child
+	auto op = make_unique<FunctionExpressionMatcher>();
+	op->matchers.push_back(make_unique<ConstantExpressionMatcher>());
+	op->matchers.push_back(make_unique<ExpressionMatcher>());
+	op->policy = SetMatcher::Policy::SOME;
+	// we only match on simple arithmetic expressions (+, -, *, /)
+	op->function = make_unique<ManyFunctionMatcher>(unordered_set<string> {"+", "-", "*", "/"});
+	// and only with numeric results
+	op->type = make_unique<IntegerTypeMatcher>();
+	op->matchers[0]->type = make_unique<IntegerTypeMatcher>();
+	op->matchers[1]->type = make_unique<IntegerTypeMatcher>();
+	root = move(op);
+}
+
+unique_ptr<Expression> ArithmeticSimplificationRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                           bool &changes_made, bool is_root) {
+	auto root = (BoundFunctionExpression *)bindings[0];
+	auto constant = (BoundConstantExpression *)bindings[1];
+	int constant_child = root->children[0].get() == constant ? 0 : 1;
+	D_ASSERT(root->children.size() == 2);
+	(void)root;
+	// any arithmetic operator involving NULL is always NULL
+	if (constant->value.IsNull()) {
+		return make_unique<BoundConstantExpression>(Value(root->return_type));
+	}
+	auto &func_name = root->function.name;
+	if (func_name == "+") {
+		if (constant->value == 0) {
+			// addition with 0
+			// we can remove the entire operator and replace it with the non-constant child
+			return move(root->children[1 - constant_child]);
+		}
+	} else if (func_name == "-") {
+		if (constant_child == 1 && constant->value == 0) {
+			// subtraction by 0
+			// we can remove the entire operator and replace it with the non-constant child
+			return move(root->children[1 - constant_child]);
+		}
+	} else if (func_name == "*") {
+		if (constant->value == 1) {
+			// multiply with 1, replace with non-constant child
+			return move(root->children[1 - constant_child]);
+		} else if (constant->value == 0) {
+			// multiply by zero: replace with constant or null
+			return ExpressionRewriter::ConstantOrNull(move(root->children[1 - constant_child]),
+			                                          Value::Numeric(root->return_type, 0));
+		}
+	} else {
+		D_ASSERT(func_name == "/");
+		if (constant_child == 1) {
+			if (constant->value == 1) {
+				// divide by 1, replace with non-constant child
+				return move(root->children[1 - constant_child]);
+			} else if (constant->value == 0) {
+				// divide by 0, replace with NULL
+				return make_unique<BoundConstantExpression>(Value(root->return_type));
+			}
+		}
+	}
+	return nullptr;
+}
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+CaseSimplificationRule::CaseSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match on a CaseExpression that has a ConstantExpression as a check
+	auto op = make_unique<CaseExpressionMatcher>();
+	root = move(op);
+}
+
+unique_ptr<Expression> CaseSimplificationRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                     bool &changes_made, bool is_root) {
+	auto root = (BoundCaseExpression *)bindings[0];
+	for (idx_t i = 0; i < root->case_checks.size(); i++) {
+		auto &case_check = root->case_checks[i];
+		if (case_check.when_expr->IsFoldable()) {
+			// the WHEN check is a foldable expression
+			// use an ExpressionExecutor to execute the expression
+			auto constant_value = ExpressionExecutor::EvaluateScalar(*case_check.when_expr);
+
+			// fold based on the constant condition
+			auto condition = constant_value.CastAs(LogicalType::BOOLEAN);
+			if (condition.IsNull() || !BooleanValue::Get(condition)) {
+				// the condition is always false: remove this case check
+				root->case_checks.erase(root->case_checks.begin() + i);
+				i--;
+			} else {
+				// the condition is always true
+				// move the THEN clause to the ELSE of the case
+				root->else_expr = move(case_check.then_expr);
+				// remove this case check and any case checks after this one
+				root->case_checks.erase(root->case_checks.begin() + i, root->case_checks.end());
+				break;
+			}
+		}
+	}
+	if (root->case_checks.empty()) {
+		// no case checks left: return the ELSE expression
+		return move(root->else_expr);
+	}
+	return nullptr;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+ComparisonSimplificationRule::ComparisonSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match on a ComparisonExpression that has a ConstantExpression as a check
+	auto op = make_unique<ComparisonExpressionMatcher>();
+	op->matchers.push_back(make_unique<FoldableConstantMatcher>());
+	op->policy = SetMatcher::Policy::SOME;
+	root = move(op);
+}
+
+unique_ptr<Expression> ComparisonSimplificationRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                           bool &changes_made, bool is_root) {
+	D_ASSERT(bindings[0]->expression_class == ExpressionClass::BOUND_COMPARISON);
+	auto expr = (BoundComparisonExpression *)bindings[0];
+	auto constant_expr = bindings[1];
+	bool column_ref_left = expr->left.get() != constant_expr;
+	auto column_ref_expr = !column_ref_left ? expr->right.get() : expr->left.get();
+	// the constant_expr is a scalar expression that we have to fold
+	// use an ExpressionExecutor to execute the expression
+	D_ASSERT(constant_expr->IsFoldable());
+	Value constant_value;
+	if (!ExpressionExecutor::TryEvaluateScalar(*constant_expr, constant_value)) {
+		return nullptr;
+	}
+	if (constant_value.IsNull() && !(expr->type == ExpressionType::COMPARE_NOT_DISTINCT_FROM ||
+	                                 expr->type == ExpressionType::COMPARE_DISTINCT_FROM)) {
+		// comparison with constant NULL, return NULL
+		return make_unique<BoundConstantExpression>(Value(LogicalType::BOOLEAN));
+	}
+	if (column_ref_expr->expression_class == ExpressionClass::BOUND_CAST) {
+		//! Here we check if we can apply the expression on the constant side
+		auto cast_expression = (BoundCastExpression *)column_ref_expr;
+		auto target_type = cast_expression->source_type();
+		if (!BoundCastExpression::CastIsInvertible(target_type, cast_expression->return_type)) {
+			return nullptr;
+		}
+		auto new_constant = constant_value.TryCastAs(target_type);
+		if (new_constant) {
+			auto child_expression = move(cast_expression->child);
+			auto new_constant_expr = make_unique<BoundConstantExpression>(constant_value);
+			//! We can cast, now we change our column_ref_expression from an operator cast to a column reference
+			if (column_ref_left) {
+				expr->left = move(child_expression);
+				expr->right = move(new_constant_expr);
+			} else {
+				expr->left = move(new_constant_expr);
+				expr->right = move(child_expression);
+			}
+		}
+	}
+	return nullptr;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+ConjunctionSimplificationRule::ConjunctionSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match on a ComparisonExpression that has a ConstantExpression as a check
+	auto op = make_unique<ConjunctionExpressionMatcher>();
+	op->matchers.push_back(make_unique<FoldableConstantMatcher>());
+	op->policy = SetMatcher::Policy::SOME;
+	root = move(op);
+}
+
+unique_ptr<Expression> ConjunctionSimplificationRule::RemoveExpression(BoundConjunctionExpression &conj,
+                                                                       Expression *expr) {
+	for (idx_t i = 0; i < conj.children.size(); i++) {
+		if (conj.children[i].get() == expr) {
+			// erase the expression
+			conj.children.erase(conj.children.begin() + i);
+			break;
+		}
+	}
+	if (conj.children.size() == 1) {
+		// one expression remaining: simply return that expression and erase the conjunction
+		return move(conj.children[0]);
+	}
+	return nullptr;
+}
+
+unique_ptr<Expression> ConjunctionSimplificationRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                            bool &changes_made, bool is_root) {
+	auto conjunction = (BoundConjunctionExpression *)bindings[0];
+	auto constant_expr = bindings[1];
+	// the constant_expr is a scalar expression that we have to fold
+	// use an ExpressionExecutor to execute the expression
+	D_ASSERT(constant_expr->IsFoldable());
+	Value constant_value;
+	if (!ExpressionExecutor::TryEvaluateScalar(*constant_expr, constant_value)) {
+		return nullptr;
+	}
+	constant_value = constant_value.CastAs(LogicalType::BOOLEAN);
+	if (constant_value.IsNull()) {
+		// we can't simplify conjunctions with a constant NULL
+		return nullptr;
+	}
+	if (conjunction->type == ExpressionType::CONJUNCTION_AND) {
+		if (!BooleanValue::Get(constant_value)) {
+			// FALSE in AND, result of expression is false
+			return make_unique<BoundConstantExpression>(Value::BOOLEAN(false));
+		} else {
+			// TRUE in AND, remove the expression from the set
+			return RemoveExpression(*conjunction, constant_expr);
+		}
+	} else {
+		D_ASSERT(conjunction->type == ExpressionType::CONJUNCTION_OR);
+		if (!BooleanValue::Get(constant_value)) {
+			// FALSE in OR, remove the expression from the set
+			return RemoveExpression(*conjunction, constant_expr);
+		} else {
+			// TRUE in OR, result of expression is true
+			return make_unique<BoundConstantExpression>(Value::BOOLEAN(true));
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+//! The ConstantFoldingExpressionMatcher matches on any scalar expression (i.e. Expression::IsFoldable is true)
+class ConstantFoldingExpressionMatcher : public FoldableConstantMatcher {
+public:
+	bool Match(Expression *expr, vector<Expression *> &bindings) override {
+		// we also do not match on ConstantExpressions, because we cannot fold those any further
+		if (expr->type == ExpressionType::VALUE_CONSTANT) {
+			return false;
+		}
+		return FoldableConstantMatcher::Match(expr, bindings);
+	}
+};
+
+ConstantFoldingRule::ConstantFoldingRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	auto op = make_unique<ConstantFoldingExpressionMatcher>();
+	root = move(op);
+}
+
+unique_ptr<Expression> ConstantFoldingRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                  bool &changes_made, bool is_root) {
+	auto root = bindings[0];
+	// the root is a scalar expression that we have to fold
+	D_ASSERT(root->IsFoldable() && root->type != ExpressionType::VALUE_CONSTANT);
+
+	// use an ExpressionExecutor to execute the expression
+	Value result_value;
+	if (!ExpressionExecutor::TryEvaluateScalar(*root, result_value)) {
+		return nullptr;
+	}
+	D_ASSERT(result_value.type().InternalType() == root->return_type.InternalType());
+	// now get the value from the result vector and insert it back into the plan as a constant expression
+	return make_unique<BoundConstantExpression>(result_value);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+DatePartSimplificationRule::DatePartSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	auto func = make_unique<FunctionExpressionMatcher>();
+	func->function = make_unique<SpecificFunctionMatcher>("date_part");
+	func->matchers.push_back(make_unique<ConstantExpressionMatcher>());
+	func->matchers.push_back(make_unique<ExpressionMatcher>());
+	func->policy = SetMatcher::Policy::ORDERED;
+	root = move(func);
+}
+
+unique_ptr<Expression> DatePartSimplificationRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                         bool &changes_made, bool is_root) {
+	auto &date_part = (BoundFunctionExpression &)*bindings[0];
+	auto &constant_expr = (BoundConstantExpression &)*bindings[1];
+	auto &constant = constant_expr.value;
+
+	if (constant.IsNull()) {
+		// NULL specifier: return constant NULL
+		return make_unique<BoundConstantExpression>(Value(date_part.return_type));
+	}
+	// otherwise check the specifier
+	auto specifier = GetDatePartSpecifier(StringValue::Get(constant));
+	string new_function_name;
+	switch (specifier) {
+	case DatePartSpecifier::YEAR:
+		new_function_name = "year";
+		break;
+	case DatePartSpecifier::MONTH:
+		new_function_name = "month";
+		break;
+	case DatePartSpecifier::DAY:
+		new_function_name = "day";
+		break;
+	case DatePartSpecifier::DECADE:
+		new_function_name = "decade";
+		break;
+	case DatePartSpecifier::CENTURY:
+		new_function_name = "century";
+		break;
+	case DatePartSpecifier::MILLENNIUM:
+		new_function_name = "millennium";
+		break;
+	case DatePartSpecifier::QUARTER:
+		new_function_name = "quarter";
+		break;
+	case DatePartSpecifier::WEEK:
+		new_function_name = "week";
+		break;
+	case DatePartSpecifier::YEARWEEK:
+		new_function_name = "yearweek";
+		break;
+	case DatePartSpecifier::DOW:
+		new_function_name = "dayofweek";
+		break;
+	case DatePartSpecifier::ISODOW:
+		new_function_name = "isodow";
+		break;
+	case DatePartSpecifier::DOY:
+		new_function_name = "dayofyear";
+		break;
+	case DatePartSpecifier::EPOCH:
+		new_function_name = "epoch";
+		break;
+	case DatePartSpecifier::MICROSECONDS:
+		new_function_name = "microsecond";
+		break;
+	case DatePartSpecifier::MILLISECONDS:
+		new_function_name = "millisecond";
+		break;
+	case DatePartSpecifier::SECOND:
+		new_function_name = "second";
+		break;
+	case DatePartSpecifier::MINUTE:
+		new_function_name = "minute";
+		break;
+	case DatePartSpecifier::HOUR:
+		new_function_name = "hour";
+		break;
+	default:
+		return nullptr;
+	}
+	// found a replacement function: bind it
+	vector<unique_ptr<Expression>> children;
+	children.push_back(move(date_part.children[1]));
+
+	string error;
+	auto function = ScalarFunction::BindScalarFunction(rewriter.context, DEFAULT_SCHEMA, new_function_name,
+	                                                   move(children), error, false);
+	if (!function) {
+		throw BinderException(error);
+	}
+	return move(function);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+DistributivityRule::DistributivityRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// we match on an OR expression within a LogicalFilter node
+	root = make_unique<ExpressionMatcher>();
+	root->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::CONJUNCTION_OR);
+}
+
+void DistributivityRule::AddExpressionSet(Expression &expr, expression_set_t &set) {
+	if (expr.type == ExpressionType::CONJUNCTION_AND) {
+		auto &and_expr = (BoundConjunctionExpression &)expr;
+		for (auto &child : and_expr.children) {
+			set.insert(child.get());
+		}
+	} else {
+		set.insert(&expr);
+	}
+}
+
+unique_ptr<Expression> DistributivityRule::ExtractExpression(BoundConjunctionExpression &conj, idx_t idx,
+                                                             Expression &expr) {
+	auto &child = conj.children[idx];
+	unique_ptr<Expression> result;
+	if (child->type == ExpressionType::CONJUNCTION_AND) {
+		// AND, remove expression from the list
+		auto &and_expr = (BoundConjunctionExpression &)*child;
+		for (idx_t i = 0; i < and_expr.children.size(); i++) {
+			if (Expression::Equals(and_expr.children[i].get(), &expr)) {
+				result = move(and_expr.children[i]);
+				and_expr.children.erase(and_expr.children.begin() + i);
+				break;
+			}
+		}
+		if (and_expr.children.size() == 1) {
+			conj.children[idx] = move(and_expr.children[0]);
+		}
+	} else {
+		// not an AND node! remove the entire expression
+		// this happens in the case of e.g. (X AND B) OR X
+		D_ASSERT(Expression::Equals(child.get(), &expr));
+		result = move(child);
+		conj.children[idx] = nullptr;
+	}
+	D_ASSERT(result);
+	return result;
+}
+
+unique_ptr<Expression> DistributivityRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                 bool &changes_made, bool is_root) {
+	auto initial_or = (BoundConjunctionExpression *)bindings[0];
+
+	// we want to find expressions that occur in each of the children of the OR
+	// i.e. (X AND A) OR (X AND B) => X occurs in all branches
+	// first, for the initial child, we create an expression set of which expressions occur
+	// this is our initial candidate set (in the example: [X, A])
+	expression_set_t candidate_set;
+	AddExpressionSet(*initial_or->children[0], candidate_set);
+	// now for each of the remaining children, we create a set again and intersect them
+	// in our example: the second set would be [X, B]
+	// the intersection would leave [X]
+	for (idx_t i = 1; i < initial_or->children.size(); i++) {
+		expression_set_t next_set;
+		AddExpressionSet(*initial_or->children[i], next_set);
+		expression_set_t intersect_result;
+		for (auto &expr : candidate_set) {
+			if (next_set.find(expr) != next_set.end()) {
+				intersect_result.insert(expr);
+			}
+		}
+		candidate_set = intersect_result;
+	}
+	if (candidate_set.empty()) {
+		// nothing found: abort
+		return nullptr;
+	}
+	// now for each of the remaining expressions in the candidate set we know that it is contained in all branches of
+	// the OR
+	auto new_root = make_unique<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+	for (auto &expr : candidate_set) {
+		D_ASSERT(initial_or->children.size() > 0);
+
+		// extract the expression from the first child of the OR
+		auto result = ExtractExpression(*initial_or, 0, (Expression &)*expr);
+		// now for the subsequent expressions, simply remove the expression
+		for (idx_t i = 1; i < initial_or->children.size(); i++) {
+			ExtractExpression(*initial_or, i, *result);
+		}
+		// now we add the expression to the new root
+		new_root->children.push_back(move(result));
+	}
+
+	// check if we completely erased one of the children of the OR
+	// this happens if we have an OR in the form of "X OR (X AND A)"
+	// the left child will be completely empty, as it only contains common expressions
+	// in this case, any other children are not useful:
+	// X OR (X AND A) is the same as "X"
+	// since (1) only tuples that do not qualify "X" will not pass this predicate
+	//   and (2) all tuples that qualify "X" will pass this predicate
+	for (idx_t i = 0; i < initial_or->children.size(); i++) {
+		if (!initial_or->children[i]) {
+			if (new_root->children.size() <= 1) {
+				return move(new_root->children[0]);
+			} else {
+				return move(new_root);
+			}
+		}
+	}
+	// finally we need to add the remaining expressions in the OR to the new root
+	if (initial_or->children.size() == 1) {
+		// one child: skip the OR entirely and only add the single child
+		new_root->children.push_back(move(initial_or->children[0]));
+	} else if (initial_or->children.size() > 1) {
+		// multiple children still remain: push them into a new OR and add that to the new root
+		auto new_or = make_unique<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_OR);
+		for (auto &child : initial_or->children) {
+			new_or->children.push_back(move(child));
+		}
+		new_root->children.push_back(move(new_or));
+	}
+	// finally return the new root
+	if (new_root->children.size() == 1) {
+		return move(new_root->children[0]);
+	}
+	return move(new_root);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+EmptyNeedleRemovalRule::EmptyNeedleRemovalRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match on a FunctionExpression that has a foldable ConstantExpression
+	auto func = make_unique<FunctionExpressionMatcher>();
+	func->matchers.push_back(make_unique<ExpressionMatcher>());
+	func->matchers.push_back(make_unique<ExpressionMatcher>());
+	func->policy = SetMatcher::Policy::SOME;
+
+	unordered_set<string> functions = {"prefix", "contains", "suffix"};
+	func->function = make_unique<ManyFunctionMatcher>(functions);
+	root = move(func);
+}
+
+unique_ptr<Expression> EmptyNeedleRemovalRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                     bool &changes_made, bool is_root) {
+	auto root = (BoundFunctionExpression *)bindings[0];
+	D_ASSERT(root->children.size() == 2);
+	(void)root;
+	auto prefix_expr = bindings[2];
+
+	// the constant_expr is a scalar expression that we have to fold
+	if (!prefix_expr->IsFoldable()) {
+		return nullptr;
+	}
+	D_ASSERT(root->return_type.id() == LogicalTypeId::BOOLEAN);
+
+	auto prefix_value = ExpressionExecutor::EvaluateScalar(*prefix_expr);
+
+	if (prefix_value.IsNull()) {
+		return make_unique<BoundConstantExpression>(Value(LogicalType::BOOLEAN));
+	}
+
+	D_ASSERT(prefix_value.type() == prefix_expr->return_type);
+	auto &needle_string = StringValue::Get(prefix_value);
+
+	// PREFIX('xyz', '') is TRUE
+	// PREFIX(NULL, '') is NULL
+	// so rewrite PREFIX(x, '') to TRUE_OR_NULL(x)
+	if (needle_string.empty()) {
+		return ExpressionRewriter::ConstantOrNull(move(root->children[0]), Value::BOOLEAN(true));
+	}
+	return nullptr;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+EnumComparisonRule::EnumComparisonRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match on a ComparisonExpression that is an Equality and has a VARCHAR and ENUM as its children
+	auto op = make_unique<ComparisonExpressionMatcher>();
+	// Enum requires expression to be root
+	op->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::COMPARE_EQUAL);
+	for (idx_t i = 0; i < 2; i++) {
+		auto child = make_unique<CastExpressionMatcher>();
+		child->type = make_unique<TypeMatcherId>(LogicalTypeId::VARCHAR);
+		child->matcher = make_unique<ExpressionMatcher>();
+		child->matcher->type = make_unique<TypeMatcherId>(LogicalTypeId::ENUM);
+		op->matchers.push_back(move(child));
+	}
+	root = move(op);
+}
+
+bool AreMatchesPossible(LogicalType &left, LogicalType &right) {
+	LogicalType *small_enum, *big_enum;
+	if (EnumType::GetSize(left) < EnumType::GetSize(right)) {
+		small_enum = &left;
+		big_enum = &right;
+	} else {
+		small_enum = &right;
+		big_enum = &left;
+	}
+	auto &string_vec = EnumType::GetValuesInsertOrder(*small_enum);
+	auto string_vec_ptr = FlatVector::GetData<string_t>(string_vec);
+	auto size = EnumType::GetSize(*small_enum);
+	for (idx_t i = 0; i < size; i++) {
+		auto key = string_vec_ptr[i].GetString();
+		if (EnumType::GetPos(*big_enum, key) != -1) {
+			return true;
+		}
+	}
+	return false;
+}
+unique_ptr<Expression> EnumComparisonRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                 bool &changes_made, bool is_root) {
+
+	auto root = (BoundComparisonExpression *)bindings[0];
+	auto left_child = (BoundCastExpression *)bindings[1];
+	auto right_child = (BoundCastExpression *)bindings[3];
+
+	if (!AreMatchesPossible(left_child->child->return_type, right_child->child->return_type)) {
+		vector<unique_ptr<Expression>> children;
+		children.push_back(move(root->left));
+		children.push_back(move(root->right));
+		return ExpressionRewriter::ConstantOrNull(move(children), Value::BOOLEAN(false));
+	}
+
+	if (!is_root || op.type != LogicalOperatorType::LOGICAL_FILTER) {
+		return nullptr;
+	}
+
+	auto cast_left_to_right =
+	    make_unique<BoundCastExpression>(move(left_child->child), right_child->child->return_type, true);
+
+	return make_unique<BoundComparisonExpression>(root->type, move(cast_left_to_right), move(right_child->child));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+EqualOrNullSimplification::EqualOrNullSimplification(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match on OR conjunction
+	auto op = make_unique<ConjunctionExpressionMatcher>();
+	op->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::CONJUNCTION_OR);
+	op->policy = SetMatcher::Policy::SOME;
+
+	// equi comparison on one side
+	auto equal_child = make_unique<ComparisonExpressionMatcher>();
+	equal_child->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::COMPARE_EQUAL);
+	equal_child->policy = SetMatcher::Policy::SOME;
+	op->matchers.push_back(move(equal_child));
+
+	// AND conjuction on the other
+	auto and_child = make_unique<ConjunctionExpressionMatcher>();
+	and_child->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::CONJUNCTION_AND);
+	and_child->policy = SetMatcher::Policy::SOME;
+
+	// IS NULL tests inside AND
+	auto isnull_child = make_unique<ExpressionMatcher>();
+	isnull_child->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::OPERATOR_IS_NULL);
+	// I could try to use std::make_unique for a copy, but it's available from C++14 only
+	auto isnull_child2 = make_unique<ExpressionMatcher>();
+	isnull_child2->expr_type = make_unique<SpecificExpressionTypeMatcher>(ExpressionType::OPERATOR_IS_NULL);
+	and_child->matchers.push_back(move(isnull_child));
+	and_child->matchers.push_back(move(isnull_child2));
+
+	op->matchers.push_back(move(and_child));
+	root = move(op);
+}
+
+// a=b OR (a IS NULL AND b IS NULL) to a IS NOT DISTINCT FROM b
+static unique_ptr<Expression> TryRewriteEqualOrIsNull(const Expression *equal_expr, const Expression *and_expr) {
+	if (equal_expr->type != ExpressionType::COMPARE_EQUAL || and_expr->type != ExpressionType::CONJUNCTION_AND) {
+		return nullptr;
+	}
+
+	const auto equal_cast = (BoundComparisonExpression *)equal_expr;
+	const auto and_cast = (BoundConjunctionExpression *)and_expr;
+
+	if (and_cast->children.size() != 2) {
+		return nullptr;
+	}
+
+	// Make sure on the AND conjuction the relevant conditions appear
+	const auto a_exp = equal_cast->left.get();
+	const auto b_exp = equal_cast->right.get();
+	bool valid = true;
+	bool a_is_null_found = false;
+	bool b_is_null_found = false;
+
+	for (const auto &item : and_cast->children) {
+		const auto next_exp = item.get();
+
+		if (next_exp->type == ExpressionType::OPERATOR_IS_NULL) {
+			const auto next_exp_cast = (BoundOperatorExpression *)next_exp;
+			const auto child = next_exp_cast->children[0].get();
+
+			// Test for equality on both 'a' and 'b' expressions
+			if (Expression::Equals(child, a_exp)) {
+				a_is_null_found = true;
+			} else if (Expression::Equals(child, b_exp)) {
+				b_is_null_found = true;
+			} else {
+				valid = false;
+				break;
+			}
+		} else {
+			valid = false;
+			break;
+		}
+	}
+	if (valid && a_is_null_found && b_is_null_found) {
+		return make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_NOT_DISTINCT_FROM, move(equal_cast->left),
+		                                              move(equal_cast->right));
+	}
+	return nullptr;
+}
+
+unique_ptr<Expression> EqualOrNullSimplification::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                        bool &changes_made, bool is_root) {
+	const Expression *or_exp = bindings[0];
+
+	if (or_exp->type != ExpressionType::CONJUNCTION_OR) {
+		return nullptr;
+	}
+
+	const auto or_exp_cast = (BoundConjunctionExpression *)or_exp;
+
+	if (or_exp_cast->children.size() != 2) {
+		return nullptr;
+	}
+
+	const auto left_exp = or_exp_cast->children[0].get();
+	const auto right_exp = or_exp_cast->children[1].get();
+	// Test for: a=b OR (a IS NULL AND b IS NULL)
+	auto first_try = TryRewriteEqualOrIsNull(left_exp, right_exp);
+	if (first_try) {
+		return first_try;
+	}
+	// Test for: (a IS NULL AND b IS NULL) OR a=b
+	return TryRewriteEqualOrIsNull(right_exp, left_exp);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+InClauseSimplificationRule::InClauseSimplificationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match on InClauseExpression that has a ConstantExpression as a check
+	auto op = make_unique<InClauseExpressionMatcher>();
+	op->policy = SetMatcher::Policy::SOME;
+	root = move(op);
+}
+
+unique_ptr<Expression> InClauseSimplificationRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                         bool &changes_made, bool is_root) {
+	D_ASSERT(bindings[0]->expression_class == ExpressionClass::BOUND_OPERATOR);
+	auto expr = (BoundOperatorExpression *)bindings[0];
+	if (expr->children[0]->expression_class != ExpressionClass::BOUND_CAST) {
+		return nullptr;
+	}
+	auto cast_expression = (BoundCastExpression *)expr->children[0].get();
+	if (cast_expression->child->expression_class != ExpressionClass::BOUND_COLUMN_REF) {
+		return nullptr;
+	}
+	//! Here we check if we can apply the expression on the constant side
+	auto target_type = cast_expression->source_type();
+	if (!BoundCastExpression::CastIsInvertible(cast_expression->return_type, target_type)) {
+		return nullptr;
+	}
+	vector<unique_ptr<BoundConstantExpression>> cast_list;
+	//! First check if we can cast all children
+	for (size_t i = 1; i < expr->children.size(); i++) {
+		if (expr->children[i]->expression_class != ExpressionClass::BOUND_CONSTANT) {
+			return nullptr;
+		}
+		D_ASSERT(expr->children[i]->IsFoldable());
+		auto constant_value = ExpressionExecutor::EvaluateScalar(*expr->children[i]);
+		auto new_constant = constant_value.TryCastAs(target_type);
+		if (!new_constant) {
+			return nullptr;
+		} else {
+			auto new_constant_expr = make_unique<BoundConstantExpression>(constant_value);
+			cast_list.push_back(move(new_constant_expr));
+		}
+	}
+	//! We can cast, so we move the new constant
+	for (size_t i = 1; i < expr->children.size(); i++) {
+		expr->children[i] = move(cast_list[i - 1]);
+
+		//		expr->children[i] = move(new_constant_expr);
+	}
+	//! We can cast the full list, so we move the column
+	expr->children[0] = move(cast_expression->child);
+	return nullptr;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+LikeOptimizationRule::LikeOptimizationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	// match on a FunctionExpression that has a foldable ConstantExpression
+	auto func = make_unique<FunctionExpressionMatcher>();
+	func->matchers.push_back(make_unique<ExpressionMatcher>());
+	func->matchers.push_back(make_unique<ConstantExpressionMatcher>());
+	func->policy = SetMatcher::Policy::ORDERED;
+	// we match on LIKE ("~~") and NOT LIKE ("!~~")
+	func->function = make_unique<ManyFunctionMatcher>(unordered_set<string> {"!~~", "~~"});
+	root = move(func);
+}
+
+static bool PatternIsConstant(const string &pattern) {
+	for (idx_t i = 0; i < pattern.size(); i++) {
+		if (pattern[i] == '%' || pattern[i] == '_') {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool PatternIsPrefix(const string &pattern) {
+	idx_t i;
+	for (i = pattern.size(); i > 0; i--) {
+		if (pattern[i - 1] != '%') {
+			break;
+		}
+	}
+	if (i == pattern.size()) {
+		// no trailing %
+		// cannot be a prefix
+		return false;
+	}
+	// continue to look in the string
+	// if there is a % or _ in the string (besides at the very end) this is not a prefix match
+	for (; i > 0; i--) {
+		if (pattern[i - 1] == '%' || pattern[i - 1] == '_') {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool PatternIsSuffix(const string &pattern) {
+	idx_t i;
+	for (i = 0; i < pattern.size(); i++) {
+		if (pattern[i] != '%') {
+			break;
+		}
+	}
+	if (i == 0) {
+		// no leading %
+		// cannot be a suffix
+		return false;
+	}
+	// continue to look in the string
+	// if there is a % or _ in the string (besides at the beginning) this is not a suffix match
+	for (; i < pattern.size(); i++) {
+		if (pattern[i] == '%' || pattern[i] == '_') {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool PatternIsContains(const string &pattern) {
+	idx_t start;
+	idx_t end;
+	for (start = 0; start < pattern.size(); start++) {
+		if (pattern[start] != '%') {
+			break;
+		}
+	}
+	for (end = pattern.size(); end > 0; end--) {
+		if (pattern[end - 1] != '%') {
+			break;
+		}
+	}
+	if (start == 0 || end == pattern.size()) {
+		// contains requires both a leading AND a trailing %
+		return false;
+	}
+	// check if there are any other special characters in the string
+	// if there is a % or _ in the string (besides at the beginning/end) this is not a contains match
+	for (idx_t i = start; i < end; i++) {
+		if (pattern[i] == '%' || pattern[i] == '_') {
+			return false;
+		}
+	}
+	return true;
+}
+
+unique_ptr<Expression> LikeOptimizationRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                   bool &changes_made, bool is_root) {
+	auto root = (BoundFunctionExpression *)bindings[0];
+	auto constant_expr = (BoundConstantExpression *)bindings[2];
+	D_ASSERT(root->children.size() == 2);
+
+	if (constant_expr->value.IsNull()) {
+		return make_unique<BoundConstantExpression>(Value(root->return_type));
+	}
+
+	// the constant_expr is a scalar expression that we have to fold
+	if (!constant_expr->IsFoldable()) {
+		return nullptr;
+	}
+
+	auto constant_value = ExpressionExecutor::EvaluateScalar(*constant_expr);
+	D_ASSERT(constant_value.type() == constant_expr->return_type);
+	auto &patt_str = StringValue::Get(constant_value);
+
+	bool is_not_like = root->function.name == "!~~";
+	if (PatternIsConstant(patt_str)) {
+		// Pattern is constant
+		return make_unique<BoundComparisonExpression>(is_not_like ? ExpressionType::COMPARE_NOTEQUAL
+		                                                          : ExpressionType::COMPARE_EQUAL,
+		                                              move(root->children[0]), move(root->children[1]));
+	} else if (PatternIsPrefix(patt_str)) {
+		// Prefix LIKE pattern : [^%_]*[%]+, ignoring underscore
+		return ApplyRule(root, PrefixFun::GetFunction(), patt_str, is_not_like);
+	} else if (PatternIsSuffix(patt_str)) {
+		// Suffix LIKE pattern: [%]+[^%_]*, ignoring underscore
+		return ApplyRule(root, SuffixFun::GetFunction(), patt_str, is_not_like);
+	} else if (PatternIsContains(patt_str)) {
+		// Contains LIKE pattern: [%]+[^%_]*[%]+, ignoring underscore
+		return ApplyRule(root, ContainsFun::GetFunction(), patt_str, is_not_like);
+	}
+	return nullptr;
+}
+
+unique_ptr<Expression> LikeOptimizationRule::ApplyRule(BoundFunctionExpression *expr, ScalarFunction function,
+                                                       string pattern, bool is_not_like) {
+	// replace LIKE by an optimized function
+	unique_ptr<Expression> result;
+	auto new_function =
+	    make_unique<BoundFunctionExpression>(expr->return_type, move(function), move(expr->children), nullptr);
+
+	// removing "%" from the pattern
+	pattern.erase(std::remove(pattern.begin(), pattern.end(), '%'), pattern.end());
+
+	new_function->children[1] = make_unique<BoundConstantExpression>(Value(move(pattern)));
+
+	result = move(new_function);
+	if (is_not_like) {
+		auto negation = make_unique<BoundOperatorExpression>(ExpressionType::OPERATOR_NOT, LogicalType::BOOLEAN);
+		negation->children.push_back(move(result));
+		result = move(negation);
+	}
+
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+MoveConstantsRule::MoveConstantsRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	auto op = make_unique<ComparisonExpressionMatcher>();
+	op->matchers.push_back(make_unique<ConstantExpressionMatcher>());
+	op->policy = SetMatcher::Policy::UNORDERED;
+
+	auto arithmetic = make_unique<FunctionExpressionMatcher>();
+	// we handle multiplication, addition and subtraction because those are "easy"
+	// integer division makes the division case difficult
+	// e.g. [x / 2 = 3] means [x = 6 OR x = 7] because of truncation -> no clean rewrite rules
+	arithmetic->function = make_unique<ManyFunctionMatcher>(unordered_set<string> {"+", "-", "*"});
+	// we match only on integral numeric types
+	arithmetic->type = make_unique<IntegerTypeMatcher>();
+	arithmetic->matchers.push_back(make_unique<ConstantExpressionMatcher>());
+	arithmetic->matchers.push_back(make_unique<ExpressionMatcher>());
+	arithmetic->policy = SetMatcher::Policy::SOME;
+	op->matchers.push_back(move(arithmetic));
+	root = move(op);
+}
+
+unique_ptr<Expression> MoveConstantsRule::Apply(LogicalOperator &op, vector<Expression *> &bindings, bool &changes_made,
+                                                bool is_root) {
+	auto comparison = (BoundComparisonExpression *)bindings[0];
+	auto outer_constant = (BoundConstantExpression *)bindings[1];
+	auto arithmetic = (BoundFunctionExpression *)bindings[2];
+	auto inner_constant = (BoundConstantExpression *)bindings[3];
+	if (!TypeIsIntegral(arithmetic->return_type.InternalType())) {
+		return nullptr;
+	}
+	if (inner_constant->value.IsNull() || outer_constant->value.IsNull()) {
+		return make_unique<BoundConstantExpression>(Value(comparison->return_type));
+	}
+	auto &constant_type = outer_constant->return_type;
+	hugeint_t outer_value = IntegralValue::Get(outer_constant->value);
+	hugeint_t inner_value = IntegralValue::Get(inner_constant->value);
+
+	idx_t arithmetic_child_index = arithmetic->children[0].get() == inner_constant ? 1 : 0;
+	auto &op_type = arithmetic->function.name;
+	if (op_type == "+") {
+		// [x + 1 COMP 10] OR [1 + x COMP 10]
+		// order does not matter in addition:
+		// simply change right side to 10-1 (outer_constant - inner_constant)
+		if (!Hugeint::SubtractInPlace(outer_value, inner_value)) {
+			return nullptr;
+		}
+		auto result_value = Value::HUGEINT(outer_value);
+		if (!result_value.TryCastAs(constant_type)) {
+			// if the cast is not possible then the comparison is not possible
+			// for example, if we have x + 5 = 3, where x is an unsigned number, we will get x = -2
+			// since this is not possible we can remove the entire branch here
+			return ExpressionRewriter::ConstantOrNull(move(arithmetic->children[arithmetic_child_index]),
+			                                          Value::BOOLEAN(false));
+		}
+		outer_constant->value = move(result_value);
+	} else if (op_type == "-") {
+		// [x - 1 COMP 10] O R [1 - x COMP 10]
+		// order matters in subtraction:
+		if (arithmetic_child_index == 0) {
+			// [x - 1 COMP 10]
+			// change right side to 10+1 (outer_constant + inner_constant)
+			if (!Hugeint::AddInPlace(outer_value, inner_value)) {
+				return nullptr;
+			}
+			auto result_value = Value::HUGEINT(outer_value);
+			if (!result_value.TryCastAs(constant_type)) {
+				// if the cast is not possible then the comparison is not possible
+				return ExpressionRewriter::ConstantOrNull(move(arithmetic->children[arithmetic_child_index]),
+				                                          Value::BOOLEAN(false));
+			}
+			outer_constant->value = move(result_value);
+		} else {
+			// [1 - x COMP 10]
+			// change right side to 1-10=-9
+			if (!Hugeint::SubtractInPlace(inner_value, outer_value)) {
+				return nullptr;
+			}
+			auto result_value = Value::HUGEINT(inner_value);
+			if (!result_value.TryCastAs(constant_type)) {
+				// if the cast is not possible then the comparison is not possible
+				return ExpressionRewriter::ConstantOrNull(move(arithmetic->children[arithmetic_child_index]),
+				                                          Value::BOOLEAN(false));
+			}
+			outer_constant->value = move(result_value);
+			// in this case, we should also flip the comparison
+			// e.g. if we have [4 - x < 2] then we should have [x > 2]
+			comparison->type = FlipComparisionExpression(comparison->type);
+		}
+	} else {
+		D_ASSERT(op_type == "*");
+		// [x * 2 COMP 10] OR [2 * x COMP 10]
+		// order does not matter in multiplication:
+		// change right side to 10/2 (outer_constant / inner_constant)
+		// but ONLY if outer_constant is cleanly divisible by the inner_constant
+		if (inner_value == 0) {
+			// x * 0, the result is either 0 or NULL
+			// we let the arithmetic_simplification rule take care of simplifying this first
+			return nullptr;
+		}
+		if (outer_value % inner_value != 0) {
+			// not cleanly divisible
+			bool is_equality = comparison->type == ExpressionType::COMPARE_EQUAL;
+			bool is_inequality = comparison->type == ExpressionType::COMPARE_NOTEQUAL;
+			if (is_equality || is_inequality) {
+				// we know the values are not equal
+				// the result will be either FALSE or NULL (if COMPARE_EQUAL)
+				// or TRUE or NULL (if COMPARE_NOTEQUAL)
+				return ExpressionRewriter::ConstantOrNull(move(arithmetic->children[arithmetic_child_index]),
+				                                          Value::BOOLEAN(is_inequality));
+			} else {
+				// not cleanly divisible and we are doing > >= < <=, skip the simplification for now
+				return nullptr;
+			}
+		}
+		if (inner_value < 0) {
+			// multiply by negative value, need to flip expression
+			comparison->type = FlipComparisionExpression(comparison->type);
+		}
+		// else divide the RHS by the LHS
+		// we need to do a range check on the cast even though we do a division
+		// because e.g. -128 / -1 = 128, which is out of range
+		auto result_value = Value::HUGEINT(outer_value / inner_value);
+		if (!result_value.TryCastAs(constant_type)) {
+			return ExpressionRewriter::ConstantOrNull(move(arithmetic->children[arithmetic_child_index]),
+			                                          Value::BOOLEAN(false));
+		}
+		outer_constant->value = move(result_value);
+	}
+	// replace left side with x
+	// first extract x from the arithmetic expression
+	auto arithmetic_child = move(arithmetic->children[arithmetic_child_index]);
+	// then place in the comparison
+	if (comparison->left.get() == outer_constant) {
+		comparison->right = move(arithmetic_child);
+	} else {
+		comparison->left = move(arithmetic_child);
+	}
+	changes_made = true;
+	return nullptr;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+RegexOptimizationRule::RegexOptimizationRule(ExpressionRewriter &rewriter) : Rule(rewriter) {
+	auto func = make_unique<FunctionExpressionMatcher>();
+	func->function = make_unique<SpecificFunctionMatcher>("regexp_matches");
+	func->policy = SetMatcher::Policy::ORDERED;
+	func->matchers.push_back(make_unique<ExpressionMatcher>());
+	func->matchers.push_back(make_unique<ConstantExpressionMatcher>());
+	root = move(func);
+}
+
+unique_ptr<Expression> RegexOptimizationRule::Apply(LogicalOperator &op, vector<Expression *> &bindings,
+                                                    bool &changes_made, bool is_root) {
+	auto root = (BoundFunctionExpression *)bindings[0];
+	auto constant_expr = (BoundConstantExpression *)bindings[2];
+	D_ASSERT(root->children.size() == 2);
+
+	if (constant_expr->value.IsNull()) {
+		return make_unique<BoundConstantExpression>(Value(root->return_type));
+	}
+
+	// the constant_expr is a scalar expression that we have to fold
+	if (!constant_expr->IsFoldable()) {
+		return nullptr;
+	}
+
+	auto constant_value = ExpressionExecutor::EvaluateScalar(*constant_expr);
+	D_ASSERT(constant_value.type() == constant_expr->return_type);
+	auto &patt_str = StringValue::Get(constant_value);
+
+	duckdb_re2::RE2 pattern(patt_str);
+	if (!pattern.ok()) {
+		return nullptr; // this should fail somewhere else
+	}
+
+	if (pattern.Regexp()->op() == duckdb_re2::kRegexpLiteralString ||
+	    pattern.Regexp()->op() == duckdb_re2::kRegexpLiteral) {
+		auto contains = make_unique<BoundFunctionExpression>(root->return_type, ContainsFun::GetFunction(),
+		                                                     move(root->children), nullptr);
+
+		contains->children[1] = make_unique<BoundConstantExpression>(Value(patt_str));
+		return move(contains);
+	}
+	return nullptr;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundAggregateExpression &aggr,
+                                                                     unique_ptr<Expression> *expr_ptr) {
+	vector<unique_ptr<BaseStatistics>> stats;
+	stats.reserve(aggr.children.size());
+	for (auto &child : aggr.children) {
+		stats.push_back(PropagateExpression(child));
+	}
+	if (!aggr.function.statistics) {
+		return nullptr;
+	}
+	return aggr.function.statistics(context, aggr, aggr.bind_info.get(), stats, node_stats.get());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+bool GetCastType(T signed_range, LogicalType &cast_type) {
+	auto range = static_cast<typename std::make_unsigned<decltype(signed_range)>::type>(signed_range);
+
+	// Check if this range fits in a smaller type
+	if (range < NumericLimits<uint8_t>::Maximum()) {
+		cast_type = LogicalType::UTINYINT;
+	} else if (sizeof(T) > sizeof(uint16_t) && range < NumericLimits<uint16_t>::Maximum()) {
+		cast_type = LogicalType::USMALLINT;
+	} else if (sizeof(T) > sizeof(uint32_t) && range < NumericLimits<uint32_t>::Maximum()) {
+		cast_type = LogicalType::UINTEGER;
+	} else {
+		return false;
+	}
+	return true;
+}
+
+template <>
+bool GetCastType(hugeint_t range, LogicalType &cast_type) {
+	if (range < NumericLimits<uint8_t>().Maximum()) {
+		cast_type = LogicalType::UTINYINT;
+	} else if (range < NumericLimits<uint16_t>().Maximum()) {
+		cast_type = LogicalType::USMALLINT;
+	} else if (range < NumericLimits<uint32_t>().Maximum()) {
+		cast_type = LogicalType::UINTEGER;
+	} else if (range < NumericLimits<uint64_t>().Maximum()) {
+		cast_type = LogicalType::UBIGINT;
+	} else {
+		return false;
+	}
+	return true;
+}
+
+template <class T>
+unique_ptr<Expression> TemplatedCastToSmallestType(unique_ptr<Expression> expr, NumericStatistics &num_stats) {
+	// Compute range
+	if (num_stats.min.IsNull() || num_stats.max.IsNull()) {
+		return expr;
+	}
+
+	auto signed_min_val = num_stats.min.GetValue<T>();
+	auto signed_max_val = num_stats.max.GetValue<T>();
+	if (signed_max_val < signed_min_val) {
+		return expr;
+	}
+
+	// Compute range, cast to unsigned to prevent comparing signed with unsigned
+	T signed_range;
+	if (!TrySubtractOperator::Operation(signed_max_val, signed_min_val, signed_range)) {
+		// overflow in subtraction: cannot do any simplification
+		return expr;
+	}
+
+	// Check if this range fits in a smaller type
+	LogicalType cast_type;
+	if (!GetCastType(signed_range, cast_type)) {
+		return expr;
+	}
+
+	// Create expression to map to a smaller range
+	auto input_type = expr->return_type;
+	auto minimum_expr = make_unique<BoundConstantExpression>(Value::CreateValue(signed_min_val));
+	vector<unique_ptr<Expression>> arguments;
+	arguments.push_back(move(expr));
+	arguments.push_back(move(minimum_expr));
+	auto minus_expr = make_unique<BoundFunctionExpression>(input_type, SubtractFun::GetFunction(input_type, input_type),
+	                                                       move(arguments), nullptr, true);
+
+	// Cast to smaller type
+	return make_unique<BoundCastExpression>(move(minus_expr), cast_type);
+}
+
+unique_ptr<Expression> CastToSmallestType(unique_ptr<Expression> expr, NumericStatistics &num_stats) {
+	auto physical_type = expr->return_type.InternalType();
+	switch (physical_type) {
+	case PhysicalType::UINT8:
+	case PhysicalType::INT8:
+		return expr;
+	case PhysicalType::UINT16:
+		return TemplatedCastToSmallestType<uint16_t>(move(expr), num_stats);
+	case PhysicalType::INT16:
+		return TemplatedCastToSmallestType<int16_t>(move(expr), num_stats);
+	case PhysicalType::UINT32:
+		return TemplatedCastToSmallestType<uint32_t>(move(expr), num_stats);
+	case PhysicalType::INT32:
+		return TemplatedCastToSmallestType<int32_t>(move(expr), num_stats);
+	case PhysicalType::UINT64:
+		return TemplatedCastToSmallestType<uint64_t>(move(expr), num_stats);
+	case PhysicalType::INT64:
+		return TemplatedCastToSmallestType<int64_t>(move(expr), num_stats);
+	case PhysicalType::INT128:
+		return TemplatedCastToSmallestType<hugeint_t>(move(expr), num_stats);
+	default:
+		throw NotImplementedException("Unknown integer type!");
+	}
+}
+
+void StatisticsPropagator::PropagateAndCompress(unique_ptr<Expression> &expr, unique_ptr<BaseStatistics> &stats) {
+	stats = PropagateExpression(expr);
+	if (stats) {
+		if (expr->return_type.IsIntegral()) {
+			expr = CastToSmallestType(move(expr), (NumericStatistics &)*stats);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundBetweenExpression &between,
+                                                                     unique_ptr<Expression> *expr_ptr) {
+	// propagate in all the children
+	auto input_stats = PropagateExpression(between.input);
+	auto lower_stats = PropagateExpression(between.lower);
+	auto upper_stats = PropagateExpression(between.upper);
+	if (!input_stats) {
+		return nullptr;
+	}
+	auto lower_comparison = between.LowerComparisonType();
+	auto upper_comparison = between.UpperComparisonType();
+	// propagate the comparisons
+	auto lower_prune = FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	auto upper_prune = FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	if (lower_stats) {
+		lower_prune = PropagateComparison(*input_stats, *lower_stats, lower_comparison);
+	}
+	if (upper_stats) {
+		upper_prune = PropagateComparison(*input_stats, *upper_stats, upper_comparison);
+	}
+	if (lower_prune == FilterPropagateResult::FILTER_ALWAYS_TRUE &&
+	    upper_prune == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+		// both filters are always true: replace the between expression with a constant true
+		*expr_ptr = make_unique<BoundConstantExpression>(Value::BOOLEAN(true));
+	} else if (lower_prune == FilterPropagateResult::FILTER_ALWAYS_FALSE ||
+	           upper_prune == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+		// either one of the filters is always false: replace the between expression with a constant false
+		*expr_ptr = make_unique<BoundConstantExpression>(Value::BOOLEAN(false));
+	} else if (lower_prune == FilterPropagateResult::FILTER_FALSE_OR_NULL ||
+	           upper_prune == FilterPropagateResult::FILTER_FALSE_OR_NULL) {
+		// either one of the filters is false or null: replace with a constant or null (false)
+		vector<unique_ptr<Expression>> children;
+		children.push_back(move(between.input));
+		children.push_back(move(between.lower));
+		children.push_back(move(between.upper));
+		*expr_ptr = ExpressionRewriter::ConstantOrNull(move(children), Value::BOOLEAN(false));
+	} else if (lower_prune == FilterPropagateResult::FILTER_TRUE_OR_NULL &&
+	           upper_prune == FilterPropagateResult::FILTER_TRUE_OR_NULL) {
+		// both filters are true or null: replace with a true or null
+		vector<unique_ptr<Expression>> children;
+		children.push_back(move(between.input));
+		children.push_back(move(between.lower));
+		children.push_back(move(between.upper));
+		*expr_ptr = ExpressionRewriter::ConstantOrNull(move(children), Value::BOOLEAN(true));
+	} else if (lower_prune == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+		// lower filter is always true: replace with upper comparison
+		*expr_ptr = make_unique<BoundComparisonExpression>(upper_comparison, move(between.input), move(between.upper));
+	} else if (upper_prune == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+		// upper filter is always true: replace with lower comparison
+		*expr_ptr = make_unique<BoundComparisonExpression>(lower_comparison, move(between.input), move(between.lower));
+	}
+	return nullptr;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundCaseExpression &bound_case,
+                                                                     unique_ptr<Expression> *expr_ptr) {
+	// propagate in all the children
+	auto result_stats = PropagateExpression(bound_case.else_expr);
+	for (auto &case_check : bound_case.case_checks) {
+		PropagateExpression(case_check.when_expr);
+		auto then_stats = PropagateExpression(case_check.then_expr);
+		if (!then_stats) {
+			result_stats.reset();
+		} else if (result_stats) {
+			result_stats->Merge(*then_stats);
+		}
+	}
+	return result_stats;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+static unique_ptr<BaseStatistics> StatisticsOperationsNumericNumericCast(const BaseStatistics *input_p,
+                                                                         const LogicalType &target) {
+	auto &input = (NumericStatistics &)*input_p;
+
+	Value min = input.min, max = input.max;
+	if (!min.TryCastAs(target) || !max.TryCastAs(target)) {
+		// overflow in cast: bailout
+		return nullptr;
+	}
+	auto stats = make_unique<NumericStatistics>(target, move(min), move(max), input.stats_type);
+	stats->CopyBase(*input_p);
+	return move(stats);
+}
+
+static unique_ptr<BaseStatistics> StatisticsNumericCastSwitch(const BaseStatistics *input, const LogicalType &target) {
+	switch (target.InternalType()) {
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::INT128:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+		return StatisticsOperationsNumericNumericCast(input, target);
+	default:
+		return nullptr;
+	}
+}
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundCastExpression &cast,
+                                                                     unique_ptr<Expression> *expr_ptr) {
+	auto child_stats = PropagateExpression(cast.child);
+	if (!child_stats) {
+		return nullptr;
+	}
+	unique_ptr<BaseStatistics> result_stats;
+	switch (cast.child->return_type.InternalType()) {
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::INT128:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+		result_stats = StatisticsNumericCastSwitch(child_stats.get(), cast.return_type);
+		break;
+	default:
+		return nullptr;
+	}
+	if (cast.try_cast && result_stats) {
+		result_stats->validity_stats = make_unique<ValidityStatistics>(true, true);
+	}
+	return result_stats;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundColumnRefExpression &colref,
+                                                                     unique_ptr<Expression> *expr_ptr) {
+	auto stats = statistics_map.find(colref.binding);
+	if (stats == statistics_map.end()) {
+		return nullptr;
+	}
+	return stats->second->Copy();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+FilterPropagateResult StatisticsPropagator::PropagateComparison(BaseStatistics &left, BaseStatistics &right,
+                                                                ExpressionType comparison) {
+	// only handle numerics for now
+	switch (left.type.InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::INT128:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+		break;
+	default:
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	auto &lstats = (NumericStatistics &)left;
+	auto &rstats = (NumericStatistics &)right;
+	if (lstats.min.IsNull() || lstats.max.IsNull() || rstats.min.IsNull() || rstats.max.IsNull()) {
+		// no stats available: nothing to prune
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	// the result of the propagation depend on whether or not either side has null values
+	// if there are null values present, we cannot say whether or not
+	bool has_null = lstats.CanHaveNull() || rstats.CanHaveNull();
+	switch (comparison) {
+	case ExpressionType::COMPARE_EQUAL:
+		// l = r, if l.min > r.max or r.min > l.max equality is not possible
+		if (lstats.min > rstats.max || rstats.min > lstats.max) {
+			return has_null ? FilterPropagateResult::FILTER_FALSE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		} else {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+	case ExpressionType::COMPARE_GREATERTHAN:
+		// l > r
+		if (lstats.min > rstats.max) {
+			// if l.min > r.max, it is always true ONLY if neither side contains nulls
+			return has_null ? FilterPropagateResult::FILTER_TRUE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		}
+		// if r.min is bigger or equal to l.max, the filter is always false
+		if (rstats.min >= lstats.max) {
+			return has_null ? FilterPropagateResult::FILTER_FALSE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		// l >= r
+		if (lstats.min >= rstats.max) {
+			// if l.min >= r.max, it is always true ONLY if neither side contains nulls
+			return has_null ? FilterPropagateResult::FILTER_TRUE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		}
+		// if r.min > l.max, the filter is always false
+		if (rstats.min > lstats.max) {
+			return has_null ? FilterPropagateResult::FILTER_FALSE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	case ExpressionType::COMPARE_LESSTHAN:
+		// l < r
+		if (lstats.max < rstats.min) {
+			// if l.max < r.min, it is always true ONLY if neither side contains nulls
+			return has_null ? FilterPropagateResult::FILTER_TRUE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		}
+		// if l.min >= rstats.max, the filter is always false
+		if (lstats.min >= rstats.max) {
+			return has_null ? FilterPropagateResult::FILTER_FALSE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		// l <= r
+		if (lstats.max <= rstats.min) {
+			// if l.max <= r.min, it is always true ONLY if neither side contains nulls
+			return has_null ? FilterPropagateResult::FILTER_TRUE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		}
+		// if l.min > rstats.max, the filter is always false
+		if (lstats.min > rstats.max) {
+			return has_null ? FilterPropagateResult::FILTER_FALSE_OR_NULL : FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	default:
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+}
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundComparisonExpression &expr,
+                                                                     unique_ptr<Expression> *expr_ptr) {
+	auto left_stats = PropagateExpression(expr.left);
+	auto right_stats = PropagateExpression(expr.right);
+	if (!left_stats || !right_stats) {
+		return nullptr;
+	}
+	// propagate the statistics of the comparison operator
+	auto propagate_result = PropagateComparison(*left_stats, *right_stats, expr.type);
+	switch (propagate_result) {
+	case FilterPropagateResult::FILTER_ALWAYS_TRUE:
+		*expr_ptr = make_unique<BoundConstantExpression>(Value::BOOLEAN(true));
+		return PropagateExpression(*expr_ptr);
+	case FilterPropagateResult::FILTER_ALWAYS_FALSE:
+		*expr_ptr = make_unique<BoundConstantExpression>(Value::BOOLEAN(false));
+		return PropagateExpression(*expr_ptr);
+	case FilterPropagateResult::FILTER_TRUE_OR_NULL: {
+		vector<unique_ptr<Expression>> children;
+		children.push_back(move(expr.left));
+		children.push_back(move(expr.right));
+		*expr_ptr = ExpressionRewriter::ConstantOrNull(move(children), Value::BOOLEAN(true));
+		return nullptr;
+	}
+	case FilterPropagateResult::FILTER_FALSE_OR_NULL: {
+		vector<unique_ptr<Expression>> children;
+		children.push_back(move(expr.left));
+		children.push_back(move(expr.right));
+		*expr_ptr = ExpressionRewriter::ConstantOrNull(move(children), Value::BOOLEAN(false));
+		return nullptr;
+	}
+	default:
+		// FIXME: we can propagate nulls here, i.e. this expression will have nulls only if left and right has nulls
+		return nullptr;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundConjunctionExpression &expr,
+                                                                     unique_ptr<Expression> *expr_ptr) {
+	auto is_and = expr.type == ExpressionType::CONJUNCTION_AND;
+	for (idx_t expr_idx = 0; expr_idx < expr.children.size(); expr_idx++) {
+		auto &child = expr.children[expr_idx];
+		auto stats = PropagateExpression(child);
+		if (!child->IsFoldable()) {
+			continue;
+		}
+		// we have a constant in a conjunction
+		// we (1) either prune the child
+		// or (2) replace the entire conjunction with a constant
+		auto constant = ExpressionExecutor::EvaluateScalar(*child);
+		if (constant.IsNull()) {
+			continue;
+		}
+		auto b = BooleanValue::Get(constant);
+		bool prune_child = false;
+		bool constant_value = true;
+		if (b) {
+			// true
+			if (is_and) {
+				// true in and: prune child
+				prune_child = true;
+			} else {
+				// true in OR: replace with TRUE
+				constant_value = true;
+			}
+		} else {
+			// false
+			if (is_and) {
+				// false in AND: replace with FALSE
+				constant_value = false;
+			} else {
+				// false in OR: prune child
+				prune_child = true;
+			}
+		}
+		if (prune_child) {
+			expr.children.erase(expr.children.begin() + expr_idx);
+			expr_idx--;
+			continue;
+		}
+		*expr_ptr = make_unique<BoundConstantExpression>(Value::BOOLEAN(constant_value));
+		return PropagateExpression(*expr_ptr);
+	}
+	if (expr.children.empty()) {
+		// if there are no children left, replace the conjunction with TRUE (for AND) or FALSE (for OR)
+		*expr_ptr = make_unique<BoundConstantExpression>(Value::BOOLEAN(is_and));
+		return PropagateExpression(*expr_ptr);
+	} else if (expr.children.size() == 1) {
+		// if there is one child left, replace the conjunction with that one child
+		*expr_ptr = move(expr.children[0]);
+	}
+	return nullptr;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+void UpdateDistinctStats(BaseStatistics &distinct_stats, const Value &input) {
+	Vector v(input);
+	auto &d_stats = (DistinctStatistics &)distinct_stats;
+	d_stats.Update(v, 1);
+}
+
+unique_ptr<BaseStatistics> StatisticsPropagator::StatisticsFromValue(const Value &input) {
+	switch (input.type().InternalType()) {
+	case PhysicalType::BOOL:
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::INT128:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE: {
+		auto result = make_unique<NumericStatistics>(input.type(), input, input, StatisticsType::GLOBAL_STATS);
+		result->validity_stats = make_unique<ValidityStatistics>(input.IsNull(), !input.IsNull());
+		UpdateDistinctStats(*result->distinct_stats, input);
+		return move(result);
+	}
+	case PhysicalType::VARCHAR: {
+		auto result = make_unique<StringStatistics>(input.type(), StatisticsType::GLOBAL_STATS);
+		result->validity_stats = make_unique<ValidityStatistics>(input.IsNull(), !input.IsNull());
+		UpdateDistinctStats(*result->distinct_stats, input);
+		if (!input.IsNull()) {
+			auto &string_value = StringValue::Get(input);
+			result->Update(string_t(string_value));
+		}
+		return move(result);
+	}
+	case PhysicalType::STRUCT: {
+		auto result = make_unique<StructStatistics>(input.type());
+		result->validity_stats = make_unique<ValidityStatistics>(input.IsNull(), !input.IsNull());
+		if (input.IsNull()) {
+			for (auto &child_stat : result->child_stats) {
+				child_stat.reset();
+			}
+		} else {
+			auto &struct_children = StructValue::GetChildren(input);
+			D_ASSERT(result->child_stats.size() == struct_children.size());
+			for (idx_t i = 0; i < result->child_stats.size(); i++) {
+				result->child_stats[i] = StatisticsFromValue(struct_children[i]);
+			}
+		}
+		return move(result);
+	}
+	case PhysicalType::LIST: {
+		auto result = make_unique<ListStatistics>(input.type());
+		result->validity_stats = make_unique<ValidityStatistics>(input.IsNull(), !input.IsNull());
+		if (input.IsNull()) {
+			result->child_stats.reset();
+		} else {
+			auto &list_children = ListValue::GetChildren(input);
+			for (auto &child_element : list_children) {
+				auto child_element_stats = StatisticsFromValue(child_element);
+				if (child_element_stats) {
+					result->child_stats->Merge(*child_element_stats);
+				} else {
+					result->child_stats.reset();
+				}
+			}
+		}
+		return move(result);
+	}
+	default:
+		return nullptr;
+	}
+}
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundConstantExpression &constant,
+                                                                     unique_ptr<Expression> *expr_ptr) {
+	return StatisticsFromValue(constant.value);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundFunctionExpression &func,
+                                                                     unique_ptr<Expression> *expr_ptr) {
+	vector<unique_ptr<BaseStatistics>> stats;
+	stats.reserve(func.children.size());
+	for (idx_t i = 0; i < func.children.size(); i++) {
+		stats.push_back(PropagateExpression(func.children[i]));
+	}
+	if (!func.function.statistics) {
+		return nullptr;
+	}
+	FunctionStatisticsInput input(func, func.bind_info.get(), stats, expr_ptr);
+	return func.function.statistics(context, input);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(BoundOperatorExpression &expr,
+                                                                     unique_ptr<Expression> *expr_ptr) {
+	bool all_have_stats = true;
+	vector<unique_ptr<BaseStatistics>> child_stats;
+	child_stats.reserve(expr.children.size());
+	for (auto &child : expr.children) {
+		auto stats = PropagateExpression(child);
+		if (!stats) {
+			all_have_stats = false;
+		}
+		child_stats.push_back(move(stats));
+	}
+	if (!all_have_stats) {
+		return nullptr;
+	}
+	switch (expr.type) {
+	case ExpressionType::OPERATOR_COALESCE:
+		// COALESCE, merge stats of all children
+		for (idx_t i = 0; i < expr.children.size(); i++) {
+			D_ASSERT(child_stats[i]);
+			if (!child_stats[i]->CanHaveNoNull()) {
+				// this child is always NULL, we can remove it from the coalesce
+				// UNLESS there is only one node remaining
+				if (expr.children.size() > 1) {
+					expr.children.erase(expr.children.begin() + i);
+					child_stats.erase(child_stats.begin() + i);
+					i--;
+				}
+			} else if (!child_stats[i]->CanHaveNull()) {
+				// coalesce child cannot have NULL entries
+				// this is the last coalesce node that influences the result
+				// we can erase any children after this node
+				if (i + 1 < expr.children.size()) {
+					expr.children.erase(expr.children.begin() + i + 1, expr.children.end());
+					child_stats.erase(child_stats.begin() + i + 1, child_stats.end());
+				}
+				break;
+			}
+		}
+		D_ASSERT(!expr.children.empty());
+		D_ASSERT(expr.children.size() == child_stats.size());
+		if (expr.children.size() == 1) {
+			// coalesce of one entry: simply return that entry
+			*expr_ptr = move(expr.children[0]);
+		} else {
+			// coalesce of multiple entries
+			// merge the stats
+			for (idx_t i = 1; i < expr.children.size(); i++) {
+				child_stats[0]->Merge(*child_stats[i]);
+			}
+		}
+		return move(child_stats[0]);
+	case ExpressionType::OPERATOR_IS_NULL:
+		if (!child_stats[0]->CanHaveNull()) {
+			// child has no null values: x IS NULL will always be false
+			*expr_ptr = make_unique<BoundConstantExpression>(Value::BOOLEAN(false));
+			return PropagateExpression(*expr_ptr);
+		}
+		return nullptr;
+	case ExpressionType::OPERATOR_IS_NOT_NULL:
+		if (!child_stats[0]->CanHaveNull()) {
+			// child has no null values: x IS NOT NULL will always be true
+			*expr_ptr = make_unique<BoundConstantExpression>(Value::BOOLEAN(true));
+			return PropagateExpression(*expr_ptr);
+		}
+		return nullptr;
+	default:
+		return nullptr;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalAggregate &aggr,
+                                                                     unique_ptr<LogicalOperator> *node_ptr) {
+	// first propagate statistics in the child node
+	node_stats = PropagateStatistics(aggr.children[0]);
+
+	// handle the groups: simply propagate statistics and assign the stats to the group binding
+	aggr.group_stats.resize(aggr.groups.size());
+	for (idx_t group_idx = 0; group_idx < aggr.groups.size(); group_idx++) {
+		auto stats = PropagateExpression(aggr.groups[group_idx]);
+		aggr.group_stats[group_idx] = stats ? stats->Copy() : nullptr;
+		if (!stats) {
+			continue;
+		}
+		if (aggr.grouping_sets.size() > 1) {
+			// aggregates with multiple grouping sets can introduce NULL values to certain groups
+			// FIXME: actually figure out WHICH groups can have null values introduced
+			stats->validity_stats = make_unique<ValidityStatistics>(true, true);
+			continue;
+		}
+		ColumnBinding group_binding(aggr.group_index, group_idx);
+		statistics_map[group_binding] = move(stats);
+	}
+	// propagate statistics in the aggregates
+	for (idx_t aggregate_idx = 0; aggregate_idx < aggr.expressions.size(); aggregate_idx++) {
+		auto stats = PropagateExpression(aggr.expressions[aggregate_idx]);
+		if (!stats) {
+			continue;
+		}
+		ColumnBinding aggregate_binding(aggr.aggregate_index, aggregate_idx);
+		statistics_map[aggregate_binding] = move(stats);
+	}
+	// the max cardinality of an aggregate is the max cardinality of the input (i.e. when every row is a unique group)
+	return move(node_stats);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalCrossProduct &cp,
+                                                                     unique_ptr<LogicalOperator> *node_ptr) {
+	// first propagate statistics in the child node
+	auto left_stats = PropagateStatistics(cp.children[0]);
+	auto right_stats = PropagateStatistics(cp.children[1]);
+	if (!left_stats || !right_stats) {
+		return nullptr;
+	}
+	MultiplyCardinalities(left_stats, *right_stats);
+	return left_stats;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static bool IsCompareDistinct(ExpressionType type) {
+	return type == ExpressionType::COMPARE_DISTINCT_FROM || type == ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+}
+
+bool StatisticsPropagator::ExpressionIsConstant(Expression &expr, const Value &val) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+		return false;
+	}
+	auto &bound_constant = (BoundConstantExpression &)expr;
+	D_ASSERT(bound_constant.value.type() == val.type());
+	return Value::NotDistinctFrom(bound_constant.value, val);
+}
+
+bool StatisticsPropagator::ExpressionIsConstantOrNull(Expression &expr, const Value &val) {
+	if (expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+		return false;
+	}
+	auto &bound_function = (BoundFunctionExpression &)expr;
+	return ConstantOrNull::IsConstantOrNull(bound_function, val);
+}
+
+void StatisticsPropagator::SetStatisticsNotNull(ColumnBinding binding) {
+	auto entry = statistics_map.find(binding);
+	if (entry == statistics_map.end()) {
+		return;
+	}
+	entry->second->validity_stats = make_unique<ValidityStatistics>(false);
+}
+
+void StatisticsPropagator::UpdateFilterStatistics(BaseStatistics &stats, ExpressionType comparison_type,
+                                                  const Value &constant) {
+	// regular comparisons removes all null values
+	if (!IsCompareDistinct(comparison_type)) {
+		stats.validity_stats = make_unique<ValidityStatistics>(false);
+	}
+	if (!stats.type.IsNumeric()) {
+		// don't handle non-numeric columns here (yet)
+		return;
+	}
+	auto &numeric_stats = (NumericStatistics &)stats;
+	if (numeric_stats.min.IsNull() || numeric_stats.max.IsNull()) {
+		// no stats available: skip this
+		return;
+	}
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_LESSTHAN:
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		// X < constant OR X <= constant
+		// max becomes the constant
+		numeric_stats.max = constant;
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		// X > constant OR X >= constant
+		// min becomes the constant
+		numeric_stats.min = constant;
+		break;
+	case ExpressionType::COMPARE_EQUAL:
+		// X = constant
+		// both min and max become the constant
+		numeric_stats.min = constant;
+		numeric_stats.max = constant;
+		break;
+	default:
+		break;
+	}
+}
+
+void StatisticsPropagator::UpdateFilterStatistics(BaseStatistics &lstats, BaseStatistics &rstats,
+                                                  ExpressionType comparison_type) {
+	// regular comparisons removes all null values
+	if (!IsCompareDistinct(comparison_type)) {
+		lstats.validity_stats = make_unique<ValidityStatistics>(false);
+		rstats.validity_stats = make_unique<ValidityStatistics>(false);
+	}
+	D_ASSERT(lstats.type == rstats.type);
+	if (!lstats.type.IsNumeric()) {
+		// don't handle non-numeric columns here (yet)
+		return;
+	}
+	auto &left_stats = (NumericStatistics &)lstats;
+	auto &right_stats = (NumericStatistics &)rstats;
+	if (left_stats.min.IsNull() || left_stats.max.IsNull() || right_stats.min.IsNull() || right_stats.max.IsNull()) {
+		// no stats available: skip this
+		return;
+	}
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_LESSTHAN:
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		// LEFT < RIGHT OR LEFT <= RIGHT
+		// we know that every value of left is smaller (or equal to) every value in right
+		// i.e. if we have left = [-50, 250] and right = [-100, 100]
+
+		// we know that left.max is AT MOST equal to right.max
+		// because any value in left that is BIGGER than right.max will not pass the filter
+		if (left_stats.max > right_stats.max) {
+			left_stats.max = right_stats.max;
+		}
+
+		// we also know that right.min is AT MOST equal to left.min
+		// because any value in right that is SMALLER than left.min will not pass the filter
+		if (right_stats.min < left_stats.min) {
+			right_stats.min = left_stats.min;
+		}
+		// so in our example, the bounds get updated as follows:
+		// left: [-50, 100], right: [-50, 100]
+		break;
+	case ExpressionType::COMPARE_GREATERTHAN:
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		// LEFT > RIGHT OR LEFT >= RIGHT
+		// we know that every value of left is bigger (or equal to) every value in right
+		// this is essentially the inverse of the less than (or equal to) scenario
+		if (right_stats.max > left_stats.max) {
+			right_stats.max = left_stats.max;
+		}
+		if (left_stats.min < right_stats.min) {
+			left_stats.min = right_stats.min;
+		}
+		break;
+	case ExpressionType::COMPARE_EQUAL:
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		// LEFT = RIGHT
+		// only the tightest bounds pass
+		// so if we have e.g. left = [-50, 250] and right = [-100, 100]
+		// the tighest bounds are [-50, 100]
+		// select the highest min
+		if (left_stats.min > right_stats.min) {
+			right_stats.min = left_stats.min;
+		} else {
+			left_stats.min = right_stats.min;
+		}
+		// select the lowest max
+		if (left_stats.max < right_stats.max) {
+			right_stats.max = left_stats.max;
+		} else {
+			left_stats.max = right_stats.max;
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+void StatisticsPropagator::UpdateFilterStatistics(Expression &left, Expression &right, ExpressionType comparison_type) {
+	// first check if either side is a bound column ref
+	// any column ref involved in a comparison will not be null after the comparison
+	bool compare_distinct = IsCompareDistinct(comparison_type);
+	if (!compare_distinct && left.type == ExpressionType::BOUND_COLUMN_REF) {
+		SetStatisticsNotNull(((BoundColumnRefExpression &)left).binding);
+	}
+	if (!compare_distinct && right.type == ExpressionType::BOUND_COLUMN_REF) {
+		SetStatisticsNotNull(((BoundColumnRefExpression &)right).binding);
+	}
+	// check if this is a comparison between a constant and a column ref
+	BoundConstantExpression *constant = nullptr;
+	BoundColumnRefExpression *columnref = nullptr;
+	if (left.type == ExpressionType::VALUE_CONSTANT && right.type == ExpressionType::BOUND_COLUMN_REF) {
+		constant = (BoundConstantExpression *)&left;
+		columnref = (BoundColumnRefExpression *)&right;
+		comparison_type = FlipComparisionExpression(comparison_type);
+	} else if (left.type == ExpressionType::BOUND_COLUMN_REF && right.type == ExpressionType::VALUE_CONSTANT) {
+		columnref = (BoundColumnRefExpression *)&left;
+		constant = (BoundConstantExpression *)&right;
+	} else if (left.type == ExpressionType::BOUND_COLUMN_REF && right.type == ExpressionType::BOUND_COLUMN_REF) {
+		// comparison between two column refs
+		auto &left_column_ref = (BoundColumnRefExpression &)left;
+		auto &right_column_ref = (BoundColumnRefExpression &)right;
+		auto lentry = statistics_map.find(left_column_ref.binding);
+		auto rentry = statistics_map.find(right_column_ref.binding);
+		if (lentry == statistics_map.end() || rentry == statistics_map.end()) {
+			return;
+		}
+		UpdateFilterStatistics(*lentry->second, *rentry->second, comparison_type);
+	} else {
+		// unsupported filter
+		return;
+	}
+	if (constant && columnref) {
+		// comparison between columnref
+		auto entry = statistics_map.find(columnref->binding);
+		if (entry == statistics_map.end()) {
+			return;
+		}
+		UpdateFilterStatistics(*entry->second, comparison_type, constant->value);
+	}
+}
+
+void StatisticsPropagator::UpdateFilterStatistics(Expression &condition) {
+	// in filters, we check for constant comparisons with bound columns
+	// if we find a comparison in the form of e.g. "i=3", we can update our statistics for that column
+	switch (condition.GetExpressionClass()) {
+	case ExpressionClass::BOUND_BETWEEN: {
+		auto &between = (BoundBetweenExpression &)condition;
+		UpdateFilterStatistics(*between.input, *between.lower, between.LowerComparisonType());
+		UpdateFilterStatistics(*between.input, *between.upper, between.UpperComparisonType());
+		break;
+	}
+	case ExpressionClass::BOUND_COMPARISON: {
+		auto &comparison = (BoundComparisonExpression &)condition;
+		UpdateFilterStatistics(*comparison.left, *comparison.right, comparison.type);
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalFilter &filter,
+                                                                     unique_ptr<LogicalOperator> *node_ptr) {
+	// first propagate to the child
+	node_stats = PropagateStatistics(filter.children[0]);
+	if (filter.children[0]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
+		ReplaceWithEmptyResult(*node_ptr);
+		return make_unique<NodeStatistics>(0, 0);
+	}
+
+	// then propagate to each of the expressions
+	for (idx_t i = 0; i < filter.expressions.size(); i++) {
+		auto &condition = filter.expressions[i];
+		PropagateExpression(condition);
+
+		if (ExpressionIsConstant(*condition, Value::BOOLEAN(true))) {
+			// filter is always true; it is useless to execute it
+			// erase this condition
+			filter.expressions.erase(filter.expressions.begin() + i);
+			i--;
+			if (filter.expressions.empty()) {
+				// all conditions have been erased: remove the entire filter
+				*node_ptr = move(filter.children[0]);
+				break;
+			}
+		} else if (ExpressionIsConstant(*condition, Value::BOOLEAN(false)) ||
+		           ExpressionIsConstantOrNull(*condition, Value::BOOLEAN(false))) {
+			// filter is always false or null; this entire filter should be replaced by an empty result block
+			ReplaceWithEmptyResult(*node_ptr);
+			return make_unique<NodeStatistics>(0, 0);
+		} else {
+			// cannot prune this filter: propagate statistics from the filter
+			UpdateFilterStatistics(*condition);
+		}
+	}
+	// the max cardinality of a filter is the cardinality of the input (i.e. no tuples get filtered)
+	return move(node_stats);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+FilterPropagateResult StatisticsPropagator::PropagateTableFilter(BaseStatistics &stats, TableFilter &filter) {
+	return filter.CheckStatistics(stats);
+}
+
+void StatisticsPropagator::UpdateFilterStatistics(BaseStatistics &input, TableFilter &filter) {
+	// FIXME: update stats...
+	switch (filter.filter_type) {
+	case TableFilterType::CONJUNCTION_AND: {
+		auto &conjunction_and = (ConjunctionAndFilter &)filter;
+		for (auto &child_filter : conjunction_and.child_filters) {
+			UpdateFilterStatistics(input, *child_filter);
+		}
+		break;
+	}
+	case TableFilterType::CONSTANT_COMPARISON: {
+		auto &constant_filter = (ConstantFilter &)filter;
+		UpdateFilterStatistics(input, constant_filter.comparison_type, constant_filter.constant);
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalGet &get,
+                                                                     unique_ptr<LogicalOperator> *node_ptr) {
+	if (get.function.cardinality) {
+		node_stats = get.function.cardinality(context, get.bind_data.get());
+	}
+	if (!get.function.statistics) {
+		// no column statistics to get
+		return move(node_stats);
+	}
+	for (idx_t i = 0; i < get.column_ids.size(); i++) {
+		auto stats = get.function.statistics(context, get.bind_data.get(), get.column_ids[i]);
+		if (stats) {
+			ColumnBinding binding(get.table_index, i);
+			statistics_map.insert(make_pair(binding, move(stats)));
+		}
+	}
+	// push table filters into the statistics
+	vector<idx_t> column_indexes;
+	column_indexes.reserve(get.table_filters.filters.size());
+	for (auto &kv : get.table_filters.filters) {
+		column_indexes.push_back(kv.first);
+	}
+
+	for (auto &table_filter_column : column_indexes) {
+		idx_t column_index;
+		for (column_index = 0; column_index < get.column_ids.size(); column_index++) {
+			if (get.column_ids[column_index] == table_filter_column) {
+				break;
+			}
+		}
+		D_ASSERT(column_index < get.column_ids.size());
+		D_ASSERT(get.column_ids[column_index] == table_filter_column);
+
+		// find the stats
+		ColumnBinding stats_binding(get.table_index, column_index);
+		auto entry = statistics_map.find(stats_binding);
+		if (entry == statistics_map.end()) {
+			// no stats for this entry
+			continue;
+		}
+		auto &stats = *entry->second;
+
+		// fetch the table filter
+		D_ASSERT(get.table_filters.filters.count(table_filter_column) > 0);
+		auto &filter = get.table_filters.filters[table_filter_column];
+		auto propagate_result = PropagateTableFilter(stats, *filter);
+		switch (propagate_result) {
+		case FilterPropagateResult::FILTER_ALWAYS_TRUE:
+			// filter is always true; it is useless to execute it
+			// erase this condition
+			get.table_filters.filters.erase(table_filter_column);
+			break;
+		case FilterPropagateResult::FILTER_FALSE_OR_NULL:
+		case FilterPropagateResult::FILTER_ALWAYS_FALSE:
+			// filter is always false; this entire filter should be replaced by an empty result block
+			ReplaceWithEmptyResult(*node_ptr);
+			return make_unique<NodeStatistics>(0, 0);
+		default:
+			// general case: filter can be true or false, update this columns' statistics
+			UpdateFilterStatistics(stats, *filter);
+			break;
+		}
+	}
+	return move(node_stats);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+void StatisticsPropagator::PropagateStatistics(LogicalComparisonJoin &join, unique_ptr<LogicalOperator> *node_ptr) {
+	for (idx_t i = 0; i < join.conditions.size(); i++) {
+		auto &condition = join.conditions[i];
+		auto stats_left = PropagateExpression(condition.left);
+		auto stats_right = PropagateExpression(condition.right);
+		if (stats_left && stats_right) {
+			if ((condition.comparison == ExpressionType::COMPARE_DISTINCT_FROM ||
+			     condition.comparison == ExpressionType::COMPARE_NOT_DISTINCT_FROM) &&
+			    stats_left->CanHaveNull() && stats_right->CanHaveNull()) {
+				// null values are equal in this join, and both sides can have null values
+				// nothing to do here
+				continue;
+			}
+			auto prune_result = PropagateComparison(*stats_left, *stats_right, condition.comparison);
+			// Add stats to logical_join for perfect hash join
+			join.join_stats.push_back(move(stats_left));
+			join.join_stats.push_back(move(stats_right));
+			switch (prune_result) {
+			case FilterPropagateResult::FILTER_FALSE_OR_NULL:
+			case FilterPropagateResult::FILTER_ALWAYS_FALSE:
+				// filter is always false or null, none of the join conditions matter
+				switch (join.join_type) {
+				case JoinType::SEMI:
+				case JoinType::INNER:
+					// semi or inner join on false; entire node can be pruned
+					ReplaceWithEmptyResult(*node_ptr);
+					return;
+				case JoinType::ANTI:
+					// anti join: replace entire join with LHS
+					*node_ptr = move(join.children[0]);
+					return;
+				case JoinType::LEFT:
+					// anti/left outer join: replace right side with empty node
+					ReplaceWithEmptyResult(join.children[1]);
+					return;
+				case JoinType::RIGHT:
+					// right outer join: replace left side with empty node
+					ReplaceWithEmptyResult(join.children[0]);
+					return;
+				default:
+					// other join types: can't do much meaningful with this information
+					// full outer join requires both sides anyway; we can skip the execution of the actual join, but eh
+					// mark/single join requires knowing if the rhs has null values or not
+					break;
+				}
+				break;
+			case FilterPropagateResult::FILTER_ALWAYS_TRUE:
+				// filter is always true
+				if (join.conditions.size() > 1) {
+					// there are multiple conditions: erase this condition
+					join.conditions.erase(join.conditions.begin() + i);
+					// remove the corresponding statistics
+					join.join_stats.clear();
+					i--;
+					continue;
+				} else {
+					// this is the only condition and it is always true: all conditions are true
+					switch (join.join_type) {
+					case JoinType::SEMI:
+						// semi join on true: replace entire join with LHS
+						*node_ptr = move(join.children[0]);
+						return;
+					case JoinType::INNER:
+					case JoinType::LEFT:
+					case JoinType::RIGHT:
+					case JoinType::OUTER: {
+						// inner/left/right/full outer join, replace with cross product
+						// since the condition is always true, left/right/outer join are equivalent to inner join here
+						auto cross_product = make_unique<LogicalCrossProduct>();
+						cross_product->children = move(join.children);
+						*node_ptr = move(cross_product);
+						return;
+					}
+					case JoinType::ANTI:
+						// anti join on true: empty result
+						ReplaceWithEmptyResult(*node_ptr);
+						return;
+					default:
+						// we don't handle mark/single join here yet
+						break;
+					}
+				}
+				break;
+			default:
+				break;
+			}
+		}
+		// after we have propagated, we can update the statistics on both sides
+		// note that it is fine to do this now, even if the same column is used again later
+		// e.g. if we have i=j AND i=k, and the stats for j and k are disjoint, we know there are no results
+		// so if we have e.g. i: [0, 100], j: [0, 25], k: [75, 100]
+		// we can set i: [0, 25] after the first comparison, and statically determine that the second comparison is fals
+
+		// note that we can't update statistics the same for all join types
+		// mark and single joins don't filter any tuples -> so there is no propagation possible
+		// anti joins have inverse statistics propagation
+		// (i.e. if we have an anti join on i: [0, 100] and j: [0, 25], the resulting stats are i:[25,100])
+		// for now we don't handle anti joins
+		if (condition.comparison == ExpressionType::COMPARE_DISTINCT_FROM ||
+		    condition.comparison == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+			// skip update when null values are equal (for now?)
+			continue;
+		}
+		switch (join.join_type) {
+		case JoinType::INNER:
+		case JoinType::SEMI: {
+			UpdateFilterStatistics(*condition.left, *condition.right, condition.comparison);
+			auto stats_left = PropagateExpression(condition.left);
+			auto stats_right = PropagateExpression(condition.right);
+			// Update join_stats when is already part of the join
+			if (join.join_stats.size() == 2) {
+				join.join_stats[0] = move(stats_left);
+				join.join_stats[1] = move(stats_right);
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+}
+
+void StatisticsPropagator::PropagateStatistics(LogicalAnyJoin &join, unique_ptr<LogicalOperator> *node_ptr) {
+	// propagate the expression into the join condition
+	PropagateExpression(join.condition);
+}
+
+void StatisticsPropagator::MultiplyCardinalities(unique_ptr<NodeStatistics> &stats, NodeStatistics &new_stats) {
+	if (!stats->has_estimated_cardinality || !new_stats.has_estimated_cardinality || !stats->has_max_cardinality ||
+	    !new_stats.has_max_cardinality) {
+		stats = nullptr;
+		return;
+	}
+	stats->estimated_cardinality = MaxValue<idx_t>(stats->estimated_cardinality, new_stats.estimated_cardinality);
+	auto new_max = Hugeint::Multiply(stats->max_cardinality, new_stats.max_cardinality);
+	if (new_max < NumericLimits<int64_t>::Maximum()) {
+		int64_t result;
+		if (!Hugeint::TryCast<int64_t>(new_max, result)) {
+			throw InternalException("Overflow in cast in statistics propagation");
+		}
+		D_ASSERT(result >= 0);
+		stats->max_cardinality = idx_t(result);
+	} else {
+		stats = nullptr;
+	}
+}
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalJoin &join,
+                                                                     unique_ptr<LogicalOperator> *node_ptr) {
+	// first propagate through the children of the join
+	node_stats = PropagateStatistics(join.children[0]);
+	for (idx_t child_idx = 1; child_idx < join.children.size(); child_idx++) {
+		auto child_stats = PropagateStatistics(join.children[child_idx]);
+		if (!child_stats) {
+			node_stats = nullptr;
+		} else if (node_stats) {
+			MultiplyCardinalities(node_stats, *child_stats);
+		}
+	}
+
+	auto join_type = join.join_type;
+	// depending on the join type, we might need to alter the statistics
+	// LEFT, FULL, RIGHT OUTER and SINGLE joins can introduce null values
+	// this requires us to alter the statistics after this point in the query plan
+	bool adds_null_on_left = IsRightOuterJoin(join_type);
+	bool adds_null_on_right = IsLeftOuterJoin(join_type) || join_type == JoinType::SINGLE;
+
+	vector<ColumnBinding> left_bindings, right_bindings;
+	if (adds_null_on_left) {
+		left_bindings = join.children[0]->GetColumnBindings();
+	}
+	if (adds_null_on_right) {
+		right_bindings = join.children[1]->GetColumnBindings();
+	}
+
+	// then propagate into the join conditions
+	switch (join.type) {
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+		PropagateStatistics((LogicalComparisonJoin &)join, node_ptr);
+		break;
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+		PropagateStatistics((LogicalAnyJoin &)join, node_ptr);
+		break;
+	default:
+		break;
+	}
+
+	if (adds_null_on_right) {
+		// left or full outer join: set IsNull() to true for all rhs statistics
+		for (auto &binding : right_bindings) {
+			auto stats = statistics_map.find(binding);
+			if (stats != statistics_map.end()) {
+				stats->second->validity_stats = make_unique<ValidityStatistics>(true);
+			}
+		}
+	}
+	if (adds_null_on_left) {
+		// right or full outer join: set IsNull() to true for all lhs statistics
+		for (auto &binding : left_bindings) {
+			auto stats = statistics_map.find(binding);
+			if (stats != statistics_map.end()) {
+				stats->second->validity_stats = make_unique<ValidityStatistics>(true);
+			}
+		}
+	}
+	return move(node_stats);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalLimit &limit,
+                                                                     unique_ptr<LogicalOperator> *node_ptr) {
+	// propagate statistics in the child node
+	PropagateStatistics(limit.children[0]);
+	// return the node stats, with as expected cardinality the amount specified in the limit
+	return make_unique<NodeStatistics>(limit.limit_val, limit.limit_val);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalOrder &order,
+                                                                     unique_ptr<LogicalOperator> *node_ptr) {
+	// first propagate to the child
+	node_stats = PropagateStatistics(order.children[0]);
+
+	// then propagate to each of the order expressions
+	for (auto &bound_order : order.orders) {
+		PropagateAndCompress(bound_order.expression, bound_order.stats);
+	}
+	return move(node_stats);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalProjection &proj,
+                                                                     unique_ptr<LogicalOperator> *node_ptr) {
+	// first propagate to the child
+	node_stats = PropagateStatistics(proj.children[0]);
+	if (proj.children[0]->type == LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
+		ReplaceWithEmptyResult(*node_ptr);
+		return move(node_stats);
+	}
+
+	// then propagate to each of the expressions
+	for (idx_t i = 0; i < proj.expressions.size(); i++) {
+		auto stats = PropagateExpression(proj.expressions[i]);
+		if (stats) {
+			ColumnBinding binding(proj.table_index, i);
+			statistics_map.insert(make_pair(binding, move(stats)));
+		}
+	}
+	return move(node_stats);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void StatisticsPropagator::AddCardinalities(unique_ptr<NodeStatistics> &stats, NodeStatistics &new_stats) {
+	if (!stats->has_estimated_cardinality || !new_stats.has_estimated_cardinality || !stats->has_max_cardinality ||
+	    !new_stats.has_max_cardinality) {
+		stats = nullptr;
+		return;
+	}
+	stats->estimated_cardinality += new_stats.estimated_cardinality;
+	auto new_max = Hugeint::Add(stats->max_cardinality, new_stats.max_cardinality);
+	if (new_max < NumericLimits<int64_t>::Maximum()) {
+		int64_t result;
+		if (!Hugeint::TryCast<int64_t>(new_max, result)) {
+			throw InternalException("Overflow in cast in statistics propagation");
+		}
+		D_ASSERT(result >= 0);
+		stats->max_cardinality = idx_t(result);
+	} else {
+		stats = nullptr;
+	}
+}
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalSetOperation &setop,
+                                                                     unique_ptr<LogicalOperator> *node_ptr) {
+	// first propagate statistics in the child nodes
+	auto left_stats = PropagateStatistics(setop.children[0]);
+	auto right_stats = PropagateStatistics(setop.children[1]);
+
+	// now fetch the column bindings on both sides
+	auto left_bindings = setop.children[0]->GetColumnBindings();
+	auto right_bindings = setop.children[1]->GetColumnBindings();
+
+	D_ASSERT(left_bindings.size() == right_bindings.size());
+	D_ASSERT(left_bindings.size() == setop.column_count);
+	for (idx_t i = 0; i < setop.column_count; i++) {
+		// for each column binding, we fetch the statistics from both the lhs and the rhs
+		auto left_entry = statistics_map.find(left_bindings[i]);
+		auto right_entry = statistics_map.find(right_bindings[i]);
+		if (left_entry == statistics_map.end() || right_entry == statistics_map.end()) {
+			// no statistics on one of the sides: can't propagate stats
+			continue;
+		}
+		unique_ptr<BaseStatistics> new_stats;
+		switch (setop.type) {
+		case LogicalOperatorType::LOGICAL_UNION:
+			// union: merge the stats of the LHS and RHS together
+			new_stats = left_entry->second->Copy();
+			new_stats->Merge(*right_entry->second);
+			break;
+		case LogicalOperatorType::LOGICAL_EXCEPT:
+			// except: use the stats of the LHS
+			new_stats = left_entry->second->Copy();
+			break;
+		case LogicalOperatorType::LOGICAL_INTERSECT:
+			// intersect: intersect the two stats
+			// FIXME: for now we just use the stats of the LHS, as this is correct
+			// however, the stats can be further refined to the minimal subset of the LHS and RHS
+			new_stats = left_entry->second->Copy();
+			break;
+		default:
+			throw InternalException("Unsupported setop type");
+		}
+		ColumnBinding binding(setop.table_index, i);
+		statistics_map[binding] = move(new_stats);
+	}
+	if (!left_stats || !right_stats) {
+		return nullptr;
+	}
+	if (setop.type == LogicalOperatorType::LOGICAL_UNION) {
+		AddCardinalities(left_stats, *right_stats);
+	}
+	return left_stats;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalWindow &window,
+                                                                     unique_ptr<LogicalOperator> *node_ptr) {
+	// first propagate to the child
+	node_stats = PropagateStatistics(window.children[0]);
+
+	// then propagate to each of the order expressions
+	for (auto &window_expr : window.expressions) {
+		auto over_expr = reinterpret_cast<BoundWindowExpression *>(window_expr.get());
+		for (auto &expr : over_expr->partitions) {
+			over_expr->partitions_stats.push_back(PropagateExpression(expr));
+		}
+		for (auto &bound_order : over_expr->orders) {
+			bound_order.stats = PropagateExpression(bound_order.expression);
+		}
+	}
+	return move(node_stats);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+StatisticsPropagator::StatisticsPropagator(ClientContext &context) : context(context) {
+}
+
+void StatisticsPropagator::ReplaceWithEmptyResult(unique_ptr<LogicalOperator> &node) {
+	node = make_unique<LogicalEmptyResult>(move(node));
+}
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateChildren(LogicalOperator &node,
+                                                                   unique_ptr<LogicalOperator> *node_ptr) {
+	for (idx_t child_idx = 0; child_idx < node.children.size(); child_idx++) {
+		PropagateStatistics(node.children[child_idx]);
+	}
+	return nullptr;
+}
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(LogicalOperator &node,
+                                                                     unique_ptr<LogicalOperator> *node_ptr) {
+	switch (node.type) {
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+		return PropagateStatistics((LogicalAggregate &)node, node_ptr);
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+		return PropagateStatistics((LogicalCrossProduct &)node, node_ptr);
+	case LogicalOperatorType::LOGICAL_FILTER:
+		return PropagateStatistics((LogicalFilter &)node, node_ptr);
+	case LogicalOperatorType::LOGICAL_GET:
+		return PropagateStatistics((LogicalGet &)node, node_ptr);
+	case LogicalOperatorType::LOGICAL_PROJECTION:
+		return PropagateStatistics((LogicalProjection &)node, node_ptr);
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+	case LogicalOperatorType::LOGICAL_JOIN:
+		return PropagateStatistics((LogicalJoin &)node, node_ptr);
+	case LogicalOperatorType::LOGICAL_UNION:
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+	case LogicalOperatorType::LOGICAL_INTERSECT:
+		return PropagateStatistics((LogicalSetOperation &)node, node_ptr);
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+		return PropagateStatistics((LogicalOrder &)node, node_ptr);
+	case LogicalOperatorType::LOGICAL_WINDOW:
+		return PropagateStatistics((LogicalWindow &)node, node_ptr);
+	default:
+		return PropagateChildren(node, node_ptr);
+	}
+}
+
+unique_ptr<NodeStatistics> StatisticsPropagator::PropagateStatistics(unique_ptr<LogicalOperator> &node_ptr) {
+	return PropagateStatistics(*node_ptr, &node_ptr);
+}
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(Expression &expr,
+                                                                     unique_ptr<Expression> *expr_ptr) {
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::BOUND_AGGREGATE:
+		return PropagateExpression((BoundAggregateExpression &)expr, expr_ptr);
+	case ExpressionClass::BOUND_BETWEEN:
+		return PropagateExpression((BoundBetweenExpression &)expr, expr_ptr);
+	case ExpressionClass::BOUND_CASE:
+		return PropagateExpression((BoundCaseExpression &)expr, expr_ptr);
+	case ExpressionClass::BOUND_CONJUNCTION:
+		return PropagateExpression((BoundConjunctionExpression &)expr, expr_ptr);
+	case ExpressionClass::BOUND_FUNCTION:
+		return PropagateExpression((BoundFunctionExpression &)expr, expr_ptr);
+	case ExpressionClass::BOUND_CAST:
+		return PropagateExpression((BoundCastExpression &)expr, expr_ptr);
+	case ExpressionClass::BOUND_COMPARISON:
+		return PropagateExpression((BoundComparisonExpression &)expr, expr_ptr);
+	case ExpressionClass::BOUND_CONSTANT:
+		return PropagateExpression((BoundConstantExpression &)expr, expr_ptr);
+	case ExpressionClass::BOUND_COLUMN_REF:
+		return PropagateExpression((BoundColumnRefExpression &)expr, expr_ptr);
+	case ExpressionClass::BOUND_OPERATOR:
+		return PropagateExpression((BoundOperatorExpression &)expr, expr_ptr);
+	default:
+		break;
+	}
+	ExpressionIterator::EnumerateChildren(expr, [&](unique_ptr<Expression> &child) { PropagateExpression(child); });
+	return nullptr;
+}
+
+unique_ptr<BaseStatistics> StatisticsPropagator::PropagateExpression(unique_ptr<Expression> &expr) {
+	auto stats = PropagateExpression(*expr, &expr);
+	if (ClientConfig::GetConfig(context).query_verification_enabled && stats) {
+		expr->verification_stats = stats->Copy();
+	}
+	return stats;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> TopN::Optimize(unique_ptr<LogicalOperator> op) {
+	if (op->type == LogicalOperatorType::LOGICAL_LIMIT &&
+	    op->children[0]->type == LogicalOperatorType::LOGICAL_ORDER_BY) {
+		auto &limit = (LogicalLimit &)*op;
+		auto &order_by = (LogicalOrder &)*(op->children[0]);
+
+		// This optimization doesn't apply when OFFSET is present without LIMIT
+		// Or if offset is not constant
+		if (limit.limit_val != NumericLimits<int64_t>::Maximum() || limit.offset) {
+			auto topn = make_unique<LogicalTopN>(move(order_by.orders), limit.limit_val, limit.offset_val);
+			topn->AddChild(move(order_by.children[0]));
+			op = move(topn);
+		}
+	} else {
+		for (auto &child : op->children) {
+			child = Optimize(move(child));
+		}
+	}
+	return op;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+Event::Event(Executor &executor_p)
+    : executor(executor_p), finished_tasks(0), total_tasks(0), finished_dependencies(0), total_dependencies(0),
+      finished(false) {
+}
+
+void Event::CompleteDependency() {
+	idx_t current_finished = ++finished_dependencies;
+	D_ASSERT(current_finished <= total_dependencies);
+	if (current_finished == total_dependencies) {
+		// all dependencies have been completed: schedule the event
+		D_ASSERT(total_tasks == 0);
+		Schedule();
+		if (total_tasks == 0) {
+			Finish();
+		}
+	}
+}
+
+void Event::Finish() {
+	D_ASSERT(!finished);
+	FinishEvent();
+	finished = true;
+	// finished processing the pipeline, now we can schedule pipelines that depend on this pipeline
+	for (auto &parent_entry : parents) {
+		auto parent = parent_entry.lock();
+		if (!parent) { // LCOV_EXCL_START
+			continue;
+		} // LCOV_EXCL_STOP
+		// mark a dependency as completed for each of the parents
+		parent->CompleteDependency();
+	}
+	FinalizeFinish();
+}
+
+void Event::AddDependency(Event &event) {
+	total_dependencies++;
+	event.parents.push_back(weak_ptr<Event>(shared_from_this()));
+}
+
+void Event::FinishTask() {
+	D_ASSERT(finished_tasks.load() < total_tasks.load());
+	idx_t current_tasks = total_tasks;
+	idx_t current_finished = ++finished_tasks;
+	D_ASSERT(current_finished <= current_tasks);
+	if (current_finished == current_tasks) {
+		Finish();
+	}
+}
+
+void Event::InsertEvent(shared_ptr<Event> replacement_event) {
+	replacement_event->parents = move(parents);
+	replacement_event->AddDependency(*this);
+	executor.AddEvent(move(replacement_event));
+}
+
+void Event::SetTasks(vector<unique_ptr<Task>> tasks) {
+	auto &ts = TaskScheduler::GetScheduler(executor.context);
+	D_ASSERT(total_tasks == 0);
+	D_ASSERT(!tasks.empty());
+	this->total_tasks = tasks.size();
+	for (auto &task : tasks) {
+		ts.ScheduleTask(executor.GetToken(), move(task));
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+Executor::Executor(ClientContext &context) : context(context) {
+}
+
+Executor::~Executor() {
+}
+
+Executor &Executor::Get(ClientContext &context) {
+	return context.GetExecutor();
+}
+
+void Executor::AddEvent(shared_ptr<Event> event) {
+	lock_guard<mutex> elock(executor_lock);
+	events.push_back(move(event));
+}
+
+struct PipelineEventStack {
+	Event *pipeline_event;
+	Event *pipeline_finish_event;
+	Event *pipeline_complete_event;
+};
+
+Pipeline *Executor::ScheduleUnionPipeline(const shared_ptr<Pipeline> &pipeline, const Pipeline *parent,
+                                          event_map_t &event_map, vector<shared_ptr<Event>> &events) {
+	pipeline->Ready();
+
+	D_ASSERT(pipeline);
+	auto pipeline_event = make_shared<PipelineEvent>(pipeline);
+
+	auto parent_stack_entry = event_map.find(parent);
+	D_ASSERT(parent_stack_entry != event_map.end());
+
+	auto &parent_stack = parent_stack_entry->second;
+
+	PipelineEventStack stack;
+	stack.pipeline_event = pipeline_event.get();
+	stack.pipeline_finish_event = parent_stack.pipeline_finish_event;
+	stack.pipeline_complete_event = parent_stack.pipeline_complete_event;
+
+	stack.pipeline_event->AddDependency(*parent_stack.pipeline_event);
+	parent_stack.pipeline_finish_event->AddDependency(*pipeline_event);
+
+	events.push_back(move(pipeline_event));
+	event_map.insert(make_pair(pipeline.get(), stack));
+
+	auto parent_pipeline = pipeline.get();
+
+	auto union_entry = union_pipelines.find(pipeline.get());
+	if (union_entry != union_pipelines.end()) {
+		for (auto &entry : union_entry->second) {
+			parent_pipeline = ScheduleUnionPipeline(entry, parent_pipeline, event_map, events);
+		}
+	}
+
+	return parent_pipeline;
+}
+
+void Executor::ScheduleChildPipeline(Pipeline *parent, const shared_ptr<Pipeline> &pipeline, event_map_t &event_map,
+                                     vector<shared_ptr<Event>> &events) {
+	pipeline->Ready();
+
+	auto child_ptr = pipeline.get();
+	auto dependencies = child_dependencies.find(child_ptr);
+	D_ASSERT(union_pipelines.find(child_ptr) == union_pipelines.end());
+	D_ASSERT(dependencies != child_dependencies.end());
+	// create the pipeline event and the event stack
+	auto pipeline_event = make_shared<PipelineEvent>(pipeline);
+
+	auto parent_entry = event_map.find(parent);
+	PipelineEventStack stack;
+	stack.pipeline_event = pipeline_event.get();
+	stack.pipeline_finish_event = parent_entry->second.pipeline_finish_event;
+	stack.pipeline_complete_event = parent_entry->second.pipeline_complete_event;
+
+	// set up the dependencies for this child pipeline
+	unordered_set<Event *> finish_events;
+	for (auto &dep : dependencies->second) {
+		auto dep_entry = event_map.find(dep);
+		D_ASSERT(dep_entry != event_map.end());
+		D_ASSERT(dep_entry->second.pipeline_event);
+		D_ASSERT(dep_entry->second.pipeline_finish_event);
+
+		auto finish_event = dep_entry->second.pipeline_finish_event;
+		stack.pipeline_event->AddDependency(*dep_entry->second.pipeline_event);
+		if (finish_events.find(finish_event) == finish_events.end()) {
+			finish_event->AddDependency(*stack.pipeline_event);
+			finish_events.insert(finish_event);
+		}
+	}
+
+	events.push_back(move(pipeline_event));
+	event_map.insert(make_pair(child_ptr, stack));
+}
+
+void Executor::SchedulePipeline(const shared_ptr<Pipeline> &pipeline, event_map_t &event_map,
+                                vector<shared_ptr<Event>> &events, bool complete_pipeline) {
+	D_ASSERT(pipeline);
+
+	pipeline->Ready();
+
+	auto pipeline_event = make_shared<PipelineEvent>(pipeline);
+	auto pipeline_finish_event = make_shared<PipelineFinishEvent>(pipeline);
+	auto pipeline_complete_event = make_shared<PipelineCompleteEvent>(pipeline->executor, complete_pipeline);
+
+	PipelineEventStack stack;
+	stack.pipeline_event = pipeline_event.get();
+	stack.pipeline_finish_event = pipeline_finish_event.get();
+	stack.pipeline_complete_event = pipeline_complete_event.get();
+
+	pipeline_finish_event->AddDependency(*pipeline_event);
+	pipeline_complete_event->AddDependency(*pipeline_finish_event);
+
+	events.push_back(move(pipeline_event));
+	events.push_back(move(pipeline_finish_event));
+	events.push_back(move(pipeline_complete_event));
+
+	event_map.insert(make_pair(pipeline.get(), stack));
+
+	auto union_entry = union_pipelines.find(pipeline.get());
+	if (union_entry != union_pipelines.end()) {
+		auto parent_pipeline = pipeline.get();
+		for (auto &entry : union_entry->second) {
+			parent_pipeline = ScheduleUnionPipeline(entry, parent_pipeline, event_map, events);
+		}
+	}
+}
+
+void Executor::ScheduleEventsInternal(const vector<shared_ptr<Pipeline>> &pipelines,
+                                      unordered_map<Pipeline *, vector<shared_ptr<Pipeline>>> &child_pipelines,
+                                      vector<shared_ptr<Event>> &events, bool main_schedule) {
+	D_ASSERT(events.empty());
+	// create all the required pipeline events
+	event_map_t event_map;
+	for (auto &pipeline : pipelines) {
+		SchedulePipeline(pipeline, event_map, events, main_schedule);
+	}
+	// schedule child pipelines
+	for (auto &entry : child_pipelines) {
+		// iterate in reverse order
+		// since child entries are added from top to bottom
+		// dependencies are in reverse order (bottom to top)
+		for (idx_t i = entry.second.size(); i > 0; i--) {
+			auto &child_entry = entry.second[i - 1];
+			ScheduleChildPipeline(entry.first, child_entry, event_map, events);
+		}
+	}
+	// set up the dependencies between pipeline events
+	for (auto &entry : event_map) {
+		auto pipeline = entry.first;
+		for (auto &dependency : pipeline->dependencies) {
+			auto dep = dependency.lock();
+			D_ASSERT(dep);
+			auto event_map_entry = event_map.find(dep.get());
+			D_ASSERT(event_map_entry != event_map.end());
+			auto &dep_entry = event_map_entry->second;
+			D_ASSERT(dep_entry.pipeline_complete_event);
+			entry.second.pipeline_event->AddDependency(*dep_entry.pipeline_complete_event);
+		}
+	}
+	// schedule the pipelines that do not have dependencies
+	for (auto &event : events) {
+		if (!event->HasDependencies()) {
+			event->Schedule();
+		}
+	}
+}
+
+void Executor::ScheduleEvents() {
+	ScheduleEventsInternal(pipelines, child_pipelines, events);
+}
+
+void Executor::ReschedulePipelines(const vector<shared_ptr<Pipeline>> &pipelines, vector<shared_ptr<Event>> &events) {
+	unordered_map<Pipeline *, vector<shared_ptr<Pipeline>>> child_pipelines;
+	ScheduleEventsInternal(pipelines, child_pipelines, events, false);
+}
+
+void Executor::ExtractPipelines(shared_ptr<Pipeline> &pipeline, vector<shared_ptr<Pipeline>> &result) {
+	pipeline->Ready();
+
+	auto pipeline_ptr = pipeline.get();
+	result.push_back(move(pipeline));
+	auto union_entry = union_pipelines.find(pipeline_ptr);
+	if (union_entry != union_pipelines.end()) {
+		auto &union_pipeline_list = union_entry->second;
+		for (auto &pipeline : union_pipeline_list) {
+			ExtractPipelines(pipeline, result);
+		}
+		union_pipelines.erase(pipeline_ptr);
+	}
+	auto child_entry = child_pipelines.find(pipeline_ptr);
+	if (child_entry != child_pipelines.end()) {
+		for (auto &entry : child_entry->second) {
+			ExtractPipelines(entry, result);
+		}
+		child_pipelines.erase(pipeline_ptr);
+	}
+}
+
+bool Executor::NextExecutor() {
+	if (root_pipeline_idx >= root_pipelines.size()) {
+		return false;
+	}
+	root_executor = make_unique<PipelineExecutor>(context, *root_pipelines[root_pipeline_idx]);
+	root_pipeline_idx++;
+	return true;
+}
+
+void Executor::VerifyPipeline(Pipeline &pipeline) {
+	D_ASSERT(!pipeline.ToString().empty());
+	auto operators = pipeline.GetOperators();
+	for (auto &other_pipeline : pipelines) {
+		auto other_operators = other_pipeline->GetOperators();
+		for (idx_t op_idx = 0; op_idx < operators.size(); op_idx++) {
+			for (idx_t other_idx = 0; other_idx < other_operators.size(); other_idx++) {
+				auto &left = *operators[op_idx];
+				auto &right = *other_operators[other_idx];
+				if (left.Equals(right)) {
+					D_ASSERT(right.Equals(left));
+				} else {
+					D_ASSERT(!right.Equals(left));
+				}
+			}
+		}
+	}
+}
+
+void Executor::VerifyPipelines() {
+#ifdef DEBUG
+	for (auto &pipeline : pipelines) {
+		VerifyPipeline(*pipeline);
+	}
+	for (auto &pipeline : root_pipelines) {
+		VerifyPipeline(*pipeline);
+	}
+#endif
+}
+
+void Executor::Initialize(unique_ptr<PhysicalOperator> physical_plan) {
+	Reset();
+	owned_plan = move(physical_plan);
+	InitializeInternal(owned_plan.get());
+}
+
+void Executor::Initialize(PhysicalOperator *plan) {
+	Reset();
+	InitializeInternal(plan);
+}
+
+void Executor::InitializeInternal(PhysicalOperator *plan) {
+
+	auto &scheduler = TaskScheduler::GetScheduler(context);
+	{
+		lock_guard<mutex> elock(executor_lock);
+		physical_plan = plan;
+
+		this->profiler = ClientData::Get(context).profiler;
+		profiler->Initialize(physical_plan);
+		this->producer = scheduler.CreateProducer();
+
+		auto root_pipeline = make_shared<Pipeline>(*this);
+		root_pipeline->sink = nullptr;
+
+		PipelineBuildState state;
+		physical_plan->BuildPipelines(*this, *root_pipeline, state);
+
+		this->total_pipelines = pipelines.size();
+
+		root_pipeline_idx = 0;
+		ExtractPipelines(root_pipeline, root_pipelines);
+
+		VerifyPipelines();
+
+		ScheduleEvents();
+	}
+}
+
+void Executor::CancelTasks() {
+	task.reset();
+	// we do this by creating weak pointers to all pipelines
+	// then clearing our references to the pipelines
+	// and waiting until all pipelines have been destroyed
+	vector<weak_ptr<Pipeline>> weak_references;
+	{
+		lock_guard<mutex> elock(executor_lock);
+		weak_references.reserve(pipelines.size());
+		for (auto &pipeline : pipelines) {
+			weak_references.push_back(weak_ptr<Pipeline>(pipeline));
+		}
+		for (auto &kv : union_pipelines) {
+			for (auto &pipeline : kv.second) {
+				weak_references.push_back(weak_ptr<Pipeline>(pipeline));
+			}
+		}
+		for (auto &kv : child_pipelines) {
+			for (auto &pipeline : kv.second) {
+				weak_references.push_back(weak_ptr<Pipeline>(pipeline));
+			}
+		}
+		pipelines.clear();
+		union_pipelines.clear();
+		child_pipelines.clear();
+		events.clear();
+	}
+	WorkOnTasks();
+	for (auto &weak_ref : weak_references) {
+		while (true) {
+			auto weak = weak_ref.lock();
+			if (!weak) {
+				break;
+			}
+		}
+	}
+}
+
+void Executor::WorkOnTasks() {
+	auto &scheduler = TaskScheduler::GetScheduler(context);
+
+	unique_ptr<Task> task;
+	while (scheduler.GetTaskFromProducer(*producer, task)) {
+		task->Execute(TaskExecutionMode::PROCESS_ALL);
+		task.reset();
+	}
+}
+
+PendingExecutionResult Executor::ExecuteTask() {
+	if (execution_result != PendingExecutionResult::RESULT_NOT_READY) {
+		return execution_result;
+	}
+	// check if there are any incomplete pipelines
+	auto &scheduler = TaskScheduler::GetScheduler(context);
+	while (completed_pipelines < total_pipelines) {
+		// there are! if we don't already have a task, fetch one
+		if (!task) {
+			scheduler.GetTaskFromProducer(*producer, task);
+		}
+		if (task) {
+			// if we have a task, partially process it
+			auto result = task->Execute(TaskExecutionMode::PROCESS_PARTIAL);
+			if (result != TaskExecutionResult::TASK_NOT_FINISHED) {
+				// if the task is finished, clean it up
+				task.reset();
+			}
+		}
+		if (!HasError()) {
+			// we (partially) processed a task and no exceptions were thrown
+			// give back control to the caller
+			return PendingExecutionResult::RESULT_NOT_READY;
+		}
+		execution_result = PendingExecutionResult::EXECUTION_ERROR;
+
+		// an exception has occurred executing one of the pipelines
+		// we need to cancel all tasks associated with this executor
+		CancelTasks();
+		ThrowException();
+	}
+	D_ASSERT(!task);
+
+	lock_guard<mutex> elock(executor_lock);
+	pipelines.clear();
+	NextExecutor();
+	if (!exceptions.empty()) { // LCOV_EXCL_START
+		// an exception has occurred executing one of the pipelines
+		execution_result = PendingExecutionResult::EXECUTION_ERROR;
+		ThrowExceptionInternal();
+	} // LCOV_EXCL_STOP
+	execution_result = PendingExecutionResult::RESULT_READY;
+	return execution_result;
+}
+
+void Executor::Reset() {
+	lock_guard<mutex> elock(executor_lock);
+	physical_plan = nullptr;
+	owned_plan.reset();
+	root_executor.reset();
+	root_pipelines.clear();
+	root_pipeline_idx = 0;
+	completed_pipelines = 0;
+	total_pipelines = 0;
+	exceptions.clear();
+	pipelines.clear();
+	events.clear();
+	union_pipelines.clear();
+	child_pipelines.clear();
+	child_dependencies.clear();
+	execution_result = PendingExecutionResult::RESULT_NOT_READY;
+}
+
+void Executor::AddChildPipeline(Pipeline *current) {
+	D_ASSERT(!current->operators.empty());
+	// found another operator that is a source
+	// schedule a child pipeline
+	auto child_pipeline = make_shared<Pipeline>(*this);
+	auto child_pipeline_ptr = child_pipeline.get();
+	child_pipeline->sink = current->sink;
+	child_pipeline->operators = current->operators;
+	child_pipeline->source = current->operators.back();
+	D_ASSERT(child_pipeline->source->IsSource());
+	child_pipeline->operators.pop_back();
+
+	vector<Pipeline *> dependencies;
+	dependencies.push_back(current);
+	auto child_entry = child_pipelines.find(current);
+	if (child_entry != child_pipelines.end()) {
+		for (auto &current_child : child_entry->second) {
+			D_ASSERT(child_dependencies.find(current_child.get()) != child_dependencies.end());
+			child_dependencies[current_child.get()].push_back(child_pipeline_ptr);
+		}
+	}
+	D_ASSERT(child_dependencies.find(child_pipeline_ptr) == child_dependencies.end());
+	child_dependencies.insert(make_pair(child_pipeline_ptr, move(dependencies)));
+	child_pipelines[current].push_back(move(child_pipeline));
+}
+
+vector<LogicalType> Executor::GetTypes() {
+	D_ASSERT(physical_plan);
+	return physical_plan->GetTypes();
+}
+
+void Executor::PushError(ExceptionType type, const string &exception) {
+	lock_guard<mutex> elock(executor_lock);
+	// interrupt execution of any other pipelines that belong to this executor
+	context.interrupted = true;
+	// push the exception onto the stack
+	exceptions.emplace_back(type, exception);
+}
+
+bool Executor::HasError() {
+	lock_guard<mutex> elock(executor_lock);
+	return !exceptions.empty();
+}
+
+void Executor::ThrowException() {
+	lock_guard<mutex> elock(executor_lock);
+	ThrowExceptionInternal();
+}
+
+void Executor::ThrowExceptionInternal() { // LCOV_EXCL_START
+	D_ASSERT(!exceptions.empty());
+	auto &entry = exceptions[0];
+	switch (entry.first) {
+	case ExceptionType::TRANSACTION:
+		throw TransactionException(entry.second);
+	case ExceptionType::CATALOG:
+		throw CatalogException(entry.second);
+	case ExceptionType::PARSER:
+		throw ParserException(entry.second);
+	case ExceptionType::BINDER:
+		throw BinderException(entry.second);
+	case ExceptionType::INTERRUPT:
+		throw InterruptException();
+	case ExceptionType::FATAL:
+		throw FatalException(entry.second);
+	case ExceptionType::INTERNAL:
+		throw InternalException(entry.second);
+	case ExceptionType::IO:
+		throw IOException(entry.second);
+	case ExceptionType::CONSTRAINT:
+		throw ConstraintException(entry.second);
+	case ExceptionType::CONVERSION:
+		throw ConversionException(entry.second);
+	default:
+		throw Exception(entry.second);
+	}
+} // LCOV_EXCL_STOP
+
+void Executor::Flush(ThreadContext &tcontext) {
+	profiler->Flush(tcontext.profiler);
+}
+
+bool Executor::GetPipelinesProgress(double &current_progress) { // LCOV_EXCL_START
+	lock_guard<mutex> elock(executor_lock);
+
+	vector<double> progress;
+	vector<idx_t> cardinality;
+	idx_t total_cardinality = 0;
+	for (auto &pipeline : pipelines) {
+		double child_percentage;
+		idx_t child_cardinality;
+		if (!pipeline->GetProgress(child_percentage, child_cardinality)) {
+			return false;
+		}
+		progress.push_back(child_percentage);
+		cardinality.push_back(child_cardinality);
+		total_cardinality += child_cardinality;
+	}
+	current_progress = 0;
+	for (size_t i = 0; i < progress.size(); i++) {
+		current_progress += progress[i] * double(cardinality[i]) / double(total_cardinality);
+	}
+	return true;
+} // LCOV_EXCL_STOP
+
+bool Executor::HasResultCollector() {
+	return physical_plan->type == PhysicalOperatorType::RESULT_COLLECTOR;
+}
+
+unique_ptr<QueryResult> Executor::GetResult() {
+	D_ASSERT(HasResultCollector());
+	auto &result_collector = (PhysicalResultCollector &)*physical_plan;
+	D_ASSERT(result_collector.sink_state);
+	return result_collector.GetResult(*result_collector.sink_state);
+}
+
+unique_ptr<DataChunk> Executor::FetchChunk() {
+	D_ASSERT(physical_plan);
+
+	auto chunk = make_unique<DataChunk>();
+	root_executor->InitializeChunk(*chunk);
+	while (true) {
+		root_executor->ExecutePull(*chunk);
+		if (chunk->size() == 0) {
+			root_executor->PullFinalize();
+			if (NextExecutor()) {
+				continue;
+			}
+			break;
+		} else {
+			break;
+		}
+	}
+	return chunk;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+ExecutorTask::ExecutorTask(Executor &executor_p) : executor(executor_p) {
+}
+
+ExecutorTask::ExecutorTask(ClientContext &context) : ExecutorTask(Executor::Get(context)) {
+}
+
+ExecutorTask::~ExecutorTask() {
+}
+
+TaskExecutionResult ExecutorTask::Execute(TaskExecutionMode mode) {
+	try {
+		return ExecuteTask(mode);
+	} catch (Exception &ex) {
+		executor.PushError(ex.type, ex.what());
+	} catch (std::exception &ex) {
+		executor.PushError(ExceptionType::UNKNOWN_TYPE, ex.what());
+	} catch (...) { // LCOV_EXCL_START
+		executor.PushError(ExceptionType::UNKNOWN_TYPE, "Unknown exception in Finalize!");
+	} // LCOV_EXCL_STOP
+	return TaskExecutionResult::TASK_ERROR;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class PipelineTask : public ExecutorTask {
+	static constexpr const idx_t PARTIAL_CHUNK_COUNT = 50;
+
+public:
+	explicit PipelineTask(Pipeline &pipeline_p, shared_ptr<Event> event_p)
+	    : ExecutorTask(pipeline_p.executor), pipeline(pipeline_p), event(move(event_p)) {
+	}
+
+	Pipeline &pipeline;
+	shared_ptr<Event> event;
+	unique_ptr<PipelineExecutor> pipeline_executor;
+
+public:
+	TaskExecutionResult ExecuteTask(TaskExecutionMode mode) override {
+		if (!pipeline_executor) {
+			pipeline_executor = make_unique<PipelineExecutor>(pipeline.GetClientContext(), pipeline);
+		}
+		if (mode == TaskExecutionMode::PROCESS_PARTIAL) {
+			bool finished = pipeline_executor->Execute(PARTIAL_CHUNK_COUNT);
+			if (!finished) {
+				return TaskExecutionResult::TASK_NOT_FINISHED;
+			}
+		} else {
+			pipeline_executor->Execute();
+		}
+		event->FinishTask();
+		pipeline_executor.reset();
+		return TaskExecutionResult::TASK_FINISHED;
+	}
+};
+
+Pipeline::Pipeline(Executor &executor_p) : executor(executor_p), ready(false), source(nullptr), sink(nullptr) {
+}
+
+ClientContext &Pipeline::GetClientContext() {
+	return executor.context;
+}
+
+bool Pipeline::GetProgress(double &current_percentage, idx_t &source_cardinality) {
+	D_ASSERT(source);
+
+	auto &client = executor.context;
+	current_percentage = source->GetProgress(client, *source_state);
+	source_cardinality = source->estimated_cardinality;
+	return current_percentage >= 0;
+}
+
+void Pipeline::ScheduleSequentialTask(shared_ptr<Event> &event) {
+	vector<unique_ptr<Task>> tasks;
+	tasks.push_back(make_unique<PipelineTask>(*this, event));
+	event->SetTasks(move(tasks));
+}
+
+bool Pipeline::ScheduleParallel(shared_ptr<Event> &event) {
+	// check if the sink, source and all intermediate operators support parallelism
+	if (!sink->ParallelSink()) {
+		return false;
+	}
+	if (!source->ParallelSource()) {
+		return false;
+	}
+	for (auto &op : operators) {
+		if (!op->ParallelOperator()) {
+			return false;
+		}
+	}
+	if (sink->RequiresBatchIndex()) {
+		if (!source->SupportsBatchIndex()) {
+			throw InternalException(
+			    "Attempting to schedule a pipeline where the sink requires batch index but source does not support it");
+		}
+	}
+	idx_t max_threads = source_state->MaxThreads();
+	return LaunchScanTasks(event, max_threads);
+}
+
+bool Pipeline::IsOrderDependent() const {
+	auto &config = DBConfig::GetConfig(executor.context);
+	if (!config.preserve_insertion_order) {
+		return false;
+	}
+	if (sink && sink->IsOrderDependent()) {
+		return true;
+	}
+	if (source->IsOrderDependent()) {
+		return true;
+	}
+	for (auto &op : operators) {
+		if (op->IsOrderDependent()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void Pipeline::Schedule(shared_ptr<Event> &event) {
+	D_ASSERT(ready);
+	D_ASSERT(sink);
+	if (!ScheduleParallel(event)) {
+		// could not parallelize this pipeline: push a sequential task instead
+		ScheduleSequentialTask(event);
+	}
+}
+
+bool Pipeline::LaunchScanTasks(shared_ptr<Event> &event, idx_t max_threads) {
+	// split the scan up into parts and schedule the parts
+	auto &scheduler = TaskScheduler::GetScheduler(executor.context);
+	idx_t active_threads = scheduler.NumberOfThreads();
+	if (max_threads > active_threads) {
+		max_threads = active_threads;
+	}
+	if (max_threads <= 1) {
+		// too small to parallelize
+		return false;
+	}
+
+	// launch a task for every thread
+	vector<unique_ptr<Task>> tasks;
+	for (idx_t i = 0; i < max_threads; i++) {
+		tasks.push_back(make_unique<PipelineTask>(*this, event));
+	}
+	event->SetTasks(move(tasks));
+	return true;
+}
+
+void Pipeline::Reset() {
+	if (sink && !sink->sink_state) {
+		sink->sink_state = sink->GetGlobalSinkState(GetClientContext());
+	}
+
+	for (auto &op : operators) {
+		if (op && !op->op_state) {
+			op->op_state = op->GetGlobalOperatorState(GetClientContext());
+		}
+	}
+
+	ResetSource();
+}
+
+void Pipeline::ResetSource() {
+	source_state = source->GetGlobalSourceState(GetClientContext());
+}
+
+void Pipeline::Ready() {
+	if (ready) {
+		return;
+	}
+	ready = true;
+	std::reverse(operators.begin(), operators.end());
+	Reset();
+}
+
+void Pipeline::Finalize(Event &event) {
+	D_ASSERT(ready);
+	try {
+		auto sink_state = sink->Finalize(*this, event, executor.context, *sink->sink_state);
+		sink->sink_state->state = sink_state;
+	} catch (Exception &ex) { // LCOV_EXCL_START
+		executor.PushError(ex.type, ex.what());
+	} catch (std::exception &ex) {
+		executor.PushError(ExceptionType::UNKNOWN_TYPE, ex.what());
+	} catch (...) {
+		executor.PushError(ExceptionType::UNKNOWN_TYPE, "Unknown exception in Finalize!");
+	} // LCOV_EXCL_STOP
+}
+
+void Pipeline::AddDependency(shared_ptr<Pipeline> &pipeline) {
+	D_ASSERT(pipeline);
+	dependencies.push_back(weak_ptr<Pipeline>(pipeline));
+	pipeline->parents.push_back(weak_ptr<Pipeline>(shared_from_this()));
+}
+
+string Pipeline::ToString() const {
+	TreeRenderer renderer;
+	return renderer.ToString(*this);
+}
+
+void Pipeline::Print() const {
+	Printer::Print(ToString());
+}
+
+vector<PhysicalOperator *> Pipeline::GetOperators() const {
+	vector<PhysicalOperator *> result;
+	D_ASSERT(source);
+	result.push_back(source);
+	result.insert(result.end(), operators.begin(), operators.end());
+	if (sink) {
+		result.push_back(sink);
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// Pipeline Build State
+//===--------------------------------------------------------------------===//
+void PipelineBuildState::SetPipelineSource(Pipeline &pipeline, PhysicalOperator *op) {
+	pipeline.source = op;
+}
+
+void PipelineBuildState::SetPipelineSink(Pipeline &pipeline, PhysicalOperator *op) {
+	pipeline.sink = op;
+	// set the base batch index of this pipeline based on how many other pipelines have this node as their sink
+	pipeline.base_batch_index = BATCH_INCREMENT * sink_pipeline_count[op];
+	// increment the number of nodes that have this pipeline as their sink
+	sink_pipeline_count[op]++;
+}
+
+void PipelineBuildState::AddPipelineOperator(Pipeline &pipeline, PhysicalOperator *op) {
+	pipeline.operators.push_back(op);
+}
+
+void PipelineBuildState::AddPipeline(Executor &executor, shared_ptr<Pipeline> pipeline) {
+	executor.pipelines.push_back(move(pipeline));
+}
+
+PhysicalOperator *PipelineBuildState::GetPipelineSource(Pipeline &pipeline) {
+	return pipeline.source;
+}
+
+PhysicalOperator *PipelineBuildState::GetPipelineSink(Pipeline &pipeline) {
+	return pipeline.sink;
+}
+
+void PipelineBuildState::SetPipelineOperators(Pipeline &pipeline, vector<PhysicalOperator *> operators) {
+	pipeline.operators = move(operators);
+}
+
+void PipelineBuildState::AddChildPipeline(Executor &executor, Pipeline &pipeline) {
+	executor.AddChildPipeline(&pipeline);
+}
+
+unordered_map<Pipeline *, vector<shared_ptr<Pipeline>>> &PipelineBuildState::GetUnionPipelines(Executor &executor) {
+	return executor.union_pipelines;
+}
+unordered_map<Pipeline *, vector<shared_ptr<Pipeline>>> &PipelineBuildState::GetChildPipelines(Executor &executor) {
+	return executor.child_pipelines;
+}
+unordered_map<Pipeline *, vector<Pipeline *>> &PipelineBuildState::GetChildDependencies(Executor &executor) {
+	return executor.child_dependencies;
+}
+
+vector<PhysicalOperator *> PipelineBuildState::GetPipelineOperators(Pipeline &pipeline) {
+	return pipeline.operators;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PipelineCompleteEvent::PipelineCompleteEvent(Executor &executor, bool complete_pipeline_p)
+    : Event(executor), complete_pipeline(complete_pipeline_p) {
+}
+
+void PipelineCompleteEvent::Schedule() {
+}
+
+void PipelineCompleteEvent::FinalizeFinish() {
+	if (complete_pipeline) {
+		executor.CompletePipeline();
+	}
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+PipelineEvent::PipelineEvent(shared_ptr<Pipeline> pipeline_p)
+    : Event(pipeline_p->executor), pipeline(move(pipeline_p)) {
+}
+
+void PipelineEvent::Schedule() {
+	auto event = shared_from_this();
+	pipeline->Schedule(event);
+	D_ASSERT(total_tasks > 0);
+}
+
+void PipelineEvent::FinishEvent() {
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+PipelineExecutor::PipelineExecutor(ClientContext &context_p, Pipeline &pipeline_p)
+    : pipeline(pipeline_p), thread(context_p), context(context_p, thread) {
+	D_ASSERT(pipeline.source_state);
+	local_source_state = pipeline.source->GetLocalSourceState(context, *pipeline.source_state);
+	if (pipeline.sink) {
+		local_sink_state = pipeline.sink->GetLocalSinkState(context);
+		requires_batch_index = pipeline.sink->RequiresBatchIndex() && pipeline.source->SupportsBatchIndex();
+	}
+	bool can_cache_in_pipeline = pipeline.sink && !pipeline.IsOrderDependent() && !requires_batch_index;
+	intermediate_chunks.reserve(pipeline.operators.size());
+	intermediate_states.reserve(pipeline.operators.size());
+	cached_chunks.resize(pipeline.operators.size());
+	for (idx_t i = 0; i < pipeline.operators.size(); i++) {
+		auto prev_operator = i == 0 ? pipeline.source : pipeline.operators[i - 1];
+		auto current_operator = pipeline.operators[i];
+		auto chunk = make_unique<DataChunk>();
+		chunk->Initialize(prev_operator->GetTypes());
+		intermediate_chunks.push_back(move(chunk));
+		intermediate_states.push_back(current_operator->GetOperatorState(context.client));
+		if (can_cache_in_pipeline && current_operator->RequiresCache()) {
+			auto &cache_types = current_operator->GetTypes();
+			bool can_cache = true;
+			for (auto &type : cache_types) {
+				if (!CanCacheType(type)) {
+					can_cache = false;
+					break;
+				}
+			}
+			if (!can_cache) {
+				continue;
+			}
+			cached_chunks[i] = make_unique<DataChunk>();
+			cached_chunks[i]->Initialize(current_operator->GetTypes());
+		}
+		if (current_operator->IsSink() && current_operator->sink_state->state == SinkFinalizeType::NO_OUTPUT_POSSIBLE) {
+			// one of the operators has already figured out no output is possible
+			// we can skip executing the pipeline
+			FinishProcessing();
+		}
+	}
+	InitializeChunk(final_chunk);
+}
+
+bool PipelineExecutor::Execute(idx_t max_chunks) {
+	D_ASSERT(pipeline.sink);
+	bool exhausted_source = false;
+	auto &source_chunk = pipeline.operators.empty() ? final_chunk : *intermediate_chunks[0];
+	for (idx_t i = 0; i < max_chunks; i++) {
+		if (IsFinished()) {
+			break;
+		}
+		source_chunk.Reset();
+		FetchFromSource(source_chunk);
+		if (source_chunk.size() == 0) {
+			exhausted_source = true;
+			break;
+		}
+		auto result = ExecutePushInternal(source_chunk);
+		if (result == OperatorResultType::FINISHED) {
+			D_ASSERT(IsFinished());
+			break;
+		}
+	}
+	if (!exhausted_source && !IsFinished()) {
+		return false;
+	}
+	PushFinalize();
+	return true;
+}
+
+void PipelineExecutor::Execute() {
+	Execute(NumericLimits<idx_t>::Maximum());
+}
+
+OperatorResultType PipelineExecutor::ExecutePush(DataChunk &input) { // LCOV_EXCL_START
+	return ExecutePushInternal(input);
+} // LCOV_EXCL_STOP
+
+void PipelineExecutor::FinishProcessing(int32_t operator_idx) {
+	finished_processing_idx = operator_idx < 0 ? NumericLimits<int32_t>::Maximum() : operator_idx;
+	in_process_operators = stack<idx_t>();
+}
+
+bool PipelineExecutor::IsFinished() {
+	return finished_processing_idx >= 0;
+}
+
+OperatorResultType PipelineExecutor::ExecutePushInternal(DataChunk &input, idx_t initial_idx) {
+	D_ASSERT(pipeline.sink);
+	if (input.size() == 0) { // LCOV_EXCL_START
+		return OperatorResultType::NEED_MORE_INPUT;
+	} // LCOV_EXCL_STOP
+	while (true) {
+		OperatorResultType result;
+		if (!pipeline.operators.empty()) {
+			final_chunk.Reset();
+			result = Execute(input, final_chunk, initial_idx);
+			if (result == OperatorResultType::FINISHED) {
+				return OperatorResultType::FINISHED;
+			}
+		} else {
+			result = OperatorResultType::NEED_MORE_INPUT;
+		}
+		auto &sink_chunk = pipeline.operators.empty() ? input : final_chunk;
+		if (sink_chunk.size() > 0) {
+			StartOperator(pipeline.sink);
+			D_ASSERT(pipeline.sink);
+			D_ASSERT(pipeline.sink->sink_state);
+			auto sink_result = pipeline.sink->Sink(context, *pipeline.sink->sink_state, *local_sink_state, sink_chunk);
+			EndOperator(pipeline.sink, nullptr);
+			if (sink_result == SinkResultType::FINISHED) {
+				FinishProcessing();
+				return OperatorResultType::FINISHED;
+			}
+		}
+		if (result == OperatorResultType::NEED_MORE_INPUT) {
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+	}
+}
+
+void PipelineExecutor::PushFinalize() {
+	if (finalized) {
+		throw InternalException("Calling PushFinalize on a pipeline that has been finalized already");
+	}
+	finalized = true;
+	// flush all caches
+	// note that even if an operator has finished, we might still need to flush caches AFTER that operator
+	// e.g. if we have SOURCE -> LIMIT -> CROSS_PRODUCT -> SINK, if the LIMIT reports no more rows will be passed on
+	// we still need to flush caches from the CROSS_PRODUCT
+	D_ASSERT(in_process_operators.empty());
+	idx_t start_idx = IsFinished() ? idx_t(finished_processing_idx) : 0;
+	for (idx_t i = start_idx; i < cached_chunks.size(); i++) {
+		if (cached_chunks[i] && cached_chunks[i]->size() > 0) {
+			ExecutePushInternal(*cached_chunks[i], i + 1);
+			cached_chunks[i].reset();
+		}
+	}
+	D_ASSERT(local_sink_state);
+	// run the combine for the sink
+	pipeline.sink->Combine(context, *pipeline.sink->sink_state, *local_sink_state);
+
+	// flush all query profiler info
+	for (idx_t i = 0; i < intermediate_states.size(); i++) {
+		intermediate_states[i]->Finalize(pipeline.operators[i], context);
+	}
+	pipeline.executor.Flush(thread);
+	local_sink_state.reset();
+}
+
+bool PipelineExecutor::CanCacheType(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::LIST:
+	case LogicalTypeId::MAP:
+		return false;
+	case LogicalTypeId::STRUCT: {
+		auto &entries = StructType::GetChildTypes(type);
+		for (auto &entry : entries) {
+			if (!CanCacheType(entry.second)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	default:
+		return true;
+	}
+}
+
+void PipelineExecutor::CacheChunk(DataChunk &current_chunk, idx_t operator_idx) {
+#if STANDARD_VECTOR_SIZE >= 128
+	if (cached_chunks[operator_idx]) {
+		if (current_chunk.size() < CACHE_THRESHOLD) {
+			// we have filtered out a significant amount of tuples
+			// add this chunk to the cache and continue
+			auto &chunk_cache = *cached_chunks[operator_idx];
+			chunk_cache.Append(current_chunk);
+			if (chunk_cache.size() >= (STANDARD_VECTOR_SIZE - CACHE_THRESHOLD)) {
+				// chunk cache full: return it
+				current_chunk.Move(chunk_cache);
+				chunk_cache.Initialize(pipeline.operators[operator_idx]->GetTypes());
+			} else {
+				// chunk cache not full: probe again
+				current_chunk.Reset();
+			}
+		}
+	}
+#endif
+}
+
+void PipelineExecutor::ExecutePull(DataChunk &result) {
+	if (IsFinished()) {
+		return;
+	}
+	auto &executor = pipeline.executor;
+	try {
+		D_ASSERT(!pipeline.sink);
+		auto &source_chunk = pipeline.operators.empty() ? result : *intermediate_chunks[0];
+		while (result.size() == 0) {
+			if (in_process_operators.empty()) {
+				source_chunk.Reset();
+				FetchFromSource(source_chunk);
+				if (source_chunk.size() == 0) {
+					break;
+				}
+			}
+			if (!pipeline.operators.empty()) {
+				auto state = Execute(source_chunk, result);
+				if (state == OperatorResultType::FINISHED) {
+					break;
+				}
+			}
+		}
+	} catch (std::exception &ex) { // LCOV_EXCL_START
+		if (executor.HasError()) {
+			executor.ThrowException();
+		}
+		throw;
+	} catch (...) {
+		if (executor.HasError()) {
+			executor.ThrowException();
+		}
+		throw;
+	} // LCOV_EXCL_STOP
+}
+
+void PipelineExecutor::PullFinalize() {
+	if (finalized) {
+		throw InternalException("Calling PullFinalize on a pipeline that has been finalized already");
+	}
+	finalized = true;
+	pipeline.executor.Flush(thread);
+}
+
+void PipelineExecutor::GoToSource(idx_t &current_idx, idx_t initial_idx) {
+	// we go back to the first operator (the source)
+	current_idx = initial_idx;
+	if (!in_process_operators.empty()) {
+		// ... UNLESS there is an in process operator
+		// if there is an in-process operator, we start executing at the latest one
+		// for example, if we have a join operator that has tuples left, we first need to emit those tuples
+		current_idx = in_process_operators.top();
+		in_process_operators.pop();
+	}
+	D_ASSERT(current_idx >= initial_idx);
+}
+
+OperatorResultType PipelineExecutor::Execute(DataChunk &input, DataChunk &result, idx_t initial_idx) {
+	if (input.size() == 0) { // LCOV_EXCL_START
+		return OperatorResultType::NEED_MORE_INPUT;
+	} // LCOV_EXCL_STOP
+	D_ASSERT(!pipeline.operators.empty());
+
+	idx_t current_idx;
+	GoToSource(current_idx, initial_idx);
+	if (current_idx == initial_idx) {
+		current_idx++;
+	}
+	if (current_idx > pipeline.operators.size()) {
+		result.Reference(input);
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+	while (true) {
+		if (context.client.interrupted) {
+			throw InterruptException();
+		}
+		// now figure out where to put the chunk
+		// if current_idx is the last possible index (>= operators.size()) we write to the result
+		// otherwise we write to an intermediate chunk
+		auto current_intermediate = current_idx;
+		auto &current_chunk =
+		    current_intermediate >= intermediate_chunks.size() ? result : *intermediate_chunks[current_intermediate];
+		current_chunk.Reset();
+		if (current_idx == initial_idx) {
+			// we went back to the source: we need more input
+			return OperatorResultType::NEED_MORE_INPUT;
+		} else {
+			auto &prev_chunk =
+			    current_intermediate == initial_idx + 1 ? input : *intermediate_chunks[current_intermediate - 1];
+			auto operator_idx = current_idx - 1;
+			auto current_operator = pipeline.operators[operator_idx];
+
+			// if current_idx > source_idx, we pass the previous' operators output through the Execute of the current
+			// operator
+			StartOperator(current_operator);
+			auto result = current_operator->Execute(context, prev_chunk, current_chunk, *current_operator->op_state,
+			                                        *intermediate_states[current_intermediate - 1]);
+			EndOperator(current_operator, &current_chunk);
+			if (result == OperatorResultType::HAVE_MORE_OUTPUT) {
+				// more data remains in this operator
+				// push in-process marker
+				in_process_operators.push(current_idx);
+			} else if (result == OperatorResultType::FINISHED) {
+				D_ASSERT(current_chunk.size() == 0);
+				FinishProcessing(current_idx);
+				return OperatorResultType::FINISHED;
+			}
+			current_chunk.Verify();
+			CacheChunk(current_chunk, operator_idx);
+		}
+
+		if (current_chunk.size() == 0) {
+			// no output from this operator!
+			if (current_idx == initial_idx) {
+				// if we got no output from the scan, we are done
+				break;
+			} else {
+				// if we got no output from an intermediate op
+				// we go back and try to pull data from the source again
+				GoToSource(current_idx, initial_idx);
+				continue;
+			}
+		} else {
+			// we got output! continue to the next operator
+			current_idx++;
+			if (current_idx > pipeline.operators.size()) {
+				// if we got output and are at the last operator, we are finished executing for this output chunk
+				// return the data and push it into the chunk
+				break;
+			}
+		}
+	}
+	return in_process_operators.empty() ? OperatorResultType::NEED_MORE_INPUT : OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+void PipelineExecutor::FetchFromSource(DataChunk &result) {
+	StartOperator(pipeline.source);
+	pipeline.source->GetData(context, result, *pipeline.source_state, *local_source_state);
+	if (result.size() != 0 && requires_batch_index) {
+		auto next_batch_index =
+		    pipeline.source->GetBatchIndex(context, result, *pipeline.source_state, *local_source_state);
+		next_batch_index += pipeline.base_batch_index;
+		D_ASSERT(local_sink_state->batch_index <= next_batch_index ||
+		         local_sink_state->batch_index == DConstants::INVALID_INDEX);
+		local_sink_state->batch_index = next_batch_index;
+	}
+	EndOperator(pipeline.source, &result);
+}
+
+void PipelineExecutor::InitializeChunk(DataChunk &chunk) {
+	PhysicalOperator *last_op = pipeline.operators.empty() ? pipeline.source : pipeline.operators.back();
+	chunk.Initialize(last_op->GetTypes());
+}
+
+void PipelineExecutor::StartOperator(PhysicalOperator *op) {
+	if (context.client.interrupted) {
+		throw InterruptException();
+	}
+	context.thread.profiler.StartOperator(op);
+}
+
+void PipelineExecutor::EndOperator(PhysicalOperator *op, DataChunk *chunk) {
+	context.thread.profiler.EndOperator(chunk);
+
+	if (chunk) {
+		chunk->Verify();
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PipelineFinishEvent::PipelineFinishEvent(shared_ptr<Pipeline> pipeline_p)
+    : Event(pipeline_p->executor), pipeline(move(pipeline_p)) {
+}
+
+void PipelineFinishEvent::Schedule() {
+}
+
+void PipelineFinishEvent::FinishEvent() {
+	pipeline->Finalize(*this);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+#ifndef DUCKDB_NO_THREADS
+
+
+
+#else
+#include <queue>
+#endif
+
+namespace duckdb {
+
+struct SchedulerThread {
+#ifndef DUCKDB_NO_THREADS
+	explicit SchedulerThread(unique_ptr<thread> thread_p) : internal_thread(move(thread_p)) {
+	}
+
+	unique_ptr<thread> internal_thread;
+#endif
+};
+
+#ifndef DUCKDB_NO_THREADS
+typedef duckdb_moodycamel::ConcurrentQueue<unique_ptr<Task>> concurrent_queue_t;
+typedef duckdb_moodycamel::LightweightSemaphore lightweight_semaphore_t;
+
+struct ConcurrentQueue {
+	concurrent_queue_t q;
+	lightweight_semaphore_t semaphore;
+
+	void Enqueue(ProducerToken &token, unique_ptr<Task> task);
+	bool DequeueFromProducer(ProducerToken &token, unique_ptr<Task> &task);
+};
+
+struct QueueProducerToken {
+	explicit QueueProducerToken(ConcurrentQueue &queue) : queue_token(queue.q) {
+	}
+
+	duckdb_moodycamel::ProducerToken queue_token;
+};
+
+void ConcurrentQueue::Enqueue(ProducerToken &token, unique_ptr<Task> task) {
+	lock_guard<mutex> producer_lock(token.producer_lock);
+	if (q.enqueue(token.token->queue_token, move(task))) {
+		semaphore.signal();
+	} else {
+		throw InternalException("Could not schedule task!");
+	}
+}
+
+bool ConcurrentQueue::DequeueFromProducer(ProducerToken &token, unique_ptr<Task> &task) {
+	lock_guard<mutex> producer_lock(token.producer_lock);
+	return q.try_dequeue_from_producer(token.token->queue_token, task);
+}
+
+#else
+struct ConcurrentQueue {
+	std::queue<std::unique_ptr<Task>> q;
+	mutex qlock;
+
+	void Enqueue(ProducerToken &token, unique_ptr<Task> task);
+	bool DequeueFromProducer(ProducerToken &token, unique_ptr<Task> &task);
+};
+
+void ConcurrentQueue::Enqueue(ProducerToken &token, unique_ptr<Task> task) {
+	lock_guard<mutex> lock(qlock);
+	q.push(move(task));
+}
+
+bool ConcurrentQueue::DequeueFromProducer(ProducerToken &token, unique_ptr<Task> &task) {
+	lock_guard<mutex> lock(qlock);
+	if (q.empty()) {
+		return false;
+	}
+	task = move(q.front());
+	q.pop();
+	return true;
+}
+
+struct QueueProducerToken {
+	QueueProducerToken(ConcurrentQueue &queue) {
+	}
+};
+#endif
+
+ProducerToken::ProducerToken(TaskScheduler &scheduler, unique_ptr<QueueProducerToken> token)
+    : scheduler(scheduler), token(move(token)) {
+}
+
+ProducerToken::~ProducerToken() {
+}
+
+TaskScheduler::TaskScheduler(DatabaseInstance &db) : db(db), queue(make_unique<ConcurrentQueue>()) {
+}
+
+TaskScheduler::~TaskScheduler() {
+#ifndef DUCKDB_NO_THREADS
+	SetThreadsInternal(1);
+#endif
+}
+
+TaskScheduler &TaskScheduler::GetScheduler(ClientContext &context) {
+	return TaskScheduler::GetScheduler(DatabaseInstance::GetDatabase(context));
+}
+
+TaskScheduler &TaskScheduler::GetScheduler(DatabaseInstance &db) {
+	return db.GetScheduler();
+}
+
+unique_ptr<ProducerToken> TaskScheduler::CreateProducer() {
+	auto token = make_unique<QueueProducerToken>(*queue);
+	return make_unique<ProducerToken>(*this, move(token));
+}
+
+void TaskScheduler::ScheduleTask(ProducerToken &token, unique_ptr<Task> task) {
+	// Enqueue a task for the given producer token and signal any sleeping threads
+	queue->Enqueue(token, move(task));
+}
+
+bool TaskScheduler::GetTaskFromProducer(ProducerToken &token, unique_ptr<Task> &task) {
+	return queue->DequeueFromProducer(token, task);
+}
+
+void TaskScheduler::ExecuteForever(atomic<bool> *marker) {
+#ifndef DUCKDB_NO_THREADS
+	unique_ptr<Task> task;
+	// loop until the marker is set to false
+	while (*marker) {
+		// wait for a signal with a timeout; the timeout allows us to periodically check
+		queue->semaphore.wait();
+		if (queue->q.try_dequeue(task)) {
+			task->Execute(TaskExecutionMode::PROCESS_ALL);
+			task.reset();
+		}
+	}
+#else
+	throw NotImplementedException("DuckDB was compiled without threads! Background thread loop is not allowed.");
+#endif
+}
+
+void TaskScheduler::ExecuteTasks(idx_t max_tasks) {
+#ifndef DUCKDB_NO_THREADS
+	unique_ptr<Task> task;
+	for (idx_t i = 0; i < max_tasks; i++) {
+		queue->semaphore.wait(TASK_TIMEOUT_USECS);
+		if (!queue->q.try_dequeue(task)) {
+			return;
+		}
+		try {
+			task->Execute(TaskExecutionMode::PROCESS_ALL);
+			task.reset();
+		} catch (...) {
+			return;
+		}
+	}
+#else
+	throw NotImplementedException("DuckDB was compiled without threads! Background thread loop is not allowed.");
+#endif
+}
+
+#ifndef DUCKDB_NO_THREADS
+static void ThreadExecuteTasks(TaskScheduler *scheduler, atomic<bool> *marker) {
+	scheduler->ExecuteForever(marker);
+}
+#endif
+
+int32_t TaskScheduler::NumberOfThreads() {
+	auto &config = DBConfig::GetConfig(db);
+	return threads.size() + config.external_threads + 1;
+}
+
+void TaskScheduler::SetThreads(int32_t n) {
+#ifndef DUCKDB_NO_THREADS
+	if (n < 1) {
+		throw SyntaxException("Must have at least 1 thread!");
+	}
+	SetThreadsInternal(n);
+#else
+	if (n != 1) {
+		throw NotImplementedException("DuckDB was compiled without threads! Setting threads > 1 is not allowed.");
+	}
+#endif
+}
+
+void TaskScheduler::SetThreadsInternal(int32_t n) {
+#ifndef DUCKDB_NO_THREADS
+	if (threads.size() == idx_t(n - 1)) {
+		return;
+	}
+	idx_t new_thread_count = n - 1;
+	if (threads.size() > new_thread_count) {
+		// we are reducing the number of threads: clear all threads first
+		for (idx_t i = 0; i < threads.size(); i++) {
+			*markers[i] = false;
+		}
+		queue->semaphore.signal(threads.size());
+		// now join the threads to ensure they are fully stopped before erasing them
+		for (idx_t i = 0; i < threads.size(); i++) {
+			threads[i]->internal_thread->join();
+		}
+		// erase the threads/markers
+		threads.clear();
+		markers.clear();
+	}
+	if (threads.size() < new_thread_count) {
+		// we are increasing the number of threads: launch them and run tasks on them
+		idx_t create_new_threads = new_thread_count - threads.size();
+		for (idx_t i = 0; i < create_new_threads; i++) {
+			// launch a thread and assign it a cancellation marker
+			auto marker = unique_ptr<atomic<bool>>(new atomic<bool>(true));
+			auto worker_thread = make_unique<thread>(ThreadExecuteTasks, this, marker.get());
+			auto thread_wrapper = make_unique<SchedulerThread>(move(worker_thread));
+
+			threads.push_back(move(thread_wrapper));
+			markers.push_back(move(marker));
+		}
+	}
+#endif
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+ThreadContext::ThreadContext(ClientContext &context) : profiler(QueryProfiler::Get(context).IsEnabled()) {
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+void BaseExpression::Print() const {
+	Printer::Print(ToString());
+}
+
+string BaseExpression::GetName() const {
+	return !alias.empty() ? alias : ToString();
+}
+
+bool BaseExpression::Equals(const BaseExpression *other) const {
+	if (!other) {
+		return false;
+	}
+	if (this->expression_class != other->expression_class || this->type != other->type) {
+		return false;
+	}
+	return true;
+}
+
+void BaseExpression::Verify() const {
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+ColumnDefinition::ColumnDefinition(string name_p, LogicalType type_p) : name(move(name_p)), type(move(type_p)) {
+}
+
+ColumnDefinition::ColumnDefinition(string name_p, LogicalType type_p, unique_ptr<ParsedExpression> expression,
+                                   TableColumnType category)
+    : name(move(name_p)), type(move(type_p)), category(category) {
+	switch (category) {
+	case TableColumnType::STANDARD: {
+		default_value = move(expression);
+		break;
+	}
+	case TableColumnType::GENERATED: {
+		generated_expression = move(expression);
+		break;
+	}
+	default: {
+		throw InternalException("Type not implemented for TableColumnType");
+	}
+	}
+}
+
+ColumnDefinition ColumnDefinition::Copy() const {
+	ColumnDefinition copy(name, type);
+	copy.oid = oid;
+	copy.storage_oid = storage_oid;
+	copy.SetDefaultValue(default_value ? default_value->Copy() : nullptr);
+	copy.generated_expression = generated_expression ? generated_expression->Copy() : nullptr;
+	copy.compression_type = compression_type;
+	copy.category = category;
+	return copy;
+}
+
+void ColumnDefinition::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	writer.WriteString(name);
+	writer.WriteSerializable(type);
+	if (Generated()) {
+		writer.WriteOptional(generated_expression);
+	} else {
+		writer.WriteOptional(default_value);
+	}
+	writer.WriteField<TableColumnType>(category);
+	writer.Finalize();
+}
+
+ColumnDefinition ColumnDefinition::Deserialize(Deserializer &source) {
+	FieldReader reader(source);
+	auto column_name = reader.ReadRequired<string>();
+	auto column_type = reader.ReadRequiredSerializable<LogicalType, LogicalType>();
+	auto expression = reader.ReadOptional<ParsedExpression>(nullptr);
+	auto category = reader.ReadField<TableColumnType>(TableColumnType::STANDARD);
+	reader.Finalize();
+
+	switch (category) {
+	case TableColumnType::STANDARD:
+		return ColumnDefinition(column_name, column_type, move(expression), TableColumnType::STANDARD);
+	case TableColumnType::GENERATED:
+		return ColumnDefinition(column_name, column_type, move(expression), TableColumnType::GENERATED);
+	default:
+		throw NotImplementedException("Type not implemented for TableColumnType");
+	}
+}
+
+const unique_ptr<ParsedExpression> &ColumnDefinition::DefaultValue() const {
+	return default_value;
+}
+
+void ColumnDefinition::SetDefaultValue(unique_ptr<ParsedExpression> default_value) {
+	this->default_value = move(default_value);
+}
+
+const LogicalType &ColumnDefinition::Type() const {
+	return type;
+}
+
+LogicalType &ColumnDefinition::TypeMutable() {
+	return type;
+}
+
+void ColumnDefinition::SetType(const LogicalType &type) {
+	this->type = type;
+}
+
+const string &ColumnDefinition::Name() const {
+	return name;
+}
+
+void ColumnDefinition::SetName(const string &name) {
+	this->name = name;
+}
+
+const duckdb::CompressionType &ColumnDefinition::CompressionType() const {
+	return compression_type;
+}
+
+void ColumnDefinition::SetCompressionType(duckdb::CompressionType compression_type) {
+	this->compression_type = compression_type;
+}
+
+const storage_t &ColumnDefinition::StorageOid() const {
+	return storage_oid;
+}
+
+void ColumnDefinition::SetStorageOid(storage_t storage_oid) {
+	this->storage_oid = storage_oid;
+}
+
+const column_t &ColumnDefinition::Oid() const {
+	return oid;
+}
+
+void ColumnDefinition::SetOid(column_t oid) {
+	this->oid = oid;
+}
+
+const TableColumnType &ColumnDefinition::Category() const {
+	return category;
+}
+
+bool ColumnDefinition::Generated() const {
+	return category == TableColumnType::GENERATED;
+}
+
+//===--------------------------------------------------------------------===//
+// Generated Columns (VIRTUAL)
+//===--------------------------------------------------------------------===//
+
+static void VerifyColumnRefs(ParsedExpression &expr) {
+	if (expr.type == ExpressionType::COLUMN_REF) {
+		auto &column_ref = (ColumnRefExpression &)expr;
+		if (column_ref.IsQualified()) {
+			throw ParserException(
+			    "Qualified (tbl.name) column references are not allowed inside of generated column expressions");
+		}
+	}
+	ParsedExpressionIterator::EnumerateChildren(
+	    expr, [&](const ParsedExpression &child) { VerifyColumnRefs((ParsedExpression &)child); });
+}
+
+static void InnerGetListOfDependencies(ParsedExpression &expr, vector<string> &dependencies) {
+	if (expr.type == ExpressionType::COLUMN_REF) {
+		auto columnref = (ColumnRefExpression &)expr;
+		auto &name = columnref.GetColumnName();
+		dependencies.push_back(name);
+	}
+	ParsedExpressionIterator::EnumerateChildren(expr, [&](const ParsedExpression &child) {
+		InnerGetListOfDependencies((ParsedExpression &)child, dependencies);
+	});
+}
+
+void ColumnDefinition::GetListOfDependencies(vector<string> &dependencies) const {
+	D_ASSERT(Generated());
+	InnerGetListOfDependencies(*generated_expression, dependencies);
+}
+
+void ColumnDefinition::SetGeneratedExpression(unique_ptr<ParsedExpression> expression) {
+	category = TableColumnType::GENERATED;
+
+	if (expression->HasSubquery()) {
+		throw ParserException("Expression of generated column \"%s\" contains a subquery, which isn't allowed", name);
+	}
+
+	VerifyColumnRefs(*expression);
+	if (type.id() == LogicalTypeId::ANY) {
+		generated_expression = move(expression);
+		return;
+	}
+	// Always wrap the expression in a cast, that way we can always update the cast when we change the type
+	// Except if the type is LogicalType::ANY (no type specified)
+	generated_expression = make_unique_base<ParsedExpression, CastExpression>(type, move(expression));
+}
+
+void ColumnDefinition::ChangeGeneratedExpressionType(const LogicalType &type) {
+	D_ASSERT(Generated());
+	// First time the type is set, add a cast around the expression
+	D_ASSERT(this->type.id() == LogicalTypeId::ANY);
+	generated_expression = make_unique_base<ParsedExpression, CastExpression>(type, move(generated_expression));
+	// Every generated expression should be wrapped in a cast on creation
+	// D_ASSERT(generated_expression->type == ExpressionType::OPERATOR_CAST);
+	// auto &cast_expr = (CastExpression &)*generated_expression;
+	// auto base_expr = move(cast_expr.child);
+	// generated_expression = make_unique_base<ParsedExpression, CastExpression>(type, move(base_expr));
+}
+
+const ParsedExpression &ColumnDefinition::GeneratedExpression() const {
+	D_ASSERT(Generated());
+	return *generated_expression;
+}
+
+ParsedExpression &ColumnDefinition::GeneratedExpressionMutable() {
+	D_ASSERT(Generated());
+	return *generated_expression;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+Constraint::Constraint(ConstraintType type) : type(type) {
+}
+
+Constraint::~Constraint() {
+}
+
+void Constraint::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	writer.WriteField<ConstraintType>(type);
+	Serialize(writer);
+	writer.Finalize();
+}
+
+unique_ptr<Constraint> Constraint::Deserialize(Deserializer &source) {
+	FieldReader reader(source);
+	auto type = reader.ReadRequired<ConstraintType>();
+	unique_ptr<Constraint> result;
+	switch (type) {
+	case ConstraintType::NOT_NULL:
+		result = NotNullConstraint::Deserialize(reader);
+		break;
+	case ConstraintType::CHECK:
+		result = CheckConstraint::Deserialize(reader);
+		break;
+	case ConstraintType::UNIQUE:
+		result = UniqueConstraint::Deserialize(reader);
+		break;
+	case ConstraintType::FOREIGN_KEY:
+		result = ForeignKeyConstraint::Deserialize(reader);
+		break;
+	default:
+		throw InternalException("Unrecognized constraint type for serialization");
+	}
+	reader.Finalize();
+	return result;
+}
+
+void Constraint::Print() const {
+	Printer::Print(ToString());
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+CheckConstraint::CheckConstraint(unique_ptr<ParsedExpression> expression)
+    : Constraint(ConstraintType::CHECK), expression(move(expression)) {
+}
+
+string CheckConstraint::ToString() const {
+	return "CHECK(" + expression->ToString() + ")";
+}
+
+unique_ptr<Constraint> CheckConstraint::Copy() const {
+	return make_unique<CheckConstraint>(expression->Copy());
+}
+
+void CheckConstraint::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(*expression);
+}
+
+unique_ptr<Constraint> CheckConstraint::Deserialize(FieldReader &source) {
+	auto expression = source.ReadRequiredSerializable<ParsedExpression>();
+	return make_unique<CheckConstraint>(move(expression));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+ForeignKeyConstraint::ForeignKeyConstraint(vector<string> pk_columns, vector<string> fk_columns, ForeignKeyInfo info)
+    : Constraint(ConstraintType::FOREIGN_KEY), pk_columns(move(pk_columns)), fk_columns(move(fk_columns)),
+      info(move(info)) {
+}
+
+string ForeignKeyConstraint::ToString() const {
+	if (info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+		string base = "FOREIGN KEY (";
+
+		for (idx_t i = 0; i < fk_columns.size(); i++) {
+			if (i > 0) {
+				base += ", ";
+			}
+			base += KeywordHelper::WriteOptionallyQuoted(fk_columns[i]);
+		}
+		base += ") REFERENCES ";
+		if (!info.schema.empty()) {
+			base += info.schema;
+			base += ".";
+		}
+		base += info.table;
+		base += "(";
+
+		for (idx_t i = 0; i < pk_columns.size(); i++) {
+			if (i > 0) {
+				base += ", ";
+			}
+			base += KeywordHelper::WriteOptionallyQuoted(pk_columns[i]);
+		}
+		base += ")";
+
+		return base;
+	}
+
+	return "";
+}
+
+unique_ptr<Constraint> ForeignKeyConstraint::Copy() const {
+	return make_unique<ForeignKeyConstraint>(pk_columns, fk_columns, info);
+}
+
+void ForeignKeyConstraint::Serialize(FieldWriter &writer) const {
+	D_ASSERT(pk_columns.size() <= NumericLimits<uint32_t>::Maximum());
+	writer.WriteList<string>(pk_columns);
+	D_ASSERT(fk_columns.size() <= NumericLimits<uint32_t>::Maximum());
+	writer.WriteList<string>(fk_columns);
+	writer.WriteField<ForeignKeyType>(info.type);
+	writer.WriteString(info.schema);
+	writer.WriteString(info.table);
+	writer.WriteList<idx_t>(info.pk_keys);
+	writer.WriteList<idx_t>(info.fk_keys);
+}
+
+unique_ptr<Constraint> ForeignKeyConstraint::Deserialize(FieldReader &source) {
+	ForeignKeyInfo read_info;
+	auto pk_columns = source.ReadRequiredList<string>();
+	auto fk_columns = source.ReadRequiredList<string>();
+	read_info.type = source.ReadRequired<ForeignKeyType>();
+	read_info.schema = source.ReadRequired<string>();
+	read_info.table = source.ReadRequired<string>();
+	read_info.pk_keys = source.ReadRequiredList<idx_t>();
+	read_info.fk_keys = source.ReadRequiredList<idx_t>();
+
+	// column list parsed constraint
+	return make_unique<ForeignKeyConstraint>(pk_columns, fk_columns, move(read_info));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+NotNullConstraint::NotNullConstraint(column_t index) : Constraint(ConstraintType::NOT_NULL), index(index) {
+}
+
+NotNullConstraint::~NotNullConstraint() {
+}
+
+string NotNullConstraint::ToString() const {
+	return "NOT NULL";
+}
+
+unique_ptr<Constraint> NotNullConstraint::Copy() const {
+	return make_unique<NotNullConstraint>(index);
+}
+
+void NotNullConstraint::Serialize(FieldWriter &writer) const {
+	writer.WriteField<idx_t>(index);
+}
+
+unique_ptr<Constraint> NotNullConstraint::Deserialize(FieldReader &source) {
+	auto index = source.ReadRequired<idx_t>();
+	return make_unique_base<Constraint, NotNullConstraint>(index);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+UniqueConstraint::UniqueConstraint(uint64_t index, bool is_primary_key)
+    : Constraint(ConstraintType::UNIQUE), index(index), is_primary_key(is_primary_key) {
+}
+UniqueConstraint::UniqueConstraint(vector<string> columns, bool is_primary_key)
+    : Constraint(ConstraintType::UNIQUE), index(DConstants::INVALID_INDEX), columns(move(columns)),
+      is_primary_key(is_primary_key) {
+}
+
+string UniqueConstraint::ToString() const {
+	string base = is_primary_key ? "PRIMARY KEY(" : "UNIQUE(";
+	for (idx_t i = 0; i < columns.size(); i++) {
+		if (i > 0) {
+			base += ", ";
+		}
+		base += KeywordHelper::WriteOptionallyQuoted(columns[i]);
+	}
+	return base + ")";
+}
+
+unique_ptr<Constraint> UniqueConstraint::Copy() const {
+	if (index == DConstants::INVALID_INDEX) {
+		return make_unique<UniqueConstraint>(columns, is_primary_key);
+	} else {
+		auto result = make_unique<UniqueConstraint>(index, is_primary_key);
+		result->columns = columns;
+		return move(result);
+	}
+}
+
+void UniqueConstraint::Serialize(FieldWriter &writer) const {
+	writer.WriteField<bool>(is_primary_key);
+	writer.WriteField<uint64_t>(index);
+	D_ASSERT(columns.size() <= NumericLimits<uint32_t>::Maximum());
+	writer.WriteList<string>(columns);
+}
+
+unique_ptr<Constraint> UniqueConstraint::Deserialize(FieldReader &source) {
+	auto is_primary_key = source.ReadRequired<bool>();
+	auto index = source.ReadRequired<uint64_t>();
+	auto columns = source.ReadRequiredList<string>();
+
+	if (index != DConstants::INVALID_INDEX) {
+		// single column parsed constraint
+		auto result = make_unique<UniqueConstraint>(index, is_primary_key);
+		result->columns = move(columns);
+		return move(result);
+	} else {
+		// column list parsed constraint
+		return make_unique<UniqueConstraint>(move(columns), is_primary_key);
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+BetweenExpression::BetweenExpression(unique_ptr<ParsedExpression> input_p, unique_ptr<ParsedExpression> lower_p,
+                                     unique_ptr<ParsedExpression> upper_p)
+    : ParsedExpression(ExpressionType::COMPARE_BETWEEN, ExpressionClass::BETWEEN), input(move(input_p)),
+      lower(move(lower_p)), upper(move(upper_p)) {
+}
+
+string BetweenExpression::ToString() const {
+	return ToString<BetweenExpression, ParsedExpression>(*this);
+}
+
+bool BetweenExpression::Equals(const BetweenExpression *a, const BetweenExpression *b) {
+	if (!a->input->Equals(b->input.get())) {
+		return false;
+	}
+	if (!a->lower->Equals(b->lower.get())) {
+		return false;
+	}
+	if (!a->upper->Equals(b->upper.get())) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<ParsedExpression> BetweenExpression::Copy() const {
+	auto copy = make_unique<BetweenExpression>(input->Copy(), lower->Copy(), upper->Copy());
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+void BetweenExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(*input);
+	writer.WriteSerializable(*lower);
+	writer.WriteSerializable(*upper);
+}
+
+unique_ptr<ParsedExpression> BetweenExpression::Deserialize(ExpressionType type, FieldReader &source) {
+	auto input = source.ReadRequiredSerializable<ParsedExpression>();
+	auto lower = source.ReadRequiredSerializable<ParsedExpression>();
+	auto upper = source.ReadRequiredSerializable<ParsedExpression>();
+	return make_unique<BetweenExpression>(move(input), move(lower), move(upper));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+CaseExpression::CaseExpression() : ParsedExpression(ExpressionType::CASE_EXPR, ExpressionClass::CASE) {
+}
+
+string CaseExpression::ToString() const {
+	return ToString<CaseExpression, ParsedExpression>(*this);
+}
+
+bool CaseExpression::Equals(const CaseExpression *a, const CaseExpression *b) {
+	if (a->case_checks.size() != b->case_checks.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < a->case_checks.size(); i++) {
+		if (!a->case_checks[i].when_expr->Equals(b->case_checks[i].when_expr.get())) {
+			return false;
+		}
+		if (!a->case_checks[i].then_expr->Equals(b->case_checks[i].then_expr.get())) {
+			return false;
+		}
+	}
+	if (!a->else_expr->Equals(b->else_expr.get())) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<ParsedExpression> CaseExpression::Copy() const {
+	auto copy = make_unique<CaseExpression>();
+	copy->CopyProperties(*this);
+	for (auto &check : case_checks) {
+		CaseCheck new_check;
+		new_check.when_expr = check.when_expr->Copy();
+		new_check.then_expr = check.then_expr->Copy();
+		copy->case_checks.push_back(move(new_check));
+	}
+	copy->else_expr = else_expr->Copy();
+	return move(copy);
+}
+
+void CaseExpression::Serialize(FieldWriter &writer) const {
+	auto &serializer = writer.GetSerializer();
+	// we write a list of multiple expressions here
+	// in order to write this as a single field we directly use the field writers' internal serializer
+	writer.WriteField<uint32_t>(case_checks.size());
+	for (auto &check : case_checks) {
+		check.when_expr->Serialize(serializer);
+		check.then_expr->Serialize(serializer);
+	}
+	writer.WriteSerializable<ParsedExpression>(*else_expr);
+}
+
+unique_ptr<ParsedExpression> CaseExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto result = make_unique<CaseExpression>();
+	auto &source = reader.GetSource();
+	auto count = reader.ReadRequired<uint32_t>();
+	for (idx_t i = 0; i < count; i++) {
+		CaseCheck new_check;
+		new_check.when_expr = ParsedExpression::Deserialize(source);
+		new_check.then_expr = ParsedExpression::Deserialize(source);
+		result->case_checks.push_back(move(new_check));
+	}
+	result->else_expr = reader.ReadRequiredSerializable<ParsedExpression>();
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+CastExpression::CastExpression(LogicalType target, unique_ptr<ParsedExpression> child, bool try_cast_p)
+    : ParsedExpression(ExpressionType::OPERATOR_CAST, ExpressionClass::CAST), cast_type(move(target)),
+      try_cast(try_cast_p) {
+	D_ASSERT(child);
+	this->child = move(child);
+}
+
+string CastExpression::ToString() const {
+	return ToString<CastExpression, ParsedExpression>(*this);
+}
+
+bool CastExpression::Equals(const CastExpression *a, const CastExpression *b) {
+	if (!a->child->Equals(b->child.get())) {
+		return false;
+	}
+	if (a->cast_type != b->cast_type) {
+		return false;
+	}
+	if (a->try_cast != b->try_cast) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<ParsedExpression> CastExpression::Copy() const {
+	auto copy = make_unique<CastExpression>(cast_type, child->Copy(), try_cast);
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+void CastExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(*child);
+	writer.WriteSerializable(cast_type);
+	writer.WriteField<bool>(try_cast);
+}
+
+unique_ptr<ParsedExpression> CastExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto child = reader.ReadRequiredSerializable<ParsedExpression>();
+	auto cast_type = reader.ReadRequiredSerializable<LogicalType, LogicalType>();
+	auto try_cast = reader.ReadRequired<bool>();
+	return make_unique_base<ParsedExpression, CastExpression>(cast_type, move(child), try_cast);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+CollateExpression::CollateExpression(string collation_p, unique_ptr<ParsedExpression> child)
+    : ParsedExpression(ExpressionType::COLLATE, ExpressionClass::COLLATE), collation(move(collation_p)) {
+	D_ASSERT(child);
+	this->child = move(child);
+}
+
+string CollateExpression::ToString() const {
+	return child->ToString() + " COLLATE " + collation;
+}
+
+bool CollateExpression::Equals(const CollateExpression *a, const CollateExpression *b) {
+	if (!a->child->Equals(b->child.get())) {
+		return false;
+	}
+	if (a->collation != b->collation) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<ParsedExpression> CollateExpression::Copy() const {
+	auto copy = make_unique<CollateExpression>(collation, child->Copy());
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+void CollateExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(*child);
+	writer.WriteString(collation);
+}
+
+unique_ptr<ParsedExpression> CollateExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto child = reader.ReadRequiredSerializable<ParsedExpression>();
+	auto collation = reader.ReadRequired<string>();
+	return make_unique_base<ParsedExpression, CollateExpression>(collation, move(child));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+ColumnRefExpression::ColumnRefExpression(string column_name, string table_name)
+    : ColumnRefExpression(table_name.empty() ? vector<string> {move(column_name)}
+                                             : vector<string> {move(table_name), move(column_name)}) {
+}
+
+ColumnRefExpression::ColumnRefExpression(string column_name) : ColumnRefExpression(vector<string> {move(column_name)}) {
+}
+
+ColumnRefExpression::ColumnRefExpression(vector<string> column_names_p)
+    : ParsedExpression(ExpressionType::COLUMN_REF, ExpressionClass::COLUMN_REF), column_names(move(column_names_p)) {
+#ifdef DEBUG
+	for (auto &col_name : column_names) {
+		D_ASSERT(!col_name.empty());
+	}
+#endif
+}
+
+bool ColumnRefExpression::IsQualified() const {
+	return column_names.size() > 1;
+}
+
+const string &ColumnRefExpression::GetColumnName() const {
+	D_ASSERT(column_names.size() <= 3);
+	return column_names.back();
+}
+
+const string &ColumnRefExpression::GetTableName() const {
+	D_ASSERT(column_names.size() >= 2 && column_names.size() <= 3);
+	return column_names.size() == 3 ? column_names[1] : column_names[0];
+}
+
+string ColumnRefExpression::GetName() const {
+	return !alias.empty() ? alias : column_names.back();
+}
+
+string ColumnRefExpression::ToString() const {
+	string result;
+	for (idx_t i = 0; i < column_names.size(); i++) {
+		if (i > 0) {
+			result += ".";
+		}
+		result += KeywordHelper::WriteOptionallyQuoted(column_names[i]);
+	}
+	return result;
+}
+
+bool ColumnRefExpression::Equals(const ColumnRefExpression *a, const ColumnRefExpression *b) {
+	if (a->column_names.size() != b->column_names.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < a->column_names.size(); i++) {
+		auto lcase_a = StringUtil::Lower(a->column_names[i]);
+		auto lcase_b = StringUtil::Lower(b->column_names[i]);
+		if (lcase_a != lcase_b) {
+			return false;
+		}
+	}
+	return true;
+}
+
+hash_t ColumnRefExpression::Hash() const {
+	hash_t result = ParsedExpression::Hash();
+	for (auto &column_name : column_names) {
+		auto lcase = StringUtil::Lower(column_name);
+		result = CombineHash(result, duckdb::Hash<const char *>(lcase.c_str()));
+	}
+	return result;
+}
+
+unique_ptr<ParsedExpression> ColumnRefExpression::Copy() const {
+	auto copy = make_unique<ColumnRefExpression>(column_names);
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+void ColumnRefExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteList<string>(column_names);
+}
+
+unique_ptr<ParsedExpression> ColumnRefExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto column_names = reader.ReadRequiredList<string>();
+	auto expression = make_unique<ColumnRefExpression>(move(column_names));
+	return move(expression);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+ComparisonExpression::ComparisonExpression(ExpressionType type, unique_ptr<ParsedExpression> left,
+                                           unique_ptr<ParsedExpression> right)
+    : ParsedExpression(type, ExpressionClass::COMPARISON) {
+	this->left = move(left);
+	this->right = move(right);
+}
+
+string ComparisonExpression::ToString() const {
+	return ToString<ComparisonExpression, ParsedExpression>(*this);
+}
+
+bool ComparisonExpression::Equals(const ComparisonExpression *a, const ComparisonExpression *b) {
+	if (!a->left->Equals(b->left.get())) {
+		return false;
+	}
+	if (!a->right->Equals(b->right.get())) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<ParsedExpression> ComparisonExpression::Copy() const {
+	auto copy = make_unique<ComparisonExpression>(type, left->Copy(), right->Copy());
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+void ComparisonExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(*left);
+	writer.WriteSerializable(*right);
+}
+
+unique_ptr<ParsedExpression> ComparisonExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto left_child = reader.ReadRequiredSerializable<ParsedExpression>();
+	auto right_child = reader.ReadRequiredSerializable<ParsedExpression>();
+	return make_unique<ComparisonExpression>(type, move(left_child), move(right_child));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+ConjunctionExpression::ConjunctionExpression(ExpressionType type)
+    : ParsedExpression(type, ExpressionClass::CONJUNCTION) {
+}
+
+ConjunctionExpression::ConjunctionExpression(ExpressionType type, vector<unique_ptr<ParsedExpression>> children)
+    : ParsedExpression(type, ExpressionClass::CONJUNCTION) {
+	for (auto &child : children) {
+		AddExpression(move(child));
+	}
+}
+
+ConjunctionExpression::ConjunctionExpression(ExpressionType type, unique_ptr<ParsedExpression> left,
+                                             unique_ptr<ParsedExpression> right)
+    : ParsedExpression(type, ExpressionClass::CONJUNCTION) {
+	AddExpression(move(left));
+	AddExpression(move(right));
+}
+
+void ConjunctionExpression::AddExpression(unique_ptr<ParsedExpression> expr) {
+	if (expr->type == type) {
+		// expr is a conjunction of the same type: merge the expression lists together
+		auto &other = (ConjunctionExpression &)*expr;
+		for (auto &child : other.children) {
+			children.push_back(move(child));
+		}
+	} else {
+		children.push_back(move(expr));
+	}
+}
+
+string ConjunctionExpression::ToString() const {
+	return ToString<ConjunctionExpression, ParsedExpression>(*this);
+}
+
+bool ConjunctionExpression::Equals(const ConjunctionExpression *a, const ConjunctionExpression *b) {
+	return ExpressionUtil::SetEquals(a->children, b->children);
+}
+
+unique_ptr<ParsedExpression> ConjunctionExpression::Copy() const {
+	vector<unique_ptr<ParsedExpression>> copy_children;
+	for (auto &expr : children) {
+		copy_children.push_back(expr->Copy());
+	}
+	auto copy = make_unique<ConjunctionExpression>(type, move(copy_children));
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+void ConjunctionExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializableList(children);
+}
+
+unique_ptr<ParsedExpression> ConjunctionExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto result = make_unique<ConjunctionExpression>(type);
+	result->children = reader.ReadRequiredSerializableList<ParsedExpression>();
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+ConstantExpression::ConstantExpression(Value val)
+    : ParsedExpression(ExpressionType::VALUE_CONSTANT, ExpressionClass::CONSTANT), value(move(val)) {
+}
+
+string ConstantExpression::ToString() const {
+	return value.ToSQLString();
+}
+
+bool ConstantExpression::Equals(const ConstantExpression *a, const ConstantExpression *b) {
+	return !ValueOperations::DistinctFrom(a->value, b->value);
+}
+
+hash_t ConstantExpression::Hash() const {
+	return ParsedExpression::Hash();
+}
+
+unique_ptr<ParsedExpression> ConstantExpression::Copy() const {
+	auto copy = make_unique<ConstantExpression>(value);
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+void ConstantExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(value);
+}
+
+unique_ptr<ParsedExpression> ConstantExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	Value value = reader.ReadRequiredSerializable<Value, Value>();
+	return make_unique<ConstantExpression>(move(value));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+DefaultExpression::DefaultExpression() : ParsedExpression(ExpressionType::VALUE_DEFAULT, ExpressionClass::DEFAULT) {
+}
+
+string DefaultExpression::ToString() const {
+	return "DEFAULT";
+}
+
+unique_ptr<ParsedExpression> DefaultExpression::Copy() const {
+	auto copy = make_unique<DefaultExpression>();
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+void DefaultExpression::Serialize(FieldWriter &writer) const {
+}
+
+unique_ptr<ParsedExpression> DefaultExpression::Deserialize(ExpressionType type, FieldReader &source) {
+	return make_unique<DefaultExpression>();
+}
+
+} // namespace duckdb
+
+
+#include <utility>
+
+
+
+
+
+namespace duckdb {
+
+FunctionExpression::FunctionExpression(string schema, const string &function_name,
+                                       vector<unique_ptr<ParsedExpression>> children_p,
+                                       unique_ptr<ParsedExpression> filter, unique_ptr<OrderModifier> order_bys_p,
+                                       bool distinct, bool is_operator, bool export_state_p)
+    : ParsedExpression(ExpressionType::FUNCTION, ExpressionClass::FUNCTION), schema(std::move(schema)),
+      function_name(StringUtil::Lower(function_name)), is_operator(is_operator), children(move(children_p)),
+      distinct(distinct), filter(move(filter)), order_bys(move(order_bys_p)), export_state(export_state_p) {
+	D_ASSERT(!function_name.empty());
+	if (!order_bys) {
+		order_bys = make_unique<OrderModifier>();
+	}
+}
+
+FunctionExpression::FunctionExpression(const string &function_name, vector<unique_ptr<ParsedExpression>> children_p,
+                                       unique_ptr<ParsedExpression> filter, unique_ptr<OrderModifier> order_bys,
+                                       bool distinct, bool is_operator, bool export_state_p)
+    : FunctionExpression(INVALID_SCHEMA, function_name, move(children_p), move(filter), move(order_bys), distinct,
+                         is_operator, export_state_p) {
+}
+
+string FunctionExpression::ToString() const {
+	return ToString<FunctionExpression, ParsedExpression>(*this, schema, function_name, is_operator, distinct,
+	                                                      filter.get(), order_bys.get(), export_state, true);
+}
+
+bool FunctionExpression::Equals(const FunctionExpression *a, const FunctionExpression *b) {
+	if (a->schema != b->schema || a->function_name != b->function_name || b->distinct != a->distinct) {
+		return false;
+	}
+	if (b->children.size() != a->children.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < a->children.size(); i++) {
+		if (!a->children[i]->Equals(b->children[i].get())) {
+			return false;
+		}
+	}
+	if (!BaseExpression::Equals(a->filter.get(), b->filter.get())) {
+		return false;
+	}
+	if (!a->order_bys->Equals(b->order_bys.get())) {
+		return false;
+	}
+	if (a->export_state != b->export_state) {
+		return false;
+	}
+	return true;
+}
+
+hash_t FunctionExpression::Hash() const {
+	hash_t result = ParsedExpression::Hash();
+	result = CombineHash(result, duckdb::Hash<const char *>(schema.c_str()));
+	result = CombineHash(result, duckdb::Hash<const char *>(function_name.c_str()));
+	result = CombineHash(result, duckdb::Hash<bool>(distinct));
+	result = CombineHash(result, duckdb::Hash<bool>(export_state));
+	return result;
+}
+
+unique_ptr<ParsedExpression> FunctionExpression::Copy() const {
+	vector<unique_ptr<ParsedExpression>> copy_children;
+	unique_ptr<ParsedExpression> filter_copy;
+	for (auto &child : children) {
+		copy_children.push_back(child->Copy());
+	}
+	if (filter) {
+		filter_copy = filter->Copy();
+	}
+	unique_ptr<OrderModifier> order_copy;
+	if (order_bys) {
+		order_copy.reset(static_cast<OrderModifier *>(order_bys->Copy().release()));
+	}
+
+	auto copy = make_unique<FunctionExpression>(function_name, move(copy_children), move(filter_copy), move(order_copy),
+	                                            distinct, is_operator, export_state);
+	copy->schema = schema;
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+void FunctionExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteString(function_name);
+	writer.WriteString(schema);
+	writer.WriteSerializableList(children);
+	writer.WriteOptional(filter);
+	writer.WriteSerializable((ResultModifier &)*order_bys);
+	writer.WriteField<bool>(distinct);
+	writer.WriteField<bool>(is_operator);
+	writer.WriteField<bool>(export_state);
+}
+
+unique_ptr<ParsedExpression> FunctionExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto function_name = reader.ReadRequired<string>();
+	auto schema = reader.ReadRequired<string>();
+	auto children = reader.ReadRequiredSerializableList<ParsedExpression>();
+	auto filter = reader.ReadOptional<ParsedExpression>(nullptr);
+	auto order_bys = unique_ptr_cast<ResultModifier, OrderModifier>(reader.ReadRequiredSerializable<ResultModifier>());
+	auto distinct = reader.ReadRequired<bool>();
+	auto is_operator = reader.ReadRequired<bool>();
+	auto export_state = reader.ReadField<bool>(false);
+
+	unique_ptr<FunctionExpression> function;
+	function = make_unique<FunctionExpression>(function_name, move(children), move(filter), move(order_bys), distinct,
+	                                           is_operator, export_state);
+	function->schema = schema;
+	return move(function);
+}
+
+void FunctionExpression::Verify() const {
+	D_ASSERT(!function_name.empty());
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+LambdaExpression::LambdaExpression(unique_ptr<ParsedExpression> lhs, unique_ptr<ParsedExpression> rhs)
+    : ParsedExpression(ExpressionType::LAMBDA, ExpressionClass::LAMBDA), lhs(move(lhs)), rhs(move(rhs)) {
+}
+
+string LambdaExpression::ToString() const {
+	return lhs->ToString() + " -> " + rhs->ToString();
+}
+
+bool LambdaExpression::Equals(const LambdaExpression *a, const LambdaExpression *b) {
+	return a->lhs->Equals(b->lhs.get()) && a->rhs->Equals(b->rhs.get());
+}
+
+hash_t LambdaExpression::Hash() const {
+	hash_t result = lhs->Hash();
+	ParsedExpression::Hash();
+	result = CombineHash(result, rhs->Hash());
+	return result;
+}
+
+unique_ptr<ParsedExpression> LambdaExpression::Copy() const {
+	return make_unique<LambdaExpression>(lhs->Copy(), rhs->Copy());
+}
+
+void LambdaExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(*lhs);
+	writer.WriteSerializable(*rhs);
+}
+
+unique_ptr<ParsedExpression> LambdaExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto lhs = reader.ReadRequiredSerializable<ParsedExpression>();
+	auto rhs = reader.ReadRequiredSerializable<ParsedExpression>();
+	return make_unique<LambdaExpression>(move(lhs), move(rhs));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+OperatorExpression::OperatorExpression(ExpressionType type, unique_ptr<ParsedExpression> left,
+                                       unique_ptr<ParsedExpression> right)
+    : ParsedExpression(type, ExpressionClass::OPERATOR) {
+	if (left) {
+		children.push_back(move(left));
+	}
+	if (right) {
+		children.push_back(move(right));
+	}
+}
+
+OperatorExpression::OperatorExpression(ExpressionType type, vector<unique_ptr<ParsedExpression>> children)
+    : ParsedExpression(type, ExpressionClass::OPERATOR), children(move(children)) {
+}
+
+string OperatorExpression::ToString() const {
+	return ToString<OperatorExpression, ParsedExpression>(*this);
+}
+
+bool OperatorExpression::Equals(const OperatorExpression *a, const OperatorExpression *b) {
+	if (a->children.size() != b->children.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < a->children.size(); i++) {
+		if (!a->children[i]->Equals(b->children[i].get())) {
+			return false;
+		}
+	}
+	return true;
+}
+
+unique_ptr<ParsedExpression> OperatorExpression::Copy() const {
+	auto copy = make_unique<OperatorExpression>(type);
+	copy->CopyProperties(*this);
+	for (auto &it : children) {
+		copy->children.push_back(it->Copy());
+	}
+	return move(copy);
+}
+
+void OperatorExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializableList(children);
+}
+
+unique_ptr<ParsedExpression> OperatorExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto expression = make_unique<OperatorExpression>(type);
+	expression->children = reader.ReadRequiredSerializableList<ParsedExpression>();
+	return move(expression);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+ParameterExpression::ParameterExpression()
+    : ParsedExpression(ExpressionType::VALUE_PARAMETER, ExpressionClass::PARAMETER), parameter_nr(0) {
+}
+
+string ParameterExpression::ToString() const {
+	return "$" + to_string(parameter_nr);
+}
+
+unique_ptr<ParsedExpression> ParameterExpression::Copy() const {
+	auto copy = make_unique<ParameterExpression>();
+	copy->parameter_nr = parameter_nr;
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+hash_t ParameterExpression::Hash() const {
+	hash_t result = ParsedExpression::Hash();
+	return CombineHash(duckdb::Hash(parameter_nr), result);
+}
+
+void ParameterExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteField<idx_t>(parameter_nr);
+}
+
+unique_ptr<ParsedExpression> ParameterExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto expression = make_unique<ParameterExpression>();
+	expression->parameter_nr = reader.ReadRequired<idx_t>();
+	return move(expression);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+PositionalReferenceExpression::PositionalReferenceExpression(idx_t index)
+    : ParsedExpression(ExpressionType::POSITIONAL_REFERENCE, ExpressionClass::POSITIONAL_REFERENCE), index(index) {
+}
+
+string PositionalReferenceExpression::ToString() const {
+	return "#" + to_string(index);
+}
+
+bool PositionalReferenceExpression::Equals(const PositionalReferenceExpression *a,
+                                           const PositionalReferenceExpression *b) {
+	return a->index == b->index;
+}
+
+unique_ptr<ParsedExpression> PositionalReferenceExpression::Copy() const {
+	auto copy = make_unique<PositionalReferenceExpression>(index);
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+hash_t PositionalReferenceExpression::Hash() const {
+	hash_t result = ParsedExpression::Hash();
+	return CombineHash(duckdb::Hash(index), result);
+}
+
+void PositionalReferenceExpression::Serialize(FieldWriter &writer) const {
+	writer.WriteField<idx_t>(index);
+}
+
+unique_ptr<ParsedExpression> PositionalReferenceExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto expression = make_unique<PositionalReferenceExpression>(reader.ReadRequired<idx_t>());
+	return move(expression);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+StarExpression::StarExpression(string relation_name_p)
+    : ParsedExpression(ExpressionType::STAR, ExpressionClass::STAR), relation_name(move(relation_name_p)) {
+}
+
+string StarExpression::ToString() const {
+	string result = relation_name.empty() ? "*" : relation_name + ".*";
+	if (!exclude_list.empty()) {
+		result += " EXCLUDE (";
+		bool first_entry = true;
+		for (auto &entry : exclude_list) {
+			if (!first_entry) {
+				result += ", ";
+			}
+			result += entry;
+			first_entry = false;
+		}
+		result += ")";
+	}
+	if (!replace_list.empty()) {
+		result += " REPLACE (";
+		bool first_entry = true;
+		for (auto &entry : replace_list) {
+			if (!first_entry) {
+				result += ", ";
+			}
+			result += entry.second->ToString();
+			result += " AS ";
+			result += entry.first;
+			first_entry = false;
+		}
+		result += ")";
+	}
+	return result;
+}
+
+bool StarExpression::Equals(const StarExpression *a, const StarExpression *b) {
+	if (a->relation_name != b->relation_name || a->exclude_list != b->exclude_list) {
+		return false;
+	}
+	if (a->replace_list.size() != b->replace_list.size()) {
+		return false;
+	}
+	for (auto &entry : a->replace_list) {
+		auto other_entry = b->replace_list.find(entry.first);
+		if (other_entry == b->replace_list.end()) {
+			return false;
+		}
+		if (!entry.second->Equals(other_entry->second.get())) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void StarExpression::Serialize(FieldWriter &writer) const {
+	auto &serializer = writer.GetSerializer();
+
+	writer.WriteString(relation_name);
+
+	// in order to write the exclude_list/replace_list as single fields we directly use the field writers' internal
+	// serializer
+	writer.WriteField<uint32_t>(exclude_list.size());
+	for (auto &exclusion : exclude_list) {
+		serializer.WriteString(exclusion);
+	}
+	writer.WriteField<uint32_t>(replace_list.size());
+	for (auto &entry : replace_list) {
+		serializer.WriteString(entry.first);
+		entry.second->Serialize(serializer);
+	}
+}
+
+unique_ptr<ParsedExpression> StarExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto &source = reader.GetSource();
+
+	auto result = make_unique<StarExpression>();
+	result->relation_name = reader.ReadRequired<string>();
+	auto exclusion_count = reader.ReadRequired<uint32_t>();
+	for (idx_t i = 0; i < exclusion_count; i++) {
+		result->exclude_list.insert(source.Read<string>());
+	}
+	auto replace_count = reader.ReadRequired<uint32_t>();
+	for (idx_t i = 0; i < replace_count; i++) {
+		auto name = source.Read<string>();
+		auto expr = ParsedExpression::Deserialize(source);
+		result->replace_list.insert(make_pair(name, move(expr)));
+	}
+	return move(result);
+}
+
+unique_ptr<ParsedExpression> StarExpression::Copy() const {
+	auto copy = make_unique<StarExpression>(relation_name);
+	copy->exclude_list = exclude_list;
+	for (auto &entry : replace_list) {
+		copy->replace_list[entry.first] = entry.second->Copy();
+	}
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+SubqueryExpression::SubqueryExpression()
+    : ParsedExpression(ExpressionType::SUBQUERY, ExpressionClass::SUBQUERY), subquery_type(SubqueryType::INVALID),
+      comparison_type(ExpressionType::INVALID) {
+}
+
+string SubqueryExpression::ToString() const {
+	switch (subquery_type) {
+	case SubqueryType::ANY:
+		return child->ToString() + " " + ExpressionTypeToOperator(comparison_type) + " ANY(" + subquery->ToString() +
+		       ")";
+	case SubqueryType::EXISTS:
+		return "EXISTS(" + subquery->ToString() + ")";
+	case SubqueryType::NOT_EXISTS:
+		return "NOT EXISTS(" + subquery->ToString() + ")";
+	case SubqueryType::SCALAR:
+		return "(" + subquery->ToString() + ")";
+	default:
+		throw InternalException("Unrecognized type for subquery");
+	}
+}
+
+bool SubqueryExpression::Equals(const SubqueryExpression *a, const SubqueryExpression *b) {
+	if (!a->subquery || !b->subquery) {
+		return false;
+	}
+	if (!BaseExpression::Equals(a->child.get(), b->child.get())) {
+		return false;
+	}
+	return a->comparison_type == b->comparison_type && a->subquery_type == b->subquery_type &&
+	       a->subquery->Equals(b->subquery.get());
+}
+
+unique_ptr<ParsedExpression> SubqueryExpression::Copy() const {
+	auto copy = make_unique<SubqueryExpression>();
+	copy->CopyProperties(*this);
+	copy->subquery = unique_ptr_cast<SQLStatement, SelectStatement>(subquery->Copy());
+	copy->subquery_type = subquery_type;
+	copy->child = child ? child->Copy() : nullptr;
+	copy->comparison_type = comparison_type;
+	return move(copy);
+}
+
+void SubqueryExpression::Serialize(FieldWriter &writer) const {
+	auto &serializer = writer.GetSerializer();
+
+	writer.WriteField<SubqueryType>(subquery_type);
+	// FIXME: this shouldn't use a serializer (probably)?
+	subquery->Serialize(serializer);
+	writer.WriteOptional(child);
+	writer.WriteField<ExpressionType>(comparison_type);
+}
+
+unique_ptr<ParsedExpression> SubqueryExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	// FIXME: this shouldn't use a source
+	auto &source = reader.GetSource();
+
+	auto subquery_type = reader.ReadRequired<SubqueryType>();
+	auto subquery = SelectStatement::Deserialize(source);
+
+	auto expression = make_unique<SubqueryExpression>();
+	expression->subquery_type = subquery_type;
+	expression->subquery = move(subquery);
+	expression->child = reader.ReadOptional<ParsedExpression>(nullptr);
+	expression->comparison_type = reader.ReadRequired<ExpressionType>();
+	return move(expression);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+WindowExpression::WindowExpression(ExpressionType type, string schema, const string &function_name)
+    : ParsedExpression(type, ExpressionClass::WINDOW), schema(move(schema)),
+      function_name(StringUtil::Lower(function_name)), ignore_nulls(false) {
+	switch (type) {
+	case ExpressionType::WINDOW_AGGREGATE:
+	case ExpressionType::WINDOW_ROW_NUMBER:
+	case ExpressionType::WINDOW_FIRST_VALUE:
+	case ExpressionType::WINDOW_LAST_VALUE:
+	case ExpressionType::WINDOW_NTH_VALUE:
+	case ExpressionType::WINDOW_RANK:
+	case ExpressionType::WINDOW_RANK_DENSE:
+	case ExpressionType::WINDOW_PERCENT_RANK:
+	case ExpressionType::WINDOW_CUME_DIST:
+	case ExpressionType::WINDOW_LEAD:
+	case ExpressionType::WINDOW_LAG:
+	case ExpressionType::WINDOW_NTILE:
+		break;
+	default:
+		throw NotImplementedException("Window aggregate type %s not supported", ExpressionTypeToString(type).c_str());
+	}
+}
+
+string WindowExpression::ToString() const {
+	return ToString<WindowExpression, ParsedExpression, OrderByNode>(*this, schema, function_name);
+}
+
+bool WindowExpression::Equals(const WindowExpression *a, const WindowExpression *b) {
+	// check if the child expressions are equivalent
+	if (b->children.size() != a->children.size()) {
+		return false;
+	}
+	if (a->ignore_nulls != b->ignore_nulls) {
+		return false;
+	}
+	for (idx_t i = 0; i < a->children.size(); i++) {
+		if (!a->children[i]->Equals(b->children[i].get())) {
+			return false;
+		}
+	}
+	if (a->start != b->start || a->end != b->end) {
+		return false;
+	}
+	// check if the framing expressions are equivalent
+	if (!BaseExpression::Equals(a->start_expr.get(), b->start_expr.get()) ||
+	    !BaseExpression::Equals(a->end_expr.get(), b->end_expr.get()) ||
+	    !BaseExpression::Equals(a->offset_expr.get(), b->offset_expr.get()) ||
+	    !BaseExpression::Equals(a->default_expr.get(), b->default_expr.get())) {
+		return false;
+	}
+
+	// check if the partitions are equivalent
+	if (a->partitions.size() != b->partitions.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < a->partitions.size(); i++) {
+		if (!a->partitions[i]->Equals(b->partitions[i].get())) {
+			return false;
+		}
+	}
+	// check if the orderings are equivalent
+	if (a->orders.size() != b->orders.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < a->orders.size(); i++) {
+		if (a->orders[i].type != b->orders[i].type) {
+			return false;
+		}
+		if (!a->orders[i].expression->Equals(b->orders[i].expression.get())) {
+			return false;
+		}
+	}
+	// check if the filter clauses are equivalent
+	if (!BaseExpression::Equals(a->filter_expr.get(), b->filter_expr.get())) {
+		return false;
+	}
+
+	return true;
+}
+
+unique_ptr<ParsedExpression> WindowExpression::Copy() const {
+	auto new_window = make_unique<WindowExpression>(type, schema, function_name);
+	new_window->CopyProperties(*this);
+
+	for (auto &child : children) {
+		new_window->children.push_back(child->Copy());
+	}
+
+	for (auto &e : partitions) {
+		new_window->partitions.push_back(e->Copy());
+	}
+
+	for (auto &o : orders) {
+		new_window->orders.emplace_back(o.type, o.null_order, o.expression->Copy());
+	}
+
+	new_window->filter_expr = filter_expr ? filter_expr->Copy() : nullptr;
+
+	new_window->start = start;
+	new_window->end = end;
+	new_window->start_expr = start_expr ? start_expr->Copy() : nullptr;
+	new_window->end_expr = end_expr ? end_expr->Copy() : nullptr;
+	new_window->offset_expr = offset_expr ? offset_expr->Copy() : nullptr;
+	new_window->default_expr = default_expr ? default_expr->Copy() : nullptr;
+	new_window->ignore_nulls = ignore_nulls;
+
+	return move(new_window);
+}
+
+void WindowExpression::Serialize(FieldWriter &writer) const {
+	auto &serializer = writer.GetSerializer();
+
+	writer.WriteString(function_name);
+	writer.WriteString(schema);
+	writer.WriteSerializableList(children);
+	writer.WriteSerializableList(partitions);
+	// FIXME: should not use serializer here (probably)?
+	D_ASSERT(orders.size() <= NumericLimits<uint32_t>::Maximum());
+	writer.WriteField<uint32_t>((uint32_t)orders.size());
+	for (auto &order : orders) {
+		order.Serialize(serializer);
+	}
+	writer.WriteField<WindowBoundary>(start);
+	writer.WriteField<WindowBoundary>(end);
+
+	writer.WriteOptional(start_expr);
+	writer.WriteOptional(end_expr);
+	writer.WriteOptional(offset_expr);
+	writer.WriteOptional(default_expr);
+	writer.WriteField<bool>(ignore_nulls);
+	writer.WriteOptional(filter_expr);
+}
+
+unique_ptr<ParsedExpression> WindowExpression::Deserialize(ExpressionType type, FieldReader &reader) {
+	auto function_name = reader.ReadRequired<string>();
+	auto schema = reader.ReadRequired<string>();
+	auto expr = make_unique<WindowExpression>(type, schema, function_name);
+	expr->children = reader.ReadRequiredSerializableList<ParsedExpression>();
+	expr->partitions = reader.ReadRequiredSerializableList<ParsedExpression>();
+
+	auto order_count = reader.ReadRequired<uint32_t>();
+	auto &source = reader.GetSource();
+	for (idx_t i = 0; i < order_count; i++) {
+		expr->orders.push_back(OrderByNode::Deserialize((source)));
+	}
+	expr->start = reader.ReadRequired<WindowBoundary>();
+	expr->end = reader.ReadRequired<WindowBoundary>();
+
+	expr->start_expr = reader.ReadOptional<ParsedExpression>(nullptr);
+	expr->end_expr = reader.ReadOptional<ParsedExpression>(nullptr);
+	expr->offset_expr = reader.ReadOptional<ParsedExpression>(nullptr);
+	expr->default_expr = reader.ReadOptional<ParsedExpression>(nullptr);
+	expr->ignore_nulls = reader.ReadRequired<bool>();
+	expr->filter_expr = reader.ReadOptional<ParsedExpression>(nullptr);
+	return move(expr);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+template <class T>
+bool ExpressionUtil::ExpressionListEquals(const vector<unique_ptr<T>> &a, const vector<unique_ptr<T>> &b) {
+	if (a.size() != b.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < a.size(); i++) {
+		if (!(*a[i] == *b[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+template <class T>
+bool ExpressionUtil::ExpressionSetEquals(const vector<unique_ptr<T>> &a, const vector<unique_ptr<T>> &b) {
+	if (a.size() != b.size()) {
+		return false;
+	}
+	// we create a map of expression -> count for the left side
+	// we keep the count because the same expression can occur multiple times (e.g. "1 AND 1" is legal)
+	// in this case we track the following value: map["Constant(1)"] = 2
+	expression_map_t<idx_t> map;
+	for (idx_t i = 0; i < a.size(); i++) {
+		map[a[i].get()]++;
+	}
+	// now on the right side we reduce the counts again
+	// if the conjunctions are identical, all the counts will be 0 after the
+	for (auto &expr : b) {
+		auto entry = map.find(expr.get());
+		// first we check if we can find the expression in the map at all
+		if (entry == map.end()) {
+			return false;
+		}
+		// if we found it we check the count; if the count is already 0 we return false
+		// this happens if e.g. the left side contains "1 AND X", and the right side contains "1 AND 1"
+		// "1" is contained in the map, however, the right side contains the expression twice
+		// hence we know the children are not identical in this case because the LHS and RHS have a different count for
+		// the Constant(1) expression
+		if (entry->second == 0) {
+			return false;
+		}
+		entry->second--;
+	}
+	return true;
+}
+
+bool ExpressionUtil::ListEquals(const vector<unique_ptr<ParsedExpression>> &a,
+                                const vector<unique_ptr<ParsedExpression>> &b) {
+	return ExpressionListEquals<ParsedExpression>(a, b);
+}
+
+bool ExpressionUtil::ListEquals(const vector<unique_ptr<Expression>> &a, const vector<unique_ptr<Expression>> &b) {
+	return ExpressionListEquals<Expression>(a, b);
+}
+
+bool ExpressionUtil::SetEquals(const vector<unique_ptr<ParsedExpression>> &a,
+                               const vector<unique_ptr<ParsedExpression>> &b) {
+	return ExpressionSetEquals<ParsedExpression>(a, b);
+}
+
+bool ExpressionUtil::SetEquals(const vector<unique_ptr<Expression>> &a, const vector<unique_ptr<Expression>> &b) {
+	return ExpressionSetEquals<Expression>(a, b);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+bool KeywordHelper::IsKeyword(const string &text) {
+	return Parser::IsKeyword(text);
+}
+
+bool KeywordHelper::RequiresQuotes(const string &text) {
+	for (size_t i = 0; i < text.size(); i++) {
+		if (i > 0 && (text[i] >= '0' && text[i] <= '9')) {
+			continue;
+		}
+		if (text[i] >= 'a' && text[i] <= 'z') {
+			continue;
+		}
+		if (text[i] == '_') {
+			continue;
+		}
+		return true;
+	}
+	return IsKeyword(text);
+}
+
+string KeywordHelper::WriteOptionallyQuoted(const string &text, char quote) {
+	if (!RequiresQuotes(text)) {
+		return text;
+	}
+	return string(1, quote) + StringUtil::Replace(text, string(1, quote), string(2, quote)) + string(1, quote);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+AlterInfo::AlterInfo(AlterType type, string schema_p, string name_p)
+    : type(type), schema(move(schema_p)), name(move(name_p)) {
+}
+
+AlterInfo::~AlterInfo() {
+}
+
+void AlterInfo::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	writer.WriteField<AlterType>(type);
+	Serialize(writer);
+	writer.Finalize();
+}
+
+unique_ptr<AlterInfo> AlterInfo::Deserialize(Deserializer &source) {
+	FieldReader reader(source);
+	auto type = reader.ReadRequired<AlterType>();
+
+	unique_ptr<AlterInfo> result;
+	switch (type) {
+	case AlterType::ALTER_TABLE:
+		result = AlterTableInfo::Deserialize(reader);
+		break;
+	case AlterType::ALTER_VIEW:
+		result = AlterViewInfo::Deserialize(reader);
+		break;
+	default:
+		throw SerializationException("Unknown alter type for deserialization!");
+	}
+	reader.Finalize();
+
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// ChangeOwnershipInfo
+//===--------------------------------------------------------------------===//
+ChangeOwnershipInfo::ChangeOwnershipInfo(CatalogType entry_catalog_type, string entry_schema_p, string entry_name_p,
+                                         string owner_schema_p, string owner_name_p)
+    : AlterInfo(AlterType::CHANGE_OWNERSHIP, move(entry_schema_p), move(entry_name_p)),
+      entry_catalog_type(entry_catalog_type), owner_schema(move(owner_schema_p)), owner_name(move(owner_name_p)) {
+}
+
+CatalogType ChangeOwnershipInfo::GetCatalogType() const {
+	return entry_catalog_type;
+}
+
+unique_ptr<AlterInfo> ChangeOwnershipInfo::Copy() const {
+	return make_unique_base<AlterInfo, ChangeOwnershipInfo>(entry_catalog_type, schema, name, owner_schema, owner_name);
+}
+
+void ChangeOwnershipInfo::Serialize(FieldWriter &writer) const {
+	throw InternalException("ChangeOwnershipInfo cannot be serialized");
+}
+
+//===--------------------------------------------------------------------===//
+// AlterTableInfo
+//===--------------------------------------------------------------------===//
+AlterTableInfo::AlterTableInfo(AlterTableType type, string schema_p, string table_p)
+    : AlterInfo(AlterType::ALTER_TABLE, move(move(schema_p)), move(table_p)), alter_table_type(type) {
+}
+AlterTableInfo::~AlterTableInfo() {
+}
+
+CatalogType AlterTableInfo::GetCatalogType() const {
+	return CatalogType::TABLE_ENTRY;
+}
+
+void AlterTableInfo::Serialize(FieldWriter &writer) const {
+	writer.WriteField<AlterTableType>(alter_table_type);
+	writer.WriteString(schema);
+	writer.WriteString(name);
+	SerializeAlterTable(writer);
+}
+
+unique_ptr<AlterInfo> AlterTableInfo::Deserialize(FieldReader &reader) {
+	auto type = reader.ReadRequired<AlterTableType>();
+	auto schema = reader.ReadRequired<string>();
+	auto table = reader.ReadRequired<string>();
+	unique_ptr<AlterTableInfo> info;
+	switch (type) {
+	case AlterTableType::RENAME_COLUMN:
+		return RenameColumnInfo::Deserialize(reader, schema, table);
+	case AlterTableType::RENAME_TABLE:
+		return RenameTableInfo::Deserialize(reader, schema, table);
+	case AlterTableType::ADD_COLUMN:
+		return AddColumnInfo::Deserialize(reader, schema, table);
+	case AlterTableType::REMOVE_COLUMN:
+		return RemoveColumnInfo::Deserialize(reader, schema, table);
+	case AlterTableType::ALTER_COLUMN_TYPE:
+		return ChangeColumnTypeInfo::Deserialize(reader, schema, table);
+	case AlterTableType::SET_DEFAULT:
+		return SetDefaultInfo::Deserialize(reader, schema, table);
+	case AlterTableType::FOREIGN_KEY_CONSTRAINT:
+		return AlterForeignKeyInfo::Deserialize(reader, schema, table);
+	default:
+		throw SerializationException("Unknown alter table type for deserialization!");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// RenameColumnInfo
+//===--------------------------------------------------------------------===//
+RenameColumnInfo::RenameColumnInfo(string schema_p, string table_p, string old_name_p, string new_name_p)
+    : AlterTableInfo(AlterTableType::RENAME_COLUMN, move(schema_p), move(table_p)), old_name(move(old_name_p)),
+      new_name(move(new_name_p)) {
+}
+RenameColumnInfo::~RenameColumnInfo() {
+}
+
+unique_ptr<AlterInfo> RenameColumnInfo::Copy() const {
+	return make_unique_base<AlterInfo, RenameColumnInfo>(schema, name, old_name, new_name);
+}
+
+void RenameColumnInfo::SerializeAlterTable(FieldWriter &writer) const {
+	writer.WriteString(old_name);
+	writer.WriteString(new_name);
+}
+
+unique_ptr<AlterInfo> RenameColumnInfo::Deserialize(FieldReader &reader, string schema, string table) {
+	auto old_name = reader.ReadRequired<string>();
+	auto new_name = reader.ReadRequired<string>();
+	return make_unique<RenameColumnInfo>(move(schema), move(table), old_name, new_name);
+}
+
+//===--------------------------------------------------------------------===//
+// RenameTableInfo
+//===--------------------------------------------------------------------===//
+RenameTableInfo::RenameTableInfo(string schema_p, string table_p, string new_name_p)
+    : AlterTableInfo(AlterTableType::RENAME_TABLE, move(schema_p), move(table_p)), new_table_name(move(new_name_p)) {
+}
+RenameTableInfo::~RenameTableInfo() {
+}
+
+unique_ptr<AlterInfo> RenameTableInfo::Copy() const {
+	return make_unique_base<AlterInfo, RenameTableInfo>(schema, name, new_table_name);
+}
+
+void RenameTableInfo::SerializeAlterTable(FieldWriter &writer) const {
+	writer.WriteString(new_table_name);
+}
+
+unique_ptr<AlterInfo> RenameTableInfo::Deserialize(FieldReader &reader, string schema, string table) {
+	auto new_name = reader.ReadRequired<string>();
+	return make_unique<RenameTableInfo>(move(schema), move(table), new_name);
+}
+
+//===--------------------------------------------------------------------===//
+// AddColumnInfo
+//===--------------------------------------------------------------------===//
+AddColumnInfo::AddColumnInfo(string schema_p, string table_p, ColumnDefinition new_column)
+    : AlterTableInfo(AlterTableType::ADD_COLUMN, move(schema_p), move(table_p)), new_column(move(new_column)) {
+}
+AddColumnInfo::~AddColumnInfo() {
+}
+
+unique_ptr<AlterInfo> AddColumnInfo::Copy() const {
+	return make_unique_base<AlterInfo, AddColumnInfo>(schema, name, new_column.Copy());
+}
+
+void AddColumnInfo::SerializeAlterTable(FieldWriter &writer) const {
+	writer.WriteSerializable(new_column);
+}
+
+unique_ptr<AlterInfo> AddColumnInfo::Deserialize(FieldReader &reader, string schema, string table) {
+	auto new_column = reader.ReadRequiredSerializable<ColumnDefinition, ColumnDefinition>();
+	return make_unique<AddColumnInfo>(move(schema), move(table), move(new_column));
+}
+
+//===--------------------------------------------------------------------===//
+// RemoveColumnInfo
+//===--------------------------------------------------------------------===//
+RemoveColumnInfo::RemoveColumnInfo(string schema, string table, string removed_column, bool if_exists, bool cascade)
+    : AlterTableInfo(AlterTableType::REMOVE_COLUMN, move(schema), move(table)), removed_column(move(removed_column)),
+      if_exists(if_exists), cascade(cascade) {
+}
+RemoveColumnInfo::~RemoveColumnInfo() {
+}
+
+unique_ptr<AlterInfo> RemoveColumnInfo::Copy() const {
+	return make_unique_base<AlterInfo, RemoveColumnInfo>(schema, name, removed_column, if_exists, cascade);
+}
+
+void RemoveColumnInfo::SerializeAlterTable(FieldWriter &writer) const {
+	writer.WriteString(removed_column);
+	writer.WriteField<bool>(if_exists);
+	writer.WriteField<bool>(cascade);
+}
+
+unique_ptr<AlterInfo> RemoveColumnInfo::Deserialize(FieldReader &reader, string schema, string table) {
+	auto new_name = reader.ReadRequired<string>();
+	auto if_exists = reader.ReadRequired<bool>();
+	auto cascade = reader.ReadRequired<bool>();
+	return make_unique<RemoveColumnInfo>(move(schema), move(table), new_name, if_exists, cascade);
+}
+
+//===--------------------------------------------------------------------===//
+// ChangeColumnTypeInfo
+//===--------------------------------------------------------------------===//
+ChangeColumnTypeInfo::ChangeColumnTypeInfo(string schema_p, string table_p, string column_name, LogicalType target_type,
+                                           unique_ptr<ParsedExpression> expression)
+    : AlterTableInfo(AlterTableType::ALTER_COLUMN_TYPE, move(schema_p), move(table_p)), column_name(move(column_name)),
+      target_type(move(target_type)), expression(move(expression)) {
+}
+ChangeColumnTypeInfo::~ChangeColumnTypeInfo() {
+}
+
+unique_ptr<AlterInfo> ChangeColumnTypeInfo::Copy() const {
+	return make_unique_base<AlterInfo, ChangeColumnTypeInfo>(schema, name, column_name, target_type,
+	                                                         expression->Copy());
+}
+
+void ChangeColumnTypeInfo::SerializeAlterTable(FieldWriter &writer) const {
+	writer.WriteString(column_name);
+	writer.WriteSerializable(target_type);
+	writer.WriteOptional(expression);
+}
+
+unique_ptr<AlterInfo> ChangeColumnTypeInfo::Deserialize(FieldReader &reader, string schema, string table) {
+	auto column_name = reader.ReadRequired<string>();
+	auto target_type = reader.ReadRequiredSerializable<LogicalType, LogicalType>();
+	auto expression = reader.ReadOptional<ParsedExpression>(nullptr);
+	return make_unique<ChangeColumnTypeInfo>(move(schema), move(table), move(column_name), move(target_type),
+	                                         move(expression));
+}
+
+//===--------------------------------------------------------------------===//
+// SetDefaultInfo
+//===--------------------------------------------------------------------===//
+SetDefaultInfo::SetDefaultInfo(string schema_p, string table_p, string column_name_p,
+                               unique_ptr<ParsedExpression> new_default)
+    : AlterTableInfo(AlterTableType::SET_DEFAULT, move(schema_p), move(table_p)), column_name(move(column_name_p)),
+      expression(move(new_default)) {
+}
+SetDefaultInfo::~SetDefaultInfo() {
+}
+
+unique_ptr<AlterInfo> SetDefaultInfo::Copy() const {
+	return make_unique_base<AlterInfo, SetDefaultInfo>(schema, name, column_name,
+	                                                   expression ? expression->Copy() : nullptr);
+}
+
+void SetDefaultInfo::SerializeAlterTable(FieldWriter &writer) const {
+	writer.WriteString(column_name);
+	writer.WriteOptional(expression);
+}
+
+unique_ptr<AlterInfo> SetDefaultInfo::Deserialize(FieldReader &reader, string schema, string table) {
+	auto column_name = reader.ReadRequired<string>();
+	auto new_default = reader.ReadOptional<ParsedExpression>(nullptr);
+	return make_unique<SetDefaultInfo>(move(schema), move(table), move(column_name), move(new_default));
+}
+
+//===--------------------------------------------------------------------===//
+// AlterForeignKeyInfo
+//===--------------------------------------------------------------------===//
+AlterForeignKeyInfo::AlterForeignKeyInfo(string schema_p, string table_p, string fk_table, vector<string> pk_columns,
+                                         vector<string> fk_columns, vector<idx_t> pk_keys, vector<idx_t> fk_keys,
+                                         AlterForeignKeyType type_p)
+    : AlterTableInfo(AlterTableType::FOREIGN_KEY_CONSTRAINT, move(schema_p), move(table_p)), fk_table(move(fk_table)),
+      pk_columns(move(pk_columns)), fk_columns(move(fk_columns)), pk_keys(move(pk_keys)), fk_keys(move(fk_keys)),
+      type(type_p) {
+}
+AlterForeignKeyInfo::~AlterForeignKeyInfo() {
+}
+
+unique_ptr<AlterInfo> AlterForeignKeyInfo::Copy() const {
+	return make_unique_base<AlterInfo, AlterForeignKeyInfo>(schema, name, fk_table, pk_columns, fk_columns, pk_keys,
+	                                                        fk_keys, type);
+}
+
+void AlterForeignKeyInfo::SerializeAlterTable(FieldWriter &writer) const {
+	writer.WriteString(fk_table);
+	writer.WriteList<string>(pk_columns);
+	writer.WriteList<string>(fk_columns);
+	writer.WriteList<idx_t>(pk_keys);
+	writer.WriteList<idx_t>(fk_keys);
+	writer.WriteField<AlterForeignKeyType>(type);
+}
+
+unique_ptr<AlterInfo> AlterForeignKeyInfo::Deserialize(FieldReader &reader, string schema, string table) {
+	auto fk_table = reader.ReadRequired<string>();
+	auto pk_columns = reader.ReadRequiredList<string>();
+	auto fk_columns = reader.ReadRequiredList<string>();
+	auto pk_keys = reader.ReadRequiredList<idx_t>();
+	auto fk_keys = reader.ReadRequiredList<idx_t>();
+	auto type = reader.ReadRequired<AlterForeignKeyType>();
+	return make_unique<AlterForeignKeyInfo>(move(schema), move(table), move(fk_table), move(pk_columns),
+	                                        move(fk_columns), move(pk_keys), move(fk_keys), type);
+}
+
+//===--------------------------------------------------------------------===//
+// Alter View
+//===--------------------------------------------------------------------===//
+AlterViewInfo::AlterViewInfo(AlterViewType type, string schema_p, string view_p)
+    : AlterInfo(AlterType::ALTER_VIEW, move(schema_p), move(view_p)), alter_view_type(type) {
+}
+AlterViewInfo::~AlterViewInfo() {
+}
+
+CatalogType AlterViewInfo::GetCatalogType() const {
+	return CatalogType::VIEW_ENTRY;
+}
+
+void AlterViewInfo::Serialize(FieldWriter &writer) const {
+	writer.WriteField<AlterViewType>(alter_view_type);
+	writer.WriteString(schema);
+	writer.WriteString(name);
+	SerializeAlterView(writer);
+}
+
+unique_ptr<AlterInfo> AlterViewInfo::Deserialize(FieldReader &reader) {
+	auto type = reader.ReadRequired<AlterViewType>();
+	auto schema = reader.ReadRequired<string>();
+	auto view = reader.ReadRequired<string>();
+	unique_ptr<AlterViewInfo> info;
+	switch (type) {
+	case AlterViewType::RENAME_VIEW:
+		return RenameViewInfo::Deserialize(reader, schema, view);
+	default:
+		throw SerializationException("Unknown alter view type for deserialization!");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// RenameViewInfo
+//===--------------------------------------------------------------------===//
+RenameViewInfo::RenameViewInfo(string schema_p, string view_p, string new_name_p)
+    : AlterViewInfo(AlterViewType::RENAME_VIEW, move(schema_p), move(view_p)), new_view_name(move(new_name_p)) {
+}
+RenameViewInfo::~RenameViewInfo() {
+}
+
+unique_ptr<AlterInfo> RenameViewInfo::Copy() const {
+	return make_unique_base<AlterInfo, RenameViewInfo>(schema, name, new_view_name);
+}
+
+void RenameViewInfo::SerializeAlterView(FieldWriter &writer) const {
+	writer.WriteString(new_view_name);
+}
+
+unique_ptr<AlterInfo> RenameViewInfo::Deserialize(FieldReader &reader, string schema, string view) {
+	auto new_name = reader.ReadRequired<string>();
+	return make_unique<RenameViewInfo>(move(schema), move(view), new_name);
+}
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+string SampleMethodToString(SampleMethod method) {
+	switch (method) {
+	case SampleMethod::SYSTEM_SAMPLE:
+		return "System";
+	case SampleMethod::BERNOULLI_SAMPLE:
+		return "Bernoulli";
+	case SampleMethod::RESERVOIR_SAMPLE:
+		return "Reservoir";
+	default:
+		return "Unknown";
+	}
+}
+
+void SampleOptions::Serialize(Serializer &serializer) {
+	FieldWriter writer(serializer);
+	writer.WriteSerializable(sample_size);
+	writer.WriteField<bool>(is_percentage);
+	writer.WriteField<SampleMethod>(method);
+	writer.WriteField<int64_t>(seed);
+	writer.Finalize();
+}
+
+unique_ptr<SampleOptions> SampleOptions::Deserialize(Deserializer &source) {
+	auto result = make_unique<SampleOptions>();
+
+	FieldReader reader(source);
+	result->sample_size = reader.ReadRequiredSerializable<Value, Value>();
+	result->is_percentage = reader.ReadRequired<bool>();
+	result->method = reader.ReadRequired<SampleMethod>();
+	result->seed = reader.ReadRequired<int64_t>();
+	reader.Finalize();
+
+	return result;
+}
+
+unique_ptr<SampleOptions> SampleOptions::Copy() {
+	auto result = make_unique<SampleOptions>();
+	result->sample_size = sample_size;
+	result->is_percentage = is_percentage;
+	result->method = method;
+	result->seed = seed;
+	return result;
+}
+
+bool SampleOptions::Equals(SampleOptions *a, SampleOptions *b) {
+	if (a == b) {
+		return true;
+	}
+	if (!a || !b) {
+		return false;
+	}
+	if (a->sample_size != b->sample_size || a->is_percentage != b->is_percentage || a->method != b->method ||
+	    a->seed != b->seed) {
+		return false;
+	}
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+bool ParsedExpression::IsAggregate() const {
+	bool is_aggregate = false;
+	ParsedExpressionIterator::EnumerateChildren(
+	    *this, [&](const ParsedExpression &child) { is_aggregate |= child.IsAggregate(); });
+	return is_aggregate;
+}
+
+bool ParsedExpression::IsWindow() const {
+	bool is_window = false;
+	ParsedExpressionIterator::EnumerateChildren(*this,
+	                                            [&](const ParsedExpression &child) { is_window |= child.IsWindow(); });
+	return is_window;
+}
+
+bool ParsedExpression::IsScalar() const {
+	bool is_scalar = true;
+	ParsedExpressionIterator::EnumerateChildren(*this, [&](const ParsedExpression &child) {
+		if (!child.IsScalar()) {
+			is_scalar = false;
+		}
+	});
+	return is_scalar;
+}
+
+bool ParsedExpression::HasParameter() const {
+	bool has_parameter = false;
+	ParsedExpressionIterator::EnumerateChildren(
+	    *this, [&](const ParsedExpression &child) { has_parameter |= child.HasParameter(); });
+	return has_parameter;
+}
+
+bool ParsedExpression::HasSubquery() const {
+	bool has_subquery = false;
+	ParsedExpressionIterator::EnumerateChildren(
+	    *this, [&](const ParsedExpression &child) { has_subquery |= child.HasSubquery(); });
+	return has_subquery;
+}
+
+bool ParsedExpression::Equals(const BaseExpression *other) const {
+	if (!BaseExpression::Equals(other)) {
+		return false;
+	}
+	switch (expression_class) {
+	case ExpressionClass::BETWEEN:
+		return BetweenExpression::Equals((BetweenExpression *)this, (BetweenExpression *)other);
+	case ExpressionClass::CASE:
+		return CaseExpression::Equals((CaseExpression *)this, (CaseExpression *)other);
+	case ExpressionClass::CAST:
+		return CastExpression::Equals((CastExpression *)this, (CastExpression *)other);
+	case ExpressionClass::COLLATE:
+		return CollateExpression::Equals((CollateExpression *)this, (CollateExpression *)other);
+	case ExpressionClass::COLUMN_REF:
+		return ColumnRefExpression::Equals((ColumnRefExpression *)this, (ColumnRefExpression *)other);
+	case ExpressionClass::COMPARISON:
+		return ComparisonExpression::Equals((ComparisonExpression *)this, (ComparisonExpression *)other);
+	case ExpressionClass::CONJUNCTION:
+		return ConjunctionExpression::Equals((ConjunctionExpression *)this, (ConjunctionExpression *)other);
+	case ExpressionClass::CONSTANT:
+		return ConstantExpression::Equals((ConstantExpression *)this, (ConstantExpression *)other);
+	case ExpressionClass::DEFAULT:
+		return true;
+	case ExpressionClass::FUNCTION:
+		return FunctionExpression::Equals((FunctionExpression *)this, (FunctionExpression *)other);
+	case ExpressionClass::LAMBDA:
+		return LambdaExpression::Equals((LambdaExpression *)this, (LambdaExpression *)other);
+	case ExpressionClass::OPERATOR:
+		return OperatorExpression::Equals((OperatorExpression *)this, (OperatorExpression *)other);
+	case ExpressionClass::PARAMETER:
+		return true;
+	case ExpressionClass::POSITIONAL_REFERENCE:
+		return PositionalReferenceExpression::Equals((PositionalReferenceExpression *)this,
+		                                             (PositionalReferenceExpression *)other);
+	case ExpressionClass::STAR:
+		return StarExpression::Equals((StarExpression *)this, (StarExpression *)other);
+	case ExpressionClass::SUBQUERY:
+		return SubqueryExpression::Equals((SubqueryExpression *)this, (SubqueryExpression *)other);
+	case ExpressionClass::WINDOW:
+		return WindowExpression::Equals((WindowExpression *)this, (WindowExpression *)other);
+	default:
+		throw SerializationException("Unsupported type for expression comparison!");
+	}
+}
+
+hash_t ParsedExpression::Hash() const {
+	hash_t hash = duckdb::Hash<uint32_t>((uint32_t)type);
+	ParsedExpressionIterator::EnumerateChildren(
+	    *this, [&](const ParsedExpression &child) { hash = CombineHash(child.Hash(), hash); });
+	return hash;
+}
+
+void ParsedExpression::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	writer.WriteField<ExpressionClass>(GetExpressionClass());
+	writer.WriteField<ExpressionType>(type);
+	writer.WriteString(alias);
+	Serialize(writer);
+	writer.Finalize();
+}
+
+unique_ptr<ParsedExpression> ParsedExpression::Deserialize(Deserializer &source) {
+	FieldReader reader(source);
+	auto expression_class = reader.ReadRequired<ExpressionClass>();
+	auto type = reader.ReadRequired<ExpressionType>();
+	auto alias = reader.ReadRequired<string>();
+	unique_ptr<ParsedExpression> result;
+	switch (expression_class) {
+	case ExpressionClass::BETWEEN:
+		result = BetweenExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::CASE:
+		result = CaseExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::CAST:
+		result = CastExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::COLLATE:
+		result = CollateExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::COLUMN_REF:
+		result = ColumnRefExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::COMPARISON:
+		result = ComparisonExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::CONJUNCTION:
+		result = ConjunctionExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::CONSTANT:
+		result = ConstantExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::DEFAULT:
+		result = DefaultExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::FUNCTION:
+		result = FunctionExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::LAMBDA:
+		result = LambdaExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::OPERATOR:
+		result = OperatorExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::PARAMETER:
+		result = ParameterExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::POSITIONAL_REFERENCE:
+		result = PositionalReferenceExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::STAR:
+		result = StarExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::SUBQUERY:
+		result = SubqueryExpression::Deserialize(type, reader);
+		break;
+	case ExpressionClass::WINDOW:
+		result = WindowExpression::Deserialize(type, reader);
+		break;
+	default:
+		throw SerializationException("Unsupported type for expression deserialization!");
+	}
+	result->alias = alias;
+	reader.Finalize();
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+void ParsedExpressionIterator::EnumerateChildren(const ParsedExpression &expression,
+                                                 const std::function<void(const ParsedExpression &child)> &callback) {
+	EnumerateChildren((ParsedExpression &)expression, [&](unique_ptr<ParsedExpression> &child) {
+		D_ASSERT(child);
+		callback(*child);
+	});
+}
+
+void ParsedExpressionIterator::EnumerateChildren(ParsedExpression &expr,
+                                                 const std::function<void(ParsedExpression &child)> &callback) {
+	EnumerateChildren(expr, [&](unique_ptr<ParsedExpression> &child) {
+		D_ASSERT(child);
+		callback(*child);
+	});
+}
+
+void ParsedExpressionIterator::EnumerateChildren(
+    ParsedExpression &expr, const std::function<void(unique_ptr<ParsedExpression> &child)> &callback) {
+	switch (expr.expression_class) {
+	case ExpressionClass::BETWEEN: {
+		auto &cast_expr = (BetweenExpression &)expr;
+		callback(cast_expr.input);
+		callback(cast_expr.lower);
+		callback(cast_expr.upper);
+		break;
+	}
+	case ExpressionClass::CASE: {
+		auto &case_expr = (CaseExpression &)expr;
+		for (auto &check : case_expr.case_checks) {
+			callback(check.when_expr);
+			callback(check.then_expr);
+		}
+		callback(case_expr.else_expr);
+		break;
+	}
+	case ExpressionClass::CAST: {
+		auto &cast_expr = (CastExpression &)expr;
+		callback(cast_expr.child);
+		break;
+	}
+	case ExpressionClass::COLLATE: {
+		auto &cast_expr = (CollateExpression &)expr;
+		callback(cast_expr.child);
+		break;
+	}
+	case ExpressionClass::COMPARISON: {
+		auto &comp_expr = (ComparisonExpression &)expr;
+		callback(comp_expr.left);
+		callback(comp_expr.right);
+		break;
+	}
+	case ExpressionClass::CONJUNCTION: {
+		auto &conj_expr = (ConjunctionExpression &)expr;
+		for (auto &child : conj_expr.children) {
+			callback(child);
+		}
+		break;
+	}
+
+	case ExpressionClass::FUNCTION: {
+		auto &func_expr = (FunctionExpression &)expr;
+		for (auto &child : func_expr.children) {
+			callback(child);
+		}
+		if (func_expr.filter) {
+			callback(func_expr.filter);
+		}
+		if (func_expr.order_bys) {
+			for (auto &order : func_expr.order_bys->orders) {
+				callback(order.expression);
+			}
+		}
+		break;
+	}
+	case ExpressionClass::LAMBDA: {
+		auto &lambda_expr = (LambdaExpression &)expr;
+		callback(lambda_expr.lhs);
+		callback(lambda_expr.rhs);
+		break;
+	}
+	case ExpressionClass::OPERATOR: {
+		auto &op_expr = (OperatorExpression &)expr;
+		for (auto &child : op_expr.children) {
+			callback(child);
+		}
+		break;
+	}
+	case ExpressionClass::SUBQUERY: {
+		auto &subquery_expr = (SubqueryExpression &)expr;
+		if (subquery_expr.child) {
+			callback(subquery_expr.child);
+		}
+		break;
+	}
+	case ExpressionClass::WINDOW: {
+		auto &window_expr = (WindowExpression &)expr;
+		for (auto &partition : window_expr.partitions) {
+			callback(partition);
+		}
+		for (auto &order : window_expr.orders) {
+			callback(order.expression);
+		}
+		for (auto &child : window_expr.children) {
+			callback(child);
+		}
+		if (window_expr.filter_expr) {
+			callback(window_expr.filter_expr);
+		}
+		if (window_expr.start_expr) {
+			callback(window_expr.start_expr);
+		}
+		if (window_expr.end_expr) {
+			callback(window_expr.end_expr);
+		}
+		if (window_expr.offset_expr) {
+			callback(window_expr.offset_expr);
+		}
+		if (window_expr.default_expr) {
+			callback(window_expr.default_expr);
+		}
+		break;
+	}
+	case ExpressionClass::BOUND_EXPRESSION:
+	case ExpressionClass::COLUMN_REF:
+	case ExpressionClass::CONSTANT:
+	case ExpressionClass::DEFAULT:
+	case ExpressionClass::STAR:
+	case ExpressionClass::PARAMETER:
+	case ExpressionClass::POSITIONAL_REFERENCE:
+		// these node types have no children
+		break;
+	default:
+		// called on non ParsedExpression type!
+		throw NotImplementedException("Unimplemented expression class");
+	}
+}
+
+void ParsedExpressionIterator::EnumerateQueryNodeModifiers(
+    QueryNode &node, const std::function<void(unique_ptr<ParsedExpression> &child)> &callback) {
+
+	for (auto &modifier : node.modifiers) {
+		switch (modifier->type) {
+		case ResultModifierType::LIMIT_MODIFIER: {
+			auto &limit_modifier = (LimitModifier &)*modifier;
+			if (limit_modifier.limit) {
+				callback(limit_modifier.limit);
+			}
+			if (limit_modifier.offset) {
+				callback(limit_modifier.offset);
+			}
+		} break;
+
+		case ResultModifierType::LIMIT_PERCENT_MODIFIER: {
+			auto &limit_modifier = (LimitPercentModifier &)*modifier;
+			if (limit_modifier.limit) {
+				callback(limit_modifier.limit);
+			}
+			if (limit_modifier.offset) {
+				callback(limit_modifier.offset);
+			}
+		} break;
+
+		case ResultModifierType::ORDER_MODIFIER: {
+			auto &order_modifier = (OrderModifier &)*modifier;
+			for (auto &order : order_modifier.orders) {
+				callback(order.expression);
+			}
+		} break;
+
+		case ResultModifierType::DISTINCT_MODIFIER: {
+			auto &distinct_modifier = (DistinctModifier &)*modifier;
+			for (auto &target : distinct_modifier.distinct_on_targets) {
+				callback(target);
+			}
+		} break;
+
+		// do nothing
+		default:
+			break;
+		}
+	}
+}
+
+void ParsedExpressionIterator::EnumerateTableRefChildren(
+    TableRef &ref, const std::function<void(unique_ptr<ParsedExpression> &child)> &callback) {
+	switch (ref.type) {
+	case TableReferenceType::CROSS_PRODUCT: {
+		auto &cp_ref = (CrossProductRef &)ref;
+		EnumerateTableRefChildren(*cp_ref.left, callback);
+		EnumerateTableRefChildren(*cp_ref.right, callback);
+		break;
+	}
+	case TableReferenceType::EXPRESSION_LIST: {
+		auto &el_ref = (ExpressionListRef &)ref;
+		for (idx_t i = 0; i < el_ref.values.size(); i++) {
+			for (idx_t j = 0; j < el_ref.values[i].size(); j++) {
+				callback(el_ref.values[i][j]);
+			}
+		}
+		break;
+	}
+	case TableReferenceType::JOIN: {
+		auto &j_ref = (JoinRef &)ref;
+		EnumerateTableRefChildren(*j_ref.left, callback);
+		EnumerateTableRefChildren(*j_ref.right, callback);
+		callback(j_ref.condition);
+		break;
+	}
+	case TableReferenceType::SUBQUERY: {
+		auto &sq_ref = (SubqueryRef &)ref;
+		EnumerateQueryNodeChildren(*sq_ref.subquery->node, callback);
+		break;
+	}
+	case TableReferenceType::TABLE_FUNCTION: {
+		auto &tf_ref = (TableFunctionRef &)ref;
+		callback(tf_ref.function);
+		break;
+	}
+	case TableReferenceType::BASE_TABLE:
+	case TableReferenceType::EMPTY:
+		// these TableRefs do not need to be unfolded
+		break;
+	default:
+		throw NotImplementedException("TableRef type not implemented for traversal");
+	}
+}
+
+void ParsedExpressionIterator::EnumerateQueryNodeChildren(
+    QueryNode &node, const std::function<void(unique_ptr<ParsedExpression> &child)> &callback) {
+	switch (node.type) {
+	case QueryNodeType::RECURSIVE_CTE_NODE: {
+		auto &rcte_node = (RecursiveCTENode &)node;
+		EnumerateQueryNodeChildren(*rcte_node.left, callback);
+		EnumerateQueryNodeChildren(*rcte_node.right, callback);
+		break;
+	}
+	case QueryNodeType::SELECT_NODE: {
+		auto &sel_node = (SelectNode &)node;
+		for (idx_t i = 0; i < sel_node.select_list.size(); i++) {
+			callback(sel_node.select_list[i]);
+		}
+		for (idx_t i = 0; i < sel_node.groups.group_expressions.size(); i++) {
+			callback(sel_node.groups.group_expressions[i]);
+		}
+		if (sel_node.where_clause) {
+			callback(sel_node.where_clause);
+		}
+		if (sel_node.having) {
+			callback(sel_node.having);
+		}
+		if (sel_node.qualify) {
+			callback(sel_node.qualify);
+		}
+
+		EnumerateTableRefChildren(*sel_node.from_table.get(), callback);
+		break;
+	}
+	case QueryNodeType::SET_OPERATION_NODE: {
+		auto &setop_node = (SetOperationNode &)node;
+		EnumerateQueryNodeChildren(*setop_node.left, callback);
+		EnumerateQueryNodeChildren(*setop_node.right, callback);
+		break;
+	}
+	default:
+		throw NotImplementedException("QueryNode type not implemented for traversal");
+	}
+
+	if (!node.modifiers.empty()) {
+		EnumerateQueryNodeModifiers(node, callback);
+	}
+
+	for (auto &kv : node.cte_map) {
+		EnumerateQueryNodeChildren(*kv.second->query->node, callback);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+Parser::Parser(ParserOptions options_p) : options(options_p) {
+}
+
+void Parser::ParseQuery(const string &query) {
+	Transformer transformer(options.max_expression_depth);
+	{
+		PostgresParser::SetPreserveIdentifierCase(options.preserve_identifier_case);
+		PostgresParser parser;
+		parser.Parse(query);
+
+		if (!parser.success) {
+			throw ParserException(QueryErrorContext::Format(query, parser.error_message, parser.error_location - 1));
+		}
+
+		if (!parser.parse_tree) {
+			// empty statement
+			return;
+		}
+
+		// if it succeeded, we transform the Postgres parse tree into a list of
+		// SQLStatements
+		transformer.TransformParseTree(parser.parse_tree, statements);
+	}
+	if (!statements.empty()) {
+		auto &last_statement = statements.back();
+		last_statement->stmt_length = query.size() - last_statement->stmt_location;
+		for (auto &statement : statements) {
+			statement->query = query;
+			if (statement->type == StatementType::CREATE_STATEMENT) {
+				auto &create = (CreateStatement &)*statement;
+				create.info->sql = query.substr(statement->stmt_location, statement->stmt_length);
+			}
+		}
+	}
+}
+
+vector<SimplifiedToken> Parser::Tokenize(const string &query) {
+	auto pg_tokens = PostgresParser::Tokenize(query);
+	vector<SimplifiedToken> result;
+	result.reserve(pg_tokens.size());
+	for (auto &pg_token : pg_tokens) {
+		SimplifiedToken token;
+		switch (pg_token.type) {
+		case duckdb_libpgquery::PGSimplifiedTokenType::PG_SIMPLIFIED_TOKEN_IDENTIFIER:
+			token.type = SimplifiedTokenType::SIMPLIFIED_TOKEN_IDENTIFIER;
+			break;
+		case duckdb_libpgquery::PGSimplifiedTokenType::PG_SIMPLIFIED_TOKEN_NUMERIC_CONSTANT:
+			token.type = SimplifiedTokenType::SIMPLIFIED_TOKEN_NUMERIC_CONSTANT;
+			break;
+		case duckdb_libpgquery::PGSimplifiedTokenType::PG_SIMPLIFIED_TOKEN_STRING_CONSTANT:
+			token.type = SimplifiedTokenType::SIMPLIFIED_TOKEN_STRING_CONSTANT;
+			break;
+		case duckdb_libpgquery::PGSimplifiedTokenType::PG_SIMPLIFIED_TOKEN_OPERATOR:
+			token.type = SimplifiedTokenType::SIMPLIFIED_TOKEN_OPERATOR;
+			break;
+		case duckdb_libpgquery::PGSimplifiedTokenType::PG_SIMPLIFIED_TOKEN_KEYWORD:
+			token.type = SimplifiedTokenType::SIMPLIFIED_TOKEN_KEYWORD;
+			break;
+		// comments are not supported by our tokenizer right now
+		case duckdb_libpgquery::PGSimplifiedTokenType::PG_SIMPLIFIED_TOKEN_COMMENT: // LCOV_EXCL_START
+			token.type = SimplifiedTokenType::SIMPLIFIED_TOKEN_COMMENT;
+			break;
+		default:
+			throw InternalException("Unrecognized token category");
+		} // LCOV_EXCL_STOP
+		token.start = pg_token.start;
+		result.push_back(token);
+	}
+	return result;
+}
+
+bool Parser::IsKeyword(const string &text) {
+	return PostgresParser::IsKeyword(text);
+}
+
+vector<ParserKeyword> Parser::KeywordList() {
+	auto keywords = PostgresParser::KeywordList();
+	vector<ParserKeyword> result;
+	for (auto &kw : keywords) {
+		ParserKeyword res;
+		res.name = kw.text;
+		switch (kw.category) {
+		case duckdb_libpgquery::PGKeywordCategory::PG_KEYWORD_RESERVED:
+			res.category = KeywordCategory::KEYWORD_RESERVED;
+			break;
+		case duckdb_libpgquery::PGKeywordCategory::PG_KEYWORD_UNRESERVED:
+			res.category = KeywordCategory::KEYWORD_UNRESERVED;
+			break;
+		case duckdb_libpgquery::PGKeywordCategory::PG_KEYWORD_TYPE_FUNC:
+			res.category = KeywordCategory::KEYWORD_TYPE_FUNC;
+			break;
+		case duckdb_libpgquery::PGKeywordCategory::PG_KEYWORD_COL_NAME:
+			res.category = KeywordCategory::KEYWORD_COL_NAME;
+			break;
+		default:
+			throw InternalException("Unrecognized keyword category");
+		}
+		result.push_back(res);
+	}
+	return result;
+}
+
+vector<unique_ptr<ParsedExpression>> Parser::ParseExpressionList(const string &select_list, ParserOptions options) {
+	// construct a mock query prefixed with SELECT
+	string mock_query = "SELECT " + select_list;
+	// parse the query
+	Parser parser(options);
+	parser.ParseQuery(mock_query);
+	// check the statements
+	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
+		throw ParserException("Expected a single SELECT statement");
+	}
+	auto &select = (SelectStatement &)*parser.statements[0];
+	if (select.node->type != QueryNodeType::SELECT_NODE) {
+		throw ParserException("Expected a single SELECT node");
+	}
+	auto &select_node = (SelectNode &)*select.node;
+	return move(select_node.select_list);
+}
+
+vector<OrderByNode> Parser::ParseOrderList(const string &select_list, ParserOptions options) {
+	// construct a mock query
+	string mock_query = "SELECT * FROM tbl ORDER BY " + select_list;
+	// parse the query
+	Parser parser(options);
+	parser.ParseQuery(mock_query);
+	// check the statements
+	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
+		throw ParserException("Expected a single SELECT statement");
+	}
+	auto &select = (SelectStatement &)*parser.statements[0];
+	if (select.node->type != QueryNodeType::SELECT_NODE) {
+		throw InternalException("Expected a single SELECT node");
+	}
+	auto &select_node = (SelectNode &)*select.node;
+	if (select_node.modifiers.empty() || select_node.modifiers[0]->type != ResultModifierType::ORDER_MODIFIER ||
+	    select_node.modifiers.size() != 1) {
+		throw InternalException("Expected a single ORDER clause");
+	}
+	auto &order = (OrderModifier &)*select_node.modifiers[0];
+	return move(order.orders);
+}
+
+void Parser::ParseUpdateList(const string &update_list, vector<string> &update_columns,
+                             vector<unique_ptr<ParsedExpression>> &expressions, ParserOptions options) {
+	// construct a mock query
+	string mock_query = "UPDATE tbl SET " + update_list;
+	// parse the query
+	Parser parser(options);
+	parser.ParseQuery(mock_query);
+	// check the statements
+	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::UPDATE_STATEMENT) {
+		throw ParserException("Expected a single UPDATE statement");
+	}
+	auto &update = (UpdateStatement &)*parser.statements[0];
+	update_columns = move(update.columns);
+	expressions = move(update.expressions);
+}
+
+vector<vector<unique_ptr<ParsedExpression>>> Parser::ParseValuesList(const string &value_list, ParserOptions options) {
+	// construct a mock query
+	string mock_query = "VALUES " + value_list;
+	// parse the query
+	Parser parser(options);
+	parser.ParseQuery(mock_query);
+	// check the statements
+	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
+		throw ParserException("Expected a single SELECT statement");
+	}
+	auto &select = (SelectStatement &)*parser.statements[0];
+	if (select.node->type != QueryNodeType::SELECT_NODE) {
+		throw ParserException("Expected a single SELECT node");
+	}
+	auto &select_node = (SelectNode &)*select.node;
+	if (!select_node.from_table || select_node.from_table->type != TableReferenceType::EXPRESSION_LIST) {
+		throw InternalException("Expected a single VALUES statement");
+	}
+	auto &values_list = (ExpressionListRef &)*select_node.from_table;
+	return move(values_list.values);
+}
+
+vector<ColumnDefinition> Parser::ParseColumnList(const string &column_list, ParserOptions options) {
+	string mock_query = "CREATE TABLE blabla (" + column_list + ")";
+	Parser parser(options);
+	parser.ParseQuery(mock_query);
+	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::CREATE_STATEMENT) {
+		throw ParserException("Expected a single CREATE statement");
+	}
+	auto &create = (CreateStatement &)*parser.statements[0];
+	if (create.info->type != CatalogType::TABLE_ENTRY) {
+		throw InternalException("Expected a single CREATE TABLE statement");
+	}
+	auto &info = ((CreateTableInfo &)*create.info);
+	return move(info.columns);
+}
+
+} // namespace duckdb

--- a/velox/external/duckdb/duckdb-7.cpp
+++ b/velox/external/duckdb/duckdb-7.cpp
@@ -1,0 +1,17276 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+
+
+
+
+namespace duckdb {
+
+string QueryErrorContext::Format(const string &query, const string &error_message, int error_loc) {
+	if (error_loc < 0 || size_t(error_loc) >= query.size()) {
+		// no location in query provided
+		return error_message;
+	}
+	idx_t error_location = idx_t(error_loc);
+	// count the line numbers until the error location
+	// and set the start position as the first character of that line
+	idx_t start_pos = 0;
+	idx_t line_number = 1;
+	for (idx_t i = 0; i < error_location; i++) {
+		if (StringUtil::CharacterIsNewline(query[i])) {
+			line_number++;
+			start_pos = i + 1;
+		}
+	}
+	// now find either the next newline token after the query, or find the end of string
+	// this is the initial end position
+	idx_t end_pos = query.size();
+	for (idx_t i = error_location; i < query.size(); i++) {
+		if (StringUtil::CharacterIsNewline(query[i])) {
+			end_pos = i;
+			break;
+		}
+	}
+	// now start scanning from the start pos
+	// we want to figure out the start and end pos of what we are going to render
+	// we want to render at most 80 characters in total, with the error_location located in the middle
+	const char *buf = query.c_str() + start_pos;
+	idx_t len = end_pos - start_pos;
+	vector<idx_t> render_widths;
+	vector<idx_t> positions;
+	if (Utf8Proc::IsValid(buf, len)) {
+		// for unicode awareness, we traverse the graphemes of the current line and keep track of their render widths
+		// and of their position in the string
+		for (idx_t cpos = 0; cpos < len;) {
+			auto char_render_width = Utf8Proc::RenderWidth(buf, len, cpos);
+			positions.push_back(cpos);
+			render_widths.push_back(char_render_width);
+			cpos = Utf8Proc::NextGraphemeCluster(buf, len, cpos);
+		}
+	} else { // LCOV_EXCL_START
+		// invalid utf-8, we can't do much at this point
+		// we just assume every character is a character, and every character has a render width of 1
+		for (idx_t cpos = 0; cpos < len; cpos++) {
+			positions.push_back(cpos);
+			render_widths.push_back(1);
+		}
+	} // LCOV_EXCL_STOP
+	// now we want to find the (unicode aware) start and end position
+	idx_t epos = 0;
+	// start by finding the error location inside the array
+	for (idx_t i = 0; i < positions.size(); i++) {
+		if (positions[i] >= (error_location - start_pos)) {
+			epos = i;
+			break;
+		}
+	}
+	bool truncate_beginning = false;
+	bool truncate_end = false;
+	idx_t spos = 0;
+	// now we iterate backwards from the error location
+	// we show max 40 render width before the error location
+	idx_t current_render_width = 0;
+	for (idx_t i = epos; i > 0; i--) {
+		current_render_width += render_widths[i];
+		if (current_render_width >= 40) {
+			truncate_beginning = true;
+			start_pos = positions[i];
+			spos = i;
+			break;
+		}
+	}
+	// now do the same, but going forward
+	current_render_width = 0;
+	for (idx_t i = epos; i < positions.size(); i++) {
+		current_render_width += render_widths[i];
+		if (current_render_width >= 40) {
+			truncate_end = true;
+			end_pos = positions[i];
+			break;
+		}
+	}
+	string line_indicator = "LINE " + to_string(line_number) + ": ";
+	string begin_trunc = truncate_beginning ? "..." : "";
+	string end_trunc = truncate_end ? "..." : "";
+
+	// get the render width of the error indicator (i.e. how many spaces we need to insert before the ^)
+	idx_t error_render_width = 0;
+	for (idx_t i = spos; i < epos; i++) {
+		error_render_width += render_widths[i];
+	}
+	error_render_width += line_indicator.size() + begin_trunc.size();
+
+	// now first print the error message plus the current line (or a subset of the line)
+	string result = error_message;
+	result += "\n" + line_indicator + begin_trunc + query.substr(start_pos, end_pos - start_pos) + end_trunc;
+	// print an arrow pointing at the error location
+	result += "\n" + string(error_render_width, ' ') + "^";
+	return result;
+}
+
+string QueryErrorContext::FormatErrorRecursive(const string &msg, vector<ExceptionFormatValue> &values) {
+	string error_message = values.empty() ? msg : ExceptionFormatValue::Format(msg, values);
+	if (!statement || query_location >= statement->query.size()) {
+		// no statement provided or query location out of range
+		return error_message;
+	}
+	return Format(statement->query, error_message, query_location);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+string RecursiveCTENode::ToString() const {
+	string result;
+	result += "(" + left->ToString() + ")";
+	result += " UNION ";
+	if (union_all) {
+		result += " ALL ";
+	}
+	result += "(" + right->ToString() + ")";
+	return result;
+}
+
+bool RecursiveCTENode::Equals(const QueryNode *other_p) const {
+	if (!QueryNode::Equals(other_p)) {
+		return false;
+	}
+	if (this == other_p) {
+		return true;
+	}
+	auto other = (RecursiveCTENode *)other_p;
+
+	if (other->union_all != union_all) {
+		return false;
+	}
+	if (!left->Equals(other->left.get())) {
+		return false;
+	}
+	if (!right->Equals(other->right.get())) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<QueryNode> RecursiveCTENode::Copy() const {
+	auto result = make_unique<RecursiveCTENode>();
+	result->ctename = ctename;
+	result->union_all = union_all;
+	result->left = left->Copy();
+	result->right = right->Copy();
+	result->aliases = aliases;
+	this->CopyProperties(*result);
+	return move(result);
+}
+
+void RecursiveCTENode::Serialize(FieldWriter &writer) const {
+	writer.WriteString(ctename);
+	writer.WriteField<bool>(union_all);
+	writer.WriteSerializable(*left);
+	writer.WriteSerializable(*right);
+	writer.WriteList<string>(aliases);
+}
+
+unique_ptr<QueryNode> RecursiveCTENode::Deserialize(FieldReader &reader) {
+	auto result = make_unique<RecursiveCTENode>();
+	result->ctename = reader.ReadRequired<string>();
+	result->union_all = reader.ReadRequired<bool>();
+	result->left = reader.ReadRequiredSerializable<QueryNode>();
+	result->right = reader.ReadRequiredSerializable<QueryNode>();
+	result->aliases = reader.ReadRequiredList<string>();
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+SelectNode::SelectNode()
+    : QueryNode(QueryNodeType::SELECT_NODE), aggregate_handling(AggregateHandling::STANDARD_HANDLING) {
+}
+
+string SelectNode::ToString() const {
+	string result;
+	result = CTEToString();
+	result += "SELECT ";
+
+	// search for a distinct modifier
+	for (idx_t modifier_idx = 0; modifier_idx < modifiers.size(); modifier_idx++) {
+		if (modifiers[modifier_idx]->type == ResultModifierType::DISTINCT_MODIFIER) {
+			auto &distinct_modifier = (DistinctModifier &)*modifiers[modifier_idx];
+			result += "DISTINCT ";
+			if (!distinct_modifier.distinct_on_targets.empty()) {
+				result += "ON (";
+				for (idx_t k = 0; k < distinct_modifier.distinct_on_targets.size(); k++) {
+					if (k > 0) {
+						result += ", ";
+					}
+					result += distinct_modifier.distinct_on_targets[k]->ToString();
+				}
+				result += ") ";
+			}
+		}
+	}
+	for (idx_t i = 0; i < select_list.size(); i++) {
+		if (i > 0) {
+			result += ", ";
+		}
+		result += select_list[i]->ToString();
+		if (!select_list[i]->alias.empty()) {
+			result += " AS " + KeywordHelper::WriteOptionallyQuoted(select_list[i]->alias);
+		}
+	}
+	if (from_table && from_table->type != TableReferenceType::EMPTY) {
+		result += " FROM " + from_table->ToString();
+	}
+	if (where_clause) {
+		result += " WHERE " + where_clause->ToString();
+	}
+	if (!groups.grouping_sets.empty()) {
+		result += " GROUP BY ";
+		// if we are dealing with multiple grouping sets, we have to add a few additional brackets
+		bool grouping_sets = groups.grouping_sets.size() > 1;
+		if (grouping_sets) {
+			result += "GROUPING SETS (";
+		}
+		for (idx_t i = 0; i < groups.grouping_sets.size(); i++) {
+			auto &grouping_set = groups.grouping_sets[i];
+			if (i > 0) {
+				result += ",";
+			}
+			if (grouping_set.empty()) {
+				result += "()";
+				continue;
+			}
+			if (grouping_sets) {
+				result += "(";
+			}
+			bool first = true;
+			for (auto &grp : grouping_set) {
+				if (!first) {
+					result += ", ";
+				}
+				result += groups.group_expressions[grp]->ToString();
+				first = false;
+			}
+			if (grouping_sets) {
+				result += ")";
+			}
+		}
+		if (grouping_sets) {
+			result += ")";
+		}
+	} else if (aggregate_handling == AggregateHandling::FORCE_AGGREGATES) {
+		result += " GROUP BY ALL";
+	}
+	if (having) {
+		result += " HAVING " + having->ToString();
+	}
+	if (qualify) {
+		result += " QUALIFY " + qualify->ToString();
+	}
+	if (sample) {
+		result += " USING SAMPLE ";
+		result += sample->sample_size.ToString();
+		if (sample->is_percentage) {
+			result += "%";
+		}
+		result += " (" + SampleMethodToString(sample->method);
+		if (sample->seed >= 0) {
+			result += ", " + std::to_string(sample->seed);
+		}
+		result += ")";
+	}
+	return result + ResultModifiersToString();
+}
+
+bool SelectNode::Equals(const QueryNode *other_p) const {
+	if (!QueryNode::Equals(other_p)) {
+		return false;
+	}
+	if (this == other_p) {
+		return true;
+	}
+	auto other = (SelectNode *)other_p;
+
+	// SELECT
+	if (!ExpressionUtil::ListEquals(select_list, other->select_list)) {
+		return false;
+	}
+	// FROM
+	if (from_table) {
+		// we have a FROM clause, compare to the other one
+		if (!from_table->Equals(other->from_table.get())) {
+			return false;
+		}
+	} else if (other->from_table) {
+		// we don't have a FROM clause, if the other statement has one they are
+		// not equal
+		return false;
+	}
+	// WHERE
+	if (!BaseExpression::Equals(where_clause.get(), other->where_clause.get())) {
+		return false;
+	}
+	// GROUP BY
+	if (!ExpressionUtil::ListEquals(groups.group_expressions, other->groups.group_expressions)) {
+		return false;
+	}
+	if (groups.grouping_sets != other->groups.grouping_sets) {
+		return false;
+	}
+	if (!SampleOptions::Equals(sample.get(), other->sample.get())) {
+		return false;
+	}
+	// HAVING
+	if (!BaseExpression::Equals(having.get(), other->having.get())) {
+		return false;
+	}
+	// QUALIFY
+	if (!BaseExpression::Equals(qualify.get(), other->qualify.get())) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<QueryNode> SelectNode::Copy() const {
+	auto result = make_unique<SelectNode>();
+	for (auto &child : select_list) {
+		result->select_list.push_back(child->Copy());
+	}
+	result->from_table = from_table ? from_table->Copy() : nullptr;
+	result->where_clause = where_clause ? where_clause->Copy() : nullptr;
+	// groups
+	for (auto &group : groups.group_expressions) {
+		result->groups.group_expressions.push_back(group->Copy());
+	}
+	result->groups.grouping_sets = groups.grouping_sets;
+	result->aggregate_handling = aggregate_handling;
+	result->having = having ? having->Copy() : nullptr;
+	result->qualify = qualify ? qualify->Copy() : nullptr;
+	result->sample = sample ? sample->Copy() : nullptr;
+	this->CopyProperties(*result);
+	return move(result);
+}
+
+void SelectNode::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializableList(select_list);
+	writer.WriteOptional(from_table);
+	writer.WriteOptional(where_clause);
+	writer.WriteSerializableList(groups.group_expressions);
+	writer.WriteField<uint32_t>(groups.grouping_sets.size());
+	auto &serializer = writer.GetSerializer();
+	for (auto &grouping_set : groups.grouping_sets) {
+		serializer.Write<idx_t>(grouping_set.size());
+		for (auto &idx : grouping_set) {
+			serializer.Write<idx_t>(idx);
+		}
+	}
+	writer.WriteField<AggregateHandling>(aggregate_handling);
+	writer.WriteOptional(having);
+	writer.WriteOptional(sample);
+	writer.WriteOptional(qualify);
+}
+
+unique_ptr<QueryNode> SelectNode::Deserialize(FieldReader &reader) {
+	auto result = make_unique<SelectNode>();
+	result->select_list = reader.ReadRequiredSerializableList<ParsedExpression>();
+	result->from_table = reader.ReadOptional<TableRef>(nullptr);
+	result->where_clause = reader.ReadOptional<ParsedExpression>(nullptr);
+	result->groups.group_expressions = reader.ReadRequiredSerializableList<ParsedExpression>();
+
+	auto grouping_set_count = reader.ReadRequired<uint32_t>();
+	auto &source = reader.GetSource();
+	for (idx_t set_idx = 0; set_idx < grouping_set_count; set_idx++) {
+		auto set_entries = source.Read<idx_t>();
+		GroupingSet grouping_set;
+		for (idx_t i = 0; i < set_entries; i++) {
+			grouping_set.insert(source.Read<idx_t>());
+		}
+		result->groups.grouping_sets.push_back(grouping_set);
+	}
+	result->aggregate_handling = reader.ReadRequired<AggregateHandling>();
+	result->having = reader.ReadOptional<ParsedExpression>(nullptr);
+	result->sample = reader.ReadOptional<SampleOptions>(nullptr);
+	result->qualify = reader.ReadOptional<ParsedExpression>(nullptr);
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+string SetOperationNode::ToString() const {
+	string result;
+	result = CTEToString();
+	result += "(" + left->ToString() + ") ";
+	bool is_distinct = false;
+	for (idx_t modifier_idx = 0; modifier_idx < modifiers.size(); modifier_idx++) {
+		if (modifiers[modifier_idx]->type == ResultModifierType::DISTINCT_MODIFIER) {
+			is_distinct = true;
+			break;
+		}
+	}
+
+	switch (setop_type) {
+	case SetOperationType::UNION:
+		result += is_distinct ? "UNION" : "UNION ALL";
+		break;
+	case SetOperationType::EXCEPT:
+		D_ASSERT(is_distinct);
+		result += "EXCEPT";
+		break;
+	case SetOperationType::INTERSECT:
+		D_ASSERT(is_distinct);
+		result += "INTERSECT";
+		break;
+	default:
+		throw InternalException("Unsupported set operation type");
+	}
+	result += " (" + right->ToString() + ")";
+	return result + ResultModifiersToString();
+}
+
+bool SetOperationNode::Equals(const QueryNode *other_p) const {
+	if (!QueryNode::Equals(other_p)) {
+		return false;
+	}
+	if (this == other_p) {
+		return true;
+	}
+	auto other = (SetOperationNode *)other_p;
+	if (setop_type != other->setop_type) {
+		return false;
+	}
+	if (!left->Equals(other->left.get())) {
+		return false;
+	}
+	if (!right->Equals(other->right.get())) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<QueryNode> SetOperationNode::Copy() const {
+	auto result = make_unique<SetOperationNode>();
+	result->setop_type = setop_type;
+	result->left = left->Copy();
+	result->right = right->Copy();
+	this->CopyProperties(*result);
+	return move(result);
+}
+
+void SetOperationNode::Serialize(FieldWriter &writer) const {
+	writer.WriteField<SetOperationType>(setop_type);
+	writer.WriteSerializable(*left);
+	writer.WriteSerializable(*right);
+}
+
+unique_ptr<QueryNode> SetOperationNode::Deserialize(FieldReader &reader) {
+	auto result = make_unique<SetOperationNode>();
+	result->setop_type = reader.ReadRequired<SetOperationType>();
+	result->left = reader.ReadRequiredSerializable<QueryNode>();
+	result->right = reader.ReadRequiredSerializable<QueryNode>();
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+string QueryNode::CTEToString() const {
+	if (cte_map.empty()) {
+		return string();
+	}
+	// check if there are any recursive CTEs
+	bool has_recursive = false;
+	for (auto &kv : cte_map) {
+		if (kv.second->query->node->type == QueryNodeType::RECURSIVE_CTE_NODE) {
+			has_recursive = true;
+			break;
+		}
+	}
+	string result = "WITH ";
+	if (has_recursive) {
+		result += "RECURSIVE ";
+	}
+	bool first_cte = true;
+	for (auto &kv : cte_map) {
+		if (!first_cte) {
+			result += ", ";
+		}
+		auto &cte = *kv.second;
+		result += KeywordHelper::WriteOptionallyQuoted(kv.first);
+		if (!cte.aliases.empty()) {
+			result += " (";
+			for (idx_t k = 0; k < cte.aliases.size(); k++) {
+				if (k > 0) {
+					result += ", ";
+				}
+				result += KeywordHelper::WriteOptionallyQuoted(cte.aliases[k]);
+			}
+			result += ")";
+		}
+		result += " AS (";
+		result += cte.query->ToString();
+		result += ")";
+		first_cte = false;
+	}
+	return result;
+}
+
+string QueryNode::ResultModifiersToString() const {
+	string result;
+	for (idx_t modifier_idx = 0; modifier_idx < modifiers.size(); modifier_idx++) {
+		auto &modifier = *modifiers[modifier_idx];
+		if (modifier.type == ResultModifierType::ORDER_MODIFIER) {
+			auto &order_modifier = (OrderModifier &)modifier;
+			result += " ORDER BY ";
+			for (idx_t k = 0; k < order_modifier.orders.size(); k++) {
+				if (k > 0) {
+					result += ", ";
+				}
+				result += order_modifier.orders[k].ToString();
+			}
+		} else if (modifier.type == ResultModifierType::LIMIT_MODIFIER) {
+			auto &limit_modifier = (LimitModifier &)modifier;
+			if (limit_modifier.limit) {
+				result += " LIMIT " + limit_modifier.limit->ToString();
+			}
+			if (limit_modifier.offset) {
+				result += " OFFSET " + limit_modifier.offset->ToString();
+			}
+		} else if (modifier.type == ResultModifierType::LIMIT_PERCENT_MODIFIER) {
+			auto &limit_p_modifier = (LimitPercentModifier &)modifier;
+			if (limit_p_modifier.limit) {
+				result += " LIMIT " + limit_p_modifier.limit->ToString() + " %";
+			}
+			if (limit_p_modifier.offset) {
+				result += " OFFSET " + limit_p_modifier.offset->ToString();
+			}
+		}
+	}
+	return result;
+}
+
+bool QueryNode::Equals(const QueryNode *other) const {
+	if (!other) {
+		return false;
+	}
+	if (this == other) {
+		return true;
+	}
+	if (other->type != this->type) {
+		return false;
+	}
+	if (modifiers.size() != other->modifiers.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < modifiers.size(); i++) {
+		if (!modifiers[i]->Equals(other->modifiers[i].get())) {
+			return false;
+		}
+	}
+	// WITH clauses (CTEs)
+	if (cte_map.size() != other->cte_map.size()) {
+		return false;
+	}
+	for (auto &entry : cte_map) {
+		auto other_entry = other->cte_map.find(entry.first);
+		if (other_entry == other->cte_map.end()) {
+			return false;
+		}
+		if (entry.second->aliases != other_entry->second->aliases) {
+			return false;
+		}
+		if (!entry.second->query->Equals(other_entry->second->query.get())) {
+			return false;
+		}
+	}
+	return other->type == type;
+}
+
+void QueryNode::CopyProperties(QueryNode &other) const {
+	for (auto &modifier : modifiers) {
+		other.modifiers.push_back(modifier->Copy());
+	}
+	for (auto &kv : cte_map) {
+		auto kv_info = make_unique<CommonTableExpressionInfo>();
+		for (auto &al : kv.second->aliases) {
+			kv_info->aliases.push_back(al);
+		}
+		kv_info->query = unique_ptr_cast<SQLStatement, SelectStatement>(kv.second->query->Copy());
+		other.cte_map[kv.first] = move(kv_info);
+	}
+}
+
+void QueryNode::Serialize(Serializer &main_serializer) const {
+	FieldWriter writer(main_serializer);
+	writer.WriteField<QueryNodeType>(type);
+	writer.WriteSerializableList(modifiers);
+	// cte_map
+	writer.WriteField<uint32_t>((uint32_t)cte_map.size());
+	auto &serializer = writer.GetSerializer();
+	for (auto &cte : cte_map) {
+		serializer.WriteString(cte.first);
+		serializer.WriteStringVector(cte.second->aliases);
+		cte.second->query->Serialize(serializer);
+	}
+	Serialize(writer);
+	writer.Finalize();
+}
+
+unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &main_source) {
+	FieldReader reader(main_source);
+
+	auto type = reader.ReadRequired<QueryNodeType>();
+	auto modifiers = reader.ReadRequiredSerializableList<ResultModifier>();
+	// cte_map
+	auto cte_count = reader.ReadRequired<uint32_t>();
+	auto &source = reader.GetSource();
+	unordered_map<string, unique_ptr<CommonTableExpressionInfo>> cte_map;
+	for (idx_t i = 0; i < cte_count; i++) {
+		auto name = source.Read<string>();
+		auto info = make_unique<CommonTableExpressionInfo>();
+		source.ReadStringVector(info->aliases);
+		info->query = SelectStatement::Deserialize(source);
+		cte_map[name] = move(info);
+	}
+
+	unique_ptr<QueryNode> result;
+	switch (type) {
+	case QueryNodeType::SELECT_NODE:
+		result = SelectNode::Deserialize(reader);
+		break;
+	case QueryNodeType::SET_OPERATION_NODE:
+		result = SetOperationNode::Deserialize(reader);
+		break;
+	case QueryNodeType::RECURSIVE_CTE_NODE:
+		result = RecursiveCTENode::Deserialize(reader);
+		break;
+	default:
+		throw SerializationException("Could not deserialize Query Node: unknown type!");
+	}
+	result->modifiers = move(modifiers);
+	result->cte_map = move(cte_map);
+	reader.Finalize();
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+bool ResultModifier::Equals(const ResultModifier *other) const {
+	if (!other) {
+		return false;
+	}
+	return type == other->type;
+}
+
+void ResultModifier::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	writer.WriteField<ResultModifierType>(type);
+	Serialize(writer);
+	writer.Finalize();
+}
+
+unique_ptr<ResultModifier> ResultModifier::Deserialize(Deserializer &source) {
+	FieldReader reader(source);
+	auto type = reader.ReadRequired<ResultModifierType>();
+
+	unique_ptr<ResultModifier> result;
+	switch (type) {
+	case ResultModifierType::LIMIT_MODIFIER:
+		result = LimitModifier::Deserialize(reader);
+		break;
+	case ResultModifierType::ORDER_MODIFIER:
+		result = OrderModifier::Deserialize(reader);
+		break;
+	case ResultModifierType::DISTINCT_MODIFIER:
+		result = DistinctModifier::Deserialize(reader);
+		break;
+	case ResultModifierType::LIMIT_PERCENT_MODIFIER:
+		result = LimitPercentModifier::Deserialize(reader);
+		break;
+	default:
+		throw InternalException("Unrecognized ResultModifierType for Deserialization");
+	}
+	reader.Finalize();
+	return result;
+}
+
+bool LimitModifier::Equals(const ResultModifier *other_p) const {
+	if (!ResultModifier::Equals(other_p)) {
+		return false;
+	}
+	auto &other = (LimitModifier &)*other_p;
+	if (!BaseExpression::Equals(limit.get(), other.limit.get())) {
+		return false;
+	}
+	if (!BaseExpression::Equals(offset.get(), other.offset.get())) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<ResultModifier> LimitModifier::Copy() const {
+	auto copy = make_unique<LimitModifier>();
+	if (limit) {
+		copy->limit = limit->Copy();
+	}
+	if (offset) {
+		copy->offset = offset->Copy();
+	}
+	return move(copy);
+}
+
+void LimitModifier::Serialize(FieldWriter &writer) const {
+	writer.WriteOptional(limit);
+	writer.WriteOptional(offset);
+}
+
+unique_ptr<ResultModifier> LimitModifier::Deserialize(FieldReader &reader) {
+	auto mod = make_unique<LimitModifier>();
+	mod->limit = reader.ReadOptional<ParsedExpression>(nullptr);
+	mod->offset = reader.ReadOptional<ParsedExpression>(nullptr);
+	return move(mod);
+}
+
+bool DistinctModifier::Equals(const ResultModifier *other_p) const {
+	if (!ResultModifier::Equals(other_p)) {
+		return false;
+	}
+	auto &other = (DistinctModifier &)*other_p;
+	if (!ExpressionUtil::ListEquals(distinct_on_targets, other.distinct_on_targets)) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<ResultModifier> DistinctModifier::Copy() const {
+	auto copy = make_unique<DistinctModifier>();
+	for (auto &expr : distinct_on_targets) {
+		copy->distinct_on_targets.push_back(expr->Copy());
+	}
+	return move(copy);
+}
+
+void DistinctModifier::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializableList(distinct_on_targets);
+}
+
+unique_ptr<ResultModifier> DistinctModifier::Deserialize(FieldReader &reader) {
+	auto mod = make_unique<DistinctModifier>();
+	mod->distinct_on_targets = reader.ReadRequiredSerializableList<ParsedExpression>();
+	return move(mod);
+}
+
+bool OrderModifier::Equals(const ResultModifier *other_p) const {
+	if (!ResultModifier::Equals(other_p)) {
+		return false;
+	}
+	auto &other = (OrderModifier &)*other_p;
+	if (orders.size() != other.orders.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < orders.size(); i++) {
+		if (orders[i].type != other.orders[i].type) {
+			return false;
+		}
+		if (!BaseExpression::Equals(orders[i].expression.get(), other.orders[i].expression.get())) {
+			return false;
+		}
+	}
+	return true;
+}
+
+unique_ptr<ResultModifier> OrderModifier::Copy() const {
+	auto copy = make_unique<OrderModifier>();
+	for (auto &order : orders) {
+		copy->orders.emplace_back(order.type, order.null_order, order.expression->Copy());
+	}
+	return move(copy);
+}
+
+string OrderByNode::ToString() const {
+	auto str = expression->ToString();
+	switch (type) {
+	case OrderType::ASCENDING:
+		str += " ASC";
+		break;
+	case OrderType::DESCENDING:
+		str += " DESC";
+		break;
+	default:
+		break;
+	}
+
+	switch (null_order) {
+	case OrderByNullType::NULLS_FIRST:
+		str += " NULLS FIRST";
+		break;
+	case OrderByNullType::NULLS_LAST:
+		str += " NULLS LAST";
+		break;
+	default:
+		break;
+	}
+	return str;
+}
+
+void OrderByNode::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	writer.WriteField<OrderType>(type);
+	writer.WriteField<OrderByNullType>(null_order);
+	writer.WriteSerializable(*expression);
+	writer.Finalize();
+}
+
+OrderByNode OrderByNode::Deserialize(Deserializer &source) {
+	FieldReader reader(source);
+	auto type = reader.ReadRequired<OrderType>();
+	auto null_order = reader.ReadRequired<OrderByNullType>();
+	auto expression = reader.ReadRequiredSerializable<ParsedExpression>();
+	reader.Finalize();
+	return OrderByNode(type, null_order, move(expression));
+}
+
+void OrderModifier::Serialize(FieldWriter &writer) const {
+	writer.WriteRegularSerializableList(orders);
+}
+
+unique_ptr<ResultModifier> OrderModifier::Deserialize(FieldReader &reader) {
+	auto mod = make_unique<OrderModifier>();
+	mod->orders = reader.ReadRequiredSerializableList<OrderByNode, OrderByNode>();
+	return move(mod);
+}
+
+bool LimitPercentModifier::Equals(const ResultModifier *other_p) const {
+	if (!ResultModifier::Equals(other_p)) {
+		return false;
+	}
+	auto &other = (LimitPercentModifier &)*other_p;
+	if (!BaseExpression::Equals(limit.get(), other.limit.get())) {
+		return false;
+	}
+	if (!BaseExpression::Equals(offset.get(), other.offset.get())) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<ResultModifier> LimitPercentModifier::Copy() const {
+	auto copy = make_unique<LimitPercentModifier>();
+	if (limit) {
+		copy->limit = limit->Copy();
+	}
+	if (offset) {
+		copy->offset = offset->Copy();
+	}
+	return move(copy);
+}
+
+void LimitPercentModifier::Serialize(FieldWriter &writer) const {
+	writer.WriteOptional(limit);
+	writer.WriteOptional(offset);
+}
+
+unique_ptr<ResultModifier> LimitPercentModifier::Deserialize(FieldReader &reader) {
+	auto mod = make_unique<LimitPercentModifier>();
+	mod->limit = reader.ReadOptional<ParsedExpression>(nullptr);
+	mod->offset = reader.ReadOptional<ParsedExpression>(nullptr);
+	return move(mod);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+AlterStatement::AlterStatement() : SQLStatement(StatementType::ALTER_STATEMENT) {
+}
+
+AlterStatement::AlterStatement(const AlterStatement &other) : SQLStatement(other), info(other.info->Copy()) {
+}
+
+unique_ptr<SQLStatement> AlterStatement::Copy() const {
+	return unique_ptr<AlterStatement>(new AlterStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+CallStatement::CallStatement() : SQLStatement(StatementType::CALL_STATEMENT) {
+}
+
+CallStatement::CallStatement(const CallStatement &other) : SQLStatement(other), function(other.function->Copy()) {
+}
+
+unique_ptr<SQLStatement> CallStatement::Copy() const {
+	return unique_ptr<CallStatement>(new CallStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+CopyStatement::CopyStatement() : SQLStatement(StatementType::COPY_STATEMENT), info(make_unique<CopyInfo>()) {
+}
+
+CopyStatement::CopyStatement(const CopyStatement &other) : SQLStatement(other), info(other.info->Copy()) {
+	if (other.select_statement) {
+		select_statement = other.select_statement->Copy();
+	}
+}
+
+unique_ptr<SQLStatement> CopyStatement::Copy() const {
+	return unique_ptr<CopyStatement>(new CopyStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+CreateStatement::CreateStatement() : SQLStatement(StatementType::CREATE_STATEMENT) {
+}
+
+CreateStatement::CreateStatement(const CreateStatement &other) : SQLStatement(other), info(other.info->Copy()) {
+}
+
+unique_ptr<SQLStatement> CreateStatement::Copy() const {
+	return unique_ptr<CreateStatement>(new CreateStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+DeleteStatement::DeleteStatement() : SQLStatement(StatementType::DELETE_STATEMENT) {
+}
+
+DeleteStatement::DeleteStatement(const DeleteStatement &other) : SQLStatement(other), table(other.table->Copy()) {
+	if (other.condition) {
+		condition = other.condition->Copy();
+	}
+	for (const auto &using_clause : other.using_clauses) {
+		using_clauses.push_back(using_clause->Copy());
+	}
+}
+
+string DeleteStatement::ToString() const {
+	string result;
+	result += "DELETE FROM ";
+	result += table->ToString();
+	if (!using_clauses.empty()) {
+		result += " USING ";
+		for (idx_t i = 0; i < using_clauses.size(); i++) {
+			if (i > 0) {
+				result += ", ";
+			}
+			result += using_clauses[i]->ToString();
+		}
+	}
+	if (condition) {
+		result += " WHERE " + condition->ToString();
+	}
+
+	if (!returning_list.empty()) {
+		result += " RETURNING ";
+		for (idx_t i = 0; i < returning_list.size(); i++) {
+			if (i > 0) {
+				result += ", ";
+			}
+			result += returning_list[i]->ToString();
+		}
+	}
+	return result;
+}
+
+unique_ptr<SQLStatement> DeleteStatement::Copy() const {
+	return unique_ptr<DeleteStatement>(new DeleteStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+DropStatement::DropStatement() : SQLStatement(StatementType::DROP_STATEMENT), info(make_unique<DropInfo>()) {
+}
+
+DropStatement::DropStatement(const DropStatement &other) : SQLStatement(other), info(other.info->Copy()) {
+}
+
+unique_ptr<SQLStatement> DropStatement::Copy() const {
+	return unique_ptr<DropStatement>(new DropStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+ExecuteStatement::ExecuteStatement() : SQLStatement(StatementType::EXECUTE_STATEMENT) {
+}
+
+ExecuteStatement::ExecuteStatement(const ExecuteStatement &other) : SQLStatement(other), name(other.name) {
+	for (const auto &value : other.values) {
+		values.push_back(value->Copy());
+	}
+}
+
+unique_ptr<SQLStatement> ExecuteStatement::Copy() const {
+	return unique_ptr<ExecuteStatement>(new ExecuteStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+ExplainStatement::ExplainStatement(unique_ptr<SQLStatement> stmt, ExplainType explain_type)
+    : SQLStatement(StatementType::EXPLAIN_STATEMENT), stmt(move(stmt)), explain_type(explain_type) {
+}
+
+ExplainStatement::ExplainStatement(const ExplainStatement &other)
+    : SQLStatement(other), stmt(other.stmt->Copy()), explain_type(other.explain_type) {
+}
+
+unique_ptr<SQLStatement> ExplainStatement::Copy() const {
+	return unique_ptr<ExplainStatement>(new ExplainStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+ExportStatement::ExportStatement(unique_ptr<CopyInfo> info)
+    : SQLStatement(StatementType::EXPORT_STATEMENT), info(move(info)) {
+}
+
+ExportStatement::ExportStatement(const ExportStatement &other) : SQLStatement(other), info(other.info->Copy()) {
+}
+
+unique_ptr<SQLStatement> ExportStatement::Copy() const {
+	return unique_ptr<ExportStatement>(new ExportStatement(*this));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+InsertStatement::InsertStatement() : SQLStatement(StatementType::INSERT_STATEMENT), schema(DEFAULT_SCHEMA) {
+}
+
+InsertStatement::InsertStatement(const InsertStatement &other)
+    : SQLStatement(other),
+      select_statement(unique_ptr_cast<SQLStatement, SelectStatement>(other.select_statement->Copy())),
+      columns(other.columns), table(other.table), schema(other.schema) {
+}
+
+string InsertStatement::ToString() const {
+	string result;
+	result = "INSERT INTO ";
+	if (!schema.empty()) {
+		result += KeywordHelper::WriteOptionallyQuoted(schema) + ".";
+	}
+	result += KeywordHelper::WriteOptionallyQuoted(table);
+	if (!columns.empty()) {
+		result += " (";
+		for (idx_t i = 0; i < columns.size(); i++) {
+			if (i > 0) {
+				result += ", ";
+			}
+			result += KeywordHelper::WriteOptionallyQuoted(columns[i]);
+		}
+		result += " )";
+	}
+	result += " ";
+	auto values_list = GetValuesList();
+	if (values_list) {
+		values_list->alias = string();
+		result += values_list->ToString();
+	} else {
+		result += select_statement->ToString();
+	}
+	if (!returning_list.empty()) {
+		result += " RETURNING ";
+		for (idx_t i = 0; i < returning_list.size(); i++) {
+			if (i > 0) {
+				result += ", ";
+			}
+			result += returning_list[i]->ToString();
+		}
+	}
+	return result;
+}
+
+unique_ptr<SQLStatement> InsertStatement::Copy() const {
+	return unique_ptr<InsertStatement>(new InsertStatement(*this));
+}
+
+ExpressionListRef *InsertStatement::GetValuesList() const {
+	if (select_statement->node->type != QueryNodeType::SELECT_NODE) {
+		return nullptr;
+	}
+	auto &node = (SelectNode &)*select_statement->node;
+	if (node.where_clause || node.qualify || node.having) {
+		return nullptr;
+	}
+	if (!node.cte_map.empty()) {
+		return nullptr;
+	}
+	if (!node.groups.grouping_sets.empty()) {
+		return nullptr;
+	}
+	if (node.aggregate_handling != AggregateHandling::STANDARD_HANDLING) {
+		return nullptr;
+	}
+	if (node.select_list.size() != 1 || node.select_list[0]->type != ExpressionType::STAR) {
+		return nullptr;
+	}
+	if (!node.from_table || node.from_table->type != TableReferenceType::EXPRESSION_LIST) {
+		return nullptr;
+	}
+	return (ExpressionListRef *)node.from_table.get();
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+LoadStatement::LoadStatement() : SQLStatement(StatementType::LOAD_STATEMENT) {
+}
+
+LoadStatement::LoadStatement(const LoadStatement &other) : SQLStatement(other), info(other.info->Copy()) {
+}
+
+unique_ptr<SQLStatement> LoadStatement::Copy() const {
+	return unique_ptr<LoadStatement>(new LoadStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+PragmaStatement::PragmaStatement() : SQLStatement(StatementType::PRAGMA_STATEMENT), info(make_unique<PragmaInfo>()) {
+}
+
+PragmaStatement::PragmaStatement(const PragmaStatement &other) : SQLStatement(other), info(other.info->Copy()) {
+}
+
+unique_ptr<SQLStatement> PragmaStatement::Copy() const {
+	return unique_ptr<PragmaStatement>(new PragmaStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+PrepareStatement::PrepareStatement() : SQLStatement(StatementType::PREPARE_STATEMENT), statement(nullptr), name("") {
+}
+
+PrepareStatement::PrepareStatement(const PrepareStatement &other)
+    : SQLStatement(other), statement(other.statement->Copy()), name(other.name) {
+}
+
+unique_ptr<SQLStatement> PrepareStatement::Copy() const {
+	return unique_ptr<PrepareStatement>(new PrepareStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+RelationStatement::RelationStatement(shared_ptr<Relation> relation)
+    : SQLStatement(StatementType::RELATION_STATEMENT), relation(move(relation)) {
+}
+
+unique_ptr<SQLStatement> RelationStatement::Copy() const {
+	return unique_ptr<RelationStatement>(new RelationStatement(*this));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+SelectStatement::SelectStatement(const SelectStatement &other) : SQLStatement(other), node(other.node->Copy()) {
+}
+
+unique_ptr<SQLStatement> SelectStatement::Copy() const {
+	return unique_ptr<SelectStatement>(new SelectStatement(*this));
+}
+
+void SelectStatement::Serialize(Serializer &serializer) const {
+	node->Serialize(serializer);
+}
+
+unique_ptr<SelectStatement> SelectStatement::Deserialize(Deserializer &source) {
+	auto result = make_unique<SelectStatement>();
+	result->node = QueryNode::Deserialize(source);
+	return result;
+}
+
+bool SelectStatement::Equals(const SQLStatement *other_p) const {
+	if (type != other_p->type) {
+		return false;
+	}
+	auto other = (SelectStatement *)other_p;
+	return node->Equals(other->node.get());
+}
+
+string SelectStatement::ToString() const {
+	return node->ToString();
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+SetStatement::SetStatement(std::string name_p, Value value_p, SetScope scope_p)
+    : SQLStatement(StatementType::SET_STATEMENT), name(move(name_p)), value(move(value_p)), scope(scope_p) {
+}
+
+unique_ptr<SQLStatement> SetStatement::Copy() const {
+	return unique_ptr<SetStatement>(new SetStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+ShowStatement::ShowStatement() : SQLStatement(StatementType::SHOW_STATEMENT), info(make_unique<ShowSelectInfo>()) {
+}
+
+ShowStatement::ShowStatement(const ShowStatement &other) : SQLStatement(other), info(other.info->Copy()) {
+}
+
+unique_ptr<SQLStatement> ShowStatement::Copy() const {
+	return unique_ptr<ShowStatement>(new ShowStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+TransactionStatement::TransactionStatement(TransactionType type)
+    : SQLStatement(StatementType::TRANSACTION_STATEMENT), info(make_unique<TransactionInfo>(type)) {
+}
+
+TransactionStatement::TransactionStatement(const TransactionStatement &other)
+    : SQLStatement(other), info(make_unique<TransactionInfo>(other.info->type)) {
+}
+
+unique_ptr<SQLStatement> TransactionStatement::Copy() const {
+	return unique_ptr<TransactionStatement>(new TransactionStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+UpdateStatement::UpdateStatement() : SQLStatement(StatementType::UPDATE_STATEMENT) {
+}
+
+UpdateStatement::UpdateStatement(const UpdateStatement &other)
+    : SQLStatement(other), table(other.table->Copy()), columns(other.columns) {
+	if (other.condition) {
+		condition = other.condition->Copy();
+	}
+	if (other.from_table) {
+		from_table = other.from_table->Copy();
+	}
+	for (auto &expr : other.expressions) {
+		expressions.emplace_back(expr->Copy());
+	}
+}
+
+string UpdateStatement::ToString() const {
+	string result;
+	result = "UPDATE ";
+	result += table->ToString();
+	result += " SET ";
+	D_ASSERT(columns.size() == expressions.size());
+	for (idx_t i = 0; i < columns.size(); i++) {
+		if (i > 0) {
+			result += ", ";
+		}
+		result += KeywordHelper::WriteOptionallyQuoted(columns[i]);
+		result += "=";
+		result += expressions[i]->ToString();
+	}
+	if (from_table) {
+		result += " FROM " + from_table->ToString();
+	}
+	if (condition) {
+		result += " WHERE " + condition->ToString();
+	}
+	if (!returning_list.empty()) {
+		result += " RETURNING ";
+		for (idx_t i = 0; i < returning_list.size(); i++) {
+			if (i > 0) {
+				result += ", ";
+			}
+			result += returning_list[i]->ToString();
+		}
+	}
+	return result;
+}
+
+unique_ptr<SQLStatement> UpdateStatement::Copy() const {
+	return unique_ptr<UpdateStatement>(new UpdateStatement(*this));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+VacuumStatement::VacuumStatement() : SQLStatement(StatementType::VACUUM_STATEMENT) {
+}
+
+unique_ptr<SQLStatement> VacuumStatement::Copy() const {
+	return unique_ptr<VacuumStatement>(new VacuumStatement(*this));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+string BaseTableRef::ToString() const {
+	string schema = schema_name.empty() ? "" : KeywordHelper::WriteOptionallyQuoted(schema_name) + ".";
+	string result = schema + KeywordHelper::WriteOptionallyQuoted(table_name);
+	return BaseToString(result, column_name_alias);
+}
+
+bool BaseTableRef::Equals(const TableRef *other_p) const {
+	if (!TableRef::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BaseTableRef *)other_p;
+	return other->schema_name == schema_name && other->table_name == table_name &&
+	       column_name_alias == other->column_name_alias;
+}
+
+void BaseTableRef::Serialize(FieldWriter &writer) const {
+	writer.WriteString(schema_name);
+	writer.WriteString(table_name);
+	writer.WriteList<string>(column_name_alias);
+}
+
+unique_ptr<TableRef> BaseTableRef::Deserialize(FieldReader &reader) {
+	auto result = make_unique<BaseTableRef>();
+
+	result->schema_name = reader.ReadRequired<string>();
+	result->table_name = reader.ReadRequired<string>();
+	result->column_name_alias = reader.ReadRequiredList<string>();
+
+	return move(result);
+}
+
+unique_ptr<TableRef> BaseTableRef::Copy() {
+	auto copy = make_unique<BaseTableRef>();
+
+	copy->schema_name = schema_name;
+	copy->table_name = table_name;
+	copy->column_name_alias = column_name_alias;
+	CopyProperties(*copy);
+
+	return move(copy);
+}
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+string CrossProductRef::ToString() const {
+	return left->ToString() + ", " + right->ToString();
+}
+
+bool CrossProductRef::Equals(const TableRef *other_p) const {
+	if (!TableRef::Equals(other_p)) {
+		return false;
+	}
+	auto other = (CrossProductRef *)other_p;
+	return left->Equals(other->left.get()) && right->Equals(other->right.get());
+}
+
+unique_ptr<TableRef> CrossProductRef::Copy() {
+	auto copy = make_unique<CrossProductRef>();
+	copy->left = left->Copy();
+	copy->right = right->Copy();
+	copy->alias = alias;
+	return move(copy);
+}
+
+void CrossProductRef::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(*left);
+	writer.WriteSerializable(*right);
+}
+
+unique_ptr<TableRef> CrossProductRef::Deserialize(FieldReader &reader) {
+	auto result = make_unique<CrossProductRef>();
+
+	result->left = reader.ReadRequiredSerializable<TableRef>();
+	result->right = reader.ReadRequiredSerializable<TableRef>();
+	D_ASSERT(result->left);
+	D_ASSERT(result->right);
+
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+string EmptyTableRef::ToString() const {
+	return "";
+}
+
+bool EmptyTableRef::Equals(const TableRef *other) const {
+	return TableRef::Equals(other);
+}
+
+unique_ptr<TableRef> EmptyTableRef::Copy() {
+	return make_unique<EmptyTableRef>();
+}
+
+void EmptyTableRef::Serialize(FieldWriter &writer) const {
+}
+
+unique_ptr<TableRef> EmptyTableRef::Deserialize(FieldReader &reader) {
+	return make_unique<EmptyTableRef>();
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+string ExpressionListRef::ToString() const {
+	D_ASSERT(!values.empty());
+	string result = "(VALUES ";
+	for (idx_t row_idx = 0; row_idx < values.size(); row_idx++) {
+		if (row_idx > 0) {
+			result += ", ";
+		}
+		auto &row = values[row_idx];
+		result += "(";
+		for (idx_t col_idx = 0; col_idx < row.size(); col_idx++) {
+			if (col_idx > 0) {
+				result += ", ";
+			}
+			result += row[col_idx]->ToString();
+		}
+		result += ")";
+	}
+	result += ")";
+	return BaseToString(result, expected_names);
+}
+
+bool ExpressionListRef::Equals(const TableRef *other_p) const {
+	if (!TableRef::Equals(other_p)) {
+		return false;
+	}
+	auto other = (ExpressionListRef *)other_p;
+	if (values.size() != other->values.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < values.size(); i++) {
+		if (values[i].size() != other->values[i].size()) {
+			return false;
+		}
+		for (idx_t j = 0; j < values[i].size(); j++) {
+			if (!values[i][j]->Equals(other->values[i][j].get())) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+unique_ptr<TableRef> ExpressionListRef::Copy() {
+	// value list
+	auto result = make_unique<ExpressionListRef>();
+	for (auto &val_list : values) {
+		vector<unique_ptr<ParsedExpression>> new_val_list;
+		new_val_list.reserve(val_list.size());
+		for (auto &val : val_list) {
+			new_val_list.push_back(val->Copy());
+		}
+		result->values.push_back(move(new_val_list));
+	}
+	result->expected_names = expected_names;
+	result->expected_types = expected_types;
+	CopyProperties(*result);
+	return move(result);
+}
+
+void ExpressionListRef::Serialize(FieldWriter &writer) const {
+	writer.WriteList<string>(expected_names);
+	writer.WriteRegularSerializableList<LogicalType>(expected_types);
+	auto &serializer = writer.GetSerializer();
+	writer.WriteField<uint32_t>(values.size());
+	for (idx_t i = 0; i < values.size(); i++) {
+		serializer.WriteList(values[i]);
+	}
+}
+
+unique_ptr<TableRef> ExpressionListRef::Deserialize(FieldReader &reader) {
+	auto result = make_unique<ExpressionListRef>();
+	// value list
+	result->expected_names = reader.ReadRequiredList<string>();
+	result->expected_types = reader.ReadRequiredSerializableList<LogicalType, LogicalType>();
+	idx_t value_list_size = reader.ReadRequired<uint32_t>();
+	auto &source = reader.GetSource();
+	for (idx_t i = 0; i < value_list_size; i++) {
+		vector<unique_ptr<ParsedExpression>> value_list;
+		source.ReadList<ParsedExpression>(value_list);
+		result->values.push_back(move(value_list));
+	}
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+string JoinRef::ToString() const {
+	string result;
+	result = left->ToString() + " ";
+	if (is_natural) {
+		result += "NATURAL ";
+	}
+	result += JoinTypeToString(type) + " JOIN ";
+	result += right->ToString();
+	if (condition) {
+		D_ASSERT(using_columns.empty());
+		result += " ON (";
+		result += condition->ToString();
+		result += ")";
+	} else if (!using_columns.empty()) {
+		result += " USING (";
+		for (idx_t i = 0; i < using_columns.size(); i++) {
+			if (i > 0) {
+				result += ", ";
+			}
+			result += using_columns[i];
+		}
+		result += ")";
+	}
+	return result;
+}
+
+bool JoinRef::Equals(const TableRef *other_p) const {
+	if (!TableRef::Equals(other_p)) {
+		return false;
+	}
+	auto other = (JoinRef *)other_p;
+	if (using_columns.size() != other->using_columns.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < using_columns.size(); i++) {
+		if (using_columns[i] != other->using_columns[i]) {
+			return false;
+		}
+	}
+	return left->Equals(other->left.get()) && right->Equals(other->right.get()) &&
+	       BaseExpression::Equals(condition.get(), other->condition.get()) && type == other->type;
+}
+
+unique_ptr<TableRef> JoinRef::Copy() {
+	auto copy = make_unique<JoinRef>();
+	copy->left = left->Copy();
+	copy->right = right->Copy();
+	if (condition) {
+		copy->condition = condition->Copy();
+	}
+	copy->type = type;
+	copy->is_natural = is_natural;
+	copy->alias = alias;
+	copy->using_columns = using_columns;
+	return move(copy);
+}
+
+void JoinRef::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(*left);
+	writer.WriteSerializable(*right);
+	writer.WriteOptional(condition);
+	writer.WriteField<JoinType>(type);
+	writer.WriteField<bool>(is_natural);
+	writer.WriteList<string>(using_columns);
+}
+
+unique_ptr<TableRef> JoinRef::Deserialize(FieldReader &reader) {
+	auto result = make_unique<JoinRef>();
+	result->left = reader.ReadRequiredSerializable<TableRef>();
+	result->right = reader.ReadRequiredSerializable<TableRef>();
+	result->condition = reader.ReadOptional<ParsedExpression>(nullptr);
+	result->type = reader.ReadRequired<JoinType>();
+	result->is_natural = reader.ReadRequired<bool>();
+	result->using_columns = reader.ReadRequiredList<string>();
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+string SubqueryRef::ToString() const {
+	string result = "(" + subquery->ToString() + ")";
+	return BaseToString(result, column_name_alias);
+}
+
+SubqueryRef::SubqueryRef(unique_ptr<SelectStatement> subquery_p, string alias_p)
+    : TableRef(TableReferenceType::SUBQUERY), subquery(move(subquery_p)) {
+	this->alias = move(alias_p);
+}
+
+bool SubqueryRef::Equals(const TableRef *other_p) const {
+	if (!TableRef::Equals(other_p)) {
+		return false;
+	}
+	auto other = (SubqueryRef *)other_p;
+	return subquery->Equals(other->subquery.get());
+}
+
+unique_ptr<TableRef> SubqueryRef::Copy() {
+	auto copy = make_unique<SubqueryRef>(unique_ptr_cast<SQLStatement, SelectStatement>(subquery->Copy()), alias);
+	copy->column_name_alias = column_name_alias;
+	CopyProperties(*copy);
+	return move(copy);
+}
+
+void SubqueryRef::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(*subquery);
+	writer.WriteList<string>(column_name_alias);
+}
+
+unique_ptr<TableRef> SubqueryRef::Deserialize(FieldReader &reader) {
+	auto subquery = reader.ReadRequiredSerializable<SelectStatement>();
+	auto result = make_unique<SubqueryRef>(move(subquery));
+	result->column_name_alias = reader.ReadRequiredList<string>();
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+TableFunctionRef::TableFunctionRef() : TableRef(TableReferenceType::TABLE_FUNCTION) {
+}
+
+string TableFunctionRef::ToString() const {
+	return BaseToString(function->ToString(), column_name_alias);
+}
+
+bool TableFunctionRef::Equals(const TableRef *other_p) const {
+	if (!TableRef::Equals(other_p)) {
+		return false;
+	}
+	auto other = (TableFunctionRef *)other_p;
+	return function->Equals(other->function.get());
+}
+
+void TableFunctionRef::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(*function);
+	writer.WriteString(alias);
+	writer.WriteList<string>(column_name_alias);
+}
+
+unique_ptr<TableRef> TableFunctionRef::Deserialize(FieldReader &reader) {
+	auto result = make_unique<TableFunctionRef>();
+	result->function = reader.ReadRequiredSerializable<ParsedExpression>();
+	result->alias = reader.ReadRequired<string>();
+	result->column_name_alias = reader.ReadRequiredList<string>();
+	return move(result);
+}
+
+unique_ptr<TableRef> TableFunctionRef::Copy() {
+	auto copy = make_unique<TableFunctionRef>();
+
+	copy->function = function->Copy();
+	copy->column_name_alias = column_name_alias;
+	CopyProperties(*copy);
+
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+string TableRef::BaseToString(string result) const {
+	vector<string> column_name_alias;
+	return BaseToString(move(result), column_name_alias);
+}
+
+string TableRef::BaseToString(string result, const vector<string> &column_name_alias) const {
+	if (!alias.empty()) {
+		result += " AS " + KeywordHelper::WriteOptionallyQuoted(alias);
+	}
+	if (!column_name_alias.empty()) {
+		D_ASSERT(!alias.empty());
+		result += "(";
+		for (idx_t i = 0; i < column_name_alias.size(); i++) {
+			if (i > 0) {
+				result += ", ";
+			}
+			result += KeywordHelper::WriteOptionallyQuoted(column_name_alias[i]);
+		}
+		result += ")";
+	}
+	if (sample) {
+		result += " TABLESAMPLE " + SampleMethodToString(sample->method);
+		result += "(" + sample->sample_size.ToString() + " " + string(sample->is_percentage ? "PERCENT" : "ROWS") + ")";
+		if (sample->seed >= 0) {
+			result += "REPEATABLE (" + to_string(sample->seed) + ")";
+		}
+	}
+
+	return result;
+}
+
+bool TableRef::Equals(const TableRef *other) const {
+	return other && type == other->type && alias == other->alias &&
+	       SampleOptions::Equals(sample.get(), other->sample.get());
+}
+
+void TableRef::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	writer.WriteField<TableReferenceType>(type);
+	writer.WriteString(alias);
+	writer.WriteOptional(sample);
+	Serialize(writer);
+	writer.Finalize();
+}
+
+unique_ptr<TableRef> TableRef::Deserialize(Deserializer &source) {
+	FieldReader reader(source);
+
+	auto type = reader.ReadRequired<TableReferenceType>();
+	auto alias = reader.ReadRequired<string>();
+	auto sample = reader.ReadOptional<SampleOptions>(nullptr);
+	unique_ptr<TableRef> result;
+	switch (type) {
+	case TableReferenceType::BASE_TABLE:
+		result = BaseTableRef::Deserialize(reader);
+		break;
+	case TableReferenceType::CROSS_PRODUCT:
+		result = CrossProductRef::Deserialize(reader);
+		break;
+	case TableReferenceType::JOIN:
+		result = JoinRef::Deserialize(reader);
+		break;
+	case TableReferenceType::SUBQUERY:
+		result = SubqueryRef::Deserialize(reader);
+		break;
+	case TableReferenceType::TABLE_FUNCTION:
+		result = TableFunctionRef::Deserialize(reader);
+		break;
+	case TableReferenceType::EMPTY:
+		result = EmptyTableRef::Deserialize(reader);
+		break;
+	case TableReferenceType::EXPRESSION_LIST:
+		result = ExpressionListRef::Deserialize(reader);
+		break;
+	case TableReferenceType::CTE:
+	case TableReferenceType::INVALID:
+		throw InternalException("Unsupported type for TableRef::Deserialize");
+	}
+	reader.Finalize();
+
+	result->alias = alias;
+	result->sample = move(sample);
+	return result;
+}
+
+void TableRef::CopyProperties(TableRef &target) const {
+	D_ASSERT(type == target.type);
+	target.alias = alias;
+	target.query_location = query_location;
+	target.sample = sample ? sample->Copy() : nullptr;
+}
+
+void TableRef::Print() {
+	Printer::Print(ToString());
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGListCell *cell) {
+	auto constraint = reinterpret_cast<duckdb_libpgquery::PGConstraint *>(cell->data.ptr_value);
+	switch (constraint->contype) {
+	case duckdb_libpgquery::PG_CONSTR_UNIQUE:
+	case duckdb_libpgquery::PG_CONSTR_PRIMARY: {
+		bool is_primary_key = constraint->contype == duckdb_libpgquery::PG_CONSTR_PRIMARY;
+		vector<string> columns;
+		for (auto kc = constraint->keys->head; kc; kc = kc->next) {
+			columns.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(kc->data.ptr_value)->val.str);
+		}
+		return make_unique<UniqueConstraint>(columns, is_primary_key);
+	}
+	case duckdb_libpgquery::PG_CONSTR_CHECK: {
+		auto expression = TransformExpression(constraint->raw_expr);
+		if (expression->HasSubquery()) {
+			throw ParserException("subqueries prohibited in CHECK constraints");
+		}
+		return make_unique<CheckConstraint>(TransformExpression(constraint->raw_expr));
+	}
+	case duckdb_libpgquery::PG_CONSTR_FOREIGN: {
+		ForeignKeyInfo fk_info;
+		fk_info.type = ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE;
+		if (constraint->pktable->schemaname) {
+			fk_info.schema = constraint->pktable->schemaname;
+		} else {
+			fk_info.schema = "";
+		}
+		fk_info.table = constraint->pktable->relname;
+		vector<string> pk_columns, fk_columns;
+		for (auto kc = constraint->fk_attrs->head; kc; kc = kc->next) {
+			fk_columns.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(kc->data.ptr_value)->val.str);
+		}
+		if (constraint->pk_attrs) {
+			for (auto kc = constraint->pk_attrs->head; kc; kc = kc->next) {
+				pk_columns.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(kc->data.ptr_value)->val.str);
+			}
+		}
+		if (!pk_columns.empty() && pk_columns.size() != fk_columns.size()) {
+			throw ParserException("The number of referencing and referenced columns for foreign keys must be the same");
+		}
+		if (fk_columns.empty()) {
+			throw ParserException("The set of referencing and referenced columns for foreign keys must be not empty");
+		}
+		return make_unique<ForeignKeyConstraint>(pk_columns, fk_columns, move(fk_info));
+	}
+	default:
+		throw NotImplementedException("Constraint type not handled yet!");
+	}
+}
+
+unique_ptr<Constraint> Transformer::TransformConstraint(duckdb_libpgquery::PGListCell *cell, ColumnDefinition &column,
+                                                        idx_t index) {
+	auto constraint = reinterpret_cast<duckdb_libpgquery::PGConstraint *>(cell->data.ptr_value);
+	D_ASSERT(constraint);
+	switch (constraint->contype) {
+	case duckdb_libpgquery::PG_CONSTR_NOTNULL:
+		return make_unique<NotNullConstraint>(index);
+	case duckdb_libpgquery::PG_CONSTR_CHECK:
+		return TransformConstraint(cell);
+	case duckdb_libpgquery::PG_CONSTR_PRIMARY:
+		return make_unique<UniqueConstraint>(index, true);
+	case duckdb_libpgquery::PG_CONSTR_UNIQUE:
+		return make_unique<UniqueConstraint>(index, false);
+	case duckdb_libpgquery::PG_CONSTR_NULL:
+		return nullptr;
+	case duckdb_libpgquery::PG_CONSTR_GENERATED_VIRTUAL: {
+		if (column.DefaultValue()) {
+			throw InvalidInputException("DEFAULT constraint on GENERATED column \"%s\" is not allowed", column.Name());
+		}
+		column.SetGeneratedExpression(TransformExpression(constraint->raw_expr));
+		return nullptr;
+	}
+	case duckdb_libpgquery::PG_CONSTR_GENERATED_STORED:
+		throw InvalidInputException("Can not create a STORED generated column!");
+	case duckdb_libpgquery::PG_CONSTR_DEFAULT:
+		column.SetDefaultValue(TransformExpression(constraint->raw_expr));
+		return nullptr;
+	case duckdb_libpgquery::PG_CONSTR_COMPRESSION:
+		column.SetCompressionType(CompressionTypeFromString(constraint->compression_name));
+		if (column.CompressionType() == CompressionType::COMPRESSION_AUTO) {
+			throw ParserException("Unrecognized option for column compression, expected none, uncompressed, rle, "
+			                      "dictionary, pfor, bitpacking or fsst");
+		}
+		return nullptr;
+	case duckdb_libpgquery::PG_CONSTR_FOREIGN: {
+		ForeignKeyInfo fk_info;
+		fk_info.type = ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE;
+		if (constraint->pktable->schemaname) {
+			fk_info.schema = constraint->pktable->schemaname;
+		} else {
+			fk_info.schema = "";
+		}
+		fk_info.table = constraint->pktable->relname;
+		vector<string> pk_columns, fk_columns;
+
+		fk_columns.emplace_back(column.Name().c_str());
+		if (constraint->pk_attrs) {
+			for (auto kc = constraint->pk_attrs->head; kc; kc = kc->next) {
+				pk_columns.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(kc->data.ptr_value)->val.str);
+			}
+		}
+		if (pk_columns.size() != fk_columns.size()) {
+			throw ParserException("The number of referencing and referenced columns for foreign keys must be the same");
+		}
+		return make_unique<ForeignKeyConstraint>(pk_columns, fk_columns, move(fk_info));
+	}
+	default:
+		throw NotImplementedException("Constraint not implemented!");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformArrayAccess(duckdb_libpgquery::PGAIndirection *indirection_node) {
+	// transform the source expression
+	unique_ptr<ParsedExpression> result;
+	result = TransformExpression(indirection_node->arg);
+
+	// now go over the indices
+	// note that a single indirection node can contain multiple indices
+	// this happens for e.g. more complex accesses (e.g. (foo).field1[42])
+	idx_t list_size = 0;
+	for (auto node = indirection_node->indirection->head; node != nullptr; node = node->next) {
+		auto target = reinterpret_cast<duckdb_libpgquery::PGNode *>(node->data.ptr_value);
+		D_ASSERT(target);
+
+		switch (target->type) {
+		case duckdb_libpgquery::T_PGAIndices: {
+			// index access (either slice or extract)
+			auto index = (duckdb_libpgquery::PGAIndices *)target;
+			vector<unique_ptr<ParsedExpression>> children;
+			children.push_back(move(result));
+			if (index->is_slice) {
+				// slice
+				children.push_back(!index->lidx ? make_unique<ConstantExpression>(Value())
+				                                : TransformExpression(index->lidx));
+				children.push_back(!index->uidx ? make_unique<ConstantExpression>(Value())
+				                                : TransformExpression(index->uidx));
+				result = make_unique<OperatorExpression>(ExpressionType::ARRAY_SLICE, move(children));
+			} else {
+				// array access
+				D_ASSERT(!index->lidx);
+				D_ASSERT(index->uidx);
+				children.push_back(TransformExpression(index->uidx));
+				result = make_unique<OperatorExpression>(ExpressionType::ARRAY_EXTRACT, move(children));
+			}
+			break;
+		}
+		case duckdb_libpgquery::T_PGString: {
+			auto val = (duckdb_libpgquery::PGValue *)target;
+			vector<unique_ptr<ParsedExpression>> children;
+			children.push_back(move(result));
+			children.push_back(TransformValue(*val));
+			result = make_unique<OperatorExpression>(ExpressionType::STRUCT_EXTRACT, move(children));
+			break;
+		}
+		default:
+			throw NotImplementedException("Unimplemented subscript type");
+		}
+		list_size++;
+		StackCheck(list_size);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformBoolExpr(duckdb_libpgquery::PGBoolExpr *root) {
+	unique_ptr<ParsedExpression> result;
+	for (auto node = root->args->head; node != nullptr; node = node->next) {
+		auto next = TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(node->data.ptr_value));
+
+		switch (root->boolop) {
+		case duckdb_libpgquery::PG_AND_EXPR: {
+			if (!result) {
+				result = move(next);
+			} else {
+				result = make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_AND, move(result), move(next));
+			}
+			break;
+		}
+		case duckdb_libpgquery::PG_OR_EXPR: {
+			if (!result) {
+				result = move(next);
+			} else {
+				result = make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_OR, move(result), move(next));
+			}
+			break;
+		}
+		case duckdb_libpgquery::PG_NOT_EXPR: {
+			if (next->type == ExpressionType::COMPARE_IN) {
+				// convert COMPARE_IN to COMPARE_NOT_IN
+				next->type = ExpressionType::COMPARE_NOT_IN;
+				result = move(next);
+			} else if (next->type >= ExpressionType::COMPARE_EQUAL &&
+			           next->type <= ExpressionType::COMPARE_GREATERTHANOREQUALTO) {
+				// NOT on a comparison: we can negate the comparison
+				// e.g. NOT(x > y) is equivalent to x <= y
+				next->type = NegateComparisionExpression(next->type);
+				result = move(next);
+			} else {
+				result = make_unique<OperatorExpression>(ExpressionType::OPERATOR_NOT, move(next));
+			}
+			break;
+		}
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformCase(duckdb_libpgquery::PGCaseExpr *root) {
+	D_ASSERT(root);
+
+	auto case_node = make_unique<CaseExpression>();
+	for (auto cell = root->args->head; cell != nullptr; cell = cell->next) {
+		CaseCheck case_check;
+
+		auto w = reinterpret_cast<duckdb_libpgquery::PGCaseWhen *>(cell->data.ptr_value);
+		auto test_raw = TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(w->expr));
+		unique_ptr<ParsedExpression> test;
+		auto arg = TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(root->arg));
+		if (arg) {
+			case_check.when_expr =
+			    make_unique<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, move(arg), move(test_raw));
+		} else {
+			case_check.when_expr = move(test_raw);
+		}
+		case_check.then_expr = TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(w->result));
+		case_node->case_checks.push_back(move(case_check));
+	}
+
+	if (root->defresult) {
+		case_node->else_expr = TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(root->defresult));
+	} else {
+		case_node->else_expr = make_unique<ConstantExpression>(Value(LogicalType::SQLNULL));
+	}
+	return move(case_node);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformTypeCast(duckdb_libpgquery::PGTypeCast *root) {
+	D_ASSERT(root);
+
+	// get the type to cast to
+	auto type_name = root->typeName;
+	LogicalType target_type = TransformTypeName(type_name);
+
+	// check for a constant BLOB value, then return ConstantExpression with BLOB
+	if (!root->tryCast && target_type == LogicalType::BLOB && root->arg->type == duckdb_libpgquery::T_PGAConst) {
+		auto c = reinterpret_cast<duckdb_libpgquery::PGAConst *>(root->arg);
+		if (c->val.type == duckdb_libpgquery::T_PGString) {
+			return make_unique<ConstantExpression>(Value::BLOB(string(c->val.val.str)));
+		}
+	}
+	// transform the expression node
+	auto expression = TransformExpression(root->arg);
+	bool try_cast = root->tryCast;
+
+	// now create a cast operation
+	return make_unique<CastExpression>(target_type, move(expression), try_cast);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+// COALESCE(a,b,c) returns the first argument that is NOT NULL, so
+// rewrite into CASE(a IS NOT NULL, a, CASE(b IS NOT NULL, b, c))
+unique_ptr<ParsedExpression> Transformer::TransformCoalesce(duckdb_libpgquery::PGAExpr *root) {
+	D_ASSERT(root);
+
+	auto coalesce_args = reinterpret_cast<duckdb_libpgquery::PGList *>(root->lexpr);
+	D_ASSERT(coalesce_args->length > 0); // parser ensures this already
+
+	auto coalesce_op = make_unique<OperatorExpression>(ExpressionType::OPERATOR_COALESCE);
+	for (auto cell = coalesce_args->head; cell; cell = cell->next) {
+		// get the value of the COALESCE
+		auto value_expr = TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(cell->data.ptr_value));
+		coalesce_op->children.push_back(move(value_expr));
+	}
+	return move(coalesce_op);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformStarExpression(duckdb_libpgquery::PGNode *node) {
+	auto star = (duckdb_libpgquery::PGAStar *)node;
+	auto result = make_unique<StarExpression>(star->relation ? star->relation : string());
+	if (star->except_list) {
+		for (auto head = star->except_list->head; head; head = head->next) {
+			auto value = (duckdb_libpgquery::PGValue *)head->data.ptr_value;
+			D_ASSERT(value->type == duckdb_libpgquery::T_PGString);
+			string exclude_entry = value->val.str;
+			if (result->exclude_list.find(exclude_entry) != result->exclude_list.end()) {
+				throw ParserException("Duplicate entry \"%s\" in EXCLUDE list", exclude_entry);
+			}
+			result->exclude_list.insert(move(exclude_entry));
+		}
+	}
+	if (star->replace_list) {
+		for (auto head = star->replace_list->head; head; head = head->next) {
+			auto list = (duckdb_libpgquery::PGList *)head->data.ptr_value;
+			D_ASSERT(list->length == 2);
+			auto replace_expression = TransformExpression((duckdb_libpgquery::PGNode *)list->head->data.ptr_value);
+			auto value = (duckdb_libpgquery::PGValue *)list->tail->data.ptr_value;
+			D_ASSERT(value->type == duckdb_libpgquery::T_PGString);
+			string exclude_entry = value->val.str;
+			if (result->replace_list.find(exclude_entry) != result->replace_list.end()) {
+				throw ParserException("Duplicate entry \"%s\" in REPLACE list", exclude_entry);
+			}
+			if (result->exclude_list.find(exclude_entry) != result->exclude_list.end()) {
+				throw ParserException("Column \"%s\" cannot occur in both EXCEPT and REPLACE list", exclude_entry);
+			}
+			result->replace_list.insert(make_pair(move(exclude_entry), move(replace_expression)));
+		}
+	}
+	return move(result);
+}
+
+unique_ptr<ParsedExpression> Transformer::TransformColumnRef(duckdb_libpgquery::PGColumnRef *root) {
+	auto fields = root->fields;
+	auto head_node = (duckdb_libpgquery::PGNode *)fields->head->data.ptr_value;
+	switch (head_node->type) {
+	case duckdb_libpgquery::T_PGString: {
+		if (fields->length < 1) {
+			throw InternalException("Unexpected field length");
+		}
+		vector<string> column_names;
+		for (auto node = fields->head; node; node = node->next) {
+			column_names.emplace_back(reinterpret_cast<duckdb_libpgquery::PGValue *>(node->data.ptr_value)->val.str);
+		}
+		auto colref = make_unique<ColumnRefExpression>(move(column_names));
+		colref->query_location = root->location;
+		return move(colref);
+	}
+	case duckdb_libpgquery::T_PGAStar: {
+		return TransformStarExpression(head_node);
+	}
+	default:
+		throw NotImplementedException("ColumnRef not implemented!");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ConstantExpression> Transformer::TransformValue(duckdb_libpgquery::PGValue val) {
+	switch (val.type) {
+	case duckdb_libpgquery::T_PGInteger:
+		D_ASSERT(val.val.ival <= NumericLimits<int32_t>::Maximum());
+		return make_unique<ConstantExpression>(Value::INTEGER((int32_t)val.val.ival));
+	case duckdb_libpgquery::T_PGBitString: // FIXME: this should actually convert to BLOB
+	case duckdb_libpgquery::T_PGString:
+		return make_unique<ConstantExpression>(Value(string(val.val.str)));
+	case duckdb_libpgquery::T_PGFloat: {
+		string_t str_val(val.val.str);
+		bool try_cast_as_integer = true;
+		bool try_cast_as_decimal = true;
+		int decimal_position = -1;
+		for (idx_t i = 0; i < str_val.GetSize(); i++) {
+			if (val.val.str[i] == '.') {
+				// decimal point: cast as either decimal or double
+				try_cast_as_integer = false;
+				decimal_position = i;
+			}
+			if (val.val.str[i] == 'e' || val.val.str[i] == 'E') {
+				// found exponent, cast as double
+				try_cast_as_integer = false;
+				try_cast_as_decimal = false;
+			}
+		}
+		if (try_cast_as_integer) {
+			int64_t bigint_value;
+			// try to cast as bigint first
+			if (TryCast::Operation<string_t, int64_t>(str_val, bigint_value)) {
+				// successfully cast to bigint: bigint value
+				return make_unique<ConstantExpression>(Value::BIGINT(bigint_value));
+			}
+			hugeint_t hugeint_value;
+			// if that is not successful; try to cast as hugeint
+			if (TryCast::Operation<string_t, hugeint_t>(str_val, hugeint_value)) {
+				// successfully cast to bigint: bigint value
+				return make_unique<ConstantExpression>(Value::HUGEINT(hugeint_value));
+			}
+		}
+		idx_t decimal_offset = val.val.str[0] == '-' ? 3 : 2;
+		if (try_cast_as_decimal && decimal_position >= 0 &&
+		    str_val.GetSize() < Decimal::MAX_WIDTH_DECIMAL + decimal_offset) {
+			// figure out the width/scale based on the decimal position
+			auto width = uint8_t(str_val.GetSize() - 1);
+			auto scale = uint8_t(width - decimal_position);
+			if (val.val.str[0] == '-') {
+				width--;
+			}
+			if (width <= Decimal::MAX_WIDTH_DECIMAL) {
+				// we can cast the value as a decimal
+				Value val = Value(str_val);
+				val = val.CastAs(LogicalType::DECIMAL(width, scale));
+				return make_unique<ConstantExpression>(move(val));
+			}
+		}
+		// if there is a decimal or the value is too big to cast as either hugeint or bigint
+		double dbl_value = Cast::Operation<string_t, double>(str_val);
+		return make_unique<ConstantExpression>(Value::DOUBLE(dbl_value));
+	}
+	case duckdb_libpgquery::T_PGNull:
+		return make_unique<ConstantExpression>(Value(LogicalType::SQLNULL));
+	default:
+		throw NotImplementedException("Value not implemented!");
+	}
+}
+
+unique_ptr<ParsedExpression> Transformer::TransformConstant(duckdb_libpgquery::PGAConst *c) {
+	return TransformValue(c->val);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformResTarget(duckdb_libpgquery::PGResTarget *root) {
+	D_ASSERT(root);
+
+	auto expr = TransformExpression(root->val);
+	if (!expr) {
+		return nullptr;
+	}
+	if (root->name) {
+		expr->alias = string(root->name);
+	}
+	return expr;
+}
+
+unique_ptr<ParsedExpression> Transformer::TransformNamedArg(duckdb_libpgquery::PGNamedArgExpr *root) {
+	D_ASSERT(root);
+
+	auto expr = TransformExpression((duckdb_libpgquery::PGNode *)root->arg);
+	if (root->name) {
+		expr->alias = string(root->name);
+	}
+	return expr;
+}
+
+unique_ptr<ParsedExpression> Transformer::TransformExpression(duckdb_libpgquery::PGNode *node) {
+	if (!node) {
+		return nullptr;
+	}
+
+	auto stack_checker = StackCheck();
+
+	switch (node->type) {
+	case duckdb_libpgquery::T_PGColumnRef:
+		return TransformColumnRef(reinterpret_cast<duckdb_libpgquery::PGColumnRef *>(node));
+	case duckdb_libpgquery::T_PGAConst:
+		return TransformConstant(reinterpret_cast<duckdb_libpgquery::PGAConst *>(node));
+	case duckdb_libpgquery::T_PGAExpr:
+		return TransformAExpr(reinterpret_cast<duckdb_libpgquery::PGAExpr *>(node));
+	case duckdb_libpgquery::T_PGFuncCall:
+		return TransformFuncCall(reinterpret_cast<duckdb_libpgquery::PGFuncCall *>(node));
+	case duckdb_libpgquery::T_PGBoolExpr:
+		return TransformBoolExpr(reinterpret_cast<duckdb_libpgquery::PGBoolExpr *>(node));
+	case duckdb_libpgquery::T_PGTypeCast:
+		return TransformTypeCast(reinterpret_cast<duckdb_libpgquery::PGTypeCast *>(node));
+	case duckdb_libpgquery::T_PGCaseExpr:
+		return TransformCase(reinterpret_cast<duckdb_libpgquery::PGCaseExpr *>(node));
+	case duckdb_libpgquery::T_PGSubLink:
+		return TransformSubquery(reinterpret_cast<duckdb_libpgquery::PGSubLink *>(node));
+	case duckdb_libpgquery::T_PGCoalesceExpr:
+		return TransformCoalesce(reinterpret_cast<duckdb_libpgquery::PGAExpr *>(node));
+	case duckdb_libpgquery::T_PGNullTest:
+		return TransformNullTest(reinterpret_cast<duckdb_libpgquery::PGNullTest *>(node));
+	case duckdb_libpgquery::T_PGResTarget:
+		return TransformResTarget(reinterpret_cast<duckdb_libpgquery::PGResTarget *>(node));
+	case duckdb_libpgquery::T_PGParamRef:
+		return TransformParamRef(reinterpret_cast<duckdb_libpgquery::PGParamRef *>(node));
+	case duckdb_libpgquery::T_PGNamedArgExpr:
+		return TransformNamedArg(reinterpret_cast<duckdb_libpgquery::PGNamedArgExpr *>(node));
+	case duckdb_libpgquery::T_PGSQLValueFunction:
+		return TransformSQLValueFunction(reinterpret_cast<duckdb_libpgquery::PGSQLValueFunction *>(node));
+	case duckdb_libpgquery::T_PGSetToDefault:
+		return make_unique<DefaultExpression>();
+	case duckdb_libpgquery::T_PGCollateClause:
+		return TransformCollateExpr(reinterpret_cast<duckdb_libpgquery::PGCollateClause *>(node));
+	case duckdb_libpgquery::T_PGIntervalConstant:
+		return TransformInterval(reinterpret_cast<duckdb_libpgquery::PGIntervalConstant *>(node));
+	case duckdb_libpgquery::T_PGLambdaFunction:
+		return TransformLambda(reinterpret_cast<duckdb_libpgquery::PGLambdaFunction *>(node));
+	case duckdb_libpgquery::T_PGAIndirection:
+		return TransformArrayAccess(reinterpret_cast<duckdb_libpgquery::PGAIndirection *>(node));
+	case duckdb_libpgquery::T_PGPositionalReference:
+		return TransformPositionalReference(reinterpret_cast<duckdb_libpgquery::PGPositionalReference *>(node));
+	case duckdb_libpgquery::T_PGGroupingFunc:
+		return TransformGroupingFunction(reinterpret_cast<duckdb_libpgquery::PGGroupingFunc *>(node));
+	case duckdb_libpgquery::T_PGAStar:
+		return TransformStarExpression(node);
+	default:
+		throw NotImplementedException("Expr of type %d not implemented\n", (int)node->type);
+	}
+}
+
+void Transformer::TransformExpressionList(duckdb_libpgquery::PGList &list,
+                                          vector<unique_ptr<ParsedExpression>> &result) {
+	for (auto node = list.head; node != nullptr; node = node->next) {
+		auto target = reinterpret_cast<duckdb_libpgquery::PGNode *>(node->data.ptr_value);
+		D_ASSERT(target);
+
+		auto expr = TransformExpression(target);
+		D_ASSERT(expr);
+
+		result.push_back(move(expr));
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static ExpressionType WindowToExpressionType(string &fun_name) {
+	if (fun_name == "rank") {
+		return ExpressionType::WINDOW_RANK;
+	} else if (fun_name == "rank_dense" || fun_name == "dense_rank") {
+		return ExpressionType::WINDOW_RANK_DENSE;
+	} else if (fun_name == "percent_rank") {
+		return ExpressionType::WINDOW_PERCENT_RANK;
+	} else if (fun_name == "row_number") {
+		return ExpressionType::WINDOW_ROW_NUMBER;
+	} else if (fun_name == "first_value" || fun_name == "first") {
+		return ExpressionType::WINDOW_FIRST_VALUE;
+	} else if (fun_name == "last_value" || fun_name == "last") {
+		return ExpressionType::WINDOW_LAST_VALUE;
+	} else if (fun_name == "nth_value" || fun_name == "last") {
+		return ExpressionType::WINDOW_NTH_VALUE;
+	} else if (fun_name == "cume_dist") {
+		return ExpressionType::WINDOW_CUME_DIST;
+	} else if (fun_name == "lead") {
+		return ExpressionType::WINDOW_LEAD;
+	} else if (fun_name == "lag") {
+		return ExpressionType::WINDOW_LAG;
+	} else if (fun_name == "ntile") {
+		return ExpressionType::WINDOW_NTILE;
+	}
+
+	return ExpressionType::WINDOW_AGGREGATE;
+}
+
+void Transformer::TransformWindowDef(duckdb_libpgquery::PGWindowDef *window_spec, WindowExpression *expr) {
+	D_ASSERT(window_spec);
+	D_ASSERT(expr);
+
+	// next: partitioning/ordering expressions
+	if (window_spec->partitionClause) {
+		TransformExpressionList(*window_spec->partitionClause, expr->partitions);
+	}
+	TransformOrderBy(window_spec->orderClause, expr->orders);
+}
+
+void Transformer::TransformWindowFrame(duckdb_libpgquery::PGWindowDef *window_spec, WindowExpression *expr) {
+	D_ASSERT(window_spec);
+	D_ASSERT(expr);
+
+	// finally: specifics of bounds
+	expr->start_expr = TransformExpression(window_spec->startOffset);
+	expr->end_expr = TransformExpression(window_spec->endOffset);
+
+	if ((window_spec->frameOptions & FRAMEOPTION_END_UNBOUNDED_PRECEDING) ||
+	    (window_spec->frameOptions & FRAMEOPTION_START_UNBOUNDED_FOLLOWING)) {
+		throw InternalException(
+		    "Window frames starting with unbounded following or ending in unbounded preceding make no sense");
+	}
+
+	const bool rangeMode = (window_spec->frameOptions & FRAMEOPTION_RANGE) != 0;
+	if (window_spec->frameOptions & FRAMEOPTION_START_UNBOUNDED_PRECEDING) {
+		expr->start = WindowBoundary::UNBOUNDED_PRECEDING;
+	} else if (window_spec->frameOptions & FRAMEOPTION_START_VALUE_PRECEDING) {
+		expr->start = rangeMode ? WindowBoundary::EXPR_PRECEDING_RANGE : WindowBoundary::EXPR_PRECEDING_ROWS;
+	} else if (window_spec->frameOptions & FRAMEOPTION_START_VALUE_FOLLOWING) {
+		expr->start = rangeMode ? WindowBoundary::EXPR_FOLLOWING_RANGE : WindowBoundary::EXPR_FOLLOWING_ROWS;
+	} else if (window_spec->frameOptions & FRAMEOPTION_START_CURRENT_ROW) {
+		expr->start = rangeMode ? WindowBoundary::CURRENT_ROW_RANGE : WindowBoundary::CURRENT_ROW_ROWS;
+	}
+
+	if (window_spec->frameOptions & FRAMEOPTION_END_UNBOUNDED_FOLLOWING) {
+		expr->end = WindowBoundary::UNBOUNDED_FOLLOWING;
+	} else if (window_spec->frameOptions & FRAMEOPTION_END_VALUE_PRECEDING) {
+		expr->end = rangeMode ? WindowBoundary::EXPR_PRECEDING_RANGE : WindowBoundary::EXPR_PRECEDING_ROWS;
+	} else if (window_spec->frameOptions & FRAMEOPTION_END_VALUE_FOLLOWING) {
+		expr->end = rangeMode ? WindowBoundary::EXPR_FOLLOWING_RANGE : WindowBoundary::EXPR_FOLLOWING_ROWS;
+	} else if (window_spec->frameOptions & FRAMEOPTION_END_CURRENT_ROW) {
+		expr->end = rangeMode ? WindowBoundary::CURRENT_ROW_RANGE : WindowBoundary::CURRENT_ROW_ROWS;
+	}
+
+	D_ASSERT(expr->start != WindowBoundary::INVALID && expr->end != WindowBoundary::INVALID);
+	if (((window_spec->frameOptions & (FRAMEOPTION_START_VALUE_PRECEDING | FRAMEOPTION_START_VALUE_FOLLOWING)) &&
+	     !expr->start_expr) ||
+	    ((window_spec->frameOptions & (FRAMEOPTION_END_VALUE_PRECEDING | FRAMEOPTION_END_VALUE_FOLLOWING)) &&
+	     !expr->end_expr)) {
+		throw InternalException("Failed to transform window boundary expression");
+	}
+}
+
+unique_ptr<ParsedExpression> Transformer::TransformFuncCall(duckdb_libpgquery::PGFuncCall *root) {
+	auto name = root->funcname;
+	string schema, function_name;
+	if (name->length == 2) {
+		// schema + name
+		schema = reinterpret_cast<duckdb_libpgquery::PGValue *>(name->head->data.ptr_value)->val.str;
+		function_name = reinterpret_cast<duckdb_libpgquery::PGValue *>(name->head->next->data.ptr_value)->val.str;
+	} else {
+		// unqualified name
+		schema = INVALID_SCHEMA;
+		function_name = reinterpret_cast<duckdb_libpgquery::PGValue *>(name->head->data.ptr_value)->val.str;
+	}
+
+	auto lowercase_name = StringUtil::Lower(function_name);
+
+	if (root->over) {
+		const auto win_fun_type = WindowToExpressionType(lowercase_name);
+		if (win_fun_type == ExpressionType::INVALID) {
+			throw InternalException("Unknown/unsupported window function");
+		}
+
+		if (root->agg_distinct) {
+			throw ParserException("DISTINCT is not implemented for window functions!");
+		}
+
+		if (root->agg_order) {
+			throw ParserException("ORDER BY is not implemented for window functions!");
+		}
+
+		if (win_fun_type != ExpressionType::WINDOW_AGGREGATE && root->agg_filter) {
+			throw ParserException("FILTER is not implemented for non-aggregate window functions!");
+		}
+		if (root->export_state) {
+			throw ParserException("EXPORT_STATE is not supported for window functions!");
+		}
+
+		if (win_fun_type == ExpressionType::WINDOW_AGGREGATE && root->agg_ignore_nulls) {
+			throw ParserException("IGNORE NULLS is not supported for windowed aggregates");
+		}
+
+		auto expr = make_unique<WindowExpression>(win_fun_type, schema, lowercase_name);
+		expr->ignore_nulls = root->agg_ignore_nulls;
+
+		if (root->agg_filter) {
+			auto filter_expr = TransformExpression(root->agg_filter);
+			expr->filter_expr = move(filter_expr);
+		}
+
+		if (root->args) {
+			vector<unique_ptr<ParsedExpression>> function_list;
+			TransformExpressionList(*root->args, function_list);
+
+			if (win_fun_type == ExpressionType::WINDOW_AGGREGATE) {
+				for (auto &child : function_list) {
+					expr->children.push_back(move(child));
+				}
+			} else {
+				if (!function_list.empty()) {
+					expr->children.push_back(move(function_list[0]));
+				}
+				if (win_fun_type == ExpressionType::WINDOW_LEAD || win_fun_type == ExpressionType::WINDOW_LAG) {
+					if (function_list.size() > 1) {
+						expr->offset_expr = move(function_list[1]);
+					}
+					if (function_list.size() > 2) {
+						expr->default_expr = move(function_list[2]);
+					}
+					if (function_list.size() > 3) {
+						throw ParserException("Incorrect number of parameters for function %s", lowercase_name);
+					}
+				} else if (win_fun_type == ExpressionType::WINDOW_NTH_VALUE) {
+					if (function_list.size() > 1) {
+						expr->children.push_back(move(function_list[1]));
+					}
+					if (function_list.size() > 2) {
+						throw ParserException("Incorrect number of parameters for function %s", lowercase_name);
+					}
+				} else {
+					if (function_list.size() > 1) {
+						throw ParserException("Incorrect number of parameters for function %s", lowercase_name);
+					}
+				}
+			}
+		}
+		auto window_spec = reinterpret_cast<duckdb_libpgquery::PGWindowDef *>(root->over);
+		if (window_spec->name) {
+			auto it = window_clauses.find(StringUtil::Lower(string(window_spec->name)));
+			if (it == window_clauses.end()) {
+				throw ParserException("window \"%s\" does not exist", window_spec->name);
+			}
+			window_spec = it->second;
+			D_ASSERT(window_spec);
+		}
+		auto window_ref = window_spec;
+		if (window_ref->refname) {
+			auto it = window_clauses.find(StringUtil::Lower(string(window_spec->refname)));
+			if (it == window_clauses.end()) {
+				throw ParserException("window \"%s\" does not exist", window_spec->refname);
+			}
+			window_ref = it->second;
+			D_ASSERT(window_ref);
+		}
+		TransformWindowDef(window_ref, expr.get());
+		TransformWindowFrame(window_spec, expr.get());
+		expr->query_location = root->location;
+		return move(expr);
+	}
+
+	if (root->agg_ignore_nulls) {
+		throw ParserException("IGNORE NULLS is not supported for non-window functions");
+	}
+
+	//  TransformExpressionList??
+	vector<unique_ptr<ParsedExpression>> children;
+	if (root->args != nullptr) {
+		for (auto node = root->args->head; node != nullptr; node = node->next) {
+			auto child_expr = TransformExpression((duckdb_libpgquery::PGNode *)node->data.ptr_value);
+			children.push_back(move(child_expr));
+		}
+	}
+	unique_ptr<ParsedExpression> filter_expr;
+	if (root->agg_filter) {
+		filter_expr = TransformExpression(root->agg_filter);
+	}
+
+	auto order_bys = make_unique<OrderModifier>();
+	TransformOrderBy(root->agg_order, order_bys->orders);
+
+	// Ordered aggregates can be either WITHIN GROUP or after the function arguments
+	if (root->agg_within_group) {
+		//	https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE
+		//  Since we implement "ordered aggregates" without sorting,
+		//  we map all the ones we support to the corresponding aggregate function.
+		if (order_bys->orders.size() != 1) {
+			throw ParserException("Cannot use multiple ORDER BY clauses with WITHIN GROUP");
+		}
+		if (lowercase_name == "percentile_cont") {
+			if (children.size() != 1) {
+				throw ParserException("Wrong number of arguments for PERCENTILE_CONT");
+			}
+			lowercase_name = "quantile_cont";
+		} else if (lowercase_name == "percentile_disc") {
+			if (children.size() != 1) {
+				throw ParserException("Wrong number of arguments for PERCENTILE_DISC");
+			}
+			lowercase_name = "quantile_disc";
+		} else if (lowercase_name == "mode") {
+			if (!children.empty()) {
+				throw ParserException("Wrong number of arguments for MODE");
+			}
+			lowercase_name = "mode";
+		} else {
+			throw ParserException("Unknown ordered aggregate \"%s\".", function_name);
+		}
+	}
+
+	// star gets eaten in the parser
+	if (lowercase_name == "count" && children.empty()) {
+		lowercase_name = "count_star";
+	}
+
+	if (lowercase_name == "if") {
+		if (children.size() != 3) {
+			throw ParserException("Wrong number of arguments to IF.");
+		}
+		auto expr = make_unique<CaseExpression>();
+		CaseCheck check;
+		check.when_expr = move(children[0]);
+		check.then_expr = move(children[1]);
+		expr->case_checks.push_back(move(check));
+		expr->else_expr = move(children[2]);
+		return move(expr);
+	} else if (lowercase_name == "construct_array") {
+		auto construct_array = make_unique<OperatorExpression>(ExpressionType::ARRAY_CONSTRUCTOR);
+		construct_array->children = move(children);
+		return move(construct_array);
+	} else if (lowercase_name == "ifnull") {
+		if (children.size() != 2) {
+			throw ParserException("Wrong number of arguments to IFNULL.");
+		}
+
+		//  Two-argument COALESCE
+		auto coalesce_op = make_unique<OperatorExpression>(ExpressionType::OPERATOR_COALESCE);
+		coalesce_op->children.push_back(move(children[0]));
+		coalesce_op->children.push_back(move(children[1]));
+		return move(coalesce_op);
+	}
+
+	auto function = make_unique<FunctionExpression>(schema, lowercase_name.c_str(), move(children), move(filter_expr),
+	                                                move(order_bys), root->agg_distinct, false, root->export_state);
+	function->query_location = root->location;
+
+	return move(function);
+}
+
+static string SQLValueOpToString(duckdb_libpgquery::PGSQLValueFunctionOp op) {
+	switch (op) {
+	case duckdb_libpgquery::PG_SVFOP_CURRENT_DATE:
+		return "current_date";
+	case duckdb_libpgquery::PG_SVFOP_CURRENT_TIME:
+		return "get_current_time";
+	case duckdb_libpgquery::PG_SVFOP_CURRENT_TIME_N:
+		return "current_time_n";
+	case duckdb_libpgquery::PG_SVFOP_CURRENT_TIMESTAMP:
+		return "get_current_timestamp";
+	case duckdb_libpgquery::PG_SVFOP_CURRENT_TIMESTAMP_N:
+		return "current_timestamp_n";
+	case duckdb_libpgquery::PG_SVFOP_LOCALTIME:
+		return "current_localtime";
+	case duckdb_libpgquery::PG_SVFOP_LOCALTIME_N:
+		return "current_localtime_n";
+	case duckdb_libpgquery::PG_SVFOP_LOCALTIMESTAMP:
+		return "current_localtimestamp";
+	case duckdb_libpgquery::PG_SVFOP_LOCALTIMESTAMP_N:
+		return "current_localtimestamp_n";
+	case duckdb_libpgquery::PG_SVFOP_CURRENT_ROLE:
+		return "current_role";
+	case duckdb_libpgquery::PG_SVFOP_CURRENT_USER:
+		return "current_user";
+	case duckdb_libpgquery::PG_SVFOP_USER:
+		return "user";
+	case duckdb_libpgquery::PG_SVFOP_SESSION_USER:
+		return "session_user";
+	case duckdb_libpgquery::PG_SVFOP_CURRENT_CATALOG:
+		return "current_catalog";
+	case duckdb_libpgquery::PG_SVFOP_CURRENT_SCHEMA:
+		return "current_schema";
+	default:
+		throw InternalException("Could not find named SQL value function specification " + to_string((int)op));
+	}
+}
+
+unique_ptr<ParsedExpression> Transformer::TransformSQLValueFunction(duckdb_libpgquery::PGSQLValueFunction *node) {
+	D_ASSERT(node);
+	vector<unique_ptr<ParsedExpression>> children;
+	auto fname = SQLValueOpToString(node->op);
+	return make_unique<FunctionExpression>(DEFAULT_SCHEMA, fname, move(children));
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformGroupingFunction(duckdb_libpgquery::PGGroupingFunc *n) {
+	auto op = make_unique<OperatorExpression>(ExpressionType::GROUPING_FUNCTION);
+	for (auto node = n->args->head; node; node = node->next) {
+		auto n = (duckdb_libpgquery::PGNode *)node->data.ptr_value;
+		op->children.push_back(TransformExpression(n));
+	}
+	op->query_location = n->location;
+	return move(op);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformInterval(duckdb_libpgquery::PGIntervalConstant *node) {
+	// handle post-fix notation of INTERVAL
+
+	// three scenarios
+	// interval (expr) year
+	// interval 'string' year
+	// interval int year
+	unique_ptr<ParsedExpression> expr;
+	switch (node->val_type) {
+	case duckdb_libpgquery::T_PGAExpr:
+		expr = TransformExpression(node->eval);
+		break;
+	case duckdb_libpgquery::T_PGString:
+		expr = make_unique<ConstantExpression>(Value(node->sval));
+		break;
+	case duckdb_libpgquery::T_PGInteger:
+		expr = make_unique<ConstantExpression>(Value(node->ival));
+		break;
+	default:
+		throw InternalException("Unsupported interval transformation");
+	}
+
+	if (!node->typmods) {
+		return make_unique<CastExpression>(LogicalType::INTERVAL, move(expr));
+	}
+
+	int32_t mask = ((duckdb_libpgquery::PGAConst *)node->typmods->head->data.ptr_value)->val.val.ival;
+	// these seemingly random constants are from datetime.hpp
+	// they are copied here to avoid having to include this header
+	// the bitshift is from the function INTERVAL_MASK in the parser
+	constexpr int32_t MONTH_MASK = 1 << 1;
+	constexpr int32_t YEAR_MASK = 1 << 2;
+	constexpr int32_t DAY_MASK = 1 << 3;
+	constexpr int32_t HOUR_MASK = 1 << 10;
+	constexpr int32_t MINUTE_MASK = 1 << 11;
+	constexpr int32_t SECOND_MASK = 1 << 12;
+	constexpr int32_t MILLISECOND_MASK = 1 << 13;
+	constexpr int32_t MICROSECOND_MASK = 1 << 14;
+
+	// we need to check certain combinations
+	// because certain interval masks (e.g. INTERVAL '10' HOURS TO DAYS) set multiple bits
+	// for now we don't support all of the combined ones
+	// (we might add support if someone complains about it)
+
+	string fname;
+	LogicalType target_type;
+	if (mask & YEAR_MASK && mask & MONTH_MASK) {
+		// DAY TO HOUR
+		throw ParserException("YEAR TO MONTH is not supported");
+	} else if (mask & DAY_MASK && mask & HOUR_MASK) {
+		// DAY TO HOUR
+		throw ParserException("DAY TO HOUR is not supported");
+	} else if (mask & DAY_MASK && mask & MINUTE_MASK) {
+		// DAY TO MINUTE
+		throw ParserException("DAY TO MINUTE is not supported");
+	} else if (mask & DAY_MASK && mask & SECOND_MASK) {
+		// DAY TO SECOND
+		throw ParserException("DAY TO SECOND is not supported");
+	} else if (mask & HOUR_MASK && mask & MINUTE_MASK) {
+		// DAY TO SECOND
+		throw ParserException("HOUR TO MINUTE is not supported");
+	} else if (mask & HOUR_MASK && mask & SECOND_MASK) {
+		// DAY TO SECOND
+		throw ParserException("HOUR TO SECOND is not supported");
+	} else if (mask & MINUTE_MASK && mask & SECOND_MASK) {
+		// DAY TO SECOND
+		throw ParserException("MINUTE TO SECOND is not supported");
+	} else if (mask & YEAR_MASK) {
+		// YEAR
+		fname = "to_years";
+		target_type = LogicalType::INTEGER;
+	} else if (mask & MONTH_MASK) {
+		// MONTH
+		fname = "to_months";
+		target_type = LogicalType::INTEGER;
+	} else if (mask & DAY_MASK) {
+		// DAY
+		fname = "to_days";
+		target_type = LogicalType::INTEGER;
+	} else if (mask & HOUR_MASK) {
+		// HOUR
+		fname = "to_hours";
+		target_type = LogicalType::BIGINT;
+	} else if (mask & MINUTE_MASK) {
+		// MINUTE
+		fname = "to_minutes";
+		target_type = LogicalType::BIGINT;
+	} else if (mask & SECOND_MASK) {
+		// SECOND
+		fname = "to_seconds";
+		target_type = LogicalType::BIGINT;
+	} else if (mask & MILLISECOND_MASK) {
+		// MILLISECOND
+		fname = "to_milliseconds";
+		target_type = LogicalType::BIGINT;
+	} else if (mask & MICROSECOND_MASK) {
+		// SECOND
+		fname = "to_microseconds";
+		target_type = LogicalType::BIGINT;
+	} else {
+		throw InternalException("Unsupported interval post-fix");
+	}
+	// first push a cast to the target type
+	expr = make_unique<CastExpression>(target_type, move(expr));
+	// now push the operation
+	vector<unique_ptr<ParsedExpression>> children;
+	children.push_back(move(expr));
+	return make_unique<FunctionExpression>(fname, move(children));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformNullTest(duckdb_libpgquery::PGNullTest *root) {
+	D_ASSERT(root);
+	auto arg = TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(root->arg));
+	if (root->argisrow) {
+		throw NotImplementedException("IS NULL argisrow");
+	}
+	ExpressionType expr_type = (root->nulltesttype == duckdb_libpgquery::PG_IS_NULL)
+	                               ? ExpressionType::OPERATOR_IS_NULL
+	                               : ExpressionType::OPERATOR_IS_NOT_NULL;
+
+	return unique_ptr<ParsedExpression>(new OperatorExpression(expr_type, move(arg)));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformLambda(duckdb_libpgquery::PGLambdaFunction *node) {
+	if (!node->lhs) {
+		throw ParserException("Lambda function must have parameters");
+	}
+	auto lhs = TransformExpression(node->lhs);
+	auto rhs = TransformExpression(node->rhs);
+	return make_unique<LambdaExpression>(move(lhs), move(rhs));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformUnaryOperator(const string &op, unique_ptr<ParsedExpression> child) {
+	const auto schema = DEFAULT_SCHEMA;
+
+	vector<unique_ptr<ParsedExpression>> children;
+	children.push_back(move(child));
+
+	// built-in operator function
+	auto result = make_unique<FunctionExpression>(schema, op, move(children));
+	result->is_operator = true;
+	return move(result);
+}
+
+unique_ptr<ParsedExpression> Transformer::TransformBinaryOperator(const string &op, unique_ptr<ParsedExpression> left,
+                                                                  unique_ptr<ParsedExpression> right) {
+	const auto schema = DEFAULT_SCHEMA;
+
+	vector<unique_ptr<ParsedExpression>> children;
+	children.push_back(move(left));
+	children.push_back(move(right));
+
+	if (op == "~" || op == "!~") {
+		// rewrite 'asdf' SIMILAR TO '.*sd.*' into regexp_full_match('asdf', '.*sd.*')
+		bool invert_similar = op == "!~";
+
+		auto result = make_unique<FunctionExpression>(schema, "regexp_full_match", move(children));
+		if (invert_similar) {
+			return make_unique<OperatorExpression>(ExpressionType::OPERATOR_NOT, move(result));
+		} else {
+			return move(result);
+		}
+	} else {
+		auto target_type = OperatorToExpressionType(op);
+		if (target_type != ExpressionType::INVALID) {
+			// built-in comparison operator
+			return make_unique<ComparisonExpression>(target_type, move(children[0]), move(children[1]));
+		}
+		// not a special operator: convert to a function expression
+		auto result = make_unique<FunctionExpression>(schema, op, move(children));
+		result->is_operator = true;
+		return move(result);
+	}
+}
+
+unique_ptr<ParsedExpression> Transformer::TransformAExpr(duckdb_libpgquery::PGAExpr *root) {
+	D_ASSERT(root);
+	auto name = string((reinterpret_cast<duckdb_libpgquery::PGValue *>(root->name->head->data.ptr_value))->val.str);
+
+	switch (root->kind) {
+	case duckdb_libpgquery::PG_AEXPR_OP_ALL:
+	case duckdb_libpgquery::PG_AEXPR_OP_ANY: {
+		// left=ANY(right)
+		// we turn this into left=ANY((SELECT UNNEST(right)))
+		auto left_expr = TransformExpression(root->lexpr);
+		auto right_expr = TransformExpression(root->rexpr);
+
+		auto subquery_expr = make_unique<SubqueryExpression>();
+		auto select_statement = make_unique<SelectStatement>();
+		auto select_node = make_unique<SelectNode>();
+		vector<unique_ptr<ParsedExpression>> children;
+		children.push_back(move(right_expr));
+
+		select_node->select_list.push_back(make_unique<FunctionExpression>("UNNEST", move(children)));
+		select_node->from_table = make_unique<EmptyTableRef>();
+		select_statement->node = move(select_node);
+		subquery_expr->subquery = move(select_statement);
+		subquery_expr->subquery_type = SubqueryType::ANY;
+		subquery_expr->child = move(left_expr);
+		subquery_expr->comparison_type = OperatorToExpressionType(name);
+		subquery_expr->query_location = root->location;
+
+		if (root->kind == duckdb_libpgquery::PG_AEXPR_OP_ALL) {
+			// ALL sublink is equivalent to NOT(ANY) with inverted comparison
+			// e.g. [= ALL()] is equivalent to [NOT(<> ANY())]
+			// first invert the comparison type
+			subquery_expr->comparison_type = NegateComparisionExpression(subquery_expr->comparison_type);
+			return make_unique<OperatorExpression>(ExpressionType::OPERATOR_NOT, move(subquery_expr));
+		}
+		return move(subquery_expr);
+	}
+	case duckdb_libpgquery::PG_AEXPR_IN: {
+		auto left_expr = TransformExpression(root->lexpr);
+		ExpressionType operator_type;
+		// this looks very odd, but seems to be the way to find out its NOT IN
+		if (name == "<>") {
+			// NOT IN
+			operator_type = ExpressionType::COMPARE_NOT_IN;
+		} else {
+			// IN
+			operator_type = ExpressionType::COMPARE_IN;
+		}
+		auto result = make_unique<OperatorExpression>(operator_type, move(left_expr));
+		result->query_location = root->location;
+		TransformExpressionList(*((duckdb_libpgquery::PGList *)root->rexpr), result->children);
+		return move(result);
+	}
+	// rewrite NULLIF(a, b) into CASE WHEN a=b THEN NULL ELSE a END
+	case duckdb_libpgquery::PG_AEXPR_NULLIF: {
+		vector<unique_ptr<ParsedExpression>> children;
+		children.push_back(TransformExpression(root->lexpr));
+		children.push_back(TransformExpression(root->rexpr));
+		return make_unique<FunctionExpression>("nullif", move(children));
+	}
+	// rewrite (NOT) X BETWEEN A AND B into (NOT) AND(GREATERTHANOREQUALTO(X,
+	// A), LESSTHANOREQUALTO(X, B))
+	case duckdb_libpgquery::PG_AEXPR_BETWEEN:
+	case duckdb_libpgquery::PG_AEXPR_NOT_BETWEEN: {
+		auto between_args = reinterpret_cast<duckdb_libpgquery::PGList *>(root->rexpr);
+		if (between_args->length != 2 || !between_args->head->data.ptr_value || !between_args->tail->data.ptr_value) {
+			throw InternalException("(NOT) BETWEEN needs two args");
+		}
+
+		auto input = TransformExpression(root->lexpr);
+		auto between_left =
+		    TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(between_args->head->data.ptr_value));
+		auto between_right =
+		    TransformExpression(reinterpret_cast<duckdb_libpgquery::PGNode *>(between_args->tail->data.ptr_value));
+
+		auto compare_between = make_unique<BetweenExpression>(move(input), move(between_left), move(between_right));
+		if (root->kind == duckdb_libpgquery::PG_AEXPR_BETWEEN) {
+			return move(compare_between);
+		} else {
+			return make_unique<OperatorExpression>(ExpressionType::OPERATOR_NOT, move(compare_between));
+		}
+	}
+	// rewrite SIMILAR TO into regexp_full_match('asdf', '.*sd.*')
+	case duckdb_libpgquery::PG_AEXPR_SIMILAR: {
+		auto left_expr = TransformExpression(root->lexpr);
+		auto right_expr = TransformExpression(root->rexpr);
+
+		vector<unique_ptr<ParsedExpression>> children;
+		children.push_back(move(left_expr));
+
+		auto &similar_func = reinterpret_cast<FunctionExpression &>(*right_expr);
+		D_ASSERT(similar_func.function_name == "similar_escape");
+		D_ASSERT(similar_func.children.size() == 2);
+		if (similar_func.children[1]->type != ExpressionType::VALUE_CONSTANT) {
+			throw NotImplementedException("Custom escape in SIMILAR TO");
+		}
+		auto &constant = (ConstantExpression &)*similar_func.children[1];
+		if (!constant.value.IsNull()) {
+			throw NotImplementedException("Custom escape in SIMILAR TO");
+		}
+		// take the child of the similar_func
+		children.push_back(move(similar_func.children[0]));
+
+		// this looks very odd, but seems to be the way to find out its NOT IN
+		bool invert_similar = false;
+		if (name == "!~") {
+			// NOT SIMILAR TO
+			invert_similar = true;
+		}
+		const auto schema = DEFAULT_SCHEMA;
+		const auto regex_function = "regexp_full_match";
+		auto result = make_unique<FunctionExpression>(schema, regex_function, move(children));
+
+		if (invert_similar) {
+			return make_unique<OperatorExpression>(ExpressionType::OPERATOR_NOT, move(result));
+		} else {
+			return move(result);
+		}
+	}
+	case duckdb_libpgquery::PG_AEXPR_NOT_DISTINCT: {
+		auto left_expr = TransformExpression(root->lexpr);
+		auto right_expr = TransformExpression(root->rexpr);
+		return make_unique<ComparisonExpression>(ExpressionType::COMPARE_NOT_DISTINCT_FROM, move(left_expr),
+		                                         move(right_expr));
+	}
+	case duckdb_libpgquery::PG_AEXPR_DISTINCT: {
+		auto left_expr = TransformExpression(root->lexpr);
+		auto right_expr = TransformExpression(root->rexpr);
+		return make_unique<ComparisonExpression>(ExpressionType::COMPARE_DISTINCT_FROM, move(left_expr),
+		                                         move(right_expr));
+	}
+
+	default:
+		break;
+	}
+	auto left_expr = TransformExpression(root->lexpr);
+	auto right_expr = TransformExpression(root->rexpr);
+
+	if (!left_expr) {
+		// prefix operator
+		return TransformUnaryOperator(name, move(right_expr));
+	} else if (!right_expr) {
+		// postfix operator, only ! is currently supported
+		return TransformUnaryOperator(name + "__postfix", move(left_expr));
+	} else {
+		return TransformBinaryOperator(name, move(left_expr), move(right_expr));
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformParamRef(duckdb_libpgquery::PGParamRef *node) {
+	D_ASSERT(node);
+	auto expr = make_unique<ParameterExpression>();
+	if (node->number < 0) {
+		throw ParserException("Parameter numbers cannot be negative");
+	}
+	if (node->number == 0) {
+		expr->parameter_nr = ParamCount() + 1;
+	} else {
+		expr->parameter_nr = node->number;
+	}
+	SetParamCount(MaxValue<idx_t>(ParamCount(), expr->parameter_nr));
+	return move(expr);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformPositionalReference(duckdb_libpgquery::PGPositionalReference *node) {
+	if (node->position <= 0) {
+		throw ParserException("Positional reference node needs to be >= 1");
+	}
+	auto result = make_unique<PositionalReferenceExpression>(node->position);
+	result->query_location = node->location;
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> Transformer::TransformSubquery(duckdb_libpgquery::PGSubLink *root) {
+	D_ASSERT(root);
+	auto subquery_expr = make_unique<SubqueryExpression>();
+
+	subquery_expr->subquery = TransformSelect(root->subselect);
+	D_ASSERT(subquery_expr->subquery);
+	D_ASSERT(subquery_expr->subquery->node->GetSelectList().size() > 0);
+
+	switch (root->subLinkType) {
+	case duckdb_libpgquery::PG_EXISTS_SUBLINK: {
+		subquery_expr->subquery_type = SubqueryType::EXISTS;
+		break;
+	}
+	case duckdb_libpgquery::PG_ANY_SUBLINK:
+	case duckdb_libpgquery::PG_ALL_SUBLINK: {
+		// comparison with ANY() or ALL()
+		subquery_expr->subquery_type = SubqueryType::ANY;
+		subquery_expr->child = TransformExpression(root->testexpr);
+		// get the operator name
+		if (!root->operName) {
+			// simple IN
+			subquery_expr->comparison_type = ExpressionType::COMPARE_EQUAL;
+		} else {
+			auto operator_name =
+			    string((reinterpret_cast<duckdb_libpgquery::PGValue *>(root->operName->head->data.ptr_value))->val.str);
+			subquery_expr->comparison_type = OperatorToExpressionType(operator_name);
+		}
+		D_ASSERT(subquery_expr->comparison_type == ExpressionType::COMPARE_EQUAL ||
+		         subquery_expr->comparison_type == ExpressionType::COMPARE_NOTEQUAL ||
+		         subquery_expr->comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
+		         subquery_expr->comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO ||
+		         subquery_expr->comparison_type == ExpressionType::COMPARE_LESSTHAN ||
+		         subquery_expr->comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO);
+		if (root->subLinkType == duckdb_libpgquery::PG_ALL_SUBLINK) {
+			// ALL sublink is equivalent to NOT(ANY) with inverted comparison
+			// e.g. [= ALL()] is equivalent to [NOT(<> ANY())]
+			// first invert the comparison type
+			subquery_expr->comparison_type = NegateComparisionExpression(subquery_expr->comparison_type);
+			return make_unique<OperatorExpression>(ExpressionType::OPERATOR_NOT, move(subquery_expr));
+		}
+		break;
+	}
+	case duckdb_libpgquery::PG_EXPR_SUBLINK: {
+		// return a single scalar value from the subquery
+		// no child expression to compare to
+		subquery_expr->subquery_type = SubqueryType::SCALAR;
+		break;
+	}
+	default:
+		throw NotImplementedException("Subquery of type %d not implemented\n", (int)root->subLinkType);
+	}
+	subquery_expr->query_location = root->location;
+	return move(subquery_expr);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+std::string Transformer::NodetypeToString(duckdb_libpgquery::PGNodeTag type) { // LCOV_EXCL_START
+	switch (type) {
+	case duckdb_libpgquery::T_PGInvalid:
+		return "T_Invalid";
+	case duckdb_libpgquery::T_PGIndexInfo:
+		return "T_IndexInfo";
+	case duckdb_libpgquery::T_PGExprContext:
+		return "T_ExprContext";
+	case duckdb_libpgquery::T_PGProjectionInfo:
+		return "T_ProjectionInfo";
+	case duckdb_libpgquery::T_PGJunkFilter:
+		return "T_JunkFilter";
+	case duckdb_libpgquery::T_PGResultRelInfo:
+		return "T_ResultRelInfo";
+	case duckdb_libpgquery::T_PGEState:
+		return "T_EState";
+	case duckdb_libpgquery::T_PGTupleTableSlot:
+		return "T_TupleTableSlot";
+	case duckdb_libpgquery::T_PGPlan:
+		return "T_Plan";
+	case duckdb_libpgquery::T_PGResult:
+		return "T_Result";
+	case duckdb_libpgquery::T_PGProjectSet:
+		return "T_ProjectSet";
+	case duckdb_libpgquery::T_PGModifyTable:
+		return "T_ModifyTable";
+	case duckdb_libpgquery::T_PGAppend:
+		return "T_Append";
+	case duckdb_libpgquery::T_PGMergeAppend:
+		return "T_MergeAppend";
+	case duckdb_libpgquery::T_PGRecursiveUnion:
+		return "T_RecursiveUnion";
+	case duckdb_libpgquery::T_PGBitmapAnd:
+		return "T_BitmapAnd";
+	case duckdb_libpgquery::T_PGBitmapOr:
+		return "T_BitmapOr";
+	case duckdb_libpgquery::T_PGScan:
+		return "T_Scan";
+	case duckdb_libpgquery::T_PGSeqScan:
+		return "T_SeqScan";
+	case duckdb_libpgquery::T_PGSampleScan:
+		return "T_SampleScan";
+	case duckdb_libpgquery::T_PGIndexScan:
+		return "T_IndexScan";
+	case duckdb_libpgquery::T_PGIndexOnlyScan:
+		return "T_IndexOnlyScan";
+	case duckdb_libpgquery::T_PGBitmapIndexScan:
+		return "T_BitmapIndexScan";
+	case duckdb_libpgquery::T_PGBitmapHeapScan:
+		return "T_BitmapHeapScan";
+	case duckdb_libpgquery::T_PGTidScan:
+		return "T_TidScan";
+	case duckdb_libpgquery::T_PGSubqueryScan:
+		return "T_SubqueryScan";
+	case duckdb_libpgquery::T_PGFunctionScan:
+		return "T_FunctionScan";
+	case duckdb_libpgquery::T_PGValuesScan:
+		return "T_ValuesScan";
+	case duckdb_libpgquery::T_PGTableFuncScan:
+		return "T_TableFuncScan";
+	case duckdb_libpgquery::T_PGCteScan:
+		return "T_CteScan";
+	case duckdb_libpgquery::T_PGNamedTuplestoreScan:
+		return "T_NamedTuplestoreScan";
+	case duckdb_libpgquery::T_PGWorkTableScan:
+		return "T_WorkTableScan";
+	case duckdb_libpgquery::T_PGForeignScan:
+		return "T_ForeignScan";
+	case duckdb_libpgquery::T_PGCustomScan:
+		return "T_CustomScan";
+	case duckdb_libpgquery::T_PGJoin:
+		return "T_Join";
+	case duckdb_libpgquery::T_PGNestLoop:
+		return "T_NestLoop";
+	case duckdb_libpgquery::T_PGMergeJoin:
+		return "T_MergeJoin";
+	case duckdb_libpgquery::T_PGHashJoin:
+		return "T_HashJoin";
+	case duckdb_libpgquery::T_PGMaterial:
+		return "T_Material";
+	case duckdb_libpgquery::T_PGSort:
+		return "T_Sort";
+	case duckdb_libpgquery::T_PGGroup:
+		return "T_Group";
+	case duckdb_libpgquery::T_PGAgg:
+		return "T_Agg";
+	case duckdb_libpgquery::T_PGWindowAgg:
+		return "T_WindowAgg";
+	case duckdb_libpgquery::T_PGUnique:
+		return "T_Unique";
+	case duckdb_libpgquery::T_PGGather:
+		return "T_Gather";
+	case duckdb_libpgquery::T_PGGatherMerge:
+		return "T_GatherMerge";
+	case duckdb_libpgquery::T_PGHash:
+		return "T_Hash";
+	case duckdb_libpgquery::T_PGSetOp:
+		return "T_SetOp";
+	case duckdb_libpgquery::T_PGLockRows:
+		return "T_LockRows";
+	case duckdb_libpgquery::T_PGLimit:
+		return "T_Limit";
+	case duckdb_libpgquery::T_PGNestLoopParam:
+		return "T_NestLoopParam";
+	case duckdb_libpgquery::T_PGPlanRowMark:
+		return "T_PlanRowMark";
+	case duckdb_libpgquery::T_PGPlanInvalItem:
+		return "T_PlanInvalItem";
+	case duckdb_libpgquery::T_PGPlanState:
+		return "T_PlanState";
+	case duckdb_libpgquery::T_PGResultState:
+		return "T_ResultState";
+	case duckdb_libpgquery::T_PGProjectSetState:
+		return "T_ProjectSetState";
+	case duckdb_libpgquery::T_PGModifyTableState:
+		return "T_ModifyTableState";
+	case duckdb_libpgquery::T_PGAppendState:
+		return "T_AppendState";
+	case duckdb_libpgquery::T_PGMergeAppendState:
+		return "T_MergeAppendState";
+	case duckdb_libpgquery::T_PGRecursiveUnionState:
+		return "T_RecursiveUnionState";
+	case duckdb_libpgquery::T_PGBitmapAndState:
+		return "T_BitmapAndState";
+	case duckdb_libpgquery::T_PGBitmapOrState:
+		return "T_BitmapOrState";
+	case duckdb_libpgquery::T_PGScanState:
+		return "T_ScanState";
+	case duckdb_libpgquery::T_PGSeqScanState:
+		return "T_SeqScanState";
+	case duckdb_libpgquery::T_PGSampleScanState:
+		return "T_SampleScanState";
+	case duckdb_libpgquery::T_PGIndexScanState:
+		return "T_IndexScanState";
+	case duckdb_libpgquery::T_PGIndexOnlyScanState:
+		return "T_IndexOnlyScanState";
+	case duckdb_libpgquery::T_PGBitmapIndexScanState:
+		return "T_BitmapIndexScanState";
+	case duckdb_libpgquery::T_PGBitmapHeapScanState:
+		return "T_BitmapHeapScanState";
+	case duckdb_libpgquery::T_PGTidScanState:
+		return "T_TidScanState";
+	case duckdb_libpgquery::T_PGSubqueryScanState:
+		return "T_SubqueryScanState";
+	case duckdb_libpgquery::T_PGFunctionScanState:
+		return "T_FunctionScanState";
+	case duckdb_libpgquery::T_PGTableFuncScanState:
+		return "T_TableFuncScanState";
+	case duckdb_libpgquery::T_PGValuesScanState:
+		return "T_ValuesScanState";
+	case duckdb_libpgquery::T_PGCteScanState:
+		return "T_CteScanState";
+	case duckdb_libpgquery::T_PGNamedTuplestoreScanState:
+		return "T_NamedTuplestoreScanState";
+	case duckdb_libpgquery::T_PGWorkTableScanState:
+		return "T_WorkTableScanState";
+	case duckdb_libpgquery::T_PGForeignScanState:
+		return "T_ForeignScanState";
+	case duckdb_libpgquery::T_PGCustomScanState:
+		return "T_CustomScanState";
+	case duckdb_libpgquery::T_PGJoinState:
+		return "T_JoinState";
+	case duckdb_libpgquery::T_PGNestLoopState:
+		return "T_NestLoopState";
+	case duckdb_libpgquery::T_PGMergeJoinState:
+		return "T_MergeJoinState";
+	case duckdb_libpgquery::T_PGHashJoinState:
+		return "T_HashJoinState";
+	case duckdb_libpgquery::T_PGMaterialState:
+		return "T_MaterialState";
+	case duckdb_libpgquery::T_PGSortState:
+		return "T_SortState";
+	case duckdb_libpgquery::T_PGGroupState:
+		return "T_GroupState";
+	case duckdb_libpgquery::T_PGAggState:
+		return "T_AggState";
+	case duckdb_libpgquery::T_PGWindowAggState:
+		return "T_WindowAggState";
+	case duckdb_libpgquery::T_PGUniqueState:
+		return "T_UniqueState";
+	case duckdb_libpgquery::T_PGGatherState:
+		return "T_GatherState";
+	case duckdb_libpgquery::T_PGGatherMergeState:
+		return "T_GatherMergeState";
+	case duckdb_libpgquery::T_PGHashState:
+		return "T_HashState";
+	case duckdb_libpgquery::T_PGSetOpState:
+		return "T_SetOpState";
+	case duckdb_libpgquery::T_PGLockRowsState:
+		return "T_LockRowsState";
+	case duckdb_libpgquery::T_PGLimitState:
+		return "T_LimitState";
+	case duckdb_libpgquery::T_PGAlias:
+		return "T_Alias";
+	case duckdb_libpgquery::T_PGRangeVar:
+		return "T_RangeVar";
+	case duckdb_libpgquery::T_PGTableFunc:
+		return "T_TableFunc";
+	case duckdb_libpgquery::T_PGExpr:
+		return "T_Expr";
+	case duckdb_libpgquery::T_PGVar:
+		return "T_Var";
+	case duckdb_libpgquery::T_PGConst:
+		return "T_Const";
+	case duckdb_libpgquery::T_PGParam:
+		return "T_Param";
+	case duckdb_libpgquery::T_PGAggref:
+		return "T_Aggref";
+	case duckdb_libpgquery::T_PGGroupingFunc:
+		return "T_GroupingFunc";
+	case duckdb_libpgquery::T_PGWindowFunc:
+		return "T_WindowFunc";
+	case duckdb_libpgquery::T_PGArrayRef:
+		return "T_ArrayRef";
+	case duckdb_libpgquery::T_PGFuncExpr:
+		return "T_FuncExpr";
+	case duckdb_libpgquery::T_PGNamedArgExpr:
+		return "T_NamedArgExpr";
+	case duckdb_libpgquery::T_PGOpExpr:
+		return "T_OpExpr";
+	case duckdb_libpgquery::T_PGDistinctExpr:
+		return "T_DistinctExpr";
+	case duckdb_libpgquery::T_PGNullIfExpr:
+		return "T_NullIfExpr";
+	case duckdb_libpgquery::T_PGScalarArrayOpExpr:
+		return "T_ScalarArrayOpExpr";
+	case duckdb_libpgquery::T_PGBoolExpr:
+		return "T_BoolExpr";
+	case duckdb_libpgquery::T_PGSubLink:
+		return "T_SubLink";
+	case duckdb_libpgquery::T_PGSubPlan:
+		return "T_SubPlan";
+	case duckdb_libpgquery::T_PGAlternativeSubPlan:
+		return "T_AlternativeSubPlan";
+	case duckdb_libpgquery::T_PGFieldSelect:
+		return "T_FieldSelect";
+	case duckdb_libpgquery::T_PGFieldStore:
+		return "T_FieldStore";
+	case duckdb_libpgquery::T_PGRelabelType:
+		return "T_RelabelType";
+	case duckdb_libpgquery::T_PGCoerceViaIO:
+		return "T_CoerceViaIO";
+	case duckdb_libpgquery::T_PGArrayCoerceExpr:
+		return "T_ArrayCoerceExpr";
+	case duckdb_libpgquery::T_PGConvertRowtypeExpr:
+		return "T_ConvertRowtypeExpr";
+	case duckdb_libpgquery::T_PGCollateExpr:
+		return "T_CollateExpr";
+	case duckdb_libpgquery::T_PGCaseExpr:
+		return "T_CaseExpr";
+	case duckdb_libpgquery::T_PGCaseWhen:
+		return "T_CaseWhen";
+	case duckdb_libpgquery::T_PGCaseTestExpr:
+		return "T_CaseTestExpr";
+	case duckdb_libpgquery::T_PGArrayExpr:
+		return "T_ArrayExpr";
+	case duckdb_libpgquery::T_PGRowExpr:
+		return "T_RowExpr";
+	case duckdb_libpgquery::T_PGRowCompareExpr:
+		return "T_RowCompareExpr";
+	case duckdb_libpgquery::T_PGCoalesceExpr:
+		return "T_CoalesceExpr";
+	case duckdb_libpgquery::T_PGMinMaxExpr:
+		return "T_MinMaxExpr";
+	case duckdb_libpgquery::T_PGSQLValueFunction:
+		return "T_SQLValueFunction";
+	case duckdb_libpgquery::T_PGXmlExpr:
+		return "T_XmlExpr";
+	case duckdb_libpgquery::T_PGNullTest:
+		return "T_NullTest";
+	case duckdb_libpgquery::T_PGBooleanTest:
+		return "T_BooleanTest";
+	case duckdb_libpgquery::T_PGCoerceToDomain:
+		return "T_CoerceToDomain";
+	case duckdb_libpgquery::T_PGCoerceToDomainValue:
+		return "T_CoerceToDomainValue";
+	case duckdb_libpgquery::T_PGSetToDefault:
+		return "T_SetToDefault";
+	case duckdb_libpgquery::T_PGCurrentOfExpr:
+		return "T_CurrentOfExpr";
+	case duckdb_libpgquery::T_PGNextValueExpr:
+		return "T_NextValueExpr";
+	case duckdb_libpgquery::T_PGInferenceElem:
+		return "T_InferenceElem";
+	case duckdb_libpgquery::T_PGTargetEntry:
+		return "T_TargetEntry";
+	case duckdb_libpgquery::T_PGRangeTblRef:
+		return "T_RangeTblRef";
+	case duckdb_libpgquery::T_PGJoinExpr:
+		return "T_JoinExpr";
+	case duckdb_libpgquery::T_PGFromExpr:
+		return "T_FromExpr";
+	case duckdb_libpgquery::T_PGOnConflictExpr:
+		return "T_OnConflictExpr";
+	case duckdb_libpgquery::T_PGIntoClause:
+		return "T_IntoClause";
+	case duckdb_libpgquery::T_PGExprState:
+		return "T_ExprState";
+	case duckdb_libpgquery::T_PGAggrefExprState:
+		return "T_AggrefExprState";
+	case duckdb_libpgquery::T_PGWindowFuncExprState:
+		return "T_WindowFuncExprState";
+	case duckdb_libpgquery::T_PGSetExprState:
+		return "T_SetExprState";
+	case duckdb_libpgquery::T_PGSubPlanState:
+		return "T_SubPlanState";
+	case duckdb_libpgquery::T_PGAlternativeSubPlanState:
+		return "T_AlternativeSubPlanState";
+	case duckdb_libpgquery::T_PGDomainConstraintState:
+		return "T_DomainConstraintState";
+	case duckdb_libpgquery::T_PGPlannerInfo:
+		return "T_PlannerInfo";
+	case duckdb_libpgquery::T_PGPlannerGlobal:
+		return "T_PlannerGlobal";
+	case duckdb_libpgquery::T_PGRelOptInfo:
+		return "T_RelOptInfo";
+	case duckdb_libpgquery::T_PGIndexOptInfo:
+		return "T_IndexOptInfo";
+	case duckdb_libpgquery::T_PGForeignKeyOptInfo:
+		return "T_ForeignKeyOptInfo";
+	case duckdb_libpgquery::T_PGParamPathInfo:
+		return "T_ParamPathInfo";
+	case duckdb_libpgquery::T_PGPath:
+		return "T_Path";
+	case duckdb_libpgquery::T_PGIndexPath:
+		return "T_IndexPath";
+	case duckdb_libpgquery::T_PGBitmapHeapPath:
+		return "T_BitmapHeapPath";
+	case duckdb_libpgquery::T_PGBitmapAndPath:
+		return "T_BitmapAndPath";
+	case duckdb_libpgquery::T_PGBitmapOrPath:
+		return "T_BitmapOrPath";
+	case duckdb_libpgquery::T_PGTidPath:
+		return "T_TidPath";
+	case duckdb_libpgquery::T_PGSubqueryScanPath:
+		return "T_SubqueryScanPath";
+	case duckdb_libpgquery::T_PGForeignPath:
+		return "T_ForeignPath";
+	case duckdb_libpgquery::T_PGCustomPath:
+		return "T_CustomPath";
+	case duckdb_libpgquery::T_PGNestPath:
+		return "T_NestPath";
+	case duckdb_libpgquery::T_PGMergePath:
+		return "T_MergePath";
+	case duckdb_libpgquery::T_PGHashPath:
+		return "T_HashPath";
+	case duckdb_libpgquery::T_PGAppendPath:
+		return "T_AppendPath";
+	case duckdb_libpgquery::T_PGMergeAppendPath:
+		return "T_MergeAppendPath";
+	case duckdb_libpgquery::T_PGResultPath:
+		return "T_ResultPath";
+	case duckdb_libpgquery::T_PGMaterialPath:
+		return "T_MaterialPath";
+	case duckdb_libpgquery::T_PGUniquePath:
+		return "T_UniquePath";
+	case duckdb_libpgquery::T_PGGatherPath:
+		return "T_GatherPath";
+	case duckdb_libpgquery::T_PGGatherMergePath:
+		return "T_GatherMergePath";
+	case duckdb_libpgquery::T_PGProjectionPath:
+		return "T_ProjectionPath";
+	case duckdb_libpgquery::T_PGProjectSetPath:
+		return "T_ProjectSetPath";
+	case duckdb_libpgquery::T_PGSortPath:
+		return "T_SortPath";
+	case duckdb_libpgquery::T_PGGroupPath:
+		return "T_GroupPath";
+	case duckdb_libpgquery::T_PGUpperUniquePath:
+		return "T_UpperUniquePath";
+	case duckdb_libpgquery::T_PGAggPath:
+		return "T_AggPath";
+	case duckdb_libpgquery::T_PGGroupingSetsPath:
+		return "T_GroupingSetsPath";
+	case duckdb_libpgquery::T_PGMinMaxAggPath:
+		return "T_MinMaxAggPath";
+	case duckdb_libpgquery::T_PGWindowAggPath:
+		return "T_WindowAggPath";
+	case duckdb_libpgquery::T_PGSetOpPath:
+		return "T_SetOpPath";
+	case duckdb_libpgquery::T_PGRecursiveUnionPath:
+		return "T_RecursiveUnionPath";
+	case duckdb_libpgquery::T_PGLockRowsPath:
+		return "T_LockRowsPath";
+	case duckdb_libpgquery::T_PGModifyTablePath:
+		return "T_ModifyTablePath";
+	case duckdb_libpgquery::T_PGLimitPath:
+		return "T_LimitPath";
+	case duckdb_libpgquery::T_PGEquivalenceClass:
+		return "T_EquivalenceClass";
+	case duckdb_libpgquery::T_PGEquivalenceMember:
+		return "T_EquivalenceMember";
+	case duckdb_libpgquery::T_PGPathKey:
+		return "T_PathKey";
+	case duckdb_libpgquery::T_PGPathTarget:
+		return "T_PathTarget";
+	case duckdb_libpgquery::T_PGRestrictInfo:
+		return "T_RestrictInfo";
+	case duckdb_libpgquery::T_PGPlaceHolderVar:
+		return "T_PlaceHolderVar";
+	case duckdb_libpgquery::T_PGSpecialJoinInfo:
+		return "T_SpecialJoinInfo";
+	case duckdb_libpgquery::T_PGAppendRelInfo:
+		return "T_AppendRelInfo";
+	case duckdb_libpgquery::T_PGPartitionedChildRelInfo:
+		return "T_PartitionedChildRelInfo";
+	case duckdb_libpgquery::T_PGPlaceHolderInfo:
+		return "T_PlaceHolderInfo";
+	case duckdb_libpgquery::T_PGMinMaxAggInfo:
+		return "T_MinMaxAggInfo";
+	case duckdb_libpgquery::T_PGPlannerParamItem:
+		return "T_PlannerParamItem";
+	case duckdb_libpgquery::T_PGRollupData:
+		return "T_RollupData";
+	case duckdb_libpgquery::T_PGGroupingSetData:
+		return "T_GroupingSetData";
+	case duckdb_libpgquery::T_PGStatisticExtInfo:
+		return "T_StatisticExtInfo";
+	case duckdb_libpgquery::T_PGMemoryContext:
+		return "T_MemoryContext";
+	case duckdb_libpgquery::T_PGAllocSetContext:
+		return "T_AllocSetContext";
+	case duckdb_libpgquery::T_PGSlabContext:
+		return "T_SlabContext";
+	case duckdb_libpgquery::T_PGValue:
+		return "T_Value";
+	case duckdb_libpgquery::T_PGInteger:
+		return "T_Integer";
+	case duckdb_libpgquery::T_PGFloat:
+		return "T_Float";
+	case duckdb_libpgquery::T_PGString:
+		return "T_String";
+	case duckdb_libpgquery::T_PGBitString:
+		return "T_BitString";
+	case duckdb_libpgquery::T_PGNull:
+		return "T_Null";
+	case duckdb_libpgquery::T_PGList:
+		return "T_List";
+	case duckdb_libpgquery::T_PGIntList:
+		return "T_IntList";
+	case duckdb_libpgquery::T_PGOidList:
+		return "T_OidList";
+	case duckdb_libpgquery::T_PGExtensibleNode:
+		return "T_ExtensibleNode";
+	case duckdb_libpgquery::T_PGRawStmt:
+		return "T_RawStmt";
+	case duckdb_libpgquery::T_PGQuery:
+		return "T_Query";
+	case duckdb_libpgquery::T_PGPlannedStmt:
+		return "T_PlannedStmt";
+	case duckdb_libpgquery::T_PGInsertStmt:
+		return "T_InsertStmt";
+	case duckdb_libpgquery::T_PGDeleteStmt:
+		return "T_DeleteStmt";
+	case duckdb_libpgquery::T_PGUpdateStmt:
+		return "T_UpdateStmt";
+	case duckdb_libpgquery::T_PGSelectStmt:
+		return "T_SelectStmt";
+	case duckdb_libpgquery::T_PGAlterTableStmt:
+		return "T_AlterTableStmt";
+	case duckdb_libpgquery::T_PGAlterTableCmd:
+		return "T_AlterTableCmd";
+	case duckdb_libpgquery::T_PGAlterDomainStmt:
+		return "T_AlterDomainStmt";
+	case duckdb_libpgquery::T_PGSetOperationStmt:
+		return "T_SetOperationStmt";
+	case duckdb_libpgquery::T_PGGrantStmt:
+		return "T_GrantStmt";
+	case duckdb_libpgquery::T_PGGrantRoleStmt:
+		return "T_GrantRoleStmt";
+	case duckdb_libpgquery::T_PGAlterDefaultPrivilegesStmt:
+		return "T_AlterDefaultPrivilegesStmt";
+	case duckdb_libpgquery::T_PGClosePortalStmt:
+		return "T_ClosePortalStmt";
+	case duckdb_libpgquery::T_PGClusterStmt:
+		return "T_ClusterStmt";
+	case duckdb_libpgquery::T_PGCopyStmt:
+		return "T_CopyStmt";
+	case duckdb_libpgquery::T_PGCreateStmt:
+		return "T_CreateStmt";
+	case duckdb_libpgquery::T_PGDefineStmt:
+		return "T_DefineStmt";
+	case duckdb_libpgquery::T_PGDropStmt:
+		return "T_DropStmt";
+	case duckdb_libpgquery::T_PGTruncateStmt:
+		return "T_TruncateStmt";
+	case duckdb_libpgquery::T_PGCommentStmt:
+		return "T_CommentStmt";
+	case duckdb_libpgquery::T_PGFetchStmt:
+		return "T_FetchStmt";
+	case duckdb_libpgquery::T_PGIndexStmt:
+		return "T_IndexStmt";
+	case duckdb_libpgquery::T_PGCreateFunctionStmt:
+		return "T_CreateFunctionStmt";
+	case duckdb_libpgquery::T_PGAlterFunctionStmt:
+		return "T_AlterFunctionStmt";
+	case duckdb_libpgquery::T_PGDoStmt:
+		return "T_DoStmt";
+	case duckdb_libpgquery::T_PGRenameStmt:
+		return "T_RenameStmt";
+	case duckdb_libpgquery::T_PGRuleStmt:
+		return "T_RuleStmt";
+	case duckdb_libpgquery::T_PGNotifyStmt:
+		return "T_NotifyStmt";
+	case duckdb_libpgquery::T_PGListenStmt:
+		return "T_ListenStmt";
+	case duckdb_libpgquery::T_PGUnlistenStmt:
+		return "T_UnlistenStmt";
+	case duckdb_libpgquery::T_PGTransactionStmt:
+		return "T_TransactionStmt";
+	case duckdb_libpgquery::T_PGViewStmt:
+		return "T_ViewStmt";
+	case duckdb_libpgquery::T_PGLoadStmt:
+		return "T_LoadStmt";
+	case duckdb_libpgquery::T_PGCreateDomainStmt:
+		return "T_CreateDomainStmt";
+	case duckdb_libpgquery::T_PGCreatedbStmt:
+		return "T_CreatedbStmt";
+	case duckdb_libpgquery::T_PGDropdbStmt:
+		return "T_DropdbStmt";
+	case duckdb_libpgquery::T_PGVacuumStmt:
+		return "T_VacuumStmt";
+	case duckdb_libpgquery::T_PGExplainStmt:
+		return "T_ExplainStmt";
+	case duckdb_libpgquery::T_PGCreateTableAsStmt:
+		return "T_CreateTableAsStmt";
+	case duckdb_libpgquery::T_PGCreateSeqStmt:
+		return "T_CreateSeqStmt";
+	case duckdb_libpgquery::T_PGAlterSeqStmt:
+		return "T_AlterSeqStmt";
+	case duckdb_libpgquery::T_PGVariableSetStmt:
+		return "T_VariableSetStmt";
+	case duckdb_libpgquery::T_PGVariableShowStmt:
+		return "T_VariableShowStmt";
+	case duckdb_libpgquery::T_PGVariableShowSelectStmt:
+		return "T_VariableShowSelectStmt";
+	case duckdb_libpgquery::T_PGDiscardStmt:
+		return "T_DiscardStmt";
+	case duckdb_libpgquery::T_PGCreateTrigStmt:
+		return "T_CreateTrigStmt";
+	case duckdb_libpgquery::T_PGCreatePLangStmt:
+		return "T_CreatePLangStmt";
+	case duckdb_libpgquery::T_PGCreateRoleStmt:
+		return "T_CreateRoleStmt";
+	case duckdb_libpgquery::T_PGAlterRoleStmt:
+		return "T_AlterRoleStmt";
+	case duckdb_libpgquery::T_PGDropRoleStmt:
+		return "T_DropRoleStmt";
+	case duckdb_libpgquery::T_PGLockStmt:
+		return "T_LockStmt";
+	case duckdb_libpgquery::T_PGConstraintsSetStmt:
+		return "T_ConstraintsSetStmt";
+	case duckdb_libpgquery::T_PGReindexStmt:
+		return "T_ReindexStmt";
+	case duckdb_libpgquery::T_PGCheckPointStmt:
+		return "T_CheckPointStmt";
+	case duckdb_libpgquery::T_PGCreateSchemaStmt:
+		return "T_CreateSchemaStmt";
+	case duckdb_libpgquery::T_PGAlterDatabaseStmt:
+		return "T_AlterDatabaseStmt";
+	case duckdb_libpgquery::T_PGAlterDatabaseSetStmt:
+		return "T_AlterDatabaseSetStmt";
+	case duckdb_libpgquery::T_PGAlterRoleSetStmt:
+		return "T_AlterRoleSetStmt";
+	case duckdb_libpgquery::T_PGCreateConversionStmt:
+		return "T_CreateConversionStmt";
+	case duckdb_libpgquery::T_PGCreateCastStmt:
+		return "T_CreateCastStmt";
+	case duckdb_libpgquery::T_PGCreateOpClassStmt:
+		return "T_CreateOpClassStmt";
+	case duckdb_libpgquery::T_PGCreateOpFamilyStmt:
+		return "T_CreateOpFamilyStmt";
+	case duckdb_libpgquery::T_PGAlterOpFamilyStmt:
+		return "T_AlterOpFamilyStmt";
+	case duckdb_libpgquery::T_PGPrepareStmt:
+		return "T_PrepareStmt";
+	case duckdb_libpgquery::T_PGExecuteStmt:
+		return "T_ExecuteStmt";
+	case duckdb_libpgquery::T_PGCallStmt:
+		return "T_CallStmt";
+	case duckdb_libpgquery::T_PGDeallocateStmt:
+		return "T_DeallocateStmt";
+	case duckdb_libpgquery::T_PGDeclareCursorStmt:
+		return "T_DeclareCursorStmt";
+	case duckdb_libpgquery::T_PGCreateTableSpaceStmt:
+		return "T_CreateTableSpaceStmt";
+	case duckdb_libpgquery::T_PGDropTableSpaceStmt:
+		return "T_DropTableSpaceStmt";
+	case duckdb_libpgquery::T_PGAlterObjectDependsStmt:
+		return "T_AlterObjectDependsStmt";
+	case duckdb_libpgquery::T_PGAlterObjectSchemaStmt:
+		return "T_AlterObjectSchemaStmt";
+	case duckdb_libpgquery::T_PGAlterOwnerStmt:
+		return "T_AlterOwnerStmt";
+	case duckdb_libpgquery::T_PGAlterOperatorStmt:
+		return "T_AlterOperatorStmt";
+	case duckdb_libpgquery::T_PGDropOwnedStmt:
+		return "T_DropOwnedStmt";
+	case duckdb_libpgquery::T_PGReassignOwnedStmt:
+		return "T_ReassignOwnedStmt";
+	case duckdb_libpgquery::T_PGCompositeTypeStmt:
+		return "T_CompositeTypeStmt";
+	case duckdb_libpgquery::T_PGCreateTypeStmt:
+		return "T_CreateTypeStmt";
+	case duckdb_libpgquery::T_PGCreateRangeStmt:
+		return "T_CreateRangeStmt";
+	case duckdb_libpgquery::T_PGAlterEnumStmt:
+		return "T_AlterEnumStmt";
+	case duckdb_libpgquery::T_PGAlterTSDictionaryStmt:
+		return "T_AlterTSDictionaryStmt";
+	case duckdb_libpgquery::T_PGAlterTSConfigurationStmt:
+		return "T_AlterTSConfigurationStmt";
+	case duckdb_libpgquery::T_PGCreateFdwStmt:
+		return "T_CreateFdwStmt";
+	case duckdb_libpgquery::T_PGAlterFdwStmt:
+		return "T_AlterFdwStmt";
+	case duckdb_libpgquery::T_PGCreateForeignServerStmt:
+		return "T_CreateForeignServerStmt";
+	case duckdb_libpgquery::T_PGAlterForeignServerStmt:
+		return "T_AlterForeignServerStmt";
+	case duckdb_libpgquery::T_PGCreateUserMappingStmt:
+		return "T_CreateUserMappingStmt";
+	case duckdb_libpgquery::T_PGAlterUserMappingStmt:
+		return "T_AlterUserMappingStmt";
+	case duckdb_libpgquery::T_PGDropUserMappingStmt:
+		return "T_DropUserMappingStmt";
+	case duckdb_libpgquery::T_PGAlterTableSpaceOptionsStmt:
+		return "T_AlterTableSpaceOptionsStmt";
+	case duckdb_libpgquery::T_PGAlterTableMoveAllStmt:
+		return "T_AlterTableMoveAllStmt";
+	case duckdb_libpgquery::T_PGSecLabelStmt:
+		return "T_SecLabelStmt";
+	case duckdb_libpgquery::T_PGCreateForeignTableStmt:
+		return "T_CreateForeignTableStmt";
+	case duckdb_libpgquery::T_PGImportForeignSchemaStmt:
+		return "T_ImportForeignSchemaStmt";
+	case duckdb_libpgquery::T_PGCreateExtensionStmt:
+		return "T_CreateExtensionStmt";
+	case duckdb_libpgquery::T_PGAlterExtensionStmt:
+		return "T_AlterExtensionStmt";
+	case duckdb_libpgquery::T_PGAlterExtensionContentsStmt:
+		return "T_AlterExtensionContentsStmt";
+	case duckdb_libpgquery::T_PGCreateEventTrigStmt:
+		return "T_CreateEventTrigStmt";
+	case duckdb_libpgquery::T_PGAlterEventTrigStmt:
+		return "T_AlterEventTrigStmt";
+	case duckdb_libpgquery::T_PGRefreshMatViewStmt:
+		return "T_RefreshMatViewStmt";
+	case duckdb_libpgquery::T_PGReplicaIdentityStmt:
+		return "T_ReplicaIdentityStmt";
+	case duckdb_libpgquery::T_PGAlterSystemStmt:
+		return "T_AlterSystemStmt";
+	case duckdb_libpgquery::T_PGCreatePolicyStmt:
+		return "T_CreatePolicyStmt";
+	case duckdb_libpgquery::T_PGAlterPolicyStmt:
+		return "T_AlterPolicyStmt";
+	case duckdb_libpgquery::T_PGCreateTransformStmt:
+		return "T_CreateTransformStmt";
+	case duckdb_libpgquery::T_PGCreateAmStmt:
+		return "T_CreateAmStmt";
+	case duckdb_libpgquery::T_PGCreatePublicationStmt:
+		return "T_CreatePublicationStmt";
+	case duckdb_libpgquery::T_PGAlterPublicationStmt:
+		return "T_AlterPublicationStmt";
+	case duckdb_libpgquery::T_PGCreateSubscriptionStmt:
+		return "T_CreateSubscriptionStmt";
+	case duckdb_libpgquery::T_PGAlterSubscriptionStmt:
+		return "T_AlterSubscriptionStmt";
+	case duckdb_libpgquery::T_PGDropSubscriptionStmt:
+		return "T_DropSubscriptionStmt";
+	case duckdb_libpgquery::T_PGCreateStatsStmt:
+		return "T_CreateStatsStmt";
+	case duckdb_libpgquery::T_PGAlterCollationStmt:
+		return "T_AlterCollationStmt";
+	case duckdb_libpgquery::T_PGAExpr:
+		return "TAExpr";
+	case duckdb_libpgquery::T_PGColumnRef:
+		return "T_ColumnRef";
+	case duckdb_libpgquery::T_PGParamRef:
+		return "T_ParamRef";
+	case duckdb_libpgquery::T_PGAConst:
+		return "TAConst";
+	case duckdb_libpgquery::T_PGFuncCall:
+		return "T_FuncCall";
+	case duckdb_libpgquery::T_PGAStar:
+		return "TAStar";
+	case duckdb_libpgquery::T_PGAIndices:
+		return "TAIndices";
+	case duckdb_libpgquery::T_PGAIndirection:
+		return "TAIndirection";
+	case duckdb_libpgquery::T_PGAArrayExpr:
+		return "TAArrayExpr";
+	case duckdb_libpgquery::T_PGResTarget:
+		return "T_ResTarget";
+	case duckdb_libpgquery::T_PGMultiAssignRef:
+		return "T_MultiAssignRef";
+	case duckdb_libpgquery::T_PGTypeCast:
+		return "T_TypeCast";
+	case duckdb_libpgquery::T_PGCollateClause:
+		return "T_CollateClause";
+	case duckdb_libpgquery::T_PGSortBy:
+		return "T_SortBy";
+	case duckdb_libpgquery::T_PGWindowDef:
+		return "T_WindowDef";
+	case duckdb_libpgquery::T_PGRangeSubselect:
+		return "T_RangeSubselect";
+	case duckdb_libpgquery::T_PGRangeFunction:
+		return "T_RangeFunction";
+	case duckdb_libpgquery::T_PGRangeTableSample:
+		return "T_RangeTableSample";
+	case duckdb_libpgquery::T_PGRangeTableFunc:
+		return "T_RangeTableFunc";
+	case duckdb_libpgquery::T_PGRangeTableFuncCol:
+		return "T_RangeTableFuncCol";
+	case duckdb_libpgquery::T_PGTypeName:
+		return "T_TypeName";
+	case duckdb_libpgquery::T_PGColumnDef:
+		return "T_ColumnDef";
+	case duckdb_libpgquery::T_PGIndexElem:
+		return "T_IndexElem";
+	case duckdb_libpgquery::T_PGConstraint:
+		return "T_Constraint";
+	case duckdb_libpgquery::T_PGDefElem:
+		return "T_DefElem";
+	case duckdb_libpgquery::T_PGRangeTblEntry:
+		return "T_RangeTblEntry";
+	case duckdb_libpgquery::T_PGRangeTblFunction:
+		return "T_RangeTblFunction";
+	case duckdb_libpgquery::T_PGTableSampleClause:
+		return "T_TableSampleClause";
+	case duckdb_libpgquery::T_PGWithCheckOption:
+		return "T_WithCheckOption";
+	case duckdb_libpgquery::T_PGSortGroupClause:
+		return "T_SortGroupClause";
+	case duckdb_libpgquery::T_PGGroupingSet:
+		return "T_GroupingSet";
+	case duckdb_libpgquery::T_PGWindowClause:
+		return "T_WindowClause";
+	case duckdb_libpgquery::T_PGObjectWithArgs:
+		return "T_ObjectWithArgs";
+	case duckdb_libpgquery::T_PGAccessPriv:
+		return "T_AccessPriv";
+	case duckdb_libpgquery::T_PGCreateOpClassItem:
+		return "T_CreateOpClassItem";
+	case duckdb_libpgquery::T_PGTableLikeClause:
+		return "T_TableLikeClause";
+	case duckdb_libpgquery::T_PGFunctionParameter:
+		return "T_FunctionParameter";
+	case duckdb_libpgquery::T_PGLockingClause:
+		return "T_LockingClause";
+	case duckdb_libpgquery::T_PGRowMarkClause:
+		return "T_RowMarkClause";
+	case duckdb_libpgquery::T_PGXmlSerialize:
+		return "T_XmlSerialize";
+	case duckdb_libpgquery::T_PGWithClause:
+		return "T_WithClause";
+	case duckdb_libpgquery::T_PGInferClause:
+		return "T_InferClause";
+	case duckdb_libpgquery::T_PGOnConflictClause:
+		return "T_OnConflictClause";
+	case duckdb_libpgquery::T_PGCommonTableExpr:
+		return "T_CommonTableExpr";
+	case duckdb_libpgquery::T_PGRoleSpec:
+		return "T_RoleSpec";
+	case duckdb_libpgquery::T_PGTriggerTransition:
+		return "T_TriggerTransition";
+	case duckdb_libpgquery::T_PGPartitionElem:
+		return "T_PartitionElem";
+	case duckdb_libpgquery::T_PGPartitionSpec:
+		return "T_PartitionSpec";
+	case duckdb_libpgquery::T_PGPartitionBoundSpec:
+		return "T_PartitionBoundSpec";
+	case duckdb_libpgquery::T_PGPartitionRangeDatum:
+		return "T_PartitionRangeDatum";
+	case duckdb_libpgquery::T_PGPartitionCmd:
+		return "T_PartitionCmd";
+	case duckdb_libpgquery::T_PGIdentifySystemCmd:
+		return "T_IdentifySystemCmd";
+	case duckdb_libpgquery::T_PGBaseBackupCmd:
+		return "T_BaseBackupCmd";
+	case duckdb_libpgquery::T_PGCreateReplicationSlotCmd:
+		return "T_CreateReplicationSlotCmd";
+	case duckdb_libpgquery::T_PGDropReplicationSlotCmd:
+		return "T_DropReplicationSlotCmd";
+	case duckdb_libpgquery::T_PGStartReplicationCmd:
+		return "T_StartReplicationCmd";
+	case duckdb_libpgquery::T_PGTimeLineHistoryCmd:
+		return "T_TimeLineHistoryCmd";
+	case duckdb_libpgquery::T_PGSQLCmd:
+		return "T_SQLCmd";
+	case duckdb_libpgquery::T_PGTriggerData:
+		return "T_TriggerData";
+	case duckdb_libpgquery::T_PGEventTriggerData:
+		return "T_EventTriggerData";
+	case duckdb_libpgquery::T_PGReturnSetInfo:
+		return "T_ReturnSetInfo";
+	case duckdb_libpgquery::T_PGWindowObjectData:
+		return "T_WindowObjectData";
+	case duckdb_libpgquery::T_PGTIDBitmap:
+		return "T_TIDBitmap";
+	case duckdb_libpgquery::T_PGInlineCodeBlock:
+		return "T_InlineCodeBlock";
+	case duckdb_libpgquery::T_PGFdwRoutine:
+		return "T_FdwRoutine";
+	case duckdb_libpgquery::T_PGIndexAmRoutine:
+		return "T_IndexAmRoutine";
+	case duckdb_libpgquery::T_PGTsmRoutine:
+		return "T_TsmRoutine";
+	case duckdb_libpgquery::T_PGForeignKeyCacheInfo:
+		return "T_ForeignKeyCacheInfo";
+	default:
+		return "(UNKNOWN)";
+	}
+} // LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+string Transformer::TransformAlias(duckdb_libpgquery::PGAlias *root, vector<string> &column_name_alias) {
+	if (!root) {
+		return "";
+	}
+	if (root->colnames) {
+		for (auto node = root->colnames->head; node != nullptr; node = node->next) {
+			column_name_alias.emplace_back(
+			    reinterpret_cast<duckdb_libpgquery::PGValue *>(node->data.ptr_value)->val.str);
+		}
+	}
+	return root->aliasname;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+void Transformer::TransformCTE(duckdb_libpgquery::PGWithClause *de_with_clause, QueryNode &select) {
+	// TODO: might need to update in case of future lawsuit
+	D_ASSERT(de_with_clause);
+
+	D_ASSERT(de_with_clause->ctes);
+	for (auto cte_ele = de_with_clause->ctes->head; cte_ele != nullptr; cte_ele = cte_ele->next) {
+		auto info = make_unique<CommonTableExpressionInfo>();
+
+		auto cte = reinterpret_cast<duckdb_libpgquery::PGCommonTableExpr *>(cte_ele->data.ptr_value);
+		if (cte->aliascolnames) {
+			for (auto node = cte->aliascolnames->head; node != nullptr; node = node->next) {
+				info->aliases.emplace_back(
+				    reinterpret_cast<duckdb_libpgquery::PGValue *>(node->data.ptr_value)->val.str);
+			}
+		}
+		// lets throw some errors on unsupported features early
+		if (cte->ctecolnames) {
+			throw NotImplementedException("Column name setting not supported in CTEs");
+		}
+		if (cte->ctecoltypes) {
+			throw NotImplementedException("Column type setting not supported in CTEs");
+		}
+		if (cte->ctecoltypmods) {
+			throw NotImplementedException("Column type modification not supported in CTEs");
+		}
+		if (cte->ctecolcollations) {
+			throw NotImplementedException("CTE collations not supported");
+		}
+		// we need a query
+		if (!cte->ctequery || cte->ctequery->type != duckdb_libpgquery::T_PGSelectStmt) {
+			throw InternalException("A CTE needs a SELECT");
+		}
+
+		// CTE transformation can either result in inlining for non recursive CTEs, or in recursive CTE bindings
+		// otherwise.
+		if (cte->cterecursive || de_with_clause->recursive) {
+			info->query = TransformRecursiveCTE(cte, *info);
+		} else {
+			info->query = TransformSelect(cte->ctequery);
+		}
+		D_ASSERT(info->query);
+		auto cte_name = string(cte->ctename);
+
+		auto it = select.cte_map.find(cte_name);
+		if (it != select.cte_map.end()) {
+			// can't have two CTEs with same name
+			throw ParserException("Duplicate CTE name \"%s\"", cte_name);
+		}
+		select.cte_map[cte_name] = move(info);
+	}
+}
+
+unique_ptr<SelectStatement> Transformer::TransformRecursiveCTE(duckdb_libpgquery::PGCommonTableExpr *cte,
+                                                               CommonTableExpressionInfo &info) {
+	auto stmt = (duckdb_libpgquery::PGSelectStmt *)cte->ctequery;
+
+	unique_ptr<SelectStatement> select;
+	switch (stmt->op) {
+	case duckdb_libpgquery::PG_SETOP_UNION:
+	case duckdb_libpgquery::PG_SETOP_EXCEPT:
+	case duckdb_libpgquery::PG_SETOP_INTERSECT: {
+		select = make_unique<SelectStatement>();
+		select->node = make_unique_base<QueryNode, RecursiveCTENode>();
+		auto result = (RecursiveCTENode *)select->node.get();
+		result->ctename = string(cte->ctename);
+		result->union_all = stmt->all;
+		result->left = TransformSelectNode(stmt->larg);
+		result->right = TransformSelectNode(stmt->rarg);
+		result->aliases = info.aliases;
+
+		D_ASSERT(result->left);
+		D_ASSERT(result->right);
+
+		if (stmt->op != duckdb_libpgquery::PG_SETOP_UNION) {
+			throw ParserException("Unsupported setop type for recursive CTE: only UNION or UNION ALL are supported");
+		}
+		break;
+	}
+	default:
+		// This CTE is not recursive. Fallback to regular query transformation.
+		return TransformSelect(cte->ctequery);
+	}
+
+	if (stmt->limitCount || stmt->limitOffset) {
+		throw ParserException("LIMIT or OFFSET in a recursive query is not allowed");
+	}
+	if (stmt->sortClause) {
+		throw ParserException("ORDER BY in a recursive query is not allowed");
+	}
+	return select;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+static void CheckGroupingSetMax(idx_t count) {
+	static constexpr const idx_t MAX_GROUPING_SETS = 65535;
+	if (count > MAX_GROUPING_SETS) {
+		throw ParserException("Maximum grouping set count of %d exceeded", MAX_GROUPING_SETS);
+	}
+}
+
+static void CheckGroupingSetCubes(idx_t current_count, idx_t cube_count) {
+	idx_t combinations = 1;
+	for (idx_t i = 0; i < cube_count; i++) {
+		combinations *= 2;
+		CheckGroupingSetMax(current_count + combinations);
+	}
+}
+
+struct GroupingExpressionMap {
+	expression_map_t<idx_t> map;
+};
+
+static GroupingSet VectorToGroupingSet(vector<idx_t> &indexes) {
+	GroupingSet result;
+	for (idx_t i = 0; i < indexes.size(); i++) {
+		result.insert(indexes[i]);
+	}
+	return result;
+}
+
+static void MergeGroupingSet(GroupingSet &result, GroupingSet &other) {
+	CheckGroupingSetMax(result.size() + other.size());
+	result.insert(other.begin(), other.end());
+}
+
+void Transformer::AddGroupByExpression(unique_ptr<ParsedExpression> expression, GroupingExpressionMap &map,
+                                       GroupByNode &result, vector<idx_t> &result_set) {
+	if (expression->type == ExpressionType::FUNCTION) {
+		auto &func = (FunctionExpression &)*expression;
+		if (func.function_name == "row") {
+			for (auto &child : func.children) {
+				AddGroupByExpression(move(child), map, result, result_set);
+			}
+			return;
+		}
+	}
+	auto entry = map.map.find(expression.get());
+	idx_t result_idx;
+	if (entry == map.map.end()) {
+		result_idx = result.group_expressions.size();
+		map.map[expression.get()] = result_idx;
+		result.group_expressions.push_back(move(expression));
+	} else {
+		result_idx = entry->second;
+	}
+	result_set.push_back(result_idx);
+}
+
+static void AddCubeSets(const GroupingSet &current_set, vector<GroupingSet> &result_set,
+                        vector<GroupingSet> &result_sets, idx_t start_idx = 0) {
+	CheckGroupingSetMax(result_sets.size());
+	result_sets.push_back(current_set);
+	for (idx_t k = start_idx; k < result_set.size(); k++) {
+		auto child_set = current_set;
+		MergeGroupingSet(child_set, result_set[k]);
+		AddCubeSets(child_set, result_set, result_sets, k + 1);
+	}
+}
+
+void Transformer::TransformGroupByExpression(duckdb_libpgquery::PGNode *n, GroupingExpressionMap &map,
+                                             GroupByNode &result, vector<idx_t> &indexes) {
+	auto expression = TransformExpression(n);
+	AddGroupByExpression(move(expression), map, result, indexes);
+}
+
+// If one GROUPING SETS clause is nested inside another,
+// the effect is the same as if all the elements of the inner clause had been written directly in the outer clause.
+void Transformer::TransformGroupByNode(duckdb_libpgquery::PGNode *n, GroupingExpressionMap &map, SelectNode &result,
+                                       vector<GroupingSet> &result_sets) {
+	if (n->type == duckdb_libpgquery::T_PGGroupingSet) {
+		auto grouping_set = (duckdb_libpgquery::PGGroupingSet *)n;
+		switch (grouping_set->kind) {
+		case duckdb_libpgquery::GROUPING_SET_EMPTY:
+			result_sets.emplace_back();
+			break;
+		case duckdb_libpgquery::GROUPING_SET_ALL: {
+			result.aggregate_handling = AggregateHandling::FORCE_AGGREGATES;
+			break;
+		}
+		case duckdb_libpgquery::GROUPING_SET_SETS: {
+			for (auto node = grouping_set->content->head; node; node = node->next) {
+				auto pg_node = (duckdb_libpgquery::PGNode *)node->data.ptr_value;
+				TransformGroupByNode(pg_node, map, result, result_sets);
+			}
+			break;
+		}
+		case duckdb_libpgquery::GROUPING_SET_ROLLUP: {
+			vector<GroupingSet> rollup_sets;
+			for (auto node = grouping_set->content->head; node; node = node->next) {
+				auto pg_node = (duckdb_libpgquery::PGNode *)node->data.ptr_value;
+				vector<idx_t> rollup_set;
+				TransformGroupByExpression(pg_node, map, result.groups, rollup_set);
+				rollup_sets.push_back(VectorToGroupingSet(rollup_set));
+			}
+			// generate the subsets of the rollup set and add them to the grouping sets
+			GroupingSet current_set;
+			result_sets.push_back(current_set);
+			for (idx_t i = 0; i < rollup_sets.size(); i++) {
+				MergeGroupingSet(current_set, rollup_sets[i]);
+				result_sets.push_back(current_set);
+			}
+			break;
+		}
+		case duckdb_libpgquery::GROUPING_SET_CUBE: {
+			vector<GroupingSet> cube_sets;
+			for (auto node = grouping_set->content->head; node; node = node->next) {
+				auto pg_node = (duckdb_libpgquery::PGNode *)node->data.ptr_value;
+				vector<idx_t> cube_set;
+				TransformGroupByExpression(pg_node, map, result.groups, cube_set);
+				cube_sets.push_back(VectorToGroupingSet(cube_set));
+			}
+			// generate the subsets of the rollup set and add them to the grouping sets
+			CheckGroupingSetCubes(result_sets.size(), cube_sets.size());
+
+			GroupingSet current_set;
+			AddCubeSets(current_set, cube_sets, result_sets, 0);
+			break;
+		}
+		default:
+			throw InternalException("Unsupported GROUPING SET type %d", grouping_set->kind);
+		}
+	} else {
+		vector<idx_t> indexes;
+		TransformGroupByExpression(n, map, result.groups, indexes);
+		result_sets.push_back(VectorToGroupingSet(indexes));
+	}
+}
+
+// If multiple grouping items are specified in a single GROUP BY clause,
+// then the final list of grouping sets is the cross product of the individual items.
+bool Transformer::TransformGroupBy(duckdb_libpgquery::PGList *group, SelectNode &select_node) {
+	if (!group) {
+		return false;
+	}
+	auto &result = select_node.groups;
+	GroupingExpressionMap map;
+	for (auto node = group->head; node != nullptr; node = node->next) {
+		auto n = reinterpret_cast<duckdb_libpgquery::PGNode *>(node->data.ptr_value);
+		vector<GroupingSet> result_sets;
+		TransformGroupByNode(n, map, select_node, result_sets);
+		CheckGroupingSetMax(result_sets.size());
+		if (result.grouping_sets.empty()) {
+			// no grouping sets yet: use the current set of grouping sets
+			result.grouping_sets = move(result_sets);
+		} else {
+			// compute the cross product
+			vector<GroupingSet> new_sets;
+			idx_t grouping_set_count = result.grouping_sets.size() * result_sets.size();
+			CheckGroupingSetMax(grouping_set_count);
+			new_sets.reserve(grouping_set_count);
+			for (idx_t current_idx = 0; current_idx < result.grouping_sets.size(); current_idx++) {
+				auto &current_set = result.grouping_sets[current_idx];
+				for (idx_t new_idx = 0; new_idx < result_sets.size(); new_idx++) {
+					auto &new_set = result_sets[new_idx];
+					GroupingSet set;
+					set.insert(current_set.begin(), current_set.end());
+					set.insert(new_set.begin(), new_set.end());
+					new_sets.push_back(move(set));
+				}
+			}
+			result.grouping_sets = move(new_sets);
+		}
+	}
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+bool Transformer::TransformOrderBy(duckdb_libpgquery::PGList *order, vector<OrderByNode> &result) {
+	if (!order) {
+		return false;
+	}
+
+	for (auto node = order->head; node != nullptr; node = node->next) {
+		auto temp = reinterpret_cast<duckdb_libpgquery::PGNode *>(node->data.ptr_value);
+		if (temp->type == duckdb_libpgquery::T_PGSortBy) {
+			OrderType type;
+			OrderByNullType null_order;
+			auto sort = reinterpret_cast<duckdb_libpgquery::PGSortBy *>(temp);
+			auto target = sort->node;
+			if (sort->sortby_dir == duckdb_libpgquery::PG_SORTBY_DEFAULT) {
+				type = OrderType::ORDER_DEFAULT;
+			} else if (sort->sortby_dir == duckdb_libpgquery::PG_SORTBY_ASC) {
+				type = OrderType::ASCENDING;
+			} else if (sort->sortby_dir == duckdb_libpgquery::PG_SORTBY_DESC) {
+				type = OrderType::DESCENDING;
+			} else {
+				throw NotImplementedException("Unimplemented order by type");
+			}
+			if (sort->sortby_nulls == duckdb_libpgquery::PG_SORTBY_NULLS_DEFAULT) {
+				null_order = OrderByNullType::ORDER_DEFAULT;
+			} else if (sort->sortby_nulls == duckdb_libpgquery::PG_SORTBY_NULLS_FIRST) {
+				null_order = OrderByNullType::NULLS_FIRST;
+			} else if (sort->sortby_nulls == duckdb_libpgquery::PG_SORTBY_NULLS_LAST) {
+				null_order = OrderByNullType::NULLS_LAST;
+			} else {
+				throw NotImplementedException("Unimplemented order by type");
+			}
+			auto order_expression = TransformExpression(target);
+			result.emplace_back(type, null_order, move(order_expression));
+		} else {
+			throw NotImplementedException("ORDER BY list member type %d\n", temp->type);
+		}
+	}
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+static SampleMethod GetSampleMethod(const string &method) {
+	auto lmethod = StringUtil::Lower(method);
+	if (lmethod == "system") {
+		return SampleMethod::SYSTEM_SAMPLE;
+	} else if (lmethod == "bernoulli") {
+		return SampleMethod::BERNOULLI_SAMPLE;
+	} else if (lmethod == "reservoir") {
+		return SampleMethod::RESERVOIR_SAMPLE;
+	} else {
+		throw ParserException("Unrecognized sampling method %s, expected system, bernoulli or reservoir", method);
+	}
+}
+
+unique_ptr<SampleOptions> Transformer::TransformSampleOptions(duckdb_libpgquery::PGNode *options) {
+	if (!options) {
+		return nullptr;
+	}
+	auto result = make_unique<SampleOptions>();
+	auto &sample_options = (duckdb_libpgquery::PGSampleOptions &)*options;
+	auto &sample_size = (duckdb_libpgquery::PGSampleSize &)*sample_options.sample_size;
+	auto sample_value = TransformValue(sample_size.sample_size)->value;
+	result->is_percentage = sample_size.is_percentage;
+	if (sample_size.is_percentage) {
+		// sample size is given in sample_size: use system sampling
+		auto percentage = sample_value.GetValue<double>();
+		if (percentage < 0 || percentage > 100) {
+			throw ParserException("Sample sample_size %llf out of range, must be between 0 and 100", percentage);
+		}
+		result->sample_size = Value::DOUBLE(percentage);
+		result->method = SampleMethod::SYSTEM_SAMPLE;
+	} else {
+		// sample size is given in rows: use reservoir sampling
+		auto rows = sample_value.GetValue<int64_t>();
+		if (rows < 0) {
+			throw ParserException("Sample rows %lld out of range, must be bigger than or equal to 0", rows);
+		}
+		result->sample_size = Value::BIGINT(rows);
+		result->method = SampleMethod::RESERVOIR_SAMPLE;
+	}
+	if (sample_options.method) {
+		result->method = GetSampleMethod(sample_options.method);
+	}
+	result->seed = sample_options.seed == 0 ? -1 : sample_options.seed;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+LogicalType Transformer::TransformTypeName(duckdb_libpgquery::PGTypeName *type_name) {
+	if (!type_name || type_name->type != duckdb_libpgquery::T_PGTypeName) {
+		throw ParserException("Expected a type");
+	}
+	auto stack_checker = StackCheck();
+
+	auto name = (reinterpret_cast<duckdb_libpgquery::PGValue *>(type_name->names->tail->data.ptr_value)->val.str);
+	// transform it to the SQL type
+	LogicalTypeId base_type = TransformStringToLogicalTypeId(name);
+
+	LogicalType result_type;
+	if (base_type == LogicalTypeId::STRUCT) {
+		if (!type_name->typmods || type_name->typmods->length == 0) {
+			throw ParserException("Struct needs a name and entries");
+		}
+		child_list_t<LogicalType> children;
+		unordered_set<string> name_collision_set;
+
+		for (auto node = type_name->typmods->head; node; node = node->next) {
+			auto &type_val = *((duckdb_libpgquery::PGList *)node->data.ptr_value);
+			if (type_val.length != 2) {
+				throw ParserException("Struct entry needs an entry name and a type name");
+			}
+
+			auto entry_name_node = (duckdb_libpgquery::PGValue *)(type_val.head->data.ptr_value);
+			D_ASSERT(entry_name_node->type == duckdb_libpgquery::T_PGString);
+			auto entry_type_node = (duckdb_libpgquery::PGValue *)(type_val.tail->data.ptr_value);
+			D_ASSERT(entry_type_node->type == duckdb_libpgquery::T_PGTypeName);
+
+			auto entry_name = string(entry_name_node->val.str);
+			D_ASSERT(!entry_name.empty());
+
+			if (name_collision_set.find(entry_name) != name_collision_set.end()) {
+				throw ParserException("Duplicate struct entry name \"%s\"", entry_name);
+			}
+			name_collision_set.insert(entry_name);
+
+			auto entry_type = TransformTypeName((duckdb_libpgquery::PGTypeName *)entry_type_node);
+			children.push_back(make_pair(entry_name, entry_type));
+		}
+		D_ASSERT(!children.empty());
+		result_type = LogicalType::STRUCT(move(children));
+	} else if (base_type == LogicalTypeId::MAP) {
+		//! We transform MAP<TYPE_KEY, TYPE_VALUE> to STRUCT<LIST<key: TYPE_KEY>, LIST<value: TYPE_VALUE>>
+
+		if (!type_name->typmods || type_name->typmods->length != 2) {
+			throw ParserException("Map type needs exactly two entries, key and value type");
+		}
+		child_list_t<LogicalType> children;
+		auto key_type = TransformTypeName((duckdb_libpgquery::PGTypeName *)type_name->typmods->head->data.ptr_value);
+		auto value_type = TransformTypeName((duckdb_libpgquery::PGTypeName *)type_name->typmods->tail->data.ptr_value);
+
+		children.push_back({"key", LogicalType::LIST(key_type)});
+		children.push_back({"value", LogicalType::LIST(value_type)});
+
+		D_ASSERT(children.size() == 2);
+
+		result_type = LogicalType::MAP(move(children));
+	} else {
+		int8_t width, scale;
+		if (base_type == LogicalTypeId::DECIMAL) {
+			// default decimal width/scale
+			width = 18;
+			scale = 3;
+		} else {
+			width = 0;
+			scale = 0;
+		}
+		// check any modifiers
+		int modifier_idx = 0;
+		if (type_name->typmods) {
+			for (auto node = type_name->typmods->head; node; node = node->next) {
+				auto &const_val = *((duckdb_libpgquery::PGAConst *)node->data.ptr_value);
+				if (const_val.type != duckdb_libpgquery::T_PGAConst ||
+				    const_val.val.type != duckdb_libpgquery::T_PGInteger) {
+					throw ParserException("Expected an integer constant as type modifier");
+				}
+				if (const_val.val.val.ival < 0) {
+					throw ParserException("Negative modifier not supported");
+				}
+				if (modifier_idx == 0) {
+					width = const_val.val.val.ival;
+				} else if (modifier_idx == 1) {
+					scale = const_val.val.val.ival;
+				} else {
+					throw ParserException("A maximum of two modifiers is supported");
+				}
+				modifier_idx++;
+			}
+		}
+		switch (base_type) {
+		case LogicalTypeId::VARCHAR:
+			if (modifier_idx > 1) {
+				throw ParserException("VARCHAR only supports a single modifier");
+			}
+			// FIXME: create CHECK constraint based on varchar width
+			width = 0;
+			result_type = LogicalType::VARCHAR;
+			break;
+		case LogicalTypeId::DECIMAL:
+			if (modifier_idx == 1) {
+				// only width is provided: set scale to 0
+				scale = 0;
+			}
+			if (width <= 0 || width > Decimal::MAX_WIDTH_DECIMAL) {
+				throw ParserException("Width must be between 1 and %d!", (int)Decimal::MAX_WIDTH_DECIMAL);
+			}
+			if (scale > width) {
+				throw ParserException("Scale cannot be bigger than width");
+			}
+			result_type = LogicalType::DECIMAL(width, scale);
+			break;
+		case LogicalTypeId::INTERVAL:
+			if (modifier_idx > 1) {
+				throw ParserException("INTERVAL only supports a single modifier");
+			}
+			width = 0;
+			result_type = LogicalType::INTERVAL;
+			break;
+		case LogicalTypeId::USER: {
+			string user_type_name {name};
+			result_type = LogicalType::USER(user_type_name);
+			break;
+		}
+		default:
+			if (modifier_idx > 0) {
+				throw ParserException("Type %s does not support any modifiers!", LogicalType(base_type).ToString());
+			}
+			result_type = LogicalType(base_type);
+			break;
+		}
+	}
+	if (type_name->arrayBounds) {
+		// array bounds: turn the type into a list
+		idx_t extra_stack = 0;
+		for (auto cell = type_name->arrayBounds->head; cell != nullptr; cell = cell->next) {
+			result_type = LogicalType::LIST(move(result_type));
+			StackCheck(extra_stack++);
+		}
+	}
+	return result_type;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<AlterStatement> Transformer::TransformAlterSequence(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGAlterSeqStmt *>(node);
+	D_ASSERT(stmt);
+	auto result = make_unique<AlterStatement>();
+
+	auto qname = TransformQualifiedName(stmt->sequence);
+	auto sequence_schema = qname.schema;
+	auto sequence_name = qname.name;
+
+	if (!stmt->options) {
+		throw InternalException("Expected an argument for ALTER SEQUENCE.");
+	}
+
+	duckdb_libpgquery::PGListCell *cell = nullptr;
+	for_each_cell(cell, stmt->options->head) {
+		auto *def_elem = reinterpret_cast<duckdb_libpgquery::PGDefElem *>(cell->data.ptr_value);
+		string opt_name = string(def_elem->defname);
+
+		if (opt_name == "owned_by") {
+			auto val = (duckdb_libpgquery::PGValue *)def_elem->arg;
+			if (!val) {
+				throw InternalException("Expected an argument for option %s", opt_name);
+			}
+			D_ASSERT(val);
+			if (val->type != duckdb_libpgquery::T_PGList) {
+				throw InternalException("Expected a string argument for option %s", opt_name);
+			}
+			auto opt_values = vector<string>();
+
+			auto opt_value_list = (duckdb_libpgquery::PGList *)(val);
+			for (auto c = opt_value_list->head; c != nullptr; c = lnext(c)) {
+				auto target = (duckdb_libpgquery::PGResTarget *)(c->data.ptr_value);
+				opt_values.emplace_back(target->name);
+			}
+			D_ASSERT(!opt_values.empty());
+			string owner_schema = "";
+			string owner_name = "";
+			if (opt_values.size() == 2) {
+				owner_schema = opt_values[0];
+				owner_name = opt_values[1];
+			} else if (opt_values.size() == 1) {
+				owner_schema = DEFAULT_SCHEMA;
+				owner_name = opt_values[0];
+			} else {
+				throw InternalException("Wrong argument for %s. Expected either <schema>.<name> or <name>", opt_name);
+			}
+			auto info = make_unique<ChangeOwnershipInfo>(CatalogType::SEQUENCE_ENTRY, sequence_schema, sequence_name,
+			                                             owner_schema, owner_name);
+			result->info = move(info);
+		} else {
+			throw NotImplementedException("ALTER SEQUENCE option not supported yet!");
+		}
+	}
+	return result;
+}
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<AlterStatement> Transformer::TransformAlter(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGAlterTableStmt *>(node);
+	D_ASSERT(stmt);
+	D_ASSERT(stmt->relation);
+
+	auto result = make_unique<AlterStatement>();
+
+	auto qname = TransformQualifiedName(stmt->relation);
+
+	// first we check the type of ALTER
+	for (auto c = stmt->cmds->head; c != nullptr; c = c->next) {
+		auto command = reinterpret_cast<duckdb_libpgquery::PGAlterTableCmd *>(lfirst(c));
+		// TODO: Include more options for command->subtype
+		switch (command->subtype) {
+		case duckdb_libpgquery::PG_AT_AddColumn: {
+			auto cdef = (duckdb_libpgquery::PGColumnDef *)command->def;
+			if (cdef->category == duckdb_libpgquery::COL_GENERATED) {
+				throw ParserException("Adding generated columns after table creation is not supported yet");
+			}
+			auto centry = TransformColumnDefinition(cdef);
+
+			if (cdef->constraints) {
+				for (auto constr = cdef->constraints->head; constr != nullptr; constr = constr->next) {
+					auto constraint = TransformConstraint(constr, centry, 0);
+					if (!constraint) {
+						continue;
+					}
+					throw ParserException("Adding columns with constraints not yet supported");
+				}
+			}
+			result->info = make_unique<AddColumnInfo>(qname.schema, qname.name, move(centry));
+			break;
+		}
+		case duckdb_libpgquery::PG_AT_DropColumn: {
+			bool cascade = command->behavior == duckdb_libpgquery::PG_DROP_CASCADE;
+			result->info =
+			    make_unique<RemoveColumnInfo>(qname.schema, qname.name, command->name, command->missing_ok, cascade);
+			break;
+		}
+		case duckdb_libpgquery::PG_AT_ColumnDefault: {
+			auto expr = TransformExpression(command->def);
+			result->info = make_unique<SetDefaultInfo>(qname.schema, qname.name, command->name, move(expr));
+			break;
+		}
+		case duckdb_libpgquery::PG_AT_AlterColumnType: {
+			auto cdef = (duckdb_libpgquery::PGColumnDef *)command->def;
+			auto column_definition = TransformColumnDefinition(cdef);
+
+			unique_ptr<ParsedExpression> expr;
+			if (cdef->raw_default) {
+				expr = TransformExpression(cdef->raw_default);
+			} else {
+				auto colref = make_unique<ColumnRefExpression>(command->name);
+				expr = make_unique<CastExpression>(column_definition.Type(), move(colref));
+			}
+			result->info = make_unique<ChangeColumnTypeInfo>(qname.schema, qname.name, command->name,
+			                                                 column_definition.Type(), move(expr));
+			break;
+		}
+		case duckdb_libpgquery::PG_AT_DropConstraint:
+		case duckdb_libpgquery::PG_AT_DropNotNull:
+		default:
+			throw NotImplementedException("ALTER TABLE option not supported yet!");
+		}
+	}
+
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<CallStatement> Transformer::TransformCall(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGCallStmt *>(node);
+	D_ASSERT(stmt);
+
+	auto result = make_unique<CallStatement>();
+	result->function = TransformFuncCall((duckdb_libpgquery::PGFuncCall *)stmt->func);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<SQLStatement> Transformer::TransformCheckpoint(duckdb_libpgquery::PGNode *node) {
+	auto checkpoint = (duckdb_libpgquery::PGCheckPointStmt *)node;
+
+	vector<unique_ptr<ParsedExpression>> children;
+	// transform into "CALL checkpoint()" or "CALL force_checkpoint()"
+	auto result = make_unique<CallStatement>();
+	result->function =
+	    make_unique<FunctionExpression>(checkpoint->force ? "force_checkpoint" : "checkpoint", move(children));
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+void Transformer::TransformCopyOptions(CopyInfo &info, duckdb_libpgquery::PGList *options) {
+	if (!options) {
+		return;
+	}
+	duckdb_libpgquery::PGListCell *cell = nullptr;
+
+	// iterate over each option
+	for_each_cell(cell, options->head) {
+		auto *def_elem = reinterpret_cast<duckdb_libpgquery::PGDefElem *>(cell->data.ptr_value);
+		if (StringUtil::Lower(def_elem->defname) == "format") {
+			// format specifier: interpret this option
+			auto *format_val = (duckdb_libpgquery::PGValue *)(def_elem->arg);
+			if (!format_val || format_val->type != duckdb_libpgquery::T_PGString) {
+				throw ParserException("Unsupported parameter type for FORMAT: expected e.g. FORMAT 'csv', 'parquet'");
+			}
+			info.format = StringUtil::Lower(format_val->val.str);
+			continue;
+		}
+		// otherwise
+		if (info.options.find(def_elem->defname) != info.options.end()) {
+			throw ParserException("Unexpected duplicate option \"%s\"", def_elem->defname);
+		}
+		if (!def_elem->arg) {
+			info.options[def_elem->defname] = vector<Value>();
+			continue;
+		}
+		switch (def_elem->arg->type) {
+		case duckdb_libpgquery::T_PGList: {
+			auto column_list = (duckdb_libpgquery::PGList *)(def_elem->arg);
+			for (auto c = column_list->head; c != nullptr; c = lnext(c)) {
+				auto target = (duckdb_libpgquery::PGResTarget *)(c->data.ptr_value);
+				info.options[def_elem->defname].push_back(Value(target->name));
+			}
+			break;
+		}
+		case duckdb_libpgquery::T_PGAStar:
+			info.options[def_elem->defname].push_back(Value("*"));
+			break;
+		default:
+			info.options[def_elem->defname].push_back(
+			    TransformValue(*((duckdb_libpgquery::PGValue *)def_elem->arg))->value);
+			break;
+		}
+	}
+}
+
+unique_ptr<CopyStatement> Transformer::TransformCopy(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGCopyStmt *>(node);
+	D_ASSERT(stmt);
+	auto result = make_unique<CopyStatement>();
+	auto &info = *result->info;
+
+	// get file_path and is_from
+	info.is_from = stmt->is_from;
+	if (!stmt->filename) {
+		// stdin/stdout
+		info.file_path = info.is_from ? "/dev/stdin" : "/dev/stdout";
+	} else {
+		// copy to a file
+		info.file_path = stmt->filename;
+	}
+	if (StringUtil::EndsWith(info.file_path, ".parquet")) {
+		info.format = "parquet";
+	} else {
+		info.format = "csv";
+	}
+
+	// get select_list
+	if (stmt->attlist) {
+		for (auto n = stmt->attlist->head; n != nullptr; n = n->next) {
+			auto target = reinterpret_cast<duckdb_libpgquery::PGResTarget *>(n->data.ptr_value);
+			if (target->name) {
+				info.select_list.emplace_back(target->name);
+			}
+		}
+	}
+
+	if (stmt->relation) {
+		auto ref = TransformRangeVar(stmt->relation);
+		auto &table = *reinterpret_cast<BaseTableRef *>(ref.get());
+		info.table = table.table_name;
+		info.schema = table.schema_name;
+	} else {
+		result->select_statement = TransformSelectNode((duckdb_libpgquery::PGSelectStmt *)stmt->query);
+	}
+
+	// handle the different options of the COPY statement
+	TransformCopyOptions(info, stmt->options);
+
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<CreateStatement> Transformer::TransformCreateFunction(duckdb_libpgquery::PGNode *node) {
+	D_ASSERT(node);
+	D_ASSERT(node->type == duckdb_libpgquery::T_PGCreateFunctionStmt);
+
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGCreateFunctionStmt *>(node);
+	D_ASSERT(stmt);
+	D_ASSERT(stmt->function || stmt->query);
+
+	auto result = make_unique<CreateStatement>();
+	auto qname = TransformQualifiedName(stmt->name);
+
+	unique_ptr<MacroFunction> macro_func;
+	;
+
+	// function can be null here
+	if (stmt->function) {
+		auto expression = TransformExpression(stmt->function);
+		macro_func = make_unique<ScalarMacroFunction>(move(expression));
+	} else if (stmt->query) {
+		auto query_node = TransformSelect(stmt->query, true)->node->Copy();
+		macro_func = make_unique<TableMacroFunction>(move(query_node));
+	}
+
+	auto info =
+	    make_unique<CreateMacroInfo>((stmt->function ? CatalogType::MACRO_ENTRY : CatalogType::TABLE_MACRO_ENTRY));
+	info->schema = qname.schema;
+	info->name = qname.name;
+
+	switch (stmt->relpersistence) {
+	case duckdb_libpgquery::PG_RELPERSISTENCE_TEMP:
+		info->temporary = true;
+		break;
+	case duckdb_libpgquery::PG_RELPERSISTENCE_UNLOGGED:
+		throw ParserException("Unlogged flag not supported for macros: '%s'", qname.name);
+		break;
+	case duckdb_libpgquery::RELPERSISTENCE_PERMANENT:
+		info->temporary = false;
+		break;
+	}
+
+	if (stmt->params) {
+		vector<unique_ptr<ParsedExpression>> parameters;
+		TransformExpressionList(*stmt->params, parameters);
+		for (auto &param : parameters) {
+			if (param->type == ExpressionType::VALUE_CONSTANT) {
+				// parameters with default value (must have an alias)
+				if (param->alias.empty()) {
+					throw ParserException("Invalid parameter: '%s'", param->ToString());
+				}
+				if (macro_func->default_parameters.find(param->alias) != macro_func->default_parameters.end()) {
+					throw ParserException("Duplicate default parameter: '%s'", param->alias);
+				}
+				macro_func->default_parameters[param->alias] = move(param);
+			} else if (param->GetExpressionClass() == ExpressionClass::COLUMN_REF) {
+				// positional parameters
+				if (!macro_func->default_parameters.empty()) {
+					throw ParserException("Positional parameters cannot come after parameters with a default value!");
+				}
+				macro_func->parameters.push_back(move(param));
+			} else {
+				throw ParserException("Invalid parameter: '%s'", param->ToString());
+			}
+		}
+	}
+
+	info->function = move(macro_func);
+	result->info = move(info);
+
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+static IndexType StringToIndexType(const string &str) {
+	string upper_str = StringUtil::Upper(str);
+	if (upper_str == "INVALID") {
+		return IndexType::INVALID;
+	} else if (upper_str == "ART") {
+		return IndexType::ART;
+	} else {
+		throw ConversionException("No IndexType conversion from string '%s'", upper_str);
+	}
+	return IndexType::INVALID;
+}
+
+unique_ptr<CreateStatement> Transformer::TransformCreateIndex(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGIndexStmt *>(node);
+	D_ASSERT(stmt);
+	auto result = make_unique<CreateStatement>();
+	auto info = make_unique<CreateIndexInfo>();
+
+	info->unique = stmt->unique;
+	info->on_conflict = TransformOnConflict(stmt->onconflict);
+
+	for (auto cell = stmt->indexParams->head; cell != nullptr; cell = cell->next) {
+		auto index_element = (duckdb_libpgquery::PGIndexElem *)cell->data.ptr_value;
+		if (index_element->collation) {
+			throw NotImplementedException("Index with collation not supported yet!");
+		}
+		if (index_element->opclass) {
+			throw NotImplementedException("Index with opclass not supported yet!");
+		}
+
+		if (index_element->name) {
+			// create a column reference expression
+			info->expressions.push_back(make_unique<ColumnRefExpression>(index_element->name, stmt->relation->relname));
+		} else {
+			// parse the index expression
+			D_ASSERT(index_element->expr);
+			info->expressions.push_back(TransformExpression(index_element->expr));
+		}
+	}
+
+	info->index_type = StringToIndexType(string(stmt->accessMethod));
+	auto tableref = make_unique<BaseTableRef>();
+	tableref->table_name = stmt->relation->relname;
+	if (stmt->relation->schemaname) {
+		tableref->schema_name = stmt->relation->schemaname;
+	}
+	info->table = move(tableref);
+	if (stmt->idxname) {
+		info->index_name = stmt->idxname;
+	} else {
+		throw NotImplementedException("Index wout a name not supported yet!");
+	}
+	result->info = move(info);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<CreateStatement> Transformer::TransformCreateSchema(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGCreateSchemaStmt *>(node);
+	D_ASSERT(stmt);
+	auto result = make_unique<CreateStatement>();
+	auto info = make_unique<CreateSchemaInfo>();
+
+	D_ASSERT(stmt->schemaname);
+	info->schema = stmt->schemaname;
+	info->on_conflict = TransformOnConflict(stmt->onconflict);
+
+	if (stmt->schemaElts) {
+		// schema elements
+		for (auto cell = stmt->schemaElts->head; cell != nullptr; cell = cell->next) {
+			auto node = reinterpret_cast<duckdb_libpgquery::PGNode *>(cell->data.ptr_value);
+			switch (node->type) {
+			case duckdb_libpgquery::T_PGCreateStmt:
+			case duckdb_libpgquery::T_PGViewStmt:
+			default:
+				throw NotImplementedException("Schema element not supported yet!");
+			}
+		}
+	}
+	result->info = move(info);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<CreateStatement> Transformer::TransformCreateSequence(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGCreateSeqStmt *>(node);
+
+	auto result = make_unique<CreateStatement>();
+	auto info = make_unique<CreateSequenceInfo>();
+
+	auto qname = TransformQualifiedName(stmt->sequence);
+	info->schema = qname.schema;
+	info->name = qname.name;
+
+	if (stmt->options) {
+		duckdb_libpgquery::PGListCell *cell = nullptr;
+		for_each_cell(cell, stmt->options->head) {
+			auto *def_elem = reinterpret_cast<duckdb_libpgquery::PGDefElem *>(cell->data.ptr_value);
+			string opt_name = string(def_elem->defname);
+
+			auto val = (duckdb_libpgquery::PGValue *)def_elem->arg;
+			if (def_elem->defaction == duckdb_libpgquery::PG_DEFELEM_UNSPEC && !val) { // e.g. NO MINVALUE
+				continue;
+			}
+			D_ASSERT(val);
+			int64_t opt_value;
+			if (val->type == duckdb_libpgquery::T_PGInteger) {
+				opt_value = val->val.ival;
+			} else if (val->type == duckdb_libpgquery::T_PGFloat) {
+				if (!TryCast::Operation<string_t, int64_t>(string_t(val->val.str), opt_value, true)) {
+					throw ParserException("Expected an integer argument for option %s", opt_name);
+				}
+			} else {
+				throw ParserException("Expected an integer argument for option %s", opt_name);
+			}
+			if (opt_name == "increment") {
+				info->increment = opt_value;
+				if (info->increment == 0) {
+					throw ParserException("Increment must not be zero");
+				}
+				if (info->increment < 0) {
+					info->start_value = info->max_value = -1;
+					info->min_value = NumericLimits<int64_t>::Minimum();
+				} else {
+					info->start_value = info->min_value = 1;
+					info->max_value = NumericLimits<int64_t>::Maximum();
+				}
+			} else if (opt_name == "minvalue") {
+				info->min_value = opt_value;
+				if (info->increment > 0) {
+					info->start_value = info->min_value;
+				}
+			} else if (opt_name == "maxvalue") {
+				info->max_value = opt_value;
+				if (info->increment < 0) {
+					info->start_value = info->max_value;
+				}
+			} else if (opt_name == "start") {
+				info->start_value = opt_value;
+			} else if (opt_name == "cycle") {
+				info->cycle = opt_value > 0;
+			} else {
+				throw ParserException("Unrecognized option \"%s\" for CREATE SEQUENCE", opt_name);
+			}
+		}
+	}
+	info->temporary = !stmt->sequence->relpersistence;
+	info->on_conflict = TransformOnConflict(stmt->onconflict);
+	if (info->max_value <= info->min_value) {
+		throw ParserException("MINVALUE (%lld) must be less than MAXVALUE (%lld)", info->min_value, info->max_value);
+	}
+	if (info->start_value < info->min_value) {
+		throw ParserException("START value (%lld) cannot be less than MINVALUE (%lld)", info->start_value,
+		                      info->min_value);
+	}
+	if (info->start_value > info->max_value) {
+		throw ParserException("START value (%lld) cannot be greater than MAXVALUE (%lld)", info->start_value,
+		                      info->max_value);
+	}
+	result->info = move(info);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+string Transformer::TransformCollation(duckdb_libpgquery::PGCollateClause *collate) {
+	if (!collate) {
+		return string();
+	}
+	string collation;
+	for (auto c = collate->collname->head; c != nullptr; c = lnext(c)) {
+		auto pgvalue = (duckdb_libpgquery::PGValue *)c->data.ptr_value;
+		if (pgvalue->type != duckdb_libpgquery::T_PGString) {
+			throw ParserException("Expected a string as collation type!");
+		}
+		auto collation_argument = string(pgvalue->val.str);
+		if (collation.empty()) {
+			collation = collation_argument;
+		} else {
+			collation += "." + collation_argument;
+		}
+	}
+	return collation;
+}
+
+OnCreateConflict Transformer::TransformOnConflict(duckdb_libpgquery::PGOnCreateConflict conflict) {
+	switch (conflict) {
+	case duckdb_libpgquery::PG_ERROR_ON_CONFLICT:
+		return OnCreateConflict::ERROR_ON_CONFLICT;
+	case duckdb_libpgquery::PG_IGNORE_ON_CONFLICT:
+		return OnCreateConflict::IGNORE_ON_CONFLICT;
+	case duckdb_libpgquery::PG_REPLACE_ON_CONFLICT:
+		return OnCreateConflict::REPLACE_ON_CONFLICT;
+	default:
+		throw InternalException("Unrecognized OnConflict type");
+	}
+}
+
+unique_ptr<ParsedExpression> Transformer::TransformCollateExpr(duckdb_libpgquery::PGCollateClause *collate) {
+	auto child = TransformExpression(collate->arg);
+	auto collation = TransformCollation(collate);
+	return make_unique<CollateExpression>(collation, move(child));
+}
+
+ColumnDefinition Transformer::TransformColumnDefinition(duckdb_libpgquery::PGColumnDef *cdef) {
+	string colname;
+	if (cdef->colname) {
+		colname = cdef->colname;
+	}
+	bool optional_type = cdef->category == duckdb_libpgquery::COL_GENERATED;
+	LogicalType target_type = (optional_type && !cdef->typeName) ? LogicalType::ANY : TransformTypeName(cdef->typeName);
+	if (cdef->collClause) {
+		if (cdef->category == duckdb_libpgquery::COL_GENERATED) {
+			throw ParserException("Collations are not supported on generated columns");
+		}
+		if (target_type.id() != LogicalTypeId::VARCHAR) {
+			throw ParserException("Only VARCHAR columns can have collations!");
+		}
+		target_type = LogicalType::VARCHAR_COLLATION(TransformCollation(cdef->collClause));
+	}
+
+	return ColumnDefinition(colname, target_type);
+}
+
+unique_ptr<CreateStatement> Transformer::TransformCreateTable(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGCreateStmt *>(node);
+	D_ASSERT(stmt);
+	auto result = make_unique<CreateStatement>();
+	auto info = make_unique<CreateTableInfo>();
+
+	if (stmt->inhRelations) {
+		throw NotImplementedException("inherited relations not implemented");
+	}
+	D_ASSERT(stmt->relation);
+
+	info->schema = INVALID_SCHEMA;
+	if (stmt->relation->schemaname) {
+		info->schema = stmt->relation->schemaname;
+	}
+	info->table = stmt->relation->relname;
+	info->on_conflict = TransformOnConflict(stmt->onconflict);
+	info->temporary =
+	    stmt->relation->relpersistence == duckdb_libpgquery::PGPostgresRelPersistence::PG_RELPERSISTENCE_TEMP;
+
+	if (info->temporary && stmt->oncommit != duckdb_libpgquery::PGOnCommitAction::PG_ONCOMMIT_PRESERVE_ROWS &&
+	    stmt->oncommit != duckdb_libpgquery::PGOnCommitAction::PG_ONCOMMIT_NOOP) {
+		throw NotImplementedException("Only ON COMMIT PRESERVE ROWS is supported");
+	}
+	if (!stmt->tableElts) {
+		throw ParserException("Table must have at least one column!");
+	}
+
+	idx_t column_count = 0;
+	for (auto c = stmt->tableElts->head; c != nullptr; c = lnext(c)) {
+		auto node = reinterpret_cast<duckdb_libpgquery::PGNode *>(c->data.ptr_value);
+		switch (node->type) {
+		case duckdb_libpgquery::T_PGColumnDef: {
+			auto cdef = (duckdb_libpgquery::PGColumnDef *)c->data.ptr_value;
+			auto centry = TransformColumnDefinition(cdef);
+			if (cdef->constraints) {
+				for (auto constr = cdef->constraints->head; constr != nullptr; constr = constr->next) {
+					auto constraint = TransformConstraint(constr, centry, info->columns.size());
+					if (constraint) {
+						info->constraints.push_back(move(constraint));
+					}
+				}
+			}
+			info->columns.push_back(move(centry));
+			column_count++;
+			break;
+		}
+		case duckdb_libpgquery::T_PGConstraint: {
+			info->constraints.push_back(TransformConstraint(c));
+			break;
+		}
+		default:
+			throw NotImplementedException("ColumnDef type not handled yet");
+		}
+	}
+
+	if (!column_count) {
+		throw ParserException("Table must have at least one column!");
+	}
+
+	result->info = move(info);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<CreateStatement> Transformer::TransformCreateTableAs(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGCreateTableAsStmt *>(node);
+	D_ASSERT(stmt);
+	if (stmt->relkind == duckdb_libpgquery::PG_OBJECT_MATVIEW) {
+		throw NotImplementedException("Materialized view not implemented");
+	}
+	if (stmt->is_select_into || stmt->into->colNames || stmt->into->options) {
+		throw NotImplementedException("Unimplemented features for CREATE TABLE as");
+	}
+	auto qname = TransformQualifiedName(stmt->into->rel);
+	if (stmt->query->type != duckdb_libpgquery::T_PGSelectStmt) {
+		throw ParserException("CREATE TABLE AS requires a SELECT clause");
+	}
+	auto query = TransformSelect(stmt->query, false);
+
+	auto result = make_unique<CreateStatement>();
+	auto info = make_unique<CreateTableInfo>();
+	info->schema = qname.schema;
+	info->table = qname.name;
+	info->on_conflict = TransformOnConflict(stmt->onconflict);
+	info->temporary =
+	    stmt->into->rel->relpersistence == duckdb_libpgquery::PGPostgresRelPersistence::PG_RELPERSISTENCE_TEMP;
+	info->query = move(query);
+	result->info = move(info);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+vector<string> ReadPgListToString(duckdb_libpgquery::PGList *column_list) {
+	vector<string> result;
+	if (!column_list) {
+		return result;
+	}
+	for (auto c = column_list->head; c != nullptr; c = lnext(c)) {
+		auto target = (duckdb_libpgquery::PGResTarget *)(c->data.ptr_value);
+		result.emplace_back(target->name);
+	}
+	return result;
+}
+
+Vector ReadPgListToVector(duckdb_libpgquery::PGList *column_list, idx_t &size) {
+	if (!column_list) {
+		Vector result(LogicalType::VARCHAR);
+		return result;
+	}
+	// First we discover the size of this list
+	for (auto c = column_list->head; c != nullptr; c = lnext(c)) {
+		size++;
+	}
+
+	Vector result(LogicalType::VARCHAR, size);
+	auto result_ptr = FlatVector::GetData<string_t>(result);
+
+	size = 0;
+	for (auto c = column_list->head; c != nullptr; c = lnext(c)) {
+		auto &type_val = *((duckdb_libpgquery::PGAConst *)c->data.ptr_value);
+		auto entry_value_node = (duckdb_libpgquery::PGValue)(type_val.val);
+		if (entry_value_node.type != duckdb_libpgquery::T_PGString) {
+			throw ParserException("Expected a string constant as value");
+		}
+
+		auto entry_value = string(entry_value_node.val.str);
+		D_ASSERT(!entry_value.empty());
+		result_ptr[size++] = StringVector::AddStringOrBlob(result, entry_value);
+	}
+	return result;
+}
+
+unique_ptr<CreateStatement> Transformer::TransformCreateType(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGCreateTypeStmt *>(node);
+	D_ASSERT(stmt);
+	auto result = make_unique<CreateStatement>();
+	auto info = make_unique<CreateTypeInfo>();
+	info->name = ReadPgListToString(stmt->typeName)[0];
+	switch (stmt->kind) {
+	case duckdb_libpgquery::PG_NEWTYPE_ENUM: {
+		info->internal = false;
+		idx_t size = 0;
+		auto ordered_array = ReadPgListToVector(stmt->vals, size);
+		info->type = LogicalType::ENUM(info->name, ordered_array, size);
+	} break;
+
+	case duckdb_libpgquery::PG_NEWTYPE_ALIAS: {
+		LogicalType target_type = TransformTypeName(stmt->ofType);
+		target_type.SetAlias(info->name);
+		info->type = target_type;
+	} break;
+
+	default:
+		throw InternalException("Unknown kind of new type");
+	}
+
+	result->info = move(info);
+	return result;
+}
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<CreateStatement> Transformer::TransformCreateView(duckdb_libpgquery::PGNode *node) {
+	D_ASSERT(node);
+	D_ASSERT(node->type == duckdb_libpgquery::T_PGViewStmt);
+
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGViewStmt *>(node);
+	D_ASSERT(stmt);
+	D_ASSERT(stmt->view);
+
+	auto result = make_unique<CreateStatement>();
+	auto info = make_unique<CreateViewInfo>();
+
+	if (stmt->view->schemaname) {
+		info->schema = stmt->view->schemaname;
+	}
+	info->view_name = stmt->view->relname;
+	info->temporary = !stmt->view->relpersistence;
+	if (info->temporary) {
+		info->schema = TEMP_SCHEMA;
+	}
+	info->on_conflict = TransformOnConflict(stmt->onconflict);
+
+	info->query = TransformSelect(stmt->query, false);
+
+	if (stmt->aliases && stmt->aliases->length > 0) {
+		for (auto c = stmt->aliases->head; c != nullptr; c = lnext(c)) {
+			auto node = reinterpret_cast<duckdb_libpgquery::PGNode *>(c->data.ptr_value);
+			switch (node->type) {
+			case duckdb_libpgquery::T_PGString: {
+				auto val = (duckdb_libpgquery::PGValue *)node;
+				info->aliases.emplace_back(val->val.str);
+				break;
+			}
+			default:
+				throw NotImplementedException("View projection type");
+			}
+		}
+		if (info->aliases.empty()) {
+			throw ParserException("Need at least one column name in CREATE VIEW projection list");
+		}
+	}
+
+	if (stmt->options && stmt->options->length > 0) {
+		throw NotImplementedException("VIEW options");
+	}
+
+	if (stmt->withCheckOption != duckdb_libpgquery::PGViewCheckOption::PG_NO_CHECK_OPTION) {
+		throw NotImplementedException("VIEW CHECK options");
+	}
+	result->info = move(info);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<DeleteStatement> Transformer::TransformDelete(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGDeleteStmt *>(node);
+	D_ASSERT(stmt);
+	auto result = make_unique<DeleteStatement>();
+
+	result->condition = TransformExpression(stmt->whereClause);
+	result->table = TransformRangeVar(stmt->relation);
+	if (result->table->type != TableReferenceType::BASE_TABLE) {
+		throw Exception("Can only delete from base tables!");
+	}
+	if (stmt->usingClause) {
+		for (auto n = stmt->usingClause->head; n != nullptr; n = n->next) {
+			auto target = reinterpret_cast<duckdb_libpgquery::PGNode *>(n->data.ptr_value);
+			auto using_entry = TransformTableRefNode(target);
+			result->using_clauses.push_back(move(using_entry));
+		}
+	}
+
+	if (stmt->returningList) {
+		Transformer::TransformExpressionList(*(stmt->returningList), result->returning_list);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<SQLStatement> Transformer::TransformDrop(duckdb_libpgquery::PGNode *node) {
+	auto stmt = (duckdb_libpgquery::PGDropStmt *)(node);
+	auto result = make_unique<DropStatement>();
+	auto &info = *result->info.get();
+	D_ASSERT(stmt);
+	if (stmt->objects->length != 1) {
+		throw NotImplementedException("Can only drop one object at a time");
+	}
+	switch (stmt->removeType) {
+	case duckdb_libpgquery::PG_OBJECT_TABLE:
+		info.type = CatalogType::TABLE_ENTRY;
+		break;
+	case duckdb_libpgquery::PG_OBJECT_SCHEMA:
+		info.type = CatalogType::SCHEMA_ENTRY;
+		break;
+	case duckdb_libpgquery::PG_OBJECT_INDEX:
+		info.type = CatalogType::INDEX_ENTRY;
+		break;
+	case duckdb_libpgquery::PG_OBJECT_VIEW:
+		info.type = CatalogType::VIEW_ENTRY;
+		break;
+	case duckdb_libpgquery::PG_OBJECT_SEQUENCE:
+		info.type = CatalogType::SEQUENCE_ENTRY;
+		break;
+	case duckdb_libpgquery::PG_OBJECT_FUNCTION:
+		info.type = CatalogType::MACRO_ENTRY;
+		break;
+	case duckdb_libpgquery::PG_OBJECT_TABLE_MACRO:
+		info.type = CatalogType::TABLE_MACRO_ENTRY;
+		break;
+	case duckdb_libpgquery::PG_OBJECT_TYPE:
+		info.type = CatalogType::TYPE_ENTRY;
+		break;
+	default:
+		throw NotImplementedException("Cannot drop this type yet");
+	}
+
+	switch (stmt->removeType) {
+	case duckdb_libpgquery::PG_OBJECT_SCHEMA:
+		info.name = ((duckdb_libpgquery::PGValue *)stmt->objects->head->data.ptr_value)->val.str;
+		break;
+	case duckdb_libpgquery::PG_OBJECT_TYPE: {
+		auto view_list = (duckdb_libpgquery::PGList *)stmt->objects;
+		auto target = (duckdb_libpgquery::PGTypeName *)(view_list->head->data.ptr_value);
+		info.name = (reinterpret_cast<duckdb_libpgquery::PGValue *>(target->names->tail->data.ptr_value)->val.str);
+		break;
+	}
+	default: {
+		auto view_list = (duckdb_libpgquery::PGList *)stmt->objects->head->data.ptr_value;
+		if (view_list->length == 2) {
+			info.schema = ((duckdb_libpgquery::PGValue *)view_list->head->data.ptr_value)->val.str;
+			info.name = ((duckdb_libpgquery::PGValue *)view_list->head->next->data.ptr_value)->val.str;
+		} else {
+			info.name = ((duckdb_libpgquery::PGValue *)view_list->head->data.ptr_value)->val.str;
+		}
+		break;
+	}
+	}
+	info.cascade = stmt->behavior == duckdb_libpgquery::PGDropBehavior::PG_DROP_CASCADE;
+	info.if_exists = stmt->missing_ok;
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<ExplainStatement> Transformer::TransformExplain(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGExplainStmt *>(node);
+	D_ASSERT(stmt);
+	auto explain_type = ExplainType::EXPLAIN_STANDARD;
+	if (stmt->options) {
+		for (auto n = stmt->options->head; n; n = n->next) {
+			auto def_elem = ((duckdb_libpgquery::PGDefElem *)n->data.ptr_value)->defname;
+			string elem(def_elem);
+			if (elem == "analyze") {
+				explain_type = ExplainType::EXPLAIN_ANALYZE;
+			} else {
+				throw NotImplementedException("Unimplemented explain type: %s", elem);
+			}
+		}
+	}
+	return make_unique<ExplainStatement>(TransformStatement(stmt->query), explain_type);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<ExportStatement> Transformer::TransformExport(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGExportStmt *>(node);
+	auto info = make_unique<CopyInfo>();
+	info->file_path = stmt->filename;
+	info->format = "csv";
+	info->is_from = false;
+	// handle export options
+	TransformCopyOptions(*info, stmt->options);
+
+	return make_unique<ExportStatement>(move(info));
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<PragmaStatement> Transformer::TransformImport(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGImportStmt *>(node);
+	auto result = make_unique<PragmaStatement>();
+	result->info->name = "import_database";
+	result->info->parameters.emplace_back(stmt->filename);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<TableRef> Transformer::TransformValuesList(duckdb_libpgquery::PGList *list) {
+	auto result = make_unique<ExpressionListRef>();
+	for (auto value_list = list->head; value_list != nullptr; value_list = value_list->next) {
+		auto target = (duckdb_libpgquery::PGList *)(value_list->data.ptr_value);
+
+		vector<unique_ptr<ParsedExpression>> insert_values;
+		TransformExpressionList(*target, insert_values);
+		if (!result->values.empty()) {
+			if (result->values[0].size() != insert_values.size()) {
+				throw ParserException("VALUES lists must all be the same length");
+			}
+		}
+		result->values.push_back(move(insert_values));
+	}
+	result->alias = "valueslist";
+	return move(result);
+}
+
+unique_ptr<InsertStatement> Transformer::TransformInsert(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGInsertStmt *>(node);
+	D_ASSERT(stmt);
+	if (stmt->onConflictClause && stmt->onConflictClause->action != duckdb_libpgquery::PG_ONCONFLICT_NONE) {
+		throw ParserException("ON CONFLICT IGNORE/UPDATE clauses are not supported");
+	}
+
+	auto result = make_unique<InsertStatement>();
+
+	// first check if there are any columns specified
+	if (stmt->cols) {
+		for (auto c = stmt->cols->head; c != nullptr; c = lnext(c)) {
+			auto target = (duckdb_libpgquery::PGResTarget *)(c->data.ptr_value);
+			result->columns.emplace_back(target->name);
+		}
+	}
+
+	// Grab and transform the returning columns from the parser.
+	if (stmt->returningList) {
+		Transformer::TransformExpressionList(*(stmt->returningList), result->returning_list);
+	}
+	result->select_statement = TransformSelect(stmt->selectStmt, false);
+
+	auto qname = TransformQualifiedName(stmt->relation);
+	result->table = qname.name;
+	result->schema = qname.schema;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<LoadStatement> Transformer::TransformLoad(duckdb_libpgquery::PGNode *node) {
+	D_ASSERT(node->type == duckdb_libpgquery::T_PGLoadStmt);
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGLoadStmt *>(node);
+
+	auto load_stmt = make_unique<LoadStatement>();
+	auto load_info = make_unique<LoadInfo>();
+	load_info->filename = std::string(stmt->filename);
+	switch (stmt->load_type) {
+	case duckdb_libpgquery::PG_LOAD_TYPE_LOAD:
+		load_info->load_type = LoadType::LOAD;
+		break;
+	case duckdb_libpgquery::PG_LOAD_TYPE_INSTALL:
+		load_info->load_type = LoadType::INSTALL;
+		break;
+	case duckdb_libpgquery::PG_LOAD_TYPE_FORCE_INSTALL:
+		load_info->load_type = LoadType::FORCE_INSTALL;
+		break;
+	}
+	load_stmt->info = move(load_info);
+	return load_stmt;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<SQLStatement> Transformer::TransformPragma(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGPragmaStmt *>(node);
+
+	auto result = make_unique<PragmaStatement>();
+	auto &info = *result->info;
+
+	info.name = stmt->name;
+	// parse the arguments, if any
+	if (stmt->args) {
+		for (auto cell = stmt->args->head; cell != nullptr; cell = cell->next) {
+			auto node = reinterpret_cast<duckdb_libpgquery::PGNode *>(cell->data.ptr_value);
+			auto expr = TransformExpression(node);
+
+			if (expr->type == ExpressionType::COMPARE_EQUAL) {
+				auto &comp = (ComparisonExpression &)*expr;
+				if (comp.right->type != ExpressionType::VALUE_CONSTANT) {
+					throw ParserException("Named parameter requires a constant on the RHS");
+				}
+				if (comp.left->type != ExpressionType::COLUMN_REF) {
+					throw ParserException("Named parameter requires a column reference on the LHS");
+				}
+				auto &columnref = (ColumnRefExpression &)*comp.left;
+				auto &constant = (ConstantExpression &)*comp.right;
+				info.named_parameters[columnref.GetName()] = constant.value;
+			} else if (node->type == duckdb_libpgquery::T_PGAConst) {
+				auto constant = TransformConstant((duckdb_libpgquery::PGAConst *)node);
+				info.parameters.push_back(((ConstantExpression &)*constant).value);
+			} else {
+				info.parameters.emplace_back(expr->ToString());
+			}
+		}
+	}
+	// now parse the pragma type
+	switch (stmt->kind) {
+	case duckdb_libpgquery::PG_PRAGMA_TYPE_NOTHING: {
+		if (!info.parameters.empty() || !info.named_parameters.empty()) {
+			throw InternalException("PRAGMA statement that is not a call or assignment cannot contain parameters");
+		}
+		break;
+	case duckdb_libpgquery::PG_PRAGMA_TYPE_ASSIGNMENT:
+		if (info.parameters.size() != 1) {
+			throw InternalException("PRAGMA statement with assignment should contain exactly one parameter");
+		}
+		if (!info.named_parameters.empty()) {
+			throw InternalException("PRAGMA statement with assignment cannot have named parameters");
+		}
+		// SQLite does not distinguish between:
+		// "PRAGMA table_info='integers'"
+		// "PRAGMA table_info('integers')"
+		// for compatibility, any pragmas that match the SQLite ones are parsed as calls
+		case_insensitive_set_t sqlite_compat_pragmas {"table_info"};
+		if (sqlite_compat_pragmas.find(info.name) != sqlite_compat_pragmas.end()) {
+			break;
+		}
+		auto set_statement = make_unique<SetStatement>(info.name, info.parameters[0], SetScope::AUTOMATIC);
+		return move(set_statement);
+	}
+	case duckdb_libpgquery::PG_PRAGMA_TYPE_CALL:
+		break;
+	default:
+		throw InternalException("Unknown pragma type");
+	}
+
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<PrepareStatement> Transformer::TransformPrepare(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGPrepareStmt *>(node);
+	D_ASSERT(stmt);
+
+	if (stmt->argtypes && stmt->argtypes->length > 0) {
+		throw NotImplementedException("Prepared statement argument types are not supported, use CAST");
+	}
+
+	auto result = make_unique<PrepareStatement>();
+	result->name = string(stmt->name);
+	result->statement = TransformStatement(stmt->query);
+	SetParamCount(0);
+
+	return result;
+}
+
+unique_ptr<ExecuteStatement> Transformer::TransformExecute(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGExecuteStmt *>(node);
+	D_ASSERT(stmt);
+
+	auto result = make_unique<ExecuteStatement>();
+	result->name = string(stmt->name);
+
+	if (stmt->params) {
+		TransformExpressionList(*stmt->params, result->values);
+	}
+	for (auto &expr : result->values) {
+		if (!expr->IsScalar()) {
+			throw Exception("Only scalar parameters or NULL supported for EXECUTE");
+		}
+	}
+	return result;
+}
+
+unique_ptr<DropStatement> Transformer::TransformDeallocate(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGDeallocateStmt *>(node);
+	D_ASSERT(stmt);
+	if (!stmt->name) {
+		throw ParserException("DEALLOCATE requires a name");
+	}
+
+	auto result = make_unique<DropStatement>();
+	result->info->type = CatalogType::PREPARED_STATEMENT;
+	result->info->name = string(stmt->name);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<AlterStatement> Transformer::TransformRename(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGRenameStmt *>(node);
+	D_ASSERT(stmt);
+	D_ASSERT(stmt->relation);
+
+	unique_ptr<AlterInfo> info;
+
+	// first we check the type of ALTER
+	switch (stmt->renameType) {
+	case duckdb_libpgquery::PG_OBJECT_COLUMN: {
+		// change column name
+
+		// get the table and schema
+		string schema = INVALID_SCHEMA;
+		string table;
+		D_ASSERT(stmt->relation->relname);
+		if (stmt->relation->relname) {
+			table = stmt->relation->relname;
+		}
+		if (stmt->relation->schemaname) {
+			schema = stmt->relation->schemaname;
+		}
+		// get the old name and the new name
+		string old_name = stmt->subname;
+		string new_name = stmt->newname;
+		info = make_unique<RenameColumnInfo>(schema, table, old_name, new_name);
+		break;
+	}
+	case duckdb_libpgquery::PG_OBJECT_TABLE: {
+		// change table name
+
+		// get the table and schema
+		string schema = DEFAULT_SCHEMA;
+		string table;
+		D_ASSERT(stmt->relation->relname);
+		if (stmt->relation->relname) {
+			table = stmt->relation->relname;
+		}
+		if (stmt->relation->schemaname) {
+			schema = stmt->relation->schemaname;
+		}
+		string new_name = stmt->newname;
+		info = make_unique<RenameTableInfo>(schema, table, new_name);
+		break;
+	}
+
+	case duckdb_libpgquery::PG_OBJECT_VIEW: {
+		// change view name
+
+		// get the view and schema
+		string schema = DEFAULT_SCHEMA;
+		string view;
+		D_ASSERT(stmt->relation->relname);
+		if (stmt->relation->relname) {
+			view = stmt->relation->relname;
+		}
+		if (stmt->relation->schemaname) {
+			schema = stmt->relation->schemaname;
+		}
+		string new_name = stmt->newname;
+		info = make_unique<RenameViewInfo>(schema, view, new_name);
+		break;
+	}
+	case duckdb_libpgquery::PG_OBJECT_DATABASE:
+	default:
+		throw NotImplementedException("Schema element not supported yet!");
+	}
+	D_ASSERT(info);
+
+	auto result = make_unique<AlterStatement>();
+	result->info = move(info);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<SelectStatement> Transformer::TransformSelect(duckdb_libpgquery::PGNode *node, bool is_select) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGSelectStmt *>(node);
+	auto result = make_unique<SelectStatement>();
+
+	// Both Insert/Create Table As uses this.
+	if (is_select) {
+		if (stmt->intoClause) {
+			throw ParserException("SELECT INTO not supported!");
+		}
+		if (stmt->lockingClause) {
+			throw ParserException("SELECT locking clause is not supported!");
+		}
+	}
+
+	result->node = TransformSelectNode(stmt);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<QueryNode> Transformer::TransformSelectNode(duckdb_libpgquery::PGSelectStmt *stmt) {
+	D_ASSERT(stmt->type == duckdb_libpgquery::T_PGSelectStmt);
+	auto stack_checker = StackCheck();
+
+	unique_ptr<QueryNode> node;
+
+	switch (stmt->op) {
+	case duckdb_libpgquery::PG_SETOP_NONE: {
+		node = make_unique<SelectNode>();
+		auto result = (SelectNode *)node.get();
+		if (stmt->withClause) {
+			TransformCTE(reinterpret_cast<duckdb_libpgquery::PGWithClause *>(stmt->withClause), *node);
+		}
+		if (stmt->windowClause) {
+			for (auto window_ele = stmt->windowClause->head; window_ele != nullptr; window_ele = window_ele->next) {
+				auto window_def = reinterpret_cast<duckdb_libpgquery::PGWindowDef *>(window_ele->data.ptr_value);
+				D_ASSERT(window_def);
+				D_ASSERT(window_def->name);
+				auto window_name = StringUtil::Lower(string(window_def->name));
+
+				auto it = window_clauses.find(window_name);
+				if (it != window_clauses.end()) {
+					throw ParserException("window \"%s\" is already defined", window_name);
+				}
+				window_clauses[window_name] = window_def;
+			}
+		}
+
+		// checks distinct clause
+		if (stmt->distinctClause != nullptr) {
+			auto modifier = make_unique<DistinctModifier>();
+			// checks distinct on clause
+			auto target = reinterpret_cast<duckdb_libpgquery::PGNode *>(stmt->distinctClause->head->data.ptr_value);
+			if (target) {
+				//  add the columns defined in the ON clause to the select list
+				TransformExpressionList(*stmt->distinctClause, modifier->distinct_on_targets);
+			}
+			result->modifiers.push_back(move(modifier));
+		}
+
+		// do this early so the value lists also have a `FROM`
+		if (stmt->valuesLists) {
+			// VALUES list, create an ExpressionList
+			D_ASSERT(!stmt->fromClause);
+			result->from_table = TransformValuesList(stmt->valuesLists);
+			result->select_list.push_back(make_unique<StarExpression>());
+		} else {
+			if (!stmt->targetList) {
+				throw ParserException("SELECT clause without selection list");
+			}
+			// select list
+			TransformExpressionList(*stmt->targetList, result->select_list);
+			result->from_table = TransformFrom(stmt->fromClause);
+		}
+
+		// where
+		result->where_clause = TransformExpression(stmt->whereClause);
+		// group by
+		TransformGroupBy(stmt->groupClause, *result);
+		// having
+		result->having = TransformExpression(stmt->havingClause);
+		// qualify
+		result->qualify = TransformExpression(stmt->qualifyClause);
+		// sample
+		result->sample = TransformSampleOptions(stmt->sampleOptions);
+		break;
+	}
+	case duckdb_libpgquery::PG_SETOP_UNION:
+	case duckdb_libpgquery::PG_SETOP_EXCEPT:
+	case duckdb_libpgquery::PG_SETOP_INTERSECT: {
+		node = make_unique<SetOperationNode>();
+		auto result = (SetOperationNode *)node.get();
+		if (stmt->withClause) {
+			TransformCTE(reinterpret_cast<duckdb_libpgquery::PGWithClause *>(stmt->withClause), *node);
+		}
+		result->left = TransformSelectNode(stmt->larg);
+		result->right = TransformSelectNode(stmt->rarg);
+		if (!result->left || !result->right) {
+			throw Exception("Failed to transform setop children.");
+		}
+
+		bool select_distinct = true;
+		switch (stmt->op) {
+		case duckdb_libpgquery::PG_SETOP_UNION:
+			select_distinct = !stmt->all;
+			result->setop_type = SetOperationType::UNION;
+			break;
+		case duckdb_libpgquery::PG_SETOP_EXCEPT:
+			result->setop_type = SetOperationType::EXCEPT;
+			break;
+		case duckdb_libpgquery::PG_SETOP_INTERSECT:
+			result->setop_type = SetOperationType::INTERSECT;
+			break;
+		default:
+			throw Exception("Unexpected setop type");
+		}
+		if (select_distinct) {
+			result->modifiers.push_back(make_unique<DistinctModifier>());
+		}
+		if (stmt->sampleOptions) {
+			throw ParserException("SAMPLE clause is only allowed in regular SELECT statements");
+		}
+		break;
+	}
+	default:
+		throw NotImplementedException("Statement type %d not implemented!", stmt->op);
+	}
+	// transform the common properties
+	// both the set operations and the regular select can have an ORDER BY/LIMIT attached to them
+	vector<OrderByNode> orders;
+	TransformOrderBy(stmt->sortClause, orders);
+	if (!orders.empty()) {
+		auto order_modifier = make_unique<OrderModifier>();
+		order_modifier->orders = move(orders);
+		node->modifiers.push_back(move(order_modifier));
+	}
+	if (stmt->limitCount || stmt->limitOffset) {
+		if (stmt->limitCount && stmt->limitCount->type == duckdb_libpgquery::T_PGLimitPercent) {
+			auto limit_percent_modifier = make_unique<LimitPercentModifier>();
+			auto expr_node = reinterpret_cast<duckdb_libpgquery::PGLimitPercent *>(stmt->limitCount)->limit_percent;
+			limit_percent_modifier->limit = TransformExpression(expr_node);
+			if (stmt->limitOffset) {
+				limit_percent_modifier->offset = TransformExpression(stmt->limitOffset);
+			}
+			node->modifiers.push_back(move(limit_percent_modifier));
+		} else {
+			auto limit_modifier = make_unique<LimitModifier>();
+			if (stmt->limitCount) {
+				limit_modifier->limit = TransformExpression(stmt->limitCount);
+			}
+			if (stmt->limitOffset) {
+				limit_modifier->offset = TransformExpression(stmt->limitOffset);
+			}
+			node->modifiers.push_back(move(limit_modifier));
+		}
+	}
+	return node;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+namespace {
+
+SetScope ToSetScope(duckdb_libpgquery::VariableSetScope pg_scope) {
+	switch (pg_scope) {
+	case duckdb_libpgquery::VariableSetScope::VAR_SET_SCOPE_LOCAL:
+		return SetScope::LOCAL;
+	case duckdb_libpgquery::VariableSetScope::VAR_SET_SCOPE_SESSION:
+		return SetScope::SESSION;
+	case duckdb_libpgquery::VariableSetScope::VAR_SET_SCOPE_GLOBAL:
+		return SetScope::GLOBAL;
+	case duckdb_libpgquery::VariableSetScope::VAR_SET_SCOPE_DEFAULT:
+		return SetScope::AUTOMATIC;
+	default:
+		throw InternalException("Unexpected pg_scope: %d", pg_scope);
+	}
+}
+
+} // namespace
+
+unique_ptr<SetStatement> Transformer::TransformSet(duckdb_libpgquery::PGNode *node) {
+	D_ASSERT(node->type == duckdb_libpgquery::T_PGVariableSetStmt);
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGVariableSetStmt *>(node);
+
+	if (stmt->kind != duckdb_libpgquery::VariableSetKind::VAR_SET_VALUE) {
+		throw ParserException("Can only SET a variable to a value");
+	}
+
+	if (stmt->scope == duckdb_libpgquery::VariableSetScope::VAR_SET_SCOPE_LOCAL) {
+		throw NotImplementedException("SET LOCAL is not implemented.");
+	}
+
+	auto name = std::string(stmt->name);
+	D_ASSERT(!name.empty()); // parser protect us!
+	if (stmt->args->length != 1) {
+		throw ParserException("SET needs a single scalar value parameter");
+	}
+	D_ASSERT(stmt->args->head && stmt->args->head->data.ptr_value);
+	D_ASSERT(((duckdb_libpgquery::PGNode *)stmt->args->head->data.ptr_value)->type == duckdb_libpgquery::T_PGAConst);
+
+	auto value = TransformValue(((duckdb_libpgquery::PGAConst *)stmt->args->head->data.ptr_value)->val)->value;
+
+	return make_unique<SetStatement>(name, value, ToSetScope(stmt->scope));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<SQLStatement> Transformer::TransformShow(duckdb_libpgquery::PGNode *node) {
+	// we transform SHOW x into PRAGMA SHOW('x')
+
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGVariableShowStmt *>(node);
+	if (stmt->is_summary) {
+		auto result = make_unique<ShowStatement>();
+		auto &info = *result->info;
+		info.is_summary = stmt->is_summary;
+
+		auto select = make_unique<SelectNode>();
+		select->select_list.push_back(make_unique<StarExpression>());
+		auto basetable = make_unique<BaseTableRef>();
+		basetable->table_name = stmt->name;
+		select->from_table = move(basetable);
+
+		info.query = move(select);
+		return move(result);
+	}
+
+	auto result = make_unique<PragmaStatement>();
+	auto &info = *result->info;
+
+	string name = stmt->name;
+	if (name == "tables") {
+		// show all tables
+		info.name = "show_tables";
+	} else if (name == "__show_tables_expanded") {
+		info.name = "show_tables_expanded";
+	} else {
+		// show one specific table
+		info.name = "show";
+		info.parameters.emplace_back(stmt->name);
+	}
+
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ShowStatement> Transformer::TransformShowSelect(duckdb_libpgquery::PGNode *node) {
+	// we capture the select statement of SHOW
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGVariableShowSelectStmt *>(node);
+	auto select_stmt = reinterpret_cast<duckdb_libpgquery::PGSelectStmt *>(stmt->stmt);
+
+	auto result = make_unique<ShowStatement>();
+	auto &info = *result->info;
+	info.is_summary = stmt->is_summary;
+
+	info.query = TransformSelectNode(select_stmt);
+
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<TransactionStatement> Transformer::TransformTransaction(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGTransactionStmt *>(node);
+	D_ASSERT(stmt);
+	switch (stmt->kind) {
+	case duckdb_libpgquery::PG_TRANS_STMT_BEGIN:
+	case duckdb_libpgquery::PG_TRANS_STMT_START:
+		return make_unique<TransactionStatement>(TransactionType::BEGIN_TRANSACTION);
+	case duckdb_libpgquery::PG_TRANS_STMT_COMMIT:
+		return make_unique<TransactionStatement>(TransactionType::COMMIT);
+	case duckdb_libpgquery::PG_TRANS_STMT_ROLLBACK:
+		return make_unique<TransactionStatement>(TransactionType::ROLLBACK);
+	default:
+		throw NotImplementedException("Transaction type %d not implemented yet", stmt->kind);
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<UpdateStatement> Transformer::TransformUpdate(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGUpdateStmt *>(node);
+	D_ASSERT(stmt);
+
+	auto result = make_unique<UpdateStatement>();
+
+	result->table = TransformRangeVar(stmt->relation);
+	if (stmt->fromClause) {
+		result->from_table = TransformFrom(stmt->fromClause);
+	}
+
+	auto root = stmt->targetList;
+	for (auto cell = root->head; cell != nullptr; cell = cell->next) {
+		auto target = (duckdb_libpgquery::PGResTarget *)(cell->data.ptr_value);
+		result->columns.emplace_back(target->name);
+		result->expressions.push_back(TransformExpression(target->val));
+	}
+
+	// Grab and transform the returning columns from the parser.
+	if (stmt->returningList) {
+		Transformer::TransformExpressionList(*(stmt->returningList), result->returning_list);
+	}
+
+	result->condition = TransformExpression(stmt->whereClause);
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<VacuumStatement> Transformer::TransformVacuum(duckdb_libpgquery::PGNode *node) {
+	auto stmt = reinterpret_cast<duckdb_libpgquery::PGVacuumStmt *>(node);
+	D_ASSERT(stmt);
+	(void)stmt;
+	auto result = make_unique<VacuumStatement>();
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<TableRef> Transformer::TransformRangeVar(duckdb_libpgquery::PGRangeVar *root) {
+	auto result = make_unique<BaseTableRef>();
+
+	result->alias = TransformAlias(root->alias, result->column_name_alias);
+	if (root->relname) {
+		result->table_name = root->relname;
+	}
+	if (root->schemaname) {
+		result->schema_name = root->schemaname;
+	}
+	if (root->sample) {
+		result->sample = TransformSampleOptions(root->sample);
+	}
+	result->query_location = root->location;
+	return move(result);
+}
+
+QualifiedName Transformer::TransformQualifiedName(duckdb_libpgquery::PGRangeVar *root) {
+	QualifiedName qname;
+	if (root->relname) {
+		qname.name = root->relname;
+	} else {
+		qname.name = string();
+	}
+	if (root->schemaname) {
+		qname.schema = root->schemaname;
+	} else {
+		qname.schema = INVALID_SCHEMA;
+	}
+	return qname;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<TableRef> Transformer::TransformFrom(duckdb_libpgquery::PGList *root) {
+	if (!root) {
+		return make_unique<EmptyTableRef>();
+	}
+
+	if (root->length > 1) {
+		// Cross Product
+		auto result = make_unique<CrossProductRef>();
+		CrossProductRef *cur_root = result.get();
+		idx_t list_size = 0;
+		for (auto node = root->head; node != nullptr; node = node->next) {
+			auto n = reinterpret_cast<duckdb_libpgquery::PGNode *>(node->data.ptr_value);
+			unique_ptr<TableRef> next = TransformTableRefNode(n);
+			if (!cur_root->left) {
+				cur_root->left = move(next);
+			} else if (!cur_root->right) {
+				cur_root->right = move(next);
+			} else {
+				auto old_res = move(result);
+				result = make_unique<CrossProductRef>();
+				result->left = move(old_res);
+				result->right = move(next);
+				cur_root = result.get();
+			}
+			list_size++;
+			StackCheck(list_size);
+		}
+		return move(result);
+	}
+
+	auto n = reinterpret_cast<duckdb_libpgquery::PGNode *>(root->head->data.ptr_value);
+	return TransformTableRefNode(n);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<TableRef> Transformer::TransformJoin(duckdb_libpgquery::PGJoinExpr *root) {
+	auto result = make_unique<JoinRef>();
+	switch (root->jointype) {
+	case duckdb_libpgquery::PG_JOIN_INNER: {
+		result->type = JoinType::INNER;
+		break;
+	}
+	case duckdb_libpgquery::PG_JOIN_LEFT: {
+		result->type = JoinType::LEFT;
+		break;
+	}
+	case duckdb_libpgquery::PG_JOIN_FULL: {
+		result->type = JoinType::OUTER;
+		break;
+	}
+	case duckdb_libpgquery::PG_JOIN_RIGHT: {
+		result->type = JoinType::RIGHT;
+		break;
+	}
+	case duckdb_libpgquery::PG_JOIN_SEMI: {
+		result->type = JoinType::SEMI;
+		break;
+	}
+	default: {
+		throw NotImplementedException("Join type %d not supported\n", root->jointype);
+	}
+	}
+
+	// Check the type of left arg and right arg before transform
+	result->left = TransformTableRefNode(root->larg);
+	result->right = TransformTableRefNode(root->rarg);
+	result->is_natural = root->isNatural;
+	result->query_location = root->location;
+
+	if (root->usingClause && root->usingClause->length > 0) {
+		// usingClause is a list of strings
+		for (auto node = root->usingClause->head; node != nullptr; node = node->next) {
+			auto target = reinterpret_cast<duckdb_libpgquery::PGNode *>(node->data.ptr_value);
+			D_ASSERT(target->type == duckdb_libpgquery::T_PGString);
+			auto column_name = string(reinterpret_cast<duckdb_libpgquery::PGValue *>(target)->val.str);
+			result->using_columns.push_back(column_name);
+		}
+		return move(result);
+	}
+
+	if (!root->quals && result->using_columns.empty() && !result->is_natural) { // CROSS PRODUCT
+		auto cross = make_unique<CrossProductRef>();
+		cross->left = move(result->left);
+		cross->right = move(result->right);
+		return move(cross);
+	}
+	result->condition = TransformExpression(root->quals);
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<TableRef> Transformer::TransformRangeSubselect(duckdb_libpgquery::PGRangeSubselect *root) {
+	Transformer subquery_transformer(this);
+	auto subquery = subquery_transformer.TransformSelect(root->subquery);
+	if (!subquery) {
+		return nullptr;
+	}
+	auto result = make_unique<SubqueryRef>(move(subquery));
+	result->alias = TransformAlias(root->alias, result->column_name_alias);
+	if (root->sample) {
+		result->sample = TransformSampleOptions(root->sample);
+	}
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<TableRef> Transformer::TransformRangeFunction(duckdb_libpgquery::PGRangeFunction *root) {
+	if (root->lateral) {
+		throw NotImplementedException("LATERAL not implemented");
+	}
+	if (root->ordinality) {
+		throw NotImplementedException("WITH ORDINALITY not implemented");
+	}
+	if (root->is_rowsfrom) {
+		throw NotImplementedException("ROWS FROM() not implemented");
+	}
+	if (root->functions->length != 1) {
+		throw NotImplementedException("Need exactly one function");
+	}
+	auto function_sublist = (duckdb_libpgquery::PGList *)root->functions->head->data.ptr_value;
+	D_ASSERT(function_sublist->length == 2);
+	auto call_tree = (duckdb_libpgquery::PGNode *)function_sublist->head->data.ptr_value;
+	auto coldef = function_sublist->head->next->data.ptr_value;
+
+	if (coldef) {
+		throw NotImplementedException("Explicit column definition not supported yet");
+	}
+	// transform the function call
+	auto result = make_unique<TableFunctionRef>();
+	switch (call_tree->type) {
+	case duckdb_libpgquery::T_PGFuncCall: {
+		auto func_call = (duckdb_libpgquery::PGFuncCall *)call_tree;
+		result->function = TransformFuncCall(func_call);
+		result->query_location = func_call->location;
+		break;
+	}
+	case duckdb_libpgquery::T_PGSQLValueFunction:
+		result->function = TransformSQLValueFunction((duckdb_libpgquery::PGSQLValueFunction *)call_tree);
+		break;
+	default:
+		throw ParserException("Not a function call or value function");
+	}
+	result->alias = TransformAlias(root->alias, result->column_name_alias);
+	if (root->sample) {
+		result->sample = TransformSampleOptions(root->sample);
+	}
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<TableRef> Transformer::TransformTableRefNode(duckdb_libpgquery::PGNode *n) {
+	auto stack_checker = StackCheck();
+
+	switch (n->type) {
+	case duckdb_libpgquery::T_PGRangeVar:
+		return TransformRangeVar(reinterpret_cast<duckdb_libpgquery::PGRangeVar *>(n));
+	case duckdb_libpgquery::T_PGJoinExpr:
+		return TransformJoin(reinterpret_cast<duckdb_libpgquery::PGJoinExpr *>(n));
+	case duckdb_libpgquery::T_PGRangeSubselect:
+		return TransformRangeSubselect(reinterpret_cast<duckdb_libpgquery::PGRangeSubselect *>(n));
+	case duckdb_libpgquery::T_PGRangeFunction:
+		return TransformRangeFunction(reinterpret_cast<duckdb_libpgquery::PGRangeFunction *>(n));
+	default:
+		throw NotImplementedException("From Type %d not supported", n->type);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+StackChecker::StackChecker(Transformer &transformer_p, idx_t stack_usage_p)
+    : transformer(transformer_p), stack_usage(stack_usage_p) {
+	transformer.stack_depth += stack_usage;
+}
+
+StackChecker::~StackChecker() {
+	transformer.stack_depth -= stack_usage;
+}
+
+StackChecker::StackChecker(StackChecker &&other) noexcept
+    : transformer(other.transformer), stack_usage(other.stack_usage) {
+	other.stack_usage = 0;
+}
+
+Transformer::Transformer(idx_t max_expression_depth_p)
+    : parent(nullptr), max_expression_depth(max_expression_depth_p), stack_depth(DConstants::INVALID_INDEX) {
+}
+
+Transformer::Transformer(Transformer *parent)
+    : parent(parent), max_expression_depth(parent->max_expression_depth), stack_depth(DConstants::INVALID_INDEX) {
+}
+
+bool Transformer::TransformParseTree(duckdb_libpgquery::PGList *tree, vector<unique_ptr<SQLStatement>> &statements) {
+	InitializeStackCheck();
+	for (auto entry = tree->head; entry != nullptr; entry = entry->next) {
+		SetParamCount(0);
+		auto stmt = TransformStatement((duckdb_libpgquery::PGNode *)entry->data.ptr_value);
+		D_ASSERT(stmt);
+		stmt->n_param = ParamCount();
+		statements.push_back(move(stmt));
+	}
+	return true;
+}
+
+void Transformer::InitializeStackCheck() {
+	stack_depth = 0;
+}
+
+StackChecker Transformer::StackCheck(idx_t extra_stack) {
+	auto node = this;
+	while (node->parent) {
+		node = node->parent;
+	}
+	D_ASSERT(node->stack_depth != DConstants::INVALID_INDEX);
+	if (node->stack_depth + extra_stack >= max_expression_depth) {
+		throw ParserException("Max expression depth limit of %lld exceeded. Use \"SET max_expression_depth TO x\" to "
+		                      "increase the maximum expression depth.",
+		                      max_expression_depth);
+	}
+	return StackChecker(*node, extra_stack);
+}
+
+unique_ptr<SQLStatement> Transformer::TransformStatement(duckdb_libpgquery::PGNode *stmt) {
+	auto result = TransformStatementInternal(stmt);
+	result->n_param = ParamCount();
+	return result;
+}
+
+unique_ptr<SQLStatement> Transformer::TransformStatementInternal(duckdb_libpgquery::PGNode *stmt) {
+	switch (stmt->type) {
+	case duckdb_libpgquery::T_PGRawStmt: {
+		auto raw_stmt = (duckdb_libpgquery::PGRawStmt *)stmt;
+		auto result = TransformStatement(raw_stmt->stmt);
+		if (result) {
+			result->stmt_location = raw_stmt->stmt_location;
+			result->stmt_length = raw_stmt->stmt_len;
+		}
+		return result;
+	}
+	case duckdb_libpgquery::T_PGSelectStmt:
+		return TransformSelect(stmt);
+	case duckdb_libpgquery::T_PGCreateStmt:
+		return TransformCreateTable(stmt);
+	case duckdb_libpgquery::T_PGCreateSchemaStmt:
+		return TransformCreateSchema(stmt);
+	case duckdb_libpgquery::T_PGViewStmt:
+		return TransformCreateView(stmt);
+	case duckdb_libpgquery::T_PGCreateSeqStmt:
+		return TransformCreateSequence(stmt);
+	case duckdb_libpgquery::T_PGCreateFunctionStmt:
+		return TransformCreateFunction(stmt);
+	case duckdb_libpgquery::T_PGDropStmt:
+		return TransformDrop(stmt);
+	case duckdb_libpgquery::T_PGInsertStmt:
+		return TransformInsert(stmt);
+	case duckdb_libpgquery::T_PGCopyStmt:
+		return TransformCopy(stmt);
+	case duckdb_libpgquery::T_PGTransactionStmt:
+		return TransformTransaction(stmt);
+	case duckdb_libpgquery::T_PGDeleteStmt:
+		return TransformDelete(stmt);
+	case duckdb_libpgquery::T_PGUpdateStmt:
+		return TransformUpdate(stmt);
+	case duckdb_libpgquery::T_PGIndexStmt:
+		return TransformCreateIndex(stmt);
+	case duckdb_libpgquery::T_PGAlterTableStmt:
+		return TransformAlter(stmt);
+	case duckdb_libpgquery::T_PGRenameStmt:
+		return TransformRename(stmt);
+	case duckdb_libpgquery::T_PGPrepareStmt:
+		return TransformPrepare(stmt);
+	case duckdb_libpgquery::T_PGExecuteStmt:
+		return TransformExecute(stmt);
+	case duckdb_libpgquery::T_PGDeallocateStmt:
+		return TransformDeallocate(stmt);
+	case duckdb_libpgquery::T_PGCreateTableAsStmt:
+		return TransformCreateTableAs(stmt);
+	case duckdb_libpgquery::T_PGPragmaStmt:
+		return TransformPragma(stmt);
+	case duckdb_libpgquery::T_PGExportStmt:
+		return TransformExport(stmt);
+	case duckdb_libpgquery::T_PGImportStmt:
+		return TransformImport(stmt);
+	case duckdb_libpgquery::T_PGExplainStmt:
+		return TransformExplain(stmt);
+	case duckdb_libpgquery::T_PGVacuumStmt:
+		return TransformVacuum(stmt);
+	case duckdb_libpgquery::T_PGVariableShowStmt:
+		return TransformShow(stmt);
+	case duckdb_libpgquery::T_PGVariableShowSelectStmt:
+		return TransformShowSelect(stmt);
+	case duckdb_libpgquery::T_PGCallStmt:
+		return TransformCall(stmt);
+	case duckdb_libpgquery::T_PGVariableSetStmt:
+		return TransformSet(stmt);
+	case duckdb_libpgquery::T_PGCheckPointStmt:
+		return TransformCheckpoint(stmt);
+	case duckdb_libpgquery::T_PGLoadStmt:
+		return TransformLoad(stmt);
+	case duckdb_libpgquery::T_PGCreateTypeStmt:
+		return TransformCreateType(stmt);
+	case duckdb_libpgquery::T_PGAlterSeqStmt:
+		return TransformAlterSequence(stmt);
+	default:
+		throw NotImplementedException(NodetypeToString(stmt->type));
+	}
+	return nullptr;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+string BindContext::GetMatchingBinding(const string &column_name) {
+	string result;
+	for (auto &kv : bindings) {
+		auto binding = kv.second.get();
+		auto is_using_binding = GetUsingBinding(column_name, kv.first);
+		if (is_using_binding) {
+			continue;
+		}
+		if (binding->HasMatchingBinding(column_name)) {
+			if (!result.empty() || is_using_binding) {
+				throw BinderException("Ambiguous reference to column name \"%s\" (use: \"%s.%s\" "
+				                      "or \"%s.%s\")",
+				                      column_name, result, column_name, kv.first, column_name);
+			}
+			result = kv.first;
+		}
+	}
+	return result;
+}
+
+vector<string> BindContext::GetSimilarBindings(const string &column_name) {
+	vector<pair<string, idx_t>> scores;
+	for (auto &kv : bindings) {
+		auto binding = kv.second.get();
+		for (auto &name : binding->names) {
+			idx_t distance = StringUtil::LevenshteinDistance(name, column_name);
+			scores.emplace_back(binding->alias + "." + name, distance);
+		}
+	}
+	return StringUtil::TopNStrings(scores);
+}
+
+void BindContext::AddUsingBinding(const string &column_name, UsingColumnSet *set) {
+	using_columns[column_name].insert(set);
+}
+
+void BindContext::AddUsingBindingSet(unique_ptr<UsingColumnSet> set) {
+	using_column_sets.push_back(move(set));
+}
+
+bool BindContext::FindUsingBinding(const string &column_name, unordered_set<UsingColumnSet *> **out) {
+	auto entry = using_columns.find(column_name);
+	if (entry != using_columns.end()) {
+		*out = &entry->second;
+		return true;
+	}
+	return false;
+}
+
+UsingColumnSet *BindContext::GetUsingBinding(const string &column_name) {
+	unordered_set<UsingColumnSet *> *using_bindings;
+	if (!FindUsingBinding(column_name, &using_bindings)) {
+		return nullptr;
+	}
+	if (using_bindings->size() > 1) {
+		string error = "Ambiguous column reference: column \"" + column_name + "\" can refer to either:\n";
+		for (auto &using_set : *using_bindings) {
+			string result_bindings;
+			for (auto &binding : using_set->bindings) {
+				if (result_bindings.empty()) {
+					result_bindings = "[";
+				} else {
+					result_bindings += ", ";
+				}
+				result_bindings += binding;
+				result_bindings += ".";
+				result_bindings += GetActualColumnName(binding, column_name);
+			}
+			error += result_bindings + "]";
+		}
+		throw BinderException(error);
+	}
+	for (auto &using_set : *using_bindings) {
+		return using_set;
+	}
+	throw InternalException("Using binding found but no entries");
+}
+
+UsingColumnSet *BindContext::GetUsingBinding(const string &column_name, const string &binding_name) {
+	if (binding_name.empty()) {
+		throw InternalException("GetUsingBinding: expected non-empty binding_name");
+	}
+	unordered_set<UsingColumnSet *> *using_bindings;
+	if (!FindUsingBinding(column_name, &using_bindings)) {
+		return nullptr;
+	}
+	for (auto &using_set : *using_bindings) {
+		auto &bindings = using_set->bindings;
+		if (bindings.find(binding_name) != bindings.end()) {
+			return using_set;
+		}
+	}
+	return nullptr;
+}
+
+void BindContext::RemoveUsingBinding(const string &column_name, UsingColumnSet *set) {
+	if (!set) {
+		return;
+	}
+	auto entry = using_columns.find(column_name);
+	if (entry == using_columns.end()) {
+		throw InternalException("Attempting to remove using binding that is not there");
+	}
+	auto &bindings = entry->second;
+	if (bindings.find(set) != bindings.end()) {
+		bindings.erase(set);
+	}
+	if (bindings.empty()) {
+		using_columns.erase(column_name);
+	}
+}
+
+void BindContext::TransferUsingBinding(BindContext &current_context, UsingColumnSet *current_set,
+                                       UsingColumnSet *new_set, const string &binding, const string &using_column) {
+	AddUsingBinding(using_column, new_set);
+	current_context.RemoveUsingBinding(using_column, current_set);
+}
+
+string BindContext::GetActualColumnName(const string &binding_name, const string &column_name) {
+	string error;
+	auto binding = GetBinding(binding_name, error);
+	if (!binding) {
+		throw InternalException("No binding with name \"%s\"", binding_name);
+	}
+	column_t binding_index;
+	if (!binding->TryGetBindingIndex(column_name, binding_index)) { // LCOV_EXCL_START
+		throw InternalException("Binding with name \"%s\" does not have a column named \"%s\"", binding_name,
+		                        column_name);
+	} // LCOV_EXCL_STOP
+	return binding->names[binding_index];
+}
+
+unordered_set<string> BindContext::GetMatchingBindings(const string &column_name) {
+	unordered_set<string> result;
+	for (auto &kv : bindings) {
+		auto binding = kv.second.get();
+		if (binding->HasMatchingBinding(column_name)) {
+			result.insert(kv.first);
+		}
+	}
+	return result;
+}
+
+unique_ptr<ParsedExpression> BindContext::ExpandGeneratedColumn(const string &table_name, const string &column_name) {
+	string error_message;
+
+	auto binding = GetBinding(table_name, error_message);
+	D_ASSERT(binding);
+	auto &table_binding = *(TableBinding *)binding;
+	return table_binding.ExpandGeneratedColumn(column_name);
+}
+
+unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const string &table_name, const string &column_name) {
+	string schema_name;
+	return CreateColumnReference(schema_name, table_name, column_name);
+}
+
+static bool ColumnIsGenerated(Binding *binding, column_t index) {
+	if (binding->binding_type != BindingType::TABLE) {
+		return false;
+	}
+	auto table_binding = (TableBinding *)binding;
+	auto catalog_entry = table_binding->GetStandardEntry();
+	if (!catalog_entry) {
+		return false;
+	}
+	if (index == COLUMN_IDENTIFIER_ROW_ID) {
+		return false;
+	}
+	D_ASSERT(catalog_entry->type == CatalogType::TABLE_ENTRY);
+	auto table_entry = (TableCatalogEntry *)catalog_entry;
+	D_ASSERT(table_entry->columns.size() >= index);
+	return table_entry->columns[index].Generated();
+}
+
+unique_ptr<ParsedExpression> BindContext::CreateColumnReference(const string &schema_name, const string &table_name,
+                                                                const string &column_name) {
+	string error_message;
+	vector<string> names;
+	if (!schema_name.empty()) {
+		names.push_back(schema_name);
+	}
+	names.push_back(table_name);
+	names.push_back(column_name);
+
+	auto result = make_unique<ColumnRefExpression>(move(names));
+	auto binding = GetBinding(table_name, error_message);
+	if (!binding) {
+		return move(result);
+	}
+	auto column_index = binding->GetBindingIndex(column_name);
+	if (ColumnIsGenerated(binding, column_index)) {
+		return ExpandGeneratedColumn(table_name, column_name);
+	} else if (column_index < binding->names.size() && binding->names[column_index] != column_name) {
+		// because of case insensitivity in the binder we rename the column to the original name
+		// as it appears in the binding itself
+		result->alias = binding->names[column_index];
+	}
+	return move(result);
+}
+
+Binding *BindContext::GetCTEBinding(const string &ctename) {
+	auto match = cte_bindings.find(ctename);
+	if (match == cte_bindings.end()) {
+		return nullptr;
+	}
+	return match->second.get();
+}
+
+Binding *BindContext::GetBinding(const string &name, string &out_error) {
+	auto match = bindings.find(name);
+	if (match == bindings.end()) {
+		// alias not found in this BindContext
+		vector<string> candidates;
+		for (auto &kv : bindings) {
+			candidates.push_back(kv.first);
+		}
+		string candidate_str =
+		    StringUtil::CandidatesMessage(StringUtil::TopNLevenshtein(candidates, name), "Candidate tables");
+		out_error = StringUtil::Format("Referenced table \"%s\" not found!%s", name, candidate_str);
+		return nullptr;
+	}
+	return match->second.get();
+}
+
+BindResult BindContext::BindColumn(ColumnRefExpression &colref, idx_t depth) {
+	if (!colref.IsQualified()) {
+		throw InternalException("Could not bind alias \"%s\"!", colref.GetColumnName());
+	}
+
+	string error;
+	auto binding = GetBinding(colref.GetTableName(), error);
+	if (!binding) {
+		return BindResult(error);
+	}
+	return binding->Bind(colref, depth);
+}
+
+string BindContext::BindColumn(PositionalReferenceExpression &ref, string &table_name, string &column_name) {
+	idx_t total_columns = 0;
+	idx_t current_position = ref.index - 1;
+	for (auto &entry : bindings_list) {
+		idx_t entry_column_count = entry.second->names.size();
+		if (ref.index == 0) {
+			// this is a row id
+			table_name = entry.first;
+			column_name = "rowid";
+			return string();
+		}
+		if (current_position < entry_column_count) {
+			table_name = entry.first;
+			column_name = entry.second->names[current_position];
+			return string();
+		} else {
+			total_columns += entry_column_count;
+			current_position -= entry_column_count;
+		}
+	}
+	return StringUtil::Format("Positional reference %d out of range (total %d columns)", ref.index, total_columns);
+}
+
+BindResult BindContext::BindColumn(PositionalReferenceExpression &ref, idx_t depth) {
+	string table_name, column_name;
+
+	string error = BindColumn(ref, table_name, column_name);
+	if (!error.empty()) {
+		return BindResult(error);
+	}
+	auto column_ref = make_unique<ColumnRefExpression>(column_name, table_name);
+	return BindColumn(*column_ref, depth);
+}
+
+bool BindContext::CheckExclusionList(StarExpression &expr, Binding *binding, const string &column_name,
+                                     vector<unique_ptr<ParsedExpression>> &new_select_list,
+                                     case_insensitive_set_t &excluded_columns) {
+	if (expr.exclude_list.find(column_name) != expr.exclude_list.end()) {
+		excluded_columns.insert(column_name);
+		return true;
+	}
+	auto entry = expr.replace_list.find(column_name);
+	if (entry != expr.replace_list.end()) {
+		auto new_entry = entry->second->Copy();
+		new_entry->alias = entry->first;
+		excluded_columns.insert(entry->first);
+		new_select_list.push_back(move(new_entry));
+		return true;
+	}
+	return false;
+}
+
+void BindContext::GenerateAllColumnExpressions(StarExpression &expr,
+                                               vector<unique_ptr<ParsedExpression>> &new_select_list) {
+	if (bindings_list.empty()) {
+		throw BinderException("SELECT * expression without FROM clause!");
+	}
+	case_insensitive_set_t excluded_columns;
+	if (expr.relation_name.empty()) {
+		// SELECT * case
+		// bind all expressions of each table in-order
+		unordered_set<UsingColumnSet *> handled_using_columns;
+		for (auto &entry : bindings_list) {
+			auto binding = entry.second;
+			for (auto &column_name : binding->names) {
+				if (CheckExclusionList(expr, binding, column_name, new_select_list, excluded_columns)) {
+					continue;
+				}
+				// check if this column is a USING column
+				auto using_binding = GetUsingBinding(column_name, binding->alias);
+				if (using_binding) {
+					// it is!
+					// check if we have already emitted the using column
+					if (handled_using_columns.find(using_binding) != handled_using_columns.end()) {
+						// we have! bail out
+						continue;
+					}
+					// we have not! output the using column
+					if (using_binding->primary_binding.empty()) {
+						// no primary binding: output a coalesce
+						auto coalesce = make_unique<OperatorExpression>(ExpressionType::OPERATOR_COALESCE);
+						for (auto &child_binding : using_binding->bindings) {
+							coalesce->children.push_back(make_unique<ColumnRefExpression>(column_name, child_binding));
+						}
+						coalesce->alias = column_name;
+						new_select_list.push_back(move(coalesce));
+					} else {
+						// primary binding: output the qualified column ref
+						new_select_list.push_back(
+						    make_unique<ColumnRefExpression>(column_name, using_binding->primary_binding));
+					}
+					handled_using_columns.insert(using_binding);
+					continue;
+				}
+				new_select_list.push_back(make_unique<ColumnRefExpression>(column_name, binding->alias));
+			}
+		}
+	} else {
+		// SELECT tbl.* case
+		string error;
+		auto binding = GetBinding(expr.relation_name, error);
+		if (!binding) {
+			throw BinderException(error);
+		}
+		for (auto &column_name : binding->names) {
+			if (CheckExclusionList(expr, binding, column_name, new_select_list, excluded_columns)) {
+				continue;
+			}
+			new_select_list.push_back(make_unique<ColumnRefExpression>(column_name, binding->alias));
+		}
+	}
+	for (auto &excluded : expr.exclude_list) {
+		if (excluded_columns.find(excluded) == excluded_columns.end()) {
+			throw BinderException("Column \"%s\" in EXCLUDE list not found in %s", excluded,
+			                      expr.relation_name.empty() ? "FROM clause" : expr.relation_name.c_str());
+		}
+	}
+	for (auto &entry : expr.replace_list) {
+		if (excluded_columns.find(entry.first) == excluded_columns.end()) {
+			throw BinderException("Column \"%s\" in REPLACE list not found in %s", entry.first,
+			                      expr.relation_name.empty() ? "FROM clause" : expr.relation_name.c_str());
+		}
+	}
+}
+
+void BindContext::AddBinding(const string &alias, unique_ptr<Binding> binding) {
+	if (bindings.find(alias) != bindings.end()) {
+		throw BinderException("Duplicate alias \"%s\" in query!", alias);
+	}
+	bindings_list.emplace_back(alias, binding.get());
+	bindings[alias] = move(binding);
+}
+
+void BindContext::AddBaseTable(idx_t index, const string &alias, const vector<string> &names,
+                               const vector<LogicalType> &types, LogicalGet &get) {
+	AddBinding(alias, make_unique<TableBinding>(alias, types, names, get, index, true));
+}
+
+void BindContext::AddTableFunction(idx_t index, const string &alias, const vector<string> &names,
+                                   const vector<LogicalType> &types, LogicalGet &get) {
+	AddBinding(alias, make_unique<TableBinding>(alias, types, names, get, index));
+}
+
+static string AddColumnNameToBinding(const string &base_name, case_insensitive_set_t &current_names) {
+	idx_t index = 1;
+	string name = base_name;
+	while (current_names.find(name) != current_names.end()) {
+		name = base_name + ":" + to_string(index++);
+	}
+	current_names.insert(name);
+	return name;
+}
+
+vector<string> BindContext::AliasColumnNames(const string &table_name, const vector<string> &names,
+                                             const vector<string> &column_aliases) {
+	vector<string> result;
+	if (column_aliases.size() > names.size()) {
+		throw BinderException("table \"%s\" has %lld columns available but %lld columns specified", table_name,
+		                      names.size(), column_aliases.size());
+	}
+	case_insensitive_set_t current_names;
+	// use any provided column aliases first
+	for (idx_t i = 0; i < column_aliases.size(); i++) {
+		result.push_back(AddColumnNameToBinding(column_aliases[i], current_names));
+	}
+	// if not enough aliases were provided, use the default names for remaining columns
+	for (idx_t i = column_aliases.size(); i < names.size(); i++) {
+		result.push_back(AddColumnNameToBinding(names[i], current_names));
+	}
+	return result;
+}
+
+void BindContext::AddSubquery(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery) {
+	auto names = AliasColumnNames(alias, subquery.names, ref.column_name_alias);
+	AddGenericBinding(index, alias, names, subquery.types);
+}
+
+void BindContext::AddEntryBinding(idx_t index, const string &alias, const vector<string> &names,
+                                  const vector<LogicalType> &types, StandardEntry *entry) {
+	D_ASSERT(entry);
+	AddBinding(alias, make_unique<EntryBinding>(alias, types, names, index, *entry));
+}
+
+void BindContext::AddView(idx_t index, const string &alias, SubqueryRef &ref, BoundQueryNode &subquery,
+                          ViewCatalogEntry *view) {
+	auto names = AliasColumnNames(alias, subquery.names, ref.column_name_alias);
+	AddEntryBinding(index, alias, names, subquery.types, (StandardEntry *)view);
+}
+
+void BindContext::AddSubquery(idx_t index, const string &alias, TableFunctionRef &ref, BoundQueryNode &subquery) {
+	auto names = AliasColumnNames(alias, subquery.names, ref.column_name_alias);
+	AddGenericBinding(index, alias, names, subquery.types);
+}
+
+void BindContext::AddGenericBinding(idx_t index, const string &alias, const vector<string> &names,
+                                    const vector<LogicalType> &types) {
+	AddBinding(alias, make_unique<Binding>(BindingType::BASE, alias, types, names, index));
+}
+
+void BindContext::AddCTEBinding(idx_t index, const string &alias, const vector<string> &names,
+                                const vector<LogicalType> &types) {
+	auto binding = make_shared<Binding>(BindingType::BASE, alias, types, names, index);
+
+	if (cte_bindings.find(alias) != cte_bindings.end()) {
+		throw BinderException("Duplicate alias \"%s\" in query!", alias);
+	}
+	cte_bindings[alias] = move(binding);
+	cte_references[alias] = std::make_shared<idx_t>(0);
+}
+
+void BindContext::AddContext(BindContext other) {
+	for (auto &binding : other.bindings) {
+		if (bindings.find(binding.first) != bindings.end()) {
+			throw BinderException("Duplicate alias \"%s\" in query!", binding.first);
+		}
+		bindings[binding.first] = move(binding.second);
+	}
+	for (auto &binding : other.bindings_list) {
+		bindings_list.push_back(move(binding));
+	}
+	for (auto &entry : other.using_columns) {
+		for (auto &alias : entry.second) {
+#ifdef DEBUG
+			for (auto &other_alias : using_columns[entry.first]) {
+				for (auto &col : alias->bindings) {
+					D_ASSERT(other_alias->bindings.find(col) == other_alias->bindings.end());
+				}
+			}
+#endif
+			using_columns[entry.first].insert(alias);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void InvertPercentileFractions(unique_ptr<ParsedExpression> &fractions) {
+	D_ASSERT(fractions.get());
+	D_ASSERT(fractions->expression_class == ExpressionClass::BOUND_EXPRESSION);
+	auto &bound = (BoundExpression &)*fractions;
+
+	if (!bound.expr->IsFoldable()) {
+		return;
+	}
+
+	Value value = ExpressionExecutor::EvaluateScalar(*bound.expr);
+	if (value.type().id() == LogicalTypeId::LIST) {
+		vector<Value> values;
+		for (const auto &element_val : ListValue::GetChildren(value)) {
+			values.push_back(Value::DOUBLE(1 - element_val.GetValue<double>()));
+		}
+		bound.expr = make_unique<BoundConstantExpression>(Value::LIST(values));
+	} else {
+		bound.expr = make_unique<BoundConstantExpression>(Value::DOUBLE(1 - value.GetValue<double>()));
+	}
+}
+
+BindResult SelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFunctionCatalogEntry *func, idx_t depth) {
+	// first bind the child of the aggregate expression (if any)
+	this->bound_aggregate = true;
+	unique_ptr<Expression> bound_filter;
+	AggregateBinder aggregate_binder(binder, context);
+	string error, filter_error;
+
+	// Now we bind the filter (if any)
+	if (aggr.filter) {
+		aggregate_binder.BindChild(aggr.filter, 0, error);
+	}
+
+	// Handle ordered-set aggregates by moving the single ORDER BY expression to the front of the children.
+	//	https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE
+	bool ordered_set_agg = false;
+	bool invert_fractions = false;
+	if (aggr.order_bys && aggr.order_bys->orders.size() == 1) {
+		const auto &func_name = aggr.function_name;
+		ordered_set_agg = (func_name == "quantile_cont" || func_name == "quantile_disc" || func_name == "mode");
+
+		if (ordered_set_agg) {
+			auto &config = DBConfig::GetConfig(context);
+			const auto &order = aggr.order_bys->orders[0];
+			const auto sense = (order.type == OrderType::ORDER_DEFAULT) ? config.default_order_type : order.type;
+			invert_fractions = (sense == OrderType::DESCENDING);
+		}
+	}
+
+	for (auto &child : aggr.children) {
+		aggregate_binder.BindChild(child, 0, error);
+		// We have to invert the fractions for PERCENTILE_XXXX DESC
+		if (invert_fractions) {
+			InvertPercentileFractions(child);
+		}
+	}
+
+	// Bind the ORDER BYs, if any
+	if (aggr.order_bys && !aggr.order_bys->orders.empty()) {
+		for (auto &order : aggr.order_bys->orders) {
+			aggregate_binder.BindChild(order.expression, 0, error);
+		}
+	}
+
+	if (!error.empty()) {
+		// failed to bind child
+		if (aggregate_binder.HasBoundColumns()) {
+			for (idx_t i = 0; i < aggr.children.size(); i++) {
+				// however, we bound columns!
+				// that means this aggregation belongs to this node
+				// check if we have to resolve any errors by binding with parent binders
+				bool success = aggregate_binder.BindCorrelatedColumns(aggr.children[i]);
+				// if there is still an error after this, we could not successfully bind the aggregate
+				if (!success) {
+					throw BinderException(error);
+				}
+				auto &bound_expr = (BoundExpression &)*aggr.children[i];
+				ExtractCorrelatedExpressions(binder, *bound_expr.expr);
+			}
+			if (aggr.filter) {
+				bool success = aggregate_binder.BindCorrelatedColumns(aggr.filter);
+				// if there is still an error after this, we could not successfully bind the aggregate
+				if (!success) {
+					throw BinderException(error);
+				}
+				auto &bound_expr = (BoundExpression &)*aggr.filter;
+				ExtractCorrelatedExpressions(binder, *bound_expr.expr);
+			}
+			if (aggr.order_bys && !aggr.order_bys->orders.empty()) {
+				for (auto &order : aggr.order_bys->orders) {
+					bool success = aggregate_binder.BindCorrelatedColumns(order.expression);
+					if (!success) {
+						throw BinderException(error);
+					}
+					auto &bound_expr = (BoundExpression &)*order.expression;
+					ExtractCorrelatedExpressions(binder, *bound_expr.expr);
+				}
+			}
+		} else {
+			// we didn't bind columns, try again in children
+			return BindResult(error);
+		}
+	}
+	if (!filter_error.empty()) {
+		return BindResult(filter_error);
+	}
+
+	if (aggr.filter) {
+		auto &child = (BoundExpression &)*aggr.filter;
+		bound_filter = move(child.expr);
+	}
+	// all children bound successfully
+	// extract the children and types
+	vector<LogicalType> types;
+	vector<LogicalType> arguments;
+	vector<unique_ptr<Expression>> children;
+
+	if (ordered_set_agg) {
+		for (auto &order : aggr.order_bys->orders) {
+			auto &child = (BoundExpression &)*order.expression;
+			types.push_back(child.expr->return_type);
+			arguments.push_back(child.expr->return_type);
+			children.push_back(move(child.expr));
+		}
+		aggr.order_bys->orders.clear();
+	}
+
+	for (idx_t i = 0; i < aggr.children.size(); i++) {
+		auto &child = (BoundExpression &)*aggr.children[i];
+		types.push_back(child.expr->return_type);
+		arguments.push_back(child.expr->return_type);
+		children.push_back(move(child.expr));
+	}
+
+	// bind the aggregate
+	bool cast_parameters;
+	idx_t best_function = Function::BindFunction(func->name, func->functions, types, error, cast_parameters);
+	if (best_function == DConstants::INVALID_INDEX) {
+		throw BinderException(binder.FormatError(aggr, error));
+	}
+	// found a matching function!
+	auto &bound_function = func->functions[best_function];
+
+	// Bind any sort columns, unless the aggregate is order-insensitive
+	auto order_bys = make_unique<BoundOrderModifier>();
+	if (!aggr.order_bys->orders.empty()) {
+		auto &config = DBConfig::GetConfig(context);
+		for (auto &order : aggr.order_bys->orders) {
+			auto &order_expr = (BoundExpression &)*order.expression;
+			const auto sense = (order.type == OrderType::ORDER_DEFAULT) ? config.default_order_type : order.type;
+			const auto null_order =
+			    (order.null_order == OrderByNullType::ORDER_DEFAULT) ? config.default_null_order : order.null_order;
+			order_bys->orders.emplace_back(BoundOrderByNode(sense, null_order, move(order_expr.expr)));
+		}
+	}
+
+	auto aggregate = AggregateFunction::BindAggregateFunction(
+	    context, bound_function, move(children), move(bound_filter), aggr.distinct, move(order_bys), cast_parameters);
+	if (aggr.export_state) {
+		aggregate = ExportAggregateFunction::Bind(move(aggregate));
+	}
+
+	// check for all the aggregates if this aggregate already exists
+	idx_t aggr_index;
+	auto entry = node.aggregate_map.find(aggregate.get());
+	if (entry == node.aggregate_map.end()) {
+		// new aggregate: insert into aggregate list
+		aggr_index = node.aggregates.size();
+		node.aggregate_map.insert(make_pair(aggregate.get(), aggr_index));
+		node.aggregates.push_back(move(aggregate));
+	} else {
+		// duplicate aggregate: simplify refer to this aggregate
+		aggr_index = entry->second;
+	}
+
+	// now create a column reference referring to the aggregate
+	auto colref = make_unique<BoundColumnRefExpression>(
+	    aggr.alias.empty() ? node.aggregates[aggr_index]->ToString() : aggr.alias,
+	    node.aggregates[aggr_index]->return_type, ColumnBinding(node.aggregate_index, aggr_index), depth);
+	// move the aggregate expression into the set of bound aggregates
+	return BindResult(move(colref));
+}
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+BindResult ExpressionBinder::BindExpression(BetweenExpression &expr, idx_t depth) {
+	// first try to bind the children of the case expression
+	string error;
+	BindChild(expr.input, depth, error);
+	BindChild(expr.lower, depth, error);
+	BindChild(expr.upper, depth, error);
+	if (!error.empty()) {
+		return BindResult(error);
+	}
+	// the children have been successfully resolved
+	auto &input = (BoundExpression &)*expr.input;
+	auto &lower = (BoundExpression &)*expr.lower;
+	auto &upper = (BoundExpression &)*expr.upper;
+
+	auto input_sql_type = input.expr->return_type;
+	auto lower_sql_type = lower.expr->return_type;
+	auto upper_sql_type = upper.expr->return_type;
+
+	// cast the input types to the same type
+	// now obtain the result type of the input types
+	auto input_type = BoundComparisonExpression::BindComparison(input_sql_type, lower_sql_type);
+	input_type = BoundComparisonExpression::BindComparison(input_type, upper_sql_type);
+	// add casts (if necessary)
+	input.expr = BoundCastExpression::AddCastToType(move(input.expr), input_type);
+	lower.expr = BoundCastExpression::AddCastToType(move(lower.expr), input_type);
+	upper.expr = BoundCastExpression::AddCastToType(move(upper.expr), input_type);
+	if (input_type.id() == LogicalTypeId::VARCHAR) {
+		// handle collation
+		auto collation = StringType::GetCollation(input_type);
+		input.expr = PushCollation(context, move(input.expr), collation, false);
+		lower.expr = PushCollation(context, move(lower.expr), collation, false);
+		upper.expr = PushCollation(context, move(upper.expr), collation, false);
+	}
+	if (!input.expr->HasSideEffects() && !input.expr->HasParameter() && !input.expr->HasSubquery()) {
+		// the expression does not have side effects and can be copied: create two comparisons
+		// the reason we do this is that individual comparisons are easier to handle in optimizers
+		// if both comparisons remain they will be folded together again into a single BETWEEN in the optimizer
+		auto left_compare = make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_GREATERTHANOREQUALTO,
+		                                                           input.expr->Copy(), move(lower.expr));
+		auto right_compare = make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_LESSTHANOREQUALTO,
+		                                                            move(input.expr), move(upper.expr));
+		return BindResult(make_unique<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND, move(left_compare),
+		                                                          move(right_compare)));
+	} else {
+		// expression has side effects: we cannot duplicate it
+		// create a bound_between directly
+		return BindResult(
+		    make_unique<BoundBetweenExpression>(move(input.expr), move(lower.expr), move(upper.expr), true, true));
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+BindResult ExpressionBinder::BindExpression(CaseExpression &expr, idx_t depth) {
+	// first try to bind the children of the case expression
+	string error;
+	for (auto &check : expr.case_checks) {
+		BindChild(check.when_expr, depth, error);
+		BindChild(check.then_expr, depth, error);
+	}
+	BindChild(expr.else_expr, depth, error);
+	if (!error.empty()) {
+		return BindResult(error);
+	}
+	// the children have been successfully resolved
+	// figure out the result type of the CASE expression
+	auto return_type = ((BoundExpression &)*expr.else_expr).expr->return_type;
+	for (auto &check : expr.case_checks) {
+		auto &then_expr = (BoundExpression &)*check.then_expr;
+		return_type = LogicalType::MaxLogicalType(return_type, then_expr.expr->return_type);
+	}
+
+	// bind all the individual components of the CASE statement
+	auto result = make_unique<BoundCaseExpression>(return_type);
+	for (idx_t i = 0; i < expr.case_checks.size(); i++) {
+		auto &check = expr.case_checks[i];
+		auto &when_expr = (BoundExpression &)*check.when_expr;
+		auto &then_expr = (BoundExpression &)*check.then_expr;
+		BoundCaseCheck result_check;
+		result_check.when_expr = BoundCastExpression::AddCastToType(move(when_expr.expr), LogicalType::BOOLEAN);
+		result_check.then_expr = BoundCastExpression::AddCastToType(move(then_expr.expr), return_type);
+		result->case_checks.push_back(move(result_check));
+	}
+	auto &else_expr = (BoundExpression &)*expr.else_expr;
+	result->else_expr = BoundCastExpression::AddCastToType(move(else_expr.expr), return_type);
+	return BindResult(move(result));
+}
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+BindResult ExpressionBinder::BindExpression(CastExpression &expr, idx_t depth) {
+	// first try to bind the child of the cast expression
+	string error = Bind(&expr.child, depth);
+	if (!error.empty()) {
+		return BindResult(error);
+	}
+	// FIXME: We can also implement 'hello'::schema.custom_type; and pass by the schema down here.
+	// Right now just considering its DEFAULT_SCHEMA always
+	Binder::BindLogicalType(context, expr.cast_type, DEFAULT_SCHEMA);
+	// the children have been successfully resolved
+	auto &child = (BoundExpression &)*expr.child;
+	if (expr.try_cast) {
+		if (child.expr->return_type == expr.cast_type) {
+			// no cast required: type matches
+			return BindResult(move(child.expr));
+		}
+		child.expr = make_unique<BoundCastExpression>(move(child.expr), expr.cast_type, true);
+	} else {
+		if (child.expr->type == ExpressionType::VALUE_PARAMETER) {
+			auto &parameter = (BoundParameterExpression &)*child.expr;
+			// parameter: move types into the parameter expression itself
+			parameter.return_type = expr.cast_type;
+		} else {
+			// otherwise add a cast to the target type
+			child.expr = BoundCastExpression::AddCastToType(move(child.expr), expr.cast_type);
+		}
+	}
+	return BindResult(move(child.expr));
+}
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+BindResult ExpressionBinder::BindExpression(CollateExpression &expr, idx_t depth) {
+	// first try to bind the child of the cast expression
+	string error = Bind(&expr.child, depth);
+	if (!error.empty()) {
+		return BindResult(error);
+	}
+	auto &child = (BoundExpression &)*expr.child;
+	if (child.expr->return_type.id() != LogicalTypeId::VARCHAR) {
+		throw BinderException("collations are only supported for type varchar");
+	}
+	child.expr->return_type = LogicalType::VARCHAR_COLLATION(expr.collation);
+	return BindResult(move(child.expr));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<ParsedExpression> ExpressionBinder::QualifyColumnName(const string &column_name, string &error_message) {
+	auto using_binding = binder.bind_context.GetUsingBinding(column_name);
+	if (using_binding) {
+		// we are referencing a USING column
+		// check if we can refer to one of the base columns directly
+		unique_ptr<Expression> expression;
+		if (!using_binding->primary_binding.empty()) {
+			// we can! just assign the table name and re-bind
+			return make_unique<ColumnRefExpression>(column_name, using_binding->primary_binding);
+		} else {
+			// // we cannot! we need to bind this as a coalesce between all the relevant columns
+			auto coalesce = make_unique<OperatorExpression>(ExpressionType::OPERATOR_COALESCE);
+			for (auto &entry : using_binding->bindings) {
+				coalesce->children.push_back(make_unique<ColumnRefExpression>(column_name, entry));
+			}
+			return move(coalesce);
+		}
+	}
+	// no table name: find a binding that contains this
+	if (binder.macro_binding != nullptr && binder.macro_binding->HasMatchingBinding(column_name)) {
+		// priority to macro parameter bindings TODO: throw a warning when this name conflicts
+		D_ASSERT(!binder.macro_binding->alias.empty());
+		return make_unique<ColumnRefExpression>(column_name, binder.macro_binding->alias);
+	} else {
+		// see if it's a column
+		string table_name = binder.bind_context.GetMatchingBinding(column_name);
+		if (!table_name.empty()) {
+			return binder.bind_context.CreateColumnReference(table_name, column_name);
+		}
+		// it's not, find candidates and error
+		auto similar_bindings = binder.bind_context.GetSimilarBindings(column_name);
+		string candidate_str = StringUtil::CandidatesMessage(similar_bindings, "Candidate bindings");
+		error_message =
+		    StringUtil::Format("Referenced column \"%s\" not found in FROM clause!%s", column_name, candidate_str);
+		return nullptr;
+	}
+}
+
+void ExpressionBinder::QualifyColumnNames(unique_ptr<ParsedExpression> &expr) {
+	switch (expr->type) {
+	case ExpressionType::COLUMN_REF: {
+		auto &colref = (ColumnRefExpression &)*expr;
+		string error_message;
+		auto new_expr = QualifyColumnName(colref, error_message);
+		if (new_expr) {
+			if (!expr->alias.empty()) {
+				new_expr->alias = expr->alias;
+			}
+			expr = move(new_expr);
+		}
+		break;
+	}
+	case ExpressionType::POSITIONAL_REFERENCE: {
+		auto &ref = (PositionalReferenceExpression &)*expr;
+		if (ref.alias.empty()) {
+			string table_name, column_name;
+			auto error = binder.bind_context.BindColumn(ref, table_name, column_name);
+			if (error.empty()) {
+				ref.alias = column_name;
+			}
+		}
+		break;
+	}
+	default:
+		break;
+	}
+	ParsedExpressionIterator::EnumerateChildren(
+	    *expr, [&](unique_ptr<ParsedExpression> &child) { QualifyColumnNames(child); });
+}
+
+void ExpressionBinder::QualifyColumnNames(Binder &binder, unique_ptr<ParsedExpression> &expr) {
+	WhereBinder where_binder(binder, binder.context);
+	where_binder.QualifyColumnNames(expr);
+}
+
+unique_ptr<ParsedExpression> ExpressionBinder::CreateStructExtract(unique_ptr<ParsedExpression> base,
+                                                                   string field_name) {
+	vector<unique_ptr<ParsedExpression>> children;
+	children.push_back(move(base));
+	children.push_back(make_unique_base<ParsedExpression, ConstantExpression>(Value(move(field_name))));
+	auto extract_fun = make_unique<OperatorExpression>(ExpressionType::STRUCT_EXTRACT, move(children));
+	return move(extract_fun);
+}
+
+unique_ptr<ParsedExpression> ExpressionBinder::CreateStructPack(ColumnRefExpression &colref) {
+	D_ASSERT(colref.column_names.size() <= 2);
+	string error_message;
+	auto &table_name = colref.column_names.back();
+	auto binding = binder.bind_context.GetBinding(table_name, error_message);
+	if (!binding) {
+		return nullptr;
+	}
+	if (colref.column_names.size() == 2) {
+		// "schema_name.table_name"
+		auto catalog_entry = binding->GetStandardEntry();
+		if (!catalog_entry) {
+			return nullptr;
+		}
+		auto &schema_name = colref.column_names[0];
+		if (catalog_entry->schema->name != schema_name || catalog_entry->name != table_name) {
+			return nullptr;
+		}
+	}
+	// We found the table, now create the struct_pack expression
+	vector<unique_ptr<ParsedExpression>> child_exprs;
+	for (const auto &column_name : binding->names) {
+		child_exprs.push_back(make_unique<ColumnRefExpression>(column_name, table_name));
+	}
+	return make_unique<FunctionExpression>("struct_pack", move(child_exprs));
+}
+
+unique_ptr<ParsedExpression> ExpressionBinder::QualifyColumnName(ColumnRefExpression &colref, string &error_message) {
+	idx_t column_parts = colref.column_names.size();
+	// column names can have an arbitrary amount of dots
+	// here is how the resolution works:
+	if (column_parts == 1) {
+		// no dots (i.e. "part1")
+		// -> part1 refers to a column
+		// check if we can qualify the column name with the table name
+		auto qualified_colref = QualifyColumnName(colref.GetColumnName(), error_message);
+		if (qualified_colref) {
+			// we could: return it
+			return qualified_colref;
+		}
+		// we could not! Try creating an implicit struct_pack
+		return CreateStructPack(colref);
+	} else if (column_parts == 2) {
+		// one dot (i.e. "part1.part2")
+		// EITHER:
+		// -> part1 is a table, part2 is a column
+		// -> part1 is a column, part2 is a property of that column (i.e. struct_extract)
+
+		// first check if part1 is a table, and part2 is a standard column
+		if (binder.HasMatchingBinding(colref.column_names[0], colref.column_names[1], error_message)) {
+			// it is! return the colref directly
+			return binder.bind_context.CreateColumnReference(colref.column_names[0], colref.column_names[1]);
+		} else {
+			// otherwise check if we can turn this into a struct extract
+			auto new_colref = make_unique<ColumnRefExpression>(colref.column_names[0]);
+			string other_error;
+			auto qualified_colref = QualifyColumnName(colref.column_names[0], other_error);
+			if (qualified_colref) {
+				// we could: create a struct extract
+				return CreateStructExtract(move(qualified_colref), colref.column_names[1]);
+			}
+			// we could not! Try creating an implicit struct_pack
+			return CreateStructPack(colref);
+		}
+	} else {
+		// two or more dots (i.e. "part1.part2.part3.part4...")
+		// -> part1 is a schema, part2 is a table, part3 is a column name, part4 and beyond are struct fields
+		// -> part1 is a table, part2 is a column name, part3 and beyond are struct fields
+		// -> part1 is a column, part2 and beyond are struct fields
+
+		// we always prefer the most top-level view
+		// i.e. in case of multiple resolution options, we resolve in order:
+		// -> 1. resolve "part1" as a schema
+		// -> 2. resolve "part1" as a table
+		// -> 3. resolve "part1" as a column
+
+		unique_ptr<ParsedExpression> result_expr;
+		idx_t struct_extract_start;
+		// first check if part1 is a schema
+		if (binder.HasMatchingBinding(colref.column_names[0], colref.column_names[1], colref.column_names[2],
+		                              error_message)) {
+			// it is! the column reference is "schema.table.column"
+			// any additional fields are turned into struct_extract calls
+			result_expr = binder.bind_context.CreateColumnReference(colref.column_names[0], colref.column_names[1],
+			                                                        colref.column_names[2]);
+			struct_extract_start = 3;
+		} else if (binder.HasMatchingBinding(colref.column_names[0], colref.column_names[1], error_message)) {
+			// part1 is a table
+			// the column reference is "table.column"
+			// any additional fields are turned into struct_extract calls
+			result_expr = binder.bind_context.CreateColumnReference(colref.column_names[0], colref.column_names[1]);
+			struct_extract_start = 2;
+		} else {
+			// part1 could be a column
+			string col_error;
+			result_expr = QualifyColumnName(colref.column_names[0], col_error);
+			if (!result_expr) {
+				// it is not! return the error
+				return nullptr;
+			}
+			// it is! add the struct extract calls
+			struct_extract_start = 1;
+		}
+		for (idx_t i = struct_extract_start; i < colref.column_names.size(); i++) {
+			result_expr = CreateStructExtract(move(result_expr), colref.column_names[i]);
+		}
+		return result_expr;
+	}
+}
+
+BindResult ExpressionBinder::BindExpression(ColumnRefExpression &colref_p, idx_t depth) {
+	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES) {
+		return BindResult(make_unique<BoundConstantExpression>(Value(LogicalType::SQLNULL)));
+	}
+	string error_message;
+	auto expr = QualifyColumnName(colref_p, error_message);
+	if (!expr) {
+		return BindResult(binder.FormatError(colref_p, error_message));
+	}
+	//! Generated column returns generated expression
+	if (expr->type != ExpressionType::COLUMN_REF) {
+		return BindExpression(&expr, depth);
+	}
+	auto &colref = (ColumnRefExpression &)*expr;
+	D_ASSERT(colref.IsQualified());
+	auto &table_name = colref.GetTableName();
+
+	// individual column reference
+	// resolve to either a base table or a subquery expression
+	// if it was a macro parameter, let macro_binding bind it to the argument
+	BindResult result;
+	if (binder.macro_binding && table_name == binder.macro_binding->alias) {
+		result = binder.macro_binding->Bind(colref, depth);
+	} else {
+		result = binder.bind_context.BindColumn(colref, depth);
+	}
+	if (!result.HasError()) {
+		BoundColumnReferenceInfo ref;
+		ref.name = colref.column_names.back();
+		ref.query_location = colref.query_location;
+		bound_columns.push_back(move(ref));
+	} else {
+		result.error = binder.FormatError(colref_p, result.error);
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<Expression> ExpressionBinder::PushCollation(ClientContext &context, unique_ptr<Expression> source,
+                                                       const string &collation_p, bool equality_only) {
+	// replace default collation with system collation
+	string collation;
+	if (collation_p.empty()) {
+		collation = DBConfig::GetConfig(context).collation;
+	} else {
+		collation = collation_p;
+	}
+	collation = StringUtil::Lower(collation);
+	// bind the collation
+	if (collation.empty() || collation == "binary" || collation == "c" || collation == "posix") {
+		// binary collation: just skip
+		return source;
+	}
+	auto &catalog = Catalog::GetCatalog(context);
+	auto splits = StringUtil::Split(StringUtil::Lower(collation), ".");
+	vector<CollateCatalogEntry *> entries;
+	for (auto &collation_argument : splits) {
+		auto collation_entry = catalog.GetEntry<CollateCatalogEntry>(context, DEFAULT_SCHEMA, collation_argument);
+		if (collation_entry->combinable) {
+			entries.insert(entries.begin(), collation_entry);
+		} else {
+			if (!entries.empty() && !entries.back()->combinable) {
+				throw BinderException("Cannot combine collation types \"%s\" and \"%s\"", entries.back()->name,
+				                      collation_entry->name);
+			}
+			entries.push_back(collation_entry);
+		}
+	}
+	for (auto &collation_entry : entries) {
+		if (equality_only && collation_entry->not_required_for_equality) {
+			continue;
+		}
+		vector<unique_ptr<Expression>> children;
+		children.push_back(move(source));
+		auto function = ScalarFunction::BindScalarFunction(context, collation_entry->function, move(children));
+		source = move(function);
+	}
+	return source;
+}
+
+void ExpressionBinder::TestCollation(ClientContext &context, const string &collation) {
+	PushCollation(context, make_unique<BoundConstantExpression>(Value("")), collation);
+}
+
+LogicalType BoundComparisonExpression::BindComparison(LogicalType left_type, LogicalType right_type) {
+	auto result_type = LogicalType::MaxLogicalType(left_type, right_type);
+	switch (result_type.id()) {
+	case LogicalTypeId::DECIMAL: {
+		// result is a decimal: we need the maximum width and the maximum scale over width
+		vector<LogicalType> argument_types = {left_type, right_type};
+		uint8_t max_width = 0, max_scale = 0, max_width_over_scale = 0;
+		for (idx_t i = 0; i < argument_types.size(); i++) {
+			uint8_t width, scale;
+			auto can_convert = argument_types[i].GetDecimalProperties(width, scale);
+			if (!can_convert) {
+				return result_type;
+			}
+			max_width = MaxValue<uint8_t>(width, max_width);
+			max_scale = MaxValue<uint8_t>(scale, max_scale);
+			max_width_over_scale = MaxValue<uint8_t>(width - scale, max_width_over_scale);
+		}
+		max_width = MaxValue<uint8_t>(max_scale + max_width_over_scale, max_width);
+		if (max_width > Decimal::MAX_WIDTH_DECIMAL) {
+			// target width does not fit in decimal: truncate the scale (if possible) to try and make it fit
+			max_width = Decimal::MAX_WIDTH_DECIMAL;
+		}
+		return LogicalType::DECIMAL(max_width, max_scale);
+	}
+	case LogicalTypeId::VARCHAR:
+		// for comparison with strings, we prefer to bind to the numeric types
+		if (left_type.IsNumeric() || left_type.id() == LogicalTypeId::BOOLEAN) {
+			return left_type;
+		} else if (right_type.IsNumeric() || right_type.id() == LogicalTypeId::BOOLEAN) {
+			return right_type;
+		} else {
+			// else: check if collations are compatible
+			auto left_collation = StringType::GetCollation(left_type);
+			auto right_collation = StringType::GetCollation(right_type);
+			if (!left_collation.empty() && !right_collation.empty() && left_collation != right_collation) {
+				throw BinderException("Cannot combine types with different collation!");
+			}
+		}
+		return result_type;
+	default:
+		return result_type;
+	}
+}
+
+BindResult ExpressionBinder::BindExpression(ComparisonExpression &expr, idx_t depth) {
+	// first try to bind the children of the case expression
+	string error;
+	BindChild(expr.left, depth, error);
+	BindChild(expr.right, depth, error);
+	if (!error.empty()) {
+		return BindResult(error);
+	}
+	// the children have been successfully resolved
+	auto &left = (BoundExpression &)*expr.left;
+	auto &right = (BoundExpression &)*expr.right;
+	auto left_sql_type = left.expr->return_type;
+	auto right_sql_type = right.expr->return_type;
+	// cast the input types to the same type
+	// now obtain the result type of the input types
+	auto input_type = BoundComparisonExpression::BindComparison(left_sql_type, right_sql_type);
+	// add casts (if necessary)
+	left.expr = BoundCastExpression::AddCastToType(move(left.expr), input_type, input_type.id() == LogicalTypeId::ENUM);
+	right.expr =
+	    BoundCastExpression::AddCastToType(move(right.expr), input_type, input_type.id() == LogicalTypeId::ENUM);
+
+	if (input_type.id() == LogicalTypeId::VARCHAR) {
+		// handle collation
+		auto collation = StringType::GetCollation(input_type);
+		left.expr = PushCollation(context, move(left.expr), collation, expr.type == ExpressionType::COMPARE_EQUAL);
+		right.expr = PushCollation(context, move(right.expr), collation, expr.type == ExpressionType::COMPARE_EQUAL);
+	}
+	// now create the bound comparison expression
+	return BindResult(make_unique<BoundComparisonExpression>(expr.type, move(left.expr), move(right.expr)));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+BindResult ExpressionBinder::BindExpression(ConjunctionExpression &expr, idx_t depth) {
+	// first try to bind the children of the case expression
+	string error;
+	for (idx_t i = 0; i < expr.children.size(); i++) {
+		BindChild(expr.children[i], depth, error);
+	}
+	if (!error.empty()) {
+		return BindResult(error);
+	}
+	// the children have been successfully resolved
+	// cast the input types to boolean (if necessary)
+	// and construct the bound conjunction expression
+	auto result = make_unique<BoundConjunctionExpression>(expr.type);
+	for (auto &child_expr : expr.children) {
+		auto &child = (BoundExpression &)*child_expr;
+		result->children.push_back(BoundCastExpression::AddCastToType(move(child.expr), LogicalType::BOOLEAN));
+	}
+	// now create the bound conjunction expression
+	return BindResult(move(result));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+BindResult ExpressionBinder::BindExpression(ConstantExpression &expr, idx_t depth) {
+	return BindResult(make_unique<BoundConstantExpression>(expr.value));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+BindResult ExpressionBinder::BindExpression(FunctionExpression &function, idx_t depth,
+                                            unique_ptr<ParsedExpression> *expr_ptr) {
+	// lookup the function in the catalog
+	QueryErrorContext error_context(binder.root_statement, function.query_location);
+
+	if (function.function_name == "unnest" || function.function_name == "unlist") {
+		// special case, not in catalog
+		// TODO make sure someone does not create such a function OR
+		// have unnest live in catalog, too
+		return BindUnnest(function, depth);
+	}
+	auto &catalog = Catalog::GetCatalog(context);
+	auto func = catalog.GetEntry(context, CatalogType::SCALAR_FUNCTION_ENTRY, function.schema, function.function_name,
+	                             false, error_context);
+	switch (func->type) {
+	case CatalogType::SCALAR_FUNCTION_ENTRY:
+		// scalar function
+		return BindFunction(function, (ScalarFunctionCatalogEntry *)func, depth);
+	case CatalogType::MACRO_ENTRY:
+		// macro function
+		return BindMacro(function, (ScalarMacroCatalogEntry *)func, depth, expr_ptr);
+	default:
+		// aggregate function
+		return BindAggregate(function, (AggregateFunctionCatalogEntry *)func, depth);
+	}
+}
+
+BindResult ExpressionBinder::BindFunction(FunctionExpression &function, ScalarFunctionCatalogEntry *func, idx_t depth) {
+	// bind the children of the function expression
+	string error;
+	for (idx_t i = 0; i < function.children.size(); i++) {
+		BindChild(function.children[i], depth, error);
+	}
+	if (!error.empty()) {
+		return BindResult(error);
+	}
+	if (binder.GetBindingMode() == BindingMode::EXTRACT_NAMES) {
+		return BindResult(make_unique<BoundConstantExpression>(Value(LogicalType::SQLNULL)));
+	}
+
+	// all children bound successfully
+	// extract the children and types
+	vector<unique_ptr<Expression>> children;
+	for (idx_t i = 0; i < function.children.size(); i++) {
+		auto &child = (BoundExpression &)*function.children[i];
+		D_ASSERT(child.expr);
+		children.push_back(move(child.expr));
+	}
+	unique_ptr<Expression> result =
+	    ScalarFunction::BindScalarFunction(context, *func, move(children), error, function.is_operator);
+	if (!result) {
+		throw BinderException(binder.FormatError(function, error));
+	}
+	return BindResult(move(result));
+}
+
+BindResult ExpressionBinder::BindAggregate(FunctionExpression &expr, AggregateFunctionCatalogEntry *function,
+                                           idx_t depth) {
+	return BindResult(binder.FormatError(expr, UnsupportedAggregateMessage()));
+}
+
+BindResult ExpressionBinder::BindUnnest(FunctionExpression &expr, idx_t depth) {
+	return BindResult(binder.FormatError(expr, UnsupportedUnnestMessage()));
+}
+
+string ExpressionBinder::UnsupportedAggregateMessage() {
+	return "Aggregate functions are not supported here";
+}
+
+string ExpressionBinder::UnsupportedUnnestMessage() {
+	return "UNNEST not supported here";
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+// static string ExtractColumnFromLambda(ParsedExpression &expr) {
+//	if (expr.type != ExpressionType::COLUMN_REF) {
+//		throw ParserException("Lambda parameter must be a column name");
+//	}
+//	auto &colref = (ColumnRefExpression &)expr;
+//	if (colref.IsQualified()) {
+//		throw ParserException("Lambda parameter must be an unqualified name (e.g. 'x', not 'a.x')");
+//	}
+//	return colref.column_names[0];
+// }
+
+BindResult ExpressionBinder::BindExpression(LambdaExpression &expr, idx_t depth) {
+	string error;
+
+	// FIXME: decide from the context whether this is actually a LambdaExpression
+	//  If it is, bind it as a lambda here
+	// // set up the lambda capture
+	// FIXME: need to get the type from the list for binding
+	// lambda_capture = expr.capture_name;
+	// // bind the child
+	// BindChild(expr.expression, depth, error);
+	// // clear the lambda capture
+	// lambda_capture = "";
+	// if (!error.empty()) {
+	// 	return BindResult(error);
+	// }
+	// expr.Print();
+	OperatorExpression arrow_expr(ExpressionType::ARROW, move(expr.lhs), move(expr.rhs));
+	return ExpressionBinder::BindExpression(arrow_expr, depth);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+void ExpressionBinder::ReplaceMacroParametersRecursive(unique_ptr<ParsedExpression> &expr) {
+	switch (expr->GetExpressionClass()) {
+	case ExpressionClass::COLUMN_REF: {
+		// if expr is a parameter, replace it with its argument
+		auto &colref = (ColumnRefExpression &)*expr;
+		bool bind_macro_parameter = false;
+		if (colref.IsQualified()) {
+			bind_macro_parameter = colref.GetTableName() == MacroBinding::MACRO_NAME;
+		} else {
+			bind_macro_parameter = macro_binding->HasMatchingBinding(colref.GetColumnName());
+		}
+		if (bind_macro_parameter) {
+			D_ASSERT(macro_binding->HasMatchingBinding(colref.GetColumnName()));
+			expr = macro_binding->ParamToArg(colref);
+		}
+		return;
+	}
+	case ExpressionClass::SUBQUERY: {
+		// replacing parameters within a subquery is slightly different
+		auto &sq = ((SubqueryExpression &)*expr).subquery;
+		ParsedExpressionIterator::EnumerateQueryNodeChildren(
+		    *sq->node, [&](unique_ptr<ParsedExpression> &child) { ReplaceMacroParametersRecursive(child); });
+		break;
+	}
+	default: // fall through
+		break;
+	}
+	// unfold child expressions
+	ParsedExpressionIterator::EnumerateChildren(
+	    *expr, [&](unique_ptr<ParsedExpression> &child) { ReplaceMacroParametersRecursive(child); });
+}
+
+BindResult ExpressionBinder::BindMacro(FunctionExpression &function, ScalarMacroCatalogEntry *macro_func, idx_t depth,
+                                       unique_ptr<ParsedExpression> *expr) {
+
+	// recast function so we can access the scalar member function->expression
+	auto &macro_def = (ScalarMacroFunction &)*macro_func->function;
+
+	// validate the arguments and separate positional and default arguments
+	vector<unique_ptr<ParsedExpression>> positionals;
+	unordered_map<string, unique_ptr<ParsedExpression>> defaults;
+
+	string error =
+	    MacroFunction::ValidateArguments(*macro_func->function, macro_func->name, function, positionals, defaults);
+	if (!error.empty()) {
+		return BindResult(binder.FormatError(*expr->get(), error));
+	}
+
+	// create a MacroBinding to bind this macro's parameters to its arguments
+	vector<LogicalType> types;
+	vector<string> names;
+	// positional parameters
+	for (idx_t i = 0; i < macro_def.parameters.size(); i++) {
+		types.emplace_back(LogicalType::SQLNULL);
+		auto &param = (ColumnRefExpression &)*macro_def.parameters[i];
+		names.push_back(param.GetColumnName());
+	}
+	// default parameters
+	for (auto it = macro_def.default_parameters.begin(); it != macro_def.default_parameters.end(); it++) {
+		types.emplace_back(LogicalType::SQLNULL);
+		names.push_back(it->first);
+		// now push the defaults into the positionals
+		positionals.push_back(move(defaults[it->first]));
+	}
+	auto new_macro_binding = make_unique<MacroBinding>(types, names, macro_func->name);
+	new_macro_binding->arguments = move(positionals);
+	macro_binding = new_macro_binding.get();
+
+	// replace current expression with stored macro expression, and replace params
+	*expr = macro_def.expression->Copy();
+	ReplaceMacroParametersRecursive(*expr);
+
+	// bind the unfolded macro
+	return BindExpression(expr, depth);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+static LogicalType ResolveNotType(OperatorExpression &op, vector<BoundExpression *> &children) {
+	// NOT expression, cast child to BOOLEAN
+	D_ASSERT(children.size() == 1);
+	children[0]->expr = BoundCastExpression::AddCastToType(move(children[0]->expr), LogicalType::BOOLEAN);
+	return LogicalType(LogicalTypeId::BOOLEAN);
+}
+
+static LogicalType ResolveInType(OperatorExpression &op, vector<BoundExpression *> &children) {
+	if (children.empty()) {
+		throw InternalException("IN requires at least a single child node");
+	}
+	// get the maximum type from the children
+	LogicalType max_type = children[0]->expr->return_type;
+	for (idx_t i = 1; i < children.size(); i++) {
+		max_type = LogicalType::MaxLogicalType(max_type, children[i]->expr->return_type);
+	}
+
+	// cast all children to the same type
+	for (idx_t i = 0; i < children.size(); i++) {
+		children[i]->expr = BoundCastExpression::AddCastToType(move(children[i]->expr), max_type);
+	}
+	// (NOT) IN always returns a boolean
+	return LogicalType::BOOLEAN;
+}
+
+static LogicalType ResolveOperatorType(OperatorExpression &op, vector<BoundExpression *> &children) {
+	switch (op.type) {
+	case ExpressionType::OPERATOR_IS_NULL:
+	case ExpressionType::OPERATOR_IS_NOT_NULL:
+		// IS (NOT) NULL always returns a boolean, and does not cast its children
+		return LogicalType::BOOLEAN;
+	case ExpressionType::COMPARE_IN:
+	case ExpressionType::COMPARE_NOT_IN:
+		return ResolveInType(op, children);
+	case ExpressionType::OPERATOR_COALESCE: {
+		ResolveInType(op, children);
+		return children[0]->expr->return_type;
+	}
+	case ExpressionType::OPERATOR_NOT:
+		return ResolveNotType(op, children);
+	default:
+		throw InternalException("Unrecognized expression type for ResolveOperatorType");
+	}
+}
+
+BindResult ExpressionBinder::BindGroupingFunction(OperatorExpression &op, idx_t depth) {
+	return BindResult("GROUPING function is not supported here");
+}
+
+BindResult ExpressionBinder::BindExpression(OperatorExpression &op, idx_t depth) {
+	if (op.type == ExpressionType::GROUPING_FUNCTION) {
+		return BindGroupingFunction(op, depth);
+	}
+	// bind the children of the operator expression
+	string error;
+	for (idx_t i = 0; i < op.children.size(); i++) {
+		BindChild(op.children[i], depth, error);
+	}
+	if (!error.empty()) {
+		return BindResult(error);
+	}
+	// all children bound successfully
+	string function_name;
+	switch (op.type) {
+	case ExpressionType::ARRAY_EXTRACT: {
+		D_ASSERT(op.children[0]->expression_class == ExpressionClass::BOUND_EXPRESSION);
+		auto &b_exp = (BoundExpression &)*op.children[0];
+		if (b_exp.expr->return_type.id() == LogicalTypeId::MAP) {
+			function_name = "map_extract";
+		} else {
+			function_name = "array_extract";
+		}
+		break;
+	}
+	case ExpressionType::ARRAY_SLICE:
+		function_name = "array_slice";
+		break;
+	case ExpressionType::STRUCT_EXTRACT: {
+		D_ASSERT(op.children.size() == 2);
+		D_ASSERT(op.children[0]->expression_class == ExpressionClass::BOUND_EXPRESSION);
+		D_ASSERT(op.children[1]->expression_class == ExpressionClass::BOUND_EXPRESSION);
+		auto &extract_exp = (BoundExpression &)*op.children[0];
+		auto &name_exp = (BoundExpression &)*op.children[1];
+		if (extract_exp.expr->return_type.id() != LogicalTypeId::STRUCT &&
+		    extract_exp.expr->return_type.id() != LogicalTypeId::SQLNULL) {
+			return BindResult(
+			    StringUtil::Format("Cannot extract field %s from expression \"%s\" because it is not a struct",
+			                       name_exp.ToString(), extract_exp.ToString()));
+		}
+		function_name = "struct_extract";
+		break;
+	}
+	case ExpressionType::ARRAY_CONSTRUCTOR:
+		function_name = "list_value";
+		break;
+	case ExpressionType::ARROW:
+		function_name = "json_extract";
+		break;
+	default:
+		break;
+	}
+	if (!function_name.empty()) {
+		auto function = make_unique<FunctionExpression>(function_name, move(op.children));
+		return BindExpression(*function, depth, nullptr);
+	}
+
+	vector<BoundExpression *> children;
+	for (idx_t i = 0; i < op.children.size(); i++) {
+		D_ASSERT(op.children[i]->expression_class == ExpressionClass::BOUND_EXPRESSION);
+		children.push_back((BoundExpression *)op.children[i].get());
+	}
+	// now resolve the types
+	LogicalType result_type = ResolveOperatorType(op, children);
+	if (op.type == ExpressionType::OPERATOR_COALESCE) {
+		if (children.empty()) {
+			throw BinderException("COALESCE needs at least one child");
+		}
+		if (children.size() == 1) {
+			return BindResult(move(children[0]->expr));
+		}
+	}
+
+	auto result = make_unique<BoundOperatorExpression>(op.type, result_type);
+	for (auto &child : children) {
+		result->children.push_back(move(child->expr));
+	}
+	return BindResult(move(result));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+BindResult ExpressionBinder::BindExpression(ParameterExpression &expr, idx_t depth) {
+	D_ASSERT(expr.parameter_nr > 0);
+	auto bound_parameter = make_unique<BoundParameterExpression>(expr.parameter_nr);
+	if (!binder.parameters) {
+		throw std::runtime_error("Unexpected prepared parameter. This type of statement can't be prepared!");
+	}
+	binder.parameters->push_back(bound_parameter.get());
+	if (binder.parameter_types && expr.parameter_nr <= binder.parameter_types->size()) {
+		bound_parameter->return_type = (*binder.parameter_types)[expr.parameter_nr - 1];
+	}
+	return BindResult(move(bound_parameter));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+BindResult ExpressionBinder::BindExpression(PositionalReferenceExpression &ref, idx_t depth) {
+	if (depth != 0) {
+		return BindResult("Positional reference expression could not be bound");
+	}
+	return binder.bind_context.BindColumn(ref, depth);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+class BoundSubqueryNode : public QueryNode {
+public:
+	BoundSubqueryNode(shared_ptr<Binder> subquery_binder, unique_ptr<BoundQueryNode> bound_node,
+	                  unique_ptr<SelectStatement> subquery)
+	    : QueryNode(QueryNodeType::BOUND_SUBQUERY_NODE), subquery_binder(move(subquery_binder)),
+	      bound_node(move(bound_node)), subquery(move(subquery)) {
+	}
+
+	shared_ptr<Binder> subquery_binder;
+	unique_ptr<BoundQueryNode> bound_node;
+	unique_ptr<SelectStatement> subquery;
+
+	const vector<unique_ptr<ParsedExpression>> &GetSelectList() const override {
+		throw InternalException("Cannot get select list of bound subquery node");
+	}
+
+	string ToString() const override {
+		throw InternalException("Cannot ToString bound subquery node");
+	}
+	unique_ptr<QueryNode> Copy() const override {
+		throw InternalException("Cannot copy bound subquery node");
+	}
+	void Serialize(FieldWriter &writer) const override {
+		throw InternalException("Cannot serialize bound subquery node");
+	}
+};
+
+BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t depth) {
+	if (expr.subquery->node->type != QueryNodeType::BOUND_SUBQUERY_NODE) {
+		D_ASSERT(depth == 0);
+		// first bind the actual subquery in a new binder
+		auto subquery_binder = Binder::CreateBinder(context, &binder);
+		subquery_binder->can_contain_nulls = true;
+		auto bound_node = subquery_binder->BindNode(*expr.subquery->node);
+		// check the correlated columns of the subquery for correlated columns with depth > 1
+		for (idx_t i = 0; i < subquery_binder->correlated_columns.size(); i++) {
+			CorrelatedColumnInfo corr = subquery_binder->correlated_columns[i];
+			if (corr.depth > 1) {
+				// depth > 1, the column references the query ABOVE the current one
+				// add to the set of correlated columns for THIS query
+				corr.depth -= 1;
+				binder.AddCorrelatedColumn(corr);
+			}
+		}
+		if (expr.subquery_type != SubqueryType::EXISTS && bound_node->types.size() > 1) {
+			throw BinderException(binder.FormatError(
+			    expr, StringUtil::Format("Subquery returns %zu columns - expected 1", bound_node->types.size())));
+		}
+		auto prior_subquery = move(expr.subquery);
+		expr.subquery = make_unique<SelectStatement>();
+		expr.subquery->node =
+		    make_unique<BoundSubqueryNode>(move(subquery_binder), move(bound_node), move(prior_subquery));
+	}
+	// now bind the child node of the subquery
+	if (expr.child) {
+		// first bind the children of the subquery, if any
+		string error = Bind(&expr.child, depth);
+		if (!error.empty()) {
+			return BindResult(error);
+		}
+	}
+	// both binding the child and binding the subquery was successful
+	D_ASSERT(expr.subquery->node->type == QueryNodeType::BOUND_SUBQUERY_NODE);
+	auto bound_subquery = (BoundSubqueryNode *)expr.subquery->node.get();
+	auto child = (BoundExpression *)expr.child.get();
+	auto subquery_binder = move(bound_subquery->subquery_binder);
+	auto bound_node = move(bound_subquery->bound_node);
+	LogicalType return_type =
+	    expr.subquery_type == SubqueryType::SCALAR ? bound_node->types[0] : LogicalType(LogicalTypeId::BOOLEAN);
+	if (return_type.id() == LogicalTypeId::UNKNOWN) {
+		return_type = LogicalType::SQLNULL;
+	}
+
+	auto result = make_unique<BoundSubqueryExpression>(return_type);
+	if (expr.subquery_type == SubqueryType::ANY) {
+		// ANY comparison
+		// cast child and subquery child to equivalent types
+		D_ASSERT(bound_node->types.size() == 1);
+		auto compare_type = LogicalType::MaxLogicalType(child->expr->return_type, bound_node->types[0]);
+		child->expr = BoundCastExpression::AddCastToType(move(child->expr), compare_type);
+		result->child_type = bound_node->types[0];
+		result->child_target = compare_type;
+	}
+	result->binder = move(subquery_binder);
+	result->subquery = move(bound_node);
+	result->subquery_type = expr.subquery_type;
+	result->child = child ? move(child->expr) : nullptr;
+	result->comparison_type = expr.comparison_type;
+
+	return BindResult(move(result));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+BindResult SelectBinder::BindUnnest(FunctionExpression &function, idx_t depth) {
+	// bind the children of the function expression
+	string error;
+	if (function.children.size() != 1) {
+		return BindResult(binder.FormatError(function, "Unnest() needs exactly one child expressions"));
+	}
+	BindChild(function.children[0], depth, error);
+	if (!error.empty()) {
+		// failed to bind
+		// try to bind correlated columns manually
+		if (!BindCorrelatedColumns(function.children[0])) {
+			return BindResult(error);
+		}
+		auto bound_expr = (BoundExpression *)function.children[0].get();
+		ExtractCorrelatedExpressions(binder, *bound_expr->expr);
+	}
+	auto &child = (BoundExpression &)*function.children[0];
+	auto &child_type = child.expr->return_type;
+
+	if (child_type.id() != LogicalTypeId::LIST && child_type.id() != LogicalTypeId::SQLNULL) {
+		return BindResult(binder.FormatError(function, "Unnest() can only be applied to lists and NULL"));
+	}
+
+	if (depth > 0) {
+		throw BinderException(binder.FormatError(function, "Unnest() for correlated expressions is not supported yet"));
+	}
+
+	auto return_type = LogicalType(LogicalTypeId::SQLNULL);
+	if (child_type.id() == LogicalTypeId::LIST) {
+		return_type = ListType::GetChildType(child_type);
+	}
+
+	auto result = make_unique<BoundUnnestExpression>(return_type);
+	result->child = move(child.expr);
+
+	auto unnest_index = node.unnests.size();
+	node.unnests.push_back(move(result));
+
+	// TODO what if we have multiple unnests in the same projection list? ignore for now
+
+	// now create a column reference referring to the unnest
+	auto colref = make_unique<BoundColumnRefExpression>(
+	    function.alias.empty() ? node.unnests[unnest_index]->ToString() : function.alias, return_type,
+	    ColumnBinding(node.unnest_index, unnest_index), depth);
+
+	return BindResult(move(colref));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static LogicalType ResolveWindowExpressionType(ExpressionType window_type, const vector<LogicalType> &child_types) {
+
+	idx_t param_count;
+	switch (window_type) {
+	case ExpressionType::WINDOW_RANK:
+	case ExpressionType::WINDOW_RANK_DENSE:
+	case ExpressionType::WINDOW_ROW_NUMBER:
+	case ExpressionType::WINDOW_PERCENT_RANK:
+	case ExpressionType::WINDOW_CUME_DIST:
+		param_count = 0;
+		break;
+	case ExpressionType::WINDOW_NTILE:
+	case ExpressionType::WINDOW_FIRST_VALUE:
+	case ExpressionType::WINDOW_LAST_VALUE:
+	case ExpressionType::WINDOW_LEAD:
+	case ExpressionType::WINDOW_LAG:
+		param_count = 1;
+		break;
+	case ExpressionType::WINDOW_NTH_VALUE:
+		param_count = 2;
+		break;
+	default:
+		throw InternalException("Unrecognized window expression type " + ExpressionTypeToString(window_type));
+	}
+	if (child_types.size() != param_count) {
+		throw BinderException("%s needs %d parameter%s, got %d", ExpressionTypeToString(window_type), param_count,
+		                      param_count == 1 ? "" : "s", child_types.size());
+	}
+	switch (window_type) {
+	case ExpressionType::WINDOW_PERCENT_RANK:
+	case ExpressionType::WINDOW_CUME_DIST:
+		return LogicalType(LogicalTypeId::DOUBLE);
+	case ExpressionType::WINDOW_ROW_NUMBER:
+	case ExpressionType::WINDOW_RANK:
+	case ExpressionType::WINDOW_RANK_DENSE:
+	case ExpressionType::WINDOW_NTILE:
+		return LogicalType::BIGINT;
+	case ExpressionType::WINDOW_NTH_VALUE:
+	case ExpressionType::WINDOW_FIRST_VALUE:
+	case ExpressionType::WINDOW_LAST_VALUE:
+	case ExpressionType::WINDOW_LEAD:
+	case ExpressionType::WINDOW_LAG:
+		return child_types[0];
+	default:
+		throw InternalException("Unrecognized window expression type " + ExpressionTypeToString(window_type));
+	}
+}
+
+static inline OrderType ResolveOrderType(const DBConfig &config, OrderType type) {
+	return (type == OrderType::ORDER_DEFAULT) ? config.default_order_type : type;
+}
+
+static inline OrderByNullType ResolveNullOrder(const DBConfig &config, OrderByNullType null_order) {
+	return (null_order == OrderByNullType::ORDER_DEFAULT) ? config.default_null_order : null_order;
+}
+
+static unique_ptr<Expression> GetExpression(unique_ptr<ParsedExpression> &expr) {
+	if (!expr) {
+		return nullptr;
+	}
+	D_ASSERT(expr.get());
+	D_ASSERT(expr->expression_class == ExpressionClass::BOUND_EXPRESSION);
+	return move(((BoundExpression &)*expr).expr);
+}
+
+static unique_ptr<Expression> CastWindowExpression(unique_ptr<ParsedExpression> &expr, const LogicalType &type) {
+	if (!expr) {
+		return nullptr;
+	}
+	D_ASSERT(expr.get());
+	D_ASSERT(expr->expression_class == ExpressionClass::BOUND_EXPRESSION);
+
+	auto &bound = (BoundExpression &)*expr;
+	bound.expr = BoundCastExpression::AddCastToType(move(bound.expr), type);
+
+	return move(bound.expr);
+}
+
+static LogicalType BindRangeExpression(ClientContext &context, const string &name, unique_ptr<ParsedExpression> &expr,
+                                       unique_ptr<ParsedExpression> &order_expr) {
+
+	vector<unique_ptr<Expression>> children;
+
+	D_ASSERT(order_expr.get());
+	D_ASSERT(order_expr->expression_class == ExpressionClass::BOUND_EXPRESSION);
+	auto &bound_order = (BoundExpression &)*order_expr;
+	children.emplace_back(bound_order.expr->Copy());
+
+	D_ASSERT(expr.get());
+	D_ASSERT(expr->expression_class == ExpressionClass::BOUND_EXPRESSION);
+	auto &bound = (BoundExpression &)*expr;
+	children.emplace_back(move(bound.expr));
+
+	string error;
+	auto function = ScalarFunction::BindScalarFunction(context, DEFAULT_SCHEMA, name, move(children), error, true);
+	if (!function) {
+		throw BinderException(error);
+	}
+	bound.expr = move(function);
+	return bound.expr->return_type;
+}
+
+BindResult SelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
+	auto name = window.GetName();
+
+	QueryErrorContext error_context(binder.root_statement, window.query_location);
+	if (inside_window) {
+		throw BinderException(error_context.FormatError("window function calls cannot be nested"));
+	}
+	if (depth > 0) {
+		throw BinderException(error_context.FormatError("correlated columns in window functions not supported"));
+	}
+	// If we have range expressions, then only one order by clause is allowed.
+	if ((window.start == WindowBoundary::EXPR_PRECEDING_RANGE || window.start == WindowBoundary::EXPR_FOLLOWING_RANGE ||
+	     window.end == WindowBoundary::EXPR_PRECEDING_RANGE || window.end == WindowBoundary::EXPR_FOLLOWING_RANGE) &&
+	    window.orders.size() != 1) {
+		throw BinderException(error_context.FormatError("RANGE frames must have only one ORDER BY expression"));
+	}
+	// bind inside the children of the window function
+	// we set the inside_window flag to true to prevent binding nested window functions
+	this->inside_window = true;
+	string error;
+	for (auto &child : window.children) {
+		BindChild(child, depth, error);
+	}
+	for (auto &child : window.partitions) {
+		BindChild(child, depth, error);
+	}
+	for (auto &order : window.orders) {
+		BindChild(order.expression, depth, error);
+	}
+	BindChild(window.filter_expr, depth, error);
+	BindChild(window.start_expr, depth, error);
+	BindChild(window.end_expr, depth, error);
+	BindChild(window.offset_expr, depth, error);
+	BindChild(window.default_expr, depth, error);
+
+	this->inside_window = false;
+	if (!error.empty()) {
+		// failed to bind children of window function
+		return BindResult(error);
+	}
+	// successfully bound all children: create bound window function
+	vector<LogicalType> types;
+	vector<unique_ptr<Expression>> children;
+	for (auto &child : window.children) {
+		D_ASSERT(child.get());
+		D_ASSERT(child->expression_class == ExpressionClass::BOUND_EXPRESSION);
+		auto &bound = (BoundExpression &)*child;
+		// Add casts for positional arguments
+		const auto argno = children.size();
+		switch (window.type) {
+		case ExpressionType::WINDOW_NTILE:
+			// ntile(bigint)
+			if (argno == 0) {
+				bound.expr = BoundCastExpression::AddCastToType(move(bound.expr), LogicalType::BIGINT);
+			}
+			break;
+		case ExpressionType::WINDOW_NTH_VALUE:
+			// nth_value(<expr>, index)
+			if (argno == 1) {
+				bound.expr = BoundCastExpression::AddCastToType(move(bound.expr), LogicalType::BIGINT);
+			}
+		default:
+			break;
+		}
+		types.push_back(bound.expr->return_type);
+		children.push_back(move(bound.expr));
+	}
+	//  Determine the function type.
+	LogicalType sql_type;
+	unique_ptr<AggregateFunction> aggregate;
+	unique_ptr<FunctionData> bind_info;
+	if (window.type == ExpressionType::WINDOW_AGGREGATE) {
+		//  Look up the aggregate function in the catalog
+		auto func =
+		    (AggregateFunctionCatalogEntry *)Catalog::GetCatalog(context).GetEntry<AggregateFunctionCatalogEntry>(
+		        context, window.schema, window.function_name, false, error_context);
+		D_ASSERT(func->type == CatalogType::AGGREGATE_FUNCTION_ENTRY);
+
+		// bind the aggregate
+		string error;
+		auto best_function = Function::BindFunction(func->name, func->functions, types, error);
+		if (best_function == DConstants::INVALID_INDEX) {
+			throw BinderException(binder.FormatError(window, error));
+		}
+		// found a matching function! bind it as an aggregate
+		auto &bound_function = func->functions[best_function];
+		auto bound_aggregate = AggregateFunction::BindAggregateFunction(context, bound_function, move(children));
+		// create the aggregate
+		aggregate = make_unique<AggregateFunction>(bound_aggregate->function);
+		bind_info = move(bound_aggregate->bind_info);
+		children = move(bound_aggregate->children);
+		sql_type = bound_aggregate->return_type;
+	} else {
+		// fetch the child of the non-aggregate window function (if any)
+		sql_type = ResolveWindowExpressionType(window.type, types);
+	}
+	auto result = make_unique<BoundWindowExpression>(window.type, sql_type, move(aggregate), move(bind_info));
+	result->children = move(children);
+	for (auto &child : window.partitions) {
+		result->partitions.push_back(GetExpression(child));
+	}
+	result->ignore_nulls = window.ignore_nulls;
+
+	// Convert RANGE boundary expressions to ORDER +/- expressions.
+	// Note that PRECEEDING and FOLLOWING refer to the sequential order in the frame,
+	// not the natural ordering of the type. This means that the offset arithmetic must be reversed
+	// for ORDER BY DESC.
+	auto &config = DBConfig::GetConfig(context);
+	auto range_sense = OrderType::INVALID;
+	LogicalType start_type = LogicalType::BIGINT;
+	if (window.start == WindowBoundary::EXPR_PRECEDING_RANGE) {
+		D_ASSERT(window.orders.size() == 1);
+		range_sense = ResolveOrderType(config, window.orders[0].type);
+		const auto name = (range_sense == OrderType::ASCENDING) ? "-" : "+";
+		start_type = BindRangeExpression(context, name, window.start_expr, window.orders[0].expression);
+	} else if (window.start == WindowBoundary::EXPR_FOLLOWING_RANGE) {
+		D_ASSERT(window.orders.size() == 1);
+		range_sense = ResolveOrderType(config, window.orders[0].type);
+		const auto name = (range_sense == OrderType::ASCENDING) ? "+" : "-";
+		start_type = BindRangeExpression(context, name, window.start_expr, window.orders[0].expression);
+	}
+
+	LogicalType end_type = LogicalType::BIGINT;
+	if (window.end == WindowBoundary::EXPR_PRECEDING_RANGE) {
+		D_ASSERT(window.orders.size() == 1);
+		range_sense = ResolveOrderType(config, window.orders[0].type);
+		const auto name = (range_sense == OrderType::ASCENDING) ? "-" : "+";
+		end_type = BindRangeExpression(context, name, window.end_expr, window.orders[0].expression);
+	} else if (window.end == WindowBoundary::EXPR_FOLLOWING_RANGE) {
+		D_ASSERT(window.orders.size() == 1);
+		range_sense = ResolveOrderType(config, window.orders[0].type);
+		const auto name = (range_sense == OrderType::ASCENDING) ? "+" : "-";
+		end_type = BindRangeExpression(context, name, window.end_expr, window.orders[0].expression);
+	}
+
+	// Cast ORDER and boundary expressions to the same type
+	if (range_sense != OrderType::INVALID) {
+		D_ASSERT(window.orders.size() == 1);
+
+		auto &order_expr = window.orders[0].expression;
+		D_ASSERT(order_expr.get());
+		D_ASSERT(order_expr->expression_class == ExpressionClass::BOUND_EXPRESSION);
+		auto &bound_order = (BoundExpression &)*order_expr;
+		auto order_type = bound_order.expr->return_type;
+		if (window.start_expr) {
+			order_type = LogicalType::MaxLogicalType(order_type, start_type);
+		}
+		if (window.end_expr) {
+			order_type = LogicalType::MaxLogicalType(order_type, end_type);
+		}
+
+		// Cast all three to match
+		bound_order.expr = BoundCastExpression::AddCastToType(move(bound_order.expr), order_type);
+		start_type = end_type = order_type;
+	}
+
+	for (auto &order : window.orders) {
+		auto type = ResolveOrderType(config, order.type);
+		auto null_order = ResolveNullOrder(config, order.null_order);
+		auto expression = GetExpression(order.expression);
+		result->orders.emplace_back(type, null_order, move(expression));
+	}
+
+	result->filter_expr = CastWindowExpression(window.filter_expr, LogicalType::BOOLEAN);
+
+	result->start_expr = CastWindowExpression(window.start_expr, start_type);
+	result->end_expr = CastWindowExpression(window.end_expr, end_type);
+	result->offset_expr = CastWindowExpression(window.offset_expr, LogicalType::BIGINT);
+	result->default_expr = CastWindowExpression(window.default_expr, result->return_type);
+	result->start = window.start;
+	result->end = window.end;
+
+	// create a BoundColumnRef that references this entry
+	auto colref = make_unique<BoundColumnRefExpression>(move(name), result->return_type,
+	                                                    ColumnBinding(node.window_index, node.windows.size()), depth);
+	// move the WINDOW expression into the set of bound windows
+	node.windows.push_back(move(result));
+	return BindResult(move(colref));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<BoundQueryNode> Binder::BindNode(RecursiveCTENode &statement) {
+	auto result = make_unique<BoundRecursiveCTENode>();
+
+	// first recursively visit the recursive CTE operations
+	// the left side is visited first and is added to the BindContext of the right side
+	D_ASSERT(statement.left);
+	D_ASSERT(statement.right);
+
+	result->ctename = statement.ctename;
+	result->union_all = statement.union_all;
+	result->setop_index = GenerateTableIndex();
+
+	result->left_binder = Binder::CreateBinder(context, this);
+	result->left = result->left_binder->BindNode(*statement.left);
+
+	// the result types of the CTE are the types of the LHS
+	result->types = result->left->types;
+	// names are picked from the LHS, unless aliases are explicitly specified
+	result->names = result->left->names;
+	for (idx_t i = 0; i < statement.aliases.size() && i < result->names.size(); i++) {
+		result->names[i] = statement.aliases[i];
+	}
+
+	// This allows the right side to reference the CTE recursively
+	bind_context.AddGenericBinding(result->setop_index, statement.ctename, result->names, result->types);
+
+	result->right_binder = Binder::CreateBinder(context, this);
+
+	// Add bindings of left side to temporary CTE bindings context
+	result->right_binder->bind_context.AddCTEBinding(result->setop_index, statement.ctename, result->names,
+	                                                 result->types);
+	result->right = result->right_binder->BindNode(*statement.right);
+
+	// move the correlated expressions from the child binders to this binder
+	MoveCorrelatedExpressions(*result->left_binder);
+	MoveCorrelatedExpressions(*result->right_binder);
+
+	// now both sides have been bound we can resolve types
+	if (result->left->types.size() != result->right->types.size()) {
+		throw BinderException("Set operations can only apply to expressions with the "
+		                      "same number of result columns");
+	}
+
+	if (!statement.modifiers.empty()) {
+		throw NotImplementedException("FIXME: bind modifiers in recursive CTE");
+	}
+
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<Expression> Binder::BindOrderExpression(OrderBinder &order_binder, unique_ptr<ParsedExpression> expr) {
+	// we treat the Distinct list as a order by
+	auto bound_expr = order_binder.Bind(move(expr));
+	if (!bound_expr) {
+		// DISTINCT ON non-integer constant
+		// remove the expression from the DISTINCT ON list
+		return nullptr;
+	}
+	D_ASSERT(bound_expr->type == ExpressionType::BOUND_COLUMN_REF);
+	return bound_expr;
+}
+
+unique_ptr<Expression> Binder::BindDelimiter(ClientContext &context, OrderBinder &order_binder,
+                                             unique_ptr<ParsedExpression> delimiter, const LogicalType &type,
+                                             Value &delimiter_value) {
+	auto new_binder = Binder::CreateBinder(context, this, true);
+	if (delimiter->HasSubquery()) {
+		return order_binder.CreateExtraReference(move(delimiter));
+	}
+	ExpressionBinder expr_binder(*new_binder, context);
+	expr_binder.target_type = type;
+	auto expr = expr_binder.Bind(delimiter);
+	if (expr->IsFoldable()) {
+		//! this is a constant
+		delimiter_value = ExpressionExecutor::EvaluateScalar(*expr).CastAs(type);
+		return nullptr;
+	}
+	return expr;
+}
+
+unique_ptr<BoundResultModifier> Binder::BindLimit(OrderBinder &order_binder, LimitModifier &limit_mod) {
+	auto result = make_unique<BoundLimitModifier>();
+	if (limit_mod.limit) {
+		Value val;
+		result->limit = BindDelimiter(context, order_binder, move(limit_mod.limit), LogicalType::BIGINT, val);
+		if (!result->limit) {
+			result->limit_val = val.GetValue<int64_t>();
+			if (result->limit_val < 0) {
+				throw BinderException("LIMIT cannot be negative");
+			}
+		}
+	}
+	if (limit_mod.offset) {
+		Value val;
+		result->offset = BindDelimiter(context, order_binder, move(limit_mod.offset), LogicalType::BIGINT, val);
+		if (!result->offset) {
+			result->offset_val = val.GetValue<int64_t>();
+			if (result->offset_val < 0) {
+				throw BinderException("OFFSET cannot be negative");
+			}
+		}
+	}
+	return move(result);
+}
+
+unique_ptr<BoundResultModifier> Binder::BindLimitPercent(OrderBinder &order_binder, LimitPercentModifier &limit_mod) {
+	auto result = make_unique<BoundLimitPercentModifier>();
+	if (limit_mod.limit) {
+		Value val;
+		result->limit = BindDelimiter(context, order_binder, move(limit_mod.limit), LogicalType::DOUBLE, val);
+		if (!result->limit) {
+			result->limit_percent = val.GetValue<double>();
+			if (result->limit_percent < 0.0) {
+				throw Exception("Limit percentage can't be negative value");
+			}
+		}
+	}
+	if (limit_mod.offset) {
+		Value val;
+		result->offset = BindDelimiter(context, order_binder, move(limit_mod.offset), LogicalType::BIGINT, val);
+		if (!result->offset) {
+			result->offset_val = val.GetValue<int64_t>();
+		}
+	}
+	return move(result);
+}
+
+void Binder::BindModifiers(OrderBinder &order_binder, QueryNode &statement, BoundQueryNode &result) {
+	for (auto &mod : statement.modifiers) {
+		unique_ptr<BoundResultModifier> bound_modifier;
+		switch (mod->type) {
+		case ResultModifierType::DISTINCT_MODIFIER: {
+			auto &distinct = (DistinctModifier &)*mod;
+			auto bound_distinct = make_unique<BoundDistinctModifier>();
+			if (distinct.distinct_on_targets.empty()) {
+				for (idx_t i = 0; i < result.names.size(); i++) {
+					distinct.distinct_on_targets.push_back(make_unique<ConstantExpression>(Value::INTEGER(1 + i)));
+				}
+			}
+			for (auto &distinct_on_target : distinct.distinct_on_targets) {
+				auto expr = BindOrderExpression(order_binder, move(distinct_on_target));
+				if (!expr) {
+					continue;
+				}
+				bound_distinct->target_distincts.push_back(move(expr));
+			}
+			bound_modifier = move(bound_distinct);
+			break;
+		}
+		case ResultModifierType::ORDER_MODIFIER: {
+			auto &order = (OrderModifier &)*mod;
+			auto bound_order = make_unique<BoundOrderModifier>();
+			auto &config = DBConfig::GetConfig(context);
+			D_ASSERT(!order.orders.empty());
+			if (order.orders[0].expression->type == ExpressionType::STAR) {
+				// ORDER BY ALL
+				// replace the order list with the maximum order by count
+				D_ASSERT(order.orders.size() == 1);
+				auto order_type = order.orders[0].type;
+				auto null_order = order.orders[0].null_order;
+
+				vector<OrderByNode> new_orders;
+				for (idx_t i = 0; i < order_binder.MaxCount(); i++) {
+					new_orders.emplace_back(order_type, null_order,
+					                        make_unique<ConstantExpression>(Value::INTEGER(i + 1)));
+				}
+				order.orders = move(new_orders);
+			}
+			for (auto &order_node : order.orders) {
+				auto order_expression = BindOrderExpression(order_binder, move(order_node.expression));
+				if (!order_expression) {
+					continue;
+				}
+				auto type = order_node.type == OrderType::ORDER_DEFAULT ? config.default_order_type : order_node.type;
+				auto null_order = order_node.null_order == OrderByNullType::ORDER_DEFAULT ? config.default_null_order
+				                                                                          : order_node.null_order;
+				bound_order->orders.emplace_back(type, null_order, move(order_expression));
+			}
+			if (!bound_order->orders.empty()) {
+				bound_modifier = move(bound_order);
+			}
+			break;
+		}
+		case ResultModifierType::LIMIT_MODIFIER:
+			bound_modifier = BindLimit(order_binder, (LimitModifier &)*mod);
+			break;
+		case ResultModifierType::LIMIT_PERCENT_MODIFIER:
+			bound_modifier = BindLimitPercent(order_binder, (LimitPercentModifier &)*mod);
+			break;
+		default:
+			throw Exception("Unsupported result modifier");
+		}
+		if (bound_modifier) {
+			result.modifiers.push_back(move(bound_modifier));
+		}
+	}
+}
+
+static void AssignReturnType(unique_ptr<Expression> &expr, const vector<LogicalType> &sql_types,
+                             idx_t projection_index) {
+	if (!expr) {
+		return;
+	}
+	if (expr->type != ExpressionType::BOUND_COLUMN_REF) {
+		return;
+	}
+	auto &bound_colref = (BoundColumnRefExpression &)*expr;
+	bound_colref.return_type = sql_types[bound_colref.binding.column_index];
+}
+
+void Binder::BindModifierTypes(BoundQueryNode &result, const vector<LogicalType> &sql_types, idx_t projection_index) {
+	for (auto &bound_mod : result.modifiers) {
+		switch (bound_mod->type) {
+		case ResultModifierType::DISTINCT_MODIFIER: {
+			auto &distinct = (BoundDistinctModifier &)*bound_mod;
+			if (distinct.target_distincts.empty()) {
+				// DISTINCT without a target: push references to the standard select list
+				for (idx_t i = 0; i < sql_types.size(); i++) {
+					distinct.target_distincts.push_back(
+					    make_unique<BoundColumnRefExpression>(sql_types[i], ColumnBinding(projection_index, i)));
+				}
+			} else {
+				// DISTINCT with target list: set types
+				for (auto &expr : distinct.target_distincts) {
+					D_ASSERT(expr->type == ExpressionType::BOUND_COLUMN_REF);
+					auto &bound_colref = (BoundColumnRefExpression &)*expr;
+					if (bound_colref.binding.column_index == DConstants::INVALID_INDEX) {
+						throw BinderException("Ambiguous name in DISTINCT ON!");
+					}
+					D_ASSERT(bound_colref.binding.column_index < sql_types.size());
+					bound_colref.return_type = sql_types[bound_colref.binding.column_index];
+				}
+			}
+			for (auto &target_distinct : distinct.target_distincts) {
+				auto &bound_colref = (BoundColumnRefExpression &)*target_distinct;
+				auto sql_type = sql_types[bound_colref.binding.column_index];
+				if (sql_type.id() == LogicalTypeId::VARCHAR) {
+					target_distinct = ExpressionBinder::PushCollation(context, move(target_distinct),
+					                                                  StringType::GetCollation(sql_type), true);
+				}
+			}
+			break;
+		}
+		case ResultModifierType::LIMIT_MODIFIER: {
+			auto &limit = (BoundLimitModifier &)*bound_mod;
+			AssignReturnType(limit.limit, sql_types, projection_index);
+			AssignReturnType(limit.offset, sql_types, projection_index);
+			break;
+		}
+		case ResultModifierType::LIMIT_PERCENT_MODIFIER: {
+			auto &limit = (BoundLimitPercentModifier &)*bound_mod;
+			AssignReturnType(limit.limit, sql_types, projection_index);
+			AssignReturnType(limit.offset, sql_types, projection_index);
+			break;
+		}
+		case ResultModifierType::ORDER_MODIFIER: {
+			auto &order = (BoundOrderModifier &)*bound_mod;
+			for (auto &order_node : order.orders) {
+				auto &expr = order_node.expression;
+				D_ASSERT(expr->type == ExpressionType::BOUND_COLUMN_REF);
+				auto &bound_colref = (BoundColumnRefExpression &)*expr;
+				if (bound_colref.binding.column_index == DConstants::INVALID_INDEX) {
+					throw BinderException("Ambiguous name in ORDER BY!");
+				}
+				D_ASSERT(bound_colref.binding.column_index < sql_types.size());
+				auto sql_type = sql_types[bound_colref.binding.column_index];
+				bound_colref.return_type = sql_types[bound_colref.binding.column_index];
+				if (sql_type.id() == LogicalTypeId::VARCHAR) {
+					order_node.expression = ExpressionBinder::PushCollation(context, move(order_node.expression),
+					                                                        StringType::GetCollation(sql_type));
+				}
+			}
+			break;
+		}
+		default:
+			break;
+		}
+	}
+}
+
+unique_ptr<BoundQueryNode> Binder::BindNode(SelectNode &statement) {
+	auto result = make_unique<BoundSelectNode>();
+	result->projection_index = GenerateTableIndex();
+	result->group_index = GenerateTableIndex();
+	result->aggregate_index = GenerateTableIndex();
+	result->groupings_index = GenerateTableIndex();
+	result->window_index = GenerateTableIndex();
+	result->unnest_index = GenerateTableIndex();
+	result->prune_index = GenerateTableIndex();
+
+	// first bind the FROM table statement
+	result->from_table = Bind(*statement.from_table);
+
+	// bind the sample clause
+	if (statement.sample) {
+		result->sample_options = move(statement.sample);
+	}
+
+	// visit the select list and expand any "*" statements
+	vector<unique_ptr<ParsedExpression>> new_select_list;
+	for (auto &select_element : statement.select_list) {
+		if (select_element->GetExpressionType() == ExpressionType::STAR) {
+			// * statement, expand to all columns from the FROM clause
+			bind_context.GenerateAllColumnExpressions((StarExpression &)*select_element, new_select_list);
+		} else {
+			// regular statement, add it to the list
+			new_select_list.push_back(move(select_element));
+		}
+	}
+	if (new_select_list.empty()) {
+		throw BinderException("SELECT list is empty after resolving * expressions!");
+	}
+	statement.select_list = move(new_select_list);
+
+	// create a mapping of (alias -> index) and a mapping of (Expression -> index) for the SELECT list
+	case_insensitive_map_t<idx_t> alias_map;
+	expression_map_t<idx_t> projection_map;
+	for (idx_t i = 0; i < statement.select_list.size(); i++) {
+		auto &expr = statement.select_list[i];
+		result->names.push_back(expr->GetName());
+		ExpressionBinder::QualifyColumnNames(*this, expr);
+		if (!expr->alias.empty()) {
+			alias_map[expr->alias] = i;
+			result->names[i] = expr->alias;
+		}
+		projection_map[expr.get()] = i;
+		result->original_expressions.push_back(expr->Copy());
+	}
+	result->column_count = statement.select_list.size();
+
+	// first visit the WHERE clause
+	// the WHERE clause happens before the GROUP BY, PROJECTION or HAVING clauses
+	if (statement.where_clause) {
+		ColumnAliasBinder alias_binder(*result, alias_map);
+		WhereBinder where_binder(*this, context, &alias_binder);
+		unique_ptr<ParsedExpression> condition = move(statement.where_clause);
+		result->where_clause = where_binder.Bind(condition);
+	}
+
+	// now bind all the result modifiers; including DISTINCT and ORDER BY targets
+	OrderBinder order_binder({this}, result->projection_index, statement, alias_map, projection_map);
+	BindModifiers(order_binder, statement, *result);
+
+	vector<unique_ptr<ParsedExpression>> unbound_groups;
+	BoundGroupInformation info;
+	auto &group_expressions = statement.groups.group_expressions;
+	if (!group_expressions.empty()) {
+		// the statement has a GROUP BY clause, bind it
+		unbound_groups.resize(group_expressions.size());
+		GroupBinder group_binder(*this, context, statement, result->group_index, alias_map, info.alias_map);
+		for (idx_t i = 0; i < group_expressions.size(); i++) {
+
+			// we keep a copy of the unbound expression;
+			// we keep the unbound copy around to check for group references in the SELECT and HAVING clause
+			// the reason we want the unbound copy is because we want to figure out whether an expression
+			// is a group reference BEFORE binding in the SELECT/HAVING binder
+			group_binder.unbound_expression = group_expressions[i]->Copy();
+			group_binder.bind_index = i;
+
+			// bind the groups
+			LogicalType group_type;
+			auto bound_expr = group_binder.Bind(group_expressions[i], &group_type);
+			D_ASSERT(bound_expr->return_type.id() != LogicalTypeId::INVALID);
+
+			// push a potential collation, if necessary
+			bound_expr =
+			    ExpressionBinder::PushCollation(context, move(bound_expr), StringType::GetCollation(group_type), true);
+			result->groups.group_expressions.push_back(move(bound_expr));
+
+			// in the unbound expression we DO bind the table names of any ColumnRefs
+			// we do this to make sure that "table.a" and "a" are treated the same
+			// if we wouldn't do this then (SELECT test.a FROM test GROUP BY a) would not work because "test.a" <> "a"
+			// hence we convert "a" -> "test.a" in the unbound expression
+			unbound_groups[i] = move(group_binder.unbound_expression);
+			ExpressionBinder::QualifyColumnNames(*this, unbound_groups[i]);
+			info.map[unbound_groups[i].get()] = i;
+		}
+	}
+	result->groups.grouping_sets = move(statement.groups.grouping_sets);
+
+	// bind the HAVING clause, if any
+	if (statement.having) {
+		HavingBinder having_binder(*this, context, *result, info, alias_map);
+		ExpressionBinder::QualifyColumnNames(*this, statement.having);
+		result->having = having_binder.Bind(statement.having);
+	}
+
+	// bind the QUALIFY clause, if any
+	if (statement.qualify) {
+		QualifyBinder qualify_binder(*this, context, *result, info, alias_map);
+		ExpressionBinder::QualifyColumnNames(*this, statement.qualify);
+		result->qualify = qualify_binder.Bind(statement.qualify);
+	}
+
+	// after that, we bind to the SELECT list
+	SelectBinder select_binder(*this, context, *result, info);
+	vector<LogicalType> internal_sql_types;
+	for (idx_t i = 0; i < statement.select_list.size(); i++) {
+		LogicalType result_type;
+		auto expr = select_binder.Bind(statement.select_list[i], &result_type);
+		if (statement.aggregate_handling == AggregateHandling::FORCE_AGGREGATES && select_binder.HasBoundColumns()) {
+			if (select_binder.BoundAggregates()) {
+				throw BinderException("Cannot mix aggregates with non-aggregated columns!");
+			}
+			// we are forcing aggregates, and the node has columns bound
+			// this entry becomes a group
+			auto group_ref = make_unique<BoundColumnRefExpression>(
+			    expr->return_type, ColumnBinding(result->group_index, result->groups.group_expressions.size()));
+			result->groups.group_expressions.push_back(move(expr));
+			expr = move(group_ref);
+		}
+		result->select_list.push_back(move(expr));
+		if (i < result->column_count) {
+			result->types.push_back(result_type);
+		}
+		internal_sql_types.push_back(result_type);
+		if (statement.aggregate_handling == AggregateHandling::FORCE_AGGREGATES) {
+			select_binder.ResetBindings();
+		}
+	}
+	result->need_prune = result->select_list.size() > result->column_count;
+
+	// in the normal select binder, we bind columns as if there is no aggregation
+	// i.e. in the query [SELECT i, SUM(i) FROM integers;] the "i" will be bound as a normal column
+	// since we have an aggregation, we need to either (1) throw an error, or (2) wrap the column in a FIRST() aggregate
+	// we choose the former one [CONTROVERSIAL: this is the PostgreSQL behavior]
+	if (!result->groups.group_expressions.empty() || !result->aggregates.empty() || statement.having ||
+	    !result->groups.grouping_sets.empty()) {
+		if (statement.aggregate_handling == AggregateHandling::NO_AGGREGATES_ALLOWED) {
+			throw BinderException("Aggregates cannot be present in a Project relation!");
+		} else if (statement.aggregate_handling == AggregateHandling::STANDARD_HANDLING) {
+			if (select_binder.HasBoundColumns()) {
+				auto &bound_columns = select_binder.GetBoundColumns();
+				throw BinderException(
+				    FormatError(bound_columns[0].query_location,
+				                "column \"%s\" must appear in the GROUP BY clause or be used in an aggregate function",
+				                bound_columns[0].name));
+			}
+		}
+	}
+
+	// QUALIFY clause requires at least one window function to be specified in at least one of the SELECT column list or
+	// the filter predicate of the QUALIFY clause
+	if (statement.qualify && result->windows.empty()) {
+		throw BinderException("at least one window function must appear in the SELECT column or QUALIFY clause");
+	}
+
+	// now that the SELECT list is bound, we set the types of DISTINCT/ORDER BY expressions
+	BindModifierTypes(*result, internal_sql_types, result->projection_index);
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void GatherAliases(BoundQueryNode &node, case_insensitive_map_t<idx_t> &aliases,
+                          expression_map_t<idx_t> &expressions) {
+	if (node.type == QueryNodeType::SET_OPERATION_NODE) {
+		// setop, recurse
+		auto &setop = (BoundSetOperationNode &)node;
+		GatherAliases(*setop.left, aliases, expressions);
+		GatherAliases(*setop.right, aliases, expressions);
+	} else {
+		// query node
+		D_ASSERT(node.type == QueryNodeType::SELECT_NODE);
+		auto &select = (BoundSelectNode &)node;
+		// fill the alias lists
+		for (idx_t i = 0; i < select.names.size(); i++) {
+			auto &name = select.names[i];
+			auto &expr = select.original_expressions[i];
+			// first check if the alias is already in there
+			auto entry = aliases.find(name);
+			if (entry != aliases.end()) {
+				// the alias already exists
+				// check if there is a conflict
+				if (entry->second != i) {
+					// there is a conflict
+					// we place "-1" in the aliases map at this location
+					// "-1" signifies that there is an ambiguous reference
+					aliases[name] = DConstants::INVALID_INDEX;
+				}
+			} else {
+				// the alias is not in there yet, just assign it
+				aliases[name] = i;
+			}
+			// now check if the node is already in the set of expressions
+			auto expr_entry = expressions.find(expr.get());
+			if (expr_entry != expressions.end()) {
+				// the node is in there
+				// repeat the same as with the alias: if there is an ambiguity we insert "-1"
+				if (expr_entry->second != i) {
+					expressions[expr.get()] = DConstants::INVALID_INDEX;
+				}
+			} else {
+				// not in there yet, just place it in there
+				expressions[expr.get()] = i;
+			}
+		}
+	}
+}
+
+unique_ptr<BoundQueryNode> Binder::BindNode(SetOperationNode &statement) {
+	auto result = make_unique<BoundSetOperationNode>();
+	result->setop_type = statement.setop_type;
+
+	// first recursively visit the set operations
+	// both the left and right sides have an independent BindContext and Binder
+	D_ASSERT(statement.left);
+	D_ASSERT(statement.right);
+
+	result->setop_index = GenerateTableIndex();
+
+	result->left_binder = Binder::CreateBinder(context, this);
+	result->left_binder->can_contain_nulls = true;
+	result->left = result->left_binder->BindNode(*statement.left);
+
+	result->right_binder = Binder::CreateBinder(context, this);
+	result->right_binder->can_contain_nulls = true;
+	result->right = result->right_binder->BindNode(*statement.right);
+
+	if (!statement.modifiers.empty()) {
+		// handle the ORDER BY/DISTINCT clauses
+
+		// we recursively visit the children of this node to extract aliases and expressions that can be referenced in
+		// the ORDER BY
+		case_insensitive_map_t<idx_t> alias_map;
+		expression_map_t<idx_t> expression_map;
+		GatherAliases(*result, alias_map, expression_map);
+
+		// now we perform the actual resolution of the ORDER BY/DISTINCT expressions
+		OrderBinder order_binder({result->left_binder.get(), result->right_binder.get()}, result->setop_index,
+		                         alias_map, expression_map, statement.left->GetSelectList().size());
+		BindModifiers(order_binder, statement, *result);
+	}
+
+	result->names = result->left->names;
+
+	// move the correlated expressions from the child binders to this binder
+	MoveCorrelatedExpressions(*result->left_binder);
+	MoveCorrelatedExpressions(*result->right_binder);
+
+	// now both sides have been bound we can resolve types
+	if (result->left->types.size() != result->right->types.size()) {
+		throw BinderException("Set operations can only apply to expressions with the "
+		                      "same number of result columns");
+	}
+
+	// figure out the types of the setop result by picking the max of both
+	for (idx_t i = 0; i < result->left->types.size(); i++) {
+		auto result_type = LogicalType::MaxLogicalType(result->left->types[i], result->right->types[i]);
+		if (!can_contain_nulls) {
+			if (ExpressionBinder::ContainsNullType(result_type)) {
+				result_type = ExpressionBinder::ExchangeNullType(result_type);
+			}
+		}
+		result->types.push_back(result_type);
+	}
+
+	// finally bind the types of the ORDER/DISTINCT clause expressions
+	BindModifierTypes(*result, result->types, result->setop_index);
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<QueryNode> Binder::BindTableMacro(FunctionExpression &function, TableMacroCatalogEntry *macro_func,
+                                             idx_t depth) {
+
+	auto &macro_def = (TableMacroFunction &)*macro_func->function;
+	auto node = macro_def.query_node->Copy();
+
+	// auto &macro_def = *macro_func->function;
+
+	// validate the arguments and separate positional and default arguments
+	vector<unique_ptr<ParsedExpression>> positionals;
+	unordered_map<string, unique_ptr<ParsedExpression>> defaults;
+	string error =
+	    MacroFunction::ValidateArguments(*macro_func->function, macro_func->name, function, positionals, defaults);
+	if (!error.empty()) {
+		// cannot use error below as binder rnot in scope
+		// return BindResult(binder. FormatError(*expr->get(), error));
+		throw BinderException(FormatError(function, error));
+	}
+
+	// create a MacroBinding to bind this macro's parameters to its arguments
+	vector<LogicalType> types;
+	vector<string> names;
+	// positional parameters
+	for (idx_t i = 0; i < macro_def.parameters.size(); i++) {
+		types.emplace_back(LogicalType::SQLNULL);
+		auto &param = (ColumnRefExpression &)*macro_def.parameters[i];
+		names.push_back(param.GetColumnName());
+	}
+	// default parameters
+	for (auto it = macro_def.default_parameters.begin(); it != macro_def.default_parameters.end(); it++) {
+		types.emplace_back(LogicalType::SQLNULL);
+		names.push_back(it->first);
+		// now push the defaults into the positionals
+		positionals.push_back(move(defaults[it->first]));
+	}
+	auto new_macro_binding = make_unique<MacroBinding>(types, names, macro_func->name);
+	new_macro_binding->arguments = move(positionals);
+
+	// We need an EXpressionBinder So that we can call ExpressionBinder::ReplaceMacroParametersRecursive()
+	auto eb = ExpressionBinder(*this, this->context);
+
+	eb.macro_binding = new_macro_binding.get();
+
+	/* Does it all goes throu every expression in a selectstmt  */
+	ParsedExpressionIterator::EnumerateQueryNodeChildren(
+	    *node, [&](unique_ptr<ParsedExpression> &child) { eb.ReplaceMacroParametersRecursive(child); });
+
+	return node;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> Binder::VisitQueryNode(BoundQueryNode &node, unique_ptr<LogicalOperator> root) {
+	D_ASSERT(root);
+	for (auto &mod : node.modifiers) {
+		switch (mod->type) {
+		case ResultModifierType::DISTINCT_MODIFIER: {
+			auto &bound = (BoundDistinctModifier &)*mod;
+			auto distinct = make_unique<LogicalDistinct>(move(bound.target_distincts));
+			distinct->AddChild(move(root));
+			root = move(distinct);
+			break;
+		}
+		case ResultModifierType::ORDER_MODIFIER: {
+			auto &bound = (BoundOrderModifier &)*mod;
+			auto order = make_unique<LogicalOrder>(move(bound.orders));
+			order->AddChild(move(root));
+			root = move(order);
+			break;
+		}
+		case ResultModifierType::LIMIT_MODIFIER: {
+			auto &bound = (BoundLimitModifier &)*mod;
+			auto limit =
+			    make_unique<LogicalLimit>(bound.limit_val, bound.offset_val, move(bound.limit), move(bound.offset));
+			limit->AddChild(move(root));
+			root = move(limit);
+			break;
+		}
+		case ResultModifierType::LIMIT_PERCENT_MODIFIER: {
+			auto &bound = (BoundLimitPercentModifier &)*mod;
+			auto limit = make_unique<LogicalLimitPercent>(bound.limit_percent, bound.offset_val, move(bound.limit),
+			                                              move(bound.offset));
+			limit->AddChild(move(root));
+			root = move(limit);
+			break;
+		}
+		default:
+			throw BinderException("Unimplemented modifier type!");
+		}
+	}
+	return root;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundRecursiveCTENode &node) {
+	// Generate the logical plan for the left and right sides of the set operation
+	node.left_binder->plan_subquery = plan_subquery;
+	node.right_binder->plan_subquery = plan_subquery;
+
+	auto left_node = node.left_binder->CreatePlan(*node.left);
+	auto right_node = node.right_binder->CreatePlan(*node.right);
+
+	// check if there are any unplanned subqueries left in either child
+	has_unplanned_subqueries =
+	    node.left_binder->has_unplanned_subqueries || node.right_binder->has_unplanned_subqueries;
+
+	// for both the left and right sides, cast them to the same types
+	left_node = CastLogicalOperatorToTypes(node.left->types, node.types, move(left_node));
+	right_node = CastLogicalOperatorToTypes(node.right->types, node.types, move(right_node));
+
+	if (!node.right_binder->bind_context.cte_references[node.ctename] ||
+	    *node.right_binder->bind_context.cte_references[node.ctename] == 0) {
+		auto root = make_unique<LogicalSetOperation>(node.setop_index, node.types.size(), move(left_node),
+		                                             move(right_node), LogicalOperatorType::LOGICAL_UNION);
+		return VisitQueryNode(node, move(root));
+	}
+	auto root = make_unique<LogicalRecursiveCTE>(node.setop_index, node.types.size(), node.union_all, move(left_node),
+	                                             move(right_node), LogicalOperatorType::LOGICAL_RECURSIVE_CTE);
+
+	return VisitQueryNode(node, move(root));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> Binder::PlanFilter(unique_ptr<Expression> condition, unique_ptr<LogicalOperator> root) {
+	PlanSubqueries(&condition, &root);
+	auto filter = make_unique<LogicalFilter>(move(condition));
+	filter->AddChild(move(root));
+	return move(filter);
+}
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSelectNode &statement) {
+	unique_ptr<LogicalOperator> root;
+	D_ASSERT(statement.from_table);
+	root = CreatePlan(*statement.from_table);
+	D_ASSERT(root);
+
+	// plan the sample clause
+	if (statement.sample_options) {
+		root = make_unique<LogicalSample>(move(statement.sample_options), move(root));
+	}
+
+	if (statement.where_clause) {
+		root = PlanFilter(move(statement.where_clause), move(root));
+	}
+
+	if (!statement.aggregates.empty() || !statement.groups.group_expressions.empty()) {
+		if (!statement.groups.group_expressions.empty()) {
+			// visit the groups
+			for (auto &group : statement.groups.group_expressions) {
+				PlanSubqueries(&group, &root);
+			}
+		}
+		// now visit all aggregate expressions
+		for (auto &expr : statement.aggregates) {
+			PlanSubqueries(&expr, &root);
+		}
+		// finally create the aggregate node with the group_index and aggregate_index as obtained from the binder
+		auto aggregate =
+		    make_unique<LogicalAggregate>(statement.group_index, statement.aggregate_index, move(statement.aggregates));
+		aggregate->groups = move(statement.groups.group_expressions);
+		aggregate->groupings_index = statement.groupings_index;
+		aggregate->grouping_sets = move(statement.groups.grouping_sets);
+		aggregate->grouping_functions = move(statement.grouping_functions);
+
+		aggregate->AddChild(move(root));
+		root = move(aggregate);
+	} else if (!statement.groups.grouping_sets.empty()) {
+		// edge case: we have grouping sets but no groups or aggregates
+		// this can only happen if we have e.g. select 1 from tbl group by ();
+		// just output a dummy scan
+		root = make_unique_base<LogicalOperator, LogicalDummyScan>(statement.group_index);
+	}
+
+	if (statement.having) {
+		PlanSubqueries(&statement.having, &root);
+		auto having = make_unique<LogicalFilter>(move(statement.having));
+
+		having->AddChild(move(root));
+		root = move(having);
+	}
+
+	if (!statement.windows.empty()) {
+		auto win = make_unique<LogicalWindow>(statement.window_index);
+		win->expressions = move(statement.windows);
+		// visit the window expressions
+		for (auto &expr : win->expressions) {
+			PlanSubqueries(&expr, &root);
+		}
+		D_ASSERT(!win->expressions.empty());
+		win->AddChild(move(root));
+		root = move(win);
+	}
+
+	if (statement.qualify) {
+		PlanSubqueries(&statement.qualify, &root);
+		auto qualify = make_unique<LogicalFilter>(move(statement.qualify));
+
+		qualify->AddChild(move(root));
+		root = move(qualify);
+	}
+
+	if (!statement.unnests.empty()) {
+		auto unnest = make_unique<LogicalUnnest>(statement.unnest_index);
+		unnest->expressions = move(statement.unnests);
+		// visit the unnest expressions
+		for (auto &expr : unnest->expressions) {
+			PlanSubqueries(&expr, &root);
+		}
+		D_ASSERT(!unnest->expressions.empty());
+		unnest->AddChild(move(root));
+		root = move(unnest);
+	}
+
+	for (auto &expr : statement.select_list) {
+		PlanSubqueries(&expr, &root);
+	}
+
+	// create the projection
+	auto proj = make_unique<LogicalProjection>(statement.projection_index, move(statement.select_list));
+	auto &projection = *proj;
+	proj->AddChild(move(root));
+	root = move(proj);
+
+	// finish the plan by handling the elements of the QueryNode
+	root = VisitQueryNode(statement, move(root));
+
+	// add a prune node if necessary
+	if (statement.need_prune) {
+		D_ASSERT(root);
+		vector<unique_ptr<Expression>> prune_expressions;
+		for (idx_t i = 0; i < statement.column_count; i++) {
+			prune_expressions.push_back(make_unique<BoundColumnRefExpression>(
+			    projection.expressions[i]->return_type, ColumnBinding(statement.projection_index, i)));
+		}
+		auto prune = make_unique<LogicalProjection>(statement.prune_index, move(prune_expressions));
+		prune->AddChild(move(root));
+		root = move(prune);
+	}
+	return root;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> Binder::CastLogicalOperatorToTypes(vector<LogicalType> &source_types,
+                                                               vector<LogicalType> &target_types,
+                                                               unique_ptr<LogicalOperator> op) {
+	D_ASSERT(op);
+	// first check if we even need to cast
+	D_ASSERT(source_types.size() == target_types.size());
+	if (source_types == target_types) {
+		// source and target types are equal: don't need to cast
+		return op;
+	}
+	// otherwise add casts
+	auto node = op.get();
+	if (node->type == LogicalOperatorType::LOGICAL_PROJECTION) {
+		// "node" is a projection; we can just do the casts in there
+		D_ASSERT(node->expressions.size() == source_types.size());
+		// add the casts to the selection list
+		for (idx_t i = 0; i < target_types.size(); i++) {
+			if (source_types[i] != target_types[i]) {
+				// differing types, have to add a cast
+				string alias = node->expressions[i]->alias;
+				node->expressions[i] = make_unique<BoundCastExpression>(move(node->expressions[i]), target_types[i]);
+				node->expressions[i]->alias = alias;
+			}
+		}
+		return op;
+	} else {
+		// found a non-projection operator
+		// push a new projection containing the casts
+
+		// fetch the set of column bindings
+		auto setop_columns = op->GetColumnBindings();
+		D_ASSERT(setop_columns.size() == source_types.size());
+
+		// now generate the expression list
+		vector<unique_ptr<Expression>> select_list;
+		for (idx_t i = 0; i < target_types.size(); i++) {
+			unique_ptr<Expression> result = make_unique<BoundColumnRefExpression>(source_types[i], setop_columns[i]);
+			if (source_types[i] != target_types[i]) {
+				// add a cast only if the source and target types are not equivalent
+				result = make_unique<BoundCastExpression>(move(result), target_types[i]);
+			}
+			select_list.push_back(move(result));
+		}
+		auto projection = make_unique<LogicalProjection>(GenerateTableIndex(), move(select_list));
+		projection->children.push_back(move(op));
+		return move(projection);
+	}
+}
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSetOperationNode &node) {
+	// Generate the logical plan for the left and right sides of the set operation
+	node.left_binder->plan_subquery = plan_subquery;
+	node.right_binder->plan_subquery = plan_subquery;
+
+	auto left_node = node.left_binder->CreatePlan(*node.left);
+	auto right_node = node.right_binder->CreatePlan(*node.right);
+
+	// check if there are any unplanned subqueries left in either child
+	has_unplanned_subqueries =
+	    node.left_binder->has_unplanned_subqueries || node.right_binder->has_unplanned_subqueries;
+
+	// for both the left and right sides, cast them to the same types
+	left_node = CastLogicalOperatorToTypes(node.left->types, node.types, move(left_node));
+	right_node = CastLogicalOperatorToTypes(node.right->types, node.types, move(right_node));
+
+	// create actual logical ops for setops
+	LogicalOperatorType logical_type;
+	switch (node.setop_type) {
+	case SetOperationType::UNION:
+		logical_type = LogicalOperatorType::LOGICAL_UNION;
+		break;
+	case SetOperationType::EXCEPT:
+		logical_type = LogicalOperatorType::LOGICAL_EXCEPT;
+		break;
+	default:
+		D_ASSERT(node.setop_type == SetOperationType::INTERSECT);
+		logical_type = LogicalOperatorType::LOGICAL_INTERSECT;
+		break;
+	}
+	auto root = make_unique<LogicalSetOperation>(node.setop_index, node.types.size(), move(left_node), move(right_node),
+	                                             logical_type);
+
+	return VisitQueryNode(node, move(root));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static unique_ptr<Expression> PlanUncorrelatedSubquery(Binder &binder, BoundSubqueryExpression &expr,
+                                                       unique_ptr<LogicalOperator> &root,
+                                                       unique_ptr<LogicalOperator> plan) {
+	D_ASSERT(!expr.IsCorrelated());
+	switch (expr.subquery_type) {
+	case SubqueryType::EXISTS: {
+		// uncorrelated EXISTS
+		// we only care about existence, hence we push a LIMIT 1 operator
+		auto limit = make_unique<LogicalLimit>(1, 0, nullptr, nullptr);
+		limit->AddChild(move(plan));
+		plan = move(limit);
+
+		// now we push a COUNT(*) aggregate onto the limit, this will be either 0 or 1 (EXISTS or NOT EXISTS)
+		auto count_star_fun = CountStarFun::GetFunction();
+		auto count_star = AggregateFunction::BindAggregateFunction(binder.context, count_star_fun, {}, nullptr, false);
+		auto idx_type = count_star->return_type;
+		vector<unique_ptr<Expression>> aggregate_list;
+		aggregate_list.push_back(move(count_star));
+		auto aggregate_index = binder.GenerateTableIndex();
+		auto aggregate =
+		    make_unique<LogicalAggregate>(binder.GenerateTableIndex(), aggregate_index, move(aggregate_list));
+		aggregate->AddChild(move(plan));
+		plan = move(aggregate);
+
+		// now we push a projection with a comparison to 1
+		auto left_child = make_unique<BoundColumnRefExpression>(idx_type, ColumnBinding(aggregate_index, 0));
+		auto right_child = make_unique<BoundConstantExpression>(Value::Numeric(idx_type, 1));
+		auto comparison =
+		    make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_EQUAL, move(left_child), move(right_child));
+
+		vector<unique_ptr<Expression>> projection_list;
+		projection_list.push_back(move(comparison));
+		auto projection_index = binder.GenerateTableIndex();
+		auto projection = make_unique<LogicalProjection>(projection_index, move(projection_list));
+		projection->AddChild(move(plan));
+		plan = move(projection);
+
+		// we add it to the main query by adding a cross product
+		// FIXME: should use something else besides cross product as we always add only one scalar constant
+		auto cross_product = make_unique<LogicalCrossProduct>();
+		cross_product->AddChild(move(root));
+		cross_product->AddChild(move(plan));
+		root = move(cross_product);
+
+		// we replace the original subquery with a ColumnRefExpression referring to the result of the projection (either
+		// TRUE or FALSE)
+		return make_unique<BoundColumnRefExpression>(expr.GetName(), LogicalType::BOOLEAN,
+		                                             ColumnBinding(projection_index, 0));
+	}
+	case SubqueryType::SCALAR: {
+		// uncorrelated scalar, we want to return the first entry
+		// figure out the table index of the bound table of the entry which we want to return
+		auto bindings = plan->GetColumnBindings();
+		D_ASSERT(bindings.size() == 1);
+		idx_t table_idx = bindings[0].table_index;
+
+		// in the uncorrelated case we are only interested in the first result of the query
+		// hence we simply push a LIMIT 1 to get the first row of the subquery
+		auto limit = make_unique<LogicalLimit>(1, 0, nullptr, nullptr);
+		limit->AddChild(move(plan));
+		plan = move(limit);
+
+		// we push an aggregate that returns the FIRST element
+		vector<unique_ptr<Expression>> expressions;
+		auto bound = make_unique<BoundColumnRefExpression>(expr.return_type, ColumnBinding(table_idx, 0));
+		vector<unique_ptr<Expression>> first_children;
+		first_children.push_back(move(bound));
+		auto first_agg = AggregateFunction::BindAggregateFunction(
+		    binder.context, FirstFun::GetFunction(expr.return_type), move(first_children), nullptr, false);
+
+		expressions.push_back(move(first_agg));
+		auto aggr_index = binder.GenerateTableIndex();
+		auto aggr = make_unique<LogicalAggregate>(binder.GenerateTableIndex(), aggr_index, move(expressions));
+		aggr->AddChild(move(plan));
+		plan = move(aggr);
+
+		// in the uncorrelated case, we add the value to the main query through a cross product
+		// FIXME: should use something else besides cross product as we always add only one scalar constant and cross
+		// product is not optimized for this.
+		D_ASSERT(root);
+		auto cross_product = make_unique<LogicalCrossProduct>();
+		cross_product->AddChild(move(root));
+		cross_product->AddChild(move(plan));
+		root = move(cross_product);
+
+		// we replace the original subquery with a BoundColumnRefExpression referring to the first result of the
+		// aggregation
+		return make_unique<BoundColumnRefExpression>(expr.GetName(), expr.return_type, ColumnBinding(aggr_index, 0));
+	}
+	default: {
+		D_ASSERT(expr.subquery_type == SubqueryType::ANY);
+		// we generate a MARK join that results in either (TRUE, FALSE or NULL)
+		// subquery has NULL values -> result is (TRUE or NULL)
+		// subquery has no NULL values -> result is (TRUE, FALSE or NULL [if input is NULL])
+		// fetch the column bindings
+		auto plan_columns = plan->GetColumnBindings();
+
+		// then we generate the MARK join with the subquery
+		idx_t mark_index = binder.GenerateTableIndex();
+		auto join = make_unique<LogicalComparisonJoin>(JoinType::MARK);
+		join->mark_index = mark_index;
+		join->AddChild(move(root));
+		join->AddChild(move(plan));
+		// create the JOIN condition
+		JoinCondition cond;
+		cond.left = move(expr.child);
+		cond.right = BoundCastExpression::AddCastToType(
+		    make_unique<BoundColumnRefExpression>(expr.child_type, plan_columns[0]), expr.child_target);
+		cond.comparison = expr.comparison_type;
+		join->conditions.push_back(move(cond));
+		root = move(join);
+
+		// we replace the original subquery with a BoundColumnRefExpression referring to the mark column
+		return make_unique<BoundColumnRefExpression>(expr.GetName(), expr.return_type, ColumnBinding(mark_index, 0));
+	}
+	}
+}
+
+static unique_ptr<LogicalDelimJoin> CreateDuplicateEliminatedJoin(vector<CorrelatedColumnInfo> &correlated_columns,
+                                                                  JoinType join_type) {
+	auto delim_join = make_unique<LogicalDelimJoin>(join_type);
+	for (idx_t i = 0; i < correlated_columns.size(); i++) {
+		auto &col = correlated_columns[i];
+		delim_join->duplicate_eliminated_columns.push_back(
+		    make_unique<BoundColumnRefExpression>(col.type, col.binding));
+		delim_join->delim_types.push_back(col.type);
+	}
+	return delim_join;
+}
+
+static void CreateDelimJoinConditions(LogicalDelimJoin &delim_join, vector<CorrelatedColumnInfo> &correlated_columns,
+                                      vector<ColumnBinding> bindings, idx_t base_offset) {
+	for (idx_t i = 0; i < correlated_columns.size(); i++) {
+		auto &col = correlated_columns[i];
+		JoinCondition cond;
+		cond.left = make_unique<BoundColumnRefExpression>(col.name, col.type, col.binding);
+		cond.right = make_unique<BoundColumnRefExpression>(col.name, col.type, bindings[base_offset + i]);
+		cond.comparison = ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+		delim_join.conditions.push_back(move(cond));
+	}
+}
+
+static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubqueryExpression &expr,
+                                                     unique_ptr<LogicalOperator> &root,
+                                                     unique_ptr<LogicalOperator> plan) {
+	auto &correlated_columns = expr.binder->correlated_columns;
+	D_ASSERT(expr.IsCorrelated());
+	// correlated subquery
+	// for a more in-depth explanation of this code, read the paper "Unnesting Arbitrary Subqueries"
+	// we handle three types of correlated subqueries: Scalar, EXISTS and ANY
+	// all three cases are very similar with some minor changes (mainly the type of join performed at the end)
+	switch (expr.subquery_type) {
+	case SubqueryType::SCALAR: {
+		// correlated SCALAR query
+		// first push a DUPLICATE ELIMINATED join
+		// a duplicate eliminated join creates a duplicate eliminated copy of the LHS
+		// and pushes it into any DUPLICATE_ELIMINATED SCAN operators on the RHS
+
+		// in the SCALAR case, we create a SINGLE join (because we are only interested in obtaining the value)
+		// NULL values are equal in this join because we join on the correlated columns ONLY
+		// and e.g. in the query: SELECT (SELECT 42 FROM integers WHERE i1.i IS NULL LIMIT 1) FROM integers i1;
+		// the input value NULL will generate the value 42, and we need to join NULL on the LHS with NULL on the RHS
+		auto delim_join = CreateDuplicateEliminatedJoin(correlated_columns, JoinType::SINGLE);
+
+		// the left side is the original plan
+		// this is the side that will be duplicate eliminated and pushed into the RHS
+		delim_join->AddChild(move(root));
+		// the right side initially is a DEPENDENT join between the duplicate eliminated scan and the subquery
+		// HOWEVER: we do not explicitly create the dependent join
+		// instead, we eliminate the dependent join by pushing it down into the right side of the plan
+		FlattenDependentJoins flatten(binder, correlated_columns);
+
+		// first we check which logical operators have correlated expressions in the first place
+		flatten.DetectCorrelatedExpressions(plan.get());
+		// now we push the dependent join down
+		auto dependent_join = flatten.PushDownDependentJoin(move(plan));
+
+		// now the dependent join is fully eliminated
+		// we only need to create the join conditions between the LHS and the RHS
+		// fetch the set of columns
+		auto plan_columns = dependent_join->GetColumnBindings();
+
+		// now create the join conditions
+		CreateDelimJoinConditions(*delim_join, correlated_columns, plan_columns, flatten.delim_offset);
+		delim_join->AddChild(move(dependent_join));
+		root = move(delim_join);
+		// finally push the BoundColumnRefExpression referring to the data element returned by the join
+		return make_unique<BoundColumnRefExpression>(expr.GetName(), expr.return_type,
+		                                             plan_columns[flatten.data_offset]);
+	}
+	case SubqueryType::EXISTS: {
+		// correlated EXISTS query
+		// this query is similar to the correlated SCALAR query, except we use a MARK join here
+		idx_t mark_index = binder.GenerateTableIndex();
+		auto delim_join = CreateDuplicateEliminatedJoin(correlated_columns, JoinType::MARK);
+		delim_join->mark_index = mark_index;
+		// LHS
+		delim_join->AddChild(move(root));
+		// RHS
+		FlattenDependentJoins flatten(binder, correlated_columns);
+		flatten.DetectCorrelatedExpressions(plan.get());
+		auto dependent_join = flatten.PushDownDependentJoin(move(plan));
+
+		// fetch the set of columns
+		auto plan_columns = dependent_join->GetColumnBindings();
+
+		// now we create the join conditions between the dependent join and the original table
+		CreateDelimJoinConditions(*delim_join, correlated_columns, plan_columns, flatten.delim_offset);
+		delim_join->AddChild(move(dependent_join));
+		root = move(delim_join);
+		// finally push the BoundColumnRefExpression referring to the marker
+		return make_unique<BoundColumnRefExpression>(expr.GetName(), expr.return_type, ColumnBinding(mark_index, 0));
+	}
+	default: {
+		D_ASSERT(expr.subquery_type == SubqueryType::ANY);
+		// correlated ANY query
+		// this query is similar to the correlated SCALAR query
+		// however, in this case we push a correlated MARK join
+		// note that in this join null values are NOT equal for ALL columns, but ONLY for the correlated columns
+		// the correlated mark join handles this case by itself
+		// as the MARK join has one extra join condition (the original condition, of the ANY expression, e.g.
+		// [i=ANY(...)])
+		idx_t mark_index = binder.GenerateTableIndex();
+		auto delim_join = CreateDuplicateEliminatedJoin(correlated_columns, JoinType::MARK);
+		delim_join->mark_index = mark_index;
+		// LHS
+		delim_join->AddChild(move(root));
+		// RHS
+		FlattenDependentJoins flatten(binder, correlated_columns, true);
+		flatten.DetectCorrelatedExpressions(plan.get());
+		auto dependent_join = flatten.PushDownDependentJoin(move(plan));
+
+		// fetch the columns
+		auto plan_columns = dependent_join->GetColumnBindings();
+
+		// now we create the join conditions between the dependent join and the original table
+		CreateDelimJoinConditions(*delim_join, correlated_columns, plan_columns, flatten.delim_offset);
+		// add the actual condition based on the ANY/ALL predicate
+		JoinCondition compare_cond;
+		compare_cond.left = move(expr.child);
+		compare_cond.right = BoundCastExpression::AddCastToType(
+		    make_unique<BoundColumnRefExpression>(expr.child_type, plan_columns[0]), expr.child_target);
+		compare_cond.comparison = expr.comparison_type;
+		delim_join->conditions.push_back(move(compare_cond));
+
+		delim_join->AddChild(move(dependent_join));
+		root = move(delim_join);
+		// finally push the BoundColumnRefExpression referring to the marker
+		return make_unique<BoundColumnRefExpression>(expr.GetName(), expr.return_type, ColumnBinding(mark_index, 0));
+	}
+	}
+}
+
+class RecursiveSubqueryPlanner : public LogicalOperatorVisitor {
+public:
+	explicit RecursiveSubqueryPlanner(Binder &binder) : binder(binder) {
+	}
+	void VisitOperator(LogicalOperator &op) override {
+		if (!op.children.empty()) {
+			root = move(op.children[0]);
+			VisitOperatorExpressions(op);
+			op.children[0] = move(root);
+			for (idx_t i = 0; i < op.children.size(); i++) {
+				VisitOperator(*op.children[i]);
+			}
+		}
+	}
+
+	unique_ptr<Expression> VisitReplace(BoundSubqueryExpression &expr, unique_ptr<Expression> *expr_ptr) override {
+		return binder.PlanSubquery(expr, root);
+	}
+
+private:
+	unique_ptr<LogicalOperator> root;
+	Binder &binder;
+};
+
+unique_ptr<Expression> Binder::PlanSubquery(BoundSubqueryExpression &expr, unique_ptr<LogicalOperator> &root) {
+	D_ASSERT(root);
+	// first we translate the QueryNode of the subquery into a logical plan
+	// note that we do not plan nested subqueries yet
+	auto sub_binder = Binder::CreateBinder(context);
+	sub_binder->plan_subquery = false;
+	auto subquery_root = sub_binder->CreatePlan(*expr.subquery);
+	D_ASSERT(subquery_root);
+
+	// now we actually flatten the subquery
+	auto plan = move(subquery_root);
+	unique_ptr<Expression> result_expression;
+	if (!expr.IsCorrelated()) {
+		result_expression = PlanUncorrelatedSubquery(*this, expr, root, move(plan));
+	} else {
+		result_expression = PlanCorrelatedSubquery(*this, expr, root, move(plan));
+	}
+	// finally, we recursively plan the nested subqueries (if there are any)
+	if (sub_binder->has_unplanned_subqueries) {
+		RecursiveSubqueryPlanner plan(*this);
+		plan.VisitOperator(*root);
+	}
+	return result_expression;
+}
+
+void Binder::PlanSubqueries(unique_ptr<Expression> *expr_ptr, unique_ptr<LogicalOperator> *root) {
+	if (!*expr_ptr) {
+		return;
+	}
+	auto &expr = **expr_ptr;
+
+	// first visit the children of the node, if any
+	ExpressionIterator::EnumerateChildren(expr, [&](unique_ptr<Expression> &expr) { PlanSubqueries(&expr, root); });
+
+	// check if this is a subquery node
+	if (expr.expression_class == ExpressionClass::BOUND_SUBQUERY) {
+		auto &subquery = (BoundSubqueryExpression &)expr;
+		// subquery node! plan it
+		if (subquery.IsCorrelated() && !plan_subquery) {
+			// detected a nested correlated subquery
+			// we don't plan it yet here, we are currently planning a subquery
+			// nested subqueries will only be planned AFTER the current subquery has been flattened entirely
+			has_unplanned_subqueries = true;
+			return;
+		}
+		*expr_ptr = PlanSubquery(subquery, *root);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(CallStatement &stmt) {
+	BoundStatement result;
+
+	TableFunctionRef ref;
+	ref.function = move(stmt.function);
+
+	auto bound_func = Bind(ref);
+	auto &bound_table_func = (BoundTableFunction &)*bound_func;
+	auto &get = (LogicalGet &)*bound_table_func.get;
+	D_ASSERT(get.returned_types.size() > 0);
+	for (idx_t i = 0; i < get.returned_types.size(); i++) {
+		get.column_ids.push_back(i);
+	}
+
+	result.types = get.returned_types;
+	result.names = get.names;
+	result.plan = CreatePlan(*bound_func);
+	properties.return_type = StatementReturnType::QUERY_RESULT;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+BoundStatement Binder::BindCopyTo(CopyStatement &stmt) {
+	// COPY TO a file
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("COPY TO is disabled by configuration");
+	}
+	BoundStatement result;
+	result.types = {LogicalType::BIGINT};
+	result.names = {"Count"};
+
+	// bind the select statement
+	auto select_node = Bind(*stmt.select_statement);
+
+	// lookup the format in the catalog
+	auto &catalog = Catalog::GetCatalog(context);
+	auto copy_function = catalog.GetEntry<CopyFunctionCatalogEntry>(context, DEFAULT_SCHEMA, stmt.info->format);
+	if (!copy_function->function.copy_to_bind) {
+		throw NotImplementedException("COPY TO is not supported for FORMAT \"%s\"", stmt.info->format);
+	}
+	bool use_tmp_file = true;
+	for (auto &option : stmt.info->options) {
+		auto loption = StringUtil::Lower(option.first);
+		if (loption == "use_tmp_file") {
+			use_tmp_file = option.second[0].CastAs(LogicalType::BOOLEAN).GetValue<bool>();
+			stmt.info->options.erase(option.first);
+			break;
+		}
+	}
+	auto function_data =
+	    copy_function->function.copy_to_bind(context, *stmt.info, select_node.names, select_node.types);
+	// now create the copy information
+	auto copy = make_unique<LogicalCopyToFile>(copy_function->function, move(function_data));
+	copy->file_path = stmt.info->file_path;
+	copy->use_tmp_file = use_tmp_file;
+	copy->is_file_and_exists = config.file_system->FileExists(copy->file_path);
+
+	copy->AddChild(move(select_node.plan));
+
+	result.plan = move(copy);
+
+	return result;
+}
+
+BoundStatement Binder::BindCopyFrom(CopyStatement &stmt) {
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("COPY FROM is disabled by configuration");
+	}
+	BoundStatement result;
+	result.types = {LogicalType::BIGINT};
+	result.names = {"Count"};
+
+	D_ASSERT(!stmt.info->table.empty());
+	// COPY FROM a file
+	// generate an insert statement for the the to-be-inserted table
+	InsertStatement insert;
+	insert.table = stmt.info->table;
+	insert.schema = stmt.info->schema;
+	insert.columns = stmt.info->select_list;
+
+	// bind the insert statement to the base table
+	auto insert_statement = Bind(insert);
+	D_ASSERT(insert_statement.plan->type == LogicalOperatorType::LOGICAL_INSERT);
+
+	auto &bound_insert = (LogicalInsert &)*insert_statement.plan;
+
+	// lookup the format in the catalog
+	auto &catalog = Catalog::GetCatalog(context);
+	auto copy_function = catalog.GetEntry<CopyFunctionCatalogEntry>(context, DEFAULT_SCHEMA, stmt.info->format);
+	if (!copy_function->function.copy_from_bind) {
+		throw NotImplementedException("COPY FROM is not supported for FORMAT \"%s\"", stmt.info->format);
+	}
+	// lookup the table to copy into
+	auto table = Catalog::GetCatalog(context).GetEntry<TableCatalogEntry>(context, stmt.info->schema, stmt.info->table);
+	vector<string> expected_names;
+	if (!bound_insert.column_index_map.empty()) {
+		expected_names.resize(bound_insert.expected_types.size());
+		for (idx_t i = 0; i < table->columns.size(); i++) {
+			if (bound_insert.column_index_map[i] != DConstants::INVALID_INDEX) {
+				expected_names[bound_insert.column_index_map[i]] = table->columns[i].Name();
+			}
+		}
+	} else {
+		expected_names.reserve(bound_insert.expected_types.size());
+		for (idx_t i = 0; i < table->columns.size(); i++) {
+			expected_names.push_back(table->columns[i].Name());
+		}
+	}
+
+	auto function_data =
+	    copy_function->function.copy_from_bind(context, *stmt.info, expected_names, bound_insert.expected_types);
+	auto get = make_unique<LogicalGet>(0, copy_function->function.copy_from_function, move(function_data),
+	                                   bound_insert.expected_types, expected_names);
+	for (idx_t i = 0; i < bound_insert.expected_types.size(); i++) {
+		get->column_ids.push_back(i);
+	}
+	insert_statement.plan->children.push_back(move(get));
+	result.plan = move(insert_statement.plan);
+	return result;
+}
+
+BoundStatement Binder::Bind(CopyStatement &stmt) {
+	if (!stmt.info->is_from && !stmt.select_statement) {
+		// copy table into file without a query
+		// generate SELECT * FROM table;
+		auto ref = make_unique<BaseTableRef>();
+		ref->schema_name = stmt.info->schema;
+		ref->table_name = stmt.info->table;
+
+		auto statement = make_unique<SelectNode>();
+		statement->from_table = move(ref);
+		if (!stmt.info->select_list.empty()) {
+			for (auto &name : stmt.info->select_list) {
+				statement->select_list.push_back(make_unique<ColumnRefExpression>(name));
+			}
+		} else {
+			statement->select_list.push_back(make_unique<StarExpression>());
+		}
+		stmt.select_statement = move(statement);
+	}
+	properties.allow_stream_result = false;
+	properties.return_type = StatementReturnType::CHANGED_ROWS;
+	if (stmt.info->is_from) {
+		return BindCopyFrom(stmt);
+	} else {
+		return BindCopyTo(stmt);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+SchemaCatalogEntry *Binder::BindSchema(CreateInfo &info) {
+	if (info.schema.empty()) {
+		info.schema = info.temporary ? TEMP_SCHEMA : ClientData::Get(context).catalog_search_path->GetDefault();
+	}
+
+	if (!info.temporary) {
+		// non-temporary create: not read only
+		if (info.schema == TEMP_SCHEMA) {
+			throw ParserException("Only TEMPORARY table names can use the \"temp\" schema");
+		}
+		properties.read_only = false;
+	} else {
+		if (info.schema != TEMP_SCHEMA) {
+			throw ParserException("TEMPORARY table names can *only* use the \"%s\" schema", TEMP_SCHEMA);
+		}
+	}
+	// fetch the schema in which we want to create the object
+	auto schema_obj = Catalog::GetCatalog(context).GetSchema(context, info.schema);
+	D_ASSERT(schema_obj->type == CatalogType::SCHEMA_ENTRY);
+	info.schema = schema_obj->name;
+	return schema_obj;
+}
+
+void Binder::BindCreateViewInfo(CreateViewInfo &base) {
+	// bind the view as if it were a query so we can catch errors
+	// note that we bind the original, and replace the original with a copy
+	auto view_binder = Binder::CreateBinder(context);
+	view_binder->can_contain_nulls = true;
+
+	auto copy = base.query->Copy();
+	auto query_node = view_binder->Bind(*base.query);
+	base.query = unique_ptr_cast<SQLStatement, SelectStatement>(move(copy));
+	if (base.aliases.size() > query_node.names.size()) {
+		throw BinderException("More VIEW aliases than columns in query result");
+	}
+	// fill up the aliases with the remaining names of the bound query
+	for (idx_t i = base.aliases.size(); i < query_node.names.size(); i++) {
+		base.aliases.push_back(query_node.names[i]);
+	}
+	base.types = query_node.types;
+}
+
+SchemaCatalogEntry *Binder::BindCreateFunctionInfo(CreateInfo &info) {
+	auto &base = (CreateMacroInfo &)info;
+	auto &scalar_function = (ScalarMacroFunction &)*base.function;
+
+	if (scalar_function.expression->HasParameter()) {
+		throw BinderException("Parameter expressions within macro's are not supported!");
+	}
+
+	// create macro binding in order to bind the function
+	vector<LogicalType> dummy_types;
+	vector<string> dummy_names;
+	// positional parameters
+	for (idx_t i = 0; i < base.function->parameters.size(); i++) {
+		auto param = (ColumnRefExpression &)*base.function->parameters[i];
+		if (param.IsQualified()) {
+			throw BinderException("Invalid parameter name '%s': must be unqualified", param.ToString());
+		}
+		dummy_types.emplace_back(LogicalType::SQLNULL);
+		dummy_names.push_back(param.GetColumnName());
+	}
+	// default parameters
+	for (auto it = base.function->default_parameters.begin(); it != base.function->default_parameters.end(); it++) {
+		auto &val = (ConstantExpression &)*it->second;
+		dummy_types.push_back(val.value.type());
+		dummy_names.push_back(it->first);
+	}
+	auto this_macro_binding = make_unique<MacroBinding>(dummy_types, dummy_names, base.name);
+	macro_binding = this_macro_binding.get();
+	ExpressionBinder::QualifyColumnNames(*this, scalar_function.expression);
+
+	// create a copy of the expression because we do not want to alter the original
+	auto expression = scalar_function.expression->Copy();
+
+	// bind it to verify the function was defined correctly
+	string error;
+	auto sel_node = make_unique<BoundSelectNode>();
+	auto group_info = make_unique<BoundGroupInformation>();
+	SelectBinder binder(*this, context, *sel_node, *group_info);
+	error = binder.Bind(&expression, 0, false);
+
+	if (!error.empty()) {
+		throw BinderException(error);
+	}
+
+	return BindSchema(info);
+}
+
+void Binder::BindLogicalType(ClientContext &context, LogicalType &type, const string &schema) {
+	if (type.id() == LogicalTypeId::LIST) {
+		auto child_type = ListType::GetChildType(type);
+		BindLogicalType(context, child_type, schema);
+		type = LogicalType::LIST(child_type);
+	} else if (type.id() == LogicalTypeId::STRUCT || type.id() == LogicalTypeId::MAP) {
+		auto child_types = StructType::GetChildTypes(type);
+		for (auto &child_type : child_types) {
+			BindLogicalType(context, child_type.second, schema);
+		}
+		// Generate new Struct/Map Type
+		if (type.id() == LogicalTypeId::STRUCT) {
+			type = LogicalType::STRUCT(child_types);
+		} else {
+			type = LogicalType::MAP(child_types);
+		}
+	} else if (type.id() == LogicalTypeId::USER) {
+		auto &catalog = Catalog::GetCatalog(context);
+		type = catalog.GetType(context, schema, UserType::GetTypeName(type));
+	} else if (type.id() == LogicalTypeId::ENUM) {
+		auto &enum_type_name = EnumType::GetTypeName(type);
+		auto enum_type_catalog = (TypeCatalogEntry *)context.db->GetCatalog().GetEntry(context, CatalogType::TYPE_ENTRY,
+		                                                                               schema, enum_type_name, true);
+		LogicalType::SetCatalog(type, enum_type_catalog);
+	}
+}
+
+static void FindMatchingPrimaryKeyColumns(vector<unique_ptr<Constraint>> &constraints, ForeignKeyConstraint &fk) {
+	if (!fk.pk_columns.empty()) {
+		return;
+	}
+	// find the matching primary key constraint
+	for (auto &constr : constraints) {
+		if (constr->type != ConstraintType::UNIQUE) {
+			continue;
+		}
+		auto &unique = (UniqueConstraint &)*constr;
+		if (!unique.is_primary_key) {
+			continue;
+		}
+		idx_t column_count;
+		if (unique.index != DConstants::INVALID_INDEX) {
+			fk.info.pk_keys.push_back(unique.index);
+			column_count = 1;
+		} else {
+			fk.pk_columns = unique.columns;
+			column_count = unique.columns.size();
+		}
+		if (column_count != fk.fk_columns.size()) {
+			throw BinderException("The number of referencing and referenced columns for foreign keys must be the same");
+		}
+		return;
+	}
+	throw BinderException("there is no primary key for referenced table \"%s\"", fk.info.table);
+}
+
+void ExpressionContainsGeneratedColumn(const ParsedExpression &expr, const unordered_set<string> &gcols,
+                                       bool &contains_gcol) {
+	if (contains_gcol) {
+		return;
+	}
+	if (expr.type == ExpressionType::COLUMN_REF) {
+		auto &column_ref = (ColumnRefExpression &)expr;
+		auto &name = column_ref.GetColumnName();
+		if (gcols.count(name)) {
+			contains_gcol = true;
+			return;
+		}
+	}
+	ParsedExpressionIterator::EnumerateChildren(
+	    expr, [&](const ParsedExpression &child) { ExpressionContainsGeneratedColumn(child, gcols, contains_gcol); });
+}
+
+static bool AnyConstraintReferencesGeneratedColumn(CreateTableInfo &table_info) {
+	unordered_set<string> generated_columns;
+	for (auto &col : table_info.columns) {
+		if (!col.Generated()) {
+			continue;
+		}
+		generated_columns.insert(col.Name());
+	}
+	if (generated_columns.empty()) {
+		return false;
+	}
+
+	for (auto &constr : table_info.constraints) {
+		switch (constr->type) {
+		case ConstraintType::CHECK: {
+			auto &constraint = (CheckConstraint &)*constr;
+			auto &expr = constraint.expression;
+			bool contains_generated_column = false;
+			ExpressionContainsGeneratedColumn(*expr, generated_columns, contains_generated_column);
+			if (contains_generated_column) {
+				return true;
+			}
+			break;
+		}
+		case ConstraintType::NOT_NULL: {
+			auto &constraint = (NotNullConstraint &)*constr;
+			auto index = constraint.index;
+			if (table_info.columns[index].Generated()) {
+				return true;
+			}
+			break;
+		}
+		case ConstraintType::UNIQUE: {
+			auto &constraint = (UniqueConstraint &)*constr;
+			auto index = constraint.index;
+			if (index == DConstants::INVALID_INDEX) {
+				for (auto &col : constraint.columns) {
+					if (generated_columns.count(col)) {
+						return true;
+					}
+				}
+			} else {
+				if (table_info.columns[index].Generated()) {
+					return true;
+				}
+			}
+			break;
+		}
+		case ConstraintType::FOREIGN_KEY: {
+			// If it contained a generated column, an exception would have been thrown inside AddDataTableIndex earlier
+			break;
+		}
+		default: {
+			throw NotImplementedException("ConstraintType not implemented");
+		}
+		}
+	}
+	return false;
+}
+
+BoundStatement Binder::Bind(CreateStatement &stmt) {
+	BoundStatement result;
+	result.names = {"Count"};
+	result.types = {LogicalType::BIGINT};
+	properties.return_type = StatementReturnType::NOTHING;
+
+	auto catalog_type = stmt.info->type;
+	switch (catalog_type) {
+	case CatalogType::SCHEMA_ENTRY:
+		result.plan = make_unique<LogicalCreate>(LogicalOperatorType::LOGICAL_CREATE_SCHEMA, move(stmt.info));
+		break;
+	case CatalogType::VIEW_ENTRY: {
+		auto &base = (CreateViewInfo &)*stmt.info;
+		// bind the schema
+		auto schema = BindSchema(*stmt.info);
+		BindCreateViewInfo(base);
+		result.plan = make_unique<LogicalCreate>(LogicalOperatorType::LOGICAL_CREATE_VIEW, move(stmt.info), schema);
+		break;
+	}
+	case CatalogType::SEQUENCE_ENTRY: {
+		auto schema = BindSchema(*stmt.info);
+		result.plan = make_unique<LogicalCreate>(LogicalOperatorType::LOGICAL_CREATE_SEQUENCE, move(stmt.info), schema);
+		break;
+	}
+	case CatalogType::TABLE_MACRO_ENTRY: {
+		auto schema = BindSchema(*stmt.info);
+		result.plan = make_unique<LogicalCreate>(LogicalOperatorType::LOGICAL_CREATE_MACRO, move(stmt.info), schema);
+		break;
+	}
+	case CatalogType::MACRO_ENTRY: {
+		auto schema = BindCreateFunctionInfo(*stmt.info);
+		result.plan = make_unique<LogicalCreate>(LogicalOperatorType::LOGICAL_CREATE_MACRO, move(stmt.info), schema);
+		break;
+	}
+	case CatalogType::INDEX_ENTRY: {
+		auto &base = (CreateIndexInfo &)*stmt.info;
+		// visit the table reference
+		auto bound_table = Bind(*base.table);
+		if (bound_table->type != TableReferenceType::BASE_TABLE) {
+			throw BinderException("Can only delete from base table!");
+		}
+		auto &table_binding = (BoundBaseTableRef &)*bound_table;
+		auto table = table_binding.table;
+		// bind the index expressions
+		vector<unique_ptr<Expression>> expressions;
+		IndexBinder binder(*this, context);
+		for (auto &expr : base.expressions) {
+			expressions.push_back(binder.Bind(expr));
+		}
+
+		auto plan = CreatePlan(*bound_table);
+		if (plan->type != LogicalOperatorType::LOGICAL_GET) {
+			throw BinderException("Cannot create index on a view!");
+		}
+		auto &get = (LogicalGet &)*plan;
+		for (auto &column_id : get.column_ids) {
+			if (column_id == COLUMN_IDENTIFIER_ROW_ID) {
+				throw BinderException("Cannot create an index on the rowid!");
+			}
+		}
+		// this gives us a logical table scan
+		// we take the required columns from here
+		// create the logical operator
+		result.plan = make_unique<LogicalCreateIndex>(*table, get.column_ids, move(expressions),
+		                                              unique_ptr_cast<CreateInfo, CreateIndexInfo>(move(stmt.info)));
+		break;
+	}
+	case CatalogType::TABLE_ENTRY: {
+		// If there is a foreign key constraint, resolve primary key column's index from primary key column's name
+		auto &create_info = (CreateTableInfo &)*stmt.info;
+		auto &catalog = Catalog::GetCatalog(context);
+		// We first check if there are any user types, if yes we check to which custom types they refer.
+		unordered_set<SchemaCatalogEntry *> fk_schemas;
+		for (idx_t i = 0; i < create_info.constraints.size(); i++) {
+			auto &cond = create_info.constraints[i];
+			if (cond->type != ConstraintType::FOREIGN_KEY) {
+				continue;
+			}
+			auto &fk = (ForeignKeyConstraint &)*cond;
+			if (fk.info.type != ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) {
+				continue;
+			}
+			D_ASSERT(fk.info.pk_keys.empty());
+			if (create_info.table == fk.info.table) {
+				fk.info.type = ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE;
+				FindMatchingPrimaryKeyColumns(create_info.constraints, fk);
+			} else {
+				// have to resolve referenced table
+				auto pk_table_entry_ptr = catalog.GetEntry<TableCatalogEntry>(context, fk.info.schema, fk.info.table);
+				fk_schemas.insert(pk_table_entry_ptr->schema);
+				D_ASSERT(fk.info.pk_keys.empty());
+				FindMatchingPrimaryKeyColumns(pk_table_entry_ptr->constraints, fk);
+				for (auto &keyname : fk.pk_columns) {
+					auto entry = pk_table_entry_ptr->name_map.find(keyname);
+					if (entry == pk_table_entry_ptr->name_map.end()) {
+						throw BinderException("column \"%s\" named in key does not exist", keyname);
+					}
+					auto column_index = entry->second;
+					auto &column = pk_table_entry_ptr->columns[column_index];
+					fk.info.pk_keys.push_back(column.StorageOid());
+				}
+				auto index = pk_table_entry_ptr->storage->info->indexes.FindForeignKeyIndex(
+				    fk.info.pk_keys, ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE);
+				if (!index) {
+					auto fk_column_names = StringUtil::Join(fk.pk_columns, ",");
+					throw BinderException("Failed to create foreign key on %s(%s): no UNIQUE or PRIMARY KEY constraint "
+					                      "present on these columns",
+					                      pk_table_entry_ptr->name, fk_column_names);
+				}
+			}
+		}
+		if (AnyConstraintReferencesGeneratedColumn(create_info)) {
+			throw BinderException("Constraints on generated columns are not supported yet");
+		}
+		auto bound_info = BindCreateTableInfo(move(stmt.info));
+		auto root = move(bound_info->query);
+
+		for (auto &fk_schema : fk_schemas) {
+			if (fk_schema != bound_info->schema) {
+				throw BinderException("Creating foreign keys across different schemas is not supported");
+			}
+		}
+
+		// create the logical operator
+		auto &schema = bound_info->schema;
+		auto create_table = make_unique<LogicalCreateTable>(schema, move(bound_info));
+		if (root) {
+			// CREATE TABLE AS
+			properties.return_type = StatementReturnType::CHANGED_ROWS;
+			create_table->children.push_back(move(root));
+		}
+		result.plan = move(create_table);
+		break;
+	}
+	case CatalogType::TYPE_ENTRY: {
+		auto schema = BindSchema(*stmt.info);
+		result.plan = make_unique<LogicalCreate>(LogicalOperatorType::LOGICAL_CREATE_TYPE, move(stmt.info), schema);
+		break;
+	}
+	default:
+		throw Exception("Unrecognized type!");
+	}
+	properties.allow_stream_result = false;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+static void CreateColumnMap(BoundCreateTableInfo &info, bool allow_duplicate_names) {
+	auto &base = (CreateTableInfo &)*info.base;
+
+	idx_t storage_idx = 0;
+	for (uint64_t oid = 0; oid < base.columns.size(); oid++) {
+		auto &col = base.columns[oid];
+		if (allow_duplicate_names) {
+			idx_t index = 1;
+			string base_name = col.Name();
+			while (info.name_map.find(col.Name()) != info.name_map.end()) {
+				col.SetName(base_name + ":" + to_string(index++));
+			}
+		} else {
+			if (info.name_map.find(col.Name()) != info.name_map.end()) {
+				throw CatalogException("Column with name %s already exists!", col.Name());
+			}
+		}
+
+		info.name_map[col.Name()] = oid;
+		col.SetOid(oid);
+		if (col.Generated()) {
+			continue;
+		}
+		col.SetStorageOid(storage_idx++);
+	}
+}
+
+static void CreateColumnDependencyManager(BoundCreateTableInfo &info) {
+	auto &base = (CreateTableInfo &)*info.base;
+	D_ASSERT(!info.name_map.empty());
+
+	for (auto &col : base.columns) {
+		if (!col.Generated()) {
+			continue;
+		}
+		info.column_dependency_manager.AddGeneratedColumn(col, info.name_map);
+	}
+}
+
+static void BindCheckConstraint(Binder &binder, BoundCreateTableInfo &info, const unique_ptr<Constraint> &cond) {
+	auto &base = (CreateTableInfo &)*info.base;
+
+	auto bound_constraint = make_unique<BoundCheckConstraint>();
+	// check constraint: bind the expression
+	CheckBinder check_binder(binder, binder.context, base.table, base.columns, bound_constraint->bound_columns);
+	auto &check = (CheckConstraint &)*cond;
+	// create a copy of the unbound expression because the binding destroys the constraint
+	auto unbound_expression = check.expression->Copy();
+	// now bind the constraint and create a new BoundCheckConstraint
+	bound_constraint->expression = check_binder.Bind(check.expression);
+	info.bound_constraints.push_back(move(bound_constraint));
+	// move the unbound constraint back into the original check expression
+	check.expression = move(unbound_expression);
+}
+
+static void BindConstraints(Binder &binder, BoundCreateTableInfo &info) {
+	auto &base = (CreateTableInfo &)*info.base;
+
+	bool has_primary_key = false;
+	vector<idx_t> primary_keys;
+	for (idx_t i = 0; i < base.constraints.size(); i++) {
+		auto &cond = base.constraints[i];
+		switch (cond->type) {
+		case ConstraintType::CHECK: {
+			BindCheckConstraint(binder, info, cond);
+			break;
+		}
+		case ConstraintType::NOT_NULL: {
+			auto &not_null = (NotNullConstraint &)*cond;
+			auto &col = base.columns[not_null.index];
+			info.bound_constraints.push_back(make_unique<BoundNotNullConstraint>(col.StorageOid()));
+			break;
+		}
+		case ConstraintType::UNIQUE: {
+			auto &unique = (UniqueConstraint &)*cond;
+			// have to resolve columns of the unique constraint
+			vector<idx_t> keys;
+			unordered_set<idx_t> key_set;
+			if (unique.index != DConstants::INVALID_INDEX) {
+				D_ASSERT(unique.index < base.columns.size());
+				// unique constraint is given by single index
+				unique.columns.push_back(base.columns[unique.index].Name());
+				keys.push_back(unique.index);
+				key_set.insert(unique.index);
+			} else {
+				// unique constraint is given by list of names
+				// have to resolve names
+				D_ASSERT(!unique.columns.empty());
+				for (auto &keyname : unique.columns) {
+					auto entry = info.name_map.find(keyname);
+					if (entry == info.name_map.end()) {
+						throw ParserException("column \"%s\" named in key does not exist", keyname);
+					}
+					auto &column_index = entry->second;
+					if (key_set.find(column_index) != key_set.end()) {
+						throw ParserException("column \"%s\" appears twice in "
+						                      "primary key constraint",
+						                      keyname);
+					}
+					keys.push_back(column_index);
+					key_set.insert(column_index);
+				}
+			}
+
+			if (unique.is_primary_key) {
+				// we can only have one primary key per table
+				if (has_primary_key) {
+					throw ParserException("table \"%s\" has more than one primary key", base.table);
+				}
+				has_primary_key = true;
+				primary_keys = keys;
+			}
+			info.bound_constraints.push_back(
+			    make_unique<BoundUniqueConstraint>(move(keys), move(key_set), unique.is_primary_key));
+			break;
+		}
+		case ConstraintType::FOREIGN_KEY: {
+			auto &fk = (ForeignKeyConstraint &)*cond;
+			D_ASSERT((fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE && !fk.info.pk_keys.empty()) ||
+			         (fk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE && !fk.info.pk_keys.empty()) ||
+			         fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE);
+			if (fk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE && fk.info.pk_keys.empty()) {
+				for (auto &keyname : fk.pk_columns) {
+					auto entry = info.name_map.find(keyname);
+					if (entry == info.name_map.end()) {
+						throw BinderException("column \"%s\" named in key does not exist", keyname);
+					}
+					auto column_index = entry->second;
+					fk.info.pk_keys.push_back(column_index);
+				}
+			}
+			if (fk.info.fk_keys.empty()) {
+				for (auto &keyname : fk.fk_columns) {
+					auto entry = info.name_map.find(keyname);
+					if (entry == info.name_map.end()) {
+						throw BinderException("column \"%s\" named in key does not exist", keyname);
+					}
+					auto column_index = entry->second;
+					fk.info.fk_keys.push_back(column_index);
+				}
+			}
+			unordered_set<idx_t> fk_key_set, pk_key_set;
+			for (idx_t i = 0; i < fk.info.pk_keys.size(); i++) {
+				pk_key_set.insert(fk.info.pk_keys[i]);
+			}
+			for (idx_t i = 0; i < fk.info.fk_keys.size(); i++) {
+				fk_key_set.insert(fk.info.fk_keys[i]);
+			}
+			info.bound_constraints.push_back(make_unique<BoundForeignKeyConstraint>(fk.info, pk_key_set, fk_key_set));
+			break;
+		}
+		default:
+			throw NotImplementedException("unrecognized constraint type in bind");
+		}
+	}
+	if (has_primary_key) {
+		// if there is a primary key index, also create a NOT NULL constraint for each of the columns
+		for (auto &column_index : primary_keys) {
+			auto &column = base.columns[column_index];
+			base.constraints.push_back(make_unique<NotNullConstraint>(column_index));
+			info.bound_constraints.push_back(make_unique<BoundNotNullConstraint>(column.StorageOid()));
+		}
+	}
+}
+
+void Binder::BindGeneratedColumns(BoundCreateTableInfo &info) {
+	auto &base = (CreateTableInfo &)*info.base;
+
+	vector<string> names;
+	vector<LogicalType> types;
+
+	D_ASSERT(base.type == CatalogType::TABLE_ENTRY);
+	for (idx_t i = 0; i < base.columns.size(); i++) {
+		auto &col = base.columns[i];
+		names.push_back(col.Name());
+		types.push_back(col.Type());
+	}
+	auto table_index = GenerateTableIndex();
+
+	// Create a new binder because we dont need (or want) these bindings in this scope
+	auto binder = Binder::CreateBinder(context);
+	binder->bind_context.AddGenericBinding(table_index, base.table, names, types);
+	auto expr_binder = ExpressionBinder(*binder, context);
+	string ignore;
+	auto table_binding = binder->bind_context.GetBinding(base.table, ignore);
+	D_ASSERT(table_binding && ignore.empty());
+
+	auto bind_order = info.column_dependency_manager.GetBindOrder(base.columns);
+	unordered_set<column_t> bound_indices;
+
+	while (!bind_order.empty()) {
+		auto i = bind_order.top();
+		bind_order.pop();
+		auto &col = base.columns[i];
+
+		//! Already bound this previously
+		//! This can not be optimized out of the GetBindOrder function
+		//! These occurrences happen because we need to make sure that ALL dependencies of a column are resolved before
+		//! it gets resolved
+		if (bound_indices.count(i)) {
+			continue;
+		}
+		D_ASSERT(col.Generated());
+		auto expression = col.GeneratedExpression().Copy();
+
+		auto bound_expression = expr_binder.Bind(expression);
+		D_ASSERT(bound_expression);
+		D_ASSERT(!bound_expression->HasSubquery());
+		if (col.Type().id() == LogicalTypeId::ANY) {
+			// Do this before changing the type, so we know it's the first time the type is set
+			col.ChangeGeneratedExpressionType(bound_expression->return_type);
+			col.SetType(bound_expression->return_type);
+
+			// Update the type in the binding, for future expansions
+			string ignore;
+			table_binding->types[i] = col.Type();
+		}
+		bound_indices.insert(i);
+	}
+}
+
+void Binder::BindDefaultValues(vector<ColumnDefinition> &columns, vector<unique_ptr<Expression>> &bound_defaults) {
+	for (idx_t i = 0; i < columns.size(); i++) {
+		unique_ptr<Expression> bound_default;
+		if (columns[i].DefaultValue()) {
+			// we bind a copy of the DEFAULT value because binding is destructive
+			// and we want to keep the original expression around for serialization
+			auto default_copy = columns[i].DefaultValue()->Copy();
+			ConstantBinder default_binder(*this, context, "DEFAULT value");
+			default_binder.target_type = columns[i].Type();
+			bound_default = default_binder.Bind(default_copy);
+		} else {
+			// no default value specified: push a default value of constant null
+			bound_default = make_unique<BoundConstantExpression>(Value(columns[i].Type()));
+		}
+		bound_defaults.push_back(move(bound_default));
+	}
+}
+
+unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateInfo> info) {
+	auto &base = (CreateTableInfo &)*info;
+
+	auto result = make_unique<BoundCreateTableInfo>(move(info));
+	result->schema = BindSchema(*result->base);
+	if (base.query) {
+		// construct the result object
+		auto query_obj = Bind(*base.query);
+		result->query = move(query_obj.plan);
+
+		// construct the set of columns based on the names and types of the query
+		auto &names = query_obj.names;
+		auto &sql_types = query_obj.types;
+		D_ASSERT(names.size() == sql_types.size());
+		for (idx_t i = 0; i < names.size(); i++) {
+			base.columns.emplace_back(names[i], sql_types[i]);
+		}
+		// create the name map for the statement
+		CreateColumnMap(*result, true);
+		CreateColumnDependencyManager(*result);
+		// bind the generated column expressions
+		BindGeneratedColumns(*result);
+	} else {
+		// create the name map for the statement
+		CreateColumnMap(*result, false);
+		CreateColumnDependencyManager(*result);
+		// bind the generated column expressions
+		BindGeneratedColumns(*result);
+		// bind any constraints
+		BindConstraints(*this, *result);
+		// bind the default values
+		BindDefaultValues(base.columns, result->bound_defaults);
+	}
+
+	// bind collations to detect any unsupported collation errors
+	for (auto &column : base.columns) {
+		if (column.Generated()) {
+			continue;
+		}
+		if (column.Type().id() == LogicalTypeId::VARCHAR) {
+			ExpressionBinder::TestCollation(context, StringType::GetCollation(column.Type()));
+		}
+		BindLogicalType(context, column.TypeMutable());
+		// We add a catalog dependency
+		auto type_dependency = LogicalType::GetCatalog(column.Type());
+		if (type_dependency) {
+			// Only if the USER comes from a create type
+			result->dependencies.insert(type_dependency);
+		}
+	}
+	properties.allow_stream_result = false;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(DeleteStatement &stmt) {
+	BoundStatement result;
+
+	// visit the table reference
+	auto bound_table = Bind(*stmt.table);
+	if (bound_table->type != TableReferenceType::BASE_TABLE) {
+		throw BinderException("Can only delete from base table!");
+	}
+	auto &table_binding = (BoundBaseTableRef &)*bound_table;
+	auto table = table_binding.table;
+
+	auto root = CreatePlan(*bound_table);
+	auto &get = (LogicalGet &)*root;
+	D_ASSERT(root->type == LogicalOperatorType::LOGICAL_GET);
+
+	if (!table->temporary) {
+		// delete from persistent table: not read only!
+		properties.read_only = false;
+	}
+
+	// plan any tables from the various using clauses
+	if (!stmt.using_clauses.empty()) {
+		unique_ptr<LogicalOperator> child_operator;
+		for (auto &using_clause : stmt.using_clauses) {
+			// bind the using clause
+			auto bound_node = Bind(*using_clause);
+			auto op = CreatePlan(*bound_node);
+			if (child_operator) {
+				// already bound a child: create a cross product to unify the two
+				auto cross_product = make_unique<LogicalCrossProduct>();
+				cross_product->children.push_back(move(child_operator));
+				cross_product->children.push_back(move(op));
+				child_operator = move(cross_product);
+			} else {
+				child_operator = move(op);
+			}
+		}
+		if (child_operator) {
+			auto cross_product = make_unique<LogicalCrossProduct>();
+			cross_product->children.push_back(move(root));
+			cross_product->children.push_back(move(child_operator));
+			root = move(cross_product);
+		}
+	}
+
+	// project any additional columns required for the condition
+	unique_ptr<Expression> condition;
+	if (stmt.condition) {
+		WhereBinder binder(*this, context);
+		condition = binder.Bind(stmt.condition);
+
+		PlanSubqueries(&condition, &root);
+		auto filter = make_unique<LogicalFilter>(move(condition));
+		filter->AddChild(move(root));
+		root = move(filter);
+	}
+	// create the delete node
+	auto del = make_unique<LogicalDelete>(table);
+	del->AddChild(move(root));
+
+	// set up the delete expression
+	del->expressions.push_back(make_unique<BoundColumnRefExpression>(
+	    LogicalType::ROW_TYPE, ColumnBinding(get.table_index, get.column_ids.size())));
+	get.column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+
+	if (!stmt.returning_list.empty()) {
+		del->return_chunk = true;
+
+		auto update_table_index = GenerateTableIndex();
+		del->table_index = update_table_index;
+
+		unique_ptr<LogicalOperator> del_as_logicaloperator = move(del);
+		return BindReturning(move(stmt.returning_list), table, update_table_index, move(del_as_logicaloperator),
+		                     move(result));
+	} else {
+		result.plan = move(del);
+		result.names = {"Count"};
+		result.types = {LogicalType::BIGINT};
+		properties.allow_stream_result = false;
+		properties.return_type = StatementReturnType::CHANGED_ROWS;
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(DropStatement &stmt) {
+	BoundStatement result;
+
+	switch (stmt.info->type) {
+	case CatalogType::PREPARED_STATEMENT:
+		// dropping prepared statements is always possible
+		// it also does not require a valid transaction
+		properties.requires_valid_transaction = false;
+		break;
+	case CatalogType::SCHEMA_ENTRY:
+		// dropping a schema is never read-only because there are no temporary schemas
+		properties.read_only = false;
+		break;
+	case CatalogType::VIEW_ENTRY:
+	case CatalogType::SEQUENCE_ENTRY:
+	case CatalogType::MACRO_ENTRY:
+	case CatalogType::TABLE_MACRO_ENTRY:
+	case CatalogType::INDEX_ENTRY:
+	case CatalogType::TABLE_ENTRY:
+	case CatalogType::TYPE_ENTRY: {
+		auto entry = (StandardEntry *)Catalog::GetCatalog(context).GetEntry(context, stmt.info->type, stmt.info->schema,
+		                                                                    stmt.info->name, true);
+		if (!entry) {
+			break;
+		}
+		if (!entry->temporary) {
+			// we can only drop temporary tables in read-only mode
+			properties.read_only = false;
+		}
+		stmt.info->schema = entry->schema->name;
+		break;
+	}
+	default:
+		throw BinderException("Unknown catalog type for drop statement!");
+	}
+	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_DROP, move(stmt.info));
+	result.names = {"Success"};
+	result.types = {LogicalType::BOOLEAN};
+	properties.allow_stream_result = false;
+	properties.return_type = StatementReturnType::NOTHING;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(ExplainStatement &stmt) {
+	BoundStatement result;
+
+	// bind the underlying statement
+	auto plan = Bind(*stmt.stmt);
+	// get the unoptimized logical plan, and create the explain statement
+	auto logical_plan_unopt = plan.plan->ToString();
+	auto explain = make_unique<LogicalExplain>(move(plan.plan), stmt.explain_type);
+	explain->logical_plan_unopt = logical_plan_unopt;
+
+	result.plan = move(explain);
+	result.names = {"explain_key", "explain_value"};
+	result.types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
+	properties.return_type = StatementReturnType::QUERY_RESULT;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+//! Sanitizes a string to have only low case chars and underscores
+string SanitizeExportIdentifier(const string &str) {
+	// Copy the original string to result
+	string result(str);
+
+	for (idx_t i = 0; i < str.length(); ++i) {
+		auto c = str[i];
+		if (c >= 'a' && c <= 'z') {
+			// If it is lower case just continue
+			continue;
+		}
+
+		if (c >= 'A' && c <= 'Z') {
+			// To lowercase
+			result[i] = tolower(c);
+		} else {
+			// Substitute to underscore
+			result[i] = '_';
+		}
+	}
+
+	return result;
+}
+
+bool IsExistMainKeyTable(string &table_name, vector<TableCatalogEntry *> &unordered) {
+	for (idx_t i = 0; i < unordered.size(); i++) {
+		if (unordered[i]->name == table_name) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void ScanForeignKeyTable(vector<TableCatalogEntry *> &ordered, vector<TableCatalogEntry *> &unordered,
+                         bool move_only_pk_table) {
+	for (auto i = unordered.begin(); i != unordered.end();) {
+		auto table_entry = *i;
+		bool move_to_ordered = true;
+		for (idx_t j = 0; j < table_entry->constraints.size(); j++) {
+			auto &cond = table_entry->constraints[j];
+			if (cond->type == ConstraintType::FOREIGN_KEY) {
+				auto &fk = (ForeignKeyConstraint &)*cond;
+				if ((move_only_pk_table && fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE) ||
+				    (!move_only_pk_table && fk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE &&
+				     IsExistMainKeyTable(fk.info.table, unordered))) {
+					move_to_ordered = false;
+					break;
+				}
+			}
+		}
+		if (move_to_ordered) {
+			ordered.push_back(table_entry);
+			i = unordered.erase(i);
+		} else {
+			i++;
+		}
+	}
+}
+
+void ReorderTableEntries(vector<TableCatalogEntry *> &tables) {
+	vector<TableCatalogEntry *> ordered;
+	vector<TableCatalogEntry *> unordered = tables;
+	ScanForeignKeyTable(ordered, unordered, true);
+	while (!unordered.empty()) {
+		ScanForeignKeyTable(ordered, unordered, false);
+	}
+	tables = ordered;
+}
+
+BoundStatement Binder::Bind(ExportStatement &stmt) {
+	// COPY TO a file
+	auto &config = DBConfig::GetConfig(context);
+	if (!config.enable_external_access) {
+		throw PermissionException("COPY TO is disabled through configuration");
+	}
+	BoundStatement result;
+	result.types = {LogicalType::BOOLEAN};
+	result.names = {"Success"};
+
+	// lookup the format in the catalog
+	auto &catalog = Catalog::GetCatalog(context);
+	auto copy_function = catalog.GetEntry<CopyFunctionCatalogEntry>(context, DEFAULT_SCHEMA, stmt.info->format);
+	if (!copy_function->function.copy_to_bind) {
+		throw NotImplementedException("COPY TO is not supported for FORMAT \"%s\"", stmt.info->format);
+	}
+
+	// gather a list of all the tables
+	vector<TableCatalogEntry *> tables;
+	auto schemas = catalog.schemas->GetEntries<SchemaCatalogEntry>(context);
+	for (auto &schema : schemas) {
+		schema->Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry *entry) {
+			if (entry->type == CatalogType::TABLE_ENTRY) {
+				tables.push_back((TableCatalogEntry *)entry);
+			}
+		});
+	}
+
+	// reorder tables because of foreign key constraint
+	ReorderTableEntries(tables);
+
+	// now generate the COPY statements for each of the tables
+	auto &fs = FileSystem::GetFileSystem(context);
+	unique_ptr<LogicalOperator> child_operator;
+
+	BoundExportData exported_tables;
+
+	unordered_set<string> table_name_index;
+	for (auto &table : tables) {
+		auto info = make_unique<CopyInfo>();
+		// we copy the options supplied to the EXPORT
+		info->format = stmt.info->format;
+		info->options = stmt.info->options;
+		// set up the file name for the COPY TO
+
+		auto exported_data = ExportedTableData();
+		idx_t id = 0;
+		while (true) {
+			string id_suffix = id == 0 ? string() : "_" + to_string(id);
+			if (table->schema->name == DEFAULT_SCHEMA) {
+				info->file_path = fs.JoinPath(stmt.info->file_path,
+				                              StringUtil::Format("%s%s.%s", SanitizeExportIdentifier(table->name),
+				                                                 id_suffix, copy_function->function.extension));
+			} else {
+				info->file_path =
+				    fs.JoinPath(stmt.info->file_path,
+				                StringUtil::Format("%s_%s%s.%s", SanitizeExportIdentifier(table->schema->name),
+				                                   SanitizeExportIdentifier(table->name), id_suffix,
+				                                   copy_function->function.extension));
+			}
+			if (table_name_index.find(info->file_path) == table_name_index.end()) {
+				// this name was not yet taken: take it
+				table_name_index.insert(info->file_path);
+				break;
+			}
+			id++;
+		}
+		info->is_from = false;
+		info->schema = table->schema->name;
+		info->table = table->name;
+
+		exported_data.table_name = info->table;
+		exported_data.schema_name = info->schema;
+		exported_data.file_path = info->file_path;
+
+		ExportedTableInfo table_info;
+		table_info.entry = table;
+		table_info.table_data = exported_data;
+		exported_tables.data.push_back(table_info);
+		id++;
+
+		// generate the copy statement and bind it
+		CopyStatement copy_stmt;
+		copy_stmt.info = move(info);
+
+		auto copy_binder = Binder::CreateBinder(context);
+		auto bound_statement = copy_binder->Bind(copy_stmt);
+		if (child_operator) {
+			// use UNION ALL to combine the individual copy statements into a single node
+			auto copy_union =
+			    make_unique<LogicalSetOperation>(GenerateTableIndex(), 1, move(child_operator),
+			                                     move(bound_statement.plan), LogicalOperatorType::LOGICAL_UNION);
+			child_operator = move(copy_union);
+		} else {
+			child_operator = move(bound_statement.plan);
+		}
+	}
+
+	// try to create the directory, if it doesn't exist yet
+	// a bit hacky to do it here, but we need to create the directory BEFORE the copy statements run
+	if (!fs.DirectoryExists(stmt.info->file_path)) {
+		fs.CreateDirectory(stmt.info->file_path);
+	}
+
+	// create the export node
+	auto export_node = make_unique<LogicalExport>(copy_function->function, move(stmt.info), exported_tables);
+
+	if (child_operator) {
+		export_node->children.push_back(move(child_operator));
+	}
+
+	result.plan = move(export_node);
+	properties.allow_stream_result = false;
+	properties.return_type = StatementReturnType::NOTHING;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static void CheckInsertColumnCountMismatch(int64_t expected_columns, int64_t result_columns, bool columns_provided,
+                                           const char *tname) {
+	if (result_columns != expected_columns) {
+		string msg = StringUtil::Format(!columns_provided ? "table %s has %lld columns but %lld values were supplied"
+		                                                  : "Column name/value mismatch for insert on %s: "
+		                                                    "expected %lld columns but %lld values were supplied",
+		                                tname, expected_columns, result_columns);
+		throw BinderException(msg);
+	}
+}
+
+BoundStatement Binder::Bind(InsertStatement &stmt) {
+	BoundStatement result;
+	result.names = {"Count"};
+	result.types = {LogicalType::BIGINT};
+
+	auto table = Catalog::GetCatalog(context).GetEntry<TableCatalogEntry>(context, stmt.schema, stmt.table);
+	D_ASSERT(table);
+	if (!table->temporary) {
+		// inserting into a non-temporary table: alters underlying database
+		properties.read_only = false;
+	}
+
+	auto insert = make_unique<LogicalInsert>(table);
+
+	idx_t generated_column_count = 0;
+	vector<idx_t> named_column_map;
+	if (!stmt.columns.empty()) {
+		// insertion statement specifies column list
+
+		// create a mapping of (list index) -> (column index)
+		case_insensitive_map_t<idx_t> column_name_map;
+		for (idx_t i = 0; i < stmt.columns.size(); i++) {
+			column_name_map[stmt.columns[i]] = i;
+			auto entry = table->name_map.find(stmt.columns[i]);
+			if (entry == table->name_map.end()) {
+				throw BinderException("Column %s not found in table %s", stmt.columns[i], table->name);
+			}
+			auto column_index = entry->second;
+			if (column_index == COLUMN_IDENTIFIER_ROW_ID) {
+				throw BinderException("Cannot explicitly insert values into rowid column");
+			}
+			if (table->columns[column_index].Generated()) {
+				throw BinderException("Cannot insert into a generated column");
+			}
+			insert->expected_types.push_back(table->columns[column_index].Type());
+			named_column_map.push_back(column_index);
+		}
+		for (idx_t i = 0; i < table->columns.size(); i++) {
+			auto &col = table->columns[i];
+			if (col.Generated()) {
+				generated_column_count++;
+			}
+			auto entry = column_name_map.find(col.Name());
+			if (entry == column_name_map.end()) {
+				// column not specified, set index to DConstants::INVALID_INDEX
+				insert->column_index_map.push_back(DConstants::INVALID_INDEX);
+			} else {
+				// column was specified, set to the index
+				insert->column_index_map.push_back(entry->second);
+			}
+		}
+	} else {
+		for (idx_t i = 0; i < table->columns.size(); i++) {
+			auto &col = table->columns[i];
+			if (col.Generated()) {
+				generated_column_count++;
+				continue;
+			}
+			named_column_map.push_back(i);
+			insert->expected_types.push_back(table->columns[i].Type());
+		}
+	}
+
+	// bind the default values
+	BindDefaultValues(table->columns, insert->bound_defaults);
+	if (!stmt.select_statement) {
+		result.plan = move(insert);
+		return result;
+	}
+
+	// Exclude the generated columns from this amount
+	idx_t expected_columns =
+	    stmt.columns.empty() ? (table->columns.size() - generated_column_count) : stmt.columns.size();
+
+	// special case: check if we are inserting from a VALUES statement
+	auto values_list = stmt.GetValuesList();
+	if (values_list) {
+		auto &expr_list = (ExpressionListRef &)*values_list;
+		expr_list.expected_types.resize(expected_columns);
+		expr_list.expected_names.resize(expected_columns);
+
+		D_ASSERT(expr_list.values.size() > 0);
+		CheckInsertColumnCountMismatch(expected_columns, expr_list.values[0].size(), !stmt.columns.empty(),
+		                               table->name.c_str());
+
+		// VALUES list!
+		for (idx_t col_idx = 0; col_idx < expected_columns; col_idx++) {
+			idx_t table_col_idx = named_column_map[col_idx];
+			D_ASSERT(table_col_idx < table->columns.size());
+
+			// set the expected types as the types for the INSERT statement
+			auto &column = table->columns[table_col_idx];
+			expr_list.expected_types[col_idx] = column.Type();
+			expr_list.expected_names[col_idx] = column.Name();
+
+			// now replace any DEFAULT values with the corresponding default expression
+			for (idx_t list_idx = 0; list_idx < expr_list.values.size(); list_idx++) {
+				if (expr_list.values[list_idx][col_idx]->type == ExpressionType::VALUE_DEFAULT) {
+					// DEFAULT value! replace the entry
+					if (column.DefaultValue()) {
+						expr_list.values[list_idx][col_idx] = column.DefaultValue()->Copy();
+					} else {
+						expr_list.values[list_idx][col_idx] = make_unique<ConstantExpression>(Value(column.Type()));
+					}
+				}
+			}
+		}
+	}
+
+	// parse select statement and add to logical plan
+	auto root_select = Bind(*stmt.select_statement);
+	CheckInsertColumnCountMismatch(expected_columns, root_select.types.size(), !stmt.columns.empty(),
+	                               table->name.c_str());
+
+	auto root = CastLogicalOperatorToTypes(root_select.types, insert->expected_types, move(root_select.plan));
+
+	insert->AddChild(move(root));
+
+	if (!stmt.returning_list.empty()) {
+		insert->return_chunk = true;
+		result.types.clear();
+		result.names.clear();
+		auto insert_table_index = GenerateTableIndex();
+		insert->table_index = insert_table_index;
+		unique_ptr<LogicalOperator> index_as_logicaloperator = move(insert);
+
+		return BindReturning(move(stmt.returning_list), table, insert_table_index, move(index_as_logicaloperator),
+		                     move(result));
+	} else {
+		D_ASSERT(result.types.size() == result.names.size());
+		result.plan = move(insert);
+		properties.allow_stream_result = false;
+		properties.return_type = StatementReturnType::CHANGED_ROWS;
+		return result;
+	}
+}
+
+} // namespace duckdb
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(LoadStatement &stmt) {
+	BoundStatement result;
+	result.types = {LogicalType::BOOLEAN};
+	result.names = {"Success"};
+
+	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_LOAD, move(stmt.info));
+	properties.allow_stream_result = false;
+	properties.return_type = StatementReturnType::NOTHING;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(PragmaStatement &stmt) {
+	auto &catalog = Catalog::GetCatalog(context);
+	// bind the pragma function
+	auto entry = catalog.GetEntry<PragmaFunctionCatalogEntry>(context, DEFAULT_SCHEMA, stmt.info->name, false);
+	string error;
+	idx_t bound_idx = Function::BindFunction(entry->name, entry->functions, *stmt.info, error);
+	if (bound_idx == DConstants::INVALID_INDEX) {
+		throw BinderException(FormatError(stmt.stmt_location, error));
+	}
+	auto &bound_function = entry->functions[bound_idx];
+	if (!bound_function.function) {
+		throw BinderException("PRAGMA function does not have a function specified");
+	}
+
+	// bind and check named params
+	QueryErrorContext error_context(root_statement, stmt.stmt_location);
+	BindNamedParameters(bound_function.named_parameters, stmt.info->named_parameters, error_context,
+	                    bound_function.name);
+
+	BoundStatement result;
+	result.names = {"Success"};
+	result.types = {LogicalType::BOOLEAN};
+	result.plan = make_unique<LogicalPragma>(bound_function, *stmt.info);
+	properties.return_type = StatementReturnType::QUERY_RESULT;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(RelationStatement &stmt) {
+	return stmt.relation->Bind(*this);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(SelectStatement &stmt) {
+	properties.allow_stream_result = true;
+	properties.return_type = StatementReturnType::QUERY_RESULT;
+	return Bind(*stmt.node);
+}
+
+} // namespace duckdb
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(SetStatement &stmt) {
+	BoundStatement result;
+	result.types = {LogicalType::BOOLEAN};
+	result.names = {"Success"};
+
+	result.plan = make_unique<LogicalSet>(stmt.name, stmt.value, stmt.scope);
+	properties.return_type = StatementReturnType::NOTHING;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(ShowStatement &stmt) {
+	BoundStatement result;
+
+	if (stmt.info->is_summary) {
+		return BindSummarize(stmt);
+	}
+	auto plan = Bind(*stmt.info->query);
+	stmt.info->types = plan.types;
+	stmt.info->aliases = plan.names;
+
+	auto show = make_unique<LogicalShow>(move(plan.plan));
+	show->types_select = plan.types;
+	show->aliases = plan.names;
+
+	result.plan = move(show);
+
+	result.names = {"column_name", "column_type", "null", "key", "default", "extra"};
+	result.types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR};
+	properties.return_type = StatementReturnType::QUERY_RESULT;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+//! This file contains the binder definitions for statements that do not need to be bound at all and only require a
+//! straightforward conversion
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(AlterStatement &stmt) {
+	BoundStatement result;
+	result.names = {"Success"};
+	result.types = {LogicalType::BOOLEAN};
+	Catalog &catalog = Catalog::GetCatalog(context);
+	auto entry = catalog.GetEntry(context, stmt.info->GetCatalogType(), stmt.info->schema, stmt.info->name, true);
+	if (entry && !entry->temporary) {
+		// we can only alter temporary tables/views in read-only mode
+		properties.read_only = false;
+	}
+	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_ALTER, move(stmt.info));
+	properties.return_type = StatementReturnType::NOTHING;
+	return result;
+}
+
+BoundStatement Binder::Bind(TransactionStatement &stmt) {
+	// transaction statements do not require a valid transaction
+	properties.requires_valid_transaction = false;
+
+	BoundStatement result;
+	result.names = {"Success"};
+	result.types = {LogicalType::BOOLEAN};
+	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_TRANSACTION, move(stmt.info));
+	properties.return_type = StatementReturnType::NOTHING;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static unique_ptr<ParsedExpression> SummarizeWrapUnnest(vector<unique_ptr<ParsedExpression>> &children,
+                                                        const string &alias) {
+	auto list_function = make_unique<FunctionExpression>("list_value", move(children));
+	vector<unique_ptr<ParsedExpression>> unnest_children;
+	unnest_children.push_back(move(list_function));
+	auto unnest_function = make_unique<FunctionExpression>("unnest", move(unnest_children));
+	unnest_function->alias = alias;
+	return move(unnest_function);
+}
+
+static unique_ptr<ParsedExpression> SummarizeCreateAggregate(const string &aggregate, string column_name) {
+	vector<unique_ptr<ParsedExpression>> children;
+	children.push_back(make_unique<ColumnRefExpression>(move(column_name)));
+	auto aggregate_function = make_unique<FunctionExpression>(aggregate, move(children));
+	auto cast_function = make_unique<CastExpression>(LogicalType::VARCHAR, move(aggregate_function));
+	return move(cast_function);
+}
+
+static unique_ptr<ParsedExpression> SummarizeCreateAggregate(const string &aggregate, string column_name,
+                                                             const Value &modifier) {
+	vector<unique_ptr<ParsedExpression>> children;
+	children.push_back(make_unique<ColumnRefExpression>(move(column_name)));
+	children.push_back(make_unique<ConstantExpression>(modifier));
+	auto aggregate_function = make_unique<FunctionExpression>(aggregate, move(children));
+	auto cast_function = make_unique<CastExpression>(LogicalType::VARCHAR, move(aggregate_function));
+	return move(cast_function);
+}
+
+static unique_ptr<ParsedExpression> SummarizeCreateCountStar() {
+	vector<unique_ptr<ParsedExpression>> children;
+	auto aggregate_function = make_unique<FunctionExpression>("count_star", move(children));
+	return move(aggregate_function);
+}
+
+static unique_ptr<ParsedExpression> SummarizeCreateBinaryFunction(const string &op, unique_ptr<ParsedExpression> left,
+                                                                  unique_ptr<ParsedExpression> right) {
+	vector<unique_ptr<ParsedExpression>> children;
+	children.push_back(move(left));
+	children.push_back(move(right));
+	auto binary_function = make_unique<FunctionExpression>(op, move(children));
+	return move(binary_function);
+}
+
+static unique_ptr<ParsedExpression> SummarizeCreateNullPercentage(string column_name) {
+	auto count_star = make_unique<CastExpression>(LogicalType::DOUBLE, SummarizeCreateCountStar());
+	auto count = make_unique<CastExpression>(LogicalType::DOUBLE, SummarizeCreateAggregate("count", move(column_name)));
+	auto null_percentage = SummarizeCreateBinaryFunction("/", move(count), move(count_star));
+	auto negate_x =
+	    SummarizeCreateBinaryFunction("-", make_unique<ConstantExpression>(Value::DOUBLE(1)), move(null_percentage));
+	auto percentage_x =
+	    SummarizeCreateBinaryFunction("*", move(negate_x), make_unique<ConstantExpression>(Value::DOUBLE(100)));
+	auto round_x =
+	    SummarizeCreateBinaryFunction("round", move(percentage_x), make_unique<ConstantExpression>(Value::INTEGER(2)));
+	auto concat_x = SummarizeCreateBinaryFunction("concat", move(round_x), make_unique<ConstantExpression>(Value("%")));
+
+	return concat_x;
+}
+
+BoundStatement Binder::BindSummarize(ShowStatement &stmt) {
+	auto query_copy = stmt.info->query->Copy();
+
+	// we bind the plan once in a child-node to figure out the column names and column types
+	auto child_binder = Binder::CreateBinder(context);
+	auto plan = child_binder->Bind(*stmt.info->query);
+	D_ASSERT(plan.types.size() == plan.names.size());
+	vector<unique_ptr<ParsedExpression>> name_children;
+	vector<unique_ptr<ParsedExpression>> type_children;
+	vector<unique_ptr<ParsedExpression>> min_children;
+	vector<unique_ptr<ParsedExpression>> max_children;
+	vector<unique_ptr<ParsedExpression>> unique_children;
+	vector<unique_ptr<ParsedExpression>> avg_children;
+	vector<unique_ptr<ParsedExpression>> std_children;
+	vector<unique_ptr<ParsedExpression>> q25_children;
+	vector<unique_ptr<ParsedExpression>> q50_children;
+	vector<unique_ptr<ParsedExpression>> q75_children;
+	vector<unique_ptr<ParsedExpression>> count_children;
+	vector<unique_ptr<ParsedExpression>> null_percentage_children;
+	auto select = make_unique<SelectStatement>();
+	select->node = move(query_copy);
+	for (idx_t i = 0; i < plan.names.size(); i++) {
+		name_children.push_back(make_unique<ConstantExpression>(Value(plan.names[i])));
+		type_children.push_back(make_unique<ConstantExpression>(Value(plan.types[i].ToString())));
+		min_children.push_back(SummarizeCreateAggregate("min", plan.names[i]));
+		max_children.push_back(SummarizeCreateAggregate("max", plan.names[i]));
+		unique_children.push_back(SummarizeCreateAggregate("approx_count_distinct", plan.names[i]));
+		if (plan.types[i].IsNumeric()) {
+			avg_children.push_back(SummarizeCreateAggregate("avg", plan.names[i]));
+			std_children.push_back(SummarizeCreateAggregate("stddev", plan.names[i]));
+			q25_children.push_back(SummarizeCreateAggregate("approx_quantile", plan.names[i], Value::FLOAT(0.25)));
+			q50_children.push_back(SummarizeCreateAggregate("approx_quantile", plan.names[i], Value::FLOAT(0.50)));
+			q75_children.push_back(SummarizeCreateAggregate("approx_quantile", plan.names[i], Value::FLOAT(0.75)));
+		} else {
+			avg_children.push_back(make_unique<ConstantExpression>(Value()));
+			std_children.push_back(make_unique<ConstantExpression>(Value()));
+			q25_children.push_back(make_unique<ConstantExpression>(Value()));
+			q50_children.push_back(make_unique<ConstantExpression>(Value()));
+			q75_children.push_back(make_unique<ConstantExpression>(Value()));
+		}
+		count_children.push_back(SummarizeCreateCountStar());
+		null_percentage_children.push_back(SummarizeCreateNullPercentage(plan.names[i]));
+	}
+	auto subquery_ref = make_unique<SubqueryRef>(move(select), "summarize_tbl");
+	subquery_ref->column_name_alias = plan.names;
+
+	auto select_node = make_unique<SelectNode>();
+	select_node->select_list.push_back(SummarizeWrapUnnest(name_children, "column_name"));
+	select_node->select_list.push_back(SummarizeWrapUnnest(type_children, "column_type"));
+	select_node->select_list.push_back(SummarizeWrapUnnest(min_children, "min"));
+	select_node->select_list.push_back(SummarizeWrapUnnest(max_children, "max"));
+	select_node->select_list.push_back(SummarizeWrapUnnest(unique_children, "approx_unique"));
+	select_node->select_list.push_back(SummarizeWrapUnnest(avg_children, "avg"));
+	select_node->select_list.push_back(SummarizeWrapUnnest(std_children, "std"));
+	select_node->select_list.push_back(SummarizeWrapUnnest(q25_children, "q25"));
+	select_node->select_list.push_back(SummarizeWrapUnnest(q50_children, "q50"));
+	select_node->select_list.push_back(SummarizeWrapUnnest(q75_children, "q75"));
+	select_node->select_list.push_back(SummarizeWrapUnnest(count_children, "count"));
+	select_node->select_list.push_back(SummarizeWrapUnnest(null_percentage_children, "null_percentage"));
+	select_node->from_table = move(subquery_ref);
+
+	properties.return_type = StatementReturnType::QUERY_RESULT;
+	return Bind(*select_node);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+static void BindExtraColumns(TableCatalogEntry &table, LogicalGet &get, LogicalProjection &proj, LogicalUpdate &update,
+                             unordered_set<column_t> &bound_columns) {
+	if (bound_columns.size() <= 1) {
+		return;
+	}
+	idx_t found_column_count = 0;
+	unordered_set<idx_t> found_columns;
+	for (idx_t i = 0; i < update.columns.size(); i++) {
+		if (bound_columns.find(update.columns[i]) != bound_columns.end()) {
+			// this column is referenced in the CHECK constraint
+			found_column_count++;
+			found_columns.insert(update.columns[i]);
+		}
+	}
+	if (found_column_count > 0 && found_column_count != bound_columns.size()) {
+		// columns in this CHECK constraint were referenced, but not all were part of the UPDATE
+		// add them to the scan and update set
+		for (auto &check_column_id : bound_columns) {
+			if (found_columns.find(check_column_id) != found_columns.end()) {
+				// column is already projected
+				continue;
+			}
+			// column is not projected yet: project it by adding the clause "i=i" to the set of updated columns
+			auto &column = table.columns[check_column_id];
+			update.expressions.push_back(make_unique<BoundColumnRefExpression>(
+			    column.Type(), ColumnBinding(proj.table_index, proj.expressions.size())));
+			proj.expressions.push_back(make_unique<BoundColumnRefExpression>(
+			    column.Type(), ColumnBinding(get.table_index, get.column_ids.size())));
+			get.column_ids.push_back(check_column_id);
+			update.columns.push_back(check_column_id);
+		}
+	}
+}
+
+static bool TypeSupportsRegularUpdate(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::LIST:
+	case LogicalTypeId::MAP:
+		// lists and maps don't support updates directly
+		return false;
+	case LogicalTypeId::STRUCT: {
+		auto &child_types = StructType::GetChildTypes(type);
+		for (auto &entry : child_types) {
+			if (!TypeSupportsRegularUpdate(entry.second)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	default:
+		return true;
+	}
+}
+
+static void BindUpdateConstraints(TableCatalogEntry &table, LogicalGet &get, LogicalProjection &proj,
+                                  LogicalUpdate &update) {
+	// check the constraints and indexes of the table to see if we need to project any additional columns
+	// we do this for indexes with multiple columns and CHECK constraints in the UPDATE clause
+	// suppose we have a constraint CHECK(i + j < 10); now we need both i and j to check the constraint
+	// if we are only updating one of the two columns we add the other one to the UPDATE set
+	// with a "useless" update (i.e. i=i) so we can verify that the CHECK constraint is not violated
+	for (auto &constraint : table.bound_constraints) {
+		if (constraint->type == ConstraintType::CHECK) {
+			auto &check = *reinterpret_cast<BoundCheckConstraint *>(constraint.get());
+			// check constraint! check if we need to add any extra columns to the UPDATE clause
+			BindExtraColumns(table, get, proj, update, check.bound_columns);
+		}
+	}
+	// for index updates we always turn any update into an insert and a delete
+	// we thus need all the columns to be available, hence we check if the update touches any index columns
+	// If the returning keyword is used, we need access to the whole row in case the user requests it.
+	// Therefore switch the update to a delete and insert.
+	update.update_is_del_and_insert = false;
+	table.storage->info->indexes.Scan([&](Index &index) {
+		if (index.IndexIsUpdated(update.columns)) {
+			update.update_is_del_and_insert = true;
+			return true;
+		}
+		return false;
+	});
+
+	// we also convert any updates on LIST columns into delete + insert
+	for (auto &col : update.columns) {
+		if (!TypeSupportsRegularUpdate(table.columns[col].Type())) {
+			update.update_is_del_and_insert = true;
+			break;
+		}
+	}
+
+	if (update.update_is_del_and_insert || update.return_chunk) {
+		// the update updates a column required by an index or requires returning the updated rows,
+		// push projections for all columns
+		unordered_set<column_t> all_columns;
+		for (idx_t i = 0; i < table.storage->column_definitions.size(); i++) {
+			all_columns.insert(i);
+		}
+		BindExtraColumns(table, get, proj, update, all_columns);
+	}
+}
+
+BoundStatement Binder::Bind(UpdateStatement &stmt) {
+	BoundStatement result;
+	unique_ptr<LogicalOperator> root;
+	LogicalGet *get;
+
+	// visit the table reference
+	auto bound_table = Bind(*stmt.table);
+	if (bound_table->type != TableReferenceType::BASE_TABLE) {
+		throw BinderException("Can only update base table!");
+	}
+	auto &table_binding = (BoundBaseTableRef &)*bound_table;
+	auto table = table_binding.table;
+
+	if (stmt.from_table) {
+		BoundCrossProductRef bound_crossproduct;
+		bound_crossproduct.left = move(bound_table);
+		bound_crossproduct.right = Bind(*stmt.from_table);
+		root = CreatePlan(bound_crossproduct);
+		get = (LogicalGet *)root->children[0].get();
+	} else {
+		root = CreatePlan(*bound_table);
+		get = (LogicalGet *)root.get();
+	}
+
+	if (!table->temporary) {
+		// update of persistent table: not read only!
+		properties.read_only = false;
+	}
+	auto update = make_unique<LogicalUpdate>(table);
+
+	// set return_chunk boolean early because it needs uses update_is_del_and_insert logic
+	if (!stmt.returning_list.empty()) {
+		update->return_chunk = true;
+	}
+	// bind the default values
+	BindDefaultValues(table->columns, update->bound_defaults);
+
+	// project any additional columns required for the condition/expressions
+	if (stmt.condition) {
+		WhereBinder binder(*this, context);
+		auto condition = binder.Bind(stmt.condition);
+
+		PlanSubqueries(&condition, &root);
+		auto filter = make_unique<LogicalFilter>(move(condition));
+		filter->AddChild(move(root));
+		root = move(filter);
+	}
+
+	D_ASSERT(stmt.columns.size() == stmt.expressions.size());
+
+	auto proj_index = GenerateTableIndex();
+	vector<unique_ptr<Expression>> projection_expressions;
+
+	for (idx_t i = 0; i < stmt.columns.size(); i++) {
+		auto &colname = stmt.columns[i];
+		auto &expr = stmt.expressions[i];
+		if (!table->ColumnExists(colname)) {
+			throw BinderException("Referenced update column %s not found in table!", colname);
+		}
+		auto &column = table->GetColumn(colname);
+		if (column.Generated()) {
+			throw BinderException("Cant update column \"%s\" because it is a generated column!", column.Name());
+		}
+		if (std::find(update->columns.begin(), update->columns.end(), column.Oid()) != update->columns.end()) {
+			throw BinderException("Multiple assignments to same column \"%s\"", colname);
+		}
+		update->columns.push_back(column.Oid());
+
+		if (expr->type == ExpressionType::VALUE_DEFAULT) {
+			update->expressions.push_back(make_unique<BoundDefaultExpression>(column.Type()));
+		} else {
+			UpdateBinder binder(*this, context);
+			binder.target_type = column.Type();
+			auto bound_expr = binder.Bind(expr);
+			PlanSubqueries(&bound_expr, &root);
+
+			update->expressions.push_back(make_unique<BoundColumnRefExpression>(
+			    bound_expr->return_type, ColumnBinding(proj_index, projection_expressions.size())));
+			projection_expressions.push_back(move(bound_expr));
+		}
+	}
+
+	// now create the projection
+	auto proj = make_unique<LogicalProjection>(proj_index, move(projection_expressions));
+	proj->AddChild(move(root));
+
+	// bind any extra columns necessary for CHECK constraints or indexes
+	BindUpdateConstraints(*table, *get, *proj, *update);
+
+	// finally add the row id column to the projection list
+	proj->expressions.push_back(make_unique<BoundColumnRefExpression>(
+	    LogicalType::ROW_TYPE, ColumnBinding(get->table_index, get->column_ids.size())));
+	get->column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+
+	// set the projection as child of the update node and finalize the result
+	update->AddChild(move(proj));
+
+	if (!stmt.returning_list.empty()) {
+		auto update_table_index = GenerateTableIndex();
+		update->table_index = update_table_index;
+		unique_ptr<LogicalOperator> update_as_logicaloperator = move(update);
+
+		return BindReturning(move(stmt.returning_list), table, update_table_index, move(update_as_logicaloperator),
+		                     move(result));
+
+	} else {
+		update->table_index = 0;
+		result.names = {"Count"};
+		result.types = {LogicalType::BIGINT};
+		result.plan = move(update);
+		properties.allow_stream_result = false;
+		properties.return_type = StatementReturnType::CHANGED_ROWS;
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+BoundStatement Binder::Bind(VacuumStatement &stmt) {
+	BoundStatement result;
+	result.names = {"Success"};
+	result.types = {LogicalType::BOOLEAN};
+	result.plan = make_unique<LogicalSimple>(LogicalOperatorType::LOGICAL_VACUUM, move(stmt.info));
+	properties.return_type = StatementReturnType::NOTHING;
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<BoundTableRef> Binder::Bind(BaseTableRef &ref) {
+	QueryErrorContext error_context(root_statement, ref.query_location);
+	// CTEs and views are also referred to using BaseTableRefs, hence need to distinguish here
+	// check if the table name refers to a CTE
+	auto cte = FindCTE(ref.table_name, ref.table_name == alias);
+	if (cte) {
+		// Check if there is a CTE binding in the BindContext
+		auto ctebinding = bind_context.GetCTEBinding(ref.table_name);
+		if (!ctebinding) {
+			if (CTEIsAlreadyBound(cte)) {
+				throw BinderException("Circular reference to CTE \"%s\", use WITH RECURSIVE to use recursive CTEs",
+				                      ref.table_name);
+			}
+			// Move CTE to subquery and bind recursively
+			SubqueryRef subquery(unique_ptr_cast<SQLStatement, SelectStatement>(cte->query->Copy()));
+			subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;
+			subquery.column_name_alias = cte->aliases;
+			for (idx_t i = 0; i < ref.column_name_alias.size(); i++) {
+				if (i < subquery.column_name_alias.size()) {
+					subquery.column_name_alias[i] = ref.column_name_alias[i];
+				} else {
+					subquery.column_name_alias.push_back(ref.column_name_alias[i]);
+				}
+			}
+			return Bind(subquery, cte);
+		} else {
+			// There is a CTE binding in the BindContext.
+			// This can only be the case if there is a recursive CTE present.
+			auto index = GenerateTableIndex();
+			auto result = make_unique<BoundCTERef>(index, ctebinding->index);
+			auto b = ctebinding;
+			auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
+			auto names = BindContext::AliasColumnNames(alias, b->names, ref.column_name_alias);
+
+			bind_context.AddGenericBinding(index, alias, names, b->types);
+			// Update references to CTE
+			auto cteref = bind_context.cte_references[ref.table_name];
+			(*cteref)++;
+
+			result->types = b->types;
+			result->bound_columns = move(names);
+			return move(result);
+		}
+	}
+	// not a CTE
+	// extract a table or view from the catalog
+	auto &catalog = Catalog::GetCatalog(context);
+	auto table_or_view =
+	    catalog.GetEntry(context, CatalogType::TABLE_ENTRY, ref.schema_name, ref.table_name, true, error_context);
+	if (!table_or_view) {
+		auto table_name = ref.schema_name.empty() ? ref.table_name : (ref.schema_name + "." + ref.table_name);
+		// table could not be found: try to bind a replacement scan
+		auto &config = DBConfig::GetConfig(context);
+		for (auto &scan : config.replacement_scans) {
+			auto replacement_function = scan.function(context, table_name, scan.data.get());
+			if (replacement_function) {
+				replacement_function->alias = ref.alias.empty() ? ref.table_name : ref.alias;
+				replacement_function->column_name_alias = ref.column_name_alias;
+				return Bind(*replacement_function);
+			}
+		}
+		// we still didn't find the table
+		if (GetBindingMode() == BindingMode::EXTRACT_NAMES) {
+			// if we are in EXTRACT_NAMES, we create a dummy table ref
+			AddTableName(table_name);
+
+			// add a bind context entry
+			auto table_index = GenerateTableIndex();
+			auto alias = ref.alias.empty() ? table_name : ref.alias;
+			vector<LogicalType> types {LogicalType::INTEGER};
+			vector<string> names {"__dummy_col" + to_string(table_index)};
+			bind_context.AddGenericBinding(table_index, alias, names, types);
+			return make_unique_base<BoundTableRef, BoundEmptyTableRef>(table_index);
+		}
+		// could not find an alternative: bind again to get the error
+		table_or_view = Catalog::GetCatalog(context).GetEntry(context, CatalogType::TABLE_ENTRY, ref.schema_name,
+		                                                      ref.table_name, false, error_context);
+	}
+	switch (table_or_view->type) {
+	case CatalogType::TABLE_ENTRY: {
+		// base table: create the BoundBaseTableRef node
+		auto table_index = GenerateTableIndex();
+		auto table = (TableCatalogEntry *)table_or_view;
+
+		auto scan_function = TableScanFunction::GetFunction();
+		auto bind_data = make_unique<TableScanBindData>(table);
+		auto alias = ref.alias.empty() ? ref.table_name : ref.alias;
+		// TODO: bundle the type and name vector in a struct (e.g PackedColumnMetadata)
+		vector<LogicalType> table_types;
+		vector<string> table_names;
+		vector<TableColumnType> table_categories;
+
+		vector<LogicalType> return_types;
+		vector<string> return_names;
+		for (auto &col : table->columns) {
+			table_types.push_back(col.Type());
+			table_names.push_back(col.Name());
+			return_types.push_back(col.Type());
+			return_names.push_back(col.Name());
+		}
+		table_names = BindContext::AliasColumnNames(alias, table_names, ref.column_name_alias);
+
+		auto logical_get = make_unique<LogicalGet>(table_index, scan_function, move(bind_data), move(return_types),
+		                                           move(return_names));
+		bind_context.AddBaseTable(table_index, alias, table_names, table_types, *logical_get);
+		return make_unique_base<BoundTableRef, BoundBaseTableRef>(table, move(logical_get));
+	}
+	case CatalogType::VIEW_ENTRY: {
+		// the node is a view: get the query that the view represents
+		auto view_catalog_entry = (ViewCatalogEntry *)table_or_view;
+		// We need to use a new binder for the view that doesn't reference any CTEs
+		// defined for this binder so there are no collisions between the CTEs defined
+		// for the view and for the current query
+		bool inherit_ctes = false;
+		auto view_binder = Binder::CreateBinder(context, this, inherit_ctes);
+		view_binder->can_contain_nulls = true;
+		SubqueryRef subquery(unique_ptr_cast<SQLStatement, SelectStatement>(view_catalog_entry->query->Copy()));
+		subquery.alias = ref.alias.empty() ? ref.table_name : ref.alias;
+		subquery.column_name_alias =
+		    BindContext::AliasColumnNames(subquery.alias, view_catalog_entry->aliases, ref.column_name_alias);
+		// bind the child subquery
+		view_binder->AddBoundView(view_catalog_entry);
+		auto bound_child = view_binder->Bind(subquery);
+
+		D_ASSERT(bound_child->type == TableReferenceType::SUBQUERY);
+		// verify that the types and names match up with the expected types and names
+		auto &bound_subquery = (BoundSubqueryRef &)*bound_child;
+		if (bound_subquery.subquery->types != view_catalog_entry->types) {
+			throw BinderException("Contents of view were altered: types don't match!");
+		}
+		bind_context.AddView(bound_subquery.subquery->GetRootIndex(), subquery.alias, subquery,
+		                     *bound_subquery.subquery, view_catalog_entry);
+		return bound_child;
+	}
+	default:
+		throw InternalException("Catalog entry type");
+	}
+}
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<BoundTableRef> Binder::Bind(CrossProductRef &ref) {
+	auto result = make_unique<BoundCrossProductRef>();
+	result->left_binder = Binder::CreateBinder(context, this);
+	result->right_binder = Binder::CreateBinder(context, this);
+	auto &left_binder = *result->left_binder;
+	auto &right_binder = *result->right_binder;
+
+	result->left = left_binder.Bind(*ref.left);
+	result->right = right_binder.Bind(*ref.right);
+
+	bind_context.AddContext(move(left_binder.bind_context));
+	bind_context.AddContext(move(right_binder.bind_context));
+	MoveCorrelatedExpressions(left_binder);
+	MoveCorrelatedExpressions(right_binder);
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<BoundTableRef> Binder::Bind(EmptyTableRef &ref) {
+	return make_unique<BoundEmptyTableRef>(GenerateTableIndex());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<BoundTableRef> Binder::Bind(ExpressionListRef &expr) {
+	auto result = make_unique<BoundExpressionListRef>();
+	result->types = expr.expected_types;
+	result->names = expr.expected_names;
+	// bind value list
+	InsertBinder binder(*this, context);
+	binder.target_type = LogicalType(LogicalTypeId::INVALID);
+	for (idx_t list_idx = 0; list_idx < expr.values.size(); list_idx++) {
+		auto &expression_list = expr.values[list_idx];
+		if (result->names.empty()) {
+			// no names provided, generate them
+			for (idx_t val_idx = 0; val_idx < expression_list.size(); val_idx++) {
+				result->names.push_back("col" + to_string(val_idx));
+			}
+		}
+
+		vector<unique_ptr<Expression>> list;
+		for (idx_t val_idx = 0; val_idx < expression_list.size(); val_idx++) {
+			if (!result->types.empty()) {
+				D_ASSERT(result->types.size() == expression_list.size());
+				binder.target_type = result->types[val_idx];
+			}
+			auto expr = binder.Bind(expression_list[val_idx]);
+			list.push_back(move(expr));
+		}
+		result->values.push_back(move(list));
+	}
+	if (result->types.empty() && !expr.values.empty()) {
+		// there are no types specified
+		// we have to figure out the result types
+		// for each column, we iterate over all of the expressions and select the max logical type
+		// we initialize all types to SQLNULL
+		result->types.resize(expr.values[0].size(), LogicalType::SQLNULL);
+		// now loop over the lists and select the max logical type
+		for (idx_t list_idx = 0; list_idx < result->values.size(); list_idx++) {
+			auto &list = result->values[list_idx];
+			for (idx_t val_idx = 0; val_idx < list.size(); val_idx++) {
+				result->types[val_idx] =
+				    LogicalType::MaxLogicalType(result->types[val_idx], list[val_idx]->return_type);
+			}
+		}
+		// finally do another loop over the expressions and add casts where required
+		for (idx_t list_idx = 0; list_idx < result->values.size(); list_idx++) {
+			auto &list = result->values[list_idx];
+			for (idx_t val_idx = 0; val_idx < list.size(); val_idx++) {
+				list[val_idx] = BoundCastExpression::AddCastToType(move(list[val_idx]), result->types[val_idx]);
+			}
+		}
+	}
+	result->bind_index = GenerateTableIndex();
+	bind_context.AddGenericBinding(result->bind_index, expr.alias, result->names, result->types);
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static unique_ptr<ParsedExpression> BindColumn(Binder &binder, ClientContext &context, const string &alias,
+                                               const string &column_name) {
+	auto expr = make_unique_base<ParsedExpression, ColumnRefExpression>(column_name, alias);
+	ExpressionBinder expr_binder(binder, context);
+	auto result = expr_binder.Bind(expr);
+	return make_unique<BoundExpression>(move(result));
+}
+
+static unique_ptr<ParsedExpression> AddCondition(ClientContext &context, Binder &left_binder, Binder &right_binder,
+                                                 const string &left_alias, const string &right_alias,
+                                                 const string &column_name) {
+	ExpressionBinder expr_binder(left_binder, context);
+	auto left = BindColumn(left_binder, context, left_alias, column_name);
+	auto right = BindColumn(right_binder, context, right_alias, column_name);
+	return make_unique<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, move(left), move(right));
+}
+
+bool Binder::TryFindBinding(const string &using_column, const string &join_side, string &result) {
+	// for each using column, get the matching binding
+	auto bindings = bind_context.GetMatchingBindings(using_column);
+	if (bindings.empty()) {
+		return false;
+	}
+	// find the join binding
+	for (auto &binding : bindings) {
+		if (!result.empty()) {
+			string error = "Column name \"";
+			error += using_column;
+			error += "\" is ambiguous: it exists more than once on ";
+			error += join_side;
+			error += " side of join.\nCandidates:";
+			for (auto &binding : bindings) {
+				error += "\n\t";
+				error += binding;
+				error += ".";
+				error += bind_context.GetActualColumnName(binding, using_column);
+			}
+			throw BinderException(error);
+		} else {
+			result = binding;
+		}
+	}
+	return true;
+}
+
+string Binder::FindBinding(const string &using_column, const string &join_side) {
+	string result;
+	if (!TryFindBinding(using_column, join_side, result)) {
+		throw BinderException("Column \"%s\" does not exist on %s side of join!", using_column, join_side);
+	}
+	return result;
+}
+
+static void AddUsingBindings(UsingColumnSet &set, UsingColumnSet *input_set, const string &input_binding) {
+	if (input_set) {
+		for (auto &entry : input_set->bindings) {
+			set.bindings.insert(entry);
+		}
+	} else {
+		set.bindings.insert(input_binding);
+	}
+}
+
+static void SetPrimaryBinding(UsingColumnSet &set, JoinType join_type, const string &left_binding,
+                              const string &right_binding) {
+	switch (join_type) {
+	case JoinType::LEFT:
+	case JoinType::INNER:
+	case JoinType::SEMI:
+	case JoinType::ANTI:
+		set.primary_binding = left_binding;
+		break;
+	case JoinType::RIGHT:
+		set.primary_binding = right_binding;
+		break;
+	default:
+		break;
+	}
+}
+
+string Binder::RetrieveUsingBinding(Binder &current_binder, UsingColumnSet *current_set, const string &using_column,
+                                    const string &join_side, UsingColumnSet *new_set) {
+	string binding;
+	if (!current_set) {
+		binding = current_binder.FindBinding(using_column, join_side);
+	} else {
+		binding = current_set->primary_binding;
+	}
+	return binding;
+}
+
+unique_ptr<BoundTableRef> Binder::Bind(JoinRef &ref) {
+	auto result = make_unique<BoundJoinRef>();
+	result->left_binder = Binder::CreateBinder(context, this);
+	result->right_binder = Binder::CreateBinder(context, this);
+	auto &left_binder = *result->left_binder;
+	auto &right_binder = *result->right_binder;
+
+	result->type = ref.type;
+	result->left = left_binder.Bind(*ref.left);
+	result->right = right_binder.Bind(*ref.right);
+
+	vector<unique_ptr<ParsedExpression>> extra_conditions;
+	vector<string> extra_using_columns;
+	if (ref.is_natural) {
+		// natural join, figure out which column names are present in both sides of the join
+		// first bind the left hand side and get a list of all the tables and column names
+		case_insensitive_set_t lhs_columns;
+		auto &lhs_binding_list = left_binder.bind_context.GetBindingsList();
+		for (auto &binding : lhs_binding_list) {
+			for (auto &column_name : binding.second->names) {
+				lhs_columns.insert(column_name);
+			}
+		}
+		// now bind the rhs
+		for (auto &column_name : lhs_columns) {
+			auto right_using_binding = right_binder.bind_context.GetUsingBinding(column_name);
+
+			string right_binding;
+			// loop over the set of lhs columns, and figure out if there is a table in the rhs with the same name
+			if (!right_using_binding) {
+				if (!right_binder.TryFindBinding(column_name, "right", right_binding)) {
+					// no match found for this column on the rhs: skip
+					continue;
+				}
+			}
+			extra_using_columns.push_back(column_name);
+		}
+		if (extra_using_columns.empty()) {
+			// no matching bindings found in natural join: throw an exception
+			string error_msg = "No columns found to join on in NATURAL JOIN.\n";
+			error_msg += "Use CROSS JOIN if you intended for this to be a cross-product.";
+			// gather all left/right candidates
+			string left_candidates, right_candidates;
+			auto &rhs_binding_list = right_binder.bind_context.GetBindingsList();
+			for (auto &binding : lhs_binding_list) {
+				for (auto &column_name : binding.second->names) {
+					if (!left_candidates.empty()) {
+						left_candidates += ", ";
+					}
+					left_candidates += binding.first + "." + column_name;
+				}
+			}
+			for (auto &binding : rhs_binding_list) {
+				for (auto &column_name : binding.second->names) {
+					if (!right_candidates.empty()) {
+						right_candidates += ", ";
+					}
+					right_candidates += binding.first + "." + column_name;
+				}
+			}
+			error_msg += "\n   Left candidates: " + left_candidates;
+			error_msg += "\n   Right candidates: " + right_candidates;
+			throw BinderException(FormatError(ref, error_msg));
+		}
+	} else if (!ref.using_columns.empty()) {
+		// USING columns
+		D_ASSERT(!result->condition);
+		extra_using_columns = ref.using_columns;
+	}
+	if (!extra_using_columns.empty()) {
+		vector<UsingColumnSet *> left_using_bindings;
+		vector<UsingColumnSet *> right_using_bindings;
+		for (idx_t i = 0; i < extra_using_columns.size(); i++) {
+			auto &using_column = extra_using_columns[i];
+			// we check if there is ALREADY a using column of the same name in the left and right set
+			// this can happen if we chain USING clauses
+			// e.g. x JOIN y USING (c) JOIN z USING (c)
+			auto left_using_binding = left_binder.bind_context.GetUsingBinding(using_column);
+			auto right_using_binding = right_binder.bind_context.GetUsingBinding(using_column);
+			if (!left_using_binding) {
+				left_binder.bind_context.GetMatchingBinding(using_column);
+			}
+			if (!right_using_binding) {
+				right_binder.bind_context.GetMatchingBinding(using_column);
+			}
+			left_using_bindings.push_back(left_using_binding);
+			right_using_bindings.push_back(right_using_binding);
+		}
+
+		for (idx_t i = 0; i < extra_using_columns.size(); i++) {
+			auto &using_column = extra_using_columns[i];
+			string left_binding;
+			string right_binding;
+
+			auto set = make_unique<UsingColumnSet>();
+			auto left_using_binding = left_using_bindings[i];
+			auto right_using_binding = right_using_bindings[i];
+			left_binding = RetrieveUsingBinding(left_binder, left_using_binding, using_column, "left", set.get());
+			right_binding = RetrieveUsingBinding(right_binder, right_using_binding, using_column, "right", set.get());
+
+			extra_conditions.push_back(
+			    AddCondition(context, left_binder, right_binder, left_binding, right_binding, using_column));
+
+			AddUsingBindings(*set, left_using_binding, left_binding);
+			AddUsingBindings(*set, right_using_binding, right_binding);
+			SetPrimaryBinding(*set, ref.type, left_binding, right_binding);
+			bind_context.TransferUsingBinding(left_binder.bind_context, left_using_binding, set.get(), left_binding,
+			                                  using_column);
+			bind_context.TransferUsingBinding(right_binder.bind_context, right_using_binding, set.get(), right_binding,
+			                                  using_column);
+			AddUsingBindingSet(move(set));
+		}
+	}
+
+	bind_context.AddContext(move(left_binder.bind_context));
+	bind_context.AddContext(move(right_binder.bind_context));
+	MoveCorrelatedExpressions(left_binder);
+	MoveCorrelatedExpressions(right_binder);
+	for (auto &condition : extra_conditions) {
+		if (ref.condition) {
+			ref.condition = make_unique<ConjunctionExpression>(ExpressionType::CONJUNCTION_AND, move(ref.condition),
+			                                                   move(condition));
+		} else {
+			ref.condition = move(condition);
+		}
+	}
+	if (ref.condition) {
+		WhereBinder binder(*this, context);
+		result->condition = binder.Bind(ref.condition);
+	}
+	D_ASSERT(result->condition);
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+void Binder::BindNamedParameters(named_parameter_type_map_t &types, named_parameter_map_t &values,
+                                 QueryErrorContext &error_context, string &func_name) {
+	for (auto &kv : values) {
+		auto entry = types.find(kv.first);
+		if (entry == types.end()) {
+			// create a list of named parameters for the error
+			string named_params;
+			for (auto &kv : types) {
+				named_params += "    ";
+				named_params += kv.first;
+				named_params += " ";
+				named_params += kv.second.ToString();
+				named_params += "\n";
+			}
+			string error_msg;
+			if (named_params.empty()) {
+				error_msg = "Function does not accept any named parameters.";
+			} else {
+				error_msg = "Candidates: " + named_params;
+			}
+			throw BinderException(error_context.FormatError("Invalid named parameter \"%s\" for function %s\n%s",
+			                                                kv.first, func_name, error_msg));
+		}
+		if (entry->second.id() != LogicalTypeId::ANY) {
+			kv.second = kv.second.CastAs(entry->second);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<BoundTableRef> Binder::Bind(SubqueryRef &ref, CommonTableExpressionInfo *cte) {
+	auto binder = Binder::CreateBinder(context, this);
+	binder->can_contain_nulls = true;
+	if (cte) {
+		binder->bound_ctes.insert(cte);
+	}
+	binder->alias = ref.alias.empty() ? "unnamed_subquery" : ref.alias;
+	auto subquery = binder->BindNode(*ref.subquery->node);
+	idx_t bind_index = subquery->GetRootIndex();
+	string alias;
+	if (ref.alias.empty()) {
+		alias = "unnamed_subquery" + to_string(bind_index);
+	} else {
+		alias = ref.alias;
+	}
+	auto result = make_unique<BoundSubqueryRef>(move(binder), move(subquery));
+	bind_context.AddSubquery(bind_index, alias, ref, *result->subquery);
+	MoveCorrelatedExpressions(*result->binder);
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static bool IsTableInTableOutFunction(TableFunctionCatalogEntry &table_function) {
+	return table_function.functions.size() == 1 && table_function.functions[0].arguments.size() == 1 &&
+	       table_function.functions[0].arguments[0].id() == LogicalTypeId::TABLE;
+}
+
+bool Binder::BindTableInTableOutFunction(vector<unique_ptr<ParsedExpression>> &expressions,
+                                         unique_ptr<BoundSubqueryRef> &subquery, string &error) {
+	auto binder = Binder::CreateBinder(this->context, this, true);
+	if (expressions.size() == 1 && expressions[0]->type == ExpressionType::SUBQUERY) {
+		// general case: argument is a subquery, bind it as part of the node
+		auto &se = (SubqueryExpression &)*expressions[0];
+		auto node = binder->BindNode(*se.subquery->node);
+		subquery = make_unique<BoundSubqueryRef>(move(binder), move(node));
+		return true;
+	}
+	// special case: non-subquery parameter to table-in table-out function
+	// generate a subquery and bind that (i.e. UNNEST([1,2,3]) becomes UNNEST((SELECT [1,2,3]))
+	auto select_node = make_unique<SelectNode>();
+	select_node->select_list = move(expressions);
+	select_node->from_table = make_unique<EmptyTableRef>();
+	auto node = binder->BindNode(*select_node);
+	subquery = make_unique<BoundSubqueryRef>(move(binder), move(node));
+	return true;
+}
+
+bool Binder::BindTableFunctionParameters(TableFunctionCatalogEntry &table_function,
+                                         vector<unique_ptr<ParsedExpression>> &expressions,
+                                         vector<LogicalType> &arguments, vector<Value> &parameters,
+                                         named_parameter_map_t &named_parameters,
+                                         unique_ptr<BoundSubqueryRef> &subquery, string &error) {
+	if (IsTableInTableOutFunction(table_function)) {
+		// special case binding for table-in table-out function
+		arguments.emplace_back(LogicalTypeId::TABLE);
+		return BindTableInTableOutFunction(expressions, subquery, error);
+	}
+	bool seen_subquery = false;
+	for (auto &child : expressions) {
+		string parameter_name;
+
+		// hack to make named parameters work
+		if (child->type == ExpressionType::COMPARE_EQUAL) {
+			// comparison, check if the LHS is a columnref
+			auto &comp = (ComparisonExpression &)*child;
+			if (comp.left->type == ExpressionType::COLUMN_REF) {
+				auto &colref = (ColumnRefExpression &)*comp.left;
+				if (!colref.IsQualified()) {
+					parameter_name = colref.GetColumnName();
+					child = move(comp.right);
+				}
+			}
+		}
+		if (child->type == ExpressionType::SUBQUERY) {
+			if (seen_subquery) {
+				error = "Table function can have at most one subquery parameter ";
+				return false;
+			}
+			auto binder = Binder::CreateBinder(this->context, this, true);
+			auto &se = (SubqueryExpression &)*child;
+			auto node = binder->BindNode(*se.subquery->node);
+			subquery = make_unique<BoundSubqueryRef>(move(binder), move(node));
+			seen_subquery = true;
+			arguments.emplace_back(LogicalTypeId::TABLE);
+			continue;
+		}
+
+		ConstantBinder binder(*this, context, "TABLE FUNCTION parameter");
+		LogicalType sql_type;
+		auto expr = binder.Bind(child, &sql_type);
+		if (!expr->IsFoldable()) {
+			error = "Table function requires a constant parameter";
+			return false;
+		}
+		auto constant = ExpressionExecutor::EvaluateScalar(*expr);
+		if (parameter_name.empty()) {
+			// unnamed parameter
+			if (!named_parameters.empty()) {
+				error = "Unnamed parameters cannot come after named parameters";
+				return false;
+			}
+			arguments.emplace_back(sql_type);
+			parameters.emplace_back(move(constant));
+		} else {
+			named_parameters[parameter_name] = move(constant);
+		}
+	}
+	return true;
+}
+
+unique_ptr<BoundTableRef> Binder::Bind(TableFunctionRef &ref) {
+	QueryErrorContext error_context(root_statement, ref.query_location);
+	auto bind_index = GenerateTableIndex();
+
+	D_ASSERT(ref.function->type == ExpressionType::FUNCTION);
+	auto fexpr = (FunctionExpression *)ref.function.get();
+
+	TableFunctionCatalogEntry *function = nullptr;
+
+	// fetch the function from the catalog
+	auto &catalog = Catalog::GetCatalog(context);
+
+	auto func_catalog = catalog.GetEntry(context, CatalogType::TABLE_FUNCTION_ENTRY, fexpr->schema,
+	                                     fexpr->function_name, false, error_context);
+
+	if (func_catalog->type == CatalogType::TABLE_FUNCTION_ENTRY) {
+		function = (TableFunctionCatalogEntry *)func_catalog;
+	} else if (func_catalog->type == CatalogType::TABLE_MACRO_ENTRY) {
+		auto macro_func = (TableMacroCatalogEntry *)func_catalog;
+		auto query_node = BindTableMacro(*fexpr, macro_func, 0);
+		D_ASSERT(query_node);
+
+		auto binder = Binder::CreateBinder(context, this);
+		binder->can_contain_nulls = true;
+
+		binder->alias = ref.alias.empty() ? "unnamed_query" : ref.alias;
+		auto query = binder->BindNode(*query_node);
+
+		idx_t bind_index = query->GetRootIndex();
+		// string alias;
+		string alias = (ref.alias.empty() ? "unnamed_query" + to_string(bind_index) : ref.alias);
+
+		auto result = make_unique<BoundSubqueryRef>(move(binder), move(query));
+		// remember ref here is TableFunctionRef and NOT base class
+		bind_context.AddSubquery(bind_index, alias, ref, *result->subquery);
+		MoveCorrelatedExpressions(*result->binder);
+		return move(result);
+	}
+
+	// evaluate the input parameters to the function
+	vector<LogicalType> arguments;
+	vector<Value> parameters;
+	named_parameter_map_t named_parameters;
+	unique_ptr<BoundSubqueryRef> subquery;
+	string error;
+	if (!BindTableFunctionParameters(*function, fexpr->children, arguments, parameters, named_parameters, subquery,
+	                                 error)) {
+		throw BinderException(FormatError(ref, error));
+	}
+
+	// select the function based on the input parameters
+	idx_t best_function_idx = Function::BindFunction(function->name, function->functions, arguments, error);
+	if (best_function_idx == DConstants::INVALID_INDEX) {
+		throw BinderException(FormatError(ref, error));
+	}
+	auto &table_function = function->functions[best_function_idx];
+
+	// now check the named parameters
+	BindNamedParameters(table_function.named_parameters, named_parameters, error_context, table_function.name);
+
+	// cast the parameters to the type of the function
+	for (idx_t i = 0; i < arguments.size(); i++) {
+		if (table_function.arguments[i] != LogicalType::ANY && table_function.arguments[i] != LogicalType::TABLE &&
+		    table_function.arguments[i] != LogicalType::POINTER &&
+		    table_function.arguments[i].id() != LogicalTypeId::LIST) {
+			parameters[i] = parameters[i].CastAs(table_function.arguments[i]);
+		}
+	}
+
+	vector<LogicalType> input_table_types;
+	vector<string> input_table_names;
+
+	if (subquery) {
+		input_table_types = subquery->subquery->types;
+		input_table_names = subquery->subquery->names;
+	}
+
+	// perform the binding
+	unique_ptr<FunctionData> bind_data;
+	vector<LogicalType> return_types;
+	vector<string> return_names;
+	if (table_function.bind) {
+		TableFunctionBindInput bind_input(parameters, named_parameters, input_table_types, input_table_names,
+		                                  table_function.function_info.get());
+		bind_data = table_function.bind(context, bind_input, return_types, return_names);
+		if (table_function.name == "pandas_scan" || table_function.name == "arrow_scan") {
+			auto arrow_bind = (PyTableFunctionData *)bind_data.get();
+			arrow_bind->external_dependency = move(ref.external_dependency);
+		}
+	}
+	if (return_types.size() != return_names.size()) {
+		throw InternalException(
+		    "Failed to bind \"%s\": Table function return_types and return_names must be of the same size",
+		    table_function.name);
+	}
+	if (return_types.empty()) {
+		throw InternalException("Failed to bind \"%s\": Table function must return at least one column",
+		                        table_function.name);
+	}
+	// overwrite the names with any supplied aliases
+	for (idx_t i = 0; i < ref.column_name_alias.size() && i < return_names.size(); i++) {
+		return_names[i] = ref.column_name_alias[i];
+	}
+	for (idx_t i = 0; i < return_names.size(); i++) {
+		if (return_names[i].empty()) {
+			return_names[i] = "C" + to_string(i);
+		}
+	}
+	auto get = make_unique<LogicalGet>(bind_index, table_function, move(bind_data), return_types, return_names);
+	// now add the table function to the bind context so its columns can be bound
+	bind_context.AddTableFunction(bind_index, ref.alias.empty() ? fexpr->function_name : ref.alias, return_names,
+	                              return_types, *get);
+	if (subquery) {
+		get->children.push_back(Binder::CreatePlan(*subquery));
+	}
+
+	return make_unique_base<BoundTableRef, BoundTableFunction>(move(get));
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundBaseTableRef &ref) {
+	return move(ref.get);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundCrossProductRef &expr) {
+	auto cross_product = make_unique<LogicalCrossProduct>();
+
+	auto left = CreatePlan(*expr.left);
+	auto right = CreatePlan(*expr.right);
+
+	cross_product->AddChild(move(left));
+	cross_product->AddChild(move(right));
+
+	return move(cross_product);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundCTERef &ref) {
+	auto index = ref.bind_index;
+
+	vector<LogicalType> types;
+	for (auto &type : ref.types) {
+		types.push_back(type);
+	}
+
+	return make_unique<LogicalCTERef>(index, ref.cte_index, types, ref.bound_columns);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundEmptyTableRef &ref) {
+	return make_unique<LogicalDummyScan>(ref.bind_index);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundExpressionListRef &ref) {
+	auto root = make_unique_base<LogicalOperator, LogicalDummyScan>(0);
+	// values list, first plan any subqueries in the list
+	for (auto &expr_list : ref.values) {
+		for (auto &expr : expr_list) {
+			PlanSubqueries(&expr, &root);
+		}
+	}
+	// now create a LogicalExpressionGet from the set of expressions
+	// fetch the types
+	vector<LogicalType> types;
+	for (auto &expr : ref.values[0]) {
+		types.push_back(expr->return_type);
+	}
+	auto expr_get = make_unique<LogicalExpressionGet>(ref.bind_index, types, move(ref.values));
+	expr_get->AddChild(move(root));
+	return move(expr_get);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//! Create a JoinCondition from a comparison
+static bool CreateJoinCondition(Expression &expr, unordered_set<idx_t> &left_bindings,
+                                unordered_set<idx_t> &right_bindings, vector<JoinCondition> &conditions) {
+	// comparison
+	auto &comparison = (BoundComparisonExpression &)expr;
+	auto left_side = JoinSide::GetJoinSide(*comparison.left, left_bindings, right_bindings);
+	auto right_side = JoinSide::GetJoinSide(*comparison.right, left_bindings, right_bindings);
+	if (left_side != JoinSide::BOTH && right_side != JoinSide::BOTH) {
+		// join condition can be divided in a left/right side
+		JoinCondition condition;
+		condition.comparison = expr.type;
+		auto left = move(comparison.left);
+		auto right = move(comparison.right);
+		if (left_side == JoinSide::RIGHT) {
+			// left = right, right = left, flip the comparison symbol and reverse sides
+			swap(left, right);
+			condition.comparison = FlipComparisionExpression(expr.type);
+		}
+		condition.left = move(left);
+		condition.right = move(right);
+		conditions.push_back(move(condition));
+		return true;
+	}
+	return false;
+}
+
+unique_ptr<LogicalOperator> LogicalComparisonJoin::CreateJoin(JoinType type, unique_ptr<LogicalOperator> left_child,
+                                                              unique_ptr<LogicalOperator> right_child,
+                                                              unordered_set<idx_t> &left_bindings,
+                                                              unordered_set<idx_t> &right_bindings,
+                                                              vector<unique_ptr<Expression>> &expressions) {
+	vector<JoinCondition> conditions;
+	vector<unique_ptr<Expression>> arbitrary_expressions;
+	// first check if we can create
+	for (auto &expr : expressions) {
+		auto total_side = JoinSide::GetJoinSide(*expr, left_bindings, right_bindings);
+		if (total_side != JoinSide::BOTH) {
+			// join condition does not reference both sides, add it as filter under the join
+			if (type == JoinType::LEFT && total_side == JoinSide::RIGHT) {
+				// filter is on RHS and the join is a LEFT OUTER join, we can push it in the right child
+				if (right_child->type != LogicalOperatorType::LOGICAL_FILTER) {
+					// not a filter yet, push a new empty filter
+					auto filter = make_unique<LogicalFilter>();
+					filter->AddChild(move(right_child));
+					right_child = move(filter);
+				}
+				// push the expression into the filter
+				auto &filter = (LogicalFilter &)*right_child;
+				filter.expressions.push_back(move(expr));
+				continue;
+			}
+		} else if ((expr->type >= ExpressionType::COMPARE_EQUAL &&
+		            expr->type <= ExpressionType::COMPARE_GREATERTHANOREQUALTO) ||
+		           expr->type == ExpressionType::COMPARE_DISTINCT_FROM ||
+		           expr->type == ExpressionType::COMPARE_NOT_DISTINCT_FROM) {
+			// comparison, check if we can create a comparison JoinCondition
+			if (CreateJoinCondition(*expr, left_bindings, right_bindings, conditions)) {
+				// successfully created the join condition
+				continue;
+			}
+		}
+		arbitrary_expressions.push_back(move(expr));
+	}
+	bool need_to_consider_arbitrary_expressions = true;
+	if (type == JoinType::INNER) {
+		// for inner joins we can push arbitrary expressions as a filter
+		// here we prefer to create a comparison join if possible
+		// that way we can use the much faster hash join to process the main join
+		// rather than doing a nested loop join to handle arbitrary expressions
+
+		// for left and full outer joins we HAVE to process all join conditions
+		// because pushing a filter will lead to an incorrect result, as non-matching tuples cannot be filtered out
+		need_to_consider_arbitrary_expressions = false;
+	}
+	if ((need_to_consider_arbitrary_expressions && !arbitrary_expressions.empty()) || conditions.empty()) {
+		if (arbitrary_expressions.empty()) {
+			// all conditions were pushed down, add TRUE predicate
+			arbitrary_expressions.push_back(make_unique<BoundConstantExpression>(Value::BOOLEAN(true)));
+		}
+		for (auto &condition : conditions) {
+			arbitrary_expressions.push_back(JoinCondition::CreateExpression(move(condition)));
+		}
+		// if we get here we could not create any JoinConditions
+		// turn this into an arbitrary expression join
+		auto any_join = make_unique<LogicalAnyJoin>(type);
+		// create the condition
+		any_join->children.push_back(move(left_child));
+		any_join->children.push_back(move(right_child));
+		// AND all the arbitrary expressions together
+		// do the same with any remaining conditions
+		any_join->condition = move(arbitrary_expressions[0]);
+		for (idx_t i = 1; i < arbitrary_expressions.size(); i++) {
+			any_join->condition = make_unique<BoundConjunctionExpression>(
+			    ExpressionType::CONJUNCTION_AND, move(any_join->condition), move(arbitrary_expressions[i]));
+		}
+		return move(any_join);
+	} else {
+		// we successfully converted expressions into JoinConditions
+		// create a LogicalComparisonJoin
+		auto comp_join = make_unique<LogicalComparisonJoin>(type);
+		comp_join->conditions = move(conditions);
+		comp_join->children.push_back(move(left_child));
+		comp_join->children.push_back(move(right_child));
+		if (!arbitrary_expressions.empty()) {
+			// we have some arbitrary expressions as well
+			// add them to a filter
+			auto filter = make_unique<LogicalFilter>();
+			for (auto &expr : arbitrary_expressions) {
+				filter->expressions.push_back(move(expr));
+			}
+			LogicalFilter::SplitPredicates(filter->expressions);
+			filter->children.push_back(move(comp_join));
+			return move(filter);
+		}
+		return move(comp_join);
+	}
+}
+
+static bool HasCorrelatedColumns(Expression &expression) {
+	if (expression.type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &colref = (BoundColumnRefExpression &)expression;
+		if (colref.depth > 0) {
+			return true;
+		}
+	}
+	bool has_correlated_columns = false;
+	ExpressionIterator::EnumerateChildren(expression, [&](Expression &child) {
+		if (HasCorrelatedColumns(child)) {
+			has_correlated_columns = true;
+		}
+	});
+	return has_correlated_columns;
+}
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundJoinRef &ref) {
+	auto left = CreatePlan(*ref.left);
+	auto right = CreatePlan(*ref.right);
+	if (ref.type == JoinType::RIGHT && ClientConfig::GetConfig(context).enable_optimizer) {
+		// we turn any right outer joins into left outer joins for optimization purposes
+		// they are the same but with sides flipped, so treating them the same simplifies life
+		ref.type = JoinType::LEFT;
+		std::swap(left, right);
+	}
+	if (ref.type == JoinType::INNER && (ref.condition->HasSubquery() || HasCorrelatedColumns(*ref.condition))) {
+		// inner join, generate a cross product + filter
+		// this will be later turned into a proper join by the join order optimizer
+		auto cross_product = make_unique<LogicalCrossProduct>();
+
+		cross_product->AddChild(move(left));
+		cross_product->AddChild(move(right));
+
+		unique_ptr<LogicalOperator> root = move(cross_product);
+
+		auto filter = make_unique<LogicalFilter>(move(ref.condition));
+		// visit the expressions in the filter
+		for (auto &expression : filter->expressions) {
+			PlanSubqueries(&expression, &root);
+		}
+		filter->AddChild(move(root));
+		return move(filter);
+	}
+
+	// split the expressions by the AND clause
+	vector<unique_ptr<Expression>> expressions;
+	expressions.push_back(move(ref.condition));
+	LogicalFilter::SplitPredicates(expressions);
+
+	// find the table bindings on the LHS and RHS of the join
+	unordered_set<idx_t> left_bindings, right_bindings;
+	LogicalJoin::GetTableReferences(*left, left_bindings);
+	LogicalJoin::GetTableReferences(*right, right_bindings);
+	// now create the join operator from the set of join conditions
+	auto result = LogicalComparisonJoin::CreateJoin(ref.type, move(left), move(right), left_bindings, right_bindings,
+	                                                expressions);
+
+	LogicalOperator *join;
+	if (result->type == LogicalOperatorType::LOGICAL_FILTER) {
+		join = result->children[0].get();
+	} else {
+		join = result.get();
+	}
+	for (auto &child : join->children) {
+		if (child->type == LogicalOperatorType::LOGICAL_FILTER) {
+			auto &filter = (LogicalFilter &)*child;
+			for (auto &expr : filter.expressions) {
+				PlanSubqueries(&expr, &filter.children[0]);
+			}
+		}
+	}
+
+	// we visit the expressions depending on the type of join
+	if (join->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+		// comparison join
+		// in this join we visit the expressions on the LHS with the LHS as root node
+		// and the expressions on the RHS with the RHS as root node
+		auto &comp_join = (LogicalComparisonJoin &)*join;
+		for (idx_t i = 0; i < comp_join.conditions.size(); i++) {
+			PlanSubqueries(&comp_join.conditions[i].left, &comp_join.children[0]);
+			PlanSubqueries(&comp_join.conditions[i].right, &comp_join.children[1]);
+		}
+	} else if (join->type == LogicalOperatorType::LOGICAL_ANY_JOIN) {
+		auto &any_join = (LogicalAnyJoin &)*join;
+		// for the any join we just visit the condition
+		if (any_join.condition->HasSubquery()) {
+			throw NotImplementedException("Cannot perform non-inner join on subquery!");
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundSubqueryRef &ref) {
+	// generate the logical plan for the subquery
+	// this happens separately from the current LogicalPlan generation
+	ref.binder->plan_subquery = plan_subquery;
+	auto subquery = ref.binder->CreatePlan(*ref.subquery);
+	if (ref.binder->has_unplanned_subqueries) {
+		has_unplanned_subqueries = true;
+	}
+	return subquery;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundTableFunction &ref) {
+	return move(ref.get);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+
+
+
+namespace duckdb {
+
+shared_ptr<Binder> Binder::CreateBinder(ClientContext &context, Binder *parent, bool inherit_ctes) {
+	return make_shared<Binder>(true, context, parent ? parent->shared_from_this() : nullptr, inherit_ctes);
+}
+
+Binder::Binder(bool, ClientContext &context, shared_ptr<Binder> parent_p, bool inherit_ctes_p)
+    : context(context), parent(move(parent_p)), bound_tables(0), inherit_ctes(inherit_ctes_p) {
+	parameters = nullptr;
+	parameter_types = nullptr;
+	if (parent) {
+		// We have to inherit macro parameter bindings from the parent binder, if there is a parent.
+		macro_binding = parent->macro_binding;
+		if (inherit_ctes) {
+			// We have to inherit CTE bindings from the parent bind_context, if there is a parent.
+			bind_context.SetCTEBindings(parent->bind_context.GetCTEBindings());
+			bind_context.cte_references = parent->bind_context.cte_references;
+			parameters = parent->parameters;
+			parameter_types = parent->parameter_types;
+		}
+	}
+}
+
+BoundStatement Binder::Bind(SQLStatement &statement) {
+	root_statement = &statement;
+	switch (statement.type) {
+	case StatementType::SELECT_STATEMENT:
+		return Bind((SelectStatement &)statement);
+	case StatementType::INSERT_STATEMENT:
+		return Bind((InsertStatement &)statement);
+	case StatementType::COPY_STATEMENT:
+		return Bind((CopyStatement &)statement);
+	case StatementType::DELETE_STATEMENT:
+		return Bind((DeleteStatement &)statement);
+	case StatementType::UPDATE_STATEMENT:
+		return Bind((UpdateStatement &)statement);
+	case StatementType::RELATION_STATEMENT:
+		return Bind((RelationStatement &)statement);
+	case StatementType::CREATE_STATEMENT:
+		return Bind((CreateStatement &)statement);
+	case StatementType::DROP_STATEMENT:
+		return Bind((DropStatement &)statement);
+	case StatementType::ALTER_STATEMENT:
+		return Bind((AlterStatement &)statement);
+	case StatementType::TRANSACTION_STATEMENT:
+		return Bind((TransactionStatement &)statement);
+	case StatementType::PRAGMA_STATEMENT:
+		return Bind((PragmaStatement &)statement);
+	case StatementType::EXPLAIN_STATEMENT:
+		return Bind((ExplainStatement &)statement);
+	case StatementType::VACUUM_STATEMENT:
+		return Bind((VacuumStatement &)statement);
+	case StatementType::SHOW_STATEMENT:
+		return Bind((ShowStatement &)statement);
+	case StatementType::CALL_STATEMENT:
+		return Bind((CallStatement &)statement);
+	case StatementType::EXPORT_STATEMENT:
+		return Bind((ExportStatement &)statement);
+	case StatementType::SET_STATEMENT:
+		return Bind((SetStatement &)statement);
+	case StatementType::LOAD_STATEMENT:
+		return Bind((LoadStatement &)statement);
+	default: // LCOV_EXCL_START
+		throw NotImplementedException("Unimplemented statement type \"%s\" for Bind",
+		                              StatementTypeToString(statement.type));
+	} // LCOV_EXCL_STOP
+}
+
+unique_ptr<BoundQueryNode> Binder::BindNode(QueryNode &node) {
+	// first we visit the set of CTEs and add them to the bind context
+	for (auto &cte_it : node.cte_map) {
+		AddCTE(cte_it.first, cte_it.second.get());
+	}
+	// now we bind the node
+	unique_ptr<BoundQueryNode> result;
+	switch (node.type) {
+	case QueryNodeType::SELECT_NODE:
+		result = BindNode((SelectNode &)node);
+		break;
+	case QueryNodeType::RECURSIVE_CTE_NODE:
+		result = BindNode((RecursiveCTENode &)node);
+		break;
+	default:
+		D_ASSERT(node.type == QueryNodeType::SET_OPERATION_NODE);
+		result = BindNode((SetOperationNode &)node);
+		break;
+	}
+	return result;
+}
+
+BoundStatement Binder::Bind(QueryNode &node) {
+	auto bound_node = BindNode(node);
+
+	BoundStatement result;
+	result.names = bound_node->names;
+	result.types = bound_node->types;
+
+	// and plan it
+	result.plan = CreatePlan(*bound_node);
+	return result;
+}
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundQueryNode &node) {
+	switch (node.type) {
+	case QueryNodeType::SELECT_NODE:
+		return CreatePlan((BoundSelectNode &)node);
+	case QueryNodeType::SET_OPERATION_NODE:
+		return CreatePlan((BoundSetOperationNode &)node);
+	case QueryNodeType::RECURSIVE_CTE_NODE:
+		return CreatePlan((BoundRecursiveCTENode &)node);
+	default:
+		throw InternalException("Unsupported bound query node type");
+	}
+}
+
+unique_ptr<BoundTableRef> Binder::Bind(TableRef &ref) {
+	unique_ptr<BoundTableRef> result;
+	switch (ref.type) {
+	case TableReferenceType::BASE_TABLE:
+		result = Bind((BaseTableRef &)ref);
+		break;
+	case TableReferenceType::CROSS_PRODUCT:
+		result = Bind((CrossProductRef &)ref);
+		break;
+	case TableReferenceType::JOIN:
+		result = Bind((JoinRef &)ref);
+		break;
+	case TableReferenceType::SUBQUERY:
+		result = Bind((SubqueryRef &)ref);
+		break;
+	case TableReferenceType::EMPTY:
+		result = Bind((EmptyTableRef &)ref);
+		break;
+	case TableReferenceType::TABLE_FUNCTION:
+		result = Bind((TableFunctionRef &)ref);
+		break;
+	case TableReferenceType::EXPRESSION_LIST:
+		result = Bind((ExpressionListRef &)ref);
+		break;
+	default:
+		throw InternalException("Unknown table ref type");
+	}
+	result->sample = move(ref.sample);
+	return result;
+}
+
+unique_ptr<LogicalOperator> Binder::CreatePlan(BoundTableRef &ref) {
+	unique_ptr<LogicalOperator> root;
+	switch (ref.type) {
+	case TableReferenceType::BASE_TABLE:
+		root = CreatePlan((BoundBaseTableRef &)ref);
+		break;
+	case TableReferenceType::SUBQUERY:
+		root = CreatePlan((BoundSubqueryRef &)ref);
+		break;
+	case TableReferenceType::JOIN:
+		root = CreatePlan((BoundJoinRef &)ref);
+		break;
+	case TableReferenceType::CROSS_PRODUCT:
+		root = CreatePlan((BoundCrossProductRef &)ref);
+		break;
+	case TableReferenceType::TABLE_FUNCTION:
+		root = CreatePlan((BoundTableFunction &)ref);
+		break;
+	case TableReferenceType::EMPTY:
+		root = CreatePlan((BoundEmptyTableRef &)ref);
+		break;
+	case TableReferenceType::EXPRESSION_LIST:
+		root = CreatePlan((BoundExpressionListRef &)ref);
+		break;
+	case TableReferenceType::CTE:
+		root = CreatePlan((BoundCTERef &)ref);
+		break;
+	default:
+		throw InternalException("Unsupported bound table ref type type");
+	}
+	// plan the sample clause
+	if (ref.sample) {
+		root = make_unique<LogicalSample>(move(ref.sample), move(root));
+	}
+	return root;
+}
+
+void Binder::AddCTE(const string &name, CommonTableExpressionInfo *info) {
+	D_ASSERT(info);
+	D_ASSERT(!name.empty());
+	auto entry = CTE_bindings.find(name);
+	if (entry != CTE_bindings.end()) {
+		throw InternalException("Duplicate CTE \"%s\" in query!", name);
+	}
+	CTE_bindings[name] = info;
+}
+
+CommonTableExpressionInfo *Binder::FindCTE(const string &name, bool skip) {
+	auto entry = CTE_bindings.find(name);
+	if (entry != CTE_bindings.end()) {
+		if (!skip || entry->second->query->node->type == QueryNodeType::RECURSIVE_CTE_NODE) {
+			return entry->second;
+		}
+	}
+	if (parent && inherit_ctes) {
+		return parent->FindCTE(name, name == alias);
+	}
+	return nullptr;
+}
+
+bool Binder::CTEIsAlreadyBound(CommonTableExpressionInfo *cte) {
+	if (bound_ctes.find(cte) != bound_ctes.end()) {
+		return true;
+	}
+	if (parent && inherit_ctes) {
+		return parent->CTEIsAlreadyBound(cte);
+	}
+	return false;
+}
+
+void Binder::AddBoundView(ViewCatalogEntry *view) {
+	// check if the view is already bound
+	auto current = this;
+	while (current) {
+		if (current->bound_views.find(view) != current->bound_views.end()) {
+			throw BinderException("infinite recursion detected: attempting to recursively bind view \"%s\"",
+			                      view->name);
+		}
+		current = current->parent.get();
+	}
+	bound_views.insert(view);
+}
+
+idx_t Binder::GenerateTableIndex() {
+	if (parent) {
+		return parent->GenerateTableIndex();
+	}
+	return bound_tables++;
+}
+
+void Binder::PushExpressionBinder(ExpressionBinder *binder) {
+	GetActiveBinders().push_back(binder);
+}
+
+void Binder::PopExpressionBinder() {
+	D_ASSERT(HasActiveBinder());
+	GetActiveBinders().pop_back();
+}
+
+void Binder::SetActiveBinder(ExpressionBinder *binder) {
+	D_ASSERT(HasActiveBinder());
+	GetActiveBinders().back() = binder;
+}
+
+ExpressionBinder *Binder::GetActiveBinder() {
+	return GetActiveBinders().back();
+}
+
+bool Binder::HasActiveBinder() {
+	return !GetActiveBinders().empty();
+}
+
+vector<ExpressionBinder *> &Binder::GetActiveBinders() {
+	if (parent) {
+		return parent->GetActiveBinders();
+	}
+	return active_binders;
+}
+
+void Binder::AddUsingBindingSet(unique_ptr<UsingColumnSet> set) {
+	if (parent) {
+		parent->AddUsingBindingSet(move(set));
+		return;
+	}
+	bind_context.AddUsingBindingSet(move(set));
+}
+
+void Binder::MoveCorrelatedExpressions(Binder &other) {
+	MergeCorrelatedColumns(other.correlated_columns);
+	other.correlated_columns.clear();
+}
+
+void Binder::MergeCorrelatedColumns(vector<CorrelatedColumnInfo> &other) {
+	for (idx_t i = 0; i < other.size(); i++) {
+		AddCorrelatedColumn(other[i]);
+	}
+}
+
+void Binder::AddCorrelatedColumn(const CorrelatedColumnInfo &info) {
+	// we only add correlated columns to the list if they are not already there
+	if (std::find(correlated_columns.begin(), correlated_columns.end(), info) == correlated_columns.end()) {
+		correlated_columns.push_back(info);
+	}
+}
+
+bool Binder::HasMatchingBinding(const string &table_name, const string &column_name, string &error_message) {
+	string empty_schema;
+	return HasMatchingBinding(empty_schema, table_name, column_name, error_message);
+}
+
+bool Binder::HasMatchingBinding(const string &schema_name, const string &table_name, const string &column_name,
+                                string &error_message) {
+	Binding *binding;
+	if (macro_binding && table_name == macro_binding->alias) {
+		binding = macro_binding;
+	} else {
+		binding = bind_context.GetBinding(table_name, error_message);
+	}
+	if (!binding) {
+		return false;
+	}
+	if (!schema_name.empty()) {
+		auto catalog_entry = binding->GetStandardEntry();
+		if (!catalog_entry) {
+			return false;
+		}
+		if (catalog_entry->schema->name != schema_name || catalog_entry->name != table_name) {
+			return false;
+		}
+	}
+	bool binding_found;
+	binding_found = binding->HasMatchingBinding(column_name);
+	if (!binding_found) {
+		error_message = binding->ColumnNotFoundError(column_name);
+	}
+	return binding_found;
+}
+
+void Binder::SetBindingMode(BindingMode mode) {
+	if (parent) {
+		parent->SetBindingMode(mode);
+	}
+	this->mode = mode;
+}
+
+BindingMode Binder::GetBindingMode() {
+	if (parent) {
+		return parent->GetBindingMode();
+	}
+	return mode;
+}
+
+void Binder::AddTableName(string table_name) {
+	if (parent) {
+		parent->AddTableName(move(table_name));
+		return;
+	}
+	table_names.insert(move(table_name));
+}
+
+const unordered_set<string> &Binder::GetTableNames() {
+	if (parent) {
+		return parent->GetTableNames();
+	}
+	return table_names;
+}
+
+string Binder::FormatError(ParsedExpression &expr_context, const string &message) {
+	return FormatError(expr_context.query_location, message);
+}
+
+string Binder::FormatError(TableRef &ref_context, const string &message) {
+	return FormatError(ref_context.query_location, message);
+}
+
+string Binder::FormatErrorRecursive(idx_t query_location, const string &message, vector<ExceptionFormatValue> &values) {
+	QueryErrorContext context(root_statement, query_location);
+	return context.FormatErrorRecursive(message, values);
+}
+
+BoundStatement Binder::BindReturning(vector<unique_ptr<ParsedExpression>> returning_list, TableCatalogEntry *table,
+                                     idx_t update_table_index, unique_ptr<LogicalOperator> child_operator,
+                                     BoundStatement result) {
+
+	vector<LogicalType> types;
+	vector<std::string> names;
+
+	auto binder = Binder::CreateBinder(context);
+
+	for (auto &col : table->columns) {
+		names.push_back(col.Name());
+		types.push_back(col.Type());
+	}
+
+	binder->bind_context.AddGenericBinding(update_table_index, table->name, names, types);
+	ReturningBinder returning_binder(*binder, context);
+
+	vector<unique_ptr<Expression>> projection_expressions;
+	LogicalType result_type;
+	for (auto &returning_expr : returning_list) {
+		auto expr_type = returning_expr->GetExpressionType();
+		if (expr_type == ExpressionType::STAR) {
+			auto generated_star_list = vector<unique_ptr<ParsedExpression>>();
+			binder->bind_context.GenerateAllColumnExpressions((StarExpression &)*returning_expr, generated_star_list);
+
+			for (auto &star_column : generated_star_list) {
+				auto star_expr = returning_binder.Bind(star_column, &result_type);
+				result.types.push_back(result_type);
+				result.names.push_back(star_expr->GetName());
+				projection_expressions.push_back(move(star_expr));
+			}
+		} else {
+			auto expr = returning_binder.Bind(returning_expr, &result_type);
+			result.names.push_back(expr->GetName());
+			result.types.push_back(result_type);
+			projection_expressions.push_back(move(expr));
+		}
+	}
+
+	auto projection = make_unique<LogicalProjection>(GenerateTableIndex(), move(projection_expressions));
+	projection->AddChild(move(child_operator));
+	D_ASSERT(result.types.size() == result.names.size());
+	result.plan = move(projection);
+	properties.allow_stream_result = true;
+	properties.return_type = StatementReturnType::QUERY_RESULT;
+	return result;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+BoundResultModifier::BoundResultModifier(ResultModifierType type) : type(type) {
+}
+
+BoundResultModifier::~BoundResultModifier() {
+}
+
+BoundOrderByNode::BoundOrderByNode(OrderType type, OrderByNullType null_order, unique_ptr<Expression> expression)
+    : type(type), null_order(null_order), expression(move(expression)) {
+}
+BoundOrderByNode::BoundOrderByNode(OrderType type, OrderByNullType null_order, unique_ptr<Expression> expression,
+                                   unique_ptr<BaseStatistics> stats)
+    : type(type), null_order(null_order), expression(move(expression)), stats(move(stats)) {
+}
+
+BoundOrderByNode BoundOrderByNode::Copy() const {
+	if (stats) {
+		return BoundOrderByNode(type, null_order, expression->Copy(), stats->Copy());
+	} else {
+		return BoundOrderByNode(type, null_order, expression->Copy());
+	}
+}
+
+string BoundOrderByNode::ToString() const {
+	auto str = expression->ToString();
+	switch (type) {
+	case OrderType::ASCENDING:
+		str += " ASC";
+		break;
+	case OrderType::DESCENDING:
+		str += " DESC";
+		break;
+	default:
+		break;
+	}
+
+	switch (null_order) {
+	case OrderByNullType::NULLS_FIRST:
+		str += " NULLS FIRST";
+		break;
+	case OrderByNullType::NULLS_LAST:
+		str += " NULLS LAST";
+		break;
+	default:
+		break;
+	}
+	return str;
+}
+
+BoundLimitModifier::BoundLimitModifier() : BoundResultModifier(ResultModifierType::LIMIT_MODIFIER) {
+}
+
+BoundOrderModifier::BoundOrderModifier() : BoundResultModifier(ResultModifierType::ORDER_MODIFIER) {
+}
+
+BoundDistinctModifier::BoundDistinctModifier() : BoundResultModifier(ResultModifierType::DISTINCT_MODIFIER) {
+}
+
+BoundLimitPercentModifier::BoundLimitPercentModifier()
+    : BoundResultModifier(ResultModifierType::LIMIT_PERCENT_MODIFIER) {
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+BoundAggregateExpression::BoundAggregateExpression(AggregateFunction function, vector<unique_ptr<Expression>> children,
+                                                   unique_ptr<Expression> filter, unique_ptr<FunctionData> bind_info,
+                                                   bool distinct)
+    : Expression(ExpressionType::BOUND_AGGREGATE, ExpressionClass::BOUND_AGGREGATE, function.return_type),
+      function(move(function)), children(move(children)), bind_info(move(bind_info)), distinct(distinct),
+      filter(move(filter)) {
+	D_ASSERT(!function.name.empty());
+}
+
+string BoundAggregateExpression::ToString() const {
+	return FunctionExpression::ToString<BoundAggregateExpression, Expression>(*this, string(), function.name, false,
+	                                                                          distinct, filter.get());
+}
+
+hash_t BoundAggregateExpression::Hash() const {
+	hash_t result = Expression::Hash();
+	result = CombineHash(result, function.Hash());
+	result = CombineHash(result, duckdb::Hash(distinct));
+	return result;
+}
+
+bool BoundAggregateExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundAggregateExpression *)other_p;
+	if (other->distinct != distinct) {
+		return false;
+	}
+	if (other->function != function) {
+		return false;
+	}
+	if (children.size() != other->children.size()) {
+		return false;
+	}
+	if (!Expression::Equals(other->filter.get(), filter.get())) {
+		return false;
+	}
+	for (idx_t i = 0; i < children.size(); i++) {
+		if (!Expression::Equals(children[i].get(), other->children[i].get())) {
+			return false;
+		}
+	}
+	if (!FunctionData::Equals(bind_info.get(), other->bind_info.get())) {
+		return false;
+	}
+	return true;
+}
+
+bool BoundAggregateExpression::PropagatesNullValues() const {
+	return !function.propagates_null_values ? false : Expression::PropagatesNullValues();
+}
+
+unique_ptr<Expression> BoundAggregateExpression::Copy() {
+	vector<unique_ptr<Expression>> new_children;
+	for (auto &child : children) {
+		new_children.push_back(child->Copy());
+	}
+	auto new_bind_info = bind_info ? bind_info->Copy() : nullptr;
+	auto new_filter = filter ? filter->Copy() : nullptr;
+	auto copy = make_unique<BoundAggregateExpression>(function, move(new_children), move(new_filter),
+	                                                  move(new_bind_info), distinct);
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+BoundBetweenExpression::BoundBetweenExpression(unique_ptr<Expression> input, unique_ptr<Expression> lower,
+                                               unique_ptr<Expression> upper, bool lower_inclusive, bool upper_inclusive)
+    : Expression(ExpressionType::COMPARE_BETWEEN, ExpressionClass::BOUND_BETWEEN, LogicalType::BOOLEAN),
+      input(move(input)), lower(move(lower)), upper(move(upper)), lower_inclusive(lower_inclusive),
+      upper_inclusive(upper_inclusive) {
+}
+
+string BoundBetweenExpression::ToString() const {
+	return BetweenExpression::ToString<BoundBetweenExpression, Expression>(*this);
+}
+
+bool BoundBetweenExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundBetweenExpression *)other_p;
+	if (!Expression::Equals(input.get(), other->input.get())) {
+		return false;
+	}
+	if (!Expression::Equals(lower.get(), other->lower.get())) {
+		return false;
+	}
+	if (!Expression::Equals(upper.get(), other->upper.get())) {
+		return false;
+	}
+	return lower_inclusive == other->lower_inclusive && upper_inclusive == other->upper_inclusive;
+}
+
+unique_ptr<Expression> BoundBetweenExpression::Copy() {
+	auto copy = make_unique<BoundBetweenExpression>(input->Copy(), lower->Copy(), upper->Copy(), lower_inclusive,
+	                                                upper_inclusive);
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+BoundCaseExpression::BoundCaseExpression(LogicalType type)
+    : Expression(ExpressionType::CASE_EXPR, ExpressionClass::BOUND_CASE, move(type)) {
+}
+
+BoundCaseExpression::BoundCaseExpression(unique_ptr<Expression> when_expr, unique_ptr<Expression> then_expr,
+                                         unique_ptr<Expression> else_expr_p)
+    : Expression(ExpressionType::CASE_EXPR, ExpressionClass::BOUND_CASE, then_expr->return_type),
+      else_expr(move(else_expr_p)) {
+	BoundCaseCheck check;
+	check.when_expr = move(when_expr);
+	check.then_expr = move(then_expr);
+	case_checks.push_back(move(check));
+}
+
+string BoundCaseExpression::ToString() const {
+	return CaseExpression::ToString<BoundCaseExpression, Expression>(*this);
+}
+
+bool BoundCaseExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto &other = (BoundCaseExpression &)*other_p;
+	if (case_checks.size() != other.case_checks.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < case_checks.size(); i++) {
+		if (!Expression::Equals(case_checks[i].when_expr.get(), other.case_checks[i].when_expr.get())) {
+			return false;
+		}
+		if (!Expression::Equals(case_checks[i].then_expr.get(), other.case_checks[i].then_expr.get())) {
+			return false;
+		}
+	}
+	if (!Expression::Equals(else_expr.get(), other.else_expr.get())) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<Expression> BoundCaseExpression::Copy() {
+	auto new_case = make_unique<BoundCaseExpression>(return_type);
+	for (auto &check : case_checks) {
+		BoundCaseCheck new_check;
+		new_check.when_expr = check.when_expr->Copy();
+		new_check.then_expr = check.then_expr->Copy();
+		new_case->case_checks.push_back(move(new_check));
+	}
+	new_case->else_expr = else_expr->Copy();
+
+	new_case->CopyProperties(*this);
+	return move(new_case);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+BoundCastExpression::BoundCastExpression(unique_ptr<Expression> child_p, LogicalType target_type_p, bool try_cast_p)
+    : Expression(ExpressionType::OPERATOR_CAST, ExpressionClass::BOUND_CAST, move(target_type_p)), child(move(child_p)),
+      try_cast(try_cast_p) {
+}
+
+unique_ptr<Expression> BoundCastExpression::AddCastToType(unique_ptr<Expression> expr, const LogicalType &target_type,
+                                                          bool try_cast) {
+	D_ASSERT(expr);
+	if (expr->expression_class == ExpressionClass::BOUND_PARAMETER) {
+		auto &parameter = (BoundParameterExpression &)*expr;
+		parameter.return_type = target_type;
+	} else if (expr->expression_class == ExpressionClass::BOUND_DEFAULT) {
+		auto &def = (BoundDefaultExpression &)*expr;
+		def.return_type = target_type;
+	} else if (expr->return_type != target_type) {
+		auto &expr_type = expr->return_type;
+		if (target_type.id() == LogicalTypeId::LIST && expr_type.id() == LogicalTypeId::LIST) {
+			auto &target_list = ListType::GetChildType(target_type);
+			auto &expr_list = ListType::GetChildType(expr_type);
+			if (target_list.id() == LogicalTypeId::ANY || expr_list == target_list) {
+				return expr;
+			}
+		}
+		return make_unique<BoundCastExpression>(move(expr), target_type, try_cast);
+	}
+	return expr;
+}
+
+bool BoundCastExpression::CastIsInvertible(const LogicalType &source_type, const LogicalType &target_type) {
+	if (source_type.id() == LogicalTypeId::BOOLEAN || target_type.id() == LogicalTypeId::BOOLEAN) {
+		return false;
+	}
+	if (source_type.id() == LogicalTypeId::FLOAT || target_type.id() == LogicalTypeId::FLOAT) {
+		return false;
+	}
+	if (source_type.id() == LogicalTypeId::DOUBLE || target_type.id() == LogicalTypeId::DOUBLE) {
+		return false;
+	}
+	if (source_type.id() == LogicalTypeId::DECIMAL || target_type.id() == LogicalTypeId::DECIMAL) {
+		uint8_t source_width, target_width;
+		uint8_t source_scale, target_scale;
+		// cast to or from decimal
+		// cast is only invertible if the cast is strictly widening
+		if (!source_type.GetDecimalProperties(source_width, source_scale)) {
+			return false;
+		}
+		if (!target_type.GetDecimalProperties(target_width, target_scale)) {
+			return false;
+		}
+		if (target_scale < source_scale) {
+			return false;
+		}
+		return true;
+	}
+	if (source_type.id() == LogicalTypeId::TIMESTAMP || source_type.id() == LogicalTypeId::TIMESTAMP_TZ) {
+		switch (target_type.id()) {
+		case LogicalTypeId::DATE:
+		case LogicalTypeId::TIME:
+		case LogicalTypeId::TIME_TZ:
+			return false;
+		default:
+			break;
+		}
+	}
+	if (source_type.id() == LogicalTypeId::VARCHAR) {
+		switch (target_type.id()) {
+		case LogicalTypeId::DATE:
+		case LogicalTypeId::TIME:
+		case LogicalTypeId::TIMESTAMP:
+		case LogicalTypeId::TIMESTAMP_NS:
+		case LogicalTypeId::TIMESTAMP_MS:
+		case LogicalTypeId::TIMESTAMP_SEC:
+		case LogicalTypeId::TIME_TZ:
+		case LogicalTypeId::TIMESTAMP_TZ:
+			return true;
+		default:
+			return false;
+		}
+	}
+	if (target_type.id() == LogicalTypeId::VARCHAR) {
+		switch (source_type.id()) {
+		case LogicalTypeId::DATE:
+		case LogicalTypeId::TIME:
+		case LogicalTypeId::TIMESTAMP:
+		case LogicalTypeId::TIMESTAMP_NS:
+		case LogicalTypeId::TIMESTAMP_MS:
+		case LogicalTypeId::TIMESTAMP_SEC:
+		case LogicalTypeId::TIME_TZ:
+		case LogicalTypeId::TIMESTAMP_TZ:
+			return true;
+		default:
+			return false;
+		}
+	}
+	return true;
+}
+
+string BoundCastExpression::ToString() const {
+	return (try_cast ? "TRY_CAST(" : "CAST(") + child->GetName() + " AS " + return_type.ToString() + ")";
+}
+
+bool BoundCastExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundCastExpression *)other_p;
+	if (!Expression::Equals(child.get(), other->child.get())) {
+		return false;
+	}
+	if (try_cast != other->try_cast) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<Expression> BoundCastExpression::Copy() {
+	auto copy = make_unique<BoundCastExpression>(child->Copy(), return_type, try_cast);
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+BoundColumnRefExpression::BoundColumnRefExpression(string alias_p, LogicalType type, ColumnBinding binding, idx_t depth)
+    : Expression(ExpressionType::BOUND_COLUMN_REF, ExpressionClass::BOUND_COLUMN_REF, move(type)), binding(binding),
+      depth(depth) {
+	this->alias = move(alias_p);
+}
+
+BoundColumnRefExpression::BoundColumnRefExpression(LogicalType type, ColumnBinding binding, idx_t depth)
+    : BoundColumnRefExpression(string(), move(type), binding, depth) {
+}
+
+unique_ptr<Expression> BoundColumnRefExpression::Copy() {
+	return make_unique<BoundColumnRefExpression>(alias, return_type, binding, depth);
+}
+
+hash_t BoundColumnRefExpression::Hash() const {
+	auto result = Expression::Hash();
+	result = CombineHash(result, duckdb::Hash<uint64_t>(binding.column_index));
+	result = CombineHash(result, duckdb::Hash<uint64_t>(binding.table_index));
+	return CombineHash(result, duckdb::Hash<uint64_t>(depth));
+}
+
+bool BoundColumnRefExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundColumnRefExpression *)other_p;
+	return other->binding == binding && other->depth == depth;
+}
+
+string BoundColumnRefExpression::ToString() const {
+	if (!alias.empty()) {
+		return alias;
+	}
+	return "#[" + to_string(binding.table_index) + "." + to_string(binding.column_index) + "]";
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+BoundComparisonExpression::BoundComparisonExpression(ExpressionType type, unique_ptr<Expression> left,
+                                                     unique_ptr<Expression> right)
+    : Expression(type, ExpressionClass::BOUND_COMPARISON, LogicalType::BOOLEAN), left(move(left)), right(move(right)) {
+}
+
+string BoundComparisonExpression::ToString() const {
+	return ComparisonExpression::ToString<BoundComparisonExpression, Expression>(*this);
+}
+
+bool BoundComparisonExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundComparisonExpression *)other_p;
+	if (!Expression::Equals(left.get(), other->left.get())) {
+		return false;
+	}
+	if (!Expression::Equals(right.get(), other->right.get())) {
+		return false;
+	}
+
+	return true;
+}
+
+unique_ptr<Expression> BoundComparisonExpression::Copy() {
+	auto copy = make_unique<BoundComparisonExpression>(type, left->Copy(), right->Copy());
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+BoundConjunctionExpression::BoundConjunctionExpression(ExpressionType type)
+    : Expression(type, ExpressionClass::BOUND_CONJUNCTION, LogicalType::BOOLEAN) {
+}
+
+BoundConjunctionExpression::BoundConjunctionExpression(ExpressionType type, unique_ptr<Expression> left,
+                                                       unique_ptr<Expression> right)
+    : BoundConjunctionExpression(type) {
+	children.push_back(move(left));
+	children.push_back(move(right));
+}
+
+string BoundConjunctionExpression::ToString() const {
+	return ConjunctionExpression::ToString<BoundConjunctionExpression, Expression>(*this);
+}
+
+bool BoundConjunctionExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundConjunctionExpression *)other_p;
+	return ExpressionUtil::SetEquals(children, other->children);
+}
+
+bool BoundConjunctionExpression::PropagatesNullValues() const {
+	return false;
+}
+
+unique_ptr<Expression> BoundConjunctionExpression::Copy() {
+	auto copy = make_unique<BoundConjunctionExpression>(type);
+	for (auto &expr : children) {
+		copy->children.push_back(expr->Copy());
+	}
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+BoundConstantExpression::BoundConstantExpression(Value value_p)
+    : Expression(ExpressionType::VALUE_CONSTANT, ExpressionClass::BOUND_CONSTANT, value_p.type()),
+      value(move(value_p)) {
+}
+
+string BoundConstantExpression::ToString() const {
+	return value.ToSQLString();
+}
+
+bool BoundConstantExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundConstantExpression *)other_p;
+	return !ValueOperations::DistinctFrom(value, other->value);
+}
+
+hash_t BoundConstantExpression::Hash() const {
+	hash_t result = Expression::Hash();
+	return CombineHash(value.Hash(), result);
+}
+
+unique_ptr<Expression> BoundConstantExpression::Copy() {
+	auto copy = make_unique<BoundConstantExpression>(value);
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+BoundFunctionExpression::BoundFunctionExpression(LogicalType return_type, ScalarFunction bound_function,
+                                                 vector<unique_ptr<Expression>> arguments,
+                                                 unique_ptr<FunctionData> bind_info, bool is_operator)
+    : Expression(ExpressionType::BOUND_FUNCTION, ExpressionClass::BOUND_FUNCTION, move(return_type)),
+      function(move(bound_function)), children(move(arguments)), bind_info(move(bind_info)), is_operator(is_operator) {
+	D_ASSERT(!function.name.empty());
+}
+
+bool BoundFunctionExpression::HasSideEffects() const {
+	return function.has_side_effects ? true : Expression::HasSideEffects();
+}
+
+bool BoundFunctionExpression::IsFoldable() const {
+	// functions with side effects cannot be folded: they have to be executed once for every row
+	return function.has_side_effects ? false : Expression::IsFoldable();
+}
+
+string BoundFunctionExpression::ToString() const {
+	return FunctionExpression::ToString<BoundFunctionExpression, Expression>(*this, string(), function.name,
+	                                                                         is_operator);
+}
+bool BoundFunctionExpression::PropagatesNullValues() const {
+	return !function.propagates_null_values ? false : Expression::PropagatesNullValues();
+}
+
+hash_t BoundFunctionExpression::Hash() const {
+	hash_t result = Expression::Hash();
+	return CombineHash(result, function.Hash());
+}
+
+bool BoundFunctionExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundFunctionExpression *)other_p;
+	if (other->function != function) {
+		return false;
+	}
+	if (!ExpressionUtil::ListEquals(children, other->children)) {
+		return false;
+	}
+	if (!FunctionData::Equals(bind_info.get(), other->bind_info.get())) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<Expression> BoundFunctionExpression::Copy() {
+	vector<unique_ptr<Expression>> new_children;
+	for (auto &child : children) {
+		new_children.push_back(child->Copy());
+	}
+	unique_ptr<FunctionData> new_bind_info = bind_info ? bind_info->Copy() : nullptr;
+
+	auto copy = make_unique<BoundFunctionExpression>(return_type, function, move(new_children), move(new_bind_info),
+	                                                 is_operator);
+	copy->CopyProperties(*this);
+	return move(copy);
+}
+
+void BoundFunctionExpression::Verify() const {
+	D_ASSERT(!function.name.empty());
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+BoundOperatorExpression::BoundOperatorExpression(ExpressionType type, LogicalType return_type)
+    : Expression(type, ExpressionClass::BOUND_OPERATOR, move(return_type)) {
+}
+
+string BoundOperatorExpression::ToString() const {
+	return OperatorExpression::ToString<BoundOperatorExpression, Expression>(*this);
+}
+
+bool BoundOperatorExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundOperatorExpression *)other_p;
+	if (!ExpressionUtil::ListEquals(children, other->children)) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<Expression> BoundOperatorExpression::Copy() {
+	auto copy = make_unique<BoundOperatorExpression>(type, return_type);
+	copy->CopyProperties(*this);
+	for (auto &child : children) {
+		copy->children.push_back(child->Copy());
+	}
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+BoundParameterExpression::BoundParameterExpression(idx_t parameter_nr)
+    : Expression(ExpressionType::VALUE_PARAMETER, ExpressionClass::BOUND_PARAMETER,
+                 LogicalType(LogicalTypeId::UNKNOWN)),
+      parameter_nr(parameter_nr), value(nullptr) {
+}
+
+bool BoundParameterExpression::IsScalar() const {
+	return true;
+}
+bool BoundParameterExpression::HasParameter() const {
+	return true;
+}
+bool BoundParameterExpression::IsFoldable() const {
+	return false;
+}
+
+string BoundParameterExpression::ToString() const {
+	return to_string(parameter_nr);
+}
+
+bool BoundParameterExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundParameterExpression *)other_p;
+	return parameter_nr == other->parameter_nr;
+}
+
+hash_t BoundParameterExpression::Hash() const {
+	hash_t result = Expression::Hash();
+	result = CombineHash(duckdb::Hash(parameter_nr), result);
+	return result;
+}
+
+unique_ptr<Expression> BoundParameterExpression::Copy() {
+	auto result = make_unique<BoundParameterExpression>(parameter_nr);
+	result->value = value;
+	result->return_type = return_type;
+	result->CopyProperties(*this);
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+BoundReferenceExpression::BoundReferenceExpression(string alias, LogicalType type, idx_t index)
+    : Expression(ExpressionType::BOUND_REF, ExpressionClass::BOUND_REF, move(type)), index(index) {
+	this->alias = move(alias);
+}
+BoundReferenceExpression::BoundReferenceExpression(LogicalType type, idx_t index)
+    : BoundReferenceExpression(string(), move(type), index) {
+}
+
+string BoundReferenceExpression::ToString() const {
+	if (!alias.empty()) {
+		return alias;
+	}
+	return "#" + to_string(index);
+}
+
+bool BoundReferenceExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundReferenceExpression *)other_p;
+	return other->index == index;
+}
+
+hash_t BoundReferenceExpression::Hash() const {
+	return CombineHash(Expression::Hash(), duckdb::Hash<idx_t>(index));
+}
+
+unique_ptr<Expression> BoundReferenceExpression::Copy() {
+	return make_unique<BoundReferenceExpression>(alias, return_type, index);
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+BoundSubqueryExpression::BoundSubqueryExpression(LogicalType return_type)
+    : Expression(ExpressionType::SUBQUERY, ExpressionClass::BOUND_SUBQUERY, move(return_type)) {
+}
+
+string BoundSubqueryExpression::ToString() const {
+	return "SUBQUERY";
+}
+
+bool BoundSubqueryExpression::Equals(const BaseExpression *other_p) const {
+	// equality between bound subqueries not implemented currently
+	return false;
+}
+
+unique_ptr<Expression> BoundSubqueryExpression::Copy() {
+	throw SerializationException("Cannot copy BoundSubqueryExpression");
+}
+
+bool BoundSubqueryExpression::PropagatesNullValues() const {
+	// TODO this can be optimized further by checking the actual subquery node
+	return false;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+BoundUnnestExpression::BoundUnnestExpression(LogicalType return_type)
+    : Expression(ExpressionType::BOUND_UNNEST, ExpressionClass::BOUND_UNNEST, move(return_type)) {
+}
+
+bool BoundUnnestExpression::IsFoldable() const {
+	return false;
+}
+
+string BoundUnnestExpression::ToString() const {
+	return "UNNEST(" + child->ToString() + ")";
+}
+
+hash_t BoundUnnestExpression::Hash() const {
+	hash_t result = Expression::Hash();
+	return CombineHash(result, duckdb::Hash("unnest"));
+}
+
+bool BoundUnnestExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundUnnestExpression *)other_p;
+	if (!Expression::Equals(child.get(), other->child.get())) {
+		return false;
+	}
+	return true;
+}
+
+unique_ptr<Expression> BoundUnnestExpression::Copy() {
+	auto copy = make_unique<BoundUnnestExpression>(return_type);
+	copy->child = child->Copy();
+	return move(copy);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+BoundWindowExpression::BoundWindowExpression(ExpressionType type, LogicalType return_type,
+                                             unique_ptr<AggregateFunction> aggregate,
+                                             unique_ptr<FunctionData> bind_info)
+    : Expression(type, ExpressionClass::BOUND_WINDOW, move(return_type)), aggregate(move(aggregate)),
+      bind_info(move(bind_info)), ignore_nulls(false) {
+}
+
+string BoundWindowExpression::ToString() const {
+	string function_name = aggregate.get() ? aggregate->name : ExpressionTypeToString(type);
+	return WindowExpression::ToString<BoundWindowExpression, Expression, BoundOrderByNode>(*this, string(),
+	                                                                                       function_name);
+}
+
+bool BoundWindowExpression::Equals(const BaseExpression *other_p) const {
+	if (!Expression::Equals(other_p)) {
+		return false;
+	}
+	auto other = (BoundWindowExpression *)other_p;
+
+	if (ignore_nulls != other->ignore_nulls) {
+		return false;
+	}
+	if (start != other->start || end != other->end) {
+		return false;
+	}
+	// check if the child expressions are equivalent
+	if (other->children.size() != children.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < children.size(); i++) {
+		if (!Expression::Equals(children[i].get(), other->children[i].get())) {
+			return false;
+		}
+	}
+	// check if the filter expressions are equivalent
+	if (!Expression::Equals(filter_expr.get(), other->filter_expr.get())) {
+		return false;
+	}
+
+	// check if the framing expressions are equivalent
+	if (!Expression::Equals(start_expr.get(), other->start_expr.get()) ||
+	    !Expression::Equals(end_expr.get(), other->end_expr.get()) ||
+	    !Expression::Equals(offset_expr.get(), other->offset_expr.get()) ||
+	    !Expression::Equals(default_expr.get(), other->default_expr.get())) {
+		return false;
+	}
+
+	return KeysAreCompatible(other);
+}
+
+bool BoundWindowExpression::KeysAreCompatible(const BoundWindowExpression *other) const {
+	// check if the partitions are equivalent
+	if (partitions.size() != other->partitions.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < partitions.size(); i++) {
+		if (!Expression::Equals(partitions[i].get(), other->partitions[i].get())) {
+			return false;
+		}
+	}
+	// check if the orderings are equivalent
+	if (orders.size() != other->orders.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < orders.size(); i++) {
+		if (orders[i].type != other->orders[i].type) {
+			return false;
+		}
+		if (!BaseExpression::Equals((BaseExpression *)orders[i].expression.get(),
+		                            (BaseExpression *)other->orders[i].expression.get())) {
+			return false;
+		}
+	}
+	return true;
+}
+
+unique_ptr<Expression> BoundWindowExpression::Copy() {
+	auto new_window = make_unique<BoundWindowExpression>(type, return_type, nullptr, nullptr);
+	new_window->CopyProperties(*this);
+
+	if (aggregate) {
+		new_window->aggregate = make_unique<AggregateFunction>(*aggregate);
+	}
+	if (bind_info) {
+		new_window->bind_info = bind_info->Copy();
+	}
+	for (auto &child : children) {
+		new_window->children.push_back(child->Copy());
+	}
+	for (auto &e : partitions) {
+		new_window->partitions.push_back(e->Copy());
+	}
+	for (auto &ps : partitions_stats) {
+		if (ps) {
+			new_window->partitions_stats.push_back(ps->Copy());
+		} else {
+			new_window->partitions_stats.push_back(nullptr);
+		}
+	}
+	for (auto &o : orders) {
+		new_window->orders.emplace_back(o.type, o.null_order, o.expression->Copy());
+	}
+
+	new_window->filter_expr = filter_expr ? filter_expr->Copy() : nullptr;
+
+	new_window->start = start;
+	new_window->end = end;
+	new_window->start_expr = start_expr ? start_expr->Copy() : nullptr;
+	new_window->end_expr = end_expr ? end_expr->Copy() : nullptr;
+	new_window->offset_expr = offset_expr ? offset_expr->Copy() : nullptr;
+	new_window->default_expr = default_expr ? default_expr->Copy() : nullptr;
+	new_window->ignore_nulls = ignore_nulls;
+
+	return move(new_window);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+Expression::Expression(ExpressionType type, ExpressionClass expression_class, LogicalType return_type)
+    : BaseExpression(type, expression_class), return_type(move(return_type)) {
+}
+
+Expression::~Expression() {
+}
+
+bool Expression::IsAggregate() const {
+	bool is_aggregate = false;
+	ExpressionIterator::EnumerateChildren(*this, [&](const Expression &child) { is_aggregate |= child.IsAggregate(); });
+	return is_aggregate;
+}
+
+bool Expression::IsWindow() const {
+	bool is_window = false;
+	ExpressionIterator::EnumerateChildren(*this, [&](const Expression &child) { is_window |= child.IsWindow(); });
+	return is_window;
+}
+
+bool Expression::IsScalar() const {
+	bool is_scalar = true;
+	ExpressionIterator::EnumerateChildren(*this, [&](const Expression &child) {
+		if (!child.IsScalar()) {
+			is_scalar = false;
+		}
+	});
+	return is_scalar;
+}
+
+bool Expression::HasSideEffects() const {
+	bool has_side_effects = false;
+	ExpressionIterator::EnumerateChildren(*this, [&](const Expression &child) {
+		if (child.HasSideEffects()) {
+			has_side_effects = true;
+		}
+	});
+	return has_side_effects;
+}
+
+bool Expression::PropagatesNullValues() const {
+	if (type == ExpressionType::OPERATOR_IS_NULL || type == ExpressionType::OPERATOR_IS_NOT_NULL ||
+	    type == ExpressionType::COMPARE_NOT_DISTINCT_FROM || type == ExpressionType::COMPARE_DISTINCT_FROM ||
+	    type == ExpressionType::CONJUNCTION_OR || type == ExpressionType::CONJUNCTION_AND) {
+		return false;
+	}
+	bool propagate_null_values = true;
+	ExpressionIterator::EnumerateChildren(*this, [&](const Expression &child) {
+		if (!child.PropagatesNullValues()) {
+			propagate_null_values = false;
+		}
+	});
+	return propagate_null_values;
+}
+
+bool Expression::IsFoldable() const {
+	bool is_foldable = true;
+	ExpressionIterator::EnumerateChildren(*this, [&](const Expression &child) {
+		if (!child.IsFoldable()) {
+			is_foldable = false;
+		}
+	});
+	return is_foldable;
+}
+
+bool Expression::HasParameter() const {
+	bool has_parameter = false;
+	ExpressionIterator::EnumerateChildren(*this,
+	                                      [&](const Expression &child) { has_parameter |= child.HasParameter(); });
+	return has_parameter;
+}
+
+bool Expression::HasSubquery() const {
+	bool has_subquery = false;
+	ExpressionIterator::EnumerateChildren(*this, [&](const Expression &child) { has_subquery |= child.HasSubquery(); });
+	return has_subquery;
+}
+
+hash_t Expression::Hash() const {
+	hash_t hash = duckdb::Hash<uint32_t>((uint32_t)type);
+	hash = CombineHash(hash, return_type.Hash());
+	ExpressionIterator::EnumerateChildren(*this,
+	                                      [&](const Expression &child) { hash = CombineHash(child.Hash(), hash); });
+	return hash;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+AggregateBinder::AggregateBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context, true) {
+}
+
+BindResult AggregateBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	switch (expr.expression_class) {
+	case ExpressionClass::WINDOW:
+		throw ParserException("aggregate function calls cannot contain window function calls");
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+string AggregateBinder::UnsupportedAggregateMessage() {
+	return "aggregate function calls cannot be nested";
+}
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+AlterBinder::AlterBinder(Binder &binder, ClientContext &context, TableCatalogEntry &table,
+                         vector<column_t> &bound_columns, LogicalType target_type)
+    : ExpressionBinder(binder, context), table(table), bound_columns(bound_columns) {
+	this->target_type = move(target_type);
+}
+
+BindResult AlterBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::WINDOW:
+		return BindResult("window functions are not allowed in alter statement");
+	case ExpressionClass::SUBQUERY:
+		return BindResult("cannot use subquery in alter statement");
+	case ExpressionClass::COLUMN_REF:
+		return BindColumn((ColumnRefExpression &)expr);
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+string AlterBinder::UnsupportedAggregateMessage() {
+	return "aggregate functions are not allowed in alter statement";
+}
+
+BindResult AlterBinder::BindColumn(ColumnRefExpression &colref) {
+	if (colref.column_names.size() > 1) {
+		return BindQualifiedColumnName(colref, table.name);
+	}
+	auto idx = table.GetColumnIndex(colref.column_names[0], true);
+	if (idx == DConstants::INVALID_INDEX) {
+		throw BinderException("Table does not contain column %s referenced in alter statement!",
+		                      colref.column_names[0]);
+	}
+	bound_columns.push_back(idx);
+	return BindResult(make_unique<BoundReferenceExpression>(table.columns[idx].Type(), bound_columns.size() - 1));
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+CheckBinder::CheckBinder(Binder &binder, ClientContext &context, string table_p, vector<ColumnDefinition> &columns,
+                         unordered_set<column_t> &bound_columns)
+    : ExpressionBinder(binder, context), table(move(table_p)), columns(columns), bound_columns(bound_columns) {
+	target_type = LogicalType::INTEGER;
+}
+
+BindResult CheckBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::WINDOW:
+		return BindResult("window functions are not allowed in check constraints");
+	case ExpressionClass::SUBQUERY:
+		return BindResult("cannot use subquery in check constraint");
+	case ExpressionClass::COLUMN_REF:
+		return BindCheckColumn((ColumnRefExpression &)expr);
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+string CheckBinder::UnsupportedAggregateMessage() {
+	return "aggregate functions are not allowed in check constraints";
+}
+
+BindResult ExpressionBinder::BindQualifiedColumnName(ColumnRefExpression &colref, const string &table_name) {
+	idx_t struct_start = 0;
+	if (colref.column_names[0] == table_name) {
+		struct_start++;
+	}
+	auto result = make_unique_base<ParsedExpression, ColumnRefExpression>(colref.column_names.back());
+	for (idx_t i = struct_start; i + 1 < colref.column_names.size(); i++) {
+		result = CreateStructExtract(move(result), colref.column_names[i]);
+	}
+	return BindExpression(&result, 0);
+}
+
+BindResult CheckBinder::BindCheckColumn(ColumnRefExpression &colref) {
+	if (colref.column_names.size() > 1) {
+		return BindQualifiedColumnName(colref, table);
+	}
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto &col = columns[i];
+		if (colref.column_names[0] == col.Name()) {
+			if (col.Generated()) {
+				auto bound_expression = col.GeneratedExpression().Copy();
+				return BindExpression(&bound_expression, 0, false);
+			}
+			bound_columns.insert(i);
+			D_ASSERT(col.StorageOid() != DConstants::INVALID_INDEX);
+			return BindResult(make_unique<BoundReferenceExpression>(col.Type(), col.StorageOid()));
+		}
+	}
+	throw BinderException("Table does not contain column %s referenced in check constraint!", colref.column_names[0]);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+ColumnAliasBinder::ColumnAliasBinder(BoundSelectNode &node, const case_insensitive_map_t<idx_t> &alias_map)
+    : node(node), alias_map(alias_map), in_alias(false) {
+}
+
+BindResult ColumnAliasBinder::BindAlias(ExpressionBinder &enclosing_binder, ColumnRefExpression &expr, idx_t depth,
+                                        bool root_expression) {
+	if (expr.IsQualified()) {
+		return BindResult(StringUtil::Format("Alias %s cannot be qualified.", expr.ToString()));
+	}
+
+	auto alias_entry = alias_map.find(expr.column_names[0]);
+	if (alias_entry == alias_map.end()) {
+		return BindResult(StringUtil::Format("Alias %s is not found.", expr.ToString()));
+	}
+
+	// found an alias: bind the alias expression
+	D_ASSERT(!in_alias);
+	auto expression = node.original_expressions[alias_entry->second]->Copy();
+	in_alias = true;
+	auto result = enclosing_binder.BindExpression(&expression, depth, root_expression);
+	in_alias = false;
+	return result;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+ConstantBinder::ConstantBinder(Binder &binder, ClientContext &context, string clause)
+    : ExpressionBinder(binder, context), clause(move(clause)) {
+}
+
+BindResult ConstantBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::COLUMN_REF:
+		return BindResult(clause + " cannot contain column names");
+	case ExpressionClass::SUBQUERY:
+		return BindResult(clause + " cannot contain subqueries");
+	case ExpressionClass::DEFAULT:
+		return BindResult(clause + " cannot contain DEFAULT clause");
+	case ExpressionClass::WINDOW:
+		return BindResult(clause + " cannot contain window functions!");
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+string ConstantBinder::UnsupportedAggregateMessage() {
+	return clause + "cannot contain aggregates!";
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+GroupBinder::GroupBinder(Binder &binder, ClientContext &context, SelectNode &node, idx_t group_index,
+                         case_insensitive_map_t<idx_t> &alias_map, case_insensitive_map_t<idx_t> &group_alias_map)
+    : ExpressionBinder(binder, context), node(node), alias_map(alias_map), group_alias_map(group_alias_map),
+      group_index(group_index) {
+}
+
+BindResult GroupBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	if (root_expression && depth == 0) {
+		switch (expr.expression_class) {
+		case ExpressionClass::COLUMN_REF:
+			return BindColumnRef((ColumnRefExpression &)expr);
+		case ExpressionClass::CONSTANT:
+			return BindConstant((ConstantExpression &)expr);
+		default:
+			break;
+		}
+	}
+	switch (expr.expression_class) {
+	case ExpressionClass::DEFAULT:
+		return BindResult("GROUP BY clause cannot contain DEFAULT clause");
+	case ExpressionClass::WINDOW:
+		return BindResult("GROUP BY clause cannot contain window functions!");
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+string GroupBinder::UnsupportedAggregateMessage() {
+	return "GROUP BY clause cannot contain aggregates!";
+}
+
+BindResult GroupBinder::BindSelectRef(idx_t entry) {
+	if (used_aliases.find(entry) != used_aliases.end()) {
+		// the alias has already been bound to before!
+		// this happens if we group on the same alias twice
+		// e.g. GROUP BY k, k or GROUP BY 1, 1
+		// in this case, we can just replace the grouping with a constant since the second grouping has no effect
+		// (the constant grouping will be optimized out later)
+		return BindResult(make_unique<BoundConstantExpression>(Value::INTEGER(42)));
+	}
+	if (entry >= node.select_list.size()) {
+		throw BinderException("GROUP BY term out of range - should be between 1 and %d", (int)node.select_list.size());
+	}
+	// we replace the root expression, also replace the unbound expression
+	unbound_expression = node.select_list[entry]->Copy();
+	// move the expression that this refers to here and bind it
+	auto select_entry = move(node.select_list[entry]);
+	auto binding = Bind(select_entry, nullptr, false);
+	// now replace the original expression in the select list with a reference to this group
+	group_alias_map[to_string(entry)] = bind_index;
+	node.select_list[entry] = make_unique<ColumnRefExpression>(to_string(entry));
+	// insert into the set of used aliases
+	used_aliases.insert(entry);
+	return BindResult(move(binding));
+}
+
+BindResult GroupBinder::BindConstant(ConstantExpression &constant) {
+	// constant as root expression
+	if (!constant.value.type().IsIntegral()) {
+		// non-integral expression, we just leave the constant here.
+		return ExpressionBinder::BindExpression(constant, 0);
+	}
+	// INTEGER constant: we use the integer as an index into the select list (e.g. GROUP BY 1)
+	auto index = (idx_t)constant.value.GetValue<int64_t>();
+	return BindSelectRef(index - 1);
+}
+
+BindResult GroupBinder::BindColumnRef(ColumnRefExpression &colref) {
+	// columns in GROUP BY clauses:
+	// FIRST refer to the original tables, and
+	// THEN if no match is found refer to aliases in the SELECT list
+	// THEN if no match is found, refer to outer queries
+
+	// first try to bind to the base columns (original tables)
+	auto result = ExpressionBinder::BindExpression(colref, 0);
+	if (result.HasError()) {
+		if (colref.IsQualified()) {
+			// explicit table name: not an alias reference
+			return result;
+		}
+		// failed to bind the column and the node is the root expression with depth = 0
+		// check if refers to an alias in the select clause
+		auto alias_name = colref.column_names[0];
+		auto entry = alias_map.find(alias_name);
+		if (entry == alias_map.end()) {
+			// no matching alias found
+			return result;
+		}
+		result = BindResult(BindSelectRef(entry->second));
+		if (!result.HasError()) {
+			group_alias_map[alias_name] = bind_index;
+		}
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+HavingBinder::HavingBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
+                           case_insensitive_map_t<idx_t> &alias_map)
+    : SelectBinder(binder, context, node, info), column_alias_binder(node, alias_map) {
+	target_type = LogicalType(LogicalTypeId::BOOLEAN);
+}
+
+BindResult HavingBinder::BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = (ColumnRefExpression &)**expr_ptr;
+	auto alias_result = column_alias_binder.BindAlias(*this, expr, depth, root_expression);
+	if (!alias_result.HasError()) {
+		return alias_result;
+	}
+
+	return BindResult(StringUtil::Format(
+	    "column %s must appear in the GROUP BY clause or be used in an aggregate function", expr.ToString()));
+}
+
+BindResult HavingBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	// check if the expression binds to one of the groups
+	auto group_index = TryBindGroup(expr, depth);
+	if (group_index != DConstants::INVALID_INDEX) {
+		return BindGroup(expr, depth, group_index);
+	}
+	switch (expr.expression_class) {
+	case ExpressionClass::WINDOW:
+		return BindResult("HAVING clause cannot contain window functions!");
+	case ExpressionClass::COLUMN_REF:
+		return BindColumnRef(expr_ptr, depth, root_expression);
+	default:
+		return duckdb::SelectBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+IndexBinder::IndexBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
+}
+
+BindResult IndexBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	switch (expr.expression_class) {
+	case ExpressionClass::WINDOW:
+		return BindResult("window functions are not allowed in index expressions");
+	case ExpressionClass::SUBQUERY:
+		return BindResult("cannot use subquery in index expressions");
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+string IndexBinder::UnsupportedAggregateMessage() {
+	return "aggregate functions are not allowed in index expressions";
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+InsertBinder::InsertBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
+}
+
+BindResult InsertBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::DEFAULT:
+		return BindResult("DEFAULT is not allowed here!");
+	case ExpressionClass::WINDOW:
+		return BindResult("INSERT statement cannot contain window functions!");
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+string InsertBinder::UnsupportedAggregateMessage() {
+	return "INSERT statement cannot contain aggregates!";
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+OrderBinder::OrderBinder(vector<Binder *> binders, idx_t projection_index, case_insensitive_map_t<idx_t> &alias_map,
+                         expression_map_t<idx_t> &projection_map, idx_t max_count)
+    : binders(move(binders)), projection_index(projection_index), max_count(max_count), extra_list(nullptr),
+      alias_map(alias_map), projection_map(projection_map) {
+}
+OrderBinder::OrderBinder(vector<Binder *> binders, idx_t projection_index, SelectNode &node,
+                         case_insensitive_map_t<idx_t> &alias_map, expression_map_t<idx_t> &projection_map)
+    : binders(move(binders)), projection_index(projection_index), alias_map(alias_map), projection_map(projection_map) {
+	this->max_count = node.select_list.size();
+	this->extra_list = &node.select_list;
+}
+
+unique_ptr<Expression> OrderBinder::CreateProjectionReference(ParsedExpression &expr, idx_t index) {
+	string alias;
+	if (extra_list && index < extra_list->size()) {
+		alias = extra_list->at(index)->ToString();
+	} else {
+		alias = expr.GetName();
+	}
+	return make_unique<BoundColumnRefExpression>(move(alias), LogicalType::INVALID,
+	                                             ColumnBinding(projection_index, index));
+}
+
+unique_ptr<Expression> OrderBinder::CreateExtraReference(unique_ptr<ParsedExpression> expr) {
+	auto result = CreateProjectionReference(*expr, extra_list->size());
+	extra_list->push_back(move(expr));
+	return result;
+}
+
+unique_ptr<Expression> OrderBinder::Bind(unique_ptr<ParsedExpression> expr) {
+	// in the ORDER BY clause we do not bind children
+	// we bind ONLY to the select list
+	// if there is no matching entry in the SELECT list already, we add the expression to the SELECT list and refer the
+	// new expression the new entry will then be bound later during the binding of the SELECT list we also don't do type
+	// resolution here: this only happens after the SELECT list has been bound
+	switch (expr->expression_class) {
+	case ExpressionClass::CONSTANT: {
+		// ORDER BY constant
+		// is the ORDER BY expression a constant integer? (e.g. ORDER BY 1)
+		auto &constant = (ConstantExpression &)*expr;
+		// ORDER BY a constant
+		if (!constant.value.type().IsIntegral()) {
+			// non-integral expression, we just leave the constant here.
+			// ORDER BY <constant> has no effect
+			// CONTROVERSIAL: maybe we should throw an error
+			return nullptr;
+		}
+		// INTEGER constant: we use the integer as an index into the select list (e.g. ORDER BY 1)
+		auto index = (idx_t)constant.value.GetValue<int64_t>();
+		if (index < 1 || index > max_count) {
+			throw BinderException("ORDER term out of range - should be between 1 and %lld", (idx_t)max_count);
+		}
+		return CreateProjectionReference(*expr, index - 1);
+	}
+	case ExpressionClass::COLUMN_REF: {
+		// COLUMN REF expression
+		// check if we can bind it to an alias in the select list
+		auto &colref = (ColumnRefExpression &)*expr;
+		// if there is an explicit table name we can't bind to an alias
+		if (colref.IsQualified()) {
+			break;
+		}
+		// check the alias list
+		auto entry = alias_map.find(colref.column_names[0]);
+		if (entry != alias_map.end()) {
+			// it does! point it to that entry
+			return CreateProjectionReference(*expr, entry->second);
+		}
+		break;
+	}
+	case ExpressionClass::POSITIONAL_REFERENCE: {
+		auto &posref = (PositionalReferenceExpression &)*expr;
+		return CreateProjectionReference(*expr, posref.index - 1);
+	}
+	default:
+		break;
+	}
+	// general case
+	// first bind the table names of this entry
+	for (auto &binder : binders) {
+		ExpressionBinder::QualifyColumnNames(*binder, expr);
+	}
+	// first check if the ORDER BY clause already points to an entry in the projection list
+	auto entry = projection_map.find(expr.get());
+	if (entry != projection_map.end()) {
+		if (entry->second == DConstants::INVALID_INDEX) {
+			throw BinderException("Ambiguous reference to column");
+		}
+		// there is a matching entry in the projection list
+		// just point to that entry
+		return CreateProjectionReference(*expr, entry->second);
+	}
+	if (!extra_list) {
+		// no extra list specified: we cannot push an extra ORDER BY clause
+		throw BinderException("Could not ORDER BY column \"%s\": add the expression/function to every SELECT, or move "
+		                      "the UNION into a FROM clause.",
+		                      expr->ToString());
+	}
+	// otherwise we need to push the ORDER BY entry into the select list
+	return CreateExtraReference(move(expr));
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+QualifyBinder::QualifyBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info,
+                             case_insensitive_map_t<idx_t> &alias_map)
+    : SelectBinder(binder, context, node, info), column_alias_binder(node, alias_map) {
+	target_type = LogicalType(LogicalTypeId::BOOLEAN);
+}
+
+BindResult QualifyBinder::BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = (ColumnRefExpression &)**expr_ptr;
+	auto result = duckdb::SelectBinder::BindExpression(expr_ptr, depth);
+	if (!result.HasError()) {
+		return result;
+	}
+
+	auto alias_result = column_alias_binder.BindAlias(*this, expr, depth, root_expression);
+	if (!alias_result.HasError()) {
+		return alias_result;
+	}
+
+	return BindResult(StringUtil::Format("Referenced column %s not found in FROM clause and can't find in alias map.",
+	                                     expr.ToString()));
+}
+
+BindResult QualifyBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	// check if the expression binds to one of the groups
+	auto group_index = TryBindGroup(expr, depth);
+	if (group_index != DConstants::INVALID_INDEX) {
+		return BindGroup(expr, depth, group_index);
+	}
+	switch (expr.expression_class) {
+	case ExpressionClass::WINDOW:
+		return BindWindow((WindowExpression &)expr, depth);
+	case ExpressionClass::COLUMN_REF:
+		return BindColumnRef(expr_ptr, depth, root_expression);
+	default:
+		return duckdb::SelectBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+RelationBinder::RelationBinder(Binder &binder, ClientContext &context, string op)
+    : ExpressionBinder(binder, context), op(move(op)) {
+}
+
+BindResult RelationBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	switch (expr.expression_class) {
+	case ExpressionClass::AGGREGATE:
+		return BindResult("aggregate functions are not allowed in " + op);
+	case ExpressionClass::DEFAULT:
+		return BindResult(op + " cannot contain DEFAULT clause");
+	case ExpressionClass::SUBQUERY:
+		return BindResult("subqueries are not allowed in " + op);
+	case ExpressionClass::WINDOW:
+		return BindResult("window functions are not allowed in " + op);
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+string RelationBinder::UnsupportedAggregateMessage() {
+	return "aggregate functions are not allowed in " + op;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+ReturningBinder::ReturningBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
+}
+
+BindResult ReturningBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::SUBQUERY:
+		return BindResult("SUBQUERY is not supported in returning statements");
+	case ExpressionClass::BOUND_SUBQUERY:
+		return BindResult("BOUND SUBQUERY is not supported in returning statements");
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+SelectBinder::SelectBinder(Binder &binder, ClientContext &context, BoundSelectNode &node, BoundGroupInformation &info)
+    : ExpressionBinder(binder, context), inside_window(false), node(node), info(info) {
+}
+
+BindResult SelectBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	// check if the expression binds to one of the groups
+	auto group_index = TryBindGroup(expr, depth);
+	if (group_index != DConstants::INVALID_INDEX) {
+		return BindGroup(expr, depth, group_index);
+	}
+	switch (expr.expression_class) {
+	case ExpressionClass::DEFAULT:
+		return BindResult("SELECT clause cannot contain DEFAULT clause");
+	case ExpressionClass::WINDOW:
+		return BindWindow((WindowExpression &)expr, depth);
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+idx_t SelectBinder::TryBindGroup(ParsedExpression &expr, idx_t depth) {
+	// first check the group alias map, if expr is a ColumnRefExpression
+	if (expr.type == ExpressionType::COLUMN_REF) {
+		auto &colref = (ColumnRefExpression &)expr;
+		if (!colref.IsQualified()) {
+			auto alias_entry = info.alias_map.find(colref.column_names[0]);
+			if (alias_entry != info.alias_map.end()) {
+				// found entry!
+				return alias_entry->second;
+			}
+		}
+	}
+	// no alias reference found
+	// check the list of group columns for a match
+	auto entry = info.map.find(&expr);
+	if (entry != info.map.end()) {
+		return entry->second;
+	}
+#ifdef DEBUG
+	for (auto entry : info.map) {
+		D_ASSERT(!entry.first->Equals(&expr));
+		D_ASSERT(!expr.Equals(entry.first));
+	}
+#endif
+	return DConstants::INVALID_INDEX;
+}
+
+BindResult SelectBinder::BindGroupingFunction(OperatorExpression &op, idx_t depth) {
+	if (op.children.empty()) {
+		throw InternalException("GROUPING requires at least one child");
+	}
+	if (node.groups.group_expressions.empty()) {
+		return BindResult(binder.FormatError(op, "GROUPING statement cannot be used without groups"));
+	}
+	if (op.children.size() >= 64) {
+		return BindResult(binder.FormatError(op, "GROUPING statement cannot have more than 64 groups"));
+	}
+	vector<idx_t> group_indexes;
+	group_indexes.reserve(op.children.size());
+	for (auto &child : op.children) {
+		ExpressionBinder::QualifyColumnNames(binder, child);
+		auto idx = TryBindGroup(*child, depth);
+		if (idx == DConstants::INVALID_INDEX) {
+			return BindResult(binder.FormatError(
+			    op, StringUtil::Format("GROUPING child \"%s\" must be a grouping column", child->GetName())));
+		}
+		group_indexes.push_back(idx);
+	}
+	auto col_idx = node.grouping_functions.size();
+	node.grouping_functions.push_back(move(group_indexes));
+	return BindResult(make_unique<BoundColumnRefExpression>(op.GetName(), LogicalType::BIGINT,
+	                                                        ColumnBinding(node.groupings_index, col_idx), depth));
+}
+
+BindResult SelectBinder::BindGroup(ParsedExpression &expr, idx_t depth, idx_t group_index) {
+	auto &group = node.groups.group_expressions[group_index];
+	return BindResult(make_unique<BoundColumnRefExpression>(expr.GetName(), group->return_type,
+	                                                        ColumnBinding(node.group_index, group_index), depth));
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+UpdateBinder::UpdateBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
+}
+
+BindResult UpdateBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	switch (expr.expression_class) {
+	case ExpressionClass::WINDOW:
+		return BindResult("window functions are not allowed in UPDATE");
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+string UpdateBinder::UnsupportedAggregateMessage() {
+	return "aggregate functions are not allowed in UPDATE";
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+WhereBinder::WhereBinder(Binder &binder, ClientContext &context, ColumnAliasBinder *column_alias_binder)
+    : ExpressionBinder(binder, context), column_alias_binder(column_alias_binder) {
+	target_type = LogicalType(LogicalTypeId::BOOLEAN);
+}
+
+BindResult WhereBinder::BindColumnRef(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = (ColumnRefExpression &)**expr_ptr;
+	auto result = ExpressionBinder::BindExpression(expr_ptr, depth);
+	if (!result.HasError() || !column_alias_binder) {
+		return result;
+	}
+
+	BindResult alias_result = column_alias_binder->BindAlias(*this, expr, depth, root_expression);
+	// This code path cannot be exercised at thispoint. #1547 might change that.
+	if (!alias_result.HasError()) {
+		return alias_result;
+	}
+
+	return result;
+}
+
+BindResult WhereBinder::BindExpression(unique_ptr<ParsedExpression> *expr_ptr, idx_t depth, bool root_expression) {
+	auto &expr = **expr_ptr;
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::DEFAULT:
+		return BindResult("WHERE clause cannot contain DEFAULT clause");
+	case ExpressionClass::WINDOW:
+		return BindResult("WHERE clause cannot contain window functions!");
+	case ExpressionClass::COLUMN_REF:
+		return BindColumnRef(expr_ptr, depth, root_expression);
+	default:
+		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	}
+}
+
+string WhereBinder::UnsupportedAggregateMessage() {
+	return "WHERE clause cannot contain aggregates!";
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+ExpressionBinder::ExpressionBinder(Binder &binder, ClientContext &context, bool replace_binder)
+    : binder(binder), context(context), stored_binder(nullptr) {
+	if (replace_binder) {
+		stored_binder = binder.GetActiveBinder();
+		binder.SetActiveBinder(this);
+	} else {
+		binder.PushExpressionBinder(this);
+	}
+}
+
+ExpressionBinder::~ExpressionBinder() {
+	if (binder.HasActiveBinder()) {
+		if (stored_binder) {
+			binder.SetActiveBinder(stored_binder);
+		} else {
+			binder.PopExpressionBinder();
+		}
+	}
+}
+
+BindResult ExpressionBinder::BindExpression(unique_ptr<ParsedExpression> *expr, idx_t depth, bool root_expression) {
+	auto &expr_ref = **expr;
+	switch (expr_ref.expression_class) {
+	case ExpressionClass::BETWEEN:
+		return BindExpression((BetweenExpression &)expr_ref, depth);
+	case ExpressionClass::CASE:
+		return BindExpression((CaseExpression &)expr_ref, depth);
+	case ExpressionClass::CAST:
+		return BindExpression((CastExpression &)expr_ref, depth);
+	case ExpressionClass::COLLATE:
+		return BindExpression((CollateExpression &)expr_ref, depth);
+	case ExpressionClass::COLUMN_REF:
+		return BindExpression((ColumnRefExpression &)expr_ref, depth);
+	case ExpressionClass::COMPARISON:
+		return BindExpression((ComparisonExpression &)expr_ref, depth);
+	case ExpressionClass::CONJUNCTION:
+		return BindExpression((ConjunctionExpression &)expr_ref, depth);
+	case ExpressionClass::CONSTANT:
+		return BindExpression((ConstantExpression &)expr_ref, depth);
+	case ExpressionClass::FUNCTION:
+		// binding function expression has extra parameter needed for macro's
+		return BindExpression((FunctionExpression &)expr_ref, depth, expr);
+	case ExpressionClass::LAMBDA:
+		return BindExpression((LambdaExpression &)expr_ref, depth);
+	case ExpressionClass::OPERATOR:
+		return BindExpression((OperatorExpression &)expr_ref, depth);
+	case ExpressionClass::SUBQUERY:
+		return BindExpression((SubqueryExpression &)expr_ref, depth);
+	case ExpressionClass::PARAMETER:
+		return BindExpression((ParameterExpression &)expr_ref, depth);
+	case ExpressionClass::POSITIONAL_REFERENCE:
+		return BindExpression((PositionalReferenceExpression &)expr_ref, depth);
+	default:
+		throw NotImplementedException("Unimplemented expression class");
+	}
+}
+
+bool ExpressionBinder::BindCorrelatedColumns(unique_ptr<ParsedExpression> &expr) {
+	// try to bind in one of the outer queries, if the binding error occurred in a subquery
+	auto &active_binders = binder.GetActiveBinders();
+	// make a copy of the set of binders, so we can restore it later
+	auto binders = active_binders;
+	active_binders.pop_back();
+	idx_t depth = 1;
+	bool success = false;
+	while (!active_binders.empty()) {
+		auto &next_binder = active_binders.back();
+		ExpressionBinder::QualifyColumnNames(next_binder->binder, expr);
+		auto bind_result = next_binder->Bind(&expr, depth);
+		if (bind_result.empty()) {
+			success = true;
+			break;
+		}
+		depth++;
+		active_binders.pop_back();
+	}
+	active_binders = binders;
+	return success;
+}
+
+void ExpressionBinder::BindChild(unique_ptr<ParsedExpression> &expr, idx_t depth, string &error) {
+	if (expr) {
+		string bind_error = Bind(&expr, depth);
+		if (error.empty()) {
+			error = bind_error;
+		}
+	}
+}
+
+void ExpressionBinder::ExtractCorrelatedExpressions(Binder &binder, Expression &expr) {
+	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &bound_colref = (BoundColumnRefExpression &)expr;
+		if (bound_colref.depth > 0) {
+			binder.AddCorrelatedColumn(CorrelatedColumnInfo(bound_colref));
+		}
+	}
+	ExpressionIterator::EnumerateChildren(expr,
+	                                      [&](Expression &child) { ExtractCorrelatedExpressions(binder, child); });
+}
+
+bool ExpressionBinder::ContainsType(const LogicalType &type, LogicalTypeId target) {
+	if (type.id() == target) {
+		return true;
+	}
+	switch (type.id()) {
+	case LogicalTypeId::STRUCT:
+	case LogicalTypeId::MAP: {
+		auto child_count = StructType::GetChildCount(type);
+		for (idx_t i = 0; i < child_count; i++) {
+			if (ContainsType(StructType::GetChildType(type, i), target)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	case LogicalTypeId::LIST:
+		return ContainsType(ListType::GetChildType(type), target);
+	default:
+		return false;
+	}
+}
+
+LogicalType ExpressionBinder::ExchangeType(const LogicalType &type, LogicalTypeId target, LogicalType new_type) {
+	if (type.id() == target) {
+		return new_type;
+	}
+	switch (type.id()) {
+	case LogicalTypeId::STRUCT:
+	case LogicalTypeId::MAP: {
+		// we make a copy of the child types of the struct here
+		auto child_types = StructType::GetChildTypes(type);
+		for (auto &child_type : child_types) {
+			child_type.second = ExchangeType(child_type.second, target, new_type);
+		}
+		return type.id() == LogicalTypeId::MAP ? LogicalType::MAP(move(child_types))
+		                                       : LogicalType::STRUCT(move(child_types));
+	}
+	case LogicalTypeId::LIST:
+		return LogicalType::LIST(ExchangeType(ListType::GetChildType(type), target, new_type));
+	default:
+		return type;
+	}
+}
+
+bool ExpressionBinder::ContainsNullType(const LogicalType &type) {
+	return ContainsType(type, LogicalTypeId::SQLNULL);
+}
+
+LogicalType ExpressionBinder::ExchangeNullType(const LogicalType &type) {
+	return ExchangeType(type, LogicalTypeId::SQLNULL, LogicalType::INTEGER);
+}
+
+unique_ptr<Expression> ExpressionBinder::Bind(unique_ptr<ParsedExpression> &expr, LogicalType *result_type,
+                                              bool root_expression) {
+	// bind the main expression
+	auto error_msg = Bind(&expr, 0, root_expression);
+	if (!error_msg.empty()) {
+		// failed to bind: try to bind correlated columns in the expression (if any)
+		bool success = BindCorrelatedColumns(expr);
+		if (!success) {
+			throw BinderException(error_msg);
+		}
+		auto bound_expr = (BoundExpression *)expr.get();
+		ExtractCorrelatedExpressions(binder, *bound_expr->expr);
+	}
+	D_ASSERT(expr->expression_class == ExpressionClass::BOUND_EXPRESSION);
+	auto bound_expr = (BoundExpression *)expr.get();
+	unique_ptr<Expression> result = move(bound_expr->expr);
+	if (target_type.id() != LogicalTypeId::INVALID) {
+		// the binder has a specific target type: add a cast to that type
+		result = BoundCastExpression::AddCastToType(move(result), target_type);
+	} else {
+		if (!binder.can_contain_nulls) {
+			// SQL NULL type is only used internally in the binder
+			// cast to INTEGER if we encounter it outside of the binder
+			if (ContainsNullType(result->return_type)) {
+				auto result_type = ExchangeNullType(result->return_type);
+				result = BoundCastExpression::AddCastToType(move(result), result_type);
+			}
+		}
+	}
+	if (result_type) {
+		*result_type = result->return_type;
+	}
+	return result;
+}
+
+string ExpressionBinder::Bind(unique_ptr<ParsedExpression> *expr, idx_t depth, bool root_expression) {
+	// bind the node, but only if it has not been bound yet
+	auto &expression = **expr;
+	auto alias = expression.alias;
+	if (expression.GetExpressionClass() == ExpressionClass::BOUND_EXPRESSION) {
+		// already bound, don't bind it again
+		return string();
+	}
+	// bind the expression
+	BindResult result = BindExpression(expr, depth, root_expression);
+	if (result.HasError()) {
+		return result.error;
+	}
+	// successfully bound: replace the node with a BoundExpression
+	*expr = make_unique<BoundExpression>(move(result.expression));
+	auto be = (BoundExpression *)expr->get();
+	D_ASSERT(be);
+	be->alias = alias;
+	if (!alias.empty()) {
+		be->expr->alias = alias;
+	}
+	return string();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+void ExpressionIterator::EnumerateChildren(const Expression &expr,
+                                           const std::function<void(const Expression &child)> &callback) {
+	EnumerateChildren((Expression &)expr, [&](unique_ptr<Expression> &child) { callback(*child); });
+}
+
+void ExpressionIterator::EnumerateChildren(Expression &expr, const std::function<void(Expression &child)> &callback) {
+	EnumerateChildren(expr, [&](unique_ptr<Expression> &child) { callback(*child); });
+}
+
+void ExpressionIterator::EnumerateChildren(Expression &expr,
+                                           const std::function<void(unique_ptr<Expression> &child)> &callback) {
+	switch (expr.expression_class) {
+	case ExpressionClass::BOUND_AGGREGATE: {
+		auto &aggr_expr = (BoundAggregateExpression &)expr;
+		for (auto &child : aggr_expr.children) {
+			callback(child);
+		}
+		if (aggr_expr.filter) {
+			callback(aggr_expr.filter);
+		}
+		break;
+	}
+	case ExpressionClass::BOUND_BETWEEN: {
+		auto &between_expr = (BoundBetweenExpression &)expr;
+		callback(between_expr.input);
+		callback(between_expr.lower);
+		callback(between_expr.upper);
+		break;
+	}
+	case ExpressionClass::BOUND_CASE: {
+		auto &case_expr = (BoundCaseExpression &)expr;
+		for (auto &case_check : case_expr.case_checks) {
+			callback(case_check.when_expr);
+			callback(case_check.then_expr);
+		}
+		callback(case_expr.else_expr);
+		break;
+	}
+	case ExpressionClass::BOUND_CAST: {
+		auto &cast_expr = (BoundCastExpression &)expr;
+		callback(cast_expr.child);
+		break;
+	}
+	case ExpressionClass::BOUND_COMPARISON: {
+		auto &comp_expr = (BoundComparisonExpression &)expr;
+		callback(comp_expr.left);
+		callback(comp_expr.right);
+		break;
+	}
+	case ExpressionClass::BOUND_CONJUNCTION: {
+		auto &conj_expr = (BoundConjunctionExpression &)expr;
+		for (auto &child : conj_expr.children) {
+			callback(child);
+		}
+		break;
+	}
+	case ExpressionClass::BOUND_FUNCTION: {
+		auto &func_expr = (BoundFunctionExpression &)expr;
+		for (auto &child : func_expr.children) {
+			callback(child);
+		}
+		break;
+	}
+	case ExpressionClass::BOUND_OPERATOR: {
+		auto &op_expr = (BoundOperatorExpression &)expr;
+		for (auto &child : op_expr.children) {
+			callback(child);
+		}
+		break;
+	}
+	case ExpressionClass::BOUND_SUBQUERY: {
+		auto &subquery_expr = (BoundSubqueryExpression &)expr;
+		if (subquery_expr.child) {
+			callback(subquery_expr.child);
+		}
+		break;
+	}
+	case ExpressionClass::BOUND_WINDOW: {
+		auto &window_expr = (BoundWindowExpression &)expr;
+		for (auto &partition : window_expr.partitions) {
+			callback(partition);
+		}
+		for (auto &order : window_expr.orders) {
+			callback(order.expression);
+		}
+		for (auto &child : window_expr.children) {
+			callback(child);
+		}
+		if (window_expr.filter_expr) {
+			callback(window_expr.filter_expr);
+		}
+		if (window_expr.start_expr) {
+			callback(window_expr.start_expr);
+		}
+		if (window_expr.end_expr) {
+			callback(window_expr.end_expr);
+		}
+		if (window_expr.offset_expr) {
+			callback(window_expr.offset_expr);
+		}
+		if (window_expr.default_expr) {
+			callback(window_expr.default_expr);
+		}
+		break;
+	}
+	case ExpressionClass::BOUND_UNNEST: {
+		auto &unnest_expr = (BoundUnnestExpression &)expr;
+		callback(unnest_expr.child);
+		break;
+	}
+	case ExpressionClass::BOUND_COLUMN_REF:
+	case ExpressionClass::BOUND_CONSTANT:
+	case ExpressionClass::BOUND_DEFAULT:
+	case ExpressionClass::BOUND_PARAMETER:
+	case ExpressionClass::BOUND_REF:
+		// these node types have no children
+		break;
+	default:
+		throw InternalException("ExpressionIterator used on unbound expression");
+	}
+}
+
+void ExpressionIterator::EnumerateExpression(unique_ptr<Expression> &expr,
+                                             const std::function<void(Expression &child)> &callback) {
+	if (!expr) {
+		return;
+	}
+	callback(*expr);
+	ExpressionIterator::EnumerateChildren(*expr,
+	                                      [&](unique_ptr<Expression> &child) { EnumerateExpression(child, callback); });
+}
+
+void ExpressionIterator::EnumerateTableRefChildren(BoundTableRef &ref,
+                                                   const std::function<void(Expression &child)> &callback) {
+	switch (ref.type) {
+	case TableReferenceType::CROSS_PRODUCT: {
+		auto &bound_crossproduct = (BoundCrossProductRef &)ref;
+		EnumerateTableRefChildren(*bound_crossproduct.left, callback);
+		EnumerateTableRefChildren(*bound_crossproduct.right, callback);
+		break;
+	}
+	case TableReferenceType::EXPRESSION_LIST: {
+		auto &bound_expr_list = (BoundExpressionListRef &)ref;
+		for (auto &expr_list : bound_expr_list.values) {
+			for (auto &expr : expr_list) {
+				EnumerateExpression(expr, callback);
+			}
+		}
+		break;
+	}
+	case TableReferenceType::JOIN: {
+		auto &bound_join = (BoundJoinRef &)ref;
+		EnumerateExpression(bound_join.condition, callback);
+		EnumerateTableRefChildren(*bound_join.left, callback);
+		EnumerateTableRefChildren(*bound_join.right, callback);
+		break;
+	}
+	case TableReferenceType::SUBQUERY: {
+		auto &bound_subquery = (BoundSubqueryRef &)ref;
+		EnumerateQueryNodeChildren(*bound_subquery.subquery, callback);
+		break;
+	}
+	case TableReferenceType::TABLE_FUNCTION:
+	case TableReferenceType::EMPTY:
+	case TableReferenceType::BASE_TABLE:
+	case TableReferenceType::CTE:
+		break;
+	default:
+		throw NotImplementedException("Unimplemented table reference type in ExpressionIterator");
+	}
+}
+
+void ExpressionIterator::EnumerateQueryNodeChildren(BoundQueryNode &node,
+                                                    const std::function<void(Expression &child)> &callback) {
+	switch (node.type) {
+	case QueryNodeType::SET_OPERATION_NODE: {
+		auto &bound_setop = (BoundSetOperationNode &)node;
+		EnumerateQueryNodeChildren(*bound_setop.left, callback);
+		EnumerateQueryNodeChildren(*bound_setop.right, callback);
+		break;
+	}
+	case QueryNodeType::RECURSIVE_CTE_NODE: {
+		auto &cte_node = (BoundRecursiveCTENode &)node;
+		EnumerateQueryNodeChildren(*cte_node.left, callback);
+		EnumerateQueryNodeChildren(*cte_node.right, callback);
+		break;
+	}
+	case QueryNodeType::SELECT_NODE: {
+		auto &bound_select = (BoundSelectNode &)node;
+		for (idx_t i = 0; i < bound_select.select_list.size(); i++) {
+			EnumerateExpression(bound_select.select_list[i], callback);
+		}
+		EnumerateExpression(bound_select.where_clause, callback);
+		for (idx_t i = 0; i < bound_select.groups.group_expressions.size(); i++) {
+			EnumerateExpression(bound_select.groups.group_expressions[i], callback);
+		}
+		EnumerateExpression(bound_select.having, callback);
+		for (idx_t i = 0; i < bound_select.aggregates.size(); i++) {
+			EnumerateExpression(bound_select.aggregates[i], callback);
+		}
+		for (idx_t i = 0; i < bound_select.unnests.size(); i++) {
+			EnumerateExpression(bound_select.unnests[i], callback);
+		}
+		for (idx_t i = 0; i < bound_select.windows.size(); i++) {
+			EnumerateExpression(bound_select.windows[i], callback);
+		}
+		if (bound_select.from_table) {
+			EnumerateTableRefChildren(*bound_select.from_table, callback);
+		}
+		break;
+	}
+	default:
+		throw NotImplementedException("Unimplemented query node in ExpressionIterator");
+	}
+	for (idx_t i = 0; i < node.modifiers.size(); i++) {
+		switch (node.modifiers[i]->type) {
+		case ResultModifierType::DISTINCT_MODIFIER:
+			for (auto &expr : ((BoundDistinctModifier &)*node.modifiers[i]).target_distincts) {
+				EnumerateExpression(expr, callback);
+			}
+			break;
+		case ResultModifierType::ORDER_MODIFIER:
+			for (auto &order : ((BoundOrderModifier &)*node.modifiers[i]).orders) {
+				EnumerateExpression(order.expression, callback);
+			}
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+ConjunctionOrFilter::ConjunctionOrFilter() : ConjunctionFilter(TableFilterType::CONJUNCTION_OR) {
+}
+
+FilterPropagateResult ConjunctionOrFilter::CheckStatistics(BaseStatistics &stats) {
+	// the OR filter is true if ANY of the children is true
+	D_ASSERT(!child_filters.empty());
+	for (auto &filter : child_filters) {
+		auto prune_result = filter->CheckStatistics(stats);
+		if (prune_result == FilterPropagateResult::NO_PRUNING_POSSIBLE) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		} else if (prune_result == FilterPropagateResult::FILTER_ALWAYS_TRUE) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		}
+	}
+	return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+}
+
+string ConjunctionOrFilter::ToString(const string &column_name) {
+	string result;
+	for (idx_t i = 0; i < child_filters.size(); i++) {
+		if (i > 0) {
+			result += " OR ";
+		}
+		result += child_filters[i]->ToString(column_name);
+	}
+	return result;
+}
+
+bool ConjunctionOrFilter::Equals(const TableFilter &other_p) const {
+	if (!ConjunctionFilter::Equals(other_p)) {
+		return false;
+	}
+	auto &other = (ConjunctionOrFilter &)other_p;
+	if (other.child_filters.size() != child_filters.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < other.child_filters.size(); i++) {
+		if (!child_filters[i]->Equals(*other.child_filters[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+ConjunctionAndFilter::ConjunctionAndFilter() : ConjunctionFilter(TableFilterType::CONJUNCTION_AND) {
+}
+
+FilterPropagateResult ConjunctionAndFilter::CheckStatistics(BaseStatistics &stats) {
+	// the AND filter is true if ALL of the children is true
+	D_ASSERT(!child_filters.empty());
+	auto result = FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	for (auto &filter : child_filters) {
+		auto prune_result = filter->CheckStatistics(stats);
+		if (prune_result == FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		} else if (prune_result != result) {
+			result = FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		}
+	}
+	return result;
+}
+
+string ConjunctionAndFilter::ToString(const string &column_name) {
+	string result;
+	for (idx_t i = 0; i < child_filters.size(); i++) {
+		if (i > 0) {
+			result += " AND ";
+		}
+		result += child_filters[i]->ToString(column_name);
+	}
+	return result;
+}
+
+bool ConjunctionAndFilter::Equals(const TableFilter &other_p) const {
+	if (!ConjunctionFilter::Equals(other_p)) {
+		return false;
+	}
+	auto &other = (ConjunctionAndFilter &)other_p;
+	if (other.child_filters.size() != child_filters.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < other.child_filters.size(); i++) {
+		if (!child_filters[i]->Equals(*other.child_filters[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+ConstantFilter::ConstantFilter(ExpressionType comparison_type_p, Value constant_p)
+    : TableFilter(TableFilterType::CONSTANT_COMPARISON), comparison_type(comparison_type_p),
+      constant(move(constant_p)) {
+}
+
+FilterPropagateResult ConstantFilter::CheckStatistics(BaseStatistics &stats) {
+	D_ASSERT(constant.type().id() == stats.type.id());
+	switch (constant.type().InternalType()) {
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::INT128:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+		return ((NumericStatistics &)stats).CheckZonemap(comparison_type, constant);
+	case PhysicalType::VARCHAR:
+		return ((StringStatistics &)stats).CheckZonemap(comparison_type, constant.ToString());
+	default:
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+}
+
+string ConstantFilter::ToString(const string &column_name) {
+	return column_name + ExpressionTypeToOperator(comparison_type) + constant.ToString();
+}
+
+bool ConstantFilter::Equals(const TableFilter &other_p) const {
+	if (!TableFilter::Equals(other_p)) {
+		return false;
+	}
+	auto &other = (ConstantFilter &)other_p;
+	return other.comparison_type == comparison_type && other.constant == constant;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+IsNullFilter::IsNullFilter() : TableFilter(TableFilterType::IS_NULL) {
+}
+
+FilterPropagateResult IsNullFilter::CheckStatistics(BaseStatistics &stats) {
+	if (!stats.CanHaveNull()) {
+		// no null values are possible: always false
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (!stats.CanHaveNoNull()) {
+		// no non-null values are possible: always true
+		return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	}
+	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
+string IsNullFilter::ToString(const string &column_name) {
+	return column_name + "IS NULL";
+}
+
+IsNotNullFilter::IsNotNullFilter() : TableFilter(TableFilterType::IS_NOT_NULL) {
+}
+
+FilterPropagateResult IsNotNullFilter::CheckStatistics(BaseStatistics &stats) {
+	if (!stats.CanHaveNoNull()) {
+		// no non-null values are possible: always false
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (!stats.CanHaveNull()) {
+		// no null values are possible: always true
+		return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+	}
+	return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+}
+
+string IsNotNullFilter::ToString(const string &column_name) {
+	return column_name + " IS NOT NULL";
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+unique_ptr<Expression> JoinCondition::CreateExpression(JoinCondition cond) {
+	auto bound_comparison = make_unique<BoundComparisonExpression>(cond.comparison, move(cond.left), move(cond.right));
+	return move(bound_comparison);
+}
+
+JoinSide JoinSide::CombineJoinSide(JoinSide left, JoinSide right) {
+	if (left == JoinSide::NONE) {
+		return right;
+	}
+	if (right == JoinSide::NONE) {
+		return left;
+	}
+	if (left != right) {
+		return JoinSide::BOTH;
+	}
+	return left;
+}
+
+JoinSide JoinSide::GetJoinSide(idx_t table_binding, unordered_set<idx_t> &left_bindings,
+                               unordered_set<idx_t> &right_bindings) {
+	if (left_bindings.find(table_binding) != left_bindings.end()) {
+		// column references table on left side
+		D_ASSERT(right_bindings.find(table_binding) == right_bindings.end());
+		return JoinSide::LEFT;
+	} else {
+		// column references table on right side
+		D_ASSERT(right_bindings.find(table_binding) != right_bindings.end());
+		return JoinSide::RIGHT;
+	}
+}
+
+JoinSide JoinSide::GetJoinSide(Expression &expression, unordered_set<idx_t> &left_bindings,
+                               unordered_set<idx_t> &right_bindings) {
+	if (expression.type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &colref = (BoundColumnRefExpression &)expression;
+		if (colref.depth > 0) {
+			throw Exception("Non-inner join on correlated columns not supported");
+		}
+		return GetJoinSide(colref.binding.table_index, left_bindings, right_bindings);
+	}
+	D_ASSERT(expression.type != ExpressionType::BOUND_REF);
+	if (expression.type == ExpressionType::SUBQUERY) {
+		D_ASSERT(expression.GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY);
+		auto &subquery = (BoundSubqueryExpression &)expression;
+		JoinSide side = JoinSide::NONE;
+		if (subquery.child) {
+			side = GetJoinSide(*subquery.child, left_bindings, right_bindings);
+		}
+		// correlated subquery, check the side of each of correlated columns in the subquery
+		for (auto &corr : subquery.binder->correlated_columns) {
+			if (corr.depth > 1) {
+				// correlated column has depth > 1
+				// it does not refer to any table in the current set of bindings
+				return JoinSide::BOTH;
+			}
+			auto correlated_side = GetJoinSide(corr.binding.table_index, left_bindings, right_bindings);
+			side = CombineJoinSide(side, correlated_side);
+		}
+		return side;
+	}
+	JoinSide join_side = JoinSide::NONE;
+	ExpressionIterator::EnumerateChildren(expression, [&](Expression &child) {
+		auto child_side = GetJoinSide(child, left_bindings, right_bindings);
+		join_side = CombineJoinSide(child_side, join_side);
+	});
+	return join_side;
+}
+
+JoinSide JoinSide::GetJoinSide(const unordered_set<idx_t> &bindings, unordered_set<idx_t> &left_bindings,
+                               unordered_set<idx_t> &right_bindings) {
+	JoinSide side = JoinSide::NONE;
+	for (auto binding : bindings) {
+		side = CombineJoinSide(side, GetJoinSide(binding, left_bindings, right_bindings));
+	}
+	return side;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+string LogicalOperator::GetName() const {
+	return LogicalOperatorToString(type);
+}
+
+string LogicalOperator::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += expressions[i]->GetName();
+	}
+	return result;
+}
+
+void LogicalOperator::ResolveOperatorTypes() {
+	// if (types.size() > 0) {
+	// 	// types already resolved for this node
+	// 	return;
+	// }
+	types.clear();
+	// first resolve child types
+	for (auto &child : children) {
+		child->ResolveOperatorTypes();
+	}
+	// now resolve the types for this operator
+	ResolveTypes();
+	D_ASSERT(types.size() == GetColumnBindings().size());
+}
+
+vector<ColumnBinding> LogicalOperator::GenerateColumnBindings(idx_t table_idx, idx_t column_count) {
+	vector<ColumnBinding> result;
+	for (idx_t i = 0; i < column_count; i++) {
+		result.emplace_back(table_idx, i);
+	}
+	return result;
+}
+
+vector<LogicalType> LogicalOperator::MapTypes(const vector<LogicalType> &types, const vector<idx_t> &projection_map) {
+	if (projection_map.empty()) {
+		return types;
+	} else {
+		vector<LogicalType> result_types;
+		result_types.reserve(projection_map.size());
+		for (auto index : projection_map) {
+			result_types.push_back(types[index]);
+		}
+		return result_types;
+	}
+}
+
+vector<ColumnBinding> LogicalOperator::MapBindings(const vector<ColumnBinding> &bindings,
+                                                   const vector<idx_t> &projection_map) {
+	if (projection_map.empty()) {
+		return bindings;
+	} else {
+		vector<ColumnBinding> result_bindings;
+		result_bindings.reserve(projection_map.size());
+		for (auto index : projection_map) {
+			result_bindings.push_back(bindings[index]);
+		}
+		return result_bindings;
+	}
+}
+
+string LogicalOperator::ToString() const {
+	TreeRenderer renderer;
+	return renderer.ToString(*this);
+}
+
+void LogicalOperator::Verify() {
+#ifdef DEBUG
+	// verify expressions
+	for (idx_t expr_idx = 0; expr_idx < expressions.size(); expr_idx++) {
+		auto str = expressions[expr_idx]->ToString();
+		// verify that we can (correctly) copy this expression
+		auto copy = expressions[expr_idx]->Copy();
+		auto original_hash = expressions[expr_idx]->Hash();
+		auto copy_hash = copy->Hash();
+		// copy should be identical to original
+		D_ASSERT(expressions[expr_idx]->ToString() == copy->ToString());
+		D_ASSERT(original_hash == copy_hash);
+		D_ASSERT(Expression::Equals(expressions[expr_idx].get(), copy.get()));
+
+		D_ASSERT(!Expression::Equals(expressions[expr_idx].get(), nullptr));
+		for (idx_t other_idx = 0; other_idx < expr_idx; other_idx++) {
+			// comparison with other expressions
+			auto other_hash = expressions[other_idx]->Hash();
+			bool expr_equal = Expression::Equals(expressions[expr_idx].get(), expressions[other_idx].get());
+			if (original_hash != other_hash) {
+				// if the hashes are not equal the expressions should not be equal either
+				D_ASSERT(!expr_equal);
+			}
+		}
+		D_ASSERT(!str.empty());
+	}
+	D_ASSERT(!ToString().empty());
+	for (auto &child : children) {
+		child->Verify();
+	}
+#endif
+}
+
+void LogicalOperator::Print() {
+	Printer::Print(ToString());
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+void LogicalOperatorVisitor::VisitOperator(LogicalOperator &op) {
+	VisitOperatorChildren(op);
+	VisitOperatorExpressions(op);
+}
+
+void LogicalOperatorVisitor::VisitOperatorChildren(LogicalOperator &op) {
+	for (auto &child : op.children) {
+		VisitOperator(*child);
+	}
+}
+
+void LogicalOperatorVisitor::EnumerateExpressions(LogicalOperator &op,
+                                                  const std::function<void(unique_ptr<Expression> *child)> &callback) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_EXPRESSION_GET: {
+		auto &get = (LogicalExpressionGet &)op;
+		for (auto &expr_list : get.expressions) {
+			for (auto &expr : expr_list) {
+				callback(&expr);
+			}
+		}
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_ORDER_BY: {
+		auto &order = (LogicalOrder &)op;
+		for (auto &node : order.orders) {
+			callback(&node.expression);
+		}
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_TOP_N: {
+		auto &order = (LogicalTopN &)op;
+		for (auto &node : order.orders) {
+			callback(&node.expression);
+		}
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_DISTINCT: {
+		auto &distinct = (LogicalDistinct &)op;
+		for (auto &target : distinct.distinct_targets) {
+			callback(&target);
+		}
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_DELIM_JOIN:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
+		if (op.type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+			auto &delim_join = (LogicalDelimJoin &)op;
+			for (auto &expr : delim_join.duplicate_eliminated_columns) {
+				callback(&expr);
+			}
+		}
+		auto &join = (LogicalComparisonJoin &)op;
+		for (auto &cond : join.conditions) {
+			callback(&cond.left);
+			callback(&cond.right);
+		}
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_ANY_JOIN: {
+		auto &join = (LogicalAnyJoin &)op;
+		callback(&join.condition);
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_LIMIT: {
+		auto &limit = (LogicalLimit &)op;
+		if (limit.limit) {
+			callback(&limit.limit);
+		}
+		if (limit.offset) {
+			callback(&limit.offset);
+		}
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_LIMIT_PERCENT: {
+		auto &limit = (LogicalLimitPercent &)op;
+		if (limit.limit) {
+			callback(&limit.limit);
+		}
+		if (limit.offset) {
+			callback(&limit.offset);
+		}
+		break;
+	}
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
+		auto &aggr = (LogicalAggregate &)op;
+		for (auto &group : aggr.groups) {
+			callback(&group);
+		}
+		break;
+	}
+	default:
+		break;
+	}
+	for (auto &expression : op.expressions) {
+		callback(&expression);
+	}
+}
+
+void LogicalOperatorVisitor::VisitOperatorExpressions(LogicalOperator &op) {
+	LogicalOperatorVisitor::EnumerateExpressions(op, [&](unique_ptr<Expression> *child) { VisitExpression(child); });
+}
+
+void LogicalOperatorVisitor::VisitExpression(unique_ptr<Expression> *expression) {
+	auto &expr = **expression;
+	unique_ptr<Expression> result;
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::BOUND_AGGREGATE:
+		result = VisitReplace((BoundAggregateExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_BETWEEN:
+		result = VisitReplace((BoundBetweenExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_CASE:
+		result = VisitReplace((BoundCaseExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_CAST:
+		result = VisitReplace((BoundCastExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_COLUMN_REF:
+		result = VisitReplace((BoundColumnRefExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_COMPARISON:
+		result = VisitReplace((BoundComparisonExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_CONJUNCTION:
+		result = VisitReplace((BoundConjunctionExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_CONSTANT:
+		result = VisitReplace((BoundConstantExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_FUNCTION:
+		result = VisitReplace((BoundFunctionExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_SUBQUERY:
+		result = VisitReplace((BoundSubqueryExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_OPERATOR:
+		result = VisitReplace((BoundOperatorExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_PARAMETER:
+		result = VisitReplace((BoundParameterExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_REF:
+		result = VisitReplace((BoundReferenceExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_DEFAULT:
+		result = VisitReplace((BoundDefaultExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_WINDOW:
+		result = VisitReplace((BoundWindowExpression &)expr, expression);
+		break;
+	case ExpressionClass::BOUND_UNNEST:
+		result = VisitReplace((BoundUnnestExpression &)expr, expression);
+		break;
+	default:
+		throw InternalException("Unrecognized expression type in logical operator visitor");
+	}
+	if (result) {
+		*expression = move(result);
+	} else {
+		// visit the children of this node
+		VisitExpressionChildren(expr);
+	}
+}
+
+void LogicalOperatorVisitor::VisitExpressionChildren(Expression &expr) {
+	ExpressionIterator::EnumerateChildren(expr, [&](unique_ptr<Expression> &expr) { VisitExpression(&expr); });
+}
+
+// these are all default methods that can be overriden
+// we don't care about coverage here
+// LCOV_EXCL_START
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundAggregateExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundBetweenExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundCaseExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundCastExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundColumnRefExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundComparisonExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundConjunctionExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundConstantExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundDefaultExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundFunctionExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundOperatorExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundParameterExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundReferenceExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundSubqueryExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundWindowExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+unique_ptr<Expression> LogicalOperatorVisitor::VisitReplace(BoundUnnestExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	return nullptr;
+}
+
+// LCOV_EXCL_STOP
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+LogicalAggregate::LogicalAggregate(idx_t group_index, idx_t aggregate_index, vector<unique_ptr<Expression>> select_list)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY, move(select_list)), group_index(group_index),
+      aggregate_index(aggregate_index), groupings_index(DConstants::INVALID_INDEX) {
+}
+
+void LogicalAggregate::ResolveTypes() {
+	D_ASSERT(groupings_index != DConstants::INVALID_INDEX || grouping_functions.empty());
+	for (auto &expr : groups) {
+		types.push_back(expr->return_type);
+	}
+	// get the chunk types from the projection list
+	for (auto &expr : expressions) {
+		types.push_back(expr->return_type);
+	}
+	for (idx_t i = 0; i < grouping_functions.size(); i++) {
+		types.emplace_back(LogicalType::BIGINT);
+	}
+}
+
+vector<ColumnBinding> LogicalAggregate::GetColumnBindings() {
+	D_ASSERT(groupings_index != DConstants::INVALID_INDEX || grouping_functions.empty());
+	vector<ColumnBinding> result;
+	for (idx_t i = 0; i < groups.size(); i++) {
+		result.emplace_back(group_index, i);
+	}
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		result.emplace_back(aggregate_index, i);
+	}
+	for (idx_t i = 0; i < grouping_functions.size(); i++) {
+		result.emplace_back(groupings_index, i);
+	}
+	return result;
+}
+
+string LogicalAggregate::ParamsToString() const {
+	string result;
+	for (idx_t i = 0; i < groups.size(); i++) {
+		if (i > 0) {
+			result += "\n";
+		}
+		result += groups[i]->GetName();
+	}
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		if (i > 0 || !groups.empty()) {
+			result += "\n";
+		}
+		result += expressions[i]->GetName();
+	}
+	return result;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+LogicalAnyJoin::LogicalAnyJoin(JoinType type) : LogicalJoin(type, LogicalOperatorType::LOGICAL_ANY_JOIN) {
+}
+
+string LogicalAnyJoin::ParamsToString() const {
+	return condition->ToString();
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+LogicalComparisonJoin::LogicalComparisonJoin(JoinType join_type, LogicalOperatorType logical_type)
+    : LogicalJoin(join_type, logical_type) {
+}
+
+string LogicalComparisonJoin::ParamsToString() const {
+	string result = JoinTypeToString(join_type);
+	for (auto &condition : conditions) {
+		result += "\n";
+		auto expr = make_unique<BoundComparisonExpression>(condition.comparison, condition.left->Copy(),
+		                                                   condition.right->Copy());
+		result += expr->ToString();
+	}
+
+	return result;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+LogicalCrossProduct::LogicalCrossProduct() : LogicalOperator(LogicalOperatorType::LOGICAL_CROSS_PRODUCT) {
+}
+
+vector<ColumnBinding> LogicalCrossProduct::GetColumnBindings() {
+	auto left_bindings = children[0]->GetColumnBindings();
+	auto right_bindings = children[1]->GetColumnBindings();
+	left_bindings.insert(left_bindings.end(), right_bindings.begin(), right_bindings.end());
+	return left_bindings;
+}
+
+void LogicalCrossProduct::ResolveTypes() {
+	types.insert(types.end(), children[0]->types.begin(), children[0]->types.end());
+	types.insert(types.end(), children[1]->types.begin(), children[1]->types.end());
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+string LogicalDistinct::ParamsToString() const {
+	string result = LogicalOperator::ParamsToString();
+	if (!distinct_targets.empty()) {
+		result += StringUtil::Join(distinct_targets, distinct_targets.size(), "\n",
+		                           [](const unique_ptr<Expression> &child) { return child->GetName(); });
+	}
+
+	return result;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+LogicalEmptyResult::LogicalEmptyResult(unique_ptr<LogicalOperator> op)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_EMPTY_RESULT) {
+
+	this->bindings = op->GetColumnBindings();
+
+	op->ResolveOperatorTypes();
+	this->return_types = op->types;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+LogicalFilter::LogicalFilter(unique_ptr<Expression> expression) : LogicalOperator(LogicalOperatorType::LOGICAL_FILTER) {
+	expressions.push_back(move(expression));
+	SplitPredicates(expressions);
+}
+
+LogicalFilter::LogicalFilter() : LogicalOperator(LogicalOperatorType::LOGICAL_FILTER) {
+}
+
+void LogicalFilter::ResolveTypes() {
+	types = MapTypes(children[0]->types, projection_map);
+}
+
+vector<ColumnBinding> LogicalFilter::GetColumnBindings() {
+	return MapBindings(children[0]->GetColumnBindings(), projection_map);
+}
+
+// Split the predicates separated by AND statements
+// These are the predicates that are safe to push down because all of them MUST
+// be true
+bool LogicalFilter::SplitPredicates(vector<unique_ptr<Expression>> &expressions) {
+	bool found_conjunction = false;
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		if (expressions[i]->type == ExpressionType::CONJUNCTION_AND) {
+			auto &conjunction = (BoundConjunctionExpression &)*expressions[i];
+			found_conjunction = true;
+			// AND expression, append the other children
+			for (idx_t k = 1; k < conjunction.children.size(); k++) {
+				expressions.push_back(move(conjunction.children[k]));
+			}
+			// replace this expression with the first child of the conjunction
+			expressions[i] = move(conjunction.children[0]);
+			// we move back by one so the right child is checked again
+			// in case it is an AND expression as well
+			i--;
+		}
+	}
+	return found_conjunction;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+LogicalGet::LogicalGet(idx_t table_index, TableFunction function, unique_ptr<FunctionData> bind_data,
+                       vector<LogicalType> returned_types, vector<string> returned_names)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_GET), table_index(table_index), function(move(function)),
+      bind_data(move(bind_data)), returned_types(move(returned_types)), names(move(returned_names)) {
+}
+
+string LogicalGet::GetName() const {
+	return StringUtil::Upper(function.name);
+}
+
+TableCatalogEntry *LogicalGet::GetTable() const {
+	return TableScanFunction::GetTableEntry(function, bind_data.get());
+}
+
+string LogicalGet::ParamsToString() const {
+	string result;
+	for (auto &kv : table_filters.filters) {
+		auto &column_index = kv.first;
+		auto &filter = kv.second;
+		if (column_index < names.size()) {
+			result += filter->ToString(names[column_index]);
+		}
+		result += "\n";
+	}
+	if (!function.to_string) {
+		return string();
+	}
+	return function.to_string(bind_data.get());
+}
+
+vector<ColumnBinding> LogicalGet::GetColumnBindings() {
+	if (column_ids.empty()) {
+		return {ColumnBinding(table_index, 0)};
+	}
+	vector<ColumnBinding> result;
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		result.emplace_back(table_index, i);
+	}
+	return result;
+}
+
+void LogicalGet::ResolveTypes() {
+	if (column_ids.empty()) {
+		column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+	}
+	for (auto &index : column_ids) {
+		if (index == COLUMN_IDENTIFIER_ROW_ID) {
+			types.emplace_back(LogicalType::ROW_TYPE);
+		} else {
+			types.push_back(returned_types[index]);
+		}
+	}
+}
+
+idx_t LogicalGet::EstimateCardinality(ClientContext &context) {
+	if (function.cardinality) {
+		auto node_stats = function.cardinality(context, bind_data.get());
+		if (node_stats && node_stats->has_estimated_cardinality) {
+			return node_stats->estimated_cardinality;
+		}
+	}
+	return 1;
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+LogicalJoin::LogicalJoin(JoinType join_type, LogicalOperatorType logical_type)
+    : LogicalOperator(logical_type), join_type(join_type) {
+}
+
+vector<ColumnBinding> LogicalJoin::GetColumnBindings() {
+	auto left_bindings = MapBindings(children[0]->GetColumnBindings(), left_projection_map);
+	if (join_type == JoinType::SEMI || join_type == JoinType::ANTI) {
+		// for SEMI and ANTI join we only project the left hand side
+		return left_bindings;
+	}
+	if (join_type == JoinType::MARK) {
+		// for MARK join we project the left hand side plus the MARK column
+		left_bindings.emplace_back(mark_index, 0);
+		return left_bindings;
+	}
+	// for other join types we project both the LHS and the RHS
+	auto right_bindings = MapBindings(children[1]->GetColumnBindings(), right_projection_map);
+	left_bindings.insert(left_bindings.end(), right_bindings.begin(), right_bindings.end());
+	return left_bindings;
+}
+
+void LogicalJoin::ResolveTypes() {
+	types = MapTypes(children[0]->types, left_projection_map);
+	if (join_type == JoinType::SEMI || join_type == JoinType::ANTI) {
+		// for SEMI and ANTI join we only project the left hand side
+		return;
+	}
+	if (join_type == JoinType::MARK) {
+		// for MARK join we project the left hand side, plus a BOOLEAN column indicating the MARK
+		types.emplace_back(LogicalType::BOOLEAN);
+		return;
+	}
+	// for any other join we project both sides
+	auto right_types = MapTypes(children[1]->types, right_projection_map);
+	types.insert(types.end(), right_types.begin(), right_types.end());
+}
+
+void LogicalJoin::GetTableReferences(LogicalOperator &op, unordered_set<idx_t> &bindings) {
+	auto column_bindings = op.GetColumnBindings();
+	for (auto binding : column_bindings) {
+		bindings.insert(binding.table_index);
+	}
+}
+
+void LogicalJoin::GetExpressionBindings(Expression &expr, unordered_set<idx_t> &bindings) {
+	if (expr.type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &colref = (BoundColumnRefExpression &)expr;
+		D_ASSERT(colref.depth == 0);
+		bindings.insert(colref.binding.table_index);
+	}
+	ExpressionIterator::EnumerateChildren(expr, [&](Expression &child) { GetExpressionBindings(child, bindings); });
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+LogicalLimit::LogicalLimit(int64_t limit_val, int64_t offset_val, unique_ptr<Expression> limit,
+                           unique_ptr<Expression> offset)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_LIMIT), limit_val(limit_val), offset_val(offset_val),
+      limit(move(limit)), offset(move(offset)) {
+}
+
+vector<ColumnBinding> LogicalLimit::GetColumnBindings() {
+	return children[0]->GetColumnBindings();
+}
+
+idx_t LogicalLimit::EstimateCardinality(ClientContext &context) {
+	auto child_cardinality = children[0]->EstimateCardinality(context);
+	if (limit_val >= 0 && idx_t(limit_val) < child_cardinality) {
+		child_cardinality = limit_val;
+	}
+	return child_cardinality;
+}
+
+void LogicalLimit::ResolveTypes() {
+	types = children[0]->types;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+LogicalProjection::LogicalProjection(idx_t table_index, vector<unique_ptr<Expression>> select_list)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_PROJECTION, move(select_list)), table_index(table_index) {
+}
+
+vector<ColumnBinding> LogicalProjection::GetColumnBindings() {
+	return GenerateColumnBindings(table_index, expressions.size());
+}
+
+void LogicalProjection::ResolveTypes() {
+	for (auto &expr : expressions) {
+		types.push_back(expr->return_type);
+	}
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+LogicalSample::LogicalSample(unique_ptr<SampleOptions> sample_options_p, unique_ptr<LogicalOperator> child)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_SAMPLE), sample_options(move(sample_options_p)) {
+	children.push_back(move(child));
+}
+
+vector<ColumnBinding> LogicalSample::GetColumnBindings() {
+	return children[0]->GetColumnBindings();
+}
+
+idx_t LogicalSample::EstimateCardinality(ClientContext &context) {
+	auto child_cardinality = children[0]->EstimateCardinality(context);
+	if (sample_options->is_percentage) {
+		return idx_t(child_cardinality * sample_options->sample_size.GetValue<double>());
+	} else {
+		auto sample_size = sample_options->sample_size.GetValue<uint64_t>();
+		if (sample_size < child_cardinality) {
+			return sample_size;
+		}
+	}
+	return child_cardinality;
+}
+
+void LogicalSample::ResolveTypes() {
+	types = children[0]->types;
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+vector<ColumnBinding> LogicalUnnest::GetColumnBindings() {
+	auto child_bindings = children[0]->GetColumnBindings();
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		child_bindings.emplace_back(unnest_index, i);
+	}
+	return child_bindings;
+}
+
+void LogicalUnnest::ResolveTypes() {
+	types.insert(types.end(), children[0]->types.begin(), children[0]->types.end());
+	for (auto &expr : expressions) {
+		types.push_back(expr->return_type);
+	}
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+vector<ColumnBinding> LogicalWindow::GetColumnBindings() {
+	auto child_bindings = children[0]->GetColumnBindings();
+	for (idx_t i = 0; i < expressions.size(); i++) {
+		child_bindings.emplace_back(window_index, i);
+	}
+	return child_bindings;
+}
+
+void LogicalWindow::ResolveTypes() {
+	types.insert(types.end(), children[0]->types.begin(), children[0]->types.end());
+	for (auto &expr : expressions) {
+		types.push_back(expr->return_type);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+Planner::Planner(ClientContext &context) : binder(Binder::CreateBinder(context)), context(context) {
+}
+
+void Planner::CreatePlan(SQLStatement &statement) {
+	auto &profiler = QueryProfiler::Get(context);
+	auto parameter_count = statement.n_param;
+
+	vector<BoundParameterExpression *> bound_parameters;
+
+	// first bind the tables and columns to the catalog
+	profiler.StartPhase("binder");
+	binder->parameters = &bound_parameters;
+	binder->parameter_types = &parameter_types;
+	auto bound_statement = binder->Bind(statement);
+	profiler.EndPhase();
+
+	this->properties = binder->properties;
+	this->properties.parameter_count = parameter_count;
+	this->names = bound_statement.names;
+	this->types = bound_statement.types;
+	this->plan = move(bound_statement.plan);
+	properties.bound_all_parameters = true;
+
+	// set up a map of parameter number -> value entries
+	for (auto &expr : bound_parameters) {
+		// check if the type of the parameter could be resolved
+		if (expr->return_type.id() == LogicalTypeId::INVALID || expr->return_type.id() == LogicalTypeId::UNKNOWN) {
+			properties.bound_all_parameters = false;
+			continue;
+		}
+		auto value = make_unique<Value>(expr->return_type);
+		expr->value = value.get();
+		// check if the parameter number has been used before
+		auto entry = value_map.find(expr->parameter_nr);
+		if (entry == value_map.end()) {
+			// not used before, create vector
+			value_map[expr->parameter_nr] = vector<unique_ptr<Value>>();
+		} else if (entry->second.back()->type() != value->type()) {
+			// used before, but types are inconsistent
+			throw BinderException(
+			    "Inconsistent types found for parameter with index %llu, current type %s, new type %s",
+			    expr->parameter_nr, entry->second.back()->type().ToString(), value->type().ToString());
+		}
+		value_map[expr->parameter_nr].push_back(move(value));
+	}
+}
+
+shared_ptr<PreparedStatementData> Planner::PrepareSQLStatement(unique_ptr<SQLStatement> statement) {
+	auto copied_statement = statement->Copy();
+	// create a plan of the underlying statement
+	CreatePlan(move(statement));
+	// now create the logical prepare
+	auto prepared_data = make_shared<PreparedStatementData>(copied_statement->type);
+	prepared_data->unbound_statement = move(copied_statement);
+	prepared_data->names = names;
+	prepared_data->types = types;
+	prepared_data->value_map = move(value_map);
+	prepared_data->properties = properties;
+	prepared_data->catalog_version = Transaction::GetTransaction(context).catalog_version;
+	return prepared_data;
+}
+
+void Planner::PlanExecute(unique_ptr<SQLStatement> statement) {
+	auto &stmt = (ExecuteStatement &)*statement;
+	auto parameter_count = stmt.n_param;
+
+	// bind the prepared statement
+	auto &client_data = ClientData::Get(context);
+
+	auto entry = client_data.prepared_statements.find(stmt.name);
+	if (entry == client_data.prepared_statements.end()) {
+		throw BinderException("Prepared statement \"%s\" does not exist", stmt.name);
+	}
+
+	// check if we need to rebind the prepared statement
+	// this happens if the catalog changes, since in this case e.g. tables we relied on may have been deleted
+	auto prepared = entry->second;
+	auto &catalog = Catalog::GetCatalog(context);
+	bool rebound = false;
+
+	// bind any supplied parameters
+	vector<Value> bind_values;
+	for (idx_t i = 0; i < stmt.values.size(); i++) {
+		ConstantBinder cbinder(*binder, context, "EXECUTE statement");
+		auto bound_expr = cbinder.Bind(stmt.values[i]);
+
+		Value value = ExpressionExecutor::EvaluateScalar(*bound_expr);
+		bind_values.push_back(move(value));
+	}
+	bool all_bound = prepared->properties.bound_all_parameters;
+	if (catalog.GetCatalogVersion() != entry->second->catalog_version || !all_bound) {
+		// catalog was modified or statement does not have clear types: rebind the statement before running the execute
+		for (auto &value : bind_values) {
+			parameter_types.push_back(value.type());
+		}
+		prepared = PrepareSQLStatement(entry->second->unbound_statement->Copy());
+		if (all_bound && prepared->types != entry->second->types) {
+			throw BinderException("Rebinding statement \"%s\" after catalog change resulted in change of types",
+			                      stmt.name);
+		}
+		D_ASSERT(prepared->properties.bound_all_parameters);
+		rebound = true;
+	}
+	// copy the properties of the prepared statement into the planner
+	this->properties = prepared->properties;
+	this->properties.parameter_count = parameter_count;
+	this->names = prepared->names;
+	this->types = prepared->types;
+
+	// add casts to the prepared statement parameters as required
+	for (idx_t i = 0; i < bind_values.size(); i++) {
+		if (prepared->value_map.count(i + 1) == 0) {
+			continue;
+		}
+		bind_values[i] = bind_values[i].CastAs(prepared->GetType(i + 1));
+	}
+
+	prepared->Bind(move(bind_values));
+	if (rebound) {
+		auto execute_plan = make_unique<LogicalExecute>(move(prepared));
+		execute_plan->children.push_back(move(plan));
+		this->plan = move(execute_plan);
+		return;
+	}
+
+	this->plan = make_unique<LogicalExecute>(move(prepared));
+}
+
+void Planner::PlanPrepare(unique_ptr<SQLStatement> statement) {
+	auto &stmt = (PrepareStatement &)*statement;
+	auto prepared_data = PrepareSQLStatement(move(stmt.statement));
+
+	auto prepare = make_unique<LogicalPrepare>(stmt.name, move(prepared_data), move(plan));
+	// we can prepare in read-only mode: prepared statements are not written to the catalog
+	properties.read_only = true;
+	// we can always prepare, even if the transaction has been invalidated
+	// this is required because most clients ALWAYS invoke prepared statements
+	properties.requires_valid_transaction = false;
+	properties.allow_stream_result = false;
+	properties.bound_all_parameters = true;
+	properties.parameter_count = 0;
+	properties.return_type = StatementReturnType::NOTHING;
+	this->names = {"Success"};
+	this->types = {LogicalType::BOOLEAN};
+	this->plan = move(prepare);
+}
+
+void Planner::CreatePlan(unique_ptr<SQLStatement> statement) {
+	D_ASSERT(statement);
+	switch (statement->type) {
+	case StatementType::SELECT_STATEMENT:
+	case StatementType::INSERT_STATEMENT:
+	case StatementType::COPY_STATEMENT:
+	case StatementType::DELETE_STATEMENT:
+	case StatementType::UPDATE_STATEMENT:
+	case StatementType::CREATE_STATEMENT:
+	case StatementType::DROP_STATEMENT:
+	case StatementType::ALTER_STATEMENT:
+	case StatementType::TRANSACTION_STATEMENT:
+	case StatementType::EXPLAIN_STATEMENT:
+	case StatementType::VACUUM_STATEMENT:
+	case StatementType::RELATION_STATEMENT:
+	case StatementType::CALL_STATEMENT:
+	case StatementType::EXPORT_STATEMENT:
+	case StatementType::PRAGMA_STATEMENT:
+	case StatementType::SHOW_STATEMENT:
+	case StatementType::SET_STATEMENT:
+	case StatementType::LOAD_STATEMENT:
+		CreatePlan(*statement);
+		break;
+	case StatementType::EXECUTE_STATEMENT:
+		PlanExecute(move(statement));
+		break;
+	case StatementType::PREPARE_STATEMENT:
+		PlanPrepare(move(statement));
+		break;
+	default:
+		throw NotImplementedException("Cannot plan statement of type %s!", StatementTypeToString(statement->type));
+	}
+}
+
+} // namespace duckdb

--- a/velox/external/duckdb/duckdb-8.cpp
+++ b/velox/external/duckdb/duckdb-8.cpp
@@ -1,0 +1,15207 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+PragmaHandler::PragmaHandler(ClientContext &context) : context(context) {
+}
+
+void PragmaHandler::HandlePragmaStatementsInternal(vector<unique_ptr<SQLStatement>> &statements) {
+	vector<unique_ptr<SQLStatement>> new_statements;
+	for (idx_t i = 0; i < statements.size(); i++) {
+		if (statements[i]->type == StatementType::PRAGMA_STATEMENT) {
+			// PRAGMA statement: check if we need to replace it by a new set of statements
+			PragmaHandler handler(context);
+			auto new_query = handler.HandlePragma(statements[i].get()); //*((PragmaStatement &)*statements[i]).info
+			if (!new_query.empty()) {
+				// this PRAGMA statement gets replaced by a new query string
+				// push the new query string through the parser again and add it to the transformer
+				Parser parser(context.GetParserOptions());
+				parser.ParseQuery(new_query);
+				// insert the new statements and remove the old statement
+				// FIXME: off by one here maybe?
+				for (idx_t j = 0; j < parser.statements.size(); j++) {
+					new_statements.push_back(move(parser.statements[j]));
+				}
+				continue;
+			}
+		}
+		new_statements.push_back(move(statements[i]));
+	}
+	statements = move(new_statements);
+}
+
+void PragmaHandler::HandlePragmaStatements(ClientContextLock &lock, vector<unique_ptr<SQLStatement>> &statements) {
+	// first check if there are any pragma statements
+	bool found_pragma = false;
+	for (idx_t i = 0; i < statements.size(); i++) {
+		if (statements[i]->type == StatementType::PRAGMA_STATEMENT) {
+			found_pragma = true;
+			break;
+		}
+	}
+	if (!found_pragma) {
+		// no pragmas: skip this step
+		return;
+	}
+	context.RunFunctionInTransactionInternal(lock, [&]() { HandlePragmaStatementsInternal(statements); });
+}
+
+string PragmaHandler::HandlePragma(SQLStatement *statement) { // PragmaInfo &info
+	auto info = *((PragmaStatement &)*statement).info;
+	auto entry =
+	    Catalog::GetCatalog(context).GetEntry<PragmaFunctionCatalogEntry>(context, DEFAULT_SCHEMA, info.name, false);
+	string error;
+	idx_t bound_idx = Function::BindFunction(entry->name, entry->functions, info, error);
+	if (bound_idx == DConstants::INVALID_INDEX) {
+		throw BinderException(error);
+	}
+	auto &bound_function = entry->functions[bound_idx];
+	if (bound_function.query) {
+		QueryErrorContext error_context(statement, statement->stmt_location);
+		Binder::BindNamedParameters(bound_function.named_parameters, info.named_parameters, error_context,
+		                            bound_function.name);
+		FunctionParameters parameters {info.parameters, info.named_parameters};
+		return bound_function.query(context, parameters);
+	}
+	return string();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+FlattenDependentJoins::FlattenDependentJoins(Binder &binder, const vector<CorrelatedColumnInfo> &correlated,
+                                             bool any_join)
+    : binder(binder), correlated_columns(correlated), any_join(any_join) {
+	for (idx_t i = 0; i < correlated_columns.size(); i++) {
+		auto &col = correlated_columns[i];
+		correlated_map[col.binding] = i;
+		delim_types.push_back(col.type);
+	}
+}
+
+bool FlattenDependentJoins::DetectCorrelatedExpressions(LogicalOperator *op) {
+	D_ASSERT(op);
+	// check if this entry has correlated expressions
+	HasCorrelatedExpressions visitor(correlated_columns);
+	visitor.VisitOperator(*op);
+	bool has_correlation = visitor.has_correlated_expressions;
+	// now visit the children of this entry and check if they have correlated expressions
+	for (auto &child : op->children) {
+		// we OR the property with its children such that has_correlation is true if either
+		// (1) this node has a correlated expression or
+		// (2) one of its children has a correlated expression
+		if (DetectCorrelatedExpressions(child.get())) {
+			has_correlation = true;
+		}
+	}
+	// set the entry in the map
+	has_correlated_expressions[op] = has_correlation;
+	return has_correlation;
+}
+
+unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoin(unique_ptr<LogicalOperator> plan) {
+	bool propagate_null_values = true;
+	auto result = PushDownDependentJoinInternal(move(plan), propagate_null_values);
+	if (!replacement_map.empty()) {
+		// check if we have to replace any COUNT aggregates into "CASE WHEN X IS NULL THEN 0 ELSE COUNT END"
+		RewriteCountAggregates aggr(replacement_map);
+		aggr.VisitOperator(*result);
+	}
+	return result;
+}
+
+bool SubqueryDependentFilter(Expression *expr) {
+	if (expr->expression_class == ExpressionClass::BOUND_CONJUNCTION &&
+	    expr->GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
+		auto bound_conjuction = (BoundConjunctionExpression *)expr;
+		for (auto &child : bound_conjuction->children) {
+			if (SubqueryDependentFilter(child.get())) {
+				return true;
+			}
+		}
+	}
+	if (expr->expression_class == ExpressionClass::BOUND_SUBQUERY) {
+		return true;
+	}
+	return false;
+}
+unique_ptr<LogicalOperator> FlattenDependentJoins::PushDownDependentJoinInternal(unique_ptr<LogicalOperator> plan,
+                                                                                 bool &parent_propagate_null_values) {
+	// first check if the logical operator has correlated expressions
+	auto entry = has_correlated_expressions.find(plan.get());
+	D_ASSERT(entry != has_correlated_expressions.end());
+	if (!entry->second) {
+		// we reached a node without correlated expressions
+		// we can eliminate the dependent join now and create a simple cross product
+		auto cross_product = make_unique<LogicalCrossProduct>();
+		// now create the duplicate eliminated scan for this node
+		auto delim_index = binder.GenerateTableIndex();
+		this->base_binding = ColumnBinding(delim_index, 0);
+		auto delim_scan = make_unique<LogicalDelimGet>(delim_index, delim_types);
+		cross_product->children.push_back(move(delim_scan));
+		cross_product->children.push_back(move(plan));
+		return move(cross_product);
+	}
+	switch (plan->type) {
+	case LogicalOperatorType::LOGICAL_UNNEST:
+	case LogicalOperatorType::LOGICAL_FILTER: {
+		// filter
+		// first we flatten the dependent join in the child of the filter
+		for (auto &expr : plan->expressions) {
+			any_join |= SubqueryDependentFilter(expr.get());
+		}
+		plan->children[0] = PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+
+		// then we replace any correlated expressions with the corresponding entry in the correlated_map
+		RewriteCorrelatedExpressions rewriter(base_binding, correlated_map);
+		rewriter.VisitOperator(*plan);
+		return plan;
+	}
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		// projection
+		// first we flatten the dependent join in the child of the projection
+		for (auto &expr : plan->expressions) {
+			parent_propagate_null_values &= expr->PropagatesNullValues();
+		}
+		plan->children[0] = PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+
+		// then we replace any correlated expressions with the corresponding entry in the correlated_map
+		RewriteCorrelatedExpressions rewriter(base_binding, correlated_map);
+		rewriter.VisitOperator(*plan);
+		// now we add all the columns of the delim_scan to the projection list
+		auto proj = (LogicalProjection *)plan.get();
+		for (idx_t i = 0; i < correlated_columns.size(); i++) {
+			auto colref = make_unique<BoundColumnRefExpression>(
+			    correlated_columns[i].type, ColumnBinding(base_binding.table_index, base_binding.column_index + i));
+			plan->expressions.push_back(move(colref));
+		}
+
+		base_binding.table_index = proj->table_index;
+		this->delim_offset = base_binding.column_index = plan->expressions.size() - correlated_columns.size();
+		this->data_offset = 0;
+		return plan;
+	}
+	case LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY: {
+		auto &aggr = (LogicalAggregate &)*plan;
+		// aggregate and group by
+		// first we flatten the dependent join in the child of the projection
+		for (auto &expr : plan->expressions) {
+			parent_propagate_null_values &= expr->PropagatesNullValues();
+		}
+		plan->children[0] = PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+		// then we replace any correlated expressions with the corresponding entry in the correlated_map
+		RewriteCorrelatedExpressions rewriter(base_binding, correlated_map);
+		rewriter.VisitOperator(*plan);
+		// now we add all the columns of the delim_scan to the grouping operators AND the projection list
+		for (idx_t i = 0; i < correlated_columns.size(); i++) {
+			auto colref = make_unique<BoundColumnRefExpression>(
+			    correlated_columns[i].type, ColumnBinding(base_binding.table_index, base_binding.column_index + i));
+			for (auto &set : aggr.grouping_sets) {
+				set.insert(aggr.groups.size());
+			}
+			aggr.groups.push_back(move(colref));
+		}
+		if (aggr.groups.size() == correlated_columns.size()) {
+			// we have to perform a LEFT OUTER JOIN between the result of this aggregate and the delim scan
+			// FIXME: this does not always have to be a LEFT OUTER JOIN, depending on whether aggr.expressions return
+			// NULL or a value
+			unique_ptr<LogicalComparisonJoin> join = make_unique<LogicalComparisonJoin>(JoinType::INNER);
+			for (auto &aggr_exp : aggr.expressions) {
+				auto b_aggr_exp = (BoundAggregateExpression *)aggr_exp.get();
+				if (!b_aggr_exp->PropagatesNullValues() || any_join || !parent_propagate_null_values) {
+					join = make_unique<LogicalComparisonJoin>(JoinType::LEFT);
+					break;
+				}
+			}
+			auto left_index = binder.GenerateTableIndex();
+			auto delim_scan = make_unique<LogicalDelimGet>(left_index, delim_types);
+			join->children.push_back(move(delim_scan));
+			join->children.push_back(move(plan));
+			for (idx_t i = 0; i < correlated_columns.size(); i++) {
+				JoinCondition cond;
+				cond.left =
+				    make_unique<BoundColumnRefExpression>(correlated_columns[i].type, ColumnBinding(left_index, i));
+				cond.right = make_unique<BoundColumnRefExpression>(
+				    correlated_columns[i].type,
+				    ColumnBinding(aggr.group_index, (aggr.groups.size() - correlated_columns.size()) + i));
+				cond.comparison = ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+				join->conditions.push_back(move(cond));
+			}
+			// for any COUNT aggregate we replace references to the column with: CASE WHEN COUNT(*) IS NULL THEN 0
+			// ELSE COUNT(*) END
+			for (idx_t i = 0; i < aggr.expressions.size(); i++) {
+				D_ASSERT(aggr.expressions[i]->GetExpressionClass() == ExpressionClass::BOUND_AGGREGATE);
+				auto bound = (BoundAggregateExpression *)&*aggr.expressions[i];
+				vector<LogicalType> arguments;
+				if (bound->function == CountFun::GetFunction() || bound->function == CountStarFun::GetFunction()) {
+					// have to replace this ColumnBinding with the CASE expression
+					replacement_map[ColumnBinding(aggr.aggregate_index, i)] = i;
+				}
+			}
+			// now we update the delim_index
+
+			base_binding.table_index = left_index;
+			this->delim_offset = base_binding.column_index = 0;
+			this->data_offset = 0;
+			return move(join);
+		} else {
+			// update the delim_index
+			base_binding.table_index = aggr.group_index;
+			this->delim_offset = base_binding.column_index = aggr.groups.size() - correlated_columns.size();
+			this->data_offset = aggr.groups.size();
+			return plan;
+		}
+	}
+	case LogicalOperatorType::LOGICAL_CROSS_PRODUCT: {
+		// cross product
+		// push into both sides of the plan
+		bool left_has_correlation = has_correlated_expressions.find(plan->children[0].get())->second;
+		bool right_has_correlation = has_correlated_expressions.find(plan->children[1].get())->second;
+		if (!right_has_correlation) {
+			// only left has correlation: push into left
+			plan->children[0] = PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+			return plan;
+		}
+		if (!left_has_correlation) {
+			// only right has correlation: push into right
+			plan->children[1] = PushDownDependentJoinInternal(move(plan->children[1]), parent_propagate_null_values);
+			return plan;
+		}
+		// both sides have correlation
+		// turn into an inner join
+		auto join = make_unique<LogicalComparisonJoin>(JoinType::INNER);
+		plan->children[0] = PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+		auto left_binding = this->base_binding;
+		plan->children[1] = PushDownDependentJoinInternal(move(plan->children[1]), parent_propagate_null_values);
+		// add the correlated columns to the join conditions
+		for (idx_t i = 0; i < correlated_columns.size(); i++) {
+			JoinCondition cond;
+			cond.left = make_unique<BoundColumnRefExpression>(
+			    correlated_columns[i].type, ColumnBinding(left_binding.table_index, left_binding.column_index + i));
+			cond.right = make_unique<BoundColumnRefExpression>(
+			    correlated_columns[i].type, ColumnBinding(base_binding.table_index, base_binding.column_index + i));
+			cond.comparison = ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+			join->conditions.push_back(move(cond));
+		}
+		join->children.push_back(move(plan->children[0]));
+		join->children.push_back(move(plan->children[1]));
+		return move(join);
+	}
+	case LogicalOperatorType::LOGICAL_ANY_JOIN:
+	case LogicalOperatorType::LOGICAL_COMPARISON_JOIN: {
+		auto &join = (LogicalJoin &)*plan;
+		D_ASSERT(plan->children.size() == 2);
+		// check the correlated expressions in the children of the join
+		bool left_has_correlation = has_correlated_expressions.find(plan->children[0].get())->second;
+		bool right_has_correlation = has_correlated_expressions.find(plan->children[1].get())->second;
+
+		if (join.join_type == JoinType::INNER) {
+			// inner join
+			if (!right_has_correlation) {
+				// only left has correlation: push into left
+				plan->children[0] =
+				    PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+				return plan;
+			}
+			if (!left_has_correlation) {
+				// only right has correlation: push into right
+				plan->children[1] =
+				    PushDownDependentJoinInternal(move(plan->children[1]), parent_propagate_null_values);
+				return plan;
+			}
+		} else if (join.join_type == JoinType::LEFT) {
+			// left outer join
+			if (!right_has_correlation) {
+				// only left has correlation: push into left
+				plan->children[0] =
+				    PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+				return plan;
+			}
+		} else if (join.join_type == JoinType::RIGHT) {
+			// left outer join
+			if (!left_has_correlation) {
+				// only right has correlation: push into right
+				plan->children[1] =
+				    PushDownDependentJoinInternal(move(plan->children[1]), parent_propagate_null_values);
+				return plan;
+			}
+		} else if (join.join_type == JoinType::MARK) {
+			if (right_has_correlation) {
+				throw Exception("MARK join with correlation in RHS not supported");
+			}
+			// push the child into the LHS
+			plan->children[0] = PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+			// rewrite expressions in the join conditions
+			RewriteCorrelatedExpressions rewriter(base_binding, correlated_map);
+			rewriter.VisitOperator(*plan);
+			return plan;
+		} else {
+			throw Exception("Unsupported join type for flattening correlated subquery");
+		}
+		// both sides have correlation
+		// push into both sides
+		plan->children[0] = PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+		auto left_binding = this->base_binding;
+		plan->children[1] = PushDownDependentJoinInternal(move(plan->children[1]), parent_propagate_null_values);
+		auto right_binding = this->base_binding;
+		// NOTE: for OUTER JOINS it matters what the BASE BINDING is after the join
+		// for the LEFT OUTER JOIN, we want the LEFT side to be the base binding after we push
+		// because the RIGHT binding might contain NULL values
+		if (join.join_type == JoinType::LEFT) {
+			this->base_binding = left_binding;
+		} else if (join.join_type == JoinType::RIGHT) {
+			this->base_binding = right_binding;
+		}
+		// add the correlated columns to the join conditions
+		for (idx_t i = 0; i < correlated_columns.size(); i++) {
+			auto left = make_unique<BoundColumnRefExpression>(
+			    correlated_columns[i].type, ColumnBinding(left_binding.table_index, left_binding.column_index + i));
+			auto right = make_unique<BoundColumnRefExpression>(
+			    correlated_columns[i].type, ColumnBinding(right_binding.table_index, right_binding.column_index + i));
+
+			if (join.type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN) {
+				JoinCondition cond;
+				cond.left = move(left);
+				cond.right = move(right);
+				cond.comparison = ExpressionType::COMPARE_NOT_DISTINCT_FROM;
+
+				auto &comparison_join = (LogicalComparisonJoin &)join;
+				comparison_join.conditions.push_back(move(cond));
+			} else {
+				auto &any_join = (LogicalAnyJoin &)join;
+				auto comparison = make_unique<BoundComparisonExpression>(ExpressionType::COMPARE_NOT_DISTINCT_FROM,
+				                                                         move(left), move(right));
+				auto conjunction = make_unique<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND,
+				                                                           move(comparison), move(any_join.condition));
+				any_join.condition = move(conjunction);
+			}
+		}
+		// then we replace any correlated expressions with the corresponding entry in the correlated_map
+		RewriteCorrelatedExpressions rewriter(right_binding, correlated_map);
+		rewriter.VisitOperator(*plan);
+		return plan;
+	}
+	case LogicalOperatorType::LOGICAL_LIMIT: {
+		auto &limit = (LogicalLimit &)*plan;
+		if (limit.offset_val > 0) {
+			throw ParserException("OFFSET not supported in correlated subquery");
+		}
+		if (limit.limit) {
+			throw ParserException("Non-constant limit not supported in correlated subquery");
+		}
+		plan->children[0] = PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+		if (limit.limit_val == 0) {
+			// limit = 0 means we return zero columns here
+			return plan;
+		} else {
+			// limit > 0 does nothing
+			return move(plan->children[0]);
+		}
+	}
+	case LogicalOperatorType::LOGICAL_LIMIT_PERCENT: {
+		throw ParserException("Limit percent operator not supported in correlated subquery");
+	}
+	case LogicalOperatorType::LOGICAL_WINDOW: {
+		auto &window = (LogicalWindow &)*plan;
+		// push into children
+		plan->children[0] = PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+		// add the correlated columns to the PARTITION BY clauses in the Window
+		for (auto &expr : window.expressions) {
+			D_ASSERT(expr->GetExpressionClass() == ExpressionClass::BOUND_WINDOW);
+			auto &w = (BoundWindowExpression &)*expr;
+			for (idx_t i = 0; i < correlated_columns.size(); i++) {
+				w.partitions.push_back(make_unique<BoundColumnRefExpression>(
+				    correlated_columns[i].type,
+				    ColumnBinding(base_binding.table_index, base_binding.column_index + i)));
+			}
+		}
+		return plan;
+	}
+	case LogicalOperatorType::LOGICAL_EXCEPT:
+	case LogicalOperatorType::LOGICAL_INTERSECT:
+	case LogicalOperatorType::LOGICAL_UNION: {
+		auto &setop = (LogicalSetOperation &)*plan;
+		// set operator, push into both children
+		plan->children[0] = PushDownDependentJoin(move(plan->children[0]));
+		plan->children[1] = PushDownDependentJoin(move(plan->children[1]));
+		// we have to refer to the setop index now
+		base_binding.table_index = setop.table_index;
+		base_binding.column_index = setop.column_count;
+		setop.column_count += correlated_columns.size();
+		return plan;
+	}
+	case LogicalOperatorType::LOGICAL_DISTINCT:
+		plan->children[0] = PushDownDependentJoin(move(plan->children[0]));
+		return plan;
+	case LogicalOperatorType::LOGICAL_EXPRESSION_GET: {
+		// expression get
+		// first we flatten the dependent join in the child
+		plan->children[0] = PushDownDependentJoinInternal(move(plan->children[0]), parent_propagate_null_values);
+		// then we replace any correlated expressions with the corresponding entry in the correlated_map
+		RewriteCorrelatedExpressions rewriter(base_binding, correlated_map);
+		rewriter.VisitOperator(*plan);
+		// now we add all the correlated columns to each of the expressions of the expression scan
+		auto expr_get = (LogicalExpressionGet *)plan.get();
+		for (idx_t i = 0; i < correlated_columns.size(); i++) {
+			for (auto &expr_list : expr_get->expressions) {
+				auto colref = make_unique<BoundColumnRefExpression>(
+				    correlated_columns[i].type, ColumnBinding(base_binding.table_index, base_binding.column_index + i));
+				expr_list.push_back(move(colref));
+			}
+			expr_get->expr_types.push_back(correlated_columns[i].type);
+		}
+
+		base_binding.table_index = expr_get->table_index;
+		this->delim_offset = base_binding.column_index = expr_get->expr_types.size() - correlated_columns.size();
+		this->data_offset = 0;
+		return plan;
+	}
+	case LogicalOperatorType::LOGICAL_ORDER_BY:
+		throw ParserException("ORDER BY not supported in correlated subquery");
+	default:
+		throw InternalException("Logical operator type \"%s\" for dependent join", LogicalOperatorToString(plan->type));
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+#include <algorithm>
+
+namespace duckdb {
+
+HasCorrelatedExpressions::HasCorrelatedExpressions(const vector<CorrelatedColumnInfo> &correlated)
+    : has_correlated_expressions(false), correlated_columns(correlated) {
+}
+
+void HasCorrelatedExpressions::VisitOperator(LogicalOperator &op) {
+	//! The HasCorrelatedExpressions does not recursively visit logical operators, it only visits the current one
+	VisitOperatorExpressions(op);
+}
+
+unique_ptr<Expression> HasCorrelatedExpressions::VisitReplace(BoundColumnRefExpression &expr,
+                                                              unique_ptr<Expression> *expr_ptr) {
+	if (expr.depth == 0) {
+		return nullptr;
+	}
+	// correlated column reference
+	D_ASSERT(expr.depth == 1);
+	has_correlated_expressions = true;
+	return nullptr;
+}
+
+unique_ptr<Expression> HasCorrelatedExpressions::VisitReplace(BoundSubqueryExpression &expr,
+                                                              unique_ptr<Expression> *expr_ptr) {
+	if (!expr.IsCorrelated()) {
+		return nullptr;
+	}
+	// check if the subquery contains any of the correlated expressions that we are concerned about in this node
+	for (idx_t i = 0; i < correlated_columns.size(); i++) {
+		if (std::find(expr.binder->correlated_columns.begin(), expr.binder->correlated_columns.end(),
+		              correlated_columns[i]) != expr.binder->correlated_columns.end()) {
+			has_correlated_expressions = true;
+			break;
+		}
+	}
+	return nullptr;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+RewriteCorrelatedExpressions::RewriteCorrelatedExpressions(ColumnBinding base_binding,
+                                                           column_binding_map_t<idx_t> &correlated_map)
+    : base_binding(base_binding), correlated_map(correlated_map) {
+}
+
+void RewriteCorrelatedExpressions::VisitOperator(LogicalOperator &op) {
+	VisitOperatorExpressions(op);
+}
+
+unique_ptr<Expression> RewriteCorrelatedExpressions::VisitReplace(BoundColumnRefExpression &expr,
+                                                                  unique_ptr<Expression> *expr_ptr) {
+	if (expr.depth == 0) {
+		return nullptr;
+	}
+	// correlated column reference
+	// replace with the entry referring to the duplicate eliminated scan
+	// if this assertion occurs it generally means the correlated expressions were not propagated correctly
+	// through different binders
+	D_ASSERT(expr.depth == 1);
+	auto entry = correlated_map.find(expr.binding);
+	D_ASSERT(entry != correlated_map.end());
+
+	expr.binding = ColumnBinding(base_binding.table_index, base_binding.column_index + entry->second);
+	expr.depth = 0;
+	return nullptr;
+}
+
+unique_ptr<Expression> RewriteCorrelatedExpressions::VisitReplace(BoundSubqueryExpression &expr,
+                                                                  unique_ptr<Expression> *expr_ptr) {
+	if (!expr.IsCorrelated()) {
+		return nullptr;
+	}
+	// subquery detected within this subquery
+	// recursively rewrite it using the RewriteCorrelatedRecursive class
+	RewriteCorrelatedRecursive rewrite(expr, base_binding, correlated_map);
+	rewrite.RewriteCorrelatedSubquery(expr);
+	return nullptr;
+}
+
+RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteCorrelatedRecursive(
+    BoundSubqueryExpression &parent, ColumnBinding base_binding, column_binding_map_t<idx_t> &correlated_map)
+    : parent(parent), base_binding(base_binding), correlated_map(correlated_map) {
+}
+
+void RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteCorrelatedSubquery(
+    BoundSubqueryExpression &expr) {
+	// rewrite the binding in the correlated list of the subquery)
+	for (auto &corr : expr.binder->correlated_columns) {
+		auto entry = correlated_map.find(corr.binding);
+		if (entry != correlated_map.end()) {
+			corr.binding = ColumnBinding(base_binding.table_index, base_binding.column_index + entry->second);
+		}
+	}
+	// now rewrite any correlated BoundColumnRef expressions inside the subquery
+	ExpressionIterator::EnumerateQueryNodeChildren(*expr.subquery,
+	                                               [&](Expression &child) { RewriteCorrelatedExpressions(child); });
+}
+
+void RewriteCorrelatedExpressions::RewriteCorrelatedRecursive::RewriteCorrelatedExpressions(Expression &child) {
+	if (child.type == ExpressionType::BOUND_COLUMN_REF) {
+		// bound column reference
+		auto &bound_colref = (BoundColumnRefExpression &)child;
+		if (bound_colref.depth == 0) {
+			// not a correlated column, ignore
+			return;
+		}
+		// correlated column
+		// check the correlated map
+		auto entry = correlated_map.find(bound_colref.binding);
+		if (entry != correlated_map.end()) {
+			// we found the column in the correlated map!
+			// update the binding and reduce the depth by 1
+			bound_colref.binding = ColumnBinding(base_binding.table_index, base_binding.column_index + entry->second);
+			bound_colref.depth--;
+		}
+	} else if (child.type == ExpressionType::SUBQUERY) {
+		// we encountered another subquery: rewrite recursively
+		D_ASSERT(child.GetExpressionClass() == ExpressionClass::BOUND_SUBQUERY);
+		auto &bound_subquery = (BoundSubqueryExpression &)child;
+		RewriteCorrelatedRecursive rewrite(bound_subquery, base_binding, correlated_map);
+		rewrite.RewriteCorrelatedSubquery(bound_subquery);
+	}
+}
+
+RewriteCountAggregates::RewriteCountAggregates(column_binding_map_t<idx_t> &replacement_map)
+    : replacement_map(replacement_map) {
+}
+
+unique_ptr<Expression> RewriteCountAggregates::VisitReplace(BoundColumnRefExpression &expr,
+                                                            unique_ptr<Expression> *expr_ptr) {
+	auto entry = replacement_map.find(expr.binding);
+	if (entry != replacement_map.end()) {
+		// reference to a COUNT(*) aggregate
+		// replace this with CASE WHEN COUNT(*) IS NULL THEN 0 ELSE COUNT(*) END
+		auto is_null = make_unique<BoundOperatorExpression>(ExpressionType::OPERATOR_IS_NULL, LogicalType::BOOLEAN);
+		is_null->children.push_back(expr.Copy());
+		auto check = move(is_null);
+		auto result_if_true = make_unique<BoundConstantExpression>(Value::Numeric(expr.return_type, 0));
+		auto result_if_false = move(*expr_ptr);
+		return make_unique<BoundCaseExpression>(move(check), move(result_if_true), move(result_if_false));
+	}
+	return nullptr;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+Binding::Binding(BindingType binding_type, const string &alias, vector<LogicalType> coltypes, vector<string> colnames,
+                 idx_t index)
+    : binding_type(binding_type), alias(alias), index(index), types(move(coltypes)), names(move(colnames)) {
+	D_ASSERT(types.size() == names.size());
+	for (idx_t i = 0; i < names.size(); i++) {
+		auto &name = names[i];
+		D_ASSERT(!name.empty());
+		if (name_map.find(name) != name_map.end()) {
+			throw BinderException("table \"%s\" has duplicate column name \"%s\"", alias, name);
+		}
+		name_map[name] = i;
+	}
+}
+
+bool Binding::TryGetBindingIndex(const string &column_name, column_t &result) {
+	auto entry = name_map.find(column_name);
+	if (entry == name_map.end()) {
+		return false;
+	}
+	auto column_info = entry->second;
+	result = column_info;
+	return true;
+}
+
+column_t Binding::GetBindingIndex(const string &column_name) {
+	column_t result;
+	if (!TryGetBindingIndex(column_name, result)) {
+		throw InternalException("Binding index for column \"%s\" not found", column_name);
+	}
+	return result;
+}
+
+bool Binding::HasMatchingBinding(const string &column_name) {
+	column_t result;
+	return TryGetBindingIndex(column_name, result);
+}
+
+string Binding::ColumnNotFoundError(const string &column_name) const {
+	return StringUtil::Format("Values list \"%s\" does not have a column named \"%s\"", alias, column_name);
+}
+
+BindResult Binding::Bind(ColumnRefExpression &colref, idx_t depth) {
+	column_t column_index;
+	bool success = false;
+	success = TryGetBindingIndex(colref.GetColumnName(), column_index);
+	if (!success) {
+		return BindResult(ColumnNotFoundError(colref.GetColumnName()));
+	}
+	ColumnBinding binding;
+	binding.table_index = index;
+	binding.column_index = column_index;
+	LogicalType sql_type = types[column_index];
+	if (colref.alias.empty()) {
+		colref.alias = names[column_index];
+	}
+	return BindResult(make_unique<BoundColumnRefExpression>(colref.GetName(), sql_type, binding, depth));
+}
+
+StandardEntry *Binding::GetStandardEntry() {
+	return nullptr;
+}
+
+EntryBinding::EntryBinding(const string &alias, vector<LogicalType> types_p, vector<string> names_p, idx_t index,
+                           StandardEntry &entry)
+    : Binding(BindingType::CATALOG_ENTRY, alias, move(types_p), move(names_p), index), entry(entry) {
+}
+
+StandardEntry *EntryBinding::GetStandardEntry() {
+	return &this->entry;
+}
+
+TableBinding::TableBinding(const string &alias, vector<LogicalType> types_p, vector<string> names_p, LogicalGet &get,
+                           idx_t index, bool add_row_id)
+    : Binding(BindingType::TABLE, alias, move(types_p), move(names_p), index), get(get) {
+	if (add_row_id) {
+		if (name_map.find("rowid") == name_map.end()) {
+			name_map["rowid"] = COLUMN_IDENTIFIER_ROW_ID;
+		}
+	}
+}
+
+static void BakeTableName(ParsedExpression &expr, const string &table_name) {
+	if (expr.type == ExpressionType::COLUMN_REF) {
+		auto &colref = (ColumnRefExpression &)expr;
+		D_ASSERT(!colref.IsQualified());
+		auto &col_names = colref.column_names;
+		col_names.insert(col_names.begin(), table_name);
+	}
+	ParsedExpressionIterator::EnumerateChildren(
+	    expr, [&](const ParsedExpression &child) { BakeTableName((ParsedExpression &)child, table_name); });
+}
+
+unique_ptr<ParsedExpression> TableBinding::ExpandGeneratedColumn(const string &column_name) {
+	auto catalog_entry = GetStandardEntry();
+	D_ASSERT(catalog_entry); // Should only be called on a TableBinding
+
+	D_ASSERT(catalog_entry->type == CatalogType::TABLE_ENTRY);
+	auto table_entry = (TableCatalogEntry *)catalog_entry;
+
+	// Get the index of the generated column
+	auto column_index = GetBindingIndex(column_name);
+	D_ASSERT(table_entry->columns[column_index].Generated());
+	// Get a copy of the generated column
+	auto expression = table_entry->columns[column_index].GeneratedExpression().Copy();
+	BakeTableName(*expression, alias);
+	return (expression);
+}
+
+BindResult TableBinding::Bind(ColumnRefExpression &colref, idx_t depth) {
+	auto &column_name = colref.GetColumnName();
+	column_t column_index;
+	bool success = false;
+	success = TryGetBindingIndex(column_name, column_index);
+	if (!success) {
+		return BindResult(ColumnNotFoundError(column_name));
+	}
+#ifdef DEBUG
+	auto entry = GetStandardEntry();
+	if (entry) {
+		D_ASSERT(entry->type == CatalogType::TABLE_ENTRY);
+		auto table_entry = (TableCatalogEntry *)entry;
+		//! Either there is no table, or the columns category has to be standard
+		if (column_index != COLUMN_IDENTIFIER_ROW_ID) {
+			D_ASSERT(table_entry->columns[column_index].Category() == TableColumnType::STANDARD);
+		}
+	}
+#endif /* DEBUG */
+	// fetch the type of the column
+	LogicalType col_type;
+	if (column_index == COLUMN_IDENTIFIER_ROW_ID) {
+		// row id: BIGINT type
+		col_type = LogicalType::BIGINT;
+	} else {
+		// normal column: fetch type from base column
+		col_type = types[column_index];
+		if (colref.alias.empty()) {
+			colref.alias = names[column_index];
+		}
+	}
+
+	auto &column_ids = get.column_ids;
+	// check if the entry already exists in the column list for the table
+	ColumnBinding binding;
+
+	binding.column_index = column_ids.size();
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		if (column_ids[i] == column_index) {
+			binding.column_index = i;
+			break;
+		}
+	}
+	if (binding.column_index == column_ids.size()) {
+		// column binding not found: add it to the list of bindings
+		column_ids.push_back(column_index);
+	}
+	binding.table_index = index;
+	return BindResult(make_unique<BoundColumnRefExpression>(colref.GetName(), col_type, binding, depth));
+}
+
+StandardEntry *TableBinding::GetStandardEntry() {
+	return get.GetTable();
+}
+
+string TableBinding::ColumnNotFoundError(const string &column_name) const {
+	return StringUtil::Format("Table \"%s\" does not have a column named \"%s\"", alias, column_name);
+}
+
+MacroBinding::MacroBinding(vector<LogicalType> types_p, vector<string> names_p, string macro_name_p)
+    : Binding(BindingType::MACRO, MacroBinding::MACRO_NAME, move(types_p), move(names_p), -1),
+      macro_name(move(macro_name_p)) {
+}
+
+BindResult MacroBinding::Bind(ColumnRefExpression &colref, idx_t depth) {
+	column_t column_index;
+	if (!TryGetBindingIndex(colref.GetColumnName(), column_index)) {
+		throw InternalException("Column %s not found in macro", colref.GetColumnName());
+	}
+	ColumnBinding binding;
+	binding.table_index = index;
+	binding.column_index = column_index;
+
+	// we are binding a parameter to create the macro, no arguments are supplied
+	return BindResult(make_unique<BoundColumnRefExpression>(colref.GetName(), types[column_index], binding, depth));
+}
+
+unique_ptr<ParsedExpression> MacroBinding::ParamToArg(ColumnRefExpression &colref) {
+	column_t column_index;
+	if (!TryGetBindingIndex(colref.GetColumnName(), column_index)) {
+		throw InternalException("Column %s not found in macro", colref.GetColumnName());
+	}
+	auto arg = arguments[column_index]->Copy();
+	arg->alias = colref.alias;
+	return arg;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+void TableFilterSet::PushFilter(idx_t column_index, unique_ptr<TableFilter> filter) {
+	auto entry = filters.find(column_index);
+	if (entry == filters.end()) {
+		// no filter yet: push the filter directly
+		filters[column_index] = move(filter);
+	} else {
+		// there is already a filter: AND it together
+		if (entry->second->filter_type == TableFilterType::CONJUNCTION_AND) {
+			auto &and_filter = (ConjunctionAndFilter &)*entry->second;
+			and_filter.child_filters.push_back(move(filter));
+		} else {
+			auto and_filter = make_unique<ConjunctionAndFilter>();
+			and_filter->child_filters.push_back(move(entry->second));
+			and_filter->child_filters.push_back(move(filter));
+			filters[column_index] = move(and_filter);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+Block::Block(Allocator &allocator, block_id_t id)
+    : FileBuffer(allocator, FileBufferType::BLOCK, Storage::BLOCK_ALLOC_SIZE), id(id) {
+}
+
+Block::Block(FileBuffer &source, block_id_t id) : FileBuffer(source, FileBufferType::BLOCK), id(id) {
+	D_ASSERT(GetMallocedSize() == Storage::BLOCK_ALLOC_SIZE);
+	D_ASSERT(size == Storage::BLOCK_SIZE);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+BufferHandle::BufferHandle(shared_ptr<BlockHandle> handle, FileBuffer *node) : handle(move(handle)), node(node) {
+}
+
+BufferHandle::~BufferHandle() {
+	auto &buffer_manager = BufferManager::GetBufferManager(handle->db);
+	buffer_manager.Unpin(handle);
+}
+
+data_ptr_t BufferHandle::Ptr() {
+	return node->buffer;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+ManagedBuffer::ManagedBuffer(DatabaseInstance &db, idx_t size, bool can_destroy, block_id_t id)
+    : FileBuffer(Allocator::Get(db), FileBufferType::MANAGED_BUFFER, size), db(db), can_destroy(can_destroy), id(id) {
+	D_ASSERT(id >= MAXIMUM_BLOCK);
+	D_ASSERT(size >= Storage::BLOCK_SIZE);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+BlockHandle::BlockHandle(DatabaseInstance &db, block_id_t block_id_p)
+    : db(db), readers(0), block_id(block_id_p), buffer(nullptr), eviction_timestamp(0), can_destroy(false) {
+	eviction_timestamp = 0;
+	state = BlockState::BLOCK_UNLOADED;
+	memory_usage = Storage::BLOCK_ALLOC_SIZE;
+}
+
+BlockHandle::BlockHandle(DatabaseInstance &db, block_id_t block_id_p, unique_ptr<FileBuffer> buffer_p,
+                         bool can_destroy_p, idx_t block_size)
+    : db(db), readers(0), block_id(block_id_p), eviction_timestamp(0), can_destroy(can_destroy_p) {
+	D_ASSERT(block_size >= Storage::BLOCK_SIZE);
+	buffer = move(buffer_p);
+	state = BlockState::BLOCK_LOADED;
+	memory_usage = block_size + Storage::BLOCK_HEADER_SIZE;
+}
+
+BlockHandle::~BlockHandle() {
+	auto &buffer_manager = BufferManager::GetBufferManager(db);
+	// no references remain to this block: erase
+	if (state == BlockState::BLOCK_LOADED) {
+		// the block is still loaded in memory: erase it
+		buffer.reset();
+		buffer_manager.current_memory -= memory_usage;
+	}
+	buffer_manager.UnregisterBlock(block_id, can_destroy);
+}
+
+unique_ptr<BufferHandle> BlockHandle::Load(shared_ptr<BlockHandle> &handle) {
+	if (handle->state == BlockState::BLOCK_LOADED) {
+		// already loaded
+		D_ASSERT(handle->buffer);
+		return make_unique<BufferHandle>(handle, handle->buffer.get());
+	}
+
+	auto &buffer_manager = BufferManager::GetBufferManager(handle->db);
+	auto &block_manager = BlockManager::GetBlockManager(handle->db);
+	if (handle->block_id < MAXIMUM_BLOCK) {
+		auto block = make_unique<Block>(Allocator::Get(handle->db), handle->block_id);
+		block_manager.Read(*block);
+		handle->buffer = move(block);
+	} else {
+		if (handle->can_destroy) {
+			return nullptr;
+		} else {
+			handle->buffer = buffer_manager.ReadTemporaryBuffer(handle->block_id);
+		}
+	}
+	handle->state = BlockState::BLOCK_LOADED;
+	return make_unique<BufferHandle>(handle, handle->buffer.get());
+}
+
+void BlockHandle::Unload() {
+	auto &buffer_manager = BufferManager::GetBufferManager(db);
+	if (state == BlockState::BLOCK_UNLOADED) {
+		// already unloaded: nothing to do
+		return;
+	}
+	D_ASSERT(CanUnload());
+	D_ASSERT(memory_usage >= Storage::BLOCK_ALLOC_SIZE);
+
+	if (block_id >= MAXIMUM_BLOCK && !can_destroy) {
+		// temporary block that cannot be destroyed: write to temporary file
+		buffer_manager.WriteTemporaryBuffer((ManagedBuffer &)*buffer);
+	}
+	buffer.reset();
+	buffer_manager.current_memory -= memory_usage;
+	state = BlockState::BLOCK_UNLOADED;
+}
+
+bool BlockHandle::CanUnload() {
+	if (state == BlockState::BLOCK_UNLOADED) {
+		// already unloaded
+		return false;
+	}
+	if (readers > 0) {
+		// there are active readers
+		return false;
+	}
+	auto &buffer_manager = BufferManager::GetBufferManager(db);
+	if (block_id >= MAXIMUM_BLOCK && !can_destroy && buffer_manager.temp_directory.empty()) {
+		// in order to unload this block we need to write it to a temporary buffer
+		// however, no temporary directory is specified!
+		// hence we cannot unload the block
+		return false;
+	}
+	return true;
+}
+
+struct BufferEvictionNode {
+	BufferEvictionNode(weak_ptr<BlockHandle> handle_p, idx_t timestamp_p)
+	    : handle(move(handle_p)), timestamp(timestamp_p) {
+		D_ASSERT(!handle.expired());
+	}
+
+	weak_ptr<BlockHandle> handle;
+	idx_t timestamp;
+
+	bool CanUnload(BlockHandle &handle_p) {
+		if (timestamp != handle_p.eviction_timestamp) {
+			// handle was used in between
+			return false;
+		}
+		return handle_p.CanUnload();
+	}
+
+	shared_ptr<BlockHandle> TryGetBlockHandle() {
+		auto handle_p = handle.lock();
+		if (!handle_p) {
+			// BlockHandle has been destroyed
+			return nullptr;
+		}
+		if (!CanUnload(*handle_p)) {
+			// handle was used in between
+			return nullptr;
+		}
+		// this is the latest node in the queue with this handle
+		return handle_p;
+	}
+};
+
+typedef duckdb_moodycamel::ConcurrentQueue<unique_ptr<BufferEvictionNode>> eviction_queue_t;
+
+struct EvictionQueue {
+	eviction_queue_t q;
+};
+
+class TemporaryDirectoryHandle {
+public:
+	TemporaryDirectoryHandle(DatabaseInstance &db, string path_p) : db(db), temp_directory(move(path_p)) {
+		auto &fs = FileSystem::GetFileSystem(db);
+		if (!temp_directory.empty()) {
+			fs.CreateDirectory(temp_directory);
+		}
+	}
+	~TemporaryDirectoryHandle() {
+		auto &fs = FileSystem::GetFileSystem(db);
+		if (!temp_directory.empty()) {
+			fs.RemoveDirectory(temp_directory);
+		}
+	}
+
+private:
+	DatabaseInstance &db;
+	string temp_directory;
+};
+
+void BufferManager::SetTemporaryDirectory(string new_dir) {
+	if (temp_directory_handle) {
+		throw NotImplementedException("Cannot switch temporary directory after the current one has been used");
+	}
+	this->temp_directory = move(new_dir);
+}
+
+BufferManager::BufferManager(DatabaseInstance &db, string tmp, idx_t maximum_memory)
+    : db(db), current_memory(0), maximum_memory(maximum_memory), temp_directory(move(tmp)),
+      queue(make_unique<EvictionQueue>()), temporary_id(MAXIMUM_BLOCK) {
+}
+
+BufferManager::~BufferManager() {
+}
+
+shared_ptr<BlockHandle> BufferManager::RegisterBlock(block_id_t block_id) {
+	lock_guard<mutex> lock(blocks_lock);
+	// check if the block already exists
+	auto entry = blocks.find(block_id);
+	if (entry != blocks.end()) {
+		// already exists: check if it hasn't expired yet
+		auto existing_ptr = entry->second.lock();
+		if (existing_ptr) {
+			//! it hasn't! return it
+			return existing_ptr;
+		}
+	}
+	// create a new block pointer for this block
+	auto result = make_shared<BlockHandle>(db, block_id);
+	// register the block pointer in the set of blocks as a weak pointer
+	blocks[block_id] = weak_ptr<BlockHandle>(result);
+	return result;
+}
+
+shared_ptr<BlockHandle> BufferManager::ConvertToPersistent(BlockManager &block_manager, block_id_t block_id,
+                                                           shared_ptr<BlockHandle> old_block) {
+
+	// pin the old block to ensure we have it loaded in memory
+	auto old_handle = Pin(old_block);
+	D_ASSERT(old_block->state == BlockState::BLOCK_LOADED);
+	D_ASSERT(old_block->buffer);
+
+	// register a block with the new block id
+	auto new_block = RegisterBlock(block_id);
+	D_ASSERT(new_block->state == BlockState::BLOCK_UNLOADED);
+	D_ASSERT(new_block->readers == 0);
+
+#ifdef DEBUG
+	lock_guard<mutex> b_lock(blocks_lock);
+#endif
+
+	// move the data from the old block into data for the new block
+	new_block->state = BlockState::BLOCK_LOADED;
+	new_block->buffer = make_unique<Block>(*old_block->buffer, block_id);
+
+	// clear the old buffer and unload it
+	old_handle.reset();
+	old_block->buffer.reset();
+	old_block->state = BlockState::BLOCK_UNLOADED;
+	old_block->memory_usage = 0;
+	old_block.reset();
+
+	// persist the new block to disk
+	block_manager.Write(*new_block->buffer, block_id);
+
+	AddToEvictionQueue(new_block);
+
+	return new_block;
+}
+
+shared_ptr<BlockHandle> BufferManager::RegisterMemory(idx_t block_size, bool can_destroy) {
+	auto alloc_size = block_size + Storage::BLOCK_HEADER_SIZE;
+	// first evict blocks until we have enough memory to store this buffer
+	if (!EvictBlocks(alloc_size, maximum_memory)) {
+		throw OutOfMemoryException("could not allocate block of %lld bytes%s", alloc_size, InMemoryWarning());
+	}
+
+	// allocate the buffer
+	auto temp_id = ++temporary_id;
+	auto buffer = make_unique<ManagedBuffer>(db, block_size, can_destroy, temp_id);
+
+	// create a new block pointer for this block
+	return make_shared<BlockHandle>(db, temp_id, move(buffer), can_destroy, block_size);
+}
+
+unique_ptr<BufferHandle> BufferManager::Allocate(idx_t block_size) {
+	auto block = RegisterMemory(block_size, true);
+	return Pin(block);
+}
+
+void BufferManager::ReAllocate(shared_ptr<BlockHandle> &handle, idx_t block_size) {
+	D_ASSERT(block_size >= Storage::BLOCK_SIZE);
+	lock_guard<mutex> lock(handle->lock);
+	D_ASSERT(handle->state == BlockState::BLOCK_LOADED);
+	auto alloc_size = block_size + Storage::BLOCK_HEADER_SIZE;
+	int64_t required_memory = alloc_size - handle->memory_usage;
+	if (required_memory == 0) {
+		return;
+	} else if (required_memory > 0) {
+		// evict blocks until we have space to resize this block
+		if (!EvictBlocks(required_memory, maximum_memory)) {
+			throw OutOfMemoryException("failed to resize block from %lld to %lld%s", handle->memory_usage, alloc_size,
+			                           InMemoryWarning());
+		}
+	} else {
+		// no need to evict blocks
+		current_memory -= idx_t(-required_memory);
+	}
+
+	// resize and adjust current memory
+	handle->buffer->Resize(block_size);
+	handle->memory_usage = alloc_size;
+}
+
+unique_ptr<BufferHandle> BufferManager::Pin(shared_ptr<BlockHandle> &handle) {
+	idx_t required_memory;
+	{
+		// lock the block
+		lock_guard<mutex> lock(handle->lock);
+		// check if the block is already loaded
+		if (handle->state == BlockState::BLOCK_LOADED) {
+			// the block is loaded, increment the reader count and return a pointer to the handle
+			handle->readers++;
+			return handle->Load(handle);
+		}
+		required_memory = handle->memory_usage;
+	}
+	// evict blocks until we have space for the current block
+	if (!EvictBlocks(required_memory, maximum_memory)) {
+		throw OutOfMemoryException("failed to pin block of size %lld%s", required_memory, InMemoryWarning());
+	}
+	// lock the handle again and repeat the check (in case anybody loaded in the mean time)
+	lock_guard<mutex> lock(handle->lock);
+	// check if the block is already loaded
+	if (handle->state == BlockState::BLOCK_LOADED) {
+		// the block is loaded, increment the reader count and return a pointer to the handle
+		handle->readers++;
+		current_memory -= required_memory;
+		return handle->Load(handle);
+	}
+	// now we can actually load the current block
+	D_ASSERT(handle->readers == 0);
+	handle->readers = 1;
+	return handle->Load(handle);
+}
+
+void BufferManager::AddToEvictionQueue(shared_ptr<BlockHandle> &handle) {
+	D_ASSERT(handle->readers == 0);
+	handle->eviction_timestamp++;
+	PurgeQueue();
+	queue->q.enqueue(make_unique<BufferEvictionNode>(weak_ptr<BlockHandle>(handle), handle->eviction_timestamp));
+}
+
+void BufferManager::Unpin(shared_ptr<BlockHandle> &handle) {
+	lock_guard<mutex> lock(handle->lock);
+	D_ASSERT(handle->readers > 0);
+	handle->readers--;
+	if (handle->readers == 0) {
+		AddToEvictionQueue(handle);
+	}
+}
+
+bool BufferManager::EvictBlocks(idx_t extra_memory, idx_t memory_limit) {
+	PurgeQueue();
+
+	unique_ptr<BufferEvictionNode> node;
+	current_memory += extra_memory;
+	while (current_memory > memory_limit) {
+		// get a block to unpin from the queue
+		if (!queue->q.try_dequeue(node)) {
+			current_memory -= extra_memory;
+			return false;
+		}
+		// get a reference to the underlying block pointer
+		auto handle = node->TryGetBlockHandle();
+		if (!handle) {
+			continue;
+		}
+		// we might be able to free this block: grab the mutex and check if we can free it
+		lock_guard<mutex> lock(handle->lock);
+		if (!node->CanUnload(*handle)) {
+			// something changed in the mean-time, bail out
+			continue;
+		}
+		// hooray, we can unload the block
+		// release the memory and mark the block as unloaded
+		handle->Unload();
+	}
+	return true;
+}
+
+void BufferManager::PurgeQueue() {
+	unique_ptr<BufferEvictionNode> node;
+	while (true) {
+		if (!queue->q.try_dequeue(node)) {
+			break;
+		}
+		auto handle = node->TryGetBlockHandle();
+		if (!handle) {
+			continue;
+		} else {
+			queue->q.enqueue(move(node));
+			break;
+		}
+	}
+}
+
+void BufferManager::UnregisterBlock(block_id_t block_id, bool can_destroy) {
+	if (block_id >= MAXIMUM_BLOCK) {
+		// in-memory buffer: destroy the buffer
+		if (!can_destroy) {
+			// buffer could have been offloaded to disk: remove the file
+			DeleteTemporaryFile(block_id);
+		}
+	} else {
+		lock_guard<mutex> lock(blocks_lock);
+		// on-disk block: erase from list of blocks in manager
+		blocks.erase(block_id);
+	}
+}
+void BufferManager::SetLimit(idx_t limit) {
+	lock_guard<mutex> l_lock(limit_lock);
+	// try to evict until the limit is reached
+	if (!EvictBlocks(0, limit)) {
+		throw OutOfMemoryException(
+		    "Failed to change memory limit to %lld: could not free up enough memory for the new limit%s", limit,
+		    InMemoryWarning());
+	}
+	idx_t old_limit = maximum_memory;
+	// set the global maximum memory to the new limit if successful
+	maximum_memory = limit;
+	// evict again
+	if (!EvictBlocks(0, limit)) {
+		// failed: go back to old limit
+		maximum_memory = old_limit;
+		throw OutOfMemoryException(
+		    "Failed to change memory limit to %lld: could not free up enough memory for the new limit%s", limit,
+		    InMemoryWarning());
+	}
+}
+
+string BufferManager::GetTemporaryPath(block_id_t id) {
+	auto &fs = FileSystem::GetFileSystem(db);
+	return fs.JoinPath(temp_directory, to_string(id) + ".block");
+}
+
+void BufferManager::RequireTemporaryDirectory() {
+	if (temp_directory.empty()) {
+		throw Exception(
+		    "Out-of-memory: cannot write buffer because no temporary directory is specified!\nTo enable "
+		    "temporary buffer eviction set a temporary directory using PRAGMA temp_directory='/path/to/tmp.tmp'");
+	}
+	lock_guard<mutex> temp_handle_guard(temp_handle_lock);
+	if (!temp_directory_handle) {
+		// temp directory has not been created yet: initialize it
+		temp_directory_handle = make_unique<TemporaryDirectoryHandle>(db, temp_directory);
+	}
+}
+
+void BufferManager::WriteTemporaryBuffer(ManagedBuffer &buffer) {
+	RequireTemporaryDirectory();
+
+	D_ASSERT(buffer.size >= Storage::BLOCK_SIZE);
+	// get the path to write to
+	auto path = GetTemporaryPath(buffer.id);
+	// create the file and write the size followed by the buffer contents
+	auto &fs = FileSystem::GetFileSystem(db);
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+	handle->Write(&buffer.size, sizeof(idx_t), 0);
+	buffer.Write(*handle, sizeof(idx_t));
+}
+
+unique_ptr<FileBuffer> BufferManager::ReadTemporaryBuffer(block_id_t id) {
+	D_ASSERT(!temp_directory.empty());
+	D_ASSERT(temp_directory_handle.get());
+	idx_t block_size;
+	// open the temporary file and read the size
+	auto path = GetTemporaryPath(id);
+	auto &fs = FileSystem::GetFileSystem(db);
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
+	handle->Read(&block_size, sizeof(idx_t), 0);
+
+	// now allocate a buffer of this size and read the data into that buffer
+	auto buffer = make_unique<ManagedBuffer>(db, block_size, false, id);
+	buffer->Read(*handle, sizeof(idx_t));
+
+	handle.reset();
+	DeleteTemporaryFile(id);
+	return move(buffer);
+}
+
+void BufferManager::DeleteTemporaryFile(block_id_t id) {
+	if (temp_directory.empty() || !temp_directory_handle) {
+		return;
+	}
+	auto &fs = FileSystem::GetFileSystem(db);
+	auto path = GetTemporaryPath(id);
+	if (fs.FileExists(path)) {
+		fs.RemoveFile(path);
+	}
+}
+
+string BufferManager::InMemoryWarning() {
+	if (!temp_directory.empty()) {
+		return "";
+	}
+	return "\nDatabase is launched in in-memory mode and no temporary directory is specified."
+	       "\nUnused blocks cannot be offloaded to disk."
+	       "\n\nLaunch the database with a persistent storage back-end"
+	       "\nOr set PRAGMA temp_directory='/path/to/tmp.tmp'";
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+TableDataReader::TableDataReader(MetaBlockReader &reader, BoundCreateTableInfo &info) : reader(reader), info(info) {
+	info.data = make_unique<PersistentTableData>(info.Base().columns.size());
+}
+
+void TableDataReader::ReadTableData() {
+	auto &columns = info.Base().columns;
+	D_ASSERT(columns.size() > 0);
+
+	// deserialize the total table statistics
+	info.data->column_stats.reserve(columns.size());
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto &col = columns[i];
+		// Have to use 'Generated()' here, storage_oid is uninitialized here
+		if (col.Generated()) {
+			continue;
+		}
+		info.data->column_stats.push_back(BaseStatistics::Deserialize(reader, columns[i].Type()));
+	}
+
+	// deserialize each of the individual row groups
+	auto row_group_count = reader.Read<uint64_t>();
+	info.data->row_groups.reserve(row_group_count);
+	for (idx_t i = 0; i < row_group_count; i++) {
+		auto row_group_pointer = RowGroup::Deserialize(reader, columns);
+		info.data->row_groups.push_back(move(row_group_pointer));
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+TableDataWriter::TableDataWriter(DatabaseInstance &, CheckpointManager &checkpoint_manager, TableCatalogEntry &table,
+                                 MetaBlockWriter &meta_writer)
+    : checkpoint_manager(checkpoint_manager), table(table), meta_writer(meta_writer) {
+}
+
+TableDataWriter::~TableDataWriter() {
+}
+
+BlockPointer TableDataWriter::WriteTableData() {
+	// start scanning the table and append the data to the uncompressed segments
+	return table.storage->Checkpoint(*this);
+}
+
+CompressionType TableDataWriter::GetColumnCompressionType(idx_t i) {
+	return table.columns[i].CompressionType();
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+WriteOverflowStringsToDisk::WriteOverflowStringsToDisk(DatabaseInstance &db)
+    : db(db), block_id(INVALID_BLOCK), offset(0) {
+}
+
+WriteOverflowStringsToDisk::~WriteOverflowStringsToDisk() {
+	auto &block_manager = BlockManager::GetBlockManager(db);
+	if (offset > 0) {
+		block_manager.Write(*handle->node, block_id);
+	}
+}
+
+void WriteOverflowStringsToDisk::WriteString(string_t string, block_id_t &result_block, int32_t &result_offset) {
+	auto &buffer_manager = BufferManager::GetBufferManager(db);
+	auto &block_manager = BlockManager::GetBlockManager(db);
+	if (!handle) {
+		handle = buffer_manager.Allocate(Storage::BLOCK_SIZE);
+	}
+	// first write the length of the string
+	if (block_id == INVALID_BLOCK || offset + 2 * sizeof(uint32_t) >= STRING_SPACE) {
+		AllocateNewBlock(block_manager.GetFreeBlockId());
+	}
+	result_block = block_id;
+	result_offset = offset;
+
+	// GZIP the string
+	auto uncompressed_size = string.GetSize();
+	MiniZStream s;
+	size_t compressed_size = 0;
+	compressed_size = s.MaxCompressedLength(uncompressed_size);
+	auto compressed_buf = unique_ptr<data_t[]>(new data_t[compressed_size]);
+	s.Compress((const char *)string.GetDataUnsafe(), uncompressed_size, (char *)compressed_buf.get(), &compressed_size);
+	string_t compressed_string((const char *)compressed_buf.get(), compressed_size);
+
+	// store sizes
+	Store<uint32_t>(compressed_size, handle->node->buffer + offset);
+	Store<uint32_t>(uncompressed_size, handle->node->buffer + offset + sizeof(uint32_t));
+
+	// now write the remainder of the string
+	offset += 2 * sizeof(uint32_t);
+	auto strptr = compressed_string.GetDataUnsafe();
+	uint32_t remaining = compressed_size;
+	while (remaining > 0) {
+		uint32_t to_write = MinValue<uint32_t>(remaining, STRING_SPACE - offset);
+		if (to_write > 0) {
+			memcpy(handle->node->buffer + offset, strptr, to_write);
+
+			remaining -= to_write;
+			offset += to_write;
+			strptr += to_write;
+		}
+		if (remaining > 0) {
+			// there is still remaining stuff to write
+			// first get the new block id and write it to the end of the previous block
+			auto new_block_id = block_manager.GetFreeBlockId();
+			Store<block_id_t>(new_block_id, handle->node->buffer + offset);
+			// now write the current block to disk and allocate a new block
+			AllocateNewBlock(new_block_id);
+		}
+	}
+}
+
+void WriteOverflowStringsToDisk::AllocateNewBlock(block_id_t new_block_id) {
+	auto &block_manager = BlockManager::GetBlockManager(db);
+	if (block_id != INVALID_BLOCK) {
+		// there is an old block, write it first
+		block_manager.Write(*handle->node, block_id);
+	}
+	offset = 0;
+	block_id = new_block_id;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+void ReorderTableEntries(vector<TableCatalogEntry *> &tables);
+
+CheckpointManager::CheckpointManager(DatabaseInstance &db) : db(db) {
+}
+
+void CheckpointManager::CreateCheckpoint() {
+	auto &config = DBConfig::GetConfig(db);
+	auto &storage_manager = StorageManager::GetStorageManager(db);
+	if (storage_manager.InMemory()) {
+		return;
+	}
+	// assert that the checkpoint manager hasn't been used before
+	D_ASSERT(!metadata_writer);
+
+	auto &block_manager = BlockManager::GetBlockManager(db);
+	block_manager.StartCheckpoint();
+
+	//! Set up the writers for the checkpoints
+	metadata_writer = make_unique<MetaBlockWriter>(db);
+	tabledata_writer = make_unique<MetaBlockWriter>(db);
+
+	// get the id of the first meta block
+	block_id_t meta_block = metadata_writer->block->id;
+
+	vector<SchemaCatalogEntry *> schemas;
+	// we scan the set of committed schemas
+	auto &catalog = Catalog::GetCatalog(db);
+	catalog.schemas->Scan([&](CatalogEntry *entry) { schemas.push_back((SchemaCatalogEntry *)entry); });
+	// write the actual data into the database
+	// write the amount of schemas
+	metadata_writer->Write<uint32_t>(schemas.size());
+	for (auto &schema : schemas) {
+		WriteSchema(*schema);
+	}
+	FlushPartialSegments();
+	// flush the meta data to disk
+	metadata_writer->Flush();
+	tabledata_writer->Flush();
+
+	// write a checkpoint flag to the WAL
+	// this protects against the rare event that the database crashes AFTER writing the file, but BEFORE truncating the
+	// WAL we write an entry CHECKPOINT "meta_block_id" into the WAL upon loading, if we see there is an entry
+	// CHECKPOINT "meta_block_id", and the id MATCHES the head idin the file we know that the database was successfully
+	// checkpointed, so we know that we should avoid replaying the WAL to avoid duplicating data
+	auto wal = storage_manager.GetWriteAheadLog();
+	wal->WriteCheckpoint(meta_block);
+	wal->Flush();
+
+	if (config.checkpoint_abort == CheckpointAbort::DEBUG_ABORT_BEFORE_HEADER) {
+		throw IOException("Checkpoint aborted before header write because of PRAGMA checkpoint_abort flag");
+	}
+
+	// finally write the updated header
+	DatabaseHeader header;
+	header.meta_block = meta_block;
+	block_manager.WriteHeader(header);
+
+	if (config.checkpoint_abort == CheckpointAbort::DEBUG_ABORT_BEFORE_TRUNCATE) {
+		throw IOException("Checkpoint aborted before truncate because of PRAGMA checkpoint_abort flag");
+	}
+
+	// truncate the WAL
+	wal->Truncate(0);
+
+	// mark all blocks written as part of the metadata as modified
+	for (auto &block_id : metadata_writer->written_blocks) {
+		block_manager.MarkBlockAsModified(block_id);
+	}
+	for (auto &block_id : tabledata_writer->written_blocks) {
+		block_manager.MarkBlockAsModified(block_id);
+	}
+}
+
+void CheckpointManager::LoadFromStorage() {
+	auto &block_manager = BlockManager::GetBlockManager(db);
+	block_id_t meta_block = block_manager.GetMetaBlock();
+	if (meta_block < 0) {
+		// storage is empty
+		return;
+	}
+
+	Connection con(db);
+	con.BeginTransaction();
+	// create the MetaBlockReader to read from the storage
+	MetaBlockReader reader(db, meta_block);
+	uint32_t schema_count = reader.Read<uint32_t>();
+	for (uint32_t i = 0; i < schema_count; i++) {
+		ReadSchema(*con.context, reader);
+	}
+	con.Commit();
+}
+
+//===--------------------------------------------------------------------===//
+// Schema
+//===--------------------------------------------------------------------===//
+void CheckpointManager::WriteSchema(SchemaCatalogEntry &schema) {
+	// write the schema data
+	schema.Serialize(*metadata_writer);
+	// then, we fetch the tables/views/sequences information
+	vector<TableCatalogEntry *> tables;
+	vector<ViewCatalogEntry *> views;
+	schema.Scan(CatalogType::TABLE_ENTRY, [&](CatalogEntry *entry) {
+		if (entry->internal) {
+			return;
+		}
+		if (entry->type == CatalogType::TABLE_ENTRY) {
+			tables.push_back((TableCatalogEntry *)entry);
+		} else if (entry->type == CatalogType::VIEW_ENTRY) {
+			views.push_back((ViewCatalogEntry *)entry);
+		} else {
+			throw NotImplementedException("Catalog type for entries");
+		}
+	});
+	vector<SequenceCatalogEntry *> sequences;
+	schema.Scan(CatalogType::SEQUENCE_ENTRY, [&](CatalogEntry *entry) {
+		if (entry->internal) {
+			return;
+		}
+		sequences.push_back((SequenceCatalogEntry *)entry);
+	});
+
+	vector<TypeCatalogEntry *> custom_types;
+	schema.Scan(CatalogType::TYPE_ENTRY, [&](CatalogEntry *entry) {
+		if (entry->internal) {
+			return;
+		}
+		custom_types.push_back((TypeCatalogEntry *)entry);
+	});
+
+	vector<ScalarMacroCatalogEntry *> macros;
+	schema.Scan(CatalogType::SCALAR_FUNCTION_ENTRY, [&](CatalogEntry *entry) {
+		if (entry->internal) {
+			return;
+		}
+		if (entry->type == CatalogType::MACRO_ENTRY) {
+			macros.push_back((ScalarMacroCatalogEntry *)entry);
+		}
+	});
+
+	vector<TableMacroCatalogEntry *> table_macros;
+	schema.Scan(CatalogType::TABLE_FUNCTION_ENTRY, [&](CatalogEntry *entry) {
+		if (entry->internal) {
+			return;
+		}
+		if (entry->type == CatalogType::TABLE_MACRO_ENTRY) {
+			table_macros.push_back((TableMacroCatalogEntry *)entry);
+		}
+	});
+
+	FieldWriter writer(*metadata_writer);
+	writer.WriteField<uint32_t>(custom_types.size());
+	writer.WriteField<uint32_t>(sequences.size());
+	writer.WriteField<uint32_t>(tables.size());
+	writer.WriteField<uint32_t>(views.size());
+	writer.WriteField<uint32_t>(macros.size());
+	writer.WriteField<uint32_t>(table_macros.size());
+	writer.Finalize();
+
+	// write the custom_types
+	for (auto &custom_type : custom_types) {
+		WriteType(*custom_type);
+	}
+
+	// write the sequences
+	for (auto &seq : sequences) {
+		WriteSequence(*seq);
+	}
+	// reorder tables because of foreign key constraint
+	ReorderTableEntries(tables);
+	// now write the tables
+	for (auto &table : tables) {
+		WriteTable(*table);
+	}
+	// now write the views
+	for (auto &view : views) {
+		WriteView(*view);
+	}
+
+	// finally write the macro's
+	for (auto &macro : macros) {
+		WriteMacro(*macro);
+	}
+
+	// finally write the macro's
+	for (auto &macro : table_macros) {
+		WriteTableMacro(*macro);
+	}
+}
+
+void CheckpointManager::ReadSchema(ClientContext &context, MetaBlockReader &reader) {
+	auto &catalog = Catalog::GetCatalog(db);
+
+	// read the schema and create it in the catalog
+	auto info = SchemaCatalogEntry::Deserialize(reader);
+	// we set create conflict to ignore to ignore the failure of recreating the main schema
+	info->on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
+	catalog.CreateSchema(context, info.get());
+
+	// first read all the counts
+	FieldReader field_reader(reader);
+	uint32_t enum_count = field_reader.ReadRequired<uint32_t>();
+	uint32_t seq_count = field_reader.ReadRequired<uint32_t>();
+	uint32_t table_count = field_reader.ReadRequired<uint32_t>();
+	uint32_t view_count = field_reader.ReadRequired<uint32_t>();
+	uint32_t macro_count = field_reader.ReadRequired<uint32_t>();
+	uint32_t table_macro_count = field_reader.ReadRequired<uint32_t>();
+	field_reader.Finalize();
+
+	// now read the enums
+	for (uint32_t i = 0; i < enum_count; i++) {
+		ReadType(context, reader);
+	}
+
+	// read the sequences
+	for (uint32_t i = 0; i < seq_count; i++) {
+		ReadSequence(context, reader);
+	}
+	// read the table count and recreate the tables
+	for (uint32_t i = 0; i < table_count; i++) {
+		ReadTable(context, reader);
+	}
+	// now read the views
+	for (uint32_t i = 0; i < view_count; i++) {
+		ReadView(context, reader);
+	}
+
+	// finally read the macro's
+	for (uint32_t i = 0; i < macro_count; i++) {
+		ReadMacro(context, reader);
+	}
+
+	for (uint32_t i = 0; i < table_macro_count; i++) {
+		ReadTableMacro(context, reader);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Views
+//===--------------------------------------------------------------------===//
+void CheckpointManager::WriteView(ViewCatalogEntry &view) {
+	view.Serialize(*metadata_writer);
+}
+
+void CheckpointManager::ReadView(ClientContext &context, MetaBlockReader &reader) {
+	auto info = ViewCatalogEntry::Deserialize(reader);
+
+	auto &catalog = Catalog::GetCatalog(db);
+	catalog.CreateView(context, info.get());
+}
+
+//===--------------------------------------------------------------------===//
+// Sequences
+//===--------------------------------------------------------------------===//
+void CheckpointManager::WriteSequence(SequenceCatalogEntry &seq) {
+	seq.Serialize(*metadata_writer);
+}
+
+void CheckpointManager::ReadSequence(ClientContext &context, MetaBlockReader &reader) {
+	auto info = SequenceCatalogEntry::Deserialize(reader);
+
+	auto &catalog = Catalog::GetCatalog(db);
+	catalog.CreateSequence(context, info.get());
+}
+
+//===--------------------------------------------------------------------===//
+// Custom Types
+//===--------------------------------------------------------------------===//
+void CheckpointManager::WriteType(TypeCatalogEntry &table) {
+	table.Serialize(*metadata_writer);
+}
+
+void CheckpointManager::ReadType(ClientContext &context, MetaBlockReader &reader) {
+	auto info = TypeCatalogEntry::Deserialize(reader);
+
+	auto &catalog = Catalog::GetCatalog(db);
+	catalog.CreateType(context, info.get());
+}
+
+//===--------------------------------------------------------------------===//
+// Macro's
+//===--------------------------------------------------------------------===//
+void CheckpointManager::WriteMacro(ScalarMacroCatalogEntry &macro) {
+	macro.Serialize(*metadata_writer);
+}
+
+void CheckpointManager::ReadMacro(ClientContext &context, MetaBlockReader &reader) {
+	auto info = ScalarMacroCatalogEntry::Deserialize(reader);
+	auto &catalog = Catalog::GetCatalog(db);
+	catalog.CreateFunction(context, info.get());
+}
+
+void CheckpointManager::WriteTableMacro(TableMacroCatalogEntry &macro) {
+	macro.Serialize(*metadata_writer);
+}
+
+void CheckpointManager::ReadTableMacro(ClientContext &context, MetaBlockReader &reader) {
+	auto info = TableMacroCatalogEntry::Deserialize(reader);
+	auto &catalog = Catalog::GetCatalog(db);
+	catalog.CreateFunction(context, info.get());
+}
+
+//===--------------------------------------------------------------------===//
+// Table Metadata
+//===--------------------------------------------------------------------===//
+void CheckpointManager::WriteTable(TableCatalogEntry &table) {
+	// write the table meta data
+	table.Serialize(*metadata_writer);
+	// now we need to write the table data
+	TableDataWriter writer(db, *this, table, *tabledata_writer);
+	auto pointer = writer.WriteTableData();
+
+	//! write the block pointer for the table info
+	metadata_writer->Write<block_id_t>(pointer.block_id);
+	metadata_writer->Write<uint64_t>(pointer.offset);
+}
+
+void CheckpointManager::ReadTable(ClientContext &context, MetaBlockReader &reader) {
+	// deserialize the table meta data
+	auto info = TableCatalogEntry::Deserialize(reader);
+	// bind the info
+	auto binder = Binder::CreateBinder(context);
+	auto bound_info = binder->BindCreateTableInfo(move(info));
+
+	// now read the actual table data and place it into the create table info
+	auto block_id = reader.Read<block_id_t>();
+	auto offset = reader.Read<uint64_t>();
+	MetaBlockReader table_data_reader(db, block_id);
+	table_data_reader.offset = offset;
+	TableDataReader data_reader(table_data_reader, *bound_info);
+	data_reader.ReadTableData();
+
+	// finally create the table in the catalog
+	auto &catalog = Catalog::GetCatalog(db);
+	catalog.CreateTable(context, bound_info.get());
+}
+
+//===--------------------------------------------------------------------===//
+// Partial Blocks
+//===--------------------------------------------------------------------===//
+bool CheckpointManager::GetPartialBlock(ColumnSegment *segment, idx_t segment_size, block_id_t &block_id,
+                                        uint32_t &offset_in_block, PartialBlock *&partial_block_ptr,
+                                        unique_ptr<PartialBlock> &owned_partial_block) {
+	auto entry = partially_filled_blocks.lower_bound(segment_size);
+	if (entry == partially_filled_blocks.end()) {
+		return false;
+	}
+	// found a partially filled block! fill in the info
+	auto partial_block = move(entry->second);
+	partial_block_ptr = partial_block.get();
+	block_id = partial_block->block_id;
+	offset_in_block = Storage::BLOCK_SIZE - entry->first;
+	partially_filled_blocks.erase(entry);
+	PartialColumnSegment partial_segment;
+	partial_segment.segment = segment;
+	partial_segment.offset_in_block = offset_in_block;
+	partial_block->segments.push_back(partial_segment);
+
+	D_ASSERT(offset_in_block > 0);
+	D_ASSERT(ValueIsAligned(offset_in_block));
+
+	// check if the block is STILL partially filled after adding the segment_size
+	auto new_size = AlignValue(offset_in_block + segment_size);
+	if (new_size <= CheckpointManager::PARTIAL_BLOCK_THRESHOLD) {
+		// the block is still partially filled: add it to the partially_filled_blocks list
+		auto new_space_left = Storage::BLOCK_SIZE - new_size;
+		partially_filled_blocks.insert(make_pair(new_space_left, move(partial_block)));
+		// should not write the block yet: perhaps more columns will be added
+	} else {
+		// we are done with this block after the current write: write it to disk
+		owned_partial_block = move(partial_block);
+	}
+	return true;
+}
+
+void CheckpointManager::RegisterPartialBlock(ColumnSegment *segment, idx_t segment_size, block_id_t block_id) {
+	D_ASSERT(segment_size <= CheckpointManager::PARTIAL_BLOCK_THRESHOLD);
+	auto partial_block = make_unique<PartialBlock>();
+	partial_block->block_id = block_id;
+	partial_block->block = segment->block;
+
+	PartialColumnSegment partial_segment;
+	partial_segment.segment = segment;
+	partial_segment.offset_in_block = 0;
+	partial_block->segments.push_back(partial_segment);
+	auto space_left = Storage::BLOCK_SIZE - AlignValue(segment_size);
+	partially_filled_blocks.insert(make_pair(space_left, move(partial_block)));
+}
+
+void CheckpointManager::FlushPartialSegments() {
+	for (auto &entry : partially_filled_blocks) {
+		entry.second->FlushToDisk(db);
+	}
+}
+
+void PartialBlock::FlushToDisk(DatabaseInstance &db) {
+	auto &buffer_manager = BufferManager::GetBufferManager(db);
+	auto &block_manager = BlockManager::GetBlockManager(db);
+
+	// the data for the block might already exists in-memory of our block
+	// instead of copying the data we alter some metadata so the buffer points to an on-disk block
+	block = buffer_manager.ConvertToPersistent(block_manager, block_id, move(block));
+
+	// now set this block as the block for all segments
+	for (auto &seg : segments) {
+		seg.segment->ConvertToPersistent(block, block_id, seg.offset_in_block);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+#include <functional>
+
+namespace duckdb {
+
+// Note that optimizations in scanning only work if this value is equal to STANDARD_VECTOR_SIZE, however we keep them
+// separated to prevent the code from break on lower vector sizes
+static constexpr const idx_t BITPACKING_WIDTH_GROUP_SIZE = 1024;
+
+struct EmptyBitpackingWriter {
+	template <class T>
+	static void Operation(T *values, bool *validity, bitpacking_width_t width, idx_t count, void *data_ptr) {
+	}
+};
+
+template <class T>
+struct BitpackingState {
+public:
+	BitpackingState() : compression_buffer_idx(0), total_size(0), data_ptr(nullptr) {
+	}
+
+	T compression_buffer[BITPACKING_WIDTH_GROUP_SIZE];
+	bool compression_buffer_validity[BITPACKING_WIDTH_GROUP_SIZE];
+	idx_t compression_buffer_idx;
+	idx_t total_size;
+	void *data_ptr;
+
+public:
+	template <class OP>
+	void Flush() {
+		bitpacking_width_t width = BitpackingPrimitives::MinimumBitWidth<T>(compression_buffer, compression_buffer_idx);
+		OP::Operation(compression_buffer, compression_buffer_validity, width, compression_buffer_idx, data_ptr);
+		total_size += (BITPACKING_WIDTH_GROUP_SIZE * width) / 8 + sizeof(bitpacking_width_t);
+		compression_buffer_idx = 0;
+	}
+
+	template <class OP = EmptyBitpackingWriter>
+	void Update(T *data, ValidityMask &validity, idx_t idx) {
+
+		if (validity.RowIsValid(idx)) {
+			compression_buffer_validity[compression_buffer_idx] = true;
+			compression_buffer[compression_buffer_idx++] = data[idx];
+		} else {
+			// We write zero for easy bitwidth analysis of the compression buffer later
+			compression_buffer_validity[compression_buffer_idx] = false;
+			compression_buffer[compression_buffer_idx++] = 0;
+		}
+
+		if (compression_buffer_idx == BITPACKING_WIDTH_GROUP_SIZE) {
+			// Calculate bitpacking width;
+			Flush<OP>();
+		}
+	}
+};
+
+//===--------------------------------------------------------------------===//
+// Analyze
+//===--------------------------------------------------------------------===//
+template <class T>
+struct BitpackingAnalyzeState : public AnalyzeState {
+	BitpackingState<T> state;
+};
+
+template <class T>
+unique_ptr<AnalyzeState> BitpackingInitAnalyze(ColumnData &col_data, PhysicalType type) {
+	return make_unique<BitpackingAnalyzeState<T>>();
+}
+
+template <class T>
+bool BitpackingAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
+	auto &analyze_state = (BitpackingAnalyzeState<T> &)state;
+	VectorData vdata;
+	input.Orrify(count, vdata);
+
+	auto data = (T *)vdata.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = vdata.sel->get_index(i);
+		analyze_state.state.template Update<EmptyBitpackingWriter>(data, vdata.validity, idx);
+	}
+
+	return true;
+}
+
+template <class T>
+idx_t BitpackingFinalAnalyze(AnalyzeState &state) {
+	auto &bitpacking_state = (BitpackingAnalyzeState<T> &)state;
+	bitpacking_state.state.template Flush<EmptyBitpackingWriter>();
+	return bitpacking_state.state.total_size;
+}
+
+//===--------------------------------------------------------------------===//
+// Compress
+//===--------------------------------------------------------------------===//
+template <class T>
+struct BitpackingCompressState : public CompressionState {
+public:
+	explicit BitpackingCompressState(ColumnDataCheckpointer &checkpointer) : checkpointer(checkpointer) {
+		auto &db = checkpointer.GetDatabase();
+		auto &type = checkpointer.GetType();
+		auto &config = DBConfig::GetConfig(db);
+		function = config.GetCompressionFunction(CompressionType::COMPRESSION_BITPACKING, type.InternalType());
+		CreateEmptySegment(checkpointer.GetRowGroup().start);
+
+		state.data_ptr = (void *)this;
+	}
+
+	ColumnDataCheckpointer &checkpointer;
+	CompressionFunction *function;
+	unique_ptr<ColumnSegment> current_segment;
+	unique_ptr<BufferHandle> handle;
+
+	// Ptr to next free spot in segment;
+	data_ptr_t data_ptr;
+	// Ptr to next free spot for storing bitwidths (growing downwards).
+	data_ptr_t width_ptr;
+
+	BitpackingState<T> state;
+
+public:
+	struct BitpackingWriter {
+		template <class VALUE_TYPE>
+		static void Operation(VALUE_TYPE *values, bool *validity, bitpacking_width_t width, idx_t count,
+		                      void *data_ptr) {
+			auto state = (BitpackingCompressState<T> *)data_ptr;
+
+			if (state->RemainingSize() < (width * BITPACKING_WIDTH_GROUP_SIZE) / 8 + sizeof(bitpacking_width_t)) {
+				// Segment is full
+				auto row_start = state->current_segment->start + state->current_segment->count;
+				state->FlushSegment();
+				state->CreateEmptySegment(row_start);
+			}
+
+			for (idx_t i = 0; i < count; i++) {
+				if (validity[i]) {
+					NumericStatistics::Update<T>(state->current_segment->stats, values[i]);
+				}
+			}
+
+			state->WriteValues(values, width, count);
+		}
+	};
+
+	// Space remaining between the width_ptr growing down and data ptr growing up
+	idx_t RemainingSize() {
+		return width_ptr - data_ptr;
+	}
+
+	void CreateEmptySegment(idx_t row_start) {
+		auto &db = checkpointer.GetDatabase();
+		auto &type = checkpointer.GetType();
+		auto compressed_segment = ColumnSegment::CreateTransientSegment(db, type, row_start);
+		compressed_segment->function = function;
+		current_segment = move(compressed_segment);
+		auto &buffer_manager = BufferManager::GetBufferManager(db);
+		handle = buffer_manager.Pin(current_segment->block);
+
+		data_ptr = handle->Ptr() + current_segment->GetBlockOffset() + BitpackingPrimitives::BITPACKING_HEADER_SIZE;
+		width_ptr =
+		    handle->Ptr() + current_segment->GetBlockOffset() + Storage::BLOCK_SIZE - sizeof(bitpacking_width_t);
+	}
+
+	void Append(VectorData &vdata, idx_t count) {
+		// TODO Optimization: avoid use of compression buffer if we can compress straight to result vector
+		auto data = (T *)vdata.data;
+
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = vdata.sel->get_index(i);
+			state.template Update<BitpackingCompressState<T>::BitpackingWriter>(data, vdata.validity, idx);
+		}
+	}
+
+	void WriteValues(T *values, bitpacking_width_t width, idx_t count) {
+		// TODO we can optimize this by stopping early if count < BITPACKING_WIDTH_GROUP_SIZE
+		BitpackingPrimitives::PackBuffer<T, false>(data_ptr, values, count, width);
+		data_ptr += (BITPACKING_WIDTH_GROUP_SIZE * width) / 8;
+
+		Store<bitpacking_width_t>(width, width_ptr);
+		width_ptr -= sizeof(bitpacking_width_t);
+
+		current_segment->count += count;
+	}
+
+	void FlushSegment() {
+		auto &state = checkpointer.GetCheckpointState();
+
+		// Compact the segment by moving the widths next to the data.
+		idx_t minimal_widths_offset = AlignValue(data_ptr - handle->node->buffer);
+		idx_t widths_size = handle->node->buffer + Storage::BLOCK_SIZE - width_ptr - 1;
+		idx_t total_segment_size = minimal_widths_offset + widths_size;
+		memmove(handle->node->buffer + minimal_widths_offset, width_ptr + 1, widths_size);
+
+		// Store the offset of the first width (which is at the highest address).
+		Store<idx_t>(minimal_widths_offset + widths_size - 1, handle->node->buffer);
+		handle.reset();
+
+		state.FlushSegment(move(current_segment), total_segment_size);
+	}
+
+	void Finalize() {
+		state.template Flush<BitpackingCompressState<T>::BitpackingWriter>();
+		FlushSegment();
+		current_segment.reset();
+	}
+};
+
+template <class T>
+unique_ptr<CompressionState> BitpackingInitCompression(ColumnDataCheckpointer &checkpointer,
+                                                       unique_ptr<AnalyzeState> state) {
+	return make_unique<BitpackingCompressState<T>>(checkpointer);
+}
+
+template <class T>
+void BitpackingCompress(CompressionState &state_p, Vector &scan_vector, idx_t count) {
+	auto &state = (BitpackingCompressState<T> &)state_p;
+	VectorData vdata;
+	scan_vector.Orrify(count, vdata);
+	state.Append(vdata, count);
+}
+
+template <class T>
+void BitpackingFinalizeCompress(CompressionState &state_p) {
+	auto &state = (BitpackingCompressState<T> &)state_p;
+	state.Finalize();
+}
+
+//===--------------------------------------------------------------------===//
+// Scan
+//===--------------------------------------------------------------------===//
+template <class T>
+struct BitpackingScanState : public SegmentScanState {
+public:
+	explicit BitpackingScanState(ColumnSegment &segment) {
+		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+		handle = buffer_manager.Pin(segment.block);
+
+		current_width_group_ptr =
+		    handle->node->buffer + segment.GetBlockOffset() + BitpackingPrimitives::BITPACKING_HEADER_SIZE;
+
+		// load offset to bitpacking widths pointer
+		auto bitpacking_widths_offset = Load<idx_t>(handle->node->buffer + segment.GetBlockOffset());
+		bitpacking_width_ptr = handle->node->buffer + segment.GetBlockOffset() + bitpacking_widths_offset;
+
+		// load the bitwidth of the first vector
+		LoadCurrentBitWidth();
+	}
+
+	unique_ptr<BufferHandle> handle;
+
+	void (*decompress_function)(data_ptr_t, data_ptr_t, bitpacking_width_t, bool skip_sign_extension);
+	T decompression_buffer[BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE];
+
+	idx_t position_in_group = 0;
+	data_ptr_t current_width_group_ptr;
+	data_ptr_t bitpacking_width_ptr;
+	bitpacking_width_t current_width;
+
+public:
+	void LoadCurrentBitWidth() {
+		D_ASSERT(bitpacking_width_ptr > handle->node->buffer &&
+		         bitpacking_width_ptr < handle->node->buffer + Storage::BLOCK_SIZE);
+		current_width = Load<bitpacking_width_t>(bitpacking_width_ptr);
+		LoadDecompressFunction();
+	}
+
+	void Skip(ColumnSegment &segment, idx_t skip_count) {
+		while (skip_count > 0) {
+			if (position_in_group + skip_count < BITPACKING_WIDTH_GROUP_SIZE) {
+				// We're not leaving this bitpacking group, we can perform all skips.
+				position_in_group += skip_count;
+				break;
+			} else {
+				// The skip crosses the current bitpacking group, we skip the remainder of this group.
+				auto skipping = BITPACKING_WIDTH_GROUP_SIZE - position_in_group;
+				position_in_group = 0;
+				current_width_group_ptr += (current_width * BITPACKING_WIDTH_GROUP_SIZE) / 8;
+
+				// Update width pointer and load new width
+				bitpacking_width_ptr -= sizeof(bitpacking_width_t);
+				LoadCurrentBitWidth();
+
+				skip_count -= skipping;
+			}
+		}
+	}
+
+	void LoadDecompressFunction() {
+		decompress_function = &BitpackingPrimitives::UnPackBlock<T>;
+	}
+};
+
+template <class T>
+unique_ptr<SegmentScanState> BitpackingInitScan(ColumnSegment &segment) {
+	auto result = make_unique<BitpackingScanState<T>>(segment);
+	return move(result);
+}
+
+//===--------------------------------------------------------------------===//
+// Scan base data
+//===--------------------------------------------------------------------===//
+template <class T>
+void BitpackingScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
+                           idx_t result_offset) {
+	auto &scan_state = (BitpackingScanState<T> &)*state.scan_state;
+
+	T *result_data = FlatVector::GetData<T>(result);
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+
+	// Fast path for when no compression was used, we can do a single memcopy
+	if (STANDARD_VECTOR_SIZE == BITPACKING_WIDTH_GROUP_SIZE) {
+		if (scan_state.current_width == sizeof(T) * 8 && scan_count <= BITPACKING_WIDTH_GROUP_SIZE &&
+		    scan_state.position_in_group == 0) {
+
+			memcpy(result_data + result_offset, scan_state.current_width_group_ptr, scan_count * sizeof(T));
+			scan_state.current_width_group_ptr += scan_count * sizeof(T);
+			scan_state.bitpacking_width_ptr -= sizeof(bitpacking_width_t);
+			scan_state.LoadCurrentBitWidth();
+			return;
+		}
+	}
+
+	// Determine if we can skip sign extension during compression
+	auto &nstats = (NumericStatistics &)*segment.stats.statistics;
+	bool skip_sign_extend = std::is_signed<T>::value && nstats.min >= 0;
+
+	idx_t scanned = 0;
+
+	while (scanned < scan_count) {
+		// Exhausted this width group, move pointers to next group and load bitwidth for next group.
+		if (scan_state.position_in_group >= BITPACKING_WIDTH_GROUP_SIZE) {
+			scan_state.position_in_group = 0;
+			scan_state.bitpacking_width_ptr -= sizeof(bitpacking_width_t);
+			scan_state.current_width_group_ptr += (scan_state.current_width * BITPACKING_WIDTH_GROUP_SIZE) / 8;
+			scan_state.LoadCurrentBitWidth();
+		}
+
+		idx_t offset_in_compression_group =
+		    scan_state.position_in_group % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE;
+
+		idx_t to_scan = MinValue<idx_t>(scan_count - scanned, BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE -
+		                                                          offset_in_compression_group);
+
+		// Calculate start of compression algorithm group
+		data_ptr_t current_position_ptr =
+		    scan_state.current_width_group_ptr + scan_state.position_in_group * scan_state.current_width / 8;
+		data_ptr_t decompression_group_start_pointer =
+		    current_position_ptr - offset_in_compression_group * scan_state.current_width / 8;
+
+		T *current_result_ptr = result_data + result_offset + scanned;
+
+		if (to_scan == BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE && offset_in_compression_group == 0) {
+			// Decompress directly into result vector
+			scan_state.decompress_function((data_ptr_t)current_result_ptr, decompression_group_start_pointer,
+			                               scan_state.current_width, skip_sign_extend);
+		} else {
+			// Decompress compression algorithm to buffer
+			scan_state.decompress_function((data_ptr_t)scan_state.decompression_buffer,
+			                               decompression_group_start_pointer, scan_state.current_width,
+			                               skip_sign_extend);
+
+			memcpy(current_result_ptr, scan_state.decompression_buffer + offset_in_compression_group,
+			       to_scan * sizeof(T));
+		}
+
+		scanned += to_scan;
+		scan_state.position_in_group += to_scan;
+	}
+}
+
+template <class T>
+void BitpackingScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
+	BitpackingScanPartial<T>(segment, state, scan_count, result, 0);
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch
+//===--------------------------------------------------------------------===//
+template <class T>
+void BitpackingFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result,
+                        idx_t result_idx) {
+	BitpackingScanState<T> scan_state(segment);
+	scan_state.Skip(segment, row_id);
+	auto result_data = FlatVector::GetData<T>(result);
+	T *current_result_ptr = result_data + result_idx;
+
+	// TODO clean up, is reused in partialscan
+	idx_t offset_in_compression_group =
+	    scan_state.position_in_group % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE;
+
+	data_ptr_t decompression_group_start_pointer =
+	    scan_state.current_width_group_ptr +
+	    (scan_state.position_in_group - offset_in_compression_group) * scan_state.current_width / 8;
+
+	auto &nstats = (NumericStatistics &)*segment.stats.statistics;
+	bool skip_sign_extend = std::is_signed<T>::value && nstats.min >= 0;
+
+	scan_state.decompress_function((data_ptr_t)scan_state.decompression_buffer, decompression_group_start_pointer,
+	                               scan_state.current_width, skip_sign_extend);
+
+	*current_result_ptr = *(T *)(scan_state.decompression_buffer + offset_in_compression_group);
+}
+template <class T>
+void BitpackingSkip(ColumnSegment &segment, ColumnScanState &state, idx_t skip_count) {
+	auto &scan_state = (BitpackingScanState<T> &)*state.scan_state;
+	scan_state.Skip(segment, skip_count);
+}
+
+//===--------------------------------------------------------------------===//
+// Get Function
+//===--------------------------------------------------------------------===//
+template <class T>
+CompressionFunction GetBitpackingFunction(PhysicalType data_type) {
+	return CompressionFunction(CompressionType::COMPRESSION_BITPACKING, data_type, BitpackingInitAnalyze<T>,
+	                           BitpackingAnalyze<T>, BitpackingFinalAnalyze<T>, BitpackingInitCompression<T>,
+	                           BitpackingCompress<T>, BitpackingFinalizeCompress<T>, BitpackingInitScan<T>,
+	                           BitpackingScan<T>, BitpackingScanPartial<T>, BitpackingFetchRow<T>, BitpackingSkip<T>);
+}
+
+CompressionFunction BitpackingFun::GetFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return GetBitpackingFunction<int8_t>(type);
+	case PhysicalType::INT16:
+		return GetBitpackingFunction<int16_t>(type);
+	case PhysicalType::INT32:
+		return GetBitpackingFunction<int32_t>(type);
+	case PhysicalType::INT64:
+		return GetBitpackingFunction<int64_t>(type);
+	case PhysicalType::UINT8:
+		return GetBitpackingFunction<uint8_t>(type);
+	case PhysicalType::UINT16:
+		return GetBitpackingFunction<uint16_t>(type);
+	case PhysicalType::UINT32:
+		return GetBitpackingFunction<uint32_t>(type);
+	case PhysicalType::UINT64:
+		return GetBitpackingFunction<uint64_t>(type);
+	default:
+		throw InternalException("Unsupported type for Bitpacking");
+	}
+}
+
+bool BitpackingFun::TypeIsSupported(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+		return true;
+	default:
+		return false;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct StringHash {
+	std::size_t operator()(const string &k) const {
+		return Hash(k.c_str(), k.size());
+	}
+};
+
+// Abstract class for keeping compression state either for compression or size analysis
+class DictionaryCompressionState : public CompressionState {
+public:
+	bool UpdateState(Vector &scan_vector, idx_t count) {
+		VectorData vdata;
+		scan_vector.Orrify(count, vdata);
+		auto data = (string_t *)vdata.data;
+		Verify();
+
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = vdata.sel->get_index(i);
+			size_t string_size = 0;
+			bool new_string = false;
+			auto row_is_valid = vdata.validity.RowIsValid(idx);
+
+			if (row_is_valid) {
+				string_size = data[idx].GetSize();
+				if (string_size >= StringUncompressed::STRING_BLOCK_LIMIT) {
+					// Big strings not implemented for dictionary compression
+					return false;
+				}
+				new_string = !LookupString(data[idx]);
+			}
+
+			bool fits = HasEnoughSpace(new_string, string_size);
+			if (!fits) {
+				Flush();
+				new_string = true;
+				D_ASSERT(HasEnoughSpace(new_string, string_size));
+			}
+
+			if (!row_is_valid) {
+				AddNull();
+			} else if (new_string) {
+				AddNewString(data[idx]);
+			} else {
+				AddLastLookup();
+			}
+
+			Verify();
+		}
+
+		return true;
+	}
+
+protected:
+	// Should verify the State
+	virtual void Verify() = 0;
+	// Performs a lookup of str, storing the result internally
+	virtual bool LookupString(string_t str) = 0;
+	// Add the most recently looked up str to compression state
+	virtual void AddLastLookup() = 0;
+	// Add string to the state that is known to not be seen yet
+	virtual void AddNewString(string_t str) = 0;
+	// Add a null value to the compression state
+	virtual void AddNull() = 0;
+	// Check if we have enough space to add a string
+	virtual bool HasEnoughSpace(bool new_string, size_t string_size) = 0;
+	// Flush the segment to disk if compressing or reset the counters if analyzing
+	virtual void Flush(bool final = false) = 0;
+};
+
+typedef struct {
+	uint32_t dict_size;
+	uint32_t dict_end;
+	uint32_t index_buffer_offset;
+	uint32_t index_buffer_count;
+	uint32_t bitpacking_width;
+} dictionary_compression_header_t;
+
+struct DictionaryCompressionStorage {
+	static constexpr float MINIMUM_COMPRESSION_RATIO = 1.2;
+	static constexpr uint16_t DICTIONARY_HEADER_SIZE = sizeof(dictionary_compression_header_t);
+	static constexpr size_t COMPACTION_FLUSH_LIMIT = (size_t)Storage::BLOCK_SIZE / 5 * 4;
+
+	static unique_ptr<AnalyzeState> StringInitAnalyze(ColumnData &col_data, PhysicalType type);
+	static bool StringAnalyze(AnalyzeState &state_p, Vector &input, idx_t count);
+	static idx_t StringFinalAnalyze(AnalyzeState &state_p);
+
+	static unique_ptr<CompressionState> InitCompression(ColumnDataCheckpointer &checkpointer,
+	                                                    unique_ptr<AnalyzeState> state);
+	static void Compress(CompressionState &state_p, Vector &scan_vector, idx_t count);
+	static void FinalizeCompress(CompressionState &state_p);
+
+	static unique_ptr<SegmentScanState> StringInitScan(ColumnSegment &segment);
+	template <bool ALLOW_DICT_VECTORS>
+	static void StringScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
+	                              idx_t result_offset);
+	static void StringScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result);
+	static void StringFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result,
+	                           idx_t result_idx);
+
+	static bool HasEnoughSpace(idx_t current_count, idx_t index_count, idx_t dict_size,
+	                           bitpacking_width_t packing_width);
+	static idx_t RequiredSpace(idx_t current_count, idx_t index_count, idx_t dict_size,
+	                           bitpacking_width_t packing_width);
+
+	static StringDictionaryContainer GetDictionary(ColumnSegment &segment, BufferHandle &handle);
+	static void SetDictionary(ColumnSegment &segment, BufferHandle &handle, StringDictionaryContainer container);
+	static string_t FetchStringFromDict(ColumnSegment &segment, StringDictionaryContainer dict, data_ptr_t baseptr,
+	                                    int32_t dict_offset, uint16_t string_len);
+	static uint16_t GetStringLength(uint32_t *index_buffer_ptr, sel_t index);
+};
+
+// Dictionary compression uses a combination of bitpacking and a dictionary to compress string segments. The data is
+// stored across three buffers: the index buffer, the selection buffer and the dictionary. Firstly the Index buffer
+// contains the offsets into the dictionary which are also used to determine the string lengths. Each value in the
+// dictionary gets a single unique index in the index buffer. Secondly, the selection buffer maps the tuples to an index
+// in the index buffer. The selection buffer is compressed with bitpacking. Finally, the dictionary contains simply all
+// the unique strings without lenghts or null termination as we can deduce the lengths from the index buffer. The
+// addition of the selection buffer is done for two reasons: firstly, to allow the scan to emit dictionary vectors by
+// scanning the whole dictionary at once and then scanning the selection buffer for each emitted vector. Secondly, it
+// allows for efficient bitpacking compression as the selection values should remain relatively small.
+struct DictionaryCompressionCompressState : public DictionaryCompressionState {
+	explicit DictionaryCompressionCompressState(ColumnDataCheckpointer &checkpointer) : checkpointer(checkpointer) {
+		auto &db = checkpointer.GetDatabase();
+		auto &config = DBConfig::GetConfig(db);
+		function = config.GetCompressionFunction(CompressionType::COMPRESSION_DICTIONARY, PhysicalType::VARCHAR);
+		CreateEmptySegment(checkpointer.GetRowGroup().start);
+	}
+
+	void CreateEmptySegment(idx_t row_start) {
+		auto &db = checkpointer.GetDatabase();
+		auto &type = checkpointer.GetType();
+		auto compressed_segment = ColumnSegment::CreateTransientSegment(db, type, row_start);
+		current_segment = move(compressed_segment);
+
+		current_segment->function = function;
+
+		// Reset the buffers and string map
+		current_string_map.clear();
+		index_buffer.clear();
+		index_buffer.push_back(0); // Reserve index 0 for null strings
+		selection_buffer.clear();
+
+		current_width = 0;
+		next_width = 0;
+
+		// Reset the pointers into the current segment
+		auto &buffer_manager = BufferManager::GetBufferManager(current_segment->db);
+		current_handle = buffer_manager.Pin(current_segment->block);
+		current_dictionary = DictionaryCompressionStorage::GetDictionary(*current_segment, *current_handle);
+		current_end_ptr = current_handle->node->buffer + current_dictionary.end;
+	}
+
+	ColumnDataCheckpointer &checkpointer;
+	CompressionFunction *function;
+
+	// State regarding current segment
+	unique_ptr<ColumnSegment> current_segment;
+	unique_ptr<BufferHandle> current_handle;
+	StringDictionaryContainer current_dictionary;
+	data_ptr_t current_end_ptr;
+
+	// Buffers and map for current segment
+	std::unordered_map<string, uint32_t, StringHash> current_string_map;
+	std::vector<uint32_t> index_buffer;
+	std::vector<uint32_t> selection_buffer;
+
+	bitpacking_width_t current_width = 0;
+	bitpacking_width_t next_width = 0;
+
+	// Result of latest LookupString call
+	uint32_t latest_lookup_result;
+
+	void Verify() override {
+		current_dictionary.Verify();
+		D_ASSERT(current_segment->count == selection_buffer.size());
+		D_ASSERT(DictionaryCompressionStorage::HasEnoughSpace(current_segment->count.load(), index_buffer.size(),
+		                                                      current_dictionary.size, current_width));
+		D_ASSERT(current_dictionary.end == Storage::BLOCK_SIZE);
+		D_ASSERT(index_buffer.size() == current_string_map.size() + 1); // +1 is for null value
+	}
+
+	bool LookupString(string_t str) override {
+		auto search = current_string_map.find(str.GetString());
+		auto has_result = search != current_string_map.end();
+
+		if (has_result) {
+			latest_lookup_result = search->second;
+		}
+		return has_result;
+	}
+
+	void AddNewString(string_t str) override {
+		UncompressedStringStorage::UpdateStringStats(current_segment->stats, str);
+
+		// Copy string to dict
+		current_dictionary.size += str.GetSize();
+		auto dict_pos = current_end_ptr - current_dictionary.size;
+		memcpy(dict_pos, str.GetDataUnsafe(), str.GetSize());
+		current_dictionary.Verify();
+		D_ASSERT(current_dictionary.end == Storage::BLOCK_SIZE);
+
+		// Update buffers and map
+		index_buffer.push_back(current_dictionary.size);
+		selection_buffer.push_back(index_buffer.size() - 1);
+		current_string_map.insert({str.GetString(), index_buffer.size() - 1});
+		DictionaryCompressionStorage::SetDictionary(*current_segment, *current_handle, current_dictionary);
+
+		current_width = next_width;
+		current_segment->count++;
+	}
+
+	void AddNull() override {
+		selection_buffer.push_back(0);
+		current_segment->count++;
+	}
+
+	void AddLastLookup() override {
+		selection_buffer.push_back(latest_lookup_result);
+		current_segment->count++;
+	}
+
+	bool HasEnoughSpace(bool new_string, size_t string_size) override {
+		if (new_string) {
+			next_width = BitpackingPrimitives::MinimumBitWidth(index_buffer.size() - 1 + new_string);
+			return DictionaryCompressionStorage::HasEnoughSpace(current_segment->count.load() + 1,
+			                                                    index_buffer.size() + 1,
+			                                                    current_dictionary.size + string_size, next_width);
+		} else {
+			return DictionaryCompressionStorage::HasEnoughSpace(current_segment->count.load() + 1, index_buffer.size(),
+			                                                    current_dictionary.size, current_width);
+		}
+	}
+
+	void Flush(bool final = false) override {
+		auto next_start = current_segment->start + current_segment->count;
+
+		auto segment_size = Finalize();
+		auto &state = checkpointer.GetCheckpointState();
+		state.FlushSegment(move(current_segment), segment_size);
+
+		if (!final) {
+			CreateEmptySegment(next_start);
+		}
+	}
+
+	idx_t Finalize() {
+		auto &buffer_manager = BufferManager::GetBufferManager(current_segment->db);
+		auto handle = buffer_manager.Pin(current_segment->block);
+		D_ASSERT(current_dictionary.end == Storage::BLOCK_SIZE);
+
+		// calculate sizes
+		auto compressed_selection_buffer_size =
+		    BitpackingPrimitives::GetRequiredSize<sel_t>(current_segment->count, current_width);
+		auto index_buffer_size = index_buffer.size() * sizeof(uint32_t);
+		auto total_size = DictionaryCompressionStorage::DICTIONARY_HEADER_SIZE + compressed_selection_buffer_size +
+		                  index_buffer_size + current_dictionary.size;
+
+		// calculate ptr and offsets
+		auto base_ptr = handle->node->buffer;
+		auto header_ptr = (dictionary_compression_header_t *)base_ptr;
+		auto compressed_selection_buffer_offset = DictionaryCompressionStorage::DICTIONARY_HEADER_SIZE;
+		auto index_buffer_offset = compressed_selection_buffer_offset + compressed_selection_buffer_size;
+
+		// Write compressed selection buffer
+		BitpackingPrimitives::PackBuffer<sel_t, false>(base_ptr + compressed_selection_buffer_offset,
+		                                               (sel_t *)(selection_buffer.data()), current_segment->count,
+		                                               current_width);
+
+		// Write the index buffer
+		memcpy(base_ptr + index_buffer_offset, index_buffer.data(), index_buffer_size);
+
+		// Store sizes and offsets in segment header
+		Store<uint32_t>(index_buffer_offset, (data_ptr_t)&header_ptr->index_buffer_offset);
+		Store<uint32_t>(index_buffer.size(), (data_ptr_t)&header_ptr->index_buffer_count);
+		Store<uint32_t>((uint32_t)current_width, (data_ptr_t)&header_ptr->bitpacking_width);
+
+		D_ASSERT(current_width == BitpackingPrimitives::MinimumBitWidth(index_buffer.size() - 1));
+		D_ASSERT(DictionaryCompressionStorage::HasEnoughSpace(current_segment->count, index_buffer.size(),
+		                                                      current_dictionary.size, current_width));
+		D_ASSERT((uint64_t)*max_element(std::begin(selection_buffer), std::end(selection_buffer)) ==
+		         index_buffer.size() - 1);
+
+		if (total_size >= DictionaryCompressionStorage::COMPACTION_FLUSH_LIMIT) {
+			// the block is full enough, don't bother moving around the dictionary
+			return Storage::BLOCK_SIZE;
+		}
+		// the block has space left: figure out how much space we can save
+		auto move_amount = Storage::BLOCK_SIZE - total_size;
+		// move the dictionary so it lines up exactly with the offsets
+		auto new_dictionary_offset = index_buffer_offset + index_buffer_size;
+		memmove(base_ptr + new_dictionary_offset, base_ptr + current_dictionary.end - current_dictionary.size,
+		        current_dictionary.size);
+		current_dictionary.end -= move_amount;
+		D_ASSERT(current_dictionary.end == total_size);
+		// write the new dictionary (with the updated "end")
+		DictionaryCompressionStorage::SetDictionary(*current_segment, *handle, current_dictionary);
+		return total_size;
+	}
+};
+
+//===--------------------------------------------------------------------===//
+// Analyze
+//===--------------------------------------------------------------------===//
+struct DictionaryCompressionAnalyzeState : public AnalyzeState, DictionaryCompressionState {
+	DictionaryCompressionAnalyzeState()
+	    : segment_count(0), current_tuple_count(0), current_unique_count(0), current_dict_size(0), current_width(0),
+	      next_width(0) {
+	}
+
+	size_t segment_count;
+	idx_t current_tuple_count;
+	idx_t current_unique_count;
+	size_t current_dict_size;
+	std::unordered_set<string, StringHash> current_set;
+	bitpacking_width_t current_width;
+	bitpacking_width_t next_width;
+
+	bool LookupString(string_t str) override {
+		return current_set.count(str.GetString());
+	}
+
+	void AddNewString(string_t str) override {
+		current_tuple_count++;
+		current_unique_count++;
+		current_dict_size += str.GetSize();
+		current_set.insert(str.GetString());
+		current_width = next_width;
+	}
+
+	void AddLastLookup() override {
+		current_tuple_count++;
+	}
+
+	void AddNull() override {
+		current_tuple_count++;
+	}
+
+	bool HasEnoughSpace(bool new_string, size_t string_size) override {
+		if (new_string) {
+			next_width =
+			    BitpackingPrimitives::MinimumBitWidth(current_unique_count + 2); // 1 for null, one for new string
+			return DictionaryCompressionStorage::HasEnoughSpace(current_tuple_count + 1, current_unique_count + 1,
+			                                                    current_dict_size + string_size, next_width);
+		} else {
+			return DictionaryCompressionStorage::HasEnoughSpace(current_tuple_count + 1, current_unique_count,
+			                                                    current_dict_size, current_width);
+		}
+	}
+
+	void Flush(bool final = false) override {
+		segment_count++;
+		current_tuple_count = 0;
+		current_unique_count = 0;
+		current_dict_size = 0;
+		current_set.clear();
+	}
+	void Verify() override {};
+};
+
+unique_ptr<AnalyzeState> DictionaryCompressionStorage::StringInitAnalyze(ColumnData &col_data, PhysicalType type) {
+	return make_unique<DictionaryCompressionAnalyzeState>();
+}
+
+bool DictionaryCompressionStorage::StringAnalyze(AnalyzeState &state_p, Vector &input, idx_t count) {
+	auto &state = (DictionaryCompressionAnalyzeState &)state_p;
+	return state.UpdateState(input, count);
+}
+
+idx_t DictionaryCompressionStorage::StringFinalAnalyze(AnalyzeState &state_p) {
+	auto &state = (DictionaryCompressionAnalyzeState &)state_p;
+
+	auto width = BitpackingPrimitives::MinimumBitWidth(state.current_unique_count + 1);
+	auto req_space =
+	    RequiredSpace(state.current_tuple_count, state.current_unique_count, state.current_dict_size, width);
+
+	return MINIMUM_COMPRESSION_RATIO * (state.segment_count * Storage::BLOCK_SIZE + req_space);
+}
+
+//===--------------------------------------------------------------------===//
+// Compress
+//===--------------------------------------------------------------------===//
+unique_ptr<CompressionState> DictionaryCompressionStorage::InitCompression(ColumnDataCheckpointer &checkpointer,
+                                                                           unique_ptr<AnalyzeState> state) {
+	return make_unique<DictionaryCompressionCompressState>(checkpointer);
+}
+
+void DictionaryCompressionStorage::Compress(CompressionState &state_p, Vector &scan_vector, idx_t count) {
+	auto &state = (DictionaryCompressionCompressState &)state_p;
+	state.UpdateState(scan_vector, count);
+}
+
+void DictionaryCompressionStorage::FinalizeCompress(CompressionState &state_p) {
+	auto &state = (DictionaryCompressionCompressState &)state_p;
+	state.Flush(true);
+}
+
+//===--------------------------------------------------------------------===//
+// Scan
+//===--------------------------------------------------------------------===//
+struct CompressedStringScanState : public StringScanState {
+	unique_ptr<BufferHandle> handle;
+	buffer_ptr<Vector> dictionary;
+	bitpacking_width_t current_width;
+	buffer_ptr<SelectionVector> sel_vec;
+	idx_t sel_vec_size = 0;
+};
+
+unique_ptr<SegmentScanState> DictionaryCompressionStorage::StringInitScan(ColumnSegment &segment) {
+	auto state = make_unique<CompressedStringScanState>();
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	state->handle = buffer_manager.Pin(segment.block);
+
+	auto baseptr = state->handle->node->buffer + segment.GetBlockOffset();
+
+	// Load header values
+	auto dict = DictionaryCompressionStorage::GetDictionary(segment, *(state->handle));
+	auto header_ptr = (dictionary_compression_header_t *)baseptr;
+	auto index_buffer_offset = Load<uint32_t>((data_ptr_t)&header_ptr->index_buffer_offset);
+	auto index_buffer_count = Load<uint32_t>((data_ptr_t)&header_ptr->index_buffer_count);
+	state->current_width = (bitpacking_width_t)(Load<uint32_t>((data_ptr_t)&header_ptr->bitpacking_width));
+
+	auto index_buffer_ptr = (uint32_t *)(baseptr + index_buffer_offset);
+
+	state->dictionary = make_buffer<Vector>(segment.type, index_buffer_count);
+	auto dict_child_data = FlatVector::GetData<string_t>(*(state->dictionary));
+
+	for (uint32_t i = 0; i < index_buffer_count; i++) {
+		// NOTE: the passing of dict_child_vector, will not be used, its for big strings
+		uint16_t str_len = GetStringLength(index_buffer_ptr, i);
+		dict_child_data[i] = FetchStringFromDict(segment, dict, baseptr, index_buffer_ptr[i], str_len);
+	}
+
+	return move(state);
+}
+
+//===--------------------------------------------------------------------===//
+// Scan base data
+//===--------------------------------------------------------------------===//
+template <bool ALLOW_DICT_VECTORS>
+void DictionaryCompressionStorage::StringScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count,
+                                                     Vector &result, idx_t result_offset) {
+	// clear any previously locked buffers and get the primary buffer handle
+	auto &scan_state = (CompressedStringScanState &)*state.scan_state;
+	auto start = segment.GetRelativeIndex(state.row_index);
+
+	auto baseptr = scan_state.handle->node->buffer + segment.GetBlockOffset();
+	auto dict = DictionaryCompressionStorage::GetDictionary(segment, *scan_state.handle);
+
+	auto header_ptr = (dictionary_compression_header_t *)baseptr;
+	auto index_buffer_offset = Load<uint32_t>((data_ptr_t)&header_ptr->index_buffer_offset);
+	auto index_buffer_ptr = (uint32_t *)(baseptr + index_buffer_offset);
+
+	auto base_data = (data_ptr_t)(baseptr + DICTIONARY_HEADER_SIZE);
+	auto result_data = FlatVector::GetData<string_t>(result);
+
+	if (!ALLOW_DICT_VECTORS || scan_count != STANDARD_VECTOR_SIZE ||
+	    start % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE != 0) {
+		// Emit regular vector
+
+		// Handling non-bitpacking-group-aligned start values;
+		idx_t start_offset = start % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE;
+
+		// We will scan in blocks of BITPACKING_ALGORITHM_GROUP_SIZE, so we may scan some extra values.
+		idx_t decompress_count = BitpackingPrimitives::RoundUpToAlgorithmGroupSize(scan_count + start_offset);
+
+		// Create a decompression buffer of sufficient size if we don't already have one.
+		if (!scan_state.sel_vec || scan_state.sel_vec_size < decompress_count) {
+			scan_state.sel_vec_size = decompress_count;
+			scan_state.sel_vec = make_buffer<SelectionVector>(decompress_count);
+		}
+
+		data_ptr_t src = &base_data[((start - start_offset) * scan_state.current_width) / 8];
+		sel_t *sel_vec_ptr = scan_state.sel_vec->data();
+
+		BitpackingPrimitives::UnPackBuffer<sel_t>((data_ptr_t)sel_vec_ptr, src, decompress_count,
+		                                          scan_state.current_width);
+
+		for (idx_t i = 0; i < scan_count; i++) {
+			// Lookup dict offset in index buffer
+			auto string_number = scan_state.sel_vec->get_index(i + start_offset);
+			auto dict_offset = index_buffer_ptr[string_number];
+			uint16_t str_len = GetStringLength(index_buffer_ptr, string_number);
+			result_data[result_offset + i] = FetchStringFromDict(segment, dict, baseptr, dict_offset, str_len);
+		}
+
+	} else {
+		D_ASSERT(start % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE == 0);
+		D_ASSERT(scan_count == STANDARD_VECTOR_SIZE);
+		D_ASSERT(result_offset == 0);
+
+		idx_t decompress_count = BitpackingPrimitives::RoundUpToAlgorithmGroupSize(scan_count);
+
+		// Create a selection vector of sufficient size if we don't already have one.
+		if (!scan_state.sel_vec || scan_state.sel_vec_size < decompress_count) {
+			scan_state.sel_vec_size = decompress_count;
+			scan_state.sel_vec = make_buffer<SelectionVector>(decompress_count);
+		}
+
+		// Scanning 1024 values, emitting a dict vector
+		data_ptr_t dst = (data_ptr_t)(scan_state.sel_vec->data());
+		data_ptr_t src = (data_ptr_t)&base_data[(start * scan_state.current_width) / 8];
+
+		BitpackingPrimitives::UnPackBuffer<sel_t>(dst, src, scan_count, scan_state.current_width);
+
+		result.Slice(*(scan_state.dictionary), *scan_state.sel_vec, scan_count);
+	}
+}
+
+void DictionaryCompressionStorage::StringScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count,
+                                              Vector &result) {
+	StringScanPartial<true>(segment, state, scan_count, result, 0);
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch
+//===--------------------------------------------------------------------===//
+void DictionaryCompressionStorage::StringFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id,
+                                                  Vector &result, idx_t result_idx) {
+	// fetch a single row from the string segment
+	// first pin the main buffer if it is not already pinned
+	auto primary_id = segment.block->BlockId();
+
+	BufferHandle *handle_ptr;
+	auto entry = state.handles.find(primary_id);
+	if (entry == state.handles.end()) {
+		// not pinned yet: pin it
+		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+		auto handle = buffer_manager.Pin(segment.block);
+		handle_ptr = handle.get();
+		state.handles[primary_id] = move(handle);
+	} else {
+		// already pinned: use the pinned handle
+		handle_ptr = entry->second.get();
+	}
+
+	auto baseptr = handle_ptr->node->buffer + segment.GetBlockOffset();
+	auto header_ptr = (dictionary_compression_header_t *)baseptr;
+	auto dict = DictionaryCompressionStorage::GetDictionary(segment, *handle_ptr);
+	auto index_buffer_offset = Load<uint32_t>((data_ptr_t)&header_ptr->index_buffer_offset);
+	auto width = (bitpacking_width_t)(Load<uint32_t>((data_ptr_t)&header_ptr->bitpacking_width));
+	auto index_buffer_ptr = (uint32_t *)(baseptr + index_buffer_offset);
+	auto base_data = (data_ptr_t)(baseptr + DICTIONARY_HEADER_SIZE);
+	auto result_data = FlatVector::GetData<string_t>(result);
+
+	// Handling non-bitpacking-group-aligned start values;
+	idx_t start_offset = row_id % BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE;
+
+	// Decompress part of selection buffer we need for this value.
+	sel_t decompression_buffer[BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE];
+	data_ptr_t src = (data_ptr_t)&base_data[((row_id - start_offset) * width) / 8];
+	BitpackingPrimitives::UnPackBuffer<sel_t>((data_ptr_t)decompression_buffer, src,
+	                                          BitpackingPrimitives::BITPACKING_ALGORITHM_GROUP_SIZE, width);
+
+	auto selection_value = decompression_buffer[start_offset];
+	auto dict_offset = index_buffer_ptr[selection_value];
+	uint16_t str_len = GetStringLength(index_buffer_ptr, selection_value);
+
+	result_data[result_idx] = FetchStringFromDict(segment, dict, baseptr, dict_offset, str_len);
+}
+
+//===--------------------------------------------------------------------===//
+// Helper Functions
+//===--------------------------------------------------------------------===//
+bool DictionaryCompressionStorage::HasEnoughSpace(idx_t current_count, idx_t index_count, idx_t dict_size,
+                                                  bitpacking_width_t packing_width) {
+	return RequiredSpace(current_count, index_count, dict_size, packing_width) <= Storage::BLOCK_SIZE;
+}
+
+idx_t DictionaryCompressionStorage::RequiredSpace(idx_t current_count, idx_t index_count, idx_t dict_size,
+                                                  bitpacking_width_t packing_width) {
+	idx_t base_space = DICTIONARY_HEADER_SIZE + dict_size;
+	idx_t string_number_space = BitpackingPrimitives::GetRequiredSize<sel_t>(current_count, packing_width);
+	idx_t index_space = index_count * sizeof(uint32_t);
+
+	idx_t used_space = base_space + index_space + string_number_space;
+
+	return used_space;
+}
+
+StringDictionaryContainer DictionaryCompressionStorage::GetDictionary(ColumnSegment &segment, BufferHandle &handle) {
+	auto header_ptr = (dictionary_compression_header_t *)(handle.node->buffer + segment.GetBlockOffset());
+	StringDictionaryContainer container;
+	container.size = Load<uint32_t>((data_ptr_t)&header_ptr->dict_size);
+	container.end = Load<uint32_t>((data_ptr_t)&header_ptr->dict_end);
+	return container;
+}
+
+void DictionaryCompressionStorage::SetDictionary(ColumnSegment &segment, BufferHandle &handle,
+                                                 StringDictionaryContainer container) {
+	auto header_ptr = (dictionary_compression_header_t *)(handle.node->buffer + segment.GetBlockOffset());
+	Store<uint32_t>(container.size, (data_ptr_t)&header_ptr->dict_size);
+	Store<uint32_t>(container.end, (data_ptr_t)&header_ptr->dict_end);
+}
+
+string_t DictionaryCompressionStorage::FetchStringFromDict(ColumnSegment &segment, StringDictionaryContainer dict,
+                                                           data_ptr_t baseptr, int32_t dict_offset,
+                                                           uint16_t string_len) {
+	D_ASSERT(dict_offset >= 0 && dict_offset <= Storage::BLOCK_SIZE);
+
+	if (dict_offset == 0) {
+		return string_t(nullptr, 0);
+	}
+	// normal string: read string from this block
+	auto dict_end = baseptr + dict.end;
+	auto dict_pos = dict_end - dict_offset;
+
+	auto str_ptr = (char *)(dict_pos);
+	return string_t(str_ptr, string_len);
+}
+
+uint16_t DictionaryCompressionStorage::GetStringLength(uint32_t *index_buffer_ptr, sel_t index) {
+	if (index == 0) {
+		return 0;
+	} else {
+		return index_buffer_ptr[index] - index_buffer_ptr[index - 1];
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Get Function
+//===--------------------------------------------------------------------===//
+CompressionFunction DictionaryCompressionFun::GetFunction(PhysicalType data_type) {
+	return CompressionFunction(
+	    CompressionType::COMPRESSION_DICTIONARY, data_type, DictionaryCompressionStorage ::StringInitAnalyze,
+	    DictionaryCompressionStorage::StringAnalyze, DictionaryCompressionStorage::StringFinalAnalyze,
+	    DictionaryCompressionStorage::InitCompression, DictionaryCompressionStorage::Compress,
+	    DictionaryCompressionStorage::FinalizeCompress, DictionaryCompressionStorage::StringInitScan,
+	    DictionaryCompressionStorage::StringScan, DictionaryCompressionStorage::StringScanPartial<false>,
+	    DictionaryCompressionStorage::StringFetchRow, UncompressedFunctions::EmptySkip);
+}
+
+bool DictionaryCompressionFun::TypeIsSupported(PhysicalType type) {
+	return type == PhysicalType::VARCHAR;
+}
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Analyze
+//===--------------------------------------------------------------------===//
+struct FixedSizeAnalyzeState : public AnalyzeState {
+	FixedSizeAnalyzeState() : count(0) {
+	}
+
+	idx_t count;
+};
+
+unique_ptr<AnalyzeState> FixedSizeInitAnalyze(ColumnData &col_data, PhysicalType type) {
+	return make_unique<FixedSizeAnalyzeState>();
+}
+
+bool FixedSizeAnalyze(AnalyzeState &state_p, Vector &input, idx_t count) {
+	auto &state = (FixedSizeAnalyzeState &)state_p;
+	state.count += count;
+	return true;
+}
+
+template <class T>
+idx_t FixedSizeFinalAnalyze(AnalyzeState &state_p) {
+	auto &state = (FixedSizeAnalyzeState &)state_p;
+	return sizeof(T) * state.count;
+}
+
+//===--------------------------------------------------------------------===//
+// Compress
+//===--------------------------------------------------------------------===//
+UncompressedCompressState::UncompressedCompressState(ColumnDataCheckpointer &checkpointer)
+    : checkpointer(checkpointer) {
+	CreateEmptySegment(checkpointer.GetRowGroup().start);
+}
+
+void UncompressedCompressState::CreateEmptySegment(idx_t row_start) {
+	auto &db = checkpointer.GetDatabase();
+	auto &type = checkpointer.GetType();
+	auto compressed_segment = ColumnSegment::CreateTransientSegment(db, type, row_start);
+	if (type.InternalType() == PhysicalType::VARCHAR) {
+		auto &state = (UncompressedStringSegmentState &)*compressed_segment->GetSegmentState();
+		state.overflow_writer = make_unique<WriteOverflowStringsToDisk>(db);
+	}
+	current_segment = move(compressed_segment);
+}
+
+void UncompressedCompressState::FlushSegment(idx_t segment_size) {
+	auto &state = checkpointer.GetCheckpointState();
+	state.FlushSegment(move(current_segment), segment_size);
+}
+
+void UncompressedCompressState::Finalize(idx_t segment_size) {
+	FlushSegment(segment_size);
+	current_segment.reset();
+}
+
+unique_ptr<CompressionState> UncompressedFunctions::InitCompression(ColumnDataCheckpointer &checkpointer,
+                                                                    unique_ptr<AnalyzeState> state) {
+	return make_unique<UncompressedCompressState>(checkpointer);
+}
+
+void UncompressedFunctions::Compress(CompressionState &state_p, Vector &data, idx_t count) {
+	auto &state = (UncompressedCompressState &)state_p;
+	VectorData vdata;
+	data.Orrify(count, vdata);
+
+	ColumnAppendState append_state;
+	idx_t offset = 0;
+	while (count > 0) {
+		idx_t appended = state.current_segment->Append(append_state, vdata, offset, count);
+		if (appended == count) {
+			// appended everything: finished
+			return;
+		}
+		auto next_start = state.current_segment->start + state.current_segment->count;
+		// the segment is full: flush it to disk
+		state.FlushSegment(state.current_segment->FinalizeAppend());
+
+		// now create a new segment and continue appending
+		state.CreateEmptySegment(next_start);
+		offset += appended;
+		count -= appended;
+	}
+}
+
+void UncompressedFunctions::FinalizeCompress(CompressionState &state_p) {
+	auto &state = (UncompressedCompressState &)state_p;
+	state.Finalize(state.current_segment->FinalizeAppend());
+}
+
+//===--------------------------------------------------------------------===//
+// Scan
+//===--------------------------------------------------------------------===//
+struct FixedSizeScanState : public SegmentScanState {
+	unique_ptr<BufferHandle> handle;
+};
+
+unique_ptr<SegmentScanState> FixedSizeInitScan(ColumnSegment &segment) {
+	auto result = make_unique<FixedSizeScanState>();
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	result->handle = buffer_manager.Pin(segment.block);
+	return move(result);
+}
+
+//===--------------------------------------------------------------------===//
+// Scan base data
+//===--------------------------------------------------------------------===//
+template <class T>
+void FixedSizeScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
+                          idx_t result_offset) {
+	auto &scan_state = (FixedSizeScanState &)*state.scan_state;
+	auto start = segment.GetRelativeIndex(state.row_index);
+
+	auto data = scan_state.handle->node->buffer + segment.GetBlockOffset();
+	auto source_data = data + start * sizeof(T);
+
+	// copy the data from the base table
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	memcpy(FlatVector::GetData(result) + result_offset * sizeof(T), source_data, scan_count * sizeof(T));
+}
+
+template <class T>
+void FixedSizeScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
+	auto &scan_state = (FixedSizeScanState &)*state.scan_state;
+	auto start = segment.GetRelativeIndex(state.row_index);
+
+	auto data = scan_state.handle->node->buffer + segment.GetBlockOffset();
+	auto source_data = data + start * sizeof(T);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	if (std::is_same<T, list_entry_t>()) {
+		// list columns are modified in-place during the scans to correct the offsets
+		// so we can't do a zero-copy there
+		memcpy(FlatVector::GetData(result), source_data, scan_count * sizeof(T));
+	} else {
+		FlatVector::SetData(result, source_data);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch
+//===--------------------------------------------------------------------===//
+template <class T>
+void FixedSizeFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result,
+                       idx_t result_idx) {
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	auto handle = buffer_manager.Pin(segment.block);
+
+	// first fetch the data from the base table
+	auto data_ptr = handle->node->buffer + segment.GetBlockOffset() + row_id * sizeof(T);
+
+	memcpy(FlatVector::GetData(result) + result_idx * sizeof(T), data_ptr, sizeof(T));
+}
+
+//===--------------------------------------------------------------------===//
+// Append
+//===--------------------------------------------------------------------===//
+template <class T>
+static void AppendLoop(SegmentStatistics &stats, data_ptr_t target, idx_t target_offset, VectorData &adata,
+                       idx_t offset, idx_t count) {
+	auto sdata = (T *)adata.data;
+	auto tdata = (T *)target;
+	if (!adata.validity.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			auto source_idx = adata.sel->get_index(offset + i);
+			auto target_idx = target_offset + i;
+			bool is_null = !adata.validity.RowIsValid(source_idx);
+			if (!is_null) {
+				NumericStatistics::Update<T>(stats, sdata[source_idx]);
+				tdata[target_idx] = sdata[source_idx];
+			} else {
+				// we insert a NullValue<T> in the null gap for debuggability
+				// this value should never be used or read anywhere
+				tdata[target_idx] = NullValue<T>();
+			}
+		}
+	} else {
+		for (idx_t i = 0; i < count; i++) {
+			auto source_idx = adata.sel->get_index(offset + i);
+			auto target_idx = target_offset + i;
+			NumericStatistics::Update<T>(stats, sdata[source_idx]);
+			tdata[target_idx] = sdata[source_idx];
+		}
+	}
+}
+
+template <>
+void AppendLoop<list_entry_t>(SegmentStatistics &stats, data_ptr_t target, idx_t target_offset, VectorData &adata,
+                              idx_t offset, idx_t count) {
+	auto sdata = (list_entry_t *)adata.data;
+	auto tdata = (list_entry_t *)target;
+	for (idx_t i = 0; i < count; i++) {
+		auto source_idx = adata.sel->get_index(offset + i);
+		auto target_idx = target_offset + i;
+		tdata[target_idx] = sdata[source_idx];
+	}
+}
+
+template <class T>
+idx_t FixedSizeAppend(ColumnSegment &segment, SegmentStatistics &stats, VectorData &data, idx_t offset, idx_t count) {
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	auto handle = buffer_manager.Pin(segment.block);
+	D_ASSERT(segment.GetBlockOffset() == 0);
+
+	auto target_ptr = handle->node->buffer;
+	idx_t max_tuple_count = Storage::BLOCK_SIZE / sizeof(T);
+	idx_t copy_count = MinValue<idx_t>(count, max_tuple_count - segment.count);
+
+	AppendLoop<T>(stats, target_ptr, segment.count, data, offset, copy_count);
+	segment.count += copy_count;
+	return copy_count;
+}
+
+template <class T>
+idx_t FixedSizeFinalizeAppend(ColumnSegment &segment, SegmentStatistics &stats) {
+	return segment.count * sizeof(T);
+}
+
+//===--------------------------------------------------------------------===//
+// Get Function
+//===--------------------------------------------------------------------===//
+template <class T>
+CompressionFunction FixedSizeGetFunction(PhysicalType data_type) {
+	return CompressionFunction(CompressionType::COMPRESSION_UNCOMPRESSED, data_type, FixedSizeInitAnalyze,
+	                           FixedSizeAnalyze, FixedSizeFinalAnalyze<T>, UncompressedFunctions::InitCompression,
+	                           UncompressedFunctions::Compress, UncompressedFunctions::FinalizeCompress,
+	                           FixedSizeInitScan, FixedSizeScan<T>, FixedSizeScanPartial<T>, FixedSizeFetchRow<T>,
+	                           UncompressedFunctions::EmptySkip, nullptr, FixedSizeAppend<T>,
+	                           FixedSizeFinalizeAppend<T>, nullptr);
+}
+
+CompressionFunction FixedSizeUncompressed::GetFunction(PhysicalType data_type) {
+	switch (data_type) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return FixedSizeGetFunction<int8_t>(data_type);
+	case PhysicalType::INT16:
+		return FixedSizeGetFunction<int16_t>(data_type);
+	case PhysicalType::INT32:
+		return FixedSizeGetFunction<int32_t>(data_type);
+	case PhysicalType::INT64:
+		return FixedSizeGetFunction<int64_t>(data_type);
+	case PhysicalType::UINT8:
+		return FixedSizeGetFunction<uint8_t>(data_type);
+	case PhysicalType::UINT16:
+		return FixedSizeGetFunction<uint16_t>(data_type);
+	case PhysicalType::UINT32:
+		return FixedSizeGetFunction<uint32_t>(data_type);
+	case PhysicalType::UINT64:
+		return FixedSizeGetFunction<uint64_t>(data_type);
+	case PhysicalType::INT128:
+		return FixedSizeGetFunction<hugeint_t>(data_type);
+	case PhysicalType::FLOAT:
+		return FixedSizeGetFunction<float>(data_type);
+	case PhysicalType::DOUBLE:
+		return FixedSizeGetFunction<double>(data_type);
+	case PhysicalType::INTERVAL:
+		return FixedSizeGetFunction<interval_t>(data_type);
+	case PhysicalType::LIST:
+		return FixedSizeGetFunction<list_entry_t>(data_type);
+	default:
+		throw InternalException("Unsupported type for FixedSizeUncompressed::GetFunction");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Scan
+//===--------------------------------------------------------------------===//
+unique_ptr<SegmentScanState> ConstantInitScan(ColumnSegment &segment) {
+	return nullptr;
+}
+
+//===--------------------------------------------------------------------===//
+// Scan base data
+//===--------------------------------------------------------------------===//
+void ConstantScanFunctionValidity(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
+	auto &validity = (ValidityStatistics &)*segment.stats.statistics;
+	if (validity.has_null) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+		ConstantVector::SetNull(result, true);
+	}
+}
+
+template <class T>
+void ConstantScanFunction(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
+	auto &nstats = (NumericStatistics &)*segment.stats.statistics;
+
+	auto data = FlatVector::GetData<T>(result);
+	data[0] = nstats.min.GetValueUnsafe<T>();
+	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+}
+
+//===--------------------------------------------------------------------===//
+// Scan Partial
+//===--------------------------------------------------------------------===//
+void ConstantFillFunctionValidity(ColumnSegment &segment, Vector &result, idx_t start_idx, idx_t count) {
+	auto &validity = (ValidityStatistics &)*segment.stats.statistics;
+	if (validity.has_null) {
+		auto &mask = FlatVector::Validity(result);
+		for (idx_t i = 0; i < count; i++) {
+			mask.SetInvalid(start_idx + i);
+		}
+	}
+}
+
+template <class T>
+void ConstantFillFunction(ColumnSegment &segment, Vector &result, idx_t start_idx, idx_t count) {
+	auto &nstats = (NumericStatistics &)*segment.stats.statistics;
+
+	auto data = FlatVector::GetData<T>(result);
+	auto constant_value = nstats.min.GetValueUnsafe<T>();
+	for (idx_t i = 0; i < count; i++) {
+		data[start_idx + i] = constant_value;
+	}
+}
+
+void ConstantScanPartialValidity(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
+                                 idx_t result_offset) {
+	ConstantFillFunctionValidity(segment, result, result_offset, scan_count);
+}
+
+template <class T>
+void ConstantScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
+                         idx_t result_offset) {
+	ConstantFillFunction<T>(segment, result, result_offset, scan_count);
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch
+//===--------------------------------------------------------------------===//
+void ConstantFetchRowValidity(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result,
+                              idx_t result_idx) {
+	ConstantFillFunctionValidity(segment, result, result_idx, 1);
+}
+
+template <class T>
+void ConstantFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result, idx_t result_idx) {
+	ConstantFillFunction<T>(segment, result, result_idx, 1);
+}
+
+//===--------------------------------------------------------------------===//
+// Get Function
+//===--------------------------------------------------------------------===//
+CompressionFunction ConstantGetFunctionValidity(PhysicalType data_type) {
+	D_ASSERT(data_type == PhysicalType::BIT);
+	return CompressionFunction(CompressionType::COMPRESSION_CONSTANT, data_type, nullptr, nullptr, nullptr, nullptr,
+	                           nullptr, nullptr, ConstantInitScan, ConstantScanFunctionValidity,
+	                           ConstantScanPartialValidity, ConstantFetchRowValidity, UncompressedFunctions::EmptySkip);
+}
+
+template <class T>
+CompressionFunction ConstantGetFunction(PhysicalType data_type) {
+	return CompressionFunction(CompressionType::COMPRESSION_CONSTANT, data_type, nullptr, nullptr, nullptr, nullptr,
+	                           nullptr, nullptr, ConstantInitScan, ConstantScanFunction<T>, ConstantScanPartial<T>,
+	                           ConstantFetchRow<T>, UncompressedFunctions::EmptySkip);
+}
+
+CompressionFunction ConstantFun::GetFunction(PhysicalType data_type) {
+	switch (data_type) {
+	case PhysicalType::BIT:
+		return ConstantGetFunctionValidity(data_type);
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return ConstantGetFunction<int8_t>(data_type);
+	case PhysicalType::INT16:
+		return ConstantGetFunction<int16_t>(data_type);
+	case PhysicalType::INT32:
+		return ConstantGetFunction<int32_t>(data_type);
+	case PhysicalType::INT64:
+		return ConstantGetFunction<int64_t>(data_type);
+	case PhysicalType::UINT8:
+		return ConstantGetFunction<uint8_t>(data_type);
+	case PhysicalType::UINT16:
+		return ConstantGetFunction<uint16_t>(data_type);
+	case PhysicalType::UINT32:
+		return ConstantGetFunction<uint32_t>(data_type);
+	case PhysicalType::UINT64:
+		return ConstantGetFunction<uint64_t>(data_type);
+	case PhysicalType::INT128:
+		return ConstantGetFunction<hugeint_t>(data_type);
+	case PhysicalType::FLOAT:
+		return ConstantGetFunction<float>(data_type);
+	case PhysicalType::DOUBLE:
+		return ConstantGetFunction<double>(data_type);
+	default:
+		throw InternalException("Unsupported type for ConstantUncompressed::GetFunction");
+	}
+}
+
+bool ConstantFun::TypeIsSupported(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+	case PhysicalType::INT128:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+		return true;
+	default:
+		throw InternalException("Unsupported type for constant function");
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+#include <functional>
+
+namespace duckdb {
+
+using rle_count_t = uint16_t;
+
+//===--------------------------------------------------------------------===//
+// Analyze
+//===--------------------------------------------------------------------===//
+struct EmptyRLEWriter {
+	template <class VALUE_TYPE>
+	static void Operation(VALUE_TYPE value, rle_count_t count, void *dataptr, bool is_null) {
+	}
+};
+
+template <class T>
+struct RLEState {
+	RLEState() : seen_count(0), last_value(NullValue<T>()), last_seen_count(0), dataptr(nullptr) {
+	}
+
+	idx_t seen_count;
+	T last_value;
+	rle_count_t last_seen_count;
+	void *dataptr;
+	bool all_null = true;
+
+public:
+	template <class OP>
+	void Flush() {
+		OP::template Operation<T>(last_value, last_seen_count, dataptr, all_null);
+	}
+
+	template <class OP = EmptyRLEWriter>
+	void Update(T *data, ValidityMask &validity, idx_t idx) {
+		if (validity.RowIsValid(idx)) {
+			all_null = false;
+			if (seen_count == 0) {
+				// no value seen yet
+				// assign the current value, and set the seen_count to 1
+				// note that we increment last_seen_count rather than setting it to 1
+				// this is intentional: this is the first VALID value we see
+				// but it might not be the first value in case of nulls!
+				last_value = data[idx];
+				seen_count = 1;
+				last_seen_count++;
+			} else if (last_value == data[idx]) {
+				// the last value is identical to this value: increment the last_seen_count
+				last_seen_count++;
+			} else {
+				// the values are different
+				// issue the callback on the last value
+				Flush<OP>();
+
+				// increment the seen_count and put the new value into the RLE slot
+				last_value = data[idx];
+				seen_count++;
+				last_seen_count = 1;
+			}
+		} else {
+			// NULL value: we merely increment the last_seen_count
+			last_seen_count++;
+		}
+		if (last_seen_count == NumericLimits<rle_count_t>::Maximum()) {
+			// we have seen the same value so many times in a row we are at the limit of what fits in our count
+			// write away the value and move to the next value
+			Flush<OP>();
+			last_seen_count = 0;
+			seen_count++;
+		}
+	}
+};
+
+template <class T>
+struct RLEAnalyzeState : public AnalyzeState {
+	RLEAnalyzeState() {
+	}
+
+	RLEState<T> state;
+};
+
+template <class T>
+unique_ptr<AnalyzeState> RLEInitAnalyze(ColumnData &col_data, PhysicalType type) {
+	return make_unique<RLEAnalyzeState<T>>();
+}
+
+template <class T>
+bool RLEAnalyze(AnalyzeState &state, Vector &input, idx_t count) {
+	auto &rle_state = (RLEAnalyzeState<T> &)state;
+	VectorData vdata;
+	input.Orrify(count, vdata);
+
+	auto data = (T *)vdata.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = vdata.sel->get_index(i);
+		rle_state.state.Update(data, vdata.validity, idx);
+	}
+	return true;
+}
+
+template <class T>
+idx_t RLEFinalAnalyze(AnalyzeState &state) {
+	auto &rle_state = (RLEAnalyzeState<T> &)state;
+	return (sizeof(rle_count_t) + sizeof(T)) * rle_state.state.seen_count;
+}
+
+//===--------------------------------------------------------------------===//
+// Compress
+//===--------------------------------------------------------------------===//
+struct RLEConstants {
+	static constexpr const idx_t RLE_HEADER_SIZE = sizeof(uint64_t);
+};
+
+template <class T>
+struct RLECompressState : public CompressionState {
+	struct RLEWriter {
+		template <class VALUE_TYPE>
+		static void Operation(VALUE_TYPE value, rle_count_t count, void *dataptr, bool is_null) {
+			auto state = (RLECompressState<T> *)dataptr;
+			state->WriteValue(value, count, is_null);
+		}
+	};
+
+	static idx_t MaxRLECount() {
+		auto entry_size = sizeof(T) + sizeof(rle_count_t);
+		auto entry_count = (Storage::BLOCK_SIZE - RLEConstants::RLE_HEADER_SIZE) / entry_size;
+		auto max_vector_count = entry_count / STANDARD_VECTOR_SIZE;
+		return max_vector_count * STANDARD_VECTOR_SIZE;
+	}
+
+	explicit RLECompressState(ColumnDataCheckpointer &checkpointer_p) : checkpointer(checkpointer_p) {
+		auto &db = checkpointer.GetDatabase();
+		auto &type = checkpointer.GetType();
+		auto &config = DBConfig::GetConfig(db);
+		function = config.GetCompressionFunction(CompressionType::COMPRESSION_RLE, type.InternalType());
+		CreateEmptySegment(checkpointer.GetRowGroup().start);
+
+		state.dataptr = (void *)this;
+		max_rle_count = MaxRLECount();
+	}
+
+	void CreateEmptySegment(idx_t row_start) {
+		auto &db = checkpointer.GetDatabase();
+		auto &type = checkpointer.GetType();
+		auto column_segment = ColumnSegment::CreateTransientSegment(db, type, row_start);
+		column_segment->function = function;
+		current_segment = move(column_segment);
+		auto &buffer_manager = BufferManager::GetBufferManager(db);
+		handle = buffer_manager.Pin(current_segment->block);
+	}
+
+	void Append(VectorData &vdata, idx_t count) {
+		auto data = (T *)vdata.data;
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = vdata.sel->get_index(i);
+			state.template Update<RLECompressState<T>::RLEWriter>(data, vdata.validity, idx);
+		}
+	}
+
+	void WriteValue(T value, rle_count_t count, bool is_null) {
+		// write the RLE entry
+		auto handle_ptr = handle->Ptr() + RLEConstants::RLE_HEADER_SIZE;
+		auto data_pointer = (T *)handle_ptr;
+		auto index_pointer = (rle_count_t *)(handle_ptr + max_rle_count * sizeof(T));
+		data_pointer[entry_count] = value;
+		index_pointer[entry_count] = count;
+		entry_count++;
+
+		// update meta data
+		if (!is_null) {
+			NumericStatistics::Update<T>(current_segment->stats, value);
+		}
+		current_segment->count += count;
+
+		if (entry_count == max_rle_count) {
+			// we have finished writing this segment: flush it and create a new segment
+			auto row_start = current_segment->start + current_segment->count;
+			FlushSegment();
+			CreateEmptySegment(row_start);
+			entry_count = 0;
+		}
+	}
+
+	void FlushSegment() {
+		// flush the segment
+		// we compact the segment by moving the counts so they are directly next to the values
+		idx_t counts_size = sizeof(rle_count_t) * entry_count;
+		idx_t original_rle_offset = RLEConstants::RLE_HEADER_SIZE + max_rle_count * sizeof(T);
+		idx_t minimal_rle_offset = AlignValue(RLEConstants::RLE_HEADER_SIZE + sizeof(T) * entry_count);
+		idx_t total_segment_size = minimal_rle_offset + counts_size;
+		memmove(handle->node->buffer + minimal_rle_offset, handle->node->buffer + original_rle_offset, counts_size);
+		// store the final RLE offset within the segment
+		Store<uint64_t>(minimal_rle_offset, handle->node->buffer);
+		handle.reset();
+
+		auto &state = checkpointer.GetCheckpointState();
+		state.FlushSegment(move(current_segment), total_segment_size);
+	}
+
+	void Finalize() {
+		state.template Flush<RLECompressState<T>::RLEWriter>();
+
+		FlushSegment();
+		current_segment.reset();
+	}
+
+	ColumnDataCheckpointer &checkpointer;
+	CompressionFunction *function;
+	unique_ptr<ColumnSegment> current_segment;
+	unique_ptr<BufferHandle> handle;
+
+	RLEState<T> state;
+	idx_t entry_count = 0;
+	idx_t max_rle_count;
+};
+
+template <class T>
+unique_ptr<CompressionState> RLEInitCompression(ColumnDataCheckpointer &checkpointer, unique_ptr<AnalyzeState> state) {
+	return make_unique<RLECompressState<T>>(checkpointer);
+}
+
+template <class T>
+void RLECompress(CompressionState &state_p, Vector &scan_vector, idx_t count) {
+	auto &state = (RLECompressState<T> &)state_p;
+	VectorData vdata;
+	scan_vector.Orrify(count, vdata);
+
+	state.Append(vdata, count);
+}
+
+template <class T>
+void RLEFinalizeCompress(CompressionState &state_p) {
+	auto &state = (RLECompressState<T> &)state_p;
+	state.Finalize();
+}
+
+//===--------------------------------------------------------------------===//
+// Scan
+//===--------------------------------------------------------------------===//
+template <class T>
+struct RLEScanState : public SegmentScanState {
+	explicit RLEScanState(ColumnSegment &segment) {
+		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+		handle = buffer_manager.Pin(segment.block);
+		entry_pos = 0;
+		position_in_entry = 0;
+		rle_count_offset = Load<uint64_t>(handle->node->buffer + segment.GetBlockOffset());
+		D_ASSERT(rle_count_offset <= Storage::BLOCK_SIZE);
+	}
+
+	void Skip(ColumnSegment &segment, idx_t skip_count) {
+		auto data = handle->node->buffer + segment.GetBlockOffset();
+		auto index_pointer = (rle_count_t *)(data + rle_count_offset);
+
+		for (idx_t i = 0; i < skip_count; i++) {
+			// assign the current value
+			position_in_entry++;
+			if (position_in_entry >= index_pointer[entry_pos]) {
+				// handled all entries in this RLE value
+				// move to the next entry
+				entry_pos++;
+				position_in_entry = 0;
+			}
+		}
+	}
+
+	unique_ptr<BufferHandle> handle;
+	uint32_t rle_offset;
+	idx_t entry_pos;
+	idx_t position_in_entry;
+	uint32_t rle_count_offset;
+};
+
+template <class T>
+unique_ptr<SegmentScanState> RLEInitScan(ColumnSegment &segment) {
+	auto result = make_unique<RLEScanState<T>>(segment);
+	return move(result);
+}
+
+//===--------------------------------------------------------------------===//
+// Scan base data
+//===--------------------------------------------------------------------===//
+template <class T>
+void RLESkip(ColumnSegment &segment, ColumnScanState &state, idx_t skip_count) {
+	auto &scan_state = (RLEScanState<T> &)*state.scan_state;
+	scan_state.Skip(segment, skip_count);
+}
+
+template <class T>
+void RLEScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
+                    idx_t result_offset) {
+	auto &scan_state = (RLEScanState<T> &)*state.scan_state;
+
+	auto data = scan_state.handle->node->buffer + segment.GetBlockOffset();
+	auto data_pointer = (T *)(data + RLEConstants::RLE_HEADER_SIZE);
+	auto index_pointer = (rle_count_t *)(data + scan_state.rle_count_offset);
+
+	auto result_data = FlatVector::GetData<T>(result);
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t i = 0; i < scan_count; i++) {
+		// assign the current value
+		result_data[result_offset + i] = data_pointer[scan_state.entry_pos];
+		scan_state.position_in_entry++;
+		if (scan_state.position_in_entry >= index_pointer[scan_state.entry_pos]) {
+			// handled all entries in this RLE value
+			// move to the next entry
+			scan_state.entry_pos++;
+			scan_state.position_in_entry = 0;
+		}
+	}
+}
+
+template <class T>
+void RLEScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
+	// FIXME: emit constant vector if repetition of single value is >= scan_count
+	RLEScanPartial<T>(segment, state, scan_count, result, 0);
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch
+//===--------------------------------------------------------------------===//
+template <class T>
+void RLEFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result, idx_t result_idx) {
+	RLEScanState<T> scan_state(segment);
+	scan_state.Skip(segment, row_id);
+
+	auto data = scan_state.handle->node->buffer + segment.GetBlockOffset();
+	auto data_pointer = (T *)(data + RLEConstants::RLE_HEADER_SIZE);
+	auto result_data = FlatVector::GetData<T>(result);
+	result_data[result_idx] = data_pointer[scan_state.entry_pos];
+}
+
+//===--------------------------------------------------------------------===//
+// Get Function
+//===--------------------------------------------------------------------===//
+template <class T>
+CompressionFunction GetRLEFunction(PhysicalType data_type) {
+	return CompressionFunction(CompressionType::COMPRESSION_RLE, data_type, RLEInitAnalyze<T>, RLEAnalyze<T>,
+	                           RLEFinalAnalyze<T>, RLEInitCompression<T>, RLECompress<T>, RLEFinalizeCompress<T>,
+	                           RLEInitScan<T>, RLEScan<T>, RLEScanPartial<T>, RLEFetchRow<T>, RLESkip<T>);
+}
+
+CompressionFunction RLEFun::GetFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return GetRLEFunction<int8_t>(type);
+	case PhysicalType::INT16:
+		return GetRLEFunction<int16_t>(type);
+	case PhysicalType::INT32:
+		return GetRLEFunction<int32_t>(type);
+	case PhysicalType::INT64:
+		return GetRLEFunction<int64_t>(type);
+	case PhysicalType::INT128:
+		return GetRLEFunction<hugeint_t>(type);
+	case PhysicalType::UINT8:
+		return GetRLEFunction<uint8_t>(type);
+	case PhysicalType::UINT16:
+		return GetRLEFunction<uint16_t>(type);
+	case PhysicalType::UINT32:
+		return GetRLEFunction<uint32_t>(type);
+	case PhysicalType::UINT64:
+		return GetRLEFunction<uint64_t>(type);
+	case PhysicalType::FLOAT:
+		return GetRLEFunction<float>(type);
+	case PhysicalType::DOUBLE:
+		return GetRLEFunction<double>(type);
+	default:
+		throw InternalException("Unsupported type for RLE");
+	}
+}
+
+bool RLEFun::TypeIsSupported(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::INT128:
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+		return true;
+	default:
+		return false;
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Storage Class
+//===--------------------------------------------------------------------===//
+UncompressedStringSegmentState::~UncompressedStringSegmentState() {
+	while (head) {
+		// prevent deep recursion here
+		head = move(head->next);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Analyze
+//===--------------------------------------------------------------------===//
+struct StringAnalyzeState : public AnalyzeState {
+	StringAnalyzeState() : count(0), total_string_size(0), overflow_strings(0) {
+	}
+
+	idx_t count;
+	idx_t total_string_size;
+	idx_t overflow_strings;
+};
+
+unique_ptr<AnalyzeState> UncompressedStringStorage::StringInitAnalyze(ColumnData &col_data, PhysicalType type) {
+	return make_unique<StringAnalyzeState>();
+}
+
+bool UncompressedStringStorage::StringAnalyze(AnalyzeState &state_p, Vector &input, idx_t count) {
+	auto &state = (StringAnalyzeState &)state_p;
+	VectorData vdata;
+	input.Orrify(count, vdata);
+
+	state.count += count;
+	auto data = (string_t *)vdata.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = vdata.sel->get_index(i);
+		if (vdata.validity.RowIsValid(idx)) {
+			auto string_size = data[idx].GetSize();
+			state.total_string_size += string_size;
+			if (string_size >= StringUncompressed::STRING_BLOCK_LIMIT) {
+				state.overflow_strings++;
+			}
+		}
+	}
+	return true;
+}
+
+idx_t UncompressedStringStorage::StringFinalAnalyze(AnalyzeState &state_p) {
+	auto &state = (StringAnalyzeState &)state_p;
+	return state.count * sizeof(int32_t) + state.total_string_size + state.overflow_strings * BIG_STRING_MARKER_SIZE;
+}
+
+//===--------------------------------------------------------------------===//
+// Scan
+//===--------------------------------------------------------------------===//
+unique_ptr<SegmentScanState> UncompressedStringStorage::StringInitScan(ColumnSegment &segment) {
+	auto result = make_unique<StringScanState>();
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	result->handle = buffer_manager.Pin(segment.block);
+	return move(result);
+}
+
+//===--------------------------------------------------------------------===//
+// Scan base data
+//===--------------------------------------------------------------------===//
+void UncompressedStringStorage::StringScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count,
+                                                  Vector &result, idx_t result_offset) {
+	// clear any previously locked buffers and get the primary buffer handle
+	auto &scan_state = (StringScanState &)*state.scan_state;
+	auto start = segment.GetRelativeIndex(state.row_index);
+
+	auto baseptr = scan_state.handle->node->buffer + segment.GetBlockOffset();
+	auto dict = GetDictionary(segment, *scan_state.handle);
+	auto base_data = (int32_t *)(baseptr + DICTIONARY_HEADER_SIZE);
+	auto result_data = FlatVector::GetData<string_t>(result);
+
+	int32_t previous_offset = start > 0 ? base_data[start - 1] : 0;
+
+	for (idx_t i = 0; i < scan_count; i++) {
+		// std::abs used since offsets can be negative to indicate big strings
+		uint32_t string_length = std::abs(base_data[start + i]) - std::abs(previous_offset);
+		result_data[result_offset + i] =
+		    FetchStringFromDict(segment, dict, result, baseptr, base_data[start + i], string_length);
+		previous_offset = base_data[start + i];
+	}
+}
+
+void UncompressedStringStorage::StringScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count,
+                                           Vector &result) {
+	StringScanPartial(segment, state, scan_count, result, 0);
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch
+//===--------------------------------------------------------------------===//
+void UncompressedStringStorage::StringFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id,
+                                               Vector &result, idx_t result_idx) {
+	// fetch a single row from the string segment
+	// first pin the main buffer if it is not already pinned
+	auto primary_id = segment.block->BlockId();
+
+	BufferHandle *handle_ptr;
+	auto entry = state.handles.find(primary_id);
+	if (entry == state.handles.end()) {
+		// not pinned yet: pin it
+		auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+		auto handle = buffer_manager.Pin(segment.block);
+		handle_ptr = handle.get();
+		state.handles[primary_id] = move(handle);
+	} else {
+		// already pinned: use the pinned handle
+		handle_ptr = entry->second.get();
+	}
+	auto baseptr = handle_ptr->node->buffer + segment.GetBlockOffset();
+	auto dict = GetDictionary(segment, *handle_ptr);
+	auto base_data = (int32_t *)(baseptr + DICTIONARY_HEADER_SIZE);
+	auto result_data = FlatVector::GetData<string_t>(result);
+
+	auto dict_offset = base_data[row_id];
+	uint32_t string_length;
+	if ((idx_t)row_id == 0) {
+		// edge case where this is the first string in the dict
+		string_length = std::abs(dict_offset);
+	} else {
+		string_length = std::abs(dict_offset) - std::abs(base_data[row_id - 1]);
+	}
+	result_data[result_idx] = FetchStringFromDict(segment, dict, result, baseptr, dict_offset, string_length);
+}
+
+//===--------------------------------------------------------------------===//
+// Append
+//===--------------------------------------------------------------------===//
+unique_ptr<CompressedSegmentState> UncompressedStringStorage::StringInitSegment(ColumnSegment &segment,
+                                                                                block_id_t block_id) {
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	if (block_id == INVALID_BLOCK) {
+		auto handle = buffer_manager.Pin(segment.block);
+		StringDictionaryContainer dictionary;
+		dictionary.size = 0;
+		dictionary.end = Storage::BLOCK_SIZE;
+		SetDictionary(segment, *handle, dictionary);
+	}
+	return make_unique<UncompressedStringSegmentState>();
+}
+
+idx_t UncompressedStringStorage::FinalizeAppend(ColumnSegment &segment, SegmentStatistics &stats) {
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	auto handle = buffer_manager.Pin(segment.block);
+	auto dict = GetDictionary(segment, *handle);
+	D_ASSERT(dict.end == Storage::BLOCK_SIZE);
+	// compute the total size required to store this segment
+	auto offset_size = DICTIONARY_HEADER_SIZE + segment.count * sizeof(int32_t);
+	auto total_size = offset_size + dict.size;
+	if (total_size >= COMPACTION_FLUSH_LIMIT) {
+		// the block is full enough, don't bother moving around the dictionary
+		return Storage::BLOCK_SIZE;
+	}
+	// the block has space left: figure out how much space we can save
+	auto move_amount = Storage::BLOCK_SIZE - total_size;
+	// move the dictionary so it lines up exactly with the offsets
+	memmove(handle->node->buffer + offset_size, handle->node->buffer + dict.end - dict.size, dict.size);
+	dict.end -= move_amount;
+	D_ASSERT(dict.end == total_size);
+	// write the new dictionary (with the updated "end")
+	SetDictionary(segment, *handle, dict);
+	return total_size;
+}
+
+//===--------------------------------------------------------------------===//
+// Get Function
+//===--------------------------------------------------------------------===//
+CompressionFunction StringUncompressed::GetFunction(PhysicalType data_type) {
+	D_ASSERT(data_type == PhysicalType::VARCHAR);
+	return CompressionFunction(CompressionType::COMPRESSION_UNCOMPRESSED, data_type,
+	                           UncompressedStringStorage::StringInitAnalyze, UncompressedStringStorage::StringAnalyze,
+	                           UncompressedStringStorage::StringFinalAnalyze, UncompressedFunctions::InitCompression,
+	                           UncompressedFunctions::Compress, UncompressedFunctions::FinalizeCompress,
+	                           UncompressedStringStorage::StringInitScan, UncompressedStringStorage::StringScan,
+	                           UncompressedStringStorage::StringScanPartial, UncompressedStringStorage::StringFetchRow,
+	                           UncompressedFunctions::EmptySkip, UncompressedStringStorage::StringInitSegment,
+	                           UncompressedStringStorage::StringAppend, UncompressedStringStorage::FinalizeAppend);
+}
+
+//===--------------------------------------------------------------------===//
+// Helper Functions
+//===--------------------------------------------------------------------===//
+void UncompressedStringStorage::SetDictionary(ColumnSegment &segment, BufferHandle &handle,
+                                              StringDictionaryContainer container) {
+	auto startptr = handle.node->buffer + segment.GetBlockOffset();
+	Store<uint32_t>(container.size, startptr);
+	Store<uint32_t>(container.end, startptr + sizeof(uint32_t));
+}
+
+StringDictionaryContainer UncompressedStringStorage::GetDictionary(ColumnSegment &segment, BufferHandle &handle) {
+	auto startptr = handle.node->buffer + segment.GetBlockOffset();
+	StringDictionaryContainer container;
+	container.size = Load<uint32_t>(startptr);
+	container.end = Load<uint32_t>(startptr + sizeof(uint32_t));
+	return container;
+}
+
+idx_t UncompressedStringStorage::RemainingSpace(ColumnSegment &segment, BufferHandle &handle) {
+	auto dictionary = GetDictionary(segment, handle);
+	D_ASSERT(dictionary.end == Storage::BLOCK_SIZE);
+	idx_t used_space = dictionary.size + segment.count * sizeof(int32_t) + DICTIONARY_HEADER_SIZE;
+	D_ASSERT(Storage::BLOCK_SIZE >= used_space);
+	return Storage::BLOCK_SIZE - used_space;
+}
+
+void UncompressedStringStorage::WriteString(ColumnSegment &segment, string_t string, block_id_t &result_block,
+                                            int32_t &result_offset) {
+	auto &state = (UncompressedStringSegmentState &)*segment.GetSegmentState();
+	if (state.overflow_writer) {
+		// overflow writer is set: write string there
+		state.overflow_writer->WriteString(string, result_block, result_offset);
+	} else {
+		// default overflow behavior: use in-memory buffer to store the overflow string
+		WriteStringMemory(segment, string, result_block, result_offset);
+	}
+}
+
+void UncompressedStringStorage::WriteStringMemory(ColumnSegment &segment, string_t string, block_id_t &result_block,
+                                                  int32_t &result_offset) {
+	uint32_t total_length = string.GetSize() + sizeof(uint32_t);
+	shared_ptr<BlockHandle> block;
+	unique_ptr<BufferHandle> handle;
+
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	auto &state = (UncompressedStringSegmentState &)*segment.GetSegmentState();
+	// check if the string fits in the current block
+	if (!state.head || state.head->offset + total_length >= state.head->size) {
+		// string does not fit, allocate space for it
+		// create a new string block
+		idx_t alloc_size = MaxValue<idx_t>(total_length, Storage::BLOCK_SIZE);
+		auto new_block = make_unique<StringBlock>();
+		new_block->offset = 0;
+		new_block->size = alloc_size;
+		// allocate an in-memory buffer for it
+		block = buffer_manager.RegisterMemory(alloc_size, false);
+		handle = buffer_manager.Pin(block);
+		state.overflow_blocks[block->BlockId()] = new_block.get();
+		new_block->block = move(block);
+		new_block->next = move(state.head);
+		state.head = move(new_block);
+	} else {
+		// string fits, copy it into the current block
+		handle = buffer_manager.Pin(state.head->block);
+	}
+
+	result_block = state.head->block->BlockId();
+	result_offset = state.head->offset;
+
+	// copy the string and the length there
+	auto ptr = handle->node->buffer + state.head->offset;
+	Store<uint32_t>(string.GetSize(), ptr);
+	ptr += sizeof(uint32_t);
+	memcpy(ptr, string.GetDataUnsafe(), string.GetSize());
+	state.head->offset += total_length;
+}
+
+string_t UncompressedStringStorage::ReadOverflowString(ColumnSegment &segment, Vector &result, block_id_t block,
+                                                       int32_t offset) {
+	D_ASSERT(block != INVALID_BLOCK);
+	D_ASSERT(offset < Storage::BLOCK_SIZE);
+
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	auto &state = (UncompressedStringSegmentState &)*segment.GetSegmentState();
+	if (block < MAXIMUM_BLOCK) {
+		// read the overflow string from disk
+		// pin the initial handle and read the length
+		auto block_handle = buffer_manager.RegisterBlock(block);
+		auto handle = buffer_manager.Pin(block_handle);
+
+		// read header
+		uint32_t compressed_size = Load<uint32_t>(handle->node->buffer + offset);
+		uint32_t uncompressed_size = Load<uint32_t>(handle->node->buffer + offset + sizeof(uint32_t));
+		uint32_t remaining = compressed_size;
+		offset += 2 * sizeof(uint32_t);
+
+		data_ptr_t decompression_ptr;
+		std::unique_ptr<data_t[]> decompression_buffer;
+
+		// If string is in single block we decompress straight from it, else we copy first
+		if (remaining <= Storage::BLOCK_SIZE - sizeof(block_id_t) - offset) {
+			decompression_ptr = handle->node->buffer + offset;
+		} else {
+			decompression_buffer = std::unique_ptr<data_t[]>(new data_t[compressed_size]);
+			auto target_ptr = decompression_buffer.get();
+
+			// now append the string to the single buffer
+			while (remaining > 0) {
+				idx_t to_write = MinValue<idx_t>(remaining, Storage::BLOCK_SIZE - sizeof(block_id_t) - offset);
+				memcpy(target_ptr, handle->node->buffer + offset, to_write);
+
+				remaining -= to_write;
+				offset += to_write;
+				target_ptr += to_write;
+				if (remaining > 0) {
+					// read the next block
+					block_id_t next_block = Load<block_id_t>(handle->node->buffer + offset);
+					block_handle = buffer_manager.RegisterBlock(next_block);
+					handle = buffer_manager.Pin(block_handle);
+					offset = 0;
+				}
+			}
+			decompression_ptr = decompression_buffer.get();
+		}
+
+		// overflow strings on disk are gzipped, decompress here
+		auto decompressed_target_handle =
+		    buffer_manager.Allocate(MaxValue<idx_t>(Storage::BLOCK_SIZE, uncompressed_size));
+		auto decompressed_target_ptr = decompressed_target_handle->node->buffer;
+		MiniZStream s;
+		s.Decompress((const char *)decompression_ptr, compressed_size, (char *)decompressed_target_ptr,
+		             uncompressed_size);
+
+		auto final_buffer = decompressed_target_handle->node->buffer;
+		StringVector::AddHandle(result, move(decompressed_target_handle));
+		return ReadString(final_buffer, 0, uncompressed_size);
+	} else {
+		// read the overflow string from memory
+		// first pin the handle, if it is not pinned yet
+		auto entry = state.overflow_blocks.find(block);
+		D_ASSERT(entry != state.overflow_blocks.end());
+		auto handle = buffer_manager.Pin(entry->second->block);
+		auto final_buffer = handle->node->buffer;
+		StringVector::AddHandle(result, move(handle));
+		return ReadStringWithLength(final_buffer, offset);
+	}
+}
+
+string_t UncompressedStringStorage::ReadString(data_ptr_t target, int32_t offset, uint32_t string_length) {
+	auto ptr = target + offset;
+	auto str_ptr = (char *)(ptr);
+	return string_t(str_ptr, string_length);
+}
+
+string_t UncompressedStringStorage::ReadStringWithLength(data_ptr_t target, int32_t offset) {
+	auto ptr = target + offset;
+	auto str_length = Load<uint32_t>(ptr);
+	auto str_ptr = (char *)(ptr + sizeof(uint32_t));
+	return string_t(str_ptr, str_length);
+}
+
+void UncompressedStringStorage::WriteStringMarker(data_ptr_t target, block_id_t block_id, int32_t offset) {
+	memcpy(target, &block_id, sizeof(block_id_t));
+	target += sizeof(block_id_t);
+	memcpy(target, &offset, sizeof(int32_t));
+}
+
+void UncompressedStringStorage::ReadStringMarker(data_ptr_t target, block_id_t &block_id, int32_t &offset) {
+	memcpy(&block_id, target, sizeof(block_id_t));
+	target += sizeof(block_id_t);
+	memcpy(&offset, target, sizeof(int32_t));
+}
+
+string_location_t UncompressedStringStorage::FetchStringLocation(StringDictionaryContainer dict, data_ptr_t baseptr,
+                                                                 int32_t dict_offset) {
+	D_ASSERT(dict_offset >= -1 * Storage::BLOCK_SIZE && dict_offset <= Storage::BLOCK_SIZE);
+	if (dict_offset < 0) {
+		string_location_t result;
+		ReadStringMarker(baseptr + dict.end - (-1 * dict_offset), result.block_id, result.offset);
+		return result;
+	} else {
+		return string_location_t(INVALID_BLOCK, dict_offset);
+	}
+}
+
+string_t UncompressedStringStorage::FetchStringFromDict(ColumnSegment &segment, StringDictionaryContainer dict,
+                                                        Vector &result, data_ptr_t baseptr, int32_t dict_offset,
+                                                        uint32_t string_length) {
+	// fetch base data
+	D_ASSERT(dict_offset <= Storage::BLOCK_SIZE);
+	string_location_t location = FetchStringLocation(dict, baseptr, dict_offset);
+	return FetchString(segment, dict, result, baseptr, location, string_length);
+}
+
+string_t UncompressedStringStorage::FetchString(ColumnSegment &segment, StringDictionaryContainer dict, Vector &result,
+                                                data_ptr_t baseptr, string_location_t location,
+                                                uint32_t string_length) {
+	if (location.block_id != INVALID_BLOCK) {
+		// big string marker: read from separate block
+		return ReadOverflowString(segment, result, location.block_id, location.offset);
+	} else {
+		if (location.offset == 0) {
+			return string_t(nullptr, 0);
+		}
+		// normal string: read string from this block
+		auto dict_end = baseptr + dict.end;
+		auto dict_pos = dict_end - location.offset;
+
+		auto str_ptr = (char *)(dict_pos);
+		return string_t(str_ptr, string_length);
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+CompressionFunction UncompressedFun::GetFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::INT128:
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+	case PhysicalType::LIST:
+	case PhysicalType::INTERVAL:
+		return FixedSizeUncompressed::GetFunction(type);
+	case PhysicalType::BIT:
+		return ValidityUncompressed::GetFunction(type);
+	case PhysicalType::VARCHAR:
+		return StringUncompressed::GetFunction(type);
+	default:
+		throw InternalException("Unsupported type for Uncompressed");
+	}
+}
+
+bool UncompressedFun::TypeIsSupported(PhysicalType type) {
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Mask constants
+//===--------------------------------------------------------------------===//
+// LOWER_MASKS contains masks with all the lower bits set until a specific value
+// LOWER_MASKS[0] has the 0 lowest bits set, i.e.:
+// 0b0000000000000000000000000000000000000000000000000000000000000000,
+// LOWER_MASKS[10] has the 10 lowest bits set, i.e.:
+// 0b0000000000000000000000000000000000000000000000000000000111111111,
+// etc...
+// 0b0000000000000000000000000000000000000001111111111111111111111111,
+// ...
+// 0b0000000000000000000001111111111111111111111111111111111111111111,
+// until LOWER_MASKS[64], which has all bits set:
+// 0b1111111111111111111111111111111111111111111111111111111111111111
+// generated with this python snippet:
+// for i in range(65):
+//   print(hex(int((64 - i) * '0' + i * '1', 2)) + ",")
+const validity_t ValidityUncompressed::LOWER_MASKS[] = {0x0,
+                                                        0x1,
+                                                        0x3,
+                                                        0x7,
+                                                        0xf,
+                                                        0x1f,
+                                                        0x3f,
+                                                        0x7f,
+                                                        0xff,
+                                                        0x1ff,
+                                                        0x3ff,
+                                                        0x7ff,
+                                                        0xfff,
+                                                        0x1fff,
+                                                        0x3fff,
+                                                        0x7fff,
+                                                        0xffff,
+                                                        0x1ffff,
+                                                        0x3ffff,
+                                                        0x7ffff,
+                                                        0xfffff,
+                                                        0x1fffff,
+                                                        0x3fffff,
+                                                        0x7fffff,
+                                                        0xffffff,
+                                                        0x1ffffff,
+                                                        0x3ffffff,
+                                                        0x7ffffff,
+                                                        0xfffffff,
+                                                        0x1fffffff,
+                                                        0x3fffffff,
+                                                        0x7fffffff,
+                                                        0xffffffff,
+                                                        0x1ffffffff,
+                                                        0x3ffffffff,
+                                                        0x7ffffffff,
+                                                        0xfffffffff,
+                                                        0x1fffffffff,
+                                                        0x3fffffffff,
+                                                        0x7fffffffff,
+                                                        0xffffffffff,
+                                                        0x1ffffffffff,
+                                                        0x3ffffffffff,
+                                                        0x7ffffffffff,
+                                                        0xfffffffffff,
+                                                        0x1fffffffffff,
+                                                        0x3fffffffffff,
+                                                        0x7fffffffffff,
+                                                        0xffffffffffff,
+                                                        0x1ffffffffffff,
+                                                        0x3ffffffffffff,
+                                                        0x7ffffffffffff,
+                                                        0xfffffffffffff,
+                                                        0x1fffffffffffff,
+                                                        0x3fffffffffffff,
+                                                        0x7fffffffffffff,
+                                                        0xffffffffffffff,
+                                                        0x1ffffffffffffff,
+                                                        0x3ffffffffffffff,
+                                                        0x7ffffffffffffff,
+                                                        0xfffffffffffffff,
+                                                        0x1fffffffffffffff,
+                                                        0x3fffffffffffffff,
+                                                        0x7fffffffffffffff,
+                                                        0xffffffffffffffff};
+
+// UPPER_MASKS contains masks with all the highest bits set until a specific value
+// UPPER_MASKS[0] has the 0 highest bits set, i.e.:
+// 0b0000000000000000000000000000000000000000000000000000000000000000,
+// UPPER_MASKS[10] has the 10 highest bits set, i.e.:
+// 0b1111111111110000000000000000000000000000000000000000000000000000,
+// etc...
+// 0b1111111111111111111111110000000000000000000000000000000000000000,
+// ...
+// 0b1111111111111111111111111111111111111110000000000000000000000000,
+// until UPPER_MASKS[64], which has all bits set:
+// 0b1111111111111111111111111111111111111111111111111111111111111111
+// generated with this python snippet:
+// for i in range(65):
+//   print(hex(int(i * '1' + (64 - i) * '0', 2)) + ",")
+const validity_t ValidityUncompressed::UPPER_MASKS[] = {0x0,
+                                                        0x8000000000000000,
+                                                        0xc000000000000000,
+                                                        0xe000000000000000,
+                                                        0xf000000000000000,
+                                                        0xf800000000000000,
+                                                        0xfc00000000000000,
+                                                        0xfe00000000000000,
+                                                        0xff00000000000000,
+                                                        0xff80000000000000,
+                                                        0xffc0000000000000,
+                                                        0xffe0000000000000,
+                                                        0xfff0000000000000,
+                                                        0xfff8000000000000,
+                                                        0xfffc000000000000,
+                                                        0xfffe000000000000,
+                                                        0xffff000000000000,
+                                                        0xffff800000000000,
+                                                        0xffffc00000000000,
+                                                        0xffffe00000000000,
+                                                        0xfffff00000000000,
+                                                        0xfffff80000000000,
+                                                        0xfffffc0000000000,
+                                                        0xfffffe0000000000,
+                                                        0xffffff0000000000,
+                                                        0xffffff8000000000,
+                                                        0xffffffc000000000,
+                                                        0xffffffe000000000,
+                                                        0xfffffff000000000,
+                                                        0xfffffff800000000,
+                                                        0xfffffffc00000000,
+                                                        0xfffffffe00000000,
+                                                        0xffffffff00000000,
+                                                        0xffffffff80000000,
+                                                        0xffffffffc0000000,
+                                                        0xffffffffe0000000,
+                                                        0xfffffffff0000000,
+                                                        0xfffffffff8000000,
+                                                        0xfffffffffc000000,
+                                                        0xfffffffffe000000,
+                                                        0xffffffffff000000,
+                                                        0xffffffffff800000,
+                                                        0xffffffffffc00000,
+                                                        0xffffffffffe00000,
+                                                        0xfffffffffff00000,
+                                                        0xfffffffffff80000,
+                                                        0xfffffffffffc0000,
+                                                        0xfffffffffffe0000,
+                                                        0xffffffffffff0000,
+                                                        0xffffffffffff8000,
+                                                        0xffffffffffffc000,
+                                                        0xffffffffffffe000,
+                                                        0xfffffffffffff000,
+                                                        0xfffffffffffff800,
+                                                        0xfffffffffffffc00,
+                                                        0xfffffffffffffe00,
+                                                        0xffffffffffffff00,
+                                                        0xffffffffffffff80,
+                                                        0xffffffffffffffc0,
+                                                        0xffffffffffffffe0,
+                                                        0xfffffffffffffff0,
+                                                        0xfffffffffffffff8,
+                                                        0xfffffffffffffffc,
+                                                        0xfffffffffffffffe,
+                                                        0xffffffffffffffff};
+
+//===--------------------------------------------------------------------===//
+// Analyze
+//===--------------------------------------------------------------------===//
+struct ValidityAnalyzeState : public AnalyzeState {
+	ValidityAnalyzeState() : count(0) {
+	}
+
+	idx_t count;
+};
+
+unique_ptr<AnalyzeState> ValidityInitAnalyze(ColumnData &col_data, PhysicalType type) {
+	return make_unique<ValidityAnalyzeState>();
+}
+
+bool ValidityAnalyze(AnalyzeState &state_p, Vector &input, idx_t count) {
+	auto &state = (ValidityAnalyzeState &)state_p;
+	state.count += count;
+	return true;
+}
+
+idx_t ValidityFinalAnalyze(AnalyzeState &state_p) {
+	auto &state = (ValidityAnalyzeState &)state_p;
+	return (state.count + 7) / 8;
+}
+
+//===--------------------------------------------------------------------===//
+// Scan
+//===--------------------------------------------------------------------===//
+struct ValidityScanState : public SegmentScanState {
+	unique_ptr<BufferHandle> handle;
+};
+
+unique_ptr<SegmentScanState> ValidityInitScan(ColumnSegment &segment) {
+	auto result = make_unique<ValidityScanState>();
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	result->handle = buffer_manager.Pin(segment.block);
+	return move(result);
+}
+
+//===--------------------------------------------------------------------===//
+// Scan base data
+//===--------------------------------------------------------------------===//
+void ValidityScanPartial(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result,
+                         idx_t result_offset) {
+	auto start = segment.GetRelativeIndex(state.row_index);
+
+	static_assert(sizeof(validity_t) == sizeof(uint64_t), "validity_t should be 64-bit");
+	auto &scan_state = (ValidityScanState &)*state.scan_state;
+
+	auto &result_mask = FlatVector::Validity(result);
+	auto buffer_ptr = scan_state.handle->node->buffer + segment.GetBlockOffset();
+	auto input_data = (validity_t *)buffer_ptr;
+
+#ifdef DEBUG
+	// this method relies on all the bits we are going to write to being set to valid
+	for (idx_t i = 0; i < scan_count; i++) {
+		D_ASSERT(result_mask.RowIsValid(result_offset + i));
+	}
+#endif
+#if STANDARD_VECTOR_SIZE < 128
+	// fallback for tiny vector sizes
+	// the bitwise ops we use below don't work if the vector size is too small
+	ValidityMask source_mask(input_data);
+	for (idx_t i = 0; i < scan_count; i++) {
+		if (!source_mask.RowIsValid(start + i)) {
+			if (result_mask.AllValid()) {
+				result_mask.Initialize(MaxValue<idx_t>(STANDARD_VECTOR_SIZE, result_offset + scan_count));
+			}
+			result_mask.SetInvalid(result_offset + i);
+		}
+	}
+#else
+	// the code below does what the fallback code above states, but using bitwise ops:
+	auto result_data = (validity_t *)result_mask.GetData();
+
+	// set up the initial positions
+	// we need to find the validity_entry to modify, together with the bit-index WITHIN the validity entry
+	idx_t result_entry = result_offset / ValidityMask::BITS_PER_VALUE;
+	idx_t result_idx = result_offset - result_entry * ValidityMask::BITS_PER_VALUE;
+
+	// same for the input: find the validity_entry we are pulling from, together with the bit-index WITHIN that entry
+	idx_t input_entry = start / ValidityMask::BITS_PER_VALUE;
+	idx_t input_idx = start - input_entry * ValidityMask::BITS_PER_VALUE;
+
+	// now start the bit games
+	idx_t pos = 0;
+	while (pos < scan_count) {
+		// these are the current validity entries we are dealing with
+		idx_t current_result_idx = result_entry;
+		idx_t offset;
+		validity_t input_mask = input_data[input_entry];
+
+		// construct the mask to AND together with the result
+		if (result_idx < input_idx) {
+			// we have to shift the input RIGHT if the result_idx is smaller than the input_idx
+			auto shift_amount = input_idx - result_idx;
+			D_ASSERT(shift_amount > 0 && shift_amount <= ValidityMask::BITS_PER_VALUE);
+
+			input_mask = input_mask >> shift_amount;
+
+			// now the upper "shift_amount" bits are set to 0
+			// we need them to be set to 1
+			// otherwise the subsequent bitwise & will modify values outside of the range of values we want to alter
+			input_mask |= ValidityUncompressed::UPPER_MASKS[shift_amount];
+
+			// after this, we move to the next input_entry
+			offset = ValidityMask::BITS_PER_VALUE - input_idx;
+			input_entry++;
+			input_idx = 0;
+			result_idx += offset;
+		} else if (result_idx > input_idx) {
+			// we have to shift the input LEFT if the result_idx is bigger than the input_idx
+			auto shift_amount = result_idx - input_idx;
+			D_ASSERT(shift_amount > 0 && shift_amount <= ValidityMask::BITS_PER_VALUE);
+
+			// to avoid overflows, we set the upper "shift_amount" values to 0 first
+			input_mask = (input_mask & ~ValidityUncompressed::UPPER_MASKS[shift_amount]) << shift_amount;
+
+			// now the lower "shift_amount" bits are set to 0
+			// we need them to be set to 1
+			// otherwise the subsequent bitwise & will modify values outside of the range of values we want to alter
+			input_mask |= ValidityUncompressed::LOWER_MASKS[shift_amount];
+
+			// after this, we move to the next result_entry
+			offset = ValidityMask::BITS_PER_VALUE - result_idx;
+			result_entry++;
+			result_idx = 0;
+			input_idx += offset;
+		} else {
+			// if the input_idx is equal to result_idx they are already aligned
+			// we just move to the next entry for both after this
+			offset = ValidityMask::BITS_PER_VALUE - result_idx;
+			input_entry++;
+			result_entry++;
+			result_idx = input_idx = 0;
+		}
+		// now we need to check if we should include the ENTIRE mask
+		// OR if we need to mask from the right side
+		pos += offset;
+		if (pos > scan_count) {
+			// we need to set any bits that are past the scan_count on the right-side to 1
+			// this is required so we don't influence any bits that are not part of the scan
+			input_mask |= ValidityUncompressed::UPPER_MASKS[pos - scan_count];
+		}
+		// now finally we can merge the input mask with the result mask
+		if (input_mask != ValidityMask::ValidityBuffer::MAX_ENTRY) {
+			if (!result_data) {
+				result_mask.Initialize(MaxValue<idx_t>(STANDARD_VECTOR_SIZE, result_offset + scan_count));
+				result_data = (validity_t *)result_mask.GetData();
+			}
+			result_data[current_result_idx] &= input_mask;
+		}
+	}
+#endif
+
+#ifdef DEBUG
+	// verify that we actually accomplished the bitwise ops equivalent that we wanted to do
+	ValidityMask input_mask(input_data);
+	for (idx_t i = 0; i < scan_count; i++) {
+		D_ASSERT(result_mask.RowIsValid(result_offset + i) == input_mask.RowIsValid(start + i));
+	}
+#endif
+}
+
+void ValidityScan(ColumnSegment &segment, ColumnScanState &state, idx_t scan_count, Vector &result) {
+	result.Normalify(scan_count);
+
+	auto start = segment.GetRelativeIndex(state.row_index);
+	if (start % ValidityMask::BITS_PER_VALUE == 0) {
+		auto &scan_state = (ValidityScanState &)*state.scan_state;
+
+		// aligned scan: no need to do anything fancy
+		// note: this is only an optimization which avoids having to do messy bitshifting in the common case
+		// it is not required for correctness
+		auto &result_mask = FlatVector::Validity(result);
+		auto buffer_ptr = scan_state.handle->node->buffer + segment.GetBlockOffset();
+		auto input_data = (validity_t *)buffer_ptr;
+		auto result_data = (validity_t *)result_mask.GetData();
+		idx_t start_offset = start / ValidityMask::BITS_PER_VALUE;
+		idx_t entry_scan_count = (scan_count + ValidityMask::BITS_PER_VALUE - 1) / ValidityMask::BITS_PER_VALUE;
+		for (idx_t i = 0; i < entry_scan_count; i++) {
+			auto input_entry = input_data[start_offset + i];
+			if (!result_data && input_entry == ValidityMask::ValidityBuffer::MAX_ENTRY) {
+				continue;
+			}
+			if (!result_data) {
+				result_mask.Initialize(MaxValue<idx_t>(STANDARD_VECTOR_SIZE, scan_count));
+				result_data = (validity_t *)result_mask.GetData();
+			}
+			result_data[i] = input_entry;
+		}
+	} else {
+		// unaligned scan: fall back to scan_partial which does bitshift tricks
+		ValidityScanPartial(segment, state, scan_count, result, 0);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch
+//===--------------------------------------------------------------------===//
+void ValidityFetchRow(ColumnSegment &segment, ColumnFetchState &state, row_t row_id, Vector &result, idx_t result_idx) {
+	D_ASSERT(row_id >= 0 && row_id < row_t(segment.count));
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	auto handle = buffer_manager.Pin(segment.block);
+	auto dataptr = handle->node->buffer + segment.GetBlockOffset();
+	ValidityMask mask((validity_t *)dataptr);
+	auto &result_mask = FlatVector::Validity(result);
+	if (!mask.RowIsValidUnsafe(row_id)) {
+		result_mask.SetInvalid(result_idx);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Append
+//===--------------------------------------------------------------------===//
+unique_ptr<CompressedSegmentState> ValidityInitSegment(ColumnSegment &segment, block_id_t block_id) {
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	if (block_id == INVALID_BLOCK) {
+		auto handle = buffer_manager.Pin(segment.block);
+		memset(handle->node->buffer, 0xFF, Storage::BLOCK_SIZE);
+	}
+	return nullptr;
+}
+
+idx_t ValidityAppend(ColumnSegment &segment, SegmentStatistics &stats, VectorData &data, idx_t offset, idx_t vcount) {
+	D_ASSERT(segment.GetBlockOffset() == 0);
+	auto &validity_stats = (ValidityStatistics &)*stats.statistics;
+
+	auto max_tuples = Storage::BLOCK_SIZE / ValidityMask::STANDARD_MASK_SIZE * STANDARD_VECTOR_SIZE;
+	idx_t append_count = MinValue<idx_t>(vcount, max_tuples - segment.count);
+	if (data.validity.AllValid()) {
+		// no null values: skip append
+		segment.count += append_count;
+		validity_stats.has_no_null = true;
+		return append_count;
+	}
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	auto handle = buffer_manager.Pin(segment.block);
+
+	ValidityMask mask((validity_t *)handle->node->buffer);
+	for (idx_t i = 0; i < append_count; i++) {
+		auto idx = data.sel->get_index(offset + i);
+		if (!data.validity.RowIsValidUnsafe(idx)) {
+			mask.SetInvalidUnsafe(segment.count + i);
+			validity_stats.has_null = true;
+		} else {
+			validity_stats.has_no_null = true;
+		}
+	}
+	segment.count += append_count;
+	return append_count;
+}
+
+idx_t ValidityFinalizeAppend(ColumnSegment &segment, SegmentStatistics &stats) {
+	return ((segment.count + STANDARD_VECTOR_SIZE - 1) / STANDARD_VECTOR_SIZE) * ValidityMask::STANDARD_MASK_SIZE;
+}
+
+void ValidityRevertAppend(ColumnSegment &segment, idx_t start_row) {
+	idx_t start_bit = start_row - segment.start;
+
+	auto &buffer_manager = BufferManager::GetBufferManager(segment.db);
+	auto handle = buffer_manager.Pin(segment.block);
+	idx_t revert_start;
+	if (start_bit % 8 != 0) {
+		// handle sub-bit stuff (yay)
+		idx_t byte_pos = start_bit / 8;
+		idx_t bit_start = byte_pos * 8;
+		idx_t bit_end = (byte_pos + 1) * 8;
+		ValidityMask mask((validity_t *)handle->node->buffer + byte_pos);
+		for (idx_t i = start_bit; i < bit_end; i++) {
+			mask.SetValid(i - bit_start);
+		}
+		revert_start = bit_end / 8;
+	} else {
+		revert_start = start_bit / 8;
+	}
+	// for the rest, we just memset
+	memset(handle->node->buffer + revert_start, 0xFF, Storage::BLOCK_SIZE - revert_start);
+}
+
+//===--------------------------------------------------------------------===//
+// Get Function
+//===--------------------------------------------------------------------===//
+CompressionFunction ValidityUncompressed::GetFunction(PhysicalType data_type) {
+	D_ASSERT(data_type == PhysicalType::BIT);
+	return CompressionFunction(CompressionType::COMPRESSION_UNCOMPRESSED, data_type, ValidityInitAnalyze,
+	                           ValidityAnalyze, ValidityFinalAnalyze, UncompressedFunctions::InitCompression,
+	                           UncompressedFunctions::Compress, UncompressedFunctions::FinalizeCompress,
+	                           ValidityInitScan, ValidityScan, ValidityScanPartial, ValidityFetchRow,
+	                           UncompressedFunctions::EmptySkip, ValidityInitSegment, ValidityAppend,
+	                           ValidityFinalizeAppend, ValidityRevertAppend);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+DataTable::DataTable(DatabaseInstance &db, const string &schema, const string &table,
+                     vector<ColumnDefinition> column_definitions_p, unique_ptr<PersistentTableData> data)
+    : info(make_shared<DataTableInfo>(db, schema, table)), column_definitions(move(column_definitions_p)), db(db),
+      total_rows(0), is_root(true) {
+	// initialize the table with the existing data from disk, if any
+	this->row_groups = make_shared<SegmentTree>();
+	auto types = GetTypes();
+	if (data && !data->row_groups.empty()) {
+		for (auto &row_group_pointer : data->row_groups) {
+			auto new_row_group = make_unique<RowGroup>(db, *info, types, row_group_pointer);
+			auto row_group_count = new_row_group->start + new_row_group->count;
+			if (row_group_count > total_rows) {
+				total_rows = row_group_count;
+			}
+			row_groups->AppendSegment(move(new_row_group));
+		}
+		column_stats.reserve(data->column_stats.size());
+		for (auto &stats : data->column_stats) {
+			column_stats.push_back(make_shared<ColumnStatistics>(move(stats)));
+		}
+		if (column_stats.size() != types.size()) { // LCOV_EXCL_START
+			throw IOException("Table statistics column count is not aligned with table column count. Corrupt file?");
+		} // LCOV_EXCL_STOP
+	}
+	if (column_stats.empty()) {
+		D_ASSERT(total_rows == 0);
+
+		AppendRowGroup(0);
+		for (auto &type : types) {
+			column_stats.push_back(ColumnStatistics::CreateEmptyStats(type));
+		}
+	} else {
+		D_ASSERT(column_stats.size() == types.size());
+		D_ASSERT(row_groups->GetRootSegment() != nullptr);
+	}
+}
+
+void DataTable::AppendRowGroup(idx_t start_row) {
+	auto types = GetTypes();
+	auto new_row_group = make_unique<RowGroup>(db, *info, start_row, 0);
+	new_row_group->InitializeEmpty(types);
+	row_groups->AppendSegment(move(new_row_group));
+}
+
+DataTable::DataTable(ClientContext &context, DataTable &parent, ColumnDefinition &new_column, Expression *default_value)
+    : info(parent.info), db(parent.db), total_rows(parent.total_rows.load()), is_root(true) {
+	for (auto &column_def : parent.column_definitions) {
+		column_definitions.emplace_back(column_def.Copy());
+	}
+	// prevent any new tuples from being added to the parent
+	lock_guard<mutex> parent_lock(parent.append_lock);
+	// add the new column to this DataTable
+	auto new_column_type = new_column.Type();
+	auto new_column_idx = parent.column_definitions.size();
+
+	// set up the statistics
+	for (idx_t i = 0; i < parent.column_stats.size(); i++) {
+		column_stats.push_back(parent.column_stats[i]);
+	}
+	column_stats.push_back(ColumnStatistics::CreateEmptyStats(new_column_type));
+
+	// add the column definitions from this DataTable
+	column_definitions.emplace_back(new_column.Copy());
+
+	auto &transaction = Transaction::GetTransaction(context);
+
+	ExpressionExecutor executor;
+	DataChunk dummy_chunk;
+	Vector result(new_column_type);
+	if (!default_value) {
+		FlatVector::Validity(result).SetAllInvalid(STANDARD_VECTOR_SIZE);
+	} else {
+		executor.AddExpression(*default_value);
+	}
+
+	// fill the column with its DEFAULT value, or NULL if none is specified
+	auto new_stats = make_unique<SegmentStatistics>(new_column.Type());
+	this->row_groups = make_shared<SegmentTree>();
+	auto current_row_group = (RowGroup *)parent.row_groups->GetRootSegment();
+	while (current_row_group) {
+		auto new_row_group = current_row_group->AddColumn(context, new_column, executor, default_value, result);
+		// merge in the statistics
+		column_stats[new_column_idx]->stats->Merge(*new_row_group->GetStatistics(new_column_idx));
+
+		row_groups->AppendSegment(move(new_row_group));
+		current_row_group = (RowGroup *)current_row_group->next.get();
+	}
+
+	// also add this column to client local storage
+	transaction.storage.AddColumn(&parent, this, new_column, default_value);
+
+	// this table replaces the previous table, hence the parent is no longer the root DataTable
+	parent.is_root = false;
+}
+
+DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t removed_column)
+    : info(parent.info), db(parent.db), total_rows(parent.total_rows.load()), is_root(true) {
+	// prevent any new tuples from being added to the parent
+	lock_guard<mutex> parent_lock(parent.append_lock);
+
+	for (auto &column_def : parent.column_definitions) {
+		column_definitions.emplace_back(column_def.Copy());
+	}
+	// first check if there are any indexes that exist that point to the removed column
+	info->indexes.Scan([&](Index &index) {
+		for (auto &column_id : index.column_ids) {
+			if (column_id == removed_column) {
+				throw CatalogException("Cannot drop this column: an index depends on it!");
+			} else if (column_id > removed_column) {
+				throw CatalogException("Cannot drop this column: an index depends on a column after it!");
+			}
+		}
+		return false;
+	});
+
+	// erase the stats from this DataTable
+	for (idx_t i = 0; i < parent.column_stats.size(); i++) {
+		if (i != removed_column) {
+			column_stats.push_back(parent.column_stats[i]);
+		}
+	}
+
+	// erase the column definitions from this DataTable
+	D_ASSERT(removed_column < column_definitions.size());
+	column_definitions.erase(column_definitions.begin() + removed_column);
+
+	storage_t storage_idx = 0;
+	for (idx_t i = 0; i < column_definitions.size(); i++) {
+		auto &col = column_definitions[i];
+		col.SetOid(i);
+		if (col.Generated()) {
+			continue;
+		}
+		col.SetStorageOid(storage_idx++);
+	}
+
+	// alter the row_groups and remove the column from each of them
+	this->row_groups = make_shared<SegmentTree>();
+	auto current_row_group = (RowGroup *)parent.row_groups->GetRootSegment();
+	while (current_row_group) {
+		auto new_row_group = current_row_group->RemoveColumn(removed_column);
+		row_groups->AppendSegment(move(new_row_group));
+		current_row_group = (RowGroup *)current_row_group->next.get();
+	}
+
+	// this table replaces the previous table, hence the parent is no longer the root DataTable
+	parent.is_root = false;
+}
+
+DataTable::DataTable(ClientContext &context, DataTable &parent, idx_t changed_idx, const LogicalType &target_type,
+                     vector<column_t> bound_columns, Expression &cast_expr)
+    : info(parent.info), db(parent.db), total_rows(parent.total_rows.load()), is_root(true) {
+	// prevent any tuples from being added to the parent
+	lock_guard<mutex> lock(append_lock);
+	for (auto &column_def : parent.column_definitions) {
+		column_definitions.emplace_back(column_def.Copy());
+	}
+	// first check if there are any indexes that exist that point to the changed column
+	info->indexes.Scan([&](Index &index) {
+		for (auto &column_id : index.column_ids) {
+			if (column_id == changed_idx) {
+				throw CatalogException("Cannot change the type of this column: an index depends on it!");
+			}
+		}
+		return false;
+	});
+
+	// change the type in this DataTable
+	column_definitions[changed_idx].SetType(target_type);
+
+	// set up the statistics for the table
+	// the column that had its type changed will have the new statistics computed during conversion
+	for (idx_t i = 0; i < column_definitions.size(); i++) {
+		if (i == changed_idx) {
+			column_stats.push_back(ColumnStatistics::CreateEmptyStats(column_definitions[i].Type()));
+		} else {
+			column_stats.push_back(parent.column_stats[i]);
+		}
+	}
+
+	// scan the original table, and fill the new column with the transformed value
+	auto &transaction = Transaction::GetTransaction(context);
+
+	vector<LogicalType> scan_types;
+	for (idx_t i = 0; i < bound_columns.size(); i++) {
+		if (bound_columns[i] == COLUMN_IDENTIFIER_ROW_ID) {
+			scan_types.emplace_back(LogicalType::ROW_TYPE);
+		} else {
+			scan_types.push_back(parent.column_definitions[bound_columns[i]].Type());
+		}
+	}
+	DataChunk scan_chunk;
+	scan_chunk.Initialize(scan_types);
+
+	ExpressionExecutor executor;
+	executor.AddExpression(cast_expr);
+
+	TableScanState scan_state;
+	scan_state.column_ids = bound_columns;
+	scan_state.max_row = total_rows;
+
+	// now alter the type of the column within all of the row_groups individually
+	this->row_groups = make_shared<SegmentTree>();
+	auto current_row_group = (RowGroup *)parent.row_groups->GetRootSegment();
+	while (current_row_group) {
+		auto new_row_group =
+		    current_row_group->AlterType(context, target_type, changed_idx, executor, scan_state, scan_chunk);
+		column_stats[changed_idx]->stats->Merge(*new_row_group->GetStatistics(changed_idx));
+		row_groups->AppendSegment(move(new_row_group));
+		current_row_group = (RowGroup *)current_row_group->next.get();
+	}
+
+	transaction.storage.ChangeType(&parent, this, changed_idx, target_type, bound_columns, cast_expr);
+
+	// this table replaces the previous table, hence the parent is no longer the root DataTable
+	parent.is_root = false;
+}
+
+vector<LogicalType> DataTable::GetTypes() {
+	vector<LogicalType> types;
+	for (auto &it : column_definitions) {
+		types.push_back(it.Type());
+	}
+	return types;
+}
+
+//===--------------------------------------------------------------------===//
+// Scan
+//===--------------------------------------------------------------------===//
+void DataTable::InitializeScan(TableScanState &state, const vector<column_t> &column_ids,
+                               TableFilterSet *table_filters) {
+	// initialize a column scan state for each column
+	// initialize the chunk scan state
+	auto row_group = (RowGroup *)row_groups->GetRootSegment();
+	state.column_ids = column_ids;
+	state.max_row = total_rows;
+	state.table_filters = table_filters;
+	if (table_filters) {
+		D_ASSERT(!table_filters->filters.empty());
+		state.adaptive_filter = make_unique<AdaptiveFilter>(table_filters);
+	}
+	while (row_group && !row_group->InitializeScan(state.row_group_scan_state)) {
+		row_group = (RowGroup *)row_group->next.get();
+	}
+}
+
+void DataTable::InitializeScan(Transaction &transaction, TableScanState &state, const vector<column_t> &column_ids,
+                               TableFilterSet *table_filters) {
+	InitializeScan(state, column_ids, table_filters);
+	transaction.storage.InitializeScan(this, state.local_state, table_filters);
+}
+
+void DataTable::InitializeScanWithOffset(TableScanState &state, const vector<column_t> &column_ids, idx_t start_row,
+                                         idx_t end_row) {
+
+	auto row_group = (RowGroup *)row_groups->GetSegment(start_row);
+	state.column_ids = column_ids;
+	state.max_row = end_row;
+	state.table_filters = nullptr;
+	idx_t start_vector = (start_row - row_group->start) / STANDARD_VECTOR_SIZE;
+	if (!row_group->InitializeScanWithOffset(state.row_group_scan_state, start_vector)) {
+		throw InternalException("Failed to initialize row group scan with offset");
+	}
+}
+
+bool DataTable::InitializeScanInRowGroup(TableScanState &state, const vector<column_t> &column_ids,
+                                         TableFilterSet *table_filters, RowGroup *row_group, idx_t vector_index,
+                                         idx_t max_row) {
+	state.column_ids = column_ids;
+	state.max_row = max_row;
+	state.table_filters = table_filters;
+	if (table_filters) {
+		D_ASSERT(!table_filters->filters.empty());
+		state.adaptive_filter = make_unique<AdaptiveFilter>(table_filters);
+	}
+	return row_group->InitializeScanWithOffset(state.row_group_scan_state, vector_index);
+}
+
+idx_t DataTable::MaxThreads(ClientContext &context) {
+	idx_t parallel_scan_vector_count = RowGroup::ROW_GROUP_VECTOR_COUNT;
+	if (ClientConfig::GetConfig(context).verify_parallelism) {
+		parallel_scan_vector_count = 1;
+	}
+	idx_t parallel_scan_tuple_count = STANDARD_VECTOR_SIZE * parallel_scan_vector_count;
+
+	return total_rows / parallel_scan_tuple_count + 1;
+}
+
+void DataTable::InitializeParallelScan(ClientContext &context, ParallelTableScanState &state) {
+	state.current_row_group = (RowGroup *)row_groups->GetRootSegment();
+	state.transaction_local_data = false;
+	// figure out the max row we can scan for both the regular and the transaction-local storage
+	state.max_row = total_rows;
+	state.vector_index = 0;
+	state.local_state.max_index = 0;
+	auto &transaction = Transaction::GetTransaction(context);
+	transaction.storage.InitializeScan(this, state.local_state, nullptr);
+}
+
+bool DataTable::NextParallelScan(ClientContext &context, ParallelTableScanState &state, TableScanState &scan_state,
+                                 const vector<column_t> &column_ids) {
+	while (state.current_row_group) {
+		idx_t vector_index;
+		idx_t max_row;
+		if (ClientConfig::GetConfig(context).verify_parallelism) {
+			vector_index = state.vector_index;
+			max_row = state.current_row_group->start +
+			          MinValue<idx_t>(state.current_row_group->count,
+			                          STANDARD_VECTOR_SIZE * state.vector_index + STANDARD_VECTOR_SIZE);
+			D_ASSERT(vector_index * STANDARD_VECTOR_SIZE < state.current_row_group->count);
+		} else {
+			vector_index = 0;
+			max_row = state.current_row_group->start + state.current_row_group->count;
+		}
+		max_row = MinValue<idx_t>(max_row, state.max_row);
+		bool need_to_scan;
+		if (state.current_row_group->count == 0) {
+			need_to_scan = false;
+		} else {
+			need_to_scan = InitializeScanInRowGroup(scan_state, column_ids, scan_state.table_filters,
+			                                        state.current_row_group, vector_index, max_row);
+		}
+		if (ClientConfig::GetConfig(context).verify_parallelism) {
+			state.vector_index++;
+			if (state.vector_index * STANDARD_VECTOR_SIZE >= state.current_row_group->count) {
+				state.current_row_group = (RowGroup *)state.current_row_group->next.get();
+				state.vector_index = 0;
+			}
+		} else {
+			state.current_row_group = (RowGroup *)state.current_row_group->next.get();
+		}
+		if (!need_to_scan) {
+			// filters allow us to skip this row group: move to the next row group
+			continue;
+		}
+		return true;
+	}
+	if (!state.transaction_local_data) {
+		auto &transaction = Transaction::GetTransaction(context);
+		// create a task for scanning the local data
+		scan_state.row_group_scan_state.max_row = 0;
+		scan_state.max_row = 0;
+		transaction.storage.InitializeScan(this, scan_state.local_state, scan_state.table_filters);
+		scan_state.local_state.max_index = state.local_state.max_index;
+		scan_state.local_state.last_chunk_count = state.local_state.last_chunk_count;
+		state.transaction_local_data = true;
+		return true;
+	} else {
+		// finished all scans: no more scans remaining
+		return false;
+	}
+}
+
+void DataTable::Scan(Transaction &transaction, DataChunk &result, TableScanState &state, vector<column_t> &column_ids) {
+	// scan the persistent segments
+	if (ScanBaseTable(transaction, result, state)) {
+		D_ASSERT(result.size() > 0);
+		return;
+	}
+
+	// scan the transaction-local segments
+	transaction.storage.Scan(state.local_state, column_ids, result);
+}
+
+bool DataTable::ScanBaseTable(Transaction &transaction, DataChunk &result, TableScanState &state) {
+	auto current_row_group = state.row_group_scan_state.row_group;
+	while (current_row_group) {
+		current_row_group->Scan(transaction, state.row_group_scan_state, result);
+		if (result.size() > 0) {
+			return true;
+		} else {
+			do {
+				current_row_group = state.row_group_scan_state.row_group = (RowGroup *)current_row_group->next.get();
+				if (current_row_group) {
+					bool scan_row_group = current_row_group->InitializeScan(state.row_group_scan_state);
+					if (scan_row_group) {
+						// skip this row group
+						break;
+					}
+				}
+			} while (current_row_group);
+		}
+	}
+	return false;
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch
+//===--------------------------------------------------------------------===//
+void DataTable::Fetch(Transaction &transaction, DataChunk &result, const vector<column_t> &column_ids,
+                      Vector &row_identifiers, idx_t fetch_count, ColumnFetchState &state) {
+	// figure out which row_group to fetch from
+	auto row_ids = FlatVector::GetData<row_t>(row_identifiers);
+	idx_t count = 0;
+	for (idx_t i = 0; i < fetch_count; i++) {
+		auto row_id = row_ids[i];
+		auto row_group = (RowGroup *)row_groups->GetSegment(row_id);
+		if (!row_group->Fetch(transaction, row_id - row_group->start)) {
+			continue;
+		}
+		row_group->FetchRow(transaction, state, column_ids, row_id, result, count);
+		count++;
+	}
+	result.SetCardinality(count);
+}
+
+//===--------------------------------------------------------------------===//
+// Append
+//===--------------------------------------------------------------------===//
+static void VerifyNotNullConstraint(TableCatalogEntry &table, Vector &vector, idx_t count, const string &col_name) {
+	if (VectorOperations::HasNull(vector, count)) {
+		throw ConstraintException("NOT NULL constraint failed: %s.%s", table.name, col_name);
+	}
+}
+
+// To avoid throwing an error at SELECT, instead this moves the error detection to INSERT
+static void VerifyGeneratedExpressionSuccess(TableCatalogEntry &table, DataChunk &chunk, Expression &expr,
+                                             column_t index) {
+	auto &col = table.columns[index];
+	D_ASSERT(col.Generated());
+	ExpressionExecutor executor(expr);
+	Vector result(col.Type());
+	try {
+		executor.ExecuteExpression(chunk, result);
+	} catch (std::exception &ex) {
+		throw ConstraintException("Incorrect %s value for generated column \"%s\"", col.Type().ToString(), col.Name());
+	}
+}
+
+static void VerifyCheckConstraint(TableCatalogEntry &table, Expression &expr, DataChunk &chunk) {
+	ExpressionExecutor executor(expr);
+	Vector result(LogicalType::INTEGER);
+	try {
+		executor.ExecuteExpression(chunk, result);
+	} catch (std::exception &ex) {
+		throw ConstraintException("CHECK constraint failed: %s (Error: %s)", table.name, ex.what());
+	} catch (...) { // LCOV_EXCL_START
+		throw ConstraintException("CHECK constraint failed: %s (Unknown Error)", table.name);
+	} // LCOV_EXCL_STOP
+	VectorData vdata;
+	result.Orrify(chunk.size(), vdata);
+
+	auto dataptr = (int32_t *)vdata.data;
+	for (idx_t i = 0; i < chunk.size(); i++) {
+		auto idx = vdata.sel->get_index(i);
+		if (vdata.validity.RowIsValid(idx) && dataptr[idx] == 0) {
+			throw ConstraintException("CHECK constraint failed: %s", table.name);
+		}
+	}
+}
+
+static bool IsForeignKeyIndex(const vector<idx_t> &fk_keys, Index &index, ForeignKeyType fk_type) {
+	if (fk_type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE ? !index.IsUnique() : !index.IsForeign()) {
+		return false;
+	}
+	if (fk_keys.size() != index.column_ids.size()) {
+		return false;
+	}
+	for (auto &fk_key : fk_keys) {
+		bool is_found = false;
+		for (auto &index_key : index.column_ids) {
+			if (fk_key == index_key) {
+				is_found = true;
+				break;
+			}
+		}
+		if (!is_found) {
+			return false;
+		}
+	}
+	return true;
+}
+
+Index *TableIndexList::FindForeignKeyIndex(const vector<idx_t> &fk_keys, ForeignKeyType fk_type) {
+	Index *result = nullptr;
+	Scan([&](Index &index) {
+		if (IsForeignKeyIndex(fk_keys, index, fk_type)) {
+			result = &index;
+		}
+		return false;
+	});
+	return result;
+}
+
+static void VerifyForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context, DataChunk &chunk,
+                                       bool is_append) {
+	const vector<idx_t> *src_keys_ptr = &bfk.info.fk_keys;
+	const vector<idx_t> *dst_keys_ptr = &bfk.info.pk_keys;
+	if (!is_append) {
+		src_keys_ptr = &bfk.info.pk_keys;
+		dst_keys_ptr = &bfk.info.fk_keys;
+	}
+
+	auto table_entry_ptr =
+	    Catalog::GetCatalog(context).GetEntry<TableCatalogEntry>(context, bfk.info.schema, bfk.info.table);
+	if (table_entry_ptr == nullptr) {
+		throw InternalException("Can't find table \"%s\" in foreign key constraint", bfk.info.table);
+	}
+
+	// make the data chunk to check
+	vector<LogicalType> types;
+	for (idx_t i = 0; i < table_entry_ptr->columns.size(); i++) {
+		types.emplace_back(table_entry_ptr->columns[i].Type());
+	}
+	DataChunk dst_chunk;
+	dst_chunk.InitializeEmpty(types);
+	for (idx_t i = 0; i < src_keys_ptr->size(); i++) {
+		dst_chunk.data[(*dst_keys_ptr)[i]].Reference(chunk.data[(*src_keys_ptr)[i]]);
+	}
+	dst_chunk.SetCardinality(chunk.size());
+	auto data_table = table_entry_ptr->storage.get();
+
+	idx_t count = dst_chunk.size();
+	if (count <= 0) {
+		return;
+	}
+
+	// we need to look at the error messages concurrently in data table's index and transaction local storage's index
+	vector<string> err_msgs, tran_err_msgs;
+	err_msgs.resize(count);
+	tran_err_msgs.resize(count);
+
+	auto fk_type = is_append ? ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE : ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE;
+	// check whether or not the chunk can be inserted or deleted into the referenced table' storage
+	auto index = data_table->info->indexes.FindForeignKeyIndex(*dst_keys_ptr, fk_type);
+	if (!index) {
+		throw InternalException("Internal Foreign Key error: could not find index to verify...");
+	}
+	if (is_append) {
+		index->VerifyAppendForeignKey(dst_chunk, err_msgs.data());
+	} else {
+		index->VerifyDeleteForeignKey(dst_chunk, err_msgs.data());
+	}
+	// check whether or not the chunk can be inserted or deleted into the referenced table' transaction local storage
+	auto &transaction = Transaction::GetTransaction(context);
+	bool transaction_check = transaction.storage.Find(data_table);
+	if (transaction_check) {
+		vector<unique_ptr<Index>> &transact_index_vec = transaction.storage.GetIndexes(data_table);
+		for (idx_t i = 0; i < transact_index_vec.size(); i++) {
+			if (IsForeignKeyIndex(*dst_keys_ptr, *transact_index_vec[i], fk_type)) {
+				if (is_append) {
+					transact_index_vec[i]->VerifyAppendForeignKey(dst_chunk, tran_err_msgs.data());
+				} else {
+					transact_index_vec[i]->VerifyDeleteForeignKey(dst_chunk, tran_err_msgs.data());
+				}
+			}
+		}
+	}
+
+	// we need to look at the error messages concurrently in data table's index and transaction local storage's index
+	for (idx_t i = 0; i < count; i++) {
+		if (!transaction_check) {
+			// if there is no transaction-local data we only need to check if there is an error message in the main
+			// index
+			if (!err_msgs[i].empty()) {
+				throw ConstraintException(err_msgs[i]);
+			} else {
+				continue;
+			}
+		}
+		if (is_append) {
+			// if we are appending we need to check to ensure the foreign key exists in either the transaction-local
+			// storage or the main table
+			if (!err_msgs[i].empty() && !tran_err_msgs[i].empty()) {
+				throw ConstraintException(err_msgs[i]);
+			} else {
+				continue;
+			}
+		}
+		// if we are deleting we need to ensure the foreign key DOES NOT exist in EITHER the transaction-local storage
+		// OR the main table
+		if (!err_msgs[i].empty() || !tran_err_msgs[i].empty()) {
+			string &err_msg = err_msgs[i];
+			if (err_msg.empty()) {
+				err_msg = tran_err_msgs[i];
+			}
+			throw ConstraintException(err_msg);
+		}
+	}
+}
+
+static void VerifyAppendForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context,
+                                             DataChunk &chunk) {
+	VerifyForeignKeyConstraint(bfk, context, chunk, true);
+}
+
+static void VerifyDeleteForeignKeyConstraint(const BoundForeignKeyConstraint &bfk, ClientContext &context,
+                                             DataChunk &chunk) {
+	VerifyForeignKeyConstraint(bfk, context, chunk, false);
+}
+
+void DataTable::VerifyAppendConstraints(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk) {
+	auto binder = Binder::CreateBinder(context);
+	auto bound_columns = unordered_set<column_t>();
+	CheckBinder generated_check_binder(*binder, context, table.name, table.columns, bound_columns);
+	for (idx_t i = 0; i < table.columns.size(); i++) {
+		auto &col = table.columns[i];
+		if (!col.Generated()) {
+			continue;
+		}
+		D_ASSERT(col.Type().id() != LogicalTypeId::ANY);
+		generated_check_binder.target_type = col.Type();
+		auto to_be_bound_expression = col.GeneratedExpression().Copy();
+		auto bound_expression = generated_check_binder.Bind(to_be_bound_expression);
+		VerifyGeneratedExpressionSuccess(table, chunk, *bound_expression, i);
+	}
+	for (idx_t i = 0; i < table.bound_constraints.size(); i++) {
+		auto &base_constraint = table.constraints[i];
+		auto &constraint = table.bound_constraints[i];
+		switch (base_constraint->type) {
+		case ConstraintType::NOT_NULL: {
+			auto &not_null = *reinterpret_cast<BoundNotNullConstraint *>(constraint.get());
+			VerifyNotNullConstraint(table, chunk.data[not_null.index], chunk.size(),
+			                        table.columns[not_null.index].Name());
+			break;
+		}
+		case ConstraintType::CHECK: {
+			auto &check = *reinterpret_cast<BoundCheckConstraint *>(constraint.get());
+			VerifyCheckConstraint(table, *check.expression, chunk);
+			break;
+		}
+		case ConstraintType::UNIQUE: {
+			//! check whether or not the chunk can be inserted into the indexes
+			info->indexes.Scan([&](Index &index) {
+				index.VerifyAppend(chunk);
+				return false;
+			});
+			break;
+		}
+		case ConstraintType::FOREIGN_KEY: {
+			auto &bfk = *reinterpret_cast<BoundForeignKeyConstraint *>(constraint.get());
+			if (bfk.info.type == ForeignKeyType::FK_TYPE_FOREIGN_KEY_TABLE ||
+			    bfk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+				VerifyAppendForeignKeyConstraint(bfk, context, chunk);
+			}
+			break;
+		}
+		default:
+			throw NotImplementedException("Constraint type not implemented!");
+		}
+	}
+}
+
+void DataTable::Append(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk) {
+	if (chunk.size() == 0) {
+		return;
+	}
+	// FIXME: could be an assertion instead?
+	if (chunk.ColumnCount() != table.StandardColumnCount()) {
+		throw InternalException("Mismatch in column count for append");
+	}
+	if (!is_root) {
+		throw TransactionException("Transaction conflict: adding entries to a table that has been altered!");
+	}
+
+	chunk.Verify();
+
+	// verify any constraints on the new chunk
+	VerifyAppendConstraints(table, context, chunk);
+
+	// append to the transaction local data
+	auto &transaction = Transaction::GetTransaction(context);
+	transaction.storage.Append(this, chunk);
+}
+
+void DataTable::InitializeAppend(Transaction &transaction, TableAppendState &state, idx_t append_count) {
+	// obtain the append lock for this table
+	state.append_lock = unique_lock<mutex>(append_lock);
+	if (!is_root) {
+		throw TransactionException("Transaction conflict: adding entries to a table that has been altered!");
+	}
+	state.row_start = total_rows;
+	state.current_row = state.row_start;
+	state.remaining_append_count = append_count;
+
+	// start writing to the row_groups
+	lock_guard<mutex> row_group_lock(row_groups->node_lock);
+	auto last_row_group = (RowGroup *)row_groups->GetLastSegment();
+	D_ASSERT(total_rows == last_row_group->start + last_row_group->count);
+	last_row_group->InitializeAppend(transaction, state.row_group_append_state, state.remaining_append_count);
+	total_rows += append_count;
+}
+
+void DataTable::Append(Transaction &transaction, DataChunk &chunk, TableAppendState &state) {
+	D_ASSERT(is_root);
+	D_ASSERT(chunk.ColumnCount() == column_definitions.size());
+	chunk.Verify();
+
+	idx_t append_count = chunk.size();
+	idx_t remaining = chunk.size();
+	while (true) {
+		auto current_row_group = state.row_group_append_state.row_group;
+		// check how much we can fit into the current row_group
+		idx_t append_count =
+		    MinValue<idx_t>(remaining, RowGroup::ROW_GROUP_SIZE - state.row_group_append_state.offset_in_row_group);
+		if (append_count > 0) {
+			current_row_group->Append(state.row_group_append_state, chunk, append_count);
+			// merge the stats
+			lock_guard<mutex> stats_guard(stats_lock);
+			for (idx_t i = 0; i < column_definitions.size(); i++) {
+				column_stats[i]->stats->Merge(*current_row_group->GetStatistics(i));
+			}
+		}
+		state.remaining_append_count -= append_count;
+		remaining -= append_count;
+		if (remaining > 0) {
+			// we expect max 1 iteration of this loop (i.e. a single chunk should never overflow more than one
+			// row_group)
+			D_ASSERT(chunk.size() == remaining + append_count);
+			// slice the input chunk
+			if (remaining < chunk.size()) {
+				SelectionVector sel(STANDARD_VECTOR_SIZE);
+				for (idx_t i = 0; i < remaining; i++) {
+					sel.set_index(i, append_count + i);
+				}
+				chunk.Slice(sel, remaining);
+			}
+			// append a new row_group
+			AppendRowGroup(current_row_group->start + current_row_group->count);
+			// set up the append state for this row_group
+			lock_guard<mutex> row_group_lock(row_groups->node_lock);
+			auto last_row_group = (RowGroup *)row_groups->GetLastSegment();
+			last_row_group->InitializeAppend(transaction, state.row_group_append_state, state.remaining_append_count);
+			continue;
+		} else {
+			break;
+		}
+	}
+	state.current_row += append_count;
+	for (idx_t col_idx = 0; col_idx < column_stats.size(); col_idx++) {
+		auto type = chunk.data[col_idx].GetType().InternalType();
+		if (type == PhysicalType::LIST || type == PhysicalType::STRUCT) {
+			continue;
+		}
+		column_stats[col_idx]->stats->UpdateDistinctStatistics(chunk.data[col_idx], chunk.size());
+	}
+}
+
+void DataTable::ScanTableSegment(idx_t row_start, idx_t count, const std::function<void(DataChunk &chunk)> &function) {
+	idx_t end = row_start + count;
+
+	vector<column_t> column_ids;
+	vector<LogicalType> types;
+	for (idx_t i = 0; i < this->column_definitions.size(); i++) {
+		auto &col = this->column_definitions[i];
+		column_ids.push_back(i);
+		types.push_back(col.Type());
+	}
+	DataChunk chunk;
+	chunk.Initialize(types);
+
+	CreateIndexScanState state;
+
+	idx_t row_start_aligned = row_start / STANDARD_VECTOR_SIZE * STANDARD_VECTOR_SIZE;
+	InitializeScanWithOffset(state, column_ids, row_start_aligned, row_start + count);
+
+	idx_t current_row = row_start_aligned;
+	while (current_row < end) {
+		ScanCreateIndex(state, chunk, TableScanType::TABLE_SCAN_COMMITTED_ROWS);
+		if (chunk.size() == 0) {
+			break;
+		}
+		idx_t end_row = current_row + chunk.size();
+		// figure out if we need to write the entire chunk or just part of it
+		idx_t chunk_start = MaxValue<idx_t>(current_row, row_start);
+		idx_t chunk_end = MinValue<idx_t>(end_row, end);
+		D_ASSERT(chunk_start < chunk_end);
+		idx_t chunk_count = chunk_end - chunk_start;
+		if (chunk_count != chunk.size()) {
+			// need to slice the chunk before insert
+			auto start_in_chunk = chunk_start % STANDARD_VECTOR_SIZE;
+			SelectionVector sel(start_in_chunk, chunk_count);
+			chunk.Slice(sel, chunk_count);
+			chunk.Verify();
+		}
+		function(chunk);
+		chunk.Reset();
+		current_row = end_row;
+	}
+}
+
+void DataTable::WriteToLog(WriteAheadLog &log, idx_t row_start, idx_t count) {
+	log.WriteSetTable(info->schema, info->table);
+	ScanTableSegment(row_start, count, [&](DataChunk &chunk) { log.WriteInsert(chunk); });
+}
+
+void DataTable::CommitAppend(transaction_t commit_id, idx_t row_start, idx_t count) {
+	lock_guard<mutex> lock(append_lock);
+
+	auto row_group = (RowGroup *)row_groups->GetSegment(row_start);
+	idx_t current_row = row_start;
+	idx_t remaining = count;
+	while (true) {
+		idx_t start_in_row_group = current_row - row_group->start;
+		idx_t append_count = MinValue<idx_t>(row_group->count - start_in_row_group, remaining);
+
+		row_group->CommitAppend(commit_id, start_in_row_group, append_count);
+
+		current_row += append_count;
+		remaining -= append_count;
+		if (remaining == 0) {
+			break;
+		}
+		row_group = (RowGroup *)row_group->next.get();
+	}
+	info->cardinality += count;
+}
+
+void DataTable::RevertAppendInternal(idx_t start_row, idx_t count) {
+	if (count == 0) {
+		// nothing to revert!
+		return;
+	}
+	if (total_rows != start_row + count) {
+		// interleaved append: don't do anything
+		// in this case the rows will stay as "inserted by transaction X", but will never be committed
+		// they will never be used by any other transaction and will essentially leave a gap
+		// this situation is rare, and as such we don't care about optimizing it (yet?)
+		// it only happens if C1 appends a lot of data -> C2 appends a lot of data -> C1 rolls back
+		return;
+	}
+	// adjust the cardinality
+	info->cardinality = start_row;
+	total_rows = start_row;
+	D_ASSERT(is_root);
+	// revert appends made to row_groups
+	lock_guard<mutex> tree_lock(row_groups->node_lock);
+	// find the segment index that the current row belongs to
+	idx_t segment_index = row_groups->GetSegmentIndex(start_row);
+	auto segment = row_groups->nodes[segment_index].node;
+	auto &info = (RowGroup &)*segment;
+
+	// remove any segments AFTER this segment: they should be deleted entirely
+	if (segment_index < row_groups->nodes.size() - 1) {
+		row_groups->nodes.erase(row_groups->nodes.begin() + segment_index + 1, row_groups->nodes.end());
+	}
+	info.next = nullptr;
+	info.RevertAppend(start_row);
+}
+
+void DataTable::RevertAppend(idx_t start_row, idx_t count) {
+	lock_guard<mutex> lock(append_lock);
+
+	if (!info->indexes.Empty()) {
+		idx_t current_row_base = start_row;
+		row_t row_data[STANDARD_VECTOR_SIZE];
+		Vector row_identifiers(LogicalType::ROW_TYPE, (data_ptr_t)row_data);
+		ScanTableSegment(start_row, count, [&](DataChunk &chunk) {
+			for (idx_t i = 0; i < chunk.size(); i++) {
+				row_data[i] = current_row_base + i;
+			}
+			info->indexes.Scan([&](Index &index) {
+				index.Delete(chunk, row_identifiers);
+				return false;
+			});
+			current_row_base += chunk.size();
+		});
+	}
+	RevertAppendInternal(start_row, count);
+}
+
+//===--------------------------------------------------------------------===//
+// Indexes
+//===--------------------------------------------------------------------===//
+bool DataTable::AppendToIndexes(TableAppendState &state, DataChunk &chunk, row_t row_start) {
+	D_ASSERT(is_root);
+	if (info->indexes.Empty()) {
+		return true;
+	}
+	// first generate the vector of row identifiers
+	Vector row_identifiers(LogicalType::ROW_TYPE);
+	VectorOperations::GenerateSequence(row_identifiers, chunk.size(), row_start, 1);
+
+	vector<Index *> already_appended;
+	bool append_failed = false;
+	// now append the entries to the indices
+	info->indexes.Scan([&](Index &index) {
+		if (!index.Append(chunk, row_identifiers)) {
+			append_failed = true;
+			return true;
+		}
+		already_appended.push_back(&index);
+		return false;
+	});
+
+	if (append_failed) {
+		// constraint violation!
+		// remove any appended entries from previous indexes (if any)
+
+		for (auto *index : already_appended) {
+			index->Delete(chunk, row_identifiers);
+		}
+
+		return false;
+	}
+	return true;
+}
+
+void DataTable::RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, row_t row_start) {
+	D_ASSERT(is_root);
+	if (info->indexes.Empty()) {
+		return;
+	}
+	// first generate the vector of row identifiers
+	Vector row_identifiers(LogicalType::ROW_TYPE);
+	VectorOperations::GenerateSequence(row_identifiers, chunk.size(), row_start, 1);
+
+	// now remove the entries from the indices
+	RemoveFromIndexes(state, chunk, row_identifiers);
+}
+
+void DataTable::RemoveFromIndexes(TableAppendState &state, DataChunk &chunk, Vector &row_identifiers) {
+	D_ASSERT(is_root);
+	info->indexes.Scan([&](Index &index) {
+		index.Delete(chunk, row_identifiers);
+		return false;
+	});
+}
+
+void DataTable::RemoveFromIndexes(Vector &row_identifiers, idx_t count) {
+	D_ASSERT(is_root);
+	auto row_ids = FlatVector::GetData<row_t>(row_identifiers);
+
+	// figure out which row_group to fetch from
+	auto row_group = (RowGroup *)row_groups->GetSegment(row_ids[0]);
+	auto row_group_vector_idx = (row_ids[0] - row_group->start) / STANDARD_VECTOR_SIZE;
+	auto base_row_id = row_group_vector_idx * STANDARD_VECTOR_SIZE + row_group->start;
+
+	// create a selection vector from the row_ids
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	for (idx_t i = 0; i < count; i++) {
+		auto row_in_vector = row_ids[i] - base_row_id;
+		D_ASSERT(row_in_vector < STANDARD_VECTOR_SIZE);
+		sel.set_index(i, row_in_vector);
+	}
+
+	// now fetch the columns from that row_group
+	// FIXME: we do not need to fetch all columns, only the columns required by the indices!
+	TableScanState state;
+	state.max_row = total_rows;
+	auto types = GetTypes();
+	for (idx_t i = 0; i < types.size(); i++) {
+		state.column_ids.push_back(i);
+	}
+	DataChunk result;
+	result.Initialize(types);
+
+	row_group->InitializeScanWithOffset(state.row_group_scan_state, row_group_vector_idx);
+	row_group->ScanCommitted(state.row_group_scan_state, result,
+	                         TableScanType::TABLE_SCAN_COMMITTED_ROWS_DISALLOW_UPDATES);
+	result.Slice(sel, count);
+
+	info->indexes.Scan([&](Index &index) {
+		index.Delete(result, row_identifiers);
+		return false;
+	});
+}
+
+void DataTable::VerifyDeleteConstraints(TableCatalogEntry &table, ClientContext &context, DataChunk &chunk) {
+	for (auto &constraint : table.bound_constraints) {
+		switch (constraint->type) {
+		case ConstraintType::NOT_NULL:
+		case ConstraintType::CHECK:
+		case ConstraintType::UNIQUE:
+			break;
+		case ConstraintType::FOREIGN_KEY: {
+			auto &bfk = *reinterpret_cast<BoundForeignKeyConstraint *>(constraint.get());
+			if (bfk.info.type == ForeignKeyType::FK_TYPE_PRIMARY_KEY_TABLE ||
+			    bfk.info.type == ForeignKeyType::FK_TYPE_SELF_REFERENCE_TABLE) {
+				VerifyDeleteForeignKeyConstraint(bfk, context, chunk);
+			}
+			break;
+		}
+		default:
+			throw NotImplementedException("Constraint type not implemented!");
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Delete
+//===--------------------------------------------------------------------===//
+idx_t DataTable::Delete(TableCatalogEntry &table, ClientContext &context, Vector &row_identifiers, idx_t count) {
+	D_ASSERT(row_identifiers.GetType().InternalType() == ROW_TYPE);
+	if (count == 0) {
+		return 0;
+	}
+
+	auto &transaction = Transaction::GetTransaction(context);
+
+	row_identifiers.Normalify(count);
+	auto ids = FlatVector::GetData<row_t>(row_identifiers);
+	auto first_id = ids[0];
+
+	// verify any constraints on the delete rows
+	DataChunk verify_chunk;
+	if (first_id >= MAX_ROW_ID) {
+		transaction.storage.FetchChunk(this, row_identifiers, count, verify_chunk);
+	} else {
+		ColumnFetchState fetch_state;
+		vector<column_t> col_ids;
+		vector<LogicalType> types;
+		for (idx_t i = 0; i < column_definitions.size(); i++) {
+			col_ids.push_back(column_definitions[i].StorageOid());
+			types.emplace_back(column_definitions[i].Type());
+		}
+		verify_chunk.Initialize(types);
+		Fetch(transaction, verify_chunk, col_ids, row_identifiers, count, fetch_state);
+	}
+	VerifyDeleteConstraints(table, context, verify_chunk);
+
+	if (first_id >= MAX_ROW_ID) {
+		// deletion is in transaction-local storage: push delete into local chunk collection
+		return transaction.storage.Delete(this, row_identifiers, count);
+	} else {
+		idx_t delete_count = 0;
+		// delete is in the row groups
+		// we need to figure out for each id to which row group it belongs
+		// usually all (or many) ids belong to the same row group
+		// we iterate over the ids and check for every id if it belongs to the same row group as their predecessor
+		idx_t pos = 0;
+		do {
+			idx_t start = pos;
+			auto row_group = (RowGroup *)row_groups->GetSegment(ids[pos]);
+			for (pos++; pos < count; pos++) {
+				D_ASSERT(ids[pos] >= 0);
+				// check if this id still belongs to this row group
+				if (idx_t(ids[pos]) < row_group->start) {
+					// id is before row_group start -> it does not
+					break;
+				}
+				if (idx_t(ids[pos]) >= row_group->start + row_group->count) {
+					// id is after row group end -> it does not
+					break;
+				}
+			}
+			delete_count += row_group->Delete(transaction, this, ids + start, pos - start);
+		} while (pos < count);
+		return delete_count;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Update
+//===--------------------------------------------------------------------===//
+static void CreateMockChunk(vector<LogicalType> &types, const vector<column_t> &column_ids, DataChunk &chunk,
+                            DataChunk &mock_chunk) {
+	// construct a mock DataChunk
+	mock_chunk.InitializeEmpty(types);
+	for (column_t i = 0; i < column_ids.size(); i++) {
+		mock_chunk.data[column_ids[i]].Reference(chunk.data[i]);
+	}
+	mock_chunk.SetCardinality(chunk.size());
+}
+
+static bool CreateMockChunk(TableCatalogEntry &table, const vector<column_t> &column_ids,
+                            unordered_set<column_t> &desired_column_ids, DataChunk &chunk, DataChunk &mock_chunk) {
+	idx_t found_columns = 0;
+	// check whether the desired columns are present in the UPDATE clause
+	for (column_t i = 0; i < column_ids.size(); i++) {
+		if (desired_column_ids.find(column_ids[i]) != desired_column_ids.end()) {
+			found_columns++;
+		}
+	}
+	if (found_columns == 0) {
+		// no columns were found: no need to check the constraint again
+		return false;
+	}
+	if (found_columns != desired_column_ids.size()) {
+		// FIXME: not all columns in UPDATE clause are present!
+		// this should not be triggered at all as the binder should add these columns
+		throw InternalException("Not all columns required for the CHECK constraint are present in the UPDATED chunk!");
+	}
+	// construct a mock DataChunk
+	auto types = table.GetTypes();
+	CreateMockChunk(types, column_ids, chunk, mock_chunk);
+	return true;
+}
+
+void DataTable::VerifyUpdateConstraints(TableCatalogEntry &table, DataChunk &chunk,
+                                        const vector<column_t> &column_ids) {
+	for (auto &constraint : table.bound_constraints) {
+		switch (constraint->type) {
+		case ConstraintType::NOT_NULL: {
+			auto &not_null = *reinterpret_cast<BoundNotNullConstraint *>(constraint.get());
+			// check if the constraint is in the list of column_ids
+			for (idx_t i = 0; i < column_ids.size(); i++) {
+				if (column_ids[i] == not_null.index) {
+					// found the column id: check the data in
+					VerifyNotNullConstraint(table, chunk.data[i], chunk.size(), table.columns[not_null.index].Name());
+					break;
+				}
+			}
+			break;
+		}
+		case ConstraintType::CHECK: {
+			auto &check = *reinterpret_cast<BoundCheckConstraint *>(constraint.get());
+
+			DataChunk mock_chunk;
+			if (CreateMockChunk(table, column_ids, check.bound_columns, chunk, mock_chunk)) {
+				VerifyCheckConstraint(table, *check.expression, mock_chunk);
+			}
+			break;
+		}
+		case ConstraintType::UNIQUE:
+		case ConstraintType::FOREIGN_KEY:
+			break;
+		default:
+			throw NotImplementedException("Constraint type not implemented!");
+		}
+	}
+	// update should not be called for indexed columns!
+	// instead update should have been rewritten to delete + update on higher layer
+#ifdef DEBUG
+	info->indexes.Scan([&](Index &index) {
+		D_ASSERT(!index.IndexIsUpdated(column_ids));
+		return false;
+	});
+
+#endif
+}
+
+void DataTable::Update(TableCatalogEntry &table, ClientContext &context, Vector &row_ids,
+                       const vector<column_t> &column_ids, DataChunk &updates) {
+	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
+
+	auto count = updates.size();
+	updates.Verify();
+	if (count == 0) {
+		return;
+	}
+
+	if (!is_root) {
+		throw TransactionException("Transaction conflict: cannot update a table that has been altered!");
+	}
+
+	// first verify that no constraints are violated
+	VerifyUpdateConstraints(table, updates, column_ids);
+
+	// now perform the actual update
+	auto &transaction = Transaction::GetTransaction(context);
+
+	updates.Normalify();
+	row_ids.Normalify(count);
+	auto ids = FlatVector::GetData<row_t>(row_ids);
+	auto first_id = FlatVector::GetValue<row_t>(row_ids, 0);
+	if (first_id >= MAX_ROW_ID) {
+		// update is in transaction-local storage: push update into local storage
+		transaction.storage.Update(this, row_ids, column_ids, updates);
+		return;
+	}
+
+	// update is in the row groups
+	// we need to figure out for each id to which row group it belongs
+	// usually all (or many) ids belong to the same row group
+	// we iterate over the ids and check for every id if it belongs to the same row group as their predecessor
+	idx_t pos = 0;
+	do {
+		idx_t start = pos;
+		auto row_group = (RowGroup *)row_groups->GetSegment(ids[pos]);
+		row_t base_id =
+		    row_group->start + ((ids[pos] - row_group->start) / STANDARD_VECTOR_SIZE * STANDARD_VECTOR_SIZE);
+		for (pos++; pos < count; pos++) {
+			D_ASSERT(ids[pos] >= 0);
+			// check if this id still belongs to this vector
+			if (ids[pos] < base_id) {
+				// id is before vector start -> it does not
+				break;
+			}
+			if (ids[pos] >= base_id + STANDARD_VECTOR_SIZE) {
+				// id is after vector end -> it does not
+				break;
+			}
+		}
+		row_group->Update(transaction, updates, ids, start, pos - start, column_ids);
+
+		lock_guard<mutex> stats_guard(stats_lock);
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			auto column_id = column_ids[i];
+			column_stats[column_id]->stats->Merge(*row_group->GetStatistics(column_id));
+		}
+	} while (pos < count);
+}
+
+void DataTable::UpdateColumn(TableCatalogEntry &table, ClientContext &context, Vector &row_ids,
+                             const vector<column_t> &column_path, DataChunk &updates) {
+	D_ASSERT(row_ids.GetType().InternalType() == ROW_TYPE);
+	D_ASSERT(updates.ColumnCount() == 1);
+	updates.Verify();
+	if (updates.size() == 0) {
+		return;
+	}
+
+	if (!is_root) {
+		throw TransactionException("Transaction conflict: cannot update a table that has been altered!");
+	}
+
+	// now perform the actual update
+	auto &transaction = Transaction::GetTransaction(context);
+
+	updates.Normalify();
+	row_ids.Normalify(updates.size());
+	auto first_id = FlatVector::GetValue<row_t>(row_ids, 0);
+	if (first_id >= MAX_ROW_ID) {
+		throw NotImplementedException("Cannot update a column-path on transaction local data");
+	}
+	// find the row_group this id belongs to
+	auto primary_column_idx = column_path[0];
+	auto row_group = (RowGroup *)row_groups->GetSegment(first_id);
+	row_group->UpdateColumn(transaction, updates, row_ids, column_path);
+
+	lock_guard<mutex> stats_guard(stats_lock);
+	column_stats[primary_column_idx]->stats->Merge(*row_group->GetStatistics(primary_column_idx));
+}
+
+//===--------------------------------------------------------------------===//
+// Create Index Scan
+//===--------------------------------------------------------------------===//
+void DataTable::InitializeCreateIndexScan(CreateIndexScanState &state, const vector<column_t> &column_ids) {
+	// we grab the append lock to make sure nothing is appended until AFTER we finish the index scan
+	state.append_lock = std::unique_lock<mutex>(append_lock);
+	state.delete_lock = std::unique_lock<mutex>(row_groups->node_lock);
+
+	InitializeScan(state, column_ids);
+}
+
+bool DataTable::ScanCreateIndex(CreateIndexScanState &state, DataChunk &result, TableScanType type) {
+	auto current_row_group = state.row_group_scan_state.row_group;
+	while (current_row_group) {
+		current_row_group->ScanCommitted(state.row_group_scan_state, result, type);
+		if (result.size() > 0) {
+			return true;
+		} else {
+			current_row_group = state.row_group_scan_state.row_group = (RowGroup *)current_row_group->next.get();
+			if (current_row_group) {
+				current_row_group->InitializeScan(state.row_group_scan_state);
+			}
+		}
+	}
+	return false;
+}
+
+void DataTable::AddIndex(unique_ptr<Index> index, const vector<unique_ptr<Expression>> &expressions) {
+	DataChunk result;
+	result.Initialize(index->logical_types);
+
+	DataChunk intermediate;
+	vector<LogicalType> intermediate_types;
+	auto column_ids = index->column_ids;
+	column_ids.push_back(COLUMN_IDENTIFIER_ROW_ID);
+	for (auto &id : index->column_ids) {
+		auto &col = column_definitions[id];
+		intermediate_types.push_back(col.Type());
+	}
+	intermediate_types.emplace_back(LogicalType::ROW_TYPE);
+	intermediate.Initialize(intermediate_types);
+
+	// initialize an index scan
+	CreateIndexScanState state;
+	InitializeCreateIndexScan(state, column_ids);
+
+	if (!is_root) {
+		throw TransactionException("Transaction conflict: cannot add an index to a table that has been altered!");
+	}
+
+	// now start incrementally building the index
+	{
+		IndexLock lock;
+		index->InitializeLock(lock);
+		ExpressionExecutor executor(expressions);
+		while (true) {
+			intermediate.Reset();
+			// scan a new chunk from the table to index
+			ScanCreateIndex(state, intermediate, TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED);
+			if (intermediate.size() == 0) {
+				// finished scanning for index creation
+				// release all locks
+				break;
+			}
+			// resolve the expressions for this chunk
+			executor.Execute(intermediate, result);
+
+			// insert into the index
+			if (!index->Insert(lock, result, intermediate.data[intermediate.ColumnCount() - 1])) {
+				throw ConstraintException(
+				    "Cant create unique index, table contains duplicate data on indexed column(s)");
+			}
+		}
+	}
+	info->indexes.AddIndex(move(index));
+}
+
+unique_ptr<BaseStatistics> DataTable::GetStatistics(ClientContext &context, column_t column_id) {
+	if (column_id == COLUMN_IDENTIFIER_ROW_ID) {
+		return nullptr;
+	}
+	lock_guard<mutex> stats_guard(stats_lock);
+	return column_stats[column_id]->stats->Copy();
+}
+
+//===--------------------------------------------------------------------===//
+// Checkpoint
+//===--------------------------------------------------------------------===//
+BlockPointer DataTable::Checkpoint(TableDataWriter &writer) {
+	// checkpoint each individual row group
+	// FIXME: we might want to combine adjacent row groups in case they have had deletions...
+	vector<unique_ptr<BaseStatistics>> global_stats;
+	for (idx_t i = 0; i < column_definitions.size(); i++) {
+		global_stats.push_back(column_stats[i]->stats->Copy());
+	}
+
+	auto row_group = (RowGroup *)row_groups->GetRootSegment();
+	vector<RowGroupPointer> row_group_pointers;
+	while (row_group) {
+		auto pointer = row_group->Checkpoint(writer, global_stats);
+		row_group_pointers.push_back(move(pointer));
+		row_group = (RowGroup *)row_group->next.get();
+	}
+	// store the current position in the metadata writer
+	// this is where the row groups for this table start
+	auto &meta_writer = writer.GetMetaWriter();
+	auto pointer = meta_writer.GetBlockPointer();
+
+	for (auto &stats : global_stats) {
+		stats->Serialize(meta_writer);
+	}
+	// now start writing the row group pointers to disk
+	meta_writer.Write<uint64_t>(row_group_pointers.size());
+	for (auto &row_group_pointer : row_group_pointers) {
+		RowGroup::Serialize(row_group_pointer, meta_writer);
+	}
+	return pointer;
+}
+
+void DataTable::CommitDropColumn(idx_t index) {
+	auto segment = (RowGroup *)row_groups->GetRootSegment();
+	while (segment) {
+		segment->CommitDropColumn(index);
+		segment = (RowGroup *)segment->next.get();
+	}
+}
+
+idx_t DataTable::GetTotalRows() {
+	return total_rows;
+}
+
+void DataTable::CommitDropTable() {
+	// commit a drop of this table: mark all blocks as modified so they can be reclaimed later on
+	auto segment = (RowGroup *)row_groups->GetRootSegment();
+	while (segment) {
+		segment->CommitDrop();
+		segment = (RowGroup *)segment->next.get();
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// GetStorageInfo
+//===--------------------------------------------------------------------===//
+vector<vector<Value>> DataTable::GetStorageInfo() {
+	vector<vector<Value>> result;
+
+	auto row_group = (RowGroup *)row_groups->GetRootSegment();
+	idx_t row_group_index = 0;
+	while (row_group) {
+		row_group->GetStorageInfo(row_group_index, result);
+		row_group_index++;
+
+		row_group = (RowGroup *)row_group->next.get();
+	}
+
+	return result;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+Index::Index(IndexType type, const vector<column_t> &column_ids_p,
+             const vector<unique_ptr<Expression>> &unbound_expressions, IndexConstraintType constraint_type_p)
+    : type(type), column_ids(column_ids_p), constraint_type(constraint_type_p) {
+	for (auto &expr : unbound_expressions) {
+		types.push_back(expr->return_type.InternalType());
+		logical_types.push_back(expr->return_type);
+		auto unbound_expression = expr->Copy();
+		bound_expressions.push_back(BindExpression(unbound_expression->Copy()));
+		this->unbound_expressions.emplace_back(move(unbound_expression));
+	}
+	for (auto &bound_expr : bound_expressions) {
+		executor.AddExpression(*bound_expr);
+	}
+	for (auto column_id : column_ids) {
+		column_id_set.insert(column_id);
+	}
+}
+
+void Index::InitializeLock(IndexLock &state) {
+	state.index_lock = unique_lock<mutex>(lock);
+}
+
+bool Index::Append(DataChunk &entries, Vector &row_identifiers) {
+	IndexLock state;
+	InitializeLock(state);
+	return Append(state, entries, row_identifiers);
+}
+
+void Index::Delete(DataChunk &entries, Vector &row_identifiers) {
+	IndexLock state;
+	InitializeLock(state);
+	Delete(state, entries, row_identifiers);
+}
+
+void Index::ExecuteExpressions(DataChunk &input, DataChunk &result) {
+	executor.Execute(input, result);
+}
+
+unique_ptr<Expression> Index::BindExpression(unique_ptr<Expression> expr) {
+	if (expr->type == ExpressionType::BOUND_COLUMN_REF) {
+		auto &bound_colref = (BoundColumnRefExpression &)*expr;
+		return make_unique<BoundReferenceExpression>(expr->return_type, column_ids[bound_colref.binding.column_index]);
+	}
+	ExpressionIterator::EnumerateChildren(*expr,
+	                                      [&](unique_ptr<Expression> &expr) { expr = BindExpression(move(expr)); });
+	return expr;
+}
+
+bool Index::IndexIsUpdated(const vector<column_t> &column_ids) const {
+	for (auto &column : column_ids) {
+		if (column_id_set.find(column) != column_id_set.end()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+LocalTableStorage::LocalTableStorage(DataTable &table) : table(table), active_scans(0) {
+	Clear();
+}
+
+LocalTableStorage::~LocalTableStorage() {
+}
+
+void LocalTableStorage::InitializeScan(LocalScanState &state, TableFilterSet *table_filters) {
+	state.table_filters = table_filters;
+	state.chunk_index = 0;
+	if (collection.ChunkCount() == 0) {
+		// nothing to scan
+		state.max_index = 0;
+		state.last_chunk_count = 0;
+		return;
+	}
+	state.SetStorage(shared_from_this());
+
+	state.max_index = collection.ChunkCount() - 1;
+	state.last_chunk_count = collection.Chunks().back()->size();
+}
+
+idx_t LocalTableStorage::EstimatedSize() {
+	idx_t appended_rows = collection.Count() - deleted_rows;
+	if (appended_rows == 0) {
+		return 0;
+	}
+	idx_t row_size = 0;
+	for (auto &type : collection.Types()) {
+		row_size += GetTypeIdSize(type.InternalType());
+	}
+	return appended_rows * row_size;
+}
+
+LocalScanState::~LocalScanState() {
+	SetStorage(nullptr);
+}
+
+void LocalScanState::SetStorage(shared_ptr<LocalTableStorage> new_storage) {
+	if (storage) {
+		D_ASSERT(storage->active_scans > 0);
+		storage->active_scans--;
+	}
+	storage = move(new_storage);
+	if (storage) {
+		storage->active_scans++;
+	}
+}
+
+void LocalTableStorage::Clear() {
+	collection.Reset();
+	deleted_entries.clear();
+	indexes.clear();
+	deleted_rows = 0;
+	table.info->indexes.Scan([&](Index &index) {
+		D_ASSERT(index.type == IndexType::ART);
+		auto &art = (ART &)index;
+		if (art.constraint_type != IndexConstraintType::NONE) {
+			// unique index: create a local ART index that maintains the same unique constraint
+			vector<unique_ptr<Expression>> unbound_expressions;
+			for (auto &expr : art.unbound_expressions) {
+				unbound_expressions.push_back(expr->Copy());
+			}
+			indexes.push_back(make_unique<ART>(art.column_ids, move(unbound_expressions), art.constraint_type));
+		}
+		return false;
+	});
+}
+
+void LocalStorage::InitializeScan(DataTable *table, LocalScanState &state, TableFilterSet *table_filters) {
+	auto entry = table_storage.find(table);
+	if (entry == table_storage.end()) {
+		// no local storage for table: set scan to nullptr
+		state.SetStorage(nullptr);
+		return;
+	}
+	auto storage = entry->second.get();
+	storage->InitializeScan(state, table_filters);
+}
+
+void LocalStorage::Scan(LocalScanState &state, const vector<column_t> &column_ids, DataChunk &result) {
+	auto storage = state.GetStorage();
+	if (!storage || state.chunk_index > state.max_index) {
+		// nothing left to scan
+		result.Reset();
+		return;
+	}
+	auto &chunk = storage->collection.GetChunk(state.chunk_index);
+	idx_t chunk_count = state.chunk_index == state.max_index ? state.last_chunk_count : chunk.size();
+	idx_t count = chunk_count;
+
+	// first create a selection vector from the deleted entries (if any)
+	SelectionVector valid_sel(STANDARD_VECTOR_SIZE);
+	auto entry = storage->deleted_entries.find(state.chunk_index);
+	if (entry != storage->deleted_entries.end()) {
+		// deleted entries! create a selection vector
+		auto deleted = entry->second.get();
+		idx_t new_count = 0;
+		for (idx_t i = 0; i < count; i++) {
+			if (!deleted[i]) {
+				valid_sel.set_index(new_count++, i);
+			}
+		}
+		if (new_count == 0 && count > 0) {
+			// all entries in this chunk were deleted: continue to next chunk
+			state.chunk_index++;
+			Scan(state, column_ids, result);
+			return;
+		}
+		count = new_count;
+	}
+
+	SelectionVector sel;
+	if (count != chunk_count) {
+		sel.Initialize(valid_sel);
+	} else {
+		sel.Initialize(nullptr);
+	}
+	// now scan the vectors of the chunk
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		auto id = column_ids[i];
+		if (id == COLUMN_IDENTIFIER_ROW_ID) {
+			// row identifier: return a sequence of rowids starting from MAX_ROW_ID plus the row offset in the chunk
+			result.data[i].Sequence(MAX_ROW_ID + state.chunk_index * STANDARD_VECTOR_SIZE, 1);
+		} else {
+			result.data[i].Reference(chunk.data[id]);
+		}
+		idx_t approved_tuple_count = count;
+		if (state.table_filters) {
+			auto column_filters = state.table_filters->filters.find(i);
+			if (column_filters != state.table_filters->filters.end()) {
+				//! We have filters to apply here
+				auto &mask = FlatVector::Validity(result.data[i]);
+				ColumnSegment::FilterSelection(sel, result.data[i], *column_filters->second, approved_tuple_count,
+				                               mask);
+				count = approved_tuple_count;
+			}
+		}
+	}
+	if (count == 0) {
+		// all entries in this chunk were filtered:: Continue on next chunk
+		state.chunk_index++;
+		Scan(state, column_ids, result);
+		return;
+	}
+	if (count == chunk_count) {
+		result.SetCardinality(count);
+	} else {
+		result.Slice(sel, count);
+	}
+	state.chunk_index++;
+}
+
+void LocalStorage::Append(DataTable *table, DataChunk &chunk) {
+	auto entry = table_storage.find(table);
+	LocalTableStorage *storage;
+	if (entry == table_storage.end()) {
+		auto new_storage = make_shared<LocalTableStorage>(*table);
+		storage = new_storage.get();
+		table_storage.insert(make_pair(table, move(new_storage)));
+	} else {
+		storage = entry->second.get();
+	}
+	// append to unique indices (if any)
+	if (!storage->indexes.empty()) {
+		idx_t base_id = MAX_ROW_ID + storage->collection.Count();
+
+		// first generate the vector of row identifiers
+		Vector row_ids(LogicalType::ROW_TYPE);
+		VectorOperations::GenerateSequence(row_ids, chunk.size(), base_id, 1);
+
+		// now append the entries to the indices
+		for (auto &index : storage->indexes) {
+			if (!index->Append(chunk, row_ids)) {
+				throw ConstraintException("PRIMARY KEY or UNIQUE constraint violated: duplicated key");
+			}
+		}
+	}
+	//! Append to the chunk
+	storage->collection.Append(chunk);
+	if (storage->active_scans == 0 && storage->collection.Count() >= RowGroup::ROW_GROUP_SIZE * 2) {
+		// flush to base storage
+		Flush(*table, *storage);
+	}
+}
+
+LocalTableStorage *LocalStorage::GetStorage(DataTable *table) {
+	auto entry = table_storage.find(table);
+	D_ASSERT(entry != table_storage.end());
+	return entry->second.get();
+}
+
+idx_t LocalStorage::EstimatedSize() {
+	idx_t estimated_size = 0;
+	for (auto &storage : table_storage) {
+		estimated_size += storage.second->EstimatedSize();
+	}
+	return estimated_size;
+}
+
+static idx_t GetChunk(Vector &row_ids) {
+	auto ids = FlatVector::GetData<row_t>(row_ids);
+	auto first_id = ids[0] - MAX_ROW_ID;
+
+	return first_id / STANDARD_VECTOR_SIZE;
+}
+
+idx_t LocalStorage::Delete(DataTable *table, Vector &row_ids, idx_t count) {
+	auto storage = GetStorage(table);
+	// figure out the chunk from which these row ids came
+	idx_t chunk_idx = GetChunk(row_ids);
+	D_ASSERT(chunk_idx < storage->collection.ChunkCount());
+
+	// delete from unique indices (if any)
+	if (!storage->indexes.empty()) {
+		// Index::Delete assumes that ALL rows are being deleted, so
+		// Slice out the rows that are being deleted from the storage Chunk
+		auto &chunk = storage->collection.GetChunk(chunk_idx);
+
+		VectorData row_ids_data;
+		row_ids.Orrify(count, row_ids_data);
+		auto row_identifiers = (const row_t *)row_ids_data.data;
+		SelectionVector sel(count);
+		for (idx_t i = 0; i < count; ++i) {
+			const auto idx = row_ids_data.sel->get_index(i);
+			sel.set_index(i, row_identifiers[idx] - MAX_ROW_ID);
+		}
+
+		DataChunk deleted;
+		deleted.InitializeEmpty(chunk.GetTypes());
+		deleted.Slice(chunk, sel, count);
+		for (auto &index : storage->indexes) {
+			index->Delete(deleted, row_ids);
+		}
+	}
+
+	// get a pointer to the deleted entries for this chunk
+	bool *deleted;
+	auto entry = storage->deleted_entries.find(chunk_idx);
+	if (entry == storage->deleted_entries.end()) {
+		// nothing deleted yet, add the deleted entries
+		auto del_entries = unique_ptr<bool[]>(new bool[STANDARD_VECTOR_SIZE]);
+		memset(del_entries.get(), 0, sizeof(bool) * STANDARD_VECTOR_SIZE);
+		deleted = del_entries.get();
+		storage->deleted_entries.insert(make_pair(chunk_idx, move(del_entries)));
+	} else {
+		deleted = entry->second.get();
+	}
+
+	// now actually mark the entries as deleted in the deleted vector
+	idx_t base_index = MAX_ROW_ID + chunk_idx * STANDARD_VECTOR_SIZE;
+
+	idx_t deleted_count = 0;
+	auto ids = FlatVector::GetData<row_t>(row_ids);
+	for (idx_t i = 0; i < count; i++) {
+		auto id = ids[i] - base_index;
+		if (!deleted[id]) {
+			deleted_count++;
+		}
+		deleted[id] = true;
+	}
+	storage->deleted_rows += deleted_count;
+	return deleted_count;
+}
+
+template <class T>
+static void TemplatedUpdateLoop(Vector &data_vector, Vector &update_vector, Vector &row_ids, idx_t count,
+                                idx_t base_index) {
+	VectorData udata;
+	update_vector.Orrify(count, udata);
+
+	auto target = FlatVector::GetData<T>(data_vector);
+	auto &mask = FlatVector::Validity(data_vector);
+	auto ids = FlatVector::GetData<row_t>(row_ids);
+	auto updates = (T *)udata.data;
+
+	for (idx_t i = 0; i < count; i++) {
+		auto uidx = udata.sel->get_index(i);
+
+		auto id = ids[i] - base_index;
+		target[id] = updates[uidx];
+		mask.Set(id, udata.validity.RowIsValid(uidx));
+	}
+}
+
+static void UpdateChunk(Vector &data, Vector &updates, Vector &row_ids, idx_t count, idx_t base_index) {
+	D_ASSERT(data.GetType() == updates.GetType());
+	D_ASSERT(row_ids.GetType() == LogicalType::ROW_TYPE);
+
+	switch (data.GetType().InternalType()) {
+	case PhysicalType::INT8:
+		TemplatedUpdateLoop<int8_t>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedUpdateLoop<uint8_t>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::INT16:
+		TemplatedUpdateLoop<int16_t>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedUpdateLoop<uint16_t>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::INT32:
+		TemplatedUpdateLoop<int32_t>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedUpdateLoop<uint32_t>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::INT64:
+		TemplatedUpdateLoop<int64_t>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedUpdateLoop<uint64_t>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedUpdateLoop<float>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedUpdateLoop<double>(data, updates, row_ids, count, base_index);
+		break;
+	case PhysicalType::VARCHAR:
+		TemplatedUpdateLoop<string_t>(data, updates, row_ids, count, base_index);
+		break;
+	default:
+		throw Exception("Unsupported type for in-place update: " + TypeIdToString(data.GetType().InternalType()));
+	}
+}
+
+void LocalStorage::Update(DataTable *table, Vector &row_ids, const vector<column_t> &column_ids, DataChunk &data) {
+	auto storage = GetStorage(table);
+	// figure out the chunk from which these row ids came
+	idx_t chunk_idx = GetChunk(row_ids);
+	D_ASSERT(chunk_idx < storage->collection.ChunkCount());
+
+	idx_t base_index = MAX_ROW_ID + chunk_idx * STANDARD_VECTOR_SIZE;
+
+	// now perform the actual update
+	auto &chunk = storage->collection.GetChunk(chunk_idx);
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		auto col_idx = column_ids[i];
+		UpdateChunk(chunk.data[col_idx], data.data[i], row_ids, data.size(), base_index);
+	}
+}
+
+template <class T>
+bool LocalStorage::ScanTableStorage(DataTable &table, LocalTableStorage &storage, T &&fun) {
+	vector<column_t> column_ids;
+	column_ids.reserve(table.column_definitions.size());
+	for (idx_t i = 0; i < table.column_definitions.size(); i++) {
+		column_ids.push_back(i);
+	}
+
+	DataChunk chunk;
+	chunk.Initialize(table.GetTypes());
+
+	// initialize the scan
+	LocalScanState state;
+	storage.InitializeScan(state);
+
+	while (true) {
+		Scan(state, column_ids, chunk);
+		if (chunk.size() == 0) {
+			return true;
+		}
+		if (!fun(chunk)) {
+			return false;
+		}
+	}
+}
+
+void LocalStorage::Flush(DataTable &table, LocalTableStorage &storage) {
+	if (storage.collection.Count() <= storage.deleted_rows) {
+		return;
+	}
+	idx_t append_count = storage.collection.Count() - storage.deleted_rows;
+	TableAppendState append_state;
+	table.InitializeAppend(transaction, append_state, append_count);
+
+	bool constraint_violated = false;
+	ScanTableStorage(table, storage, [&](DataChunk &chunk) -> bool {
+		// append this chunk to the indexes of the table
+		if (!table.AppendToIndexes(append_state, chunk, append_state.current_row)) {
+			constraint_violated = true;
+			return false;
+		}
+		// append to base table
+		table.Append(transaction, chunk, append_state);
+		return true;
+	});
+	if (constraint_violated) {
+		// need to revert the append
+		row_t current_row = append_state.row_start;
+		// remove the data from the indexes, if there are any indexes
+		ScanTableStorage(table, storage, [&](DataChunk &chunk) -> bool {
+			// append this chunk to the indexes of the table
+			table.RemoveFromIndexes(append_state, chunk, current_row);
+
+			current_row += chunk.size();
+			if (current_row >= append_state.current_row) {
+				// finished deleting all rows from the index: abort now
+				return false;
+			}
+			return true;
+		});
+		table.RevertAppendInternal(append_state.row_start, append_count);
+		storage.Clear();
+		throw ConstraintException("PRIMARY KEY or UNIQUE constraint violated: duplicated key");
+	}
+	storage.Clear();
+	transaction.PushAppend(&table, append_state.row_start, append_count);
+}
+
+void LocalStorage::Commit(LocalStorage::CommitState &commit_state, Transaction &transaction, WriteAheadLog *log,
+                          transaction_t commit_id) {
+	// commit local storage, iterate over all entries in the table storage map
+	for (auto &entry : table_storage) {
+		auto table = entry.first;
+		auto storage = entry.second.get();
+		Flush(*table, *storage);
+	}
+	// finished commit: clear local storage
+	table_storage.clear();
+}
+
+void LocalStorage::AddColumn(DataTable *old_dt, DataTable *new_dt, ColumnDefinition &new_column,
+                             Expression *default_value) {
+	// check if there are any pending appends for the old version of the table
+	auto entry = table_storage.find(old_dt);
+	if (entry == table_storage.end()) {
+		return;
+	}
+	// take over the storage from the old entry
+	auto new_storage = move(entry->second);
+
+	// now add the new column filled with the default value to all chunks
+	const auto &new_column_type = new_column.Type();
+	ExpressionExecutor executor;
+	DataChunk dummy_chunk;
+	if (default_value) {
+		executor.AddExpression(*default_value);
+	}
+
+	new_storage->collection.Types().push_back(new_column_type);
+	for (idx_t chunk_idx = 0; chunk_idx < new_storage->collection.ChunkCount(); chunk_idx++) {
+		auto &chunk = new_storage->collection.GetChunk(chunk_idx);
+		Vector result(new_column_type);
+		if (default_value) {
+			dummy_chunk.SetCardinality(chunk.size());
+			executor.ExecuteExpression(dummy_chunk, result);
+		} else {
+			FlatVector::Validity(result).SetAllInvalid(chunk.size());
+		}
+		result.Normalify(chunk.size());
+		chunk.data.push_back(move(result));
+	}
+
+	table_storage.erase(entry);
+	table_storage[new_dt] = move(new_storage);
+}
+
+void LocalStorage::ChangeType(DataTable *old_dt, DataTable *new_dt, idx_t changed_idx, const LogicalType &target_type,
+                              const vector<column_t> &bound_columns, Expression &cast_expr) {
+	// check if there are any pending appends for the old version of the table
+	auto entry = table_storage.find(old_dt);
+	if (entry == table_storage.end()) {
+		return;
+	}
+	throw NotImplementedException("FIXME: ALTER TYPE with transaction local data not currently supported");
+}
+
+void LocalStorage::FetchChunk(DataTable *table, Vector &row_ids, idx_t count, DataChunk &dst_chunk) {
+	auto storage = GetStorage(table);
+	idx_t chunk_idx = GetChunk(row_ids);
+	auto &chunk = storage->collection.GetChunk(chunk_idx);
+
+	VectorData row_ids_data;
+	row_ids.Orrify(count, row_ids_data);
+	auto row_identifiers = (const row_t *)row_ids_data.data;
+	SelectionVector sel(count);
+	for (idx_t i = 0; i < count; ++i) {
+		const auto idx = row_ids_data.sel->get_index(i);
+		sel.set_index(i, row_identifiers[idx] - MAX_ROW_ID);
+	}
+
+	dst_chunk.InitializeEmpty(chunk.GetTypes());
+	dst_chunk.Slice(chunk, sel, count);
+}
+
+vector<unique_ptr<Index>> &LocalStorage::GetIndexes(DataTable *table) {
+	auto storage = GetStorage(table);
+
+	return storage->indexes;
+}
+
+} // namespace duckdb
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+MetaBlockReader::MetaBlockReader(DatabaseInstance &db, block_id_t block_id)
+    : db(db), handle(nullptr), offset(0), next_block(-1) {
+	ReadNewBlock(block_id);
+}
+
+MetaBlockReader::~MetaBlockReader() {
+}
+
+void MetaBlockReader::ReadData(data_ptr_t buffer, idx_t read_size) {
+	while (offset + read_size > handle->node->size) {
+		// cannot read entire entry from block
+		// first read what we can from this block
+		idx_t to_read = handle->node->size - offset;
+		if (to_read > 0) {
+			memcpy(buffer, handle->node->buffer + offset, to_read);
+			read_size -= to_read;
+			buffer += to_read;
+		}
+		// then move to the next block
+		ReadNewBlock(next_block);
+	}
+	// we have enough left in this block to read from the buffer
+	memcpy(buffer, handle->node->buffer + offset, read_size);
+	offset += read_size;
+}
+
+void MetaBlockReader::ReadNewBlock(block_id_t id) {
+	auto &block_manager = BlockManager::GetBlockManager(db);
+	auto &buffer_manager = BufferManager::GetBufferManager(db);
+
+	block_manager.MarkBlockAsModified(id);
+	block = buffer_manager.RegisterBlock(id);
+	handle = buffer_manager.Pin(block);
+
+	next_block = Load<block_id_t>(handle->node->buffer);
+	D_ASSERT(next_block >= -1);
+	offset = sizeof(block_id_t);
+}
+
+} // namespace duckdb
+
+
+#include <cstring>
+
+namespace duckdb {
+
+MetaBlockWriter::MetaBlockWriter(DatabaseInstance &db, block_id_t initial_block_id) : db(db) {
+	if (initial_block_id == INVALID_BLOCK) {
+		initial_block_id = GetNextBlockId();
+	}
+	auto &block_manager = BlockManager::GetBlockManager(db);
+	block = block_manager.CreateBlock(initial_block_id);
+	Store<block_id_t>(-1, block->buffer);
+	offset = sizeof(block_id_t);
+}
+
+MetaBlockWriter::~MetaBlockWriter() {
+	if (Exception::UncaughtException()) {
+		return;
+	}
+	try {
+		Flush();
+	} catch (...) {
+	}
+}
+
+block_id_t MetaBlockWriter::GetNextBlockId() {
+	auto &block_manager = BlockManager::GetBlockManager(db);
+	return block_manager.GetFreeBlockId();
+}
+
+BlockPointer MetaBlockWriter::GetBlockPointer() {
+	BlockPointer pointer;
+	pointer.block_id = block->id;
+	pointer.offset = offset;
+	return pointer;
+}
+
+void MetaBlockWriter::Flush() {
+	written_blocks.insert(block->id);
+	if (offset > sizeof(block_id_t)) {
+		auto &block_manager = BlockManager::GetBlockManager(db);
+		block_manager.Write(*block);
+		offset = sizeof(block_id_t);
+	}
+}
+
+void MetaBlockWriter::WriteData(const_data_ptr_t buffer, idx_t write_size) {
+	while (offset + write_size > block->size) {
+		// we need to make a new block
+		// first copy what we can
+		D_ASSERT(offset <= block->size);
+		idx_t copy_amount = block->size - offset;
+		if (copy_amount > 0) {
+			memcpy(block->buffer + offset, buffer, copy_amount);
+			buffer += copy_amount;
+			offset += copy_amount;
+			write_size -= copy_amount;
+		}
+		// now we need to get a new block id
+		block_id_t new_block_id = GetNextBlockId();
+		// write the block id of the new block to the start of the current block
+		Store<block_id_t>(new_block_id, block->buffer);
+		// first flush the old block
+		Flush();
+		// now update the block id of the lbock
+		block->id = new_block_id;
+		Store<block_id_t>(-1, block->buffer);
+	}
+	memcpy(block->buffer + offset, buffer, write_size);
+	offset += write_size;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+#include <algorithm>
+#include <cstring>
+
+namespace duckdb {
+
+const char MainHeader::MAGIC_BYTES[] = "DUCK";
+
+void MainHeader::Serialize(Serializer &ser) {
+	ser.WriteData((data_ptr_t)MAGIC_BYTES, MAGIC_BYTE_SIZE);
+	ser.Write<uint64_t>(version_number);
+	FieldWriter writer(ser);
+	for (idx_t i = 0; i < FLAG_COUNT; i++) {
+		writer.WriteField<uint64_t>(flags[i]);
+	}
+	writer.Finalize();
+}
+
+void MainHeader::CheckMagicBytes(FileHandle &handle) {
+	data_t magic_bytes[MAGIC_BYTE_SIZE];
+	if (handle.GetFileSize() < MainHeader::MAGIC_BYTE_SIZE + MainHeader::MAGIC_BYTE_OFFSET) {
+		throw IOException("The file is not a valid DuckDB database file!");
+	}
+	handle.Read(magic_bytes, MainHeader::MAGIC_BYTE_SIZE, MainHeader::MAGIC_BYTE_OFFSET);
+	if (memcmp(magic_bytes, MainHeader::MAGIC_BYTES, MainHeader::MAGIC_BYTE_SIZE) != 0) {
+		throw IOException("The file is not a valid DuckDB database file!");
+	}
+}
+
+MainHeader MainHeader::Deserialize(Deserializer &source) {
+	data_t magic_bytes[MAGIC_BYTE_SIZE];
+	MainHeader header;
+	source.ReadData(magic_bytes, MainHeader::MAGIC_BYTE_SIZE);
+	if (memcmp(magic_bytes, MainHeader::MAGIC_BYTES, MainHeader::MAGIC_BYTE_SIZE) != 0) {
+		throw IOException("The file is not a valid DuckDB database file!");
+	}
+	header.version_number = source.Read<uint64_t>();
+	// read the flags
+	FieldReader reader(source);
+	for (idx_t i = 0; i < FLAG_COUNT; i++) {
+		header.flags[i] = reader.ReadRequired<uint64_t>();
+	}
+	reader.Finalize();
+	return header;
+}
+
+void DatabaseHeader::Serialize(Serializer &ser) {
+	ser.Write<uint64_t>(iteration);
+	ser.Write<block_id_t>(meta_block);
+	ser.Write<block_id_t>(free_list);
+	ser.Write<uint64_t>(block_count);
+}
+
+DatabaseHeader DatabaseHeader::Deserialize(Deserializer &source) {
+	DatabaseHeader header;
+	header.iteration = source.Read<uint64_t>();
+	header.meta_block = source.Read<block_id_t>();
+	header.free_list = source.Read<block_id_t>();
+	header.block_count = source.Read<uint64_t>();
+	return header;
+}
+
+template <class T>
+void SerializeHeaderStructure(T header, data_ptr_t ptr) {
+	BufferedSerializer ser(ptr, Storage::FILE_HEADER_SIZE);
+	header.Serialize(ser);
+}
+
+template <class T>
+T DeserializeHeaderStructure(data_ptr_t ptr) {
+	BufferedDeserializer source(ptr, Storage::FILE_HEADER_SIZE);
+	return T::Deserialize(source);
+}
+
+SingleFileBlockManager::SingleFileBlockManager(DatabaseInstance &db, string path_p, bool read_only, bool create_new,
+                                               bool use_direct_io)
+    : db(db), path(move(path_p)),
+      header_buffer(Allocator::Get(db), FileBufferType::MANAGED_BUFFER, Storage::FILE_HEADER_SIZE), iteration_count(0),
+      read_only(read_only), use_direct_io(use_direct_io) {
+	uint8_t flags;
+	FileLockType lock;
+	if (read_only) {
+		D_ASSERT(!create_new);
+		flags = FileFlags::FILE_FLAGS_READ;
+		lock = FileLockType::READ_LOCK;
+	} else {
+		flags = FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ;
+		lock = FileLockType::WRITE_LOCK;
+		if (create_new) {
+			flags |= FileFlags::FILE_FLAGS_FILE_CREATE;
+		}
+	}
+	if (use_direct_io) {
+		flags |= FileFlags::FILE_FLAGS_DIRECT_IO;
+	}
+	// open the RDBMS handle
+	auto &fs = FileSystem::GetFileSystem(db);
+	handle = fs.OpenFile(path, flags, lock);
+	if (create_new) {
+		// if we create a new file, we fill the metadata of the file
+		// first fill in the new header
+		header_buffer.Clear();
+
+		MainHeader main_header;
+		main_header.version_number = VERSION_NUMBER;
+		memset(main_header.flags, 0, sizeof(uint64_t) * 4);
+
+		SerializeHeaderStructure<MainHeader>(main_header, header_buffer.buffer);
+		// now write the header to the file
+		header_buffer.ChecksumAndWrite(*handle, 0);
+		header_buffer.Clear();
+
+		// write the database headers
+		// initialize meta_block and free_list to INVALID_BLOCK because the database file does not contain any actual
+		// content yet
+		DatabaseHeader h1, h2;
+		// header 1
+		h1.iteration = 0;
+		h1.meta_block = INVALID_BLOCK;
+		h1.free_list = INVALID_BLOCK;
+		h1.block_count = 0;
+		SerializeHeaderStructure<DatabaseHeader>(h1, header_buffer.buffer);
+		header_buffer.ChecksumAndWrite(*handle, Storage::FILE_HEADER_SIZE);
+		// header 2
+		h2.iteration = 0;
+		h2.meta_block = INVALID_BLOCK;
+		h2.free_list = INVALID_BLOCK;
+		h2.block_count = 0;
+		SerializeHeaderStructure<DatabaseHeader>(h2, header_buffer.buffer);
+		header_buffer.ChecksumAndWrite(*handle, Storage::FILE_HEADER_SIZE * 2);
+		// ensure that writing to disk is completed before returning
+		handle->Sync();
+		// we start with h2 as active_header, this way our initial write will be in h1
+		iteration_count = 0;
+		active_header = 1;
+		max_block = 0;
+	} else {
+		MainHeader::CheckMagicBytes(*handle);
+		// otherwise, we check the metadata of the file
+		header_buffer.ReadAndChecksum(*handle, 0);
+		MainHeader header = DeserializeHeaderStructure<MainHeader>(header_buffer.buffer);
+		// check the version number
+		if (header.version_number != VERSION_NUMBER) {
+			throw IOException(
+			    "Trying to read a database file with version number %lld, but we can only read version %lld.\n"
+			    "The database file was created with an %s version of DuckDB.\n\n"
+			    "The storage of DuckDB is not yet stable; newer versions of DuckDB cannot read old database files and "
+			    "vice versa.\n"
+			    "The storage will be stabilized when version 1.0 releases.\n\n"
+			    "For now, we recommend that you load the database file in a supported version of DuckDB, and use the "
+			    "EXPORT DATABASE command "
+			    "followed by IMPORT DATABASE on the current version of DuckDB.",
+			    header.version_number, VERSION_NUMBER, VERSION_NUMBER > header.version_number ? "older" : "newer");
+		}
+
+		// read the database headers from disk
+		DatabaseHeader h1, h2;
+		header_buffer.ReadAndChecksum(*handle, Storage::FILE_HEADER_SIZE);
+		h1 = DeserializeHeaderStructure<DatabaseHeader>(header_buffer.buffer);
+		header_buffer.ReadAndChecksum(*handle, Storage::FILE_HEADER_SIZE * 2);
+		h2 = DeserializeHeaderStructure<DatabaseHeader>(header_buffer.buffer);
+		// check the header with the highest iteration count
+		if (h1.iteration > h2.iteration) {
+			// h1 is active header
+			active_header = 0;
+			Initialize(h1);
+		} else {
+			// h2 is active header
+			active_header = 1;
+			Initialize(h2);
+		}
+	}
+}
+
+void SingleFileBlockManager::Initialize(DatabaseHeader &header) {
+	free_list_id = header.free_list;
+	meta_block = header.meta_block;
+	iteration_count = header.iteration;
+	max_block = header.block_count;
+}
+
+void SingleFileBlockManager::LoadFreeList() {
+	if (read_only) {
+		// no need to load free list for read only db
+		return;
+	}
+	if (free_list_id == INVALID_BLOCK) {
+		// no free list
+		return;
+	}
+	MetaBlockReader reader(db, free_list_id);
+	auto free_list_count = reader.Read<uint64_t>();
+	free_list.clear();
+	for (idx_t i = 0; i < free_list_count; i++) {
+		free_list.insert(reader.Read<block_id_t>());
+	}
+	auto multi_use_blocks_count = reader.Read<uint64_t>();
+	multi_use_blocks.clear();
+	for (idx_t i = 0; i < multi_use_blocks_count; i++) {
+		auto block_id = reader.Read<block_id_t>();
+		auto usage_count = reader.Read<uint32_t>();
+		multi_use_blocks[block_id] = usage_count;
+	}
+}
+
+void SingleFileBlockManager::StartCheckpoint() {
+}
+
+bool SingleFileBlockManager::IsRootBlock(block_id_t root) {
+	return root == meta_block;
+}
+
+block_id_t SingleFileBlockManager::GetFreeBlockId() {
+	block_id_t block;
+	if (!free_list.empty()) {
+		// free list is non empty
+		// take an entry from the free list
+		block = *free_list.begin();
+		// erase the entry from the free list again
+		free_list.erase(free_list.begin());
+	} else {
+		block = max_block++;
+	}
+	return block;
+}
+
+void SingleFileBlockManager::MarkBlockAsModified(block_id_t block_id) {
+	D_ASSERT(block_id >= 0);
+
+	// check if the block is a multi-use block
+	auto entry = multi_use_blocks.find(block_id);
+	if (entry != multi_use_blocks.end()) {
+		// it is! reduce the reference count of the block
+		entry->second--;
+		// check the reference count: is the block still a multi-use block?
+		if (entry->second <= 1) {
+			// no longer a multi-use block!
+			multi_use_blocks.erase(entry);
+		}
+		return;
+	}
+	modified_blocks.insert(block_id);
+}
+
+void SingleFileBlockManager::IncreaseBlockReferenceCount(block_id_t block_id) {
+	D_ASSERT(free_list.find(block_id) == free_list.end());
+	auto entry = multi_use_blocks.find(block_id);
+	if (entry != multi_use_blocks.end()) {
+		entry->second++;
+	} else {
+		multi_use_blocks[block_id] = 2;
+	}
+}
+
+block_id_t SingleFileBlockManager::GetMetaBlock() {
+	return meta_block;
+}
+
+unique_ptr<Block> SingleFileBlockManager::CreateBlock(block_id_t block_id) {
+	return make_unique<Block>(Allocator::Get(db), block_id);
+}
+
+void SingleFileBlockManager::Read(Block &block) {
+	D_ASSERT(block.id >= 0);
+	D_ASSERT(std::find(free_list.begin(), free_list.end(), block.id) == free_list.end());
+	block.ReadAndChecksum(*handle, BLOCK_START + block.id * Storage::BLOCK_ALLOC_SIZE);
+}
+
+void SingleFileBlockManager::Write(FileBuffer &buffer, block_id_t block_id) {
+	D_ASSERT(block_id >= 0);
+	buffer.ChecksumAndWrite(*handle, BLOCK_START + block_id * Storage::BLOCK_ALLOC_SIZE);
+}
+
+vector<block_id_t> SingleFileBlockManager::GetFreeListBlocks() {
+	vector<block_id_t> free_list_blocks;
+
+	if (!free_list.empty() || !multi_use_blocks.empty() || !modified_blocks.empty()) {
+		// there are blocks in the free list or multi_use_blocks
+		// figure out how many blocks we need to write these to the file
+		auto free_list_size = sizeof(uint64_t) + sizeof(block_id_t) * (free_list.size() + modified_blocks.size());
+		auto multi_use_blocks_size =
+		    sizeof(uint64_t) + (sizeof(block_id_t) + sizeof(uint32_t)) * multi_use_blocks.size();
+		auto total_size = free_list_size + multi_use_blocks_size;
+		// because of potential alignment issues and needing to store a next pointer in a block we subtract
+		// a bit from the max block size
+		auto space_in_block = Storage::BLOCK_SIZE - 4 * sizeof(block_id_t);
+		auto total_blocks = (total_size + space_in_block - 1) / space_in_block;
+		auto &config = DBConfig::GetConfig(db);
+		if (config.debug_many_free_list_blocks) {
+			total_blocks++;
+		}
+		D_ASSERT(total_size > 0);
+		D_ASSERT(total_blocks > 0);
+
+		// reserve the blocks that we are going to write
+		// since these blocks are no longer free we cannot just include them in the free list!
+		for (idx_t i = 0; i < total_blocks; i++) {
+			auto block_id = GetFreeBlockId();
+			free_list_blocks.push_back(block_id);
+		}
+	}
+
+	return free_list_blocks;
+}
+
+class FreeListBlockWriter : public MetaBlockWriter {
+public:
+	FreeListBlockWriter(DatabaseInstance &db_p, vector<block_id_t> &free_list_blocks_p)
+	    : MetaBlockWriter(db_p, free_list_blocks_p[0]), free_list_blocks(free_list_blocks_p), index(1) {
+	}
+
+	vector<block_id_t> &free_list_blocks;
+	idx_t index;
+
+protected:
+	block_id_t GetNextBlockId() override {
+		if (index >= free_list_blocks.size()) {
+			throw InternalException(
+			    "Free List Block Writer ran out of blocks, this means not enough blocks were allocated up front");
+		}
+		return free_list_blocks[index++];
+	}
+};
+
+void SingleFileBlockManager::WriteHeader(DatabaseHeader header) {
+	// set the iteration count
+	header.iteration = ++iteration_count;
+
+	vector<block_id_t> free_list_blocks = GetFreeListBlocks();
+
+	// now handle the free list
+	// add all modified blocks to the free list: they can now be written to again
+	for (auto &block : modified_blocks) {
+		free_list.insert(block);
+	}
+	modified_blocks.clear();
+
+	if (!free_list_blocks.empty()) {
+		// there are blocks to write, either in the free_list or in the modified_blocks
+		// we write these blocks specifically to the free_list_blocks
+		// a normal MetaBlockWriter will fetch blocks to use from the free_list
+		// but since we are WRITING the free_list, this behavior is sub-optimal
+
+		FreeListBlockWriter writer(db, free_list_blocks);
+
+		D_ASSERT(writer.block->id == free_list_blocks[0]);
+		header.free_list = writer.block->id;
+		for (auto &block_id : free_list_blocks) {
+			modified_blocks.insert(block_id);
+		}
+
+		writer.Write<uint64_t>(free_list.size());
+		for (auto &block_id : free_list) {
+			writer.Write<block_id_t>(block_id);
+		}
+		writer.Write<uint64_t>(multi_use_blocks.size());
+		for (auto &entry : multi_use_blocks) {
+			writer.Write<block_id_t>(entry.first);
+			writer.Write<uint32_t>(entry.second);
+		}
+		writer.Flush();
+	} else {
+		// no blocks in the free list
+		header.free_list = INVALID_BLOCK;
+	}
+	header.block_count = max_block;
+
+	auto &config = DBConfig::GetConfig(db);
+	if (config.checkpoint_abort == CheckpointAbort::DEBUG_ABORT_AFTER_FREE_LIST_WRITE) {
+		throw IOException("Checkpoint aborted after free list write because of PRAGMA checkpoint_abort flag");
+	}
+
+	if (!use_direct_io) {
+		// if we are not using Direct IO we need to fsync BEFORE we write the header to ensure that all the previous
+		// blocks are written as well
+		handle->Sync();
+	}
+	// set the header inside the buffer
+	header_buffer.Clear();
+	Store<DatabaseHeader>(header, header_buffer.buffer);
+	// now write the header to the file, active_header determines whether we write to h1 or h2
+	// note that if active_header is h1 we write to h2, and vice versa
+	header_buffer.ChecksumAndWrite(*handle,
+	                               active_header == 1 ? Storage::FILE_HEADER_SIZE : Storage::FILE_HEADER_SIZE * 2);
+	// switch active header to the other header
+	active_header = 1 - active_header;
+	//! Ensure the header write ends up on disk
+	handle->Sync();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+BaseStatistics::BaseStatistics(LogicalType type, StatisticsType stats_type) : type(move(type)), stats_type(stats_type) {
+}
+
+BaseStatistics::~BaseStatistics() {
+}
+
+void BaseStatistics::InitializeBase() {
+	validity_stats = make_unique<ValidityStatistics>(false);
+	if (stats_type == GLOBAL_STATS) {
+		distinct_stats = make_unique<DistinctStatistics>();
+	}
+}
+
+bool BaseStatistics::CanHaveNull() const {
+	if (!validity_stats) {
+		// we don't know
+		// solid maybe
+		return true;
+	}
+	return ((ValidityStatistics &)*validity_stats).has_null;
+}
+
+bool BaseStatistics::CanHaveNoNull() const {
+	if (!validity_stats) {
+		// we don't know
+		// solid maybe
+		return true;
+	}
+	return ((ValidityStatistics &)*validity_stats).has_no_null;
+}
+
+void BaseStatistics::UpdateDistinctStatistics(Vector &v, idx_t count) {
+	if (!distinct_stats) {
+		return;
+	}
+	auto &d_stats = (DistinctStatistics &)*distinct_stats;
+	d_stats.Update(v, count);
+}
+
+void MergeInternal(unique_ptr<BaseStatistics> &orig, const unique_ptr<BaseStatistics> &other) {
+	if (other) {
+		if (orig) {
+			orig->Merge(*other);
+		} else {
+			orig = other->Copy();
+		}
+	}
+}
+
+void BaseStatistics::Merge(const BaseStatistics &other) {
+	D_ASSERT(type == other.type);
+	MergeInternal(validity_stats, other.validity_stats);
+	if (stats_type == GLOBAL_STATS) {
+		MergeInternal(distinct_stats, other.distinct_stats);
+	}
+}
+
+unique_ptr<BaseStatistics> BaseStatistics::CreateEmpty(LogicalType type, StatisticsType stats_type) {
+	unique_ptr<BaseStatistics> result;
+	switch (type.InternalType()) {
+	case PhysicalType::BIT:
+		return make_unique<ValidityStatistics>(false, false);
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+	case PhysicalType::INT128:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+		result = make_unique<NumericStatistics>(move(type), stats_type);
+		break;
+	case PhysicalType::VARCHAR:
+		result = make_unique<StringStatistics>(move(type), stats_type);
+		break;
+	case PhysicalType::STRUCT:
+		result = make_unique<StructStatistics>(move(type));
+		break;
+	case PhysicalType::LIST:
+		result = make_unique<ListStatistics>(move(type));
+		break;
+	case PhysicalType::INTERVAL:
+	default:
+		result = make_unique<BaseStatistics>(move(type), stats_type);
+	}
+	result->InitializeBase();
+	return result;
+}
+
+unique_ptr<BaseStatistics> BaseStatistics::Copy() const {
+	auto result = make_unique<BaseStatistics>(type, stats_type);
+	result->CopyBase(*this);
+	return result;
+}
+
+void BaseStatistics::CopyBase(const BaseStatistics &orig) {
+	if (orig.validity_stats) {
+		validity_stats = orig.validity_stats->Copy();
+	}
+	if (orig.distinct_stats) {
+		distinct_stats = orig.distinct_stats->Copy();
+	}
+}
+
+void BaseStatistics::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	ValidityStatistics(CanHaveNull(), CanHaveNoNull()).Serialize(writer);
+	Serialize(writer);
+	auto ptype = type.InternalType();
+	if (ptype != PhysicalType::BIT) {
+		writer.WriteField<StatisticsType>(stats_type);
+		writer.WriteOptional<BaseStatistics>(distinct_stats);
+	}
+	writer.Finalize();
+}
+
+void BaseStatistics::Serialize(FieldWriter &writer) const {
+}
+
+unique_ptr<BaseStatistics> BaseStatistics::Deserialize(Deserializer &source, LogicalType type) {
+	FieldReader reader(source);
+	auto validity_stats = ValidityStatistics::Deserialize(reader);
+	unique_ptr<BaseStatistics> result;
+	auto ptype = type.InternalType();
+	switch (ptype) {
+	case PhysicalType::BIT:
+		result = ValidityStatistics::Deserialize(reader);
+		break;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+	case PhysicalType::INT16:
+	case PhysicalType::INT32:
+	case PhysicalType::INT64:
+	case PhysicalType::UINT8:
+	case PhysicalType::UINT16:
+	case PhysicalType::UINT32:
+	case PhysicalType::UINT64:
+	case PhysicalType::INT128:
+	case PhysicalType::FLOAT:
+	case PhysicalType::DOUBLE:
+		result = NumericStatistics::Deserialize(reader, move(type));
+		break;
+	case PhysicalType::VARCHAR:
+		result = StringStatistics::Deserialize(reader, move(type));
+		break;
+	case PhysicalType::STRUCT:
+		result = StructStatistics::Deserialize(reader, move(type));
+		break;
+	case PhysicalType::LIST:
+		result = ListStatistics::Deserialize(reader, move(type));
+		break;
+	case PhysicalType::INTERVAL:
+		result = make_unique<BaseStatistics>(move(type), StatisticsType::LOCAL_STATS);
+		break;
+	default:
+		throw InternalException("Unimplemented type for statistics deserialization");
+	}
+
+	if (ptype != PhysicalType::BIT) {
+		result->validity_stats = move(validity_stats);
+		result->stats_type = reader.ReadField<StatisticsType>(StatisticsType::LOCAL_STATS);
+		result->distinct_stats = reader.ReadOptional<DistinctStatistics>(nullptr);
+	}
+
+	reader.Finalize();
+	return result;
+}
+
+string BaseStatistics::ToString() const {
+	return StringUtil::Format("%s%s", validity_stats ? validity_stats->ToString() : "",
+	                          distinct_stats ? distinct_stats->ToString() : "");
+}
+
+void BaseStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count) const {
+	D_ASSERT(vector.GetType() == this->type);
+	if (validity_stats) {
+		validity_stats->Verify(vector, sel, count);
+	}
+}
+
+void BaseStatistics::Verify(Vector &vector, idx_t count) const {
+	auto sel = FlatVector::IncrementalSelectionVector();
+	Verify(vector, *sel, count);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+ColumnStatistics::ColumnStatistics(unique_ptr<BaseStatistics> stats_p) : stats(move(stats_p)) {
+}
+
+shared_ptr<ColumnStatistics> ColumnStatistics::CreateEmptyStats(const LogicalType &type) {
+	auto col_stats = BaseStatistics::CreateEmpty(type, StatisticsType::GLOBAL_STATS);
+	return make_shared<ColumnStatistics>(move(col_stats));
+}
+
+} // namespace duckdb
+
+
+
+
+
+#include <math.h>
+
+namespace duckdb {
+
+DistinctStatistics::DistinctStatistics()
+    : BaseStatistics(LogicalType::INVALID, StatisticsType::LOCAL_STATS), log(make_unique<HyperLogLog>()),
+      sample_count(0), total_count(0) {
+}
+
+DistinctStatistics::DistinctStatistics(unique_ptr<HyperLogLog> log, idx_t sample_count, idx_t total_count)
+    : BaseStatistics(LogicalType::INVALID, StatisticsType::LOCAL_STATS), log(move(log)), sample_count(sample_count),
+      total_count(total_count) {
+}
+
+unique_ptr<BaseStatistics> DistinctStatistics::Copy() const {
+	return make_unique<DistinctStatistics>(log->Copy(), sample_count, total_count);
+}
+
+void DistinctStatistics::Merge(const BaseStatistics &other_p) {
+	BaseStatistics::Merge(other_p);
+	auto &other = (const DistinctStatistics &)other_p;
+	log->Merge(*other.log);
+	sample_count += other.sample_count;
+	total_count += other.total_count;
+}
+
+void DistinctStatistics::Serialize(Serializer &serializer) const {
+	FieldWriter writer(serializer);
+	Serialize(writer);
+	writer.Finalize();
+}
+
+void DistinctStatistics::Serialize(FieldWriter &writer) const {
+	writer.WriteField<idx_t>(sample_count);
+	writer.WriteField<idx_t>(total_count);
+	log->Serialize(writer);
+}
+
+unique_ptr<DistinctStatistics> DistinctStatistics::Deserialize(Deserializer &source) {
+	FieldReader reader(source);
+	auto result = Deserialize(reader);
+	reader.Finalize();
+	return result;
+}
+
+unique_ptr<DistinctStatistics> DistinctStatistics::Deserialize(FieldReader &reader) {
+	auto sample_count = reader.ReadRequired<idx_t>();
+	auto total_count = reader.ReadRequired<idx_t>();
+	return make_unique<DistinctStatistics>(HyperLogLog::Deserialize(reader), sample_count, total_count);
+}
+
+void DistinctStatistics::Update(Vector &v, idx_t count) {
+	VectorData vdata;
+	v.Orrify(count, vdata);
+	Update(vdata, v.GetType(), count);
+}
+
+void DistinctStatistics::Update(VectorData &vdata, const LogicalType &type, idx_t count) {
+	if (count == 0) {
+		return;
+	}
+	total_count += count;
+	count = MinValue<idx_t>(idx_t(SAMPLE_RATE * MaxValue<idx_t>(STANDARD_VECTOR_SIZE, count)), count);
+	sample_count += count;
+
+	uint64_t indices[STANDARD_VECTOR_SIZE];
+	uint8_t counts[STANDARD_VECTOR_SIZE];
+
+	HyperLogLog::ProcessEntries(vdata, type, indices, counts, count);
+	log->AddToLog(vdata, count, indices, counts);
+}
+
+string DistinctStatistics::ToString() const {
+	return StringUtil::Format("[Approx Unique: %s]", to_string(GetCount()));
+}
+
+idx_t DistinctStatistics::GetCount() const {
+	if (sample_count == 0 || total_count == 0) {
+		return 0;
+	}
+
+	double u = MinValue<idx_t>(log->Count(), sample_count);
+	double s = sample_count;
+	double n = total_count;
+
+	// Assume this proportion of the the sampled values occurred only once
+	double u1 = pow(u / s, 2) * u;
+
+	// Estimate total uniques using Good Turing Estimation
+	idx_t estimate = u + u1 / s * (n - s);
+	return MinValue<idx_t>(estimate, total_count);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+ListStatistics::ListStatistics(LogicalType type_p) : BaseStatistics(move(type_p), StatisticsType::LOCAL_STATS) {
+	D_ASSERT(type.InternalType() == PhysicalType::LIST);
+	InitializeBase();
+	auto &child_type = ListType::GetChildType(type);
+	child_stats = BaseStatistics::CreateEmpty(child_type, StatisticsType::LOCAL_STATS);
+}
+
+void ListStatistics::Merge(const BaseStatistics &other_p) {
+	BaseStatistics::Merge(other_p);
+
+	auto &other = (const ListStatistics &)other_p;
+	if (child_stats && other.child_stats) {
+		child_stats->Merge(*other.child_stats);
+	} else {
+		child_stats.reset();
+	}
+}
+
+// LCOV_EXCL_START
+FilterPropagateResult ListStatistics::CheckZonemap(ExpressionType comparison_type, const Value &constant) const {
+	throw InternalException("List zonemaps are not supported yet");
+}
+// LCOV_EXCL_STOP
+
+unique_ptr<BaseStatistics> ListStatistics::Copy() const {
+	auto result = make_unique<ListStatistics>(type);
+	result->CopyBase(*this);
+
+	result->child_stats = child_stats ? child_stats->Copy() : nullptr;
+	return move(result);
+}
+
+void ListStatistics::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(*child_stats);
+}
+
+unique_ptr<BaseStatistics> ListStatistics::Deserialize(FieldReader &reader, LogicalType type) {
+	D_ASSERT(type.InternalType() == PhysicalType::LIST);
+	auto result = make_unique<ListStatistics>(move(type));
+	auto &child_type = ListType::GetChildType(result->type);
+	result->child_stats = reader.ReadRequiredSerializable<BaseStatistics>(child_type);
+	return move(result);
+}
+
+string ListStatistics::ToString() const {
+	return StringUtil::Format("[%s]%s", child_stats ? child_stats->ToString() : "No Stats", BaseStatistics::ToString());
+}
+
+void ListStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count) const {
+	BaseStatistics::Verify(vector, sel, count);
+
+	if (child_stats) {
+		auto &child_entry = ListVector::GetEntry(vector);
+		VectorData vdata;
+		vector.Orrify(count, vdata);
+
+		auto list_data = (list_entry_t *)vdata.data;
+		idx_t total_list_count = 0;
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+			auto index = vdata.sel->get_index(idx);
+			auto list = list_data[index];
+			if (vdata.validity.RowIsValid(index)) {
+				for (idx_t list_idx = 0; list_idx < list.length; list_idx++) {
+					total_list_count++;
+				}
+			}
+		}
+		SelectionVector list_sel(total_list_count);
+		idx_t list_count = 0;
+		for (idx_t i = 0; i < count; i++) {
+			auto idx = sel.get_index(i);
+			auto index = vdata.sel->get_index(idx);
+			auto list = list_data[index];
+			if (vdata.validity.RowIsValid(index)) {
+				for (idx_t list_idx = 0; list_idx < list.length; list_idx++) {
+					list_sel.set_index(list_count++, list.offset + list_idx);
+				}
+			}
+		}
+
+		child_stats->Verify(child_entry, list_sel, list_count);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+template <>
+void NumericStatistics::Update<interval_t>(SegmentStatistics &stats, interval_t new_value) {
+}
+
+template <>
+void NumericStatistics::Update<list_entry_t>(SegmentStatistics &stats, list_entry_t new_value) {
+}
+
+NumericStatistics::NumericStatistics(LogicalType type_p, StatisticsType stats_type)
+    : BaseStatistics(move(type_p), stats_type) {
+	InitializeBase();
+	min = Value::MaximumValue(type);
+	max = Value::MinimumValue(type);
+}
+
+NumericStatistics::NumericStatistics(LogicalType type_p, Value min_p, Value max_p, StatisticsType stats_type)
+    : BaseStatistics(move(type_p), stats_type), min(move(min_p)), max(move(max_p)) {
+	InitializeBase();
+}
+
+void NumericStatistics::Merge(const BaseStatistics &other_p) {
+	BaseStatistics::Merge(other_p);
+	auto &other = (const NumericStatistics &)other_p;
+	if (other.min.IsNull() || min.IsNull()) {
+		min = Value(type);
+	} else if (other.min < min) {
+		min = other.min;
+	}
+	if (other.max.IsNull() || max.IsNull()) {
+		max = Value(type);
+	} else if (other.max > max) {
+		max = other.max;
+	}
+}
+
+FilterPropagateResult NumericStatistics::CheckZonemap(ExpressionType comparison_type, const Value &constant) const {
+	if (constant.IsNull()) {
+		return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+	}
+	if (min.IsNull() || max.IsNull()) {
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	}
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_EQUAL:
+		if (constant == min && constant == max) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		} else if (constant >= min && constant <= max) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		} else {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+	case ExpressionType::COMPARE_NOTEQUAL:
+		if (constant < min || constant > max) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		} else if (min == max && min == constant) {
+			// corner case of a cluster with one numeric equal to the target constant
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		// X >= C
+		// this can be true only if max(X) >= C
+		// if min(X) >= C, then this is always true
+		if (min >= constant) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		} else if (max >= constant) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		} else {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+	case ExpressionType::COMPARE_GREATERTHAN:
+		// X > C
+		// this can be true only if max(X) > C
+		// if min(X) > C, then this is always true
+		if (min > constant) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		} else if (max > constant) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		} else {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		// X <= C
+		// this can be true only if min(X) <= C
+		// if max(X) <= C, then this is always true
+		if (max <= constant) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		} else if (min <= constant) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		} else {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+	case ExpressionType::COMPARE_LESSTHAN:
+		// X < C
+		// this can be true only if min(X) < C
+		// if max(X) < C, then this is always true
+		if (max < constant) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		} else if (min < constant) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		} else {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+	default:
+		throw InternalException("Expression type in zonemap check not implemented");
+	}
+}
+
+unique_ptr<BaseStatistics> NumericStatistics::Copy() const {
+	auto result = make_unique<NumericStatistics>(type, min, max, stats_type);
+	result->CopyBase(*this);
+	return move(result);
+}
+
+bool NumericStatistics::IsConstant() const {
+	return max <= min;
+}
+
+void NumericStatistics::Serialize(FieldWriter &writer) const {
+	writer.WriteSerializable(min);
+	writer.WriteSerializable(max);
+}
+
+unique_ptr<BaseStatistics> NumericStatistics::Deserialize(FieldReader &reader, LogicalType type) {
+	auto min = reader.ReadRequiredSerializable<Value, Value>();
+	auto max = reader.ReadRequiredSerializable<Value, Value>();
+	return make_unique_base<BaseStatistics, NumericStatistics>(move(type), min, max, StatisticsType::LOCAL_STATS);
+}
+
+string NumericStatistics::ToString() const {
+	return StringUtil::Format("[Min: %s, Max: %s]%s", min.ToString(), max.ToString(), BaseStatistics::ToString());
+}
+
+template <class T>
+void NumericStatistics::TemplatedVerify(Vector &vector, const SelectionVector &sel, idx_t count) const {
+	VectorData vdata;
+	vector.Orrify(count, vdata);
+
+	auto data = (T *)vdata.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto index = vdata.sel->get_index(idx);
+		if (!vdata.validity.RowIsValid(index)) {
+			continue;
+		}
+		if (!min.IsNull() && LessThan::Operation(data[index], min.GetValueUnsafe<T>())) { // LCOV_EXCL_START
+			throw InternalException("Statistics mismatch: value is smaller than min.\nStatistics: %s\nVector: %s",
+			                        ToString(), vector.ToString(count));
+		} // LCOV_EXCL_STOP
+		if (!max.IsNull() && GreaterThan::Operation(data[index], max.GetValueUnsafe<T>())) {
+			throw InternalException("Statistics mismatch: value is bigger than max.\nStatistics: %s\nVector: %s",
+			                        ToString(), vector.ToString(count));
+		}
+	}
+}
+
+void NumericStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count) const {
+	BaseStatistics::Verify(vector, sel, count);
+
+	switch (type.InternalType()) {
+	case PhysicalType::BOOL:
+		break;
+	case PhysicalType::INT8:
+		TemplatedVerify<int8_t>(vector, sel, count);
+		break;
+	case PhysicalType::INT16:
+		TemplatedVerify<int16_t>(vector, sel, count);
+		break;
+	case PhysicalType::INT32:
+		TemplatedVerify<int32_t>(vector, sel, count);
+		break;
+	case PhysicalType::INT64:
+		TemplatedVerify<int64_t>(vector, sel, count);
+		break;
+	case PhysicalType::UINT8:
+		TemplatedVerify<uint8_t>(vector, sel, count);
+		break;
+	case PhysicalType::UINT16:
+		TemplatedVerify<uint16_t>(vector, sel, count);
+		break;
+	case PhysicalType::UINT32:
+		TemplatedVerify<uint32_t>(vector, sel, count);
+		break;
+	case PhysicalType::UINT64:
+		TemplatedVerify<uint64_t>(vector, sel, count);
+		break;
+	case PhysicalType::INT128:
+		TemplatedVerify<hugeint_t>(vector, sel, count);
+		break;
+	case PhysicalType::FLOAT:
+		TemplatedVerify<float>(vector, sel, count);
+		break;
+	case PhysicalType::DOUBLE:
+		TemplatedVerify<double>(vector, sel, count);
+		break;
+	default:
+		throw InternalException("Unsupported type %s for numeric statistics verify", type.ToString());
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+SegmentStatistics::SegmentStatistics(LogicalType type) : type(move(type)) {
+	Reset();
+}
+
+SegmentStatistics::SegmentStatistics(LogicalType type, unique_ptr<BaseStatistics> stats)
+    : type(move(type)), statistics(move(stats)) {
+	if (!statistics) {
+		Reset();
+	}
+}
+
+void SegmentStatistics::Reset() {
+	statistics = BaseStatistics::CreateEmpty(type, StatisticsType::LOCAL_STATS);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+StringStatistics::StringStatistics(LogicalType type_p, StatisticsType stats_type)
+    : BaseStatistics(move(type_p), stats_type) {
+	InitializeBase();
+	for (idx_t i = 0; i < MAX_STRING_MINMAX_SIZE; i++) {
+		min[i] = 0xFF;
+		max[i] = 0;
+	}
+	max_string_length = 0;
+	has_unicode = false;
+	has_overflow_strings = false;
+}
+
+unique_ptr<BaseStatistics> StringStatistics::Copy() const {
+	auto result = make_unique<StringStatistics>(type, stats_type);
+	result->CopyBase(*this);
+
+	memcpy(result->min, min, MAX_STRING_MINMAX_SIZE);
+	memcpy(result->max, max, MAX_STRING_MINMAX_SIZE);
+	result->has_unicode = has_unicode;
+	result->max_string_length = max_string_length;
+	return move(result);
+}
+
+void StringStatistics::Serialize(FieldWriter &writer) const {
+	writer.WriteBlob(min, MAX_STRING_MINMAX_SIZE);
+	writer.WriteBlob(max, MAX_STRING_MINMAX_SIZE);
+	writer.WriteField<bool>(has_unicode);
+	writer.WriteField<uint32_t>(max_string_length);
+	writer.WriteField<bool>(has_overflow_strings);
+}
+
+unique_ptr<BaseStatistics> StringStatistics::Deserialize(FieldReader &reader, LogicalType type) {
+	auto stats = make_unique<StringStatistics>(move(type), StatisticsType::LOCAL_STATS);
+	reader.ReadBlob(stats->min, MAX_STRING_MINMAX_SIZE);
+	reader.ReadBlob(stats->max, MAX_STRING_MINMAX_SIZE);
+	stats->has_unicode = reader.ReadRequired<bool>();
+	stats->max_string_length = reader.ReadRequired<uint32_t>();
+	stats->has_overflow_strings = reader.ReadRequired<bool>();
+	return move(stats);
+}
+
+static int StringValueComparison(const_data_ptr_t data, idx_t len, const_data_ptr_t comparison) {
+	D_ASSERT(len <= StringStatistics::MAX_STRING_MINMAX_SIZE);
+	for (idx_t i = 0; i < len; i++) {
+		if (data[i] < comparison[i]) {
+			return -1;
+		} else if (data[i] > comparison[i]) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+static void ConstructValue(const_data_ptr_t data, idx_t size, data_t target[]) {
+	idx_t value_size =
+	    size > StringStatistics::MAX_STRING_MINMAX_SIZE ? StringStatistics::MAX_STRING_MINMAX_SIZE : size;
+	memcpy(target, data, value_size);
+	for (idx_t i = value_size; i < StringStatistics::MAX_STRING_MINMAX_SIZE; i++) {
+		target[i] = '\0';
+	}
+}
+
+void StringStatistics::Update(const string_t &value) {
+	auto data = (const_data_ptr_t)value.GetDataUnsafe();
+	auto size = value.GetSize();
+
+	//! we can only fit 8 bytes, so we might need to trim our string
+	// construct the value
+	data_t target[MAX_STRING_MINMAX_SIZE];
+	ConstructValue(data, size, target);
+
+	// update the min and max
+	if (StringValueComparison(target, MAX_STRING_MINMAX_SIZE, min) < 0) {
+		memcpy(min, target, MAX_STRING_MINMAX_SIZE);
+	}
+	if (StringValueComparison(target, MAX_STRING_MINMAX_SIZE, max) > 0) {
+		memcpy(max, target, MAX_STRING_MINMAX_SIZE);
+	}
+	if (size > max_string_length) {
+		max_string_length = size;
+	}
+	if (type.id() == LogicalTypeId::VARCHAR && !has_unicode) {
+		auto unicode = Utf8Proc::Analyze((const char *)data, size);
+		if (unicode == UnicodeType::UNICODE) {
+			has_unicode = true;
+		} else if (unicode == UnicodeType::INVALID) {
+			throw InternalException("Invalid unicode detected in segment statistics update!");
+		}
+	}
+}
+
+void StringStatistics::Merge(const BaseStatistics &other_p) {
+	BaseStatistics::Merge(other_p);
+	auto &other = (const StringStatistics &)other_p;
+	if (StringValueComparison(other.min, MAX_STRING_MINMAX_SIZE, min) < 0) {
+		memcpy(min, other.min, MAX_STRING_MINMAX_SIZE);
+	}
+	if (StringValueComparison(other.max, MAX_STRING_MINMAX_SIZE, max) > 0) {
+		memcpy(max, other.max, MAX_STRING_MINMAX_SIZE);
+	}
+	has_unicode = has_unicode || other.has_unicode;
+	max_string_length = MaxValue<uint32_t>(max_string_length, other.max_string_length);
+	has_overflow_strings = has_overflow_strings || other.has_overflow_strings;
+}
+
+FilterPropagateResult StringStatistics::CheckZonemap(ExpressionType comparison_type, const string &constant) const {
+	auto data = (const_data_ptr_t)constant.c_str();
+	auto size = constant.size();
+
+	idx_t value_size = size > MAX_STRING_MINMAX_SIZE ? MAX_STRING_MINMAX_SIZE : size;
+	int min_comp = StringValueComparison(data, value_size, min);
+	int max_comp = StringValueComparison(data, value_size, max);
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_EQUAL:
+		if (min_comp >= 0 && max_comp <= 0) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		} else {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+	case ExpressionType::COMPARE_NOTEQUAL:
+		if (min_comp < 0 || max_comp > 0) {
+			return FilterPropagateResult::FILTER_ALWAYS_TRUE;
+		}
+		return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+	case ExpressionType::COMPARE_GREATERTHAN:
+		if (max_comp <= 0) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		} else {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+	case ExpressionType::COMPARE_LESSTHAN:
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		if (min_comp >= 0) {
+			return FilterPropagateResult::NO_PRUNING_POSSIBLE;
+		} else {
+			return FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		}
+	default:
+		throw InternalException("Expression type not implemented for string statistics zone map");
+	}
+}
+
+static idx_t GetValidMinMaxSubstring(const_data_ptr_t data) {
+	for (idx_t i = 0; i < StringStatistics::MAX_STRING_MINMAX_SIZE; i++) {
+		if (data[i] == '\0') {
+			return i;
+		}
+		if ((data[i] & 0x80) != 0) {
+			return i;
+		}
+	}
+	return StringStatistics::MAX_STRING_MINMAX_SIZE;
+}
+
+string StringStatistics::ToString() const {
+	idx_t min_len = GetValidMinMaxSubstring(min);
+	idx_t max_len = GetValidMinMaxSubstring(max);
+	return StringUtil::Format("[Min: %s, Max: %s, Has Unicode: %s, Max String Length: %lld]%s",
+	                          string((const char *)min, min_len), string((const char *)max, max_len),
+	                          has_unicode ? "true" : "false", max_string_length, BaseStatistics::ToString());
+}
+
+void StringStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count) const {
+	BaseStatistics::Verify(vector, sel, count);
+
+	string_t min_string((const char *)min, MAX_STRING_MINMAX_SIZE);
+	string_t max_string((const char *)max, MAX_STRING_MINMAX_SIZE);
+
+	VectorData vdata;
+	vector.Orrify(count, vdata);
+	auto data = (string_t *)vdata.data;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto index = vdata.sel->get_index(idx);
+		if (!vdata.validity.RowIsValid(index)) {
+			continue;
+		}
+		auto value = data[index];
+		auto data = value.GetDataUnsafe();
+		auto len = value.GetSize();
+		// LCOV_EXCL_START
+		if (len > max_string_length) {
+			throw InternalException(
+			    "Statistics mismatch: string value exceeds maximum string length.\nStatistics: %s\nVector: %s",
+			    ToString(), vector.ToString(count));
+		}
+		if (type.id() == LogicalTypeId::VARCHAR && !has_unicode) {
+			auto unicode = Utf8Proc::Analyze(data, len);
+			if (unicode == UnicodeType::UNICODE) {
+				throw InternalException("Statistics mismatch: string value contains unicode, but statistics says it "
+				                        "shouldn't.\nStatistics: %s\nVector: %s",
+				                        ToString(), vector.ToString(count));
+			} else if (unicode == UnicodeType::INVALID) {
+				throw InternalException("Invalid unicode detected in vector: %s", vector.ToString(count));
+			}
+		}
+		if (StringValueComparison((const_data_ptr_t)data, MinValue<idx_t>(len, MAX_STRING_MINMAX_SIZE), min) < 0) {
+			throw InternalException("Statistics mismatch: value is smaller than min.\nStatistics: %s\nVector: %s",
+			                        ToString(), vector.ToString(count));
+		}
+		if (StringValueComparison((const_data_ptr_t)data, MinValue<idx_t>(len, MAX_STRING_MINMAX_SIZE), max) > 0) {
+			throw InternalException("Statistics mismatch: value is bigger than max.\nStatistics: %s\nVector: %s",
+			                        ToString(), vector.ToString(count));
+		}
+		// LCOV_EXCL_STOP
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+StructStatistics::StructStatistics(LogicalType type_p) : BaseStatistics(move(type_p), StatisticsType::LOCAL_STATS) {
+	D_ASSERT(type.InternalType() == PhysicalType::STRUCT);
+	InitializeBase();
+
+	auto &child_types = StructType::GetChildTypes(type);
+	child_stats.resize(child_types.size());
+	for (idx_t i = 0; i < child_types.size(); i++) {
+		child_stats[i] = BaseStatistics::CreateEmpty(child_types[i].second, StatisticsType::LOCAL_STATS);
+	}
+}
+
+void StructStatistics::Merge(const BaseStatistics &other_p) {
+	BaseStatistics::Merge(other_p);
+
+	auto &other = (const StructStatistics &)other_p;
+	D_ASSERT(other.child_stats.size() == child_stats.size());
+	for (idx_t i = 0; i < child_stats.size(); i++) {
+		if (child_stats[i] && other.child_stats[i]) {
+			child_stats[i]->Merge(*other.child_stats[i]);
+		} else {
+			child_stats[i].reset();
+		}
+	}
+}
+
+// LCOV_EXCL_START
+FilterPropagateResult StructStatistics::CheckZonemap(ExpressionType comparison_type, const Value &constant) const {
+	throw InternalException("Struct zonemaps are not supported yet");
+}
+// LCOV_EXCL_STOP
+
+unique_ptr<BaseStatistics> StructStatistics::Copy() const {
+	auto result = make_unique<StructStatistics>(type);
+	result->CopyBase(*this);
+
+	for (idx_t i = 0; i < child_stats.size(); i++) {
+		result->child_stats[i] = child_stats[i] ? child_stats[i]->Copy() : nullptr;
+	}
+	return move(result);
+}
+
+void StructStatistics::Serialize(FieldWriter &writer) const {
+	writer.WriteField<uint32_t>(child_stats.size());
+	auto &serializer = writer.GetSerializer();
+	for (idx_t i = 0; i < child_stats.size(); i++) {
+		serializer.Write<bool>(child_stats[i] ? true : false);
+		if (child_stats[i]) {
+			child_stats[i]->Serialize(serializer);
+		}
+	}
+}
+
+unique_ptr<BaseStatistics> StructStatistics::Deserialize(FieldReader &reader, LogicalType type) {
+	D_ASSERT(type.InternalType() == PhysicalType::STRUCT);
+	auto result = make_unique<StructStatistics>(move(type));
+	auto &child_types = StructType::GetChildTypes(result->type);
+
+	auto child_type_count = reader.ReadRequired<uint32_t>();
+	if (child_types.size() != child_type_count) {
+		throw InternalException("Struct stats deserialization failure: child count does not match type count!");
+	}
+	auto &source = reader.GetSource();
+	for (idx_t i = 0; i < child_types.size(); i++) {
+		auto has_child = source.Read<bool>();
+		if (has_child) {
+			result->child_stats[i] = BaseStatistics::Deserialize(source, child_types[i].second);
+		} else {
+			result->child_stats[i].reset();
+		}
+	}
+	return move(result);
+}
+
+string StructStatistics::ToString() const {
+	string result;
+	result += " {";
+	auto &child_types = StructType::GetChildTypes(type);
+	for (idx_t i = 0; i < child_types.size(); i++) {
+		if (i > 0) {
+			result += ", ";
+		}
+		result += child_types[i].first + ": " + (child_stats[i] ? child_stats[i]->ToString() : "No Stats");
+	}
+	result += "}";
+	result += BaseStatistics::ToString();
+	return result;
+}
+
+void StructStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count) const {
+	BaseStatistics::Verify(vector, sel, count);
+
+	auto &child_entries = StructVector::GetEntries(vector);
+	for (idx_t i = 0; i < child_entries.size(); i++) {
+		if (child_stats[i]) {
+			child_stats[i]->Verify(*child_entries[i], sel, count);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+ValidityStatistics::ValidityStatistics(bool has_null, bool has_no_null)
+    : BaseStatistics(LogicalType(LogicalTypeId::VALIDITY), StatisticsType::LOCAL_STATS), has_null(has_null),
+      has_no_null(has_no_null) {
+}
+
+unique_ptr<BaseStatistics> ValidityStatistics::Combine(const unique_ptr<BaseStatistics> &lstats,
+                                                       const unique_ptr<BaseStatistics> &rstats) {
+	if (!lstats && !rstats) {
+		return nullptr;
+	} else if (!lstats) {
+		return rstats->Copy();
+	} else if (!rstats) {
+		return lstats->Copy();
+	} else {
+		auto &l = (ValidityStatistics &)*lstats;
+		auto &r = (ValidityStatistics &)*rstats;
+		return make_unique<ValidityStatistics>(l.has_null || r.has_null, l.has_no_null || r.has_no_null);
+	}
+}
+
+bool ValidityStatistics::IsConstant() const {
+	if (!has_null) {
+		return true;
+	}
+	if (!has_no_null) {
+		return true;
+	}
+	return false;
+}
+
+void ValidityStatistics::Merge(const BaseStatistics &other_p) {
+	auto &other = (ValidityStatistics &)other_p;
+	has_null = has_null || other.has_null;
+	has_no_null = has_no_null || other.has_no_null;
+}
+
+unique_ptr<BaseStatistics> ValidityStatistics::Copy() const {
+	return make_unique<ValidityStatistics>(has_null, has_no_null);
+}
+
+void ValidityStatistics::Serialize(FieldWriter &writer) const {
+	writer.WriteField<bool>(has_null);
+	writer.WriteField<bool>(has_no_null);
+}
+
+unique_ptr<ValidityStatistics> ValidityStatistics::Deserialize(FieldReader &reader) {
+	bool has_null = reader.ReadRequired<bool>();
+	bool has_no_null = reader.ReadRequired<bool>();
+	return make_unique<ValidityStatistics>(has_null, has_no_null);
+}
+
+void ValidityStatistics::Verify(Vector &vector, const SelectionVector &sel, idx_t count) const {
+	if (has_null && has_no_null) {
+		// nothing to verify
+		return;
+	}
+	VectorData vdata;
+	vector.Orrify(count, vdata);
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto index = vdata.sel->get_index(idx);
+		bool row_is_valid = vdata.validity.RowIsValid(index);
+		if (row_is_valid && !has_no_null) {
+			throw InternalException(
+			    "Statistics mismatch: vector labeled as having only NULL values, but vector contains valid values: %s",
+			    vector.ToString(count));
+		}
+		if (!row_is_valid && !has_null) {
+			throw InternalException(
+			    "Statistics mismatch: vector labeled as not having NULL values, but vector contains null values: %s",
+			    vector.ToString(count));
+		}
+	}
+}
+
+string ValidityStatistics::ToString() const {
+	auto has_n = has_null ? "true" : "false";
+	auto has_n_n = has_no_null ? "true" : "false";
+	return StringUtil::Format("[Has Null: %s, Has No Null: %s]", has_n, has_n_n);
+}
+
+} // namespace duckdb
+
+
+namespace duckdb {
+
+const uint64_t VERSION_NUMBER = 35;
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+StorageLockKey::StorageLockKey(StorageLock &lock, StorageLockType type) : lock(lock), type(type) {
+}
+
+StorageLockKey::~StorageLockKey() {
+	if (type == StorageLockType::EXCLUSIVE) {
+		lock.ReleaseExclusiveLock();
+	} else {
+		D_ASSERT(type == StorageLockType::SHARED);
+		lock.ReleaseSharedLock();
+	}
+}
+
+StorageLock::StorageLock() : read_count(0) {
+}
+
+unique_ptr<StorageLockKey> StorageLock::GetExclusiveLock() {
+	exclusive_lock.lock();
+	while (read_count != 0) {
+	}
+	return make_unique<StorageLockKey>(*this, StorageLockType::EXCLUSIVE);
+}
+
+unique_ptr<StorageLockKey> StorageLock::GetSharedLock() {
+	exclusive_lock.lock();
+	read_count++;
+	exclusive_lock.unlock();
+	return make_unique<StorageLockKey>(*this, StorageLockType::SHARED);
+}
+
+void StorageLock::ReleaseExclusiveLock() {
+	exclusive_lock.unlock();
+}
+
+void StorageLock::ReleaseSharedLock() {
+	read_count--;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+StorageManager::StorageManager(DatabaseInstance &db, string path, bool read_only)
+    : db(db), path(move(path)), wal(db), read_only(read_only) {
+}
+
+StorageManager::~StorageManager() {
+}
+
+StorageManager &StorageManager::GetStorageManager(ClientContext &context) {
+	return StorageManager::GetStorageManager(*context.db);
+}
+
+BufferManager &BufferManager::GetBufferManager(ClientContext &context) {
+	return BufferManager::GetBufferManager(*context.db);
+}
+
+ObjectCache &ObjectCache::GetObjectCache(ClientContext &context) {
+	return context.db->GetObjectCache();
+}
+
+bool ObjectCache::ObjectCacheEnabled(ClientContext &context) {
+	return context.db->config.object_cache_enable;
+}
+
+bool StorageManager::InMemory() {
+	return path.empty() || path == ":memory:";
+}
+
+void StorageManager::Initialize() {
+	bool in_memory = InMemory();
+	if (in_memory && read_only) {
+		throw CatalogException("Cannot launch in-memory database in read-only mode!");
+	}
+
+	// first initialize the base system catalogs
+	// these are never written to the WAL
+	Connection con(db);
+	con.BeginTransaction();
+
+	auto &config = DBConfig::GetConfig(db);
+	auto &catalog = Catalog::GetCatalog(*con.context);
+
+	// create the default schema
+	CreateSchemaInfo info;
+	info.schema = DEFAULT_SCHEMA;
+	info.internal = true;
+	catalog.CreateSchema(*con.context, &info);
+
+	if (config.initialize_default_database) {
+		// initialize default functions
+		BuiltinFunctions builtin(*con.context, catalog);
+		builtin.Initialize();
+	}
+
+	// commit transactions
+	con.Commit();
+
+	if (!in_memory) {
+		// create or load the database from disk, if not in-memory mode
+		LoadDatabase();
+	} else {
+		block_manager = make_unique<InMemoryBlockManager>();
+		buffer_manager = make_unique<BufferManager>(db, config.temporary_directory, config.maximum_memory);
+	}
+}
+
+void StorageManager::LoadDatabase() {
+	string wal_path = path + ".wal";
+	auto &fs = db.GetFileSystem();
+	auto &config = db.config;
+	bool truncate_wal = false;
+	// first check if the database exists
+	if (!fs.FileExists(path)) {
+		if (read_only) {
+			throw CatalogException("Cannot open database \"%s\" in read-only mode: database does not exist", path);
+		}
+		// check if the WAL exists
+		if (fs.FileExists(wal_path)) {
+			// WAL file exists but database file does not
+			// remove the WAL
+			fs.RemoveFile(wal_path);
+		}
+		// initialize the block manager while creating a new db file
+		block_manager = make_unique<SingleFileBlockManager>(db, path, read_only, true, config.use_direct_io);
+		buffer_manager = make_unique<BufferManager>(db, config.temporary_directory, config.maximum_memory);
+	} else {
+		// initialize the block manager while loading the current db file
+		auto sf_bm = make_unique<SingleFileBlockManager>(db, path, read_only, false, config.use_direct_io);
+		auto sf = sf_bm.get();
+		block_manager = move(sf_bm);
+		buffer_manager = make_unique<BufferManager>(db, config.temporary_directory, config.maximum_memory);
+		sf->LoadFreeList();
+
+		//! Load from storage
+		CheckpointManager checkpointer(db);
+		checkpointer.LoadFromStorage();
+		// check if the WAL file exists
+		if (fs.FileExists(wal_path)) {
+			// replay the WAL
+			truncate_wal = WriteAheadLog::Replay(db, wal_path);
+		}
+	}
+	// initialize the WAL file
+	if (!read_only) {
+		wal.Initialize(wal_path);
+		if (truncate_wal) {
+			wal.Truncate(0);
+		}
+	}
+}
+
+void StorageManager::CreateCheckpoint(bool delete_wal, bool force_checkpoint) {
+	if (InMemory() || read_only || !wal.initialized) {
+		return;
+	}
+	if (wal.GetWALSize() > 0 || db.config.force_checkpoint || force_checkpoint) {
+		// we only need to checkpoint if there is anything in the WAL
+		CheckpointManager checkpointer(db);
+		checkpointer.CreateCheckpoint();
+	}
+	if (delete_wal) {
+		wal.Delete();
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+struct TransactionVersionOperator {
+	static bool UseInsertedVersion(transaction_t start_time, transaction_t transaction_id, transaction_t id) {
+		return id < start_time || id == transaction_id;
+	}
+
+	static bool UseDeletedVersion(transaction_t start_time, transaction_t transaction_id, transaction_t id) {
+		return !UseInsertedVersion(start_time, transaction_id, id);
+	}
+};
+
+struct CommittedVersionOperator {
+	static bool UseInsertedVersion(transaction_t start_time, transaction_t transaction_id, transaction_t id) {
+		return true;
+	}
+
+	static bool UseDeletedVersion(transaction_t min_start_time, transaction_t min_transaction_id, transaction_t id) {
+		return (id >= min_start_time && id < TRANSACTION_ID_START) || (id >= min_transaction_id);
+	}
+};
+
+static bool UseVersion(Transaction &transaction, transaction_t id) {
+	return TransactionVersionOperator::UseInsertedVersion(transaction.start_time, transaction.transaction_id, id);
+}
+
+unique_ptr<ChunkInfo> ChunkInfo::Deserialize(Deserializer &source) {
+	auto type = source.Read<ChunkInfoType>();
+	switch (type) {
+	case ChunkInfoType::EMPTY_INFO:
+		return nullptr;
+	case ChunkInfoType::CONSTANT_INFO:
+		return ChunkConstantInfo::Deserialize(source);
+	case ChunkInfoType::VECTOR_INFO:
+		return ChunkVectorInfo::Deserialize(source);
+	default:
+		throw SerializationException("Could not deserialize Chunk Info Type: unrecognized type");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Constant info
+//===--------------------------------------------------------------------===//
+ChunkConstantInfo::ChunkConstantInfo(idx_t start)
+    : ChunkInfo(start, ChunkInfoType::CONSTANT_INFO), insert_id(0), delete_id(NOT_DELETED_ID) {
+}
+
+template <class OP>
+idx_t ChunkConstantInfo::TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id,
+                                               SelectionVector &sel_vector, idx_t max_count) {
+	if (OP::UseInsertedVersion(start_time, transaction_id, insert_id) &&
+	    OP::UseDeletedVersion(start_time, transaction_id, delete_id)) {
+		return max_count;
+	}
+	return 0;
+}
+
+idx_t ChunkConstantInfo::GetSelVector(Transaction &transaction, SelectionVector &sel_vector, idx_t max_count) {
+	return TemplatedGetSelVector<TransactionVersionOperator>(transaction.start_time, transaction.transaction_id,
+	                                                         sel_vector, max_count);
+}
+
+idx_t ChunkConstantInfo::GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
+                                               SelectionVector &sel_vector, idx_t max_count) {
+	return TemplatedGetSelVector<CommittedVersionOperator>(min_start_id, min_transaction_id, sel_vector, max_count);
+}
+
+bool ChunkConstantInfo::Fetch(Transaction &transaction, row_t row) {
+	return UseVersion(transaction, insert_id) && !UseVersion(transaction, delete_id);
+}
+
+void ChunkConstantInfo::CommitAppend(transaction_t commit_id, idx_t start, idx_t end) {
+	D_ASSERT(start == 0 && end == STANDARD_VECTOR_SIZE);
+	insert_id = commit_id;
+}
+
+void ChunkConstantInfo::Serialize(Serializer &serializer) {
+	// we only need to write this node if any tuple deletions have been committed
+	bool is_deleted = insert_id >= TRANSACTION_ID_START || delete_id < TRANSACTION_ID_START;
+	if (!is_deleted) {
+		serializer.Write<ChunkInfoType>(ChunkInfoType::EMPTY_INFO);
+		return;
+	}
+	serializer.Write<ChunkInfoType>(type);
+	serializer.Write<idx_t>(start);
+}
+
+unique_ptr<ChunkInfo> ChunkConstantInfo::Deserialize(Deserializer &source) {
+	auto start = source.Read<idx_t>();
+
+	auto info = make_unique<ChunkConstantInfo>(start);
+	info->insert_id = 0;
+	info->delete_id = 0;
+	return move(info);
+}
+
+//===--------------------------------------------------------------------===//
+// Vector info
+//===--------------------------------------------------------------------===//
+ChunkVectorInfo::ChunkVectorInfo(idx_t start)
+    : ChunkInfo(start, ChunkInfoType::VECTOR_INFO), insert_id(0), same_inserted_id(true), any_deleted(false) {
+	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+		inserted[i] = 0;
+		deleted[i] = NOT_DELETED_ID;
+	}
+}
+
+template <class OP>
+idx_t ChunkVectorInfo::TemplatedGetSelVector(transaction_t start_time, transaction_t transaction_id,
+                                             SelectionVector &sel_vector, idx_t max_count) {
+	idx_t count = 0;
+	if (same_inserted_id && !any_deleted) {
+		// all tuples have the same inserted id: and no tuples were deleted
+		if (OP::UseInsertedVersion(start_time, transaction_id, insert_id)) {
+			return max_count;
+		} else {
+			return 0;
+		}
+	} else if (same_inserted_id) {
+		if (!OP::UseInsertedVersion(start_time, transaction_id, insert_id)) {
+			return 0;
+		}
+		// have to check deleted flag
+		for (idx_t i = 0; i < max_count; i++) {
+			if (OP::UseDeletedVersion(start_time, transaction_id, deleted[i])) {
+				sel_vector.set_index(count++, i);
+			}
+		}
+	} else if (!any_deleted) {
+		// have to check inserted flag
+		for (idx_t i = 0; i < max_count; i++) {
+			if (OP::UseInsertedVersion(start_time, transaction_id, inserted[i])) {
+				sel_vector.set_index(count++, i);
+			}
+		}
+	} else {
+		// have to check both flags
+		for (idx_t i = 0; i < max_count; i++) {
+			if (OP::UseInsertedVersion(start_time, transaction_id, inserted[i]) &&
+			    OP::UseDeletedVersion(start_time, transaction_id, deleted[i])) {
+				sel_vector.set_index(count++, i);
+			}
+		}
+	}
+	return count;
+}
+
+idx_t ChunkVectorInfo::GetSelVector(transaction_t start_time, transaction_t transaction_id, SelectionVector &sel_vector,
+                                    idx_t max_count) {
+	return TemplatedGetSelVector<TransactionVersionOperator>(start_time, transaction_id, sel_vector, max_count);
+}
+
+idx_t ChunkVectorInfo::GetCommittedSelVector(transaction_t min_start_id, transaction_t min_transaction_id,
+                                             SelectionVector &sel_vector, idx_t max_count) {
+	return TemplatedGetSelVector<CommittedVersionOperator>(min_start_id, min_transaction_id, sel_vector, max_count);
+}
+
+idx_t ChunkVectorInfo::GetSelVector(Transaction &transaction, SelectionVector &sel_vector, idx_t max_count) {
+	return GetSelVector(transaction.start_time, transaction.transaction_id, sel_vector, max_count);
+}
+
+bool ChunkVectorInfo::Fetch(Transaction &transaction, row_t row) {
+	return UseVersion(transaction, inserted[row]) && !UseVersion(transaction, deleted[row]);
+}
+
+idx_t ChunkVectorInfo::Delete(Transaction &transaction, row_t rows[], idx_t count) {
+	any_deleted = true;
+
+	idx_t deleted_tuples = 0;
+	for (idx_t i = 0; i < count; i++) {
+		if (deleted[rows[i]] == transaction.transaction_id) {
+			continue;
+		}
+		// first check the chunk for conflicts
+		if (deleted[rows[i]] != NOT_DELETED_ID) {
+			// tuple was already deleted by another transaction
+			throw TransactionException("Conflict on tuple deletion!");
+		}
+		if (inserted[rows[i]] >= TRANSACTION_ID_START) {
+			throw TransactionException("Deleting non-committed tuples is not supported (for now...)");
+		}
+		// after verifying that there are no conflicts we mark the tuple as deleted
+		deleted[rows[i]] = transaction.transaction_id;
+		deleted_tuples++;
+	}
+	return deleted_tuples;
+}
+
+void ChunkVectorInfo::CommitDelete(transaction_t commit_id, row_t rows[], idx_t count) {
+	for (idx_t i = 0; i < count; i++) {
+		deleted[rows[i]] = commit_id;
+	}
+}
+
+void ChunkVectorInfo::Append(idx_t start, idx_t end, transaction_t commit_id) {
+	if (start == 0) {
+		insert_id = commit_id;
+	} else if (insert_id != commit_id) {
+		same_inserted_id = false;
+		insert_id = NOT_DELETED_ID;
+	}
+	for (idx_t i = start; i < end; i++) {
+		inserted[i] = commit_id;
+	}
+}
+
+void ChunkVectorInfo::CommitAppend(transaction_t commit_id, idx_t start, idx_t end) {
+	if (same_inserted_id) {
+		insert_id = commit_id;
+	}
+	for (idx_t i = start; i < end; i++) {
+		inserted[i] = commit_id;
+	}
+}
+
+void ChunkVectorInfo::Serialize(Serializer &serializer) {
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	transaction_t start_time = TRANSACTION_ID_START - 1;
+	transaction_t transaction_id = DConstants::INVALID_INDEX;
+	idx_t count = GetSelVector(start_time, transaction_id, sel, STANDARD_VECTOR_SIZE);
+	if (count == STANDARD_VECTOR_SIZE) {
+		// nothing is deleted: skip writing anything
+		serializer.Write<ChunkInfoType>(ChunkInfoType::EMPTY_INFO);
+		return;
+	}
+	if (count == 0) {
+		// everything is deleted: write a constant vector
+		serializer.Write<ChunkInfoType>(ChunkInfoType::CONSTANT_INFO);
+		serializer.Write<idx_t>(start);
+		return;
+	}
+	// write a boolean vector
+	serializer.Write<ChunkInfoType>(ChunkInfoType::VECTOR_INFO);
+	serializer.Write<idx_t>(start);
+	bool deleted_tuples[STANDARD_VECTOR_SIZE];
+	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+		deleted_tuples[i] = true;
+	}
+	for (idx_t i = 0; i < count; i++) {
+		deleted_tuples[sel.get_index(i)] = false;
+	}
+	serializer.WriteData((data_ptr_t)deleted_tuples, sizeof(bool) * STANDARD_VECTOR_SIZE);
+}
+
+unique_ptr<ChunkInfo> ChunkVectorInfo::Deserialize(Deserializer &source) {
+	auto start = source.Read<idx_t>();
+
+	auto result = make_unique<ChunkVectorInfo>(start);
+	result->any_deleted = true;
+	bool deleted_tuples[STANDARD_VECTOR_SIZE];
+	source.ReadData((data_ptr_t)deleted_tuples, sizeof(bool) * STANDARD_VECTOR_SIZE);
+	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+		if (deleted_tuples[i]) {
+			result->deleted[i] = 0;
+		}
+	}
+	return move(result);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+ColumnCheckpointState::ColumnCheckpointState(RowGroup &row_group, ColumnData &column_data, TableDataWriter &writer)
+    : row_group(row_group), column_data(column_data), writer(writer) {
+}
+
+ColumnCheckpointState::~ColumnCheckpointState() {
+}
+
+void ColumnCheckpointState::FlushSegment(unique_ptr<ColumnSegment> segment, idx_t segment_size) {
+	D_ASSERT(segment_size <= Storage::BLOCK_SIZE);
+	auto tuple_count = segment->count.load();
+	if (tuple_count == 0) { // LCOV_EXCL_START
+		return;
+	} // LCOV_EXCL_STOP
+
+	// merge the segment stats into the global stats
+	global_stats->Merge(*segment->stats.statistics);
+
+	// get the buffer of the segment and pin it
+	auto &db = column_data.GetDatabase();
+	auto &buffer_manager = BufferManager::GetBufferManager(db);
+	auto &block_manager = BlockManager::GetBlockManager(db);
+	auto &checkpoint_manager = writer.GetCheckpointManager();
+
+	bool block_is_constant = segment->stats.statistics->IsConstant();
+
+	block_id_t block_id = INVALID_BLOCK;
+	uint32_t offset_in_block = 0;
+	bool need_to_write = true;
+	PartialBlock *partial_block = nullptr;
+	unique_ptr<PartialBlock> owned_partial_block;
+	if (!block_is_constant) {
+		// non-constant block
+		// if the block is less than 80% full, we consider it a "partial block"
+		// which means we will try to fit it with other blocks
+		if (segment_size <= CheckpointManager::PARTIAL_BLOCK_THRESHOLD) {
+			// the block is a partial block
+			// check if there is a partial block available we can write to
+			if (checkpoint_manager.GetPartialBlock(segment.get(), segment_size, block_id, offset_in_block,
+			                                       partial_block, owned_partial_block)) {
+				//! there is! increase the reference count of this block
+				block_manager.IncreaseBlockReferenceCount(block_id);
+			} else {
+				// there isn't: generate a new block for this segment
+				block_id = block_manager.GetFreeBlockId();
+				offset_in_block = 0;
+				need_to_write = false;
+				// now register this block as a partial block
+				checkpoint_manager.RegisterPartialBlock(segment.get(), segment_size, block_id);
+			}
+		} else {
+			// full block: get a free block to write to
+			block_id = block_manager.GetFreeBlockId();
+			offset_in_block = 0;
+		}
+	} else {
+		// constant block: no need to write anything to disk besides the stats
+		// set up the compression function to constant
+		auto &config = DBConfig::GetConfig(db);
+		segment->function =
+		    config.GetCompressionFunction(CompressionType::COMPRESSION_CONSTANT, segment->type.InternalType());
+	}
+
+	// construct the data pointer
+	DataPointer data_pointer;
+	data_pointer.block_pointer.block_id = block_id;
+	data_pointer.block_pointer.offset = offset_in_block;
+	data_pointer.row_start = row_group.start;
+	if (!data_pointers.empty()) {
+		auto &last_pointer = data_pointers.back();
+		data_pointer.row_start = last_pointer.row_start + last_pointer.tuple_count;
+	}
+	data_pointer.tuple_count = tuple_count;
+	data_pointer.compression_type = segment->function->type;
+	data_pointer.statistics = segment->stats.statistics->Copy();
+
+	if (need_to_write) {
+		if (partial_block) {
+			// pin the current block
+			auto old_handle = buffer_manager.Pin(segment->block);
+			// pin the new block
+			auto new_handle = buffer_manager.Pin(partial_block->block);
+			// memcpy the contents of the old block to the new block
+			memcpy(new_handle->Ptr() + offset_in_block, old_handle->Ptr(), segment_size);
+		} else {
+			// convert the segment into a persistent segment that points to this block
+			segment->ConvertToPersistent(block_id);
+		}
+	}
+	if (owned_partial_block) {
+		// the partial block has become full: write it to disk
+		owned_partial_block->FlushToDisk(db);
+	}
+
+	// append the segment to the new segment tree
+	new_tree.AppendSegment(move(segment));
+	data_pointers.push_back(move(data_pointer));
+}
+
+void ColumnCheckpointState::FlushToDisk() {
+	auto &meta_writer = writer.GetMetaWriter();
+
+	meta_writer.Write<idx_t>(data_pointers.size());
+	// then write the data pointers themselves
+	for (idx_t k = 0; k < data_pointers.size(); k++) {
+		auto &data_pointer = data_pointers[k];
+		meta_writer.Write<idx_t>(data_pointer.row_start);
+		meta_writer.Write<idx_t>(data_pointer.tuple_count);
+		meta_writer.Write<block_id_t>(data_pointer.block_pointer.block_id);
+		meta_writer.Write<uint32_t>(data_pointer.block_pointer.offset);
+		meta_writer.Write<CompressionType>(data_pointer.compression_type);
+		data_pointer.statistics->Serialize(meta_writer);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+ColumnData::ColumnData(DataTableInfo &info, idx_t column_index, idx_t start_row, LogicalType type, ColumnData *parent)
+    : info(info), column_index(column_index), start(start_row), type(move(type)), parent(parent) {
+}
+
+ColumnData::~ColumnData() {
+}
+
+DatabaseInstance &ColumnData::GetDatabase() const {
+	return info.db;
+}
+
+DataTableInfo &ColumnData::GetTableInfo() const {
+	return info;
+}
+
+const LogicalType &ColumnData::RootType() const {
+	if (parent) {
+		return parent->RootType();
+	}
+	return type;
+}
+
+idx_t ColumnData::GetMaxEntry() {
+	auto last_segment = data.GetLastSegment();
+	return last_segment ? last_segment->start + last_segment->count : start;
+}
+
+void ColumnData::InitializeScan(ColumnScanState &state) {
+	state.current = (ColumnSegment *)data.GetRootSegment();
+	state.row_index = state.current ? state.current->start : 0;
+	state.internal_index = state.row_index;
+	state.initialized = false;
+}
+
+void ColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) {
+	state.current = (ColumnSegment *)data.GetSegment(row_idx);
+	state.row_index = row_idx;
+	state.internal_index = state.current->start;
+	state.initialized = false;
+}
+
+idx_t ColumnData::ScanVector(ColumnScanState &state, Vector &result, idx_t remaining) {
+	if (!state.initialized) {
+		D_ASSERT(state.current);
+		state.current->InitializeScan(state);
+		state.internal_index = state.current->start;
+		state.initialized = true;
+	}
+	D_ASSERT(state.internal_index <= state.row_index);
+	if (state.internal_index < state.row_index) {
+		state.current->Skip(state);
+	}
+	D_ASSERT(state.current->type == type);
+	idx_t initial_remaining = remaining;
+	while (remaining > 0) {
+		D_ASSERT(state.row_index >= state.current->start &&
+		         state.row_index <= state.current->start + state.current->count);
+		idx_t scan_count = MinValue<idx_t>(remaining, state.current->start + state.current->count - state.row_index);
+		idx_t result_offset = initial_remaining - remaining;
+		state.current->Scan(state, scan_count, result, result_offset, scan_count == initial_remaining);
+
+		state.row_index += scan_count;
+		remaining -= scan_count;
+		if (remaining > 0) {
+			if (!state.current->next) {
+				break;
+			}
+			state.current = (ColumnSegment *)state.current->next.get();
+			state.current->InitializeScan(state);
+			state.segment_checked = false;
+			D_ASSERT(state.row_index >= state.current->start &&
+			         state.row_index <= state.current->start + state.current->count);
+		}
+	}
+	state.internal_index = state.row_index;
+	return initial_remaining - remaining;
+}
+
+template <bool SCAN_COMMITTED, bool ALLOW_UPDATES>
+idx_t ColumnData::ScanVector(Transaction *transaction, idx_t vector_index, ColumnScanState &state, Vector &result) {
+	auto scan_count = ScanVector(state, result, STANDARD_VECTOR_SIZE);
+
+	lock_guard<mutex> update_guard(update_lock);
+	if (updates) {
+		if (!ALLOW_UPDATES && updates->HasUncommittedUpdates(vector_index)) {
+			throw TransactionException("Cannot create index with outstanding updates");
+		}
+		result.Normalify(scan_count);
+		if (SCAN_COMMITTED) {
+			updates->FetchCommitted(vector_index, result);
+		} else {
+			D_ASSERT(transaction);
+			updates->FetchUpdates(*transaction, vector_index, result);
+		}
+	}
+	return scan_count;
+}
+
+template idx_t ColumnData::ScanVector<false, false>(Transaction *transaction, idx_t vector_index,
+                                                    ColumnScanState &state, Vector &result);
+template idx_t ColumnData::ScanVector<true, false>(Transaction *transaction, idx_t vector_index, ColumnScanState &state,
+                                                   Vector &result);
+template idx_t ColumnData::ScanVector<false, true>(Transaction *transaction, idx_t vector_index, ColumnScanState &state,
+                                                   Vector &result);
+template idx_t ColumnData::ScanVector<true, true>(Transaction *transaction, idx_t vector_index, ColumnScanState &state,
+                                                  Vector &result);
+
+idx_t ColumnData::Scan(Transaction &transaction, idx_t vector_index, ColumnScanState &state, Vector &result) {
+	return ScanVector<false, true>(&transaction, vector_index, state, result);
+}
+
+idx_t ColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates) {
+	if (allow_updates) {
+		return ScanVector<true, true>(nullptr, vector_index, state, result);
+	} else {
+		return ScanVector<true, false>(nullptr, vector_index, state, result);
+	}
+}
+
+void ColumnData::ScanCommittedRange(idx_t row_group_start, idx_t offset_in_row_group, idx_t count, Vector &result) {
+	ColumnScanState child_state;
+	InitializeScanWithOffset(child_state, row_group_start + offset_in_row_group);
+	auto scan_count = ScanVector(child_state, result, count);
+	if (updates) {
+		result.Normalify(scan_count);
+		updates->FetchCommittedRange(offset_in_row_group, count, result);
+	}
+}
+
+idx_t ColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count) {
+	if (count == 0) {
+		return 0;
+	}
+	// ScanCount can only be used if there are no updates
+	D_ASSERT(!updates);
+	return ScanVector(state, result, count);
+}
+
+void ColumnData::Select(Transaction &transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
+                        SelectionVector &sel, idx_t &count, const TableFilter &filter) {
+	idx_t scan_count = Scan(transaction, vector_index, state, result);
+	result.Normalify(scan_count);
+	ColumnSegment::FilterSelection(sel, result, filter, count, FlatVector::Validity(result));
+}
+
+void ColumnData::FilterScan(Transaction &transaction, idx_t vector_index, ColumnScanState &state, Vector &result,
+                            SelectionVector &sel, idx_t count) {
+	Scan(transaction, vector_index, state, result);
+	result.Slice(sel, count);
+}
+
+void ColumnData::FilterScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, SelectionVector &sel,
+                                     idx_t count, bool allow_updates) {
+	ScanCommitted(vector_index, state, result, allow_updates);
+	result.Slice(sel, count);
+}
+
+void ColumnData::Skip(ColumnScanState &state, idx_t count) {
+	state.Next(count);
+}
+
+void ColumnScanState::NextInternal(idx_t count) {
+	if (!current) {
+		//! There is no column segment
+		return;
+	}
+	row_index += count;
+	while (row_index >= current->start + current->count) {
+		current = (ColumnSegment *)current->next.get();
+		initialized = false;
+		segment_checked = false;
+		if (!current) {
+			break;
+		}
+	}
+	D_ASSERT(!current || (row_index >= current->start && row_index < current->start + current->count));
+}
+
+void ColumnScanState::Next(idx_t count) {
+	NextInternal(count);
+	for (auto &child_state : child_states) {
+		child_state.Next(count);
+	}
+}
+
+void ColumnScanState::NextVector() {
+	Next(STANDARD_VECTOR_SIZE);
+}
+
+void ColumnData::Append(BaseStatistics &stats, ColumnAppendState &state, Vector &vector, idx_t count) {
+	VectorData vdata;
+	vector.Orrify(count, vdata);
+	AppendData(stats, state, vdata, count);
+}
+
+void ColumnData::InitializeAppend(ColumnAppendState &state) {
+	lock_guard<mutex> tree_lock(data.node_lock);
+	if (data.nodes.empty()) {
+		// no segments yet, append an empty segment
+		AppendTransientSegment(start);
+	}
+	auto segment = (ColumnSegment *)data.GetLastSegment();
+	if (segment->segment_type == ColumnSegmentType::PERSISTENT) {
+		// no transient segments yet
+		auto total_rows = segment->start + segment->count;
+		AppendTransientSegment(total_rows);
+		state.current = (ColumnSegment *)data.GetLastSegment();
+	} else {
+		state.current = (ColumnSegment *)segment;
+	}
+
+	D_ASSERT(state.current->segment_type == ColumnSegmentType::TRANSIENT);
+	state.current->InitializeAppend(state);
+}
+
+void ColumnData::AppendData(BaseStatistics &stats, ColumnAppendState &state, VectorData &vdata, idx_t count) {
+	idx_t offset = 0;
+	while (true) {
+		// append the data from the vector
+		idx_t copied_elements = state.current->Append(state, vdata, offset, count);
+		stats.Merge(*state.current->stats.statistics);
+		if (copied_elements == count) {
+			// finished copying everything
+			break;
+		}
+
+		// we couldn't fit everything we wanted in the current column segment, create a new one
+		{
+			lock_guard<mutex> tree_lock(data.node_lock);
+			AppendTransientSegment(state.current->start + state.current->count);
+			state.current = (ColumnSegment *)data.GetLastSegment();
+			state.current->InitializeAppend(state);
+		}
+		offset += copied_elements;
+		count -= copied_elements;
+	}
+}
+
+void ColumnData::RevertAppend(row_t start_row) {
+	lock_guard<mutex> tree_lock(data.node_lock);
+	// check if this row is in the segment tree at all
+	if (idx_t(start_row) >= data.nodes.back().row_start + data.nodes.back().node->count) {
+		// the start row is equal to the final portion of the column data: nothing was ever appended here
+		D_ASSERT(idx_t(start_row) == data.nodes.back().row_start + data.nodes.back().node->count);
+		return;
+	}
+	// find the segment index that the current row belongs to
+	idx_t segment_index = data.GetSegmentIndex(start_row);
+	auto segment = data.nodes[segment_index].node;
+	auto &transient = (ColumnSegment &)*segment;
+	D_ASSERT(transient.segment_type == ColumnSegmentType::TRANSIENT);
+
+	// remove any segments AFTER this segment: they should be deleted entirely
+	if (segment_index < data.nodes.size() - 1) {
+		data.nodes.erase(data.nodes.begin() + segment_index + 1, data.nodes.end());
+	}
+	segment->next = nullptr;
+	transient.RevertAppend(start_row);
+}
+
+idx_t ColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &result) {
+	D_ASSERT(row_id >= 0);
+	D_ASSERT(idx_t(row_id) >= start);
+	// perform the fetch within the segment
+	state.row_index = start + ((row_id - start) / STANDARD_VECTOR_SIZE * STANDARD_VECTOR_SIZE);
+	state.current = (ColumnSegment *)data.GetSegment(state.row_index);
+	state.internal_index = state.current->start;
+	return ScanVector(state, result, STANDARD_VECTOR_SIZE);
+}
+
+void ColumnData::FetchRow(Transaction &transaction, ColumnFetchState &state, row_t row_id, Vector &result,
+                          idx_t result_idx) {
+	auto segment = (ColumnSegment *)data.GetSegment(row_id);
+
+	// now perform the fetch within the segment
+	segment->FetchRow(state, row_id, result, result_idx);
+	// merge any updates made to this row
+	lock_guard<mutex> update_guard(update_lock);
+	if (updates) {
+		updates->FetchRow(transaction, row_id, result, result_idx);
+	}
+}
+
+void ColumnData::Update(Transaction &transaction, idx_t column_index, Vector &update_vector, row_t *row_ids,
+                        idx_t update_count) {
+	lock_guard<mutex> update_guard(update_lock);
+	if (!updates) {
+		updates = make_unique<UpdateSegment>(*this);
+	}
+	Vector base_vector(type);
+	ColumnScanState state;
+	auto fetch_count = Fetch(state, row_ids[0], base_vector);
+
+	base_vector.Normalify(fetch_count);
+	updates->Update(transaction, column_index, update_vector, row_ids, update_count, base_vector);
+}
+
+void ColumnData::UpdateColumn(Transaction &transaction, const vector<column_t> &column_path, Vector &update_vector,
+                              row_t *row_ids, idx_t update_count, idx_t depth) {
+	// this method should only be called at the end of the path in the base column case
+	D_ASSERT(depth >= column_path.size());
+	ColumnData::Update(transaction, column_path[0], update_vector, row_ids, update_count);
+}
+
+unique_ptr<BaseStatistics> ColumnData::GetUpdateStatistics() {
+	lock_guard<mutex> update_guard(update_lock);
+	return updates ? updates->GetStatistics() : nullptr;
+}
+
+void ColumnData::AppendTransientSegment(idx_t start_row) {
+	auto new_segment = ColumnSegment::CreateTransientSegment(GetDatabase(), type, start_row);
+	data.AppendSegment(move(new_segment));
+}
+
+void ColumnData::CommitDropColumn() {
+	auto &block_manager = BlockManager::GetBlockManager(GetDatabase());
+	auto segment = (ColumnSegment *)data.GetRootSegment();
+	while (segment) {
+		if (segment->segment_type == ColumnSegmentType::PERSISTENT) {
+			auto block_id = segment->GetBlockId();
+			if (block_id != INVALID_BLOCK) {
+				block_manager.MarkBlockAsModified(block_id);
+			}
+		}
+		segment = (ColumnSegment *)segment->next.get();
+	}
+}
+
+unique_ptr<ColumnCheckpointState> ColumnData::CreateCheckpointState(RowGroup &row_group, TableDataWriter &writer) {
+	return make_unique<ColumnCheckpointState>(row_group, *this, writer);
+}
+
+void ColumnData::CheckpointScan(ColumnSegment *segment, ColumnScanState &state, idx_t row_group_start, idx_t count,
+                                Vector &scan_vector) {
+	segment->Scan(state, count, scan_vector, 0, true);
+	if (updates) {
+		scan_vector.Normalify(count);
+		updates->FetchCommittedRange(state.row_index - row_group_start, count, scan_vector);
+	}
+}
+
+unique_ptr<ColumnCheckpointState> ColumnData::Checkpoint(RowGroup &row_group, TableDataWriter &writer,
+                                                         ColumnCheckpointInfo &checkpoint_info) {
+	// scan the segments of the column data
+	// set up the checkpoint state
+	auto checkpoint_state = CreateCheckpointState(row_group, writer);
+	checkpoint_state->global_stats = BaseStatistics::CreateEmpty(type, StatisticsType::LOCAL_STATS);
+
+	if (!data.root_node) {
+		// empty table: flush the empty list
+		return checkpoint_state;
+	}
+	lock_guard<mutex> update_guard(update_lock);
+
+	ColumnDataCheckpointer checkpointer(*this, row_group, *checkpoint_state, checkpoint_info);
+	checkpointer.Checkpoint(move(data.root_node));
+
+	// replace the old tree with the new one
+	data.Replace(checkpoint_state->new_tree);
+
+	return checkpoint_state;
+}
+
+void ColumnData::DeserializeColumn(Deserializer &source) {
+	// load the data pointers for the column
+	idx_t data_pointer_count = source.Read<idx_t>();
+	for (idx_t data_ptr = 0; data_ptr < data_pointer_count; data_ptr++) {
+		// read the data pointer
+		DataPointer data_pointer;
+		data_pointer.row_start = source.Read<idx_t>();
+		data_pointer.tuple_count = source.Read<idx_t>();
+		data_pointer.block_pointer.block_id = source.Read<block_id_t>();
+		data_pointer.block_pointer.offset = source.Read<uint32_t>();
+		data_pointer.compression_type = source.Read<CompressionType>();
+		data_pointer.statistics = BaseStatistics::Deserialize(source, type);
+
+		// create a persistent segment
+		auto segment = ColumnSegment::CreatePersistentSegment(
+		    GetDatabase(), data_pointer.block_pointer.block_id, data_pointer.block_pointer.offset, type,
+		    data_pointer.row_start, data_pointer.tuple_count, data_pointer.compression_type,
+		    move(data_pointer.statistics));
+		data.AppendSegment(move(segment));
+	}
+}
+
+shared_ptr<ColumnData> ColumnData::Deserialize(DataTableInfo &info, idx_t column_index, idx_t start_row,
+                                               Deserializer &source, const LogicalType &type, ColumnData *parent) {
+	auto entry = ColumnData::CreateColumn(info, column_index, start_row, type, parent);
+	entry->DeserializeColumn(source);
+	return entry;
+}
+
+void ColumnData::GetStorageInfo(idx_t row_group_index, vector<idx_t> col_path, vector<vector<Value>> &result) {
+	D_ASSERT(!col_path.empty());
+
+	// convert the column path to a string
+	string col_path_str = "[";
+	for (idx_t i = 0; i < col_path.size(); i++) {
+		if (i > 0) {
+			col_path_str += ", ";
+		}
+		col_path_str += to_string(col_path[i]);
+	}
+	col_path_str += "]";
+
+	// iterate over the segments
+	idx_t segment_idx = 0;
+	auto segment = (ColumnSegment *)data.GetRootSegment();
+	while (segment) {
+		vector<Value> column_info;
+		// row_group_id
+		column_info.push_back(Value::BIGINT(row_group_index));
+		// column_id
+		column_info.push_back(Value::BIGINT(col_path[0]));
+		// column_path
+		column_info.emplace_back(col_path_str);
+		// segment_id
+		column_info.push_back(Value::BIGINT(segment_idx));
+		// segment_type
+		column_info.emplace_back(type.ToString());
+		// start
+		column_info.push_back(Value::BIGINT(segment->start));
+		// count
+		column_info.push_back(Value::BIGINT(segment->count));
+		// compression
+		column_info.emplace_back(CompressionTypeToString(segment->function->type));
+		// stats
+		column_info.emplace_back(segment->stats.statistics ? segment->stats.statistics->ToString()
+		                                                   : string("No Stats"));
+		// has_updates
+		column_info.push_back(Value::BOOLEAN(updates ? true : false));
+		// persistent
+		// block_id
+		// block_offset
+		if (segment->segment_type == ColumnSegmentType::PERSISTENT) {
+			column_info.push_back(Value::BOOLEAN(true));
+			column_info.push_back(Value::BIGINT(segment->GetBlockId()));
+			column_info.push_back(Value::BIGINT(segment->GetBlockOffset()));
+		} else {
+			column_info.push_back(Value::BOOLEAN(false));
+			column_info.emplace_back();
+			column_info.emplace_back();
+		}
+
+		result.push_back(move(column_info));
+
+		segment_idx++;
+		segment = (ColumnSegment *)segment->next.get();
+	}
+}
+
+void ColumnData::Verify(RowGroup &parent) {
+#ifdef DEBUG
+	D_ASSERT(this->start == parent.start);
+	auto root = data.GetRootSegment();
+	if (root) {
+		D_ASSERT(root != nullptr);
+		D_ASSERT(root->start == this->start);
+		idx_t prev_end = root->start;
+		while (root) {
+			D_ASSERT(prev_end == root->start);
+			prev_end = root->start + root->count;
+			if (!root->next) {
+				D_ASSERT(prev_end == parent.start + parent.count);
+			}
+			root = root->next.get();
+		}
+	} else {
+		if (type.InternalType() != PhysicalType::STRUCT) {
+			D_ASSERT(parent.count == 0);
+		}
+	}
+#endif
+}
+
+template <class RET, class OP>
+static RET CreateColumnInternal(DataTableInfo &info, idx_t column_index, idx_t start_row, const LogicalType &type,
+                                ColumnData *parent) {
+	if (type.InternalType() == PhysicalType::STRUCT) {
+		return OP::template Create<StructColumnData>(info, column_index, start_row, type, parent);
+	} else if (type.InternalType() == PhysicalType::LIST) {
+		return OP::template Create<ListColumnData>(info, column_index, start_row, type, parent);
+	} else if (type.id() == LogicalTypeId::VALIDITY) {
+		return OP::template Create<ValidityColumnData>(info, column_index, start_row, parent);
+	}
+	return OP::template Create<StandardColumnData>(info, column_index, start_row, type, parent);
+}
+
+shared_ptr<ColumnData> ColumnData::CreateColumn(DataTableInfo &info, idx_t column_index, idx_t start_row,
+                                                const LogicalType &type, ColumnData *parent) {
+	return CreateColumnInternal<shared_ptr<ColumnData>, SharedConstructor>(info, column_index, start_row, type, parent);
+}
+
+unique_ptr<ColumnData> ColumnData::CreateColumnUnique(DataTableInfo &info, idx_t column_index, idx_t start_row,
+                                                      const LogicalType &type, ColumnData *parent) {
+	return CreateColumnInternal<unique_ptr<ColumnData>, UniqueConstructor>(info, column_index, start_row, type, parent);
+}
+
+} // namespace duckdb
+
+
+
+
+
+namespace duckdb {
+
+ColumnDataCheckpointer::ColumnDataCheckpointer(ColumnData &col_data_p, RowGroup &row_group_p,
+                                               ColumnCheckpointState &state_p, ColumnCheckpointInfo &checkpoint_info_p)
+    : col_data(col_data_p), row_group(row_group_p), state(state_p),
+      is_validity(GetType().id() == LogicalTypeId::VALIDITY),
+      intermediate(is_validity ? LogicalType::BOOLEAN : GetType(), true, is_validity),
+      checkpoint_info(checkpoint_info_p) {
+	auto &config = DBConfig::GetConfig(GetDatabase());
+	compression_functions = config.GetCompressionFunctions(GetType().InternalType());
+}
+
+DatabaseInstance &ColumnDataCheckpointer::GetDatabase() {
+	return col_data.GetDatabase();
+}
+
+const LogicalType &ColumnDataCheckpointer::GetType() const {
+	return col_data.type;
+}
+
+ColumnData &ColumnDataCheckpointer::GetColumnData() {
+	return col_data;
+}
+
+RowGroup &ColumnDataCheckpointer::GetRowGroup() {
+	return row_group;
+}
+
+ColumnCheckpointState &ColumnDataCheckpointer::GetCheckpointState() {
+	return state;
+}
+
+void ColumnDataCheckpointer::ScanSegments(const std::function<void(Vector &, idx_t)> &callback) {
+	Vector scan_vector(intermediate.GetType(), nullptr);
+	for (auto segment = (ColumnSegment *)owned_segment.get(); segment; segment = (ColumnSegment *)segment->next.get()) {
+		ColumnScanState scan_state;
+		scan_state.current = segment;
+		segment->InitializeScan(scan_state);
+
+		for (idx_t base_row_index = 0; base_row_index < segment->count; base_row_index += STANDARD_VECTOR_SIZE) {
+			scan_vector.Reference(intermediate);
+
+			idx_t count = MinValue<idx_t>(segment->count - base_row_index, STANDARD_VECTOR_SIZE);
+			scan_state.row_index = segment->start + base_row_index;
+
+			col_data.CheckpointScan(segment, scan_state, row_group.start, count, scan_vector);
+
+			callback(scan_vector, count);
+		}
+	}
+}
+
+void ForceCompression(vector<CompressionFunction *> &compression_functions, CompressionType compression_type) {
+	// On of the force_compression flags has been set
+	// check if this compression method is available
+	bool found = false;
+	for (idx_t i = 0; i < compression_functions.size(); i++) {
+		if (compression_functions[i]->type == compression_type) {
+			found = true;
+			break;
+		}
+	}
+	if (found) {
+		// the force_compression method is available
+		// clear all other compression methods
+		for (idx_t i = 0; i < compression_functions.size(); i++) {
+			if (compression_functions[i]->type != compression_type) {
+				compression_functions[i] = nullptr;
+			}
+		}
+	}
+}
+
+unique_ptr<AnalyzeState> ColumnDataCheckpointer::DetectBestCompressionMethod(idx_t &compression_idx) {
+	D_ASSERT(!compression_functions.empty());
+	auto &config = DBConfig::GetConfig(GetDatabase());
+
+	auto compression_type = checkpoint_info.compression_type;
+	if (compression_type != CompressionType::COMPRESSION_AUTO) {
+		ForceCompression(compression_functions, compression_type);
+	}
+	if (compression_type == CompressionType::COMPRESSION_AUTO &&
+	    config.force_compression != CompressionType::COMPRESSION_AUTO) {
+		ForceCompression(compression_functions, config.force_compression);
+	}
+	// set up the analyze states for each compression method
+	vector<unique_ptr<AnalyzeState>> analyze_states;
+	analyze_states.reserve(compression_functions.size());
+	for (idx_t i = 0; i < compression_functions.size(); i++) {
+		if (!compression_functions[i]) {
+			analyze_states.push_back(nullptr);
+			continue;
+		}
+		analyze_states.push_back(compression_functions[i]->init_analyze(col_data, col_data.type.InternalType()));
+	}
+
+	// scan over all the segments and run the analyze step
+	ScanSegments([&](Vector &scan_vector, idx_t count) {
+		for (idx_t i = 0; i < compression_functions.size(); i++) {
+			if (!compression_functions[i]) {
+				continue;
+			}
+			auto success = compression_functions[i]->analyze(*analyze_states[i], scan_vector, count);
+			if (!success) {
+				// could not use this compression function on this data set
+				// erase it
+				compression_functions[i] = nullptr;
+				analyze_states[i].reset();
+			}
+		}
+	});
+
+	// now that we have passed over all the data, we need to figure out the best method
+	// we do this using the final_analyze method
+	unique_ptr<AnalyzeState> state;
+	compression_idx = DConstants::INVALID_INDEX;
+	idx_t best_score = NumericLimits<idx_t>::Maximum();
+	for (idx_t i = 0; i < compression_functions.size(); i++) {
+		if (!compression_functions[i]) {
+			continue;
+		}
+		auto score = compression_functions[i]->final_analyze(*analyze_states[i]);
+		if (score < best_score) {
+			compression_idx = i;
+			best_score = score;
+			state = move(analyze_states[i]);
+		}
+	}
+	return state;
+}
+
+void ColumnDataCheckpointer::WriteToDisk() {
+	// there were changes or transient segments
+	// we need to rewrite the column segments to disk
+
+	// first we check the current segments
+	// if there are any persistent segments, we will mark their old block ids as modified
+	// since the segments will be rewritten their old on disk data is no longer required
+	auto &block_manager = BlockManager::GetBlockManager(GetDatabase());
+	for (auto segment = (ColumnSegment *)owned_segment.get(); segment; segment = (ColumnSegment *)segment->next.get()) {
+		if (segment->segment_type == ColumnSegmentType::PERSISTENT) {
+			// persistent segment has updates: mark it as modified and rewrite the block with the merged updates
+			auto block_id = segment->GetBlockId();
+			if (block_id != INVALID_BLOCK) {
+				block_manager.MarkBlockAsModified(block_id);
+			}
+		}
+	}
+
+	// now we need to write our segment
+	// we will first run an analyze step that determines which compression function to use
+	idx_t compression_idx;
+	auto analyze_state = DetectBestCompressionMethod(compression_idx);
+
+	if (!analyze_state) {
+		throw InternalException("No suitable compression/storage method found to store column");
+	}
+
+	// now that we have analyzed the compression functions we can start writing to disk
+	auto best_function = compression_functions[compression_idx];
+	auto compress_state = best_function->init_compression(*this, move(analyze_state));
+	ScanSegments(
+	    [&](Vector &scan_vector, idx_t count) { best_function->compress(*compress_state, scan_vector, count); });
+	best_function->compress_finalize(*compress_state);
+
+	// now we actually write the data to disk
+	owned_segment.reset();
+}
+
+bool ColumnDataCheckpointer::HasChanges() {
+	for (auto segment = (ColumnSegment *)owned_segment.get(); segment; segment = (ColumnSegment *)segment->next.get()) {
+		if (segment->segment_type == ColumnSegmentType::TRANSIENT) {
+			// transient segment: always need to write to disk
+			return true;
+		} else {
+			// persistent segment; check if there were any updates or deletions in this segment
+			idx_t start_row_idx = segment->start - row_group.start;
+			idx_t end_row_idx = start_row_idx + segment->count;
+			if (col_data.updates && col_data.updates->HasUpdates(start_row_idx, end_row_idx)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+void ColumnDataCheckpointer::WritePersistentSegments() {
+	// all segments are persistent and there are no updates
+	// we only need to write the metadata
+	auto segment = (ColumnSegment *)owned_segment.get();
+	while (segment) {
+		auto next_segment = move(segment->next);
+
+		D_ASSERT(segment->segment_type == ColumnSegmentType::PERSISTENT);
+
+		// set up the data pointer directly using the data from the persistent segment
+		DataPointer pointer;
+		pointer.block_pointer.block_id = segment->GetBlockId();
+		pointer.block_pointer.offset = segment->GetBlockOffset();
+		pointer.row_start = segment->start;
+		pointer.tuple_count = segment->count;
+		pointer.compression_type = segment->function->type;
+		pointer.statistics = segment->stats.statistics->Copy();
+
+		// merge the persistent stats into the global column stats
+		state.global_stats->Merge(*segment->stats.statistics);
+
+		// directly append the current segment to the new tree
+		state.new_tree.AppendSegment(move(owned_segment));
+
+		state.data_pointers.push_back(move(pointer));
+
+		// move to the next segment in the list
+		owned_segment = move(next_segment);
+		segment = (ColumnSegment *)owned_segment.get();
+	}
+}
+
+void ColumnDataCheckpointer::Checkpoint(unique_ptr<SegmentBase> segment) {
+	D_ASSERT(!owned_segment);
+	this->owned_segment = move(segment);
+	// first check if any of the segments have changes
+	if (!HasChanges()) {
+		// no changes: only need to write the metadata for this column
+		WritePersistentSegments();
+	} else {
+		// there are changes: rewrite the set of columns
+		WriteToDisk();
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+unique_ptr<ColumnSegment> ColumnSegment::CreatePersistentSegment(DatabaseInstance &db, block_id_t block_id,
+                                                                 idx_t offset, const LogicalType &type, idx_t start,
+                                                                 idx_t count, CompressionType compression_type,
+                                                                 unique_ptr<BaseStatistics> statistics) {
+	auto &config = DBConfig::GetConfig(db);
+	CompressionFunction *function;
+	if (block_id == INVALID_BLOCK) {
+		function = config.GetCompressionFunction(CompressionType::COMPRESSION_CONSTANT, type.InternalType());
+	} else {
+		function = config.GetCompressionFunction(compression_type, type.InternalType());
+	}
+	return make_unique<ColumnSegment>(db, type, ColumnSegmentType::PERSISTENT, start, count, function, move(statistics),
+	                                  block_id, offset);
+}
+
+unique_ptr<ColumnSegment> ColumnSegment::CreateTransientSegment(DatabaseInstance &db, const LogicalType &type,
+                                                                idx_t start) {
+	auto &config = DBConfig::GetConfig(db);
+	auto function = config.GetCompressionFunction(CompressionType::COMPRESSION_UNCOMPRESSED, type.InternalType());
+	return make_unique<ColumnSegment>(db, type, ColumnSegmentType::TRANSIENT, start, 0, function, nullptr,
+	                                  INVALID_BLOCK, 0);
+}
+
+ColumnSegment::ColumnSegment(DatabaseInstance &db, LogicalType type_p, ColumnSegmentType segment_type, idx_t start,
+                             idx_t count, CompressionFunction *function_p, unique_ptr<BaseStatistics> statistics,
+                             block_id_t block_id_p, idx_t offset_p)
+    : SegmentBase(start, count), db(db), type(move(type_p)), type_size(GetTypeIdSize(type.InternalType())),
+      segment_type(segment_type), function(function_p), stats(type, move(statistics)), block_id(block_id_p),
+      offset(offset_p) {
+	D_ASSERT(function);
+	auto &buffer_manager = BufferManager::GetBufferManager(db);
+	if (block_id == INVALID_BLOCK) {
+		// no block id specified
+		// there are two cases here:
+		// transient: allocate a buffer for the uncompressed segment
+		// persistent: constant segment, no need to allocate anything
+		if (segment_type == ColumnSegmentType::TRANSIENT) {
+			this->block = buffer_manager.RegisterMemory(Storage::BLOCK_SIZE, false);
+		}
+	} else {
+		D_ASSERT(segment_type == ColumnSegmentType::PERSISTENT);
+		this->block = buffer_manager.RegisterBlock(block_id);
+	}
+	if (function->init_segment) {
+		segment_state = function->init_segment(*this, block_id);
+	}
+}
+
+ColumnSegment::~ColumnSegment() {
+}
+
+//===--------------------------------------------------------------------===//
+// Scan
+//===--------------------------------------------------------------------===//
+void ColumnSegment::InitializeScan(ColumnScanState &state) {
+	state.scan_state = function->init_scan(*this);
+}
+
+void ColumnSegment::Scan(ColumnScanState &state, idx_t scan_count, Vector &result, idx_t result_offset,
+                         bool entire_vector) {
+	if (entire_vector) {
+		D_ASSERT(result_offset == 0);
+		Scan(state, scan_count, result);
+	} else {
+		D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
+		ScanPartial(state, scan_count, result, result_offset);
+		D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
+	}
+}
+
+void ColumnSegment::Skip(ColumnScanState &state) {
+	function->skip(*this, state, state.row_index - state.internal_index);
+	state.internal_index = state.row_index;
+}
+
+void ColumnSegment::Scan(ColumnScanState &state, idx_t scan_count, Vector &result) {
+	function->scan_vector(*this, state, scan_count, result);
+}
+
+void ColumnSegment::ScanPartial(ColumnScanState &state, idx_t scan_count, Vector &result, idx_t result_offset) {
+	function->scan_partial(*this, state, scan_count, result, result_offset);
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch
+//===--------------------------------------------------------------------===//
+void ColumnSegment::FetchRow(ColumnFetchState &state, row_t row_id, Vector &result, idx_t result_idx) {
+	function->fetch_row(*this, state, row_id - this->start, result, result_idx);
+}
+
+void ColumnSegment::InitializeAppend(ColumnAppendState &state) {
+	D_ASSERT(segment_type == ColumnSegmentType::TRANSIENT);
+}
+
+//===--------------------------------------------------------------------===//
+// Append
+//===--------------------------------------------------------------------===//
+idx_t ColumnSegment::Append(ColumnAppendState &state, VectorData &append_data, idx_t offset, idx_t count) {
+	D_ASSERT(segment_type == ColumnSegmentType::TRANSIENT);
+	if (!function->append) {
+		throw InternalException("Attempting to append to a segment without append method");
+	}
+	return function->append(*this, stats, append_data, offset, count);
+}
+
+idx_t ColumnSegment::FinalizeAppend() {
+	D_ASSERT(segment_type == ColumnSegmentType::TRANSIENT);
+	if (!function->finalize_append) {
+		throw InternalException("Attempting to call FinalizeAppend on a segment without a finalize_append method");
+	}
+	return function->finalize_append(*this, stats);
+}
+
+void ColumnSegment::RevertAppend(idx_t start_row) {
+	D_ASSERT(segment_type == ColumnSegmentType::TRANSIENT);
+	if (function->revert_append) {
+		function->revert_append(*this, start_row);
+	}
+	this->count = start_row - this->start;
+}
+
+//===--------------------------------------------------------------------===//
+// Convert To Persistent
+//===--------------------------------------------------------------------===//
+void ColumnSegment::ConvertToPersistent(block_id_t block_id_p) {
+	D_ASSERT(segment_type == ColumnSegmentType::TRANSIENT);
+	segment_type = ColumnSegmentType::PERSISTENT;
+	block_id = block_id_p;
+	offset = 0;
+
+	if (block_id == INVALID_BLOCK) {
+		// constant block: reset the block buffer
+		block.reset();
+	} else {
+		// non-constant block: write the block to disk
+		auto &buffer_manager = BufferManager::GetBufferManager(db);
+		auto &block_manager = BlockManager::GetBlockManager(db);
+
+		// the data for the block already exists in-memory of our block
+		// instead of copying the data we alter some metadata so the buffer points to an on-disk block
+		block = buffer_manager.ConvertToPersistent(block_manager, block_id, move(block));
+	}
+
+	segment_state.reset();
+	if (function->init_segment) {
+		segment_state = function->init_segment(*this, block_id);
+	}
+}
+
+void ColumnSegment::ConvertToPersistent(shared_ptr<BlockHandle> block_p, block_id_t block_id_p, uint32_t offset_p) {
+	D_ASSERT(segment_type == ColumnSegmentType::TRANSIENT);
+	segment_type = ColumnSegmentType::PERSISTENT;
+	block_id = block_id_p;
+	offset = offset_p;
+	block = move(block_p);
+
+	segment_state.reset();
+	if (function->init_segment) {
+		segment_state = function->init_segment(*this, block_id);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Filter Selection
+//===--------------------------------------------------------------------===//
+template <class T, class OP, bool HAS_NULL>
+static idx_t TemplatedFilterSelection(T *vec, T *predicate, SelectionVector &sel, idx_t approved_tuple_count,
+                                      ValidityMask &mask, SelectionVector &result_sel) {
+	idx_t result_count = 0;
+	for (idx_t i = 0; i < approved_tuple_count; i++) {
+		auto idx = sel.get_index(i);
+		if ((!HAS_NULL || mask.RowIsValid(idx)) && OP::Operation(vec[idx], *predicate)) {
+			result_sel.set_index(result_count++, idx);
+		}
+	}
+	return result_count;
+}
+
+template <class T>
+static void FilterSelectionSwitch(T *vec, T *predicate, SelectionVector &sel, idx_t &approved_tuple_count,
+                                  ExpressionType comparison_type, ValidityMask &mask) {
+	SelectionVector new_sel(approved_tuple_count);
+	// the inplace loops take the result as the last parameter
+	switch (comparison_type) {
+	case ExpressionType::COMPARE_EQUAL: {
+		if (mask.AllValid()) {
+			approved_tuple_count =
+			    TemplatedFilterSelection<T, Equals, false>(vec, predicate, sel, approved_tuple_count, mask, new_sel);
+		} else {
+			approved_tuple_count =
+			    TemplatedFilterSelection<T, Equals, true>(vec, predicate, sel, approved_tuple_count, mask, new_sel);
+		}
+		break;
+	}
+	case ExpressionType::COMPARE_NOTEQUAL: {
+		if (mask.AllValid()) {
+			approved_tuple_count =
+			    TemplatedFilterSelection<T, NotEquals, false>(vec, predicate, sel, approved_tuple_count, mask, new_sel);
+		} else {
+			approved_tuple_count =
+			    TemplatedFilterSelection<T, NotEquals, true>(vec, predicate, sel, approved_tuple_count, mask, new_sel);
+		}
+		break;
+	}
+	case ExpressionType::COMPARE_LESSTHAN: {
+		if (mask.AllValid()) {
+			approved_tuple_count =
+			    TemplatedFilterSelection<T, LessThan, false>(vec, predicate, sel, approved_tuple_count, mask, new_sel);
+		} else {
+			approved_tuple_count =
+			    TemplatedFilterSelection<T, LessThan, true>(vec, predicate, sel, approved_tuple_count, mask, new_sel);
+		}
+		break;
+	}
+	case ExpressionType::COMPARE_GREATERTHAN: {
+		if (mask.AllValid()) {
+			approved_tuple_count = TemplatedFilterSelection<T, GreaterThan, false>(vec, predicate, sel,
+			                                                                       approved_tuple_count, mask, new_sel);
+		} else {
+			approved_tuple_count = TemplatedFilterSelection<T, GreaterThan, true>(vec, predicate, sel,
+			                                                                      approved_tuple_count, mask, new_sel);
+		}
+		break;
+	}
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO: {
+		if (mask.AllValid()) {
+			approved_tuple_count = TemplatedFilterSelection<T, LessThanEquals, false>(
+			    vec, predicate, sel, approved_tuple_count, mask, new_sel);
+		} else {
+			approved_tuple_count = TemplatedFilterSelection<T, LessThanEquals, true>(
+			    vec, predicate, sel, approved_tuple_count, mask, new_sel);
+		}
+		break;
+	}
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO: {
+		if (mask.AllValid()) {
+			approved_tuple_count = TemplatedFilterSelection<T, GreaterThanEquals, false>(
+			    vec, predicate, sel, approved_tuple_count, mask, new_sel);
+		} else {
+			approved_tuple_count = TemplatedFilterSelection<T, GreaterThanEquals, true>(
+			    vec, predicate, sel, approved_tuple_count, mask, new_sel);
+		}
+		break;
+	}
+	default:
+		throw NotImplementedException("Unknown comparison type for filter pushed down to table!");
+	}
+	sel.Initialize(new_sel);
+}
+
+template <bool IS_NULL>
+static idx_t TemplatedNullSelection(SelectionVector &sel, idx_t approved_tuple_count, ValidityMask &mask) {
+	if (mask.AllValid()) {
+		// no NULL values
+		if (IS_NULL) {
+			return 0;
+		} else {
+			return approved_tuple_count;
+		}
+	} else {
+		SelectionVector result_sel(approved_tuple_count);
+		idx_t result_count = 0;
+		for (idx_t i = 0; i < approved_tuple_count; i++) {
+			auto idx = sel.get_index(i);
+			if (mask.RowIsValid(idx) != IS_NULL) {
+				result_sel.set_index(result_count++, idx);
+			}
+		}
+		sel.Initialize(result_sel);
+		return result_count;
+	}
+}
+
+idx_t ColumnSegment::FilterSelection(SelectionVector &sel, Vector &result, const TableFilter &filter,
+                                     idx_t &approved_tuple_count, ValidityMask &mask) {
+	switch (filter.filter_type) {
+	case TableFilterType::CONJUNCTION_OR: {
+		// similar to the CONJUNCTION_AND, but we need to take care of the SelectionVectors (OR all of them)
+		idx_t count_total = 0;
+		SelectionVector result_sel(approved_tuple_count);
+		auto &conjunction_or = (ConjunctionOrFilter &)filter;
+		for (auto &child_filter : conjunction_or.child_filters) {
+			SelectionVector temp_sel;
+			temp_sel.Initialize(sel);
+			idx_t temp_tuple_count = approved_tuple_count;
+			idx_t temp_count = FilterSelection(temp_sel, result, *child_filter, temp_tuple_count, mask);
+			// tuples passed, move them into the actual result vector
+			for (idx_t i = 0; i < temp_count; i++) {
+				auto new_idx = temp_sel.get_index(i);
+				bool is_new_idx = true;
+				for (idx_t res_idx = 0; res_idx < count_total; res_idx++) {
+					if (result_sel.get_index(res_idx) == new_idx) {
+						is_new_idx = false;
+						break;
+					}
+				}
+				if (is_new_idx) {
+					result_sel.set_index(count_total++, new_idx);
+				}
+			}
+		}
+		sel.Initialize(result_sel);
+		approved_tuple_count = count_total;
+		return approved_tuple_count;
+	}
+	case TableFilterType::CONJUNCTION_AND: {
+		auto &conjunction_and = (ConjunctionAndFilter &)filter;
+		for (auto &child_filter : conjunction_and.child_filters) {
+			FilterSelection(sel, result, *child_filter, approved_tuple_count, mask);
+		}
+		return approved_tuple_count;
+	}
+	case TableFilterType::CONSTANT_COMPARISON: {
+		auto &constant_filter = (ConstantFilter &)filter;
+		// the inplace loops take the result as the last parameter
+		switch (result.GetType().InternalType()) {
+		case PhysicalType::UINT8: {
+			auto result_flat = FlatVector::GetData<uint8_t>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<uint8_t>(predicate_vector);
+			FilterSelectionSwitch<uint8_t>(result_flat, predicate, sel, approved_tuple_count,
+			                               constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::UINT16: {
+			auto result_flat = FlatVector::GetData<uint16_t>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<uint16_t>(predicate_vector);
+			FilterSelectionSwitch<uint16_t>(result_flat, predicate, sel, approved_tuple_count,
+			                                constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::UINT32: {
+			auto result_flat = FlatVector::GetData<uint32_t>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<uint32_t>(predicate_vector);
+			FilterSelectionSwitch<uint32_t>(result_flat, predicate, sel, approved_tuple_count,
+			                                constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::UINT64: {
+			auto result_flat = FlatVector::GetData<uint64_t>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<uint64_t>(predicate_vector);
+			FilterSelectionSwitch<uint64_t>(result_flat, predicate, sel, approved_tuple_count,
+			                                constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::INT8: {
+			auto result_flat = FlatVector::GetData<int8_t>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<int8_t>(predicate_vector);
+			FilterSelectionSwitch<int8_t>(result_flat, predicate, sel, approved_tuple_count,
+			                              constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::INT16: {
+			auto result_flat = FlatVector::GetData<int16_t>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<int16_t>(predicate_vector);
+			FilterSelectionSwitch<int16_t>(result_flat, predicate, sel, approved_tuple_count,
+			                               constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::INT32: {
+			auto result_flat = FlatVector::GetData<int32_t>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<int32_t>(predicate_vector);
+			FilterSelectionSwitch<int32_t>(result_flat, predicate, sel, approved_tuple_count,
+			                               constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::INT64: {
+			auto result_flat = FlatVector::GetData<int64_t>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<int64_t>(predicate_vector);
+			FilterSelectionSwitch<int64_t>(result_flat, predicate, sel, approved_tuple_count,
+			                               constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::INT128: {
+			auto result_flat = FlatVector::GetData<hugeint_t>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<hugeint_t>(predicate_vector);
+			FilterSelectionSwitch<hugeint_t>(result_flat, predicate, sel, approved_tuple_count,
+			                                 constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::FLOAT: {
+			auto result_flat = FlatVector::GetData<float>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<float>(predicate_vector);
+			FilterSelectionSwitch<float>(result_flat, predicate, sel, approved_tuple_count,
+			                             constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::DOUBLE: {
+			auto result_flat = FlatVector::GetData<double>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<double>(predicate_vector);
+			FilterSelectionSwitch<double>(result_flat, predicate, sel, approved_tuple_count,
+			                              constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::VARCHAR: {
+			auto result_flat = FlatVector::GetData<string_t>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<string_t>(predicate_vector);
+			FilterSelectionSwitch<string_t>(result_flat, predicate, sel, approved_tuple_count,
+			                                constant_filter.comparison_type, mask);
+			break;
+		}
+		case PhysicalType::BOOL: {
+			auto result_flat = FlatVector::GetData<bool>(result);
+			Vector predicate_vector(constant_filter.constant);
+			auto predicate = FlatVector::GetData<bool>(predicate_vector);
+			FilterSelectionSwitch<bool>(result_flat, predicate, sel, approved_tuple_count,
+			                            constant_filter.comparison_type, mask);
+			break;
+		}
+		default:
+			throw InvalidTypeException(result.GetType(), "Invalid type for filter pushed down to table comparison");
+		}
+		return approved_tuple_count;
+	}
+	case TableFilterType::IS_NULL:
+		return TemplatedNullSelection<true>(sel, approved_tuple_count, mask);
+	case TableFilterType::IS_NOT_NULL:
+		return TemplatedNullSelection<false>(sel, approved_tuple_count, mask);
+	default:
+		throw InternalException("FIXME: unsupported type for filter selection");
+	}
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+ListColumnData::ListColumnData(DataTableInfo &info, idx_t column_index, idx_t start_row, LogicalType type_p,
+                               ColumnData *parent)
+    : ColumnData(info, column_index, start_row, move(type_p), parent), validity(info, 0, start_row, this) {
+	D_ASSERT(type.InternalType() == PhysicalType::LIST);
+	auto &child_type = ListType::GetChildType(type);
+	// the child column, with column index 1 (0 is the validity mask)
+	child_column = ColumnData::CreateColumnUnique(info, 1, start_row, child_type, this);
+}
+
+bool ListColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
+	// table filters are not supported yet for list columns
+	return false;
+}
+
+void ListColumnData::InitializeScan(ColumnScanState &state) {
+	ColumnData::InitializeScan(state);
+
+	// initialize the validity segment
+	ColumnScanState validity_state;
+	validity.InitializeScan(validity_state);
+	state.child_states.push_back(move(validity_state));
+
+	// initialize the child scan
+	ColumnScanState child_state;
+	child_column->InitializeScan(child_state);
+	state.child_states.push_back(move(child_state));
+}
+
+list_entry_t ListColumnData::FetchListEntry(idx_t row_idx) {
+	auto segment = (ColumnSegment *)data.GetSegment(row_idx);
+	ColumnFetchState fetch_state;
+	Vector result(type, 1);
+	segment->FetchRow(fetch_state, row_idx, result, 0);
+
+	// initialize the child scan with the required offset
+	auto list_data = FlatVector::GetData<list_entry_t>(result);
+	return list_data[0];
+}
+
+void ListColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) {
+	if (row_idx == 0) {
+		InitializeScan(state);
+		return;
+	}
+	ColumnData::InitializeScanWithOffset(state, row_idx);
+
+	// initialize the validity segment
+	ColumnScanState validity_state;
+	validity.InitializeScanWithOffset(validity_state, row_idx);
+	state.child_states.push_back(move(validity_state));
+
+	// we need to read the list at position row_idx to get the correct row offset of the child
+	auto list_entry = FetchListEntry(row_idx);
+	auto child_offset = list_entry.offset;
+
+	D_ASSERT(child_offset <= child_column->GetMaxEntry());
+	ColumnScanState child_state;
+	if (child_offset < child_column->GetMaxEntry()) {
+		child_column->InitializeScanWithOffset(child_state, child_offset);
+	}
+	state.child_states.push_back(move(child_state));
+}
+
+idx_t ListColumnData::Scan(Transaction &transaction, idx_t vector_index, ColumnScanState &state, Vector &result) {
+	return ScanCount(state, result, STANDARD_VECTOR_SIZE);
+}
+
+idx_t ListColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates) {
+	return ScanCount(state, result, STANDARD_VECTOR_SIZE);
+}
+
+idx_t ListColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count) {
+	if (count == 0) {
+		return 0;
+	}
+	// updates not supported for lists
+	D_ASSERT(!updates);
+
+	idx_t scan_count = ScanVector(state, result, count);
+	D_ASSERT(scan_count > 0);
+	validity.ScanCount(state.child_states[0], result, count);
+
+	auto data = FlatVector::GetData<list_entry_t>(result);
+	auto first_entry = data[0];
+	auto last_entry = data[scan_count - 1];
+
+#ifdef DEBUG
+	for (idx_t i = 1; i < scan_count; i++) {
+		D_ASSERT(data[i].offset == data[i - 1].offset + data[i - 1].length);
+	}
+#endif
+	// shift all offsets so they are 0 at the first entry
+	for (idx_t i = 0; i < scan_count; i++) {
+		data[i].offset -= first_entry.offset;
+	}
+
+	D_ASSERT(last_entry.offset >= first_entry.offset);
+	idx_t child_scan_count = last_entry.offset + last_entry.length - first_entry.offset;
+	ListVector::Reserve(result, child_scan_count);
+
+	if (child_scan_count > 0) {
+		auto &child_entry = ListVector::GetEntry(result);
+		D_ASSERT(child_entry.GetType().InternalType() == PhysicalType::STRUCT ||
+		         state.child_states[1].row_index + child_scan_count <= child_column->GetMaxEntry());
+		child_column->ScanCount(state.child_states[1], child_entry, child_scan_count);
+	}
+
+	ListVector::SetListSize(result, child_scan_count);
+	return scan_count;
+}
+
+void ListColumnData::Skip(ColumnScanState &state, idx_t count) {
+	// skip inside the validity segment
+	validity.Skip(state.child_states[0], count);
+
+	// we need to read the list entries/offsets to figure out how much to skip
+	// note that we only need to read the first and last entry
+	// however, let's just read all "count" entries for now
+	auto data = unique_ptr<list_entry_t[]>(new list_entry_t[count]);
+	Vector result(type, (data_ptr_t)data.get());
+	idx_t scan_count = ScanVector(state, result, count);
+	if (scan_count == 0) {
+		return;
+	}
+
+	auto &first_entry = data[0];
+	auto &last_entry = data[scan_count - 1];
+	idx_t child_scan_count = last_entry.offset + last_entry.length - first_entry.offset;
+
+	// skip the child state forward by the child_scan_count
+	child_column->Skip(state.child_states[1], child_scan_count);
+}
+
+void ListColumnData::InitializeAppend(ColumnAppendState &state) {
+	// initialize the list offset append
+	ColumnData::InitializeAppend(state);
+
+	// initialize the validity append
+	ColumnAppendState validity_append_state;
+	validity.InitializeAppend(validity_append_state);
+	state.child_appends.push_back(move(validity_append_state));
+
+	// initialize the child column append
+	ColumnAppendState child_append_state;
+	child_column->InitializeAppend(child_append_state);
+	state.child_appends.push_back(move(child_append_state));
+}
+
+void ListColumnData::Append(BaseStatistics &stats_p, ColumnAppendState &state, Vector &vector, idx_t count) {
+	D_ASSERT(count > 0);
+	auto &stats = (ListStatistics &)stats_p;
+
+	vector.Normalify(count);
+	auto &list_validity = FlatVector::Validity(vector);
+
+	// construct the list_entry_t entries to append to the column data
+	auto input_offsets = FlatVector::GetData<list_entry_t>(vector);
+	auto start_offset = child_column->GetMaxEntry();
+	idx_t child_count = 0;
+
+	auto append_offsets = unique_ptr<list_entry_t[]>(new list_entry_t[count]);
+	for (idx_t i = 0; i < count; i++) {
+		if (list_validity.RowIsValid(i)) {
+			append_offsets[i].offset = start_offset + input_offsets[i].offset;
+			append_offsets[i].length = input_offsets[i].length;
+			child_count += input_offsets[i].length;
+		} else {
+			if (i > 0) {
+				append_offsets[i].offset = append_offsets[i - 1].offset + append_offsets[i - 1].length;
+			} else {
+				append_offsets[i].offset = start_offset;
+			}
+			append_offsets[i].length = 0;
+		}
+	}
+#ifdef DEBUG
+	D_ASSERT(append_offsets[0].offset == start_offset);
+	for (idx_t i = 1; i < count; i++) {
+		D_ASSERT(append_offsets[i].offset == append_offsets[i - 1].offset + append_offsets[i - 1].length);
+	}
+	D_ASSERT(append_offsets[count - 1].offset + append_offsets[count - 1].length - append_offsets[0].offset ==
+	         child_count);
+#endif
+
+	VectorData vdata;
+	vdata.validity = list_validity;
+	vdata.sel = FlatVector::IncrementalSelectionVector();
+	vdata.data = (data_ptr_t)append_offsets.get();
+
+	// append the list offsets
+	ColumnData::AppendData(stats, state, vdata, count);
+	// append the validity data
+	validity.AppendData(*stats.validity_stats, state.child_appends[0], vdata, count);
+	// append the child vector
+	if (child_count > 0) {
+		auto &child_vector = ListVector::GetEntry(vector);
+		child_column->Append(*stats.child_stats, state.child_appends[1], child_vector, child_count);
+	}
+}
+
+void ListColumnData::RevertAppend(row_t start_row) {
+	ColumnData::RevertAppend(start_row);
+	validity.RevertAppend(start_row);
+	auto column_count = GetMaxEntry();
+	if (column_count > start) {
+		// revert append in the child column
+		auto list_entry = FetchListEntry(column_count - 1);
+		child_column->RevertAppend(list_entry.offset + list_entry.length);
+	}
+}
+
+idx_t ListColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &result) {
+	throw NotImplementedException("List Fetch");
+}
+
+void ListColumnData::Update(Transaction &transaction, idx_t column_index, Vector &update_vector, row_t *row_ids,
+                            idx_t update_count) {
+	throw NotImplementedException("List Update is not supported.");
+}
+
+void ListColumnData::UpdateColumn(Transaction &transaction, const vector<column_t> &column_path, Vector &update_vector,
+                                  row_t *row_ids, idx_t update_count, idx_t depth) {
+	throw NotImplementedException("List Update Column is not supported");
+}
+
+unique_ptr<BaseStatistics> ListColumnData::GetUpdateStatistics() {
+	return nullptr;
+}
+
+void ListColumnData::FetchRow(Transaction &transaction, ColumnFetchState &state, row_t row_id, Vector &result,
+                              idx_t result_idx) {
+	// insert any child states that are required
+	// we need two (validity & list child)
+	// note that we need a scan state for the child vector
+	// this is because we will (potentially) fetch more than one tuple from the list child
+	if (state.child_states.empty()) {
+		auto child_state = make_unique<ColumnFetchState>();
+		state.child_states.push_back(move(child_state));
+	}
+	// fetch the list_entry_t and the validity mask for that list
+	auto segment = (ColumnSegment *)data.GetSegment(row_id);
+
+	// now perform the fetch within the segment
+	segment->FetchRow(state, row_id, result, result_idx);
+	validity.FetchRow(transaction, *state.child_states[0], row_id, result, result_idx);
+
+	auto &validity = FlatVector::Validity(result);
+	auto list_data = FlatVector::GetData<list_entry_t>(result);
+	auto &list_entry = list_data[result_idx];
+	auto original_offset = list_entry.offset;
+	// set the list entry offset to the size of the current list
+	list_entry.offset = ListVector::GetListSize(result);
+	if (!validity.RowIsValid(result_idx)) {
+		// the list is NULL! no need to fetch the child
+		D_ASSERT(list_entry.length == 0);
+		return;
+	}
+
+	// now we need to read from the child all the elements between [offset...length]
+	auto child_scan_count = list_entry.length;
+	if (child_scan_count > 0) {
+		auto child_state = make_unique<ColumnScanState>();
+		auto &child_type = ListType::GetChildType(result.GetType());
+		Vector child_scan(child_type, child_scan_count);
+		// seek the scan towards the specified position and read [length] entries
+		child_column->InitializeScanWithOffset(*child_state, original_offset);
+		D_ASSERT(child_type.InternalType() == PhysicalType::STRUCT ||
+		         child_state->row_index + child_scan_count <= child_column->GetMaxEntry());
+		child_column->ScanCount(*child_state, child_scan, child_scan_count);
+
+		ListVector::Append(result, child_scan, child_scan_count);
+	}
+}
+
+void ListColumnData::CommitDropColumn() {
+	validity.CommitDropColumn();
+	child_column->CommitDropColumn();
+}
+
+struct ListColumnCheckpointState : public ColumnCheckpointState {
+	ListColumnCheckpointState(RowGroup &row_group, ColumnData &column_data, TableDataWriter &writer)
+	    : ColumnCheckpointState(row_group, column_data, writer) {
+		global_stats = make_unique<ListStatistics>(column_data.type);
+	}
+
+	unique_ptr<ColumnCheckpointState> validity_state;
+	unique_ptr<ColumnCheckpointState> child_state;
+
+public:
+	unique_ptr<BaseStatistics> GetStatistics() override {
+		auto stats = global_stats->Copy();
+		auto &list_stats = (ListStatistics &)*stats;
+		stats->validity_stats = validity_state->GetStatistics();
+		list_stats.child_stats = child_state->GetStatistics();
+		return stats;
+	}
+
+	void FlushToDisk() override {
+		ColumnCheckpointState::FlushToDisk();
+		validity_state->FlushToDisk();
+		child_state->FlushToDisk();
+	}
+};
+
+unique_ptr<ColumnCheckpointState> ListColumnData::CreateCheckpointState(RowGroup &row_group, TableDataWriter &writer) {
+	return make_unique<ListColumnCheckpointState>(row_group, *this, writer);
+}
+
+unique_ptr<ColumnCheckpointState> ListColumnData::Checkpoint(RowGroup &row_group, TableDataWriter &writer,
+                                                             ColumnCheckpointInfo &checkpoint_info) {
+	auto validity_state = validity.Checkpoint(row_group, writer, checkpoint_info);
+	auto base_state = ColumnData::Checkpoint(row_group, writer, checkpoint_info);
+	auto child_state = child_column->Checkpoint(row_group, writer, checkpoint_info);
+
+	auto &checkpoint_state = (ListColumnCheckpointState &)*base_state;
+	checkpoint_state.validity_state = move(validity_state);
+	checkpoint_state.child_state = move(child_state);
+	return base_state;
+}
+
+void ListColumnData::DeserializeColumn(Deserializer &source) {
+	ColumnData::DeserializeColumn(source);
+	validity.DeserializeColumn(source);
+	child_column->DeserializeColumn(source);
+}
+
+void ListColumnData::GetStorageInfo(idx_t row_group_index, vector<idx_t> col_path, vector<vector<Value>> &result) {
+	col_path.push_back(0);
+	validity.GetStorageInfo(row_group_index, col_path, result);
+	col_path.back() = 1;
+	child_column->GetStorageInfo(row_group_index, col_path, result);
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+PersistentTableData::PersistentTableData(idx_t column_count) {
+}
+
+PersistentTableData::~PersistentTableData() {
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+constexpr const idx_t RowGroup::ROW_GROUP_VECTOR_COUNT;
+constexpr const idx_t RowGroup::ROW_GROUP_SIZE;
+
+RowGroup::RowGroup(DatabaseInstance &db, DataTableInfo &table_info, idx_t start, idx_t count)
+    : SegmentBase(start, count), db(db), table_info(table_info) {
+
+	Verify();
+}
+
+RowGroup::RowGroup(DatabaseInstance &db, DataTableInfo &table_info, const vector<LogicalType> &types,
+                   RowGroupPointer &pointer)
+    : SegmentBase(pointer.row_start, pointer.tuple_count), db(db), table_info(table_info) {
+	// deserialize the columns
+	if (pointer.data_pointers.size() != types.size()) {
+		throw IOException("Row group column count is unaligned with table column count. Corrupt file?");
+	}
+	for (idx_t i = 0; i < pointer.data_pointers.size(); i++) {
+		auto &block_pointer = pointer.data_pointers[i];
+		MetaBlockReader column_data_reader(db, block_pointer.block_id);
+		column_data_reader.offset = block_pointer.offset;
+		this->columns.push_back(ColumnData::Deserialize(table_info, i, start, column_data_reader, types[i], nullptr));
+	}
+
+	// set up the statistics
+	for (auto &stats : pointer.statistics) {
+		auto stats_type = stats->type;
+		this->stats.push_back(make_shared<SegmentStatistics>(stats_type, move(stats)));
+	}
+	this->version_info = move(pointer.versions);
+
+	Verify();
+}
+
+RowGroup::~RowGroup() {
+}
+
+void RowGroup::InitializeEmpty(const vector<LogicalType> &types) {
+	// set up the segment trees for the column segments
+	for (idx_t i = 0; i < types.size(); i++) {
+		auto column_data = ColumnData::CreateColumn(GetTableInfo(), i, start, types[i]);
+		stats.push_back(make_shared<SegmentStatistics>(types[i]));
+		columns.push_back(move(column_data));
+	}
+}
+
+bool RowGroup::InitializeScanWithOffset(RowGroupScanState &state, idx_t vector_offset) {
+	auto &column_ids = state.parent.column_ids;
+	if (state.parent.table_filters) {
+		if (!CheckZonemap(*state.parent.table_filters, column_ids)) {
+			return false;
+		}
+	}
+
+	state.row_group = this;
+	state.vector_index = vector_offset;
+	state.max_row =
+	    this->start > state.parent.max_row ? 0 : MinValue<idx_t>(this->count, state.parent.max_row - this->start);
+	state.column_scans = unique_ptr<ColumnScanState[]>(new ColumnScanState[column_ids.size()]);
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		auto column = column_ids[i];
+		if (column != COLUMN_IDENTIFIER_ROW_ID) {
+			columns[column]->InitializeScanWithOffset(state.column_scans[i],
+			                                          start + vector_offset * STANDARD_VECTOR_SIZE);
+		} else {
+			state.column_scans[i].current = nullptr;
+		}
+	}
+	return true;
+}
+
+bool RowGroup::InitializeScan(RowGroupScanState &state) {
+	auto &column_ids = state.parent.column_ids;
+	if (state.parent.table_filters) {
+		if (!CheckZonemap(*state.parent.table_filters, column_ids)) {
+			return false;
+		}
+	}
+	state.row_group = this;
+	state.vector_index = 0;
+	state.max_row =
+	    this->start > state.parent.max_row ? 0 : MinValue<idx_t>(this->count, state.parent.max_row - this->start);
+	state.column_scans = unique_ptr<ColumnScanState[]>(new ColumnScanState[column_ids.size()]);
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		auto column = column_ids[i];
+		if (column != COLUMN_IDENTIFIER_ROW_ID) {
+			columns[column]->InitializeScan(state.column_scans[i]);
+		} else {
+			state.column_scans[i].current = nullptr;
+		}
+	}
+	return true;
+}
+
+unique_ptr<RowGroup> RowGroup::AlterType(ClientContext &context, const LogicalType &target_type, idx_t changed_idx,
+                                         ExpressionExecutor &executor, TableScanState &scan_state,
+                                         DataChunk &scan_chunk) {
+	Verify();
+
+	// construct a new column data for this type
+	auto column_data = ColumnData::CreateColumn(GetTableInfo(), changed_idx, start, target_type);
+
+	ColumnAppendState append_state;
+	column_data->InitializeAppend(append_state);
+
+	// scan the original table, and fill the new column with the transformed value
+	InitializeScan(scan_state.row_group_scan_state);
+
+	Vector append_vector(target_type);
+	auto altered_col_stats = make_shared<SegmentStatistics>(target_type);
+	while (true) {
+		// scan the table
+		scan_chunk.Reset();
+		ScanCommitted(scan_state.row_group_scan_state, scan_chunk, TableScanType::TABLE_SCAN_COMMITTED_ROWS);
+		if (scan_chunk.size() == 0) {
+			break;
+		}
+		// execute the expression
+		executor.ExecuteExpression(scan_chunk, append_vector);
+		column_data->Append(*altered_col_stats->statistics, append_state, append_vector, scan_chunk.size());
+	}
+
+	// set up the row_group based on this row_group
+	auto row_group = make_unique<RowGroup>(db, table_info, this->start, this->count);
+	row_group->version_info = version_info;
+	for (idx_t i = 0; i < columns.size(); i++) {
+		if (i == changed_idx) {
+			// this is the altered column: use the new column
+			row_group->columns.push_back(move(column_data));
+			row_group->stats.push_back(move(altered_col_stats));
+		} else {
+			// this column was not altered: use the data directly
+			row_group->columns.push_back(columns[i]);
+			row_group->stats.push_back(stats[i]);
+		}
+	}
+	row_group->Verify();
+	return row_group;
+}
+
+unique_ptr<RowGroup> RowGroup::AddColumn(ClientContext &context, ColumnDefinition &new_column,
+                                         ExpressionExecutor &executor, Expression *default_value, Vector &result) {
+	Verify();
+
+	// construct a new column data for the new column
+	auto added_column = ColumnData::CreateColumn(GetTableInfo(), columns.size(), start, new_column.Type());
+	auto added_col_stats = make_shared<SegmentStatistics>(
+	    new_column.Type(), BaseStatistics::CreateEmpty(new_column.Type(), StatisticsType::LOCAL_STATS));
+
+	idx_t rows_to_write = this->count;
+	if (rows_to_write > 0) {
+		DataChunk dummy_chunk;
+
+		ColumnAppendState state;
+		added_column->InitializeAppend(state);
+		for (idx_t i = 0; i < rows_to_write; i += STANDARD_VECTOR_SIZE) {
+			idx_t rows_in_this_vector = MinValue<idx_t>(rows_to_write - i, STANDARD_VECTOR_SIZE);
+			if (default_value) {
+				dummy_chunk.SetCardinality(rows_in_this_vector);
+				executor.ExecuteExpression(dummy_chunk, result);
+			}
+			added_column->Append(*added_col_stats->statistics, state, result, rows_in_this_vector);
+		}
+	}
+
+	// set up the row_group based on this row_group
+	auto row_group = make_unique<RowGroup>(db, table_info, this->start, this->count);
+	row_group->version_info = version_info;
+	row_group->columns = columns;
+	row_group->stats = stats;
+	// now add the new column
+	row_group->columns.push_back(move(added_column));
+	row_group->stats.push_back(move(added_col_stats));
+
+	row_group->Verify();
+	return row_group;
+}
+
+unique_ptr<RowGroup> RowGroup::RemoveColumn(idx_t removed_column) {
+	Verify();
+
+	D_ASSERT(removed_column < columns.size());
+
+	auto row_group = make_unique<RowGroup>(db, table_info, this->start, this->count);
+	row_group->version_info = version_info;
+	row_group->columns = columns;
+	row_group->stats = stats;
+	// now remove the column
+	row_group->columns.erase(row_group->columns.begin() + removed_column);
+	row_group->stats.erase(row_group->stats.begin() + removed_column);
+
+	row_group->Verify();
+	return row_group;
+}
+
+void RowGroup::CommitDrop() {
+	for (idx_t column_idx = 0; column_idx < columns.size(); column_idx++) {
+		CommitDropColumn(column_idx);
+	}
+}
+
+void RowGroup::CommitDropColumn(idx_t column_idx) {
+	D_ASSERT(column_idx < columns.size());
+	columns[column_idx]->CommitDropColumn();
+}
+
+void RowGroup::NextVector(RowGroupScanState &state) {
+	state.vector_index++;
+	for (idx_t i = 0; i < state.parent.column_ids.size(); i++) {
+		auto column = state.parent.column_ids[i];
+		if (column == COLUMN_IDENTIFIER_ROW_ID) {
+			continue;
+		}
+		D_ASSERT(column < columns.size());
+		columns[column]->Skip(state.column_scans[i]);
+	}
+}
+
+bool RowGroup::CheckZonemap(TableFilterSet &filters, const vector<column_t> &column_ids) {
+	for (auto &entry : filters.filters) {
+		auto column_index = entry.first;
+		auto &filter = entry.second;
+		auto base_column_index = column_ids[column_index];
+
+		auto propagate_result = filter->CheckStatistics(*stats[base_column_index]->statistics);
+		if (propagate_result == FilterPropagateResult::FILTER_ALWAYS_FALSE ||
+		    propagate_result == FilterPropagateResult::FILTER_FALSE_OR_NULL) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool RowGroup::CheckZonemapSegments(RowGroupScanState &state) {
+	if (!state.parent.table_filters) {
+		return true;
+	}
+	auto &column_ids = state.parent.column_ids;
+	for (auto &entry : state.parent.table_filters->filters) {
+		D_ASSERT(entry.first < column_ids.size());
+		auto column_idx = entry.first;
+		auto base_column_idx = column_ids[column_idx];
+		bool read_segment = columns[base_column_idx]->CheckZonemap(state.column_scans[column_idx], *entry.second);
+		if (!read_segment) {
+			idx_t target_row =
+			    state.column_scans[column_idx].current->start + state.column_scans[column_idx].current->count;
+			D_ASSERT(target_row >= this->start);
+			D_ASSERT(target_row <= this->start + this->count);
+			idx_t target_vector_index = (target_row - this->start) / STANDARD_VECTOR_SIZE;
+			if (state.vector_index == target_vector_index) {
+				// we can't skip any full vectors because this segment contains less than a full vector
+				// for now we just bail-out
+				// FIXME: we could check if we can ALSO skip the next segments, in which case skipping a full vector
+				// might be possible
+				// we don't care that much though, since a single segment that fits less than a full vector is
+				// exceedingly rare
+				return true;
+			}
+			while (state.vector_index < target_vector_index) {
+				NextVector(state);
+			}
+			return false;
+		}
+	}
+
+	return true;
+}
+
+template <TableScanType TYPE>
+void RowGroup::TemplatedScan(Transaction *transaction, RowGroupScanState &state, DataChunk &result) {
+	const bool ALLOW_UPDATES = TYPE != TableScanType::TABLE_SCAN_COMMITTED_ROWS_DISALLOW_UPDATES &&
+	                           TYPE != TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED;
+	auto &table_filters = state.parent.table_filters;
+	auto &column_ids = state.parent.column_ids;
+	auto &adaptive_filter = state.parent.adaptive_filter;
+	while (true) {
+		if (state.vector_index * STANDARD_VECTOR_SIZE >= state.max_row) {
+			// exceeded the amount of rows to scan
+			return;
+		}
+		idx_t current_row = state.vector_index * STANDARD_VECTOR_SIZE;
+		auto max_count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, state.max_row - current_row);
+
+		//! first check the zonemap if we have to scan this partition
+		if (!CheckZonemapSegments(state)) {
+			continue;
+		}
+		// second, scan the version chunk manager to figure out which tuples to load for this transaction
+		idx_t count;
+		SelectionVector valid_sel(STANDARD_VECTOR_SIZE);
+		if (TYPE == TableScanType::TABLE_SCAN_REGULAR) {
+			D_ASSERT(transaction);
+			count = state.row_group->GetSelVector(*transaction, state.vector_index, valid_sel, max_count);
+			if (count == 0) {
+				// nothing to scan for this vector, skip the entire vector
+				NextVector(state);
+				continue;
+			}
+		} else if (TYPE == TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED) {
+			auto &transaction_manager = TransactionManager::Get(db);
+			auto lowest_active_start = transaction_manager.LowestActiveStart();
+			auto lowest_active_id = transaction_manager.LowestActiveId();
+
+			count = state.row_group->GetCommittedSelVector(lowest_active_start, lowest_active_id, state.vector_index,
+			                                               valid_sel, max_count);
+			if (count == 0) {
+				// nothing to scan for this vector, skip the entire vector
+				NextVector(state);
+				continue;
+			}
+		} else {
+			count = max_count;
+		}
+		if (count == max_count && !table_filters) {
+			// scan all vectors completely: full scan without deletions or table filters
+			for (idx_t i = 0; i < column_ids.size(); i++) {
+				auto column = column_ids[i];
+				if (column == COLUMN_IDENTIFIER_ROW_ID) {
+					// scan row id
+					D_ASSERT(result.data[i].GetType().InternalType() == ROW_TYPE);
+					result.data[i].Sequence(this->start + current_row, 1);
+				} else {
+					if (TYPE != TableScanType::TABLE_SCAN_REGULAR) {
+						columns[column]->ScanCommitted(state.vector_index, state.column_scans[i], result.data[i],
+						                               ALLOW_UPDATES);
+					} else {
+						D_ASSERT(transaction);
+						columns[column]->Scan(*transaction, state.vector_index, state.column_scans[i], result.data[i]);
+					}
+				}
+			}
+		} else {
+			// partial scan: we have deletions or table filters
+			idx_t approved_tuple_count = count;
+			SelectionVector sel;
+			if (count != max_count) {
+				sel.Initialize(valid_sel);
+			} else {
+				sel.Initialize(nullptr);
+			}
+			//! first, we scan the columns with filters, fetch their data and generate a selection vector.
+			//! get runtime statistics
+			auto start_time = high_resolution_clock::now();
+			if (table_filters) {
+				D_ASSERT(ALLOW_UPDATES);
+				for (idx_t i = 0; i < table_filters->filters.size(); i++) {
+					auto tf_idx = adaptive_filter->permutation[i];
+					auto col_idx = column_ids[tf_idx];
+					columns[col_idx]->Select(*transaction, state.vector_index, state.column_scans[tf_idx],
+					                         result.data[tf_idx], sel, approved_tuple_count,
+					                         *table_filters->filters[tf_idx]);
+				}
+				for (auto &table_filter : table_filters->filters) {
+					result.data[table_filter.first].Slice(sel, approved_tuple_count);
+				}
+			}
+			if (approved_tuple_count == 0) {
+				// all rows were filtered out by the table filters
+				// skip this vector in all the scans that were not scanned yet
+				D_ASSERT(table_filters);
+				result.Reset();
+				for (idx_t i = 0; i < column_ids.size(); i++) {
+					auto col_idx = column_ids[i];
+					if (col_idx == COLUMN_IDENTIFIER_ROW_ID) {
+						continue;
+					}
+					if (table_filters->filters.find(i) == table_filters->filters.end()) {
+						columns[col_idx]->Skip(state.column_scans[i]);
+					}
+				}
+				state.vector_index++;
+				continue;
+			}
+			//! Now we use the selection vector to fetch data for the other columns.
+			for (idx_t i = 0; i < column_ids.size(); i++) {
+				if (!table_filters || table_filters->filters.find(i) == table_filters->filters.end()) {
+					auto column = column_ids[i];
+					if (column == COLUMN_IDENTIFIER_ROW_ID) {
+						D_ASSERT(result.data[i].GetType().InternalType() == PhysicalType::INT64);
+						result.data[i].SetVectorType(VectorType::FLAT_VECTOR);
+						auto result_data = (int64_t *)FlatVector::GetData(result.data[i]);
+						for (size_t sel_idx = 0; sel_idx < approved_tuple_count; sel_idx++) {
+							result_data[sel_idx] = this->start + current_row + sel.get_index(sel_idx);
+						}
+					} else {
+						if (TYPE == TableScanType::TABLE_SCAN_REGULAR) {
+							D_ASSERT(transaction);
+							columns[column]->FilterScan(*transaction, state.vector_index, state.column_scans[i],
+							                            result.data[i], sel, approved_tuple_count);
+						} else {
+							D_ASSERT(!transaction);
+							columns[column]->FilterScanCommitted(state.vector_index, state.column_scans[i],
+							                                     result.data[i], sel, approved_tuple_count,
+							                                     ALLOW_UPDATES);
+						}
+					}
+				}
+			}
+			auto end_time = high_resolution_clock::now();
+			if (adaptive_filter && table_filters->filters.size() > 1) {
+				adaptive_filter->AdaptRuntimeStatistics(duration_cast<duration<double>>(end_time - start_time).count());
+			}
+			D_ASSERT(approved_tuple_count > 0);
+			count = approved_tuple_count;
+		}
+		result.SetCardinality(count);
+		state.vector_index++;
+		break;
+	}
+}
+
+void RowGroup::Scan(Transaction &transaction, RowGroupScanState &state, DataChunk &result) {
+	TemplatedScan<TableScanType::TABLE_SCAN_REGULAR>(&transaction, state, result);
+}
+
+void RowGroup::ScanCommitted(RowGroupScanState &state, DataChunk &result, TableScanType type) {
+	switch (type) {
+	case TableScanType::TABLE_SCAN_COMMITTED_ROWS:
+		TemplatedScan<TableScanType::TABLE_SCAN_COMMITTED_ROWS>(nullptr, state, result);
+		break;
+	case TableScanType::TABLE_SCAN_COMMITTED_ROWS_DISALLOW_UPDATES:
+		TemplatedScan<TableScanType::TABLE_SCAN_COMMITTED_ROWS_DISALLOW_UPDATES>(nullptr, state, result);
+		break;
+	case TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED:
+		TemplatedScan<TableScanType::TABLE_SCAN_COMMITTED_ROWS_OMIT_PERMANENTLY_DELETED>(nullptr, state, result);
+		break;
+	default:
+		throw InternalException("Unrecognized table scan type");
+	}
+}
+
+ChunkInfo *RowGroup::GetChunkInfo(idx_t vector_idx) {
+	if (!version_info) {
+		return nullptr;
+	}
+	return version_info->info[vector_idx].get();
+}
+
+idx_t RowGroup::GetSelVector(Transaction &transaction, idx_t vector_idx, SelectionVector &sel_vector, idx_t max_count) {
+	lock_guard<mutex> lock(row_group_lock);
+
+	auto info = GetChunkInfo(vector_idx);
+	if (!info) {
+		return max_count;
+	}
+	return info->GetSelVector(transaction, sel_vector, max_count);
+}
+
+idx_t RowGroup::GetCommittedSelVector(transaction_t start_time, transaction_t transaction_id, idx_t vector_idx,
+                                      SelectionVector &sel_vector, idx_t max_count) {
+	lock_guard<mutex> lock(row_group_lock);
+
+	auto info = GetChunkInfo(vector_idx);
+	if (!info) {
+		return max_count;
+	}
+	return info->GetCommittedSelVector(start_time, transaction_id, sel_vector, max_count);
+}
+
+bool RowGroup::Fetch(Transaction &transaction, idx_t row) {
+	D_ASSERT(row < this->count);
+	lock_guard<mutex> lock(row_group_lock);
+
+	idx_t vector_index = row / STANDARD_VECTOR_SIZE;
+	auto info = GetChunkInfo(vector_index);
+	if (!info) {
+		return true;
+	}
+	return info->Fetch(transaction, row - vector_index * STANDARD_VECTOR_SIZE);
+}
+
+void RowGroup::FetchRow(Transaction &transaction, ColumnFetchState &state, const vector<column_t> &column_ids,
+                        row_t row_id, DataChunk &result, idx_t result_idx) {
+	for (idx_t col_idx = 0; col_idx < column_ids.size(); col_idx++) {
+		auto column = column_ids[col_idx];
+		if (column == COLUMN_IDENTIFIER_ROW_ID) {
+			// row id column: fill in the row ids
+			D_ASSERT(result.data[col_idx].GetType().InternalType() == PhysicalType::INT64);
+			result.data[col_idx].SetVectorType(VectorType::FLAT_VECTOR);
+			auto data = FlatVector::GetData<row_t>(result.data[col_idx]);
+			data[result_idx] = row_id;
+		} else {
+			// regular column: fetch data from the base column
+			columns[column]->FetchRow(transaction, state, row_id, result.data[col_idx], result_idx);
+		}
+	}
+}
+
+void RowGroup::AppendVersionInfo(Transaction &transaction, idx_t row_group_start, idx_t count,
+                                 transaction_t commit_id) {
+	idx_t row_group_end = row_group_start + count;
+	lock_guard<mutex> lock(row_group_lock);
+
+	this->count += count;
+	D_ASSERT(this->count <= RowGroup::ROW_GROUP_SIZE);
+
+	// create the version_info if it doesn't exist yet
+	if (!version_info) {
+		version_info = make_unique<VersionNode>();
+	}
+	idx_t start_vector_idx = row_group_start / STANDARD_VECTOR_SIZE;
+	idx_t end_vector_idx = (row_group_end - 1) / STANDARD_VECTOR_SIZE;
+	for (idx_t vector_idx = start_vector_idx; vector_idx <= end_vector_idx; vector_idx++) {
+		idx_t start = vector_idx == start_vector_idx ? row_group_start - start_vector_idx * STANDARD_VECTOR_SIZE : 0;
+		idx_t end =
+		    vector_idx == end_vector_idx ? row_group_end - end_vector_idx * STANDARD_VECTOR_SIZE : STANDARD_VECTOR_SIZE;
+		if (start == 0 && end == STANDARD_VECTOR_SIZE) {
+			// entire vector is encapsulated by append: append a single constant
+			auto constant_info = make_unique<ChunkConstantInfo>(this->start + vector_idx * STANDARD_VECTOR_SIZE);
+			constant_info->insert_id = commit_id;
+			constant_info->delete_id = NOT_DELETED_ID;
+			version_info->info[vector_idx] = move(constant_info);
+		} else {
+			// part of a vector is encapsulated: append to that part
+			ChunkVectorInfo *info;
+			if (!version_info->info[vector_idx]) {
+				// first time appending to this vector: create new info
+				auto insert_info = make_unique<ChunkVectorInfo>(this->start + vector_idx * STANDARD_VECTOR_SIZE);
+				info = insert_info.get();
+				version_info->info[vector_idx] = move(insert_info);
+			} else {
+				D_ASSERT(version_info->info[vector_idx]->type == ChunkInfoType::VECTOR_INFO);
+				// use existing vector
+				info = (ChunkVectorInfo *)version_info->info[vector_idx].get();
+			}
+			info->Append(start, end, commit_id);
+		}
+	}
+}
+
+void RowGroup::CommitAppend(transaction_t commit_id, idx_t row_group_start, idx_t count) {
+	D_ASSERT(version_info.get());
+	idx_t row_group_end = row_group_start + count;
+	lock_guard<mutex> lock(row_group_lock);
+
+	idx_t start_vector_idx = row_group_start / STANDARD_VECTOR_SIZE;
+	idx_t end_vector_idx = (row_group_end - 1) / STANDARD_VECTOR_SIZE;
+	for (idx_t vector_idx = start_vector_idx; vector_idx <= end_vector_idx; vector_idx++) {
+		idx_t start = vector_idx == start_vector_idx ? row_group_start - start_vector_idx * STANDARD_VECTOR_SIZE : 0;
+		idx_t end =
+		    vector_idx == end_vector_idx ? row_group_end - end_vector_idx * STANDARD_VECTOR_SIZE : STANDARD_VECTOR_SIZE;
+
+		auto info = version_info->info[vector_idx].get();
+		info->CommitAppend(commit_id, start, end);
+	}
+}
+
+void RowGroup::RevertAppend(idx_t row_group_start) {
+	if (!version_info) {
+		return;
+	}
+	idx_t start_row = row_group_start - this->start;
+	idx_t start_vector_idx = (start_row + (STANDARD_VECTOR_SIZE - 1)) / STANDARD_VECTOR_SIZE;
+	for (idx_t vector_idx = start_vector_idx; vector_idx < RowGroup::ROW_GROUP_VECTOR_COUNT; vector_idx++) {
+		version_info->info[vector_idx].reset();
+	}
+	for (auto &column : columns) {
+		column->RevertAppend(row_group_start);
+	}
+	this->count = MinValue<idx_t>(row_group_start - this->start, this->count);
+	Verify();
+}
+
+void RowGroup::InitializeAppend(Transaction &transaction, RowGroupAppendState &append_state,
+                                idx_t remaining_append_count) {
+	append_state.row_group = this;
+	append_state.offset_in_row_group = this->count;
+	// for each column, initialize the append state
+	append_state.states = unique_ptr<ColumnAppendState[]>(new ColumnAppendState[columns.size()]);
+	for (idx_t i = 0; i < columns.size(); i++) {
+		columns[i]->InitializeAppend(append_state.states[i]);
+	}
+	// append the version info for this row_group
+	idx_t append_count = MinValue<idx_t>(remaining_append_count, RowGroup::ROW_GROUP_SIZE - this->count);
+	AppendVersionInfo(transaction, this->count, append_count, transaction.transaction_id);
+}
+
+void RowGroup::Append(RowGroupAppendState &state, DataChunk &chunk, idx_t append_count) {
+	// append to the current row_group
+	for (idx_t i = 0; i < columns.size(); i++) {
+		columns[i]->Append(*stats[i]->statistics, state.states[i], chunk.data[i], append_count);
+	}
+	state.offset_in_row_group += append_count;
+}
+
+void RowGroup::Update(Transaction &transaction, DataChunk &update_chunk, row_t *ids, idx_t offset, idx_t count,
+                      const vector<column_t> &column_ids) {
+#ifdef DEBUG
+	for (size_t i = offset; i < offset + count; i++) {
+		D_ASSERT(ids[i] >= row_t(this->start) && ids[i] < row_t(this->start + this->count));
+	}
+#endif
+	for (idx_t i = 0; i < column_ids.size(); i++) {
+		auto column = column_ids[i];
+		D_ASSERT(column != COLUMN_IDENTIFIER_ROW_ID);
+		D_ASSERT(columns[column]->type.id() == update_chunk.data[i].GetType().id());
+		if (offset > 0) {
+			Vector sliced_vector(update_chunk.data[i], offset);
+			sliced_vector.Normalify(count);
+			columns[column]->Update(transaction, column, sliced_vector, ids + offset, count);
+		} else {
+			columns[column]->Update(transaction, column, update_chunk.data[i], ids, count);
+		}
+		MergeStatistics(column, *columns[column]->GetUpdateStatistics());
+	}
+}
+
+void RowGroup::UpdateColumn(Transaction &transaction, DataChunk &updates, Vector &row_ids,
+                            const vector<column_t> &column_path) {
+	D_ASSERT(updates.ColumnCount() == 1);
+	auto ids = FlatVector::GetData<row_t>(row_ids);
+
+	auto primary_column_idx = column_path[0];
+	D_ASSERT(primary_column_idx != COLUMN_IDENTIFIER_ROW_ID);
+	D_ASSERT(primary_column_idx < columns.size());
+	columns[primary_column_idx]->UpdateColumn(transaction, column_path, updates.data[0], ids, updates.size(), 1);
+	MergeStatistics(primary_column_idx, *columns[primary_column_idx]->GetUpdateStatistics());
+}
+
+unique_ptr<BaseStatistics> RowGroup::GetStatistics(idx_t column_idx) {
+	D_ASSERT(column_idx < stats.size());
+
+	lock_guard<mutex> slock(stats_lock);
+	return stats[column_idx]->statistics->Copy();
+}
+
+void RowGroup::MergeStatistics(idx_t column_idx, BaseStatistics &other) {
+	D_ASSERT(column_idx < stats.size());
+
+	lock_guard<mutex> slock(stats_lock);
+	stats[column_idx]->statistics->Merge(other);
+}
+
+RowGroupPointer RowGroup::Checkpoint(TableDataWriter &writer, vector<unique_ptr<BaseStatistics>> &global_stats) {
+	vector<unique_ptr<ColumnCheckpointState>> states;
+	states.reserve(columns.size());
+
+	// checkpoint the individual columns of the row group
+	for (idx_t column_idx = 0; column_idx < columns.size(); column_idx++) {
+		auto &column = columns[column_idx];
+		ColumnCheckpointInfo checkpoint_info {writer.GetColumnCompressionType(column_idx)};
+		auto checkpoint_state = column->Checkpoint(*this, writer, checkpoint_info);
+		D_ASSERT(checkpoint_state);
+
+		auto stats = checkpoint_state->GetStatistics();
+		D_ASSERT(stats);
+
+		global_stats[column_idx]->Merge(*stats);
+		states.push_back(move(checkpoint_state));
+	}
+
+	// construct the row group pointer and write the column meta data to disk
+	D_ASSERT(states.size() == columns.size());
+	RowGroupPointer row_group_pointer;
+	row_group_pointer.row_start = start;
+	row_group_pointer.tuple_count = count;
+	for (auto &state : states) {
+		// get the current position of the meta data writer
+		auto &meta_writer = writer.GetMetaWriter();
+		auto pointer = meta_writer.GetBlockPointer();
+
+		// store the stats and the data pointers in the row group pointers
+		row_group_pointer.data_pointers.push_back(pointer);
+		row_group_pointer.statistics.push_back(state->GetStatistics());
+
+		// now flush the actual column data to disk
+		state->FlushToDisk();
+	}
+	row_group_pointer.versions = version_info;
+	Verify();
+	return row_group_pointer;
+}
+
+void RowGroup::CheckpointDeletes(VersionNode *versions, Serializer &serializer) {
+	if (!versions) {
+		// no version information: write nothing
+		serializer.Write<idx_t>(0);
+		return;
+	}
+	// first count how many ChunkInfo's we need to deserialize
+	idx_t chunk_info_count = 0;
+	for (idx_t vector_idx = 0; vector_idx < RowGroup::ROW_GROUP_VECTOR_COUNT; vector_idx++) {
+		auto chunk_info = versions->info[vector_idx].get();
+		if (!chunk_info) {
+			continue;
+		}
+		chunk_info_count++;
+	}
+	// now serialize the actual version information
+	serializer.Write<idx_t>(chunk_info_count);
+	for (idx_t vector_idx = 0; vector_idx < RowGroup::ROW_GROUP_VECTOR_COUNT; vector_idx++) {
+		auto chunk_info = versions->info[vector_idx].get();
+		if (!chunk_info) {
+			continue;
+		}
+		serializer.Write<idx_t>(vector_idx);
+		chunk_info->Serialize(serializer);
+	}
+}
+
+shared_ptr<VersionNode> RowGroup::DeserializeDeletes(Deserializer &source) {
+	auto chunk_count = source.Read<idx_t>();
+	if (chunk_count == 0) {
+		// no deletes
+		return nullptr;
+	}
+	auto version_info = make_shared<VersionNode>();
+	for (idx_t i = 0; i < chunk_count; i++) {
+		idx_t vector_index = source.Read<idx_t>();
+		if (vector_index >= RowGroup::ROW_GROUP_VECTOR_COUNT) {
+			throw Exception("In DeserializeDeletes, vector_index is out of range for the row group. Corrupted file?");
+		}
+		version_info->info[vector_index] = ChunkInfo::Deserialize(source);
+	}
+	return version_info;
+}
+
+void RowGroup::Serialize(RowGroupPointer &pointer, Serializer &main_serializer) {
+	FieldWriter writer(main_serializer);
+	writer.WriteField<uint64_t>(pointer.row_start);
+	writer.WriteField<uint64_t>(pointer.tuple_count);
+	auto &serializer = writer.GetSerializer();
+	for (auto &stats : pointer.statistics) {
+		stats->Serialize(serializer);
+	}
+	for (auto &data_pointer : pointer.data_pointers) {
+		serializer.Write<block_id_t>(data_pointer.block_id);
+		serializer.Write<uint64_t>(data_pointer.offset);
+	}
+	CheckpointDeletes(pointer.versions.get(), serializer);
+	writer.Finalize();
+}
+
+RowGroupPointer RowGroup::Deserialize(Deserializer &main_source, const vector<ColumnDefinition> &columns) {
+	RowGroupPointer result;
+
+	FieldReader reader(main_source);
+	result.row_start = reader.ReadRequired<uint64_t>();
+	result.tuple_count = reader.ReadRequired<uint64_t>();
+
+	result.data_pointers.reserve(columns.size());
+	result.statistics.reserve(columns.size());
+
+	auto &source = reader.GetSource();
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto &col = columns[i];
+		if (col.Generated()) {
+			continue;
+		}
+		auto stats = BaseStatistics::Deserialize(source, columns[i].Type());
+		result.statistics.push_back(move(stats));
+	}
+	for (idx_t i = 0; i < columns.size(); i++) {
+		auto &col = columns[i];
+		if (col.Generated()) {
+			continue;
+		}
+		BlockPointer pointer;
+		pointer.block_id = source.Read<block_id_t>();
+		pointer.offset = source.Read<uint64_t>();
+		result.data_pointers.push_back(pointer);
+	}
+	result.versions = DeserializeDeletes(source);
+
+	reader.Finalize();
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// GetStorageInfo
+//===--------------------------------------------------------------------===//
+void RowGroup::GetStorageInfo(idx_t row_group_index, vector<vector<Value>> &result) {
+	for (idx_t col_idx = 0; col_idx < columns.size(); col_idx++) {
+		columns[col_idx]->GetStorageInfo(row_group_index, {col_idx}, result);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Version Delete Information
+//===--------------------------------------------------------------------===//
+class VersionDeleteState {
+public:
+	VersionDeleteState(RowGroup &info, Transaction &transaction, DataTable *table, idx_t base_row)
+	    : info(info), transaction(transaction), table(table), current_info(nullptr),
+	      current_chunk(DConstants::INVALID_INDEX), count(0), base_row(base_row), delete_count(0) {
+	}
+
+	RowGroup &info;
+	Transaction &transaction;
+	DataTable *table;
+	ChunkVectorInfo *current_info;
+	idx_t current_chunk;
+	row_t rows[STANDARD_VECTOR_SIZE];
+	idx_t count;
+	idx_t base_row;
+	idx_t chunk_row;
+	idx_t delete_count;
+
+public:
+	void Delete(row_t row_id);
+	void Flush();
+};
+
+idx_t RowGroup::Delete(Transaction &transaction, DataTable *table, row_t *ids, idx_t count) {
+	lock_guard<mutex> lock(row_group_lock);
+	VersionDeleteState del_state(*this, transaction, table, this->start);
+
+	// obtain a write lock
+	for (idx_t i = 0; i < count; i++) {
+		D_ASSERT(ids[i] >= 0);
+		D_ASSERT(idx_t(ids[i]) >= this->start && idx_t(ids[i]) < this->start + this->count);
+		del_state.Delete(ids[i] - this->start);
+	}
+	del_state.Flush();
+	return del_state.delete_count;
+}
+
+void RowGroup::Verify() {
+#ifdef DEBUG
+	for (auto &column : columns) {
+		column->Verify(*this);
+	}
+#endif
+}
+
+void VersionDeleteState::Delete(row_t row_id) {
+	D_ASSERT(row_id >= 0);
+	idx_t vector_idx = row_id / STANDARD_VECTOR_SIZE;
+	idx_t idx_in_vector = row_id - vector_idx * STANDARD_VECTOR_SIZE;
+	if (current_chunk != vector_idx) {
+		Flush();
+
+		if (!info.version_info) {
+			info.version_info = make_unique<VersionNode>();
+		}
+
+		if (!info.version_info->info[vector_idx]) {
+			// no info yet: create it
+			info.version_info->info[vector_idx] =
+			    make_unique<ChunkVectorInfo>(info.start + vector_idx * STANDARD_VECTOR_SIZE);
+		} else if (info.version_info->info[vector_idx]->type == ChunkInfoType::CONSTANT_INFO) {
+			auto &constant = (ChunkConstantInfo &)*info.version_info->info[vector_idx];
+			// info exists but it's a constant info: convert to a vector info
+			auto new_info = make_unique<ChunkVectorInfo>(info.start + vector_idx * STANDARD_VECTOR_SIZE);
+			new_info->insert_id = constant.insert_id.load();
+			for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+				new_info->inserted[i] = constant.insert_id.load();
+			}
+			info.version_info->info[vector_idx] = move(new_info);
+		}
+		D_ASSERT(info.version_info->info[vector_idx]->type == ChunkInfoType::VECTOR_INFO);
+		current_info = (ChunkVectorInfo *)info.version_info->info[vector_idx].get();
+		current_chunk = vector_idx;
+		chunk_row = vector_idx * STANDARD_VECTOR_SIZE;
+	}
+	rows[count++] = idx_in_vector;
+}
+
+void VersionDeleteState::Flush() {
+	if (count == 0) {
+		return;
+	}
+	// delete in the current info
+	delete_count += current_info->Delete(transaction, rows, count);
+	// now push the delete into the undo buffer
+	transaction.PushDelete(table, current_info, rows, count, base_row + chunk_row);
+	count = 0;
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+SegmentBase *SegmentTree::GetRootSegment() {
+	return root_node.get();
+}
+
+SegmentBase *SegmentTree::GetLastSegment() {
+	return nodes.empty() ? nullptr : nodes.back().node;
+}
+
+SegmentBase *SegmentTree::GetSegment(idx_t row_number) {
+	lock_guard<mutex> tree_lock(node_lock);
+	return nodes[GetSegmentIndex(row_number)].node;
+}
+
+idx_t SegmentTree::GetSegmentIndex(idx_t row_number) {
+	D_ASSERT(!nodes.empty());
+	D_ASSERT(row_number >= nodes[0].row_start);
+	D_ASSERT(row_number < nodes.back().row_start + nodes.back().node->count);
+	idx_t lower = 0;
+	idx_t upper = nodes.size() - 1;
+	// binary search to find the node
+	while (lower <= upper) {
+		idx_t index = (lower + upper) / 2;
+		D_ASSERT(index < nodes.size());
+		auto &entry = nodes[index];
+		D_ASSERT(entry.row_start == entry.node->start);
+		if (row_number < entry.row_start) {
+			upper = index - 1;
+		} else if (row_number >= entry.row_start + entry.node->count) {
+			lower = index + 1;
+		} else {
+			return index;
+		}
+	}
+	throw InternalException("Could not find node in column segment tree!");
+}
+
+void SegmentTree::AppendSegment(unique_ptr<SegmentBase> segment) {
+	D_ASSERT(segment);
+	// add the node to the list of nodes
+	SegmentNode node;
+	node.row_start = segment->start;
+	node.node = segment.get();
+	nodes.push_back(node);
+
+	if (nodes.size() > 1) {
+		// add the node as the next pointer of the last node
+		D_ASSERT(!nodes[nodes.size() - 2].node->next);
+		nodes[nodes.size() - 2].node->next = move(segment);
+	} else {
+		root_node = move(segment);
+	}
+}
+
+void SegmentTree::Replace(SegmentTree &other) {
+	root_node = move(other.root_node);
+	nodes = move(other.nodes);
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+namespace duckdb {
+
+StandardColumnData::StandardColumnData(DataTableInfo &info, idx_t column_index, idx_t start_row, LogicalType type,
+                                       ColumnData *parent)
+    : ColumnData(info, column_index, start_row, move(type), parent), validity(info, 0, start_row, this) {
+}
+
+bool StandardColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
+	if (!state.segment_checked) {
+		if (!state.current) {
+			return true;
+		}
+		state.segment_checked = true;
+		auto prune_result = filter.CheckStatistics(*state.current->stats.statistics);
+		if (prune_result != FilterPropagateResult::FILTER_ALWAYS_FALSE) {
+			return true;
+		}
+		if (updates) {
+			auto update_stats = updates->GetStatistics();
+			prune_result = filter.CheckStatistics(*update_stats);
+			return prune_result != FilterPropagateResult::FILTER_ALWAYS_FALSE;
+		} else {
+			return false;
+		}
+	} else {
+		return true;
+	}
+}
+
+void StandardColumnData::InitializeScan(ColumnScanState &state) {
+	ColumnData::InitializeScan(state);
+
+	// initialize the validity segment
+	ColumnScanState child_state;
+	validity.InitializeScan(child_state);
+	state.child_states.push_back(move(child_state));
+}
+
+void StandardColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) {
+	ColumnData::InitializeScanWithOffset(state, row_idx);
+
+	// initialize the validity segment
+	ColumnScanState child_state;
+	validity.InitializeScanWithOffset(child_state, row_idx);
+	state.child_states.push_back(move(child_state));
+}
+
+idx_t StandardColumnData::Scan(Transaction &transaction, idx_t vector_index, ColumnScanState &state, Vector &result) {
+	D_ASSERT(state.row_index == state.child_states[0].row_index);
+	auto scan_count = ColumnData::Scan(transaction, vector_index, state, result);
+	validity.Scan(transaction, vector_index, state.child_states[0], result);
+	return scan_count;
+}
+
+idx_t StandardColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result,
+                                        bool allow_updates) {
+	D_ASSERT(state.row_index == state.child_states[0].row_index);
+	auto scan_count = ColumnData::ScanCommitted(vector_index, state, result, allow_updates);
+	validity.ScanCommitted(vector_index, state.child_states[0], result, allow_updates);
+	return scan_count;
+}
+
+idx_t StandardColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count) {
+	auto scan_count = ColumnData::ScanCount(state, result, count);
+	validity.ScanCount(state.child_states[0], result, count);
+	return scan_count;
+}
+
+void StandardColumnData::InitializeAppend(ColumnAppendState &state) {
+	ColumnData::InitializeAppend(state);
+
+	ColumnAppendState child_append;
+	validity.InitializeAppend(child_append);
+	state.child_appends.push_back(move(child_append));
+}
+
+void StandardColumnData::AppendData(BaseStatistics &stats, ColumnAppendState &state, VectorData &vdata, idx_t count) {
+	ColumnData::AppendData(stats, state, vdata, count);
+
+	validity.AppendData(*stats.validity_stats, state.child_appends[0], vdata, count);
+}
+
+void StandardColumnData::RevertAppend(row_t start_row) {
+	ColumnData::RevertAppend(start_row);
+
+	validity.RevertAppend(start_row);
+}
+
+idx_t StandardColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &result) {
+	// fetch validity mask
+	if (state.child_states.empty()) {
+		ColumnScanState child_state;
+		state.child_states.push_back(move(child_state));
+	}
+	auto scan_count = ColumnData::Fetch(state, row_id, result);
+	validity.Fetch(state.child_states[0], row_id, result);
+	return scan_count;
+}
+
+void StandardColumnData::Update(Transaction &transaction, idx_t column_index, Vector &update_vector, row_t *row_ids,
+                                idx_t update_count) {
+	ColumnData::Update(transaction, column_index, update_vector, row_ids, update_count);
+	validity.Update(transaction, column_index, update_vector, row_ids, update_count);
+}
+
+void StandardColumnData::UpdateColumn(Transaction &transaction, const vector<column_t> &column_path,
+                                      Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth) {
+	if (depth >= column_path.size()) {
+		// update this column
+		ColumnData::Update(transaction, column_path[0], update_vector, row_ids, update_count);
+	} else {
+		// update the child column (i.e. the validity column)
+		validity.UpdateColumn(transaction, column_path, update_vector, row_ids, update_count, depth + 1);
+	}
+}
+
+unique_ptr<BaseStatistics> StandardColumnData::GetUpdateStatistics() {
+	auto stats = updates ? updates->GetStatistics() : nullptr;
+	auto validity_stats = validity.GetUpdateStatistics();
+	if (!stats && !validity_stats) {
+		return nullptr;
+	}
+	if (!stats) {
+		stats = BaseStatistics::CreateEmpty(type, StatisticsType::GLOBAL_STATS);
+	}
+	stats->validity_stats = move(validity_stats);
+	return stats;
+}
+
+void StandardColumnData::FetchRow(Transaction &transaction, ColumnFetchState &state, row_t row_id, Vector &result,
+                                  idx_t result_idx) {
+	// find the segment the row belongs to
+	if (state.child_states.empty()) {
+		auto child_state = make_unique<ColumnFetchState>();
+		state.child_states.push_back(move(child_state));
+	}
+	validity.FetchRow(transaction, *state.child_states[0], row_id, result, result_idx);
+	ColumnData::FetchRow(transaction, state, row_id, result, result_idx);
+}
+
+void StandardColumnData::CommitDropColumn() {
+	ColumnData::CommitDropColumn();
+	validity.CommitDropColumn();
+}
+
+struct StandardColumnCheckpointState : public ColumnCheckpointState {
+	StandardColumnCheckpointState(RowGroup &row_group, ColumnData &column_data, TableDataWriter &writer)
+	    : ColumnCheckpointState(row_group, column_data, writer) {
+	}
+
+	unique_ptr<ColumnCheckpointState> validity_state;
+
+public:
+	unique_ptr<BaseStatistics> GetStatistics() override {
+		auto stats = global_stats->Copy();
+		stats->validity_stats = validity_state->GetStatistics();
+		return stats;
+	}
+
+	void FlushToDisk() override {
+		ColumnCheckpointState::FlushToDisk();
+		validity_state->FlushToDisk();
+	}
+};
+
+unique_ptr<ColumnCheckpointState> StandardColumnData::CreateCheckpointState(RowGroup &row_group,
+                                                                            TableDataWriter &writer) {
+	return make_unique<StandardColumnCheckpointState>(row_group, *this, writer);
+}
+
+unique_ptr<ColumnCheckpointState> StandardColumnData::Checkpoint(RowGroup &row_group, TableDataWriter &writer,
+                                                                 ColumnCheckpointInfo &checkpoint_info) {
+	auto validity_state = validity.Checkpoint(row_group, writer, checkpoint_info);
+	auto base_state = ColumnData::Checkpoint(row_group, writer, checkpoint_info);
+	auto &checkpoint_state = (StandardColumnCheckpointState &)*base_state;
+	checkpoint_state.validity_state = move(validity_state);
+	return base_state;
+}
+
+void StandardColumnData::CheckpointScan(ColumnSegment *segment, ColumnScanState &state, idx_t row_group_start,
+                                        idx_t count, Vector &scan_vector) {
+	ColumnData::CheckpointScan(segment, state, row_group_start, count, scan_vector);
+
+	idx_t offset_in_row_group = state.row_index - row_group_start;
+	validity.ScanCommittedRange(row_group_start, offset_in_row_group, count, scan_vector);
+}
+
+void StandardColumnData::DeserializeColumn(Deserializer &source) {
+	ColumnData::DeserializeColumn(source);
+	validity.DeserializeColumn(source);
+}
+
+void StandardColumnData::GetStorageInfo(idx_t row_group_index, vector<idx_t> col_path, vector<vector<Value>> &result) {
+	ColumnData::GetStorageInfo(row_group_index, col_path, result);
+	col_path.push_back(0);
+	validity.GetStorageInfo(row_group_index, move(col_path), result);
+}
+
+void StandardColumnData::Verify(RowGroup &parent) {
+#ifdef DEBUG
+	ColumnData::Verify(parent);
+	validity.Verify(parent);
+#endif
+}
+
+} // namespace duckdb
+
+
+
+namespace duckdb {
+
+StructColumnData::StructColumnData(DataTableInfo &info, idx_t column_index, idx_t start_row, LogicalType type_p,
+                                   ColumnData *parent)
+    : ColumnData(info, column_index, start_row, move(type_p), parent), validity(info, 0, start_row, this) {
+	D_ASSERT(type.InternalType() == PhysicalType::STRUCT);
+	auto &child_types = StructType::GetChildTypes(type);
+	D_ASSERT(child_types.size() > 0);
+	// the sub column index, starting at 1 (0 is the validity mask)
+	idx_t sub_column_index = 1;
+	for (auto &child_type : child_types) {
+		sub_columns.push_back(
+		    ColumnData::CreateColumnUnique(info, sub_column_index, start_row, child_type.second, this));
+		sub_column_index++;
+	}
+}
+
+bool StructColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
+	// table filters are not supported yet for struct columns
+	return false;
+}
+
+idx_t StructColumnData::GetMaxEntry() {
+	return sub_columns[0]->GetMaxEntry();
+}
+
+void StructColumnData::InitializeScan(ColumnScanState &state) {
+	D_ASSERT(state.child_states.empty());
+
+	state.row_index = 0;
+	state.current = nullptr;
+
+	// initialize the validity segment
+	ColumnScanState validity_state;
+	validity.InitializeScan(validity_state);
+	state.child_states.push_back(move(validity_state));
+
+	// initialize the sub-columns
+	for (auto &sub_column : sub_columns) {
+		ColumnScanState child_state;
+		sub_column->InitializeScan(child_state);
+		state.child_states.push_back(move(child_state));
+	}
+}
+
+void StructColumnData::InitializeScanWithOffset(ColumnScanState &state, idx_t row_idx) {
+	D_ASSERT(state.child_states.empty());
+
+	state.row_index = row_idx;
+	state.current = nullptr;
+
+	// initialize the validity segment
+	ColumnScanState validity_state;
+	validity.InitializeScanWithOffset(validity_state, row_idx);
+	state.child_states.push_back(move(validity_state));
+
+	// initialize the sub-columns
+	for (auto &sub_column : sub_columns) {
+		ColumnScanState child_state;
+		sub_column->InitializeScanWithOffset(child_state, row_idx);
+		state.child_states.push_back(move(child_state));
+	}
+}
+
+idx_t StructColumnData::Scan(Transaction &transaction, idx_t vector_index, ColumnScanState &state, Vector &result) {
+	auto scan_count = validity.Scan(transaction, vector_index, state.child_states[0], result);
+	auto &child_entries = StructVector::GetEntries(result);
+	for (idx_t i = 0; i < sub_columns.size(); i++) {
+		sub_columns[i]->Scan(transaction, vector_index, state.child_states[i + 1], *child_entries[i]);
+	}
+	return scan_count;
+}
+
+idx_t StructColumnData::ScanCommitted(idx_t vector_index, ColumnScanState &state, Vector &result, bool allow_updates) {
+	auto scan_count = validity.ScanCommitted(vector_index, state.child_states[0], result, allow_updates);
+	auto &child_entries = StructVector::GetEntries(result);
+	for (idx_t i = 0; i < sub_columns.size(); i++) {
+		sub_columns[i]->ScanCommitted(vector_index, state.child_states[i + 1], *child_entries[i], allow_updates);
+	}
+	return scan_count;
+}
+
+idx_t StructColumnData::ScanCount(ColumnScanState &state, Vector &result, idx_t count) {
+	auto scan_count = validity.ScanCount(state.child_states[0], result, count);
+	auto &child_entries = StructVector::GetEntries(result);
+	for (idx_t i = 0; i < sub_columns.size(); i++) {
+		sub_columns[i]->ScanCount(state.child_states[i + 1], *child_entries[i], count);
+	}
+	return scan_count;
+}
+
+void StructColumnData::InitializeAppend(ColumnAppendState &state) {
+	ColumnAppendState validity_append;
+	validity.InitializeAppend(validity_append);
+	state.child_appends.push_back(move(validity_append));
+
+	for (auto &sub_column : sub_columns) {
+		ColumnAppendState child_append;
+		sub_column->InitializeAppend(child_append);
+		state.child_appends.push_back(move(child_append));
+	}
+}
+
+void StructColumnData::Append(BaseStatistics &stats, ColumnAppendState &state, Vector &vector, idx_t count) {
+	vector.Normalify(count);
+
+	// append the null values
+	validity.Append(*stats.validity_stats, state.child_appends[0], vector, count);
+
+	auto &struct_validity = FlatVector::Validity(vector);
+
+	auto &struct_stats = (StructStatistics &)stats;
+	auto &child_entries = StructVector::GetEntries(vector);
+	for (idx_t i = 0; i < child_entries.size(); i++) {
+		if (!struct_validity.AllValid()) {
+			// we set the child entries of the struct to NULL
+			// for any values in which the struct itself is NULL
+			child_entries[i]->Normalify(count);
+
+			auto &child_validity = FlatVector::Validity(*child_entries[i]);
+			child_validity.Combine(struct_validity, count);
+		}
+		sub_columns[i]->Append(*struct_stats.child_stats[i], state.child_appends[i + 1], *child_entries[i], count);
+	}
+}
+
+void StructColumnData::RevertAppend(row_t start_row) {
+	validity.RevertAppend(start_row);
+	for (auto &sub_column : sub_columns) {
+		sub_column->RevertAppend(start_row);
+	}
+}
+
+idx_t StructColumnData::Fetch(ColumnScanState &state, row_t row_id, Vector &result) {
+	// fetch validity mask
+	auto &child_entries = StructVector::GetEntries(result);
+	// insert any child states that are required
+	for (idx_t i = state.child_states.size(); i < child_entries.size() + 1; i++) {
+		ColumnScanState child_state;
+		state.child_states.push_back(move(child_state));
+	}
+	// fetch the validity state
+	idx_t scan_count = validity.Fetch(state.child_states[0], row_id, result);
+	// fetch the sub-column states
+	for (idx_t i = 0; i < child_entries.size(); i++) {
+		sub_columns[i]->Fetch(state.child_states[i + 1], row_id, *child_entries[i]);
+	}
+	return scan_count;
+}
+
+void StructColumnData::Update(Transaction &transaction, idx_t column_index, Vector &update_vector, row_t *row_ids,
+                              idx_t update_count) {
+	validity.Update(transaction, column_index, update_vector, row_ids, update_count);
+	auto &child_entries = StructVector::GetEntries(update_vector);
+	for (idx_t i = 0; i < child_entries.size(); i++) {
+		sub_columns[i]->Update(transaction, column_index, *child_entries[i], row_ids, update_count);
+	}
+}
+
+void StructColumnData::UpdateColumn(Transaction &transaction, const vector<column_t> &column_path,
+                                    Vector &update_vector, row_t *row_ids, idx_t update_count, idx_t depth) {
+	// we can never DIRECTLY update a struct column
+	if (depth >= column_path.size()) {
+		throw InternalException("Attempting to directly update a struct column - this should not be possible");
+	}
+	auto update_column = column_path[depth];
+	if (update_column == 0) {
+		// update the validity column
+		validity.UpdateColumn(transaction, column_path, update_vector, row_ids, update_count, depth + 1);
+	} else {
+		if (update_column > sub_columns.size()) {
+			throw InternalException("Update column_path out of range");
+		}
+		sub_columns[update_column - 1]->UpdateColumn(transaction, column_path, update_vector, row_ids, update_count,
+		                                             depth + 1);
+	}
+}
+
+unique_ptr<BaseStatistics> StructColumnData::GetUpdateStatistics() {
+	// check if any child column has updates
+	auto stats = BaseStatistics::CreateEmpty(type, StatisticsType::GLOBAL_STATS);
+	auto &struct_stats = (StructStatistics &)*stats;
+	stats->validity_stats = validity.GetUpdateStatistics();
+	for (idx_t i = 0; i < sub_columns.size(); i++) {
+		auto child_stats = sub_columns[i]->GetUpdateStatistics();
+		if (child_stats) {
+			struct_stats.child_stats[i] = move(child_stats);
+		}
+	}
+	return stats;
+}
+
+void StructColumnData::FetchRow(Transaction &transaction, ColumnFetchState &state, row_t row_id, Vector &result,
+                                idx_t result_idx) {
+	// fetch validity mask
+	auto &child_entries = StructVector::GetEntries(result);
+	// insert any child states that are required
+	for (idx_t i = state.child_states.size(); i < child_entries.size() + 1; i++) {
+		auto child_state = make_unique<ColumnFetchState>();
+		state.child_states.push_back(move(child_state));
+	}
+	// fetch the validity state
+	validity.FetchRow(transaction, *state.child_states[0], row_id, result, result_idx);
+	// fetch the sub-column states
+	for (idx_t i = 0; i < child_entries.size(); i++) {
+		sub_columns[i]->FetchRow(transaction, *state.child_states[i + 1], row_id, *child_entries[i], result_idx);
+	}
+}
+
+void StructColumnData::CommitDropColumn() {
+	validity.CommitDropColumn();
+	for (auto &sub_column : sub_columns) {
+		sub_column->CommitDropColumn();
+	}
+}
+
+struct StructColumnCheckpointState : public ColumnCheckpointState {
+	StructColumnCheckpointState(RowGroup &row_group, ColumnData &column_data, TableDataWriter &writer)
+	    : ColumnCheckpointState(row_group, column_data, writer) {
+		global_stats = make_unique<StructStatistics>(column_data.type);
+	}
+
+	unique_ptr<ColumnCheckpointState> validity_state;
+	vector<unique_ptr<ColumnCheckpointState>> child_states;
+
+public:
+	unique_ptr<BaseStatistics> GetStatistics() override {
+		auto stats = make_unique<StructStatistics>(column_data.type);
+		D_ASSERT(stats->child_stats.size() == child_states.size());
+		stats->validity_stats = validity_state->GetStatistics();
+		for (idx_t i = 0; i < child_states.size(); i++) {
+			stats->child_stats[i] = child_states[i]->GetStatistics();
+			D_ASSERT(stats->child_stats[i]);
+		}
+		return move(stats);
+	}
+
+	void FlushToDisk() override {
+		validity_state->FlushToDisk();
+		for (auto &state : child_states) {
+			state->FlushToDisk();
+		}
+	}
+};
+
+unique_ptr<ColumnCheckpointState> StructColumnData::CreateCheckpointState(RowGroup &row_group,
+                                                                          TableDataWriter &writer) {
+	return make_unique<StructColumnCheckpointState>(row_group, *this, writer);
+}
+
+unique_ptr<ColumnCheckpointState> StructColumnData::Checkpoint(RowGroup &row_group, TableDataWriter &writer,
+                                                               ColumnCheckpointInfo &checkpoint_info) {
+	auto checkpoint_state = make_unique<StructColumnCheckpointState>(row_group, *this, writer);
+	checkpoint_state->validity_state = validity.Checkpoint(row_group, writer, checkpoint_info);
+	for (auto &sub_column : sub_columns) {
+		checkpoint_state->child_states.push_back(sub_column->Checkpoint(row_group, writer, checkpoint_info));
+	}
+	return move(checkpoint_state);
+}
+
+void StructColumnData::DeserializeColumn(Deserializer &source) {
+	validity.DeserializeColumn(source);
+	for (auto &sub_column : sub_columns) {
+		sub_column->DeserializeColumn(source);
+	}
+}
+
+void StructColumnData::GetStorageInfo(idx_t row_group_index, vector<idx_t> col_path, vector<vector<Value>> &result) {
+	col_path.push_back(0);
+	validity.GetStorageInfo(row_group_index, col_path, result);
+	for (idx_t i = 0; i < sub_columns.size(); i++) {
+		col_path.back() = i + 1;
+		sub_columns[i]->GetStorageInfo(row_group_index, col_path, result);
+	}
+}
+
+void StructColumnData::Verify(RowGroup &parent) {
+#ifdef DEBUG
+	ColumnData::Verify(parent);
+	validity.Verify(parent);
+	for (auto &sub_column : sub_columns) {
+		sub_column->Verify(parent);
+	}
+#endif
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+static UpdateSegment::initialize_update_function_t GetInitializeUpdateFunction(PhysicalType type);
+static UpdateSegment::fetch_update_function_t GetFetchUpdateFunction(PhysicalType type);
+static UpdateSegment::fetch_committed_function_t GetFetchCommittedFunction(PhysicalType type);
+static UpdateSegment::fetch_committed_range_function_t GetFetchCommittedRangeFunction(PhysicalType type);
+
+static UpdateSegment::merge_update_function_t GetMergeUpdateFunction(PhysicalType type);
+static UpdateSegment::rollback_update_function_t GetRollbackUpdateFunction(PhysicalType type);
+static UpdateSegment::statistics_update_function_t GetStatisticsUpdateFunction(PhysicalType type);
+static UpdateSegment::fetch_row_function_t GetFetchRowFunction(PhysicalType type);
+
+UpdateSegment::UpdateSegment(ColumnData &column_data) : column_data(column_data), stats(column_data.type) {
+	auto physical_type = column_data.type.InternalType();
+
+	this->type_size = GetTypeIdSize(physical_type);
+
+	this->initialize_update_function = GetInitializeUpdateFunction(physical_type);
+	this->fetch_update_function = GetFetchUpdateFunction(physical_type);
+	this->fetch_committed_function = GetFetchCommittedFunction(physical_type);
+	this->fetch_committed_range = GetFetchCommittedRangeFunction(physical_type);
+	this->fetch_row_function = GetFetchRowFunction(physical_type);
+	this->merge_update_function = GetMergeUpdateFunction(physical_type);
+	this->rollback_update_function = GetRollbackUpdateFunction(physical_type);
+	this->statistics_update_function = GetStatisticsUpdateFunction(physical_type);
+}
+
+UpdateSegment::~UpdateSegment() {
+}
+
+void UpdateSegment::ClearUpdates() {
+	stats.Reset();
+	root.reset();
+	heap.Destroy();
+}
+
+//===--------------------------------------------------------------------===//
+// Update Info Helpers
+//===--------------------------------------------------------------------===//
+Value UpdateInfo::GetValue(idx_t index) {
+	auto &type = segment->column_data.type;
+
+	switch (type.id()) {
+	case LogicalTypeId::VALIDITY:
+		return Value::BOOLEAN(((bool *)tuple_data)[index]);
+	case LogicalTypeId::INTEGER:
+		return Value::INTEGER(((int32_t *)tuple_data)[index]);
+	default:
+		throw NotImplementedException("Unimplemented type for UpdateInfo::GetValue");
+	}
+}
+
+void UpdateInfo::Print() {
+	Printer::Print(ToString());
+}
+
+string UpdateInfo::ToString() {
+	auto &type = segment->column_data.type;
+	string result = "Update Info [" + type.ToString() + ", Count: " + to_string(N) +
+	                ", Transaction Id: " + to_string(version_number) + "]\n";
+	for (idx_t i = 0; i < N; i++) {
+		result += to_string(tuples[i]) + ": " + GetValue(i).ToString() + "\n";
+	}
+	if (next) {
+		result += "\nChild Segment: " + next->ToString();
+	}
+	return result;
+}
+
+void UpdateInfo::Verify() {
+#ifdef DEBUG
+	for (idx_t i = 1; i < N; i++) {
+		D_ASSERT(tuples[i] > tuples[i - 1] && tuples[i] < STANDARD_VECTOR_SIZE);
+	}
+#endif
+}
+
+//===--------------------------------------------------------------------===//
+// Update Fetch
+//===--------------------------------------------------------------------===//
+static void MergeValidityInfo(UpdateInfo *current, ValidityMask &result_mask) {
+	auto info_data = (bool *)current->tuple_data;
+	for (idx_t i = 0; i < current->N; i++) {
+		result_mask.Set(current->tuples[i], info_data[i]);
+	}
+}
+
+static void UpdateMergeValidity(transaction_t start_time, transaction_t transaction_id, UpdateInfo *info,
+                                Vector &result) {
+	auto &result_mask = FlatVector::Validity(result);
+	UpdateInfo::UpdatesForTransaction(info, start_time, transaction_id,
+	                                  [&](UpdateInfo *current) { MergeValidityInfo(current, result_mask); });
+}
+
+template <class T>
+static void MergeUpdateInfo(UpdateInfo *current, T *result_data) {
+	auto info_data = (T *)current->tuple_data;
+	if (current->N == STANDARD_VECTOR_SIZE) {
+		// special case: update touches ALL tuples of this vector
+		// in this case we can just memcpy the data
+		// since the layout of the update info is guaranteed to be [0, 1, 2, 3, ...]
+		memcpy(result_data, info_data, sizeof(T) * current->N);
+	} else {
+		for (idx_t i = 0; i < current->N; i++) {
+			result_data[current->tuples[i]] = info_data[i];
+		}
+	}
+}
+
+template <class T>
+static void UpdateMergeFetch(transaction_t start_time, transaction_t transaction_id, UpdateInfo *info, Vector &result) {
+	auto result_data = FlatVector::GetData<T>(result);
+	UpdateInfo::UpdatesForTransaction(info, start_time, transaction_id,
+	                                  [&](UpdateInfo *current) { MergeUpdateInfo<T>(current, result_data); });
+}
+
+static UpdateSegment::fetch_update_function_t GetFetchUpdateFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+		return UpdateMergeValidity;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return UpdateMergeFetch<int8_t>;
+	case PhysicalType::INT16:
+		return UpdateMergeFetch<int16_t>;
+	case PhysicalType::INT32:
+		return UpdateMergeFetch<int32_t>;
+	case PhysicalType::INT64:
+		return UpdateMergeFetch<int64_t>;
+	case PhysicalType::UINT8:
+		return UpdateMergeFetch<uint8_t>;
+	case PhysicalType::UINT16:
+		return UpdateMergeFetch<uint16_t>;
+	case PhysicalType::UINT32:
+		return UpdateMergeFetch<uint32_t>;
+	case PhysicalType::UINT64:
+		return UpdateMergeFetch<uint64_t>;
+	case PhysicalType::INT128:
+		return UpdateMergeFetch<hugeint_t>;
+	case PhysicalType::FLOAT:
+		return UpdateMergeFetch<float>;
+	case PhysicalType::DOUBLE:
+		return UpdateMergeFetch<double>;
+	case PhysicalType::INTERVAL:
+		return UpdateMergeFetch<interval_t>;
+	case PhysicalType::VARCHAR:
+		return UpdateMergeFetch<string_t>;
+	default:
+		throw NotImplementedException("Unimplemented type for update segment");
+	}
+}
+
+void UpdateSegment::FetchUpdates(Transaction &transaction, idx_t vector_index, Vector &result) {
+	auto lock_handle = lock.GetSharedLock();
+	if (!root) {
+		return;
+	}
+	if (!root->info[vector_index]) {
+		return;
+	}
+	// FIXME: normalify if this is not the case... need to pass in count?
+	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
+
+	fetch_update_function(transaction.start_time, transaction.transaction_id, root->info[vector_index]->info.get(),
+	                      result);
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch Committed
+//===--------------------------------------------------------------------===//
+static void FetchCommittedValidity(UpdateInfo *info, Vector &result) {
+	auto &result_mask = FlatVector::Validity(result);
+	MergeValidityInfo(info, result_mask);
+}
+
+template <class T>
+static void TemplatedFetchCommitted(UpdateInfo *info, Vector &result) {
+	auto result_data = FlatVector::GetData<T>(result);
+	MergeUpdateInfo<T>(info, result_data);
+}
+
+static UpdateSegment::fetch_committed_function_t GetFetchCommittedFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+		return FetchCommittedValidity;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedFetchCommitted<int8_t>;
+	case PhysicalType::INT16:
+		return TemplatedFetchCommitted<int16_t>;
+	case PhysicalType::INT32:
+		return TemplatedFetchCommitted<int32_t>;
+	case PhysicalType::INT64:
+		return TemplatedFetchCommitted<int64_t>;
+	case PhysicalType::UINT8:
+		return TemplatedFetchCommitted<uint8_t>;
+	case PhysicalType::UINT16:
+		return TemplatedFetchCommitted<uint16_t>;
+	case PhysicalType::UINT32:
+		return TemplatedFetchCommitted<uint32_t>;
+	case PhysicalType::UINT64:
+		return TemplatedFetchCommitted<uint64_t>;
+	case PhysicalType::INT128:
+		return TemplatedFetchCommitted<hugeint_t>;
+	case PhysicalType::FLOAT:
+		return TemplatedFetchCommitted<float>;
+	case PhysicalType::DOUBLE:
+		return TemplatedFetchCommitted<double>;
+	case PhysicalType::INTERVAL:
+		return TemplatedFetchCommitted<interval_t>;
+	case PhysicalType::VARCHAR:
+		return TemplatedFetchCommitted<string_t>;
+	default:
+		throw NotImplementedException("Unimplemented type for update segment");
+	}
+}
+
+void UpdateSegment::FetchCommitted(idx_t vector_index, Vector &result) {
+	auto lock_handle = lock.GetSharedLock();
+
+	if (!root) {
+		return;
+	}
+	if (!root->info[vector_index]) {
+		return;
+	}
+	// FIXME: normalify if this is not the case... need to pass in count?
+	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
+
+	fetch_committed_function(root->info[vector_index]->info.get(), result);
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch Range
+//===--------------------------------------------------------------------===//
+static void MergeUpdateInfoRangeValidity(UpdateInfo *current, idx_t start, idx_t end, idx_t result_offset,
+                                         ValidityMask &result_mask) {
+	auto info_data = (bool *)current->tuple_data;
+	for (idx_t i = 0; i < current->N; i++) {
+		auto tuple_idx = current->tuples[i];
+		if (tuple_idx < start) {
+			continue;
+		} else if (tuple_idx >= end) {
+			break;
+		}
+		auto result_idx = result_offset + tuple_idx - start;
+		result_mask.Set(result_idx, info_data[i]);
+	}
+}
+
+static void FetchCommittedRangeValidity(UpdateInfo *info, idx_t start, idx_t end, idx_t result_offset, Vector &result) {
+	auto &result_mask = FlatVector::Validity(result);
+	MergeUpdateInfoRangeValidity(info, start, end, result_offset, result_mask);
+}
+
+template <class T>
+static void MergeUpdateInfoRange(UpdateInfo *current, idx_t start, idx_t end, idx_t result_offset, T *result_data) {
+	auto info_data = (T *)current->tuple_data;
+	for (idx_t i = 0; i < current->N; i++) {
+		auto tuple_idx = current->tuples[i];
+		if (tuple_idx < start) {
+			continue;
+		} else if (tuple_idx >= end) {
+			break;
+		}
+		auto result_idx = result_offset + tuple_idx - start;
+		result_data[result_idx] = info_data[i];
+	}
+}
+
+template <class T>
+static void TemplatedFetchCommittedRange(UpdateInfo *info, idx_t start, idx_t end, idx_t result_offset,
+                                         Vector &result) {
+	auto result_data = FlatVector::GetData<T>(result);
+	MergeUpdateInfoRange<T>(info, start, end, result_offset, result_data);
+}
+
+static UpdateSegment::fetch_committed_range_function_t GetFetchCommittedRangeFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+		return FetchCommittedRangeValidity;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedFetchCommittedRange<int8_t>;
+	case PhysicalType::INT16:
+		return TemplatedFetchCommittedRange<int16_t>;
+	case PhysicalType::INT32:
+		return TemplatedFetchCommittedRange<int32_t>;
+	case PhysicalType::INT64:
+		return TemplatedFetchCommittedRange<int64_t>;
+	case PhysicalType::UINT8:
+		return TemplatedFetchCommittedRange<uint8_t>;
+	case PhysicalType::UINT16:
+		return TemplatedFetchCommittedRange<uint16_t>;
+	case PhysicalType::UINT32:
+		return TemplatedFetchCommittedRange<uint32_t>;
+	case PhysicalType::UINT64:
+		return TemplatedFetchCommittedRange<uint64_t>;
+	case PhysicalType::INT128:
+		return TemplatedFetchCommittedRange<hugeint_t>;
+	case PhysicalType::FLOAT:
+		return TemplatedFetchCommittedRange<float>;
+	case PhysicalType::DOUBLE:
+		return TemplatedFetchCommittedRange<double>;
+	case PhysicalType::INTERVAL:
+		return TemplatedFetchCommittedRange<interval_t>;
+	case PhysicalType::VARCHAR:
+		return TemplatedFetchCommittedRange<string_t>;
+	default:
+		throw NotImplementedException("Unimplemented type for update segment");
+	}
+}
+
+void UpdateSegment::FetchCommittedRange(idx_t start_row, idx_t count, Vector &result) {
+	D_ASSERT(count > 0);
+	if (!root) {
+		return;
+	}
+	D_ASSERT(result.GetVectorType() == VectorType::FLAT_VECTOR);
+
+	idx_t end_row = start_row + count;
+	idx_t start_vector = start_row / STANDARD_VECTOR_SIZE;
+	idx_t end_vector = (end_row - 1) / STANDARD_VECTOR_SIZE;
+	D_ASSERT(start_vector <= end_vector);
+	D_ASSERT(end_vector < RowGroup::ROW_GROUP_VECTOR_COUNT);
+
+	for (idx_t vector_idx = start_vector; vector_idx <= end_vector; vector_idx++) {
+		if (!root->info[vector_idx]) {
+			continue;
+		}
+		idx_t start_in_vector = vector_idx == start_vector ? start_row - start_vector * STANDARD_VECTOR_SIZE : 0;
+		idx_t end_in_vector =
+		    vector_idx == end_vector ? end_row - end_vector * STANDARD_VECTOR_SIZE : STANDARD_VECTOR_SIZE;
+		D_ASSERT(start_in_vector < end_in_vector);
+		D_ASSERT(end_in_vector > 0 && end_in_vector <= STANDARD_VECTOR_SIZE);
+		idx_t result_offset = ((vector_idx * STANDARD_VECTOR_SIZE) + start_in_vector) - start_row;
+		fetch_committed_range(root->info[vector_idx]->info.get(), start_in_vector, end_in_vector, result_offset,
+		                      result);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Fetch Row
+//===--------------------------------------------------------------------===//
+static void FetchRowValidity(transaction_t start_time, transaction_t transaction_id, UpdateInfo *info, idx_t row_idx,
+                             Vector &result, idx_t result_idx) {
+	auto &result_mask = FlatVector::Validity(result);
+	UpdateInfo::UpdatesForTransaction(info, start_time, transaction_id, [&](UpdateInfo *current) {
+		auto info_data = (bool *)current->tuple_data;
+		// FIXME: we could do a binary search in here
+		for (idx_t i = 0; i < current->N; i++) {
+			if (current->tuples[i] == row_idx) {
+				result_mask.Set(result_idx, info_data[i]);
+				break;
+			} else if (current->tuples[i] > row_idx) {
+				break;
+			}
+		}
+	});
+}
+
+template <class T>
+static void TemplatedFetchRow(transaction_t start_time, transaction_t transaction_id, UpdateInfo *info, idx_t row_idx,
+                              Vector &result, idx_t result_idx) {
+	auto result_data = FlatVector::GetData<T>(result);
+	UpdateInfo::UpdatesForTransaction(info, start_time, transaction_id, [&](UpdateInfo *current) {
+		auto info_data = (T *)current->tuple_data;
+		// FIXME: we could do a binary search in here
+		for (idx_t i = 0; i < current->N; i++) {
+			if (current->tuples[i] == row_idx) {
+				result_data[result_idx] = info_data[i];
+				break;
+			} else if (current->tuples[i] > row_idx) {
+				break;
+			}
+		}
+	});
+}
+
+static UpdateSegment::fetch_row_function_t GetFetchRowFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+		return FetchRowValidity;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedFetchRow<int8_t>;
+	case PhysicalType::INT16:
+		return TemplatedFetchRow<int16_t>;
+	case PhysicalType::INT32:
+		return TemplatedFetchRow<int32_t>;
+	case PhysicalType::INT64:
+		return TemplatedFetchRow<int64_t>;
+	case PhysicalType::UINT8:
+		return TemplatedFetchRow<uint8_t>;
+	case PhysicalType::UINT16:
+		return TemplatedFetchRow<uint16_t>;
+	case PhysicalType::UINT32:
+		return TemplatedFetchRow<uint32_t>;
+	case PhysicalType::UINT64:
+		return TemplatedFetchRow<uint64_t>;
+	case PhysicalType::INT128:
+		return TemplatedFetchRow<hugeint_t>;
+	case PhysicalType::FLOAT:
+		return TemplatedFetchRow<float>;
+	case PhysicalType::DOUBLE:
+		return TemplatedFetchRow<double>;
+	case PhysicalType::INTERVAL:
+		return TemplatedFetchRow<interval_t>;
+	case PhysicalType::VARCHAR:
+		return TemplatedFetchRow<string_t>;
+	default:
+		throw NotImplementedException("Unimplemented type for update segment fetch row");
+	}
+}
+
+void UpdateSegment::FetchRow(Transaction &transaction, idx_t row_id, Vector &result, idx_t result_idx) {
+	if (!root) {
+		return;
+	}
+	idx_t vector_index = (row_id - column_data.start) / STANDARD_VECTOR_SIZE;
+	if (!root->info[vector_index]) {
+		return;
+	}
+	idx_t row_in_vector = row_id - vector_index * STANDARD_VECTOR_SIZE;
+	fetch_row_function(transaction.start_time, transaction.transaction_id, root->info[vector_index]->info.get(),
+	                   row_in_vector, result, result_idx);
+}
+
+//===--------------------------------------------------------------------===//
+// Rollback update
+//===--------------------------------------------------------------------===//
+template <class T>
+static void RollbackUpdate(UpdateInfo *base_info, UpdateInfo *rollback_info) {
+	auto base_data = (T *)base_info->tuple_data;
+	auto rollback_data = (T *)rollback_info->tuple_data;
+	idx_t base_offset = 0;
+	for (idx_t i = 0; i < rollback_info->N; i++) {
+		auto id = rollback_info->tuples[i];
+		while (base_info->tuples[base_offset] < id) {
+			base_offset++;
+			D_ASSERT(base_offset < base_info->N);
+		}
+		base_data[base_offset] = rollback_data[i];
+	}
+}
+
+static UpdateSegment::rollback_update_function_t GetRollbackUpdateFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+		return RollbackUpdate<bool>;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return RollbackUpdate<int8_t>;
+	case PhysicalType::INT16:
+		return RollbackUpdate<int16_t>;
+	case PhysicalType::INT32:
+		return RollbackUpdate<int32_t>;
+	case PhysicalType::INT64:
+		return RollbackUpdate<int64_t>;
+	case PhysicalType::UINT8:
+		return RollbackUpdate<uint8_t>;
+	case PhysicalType::UINT16:
+		return RollbackUpdate<uint16_t>;
+	case PhysicalType::UINT32:
+		return RollbackUpdate<uint32_t>;
+	case PhysicalType::UINT64:
+		return RollbackUpdate<uint64_t>;
+	case PhysicalType::INT128:
+		return RollbackUpdate<hugeint_t>;
+	case PhysicalType::FLOAT:
+		return RollbackUpdate<float>;
+	case PhysicalType::DOUBLE:
+		return RollbackUpdate<double>;
+	case PhysicalType::INTERVAL:
+		return RollbackUpdate<interval_t>;
+	case PhysicalType::VARCHAR:
+		return RollbackUpdate<string_t>;
+	default:
+		throw NotImplementedException("Unimplemented type for uncompressed segment");
+	}
+}
+
+void UpdateSegment::RollbackUpdate(UpdateInfo *info) {
+	// obtain an exclusive lock
+	auto lock_handle = lock.GetExclusiveLock();
+
+	// move the data from the UpdateInfo back into the base info
+	D_ASSERT(root->info[info->vector_index]);
+	rollback_update_function(root->info[info->vector_index]->info.get(), info);
+
+	// clean up the update chain
+	CleanupUpdateInternal(*lock_handle, info);
+}
+
+//===--------------------------------------------------------------------===//
+// Cleanup Update
+//===--------------------------------------------------------------------===//
+void UpdateSegment::CleanupUpdateInternal(const StorageLockKey &lock, UpdateInfo *info) {
+	D_ASSERT(info->prev);
+	auto prev = info->prev;
+	prev->next = info->next;
+	if (prev->next) {
+		prev->next->prev = prev;
+	}
+}
+
+void UpdateSegment::CleanupUpdate(UpdateInfo *info) {
+	// obtain an exclusive lock
+	auto lock_handle = lock.GetExclusiveLock();
+	CleanupUpdateInternal(*lock_handle, info);
+}
+
+//===--------------------------------------------------------------------===//
+// Check for conflicts in update
+//===--------------------------------------------------------------------===//
+static void CheckForConflicts(UpdateInfo *info, Transaction &transaction, row_t *ids, const SelectionVector &sel,
+                              idx_t count, row_t offset, UpdateInfo *&node) {
+	if (!info) {
+		return;
+	}
+	if (info->version_number == transaction.transaction_id) {
+		// this UpdateInfo belongs to the current transaction, set it in the node
+		node = info;
+	} else if (info->version_number > transaction.start_time) {
+		// potential conflict, check that tuple ids do not conflict
+		// as both ids and info->tuples are sorted, this is similar to a merge join
+		idx_t i = 0, j = 0;
+		while (true) {
+			auto id = ids[sel.get_index(i)] - offset;
+			if (id == info->tuples[j]) {
+				throw TransactionException("Conflict on update!");
+			} else if (id < info->tuples[j]) {
+				// id < the current tuple in info, move to next id
+				i++;
+				if (i == count) {
+					break;
+				}
+			} else {
+				// id > the current tuple, move to next tuple in info
+				j++;
+				if (j == info->N) {
+					break;
+				}
+			}
+		}
+	}
+	CheckForConflicts(info->next, transaction, ids, sel, count, offset, node);
+}
+
+//===--------------------------------------------------------------------===//
+// Initialize update info
+//===--------------------------------------------------------------------===//
+void UpdateSegment::InitializeUpdateInfo(UpdateInfo &info, row_t *ids, const SelectionVector &sel, idx_t count,
+                                         idx_t vector_index, idx_t vector_offset) {
+	info.segment = this;
+	info.vector_index = vector_index;
+	info.prev = nullptr;
+	info.next = nullptr;
+
+	// set up the tuple ids
+	info.N = count;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		auto id = ids[idx];
+		D_ASSERT(idx_t(id) >= vector_offset && idx_t(id) < vector_offset + STANDARD_VECTOR_SIZE);
+		info.tuples[i] = id - vector_offset;
+	};
+}
+
+static void InitializeUpdateValidity(UpdateInfo *base_info, Vector &base_data, UpdateInfo *update_info, Vector &update,
+                                     const SelectionVector &sel) {
+	auto &update_mask = FlatVector::Validity(update);
+	auto tuple_data = (bool *)update_info->tuple_data;
+
+	if (!update_mask.AllValid()) {
+		for (idx_t i = 0; i < update_info->N; i++) {
+			auto idx = sel.get_index(i);
+			tuple_data[i] = update_mask.RowIsValidUnsafe(idx);
+		}
+	} else {
+		for (idx_t i = 0; i < update_info->N; i++) {
+			tuple_data[i] = true;
+		}
+	}
+
+	auto &base_mask = FlatVector::Validity(base_data);
+	auto base_tuple_data = (bool *)base_info->tuple_data;
+	if (!base_mask.AllValid()) {
+		for (idx_t i = 0; i < base_info->N; i++) {
+			base_tuple_data[i] = base_mask.RowIsValidUnsafe(base_info->tuples[i]);
+		}
+	} else {
+		for (idx_t i = 0; i < base_info->N; i++) {
+			base_tuple_data[i] = true;
+		}
+	}
+}
+
+struct UpdateSelectElement {
+	template <class T>
+	static T Operation(UpdateSegment *segment, T element) {
+		return element;
+	}
+};
+
+template <>
+string_t UpdateSelectElement::Operation(UpdateSegment *segment, string_t element) {
+	return element.IsInlined() ? element : segment->GetStringHeap().AddString(element);
+}
+
+template <class T>
+static void InitializeUpdateData(UpdateInfo *base_info, Vector &base_data, UpdateInfo *update_info, Vector &update,
+                                 const SelectionVector &sel) {
+	auto update_data = FlatVector::GetData<T>(update);
+	auto tuple_data = (T *)update_info->tuple_data;
+
+	for (idx_t i = 0; i < update_info->N; i++) {
+		auto idx = sel.get_index(i);
+		tuple_data[i] = update_data[idx];
+	}
+
+	auto base_array_data = FlatVector::GetData<T>(base_data);
+	auto base_tuple_data = (T *)base_info->tuple_data;
+	for (idx_t i = 0; i < base_info->N; i++) {
+		base_tuple_data[i] =
+		    UpdateSelectElement::Operation<T>(base_info->segment, base_array_data[base_info->tuples[i]]);
+	}
+}
+
+static UpdateSegment::initialize_update_function_t GetInitializeUpdateFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+		return InitializeUpdateValidity;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return InitializeUpdateData<int8_t>;
+	case PhysicalType::INT16:
+		return InitializeUpdateData<int16_t>;
+	case PhysicalType::INT32:
+		return InitializeUpdateData<int32_t>;
+	case PhysicalType::INT64:
+		return InitializeUpdateData<int64_t>;
+	case PhysicalType::UINT8:
+		return InitializeUpdateData<uint8_t>;
+	case PhysicalType::UINT16:
+		return InitializeUpdateData<uint16_t>;
+	case PhysicalType::UINT32:
+		return InitializeUpdateData<uint32_t>;
+	case PhysicalType::UINT64:
+		return InitializeUpdateData<uint64_t>;
+	case PhysicalType::INT128:
+		return InitializeUpdateData<hugeint_t>;
+	case PhysicalType::FLOAT:
+		return InitializeUpdateData<float>;
+	case PhysicalType::DOUBLE:
+		return InitializeUpdateData<double>;
+	case PhysicalType::INTERVAL:
+		return InitializeUpdateData<interval_t>;
+	case PhysicalType::VARCHAR:
+		return InitializeUpdateData<string_t>;
+	default:
+		throw NotImplementedException("Unimplemented type for update segment");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Merge update info
+//===--------------------------------------------------------------------===//
+template <class F1, class F2, class F3>
+static idx_t MergeLoop(row_t a[], sel_t b[], idx_t acount, idx_t bcount, idx_t aoffset, F1 merge, F2 pick_a, F3 pick_b,
+                       const SelectionVector &asel) {
+	idx_t aidx = 0, bidx = 0;
+	idx_t count = 0;
+	while (aidx < acount && bidx < bcount) {
+		auto a_index = asel.get_index(aidx);
+		auto a_id = a[a_index] - aoffset;
+		auto b_id = b[bidx];
+		if (a_id == b_id) {
+			merge(a_id, a_index, bidx, count);
+			aidx++;
+			bidx++;
+			count++;
+		} else if (a_id < b_id) {
+			pick_a(a_id, a_index, count);
+			aidx++;
+			count++;
+		} else {
+			pick_b(b_id, bidx, count);
+			bidx++;
+			count++;
+		}
+	}
+	for (; aidx < acount; aidx++) {
+		auto a_index = asel.get_index(aidx);
+		pick_a(a[a_index] - aoffset, a_index, count);
+		count++;
+	}
+	for (; bidx < bcount; bidx++) {
+		pick_b(b[bidx], bidx, count);
+		count++;
+	}
+	return count;
+}
+
+struct ExtractStandardEntry {
+	template <class T, class V>
+	static T Extract(V *data, idx_t entry) {
+		return data[entry];
+	}
+};
+
+struct ExtractValidityEntry {
+	template <class T, class V>
+	static T Extract(V *data, idx_t entry) {
+		return data->RowIsValid(entry);
+	}
+};
+
+template <class T, class V, class OP = ExtractStandardEntry>
+static void MergeUpdateLoopInternal(UpdateInfo *base_info, V *base_table_data, UpdateInfo *update_info,
+                                    V *update_vector_data, row_t *ids, idx_t count, const SelectionVector &sel) {
+	auto base_id = base_info->segment->column_data.start + base_info->vector_index * STANDARD_VECTOR_SIZE;
+#ifdef DEBUG
+	// all of these should be sorted, otherwise the below algorithm does not work
+	for (idx_t i = 1; i < count; i++) {
+		auto prev_idx = sel.get_index(i - 1);
+		auto idx = sel.get_index(i);
+		D_ASSERT(ids[idx] > ids[prev_idx] && ids[idx] >= row_t(base_id) &&
+		         ids[idx] < row_t(base_id + STANDARD_VECTOR_SIZE));
+	}
+#endif
+
+	// we have a new batch of updates (update, ids, count)
+	// we already have existing updates (base_info)
+	// and potentially, this transaction already has updates present (update_info)
+	// we need to merge these all together so that the latest updates get merged into base_info
+	// and the "old" values (fetched from EITHER base_info OR from base_data) get placed into update_info
+	auto base_info_data = (T *)base_info->tuple_data;
+	auto update_info_data = (T *)update_info->tuple_data;
+
+	// we first do the merging of the old values
+	// what we are trying to do here is update the "update_info" of this transaction with all the old data we require
+	// this means we need to merge (1) any previously updated values (stored in update_info->tuples)
+	// together with (2)
+	// to simplify this, we create new arrays here
+	// we memcpy these over afterwards
+	T result_values[STANDARD_VECTOR_SIZE];
+	sel_t result_ids[STANDARD_VECTOR_SIZE];
+
+	idx_t base_info_offset = 0;
+	idx_t update_info_offset = 0;
+	idx_t result_offset = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = sel.get_index(i);
+		// we have to merge the info for "ids[i]"
+		auto update_id = ids[idx] - base_id;
+
+		while (update_info_offset < update_info->N && update_info->tuples[update_info_offset] < update_id) {
+			// old id comes before the current id: write it
+			result_values[result_offset] = update_info_data[update_info_offset];
+			result_ids[result_offset++] = update_info->tuples[update_info_offset];
+			update_info_offset++;
+		}
+		// write the new id
+		if (update_info_offset < update_info->N && update_info->tuples[update_info_offset] == update_id) {
+			// we have an id that is equivalent in the current update info: write the update info
+			result_values[result_offset] = update_info_data[update_info_offset];
+			result_ids[result_offset++] = update_info->tuples[update_info_offset];
+			update_info_offset++;
+			continue;
+		}
+
+		/// now check if we have the current update_id in the base_info, or if we should fetch it from the base data
+		while (base_info_offset < base_info->N && base_info->tuples[base_info_offset] < update_id) {
+			base_info_offset++;
+		}
+		if (base_info_offset < base_info->N && base_info->tuples[base_info_offset] == update_id) {
+			// it is! we have to move the tuple from base_info->ids[base_info_offset] to update_info
+			result_values[result_offset] = base_info_data[base_info_offset];
+		} else {
+			// it is not! we have to move base_table_data[update_id] to update_info
+			result_values[result_offset] = UpdateSelectElement::Operation<T>(
+			    base_info->segment, OP::template Extract<T, V>(base_table_data, update_id));
+		}
+		result_ids[result_offset++] = update_id;
+	}
+	// write any remaining entries from the old updates
+	while (update_info_offset < update_info->N) {
+		result_values[result_offset] = update_info_data[update_info_offset];
+		result_ids[result_offset++] = update_info->tuples[update_info_offset];
+		update_info_offset++;
+	}
+	// now copy them back
+	update_info->N = result_offset;
+	memcpy(update_info_data, result_values, result_offset * sizeof(T));
+	memcpy(update_info->tuples, result_ids, result_offset * sizeof(sel_t));
+
+	// now we merge the new values into the base_info
+	result_offset = 0;
+	auto pick_new = [&](idx_t id, idx_t aidx, idx_t count) {
+		result_values[result_offset] = OP::template Extract<T, V>(update_vector_data, aidx);
+		result_ids[result_offset] = id;
+		result_offset++;
+	};
+	auto pick_old = [&](idx_t id, idx_t bidx, idx_t count) {
+		result_values[result_offset] = base_info_data[bidx];
+		result_ids[result_offset] = id;
+		result_offset++;
+	};
+	// now we perform a merge of the new ids with the old ids
+	auto merge = [&](idx_t id, idx_t aidx, idx_t bidx, idx_t count) {
+		pick_new(id, aidx, count);
+	};
+	MergeLoop(ids, base_info->tuples, count, base_info->N, base_id, merge, pick_new, pick_old, sel);
+
+	base_info->N = result_offset;
+	memcpy(base_info_data, result_values, result_offset * sizeof(T));
+	memcpy(base_info->tuples, result_ids, result_offset * sizeof(sel_t));
+}
+
+static void MergeValidityLoop(UpdateInfo *base_info, Vector &base_data, UpdateInfo *update_info, Vector &update,
+                              row_t *ids, idx_t count, const SelectionVector &sel) {
+	auto &base_validity = FlatVector::Validity(base_data);
+	auto &update_validity = FlatVector::Validity(update);
+	MergeUpdateLoopInternal<bool, ValidityMask, ExtractValidityEntry>(base_info, &base_validity, update_info,
+	                                                                  &update_validity, ids, count, sel);
+}
+
+template <class T>
+static void MergeUpdateLoop(UpdateInfo *base_info, Vector &base_data, UpdateInfo *update_info, Vector &update,
+                            row_t *ids, idx_t count, const SelectionVector &sel) {
+	auto base_table_data = FlatVector::GetData<T>(base_data);
+	auto update_vector_data = FlatVector::GetData<T>(update);
+	MergeUpdateLoopInternal<T, T>(base_info, base_table_data, update_info, update_vector_data, ids, count, sel);
+}
+
+static UpdateSegment::merge_update_function_t GetMergeUpdateFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+		return MergeValidityLoop;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return MergeUpdateLoop<int8_t>;
+	case PhysicalType::INT16:
+		return MergeUpdateLoop<int16_t>;
+	case PhysicalType::INT32:
+		return MergeUpdateLoop<int32_t>;
+	case PhysicalType::INT64:
+		return MergeUpdateLoop<int64_t>;
+	case PhysicalType::UINT8:
+		return MergeUpdateLoop<uint8_t>;
+	case PhysicalType::UINT16:
+		return MergeUpdateLoop<uint16_t>;
+	case PhysicalType::UINT32:
+		return MergeUpdateLoop<uint32_t>;
+	case PhysicalType::UINT64:
+		return MergeUpdateLoop<uint64_t>;
+	case PhysicalType::INT128:
+		return MergeUpdateLoop<hugeint_t>;
+	case PhysicalType::FLOAT:
+		return MergeUpdateLoop<float>;
+	case PhysicalType::DOUBLE:
+		return MergeUpdateLoop<double>;
+	case PhysicalType::INTERVAL:
+		return MergeUpdateLoop<interval_t>;
+	case PhysicalType::VARCHAR:
+		return MergeUpdateLoop<string_t>;
+	default:
+		throw NotImplementedException("Unimplemented type for uncompressed segment");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Update statistics
+//===--------------------------------------------------------------------===//
+unique_ptr<BaseStatistics> UpdateSegment::GetStatistics() {
+	lock_guard<mutex> stats_guard(stats_lock);
+	return stats.statistics->Copy();
+}
+
+idx_t UpdateValidityStatistics(UpdateSegment *segment, SegmentStatistics &stats, Vector &update, idx_t count,
+                               SelectionVector &sel) {
+	auto &mask = FlatVector::Validity(update);
+	auto &validity = (ValidityStatistics &)*stats.statistics;
+	if (!mask.AllValid() && !validity.has_null) {
+		for (idx_t i = 0; i < count; i++) {
+			if (!mask.RowIsValid(i)) {
+				validity.has_null = true;
+				break;
+			}
+		}
+	}
+	sel.Initialize(nullptr);
+	return count;
+}
+
+template <class T>
+idx_t TemplatedUpdateNumericStatistics(UpdateSegment *segment, SegmentStatistics &stats, Vector &update, idx_t count,
+                                       SelectionVector &sel) {
+	auto update_data = FlatVector::GetData<T>(update);
+	auto &mask = FlatVector::Validity(update);
+
+	if (mask.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			NumericStatistics::Update<T>(stats, update_data[i]);
+		}
+		sel.Initialize(nullptr);
+		return count;
+	} else {
+		idx_t not_null_count = 0;
+		sel.Initialize(STANDARD_VECTOR_SIZE);
+		for (idx_t i = 0; i < count; i++) {
+			if (mask.RowIsValid(i)) {
+				sel.set_index(not_null_count++, i);
+				NumericStatistics::Update<T>(stats, update_data[i]);
+			}
+		}
+		return not_null_count;
+	}
+}
+
+idx_t UpdateStringStatistics(UpdateSegment *segment, SegmentStatistics &stats, Vector &update, idx_t count,
+                             SelectionVector &sel) {
+	auto update_data = FlatVector::GetData<string_t>(update);
+	auto &mask = FlatVector::Validity(update);
+	if (mask.AllValid()) {
+		for (idx_t i = 0; i < count; i++) {
+			((StringStatistics &)*stats.statistics).Update(update_data[i]);
+			if (!update_data[i].IsInlined()) {
+				update_data[i] = segment->GetStringHeap().AddString(update_data[i]);
+			}
+		}
+		sel.Initialize(nullptr);
+		return count;
+	} else {
+		idx_t not_null_count = 0;
+		sel.Initialize(STANDARD_VECTOR_SIZE);
+		for (idx_t i = 0; i < count; i++) {
+			if (mask.RowIsValid(i)) {
+				sel.set_index(not_null_count++, i);
+				((StringStatistics &)*stats.statistics).Update(update_data[i]);
+				if (!update_data[i].IsInlined()) {
+					update_data[i] = segment->GetStringHeap().AddString(update_data[i]);
+				}
+			}
+		}
+		return not_null_count;
+	}
+}
+
+UpdateSegment::statistics_update_function_t GetStatisticsUpdateFunction(PhysicalType type) {
+	switch (type) {
+	case PhysicalType::BIT:
+		return UpdateValidityStatistics;
+	case PhysicalType::BOOL:
+	case PhysicalType::INT8:
+		return TemplatedUpdateNumericStatistics<int8_t>;
+	case PhysicalType::INT16:
+		return TemplatedUpdateNumericStatistics<int16_t>;
+	case PhysicalType::INT32:
+		return TemplatedUpdateNumericStatistics<int32_t>;
+	case PhysicalType::INT64:
+		return TemplatedUpdateNumericStatistics<int64_t>;
+	case PhysicalType::UINT8:
+		return TemplatedUpdateNumericStatistics<uint8_t>;
+	case PhysicalType::UINT16:
+		return TemplatedUpdateNumericStatistics<uint16_t>;
+	case PhysicalType::UINT32:
+		return TemplatedUpdateNumericStatistics<uint32_t>;
+	case PhysicalType::UINT64:
+		return TemplatedUpdateNumericStatistics<uint64_t>;
+	case PhysicalType::INT128:
+		return TemplatedUpdateNumericStatistics<hugeint_t>;
+	case PhysicalType::FLOAT:
+		return TemplatedUpdateNumericStatistics<float>;
+	case PhysicalType::DOUBLE:
+		return TemplatedUpdateNumericStatistics<double>;
+	case PhysicalType::INTERVAL:
+		return TemplatedUpdateNumericStatistics<interval_t>;
+	case PhysicalType::VARCHAR:
+		return UpdateStringStatistics;
+	default:
+		throw NotImplementedException("Unimplemented type for uncompressed segment");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Update
+//===--------------------------------------------------------------------===//
+static idx_t SortSelectionVector(SelectionVector &sel, idx_t count, row_t *ids) {
+	D_ASSERT(count > 0);
+
+	bool is_sorted = true;
+	for (idx_t i = 1; i < count; i++) {
+		auto prev_idx = sel.get_index(i - 1);
+		auto idx = sel.get_index(i);
+		if (ids[idx] <= ids[prev_idx]) {
+			is_sorted = false;
+			break;
+		}
+	}
+	if (is_sorted) {
+		// already sorted: bailout
+		return count;
+	}
+	// not sorted: need to sort the selection vector
+	SelectionVector sorted_sel(count);
+	for (idx_t i = 0; i < count; i++) {
+		sorted_sel.set_index(i, sel.get_index(i));
+	}
+	std::sort(sorted_sel.data(), sorted_sel.data() + count, [&](sel_t l, sel_t r) { return ids[l] < ids[r]; });
+	// eliminate any duplicates
+	idx_t pos = 1;
+	for (idx_t i = 1; i < count; i++) {
+		auto prev_idx = sorted_sel.get_index(i - 1);
+		auto idx = sorted_sel.get_index(i);
+		D_ASSERT(ids[idx] >= ids[prev_idx]);
+		if (ids[prev_idx] != ids[idx]) {
+			sorted_sel.set_index(pos++, idx);
+		}
+	}
+#ifdef DEBUG
+	for (idx_t i = 1; i < pos; i++) {
+		auto prev_idx = sorted_sel.get_index(i - 1);
+		auto idx = sorted_sel.get_index(i);
+		D_ASSERT(ids[idx] > ids[prev_idx]);
+	}
+#endif
+
+	sel.Initialize(sorted_sel);
+	D_ASSERT(pos > 0);
+	return pos;
+}
+
+void UpdateSegment::Update(Transaction &transaction, idx_t column_index, Vector &update, row_t *ids, idx_t count,
+                           Vector &base_data) {
+	// obtain an exclusive lock
+	auto write_lock = lock.GetExclusiveLock();
+
+	update.Normalify(count);
+
+	// update statistics
+	SelectionVector sel;
+	{
+		lock_guard<mutex> stats_guard(stats_lock);
+		count = statistics_update_function(this, stats, update, count, sel);
+	}
+	if (count == 0) {
+		return;
+	}
+
+	// subsequent algorithms used by the update require row ids to be (1) sorted, and (2) unique
+	// this is usually the case for "standard" queries (e.g. UPDATE tbl SET x=bla WHERE cond)
+	// however, for more exotic queries involving e.g. cross products/joins this might not be the case
+	// hence we explicitly check here if the ids are sorted and, if not, sort + duplicate eliminate them
+	count = SortSelectionVector(sel, count, ids);
+	D_ASSERT(count > 0);
+
+	// create the versions for this segment, if there are none yet
+	if (!root) {
+		root = make_unique<UpdateNode>();
+	}
+
+	// get the vector index based on the first id
+	// we assert that all updates must be part of the same vector
+	auto first_id = ids[sel.get_index(0)];
+	idx_t vector_index = (first_id - column_data.start) / STANDARD_VECTOR_SIZE;
+	idx_t vector_offset = column_data.start + vector_index * STANDARD_VECTOR_SIZE;
+
+	D_ASSERT(idx_t(first_id) >= column_data.start);
+	D_ASSERT(vector_index < RowGroup::ROW_GROUP_VECTOR_COUNT);
+
+	// first check the version chain
+	UpdateInfo *node = nullptr;
+
+	if (root->info[vector_index]) {
+		// there is already a version here, check if there are any conflicts and search for the node that belongs to
+		// this transaction in the version chain
+		auto base_info = root->info[vector_index]->info.get();
+		CheckForConflicts(base_info->next, transaction, ids, sel, count, vector_offset, node);
+
+		// there are no conflicts
+		// first, check if this thread has already done any updates
+		auto node = base_info->next;
+		while (node) {
+			if (node->version_number == transaction.transaction_id) {
+				// it has! use this node
+				break;
+			}
+			node = node->next;
+		}
+		if (!node) {
+			// no updates made yet by this transaction: initially the update info to empty
+			node = transaction.CreateUpdateInfo(type_size, count);
+			node->segment = this;
+			node->vector_index = vector_index;
+			node->N = 0;
+			node->column_index = column_index;
+
+			// insert the new node into the chain
+			node->next = base_info->next;
+			if (node->next) {
+				node->next->prev = node;
+			}
+			node->prev = base_info;
+			base_info->next = node;
+		}
+		base_info->Verify();
+		node->Verify();
+
+		// now we are going to perform the merge
+		merge_update_function(base_info, base_data, node, update, ids, count, sel);
+
+		base_info->Verify();
+		node->Verify();
+	} else {
+		// there is no version info yet: create the top level update info and fill it with the updates
+		auto result = make_unique<UpdateNodeData>();
+
+		result->info = make_unique<UpdateInfo>();
+		result->tuples = unique_ptr<sel_t[]>(new sel_t[STANDARD_VECTOR_SIZE]);
+		result->tuple_data = unique_ptr<data_t[]>(new data_t[STANDARD_VECTOR_SIZE * type_size]);
+		result->info->tuples = result->tuples.get();
+		result->info->tuple_data = result->tuple_data.get();
+		result->info->version_number = TRANSACTION_ID_START - 1;
+		result->info->column_index = column_index;
+		InitializeUpdateInfo(*result->info, ids, sel, count, vector_index, vector_offset);
+
+		// now create the transaction level update info in the undo log
+		auto transaction_node = transaction.CreateUpdateInfo(type_size, count);
+		InitializeUpdateInfo(*transaction_node, ids, sel, count, vector_index, vector_offset);
+
+		// we write the updates in the
+		initialize_update_function(transaction_node, base_data, result->info.get(), update, sel);
+
+		result->info->next = transaction_node;
+		result->info->prev = nullptr;
+		transaction_node->next = nullptr;
+		transaction_node->prev = result->info.get();
+		transaction_node->column_index = column_index;
+
+		transaction_node->Verify();
+		result->info->Verify();
+
+		root->info[vector_index] = move(result);
+	}
+}
+
+bool UpdateSegment::HasUpdates() const {
+	return root.get() != nullptr;
+}
+
+bool UpdateSegment::HasUpdates(idx_t vector_index) const {
+	if (!HasUpdates()) {
+		return false;
+	}
+	return root->info[vector_index].get();
+}
+
+bool UpdateSegment::HasUncommittedUpdates(idx_t vector_index) {
+	if (!HasUpdates(vector_index)) {
+		return false;
+	}
+	auto read_lock = lock.GetSharedLock();
+	auto entry = root->info[vector_index].get();
+	if (entry->info->next) {
+		return true;
+	}
+	return false;
+}
+
+bool UpdateSegment::HasUpdates(idx_t start_row_index, idx_t end_row_index) {
+	if (!HasUpdates()) {
+		return false;
+	}
+	auto read_lock = lock.GetSharedLock();
+	idx_t base_vector_index = start_row_index / STANDARD_VECTOR_SIZE;
+	idx_t end_vector_index = end_row_index / STANDARD_VECTOR_SIZE;
+	for (idx_t i = base_vector_index; i <= end_vector_index; i++) {
+		if (root->info[i]) {
+			return true;
+		}
+	}
+	return false;
+}
+
+} // namespace duckdb
+
+
+
+
+namespace duckdb {
+
+ValidityColumnData::ValidityColumnData(DataTableInfo &info, idx_t column_index, idx_t start_row, ColumnData *parent)
+    : ColumnData(info, column_index, start_row, LogicalType(LogicalTypeId::VALIDITY), parent) {
+}
+
+bool ValidityColumnData::CheckZonemap(ColumnScanState &state, TableFilter &filter) {
+	return true;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+class ReplayState {
+public:
+	ReplayState(DatabaseInstance &db, ClientContext &context, Deserializer &source)
+	    : db(db), context(context), source(source), current_table(nullptr), deserialize_only(false),
+	      checkpoint_id(INVALID_BLOCK) {
+	}
+
+	DatabaseInstance &db;
+	ClientContext &context;
+	Deserializer &source;
+	TableCatalogEntry *current_table;
+	bool deserialize_only;
+	block_id_t checkpoint_id;
+
+public:
+	void ReplayEntry(WALType entry_type);
+
+private:
+	void ReplayCreateTable();
+	void ReplayDropTable();
+	void ReplayAlter();
+
+	void ReplayCreateView();
+	void ReplayDropView();
+
+	void ReplayCreateSchema();
+	void ReplayDropSchema();
+
+	void ReplayCreateType();
+	void ReplayDropType();
+
+	void ReplayCreateSequence();
+	void ReplayDropSequence();
+	void ReplaySequenceValue();
+
+	void ReplayCreateMacro();
+	void ReplayDropMacro();
+
+	void ReplayCreateTableMacro();
+	void ReplayDropTableMacro();
+
+	void ReplayUseTable();
+	void ReplayInsert();
+	void ReplayDelete();
+	void ReplayUpdate();
+	void ReplayCheckpoint();
+};
+
+bool WriteAheadLog::Replay(DatabaseInstance &database, string &path) {
+	auto initial_reader = make_unique<BufferedFileReader>(database.GetFileSystem(), path.c_str());
+	if (initial_reader->Finished()) {
+		// WAL is empty
+		return false;
+	}
+	Connection con(database);
+	con.BeginTransaction();
+
+	// first deserialize the WAL to look for a checkpoint flag
+	// if there is a checkpoint flag, we might have already flushed the contents of the WAL to disk
+	ReplayState checkpoint_state(database, *con.context, *initial_reader);
+	checkpoint_state.deserialize_only = true;
+	try {
+		while (true) {
+			// read the current entry
+			WALType entry_type = initial_reader->Read<WALType>();
+			if (entry_type == WALType::WAL_FLUSH) {
+				// check if the file is exhausted
+				if (initial_reader->Finished()) {
+					// we finished reading the file: break
+					break;
+				}
+			} else {
+				// replay the entry
+				checkpoint_state.ReplayEntry(entry_type);
+			}
+		}
+	} catch (std::exception &ex) { // LCOV_EXCL_START
+		Printer::Print(StringUtil::Format("Exception in WAL playback during initial read: %s\n", ex.what()));
+		return false;
+	} catch (...) {
+		Printer::Print("Unknown Exception in WAL playback during initial read");
+		return false;
+	} // LCOV_EXCL_STOP
+	initial_reader.reset();
+	if (checkpoint_state.checkpoint_id != INVALID_BLOCK) {
+		// there is a checkpoint flag: check if we need to deserialize the WAL
+		auto &manager = BlockManager::GetBlockManager(database);
+		if (manager.IsRootBlock(checkpoint_state.checkpoint_id)) {
+			// the contents of the WAL have already been checkpointed
+			// we can safely truncate the WAL and ignore its contents
+			return true;
+		}
+	}
+
+	// we need to recover from the WAL: actually set up the replay state
+	BufferedFileReader reader(database.GetFileSystem(), path.c_str());
+	ReplayState state(database, *con.context, reader);
+
+	// replay the WAL
+	// note that everything is wrapped inside a try/catch block here
+	// there can be errors in WAL replay because of a corrupt WAL file
+	// in this case we should throw a warning but startup anyway
+	try {
+		while (true) {
+			// read the current entry
+			WALType entry_type = reader.Read<WALType>();
+			if (entry_type == WALType::WAL_FLUSH) {
+				// flush: commit the current transaction
+				con.Commit();
+				// check if the file is exhausted
+				if (reader.Finished()) {
+					// we finished reading the file: break
+					break;
+				}
+				// otherwise we keep on reading
+				con.BeginTransaction();
+			} else {
+				// replay the entry
+				state.ReplayEntry(entry_type);
+			}
+		}
+	} catch (std::exception &ex) { // LCOV_EXCL_START
+		// FIXME: this should report a proper warning in the connection
+		Printer::Print(StringUtil::Format("Exception in WAL playback: %s\n", ex.what()));
+		// exception thrown in WAL replay: rollback
+		con.Rollback();
+	} catch (...) {
+		Printer::Print("Unknown Exception in WAL playback: %s\n");
+		// exception thrown in WAL replay: rollback
+		con.Rollback();
+	} // LCOV_EXCL_STOP
+	return false;
+}
+
+//===--------------------------------------------------------------------===//
+// Replay Entries
+//===--------------------------------------------------------------------===//
+void ReplayState::ReplayEntry(WALType entry_type) {
+	switch (entry_type) {
+	case WALType::CREATE_TABLE:
+		ReplayCreateTable();
+		break;
+	case WALType::DROP_TABLE:
+		ReplayDropTable();
+		break;
+	case WALType::ALTER_INFO:
+		ReplayAlter();
+		break;
+	case WALType::CREATE_VIEW:
+		ReplayCreateView();
+		break;
+	case WALType::DROP_VIEW:
+		ReplayDropView();
+		break;
+	case WALType::CREATE_SCHEMA:
+		ReplayCreateSchema();
+		break;
+	case WALType::DROP_SCHEMA:
+		ReplayDropSchema();
+		break;
+	case WALType::CREATE_SEQUENCE:
+		ReplayCreateSequence();
+		break;
+	case WALType::DROP_SEQUENCE:
+		ReplayDropSequence();
+		break;
+	case WALType::SEQUENCE_VALUE:
+		ReplaySequenceValue();
+		break;
+	case WALType::CREATE_MACRO:
+		ReplayCreateMacro();
+		break;
+	case WALType::DROP_MACRO:
+		ReplayDropMacro();
+		break;
+	case WALType::CREATE_TABLE_MACRO:
+		ReplayCreateTableMacro();
+		break;
+	case WALType::DROP_TABLE_MACRO:
+		ReplayDropTableMacro();
+		break;
+	case WALType::USE_TABLE:
+		ReplayUseTable();
+		break;
+	case WALType::INSERT_TUPLE:
+		ReplayInsert();
+		break;
+	case WALType::DELETE_TUPLE:
+		ReplayDelete();
+		break;
+	case WALType::UPDATE_TUPLE:
+		ReplayUpdate();
+		break;
+	case WALType::CHECKPOINT:
+		ReplayCheckpoint();
+		break;
+	case WALType::CREATE_TYPE:
+		ReplayCreateType();
+		break;
+	case WALType::DROP_TYPE:
+		ReplayDropType();
+		break;
+
+	default:
+		throw InternalException("Invalid WAL entry type!");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Replay Table
+//===--------------------------------------------------------------------===//
+void ReplayState::ReplayCreateTable() {
+	auto info = TableCatalogEntry::Deserialize(source);
+	if (deserialize_only) {
+		return;
+	}
+
+	// bind the constraints to the table again
+	auto binder = Binder::CreateBinder(context);
+	auto bound_info = binder->BindCreateTableInfo(move(info));
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.CreateTable(context, bound_info.get());
+}
+
+void ReplayState::ReplayDropTable() {
+	DropInfo info;
+
+	info.type = CatalogType::TABLE_ENTRY;
+	info.schema = source.Read<string>();
+	info.name = source.Read<string>();
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.DropEntry(context, &info);
+}
+
+void ReplayState::ReplayAlter() {
+	auto info = AlterInfo::Deserialize(source);
+	if (deserialize_only) {
+		return;
+	}
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.Alter(context, info.get());
+}
+
+//===--------------------------------------------------------------------===//
+// Replay View
+//===--------------------------------------------------------------------===//
+void ReplayState::ReplayCreateView() {
+	auto entry = ViewCatalogEntry::Deserialize(source);
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.CreateView(context, entry.get());
+}
+
+void ReplayState::ReplayDropView() {
+	DropInfo info;
+	info.type = CatalogType::VIEW_ENTRY;
+	info.schema = source.Read<string>();
+	info.name = source.Read<string>();
+	if (deserialize_only) {
+		return;
+	}
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.DropEntry(context, &info);
+}
+
+//===--------------------------------------------------------------------===//
+// Replay Schema
+//===--------------------------------------------------------------------===//
+void ReplayState::ReplayCreateSchema() {
+	CreateSchemaInfo info;
+	info.schema = source.Read<string>();
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.CreateSchema(context, &info);
+}
+
+void ReplayState::ReplayDropSchema() {
+	DropInfo info;
+
+	info.type = CatalogType::SCHEMA_ENTRY;
+	info.name = source.Read<string>();
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.DropEntry(context, &info);
+}
+
+//===--------------------------------------------------------------------===//
+// Replay Custom Type
+//===--------------------------------------------------------------------===//
+void ReplayState::ReplayCreateType() {
+	auto info = TypeCatalogEntry::Deserialize(source);
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.CreateType(context, info.get());
+}
+
+void ReplayState::ReplayDropType() {
+	DropInfo info;
+
+	info.type = CatalogType::TYPE_ENTRY;
+	info.schema = source.Read<string>();
+	info.name = source.Read<string>();
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.DropEntry(context, &info);
+}
+
+//===--------------------------------------------------------------------===//
+// Replay Sequence
+//===--------------------------------------------------------------------===//
+void ReplayState::ReplayCreateSequence() {
+	auto entry = SequenceCatalogEntry::Deserialize(source);
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.CreateSequence(context, entry.get());
+}
+
+void ReplayState::ReplayDropSequence() {
+	DropInfo info;
+	info.type = CatalogType::SEQUENCE_ENTRY;
+	info.schema = source.Read<string>();
+	info.name = source.Read<string>();
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.DropEntry(context, &info);
+}
+
+void ReplayState::ReplaySequenceValue() {
+	auto schema = source.Read<string>();
+	auto name = source.Read<string>();
+	auto usage_count = source.Read<uint64_t>();
+	auto counter = source.Read<int64_t>();
+	if (deserialize_only) {
+		return;
+	}
+
+	// fetch the sequence from the catalog
+	auto &catalog = Catalog::GetCatalog(context);
+	auto seq = catalog.GetEntry<SequenceCatalogEntry>(context, schema, name);
+	if (usage_count > seq->usage_count) {
+		seq->usage_count = usage_count;
+		seq->counter = counter;
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Replay Macro
+//===--------------------------------------------------------------------===//
+void ReplayState::ReplayCreateMacro() {
+	auto entry = ScalarMacroCatalogEntry::Deserialize(source);
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.CreateFunction(context, entry.get());
+}
+
+void ReplayState::ReplayDropMacro() {
+	DropInfo info;
+	info.type = CatalogType::MACRO_ENTRY;
+	info.schema = source.Read<string>();
+	info.name = source.Read<string>();
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.DropEntry(context, &info);
+}
+
+//===--------------------------------------------------------------------===//
+// Replay Table Macro
+//===--------------------------------------------------------------------===//
+void ReplayState::ReplayCreateTableMacro() {
+	auto entry = TableMacroCatalogEntry::Deserialize(source);
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.CreateFunction(context, entry.get());
+}
+
+void ReplayState::ReplayDropTableMacro() {
+	DropInfo info;
+	info.type = CatalogType::TABLE_MACRO_ENTRY;
+	info.schema = source.Read<string>();
+	info.name = source.Read<string>();
+	if (deserialize_only) {
+		return;
+	}
+
+	auto &catalog = Catalog::GetCatalog(context);
+	catalog.DropEntry(context, &info);
+}
+
+//===--------------------------------------------------------------------===//
+// Replay Data
+//===--------------------------------------------------------------------===//
+void ReplayState::ReplayUseTable() {
+	auto schema_name = source.Read<string>();
+	auto table_name = source.Read<string>();
+	if (deserialize_only) {
+		return;
+	}
+	auto &catalog = Catalog::GetCatalog(context);
+	current_table = catalog.GetEntry<TableCatalogEntry>(context, schema_name, table_name);
+}
+
+void ReplayState::ReplayInsert() {
+	DataChunk chunk;
+	chunk.Deserialize(source);
+	if (deserialize_only) {
+		return;
+	}
+	if (!current_table) {
+		throw Exception("Corrupt WAL: insert without table");
+	}
+
+	// append to the current table
+	current_table->storage->Append(*current_table, context, chunk);
+}
+
+void ReplayState::ReplayDelete() {
+	DataChunk chunk;
+	chunk.Deserialize(source);
+	if (deserialize_only) {
+		return;
+	}
+	if (!current_table) {
+		throw InternalException("Corrupt WAL: delete without table");
+	}
+
+	D_ASSERT(chunk.ColumnCount() == 1 && chunk.data[0].GetType() == LogicalType::ROW_TYPE);
+	row_t row_ids[1];
+	Vector row_identifiers(LogicalType::ROW_TYPE, (data_ptr_t)row_ids);
+
+	auto source_ids = FlatVector::GetData<row_t>(chunk.data[0]);
+	// delete the tuples from the current table
+	for (idx_t i = 0; i < chunk.size(); i++) {
+		row_ids[0] = source_ids[i];
+		current_table->storage->Delete(*current_table, context, row_identifiers, 1);
+	}
+}
+
+void ReplayState::ReplayUpdate() {
+	vector<column_t> column_path;
+	auto column_index_count = source.Read<idx_t>();
+	column_path.reserve(column_index_count);
+	for (idx_t i = 0; i < column_index_count; i++) {
+		column_path.push_back(source.Read<column_t>());
+	}
+	DataChunk chunk;
+	chunk.Deserialize(source);
+	if (deserialize_only) {
+		return;
+	}
+	if (!current_table) {
+		throw InternalException("Corrupt WAL: update without table");
+	}
+
+	if (column_path[0] >= current_table->columns.size()) {
+		throw InternalException("Corrupt WAL: column index for update out of bounds");
+	}
+
+	// remove the row id vector from the chunk
+	auto row_ids = move(chunk.data.back());
+	chunk.data.pop_back();
+
+	// now perform the update
+	current_table->storage->UpdateColumn(*current_table, context, row_ids, column_path, chunk);
+}
+
+void ReplayState::ReplayCheckpoint() {
+	checkpoint_id = source.Read<block_id_t>();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+WriteAheadLog::WriteAheadLog(DatabaseInstance &database) : initialized(false), skip_writing(false), database(database) {
+}
+
+void WriteAheadLog::Initialize(string &path) {
+	wal_path = path;
+	writer = make_unique<BufferedFileWriter>(database.GetFileSystem(), path.c_str(),
+	                                         FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE |
+	                                             FileFlags::FILE_FLAGS_APPEND);
+	initialized = true;
+}
+
+int64_t WriteAheadLog::GetWALSize() {
+	D_ASSERT(writer);
+	return writer->GetFileSize();
+}
+
+idx_t WriteAheadLog::GetTotalWritten() {
+	D_ASSERT(writer);
+	return writer->GetTotalWritten();
+}
+
+void WriteAheadLog::Truncate(int64_t size) {
+	writer->Truncate(size);
+}
+
+void WriteAheadLog::Delete() {
+	if (!initialized) {
+		return;
+	}
+	initialized = false;
+	writer.reset();
+
+	auto &fs = FileSystem::GetFileSystem(database);
+	fs.RemoveFile(wal_path);
+}
+
+//===--------------------------------------------------------------------===//
+// Write Entries
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteCheckpoint(block_id_t meta_block) {
+	writer->Write<WALType>(WALType::CHECKPOINT);
+	writer->Write<block_id_t>(meta_block);
+}
+
+//===--------------------------------------------------------------------===//
+// CREATE TABLE
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteCreateTable(TableCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::CREATE_TABLE);
+	entry->Serialize(*writer);
+}
+
+//===--------------------------------------------------------------------===//
+// DROP TABLE
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteDropTable(TableCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::DROP_TABLE);
+	writer->WriteString(entry->schema->name);
+	writer->WriteString(entry->name);
+}
+
+//===--------------------------------------------------------------------===//
+// CREATE SCHEMA
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteCreateSchema(SchemaCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::CREATE_SCHEMA);
+	writer->WriteString(entry->name);
+}
+
+//===--------------------------------------------------------------------===//
+// SEQUENCES
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteCreateSequence(SequenceCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::CREATE_SEQUENCE);
+	entry->Serialize(*writer);
+}
+
+void WriteAheadLog::WriteDropSequence(SequenceCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::DROP_SEQUENCE);
+	writer->WriteString(entry->schema->name);
+	writer->WriteString(entry->name);
+}
+
+void WriteAheadLog::WriteSequenceValue(SequenceCatalogEntry *entry, SequenceValue val) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::SEQUENCE_VALUE);
+	writer->WriteString(entry->schema->name);
+	writer->WriteString(entry->name);
+	writer->Write<uint64_t>(val.usage_count);
+	writer->Write<int64_t>(val.counter);
+}
+
+//===--------------------------------------------------------------------===//
+// MACRO'S
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteCreateMacro(ScalarMacroCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::CREATE_MACRO);
+	entry->Serialize(*writer);
+}
+
+void WriteAheadLog::WriteDropMacro(ScalarMacroCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::DROP_MACRO);
+	writer->WriteString(entry->schema->name);
+	writer->WriteString(entry->name);
+}
+
+void WriteAheadLog::WriteCreateTableMacro(TableMacroCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::CREATE_TABLE_MACRO);
+	entry->Serialize(*writer);
+}
+
+void WriteAheadLog::WriteDropTableMacro(TableMacroCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::DROP_TABLE_MACRO);
+	writer->WriteString(entry->schema->name);
+	writer->WriteString(entry->name);
+}
+
+//===--------------------------------------------------------------------===//
+// Custom Types
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteCreateType(TypeCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::CREATE_TYPE);
+	entry->Serialize(*writer);
+}
+
+void WriteAheadLog::WriteDropType(TypeCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::DROP_TYPE);
+	writer->WriteString(entry->schema->name);
+	writer->WriteString(entry->name);
+}
+
+//===--------------------------------------------------------------------===//
+// VIEWS
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteCreateView(ViewCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::CREATE_VIEW);
+	entry->Serialize(*writer);
+}
+
+void WriteAheadLog::WriteDropView(ViewCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::DROP_VIEW);
+	writer->WriteString(entry->schema->name);
+	writer->WriteString(entry->name);
+}
+
+//===--------------------------------------------------------------------===//
+// DROP SCHEMA
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteDropSchema(SchemaCatalogEntry *entry) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::DROP_SCHEMA);
+	writer->WriteString(entry->name);
+}
+
+//===--------------------------------------------------------------------===//
+// DATA
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteSetTable(string &schema, string &table) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::USE_TABLE);
+	writer->WriteString(schema);
+	writer->WriteString(table);
+}
+
+void WriteAheadLog::WriteInsert(DataChunk &chunk) {
+	if (skip_writing) {
+		return;
+	}
+	D_ASSERT(chunk.size() > 0);
+	chunk.Verify();
+
+	writer->Write<WALType>(WALType::INSERT_TUPLE);
+	chunk.Serialize(*writer);
+}
+
+void WriteAheadLog::WriteDelete(DataChunk &chunk) {
+	if (skip_writing) {
+		return;
+	}
+	D_ASSERT(chunk.size() > 0);
+	D_ASSERT(chunk.ColumnCount() == 1 && chunk.data[0].GetType() == LogicalType::ROW_TYPE);
+	chunk.Verify();
+
+	writer->Write<WALType>(WALType::DELETE_TUPLE);
+	chunk.Serialize(*writer);
+}
+
+void WriteAheadLog::WriteUpdate(DataChunk &chunk, const vector<column_t> &column_indexes) {
+	if (skip_writing) {
+		return;
+	}
+	D_ASSERT(chunk.size() > 0);
+	D_ASSERT(chunk.ColumnCount() == 2);
+	D_ASSERT(chunk.data[1].GetType().id() == LogicalType::ROW_TYPE);
+	chunk.Verify();
+
+	writer->Write<WALType>(WALType::UPDATE_TUPLE);
+	writer->Write<idx_t>(column_indexes.size());
+	for (auto &col_idx : column_indexes) {
+		writer->Write<column_t>(col_idx);
+	}
+	chunk.Serialize(*writer);
+}
+
+//===--------------------------------------------------------------------===//
+// Write ALTER Statement
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::WriteAlter(AlterInfo &info) {
+	if (skip_writing) {
+		return;
+	}
+	writer->Write<WALType>(WALType::ALTER_INFO);
+	info.Serialize(*writer);
+}
+
+//===--------------------------------------------------------------------===//
+// FLUSH
+//===--------------------------------------------------------------------===//
+void WriteAheadLog::Flush() {
+	if (skip_writing) {
+		return;
+	}
+	// write an empty entry
+	writer->Write<WALType>(WALType::WAL_FLUSH);
+	// flushes all changes made to the WAL to disk
+	writer->Sync();
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+CleanupState::CleanupState() : current_table(nullptr), count(0) {
+}
+
+CleanupState::~CleanupState() {
+	Flush();
+}
+
+void CleanupState::CleanupEntry(UndoFlags type, data_ptr_t data) {
+	switch (type) {
+	case UndoFlags::CATALOG_ENTRY: {
+		auto catalog_entry = Load<CatalogEntry *>(data);
+		D_ASSERT(catalog_entry);
+		D_ASSERT(catalog_entry->set);
+		catalog_entry->set->CleanupEntry(catalog_entry);
+		break;
+	}
+	case UndoFlags::DELETE_TUPLE: {
+		auto info = (DeleteInfo *)data;
+		CleanupDelete(info);
+		break;
+	}
+	case UndoFlags::UPDATE_TUPLE: {
+		auto info = (UpdateInfo *)data;
+		CleanupUpdate(info);
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+void CleanupState::CleanupUpdate(UpdateInfo *info) {
+	// remove the update info from the update chain
+	// first obtain an exclusive lock on the segment
+	info->segment->CleanupUpdate(info);
+}
+
+void CleanupState::CleanupDelete(DeleteInfo *info) {
+	auto version_table = info->table;
+	version_table->info->cardinality -= info->count;
+	if (version_table->info->indexes.Empty()) {
+		// this table has no indexes: no cleanup to be done
+		return;
+	}
+	if (current_table != version_table) {
+		// table for this entry differs from previous table: flush and switch to the new table
+		Flush();
+		current_table = version_table;
+	}
+	count = 0;
+	for (idx_t i = 0; i < info->count; i++) {
+		row_numbers[count++] = info->vinfo->start + info->rows[i];
+	}
+	Flush();
+}
+
+void CleanupState::Flush() {
+	if (count == 0) {
+		return;
+	}
+
+	// set up the row identifiers vector
+	Vector row_identifiers(LogicalType::ROW_TYPE, (data_ptr_t)row_numbers);
+
+	// delete the tuples from all the indexes
+	current_table->RemoveFromIndexes(row_identifiers, count);
+
+	count = 0;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+CommitState::CommitState(transaction_t commit_id, WriteAheadLog *log)
+    : log(log), commit_id(commit_id), current_table_info(nullptr) {
+}
+
+void CommitState::SwitchTable(DataTableInfo *table_info, UndoFlags new_op) {
+	if (current_table_info != table_info) {
+		// write the current table to the log
+		log->WriteSetTable(table_info->schema, table_info->table);
+		current_table_info = table_info;
+	}
+}
+
+void CommitState::WriteCatalogEntry(CatalogEntry *entry, data_ptr_t dataptr) {
+	if (entry->temporary || entry->parent->temporary) {
+		return;
+	}
+	D_ASSERT(log);
+	// look at the type of the parent entry
+	auto parent = entry->parent;
+	switch (parent->type) {
+	case CatalogType::TABLE_ENTRY:
+		if (entry->type == CatalogType::TABLE_ENTRY) {
+			auto table_entry = (TableCatalogEntry *)entry;
+			// ALTER TABLE statement, read the extra data after the entry
+			auto extra_data_size = Load<idx_t>(dataptr);
+			auto extra_data = (data_ptr_t)(dataptr + sizeof(idx_t));
+			// deserialize it
+			BufferedDeserializer source(extra_data, extra_data_size);
+			auto info = AlterInfo::Deserialize(source);
+			// write the alter table in the log
+			table_entry->CommitAlter(*info);
+			log->WriteAlter(*info);
+		} else {
+			// CREATE TABLE statement
+			log->WriteCreateTable((TableCatalogEntry *)parent);
+		}
+		break;
+	case CatalogType::SCHEMA_ENTRY:
+		if (entry->type == CatalogType::SCHEMA_ENTRY) {
+			// ALTER TABLE statement, skip it
+			return;
+		}
+		log->WriteCreateSchema((SchemaCatalogEntry *)parent);
+		break;
+	case CatalogType::VIEW_ENTRY:
+		if (entry->type == CatalogType::VIEW_ENTRY) {
+			// ALTER TABLE statement, read the extra data after the entry
+			auto extra_data_size = Load<idx_t>(dataptr);
+			auto extra_data = (data_ptr_t)(dataptr + sizeof(idx_t));
+			// deserialize it
+			BufferedDeserializer source(extra_data, extra_data_size);
+			auto info = AlterInfo::Deserialize(source);
+			// write the alter table in the log
+			log->WriteAlter(*info);
+		} else {
+			log->WriteCreateView((ViewCatalogEntry *)parent);
+		}
+		break;
+	case CatalogType::SEQUENCE_ENTRY:
+		log->WriteCreateSequence((SequenceCatalogEntry *)parent);
+		break;
+	case CatalogType::MACRO_ENTRY:
+		log->WriteCreateMacro((ScalarMacroCatalogEntry *)parent);
+		break;
+	case CatalogType::TABLE_MACRO_ENTRY:
+		log->WriteCreateTableMacro((TableMacroCatalogEntry *)parent);
+		break;
+
+	case CatalogType::TYPE_ENTRY:
+		log->WriteCreateType((TypeCatalogEntry *)parent);
+		break;
+	case CatalogType::DELETED_ENTRY:
+		switch (entry->type) {
+		case CatalogType::TABLE_ENTRY: {
+			auto table_entry = (TableCatalogEntry *)entry;
+			table_entry->CommitDrop();
+			log->WriteDropTable(table_entry);
+			break;
+		}
+		case CatalogType::SCHEMA_ENTRY:
+			log->WriteDropSchema((SchemaCatalogEntry *)entry);
+			break;
+		case CatalogType::VIEW_ENTRY:
+			log->WriteDropView((ViewCatalogEntry *)entry);
+			break;
+		case CatalogType::SEQUENCE_ENTRY:
+			log->WriteDropSequence((SequenceCatalogEntry *)entry);
+			break;
+		case CatalogType::MACRO_ENTRY:
+			log->WriteDropMacro((ScalarMacroCatalogEntry *)entry);
+			break;
+		case CatalogType::TABLE_MACRO_ENTRY:
+			log->WriteDropTableMacro((TableMacroCatalogEntry *)entry);
+			break;
+		case CatalogType::TYPE_ENTRY:
+			log->WriteDropType((TypeCatalogEntry *)entry);
+			break;
+		case CatalogType::INDEX_ENTRY:
+		case CatalogType::PREPARED_STATEMENT:
+		case CatalogType::SCALAR_FUNCTION_ENTRY:
+			// do nothing, indexes/prepared statements/functions aren't persisted to disk
+			break;
+		default:
+			throw InternalException("Don't know how to drop this type!");
+		}
+		break;
+	case CatalogType::INDEX_ENTRY:
+	case CatalogType::PREPARED_STATEMENT:
+	case CatalogType::AGGREGATE_FUNCTION_ENTRY:
+	case CatalogType::SCALAR_FUNCTION_ENTRY:
+	case CatalogType::TABLE_FUNCTION_ENTRY:
+	case CatalogType::COPY_FUNCTION_ENTRY:
+	case CatalogType::PRAGMA_FUNCTION_ENTRY:
+	case CatalogType::COLLATION_ENTRY:
+		// do nothing, these entries are not persisted to disk
+		break;
+	default:
+		throw InternalException("UndoBuffer - don't know how to write this entry to the WAL");
+	}
+}
+
+void CommitState::WriteDelete(DeleteInfo *info) {
+	D_ASSERT(log);
+	// switch to the current table, if necessary
+	SwitchTable(info->table->info.get(), UndoFlags::DELETE_TUPLE);
+
+	if (!delete_chunk) {
+		delete_chunk = make_unique<DataChunk>();
+		vector<LogicalType> delete_types = {LogicalType::ROW_TYPE};
+		delete_chunk->Initialize(delete_types);
+	}
+	auto rows = FlatVector::GetData<row_t>(delete_chunk->data[0]);
+	for (idx_t i = 0; i < info->count; i++) {
+		rows[i] = info->base_row + info->rows[i];
+	}
+	delete_chunk->SetCardinality(info->count);
+	log->WriteDelete(*delete_chunk);
+}
+
+void CommitState::WriteUpdate(UpdateInfo *info) {
+	D_ASSERT(log);
+	// switch to the current table, if necessary
+	auto &column_data = info->segment->column_data;
+	auto &table_info = column_data.GetTableInfo();
+
+	SwitchTable(&table_info, UndoFlags::UPDATE_TUPLE);
+
+	// initialize the update chunk
+	vector<LogicalType> update_types;
+	if (column_data.type.id() == LogicalTypeId::VALIDITY) {
+		update_types.emplace_back(LogicalType::BOOLEAN);
+	} else {
+		update_types.push_back(column_data.type);
+	}
+	update_types.emplace_back(LogicalType::ROW_TYPE);
+
+	update_chunk = make_unique<DataChunk>();
+	update_chunk->Initialize(update_types);
+
+	// fetch the updated values from the base segment
+	info->segment->FetchCommitted(info->vector_index, update_chunk->data[0]);
+
+	// write the row ids into the chunk
+	auto row_ids = FlatVector::GetData<row_t>(update_chunk->data[1]);
+	idx_t start = column_data.start + info->vector_index * STANDARD_VECTOR_SIZE;
+	for (idx_t i = 0; i < info->N; i++) {
+		row_ids[info->tuples[i]] = start + info->tuples[i];
+	}
+	if (column_data.type.id() == LogicalTypeId::VALIDITY) {
+		// zero-initialize the booleans
+		// FIXME: this is only required because of NullValue<T> in Vector::Serialize...
+		auto booleans = FlatVector::GetData<bool>(update_chunk->data[0]);
+		for (idx_t i = 0; i < info->N; i++) {
+			auto idx = info->tuples[i];
+			booleans[idx] = false;
+		}
+	}
+	SelectionVector sel(info->tuples);
+	update_chunk->Slice(sel, info->N);
+
+	// construct the column index path
+	vector<column_t> column_indexes;
+	auto column_data_ptr = &column_data;
+	while (column_data_ptr->parent) {
+		column_indexes.push_back(column_data_ptr->column_index);
+		column_data_ptr = column_data_ptr->parent;
+	}
+	column_indexes.push_back(info->column_index);
+	std::reverse(column_indexes.begin(), column_indexes.end());
+
+	log->WriteUpdate(*update_chunk, column_indexes);
+}
+
+template <bool HAS_LOG>
+void CommitState::CommitEntry(UndoFlags type, data_ptr_t data) {
+	switch (type) {
+	case UndoFlags::CATALOG_ENTRY: {
+		// set the commit timestamp of the catalog entry to the given id
+		auto catalog_entry = Load<CatalogEntry *>(data);
+		D_ASSERT(catalog_entry->parent);
+		catalog_entry->set->UpdateTimestamp(catalog_entry->parent, commit_id);
+		if (catalog_entry->name != catalog_entry->parent->name) {
+			catalog_entry->set->UpdateTimestamp(catalog_entry, commit_id);
+		}
+		if (HAS_LOG) {
+			// push the catalog update to the WAL
+			WriteCatalogEntry(catalog_entry, data + sizeof(CatalogEntry *));
+		}
+		break;
+	}
+	case UndoFlags::INSERT_TUPLE: {
+		// append:
+		auto info = (AppendInfo *)data;
+		if (HAS_LOG && !info->table->info->IsTemporary()) {
+			info->table->WriteToLog(*log, info->start_row, info->count);
+		}
+		// mark the tuples as committed
+		info->table->CommitAppend(commit_id, info->start_row, info->count);
+		break;
+	}
+	case UndoFlags::DELETE_TUPLE: {
+		// deletion:
+		auto info = (DeleteInfo *)data;
+		if (HAS_LOG && !info->table->info->IsTemporary()) {
+			WriteDelete(info);
+		}
+		// mark the tuples as committed
+		info->vinfo->CommitDelete(commit_id, info->rows, info->count);
+		break;
+	}
+	case UndoFlags::UPDATE_TUPLE: {
+		// update:
+		auto info = (UpdateInfo *)data;
+		if (HAS_LOG && !info->segment->column_data.GetTableInfo().IsTemporary()) {
+			WriteUpdate(info);
+		}
+		info->version_number = commit_id;
+		break;
+	}
+	default:
+		throw InternalException("UndoBuffer - don't know how to commit this type!");
+	}
+}
+
+void CommitState::RevertCommit(UndoFlags type, data_ptr_t data) {
+	transaction_t transaction_id = commit_id;
+	switch (type) {
+	case UndoFlags::CATALOG_ENTRY: {
+		// set the commit timestamp of the catalog entry to the given id
+		auto catalog_entry = Load<CatalogEntry *>(data);
+		D_ASSERT(catalog_entry->parent);
+		catalog_entry->set->UpdateTimestamp(catalog_entry->parent, transaction_id);
+		if (catalog_entry->name != catalog_entry->parent->name) {
+			catalog_entry->set->UpdateTimestamp(catalog_entry, transaction_id);
+		}
+		break;
+	}
+	case UndoFlags::INSERT_TUPLE: {
+		auto info = (AppendInfo *)data;
+		// revert this append
+		info->table->RevertAppend(info->start_row, info->count);
+		break;
+	}
+	case UndoFlags::DELETE_TUPLE: {
+		// deletion:
+		auto info = (DeleteInfo *)data;
+		info->table->info->cardinality += info->count;
+		// revert the commit by writing the (uncommitted) transaction_id back into the version info
+		info->vinfo->CommitDelete(transaction_id, info->rows, info->count);
+		break;
+	}
+	case UndoFlags::UPDATE_TUPLE: {
+		// update:
+		auto info = (UpdateInfo *)data;
+		info->version_number = transaction_id;
+		break;
+	}
+	default:
+		throw InternalException("UndoBuffer - don't know how to revert commit of this type!");
+	}
+}
+
+template void CommitState::CommitEntry<true>(UndoFlags type, data_ptr_t data);
+template void CommitState::CommitEntry<false>(UndoFlags type, data_ptr_t data);
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+void RollbackState::RollbackEntry(UndoFlags type, data_ptr_t data) {
+	switch (type) {
+	case UndoFlags::CATALOG_ENTRY: {
+		// undo this catalog entry
+		auto catalog_entry = Load<CatalogEntry *>(data);
+		D_ASSERT(catalog_entry->set);
+		catalog_entry->set->Undo(catalog_entry);
+		break;
+	}
+	case UndoFlags::INSERT_TUPLE: {
+		auto info = (AppendInfo *)data;
+		// revert the append in the base table
+		info->table->RevertAppend(info->start_row, info->count);
+		break;
+	}
+	case UndoFlags::DELETE_TUPLE: {
+		auto info = (DeleteInfo *)data;
+		// reset the deleted flag on rollback
+		info->vinfo->CommitDelete(NOT_DELETED_ID, info->rows, info->count);
+		break;
+	}
+	case UndoFlags::UPDATE_TUPLE: {
+		auto info = (UpdateInfo *)data;
+		info->segment->RollbackUpdate(info);
+		break;
+	}
+	default: // LCOV_EXCL_START
+		D_ASSERT(type == UndoFlags::EMPTY_ENTRY);
+		break;
+	} // LCOV_EXCL_STOP
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <cstring>
+
+namespace duckdb {
+
+Transaction &Transaction::GetTransaction(ClientContext &context) {
+	return context.ActiveTransaction();
+}
+
+void Transaction::PushCatalogEntry(CatalogEntry *entry, data_ptr_t extra_data, idx_t extra_data_size) {
+	idx_t alloc_size = sizeof(CatalogEntry *);
+	if (extra_data_size > 0) {
+		alloc_size += extra_data_size + sizeof(idx_t);
+	}
+	auto baseptr = undo_buffer.CreateEntry(UndoFlags::CATALOG_ENTRY, alloc_size);
+	// store the pointer to the catalog entry
+	Store<CatalogEntry *>(entry, baseptr);
+	if (extra_data_size > 0) {
+		// copy the extra data behind the catalog entry pointer (if any)
+		baseptr += sizeof(CatalogEntry *);
+		// first store the extra data size
+		Store<idx_t>(extra_data_size, baseptr);
+		baseptr += sizeof(idx_t);
+		// then copy over the actual data
+		memcpy(baseptr, extra_data, extra_data_size);
+	}
+}
+
+void Transaction::PushDelete(DataTable *table, ChunkVectorInfo *vinfo, row_t rows[], idx_t count, idx_t base_row) {
+	auto delete_info =
+	    (DeleteInfo *)undo_buffer.CreateEntry(UndoFlags::DELETE_TUPLE, sizeof(DeleteInfo) + sizeof(row_t) * count);
+	delete_info->vinfo = vinfo;
+	delete_info->table = table;
+	delete_info->count = count;
+	delete_info->base_row = base_row;
+	memcpy(delete_info->rows, rows, sizeof(row_t) * count);
+}
+
+void Transaction::PushAppend(DataTable *table, idx_t start_row, idx_t row_count) {
+	auto append_info = (AppendInfo *)undo_buffer.CreateEntry(UndoFlags::INSERT_TUPLE, sizeof(AppendInfo));
+	append_info->table = table;
+	append_info->start_row = start_row;
+	append_info->count = row_count;
+}
+
+UpdateInfo *Transaction::CreateUpdateInfo(idx_t type_size, idx_t entries) {
+	auto update_info = (UpdateInfo *)undo_buffer.CreateEntry(
+	    UndoFlags::UPDATE_TUPLE, sizeof(UpdateInfo) + (sizeof(sel_t) + type_size) * STANDARD_VECTOR_SIZE);
+	update_info->max = STANDARD_VECTOR_SIZE;
+	update_info->tuples = (sel_t *)(((data_ptr_t)update_info) + sizeof(UpdateInfo));
+	update_info->tuple_data = ((data_ptr_t)update_info) + sizeof(UpdateInfo) + sizeof(sel_t) * update_info->max;
+	update_info->version_number = transaction_id;
+	return update_info;
+}
+
+bool Transaction::ChangesMade() {
+	return undo_buffer.ChangesMade() || storage.ChangesMade();
+}
+
+bool Transaction::AutomaticCheckpoint(DatabaseInstance &db) {
+	auto &config = DBConfig::GetConfig(db);
+	auto &storage_manager = StorageManager::GetStorageManager(db);
+	auto log = storage_manager.GetWriteAheadLog();
+	if (!log) {
+		return false;
+	}
+
+	auto initial_size = log->GetWALSize();
+	idx_t expected_wal_size = initial_size + storage.EstimatedSize() + undo_buffer.EstimatedSize();
+	return expected_wal_size > config.checkpoint_wal_size;
+}
+
+string Transaction::Commit(DatabaseInstance &db, transaction_t commit_id, bool checkpoint) noexcept {
+	this->commit_id = commit_id;
+	auto &storage_manager = StorageManager::GetStorageManager(db);
+	auto log = storage_manager.GetWriteAheadLog();
+
+	UndoBuffer::IteratorState iterator_state;
+	LocalStorage::CommitState commit_state;
+	idx_t initial_wal_size = 0;
+	idx_t initial_written = 0;
+	if (log) {
+		auto initial_size = log->GetWALSize();
+		initial_written = log->GetTotalWritten();
+		initial_wal_size = initial_size < 0 ? 0 : idx_t(initial_size);
+	} else {
+		D_ASSERT(!checkpoint);
+	}
+	try {
+		if (checkpoint) {
+			// check if we are checkpointing after this commit
+			// if we are checkpointing, we don't need to write anything to the WAL
+			// this saves us a lot of unnecessary writes to disk in the case of large commits
+			log->skip_writing = true;
+		}
+		storage.Commit(commit_state, *this, log, commit_id);
+		undo_buffer.Commit(iterator_state, log, commit_id);
+		if (log) {
+			// commit any sequences that were used to the WAL
+			for (auto &entry : sequence_usage) {
+				log->WriteSequenceValue(entry.first, entry.second);
+			}
+			// flush the WAL if any changes were made
+			if (log->GetTotalWritten() > initial_written) {
+				D_ASSERT(!checkpoint);
+				D_ASSERT(!log->skip_writing);
+				log->Flush();
+			}
+			log->skip_writing = false;
+		}
+		return string();
+	} catch (std::exception &ex) {
+		undo_buffer.RevertCommit(iterator_state, transaction_id);
+		if (log) {
+			log->skip_writing = false;
+			if (log->GetTotalWritten() > initial_written) {
+				// remove any entries written into the WAL by truncating it
+				log->Truncate(initial_wal_size);
+			}
+		}
+		D_ASSERT(!log || !log->skip_writing);
+		return ex.what();
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+namespace duckdb {
+
+TransactionContext::~TransactionContext() {
+	if (current_transaction) {
+		try {
+			Rollback();
+		} catch (...) {
+		}
+	}
+}
+
+void TransactionContext::BeginTransaction() {
+	if (current_transaction) {
+		throw TransactionException("cannot start a transaction within a transaction");
+	}
+	current_transaction = transaction_manager.StartTransaction(context);
+}
+
+void TransactionContext::Commit() {
+	if (!current_transaction) {
+		throw TransactionException("failed to commit: no transaction active");
+	}
+	auto transaction = current_transaction;
+	SetAutoCommit(true);
+	current_transaction = nullptr;
+	string error = transaction_manager.CommitTransaction(context, transaction);
+	if (!error.empty()) {
+		throw TransactionException("Failed to commit: %s", error);
+	}
+}
+
+void TransactionContext::SetAutoCommit(bool value) {
+	auto_commit = value;
+	if (!auto_commit && !current_transaction) {
+		BeginTransaction();
+	}
+}
+
+void TransactionContext::Rollback() {
+	if (!current_transaction) {
+		throw TransactionException("failed to rollback: no transaction active");
+	}
+	auto transaction = current_transaction;
+	ClearTransaction();
+	transaction_manager.RollbackTransaction(transaction);
+}
+
+void TransactionContext::ClearTransaction() {
+	SetAutoCommit(true);
+	current_transaction = nullptr;
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+namespace duckdb {
+
+struct CheckpointLock {
+	explicit CheckpointLock(TransactionManager &manager) : manager(manager), is_locked(false) {
+	}
+	~CheckpointLock() {
+		Unlock();
+	}
+
+	TransactionManager &manager;
+	bool is_locked;
+
+	void Lock() {
+		D_ASSERT(!manager.thread_is_checkpointing);
+		manager.thread_is_checkpointing = true;
+		is_locked = true;
+	}
+	void Unlock() {
+		if (!is_locked) {
+			return;
+		}
+		D_ASSERT(manager.thread_is_checkpointing);
+		manager.thread_is_checkpointing = false;
+		is_locked = false;
+	}
+};
+
+TransactionManager::TransactionManager(DatabaseInstance &db) : db(db), thread_is_checkpointing(false) {
+	// start timestamp starts at zero
+	current_start_timestamp = 0;
+	// transaction ID starts very high:
+	// it should be much higher than the current start timestamp
+	// if transaction_id < start_timestamp for any set of active transactions
+	// uncommited data could be read by
+	current_transaction_id = TRANSACTION_ID_START;
+	// the current active query id
+	current_query_number = 1;
+	lowest_active_id = TRANSACTION_ID_START;
+	lowest_active_start = MAX_TRANSACTION_ID;
+}
+
+TransactionManager::~TransactionManager() {
+}
+
+Transaction *TransactionManager::StartTransaction(ClientContext &context) {
+	// obtain the transaction lock during this function
+	lock_guard<mutex> lock(transaction_lock);
+	if (current_start_timestamp >= TRANSACTION_ID_START) { // LCOV_EXCL_START
+		throw InternalException("Cannot start more transactions, ran out of "
+		                        "transaction identifiers!");
+	} // LCOV_EXCL_STOP
+
+	// obtain the start time and transaction ID of this transaction
+	transaction_t start_time = current_start_timestamp++;
+	transaction_t transaction_id = current_transaction_id++;
+	timestamp_t start_timestamp = Timestamp::GetCurrentTimestamp();
+	if (active_transactions.empty()) {
+		lowest_active_start = start_time;
+		lowest_active_id = transaction_id;
+	}
+
+	// create the actual transaction
+	auto &catalog = Catalog::GetCatalog(db);
+	auto transaction = make_unique<Transaction>(weak_ptr<ClientContext>(context.shared_from_this()), start_time,
+	                                            transaction_id, start_timestamp, catalog.GetCatalogVersion());
+	auto transaction_ptr = transaction.get();
+
+	// store it in the set of active transactions
+	active_transactions.push_back(move(transaction));
+	return transaction_ptr;
+}
+
+struct ClientLockWrapper {
+	ClientLockWrapper(mutex &client_lock, shared_ptr<ClientContext> connection)
+	    : connection(move(connection)), connection_lock(make_unique<lock_guard<mutex>>(client_lock)) {
+	}
+
+	shared_ptr<ClientContext> connection;
+	unique_ptr<lock_guard<mutex>> connection_lock;
+};
+
+void TransactionManager::LockClients(vector<ClientLockWrapper> &client_locks, ClientContext &context) {
+	auto &connection_manager = ConnectionManager::Get(context);
+	client_locks.emplace_back(connection_manager.connections_lock, nullptr);
+	auto connection_list = connection_manager.GetConnectionList();
+	for (auto &con : connection_list) {
+		if (con.get() == &context) {
+			continue;
+		}
+		auto &context_lock = con->context_lock;
+		client_locks.emplace_back(context_lock, move(con));
+	}
+}
+
+void TransactionManager::Checkpoint(ClientContext &context, bool force) {
+	auto &storage_manager = StorageManager::GetStorageManager(db);
+	if (storage_manager.InMemory()) {
+		return;
+	}
+
+	// first check if no other thread is checkpointing right now
+	auto lock = make_unique<lock_guard<mutex>>(transaction_lock);
+	if (thread_is_checkpointing) {
+		throw TransactionException("Cannot CHECKPOINT: another thread is checkpointing right now");
+	}
+	CheckpointLock checkpoint_lock(*this);
+	checkpoint_lock.Lock();
+	lock.reset();
+
+	// lock all the clients AND the connection manager now
+	// this ensures no new queries can be started, and no new connections to the database can be made
+	// to avoid deadlock we release the transaction lock while locking the clients
+	vector<ClientLockWrapper> client_locks;
+	LockClients(client_locks, context);
+
+	lock = make_unique<lock_guard<mutex>>(transaction_lock);
+	auto current = &Transaction::GetTransaction(context);
+	if (current->ChangesMade()) {
+		throw TransactionException("Cannot CHECKPOINT: the current transaction has transaction local changes");
+	}
+	if (!force) {
+		if (!CanCheckpoint(current)) {
+			throw TransactionException("Cannot CHECKPOINT: there are other transactions. Use FORCE CHECKPOINT to abort "
+			                           "the other transactions and force a checkpoint");
+		}
+	} else {
+		if (!CanCheckpoint(current)) {
+			for (size_t i = 0; i < active_transactions.size(); i++) {
+				auto &transaction = active_transactions[i];
+				// rollback the transaction
+				transaction->Rollback();
+				auto transaction_context = transaction->context.lock();
+
+				// remove the transaction id from the list of active transactions
+				// potentially resulting in garbage collection
+				RemoveTransaction(transaction.get());
+				if (transaction_context) {
+					transaction_context->transaction.ClearTransaction();
+				}
+				i--;
+			}
+			D_ASSERT(CanCheckpoint(nullptr));
+		}
+	}
+	auto &storage = StorageManager::GetStorageManager(context);
+	storage.CreateCheckpoint();
+}
+
+bool TransactionManager::CanCheckpoint(Transaction *current) {
+	auto &storage_manager = StorageManager::GetStorageManager(db);
+	if (storage_manager.InMemory()) {
+		return false;
+	}
+	if (!recently_committed_transactions.empty() || !old_transactions.empty()) {
+		return false;
+	}
+	for (auto &transaction : active_transactions) {
+		if (transaction.get() != current) {
+			return false;
+		}
+	}
+	return true;
+}
+
+string TransactionManager::CommitTransaction(ClientContext &context, Transaction *transaction) {
+	vector<ClientLockWrapper> client_locks;
+	auto lock = make_unique<lock_guard<mutex>>(transaction_lock);
+	CheckpointLock checkpoint_lock(*this);
+	// check if we can checkpoint
+	bool checkpoint = thread_is_checkpointing ? false : CanCheckpoint(transaction);
+	if (checkpoint) {
+		if (transaction->AutomaticCheckpoint(db)) {
+			checkpoint_lock.Lock();
+			// we might be able to checkpoint: lock all clients
+			// to avoid deadlock we release the transaction lock while locking the clients
+			lock.reset();
+
+			LockClients(client_locks, context);
+
+			lock = make_unique<lock_guard<mutex>>(transaction_lock);
+			checkpoint = CanCheckpoint(transaction);
+			if (!checkpoint) {
+				checkpoint_lock.Unlock();
+				client_locks.clear();
+			}
+		} else {
+			checkpoint = false;
+		}
+	}
+	// obtain a commit id for the transaction
+	transaction_t commit_id = current_start_timestamp++;
+	// commit the UndoBuffer of the transaction
+	string error = transaction->Commit(db, commit_id, checkpoint);
+	if (!error.empty()) {
+		// commit unsuccessful: rollback the transaction instead
+		checkpoint = false;
+		transaction->commit_id = 0;
+		transaction->Rollback();
+	}
+	if (!checkpoint) {
+		// we won't checkpoint after all: unlock the clients again
+		checkpoint_lock.Unlock();
+		client_locks.clear();
+	}
+
+	// commit successful: remove the transaction id from the list of active transactions
+	// potentially resulting in garbage collection
+	RemoveTransaction(transaction);
+	// now perform a checkpoint if (1) we are able to checkpoint, and (2) the WAL has reached sufficient size to
+	// checkpoint
+	if (checkpoint) {
+		// checkpoint the database to disk
+		auto &storage_manager = StorageManager::GetStorageManager(db);
+		storage_manager.CreateCheckpoint(false, true);
+	}
+	return error;
+}
+
+void TransactionManager::RollbackTransaction(Transaction *transaction) {
+	// obtain the transaction lock during this function
+	lock_guard<mutex> lock(transaction_lock);
+
+	// rollback the transaction
+	transaction->Rollback();
+
+	// remove the transaction id from the list of active transactions
+	// potentially resulting in garbage collection
+	RemoveTransaction(transaction);
+}
+
+void TransactionManager::RemoveTransaction(Transaction *transaction) noexcept {
+	// remove the transaction from the list of active transactions
+	idx_t t_index = active_transactions.size();
+	// check for the lowest and highest start time in the list of transactions
+	transaction_t lowest_start_time = TRANSACTION_ID_START;
+	transaction_t lowest_transaction_id = MAX_TRANSACTION_ID;
+	transaction_t lowest_active_query = MAXIMUM_QUERY_ID;
+	for (idx_t i = 0; i < active_transactions.size(); i++) {
+		if (active_transactions[i].get() == transaction) {
+			t_index = i;
+		} else {
+			transaction_t active_query = active_transactions[i]->active_query;
+			lowest_start_time = MinValue(lowest_start_time, active_transactions[i]->start_time);
+			lowest_active_query = MinValue(lowest_active_query, active_query);
+			lowest_transaction_id = MinValue(lowest_transaction_id, active_transactions[i]->transaction_id);
+		}
+	}
+	lowest_active_start = lowest_start_time;
+	lowest_active_id = lowest_transaction_id;
+
+	transaction_t lowest_stored_query = lowest_start_time;
+	D_ASSERT(t_index != active_transactions.size());
+	auto current_transaction = move(active_transactions[t_index]);
+	if (transaction->commit_id != 0) {
+		// the transaction was committed, add it to the list of recently
+		// committed transactions
+		recently_committed_transactions.push_back(move(current_transaction));
+	} else {
+		// the transaction was aborted, but we might still need its information
+		// add it to the set of transactions awaiting GC
+		current_transaction->highest_active_query = current_query_number;
+		old_transactions.push_back(move(current_transaction));
+	}
+	// remove the transaction from the set of currently active transactions
+	active_transactions.erase(active_transactions.begin() + t_index);
+	// traverse the recently_committed transactions to see if we can remove any
+	idx_t i = 0;
+	for (; i < recently_committed_transactions.size(); i++) {
+		D_ASSERT(recently_committed_transactions[i]);
+		lowest_stored_query = MinValue(recently_committed_transactions[i]->start_time, lowest_stored_query);
+		if (recently_committed_transactions[i]->commit_id < lowest_start_time) {
+			// changes made BEFORE this transaction are no longer relevant
+			// we can cleanup the undo buffer
+
+			// HOWEVER: any currently running QUERY can still be using
+			// the version information after the cleanup!
+
+			// if we remove the UndoBuffer immediately, we have a race
+			// condition
+
+			// we can only safely do the actual memory cleanup when all the
+			// currently active queries have finished running! (actually,
+			// when all the currently active scans have finished running...)
+			recently_committed_transactions[i]->Cleanup();
+			// store the current highest active query
+			recently_committed_transactions[i]->highest_active_query = current_query_number;
+			// move it to the list of transactions awaiting GC
+			old_transactions.push_back(move(recently_committed_transactions[i]));
+		} else {
+			// recently_committed_transactions is ordered on commit_id
+			// implicitly thus if the current one is bigger than
+			// lowest_start_time any subsequent ones are also bigger
+			break;
+		}
+	}
+	if (i > 0) {
+		// we garbage collected transactions: remove them from the list
+		recently_committed_transactions.erase(recently_committed_transactions.begin(),
+		                                      recently_committed_transactions.begin() + i);
+	}
+	// check if we can free the memory of any old transactions
+	i = active_transactions.empty() ? old_transactions.size() : 0;
+	for (; i < old_transactions.size(); i++) {
+		D_ASSERT(old_transactions[i]);
+		D_ASSERT(old_transactions[i]->highest_active_query > 0);
+		if (old_transactions[i]->highest_active_query >= lowest_active_query) {
+			// there is still a query running that could be using
+			// this transactions' data
+			break;
+		}
+	}
+	if (i > 0) {
+		// we garbage collected transactions: remove them from the list
+		old_transactions.erase(old_transactions.begin(), old_transactions.begin() + i);
+	}
+	// check if we can free the memory of any old catalog sets
+	for (i = 0; i < old_catalog_sets.size(); i++) {
+		D_ASSERT(old_catalog_sets[i].highest_active_query > 0);
+		if (old_catalog_sets[i].highest_active_query >= lowest_stored_query) {
+			// there is still a query running that could be using
+			// this catalog sets' data
+			break;
+		}
+	}
+	if (i > 0) {
+		// we garbage collected catalog sets: remove them from the list
+		old_catalog_sets.erase(old_catalog_sets.begin(), old_catalog_sets.begin() + i);
+	}
+}
+
+} // namespace duckdb
+
+
+
+
+
+
+
+
+
+
+
+
+
+#include <unordered_map>
+
+namespace duckdb {
+constexpr uint32_t DEFAULT_UNDO_CHUNK_SIZE = 4096 * 3;
+constexpr uint32_t UNDO_ENTRY_HEADER_SIZE = sizeof(UndoFlags) + sizeof(uint32_t);
+
+static idx_t AlignLength(idx_t len) {
+	return (len + 7) / 8 * 8;
+}
+
+UndoBuffer::UndoBuffer() {
+	head = make_unique<UndoChunk>(0);
+	tail = head.get();
+}
+
+UndoChunk::UndoChunk(idx_t size) : current_position(0), maximum_size(size), prev(nullptr) {
+	if (size > 0) {
+		data = unique_ptr<data_t[]>(new data_t[maximum_size]);
+	}
+}
+UndoChunk::~UndoChunk() {
+	if (next) {
+		auto current_next = move(next);
+		while (current_next) {
+			current_next = move(current_next->next);
+		}
+	}
+}
+
+data_ptr_t UndoChunk::WriteEntry(UndoFlags type, uint32_t len) {
+	len = AlignLength(len);
+	D_ASSERT(sizeof(UndoFlags) + sizeof(len) == 8);
+	Store<UndoFlags>(type, data.get() + current_position);
+	current_position += sizeof(UndoFlags);
+	Store<uint32_t>(len, data.get() + current_position);
+	current_position += sizeof(uint32_t);
+
+	data_ptr_t result = data.get() + current_position;
+	current_position += len;
+	return result;
+}
+
+data_ptr_t UndoBuffer::CreateEntry(UndoFlags type, idx_t len) {
+	D_ASSERT(len <= NumericLimits<uint32_t>::Maximum());
+	idx_t needed_space = AlignLength(len + UNDO_ENTRY_HEADER_SIZE);
+	if (head->current_position + needed_space >= head->maximum_size) {
+		auto new_chunk =
+		    make_unique<UndoChunk>(needed_space > DEFAULT_UNDO_CHUNK_SIZE ? needed_space : DEFAULT_UNDO_CHUNK_SIZE);
+		head->prev = new_chunk.get();
+		new_chunk->next = move(head);
+		head = move(new_chunk);
+	}
+	return head->WriteEntry(type, len);
+}
+
+template <class T>
+void UndoBuffer::IterateEntries(UndoBuffer::IteratorState &state, T &&callback) {
+	// iterate in insertion order: start with the tail
+	state.current = tail;
+	while (state.current) {
+		state.start = state.current->data.get();
+		state.end = state.start + state.current->current_position;
+		while (state.start < state.end) {
+			UndoFlags type = Load<UndoFlags>(state.start);
+			state.start += sizeof(UndoFlags);
+
+			uint32_t len = Load<uint32_t>(state.start);
+			state.start += sizeof(uint32_t);
+			callback(type, state.start);
+			state.start += len;
+		}
+		state.current = state.current->prev;
+	}
+}
+
+template <class T>
+void UndoBuffer::IterateEntries(UndoBuffer::IteratorState &state, UndoBuffer::IteratorState &end_state, T &&callback) {
+	// iterate in insertion order: start with the tail
+	state.current = tail;
+	while (state.current) {
+		state.start = state.current->data.get();
+		state.end =
+		    state.current == end_state.current ? end_state.start : state.start + state.current->current_position;
+		while (state.start < state.end) {
+			auto type = Load<UndoFlags>(state.start);
+			state.start += sizeof(UndoFlags);
+			auto len = Load<uint32_t>(state.start);
+			state.start += sizeof(uint32_t);
+			callback(type, state.start);
+			state.start += len;
+		}
+		if (state.current == end_state.current) {
+			// finished executing until the current end state
+			return;
+		}
+		state.current = state.current->prev;
+	}
+}
+
+template <class T>
+void UndoBuffer::ReverseIterateEntries(T &&callback) {
+	// iterate in reverse insertion order: start with the head
+	auto current = head.get();
+	while (current) {
+		data_ptr_t start = current->data.get();
+		data_ptr_t end = start + current->current_position;
+		// create a vector with all nodes in this chunk
+		vector<pair<UndoFlags, data_ptr_t>> nodes;
+		while (start < end) {
+			auto type = Load<UndoFlags>(start);
+			start += sizeof(UndoFlags);
+			auto len = Load<uint32_t>(start);
+			start += sizeof(uint32_t);
+			nodes.emplace_back(type, start);
+			start += len;
+		}
+		// iterate over it in reverse order
+		for (idx_t i = nodes.size(); i > 0; i--) {
+			callback(nodes[i - 1].first, nodes[i - 1].second);
+		}
+		current = current->next.get();
+	}
+}
+
+bool UndoBuffer::ChangesMade() {
+	return head->maximum_size > 0;
+}
+
+idx_t UndoBuffer::EstimatedSize() {
+	idx_t estimated_size = 0;
+	auto node = head.get();
+	while (node) {
+		estimated_size += node->current_position;
+		node = node->next.get();
+	}
+	return estimated_size;
+}
+
+void UndoBuffer::Cleanup() {
+	// garbage collect everything in the Undo Chunk
+	// this should only happen if
+	//  (1) the transaction this UndoBuffer belongs to has successfully
+	//  committed
+	//      (on Rollback the Rollback() function should be called, that clears
+	//      the chunks)
+	//  (2) there is no active transaction with start_id < commit_id of this
+	//  transaction
+	CleanupState state;
+	UndoBuffer::IteratorState iterator_state;
+	IterateEntries(iterator_state, [&](UndoFlags type, data_ptr_t data) { state.CleanupEntry(type, data); });
+}
+
+void UndoBuffer::Commit(UndoBuffer::IteratorState &iterator_state, WriteAheadLog *log, transaction_t commit_id) {
+	CommitState state(commit_id, log);
+	if (log) {
+		// commit WITH write ahead log
+		IterateEntries(iterator_state, [&](UndoFlags type, data_ptr_t data) { state.CommitEntry<true>(type, data); });
+	} else {
+		// commit WITHOUT write ahead log
+		IterateEntries(iterator_state, [&](UndoFlags type, data_ptr_t data) { state.CommitEntry<false>(type, data); });
+	}
+}
+
+void UndoBuffer::RevertCommit(UndoBuffer::IteratorState &end_state, transaction_t transaction_id) {
+	CommitState state(transaction_id, nullptr);
+	UndoBuffer::IteratorState start_state;
+	IterateEntries(start_state, end_state, [&](UndoFlags type, data_ptr_t data) { state.RevertCommit(type, data); });
+}
+
+void UndoBuffer::Rollback() noexcept {
+	// rollback needs to be performed in reverse
+	RollbackState state;
+	ReverseIterateEntries([&](UndoFlags type, data_ptr_t data) { state.RollbackEntry(type, data); });
+}
+} // namespace duckdb

--- a/velox/external/duckdb/duckdb-fastpforlib.cpp
+++ b/velox/external/duckdb/duckdb-fastpforlib.cpp
@@ -1,0 +1,1300 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+// LICENSE_CHANGE_BEGIN
+// The following code up to LICENSE_CHANGE_END is subject to THIRD PARTY LICENSE #12
+// See the end of this file for a list
+
+
+
+#include <cstdint>
+#include <type_traits>
+
+namespace duckdb_fastpforlib {
+namespace internal {
+
+// Used for uint8_t, uint16_t and uint32_t
+template <uint8_t DELTA, uint8_t SHR, class TYPE, uint8_t TYPE_SIZE = sizeof(TYPE) * 8>
+typename std::enable_if<(DELTA + SHR) < TYPE_SIZE>::type unpack_single_out(const TYPE *__restrict in,
+                                                                           TYPE *__restrict out) {
+	*out = ((*in) >> SHR) % (1 << DELTA);
+}
+
+// Used for uint8_t, uint16_t and uint32_t
+template <uint8_t DELTA, uint8_t SHR, class TYPE, uint8_t TYPE_SIZE = sizeof(TYPE) * 8>
+typename std::enable_if<(DELTA + SHR) >= TYPE_SIZE>::type unpack_single_out(const TYPE *__restrict &in,
+                                                                            TYPE *__restrict out) {
+	*out = (*in) >> SHR;
+	++in;
+
+	static const TYPE NEXT_SHR = SHR + DELTA - TYPE_SIZE;
+	*out |= ((*in) % (1U << NEXT_SHR)) << (TYPE_SIZE - SHR);
+}
+
+template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) < 32>::type unpack_single_out(const uint32_t *__restrict in,
+                                                                    uint64_t *__restrict out) {
+	*out = ((static_cast<uint64_t>(*in)) >> SHR) % (1ULL << DELTA);
+}
+
+template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) >= 32 && (DELTA + SHR) < 64>::type
+unpack_single_out(const uint32_t *__restrict &in, uint64_t *__restrict out) {
+	*out = static_cast<uint64_t>(*in) >> SHR;
+	++in;
+	if (DELTA + SHR > 32) {
+		static const uint8_t NEXT_SHR = SHR + DELTA - 32;
+		*out |= static_cast<uint64_t>((*in) % (1U << NEXT_SHR)) << (32 - SHR);
+	}
+}
+
+template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) >= 64>::type unpack_single_out(const uint32_t *__restrict &in,
+                                                                     uint64_t *__restrict out) {
+	*out = static_cast<uint64_t>(*in) >> SHR;
+	++in;
+
+	*out |= static_cast<uint64_t>(*in) << (32 - SHR);
+	++in;
+
+	if (DELTA + SHR > 64) {
+		static const uint8_t NEXT_SHR = DELTA + SHR - 64;
+		*out |= static_cast<uint64_t>((*in) % (1U << NEXT_SHR)) << (64 - SHR);
+	}
+}
+
+// Used for uint8_t, uint16_t and uint32_t
+template <class TYPE, uint16_t DELTA, uint16_t SHL, TYPE MASK, uint8_t TYPE_SIZE = sizeof(TYPE) * 8>
+    typename std::enable_if < DELTA + SHL<TYPE_SIZE>::type pack_single_in(const TYPE in, TYPE *__restrict out) {
+	if (SHL == 0) {
+		*out = in & MASK;
+	} else {
+		*out |= (in & MASK) << SHL;
+	}
+}
+
+// Used for uint8_t, uint16_t and uint32_t
+template <class TYPE, uint16_t DELTA, uint16_t SHL, TYPE MASK, uint8_t TYPE_SIZE = sizeof(TYPE) * 8>
+typename std::enable_if<DELTA + SHL >= TYPE_SIZE>::type pack_single_in(const TYPE in, TYPE *__restrict &out) {
+	*out |= in << SHL;
+	++out;
+
+	if (DELTA + SHL > TYPE_SIZE) {
+		*out = (in & MASK) >> (TYPE_SIZE - SHL);
+	}
+}
+
+template <uint16_t DELTA, uint16_t SHL, uint64_t MASK>
+    typename std::enable_if < DELTA + SHL<32>::type pack_single_in64(const uint64_t in, uint32_t *__restrict out) {
+	if (SHL == 0) {
+		*out = static_cast<uint32_t>(in & MASK);
+	} else {
+		*out |= (in & MASK) << SHL;
+	}
+}
+template <uint16_t DELTA, uint16_t SHL, uint64_t MASK>
+        typename std::enable_if < DELTA + SHL >= 32 &&
+    DELTA + SHL<64>::type pack_single_in64(const uint64_t in, uint32_t *__restrict &out) {
+	if (SHL == 0) {
+		*out = static_cast<uint32_t>(in & MASK);
+	} else {
+		*out |= (in & MASK) << SHL;
+	}
+
+	++out;
+
+	if (DELTA + SHL > 32) {
+		*out = static_cast<uint32_t>((in & MASK) >> (32 - SHL));
+	}
+}
+template <uint16_t DELTA, uint16_t SHL, uint64_t MASK>
+typename std::enable_if<DELTA + SHL >= 64>::type pack_single_in64(const uint64_t in, uint32_t *__restrict &out) {
+	*out |= in << SHL;
+	++out;
+
+	*out = static_cast<uint32_t>((in & MASK) >> (32 - SHL));
+	++out;
+
+	if (DELTA + SHL > 64) {
+		*out = (in & MASK) >> (64 - SHL);
+	}
+}
+template <uint16_t DELTA, uint16_t OINDEX = 0>
+struct Unroller8 {
+	static void Unpack(const uint8_t *__restrict &in, uint8_t *__restrict out) {
+		unpack_single_out<DELTA, (DELTA * OINDEX) % 8>(in, out + OINDEX);
+
+		Unroller8<DELTA, OINDEX + 1>::Unpack(in, out);
+	}
+
+	static void Pack(const uint8_t *__restrict in, uint8_t *__restrict out) {
+		pack_single_in<uint8_t, DELTA, (DELTA * OINDEX) % 8, (1U << DELTA) - 1>(in[OINDEX], out);
+
+		Unroller8<DELTA, OINDEX + 1>::Pack(in, out);
+	}
+
+};\
+template <uint16_t DELTA>
+struct Unroller8<DELTA, 7> {
+	enum { SHIFT = (DELTA * 7) % 8 };
+
+	static void Unpack(const uint8_t *__restrict in, uint8_t *__restrict out) {
+		out[7] = (*in) >> SHIFT;
+	}
+
+	static void Pack(const uint8_t *__restrict in, uint8_t *__restrict out) {
+		*out |= (in[7] << SHIFT);
+	}
+};
+
+template <uint16_t DELTA, uint16_t OINDEX = 0>
+struct Unroller16 {
+	static void Unpack(const uint16_t *__restrict &in, uint16_t *__restrict out) {
+		unpack_single_out<DELTA, (DELTA * OINDEX) % 16>(in, out + OINDEX);
+
+		Unroller16<DELTA, OINDEX + 1>::Unpack(in, out);
+	}
+
+	static void Pack(const uint16_t *__restrict in, uint16_t *__restrict out) {
+		pack_single_in<uint16_t, DELTA, (DELTA * OINDEX) % 16, (1U << DELTA) - 1>(in[OINDEX], out);
+
+		Unroller16<DELTA, OINDEX + 1>::Pack(in, out);
+	}
+
+};
+
+template <uint16_t DELTA>
+struct Unroller16<DELTA, 15> {
+	enum { SHIFT = (DELTA * 15) % 16 };
+
+	static void Unpack(const uint16_t *__restrict in, uint16_t *__restrict out) {
+		out[15] = (*in) >> SHIFT;
+	}
+
+	static void Pack(const uint16_t *__restrict in, uint16_t *__restrict out) {
+		*out |= (in[15] << SHIFT);
+	}
+};
+
+template <uint16_t DELTA, uint16_t OINDEX = 0>
+struct Unroller {
+	static void Unpack(const uint32_t *__restrict &in, uint32_t *__restrict out) {
+		unpack_single_out<DELTA, (DELTA * OINDEX) % 32>(in, out + OINDEX);
+
+		Unroller<DELTA, OINDEX + 1>::Unpack(in, out);
+	}
+
+	static void Unpack(const uint32_t *__restrict &in, uint64_t *__restrict out) {
+		unpack_single_out<DELTA, (DELTA * OINDEX) % 32>(in, out + OINDEX);
+
+		Unroller<DELTA, OINDEX + 1>::Unpack(in, out);
+	}
+
+	static void Pack(const uint32_t *__restrict in, uint32_t *__restrict out) {
+		pack_single_in<uint32_t, DELTA, (DELTA * OINDEX) % 32, (1U << DELTA) - 1>(in[OINDEX], out);
+
+		Unroller<DELTA, OINDEX + 1>::Pack(in, out);
+	}
+
+	static void Pack(const uint64_t *__restrict in, uint32_t *__restrict out) {
+		pack_single_in64<DELTA, (DELTA * OINDEX) % 32, (1ULL << DELTA) - 1>(in[OINDEX], out);
+
+		Unroller<DELTA, OINDEX + 1>::Pack(in, out);
+	}
+};
+
+template <uint16_t DELTA>
+struct Unroller<DELTA, 31> {
+	enum { SHIFT = (DELTA * 31) % 32 };
+
+	static void Unpack(const uint32_t *__restrict in, uint32_t *__restrict out) {
+		out[31] = (*in) >> SHIFT;
+	}
+
+	static void Unpack(const uint32_t *__restrict in, uint64_t *__restrict out) {
+		out[31] = (*in) >> SHIFT;
+		if (DELTA > 32) {
+			++in;
+			out[31] |= static_cast<uint64_t>(*in) << (32 - SHIFT);
+		}
+	}
+
+	static void Pack(const uint32_t *__restrict in, uint32_t *__restrict out) {
+		*out |= (in[31] << SHIFT);
+	}
+
+	static void Pack(const uint64_t *__restrict in, uint32_t *__restrict out) {
+		*out |= (in[31] << SHIFT);
+		if (DELTA > 32) {
+			++out;
+			*out = static_cast<uint32_t>(in[31] >> (32 - SHIFT));
+		}
+	}
+};
+
+// Special cases
+void __fastunpack0(const uint8_t *__restrict, uint8_t *__restrict out) {
+	for (uint8_t i = 0; i < 8; ++i)
+		*(out++) = 0;
+}
+
+void __fastunpack0(const uint16_t *__restrict, uint16_t *__restrict out) {
+	for (uint16_t i = 0; i < 16; ++i)
+		*(out++) = 0;
+}
+
+void __fastunpack0(const uint32_t *__restrict, uint32_t *__restrict out) {
+	for (uint32_t i = 0; i < 32; ++i)
+		*(out++) = 0;
+}
+
+void __fastunpack0(const uint32_t *__restrict, uint64_t *__restrict out) {
+	for (uint32_t i = 0; i < 32; ++i)
+		*(out++) = 0;
+}
+
+void __fastpack0(const uint8_t *__restrict, uint8_t *__restrict) {
+}
+void __fastpack0(const uint16_t *__restrict, uint16_t *__restrict) {
+}
+void __fastpack0(const uint32_t *__restrict, uint32_t *__restrict) {
+}
+void __fastpack0(const uint64_t *__restrict, uint32_t *__restrict) {
+}
+
+// fastunpack for 8 bits
+void __fastunpack1(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<1>::Unpack(in, out);
+}
+
+void __fastunpack2(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<2>::Unpack(in, out);
+}
+
+void __fastunpack3(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<3>::Unpack(in, out);
+}
+
+void __fastunpack4(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	for (uint8_t outer = 0; outer < 4; ++outer) {
+		for (uint8_t inwordpointer = 0; inwordpointer < 8; inwordpointer += 4)
+			*(out++) = ((*in) >> inwordpointer) % (1U << 4);
+		++in;
+	}
+}
+
+void __fastunpack5(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<5>::Unpack(in, out);
+}
+
+void __fastunpack6(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<6>::Unpack(in, out);
+}
+
+void __fastunpack7(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<7>::Unpack(in, out);
+}
+
+void __fastunpack8(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	for (int k = 0; k < 8; ++k)
+		out[k] = in[k];
+}
+
+
+// fastunpack for 16 bits
+void __fastunpack1(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<1>::Unpack(in, out);
+}
+
+void __fastunpack2(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<2>::Unpack(in, out);
+}
+
+void __fastunpack3(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<3>::Unpack(in, out);
+}
+
+void __fastunpack4(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	for (uint16_t outer = 0; outer < 4; ++outer) {
+		for (uint16_t inwordpointer = 0; inwordpointer < 16; inwordpointer += 4)
+			*(out++) = ((*in) >> inwordpointer) % (1U << 4);
+		++in;
+	}
+}
+
+void __fastunpack5(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<5>::Unpack(in, out);
+}
+
+void __fastunpack6(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<6>::Unpack(in, out);
+}
+
+void __fastunpack7(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<7>::Unpack(in, out);
+}
+
+void __fastunpack8(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	for (uint16_t outer = 0; outer < 8; ++outer) {
+		for (uint16_t inwordpointer = 0; inwordpointer < 16; inwordpointer += 8)
+			*(out++) = ((*in) >> inwordpointer) % (1U << 8);
+		++in;
+	}
+}
+
+void __fastunpack9(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<9>::Unpack(in, out);
+}
+
+void __fastunpack10(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<10>::Unpack(in, out);
+}
+
+void __fastunpack11(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<11>::Unpack(in, out);
+}
+
+void __fastunpack12(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<12>::Unpack(in, out);
+}
+
+void __fastunpack13(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<13>::Unpack(in, out);
+}
+
+void __fastunpack14(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<14>::Unpack(in, out);
+}
+
+void __fastunpack15(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<15>::Unpack(in, out);
+}
+
+void __fastunpack16(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	for (int k = 0; k < 16; ++k)
+		out[k] = in[k];
+}
+
+// fastunpack for 32 bits
+void __fastunpack1(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<1>::Unpack(in, out);
+}
+
+void __fastunpack2(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<2>::Unpack(in, out);
+}
+
+void __fastunpack3(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<3>::Unpack(in, out);
+}
+
+void __fastunpack4(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	for (uint32_t outer = 0; outer < 4; ++outer) {
+		for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 4)
+			*(out++) = ((*in) >> inwordpointer) % (1U << 4);
+		++in;
+	}
+}
+
+void __fastunpack5(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<5>::Unpack(in, out);
+}
+
+void __fastunpack6(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<6>::Unpack(in, out);
+}
+
+void __fastunpack7(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<7>::Unpack(in, out);
+}
+
+void __fastunpack8(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	for (uint32_t outer = 0; outer < 8; ++outer) {
+		for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 8)
+			*(out++) = ((*in) >> inwordpointer) % (1U << 8);
+		++in;
+	}
+}
+
+void __fastunpack9(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<9>::Unpack(in, out);
+}
+
+void __fastunpack10(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<10>::Unpack(in, out);
+}
+
+void __fastunpack11(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<11>::Unpack(in, out);
+}
+
+void __fastunpack12(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<12>::Unpack(in, out);
+}
+
+void __fastunpack13(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<13>::Unpack(in, out);
+}
+
+void __fastunpack14(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<14>::Unpack(in, out);
+}
+
+void __fastunpack15(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<15>::Unpack(in, out);
+}
+
+void __fastunpack16(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	for (uint32_t outer = 0; outer < 16; ++outer) {
+		for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 16)
+			*(out++) = ((*in) >> inwordpointer) % (1U << 16);
+		++in;
+	}
+}
+
+void __fastunpack17(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<17>::Unpack(in, out);
+}
+
+void __fastunpack18(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<18>::Unpack(in, out);
+}
+
+void __fastunpack19(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<19>::Unpack(in, out);
+}
+
+void __fastunpack20(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<20>::Unpack(in, out);
+}
+
+void __fastunpack21(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<21>::Unpack(in, out);
+}
+
+void __fastunpack22(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<22>::Unpack(in, out);
+}
+
+void __fastunpack23(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<23>::Unpack(in, out);
+}
+
+void __fastunpack24(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<24>::Unpack(in, out);
+}
+
+void __fastunpack25(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<25>::Unpack(in, out);
+}
+
+void __fastunpack26(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<26>::Unpack(in, out);
+}
+
+void __fastunpack27(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<27>::Unpack(in, out);
+}
+
+void __fastunpack28(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<28>::Unpack(in, out);
+}
+
+void __fastunpack29(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<29>::Unpack(in, out);
+}
+
+void __fastunpack30(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<30>::Unpack(in, out);
+}
+
+void __fastunpack31(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<31>::Unpack(in, out);
+}
+
+void __fastunpack32(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	for (int k = 0; k < 32; ++k)
+		out[k] = in[k];
+}
+
+// fastupack for 64 bits
+void __fastunpack1(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<1>::Unpack(in, out);
+}
+
+void __fastunpack2(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<2>::Unpack(in, out);
+}
+
+void __fastunpack3(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<3>::Unpack(in, out);
+}
+
+void __fastunpack4(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	for (uint32_t outer = 0; outer < 4; ++outer) {
+		for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 4)
+			*(out++) = ((*in) >> inwordpointer) % (1U << 4);
+		++in;
+	}
+}
+
+void __fastunpack5(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<5>::Unpack(in, out);
+}
+
+void __fastunpack6(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<6>::Unpack(in, out);
+}
+
+void __fastunpack7(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<7>::Unpack(in, out);
+}
+
+void __fastunpack8(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	for (uint32_t outer = 0; outer < 8; ++outer) {
+		for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 8) {
+			*(out++) = ((*in) >> inwordpointer) % (1U << 8);
+		}
+		++in;
+	}
+}
+
+void __fastunpack9(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<9>::Unpack(in, out);
+}
+
+void __fastunpack10(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<10>::Unpack(in, out);
+}
+
+void __fastunpack11(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<11>::Unpack(in, out);
+}
+
+void __fastunpack12(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<12>::Unpack(in, out);
+}
+
+void __fastunpack13(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<13>::Unpack(in, out);
+}
+
+void __fastunpack14(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<14>::Unpack(in, out);
+}
+
+void __fastunpack15(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<15>::Unpack(in, out);
+}
+
+void __fastunpack16(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	for (uint32_t outer = 0; outer < 16; ++outer) {
+		for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 16)
+			*(out++) = ((*in) >> inwordpointer) % (1U << 16);
+		++in;
+	}
+}
+
+void __fastunpack17(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<17>::Unpack(in, out);
+}
+
+void __fastunpack18(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<18>::Unpack(in, out);
+}
+
+void __fastunpack19(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<19>::Unpack(in, out);
+}
+
+void __fastunpack20(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<20>::Unpack(in, out);
+}
+
+void __fastunpack21(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<21>::Unpack(in, out);
+}
+
+void __fastunpack22(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<22>::Unpack(in, out);
+}
+
+void __fastunpack23(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<23>::Unpack(in, out);
+}
+
+void __fastunpack24(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<24>::Unpack(in, out);
+}
+
+void __fastunpack25(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<25>::Unpack(in, out);
+}
+
+void __fastunpack26(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<26>::Unpack(in, out);
+}
+
+void __fastunpack27(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<27>::Unpack(in, out);
+}
+
+void __fastunpack28(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<28>::Unpack(in, out);
+}
+
+void __fastunpack29(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<29>::Unpack(in, out);
+}
+
+void __fastunpack30(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<30>::Unpack(in, out);
+}
+
+void __fastunpack31(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<31>::Unpack(in, out);
+}
+
+void __fastunpack32(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	for (int k = 0; k < 32; ++k)
+		out[k] = in[k];
+}
+
+void __fastunpack33(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<33>::Unpack(in, out);
+}
+
+void __fastunpack34(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<34>::Unpack(in, out);
+}
+
+void __fastunpack35(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<35>::Unpack(in, out);
+}
+
+void __fastunpack36(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<36>::Unpack(in, out);
+}
+
+void __fastunpack37(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<37>::Unpack(in, out);
+}
+
+void __fastunpack38(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<38>::Unpack(in, out);
+}
+
+void __fastunpack39(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<39>::Unpack(in, out);
+}
+
+void __fastunpack40(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<40>::Unpack(in, out);
+}
+
+void __fastunpack41(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<41>::Unpack(in, out);
+}
+
+void __fastunpack42(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<42>::Unpack(in, out);
+}
+
+void __fastunpack43(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<43>::Unpack(in, out);
+}
+
+void __fastunpack44(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<44>::Unpack(in, out);
+}
+
+void __fastunpack45(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<45>::Unpack(in, out);
+}
+
+void __fastunpack46(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<46>::Unpack(in, out);
+}
+
+void __fastunpack47(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<47>::Unpack(in, out);
+}
+
+void __fastunpack48(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<48>::Unpack(in, out);
+}
+
+void __fastunpack49(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<49>::Unpack(in, out);
+}
+
+void __fastunpack50(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<50>::Unpack(in, out);
+}
+
+void __fastunpack51(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<51>::Unpack(in, out);
+}
+
+void __fastunpack52(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<52>::Unpack(in, out);
+}
+
+void __fastunpack53(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<53>::Unpack(in, out);
+}
+
+void __fastunpack54(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<54>::Unpack(in, out);
+}
+
+void __fastunpack55(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<55>::Unpack(in, out);
+}
+
+void __fastunpack56(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<56>::Unpack(in, out);
+}
+
+void __fastunpack57(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<57>::Unpack(in, out);
+}
+
+void __fastunpack58(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<58>::Unpack(in, out);
+}
+
+void __fastunpack59(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<59>::Unpack(in, out);
+}
+
+void __fastunpack60(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<60>::Unpack(in, out);
+}
+
+void __fastunpack61(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<61>::Unpack(in, out);
+}
+
+void __fastunpack62(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<62>::Unpack(in, out);
+}
+
+void __fastunpack63(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	Unroller<63>::Unpack(in, out);
+}
+
+void __fastunpack64(const uint32_t *__restrict in, uint64_t *__restrict out) {
+	for (int k = 0; k < 32; ++k) {
+		out[k] = in[k * 2];
+		out[k] |= static_cast<uint64_t>(in[k * 2 + 1]) << 32;
+	}
+}
+
+// fastpack for 8 bits
+
+void __fastpack1(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<1>::Pack(in, out);
+}
+
+void __fastpack2(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<2>::Pack(in, out);
+}
+
+void __fastpack3(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<3>::Pack(in, out);
+}
+
+void __fastpack4(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<4>::Pack(in, out);
+}
+
+void __fastpack5(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<5>::Pack(in, out);
+}
+
+void __fastpack6(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<6>::Pack(in, out);
+}
+
+void __fastpack7(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	Unroller8<7>::Pack(in, out);
+}
+
+void __fastpack8(const uint8_t *__restrict in, uint8_t *__restrict out) {
+	for (int k = 0; k < 8; ++k)
+		out[k] = in[k];
+}
+
+// fastpack for 16 bits
+
+void __fastpack1(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<1>::Pack(in, out);
+}
+
+void __fastpack2(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<2>::Pack(in, out);
+}
+
+void __fastpack3(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<3>::Pack(in, out);
+}
+
+void __fastpack4(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<4>::Pack(in, out);
+}
+
+void __fastpack5(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<5>::Pack(in, out);
+}
+
+void __fastpack6(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<6>::Pack(in, out);
+}
+
+void __fastpack7(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<7>::Pack(in, out);
+}
+
+void __fastpack8(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<8>::Pack(in, out);
+}
+
+void __fastpack9(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<9>::Pack(in, out);
+}
+
+void __fastpack10(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<10>::Pack(in, out);
+}
+
+void __fastpack11(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<11>::Pack(in, out);
+}
+
+void __fastpack12(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<12>::Pack(in, out);
+}
+
+void __fastpack13(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<13>::Pack(in, out);
+}
+
+void __fastpack14(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<14>::Pack(in, out);
+}
+
+void __fastpack15(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	Unroller16<15>::Pack(in, out);
+}
+
+void __fastpack16(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	for (int k = 0; k < 16; ++k)
+		out[k] = in[k];
+}
+
+
+// fastpack for 32 bits
+
+void __fastpack1(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<1>::Pack(in, out);
+}
+
+void __fastpack2(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<2>::Pack(in, out);
+}
+
+void __fastpack3(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<3>::Pack(in, out);
+}
+
+void __fastpack4(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<4>::Pack(in, out);
+}
+
+void __fastpack5(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<5>::Pack(in, out);
+}
+
+void __fastpack6(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<6>::Pack(in, out);
+}
+
+void __fastpack7(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<7>::Pack(in, out);
+}
+
+void __fastpack8(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<8>::Pack(in, out);
+}
+
+void __fastpack9(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<9>::Pack(in, out);
+}
+
+void __fastpack10(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<10>::Pack(in, out);
+}
+
+void __fastpack11(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<11>::Pack(in, out);
+}
+
+void __fastpack12(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<12>::Pack(in, out);
+}
+
+void __fastpack13(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<13>::Pack(in, out);
+}
+
+void __fastpack14(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<14>::Pack(in, out);
+}
+
+void __fastpack15(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<15>::Pack(in, out);
+}
+
+void __fastpack16(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<16>::Pack(in, out);
+}
+
+void __fastpack17(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<17>::Pack(in, out);
+}
+
+void __fastpack18(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<18>::Pack(in, out);
+}
+
+void __fastpack19(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<19>::Pack(in, out);
+}
+
+void __fastpack20(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<20>::Pack(in, out);
+}
+
+void __fastpack21(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<21>::Pack(in, out);
+}
+
+void __fastpack22(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<22>::Pack(in, out);
+}
+
+void __fastpack23(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<23>::Pack(in, out);
+}
+
+void __fastpack24(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<24>::Pack(in, out);
+}
+
+void __fastpack25(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<25>::Pack(in, out);
+}
+
+void __fastpack26(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<26>::Pack(in, out);
+}
+
+void __fastpack27(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<27>::Pack(in, out);
+}
+
+void __fastpack28(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<28>::Pack(in, out);
+}
+
+void __fastpack29(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<29>::Pack(in, out);
+}
+
+void __fastpack30(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<30>::Pack(in, out);
+}
+
+void __fastpack31(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<31>::Pack(in, out);
+}
+
+void __fastpack32(const uint32_t *__restrict in, uint32_t *__restrict out) {
+	for (int k = 0; k < 32; ++k)
+		out[k] = in[k];
+}
+
+// fastpack for 64 bits
+
+void __fastpack1(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<1>::Pack(in, out);
+}
+
+void __fastpack2(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<2>::Pack(in, out);
+}
+
+void __fastpack3(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<3>::Pack(in, out);
+}
+
+void __fastpack4(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<4>::Pack(in, out);
+}
+
+void __fastpack5(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<5>::Pack(in, out);
+}
+
+void __fastpack6(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<6>::Pack(in, out);
+}
+
+void __fastpack7(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<7>::Pack(in, out);
+}
+
+void __fastpack8(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<8>::Pack(in, out);
+}
+
+void __fastpack9(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<9>::Pack(in, out);
+}
+
+void __fastpack10(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<10>::Pack(in, out);
+}
+
+void __fastpack11(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<11>::Pack(in, out);
+}
+
+void __fastpack12(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<12>::Pack(in, out);
+}
+
+void __fastpack13(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<13>::Pack(in, out);
+}
+
+void __fastpack14(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<14>::Pack(in, out);
+}
+
+void __fastpack15(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<15>::Pack(in, out);
+}
+
+void __fastpack16(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<16>::Pack(in, out);
+}
+
+void __fastpack17(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<17>::Pack(in, out);
+}
+
+void __fastpack18(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<18>::Pack(in, out);
+}
+
+void __fastpack19(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<19>::Pack(in, out);
+}
+
+void __fastpack20(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<20>::Pack(in, out);
+}
+
+void __fastpack21(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<21>::Pack(in, out);
+}
+
+void __fastpack22(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<22>::Pack(in, out);
+}
+
+void __fastpack23(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<23>::Pack(in, out);
+}
+
+void __fastpack24(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<24>::Pack(in, out);
+}
+
+void __fastpack25(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<25>::Pack(in, out);
+}
+
+void __fastpack26(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<26>::Pack(in, out);
+}
+
+void __fastpack27(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<27>::Pack(in, out);
+}
+
+void __fastpack28(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<28>::Pack(in, out);
+}
+
+void __fastpack29(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<29>::Pack(in, out);
+}
+
+void __fastpack30(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<30>::Pack(in, out);
+}
+
+void __fastpack31(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<31>::Pack(in, out);
+}
+
+void __fastpack32(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	for (int k = 0; k < 32; ++k) {
+		out[k] = static_cast<uint32_t>(in[k]);
+	}
+}
+
+void __fastpack33(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<33>::Pack(in, out);
+}
+
+void __fastpack34(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<34>::Pack(in, out);
+}
+
+void __fastpack35(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<35>::Pack(in, out);
+}
+
+void __fastpack36(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<36>::Pack(in, out);
+}
+
+void __fastpack37(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<37>::Pack(in, out);
+}
+
+void __fastpack38(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<38>::Pack(in, out);
+}
+
+void __fastpack39(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<39>::Pack(in, out);
+}
+
+void __fastpack40(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<40>::Pack(in, out);
+}
+
+void __fastpack41(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<41>::Pack(in, out);
+}
+
+void __fastpack42(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<42>::Pack(in, out);
+}
+
+void __fastpack43(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<43>::Pack(in, out);
+}
+
+void __fastpack44(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<44>::Pack(in, out);
+}
+
+void __fastpack45(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<45>::Pack(in, out);
+}
+
+void __fastpack46(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<46>::Pack(in, out);
+}
+
+void __fastpack47(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<47>::Pack(in, out);
+}
+
+void __fastpack48(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<48>::Pack(in, out);
+}
+
+void __fastpack49(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<49>::Pack(in, out);
+}
+
+void __fastpack50(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<50>::Pack(in, out);
+}
+
+void __fastpack51(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<51>::Pack(in, out);
+}
+
+void __fastpack52(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<52>::Pack(in, out);
+}
+
+void __fastpack53(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<53>::Pack(in, out);
+}
+
+void __fastpack54(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<54>::Pack(in, out);
+}
+
+void __fastpack55(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<55>::Pack(in, out);
+}
+
+void __fastpack56(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<56>::Pack(in, out);
+}
+
+void __fastpack57(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<57>::Pack(in, out);
+}
+
+void __fastpack58(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<58>::Pack(in, out);
+}
+
+void __fastpack59(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<59>::Pack(in, out);
+}
+
+void __fastpack60(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<60>::Pack(in, out);
+}
+
+void __fastpack61(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<61>::Pack(in, out);
+}
+
+void __fastpack62(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<62>::Pack(in, out);
+}
+
+void __fastpack63(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	Unroller<63>::Pack(in, out);
+}
+
+void __fastpack64(const uint64_t *__restrict in, uint32_t *__restrict out) {
+	for (int i = 0; i < 32; ++i) {
+		out[2 * i] = static_cast<uint32_t>(in[i]);
+		out[2 * i + 1] = in[i] >> 32;
+	}
+}
+} // namespace internal
+} // namespace duckdb_fastpforlib
+
+
+// LICENSE_CHANGE_END

--- a/velox/external/duckdb/duckdb-fmt.cpp
+++ b/velox/external/duckdb/duckdb-fmt.cpp
@@ -1,0 +1,1417 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+// LICENSE_CHANGE_BEGIN
+// The following code up to LICENSE_CHANGE_END is subject to THIRD PARTY LICENSE #1
+// See the end of this file for a list
+
+// Formatting library for C++
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+
+
+// LICENSE_CHANGE_BEGIN
+// The following code up to LICENSE_CHANGE_END is subject to THIRD PARTY LICENSE #1
+// See the end of this file for a list
+
+// Formatting library for C++ - implementation
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_FORMAT_INL_H_
+#define FMT_FORMAT_INL_H_
+
+
+
+#include <cassert>
+#include <cctype>
+#include <climits>
+#include <cmath>
+#include <cstdarg>
+#include <cstring>  // for std::memmove
+#include <cwchar>
+#if !defined(FMT_STATIC_THOUSANDS_SEPARATOR)
+#  include <locale>
+#endif
+
+#if FMT_EXCEPTIONS
+#  define FMT_TRY try
+#  define FMT_CATCH(x) catch (x)
+#else
+#  define FMT_TRY if (true)
+#  define FMT_CATCH(x) if (false)
+#endif
+
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable : 4702)  // unreachable code
+#endif
+
+// Dummy implementations of strerror_r and strerror_s called if corresponding
+// system functions are not available.
+inline duckdb_fmt::internal::null<> strerror_r(int, char*, ...) { return {}; }
+inline duckdb_fmt::internal::null<> strerror_s(char*, std::size_t, ...) { return {}; }
+
+FMT_BEGIN_NAMESPACE
+namespace internal {
+
+#ifndef _MSC_VER
+#  define FMT_SNPRINTF snprintf
+#else  // _MSC_VER
+inline int fmt_snprintf(char* buffer, size_t size, const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  int result = vsnprintf_s(buffer, size, _TRUNCATE, format, args);
+  va_end(args);
+  return result;
+}
+#  define FMT_SNPRINTF fmt_snprintf
+#endif  // _MSC_VER
+
+using format_func = void (*)(internal::buffer<char>&, int, string_view);
+
+// A portable thread-safe version of strerror.
+// Sets buffer to point to a string describing the error code.
+// This can be either a pointer to a string stored in buffer,
+// or a pointer to some static immutable string.
+// Returns one of the following values:
+//   0      - success
+//   ERANGE - buffer is not large enough to store the error message
+//   other  - failure
+// Buffer should be at least of size 1.
+FMT_FUNC int safe_strerror(int error_code, char*& buffer,
+                           std::size_t buffer_size) FMT_NOEXCEPT {
+  FMT_ASSERT(buffer != nullptr && buffer_size != 0, "invalid buffer");
+
+  class dispatcher {
+   private:
+    int error_code_;
+    char*& buffer_;
+    std::size_t buffer_size_;
+
+    // A noop assignment operator to avoid bogus warnings.
+    void operator=(const dispatcher&) {}
+
+    // Handle the result of XSI-compliant version of strerror_r.
+    int handle(int result) {
+      // glibc versions before 2.13 return result in errno.
+      return result == -1 ? errno : result;
+    }
+
+    // Handle the result of GNU-specific version of strerror_r.
+    int handle(char* message) {
+      // If the buffer is full then the message is probably truncated.
+      if (message == buffer_ && strlen(buffer_) == buffer_size_ - 1)
+        return ERANGE;
+      buffer_ = message;
+      return 0;
+    }
+
+    // Handle the case when strerror_r is not available.
+    int handle(internal::null<>) {
+      return fallback(strerror_s(buffer_, buffer_size_, error_code_));
+    }
+
+    // Fallback to strerror_s when strerror_r is not available.
+    int fallback(int result) {
+      // If the buffer is full then the message is probably truncated.
+      return result == 0 && strlen(buffer_) == buffer_size_ - 1 ? ERANGE
+                                                                : result;
+    }
+
+#if !FMT_MSC_VER
+    // Fallback to strerror if strerror_r and strerror_s are not available.
+    int fallback(internal::null<>) {
+      errno = 0;
+      buffer_ = strerror(error_code_);
+      return errno;
+    }
+#endif
+
+   public:
+    dispatcher(int err_code, char*& buf, std::size_t buf_size)
+        : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
+
+    int run() { return handle(strerror_r(error_code_, buffer_, buffer_size_)); }
+  };
+  return dispatcher(error_code, buffer, buffer_size).run();
+}
+
+FMT_FUNC void format_error_code(internal::buffer<char>& out, int error_code,
+                                string_view message) FMT_NOEXCEPT {
+  // Report error code making sure that the output fits into
+  // inline_buffer_size to avoid dynamic memory allocation and potential
+  // bad_alloc.
+  out.resize(0);
+  static const char SEP[] = ": ";
+  static const char ERROR_STR[] = "error ";
+  // Subtract 2 to account for terminating null characters in SEP and ERROR_STR.
+  std::size_t error_code_size = sizeof(SEP) + sizeof(ERROR_STR) - 2;
+  auto abs_value = static_cast<uint32_or_64_or_128_t<int>>(error_code);
+  if (internal::is_negative(error_code)) {
+    abs_value = 0 - abs_value;
+    ++error_code_size;
+  }
+  error_code_size += internal::to_unsigned(internal::count_digits(abs_value));
+  internal::writer w(out);
+  if (message.size() <= inline_buffer_size - error_code_size) {
+    w.write(message);
+    w.write(SEP);
+  }
+  w.write(ERROR_STR);
+  w.write(error_code);
+  assert(out.size() <= inline_buffer_size);
+}
+
+FMT_FUNC void report_error(format_func func, int error_code,
+                           string_view message) FMT_NOEXCEPT {
+  memory_buffer full_message;
+  func(full_message, error_code, message);
+  /*// R does not allow us to have a reference to stderr even if we are not using it
+  // Don't use fwrite_fully because the latter may throw.
+  (void)std::fwrite(full_message.data(), full_message.size(), 1, stderr);
+  std::fputc('\n', stderr);
+  */
+}
+}  // namespace internal
+
+#if !defined(FMT_STATIC_THOUSANDS_SEPARATOR)
+namespace internal {
+
+template <typename Locale>
+locale_ref::locale_ref(const Locale& loc) : locale_(&loc) {
+  static_assert(std::is_same<Locale, std::locale>::value, "");
+}
+
+template <typename Locale> Locale locale_ref::get() const {
+  static_assert(std::is_same<Locale, std::locale>::value, "");
+  return locale_ ? *static_cast<const std::locale*>(locale_) : std::locale();
+}
+
+template <typename Char> FMT_FUNC std::string grouping_impl(locale_ref loc) {
+  return std::use_facet<std::numpunct<Char>>(loc.get<std::locale>()).grouping();
+}
+template <typename Char> FMT_FUNC Char thousands_sep_impl(locale_ref loc) {
+  return std::use_facet<std::numpunct<Char>>(loc.get<std::locale>())
+      .thousands_sep();
+}
+template <typename Char> FMT_FUNC Char decimal_point_impl(locale_ref loc) {
+  return std::use_facet<std::numpunct<Char>>(loc.get<std::locale>())
+      .decimal_point();
+}
+}  // namespace internal
+#else
+template <typename Char>
+FMT_FUNC std::string internal::grouping_impl(locale_ref) {
+  return "\03";
+}
+template <typename Char>
+FMT_FUNC Char internal::thousands_sep_impl(locale_ref) {
+  return FMT_STATIC_THOUSANDS_SEPARATOR;
+}
+template <typename Char>
+FMT_FUNC Char internal::decimal_point_impl(locale_ref) {
+  return '.';
+}
+#endif
+
+namespace internal {
+
+template <> FMT_FUNC int count_digits<4>(internal::fallback_uintptr n) {
+  // fallback_uintptr is always stored in little endian.
+  int i = static_cast<int>(sizeof(void*)) - 1;
+  while (i > 0 && n.value[i] == 0) --i;
+  auto char_digits = std::numeric_limits<unsigned char>::digits / 4;
+  return i >= 0 ? i * char_digits + count_digits<4, unsigned>(n.value[i]) : 1;
+}
+
+template <typename T>
+const char basic_data<T>::digits[] =
+    "0001020304050607080910111213141516171819"
+    "2021222324252627282930313233343536373839"
+    "4041424344454647484950515253545556575859"
+    "6061626364656667686970717273747576777879"
+    "8081828384858687888990919293949596979899";
+
+template <typename T>
+const char basic_data<T>::hex_digits[] = "0123456789abcdef";
+
+#define FMT_POWERS_OF_10(factor)                                             \
+  factor * 10, (factor)*100, (factor)*1000, (factor)*10000, (factor)*100000, \
+      (factor)*1000000, (factor)*10000000, (factor)*100000000,               \
+      (factor)*1000000000
+
+template <typename T>
+const uint64_t basic_data<T>::powers_of_10_64[] = {
+    1, FMT_POWERS_OF_10(1), FMT_POWERS_OF_10(1000000000ULL),
+    10000000000000000000ULL};
+
+template <typename T>
+const uint32_t basic_data<T>::zero_or_powers_of_10_32[] = {0,
+                                                           FMT_POWERS_OF_10(1)};
+
+template <typename T>
+const uint64_t basic_data<T>::zero_or_powers_of_10_64[] = {
+    0, FMT_POWERS_OF_10(1), FMT_POWERS_OF_10(1000000000ULL),
+    10000000000000000000ULL};
+
+// Normalized 64-bit significands of pow(10, k), for k = -348, -340, ..., 340.
+// These are generated by support/compute-powers.py.
+template <typename T>
+const uint64_t basic_data<T>::pow10_significands[] = {
+    0xfa8fd5a0081c0288, 0xbaaee17fa23ebf76, 0x8b16fb203055ac76,
+    0xcf42894a5dce35ea, 0x9a6bb0aa55653b2d, 0xe61acf033d1a45df,
+    0xab70fe17c79ac6ca, 0xff77b1fcbebcdc4f, 0xbe5691ef416bd60c,
+    0x8dd01fad907ffc3c, 0xd3515c2831559a83, 0x9d71ac8fada6c9b5,
+    0xea9c227723ee8bcb, 0xaecc49914078536d, 0x823c12795db6ce57,
+    0xc21094364dfb5637, 0x9096ea6f3848984f, 0xd77485cb25823ac7,
+    0xa086cfcd97bf97f4, 0xef340a98172aace5, 0xb23867fb2a35b28e,
+    0x84c8d4dfd2c63f3b, 0xc5dd44271ad3cdba, 0x936b9fcebb25c996,
+    0xdbac6c247d62a584, 0xa3ab66580d5fdaf6, 0xf3e2f893dec3f126,
+    0xb5b5ada8aaff80b8, 0x87625f056c7c4a8b, 0xc9bcff6034c13053,
+    0x964e858c91ba2655, 0xdff9772470297ebd, 0xa6dfbd9fb8e5b88f,
+    0xf8a95fcf88747d94, 0xb94470938fa89bcf, 0x8a08f0f8bf0f156b,
+    0xcdb02555653131b6, 0x993fe2c6d07b7fac, 0xe45c10c42a2b3b06,
+    0xaa242499697392d3, 0xfd87b5f28300ca0e, 0xbce5086492111aeb,
+    0x8cbccc096f5088cc, 0xd1b71758e219652c, 0x9c40000000000000,
+    0xe8d4a51000000000, 0xad78ebc5ac620000, 0x813f3978f8940984,
+    0xc097ce7bc90715b3, 0x8f7e32ce7bea5c70, 0xd5d238a4abe98068,
+    0x9f4f2726179a2245, 0xed63a231d4c4fb27, 0xb0de65388cc8ada8,
+    0x83c7088e1aab65db, 0xc45d1df942711d9a, 0x924d692ca61be758,
+    0xda01ee641a708dea, 0xa26da3999aef774a, 0xf209787bb47d6b85,
+    0xb454e4a179dd1877, 0x865b86925b9bc5c2, 0xc83553c5c8965d3d,
+    0x952ab45cfa97a0b3, 0xde469fbd99a05fe3, 0xa59bc234db398c25,
+    0xf6c69a72a3989f5c, 0xb7dcbf5354e9bece, 0x88fcf317f22241e2,
+    0xcc20ce9bd35c78a5, 0x98165af37b2153df, 0xe2a0b5dc971f303a,
+    0xa8d9d1535ce3b396, 0xfb9b7cd9a4a7443c, 0xbb764c4ca7a44410,
+    0x8bab8eefb6409c1a, 0xd01fef10a657842c, 0x9b10a4e5e9913129,
+    0xe7109bfba19c0c9d, 0xac2820d9623bf429, 0x80444b5e7aa7cf85,
+    0xbf21e44003acdd2d, 0x8e679c2f5e44ff8f, 0xd433179d9c8cb841,
+    0x9e19db92b4e31ba9, 0xeb96bf6ebadf77d9, 0xaf87023b9bf0ee6b,
+};
+
+// Binary exponents of pow(10, k), for k = -348, -340, ..., 340, corresponding
+// to significands above.
+template <typename T>
+const int16_t basic_data<T>::pow10_exponents[] = {
+    -1220, -1193, -1166, -1140, -1113, -1087, -1060, -1034, -1007, -980, -954,
+    -927,  -901,  -874,  -847,  -821,  -794,  -768,  -741,  -715,  -688, -661,
+    -635,  -608,  -582,  -555,  -529,  -502,  -475,  -449,  -422,  -396, -369,
+    -343,  -316,  -289,  -263,  -236,  -210,  -183,  -157,  -130,  -103, -77,
+    -50,   -24,   3,     30,    56,    83,    109,   136,   162,   189,  216,
+    242,   269,   295,   322,   348,   375,   402,   428,   455,   481,  508,
+    534,   561,   588,   614,   641,   667,   694,   720,   747,   774,  800,
+    827,   853,   880,   907,   933,   960,   986,   1013,  1039,  1066};
+
+template <typename T>
+const char basic_data<T>::foreground_color[] = "\x1b[38;2;";
+template <typename T>
+const char basic_data<T>::background_color[] = "\x1b[48;2;";
+template <typename T> const char basic_data<T>::reset_color[] = "\x1b[0m";
+template <typename T> const wchar_t basic_data<T>::wreset_color[] = L"\x1b[0m";
+template <typename T> const char basic_data<T>::signs[] = {0, '-', '+', ' '};
+
+template <typename T> struct bits {
+  static FMT_CONSTEXPR_DECL const int value =
+      static_cast<int>(sizeof(T) * std::numeric_limits<unsigned char>::digits);
+};
+
+class fp;
+template <int SHIFT = 0> fp normalize(fp value);
+
+// Lower (upper) boundary is a value half way between a floating-point value
+// and its predecessor (successor). Boundaries have the same exponent as the
+// value so only significands are stored.
+struct boundaries {
+  uint64_t lower;
+  uint64_t upper;
+};
+
+// A handmade floating-point number f * pow(2, e).
+class fp {
+ private:
+  using significand_type = uint64_t;
+
+  // All sizes are in bits.
+  // Subtract 1 to account for an implicit most significant bit in the
+  // normalized form.
+  static FMT_CONSTEXPR_DECL const int double_significand_size =
+      std::numeric_limits<double>::digits - 1;
+  static FMT_CONSTEXPR_DECL const uint64_t implicit_bit =
+      1ULL << double_significand_size;
+
+ public:
+  significand_type f;
+  int e;
+
+  static FMT_CONSTEXPR_DECL const int significand_size =
+      bits<significand_type>::value;
+
+  fp() : f(0), e(0) {}
+  fp(uint64_t f_val, int e_val) : f(f_val), e(e_val) {}
+
+  // Constructs fp from an IEEE754 double. It is a template to prevent compile
+  // errors on platforms where double is not IEEE754.
+  template <typename Double> explicit fp(Double d) { assign(d); }
+
+  // Normalizes the value converted from double and multiplied by (1 << SHIFT).
+  template <int SHIFT> friend fp normalize(fp value) {
+    // Handle subnormals.
+    const auto shifted_implicit_bit = fp::implicit_bit << SHIFT;
+    while ((value.f & shifted_implicit_bit) == 0) {
+      value.f <<= 1;
+      --value.e;
+    }
+    // Subtract 1 to account for hidden bit.
+    const auto offset =
+        fp::significand_size - fp::double_significand_size - SHIFT - 1;
+    value.f <<= offset;
+    value.e -= offset;
+    return value;
+  }
+
+  // Assigns d to this and return true iff predecessor is closer than successor.
+  template <typename Double, FMT_ENABLE_IF(sizeof(Double) == sizeof(uint64_t))>
+  bool assign(Double d) {
+    // Assume double is in the format [sign][exponent][significand].
+    using limits = std::numeric_limits<Double>;
+    const int exponent_size =
+        bits<Double>::value - double_significand_size - 1;  // -1 for sign
+    const uint64_t significand_mask = implicit_bit - 1;
+    const uint64_t exponent_mask = (~0ULL >> 1) & ~significand_mask;
+    const int exponent_bias = (1 << exponent_size) - limits::max_exponent - 1;
+    auto u = bit_cast<uint64_t>(d);
+    f = u & significand_mask;
+    auto biased_e = (u & exponent_mask) >> double_significand_size;
+    // Predecessor is closer if d is a normalized power of 2 (f == 0) other than
+    // the smallest normalized number (biased_e > 1).
+    bool is_predecessor_closer = f == 0 && biased_e > 1;
+    if (biased_e != 0)
+      f += implicit_bit;
+    else
+      biased_e = 1;  // Subnormals use biased exponent 1 (min exponent).
+    e = static_cast<int>(biased_e - exponent_bias - double_significand_size);
+    return is_predecessor_closer;
+  }
+
+  template <typename Double, FMT_ENABLE_IF(sizeof(Double) != sizeof(uint64_t))>
+  bool assign(Double) {
+    *this = fp();
+    return false;
+  }
+
+  // Assigns d to this together with computing lower and upper boundaries,
+  // where a boundary is a value half way between the number and its predecessor
+  // (lower) or successor (upper). The upper boundary is normalized and lower
+  // has the same exponent but may be not normalized.
+  template <typename Double> boundaries assign_with_boundaries(Double d) {
+    bool is_lower_closer = assign(d);
+    fp lower =
+        is_lower_closer ? fp((f << 2) - 1, e - 2) : fp((f << 1) - 1, e - 1);
+    // 1 in normalize accounts for the exponent shift above.
+    fp upper = normalize<1>(fp((f << 1) + 1, e - 1));
+    lower.f <<= lower.e - upper.e;
+    return boundaries{lower.f, upper.f};
+  }
+
+  template <typename Double> boundaries assign_float_with_boundaries(Double d) {
+    assign(d);
+    constexpr int min_normal_e = std::numeric_limits<float>::min_exponent -
+                                 std::numeric_limits<double>::digits;
+    significand_type half_ulp = 1 << (std::numeric_limits<double>::digits -
+                                      std::numeric_limits<float>::digits - 1);
+    if (min_normal_e > e) half_ulp <<= min_normal_e - e;
+    fp upper = normalize<0>(fp(f + half_ulp, e));
+    fp lower = fp(
+        f - (half_ulp >> ((f == implicit_bit && e > min_normal_e) ? 1 : 0)), e);
+    lower.f <<= lower.e - upper.e;
+    return boundaries{lower.f, upper.f};
+  }
+};
+
+inline bool operator==(fp x, fp y) { return x.f == y.f && x.e == y.e; }
+
+// Computes lhs * rhs / pow(2, 64) rounded to nearest with half-up tie breaking.
+inline uint64_t multiply(uint64_t lhs, uint64_t rhs) {
+#if FMT_USE_INT128
+  auto product = static_cast<__uint128_t>(lhs) * rhs;
+  auto f = static_cast<uint64_t>(product >> 64);
+  return (static_cast<uint64_t>(product) & (1ULL << 63)) != 0 ? f + 1 : f;
+#else
+  // Multiply 32-bit parts of significands.
+  uint64_t mask = (1ULL << 32) - 1;
+  uint64_t a = lhs >> 32, b = lhs & mask;
+  uint64_t c = rhs >> 32, d = rhs & mask;
+  uint64_t ac = a * c, bc = b * c, ad = a * d, bd = b * d;
+  // Compute mid 64-bit of result and round.
+  uint64_t mid = (bd >> 32) + (ad & mask) + (bc & mask) + (1U << 31);
+  return ac + (ad >> 32) + (bc >> 32) + (mid >> 32);
+#endif
+}
+
+inline fp operator*(fp x, fp y) { return {multiply(x.f, y.f), x.e + y.e + 64}; }
+
+// Returns a cached power of 10 `c_k = c_k.f * pow(2, c_k.e)` such that its
+// (binary) exponent satisfies `min_exponent <= c_k.e <= min_exponent + 28`.
+FMT_FUNC fp get_cached_power(int min_exponent, int& pow10_exponent) {
+  const uint64_t one_over_log2_10 = 0x4d104d42;  // round(pow(2, 32) / log2(10))
+  int index = static_cast<int>(
+      static_cast<int64_t>(
+          (min_exponent + fp::significand_size - 1) * one_over_log2_10 +
+          ((uint64_t(1) << 32) - 1)  // ceil
+          ) >>
+      32  // arithmetic shift
+  );
+  // Decimal exponent of the first (smallest) cached power of 10.
+  const int first_dec_exp = -348;
+  // Difference between 2 consecutive decimal exponents in cached powers of 10.
+  const int dec_exp_step = 8;
+  index = (index - first_dec_exp - 1) / dec_exp_step + 1;
+  pow10_exponent = first_dec_exp + index * dec_exp_step;
+  return {data::pow10_significands[index], data::pow10_exponents[index]};
+}
+
+// A simple accumulator to hold the sums of terms in bigint::square if uint128_t
+// is not available.
+struct accumulator {
+  uint64_t lower;
+  uint64_t upper;
+
+  accumulator() : lower(0), upper(0) {}
+  explicit operator uint32_t() const { return static_cast<uint32_t>(lower); }
+
+  void operator+=(uint64_t n) {
+    lower += n;
+    if (lower < n) ++upper;
+  }
+  void operator>>=(int shift) {
+    assert(shift == 32);
+    (void)shift;
+    lower = (upper << 32) | (lower >> 32);
+    upper >>= 32;
+  }
+};
+
+class bigint {
+ private:
+  // A bigint is stored as an array of bigits (big digits), with bigit at index
+  // 0 being the least significant one.
+  using bigit = uint32_t;
+  using double_bigit = uint64_t;
+  enum { bigits_capacity = 32 };
+  basic_memory_buffer<bigit, bigits_capacity> bigits_;
+  int exp_;
+
+  static FMT_CONSTEXPR_DECL const int bigit_bits = bits<bigit>::value;
+
+  friend struct formatter<bigint>;
+
+  void subtract_bigits(int index, bigit other, bigit& borrow) {
+    auto result = static_cast<double_bigit>(bigits_[index]) - other - borrow;
+    bigits_[index] = static_cast<bigit>(result);
+    borrow = static_cast<bigit>(result >> (bigit_bits * 2 - 1));
+  }
+
+  void remove_leading_zeros() {
+    int num_bigits = static_cast<int>(bigits_.size()) - 1;
+    while (num_bigits > 0 && bigits_[num_bigits] == 0) --num_bigits;
+    bigits_.resize(num_bigits + 1);
+  }
+
+  // Computes *this -= other assuming aligned bigints and *this >= other.
+  void subtract_aligned(const bigint& other) {
+    FMT_ASSERT(other.exp_ >= exp_, "unaligned bigints");
+    FMT_ASSERT(compare(*this, other) >= 0, "");
+    bigit borrow = 0;
+    int i = other.exp_ - exp_;
+    for (int j = 0, n = static_cast<int>(other.bigits_.size()); j != n;
+         ++i, ++j) {
+      subtract_bigits(i, other.bigits_[j], borrow);
+    }
+    while (borrow > 0) subtract_bigits(i, 0, borrow);
+    remove_leading_zeros();
+  }
+
+  void multiply(uint32_t value) {
+    const double_bigit wide_value = value;
+    bigit carry = 0;
+    for (size_t i = 0, n = bigits_.size(); i < n; ++i) {
+      double_bigit result = bigits_[i] * wide_value + carry;
+      bigits_[i] = static_cast<bigit>(result);
+      carry = static_cast<bigit>(result >> bigit_bits);
+    }
+    if (carry != 0) bigits_.push_back(carry);
+  }
+
+  void multiply(uint64_t value) {
+    const bigit mask = ~bigit(0);
+    const double_bigit lower = value & mask;
+    const double_bigit upper = value >> bigit_bits;
+    double_bigit carry = 0;
+    for (size_t i = 0, n = bigits_.size(); i < n; ++i) {
+      double_bigit result = bigits_[i] * lower + (carry & mask);
+      carry =
+          bigits_[i] * upper + (result >> bigit_bits) + (carry >> bigit_bits);
+      bigits_[i] = static_cast<bigit>(result);
+    }
+    while (carry != 0) {
+      bigits_.push_back(carry & mask);
+      carry >>= bigit_bits;
+    }
+  }
+
+ public:
+  bigint() : exp_(0) {}
+  explicit bigint(uint64_t n) { assign(n); }
+  ~bigint() { assert(bigits_.capacity() <= bigits_capacity); }
+
+  bigint(const bigint&) = delete;
+  void operator=(const bigint&) = delete;
+
+  void assign(const bigint& other) {
+    bigits_.resize(other.bigits_.size());
+    auto data = other.bigits_.data();
+    std::copy(data, data + other.bigits_.size(), bigits_.data());
+    exp_ = other.exp_;
+  }
+
+  void assign(uint64_t n) {
+    int num_bigits = 0;
+    do {
+      bigits_[num_bigits++] = n & ~bigit(0);
+      n >>= bigit_bits;
+    } while (n != 0);
+    bigits_.resize(num_bigits);
+    exp_ = 0;
+  }
+
+  int num_bigits() const { return static_cast<int>(bigits_.size()) + exp_; }
+
+  bigint& operator<<=(int shift) {
+    assert(shift >= 0);
+    exp_ += shift / bigit_bits;
+    shift %= bigit_bits;
+    if (shift == 0) return *this;
+    bigit carry = 0;
+    for (size_t i = 0, n = bigits_.size(); i < n; ++i) {
+      bigit c = bigits_[i] >> (bigit_bits - shift);
+      bigits_[i] = (bigits_[i] << shift) + carry;
+      carry = c;
+    }
+    if (carry != 0) bigits_.push_back(carry);
+    return *this;
+  }
+
+  template <typename Int> bigint& operator*=(Int value) {
+    FMT_ASSERT(value > 0, "");
+    multiply(uint32_or_64_or_128_t<Int>(value));
+    return *this;
+  }
+
+  friend int compare(const bigint& lhs, const bigint& rhs) {
+    int num_lhs_bigits = lhs.num_bigits(), num_rhs_bigits = rhs.num_bigits();
+    if (num_lhs_bigits != num_rhs_bigits)
+      return num_lhs_bigits > num_rhs_bigits ? 1 : -1;
+    int i = static_cast<int>(lhs.bigits_.size()) - 1;
+    int j = static_cast<int>(rhs.bigits_.size()) - 1;
+    int end = i - j;
+    if (end < 0) end = 0;
+    for (; i >= end; --i, --j) {
+      bigit lhs_bigit = lhs.bigits_[i], rhs_bigit = rhs.bigits_[j];
+      if (lhs_bigit != rhs_bigit) return lhs_bigit > rhs_bigit ? 1 : -1;
+    }
+    if (i != j) return i > j ? 1 : -1;
+    return 0;
+  }
+
+  // Returns compare(lhs1 + lhs2, rhs).
+  friend int add_compare(const bigint& lhs1, const bigint& lhs2,
+                         const bigint& rhs) {
+    int max_lhs_bigits = (std::max)(lhs1.num_bigits(), lhs2.num_bigits());
+    int num_rhs_bigits = rhs.num_bigits();
+    if (max_lhs_bigits + 1 < num_rhs_bigits) return -1;
+    if (max_lhs_bigits > num_rhs_bigits) return 1;
+    auto get_bigit = [](const bigint& n, int i) -> bigit {
+      return i >= n.exp_ && i < n.num_bigits() ? n.bigits_[i - n.exp_] : 0;
+    };
+    double_bigit borrow = 0;
+    int min_exp = (std::min)((std::min)(lhs1.exp_, lhs2.exp_), rhs.exp_);
+    for (int i = num_rhs_bigits - 1; i >= min_exp; --i) {
+      double_bigit sum =
+          static_cast<double_bigit>(get_bigit(lhs1, i)) + get_bigit(lhs2, i);
+      bigit rhs_bigit = get_bigit(rhs, i);
+      if (sum > rhs_bigit + borrow) return 1;
+      borrow = rhs_bigit + borrow - sum;
+      if (borrow > 1) return -1;
+      borrow <<= bigit_bits;
+    }
+    return borrow != 0 ? -1 : 0;
+  }
+
+  // Assigns pow(10, exp) to this bigint.
+  void assign_pow10(int exp) {
+    assert(exp >= 0);
+    if (exp == 0) return assign(1);
+    // Find the top bit.
+    int bitmask = 1;
+    while (exp >= bitmask) bitmask <<= 1;
+    bitmask >>= 1;
+    // pow(10, exp) = pow(5, exp) * pow(2, exp). First compute pow(5, exp) by
+    // repeated squaring and multiplication.
+    assign(5);
+    bitmask >>= 1;
+    while (bitmask != 0) {
+      square();
+      if ((exp & bitmask) != 0) *this *= 5;
+      bitmask >>= 1;
+    }
+    *this <<= exp;  // Multiply by pow(2, exp) by shifting.
+  }
+
+  void square() {
+    basic_memory_buffer<bigit, bigits_capacity> n(std::move(bigits_));
+    int num_bigits = static_cast<int>(bigits_.size());
+    int num_result_bigits = 2 * num_bigits;
+    bigits_.resize(num_result_bigits);
+    using accumulator_t = conditional_t<FMT_USE_INT128, uint128_t, accumulator>;
+    auto sum = accumulator_t();
+    for (int bigit_index = 0; bigit_index < num_bigits; ++bigit_index) {
+      // Compute bigit at position bigit_index of the result by adding
+      // cross-product terms n[i] * n[j] such that i + j == bigit_index.
+      for (int i = 0, j = bigit_index; j >= 0; ++i, --j) {
+        // Most terms are multiplied twice which can be optimized in the future.
+        sum += static_cast<double_bigit>(n[i]) * n[j];
+      }
+      bigits_[bigit_index] = static_cast<bigit>(sum);
+      sum >>= bits<bigit>::value;  // Compute the carry.
+    }
+    // Do the same for the top half.
+    for (int bigit_index = num_bigits; bigit_index < num_result_bigits;
+         ++bigit_index) {
+      for (int j = num_bigits - 1, i = bigit_index - j; i < num_bigits;)
+        sum += static_cast<double_bigit>(n[i++]) * n[j--];
+      bigits_[bigit_index] = static_cast<bigit>(sum);
+      sum >>= bits<bigit>::value;
+    }
+    --num_result_bigits;
+    remove_leading_zeros();
+    exp_ *= 2;
+  }
+
+  // Divides this bignum by divisor, assigning the remainder to this and
+  // returning the quotient.
+  int divmod_assign(const bigint& divisor) {
+    FMT_ASSERT(this != &divisor, "");
+    if (compare(*this, divisor) < 0) return 0;
+    int num_bigits = static_cast<int>(bigits_.size());
+    FMT_ASSERT(divisor.bigits_[divisor.bigits_.size() - 1] != 0, "");
+    int exp_difference = exp_ - divisor.exp_;
+    if (exp_difference > 0) {
+      // Align bigints by adding trailing zeros to simplify subtraction.
+      bigits_.resize(num_bigits + exp_difference);
+      for (int i = num_bigits - 1, j = i + exp_difference; i >= 0; --i, --j)
+        bigits_[j] = bigits_[i];
+      std::uninitialized_fill_n(bigits_.data(), exp_difference, 0);
+      exp_ -= exp_difference;
+    }
+    int quotient = 0;
+    do {
+      subtract_aligned(divisor);
+      ++quotient;
+    } while (compare(*this, divisor) >= 0);
+    return quotient;
+  }
+};
+
+enum round_direction { unknown, up, down };
+
+// Given the divisor (normally a power of 10), the remainder = v % divisor for
+// some number v and the error, returns whether v should be rounded up, down, or
+// whether the rounding direction can't be determined due to error.
+// error should be less than divisor / 2.
+inline round_direction get_round_direction(uint64_t divisor, uint64_t remainder,
+                                           uint64_t error) {
+  FMT_ASSERT(remainder < divisor, "");  // divisor - remainder won't overflow.
+  FMT_ASSERT(error < divisor, "");      // divisor - error won't overflow.
+  FMT_ASSERT(error < divisor - error, "");  // error * 2 won't overflow.
+  // Round down if (remainder + error) * 2 <= divisor.
+  if (remainder <= divisor - remainder && error * 2 <= divisor - remainder * 2)
+    return down;
+  // Round up if (remainder - error) * 2 >= divisor.
+  if (remainder >= error &&
+      remainder - error >= divisor - (remainder - error)) {
+    return up;
+  }
+  return unknown;
+}
+
+namespace digits {
+enum result {
+  more,  // Generate more digits.
+  done,  // Done generating digits.
+  error  // Digit generation cancelled due to an error.
+};
+}
+
+// Generates output using the Grisu digit-gen algorithm.
+// error: the size of the region (lower, upper) outside of which numbers
+// definitely do not round to value (Delta in Grisu3).
+template <typename Handler>
+FMT_ALWAYS_INLINE digits::result grisu_gen_digits(fp value, uint64_t error,
+                                                  int& exp, Handler& handler) {
+  const fp one(1ULL << -value.e, value.e);
+  // The integral part of scaled value (p1 in Grisu) = value / one. It cannot be
+  // zero because it contains a product of two 64-bit numbers with MSB set (due
+  // to normalization) - 1, shifted right by at most 60 bits.
+  auto integral = static_cast<uint32_t>(value.f >> -one.e);
+  FMT_ASSERT(integral != 0, "");
+  FMT_ASSERT(integral == value.f >> -one.e, "");
+  // The fractional part of scaled value (p2 in Grisu) c = value % one.
+  uint64_t fractional = value.f & (one.f - 1);
+  exp = count_digits(integral);  // kappa in Grisu.
+  // Divide by 10 to prevent overflow.
+  auto result = handler.on_start(data::powers_of_10_64[exp - 1] << -one.e,
+                                 value.f / 10, error * 10, exp);
+  if (result != digits::more) return result;
+  // Generate digits for the integral part. This can produce up to 10 digits.
+  do {
+    uint32_t digit = 0;
+    auto divmod_integral = [&](uint32_t divisor) {
+      digit = integral / divisor;
+      integral %= divisor;
+    };
+    // This optimization by Milo Yip reduces the number of integer divisions by
+    // one per iteration.
+    switch (exp) {
+    case 10:
+      divmod_integral(1000000000);
+      break;
+    case 9:
+      divmod_integral(100000000);
+      break;
+    case 8:
+      divmod_integral(10000000);
+      break;
+    case 7:
+      divmod_integral(1000000);
+      break;
+    case 6:
+      divmod_integral(100000);
+      break;
+    case 5:
+      divmod_integral(10000);
+      break;
+    case 4:
+      divmod_integral(1000);
+      break;
+    case 3:
+      divmod_integral(100);
+      break;
+    case 2:
+      divmod_integral(10);
+      break;
+    case 1:
+      digit = integral;
+      integral = 0;
+      break;
+    default:
+      FMT_ASSERT(false, "invalid number of digits");
+    }
+    --exp;
+    uint64_t remainder =
+        (static_cast<uint64_t>(integral) << -one.e) + fractional;
+    result = handler.on_digit(static_cast<char>('0' + digit),
+                              data::powers_of_10_64[exp] << -one.e, remainder,
+                              error, exp, true);
+    if (result != digits::more) return result;
+  } while (exp > 0);
+  // Generate digits for the fractional part.
+  for (;;) {
+    fractional *= 10;
+    error *= 10;
+    char digit =
+        static_cast<char>('0' + static_cast<char>(fractional >> -one.e));
+    fractional &= one.f - 1;
+    --exp;
+    result = handler.on_digit(digit, one.f, fractional, error, exp, false);
+    if (result != digits::more) return result;
+  }
+}
+
+// The fixed precision digit handler.
+struct fixed_handler {
+  char* buf;
+  int size;
+  int precision;
+  int exp10;
+  bool fixed;
+
+  digits::result on_start(uint64_t divisor, uint64_t remainder, uint64_t error,
+                          int& exp) {
+    // Non-fixed formats require at least one digit and no precision adjustment.
+    if (!fixed) return digits::more;
+    // Adjust fixed precision by exponent because it is relative to decimal
+    // point.
+    precision += exp + exp10;
+    // Check if precision is satisfied just by leading zeros, e.g.
+    // format("{:.2f}", 0.001) gives "0.00" without generating any digits.
+    if (precision > 0) return digits::more;
+    if (precision < 0) return digits::done;
+    auto dir = get_round_direction(divisor, remainder, error);
+    if (dir == unknown) return digits::error;
+    buf[size++] = dir == up ? '1' : '0';
+    return digits::done;
+  }
+
+  digits::result on_digit(char digit, uint64_t divisor, uint64_t remainder,
+                          uint64_t error, int, bool integral) {
+    FMT_ASSERT(remainder < divisor, "");
+    buf[size++] = digit;
+    if (size < precision) return digits::more;
+    if (!integral) {
+      // Check if error * 2 < divisor with overflow prevention.
+      // The check is not needed for the integral part because error = 1
+      // and divisor > (1 << 32) there.
+      if (error >= divisor || error >= divisor - error) return digits::error;
+    } else {
+      FMT_ASSERT(error == 1 && divisor > 2, "");
+    }
+    auto dir = get_round_direction(divisor, remainder, error);
+    if (dir != up) return dir == down ? digits::done : digits::error;
+    ++buf[size - 1];
+    for (int i = size - 1; i > 0 && buf[i] > '9'; --i) {
+      buf[i] = '0';
+      ++buf[i - 1];
+    }
+    if (buf[0] > '9') {
+      buf[0] = '1';
+      buf[size++] = '0';
+    }
+    return digits::done;
+  }
+};
+
+// The shortest representation digit handler.
+struct grisu_shortest_handler {
+  char* buf;
+  int size;
+  // Distance between scaled value and upper bound (wp_W in Grisu3).
+  uint64_t diff;
+
+  digits::result on_start(uint64_t, uint64_t, uint64_t, int&) {
+    return digits::more;
+  }
+
+  // Decrement the generated number approaching value from above.
+  void round(uint64_t d, uint64_t divisor, uint64_t& remainder,
+             uint64_t error) {
+    while (
+        remainder < d && error - remainder >= divisor &&
+        (remainder + divisor < d || d - remainder >= remainder + divisor - d)) {
+      --buf[size - 1];
+      remainder += divisor;
+    }
+  }
+
+  // Implements Grisu's round_weed.
+  digits::result on_digit(char digit, uint64_t divisor, uint64_t remainder,
+                          uint64_t error, int exp, bool integral) {
+    buf[size++] = digit;
+    if (remainder >= error) return digits::more;
+    uint64_t unit = integral ? 1 : data::powers_of_10_64[-exp];
+    uint64_t up = (diff - 1) * unit;  // wp_Wup
+    round(up, divisor, remainder, error);
+    uint64_t down = (diff + 1) * unit;  // wp_Wdown
+    if (remainder < down && error - remainder >= divisor &&
+        (remainder + divisor < down ||
+         down - remainder > remainder + divisor - down)) {
+      return digits::error;
+    }
+    return 2 * unit <= remainder && remainder <= error - 4 * unit
+               ? digits::done
+               : digits::error;
+  }
+};
+
+// Formats value using a variation of the Fixed-Precision Positive
+// Floating-Point Printout ((FPP)^2) algorithm by Steele & White:
+// https://fmt.dev/p372-steele.pdf.
+template <typename Double>
+void fallback_format(Double d, buffer<char>& buf, int& exp10) {
+  bigint numerator;    // 2 * R in (FPP)^2.
+  bigint denominator;  // 2 * S in (FPP)^2.
+  // lower and upper are differences between value and corresponding boundaries.
+  bigint lower;             // (M^- in (FPP)^2).
+  bigint upper_store;       // upper's value if different from lower.
+  bigint* upper = nullptr;  // (M^+ in (FPP)^2).
+  fp value;
+  // Shift numerator and denominator by an extra bit or two (if lower boundary
+  // is closer) to make lower and upper integers. This eliminates multiplication
+  // by 2 during later computations.
+  // TODO: handle float
+  int shift = value.assign(d) ? 2 : 1;
+  uint64_t significand = value.f << shift;
+  if (value.e >= 0) {
+    numerator.assign(significand);
+    numerator <<= value.e;
+    lower.assign(1);
+    lower <<= value.e;
+    if (shift != 1) {
+      upper_store.assign(1);
+      upper_store <<= value.e + 1;
+      upper = &upper_store;
+    }
+    denominator.assign_pow10(exp10);
+    denominator <<= 1;
+  } else if (exp10 < 0) {
+    numerator.assign_pow10(-exp10);
+    lower.assign(numerator);
+    if (shift != 1) {
+      upper_store.assign(numerator);
+      upper_store <<= 1;
+      upper = &upper_store;
+    }
+    numerator *= significand;
+    denominator.assign(1);
+    denominator <<= shift - value.e;
+  } else {
+    numerator.assign(significand);
+    denominator.assign_pow10(exp10);
+    denominator <<= shift - value.e;
+    lower.assign(1);
+    if (shift != 1) {
+      upper_store.assign(1ULL << 1);
+      upper = &upper_store;
+    }
+  }
+  if (!upper) upper = &lower;
+  // Invariant: value == (numerator / denominator) * pow(10, exp10).
+  bool even = (value.f & 1) == 0;
+  int num_digits = 0;
+  char* data = buf.data();
+  for (;;) {
+    int digit = numerator.divmod_assign(denominator);
+    bool low = compare(numerator, lower) - even < 0;  // numerator <[=] lower.
+    // numerator + upper >[=] pow10:
+    bool high = add_compare(numerator, *upper, denominator) + even > 0;
+    data[num_digits++] = static_cast<char>('0' + digit);
+    if (low || high) {
+      if (!low) {
+        ++data[num_digits - 1];
+      } else if (high) {
+        int result = add_compare(numerator, numerator, denominator);
+        // Round half to even.
+        if (result > 0 || (result == 0 && (digit % 2) != 0))
+          ++data[num_digits - 1];
+      }
+      buf.resize(num_digits);
+      exp10 -= num_digits - 1;
+      return;
+    }
+    numerator *= 10;
+    lower *= 10;
+    if (upper != &lower) *upper *= 10;
+  }
+}
+
+// Formats value using the Grisu algorithm
+// (https://www.cs.tufts.edu/~nr/cs257/archive/florian-loitsch/printf.pdf)
+// if T is a IEEE754 binary32 or binary64 and snprintf otherwise.
+template <typename T>
+int format_float(T value, int precision, float_specs specs, buffer<char>& buf) {
+  static_assert(!std::is_same<T, float>(), "");
+  FMT_ASSERT(value >= 0, "value is negative");
+
+  const bool fixed = specs.format == float_format::fixed;
+  if (value <= 0) {  // <= instead of == to silence a warning.
+    if (precision <= 0 || !fixed) {
+      buf.push_back('0');
+      return 0;
+    }
+    buf.resize(to_unsigned(precision));
+    std::uninitialized_fill_n(buf.data(), precision, '0');
+    return -precision;
+  }
+
+  if (!specs.use_grisu) return snprintf_float(value, precision, specs, buf);
+
+  int exp = 0;
+  const int min_exp = -60;  // alpha in Grisu.
+  int cached_exp10 = 0;     // K in Grisu.
+  if (precision != -1) {
+    if (precision > 17) return snprintf_float(value, precision, specs, buf);
+    fp normalized = normalize(fp(value));
+    const auto cached_pow = get_cached_power(
+        min_exp - (normalized.e + fp::significand_size), cached_exp10);
+    normalized = normalized * cached_pow;
+    fixed_handler handler{buf.data(), 0, precision, -cached_exp10, fixed};
+    if (grisu_gen_digits(normalized, 1, exp, handler) == digits::error)
+      return snprintf_float(value, precision, specs, buf);
+    int num_digits = handler.size;
+    if (!fixed) {
+      // Remove trailing zeros.
+      while (num_digits > 0 && buf[num_digits - 1] == '0') {
+        --num_digits;
+        ++exp;
+      }
+    }
+    buf.resize(to_unsigned(num_digits));
+  } else {
+    fp fp_value;
+    auto boundaries = specs.binary32
+                          ? fp_value.assign_float_with_boundaries(value)
+                          : fp_value.assign_with_boundaries(value);
+    fp_value = normalize(fp_value);
+    // Find a cached power of 10 such that multiplying value by it will bring
+    // the exponent in the range [min_exp, -32].
+    const fp cached_pow = get_cached_power(
+        min_exp - (fp_value.e + fp::significand_size), cached_exp10);
+    // Multiply value and boundaries by the cached power of 10.
+    fp_value = fp_value * cached_pow;
+    boundaries.lower = multiply(boundaries.lower, cached_pow.f);
+    boundaries.upper = multiply(boundaries.upper, cached_pow.f);
+    assert(min_exp <= fp_value.e && fp_value.e <= -32);
+    --boundaries.lower;  // \tilde{M}^- - 1 ulp -> M^-_{\downarrow}.
+    ++boundaries.upper;  // \tilde{M}^+ + 1 ulp -> M^+_{\uparrow}.
+    // Numbers outside of (lower, upper) definitely do not round to value.
+    grisu_shortest_handler handler{buf.data(), 0,
+                                   boundaries.upper - fp_value.f};
+    auto result =
+        grisu_gen_digits(fp(boundaries.upper, fp_value.e),
+                         boundaries.upper - boundaries.lower, exp, handler);
+    if (result == digits::error) {
+      exp += handler.size - cached_exp10 - 1;
+      fallback_format(value, buf, exp);
+      return exp;
+    }
+    buf.resize(to_unsigned(handler.size));
+  }
+  return exp - cached_exp10;
+}
+
+template <typename T>
+int snprintf_float(T value, int precision, float_specs specs,
+                   buffer<char>& buf) {
+  // Buffer capacity must be non-zero, otherwise MSVC's vsnprintf_s will fail.
+  FMT_ASSERT(buf.capacity() > buf.size(), "empty buffer");
+  static_assert(!std::is_same<T, float>(), "");
+
+  // Subtract 1 to account for the difference in precision since we use %e for
+  // both general and exponent format.
+  if (specs.format == float_format::general ||
+      specs.format == float_format::exp)
+    precision = (precision >= 0 ? precision : 6) - 1;
+
+  // Build the format string.
+  enum { max_format_size = 7 };  // Ths longest format is "%#.*Le".
+  char format[max_format_size];
+  char* format_ptr = format;
+  *format_ptr++ = '%';
+  if (specs.trailing_zeros) *format_ptr++ = '#';
+  if (precision >= 0) {
+    *format_ptr++ = '.';
+    *format_ptr++ = '*';
+  }
+  if (std::is_same<T, long double>()) *format_ptr++ = 'L';
+  *format_ptr++ = specs.format != float_format::hex
+                      ? (specs.format == float_format::fixed ? 'f' : 'e')
+                      : (specs.upper ? 'A' : 'a');
+  *format_ptr = '\0';
+
+  // Format using snprintf.
+  auto offset = buf.size();
+  for (;;) {
+    auto begin = buf.data() + offset;
+    auto capacity = buf.capacity() - offset;
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    if (precision > 100000)
+      throw std::runtime_error(
+          "fuzz mode - avoid large allocation inside snprintf");
+#endif
+    // Suppress the warning about a nonliteral format string.
+    auto snprintf_ptr = FMT_SNPRINTF;
+    int result = precision >= 0
+                     ? snprintf_ptr(begin, capacity, format, precision, value)
+                     : snprintf_ptr(begin, capacity, format, value);
+    if (result < 0) {
+      buf.reserve(buf.capacity() + 1);  // The buffer will grow exponentially.
+      continue;
+    }
+    unsigned size = to_unsigned(result);
+    // Size equal to capacity means that the last character was truncated.
+    if (size >= capacity) {
+      buf.reserve(size + offset + 1);  // Add 1 for the terminating '\0'.
+      continue;
+    }
+    auto is_digit = [](char c) { return c >= '0' && c <= '9'; };
+    if (specs.format == float_format::fixed) {
+      if (precision == 0) {
+        buf.resize(size);
+        return 0;
+      }
+      // Find and remove the decimal point.
+      auto end = begin + size, p = end;
+      do {
+        --p;
+      } while (is_digit(*p));
+      int fraction_size = static_cast<int>(end - p - 1);
+      std::memmove(p, p + 1, fraction_size);
+      buf.resize(size - 1);
+      return -fraction_size;
+    }
+    if (specs.format == float_format::hex) {
+      buf.resize(size + offset);
+      return 0;
+    }
+    // Find and parse the exponent.
+    auto end = begin + size, exp_pos = end;
+    do {
+      --exp_pos;
+    } while (*exp_pos != 'e');
+    char sign = exp_pos[1];
+    assert(sign == '+' || sign == '-');
+    int exp = 0;
+    auto p = exp_pos + 2;  // Skip 'e' and sign.
+    do {
+      assert(is_digit(*p));
+      exp = exp * 10 + (*p++ - '0');
+    } while (p != end);
+    if (sign == '-') exp = -exp;
+    int fraction_size = 0;
+    if (exp_pos != begin + 1) {
+      // Remove trailing zeros.
+      auto fraction_end = exp_pos - 1;
+      while (*fraction_end == '0') --fraction_end;
+      // Move the fractional part left to get rid of the decimal point.
+      fraction_size = static_cast<int>(fraction_end - begin - 1);
+      std::memmove(begin + 1, begin + 2, fraction_size);
+    }
+    buf.resize(fraction_size + offset + 1);
+    return exp - fraction_size;
+  }
+}
+}  // namespace internal
+
+template <> struct formatter<internal::bigint> {
+  format_parse_context::iterator parse(format_parse_context& ctx) {
+    return ctx.begin();
+  }
+
+  format_context::iterator format(const internal::bigint& n,
+                                  format_context& ctx) {
+    auto out = ctx.out();
+    bool first = true;
+    for (auto i = n.bigits_.size(); i > 0; --i) {
+      auto value = n.bigits_[i - 1];
+      if (first) {
+        out = format_to(out, "{:x}", value);
+        first = false;
+        continue;
+      }
+      out = format_to(out, "{:08x}", value);
+    }
+    if (n.exp_ > 0)
+      out = format_to(out, "p{}", n.exp_ * internal::bigint::bigit_bits);
+    return out;
+  }
+};
+
+FMT_FUNC void internal::error_handler::on_error(const char* message) {
+  FMT_THROW(duckdb::Exception(message));
+}
+
+FMT_END_NAMESPACE
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
+
+#endif  // FMT_FORMAT_INL_H_
+
+
+// LICENSE_CHANGE_END
+
+
+FMT_BEGIN_NAMESPACE
+namespace internal {
+
+template <typename T>
+int format_float(char* buf, std::size_t size, const char* format, int precision,
+                 T value) {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+  if (precision > 100000)
+    throw std::runtime_error(
+        "fuzz mode - avoid large allocation inside snprintf");
+#endif
+  // Suppress the warning about nonliteral format string.
+  auto snprintf_ptr = FMT_SNPRINTF;
+  return precision < 0 ? snprintf_ptr(buf, size, format, value)
+                       : snprintf_ptr(buf, size, format, precision, value);
+}
+struct sprintf_specs {
+  int precision;
+  char type;
+  bool alt : 1;
+
+  template <typename Char>
+  constexpr sprintf_specs(basic_format_specs<Char> specs)
+      : precision(specs.precision), type(specs.type), alt(specs.alt) {}
+
+  constexpr bool has_precision() const { return precision >= 0; }
+};
+
+// This is deprecated and is kept only to preserve ABI compatibility.
+template <typename Double>
+char* sprintf_format(Double value, internal::buffer<char>& buf,
+                     sprintf_specs specs) {
+  // Buffer capacity must be non-zero, otherwise MSVC's vsnprintf_s will fail.
+  FMT_ASSERT(buf.capacity() != 0, "empty buffer");
+
+  // Build format string.
+  enum { max_format_size = 10 };  // longest format: %#-*.*Lg
+  char format[max_format_size];
+  char* format_ptr = format;
+  *format_ptr++ = '%';
+  if (specs.alt || !specs.type) *format_ptr++ = '#';
+  if (specs.precision >= 0) {
+    *format_ptr++ = '.';
+    *format_ptr++ = '*';
+  }
+  if (std::is_same<Double, long double>::value) *format_ptr++ = 'L';
+
+  char type = specs.type;
+
+  if (type == '%')
+    type = 'f';
+  else if (type == 0 || type == 'n')
+    type = 'g';
+#if FMT_MSC_VER
+  if (type == 'F') {
+    // MSVC's printf doesn't support 'F'.
+    type = 'f';
+  }
+#endif
+  *format_ptr++ = type;
+  *format_ptr = '\0';
+
+  // Format using snprintf.
+  char* start = nullptr;
+  char* decimal_point_pos = nullptr;
+  for (;;) {
+    std::size_t buffer_size = buf.capacity();
+    start = &buf[0];
+    int result =
+        format_float(start, buffer_size, format, specs.precision, value);
+    if (result >= 0) {
+      unsigned n = internal::to_unsigned(result);
+      if (n < buf.capacity()) {
+        // Find the decimal point.
+        auto p = buf.data(), end = p + n;
+        if (*p == '+' || *p == '-') ++p;
+        if (specs.type != 'a' && specs.type != 'A') {
+          while (p < end && *p >= '0' && *p <= '9') ++p;
+          if (p < end && *p != 'e' && *p != 'E') {
+            decimal_point_pos = p;
+            if (!specs.type) {
+              // Keep only one trailing zero after the decimal point.
+              ++p;
+              if (*p == '0') ++p;
+              while (p != end && *p >= '1' && *p <= '9') ++p;
+              char* where = p;
+              while (p != end && *p == '0') ++p;
+              if (p == end || *p < '0' || *p > '9') {
+                if (p != end) std::memmove(where, p, to_unsigned(end - p));
+                n -= static_cast<unsigned>(p - where);
+              }
+            }
+          }
+        }
+        buf.resize(n);
+        break;  // The buffer is large enough - continue with formatting.
+      }
+      buf.reserve(n + 1);
+    } else {
+      // If result is negative we ask to increase the capacity by at least 1,
+      // but as std::vector, the buffer grows exponentially.
+      buf.reserve(buf.capacity() + 1);
+    }
+  }
+  return decimal_point_pos;
+}
+}  // namespace internal
+
+template FMT_API char* internal::sprintf_format(double, internal::buffer<char>&,
+                                                sprintf_specs);
+template FMT_API char* internal::sprintf_format(long double,
+                                                internal::buffer<char>&,
+                                                sprintf_specs);
+
+template struct FMT_API internal::basic_data<void>;
+
+// Workaround a bug in MSVC2013 that prevents instantiation of format_float.
+int (*instantiate_format_float)(double, int, internal::float_specs,
+                                internal::buffer<char>&) =
+    internal::format_float;
+
+#ifndef FMT_STATIC_THOUSANDS_SEPARATOR
+template FMT_API internal::locale_ref::locale_ref(const std::locale& loc);
+template FMT_API std::locale internal::locale_ref::get<std::locale>() const;
+#endif
+
+// Explicit instantiations for char.
+
+template FMT_API std::string internal::grouping_impl<char>(locale_ref);
+template FMT_API char internal::thousands_sep_impl(locale_ref);
+template FMT_API char internal::decimal_point_impl(locale_ref);
+
+template FMT_API void internal::buffer<char>::append(const char*, const char*);
+
+template FMT_API void internal::arg_map<format_context>::init(
+    const basic_format_args<format_context>& args);
+
+template FMT_API std::string internal::vformat<char>(
+    string_view, basic_format_args<format_context>);
+
+template FMT_API format_context::iterator internal::vformat_to(
+    internal::buffer<char>&, string_view, basic_format_args<format_context>);
+
+template FMT_API int internal::snprintf_float(double, int,
+                                              internal::float_specs,
+                                              internal::buffer<char>&);
+template FMT_API int internal::snprintf_float(long double, int,
+                                              internal::float_specs,
+                                              internal::buffer<char>&);
+template FMT_API int internal::format_float(double, int, internal::float_specs,
+                                            internal::buffer<char>&);
+template FMT_API int internal::format_float(long double, int,
+                                            internal::float_specs,
+                                            internal::buffer<char>&);
+
+// Explicit instantiations for wchar_t.
+
+template FMT_API std::string internal::grouping_impl<wchar_t>(locale_ref);
+template FMT_API wchar_t internal::thousands_sep_impl(locale_ref);
+template FMT_API wchar_t internal::decimal_point_impl(locale_ref);
+
+template FMT_API void internal::buffer<wchar_t>::append(const wchar_t*,
+                                                        const wchar_t*);
+
+template FMT_API std::wstring internal::vformat<wchar_t>(
+    wstring_view, basic_format_args<wformat_context>);
+FMT_END_NAMESPACE
+
+
+// LICENSE_CHANGE_END

--- a/velox/external/duckdb/duckdb-hyperloglog.cpp
+++ b/velox/external/duckdb/duckdb-hyperloglog.cpp
@@ -1,0 +1,2718 @@
+// See https://raw.githubusercontent.com/cwida/duckdb/master/LICENSE for licensing information
+
+#include "duckdb.hpp"
+#include "duckdb-internal.hpp"
+#ifndef DUCKDB_AMALGAMATION
+#error header mismatch
+#endif
+
+
+// LICENSE_CHANGE_BEGIN
+// The following code up to LICENSE_CHANGE_END is subject to THIRD PARTY LICENSE #7
+// See the end of this file for a list
+
+/* hyperloglog.c - Redis HyperLogLog probabilistic cardinality approximation.
+ * This file implements the algorithm and the exported Redis commands.
+ *
+ * Copyright (c) 2014, Salvatore Sanfilippo <antirez at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+
+
+
+
+
+// LICENSE_CHANGE_BEGIN
+// The following code up to LICENSE_CHANGE_END is subject to THIRD PARTY LICENSE #7
+// See the end of this file for a list
+
+/* SDSLib 2.0 -- A C dynamic strings library
+ *
+ * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2015, Oran Agra
+ * Copyright (c) 2015, Redis Labs, Inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __SDS_H
+#define __SDS_H
+
+
+#ifdef _MSC_VER
+#define __attribute__(A)
+#define ssize_t int64_t
+#endif
+
+#define SDS_MAX_PREALLOC (1024*1024)
+
+#include <sys/types.h>
+#include <stdarg.h>
+#include <stdint.h>
+
+namespace duckdb_hll {
+
+
+typedef char *sds;
+
+/* Note: sdshdr5 is never used, we just access the flags byte directly.
+ * However is here to document the layout of type 5 SDS strings. */
+struct __attribute__ ((__packed__)) sdshdr5 {
+    unsigned char flags; /* 3 lsb of type, and 5 msb of string length */
+    char buf[1];
+};
+struct __attribute__ ((__packed__)) sdshdr8 {
+    uint8_t len; /* used */
+    uint8_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[1];
+};
+struct __attribute__ ((__packed__)) sdshdr16 {
+    uint16_t len; /* used */
+    uint16_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[1];
+};
+struct __attribute__ ((__packed__)) sdshdr32 {
+    uint32_t len; /* used */
+    uint32_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[1];
+};
+struct __attribute__ ((__packed__)) sdshdr64 {
+    uint64_t len; /* used */
+    uint64_t alloc; /* excluding the header and null terminator */
+    unsigned char flags; /* 3 lsb of type, 5 unused bits */
+    char buf[1];
+};
+
+#define SDS_TYPE_5  0
+#define SDS_TYPE_8  1
+#define SDS_TYPE_16 2
+#define SDS_TYPE_32 3
+#define SDS_TYPE_64 4
+#define SDS_TYPE_MASK 7
+#define SDS_TYPE_BITS 3
+#define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (struct sdshdr##T *)((s)-(sizeof(struct sdshdr##T)));
+#define SDS_HDR(T,s) ((struct sdshdr##T *)((s)-(sizeof(struct sdshdr##T))))
+#define SDS_TYPE_5_LEN(f) ((f)>>SDS_TYPE_BITS)
+
+static inline size_t sdslen(const sds s) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return SDS_TYPE_5_LEN(flags);
+        case SDS_TYPE_8:
+            return SDS_HDR(8,s)->len;
+        case SDS_TYPE_16:
+            return SDS_HDR(16,s)->len;
+        case SDS_TYPE_32:
+            return SDS_HDR(32,s)->len;
+        case SDS_TYPE_64:
+            return SDS_HDR(64,s)->len;
+    }
+    return 0;
+}
+
+static inline size_t sdsavail(const sds s) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5: {
+            return 0;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            return sh->alloc - sh->len;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            return sh->alloc - sh->len;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            return sh->alloc - sh->len;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            return sh->alloc - sh->len;
+        }
+    }
+    return 0;
+}
+
+static inline void sdssetlen(sds s, size_t newlen) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            {
+                unsigned char *fp = ((unsigned char*)s)-1;
+                *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
+            }
+            break;
+        case SDS_TYPE_8:
+            SDS_HDR(8,s)->len = newlen;
+            break;
+        case SDS_TYPE_16:
+            SDS_HDR(16,s)->len = newlen;
+            break;
+        case SDS_TYPE_32:
+            SDS_HDR(32,s)->len = newlen;
+            break;
+        case SDS_TYPE_64:
+            SDS_HDR(64,s)->len = newlen;
+            break;
+    }
+}
+
+static inline void sdsinclen(sds s, size_t inc) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            {
+                unsigned char *fp = ((unsigned char*)s)-1;
+                unsigned char newlen = SDS_TYPE_5_LEN(flags)+inc;
+                *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
+            }
+            break;
+        case SDS_TYPE_8:
+            SDS_HDR(8,s)->len += inc;
+            break;
+        case SDS_TYPE_16:
+            SDS_HDR(16,s)->len += inc;
+            break;
+        case SDS_TYPE_32:
+            SDS_HDR(32,s)->len += inc;
+            break;
+        case SDS_TYPE_64:
+            SDS_HDR(64,s)->len += inc;
+            break;
+    }
+}
+
+/* sdsalloc() = sdsavail() + sdslen() */
+static inline size_t sdsalloc(const sds s) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return SDS_TYPE_5_LEN(flags);
+        case SDS_TYPE_8:
+            return SDS_HDR(8,s)->alloc;
+        case SDS_TYPE_16:
+            return SDS_HDR(16,s)->alloc;
+        case SDS_TYPE_32:
+            return SDS_HDR(32,s)->alloc;
+        case SDS_TYPE_64:
+            return SDS_HDR(64,s)->alloc;
+    }
+    return 0;
+}
+
+static inline void sdssetalloc(sds s, size_t newlen) {
+    unsigned char flags = s[-1];
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            /* Nothing to do, this type has no total allocation info. */
+            break;
+        case SDS_TYPE_8:
+            SDS_HDR(8,s)->alloc = newlen;
+            break;
+        case SDS_TYPE_16:
+            SDS_HDR(16,s)->alloc = newlen;
+            break;
+        case SDS_TYPE_32:
+            SDS_HDR(32,s)->alloc = newlen;
+            break;
+        case SDS_TYPE_64:
+            SDS_HDR(64,s)->alloc = newlen;
+            break;
+    }
+}
+
+sds sdsnewlen(const void *init, size_t initlen);
+sds sdsnew(const char *init);
+sds sdsempty(void);
+sds sdsdup(const sds s);
+void sdsfree(sds s);
+sds sdsgrowzero(sds s, size_t len);
+sds sdscatlen(sds s, const void *t, size_t len);
+sds sdscat(sds s, const char *t);
+sds sdscatsds(sds s, const sds t);
+sds sdscpylen(sds s, const char *t, size_t len);
+sds sdscpy(sds s, const char *t);
+
+sds sdscatvprintf(sds s, const char *fmt, va_list ap);
+#ifdef __GNUC__
+sds sdscatprintf(sds s, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
+#else
+sds sdscatprintf(sds s, const char *fmt, ...);
+#endif
+
+sds sdscatfmt(sds s, char const *fmt, ...);
+sds sdstrim(sds s, const char *cset);
+void sdsrange(sds s, ssize_t start, ssize_t end);
+void sdsupdatelen(sds s);
+void sdsclear(sds s);
+int sdscmp(const sds s1, const sds s2);
+sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *count);
+void sdsfreesplitres(sds *tokens, int count);
+void sdstolower(sds s);
+void sdstoupper(sds s);
+sds sdsfromlonglong(long long value);
+sds sdscatrepr(sds s, const char *p, size_t len);
+sds *sdssplitargs(const char *line, int *argc);
+sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen);
+sds sdsjoin(char **argv, int argc, char *sep);
+sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
+
+/* Low level functions exposed to the user API */
+sds sdsMakeRoomFor(sds s, size_t addlen);
+void sdsIncrLen(sds s, ssize_t incr);
+sds sdsRemoveFreeSpace(sds s);
+size_t sdsAllocSize(sds s);
+void *sdsAllocPtr(sds s);
+
+/* Export the allocator used by SDS to the program using SDS.
+ * Sometimes the program SDS is linked to, may use a different set of
+ * allocators, but may want to allocate or free things that SDS will
+ * respectively free or allocate. */
+void *sds_malloc(size_t size);
+void *sds_realloc(void *ptr, size_t size);
+void sds_free(void *ptr);
+
+#ifdef REDIS_TEST
+int sdsTest(int argc, char *argv[]);
+#endif
+}
+
+
+#endif
+
+// LICENSE_CHANGE_END
+
+
+#include <assert.h>
+#include <stdint.h>
+#include <math.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+
+
+
+namespace duckdb_hll {
+
+#define HLL_SPARSE_MAX_BYTES 3000
+
+/* The Redis HyperLogLog implementation is based on the following ideas:
+ *
+ * * The use of a 64 bit hash function as proposed in [1], in order to don't
+ *   limited to cardinalities up to 10^9, at the cost of just 1 additional
+ *   bit per register.
+ * * The use of 16384 6-bit registers for a great level of accuracy, using
+ *   a total of 12k per key.
+ * * The use of the Redis string data type. No new type is introduced.
+ * * No attempt is made to compress the data structure as in [1]. Also the
+ *   algorithm used is the original HyperLogLog Algorithm as in [2], with
+ *   the only difference that a 64 bit hash function is used, so no correction
+ *   is performed for values near 2^32 as in [1].
+ *
+ * [1] Heule, Nunkesser, Hall: HyperLogLog in Practice: Algorithmic
+ *     Engineering of a State of The Art Cardinality Estimation Algorithm.
+ *
+ * [2] P. Flajolet, Éric Fusy, O. Gandouet, and F. Meunier. Hyperloglog: The
+ *     analysis of a near-optimal cardinality estimation algorithm.
+ *
+ * Redis uses two representations:
+ *
+ * 1) A "dense" representation where every entry is represented by
+ *    a 6-bit integer.
+ * 2) A "sparse" representation using run length compression suitable
+ *    for representing HyperLogLogs with many registers set to 0 in
+ *    a memory efficient way.
+ *
+ *
+ * HLL header
+ * ===
+ *
+ * Both the dense and sparse representation have a 16 byte header as follows:
+ *
+ * +------+---+-----+----------+
+ * | HYLL | E | N/U | Cardin.  |
+ * +------+---+-----+----------+
+ *
+ * The first 4 bytes are a magic string set to the bytes "HYLL".
+ * "E" is one byte encoding, currently set to HLL_DENSE or
+ * HLL_SPARSE. N/U are three not used bytes.
+ *
+ * The "Cardin." field is a 64 bit integer stored in little endian format
+ * with the latest cardinality computed that can be reused if the data
+ * structure was not modified since the last computation (this is useful
+ * because there are high probabilities that HLLADD operations don't
+ * modify the actual data structure and hence the approximated cardinality).
+ *
+ * When the most significant bit in the most significant byte of the cached
+ * cardinality is set, it means that the data structure was modified and
+ * we can't reuse the cached value that must be recomputed.
+ *
+ * Dense representation
+ * ===
+ *
+ * The dense representation used by Redis is the following:
+ *
+ * +--------+--------+--------+------//      //--+
+ * |11000000|22221111|33333322|55444444 ....     |
+ * +--------+--------+--------+------//      //--+
+ *
+ * The 6 bits counters are encoded one after the other starting from the
+ * LSB to the MSB, and using the next bytes as needed.
+ *
+ * Sparse representation
+ * ===
+ *
+ * The sparse representation encodes registers using a run length
+ * encoding composed of three opcodes, two using one byte, and one using
+ * of two bytes. The opcodes are called ZERO, XZERO and VAL.
+ *
+ * ZERO opcode is represented as 00xxxxxx. The 6-bit integer represented
+ * by the six bits 'xxxxxx', plus 1, means that there are N registers set
+ * to 0. This opcode can represent from 1 to 64 contiguous registers set
+ * to the value of 0.
+ *
+ * XZERO opcode is represented by two bytes 01xxxxxx yyyyyyyy. The 14-bit
+ * integer represented by the bits 'xxxxxx' as most significant bits and
+ * 'yyyyyyyy' as least significant bits, plus 1, means that there are N
+ * registers set to 0. This opcode can represent from 0 to 16384 contiguous
+ * registers set to the value of 0.
+ *
+ * VAL opcode is represented as 1vvvvvxx. It contains a 5-bit integer
+ * representing the value of a register, and a 2-bit integer representing
+ * the number of contiguous registers set to that value 'vvvvv'.
+ * To obtain the value and run length, the integers vvvvv and xx must be
+ * incremented by one. This opcode can represent values from 1 to 32,
+ * repeated from 1 to 4 times.
+ *
+ * The sparse representation can't represent registers with a value greater
+ * than 32, however it is very unlikely that we find such a register in an
+ * HLL with a cardinality where the sparse representation is still more
+ * memory efficient than the dense representation. When this happens the
+ * HLL is converted to the dense representation.
+ *
+ * The sparse representation is purely positional. For example a sparse
+ * representation of an empty HLL is just: XZERO:16384.
+ *
+ * An HLL having only 3 non-zero registers at position 1000, 1020, 1021
+ * respectively set to 2, 3, 3, is represented by the following three
+ * opcodes:
+ *
+ * XZERO:1000 (Registers 0-999 are set to 0)
+ * VAL:2,1    (1 register set to value 2, that is register 1000)
+ * ZERO:19    (Registers 1001-1019 set to 0)
+ * VAL:3,2    (2 registers set to value 3, that is registers 1020,1021)
+ * XZERO:15362 (Registers 1022-16383 set to 0)
+ *
+ * In the example the sparse representation used just 7 bytes instead
+ * of 12k in order to represent the HLL registers. In general for low
+ * cardinality there is a big win in terms of space efficiency, traded
+ * with CPU time since the sparse representation is slower to access:
+ *
+ * The following table shows average cardinality vs bytes used, 100
+ * samples per cardinality (when the set was not representable because
+ * of registers with too big value, the dense representation size was used
+ * as a sample).
+ *
+ * 100 267
+ * 200 485
+ * 300 678
+ * 400 859
+ * 500 1033
+ * 600 1205
+ * 700 1375
+ * 800 1544
+ * 900 1713
+ * 1000 1882
+ * 2000 3480
+ * 3000 4879
+ * 4000 6089
+ * 5000 7138
+ * 6000 8042
+ * 7000 8823
+ * 8000 9500
+ * 9000 10088
+ * 10000 10591
+ *
+ * The dense representation uses 12288 bytes, so there is a big win up to
+ * a cardinality of ~2000-3000. For bigger cardinalities the constant times
+ * involved in updating the sparse representation is not justified by the
+ * memory savings. The exact maximum length of the sparse representation
+ * when this implementation switches to the dense representation is
+ * configured via the define server.hll_sparse_max_bytes.
+ */
+
+struct hllhdr {
+    char magic[4];      /* "HYLL" */
+    uint8_t encoding;   /* HLL_DENSE or HLL_SPARSE. */
+    uint8_t notused[3]; /* Reserved for future use, must be zero. */
+    uint8_t card[8];    /* Cached cardinality, little endian. */
+    uint8_t registers[1]; /* Data bytes. */
+};
+
+/* The cached cardinality MSB is used to signal validity of the cached value. */
+#define HLL_INVALIDATE_CACHE(hdr) (hdr)->card[7] |= (1<<7)
+#define HLL_VALID_CACHE(hdr) (((hdr)->card[7] & (1<<7)) == 0)
+
+#define HLL_P 12 /* The greater is P, the smaller the error. */
+#define HLL_Q (64-HLL_P) /* The number of bits of the hash value used for
+                            determining the number of leading zeros. */
+#define HLL_REGISTERS (1<<HLL_P) /* With P=14, 16384 registers. */
+#define HLL_P_MASK (HLL_REGISTERS-1) /* Mask to index register. */
+#define HLL_BITS 6 /* Enough to count up to 63 leading zeroes. */
+#define HLL_REGISTER_MAX ((1<<HLL_BITS)-1)
+#define HLL_HDR_SIZE sizeof(struct hllhdr)
+#define HLL_DENSE_SIZE (HLL_HDR_SIZE+((HLL_REGISTERS*HLL_BITS+7)/8))
+#define HLL_DENSE 0 /* Dense encoding. */
+#define HLL_SPARSE 1 /* Sparse encoding. */
+#define HLL_RAW 255 /* Only used internally, never exposed. */
+#define HLL_MAX_ENCODING 1
+
+/* =========================== Low level bit macros ========================= */
+
+/* Macros to access the dense representation.
+ *
+ * We need to get and set 6 bit counters in an array of 8 bit bytes.
+ * We use macros to make sure the code is inlined since speed is critical
+ * especially in order to compute the approximated cardinality in
+ * HLLCOUNT where we need to access all the registers at once.
+ * For the same reason we also want to avoid conditionals in this code path.
+ *
+ * +--------+--------+--------+------//
+ * |11000000|22221111|33333322|55444444
+ * +--------+--------+--------+------//
+ *
+ * Note: in the above representation the most significant bit (MSB)
+ * of every byte is on the left. We start using bits from the LSB to MSB,
+ * and so forth passing to the next byte.
+ *
+ * Example, we want to access to counter at pos = 1 ("111111" in the
+ * illustration above).
+ *
+ * The index of the first byte b0 containing our data is:
+ *
+ *  b0 = 6 * pos / 8 = 0
+ *
+ *   +--------+
+ *   |11000000|  <- Our byte at b0
+ *   +--------+
+ *
+ * The position of the first bit (counting from the LSB = 0) in the byte
+ * is given by:
+ *
+ *  fb = 6 * pos % 8 -> 6
+ *
+ * Right shift b0 of 'fb' bits.
+ *
+ *   +--------+
+ *   |11000000|  <- Initial value of b0
+ *   |00000011|  <- After right shift of 6 pos.
+ *   +--------+
+ *
+ * Left shift b1 of bits 8-fb bits (2 bits)
+ *
+ *   +--------+
+ *   |22221111|  <- Initial value of b1
+ *   |22111100|  <- After left shift of 2 bits.
+ *   +--------+
+ *
+ * OR the two bits, and finally AND with 111111 (63 in decimal) to
+ * clean the higher order bits we are not interested in:
+ *
+ *   +--------+
+ *   |00000011|  <- b0 right shifted
+ *   |22111100|  <- b1 left shifted
+ *   |22111111|  <- b0 OR b1
+ *   |  111111|  <- (b0 OR b1) AND 63, our value.
+ *   +--------+
+ *
+ * We can try with a different example, like pos = 0. In this case
+ * the 6-bit counter is actually contained in a single byte.
+ *
+ *  b0 = 6 * pos / 8 = 0
+ *
+ *   +--------+
+ *   |11000000|  <- Our byte at b0
+ *   +--------+
+ *
+ *  fb = 6 * pos % 8 = 0
+ *
+ *  So we right shift of 0 bits (no shift in practice) and
+ *  left shift the next byte of 8 bits, even if we don't use it,
+ *  but this has the effect of clearing the bits so the result
+ *  will not be affacted after the OR.
+ *
+ * -------------------------------------------------------------------------
+ *
+ * Setting the register is a bit more complex, let's assume that 'val'
+ * is the value we want to set, already in the right range.
+ *
+ * We need two steps, in one we need to clear the bits, and in the other
+ * we need to bitwise-OR the new bits.
+ *
+ * Let's try with 'pos' = 1, so our first byte at 'b' is 0,
+ *
+ * "fb" is 6 in this case.
+ *
+ *   +--------+
+ *   |11000000|  <- Our byte at b0
+ *   +--------+
+ *
+ * To create a AND-mask to clear the bits about this position, we just
+ * initialize the mask with the value 63, left shift it of "fs" bits,
+ * and finally invert the result.
+ *
+ *   +--------+
+ *   |00111111|  <- "mask" starts at 63
+ *   |11000000|  <- "mask" after left shift of "ls" bits.
+ *   |00111111|  <- "mask" after invert.
+ *   +--------+
+ *
+ * Now we can bitwise-AND the byte at "b" with the mask, and bitwise-OR
+ * it with "val" left-shifted of "ls" bits to set the new bits.
+ *
+ * Now let's focus on the next byte b1:
+ *
+ *   +--------+
+ *   |22221111|  <- Initial value of b1
+ *   +--------+
+ *
+ * To build the AND mask we start again with the 63 value, right shift
+ * it by 8-fb bits, and invert it.
+ *
+ *   +--------+
+ *   |00111111|  <- "mask" set at 2&6-1
+ *   |00001111|  <- "mask" after the right shift by 8-fb = 2 bits
+ *   |11110000|  <- "mask" after bitwise not.
+ *   +--------+
+ *
+ * Now we can mask it with b+1 to clear the old bits, and bitwise-OR
+ * with "val" left-shifted by "rs" bits to set the new value.
+ */
+
+/* Note: if we access the last counter, we will also access the b+1 byte
+ * that is out of the array, but sds strings always have an implicit null
+ * term, so the byte exists, and we can skip the conditional (or the need
+ * to allocate 1 byte more explicitly). */
+
+/* Store the value of the register at position 'regnum' into variable 'target'.
+ * 'p' is an array of unsigned bytes. */
+#define HLL_DENSE_GET_REGISTER(target,p,regnum) do { \
+    uint8_t *_p = (uint8_t*) p; \
+    unsigned long _byte = regnum*HLL_BITS/8; \
+    unsigned long _fb = regnum*HLL_BITS&7; \
+    unsigned long _fb8 = 8 - _fb; \
+    unsigned long b0 = _p[_byte]; \
+    unsigned long b1 = _p[_byte+1]; \
+    target = ((b0 >> _fb) | (b1 << _fb8)) & HLL_REGISTER_MAX; \
+} while(0)
+
+/* Set the value of the register at position 'regnum' to 'val'.
+ * 'p' is an array of unsigned bytes. */
+#define HLL_DENSE_SET_REGISTER(p,regnum,val) do { \
+    uint8_t *_p = (uint8_t*) p; \
+    unsigned long _byte = regnum*HLL_BITS/8; \
+    unsigned long _fb = regnum*HLL_BITS&7; \
+    unsigned long _fb8 = 8 - _fb; \
+    unsigned long _v = val; \
+    _p[_byte] &= ~(HLL_REGISTER_MAX << _fb); \
+    _p[_byte] |= _v << _fb; \
+    _p[_byte+1] &= ~(HLL_REGISTER_MAX >> _fb8); \
+    _p[_byte+1] |= _v >> _fb8; \
+} while(0)
+
+/* Macros to access the sparse representation.
+ * The macros parameter is expected to be an uint8_t pointer. */
+#define HLL_SPARSE_XZERO_BIT 0x40 /* 01xxxxxx */
+#define HLL_SPARSE_VAL_BIT 0x80 /* 1vvvvvxx */
+#define HLL_SPARSE_IS_ZERO(p) (((*(p)) & 0xc0) == 0) /* 00xxxxxx */
+#define HLL_SPARSE_IS_XZERO(p) (((*(p)) & 0xc0) == HLL_SPARSE_XZERO_BIT)
+#define HLL_SPARSE_IS_VAL(p) ((*(p)) & HLL_SPARSE_VAL_BIT)
+#define HLL_SPARSE_ZERO_LEN(p) (((*(p)) & 0x3f)+1)
+#define HLL_SPARSE_XZERO_LEN(p) (((((*(p)) & 0x3f) << 8) | (*((p)+1)))+1)
+#define HLL_SPARSE_VAL_VALUE(p) ((((*(p)) >> 2) & 0x1f)+1)
+#define HLL_SPARSE_VAL_LEN(p) (((*(p)) & 0x3)+1)
+#define HLL_SPARSE_VAL_MAX_VALUE 32
+#define HLL_SPARSE_VAL_MAX_LEN 4
+#define HLL_SPARSE_ZERO_MAX_LEN 64
+#define HLL_SPARSE_XZERO_MAX_LEN 16384
+#define HLL_SPARSE_VAL_SET(p,val,len) do { \
+    *(p) = (((val)-1)<<2|((len)-1))|HLL_SPARSE_VAL_BIT; \
+} while(0)
+#define HLL_SPARSE_ZERO_SET(p,len) do { \
+    *(p) = (len)-1; \
+} while(0)
+#define HLL_SPARSE_XZERO_SET(p,len) do { \
+    int _l = (len)-1; \
+    *(p) = (_l>>8) | HLL_SPARSE_XZERO_BIT; \
+    *((p)+1) = (_l&0xff); \
+} while(0)
+#define HLL_ALPHA_INF 0.721347520444481703680 /* constant for 0.5/ln(2) */
+
+/* ========================= HyperLogLog algorithm  ========================= */
+
+/* Our hash function is MurmurHash2, 64 bit version.
+ * It was modified for Redis in order to provide the same result in
+ * big and little endian archs (endian neutral). */
+uint64_t MurmurHash64A (const void * key, int len, unsigned int seed) {
+    const uint64_t m = 0xc6a4a7935bd1e995;
+    const int r = 47;
+    uint64_t h = seed ^ (len * m);
+    const uint8_t *data = (const uint8_t *)key;
+    const uint8_t *end = data + (len-(len&7));
+
+    while(data != end) {
+        uint64_t k;
+
+#if (BYTE_ORDER == LITTLE_ENDIAN)
+    #ifdef USE_ALIGNED_ACCESS
+        memcpy(&k,data,sizeof(uint64_t));
+    #else
+        k = *((uint64_t*)data);
+    #endif
+#else
+        k = (uint64_t) data[0];
+        k |= (uint64_t) data[1] << 8;
+        k |= (uint64_t) data[2] << 16;
+        k |= (uint64_t) data[3] << 24;
+        k |= (uint64_t) data[4] << 32;
+        k |= (uint64_t) data[5] << 40;
+        k |= (uint64_t) data[6] << 48;
+        k |= (uint64_t) data[7] << 56;
+#endif
+
+        k *= m;
+        k ^= k >> r;
+        k *= m;
+        h ^= k;
+        h *= m;
+        data += 8;
+    }
+
+    switch(len & 7) {
+    case 7: h ^= (uint64_t)data[6] << 48; /* fall-thru */
+    case 6: h ^= (uint64_t)data[5] << 40; /* fall-thru */
+    case 5: h ^= (uint64_t)data[4] << 32; /* fall-thru */
+    case 4: h ^= (uint64_t)data[3] << 24; /* fall-thru */
+    case 3: h ^= (uint64_t)data[2] << 16; /* fall-thru */
+    case 2: h ^= (uint64_t)data[1] << 8; /* fall-thru */
+    case 1: h ^= (uint64_t)data[0];
+            h *= m; /* fall-thru */
+    };
+
+    h ^= h >> r;
+    h *= m;
+    h ^= h >> r;
+    return h;
+}
+
+/* Given a string element to add to the HyperLogLog, returns the length
+ * of the pattern 000..1 of the element hash. As a side effect 'regp' is
+ * set to the register index this element hashes to. */
+int hllPatLen(unsigned char *ele, size_t elesize, long *regp) {
+    uint64_t hash, bit, index;
+    int count;
+
+    /* Count the number of zeroes starting from bit HLL_REGISTERS
+     * (that is a power of two corresponding to the first bit we don't use
+     * as index). The max run can be 64-P+1 = Q+1 bits.
+     *
+     * Note that the final "1" ending the sequence of zeroes must be
+     * included in the count, so if we find "001" the count is 3, and
+     * the smallest count possible is no zeroes at all, just a 1 bit
+     * at the first position, that is a count of 1.
+     *
+     * This may sound like inefficient, but actually in the average case
+     * there are high probabilities to find a 1 after a few iterations. */
+    hash = MurmurHash64A(ele,elesize,0xadc83b19ULL);
+    index = hash & HLL_P_MASK; /* Register index. */
+    hash >>= HLL_P; /* Remove bits used to address the register. */
+    hash |= ((uint64_t)1<<HLL_Q); /* Make sure the loop terminates
+                                     and count will be <= Q+1. */
+    bit = 1;
+    count = 1; /* Initialized to 1 since we count the "00000...1" pattern. */
+    while((hash & bit) == 0) {
+        count++;
+        bit <<= 1;
+    }
+    *regp = (int) index;
+    return count;
+}
+
+/* ================== Dense representation implementation  ================== */
+
+/* Low level function to set the dense HLL register at 'index' to the
+ * specified value if the current value is smaller than 'count'.
+ *
+ * 'registers' is expected to have room for HLL_REGISTERS plus an
+ * additional byte on the right. This requirement is met by sds strings
+ * automatically since they are implicitly null terminated.
+ *
+ * The function always succeed, however if as a result of the operation
+ * the approximated cardinality changed, 1 is returned. Otherwise 0
+ * is returned. */
+static inline int hllDenseSet(uint8_t *registers, long index, uint8_t count) {
+    uint8_t oldcount;
+
+    HLL_DENSE_GET_REGISTER(oldcount,registers,index);
+    if (count > oldcount) {
+        HLL_DENSE_SET_REGISTER(registers,index,count);
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+/* "Add" the element in the dense hyperloglog data structure.
+ * Actually nothing is added, but the max 0 pattern counter of the subset
+ * the element belongs to is incremented if needed.
+ *
+ * This is just a wrapper to hllDenseSet(), performing the hashing of the
+ * element in order to retrieve the index and zero-run count. */
+int hllDenseAdd(uint8_t *registers, unsigned char *ele, size_t elesize) {
+    long index;
+    uint8_t count = hllPatLen(ele,elesize,&index);
+    /* Update the register if this element produced a longer run of zeroes. */
+    return hllDenseSet(registers,index,count);
+}
+
+/* Compute the register histogram in the dense representation. */
+void hllDenseRegHisto(uint8_t *registers, int* reghisto) {
+    int j;
+
+    /* Redis default is to use 16384 registers 6 bits each. The code works
+     * with other values by modifying the defines, but for our target value
+     * we take a faster path with unrolled loops. */
+    if (HLL_REGISTERS == 16384 && HLL_BITS == 6) {
+        uint8_t *r = registers;
+        unsigned long r0, r1, r2, r3, r4, r5, r6, r7, r8, r9,
+                      r10, r11, r12, r13, r14, r15;
+        for (j = 0; j < 1024; j++) {
+            /* Handle 16 registers per iteration. */
+            r0 = r[0] & 63;
+            r1 = (r[0] >> 6 | r[1] << 2) & 63;
+            r2 = (r[1] >> 4 | r[2] << 4) & 63;
+            r3 = (r[2] >> 2) & 63;
+            r4 = r[3] & 63;
+            r5 = (r[3] >> 6 | r[4] << 2) & 63;
+            r6 = (r[4] >> 4 | r[5] << 4) & 63;
+            r7 = (r[5] >> 2) & 63;
+            r8 = r[6] & 63;
+            r9 = (r[6] >> 6 | r[7] << 2) & 63;
+            r10 = (r[7] >> 4 | r[8] << 4) & 63;
+            r11 = (r[8] >> 2) & 63;
+            r12 = r[9] & 63;
+            r13 = (r[9] >> 6 | r[10] << 2) & 63;
+            r14 = (r[10] >> 4 | r[11] << 4) & 63;
+            r15 = (r[11] >> 2) & 63;
+
+            reghisto[r0]++;
+            reghisto[r1]++;
+            reghisto[r2]++;
+            reghisto[r3]++;
+            reghisto[r4]++;
+            reghisto[r5]++;
+            reghisto[r6]++;
+            reghisto[r7]++;
+            reghisto[r8]++;
+            reghisto[r9]++;
+            reghisto[r10]++;
+            reghisto[r11]++;
+            reghisto[r12]++;
+            reghisto[r13]++;
+            reghisto[r14]++;
+            reghisto[r15]++;
+
+            r += 12;
+        }
+    } else {
+        for(j = 0; j < HLL_REGISTERS; j++) {
+            unsigned long reg;
+            HLL_DENSE_GET_REGISTER(reg,registers,j);
+            reghisto[reg]++;
+        }
+    }
+}
+
+/* ================== Sparse representation implementation  ================= */
+
+/* Convert the HLL with sparse representation given as input in its dense
+ * representation. Both representations are represented by SDS strings, and
+ * the input representation is freed as a side effect.
+ *
+ * The function returns C_OK if the sparse representation was valid,
+ * otherwise C_ERR is returned if the representation was corrupted. */
+int hllSparseToDense(robj *o) {
+    sds sparse = (sds) o->ptr, dense;
+    struct hllhdr *hdr, *oldhdr = (struct hllhdr*)sparse;
+    int idx = 0, runlen, regval;
+    uint8_t *p = (uint8_t*)sparse, *end = p+sdslen(sparse);
+
+    /* If the representation is already the right one return ASAP. */
+    hdr = (struct hllhdr*) sparse;
+    if (hdr->encoding == HLL_DENSE) return HLL_C_OK;
+
+    /* Create a string of the right size filled with zero bytes.
+     * Note that the cached cardinality is set to 0 as a side effect
+     * that is exactly the cardinality of an empty HLL. */
+    dense = sdsnewlen(NULL,HLL_DENSE_SIZE);
+    hdr = (struct hllhdr*) dense;
+    *hdr = *oldhdr; /* This will copy the magic and cached cardinality. */
+    hdr->encoding = HLL_DENSE;
+
+    /* Now read the sparse representation and set non-zero registers
+     * accordingly. */
+    p += HLL_HDR_SIZE;
+    while(p < end) {
+        if (HLL_SPARSE_IS_ZERO(p)) {
+            runlen = HLL_SPARSE_ZERO_LEN(p);
+            idx += runlen;
+            p++;
+        } else if (HLL_SPARSE_IS_XZERO(p)) {
+            runlen = HLL_SPARSE_XZERO_LEN(p);
+            idx += runlen;
+            p += 2;
+        } else {
+            runlen = HLL_SPARSE_VAL_LEN(p);
+            regval = HLL_SPARSE_VAL_VALUE(p);
+            while(runlen--) {
+                HLL_DENSE_SET_REGISTER(hdr->registers + 1,idx,regval);
+                idx++;
+            }
+            p++;
+        }
+    }
+
+    /* If the sparse representation was valid, we expect to find idx
+     * set to HLL_REGISTERS. */
+    if (idx != HLL_REGISTERS) {
+        sdsfree(dense);
+        return HLL_C_ERR;
+    }
+
+    /* Free the old representation and set the new one. */
+    sdsfree((sds) o->ptr);
+    o->ptr = dense;
+    return HLL_C_OK;
+}
+
+/* Low level function to set the sparse HLL register at 'index' to the
+ * specified value if the current value is smaller than 'count'.
+ *
+ * The object 'o' is the String object holding the HLL. The function requires
+ * a reference to the object in order to be able to enlarge the string if
+ * needed.
+ *
+ * On success, the function returns 1 if the cardinality changed, or 0
+ * if the register for this element was not updated.
+ * On error (if the representation is invalid) -1 is returned.
+ *
+ * As a side effect the function may promote the HLL representation from
+ * sparse to dense: this happens when a register requires to be set to a value
+ * not representable with the sparse representation, or when the resulting
+ * size would be greater than server.hll_sparse_max_bytes. */
+int hllSparseSet(robj *o, long index, uint8_t count) {
+    struct hllhdr *hdr;
+    uint8_t oldcount, *sparse, *end, *p, *prev, *next;
+    long first, span;
+    long is_zero = 0, is_xzero = 0, is_val = 0, runlen = 0;
+    uint8_t seq[5], *n;
+    int last;
+    int len;
+    int seqlen;
+    int oldlen;
+    int deltalen;
+
+    /* If the count is too big to be representable by the sparse representation
+     * switch to dense representation. */
+    if (count > HLL_SPARSE_VAL_MAX_VALUE) goto promote;
+
+    /* When updating a sparse representation, sometimes we may need to
+     * enlarge the buffer for up to 3 bytes in the worst case (XZERO split
+     * into XZERO-VAL-XZERO). Make sure there is enough space right now
+     * so that the pointers we take during the execution of the function
+     * will be valid all the time. */
+    o->ptr = (sds) sdsMakeRoomFor((sds) o->ptr,3);
+
+    /* Step 1: we need to locate the opcode we need to modify to check
+     * if a value update is actually needed. */
+    sparse = p = ((uint8_t*)o->ptr) + HLL_HDR_SIZE;
+    end = p + sdslen((sds) o->ptr) - HLL_HDR_SIZE;
+
+    first = 0;
+    prev = NULL; /* Points to previous opcode at the end of the loop. */
+    next = NULL; /* Points to the next opcode at the end of the loop. */
+    span = 0;
+    while(p < end) {
+        long oplen;
+
+        /* Set span to the number of registers covered by this opcode.
+         *
+         * This is the most performance critical loop of the sparse
+         * representation. Sorting the conditionals from the most to the
+         * least frequent opcode in many-bytes sparse HLLs is faster. */
+        oplen = 1;
+        if (HLL_SPARSE_IS_ZERO(p)) {
+            span = HLL_SPARSE_ZERO_LEN(p);
+        } else if (HLL_SPARSE_IS_VAL(p)) {
+            span = HLL_SPARSE_VAL_LEN(p);
+        } else { /* XZERO. */
+            span = HLL_SPARSE_XZERO_LEN(p);
+            oplen = 2;
+        }
+        /* Break if this opcode covers the register as 'index'. */
+        if (index <= first+span-1) break;
+        prev = p;
+        p += oplen;
+        first += span;
+    }
+    if (span == 0) return -1; /* Invalid format. */
+
+    next = HLL_SPARSE_IS_XZERO(p) ? p+2 : p+1;
+    if (next >= end) next = NULL;
+
+    /* Cache current opcode type to avoid using the macro again and
+     * again for something that will not change.
+     * Also cache the run-length of the opcode. */
+    if (HLL_SPARSE_IS_ZERO(p)) {
+        is_zero = 1;
+        runlen = HLL_SPARSE_ZERO_LEN(p);
+    } else if (HLL_SPARSE_IS_XZERO(p)) {
+        is_xzero = 1;
+        runlen = HLL_SPARSE_XZERO_LEN(p);
+    } else {
+        is_val = 1;
+        runlen = HLL_SPARSE_VAL_LEN(p);
+    }
+
+    /* Step 2: After the loop:
+     *
+     * 'first' stores to the index of the first register covered
+     *  by the current opcode, which is pointed by 'p'.
+     *
+     * 'next' ad 'prev' store respectively the next and previous opcode,
+     *  or NULL if the opcode at 'p' is respectively the last or first.
+     *
+     * 'span' is set to the number of registers covered by the current
+     *  opcode.
+     *
+     * There are different cases in order to update the data structure
+     * in place without generating it from scratch:
+     *
+     * A) If it is a VAL opcode already set to a value >= our 'count'
+     *    no update is needed, regardless of the VAL run-length field.
+     *    In this case PFADD returns 0 since no changes are performed.
+     *
+     * B) If it is a VAL opcode with len = 1 (representing only our
+     *    register) and the value is less than 'count', we just update it
+     *    since this is a trivial case. */
+    if (is_val) {
+        oldcount = HLL_SPARSE_VAL_VALUE(p);
+        /* Case A. */
+        if (oldcount >= count) return 0;
+
+        /* Case B. */
+        if (runlen == 1) {
+            HLL_SPARSE_VAL_SET(p,count,1);
+            goto updated;
+        }
+    }
+
+    /* C) Another trivial to handle case is a ZERO opcode with a len of 1.
+     * We can just replace it with a VAL opcode with our value and len of 1. */
+    if (is_zero && runlen == 1) {
+        HLL_SPARSE_VAL_SET(p,count,1);
+        goto updated;
+    }
+
+    /* D) General case.
+     *
+     * The other cases are more complex: our register requires to be updated
+     * and is either currently represented by a VAL opcode with len > 1,
+     * by a ZERO opcode with len > 1, or by an XZERO opcode.
+     *
+     * In those cases the original opcode must be split into multiple
+     * opcodes. The worst case is an XZERO split in the middle resuling into
+     * XZERO - VAL - XZERO, so the resulting sequence max length is
+     * 5 bytes.
+     *
+     * We perform the split writing the new sequence into the 'new' buffer
+     * with 'newlen' as length. Later the new sequence is inserted in place
+     * of the old one, possibly moving what is on the right a few bytes
+     * if the new sequence is longer than the older one. */
+    n = seq;
+    last = first+span-1; /* Last register covered by the sequence. */
+
+    if (is_zero || is_xzero) {
+        /* Handle splitting of ZERO / XZERO. */
+        if (index != first) {
+            len = index-first;
+            if (len > HLL_SPARSE_ZERO_MAX_LEN) {
+                HLL_SPARSE_XZERO_SET(n,len);
+                n += 2;
+            } else {
+                HLL_SPARSE_ZERO_SET(n,len);
+                n++;
+            }
+        }
+        HLL_SPARSE_VAL_SET(n,count,1);
+        n++;
+        if (index != last) {
+            len = last-index;
+            if (len > HLL_SPARSE_ZERO_MAX_LEN) {
+                HLL_SPARSE_XZERO_SET(n,len);
+                n += 2;
+            } else {
+                HLL_SPARSE_ZERO_SET(n,len);
+                n++;
+            }
+        }
+    } else {
+        /* Handle splitting of VAL. */
+        int curval = HLL_SPARSE_VAL_VALUE(p);
+
+        if (index != first) {
+            len = index-first;
+            HLL_SPARSE_VAL_SET(n,curval,len);
+            n++;
+        }
+        HLL_SPARSE_VAL_SET(n,count,1);
+        n++;
+        if (index != last) {
+            len = last-index;
+            HLL_SPARSE_VAL_SET(n,curval,len);
+            n++;
+        }
+    }
+
+    /* Step 3: substitute the new sequence with the old one.
+     *
+     * Note that we already allocated space on the sds string
+     * calling sdsMakeRoomFor(). */
+     seqlen = n-seq;
+     oldlen = is_xzero ? 2 : 1;
+     deltalen = seqlen-oldlen;
+
+     if (deltalen > 0 &&
+         sdslen((sds) o->ptr)+deltalen > HLL_SPARSE_MAX_BYTES) goto promote;
+     if (deltalen && next) memmove(next+deltalen,next,end-next);
+     sdsIncrLen((sds) o->ptr,deltalen);
+     memcpy(p,seq,seqlen);
+     end += deltalen;
+
+updated: {
+    /* Step 4: Merge adjacent values if possible.
+     *
+     * The representation was updated, however the resulting representation
+     * may not be optimal: adjacent VAL opcodes can sometimes be merged into
+     * a single one. */
+    p = prev ? prev : sparse;
+    int scanlen = 5; /* Scan up to 5 upcodes starting from prev. */
+    while (p < end && scanlen--) {
+        if (HLL_SPARSE_IS_XZERO(p)) {
+            p += 2;
+            continue;
+        } else if (HLL_SPARSE_IS_ZERO(p)) {
+            p++;
+            continue;
+        }
+        /* We need two adjacent VAL opcodes to try a merge, having
+         * the same value, and a len that fits the VAL opcode max len. */
+        if (p+1 < end && HLL_SPARSE_IS_VAL(p+1)) {
+            int v1 = HLL_SPARSE_VAL_VALUE(p);
+            int v2 = HLL_SPARSE_VAL_VALUE(p+1);
+            if (v1 == v2) {
+                int len = HLL_SPARSE_VAL_LEN(p)+HLL_SPARSE_VAL_LEN(p+1);
+                if (len <= HLL_SPARSE_VAL_MAX_LEN) {
+                    HLL_SPARSE_VAL_SET(p+1,v1,len);
+                    memmove(p,p+1,end-p);
+                    sdsIncrLen((sds) o->ptr,-1);
+                    end--;
+                    /* After a merge we reiterate without incrementing 'p'
+                     * in order to try to merge the just merged value with
+                     * a value on its right. */
+                    continue;
+                }
+            }
+        }
+        p++;
+    }
+
+    /* Invalidate the cached cardinality. */
+    hdr = (struct hllhdr *) o->ptr;
+    HLL_INVALIDATE_CACHE(hdr);
+    return 1;
+}
+promote: /* Promote to dense representation. */
+    if (hllSparseToDense(o) == HLL_C_ERR) return -1; /* Corrupted HLL. */
+    hdr = (struct hllhdr *) o->ptr;
+
+    /* We need to call hllDenseAdd() to perform the operation after the
+     * conversion. However the result must be 1, since if we need to
+     * convert from sparse to dense a register requires to be updated.
+     *
+     * Note that this in turn means that PFADD will make sure the command
+     * is propagated to slaves / AOF, so if there is a sparse -> dense
+     * conversion, it will be performed in all the slaves as well. */
+    int dense_retval = hllDenseSet(hdr->registers + 1,index,count);
+    assert(dense_retval == 1);
+    return dense_retval;
+}
+
+/* "Add" the element in the sparse hyperloglog data structure.
+ * Actually nothing is added, but the max 0 pattern counter of the subset
+ * the element belongs to is incremented if needed.
+ *
+ * This function is actually a wrapper for hllSparseSet(), it only performs
+ * the hashshing of the elmenet to obtain the index and zeros run length. */
+int hllSparseAdd(robj *o, unsigned char *ele, size_t elesize) {
+    long index;
+    uint8_t count = hllPatLen(ele,elesize,&index);
+    /* Update the register if this element produced a longer run of zeroes. */
+    return hllSparseSet(o,index,count);
+}
+
+/* Compute the register histogram in the sparse representation. */
+void hllSparseRegHisto(uint8_t *sparse, int sparselen, int *invalid, int* reghisto) {
+    int idx = 0, runlen, regval;
+    uint8_t *end = sparse+sparselen, *p = sparse;
+
+    while(p < end) {
+        if (HLL_SPARSE_IS_ZERO(p)) {
+            runlen = HLL_SPARSE_ZERO_LEN(p);
+            idx += runlen;
+            reghisto[0] += runlen;
+            p++;
+        } else if (HLL_SPARSE_IS_XZERO(p)) {
+            runlen = HLL_SPARSE_XZERO_LEN(p);
+            idx += runlen;
+            reghisto[0] += runlen;
+            p += 2;
+        } else {
+            runlen = HLL_SPARSE_VAL_LEN(p);
+            regval = HLL_SPARSE_VAL_VALUE(p);
+            idx += runlen;
+            reghisto[regval] += runlen;
+            p++;
+        }
+    }
+    if (idx != HLL_REGISTERS && invalid) *invalid = 1;
+}
+
+/* ========================= HyperLogLog Count ==============================
+ * This is the core of the algorithm where the approximated count is computed.
+ * The function uses the lower level hllDenseRegHisto() and hllSparseRegHisto()
+ * functions as helpers to compute histogram of register values part of the
+ * computation, which is representation-specific, while all the rest is common. */
+
+/* Implements the register histogram calculation for uint8_t data type
+ * which is only used internally as speedup for PFCOUNT with multiple keys. */
+void hllRawRegHisto(uint8_t *registers, int* reghisto) {
+    uint64_t *word = (uint64_t*) registers;
+    uint8_t *bytes;
+    int j;
+
+    for (j = 0; j < HLL_REGISTERS/8; j++) {
+        if (*word == 0) {
+            reghisto[0] += 8;
+        } else {
+            bytes = (uint8_t*) word;
+            reghisto[bytes[0]]++;
+            reghisto[bytes[1]]++;
+            reghisto[bytes[2]]++;
+            reghisto[bytes[3]]++;
+            reghisto[bytes[4]]++;
+            reghisto[bytes[5]]++;
+            reghisto[bytes[6]]++;
+            reghisto[bytes[7]]++;
+        }
+        word++;
+    }
+}
+
+// somehow this is missing on some platforms
+#ifndef INFINITY
+// from math.h
+#define INFINITY 1e50f
+#endif
+
+
+/* Helper function sigma as defined in
+ * "New cardinality estimation algorithms for HyperLogLog sketches"
+ * Otmar Ertl, arXiv:1702.01284 */
+double hllSigma(double x) {
+    if (x == 1.) return INFINITY;
+    double zPrime;
+    double y = 1;
+    double z = x;
+    do {
+        x *= x;
+        zPrime = z;
+        z += x * y;
+        y += y;
+    } while(zPrime != z);
+    return z;
+}
+
+/* Helper function tau as defined in
+ * "New cardinality estimation algorithms for HyperLogLog sketches"
+ * Otmar Ertl, arXiv:1702.01284 */
+double hllTau(double x) {
+    if (x == 0. || x == 1.) return 0.;
+    double zPrime;
+    double y = 1.0;
+    double z = 1 - x;
+    do {
+        x = sqrt(x);
+        zPrime = z;
+        y *= 0.5;
+        z -= pow(1 - x, 2)*y;
+    } while(zPrime != z);
+    return z / 3;
+}
+
+/* Return the approximated cardinality of the set based on the harmonic
+ * mean of the registers values. 'hdr' points to the start of the SDS
+ * representing the String object holding the HLL representation.
+ *
+ * If the sparse representation of the HLL object is not valid, the integer
+ * pointed by 'invalid' is set to non-zero, otherwise it is left untouched.
+ *
+ * hllCount() supports a special internal-only encoding of HLL_RAW, that
+ * is, hdr->registers will point to an uint8_t array of HLL_REGISTERS element.
+ * This is useful in order to speedup PFCOUNT when called against multiple
+ * keys (no need to work with 6-bit integers encoding). */
+uint64_t hllCount(struct hllhdr *hdr, int *invalid) {
+    double m = HLL_REGISTERS;
+    double E;
+    int j;
+    int reghisto[HLL_Q+2] = {0};
+
+    /* Compute register histogram */
+    if (hdr->encoding == HLL_DENSE) {
+        hllDenseRegHisto(hdr->registers + 1,reghisto);
+    } else if (hdr->encoding == HLL_SPARSE) {
+        hllSparseRegHisto(hdr->registers + 1,
+                         sdslen((sds)hdr)-HLL_HDR_SIZE,invalid,reghisto);
+    } else if (hdr->encoding == HLL_RAW) {
+        hllRawRegHisto(hdr->registers + 1,reghisto);
+    } else {
+		*invalid = 1;
+		return 0;
+        //serverPanic("Unknown HyperLogLog encoding in hllCount()");
+    }
+
+    /* Estimate cardinality form register histogram. See:
+     * "New cardinality estimation algorithms for HyperLogLog sketches"
+     * Otmar Ertl, arXiv:1702.01284 */
+    double z = m * hllTau((m-reghisto[HLL_Q+1])/(double)m);
+    for (j = HLL_Q; j >= 1; --j) {
+        z += reghisto[j];
+        z *= 0.5;
+    }
+    z += m * hllSigma(reghisto[0]/(double)m);
+    E = llroundl(HLL_ALPHA_INF*m*m/z);
+
+    return (uint64_t) E;
+}
+
+/* Call hllDenseAdd() or hllSparseAdd() according to the HLL encoding. */
+int hll_add(robj *o, unsigned char *ele, size_t elesize) {
+    struct hllhdr *hdr = (struct hllhdr *) o->ptr;
+    switch(hdr->encoding) {
+    case HLL_DENSE: return hllDenseAdd(hdr->registers + 1,ele,elesize);
+    case HLL_SPARSE: return hllSparseAdd(o,ele,elesize);
+    default: return -1; /* Invalid representation. */
+    }
+}
+
+/* Merge by computing MAX(registers[i],hll[i]) the HyperLogLog 'hll'
+ * with an array of uint8_t HLL_REGISTERS registers pointed by 'max'.
+ *
+ * The hll object must be already validated via isHLLObjectOrReply()
+ * or in some other way.
+ *
+ * If the HyperLogLog is sparse and is found to be invalid, C_ERR
+ * is returned, otherwise the function always succeeds. */
+int hllMerge(uint8_t *max, robj *hll) {
+    struct hllhdr *hdr = (struct hllhdr *) hll->ptr;
+    int i;
+
+    if (hdr->encoding == HLL_DENSE) {
+        uint8_t val;
+
+        for (i = 0; i < HLL_REGISTERS; i++) {
+            HLL_DENSE_GET_REGISTER(val,hdr->registers + 1,i);
+            if (val > max[i]) max[i] = val;
+        }
+    } else {
+        uint8_t *p = (uint8_t *) hll->ptr, *end = p + sdslen((sds) hll->ptr);
+        long runlen, regval;
+
+        p += HLL_HDR_SIZE;
+        i = 0;
+        while(p < end) {
+            if (HLL_SPARSE_IS_ZERO(p)) {
+                runlen = HLL_SPARSE_ZERO_LEN(p);
+                i += runlen;
+                p++;
+            } else if (HLL_SPARSE_IS_XZERO(p)) {
+                runlen = HLL_SPARSE_XZERO_LEN(p);
+                i += runlen;
+                p += 2;
+            } else {
+                runlen = HLL_SPARSE_VAL_LEN(p);
+                regval = HLL_SPARSE_VAL_VALUE(p);
+                while(runlen--) {
+                    if (regval > max[i]) max[i] = regval;
+                    i++;
+                }
+                p++;
+            }
+        }
+        if (i != HLL_REGISTERS) return HLL_C_ERR;
+    }
+    return HLL_C_OK;
+}
+
+/* ========================== robj creation ========================== */
+robj *createObject(void *ptr) {
+	robj *result = (robj*) malloc(sizeof(robj));
+	result->ptr = ptr;
+	return result;
+}
+
+void destroyObject(robj *obj) {
+	free(obj);
+}
+
+/* ========================== HyperLogLog commands ========================== */
+
+/* Create an HLL object. We always create the HLL using sparse encoding.
+ * This will be upgraded to the dense representation as needed. */
+robj *hll_create(void) {
+    robj *o;
+    struct hllhdr *hdr;
+    sds s;
+    uint8_t *p;
+    int sparselen = HLL_HDR_SIZE +
+                    (((HLL_REGISTERS+(HLL_SPARSE_XZERO_MAX_LEN-1)) /
+                     HLL_SPARSE_XZERO_MAX_LEN)*2);
+    int aux;
+
+    /* Populate the sparse representation with as many XZERO opcodes as
+     * needed to represent all the registers. */
+    aux = HLL_REGISTERS;
+    s = sdsnewlen(NULL,sparselen);
+    p = (uint8_t*)s + HLL_HDR_SIZE;
+    while(aux) {
+        int xzero = HLL_SPARSE_XZERO_MAX_LEN;
+        if (xzero > aux) xzero = aux;
+        HLL_SPARSE_XZERO_SET(p,xzero);
+        p += 2;
+        aux -= xzero;
+    }
+    assert((p-(uint8_t*)s) == sparselen);
+
+    /* Create the actual object. */
+    o = createObject(s);
+    hdr = (struct hllhdr *) o->ptr;
+    memcpy(hdr->magic,"HYLL",4);
+    hdr->encoding = HLL_SPARSE;
+    return o;
+}
+
+void hll_destroy(robj *obj) {
+	if (!obj) {
+		return;
+	}
+	sdsfree((sds) obj->ptr);
+	destroyObject(obj);
+}
+
+
+
+int hll_count(robj *o, size_t *result) {
+	int invalid = 0;
+	*result = hllCount((struct hllhdr*) o->ptr, &invalid);
+	return invalid == 0 ? HLL_C_OK : HLL_C_ERR;
+}
+
+robj *hll_merge(robj **hlls, size_t hll_count) {
+    uint8_t max[HLL_REGISTERS];
+    struct hllhdr *hdr;
+    size_t j;
+	 /* Use dense representation as target? */
+    int use_dense = 0;
+
+    /* Compute an HLL with M[i] = MAX(M[i]_j).
+     * We store the maximum into the max array of registers. We'll write
+     * it to the target variable later. */
+    memset(max, 0, sizeof(max));
+    for (j = 0; j < hll_count; j++) {
+        /* Check type and size. */
+        robj *o = hlls[j];
+        if (o == NULL) continue; /* Assume empty HLL for non existing var. */
+
+        /* If at least one involved HLL is dense, use the dense representation
+         * as target ASAP to save time and avoid the conversion step. */
+        hdr = (struct hllhdr *) o->ptr;
+        if (hdr->encoding == HLL_DENSE) use_dense = 1;
+
+        /* Merge with this HLL with our 'max' HHL by setting max[i]
+         * to MAX(max[i],hll[i]). */
+        if (hllMerge(max, o) == HLL_C_ERR) {
+            return NULL;
+        }
+    }
+
+    /* Create the destination key's value. */
+    robj *result = hll_create();
+	if (!result) {
+		return NULL;
+	}
+
+    /* Convert the destination object to dense representation if at least
+     * one of the inputs was dense. */
+    if (use_dense && hllSparseToDense(result) == HLL_C_ERR) {
+		hll_destroy(result);
+        return NULL;
+    }
+
+    /* Write the resulting HLL to the destination HLL registers and
+     * invalidate the cached value. */
+    for (j = 0; j < HLL_REGISTERS; j++) {
+        if (max[j] == 0) continue;
+        hdr = (struct hllhdr *) result->ptr;
+        switch(hdr->encoding) {
+        case HLL_DENSE: hllDenseSet(hdr->registers + 1,j,max[j]); break;
+        case HLL_SPARSE: hllSparseSet(result,j,max[j]); break;
+        }
+    }
+	return result;
+}
+
+uint64_t get_size() {
+	return HLL_DENSE_SIZE;
+}
+
+}
+
+namespace duckdb {
+
+static inline int AddToLog(void *log, const uint64_t &index, const uint8_t &count) {
+	auto o = (duckdb_hll::robj *)log;
+	duckdb_hll::hllhdr *hdr = (duckdb_hll::hllhdr *)o->ptr;
+	D_ASSERT(hdr->encoding == HLL_DENSE);
+	return duckdb_hll::hllDenseSet(hdr->registers + 1, index, count);
+}
+
+void AddToLogsInternal(VectorData &vdata, idx_t count, uint64_t indices[], uint8_t counts[], void ***logs[],
+                       const SelectionVector *log_sel) {
+	// 'logs' is an array of pointers to AggregateStates
+	// AggregateStates have a pointer to a HyperLogLog object
+	// HyperLogLog objects have a pointer to a 'robj', which we need
+	for (idx_t i = 0; i < count; i++) {
+		auto log = logs[log_sel->get_index(i)];
+		if (log && vdata.validity.RowIsValid(vdata.sel->get_index(i))) {
+			AddToLog(**log, indices[i], counts[i]);
+		}
+	}
+}
+
+void AddToSingleLogInternal(VectorData &vdata, idx_t count, uint64_t indices[], uint8_t counts[], void *log) {
+	const auto o = (duckdb_hll::robj *)log;
+	duckdb_hll::hllhdr *hdr = (duckdb_hll::hllhdr *)o->ptr;
+	D_ASSERT(hdr->encoding == HLL_DENSE);
+
+	const auto registers = hdr->registers + 1;
+	for (idx_t i = 0; i < count; i++) {
+		if (vdata.validity.RowIsValid(vdata.sel->get_index(i))) {
+			duckdb_hll::hllDenseSet(registers, indices[i], counts[i]);
+		}
+	}
+}
+
+} // namespace duckdb
+
+
+// LICENSE_CHANGE_END
+
+
+// LICENSE_CHANGE_BEGIN
+// The following code up to LICENSE_CHANGE_END is subject to THIRD PARTY LICENSE #7
+// See the end of this file for a list
+
+/* SDSLib 2.0 -- A C dynamic strings library
+ *
+ * Copyright (c) 2006-2015, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2015, Oran Agra
+ * Copyright (c) 2015, Redis Labs, Inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <assert.h>
+#include <limits.h>
+
+
+namespace duckdb_hll {
+
+static inline int sdsHdrSize(char type) {
+    switch(type&SDS_TYPE_MASK) {
+        case SDS_TYPE_5:
+            return sizeof(struct sdshdr5);
+        case SDS_TYPE_8:
+            return sizeof(struct sdshdr8);
+        case SDS_TYPE_16:
+            return sizeof(struct sdshdr16);
+        case SDS_TYPE_32:
+            return sizeof(struct sdshdr32);
+        case SDS_TYPE_64:
+            return sizeof(struct sdshdr64);
+    }
+    return 0;
+}
+
+static inline char sdsReqType(size_t string_size) {
+    if (string_size < 1<<5)
+        return SDS_TYPE_5;
+    if (string_size < 1<<8)
+        return SDS_TYPE_8;
+    if (string_size < 1<<16)
+        return SDS_TYPE_16;
+#if (LONG_MAX == LLONG_MAX)
+    if (string_size < 1ll<<32)
+        return SDS_TYPE_32;
+    return SDS_TYPE_64;
+#else
+    return SDS_TYPE_32;
+#endif
+}
+
+/* Create a new sds string with the content specified by the 'init' pointer
+ * and 'initlen'.
+ * If NULL is used for 'init' the string is initialized with zero bytes.
+ * If SDS_NOINIT is used, the buffer is left uninitialized;
+ *
+ * The string is always null-termined (all the sds strings are, always) so
+ * even if you create an sds string with:
+ *
+ * mystring = sdsnewlen("abc",3);
+ *
+ * You can print the string with printf() as there is an implicit \0 at the
+ * end of the string. However the string is binary safe and can contain
+ * \0 characters in the middle, as the length is stored in the sds header. */
+sds sdsnewlen(const void *init, size_t initlen) {
+    void *sh;
+    sds s;
+    char type = sdsReqType(initlen);
+    /* Empty strings are usually created in order to append. Use type 8
+     * since type 5 is not good at this. */
+    if (type == SDS_TYPE_5 && initlen == 0) type = SDS_TYPE_8;
+    int hdrlen = sdsHdrSize(type);
+    unsigned char *fp; /* flags pointer. */
+
+    sh = malloc(hdrlen+initlen+1);
+    if (!init)
+        memset(sh, 0, hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
+    s = (char*)sh+hdrlen;
+    fp = ((unsigned char*)s)-1;
+    switch(type) {
+        case SDS_TYPE_5: {
+            *fp = type | (initlen << SDS_TYPE_BITS);
+            break;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            sh->len = initlen;
+            sh->alloc = initlen;
+            *fp = type;
+            break;
+        }
+    }
+    if (initlen && init)
+        memcpy(s, init, initlen);
+    s[initlen] = '\0';
+    return s;
+}
+
+/* Create an empty (zero length) sds string. Even in this case the string
+ * always has an implicit null term. */
+sds sdsempty(void) {
+    return sdsnewlen("",0);
+}
+
+/* Create a new sds string starting from a null terminated C string. */
+sds sdsnew(const char *init) {
+    size_t initlen = (init == NULL) ? 0 : strlen(init);
+    return sdsnewlen(init, initlen);
+}
+
+/* Duplicate an sds string. */
+sds sdsdup(const sds s) {
+    return sdsnewlen(s, sdslen(s));
+}
+
+/* Free an sds string. No operation is performed if 's' is NULL. */
+void sdsfree(sds s) {
+    if (s == NULL) return;
+    free((char*)s-sdsHdrSize(s[-1]));
+}
+
+/* Set the sds string length to the length as obtained with strlen(), so
+ * considering as content only up to the first null term character.
+ *
+ * This function is useful when the sds string is hacked manually in some
+ * way, like in the following example:
+ *
+ * s = sdsnew("foobar");
+ * s[2] = '\0';
+ * sdsupdatelen(s);
+ * printf("%d\n", sdslen(s));
+ *
+ * The output will be "2", but if we comment out the call to sdsupdatelen()
+ * the output will be "6" as the string was modified but the logical length
+ * remains 6 bytes. */
+void sdsupdatelen(sds s) {
+    size_t reallen = strlen(s);
+    sdssetlen(s, reallen);
+}
+
+/* Modify an sds string in-place to make it empty (zero length).
+ * However all the existing buffer is not discarded but set as free space
+ * so that next append operations will not require allocations up to the
+ * number of bytes previously available. */
+void sdsclear(sds s) {
+    sdssetlen(s, 0);
+    s[0] = '\0';
+}
+
+/* Enlarge the free space at the end of the sds string so that the caller
+ * is sure that after calling this function can overwrite up to addlen
+ * bytes after the end of the string, plus one more byte for nul term.
+ *
+ * Note: this does not change the *length* of the sds string as returned
+ * by sdslen(), but only the free buffer space we have. */
+sds sdsMakeRoomFor(sds s, size_t addlen) {
+    void *sh, *newsh;
+    size_t avail = sdsavail(s);
+    size_t len, newlen;
+    char type, oldtype = s[-1] & SDS_TYPE_MASK;
+    int hdrlen;
+
+    /* Return ASAP if there is enough space left. */
+    if (avail >= addlen) return s;
+
+    len = sdslen(s);
+    sh = (char*)s-sdsHdrSize(oldtype);
+    newlen = (len+addlen);
+    if (newlen < SDS_MAX_PREALLOC)
+        newlen *= 2;
+    else
+        newlen += SDS_MAX_PREALLOC;
+
+    type = sdsReqType(newlen);
+
+    /* Don't use type 5: the user is appending to the string and type 5 is
+     * not able to remember empty space, so sdsMakeRoomFor() must be called
+     * at every appending operation. */
+    if (type == SDS_TYPE_5) type = SDS_TYPE_8;
+
+    hdrlen = sdsHdrSize(type);
+    if (oldtype==type) {
+        newsh = realloc(sh, hdrlen+newlen+1);
+        if (newsh == NULL) return NULL;
+        s = (char*)newsh+hdrlen;
+    } else {
+        /* Since the header size changes, need to move the string forward,
+         * and can't use realloc */
+        newsh = malloc(hdrlen+newlen+1);
+        if (newsh == NULL) return NULL;
+        memcpy((char*)newsh+hdrlen, s, len+1);
+        free(sh);
+        s = (char*)newsh+hdrlen;
+        s[-1] = type;
+        sdssetlen(s, len);
+    }
+    sdssetalloc(s, newlen);
+    return s;
+}
+
+/* Reallocate the sds string so that it has no free space at the end. The
+ * contained string remains not altered, but next concatenation operations
+ * will require a reallocation.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdsRemoveFreeSpace(sds s) {
+    void *sh, *newsh;
+    char type, oldtype = s[-1] & SDS_TYPE_MASK;
+    int hdrlen, oldhdrlen = sdsHdrSize(oldtype);
+    size_t len = sdslen(s);
+    sh = (char*)s-oldhdrlen;
+
+    /* Check what would be the minimum SDS header that is just good enough to
+     * fit this string. */
+    type = sdsReqType(len);
+    hdrlen = sdsHdrSize(type);
+
+    /* If the type is the same, or at least a large enough type is still
+     * required, we just realloc(), letting the allocator to do the copy
+     * only if really needed. Otherwise if the change is huge, we manually
+     * reallocate the string to use the different header type. */
+    if (oldtype==type || type > SDS_TYPE_8) {
+        newsh = realloc(sh, oldhdrlen+len+1);
+        if (newsh == NULL) return NULL;
+        s = (char*)newsh+oldhdrlen;
+    } else {
+        newsh = malloc(hdrlen+len+1);
+        if (newsh == NULL) return NULL;
+        memcpy((char*)newsh+hdrlen, s, len+1);
+        free(sh);
+        s = (char*)newsh+hdrlen;
+        s[-1] = type;
+        sdssetlen(s, len);
+    }
+    sdssetalloc(s, len);
+    return s;
+}
+
+/* Return the total size of the allocation of the specified sds string,
+ * including:
+ * 1) The sds header before the pointer.
+ * 2) The string.
+ * 3) The free buffer at the end if any.
+ * 4) The implicit null term.
+ */
+size_t sdsAllocSize(sds s) {
+    size_t alloc = sdsalloc(s);
+    return sdsHdrSize(s[-1])+alloc+1;
+}
+
+/* Return the pointer of the actual SDS allocation (normally SDS strings
+ * are referenced by the start of the string buffer). */
+void *sdsAllocPtr(sds s) {
+    return (void*) (s-sdsHdrSize(s[-1]));
+}
+
+/* Increment the sds length and decrements the left free space at the
+ * end of the string according to 'incr'. Also set the null term
+ * in the new end of the string.
+ *
+ * This function is used in order to fix the string length after the
+ * user calls sdsMakeRoomFor(), writes something after the end of
+ * the current string, and finally needs to set the new length.
+ *
+ * Note: it is possible to use a negative increment in order to
+ * right-trim the string.
+ *
+ * Usage example:
+ *
+ * Using sdsIncrLen() and sdsMakeRoomFor() it is possible to mount the
+ * following schema, to cat bytes coming from the kernel to the end of an
+ * sds string without copying into an intermediate buffer:
+ *
+ * oldlen = sdslen(s);
+ * s = sdsMakeRoomFor(s, BUFFER_SIZE);
+ * nread = read(fd, s+oldlen, BUFFER_SIZE);
+ * ... check for nread <= 0 and handle it ...
+ * sdsIncrLen(s, nread);
+ */
+void sdsIncrLen(sds s, ssize_t incr) {
+    unsigned char flags = s[-1];
+    size_t len;
+    switch(flags&SDS_TYPE_MASK) {
+        case SDS_TYPE_5: {
+            unsigned char *fp = ((unsigned char*)s)-1;
+            unsigned char oldlen = SDS_TYPE_5_LEN(flags);
+            assert((incr > 0 && oldlen+incr < 32) || (incr < 0 && oldlen >= (unsigned int)(-incr)));
+            *fp = SDS_TYPE_5 | ((oldlen+incr) << SDS_TYPE_BITS);
+            len = oldlen+incr;
+            break;
+        }
+        case SDS_TYPE_8: {
+            SDS_HDR_VAR(8,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_16: {
+            SDS_HDR_VAR(16,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_32: {
+            SDS_HDR_VAR(32,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= (unsigned int)incr) || (incr < 0 && sh->len >= (unsigned int)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        case SDS_TYPE_64: {
+            SDS_HDR_VAR(64,s);
+            assert((incr >= 0 && sh->alloc-sh->len >= (uint64_t)incr) || (incr < 0 && sh->len >= (uint64_t)(-incr)));
+            len = (sh->len += incr);
+            break;
+        }
+        default: len = 0; /* Just to avoid compilation warnings. */
+    }
+    s[len] = '\0';
+}
+
+/* Grow the sds to have the specified length. Bytes that were not part of
+ * the original length of the sds will be set to zero.
+ *
+ * if the specified length is smaller than the current length, no operation
+ * is performed. */
+sds sdsgrowzero(sds s, size_t len) {
+    size_t curlen = sdslen(s);
+
+    if (len <= curlen) return s;
+    s = sdsMakeRoomFor(s,len-curlen);
+    if (s == NULL) return NULL;
+
+    /* Make sure added region doesn't contain garbage */
+    memset(s+curlen,0,(len-curlen+1)); /* also set trailing \0 byte */
+    sdssetlen(s, len);
+    return s;
+}
+
+/* Append the specified binary-safe string pointed by 't' of 'len' bytes to the
+ * end of the specified sds string 's'.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatlen(sds s, const void *t, size_t len) {
+    size_t curlen = sdslen(s);
+
+    s = sdsMakeRoomFor(s,len);
+    if (s == NULL) return NULL;
+    memcpy(s+curlen, t, len);
+    sdssetlen(s, curlen+len);
+    s[curlen+len] = '\0';
+    return s;
+}
+
+/* Append the specified null termianted C string to the sds string 's'.
+ *
+ * After the call, the passed sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscat(sds s, const char *t) {
+    return sdscatlen(s, t, strlen(t));
+}
+
+/* Append the specified sds 't' to the existing sds 's'.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatsds(sds s, const sds t) {
+    return sdscatlen(s, t, sdslen(t));
+}
+
+/* Destructively modify the sds string 's' to hold the specified binary
+ * safe string pointed by 't' of length 'len' bytes. */
+sds sdscpylen(sds s, const char *t, size_t len) {
+    if (sdsalloc(s) < len) {
+        s = sdsMakeRoomFor(s,len-sdslen(s));
+        if (s == NULL) return NULL;
+    }
+    memcpy(s, t, len);
+    s[len] = '\0';
+    sdssetlen(s, len);
+    return s;
+}
+
+/* Like sdscpylen() but 't' must be a null-termined string so that the length
+ * of the string is obtained with strlen(). */
+sds sdscpy(sds s, const char *t) {
+    return sdscpylen(s, t, strlen(t));
+}
+
+/* Helper for sdscatlonglong() doing the actual number -> string
+ * conversion. 's' must point to a string with room for at least
+ * SDS_LLSTR_SIZE bytes.
+ *
+ * The function returns the length of the null-terminated string
+ * representation stored at 's'. */
+#define SDS_LLSTR_SIZE 21
+int sdsll2str(char *s, long long value) {
+    char *p, aux;
+    unsigned long long v;
+    size_t l;
+
+    /* Generate the string representation, this method produces
+     * an reversed string. */
+    v = (value < 0) ? -value : value;
+    p = s;
+    do {
+        *p++ = '0'+(v%10);
+        v /= 10;
+    } while(v);
+    if (value < 0) *p++ = '-';
+
+    /* Compute length and add null term. */
+    l = p-s;
+    *p = '\0';
+
+    /* Reverse the string. */
+    p--;
+    while(s < p) {
+        aux = *s;
+        *s = *p;
+        *p = aux;
+        s++;
+        p--;
+    }
+    return l;
+}
+
+/* Identical sdsll2str(), but for unsigned long long type. */
+int sdsull2str(char *s, unsigned long long v) {
+    char *p, aux;
+    size_t l;
+
+    /* Generate the string representation, this method produces
+     * an reversed string. */
+    p = s;
+    do {
+        *p++ = '0'+(v%10);
+        v /= 10;
+    } while(v);
+
+    /* Compute length and add null term. */
+    l = p-s;
+    *p = '\0';
+
+    /* Reverse the string. */
+    p--;
+    while(s < p) {
+        aux = *s;
+        *s = *p;
+        *p = aux;
+        s++;
+        p--;
+    }
+    return l;
+}
+
+/* Create an sds string from a long long value. It is much faster than:
+ *
+ * sdscatprintf(sdsempty(),"%lld\n", value);
+ */
+sds sdsfromlonglong(long long value) {
+    char buf[SDS_LLSTR_SIZE];
+    int len = sdsll2str(buf,value);
+
+    return sdsnewlen(buf,len);
+}
+
+/* Like sdscatprintf() but gets va_list instead of being variadic. */
+sds sdscatvprintf(sds s, const char *fmt, va_list ap) {
+    va_list cpy;
+    char staticbuf[1024], *buf = staticbuf, *t;
+    size_t buflen = strlen(fmt)*2;
+
+    /* We try to start using a static buffer for speed.
+     * If not possible we revert to heap allocation. */
+    if (buflen > sizeof(staticbuf)) {
+        buf = (char*) malloc(buflen);
+        if (buf == NULL) return NULL;
+    } else {
+        buflen = sizeof(staticbuf);
+    }
+
+    /* Try with buffers two times bigger every time we fail to
+     * fit the string in the current buffer size. */
+    while(1) {
+        buf[buflen-2] = '\0';
+        va_copy(cpy,ap);
+        vsnprintf(buf, buflen, fmt, cpy);
+        va_end(cpy);
+        if (buf[buflen-2] != '\0') {
+            if (buf != staticbuf) free(buf);
+            buflen *= 2;
+            buf = (char*) malloc(buflen);
+            if (buf == NULL) return NULL;
+            continue;
+        }
+        break;
+    }
+
+    /* Finally concat the obtained string to the SDS string and return it. */
+    t = sdscat(s, buf);
+    if (buf != staticbuf) free(buf);
+    return t;
+}
+
+/* Append to the sds string 's' a string obtained using printf-alike format
+ * specifier.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call.
+ *
+ * Example:
+ *
+ * s = sdsnew("Sum is: ");
+ * s = sdscatprintf(s,"%d+%d = %d",a,b,a+b).
+ *
+ * Often you need to create a string from scratch with the printf-alike
+ * format. When this is the need, just use sdsempty() as the target string:
+ *
+ * s = sdscatprintf(sdsempty(), "... your format ...", args);
+ */
+sds sdscatprintf(sds s, const char *fmt, ...) {
+    va_list ap;
+    char *t;
+    va_start(ap, fmt);
+    t = sdscatvprintf(s,fmt,ap);
+    va_end(ap);
+    return t;
+}
+
+/* This function is similar to sdscatprintf, but much faster as it does
+ * not rely on sprintf() family functions implemented by the libc that
+ * are often very slow. Moreover directly handling the sds string as
+ * new data is concatenated provides a performance improvement.
+ *
+ * However this function only handles an incompatible subset of printf-alike
+ * format specifiers:
+ *
+ * %s - C String
+ * %S - SDS string
+ * %i - signed int
+ * %I - 64 bit signed integer (long long, int64_t)
+ * %u - unsigned int
+ * %U - 64 bit unsigned integer (unsigned long long, uint64_t)
+ * %% - Verbatim "%" character.
+ */
+sds sdscatfmt(sds s, char const *fmt, ...) {
+    size_t initlen = sdslen(s);
+    const char *f = fmt;
+    long i;
+    va_list ap;
+
+    va_start(ap,fmt);
+    f = fmt;    /* Next format specifier byte to process. */
+    i = initlen; /* Position of the next byte to write to dest str. */
+    while(*f) {
+        char next, *str;
+        size_t l;
+        long long num;
+        unsigned long long unum;
+
+        /* Make sure there is always space for at least 1 char. */
+        if (sdsavail(s)==0) {
+            s = sdsMakeRoomFor(s,1);
+        }
+
+        switch(*f) {
+        case '%':
+            next = *(f+1);
+            f++;
+            switch(next) {
+            case 's':
+            case 'S':
+                str = va_arg(ap,char*);
+                l = (next == 's') ? strlen(str) : sdslen(str);
+                if (sdsavail(s) < l) {
+                    s = sdsMakeRoomFor(s,l);
+                }
+                memcpy(s+i,str,l);
+                sdsinclen(s,l);
+                i += l;
+                break;
+            case 'i':
+            case 'I':
+                if (next == 'i')
+                    num = va_arg(ap,int);
+                else
+                    num = va_arg(ap,long long);
+                {
+                    char buf[SDS_LLSTR_SIZE];
+                    l = sdsll2str(buf,num);
+                    if (sdsavail(s) < l) {
+                        s = sdsMakeRoomFor(s,l);
+                    }
+                    memcpy(s+i,buf,l);
+                    sdsinclen(s,l);
+                    i += l;
+                }
+                break;
+            case 'u':
+            case 'U':
+                if (next == 'u')
+                    unum = va_arg(ap,unsigned int);
+                else
+                    unum = va_arg(ap,unsigned long long);
+                {
+                    char buf[SDS_LLSTR_SIZE];
+                    l = sdsull2str(buf,unum);
+                    if (sdsavail(s) < l) {
+                        s = sdsMakeRoomFor(s,l);
+                    }
+                    memcpy(s+i,buf,l);
+                    sdsinclen(s,l);
+                    i += l;
+                }
+                break;
+            default: /* Handle %% and generally %<unknown>. */
+                s[i++] = next;
+                sdsinclen(s,1);
+                break;
+            }
+            break;
+        default:
+            s[i++] = *f;
+            sdsinclen(s,1);
+            break;
+        }
+        f++;
+    }
+    va_end(ap);
+
+    /* Add null-term */
+    s[i] = '\0';
+    return s;
+}
+
+/* Remove the part of the string from left and from right composed just of
+ * contiguous characters found in 'cset', that is a null terminted C string.
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call.
+ *
+ * Example:
+ *
+ * s = sdsnew("AA...AA.a.aa.aHelloWorld     :::");
+ * s = sdstrim(s,"Aa. :");
+ * printf("%s\n", s);
+ *
+ * Output will be just "Hello World".
+ */
+sds sdstrim(sds s, const char *cset) {
+    char *start, *end, *sp, *ep;
+    size_t len;
+
+    sp = start = s;
+    ep = end = s+sdslen(s)-1;
+    while(sp <= end && strchr(cset, *sp)) sp++;
+    while(ep > sp && strchr(cset, *ep)) ep--;
+    len = (sp > ep) ? 0 : ((ep-sp)+1);
+    if (s != sp) memmove(s, sp, len);
+    s[len] = '\0';
+    sdssetlen(s,len);
+    return s;
+}
+
+/* Turn the string into a smaller (or equal) string containing only the
+ * substring specified by the 'start' and 'end' indexes.
+ *
+ * start and end can be negative, where -1 means the last character of the
+ * string, -2 the penultimate character, and so forth.
+ *
+ * The interval is inclusive, so the start and end characters will be part
+ * of the resulting string.
+ *
+ * The string is modified in-place.
+ *
+ * Example:
+ *
+ * s = sdsnew("Hello World");
+ * sdsrange(s,1,-1); => "ello World"
+ */
+void sdsrange(sds s, ssize_t start, ssize_t end) {
+    size_t newlen, len = sdslen(s);
+
+    if (len == 0) return;
+    if (start < 0) {
+        start = len+start;
+        if (start < 0) start = 0;
+    }
+    if (end < 0) {
+        end = len+end;
+        if (end < 0) end = 0;
+    }
+    newlen = (start > end) ? 0 : (end-start)+1;
+    if (newlen != 0) {
+        if (start >= (ssize_t)len) {
+            newlen = 0;
+        } else if (end >= (ssize_t)len) {
+            end = len-1;
+            newlen = (start > end) ? 0 : (end-start)+1;
+        }
+    } else {
+        start = 0;
+    }
+    if (start && newlen) memmove(s, s+start, newlen);
+    s[newlen] = 0;
+    sdssetlen(s,newlen);
+}
+
+/* Apply tolower() to every character of the sds string 's'. */
+void sdstolower(sds s) {
+    size_t len = sdslen(s), j;
+
+    for (j = 0; j < len; j++) s[j] = tolower(s[j]);
+}
+
+/* Apply toupper() to every character of the sds string 's'. */
+void sdstoupper(sds s) {
+    size_t len = sdslen(s), j;
+
+    for (j = 0; j < len; j++) s[j] = toupper(s[j]);
+}
+
+/* Compare two sds strings s1 and s2 with memcmp().
+ *
+ * Return value:
+ *
+ *     positive if s1 > s2.
+ *     negative if s1 < s2.
+ *     0 if s1 and s2 are exactly the same binary string.
+ *
+ * If two strings share exactly the same prefix, but one of the two has
+ * additional characters, the longer string is considered to be greater than
+ * the smaller one. */
+int sdscmp(const sds s1, const sds s2) {
+    size_t l1, l2, minlen;
+    int cmp;
+
+    l1 = sdslen(s1);
+    l2 = sdslen(s2);
+    minlen = (l1 < l2) ? l1 : l2;
+    cmp = memcmp(s1,s2,minlen);
+    if (cmp == 0) return l1>l2? 1: (l1<l2? -1: 0);
+    return cmp;
+}
+
+/* Split 's' with separator in 'sep'. An array
+ * of sds strings is returned. *count will be set
+ * by reference to the number of tokens returned.
+ *
+ * On out of memory, zero length string, zero length
+ * separator, NULL is returned.
+ *
+ * Note that 'sep' is able to split a string using
+ * a multi-character separator. For example
+ * sdssplit("foo_-_bar","_-_"); will return two
+ * elements "foo" and "bar".
+ *
+ * This version of the function is binary-safe but
+ * requires length arguments. sdssplit() is just the
+ * same function but for zero-terminated strings.
+ */
+sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *count) {
+    int elements = 0, slots = 5;
+    long start = 0, j;
+    sds *tokens;
+
+    if (seplen < 1 || len < 0) return NULL;
+
+    tokens = (sds*) malloc(sizeof(sds)*slots);
+    if (tokens == NULL) return NULL;
+
+    if (len == 0) {
+        *count = 0;
+        return tokens;
+    }
+    for (j = 0; j < (len-(seplen-1)); j++) {
+        /* make sure there is room for the next element and the final one */
+        if (slots < elements+2) {
+            sds *newtokens;
+
+            slots *= 2;
+            newtokens = (sds*) realloc(tokens,sizeof(sds)*slots);
+            if (newtokens == NULL) goto cleanup;
+            tokens = newtokens;
+        }
+        /* search the separator */
+        if ((seplen == 1 && *(s+j) == sep[0]) || (memcmp(s+j,sep,seplen) == 0)) {
+            tokens[elements] = sdsnewlen(s+start,j-start);
+            if (tokens[elements] == NULL) goto cleanup;
+            elements++;
+            start = j+seplen;
+            j = j+seplen-1; /* skip the separator */
+        }
+    }
+    /* Add the final element. We are sure there is room in the tokens array. */
+    tokens[elements] = sdsnewlen(s+start,len-start);
+    if (tokens[elements] == NULL) goto cleanup;
+    elements++;
+    *count = elements;
+    return tokens;
+
+cleanup:
+    {
+        int i;
+        for (i = 0; i < elements; i++) sdsfree(tokens[i]);
+        free(tokens);
+        *count = 0;
+        return NULL;
+    }
+}
+
+/* Free the result returned by sdssplitlen(), or do nothing if 'tokens' is NULL. */
+void sdsfreesplitres(sds *tokens, int count) {
+    if (!tokens) return;
+    while(count--)
+        sdsfree(tokens[count]);
+    free(tokens);
+}
+
+/* Append to the sds string "s" an escaped string representation where
+ * all the non-printable characters (tested with isprint()) are turned into
+ * escapes in the form "\n\r\a...." or "\x<hex-number>".
+ *
+ * After the call, the modified sds string is no longer valid and all the
+ * references must be substituted with the new pointer returned by the call. */
+sds sdscatrepr(sds s, const char *p, size_t len) {
+    s = sdscatlen(s,"\"",1);
+    while(len--) {
+        switch(*p) {
+        case '\\':
+        case '"':
+            s = sdscatprintf(s,"\\%c",*p);
+            break;
+        case '\n': s = sdscatlen(s,"\\n",2); break;
+        case '\r': s = sdscatlen(s,"\\r",2); break;
+        case '\t': s = sdscatlen(s,"\\t",2); break;
+        case '\a': s = sdscatlen(s,"\\a",2); break;
+        case '\b': s = sdscatlen(s,"\\b",2); break;
+        default:
+            if (isprint(*p))
+                s = sdscatprintf(s,"%c",*p);
+            else
+                s = sdscatprintf(s,"\\x%02x",(unsigned char)*p);
+            break;
+        }
+        p++;
+    }
+    return sdscatlen(s,"\"",1);
+}
+
+/* Helper function for sdssplitargs() that returns non zero if 'c'
+ * is a valid hex digit. */
+int is_hex_digit(char c) {
+    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+           (c >= 'A' && c <= 'F');
+}
+
+/* Helper function for sdssplitargs() that converts a hex digit into an
+ * integer from 0 to 15 */
+int hex_digit_to_int(char c) {
+    switch(c) {
+    case '0': return 0;
+    case '1': return 1;
+    case '2': return 2;
+    case '3': return 3;
+    case '4': return 4;
+    case '5': return 5;
+    case '6': return 6;
+    case '7': return 7;
+    case '8': return 8;
+    case '9': return 9;
+    case 'a': case 'A': return 10;
+    case 'b': case 'B': return 11;
+    case 'c': case 'C': return 12;
+    case 'd': case 'D': return 13;
+    case 'e': case 'E': return 14;
+    case 'f': case 'F': return 15;
+    default: return 0;
+    }
+}
+
+/* Split a line into arguments, where every argument can be in the
+ * following programming-language REPL-alike form:
+ *
+ * foo bar "newline are supported\n" and "\xff\x00otherstuff"
+ *
+ * The number of arguments is stored into *argc, and an array
+ * of sds is returned.
+ *
+ * The caller should free the resulting array of sds strings with
+ * sdsfreesplitres().
+ *
+ * Note that sdscatrepr() is able to convert back a string into
+ * a quoted string in the same format sdssplitargs() is able to parse.
+ *
+ * The function returns the allocated tokens on success, even when the
+ * input string is empty, or NULL if the input contains unbalanced
+ * quotes or closed quotes followed by non space characters
+ * as in: "foo"bar or "foo'
+ */
+sds *sdssplitargs(const char *line, int *argc) {
+    const char *p = line;
+    char *current = NULL;
+    char **vector = NULL;
+
+    *argc = 0;
+    while(1) {
+        /* skip blanks */
+        while(*p && isspace(*p)) p++;
+        if (*p) {
+            /* get a token */
+            int inq=0;  /* set to 1 if we are in "quotes" */
+            int insq=0; /* set to 1 if we are in 'single quotes' */
+            int done=0;
+
+            if (current == NULL) current = sdsempty();
+            while(!done) {
+                if (inq) {
+                    if (*p == '\\' && *(p+1) == 'x' &&
+                                             is_hex_digit(*(p+2)) &&
+                                             is_hex_digit(*(p+3)))
+                    {
+                        unsigned char byte;
+
+                        byte = (hex_digit_to_int(*(p+2))*16)+
+                                hex_digit_to_int(*(p+3));
+                        current = sdscatlen(current,(char*)&byte,1);
+                        p += 3;
+                    } else if (*p == '\\' && *(p+1)) {
+                        char c;
+
+                        p++;
+                        switch(*p) {
+                        case 'n': c = '\n'; break;
+                        case 'r': c = '\r'; break;
+                        case 't': c = '\t'; break;
+                        case 'b': c = '\b'; break;
+                        case 'a': c = '\a'; break;
+                        default: c = *p; break;
+                        }
+                        current = sdscatlen(current,&c,1);
+                    } else if (*p == '"') {
+                        /* closing quote must be followed by a space or
+                         * nothing at all. */
+                        if (*(p+1) && !isspace(*(p+1))) goto err;
+                        done=1;
+                    } else if (!*p) {
+                        /* unterminated quotes */
+                        goto err;
+                    } else {
+                        current = sdscatlen(current,p,1);
+                    }
+                } else if (insq) {
+                    if (*p == '\\' && *(p+1) == '\'') {
+                        p++;
+                        current = sdscatlen(current,"'",1);
+                    } else if (*p == '\'') {
+                        /* closing quote must be followed by a space or
+                         * nothing at all. */
+                        if (*(p+1) && !isspace(*(p+1))) goto err;
+                        done=1;
+                    } else if (!*p) {
+                        /* unterminated quotes */
+                        goto err;
+                    } else {
+                        current = sdscatlen(current,p,1);
+                    }
+                } else {
+                    switch(*p) {
+                    case ' ':
+                    case '\n':
+                    case '\r':
+                    case '\t':
+                    case '\0':
+                        done=1;
+                        break;
+                    case '"':
+                        inq=1;
+                        break;
+                    case '\'':
+                        insq=1;
+                        break;
+                    default:
+                        current = sdscatlen(current,p,1);
+                        break;
+                    }
+                }
+                if (*p) p++;
+            }
+            /* add the token to the vector */
+            vector = (char**) realloc(vector,((*argc)+1)*sizeof(char*));
+            vector[*argc] = current;
+            (*argc)++;
+            current = NULL;
+        } else {
+            /* Even on empty input string return something not NULL. */
+            if (vector == NULL) vector = (char**) malloc(sizeof(void*));
+            return vector;
+        }
+    }
+
+err:
+    while((*argc)--)
+        sdsfree(vector[*argc]);
+    free(vector);
+    if (current) sdsfree(current);
+    *argc = 0;
+    return NULL;
+}
+
+/* Modify the string substituting all the occurrences of the set of
+ * characters specified in the 'from' string to the corresponding character
+ * in the 'to' array.
+ *
+ * For instance: sdsmapchars(mystring, "ho", "01", 2)
+ * will have the effect of turning the string "hello" into "0ell1".
+ *
+ * The function returns the sds string pointer, that is always the same
+ * as the input pointer since no resize is needed. */
+sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen) {
+    size_t j, i, l = sdslen(s);
+
+    for (j = 0; j < l; j++) {
+        for (i = 0; i < setlen; i++) {
+            if (s[j] == from[i]) {
+                s[j] = to[i];
+                break;
+            }
+        }
+    }
+    return s;
+}
+
+/* Join an array of C strings using the specified separator (also a C string).
+ * Returns the result as an sds string. */
+sds sdsjoin(char **argv, int argc, char *sep) {
+    sds join = sdsempty();
+    int j;
+
+    for (j = 0; j < argc; j++) {
+        join = sdscat(join, argv[j]);
+        if (j != argc-1) join = sdscat(join,sep);
+    }
+    return join;
+}
+
+/* Like sdsjoin, but joins an array of SDS strings. */
+sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen) {
+    sds join = sdsempty();
+    int j;
+
+    for (j = 0; j < argc; j++) {
+        join = sdscatsds(join, argv[j]);
+        if (j != argc-1) join = sdscatlen(join,sep,seplen);
+    }
+    return join;
+}
+
+/* Wrappers to the allocators used by SDS. Note that SDS will actually
+ * just use the macros defined into sdsalloc.h in order to avoid to pay
+ * the overhead of function calls. Here we define these wrappers only for
+ * the programs SDS is linked to, if they want to touch the SDS internals
+ * even if they use a different allocator. */
+void *sdmalloc(size_t size) { return malloc(size); }
+void *sdrealloc(void *ptr, size_t size) { return realloc(ptr,size); }
+void sdfree(void *ptr) { free(ptr); }
+
+}
+
+// LICENSE_CHANGE_END


### PR DESCRIPTION
Summary:
Splitting the large DuckDB amalgamated .cpp file into 8 units, which
can be compiled in parallel. DuckDB supports a --splits=8 parameter when
calling the amalgamation script.
With this change, a recompilation of duckdb code goes from +3mins to
<50sec in my local development environment. allow-large-files
.

Differential Revision: D37572466

