### PR TITLE
Back out "Optimize serialized byte size for KllSketch"

### DIFF
--- a/velox/functions/lib/KllSketch.h
+++ b/velox/functions/lib/KllSketch.h
@@ -60,9 +60,6 @@ struct KllSketch {
   /// Add one new value to the sketch.
   void insert(T value);
 
-  /// Call this before serialization can optimize the space used.
-  void compact();
-
   /// Merge this sketch with values from multiple other sketches.
   /// @tparam Iter Iterator type dereferenceable to the same type as this sketch
   ///  (KllSketch<T, Allocator, Compare>)
@@ -125,9 +122,6 @@ struct KllSketch {
   /// Merge with another deserialized sketch.  This is more efficient
   /// than deserialize then merge.
   void mergeDeserialized(const char* data);
-
-  /// Get frequencies of items being tracked.  The result is sorted by item.
-  std::vector<std::pair<T, uint64_t>> getFrequencies() const;
 
  private:
   KllSketch(const Allocator&, uint32_t seed);

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -221,25 +221,6 @@ TEST(KllSketchTest, serialize) {
   EXPECT_EQ(v, v2);
 }
 
-TEST(KllSketchTest, compact) {
-  constexpr int N = 1e5;
-  KllSketch<double> kll(kFromEpsilon(0.001));
-  for (int i = 0; i < N; ++i) {
-    kll.insert(i % 100);
-  }
-  kll.finish();
-  auto kll2 = kll;
-  kll2.compact();
-  EXPECT_GT(kll.serializedByteSize(), 60000);
-  EXPECT_LT(kll2.serializedByteSize(), 7000);
-  auto freq = kll.getFrequencies();
-  auto freq2 = kll2.getFrequencies();
-  ASSERT_EQ(freq.size(), freq2.size());
-  for (int i = 0; i < freq.size(); ++i) {
-    EXPECT_EQ(freq[i], freq2[i]);
-  }
-}
-
 TEST(KllSketchTest, fromRepeatedValue) {
   constexpr int N = 1000;
   constexpr int kTotal = (1 + N) * N / 2;

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -78,7 +78,7 @@ struct KllSketchAccumulator {
     if (!largeCountValues_.empty()) {
       flush();
     }
-    sketch_.compact();
+    sketch_.finish();
   }
 
   const KllSketch<T>& getSketch() {


### PR DESCRIPTION
Summary: This diff introduces regressions to the system, causing crashes. Investigation is currently going on. It will be re-applied when all issues are addressed.

Differential Revision: D37967590

