### PR TITLE
Add TPC-H query 16 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -187,6 +187,11 @@ BENCHMARK(q15) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q16) {
+  const auto planContext = queryBuilder->getQueryPlan(16);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q18) {
   const auto planContext = queryBuilder->getQueryPlan(18);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
@@ -214,6 +214,11 @@ TEST_F(ParquetTpchTest, Q15) {
   assertQuery(15, std::move(sortingKeys));
 }
 
+TEST_F(ParquetTpchTest, Q16) {
+  std::vector<uint32_t> sortingKeys{0, 1, 2, 3};
+  assertQuery(16, std::move(sortingKeys));
+}
+
 TEST_F(ParquetTpchTest, Q18) {
   assertQuery(18);
 }

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -86,6 +86,7 @@ class TpchQueryBuilder {
   TpchPlan getQ13Plan() const;
   TpchPlan getQ14Plan() const;
   TpchPlan getQ15Plan() const;
+  TpchPlan getQ16Plan() const;
   TpchPlan getQ18Plan() const;
   TpchPlan getQ19Plan() const;
   TpchPlan getQ22Plan() const;


### PR DESCRIPTION
Adds TPC-H query 16 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 16.
```
| # Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds) |
|:----------------------:|:--------------:|:---------------:|
|            1           |      2.20      |       1.53      |  
|            4           |      0.92      |       0.67      | 
|            8           |      0.86      |       0.61      | 
|           16           |      0.95      |       0.57      |
```
DuckDB seems to have a count distinct operator. So it performs better. 

PrintPlanWithStats: 
```
Execution time: 2.75s
Splits total: 230, finished: 230
-- OrderBy[supplier_cnt DESC NULLS LAST, p_brand ASC NULLS LAST, p_type ASC NULLS LAST, p_size ASC NULLS LAST] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
   Output: 27840 rows (1.94MB, 1 batches), Cpu time: 37.08ms, Blocked wall time: 0ns, Peak memory: 4.00MB, Memory allocations: 50, Threads: 1
  -- Aggregation[FINAL [p_brand, p_type, p_size] supplier_cnt := count("supplier_cnt")] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
     Output: 27840 rows (3.11MB, 28 batches), Cpu time: 15.97ms, Blocked wall time: 0ns, Peak memory: 9.00MB, Memory allocations: 97, Threads: 1
    -- LocalPartition[GATHER] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
       Output: 55680 rows (6.22MB, 28 batches), Cpu time: 5.17ms, Blocked wall time: 2.76s, Peak memory: 0B, Memory allocations: 0
       LocalPartition: Input: 27840 rows (3.11MB, 28 batches), Output: 27840 rows (3.11MB, 0 batches), Cpu time: 5.02ms, Blocked wall time: 9.58ms, Peak memory: 0B, Memory allocations: 0, Threads: 1
          queuedWallNanos    sum: 170.00us, count: 2, min: 69.00us, max: 101.00us
       LocalExchange: Input: 27840 rows (3.11MB, 0 batches), Output: 27840 rows (3.11MB, 28 batches), Cpu time: 152.00us, Blocked wall time: 2.75s, Peak memory: 0B, Memory allocations: 0, Threads: 1
          queuedWallNanos    sum: 22.00us, count: 1, min: 22.00us, max: 22.00us
      -- Aggregation[PARTIAL [p_brand, p_type, p_size] supplier_cnt := count(ROW["ps_suppkey"])] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, supplier_cnt:BIGINT
         Output: 27840 rows (3.11MB, 28 batches), Cpu time: 170.03ms, Blocked wall time: 0ns, Peak memory: 11.00MB, Memory allocations: 209, Threads: 1
        -- Aggregation[FINAL [p_brand, p_type, p_size, ps_suppkey] ] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, ps_suppkey:BIGINT
           Output: 1186339 rows (142.58MB, 1602 batches), Cpu time: 800.93ms, Blocked wall time: 0ns, Peak memory: 112.00MB, Memory allocations: 3092, Threads: 1
          -- LocalPartition[REPARTITION] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, ps_suppkey:BIGINT
             Output: 2373122 rows (285.21MB, 1602 batches), Cpu time: 42.73ms, Blocked wall time: 1.67s, Peak memory: 0B, Memory allocations: 0
             LocalPartition: Input: 1186561 rows (142.61MB, 1602 batches), Output: 1186561 rows (142.61MB, 0 batches), Cpu time: 31.74ms, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1
                queuedWallNanos    sum: 89.00us, count: 1, min: 89.00us, max: 89.00us
             LocalExchange: Input: 1186561 rows (142.61MB, 0 batches), Output: 1186561 rows (142.61MB, 1602 batches), Cpu time: 10.99ms, Blocked wall time: 1.67s, Peak memory: 0B, Memory allocations: 0, Threads: 1
                queuedWallNanos    sum: 27.54ms, count: 669, min: 17.00us, max: 160.00us
            -- Aggregation[PARTIAL [p_brand, p_type, p_size, ps_suppkey] ] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, ps_suppkey:BIGINT
               Output: 1186561 rows (142.61MB, 1602 batches), Cpu time: 522.82ms, Blocked wall time: 0ns, Peak memory: 20.00MB, Memory allocations: 3098, Threads: 1
                  flushRowCount            sum: 1058008, count: 6, min: 175928, max: 176997
                  partialAggregationPct    sum: 594, count: 6, min: 99, max: 99
              -- HashJoin[ANTI ps_suppkey=s_suppkey] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
                 Output: 1186602 rows (142.61MB, 1602 batches), Cpu time: 42.51ms, Blocked wall time: 131.03ms, Peak memory: 2.00MB, Memory allocations: 1609
                 HashBuild: Input: 56 rows (4.67KB, 12 batches), Output: 0 rows (0B, 0 batches), Cpu time: 1.44ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 3, Threads: 1
                    distinctKey0       sum: 57, count: 1, min: 57, max: 57
                    queuedWallNanos    sum: 74.00us, count: 1, min: 74.00us, max: 74.00us
                    rangeKey0          sum: 99501, count: 1, min: 99501, max: 99501
                 HashProbe: Input: 1187296 rows (142.67MB, 1602 batches), Output: 1186602 rows (142.61MB, 1602 batches), Cpu time: 41.08ms, Blocked wall time: 131.03ms, Peak memory: 1.00MB, Memory allocations: 1606, Threads: 1
                    queuedWallNanos    sum: 71.00us, count: 1, min: 71.00us, max: 71.00us
                -- HashJoin[INNER ps_partkey=p_partkey] -> ps_suppkey:BIGINT, p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER
                   Output: 1187296 rows (142.67MB, 1602 batches), Cpu time: 1.83s, Blocked wall time: 260.41ms, Peak memory: 54.00MB, Memory allocations: 14825
                   HashBuild: Input: 296824 rows (29.82MB, 204 batches), Output: 0 rows (0B, 0 batches), Cpu time: 194.93ms, Blocked wall time: 0ns, Peak memory: 44.00MB, Memory allocations: 408, Threads: 1
                      queuedWallNanos    sum: 80.00us, count: 1, min: 80.00us, max: 80.00us
                      rangeKey0          sum: 1999995, count: 1, min: 1999995, max: 1999995
                   HashProbe: Input: 8000000 rows (0B, 803 batches), Output: 1187296 rows (142.67MB, 1602 batches), Cpu time: 1.64s, Blocked wall time: 260.41ms, Peak memory: 10.00MB, Memory allocations: 14417, Threads: 1
                      dataSourceLazyWallNanos    sum: 269.55ms, count: 803, min: 65.00us, max: 950.00us
                      queuedWallNanos            sum: 69.00us, count: 1, min: 69.00us, max: 69.00us
                  -- TableScan[table: partsupp] -> ps_partkey:BIGINT, ps_suppkey:BIGINT
                     Input: 8000000 rows (0B, 0 batches), Output: 8000000 rows (0B, 803 batches), Cpu time: 35.94ms, Blocked wall time: 0ns, Peak memory: 8.00MB, Memory allocations: 2643, Threads: 1, Splits: 80
                        dataSourceLazyWallNanos    sum: 2.45s, count: 1606, min: 373.00us, max: 2.39ms
                        dataSourceWallNanos        sum: 23.56ms, count: 883, min: 3.00us, max: 2.83ms
                        localReadBytes             sum: 0B, count: 1, min: 0B, max: 0B
                        numLocalRead               sum: 0, count: 1, min: 0, max: 0
                        numPrefetch                sum: 0, count: 1, min: 0, max: 0
                        numRamRead                 sum: 0, count: 1, min: 0, max: 0
                        numStorageRead             sum: 0, count: 1, min: 0, max: 0
                        prefetchBytes              sum: 0B, count: 1, min: 0B, max: 0B
                        ramReadBytes               sum: 0B, count: 1, min: 0B, max: 0B
                        skippedSplitBytes          sum: 0B, count: 1, min: 0B, max: 0B
                        skippedSplits              sum: 0, count: 1, min: 0, max: 0
                        skippedStrides             sum: 0, count: 1, min: 0, max: 0
                        storageReadBytes           sum: 0B, count: 1, min: 0B, max: 0B
                  -- Filter[expression: neq(ROW["p_brand"],"Brand#45")] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, p_partkey:BIGINT
                     Output: 296824 rows (29.82MB, 204 batches), Cpu time: 36.03ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 199, Threads: 1
                        dataSourceLazyWallNanos    sum: 134.52ms, count: 409, min: 3.00us, max: 874.00us
                    -- TableScan[table: part, range filters: [(size, Filter(BigintValuesUsingBitmask, deterministic, null not allowed))], remaining filter: (not(like(ROW["type"],"MEDIUM POLISHED%")))] -> p_brand:VARCHAR, p_type:VARCHAR, p_size:INTEGER, p_partkey:BIGINT
                       Input: 309084 rows (18.53MB, 0 batches), Raw Input: 2000000 rows (406.29MB), Output: 309084 rows (22.76MB, 204 batches), Cpu time: 148.85ms, Blocked wall time: 0ns, Peak memory: 8.00MB, Memory allocations: 1955, Threads: 1, Splits: 80
                          dataSourceLazyWallNanos    sum: 39.51ms, count: 204, min: 4.00us, max: 733.00us
                          dataSourceWallNanos        sum: 78.47ms, count: 284, min: 4.00us, max: 1.54ms
                          localReadBytes             sum: 0B, count: 1, min: 0B, max: 0B
                          numLocalRead               sum: 0, count: 1, min: 0, max: 0
                          numPrefetch                sum: 0, count: 1, min: 0, max: 0
                          numRamRead                 sum: 0, count: 1, min: 0, max: 0
                          numStorageRead             sum: 0, count: 1, min: 0, max: 0
                          prefetchBytes              sum: 0B, count: 1, min: 0B, max: 0B
                          ramReadBytes               sum: 0B, count: 1, min: 0B, max: 0B
                          skippedSplitBytes          sum: 0B, count: 1, min: 0B, max: 0B
                          skippedSplits              sum: 0, count: 1, min: 0, max: 0
                          skippedStrides             sum: 0, count: 1, min: 0, max: 0
                          storageReadBytes           sum: 0B, count: 1, min: 0B, max: 0B
                -- TableScan[table: supplier, remaining filter: (like(ROW["comment"],"%Customer%Complaints%"))] -> s_suppkey:BIGINT, s_comment:VARCHAR
                   Input: 56 rows (9.32MB, 0 batches), Raw Input: 100000 rows (47.46MB), Output: 56 rows (4.67KB, 12 batches), Cpu time: 126.41ms, Blocked wall time: 0ns, Peak memory: 4.00MB, Memory allocations: 504, Threads: 1, Splits: 70
                      dataSourceLazyWallNanos    sum: 12.47ms, count: 24, min: 23.00us, max: 1.84ms
                      dataSourceWallNanos        sum: 115.77ms, count: 82, min: 3.00us, max: 13.37ms
                      localReadBytes             sum: 0B, count: 1, min: 0B, max: 0B
                      numLocalRead               sum: 0, count: 1, min: 0, max: 0
                      numPrefetch                sum: 0, count: 1, min: 0, max: 0
                      numRamRead                 sum: 0, count: 1, min: 0, max: 0
                      numStorageRead             sum: 0, count: 1, min: 0, max: 0
                      prefetchBytes              sum: 0B, count: 1, min: 0B, max: 0B
                      ramReadBytes               sum: 0B, count: 1, min: 0B, max: 0B
                      skippedSplitBytes          sum: 0B, count: 1, min: 0B, max: 0B
                      skippedSplits              sum: 0, count: 1, min: 0, max: 0
                      skippedStrides             sum: 0, count: 1, min: 0, max: 0
                      storageReadBytes           sum: 0B, count: 1, min: 0B, max: 0B
```