### PR TITLE
Fix "missing a nullability type specifier" build warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,6 @@ if("${ENABLE_ALL_WARNINGS}")
        -Wno-unused-parameter \
        -Wno-sign-compare \
        -Wno-ignored-qualifiers \
-       -Wno-nullability-completeness \
        ${KNOWN_COMPILER_SPECIFIC_WARNINGS}")
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra ${KNOWN_WARNINGS}")

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -192,7 +192,7 @@ class ScopedMemoryPool final : public MemoryPool {
     return pool_.reallocate(p, size, newSize);
   }
 
-  void free(void* p, int64_t size) override {
+  void free(void* FOLLY_NULLABLE p, int64_t size) override {
     return pool_.free(p, size);
   }
 

--- a/velox/common/time/Timer.h
+++ b/velox/common/time/Timer.h
@@ -40,7 +40,7 @@ class MicrosecondTimer {
 
  private:
   std::chrono::steady_clock::time_point start_;
-  uint64_t* timer_;
+  uint64_t* FOLLY_NONNULL timer_;
 };
 
 // Measures the time between construction and destruction with

--- a/velox/dwio/dwrf/reader/DwrfData.cpp
+++ b/velox/dwio/dwrf/reader/DwrfData.cpp
@@ -85,7 +85,7 @@ dwio::common::PositionProvider DwrfData::seekToRowGroup(uint32_t index) {
 
 void DwrfData::readNulls(
     vector_size_t numValues,
-    const uint64_t* incomingNulls,
+    const uint64_t* FOLLY_NULLABLE incomingNulls,
     BufferPtr& nulls) {
   if (!notNullDecoder_ && !incomingNulls) {
     nulls = nullptr;

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -40,7 +40,7 @@ class DwrfData : public dwio::common::FormatData {
 
   void readNulls(
       vector_size_t numValues,
-      const uint64_t* incomingNulls,
+      const uint64_t* FOLLY_NULLABLE incomingNulls,
       BufferPtr& nulls) override;
 
   uint64_t skipNulls(uint64_t numValues) override;


### PR DESCRIPTION
This PR fixes the "missing a nullability type specifier" warning thrown during the build process, so that the build messages get cleaner. The following message no longer appear after this fix:

```
In file included from /Users/yingsu/repo/velox1/velox/velox/functions/sparksql/tests/MapTest.cpp:17:
In file included from /Users/yingsu/repo/velox1/velox/./velox/functions/prestosql/tests/FunctionBaseTest.h:20:
In file included from /Users/yingsu/repo/velox1/velox/./velox/expression/Expr.h:24:
In file included from /Users/yingsu/repo/velox1/velox/./velox/core/Expressions.h:20:
In file included from /Users/yingsu/repo/velox1/velox/./velox/vector/BaseVector.h:29:
In file included from /Users/yingsu/repo/velox1/velox/./velox/buffer/Buffer.h:26:
/Users/yingsu/repo/velox1/velox/./velox/common/memory/Memory.h:185:17: warning: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Wnullability-completeness]
  void free(void* p, int64_t size) override {
                ^
/Users/yingsu/repo/velox1/velox/./velox/common/memory/Memory.h:185:17: note: insert '_Nullable' if the pointer may be null
  void free(void* p, int64_t size) override {
                ^
                  _Nullable
/Users/yingsu/repo/velox1/velox/./velox/common/memory/Memory.h:185:17: note: insert '_Nonnull' if the pointer should never be null
  void free(void* p, int64_t size) override {
                ^
                  _Nonnull
In file included from /Users/yingsu/repo/velox1/velox/velox/functions/sparksql/tests/MapTest.cpp:17:
In file included from /Users/yingsu/repo/velox1/velox/./velox/functions/prestosql/tests/FunctionBaseTest.h:20:
In file included from /Users/yingsu/repo/velox1/velox/./velox/expression/Expr.h:24:
In file included from /Users/yingsu/repo/velox1/velox/./velox/core/Expressions.h:20:
In file included from /Users/yingsu/repo/velox1/velox/./velox/vector/BaseVector.h:40:
In file included from /Users/yingsu/repo/velox1/velox/./velox/vector/VectorStream.h:19:
In file included from /Users/yingsu/repo/velox1/velox/./velox/common/memory/ByteStream.h:18:
In file included from /Users/yingsu/repo/velox1/velox/./velox/common/memory/StreamArena.h:17:
In file included from /Users/yingsu/repo/velox1/velox/./velox/common/memory/MappedMemory.h:29:
/Users/yingsu/repo/velox1/velox/./velox/common/time/Timer.h:43:11: warning: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Wnullability-completeness]
  uint64_t* timer_;
          ^
/Users/yingsu/repo/velox1/velox/./velox/common/time/Timer.h:43:11: note: insert '_Nullable' if the pointer may be null
  uint64_t* timer_;
          ^
            _Nullable
/Users/yingsu/repo/velox1/velox/./velox/common/time/Timer.h:43:11: note: insert '_Nonnull' if the pointer should never be null
  uint64_t* timer_;
          ^
            _Nonnull
2 warnings generated.
```

 