### PR TITLE
Drop SelectiveColumnReader inheritance from ColumnReader

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReaderShared.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReaderShared.cpp
@@ -88,11 +88,6 @@ DwrfRowReaderShared::DwrfRowReaderShared(
     return exceptionMessageContext;
   };
 
-  if (options_.getScanSpec()) {
-    columnReaderFactory_ =
-        std::make_unique<SelectiveColumnReaderFactory>(options_.getScanSpec());
-  }
-
   CompatChecker::check(
       *getReader().getSchema(), *getType(), true, createExceptionContext);
 }

--- a/velox/dwio/dwrf/reader/DwrfReaderShared.h
+++ b/velox/dwio/dwrf/reader/DwrfReaderShared.h
@@ -43,7 +43,6 @@ class DwrfRowReaderShared : public StrideIndexProvider,
   uint64_t strideIndex_;
   std::shared_ptr<StripeDictionaryCache> stripeDictionaryCache_;
   dwio::common::RowReaderOptions options_;
-  std::unique_ptr<ColumnReaderFactory> columnReaderFactory_;
 
   // column selector
   std::shared_ptr<dwio::common::ColumnSelector> columnSelector_;

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.cpp
@@ -19,7 +19,7 @@
 namespace facebook::velox::dwrf {
 
 uint64_t SelectiveByteRleColumnReader::skip(uint64_t numValues) {
-  numValues = ColumnReader::skip(numValues);
+  numValues = SelectiveColumnReader::skip(numValues);
   if (byteRle_) {
     byteRle_->skip(numValues);
   } else {

--- a/velox/dwio/dwrf/reader/SelectiveColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveColumnReader.h
@@ -98,7 +98,7 @@ struct ScanState {
   RawScanState rawState;
 };
 
-class SelectiveColumnReader : public ColumnReader {
+class SelectiveColumnReader {
  public:
   static constexpr uint64_t kStringBufferSize = 16 * 1024;
 
@@ -109,15 +109,24 @@ class SelectiveColumnReader : public ColumnReader {
       const TypePtr& type,
       FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext());
 
+  virtual ~SelectiveColumnReader() = default;
+
+  /**
+   * Skip number of specified rows.
+   * @param numValues the number of values to skip
+   * @return the number of non-null values skipped
+   */
+  virtual uint64_t skip(uint64_t numValues);
+
   /**
    * Read the next group of values into a RowVector.
    * @param numValues the number of values to read
    * @param vector to read into
    */
-  void next(
-      uint64_t /*numValues*/,
-      VectorPtr& /*result*/,
-      const uint64_t* /*incomingNulls*/) override {
+  virtual void next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* incomingNulls = nullptr) {
     VELOX_UNSUPPORTED("next() is only defined in SelectiveStructColumnReader");
   }
 
@@ -276,9 +285,16 @@ class SelectiveColumnReader : public ColumnReader {
     initTimeClocks_ = 0;
   }
 
-  std::vector<uint32_t> filterRowGroups(
+  virtual std::vector<uint32_t> filterRowGroups(
       uint64_t rowGroupSize,
-      const StatsContext& context) const override;
+      const StatsContext& context) const;
+
+  // Sets the streams of this and child readers to the first row of
+  // the row group at 'index'. This advances readers and touches the
+  // actual data, unlike setRowGroup().
+  virtual void seekToRowGroup(uint32_t /*index*/) {
+    VELOX_NYI();
+  }
 
   raw_vector<int32_t>& innerNonNullRows() {
     return innerNonNullRows_;
@@ -324,6 +340,17 @@ class SelectiveColumnReader : public ColumnReader {
 
   template <typename T>
   void filterNulls(RowSet rows, bool isNull, bool extractValues);
+
+  // Reads nulls, if any. Sets '*nulls' to nullptr if void
+  // the reader has no nulls and there are no incoming
+  //          nulls.Takes 'nulls' from 'result' if '*result' is non -
+  //      null.Otherwise ensures that 'nulls' has a buffer of sufficient
+  //          size and uses this.
+  void readNulls(
+      vector_size_t numValues,
+      const uint64_t* incomingNulls,
+      VectorPtr* result,
+      BufferPtr& nulls);
 
   template <typename T>
   void
@@ -374,6 +401,11 @@ class SelectiveColumnReader : public ColumnReader {
       index_ = ProtoUtils::readProto<proto::RowIndex>(std::move(indexStream_));
     }
   }
+
+  std::unique_ptr<ByteRleDecoder> notNullDecoder_;
+  const std::shared_ptr<const dwio::common::TypeWithId> nodeType_;
+  memory::MemoryPool& memoryPool_;
+  FlatMapContext flatMapContext_;
 
   // Specification of filters, value extraction, pruning etc. The
   // spec is assigned at construction and the contents may change at
@@ -477,30 +509,6 @@ inline void SelectiveColumnReader::addValue(const folly::StringPiece value) {
   }
   addStringValue(value);
 }
-
-class SelectiveColumnReaderFactory : public ColumnReaderFactory {
- public:
-  explicit SelectiveColumnReaderFactory(
-      std::shared_ptr<common::ScanSpec> scanSpec)
-      : scanSpec_(scanSpec) {}
-  std::unique_ptr<ColumnReader> build(
-      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
-      const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
-      StripeStreams& stripe,
-      FlatMapContext flatMapContext) override {
-    auto reader = SelectiveColumnReader::build(
-        requestedType,
-        dataType,
-        stripe,
-        scanSpec_.get(),
-        std::move(flatMapContext));
-    reader->setIsTopLevel();
-    return reader;
-  }
-
- private:
-  std::shared_ptr<common::ScanSpec> const scanSpec_;
-};
 
 } // namespace facebook::velox::dwrf
 

--- a/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
@@ -98,7 +98,7 @@ SelectiveFloatingPointColumnReader<TData, TRequested>::
 template <typename TData, typename TRequested>
 uint64_t SelectiveFloatingPointColumnReader<TData, TRequested>::skip(
     uint64_t numValues) {
-  numValues = ColumnReader::skip(numValues);
+  numValues = SelectiveColumnReader::skip(numValues);
   decoder_.skip(numValues);
   return numValues;
 }

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -58,7 +58,7 @@ SelectiveIntegerDictionaryColumnReader::SelectiveIntegerDictionaryColumnReader(
 }
 
 uint64_t SelectiveIntegerDictionaryColumnReader::skip(uint64_t numValues) {
-  numValues = ColumnReader::skip(numValues);
+  numValues = SelectiveColumnReader::skip(numValues);
   dataReader_->skip(numValues);
   if (inDictionaryReader_) {
     inDictionaryReader_->skip(numValues);

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
@@ -19,7 +19,7 @@
 namespace facebook::velox::dwrf {
 
 uint64_t SelectiveIntegerDirectColumnReader::skip(uint64_t numValues) {
-  numValues = ColumnReader::skip(numValues);
+  numValues = SelectiveColumnReader::skip(numValues);
   ints->skip(numValues);
   return numValues;
 }

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -54,7 +54,7 @@ SelectiveListColumnReader::SelectiveListColumnReader(
 }
 
 uint64_t SelectiveListColumnReader::skip(uint64_t numValues) {
-  numValues = ColumnReader::skip(numValues);
+  numValues = SelectiveColumnReader::skip(numValues);
   if (child_) {
     std::array<int64_t, kBufferSize> buffer;
     uint64_t childElements = 0;
@@ -160,7 +160,7 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
 }
 
 uint64_t SelectiveMapColumnReader::skip(uint64_t numValues) {
-  numValues = ColumnReader::skip(numValues);
+  numValues = SelectiveColumnReader::skip(numValues);
   if (keyReader_ || elementReader_) {
     std::array<int64_t, kBufferSize> buffer;
     uint64_t childElements = 0;

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -89,7 +89,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
 }
 
 uint64_t SelectiveStringDictionaryColumnReader::skip(uint64_t numValues) {
-  numValues = ColumnReader::skip(numValues);
+  numValues = SelectiveColumnReader::skip(numValues);
   dictIndex_->skip(numValues);
   if (inDictionaryReader_) {
     inDictionaryReader_->skip(numValues);

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -46,7 +46,7 @@ SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
 }
 
 uint64_t SelectiveStringDirectColumnReader::skip(uint64_t numValues) {
-  numValues = ColumnReader::skip(numValues);
+  numValues = SelectiveColumnReader::skip(numValues);
   detail::ensureCapacity<int64_t>(lengths_, numValues, &memoryPool_);
   lengthDecoder_->nextLengths(lengths_->asMutable<int32_t>(), numValues);
   rawLengths_ = lengths_->as<uint32_t>();

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -89,7 +89,7 @@ std::vector<uint32_t> SelectiveStructColumnReader::filterRowGroups(
 }
 
 uint64_t SelectiveStructColumnReader::skip(uint64_t numValues) {
-  auto numNonNulls = ColumnReader::skip(numValues);
+  auto numNonNulls = SelectiveColumnReader::skip(numValues);
   // 'readOffset_' of struct child readers is aligned with
   // 'readOffset_' of the struct. The child readers may have fewer
   // values since there is no value in children where the struct is

--- a/velox/dwio/dwrf/test/E2EFilterTestBase.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTestBase.cpp
@@ -179,7 +179,7 @@ void E2EFilterTestBase::readWithoutFilter(
   dwio::common::ReaderOptions readerOpts;
   dwio::common::RowReaderOptions rowReaderOpts;
   auto reader = makeReader(readerOpts, std::move(input));
-  ;
+
   // The spec must stay live over the lifetime of the reader.
   rowReaderOpts.setScanSpec(spec);
   OwnershipChecker ownershipChecker;
@@ -229,7 +229,6 @@ void E2EFilterTestBase::readWithFilter(
   dwio::common::ReaderOptions readerOpts;
   dwio::common::RowReaderOptions rowReaderOpts;
   auto reader = makeReader(readerOpts, std::move(input));
-  auto factory = std::make_unique<SelectiveColumnReaderFactory>(spec);
   // The  spec must stay live over the lifetime of the reader.
   rowReaderOpts.setScanSpec(spec);
   OwnershipChecker ownershipChecker;

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -82,148 +82,8 @@ void makeFieldSpecs(
   }
 }
 
-class SelectiveColumnReaderBuilder {
- public:
-  std::unique_ptr<ColumnReader> build(
-      const std::shared_ptr<const Type>& requestedType,
-      MockStripeStreams& stripe,
-      std::vector<uint64_t> nodes = {},
-      const std::shared_ptr<const Type>& dataType = nullptr) {
-    const auto& rowType =
-        std::dynamic_pointer_cast<const RowType>(requestedType);
-    ColumnSelector cs(rowType, nodes, true);
-    auto options = RowReaderOptions();
-    EXPECT_CALL(stripe, getColumnSelectorProxy())
-        .WillRepeatedly(testing::Return(&cs));
-    EXPECT_CALL(stripe, getRowReaderOptionsProxy())
-        .WillRepeatedly(testing::Return(&options));
-    auto dataTypeWithId =
-        TypeWithId::create(dataType ? dataType : requestedType);
-
-    scanSpec_ = std::make_unique<common::ScanSpec>("root");
-    makeFieldSpecs("", 0, rowType, scanSpec_.get());
-
-    return SelectiveColumnReader::build(
-        cs.getSchemaWithId(),
-        dataTypeWithId,
-        stripe,
-        scanSpec_.get(),
-        FlatMapContext::nonFlatMapContext());
-  }
-
- private:
-  std::unique_ptr<common::ScanSpec> scanSpec_;
-};
-
 bool isNotNull(tm* timeptr) {
   return timeptr != nullptr;
-}
-
-std::unique_ptr<ColumnReader> buildColumnReader(
-    const std::shared_ptr<const Type>& requestedType,
-    MockStripeStreams& stripe,
-    std::vector<uint64_t> nodes = {},
-    bool returnFlatVector = false,
-    const std::shared_ptr<const Type>& dataType = nullptr) {
-  const std::shared_ptr<const RowType>& rowType =
-      std::dynamic_pointer_cast<const RowType>(requestedType);
-  ColumnSelector cs(rowType, nodes, true);
-  auto options = RowReaderOptions();
-  options.setReturnFlatVector(returnFlatVector);
-  EXPECT_CALL(stripe, getColumnSelectorProxy())
-      .WillRepeatedly(testing::Return(&cs));
-  EXPECT_CALL(stripe, getRowReaderOptionsProxy())
-      .WillRepeatedly(testing::Return(&options));
-  auto dataTypeWithId = TypeWithId::create(dataType ? dataType : requestedType);
-  return ColumnReader::build(cs.getSchemaWithId(), dataTypeWithId, stripe);
-}
-
-struct StringReaderTestParams {
-  const bool useSelectiveReader;
-  const bool returnFlatVector;
-  const bool expectMemoryReuse;
-
-  std::string toString() const {
-    std::ostringstream out;
-    out << (useSelectiveReader ? "selective" : "") << "_"
-        << (returnFlatVector ? "as_flat" : "") << "_"
-        << (expectMemoryReuse ? "reuse" : "");
-    return out.str();
-  }
-};
-
-class StringReaderTests
-    : public ::testing::TestWithParam<StringReaderTestParams> {
- protected:
-  StringReaderTests()
-      : expectMemoryReuse_{GetParam().expectMemoryReuse},
-        returnFlatVector_{GetParam().returnFlatVector} {}
-
-  std::unique_ptr<ColumnReader> buildReader(
-      const std::shared_ptr<const Type>& requestedType,
-      MockStripeStreams& stripe,
-      std::vector<uint64_t> nodes = {},
-      const std::shared_ptr<const Type>& dataType = nullptr) {
-    if (useSelectiveReader()) {
-      return builder_.build(requestedType, stripe, nodes, dataType);
-    } else {
-      return buildColumnReader(
-          requestedType, stripe, nodes, returnFlatVector_, dataType);
-    }
-  }
-
-  VectorPtr newBatch(const TypePtr& rowType) const {
-    return useSelectiveReader()
-        ? BaseVector::create(rowType, 0, &streams.getMemoryPool())
-        : nullptr;
-  }
-
-  vector_size_t getNullCount(const VectorPtr& vector) const {
-    if (useSelectiveReader()) {
-      return BaseVector::countNulls(vector->nulls(), vector->size());
-    } else {
-      return vector->getNullCount().value();
-    }
-  }
-
-  // TODO Rename to streams_
-  MockStripeStreams streams;
-  const bool expectMemoryReuse_;
-  const bool returnFlatVector_;
-
- private:
-  bool useSelectiveReader() const {
-    return GetParam().useSelectiveReader;
-  }
-
-  SelectiveColumnReaderBuilder builder_;
-};
-
-void skip(std::unique_ptr<ColumnReader>& reader, int32_t skipSize = 0) {
-  if (skipSize > 0) {
-    reader->skip(skipSize);
-    // TODO Fix SelectiveColumnReader::skip
-    auto selectiveReader = dynamic_cast<SelectiveColumnReader*>(reader.get());
-    if (selectiveReader) {
-      selectiveReader->setReadOffset(selectiveReader->readOffset() + skipSize);
-    }
-  }
-}
-
-void skipAndRead(
-    std::unique_ptr<ColumnReader>& reader,
-    VectorPtr& batch,
-    int32_t readSize = 2,
-    int32_t skipSize = 0,
-    int32_t nullCount = 0) {
-  skip(reader, skipSize);
-
-  reader->next(readSize, batch);
-  ASSERT_EQ(readSize, batch->size());
-  ASSERT_EQ(nullCount, BaseVector::countNulls(batch->nulls(), batch->size()));
-  if (batch->getNullCount().has_value()) {
-    ASSERT_EQ(nullCount, batch->getNullCount().value());
-  }
 }
 
 template <typename T, typename F>
@@ -246,6 +106,154 @@ std::shared_ptr<T> getChild(std::shared_ptr<F>& batch, size_t index) {
   return child;
 }
 
+class ColumnReaderTestBase {
+ protected:
+  virtual ~ColumnReaderTestBase() = default;
+
+  void buildReader(
+      const std::shared_ptr<const Type>& requestedType,
+      std::vector<uint64_t> nodes = {},
+      const std::shared_ptr<const Type>& dataType = nullptr) {
+    const std::shared_ptr<const RowType>& rowType =
+        std::dynamic_pointer_cast<const RowType>(requestedType);
+    ColumnSelector cs(rowType, nodes, true);
+    auto options = RowReaderOptions();
+    options.setReturnFlatVector(returnFlatVector());
+
+    EXPECT_CALL(streams_, getColumnSelectorProxy())
+        .WillRepeatedly(testing::Return(&cs));
+    EXPECT_CALL(streams_, getRowReaderOptionsProxy())
+        .WillRepeatedly(testing::Return(&options));
+
+    auto dataTypeWithId =
+        TypeWithId::create(dataType ? dataType : requestedType);
+
+    if (useSelectiveReader()) {
+      scanSpec_ = std::make_unique<common::ScanSpec>("root");
+      makeFieldSpecs("", 0, rowType, scanSpec_.get());
+      selectiveColumnReader_ = SelectiveColumnReader::build(
+          cs.getSchemaWithId(),
+          dataTypeWithId,
+          streams_,
+          scanSpec_.get(),
+          FlatMapContext::nonFlatMapContext());
+      selectiveColumnReader_->setIsTopLevel();
+      columnReader_ = nullptr;
+    } else {
+      columnReader_ =
+          ColumnReader::build(cs.getSchemaWithId(), dataTypeWithId, streams_);
+      selectiveColumnReader_ = nullptr;
+    }
+  }
+
+  void next(uint64_t numValues, VectorPtr& result) {
+    if (columnReader_) {
+      columnReader_->next(numValues, result);
+    } else {
+      selectiveColumnReader_->next(numValues, result);
+    }
+  }
+
+  void skip(int32_t skipSize = 0) {
+    if (skipSize > 0) {
+      if (columnReader_) {
+        columnReader_->skip(skipSize);
+      } else {
+        selectiveColumnReader_->skip(skipSize);
+        selectiveColumnReader_->setReadOffset(
+            selectiveColumnReader_->readOffset() + skipSize);
+      }
+    }
+  }
+
+  void skipAndRead(
+      VectorPtr& batch,
+      int32_t readSize = 2,
+      int32_t skipSize = 0,
+      int32_t nullCount = 0) {
+    skip(skipSize);
+
+    if (columnReader_) {
+      columnReader_->next(readSize, batch);
+    } else {
+      selectiveColumnReader_->next(readSize, batch);
+    }
+
+    ASSERT_EQ(readSize, batch->size());
+    ASSERT_EQ(nullCount, BaseVector::countNulls(batch->nulls(), batch->size()));
+    if (batch->getNullCount().has_value()) {
+      ASSERT_EQ(nullCount, batch->getNullCount().value());
+    }
+  }
+
+  void resetReader() {
+    if (columnReader_) {
+      columnReader_.reset(nullptr);
+    } else {
+      selectiveColumnReader_.reset(nullptr);
+    }
+  }
+
+  virtual const bool useSelectiveReader() const = 0;
+  virtual const bool returnFlatVector() const = 0;
+
+  MockStripeStreams streams_;
+  std::unique_ptr<ColumnReader> columnReader_;
+  std::unique_ptr<SelectiveColumnReader> selectiveColumnReader_;
+
+ private:
+  std::unique_ptr<common::ScanSpec> scanSpec_;
+};
+
+struct StringReaderTestParams {
+  const bool useSelectiveReader;
+  const bool returnFlatVector;
+  const bool expectMemoryReuse;
+
+  std::string toString() const {
+    std::ostringstream out;
+    out << (useSelectiveReader ? "selective" : "") << "_"
+        << (returnFlatVector ? "as_flat" : "") << "_"
+        << (expectMemoryReuse ? "reuse" : "");
+    return out.str();
+  }
+};
+
+class StringReaderTests
+    : public ::testing::TestWithParam<StringReaderTestParams>,
+      public ColumnReaderTestBase {
+ protected:
+  StringReaderTests()
+      : expectMemoryReuse_{GetParam().expectMemoryReuse},
+        returnFlatVector_{GetParam().returnFlatVector} {}
+
+  VectorPtr newBatch(const TypePtr& rowType) const {
+    return useSelectiveReader()
+        ? BaseVector::create(rowType, 0, &streams_.getMemoryPool())
+        : nullptr;
+  }
+
+  vector_size_t getNullCount(const VectorPtr& vector) const {
+    if (useSelectiveReader()) {
+      return BaseVector::countNulls(vector->nulls(), vector->size());
+    } else {
+      return vector->getNullCount().value();
+    }
+  }
+
+  const bool expectMemoryReuse_;
+  const bool returnFlatVector_;
+
+ private:
+  const bool useSelectiveReader() const override {
+    return GetParam().useSelectiveReader;
+  }
+
+  const bool returnFlatVector() const override {
+    return returnFlatVector_;
+  }
+};
+
 struct ReaderTestParams {
   const bool useSelectiveReader;
   const bool expectMemoryReuse;
@@ -258,26 +266,14 @@ struct ReaderTestParams {
   }
 };
 
-class TestColumnReader : public testing::TestWithParam<ReaderTestParams> {
+class TestColumnReader : public testing::TestWithParam<ReaderTestParams>,
+                         public ColumnReaderTestBase {
  protected:
   TestColumnReader() : expectMemoryReuse_{GetParam().expectMemoryReuse} {}
 
-  std::unique_ptr<ColumnReader> buildReader(
-      const std::shared_ptr<const Type>& requestedType,
-      std::vector<uint64_t> nodes = {},
-      bool returnFlatVector = false,
-      const std::shared_ptr<const Type>& dataType = nullptr) {
-    if (useSelectiveReader()) {
-      return builder_.build(requestedType, streams, nodes, dataType);
-    } else {
-      return buildColumnReader(
-          requestedType, streams, nodes, returnFlatVector, dataType);
-    }
-  }
-
   VectorPtr newBatch(const TypePtr& rowType) const {
     return useSelectiveReader()
-        ? BaseVector::create(rowType, 0, &streams.getMemoryPool())
+        ? BaseVector::create(rowType, 0, &streams_.getMemoryPool())
         : nullptr;
   }
 
@@ -293,51 +289,110 @@ class TestColumnReader : public testing::TestWithParam<ReaderTestParams> {
     }
   }
 
-  bool useSelectiveReader() const {
+  const bool useSelectiveReader() const override {
     return GetParam().useSelectiveReader;
   }
 
-  const bool expectMemoryReuse_;
-  // TODO Rename to streams_
-  MockStripeStreams streams;
+  const bool returnFlatVector() const override {
+    return false;
+  }
 
- private:
-  SelectiveColumnReaderBuilder builder_;
+  const bool expectMemoryReuse_;
+};
+
+class SchemaMismatchTest : public TestWithParam<bool>,
+                           public ColumnReaderTestBase {
+ protected:
+  VectorPtr newBatch(const TypePtr& rowType) {
+    return useSelectiveReader()
+        ? BaseVector::create(rowType, 0, &streams_.getMemoryPool())
+        : nullptr;
+  }
+
+  const bool useSelectiveReader() const override {
+    return GetParam();
+  }
+
+  const bool returnFlatVector() const override {
+    return false;
+  }
+
+  template <typename From, typename To>
+  void runTest(uint64_t size) {
+    auto dataType = ROW({"c0"}, {CppToType<From>::create()});
+    auto requestedType = ROW({"c0"}, {CppToType<To>::create()});
+
+    // build asIsColumnReader_ and asIsSelectiveColumnReader_.
+    buildReader(dataType);
+    asIsColumnReader_ = std::move(columnReader_);
+    asIsSelectiveColumnReader_ = std::move(selectiveColumnReader_);
+    VectorPtr asIsBatch = newBatch(dataType);
+    if (asIsColumnReader_) {
+      asIsColumnReader_->next(size, asIsBatch, nullptr);
+    } else {
+      asIsSelectiveColumnReader_->next(size, asIsBatch, nullptr);
+    }
+
+    // build columnReader_ and selectiveColumnReader_. They are used as
+    // mismatch ColumnReaders
+    buildReader(requestedType, {}, dataType);
+    VectorPtr mismatchBatch = newBatch(requestedType);
+    if (columnReader_) {
+      columnReader_->next(size, mismatchBatch, nullptr);
+    } else {
+      selectiveColumnReader_->next(size, mismatchBatch, nullptr);
+    }
+
+    ASSERT_EQ(asIsBatch->size(), mismatchBatch->size());
+    auto mismatchField = getOnlyChild<SimpleVector<To>>(mismatchBatch);
+    auto asIsField = getOnlyChild<SimpleVector<From>>(asIsBatch);
+    for (auto i = 0; i < asIsBatch->size(); ++i) {
+      auto isNull = asIsField->isNullAt(i);
+      EXPECT_EQ(isNull, mismatchField->isNullAt(i));
+      if (!isNull) {
+        EXPECT_EQ(asIsField->valueAt(i), mismatchField->valueAt(i));
+      }
+    }
+  }
+
+  // columnReader_ and selectiveColumnReader_ are mismatch ColumnReaders
+  std::unique_ptr<ColumnReader> asIsColumnReader_;
+  std::unique_ptr<SelectiveColumnReader> asIsSelectiveColumnReader_;
 };
 
 TEST_P(TestColumnReader, testBooleanWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   // alternate 4 non-null and 4 null via [0xf0 for x in range(512 / 8)]
   const unsigned char buffer1[] = {0x3d, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
   // [0x0f for x in range(256 / 8)]
   const unsigned char buffer2[] = {0x1d, 0x0f};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:boolean>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
 
   auto boolBatch = getOnlyChild<FlatVector<bool>>(batch);
   ASSERT_EQ(512, boolBatch->size());
@@ -358,35 +413,35 @@ TEST_P(TestColumnReader, testBooleanWithNullsFractional) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   // alternate 4 non-null and 4 null via [0xf0 for x in range(512 / 8)]
   std::array<const unsigned char, 2> buffer1 = {0x3d, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(buffer1.data(), buffer1.size())));
 
   // [0x0f for x in range(256 / 8)]
   std::array<const unsigned char, 2> buffer2 = {0x1d, 0x0f};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(buffer2.data(), buffer2.size())));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:boolean>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   VectorPtr batch = newBatch(rowType);
 
-  skipAndRead(reader, batch, /* read */ 7);
+  skipAndRead(batch, /* read */ 7);
 
   auto boolBatch = getOnlyChild<FlatVector<bool>>(batch);
   ASSERT_EQ(7, boolBatch->size());
@@ -406,7 +461,7 @@ TEST_P(TestColumnReader, testBooleanWithNullsFractional) {
   if (expectMemoryReuse_) {
     boolBatch.reset();
   }
-  skipAndRead(reader, batch, /* read */ 2);
+  skipAndRead(batch, /* read */ 2);
 
   boolBatch = getOnlyChild<FlatVector<bool>>(batch);
   ASSERT_EQ(expectMemoryReuse_, boolBatch.get() == boolBatchPtr);
@@ -421,33 +476,33 @@ TEST_P(TestColumnReader, testBooleanSkipsWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   // alternate 4 non-null and 4 null via [0xf0 for x in range(512 / 8)]
   const unsigned char buffer1[] = {0x3d, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
   // [0x0f for x in range(128 / 8)]
   const unsigned char buffer2[] = {0x1d, 0x0f};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:boolean>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 1);
+  skipAndRead(batch, /* read */ 1);
 
   auto boolBatch = getOnlyChild<FlatVector<bool>>(batch);
   ASSERT_EQ(1, boolBatch->size());
@@ -458,7 +513,7 @@ TEST_P(TestColumnReader, testBooleanSkipsWithNulls) {
   if (expectMemoryReuse_) {
     boolBatch.reset();
   }
-  skipAndRead(reader, batch, /* read */ 5, /* skip */ 506);
+  skipAndRead(batch, /* read */ 5, /* skip */ 506);
 
   boolBatch = getOnlyChild<FlatVector<bool>>(batch);
   ASSERT_EQ(expectMemoryReuse_, boolBatch.get() == boolBatchPtr);
@@ -476,19 +531,19 @@ TEST_P(TestColumnReader, testByteWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   // alternate 4 non-null and 4 null via [0xf0 for x in range(512 / 8)]
   const unsigned char buffer1[] = {0x3d, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -502,16 +557,16 @@ TEST_P(TestColumnReader, testByteWithNulls) {
   for (uint32_t i = 128; i < 256; ++i) {
     buffer[i + 2] = static_cast<char>(i);
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer, VELOX_ARRAY_SIZE(buffer))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:tinyint>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
 
   auto byteBatch = getOnlyChild<FlatVector<int8_t>>(batch);
   ASSERT_EQ(512, byteBatch->size());
@@ -532,22 +587,22 @@ TEST_P(TestColumnReader, testBatchReusedSizeEnsured) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // build up 3 rows of byte value
   const std::array<unsigned char, 2> buffer = {0x3d, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(buffer.data(), buffer.size())));
 
@@ -555,9 +610,9 @@ TEST_P(TestColumnReader, testBatchReusedSizeEnsured) {
   auto rowType = HiveTypeParser().parse("struct<col0:tinyint>");
 
   // somehow this batch was resized somewhere before reader fill data for it
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 7);
+  skipAndRead(batch, /* read */ 7);
 
   auto byteBatch = getOnlyChild<FlatVector<int8_t>>(batch);
   ASSERT_EQ(7, byteBatch->size());
@@ -571,19 +626,19 @@ TEST_P(TestColumnReader, testByteSkipsWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   // alternate 4 non-null and 4 null via [0xf0 for x in range(512 / 8)]
   const unsigned char buffer1[] = {0x3d, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -597,16 +652,16 @@ TEST_P(TestColumnReader, testByteSkipsWithNulls) {
   for (uint32_t i = 128; i < 256; ++i) {
     buffer[i + 2] = static_cast<char>(i);
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer, VELOX_ARRAY_SIZE(buffer))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:tinyint>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 1);
+  skipAndRead(batch, /* read */ 1);
 
   auto byteBatch = getOnlyChild<FlatVector<int8_t>>(batch);
   ASSERT_EQ(1, byteBatch->size());
@@ -617,7 +672,7 @@ TEST_P(TestColumnReader, testByteSkipsWithNulls) {
   if (expectMemoryReuse_) {
     byteBatch.reset();
   }
-  skipAndRead(reader, batch, /* read */ 5, /* skip */ 506);
+  skipAndRead(batch, /* read */ 5, /* skip */ 506);
 
   byteBatch = getOnlyChild<FlatVector<int8_t>>(batch);
   ASSERT_EQ(expectMemoryReuse_, byteBatch.get() == byteBatchPtr);
@@ -635,32 +690,32 @@ TEST_P(TestColumnReader, testIntegerWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   const unsigned char buffer1[] = {0x16, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
   char buffer2[1024];
   size_t size = writeRange(buffer2, 0, 100);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer2, size)));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myInt:int>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 200);
+  skipAndRead(batch, /* read */ 200);
 
   auto intBatch = getOnlyChild<FlatVector<int32_t>>(batch);
   ASSERT_EQ(200, intBatch->size());
@@ -683,17 +738,17 @@ TEST_P(TestColumnReader, testIntDictSkipNoNullsAllInDict) {
   proto::ColumnEncoding dictEncoding;
   dictEncoding.set_kind(proto::ColumnEncoding_Kind_DICTIONARY);
   dictEncoding.set_dictionarysize(100);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
-  EXPECT_CALL(streams, getEncodingProxy(1))
+  EXPECT_CALL(streams_, getEncodingProxy(1))
       .WillRepeatedly(Return(&dictEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // even row points to dictionary.
@@ -704,14 +759,14 @@ TEST_P(TestColumnReader, testIntDictSkipNoNullsAllInDict) {
     v.push_back(i);
   }
   size_t size = writeVuLongs(data + 1, v);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(data, size + 1)));
 
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, genMockDictDataSetter(1, 0))
+  EXPECT_CALL(streams_, genMockDictDataSetter(1, 0))
       .WillRepeatedly(Return([&](BufferPtr& buffer, MemoryPool* pool) {
         buffer = useSelectiveReader() ? sequence<int32_t>(pool, 0, 100)
                                       : sequence<int64_t>(pool, 0, 100);
@@ -720,7 +775,7 @@ TEST_P(TestColumnReader, testIntDictSkipNoNullsAllInDict) {
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myInt:int>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   long offset = 0;
   VectorPtr batch = newBatch(rowType);
   FlatVectorPtr<int32_t> intBatch;
@@ -729,7 +784,7 @@ TEST_P(TestColumnReader, testIntDictSkipNoNullsAllInDict) {
     if (expectMemoryReuse_) {
       intBatch.reset();
     }
-    skipAndRead(reader, batch, /* read */ 40, /* skip */ 10);
+    skipAndRead(batch, /* read */ 40, /* skip */ 10);
 
     intBatch = getOnlyChild<FlatVector<int32_t>>(batch);
     if (round > 0) {
@@ -752,20 +807,20 @@ TEST_P(TestColumnReader, testIntDictSkipWithNulls) {
   proto::ColumnEncoding dictEncoding;
   dictEncoding.set_kind(proto::ColumnEncoding_Kind_DICTIONARY);
   dictEncoding.set_dictionarysize(50);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
-  EXPECT_CALL(streams, getEncodingProxy(1))
+  EXPECT_CALL(streams_, getEncodingProxy(1))
       .WillRepeatedly(Return(&dictEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   const unsigned char buffer1[] = {0x16, 0xaa};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -777,16 +832,16 @@ TEST_P(TestColumnReader, testIntDictSkipWithNulls) {
     v.push_back(i % 2 == 0 ? i / 2 : i + 1000);
   }
   size_t size = writeVuLongs(buffer2 + 1, v);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer2, size + 1)));
 
   const unsigned char buffer3[] = {0x0a, 0xaa};
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer3, VELOX_ARRAY_SIZE(buffer3))));
 
-  EXPECT_CALL(streams, genMockDictDataSetter(1, 0))
+  EXPECT_CALL(streams_, genMockDictDataSetter(1, 0))
       .WillRepeatedly(Return([&](BufferPtr& buffer, MemoryPool* pool) {
         if (useSelectiveReader()) {
           buffer = AlignedBuffer::allocate<int32_t>(1024, pool);
@@ -805,7 +860,7 @@ TEST_P(TestColumnReader, testIntDictSkipWithNulls) {
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myInt:int>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   long next = 0;
   VectorPtr batch = newBatch(rowType);
   FlatVectorPtr<int32_t> intBatch;
@@ -814,7 +869,7 @@ TEST_P(TestColumnReader, testIntDictSkipWithNulls) {
     if (expectMemoryReuse_) {
       intBatch.reset();
     }
-    skipAndRead(reader, batch, /* read */ 90, /* skip */ 10);
+    skipAndRead(batch, /* read */ 90, /* skip */ 10);
     next += 5;
 
     intBatch = getOnlyChild<FlatVector<int32_t>>(batch);
@@ -839,22 +894,22 @@ TEST_P(TestColumnReader, testIntDictBoundary) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   constexpr size_t dictSize = std::numeric_limits<uint16_t>::max() + 1;
   proto::ColumnEncoding dictEncoding;
   dictEncoding.set_kind(proto::ColumnEncoding_Kind_DICTIONARY);
   dictEncoding.set_dictionarysize(dictSize);
-  EXPECT_CALL(streams, getEncodingProxy(1))
+  EXPECT_CALL(streams_, getEncodingProxy(1))
       .WillRepeatedly(Return(&dictEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // even row points to dictionary.
@@ -869,14 +924,14 @@ TEST_P(TestColumnReader, testIntDictBoundary) {
     size = writeVuLong(data.data(), size, count);
     count += toWrite;
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(data.data(), size)));
 
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, genMockDictDataSetter(1, 0))
+  EXPECT_CALL(streams_, genMockDictDataSetter(1, 0))
       .WillRepeatedly(Return([&](BufferPtr& buffer, MemoryPool* pool) {
         int64_t begin = std::numeric_limits<int16_t>::min();
         auto end =
@@ -888,10 +943,10 @@ TEST_P(TestColumnReader, testIntDictBoundary) {
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<foo:smallint>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   VectorPtr batch = newBatch(rowType);
 
-  skipAndRead(reader, batch, /* read */ dictSize);
+  skipAndRead(batch, /* read */ dictSize);
 
   auto shortBatch = getOnlyChild<FlatVector<int16_t>>(batch);
   ASSERT_EQ(dictSize, shortBatch->size());
@@ -907,48 +962,49 @@ TEST_P(StringReaderTests, testDictionaryWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(0))
+  EXPECT_CALL(streams_, getEncodingProxy(0))
       .WillRepeatedly(Return(&directEncoding));
   proto::ColumnEncoding dictionaryEncoding;
   dictionaryEncoding.set_kind(proto::ColumnEncoding_Kind_DICTIONARY);
   dictionaryEncoding.set_dictionarysize(2);
-  EXPECT_CALL(streams, getEncodingProxy(1))
+  EXPECT_CALL(streams_, getEncodingProxy(1))
       .WillRepeatedly(Return(&dictionaryEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(1, _, _)).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams_, getStreamProxy(1, _, _))
+      .WillRepeatedly(Return(nullptr));
   const unsigned char buffer1[] = {0x19, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
   const unsigned char buffer2[] = {0x2f, 0x00, 0x00, 0x2f, 0x00, 0x01};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
   const unsigned char buffer3[] = {0x4f, 0x52, 0x43, 0x4f, 0x77, 0x65, 0x6e};
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer3, VELOX_ARRAY_SIZE(buffer3))));
   const unsigned char buffer4[] = {0x02, 0x01, 0x03};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer4, VELOX_ARRAY_SIZE(buffer4))));
 
   TestStrideIndexProvider provider(10000);
-  EXPECT_CALL(streams, getStrideIndexProviderProxy())
+  EXPECT_CALL(streams_, getStrideIndexProviderProxy())
       .WillRepeatedly(Return(&provider));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myString:string>");
 
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 200);
+  skipAndRead(batch, /* read */ 200);
 
   std::shared_ptr<SimpleVector<StringView>> stringBatch;
   if (returnFlatVector_) {
@@ -978,12 +1034,12 @@ TEST_P(StringReaderTests, testStringDictSkipNoNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
   proto::ColumnEncoding dictionaryEncoding;
   dictionaryEncoding.set_kind(proto::ColumnEncoding_Kind_DICTIONARY);
   dictionaryEncoding.set_dictionarysize(50);
-  EXPECT_CALL(streams, getEncodingProxy(1))
+  EXPECT_CALL(streams_, getEncodingProxy(1))
       .WillRepeatedly(Return(&dictionaryEncoding));
 
   // set row index
@@ -991,9 +1047,9 @@ TEST_P(StringReaderTests, testStringDictSkipNoNulls) {
   proto::RowIndex index;
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   char data[1024];
@@ -1037,13 +1093,13 @@ TEST_P(StringReaderTests, testStringDictSkipNoNulls) {
     }
   }
   entry->add_positions(strideDictSize);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(data, len)));
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
       .WillRepeatedly(Return(new SeekableArrayInputStream(dict, dictLen)));
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY, true))
+      streams_, getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(strideDict, strideDictLen)));
 
@@ -1058,38 +1114,38 @@ TEST_P(StringReaderTests, testStringDictSkipNoNulls) {
     strideDictLen = writeVuLong(
         strideDictLength, strideDictLen, strideDictVals[i].length());
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(dictLength, dictLen)));
   EXPECT_CALL(
-      streams,
+      streams_,
       getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(strideDictLength, strideDictLen)));
   const unsigned char inDict[] = {0x0a, 0xaa};
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(inDict, VELOX_ARRAY_SIZE(inDict))));
 
   auto indexData = index.SerializePartialAsString();
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, _))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, _))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(indexData.data(), indexData.size())));
   TestStrideIndexProvider provider(rowIndexStride);
-  EXPECT_CALL(streams, getStrideIndexProviderProxy())
+  EXPECT_CALL(streams_, getStrideIndexProviderProxy())
       .WillRepeatedly(Return(&provider));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myString:string>");
 
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
   uint64_t rowCount = 0;
   VectorPtr batch = newBatch(rowType);
   std::shared_ptr<SimpleVector<StringView>> stringBatch;
   VectorPtr rowVector;
   for (uint64_t toSkip = 0; toSkip < 10; ++toSkip) {
-    skip(reader, toSkip);
+    skip(toSkip);
 
     provider.addRow(toSkip);
     rowCount += toSkip;
@@ -1099,7 +1155,13 @@ TEST_P(StringReaderTests, testStringDictSkipNoNulls) {
     if (expectMemoryReuse_) {
       stringBatch.reset();
     }
-    reader->next(rowsRead, batch);
+
+    if (columnReader_) {
+      columnReader_->next(rowsRead, batch);
+    } else {
+      selectiveColumnReader_->next(rowsRead, batch);
+    }
+
     ASSERT_EQ(rowsRead, batch->size());
     ASSERT_EQ(0, getNullCount(batch));
 
@@ -1129,12 +1191,12 @@ TEST_P(StringReaderTests, testStringDictSkipWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
   proto::ColumnEncoding dictionaryEncoding;
   dictionaryEncoding.set_kind(proto::ColumnEncoding_Kind_DICTIONARY);
   dictionaryEncoding.set_dictionarysize(50);
-  EXPECT_CALL(streams, getEncodingProxy(1))
+  EXPECT_CALL(streams_, getEncodingProxy(1))
       .WillRepeatedly(Return(&dictionaryEncoding));
 
   // set row index
@@ -1142,12 +1204,12 @@ TEST_P(StringReaderTests, testStringDictSkipWithNulls) {
   proto::RowIndex index;
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   const unsigned char present[] = {0x16, 0xaa};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(present, VELOX_ARRAY_SIZE(present))));
 
@@ -1197,13 +1259,13 @@ TEST_P(StringReaderTests, testStringDictSkipWithNulls) {
     }
   }
   entry->add_positions(strideDictSize);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(data, len)));
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
       .WillRepeatedly(Return(new SeekableArrayInputStream(dict, dictLen)));
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY, true))
+      streams_, getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(strideDict, strideDictLen)));
 
@@ -1218,33 +1280,33 @@ TEST_P(StringReaderTests, testStringDictSkipWithNulls) {
     strideDictLen = writeVuLong(
         strideDictLength, strideDictLen, strideDictVals[i].length());
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(dictLength, dictLen)));
   EXPECT_CALL(
-      streams,
+      streams_,
       getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(strideDictLength, strideDictLen)));
   const unsigned char inDict[] = {0x0a, 0xaa};
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(inDict, VELOX_ARRAY_SIZE(inDict))));
 
   auto indexData = index.SerializePartialAsString();
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, _))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, _))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(indexData.data(), indexData.size())));
   TestStrideIndexProvider provider(rowIndexStride);
