### PR TITLE
Add a pool of recyclable vectors

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -218,6 +218,32 @@ class EvalCtx {
     moveOrCopyResult(localResult, rows, *result);
   }
 
+  VectorPool& vectorPool() const {
+    return execCtx_->vectorPool();
+  }
+
+  VectorPtr getVector(const TypePtr& type, vector_size_t size) {
+    return execCtx_->getVector(type, size);
+  }
+
+  bool releaseVector(VectorPtr& vector) {
+    return execCtx_->releaseVector(vector);
+  }
+
+  size_t releaseVectors(std::vector<VectorPtr>& vectors) {
+    return execCtx_->releaseVectors(vectors);
+  }
+
+  /// Makes 'result' writable for 'rows'. Allocates or reuses a vector from the
+  /// pool of 'execCtx_' if needed.
+  void ensureWritable(
+      const SelectivityVector& rows,
+      const TypePtr& type,
+      VectorPtr& result) {
+    BaseVector::ensureWritable(
+        rows, type, execCtx_->pool(), &result, &execCtx_->vectorPool());
+  }
+
  private:
   core::ExecCtx* const FOLLY_NONNULL execCtx_;
   ExprSet* FOLLY_NULLABLE const exprSet_;

--- a/velox/expression/tests/EvalCtxTest.cpp
+++ b/velox/expression/tests/EvalCtxTest.cpp
@@ -16,7 +16,6 @@
 
 #include "gtest/gtest.h"
 
-#include "velox/common/base/Exceptions.h"
 #include "velox/expression/EvalCtx.h"
 #include "velox/vector/tests/VectorTestBase.h"
 
