### PR TITLE
Add TPC-H query 8 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -162,6 +162,11 @@ BENCHMARK(q6) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q8) {
+  const auto planContext = queryBuilder->getQueryPlan(8);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q9) {
   const auto planContext = queryBuilder->getQueryPlan(9);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
@@ -185,6 +185,11 @@ TEST_F(ParquetTpchTest, Q6) {
   assertQuery(6);
 }
 
+TEST_F(ParquetTpchTest, Q8) {
+  std::vector<uint32_t> sortingKeys{0};
+  assertQuery(8, std::move(sortingKeys));
+}
+
 TEST_F(ParquetTpchTest, Q9) {
   std::vector<uint32_t> sortingKeys{0, 1};
   assertQuery(9, std::move(sortingKeys));

--- a/velox/dwio/parquet/tests/reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTpchTest.cpp
@@ -193,6 +193,11 @@ TEST_F(ParquetTpchTest, Q6) {
   assertQuery(6);
 }
 
+TEST_F(ParquetTpchTest, Q8) {
+  std::vector<uint32_t> sortingKeys{0};
+  assertQuery(8, std::move(sortingKeys));
+}
+
 TEST_F(ParquetTpchTest, Q9) {
   std::vector<uint32_t> sortingKeys{0, 1};
   assertQuery(9, std::move(sortingKeys));

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -127,6 +127,8 @@ TpchPlan TpchQueryBuilder::getQueryPlan(int queryId) const {
       return getQ5Plan();
     case 6:
       return getQ6Plan();
+    case 8:
+      return getQ8Plan();
     case 9:
       return getQ9Plan();
     case 10:
@@ -452,6 +454,184 @@ TpchPlan TpchQueryBuilder::getQ6Plan() const {
   TpchPlan context;
   context.plan = std::move(plan);
   context.dataFiles[lineitemPlanNodeId] = getTableFilePaths(kLineitem);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+TpchPlan TpchQueryBuilder::getQ8Plan() const {
+  std::vector<std::string> partColumns = {"p_partkey", "p_type"};
+  std::vector<std::string> supplierColumns = {"s_suppkey", "s_nationkey"};
+  std::vector<std::string> lineitemColumns = {
+      "l_suppkey", "l_orderkey", "l_partkey", "l_extendedprice", "l_discount"};
+  std::vector<std::string> ordersColumns = {
+      "o_orderdate", "o_orderkey", "o_custkey"};
+  std::vector<std::string> customerColumns = {"c_nationkey", "c_custkey"};
+  std::vector<std::string> nationColumns = {"n_nationkey", "n_regionkey"};
+  std::vector<std::string> nationColumnsWithName = {
+      "n_name", "n_nationkey", "n_regionkey"};
+  std::vector<std::string> regionColumns = {"r_name", "r_regionkey"};
+
+  auto partSelectedRowType = getRowType(kPart, partColumns);
+  const auto& partFileColumns = getFileColumnNames(kPart);
+  auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+  const auto lineitemSelectedRowType = getRowType(kLineitem, lineitemColumns);
+  const auto& lineitemFileColumns = getFileColumnNames(kLineitem);
+  const auto ordersSelectedRowType = getRowType(kOrders, ordersColumns);
+  const auto& ordersFileColumns = getFileColumnNames(kOrders);
+  const auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
+  const auto& customerFileColumns = getFileColumnNames(kCustomer);
+  const auto nationSelectedRowType = getRowType(kNation, nationColumns);
+  const auto& nationFileColumns = getFileColumnNames(kNation);
+  const auto nationSelectedRowTypeWithName =
+      getRowType(kNation, nationColumnsWithName);
+  const auto& nationFileColumnsWithName = getFileColumnNames(kNation);
+  const auto regionSelectedRowType = getRowType(kRegion, regionColumns);
+  const auto& regionFileColumns = getFileColumnNames(kRegion);
+
+  const auto orderDateFilter = formatDateFilter(
+      "o_orderdate", ordersSelectedRowType, "'1995-01-01'", "'1996-12-31'");
+
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  core::PlanNodeId partScanNodeId;
+  core::PlanNodeId supplierScanNodeId;
+  core::PlanNodeId lineitemScanNodeId;
+  core::PlanNodeId ordersScanNodeId;
+  core::PlanNodeId customerScanNodeId;
+  core::PlanNodeId nationScanNodeId;
+  core::PlanNodeId nationScanNodeIdWithName;
+  core::PlanNodeId regionScanNodeId;
+
+  auto nationWithName =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kNation, nationSelectedRowTypeWithName, nationFileColumnsWithName)
+          .capturePlanNodeId(nationScanNodeIdWithName)
+          .planNode();
+
+  auto region = PlanBuilder(planNodeIdGenerator)
+                    .tableScan(
+                        kRegion,
+                        regionSelectedRowType,
+                        regionFileColumns,
+                        {"r_name = 'AMERICA'"})
+                    .capturePlanNodeId(regionScanNodeId)
+                    .planNode();
+
+  auto part = PlanBuilder(planNodeIdGenerator)
+                  .tableScan(
+                      kPart,
+                      partSelectedRowType,
+                      partFileColumns,
+                      {"p_type = 'ECONOMY ANODIZED STEEL'"})
+                  .capturePlanNodeId(partScanNodeId)
+                  .planNode();
+
+  auto nationJoinRegion =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kNation, nationSelectedRowType, nationFileColumns)
+          .capturePlanNodeId(nationScanNodeId)
+          .hashJoin(
+              {"n_regionkey"}, {"r_regionkey"}, region, "", {"n_nationkey"})
+          .planNode();
+
+  auto customerJoinNationJoinRegion =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kCustomer, customerSelectedRowType, customerFileColumns)
+          .capturePlanNodeId(customerScanNodeId)
+          .hashJoin(
+              {"c_nationkey"},
+              {"n_nationkey"},
+              nationJoinRegion,
+              "",
+              {"c_custkey"})
+          .planNode();
+
+  auto ordersJoinCustomerJoinNationJoinRegion =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kOrders,
+              ordersSelectedRowType,
+              ordersFileColumns,
+              {orderDateFilter})
+          .capturePlanNodeId(ordersScanNodeId)
+          .hashJoin(
+              {"o_custkey"},
+              {"c_custkey"},
+              customerJoinNationJoinRegion,
+              "",
+              {"o_orderkey", "o_orderdate"})
+          .planNode();
+
+  auto supplierJoinNation =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kSupplier, supplierSelectedRowType, supplierFileColumns)
+          .capturePlanNodeId(supplierScanNodeId)
+          .hashJoin(
+              {"s_nationkey"},
+              {"n_nationkey"},
+              nationWithName,
+              "",
+              {"s_suppkey", "n_name"})
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineitem, lineitemSelectedRowType, lineitemFileColumns)
+          .capturePlanNodeId(lineitemScanNodeId)
+          .hashJoin(
+              {"l_orderkey"},
+              {"o_orderkey"},
+              ordersJoinCustomerJoinNationJoinRegion,
+              "",
+              {"l_partkey",
+               "l_suppkey",
+               "o_orderdate",
+               "l_extendedprice",
+               "l_discount"})
+          .hashJoin(
+              {"l_suppkey"},
+              {"s_suppkey"},
+              supplierJoinNation,
+              "",
+              {"n_name",
+               "o_orderdate",
+               "l_partkey",
+               "l_extendedprice",
+               "l_discount"})
+          .hashJoin(
+              {"l_partkey"},
+              {"p_partkey"},
+              part,
+              "",
+              {"n_name", "o_orderdate", "l_extendedprice", "l_discount"})
+          .project(
+              {"l_extendedprice * (1.0 - l_discount) as volume",
+               "n_name",
+               "o_orderdate"})
+          .project(
+              {"volume",
+               "(CASE WHEN n_name = 'BRAZIL' THEN volume ELSE 0.0 END) as brazil_volume",
+               "year(o_orderdate) AS o_year"})
+          .partialAggregation(
+              {"o_year"},
+              {"sum(brazil_volume) as volume_num", "sum(volume) as volume_den"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"o_year"}, false)
+          .project({"o_year", "(volume_num / volume_den) as mkt_share"})
+          .planNode();
+
+  TpchPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[partScanNodeId] = getTableFilePaths(kPart);
+  context.dataFiles[supplierScanNodeId] = getTableFilePaths(kSupplier);
+  context.dataFiles[lineitemScanNodeId] = getTableFilePaths(kLineitem);
+  context.dataFiles[ordersScanNodeId] = getTableFilePaths(kOrders);
+  context.dataFiles[customerScanNodeId] = getTableFilePaths(kCustomer);
+  context.dataFiles[nationScanNodeId] = getTableFilePaths(kNation);
+  context.dataFiles[nationScanNodeIdWithName] = getTableFilePaths(kNation);
+  context.dataFiles[regionScanNodeId] = getTableFilePaths(kRegion);
   context.dataFileFormat = format_;
   return context;
 }

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -615,11 +615,12 @@ TpchPlan TpchQueryBuilder::getQ8Plan() const {
                "year(o_orderdate) AS o_year"})
           .partialAggregation(
               {"o_year"},
-              {"sum(brazil_volume) as volume_num", "sum(volume) as volume_den"})
+              {"sum(brazil_volume) as volume_brazil",
+               "sum(volume) as volume_all"})
           .localPartition({})
           .finalAggregation()
           .orderBy({"o_year"}, false)
