### PR TITLE
Upgrade FB_OS_VERSION to v2022.07.11.00

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ workflows:
 executors:
   build:
     docker:
-      - image : prestocpp/velox-avx-circleci:mikesh-20220628
+      - image : prestocpp/velox-avx-circleci:mikesh-20220717
     resource_class: 2xlarge
     environment:
         CC:  /opt/rh/gcc-toolset-9/root/bin/gcc

--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -67,7 +67,7 @@ wget_and_untar https://github.com/google/glog/archive/v0.4.0.tar.gz glog &
 wget_and_untar http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz lzo &
 wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz boost &
 wget_and_untar https://github.com/google/snappy/archive/1.1.8.tar.gz snappy &
-wget_and_untar https://github.com/facebook/folly/archive/v2022.03.14.00.tar.gz folly &
+wget_and_untar https://github.com/facebook/folly/archive/v2022.07.11.00.tar.gz folly &
 wget_and_untar https://github.com/fmtlib/fmt/archive/8.0.0.tar.gz fmt &
 #  wget_and_untar https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz ranges-v3 &
 wget_and_untar https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz hadoop

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -32,7 +32,7 @@ SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
 source $SCRIPTDIR/setup-helper-functions.sh
 
 CPU_TARGET="${CPU_TARGET:-avx}"
-FB_OS_VERSION=v2022.03.14.00
+FB_OS_VERSION=v2022.07.11.00
 NPROC=$(getconf _NPROCESSORS_ONLN)
 COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -22,7 +22,7 @@ source $SCRIPTDIR/setup-helper-functions.sh
 # are the same size.
 CPU_TARGET="${CPU_TARGET:-avx}"
 export COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
-FB_OS_VERSION=v2022.03.14.00
+FB_OS_VERSION=v2022.07.11.00
 NPROC=$(getconf _NPROCESSORS_ONLN)
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 

--- a/scripts/setup-velox-torcharrow.sh
+++ b/scripts/setup-velox-torcharrow.sh
@@ -77,7 +77,7 @@ function wget_and_untar {
 wget_and_untar https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz gflags
 wget_and_untar https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz openssl &
 wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz boost &
-wget_and_untar https://github.com/facebook/folly/archive/v2022.03.14.00.tar.gz folly &
+wget_and_untar https://github.com/facebook/folly/archive/v2022.07.11.00.tar.gz folly &
 
 wait
 


### PR DESCRIPTION
To fix an issue building fbthrift for presto_cpp https://github.com/facebook/fbthrift/pull/494