### PR TITLE
Add TPC-H query 22 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -186,6 +186,11 @@ BENCHMARK(q19) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q22) {
+  const auto planContext = queryBuilder->getQueryPlan(22);
+  benchmark.run(planContext);
+}
+
 int main(int argc, char** argv) {
   folly::init(&argc, &argv, false);
   benchmark.initialize();

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
@@ -208,6 +208,11 @@ TEST_F(ParquetTpchTest, Q19) {
   assertQuery(19);
 }
 
+TEST_F(ParquetTpchTest, Q22) {
+  std::vector<uint32_t> sortingKeys{0};
+  assertQuery(22, std::move(sortingKeys));
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   folly::init(&argc, &argv, false);

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -127,6 +127,8 @@ TpchPlan TpchQueryBuilder::getQueryPlan(int queryId) const {
       return getQ18Plan();
     case 19:
       return getQ19Plan();
+    case 22:
+      return getQ22Plan();
     default:
       VELOX_NYI("TPC-H query {} is not supported yet", queryId);
   }
@@ -897,6 +899,86 @@ TpchPlan TpchQueryBuilder::getQ19Plan() const {
   context.plan = std::move(plan);
   context.dataFiles[lineitemScanNodeId] = getTableFilePaths(kLineitem);
   context.dataFiles[partScanNodeId] = getTableFilePaths(kPart);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+TpchPlan TpchQueryBuilder::getQ22Plan() const {
+  std::vector<std::string> ordersColumns = {"o_custkey"};
+  std::vector<std::string> customerColumns = {"c_acctbal", "c_phone"};
+  std::vector<std::string> customerColumnsWithKey = {
+      "c_custkey", "c_acctbal", "c_phone"};
+
+  const auto ordersSelectedRowType = getRowType(kOrders, ordersColumns);
+  const auto& ordersFileColumns = getFileColumnNames(kOrders);
+  const auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
+  const auto& customerFileColumns = getFileColumnNames(kCustomer);
+  const auto customerSelectedRowTypeWithKey =
+      getRowType(kCustomer, customerColumnsWithKey);
+  const auto& customerFileColumnsWithKey = getFileColumnNames(kCustomer);
+
+  const std::string phoneFilter =
+      "substr(c_phone, 1, 2) IN ('13', '31', '23', '29', '30', '18', '17')";
+
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  core::PlanNodeId customerScanNodeId;
+  core::PlanNodeId customerScanNodeIdWithKey;
+  core::PlanNodeId ordersScanNodeId;
+
+  auto orders =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kOrders, ordersSelectedRowType, ordersFileColumns)
+          .capturePlanNodeId(ordersScanNodeId)
+          .planNode();
+
+  auto customerAvgAccountBalance =
+      PlanBuilder(planNodeIdGenerator, pool_.get())
+          .tableScan(
+              kCustomer,
+              customerSelectedRowType,
+              customerFileColumns,
+              {"c_acctbal > 0.0"},
+              phoneFilter)
+          .capturePlanNodeId(customerScanNodeId)
+          .partialAggregation({}, {"avg(c_acctbal) as avg_acctbal"})
+          .localPartition({})
+          .finalAggregation()
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator, pool_.get())
+          .tableScan(
+              kCustomer,
+              customerSelectedRowTypeWithKey,
+              customerFileColumnsWithKey,
+              {},
+              phoneFilter)
+          .capturePlanNodeId(customerScanNodeIdWithKey)
+          .crossJoin(
+              customerAvgAccountBalance,
+              {"c_acctbal", "avg_acctbal", "c_custkey", "c_phone"})
+          .filter("c_acctbal > avg_acctbal")
+          .hashJoin(
+              {"c_custkey"},
+              {"o_custkey"},
+              orders,
+              "",
+              {"c_acctbal", "c_phone"},
+              core::JoinType::kAnti)
+          .project({"substr(c_phone, 1, 2) AS country_code", "c_acctbal"})
+          .partialAggregation(
+              {"country_code"},
+              {"count(0) AS numcust", "sum(c_acctbal) AS totacctbal"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"country_code"}, false)
+          .planNode();
+
+  TpchPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[ordersScanNodeId] = getTableFilePaths(kOrders);
+  context.dataFiles[customerScanNodeId] = getTableFilePaths(kCustomer);
+  context.dataFiles[customerScanNodeIdWithKey] = getTableFilePaths(kCustomer);
   context.dataFileFormat = format_;
   return context;
 }

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -86,6 +86,7 @@ class TpchQueryBuilder {
   TpchPlan getQ14Plan() const;
   TpchPlan getQ18Plan() const;
   TpchPlan getQ19Plan() const;
+  TpchPlan getQ22Plan() const;
 
   const std::vector<std::string>& getTableFilePaths(
       const std::string& tableName) const {


### PR DESCRIPTION
Adds TPC-H query 22 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 22.
```
| # Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds) |
|:----------------------:|:--------------:|:---------------:|
|            1           |      3.11      |       2.15      |
|            4           |      0.96      |       0.98      | 
|            8           |      0.81      |       0.99      | 
|           16           |      0.89      |       0.92      |
```