### PR TITLE
Properly classify index streams

### DIFF
--- a/velox/dwio/dwrf/common/Common.h
+++ b/velox/dwio/dwrf/common/Common.h
@@ -68,6 +68,11 @@ enum StreamKind {
   StreamKind_IN_MAP = 11
 };
 
+inline bool isIndexStream(StreamKind kind) {
+  return kind == StreamKind::StreamKind_ROW_INDEX ||
+      kind == StreamKind::StreamKind_BLOOM_FILTER_UTF8;
+}
+
 /**
  * Get the string representation of the StreamKind.
  */

--- a/velox/dwio/dwrf/reader/StripeStream.cpp
+++ b/velox/dwio/dwrf/reader/StripeStream.cpp
@@ -217,7 +217,7 @@ StripeStreamsImpl::getCompressedStream(const DwrfStreamIdentifier& si) const {
   const auto& info = getStreamInfo(si);
 
   std::unique_ptr<dwio::common::SeekableInputStream> streamRead;
-  if (si.kind() == StreamKind::StreamKind_ROW_INDEX) {
+  if (isIndexStream(si.kind())) {
     streamRead = getIndexStreamFromCache(info);
   }
 
@@ -268,7 +268,7 @@ std::unique_ptr<dwio::common::SeekableInputStream> StripeStreamsImpl::getStream(
   }
 
   std::unique_ptr<dwio::common::SeekableInputStream> streamRead;
-  if (si.kind() == StreamKind::StreamKind_ROW_INDEX) {
+  if (isIndexStream(si.kind())) {
     streamRead = getIndexStreamFromCache(info);
   }
 

--- a/velox/dwio/dwrf/writer/LayoutPlanner.cpp
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.cpp
@@ -53,7 +53,7 @@ void LayoutPlanner::plan() {
   // place index before data
   auto iter =
       std::partition(streams_.begin(), streams_.end(), [](auto& stream) {
-        return stream.first->kind() == StreamKind::StreamKind_ROW_INDEX;
+        return isIndexStream(stream.first->kind());
       });
   indexCount_ = iter - streams_.begin();
 

--- a/velox/dwio/dwrf/writer/WriterShared.cpp
+++ b/velox/dwio/dwrf/writer/WriterShared.cpp
@@ -385,9 +385,8 @@ void WriterShared::flushStripe(bool close) {
   auto planner = layoutPlannerFactory_(getStreamList(context), encodingManager);
   planner->plan();
   planner->iterateIndexStreams([&](auto& streamId, auto& content) {
-    DWIO_ENSURE_EQ(
-        streamId.kind(),
-        StreamKind::StreamKind_ROW_INDEX,
+    DWIO_ENSURE(
+        isIndexStream(streamId.kind()),
         "unexpected stream kind ",
         streamId.kind());
     indexLength += content.size();
@@ -398,9 +397,8 @@ void WriterShared::flushStripe(bool close) {
   uint64_t dataLength = 0;
   sink.setMode(WriterSink::Mode::Data);
   planner->iterateDataStreams([&](auto& streamId, auto& content) {
-    DWIO_ENSURE_NE(
-        streamId.kind(),
-        StreamKind::StreamKind_ROW_INDEX,
+    DWIO_ENSURE(
+        !isIndexStream(streamId.kind()),
         "unexpected stream kind ",
         streamId.kind());
     dataLength += content.size();


### PR DESCRIPTION
Summary: Bloom filter should be classified as index instead of data

Differential Revision: D38016241

