### PR TITLE
Add Support for Parsing Decimal Constant

### DIFF
--- a/velox/benchmarks/basic/Preproc.cpp
+++ b/velox/benchmarks/basic/Preproc.cpp
@@ -59,8 +59,9 @@ class PreprocBenchmark : public functions::test::FunctionBenchmarkBase {
 
   exec::ExprSet compile(const std::vector<std::string>& texts) {
     std::vector<core::TypedExprPtr> typedExprs;
+    parse::ParseOptions options;
     for (const auto& text : texts) {
-      auto untyped = parse::parseExpr(text);
+      auto untyped = parse::parseExpr(text, options);
       auto typed = core::Expressions::inferTypes(
           untyped, ROW({"c0"}, {REAL()}), execCtx_.pool());
       typedExprs.push_back(typed);

--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -32,6 +32,33 @@ using ::duckdb::dtime_t;
 using ::duckdb::string_t;
 using ::duckdb::timestamp_t;
 
+namespace {
+variant decimalVariant(const Value& val) {
+  uint8_t precision;
+  uint8_t scale;
+  val.type().GetDecimalProperties(precision, scale);
+  auto decimalType = DECIMAL(precision, scale);
+  switch (val.type().InternalType()) {
+    case ::duckdb::PhysicalType::INT128: {
+      auto unscaledValue = val.GetValueUnsafe<::duckdb::hugeint_t>();
+      return variant::longDecimal(
+          buildInt128(unscaledValue.upper, unscaledValue.lower), decimalType);
+    }
+    case ::duckdb::PhysicalType::INT16: {
+      return variant::shortDecimal(val.GetValueUnsafe<int16_t>(), decimalType);
+    }
+    case ::duckdb::PhysicalType::INT32: {
+      return variant::shortDecimal(val.GetValueUnsafe<int32_t>(), decimalType);
+    }
+    case ::duckdb::PhysicalType::INT64: {
+      return variant::shortDecimal(val.GetValueUnsafe<int64_t>(), decimalType);
+    }
+    default:
+      VELOX_UNSUPPORTED();
+  }
+}
+} // namespace
+
 //! Type mapping for velox -> DuckDB conversions
 LogicalType fromVeloxType(TypeKind kind) {
   switch (kind) {
@@ -119,7 +146,7 @@ TypePtr toVeloxType(LogicalType type) {
   }
 }
 
-variant duckValueToVariant(const Value& val) {
+variant duckValueToVariant(const Value& val, bool parseDecimalAsDouble) {
   switch (val.type().id()) {
     case LogicalTypeId::SQLNULL:
       return variant(TypeKind::UNKNOWN);
@@ -138,7 +165,11 @@ variant duckValueToVariant(const Value& val) {
     case LogicalTypeId::DOUBLE:
       return variant(val.GetValue<double>());
     case LogicalTypeId::DECIMAL:
-      return variant(val.GetValue<double>());
+      if (parseDecimalAsDouble) {
+        return variant(val.GetValue<double>());
+      } else {
+        return decimalVariant(val);
+      }
     case LogicalTypeId::VARCHAR:
       return variant(val.GetValue<std::string>());
     case LogicalTypeId::BLOB:

--- a/velox/duckdb/conversion/DuckConversion.h
+++ b/velox/duckdb/conversion/DuckConversion.h
@@ -42,7 +42,9 @@ static Timestamp duckdbTimestampToVelox(
 
 // Converts a duckDB Value (class that holds an arbitraty data type) into a
 // VELOX's variant.
-variant duckValueToVariant(const ::duckdb::Value& val);
+variant duckValueToVariant(
+    const ::duckdb::Value& val,
+    bool parseDecimalAsDouble);
 
 // value conversion routines
 template <class T>

--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -24,11 +24,12 @@ class IExpr;
 class SortOrder;
 } // namespace facebook::velox::core
 
-namespace duckdb {
-struct ParserOptions;
-} // namespace duckdb
-
 namespace facebook::velox::duckdb {
+/// Hold parsing options.
+struct ParseOptions {
+  // Retain legacy behavior by default.
+  bool parseDecimalAsDouble = true;
+};
 
 // Parses an input expression using DuckDB's internal postgresql-based parser,
 // converting it to an IExpr tree. Takes a single expression as input.
@@ -39,7 +40,7 @@ namespace facebook::velox::duckdb {
 // "concatrow").
 std::shared_ptr<const core::IExpr> parseExpr(
     const std::string& exprString,
-    const ::duckdb::ParserOptions& options);
+    const ParseOptions& options);
 
 // Parses an ORDER BY clause using DuckDB's internal postgresql-based parser,
 // converting it to a pair of an IExpr tree and a core::SortOrder. Uses ASC

--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -24,6 +24,10 @@ class IExpr;
 class SortOrder;
 } // namespace facebook::velox::core
 
+namespace duckdb {
+struct ParserOptions;
+} // namespace duckdb
+
 namespace facebook::velox::duckdb {
 
 // Parses an input expression using DuckDB's internal postgresql-based parser,
@@ -33,7 +37,9 @@ namespace facebook::velox::duckdb {
 // are lower-cased, what prevents you to use functions and column names
 // containing upper case letters (e.g: "concatRow" will be parsed as
 // "concatrow").
-std::shared_ptr<const core::IExpr> parseExpr(const std::string& exprString);
+std::shared_ptr<const core::IExpr> parseExpr(
+    const std::string& exprString,
+    const ::duckdb::ParserOptions& options);
 
 // Parses an ORDER BY clause using DuckDB's internal postgresql-based parser,
 // converting it to a pair of an IExpr tree and a core::SortOrder. Uses ASC

--- a/velox/duckdb/conversion/tests/DuckConversionTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckConversionTest.cpp
@@ -27,47 +27,67 @@ using ::duckdb::Value;
 
 TEST(DuckConversionTest, duckValueToVariant) {
   // NULLs must be the same.
-  EXPECT_EQ(variant(TypeKind::UNKNOWN), duckValueToVariant(Value()));
+  EXPECT_EQ(variant(TypeKind::UNKNOWN), duckValueToVariant(Value(), true));
 
   // Booleans.
-  EXPECT_EQ(variant(false), duckValueToVariant(Value::BOOLEAN(0)));
-  EXPECT_EQ(variant(true), duckValueToVariant(Value::BOOLEAN(1)));
+  EXPECT_EQ(variant(false), duckValueToVariant(Value::BOOLEAN(0), true));
+  EXPECT_EQ(variant(true), duckValueToVariant(Value::BOOLEAN(1), true));
 
   // Integers.
   auto min8 = std::numeric_limits<int8_t>::min();
   auto max8 = std::numeric_limits<int8_t>::max();
-  EXPECT_EQ(variant(min8), duckValueToVariant(Value::TINYINT(min8)));
-  EXPECT_EQ(variant(max8), duckValueToVariant(Value::TINYINT(max8)));
+  EXPECT_EQ(variant(min8), duckValueToVariant(Value::TINYINT(min8), true));
+  EXPECT_EQ(variant(max8), duckValueToVariant(Value::TINYINT(max8), true));
 
   auto min16 = std::numeric_limits<int16_t>::min();
   auto max16 = std::numeric_limits<int16_t>::max();
-  EXPECT_EQ(variant(min16), duckValueToVariant(Value::SMALLINT(min16)));
-  EXPECT_EQ(variant(max16), duckValueToVariant(Value::SMALLINT(max16)));
+  EXPECT_EQ(variant(min16), duckValueToVariant(Value::SMALLINT(min16), true));
+  EXPECT_EQ(variant(max16), duckValueToVariant(Value::SMALLINT(max16), true));
 
   auto min32 = std::numeric_limits<int32_t>::min();
   auto max32 = std::numeric_limits<int32_t>::max();
-  EXPECT_EQ(variant(min32), duckValueToVariant(Value::INTEGER(min32)));
-  EXPECT_EQ(variant(max32), duckValueToVariant(Value::INTEGER(max32)));
+  EXPECT_EQ(variant(min32), duckValueToVariant(Value::INTEGER(min32), true));
+  EXPECT_EQ(variant(max32), duckValueToVariant(Value::INTEGER(max32), true));
 
   auto min64 = std::numeric_limits<int64_t>::min();
   auto max64 = std::numeric_limits<int64_t>::max();
-  EXPECT_EQ(variant(min64), duckValueToVariant(Value::BIGINT(min64)));
-  EXPECT_EQ(variant(max64), duckValueToVariant(Value::BIGINT(max64)));
+  EXPECT_EQ(variant(min64), duckValueToVariant(Value::BIGINT(min64), true));
+  EXPECT_EQ(variant(max64), duckValueToVariant(Value::BIGINT(max64), true));
 
   // Doubles.
   for (const auto i : {0.99L, 88.321L, -3.23L}) {
-    EXPECT_EQ(variant(double(i)), duckValueToVariant(Value::DOUBLE(i)));
+    EXPECT_EQ(variant(double(i)), duckValueToVariant(Value::DOUBLE(i), true));
 
     // Floats are harder to compare because of low-precision. Just making sure
     // they don't throw.
-    EXPECT_NO_THROW(duckValueToVariant(Value::FLOAT(i)));
+    EXPECT_NO_THROW(duckValueToVariant(Value::FLOAT(i), true));
   }
 
   // Strings.
   std::vector<std::string> vec = {"", "asdf", "aS$!#^*HFD"};
   for (const auto& i : vec) {
-    EXPECT_EQ(variant(i), duckValueToVariant(Value(i)));
+    EXPECT_EQ(variant(i), duckValueToVariant(Value(i), true));
   }
+
+  // Decimal type inference.
+  EXPECT_EQ(
+      *DECIMAL(4, 2),
+      *duckValueToVariant(Value::DECIMAL(static_cast<int16_t>(10), 4, 2), false)
+           .inferType());
+  EXPECT_EQ(
+      *DECIMAL(9, 2),
+      *duckValueToVariant(Value::DECIMAL(static_cast<int32_t>(10), 9, 2), false)
+           .inferType());
+  EXPECT_EQ(
+      *DECIMAL(17, 2),
+      *duckValueToVariant(
+           Value::DECIMAL(static_cast<int64_t>(10), 17, 2), false)
+           .inferType());
+  EXPECT_EQ(
+      *DECIMAL(20, 2),
+      *duckValueToVariant(
+           Value::DECIMAL(::duckdb::hugeint_t(100), 20, 2), false)
+           .inferType());
 }
 
 TEST(DuckConversionTest, duckValueToVariantUnsupported) {
@@ -80,6 +100,6 @@ TEST(DuckConversionTest, duckValueToVariantUnsupported) {
           {{"a", LogicalType::INTEGER}, {"b", LogicalType::TINYINT}})};
 
   for (const auto& i : unsupported) {
-    EXPECT_THROW(duckValueToVariant(Value(i)), std::runtime_error);
+    EXPECT_THROW(duckValueToVariant(Value(i), true), std::runtime_error);
   }
 }

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -24,8 +24,8 @@ using namespace facebook::velox::duckdb;
 
 namespace {
 std::shared_ptr<const core::IExpr> parseExpr(const std::string& exprString) {
-  ::duckdb::ParserOptions options;
-  return ::parseExpr(exprString, options);
+  ParseOptions options;
+  return parseExpr(exprString, options);
 }
 } // namespace
 
@@ -450,8 +450,8 @@ TEST(DuckParserTest, invalidExpression) {
 }
 
 TEST(DuckParserTest, parseDecimalConstant) {
-  ::duckdb::ParserOptions options;
-  options.parse_decimal_as_double = false;
+  ParseOptions options;
+  options.parseDecimalAsDouble = false;
   auto expr = parseExpr("1.234", options);
   if (auto constant =
           std::dynamic_pointer_cast<const core::ConstantExpr>(expr)) {

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -21,11 +21,10 @@
 
 using namespace facebook::velox;
 using namespace facebook::velox::duckdb;
-using ::duckdb::ParserOptions;
 
 namespace {
 std::shared_ptr<const core::IExpr> parseExpr(const std::string& exprString) {
-  ParserOptions options;
+  ::duckdb::ParserOptions options;
   return ::parseExpr(exprString, options);
 }
 } // namespace
@@ -339,27 +338,27 @@ TEST(DuckParserTest, orderBy) {
 }
 
 namespace {
-const std::string windowTypeString(duckdb::WindowType w) {
+const std::string windowTypeString(WindowType w) {
   switch (w) {
-    case duckdb::WindowType::kRange:
+    case WindowType::kRange:
       return "RANGE";
-    case duckdb::WindowType::kRows:
+    case WindowType::kRows:
       return "ROWS";
   }
   VELOX_UNREACHABLE();
 }
 
-const std::string boundTypeString(duckdb::BoundType b) {
+const std::string boundTypeString(BoundType b) {
   switch (b) {
-    case duckdb::BoundType::kUnboundedPreceding:
+    case BoundType::kUnboundedPreceding:
       return "UNBOUNDED PRECEDING";
-    case duckdb::BoundType::kUnboundedFollowing:
+    case BoundType::kUnboundedFollowing:
       return "UNBOUNDED FOLLOWING";
-    case duckdb::BoundType::kPreceding:
+    case BoundType::kPreceding:
       return "PRECEDING";
-    case duckdb::BoundType::kFollowing:
+    case BoundType::kFollowing:
       return "FOLLOWING";
-    case duckdb::BoundType::kCurrentRow:
+    case BoundType::kCurrentRow:
       return "CURRENT ROW";
   }
   VELOX_UNREACHABLE();
@@ -451,7 +450,7 @@ TEST(DuckParserTest, invalidExpression) {
 }
 
 TEST(DuckParserTest, parseDecimalConstant) {
-  ParserOptions options;
+  ::duckdb::ParserOptions options;
   options.parse_decimal_as_double = false;
   auto expr = parseExpr("1.234", options);
   if (auto constant =

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -501,3 +501,18 @@ TEST_F(PlanNodeToStringTest, tableScan) {
         plan->toString(true, false));
   }
 }
+
+TEST_F(PlanNodeToStringTest, decimalConstant) {
+  parse::ParseOptions options;
+  options.parseDecimalAsDouble = false;
+
+  auto plan = PlanBuilder()
+                  .setParseOptions(options)
+                  .tableScan(ROW({"a"}, {VARCHAR()}))
+                  .project({"a", "1.234"})
+                  .planNode();
+
+  ASSERT_EQ(
+      "-- Project[expressions: (a:VARCHAR, ROW[\"a\"]), (p1:SHORT_DECIMAL(4,3), 1.234)] -> a:VARCHAR, p1:SHORT_DECIMAL(4,3)\n",
+      plan->toString(true));
+}

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -58,7 +58,8 @@ class VeloxIn10MinDemo : public VectorTestBase {
   core::TypedExprPtr parseExpression(
       const std::string& text,
       const RowTypePtr& rowType) {
-    auto untyped = parse::parseExpr(text);
+    parse::ParseOptions options;
+    auto untyped = parse::parseExpr(text, options);
     return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
   }
 

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -29,7 +29,6 @@ add_library(
 target_link_libraries(
   velox_exec_test_util
   velox_temp_path
-  duckdb
   velox_core
   velox_exception
   velox_expression

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -139,8 +139,9 @@ std::shared_ptr<core::FieldAccessTypedExpr> OperatorTestBase::toFieldExpr(
 
 std::shared_ptr<const core::ITypedExpr> OperatorTestBase::parseExpr(
     const std::string& text,
-    RowTypePtr rowType) {
-  auto untyped = parse::parseExpr(text);
+    RowTypePtr rowType,
+    const parse::ParseOptions& options) {
+  auto untyped = parse::parseExpr(text, options);
   return core::Expressions::inferTypes(untyped, rowType, pool_.get());
 }
 

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -20,6 +20,7 @@
 #include "velox/core/Expressions.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/parse/ExpressionsParser.h"
 #include "velox/type/Variant.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/tests/VectorMaker.h"
@@ -121,7 +122,8 @@ class OperatorTestBase : public testing::Test,
 
   std::shared_ptr<const core::ITypedExpr> parseExpr(
       const std::string& text,
-      RowTypePtr rowType);
+      RowTypePtr rowType,
+      const parse::ParseOptions& options = {});
 
   DuckDbQueryRunner duckDbQueryRunner_;
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/tpch/TpchConnector.h"
+#include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/RoundRobinPartitionFunction.h"

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -16,11 +16,9 @@
 
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include <velox/core/ITypedExpr.h>
-#include <velox/type/Filter.h>
 #include "velox/common/memory/Memory.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/tpch/TpchConnector.h"
-#include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/RoundRobinPartitionFunction.h"
@@ -28,6 +26,7 @@
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include "velox/expression/SignatureBinder.h"
 #include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::connector::hive;
@@ -43,8 +42,9 @@ static const std::string kTpchConnectorId = "test-tpch";
 core::TypedExprPtr parseExpr(
     const std::string& text,
     const RowTypePtr& rowType,
+    const parse::ParseOptions& options,
     memory::MemoryPool* pool) {
-  auto untyped = duckdb::parseExpr(text);
+  auto untyped = parse::parseExpr(text, options);
   return core::Expressions::inferTypes(untyped, rowType, pool);
 }
 
@@ -90,7 +90,7 @@ PlanBuilder& PlanBuilder::tableScan(
   SubfieldFilters filters;
   filters.reserve(subfieldFilters.size());
   for (const auto& filter : subfieldFilters) {
-    auto filterExpr = parseExpr(filter, outputType, pool_);
+    auto filterExpr = parseExpr(filter, outputType, options_, pool_);
     auto [subfield, subfieldFilter] = exec::toSubfieldFilter(filterExpr);
 
     auto it = columnAliases.find(subfield.toString());
@@ -109,8 +109,9 @@ PlanBuilder& PlanBuilder::tableScan(
 
   core::TypedExprPtr remainingFilterExpr;
   if (!remainingFilter.empty()) {
-    remainingFilterExpr = parseExpr(remainingFilter, outputType, pool_)
-                              ->rewriteInputNames(columnAliases);
+    remainingFilterExpr =
+        parseExpr(remainingFilter, outputType, options_, pool_)
+            ->rewriteInputNames(columnAliases);
   }
 
   auto tableHandle = std::make_shared<HiveTableHandle>(
@@ -185,7 +186,7 @@ parseOrderByClauses(
   std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> sortingKeys;
   std::vector<core::SortOrder> sortingOrders;
   for (const auto& key : keys) {
-    auto [untypedExpr, sortOrder] = duckdb::parseOrderByExpr(key);
+    auto [untypedExpr, sortOrder] = parse::parseOrderByExpr(key);
     auto typedExpr =
         core::Expressions::inferTypes(untypedExpr, inputType, pool);
 
@@ -219,7 +220,7 @@ PlanBuilder& PlanBuilder::project(const std::vector<std::string>& projections) {
   std::vector<core::TypedExprPtr> expressions;
   std::vector<std::string> projectNames;
   for (auto i = 0; i < projections.size(); ++i) {
-    auto untypedExpr = duckdb::parseExpr(projections[i]);
+    auto untypedExpr = parse::parseExpr(projections[i], options_);
     expressions.push_back(inferTypes(untypedExpr));
     if (untypedExpr->alias().has_value()) {
       projectNames.push_back(untypedExpr->alias().value());
@@ -242,7 +243,7 @@ PlanBuilder& PlanBuilder::project(const std::vector<std::string>& projections) {
 PlanBuilder& PlanBuilder::filter(const std::string& filter) {
   planNode_ = std::make_shared<core::FilterNode>(
       nextPlanNodeId(),
-      parseExpr(filter, planNode_->outputType(), pool_),
+      parseExpr(filter, planNode_->outputType(), options_, pool_),
       planNode_);
   return *this;
 }
@@ -524,7 +525,7 @@ PlanBuilder::createAggregateExpressionsAndNames(
       resolver.setResultType(resultTypes[i]);
     }
 
-    auto untypedExpr = duckdb::parseExpr(agg);
+    auto untypedExpr = parse::parseExpr(agg, options_);
 
     auto expr = std::dynamic_pointer_cast<const core::CallTypedExpr>(
         inferTypes(untypedExpr));
@@ -764,7 +765,8 @@ struct LocalPartitionTypes {
 
 LocalPartitionTypes genLocalPartitionTypes(
     const std::vector<core::PlanNodePtr>& sources,
-    const std::vector<std::string>& outputLayout) {
+    const std::vector<std::string>& outputLayout,
+    const parse::ParseOptions& options) {
   LocalPartitionTypes ret;
   auto inputType = sources[0]->outputType();
 
@@ -773,7 +775,7 @@ LocalPartitionTypes genLocalPartitionTypes(
   std::vector<std::string> outputNames;
   std::vector<std::string> outputAliases;
   for (const auto& output : outputLayout) {
-    auto untypedExpr = duckdb::parseExpr(output);
+    auto untypedExpr = parse::parseExpr(output, options);
     auto fieldExpr =
         dynamic_cast<const core::FieldAccessExpr*>(untypedExpr.get());
     VELOX_CHECK_NOT_NULL(
@@ -803,8 +805,9 @@ core::PlanNodePtr createLocalPartitionNode(
     const core::PlanNodeId& planNodeId,
     const std::vector<std::string>& keys,
     const std::vector<core::PlanNodePtr>& sources,
-    const std::vector<std::string>& outputLayout) {
-  auto types = genLocalPartitionTypes(sources, outputLayout);
+    const std::vector<std::string>& outputLayout,
+    const parse::ParseOptions& options) {
+  auto types = genLocalPartitionTypes(sources, outputLayout, options);
 
   auto partitionFunctionFactory =
       createPartitionFunctionFactory(sources[0]->outputType(), keys);
@@ -863,8 +866,8 @@ PlanBuilder& PlanBuilder::localPartition(
     const std::vector<core::PlanNodePtr>& sources,
     const std::vector<std::string>& outputLayout) {
   VELOX_CHECK_NULL(planNode_, "localPartition() must be the first call");
-  planNode_ =
-      createLocalPartitionNode(nextPlanNodeId(), keys, sources, outputLayout);
+  planNode_ = createLocalPartitionNode(
+      nextPlanNodeId(), keys, sources, outputLayout, options_);
   return *this;
 }
 
@@ -872,7 +875,7 @@ PlanBuilder& PlanBuilder::localPartition(
     const std::vector<std::string>& keys,
     const std::vector<std::string>& outputLayout) {
   planNode_ = createLocalPartitionNode(
-      nextPlanNodeId(), keys, {planNode_}, outputLayout);
+      nextPlanNodeId(), keys, {planNode_}, outputLayout, options_);
   return *this;
 }
 
@@ -882,7 +885,7 @@ PlanBuilder& PlanBuilder::localPartitionRoundRobin(
   VELOX_CHECK_NULL(
       planNode_, "localPartitionRoundRobin() must be the first call");
 
-  auto types = genLocalPartitionTypes(sources, outputLayout);
+  auto types = genLocalPartitionTypes(sources, outputLayout, options_);
 
   auto partitionFunctionFactory = [](auto numPartitions) {
     return std::make_unique<velox::exec::RoundRobinPartitionFunction>(
@@ -912,7 +915,7 @@ PlanBuilder& PlanBuilder::hashJoin(
   auto resultType = concat(leftType, rightType);
   core::TypedExprPtr filterExpr;
   if (!filter.empty()) {
-    filterExpr = parseExpr(filter, resultType, pool_);
+    filterExpr = parseExpr(filter, resultType, options_, pool_);
   }
   auto outputType = extract(resultType, outputLayout);
   auto leftKeyFields = fields(leftType, leftKeys);
@@ -944,7 +947,7 @@ PlanBuilder& PlanBuilder::mergeJoin(
   auto resultType = concat(leftType, rightType);
   core::TypedExprPtr filterExpr;
   if (!filter.empty()) {
-    filterExpr = parseExpr(filter, resultType, pool_);
+    filterExpr = parseExpr(filter, resultType, options_, pool_);
   }
   auto outputType = extract(resultType, outputLayout);
   auto leftKeyFields = fields(leftType, leftKeys);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -19,6 +19,7 @@
 #include <velox/core/PlanFragment.h>
 #include <velox/core/PlanNode.h>
 #include "velox/common/memory/Memory.h"
+#include "velox/parse/ExpressionsParser.h"
 
 namespace facebook::velox::core {
 class IExpr;
@@ -699,6 +700,12 @@ class PlanBuilder {
     return *this;
   }
 
+  /// Set parsing options
+  PlanBuilder& setParseOptions(const parse::ParseOptions& options) {
+    options_ = options;
+    return *this;
+  }
+
  private:
   std::string nextPlanNodeId();
 
@@ -757,5 +764,6 @@ class PlanBuilder {
   std::shared_ptr<PlanNodeIdGenerator> planNodeIdGenerator_;
   core::PlanNodePtr planNode_;
   memory::MemoryPool* pool_;
+  parse::ParseOptions options_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/experimental/codegen/code_generator/tests/ASTAnalysisTest.cpp
+++ b/velox/experimental/codegen/code_generator/tests/ASTAnalysisTest.cpp
@@ -32,7 +32,7 @@ class ASTAnalysisTest : public ExpressionCodegenTestBase {
   template <typename InputRowTypeTrait>
   ASTNodePtr generateCodegenAST(const std::string& expression) {
     auto inputRowType = makeRowType(InputRowTypeTrait::veloxDynamicTypes());
-    auto untypedExpr = parse::parseExpr(expression);
+    auto untypedExpr = parse::parseExpr(expression, options_);
     auto typedExpr = core::Expressions::inferTypes(
         untypedExpr, inputRowType, getExecContext().pool());
 
@@ -82,6 +82,8 @@ class ASTAnalysisTest : public ExpressionCodegenTestBase {
         codegen::analysis::isFilterDefaultNull(codegenExprTree),
         expectedResult);
   }
+
+  parse::ParseOptions options_;
 };
 
 TEST_F(ASTAnalysisTest, DefaultNullStrict) {

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -554,7 +554,7 @@ class ExpressionCodegenTestBase : public testing::Test {
   std::shared_ptr<const core::ConcatTypedExpr> makeConcatTypedExpr(
       const std::string& text,
       const std::shared_ptr<const RowType>& inputRowType) {
-    auto untypedExpr = parse::parseExpr(text);
+    auto untypedExpr = parse::parseExpr(text, options_);
     auto typedExpr = core::Expressions::inferTypes(
         untypedExpr, inputRowType, execCtx_->pool());
 
@@ -590,6 +590,7 @@ class ExpressionCodegenTestBase : public testing::Test {
   std::unique_ptr<CodeManager> codeManager_;
   std::unique_ptr<ExprCodeGenerator> generator_;
   DefaultScopedTimer::EventSequence eventSequence_;
+  parse::ParseOptions options_;
 };
 
 } // namespace expressions::test

--- a/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
+++ b/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
@@ -38,10 +38,11 @@ namespace facebook::velox::codegen {
 
 auto parseTypedExprs(
     const std::vector<std::string>& stringExprs,
-    std::shared_ptr<const RowType>& rowType) {
+    std::shared_ptr<const RowType>& rowType,
+    const parse::ParseOptions& options) {
   std::vector<std::shared_ptr<const core::ITypedExpr>> typedExprs;
   for (const auto& stringExpr : stringExprs) {
-    auto untyped = parse::parseExpr(stringExpr);
+    auto untyped = parse::parseExpr(stringExpr, options);
     auto typed = core::Expressions::inferTypes(untyped, rowType);
     typedExprs.push_back(std::move(typed));
   };
@@ -68,7 +69,7 @@ class GenerateAstTest : public CodegenTestBase {
 
     std::vector<std::string> exprString{"c0 + c1", "c1 - c0"};
 
-    auto projections = parseTypedExprs(exprString, rowType_);
+    auto projections = parseTypedExprs(exprString, rowType_, options_);
 
     project_ = std::make_shared<ProjectNode>(
         "projection",
@@ -85,6 +86,7 @@ class GenerateAstTest : public CodegenTestBase {
 
   bool useBuiltInForArithmetic_;
   UDFManager udfManager_;
+  parse::ParseOptions options_;
 };
 
 TEST_F(GenerateAstTest, CreateAST) {

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -80,7 +80,7 @@ class CodegenTestCore {
   std::shared_ptr<const core::ITypedExpr> makeTypedExpr(
       const std::string& text,
       const TypePtr& rowType) {
-    auto untyped = parse::parseExpr(text);
+    auto untyped = parse::parseExpr(text, options_);
     return core::Expressions::inferTypes(untyped, rowType, pool_.get());
   }
 
@@ -286,6 +286,7 @@ class CodegenTestCore {
   UDFManager udfManager_;
   bool useSymbolForArithmetic_;
   NamedSteadyClockEventSequence eventSequence_;
+  parse::ParseOptions options_;
 };
 
 class CodegenTestBase : public CodegenTestCore, public testing::Test {

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -146,7 +146,7 @@ class ExprEncodingsTest : public testing::Test, public VectorTestBase {
   std::shared_ptr<const core::ITypedExpr> parseExpression(
       const std::string& text,
       const RowTypePtr& rowType) {
-    auto untyped = parse::parseExpr(text);
+    auto untyped = parse::parseExpr(text, options_);
     return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
   }
 
@@ -460,6 +460,7 @@ class ExprEncodingsTest : public testing::Test, public VectorTestBase {
   TestData testData_;
   RowTypePtr testDataType_;
   std::vector<std::vector<EncodingOptions>> testEncodings_;
+  parse::ParseOptions options_;
 };
 
 #define IS_BIGINT1 testData_.bigint1.reference[row].has_value()

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -41,7 +41,7 @@ class ExprTest : public testing::Test, public VectorTestBase {
   std::shared_ptr<const core::ITypedExpr> parseExpression(
       const std::string& text,
       const RowTypePtr& rowType) {
-    auto untyped = parse::parseExpr(text);
+    auto untyped = parse::parseExpr(text, options_);
     return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
   }
 
@@ -149,6 +149,7 @@ class ExprTest : public testing::Test, public VectorTestBase {
   std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
+  parse::ParseOptions options_;
 };
 
 TEST_F(ExprTest, moreEncodings) {
@@ -2036,7 +2037,7 @@ TEST_F(ExprTest, lambdaExceptionContext) {
       "lambda1",
       ROW({"x"}, {BIGINT()}),
       ROW({ARRAY(BIGINT())}),
-      parse::parseExpr("x / 0 > 1"),
+      parse::parseExpr("x / 0 > 1", options_),
       execCtx_->pool());
   assertError(
       "filter(c0, function('lambda1'))",
@@ -2049,7 +2050,7 @@ TEST_F(ExprTest, lambdaExceptionContext) {
       "lambda2",
       ROW({"x"}, {BIGINT()}),
       ROW({"c1"}, {INTEGER()}),
-      parse::parseExpr("x / c1 > 1"),
+      parse::parseExpr("x / c1 > 1", options_),
       execCtx_->pool());
   assertError(
       "filter(c0, function('lambda2'))",
@@ -2088,7 +2089,7 @@ TEST_F(ExprTest, lambdaWithRowField) {
       "lambda1",
       ROW({"x"}, {BIGINT()}),
       ROW({"c0", "c1"}, {ROW({"val"}, {BIGINT()}), ARRAY(BIGINT())}),
-      parse::parseExpr("x + c0.val >= 0"),
+      parse::parseExpr("x + c0.val >= 0", options_),
       execCtx_->pool());
 
   auto rowVector = vectorMaker_.rowVector({"c0", "c1"}, {row, array});

--- a/velox/external/duckdb/duckdb.hpp
+++ b/velox/external/duckdb/duckdb.hpp
@@ -22112,7 +22112,6 @@ class ParserExtension;
 
 struct ParserOptions {
 	bool preserve_identifier_case = true;
-	bool parse_decimal_as_double = true;
 	idx_t max_expression_depth = 1000;
 	vector<ParserExtension> *extensions = nullptr;
 };

--- a/velox/external/duckdb/duckdb.hpp
+++ b/velox/external/duckdb/duckdb.hpp
@@ -22112,6 +22112,7 @@ class ParserExtension;
 
 struct ParserOptions {
 	bool preserve_identifier_case = true;
+	bool parse_decimal_as_double = true;
 	idx_t max_expression_depth = 1000;
 	vector<ParserExtension> *extensions = nullptr;
 };

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -32,7 +32,7 @@ class FunctionBenchmarkBase {
   exec::ExprSet compileExpression(
       const std::string& text,
       const TypePtr& rowType) {
-    auto untyped = parse::parseExpr(text);
+    auto untyped = parse::parseExpr(text, options_);
     auto typed =
         core::Expressions::inferTypes(untyped, rowType, execCtx_.pool());
     return exec::ExprSet({typed}, &execCtx_);
@@ -60,5 +60,6 @@ class FunctionBenchmarkBase {
       memory::getDefaultScopedMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
+  parse::ParseOptions options_;
 };
 } // namespace facebook::velox::functions::test

--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -67,7 +67,7 @@ class FunctionBaseTest : public testing::Test,
   std::shared_ptr<const core::ITypedExpr> makeTypedExpr(
       const std::string& text,
       const RowTypePtr& rowType) {
-    auto untyped = parse::parseExpr(text);
+    auto untyped = parse::parseExpr(text, options_);
     return core::Expressions::inferTypes(untyped, rowType, execCtx_.pool());
   }
 
@@ -227,13 +227,17 @@ class FunctionBaseTest : public testing::Test,
       TypePtr rowType,
       const std::string& body) {
     core::Expressions::registerLambda(
-        name, signature, rowType, parse::parseExpr(body), execCtx_.pool());
+        name,
+        signature,
+        rowType,
+        parse::parseExpr(body, options_),
+        execCtx_.pool());
   }
 
   core::TypedExprPtr parseExpression(
       const std::string& text,
       const RowTypePtr& rowType) {
-    auto untyped = parse::parseExpr(text);
+    auto untyped = parse::parseExpr(text, options_);
     return core::Expressions::inferTypes(untyped, rowType, pool());
   }
 
@@ -259,6 +263,7 @@ class FunctionBaseTest : public testing::Test,
 
   std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
+  parse::ParseOptions options_;
 
  private:
   template <typename T>

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -13,17 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/duckdb/conversion/DuckParser.h"
+#include "velox/external/duckdb/duckdb.hpp"
 
-namespace facebook {
-namespace velox {
-namespace parse {
+namespace facebook::velox::parse {
 
-std::shared_ptr<const core::IExpr> parseExpr(const std::string& strExpr) {
-  return facebook::velox::duckdb::parseExpr(strExpr);
+std::shared_ptr<const core::IExpr> parseExpr(
+    const std::string& expr,
+    const ParseOptions& options) {
+  ::duckdb::ParserOptions duckdbOptions;
+  duckdbOptions.parse_decimal_as_double = options.parseDecimalAsDouble;
+  duckdbOptions.preserve_identifier_case = options.preserveIdentifierCase;
+  duckdbOptions.max_expression_depth = options.maxExpressionDepth;
+  return facebook::velox::duckdb::parseExpr(expr, duckdbOptions);
 }
 
-} // namespace parse
-} // namespace velox
-} // namespace facebook
+std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
+    const std::string& expr) {
+  return facebook::velox::duckdb::parseOrderByExpr(expr);
+}
+
+} // namespace facebook::velox::parse

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -16,18 +16,15 @@
 
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/duckdb/conversion/DuckParser.h"
-#include "velox/external/duckdb/duckdb.hpp"
 
 namespace facebook::velox::parse {
 
 std::shared_ptr<const core::IExpr> parseExpr(
     const std::string& expr,
     const ParseOptions& options) {
-  ::duckdb::ParserOptions duckdbOptions;
-  duckdbOptions.parse_decimal_as_double = options.parseDecimalAsDouble;
-  duckdbOptions.preserve_identifier_case = options.preserveIdentifierCase;
-  duckdbOptions.max_expression_depth = options.maxExpressionDepth;
-  return facebook::velox::duckdb::parseExpr(expr, duckdbOptions);
+  facebook::velox::duckdb::ParseOptions duckConversionOptions;
+  duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
+  return facebook::velox::duckdb::parseExpr(expr, duckConversionOptions);
 }
 
 std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -25,9 +25,7 @@ namespace facebook::velox::parse {
 /// Hold parsing options.
 struct ParseOptions {
   // Retain legacy behavior by default.
-  bool preserveIdentifierCase = true;
   bool parseDecimalAsDouble = true;
-  int maxExpressionDepth = 1000;
 };
 
 std::shared_ptr<const core::IExpr> parseExpr(

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -16,15 +16,25 @@
 #pragma once
 
 #include <set>
+#include "velox/core/PlanNode.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/parse/IExpr.h"
 
-namespace facebook {
-namespace velox {
-namespace parse {
+namespace facebook::velox::parse {
 
-std::shared_ptr<const core::IExpr> parseExpr(const std::string& expr);
+/// Hold parsing options.
+struct ParseOptions {
+  // Retain legacy behavior by default.
+  bool preserveIdentifierCase = true;
+  bool parseDecimalAsDouble = true;
+  int maxExpressionDepth = 1000;
+};
 
-} // namespace parse
-} // namespace velox
-} // namespace facebook
+std::shared_ptr<const core::IExpr> parseExpr(
+    const std::string& expr,
+    const ParseOptions& options);
+
+std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
+    const std::string& expr);
+
+} // namespace facebook::velox::parse


### PR DESCRIPTION
Introduce `ParseOptions` struct to specify DuckDB to Velox parsing options.
`ParseOptions` instance is now passed to `DuckParser::parseExpr` to
choose parsing DuckDB decimal value as Velox decimal or double.