### PR TITLE
Add NegatedBigintRange filters to dwio/dwrf/reader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -181,6 +181,10 @@ void SelectiveByteRleColumnReader::processFilter(
     case FilterKind::kBigintRange:
       readHelper<common::BigintRange, isDense>(filter, rows, extractValues);
       break;
+    case FilterKind::kNegatedBigintRange:
+      readHelper<common::NegatedBigintRange, isDense>(
+          filter, rows, extractValues);
+      break;
     case FilterKind::kBigintValuesUsingBitmask:
       readHelper<common::BigintValuesUsingBitmask, isDense>(
           filter, rows, extractValues);

--- a/velox/dwio/dwrf/reader/SelectiveIntegerColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerColumnReader.h
@@ -132,6 +132,10 @@ void SelectiveIntegerColumnReader::processFilter(
       readHelper<Reader, common::BigintRange, isDense>(
           filter, rows, extractValues);
       break;
+    case common::FilterKind::kNegatedBigintRange:
+      readHelper<Reader, common::NegatedBigintRange, isDense>(
+          filter, rows, extractValues);
+      break;
     case common::FilterKind::kBigintValuesUsingHashTable:
       readHelper<Reader, common::BigintValuesUsingHashTable, isDense>(
           filter, rows, extractValues);

--- a/velox/dwio/dwrf/test/utils/FilterGenerator.h
+++ b/velox/dwio/dwrf/test/utils/FilterGenerator.h
@@ -242,6 +242,11 @@ class ColumnStats : public AbstractColumnStats {
       }
       return velox::common::createBigintValues(in, true);
     }
+    // sometimes make a negated filter instead (1/4 chance)
+    if (counter_ % 4 == 1 && selectPct < 100.0) {
+      return std::make_unique<velox::common::NegatedBigintRange>(
+          lower, upper, selectPct < 75);
+    }
     return std::make_unique<velox::common::BigintRange>(
         lower, upper, selectPct > 25);
   }


### PR DESCRIPTION
Summary:
This diff updates the dwrf reader to support `NegatedBigintRange` filters when reading integer data from a file. Two types of column readers were updated for this - the `SelectiveByteRleColumnReader` is used for byte (tinyint/int8_t) value reading, while the `SelectiveIntegerColumnReader` is used for the other integer types. Both of these can now read using the new `NegatedBigintRange` filters.

To test this, `FilterGenerator.h` has been modified to occasionally generate `NegatedBigintRange` filters rather than `BigintRange` filters when creating filters for integer columns. This ensures that the reader can handle reading using one such filter.

Reviewed By: Yuhta, gggrace14

Differential Revision: D37534948

