### PR TITLE
Add utility for concatenating null flags

### DIFF
--- a/velox/dwio/common/BitConcatenation.cpp
+++ b/velox/dwio/common/BitConcatenation.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/BitConcatenation.h"
+
+namespace facebook::velox::dwio::common {
+
+void BitConcatenation::append(
+    const uint64_t* FOLLY_NULLABLE bits,
+    int32_t begin,
+    int32_t end) {
+  int32_t numBits = end - begin;
+  if (!bits || bits::isAllSet(bits, begin, end, true)) {
+    appendOnes(numBits);
+    return;
+  }
+
+  hasZeros_ = true;
+  bits::copyBits(bits, begin, ensureSpace(numBits), numBits_, numBits);
+  numBits_ += numBits;
+  setSize();
+}
+
+void BitConcatenation::appendOnes(int32_t numOnes) {
+  if (hasZeros_) {
+    bits::fillBits(ensureSpace(numOnes), numBits_, numBits_ + numOnes, 1);
+  }
+  numBits_ += numOnes;
+  setSize();
+}
+
+uint64_t* FOLLY_NONNULL BitConcatenation::ensureSpace(int32_t numBits) {
+  if (!*buffer_) {
+    *buffer_ = AlignedBuffer::allocate<bool>(numBits_ + numBits, &pool_, true);
+  } else if (numBits_ + numBits > (*buffer_)->capacity() * 8) {
+    AlignedBuffer::reallocate<bool>(buffer_, 2 * (numBits_ + numBits));
+  }
+  return (*buffer_)->asMutable<uint64_t>();
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/BitConcatenation.h
+++ b/velox/dwio/common/BitConcatenation.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/buffer/Buffer.h"
+
+namespace facebook::velox::dwio::common {
+
+/// Concatenates multiple bit vectors and exposes the result in a
+/// single Buffer. Creates and resizes the result Buffer as needed. If
+/// only one bits were added, sets the output buffer to nullptr.
+class BitConcatenation {
+ public:
+  BitConcatenation(memory::MemoryPool& pool) : pool_(pool) {}
+
+  /// Prepares to concatenate bits given to append() or appendOnes()
+  /// into 'buffer'. 'buffer' is allocated and resized as needed. If
+  /// 'buffer' is initially nullptr and only ones are appended, buffer
+  /// may stay nullptr. The size() of 'buffer' is set to the next byte,
+  /// so the caller must  use numBits() to get the bit count.
+  void reset(BufferPtr& outBuffer) {
+    buffer_ = &outBuffer;
+    numBits_ = 0;
+    hasZeros_ = false;
+  }
+
+  /// Appends  'bits' between bit offset 'begin' and 'end' to the result.
+  /// A nullptr 'bits' is treated as a bit range with all bits set.
+  void append(const uint64_t* FOLLY_NULLABLE bits, int32_t begin, int32_t end);
+
+  /// Appends 'numOnes' ones.
+  void appendOnes(int32_t numOnes);
+
+  // Returns 'buffer_' or nullptr if only ones have been appended.
+  BufferPtr buffer() const {
+    return hasZeros_ ? *buffer_ : nullptr;
+  }
+
+  int32_t numBits() const {
+    return numBits_;
+  }
+
+ private:
+  // Allocates or reallocates '*buffer' to have space for 'numBits_ + newBits'
+  // bits. Retuns a pointer to the first word of 'buffer_'.
+  uint64_t* FOLLY_NONNULL ensureSpace(int32_t newBits);
+
+  void setSize() {
+    if (*buffer_) {
+      (*buffer_)->setSize(bits::roundUp(numBits_, 8) / 8);
+    }
+  }
+
+  memory::MemoryPool& pool_;
+  BufferPtr* FOLLY_NULLABLE buffer_{nullptr};
+  int32_t numBits_{0};
+  bool hasZeros_{false};
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 
 add_library(
   velox_dwio_common
+  BitConcatenation.cpp
   BufferedInput.cpp
   CachedBufferedInput.cpp
   CacheInputStream.cpp

--- a/velox/dwio/common/tests/BitConcatenationTest.cpp
+++ b/velox/dwio/common/tests/BitConcatenationTest.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/BitConcatenation.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::dwio::common;
+
+TEST(BitConcatenationTests, basic) {
+  auto pool = facebook::velox::memory::getDefaultScopedMemoryPool();
+  BitConcatenation bits(*pool);
+  BufferPtr result;
+
+  std::vector<uint64_t> oneBits(10, ~0UL);
+  std::vector<uint64_t> zeroBits(10, 0UL);
+
+  // add only one bits, expect nullptr.
+  bits.reset(result);
+  bits.appendOnes(34);
+  bits.append(oneBits.data(), 3, 29);
+  EXPECT_EQ(34 + (29 - 3), bits.numBits());
+  EXPECT_TRUE(!result);
+  EXPECT_TRUE(!bits.buffer());
+
+  // Add ones, then zeros and then ones. Expect bitmap.
+  bits.reset(result);
+  bits.append(oneBits.data(), 0, 29);
+  bits.append(zeroBits.data(), 3, 29);
+  bits.append(oneBits.data(), 6, 29);
+  // Expecting  29 ones, 26 zeros and 23 zeros.
+  EXPECT_EQ(29 + 26 + 23, bits.numBits());
+  auto data = result->as<uint64_t>();
+  EXPECT_TRUE(bits::isAllSet(data, 0, 29, true));
+  EXPECT_TRUE(bits::isAllSet(data, 29, 29 + 26, false));
+  EXPECT_TRUE(bits::isAllSet(data, 29 + 26, 29 + 26 + 23, true));
+
+  // Add only one bits, expect nullptr, even though 'result' has a value.
+  bits.reset(result);
+  bits.appendOnes(24);
+  bits.append(oneBits.data(), 3, 29);
+  EXPECT_EQ(24 + (29 - 3), bits.numBits());
+  EXPECT_TRUE(!bits.buffer());
+  EXPECT_FALSE(!result);
+}

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 add_executable(
   velox_dwio_common_test
+  BitConcatenationTest.cpp
   ChainedBufferTests.cpp
   DataBufferTests.cpp
   DecoderUtilTest.cpp


### PR DESCRIPTION
Adds a class managing concatenation of bits.  There is a special case
for all ones, where the bitmap comes out as nullptr. This corresponds
to the all non-null case in readers.

Used for Parquet and Alpha, where a read may span multiple encoded
runs, each with its own nulls.