### PR TITLE
Update buildMysqlDateTimeFormatter to throw on empty format string

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1000,6 +1000,10 @@ DateTimeResult DateTimeFormatter::parse(const std::string_view& input) const {
 
 std::shared_ptr<DateTimeFormatter> buildMysqlDateTimeFormatter(
     const std::string_view& format) {
+  if (format.empty()) {
+    VELOX_USER_FAIL("Both printing and parsing not supported");
+  }
+
   // For %r we should reserve 1 extra space because it has 3 literals ':' ':'
   // and ' '
   DateTimeFormatterBuilder builder(

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -1055,6 +1055,9 @@ TEST_F(MysqlDateTimeTest, invalidBuild) {
   EXPECT_THROW(buildMysqlDateTimeFormatter("%u"), VeloxUserError);
   EXPECT_THROW(buildMysqlDateTimeFormatter("%V"), VeloxUserError);
   EXPECT_THROW(buildMysqlDateTimeFormatter("%w"), VeloxUserError);
+
+  // Empty format string
+  EXPECT_THROW(buildMysqlDateTimeFormatter(""), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, formatYear) {


### PR DESCRIPTION
Summary: buildMysqlDateTimeFormatter did not throw on empty fomat string input as it should. Implemented throw with proper message and test to ensure it throws when appropriate.

Differential Revision: D37793725

