### PR TITLE
Skip fuzzer test for functions that need variable bindings

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -203,7 +203,8 @@ std::optional<CallableSignature> processSignature(
     const exec::FunctionSignature& signature) {
   // Don't support functions with parametrized signatures or variable number of
   // arguments yet.
-  if (!signature.typeVariableConstants().empty() || signature.variableArity()) {
+  if (!signature.typeVariableConstants().empty() || signature.variableArity() ||
+      !signature.variables().empty()) {
     LOG(WARNING) << "Skipping unsupported signature: " << functionName
                  << signature.toString();
     return std::nullopt;


### PR DESCRIPTION
Decimal arithmetic functions like decimal Add, Subtract etc. require not only signature binding but also variable bindings to create DECIMAL type with precision and scale.

Example:
`DECIMAL(x,y) plus(DECIMAL(aR, aS), DECIMAL(bR, bS));`

In the above function signature the variables `aR, aS, bR and bS` require binding with constants. This is essential to resolve the return type. Today, fuzzer test framework has no capability to assign suitable constants to these variables and hence will fail `Signature::tryResolveType` call.

This change will skip function signatures that have a non-empty `variables` member in the `Signature`.