### PR TITLE
Add NegatedBytesRange filters to dwio/dwrf/reader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -150,6 +150,10 @@ void SelectiveStringDictionaryColumnReader::processFilter(
     case common::FilterKind::kBytesRange:
       readHelper<common::BytesRange, isDense>(filter, rows, extractValues);
       break;
+    case common::FilterKind::kNegatedBytesRange:
+      readHelper<common::NegatedBytesRange, isDense>(
+          filter, rows, extractValues);
+      break;
     case common::FilterKind::kBytesValues:
       readHelper<common::BytesValues, isDense>(filter, rows, extractValues);
       break;

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -397,6 +397,10 @@ void SelectiveStringDirectColumnReader::processFilter(
     case common::FilterKind::kBytesRange:
       readHelper<common::BytesRange, isDense>(filter, rows, extractValues);
       break;
+    case common::FilterKind::kNegatedBytesRange:
+      readHelper<common::NegatedBytesRange, isDense>(
+          filter, rows, extractValues);
+      break;
     case common::FilterKind::kBytesValues:
       readHelper<common::BytesValues, isDense>(filter, rows, extractValues);
       break;

--- a/velox/dwio/dwrf/test/utils/FilterGenerator.cpp
+++ b/velox/dwio/dwrf/test/utils/FilterGenerator.cpp
@@ -159,6 +159,18 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRangeFilter(
         inRange, selectPct > 25);
   }
 
+  // sometimes create a negated filter instead
+  if (counter_ % 4 == 1 && selectPct < 100.0) {
+    return std::make_unique<velox::common::NegatedBytesRange>(
+        std::string(lower),
+        false,
+        false,
+        std::string(upper),
+        false,
+        false,
+        selectPct < 75);
+  }
+
   return std::make_unique<velox::common::BytesRange>(
       std::string(lower),
       false,


### PR DESCRIPTION
Summary: This diff integrates the new `NegatedBytesRange` filters into the dwrf reader by adding code to `SelectiveStringDictionaryColumnReader.h` and `SelectiveStringDirectColumnReader.cpp` to support reading using the new filter. Additional tests were added to `FilterGenerator.cpp` to sometimes generate these types of filters for testing the dwrf reader.

Reviewed By: Yuhta

Differential Revision: D37764508

