### PR TITLE
Add TPC-H query 21 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -219,6 +219,11 @@ BENCHMARK(q19) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q21) {
+  const auto planContext = queryBuilder->getQueryPlan(21);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q22) {
   const auto planContext = queryBuilder->getQueryPlan(22);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -95,6 +95,11 @@ TEST_P(MultiParquetTpchTest, Q19) {
   assertQuery(19);
 }
 
+TEST_P(MultiParquetTpchTest, Q21) {
+  std::vector<uint32_t> sortingKeys{0, 1};
+  assertQuery(21, std::move(sortingKeys));
+}
+
 TEST_P(MultiParquetTpchTest, Q22) {
   std::vector<uint32_t> sortingKeys{0};
   assertQuery(22, std::move(sortingKeys));

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -91,6 +91,7 @@ class TpchQueryBuilder {
   TpchPlan getQ16Plan() const;
   TpchPlan getQ18Plan() const;
   TpchPlan getQ19Plan() const;
+  TpchPlan getQ21Plan() const;
   TpchPlan getQ22Plan() const;
 
   const std::vector<std::string>& getTableFilePaths(


### PR DESCRIPTION
Adds TPC-H query 21 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 21.
Performance comparison with DuckDb (Parquet file format):
```
| # Num Threads/ Drivers | Velox(seconds) | DuckDB(seconds) |
|:----------------------:|:--------------:|:---------------:|
|            1           |      10.77     |      43.92      |
|            4           |      4.58      |       6.44      | 
|            8           |      3.65      |       4.30      | 
|           16           |      3.48      |       4.82      |
```