-  EXPECT_CALL(streams, getStrideIndexProviderProxy())
+  EXPECT_CALL(streams_, getStrideIndexProviderProxy())
       .WillRepeatedly(Return(&provider));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myString:string>");
 
-  auto reader = buildReader(rowType, streams, {});
-  skip(reader, 50);
+  buildReader(rowType, {});
+  skip(50);
   provider.addRow(50);
   uint32_t rowCount = 0;
   VectorPtr batch = newBatch(rowType);
@@ -1255,7 +1317,7 @@ TEST_P(StringReaderTests, testStringDictSkipWithNulls) {
     if (expectMemoryReuse_) {
       stringBatch.reset();
     }
-    reader->next(rowIndexStride, batch);
+    next(rowIndexStride, batch);
     ASSERT_EQ(rowIndexStride, batch->size());
     ASSERT_EQ(0, getNullCount(batch));
 
@@ -1296,41 +1358,41 @@ TEST_P(TestColumnReader, testSubstructsWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   const unsigned char buffer1[] = {0x16, 0x0f};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
   const unsigned char buffer2[] = {0x0a, 0x55};
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   const unsigned char buffer3[] = {0x04, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(3, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(3, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer3, VELOX_ARRAY_SIZE(buffer3))));
 
   char buffer4[256];
   size_t size = writeRange(buffer4, 0, 26);
-  EXPECT_CALL(streams, getStreamProxy(3, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(3, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer4, size)));
 
   // create the row type
   auto rowType =
       HiveTypeParser().parse("struct<col0:struct<col1:struct<col2:bigint>>>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 200);
+  skipAndRead(batch, /* read */ 200);
 
   auto middle = getOnlyChild<RowVector>(batch);
   ASSERT_EQ(200, middle->size());
@@ -1373,41 +1435,42 @@ TEST_P(TestColumnReader, testSkipWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
   proto::ColumnEncoding dictionaryEncoding;
   dictionaryEncoding.set_kind(proto::ColumnEncoding_Kind_DICTIONARY);
   dictionaryEncoding.set_dictionarysize(100);
-  EXPECT_CALL(streams, getEncodingProxy(2))
+  EXPECT_CALL(streams_, getEncodingProxy(2))
       .WillRepeatedly(Return(&dictionaryEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   const unsigned char buffer1[] = {
       0x03, 0x00, 0xff, 0x3f, 0x08, 0xff, 0xff, 0xfc, 0x03, 0x00};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
-  EXPECT_CALL(streams, getStreamProxy(2, _, _)).WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(2, _, _))
+      .WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
   TestStrideIndexProvider provider(10000);
-  EXPECT_CALL(streams, getStrideIndexProviderProxy())
+  EXPECT_CALL(streams_, getStrideIndexProviderProxy())
       .WillRepeatedly(Return(&provider));
 
   char buffer2[1024];
   size_t size = writeRange(buffer2, 0, 100);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer2, size)));
   const unsigned char buffer3[] = {0x61, 0x01, 0x00};
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer3, VELOX_ARRAY_SIZE(buffer3))));
 