@@ -26,12 +25,11 @@ using namespace facebook::velox::test;
 
 class EvalCtxTest : public testing::Test, public VectorTestBase {
  protected:
-  std::unique_ptr<core::ExecCtx> execCtx_{
-      std::make_unique<core::ExecCtx>(pool_.get(), nullptr)};
+  core::ExecCtx execCtx_{pool_.get(), nullptr};
 };
 
 TEST_F(EvalCtxTest, selectivityVectors) {
-  EvalCtx context(execCtx_.get());
+  EvalCtx context(&execCtx_);
   SelectivityVector all100(100, true);
   SelectivityVector none100(100, false);
 
@@ -51,4 +49,31 @@ TEST_F(EvalCtxTest, selectivityVectors) {
   // Init from existing
   LocalSelectivityVector local2(context, all100);
   EXPECT_EQ(all100, *local2.get());
+}
+
+TEST_F(EvalCtxTest, vectorPool) {
+  EvalCtx context(&execCtx_);
+
+  auto vector = context.getVector(BIGINT(), 1'000);
+  ASSERT_NE(vector, nullptr);
+  ASSERT_EQ(vector->size(), 1'000);
+
+  auto* vectorPtr = vector.get();
+  ASSERT_TRUE(context.releaseVector(vector));
+  ASSERT_EQ(vector, nullptr);
+
+  auto recycledVector = context.getVector(BIGINT(), 2'000);
+  ASSERT_NE(recycledVector, nullptr);
+  ASSERT_EQ(recycledVector->size(), 2'000);
+  ASSERT_EQ(recycledVector.get(), vectorPtr);
+
+  ASSERT_TRUE(context.releaseVector(recycledVector));
+  ASSERT_EQ(recycledVector, nullptr);
+
+  VectorPtr anotherVector;
+  SelectivityVector rows(512);
+  context.ensureWritable(rows, BIGINT(), anotherVector);
+  ASSERT_NE(anotherVector, nullptr);
+  ASSERT_EQ(anotherVector->size(), 512);
+  ASSERT_EQ(anotherVector.get(), vectorPtr);
 }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -49,6 +49,8 @@ class SimpleVector;
 template <typename T>
 class FlatVector;
 
+class VectorPool;
+
 /**
  * Base class for all columnar-based vectors of any type.
  */
@@ -449,7 +451,8 @@ class BaseVector {
       const SelectivityVector& rows,
       const TypePtr& type,
       velox::memory::MemoryPool* pool,
-      std::shared_ptr<BaseVector>* result);
+      std::shared_ptr<BaseVector>* result,
+      VectorPool* vectorPool = nullptr);
 
   virtual void ensureWritable(const SelectivityVector& rows);
 

--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   SelectivityVector.cpp
   SequenceVector.cpp
   VectorEncoding.cpp
+  VectorPool.cpp
   VectorStream.cpp)
 
 target_link_libraries(velox_vector velox_encode velox_memory velox_time

--- a/velox/vector/VectorPool.cpp
+++ b/velox/vector/VectorPool.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/vector/VectorPool.h"
+
+namespace facebook::velox {
+
+inline int32_t toCacheIndex(TypeKind kind) {
+  return static_cast<int32_t>(kind);
+}
+
+VectorPtr VectorPool::get(const TypePtr& type, vector_size_t size) {
+  auto cacheIndex = toCacheIndex(type->kind());
+  if (cacheIndex < kNumCachedVectorTypes && size <= kMaxRecycleSize) {
+    return vectors_[cacheIndex].pop(type, size, *pool_);
+  }
+  return BaseVector::create(type, size, pool_);
+}
+
+bool VectorPool::release(VectorPtr& vector) {
+  if (!vector.unique() || vector->size() > kMaxRecycleSize) {
+    return false;
+  }
+  auto cacheIndex = toCacheIndex(vector->typeKind());
+  if (cacheIndex >= kNumCachedVectorTypes) {
+    return false;
+  }
+  return vectors_[cacheIndex].maybePushBack(vector);
+}
+
+size_t VectorPool::release(std::vector<VectorPtr>& vectors) {
+  size_t numReleased = 0;
+  for (auto& vector : vectors) {
+    if (FOLLY_LIKELY(vector != nullptr)) {
+      if (release(vector)) {
+        ++numReleased;
+      }
+    }
+  }
+  return numReleased;
+}
+
+bool VectorPool::TypePool::maybePushBack(VectorPtr& vector) {
+  if (!vector->isRecyclable()) {
+    return false;
+  }
+  if (size >= kNumPerType) {
+    return false;
+  }
+
+  vector->prepareForReuse();
+  vectors[size++] = std::move(vector);
+  return true;
+}
+
+VectorPtr VectorPool::TypePool::pop(
+    const TypePtr& type,
+    vector_size_t vectorSize,
+    memory::MemoryPool& pool) {
+  if (size) {
+    auto result = std::move(vectors[--size]);
+    if (UNLIKELY(result->rawNulls() != nullptr)) {
+      // This is a recyclable vector, no need to check uniqueness.
+      simd::memset(
+          const_cast<uint64_t*>(result->rawNulls()),
+          bits::kNotNullByte,
+          bits::roundUp(std::min<int32_t>(vectorSize, result->size()), 64) / 8);
+    }
+    if (UNLIKELY(
+            result->typeKind() == TypeKind::VARCHAR ||
+            result->typeKind() == TypeKind::VARBINARY)) {
+      simd::memset(
+          const_cast<void*>(result->valuesAsVoid()),
+          0,
+          std::min<int32_t>(vectorSize, result->size()) * sizeof(StringView));
+    }
+    if (result->size() != vectorSize) {
+      result->resize(vectorSize);
+    }
+    return result;
+  }
+  return BaseVector::create(type, vectorSize, &pool);
+}
+} // namespace facebook::velox

--- a/velox/vector/VectorPool.h
+++ b/velox/vector/VectorPool.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox {
+
+/// A thread-level cache of pre-allocated flat vectors of different types.
+/// Keeps up to 10 recyclable vectors of each of primitive types. A vector is
+/// recyclable if it is flat and recursively singly-referenced.
+class VectorPool {
+ public:
+  explicit VectorPool(memory::MemoryPool* pool) : pool_{pool} {}
+
+  /// Gets a possibly recycled vector of 'type and 'size'. Allocates from
+  /// 'pool_' if no pre-allocated vector or type is a complex type.
+  VectorPtr get(const TypePtr& type, vector_size_t size);
+
+  /// Moves vector into 'this' if it is flat, recursively singly referenced and
+  /// there is space.
+  bool release(VectorPtr& vector);
+
+  size_t release(std::vector<VectorPtr>& vectors);
+
+ private:
+  static constexpr int32_t kNumCachedVectorTypes =
+      static_cast<int32_t>(TypeKind::ARRAY);
+  /// Max number of elements for a vector to be recyclable. The larger
+  /// the batch the less the win from recycling.
+  static constexpr vector_size_t kMaxRecycleSize = 64 * 1024;
+  static constexpr int32_t kNumPerType = 10;
+
+  struct TypePool {
+    int32_t size{0};
+    std::array<VectorPtr, kNumPerType> vectors;
+
+    bool maybePushBack(VectorPtr& vector);
+
+    VectorPtr pop(
+        const TypePtr& type,
+        vector_size_t vectorSize,
+        memory::MemoryPool& pool);
+  };
+
+  memory::MemoryPool* const pool_;
+
+  /// Caches of pre-allocated vectors indexed by typeKind.
+  std::array<TypePool, kNumCachedVectorTypes> vectors_;
+};
+
+} // namespace facebook::velox

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
   velox_vector_test
   VectorCompareTest.cpp
   VectorMakerTest.cpp
+  VectorPoolTest.cpp
   VectorTest.cpp
   VectorToStringTest.cpp
   VectorEstimateFlatSizeTest.cpp

--- a/velox/vector/tests/VectorPoolTest.cpp
+++ b/velox/vector/tests/VectorPoolTest.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/vector/VectorPool.h"
+#include <gtest/gtest.h>
+#include "velox/vector/tests/VectorTestBase.h"
+
+namespace facebook::velox::test {
+
+class VectorPoolTest : public testing::Test, public test::VectorTestBase {};
+
+TEST_F(VectorPoolTest, basic) {
+  VectorPool vectorPool(pool());
+
+  // Get new vector from the pool.
+  auto vector = vectorPool.get(BIGINT(), 1'000);
+  ASSERT_NE(vector, nullptr);
+  ASSERT_EQ(1'000, vector->size());
+
+  // Return the vector to the pool and fetch it back.
+  auto* vectorPtr = vector.get();
+  ASSERT_TRUE(vectorPool.release(vector));
+  ASSERT_EQ(vector, nullptr);
+
+  auto recycledVector = vectorPool.get(BIGINT(), 1'000);
+  ASSERT_NE(recycledVector, nullptr);
+  ASSERT_EQ(vectorPtr, recycledVector.get());
+  ASSERT_EQ(1'000, recycledVector->size());
+
+  // Get another vector from the pool.
+  auto anotherVector = vectorPool.get(BIGINT(), 1'000);
+  ASSERT_NE(anotherVector, nullptr);
+  ASSERT_NE(anotherVector.get(), recycledVector.get());
+  ASSERT_EQ(1'000, anotherVector->size());
+
+  // Return the vector to the pool and fetch it back using a larger size.
+  auto* anotherVectorPtr = anotherVector.get();
+  ASSERT_TRUE(vectorPool.release(anotherVector));
+  ASSERT_EQ(anotherVector, nullptr);
+
+  auto anotherRecycledVector = vectorPool.get(BIGINT(), 2'000);
+  ASSERT_NE(anotherRecycledVector, nullptr);
+  ASSERT_EQ(anotherRecycledVector.get(), anotherVectorPtr);
+  ASSERT_EQ(2'000, anotherRecycledVector->size());
+
+  // Verify that multiply-referenced vector cannot be returned to the pool.
+  auto copy = anotherRecycledVector;
+  ASSERT_FALSE(vectorPool.release(anotherRecycledVector));
+}
+
+TEST_F(VectorPoolTest, limit) {
+  VectorPool vectorPool(pool());
+
+  // Fill up vector pool and verify that vectors are not added above the limit.
+  std::vector<VectorPtr> vectors(15);
+  std::vector<BaseVector*> vectorPtrs(15);
+  for (auto i = 0; i < 15; ++i) {
+    vectors[i] = vectorPool.get(BIGINT(), 1'000);
+    ASSERT_NE(vectors[i], nullptr);
+    vectorPtrs[i] = vectors[i].get();
+  }
+
+  // Verify that we can release only 'limit' number of vectors.
+  for (auto i = 0; i < 10; ++i) {
+    ASSERT_TRUE(vectorPool.release(vectors[i]));
+    ASSERT_EQ(vectors[i], nullptr);
+  }
+
+  for (auto i = 10; i < 15; ++i) {
+    ASSERT_FALSE(vectorPool.release(vectors[i]));
+    ASSERT_NE(vectors[i], nullptr);
+  }
+
+  // Fetch recycled vectors from the pool.
+  for (auto i = 9; i >= 0; --i) {
+    vectors[i] = vectorPool.get(BIGINT(), 1'000);
+    ASSERT_NE(vectors[i], nullptr);
+    ASSERT_EQ(vectors[i].get(), vectorPtrs[i]);
+  }
+
+  // Return all vectors to the pool. Verify that only 'limit' number of vectors
+  // can be returned.
+  ASSERT_EQ(vectorPool.release(vectors), 10);
+}
+} // namespace facebook::velox::test


### PR DESCRIPTION
ML data preprocessing workloads perform simple calculations over small batches
of flat vectors. The overhead of allocating vectors for intermediate results in
these workloads is significant. This change adds a thread-local pool of recyclable
vectors. This pool will be used to reduce allocations during expression evaluation.

VectorPool holds up to 10 recycled vectors for each primitive type.

VectorPool::get(type, size) returns a vector of the specified type and size. If
a recycled vector of the same type is available, it is resized and returned.
Otherwise, a new vector is allocated from the memory pool passed in the
constructor. 

VectorPool::release(vector) checks if the vector is recyclable, e.g. flat and
signly-referenced, and std::moves it to the pool. If vector is not recyclable
it is left in place. Release operation is best effort and returns a boolean
indicating whether the vector was successfully moved into the pool.

VectorPool::release(vectors) is a convenience method to return multiple vectors
to the pool at once. Only a subset of recyclable vectors is moved into the
pool. The rest are left in place. This operations returns the number of vectors
successfully moved into the pool, which can be 0.

Complex type vectors do not support recycling. These are always allocated from 
the memory pool. 

Before this change, ExecCtx hosted pools of SelectivityVectors and
DecodedVectors. Now, ExecCtx also hosts a VectorPool.

VectorPool stored in ExecCtx is also accessible from an EvalCtx.

BaseVector::ensureWritable now takes an optional VectorPool parameter.

A new EvalCtx::ensureWritable method is a convenient shortcut for 
BaseVector::ensureWritable.