### PR TITLE
Add Arrow Parquet Writer

### DIFF
--- a/velox/dwio/parquet/CMakeLists.txt
+++ b/velox/dwio/parquet/CMakeLists.txt
@@ -16,8 +16,6 @@ include(ExternalProject)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/local/lib64/cmake/arrow")
 
-find_package(Parquet REQUIRED)
-
 add_subdirectory(duckdb_reader)
 
 add_subdirectory(writer)

--- a/velox/dwio/parquet/tests/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/CMakeLists.txt
@@ -26,3 +26,17 @@ set(TEST_LINK_LIBS
     ${FILESYSTEM})
 
 add_subdirectory(duckdb_reader)
+
+add_executable(velox_parquet_e2e_filter_test E2EFilterTest.cpp)
+
+add_test(velox_parquet_e2e_filter_test velox_dwrf_e2e_filter_test)
+
+target_link_libraries(
+  velox_parquet_e2e_filter_test
+  velox_e2e_filter_test_base
+  velox_dwio_parquet_writer
+  ${LZ4}
+  ${LZO}
+  ${ZSTD}
+  ${ZLIB_LIBRARIES}
+  ${TEST_LINK_LIBS})

--- a/velox/dwio/parquet/tests/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/E2EFilterTest.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/dwrf/test/E2EFilterTestBase.h"
+#include "velox/dwio/parquet/writer/Writer.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::common;
+using namespace facebook::velox::dwio::dwrf;
+
+using dwio::common::MemoryInputStream;
+using dwio::common::MemorySink;
+
+class E2EFilterTest : public E2EFilterTestBase {
+ protected:
+  void SetUp() override {
+    E2EFilterTestBase::SetUp();
+    writerProperties_ = ::parquet::WriterProperties::Builder().build();
+  }
+
+  void writeToMemory(
+      const TypePtr& type,
+      const std::vector<RowVectorPtr>& batches,
+      bool forRowGroupSkip) override {
+    auto sink = std::make_unique<MemorySink>(*pool_, 200 * 1024 * 1024);
+    sinkPtr_ = sink.get();
+
+    writer_ = std::make_unique<facebook::velox::parquet::Writer>(
+        std::move(sink), *pool_, 10000, writerProperties_);
+    for (auto& batch : batches) {
+      writer_->write(batch);
+    }
+    writer_->close();
+  }
+
+  std::unique_ptr<dwio::common::Reader> makeReader(
+      const dwio::common::ReaderOptions& opts,
+      std::unique_ptr<dwio::common::InputStream> input) override {
+    VELOX_NYI();
+  }
+
+  std::unique_ptr<facebook::velox::parquet::Writer> writer_;
+  std::shared_ptr<::parquet::WriterProperties> writerProperties_;
+};
+
+TEST_F(E2EFilterTest, writerMagic) {
+  rowType_ = ROW({INTEGER()});
+  batches_.push_back(std::static_pointer_cast<RowVector>(
+      test::BatchMaker::createBatch(rowType_, 20000, *pool_, nullptr, 0)));
+  writeToMemory(rowType_, batches_, false);
+  auto data = sinkPtr_->getData();
+  auto size = sinkPtr_->size();
+  EXPECT_EQ("PAR1", std::string(data, 4));
+  EXPECT_EQ("PAR1", std::string(data + size - 4, 4));
+}

