### PR TITLE
Extract out format-independent reader files

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -18,7 +18,6 @@
 #include <memory>
 
 #include "velox/dwio/common/InputStream.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReader.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/type/Conversions.h"
 #include "velox/type/Type.h"

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -39,6 +39,9 @@ add_library(
   Options.cpp
   ReaderFactory.cpp
   ScanSpec.cpp
+  ColumnLoader.cpp
+  SelectiveColumnReader.cpp
+  SelectiveStructColumnReader.cpp
   SeekableInputStream.cpp
   TypeWithId.cpp)
 

--- a/velox/dwio/common/ColumnLoader.cpp
+++ b/velox/dwio/common/ColumnLoader.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/dwrf/reader/ColumnLoader.h"
+#include "velox/dwio/common/ColumnLoader.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 // Wraps '*result' in a dictionary to make the contiguous values
 // appear at the indices i 'rows'. Used when loading a LazyVector for

--- a/velox/dwio/common/ColumnLoader.h
+++ b/velox/dwio/common/ColumnLoader.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include "velox/dwio/dwrf/reader/SelectiveStructColumnReader.h"
+#include "velox/dwio/common/SelectiveStructColumnReader.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 class ColumnLoader : public velox::VectorLoader {
  public:

--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -19,9 +19,9 @@
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/SimdUtil.h"
 #include "velox/dwio/common/DecoderUtil.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReader.h"
+#include "velox/dwio/common/SelectiveColumnReader.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 // structs for extractValues in ColumnVisitor.
 
