### PR TITLE
Add TPC-H query 12 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -161,6 +161,11 @@ BENCHMARK(q10) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q12) {
+  const auto planContext = queryBuilder->getQueryPlan(12);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q13) {
   const auto planContext = queryBuilder->getQueryPlan(13);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
@@ -191,6 +191,11 @@ TEST_F(ParquetTpchTest, Q10) {
   assertQuery(10, 5, 40, std::move(sortingKeys));
 }
 
+TEST_F(ParquetTpchTest, Q12) {
+  std::vector<uint32_t> sortingKeys{0};
+  assertQuery(12, 3, 20, std::move(sortingKeys));
+}
+
 TEST_F(ParquetTpchTest, Q13) {
   std::vector<uint32_t> sortingKeys{0, 1};
   assertQuery(13, 3, 20, std::move(sortingKeys));

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -117,6 +117,8 @@ TpchPlan TpchQueryBuilder::getQueryPlan(int queryId) const {
       return getQ6Plan();
     case 10:
       return getQ10Plan();
+    case 12:
+      return getQ12Plan();
     case 13:
       return getQ13Plan();
     case 14:
@@ -559,6 +561,76 @@ TpchPlan TpchQueryBuilder::getQ10Plan() const {
   context.dataFiles[nationScanNodeId] = getTableFilePaths(kNation);
   context.dataFiles[lineitemScanNodeId] = getTableFilePaths(kLineitem);
   context.dataFiles[ordersScanNodeId] = getTableFilePaths(kOrders);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+TpchPlan TpchQueryBuilder::getQ12Plan() const {
+  std::vector<std::string> ordersColumns = {"o_orderkey", "o_orderpriority"};
+  std::vector<std::string> lineitemColumns = {
+      "l_receiptdate",
+      "l_orderkey",
+      "l_commitdate",
+      "l_shipmode",
+      "l_shipdate"};
+
+  auto ordersSelectedRowType = getRowType(kOrders, ordersColumns);
+  const auto& ordersFileColumns = getFileColumnNames(kOrders);
+  auto lineitemSelectedRowType = getRowType(kLineitem, lineitemColumns);
+  const auto& lineitemFileColumns = getFileColumnNames(kLineitem);
+
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  core::PlanNodeId ordersScanNodeId;
+  core::PlanNodeId lineitemScanNodeId;
+
+  const std::string receiptDateFilter = formatDateFilter(
+      "l_receiptdate", lineitemSelectedRowType, "'1994-01-01'", "'1994-12-31'");
+  const std::string shipDateFilter = formatDateFilter(
+      "l_shipdate", lineitemSelectedRowType, "", "'1995-01-01'");
+  const std::string commitDateFilter = formatDateFilter(
+      "l_commitdate", lineitemSelectedRowType, "", "'1995-01-01'");
+
+  auto lineitem = PlanBuilder(planNodeIdGenerator, pool_.get())
+                      .tableScan(
+                          kLineitem,
+                          lineitemSelectedRowType,
+                          lineitemFileColumns,
+                          {receiptDateFilter,
+                           "l_shipmode IN ('MAIL', 'SHIP')",
+                           shipDateFilter,
+                           commitDateFilter},
+                          "l_commitdate < l_receiptdate")
+                      .capturePlanNodeId(lineitemScanNodeId)
+                      .filter("l_shipdate < l_commitdate")
+                      .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kOrders, ordersSelectedRowType, ordersFileColumns, {})
+          .capturePlanNodeId(ordersScanNodeId)
+          .hashJoin(
+              {"o_orderkey"},
+              {"l_orderkey"},
+              lineitem,
+              "",
+              {"l_shipmode", "o_orderpriority"})
+          .project(
+              {"l_shipmode",
+               "(CASE WHEN o_orderpriority = '1-URGENT' OR o_orderpriority = '2-HIGH' THEN 1 ELSE 0 END) AS high_line_count_partial",
+               "(CASE WHEN o_orderpriority <> '1-URGENT' AND o_orderpriority <> '2-HIGH' THEN 1 ELSE 0 END) AS low_line_count_partial"})
+          .partialAggregation(
+              {"l_shipmode"},
+              {"sum(high_line_count_partial) as high_line_count",
+               "sum(low_line_count_partial) as low_line_count"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"l_shipmode"}, false)
+          .planNode();
+
+  TpchPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[ordersScanNodeId] = getTableFilePaths(kOrders);
+  context.dataFiles[lineitemScanNodeId] = getTableFilePaths(kLineitem);
   context.dataFileFormat = format_;
   return context;
 }

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -81,6 +81,7 @@ class TpchQueryBuilder {
   TpchPlan getQ5Plan() const;
   TpchPlan getQ6Plan() const;
   TpchPlan getQ10Plan() const;
+  TpchPlan getQ12Plan() const;
   TpchPlan getQ13Plan() const;
   TpchPlan getQ14Plan() const;
   TpchPlan getQ18Plan() const;


### PR DESCRIPTION
Adds TPC-H query 12 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 12.
Performance comparison with DuckDb
```
| # Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds) | 
|:----------------------:|:--------------:|:---------------:|
|            1           |      8.17      |      12.80      |  
|            4           |      2.47      |       5.78      | 
|            8           |      1.77      |       2.38      | 
|           16           |      1.96      |       1.82      |
```