### PR TITLE
Mac: build debug and release versions of protobuf

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -37,7 +37,7 @@ NPROC=$(getconf _NPROCESSORS_ONLN)
 COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_DEPS="ninja flex bison cmake ccache protobuf icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl@1.1"
+MACOS_DEPS="ninja flex bison cmake ccache protobuf@3 icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl@1.1"
 
 function run_and_time {
   time "$@"


### PR DESCRIPTION
Protobuf recently made a change that made it so debug builds of Velox on Mac broke.  See 
https://github.com/facebookincubator/velox/issues/2029

This seems like a conscious tradeoff on the Protobuf side, building debug code linking agains release builds of Protobuf 
was never supported, it just happened to work according to the comments here 
https://github.com/protocolbuffers/protobuf/issues/9947

To address this, I've changed setup-macos.sh to checkout the latest (as of writing) release of Protobuf and build/install 
both optimized and debug versions of the library.  cmake seems to be smart enough to figure out when to use which.

I also tried continuing to use brew to install the optimized version, but that seemed to break find_package(Protobuf 3.0.0 
REQUIRED) it would only find the optimized version, not the debug version, even though I built and installed that 
separately.

I suspect this works in Linux builds because we use the protobuf-devel package which I'm guessing includes the debug 
build, but I didn't dig into it too much.

I verified `make debug` runs on my Mac now, I'm verifying `make release` finishes successfully as well.