### PR TITLE
SimpleFunction should only reuse variadic arg vector if it's flat and reusable

### DIFF
--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -241,8 +241,10 @@ class SimpleFunctionAdapter : public VectorFunction {
       if constexpr (
           CppToType<typename arg_at<POSITION>::underlying_type>::typeKind ==
           return_type_traits::typeKind) {
-        if (args.size() > POSITION) {
-          return &args[POSITION];
+        for (auto i = POSITION; i < args.size(); i++) {
+          if (BaseVector::isReusableFlatVector(args[i])) {
+            return &args[i];
+          }
         }
       }
       // A Variadic arg is always the last, so if we haven't found a match yet,

--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -230,6 +230,33 @@ class FunctionBaseTest : public testing::Test,
         name, signature, rowType, parse::parseExpr(body), execCtx_.pool());
   }
 
+  core::TypedExprPtr parseExpression(
+      const std::string& text,
+      const RowTypePtr& rowType) {
+    auto untyped = parse::parseExpr(text);
+    return core::Expressions::inferTypes(untyped, rowType, pool());
+  }
+
+  std::unique_ptr<exec::ExprSet> compileExpressions(
+      const std::vector<std::string>& exprs,
+      const RowTypePtr& rowType) {
+    std::vector<core::TypedExprPtr> expressions;
+    expressions.reserve(exprs.size());
+    for (const auto& expr : exprs) {
+      expressions.emplace_back(parseExpression(expr, rowType));
+    }
+    return std::make_unique<exec::ExprSet>(std::move(expressions), &execCtx_);
+  }
+
+  VectorPtr evaluate(exec::ExprSet& exprSet, const RowVectorPtr& input) {
+    exec::EvalCtx context(&execCtx_, &exprSet, input.get());
+
+    SelectivityVector rows(input->size());
+    std::vector<VectorPtr> result(1);
+    exprSet.eval(rows, &context, &result);
+    return result[0];
+  }
+
   std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
 


### PR DESCRIPTION
Summary:
This fixes a bug where we wouldn't check to see if a vector in a Variadic argument was
reusable and flat before reusing it. (Thanks Laith for catching this!)

Added a check so we use the first reusable flat vector in those passed under the
Variadic type.

I also did some refactoring of tests so that we test for reuse in SimpleFunctionTest
instead of ExprStatsTest (this isn't really testing the ExprStats but the behavior of
SimpleFunction Adapter).

Differential Revision: D37636313