-          .project({"o_year", "(volume_num / volume_den) as mkt_share"})
+          .project({"o_year", "(volume_brazil / volume_all) as mkt_share"})
           .planNode();
 
   TpchPlan context;

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -80,6 +80,7 @@ class TpchQueryBuilder {
   TpchPlan getQ3Plan() const;
   TpchPlan getQ5Plan() const;
   TpchPlan getQ6Plan() const;
+  TpchPlan getQ8Plan() const;
   TpchPlan getQ9Plan() const;
   TpchPlan getQ10Plan() const;
   TpchPlan getQ12Plan() const;


### PR DESCRIPTION
Adds TPC-H query 8 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 8.
```
| # Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds) |
|:----------------------:|:--------------:|:---------------:|
|            1           |      14.88     |      19.65      |
|            4           |      3.74      |       5.24      |
|            8           |      2.66      |       3.03      |
|           16           |      2.70      |       2.42      |
```
Query plan with stats (8 drivers):
```
Execution time: 3.52s
Splits total: 430, finished: 430
-- Project[expressions: (o_year:VARCHAR, ROW["o_year"]), (mkt_share:DOUBLE, divide(ROW["volume_brazil"],ROW["volume_all"]))] -> o_year:VARCHAR, mkt_share:DOUBLE
   Output: 2 rows (96B, 1 batches), Cpu time: 124.00us, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 2, Threads: 1
  -- OrderBy[o_year ASC NULLS LAST] -> o_year:VARCHAR, volume_brazil:DOUBLE, volume_all:DOUBLE
     Output: 2 rows (160B, 1 batches), Cpu time: 159.00us, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 6, Threads: 1
    -- Aggregation[FINAL [o_year] volume_brazil := sum("volume_brazil"), volume_all := sum("volume_all")] -> o_year:VARCHAR, volume_brazil:DOUBLE, volume_all:DOUBLE
       Output: 2 rows (47.72KB, 1 batches), Cpu time: 4.33ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 5, Threads: 1
      -- LocalPartition[GATHER] -> o_year:VARCHAR, volume_brazil:DOUBLE, volume_all:DOUBLE
         Output: 32 rows (763.50KB, 8 batches), Cpu time: 1.73ms, Blocked wall time: 6.56s, Peak memory: 0B, Memory allocations: 0
         LocalPartition: Input: 16 rows (381.75KB, 8 batches), Output: 16 rows (381.75KB, 0 batches), Cpu time: 1.20ms, Blocked wall time: 3.05s, Peak memory: 0B, Memory allocations: 0, Threads: 8
            queuedWallNanos    sum: 8.06ms, count: 16, min: 76.00us, max: 2.85ms
         LocalExchange: Input: 16 rows (381.75KB, 0 batches), Output: 16 rows (381.75KB, 8 batches), Cpu time: 537.00us, Blocked wall time: 3.51s, Peak memory: 0B, Memory allocations: 0, Threads: 1
            queuedWallNanos    sum: 4.14ms, count: 8, min: 38.00us, max: 3.62ms
        -- Aggregation[PARTIAL [o_year] volume_brazil := sum(ROW["brazil_volume"]), volume_all := sum(ROW["volume"])] -> o_year:VARCHAR, volume_brazil:DOUBLE, volume_all:DOUBLE
           Output: 16 rows (381.75KB, 8 batches), Cpu time: 75.84ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 64, Threads: 8
          -- Project[expressions: (volume:DOUBLE, ROW["volume"]), (brazil_volume:DOUBLE, if(eq(ROW["n_name"],"BRAZIL"),ROW["volume"],"0")), (o_year:VARCHAR, substr(ROW["o_orderdate"],1,4))] -> volume:DOUBLE, brazil_volume:DOUBLE, o_year:VARCHAR
             Output: 24254 rows (1.10MB, 5901 batches), Cpu time: 185.65ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 18, Threads: 8
            -- Project[expressions: (volume:DOUBLE, multiply(ROW["l_extendedprice"],minus(1,ROW["l_discount"]))), (n_name:VARCHAR, ROW["n_name"]), (o_orderdate:VARCHAR, ROW["o_orderdate"])] -> volume:DOUBLE, n_name:VARCHAR, o_orderdate:VARCHAR
               Output: 24254 rows (77.48MB, 5901 batches), Cpu time: 163.02ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 6666, Threads: 8
              -- HashJoin[INNER l_partkey=p_partkey] -> n_name:VARCHAR, o_orderdate:VARCHAR, l_extendedprice:DOUBLE, l_discount:DOUBLE
                 Output: 24254 rows (77.72MB, 5901 batches), Cpu time: 115.04ms, Blocked wall time: 1.82s, Peak memory: 16.00MB, Memory allocations: 21
                 HashBuild: Input: 13452 rows (744.85KB, 205 batches), Output: 0 rows (0B, 0 batches), Cpu time: 29.03ms, Blocked wall time: 86.94ms, Peak memory: 16.00MB, Memory allocations: 21, Threads: 8
                    distinctKey0       sum: 13453, count: 1, min: 13453, max: 13453
                    queuedWallNanos    sum: 10.01ms, count: 15, min: 28.00us, max: 1.23ms
                    rangeKey0          sum: 1999807, count: 1, min: 1999807, max: 1999807
                 HashProbe: Input: 24254 rows (111.45MB, 5901 batches), Output: 24254 rows (77.72MB, 5901 batches), Cpu time: 86.01ms, Blocked wall time: 1.73s, Peak memory: 0B, Memory allocations: 0, Threads: 8
                    dynamicFiltersProduced           sum: 8, count: 8, min: 1, max: 1
                    queuedWallNanos                  sum: 29.84ms, count: 8, min: 23.00us, max: 7.41ms
                    replacedWithDynamicFilterRows    sum: 24254, count: 5901, min: 1, max: 14
                -- HashJoin[INNER l_suppkey=s_suppkey] -> n_name:VARCHAR, o_orderdate:VARCHAR, l_partkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
                   Output: 24254 rows (111.45MB, 5901 batches), Cpu time: 205.67ms, Blocked wall time: 11.41ms, Peak memory: 4.00MB, Memory allocations: 7208
                   HashBuild: Input: 100000 rows (8.25MB, 104 batches), Output: 0 rows (0B, 0 batches), Cpu time: 60.67ms, Blocked wall time: 11.41ms, Peak memory: 3.00MB, Memory allocations: 76, Threads: 8
                      distinctKey0       sum: 100001, count: 1, min: 100001, max: 100001
                      queuedWallNanos    sum: 577.61ms, count: 15, min: 514.00us, max: 82.46ms
                      rangeKey0          sum: 100001, count: 1, min: 100001, max: 100001
                   HashProbe: Input: 24254 rows (34.99MB, 5901 batches), Output: 24254 rows (111.45MB, 5901 batches), Cpu time: 144.99ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 7132, Threads: 8
                      dynamicFiltersProduced    sum: 8, count: 8, min: 1, max: 1
                  -- HashJoin[INNER l_orderkey=o_orderkey] -> l_partkey:BIGINT, l_suppkey:BIGINT, o_orderdate:VARCHAR, l_extendedprice:DOUBLE, l_discount:DOUBLE
                     Output: 24254 rows (34.99MB, 5901 batches), Cpu time: 530.47ms, Blocked wall time: 4.95s, Peak memory: 16.00MB, Memory allocations: 12248
                     HashBuild: Input: 910360 rows (44.05MB, 1504 batches), Output: 0 rows (0B, 0 batches), Cpu time: 344.17ms, Blocked wall time: 173.82ms, Peak memory: 15.00MB, Memory allocations: 630, Threads: 8
                        queuedWallNanos    sum: 9.61ms, count: 15, min: 77.00us, max: 1.13ms
                        rangeKey0          sum: 59999939, count: 1, min: 59999939, max: 59999939
                     HashProbe: Input: 403487 rows (578.21MB, 6005 batches), Output: 24254 rows (34.99MB, 5901 batches), Cpu time: 186.29ms, Blocked wall time: 4.77s, Peak memory: 1.00MB, Memory allocations: 11618, Threads: 8
                        queuedWallNanos    sum: 339.00us, count: 8, min: 23.00us, max: 78.00us
                    -- TableScan[table: lineitem] -> l_suppkey:BIGINT, l_orderkey:BIGINT, l_partkey:BIGINT, l_extendedprice:DOUBLE, l_discount:DOUBLE
                       Input: 403487 rows (578.22MB, 0 batches), Raw Input: 59986052 rows (748.31MB), Output: 403487 rows (578.21MB, 6005 batches), Cpu time: 8.56s, Blocked wall time: 0ns, Peak memory: 60.00MB, Memory allocations: 66013, Threads: 8, Splits: 80
                          dataSourceWallNanos       sum: 16.08s, count: 6090, min: 12.00us, max: 647.70ms
                          dynamicFiltersAccepted    sum: 16, count: 16, min: 1, max: 1
                          localReadBytes            sum: 0B, count: 8, min: 0B, max: 0B
                          numLocalRead              sum: 0, count: 8, min: 0, max: 0
                          numPrefetch               sum: 0, count: 8, min: 0, max: 0
                          numRamRead                sum: 0, count: 8, min: 0, max: 0
                          numStorageRead            sum: 0, count: 8, min: 0, max: 0
                          prefetchBytes             sum: 0B, count: 8, min: 0B, max: 0B
                          ramReadBytes              sum: 0B, count: 8, min: 0B, max: 0B
                          skippedSplitBytes         sum: 0B, count: 8, min: 0B, max: 0B
                          skippedSplits             sum: 0, count: 8, min: 0, max: 0
                          skippedStrides            sum: 0, count: 8, min: 0, max: 0
                          storageReadBytes          sum: 0B, count: 8, min: 0B, max: 0B
                    -- HashJoin[INNER o_custkey=c_custkey] -> o_orderkey:BIGINT, o_orderdate:VARCHAR
                       Output: 910360 rows (44.05MB, 1504 batches), Cpu time: 123.89ms, Blocked wall time: 2.23s, Peak memory: 13.00MB, Memory allocations: 118
                       HashBuild: Input: 299436 rows (2.54MB, 153 batches), Output: 0 rows (0B, 0 batches), Cpu time: 98.66ms, Blocked wall time: 75.75ms, Peak memory: 13.00MB, Memory allocations: 118, Threads: 8
                          distinctKey0       sum: 299437, count: 1, min: 299437, max: 299437
                          queuedWallNanos    sum: 2.99ms, count: 15, min: 22.00us, max: 365.00us
                          rangeKey0          sum: 1499999, count: 1, min: 1499999, max: 1499999
                       HashProbe: Input: 910360 rows (173.26MB, 1504 batches), Output: 910360 rows (44.05MB, 1504 batches), Cpu time: 25.23ms, Blocked wall time: 2.15s, Peak memory: 0B, Memory allocations: 0, Threads: 8
                          dynamicFiltersProduced           sum: 8, count: 8, min: 1, max: 1
                          queuedWallNanos                  sum: 219.00us, count: 8, min: 21.00us, max: 43.00us
                          replacedWithDynamicFilterRows    sum: 910360, count: 1504, min: 17, max: 691
                      -- TableScan[table: orders, range filters: [(orderdate, BytesRange: [1995-01-01, 1996-12-31] no nulls)]] -> o_orderdate:VARCHAR, o_orderkey:BIGINT, o_custkey:BIGINT
                         Input: 910360 rows (354.21MB, 0 batches), Raw Input: 15000000 rows (169.66MB), Output: 910360 rows (173.26MB, 1504 batches), Cpu time: 1.53s, Blocked wall time: 0ns, Peak memory: 13.00MB, Memory allocations: 9218, Threads: 8, Splits: 80
                            dataSourceWallNanos       sum: 2.84s, count: 1585, min: 5.00us, max: 184.60ms
                            dynamicFiltersAccepted    sum: 8, count: 8, min: 1, max: 1
                            localReadBytes            sum: 0B, count: 8, min: 0B, max: 0B
                            numLocalRead              sum: 0, count: 8, min: 0, max: 0
                            numPrefetch               sum: 0, count: 8, min: 0, max: 0
                            numRamRead                sum: 0, count: 8, min: 0, max: 0
                            numStorageRead            sum: 0, count: 8, min: 0, max: 0
                            prefetchBytes             sum: 0B, count: 8, min: 0B, max: 0B
                            ramReadBytes              sum: 0B, count: 8, min: 0B, max: 0B
                            skippedSplitBytes         sum: 0B, count: 8, min: 0B, max: 0B
                            skippedSplits             sum: 0, count: 8, min: 0, max: 0
                            skippedStrides            sum: 0, count: 8, min: 0, max: 0
                            storageReadBytes          sum: 0B, count: 8, min: 0B, max: 0B
                      -- HashJoin[INNER c_nationkey=n_nationkey] -> c_custkey:BIGINT
                         Output: 299436 rows (2.54MB, 153 batches), Cpu time: 3.54ms, Blocked wall time: 40.89ms, Peak memory: 1.00MB, Memory allocations: 2
                         HashBuild: Input: 5 rows (96B, 1 batches), Output: 0 rows (0B, 0 batches), Cpu time: 467.00us, Blocked wall time: 5.71ms, Peak memory: 1.00MB, Memory allocations: 2, Threads: 8
                            distinctKey0       sum: 6, count: 1, min: 6, max: 6
                            queuedWallNanos    sum: 611.77ms, count: 15, min: 380.00us, max: 87.05ms
                            rangeKey0          sum: 25, count: 1, min: 25, max: 25
                         HashProbe: Input: 299436 rows (16.57MB, 153 batches), Output: 299436 rows (2.54MB, 153 batches), Cpu time: 3.07ms, Blocked wall time: 35.18ms, Peak memory: 0B, Memory allocations: 0, Threads: 8
                            dynamicFiltersProduced           sum: 8, count: 8, min: 1, max: 1
                            queuedWallNanos                  sum: 1.03s, count: 8, min: 87.03ms, max: 160.44ms
                            replacedWithDynamicFilterRows    sum: 299436, count: 153, min: 306, max: 2081
                        -- TableScan[table: customer] -> c_nationkey:BIGINT, c_custkey:BIGINT
                           Input: 299436 rows (16.57MB, 0 batches), Raw Input: 1500000 rows (153.04MB), Output: 299436 rows (16.57MB, 153 batches), Cpu time: 282.09ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 773, Threads: 8, Splits: 80
                              dataSourceWallNanos       sum: 134.13ms, count: 233, min: 8.00us, max: 6.70ms
                              dynamicFiltersAccepted    sum: 8, count: 8, min: 1, max: 1
                              localReadBytes            sum: 0B, count: 8, min: 0B, max: 0B
                              numLocalRead              sum: 0, count: 8, min: 0, max: 0
                              numPrefetch               sum: 0, count: 8, min: 0, max: 0
                              numRamRead                sum: 0, count: 8, min: 0, max: 0
                              numStorageRead            sum: 0, count: 8, min: 0, max: 0
                              prefetchBytes             sum: 0B, count: 8, min: 0B, max: 0B
                              ramReadBytes              sum: 0B, count: 8, min: 0B, max: 0B
                              skippedSplitBytes         sum: 0B, count: 8, min: 0B, max: 0B
                              skippedSplits             sum: 0, count: 8, min: 0, max: 0
                              skippedStrides            sum: 0, count: 8, min: 0, max: 0
                              storageReadBytes          sum: 0B, count: 8, min: 0B, max: 0B
                        -- HashJoin[INNER n_regionkey=r_regionkey] -> n_nationkey:BIGINT
                           Output: 5 rows (96B, 1 batches), Cpu time: 710.00us, Blocked wall time: 14.64ms, Peak memory: 1.00MB, Memory allocations: 2
                           HashBuild: Input: 1 rows (256B, 1 batches), Output: 0 rows (0B, 0 batches), Cpu time: 551.00us, Blocked wall time: 3.26ms, Peak memory: 1.00MB, Memory allocations: 2, Threads: 8
                              distinctKey0       sum: 2, count: 1, min: 2, max: 2
                              queuedWallNanos    sum: 4.79ms, count: 15, min: 93.00us, max: 491.00us
                              rangeKey0          sum: 2, count: 1, min: 2, max: 2
                           HashProbe: Input: 5 rows (384B, 1 batches), Output: 5 rows (96B, 1 batches), Cpu time: 159.00us, Blocked wall time: 11.38ms, Peak memory: 0B, Memory allocations: 0, Threads: 8
                              dynamicFiltersProduced           sum: 8, count: 8, min: 1, max: 1
                              queuedWallNanos                  sum: 10.39ms, count: 8, min: 179.00us, max: 2.28ms
                              replacedWithDynamicFilterRows    sum: 5, count: 1, min: 5, max: 5
                          -- TableScan[table: nation] -> n_nationkey:BIGINT, n_regionkey:BIGINT
                             Input: 5 rows (384B, 0 batches), Raw Input: 25 rows (21.80KB), Output: 5 rows (384B, 1 batches), Cpu time: 1.39ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 25, Threads: 8, Splits: 10
                                dataSourceWallNanos       sum: 186.00us, count: 11, min: 5.00us, max: 105.00us
                                dynamicFiltersAccepted    sum: 8, count: 8, min: 1, max: 1
                                localReadBytes            sum: 0B, count: 3, min: 0B, max: 0B
                                numLocalRead              sum: 0, count: 3, min: 0, max: 0
                                numPrefetch               sum: 0, count: 3, min: 0, max: 0
                                numRamRead                sum: 0, count: 3, min: 0, max: 0
                                numStorageRead            sum: 0, count: 3, min: 0, max: 0
                                prefetchBytes             sum: 0B, count: 3, min: 0B, max: 0B
                                ramReadBytes              sum: 0B, count: 3, min: 0B, max: 0B
                                skippedSplitBytes         sum: 0B, count: 3, min: 0B, max: 0B
                                skippedSplits             sum: 0, count: 3, min: 0, max: 0
                                skippedStrides            sum: 0, count: 3, min: 0, max: 0
                                storageReadBytes          sum: 0B, count: 3, min: 0B, max: 0B
                          -- TableScan[table: region, range filters: [(name, Filter(BytesValues, deterministic, null not allowed))]] -> r_name:VARCHAR, r_regionkey:BIGINT
                             Input: 1 rows (256B, 0 batches), Raw Input: 5 rows (11.49KB), Output: 1 rows (256B, 1 batches), Cpu time: 1.97ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 36, Threads: 8, Splits: 10
                                dataSourceWallNanos    sum: 412.00us, count: 11, min: 6.00us, max: 211.00us
                                localReadBytes         sum: 0B, count: 8, min: 0B, max: 0B
                                numLocalRead           sum: 0, count: 8, min: 0, max: 0
                                numPrefetch            sum: 0, count: 8, min: 0, max: 0
                                numRamRead             sum: 0, count: 8, min: 0, max: 0
                                numStorageRead         sum: 0, count: 8, min: 0, max: 0
                                prefetchBytes          sum: 0B, count: 8, min: 0B, max: 0B
                                ramReadBytes           sum: 0B, count: 8, min: 0B, max: 0B
                                skippedSplitBytes      sum: 0B, count: 8, min: 0B, max: 0B
                                skippedSplits          sum: 0, count: 8, min: 0, max: 0
                                skippedStrides         sum: 0, count: 8, min: 0, max: 0
                                storageReadBytes       sum: 0B, count: 8, min: 0B, max: 0B
                  -- HashJoin[INNER s_nationkey=n_nationkey] -> s_suppkey:BIGINT, n_name:VARCHAR
                     Output: 100000 rows (8.25MB, 104 batches), Cpu time: 10.22ms, Blocked wall time: 25.20ms, Peak memory: 2.00MB, Memory allocations: 119
                     HashBuild: Input: 25 rows (25.12KB, 1 batches), Output: 0 rows (0B, 0 batches), Cpu time: 537.00us, Blocked wall time: 5.40ms, Peak memory: 1.00MB, Memory allocations: 3, Threads: 8
                        distinctKey0       sum: 26, count: 1, min: 26, max: 26
                        queuedWallNanos    sum: 19.90ms, count: 15, min: 590.00us, max: 2.10ms
                        rangeKey0          sum: 26, count: 1, min: 26, max: 26
                     HashProbe: Input: 100000 rows (1.90MB, 13 batches), Output: 100000 rows (8.25MB, 104 batches), Cpu time: 9.68ms, Blocked wall time: 19.80ms, Peak memory: 1.00MB, Memory allocations: 116, Threads: 8
                        dynamicFiltersProduced    sum: 8, count: 8, min: 1, max: 1
                        queuedWallNanos           sum: 358.07ms, count: 8, min: 1.24ms, max: 88.03ms
                    -- TableScan[table: supplier] -> s_suppkey:BIGINT, s_nationkey:BIGINT
                       Input: 100000 rows (1.90MB, 0 batches), Output: 100000 rows (1.90MB, 13 batches), Cpu time: 65.47ms, Blocked wall time: 0ns, Peak memory: 2.00MB, Memory allocations: 188, Threads: 8, Splits: 80
                          dataSourceWallNanos       sum: 30.11ms, count: 93, min: 6.00us, max: 6.14ms
                          dynamicFiltersAccepted    sum: 8, count: 8, min: 1, max: 1
                          localReadBytes            sum: 0B, count: 4, min: 0B, max: 0B
                          numLocalRead              sum: 0, count: 4, min: 0, max: 0
                          numPrefetch               sum: 0, count: 4, min: 0, max: 0
                          numRamRead                sum: 0, count: 4, min: 0, max: 0
                          numStorageRead            sum: 0, count: 4, min: 0, max: 0
                          prefetchBytes             sum: 0B, count: 4, min: 0B, max: 0B
                          ramReadBytes              sum: 0B, count: 4, min: 0B, max: 0B
                          skippedSplitBytes         sum: 0B, count: 4, min: 0B, max: 0B
                          skippedSplits             sum: 0, count: 4, min: 0, max: 0
                          skippedStrides            sum: 0, count: 4, min: 0, max: 0
                          storageReadBytes          sum: 0B, count: 4, min: 0B, max: 0B
                    -- TableScan[table: nation] -> n_name:VARCHAR, n_nationkey:BIGINT, n_regionkey:BIGINT
                       Input: 25 rows (25.12KB, 0 batches), Output: 25 rows (25.12KB, 1 batches), Cpu time: 1.49ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 41, Threads: 8, Splits: 10
                          dataSourceWallNanos    sum: 361.00us, count: 11, min: 6.00us, max: 200.00us
                          localReadBytes         sum: 0B, count: 6, min: 0B, max: 0B
                          numLocalRead           sum: 0, count: 6, min: 0, max: 0
                          numPrefetch            sum: 0, count: 6, min: 0, max: 0
                          numRamRead             sum: 0, count: 6, min: 0, max: 0
                          numStorageRead         sum: 0, count: 6, min: 0, max: 0
                          prefetchBytes          sum: 0B, count: 6, min: 0B, max: 0B
                          ramReadBytes           sum: 0B, count: 6, min: 0B, max: 0B
                          skippedSplitBytes      sum: 0B, count: 6, min: 0B, max: 0B
                          skippedSplits          sum: 0, count: 6, min: 0, max: 0
                          skippedStrides         sum: 0, count: 6, min: 0, max: 0
                          storageReadBytes       sum: 0B, count: 6, min: 0B, max: 0B
                -- TableScan[table: part, range filters: [(type, Filter(BytesValues, deterministic, null not allowed))]] -> p_partkey:BIGINT, p_type:VARCHAR
                   Input: 13452 rows (38.94MB, 0 batches), Raw Input: 2000000 rows (423.63MB), Output: 13452 rows (744.85KB, 205 batches), Cpu time: 504.51ms, Blocked wall time: 0ns, Peak memory: 2.00MB, Memory allocations: 993, Threads: 8, Splits: 80
                      dataSourceWallNanos    sum: 150.57ms, count: 285, min: 9.00us, max: 7.23ms
                      localReadBytes         sum: 0B, count: 8, min: 0B, max: 0B
                      numLocalRead           sum: 0, count: 8, min: 0, max: 0
                      numPrefetch            sum: 0, count: 8, min: 0, max: 0
                      numRamRead             sum: 0, count: 8, min: 0, max: 0
                      numStorageRead         sum: 0, count: 8, min: 0, max: 0
                      prefetchBytes          sum: 0B, count: 8, min: 0B, max: 0B
                      ramReadBytes           sum: 0B, count: 8, min: 0B, max: 0B
                      skippedSplitBytes      sum: 0B, count: 8, min: 0B, max: 0B
                      skippedSplits          sum: 0, count: 8, min: 0, max: 0
                      skippedStrides         sum: 0, count: 8, min: 0, max: 0
                      storageReadBytes       sum: 0B, count: 8, min: 0B, max: 0B
```