### PR TITLE
faster clamp

### DIFF
--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -170,7 +170,9 @@ struct ClampFunction {
   FOLLY_ALWAYS_INLINE void
   call(TInput& result, const TInput& v, const TInput& lo, const TInput& hi) {
     VELOX_USER_CHECK_LE(lo, hi, "Lo > hi in clamp.");
-    result = std::clamp(v, lo, hi);
+    // std::clamp emits less efficient ASM
+    const TInput& a = v < lo ? lo : v;
+    result = a > hi ? hi : a;
   }
 };
 


### PR DESCRIPTION
Summary:
Alternative implementation of std::clamp.  It contains the same order of bounding (lower bound before upper bounding).

Produces better ASM (https://godbolt.org/z/b6YPxsoY7)

Benchmarks:

After:
```
============================================================================
[...]hmarks/basic/FeatureNormalization.cpp     relative  time/iter   iters/s
============================================================================
normalize                                                  22.88ns    43.70M
normalizeConstant                                          30.10ns    33.22M
```

Before:
```
============================================================================
[...]hmarks/basic/FeatureNormalization.cpp     relative  time/iter   iters/s
============================================================================
normalize                                                  26.81ns    37.30M
normalizeConstant                                          31.83ns    31.42M
```

Reviewed By: pedroerp

Differential Revision: D37737908

