### PR TITLE
Updated DateTimeFormatter to throw error for empty Mysql format string

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -338,6 +338,9 @@ std::string DateTimeFormatter::format(
 
 std::shared_ptr<DateTimeFormatter> buildMysqlDateTimeFormatter(
     const std::string_view& format) {
+  if (format.empty()) {
+    VELOX_USER_FAIL("Both printing and parsing not supported");
+  }
   // For %r we should reserve 1 extra space because it has 3 literals ':' ':'
   // and ' '
   DateTimeFormatterBuilder builder(

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -381,6 +381,9 @@ TEST_F(MysqlDateTimeTest, invalidBuild) {
   EXPECT_THROW(buildMysqlDateTimeFormatter("%u"), VeloxUserError);
   EXPECT_THROW(buildMysqlDateTimeFormatter("%V"), VeloxUserError);
   EXPECT_THROW(buildMysqlDateTimeFormatter("%w"), VeloxUserError);
+
+  // Empty format string
+  EXPECT_THROW(buildMysqlDateTimeFormatter(""), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, formatYear) {


### PR DESCRIPTION
Differential Revision: D37542529