@@ -1420,20 +1483,20 @@ TEST_P(TestColumnReader, testSkipWithNulls) {
     }
   }
   EXPECT_CALL(
-      streams, getStreamProxy(2, proto::Stream_Kind_DICTIONARY_DATA, false))
+      streams_, getStreamProxy(2, proto::Stream_Kind_DICTIONARY_DATA, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(digits, VELOX_ARRAY_SIZE(digits))));
   const unsigned char buffer4[] = {0x61, 0x00, 0x02};
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_LENGTH, false))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_LENGTH, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer4, VELOX_ARRAY_SIZE(buffer4))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myInt:int,myString:string>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 20);
+  skipAndRead(batch, /* read */ 20);
 
   auto intBatch = getChild<SimpleVector<int32_t>>(batch, 0);
   ASSERT_EQ(20, intBatch->size());
@@ -1454,7 +1517,7 @@ TEST_P(TestColumnReader, testSkipWithNulls) {
     intBatch.reset();
     stringBatch.reset();
   }
-  skipAndRead(reader, batch, /* read */ 100, /* skip */ 30);
+  skipAndRead(batch, /* read */ 100, /* skip */ 30);
 
   intBatch = getChild<SimpleVector<int32_t>>(batch, 0);
   stringBatch = getChild<DictionaryVector<StringView>>(batch, 1);