--- a/velox/dwio/parquet/writer/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/CMakeLists.txt
@@ -12,20 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(ExternalProject)
+add_library(velox_dwio_parquet_writer Writer.cpp)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/local/lib64/cmake/arrow")
-
-find_package(Parquet REQUIRED)
-
-add_subdirectory(duckdb_reader)
-
-add_subdirectory(writer)
-
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-endif()
-
-add_library(velox_dwio_parquet_reader RegisterParquetReader.cpp)
-target_link_libraries(velox_dwio_parquet_reader
-                      velox_dwio_duckdb_parquet_reader gtest xsimd)
+target_link_libraries(velox_dwio_parquet_writer velox_dwio_common
+                      velox_arrow_bridge parquet_shared arrow_shared ${FMT})

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/parquet/writer/Writer.h"
+#include <arrow/c/bridge.h>
+#include <arrow/table.h>
+#include "velox/vector/arrow/Bridge.h"
+
+namespace facebook::velox::parquet {
+
+void Writer::write(const RowVectorPtr& data) {
+  ArrowArray array;
+  ArrowSchema schema;
+  exportToArrow(data, array, &pool_);
+  exportToArrow(data->type(), schema);
+  PARQUET_ASSIGN_OR_THROW(
+      auto recordBatch, arrow::ImportRecordBatch(&array, &schema));
+  auto table = arrow::Table::Make(
+      recordBatch->schema(), recordBatch->columns(), data->size());
+  if (!arrowWriter_) {
+    stream_ = std::make_shared<DataBufferSink>(pool_);
+    auto arrowProperties = ::parquet::ArrowWriterProperties::Builder().build();
+    PARQUET_THROW_NOT_OK(::parquet::arrow::FileWriter::Open(
+        *recordBatch->schema(),
+        arrow::default_memory_pool(),
+        stream_,
+        properties_,
+        arrowProperties,
+        &arrowWriter_));
+  }
+
+  PARQUET_THROW_NOT_OK(arrowWriter_->WriteTable(*table, 10000));
+}
+
+void Writer::close() {
+  if (arrowWriter_) {
+    arrowWriter_->Close();
+    finalSink_->write(std::move(stream_->dataBuffer()));
+  }
+}
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/DataBuffer.h"
+#include "velox/dwio/common/DataSink.h"
+
+#include "velox/vector/ComplexVector.h"
+
+#include <parquet/arrow/writer.h>
+
+namespace facebook::velox::parquet {
+
+// Utility for caapturing Arrow output into a DataBuffer.
+class DataBufferSink : public arrow::io::OutputStream {
+ public:
+  DataBufferSink(memory::MemoryPool& pool) : buffer_(pool) {}
+
+  arrow::Status Write(const std::shared_ptr<arrow::Buffer>& data) override {
+    buffer_.append(
+        buffer_.size(),
+        reinterpret_cast<const char*>(data->data()),
+        data->size());
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Write(const void* data, int64_t nbytes) override {
+    buffer_.append(buffer_.size(), reinterpret_cast<const char*>(data), nbytes);
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Flush() override {
+    return arrow::Status::OK();
+  }
+
+  arrow::Result<int64_t> Tell() const override {
+    return buffer_.size();
+  }
+
+  arrow::Status Close() override {
+    return arrow::Status::OK();
+  }
+
+  bool closed() const override {
+    return false;
+  }
+
+  dwio::common::DataBuffer<char>& dataBuffer() {
+    return buffer_;
+  }
+
+ private:
+  dwio::common::DataBuffer<char> buffer_;
+};
+
+// Writes Velox vectors into  a DataSink using Arrow Parquet writer.
+class Writer {
+ public:
+  // Constructts a writer with output to 'sink'. A new row group is
+  // started every 'rowsInRowGroup[ top level rows. 'pool' is used for
+  // temporary memory. 'properties' specifies Parquet-specific
+  // options.
+  Writer(
+      std::unique_ptr<dwio::common::DataSink> sink,
+      memory::MemoryPool& pool,
+      int32_t rowsInRowGroup,
+      std::shared_ptr<::parquet::WriterProperties> properties =
+          ::parquet::WriterProperties::Builder().build())
+      : rowsInRowGroup_(rowsInRowGroup),
+        pool_(pool),
+        finalSink_(std::move(sink)),
+        properties_(std::move(properties)) {}
+
+  // Appends 'data' into the writer.
+  void write(const RowVectorPtr& data);
+
+  // Forces a row group boundary before the data added by next write().
+  void newRowGroup(int32_t numRows) {
+    arrowWriter_->NewRowGroup(numRows);
+  }
+
+  // Closes 'this', After close, data can no longer be added and the completed
+  // Parquet file is flushed into 'sink' provided at construction. 'sink' stays
+  // live until destruction of 'this'.
+  void close();
+
+ private:
+  const int32_t rowsInRowGroup_;
+
+  // Pool for 'stream_'.
+  memory::MemoryPool& pool_;
+
+  // Final destination of output.
+  std::unique_ptr<dwio::common::DataSink> finalSink_;
+
+  // Temporary Arrow stream for capturing the output.
+  std::shared_ptr<DataBufferSink> stream_;
+
+  std::unique_ptr<::parquet::arrow::FileWriter> arrowWriter_;
+
+  std::shared_ptr<::parquet::WriterProperties> properties_;
+};
+
+} // namespace facebook::velox::parquet

--- a/velox/vector/arrow/Abi.h
+++ b/velox/vector/arrow/Abi.h
@@ -19,6 +19,11 @@
 
 #pragma once
 
+// Use ARROW_FLAG_DICTIONARY_ORDERED as include guard. Building with
+// Arrow headers will include the Arrow copy of the same and pragma
+// once will not catch the duplication.
+#ifndef ARROW_FLAG_DICTIONARY_ORDERED
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -105,3 +110,4 @@ struct ArrowArrayStream {
 #ifdef __cplusplus
 }
 #endif
+#endif // ARROW_FLAG_DICTIONARY_ORDERED


### PR DESCRIPTION
Adds a thin wrapper around Arrow Parquet writer. Converts Velox
Vectors to Arrow using the Velox-Arrow bridge and then writes these
using the Arrow writer.

Adds the initial base class for the Parquet E2EFilterTest and a test
for checking that the writer produces the right magic numbers. As
parts of the reader are added we will check that the metadata and
columns are correctly read back.