### PR TITLE
Add LengthRange filter

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -288,6 +288,11 @@ inline std::unique_ptr<common::NegatedBytesValues> notIn(
   return std::make_unique<common::NegatedBytesValues>(values, nullAllowed);
 }
 
+inline std::unique_ptr<common::LengthRange>
+lengthBetween(int min, int max, bool nullAllowed = false) {
+  return std::make_unique<common::LengthRange>(min, max, nullAllowed);
+}
+
 inline std::unique_ptr<common::BoolValue> boolEqual(
     bool value,
     bool nullAllowed = false) {


### PR DESCRIPTION
Summary: This diff adds a `LengthRange` class, which accepts a string if its length is in a specified range bounded inclusively by two integers. The relevant methods in `Filter.h` and `Filter.cpp`, including test methods, `toString`, and `mergeWith` have been added, and testing code has been added in `FilterTest.cpp` and `ExprToSubfieldFilter.h`. Notably, the `LengthRange` class is only able to merge with `BytesValues` and other `LengthRange` filters, as well as the untyped filters -- no other merges are supported.

Differential Revision: D37836269