@@ -1474,26 +1537,26 @@ TEST_P(TestColumnReader, testSkipWithNulls) {
           << "Wrong at " << k;
     }
   }
-  reader->skip(50);
+  skip(50);
 }
 
 TEST_P(StringReaderTests, testBinaryDirect) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
-      .WillRepeatedly(Return(nullptr));
-
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   char blob[200];
@@ -1503,19 +1566,19 @@ TEST_P(StringReaderTests, testBinaryDirect) {
       blob[2 * (10 * i + j) + 1] = static_cast<char>(j);
     }
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(blob, VELOX_ARRAY_SIZE(blob))));
 
   const unsigned char buffer[] = {0x61, 0x00, 0x02};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer, VELOX_ARRAY_SIZE(buffer))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:binary>");
 
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
 
   VectorPtr batch = newBatch(rowType);
   FlatVectorPtr<StringView> strings;
@@ -1525,7 +1588,7 @@ TEST_P(StringReaderTests, testBinaryDirect) {
     if (expectMemoryReuse_) {
       strings.reset();
     }
-    skipAndRead(reader, batch, /* read */ 50);
+    skipAndRead(batch, /* read */ 50);
 
     strings = getOnlyChild<FlatVector<StringView>>(batch);
     if (i > 0) {
@@ -1545,20 +1608,20 @@ TEST_P(StringReaderTests, testBinaryDirectWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   const unsigned char buffer1[] = {0x1d, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -1569,19 +1632,19 @@ TEST_P(StringReaderTests, testBinaryDirectWithNulls) {
       blob[2 * (16 * i + j) + 1] = static_cast<char>('A' + j);
     }
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(blob, VELOX_ARRAY_SIZE(blob))));
 
   const unsigned char buffer2[] = {0x7d, 0x00, 0x02};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:binary>");
 
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
 
   size_t next = 0;
   VectorPtr batch = newBatch(rowType);
@@ -1592,7 +1655,7 @@ TEST_P(StringReaderTests, testBinaryDirectWithNulls) {
     if (expectMemoryReuse_) {
       strings.reset();
     }
-    skipAndRead(reader, batch, /* read */ 128);
+    skipAndRead(batch, /* read */ 128);
 
     strings = getOnlyChild<FlatVector<StringView>>(batch);
     if (i > 0) {
@@ -1618,39 +1681,39 @@ TEST_P(TestColumnReader, testShortBlobError) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
-      .WillRepeatedly(Return(nullptr));
-
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   char blob[100];
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(blob, VELOX_ARRAY_SIZE(blob))));
 
   const unsigned char buffer1[] = {0x61, 0x00, 0x02};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:string>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
   try {
-    reader->next(100, batch);
+    next(100, batch);
     batch->as<RowVector>()->childAt(0)->loadedVector();
     FAIL() << "Expected an error";
   } catch (const exception::LoggedException& e) {
@@ -1664,19 +1727,19 @@ TEST_P(StringReaderTests, testStringDirectShortBuffer) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
-      .WillRepeatedly(Return(nullptr));
-
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   char blob[200];
@@ -1686,19 +1749,19 @@ TEST_P(StringReaderTests, testStringDirectShortBuffer) {
       blob[2 * (10 * i + j) + 1] = static_cast<char>(j);
     }
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(blob, VELOX_ARRAY_SIZE(blob), 3)));
 
   const unsigned char buffer1[] = {0x61, 0x00, 0x02};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:string>");
 
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
 
   VectorPtr batch = newBatch(rowType);
   FlatVectorPtr<StringView> strings;
@@ -1708,7 +1771,7 @@ TEST_P(StringReaderTests, testStringDirectShortBuffer) {
     if (expectMemoryReuse_) {
       strings.reset();
     }
-    skipAndRead(reader, batch, /* read */ 25);
+    skipAndRead(batch, /* read */ 25);
 
     strings = getOnlyChild<FlatVector<StringView>>(batch);
     if (i > 0) {
@@ -1728,20 +1791,20 @@ TEST_P(StringReaderTests, testStringDirectShortBufferWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   const unsigned char buffer1[] = {0x3d, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -1752,19 +1815,19 @@ TEST_P(StringReaderTests, testStringDirectShortBufferWithNulls) {
       blob[2 * (16 * i + j) + 1] = static_cast<char>('A' + j);
     }
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(blob, VELOX_ARRAY_SIZE(blob), 30)));
 
   const unsigned char buffer2[] = {0x7d, 0x00, 0x02, 0x7d, 0x00, 0x02};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:string>");
 
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
 
   size_t next = 0;
   VectorPtr batch = newBatch(rowType);
@@ -1775,7 +1838,7 @@ TEST_P(StringReaderTests, testStringDirectShortBufferWithNulls) {
     if (expectMemoryReuse_) {
       strings.reset();
     }
-    skipAndRead(reader, batch, /* read */ 64);
+    skipAndRead(batch, /* read */ 64);
 
     strings = getOnlyChild<FlatVector<StringView>>(batch);
     if (i > 0) {
@@ -1807,43 +1870,43 @@ TEST_P(StringReaderTests, testStringDirectNullAcrossWindow) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   const unsigned char isNull[2] = {0xff, 0x7f};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(isNull, VELOX_ARRAY_SIZE(isNull))));
 
   const char blob[] = "abcdefg";
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(blob, VELOX_ARRAY_SIZE(blob), 4)));
 
   // [1] * 7
   const unsigned char lenData[] = {0x04, 0x00, 0x01};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(lenData, VELOX_ARRAY_SIZE(lenData))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:string>");
 
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
 
   VectorPtr batch = newBatch(rowType);
   // This length value won't be overwritten because the value is null,
   // but it induces the problem.
-  skipAndRead(reader, batch, /* read */ 6);
+  skipAndRead(batch, /* read */ 6);
   FlatVectorPtr<StringView> strings;
   strings = getOnlyChild<FlatVector<StringView>>(batch);
   ASSERT_EQ(6, strings->size());
@@ -1855,7 +1918,7 @@ TEST_P(StringReaderTests, testStringDirectNullAcrossWindow) {
     ASSERT_EQ('a' + j - 1, strings->valueAt(j).data()[0])
         << "difference at " << j;
 
-    skipAndRead(reader, batch, /* read */ 2);
+    skipAndRead(batch, /* read */ 2);
     strings = getOnlyChild<FlatVector<StringView>>(batch);
     ASSERT_EQ(2, strings->size());
     ASSERT_EQ(0, getNullCount(strings));
@@ -1882,19 +1945,19 @@ TEST_P(StringReaderTests, testStringDirectSkip) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
-      .WillRepeatedly(Return(nullptr));
-
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+      .WillRepeatedly(Return(nullptr));
+
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // sum(0 to 1199)
@@ -1906,7 +1969,7 @@ TEST_P(StringReaderTests, testStringDirectSkip) {
       blob[posn++] = static_cast<char>(ch);
     }
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(blob, BLOB_SIZE, 200)));
 
@@ -1916,29 +1979,29 @@ TEST_P(StringReaderTests, testStringDirectSkip) {
       0x02, 0x7f, 0x01, 0x86, 0x03, 0x7f, 0x01, 0x88, 0x04, 0x7f,
       0x01, 0x8a, 0x05, 0x7f, 0x01, 0x8c, 0x06, 0x7f, 0x01, 0x8e,
       0x07, 0x7f, 0x01, 0x90, 0x08, 0x1b, 0x01, 0x92, 0x09};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:string>");
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
 
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 2);
+  skipAndRead(batch, /* read */ 2);
   FlatVectorPtr<StringView> strings;
 
   strings = getOnlyChild<FlatVector<StringView>>(batch);
   ASSERT_EQ(2, strings->size());
   ASSERT_EQ(0, getNullCount(strings));
   validateFlatVectorBatch(batch, strings, 0);
-  skipAndRead(reader, batch, /* read */ 2, /* skip */ 14);
+  skipAndRead(batch, /* read */ 2, /* skip */ 14);
 
   strings = getOnlyChild<FlatVector<StringView>>(batch);
   ASSERT_EQ(2, strings->size());
   ASSERT_EQ(0, getNullCount(strings));
   validateFlatVectorBatch(batch, strings, 16);
-  skipAndRead(reader, batch, /* read */ 2, /* skip */ 1180);
+  skipAndRead(batch, /* read */ 2, /* skip */ 1180);
 
   strings = getOnlyChild<FlatVector<StringView>>(batch);
   ASSERT_EQ(2, strings->size());
@@ -1950,21 +2013,21 @@ TEST_P(StringReaderTests, testStringDirectSkipWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   // alternate 4 non-null and 4 null via [0xf0 for x in range(2400 / 8)]
   const unsigned char buffer1[] = {0x7f, 0xf0, 0x7f, 0xf0, 0x25, 0xf0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -1979,7 +2042,7 @@ TEST_P(StringReaderTests, testStringDirectSkipWithNulls) {
       blob[posn++] = static_cast<char>(ch);
     }
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(blob, BLOB_SIZE, 200)));
 
@@ -1989,31 +2052,31 @@ TEST_P(StringReaderTests, testStringDirectSkipWithNulls) {
       0x02, 0x7f, 0x01, 0x86, 0x03, 0x7f, 0x01, 0x88, 0x04, 0x7f,
       0x01, 0x8a, 0x05, 0x7f, 0x01, 0x8c, 0x06, 0x7f, 0x01, 0x8e,
       0x07, 0x7f, 0x01, 0x90, 0x08, 0x1b, 0x01, 0x92, 0x09};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:string>");
 
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
 
   VectorPtr batch = newBatch(rowType);
   SimpleVectorPtr<StringView> strings;
-  skipAndRead(reader, batch, /* read */ 2);
+  skipAndRead(batch, /* read */ 2);
 
   strings = getOnlyChild<FlatVector<StringView>>(batch);
   ASSERT_EQ(2, strings->size());
   ASSERT_EQ(0, getNullCount(strings));
   validateFlatVectorBatch(batch, strings, 0);
 
