### PR TITLE
Fix uncasted check bug in PagedInputStream

### DIFF
--- a/velox/dwio/dwrf/common/PagedInputStream.cpp
+++ b/velox/dwio/dwrf/common/PagedInputStream.cpp
@@ -199,7 +199,7 @@ void PagedInputStream::BackUp(int32_t count) {
     // decompression / decryption. Check that we do not back out of
     // the last range returned from input_->Next().
     VELOX_CHECK_GE(
-        inputBufferPtr_ - static_cast<size_t>(count), inputBufferStart_);
+        inputBufferPtr_ - inputBufferStart_, static_cast<size_t>(count));
   }
   outputBufferPtr_ -= static_cast<size_t>(count);
   outputBufferLength_ += static_cast<size_t>(count);


### PR DESCRIPTION
Summary:
In this check VELOX_CHECK_GE(inputBufferPtr_ - static_cast<size_t>(count), inputBufferStart_)

inputBufferPtr_ is of 'const char*' type. After minus an integer this is still a 'const char*' type.
inputBufferStart_ is of 'const char*' type.

When the check fails, velox/common/base/Exceptions.h tries to compose a message that uses format taking these 2 arguments of type 'const char*'. They are going to be formatted as a string instead of "address". And since the check fails, (inputBufferPtr_ - count) is already pointing to something weird, hence failing ASAN.

Differential Revision: D38067534

