### PR TITLE
Simdize comparison functions.

### DIFF
--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2179,7 +2179,7 @@ TEST_F(ExprTest, flatNoNullsFastPath) {
 
   exprSet = compileExpression("if (a > 10::integer, 0::integer, b)", rowType);
   ASSERT_EQ(1, exprSet->exprs().size());
-  ASSERT_TRUE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath())
+  ASSERT_FALSE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath())
       << exprSet->toString();
 
   // If statement with 'then' or 'else' branch that can return null does not
@@ -2193,7 +2193,7 @@ TEST_F(ExprTest, flatNoNullsFastPath) {
       "case when a > 10::integer then 1 when b > 10::integer then 2 else 3 end",
       rowType);
   ASSERT_EQ(1, exprSet->exprs().size());
-  ASSERT_TRUE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath())
+  ASSERT_FALSE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath())
       << exprSet->toString();
 
   // Switch without an else clause doesn't support fast path.
@@ -2208,13 +2208,13 @@ TEST_F(ExprTest, flatNoNullsFastPath) {
 
   exprSet = compileExpression("a > 10::integer AND b < 0::integer", rowType);
   ASSERT_EQ(1, exprSet->exprs().size());
-  ASSERT_TRUE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath())
+  ASSERT_FALSE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath())
       << exprSet->toString();
 
   exprSet = compileExpression(
       "a > 10::integer OR (b % 7::integer == 4::integer)", rowType);
   ASSERT_EQ(1, exprSet->exprs().size());
-  ASSERT_TRUE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath())
+  ASSERT_FALSE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath())
       << exprSet->toString();
 
   // Coalesce expression.

--- a/velox/functions/lib/RegistrationHelpers.h
+++ b/velox/functions/lib/RegistrationHelpers.h
@@ -55,6 +55,15 @@ void registerBinaryScalar(const std::vector<std::string>& aliases) {
   registerFunction<T, TReturn, Date, Date>(aliases);
 }
 
