### PR TITLE
Add array_sort with both scalar and complex data types support

### DIFF
--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/container/F14Set.h>
+
+#include "velox/expression/EvalCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/LambdaFunctionUtil.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+void applyComplexType(
+    const SelectivityVector& rows,
+    ArrayVector* inputArray,
+    exec::EvalCtx* context,
+    VectorPtr* resultElements) {
+  auto inputElements = inputArray->elements();
+  const SelectivityVector inputElementRows =
+      toElementRows(inputElements->size(), rows, inputArray);
+  exec::LocalDecodedVector decodedElements(
+      context, *inputElements, inputElementRows);
+  const auto* baseElementsVector = decodedElements->base();
+
+  // Allocate new vectors for indices.
+  BufferPtr indices = allocateIndices(inputElements->size(), context->pool());
+  vector_size_t* rawIndices = indices->asMutable<vector_size_t>();
+
+  const CompareFlags flags{.nullsFirst = false, .ascending = true};
+  rows.applyToSelected([&](vector_size_t row) {
+    const auto size = inputArray->sizeAt(row);
+    const auto offset = inputArray->offsetAt(row);
+    for (auto i = offset; i < offset + size; ++i) {
+      rawIndices[i] = i;
+    }
+    std::sort(
+        rawIndices + offset,
+        rawIndices + offset + size,
+        [&](vector_size_t& a, vector_size_t& b) {
+          return baseElementsVector->compare(baseElementsVector, a, b, flags) <
+              0;
+        });
+  });
+
+  *resultElements = BaseVector::transpose(indices, std::move(inputElements));
+}
+
+template <typename T>
+inline void swapWithNull(
+    FlatVector<T>* vector,
+    vector_size_t index,
+    vector_size_t nullIndex) {
+  // Values are already present in vector stringBuffers. Don't create additional
+  // copy.
+  if constexpr (std::is_same_v<T, StringView>) {
+    vector->setNoCopy(nullIndex, vector->valueAt(index));
+  } else {
+    vector->set(nullIndex, vector->valueAt(index));
+  }
+  vector->setNull(index, true);
+}
+
+template <TypeKind kind>
+void applyScalarType(
+    const SelectivityVector& rows,
+    const ArrayVector* inputArray,
+    exec::EvalCtx* context,
+    VectorPtr* resultElements) {
+  using T = typename TypeTraits<kind>::NativeType;
+
+  // Copy array elements to new vector.
+  const VectorPtr& inputElements = inputArray->elements();
+  VELOX_DCHECK(kind == inputElements->typeKind());
+  const SelectivityVector inputElementRows =
+      toElementRows(inputElements->size(), rows, inputArray);
+  exec::LocalDecodedVector decodedElements(
+      context, *inputElements, inputElementRows);
+  const vector_size_t elementsCount = inputElementRows.size();
+
+  // TODO: consider to use dictionary wrapping to avoid the direct sorting on
+  // the scalar values as we do for complex data type if this runs slow in
+  // practice.
+  *resultElements =
+      BaseVector::create(inputElements->type(), elementsCount, context->pool());
+  (*resultElements)
+      ->copy(
+          decodedElements->base(), inputElementRows, /*toSourceRow=*/nullptr);
+
+  auto flatResults = (*resultElements)->asFlatVector<T>();
+
+  auto processRow = [&](vector_size_t row) {
+    const auto size = inputArray->sizeAt(row);
+    const auto offset = inputArray->offsetAt(row);
+    if (size == 0) {
+      return;
+    }
+    vector_size_t numNulls = 0;
+    // Move nulls to end of array.
+    for (vector_size_t i = size - 1; i >= 0; --i) {
+      if (flatResults->isNullAt(offset + i)) {
+        swapWithNull<T>(flatResults, offset + size - numNulls - 1, offset + i);
+        ++numNulls;
+      }
+    }
+    // Exclude null values while sorting.
+    const auto startRow = offset;
+    const auto endRow = startRow + size - numNulls;
+
+    if constexpr (kind == TypeKind::BOOLEAN) {
+      uint64_t* rawBits = flatResults->template mutableRawValues<uint64_t>();
+      const auto numOneBits = bits::countBits(rawBits, startRow, endRow);
+      const auto endZeroRow = endRow - numOneBits;
+      bits::fillBits(rawBits, startRow, endZeroRow, bits::kNull);
+      bits::fillBits(rawBits, endZeroRow, endRow, bits::kNotNull);
+    } else {
+      T* resultRawValues = flatResults->mutableRawValues();
+      std::sort(resultRawValues + startRow, resultRawValues + endRow);
+    }
+  };
+  rows.applyToSelected(processRow);
+}
+
+// See documentation at https://prestodb.io/docs/current/functions/array.html
+template <TypeKind T>
+class ArraySortFunction : public exec::VectorFunction {
+ public:
+  /// This class implements the array_sort query function. Takes an array as
+  /// input and sorts it in ascending order and null elements will be placed at
+  /// the end of the returned array.
+  ///
+  /// Along with the set, we maintain a `hasNull` flag that indicates whether
+  /// null is present in the array.
+  ///
+  /// Zero element copy for complex data type:
+  ///
+  /// In order to prevent copies of array elements with complex data type, the
+  /// function reuses the internal elements() vector from the original
+  /// ArrayVector. A new vector is created containing the indices of the sorted
+  /// elements in the output, and wrapped into a DictionaryVector. The 'lengths'
+  /// and 'offsets' vectors that control where output arrays start and end
+  /// remain the same in the output ArrayVector.
+
+  ArraySortFunction() {}
+
+  // Execute function.
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /*outputType*/,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    VELOX_CHECK_EQ(args.size(), 1);
+
+    // Acquire the array elements vector.
+    auto inputArray = args.front()->as<ArrayVector>();
+    VectorPtr resultElements;
+
+    if (velox::TypeTraits<T>::isPrimitiveType) {
+      VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+          applyScalarType, T, rows, inputArray, context, &resultElements);
+
+    } else {
+      applyComplexType(rows, inputArray, context, &resultElements);
+    }
+
+    auto resultArray = std::make_shared<ArrayVector>(
+        context->pool(),
+        inputArray->type(),
+        inputArray->nulls(),
+        rows.end(),
+        inputArray->offsets(),
+        inputArray->sizes(),
+        resultElements,
+        inputArray->getNullCount());
+
+    context->moveOrCopyResult(resultArray, rows, result);
+  }
+};
+
+// Validate number of parameters and types.
+void validateType(const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  VELOX_USER_CHECK_EQ(
+      inputArgs.size(), 1, "array_distinct requires exactly one parameter");
+
+  auto arrayType = inputArgs.front().type;
+  VELOX_USER_CHECK_EQ(
+      arrayType->kind(),
+      TypeKind::ARRAY,
+      "array_sort requires arguments of type ARRAY");
+}
+
+// Create function template based on type.
+template <TypeKind kind>
+std::shared_ptr<exec::VectorFunction> createTyped(
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  VELOX_CHECK_EQ(inputArgs.size(), 1);
+  return std::make_shared<ArraySortFunction<kind>>();
+}
+
+// Create function.
+std::shared_ptr<exec::VectorFunction> create(
+    const std::string& /* name */,
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  validateType(inputArgs);
+  auto elementType = inputArgs.front().type->childAt(0);
+  return VELOX_DYNAMIC_TYPE_DISPATCH(
+      createTyped, elementType->kind(), inputArgs);
+}
+
+// Define function signature.
+std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+  // array(T) -> array(T)
+  return {exec::FunctionSignatureBuilder()
+              .typeVariable("T")
+              .returnType("array(T)")
+              .argumentType("array(T)")
+              .build()};
+}
+
+} // namespace
+
+// Register function.
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(udf_array_sort, signatures(), create);
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
   ArrayDuplicates.cpp
   ArrayIntersectExcept.cpp
   ArrayPosition.cpp
