### PR TITLE
Support casting to DynamicRow from GenericWriter

### DIFF
--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -582,4 +582,152 @@ struct VectorWriter<Generic<T>> {
   TypePtr castType_;
 };
 
+class DynamicRowWriter {
+ public:
+  using child_writer_t = GenericWriter;
+  using writers_t = std::vector<std::shared_ptr<VectorWriter<Any, void>>>;
+
+  void set_null_at(column_index_t index) {
+    VELOX_USER_CHECK_LT(
+        index,
+        childrenVectors_->size(),
+        "Failed to access the child vector at index {}. Row vector has only {} children.",
+        index,
+        childrenVectors_->size());
+
+    (*childrenVectors_)[index]->setNull(offset_, true);
+    needCommit_[index] = false;
+  }
+
+  child_writer_t& get_writer_at(column_index_t index) {
+    VELOX_USER_CHECK_LT(
+        index,
+        childrenVectors_->size(),
+        "Failed to access the child vector at index {}. Row vector has only {} children.",
+        index,
+        childrenVectors_->size());
+
+    needCommit_[index] = true;
+    childrenWriters_[index]->setOffset(offset_);
+    return childrenWriters_[index]->current();
+  }
+
+ private:
+  // Make sure user do not use those.
+  DynamicRowWriter() = default;
+
+  DynamicRowWriter(const DynamicRowWriter&) = default;
+
+  DynamicRowWriter& operator=(const DynamicRowWriter&) = default;
+
+  void initialize(BaseVector* vector) {
+    childrenVectors_ = &vector->as<RowVector>()->children();
+    childrenCount_ = childrenVectors_->size();
+
+    for (int i = 0; i < childrenCount_; ++i) {
+      childrenWriters_.push_back(std::make_shared<VectorWriter<Any, void>>());
+      childrenWriters_[i]->init(*(*childrenVectors_)[i]);
+      childrenWriters_[i]->ensureSize(vector->size());
+
+      needCommit_.push_back(false);
+    }
+  }
+
+  void finalize() {
+    for (int i = 0; i < childrenCount_; ++i) {
+      if (needCommit_[i]) {
+        childrenWriters_[i]->commit(true);
+        needCommit_[i] = false;
+      }
+    }
+  }
+
+  void finalizeNull() {
+    for (int i = 0; i < childrenCount_; ++i) {
+      childrenWriters_[i]->current().finalizeNull();
+      needCommit_[i] = false;
+    }
+  }
+
+  writers_t childrenWriters_;
+
+  column_index_t childrenCount_;
+
+  std::vector<VectorPtr>* childrenVectors_;
+
+  std::vector<bool> needCommit_;
+
+  vector_size_t offset_;
+
+  template <typename A, typename B>
+  friend struct VectorWriter;
+
+  friend class GenericWriter;
+};
+
+template <>
+struct VectorWriter<DynamicRow, void> {
+  using vector_t = RowVector;
+  using exec_out_t = DynamicRowWriter;
+
+  VectorWriter() {}
+
+  void init(vector_t& vector) {
+    rowVector_ = &vector;
+    writer_.initialize(rowVector_);
+  }
+
+  // This should be called once all rows are processed.
+  void finish() {
+    for (int i = 0; i < writer_.childrenCount_; ++i) {
+      writer_.childrenWriters_[i]->finish();
+    }
+  }
+
+  exec_out_t& current() {
+    return writer_;
+  }
+
+  vector_t& vector() {
+    return *rowVector_;
+  }
+
+  void ensureSize(size_t size) {
+    if (size > rowVector_->size()) {
+      rowVector_->resize(size, /*setNotNull*/ false);
+      for (int i = 0; i < writer_.childrenCount_; ++i) {
+        writer_.childrenWriters_[i]->ensureSize(size);
+      }
+    }
+  }
+
+  void commitNull() {
+    writer_.finalizeNull();
+    rowVector_->setNull(writer_.offset_, true);
+  }
+
+  void commit(bool isSet = true) {
+    VELOX_DCHECK(rowVector_->size() > writer_.offset_);
+
+    if (LIKELY(isSet)) {
+      rowVector_->setNull(writer_.offset_, false);
+      writer_.finalize();
+    } else {
+      commitNull();
+    }
+  }
+
+  void setOffset(size_t offset) {
+    writer_.offset_ = offset;
+  }
+
+  void reset() {
+    writer_.offset_ = 0;
+  }
+
+ private:
+  DynamicRowWriter writer_;
+  vector_t* rowVector_ = nullptr;
+};
+
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -223,9 +223,9 @@ TEST_F(GenericWriterTest, map) {
 
     auto& current = writer.current().castTo<Map<Any, Any>>();
 
-    auto tuple = current.add_item();
-    std::get<0>(tuple).castTo<Varchar>().copy_from(std::to_string(i * 2));
-    *std::get<1>(tuple).tryCastTo<int64_t>() = i * 2;
+    auto [keyWriter, valueWriter] = current.add_item();
+    keyWriter.castTo<Varchar>().copy_from(std::to_string(i * 2));
+    *valueWriter.tryCastTo<int64_t>() = i * 2;
 
     auto& key = current.add_null();
     key.castTo<Varchar>().copy_from(std::to_string(i * 2 + 1));
@@ -248,7 +248,7 @@ TEST_F(GenericWriterTest, map) {
 TEST_F(GenericWriterTest, row) {
   VectorPtr result;
   BaseVector::ensureWritable(
-      SelectivityVector(4),
+      SelectivityVector(5),
       ROW({VARCHAR(), BIGINT(), DOUBLE()}),
       pool(),
       &result);
@@ -256,29 +256,46 @@ TEST_F(GenericWriterTest, row) {
   VectorWriter<Any> writer;
   writer.init(*result);
 
-  for (int i = 0; i < 4; ++i) {
+  for (int i = 0; i < 3; ++i) {
     writer.setOffset(i);
     auto& current = writer.current().castTo<Row<Any, Any, Any>>();
 
     auto& childCurrent = current.get_writer_at<0>().castTo<Varchar>();
     childCurrent.copy_from(std::to_string(i * 2));
     current.get_writer_at<1>().castTo<int64_t>() = i * 2 + 1;
+
+    current.get_writer_at<2>().castTo<double>() = i * 2.2 + 1.1;
     current.set_null_at<2>();
 
     writer.commit(true);
   }
+
+  // Use tryCastTo at the last iteration.
+  writer.setOffset(3);
+  auto* rowWriter = writer.current().tryCastTo<Row<Any, Any, Any>>();
+  rowWriter->get_writer_at<0>().tryCastTo<Varchar>()->copy_from(
+      std::to_string(3 * 2));
+  *rowWriter->get_writer_at<1>().tryCastTo<int64_t>() = 3 * 2 + 1;
+  rowWriter->set_null_at<2>();
+  writer.commit(true);
+
+  // Test commitNull after casting.
+  writer.setOffset(4);
+  writer.commitNull();
+
   writer.finish();
 
-  ASSERT_EQ(result->as<RowVector>()->childAt(0)->size(), 4);
-  ASSERT_EQ(result->as<RowVector>()->childAt(1)->size(), 4);
-  ASSERT_EQ(result->as<RowVector>()->childAt(2)->size(), 4);
+  ASSERT_EQ(result->as<RowVector>()->childAt(0)->size(), 5);
+  ASSERT_EQ(result->as<RowVector>()->childAt(1)->size(), 5);
+  ASSERT_EQ(result->as<RowVector>()->childAt(2)->size(), 5);
 
-  auto child1 =
-      makeNullableFlatVector<StringView>({"0"_sv, "2"_sv, "4"_sv, "6"_sv});
-  auto child2 = makeNullableFlatVector<int64_t>({1, 3, 5, 7});
+  auto child1 = makeNullableFlatVector<StringView>(
+      {"0"_sv, "2"_sv, "4"_sv, "6"_sv, std::nullopt});
+  auto child2 = makeNullableFlatVector<int64_t>({1, 3, 5, 7, std::nullopt});
   auto child3 = makeNullableFlatVector<double>(
-      {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
-  auto data = makeRowVector({child1, child2, child3});
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  auto data = makeRowVector(
+      {child1, child2, child3}, [](vector_size_t row) { return row == 4; });
 
   test::assertEqualVectors(data, result);
 
@@ -287,6 +304,91 @@ TEST_F(GenericWriterTest, row) {
   writer.setOffset(0);
   auto& current = writer.current();
   ASSERT_THROW(current.castTo<Row<Any>>(), VeloxUserError);
+
+  // Casting to DynamicRow after casting to Row<Any, ...> is not allowed.
+  ASSERT_THROW(current.castTo<DynamicRow>(), VeloxUserError);
+
+  ASSERT_NO_THROW(current.tryCastTo<DynamicRow>());
+  ASSERT_TRUE(current.tryCastTo<DynamicRow>() == nullptr);
+}
+
+TEST_F(GenericWriterTest, dynamicRow) {
+  VectorPtr result;
+  BaseVector::ensureWritable(
+      SelectivityVector(6), ROW({BIGINT(), DOUBLE()}), pool(), &result);
+
+  VectorWriter<Any> writer;
+  writer.init(*result);
+
+  writer.setOffset(0);
+  writer.commitNull();
+
+  for (int i = 1; i < 4; ++i) {
+    writer.setOffset(i);
+    auto& current = writer.current().castTo<DynamicRow>();
+
+    current.get_writer_at(0).castTo<int64_t>() = i * 2;
+    current.get_writer_at(1).castTo<double>() = i * 2 + 1.1;
+
+    if (i % 2 == 0) {
+      current.set_null_at(1);
+    } else {
+      current.set_null_at(0);
+    }
+    writer.commit(true);
+  }
+
+  // Use tryCastTo at the last iteration.
+  writer.setOffset(4);
+  auto* rowWriter = writer.current().tryCastTo<DynamicRow>();
+  *rowWriter->get_writer_at(0).tryCastTo<int64_t>() = 4 * 2;
+  rowWriter->set_null_at(1);
+  writer.commit(true);
+
+  // Test commitNull after casting.
+  writer.setOffset(5);
+  writer.commitNull();
+
+  writer.finish();
+
+  ASSERT_EQ(result->as<RowVector>()->childAt(0)->size(), 6);
+  ASSERT_EQ(result->as<RowVector>()->childAt(1)->size(), 6);
+
+  auto child1 = makeNullableFlatVector<int64_t>(
+      {std::nullopt, std::nullopt, 4, std::nullopt, 8, std::nullopt});
+  auto child2 = makeNullableFlatVector<double>(
+      {std::nullopt, 3.1, std::nullopt, 7.1, std::nullopt, std::nullopt});
+  auto data = makeRowVector(
+      {child1, child2}, [](vector_size_t row) { return row == 0 || row == 5; });
+
+  test::assertEqualVectors(data, result);
+
+  // Casting to Row<Any, ...> after casting to DynamicRow is not allowed.
+  writer.setOffset(0);
+  auto& current = writer.current();
+  ASSERT_THROW((current.castTo<Row<Any, Any>>()), VeloxUserError);
+
+  ASSERT_NO_THROW((current.tryCastTo<Row<Any, Any>>()));
+  ASSERT_TRUE((current.tryCastTo<Row<Any, Any>>()) == nullptr);
+
+  // Accessing child writer at an index greater than or equal to the number of
+  // children should fail.
+  auto& typedCurrent = current.castTo<DynamicRow>();
+  ASSERT_THROW(typedCurrent.get_writer_at(2), VeloxUserError);
+  ASSERT_THROW(typedCurrent.set_null_at(2), VeloxUserError);
+
+  // Casting to DynamicRow when the underlying vector is not a RowVector should
+  // fail.
+  VectorPtr array;
+  BaseVector::ensureWritable(
+      SelectivityVector(4), ARRAY(BIGINT()), pool(), &array);
+
+  VectorWriter<Any> writer2;
+  writer2.init(*array);
+
+  writer2.setOffset(0);
+  auto& current2 = writer2.current();
+  ASSERT_THROW(current2.castTo<DynamicRow>(), VeloxUserError);
 }
 
 TEST_F(GenericWriterTest, nested) {
@@ -294,7 +396,7 @@ TEST_F(GenericWriterTest, nested) {
   VectorPtr result;
   BaseVector::ensureWritable(
       SelectivityVector(3),
-      MAP(BIGINT(), ROW({ARRAY(BIGINT()), TINYINT()})),
+      MAP(BIGINT(), ROW({ARRAY(BIGINT()), TINYINT(), ROW({SMALLINT()})})),
       pool(),
       &result);
 
@@ -306,17 +408,20 @@ TEST_F(GenericWriterTest, nested) {
 
     auto& current = writer.current().castTo<Map<Any, Any>>();
 
-    auto pair = current.add_item();
-    std::get<0>(pair).castTo<int64_t>() = i * 3;
+    auto [keyWriter, valueWriter] = current.add_item();
+    keyWriter.castTo<int64_t>() = i * 3;
 
-    auto& row = std::get<1>(pair).castTo<Row<Any, Any>>();
+    auto& rowWriter = valueWriter.castTo<DynamicRow>();
 
-    auto& array = row.get_writer_at<0>().castTo<Array<Any>>();
-    array.add_item().castTo<int64_t>() = i * 3 + 1;
-    *array.add_item().tryCastTo<int64_t>() = i * 3 + 2;
-    array.add_null();
+    auto& arrayWriter = rowWriter.get_writer_at(0).castTo<Array<Any>>();
+    arrayWriter.add_item().castTo<int64_t>() = i * 3 + 1;
+    *arrayWriter.add_item().tryCastTo<int64_t>() = i * 3 + 2;
+    arrayWriter.add_null();
 
-    row.get_writer_at<1>().castTo<int8_t>() = i + 1;
+    rowWriter.get_writer_at(1).castTo<int8_t>() = i + 1;
+
+    auto& innerRowWriter = rowWriter.get_writer_at(2).castTo<Row<Any>>();
+    innerRowWriter.get_writer_at<0>().castTo<int16_t>() = i + 2;
 
     writer.commit(true);
   }
@@ -337,7 +442,10 @@ TEST_F(GenericWriterTest, nested) {
   auto arrayVector = makeNullableArrayVector<int64_t>(
       {{1, 2, std::nullopt}, {4, 5, std::nullopt}, {7, 8, std::nullopt}});
   auto tinyintVector = makeNullableFlatVector<int8_t>({1, 2, 3});
-  auto valueVector = makeRowVector({arrayVector, tinyintVector});
+  auto smallintVector = makeNullableFlatVector<int16_t>({2, 3, 4});
+
+  auto valueVector = makeRowVector(
+      {arrayVector, tinyintVector, makeRowVector({smallintVector})});
   auto keyVector = makeNullableFlatVector<int64_t>({0, 3, 6});
 
   auto offsets = AlignedBuffer::allocate<vector_size_t>(3, pool());
@@ -352,7 +460,7 @@ TEST_F(GenericWriterTest, nested) {
 
   auto mapVector = std::make_shared<MapVector>(
       pool(),
-      MAP(BIGINT(), ROW({ARRAY(BIGINT()), TINYINT()})),
+      MAP(BIGINT(), ROW({ARRAY(BIGINT()), TINYINT(), ROW({SMALLINT()})})),
       nullptr,
       3,
       offsets,
@@ -383,8 +491,8 @@ TEST_F(GenericWriterTest, commitNull) {
 }
 
 TEST_F(GenericWriterTest, handleMisuse) {
-  auto initializeAndAddElements = [](const VectorPtr& vector,
-                                     VectorWriter<Any>& writer) {
+  auto initializeAndAddElementsForArray = [](const VectorPtr& vector,
+                                             VectorWriter<Any>& writer) {
     writer.init(*vector);
     writer.setOffset(0);
 
@@ -396,23 +504,66 @@ TEST_F(GenericWriterTest, handleMisuse) {
   // Test finish without commit.
   VectorPtr result;
   BaseVector::ensureWritable(
-      SelectivityVector(1), ARRAY(BIGINT()), pool(), &result);
+      SelectivityVector(2), ARRAY(BIGINT()), pool(), &result);
 
-  VectorWriter<Any> writer1;
-  initializeAndAddElements(result, writer1);
+  {
+    VectorWriter<Any> writer;
+    initializeAndAddElementsForArray(result, writer);
 
-  writer1.finish();
-  ASSERT_EQ(result->as<ArrayVector>()->elements()->size(), 0);
+    writer.finish();
+    ASSERT_EQ(result->as<ArrayVector>()->elements()->size(), 0);
+  }
 
-  // Test commitNull after adding elements.
-  VectorWriter<Any> writer2;
-  initializeAndAddElements(result, writer2);
+  // Test commitNull after adding elements to array.
+  {
+    VectorWriter<Any> writer;
+    initializeAndAddElementsForArray(result, writer);
+    writer.commitNull();
 
-  writer2.commitNull();
-  writer2.finish();
+    writer.setOffset(1);
+    writer.commit(true);
+    writer.finish();
 
-  ASSERT_EQ(result->as<ArrayVector>()->elements()->size(), 0);
-  ASSERT_TRUE(result->as<ArrayVector>()->isNullAt(0));
+    ASSERT_EQ(result->as<ArrayVector>()->elements()->size(), 0);
+    ASSERT_TRUE(result->isNullAt(0));
+    ASSERT_FALSE(result->isNullAt(1));
+  }
+
+  // Test commitNull after adding elements to DynamicRow of array.
+  {
+    VectorPtr result;
+    BaseVector::ensureWritable(
+        SelectivityVector(2),
+        ROW({ARRAY(BIGINT()), TINYINT()}),
+        pool(),
+        &result);
+
+    VectorWriter<Any> writer;
+    writer.init(*result);
+
+    for (int i = 0; i < 2; ++i) {
+      writer.setOffset(i);
+      auto& rowWriter = writer.current().castTo<DynamicRow>();
+      auto& arrayWriter = rowWriter.get_writer_at(0).castTo<Array<Any>>();
+      arrayWriter.add_item().castTo<int64_t>() = i * 2;
+      rowWriter.get_writer_at(1).castTo<int8_t>() = i * 2 + 1;
+
+      if (i == 0) {
+        writer.commitNull();
+      } else {
+        writer.commit(true);
+      }
+    }
+    writer.finish();
+    ASSERT_TRUE(result->isNullAt(0));
+
+    auto child1 =
+        vectorMaker_.arrayVectorNullable<int64_t>({std::nullopt, {{2}}});
+    auto child2 = makeNullableFlatVector<int8_t>({std::nullopt, 3});
+    auto rowVector = makeRowVector({child1, child2});
+    rowVector->setNull(0, true);
+    test::assertEqualVectors(rowVector, result);
+  }
 }
 
 } // namespace

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1912,6 +1912,13 @@ struct CastTypeChecker {
   }
 };
 
+template <>
+struct CastTypeChecker<DynamicRow> {
+  static bool check(const TypePtr& vectorType) {
+    return TypeKind::ROW == vectorType->kind();
+  }
+};
+
 template <typename T>
 struct CastTypeChecker<Generic<T>> {
   static bool check(const TypePtr&) {


### PR DESCRIPTION
Summary: This diff adds support for casting a GenericWriter to a DynamicRowWriter that allows arbitrary number of children (determined by the vector being written to). This is necessary for cast-JSON-to-ROW implementation.

Differential Revision: D37566345

