### PR TITLE
Do not copy StripeMetaDataCache contents

### DIFF
--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -377,7 +377,8 @@ void SsdFile::write(std::vector<CachePin>& pins) {
     storeIndex += numWritten;
   }
 
-  if (bytesAfterCheckpoint_ > checkpointIntervalBytes_) {
+  if (checkpointIntervalBytes_ &&
+      bytesAfterCheckpoint_ > checkpointIntervalBytes_) {
     checkpoint();
   }
 }

--- a/velox/dwio/dwrf/reader/StripeStream.cpp
+++ b/velox/dwio/dwrf/reader/StripeStream.cpp
@@ -323,7 +323,12 @@ StripeStreamsImpl::getIndexStreamFromCache(
     if (indexBase) {
       auto offset = info.getOffset();
       auto length = info.getLength();
-
+      if (auto cacheInput =
+              dynamic_cast<dwio::common::CacheInputStream*>(indexBase.get())) {
+        cacheInput->Skip(offset);
+        cacheInput->setRemainingBytes(length);
+        return indexBase;
+      }
       const void* start;
       int32_t ignored;
       DWIO_ENSURE(indexBase->Next(&start, &ignored), "failed to read index");

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -482,3 +482,20 @@ target_link_libraries(
   ${FOLLY}
   ${FOLLY_BENCHMARK}
   ${FMT})
+
+add_executable(velox_dwio_cache_test CacheInputTest.cpp)
+
+add_test(velox_dwio_cache_test velox_dwio_cache_test)
+
+target_link_libraries(
+  velox_dwio_cache_test
+  ${VELOX_LINK_LIBS}
+  velox_temp_path
+  ${DOUBLE_CONVERSION}
+  ${FOLLY_WITH_DEPENDENCIES}
+  ${FMT}
+  ${LZ4}
+  ${LZO}
+  ${ZSTD}
+  ${ZLIB_LIBRARIES}
+  ${TEST_LINK_LIBS})


### PR DESCRIPTION
Do not copy StripeMetaDataCache contents, re-add CacheInputTest.cpp

When data comes from a CacheInputStream, the the DWRF metadata at the
end of the file is normally read into cache. This data was then copied
into a new contiguous block of memory for each stripe of the file. In
one case this would be 6.5MB each time. This would be more than all
other memory allocation combined and the minor faults this caused
would drive the system CPU to be over half of total CPU. Fixing this
drops system CPU down to ~20% of total.

Now, instead of copying the metadata, the StripeMetadataCache gives
out a CacheInputStream that is scoped to a range of bytes inside the
cached data. Because the stream is used for reading protobufs, the
stream must end after the serialized metadata, otherwise the protobuf
decoder will read past end. Hence we add an interface to clone
CacheInputStreams and to limit them to a subrange of the originally
covered range of bytes.

The code is covered vy existing tests in TableScanTest.cpp, which all
access this metadata.

Adds a test for the new functions of CacheInputStream.

Enables the dwrf/test/CacheInputTest.cpp. In so doing, removes extra
logging of eviction in non-checkpointed SSD cache mode, since this
makes noise in the error log.

