### PR TITLE
Add DWRF pushdown filters for structs and struct members

### DIFF
--- a/velox/dwio/common/FormatData.h
+++ b/velox/dwio/common/FormatData.h
@@ -77,7 +77,8 @@ class FormatData {
   /// existence of an actual null, though. For example, if the format
   /// is ORC and there is a nulls decoder for the column this returns
   /// true. False if it is certain there is no null in the range of
-  /// 'this'.
+  /// 'this'. In ORC this means the column does not add nulls but does
+  /// not exclude nulls coming from enclosing null structs.
   virtual bool hasNulls() const = 0;
 
   /// Seeks the position to the 'index'th row group for the streams
@@ -97,6 +98,15 @@ class FormatData {
       const velox::common::ScanSpec& scanSpec,
       uint64_t rowsPerRowGroup,
       const StatsContext& writerContext) = 0;
+
+  /// If the format divides data into even-sized runs for purposes of
+  /// column statistics and random access, returns the number of rows
+  /// in such a group. This is the row group size for ORC and nullopt
+  /// for Parquet, where row groups are physically separate runs of
+  /// arbitrary nunber of rows.
+  virtual std::optional<int64_t> rowsPerRowGroup() const {
+    return std::nullopt;
+  }
 
   /// Test if the 'i'th RowGroup can potentially match the 'filter' using the
   /// RowGroup's statistics on all columns. Returns true if all columns in this

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -178,11 +178,16 @@ class SelectiveColumnReader {
 
   // Advances to 'offset', so that the next item to be read is the
   // offset-th from the start of stripe.
-  void seekTo(vector_size_t offset, bool readsNullsOnly);
+  virtual void seekTo(vector_size_t offset, bool readsNullsOnly);
 
-  // Positions this at the start of 'index'th row group. Interpretation of
-  // 'index' depends on format.
-  virtual void seekToRowGroup(uint32_t index) = 0;
+  // Positions this at the start of 'index'th row
+  // group. Interpretation of 'index' depends on format. Clears counts
+  // of skipped enclosing struct nulls for formats where nulls are
+  // recorded at each nesting level, i.e. not rep-def.
+  virtual void seekToRowGroup(uint32_t index) {
+    numParentNulls_ = 0;
+    parentNullsRecordedTo_ = 0;
+  }
 
   const TypePtr& type() const {
     return type_;
@@ -388,6 +393,34 @@ class SelectiveColumnReader {
     return scanState_;
   }
 
+  // If 'this' has values set for returning as dictionary-encoded,
+  // converts these values to flat so that additional values can be
+  // added without reference to dictionary. Resets dictionary info in
+  // 'scanState_'. No-op for non-string readers. This is needed when
+  // scanning a Parquet ColumnChunk that begins with dictionaries and
+  // converts to direct in mid-read.
+  virtual void dedictionarize() {}
+
+  // A reader nested inside nullable containers has fewer rows than
+  // the top level table. addParentNulls records how many parent nulls
+  // there are between the position of 'this' and 'rows.back() + 1',
+  // i.e. the position of the scan in top level rows. 'firstRowInNulls' is
+  // the top level row corresponding to the first bit in
+  // 'nulls'. 'nulls' is in terms of top level rows and represents all
+  // null parents at any enclosing level. 'nulls' is nullptr if there are no
+  // parent nulls.
+  void addParentNulls(
+      int32_t firstRowInNulls,
+      const uint64_t* FOLLY_NULLABLE nulls,
+      RowSet rows);
+
+  // When skipping rows in a struct, records how many parent nulls at
+  // any level there are between top level row 'from' and 'to'. If
+  // called many times, the 'from' of the next should be the 'to' of
+  // the previous.
+  void
+  addSkippedParentNulls(vector_size_t from, vector_size_t to, int32_t numNulls);
+
   static constexpr int8_t kNoValueSize = -1;
   static constexpr uint32_t kRowGroupNotSet = ~0;
 
@@ -403,20 +436,12 @@ class SelectiveColumnReader {
   // 'extraSpace' bits worth of space in the nulls buffer.
   void prepareNulls(RowSet rows, bool hasNulls, int32_t extraRows = 0);
 
+ protected:
   // Filters 'rows' according to 'is_null'. Only applies to cases where
   // readsNullsOnly() is true.
   template <typename T>
   void filterNulls(RowSet rows, bool isNull, bool extractValues);
 
-  // If 'this' has values set for returning as dictionary-encoded,
-  // converts these values to flat so that additional values can be
-  // added without reference to dictionary. Resets dictionary info in
-  // 'scanState_'. No-op for non-string readers. This is needed when
-  // scanning a Parquet ColumnChunk that begins with dictionaries and
-  // converts to direct in mid-read.
-  virtual void dedictionarize() {}
-
- protected:
   template <typename T>
   void
   prepareRead(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls);
@@ -447,6 +472,14 @@ class SelectiveColumnReader {
   template <typename T, typename TVector>
   void compactScalarValues(RowSet rows, bool isFinal);
 
+  // Compacts values extracted for a complex type column with
+  // filter. The values for 'rows' are shifted to be consecutive at
+  // indices [0..rows.size() - 1]'. 'move' is a function that takes
+  // two indices source and target and moves the value at source to
+  // target. target is <= source for all calls.
+  template <typename Move>
+  void compactComplexValues(RowSet rows, Move move, bool isFinal);
+
   template <typename T, typename TVector>
   void upcastScalarValues(RowSet rows);
 
@@ -475,6 +508,16 @@ class SelectiveColumnReader {
 
   // Row number after last read row, relative to stripe start.
   vector_size_t readOffset_ = 0;
+
+  // Number of parent nulls between 'readOffset_' and 'parentNullsRecordedTo_'.
+  // When skipping, subtract the parent nulls from the skip distance because the
+  // child does not have values for these.
+  int32_t numParentNulls_{0};
+
+  // The end of the row range starting at 'readOffset_' to which
+  // 'numParentNulls_' applies.
+  int32_t parentNullsRecordedTo_{0};
+
   // The rows to process in read(). References memory supplied by
   // caller. The values must remain live until the next call to read().
   RowSet inputRows_;

--- a/velox/dwio/common/SelectiveColumnReaderInternal.h
+++ b/velox/dwio/common/SelectiveColumnReaderInternal.h
@@ -283,23 +283,68 @@ inline int32_t sizeOfIntKind(TypeKind kind) {
   }
 }
 
+template <typename Move>
+void SelectiveColumnReader::compactComplexValues(
+    RowSet rows,
+    Move move,
+    bool isFinal) {
+  VELOX_CHECK_LE(rows.size(), outputRows_.size());
+  VELOX_CHECK(!rows.empty());
+  if (rows.size() == outputRows_.size()) {
+    return;
+  }
+  RowSet sourceRows;
+  // The row numbers corresponding to elements in 'values_' are in
+  // 'valueRows_' if values have been accessed before. Otherwise
+  // they are in 'outputRows_' if these are non-empty (there is a
+  // filter) and in 'inputRows_' otherwise.
+  if (!valueRows_.empty()) {
+    sourceRows = valueRows_;
+  } else if (!outputRows_.empty()) {
+    sourceRows = outputRows_;
+  } else {
+    sourceRows = inputRows_;
+  }
+  if (valueRows_.empty()) {
+    valueRows_.resize(rows.size());
+  }
+  vector_size_t rowIndex = 0;
+  auto nextRow = rows[rowIndex];
+  bool moveNulls = shouldMoveNulls(rows);
+  for (size_t i = 0; i < numValues_; i++) {
+    if (sourceRows[i] < nextRow) {
+      continue;
+    }
+
+    VELOX_DCHECK(sourceRows[i] == nextRow);
+    // The value at i is moved to be the value at 'rowIndex'.
+    move(i, rowIndex);
+    if (moveNulls && rowIndex != i) {
+      bits::setBit(
+          rawResultNulls_, rowIndex, bits::isBitSet(rawResultNulls_, i));
+    }
+    if (!isFinal) {
+      valueRows_[rowIndex] = nextRow;
+    }
+    rowIndex++;
+    if (rowIndex >= rows.size()) {
+      break;
+    }
+    nextRow = rows[rowIndex];
+  }
+  numValues_ = rows.size();
+  valueRows_.resize(numValues_);
+}
+
 template <typename T>
 void SelectiveColumnReader::filterNulls(
     RowSet rows,
     bool isNull,
     bool extractValues) {
-  if (!formatData_->hasNulls()) {
-    if (isNull) {
-      // The whole stripe will be empty. We do not update
-      // 'readOffset' since nothing is read from either nulls or data.
-      return;
-    }
-    // All pass. We do not update 'readOffset' because neither nulls
-    // or data will be read for the whole stripe.
-    setOutputRows(rows);
-    return;
-  }
   bool isDense = rows.back() == rows.size() - 1;
+  // We decide is (not) null based on 'nullsInReadRange_'. This may be
+  // set due to nulls in enclosing structs even if the column itself
+  // does not add nulls.
   auto rawNulls =
       nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
   if (isNull) {

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -106,6 +106,12 @@ class SelectiveStructColumnReader : public SelectiveColumnReader {
   }
 
  protected:
+  // Records the number of nulls added by 'this' between the end
+  // position of each child reader and the end of the range of
+  // 'read(). This must be done also if a child is not read so that we
+  // know how much to skip when seeking forward within the row group.
+  void recordParentNullsInChildren(vector_size_t offset, RowSet rows);
+
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<SelectiveColumnReader>> children_;
   // Sequence number of output batch. Checked against ColumnLoaders

--- a/velox/dwio/common/tests/utils/BatchMaker.h
+++ b/velox/dwio/common/tests/utils/BatchMaker.h
@@ -22,6 +22,13 @@
 
 namespace facebook::velox::test {
 
+// sets child elements of null row/array/map to null. the result of
+// 'a.b.c is null' can be determined just by looking at 'c' because
+// a null parent 'b' is also null in 'c'. This makes generating
+// testing filters simpler. Non-null content under a null container
+// cannot be represented in file formats in any case.
+void propagateNullsRecursive(BaseVector& vector);
+
 struct BatchMaker {
   static VectorPtr createBatch(
       const std::shared_ptr<const Type>& type,

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -436,8 +436,11 @@ SubfieldFilters FilterGenerator::makeSubfieldFilters(
       case TypeKind::DOUBLE:
         stats = makeStats<TypeKind::DOUBLE>(vector->type(), rowType_);
         break;
-        // TODO:
-        // Add support for TTypeKind::IMESTAMP and TypeKind::ROW
+      case TypeKind::ROW:
+        stats = makeStats<TypeKind::ROW>(vector->type(), rowType_);
+        break;
+      // TODO:
+      // Add support for TTypeKind::IMESTAMP.
       default:
         VELOX_CHECK(
             false,
@@ -457,7 +460,9 @@ SubfieldFilters FilterGenerator::makeSubfieldFilters(
           subfield,
           hitRows);
     }
-    filters[Subfield(filterSpec.field)] = std::move(filter);
+    if (filter) {
+      filters[Subfield(filterSpec.field)] = std::move(filter);
+    }
   }
 
   return filters;

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -78,7 +78,7 @@ class DwrfData : public dwio::common::FormatData {
   // and returns a PositionsProvider for the other streams.
   dwio::common::PositionProvider seekToRowGroup(uint32_t index) override;
 
-  uint32_t rowsPerRowGroup() const {
+  std::optional<int64_t> rowsPerRowGroup() const override {
     return rowsPerRowGroup_;
   }
 

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -51,6 +51,7 @@ class SelectiveByteRleColumnReader
   }
 
   void seekToRowGroup(uint32_t index) override {
+    SelectiveColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->seekToRowGroup(index);
     if (boolRle_) {
       boolRle_->seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -34,6 +34,7 @@ class SelectiveIntegerDictionaryColumnReader
       uint32_t numBytes);
 
   void seekToRowGroup(uint32_t index) override {
+    SelectiveColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->seekToRowGroup(index);
     if (inDictionaryReader_) {
       inDictionaryReader_->seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -55,6 +55,7 @@ class SelectiveIntegerDirectColumnReader
   }
 
   void seekToRowGroup(uint32_t index) override {
+    SelectiveColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->seekToRowGroup(index);
     ints->seekToRowGroup(positionsProvider);
 

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -185,6 +185,7 @@ class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
   }
 
   void seekToRowGroup(uint32_t index) override {
+    SelectiveColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->seekToRowGroup(index);
     length_->seekToRowGroup(positionsProvider);
 
@@ -221,6 +222,7 @@ class SelectiveMapColumnReader : public SelectiveRepeatedColumnReader {
   }
 
   void seekToRowGroup(uint32_t index) override {
+    SelectiveColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->seekToRowGroup(index);
 
     length_->seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -32,6 +32,7 @@ class SelectiveStringDictionaryColumnReader
       common::ScanSpec& scanSpec);
 
   void seekToRowGroup(uint32_t index) override {
+    SelectiveColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->as<DwrfData>().seekToRowGroup(index);
     if (strideDictStream_) {
       strideDictStream_->seekToPosition(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
@@ -31,6 +31,7 @@ class SelectiveStringDirectColumnReader
       common::ScanSpec& scanSpec);
 
   void seekToRowGroup(uint32_t index) override {
+    SelectiveColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->seekToRowGroup(index);
     blobStream_->seekToPosition(positionsProvider);
     lengthDecoder_->seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -30,7 +30,10 @@ class SelectiveStructColumnReader
       DwrfParams& params,
       common::ScanSpec& scanSpec);
 
+  void seekTo(vector_size_t offset, bool readsNullsOnly) override;
+
   void seekToRowGroup(uint32_t index) override {
+    SelectiveColumnReader::seekToRowGroup(index);
     if (isTopLevel_ && !formatData_->hasNulls()) {
       readOffset_ = index * rowsPerRowGroup_;
       return;
@@ -60,6 +63,12 @@ class SelectiveStructColumnReader
       reader->setReadOffset(nextRowGroup * rowsPerRowGroup_);
     }
   }
+
+  // Records the number of nulls added by 'this' between the end
+  // position of each child reader and the of the range of
+  // 'read(). This must be done also if a child is not read so that we
+  // know how much to skip when seeking forward within the row group.
+  void recordParentNullsInChildren(vector_size_t offset, RowSet rows);
 
  private:
   const int32_t rowsPerRowGroup_;

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -19,6 +19,8 @@
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 
+#include <folly/init/Init.h>
+
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::dwrf;
 using namespace facebook::velox;
@@ -237,4 +239,31 @@ TEST_F(E2EFilterTest, lazyStruct) {
       10,
       true,
       false);
+}
+
+TEST_F(E2EFilterTest, filterStruct) {
+  // The data has a struct member with one second level struct
+  // column. Both structs have a column that gets filtered 'nestedxxx'
+  // and one that does not 'dataxxx'.
+  testWithTypes(
+      "long_val:bigint,"
+      "outer_struct: struct<nested1:bigint, "
+      "  data1: string, "
+      "  inner_struct: struct<nested2: bigint, data2: smallint>>",
+      [&]() {},
+      true,
+      {"long_val",
+       "outer_struct.inner_struct",
+       "outer_struct.nested1",
+       "outer_struct.inner_struct.nested2"},
+      40,
+      true,
+      false);
+}
+
+// Define main so that gflags get processed.
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
 }

--- a/velox/dwio/parquet/reader/FloatingPointColumnReader.h
+++ b/velox/dwio/parquet/reader/FloatingPointColumnReader.h
@@ -37,6 +37,7 @@ class FloatingPointColumnReader
       common::ScanSpec& scanSpec);
 
   void seekToRowGroup(uint32_t index) override {
+    root::seekToRowGroup(index);
     root::scanState().clear();
     root::readOffset_ = 0;
     root::formatData_->as<ParquetData>().seekToRowGroup(index);

--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -39,6 +39,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
   }
 
   void seekToRowGroup(uint32_t index) override {
+    SelectiveColumnReader::seekToRowGroup(index);
     scanState().clear();
     readOffset_ = 0;
     formatData_->as<ParquetData>().seekToRowGroup(index);

--- a/velox/dwio/parquet/reader/StringColumnReader.h
+++ b/velox/dwio/parquet/reader/StringColumnReader.h
@@ -35,6 +35,7 @@ class StringColumnReader : public dwio::common::SelectiveColumnReader {
   }
 
   void seekToRowGroup(uint32_t index) override {
+    SelectiveColumnReader::seekToRowGroup(index);
     scanState().clear();
     readOffset_ = 0;
     formatData_->as<ParquetData>().seekToRowGroup(index);

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -53,6 +53,7 @@ void StructColumnReader::enqueueRowGroup(
 }
 
 void StructColumnReader::seekToRowGroup(uint32_t index) {
+  SelectiveColumnReader::seekToRowGroup(index);
   readOffset_ = 0;
   for (auto& child : children_) {
     child->seekToRowGroup(index);

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -18,6 +18,8 @@
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/dwio/parquet/writer/Writer.h"
 
+#include <folly/init/Init.h>
+
 using namespace facebook::velox;
 using namespace facebook::velox::common;
 using namespace facebook::velox::dwio::common;
@@ -231,4 +233,11 @@ TEST_F(E2EFilterTest, stringDictionary) {
       {"string_val", "string_val_2"},
       20,
       true);
+}
+
+// Define main so that gflags get processed.
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Add DWRF pushdown filters for structs and struct members

Supports filters for non-top-level struct columns and their members.

Keeps a count of parent nulls in field readers. This allows skipping
arbitrarily far without advancing a particular field, for example if
filters for other fields come out false. When moving the field reader
forward, we know how many rows to subtract from the skip distance to
account for rows where a parent is null and there consequently is no
child value.

Adds filter generator support for complex type is null/is not null
filters.

Adds resetting the parent nulls count when skipping to a row group.

Adds a test for filters on struct columns and their members.
