### PR TITLE
Add NegatedBytesRange filter

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -236,6 +236,22 @@ inline std::unique_ptr<common::BytesRange> betweenExclusive(
       min, false, true, max, false, true, nullAllowed);
 }
 
+inline std::unique_ptr<common::NegatedBytesRange> notBetween(
+    const std::string& min,
+    const std::string& max,
+    bool nullAllowed = false) {
+  return std::make_unique<common::NegatedBytesRange>(
+      min, false, false, max, false, false, nullAllowed);
+}
+
+inline std::unique_ptr<common::NegatedBytesRange> notBetweenExclusive(
+    const std::string& min,
+    const std::string& max,
+    bool nullAllowed = false) {
+  return std::make_unique<common::NegatedBytesRange>(
+      min, false, true, max, false, true, nullAllowed);
+}
+
 inline std::unique_ptr<common::BytesRange> lessThanOrEqual(
     const std::string& max,
     bool nullAllowed = false) {

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -840,6 +840,61 @@ TEST(FilterTest, bytesRange) {
   EXPECT_TRUE(filter->testBytes("abc", 3));
 }
 
+TEST(FilterTest, negatedBytesRange) {
+  auto filter = notBetween("a", "c");
+
+  EXPECT_TRUE(filter->testBytes("A", 1));
+  EXPECT_TRUE(filter->testBytes(nullptr, 0));
+  EXPECT_TRUE(filter->testBytes("ca", 2));
+  EXPECT_TRUE(filter->testBytes("z", 1));
+
+  EXPECT_FALSE(filter->testBytes("a", 1));
+  EXPECT_FALSE(filter->testBytes("apple", 5));
+  EXPECT_FALSE(filter->testBytes("c", 1));
+  EXPECT_FALSE(filter->testNull());
+
+  EXPECT_TRUE(filter->testLength(1));
+  EXPECT_TRUE(filter->testLength(3));
+  EXPECT_TRUE(filter->testLength(5));
+  EXPECT_TRUE(filter->testLength(100));
+
+  EXPECT_TRUE(filter->testBytesRange(std::nullopt, "b", false));
+  EXPECT_TRUE(filter->testBytesRange("a", std::nullopt, false));
+  EXPECT_TRUE(filter->testBytesRange("a", "ca", false));
+  EXPECT_TRUE(filter->testBytesRange("", "c", false));
+
+  EXPECT_FALSE(filter->testBytesRange("a", "c", false));
+  EXPECT_FALSE(filter->testBytesRange("ab", "bzzzzzzz", false));
+
+  EXPECT_FALSE(filter->isSingleValue());
+  EXPECT_EQ("a", filter->lower());
+  EXPECT_EQ("c", filter->upper());
+  EXPECT_FALSE(filter->isLowerUnbounded());
+  EXPECT_FALSE(filter->isUpperUnbounded());
+
+  filter = notBetweenExclusive("b", "d");
+  EXPECT_TRUE(filter->testBytes("b", 1));
+  EXPECT_TRUE(filter->testBytes("d", 1));
+
+  EXPECT_TRUE(filter->testBytesRange("b", "c", false));
+  EXPECT_TRUE(filter->testBytesRange("c", "d", false));
+  EXPECT_FALSE(filter->testBytesRange("bb", "cc", true));
+
+  EXPECT_FALSE(filter->isSingleValue());
+  EXPECT_EQ("b", filter->lower());
+  EXPECT_EQ("d", filter->upper());
+  EXPECT_FALSE(filter->isLowerUnbounded());
+  EXPECT_FALSE(filter->isUpperUnbounded());
+
+  auto filter_with_null = filter->clone(true);
+  EXPECT_TRUE(filter_with_null->testBytesRange("bb", "cc", true));
+  EXPECT_TRUE(filter_with_null->testNull());
+
+  auto filter_with_null_copy = filter_with_null->clone();
+  EXPECT_TRUE(filter_with_null_copy->testBytesRange("bb", "cc", true));
+  EXPECT_TRUE(filter_with_null_copy->testNull());
+}
+
 TEST(FilterTest, bytesValues) {
   // The filter has values of size on either side of 8 bytes.
   std::vector<std::string> values({"Igne", "natura", "renovitur", "integra."});


### PR DESCRIPTION
Summary: This diff adds a filter for `NOT BETWEEN [lower] AND [upper]` queries on strings (varchar). This is accomplished by creating a wrapper class around a `BytesRange`, which is used to represent the rejected range of values. The corresponding methods for a string filter have been added to `Filter.h` and `Filter.cpp` and the appropriate tests have been added to `FilterTest.cpp`.

Reviewed By: Yuhta

Differential Revision: D37739984

