### PR TITLE
Generate top-level nulls for complex types and dictionaries

### DIFF
--- a/velox/dwio/dwrf/test/E2EWriterTests.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTests.cpp
@@ -1172,8 +1172,10 @@ TEST(E2EWriterTests, fuzzSimple) {
   auto iterations = 20;
   auto batches = 20;
   for (auto i = 0; i < iterations; ++i) {
-    testWriter(pool, type, batches, [&]() { return noNulls.fuzzRow(type); });
-    testWriter(pool, type, batches, [&]() { return hasNulls.fuzzRow(type); });
+    testWriter(
+        pool, type, batches, [&]() { return noNulls.fuzzInputRow(type); });
+    testWriter(
+        pool, type, batches, [&]() { return hasNulls.fuzzInputRow(type); });
   }
 }
 
@@ -1227,8 +1229,10 @@ TEST(E2EWriterTests, fuzzComplex) {
   auto iterations = 20;
   auto batches = 20;
   for (auto i = 0; i < iterations; ++i) {
-    testWriter(pool, type, batches, [&]() { return noNulls.fuzzRow(type); });
-    testWriter(pool, type, batches, [&]() { return hasNulls.fuzzRow(type); });
+    testWriter(
+        pool, type, batches, [&]() { return noNulls.fuzzInputRow(type); });
+    testWriter(
+        pool, type, batches, [&]() { return hasNulls.fuzzInputRow(type); });
   }
 }
 

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -327,16 +327,11 @@ class ExpressionFuzzer {
   }
 
   void printRowVector(const RowVectorPtr& rowVector) {
-    LOG(INFO) << "RowVector contents:";
+    LOG(INFO) << "RowVector contents (" << rowVector->type()->toString()
+              << "):";
 
-    for (size_t i = 0; i < rowVector->childrenSize(); ++i) {
-      LOG(INFO) << "Column C" << i << ":";
-      auto child = rowVector->childAt(i);
-
-      // If verbose mode, print the whole vector.
-      for (size_t j = 0; j < child->size(); ++j) {
-        LOG(INFO) << "\tC" << i << "[" << j << "]: " << child->toString(j);
-      }
+    for (size_t i = 0; i < rowVector->size(); ++i) {
+      LOG(INFO) << "\tAt " << i << ": " << rowVector->toString(i);
     }
   }
 

--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -986,6 +986,8 @@ TYPED_TEST(
 VectorFuzzer::Options fuzzerOptions() {
   return {
       .nullRatio = 0.1,
+      .containerHasNulls = false,
+      .dictionaryHasNulls = false,
       .stringVariableLength = true,
       .containerVariableLength = true,
       .useMicrosecondPrecisionTimestamp = true,

--- a/velox/row/tests/UnsafeRowFuzzTests.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTests.cpp
@@ -69,6 +69,8 @@ TEST_F(UnsafeRowFuzzTests, simpleTypeRoundTripTest) {
   VectorFuzzer::Options opts;
   opts.vectorSize = 1;
   opts.nullRatio = 0.1;
+  opts.containerHasNulls = false;
+  opts.dictionaryHasNulls = false;
   opts.stringVariableLength = true;
   opts.stringLength = 20;
   // Spark uses microseconds to store timestamp

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -46,29 +46,39 @@ class VectorFuzzer {
     /// double between 0 and 1).
     double nullRatio{0};
 
-    // Size of the generated strings. If `stringVariableLength` is true, the
-    // semantic of this option becomes "string maximum length". Here this
-    // represents number of characters and not bytes.
+    /// If true, fuzzer will generate top-level nulls for containers
+    /// (arrays/maps/rows), i.e, nulls for the containers themselves, not the
+    /// elements.
+    ///
+    /// The amount of nulls are controlled by `nullRatio`.
+    bool containerHasNulls{true};
+
+    /// If true, fuzzer will generate top-level nulls for dictionaries.
+    bool dictionaryHasNulls{true};
+
+    /// Size of the generated strings. If `stringVariableLength` is true, the
+    /// semantic of this option becomes "string maximum length". Here this
+    /// represents number of characters and not bytes.
     size_t stringLength{50};
 
-    // Vector of String charsets to choose from; bias a charset by including it
-    // multiple times.
+    /// Vector of String charsets to choose from; bias a charset by including it
+    /// multiple times.
     std::vector<UTF8CharList> charEncodings{ASCII};
 
-    // If true, the length of strings are randomly generated and `stringLength`
-    // is treated as maximum length.
+    /// If true, the length of strings are randomly generated and `stringLength`
+    /// is treated as maximum length.
     bool stringVariableLength{false};
 
-    // Size of the generated array/map. If `containerVariableLength` is true,
-    // the semantic of this option becomes "container maximum length".
+    /// Size of the generated array/map. If `containerVariableLength` is true,
+    /// the semantic of this option becomes "container maximum length".
     size_t containerLength{10};
 
-    // If true, the length of array/map are randomly generated and
-    // `containerLength` is treated as maximum length.
+    /// If true, the length of array/map are randomly generated and
+    /// `containerLength` is treated as maximum length.
     bool containerVariableLength{false};
 
-    // If true, the random generated timestamp value will only be in
-    // microsecond precision (default is nanosecond).
+    /// If true, the random generated timestamp value will only be in
+    /// microsecond precision (default is nanosecond).
     bool useMicrosecondPrecisionTimestamp{false};
   };
 
@@ -102,6 +112,12 @@ class VectorFuzzer {
   // Returns a "fuzzed" row vector with randomized data and nulls.
   RowVectorPtr fuzzRow(const RowTypePtr& rowType);
 
+  // Same as the function above, but never return nulls for the top-level row
+  // elements.
+  RowVectorPtr fuzzInputRow(const RowTypePtr& rowType) {
+    return fuzzRow(rowType, opts_.vectorSize, false);
+  }
+
   variant randVariant(const TypePtr& arg);
 
   // Generates a random type, including maps, vectors, and arrays. maxDepth
@@ -132,7 +148,7 @@ class VectorFuzzer {
   VectorPtr fuzzComplex(const TypePtr& type, vector_size_t size);
 
   RowVectorPtr
-  fuzzRow(const RowTypePtr& rowType, vector_size_t size, bool mayHaveNulls);
+  fuzzRow(const RowTypePtr& rowType, vector_size_t size, bool rowHasNulls);
 
   // Generate a random null vector.
   BufferPtr fuzzNulls(vector_size_t size);


### PR DESCRIPTION
Summary:
Generate top-level nulls for complex types and dictionaries, to
increase entropy.

Reviewed By: mbasmanova

Differential Revision: D37733511

