### PR TITLE
Fix global partial aggregation state reset and output row counting is…

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -295,13 +295,16 @@ void GroupingSet::initializeGlobalAggregation() {
     ++nullOffset;
   }
 
-  auto singleGroup = std::vector<vector_size_t>{0};
   lookup_->hits[0] = rows_.allocateFixed(offset);
+  resetGlobalAggregation();
+  globalAggregationInitialized_ = true;
+}
+
+void GroupingSet::resetGlobalAggregation() {
+  const auto singleGroup = std::vector<vector_size_t>{0};
   for (auto& aggregate : aggregates_) {
     aggregate->initializeNewGroups(lookup_->hits.data(), singleGroup);
   }
-
-  globalAggregationInitialized_ = true;
 }
 
 void GroupingSet::addGlobalAggregationInput(
@@ -441,8 +444,11 @@ void GroupingSet::extractGroups(
 }
 
 void GroupingSet::resetPartial() {
-  if (table_) {
+  if (table_ != nullptr) {
     table_->clear();
+  }
+  if (isGlobal_ && globalAggregationInitialized_) {
+    resetGlobalAggregation();
   }
 }
 

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -63,6 +63,10 @@ class GroupingSet {
 
   void resetPartial();
 
+  /// Invoked to reset the intermediate aggregation state on init or partial
+  /// output flush.
+  void resetGlobalAggregation();
+
   const HashLookup& hashLookup() const;
 
   /// Spills content until under 'targetRows' and under 'targetBytes'

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -73,6 +73,10 @@ class HashAggregation : public Operator {
   bool pushdownChecked_ = false;
   bool mayPushdown_ = false;
 
+  /// Count the number of output rows. It is reset on partial aggregation output
+  /// flush.
+  int64_t numOutputRows_ = 0;
+
   /// Possibly reusable output vector.
   RowVectorPtr output_;
 };


### PR DESCRIPTION
This PR fixes two issues: (1) current code doesn't reset the global intermediate aggregation state on partial full flush such as the case found in production query replay a single aggregation state could be very large; (2) the current output flush counting runtime stats is not reliable. It doesn't handle global case so that the actual count value is always zero. Also the table has already been cleared on the last output. This PR add a counter in HashAggregation to track the output rows explicitly.