### PR TITLE
Support Complex types in fuzzFlat

### DIFF
--- a/velox/benchmarks/basic/VectorCompare.cpp
+++ b/velox/benchmarks/basic/VectorCompare.cpp
@@ -42,13 +42,13 @@ class VectorCompareBenchmark : public functions::test::FunctionBenchmarkBase {
     flatVector_ = fuzzer.fuzzFlat(BIGINT());
 
     arrayVector_ =
-        fuzzer.fuzzComplex(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+        fuzzer.fuzzFlat(std::make_shared<ArrayType>(ArrayType(BIGINT())));
 
-    mapVector_ = fuzzer.fuzzComplex(
-        std::make_shared<MapType>(MapType(BIGINT(), BIGINT())));
+    mapVector_ =
+        fuzzer.fuzzFlat(std::make_shared<MapType>(MapType(BIGINT(), BIGINT())));
 
-    rowVector_ = fuzzer.fuzzComplex(
-        vectorMaker_.rowType({BIGINT(), BIGINT(), BIGINT()}));
+    rowVector_ =
+        fuzzer.fuzzFlat(vectorMaker_.rowType({BIGINT(), BIGINT(), BIGINT()}));
   }
 
   size_t run(const VectorPtr& vector) {

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -96,7 +96,8 @@ class VectorFuzzer {
   // vector (dictionary).
   VectorPtr fuzz(const TypePtr& type);
 
-  // Returns a flat vector with randomized data and nulls.
+  // Returns a flat vector or a complex vector with flat children with
+  // randomized data and nulls.
   VectorPtr fuzzFlat(const TypePtr& type);
 
   // Returns a random constant vector (which could be a null constant).
@@ -105,9 +106,6 @@ class VectorFuzzer {
   // Wraps `vector` using a randomized indices vector, returning a
   // DictionaryVector.
   VectorPtr fuzzDictionary(const VectorPtr& vector);
-
-  // Returns a complex vector with randomized data and nulls.
-  VectorPtr fuzzComplex(const TypePtr& type);
 
   // Returns a "fuzzed" row vector with randomized data and nulls.
   RowVectorPtr fuzzRow(const RowTypePtr& rowType);
@@ -139,16 +137,27 @@ class VectorFuzzer {
   }
 
  private:
-  VectorPtr fuzz(const TypePtr& type, vector_size_t size);
+  VectorPtr
+  fuzz(const TypePtr& type, vector_size_t size, bool flatEncoding = false);
 
   VectorPtr fuzzFlat(const TypePtr& type, vector_size_t size);
 
   VectorPtr fuzzConstant(const TypePtr& type, vector_size_t size);
 
-  VectorPtr fuzzComplex(const TypePtr& type, vector_size_t size);
+  // Returns a complex vector with randomized data and nulls.  The children and
+  // all other descendant vectors will randomly use constant, dictionary, or
+  // flat encodings if flatEncoding is set to false, otherwise they will all be
+  // flat.
+  VectorPtr fuzzComplex(
+      const TypePtr& type,
+      vector_size_t size,
+      bool flatEncoding = false);
 
-  RowVectorPtr
-  fuzzRow(const RowTypePtr& rowType, vector_size_t size, bool rowHasNulls);
+  RowVectorPtr fuzzRow(
+      const RowTypePtr& rowType,
+      vector_size_t size,
+      bool rowHasNulls,
+      bool flatEncoding = false);
 
   // Generate a random null vector.
   BufferPtr fuzzNulls(vector_size_t size);


### PR DESCRIPTION
Summary:
Today fuzzFlat does not support Complex types, only scalars.

I would like to extend this function to support Complex types by return a ComplexVector (ComplexVectors are the "flat" equivalent of FlatVectors for scalars) where any descendant Vectors are flat.

This has value for cases where we don't want any encodings, and is impossible today with VectorFuzzer without manually constructing the tree of Vectors (fuzzComplex will randomly use Constant/Dictionary/Flat encoding for descendants).

This isn't as applicable to Dictionary encoding (fuzzDictionary takes a Vector and wraps it in a dictionary, rather than constructing a Vector from whole cloth), or Constant encoding (a Constant ComplexVector with Constant descendants would be a strange use case).

Reviewed By: pedroerp

Differential Revision: D37890376

