### PR TITLE
Allow creating ConstantTypedExpr of complex-type NULL without passing an actual vector

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -75,7 +75,8 @@ class ConstantTypedExpr : public ITypedExpr {
       : ITypedExpr{value.inferType()}, value_{std::move(value)} {}
 
   // Creates constant expression for cases when type cannot be properly inferred
-  // from the variant, like variant::null().
+  // from the variant, like variant::null(). For complex types, only
+  // variant::null() is supported.
   ConstantTypedExpr(std::shared_ptr<const Type> type, variant value)
       : ITypedExpr{std::move(type)}, value_{std::move(value)} {}
 

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -442,8 +442,13 @@ ExprPtr compileExpression(
     if (constant->hasValueVector()) {
       result = std::make_shared<ConstantExpr>(constant->valueVector());
     } else {
-      result = std::make_shared<ConstantExpr>(
-          BaseVector::createConstant(constant->value(), 1, pool));
+      if (constant->value().isNull()) {
+        result = std::make_shared<ConstantExpr>(
+            BaseVector::createNullConstant(constant->type(), 1, pool));
+      } else {
+        result = std::make_shared<ConstantExpr>(
+            BaseVector::createConstant(constant->value(), 1, pool));
+      }
     }
   } else if (
       auto lambda = dynamic_cast<const core::LambdaTypedExpr*>(expr.get())) {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -1092,6 +1092,38 @@ TEST_F(ExprTest, constantArray) {
   ASSERT_TRUE(b->equalValueAt(result[1].get(), 5, 0));
 }
 
+TEST_F(ExprTest, constantComplexNull) {
+  std::vector<core::TypedExprPtr> expressions = {
+      std::make_shared<const core::ConstantTypedExpr>(
+          ARRAY(BIGINT()), variant::null(TypeKind::ARRAY)),
+      std::make_shared<const core::ConstantTypedExpr>(
+          MAP(VARCHAR(), BIGINT()), variant::null(TypeKind::MAP)),
+      std::make_shared<const core::ConstantTypedExpr>(
+          ROW({SMALLINT(), BIGINT()}), variant::null(TypeKind::ROW))};
+  auto exprSet =
+      std::make_unique<exec::ExprSet>(std::move(expressions), execCtx_.get());
+
+  const vector_size_t size = 10;
+  auto input = makeRowVector(ROW({}), size);
+  exec::EvalCtx context(execCtx_.get(), exprSet.get(), input.get());
+
+  SelectivityVector rows(size);
+  std::vector<VectorPtr> result(3);
+  exprSet->eval(rows, &context, &result);
+
+  ASSERT_EQ(VectorEncoding::Simple::CONSTANT, result[0]->encoding());
+  ASSERT_EQ(TypeKind::ARRAY, result[0]->typeKind());
+  ASSERT_TRUE(result[0]->as<ConstantVector<ComplexType>>()->isNullAt(0));
+
+  ASSERT_EQ(VectorEncoding::Simple::CONSTANT, result[1]->encoding());
+  ASSERT_EQ(TypeKind::MAP, result[1]->typeKind());
+  ASSERT_TRUE(result[1]->as<ConstantVector<ComplexType>>()->isNullAt(0));
+
+  ASSERT_EQ(VectorEncoding::Simple::CONSTANT, result[2]->encoding());
+  ASSERT_EQ(TypeKind::ROW, result[2]->typeKind());
+  ASSERT_TRUE(result[2]->as<ConstantVector<ComplexType>>()->isNullAt(0));
+}
+
 TEST_F(ExprTest, constantScalarEquals) {
   auto a = makeFlatVector<int32_t>(10, [](auto row) { return row; });
   auto b = makeFlatVector<int32_t>(10, [](auto row) { return row; });


### PR DESCRIPTION
Summary: The constructor `ConstantTypedExpr(std::shared_ptr<const Type> type, 
variant value)` allows creating a ConstantTypedExpr without passing an actual vector. 
This interface, however, doesn't work for complex types. There are cases where users 
would like to create a ConstantTypedExpr of complex-type NULL. So this diff allows 
creating such ConstantTypedExpr through the aforementioned interface. (Note that 
only null constant is supported for complex types.)

Differential Revision: D38092564

