### PR TITLE
Add duration flag to ExpressionFuzzer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ endif
 NUM_THREADS ?= $(shell getconf _NPROCESSORS_CONF 2>/dev/null || echo 1)
 CPU_TARGET ?= "avx"
 
+FUZZER_SEED ?= 123456
+FUZZER_DURATION_SEC ?= 60
+
 all: release			#: Build the release version
 
 clean:					#: Delete all build artifacts
@@ -107,8 +110,8 @@ unittest: debug			#: Build with debugging and run unit tests
 # ensure the tests are reproducible.
 fuzzertest: debug
 	$(BUILD_BASE_DIR)/debug/velox/expression/tests/velox_expression_fuzzer_test \
-		--seed 123456 \
-		--steps 100000 \
+		--seed $(FUZZER_SEED) \
+		--duration_sec $(FUZZER_DURATION_SEC) \
 		--logtostderr=1 \
 		--minloglevel=0
 

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -20,11 +20,8 @@
 
 namespace facebook::velox::test {
 
-// Generates random expressions based on `signatures` and random input data (via
-// VectorFuzzer). Generates `steps` distinct expressions.
-void expressionFuzzer(
-    FunctionSignatureMap signatureMap,
-    size_t steps,
-    size_t seed);
+// Generates random expressions based on `signatures`, random input data (via
+// VectorFuzzer), and executes them.
+void expressionFuzzer(FunctionSignatureMap signatureMap, size_t seed);
 
 } // namespace facebook::velox::test

--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -37,8 +37,6 @@ DEFINE_string(
     "this comma separated list of function names "
     "(e.g: --only \"split\" or --only \"substr,ltrim\").");
 
-DEFINE_int32(steps, 10, "Number of expressions to generate.");
-
 int main(int argc, char** argv) {
   facebook::velox::functions::prestosql::registerAllScalarFunctions();
 
@@ -59,5 +57,5 @@ int main(int argc, char** argv) {
       "cardinality",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
-  return FuzzerRunner::run(FLAGS_only, FLAGS_steps, initialSeed, skipFunctions);
+  return FuzzerRunner::run(FLAGS_only, initialSeed, skipFunctions);
 }

--- a/velox/expression/tests/FuzzerRunner.h
+++ b/velox/expression/tests/FuzzerRunner.h
@@ -24,9 +24,8 @@
 #include "velox/expression/tests/ExpressionFuzzer.h"
 #include "velox/functions/FunctionRegistry.h"
 
-/// ExpressionFuzzerTest is an test/executable helper that leverages
-/// ExpressionFuzzer and VectorFuzzer to automatically generate and execute
-/// expression tests. It works by:
+/// FuzzerRunner leverages ExpressionFuzzer and VectorFuzzer to automatically
+/// generate and execute expression tests. It works by:
 ///
 ///  1. Taking an initial set of available function signatures.
 ///  2. Generating a random expression tree based on the available function
@@ -43,7 +42,8 @@
 ///
 /// The important flags that control Fuzzer's behavior are:
 ///
-///  --steps: how many iterations to run
+///  --steps: how many iterations to run.
+///  --duration_sec: alternatively, for how many seconds it should run.
 ///  --seed: pass a deterministic seed to reproduce the behavior (each iteration
 ///          will print a seed as part of the logs).
 ///  --v=1: verbose logging; print a lot more details about the execution.
@@ -102,7 +102,6 @@ class FuzzerRunner {
  public:
   static int run(
       const std::string& onlyFunctions,
-      size_t steps,
       size_t seed,
       const std::unordered_set<std::string>& skipFunctions) {
     facebook::velox::test::expressionFuzzer(
@@ -110,7 +109,6 @@ class FuzzerRunner {
             facebook::velox::getFunctionSignatures(),
             onlyFunctions,
             skipFunctions),
-        steps,
         seed);
     return RUN_ALL_TESTS();
   }

--- a/velox/expression/tests/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/SparkExpressionFuzzerTest.cpp
@@ -37,8 +37,6 @@ DEFINE_string(
     "this comma separated list of function names "
     "(e.g: --only \"split\" or --only \"substr,ltrim\").");
 
-DEFINE_int32(steps, 10, "Number of expressions to generate.");
-
 int main(int argc, char** argv) {
   facebook::velox::functions::sparksql::registerFunctions("");
 
@@ -54,5 +52,5 @@ int main(int argc, char** argv) {
   // rlike, md5 and upper
   std::unordered_set<std::string> skipFunctions = {
       "regexp_extract", "rlike", "chr", "replace"};
-  return FuzzerRunner::run(FLAGS_only, FLAGS_steps, FLAGS_seed, skipFunctions);
+  return FuzzerRunner::run(FLAGS_only, FLAGS_seed, skipFunctions);
 }


### PR DESCRIPTION
Summary:
Add flag to let users control expression fuzzer runs duration based on
time (seconds). The next PR will hook this up into a nightly job.

Differential Revision: D38094342

