### PR TITLE
Add Right Semi Join

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -931,7 +931,15 @@ class PartitionedOutputNode : public PlanNode {
   const RowTypePtr outputType_;
 };
 
-enum class JoinType { kInner, kLeft, kRight, kFull, kLeftSemi, kAnti };
+enum class JoinType {
+  kInner,
+  kLeft,
+  kRight,
+  kFull,
+  kLeftSemi,
+  kRightSemi,
+  kAnti
+};
 
 inline const char* joinTypeName(JoinType joinType) {
   switch (joinType) {
@@ -945,6 +953,8 @@ inline const char* joinTypeName(JoinType joinType) {
       return "FULL";
     case JoinType::kLeftSemi:
       return "LEFT SEMI";
+    case JoinType::kRightSemi:
+      return "RIGHT SEMI";
     case JoinType::kAnti:
       return "ANTI";
   }
@@ -969,6 +979,10 @@ inline bool isFullJoin(JoinType joinType) {
 
 inline bool isLeftSemiJoin(JoinType joinType) {
   return joinType == JoinType::kLeftSemi;
+}
+
+inline bool isRightSemiJoin(JoinType joinType) {
+  return joinType == JoinType::kRightSemi;
 }
 
 inline bool isAntiJoin(JoinType joinType) {
@@ -1019,6 +1033,10 @@ class AbstractJoinNode : public PlanNode {
 
   bool isLeftSemiJoin() const {
     return joinType_ == JoinType::kLeftSemi;
+  }
+
+  bool isRightSemiJoin() const {
+    return joinType_ == JoinType::kRightSemi;
   }
 
   bool isAntiJoin() const {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -107,16 +107,18 @@ HashBuild::HashBuild(
         true, // hasProbedFlag
         mappedMemory_);
   } else {
-    // Semi and anti join with no extra filter only needs to know whether there
-    // is a match. Hence, no need to store entries with duplicate keys.
+    // (Left) semi and anti join with no extra filter only needs to know whether
+    // there is a match. Hence, no need to store entries with duplicate keys.
     const bool dropDuplicates = !joinNode->filter() &&
         (joinNode->isLeftSemiJoin() || joinNode->isAntiJoin());
-
+    // Right semi join needs to tag build rows that were probed.
+    const bool needProbedFlag = joinNode->isRightSemiJoin();
+    // Ignore null keys
     table_ = HashTable<true>::createForJoin(
         std::move(keyHashers),
         dependentTypes,
         !dropDuplicates, // allowDuplicates
-        false, // hasProbedFlag
+        needProbedFlag, // hasProbedFlag
         mappedMemory_);
   }
   analyzeKeys_ = table_->hashMode() != BaseHashTable::HashMode::kHash;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -217,7 +217,7 @@ class HashProbe : public Operator {
   };
 
   /// True if this is the last HashProbe operator in the pipeline. It is
-  /// responsible for producing matching build-side rows for the right\ semi
+  /// responsible for producing matching build-side rows for the right semi
   /// join and non-matching build-side rows for right join and full join.
   bool lastProbe_{false};
 

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -75,9 +75,10 @@ class HashProbe : public Operator {
   // producer.
   void clearIdentityProjectedOutput();
 
-  // Populate output columns with build-side rows that didn't match join
-  // condition.
-  RowVectorPtr getNonMatchingOutputForRightJoin();
+  /// Populate output columns with matching build-side rows
+  /// for the right semi join and non-matching build-side rows
+  /// for right join and full join.
+  RowVectorPtr getBuildSideOutput();
 
   // Populate filter input columns.
   void fillFilterInput(vector_size_t size);
@@ -216,10 +217,11 @@ class HashProbe : public Operator {
   };
 
   /// True if this is the last HashProbe operator in the pipeline. It is
-  /// responsible for producing non-matching build-side rows for the right join.
-  bool lastRightJoinProbe_{false};
+  /// responsible for producing matching build-side rows for the right\ semi
+  /// join and non-matching build-side rows for right join and full join.
+  bool lastProbe_{false};
 
-  BaseHashTable::NotProbedRowsIterator rightJoinIterator_;
+  BaseHashTable::RowsIterator lastProbeIterator_;
 
   /// For left and anti join with filter, tracks the probe side rows which had
   /// matches on the build side but didn't pass the filter.

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -210,6 +210,80 @@ class RowContainer {
   static inline uint8_t nullMask(int32_t nullOffset) {
     return 1 << (nullOffset & 7);
   }
+
+  enum class ProbeType { kAll, kProbed, kNotProbed };
+
+  template <ProbeType probeType>
+  int32_t listRows(
+      RowContainerIterator* iter,
+      int32_t maxRows,
+      uint64_t maxBytes,
+      char** rows) {
+    int32_t count = 0;
+    uint64_t totalBytes = 0;
+    VELOX_CHECK_EQ(rows_.numLargeAllocations(), 0);
+    auto numAllocations = rows_.numSmallAllocations();
+    if (iter->allocationIndex == 0 && iter->runIndex == 0 &&
+        iter->rowOffset == 0) {
+      iter->normalizedKeysLeft = numRowsWithNormalizedKey_;
+    }
+    int32_t rowSize = fixedRowSize_ +
+        (iter->normalizedKeysLeft > 0 ? sizeof(normalized_key_t) : 0);
+    for (auto i = iter->allocationIndex; i < numAllocations; ++i) {
+      auto allocation = rows_.allocationAt(i);
+      auto numRuns = allocation->numRuns();
+      for (auto runIndex = iter->runIndex; runIndex < numRuns; ++runIndex) {
+        memory::MappedMemory::PageRun run = allocation->runAt(runIndex);
+        auto data = run.data<char>();
+        int64_t limit;
+        if (i == numAllocations - 1 && runIndex == rows_.currentRunIndex()) {
+          limit = rows_.currentOffset();
+        } else {
+          limit = run.numPages() * memory::MappedMemory::kPageSize;
+        }
+        auto row = iter->rowOffset;
+        while (row + rowSize <= limit) {
+          rows[count++] = data + row +
+              (iter->normalizedKeysLeft > 0 ? sizeof(normalized_key_t) : 0);
+          row += rowSize;
+          if (--iter->normalizedKeysLeft == 0) {
+            rowSize -= sizeof(normalized_key_t);
+          }
+          if (bits::isBitSet(rows[count - 1], freeFlagOffset_)) {
+            --count;
+            continue;
+          }
+          if constexpr (probeType == ProbeType::kNotProbed) {
+            if (bits::isBitSet(rows[count - 1], probedFlagOffset_)) {
+              --count;
+              continue;
+            }
+          }
+          if constexpr (probeType == ProbeType::kProbed) {
+            if (not(bits::isBitSet(rows[count - 1], probedFlagOffset_))) {
+              --count;
+              continue;
+            }
+          }
+          totalBytes += rowSize;
+          if (rowSizeOffset_) {
+            totalBytes += variableRowSize(rows[count - 1]);
+          }
+          if (count == maxRows || totalBytes > maxBytes) {
+            iter->rowOffset = row;
+            iter->runIndex = runIndex;
+            iter->allocationIndex = i;
+            return count;
+          }
+        }
+        iter->rowOffset = 0;
+      }
+      iter->runIndex = 0;
+    }
+    iter->allocationIndex = std::numeric_limits<int32_t>::max();
+    return count;
+  }
+
   // Extracts up to 'maxRows' rows starting at the position of
   // 'iter'. A default constructed or reset iter starts at the
   // beginning. Returns the number of rows written to 'rows'. Returns
@@ -220,11 +294,11 @@ class RowContainer {
       int32_t maxRows,
       uint64_t maxBytes,
       char** rows) {
-    return listRows<false>(iter, maxRows, maxBytes, rows);
+    return listRows<ProbeType::kAll>(iter, maxRows, maxBytes, rows);
   }
 
   int32_t listRows(RowContainerIterator* iter, int32_t maxRows, char** rows) {
-    return listRows<false>(iter, maxRows, kUnlimited, rows);
+    return listRows<ProbeType::kAll>(iter, maxRows, kUnlimited, rows);
   }
 
   /// Sets 'probed' flag for the specified rows. Used by the right and full join
@@ -233,15 +307,6 @@ class RowContainer {
   /// build rows. In case of the full join, 'rows' may include null entries that
   /// correspond to probe rows with no match.
   void setProbedFlag(char** rows, int32_t numRows);
-
-  /// Returns rows with 'probed' flag unset. Used by the right and full join.
-  int32_t listNotProbedRows(
-      RowContainerIterator* iter,
-      int32_t maxRows,
-      uint64_t maxBytes,
-      char** rows) {
-    return listRows<true>(iter, maxRows, maxBytes, rows);
-  }
 
   // Returns true if 'row' at 'column' equals the value at 'index' in
   // 'decoded'. 'mayHaveNulls' specifies if nulls need to be checked. This is
@@ -670,71 +735,6 @@ class RowContainer {
       int32_t offset,
       int32_t nullByte = 0,
       uint8_t nullMask = 0);
-
-  template <bool nonProbedRowsOnly>
-  int32_t listRows(
-      RowContainerIterator* iter,
-      int32_t maxRows,
-      uint64_t maxBytes,
-      char** rows) {
-    int32_t count = 0;
-    uint64_t totalBytes = 0;
-    VELOX_CHECK_EQ(rows_.numLargeAllocations(), 0);
-    auto numAllocations = rows_.numSmallAllocations();
-    if (iter->allocationIndex == 0 && iter->runIndex == 0 &&
-        iter->rowOffset == 0) {
-      iter->normalizedKeysLeft = numRowsWithNormalizedKey_;
-    }
-    int32_t rowSize = fixedRowSize_ +
-        (iter->normalizedKeysLeft > 0 ? sizeof(normalized_key_t) : 0);
-    for (auto i = iter->allocationIndex; i < numAllocations; ++i) {
-      auto allocation = rows_.allocationAt(i);
-      auto numRuns = allocation->numRuns();
-      for (auto runIndex = iter->runIndex; runIndex < numRuns; ++runIndex) {
-        memory::MappedMemory::PageRun run = allocation->runAt(runIndex);
-        auto data = run.data<char>();
-        int64_t limit;
-        if (i == numAllocations - 1 && runIndex == rows_.currentRunIndex()) {
-          limit = rows_.currentOffset();
-        } else {
-          limit = run.numPages() * memory::MappedMemory::kPageSize;
-        }
-        auto row = iter->rowOffset;
-        while (row + rowSize <= limit) {
-          rows[count++] = data + row +
-              (iter->normalizedKeysLeft > 0 ? sizeof(normalized_key_t) : 0);
-          row += rowSize;
-          if (--iter->normalizedKeysLeft == 0) {
-            rowSize -= sizeof(normalized_key_t);
-          }
-          if (bits::isBitSet(rows[count - 1], freeFlagOffset_)) {
-            --count;
-            continue;
-          }
-          if constexpr (nonProbedRowsOnly) {
-            if (bits::isBitSet(rows[count - 1], probedFlagOffset_)) {
-              --count;
-              continue;
-            }
-          }
-          totalBytes += rowSize;
-          if (rowSizeOffset_) {
-            totalBytes += variableRowSize(rows[count - 1]);
-          }
-          if (count == maxRows || totalBytes > maxBytes) {
-            iter->rowOffset = row;
-            iter->runIndex = runIndex;
-            iter->allocationIndex = i;
-            return count;
-          }
-        }
-        iter->rowOffset = 0;
-      }
-      iter->runIndex = 0;
-    }
-    iter->allocationIndex = std::numeric_limits<int32_t>::max();
-    return count;
-  }
 
   static void extractComplexType(
       const char* const* rows,

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -691,7 +691,7 @@ TEST_F(HashJoinTest, rightSemiJoinWithFilter) {
   createDuckDbTable("t", {rightVectors});
 
   auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
-  auto Plan = [&](const std::string& filter) -> core::PlanNodePtr {
+  auto plan = [&](const std::string& filter) -> core::PlanNodePtr {
     return PlanBuilder(planNodeIdGenerator)
         .values({leftVectors})
         .hashJoin(
@@ -706,35 +706,35 @@ TEST_F(HashJoinTest, rightSemiJoinWithFilter) {
   {
     // Always true filter.
     auto task = assertQuery(
-        Plan("u1 > -1"),
+        plan("u1 > -1"),
         "SELECT t.* FROM t WHERE EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND u1 > -1)");
     EXPECT_EQ(getOutputPositions(task, "HashProbe"), 1'000);
   }
   {
     // Always true filter.
     auto task = assertQuery(
-        Plan("t1 > -1"),
+        plan("t1 > -1"),
         "SELECT t.* FROM t WHERE EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND t1 > -1)");
     EXPECT_EQ(getOutputPositions(task, "HashProbe"), 1'000);
   }
   {
     // Always false filter.
     auto task = assertQuery(
-        Plan("u1 > 100000"),
+        plan("u1 > 100000"),
         "SELECT t.* FROM t WHERE EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND u1 > 100000)");
     EXPECT_EQ(getOutputPositions(task, "HashProbe"), 0);
   }
   {
     // Always false filter.
     auto task = assertQuery(
-        Plan("t1 > 100000"),
+        plan("t1 > 100000"),
         "SELECT t.* FROM t WHERE EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND t1 > 100000)");
     EXPECT_EQ(getOutputPositions(task, "HashProbe"), 0);
   }
   {
     // Selective filter.
     auto task = assertQuery(
-        Plan("u1%5 = 0"),
+        plan("u1%5 = 0"),
         "SELECT t.* FROM t WHERE EXISTS (SELECT u0, u1 FROM u WHERE t0 = u0 AND u1 %5 = 0)");
     EXPECT_EQ(getOutputPositions(task, "HashProbe"), 200);
   }

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -734,8 +734,8 @@ TEST_F(HashJoinTest, rightSemiJoinWithFilter) {
   {
     // Selective filter.
     auto task = assertQuery(
-        plan("u1%5 = 0"),
-        "SELECT t.* FROM t WHERE EXISTS (SELECT u0, u1 FROM u WHERE t0 = u0 AND u1 %5 = 0)");
+        plan("u1 % 5 = 0"),
+        "SELECT t.* FROM t WHERE EXISTS (SELECT u0, u1 FROM u WHERE t0 = u0 AND u1 % 5 = 0)");
     EXPECT_EQ(getOutputPositions(task, "HashProbe"), 200);
   }
 }

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -135,25 +135,20 @@ class HashJoinTest : public HiveConnectorTestBase {
     return stats[operatorIndex].inputPositions;
   }
 
-  static void ensureTaskCompletion(exec::Task* task) {
-    // ASSERT_TRUE requires a function with return type void.
-    ASSERT_TRUE(waitForTaskCompletion(task));
-  }
-
   static uint64_t getOutputPositions(
       const std::shared_ptr<Task>& task,
       const core::PlanNodeId planId,
       const std::string& operatorType) {
-    ensureTaskCompletion(task.get());
+    uint64_t count = 0;
     for (const auto& pipelineStat : task->taskStats().pipelineStats) {
       for (const auto& operatorStat : pipelineStat.operatorStats) {
         if (operatorStat.planNodeId == planId &&
             operatorStat.operatorType == operatorType) {
-          return operatorStat.outputPositions;
+          count += operatorStat.outputPositions;
         }
       }
     }
-    return -1;
+    return count;
   }
 };
 


### PR DESCRIPTION
A Right Semi Join is implemented as follows: For every row from the left/probe side, 
matching rows from the right/build side are returned. Rows from the build side are returned 
each at most once. No columns from the probe side are returned.

The Right Semi Join implementation is blocking because all the probe
 side rows are processed first before returning the 'probed' build side rows. 
This is helpful for queries like TPC-H q4 where there is a downstream blocking operator.

There is no SQL statement that purely represents a Right Semi Join.
EXISTS/IN queries can be implemented using a left or a Right Semi Join,
whichever keeps the build size small.

Resolves https://github.com/facebookincubator/velox/issues/1884