### PR TITLE
Add TPCH query 19 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -176,6 +176,11 @@ BENCHMARK(q18) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q19) {
+  const auto planContext = queryBuilder->getQueryPlan(19);
+  benchmark.run(planContext);
+}
+
 int main(int argc, char** argv) {
   folly::init(&argc, &argv, false);
   benchmark.initialize();

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
@@ -204,6 +204,10 @@ TEST_F(ParquetTpchTest, Q18) {
   assertQuery(18, 5, 30);
 }
 
+TEST_F(ParquetTpchTest, Q19) {
+  assertQuery(19, 3, 20);
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   folly::init(&argc, &argv, false);

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -84,6 +84,7 @@ class TpchQueryBuilder {
   TpchPlan getQ13Plan() const;
   TpchPlan getQ14Plan() const;
   TpchPlan getQ18Plan() const;
+  TpchPlan getQ19Plan() const;
 
   const std::vector<std::string>& getTableFilePaths(
       const std::string& tableName) const {
@@ -116,6 +117,8 @@ class TpchQueryBuilder {
   static constexpr const char* kRegion = "region";
   static constexpr const char* kPart = "part";
   static constexpr const char* kSupplier = "supplier";
+  std::unique_ptr<memory::ScopedMemoryPool> pool_ =
+      memory::getDefaultScopedMemoryPool();
 };
 
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Adds TPC-H query 19 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 19.
```
| # Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds) |
|:----------------------:|:--------------:|:---------------:|
|            1           | 6.35           | 9.50            | 
|            4           | 2.38           | 5.85            | 
|            8           | 1.55           | 3.05            | 
|           16           | 1.39           | 1.55            | 
``` 

At the top of the Velox profile are `dwrf::IntDecoder::bulkRead` and
`dwrf::IntDecoder::bulkReadRows`. These relate to`varint` decoding
and are specific to the DWRF format.
The third is `exec::ConjunctExpr::UpdateResult` which is expected for this query.