-  skipAndRead(reader, batch, /* read */ 2, /* skip */ 30);
+  skipAndRead(batch, /* read */ 2, /* skip */ 30);
   strings = getOnlyChild<FlatVector<StringView>>(batch);
   ASSERT_EQ(2, strings->size());
   ASSERT_EQ(0, getNullCount(strings));
   validateFlatVectorBatch(batch, strings, 16);
 
-  skipAndRead(reader, batch, /* read */ 2, /* skip */ 2364);
+  skipAndRead(batch, /* read */ 2, /* skip */ 2364);
   strings = getOnlyChild<SimpleVector<StringView>>(batch);
   ASSERT_EQ(2, strings->size());
   ASSERT_LT(0, getNullCount(strings));
@@ -2026,13 +2089,13 @@ TEST_P(TestColumnReader, testList) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [2 for x in range(600)]
@@ -2052,23 +2115,23 @@ TEST_P(TestColumnReader, testList) {
       0x4d,
       0x00,
       0x02};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
   // range(1200)
   char buffer2[8192];
   size_t size = writeRange(buffer2, 0, 1200);
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer2, size)));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:array<bigint>>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
 
   auto lists = getOnlyChild<ArrayVector>(batch);
   ASSERT_EQ(512, lists->size());
@@ -2096,30 +2159,30 @@ TEST_P(TestColumnReader, testListPropagateNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // set getStream
   const unsigned char buffer[] = {0xff, 0x00};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer, VELOX_ARRAY_SIZE(buffer))));
 
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer, 0)));
 
-  EXPECT_CALL(streams, getStreamProxy(3, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(3, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer, 0)));
 
   // create the row type
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 8);
+  skipAndRead(batch, /* read */ 8);
 
   auto structs = getOnlyChild<RowVector>(batch);
   ASSERT_EQ(8, structs->size());
@@ -2143,20 +2206,20 @@ TEST_P(TestColumnReader, testListWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [0xaa for x in range(2048/8)]
   const unsigned char buffer1[] = {0x7f, 0xaa, 0x7b, 0xaa};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [1 for x in range(260)] +
@@ -2168,23 +2231,23 @@ TEST_P(TestColumnReader, testListWithNulls) {
                                    0x00, 0x04, 0x7f, 0x00, 0x04, 0x7f, 0x00,
                                    0x00, 0x7f, 0x00, 0x00, 0x7f, 0x00, 0x03,
                                    0x6e, 0x00, 0x03, 0xff, 0x13};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // range(2048)
   char buffer3[8192];
   size_t size = writeRange(buffer3, 0, 2048);
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer3, size)));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:array<bigint>>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
 
   auto lists = getOnlyChild<ArrayVector>(batch);
   ASSERT_EQ(512, lists->size());
@@ -2209,7 +2272,7 @@ TEST_P(TestColumnReader, testListWithNulls) {
     lists.reset();
     longs.reset();
   }
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
   lists = getOnlyChild<ArrayVector>(batch);
   longs = std::dynamic_pointer_cast<FlatVector<int64_t>>(lists->elements());
   ASSERT_EQ(expectMemoryReuse_, lists.get() == listsPtr);
@@ -2239,7 +2302,7 @@ TEST_P(TestColumnReader, testListWithNulls) {
     lists.reset();
     longs.reset();
   }
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
   lists = getOnlyChild<ArrayVector>(batch);
   longs = std::dynamic_pointer_cast<FlatVector<int64_t>>(lists->elements());
   ASSERT_EQ(expectMemoryReuse_, lists.get() == listsPtr);
@@ -2269,7 +2332,7 @@ TEST_P(TestColumnReader, testListWithNulls) {
     lists.reset();
     longs.reset();
   }
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
   lists = getOnlyChild<ArrayVector>(batch);
   longs = std::dynamic_pointer_cast<FlatVector<int64_t>>(lists->elements());
   ASSERT_EQ(expectMemoryReuse_, lists.get() == listsPtr);
@@ -2307,20 +2370,20 @@ TEST_P(TestColumnReader, testListSkipWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [0xaa for x in range(2048/8)]
   const unsigned char buffer1[] = {0x7f, 0xaa, 0x7b, 0xaa};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [1 for x in range(260)] +
@@ -2332,24 +2395,24 @@ TEST_P(TestColumnReader, testListSkipWithNulls) {
                                    0x00, 0x04, 0x7f, 0x00, 0x04, 0x7f, 0x00,
                                    0x00, 0x7f, 0x00, 0x00, 0x7f, 0x00, 0x03,
                                    0x6e, 0x00, 0x03, 0xff, 0x13};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // range(2048)
   char buffer3[8192];
   size_t size = writeRange(buffer3, 0, 2048);
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer3, size)));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:array<bigint>>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
 
-  skipAndRead(reader, batch, /* read */ 1);
+  skipAndRead(batch, /* read */ 1);
 
   auto lists = getOnlyChild<ArrayVector>(batch);
   ASSERT_EQ(1, lists->size());
@@ -2368,7 +2431,7 @@ TEST_P(TestColumnReader, testListSkipWithNulls) {
     lists.reset();
     longs.reset();
   }
-  skipAndRead(reader, batch, /* read */ 1, /* skip */ 13);
+  skipAndRead(batch, /* read */ 1, /* skip */ 13);
   lists = getOnlyChild<ArrayVector>(batch);
   longs = std::dynamic_pointer_cast<FlatVector<int64_t>>(lists->elements());
   ASSERT_EQ(expectMemoryReuse_, lists.get() == listsPtr);
@@ -2387,7 +2450,7 @@ TEST_P(TestColumnReader, testListSkipWithNulls) {
     lists.reset();
     longs.reset();
   }
-  skipAndRead(reader, batch, /* read */ 2, /* skip */ 2031);
+  skipAndRead(batch, /* read */ 2, /* skip */ 2031);
   lists = getOnlyChild<ArrayVector>(batch);
   longs = std::dynamic_pointer_cast<FlatVector<int64_t>>(lists->elements());
   ASSERT_EQ(expectMemoryReuse_, lists.get() == listsPtr);
@@ -2413,20 +2476,20 @@ TEST_P(TestColumnReader, testListSkipWithNullsNoData) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [0xaa for x in range(2048/8)]
   const unsigned char buffer1[] = {0x7f, 0xaa, 0x7b, 0xaa};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [1 for x in range(260)] +
@@ -2438,21 +2501,21 @@ TEST_P(TestColumnReader, testListSkipWithNullsNoData) {
                                    0x00, 0x04, 0x7f, 0x00, 0x04, 0x7f, 0x00,
                                    0x00, 0x7f, 0x00, 0x00, 0x7f, 0x00, 0x03,
                                    0x6e, 0x00, 0x03, 0xff, 0x13};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(nullptr));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:array<bigint>>");
   // selected filter tree nodes list
-  auto reader = buildReader(rowType, {0, 1});
+  buildReader(rowType, {0, 1});
 
   VectorPtr batch = newBatch(rowType);
 
-  skipAndRead(reader, batch, /* read */ 1);
+  skipAndRead(batch, /* read */ 1);
 
   auto lists = getOnlyChild<ArrayVector>(batch);
   ASSERT_EQ(1, lists->size());
@@ -2463,7 +2526,7 @@ TEST_P(TestColumnReader, testListSkipWithNullsNoData) {
   if (expectMemoryReuse_) {
     lists.reset();
   }
-  skipAndRead(reader, batch, /* read */ 1, /* skip */ 13);
+  skipAndRead(batch, /* read */ 1, /* skip */ 13);
   lists = getOnlyChild<ArrayVector>(batch);
   ASSERT_EQ(expectMemoryReuse_, lists.get() == listsPtr);
 
@@ -2475,7 +2538,7 @@ TEST_P(TestColumnReader, testListSkipWithNullsNoData) {
   if (expectMemoryReuse_) {
     lists.reset();
   }
-  skipAndRead(reader, batch, /* read */ 2, /* skip */ 2031);
+  skipAndRead(batch, /* read */ 2, /* skip */ 2031);
   lists = getOnlyChild<ArrayVector>(batch);
   ASSERT_EQ(expectMemoryReuse_, lists.get() == listsPtr);
 
@@ -2496,29 +2559,29 @@ TEST_P(TestColumnReader, testListWithAllNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // set getStream
   const unsigned char buffer[] = {0xff, 0x00};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer, VELOX_ARRAY_SIZE(buffer))));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer, 0)));
 
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer, 0)));
 
   // create the row type
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 8);
+  skipAndRead(batch, /* read */ 8);
 
   auto lists = getOnlyChild<ArrayVector>(batch);
   ASSERT_EQ(8, lists->size());
@@ -2533,13 +2596,13 @@ TEST_P(TestColumnReader, testMap) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [2 for x in range(600)]
@@ -2559,29 +2622,29 @@ TEST_P(TestColumnReader, testMap) {
       0x4d,
       0x00,
       0x02};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
   // range(1200)
   char buffer2[8192];
   size_t size = writeRange(buffer2, 0, 1200);
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer2, size)));
 
   // range(8, 1208)
   char buffer3[8192];
   size = writeRange(buffer3, 8, 1208);
-  EXPECT_CALL(streams, getStreamProxy(3, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(3, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer3, size)));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:map<bigint,bigint>>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
 
   auto maps = getOnlyChild<MapVector>(batch);
   ASSERT_EQ(512, maps->size());
@@ -2612,25 +2675,25 @@ TEST_P(TestColumnReader, testMapWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [0xaa for x in range(2048/8)]
   const unsigned char buffer1[] = {0x7f, 0xaa, 0x7b, 0xaa};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [0x55 for x in range(2048/8)]
   const unsigned char buffer2[] = {0x7f, 0x55, 0x7b, 0x55};
-  EXPECT_CALL(streams, getStreamProxy(3, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(3, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
@@ -2643,29 +2706,29 @@ TEST_P(TestColumnReader, testMapWithNulls) {
                                    0x00, 0x04, 0x7f, 0x00, 0x04, 0x7f, 0x00,
                                    0x00, 0x7f, 0x00, 0x00, 0x7f, 0x00, 0x03,
                                    0x6e, 0x00, 0x03, 0xff, 0x13};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer3, VELOX_ARRAY_SIZE(buffer3))));
 
   // range(2048)
   char buffer4[8192];
   size_t size = writeRange(buffer4, 0, 2048);
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer4, size)));
 
   // range(8, 1032)
   char buffer5[8192];
   size = writeRange(buffer5, 8, 1032);
-  EXPECT_CALL(streams, getStreamProxy(3, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(3, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer5, size)));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:map<bigint,bigint>>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
 
   auto maps = getOnlyChild<MapVector>(batch);
   ASSERT_EQ(512, maps->size());
@@ -2700,7 +2763,7 @@ TEST_P(TestColumnReader, testMapWithNulls) {
     keys.reset();
     elements.reset();
   }
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
   maps = getOnlyChild<MapVector>(batch);
   keys = std::dynamic_pointer_cast<FlatVector<int64_t>>(maps->mapKeys());
   elements = std::dynamic_pointer_cast<FlatVector<int64_t>>(maps->mapValues());
@@ -2739,7 +2802,7 @@ TEST_P(TestColumnReader, testMapWithNulls) {
     keys.reset();
     elements.reset();
   }
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
   maps = getOnlyChild<MapVector>(batch);
   keys = std::dynamic_pointer_cast<FlatVector<int64_t>>(maps->mapKeys());
   elements = std::dynamic_pointer_cast<FlatVector<int64_t>>(maps->mapValues());
@@ -2777,7 +2840,7 @@ TEST_P(TestColumnReader, testMapWithNulls) {
     keys.reset();
     elements.reset();
   }
-  skipAndRead(reader, batch, /* read */ 512);
+  skipAndRead(batch, /* read */ 512);
   maps = getOnlyChild<MapVector>(batch);
   keys = std::dynamic_pointer_cast<FlatVector<int64_t>>(maps->mapKeys());
   elements = std::dynamic_pointer_cast<FlatVector<int64_t>>(maps->mapValues());
@@ -2822,16 +2885,16 @@ TEST_P(TestColumnReader, testMapSkipWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [0xaa for x in range(2048/8)]
   const unsigned char buffer1[] = {0x7f, 0xaa, 0x7b, 0xaa};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -2844,30 +2907,30 @@ TEST_P(TestColumnReader, testMapSkipWithNulls) {
                                    0x00, 0x04, 0x7f, 0x00, 0x04, 0x7f, 0x00,
                                    0x00, 0x7f, 0x00, 0x00, 0x7f, 0x00, 0x03,
                                    0x6e, 0x00, 0x03, 0xff, 0x13};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // range(2048)
   char buffer3[8192];
   size_t size = writeRange(buffer3, 0, 2048);
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer3, size)));
 
   // range(8, 2056)
   char buffer4[8192];
   size = writeRange(buffer4, 8, 2056);
-  EXPECT_CALL(streams, getStreamProxy(3, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(3, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer4, size)));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:map<bigint,bigint>>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
 
-  skipAndRead(reader, batch, /* read */ 1);
+  skipAndRead(batch, /* read */ 1);
 
   auto maps = getOnlyChild<MapVector>(batch);
   ASSERT_EQ(1, maps->size());
@@ -2893,7 +2956,7 @@ TEST_P(TestColumnReader, testMapSkipWithNulls) {
     keys.reset();
     elements.reset();
   }
-  skipAndRead(reader, batch, /* read */ 1, /* skip */ 13);
+  skipAndRead(batch, /* read */ 1, /* skip */ 13);
   maps = getOnlyChild<MapVector>(batch);
   keys = std::dynamic_pointer_cast<FlatVector<int64_t>>(maps->mapKeys());
   elements = std::dynamic_pointer_cast<FlatVector<int64_t>>(maps->mapValues());
@@ -2919,7 +2982,7 @@ TEST_P(TestColumnReader, testMapSkipWithNulls) {
     keys.reset();
     elements.reset();
   }
-  skipAndRead(reader, batch, /* read */ 2, /* skip */ 2031);
+  skipAndRead(batch, /* read */ 2, /* skip */ 2031);
   maps = getOnlyChild<MapVector>(batch);
   keys = std::dynamic_pointer_cast<FlatVector<int64_t>>(maps->mapKeys());
   elements = std::dynamic_pointer_cast<FlatVector<int64_t>>(maps->mapValues());
