### PR TITLE
Remove dynamic cast from getFlatBool

### DIFF
--- a/velox/expression/ControlExpr.h
+++ b/velox/expression/ControlExpr.h
@@ -46,18 +46,6 @@ class SpecialForm : public Expr {
             trackCpuUsage) {}
 };
 
-enum class BooleanMix { kAllTrue, kAllFalse, kAllNull, kMixNonNull, kMix };
-
-BooleanMix getFlatBool(
-    BaseVector* vector,
-    const SelectivityVector& activeRows,
-    EvalCtx& context,
-    BufferPtr* tempValues,
-    BufferPtr* tempNulls,
-    bool mergeNullsToValues,
-    const uint64_t** valuesOut,
-    const uint64_t** nullsOut);
-
 class ConstantExpr : public SpecialForm {
  public:
   ConstantExpr(TypePtr type, variant value)


### PR DESCRIPTION
Dynamic cast in getFlatBool showed up on the profile for an expression from ML
preprocessing: `if(floor(c = 1.0, 1.0, 0.0))`. This change removes it. 

`auto values = vector->asFlatVector<bool>()->rawValues<uint64_t>();`

->

`auto values = vector->asUnchecked<FlatVector<bool>>()->rawValues<uint64_t>();`

Also, removed dead code from SwitchExpr::evalSpecialForm and moved getFlatBool
from .h to .cpp to speed up builds.