### PR TITLE
Make ExchangeQueue's backing memory tracked by memory pool

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -26,6 +26,7 @@
 #include <fmt/format.h>
 #include <glog/logging.h>
 
+#include <velox/common/base/Exceptions.h>
 #include "folly/CPortability.h"
 #include "folly/Likely.h"
 #include "folly/Random.h"
@@ -134,6 +135,15 @@ class MemoryPool : public AbstractMemoryPool {
   // reference to self would be invalid after this call. This will also drop the
   // entire subtree.
   virtual void removeSelf() = 0;
+
+  // Used to manage existing externally allocated memories without doing a new
+  // allocation.
+  virtual void reserve(int64_t bytes) {
+    VELOX_NYI("reserve() needs to be implemented in derived memory pool.");
+  }
+  virtual void release(int64_t bytes) {
+    VELOX_NYI("release() needs to be implemented in derived memory pool.");
+  }
 };
 
 namespace detail {
@@ -276,6 +286,14 @@ class ScopedMemoryPool final : public MemoryPool {
 
   MemoryPool& getPool() {
     return pool_;
+  }
+
+  void reserve(int64_t bytes) override {
+    pool_.reserve(bytes);
+  }
+
+  void release(int64_t bytes) override {
+    pool_.release(bytes);
   }
 
  private:
@@ -433,6 +451,10 @@ class MemoryPoolImpl : public MemoryPoolBase {
   int64_t getAggregateBytes() const;
   int64_t getSubtreeMaxBytes() const;
 
+  // TODO: consider returning bool instead.
+  void reserve(int64_t size) override;
+  void release(int64_t size) override;
+
  private:
   VELOX_FRIEND_TEST(MemoryPoolTest, Ctor);
 
@@ -482,10 +504,6 @@ class MemoryPoolImpl : public MemoryPoolBase {
   void accessSubtreeMemoryUsage(
       std::function<void(const MemoryUsage&)> visitor) const;
   void updateSubtreeMemoryUsage(std::function<void(MemoryUsage&)> visitor);
-
-  // TODO: consider returning bool instead.
-  void reserve(int64_t size);
-  void release(int64_t size);
 
   MemoryManager<Allocator, ALIGNMENT>& memoryManager_;
 

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -228,6 +228,28 @@ TEST(MemoryPoolTest, UncapMemory) {
   // caps are supported again.
 }
 
+// Mainly tests how it tracks externally allocated memory.
+TEST(MemoryPoolTest, ReserveTest) {
+  MemoryManager<MemoryAllocator> manager{8 * GB};
+  auto& root = manager.getRoot();
+
+  auto& child = root.addChild("elastic_quota");
+
+  const int64_t kChunkSize{32L * MB};
+
+  child.reserve(kChunkSize);
+  EXPECT_EQ(child.getCurrentBytes(), kChunkSize);
+
+  child.reserve(2 * kChunkSize);
+  EXPECT_EQ(child.getCurrentBytes(), 3 * kChunkSize);
+
+  child.release(1 * kChunkSize);
+  EXPECT_EQ(child.getCurrentBytes(), 2 * kChunkSize);
+
+  child.release(2 * kChunkSize);
+  EXPECT_EQ(child.getCurrentBytes(), 0);
+}
+
 // Mainly tests how it updates the memory usage in MemoryPool.
 TEST(MemoryPoolTest, AllocTest) {
   MemoryManager<MemoryAllocator> manager{8 * GB};


### PR DESCRIPTION
Summary:
A situation can happen in the following manner:

Let's assume we have following setup:
160 nodes cluster, ungrouped final aggregation, 15 max total drivers(threads). So on the final aggregation node we have 1 thread running final aggregation, 14 threads running Exchange, fetching data from upstream partial aggregation nodes. Following is step by step "repro" of the issue:

1. Exchange in final aggr node sees the shared ExchangeQueue (only 1 queue in the entire node) size is less than minBytes_(32MB).
2. Exchange tries to issue http requests to upstream partial aggregation nodes. That is 14 Exchange threads each to 159 partial aggregation nodes -> 2226 requests at the same time (worst case), each request with PRESTO_MAX_SIZE_HTTP_HEADER specified to 32MB.
3. Partial aggregation nodes receive the request and try to fulfil the request. It puts one 31MB row (worst case) in the response and checks that this response is less than the requested PRESTO_MAX_SIZE_HTTP_HEADER of 32MB. And then it appends another row of 31MB, making the response 62MB and sends back to final aggr node.
4. Final aggr node gets all responses back to put in the ExchangeQueue, of size 14(exchange threads) * 159(requests per thread) * 62MB(size per request) = 134GB worst case. This memory is directly allocated by Proxygen in folly::IOBuf when it receives http responses, and hence not tracked and controlled.
5. 134GB is good enough to make the final aggr host die.

To avoid this scenario to OOM host we need to have that large amount of memory tracked.

Differential Revision: D37840570

