### PR TITLE
Add NegatedBytesValues filters to dwrf reader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -164,6 +164,10 @@ void SelectiveStringDictionaryColumnReader::processFilter(
     case common::FilterKind::kBytesValues:
       readHelper<common::BytesValues, isDense>(filter, rows, extractValues);
       break;
+    case common::FilterKind::kNegatedBytesValues:
+      readHelper<common::NegatedBytesValues, isDense>(
+          filter, rows, extractValues);
+      break;
     default:
       readHelper<common::Filter, isDense>(filter, rows, extractValues);
       break;

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -403,6 +403,10 @@ void SelectiveStringDirectColumnReader::processFilter(
     case common::FilterKind::kBytesValues:
       readHelper<common::BytesValues, isDense>(filter, rows, extractValues);
       break;
+    case common::FilterKind::kNegatedBytesValues:
+      readHelper<common::NegatedBytesValues, isDense>(
+          filter, rows, extractValues);
+      break;
     default:
       readHelper<common::Filter, isDense>(filter, rows, extractValues);
       break;


### PR DESCRIPTION
Summary:
This diff adds support for the `NegatedBytesValues` filter class to the dwrf reader, which takes a filter and reads rows from a file that are accepted by the filter. These changes were made in the two files that deal with reading values of type varchar, which are `SelectiveStringDictionaryColumnReader.h` and `SelectiveStringDirectColumnReader.cpp`.

With this added support, `FilterGenerator.cpp` has also been modified to sometimes create `BytesValues` and `NegatedBytesValues` filters (similar to what was done in D37133348 (https://github.com/facebookincubator/velox/commit/f2ec094803f92badf100b4c20d25cfa6fa8c2e08)) so that the unit tests in `E2EFilterTest.cpp` will check this functionality as well.

Reviewed By: gggrace14

Differential Revision: D37398220

