### PR TITLE
Support casting to Row type from GenericWriter

### DIFF
--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -709,7 +709,17 @@ class GenericWriter {
       writer_ptr_t<Varchar>,
       writer_ptr_t<Varbinary>,
       writer_ptr_t<Array<Any>>,
-      writer_ptr_t<Map<Any, Any>>>;
+      writer_ptr_t<Map<Any, Any>>,
+      writer_ptr_t<Row<Any>>,
+      writer_ptr_t<Row<Any, Any>>,
+      writer_ptr_t<Row<Any, Any, Any>>,
+      writer_ptr_t<Row<Any, Any, Any, Any>>,
+      writer_ptr_t<Row<Any, Any, Any, Any, Any>>,
+      writer_ptr_t<Row<Any, Any, Any, Any, Any, Any>>,
+      writer_ptr_t<Row<Any, Any, Any, Any, Any, Any, Any>>,
+      writer_ptr_t<Row<Any, Any, Any, Any, Any, Any, Any, Any>>,
+      writer_ptr_t<Row<Any, Any, Any, Any, Any, Any, Any, Any, Any>>,
+      writer_ptr_t<Row<Any, Any, Any, Any, Any, Any, Any, Any, Any, Any>>>;
 
   GenericWriter(writer_variant_t& castWriter, TypePtr& castType, size_t& index)
       : castWriter_{castWriter}, castType_{castType}, index_{index} {}


### PR DESCRIPTION
Summary: This diff adds support for casting a GenericWriter to a RowWriter with no more than 10 children. Support for casting to DynamicRow type that allows more than 10 children will be added in a following diff.

Differential Revision: D37542412

