### PR TITLE
Add TPC-H query 15 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -182,6 +182,11 @@ BENCHMARK(q14) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q15) {
+  const auto planContext = queryBuilder->getQueryPlan(15);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q18) {
   const auto planContext = queryBuilder->getQueryPlan(18);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTpchTest.cpp
@@ -209,6 +209,11 @@ TEST_F(ParquetTpchTest, Q14) {
   assertQuery(14);
 }
 
+TEST_F(ParquetTpchTest, Q15) {
+  std::vector<uint32_t> sortingKeys{0};
+  assertQuery(15, std::move(sortingKeys));
+}
+
 TEST_F(ParquetTpchTest, Q18) {
   assertQuery(18);
 }

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -137,6 +137,8 @@ TpchPlan TpchQueryBuilder::getQueryPlan(int queryId) const {
       return getQ13Plan();
     case 14:
       return getQ14Plan();
+    case 15:
+      return getQ15Plan();
     case 18:
       return getQ18Plan();
     case 19:
@@ -888,6 +890,91 @@ TpchPlan TpchQueryBuilder::getQ14Plan() const {
   context.plan = std::move(plan);
   context.dataFiles[lineitemScanNodeId] = getTableFilePaths(kLineitem);
   context.dataFiles[partScanNodeId] = getTableFilePaths(kPart);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+TpchPlan TpchQueryBuilder::getQ15Plan() const {
+  std::vector<std::string> lineitemColumns = {
+      "l_suppkey", "l_shipdate", "l_extendedprice", "l_discount"};
+  std::vector<std::string> supplierColumns = {
+      "s_suppkey", "s_name", "s_address", "s_phone"};
+
+  const auto lineitemSelectedRowType = getRowType(kLineitem, lineitemColumns);
+  const auto& lineitemFileColumns = getFileColumnNames(kLineitem);
+  const auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+
+  const std::string shipDateFilter = formatDateFilter(
+      "l_shipdate", lineitemSelectedRowType, "'1996-01-01'", "'1996-02-29'");
+
+  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  core::PlanNodeId lineitemScanNodeIdSubQuery;
+  core::PlanNodeId lineitemScanNodeId;
+  core::PlanNodeId supplierScanNodeId;
+
+  auto revenue0 =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kLineitem,
+              lineitemSelectedRowType,
+              lineitemFileColumns,
+              {shipDateFilter})
+          .capturePlanNodeId(lineitemScanNodeIdSubQuery)
+          .project(
+              {"l_suppkey as supplier_no",
+               "l_extendedprice * (1.0 - l_discount) as part_revenue"})
+          .partialAggregation(
+              {"supplier_no"}, {"sum(part_revenue) as total_revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .planNode();
+
+  auto lineitemMaxRevenue =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kLineitem,
+              lineitemSelectedRowType,
+              lineitemFileColumns,
+              {shipDateFilter})
+          .capturePlanNodeId(lineitemScanNodeId)
+          .project(
+              {"l_suppkey",
+               "l_extendedprice * (1.0 - l_discount) as part_revenue"})
+          .partialAggregation(
+              {"l_suppkey"}, {"sum(part_revenue) as total_revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .partialAggregation({}, {"max(total_revenue) as max_revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kSupplier, supplierSelectedRowType, supplierFileColumns)
+          .capturePlanNodeId(supplierScanNodeId)
+          .hashJoin(
+              {"s_suppkey"},
+              {"supplier_no"},
+              revenue0,
+              "",
+              {"s_suppkey", "s_name", "s_address", "s_phone", "total_revenue"})
+          .hashJoin(
+              {"total_revenue"},
+              {"max_revenue"},
+              lineitemMaxRevenue,
+              "",
+              {"s_suppkey", "s_name", "s_address", "s_phone", "total_revenue"})
+          .localPartition({})
+          .orderBy({"s_suppkey"}, false)
+          .planNode();
+
+  TpchPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[lineitemScanNodeIdSubQuery] = getTableFilePaths(kLineitem);
+  context.dataFiles[lineitemScanNodeId] = getTableFilePaths(kLineitem);
+  context.dataFiles[supplierScanNodeId] = getTableFilePaths(kSupplier);
   context.dataFileFormat = format_;
   return context;
 }

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -85,6 +85,7 @@ class TpchQueryBuilder {
   TpchPlan getQ12Plan() const;
   TpchPlan getQ13Plan() const;
   TpchPlan getQ14Plan() const;
+  TpchPlan getQ15Plan() const;
   TpchPlan getQ18Plan() const;
   TpchPlan getQ19Plan() const;
   TpchPlan getQ22Plan() const;


### PR DESCRIPTION
Adds TPC-H query 15 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 15.
```
| # Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds) |
|:----------------------:|:--------------:|:---------------:|
|            1           |      7.54      |      18.79      |
|            4           |      2.83      |       5.15      |
|            8           |      2.85      |       3.32      |
|           16           |      2.92      |       2.79      |
```
The query plan with statistics is as follows:
```
Execution time: 7.79s
Splits total: 230, finished: 230
-- OrderBy[s_suppkey ASC NULLS LAST] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, total_revenue:DOUBLE
   Output: 1 rows (143.94KB, 1 batches), Cpu time: 1.23ms, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 12, Threads: 1
  -- HashJoin[INNER s_suppkey=supplier_no] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR, total_revenue:DOUBLE
     Output: 1 rows (47.97KB, 1 batches), Cpu time: 137.00us, Blocked wall time: 7.77s, Peak memory: 2.00MB, Memory allocations: 9
     HashBuild: Input: 1 rows (23B, 1 batches), Output: 0 rows (0B, 0 batches), Cpu time: 98.00us, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 2, Threads: 1
        distinctKey0       sum: 2, count: 1, min: 2, max: 2
        queuedWallNanos    sum: 75.00us, count: 1, min: 75.00us, max: 75.00us
        rangeKey0          sum: 2, count: 1, min: 2, max: 2
     HashProbe: Input: 1 rows (47.91KB, 1 batches), Output: 1 rows (47.97KB, 1 batches), Cpu time: 39.00us, Blocked wall time: 7.77s, Peak memory: 1.00MB, Memory allocations: 7, Threads: 1
        dataSourceLazyWallNanos    sum: 1.16ms, count: 3, min: 262.00us, max: 509.00us
        dynamicFiltersProduced     sum: 1, count: 1, min: 1, max: 1
        queuedWallNanos            sum: 18.00us, count: 1, min: 18.00us, max: 18.00us
    -- TableScan[table: supplier] -> s_suppkey:BIGINT, s_name:VARCHAR, s_address:VARCHAR, s_phone:VARCHAR
       Input: 1 rows (47.91KB, 0 batches), Raw Input: 53785 rows (47.46MB), Output: 1 rows (47.91KB, 1 batches), Cpu time: 14.25ms, Blocked wall time: 0ns, Peak memory: 2.00MB, Memory allocations: 197, Threads: 1, Splits: 70
          dataSourceWallNanos       sum: 6.92ms, count: 76, min: 2.00us, max: 1.58ms
          dynamicFiltersAccepted    sum: 1, count: 1, min: 1, max: 1
          localReadBytes            sum: 0B, count: 1, min: 0B, max: 0B
          numLocalRead              sum: 0, count: 1, min: 0, max: 0
          numPrefetch               sum: 0, count: 1, min: 0, max: 0
          numRamRead                sum: 0, count: 1, min: 0, max: 0
          numStorageRead            sum: 0, count: 1, min: 0, max: 0
          prefetchBytes             sum: 0B, count: 1, min: 0B, max: 0B
          ramReadBytes              sum: 0B, count: 1, min: 0B, max: 0B
          skippedSplitBytes         sum: 912.76KB, count: 1, min: 912.76KB, max: 912.76KB
          skippedSplits             sum: 30, count: 1, min: 30, max: 30
          skippedStrides            sum: 3, count: 1, min: 3, max: 3
          storageReadBytes          sum: 0B, count: 1, min: 0B, max: 0B
    -- HashJoin[INNER total_revenue=max_revenue] -> supplier_no:BIGINT, total_revenue:DOUBLE
       Output: 1 rows (23B, 1 batches), Cpu time: 2.27ms, Blocked wall time: 7.75s, Peak memory: 2.00MB, Memory allocations: 5
       HashBuild: Input: 1 rows (32B, 1 batches), Output: 0 rows (0B, 0 batches), Cpu time: 76.00us, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 2, Threads: 1
          distinctKey0       sum: 1, count: 1, min: 1, max: 1
          queuedWallNanos    sum: 68.00us, count: 1, min: 68.00us, max: 68.00us
       HashProbe: Input: 100000 rows (2.29MB, 98 batches), Output: 1 rows (23B, 1 batches), Cpu time: 2.20ms, Blocked wall time: 7.75s, Peak memory: 1.00MB, Memory allocations: 3, Threads: 1
          queuedWallNanos    sum: 20.00us, count: 1, min: 20.00us, max: 20.00us
      -- Aggregation[FINAL [supplier_no] total_revenue := sum("total_revenue")] -> supplier_no:BIGINT, total_revenue:DOUBLE
         Output: 100000 rows (2.29MB, 98 batches), Cpu time: 6.32ms, Blocked wall time: 0ns, Peak memory: 4.00MB, Memory allocations: 140, Threads: 1
        -- LocalPartition[GATHER] -> supplier_no:BIGINT, total_revenue:DOUBLE
           Output: 200000 rows (4.59MB, 98 batches), Cpu time: 826.00us, Blocked wall time: 12.93ms, Peak memory: 0B, Memory allocations: 0
           LocalPartition: Input: 100000 rows (2.29MB, 98 batches), Output: 100000 rows (2.29MB, 0 batches), Cpu time: 501.00us, Blocked wall time: 12.93ms, Peak memory: 0B, Memory allocations: 0, Threads: 1
              queuedWallNanos    sum: 121.00us, count: 2, min: 58.00us, max: 63.00us
           LocalExchange: Input: 100000 rows (2.29MB, 0 batches), Output: 100000 rows (2.29MB, 98 batches), Cpu time: 325.00us, Blocked wall time: 0ns, Peak memory: 0B, Memory allocations: 0, Threads: 1
          -- Aggregation[PARTIAL [supplier_no] total_revenue := sum(ROW["part_revenue"])] -> supplier_no:BIGINT, total_revenue:DOUBLE
             Output: 100000 rows (2.29MB, 98 batches), Cpu time: 745.80ms, Blocked wall time: 0ns, Peak memory: 7.00MB, Memory allocations: 336, Threads: 1
            -- Project[expressions: (supplier_no:BIGINT, ROW["l_suppkey"]), (part_revenue:DOUBLE, multiply(ROW["l_extendedprice"],minus(1,ROW["l_discount"])))] -> supplier_no:BIGINT, part_revenue:DOUBLE
               Output: 2265714 rows (28.35MB, 6011 batches), Cpu time: 1.11s, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 5, Threads: 1
                  dataSourceLazyWallNanos    sum: 2.35s, count: 24044, min: 0ns, max: 545.00us
              -- TableScan[table: lineitem, range filters: [(shipdate, BytesRange: [1996-01-01, 1996-03-31] no nulls)]] -> l_suppkey:BIGINT, l_shipdate:VARCHAR, l_extendedprice:DOUBLE, l_discount:DOUBLE
                 Input: 2265714 rows (749.18MB, 0 batches), Raw Input: 59986052 rows (625.41MB), Output: 2265714 rows (69.91MB, 6011 batches), Cpu time: 5.63s, Blocked wall time: 0ns, Peak memory: 24.00MB, Memory allocations: 12972, Threads: 1, Splits: 80
                    dataSourceWallNanos    sum: 5.75s, count: 6091, min: 5.00us, max: 16.00ms
                    localReadBytes         sum: 0B, count: 1, min: 0B, max: 0B
                    numLocalRead           sum: 0, count: 1, min: 0, max: 0
                    numPrefetch            sum: 0, count: 1, min: 0, max: 0
                    numRamRead             sum: 0, count: 1, min: 0, max: 0
                    numStorageRead         sum: 0, count: 1, min: 0, max: 0
                    prefetchBytes          sum: 0B, count: 1, min: 0B, max: 0B
                    ramReadBytes           sum: 0B, count: 1, min: 0B, max: 0B
                    skippedSplitBytes      sum: 0B, count: 1, min: 0B, max: 0B
                    skippedSplits          sum: 0, count: 1, min: 0, max: 0
                    skippedStrides         sum: 0, count: 1, min: 0, max: 0
                    storageReadBytes       sum: 0B, count: 1, min: 0B, max: 0B
      -- Aggregation[SINGLE max_revenue := max(ROW["total_revenue"])] -> max_revenue:DOUBLE
         Output: 1 rows (32B, 1 batches), Cpu time: 603.00us, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 2, Threads: 1
        -- Aggregation[FINAL [l_suppkey] total_revenue := sum("total_revenue")] -> l_suppkey:BIGINT, total_revenue:DOUBLE
           Output: 100000 rows (2.29MB, 98 batches), Cpu time: 6.19ms, Blocked wall time: 0ns, Peak memory: 4.00MB, Memory allocations: 140, Threads: 1
          -- LocalPartition[GATHER] -> l_suppkey:BIGINT, total_revenue:DOUBLE
             Output: 200000 rows (4.59MB, 98 batches), Cpu time: 853.00us, Blocked wall time: 7.75s, Peak memory: 0B, Memory allocations: 0
             LocalPartition: Input: 100000 rows (2.29MB, 98 batches), Output: 100000 rows (2.29MB, 0 batches), Cpu time: 574.00us, Blocked wall time: 2.35ms, Peak memory: 0B, Memory allocations: 0, Threads: 1
                queuedWallNanos    sum: 88.00us, count: 2, min: 26.00us, max: 62.00us
             LocalExchange: Input: 100000 rows (2.29MB, 0 batches), Output: 100000 rows (2.29MB, 98 batches), Cpu time: 279.00us, Blocked wall time: 7.75s, Peak memory: 0B, Memory allocations: 0, Threads: 1
                queuedWallNanos    sum: 62.00us, count: 1, min: 62.00us, max: 62.00us
            -- Aggregation[PARTIAL [l_suppkey] total_revenue := sum(ROW["part_revenue"])] -> l_suppkey:BIGINT, total_revenue:DOUBLE
               Output: 100000 rows (2.29MB, 98 batches), Cpu time: 745.33ms, Blocked wall time: 0ns, Peak memory: 6.00MB, Memory allocations: 336, Threads: 1
              -- Project[expressions: (l_suppkey:BIGINT, ROW["l_suppkey"]), (part_revenue:DOUBLE, multiply(ROW["l_extendedprice"],minus(1,ROW["l_discount"])))] -> l_suppkey:BIGINT, part_revenue:DOUBLE
                 Output: 2265714 rows (28.35MB, 6011 batches), Cpu time: 1.12s, Blocked wall time: 0ns, Peak memory: 1.00MB, Memory allocations: 5, Threads: 1
                    dataSourceLazyWallNanos    sum: 2.35s, count: 24044, min: 0ns, max: 585.00us
                -- TableScan[table: lineitem, range filters: [(shipdate, BytesRange: [1996-01-01, 1996-03-31] no nulls)]] -> l_suppkey:BIGINT, l_shipdate:VARCHAR, l_extendedprice:DOUBLE, l_discount:DOUBLE
                   Input: 2265714 rows (749.18MB, 0 batches), Raw Input: 59986052 rows (625.41MB), Output: 2265714 rows (69.91MB, 6011 batches), Cpu time: 5.64s, Blocked wall time: 0ns, Peak memory: 24.00MB, Memory allocations: 12972, Threads: 1, Splits: 80
                      dataSourceWallNanos    sum: 5.74s, count: 6091, min: 5.00us, max: 15.97ms
                      localReadBytes         sum: 0B, count: 1, min: 0B, max: 0B
                      numLocalRead           sum: 0, count: 1, min: 0, max: 0
                      numPrefetch            sum: 0, count: 1, min: 0, max: 0
                      numRamRead             sum: 0, count: 1, min: 0, max: 0
                      numStorageRead         sum: 0, count: 1, min: 0, max: 0
                      prefetchBytes          sum: 0B, count: 1, min: 0B, max: 0B
                      ramReadBytes           sum: 0B, count: 1, min: 0B, max: 0B
                      skippedSplitBytes      sum: 0B, count: 1, min: 0B, max: 0B
                      skippedSplits          sum: 0, count: 1, min: 0, max: 0
                      skippedStrides         sum: 0, count: 1, min: 0, max: 0
                      storageReadBytes       sum: 0B, count: 1, min: 0B, max: 0B
```
Tablescan of lineitem takes the most time in the query plan, blocking the join on suppkey.