### PR TITLE
Add arrow conversion for dictionary

### DIFF
--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -25,7 +25,7 @@ void Writer::write(const RowVectorPtr& data) {
   ArrowArray array;
   ArrowSchema schema;
   exportToArrow(data, array, &pool_);
-  exportToArrow(data->type(), schema);
+  exportToArrow(data, schema);
   PARQUET_ASSIGN_OR_THROW(
       auto recordBatch, arrow::ImportRecordBatch(&array, &schema));
   auto table = arrow::Table::Make(

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -60,7 +60,7 @@ void exportToArrow(
     memory::MemoryPool* pool =
         &velox::memory::getProcessDefaultMemoryManager().getRoot());
 
-/// Export a generic Velox Type to an ArrowSchema.
+/// Export the type of a Velox vector to an ArrowSchema.
 ///
 /// The guidelines on API usage and memory management are the same as the ones
 /// described for the VectorPtr->ArrowArray export function.
@@ -77,7 +77,9 @@ void exportToArrow(
 ///
 ///   arrowSchema.release(&arrowSchema);
 ///
-void exportToArrow(const TypePtr& type, ArrowSchema& arrowSchema);
+/// NOTE: Since Arrow couples type and encoding, we need both Velox type and
+/// actual data (containing encoding) to create an ArrowSchema.
+void exportToArrow(const VectorPtr&, ArrowSchema&);
 
 /// Import an ArrowSchema into a Velox Type object.
 ///

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -27,6 +27,12 @@ namespace {
 using namespace facebook::velox;
 static void mockRelease(ArrowSchema*) {}
 
+void exportToArrow(const TypePtr& type, ArrowSchema& out) {
+  auto pool =
+      &facebook::velox::memory::getProcessDefaultMemoryManager().getRoot();
+  exportToArrow(BaseVector::create(type, 0, pool), out);
+}
+
 class ArrowBridgeSchemaExportTest : public testing::Test {
  protected:
   void testScalarType(const TypePtr& type, const char* arrowFormat) {


### PR DESCRIPTION
Summary:
In arrow, dictionary is treated as a type instead of encoding, but in
velox it is with the vector and not in the type.  So we need the whole vector
instead of just the type when convert it to arrow type.

Differential Revision: D38075710

