### PR TITLE
Fix rowcount generation for lineitem

### DIFF
--- a/velox/connectors/tpch/TpchConnector.cpp
+++ b/velox/connectors/tpch/TpchConnector.cpp
@@ -142,12 +142,9 @@ std::optional<RowVectorPtr> TpchDataSource::next(
   VELOX_CHECK_NOT_NULL(
       currentSplit_, "No split to process. Call addSplit() first.");
 
-  auto outputVector = getTpchData(
-      tpchTable_,
-      std::min(size, (splitEnd_ - splitOffset_)),
-      splitOffset_,
-      scaleFactor_,
-      pool_);
+  size_t maxRows = std::min(size, (splitEnd_ - splitOffset_));
+  auto outputVector =
+      getTpchData(tpchTable_, maxRows, splitOffset_, scaleFactor_, pool_);
 
   // If the split is exhausted.
   if (!outputVector || outputVector->size() == 0) {
@@ -155,7 +152,10 @@ std::optional<RowVectorPtr> TpchDataSource::next(
     return nullptr;
   }
 
-  splitOffset_ += outputVector->size();
+  // splitOffset needs to advance based on maxRows passed to getTphData(), and
+  // not the actual number of returned rows in the output vector, as they are
+  // not the same for lineitem.
+  splitOffset_ += maxRows;
   completedRows_ += outputVector->size();
   completedBytes_ += outputVector->retainedSize();
 

--- a/velox/tpch/gen/TpchGen.h
+++ b/velox/tpch/gen/TpchGen.h
@@ -93,7 +93,7 @@ RowVectorPtr genTpchOrders(
 //
 /// In order to make this function reproducible and deterministic, the
 /// parameters (maxRows and offset) refer to orders, not lineitems, and thus the
-/// number of linteitem returned rows will be on average 4 * maxOrderRows.
+/// number of lineitem returned rows will be on average 4 * maxOrderRows.
 ///
 /// Returns a row vector containing on average `maxOrderRows * 4` (from
 /// `maxOrderRows` to `maxOrderRows * 7`) rows of the "lineitem" table. The


### PR DESCRIPTION
Summary:
Lineitem is generated based on rows counts from the Orders table, so
the offsets need to advance based on the requested rows, rather than on number
of returned rows in the vectors. This is more general and works for other
tables as well, since they only case when less rows are returned than requested
is when the connector exhausted the generated rows.

Differential Revision: D37584637

