### PR TITLE
Enable BaseVector::toString for vectors of type Opaque

### DIFF
--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -180,7 +180,7 @@ class SimpleVector : public BaseVector {
       out << "null";
     } else {
       if constexpr (std::is_same<T, std::shared_ptr<void>>::value) {
-        VELOX_NYI("Can't serialize opaque objects yet");
+        out << "<opaque>";
       } else {
         out << velox::to<std::string>(valueAt(index));
       }

--- a/velox/vector/tests/VectorToStringTest.cpp
+++ b/velox/vector/tests/VectorToStringTest.cpp
@@ -88,4 +88,15 @@ TEST_F(VectorToStringTest, row) {
       "1: {2, 2.299999952316284, 1}\n"
       "2: {3, 444.55999755859375, 1}");
 }
+
+TEST_F(VectorToStringTest, opaque) {
+  auto opaque = BaseVector::create(OPAQUE<int>(), 10, pool_.get());
+
+  ASSERT_EQ(opaque->toString(), "[FLAT OPAQUE<int>: 10 elements, no nulls]");
+  ASSERT_EQ(
+      opaque->toString(0, 3),
+      "0: <opaque>\n"
+      "1: <opaque>\n"
+      "2: <opaque>");
+}
 } // namespace facebook::velox::test


### PR DESCRIPTION
It is nice to be able to call toString() on any kind of vector. Before this
change, calling toString on opaque vectors raised an exception: "Can't
serialize opaque objects yet".