### PR TITLE
Add TPC-H query 20 to TpchQueryBuilder

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -261,6 +261,11 @@ BENCHMARK(q19) {
   benchmark.run(planContext);
 }
 
+BENCHMARK(q20) {
+  const auto planContext = queryBuilder->getQueryPlan(20);
+  benchmark.run(planContext);
+}
+
 BENCHMARK(q21) {
   const auto planContext = queryBuilder->getQueryPlan(21);
   benchmark.run(planContext);

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -99,6 +99,11 @@ TEST_P(MultiParquetTpchTest, Q19) {
   assertQuery(19);
 }
 
+TEST_P(MultiParquetTpchTest, Q20) {
+  std::vector<uint32_t> sortingKeys{0};
+  assertQuery(20, std::move(sortingKeys));
+}
+
 TEST_P(MultiParquetTpchTest, Q21) {
   std::vector<uint32_t> sortingKeys{0, 1};
   assertQuery(21, std::move(sortingKeys));

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -92,6 +92,7 @@ class TpchQueryBuilder {
   TpchPlan getQ17Plan() const;
   TpchPlan getQ18Plan() const;
   TpchPlan getQ19Plan() const;
+  TpchPlan getQ20Plan() const;
   TpchPlan getQ21Plan() const;
   TpchPlan getQ22Plan() const;
 


### PR DESCRIPTION
Adds TPC-H query 20 to TpchQueryBuilder.
Extends TpchBenchmark and ParquetTpchTest with query 20.
Performance comparison with DuckDb (with Parquet file format):
```
| Num Threads/ Drivers | Velox (sec) | DuckDB (sec) |
|:--------------------:|:-----------:|:------------:|
|           1          |     4.0     |     22.09    |
|           4          |     1.77    |     6.89     | 
|           8          |     1.21    |     3.93     | 
|          16          |     1.12    |     3.52     |
```