+template <template <class> class T, typename TReturn>
+void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
+  registerFunction<T, TReturn, Varchar, Varchar>(aliases);
+  registerFunction<T, TReturn, Varbinary, Varbinary>(aliases);
+  registerFunction<T, TReturn, bool, bool>(aliases);
+  registerFunction<T, TReturn, Timestamp, Timestamp>(aliases);
+  registerFunction<T, TReturn, Date, Date>(aliases);
+}
+
 template <template <class> class T>
 void registerUnaryIntegral(const std::vector<std::string>& aliases) {
   registerFunction<T, int8_t, int8_t>(aliases);

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
   ArrayIntersectExcept.cpp
   ArrayPosition.cpp
   ArraySort.cpp
+  Comparisons.cpp
   DecimalArithmetic.cpp
   ElementAt.cpp
   FilterFunctions.cpp

--- a/velox/functions/prestosql/Comparisons.cpp
+++ b/velox/functions/prestosql/Comparisons.cpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/Comparisons.h"
+#include "velox/functions/Udf.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::functions {
+
+namespace {
+
+/// This class implements comparison for vectors of primitive types using SIMD.
+/// Currently this only supports fixed length primitive types (except Boolean).
+/// It also requires the vectors to have a flat encoding.
+/// If the vector encoding is not flat, we revert to non simd approach.
+template <typename ComparisonOp, typename Arch = xsimd::default_arch>
+struct SimdComparator {
+  template <typename T, bool isConstant>
+  inline auto loadSimdData(const T* rawData, vector_size_t offset) {
+    using d_type = xsimd::batch<T>;
+    if constexpr (isConstant) {
+      return xsimd::broadcast<T>(rawData[0]);
+    }
+    return d_type::load_unaligned(rawData + offset);
+  }
+
+  template <typename T, bool isLeftConstant, bool isRightConstant>
+  void applySimdComparison(
+      vector_size_t begin,
+      vector_size_t end,
+      const T* rawLhs,
+      const T* rawRhs,
+      uint8_t* rawResult) {
+    using d_type = xsimd::batch<T>;
+    constexpr auto numScalarElements = d_type::size;
+    const auto vectorEnd = (end - begin) - (end - begin) % numScalarElements;
+
+    if constexpr (numScalarElements == 2 || numScalarElements == 4) {
+      for (auto i = begin; i < vectorEnd; i += 8) {
+        rawResult[i / 8] = 0;
+        for (auto j = 0; j < 8 && j < vectorEnd; j += numScalarElements) {
+          auto left = loadSimdData<T, isLeftConstant>(rawLhs, i + j);
+          auto right = loadSimdData<T, isRightConstant>(rawRhs, i + j);
+
+          uint8_t res = simd::toBitMask(ComparisonOp()(left, right));
+          rawResult[i / 8] |= res << j;
+        }
+      }
+    } else {
+      for (auto i = begin; i < vectorEnd; i += numScalarElements) {
+        auto left = loadSimdData<T, isLeftConstant>(rawLhs, i);
+        auto right = loadSimdData<T, isRightConstant>(rawRhs, i);
+
+        auto res = simd::toBitMask(ComparisonOp()(left, right));
+        if constexpr (numScalarElements == 8) {
+          rawResult[i / 8] = res;
+        } else if constexpr (numScalarElements == 16) {
+          uint16_t* addr = reinterpret_cast<uint16_t*>(rawResult + i / 8);
+          *addr = res;
+        } else if constexpr (numScalarElements == 32) {
+          uint32_t* addr = reinterpret_cast<uint32_t*>(rawResult + i / 8);
+          *addr = res;
+        } else {
+          VELOX_FAIL("Unsupported number of scalar elements");
+        }
+      }
+    }
+
+    // Evaluate remaining values.
+    for (auto i = vectorEnd; i < end; i++) {
+      if constexpr (isRightConstant) {
+        bits::setBit(rawResult, i, ComparisonOp()(rawLhs[i], rawRhs[0]));
+      } else if constexpr (isLeftConstant) {
+        bits::setBit(rawResult, i, ComparisonOp()(rawLhs[0], rawRhs[i]));
+      } else {
+        bits::setBit(rawResult, i, ComparisonOp()(rawLhs[i], rawRhs[i]));
+      }
+    }
+  }
+
+  template <
+      TypeKind kind,
+      typename std::enable_if_t<
+          xsimd::has_simd_register<
+              typename TypeTraits<kind>::NativeType>::value,
+          int> = 0>
+  void applyComparison(
+      const SelectivityVector& rows,
+      DecodedVector& lhs,
+      DecodedVector& rhs,
+      exec::EvalCtx* context,
+      VectorPtr* result) {
+    using T = typename TypeTraits<kind>::NativeType;
+
+    auto rawRhs = rhs.template data<T>();
+    auto rawLhs = lhs.template data<T>();
+    auto resultVector = (*result)->asUnchecked<FlatVector<bool>>();
+    auto rawResult = resultVector->mutableRawValues<uint8_t>();
+
+    auto isSimdizable = lhs.isIdentityMapping() && rhs.isIdentityMapping() &&
+        rows.isAllSelected();
+
+    if (!isSimdizable) {
+      context->template applyToSelectedNoThrow(rows, [&](auto row) {
+        auto l = lhs.template valueAt<T>(row);
+        auto r = rhs.template valueAt<T>(row);
+        auto filtered = ComparisonOp()(l, r);
+        resultVector->set(row, filtered);
+      });
+      return;
+    }
+
+    if (lhs.isConstantMapping()) {
+      applySimdComparison<T, true, false>(
+          rows.begin(), rows.end(), rawLhs, rawRhs, rawResult);
+    } else if (rhs.isConstantMapping()) {
+      applySimdComparison<T, false, true>(
+          rows.begin(), rows.end(), rawLhs, rawRhs, rawResult);
+    } else {
+      applySimdComparison<T, false, false>(
+          rows.begin(), rows.end(), rawLhs, rawRhs, rawResult);
+    }
+
+    auto nullsBuffer = resultVector->mutableRawNulls();
+    bits::fillBits(nullsBuffer, rows.begin(), rows.end(), bits::kNotNull);
+  }
+
+  template <
+      TypeKind kind,
+      typename std::enable_if_t<
+          !xsimd::has_simd_register<
+              typename TypeTraits<kind>::NativeType>::value,
+          int> = 0>
+  void applyComparison(
+      const SelectivityVector& rows,
+      DecodedVector& lhs,
+      DecodedVector& rhs,
+      exec::EvalCtx* context,
+      VectorPtr* result) {
+    VELOX_FAIL("Unsupported type for SIMD comparison");
+  }
+};
+
+template <typename ComparisonOp, typename Arch = xsimd::default_arch>
+class ComparisonSimdFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx* context,
+      VectorPtr* result) const override {
+    VELOX_CHECK_EQ(args.size(), 2, "Comparison requires two arguments");
+    VELOX_CHECK_EQ(args[0]->typeKind(), args[1]->typeKind());
+    VELOX_USER_CHECK_EQ(outputType, BOOLEAN());
+
+    BaseVector::ensureWritable(rows, BOOLEAN(), context->pool(), result);
+
+    exec::LocalDecodedVector lhs(context, *args[0], rows);
+    exec::LocalDecodedVector rhs(context, *args[1], rows);
+    auto comparator = SimdComparator<ComparisonOp>{};
+
+    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        comparator.template applyComparison,
+        args[0]->typeKind(),
+        rows,
+        *lhs.get(),
+        *rhs.get(),
+        context,
+        result);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+
+    for (const auto& inputType :
+         {"tinyint", "smallint", "integer", "bigint", "real", "double"}) {
+      signatures.push_back(exec::FunctionSignatureBuilder()
+                               .returnType("boolean")
+                               .argumentType(inputType)
+                               .argumentType(inputType)
+                               .build());
+    }
+
+    return signatures;
+  }
+};
+
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_simd_comparison_eq,
+    (ComparisonSimdFunction<std::equal_to<>>::signatures()),
+    (std::make_unique<ComparisonSimdFunction<std::equal_to<>>>()));
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_simd_comparison_neq,
+    (ComparisonSimdFunction<std::not_equal_to<>>::signatures()),
+    (std::make_unique<ComparisonSimdFunction<std::not_equal_to<>>>()));
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_simd_comparison_lt,
+    (ComparisonSimdFunction<std::less<>>::signatures()),
+    (std::make_unique<ComparisonSimdFunction<std::less<>>>()));
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_simd_comparison_gt,
+    (ComparisonSimdFunction<std::greater<>>::signatures()),
+    (std::make_unique<ComparisonSimdFunction<std::greater<>>>()));
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_simd_comparison_lte,
+    (ComparisonSimdFunction<std::less_equal<>>::signatures()),
+    (std::make_unique<ComparisonSimdFunction<std::less_equal<>>>()));
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_simd_comparison_gte,
+    (ComparisonSimdFunction<std::greater_equal<>>::signatures()),
+    (std::make_unique<ComparisonSimdFunction<std::greater_equal<>>>()));
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -131,3 +131,8 @@ target_link_libraries(velox_functions_prestosql_benchmarks_zip
 add_executable(velox_functions_prestosql_benchmarks_row Row.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_row
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_comparisons
+               ComparisonsBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_comparisons
+                      ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/ComparisonsBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ComparisonsBenchmark.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/RegistrationHelpers.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/Comparisons.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::functions {
+
+void registerVectorFunctions() {
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_eq, "eq");
+  registerBinaryScalar<EqFunction, bool>({"nonsimd_eq"});
+}
+
+} // namespace facebook::velox::functions
+
+namespace {
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions;
+
+class ComparisonsBechmark
+    : public facebook::velox::functions::test::FunctionBenchmarkBase {
+ public:
+  ComparisonsBechmark() {
+    registerVectorFunctions();
+  }
+
+  template <TypeKind kind>
+  RowVectorPtr createRowData() {
+    VELOX_CHECK(TypeTraits<kind>::isPrimitiveType);
+    VectorFuzzer::Options opts;
+    opts.nullRatio = 0;
+    opts.vectorSize = 10'000;
+    VectorFuzzer fuzzer(opts, execCtx_.pool());
+    auto type = TypeTraits<kind>::ImplType::create();
+    auto vectorLeft = fuzzer.fuzzFlat(type);
+    auto vectorRight = fuzzer.fuzzFlat(type);
+    return vectorMaker_.rowVector({vectorLeft, vectorRight});
+  }
+
+  template <TypeKind kind>
+  void runNonSimdComparison() {
+    folly::BenchmarkSuspender suspender;
+    auto rowVector = createRowData<kind>();
+    auto exprSet = compileExpression("nonsimd_eq(c0, c1)", rowVector->type());
+    suspender.dismiss();
+
+    doRun(exprSet, rowVector);
+  }
+
+  template <TypeKind kind>
+  void runSimdComparison() {
+    folly::BenchmarkSuspender suspender;
+    registerVectorFunctions();
+    auto rowVector = createRowData<kind>();
+    auto exprSet = compileExpression("eq(c0, c1)", rowVector->type());
+    suspender.dismiss();
+    doRun(exprSet, rowVector);
+  }
+
+  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
+    uint32_t cnt = 0;
+    for (auto i = 0; i < 100; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+};
+
+BENCHMARK(non_simd_bigint_eq) {
+  ComparisonsBechmark benchmark;
+  benchmark.runNonSimdComparison<TypeKind::BIGINT>();
+}
+
+BENCHMARK_RELATIVE(simd_bigint_eq) {
+  ComparisonsBechmark benchmark;
+  benchmark.runSimdComparison<TypeKind::BIGINT>();
+}
+
+BENCHMARK(non_simd_tinyint_eq) {
+  ComparisonsBechmark benchmark;
+  benchmark.runNonSimdComparison<TypeKind::TINYINT>();
+}
+
+BENCHMARK_RELATIVE(simd_tinyint_eq) {
+  ComparisonsBechmark benchmark;
+  benchmark.runSimdComparison<TypeKind::TINYINT>();
+}
+
+} // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -21,14 +21,26 @@
 namespace facebook::velox::functions {
 
 void registerComparisonFunctions() {
-  registerBinaryScalar<EqFunction, bool>({"eq"});
+  registerNonSimdizableScalar<EqFunction, bool>({"eq"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_eq, "eq");
   registerFunction<EqFunction, bool, Generic<T1>, Generic<T1>>({"eq"});
 
+  // Not enabling simd for neq due to xsimd bug.
+  // See here: https://github.com/xtensor-stack/xsimd/issues/805
   registerBinaryScalar<NeqFunction, bool>({"neq"});
-  registerBinaryScalar<LtFunction, bool>({"lt"});
-  registerBinaryScalar<GtFunction, bool>({"gt"});
-  registerBinaryScalar<LteFunction, bool>({"lte"});
-  registerBinaryScalar<GteFunction, bool>({"gte"});
+
+  registerNonSimdizableScalar<LtFunction, bool>({"lt"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lt, "lt");
+
+  registerNonSimdizableScalar<GtFunction, bool>({"gt"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gt, "gt");
+
+  registerNonSimdizableScalar<LteFunction, bool>({"lte"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lte, "lte");
+
+  registerNonSimdizableScalar<GteFunction, bool>({"gte"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gte, "gte");
+
   registerBinaryScalar<DistinctFromFunction, bool>({"distinct_from"});
 
   registerFunction<BetweenFunction, bool, int8_t, int8_t, int8_t>({"between"});

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
@@ -290,4 +292,199 @@ TEST_F(ComparisonsTest, eqNestedComplex) {
         evaluate<SimpleVector<bool>>("c0 == c1", makeRowVector({row1, row2}));
     ASSERT_EQ(result->isNullAt(0), true);
   }
+}
+
+namespace {
+template <typename Tp, typename Op, const char* fnName>
+struct ComparisonTypeOp {
+  typedef Tp type;
+  typedef Op fn;
+  std::string sqlFunction{fnName};
+
+  static std::string toString() {
+    return fmt::format("{}:{}", Tp().toString(), fnName);
+  }
+};
+
+const char eq[] = "eq";
+const char neq[] = "neq";
+const char lt[] = "lt";
+const char gt[] = "gt";
+const char lte[] = "lte";
+const char gte[] = "gte";
+
+#define ComparisonTypes(Tp)                           \
+  ComparisonTypeOp<Tp, std::equal_to<>, eq>,          \
+      ComparisonTypeOp<Tp, std::not_equal_to<>, neq>, \
+      ComparisonTypeOp<Tp, std::less<>, lt>,          \
+      ComparisonTypeOp<Tp, std::greater<>, gt>,       \
+      ComparisonTypeOp<Tp, std::less_equal<>, lte>,   \
+      ComparisonTypeOp<Tp, std::greater_equal<>, gte>
+
+typedef ::testing::Types<
+    ComparisonTypes(TinyintType),
+    ComparisonTypes(SmallintType),
+    ComparisonTypes(IntegerType),
+    ComparisonTypes(BigintType),
+    ComparisonTypes(RealType),
+    ComparisonTypes(DoubleType)>
+    comparisonTypes;
+} // namespace
+
+template <typename ComparisonTypeOp>
+class SimdComparisonsTest : public functions::test::FunctionBaseTest {
+ public:
+  using T = typename ComparisonTypeOp::type::NativeType::NativeType;
+  using ComparisonOp = typename ComparisonTypeOp::fn;
+  const std::string sqlFn = ComparisonTypeOp().sqlFunction;
+
+  auto checkConstantComparison(
+      const std::vector<T>& data,
+      T constVal,
+      bool constantRhs = true) {
+    auto vector1 = makeFlatVector<T>(data);
+    auto vector2 = makeConstant<T>(constVal, vector1->size());
+    auto rowVector = constantRhs ? makeRowVector({vector1, vector2})
+                                 : makeRowVector({vector2, vector1});
+    return evaluate<SimpleVector<bool>>(
+        fmt::format("{}(c0, c1)", sqlFn), rowVector);
+  }
+
+  void vectorComparisonImpl(
+      const std::vector<T>& lhs,
+      const std::vector<T>& rhs) {
+    auto rowVector =
+        makeRowVector({makeFlatVector<T>(lhs), makeFlatVector<T>(rhs)});
+    auto result = evaluate<SimpleVector<bool>>(
+        fmt::format("{}(c0, c1)", sqlFn), rowVector);
+
+    auto expectedResult = std::vector<bool>();
+    expectedResult.reserve(lhs.size());
+    for (auto i = 0; i < lhs.size(); i++) {
+      expectedResult.push_back(ComparisonOp()(lhs[i], rhs[i]));
+    }
+
+    test::assertEqualVectors(result, makeFlatVector<bool>(expectedResult));
+  }
+
+  void testVectorComparison(
+      const std::vector<T>& lhs,
+      const std::vector<T>& rhs) {
+    vectorComparisonImpl(lhs, rhs);
+    vectorComparisonImpl(rhs, lhs);
+  }
+
+  void testConstant(uint32_t vectorLength, T constVal) {
+    auto data = std::vector<T>(vectorLength);
+    for (int i = 0; i < vectorLength; i++) {
+      data[i] = i;
+    }
+
+    auto result = checkConstantComparison(data, constVal);
+    ASSERT_EQ(result->size(), vectorLength);
+
+    for (int i = 0; i < vectorLength; i++) {
+      ASSERT_FALSE(result->isNullAt(i));
+      ASSERT_EQ(result->valueAt(i), ComparisonOp()(((T)i), constVal))
+          << "Values not matching at " << i;
+    }
+
+    // Now check converse
+    result = checkConstantComparison(data, constVal, false);
+    ASSERT_EQ(result->size(), vectorLength);
+
+    for (int i = 0; i < vectorLength; i++) {
+      ASSERT_FALSE(result->isNullAt(i));
+      ASSERT_EQ(result->valueAt(i), ComparisonOp()(constVal, ((T)i)))
+          << "Values not matching at " << i;
+    }
+  }
+
+  void testFlat() {
+    // Basic comparison test.
+    auto lhsVector = std::vector<T>{1, 2, 3, 4, 5, 6, 7};
+    auto rhsVector = std::vector<T>{1, 2, 3, 7, 8, 9, 0};
+
+    testVectorComparison(lhsVector, rhsVector);
+
+    // Test some larger vectors.
+    lhsVector = std::vector<T>(2047);
+    std::fill(
+        lhsVector.begin(), lhsVector.end(), std::numeric_limits<T>::max());
+    lhsVector[13] = std::numeric_limits<T>::min();
+    lhsVector[257] = std::numeric_limits<T>::min();
+
+    rhsVector = std::vector<T>(lhsVector.size());
+    std::fill(
+        rhsVector.begin(), rhsVector.end(), std::numeric_limits<T>::min());
+
+    testVectorComparison(lhsVector, rhsVector);
+
+    // Add tests against Nan and other edge cases.
+    if constexpr (std::is_floating_point_v<T>) {
+      lhsVector = std::vector<T>(47);
+      rhsVector = std::vector<T>(47);
+
+      std::fill(
+          lhsVector.begin(),
+          lhsVector.end(),
+          std::numeric_limits<T>::signaling_NaN());
+      std::fill(
+          rhsVector.begin(),
+          rhsVector.end(),
+          std::numeric_limits<T>::signaling_NaN());
+      testVectorComparison(lhsVector, rhsVector);
+
+      std::fill(
+          lhsVector.begin(),
+          lhsVector.end(),
+          std::numeric_limits<T>::signaling_NaN());
+      std::fill(rhsVector.begin(), rhsVector.end(), 1);
+      testVectorComparison(lhsVector, rhsVector);
+    }
+  }
+
+  void testDictionary() {
+    // Identity mapping, however this will result in non-simd path.
+    auto makeDictionary = [&](const std::vector<T>& data) {
+      auto base = makeFlatVector(data);
+      auto indices = makeIndices(data.size(), [](auto row) { return row; });
+      return wrapInDictionary(indices, data.size(), base);
+    };
+
+    auto lhs = std::vector<T>{1, 2, 3, 4, 5};
+    auto rhs = std::vector<T>{1, 0, 0, 0, 5};
+    auto lhsVector = makeDictionary(lhs);
+    auto rhsVector = makeDictionary(rhs);
+
+    auto rowVector = makeRowVector({lhsVector, rhsVector});
+    auto result = evaluate<SimpleVector<bool>>(
+        fmt::format("{}(c0, c1)", sqlFn), rowVector);
+    auto expectedResult = std::vector<bool>();
+    expectedResult.reserve(lhsVector->size());
+    for (auto i = 0; i < lhsVector->size(); i++) {
+      expectedResult.push_back(ComparisonOp()(lhs[i], rhs[i]));
+    }
+    test::assertEqualVectors(result, makeFlatVector<bool>(expectedResult));
+  }
+};
+
+TYPED_TEST_SUITE(
+    SimdComparisonsTest,
+    comparisonTypes,
+    functions::test::FunctionBaseTest::TypeNames);
+
+TYPED_TEST(SimdComparisonsTest, constant) {
+  this->testConstant(35, 17);
+  this->testConstant(1024, 53);
+  this->testConstant(99, 7);
+  this->testConstant(1027, 13);
+}
+
+TYPED_TEST(SimdComparisonsTest, flat) {
+  this->testFlat();
+}
+
+TYPED_TEST(SimdComparisonsTest, dictionary) {
+  this->testDictionary();
 }

--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -45,6 +45,14 @@ class FunctionBaseTest : public testing::Test,
 
   using FloatingPointTypes = ::testing::Types<DoubleType, RealType>;
 
+  using FloatingPointAndIntegralTypes = ::testing::Types<
+      TinyintType,
+      SmallintType,
+      IntegerType,
+      BigintType,
+      DoubleType,
+      RealType>;
+
  protected:
   static void SetUpTestCase();
 


### PR DESCRIPTION
Simdizes comparison functions.
1. Supports eq, neq, lt, gt, lte, gte. 
2. Supports all primitive types except booleans.
3. Only supports flat primitive vectors - defaults to non simd approach if no identity mapping present.

Added benchmark for eq: 

```
============================================================================
/Users/kpai/src/Velox/velox/functions/prestosql/benchmarks/ComparisonsBenchmark.cpprelative  time/iter  iters/s
============================================================================
non_simd_bigint_eq                                           1.91ms   522.39
simd_bigint_eq                                   624.25%   306.65us    3.26K
non_simd_tinyint_eq                                          1.89ms   529.48
simd_tinyint_eq                                 1396.16%   135.27us    7.39K
```
