### PR TITLE
Implement MergeWith for NegatedBytesRange filter

### DIFF
--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1450,6 +1450,8 @@ class NegatedBytesRange final : public Filter {
   }
 
  private:
+  std::unique_ptr<Filter> toMultiRange() const;
+
   std::unique_ptr<BytesRange> nonNegated_;
 };
 

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -20,6 +20,7 @@
 #include <numeric>
 #include <optional>
 
+#include <velox/type/Filter.h>
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include "velox/type/Filter.h"
 
@@ -1628,6 +1629,18 @@ TEST(FilterTest, mergeWithBytesRange) {
   filters.push_back(between("<<", ">>", true));
   filters.push_back(between("ABCDE", "abcde"));
   filters.push_back(between("1", "123456", true));
+
+  filters.push_back(notBetween("b", "f"));
+  filters.push_back(notBetween("b", "f", true));
+  filters.push_back(notBetween("a", "d"));
+  filters.push_back(notBetween("a", "d", true));
+  filters.push_back(notBetweenExclusive("b", "f"));
+  filters.push_back(notBetweenExclusive("b", "f", true));
+
+  // test unbounded negatedRange
+  filters.push_back(
+      std::make_unique<facebook::velox::common::NegatedBytesRange>(
+          "", true, false, "l", false, false, false));
 
   filters.push_back(lessThanOrEqual("k"));
   filters.push_back(lessThanOrEqual("k", true));


### PR DESCRIPTION
Summary: This diff implements the `MergeWith` method for `NegatedBytesRange` filters. Since merging most negated ranges will result in the creation of a `MultiRange` filter that cannot be easily represented otherwise, many of these merges are performed by creating the equivalent `MultiRange` filter with the `toMultiRange` method. This allows the `AND` merge of the new `NegatedBytesRange` filter with another varchar or untyped filter. Tests for this have also been added to `FilterTest.cpp`.

Reviewed By: Yuhta

Differential Revision: D37762978

