### PR TITLE
Fix buffer reuse bug on Upper/Lower function

### DIFF
--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -99,19 +99,17 @@ class UpperLowerTemplateFunction : public exec::VectorFunction {
     bool tryInplace = ascii &&
         (inputStringsVector->encoding() == VectorEncoding::Simple::FLAT);
 
-    bool inputVectorMoved =
-        prepareFlatResultsVector(result, rows, context, args.at(0));
-
-    bool inPlace = tryInplace && inputVectorMoved;
-
-    if (inPlace) {
+    // If tryInplace, then call prepareFlatResultsVector(). If the latter
+    // returns true, note that the input arg was moved to result, so that the
+    // buffer can be reused as output.
+    if (tryInplace &&
+        prepareFlatResultsVector(result, rows, context, args.at(0))) {
       auto* resultFlatVector = (*result)->as<FlatVector<StringView>>();
-
       applyInternalInPlace(rows, decodedInput, resultFlatVector);
       return;
     }
 
-    // Not in place path
+    // Not in place path.
     VectorPtr emptyVectorPtr;
     prepareFlatResultsVector(result, rows, context, emptyVectorPtr);
     auto* resultFlatVector = (*result)->as<FlatVector<StringView>>();


### PR DESCRIPTION
Summary:
Another bug caught by Fuzzer: UpperLower vectorized function was
moving away the input buffer and losing all references to it, causing the
Vector that holds the string buffer to run out of scope and be destroyed before
the function execution started, causing the function to trigger a
use-after-free ASAN crash. The issue is only reported in ASAN mode.

Differential Revision: D37674304

