### PR TITLE
Added new config variable MAP_FLAT_STRUCT_COLS

### DIFF
--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -141,6 +141,12 @@ Config::Entry<const std::vector<uint32_t>> Config::MAP_FLAT_COLS(
       return result;
     });
 
+Config::Entry<folly::dynamic> Config::MAP_FLAT_STRUCT_COLS(
+    "orc.map.flat.struct.cols",
+    folly::dynamic::object,
+    [](const folly::dynamic& val) { return folly::toJson(val); },
+    [](const std::string& val) { return folly::parseJson(val); });
+
 Config::Entry<uint32_t> Config::MAP_FLAT_MAX_KEYS(
     "orc.map.flat.max.keys",
     20000);

--- a/velox/dwio/dwrf/common/Config.h
+++ b/velox/dwio/dwrf/common/Config.h
@@ -106,6 +106,7 @@ class Config {
   static Entry<bool> MAP_FLAT_DISABLE_DICT_ENCODING_STRING;
   static Entry<bool> MAP_FLAT_DICT_SHARE;
   static Entry<const std::vector<uint32_t>> MAP_FLAT_COLS;
+  static Entry<folly::dynamic> MAP_FLAT_STRUCT_COLS;
   static Entry<uint32_t> MAP_FLAT_MAX_KEYS;
   static Entry<uint64_t> MAX_DICTIONARY_SIZE;
   static Entry<uint64_t> STRIPE_SIZE;

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <optional>
 #include <vector>
+#include "folly/DynamicConverter.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/common/MemoryInputStream.h"
@@ -839,9 +840,13 @@ void testMapWriter(
       // printStructs(structs);
 
       // TODO: add config variable, create config map, serialize map, set config
+      // std::map<uint32_t, std::vector<TKEY>> structConfig;
+      // structConfig[0] = uniqueKeys;
+      folly::dynamic structConfig =
+          folly::toDynamic<std::map<std::string, std::vector<TKEY>>>(
+              {{"0", uniqueKeys}});
 
-      // config->set(Config::MAP_FLAT_STRUCT_COLS,
-      // /* map of column 0->vector of keys */);
+      config->set(Config::MAP_FLAT_STRUCT_COLS, structConfig);
     }
 
     config->set(Config::FLATTEN_MAP, true);
@@ -849,7 +854,6 @@ void testMapWriter(
     config->set(
         Config::MAP_FLAT_DISABLE_DICT_ENCODING, disableDictionaryEncoding);
 
-    // if isStruct, convert batches to struct before writing
     // expect that if we pass isStruct true with useFlatMap false, it will fail
   }
 


### PR DESCRIPTION
Summary: Added new entry to Config.h and Config.cpp. This config takes in a map from column number to vector of keys in that column. This will be used for the writer to know which columns to expect a struct encoding format from and the uniqueKeys they have.

Differential Revision: D38063137

