### PR TITLE
Implement MergeWith for NegatedBigintRange filters

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -419,7 +419,7 @@ std::unique_ptr<Filter> createBigintValuesFilter(
   bool overflow = __builtin_sub_overflow(max, min, &range);
   if (LIKELY(!overflow)) {
     // all accepted/rejected values form one contiguous block
-    if (range + 1 == values.size()) {
+    if ((uint64_t)range + 1 == values.size()) {
       if (!negated) {
         return std::make_unique<BigintRange>(min, max, nullAllowed);
       }
@@ -989,6 +989,60 @@ std::unique_ptr<Filter> combineNegatedBigintLists(
   return createNegatedBigintValues(allRejected, nullAllowed);
 }
 
+std::unique_ptr<Filter> combineNegatedRangeOnIntRanges(
+    int64_t negatedLower,
+    int64_t negatedUpper,
+    const std::vector<std::unique_ptr<BigintRange>>& ranges,
+    bool nullAllowed) {
+  std::vector<std::unique_ptr<BigintRange>> outRanges;
+  // for a sensible set of ranges, at most one creates 2 output ranges
+  outRanges.reserve(ranges.size() + 1);
+  for (int i = 0; i < ranges.size(); ++i) {
+    if (negatedUpper < ranges[i]->lower() ||
+        ranges[i]->upper() < negatedLower) {
+      outRanges.emplace_back(std::make_unique<BigintRange>(
+          ranges[i]->lower(), ranges[i]->upper(), false));
+    } else {
+      if (ranges[i]->lower() < negatedLower) {
+        outRanges.emplace_back(std::make_unique<BigintRange>(
+            ranges[i]->lower(), negatedLower - 1, false));
+      }
+      if (negatedUpper < ranges[i]->upper()) {
+        outRanges.emplace_back(std::make_unique<BigintRange>(
+            negatedUpper + 1, ranges[i]->upper(), false));
+      }
+    }
+  }
+
+  return combineBigintRanges(std::move(outRanges), nullAllowed);
+}
+
+std::vector<std::unique_ptr<BigintRange>> negatedValuesToRanges(
+    std::vector<int64_t>& values) {
+  VELOX_DCHECK(std::is_sorted(values.begin(), values.end()));
+  auto front = ++(values.begin());
+  auto back = values.begin();
+  std::vector<std::unique_ptr<BigintRange>> res;
+  res.reserve(values.size() + 1);
+  if (*back > std::numeric_limits<int64_t>::min()) {
+    res.emplace_back(std::make_unique<BigintRange>(
+        std::numeric_limits<int64_t>::min(), *back - 1, false));
+  }
+  while (front != values.end()) {
+    if (*back + 1 <= *front - 1) {
+      res.emplace_back(
+          std::make_unique<BigintRange>(*back + 1, *front - 1, false));
+    }
+    ++front;
+    ++back;
+  }
+  if (*back < std::numeric_limits<int64_t>::max()) {
+    res.emplace_back(std::make_unique<BigintRange>(
+        *back + 1, std::numeric_limits<int64_t>::max(), false));
+  }
+  return res;
+}
+
 } // namespace
 
 std::unique_ptr<Filter> BigintRange::mergeWith(const Filter* other) const {
@@ -1013,6 +1067,7 @@ std::unique_ptr<Filter> BigintRange::mergeWith(const Filter* other) const {
 
       return nullOrFalse(bothNullAllowed);
     }
+    case FilterKind::kNegatedBigintRange:
     case FilterKind::kBigintValuesUsingBitmask:
     case FilterKind::kBigintValuesUsingHashTable:
       return other->mergeWith(this);
@@ -1059,7 +1114,95 @@ std::unique_ptr<Filter> BigintRange::mergeWith(const Filter* other) const {
 
 std::unique_ptr<Filter> NegatedBigintRange::mergeWith(
     const Filter* other) const {
-  VELOX_NYI("mergeWith is not yet implemented for NegatedBigintRange");
+  switch (other->kind()) {
+    case FilterKind::kAlwaysTrue:
+    case FilterKind::kAlwaysFalse:
+    case FilterKind::kIsNull:
+      return other->mergeWith(this);
+    case FilterKind::kIsNotNull:
+      return this->clone(false);
+    case FilterKind::kBigintRange: {
+      bool bothNullAllowed = nullAllowed_ && other->testNull();
+      auto otherRange = static_cast<const BigintRange*>(other);
+      std::vector<std::unique_ptr<common::BigintRange>> rangeList;
+      rangeList.emplace_back(std::make_unique<BigintRange>(
+          otherRange->lower(), otherRange->upper(), false));
+      return combineNegatedRangeOnIntRanges(
+          this->lower(), this->upper(), rangeList, bothNullAllowed);
+    }
+    case FilterKind::kNegatedBigintRange: {
+      bool bothNullAllowed = nullAllowed_ && other->testNull();
+      auto otherNegatedRange = static_cast<const NegatedBigintRange*>(other);
+      if (this->lower() > otherNegatedRange->lower()) {
+        return other->mergeWith(this);
+      }
+      assert(this->lower() <= otherNegatedRange->lower());
+      if (this->upper() + 1 < otherNegatedRange->lower()) {
+        std::vector<std::unique_ptr<common::BigintRange>> outRanges;
+        int64_t smallLower = this->lower();
+        int64_t smallUpper = this->upper();
+        int64_t bigLower = otherNegatedRange->lower();
+        int64_t bigUpper = otherNegatedRange->upper();
+        if (smallLower > std::numeric_limits<int64_t>::min()) {
+          outRanges.emplace_back(std::make_unique<common::BigintRange>(
+              std::numeric_limits<int64_t>::min(), smallLower - 1, false));
+        }
+        if (smallUpper < std::numeric_limits<int64_t>::max() &&
+            bigLower > std::numeric_limits<int64_t>::min()) {
+          outRanges.emplace_back(std::make_unique<common::BigintRange>(
+              smallUpper + 1, bigLower - 1, false));
+        }
+        if (bigUpper < std::numeric_limits<int64_t>::max()) {
+          outRanges.emplace_back(std::make_unique<common::BigintRange>(
+              bigUpper + 1, std::numeric_limits<int64_t>::max(), false));
+        }
+        return combineBigintRanges(std::move(outRanges), bothNullAllowed);
+      }
+      return std::make_unique<common::NegatedBigintRange>(
+          this->lower(),
+          std::max<int64_t>(this->upper(), otherNegatedRange->upper()),
+          bothNullAllowed);
+    }
+    case FilterKind::kBigintMultiRange: {
+      bool bothNullAllowed = nullAllowed_ && other->testNull();
+      auto otherMultiRanges = static_cast<const BigintMultiRange*>(other);
+      return combineNegatedRangeOnIntRanges(
+          this->lower(),
+          this->upper(),
+          otherMultiRanges->ranges(),
+          bothNullAllowed);
+    }
+    case FilterKind::kBigintValuesUsingHashTable:
+    case FilterKind::kBigintValuesUsingBitmask:
+      return other->mergeWith(this);
+    case FilterKind::kNegatedBigintValuesUsingHashTable:
+    case FilterKind::kNegatedBigintValuesUsingBitmask: {
+      bool bothNullAllowed = nullAllowed_ && other->testNull();
+      std::vector<int64_t> rejectedValues;
+      if (other->kind() == FilterKind::kNegatedBigintValuesUsingHashTable) {
+        auto otherHashTable =
+            static_cast<const NegatedBigintValuesUsingHashTable*>(other);
+        rejectedValues = otherHashTable->values();
+      } else {
+        auto otherBitmask =
+            static_cast<const NegatedBigintValuesUsingBitmask*>(other);
+        rejectedValues = otherBitmask->values();
+      }
+      if (nonNegated_->isSingleValue()) {
+        if (other->testInt64(this->lower())) {
+          rejectedValues.push_back(this->lower());
+        }
+        return createNegatedBigintValues(rejectedValues, bothNullAllowed);
+      }
+      return combineNegatedRangeOnIntRanges(
+          this->lower(),
+          this->upper(),
+          negatedValuesToRanges(rejectedValues),
+          bothNullAllowed);
+    }
+    default:
+      VELOX_UNREACHABLE();
+  }
 }
 
 std::unique_ptr<Filter> BigintValuesUsingHashTable::mergeWith(
@@ -1110,6 +1253,7 @@ std::unique_ptr<Filter> BigintValuesUsingHashTable::mergeWith(
       bool bothNullAllowed = nullAllowed_ && other->testNull();
       return createBigintValues(valuesToKeep, bothNullAllowed);
     }
+    case FilterKind::kNegatedBigintRange:
     case FilterKind::kNegatedBigintValuesUsingBitmask:
     case FilterKind::kNegatedBigintValuesUsingHashTable: {
       return mergeWith(min_, max_, other);
@@ -1202,6 +1346,7 @@ std::unique_ptr<Filter> BigintValuesUsingBitmask::mergeWith(
       bool bothNullAllowed = nullAllowed_ && other->testNull();
       return createBigintValues(valuesToKeep, bothNullAllowed);
     }
+    case FilterKind::kNegatedBigintRange:
     case FilterKind::kNegatedBigintValuesUsingBitmask:
     case FilterKind::kNegatedBigintValuesUsingHashTable: {
       return mergeWith(min_, max_, other);
@@ -1256,6 +1401,7 @@ std::unique_ptr<Filter> NegatedBigintValuesUsingHashTable::mergeWith(
       return combineNegatedBigintLists(
           values(), otherNegated->values(), bothNullAllowed);
     }
+    case FilterKind::kNegatedBigintRange:
     case FilterKind::kNegatedBigintValuesUsingBitmask: {
       return other->mergeWith(this);
     }
@@ -1284,6 +1430,7 @@ std::unique_ptr<Filter> NegatedBigintValuesUsingBitmask::mergeWith(
     case FilterKind::kBigintValuesUsingHashTable:
     case FilterKind::kBigintValuesUsingBitmask:
     case FilterKind::kBigintRange:
+    case FilterKind::kNegatedBigintRange:
     case FilterKind::kBigintMultiRange: {
       return other->mergeWith(this);
     }
@@ -1322,6 +1469,7 @@ std::unique_ptr<Filter> BigintMultiRange::mergeWith(const Filter* other) const {
       return std::make_unique<BigintMultiRange>(std::move(ranges), false);
     }
     case FilterKind::kBigintRange:
+    case FilterKind::kNegatedBigintRange:
     case FilterKind::kBigintValuesUsingBitmask:
     case FilterKind::kBigintValuesUsingHashTable: {
       return other->mergeWith(this);

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -1273,6 +1273,25 @@ TEST(FilterTest, mergeWithBigint) {
   filters.push_back(between(150, 500));
   filters.push_back(between(150, 500, true));
 
+  // Inequality.
+  filters.push_back(notEqual(123));
+  filters.push_back(notEqual(123, true));
+  filters.push_back(notEqual(300));
+  filters.push_back(notEqual(300, true));
+  filters.push_back(notEqual(2));
+  filters.push_back(notEqual(3));
+
+  // Not between.
+  filters.push_back(notBetween(150, 500));
+  filters.push_back(notBetween(150, 500, true));
+  filters.push_back(notBetween(0, 100));
+  filters.push_back(notBetween(0, 100, true));
+  filters.push_back(notBetween(0, 200));
+  filters.push_back(notBetween(400, 600));
+  filters.push_back(notBetween(0, 600));
+  filters.push_back(notBetween(1000, 10'134));
+  filters.push_back(notBetween(200, 300));
+
   // IN-list.
   filters.push_back(in({1, 2, 3, 67'000'000'000, 134}));
   filters.push_back(in({1, 2, 3, 67'000'000'000, 134}, true));
@@ -1382,6 +1401,28 @@ TEST(FilterTest, mergeWithBigintMultiRange) {
   filters.push_back(bigintOr(lessThan(-3), equal(12), between(25, 47)));
   filters.push_back(bigintOr(lessThan(-3), equal(12), between(25, 47), true));
 
+  // not equal
+  filters.push_back(notEqual(20));
+  filters.push_back(notEqual(20, true));
+  filters.push_back(notEqual(12));
+  filters.push_back(notEqual(12, true));
+  filters.push_back(notEqual(-210));
+  filters.push_back(notEqual(-210, true));
+
+  // not between
+  filters.push_back(notBetween(25, 47));
+  filters.push_back(notBetween(25, 47, true));
+  filters.push_back(notBetween(0, 40));
+  filters.push_back(notBetween(30, 40));
+  filters.push_back(notBetween(-20, 40));
+  filters.push_back(notBetween(12, 40));
+  filters.push_back(notBetween(13, 40));
+  filters.push_back(notBetween(20, 50));
+  filters.push_back(notBetween(-10, -1));
+  filters.push_back(notBetween(90, 100));
+  filters.push_back(notBetween(std::numeric_limits<int64_t>::min(), -4));
+  filters.push_back(notBetween(std::numeric_limits<int64_t>::min(), -4, true));
+
   // IN-list using bitmask.
   filters.push_back(in({1, 2, 3, 56}));
   filters.push_back(in({1, 2, 3, 56}, true));
@@ -1389,6 +1430,11 @@ TEST(FilterTest, mergeWithBigintMultiRange) {
   // IN-list using hash table.
   filters.push_back(in({1, 2, 3, 67, 10'134}));
   filters.push_back(in({1, 2, 3, 67, 10'134}, true));
+  filters.push_back(
+      in({std::numeric_limits<int64_t>::min(),
+          0,
+          std::numeric_limits<int64_t>::max()},
+         true));
 
   // NOT IN-list using bitmask.
   filters.push_back(notIn({0, 3, 5, 20, 32, 210}));


### PR DESCRIPTION
Summary:
This diff implements the `MergeWith` function for the newly added `NegatedBigintRange` filters, which allows two filters to get merged into a larger filter which only accepts values that pass both of the original filters. `MergeWith` for the `NegatedBigintRange` filters is compatible with untyped (null/not null/true/false) filters as well as other filters on integers, such as `BigintRange`, `BigintMultiRange`, and the `Values` and `NegatedValues` classes of filters. The corresponding `MergeWith` methods in the other integer classes have also been updated to support merging with `NegatedBigintRange` as well.

Tests for `MergeWith` on `NegatedBigintRange` filters have been added to `FilterTest.cpp` as well.

Reviewed By: Yuhta

Differential Revision: D37503903