+  ArraySort.cpp
   ElementAt.cpp
   FilterFunctions.cpp
   FromUnixTime.cpp

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -53,6 +53,7 @@ void registerArrayFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_slice, "slice");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_zip, "zip");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_position, "array_position");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sort, "array_sort");
 
   exec::registerStatefulVectorFunction(
       "width_bucket", widthBucketArraySignature(), makeWidthBucketArray);

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+
+#include <fmt/format.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using facebook::velox::functions::test::FunctionBaseTest;
+
+namespace {
+
+const std::unordered_set<TypeKind> kSupportedTypes = {
+    TypeKind::BOOLEAN,
+    TypeKind::TINYINT,
+    TypeKind::SMALLINT,
+    TypeKind::INTEGER,
+    TypeKind::BIGINT,
+    TypeKind::REAL,
+    TypeKind::DOUBLE,
+    TypeKind::VARCHAR,
+    TypeKind::MAP,
+    TypeKind::ARRAY,
+    TypeKind::ROW};
+
+using TestMapType = std::vector<std::pair<int32_t, std::optional<int32_t>>>;
+using TestArrayType = std::vector<std::optional<StringView>>;
+using TestRowType = variant;
+
+class ArraySortTest : public FunctionBaseTest,
+                      public testing::WithParamInterface<TypeKind> {
+ protected:
+  ArraySortTest() : numValues_(10), numVectors_(5) {}
+
+  void SetUp() override;
+
+  // Build a flat vector with numeric native type of T. The value in the
+  // returned flat vector is in ascending order.
+  template <typename T>
+  FlatVectorPtr<T> buildScalarVector() {
+    return makeFlatVector<T>(numValues_, [](auto row) { return row + 1; });
+  }
+
+  template <typename T>
+  const FlatVector<T>* getScalarVector() {
+    return dataVectorsByType_[CppToType<T>::typeKind]
+        ->template asFlatVector<T>();
+  }
+
+  const MapVector* getMapVector() {
+    return dynamic_cast<MapVector*>(dataVectorsByType_[TypeKind::MAP].get());
+  }
+
+  template <typename T>
+  T dataAt(vector_size_t index) {
+    EXPECT_LT(index, numValues_);
+    return getScalarVector<T>()->valueAt(index);
+  }
+
+  template <typename T>
+  ArrayVectorPtr arrayVector(const std::vector<std::optional<T>>& inputValues) {
+    std::vector<std::vector<std::optional<T>>> inputVectors;
+    inputVectors.reserve(numVectors_);
+    for (int i = 0; i < numVectors_; ++i) {
+      inputVectors.push_back(inputValues);
+    }
+    return makeNullableArrayVector<T>(inputVectors);
+  }
+
+  MapVectorPtr buildMapVector() {
+    return makeMapVector<int32_t, int32_t>(
+        numValues_,
+        [&](vector_size_t /*row*/) { return 1; },
+        [&](vector_size_t row) { return row; },
+        [&](vector_size_t row) { return row; });
+  }
+
+  template <typename T>
+  void test() {
+    struct {
+      const RowVectorPtr inputVector;
+      const VectorPtr expectedResult;
+
+      const std::string debugString() const {
+        return fmt::format(
+            "\ntype: {}\ninputVector: {}\nexpectedResult: {}",
+            GetParam(),
+            inputVector->toString(0, inputVector->size()),
+            expectedResult->toString(0, expectedResult->size()));
+      }
+    } testSettings[] = {
+        {makeRowVector({arrayVector(std::vector<std::optional<T>>(
+             {dataAt<T>(2), dataAt<T>(1), dataAt<T>(0)}))}),
+         arrayVector(std::vector<std::optional<T>>{
+             dataAt<T>(0), dataAt<T>(1), dataAt<T>(2)})},
+
+        {makeRowVector({arrayVector(std::vector<std::optional<T>>(
+             {dataAt<T>(0), dataAt<T>(1), dataAt<T>(2)}))}),
+         arrayVector(std::vector<std::optional<T>>{
+             dataAt<T>(0), dataAt<T>(1), dataAt<T>(2)})},
+
+        {makeRowVector({arrayVector(std::vector<std::optional<T>>(
+             {dataAt<T>(0), dataAt<T>(0), dataAt<T>(0)}))}),
+         arrayVector(std::vector<std::optional<T>>{
+             dataAt<T>(0), dataAt<T>(0), dataAt<T>(0)})},
+
+        {makeRowVector({arrayVector(std::vector<std::optional<T>>(
+             {dataAt<T>(1), dataAt<T>(0), dataAt<T>(2)}))}),
+         arrayVector(std::vector<std::optional<T>>{
+             dataAt<T>(0), dataAt<T>(1), dataAt<T>(2)})},
+
+        {makeRowVector({arrayVector(std::vector<std::optional<T>>(
+             {std::nullopt, dataAt<T>(1), dataAt<T>(0), dataAt<T>(2)}))}),
+         arrayVector(std::vector<std::optional<T>>{
+             dataAt<T>(0), dataAt<T>(1), dataAt<T>(2), std::nullopt})},
+
+        {makeRowVector({arrayVector(std::vector<std::optional<T>>(
+             {std::nullopt,
+              std::nullopt,
+              dataAt<T>(1),
+              dataAt<T>(0),
+              dataAt<T>(2)}))}),
+         arrayVector(std::vector<std::optional<T>>{
+             dataAt<T>(0),
+             dataAt<T>(1),
+             dataAt<T>(2),
+             std::nullopt,
+             std::nullopt})},
+
+        {makeRowVector({arrayVector(std::vector<std::optional<T>>(
+             {std::nullopt,
+              dataAt<T>(1),
+              dataAt<T>(0),
+              std::nullopt,
+              dataAt<T>(2)}))}),
+         arrayVector(std::vector<std::optional<T>>{
+             dataAt<T>(0),
+             dataAt<T>(1),
+             dataAt<T>(2),
+             std::nullopt,
+             std::nullopt})},
+
+        {makeRowVector({arrayVector(std::vector<std::optional<T>>(
+             {dataAt<T>(1),
+              std::nullopt,
+              dataAt<T>(0),
+              dataAt<T>(2),
+              std::nullopt}))}),
+         arrayVector(std::vector<std::optional<T>>{
+             dataAt<T>(0),
+             dataAt<T>(1),
+             dataAt<T>(2),
+             std::nullopt,
+             std::nullopt})},
+        {makeRowVector({arrayVector(std::vector<std::optional<T>>(
+             {std::nullopt,
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
+              std::nullopt}))}),
+         arrayVector(std::vector<std::optional<T>>{
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt,
+             std::nullopt})}};
+    for (const auto& testData : testSettings) {
+      SCOPED_TRACE(testData.debugString());
+      auto actualResult =
+          evaluate<ArrayVector>("array_sort(c0)", testData.inputVector);
+      assertEqualVectors(testData.expectedResult, actualResult);
+    }
+  }
+
+  void runTest(TypeKind kind) {
+    switch (kind) {
+      case TypeKind::BOOLEAN:
+        test<bool>();
+        break;
+      case TypeKind::TINYINT:
+        test<int8_t>();
+        break;
+      case TypeKind::SMALLINT:
+        test<int16_t>();
+        break;
+      case TypeKind::INTEGER:
+        test<int32_t>();
+        break;
+      case TypeKind::BIGINT:
+        test<int64_t>();
+        break;
+      case TypeKind::REAL:
+        test<float>();
+        break;
+      case TypeKind::DOUBLE:
+        test<double>();
+        break;
+      case TypeKind::VARCHAR:
+        test<StringView>();
+        break;
+      case TypeKind::MAP:
+        test<TestMapType>();
+        break;
+      case TypeKind::ARRAY:
+        test<TestArrayType>();
+        break;
+      case TypeKind::ROW:
+        test<TestRowType>();
+        break;
+      default:
+        VELOX_FAIL(
+            "Unsupported data type of sort_array: {}", mapTypeKindToName(kind));
+    }
+  }
+
+  // Specify the number of values per each data vector in 'dataVectorsByType_'.
+  const int numValues_;
+  std::unordered_map<TypeKind, VectorPtr> dataVectorsByType_;
+  // Specify the number of vectors in test.
+  const int numVectors_;
+};
+
+// Build a flat vector with StringView. The value in the returned flat vector
+// is in ascending order.
+template <>
+FlatVectorPtr<StringView> ArraySortTest::buildScalarVector() {
+  std::string value;
+  return makeFlatVector<StringView>(
+      numValues_,
+      [&, maxValueLen = (int)std::ceil((double)numValues_ / 26.0)](auto row) {
+        const int valueLen = row % maxValueLen + 1;
+        const char c = 'a' + row / maxValueLen;
+        value = std::string(valueLen, c);
+        return StringView(value);
+      });
+}
+
+template <>
+FlatVectorPtr<bool> ArraySortTest::buildScalarVector() {
+  std::string value;
+  return makeFlatVector<bool>(numValues_, [&](auto row) {
+    return row < numValues_ / 2 ? false : true;
+  });
+}
+
+template <>
+TestMapType ArraySortTest::dataAt<TestMapType>(vector_size_t index) {
+  EXPECT_LT(index, numValues_);
+  const int32_t key =
+      getMapVector()->mapKeys()->asFlatVector<int32_t>()->valueAt(index);
+  const std::optional<int32_t> value =
+      getMapVector()->mapValues()->asFlatVector<int32_t>()->valueAt(index);
+  return TestMapType({std::pair{key, value}});
+}
+
+template <>
+TestArrayType ArraySortTest::dataAt<TestArrayType>(vector_size_t index) {
+  EXPECT_LT(index, numValues_);
+  TestArrayType array;
+  const auto elementValue = getScalarVector<StringView>()->valueAt(index);
+  for (int i = 0; i < numValues_; ++i) {
+    array.push_back(elementValue);
+  }
+  return array;
+}
+
+template <>
+TestRowType ArraySortTest::dataAt<TestRowType>(vector_size_t index) {
+  EXPECT_LT(index, numValues_);
+  return variant::row({getScalarVector<double>()->valueAt(index)});
+}
+
+template <>
+ArrayVectorPtr ArraySortTest::arrayVector<TestMapType>(
+    const std::vector<std::optional<TestMapType>>& inputValues) {
+  std::vector<std::vector<std::optional<TestMapType>>> inputVectors;
+  inputVectors.reserve(numVectors_);
+  for (int i = 0; i < numVectors_; ++i) {
+    inputVectors.push_back(inputValues);
+  }
+  return makeArrayOfMapVector<int32_t, int32_t>(inputVectors);
+}
+
+template <>
+ArrayVectorPtr ArraySortTest::arrayVector<TestArrayType>(
+    const std::vector<std::optional<TestArrayType>>& inputValues) {
+  std::vector<std::vector<std::optional<TestArrayType>>> inputVectors;
+  inputVectors.reserve(numVectors_);
+  for (int i = 0; i < numVectors_; ++i) {
+    inputVectors.push_back(inputValues);
+  }
+  return makeNestedArrayVector<StringView>(inputVectors);
+}
+
+template <>
+ArrayVectorPtr ArraySortTest::arrayVector<TestRowType>(
+    const std::vector<std::optional<TestRowType>>& inputValues) {
+  std::vector<variant> inputVariants;
+  inputVariants.reserve(inputValues.size());
+  for (int i = 0; i < inputValues.size(); ++i) {
+    if (inputValues[i].has_value()) {
+      inputVariants.push_back(inputValues[i].value());
+    } else {
+      inputVariants.push_back(variant::null(TypeKind::ROW));
+    }
+  }
+
+  std::vector<std::vector<variant>> inputVariantVectors;
+  inputVariantVectors.reserve(numVectors_);
+  for (int i = 0; i < numVectors_; ++i) {
+    inputVariantVectors.push_back(inputVariants);
+  }
+
+  const auto rowType = ROW({DOUBLE()});
+  return makeArrayOfRowVector(rowType, inputVariantVectors);
+}
+
+void ArraySortTest::SetUp() {
+  for (const TypeKind type : kSupportedTypes) {
+    switch (type) {
+      case TypeKind::BOOLEAN:
+        dataVectorsByType_.emplace(type, buildScalarVector<bool>());
+        break;
+      case TypeKind::TINYINT:
+        dataVectorsByType_.emplace(type, buildScalarVector<int8_t>());
+        break;
+      case TypeKind::SMALLINT:
+        dataVectorsByType_.emplace(type, buildScalarVector<int16_t>());
+        break;
+      case TypeKind::INTEGER:
+        dataVectorsByType_.emplace(type, buildScalarVector<int32_t>());
+        break;
+      case TypeKind::BIGINT:
+        dataVectorsByType_.emplace(type, buildScalarVector<int64_t>());
+        break;
+      case TypeKind::REAL:
+        dataVectorsByType_.emplace(type, buildScalarVector<float>());
+        break;
+      case TypeKind::DOUBLE:
+        dataVectorsByType_.emplace(type, buildScalarVector<double>());
+        break;
+      case TypeKind::VARCHAR:
+        dataVectorsByType_.emplace(type, buildScalarVector<StringView>());
+        break;
+      case TypeKind::MAP:
+        dataVectorsByType_.emplace(type, buildMapVector());
+        break;
+      case TypeKind::ARRAY:
+      case TypeKind::ROW:
+        // ARRAY and ROW will reuse the scalar data vectors built for DOUBLE and
+        // VARCHAR respectively.
+        break;
+      default:
+        VELOX_FAIL(
+            "Unsupported data type of sort_array: {}", mapTypeKindToName(type));
+    }
+  }
+  ASSERT_LE(dataVectorsByType_.size(), kSupportedTypes.size());
+}
+
+TEST_P(ArraySortTest, basic) {
+  runTest(GetParam());
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    ArraySortTest,
+    ArraySortTest,
+    testing::ValuesIn(kSupportedTypes));
+} // namespace

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   ArrayMaxTest.cpp
   ArrayMinTest.cpp
   ArrayPositionTest.cpp
+  ArraySortTest.cpp
   ArraysOverlapTest.cpp
   BitwiseTest.cpp
   CardinalityTest.cpp


### PR DESCRIPTION
Add array_sort with both scalar and complex data types support. Will add ARRAY and ROW data type tests later.