### PR TITLE
Adaptive tune the partial aggregation buffer size according to the workload

### DIFF
--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -135,7 +135,7 @@ class MemoryUsageTracker
 
   // Increments the reservation for 'this' so that we can allocate at
   // least 'size' bytes on top of the current allocation. This is used
-  // when an a memory user needs to allocate more memory and needs a
+  // when a memory user needs to allocate more memory and needs a
   // guarantee of at least 'size' being available. If less memory ends
   // up being needed, the unused reservation should be released with
   // release().  If the new reserved amount exceeds the usage limit,

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -77,6 +77,15 @@ class QueryConfig {
   static constexpr const char* kMaxPartialAggregationMemory =
       "max_partial_aggregation_memory";
 
+  static constexpr const char* kMaxExtendedPartialAggregationMemory =
+      "max_extended_partial_aggregation_memory";
+
+  /// Output volume as percentage of input volume below which we will not seek
+  /// to increase reduction by using more memory. the data volume is measured as
+  /// the number of rows.
+  static constexpr const char* kPartialAggregationGoodPct =
+      "partial_aggregation_reduction_ratio_threshold";
+
   static constexpr const char* kMaxPartitionedOutputBufferSize =
       "driver.max-page-partitioning-buffer-size";
 
@@ -100,6 +109,16 @@ class QueryConfig {
   uint64_t maxPartialAggregationMemoryUsage() const {
     static constexpr uint64_t kDefault = 1L << 24;
     return get<uint64_t>(kMaxPartialAggregationMemory, kDefault);
+  }
+
+  uint64_t maxExtendedPartialAggregationMemoryUsage() const {
+    static constexpr uint64_t kDefault = 1L << 24;
+    return get<uint64_t>(kMaxExtendedPartialAggregationMemory, kDefault);
+  }
+
+  double partialAggregationGoodPct() const {
+    static constexpr double kDefault = 0.5;
+    return get<double>(kPartialAggregationGoodPct, kDefault);
   }
 
   // Returns the target size for a Task's buffered output. The

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -47,6 +47,8 @@ class HashAggregation : public Operator {
   bool isFinished() override;
 
   void close() override {
+    // Release the unused memory reservation on close.
+    operatorCtx_->pool()->getMemoryUsageTracker()->release();
     Operator::close();
     groupingSet_.reset();
   }
@@ -58,15 +60,23 @@ class HashAggregation : public Operator {
   /// flushed.
   void resetPartialOutputIfNeed();
 
+  /// Invoked on partial output flush to try to bump up the partial aggregation
+  /// memory usage if it needs. 'aggregationPct' is the ratio between the number
+  /// of output rows and the number of input rows as a percentage. It is a
+  /// measure of the effectiveness of the partial aggregation.
+  void maybeIncreasePartialAggregationMemoryUsage(double aggregationPct);
+
   /// Maximum number of rows in the output batch.
   const uint32_t outputBatchSize_;
-
-  const int64_t maxPartialAggregationMemoryUsage_;
 
   const bool isPartialOutput_;
   const bool isDistinct_;
   const bool isGlobal_;
+  const std::shared_ptr<memory::MemoryUsageTracker> memoryTracker_;
+  const double partialAggregationGoodPct_;
+  const int64_t maxExtendedPartialAggregationMemoryUsage_;
 
+  int64_t maxPartialAggregationMemoryUsage_;
   std::unique_ptr<GroupingSet> groupingSet_;
 
   bool partialFull_ = false;
@@ -76,6 +86,9 @@ class HashAggregation : public Operator {
   bool pushdownChecked_ = false;
   bool mayPushdown_ = false;
 
+  /// Count the number of input rows. It is reset on partial aggregation output
+  /// flush.
+  int64_t numInputRows_ = 0;
   /// Count the number of output rows. It is reset on partial aggregation output
   /// flush.
   int64_t numOutputRows_ = 0;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -304,7 +304,6 @@ bool Spiller::fillSpillRuns(
   constexpr int32_t kHashBatchSize = 1024;
   bool final = false;
   if (rowsFromNonSpillingPartitions) {
-    final = true;
     VELOX_CHECK_EQ(
         targetSize,
         RowContainer::kUnlimited,


### PR DESCRIPTION
Adaptive tune the partial aggregation buffer size according to the workload.
It will extend the partial aggregation buffer size on output flush if the current
aggregation reduction ratio is low and there is available memory to reserve.
Also adds new query configs: kMaxExtendedPartialAggregationMemory to cap
the partial aggregation buffer limit, kPartialAggregationGoodPct to set the
good aggregation reduction ratio to avoid using too much memory.