### PR TITLE
Add fast path to expression evaluation for flat non-null inputs

### DIFF
--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -74,6 +74,7 @@ class CastExpr : public SpecialForm {
             type,
             std::vector<ExprPtr>({expr}),
             kCast.data(),
+            false /* supportsFlatNoNullsFastPath */,
             trackCpuUsage),
         nullOnFailure_(nullOnFailure) {
     auto fromType = inputs_[0]->type();

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -18,11 +18,15 @@
 
 namespace facebook::velox::exec {
 
-CoalesceExpr::CoalesceExpr(TypePtr type, std::vector<ExprPtr>&& inputs)
+CoalesceExpr::CoalesceExpr(
+    TypePtr type,
+    std::vector<ExprPtr>&& inputs,
+    bool inputsSupportFlatNoNullsFastPath)
     : SpecialForm(
           std::move(type),
           std::move(inputs),
           kCoalesce,
+          inputsSupportFlatNoNullsFastPath,
           false /* trackCpuUsage */) {
   for (auto i = 1; i < inputs_.size(); i++) {
     VELOX_USER_CHECK_EQ(

--- a/velox/expression/CoalesceExpr.h
+++ b/velox/expression/CoalesceExpr.h
@@ -23,7 +23,10 @@ const char* const kCoalesce = "coalesce";
 
 class CoalesceExpr : public SpecialForm {
  public:
-  CoalesceExpr(TypePtr type, std::vector<ExprPtr>&& inputs);
+  CoalesceExpr(
+      TypePtr type,
+      std::vector<ExprPtr>&& inputs,
+      bool inputsSupportFlatNoNullsFastPath);
 
   void evalSpecialForm(
       const SelectivityVector& rows,

--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -22,11 +22,16 @@ namespace facebook::velox::exec {
 
 class ConjunctExpr : public SpecialForm {
  public:
-  ConjunctExpr(TypePtr type, std::vector<ExprPtr>&& inputs, bool isAnd)
+  ConjunctExpr(
+      TypePtr type,
+      std::vector<ExprPtr>&& inputs,
+      bool isAnd,
+      bool inputsSupportFlatNoNullsFastPath)
       : SpecialForm(
             std::move(type),
             std::move(inputs),
             isAnd ? "and" : "or",
+            inputsSupportFlatNoNullsFastPath,
             false /* trackCpuUsage */),
         isAnd_(isAnd) {
     selectivity_.resize(inputs_.size());

--- a/velox/expression/ConstantExpr.h
+++ b/velox/expression/ConstantExpr.h
@@ -25,6 +25,7 @@ class ConstantExpr : public SpecialForm {
             std::move(type),
             std::vector<ExprPtr>(),
             "literal",
+            !value.isNull() /* supportsFlatNoNullsFastPath */,
             false /* trackCpuUsage */),
         value_(std::move(value)),
         needToSetIsAscii_{type->isVarchar()} {}
@@ -34,6 +35,7 @@ class ConstantExpr : public SpecialForm {
             value->type(),
             std::vector<ExprPtr>(),
             "literal",
+            !value->isNullAt(0) /* supportsFlatNoNullsFastPath */,
             false /* trackCpuUsage */),
         needToSetIsAscii_{value->type()->isVarchar()} {
     VELOX_CHECK_EQ(value->encoding(), VectorEncoding::Simple::CONSTANT);

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -33,8 +33,14 @@ EvalCtx::EvalCtx(core::ExecCtx* execCtx, ExprSet* exprSet, const RowVector* row)
   VELOX_CHECK_NOT_NULL(execCtx);
   VELOX_CHECK_NOT_NULL(exprSet);
   VELOX_CHECK_NOT_NULL(row);
+
+  inputFlatNoNulls_ = true;
   for (const auto& child : row->children()) {
     VELOX_CHECK_NOT_NULL(child);
+    if ((!child->isFlatEncoding() && !child->isConstantEncoding()) ||
+        child->mayHaveNulls()) {
+      inputFlatNoNulls_ = false;
+    }
   }
 }
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -43,6 +43,12 @@ class EvalCtx {
     return row_;
   }
 
+  /// Returns true if all input vectors in 'row' are flat or constant and have
+  /// no nulls.
+  bool inputFlatNoNulls() const {
+    return inputFlatNoNulls_;
+  }
+
   memory::MemoryPool* FOLLY_NONNULL pool() const {
     return execCtx_->pool();
   }
@@ -125,6 +131,10 @@ class EvalCtx {
 
   void swapErrors(ErrorVectorPtr& other) {
     std::swap(errors_, other);
+  }
+
+  bool throwOnError() const {
+    return throwOnError_;
   }
 
   bool* FOLLY_NONNULL mutableThrowOnError() {
@@ -212,6 +222,7 @@ class EvalCtx {
   core::ExecCtx* const FOLLY_NONNULL execCtx_;
   ExprSet* FOLLY_NULLABLE const exprSet_;
   const RowVector* FOLLY_NULLABLE row_;
+  bool inputFlatNoNulls_;
 
   // Corresponds 1:1 to children of 'row_'. Set to an inner vector
   // after removing dictionary/sequence wrappers.

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -187,7 +187,10 @@ ExprPtr getSpecialForm(
     std::vector<ExprPtr>&& compiledChildren,
     bool trackCpuUsage) {
   if (name == kIf || name == kSwitch) {
-    return std::make_shared<SwitchExpr>(type, std::move(compiledChildren));
+    bool inputsSupportFlatNoNullsFastPath =
+        Expr::allSupportFlatNoNullsFastPath(compiledChildren);
+    return std::make_shared<SwitchExpr>(
+        type, std::move(compiledChildren), inputsSupportFlatNoNullsFastPath);
   }
   if (name == kCast) {
     VELOX_CHECK_EQ(compiledChildren.size(), 1);
@@ -198,19 +201,32 @@ ExprPtr getSpecialForm(
         false /* nullOnFailure */);
   }
   if (name == kAnd) {
+    bool inputsSupportFlatNoNullsFastPath =
+        Expr::allSupportFlatNoNullsFastPath(compiledChildren);
     return std::make_shared<ConjunctExpr>(
-        type, std::move(compiledChildren), true);
+        type,
+        std::move(compiledChildren),
+        true /* isAnd */,
+        inputsSupportFlatNoNullsFastPath);
   }
   if (name == kOr) {
+    bool inputsSupportFlatNoNullsFastPath =
+        Expr::allSupportFlatNoNullsFastPath(compiledChildren);
     return std::make_shared<ConjunctExpr>(
-        type, std::move(compiledChildren), false);
+        type,
+        std::move(compiledChildren),
+        false /* isAnd */,
+        inputsSupportFlatNoNullsFastPath);
   }
   if (name == kTry) {
     VELOX_CHECK_EQ(compiledChildren.size(), 1);
     return std::make_shared<TryExpr>(type, std::move(compiledChildren[0]));
   }
   if (name == kCoalesce) {
-    return std::make_shared<CoalesceExpr>(type, std::move(compiledChildren));
+    bool inputsSupportFlatNoNullsFastPath =
+        Expr::allSupportFlatNoNullsFastPath(compiledChildren);
+    return std::make_shared<CoalesceExpr>(
+        type, std::move(compiledChildren), inputsSupportFlatNoNullsFastPath);
   }
   return nullptr;
 }

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -29,6 +29,7 @@ class FieldReference : public SpecialForm {
             std::move(type),
             std::move(inputs),
             field,
+            true /* supportsFlatNoNullsFastPath */,
             false /* trackCpuUsage */),
         field_(field) {}
 
@@ -36,7 +37,7 @@ class FieldReference : public SpecialForm {
     return field_;
   }
 
-  int32_t index(EvalCtx& context) {
+  int32_t index(const EvalCtx& context) {
     if (index_ != -1) {
       return index_;
     }

--- a/velox/expression/LambdaExpr.h
+++ b/velox/expression/LambdaExpr.h
@@ -31,6 +31,7 @@ class LambdaExpr : public SpecialForm {
             std::move(type),
             std::vector<std::shared_ptr<Expr>>(),
             "lambda",
+            false /* supportsFlatNoNullsFastPath */,
             trackCpuUsage),
         signature_(std::move(signature)),
         capture_(std::move(capture)),

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -398,6 +398,10 @@ class SimpleFunctionAdapter : public VectorFunction {
     return fn_->is_default_null_behavior;
   }
 
+  bool supportsFlatNoNullsFastPath() const override {
+    return !FUNC::can_produce_null_output;
+  }
+
   bool ensureStringEncodingSetAtAllInputs() const override {
     return fn_->has_ascii;
   }

--- a/velox/expression/SpecialForm.h
+++ b/velox/expression/SpecialForm.h
@@ -23,14 +23,16 @@ class SpecialForm : public Expr {
  public:
   SpecialForm(
       TypePtr type,
-      std::vector<ExprPtr>&& inputs,
+      std::vector<ExprPtr> inputs,
       const std::string& name,
+      bool supportsFlatNoNullsFastPath,
       bool trackCpuUsage)
       : Expr(
             std::move(type),
             std::move(inputs),
             name,
             true /* specialForm */,
+            supportsFlatNoNullsFastPath,
             trackCpuUsage) {}
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/SwitchExpr.h
+++ b/velox/expression/SwitchExpr.h
@@ -37,21 +37,10 @@ class SwitchExpr : public SpecialForm {
  public:
   /// Inputs are concatenated conditions and results with an optional "else" at
   /// the end, e.g. {condition1, result1, condition2, result2,..else}
-  SwitchExpr(TypePtr type, std::vector<ExprPtr>&& inputs)
-      : SpecialForm(
-            std::move(type),
-            std::move(inputs),
-            "switch",
-            false /* trackCpuUsage */),
-        numCases_{inputs_.size() / 2},
-        hasElseClause_{inputs_.size() % 2 == 1} {
-    VELOX_CHECK_GT(numCases_, 0);
-
-    for (auto i = 0; i < numCases_; i++) {
-      auto& condition = inputs_[i * 2];
-      VELOX_CHECK_EQ(condition->type()->kind(), TypeKind::BOOLEAN);
-    }
-  }
+  SwitchExpr(
+      TypePtr type,
+      const std::vector<ExprPtr>& inputs,
+      bool inputsSupportFlatNoNullsFastPath);
 
   void evalSpecialForm(
       const SelectivityVector& rows,

--- a/velox/expression/TryExpr.h
+++ b/velox/expression/TryExpr.h
@@ -21,11 +21,13 @@ namespace facebook::velox::exec {
 
 class TryExpr : public SpecialForm {
  public:
+  /// Try expression adds nulls, hence, doesn't support flat-no-nulls fast path.
   TryExpr(TypePtr type, ExprPtr&& input)
       : SpecialForm(
             std::move(type),
             {std::move(input)},
             "try",
+            false /* supportsFlatNoNullsFastPath */,
             false /* trackCpuUsage */) {}
 
   void evalSpecialForm(

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -91,6 +91,14 @@ class VectorFunction {
     return true;
   }
 
+  /// Returns true if (1) supports evaluation on all constant inputs of size >
+  /// 1; (2) returns flat or constant result when inputs are all flat, all
+  /// constant or a mix of flat and constant; (3) guarantees that if all inputs
+  /// are not null, the result is also not null.
+  virtual bool supportsFlatNoNullsFastPath() const {
+    return false;
+  }
+
   // The evaluation engine will scan and set the string encoding of the
   // specified input arguments when presented if their type is VARCHAR before
   // applying the function

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-#include <folly/Benchmark.h>
 #include "glog/logging.h"
 #include "gtest/gtest.h"
 
 #include "velox/common/base/Exceptions.h"
-#include "velox/dwio/common/DataSink.h"
 #include "velox/expression/ConjunctExpr.h"
 #include "velox/expression/ConstantExpr.h"
 #include "velox/functions/Udf.h"
@@ -2557,7 +2555,7 @@ TEST_F(ExprTest, peeledConstant) {
     }
     EXPECT_LE(1, result->valueAt(i).size());
     // Check that the data is readable.
-    folly::doNotOptimizeAway(result->toString(i));
+    EXPECT_NO_THROW(result->toString(i));
   }
 }
 


### PR DESCRIPTION
ML data preprocessing workloads perform simple calculations over small batches
of flat vectors with no nulls. The overhead of expression evaluation engine in
these workloads is significant. This change adds a fast path for flat-no-nulls
inputs.

Fast path doesn't include any handling for nulls or encodings.

Evaluating constant expressions is expensive as it involves copying shared
pointers. Fast path caches constant expression results and uses std::move() to
avoid copying shared pointers.

Fast path is enabled if all of the conditions are met:

- all inputs are flat or constant and have no nulls;
- all expressions are guaranteed to produce non-null for non-null inputs;
- all expressions can process inputs that are all constant and have size > 1;
- there is no parent 'try' expression;
- all input and intermediate result types are primitive non-string types (effectively numeric types);
- batch size is < 1'000.


Since fast path doesn't peel off constant encoding, it may be expensive to apply
to large batches or expressions that manipulate strings or complex types. 

Also, harden ExprStatsTest to avoid crashing on test failures.