@@ -303,7 +303,7 @@ class ColumnVisitor {
   FOLLY_ALWAYS_INLINE vector_size_t process(T value, bool& atEnd) {
     if (!TFilter::deterministic) {
       auto previous = currentRow();
-      if (common::applyFilter(filter_, value)) {
+      if (velox::common::applyFilter(filter_, value)) {
         filterPassed(value);
       } else {
         filterFailed();
@@ -315,7 +315,7 @@ class ColumnVisitor {
       return currentRow() - previous - 1;
     }
     // The filter passes or fails and we go to the next row if any.
-    if (common::applyFilter(filter_, value)) {
+    if (velox::common::applyFilter(filter_, value)) {
       filterPassed(value);
     } else {
       filterFailed();
@@ -365,14 +365,14 @@ class ColumnVisitor {
 
   void filterPassed(T value) {
     addResult(value);
-    if (!std::is_same<TFilter, common::AlwaysTrue>::value) {
+    if (!std::is_same<TFilter, velox::common::AlwaysTrue>::value) {
       addOutputRow(currentRow());
     }
   }
 
   inline void filterPassedForNull() {
     addNull();
-    if (!std::is_same<TFilter, common::AlwaysTrue>::value) {
+    if (!std::is_same<TFilter, velox::common::AlwaysTrue>::value) {
       addOutputRow(currentRow());
     }
   }
@@ -392,7 +392,7 @@ class ColumnVisitor {
 
   void setNumValues(int32_t size) {
     reader_->setNumValues(size);
-    if (!std::is_same<TFilter, common::AlwaysTrue>::value) {
+    if (!std::is_same<TFilter, velox::common::AlwaysTrue>::value) {
       reader_->setNumRows(size);
     }
   }
@@ -667,7 +667,7 @@ class DictionaryColumnVisitor
         isDense && TFilter::deterministic ? 0 : super::currentRow();
     std::make_unsigned_t<T> index = value;
     T valueInDictionary = dict()[index];
-    if (std::is_same<TFilter, common::AlwaysTrue>::value) {
+    if (std::is_same<TFilter, velox::common::AlwaysTrue>::value) {
       super::filterPassed(valueInDictionary);
     } else {
       // check the dictionary cache
@@ -820,7 +820,7 @@ class DictionaryColumnVisitor
             if (i + index >= numInput) {
               break;
             }
-            if (common::applyFilter(super::filter_, input[i + index])) {
+            if (velox::common::applyFilter(super::filter_, input[i + index])) {
               passed |= 1 << index;
             }
           }
@@ -1013,8 +1013,6 @@ ColumnVisitor<T, TFilter, ExtractValues, isDense>::toDictionaryColumnVisitor() {
       filter_, reader_, RowSet(rows_ + rowIndex_, numRows_), values_);
 }
 
-class SelectiveStringDictionaryColumnReader;
-
 template <typename TFilter, typename ExtractValues, bool isDense>
 class StringDictionaryColumnVisitor
     : public DictionaryColumnVisitor<int32_t, TFilter, ExtractValues, isDense> {
@@ -1025,7 +1023,7 @@ class StringDictionaryColumnVisitor
  public:
   StringDictionaryColumnVisitor(
       TFilter& filter,
-      SelectiveStringDictionaryColumnReader* reader,
+      SelectiveColumnReader* reader,
       RowSet rows,
       ExtractValues values)
       : DictionaryColumnVisitor<int32_t, TFilter, ExtractValues, isDense>(
@@ -1042,7 +1040,7 @@ class StringDictionaryColumnVisitor
     }
     vector_size_t previous =
         isDense && TFilter::deterministic ? 0 : super::currentRow();
-    if (std::is_same<TFilter, common::AlwaysTrue>::value) {
+    if (std::is_same<TFilter, velox::common::AlwaysTrue>::value) {
       super::filterPassed(index);
     } else {
       // check the dictionary cache
@@ -1054,7 +1052,7 @@ class StringDictionaryColumnVisitor
           DictSuper::filterCache()[index] == FilterResult::kFailure) {
         super::filterFailed();
       } else {
-        if (common::applyFilter(
+        if (velox::common::applyFilter(
                 super::filter_, valueInDictionary(value, inStrideDict))) {
           super::filterPassed(index);
           if (TFilter::deterministic) {

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 using dwio::common::TypeWithId;
 using dwio::common::typeutils::CompatChecker;
 
-// Buffer size for reading length stream
-constexpr uint64_t BUFFER_SIZE = 1024;
-
-common::AlwaysTrue& alwaysTrue() {
-  static common::AlwaysTrue alwaysTrue;
+velox::common::AlwaysTrue& alwaysTrue() {
+  static velox::common::AlwaysTrue alwaysTrue;
   return alwaysTrue;
 }
 
@@ -48,7 +45,7 @@ void ScanState::updateRawState() {
 SelectiveColumnReader::SelectiveColumnReader(
     std::shared_ptr<const dwio::common::TypeWithId> requestedType,
     dwio::common::FormatParams& params,
-    common::ScanSpec& scanSpec,
+    velox::common::ScanSpec& scanSpec,
     const TypePtr& type)
     : memoryPool_(params.pool()),
       nodeType_(requestedType),
@@ -302,4 +299,4 @@ void SelectiveColumnReader::resetFilterCaches() {
   }
 }
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -23,7 +23,7 @@
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/type/Filter.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 // Generalized representation of a set of distinct values for dictionary
 // encodings.
@@ -105,7 +105,7 @@ class SelectiveColumnReader {
   SelectiveColumnReader(
       std::shared_ptr<const dwio::common::TypeWithId> requestedType,
       dwio::common::FormatParams& params,
-      common::ScanSpec& scanSpec,
+      velox::common::ScanSpec& scanSpec,
       const TypePtr& type);
 
   virtual ~SelectiveColumnReader() = default;
@@ -243,7 +243,7 @@ class SelectiveColumnReader {
     numValues_ -= count;
   }
 
-  common::ScanSpec* scanSpec() const {
+  velox::common::ScanSpec* scanSpec() const {
     return scanSpec_;
   }
 
@@ -390,7 +390,7 @@ class SelectiveColumnReader {
   // Specification of filters, value extraction, pruning etc. The
   // spec is assigned at construction and the contents may change at
   // run time based on adaptation. Owned by caller.
-  common::ScanSpec* const scanSpec_;
+  velox::common::ScanSpec* const scanSpec_;
   TypePtr type_;
 
   // Row number after last read row, relative to stripe start.

--- a/velox/dwio/common/SelectiveColumnReaderInternal.h
+++ b/velox/dwio/common/SelectiveColumnReaderInternal.h
@@ -19,11 +19,8 @@
 #include "velox/common/base/Portability.h"
 #include "velox/dwio/common/DirectDecoder.h"
 #include "velox/dwio/common/TypeUtils.h"
-#include "velox/dwio/dwrf/common/FloatingPointDecoder.h"
-#include "velox/dwio/dwrf/common/RLEv1.h"
-#include "velox/dwio/dwrf/reader/ColumnVisitors.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReader.h"
-#include "velox/dwio/dwrf/utils/ProtoUtils.h"
+#include "velox/dwio/common/ColumnVisitors.h"
+#include "velox/dwio/common/SelectiveColumnReader.h"
 #include "velox/exec/AggregationHook.h"
 #include "velox/type/Timestamp.h"
 #include "velox/vector/ConstantVector.h"
@@ -32,9 +29,9 @@
 
 #include <numeric>
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
-common::AlwaysTrue& alwaysTrue();
+  velox::common::AlwaysTrue& alwaysTrue();
 
 class Timer {
  public:
@@ -47,16 +44,6 @@ class Timer {
  private:
   const uint64_t startClocks_;
 };
-
-inline RleVersion convertRleVersion(proto::ColumnEncoding_Kind kind) {
-  switch (static_cast<int64_t>(kind)) {
-    case proto::ColumnEncoding_Kind_DIRECT:
-    case proto::ColumnEncoding_Kind_DICTIONARY:
-      return RleVersion_1;
-    default:
-      DWIO_RAISE("Unknown encoding in convertRleVersion");
-  }
-}
 
 template <typename T>
 void SelectiveColumnReader::ensureValuesCapacity(vector_size_t numRows) {
@@ -360,7 +347,5 @@ void SelectiveColumnReader::filterNulls(
   }
   readOffset_ += rows.back() + 1;
 }
-
-std::vector<uint64_t> toPositions(const proto::RowIndexEntry& entry);
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/common/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/common/SelectiveFloatingPointColumnReader.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
+
+namespace facebook::velox::dwio::common {
+
+template <typename TData, typename TRequested>
+class SelectiveFloatingPointColumnReader : public SelectiveColumnReader {
+ public:
+  using ValueType = TRequested;
+  SelectiveFloatingPointColumnReader(
+      std::shared_ptr<const dwio::common::TypeWithId> nodeType,
+      FormatParams& params,
+      velox::common::ScanSpec& scanSpec)
+      : SelectiveColumnReader(
+            std::move(nodeType),
+            params,
+            scanSpec,
+            CppToType<TData>::create()) {}
+
+  // Offers fast path only if data and result widths match.
+  bool hasBulkPath() const override {
+    return std::is_same<TData, TRequested>::value;
+  }
+
+  template <typename Reader>
+  void
+  readCommon(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls);
+
+  void getValues(RowSet rows, VectorPtr* result) override {
+    getFlatValues<TRequested, TRequested>(rows, result);
+  }
+
+ protected:
+  template <
+      typename Reader,
+      typename TFilter,
+      bool isDense,
+      typename ExtractValues>
+  void
+  readHelper(velox::common::Filter* filter, RowSet rows, ExtractValues values);
+
+  template <typename Reader, bool isDense, typename ExtractValues>
+  void processFilter(
+      velox::common::Filter* filter,
+      RowSet rows,
+      ExtractValues extractValues);
+
+  template <typename Reader, bool isDense>
+  void processValueHook(RowSet rows, ValueHook* hook);
+};
+
+template <typename TData, typename TRequested>
+template <
+    typename Reader,
+    typename TFilter,
+    bool isDense,
+    typename ExtractValues>
+void SelectiveFloatingPointColumnReader<TData, TRequested>::readHelper(
+    velox::common::Filter* filter,
+    RowSet rows,
+    ExtractValues extractValues) {
+  reinterpret_cast<Reader*>(this)->readWithVisitor(
+      rows,
+      ColumnVisitor<TRequested, TFilter, ExtractValues, isDense>(
+          *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
+}
+
+template <typename TData, typename TRequested>
+template <typename Reader, bool isDense, typename ExtractValues>
+void SelectiveFloatingPointColumnReader<TData, TRequested>::processFilter(
+    velox::common::Filter* filter,
+    RowSet rows,
+    ExtractValues extractValues) {
+  switch (filter ? filter->kind() : velox::common::FilterKind::kAlwaysTrue) {
+    case velox::common::FilterKind::kAlwaysTrue:
+      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
+          filter, rows, extractValues);
+      break;
+    case velox::common::FilterKind::kIsNull:
+      filterNulls<TRequested>(
+          rows,
+          true,
+          !std::is_same<decltype(extractValues), DropValues>::value);
+      break;
+    case velox::common::FilterKind::kIsNotNull:
+      if (std::is_same<decltype(extractValues), DropValues>::value) {
+        filterNulls<TRequested>(rows, false, false);
+      } else {
+        readHelper<Reader, velox::common::IsNotNull, isDense>(
+            filter, rows, extractValues);
+      }
+      break;
+    case velox::common::FilterKind::kDoubleRange:
+    case velox::common::FilterKind::kFloatRange:
+      readHelper<Reader, velox::common::FloatingPointRange<TData>, isDense>(
+          filter, rows, extractValues);
+      break;
+    default:
+      readHelper<Reader, velox::common::Filter, isDense>(
+          filter, rows, extractValues);
+      break;
+  }
+}
+
+template <typename TData, typename TRequested>
+template <typename Reader, bool isDense>
+void SelectiveFloatingPointColumnReader<TData, TRequested>::processValueHook(
+    RowSet rows,
+    ValueHook* hook) {
+  switch (hook->kind()) {
+    case aggregate::AggregationHook::kSumFloatToDouble:
+      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
+          &alwaysTrue(),
+          rows,
+          ExtractToHook<aggregate::SumHook<float, double>>(hook));
+      break;
+    case aggregate::AggregationHook::kSumDoubleToDouble:
+      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
+          &alwaysTrue(),
+          rows,
+          ExtractToHook<aggregate::SumHook<double, double>>(hook));
+      break;
+    case aggregate::AggregationHook::kFloatMax:
+    case aggregate::AggregationHook::kDoubleMax:
+      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
+          &alwaysTrue(),
+          rows,
+          ExtractToHook<aggregate::MinMaxHook<TRequested, false>>(hook));
+      break;
+    case aggregate::AggregationHook::kFloatMin:
+    case aggregate::AggregationHook::kDoubleMin:
+      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
+          &alwaysTrue(),
+          rows,
+          ExtractToHook<aggregate::MinMaxHook<TRequested, true>>(hook));
+      break;
+    default:
+      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
+          &alwaysTrue(), rows, ExtractToGenericHook(hook));
+  }
+}
+
+template <typename TData, typename TRequested>
+template <typename Reader>
+void SelectiveFloatingPointColumnReader<TData, TRequested>::readCommon(
+    vector_size_t offset,
+    RowSet rows,
+    const uint64_t* incomingNulls) {
+  prepareRead<TRequested>(offset, rows, incomingNulls);
+  bool isDense = rows.back() == rows.size() - 1;
+  if (scanSpec_->keepValues()) {
+    if (scanSpec_->valueHook()) {
+      if (isDense) {
+        processValueHook<Reader, true>(rows, scanSpec_->valueHook());
+      } else {
+        processValueHook<Reader, false>(rows, scanSpec_->valueHook());
+      }
+      return;
+    }
+    if (isDense) {
+      processFilter<Reader, true>(
+          scanSpec_->filter(), rows, ExtractToReader(this));
+    } else {
+      processFilter<Reader, false>(
+          scanSpec_->filter(), rows, ExtractToReader(this));
+    }
+  } else {
+    if (isDense) {
+      processFilter<Reader, true>(scanSpec_->filter(), rows, DropValues());
+    } else {
+      processFilter<Reader, false>(scanSpec_->filter(), rows, DropValues());
+    }
+  }
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/SelectiveIntegerColumnReader.h
+++ b/velox/dwio/common/SelectiveIntegerColumnReader.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwio::common {
 
 // Abstract class for format and encoding-independent parts of reading ingeger
 // columns.
@@ -27,7 +27,7 @@ class SelectiveIntegerColumnReader : public SelectiveColumnReader {
   SelectiveIntegerColumnReader(
       std::shared_ptr<const dwio::common::TypeWithId> requestedType,
       dwio::common::FormatParams& params,
-      common::ScanSpec& scanSpec,
+      velox::common::ScanSpec& scanSpec,
       const TypePtr& type)
       : SelectiveColumnReader(
             std::move(requestedType),
@@ -43,7 +43,7 @@ class SelectiveIntegerColumnReader : public SelectiveColumnReader {
   // Switches based on filter type between different readHelper instantiations.
   template <typename Reader, bool isDense, typename ExtractValues>
   void processFilter(
-      common::Filter* filter,
+		     velox::common::Filter* filter,
       ExtractValues extractValues,
       RowSet rows);
 
@@ -59,7 +59,7 @@ class SelectiveIntegerColumnReader : public SelectiveColumnReader {
       bool isDense,
       typename ExtractValues>
   void
-  readHelper(common::Filter* filter, RowSet rows, ExtractValues extractValues);
+  readHelper(velox::common::Filter* filter, RowSet rows, ExtractValues extractValues);
 
   // The common part of integer reading. calls the appropriate
   // instantiation of processValueHook or processFilter based on
@@ -74,7 +74,7 @@ template <
     bool isDense,
     typename ExtractValues>
 void SelectiveIntegerColumnReader::readHelper(
-    common::Filter* filter,
+					      velox::common::Filter* filter,
     RowSet rows,
     ExtractValues extractValues) {
   switch (valueSize_) {
@@ -106,54 +106,54 @@ void SelectiveIntegerColumnReader::readHelper(
 
 template <typename Reader, bool isDense, typename ExtractValues>
 void SelectiveIntegerColumnReader::processFilter(
-    common::Filter* filter,
+						 velox::common::Filter* filter,
     ExtractValues extractValues,
     RowSet rows) {
-  switch (filter ? filter->kind() : common::FilterKind::kAlwaysTrue) {
-    case common::FilterKind::kAlwaysTrue:
-      readHelper<Reader, common::AlwaysTrue, isDense>(
+  switch (filter ? filter->kind() : velox::common::FilterKind::kAlwaysTrue) {
+  case velox::common::FilterKind::kAlwaysTrue:
+    readHelper<Reader, velox::common::AlwaysTrue, isDense>(
           filter, rows, extractValues);
       break;
-    case common::FilterKind::kIsNull:
+    case velox::common::FilterKind::kIsNull:
       filterNulls<int64_t>(
           rows,
           true,
           !std::is_same<decltype(extractValues), DropValues>::value);
       break;
-    case common::FilterKind::kIsNotNull:
+    case velox::common::FilterKind::kIsNotNull:
       if (std::is_same<decltype(extractValues), DropValues>::value) {
         filterNulls<int64_t>(rows, false, false);
       } else {
-        readHelper<Reader, common::IsNotNull, isDense>(
+        readHelper<Reader, velox::common::IsNotNull, isDense>(
             filter, rows, extractValues);
       }
       break;
-    case common::FilterKind::kBigintRange:
-      readHelper<Reader, common::BigintRange, isDense>(
+    case velox::common::FilterKind::kBigintRange:
+      readHelper<Reader, velox::common::BigintRange, isDense>(
           filter, rows, extractValues);
       break;
-    case common::FilterKind::kNegatedBigintRange:
-      readHelper<Reader, common::NegatedBigintRange, isDense>(
+  case velox::common::FilterKind::kNegatedBigintRange:
+    readHelper<Reader, velox::common::NegatedBigintRange, isDense>(
           filter, rows, extractValues);
       break;
-    case common::FilterKind::kBigintValuesUsingHashTable:
-      readHelper<Reader, common::BigintValuesUsingHashTable, isDense>(
+  case velox::common::FilterKind::kBigintValuesUsingHashTable:
+    readHelper<Reader, velox::common::BigintValuesUsingHashTable, isDense>(
           filter, rows, extractValues);
       break;
-    case common::FilterKind::kBigintValuesUsingBitmask:
-      readHelper<Reader, common::BigintValuesUsingBitmask, isDense>(
+    case velox::common::FilterKind::kBigintValuesUsingBitmask:
+      readHelper<Reader, velox::common::BigintValuesUsingBitmask, isDense>(
           filter, rows, extractValues);
       break;
-    case common::FilterKind::kNegatedBigintValuesUsingHashTable:
-      readHelper<Reader, common::NegatedBigintValuesUsingHashTable, isDense>(
+    case velox::common::FilterKind::kNegatedBigintValuesUsingHashTable:
+      readHelper<Reader, velox::common::NegatedBigintValuesUsingHashTable, isDense>(
           filter, rows, extractValues);
       break;
-    case common::FilterKind::kNegatedBigintValuesUsingBitmask:
-      readHelper<Reader, common::NegatedBigintValuesUsingBitmask, isDense>(
+    case velox::common::FilterKind::kNegatedBigintValuesUsingBitmask:
+      readHelper<Reader, velox::common::NegatedBigintValuesUsingBitmask, isDense>(
           filter, rows, extractValues);
       break;
     default:
-      readHelper<Reader, common::Filter, isDense>(filter, rows, extractValues);
+      readHelper<Reader, velox::common::Filter, isDense>(filter, rows, extractValues);
       break;
   }
 }
@@ -164,25 +164,25 @@ void SelectiveIntegerColumnReader::processValueHook(
     ValueHook* hook) {
   switch (hook->kind()) {
     case aggregate::AggregationHook::kSumBigintToBigint:
-      readHelper<Reader, common::AlwaysTrue, isDense>(
+      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
           &alwaysTrue(),
           rows,
           ExtractToHook<aggregate::SumHook<int64_t, int64_t>>(hook));
       break;
     case aggregate::AggregationHook::kBigintMax:
-      readHelper<Reader, common::AlwaysTrue, isDense>(
-          &alwaysTrue(),
+      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
+							     &dwio::common::alwaysTrue(),
           rows,
           ExtractToHook<aggregate::MinMaxHook<int64_t, false>>(hook));
       break;
     case aggregate::AggregationHook::kBigintMin:
-      readHelper<Reader, common::AlwaysTrue, isDense>(
-          &alwaysTrue(),
+      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
+							     &alwaysTrue(),
           rows,
           ExtractToHook<aggregate::MinMaxHook<int64_t, true>>(hook));
       break;
     default:
-      readHelper<Reader, common::AlwaysTrue, isDense>(
+      readHelper<Reader, velox::common::AlwaysTrue, isDense>(
           &alwaysTrue(), rows, ExtractToGenericHook(hook));
   }
 }
@@ -190,7 +190,7 @@ void SelectiveIntegerColumnReader::processValueHook(
 template <typename Reader>
 void SelectiveIntegerColumnReader::readCommon(RowSet rows) {
   bool isDense = rows.back() == rows.size() - 1;
-  common::Filter* filter =
+  velox::common::Filter* filter =
       scanSpec_->filter() ? scanSpec_->filter() : &alwaysTrue();
   if (scanSpec_->keepValues()) {
     if (scanSpec_->valueHook()) {

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/SelectiveStructColumnReader.h"
+#include "velox/dwio/common/ColumnLoader.h"
+
+namespace facebook::velox::dwio::common {
+
+std::vector<uint32_t> SelectiveStructColumnReader::filterRowGroups(
+    uint64_t rowGroupSize,
+    const dwio::common::StatsContext& context) const {
+  auto stridesToSkip =
+      SelectiveColumnReader::filterRowGroups(rowGroupSize, context);
+  for (const auto& child : children_) {
+    auto childStridesToSkip = child->filterRowGroups(rowGroupSize, context);
+    if (stridesToSkip.empty()) {
+      stridesToSkip = std::move(childStridesToSkip);
+    } else {
+      std::vector<uint32_t> merged;
+      merged.reserve(childStridesToSkip.size() + stridesToSkip.size());
+      std::merge(
+          childStridesToSkip.begin(),
+          childStridesToSkip.end(),
+          stridesToSkip.begin(),
+          stridesToSkip.end(),
+          std::back_inserter(merged));
+      stridesToSkip = std::move(merged);
+    }
+  }
+  return stridesToSkip;
+}
+
+uint64_t SelectiveStructColumnReader::skip(uint64_t numValues) {
+  auto numNonNulls = formatData_->skipNulls(numValues);
+  // 'readOffset_' of struct child readers is aligned with
+  // 'readOffset_' of the struct. The child readers may have fewer
+  // values since there is no value in children where the struct is
+  // null. But because struct nulls are injected as nulls in child
+  // readers, it is practical to keep the row numbers in terms of the
+  // enclosing struct.
+  //
+  // Setting the 'readOffset_' in children is recursive so that nested
+  // nullable structs, where inner structs may advance less because of
+  // nulls above them still end up on the same row in terms of top
+  // level rows.
+  for (auto& child : children_) {
+    if (child) {
+      child->skip(numNonNulls);
+      child->setReadOffsetRecursive(child->readOffset() + numValues);
+    }
+  }
+  return numValues;
+}
+
+void SelectiveStructColumnReader::next(
+    uint64_t numValues,
+    VectorPtr& result,
+    const uint64_t* incomingNulls) {
+  VELOX_CHECK(!incomingNulls, "next may only be called for the root reader.");
+  if (children_.empty()) {
+    // no readers
+    // This can be either count(*) query or a query that select only
+    // constant columns (partition keys or columns missing from an old file
+    // due to schema evolution)
+    result->resize(numValues);
+
+    auto resultRowVector = std::dynamic_pointer_cast<RowVector>(result);
+    auto& childSpecs = scanSpec_->children();
+    for (auto& childSpec : childSpecs) {
+      VELOX_CHECK(childSpec->isConstant());
+      auto channel = childSpec->channel();
+      resultRowVector->childAt(channel) =
+          BaseVector::wrapInConstant(numValues, 0, childSpec->constantValue());
+    }
+    return;
+  }
+  auto oldSize = rows_.size();
+  rows_.resize(numValues);
+  if (numValues > oldSize) {
+    std::iota(&rows_[oldSize], &rows_[rows_.size()], oldSize);
+  }
+  read(readOffset_, rows_, nullptr);
+  getValues(outputRows(), &result);
+}
+
+void SelectiveStructColumnReader::read(
+    vector_size_t offset,
+    RowSet rows,
+    const uint64_t* incomingNulls) {
+  numReads_ = scanSpec_->newRead();
+  prepareRead<char>(offset, rows, incomingNulls);
+  RowSet activeRows = rows;
+  auto& childSpecs = scanSpec_->children();
+  const uint64_t* structNulls =
+      nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+  bool hasFilter = false;
+  assert(!children_.empty());
+  for (size_t i = 0; i < childSpecs.size(); ++i) {
+    auto& childSpec = childSpecs[i];
+    if (childSpec->isConstant()) {
+      continue;
+    }
+    auto fieldIndex = childSpec->subscript();
+    auto reader = children_.at(fieldIndex).get();
+    if (reader->isTopLevel() && childSpec->projectOut() &&
+        !childSpec->filter() && !childSpec->extractValues()) {
+      // Will make a LazyVector.
+      continue;
+    }
+    advanceFieldReader(reader, offset);
+    if (childSpec->filter()) {
+      hasFilter = true;
+      {
+        SelectivityTimer timer(childSpec->selectivity(), activeRows.size());
+
+        reader->resetInitTimeClocks();
+        reader->read(offset, activeRows, structNulls);
+
+        // Exclude initialization time.
+        timer.subtract(reader->initTimeClocks());
+
+        activeRows = reader->outputRows();
+        childSpec->selectivity().addOutput(activeRows.size());
+      }
+      if (activeRows.empty()) {
+        break;
+      }
+    } else {
+      reader->read(offset, activeRows, structNulls);
+    }
+  }
+  if (hasFilter) {
+    setOutputRows(activeRows);
+  }
+  lazyVectorReadOffset_ = offset;
+  readOffset_ = offset + rows.back() + 1;
+}
+
+namespace {
+//   Recursively makes empty RowVectors for positions in 'children'
+//   where the corresponding child type in 'rowType' is a row. The
+//   reader expects RowVector outputs to be initialized so that the
+//   content corresponds to the query schema regardless of the file
+//   schema. An empty RowVector can have nullptr for all its non-row
+//   children.
+void fillRowVectorChildren(
+    memory::MemoryPool& pool,
+    const RowType& rowType,
+    std::vector<VectorPtr>& children) {
+  for (auto i = 0; i < children.size(); ++i) {
+    const auto& type = rowType.childAt(i);
+    if (type->isRow()) {
+      std::vector<VectorPtr> innerChildren(type->size());
+      fillRowVectorChildren(pool, type->asRow(), innerChildren);
+      children[i] = std::make_shared<RowVector>(
+          &pool, type, nullptr, 0, std::move(innerChildren));
+    }
+  }
+}
+} // namespace
+
+void SelectiveStructColumnReader::getValues(RowSet rows, VectorPtr* result) {
+  assert(!children_.empty());
+  VELOX_CHECK(
+      *result != nullptr,
+      "SelectiveStructColumnReader expects a non-null result");
+  VELOX_CHECK(
+      result->get()->type()->isRow(),
+      "Struct reader expects a result of type ROW.");
+
+  auto resultRow = static_cast<RowVector*>(result->get());
+  if (!result->unique()) {
+    std::vector<VectorPtr> children(resultRow->children().size());
+    fillRowVectorChildren(
+        *resultRow->pool(), resultRow->type()->asRow(), children);
+    *result = std::make_unique<RowVector>(
+        resultRow->pool(),
+        resultRow->type(),
+        BufferPtr(nullptr),
+        0,
+        std::move(children));
+    resultRow = static_cast<RowVector*>(result->get());
+  }
+  resultRow->resize(rows.size());
+  if (!rows.size()) {
+    return;
+  }
+  if (nullsInReadRange_) {
+    auto readerNulls = nullsInReadRange_->as<uint64_t>();
+    auto nulls = resultRow->mutableNulls(rows.size())->asMutable<uint64_t>();
+    for (size_t i = 0; i < rows.size(); ++i) {
+      bits::setBit(nulls, i, bits::isBitSet(readerNulls, rows[i]));
+    }
+  } else {
+    resultRow->clearNulls(0, rows.size());
+  }
+  bool lazyPrepared = false;
+  auto& childSpecs = scanSpec_->children();
+  for (auto i = 0; i < childSpecs.size(); ++i) {
+    auto& childSpec = childSpecs[i];
+    if (!childSpec->projectOut()) {
+      continue;
+    }
+    auto index = childSpec->subscript();
+    auto channel = childSpec->channel();
+    if (childSpec->isConstant()) {
+      resultRow->childAt(channel) = BaseVector::wrapInConstant(
+          rows.size(), 0, childSpec->constantValue());
+    } else {
+      if (!childSpec->extractValues() && !childSpec->filter() &&
+          children_[index]->isTopLevel()) {
+        // LazyVector result.
+        if (!lazyPrepared) {
+          if (rows.size() != outputRows_.size()) {
+            setOutputRows(rows);
+          }
+          lazyPrepared = true;
+        }
+        resultRow->childAt(channel) = std::make_shared<LazyVector>(
+            &memoryPool_,
+            resultRow->type()->childAt(channel),
+            rows.size(),
+            std::make_unique<ColumnLoader>(
+                this, children_[index].get(), numReads_));
+      } else {
+        children_[index]->getValues(rows, &resultRow->childAt(channel));
+      }
+    }
+  }
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
+
+namespace facebook::velox::dwio::common {
+
+class SelectiveStructColumnReader : public SelectiveColumnReader {
+ public:
+  SelectiveStructColumnReader(
+      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
+      FormatParams& params,
+      velox::common::ScanSpec& scanSpec)
+      : SelectiveColumnReader(dataType, params, scanSpec, dataType->type),
+        requestedType_(requestedType),
+        debugString_(getExceptionContext().message()) {}
+
+  void resetFilterCaches() override {
+    for (auto& child : children_) {
+      child->resetFilterCaches();
+    }
+  }
+
+  uint64_t skip(uint64_t numValues) override;
+
+  void next(
+      uint64_t numValues,
+      VectorPtr& result,
+      const uint64_t* incomingNulls) override;
+
+  std::vector<uint32_t> filterRowGroups(
+      uint64_t rowGroupSize,
+      const dwio::common::StatsContext& context) const override;
+
+  void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
+      override;
+
+  void getValues(RowSet rows, VectorPtr* result) override;
+
+  uint64_t numReads() const {
+    return numReads_;
+  }
+
+  vector_size_t lazyVectorReadOffset() const {
+    return lazyVectorReadOffset_;
+  }
+
+  /// Advance field reader to the row group closest to specified offset by
+  /// calling seekToRowGroup.
+  virtual void advanceFieldReader(
+      SelectiveColumnReader* reader,
+      vector_size_t offset) = 0;
+
+  // Returns the nulls bitmap from reading this. Used in LazyVector loaders.
+  const uint64_t* nulls() const {
+    return nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+  }
+
+  void setReadOffsetRecursive(vector_size_t readOffset) override {
+    readOffset_ = readOffset;
+    for (auto& child : children_) {
+      child->setReadOffsetRecursive(readOffset);
+    }
+  }
+
+  void setIsTopLevel() override {
+    isTopLevel_ = true;
+    if (!formatData_->hasNulls()) {
+      for (auto& child : children_) {
+        child->setIsTopLevel();
+      }
+    }
+  }
+
+  // Sets 'rows' as the set of rows for which 'this' or its children
+  // may be loaded as LazyVectors. When a struct is loaded as lazy,
+  // its children will be lazy if the struct does not add nulls. The
+  // children will reference the struct reader, whih must have a live
+  // and up-to-date set of rows for which children can be loaded.
+  void setLoadableRows(RowSet rows) {
+    setOutputRows(rows);
+    inputRows_ = outputRows_;
+  }
+
+  const std::string& debugString() const {
+    return debugString_;
+  }
+
+ protected:
+  const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
+  std::vector<std::unique_ptr<SelectiveColumnReader>> children_;
+  // Sequence number of output batch. Checked against ColumnLoaders
+  // created by 'this' to verify they are still valid at load.
+  uint64_t numReads_ = 0;
+  vector_size_t lazyVectorReadOffset_;
+
+  // Dense set of rows to read in next().
+  raw_vector<vector_size_t> rows_;
+
+  // Context information obtained from ExceptionContext. Stored here
+  // so that LazyVector readers under this can add this to their
+  // ExceptionContext. Allows contextualizing reader errors to split
+  // and query. Set at construction, which takes place on first
+  // use. If no ExceptionContext is in effect, this is "".
+  const std::string debugString_;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/reader/CMakeLists.txt
+++ b/velox/dwio/dwrf/reader/CMakeLists.txt
@@ -22,7 +22,6 @@ add_library(
   FlatMapColumnReader.cpp
   FlatMapHelper.cpp
   ReaderBase.cpp
-  SelectiveColumnReader.cpp
   SelectiveDwrfReader.cpp
   SelectiveByteRleColumnReader.cpp
   SelectiveIntegerDirectColumnReader.cpp
@@ -31,7 +30,6 @@ add_library(
   SelectiveStringDictionaryColumnReader.cpp
   SelectiveTimestampColumnReader.cpp
   SelectiveStructColumnReader.cpp
-  ColumnLoader.cpp
   SelectiveRepeatedColumnReader.cpp
   StripeDictionaryCache.cpp
   StripeReaderBase.cpp

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -22,6 +22,7 @@
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/dwrf/common/ByteRLE.h"
 #include "velox/dwio/dwrf/common/Compression.h"
+#include "velox/dwio/dwrf/common/RLEv1.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/reader/EncodingContext.h"
 #include "velox/dwio/dwrf/reader/StripeStream.h"
@@ -130,5 +131,15 @@ class DwrfParams : public dwio::common::FormatParams {
   StripeStreams& stripeStreams_;
   FlatMapContext flatMapContext_;
 };
+
+inline RleVersion convertRleVersion(proto::ColumnEncoding_Kind kind) {
+  switch (static_cast<int64_t>(kind)) {
+    case proto::ColumnEncoding_Kind_DIRECT:
+    case proto::ColumnEncoding_Kind_DICTIONARY:
+      return RleVersion_1;
+    default:
+      DWIO_RAISE("Unknown encoding in convertRleVersion");
+  }
+}
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/common/exception/Exception.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReader.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -93,7 +93,7 @@ class DwrfRowReader : public DwrfRowReaderShared {
   void checkSkipStrides(const StatsContext& context, uint64_t strideSize);
 
   std::unique_ptr<ColumnReader> columnReader_;
-  std::unique_ptr<SelectiveColumnReader> selectiveColumnReader_;
+  std::unique_ptr<dwio::common::SelectiveColumnReader> selectiveColumnReader_;
   std::vector<uint32_t> stridesToSkip_;
   // Record of strides to skip in each visited stripe. Used for diagnostics.
   std::unordered_map<uint32_t, std::vector<uint32_t>> stripeStridesToSkip_;

--- a/velox/dwio/dwrf/reader/DwrfReaderShared.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReaderShared.cpp
@@ -21,7 +21,6 @@
 #include "velox/dwio/common/exception/Exceptions.h"
 #include "velox/dwio/dwrf/common/Statistics.h"
 #include "velox/dwio/dwrf/reader/DwrfReaderShared.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReader.h"
 #include "velox/dwio/dwrf/reader/SelectiveDwrfReader.h"
 #include "velox/dwio/dwrf/reader/StripeStream.h"
 

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.cpp
@@ -35,7 +35,7 @@ void SelectiveByteRleColumnReader::read(
   prepareRead<int8_t>(offset, rows, incomingNulls);
   bool isDense = rows.back() == rows.size() - 1;
   common::Filter* filter =
-      scanSpec_->filter() ? scanSpec_->filter() : &alwaysTrue();
+      scanSpec_->filter() ? scanSpec_->filter() : &dwio::common::alwaysTrue();
   if (scanSpec_->keepValues()) {
     if (scanSpec_->valueHook()) {
       if (isDense) {
@@ -46,15 +46,15 @@ void SelectiveByteRleColumnReader::read(
       return;
     }
     if (isDense) {
-      processFilter<true>(filter, ExtractToReader(this), rows);
+      processFilter<true>(filter, dwio::common::ExtractToReader(this), rows);
     } else {
-      processFilter<false>(filter, ExtractToReader(this), rows);
+      processFilter<false>(filter, dwio::common::ExtractToReader(this), rows);
     }
   } else {
     if (isDense) {
-      processFilter<true>(filter, DropValues(), rows);
+      processFilter<true>(filter, dwio::common::DropValues(), rows);
     } else {
-      processFilter<false>(filter, DropValues(), rows);
+      processFilter<false>(filter, dwio::common::DropValues(), rows);
     }
   }
 }

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -16,12 +16,13 @@
 
 #pragma once
 
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwrf {
 
-class SelectiveByteRleColumnReader : public SelectiveColumnReader {
+class SelectiveByteRleColumnReader
+    : public dwio::common::SelectiveColumnReader {
  public:
   using ValueType = int8_t;
 
@@ -143,7 +144,7 @@ void SelectiveByteRleColumnReader::readHelper(
     ExtractValues extractValues) {
   readWithVisitor(
       rows,
-      ColumnVisitor<int8_t, TFilter, ExtractValues, isDense>(
+      dwio::common::ColumnVisitor<int8_t, TFilter, ExtractValues, isDense>(
           *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
 }
 
@@ -199,11 +200,15 @@ void SelectiveByteRleColumnReader::processValueHook(
   switch (hook->kind()) {
     case aggregate::AggregationHook::kSumBigintToBigint:
       readHelper<common::AlwaysTrue, isDense>(
-          &alwaysTrue(), rows, ExtractToHook<SumHook<int64_t, int64_t>>(hook));
+          &dwio::common::alwaysTrue(),
+          rows,
+          dwio::common::ExtractToHook<SumHook<int64_t, int64_t>>(hook));
       break;
     default:
       readHelper<common::AlwaysTrue, isDense>(
-          &alwaysTrue(), rows, ExtractToGenericHook(hook));
+          &dwio::common::alwaysTrue(),
+          rows,
+          dwio::common::ExtractToGenericHook(hook));
   }
 }
 

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
@@ -16,16 +16,16 @@
 
 #pragma once
 
+#include "velox/dwio/common/SelectiveColumnReader.h"
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReader.h"
 
 namespace facebook::velox::dwrf {
 
 // Wrapper for static functions for making DWRF readers
 class SelectiveDwrfReader {
  public:
-  static std::unique_ptr<SelectiveColumnReader> build(
+  static std::unique_ptr<dwio::common::SelectiveColumnReader> build(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       DwrfParams& params,
@@ -33,7 +33,7 @@ class SelectiveDwrfReader {
 
   // Compatibility wrapper for tests. Takes the components of DwrfParams as
   // separate.
-  static std::unique_ptr<SelectiveColumnReader> build(
+  static std::unique_ptr<dwio::common::SelectiveColumnReader> build(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
@@ -50,7 +50,7 @@ class SelectiveColumnReaderFactory : public ColumnReaderFactory {
       std::shared_ptr<common::ScanSpec> scanSpec)
       : scanSpec_(scanSpec) {}
 
-  std::unique_ptr<SelectiveColumnReader> buildSelective(
+  std::unique_ptr<dwio::common::SelectiveColumnReader> buildSelective(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -16,13 +16,13 @@
 
 #pragma once
 
+#include "velox/dwio/common/SelectiveIntegerColumnReader.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
-#include "velox/dwio/dwrf/reader/SelectiveIntegerColumnReader.h"
 
 namespace facebook::velox::dwrf {
 
 class SelectiveIntegerDictionaryColumnReader
-    : public SelectiveIntegerColumnReader {
+    : public dwio::common::SelectiveIntegerColumnReader {
  public:
   using ValueType = int64_t;
 

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
@@ -29,7 +29,11 @@ void SelectiveIntegerDirectColumnReader::read(
     RowSet rows,
     const uint64_t* incomingNulls) {
   VELOX_WIDTH_DISPATCH(
-      sizeOfIntKind(type_->kind()), prepareRead, offset, rows, incomingNulls);
+      dwio::common::sizeOfIntKind(type_->kind()),
+      prepareRead,
+      offset,
+      rows,
+      incomingNulls);
   readCommon<SelectiveIntegerDirectColumnReader>(rows);
 }
 

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -16,13 +16,14 @@
 
 #pragma once
 
+#include "velox/dwio/common/SelectiveIntegerColumnReader.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
-#include "velox/dwio/dwrf/reader/SelectiveIntegerColumnReader.h"
 
 namespace facebook::velox::dwrf {
 
-class SelectiveIntegerDirectColumnReader : public SelectiveIntegerColumnReader {
+class SelectiveIntegerDirectColumnReader
+    : public dwio::common::SelectiveIntegerColumnReader {
  public:
   using ValueType = int64_t;
 

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -17,15 +17,16 @@
 #pragma once
 
 #include "velox/dwio/common/BufferUtil.h"
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwrf {
 
 // Abstract superclass for list and map readers. Encapsulates common
 // logic for dealing with mapping between enclosing and nested rows.
-class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
+class SelectiveRepeatedColumnReader
+    : public dwio::common::SelectiveColumnReader {
  public:
   bool useBulkPath() const override {
     return false;

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -246,9 +246,11 @@ void SelectiveStringDictionaryColumnReader::read(
     }
   } else {
     if (isDense) {
-      processFilter<true>(scanSpec_->filter(), rows, DropValues());
+      processFilter<true>(
+          scanSpec_->filter(), rows, dwio::common::DropValues());
     } else {
-      processFilter<false>(scanSpec_->filter(), rows, DropValues());
+      processFilter<false>(
+          scanSpec_->filter(), rows, dwio::common::DropValues());
     }
   }
 }

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -16,12 +16,13 @@
 
 #pragma once
 
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwrf {
 
-class SelectiveStringDictionaryColumnReader : public SelectiveColumnReader {
+class SelectiveStringDictionaryColumnReader
+    : public dwio::common::SelectiveColumnReader {
  public:
   using ValueType = int32_t;
 
@@ -76,7 +77,7 @@ class SelectiveStringDictionaryColumnReader : public SelectiveColumnReader {
   void loadDictionary(
       dwio::common::SeekableInputStream& data,
       dwio::common::IntDecoder</*isSigned*/ false>& lengthDecoder,
-      DictionaryValues& values);
+      dwio::common::DictionaryValues& values);
   void ensureInitialized();
   std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> dictIndex_;
   std::unique_ptr<ByteRleDecoder> inDictionaryReader_;
@@ -121,8 +122,9 @@ void SelectiveStringDictionaryColumnReader::readHelper(
     ExtractValues values) {
   readWithVisitor(
       rows,
-      StringDictionaryColumnVisitor<TFilter, ExtractValues, isDense>(
-          *reinterpret_cast<TFilter*>(filter), this, rows, values));
+      dwio::common::
+          StringDictionaryColumnVisitor<TFilter, ExtractValues, isDense>(
+              *reinterpret_cast<TFilter*>(filter), this, rows, values));
 }
 
 template <bool isDense, typename ExtractValues>

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -318,7 +318,8 @@ void SelectiveStringDirectColumnReader::readWithVisitor(
       std::is_same<typename TVisitor::FilterType, common::AlwaysTrue>::value &&
       std::is_same<
           typename TVisitor::Extract,
-          ExtractToReader<SelectiveStringDirectColumnReader>>::value;
+          dwio::common::ExtractToReader<SelectiveStringDirectColumnReader>>::
+          value;
   auto nulls = nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
 
   if (process::hasAvx2() && isExtract) {
@@ -368,8 +369,9 @@ void SelectiveStringDirectColumnReader::readHelper(
     ExtractValues extractValues) {
   readWithVisitor(
       rows,
-      ColumnVisitor<folly::StringPiece, TFilter, ExtractValues, isDense>(
-          *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
+      dwio::common::
+          ColumnVisitor<folly::StringPiece, TFilter, ExtractValues, isDense>(
+              *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
 }
 
 template <bool isDense, typename ExtractValues>
@@ -432,23 +434,31 @@ void SelectiveStringDirectColumnReader::read(
     if (scanSpec_->valueHook()) {
       if (isDense) {
         readHelper<common::AlwaysTrue, true>(
-            &alwaysTrue(), rows, ExtractToGenericHook(scanSpec_->valueHook()));
+            &dwio::common::alwaysTrue(),
+            rows,
+            dwio::common::ExtractToGenericHook(scanSpec_->valueHook()));
       } else {
         readHelper<common::AlwaysTrue, false>(
-            &alwaysTrue(), rows, ExtractToGenericHook(scanSpec_->valueHook()));
+            &dwio::common::alwaysTrue(),
+            rows,
+            dwio::common::ExtractToGenericHook(scanSpec_->valueHook()));
       }
       return;
     }
     if (isDense) {
-      processFilter<true>(scanSpec_->filter(), rows, ExtractToReader(this));
+      processFilter<true>(
+          scanSpec_->filter(), rows, dwio::common::ExtractToReader(this));
     } else {
-      processFilter<false>(scanSpec_->filter(), rows, ExtractToReader(this));
+      processFilter<false>(
+          scanSpec_->filter(), rows, dwio::common::ExtractToReader(this));
     }
   } else {
     if (isDense) {
-      processFilter<true>(scanSpec_->filter(), rows, DropValues());
+      processFilter<true>(
+          scanSpec_->filter(), rows, dwio::common::DropValues());
     } else {
-      processFilter<false>(scanSpec_->filter(), rows, DropValues());
+      processFilter<false>(
+          scanSpec_->filter(), rows, dwio::common::DropValues());
     }
   }
 }

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
@@ -16,12 +16,13 @@
 
 #pragma once
 
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwrf {
 
-class SelectiveStringDirectColumnReader : public SelectiveColumnReader {
+class SelectiveStringDirectColumnReader
+    : public dwio::common::SelectiveColumnReader {
  public:
   using ValueType = StringView;
   SelectiveStringDirectColumnReader(

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/dwio/dwrf/reader/SelectiveStructColumnReader.h"
-#include "velox/dwio/dwrf/reader/ColumnLoader.h"
+#include "velox/dwio/common/ColumnLoader.h"
 #include "velox/dwio/dwrf/reader/SelectiveDwrfReader.h"
 
 namespace facebook::velox::dwrf {
@@ -27,10 +27,12 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
     const std::shared_ptr<const TypeWithId>& dataType,
     DwrfParams& params,
     common::ScanSpec& scanSpec)
-    : SelectiveColumnReader(dataType, params, scanSpec, dataType->type),
-      requestedType_{requestedType},
-      rowsPerRowGroup_(formatData_->as<DwrfData>().rowsPerRowGroup()),
-      debugString_(getExceptionContext().message()) {
+    : dwio::common::SelectiveStructColumnReader(
+          requestedType,
+          dataType,
+          params,
+          scanSpec),
+      rowsPerRowGroup_(formatData_->as<DwrfData>().rowsPerRowGroup()) {
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   DWIO_ENSURE_EQ(encodingKey.node, dataType->id, "working on the same node");
   auto& stripe = params.stripeStreams();
@@ -56,229 +58,6 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
     children_.push_back(SelectiveDwrfReader::build(
         childRequestedType, childDataType, childParams, *childSpec));
     childSpec->setSubscript(children_.size() - 1);
-  }
-}
-
-std::vector<uint32_t> SelectiveStructColumnReader::filterRowGroups(
-    uint64_t rowGroupSize,
-    const dwio::common::StatsContext& context) const {
-  auto stridesToSkip =
-      SelectiveColumnReader::filterRowGroups(rowGroupSize, context);
-  for (const auto& child : children_) {
-    auto childStridesToSkip = child->filterRowGroups(rowGroupSize, context);
-    if (stridesToSkip.empty()) {
-      stridesToSkip = std::move(childStridesToSkip);
-    } else {
-      std::vector<uint32_t> merged;
-      merged.reserve(childStridesToSkip.size() + stridesToSkip.size());
-      std::merge(
-          childStridesToSkip.begin(),
-          childStridesToSkip.end(),
-          stridesToSkip.begin(),
-          stridesToSkip.end(),
-          std::back_inserter(merged));
-      stridesToSkip = std::move(merged);
-    }
-  }
-  return stridesToSkip;
-}
-
-uint64_t SelectiveStructColumnReader::skip(uint64_t numValues) {
-  auto numNonNulls = formatData_->skipNulls(numValues);
-  // 'readOffset_' of struct child readers is aligned with
-  // 'readOffset_' of the struct. The child readers may have fewer
-  // values since there is no value in children where the struct is
-  // null. But because struct nulls are injected as nulls in child
-  // readers, it is practical to keep the row numbers in terms of the
-  // enclosing struct.
-  //
-  // Setting the 'readOffset_' in children is recursive so that nested
-  // nullable structs, where inner structs may advance less because of
-  // nulls above them still end up on the same row in terms of top
-  // level rows.
-  for (auto& child : children_) {
-    if (child) {
-      child->skip(numNonNulls);
-      child->setReadOffsetRecursive(child->readOffset() + numValues);
-    }
-  }
-  return numValues;
-}
-
-void SelectiveStructColumnReader::next(
-    uint64_t numValues,
-    VectorPtr& result,
-    const uint64_t* incomingNulls) {
-  VELOX_CHECK(!incomingNulls, "next may only be called for the root reader.");
-  if (children_.empty()) {
-    // no readers
-    // This can be either count(*) query or a query that select only
-    // constant columns (partition keys or columns missing from an old file
-    // due to schema evolution)
-    result->resize(numValues);
-
-    auto resultRowVector = std::dynamic_pointer_cast<RowVector>(result);
-    auto& childSpecs = scanSpec_->children();
-    for (auto& childSpec : childSpecs) {
-      VELOX_CHECK(childSpec->isConstant());
-      auto channel = childSpec->channel();
-      resultRowVector->childAt(channel) =
-          BaseVector::wrapInConstant(numValues, 0, childSpec->constantValue());
-    }
-    return;
-  }
-  auto oldSize = rows_.size();
-  rows_.resize(numValues);
-  if (numValues > oldSize) {
-    std::iota(&rows_[oldSize], &rows_[rows_.size()], oldSize);
-  }
-  read(readOffset_, rows_, nullptr);
-  getValues(outputRows(), &result);
-}
-
-void SelectiveStructColumnReader::read(
-    vector_size_t offset,
-    RowSet rows,
-    const uint64_t* incomingNulls) {
-  numReads_ = scanSpec_->newRead();
-  prepareRead<char>(offset, rows, incomingNulls);
-  RowSet activeRows = rows;
-  auto& childSpecs = scanSpec_->children();
-  const uint64_t* structNulls =
-      nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
-  bool hasFilter = false;
-  assert(!children_.empty());
-  for (size_t i = 0; i < childSpecs.size(); ++i) {
-    auto& childSpec = childSpecs[i];
-    if (childSpec->isConstant()) {
-      continue;
-    }
-    auto fieldIndex = childSpec->subscript();
-    auto reader = children_.at(fieldIndex).get();
-    if (reader->isTopLevel() && childSpec->projectOut() &&
-        !childSpec->filter() && !childSpec->extractValues()) {
-      // Will make a LazyVector.
-      continue;
-    }
-    advanceFieldReader(reader, offset);
-    if (childSpec->filter()) {
-      hasFilter = true;
-      {
-        SelectivityTimer timer(childSpec->selectivity(), activeRows.size());
-
-        reader->resetInitTimeClocks();
-        reader->read(offset, activeRows, structNulls);
-
-        // Exclude initialization time.
-        timer.subtract(reader->initTimeClocks());
-
-        activeRows = reader->outputRows();
-        childSpec->selectivity().addOutput(activeRows.size());
-      }
-      if (activeRows.empty()) {
-        break;
-      }
-    } else {
-      reader->read(offset, activeRows, structNulls);
-    }
-  }
-  if (hasFilter) {
-    setOutputRows(activeRows);
-  }
-  lazyVectorReadOffset_ = offset;
-  readOffset_ = offset + rows.back() + 1;
-}
-
-namespace {
-//   Recursively makes empty RowVectors for positions in 'children'
-//   where the corresponding child type in 'rowType' is a row. The
-//   reader expects RowVector outputs to be initialized so that the
-//   content corresponds to the query schema regardless of the file
-//   schema. An empty RowVector can have nullptr for all its non-row
-//   children.
-void fillRowVectorChildren(
-    memory::MemoryPool& pool,
-    const RowType& rowType,
-    std::vector<VectorPtr>& children) {
-  for (auto i = 0; i < children.size(); ++i) {
-    const auto& type = rowType.childAt(i);
-    if (type->isRow()) {
-      std::vector<VectorPtr> innerChildren(type->size());
-      fillRowVectorChildren(pool, type->asRow(), innerChildren);
-      children[i] = std::make_shared<RowVector>(
-          &pool, type, nullptr, 0, std::move(innerChildren));
-    }
-  }
-}
-} // namespace
-
-void SelectiveStructColumnReader::getValues(RowSet rows, VectorPtr* result) {
-  assert(!children_.empty());
-  VELOX_CHECK(
-      *result != nullptr,
-      "SelectiveStructColumnReader expects a non-null result");
-  VELOX_CHECK(
-      result->get()->type()->isRow(),
-      "Struct reader expects a result of type ROW.");
-
-  auto resultRow = static_cast<RowVector*>(result->get());
-  if (!result->unique()) {
-    std::vector<VectorPtr> children(resultRow->children().size());
-    fillRowVectorChildren(
-        *resultRow->pool(), resultRow->type()->asRow(), children);
-    *result = std::make_unique<RowVector>(
-        resultRow->pool(),
-        resultRow->type(),
-        BufferPtr(nullptr),
-        0,
-        std::move(children));
-    resultRow = static_cast<RowVector*>(result->get());
-  }
-  resultRow->resize(rows.size());
-  if (!rows.size()) {
-    return;
-  }
-  if (nullsInReadRange_) {
-    auto readerNulls = nullsInReadRange_->as<uint64_t>();
-    auto nulls = resultRow->mutableNulls(rows.size())->asMutable<uint64_t>();
-    for (size_t i = 0; i < rows.size(); ++i) {
-      bits::setBit(nulls, i, bits::isBitSet(readerNulls, rows[i]));
-    }
-  } else {
-    resultRow->clearNulls(0, rows.size());
-  }
-  bool lazyPrepared = false;
-  auto& childSpecs = scanSpec_->children();
-  for (auto i = 0; i < childSpecs.size(); ++i) {
-    auto& childSpec = childSpecs[i];
-    if (!childSpec->projectOut()) {
-      continue;
-    }
-    auto index = childSpec->subscript();
-    auto channel = childSpec->channel();
-    if (childSpec->isConstant()) {
-      resultRow->childAt(channel) = BaseVector::wrapInConstant(
-          rows.size(), 0, childSpec->constantValue());
-    } else {
-      if (!childSpec->extractValues() && !childSpec->filter() &&
-          children_[index]->isTopLevel()) {
-        // LazyVector result.
-        if (!lazyPrepared) {
-          if (rows.size() != outputRows_.size()) {
-            setOutputRows(rows);
-          }
-          lazyPrepared = true;
-        }
-        resultRow->childAt(channel) = std::make_shared<LazyVector>(
-            &memoryPool_,
-            resultRow->type()->childAt(channel),
-            rows.size(),
-            std::make_unique<ColumnLoader>(
-                this, children_[index].get(), numReads_));
-      } else {
-        children_[index]->getValues(rows, &resultRow->childAt(channel));
-      }
-    }
   }
 }
 

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -16,24 +16,19 @@
 
 #pragma once
 
+#include "velox/dwio/common/SelectiveStructColumnReader.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwrf {
 
-class SelectiveStructColumnReader : public SelectiveColumnReader {
+class SelectiveStructColumnReader
+    : public dwio::common::SelectiveStructColumnReader {
  public:
   SelectiveStructColumnReader(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       DwrfParams& params,
       common::ScanSpec& scanSpec);
-
-  void resetFilterCaches() override {
-    for (auto& child : children_) {
-      child->resetFilterCaches();
-    }
-  }
 
   void seekToRowGroup(uint32_t index) override {
     if (isTopLevel_ && !formatData_->hasNulls()) {
@@ -51,33 +46,10 @@ class SelectiveStructColumnReader : public SelectiveColumnReader {
     }
   }
 
-  uint64_t skip(uint64_t numValues) override;
-
-  void next(
-      uint64_t numValues,
-      VectorPtr& result,
-      const uint64_t* incomingNulls) override;
-
-  std::vector<uint32_t> filterRowGroups(
-      uint64_t rowGroupSize,
-      const dwio::common::StatsContext& context) const override;
-
-  void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
-      override;
-
-  void getValues(RowSet rows, VectorPtr* result) override;
-
-  uint64_t numReads() const {
-    return numReads_;
-  }
-
-  vector_size_t lazyVectorReadOffset() const {
-    return lazyVectorReadOffset_;
-  }
-
   /// Advance field reader to the row group closest to specified offset by
   /// calling seekToRowGroup.
-  void advanceFieldReader(SelectiveColumnReader* reader, vector_size_t offset) {
+  void advanceFieldReader(SelectiveColumnReader* reader, vector_size_t offset)
+      override {
     if (!reader->isTopLevel()) {
       return;
     }
@@ -89,60 +61,8 @@ class SelectiveStructColumnReader : public SelectiveColumnReader {
     }
   }
 
-  // Returns the nulls bitmap from reading this. Used in LazyVector loaders.
-  const uint64_t* nulls() const {
-    return nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
-  }
-
-  void setReadOffsetRecursive(vector_size_t readOffset) override {
-    readOffset_ = readOffset;
-    for (auto& child : children_) {
-      child->setReadOffsetRecursive(readOffset);
-    }
-  }
-
-  void setIsTopLevel() override {
-    isTopLevel_ = true;
-    if (!formatData_->hasNulls()) {
-      for (auto& child : children_) {
-        child->setIsTopLevel();
-      }
-    }
-  }
-
-  // Sets 'rows' as the set of rows for which 'this' or its children
-  // may be loaded as LazyVectors. When a struct is loaded as lazy,
-  // its children will be lazy if the struct does not add nulls. The
-  // children will reference the struct reader, whih must have a live
-  // and up-to-date set of rows for which children can be loaded.
-  void setLoadableRows(RowSet rows) {
-    setOutputRows(rows);
-    inputRows_ = outputRows_;
-  }
-
-  const std::string& debugString() const {
-    return debugString_;
-  }
-
  private:
-  const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
-  std::vector<std::unique_ptr<SelectiveColumnReader>> children_;
-  // Sequence number of output batch. Checked against ColumnLoaders
-  // created by 'this' to verify they are still valid at load.
-  uint64_t numReads_ = 0;
-  vector_size_t lazyVectorReadOffset_;
-
   const int32_t rowsPerRowGroup_;
-
-  // Dense set of rows to read in next().
-  raw_vector<vector_size_t> rows_;
-
-  // Context information obtained from ExceptionContext. Stored here
-  // so that LazyVector readers under this can add this to their
-  // ExceptionContext. Allows contextualizing reader errors to split
-  // and query. Set at construction, which takes place on first
-  // use. If no ExceptionContext is in effect, this is "".
-  const std::string debugString_;
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
@@ -16,11 +16,12 @@
 
 #pragma once
 
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwrf {
-class SelectiveTimestampColumnReader : public SelectiveColumnReader {
+class SelectiveTimestampColumnReader
+    : public dwio::common::SelectiveColumnReader {
  public:
   // The readers produce int64_t, the vector is Timestamps.
   using ValueType = int64_t;

--- a/velox/dwio/dwrf/test/E2EFilterTestBase.h
+++ b/velox/dwio/dwrf/test/E2EFilterTestBase.h
@@ -27,8 +27,8 @@
 #include "velox/vector/FlatVector.h"
 
 #include "velox/dwio/common/MemoryInputStream.h"
+#include "velox/dwio/common/SelectiveColumnReader.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
-#include "velox/dwio/dwrf/reader/SelectiveColumnReader.h"
 #include "velox/dwio/dwrf/test/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/test/utils/FilterGenerator.h"
 #include "velox/dwio/dwrf/writer/Writer.h"


### PR DESCRIPTION
Moves format-generic reader files into dwio/common.
Divides struct and floating point column readers into generic and DWRF-specific parts.