### PR TITLE
Allow constant input for single-argument vector functions

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -260,17 +260,6 @@ class Expr {
       EvalCtx& context,
       VectorPtr& result);
 
-  // Calls 'vectorFunction_' on values in 'inputValues_'.
-  void applyVectorFunction(
-      const SelectivityVector& rows,
-      EvalCtx& context,
-      VectorPtr& result);
-
-  void applySingleConstArgVectorFunction(
-      const SelectivityVector& rows,
-      EvalCtx& context,
-      VectorPtr& result);
-
   // Returns true if values in 'distinctFields_' have nulls that are
   // worth skipping. If so, the rows in 'rows' with at least one sure
   // null are deselected in 'nullHolder->get()'.

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -38,14 +38,13 @@ class VectorFunction {
   ///
   /// The rows may or may not be contiguous.
   ///
-  /// Single-argument deterministic functions always receive their argument
-  /// vector as flat. These functions don't need to use DecodedVector to handle
-  /// encodings.
+  /// Single-argument deterministic functions may receive their only argument
+  /// vector as flat or constant, but not dictionary encoded.
   ///
   /// Single-argument functions that specify null-in-null-out behavior, e.g.
-  /// isDefaultNullBehavior returns true, will never see a null row in rows.
-  /// Hence, they can safely assume that args[0] vector is flat and has no nulls
-  /// in specified positions.
+  /// isDefaultNullBehavior returns true, will never see a null row in 'rows'.
+  /// Hence, they can safely assume that args[0] vector is flat or constant and
+  /// has no nulls in specified positions.
   ///
   /// Multi-argument functions that specify null-in-null-out behavior will never
   /// see a null row in any of the arguments. They can safely assume that there

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -1172,30 +1172,28 @@ class PlusConstantFunction : public exec::VectorFunction {
       VectorPtr* result) const override {
     VELOX_CHECK_EQ(args.size(), 1);
 
-    auto arg = args[0];
-    VELOX_CHECK_EQ(
-        arg->encoding(), facebook::velox::VectorEncoding::Simple::FLAT);
+    auto& arg = args[0];
 
-    auto rawInput = arg->asFlatVector<int32_t>()->rawValues();
+    // The argument may be flat or constant.
+    VELOX_CHECK(arg->isFlatEncoding() || arg->isConstantEncoding());
 
-    if (!result) {
-      *result = BaseVector::create(INTEGER(), rows.size(), context->pool());
-    } else {
-      BaseVector::ensureWritable(rows, INTEGER(), context->pool(), result);
-    }
+    BaseVector::ensureWritable(rows, INTEGER(), context->pool(), result);
+
     auto flatResult = (*result)->asFlatVector<int32_t>();
     auto rawResult = flatResult->mutableRawValues();
-    uint64_t* rawNulls = nullptr;
-    if (flatResult->mayHaveNulls()) {
-      rawNulls = flatResult->mutableRawNulls();
+
+    flatResult->clearNulls(rows);
+
+    if (arg->isConstantEncoding()) {
+      auto value = arg->as<ConstantVector<int32_t>>()->valueAt(0);
+      rows.applyToSelected(
+          [&](auto row) { rawResult[row] = value + addition_; });
+    } else {
+      auto* rawInput = arg->as<FlatVector<int32_t>>()->rawValues();
+
+      rows.applyToSelected(
+          [&](auto row) { rawResult[row] = rawInput[row] + addition_; });
     }
-    rows.applyToSelected([&](vector_size_t row) {
-      rawResult[row] = rawInput[row] + addition_;
-      if (rawNulls) {
-        bits::clearBit(rawNulls, row);
-      }
-      return true;
-    });
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
@@ -2098,7 +2096,7 @@ class TestingSequenceFunction : public exec::VectorFunction {
 };
 
 // Single-argument deterministic functions always receive their argument
-// vector as flat.
+// vector as flat or constant.
 class TestingSingleArgDeterministicFunction : public exec::VectorFunction {
  public:
   void apply(
@@ -2107,9 +2105,10 @@ class TestingSingleArgDeterministicFunction : public exec::VectorFunction {
       const TypePtr& outputType,
       exec::EvalCtx* context,
       VectorPtr* result) const override {
-    VELOX_CHECK_EQ(args[0]->encoding(), VectorEncoding::Simple::FLAT);
+    auto& arg = args[0];
+    VELOX_CHECK(arg->isFlatEncoding() || arg->isConstantEncoding());
     BaseVector::ensureWritable(rows, outputType, context->pool(), result);
-    (*result)->copy(args[0].get(), rows, nullptr);
+    (*result)->copy(arg.get(), rows, nullptr);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/prestosql/ArrayDistinct.cpp
+++ b/velox/functions/prestosql/ArrayDistinct.cpp
@@ -24,36 +24,61 @@
 namespace facebook::velox::functions {
 namespace {
 
-// See documentation at https://prestodb.io/docs/current/functions/array.html
+/// See documentation at https://prestodb.io/docs/current/functions/array.html
+///
+/// array_distinct SQL function.
+///
+/// Along with the set, we maintain a `hasNull` flag that indicates whether
+/// null is present in the array.
+///
+/// Zero element copy:
+///
+/// In order to prevent copies of array elements, the function reuses the
+/// internal elements() vector from the original ArrayVector.
+///
+/// First a new vector is created containing the indices of the elements
+/// which will be present in the output, and wrapped into a DictionaryVector.
+/// Next the `lengths` and `offsets` vectors that control where output arrays
+/// start and end are wrapped into the output ArrayVector.template <typename T>
 template <typename T>
 class ArrayDistinctFunction : public exec::VectorFunction {
  public:
-  /// This class implements the array_distinct query function.
-  ///
-  /// Along with the set, we maintain a `hasNull` flag that indicates whether
-  /// null is present in the array.
-  ///
-  /// Zero element copy:
-  ///
-  /// In order to prevent copies of array elements, the function reuses the
-  /// internal elements() vector from the original ArrayVector.
-  ///
-  /// First a new vector is created containing the indices of the elements
-  /// which will be present in the output, and wrapped into a DictionaryVector.
-  /// Next the `lengths` and `offsets` vectors that control where output arrays
-  /// start and end are wrapped into the output ArrayVector.
-
-  ArrayDistinctFunction() {}
-
-  // Execute function.
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
       exec::EvalCtx* context,
       VectorPtr* result) const override {
-    // Acquire the array elements vector.
-    auto arrayVector = args.front()->as<ArrayVector>();
+    auto& arg = args[0];
+
+    VectorPtr localResult;
+
+    // Input can be constant or flat.
+    if (arg->isConstantEncoding()) {
+      auto* constantArray = arg->as<ConstantVector<ComplexType>>();
+      const auto& flatArray = constantArray->valueVector();
+      const auto flatIndex = constantArray->index();
+
+      SelectivityVector singleRow(flatIndex + 1, false);
+      singleRow.setValid(flatIndex, true);
+      singleRow.updateBounds();
+
+      localResult = applyFlat(singleRow, flatArray, context);
+      localResult =
+          BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
+    } else {
+      localResult = applyFlat(rows, arg, context);
+    }
+
+    context->moveOrCopyResult(localResult, rows, result);
+  }
+
+ private:
+  VectorPtr applyFlat(
+      const SelectivityVector& rows,
+      const VectorPtr& arg,
+      exec::EvalCtx* context) const {
+    auto arrayVector = arg->as<ArrayVector>();
     auto elementsVector = arrayVector->elements();
     auto elementsRows =
         toElementRows(elementsVector->size(), rows, arrayVector);
@@ -106,17 +131,15 @@ class ArrayDistinctFunction : public exec::VectorFunction {
     auto newElements =
         BaseVector::transpose(newIndices, std::move(elementsVector));
 
-    // Prepare and return result set.
-    auto resultArray = std::make_shared<ArrayVector>(
+    return std::make_shared<ArrayVector>(
         pool,
-        outputType,
+        arrayVector->type(),
         nullptr,
         rowCount,
         std::move(newOffsets),
         std::move(newLengths),
         std::move(newElements),
         0);
-    context->moveOrCopyResult(resultArray, rows, result);
   }
 };
 

--- a/velox/functions/prestosql/MapEntries.cpp
+++ b/velox/functions/prestosql/MapEntries.cpp
@@ -28,27 +28,28 @@ class MapEntriesFunction : public exec::VectorFunction {
       const TypePtr& outputType,
       exec::EvalCtx* context,
       VectorPtr* result) const override {
-    VELOX_CHECK_EQ(args.size(), 1);
-    VELOX_CHECK_EQ(args[0]->type()->kind(), TypeKind::MAP);
+    auto& arg = args[0];
 
-    const auto inputMap = args[0]->as<MapVector>();
+    VectorPtr localResult;
 
-    VectorPtr resultElements = std::make_shared<RowVector>(
-        context->pool(),
-        outputType->childAt(0),
-        BufferPtr(nullptr),
-        inputMap->mapKeys()->size(),
-        std::vector<VectorPtr>{inputMap->mapKeys(), inputMap->mapValues()});
-    auto resultArray = std::make_shared<ArrayVector>(
-        context->pool(),
-        outputType,
-        inputMap->nulls(),
-        rows.size(),
-        inputMap->offsets(),
-        inputMap->sizes(),
-        resultElements);
+    // Input can be constant or flat.
+    if (arg->isConstantEncoding()) {
+      auto* constantMap = arg->as<ConstantVector<ComplexType>>();
+      const auto& flatMap = constantMap->valueVector();
+      const auto flatIndex = constantMap->index();
 
-    context->moveOrCopyResult(resultArray, rows, result);
+      SelectivityVector singleRow(flatIndex + 1, false);
+      singleRow.setValid(flatIndex, true);
+      singleRow.updateBounds();
+
+      localResult = applyFlat(singleRow, flatMap, outputType, context);
+      localResult =
+          BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
+    } else {
+      localResult = applyFlat(rows, arg, outputType, context);
+    }
+
+    context->moveOrCopyResult(localResult, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
@@ -59,6 +60,31 @@ class MapEntriesFunction : public exec::VectorFunction {
                 .returnType("array(row(K,V))")
                 .argumentType("map(K,V)")
                 .build()};
+  }
+
+ private:
+  VectorPtr applyFlat(
+      const SelectivityVector& rows,
+      const VectorPtr& arg,
+      const TypePtr& outputType,
+      exec::EvalCtx* context) const {
+    const auto inputMap = arg->as<MapVector>();
+
+    VectorPtr resultElements = std::make_shared<RowVector>(
+        context->pool(),
+        outputType->childAt(0),
+        BufferPtr(nullptr),
+        inputMap->mapKeys()->size(),
+        std::vector<VectorPtr>{inputMap->mapKeys(), inputMap->mapValues()});
+
+    return std::make_shared<ArrayVector>(
+        context->pool(),
+        outputType,
+        inputMap->nulls(),
+        rows.size(),
+        inputMap->offsets(),
+        inputMap->sizes(),
+        resultElements);
   }
 };
 } // namespace

--- a/velox/functions/prestosql/Reverse.cpp
+++ b/velox/functions/prestosql/Reverse.cpp
@@ -24,7 +24,7 @@ namespace facebook::velox::functions {
 
 ///  reverse(Array[E]) -> Array[E]
 ///  Takes any array as an input and returns the reversed array.
-
+///
 ///  reverse(Varchar) -> Varchar
 ///  Takes any Varchar as an input and returns the reversed varchar.
 class ReverseFunction : public exec::VectorFunction {
@@ -72,16 +72,35 @@ class ReverseFunction : public exec::VectorFunction {
       std::vector<VectorPtr>& args,
       exec::EvalCtx* context,
       VectorPtr* result) const {
-    BaseVector* inputStringsVector = args[0].get();
-    auto inputStringVector = inputStringsVector->as<FlatVector<StringView>>();
+    auto* arg = args[0].get();
 
-    auto ascii = isAscii(inputStringsVector, rows);
+    auto ascii = isAscii(arg, rows);
 
     prepareFlatResultsVector(result, rows, context, args[0]);
-    auto* resultFlatVector = (*result)->as<FlatVector<StringView>>();
+    auto* flatResult = (*result)->as<FlatVector<StringView>>();
 
-    StringEncodingTemplateWrapper<ApplyVarcharInternal>::apply(
-        ascii, rows, inputStringVector, resultFlatVector);
+    // Input can be constant or flat.
+    if (arg->isConstantEncoding()) {
+      auto value = arg->as<ConstantVector<StringView>>()->valueAt(0);
+
+      auto proxy = exec::StringWriter<>(flatResult, rows.begin());
+      if (ascii) {
+        stringImpl::reverse<true>(proxy, value.str());
+      } else {
+        stringImpl::reverse<false>(proxy, value.str());
+      }
+      proxy.finalize();
+
+      auto rawResults = flatResult->mutableRawValues();
+      auto reversedValue = rawResults[rows.begin()];
+
+      rows.applyToSelected([&](auto row) { rawResults[row] = reversedValue; });
+    } else {
+      auto flatInput = arg->as<FlatVector<StringView>>();
+
+      StringEncodingTemplateWrapper<ApplyVarcharInternal>::apply(
+          ascii, rows, flatInput, flatResult);
+    }
   }
 
   bool ensureStringEncodingSetAtAllInputs() const override {
@@ -97,7 +116,34 @@ class ReverseFunction : public exec::VectorFunction {
       std::vector<VectorPtr>& args,
       exec::EvalCtx* context,
       VectorPtr* result) const {
-    auto vector = args[0].get();
+    auto& arg = args[0];
+
+    VectorPtr localResult;
+
+    // Input can be constant or flat.
+    if (arg->isConstantEncoding()) {
+      auto* constantArray = arg->as<ConstantVector<ComplexType>>();
+      const auto& flatArray = constantArray->valueVector();
+      const auto flatIndex = constantArray->index();
+
+      SelectivityVector singleRow(flatIndex + 1, false);
+      singleRow.setValid(flatIndex, true);
+      singleRow.updateBounds();
+
+      localResult = applyArrayFlat(singleRow, flatArray, context);
+      localResult =
+          BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
+    } else {
+      localResult = applyArrayFlat(rows, arg, context);
+    }
+
+    context->moveOrCopyResult(localResult, rows, result);
+  }
+
+  VectorPtr applyArrayFlat(
+      const SelectivityVector& rows,
+      const VectorPtr& vector,
+      exec::EvalCtx* context) const {
     auto arrayVector = vector->as<ArrayVector>();
     auto elementCount = arrayVector->elements()->size();
 
@@ -122,7 +168,7 @@ class ReverseFunction : public exec::VectorFunction {
     auto elementsDict =
         BaseVector::transpose(indices, std::move(elementsVector));
 
-    auto resultArray = std::make_shared<ArrayVector>(
+    return std::make_shared<ArrayVector>(
         pool,
         vector->type(),
         arrayVector->nulls(),
@@ -131,8 +177,6 @@ class ReverseFunction : public exec::VectorFunction {
         arrayVector->sizes(),
         elementsDict,
         arrayVector->getNullCount());
-
-    context->moveOrCopyResult(resultArray, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
@@ -305,3 +305,27 @@ TEST_F(ArrayDistinctTest, nonContiguousRows) {
       makeRowVector({c0, c1, c2}));
   assertEqualVectors(expected, result);
 }
+
+TEST_F(ArrayDistinctTest, constant) {
+  vector_size_t size = 1'000;
+  auto data =
+      makeArrayVector<int64_t>({{1, 2, 3, 2, 1}, {4, 5, 4, 5}, {6, 6, 6, 6}});
+
+  auto evaluateConstant = [&](vector_size_t row, const VectorPtr& vector) {
+    return evaluate(
+        "array_distinct(c0)",
+        makeRowVector({BaseVector::wrapInConstant(size, row, vector)}));
+  };
+
+  auto result = evaluateConstant(0, data);
+  auto expected = makeConstantArray<int64_t>(size, {1, 2, 3});
+  assertEqualVectors(expected, result);
+
+  result = evaluateConstant(1, data);
+  expected = makeConstantArray<int64_t>(size, {4, 5});
+  assertEqualVectors(expected, result);
+
+  result = evaluateConstant(2, data);
+  expected = makeConstantArray<int64_t>(size, {6});
+  assertEqualVectors(expected, result);
+}

--- a/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
@@ -174,3 +174,26 @@ TEST_F(ArrayDuplicatesTest, nonContiguousRows) {
       makeRowVector({c0, c1, c2}));
   assertEqualVectors(expected, result);
 }
+
+TEST_F(ArrayDuplicatesTest, constant) {
+  vector_size_t size = 1'000;
+  auto data = makeArrayVector<int64_t>({{1, 2, 3}, {4, 5, 4, 5}, {6, 6, 6, 6}});
+
+  auto evaluateConstant = [&](vector_size_t row, const VectorPtr& vector) {
+    return evaluate(
+        "array_duplicates(c0)",
+        makeRowVector({BaseVector::wrapInConstant(size, row, vector)}));
+  };
+
+  auto result = evaluateConstant(0, data);
+  auto expected = makeConstantArray<int64_t>(size, {});
+  assertEqualVectors(expected, result);
+
+  result = evaluateConstant(1, data);
+  expected = makeConstantArray<int64_t>(size, {4, 5});
+  assertEqualVectors(expected, result);
+
+  result = evaluateConstant(2, data);
+  expected = makeConstantArray<int64_t>(size, {6});
+  assertEqualVectors(expected, result);
+}

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -376,6 +376,34 @@ TEST_P(ArraySortTest, basic) {
   runTest(GetParam());
 }
 
+TEST_P(ArraySortTest, constant) {
+  if (GetParam() != TypeKind::BIGINT) {
+    GTEST_SKIP() << "Skipping constant test for non-bigint type";
+  }
+
+  vector_size_t size = 1'000;
+  auto data =
+      makeArrayVector<int64_t>({{1, 2, 3, 0}, {4, 5, 4, 5}, {6, 6, 6, 6}});
+
+  auto evaluateConstant = [&](vector_size_t row, const VectorPtr& vector) {
+    return evaluate(
+        "array_sort(c0)",
+        makeRowVector({BaseVector::wrapInConstant(size, row, vector)}));
+  };
+
+  auto result = evaluateConstant(0, data);
+  auto expected = makeConstantArray<int64_t>(size, {0, 1, 2, 3});
+  assertEqualVectors(expected, result);
+
+  result = evaluateConstant(1, data);
+  expected = makeConstantArray<int64_t>(size, {4, 4, 5, 5});
+  assertEqualVectors(expected, result);
+
+  result = evaluateConstant(2, data);
+  expected = makeConstantArray<int64_t>(size, {6, 6, 6, 6});
+  assertEqualVectors(expected, result);
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     ArraySortTest,
     ArraySortTest,

--- a/velox/functions/prestosql/tests/MapKeysAndValuesTest.cpp
+++ b/velox/functions/prestosql/tests/MapKeysAndValuesTest.cpp
@@ -232,6 +232,43 @@ TEST_F(MapKeysTest, partiallyPopulatedSomeNulls) {
   testMapKeysPartiallyPopulated(sizeAt, nullEvery(5));
 }
 
+TEST_F(MapKeysTest, constant) {
+  vector_size_t size = 1'000;
+  auto data = makeMapVector<int64_t, int64_t>({
+      {
+          {0, 0},
+          {1, 10},
+          {2, 20},
+          {3, 30},
+      },
+      {
+          {4, 40},
+          {5, 50},
+      },
+      {
+          {6, 60},
+      },
+  });
+
+  auto evaluateConstant = [&](vector_size_t row, const VectorPtr& vector) {
+    return evaluate(
+        "map_keys(c0)",
+        makeRowVector({BaseVector::wrapInConstant(size, row, vector)}));
+  };
+
+  auto result = evaluateConstant(0, data);
+  auto expected = makeConstantArray<int64_t>(size, {0, 1, 2, 3});
+  test::assertEqualVectors(expected, result);
+
+  result = evaluateConstant(1, data);
+  expected = makeConstantArray<int64_t>(size, {4, 5});
+  test::assertEqualVectors(expected, result);
+
+  result = evaluateConstant(2, data);
+  expected = makeConstantArray<int64_t>(size, {6});
+  test::assertEqualVectors(expected, result);
+}
+
 TEST_F(MapValuesTest, noNulls) {
   auto sizeAt = [](vector_size_t row) { return row % 7; };
   testMapValues(sizeAt, nullptr);
@@ -255,4 +292,41 @@ TEST_F(MapValuesTest, partiallyPopulatedNoNulls) {
 TEST_F(MapValuesTest, partiallyPopulatedSomeNulls) {
   auto sizeAt = [](vector_size_t /* row */) { return 1; };
   testMapValuesPartiallyPopulated(sizeAt, nullEvery(5));
+}
+
+TEST_F(MapValuesTest, constant) {
+  vector_size_t size = 1'000;
+  auto data = makeMapVector<int64_t, int64_t>({
+      {
+          {0, 0},
+          {1, 10},
+          {2, 20},
+          {3, 30},
+      },
+      {
+          {4, 40},
+          {5, 50},
+      },
+      {
+          {6, 60},
+      },
+  });
+
+  auto evaluateConstant = [&](vector_size_t row, const VectorPtr& vector) {
+    return evaluate(
+        "map_values(c0)",
+        makeRowVector({BaseVector::wrapInConstant(size, row, vector)}));
+  };
+
+  auto result = evaluateConstant(0, data);
+  auto expected = makeConstantArray<int64_t>(size, {0, 10, 20, 30});
+  test::assertEqualVectors(expected, result);
+
+  result = evaluateConstant(1, data);
+  expected = makeConstantArray<int64_t>(size, {40, 50});
+  test::assertEqualVectors(expected, result);
+
+  result = evaluateConstant(2, data);
+  expected = makeConstantArray<int64_t>(size, {60});
+  test::assertEqualVectors(expected, result);
 }

--- a/velox/functions/prestosql/tests/NotTest.cpp
+++ b/velox/functions/prestosql/tests/NotTest.cpp
@@ -23,21 +23,27 @@ class NotTest : public functions::test::FunctionBaseTest {};
 TEST_F(NotTest, noNulls) {
   constexpr vector_size_t size = 1'000;
 
-  // All true.
+  // All true. Flat encoding.
   auto allTrue = makeFlatVector<bool>(size, [](auto /*row*/) { return true; });
   auto result =
       evaluate<SimpleVector<bool>>("not(c0)", makeRowVector({allTrue}));
-  for (int i = 0; i < size; ++i) {
-    EXPECT_FALSE(result->valueAt(i)) << "at " << i;
-  }
+  assertEqualVectors(makeConstant(false, size), result);
 
-  // All false.
+  // All true. Constant encoding.
+  result = evaluate<SimpleVector<bool>>(
+      "not(c0)", makeRowVector({makeConstant(true, size)}));
+  assertEqualVectors(makeConstant(false, size), result);
+
+  // All false. Flat encoding.
   auto allFalse =
       makeFlatVector<bool>(size, [](auto /*row*/) { return false; });
   result = evaluate<SimpleVector<bool>>("not(c0)", makeRowVector({allFalse}));
-  for (int i = 0; i < size; ++i) {
-    EXPECT_TRUE(result->valueAt(i)) << "at " << i;
-  }
+  assertEqualVectors(makeConstant(true, size), result);
+
+  // All false. Constant encoding.
+  result = evaluate<SimpleVector<bool>>(
+      "not(c0)", makeRowVector({makeConstant(false, size)}));
+  assertEqualVectors(makeConstant(true, size), result);
 
   // False in odd positions: True, False, True, False,... .
   auto oddFalse =

--- a/velox/functions/sparksql/ArraySort.h
+++ b/velox/functions/sparksql/ArraySort.h
@@ -41,8 +41,13 @@ class ArraySort : public exec::VectorFunction {
       VectorPtr* result) const override;
 
  private:
-  bool ascending_;
-  bool nullsFirst_;
+  VectorPtr applyFlat(
+      const SelectivityVector& rows,
+      const VectorPtr& arg,
+      exec::EvalCtx* context) const;
+
+  const bool ascending_;
+  const bool nullsFirst_;
 };
 
 std::shared_ptr<exec::VectorFunction> makeArraySort(

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -385,16 +385,6 @@ class BaseVector {
     return result;
   }
 
-  // Move or copy an element at 'source' row into 'target' row.
-  // This can be more efficient than copy for complex types.
-  virtual void move(vector_size_t source, vector_size_t target) {
-    VELOX_CHECK_LT(source, size());
-    VELOX_CHECK_LT(target, size());
-    if (source != target) {
-      copy(this, target, source, 1);
-    }
-  }
-
   virtual void copy(
       const BaseVector* source,
       vector_size_t targetIndex,

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -239,18 +239,6 @@ void RowVector::copy(
   }
 }
 
-void RowVector::move(vector_size_t source, vector_size_t target) {
-  VELOX_CHECK_LT(source, size());
-  VELOX_CHECK_LT(target, size());
-  if (source != target) {
-    for (auto& child : children_) {
-      if (child) {
-        child->move(source, target);
-      }
-    }
-  }
-}
-
 uint64_t RowVector::hashValueAt(vector_size_t index) const {
   if (isNullAt(index)) {
     return BaseVector::kNullHash;
@@ -495,19 +483,6 @@ void ArrayVector::copy(
   }
 }
 
-void ArrayVector::move(vector_size_t source, vector_size_t target) {
-  VELOX_CHECK_LT(source, size());
-  VELOX_CHECK_LT(target, size());
-  if (source != target) {
-    if (isNullAt(source)) {
-      setNull(target, true);
-    } else {
-      offsets_->asMutable<vector_size_t>()[target] = rawOffsets_[source];
-      sizes_->asMutable<vector_size_t>()[target] = rawSizes_[source];
-    }
-  }
-}
-
 std::string ArrayVector::toString(vector_size_t index) const {
   if (isNullAt(index)) {
     return "null";
@@ -719,19 +694,6 @@ void MapVector::copy(
             sourceMap->offsetAt(wrappedIndex),
             copySize);
       }
-    }
-  }
-}
-
-void MapVector::move(vector_size_t source, vector_size_t target) {
-  VELOX_CHECK_LT(source, size());
-  VELOX_CHECK_LT(target, size());
-  if (source != target) {
-    if (isNullAt(source)) {
-      setNull(target, true);
-    } else {
-      offsets_->asMutable<vector_size_t>()[target] = rawOffsets_[source];
-      sizes_->asMutable<vector_size_t>()[target] = rawSizes_[source];
     }
   }
 }

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -128,8 +128,6 @@ class RowVector : public BaseVector {
       const SelectivityVector& rows,
       const vector_size_t* toSourceRow) override;
 
-  void move(vector_size_t source, vector_size_t target) override;
-
   uint64_t retainedSize() const override {
     auto size = BaseVector::retainedSize();
     for (auto& child : children_) {
@@ -359,8 +357,6 @@ class ArrayVector : public BaseVector {
       vector_size_t sourceIndex,
       vector_size_t count) override;
 
-  void move(vector_size_t source, vector_size_t target) override;
-
   uint64_t retainedSize() const override {
     return BaseVector::retainedSize() + offsets_->capacity() +
         sizes_->capacity() + elements_->retainedSize();
@@ -536,8 +532,6 @@ class MapVector : public BaseVector {
       vector_size_t targetIndex,
       vector_size_t sourceIndex,
       vector_size_t count) override;
-
-  void move(vector_size_t source, vector_size_t target) override;
 
   uint64_t retainedSize() const override {
     return BaseVector::retainedSize() + offsets_->capacity() +

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -292,11 +292,6 @@ class ConstantVector final : public SimpleVector<T> {
     VELOX_FAIL("addNulls not supported");
   }
 
-  void move(vector_size_t /*source*/, vector_size_t target) override {
-    VELOX_CHECK_LT(target, BaseVector::length_);
-    // nothing to do
-  }
-
   std::optional<int32_t> compare(
       const BaseVector* other,
       vector_size_t index,

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -508,26 +508,6 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     }
   }
 
-  void testMove(
-      const VectorPtr& vector,
-      vector_size_t source,
-      vector_size_t target) {
-    // Save 'source' row in a temp vector.
-    auto temp = BaseVector::create(vector->type(), 1, pool_.get());
-    temp->copy(vector.get(), 0, source, 1);
-
-    // Confirm that source and target rows are not the same.
-    ASSERT_TRUE(temp->equalValueAt(vector.get(), 0, source));
-    ASSERT_FALSE(temp->equalValueAt(vector.get(), 0, target));
-
-    vector->move(source, target);
-
-    // Verify that source and target rows are now the same and equal the
-    // original source row.
-    ASSERT_TRUE(temp->equalValueAt(vector.get(), 0, source));
-    ASSERT_TRUE(temp->equalValueAt(vector.get(), 0, target));
-  }
-
   void testCopy(VectorPtr source, int level) {
     testCopyEncoded(source);
     if (level == 0) {
@@ -912,8 +892,6 @@ TEST_F(VectorTest, row) {
   auto allNull =
       BaseVector::createNullConstant(baseRow->type(), 50, pool_.get());
   testCopy(allNull, numIterations_);
-
-  testMove(baseRow, 5, 23);
 }
 
 TEST_F(VectorTest, array) {
@@ -924,8 +902,6 @@ TEST_F(VectorTest, array) {
   auto allNull =
       BaseVector::createNullConstant(baseArray->type(), 50, pool_.get());
   testCopy(allNull, numIterations_);
-
-  testMove(baseArray, 5, 23);
 }
 
 TEST_F(VectorTest, fixedSizeArray) {
@@ -937,8 +913,6 @@ TEST_F(VectorTest, fixedSizeArray) {
   auto allNull =
       BaseVector::createNullConstant(baseArray->type(), 50, pool_.get());
   testCopy(allNull, numIterations_);
-
-  testMove(baseArray, 5, 23);
 }
 
 TEST_F(VectorTest, map) {
@@ -949,8 +923,6 @@ TEST_F(VectorTest, map) {
   auto allNull =
       BaseVector::createNullConstant(baseMap->type(), 50, pool_.get());
   testCopy(allNull, numIterations_);
-
-  testMove(baseMap, 5, 23);
 }
 
 TEST_F(VectorTest, unknown) {

--- a/velox/vector/tests/VectorTestBase.h
+++ b/velox/vector/tests/VectorTestBase.h
@@ -550,6 +550,13 @@ class VectorTestBase {
     return vectorMaker_.constantRow(rowType, value, size);
   }
 
+  /// Create constant vector of type ARRAY from a std::vector.
+  template <typename T>
+  VectorPtr makeConstantArray(vector_size_t size, const std::vector<T>& data) {
+    return BaseVector::wrapInConstant(
+        size, 0, vectorMaker_.arrayVector<T>({data}));
+  }
+
   VectorPtr makeNullConstant(TypeKind typeKind, vector_size_t size) {
     return BaseVector::createConstant(variant(typeKind), size, pool());
   }


### PR DESCRIPTION
VectorFunction::apply used to guarantee that single-argument functions always
receive their only input as flat. This guarantee allowed for simpler
implementation of these functions. To satisfy this contract, expression
evaluation engine needed to flatten constant inputs by copying the only value
and making a new FlatVector. This computation significantly affects performance
of ML preprocessing workloads and shows up prominently in the profile of a new
flat-no-nulls fast path. 

With all the recent improvements, the simple functions API is now very powerful
and performant, hence, the need to write a vector function is rare. This change 
drops the guarantee for single-argument functions.

It also used to be that when all inputs to a vector function are constants, the
function will be evaluated only on one row. The new flat-no-nulls fast path
will change that and vector functions may be called with all-constant inputs
and > 1 row.

Updated single-argument Presto functions to add handling for constant input:
- not
- reverse
- to_utf8
- array_distinct
- array_duplicates
- map_entries
- map_keys
- map_values

Updated single-argument Spark function array_sort.

Removed no longer used BaseVector::move method.