### PR TITLE
Change oneIn semantic to percentage

### DIFF
--- a/velox/benchmarks/basic/ComparisonConjunct.cpp
+++ b/velox/benchmarks/basic/ComparisonConjunct.cpp
@@ -74,7 +74,7 @@ class ComparisonBenchmark : public functions::test::FunctionBenchmarkBase {
     // Generate input data.
     VectorFuzzer::Options opts;
     opts.vectorSize = vectorSize;
-    opts.nullChance = 0;
+    opts.nullRatio = 0;
     VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
 
     std::vector<VectorPtr> children;
@@ -85,7 +85,7 @@ class ComparisonBenchmark : public functions::test::FunctionBenchmarkBase {
     children.emplace_back(fuzzer.fuzzFlat(BOOLEAN())); // E
     children.emplace_back(fuzzer.fuzzConstant(DOUBLE())); // Constant
 
-    opts.nullChance = 2; // 50%
+    opts.nullRatio = 0.5; // 50%
     fuzzer.setOptions(opts);
     children.emplace_back(fuzzer.fuzzFlat(DOUBLE())); // HalfNull
     children.emplace_back(fuzzer.fuzzFlat(BOOLEAN())); // BoolHalfNull

--- a/velox/benchmarks/basic/DecodedVector.cpp
+++ b/velox/benchmarks/basic/DecodedVector.cpp
@@ -35,7 +35,7 @@ class DecodedVectorBenchmark : public functions::test::FunctionBenchmarkBase {
       : FunctionBenchmarkBase(), vectorSize_(vectorSize), rows_(vectorSize) {
     VectorFuzzer::Options opts;
     opts.vectorSize = vectorSize_;
-    opts.nullChance = 0;
+    opts.nullRatio = 0;
     VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
 
     flatVector_ = fuzzer.fuzzFlat(BIGINT());

--- a/velox/benchmarks/basic/FeatureNormalization.cpp
+++ b/velox/benchmarks/basic/FeatureNormalization.cpp
@@ -50,7 +50,7 @@ class FeatureNormailzationBenchmark
   RowVectorPtr makeRowVector(vector_size_t size) {
     VectorFuzzer::Options opts;
     opts.vectorSize = size;
-    opts.nullChance = 0;
+    opts.nullRatio = 0;
     VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
 
     std::vector<VectorPtr> children{fuzzer.fuzzFlat(REAL())};

--- a/velox/benchmarks/basic/SelectivityVector.cpp
+++ b/velox/benchmarks/basic/SelectivityVector.cpp
@@ -42,28 +42,28 @@ class SelectivityVectorBenchmark
         rows1PerCent_(vectorSize) {
     VectorFuzzer::Options opts;
     opts.vectorSize = vectorSize_;
-    opts.nullChance = 0;
+    opts.nullRatio = 0;
     VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
     flatVector_ = fuzzer.fuzzFlat(BIGINT());
 
     for (size_t i = 0; i < vectorSize_; ++i) {
       // Set half to invalid.
-      if (fuzzer.oneIn(2)) {
+      if (fuzzer.coinToss(0.5)) {
         rows50PerCent_.setValid(i, false);
       }
 
-      // Set 9/10 to invalid.
-      if (!fuzzer.oneIn(10)) {
+      // Set 90% to invalid.
+      if (fuzzer.coinToss(0.9)) {
         rows10PerCent_.setValid(i, false);
       }
 
-      // Set 99/100 to invalid.
-      if (!fuzzer.oneIn(100)) {
+      // Set 99% to invalid.
+      if (fuzzer.coinToss(0.99)) {
         rows1PerCent_.setValid(i, false);
       }
 
-      // Set 1/100 to invalid.
-      if (fuzzer.oneIn(100)) {
+      // Set 1% to invalid.
+      if (fuzzer.coinToss(0.01)) {
         rows99PerCent_.setValid(i, false);
       }
     }

--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -114,7 +114,7 @@ class SimpleArithmeticBenchmark
   RowVectorPtr makeRowVector(vector_size_t size) {
     VectorFuzzer::Options opts;
     opts.vectorSize = size;
-    opts.nullChance = 0;
+    opts.nullRatio = 0;
     VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
 
     std::vector<VectorPtr> children;
@@ -124,7 +124,7 @@ class SimpleArithmeticBenchmark
     children.emplace_back(fuzzer.fuzzFlat(BIGINT())); // D
     children.emplace_back(fuzzer.fuzzConstant(DOUBLE())); // Constant
 
-    opts.nullChance = 2; // 50%
+    opts.nullRatio = 0.5; // 50%
     fuzzer.setOptions(opts);
     children.emplace_back(fuzzer.fuzzFlat(DOUBLE())); // HalfNull
 

--- a/velox/benchmarks/basic/VectorCompare.cpp
+++ b/velox/benchmarks/basic/VectorCompare.cpp
@@ -35,7 +35,7 @@ class VectorCompareBenchmark : public functions::test::FunctionBenchmarkBase {
       : FunctionBenchmarkBase(), vectorSize_(vectorSize), rows_(vectorSize) {
     VectorFuzzer::Options opts;
     opts.vectorSize = vectorSize_;
-    opts.nullChance = 0;
+    opts.nullRatio = 0;
     opts.containerVariableLength = 1000;
     VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
 

--- a/velox/dwio/dwrf/test/E2EWriterTests.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTests.cpp
@@ -1152,7 +1152,7 @@ TEST(E2EWriterTests, fuzzSimple) {
   VectorFuzzer noNulls(
       {
           .vectorSize = batchSize,
-          .nullChance = 0,
+          .nullRatio = 0,
           .stringLength = 20,
           .stringVariableLength = true,
       },
@@ -1162,7 +1162,7 @@ TEST(E2EWriterTests, fuzzSimple) {
   VectorFuzzer hasNulls{
       {
           .vectorSize = batchSize,
-          .nullChance = 20,
+          .nullRatio = 0.05,
           .stringLength = 10,
           .stringVariableLength = true,
       },
@@ -1203,7 +1203,7 @@ TEST(E2EWriterTests, fuzzComplex) {
   VectorFuzzer noNulls(
       {
           .vectorSize = batchSize,
-          .nullChance = 0,
+          .nullRatio = 0,
           .stringLength = 20,
           .stringVariableLength = true,
           .containerLength = 5,
@@ -1215,7 +1215,7 @@ TEST(E2EWriterTests, fuzzComplex) {
   VectorFuzzer hasNulls{
       {
           .vectorSize = batchSize,
-          .nullChance = 20,
+          .nullRatio = 0.05,
           .stringLength = 10,
           .stringVariableLength = true,
           .containerLength = 5,
@@ -1253,7 +1253,7 @@ TEST(E2EWriterTests, fuzzFlatmap) {
   VectorFuzzer fuzzer(
       {
           .vectorSize = batchSize,
-          .nullChance = 0,
+          .nullRatio = 0,
           .stringLength = 20,
           .stringVariableLength = true,
           .containerLength = 5,
@@ -1279,7 +1279,7 @@ TEST(E2EWriterTests, fuzzFlatmap) {
     VectorFuzzer valueFuzzer(
         {
             .vectorSize = static_cast<size_t>(childSize),
-            .nullChance = 0,
+            .nullRatio = 0,
             .stringLength = 20,
             .stringVariableLength = true,
             .containerLength = 5,

--- a/velox/expression/tests/EvalSimplifiedTest.cpp
+++ b/velox/expression/tests/EvalSimplifiedTest.cpp
@@ -82,7 +82,7 @@ class EvalSimplifiedTest : public FunctionBaseTest {
     fuzzerOpts.vectorSize = 100;
     fuzzerOpts.stringVariableLength = true;
     fuzzerOpts.stringLength = 100;
-    fuzzerOpts.nullChance = 10;
+    fuzzerOpts.nullRatio = 0.1;
 
     for (size_t i = 0; i < iterations_; ++i) {
       LOG(INFO) << "============== Starting iteration with seed: " << seed_;

--- a/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
@@ -55,7 +55,7 @@ class SimpleAggregatesBenchmark : public HiveConnectorTestBase {
 
     VectorFuzzer::Options opts;
     opts.vectorSize = kRowsPerVector;
-    opts.nullChance = 0;
+    opts.nullRatio = 0;
     VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
 
     std::vector<RowVectorPtr> vectors;
@@ -92,7 +92,7 @@ class SimpleAggregatesBenchmark : public HiveConnectorTestBase {
 
       // Generate random values with nulls.
 
-      opts.nullChance = 2; // 50%
+      opts.nullRatio = 0.5; // 50%
       fuzzer.setOptions(opts);
 
       children.emplace_back(fuzzer.fuzzFlat(INTEGER()));

--- a/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
+++ b/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
@@ -95,7 +95,7 @@ class BenchmarkHelper {
 
     VectorFuzzer::Options opts;
     opts.vectorSize = 1;
-    opts.nullChance = 10;
+    opts.nullRatio = 0.1;
     opts.stringVariableLength = true;
     opts.stringLength = 20;
     // Spark uses microseconds to store timestamp

--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -985,7 +985,7 @@ TYPED_TEST(
 
 VectorFuzzer::Options fuzzerOptions() {
   return {
-      .nullChance = 10,
+      .nullRatio = 0.1,
       .stringVariableLength = true,
       .containerVariableLength = true,
       .useMicrosecondPrecisionTimestamp = true,

--- a/velox/row/tests/UnsafeRowFuzzTests.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTests.cpp
@@ -68,7 +68,7 @@ TEST_F(UnsafeRowFuzzTests, simpleTypeRoundTripTest) {
 
   VectorFuzzer::Options opts;
   opts.vectorSize = 1;
-  opts.nullChance = 10;
+  opts.nullRatio = 0.1;
   opts.stringVariableLength = true;
   opts.stringLength = 20;
   // Spark uses microseconds to store timestamp

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -242,12 +242,12 @@ VectorPtr VectorFuzzer::fuzz(const TypePtr& type) {
 VectorPtr VectorFuzzer::fuzz(const TypePtr& type, vector_size_t size) {
   VectorPtr vector;
 
-  // One in 5 chance of adding a constant vector.
-  if (oneIn(5)) {
+  // 20% chance of adding a constant vector.
+  if (coinToss(0.2)) {
     // If adding a constant vector, 50% of chance between:
     // - generate a regular constant vector (only for primitive types).
     // - generate a random vector and wrap it using a constant vector.
-    if (type->isPrimitiveType() && oneIn(2)) {
+    if (type->isPrimitiveType() && coinToss(0.5)) {
       vector = fuzzConstant(type, size);
     } else {
       // Vector size can't be zero.
@@ -263,7 +263,7 @@ VectorPtr VectorFuzzer::fuzz(const TypePtr& type, vector_size_t size) {
   }
 
   // Toss a coin and add dictionary indirections.
-  while (oneIn(2)) {
+  while (coinToss(0.5)) {
     vector = fuzzDictionary(vector);
   }
   return vector;
@@ -274,7 +274,7 @@ VectorPtr VectorFuzzer::fuzzConstant(const TypePtr& type) {
 }
 
 VectorPtr VectorFuzzer::fuzzConstant(const TypePtr& type, vector_size_t size) {
-  if (oneIn(opts_.nullChance)) {
+  if (coinToss(opts_.nullRatio)) {
     return BaseVector::createNullConstant(type, size, pool_);
   }
   return BaseVector::createConstant(randVariant(type), size, pool_);
@@ -294,7 +294,7 @@ VectorPtr VectorFuzzer::fuzzFlat(const TypePtr& type, vector_size_t size) {
 
   // Second, generate a random null vector.
   for (size_t i = 0; i < vector->size(); ++i) {
-    if (oneIn(opts_.nullChance)) {
+    if (coinToss(opts_.nullRatio)) {
       vector->setNull(i, true);
     }
   }
@@ -387,7 +387,7 @@ RowVectorPtr VectorFuzzer::fuzzRow(
 BufferPtr VectorFuzzer::fuzzNulls(vector_size_t size) {
   NullsBuilder builder{size, pool_};
   for (size_t i = 0; i < size; ++i) {
-    if (oneIn(opts_.nullChance)) {
+    if (coinToss(opts_.nullRatio)) {
       builder.setNull(i);
     }
   }

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -42,9 +42,9 @@ class VectorFuzzer {
   struct Options {
     size_t vectorSize{100};
 
-    // One in X chance of generating a null value in the output vector (e.g: 10
-    // for 10%, 2 for 50%, 1 for 100%, 0 for 0%).
-    size_t nullChance{0};
+    /// Chance of generating a null value in the output vector (`nullRatio` is a
+    /// double between 0 and 1).
+    double nullRatio{0};
 
     // Size of the generated strings. If `stringVariableLength` is true, the
     // semantic of this option becomes "string maximum length". Here this
@@ -117,9 +117,9 @@ class VectorFuzzer {
     rng_.seed(seed);
   }
 
-  // Returns true 1/n of times.
-  bool oneIn(size_t n) {
-    return folly::Random::oneIn(n, rng_);
+  /// Returns true n% of times (`n` is a double between 0 and 1).
+  bool coinToss(double n) {
+    return folly::Random::randDouble01(rng_) < n;
   }
 
  private:


### PR DESCRIPTION
Summary:
Simplify oneIn logic to just specify a percentage. Renaming nullChance
fuzzer parameter to nullRatio. Fixing all callsites.

Differential Revision: D37732569

