### PR TITLE
Fix null dereference in SwitchExpr that has no else and no match

### DIFF
--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -95,11 +95,6 @@ void SwitchExpr::evalSpecialForm(
         thenRows.get()->updateBounds();
 
         if (thenRows.get()->hasSelections()) {
-          if (result) {
-            BaseVector::ensureWritable(
-                *thenRows.get(), result->type(), context.pool(), &result);
-          }
-
           inputs_[2 * i + 1]->eval(*thenRows.get(), context, result);
           remainingRows.get()->deselect(*thenRows.get());
         }
@@ -109,15 +104,13 @@ void SwitchExpr::evalSpecialForm(
 
   // Evaluate the "else" clause.
   if (remainingRows.get()->hasSelections()) {
-    if (result) {
-      BaseVector::ensureWritable(
-          *remainingRows.get(), result->type(), context.pool(), &result);
-    }
-
     if (hasElseClause_) {
       inputs_.back()->eval(*remainingRows.get(), context, result);
 
     } else {
+      BaseVector::ensureWritable(
+          *remainingRows.get(), type(), context.pool(), &result);
+
       // fill in nulls for remainingRows
       remainingRows.get()->applyToSelected(
           [&](auto row) { result->setNull(row, true); });

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -1887,11 +1887,11 @@ TEST_F(ExprTest, opaque) {
 
 TEST_F(ExprTest, switchExpr) {
   vector_size_t size = 1'000;
-  auto vector = makeRowVector({
-      makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-      makeFlatVector<int32_t>(
-          size, [](auto row) { return row; }, nullEvery(5)),
-  });
+  auto vector = makeRowVector(
+      {makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+       makeFlatVector<int32_t>(
+           size, [](auto row) { return row; }, nullEvery(5)),
+       makeConstant<int32_t>(0, size)});
 
   auto result =
       evaluate("case c0 when 7 then 1 when 11 then 2 else 0 end", vector);
@@ -1919,6 +1919,14 @@ TEST_F(ExprTest, switchExpr) {
   assertEqualVectors(expected, result);
 
   result = evaluate("case c1 when 7 then 1 when 11 then 2 end", vector);
+  assertEqualVectors(expected, result);
+
+  // No "else" clause and no match.
+  result = evaluate("case 0 when 100 then 1 when 200 then 2 end", vector);
+  expected = makeAllNullFlatVector<int64_t>(size);
+  assertEqualVectors(expected, result);
+
+  result = evaluate("case c2 when 100 then 1 when 200 then 2 end", vector);
   assertEqualVectors(expected, result);
 
   // non-equality case expression


### PR DESCRIPTION
Summary: The result vector of a SwitchExpr is firstly create when a branch of the switch gets executed. If no branch matches any row, the result vector remains a nullptr. Meanwhile, if a SwitchExpr has no "else" clause, the rows that do not match any branch should be set to null. Therefore, there is a corner case where a SwitchExpr has no "else" clause and no row match any branch. In this situation, the result vector is nullptr when all rows are set to null, which caused null dereference. This diff fixes this bug by creating the result vector before setting nulls.

Reviewed By: mbasmanova

Differential Revision: D38051577

