### PR TITLE
Add TPC-H query 14 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -166,6 +166,11 @@ BENCHMARK(q13) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q14) {
+  const auto planContext = queryBuilder->getQueryPlan(14);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q18) {
   const auto planContext = queryBuilder->getQueryPlan(18);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
@@ -162,6 +162,9 @@ std::unordered_map<std::string, std::string> ParquetTpchTest::duckDbParquetWrite
         "region",
         R"(COPY (SELECT * FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
     std::make_pair(
+        "part",
+        R"(COPY (SELECT * FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))"),
+    std::make_pair(
         "supplier",
         R"(COPY (SELECT * FROM {}) TO '{}' (FORMAT 'parquet', ROW_GROUP_SIZE {}))")};
 
@@ -191,6 +194,10 @@ TEST_F(ParquetTpchTest, Q10) {
 TEST_F(ParquetTpchTest, Q13) {
   std::vector<uint32_t> sortingKeys{0, 1};
   assertQuery(13, 3, 20, std::move(sortingKeys));
+}
+
+TEST_F(ParquetTpchTest, Q14) {
+  assertQuery(14, 3, 20);
 }
 
 TEST_F(ParquetTpchTest, Q18) {

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -82,6 +82,7 @@ class TpchQueryBuilder {
   TpchPlan getQ6Plan() const;
   TpchPlan getQ10Plan() const;
   TpchPlan getQ13Plan() const;
+  TpchPlan getQ14Plan() const;
   TpchPlan getQ18Plan() const;
 
   const std::vector<std::string>& getTableFilePaths(
@@ -113,6 +114,7 @@ class TpchQueryBuilder {
   static constexpr const char* kOrders = "orders";
   static constexpr const char* kNation = "nation";
   static constexpr const char* kRegion = "region";
+  static constexpr const char* kPart = "part";
   static constexpr const char* kSupplier = "supplier";
 };
 


### PR DESCRIPTION
Adds TPC-H query 14 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 14.
Performance comparison with DuckDb:
```
| # Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds) |
|:----------------------:|:--------------:|:---------------:|
|            1           |      9.55      |      11.53      |
|            4           |      2.76      |       3.43      |
|            8           |      1.94      |       1.88      |
|           16           |      1.86      |       1.06      |
```