@@ -2950,16 +3013,16 @@ TEST_P(TestColumnReader, testMapSkipWithNullsNoData) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // [0xaa for x in range(2048/8)]
   const unsigned char buffer1[] = {0x7f, 0xaa, 0x7b, 0xaa};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -2972,17 +3035,17 @@ TEST_P(TestColumnReader, testMapSkipWithNullsNoData) {
                                    0x00, 0x04, 0x7f, 0x00, 0x04, 0x7f, 0x00,
                                    0x00, 0x7f, 0x00, 0x00, 0x7f, 0x00, 0x03,
                                    0x6e, 0x00, 0x03, 0xff, 0x13};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:map<bigint,bigint>>");
-  auto reader = buildReader(rowType, {0, 1});
+  buildReader(rowType, {0, 1});
 
   VectorPtr batch = newBatch(rowType);
 
-  skipAndRead(reader, batch, /* read */ 1);
+  skipAndRead(batch, /* read */ 1);
 
   auto maps = getOnlyChild<MapVector>(batch);
   ASSERT_EQ(1, maps->size());
@@ -2993,7 +3056,7 @@ TEST_P(TestColumnReader, testMapSkipWithNullsNoData) {
   if (expectMemoryReuse_) {
     maps.reset();
   }
-  skipAndRead(reader, batch, /* read */ 1, /* skip */ 13);
+  skipAndRead(batch, /* read */ 1, /* skip */ 13);
   maps = getOnlyChild<MapVector>(batch);
   ASSERT_EQ(expectMemoryReuse_, maps.get() == mapsPtr);
 
@@ -3005,7 +3068,7 @@ TEST_P(TestColumnReader, testMapSkipWithNullsNoData) {
   if (expectMemoryReuse_) {
     maps.reset();
   }
-  skipAndRead(reader, batch, /* read */ 2, /* skip */ 2031);
+  skipAndRead(batch, /* read */ 2, /* skip */ 2031);
   maps = getOnlyChild<MapVector>(batch);
   ASSERT_EQ(expectMemoryReuse_, maps.get() == mapsPtr);
 
@@ -3024,26 +3087,27 @@ TEST_P(TestColumnReader, testMapWithAllNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   const unsigned char buffer1[] = {0xff, 0x00};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(buffer1, 0)));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:map<bigint,bigint>>");
-  auto reader = buildReader(rowType, {0, 1});
+  buildReader(rowType, {0, 1});
+
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 8);
+  skipAndRead(batch, /* read */ 8);
 
   auto maps = getOnlyChild<MapVector>(batch);
   ASSERT_EQ(8, maps->size());
@@ -3059,21 +3123,21 @@ TEST_P(TestColumnReader, testFloatBatchNotAligned) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   const float testValues[] = {1.0f, 2.5f, -100.125f};
   const unsigned char byteValues[] = {
       0x00, 0x00, 0x80, 0x3f, 0x00, 0x00, 0x20, 0x40, 0x00, 0x40, 0xc8, 0xc2};
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(
           byteValues,
           VELOX_ARRAY_SIZE(byteValues),
@@ -3082,10 +3146,10 @@ TEST_P(TestColumnReader, testFloatBatchNotAligned) {
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myFloat:float>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 3);
+  skipAndRead(batch, /* read */ 3);
 
   auto floatBatch = getOnlyChild<FlatVector<float>>(batch);
   ASSERT_EQ(3, floatBatch->size());
@@ -3100,19 +3164,19 @@ TEST_P(TestColumnReader, testFloatWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   // 13 non-nulls followed by 19 nulls
   const unsigned char buffer1[] = {0xfc, 0xff, 0xf8, 0x0, 0x0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -3136,17 +3200,17 @@ TEST_P(TestColumnReader, testFloatWithNulls) {
       0x25, 0xac, 0x0,  0x0,  0x80, 0x7f, 0x0,  0x0,  0xc0, 0x7f, 0x0,
       0x0,  0x80, 0xff, 0xff, 0xff, 0x7f, 0x7f, 0xff, 0xff, 0x7f, 0xff,
       0x1,  0x0,  0x0,  0x0,  0x1,  0x0,  0x0,  0x80};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myFloat:float>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 32);
+  skipAndRead(batch, /* read */ 32);
 
   auto floatBatch = getOnlyChild<FlatVector<float>>(batch);
   ASSERT_EQ(32, floatBatch->size());
@@ -3169,19 +3233,19 @@ TEST_P(TestColumnReader, testFloatSkipWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   // 2 non-nulls, 2 nulls, 2 non-nulls, 2 nulls
   const unsigned char buffer1[] = {0xff, 0xcc};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -3203,21 +3267,21 @@ TEST_P(TestColumnReader, testFloatSkipWithNulls) {
       0x40,
       0x1c,
       0x46};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myFloat:float>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
 
   float test_vals[] = {1.0, 2.5, -100.125, 10000.0};
   int32_t vals_ix = 0;
 
-  skipAndRead(reader, batch, /* read */ 3);
+  skipAndRead(batch, /* read */ 3);
 
   auto floatBatch = getOnlyChild<FlatVector<float>>(batch);
   ASSERT_EQ(3, floatBatch->size());
@@ -3238,7 +3302,7 @@ TEST_P(TestColumnReader, testFloatSkipWithNulls) {
     floatBatch.reset();
   }
 
-  skipAndRead(reader, batch, /* read */ 4, /* skip */ 1);
+  skipAndRead(batch, /* read */ 4, /* skip */ 1);
 
   floatBatch = getOnlyChild<FlatVector<float>>(batch);
   ASSERT_EQ(expectMemoryReuse_, floatBatch.get() == floatBatchPtr);
@@ -3260,19 +3324,19 @@ TEST_P(TestColumnReader, testDoubleWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   // 13 non-nulls followed by 19 nulls
   const unsigned char buffer1[] = {0xfc, 0xff, 0xf8, 0x0, 0x0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -3300,17 +3364,17 @@ TEST_P(TestColumnReader, testDoubleWithNulls) {
       0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xef, 0x7f, 0xff, 0xff, 0xff, 0xff,
       0xff, 0xff, 0xef, 0xff, 0x1,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0,
       0x1,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x80};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myDouble:double>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(reader, batch, /* read */ 32);
+  skipAndRead(batch, /* read */ 32);
 
   auto doubleBatch = getOnlyChild<FlatVector<double>>(batch);
   ASSERT_EQ(32, doubleBatch->size());
@@ -3334,19 +3398,19 @@ TEST_P(TestColumnReader, testDoubleSkipWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   // 1 non-null, 5 nulls, 2 non-nulls
   const unsigned char buffer1[] = {0xff, 0x83};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -3354,21 +3418,21 @@ TEST_P(TestColumnReader, testDoubleSkipWithNulls) {
   const unsigned char buffer2[] = {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f, 0x00, 0x00, 0x00, 0x00,
       0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc0};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myDouble:double>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
 
   double test_vals[] = {1.0, 2.0, -2.0};
   int32_t vals_ix = 0;
 
-  skipAndRead(reader, batch, /* read */ 2);
+  skipAndRead(batch, /* read */ 2);
 
   auto doubleBatch = getOnlyChild<FlatVector<double>>(batch);
   ASSERT_EQ(2, doubleBatch->size());
@@ -3388,7 +3452,7 @@ TEST_P(TestColumnReader, testDoubleSkipWithNulls) {
   if (expectMemoryReuse_) {
     doubleBatch.reset();
   }
-  skipAndRead(reader, batch, /* read */ 3, /* skip */ 3);
+  skipAndRead(batch, /* read */ 3, /* skip */ 3);
 
   doubleBatch = getOnlyChild<FlatVector<double>>(batch);
   ASSERT_EQ(expectMemoryReuse_, doubleBatch.get() == doubleBatchPtr);
@@ -3410,19 +3474,19 @@ TEST_P(TestColumnReader, testTimestampSkipWithNulls) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   // 2 non-nulls, 2 nulls, 2 non-nulls, 2 nulls
   const unsigned char buffer1[] = {0xff, 0xcc};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
@@ -3444,19 +3508,19 @@ TEST_P(TestColumnReader, testTimestampSkipWithNulls) {
       0xa0,
       0xd4,
       0x30};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   const unsigned char buffer3[] = {0x1, 0x8, 0x5e};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer3, VELOX_ARRAY_SIZE(buffer3))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myTimestamp:timestamp>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
 
@@ -3469,7 +3533,7 @@ TEST_P(TestColumnReader, testTimestampSkipWithNulls) {
       {110000000, 120000000, 130000000, 140000000}};
   int32_t vals_ix = 0;
 
-  skipAndRead(reader, batch, /* read */ 3);
+  skipAndRead(batch, /* read */ 3);
 
   auto tsBatch = getOnlyChild<FlatVector<Timestamp>>(batch);
   ASSERT_EQ(3, tsBatch->size());
@@ -3497,7 +3561,7 @@ TEST_P(TestColumnReader, testTimestampSkipWithNulls) {
   if (expectMemoryReuse_) {
     tsBatch.reset();
   }
-  skipAndRead(reader, batch, /* read */ 4, /* skip */ 1);
+  skipAndRead(batch, /* read */ 4, /* skip */ 1);
 
   tsBatch = getOnlyChild<FlatVector<Timestamp>>(batch);
   ASSERT_EQ(expectMemoryReuse_, tsBatch.get() == tsBatchPtr);
@@ -3524,14 +3588,14 @@ TEST_P(TestColumnReader, testTimestamp) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   const unsigned char buffer1[] = {
@@ -3540,21 +3604,21 @@ TEST_P(TestColumnReader, testTimestamp) {
       0xb8, 0xcd, 0xdc, 0x1a, 0x9d, 0xea, 0xc3, 0xbe, 0x1a, 0x9d, 0x9c,
       0xba, 0xa0, 0x1a, 0x9d, 0x88, 0xa6, 0x82, 0x1a, 0x9d, 0xba, 0x9c,
       0xe4, 0x19, 0x9d, 0xee, 0xe1, 0xcd, 0x18};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer1, VELOX_ARRAY_SIZE(buffer1))));
 
   const unsigned char buffer2[] = {
       0xf6, 0x00, 0xa8, 0xd1, 0xf9, 0xd6, 0x03, 0x00, 0x9e, 0x01, 0xec,
       0x76, 0xf4, 0x76, 0xfc, 0x76, 0x84, 0x77, 0x8c, 0x77, 0xfd, 0x0b};
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_NANO_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myTimestamp:timestamp>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   VectorPtr batch = newBatch(rowType);
   const std::array<const char*, 10> expected{
@@ -3580,7 +3644,7 @@ TEST_P(TestColumnReader, testTimestamp) {
        190500000,
        191000000}};
 
-  skipAndRead(reader, batch, /* read */ 10);
+  skipAndRead(batch, /* read */ 10);
 
   auto tsBatch = getOnlyChild<FlatVector<Timestamp>>(batch);
   ASSERT_EQ(10, tsBatch->size());
@@ -3601,13 +3665,13 @@ TEST_P(TestColumnReader, testLargeSkip) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // repeat 40 times [1, 60]
@@ -3618,22 +3682,22 @@ TEST_P(TestColumnReader, testLargeSkip) {
     length[pos + 1] = 0x01;
     length[pos + 2] = 0x01;
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(length, VELOX_ARRAY_SIZE(length))));
 
   char data[1024 * 1024];
   size_t size = writeRange(data, 0, 73200);
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(data, size)));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<col0:array<bigint>>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
   VectorPtr batch = newBatch(rowType);
 
-  skipAndRead(reader, batch, /* read */ 100, /* skip */ 2100);
+  skipAndRead(batch, /* read */ 100, /* skip */ 2100);
 
   auto lists = getOnlyChild<ArrayVector>(batch);
   ASSERT_EQ(100, lists->size());
@@ -3681,13 +3745,13 @@ TEST_P(StringReaderTests, testStringDirectUseBatchAfterClose) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // sum(range(1..26))
@@ -3701,33 +3765,33 @@ TEST_P(StringReaderTests, testStringDirectUseBatchAfterClose) {
       blob[posn++] = static_cast<char>('a' + len - 1);
     }
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(blob.data(), BLOB_SIZE)));
 
   // range(1..131)
   auto lengths = folly::make_array<char>(0x7f, 0x01, 0x01);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(lengths.data(), lengths.size())));
 
   auto rowType = HiveTypeParser().parse("struct<myString:string>");
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
 
   std::vector<VectorPtr> batches;
   for (size_t i = 0; i < ROW_COUNT; ++i) {
     VectorPtr batch = newBatch(rowType);
-    reader->next(1, batch);
+    next(1, batch);
     batch->as<RowVector>()->childAt(0)->loadedVector();
     batches.push_back(batch);
   }
 
-  validateStringDirectBatches(batches, streams);
+  validateStringDirectBatches(batches, streams_);
 
   // make sure data can still be accessed after releasing column reader. This
   // will fail in asan mode if memory is recycled.
-  reader.reset(nullptr);
-  validateStringDirectBatches(batches, streams);
+  resetReader();
+  validateStringDirectBatches(batches, streams_);
 }
 
 void validateStringDictBatches(
@@ -3770,17 +3834,17 @@ TEST_P(StringReaderTests, testStringDictUseBatchAfterClose) {
   dictEncoding.set_dictionarysize(DICT_SIZE);
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(0))
+  EXPECT_CALL(streams_, getEncodingProxy(0))
       .WillRepeatedly(Return(&directEncoding));
-  EXPECT_CALL(streams, getEncodingProxy(1))
+  EXPECT_CALL(streams_, getEncodingProxy(1))
       .WillRepeatedly(Return(&dictEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // dictionary content
@@ -3794,21 +3858,21 @@ TEST_P(StringReaderTests, testStringDictUseBatchAfterClose) {
     }
   }
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(dict.data(), BLOB_SIZE)));
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY, true))
+      streams_, getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(strideDict.data(), BLOB_SIZE)));
 
   // length
   auto length = folly::make_array<char>(0x17, 0x01, 0x01);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(length.data(), length.size())));
   EXPECT_CALL(
-      streams,
+      streams_,
       getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(length.data(), length.size())));
