### PR TITLE
Convert duckDB decimal value to velox variant

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -138,14 +138,30 @@ variant duckValueToVariant(const Value& val) {
     case LogicalTypeId::DOUBLE:
       return variant(val.GetValue<double>());
     case LogicalTypeId::DECIMAL: {
-      if (val.type().InternalType() == ::duckdb::PhysicalType::INT128) {
-        auto unscaledValue = val.GetValueUnsafe<::duckdb::hugeint_t>();
-        return variant(
-            LongDecimal(buildInt128(unscaledValue.upper, unscaledValue.lower)));
-      } else {
-        return variant(ShortDecimal(val.GetValueUnsafe<int64_t>()));
+      switch (val.type().InternalType()) {
+        case ::duckdb::PhysicalType::INT8: {
+          auto unscaledValue = val.GetValueUnsafe<int8_t>();
+          return variant(ShortDecimal(unscaledValue));
+        }
+        case ::duckdb::PhysicalType::INT16: {
+          auto unscaledValue = val.GetValueUnsafe<int16_t>();
+          return variant(ShortDecimal(unscaledValue));
+        }
+        case ::duckdb::PhysicalType::INT32: {
+          auto unscaledValue = val.GetValueUnsafe<int32_t>();
+          return variant(ShortDecimal(unscaledValue));
+        }
+        case ::duckdb::PhysicalType::INT64: {
+          return variant(ShortDecimal(val.GetValueUnsafe<int64_t>()));
+        }
+        case ::duckdb::PhysicalType::INT128: {
+          auto unscaledValue = val.GetValueUnsafe<::duckdb::hugeint_t>();
+          return variant(LongDecimal(
+              buildInt128(unscaledValue.upper, unscaledValue.lower)));
+        }
+        default:
+          VELOX_UNSUPPORTED();
       }
-      VELOX_UNSUPPORTED();
     }
     case LogicalTypeId::VARCHAR:
       return variant(val.GetValue<std::string>());

--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -139,11 +139,11 @@ variant duckValueToVariant(const Value& val) {
       return variant(val.GetValue<double>());
     case LogicalTypeId::DECIMAL: {
       if (val.type().InternalType() == ::duckdb::PhysicalType::INT128) {
-        auto unscaledValue = val.GetValue<::duckdb::hugeint_t>();
+        auto unscaledValue = val.GetValueUnsafe<::duckdb::hugeint_t>();
         return variant(
-            LongDecimal(buildInt128(unscaledValue.lower, unscaledValue.upper)));
-      } else if (val.type().InternalType() == ::duckdb::PhysicalType::INT64) {
-        return variant(ShortDecimal(val.GetValue<int64_t>()));
+            LongDecimal(buildInt128(unscaledValue.upper, unscaledValue.lower)));
+      } else {
+        return variant(ShortDecimal(val.GetValueUnsafe<int64_t>()));
       }
       VELOX_UNSUPPORTED();
     }

--- a/velox/duckdb/conversion/tests/DuckConversionTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckConversionTest.cpp
@@ -66,10 +66,11 @@ TEST(DuckConversionTest, duckValueToVariant) {
   // Decimals.
   for (int64_t i : {111, 200, 300}) {
     EXPECT_EQ(
-        variant(LongDecimal(buildInt128(0, i))),
+        variant(DecimalVariantValue(i, 20, 2)),
         duckValueToVariant(Value::DECIMAL(::duckdb::hugeint_t(i), 20, 2)));
     EXPECT_EQ(
-        variant(ShortDecimal(i)), duckValueToVariant(Value::DECIMAL(i, 10, 2)));
+        variant(DecimalVariantValue(i, 10, 2)),
+        duckValueToVariant(Value::DECIMAL(i, 10, 2)));
   }
 
   // Strings.

--- a/velox/duckdb/conversion/tests/DuckConversionTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckConversionTest.cpp
@@ -63,6 +63,15 @@ TEST(DuckConversionTest, duckValueToVariant) {
     EXPECT_NO_THROW(duckValueToVariant(Value::FLOAT(i)));
   }
 
+  // Decimals.
+  for (int64_t i : {111, 200, 300}) {
+    EXPECT_EQ(
+        variant(LongDecimal(buildInt128(0, i))),
+        duckValueToVariant(Value::DECIMAL(::duckdb::hugeint_t(i), 20, 2)));
+    EXPECT_EQ(
+        variant(ShortDecimal(i)), duckValueToVariant(Value::DECIMAL(i, 10, 2)));
+  }
+
   // Strings.
   std::vector<std::string> vec = {"", "asdf", "aS$!#^*HFD"};
   for (const auto& i : vec) {

--- a/velox/duckdb/functions/tests/DuckFunctionTest.cpp
+++ b/velox/duckdb/functions/tests/DuckFunctionTest.cpp
@@ -379,7 +379,7 @@ TEST_F(BaseDuckTest, mod) {
 
   runDuckTest<double, double>(
       DOUBLE(),
-      "duckdb_mod(c0, CAST(3.1 AS DOUBLE))",
+      "duckdb_mod(c0, CAST('3.1' AS DOUBLE))",
       {0, 1.0, 4.2},
       {0, 1.0, 1.1});
 }
@@ -441,7 +441,7 @@ TEST_F(BaseDuckTest, bigMix) {
   runDuckTestBinary<double, double, double>(
       DOUBLE(),
       DOUBLE(),
-      "duckdb_floor(duckdb_mod(cast(ceil(c0) as integer), cast(floor(c1) as integer)) + 0.5)",
+      "duckdb_floor(duckdb_mod(cast(ceil(c0) as integer), cast(floor(c1) as integer)) + '0.5'::double)",
       {1.2, 4.7, 39.8, 88, 300},
       {1.2, 2.1, 7.3, 23.22, 101.77},
       {0, 1, 5, 19, 98});

--- a/velox/exec/tests/FilterProjectTest.cpp
+++ b/velox/exec/tests/FilterProjectTest.cpp
@@ -202,10 +202,11 @@ TEST_F(FilterProjectTest, projectOverLazy) {
 
   createDuckDbTable({vectors});
 
-  auto plan = PlanBuilder()
-                  .values({lazyVectors})
-                  .project({"c0 > 0 AND c1 > 0.0", "c1 + 5.2"})
-                  .planNode();
+  auto plan =
+      PlanBuilder()
+          .values({lazyVectors})
+          .project({"c0 > 0 AND c1 > '0.0'::double", "c1 + '5.2'::double"})
+          .planNode();
   assertQuery(plan, "SELECT c0 > 0 AND c1 > 0, c1 + 5.2 FROM tmp");
 }
 

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -474,8 +474,8 @@ TEST_F(PlanNodeToStringTest, tableScan) {
                     .tableScan(
                         rowType,
                         {"shipdate between '1994-01-01' and '1994-12-31'",
-                         "discount between 0.05 and 0.07",
-                         "quantity < 24.0::DOUBLE"},
+                         "discount between '0.05'::double and '0.07'::double",
+                         "quantity < '24.0'::DOUBLE"},
                         "comment NOT LIKE '%special%request%'")
                     .planNode();
 

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -17,7 +17,6 @@
 #include "velox/type/Variant.h"
 #include "common/encode/Base64.h"
 #include "folly/json.h"
-#include "velox/type/DecimalUtils.h"
 
 namespace facebook::velox {
 
@@ -312,12 +311,10 @@ std::string variant::toJson() const {
       return "\"Opaque<" + value<TypeKind::OPAQUE>().type->toString() + ">\"";
     }
     case TypeKind::SHORT_DECIMAL: {
-      return formatAsDecimal(
-          0, value<TypeKind::SHORT_DECIMAL>().unscaledValue());
+      return value<TypeKind::SHORT_DECIMAL>().toString();
     }
     case TypeKind::LONG_DECIMAL: {
-      return formatAsDecimal(
-          0, value<TypeKind::LONG_DECIMAL>().unscaledValue());
+      return value<TypeKind::LONG_DECIMAL>().toString();
     }
     case TypeKind::FUNCTION:
     case TypeKind::UNKNOWN:

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -17,6 +17,7 @@
 #include "velox/type/Variant.h"
 #include "common/encode/Base64.h"
 #include "folly/json.h"
+#include "velox/type/DecimalUtils.h"
 
 namespace facebook::velox {
 
@@ -310,8 +311,14 @@ std::string variant::toJson() const {
       // debugging only. Variant::serialize should actually serialize the data.
       return "\"Opaque<" + value<TypeKind::OPAQUE>().type->toString() + ">\"";
     }
-    case TypeKind::SHORT_DECIMAL:
-    case TypeKind::LONG_DECIMAL:
+    case TypeKind::SHORT_DECIMAL: {
+      return formatAsDecimal(
+          0, value<TypeKind::SHORT_DECIMAL>().unscaledValue());
+    }
+    case TypeKind::LONG_DECIMAL: {
+      return formatAsDecimal(
+          0, value<TypeKind::LONG_DECIMAL>().unscaledValue());
+    }
     case TypeKind::FUNCTION:
     case TypeKind::UNKNOWN:
     case TypeKind::INVALID:

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -39,6 +39,21 @@ struct VariantConverter;
 
 class variant;
 
+struct DecimalVariantValue {
+  uint8_t precision;
+  uint8_t scale;
+  int128_t unscaledValue;
+
+  // 123456789
+  std::string toString() const {
+    if (precision <= 18) {
+      return formatDecimal(
+          scale, (int64_t)unscaledValue);
+    }
+    return formatDecimal(scale, unscaledValue);
+  }
+};
+
 template <TypeKind KIND>
 struct VariantEquality;
 


### PR DESCRIPTION
The decimal value from velox are by default converted to double. This change fixes it by returning a variant of unscaled values for LongDecimal and ShortDecimal.
