### PR TITLE
Explicitly destroy accumulators using external memory in global aggregation

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -104,6 +104,12 @@ GroupingSet::GroupingSet(
   }
 }
 
+GroupingSet::~GroupingSet() {
+  if (isGlobal_) {
+    destroyGlobalAggregations();
+  }
+}
+
 namespace {
 bool equalKeys(
     const std::vector<column_index_t>& keys,
@@ -364,8 +370,6 @@ bool GroupingSet::getGlobalAggregationOutput(
       aggregates_[i]->extractValues(groups, 1, &result->childAt(i));
     }
   }
-
-  destroyGlobalAggregations();
 
   iterator.allocationIndex = std::numeric_limits<int32_t>::max();
   return true;

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -104,10 +104,6 @@ GroupingSet::GroupingSet(
   }
 }
 
-GroupingSet::~GroupingSet() {
-  destroyGlobalAggregations();
-}
-
 namespace {
 bool equalKeys(
     const std::vector<column_index_t>& keys,
@@ -368,6 +364,8 @@ bool GroupingSet::getGlobalAggregationOutput(
       aggregates_[i]->extractValues(groups, 1, &result->childAt(i));
     }
   }
+
+  destroyGlobalAggregations();
 
   iterator.allocationIndex = std::numeric_limits<int32_t>::max();
   return true;

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -374,10 +374,9 @@ bool GroupingSet::getGlobalAggregationOutput(
 }
 
 void GroupingSet::destroyGlobalAggregations() {
-  auto groups = lookup_->hits.data();
-
   for (int32_t i = 0; i < aggregates_.size(); ++i) {
     if (aggregates_[i]->accumulatorUsesExternalMemory()) {
+      auto groups = lookup_->hits.data();
       aggregates_[i]->destroy(folly::Range(groups, 1));
     }
   }

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -364,8 +364,21 @@ bool GroupingSet::getGlobalAggregationOutput(
       aggregates_[i]->extractValues(groups, 1, &result->childAt(i));
     }
   }
+
+  destroyGlobalAggregations();
+
   iterator.allocationIndex = std::numeric_limits<int32_t>::max();
   return true;
+}
+
+void GroupingSet::destroyGlobalAggregations() {
+  auto groups = lookup_->hits.data();
+
+  for (int32_t i = 0; i < aggregates_.size(); ++i) {
+    if (aggregates_[i]->accumulatorUsesExternalMemory()) {
+      aggregates_[i]->destroy(folly::Range(groups, 1));
+    }
+  }
 }
 
 void GroupingSet::populateTempVectors(

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -104,6 +104,10 @@ GroupingSet::GroupingSet(
   }
 }
 
+GroupingSet::~GroupingSet() {
+  destroyGlobalAggregations();
+}
+
 namespace {
 bool equalKeys(
     const std::vector<column_index_t>& keys,
@@ -364,8 +368,6 @@ bool GroupingSet::getGlobalAggregationOutput(
       aggregates_[i]->extractValues(groups, 1, &result->childAt(i));
     }
   }
-
-  destroyGlobalAggregations();
 
   iterator.allocationIndex = std::numeric_limits<int32_t>::max();
   return true;

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -40,6 +40,8 @@ class GroupingSet {
       bool isRawInput,
       OperatorCtx* FOLLY_NONNULL operatorCtx);
 
+  ~GroupingSet();
+
   void addInput(const RowVectorPtr& input, bool mayPushdown);
 
   void noMoreInput();

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -91,6 +91,8 @@ class GroupingSet {
 
   void initializeGlobalAggregation();
 
+  void destroyGlobalAggregations();
+
   void addGlobalAggregationInput(const RowVectorPtr& input, bool mayPushdown);
 
   bool getGlobalAggregationOutput(

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -40,8 +40,6 @@ class GroupingSet {
       bool isRawInput,
       OperatorCtx* FOLLY_NONNULL operatorCtx);
 
-  ~GroupingSet();
-
   void addInput(const RowVectorPtr& input, bool mayPushdown);
 
   void noMoreInput();

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -103,6 +103,14 @@ StreamingAggregation::StreamingAggregation(
       ContainerRowSerde::instance());
 }
 
+StreamingAggregation::~StreamingAggregation() {
+  for (int32_t i = 0; i < aggregates_.size(); ++i) {
+    if (aggregates_[i]->accumulatorUsesExternalMemory()) {
+      aggregates_[i]->destroy(folly::Range(groups_.data(), groups_.size()));
+    }
+  }
+}
+
 void StreamingAggregation::addInput(RowVectorPtr input) {
   input_ = std::move(input);
 }

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/RowContainer.h"
 
+
 namespace facebook::velox::exec {
 
 StreamingAggregation::StreamingAggregation(

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -17,7 +17,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/RowContainer.h"
 
-
 namespace facebook::velox::exec {
 
 StreamingAggregation::StreamingAggregation(

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -30,6 +30,8 @@ class StreamingAggregation : public Operator {
       DriverCtx* driverCtx,
       const std::shared_ptr<const core::AggregationNode>& aggregationNode);
 
+  ~StreamingAggregation();
+
   void addInput(RowVectorPtr input) override;
 
   RowVectorPtr getOutput() override;

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -551,7 +551,8 @@ TEST_F(AggregationTest, global) {
                      "max(c2)",
                      "max(c3)",
                      "max(c4)",
-                     "max(c5)"},
+                     "max(c5)",
+                     "sumnonpod(1)"},
                     {},
                     core::AggregationNode::Step::kPartial,
                     false)
@@ -561,7 +562,9 @@ TEST_F(AggregationTest, global) {
       op,
       "SELECT sum(15), sum(c1), sum(c2), sum(c4), sum(c5), "
       "min(15), min(c1), min(c2), min(c3), min(c4), min(c5), "
-      "max(15), max(c1), max(c2), max(c3), max(c4), max(c5) FROM tmp");
+      "max(15), max(c1), max(c2), max(c3), max(c4), max(c5), sum(1) FROM tmp");
+
+  EXPECT_EQ(NonPODInt64::constructed, NonPODInt64::destructed);
 }
 
 TEST_F(AggregationTest, singleBigintKey) {


### PR DESCRIPTION
When accumulator of global aggregator uses external memory, we need to use destructor of the accumulator through aggregate's destroy method. This can cause memory leak.

This happens for non global aggregates, but not global aggregates. Fixing the issue.