@@ -3821,14 +3885,14 @@ TEST_P(StringReaderTests, testStringDictUseBatchAfterClose) {
     dataSize = writeVuLong(data.data(), dataSize, i);
     dataSize = writeVuLong(data.data(), dataSize, 0);
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(data.data(), dataSize)));
 
   // in_dict
   auto inDict = folly::make_array<char>(0x04, 0xaa);
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(inDict.data(), inDict.size())));
 
@@ -3846,39 +3910,39 @@ TEST_P(StringReaderTests, testStringDictUseBatchAfterClose) {
 
   const uint64_t BATCH_SIZE = 2;
   auto indexData = index.SerializePartialAsString();
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, _))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, _))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(indexData.data(), indexData.size())));
   TestStrideIndexProvider provider(BATCH_SIZE);
-  EXPECT_CALL(streams, getStrideIndexProviderProxy())
+  EXPECT_CALL(streams_, getStrideIndexProviderProxy())
       .WillRepeatedly(Return(&provider));
 
   auto rowType = HiveTypeParser().parse("struct<myString:string>");
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
 
   std::vector<VectorPtr> batches;
   for (size_t i = 0; i < DICT_SIZE; ++i) {
     VectorPtr batch = newBatch(rowType);
-    reader->next(BATCH_SIZE, batch);
+    next(BATCH_SIZE, batch);
     for (auto& child : batch->as<RowVector>()->children()) {
       child->loadedVector();
     }
     provider.addRow(BATCH_SIZE);
     batches.push_back(batch);
   }
-  validateStringDictBatches(batches, returnFlatVector_, streams);
+  validateStringDictBatches(batches, returnFlatVector_, streams_);
 
   // make sure data can still be accessed after releasing column reader. This
   // will fail in asan mode if memory is recycled.
-  reader.reset(nullptr);
-  validateStringDictBatches(batches, returnFlatVector_, streams);
+  resetReader();
+  validateStringDictBatches(batches, returnFlatVector_, streams_);
 }
 
 TEST_P(StringReaderTests, testStringDictStrideDictDoesntExist) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set row index
@@ -3887,9 +3951,9 @@ TEST_P(StringReaderTests, testStringDictStrideDictDoesntExist) {
   const size_t totalRowCount = rowIndexStride * 10;
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   std::array<char, 1024> data;
@@ -3943,17 +4007,17 @@ TEST_P(StringReaderTests, testStringDictStrideDictDoesntExist) {
   proto::ColumnEncoding dictionaryEncoding;
   dictionaryEncoding.set_kind(proto::ColumnEncoding_Kind_DICTIONARY);
   dictionaryEncoding.set_dictionarysize(dictVals.size());
-  EXPECT_CALL(streams, getEncodingProxy(1))
+  EXPECT_CALL(streams_, getEncodingProxy(1))
       .WillRepeatedly(Return(&dictionaryEncoding));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(data.data(), len)));
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(dict.data(), dictLen)));
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY, true))
+      streams_, getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(strideDict.data(), strideDictLen)));
 
@@ -3970,11 +4034,11 @@ TEST_P(StringReaderTests, testStringDictStrideDictDoesntExist) {
     strideDictLen = writeVuLong(
         strideDictLength.data(), strideDictLen, strideDictVals[i].length());
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(dictLength.data(), dictLen)));
   EXPECT_CALL(
-      streams,
+      streams_,
       getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(
           strideDictLength.data(), strideDictLen)));
@@ -3982,22 +4046,22 @@ TEST_P(StringReaderTests, testStringDictStrideDictDoesntExist) {
   auto inDict = folly::make_array<char>(
       0xf6, 0x55, 0xff, 0x55, 0xff, 0x55, 0xff, 0x55, 0xff, 0x55, 0xff);
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(inDict.data(), inDict.size())));
 
   auto indexData = index.SerializePartialAsString();
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, _))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, _))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(indexData.data(), indexData.size())));
   TestStrideIndexProvider provider(rowIndexStride);
-  EXPECT_CALL(streams, getStrideIndexProviderProxy())
+  EXPECT_CALL(streams_, getStrideIndexProviderProxy())
       .WillRepeatedly(Return(&provider));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myString:string>");
 
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
   uint64_t rowCount = 0;
   size_t dictOffset = 0;
   size_t strideDictOffset = 0;
@@ -4009,7 +4073,7 @@ TEST_P(StringReaderTests, testStringDictStrideDictDoesntExist) {
     if (expectMemoryReuse_) {
       stringBatch.reset();
     }
-    reader->next(rowIndexStride, batch);
+    next(rowIndexStride, batch);
     ASSERT_EQ(rowIndexStride, batch->size());
     ASSERT_EQ(0, getNullCount(batch));
     if (returnFlatVector_) {
@@ -4038,7 +4102,7 @@ TEST_P(StringReaderTests, testStringDictZeroLengthStrideDict) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set row index
@@ -4047,9 +4111,9 @@ TEST_P(StringReaderTests, testStringDictZeroLengthStrideDict) {
   const size_t totalRowCount = rowIndexStride * 10;
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(0, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
 
   std::array<char, 1024> data;
@@ -4104,17 +4168,17 @@ TEST_P(StringReaderTests, testStringDictZeroLengthStrideDict) {
   proto::ColumnEncoding dictionaryEncoding;
   dictionaryEncoding.set_kind(proto::ColumnEncoding_Kind_DICTIONARY);
   dictionaryEncoding.set_dictionarysize(dictVals.size());
-  EXPECT_CALL(streams, getEncodingProxy(1))
+  EXPECT_CALL(streams_, getEncodingProxy(1))
       .WillRepeatedly(Return(&dictionaryEncoding));
 
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(data.data(), len)));
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_DICTIONARY_DATA, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(dict.data(), dictLen)));
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY, true))
+      streams_, getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(strideDict.data(), strideDictLen)));
 
@@ -4131,11 +4195,11 @@ TEST_P(StringReaderTests, testStringDictZeroLengthStrideDict) {
     strideDictLen = writeVuLong(
         strideDictLength.data(), strideDictLen, strideDictVals[i].length());
   }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(dictLength.data(), dictLen)));
   EXPECT_CALL(
-      streams,
+      streams_,
       getStreamProxy(1, proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH, true))
       .WillRepeatedly(Return(new SeekableArrayInputStream(
           strideDictLength.data(), strideDictLen)));
@@ -4143,27 +4207,27 @@ TEST_P(StringReaderTests, testStringDictZeroLengthStrideDict) {
   auto inDict = folly::make_array<char>(
       0xf6, 0x55, 0xff, 0x55, 0xff, 0x55, 0xff, 0x55, 0xff, 0x55, 0xff);
   EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
+      streams_, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(inDict.data(), inDict.size())));
 
   auto indexData = index.SerializePartialAsString();
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, _))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_ROW_INDEX, _))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(indexData.data(), indexData.size())));
   TestStrideIndexProvider provider(rowIndexStride);
-  EXPECT_CALL(streams, getStrideIndexProviderProxy())
+  EXPECT_CALL(streams_, getStrideIndexProviderProxy())
       .WillRepeatedly(Return(&provider));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<myString:string>");
-  auto reader = buildReader(rowType, streams, {});
+  buildReader(rowType, {});
   VectorPtr batch = newBatch(rowType);
   uint64_t rowCount = 0;
   size_t dictOffset = 0;
   size_t strideDictOffset = 0;
   while (rowCount < totalRowCount) {
-    reader->next(rowIndexStride, batch);
+    next(rowIndexStride, batch);
     ASSERT_EQ(rowIndexStride, batch->size());
     ASSERT_EQ(0, getNullCount(batch));
     std::shared_ptr<SimpleVector<StringView>> stringBatch;
@@ -4190,29 +4254,29 @@ TEST_P(TestColumnReader, testPresentStreamChange) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // increasing values
   std::array<char, 1024> data;
   writeRange(data.data(), 0, 256);
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(data.data(), data.size())));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<a:int>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   // simulate vector reuse
-  auto pool = &streams.getMemoryPool();
+  auto pool = &streams_.getMemoryPool();
   VectorPtr toReset = std::make_shared<FlatVector<int32_t>>(
       pool,
       AlignedBuffer::allocate<bool>(1, pool),
@@ -4223,7 +4287,7 @@ TEST_P(TestColumnReader, testPresentStreamChange) {
       pool, rowType, nullptr, 1, std::vector<VectorPtr>{toReset}, 0);
 
   auto size = 100;
-  reader->next(size, batch);
+  next(size, batch);
   ASSERT_EQ(size, batch->size());
   ASSERT_EQ(0, getNullCount(batch));
 
@@ -4240,29 +4304,29 @@ TEST_P(TestColumnReader, testStructVectorTypeChange) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // increasing values
   std::array<char, 1024> data;
   writeRange(data.data(), 0, 256);
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(data.data(), data.size())));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<a:int>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   // simulate vector reset by creating vector of wrong type
-  auto pool = &streams.getMemoryPool();
+  auto pool = &streams_.getMemoryPool();
   VectorPtr toReset = std::make_shared<FlatVector<float>>(
       pool,
       nullptr,
@@ -4273,7 +4337,7 @@ TEST_P(TestColumnReader, testStructVectorTypeChange) {
       pool, ROW({REAL()}), nullptr, 1, std::vector<VectorPtr>{toReset}, 0);
 
   auto size = 100;
-  reader->next(size, batch);
+  next(size, batch);
   ASSERT_EQ(size, batch->size());
   ASSERT_EQ(0, getNullCount(batch));
 
@@ -4289,35 +4353,35 @@ TEST_P(TestColumnReader, testListVectorTypeChange) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // length of 2s
   auto lengths = folly::make_array<char>(0x7f, 0x00, 0x02);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(lengths.data(), lengths.size())));
 
   // increasing values
   std::array<char, 1024> data;
   writeRange(data.data(), 0, 256);
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(data.data(), data.size())));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<a:array<int>>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   // simulate batch reuse
-  auto pool = &streams.getMemoryPool();
+  auto pool = &streams_.getMemoryPool();
   VectorPtr elements = std::make_shared<FlatVector<int8_t>>(
       pool,
       nullptr,
@@ -4342,7 +4406,7 @@ TEST_P(TestColumnReader, testListVectorTypeChange) {
       0);
 
   auto size = 100;
-  reader->next(size, batch);
+  next(size, batch);
   ASSERT_EQ(size, batch->size());
   ASSERT_EQ(0, getNullCount(batch));
 
@@ -4366,38 +4430,38 @@ TEST_P(TestColumnReader, testMapVectorTypeChange) {
   // set getEncoding
   proto::ColumnEncoding directEncoding;
   directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
+  EXPECT_CALL(streams_, getEncodingProxy(_))
       .WillRepeatedly(Return(&directEncoding));
 
   // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
 
   // length of 2s
   auto lengths = folly::make_array<char>(0x7f, 0x00, 0x02);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(lengths.data(), lengths.size())));
 
   // increasing values
   std::array<char, 1024> data;
   writeRange(data.data(), 0, 256);
