### PR TITLE
Add TPC-H query 7 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -162,6 +162,11 @@ BENCHMARK(q6) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q7) {
+  const auto planContext = queryBuilder->getQueryPlan(7);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q8) {
   const auto planContext = queryBuilder->getQueryPlan(8);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
@@ -185,6 +185,11 @@ TEST_F(ParquetTpchTest, Q6) {
   assertQuery(6);
 }
 
+TEST_F(ParquetTpchTest, Q7) {
+  std::vector<uint32_t> sortingKeys{0, 1, 2};
+  assertQuery(7, std::move(sortingKeys));
+}
+
 TEST_F(ParquetTpchTest, Q8) {
   std::vector<uint32_t> sortingKeys{0};
   assertQuery(8, std::move(sortingKeys));

--- a/velox/dwio/parquet/tests/reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTpchTest.cpp
@@ -193,6 +193,11 @@ TEST_F(ParquetTpchTest, Q6) {
   assertQuery(6);
 }
 
+TEST_F(ParquetTpchTest, Q7) {
+  std::vector<uint32_t> sortingKeys{0, 1, 2};
+  assertQuery(7, std::move(sortingKeys));
+}
+
 TEST_F(ParquetTpchTest, Q8) {
   std::vector<uint32_t> sortingKeys{0};
   assertQuery(8, std::move(sortingKeys));

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -80,6 +80,7 @@ class TpchQueryBuilder {
   TpchPlan getQ3Plan() const;
   TpchPlan getQ5Plan() const;
   TpchPlan getQ6Plan() const;
+  TpchPlan getQ7Plan() const;
   TpchPlan getQ8Plan() const;
   TpchPlan getQ9Plan() const;
   TpchPlan getQ10Plan() const;


### PR DESCRIPTION
Adds TPC-H query 7 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 7.
```
| # Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds) |
|:----------------------:|:--------------:|:---------------:|
|            1           |      13.41     |      21.62      |
|            4           |      3.70      |       3.86      |
|            8           |      2.48      |       2.89      |
|           16           |      2.51      |       2.59      |
```
Query plan with stats (for 8 drivers):
```
Execution time: 1.46s
Splits total: 340, finished: 340
-- OrderBy[supp_nation ASC NULLS LAST, cust_nation ASC NULLS LAST, l_year ASC NULLS LAST] -> supp_nation:VARCHAR, cust_nation:VARCHAR, l_year:VARCHAR, revenue:DOUBLE
   Output: 4 rows (352B, 1 batches), Cpu time: 110.00us, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 6, Threads: 1
  -- Aggregation[FINAL [supp_nation, cust_nation, l_year] revenue := sum("revenue")] -> supp_nation:VARCHAR, cust_nation:VARCHAR, l_year:VARCHAR, revenue:DOUBLE
     Output: 4 rows (83.62KB, 1 batches), Cpu time: 222.00us, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 6, Threads: 1
    -- LocalPartition[GATHER] -> supp_nation:VARCHAR, cust_nation:VARCHAR, l_year:VARCHAR, revenue:DOUBLE
       Output: 64 rows (1.31MB, 8 batches), Cpu time: 934.00us, Blocked wall time: 3.07s, Peak memory: 0B, Memory allocations: 0
       LocalPartition: Input: 32 rows (669.00KB, 8 batches), Output: 32 rows (669.00KB, 0 batches), Cpu time: 834.00us, Blocked wall time: 1.61s, Peak memory: 0B, Memory allocations: 0, Threads: 8
          queuedWallNanos    sum: 925.00us, count: 15, min: 18.00us, max: 99.00us
       LocalExchange: Input: 32 rows (669.00KB, 0 batches), Output: 32 rows (669.00KB, 8 batches), Cpu time: 100.00us, Blocked wall time: 1.46s, Peak memory: 0B, Memory allocations: 0, Threads: 1
          queuedWallNanos    sum: 356.00us, count: 9, min: 22.00us, max: 68.00us
      -- Aggregation[PARTIAL [supp_nation, cust_nation, l_year] revenue := sum(ROW["part_revenue"])] -> supp_nation:VARCHAR, cust_nation:VARCHAR, l_year:VARCHAR, revenue:DOUBLE
         Output: 32 rows (669.00KB, 8 batches), Cpu time: 74.78ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 80, Threads: 8
        -- Project[expressions: (cust_nation:VARCHAR, ROW["cust_nation"]), (supp_nation:VARCHAR, ROW["supp_nation"]), (part_revenue:DOUBLE, multiply(ROW["l_extendedprice"],minus(1,ROW["l_discount"]))), (l_year:VARCHAR, substr(ROW["l_shipdate"],1,4))] -> cust_nation:VARCHAR, supp_nation:VARCHAR, part_revenue:DOUBLE, l_year:VARCHAR
           Output: 58365 rows (5.86MB, 6002 batches), Cpu time: 242.36ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 11988, Threads: 8
          -- HashJoin[INNER l_orderkey=o_orderkey, filter: or(and(eq(ROW["cust_nation"],"FRANCE"),eq(ROW["supp_nation"],"GERMANY")),and(eq(ROW["cust_nation"],"GERMANY"),eq(ROW["supp_nation"],"FRANCE")))] -> supp_nation:VARCHAR, cust_nation:VARCHAR, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:VARCHAR
             Output: 58365 rows (6.69MB, 6002 batches), Cpu time: 634.32ms, Blocked wall time: 2.77s, Peak memory: 29.00MB, Memory allocations: 19038
             HashBuild: Input: 1205808 rows (34.88MB, 1505 batches), Output: 0 rows (0B, 0 batches), Cpu time: 296.86ms, Blocked wall time: 93.22ms, Peak memory: 28.00MB, Memory allocations: 832, Threads: 8
                queuedWallNanos    sum: 3.00ms, count: 15, min: 40.00us, max: 352.00us
                rangeKey0          sum: 59999935, count: 1, min: 59999935, max: 59999935
             HashProbe: Input: 1460257 rows (124.38MB, 6008 batches), Output: 58365 rows (6.69MB, 6002 batches), Cpu time: 337.46ms, Blocked wall time: 2.67s, Peak memory: 1.00MB, Memory allocations: 18206, Threads: 8
                queuedWallNanos    sum: 499.00us, count: 8, min: 52.00us, max: 89.00us
            -- HashJoin[INNER l_suppkey=s_suppkey] -> supp_nation:VARCHAR, l_extendedprice:DOUBLE, l_discount:DOUBLE, l_shipdate:VARCHAR, l_orderkey:BIGINT
               Output: 1460257 rows (124.38MB, 6008 batches), Cpu time: 206.21ms, Blocked wall time: 7.88ms, Peak memory: 2.00MB, Memory allocations: 12054
               HashBuild: Input: 8010 rows (265.56KB, 13 batches), Output: 0 rows (0B, 0 batches), Cpu time: 2.98ms, Blocked wall time: 7.88ms, Peak memory: 1.00MB, Memory allocations: 10, Threads: 8
                  distinctKey0       sum: 8011, count: 1, min: 8011, max: 8011
                  queuedWallNanos    sum: 2.16ms, count: 15, min: 28.00us, max: 230.00us
                  rangeKey0          sum: 99959, count: 1, min: 99959, max: 99959
               HashProbe: Input: 1460257 rows (659.47MB, 6008 batches), Output: 1460257 rows (124.38MB, 6008 batches), Cpu time: 203.23ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 12044, Threads: 8
                  dynamicFiltersProduced    sum: 8, count: 8, min: 1, max: 1
              -- TableScan[table: lineitem, range filters: [(shipdate, BytesRange: [1995-01-01, 1996-12-31] no nulls)]] -> l_shipdate:VARCHAR, l_suppkey:BIGINT, l_discount:DOUBLE, l_extendedprice:DOUBLE, l_orderkey:BIGINT
                 Input: 1460257 rows (1.23GB, 0 batches), Raw Input: 59986052 rows (631.03MB), Output: 1460257 rows (659.47MB, 6008 batches), Cpu time: 5.66s, Blocked wall time: 0ns, Peak memory: 48.00MB, Memory allocations: 72532, Threads: 8, Splits: 80
                    dataSourceWallNanos       sum: 5.92s, count: 6090, min: 9.00us, max: 70.64ms
                    dynamicFiltersAccepted    sum: 8, count: 8, min: 1, max: 1
                    localReadBytes            sum: 0B, count: 8, min: 0B, max: 0B
                    numLocalRead              sum: 0, count: 8, min: 0, max: 0
                    numPrefetch               sum: 0, count: 8, min: 0, max: 0
                    numRamRead                sum: 0, count: 8, min: 0, max: 0
                    numStorageRead            sum: 0, count: 8, min: 0, max: 0
                    prefetchBytes             sum: 0B, count: 8, min: 0B, max: 0B
                    ramReadBytes              sum: 0B, count: 8, min: 0B, max: 0B
                    skippedSplitBytes         sum: 0B, count: 8, min: 0B, max: 0B
                    skippedSplits             sum: 0, count: 8, min: 0, max: 0
                    skippedStrides            sum: 0, count: 8, min: 0, max: 0
                    storageReadBytes          sum: 0B, count: 8, min: 0B, max: 0B
              -- Project[expressions: (supp_nation:VARCHAR, ROW["n_name"]), (s_suppkey:BIGINT, ROW["s_suppkey"])] -> supp_nation:VARCHAR, s_suppkey:BIGINT
                 Output: 8010 rows (265.56KB, 13 batches), Cpu time: 384.00us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 8
                -- HashJoin[INNER s_nationkey=n_nationkey] -> n_name:VARCHAR, s_suppkey:BIGINT
                   Output: 8010 rows (265.56KB, 13 batches), Cpu time: 1.48ms, Blocked wall time: 9.58ms, Peak memory: 2.00MB, Memory allocations: 17
                   HashBuild: Input: 2 rows (768B, 1 batches), Output: 0 rows (0B, 0 batches), Cpu time: 646.00us, Blocked wall time: 1.49ms, Peak memory: 1.00MB, Memory allocations: 2, Threads: 8
                      distinctKey0       sum: 3, count: 1, min: 3, max: 3
                      queuedWallNanos    sum: 2.35ms, count: 15, min: 23.00us, max: 277.00us
                      rangeKey0          sum: 3, count: 1, min: 3, max: 3
                   HashProbe: Input: 8010 rows (1.02MB, 13 batches), Output: 8010 rows (265.56KB, 13 batches), Cpu time: 835.00us, Blocked wall time: 8.10ms, Peak memory: 1.00MB, Memory allocations: 15, Threads: 8
                      dynamicFiltersProduced    sum: 8, count: 8, min: 1, max: 1
                      queuedWallNanos           sum: 29.48ms, count: 8, min: 20.00us, max: 14.45ms
                  -- TableScan[table: supplier] -> s_nationkey:BIGINT, s_suppkey:BIGINT
                     Input: 8010 rows (1.02MB, 0 batches), Raw Input: 100000 rows (51.89MB), Output: 8010 rows (1.02MB, 13 batches), Cpu time: 49.97ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 197, Threads: 8, Splits: 80
                        dataSourceWallNanos       sum: 7.07ms, count: 93, min: 5.00us, max: 1.19ms
                        dynamicFiltersAccepted    sum: 8, count: 8, min: 1, max: 1
                        localReadBytes            sum: 0B, count: 6, min: 0B, max: 0B
                        numLocalRead              sum: 0, count: 6, min: 0, max: 0
                        numPrefetch               sum: 0, count: 6, min: 0, max: 0
                        numRamRead                sum: 0, count: 6, min: 0, max: 0
                        numStorageRead            sum: 0, count: 6, min: 0, max: 0
                        prefetchBytes             sum: 0B, count: 6, min: 0B, max: 0B
                        ramReadBytes              sum: 0B, count: 6, min: 0B, max: 0B
                        skippedSplitBytes         sum: 0B, count: 6, min: 0B, max: 0B
                        skippedSplits             sum: 0, count: 6, min: 0, max: 0
                        skippedStrides            sum: 0, count: 6, min: 0, max: 0
                        storageReadBytes          sum: 0B, count: 6, min: 0B, max: 0B
                  -- TableScan[table: nation, range filters: [(name, Filter(BytesValues, deterministic, null not allowed))]] -> n_nationkey:BIGINT, n_name:VARCHAR
                     Input: 2 rows (768B, 0 batches), Raw Input: 25 rows (21.69KB), Output: 2 rows (768B, 1 batches), Cpu time: 2.32ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 34, Threads: 8, Splits: 10
                        dataSourceWallNanos    sum: 387.00us, count: 11, min: 5.00us, max: 217.00us
                        localReadBytes         sum: 0B, count: 8, min: 0B, max: 0B
                        numLocalRead           sum: 0, count: 8, min: 0, max: 0
                        numPrefetch            sum: 0, count: 8, min: 0, max: 0
                        numRamRead             sum: 0, count: 8, min: 0, max: 0
                        numStorageRead         sum: 0, count: 8, min: 0, max: 0
                        prefetchBytes          sum: 0B, count: 8, min: 0B, max: 0B
                        ramReadBytes           sum: 0B, count: 8, min: 0B, max: 0B
                        skippedSplitBytes      sum: 0B, count: 8, min: 0B, max: 0B
                        skippedSplits          sum: 0, count: 8, min: 0, max: 0
                        skippedStrides         sum: 0, count: 8, min: 0, max: 0
                        storageReadBytes       sum: 0B, count: 8, min: 0B, max: 0B
            -- HashJoin[INNER o_custkey=c_custkey] -> cust_nation:VARCHAR, o_orderkey:BIGINT
               Output: 1205808 rows (34.88MB, 1505 batches), Cpu time: 154.09ms, Blocked wall time: 593.82ms, Peak memory: 14.00MB, Memory allocations: 111
               HashBuild: Input: 120469 rows (3.53MB, 153 batches), Output: 0 rows (0B, 0 batches), Cpu time: 36.73ms, Blocked wall time: 51.24ms, Peak memory: 13.00MB, Memory allocations: 87, Threads: 8
                  distinctKey0       sum: 120470, count: 1, min: 120470, max: 120470
                  queuedWallNanos    sum: 3.49ms, count: 15, min: 26.00us, max: 428.00us
                  rangeKey0          sum: 1499981, count: 1, min: 1499981, max: 1499981
               HashProbe: Input: 1205808 rows (152.00MB, 1505 batches), Output: 1205808 rows (34.88MB, 1505 batches), Cpu time: 117.37ms, Blocked wall time: 542.58ms, Peak memory: 1.00MB, Memory allocations: 24, Threads: 8
                  dynamicFiltersProduced    sum: 8, count: 8, min: 1, max: 1
                  queuedWallNanos           sum: 427.00us, count: 8, min: 44.00us, max: 62.00us
              -- TableScan[table: orders] -> o_custkey:BIGINT, o_orderkey:BIGINT
                 Input: 1205808 rows (152.00MB, 0 batches), Raw Input: 15000000 rows (148.27MB), Output: 1205808 rows (152.00MB, 1505 batches), Cpu time: 1.02s, Blocked wall time: 0ns, Peak memory: 10.00MB, Memory allocations: 6158, Threads: 8, Splits: 80
                    dataSourceWallNanos       sum: 974.57ms, count: 1585, min: 4.00us, max: 9.37ms
                    dynamicFiltersAccepted    sum: 8, count: 8, min: 1, max: 1
                    localReadBytes            sum: 0B, count: 8, min: 0B, max: 0B
                    numLocalRead              sum: 0, count: 8, min: 0, max: 0
                    numPrefetch               sum: 0, count: 8, min: 0, max: 0
                    numRamRead                sum: 0, count: 8, min: 0, max: 0
                    numStorageRead            sum: 0, count: 8, min: 0, max: 0
                    prefetchBytes             sum: 0B, count: 8, min: 0B, max: 0B
                    ramReadBytes              sum: 0B, count: 8, min: 0B, max: 0B
                    skippedSplitBytes         sum: 0B, count: 8, min: 0B, max: 0B
                    skippedSplits             sum: 0, count: 8, min: 0, max: 0
                    skippedStrides            sum: 0, count: 8, min: 0, max: 0
                    storageReadBytes          sum: 0B, count: 8, min: 0B, max: 0B
              -- Project[expressions: (cust_nation:VARCHAR, ROW["n_name"]), (c_custkey:BIGINT, ROW["c_custkey"])] -> cust_nation:VARCHAR, c_custkey:BIGINT
                 Output: 120469 rows (3.53MB, 153 batches), Cpu time: 2.27ms, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 8
                -- HashJoin[INNER c_nationkey=n_nationkey] -> n_name:VARCHAR, c_custkey:BIGINT
                   Output: 120469 rows (3.53MB, 153 batches), Cpu time: 7.33ms, Blocked wall time: 8.66ms, Peak memory: 2.00MB, Memory allocations: 23
                   HashBuild: Input: 2 rows (768B, 1 batches), Output: 0 rows (0B, 0 batches), Cpu time: 588.00us, Blocked wall time: 1.88ms, Peak memory: 1.00MB, Memory allocations: 2, Threads: 8
                      distinctKey0       sum: 3, count: 1, min: 3, max: 3
                      queuedWallNanos    sum: 4.77ms, count: 15, min: 13.00us, max: 714.00us
                      rangeKey0          sum: 3, count: 1, min: 3, max: 3
                   HashProbe: Input: 120469 rows (15.19MB, 153 batches), Output: 120469 rows (3.53MB, 153 batches), Cpu time: 6.74ms, Blocked wall time: 6.78ms, Peak memory: 1.00MB, Memory allocations: 21, Threads: 8
                      dynamicFiltersProduced    sum: 8, count: 8, min: 1, max: 1
                      queuedWallNanos           sum: 28.81ms, count: 8, min: 28.00us, max: 14.40ms
                  -- TableScan[table: customer] -> c_custkey:BIGINT, c_nationkey:BIGINT
                     Input: 120469 rows (15.19MB, 0 batches), Raw Input: 1500000 rows (153.04MB), Output: 120469 rows (15.19MB, 153 batches), Cpu time: 198.97ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 772, Threads: 8, Splits: 80
                        dataSourceWallNanos       sum: 61.73ms, count: 233, min: 4.00us, max: 2.43ms
                        dynamicFiltersAccepted    sum: 8, count: 8, min: 1, max: 1
                        localReadBytes            sum: 0B, count: 8, min: 0B, max: 0B
                        numLocalRead              sum: 0, count: 8, min: 0, max: 0
                        numPrefetch               sum: 0, count: 8, min: 0, max: 0
                        numRamRead                sum: 0, count: 8, min: 0, max: 0
                        numStorageRead            sum: 0, count: 8, min: 0, max: 0
                        prefetchBytes             sum: 0B, count: 8, min: 0B, max: 0B
                        ramReadBytes              sum: 0B, count: 8, min: 0B, max: 0B
                        skippedSplitBytes         sum: 0B, count: 8, min: 0B, max: 0B
                        skippedSplits             sum: 0, count: 8, min: 0, max: 0
                        skippedStrides            sum: 0, count: 8, min: 0, max: 0
                        storageReadBytes          sum: 0B, count: 8, min: 0B, max: 0B
                  -- TableScan[table: nation, range filters: [(name, Filter(BytesValues, deterministic, null not allowed))]] -> n_nationkey:BIGINT, n_name:VARCHAR
                     Input: 2 rows (768B, 0 batches), Raw Input: 25 rows (21.69KB), Output: 2 rows (768B, 1 batches), Cpu time: 1.19ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 28, Threads: 8, Splits: 10
                        dataSourceWallNanos    sum: 235.00us, count: 11, min: 5.00us, max: 143.00us
                        localReadBytes         sum: 0B, count: 5, min: 0B, max: 0B
                        numLocalRead           sum: 0, count: 5, min: 0, max: 0
                        numPrefetch            sum: 0, count: 5, min: 0, max: 0
                        numRamRead             sum: 0, count: 5, min: 0, max: 0
                        numStorageRead         sum: 0, count: 5, min: 0, max: 0
                        prefetchBytes          sum: 0B, count: 5, min: 0B, max: 0B
                        ramReadBytes           sum: 0B, count: 5, min: 0B, max: 0B
                        skippedSplitBytes      sum: 0B, count: 5, min: 0B, max: 0B
                        skippedSplits          sum: 0, count: 5, min: 0, max: 0
                        skippedStrides         sum: 0, count: 5, min: 0, max: 0
                        storageReadBytes       sum: 0B, count: 5, min: 0B, max: 0B
```