### PR TITLE
Fix sha error in torcharrow image.

### DIFF
--- a/scripts/setup-velox-torcharrow.sh
+++ b/scripts/setup-velox-torcharrow.sh
@@ -41,6 +41,10 @@ yum -y install lzo-devel
 yum -y install wget
 yum -y install python3-devel.x86_64
 yum -y install fmt-devel
+yum -y install perl-core
+yum -y install pcre-devel
+yum -y install zlib-devel
+yum -y install flex
 
 #Install conda
 rpm --import https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc
@@ -67,14 +71,21 @@ function wget_and_untar {
   local URL=$1
   local DIR=$2
   mkdir -p "${DIR}"
-  wget -q --max-redirect 3 -O - "${URL}" | tar -xz -C "${DIR}" --strip-components=1
+  wget --no-check-certificate -q --max-redirect 3 -O - "${URL}" | tar -xz -C "${DIR}" --strip-components=1
 }
 
-
+wget_and_untar https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz gflags
+wget_and_untar https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz openssl &
 wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz boost &
 wget_and_untar https://github.com/facebook/folly/archive/v2022.03.14.00.tar.gz folly &
 
 wait
+
+(
+  cd openssl
+  ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic
+  make install
+)
 
 (
   cd boost
@@ -85,4 +96,5 @@ wait
 
 # Folly fails to build in release-mode due
 # AtomicUtil-inl.h:202: Error: operand type mismatch for `bts'
+cmake_install gflags -DBUILD_SHARED_LIBS=ON
 cmake_install folly

--- a/scripts/velox-torcharrow-container.dockfile
+++ b/scripts/velox-torcharrow-container.dockfile
@@ -18,4 +18,4 @@ FROM quay.io/pypa/manylinux2014_x86_64:2022-02-13-594988e
 ARG cpu_target
 COPY setup-velox-torcharrow.sh /
 COPY setup-helper-functions.sh /
-RUN mkdir build && ( cd build && CPU_TARGET="$cpu_target" bash /setup-velox-torcharrow.sh )
+RUN mkdir build && ( cd build && CPU_TARGET="$cpu_target" bash /setup-velox-torcharrow.sh ) && rm -rf build


### PR DESCRIPTION
Recent TA builds have been failing with a openssl sha error. This change:
- installs openssl 1.1
- latest compatible gflags

Tested locally. 