-  EXPECT_CALL(streams, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(data.data(), data.size())));
-  EXPECT_CALL(streams, getStreamProxy(3, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(streams_, getStreamProxy(3, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Return(new SeekableArrayInputStream(data.data(), data.size())));
 
   // create the row type
   auto rowType = HiveTypeParser().parse("struct<a:map<int,int>>");
 
-  auto reader = buildReader(rowType);
+  buildReader(rowType);
 
   // simulate batch reuse
-  auto pool = &streams.getMemoryPool();
+  auto pool = &streams_.getMemoryPool();
   VectorPtr toReset = std::make_shared<FlatVector<int8_t>>(
       pool,
       nullptr,
@@ -4423,7 +4487,7 @@ TEST_P(TestColumnReader, testMapVectorTypeChange) {
       0);
 
   auto size = 100;
-  reader->next(size, batch);
+  next(size, batch);
   ASSERT_EQ(size, batch->size());
   ASSERT_EQ(0, getNullCount(batch));
 
@@ -4445,6 +4509,212 @@ TEST_P(TestColumnReader, testMapVectorTypeChange) {
     EXPECT_EQ(i, keys->valueAt(i));
     EXPECT_EQ(i, values->valueAt(i));
   }
+}
+
+TEST_P(SchemaMismatchTest, testBoolean) {
+  // set getEncoding
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+
+  // set getStream
+  EXPECT_CALL(streams_, getStreamProxy(_, _, _))
+      .WillRepeatedly(Return(nullptr));
+  // interleaved nulls, encoded as ByteRLE. 0x7f - 130 bytes (0x55 - 0101 0101)
+  // repeated.
+  auto nulls = folly::make_array<char>(0x7f, 0x55);
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(
+          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+            return new SeekableArrayInputStream(nulls.data(), nulls.size());
+          }));
+  auto data = folly::make_array<char>(0x7f, 0xaa);
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(
+          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+            return new SeekableArrayInputStream(data.data(), data.size());
+          }));
+
+  auto size = 100;
+  runTest<bool, int8_t>(size);
+  runTest<bool, int16_t>(size);
+  runTest<bool, int32_t>(size);
+  runTest<bool, int64_t>(size);
+}
+
+TEST_P(SchemaMismatchTest, testByte) {
+  // set getEncoding
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+
+  // set getStream
+  EXPECT_CALL(streams_, getStreamProxy(_, _, _))
+      .WillRepeatedly(Return(nullptr));
+  // interleaved nulls, encoded as ByteRLE. 0x7f - 130 bytes (0x55 - 0101 0101)
+  // repeated.
+  auto nulls = folly::make_array<char>(0x7f, 0x55);
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(
+          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+            return new SeekableArrayInputStream(nulls.data(), nulls.size());
+          }));
+
+  constexpr auto round = 10;
+  constexpr auto batch = 8;
+  std::array<char, round*(batch + 1)> data;
+  auto pos = 0;
+  for (auto i = 0; i < round; ++i) {
+    data[pos++] = 0xf8;
+    for (auto j = 0; j < batch; ++j) {
+      data[pos++] = (0x01 + j * 0x10);
+    }
+  }
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(
+          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+            return new SeekableArrayInputStream(data.data(), data.size());
+          }));
+
+  auto size = 100;
+  runTest<int8_t, int16_t>(size);
+  runTest<int8_t, int32_t>(size);
+  runTest<int8_t, int64_t>(size);
+}
+
+TEST_P(SchemaMismatchTest, testIntDirect) {
+  // set getEncoding
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+
+  // set getStream
+  EXPECT_CALL(streams_, getStreamProxy(_, _, _))
+      .WillRepeatedly(Return(nullptr));
+  // interleaved nulls, encoded as ByteRLE. 0x7f - 130 bytes (0x55 - 0101 0101)
+  // repeated.
+  auto nulls = folly::make_array<char>(0x7f, 0x55);
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(
+          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+            return new SeekableArrayInputStream(nulls.data(), nulls.size());
+          }));
+
+  // increasing values
+  std::array<char, 1024> data;
+  writeRange(data.data(), 0, 256);
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(
+          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+            return new SeekableArrayInputStream(data.data(), data.size());
+          }));
+
+  auto size = 100;
+  runTest<int16_t, int32_t>(size);
+  runTest<int16_t, int64_t>(size);
+  runTest<int32_t, int64_t>(size);
+}
+
+TEST_P(SchemaMismatchTest, testIntDict) {
+  // set getEncoding
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  int32_t sourceWidth = 0;
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+  proto::ColumnEncoding dictEncoding;
+  const auto dictSize = 100;
+  dictEncoding.set_kind(proto::ColumnEncoding_Kind_DICTIONARY);
+  dictEncoding.set_dictionarysize(dictSize);
+  EXPECT_CALL(streams_, getEncodingProxy(1))
+      .WillRepeatedly(Return(&dictEncoding));
+
+  // set getStream
+  EXPECT_CALL(streams_, getStreamProxy(_, _, _))
+      .WillRepeatedly(Return(nullptr));
+  // interleaved nulls, encoded as ByteRLE. 0x7f - 130 bytes (0x55 - 0101 0101)
+  // repeated.
+  auto nulls = folly::make_array<char>(0x7f, 0x55);
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(
+          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+            return new SeekableArrayInputStream(nulls.data(), nulls.size());
+          }));
+
+  std::array<char, 1024> data;
+  std::vector<uint64_t> v;
+  data[0] = 0x9c; // rle literal, -100
+  for (uint64_t i = 0; i < dictSize; ++i) {
+    v.push_back(i);
+  }
+  auto count = writeVuLongs(data.data() + 1, v);
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(
+          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+            return new SeekableArrayInputStream(data.data(), count + 1);
+          }));
+
+  EXPECT_CALL(
+      streams_, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
+      .WillRepeatedly(Return(nullptr));
+
+  EXPECT_CALL(streams_, genMockDictDataSetter(1, 0))
+      .WillRepeatedly(Return([&](BufferPtr& buffer, MemoryPool* pool) {
+        // Non-selective path always has int64 dictionary entries. Selective can
+        // have 2 and 4 as well.
+        if (!useSelectiveReader() || sourceWidth == 8) {
+          buffer = sequence<int64_t>(pool, 0, dictSize);
+        } else if (sourceWidth == 2) {
+          buffer = sequence<int16_t>(pool, 0, dictSize);
+        } else {
+          buffer = sequence<int32_t>(pool, 0, dictSize);
+        }
+      }));
+
+  auto size = 100;
+
+  sourceWidth = 2;
+  runTest<int16_t, int32_t>(size);
+  runTest<int16_t, int64_t>(size);
+  sourceWidth = 4;
+  runTest<int32_t, int64_t>(size);
+}
+
+TEST_P(SchemaMismatchTest, testFloat) {
+  // set getEncoding
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams_, getEncodingProxy(_))
+      .WillRepeatedly(Return(&directEncoding));
+
+  // set getStream
+  EXPECT_CALL(streams_, getStreamProxy(_, _, _))
+      .WillRepeatedly(Return(nullptr));
+  // interleaved nulls, encoded as ByteRLE. 0x7f - 130 bytes (0x55 - 0101 0101)
+  // repeated.
+  auto nulls = folly::make_array<char>(0x7f, 0x55);
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
+      .WillRepeatedly(
+          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+            return new SeekableArrayInputStream(nulls.data(), nulls.size());
+          }));
+  constexpr auto size = 100;
+  std::array<float, size> data;
+  for (auto i = 0; i < size; ++i) {
+    data[i] = folly::Random::randDouble(0, 100);
+  }
+  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(
+          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+            return new SeekableArrayInputStream(
+                reinterpret_cast<char*>(data.data()),
+                data.size() * sizeof(float));
+          }));
+
+  runTest<float, double>(size);
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
@@ -4491,269 +4761,6 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
     StringReaderTests,
     ::testing::Values(StringReaderTestParams{true, false, false}),
     [](auto p) { return p.param.toString(); });
-
-class SchemaMismatchTest : public TestWithParam<bool> {
- protected:
-  std::unique_ptr<ColumnReader> buildReader(
-      SelectiveColumnReaderBuilder& builder,
-      const std::shared_ptr<const Type>& requestedType,
-      MockStripeStreams& stripe,
-      std::vector<uint64_t> nodes = {},
-      bool returnFlatVector = false,
-      const std::shared_ptr<const Type>& dataType = nullptr) {
-    if (useSelectiveReader()) {
-      LOG(INFO) << "Using selective reader";
-      return builder.build(requestedType, stripe, nodes, dataType);
-    } else {
-      LOG(INFO) << "Using normal reader";
-      return buildColumnReader(
-          requestedType, stripe, nodes, returnFlatVector, dataType);
-    }
-  }
-
-  VectorPtr newBatch(const TypePtr& rowType) {
-    return useSelectiveReader()
-        ? BaseVector::create(rowType, 0, &streams.getMemoryPool())
-        : nullptr;
-  }
-
-  // TODO Rename to streams_
-  MockStripeStreams streams;
-
-  bool useSelectiveReader() const {
-    return GetParam();
-  }
-
-  template <typename From, typename To>
-  void runTest(uint64_t size) {
-    // create reader
-    auto dataType = ROW({"c0"}, {CppToType<From>::create()});
-    auto requestedType = ROW({"c0"}, {CppToType<To>::create()});
-    auto mismatchReader =
-        buildReader(builder_, requestedType, streams, {}, false, dataType);
-    VectorPtr mismatchBatch = newBatch(requestedType);
-    mismatchReader->next(size, mismatchBatch, nullptr);
-
-    auto asIsReader = buildReader(builder2_, dataType, streams);
-    VectorPtr asIsBatch = newBatch(dataType);
-    asIsReader->next(size, asIsBatch, nullptr);
-
-    ASSERT_EQ(asIsBatch->size(), mismatchBatch->size());
-    auto mismatchField = getOnlyChild<SimpleVector<To>>(mismatchBatch);
-    auto asIsField = getOnlyChild<SimpleVector<From>>(asIsBatch);
-    for (auto i = 0; i < asIsBatch->size(); ++i) {
-      auto isNull = asIsField->isNullAt(i);
-      EXPECT_EQ(isNull, mismatchField->isNullAt(i));
-      if (!isNull) {
-        EXPECT_EQ(asIsField->valueAt(i), mismatchField->valueAt(i));
-      }
-    }
-  }
-
-  SelectiveColumnReaderBuilder builder_;
-  SelectiveColumnReaderBuilder builder2_;
-};
-
-TEST_P(SchemaMismatchTest, testBoolean) {
-  // set getEncoding
-  proto::ColumnEncoding directEncoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
-      .WillRepeatedly(Return(&directEncoding));
-
-  // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, _, _)).WillRepeatedly(Return(nullptr));
-  // interleaved nulls, encoded as ByteRLE. 0x7f - 130 bytes (0x55 - 0101 0101)
-  // repeated.
-  auto nulls = folly::make_array<char>(0x7f, 0x55);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
-      .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
-            return new SeekableArrayInputStream(nulls.data(), nulls.size());
-          }));
-  auto data = folly::make_array<char>(0x7f, 0xaa);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
-      .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
-            return new SeekableArrayInputStream(data.data(), data.size());
-          }));
-
-  auto size = 100;
-  runTest<bool, int8_t>(size);
-  runTest<bool, int16_t>(size);
-  runTest<bool, int32_t>(size);
-  runTest<bool, int64_t>(size);
-}
-
-TEST_P(SchemaMismatchTest, testByte) {
-  // set getEncoding
-  proto::ColumnEncoding directEncoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
-      .WillRepeatedly(Return(&directEncoding));
-
-  // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, _, _)).WillRepeatedly(Return(nullptr));
-  // interleaved nulls, encoded as ByteRLE. 0x7f - 130 bytes (0x55 - 0101 0101)
-  // repeated.
-  auto nulls = folly::make_array<char>(0x7f, 0x55);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
-      .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
-            return new SeekableArrayInputStream(nulls.data(), nulls.size());
-          }));
-
-  constexpr auto round = 10;
-  constexpr auto batch = 8;
-  std::array<char, round*(batch + 1)> data;
-  auto pos = 0;
-  for (auto i = 0; i < round; ++i) {
-    data[pos++] = 0xf8;
-    for (auto j = 0; j < batch; ++j) {
-      data[pos++] = (0x01 + j * 0x10);
-    }
-  }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
-      .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
-            return new SeekableArrayInputStream(data.data(), data.size());
-          }));
-
-  auto size = 100;
-  runTest<int8_t, int16_t>(size);
-  runTest<int8_t, int32_t>(size);
-  runTest<int8_t, int64_t>(size);
-}
-
-TEST_P(SchemaMismatchTest, testIntDirect) {
-  // set getEncoding
-  proto::ColumnEncoding directEncoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
-      .WillRepeatedly(Return(&directEncoding));
-
-  // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, _, _)).WillRepeatedly(Return(nullptr));
-  // interleaved nulls, encoded as ByteRLE. 0x7f - 130 bytes (0x55 - 0101 0101)
-  // repeated.
-  auto nulls = folly::make_array<char>(0x7f, 0x55);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
-      .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
-            return new SeekableArrayInputStream(nulls.data(), nulls.size());
-          }));
-
-  // increasing values
-  std::array<char, 1024> data;
-  writeRange(data.data(), 0, 256);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
-      .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
-            return new SeekableArrayInputStream(data.data(), data.size());
-          }));
-
-  auto size = 100;
-  runTest<int16_t, int32_t>(size);
-  runTest<int16_t, int64_t>(size);
-  runTest<int32_t, int64_t>(size);
-}
-
-TEST_P(SchemaMismatchTest, testIntDict) {
-  // set getEncoding
-  proto::ColumnEncoding directEncoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  int32_t sourceWidth = 0;
-  EXPECT_CALL(streams, getEncodingProxy(_))
-      .WillRepeatedly(Return(&directEncoding));
-  proto::ColumnEncoding dictEncoding;
-  const auto dictSize = 100;
-  dictEncoding.set_kind(proto::ColumnEncoding_Kind_DICTIONARY);
-  dictEncoding.set_dictionarysize(dictSize);
-  EXPECT_CALL(streams, getEncodingProxy(1))
-      .WillRepeatedly(Return(&dictEncoding));
-
-  // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, _, _)).WillRepeatedly(Return(nullptr));
-  // interleaved nulls, encoded as ByteRLE. 0x7f - 130 bytes (0x55 - 0101 0101)
-  // repeated.
-  auto nulls = folly::make_array<char>(0x7f, 0x55);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
-      .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
-            return new SeekableArrayInputStream(nulls.data(), nulls.size());
-          }));
-
-  std::array<char, 1024> data;
-  std::vector<uint64_t> v;
-  data[0] = 0x9c; // rle literal, -100
-  for (uint64_t i = 0; i < dictSize; ++i) {
-    v.push_back(i);
-  }
-  auto count = writeVuLongs(data.data() + 1, v);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
-      .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
-            return new SeekableArrayInputStream(data.data(), count + 1);
-          }));
-
-  EXPECT_CALL(
-      streams, getStreamProxy(1, proto::Stream_Kind_IN_DICTIONARY, false))
-      .WillRepeatedly(Return(nullptr));
-
-  EXPECT_CALL(streams, genMockDictDataSetter(1, 0))
-      .WillRepeatedly(Return([&](BufferPtr& buffer, MemoryPool* pool) {
-        // Non-selective path always has int64 dictionary entries. Selective can
-        // have 2 and 4 as well.
-        if (!useSelectiveReader() || sourceWidth == 8) {
-          buffer = sequence<int64_t>(pool, 0, dictSize);
-        } else if (sourceWidth == 2) {
-          buffer = sequence<int16_t>(pool, 0, dictSize);
-        } else {
-          buffer = sequence<int32_t>(pool, 0, dictSize);
-        }
-      }));
-
-  auto size = 100;
-
-  sourceWidth = 2;
-  runTest<int16_t, int32_t>(size);
-  runTest<int16_t, int64_t>(size);
-  sourceWidth = 4;
-  runTest<int32_t, int64_t>(size);
-}
-
-TEST_P(SchemaMismatchTest, testFloat) {
-  // set getEncoding
-  proto::ColumnEncoding directEncoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  EXPECT_CALL(streams, getEncodingProxy(_))
-      .WillRepeatedly(Return(&directEncoding));
-
-  // set getStream
-  EXPECT_CALL(streams, getStreamProxy(_, _, _)).WillRepeatedly(Return(nullptr));
-  // interleaved nulls, encoded as ByteRLE. 0x7f - 130 bytes (0x55 - 0101 0101)
-  // repeated.
-  auto nulls = folly::make_array<char>(0x7f, 0x55);
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, false))
-      .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
-            return new SeekableArrayInputStream(nulls.data(), nulls.size());
-          }));
-  constexpr auto size = 100;
-  std::array<float, size> data;
-  for (auto i = 0; i < size; ++i) {
-    data[i] = folly::Random::randDouble(0, 100);
-  }
-  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
-      .WillRepeatedly(
-          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
-            return new SeekableArrayInputStream(
-                reinterpret_cast<char*>(data.data()),
-                data.size() * sizeof(float));
-          }));
-
-  runTest<float, double>(size);
-}
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
     SchemaMismatch,


### PR DESCRIPTION
SelectiveColumnReader will be moved to dwio::common but ColumnReader
will remain untouched, based on the assumption ColumnReader and its
descendent classes will retire soon. This commit removes the inheritance
of SelectiveColumnReader to ColumnReader. To do this, DwrfRowReaderShared
would contain a SelectiveColumnReader and a ColumnReader as its members,
but only one of them is not null. TestColumnReader.cpp was also modified
this way to make the tests work. In addition, the contents in
TestColumnReader.cpp were reordered to form 3 sections: 1) test class
definitions, 2) tests, and 3) test instantiations.