### PR TITLE
Create NegatedBigintRange filter class

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -50,6 +50,18 @@ inline std::unique_ptr<common::BigintRange> greaterThanOrEqual(
       min, std::numeric_limits<int64_t>::max(), nullAllowed);
 }
 
+inline std::unique_ptr<common::NegatedBigintRange> notEqual(
+    int64_t val,
+    bool nullAllowed = false) {
+  return std::make_unique<common::NegatedBigintRange>(val, val, nullAllowed);
+}
+
+inline std::unique_ptr<common::NegatedBigintRange>
+notBetween(int64_t lower, int64_t upper, bool nullAllowed = false) {
+  return std::make_unique<common::NegatedBigintRange>(
+      lower, upper, nullAllowed);
+}
+
 inline std::unique_ptr<common::DoubleRange> lessThanDouble(
     double max,
     bool nullAllowed = false) {

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -47,6 +47,9 @@ std::string Filter::toString() const {
     case FilterKind::kBigintRange:
       strKind = "BigintRange";
       break;
+    case FilterKind::kNegatedBigintRange:
+      strKind = "NegatedBigintRange";
+      break;
     case FilterKind::kBigintValuesUsingHashTable:
       strKind = "BigintValuesUsingHashTable";
       break;
@@ -1052,6 +1055,11 @@ std::unique_ptr<Filter> BigintRange::mergeWith(const Filter* other) const {
     default:
       VELOX_UNREACHABLE();
   }
+}
+
+std::unique_ptr<Filter> NegatedBigintRange::mergeWith(
+    const Filter* other) const {
+  VELOX_NYI("mergeWith is not yet implemented for NegatedBigintRange");
 }
 
 std::unique_ptr<Filter> BigintValuesUsingHashTable::mergeWith(

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -37,6 +37,7 @@ enum class FilterKind {
   kIsNotNull,
   kBoolValue,
   kBigintRange,
+  kNegatedBigintRange,
   kBigintValuesUsingHashTable,
   kBigintValuesUsingBitmask,
   kNegatedBigintValuesUsingHashTable,
@@ -627,6 +628,69 @@ class BigintRange final : public Filter {
   const int16_t lower16_;
   const int16_t upper16_;
   const bool isSingleValue_;
+};
+
+class NegatedBigintRange final : public Filter {
+ public:
+  /// @param lower Lowest value in the rejected range, inclusive.
+  /// @param upper Highest value in the range, inclusive.
+  /// @param nullAllowed Null values are passing the filter if true.
+  NegatedBigintRange(int64_t lower, int64_t upper, bool nullAllowed)
+      : Filter(true, nullAllowed, FilterKind::kNegatedBigintRange),
+        nonNegated_(std::make_unique<BigintRange>(lower, upper, !nullAllowed)) {
+  }
+
+  std::unique_ptr<Filter> clone(
+      std::optional<bool> nullAllowed = std::nullopt) const final {
+    return std::make_unique<NegatedBigintRange>(
+        nonNegated_->lower(),
+        nonNegated_->upper(),
+        nullAllowed.value_or(nullAllowed_));
+  }
+
+  bool testInt64(int64_t value) const final {
+    return !nonNegated_->testInt64(value);
+  }
+
+  xsimd::batch_bool<int64_t> testValues(
+      xsimd::batch<int64_t> values) const final {
+    return ~nonNegated_->testValues(values);
+  }
+
+  xsimd::batch_bool<int32_t> testValues(
+      xsimd::batch<int32_t> values) const final {
+    return ~nonNegated_->testValues(values);
+  }
+
+  xsimd::batch_bool<int16_t> testValues(
+      xsimd::batch<int16_t> values) const final {
+    return ~nonNegated_->testValues(values);
+  }
+
+  bool testInt64Range(int64_t min, int64_t max, bool hasNull) const final {
+    if (hasNull && nullAllowed_) {
+      return true;
+    }
+
+    return !(nonNegated_->lower() <= min && max <= nonNegated_->upper());
+  }
+
+  int64_t lower() const {
+    return nonNegated_->lower();
+  }
+
+  int64_t upper() const {
+    return nonNegated_->upper();
+  }
+
+  std::unique_ptr<Filter> mergeWith(const Filter* other) const final;
+
+  std::string toString() const final {
+    return "Negated" + nonNegated_->toString();
+  }
+
+ private:
+  std::unique_ptr<BigintRange> nonNegated_;
 };
 
 /// IN-list filter for integral data types. Implemented as a hash table. Good

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -175,6 +175,67 @@ TEST(FilterTest, bigIntRange) {
   EXPECT_TRUE(filter->testInt64Range(-100, 10, true));
 }
 
+TEST(FilterTest, negatedBigintRange) {
+  auto filter = notEqual(1, false);
+  EXPECT_FALSE(filter->testNull());
+  EXPECT_FALSE(filter->testInt64(1));
+
+  EXPECT_TRUE(filter->testInt64(-1));
+  EXPECT_TRUE(filter->testInt64(0));
+  EXPECT_TRUE(filter->testInt64(11));
+
+  EXPECT_FALSE(filter->testInt64Range(1, 1, false));
+  EXPECT_FALSE(filter->testInt64Range(1, 1, true));
+  EXPECT_TRUE(filter->testInt64Range(1, 2, false));
+  EXPECT_TRUE(filter->testInt64Range(8, 9, false));
+
+  EXPECT_EQ(filter->lower(), 1);
+  EXPECT_EQ(filter->upper(), 1);
+
+  auto testInt64 = [&](int64_t x) { return filter->testInt64(x); };
+
+  int64_t n4[] = {0, 1, 26, std::numeric_limits<int64_t>::max()};
+  checkSimd(filter.get(), n4, testInt64);
+  int32_t n8[] = {2, 1, 1000, -1000, 1, 15, 0, 1111};
+  checkSimd(filter.get(), n8, testInt64);
+  int16_t n16[] = {
+      2, 1, 1000, -1000, 1, -5, 0, 1111, 2, 1, 1000, -1000, 1, 1, 0, 1111};
+  checkSimd(filter.get(), n16, testInt64);
+
+  filter = notBetween(-5, 15, false);
+  EXPECT_FALSE(filter->testNull());
+  EXPECT_FALSE(filter->testInt64(-5));
+  EXPECT_FALSE(filter->testInt64(-1));
+  EXPECT_FALSE(filter->testInt64(0));
+  EXPECT_FALSE(filter->testInt64(1));
+  EXPECT_FALSE(filter->testInt64(15));
+
+  EXPECT_TRUE(filter->testInt64(-6));
+  EXPECT_TRUE(filter->testInt64(16));
+  EXPECT_TRUE(filter->testInt64(99));
+
+  EXPECT_FALSE(filter->testInt64Range(-5, 15, false));
+  EXPECT_FALSE(filter->testInt64Range(-5, 15, true));
+  EXPECT_FALSE(filter->testInt64Range(-3, -1, false));
+  EXPECT_FALSE(filter->testInt64Range(-4, 0, false));
+  EXPECT_FALSE(filter->testInt64Range(0, 8, false));
+
+  EXPECT_TRUE(filter->testInt64Range(16, 16, false));
+  EXPECT_TRUE(filter->testInt64Range(15, 16, false));
+  EXPECT_TRUE(filter->testInt64Range(-10, 20, false));
+  EXPECT_TRUE(filter->testInt64Range(-6, 15, false));
+  checkSimd(filter.get(), n4, testInt64);
+  checkSimd(filter.get(), n8, testInt64);
+  checkSimd(filter.get(), n16, testInt64);
+
+  EXPECT_EQ(filter->lower(), -5);
+  EXPECT_EQ(filter->upper(), 15);
+
+  auto filter_with_null = filter->clone(true);
+  EXPECT_TRUE(filter_with_null->testNull());
+  EXPECT_TRUE(filter_with_null->testInt64Range(5, 15, true));
+}
+
 TEST(FilterTest, bigintValuesUsingHashTable) {
   auto filter = createBigintValues({1, 10, 100, 10'000}, false);
   ASSERT_TRUE(dynamic_cast<BigintValuesUsingHashTable*>(filter.get()));


### PR DESCRIPTION
Summary: This diff adds the `NegatedBigintRange` class of filters, which represents queries in the form `NOT BETWEEN low AND high` for big integer bounds. The necessary methods for a string filter have been added to `Filter.h` and `Filter.cpp`, which builds a wrapper class around the existing `BigintRange` filter for BETWEEN queries. This diff also adds tests for the new class and its member functions within `FilterTest.cpp`, and modifies `ExprToSubfieldFilter.h` to create methods capable of generating these new filters for testing.

Reviewed By: Yuhta

Differential Revision: D37496231

