### PR TITLE
Restructure Allocation and ContiguousAllocation

### DIFF
--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -37,8 +37,9 @@ char* AllocationPool::allocateFixed(uint64_t bytes) {
   // Use contiguous allocations from mapped memory if allocation size is large
   if (numPages > mappedMemory_->largestSizeClass()) {
     auto largeAlloc =
-        std::make_unique<memory::MappedMemory::ContiguousAllocation>();
-    largeAlloc->reset(mappedMemory_, nullptr, 0);
+        std::make_unique<memory::MappedMemory::ContiguousAllocation>(
+            mappedMemory_);
+    largeAlloc->reset(nullptr, 0);
     if (!mappedMemory_->allocateContiguous(numPages, nullptr, *largeAlloc)) {
       throw std::bad_alloc();
     }

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -177,11 +177,11 @@ bool MmapAllocator::allocateContiguousImpl(
   }
   int64_t numLargeCollateralPages = allocation.numPages();
   if (numLargeCollateralPages) {
-    if (munmap(allocation.data(), allocation.size()) < 0) {
+    if (munmap(allocation.data(), allocation.byteSize()) < 0) {
       LOG(ERROR) << "munmap got " << errno << "for " << allocation.data()
-                 << ", " << allocation.size();
+                 << ", " << allocation.byteSize();
     }
-    allocation.reset(nullptr, nullptr, 0);
+    allocation.reset(nullptr, 0);
   }
   auto totalCollateralPages = numCollateralPages + numLargeCollateralPages;
   auto numCollateralUnmap = numLargeCollateralPages;
@@ -269,15 +269,15 @@ bool MmapAllocator::allocateContiguousImpl(
 }
 
 void MmapAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
-  if (allocation.data() && allocation.size()) {
-    if (munmap(allocation.data(), allocation.size()) < 0) {
+  if (allocation.data() && allocation.byteSize()) {
+    if (munmap(allocation.data(), allocation.byteSize()) < 0) {
       LOG(ERROR) << "munmap returned " << errno << "for " << allocation.data()
-                 << ", " << allocation.size();
+                 << ", " << allocation.byteSize();
     }
     numMapped_ -= allocation.numPages();
     numExternalMapped_ -= allocation.numPages();
     numAllocated_ -= allocation.numPages();
-    allocation.reset(nullptr, nullptr, 0);
+    allocation.reset(nullptr, 0);
   }
 }
 

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -78,7 +78,7 @@ class MmapAllocator : public MappedMemory {
 
   void freeContiguous(ContiguousAllocation& allocation) override {
     stats_.recordFree(
-        allocation.size(), [&]() { freeContiguousImpl(allocation); });
+        allocation.byteSize(), [&]() { freeContiguousImpl(allocation); });
   }
 
   // Checks internal consistency of allocation data

--- a/velox/common/memory/tests/FragmentationBenchmark.cpp
+++ b/velox/common/memory/tests/FragmentationBenchmark.cpp
@@ -43,7 +43,7 @@ struct Block {
   size_t size = 0;
   char* data = nullptr;
   std::shared_ptr<MappedMemory::Allocation> allocation;
-  MmapAllocator::ContiguousAllocation contiguous;
+  std::shared_ptr<MmapAllocator::ContiguousAllocation> contiguous;
 };
 
 class FragmentationTest {
@@ -101,13 +101,15 @@ class FragmentationTest {
           }
         }
       } else {
+        block->contiguous =
+            std::make_shared<MappedMemory::ContiguousAllocation>(memory_.get());
         if (!memory_->allocateContiguous(
-                size / 4096, nullptr, block->contiguous)) {
+                size / 4096, nullptr, *block->contiguous)) {
           VELOX_FAIL();
         }
-        for (auto offset = 0; offset < block->contiguous.numPages() * 4096;
+        for (auto offset = 0; offset < block->contiguous->numPages() * 4096;
              offset += 4096) {
-          block->contiguous.data()[offset] = 1;
+          block->contiguous->data()[offset] = 1;
         }
       }
     } else {

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -43,7 +43,8 @@ HashTable<ignoreNullKeys>::HashTable(
     memory::MappedMemory* mappedMemory)
     : BaseHashTable(std::move(hashers)),
       aggregates_(aggregates),
-      isJoinBuild_(isJoinBuild) {
+      isJoinBuild_(isJoinBuild),
+      tableAllocation_(mappedMemory) {
   std::vector<TypePtr> keys;
   for (auto& hasher : hashers_) {
     keys.push_back(hasher->type());
@@ -1015,10 +1016,10 @@ template <bool ignoreNullKeys>
 std::string HashTable<ignoreNullKeys>::toString() {
   std::stringstream out;
   int32_t occupied = 0;
-  if (table_ && tableAllocation_.data() && tableAllocation_.size()) {
+  if (table_ && tableAllocation_.data() && tableAllocation_.byteSize()) {
     // 'size_' and 'table_' may not be set if initializing.
     uint64_t size =
-        std::min<uint64_t>(tableAllocation_.size() / sizeof(char*), size_);
+        std::min<uint64_t>(tableAllocation_.byteSize() / sizeof(char*), size_);
     for (int32_t i = 0; i < size; ++i) {
       occupied += table_[i] != nullptr;
     }


### PR DESCRIPTION
Summary: Allocation and ContiguousAllocation have many in common. They are also used in the same manner in AllocationPool. Uniform them into parent/child class structure can make the code cleaner and more reusable.

Differential Revision: D38097744

