### PR TITLE
Back out "Port to use native flex/yacc support"

### DIFF
--- a/velox/expression/type_calculation/TypeCalculation.ll
+++ b/velox/expression/type_calculation/TypeCalculation.ll
@@ -1,5 +1,5 @@
 %{
-#include "velox/expression/type_calculation/TypeCalculation.yy.h"  // @manual
+#include "Parser.h"
 #include "velox/expression/type_calculation/Scanner.h"
 #define YY_DECL int facebook::velox::expression::calculate::Scanner::lex(facebook::velox::expression::calculate::Parser::semantic_type *yylval)
 %}

--- a/velox/expression/type_calculation/parser_gen.sh
+++ b/velox/expression/type_calculation/parser_gen.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+FLEX="$(which flex)"
+BISON="$(which bison)"
+
+$FLEX --prefix=veloxtc --outfile=Scanner.cpp TypeCalculation.ll
+$BISON --defines=Parser.h --output=Parser.cpp TypeCalculation.yy
+
+# Fix include path
+sed -i 's|Parser.h|velox/expression/type_calculation/Parser.h|g' Parser.cpp
+
+cp Scanner.cpp Parser.cpp Parser.h stack.hh "$INSTALL_DIR"/


### PR DESCRIPTION
Summary:
Original commit changeset: 77187cbe4b6f

Original Phabricator Diff: D37928602 (https://github.com/facebookincubator/velox/commit/c972a991e7d313628e7a2d6b5daad5fbaf59a673)

Differential Revision: D37947654

