### PR TITLE
Optimize row_constructor Presto function

### DIFF
--- a/velox/functions/prestosql/RowFunction.cpp
+++ b/velox/functions/prestosql/RowFunction.cpp
@@ -35,12 +35,7 @@ class RowFunction : public exec::VectorFunction {
         rows.size(),
         std::move(argsCopy),
         0 /*nullCount*/);
-    if (*result) {
-      BaseVector::ensureWritable(rows, outputType, context->pool(), result);
-      (*result)->copy(row.get(), rows, nullptr);
-    } else {
-      *result = std::move(row);
-    }
+    context->moveOrCopyResult(row, rows, *result);
   }
 
   bool isDefaultNullBehavior() const override {

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -127,3 +127,7 @@ target_link_libraries(velox_functions_benchmarks_string_writer_no_nulls
 add_executable(velox_functions_prestosql_benchmarks_zip ZipBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_zip
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_row Row.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_row
+                      ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/Row.cpp
+++ b/velox/functions/prestosql/benchmarks/Row.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include "velox/functions/Macros.h"
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+
+class RowFunctionBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  RowFunctionBenchmark() : FunctionBenchmarkBase() {
+    functions::prestosql::registerAllScalarFunctions();
+  }
+
+  void run(const std::string& expr) {
+    folly::BenchmarkSuspender suspender;
+    vector_size_t size = 1'000;
+
+    auto rowVector = vectorMaker_.rowVector({
+        vectorMaker_.flatVector<int64_t>(size, [](auto row) { return row; }),
+        vectorMaker_.flatVector<double>(
+            size, [](auto row) { return row * 0.1; }),
+    });
+
+    auto exprSet = compileExpression(expr, rowVector->type());
+    suspender.dismiss();
+
+    int cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+};
+
+BENCHMARK(noCopy) {
+  RowFunctionBenchmark benchmark;
+  benchmark.run("row_constructor(c0, c1)");
+}
+
+BENCHMARK(copyMostlyFlat) {
+  RowFunctionBenchmark benchmark;
+  benchmark.run(
+      "if(c0 > 100, row_constructor(c0, c1), row_constructor(1, 0.1))");
+}
+
+BENCHMARK(copyMostlyConst) {
+  RowFunctionBenchmark benchmark;
+  benchmark.run(
+      "if(c0 < 100, row_constructor(c0, c1), row_constructor(1, 0.1))");
+}
+
+} // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -123,6 +123,11 @@ class RowVector : public BaseVector {
       vector_size_t sourceIndex,
       vector_size_t count) override;
 
+  void copy(
+      const BaseVector* source,
+      const SelectivityVector& rows,
+      const vector_size_t* toSourceRow) override;
+
   void move(vector_size_t source, vector_size_t target) override;
 
   uint64_t retainedSize() const override {

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -245,6 +245,13 @@ class SelectivityVector {
     }
   }
 
+  /// Set null bits in 'nulls' for active rows.
+  void setNulls(BufferPtr& nulls) const {
+    VELOX_CHECK_NOT_NULL(nulls);
+    bits::andWithNegatedBits(
+        nulls->asMutable<uint64_t>(), bits_.data(), begin_, end_);
+  }
+
   /**
    * Merges the valid vector of another SelectivityVector by or'ing
    * them together. This is used to support memoization where a state


### PR DESCRIPTION
row_constructor function used to copy data in cases when it was not necessary.
Fix this by using `context->moveOrCopyResult`.

Also, optimize RowVector::copy to copy one column at a time instead of one cell
(value) at a time.

Added a benchmark.

Before:

```
============================================================================
[...]unctions/prestosql/benchmarks/Row.cpp     relative  time/iter   iters/s
============================================================================
noCopy                                                    791.06us     1.26K
copyMostlyFlat                                              4.28ms    233.54
copyMostlyConst                                            24.67ms     40.53
```

After

```
============================================================================
[...]unctions/prestosql/benchmarks/Row.cpp     relative  time/iter   iters/s
============================================================================
noCopy                                                    760.95us     1.31K
copyMostlyFlat                                              1.69ms    592.85
copyMostlyConst                                             1.50ms    664.71
```