### PR TITLE
Add testvalue test facility for velox

### DIFF
--- a/velox/common/testutil/CMakeLists.txt
+++ b/velox/common/testutil/CMakeLists.txt
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(base)
-add_subdirectory(caching)
-add_subdirectory(encode)
-add_subdirectory(file)
-add_subdirectory(memory)
-add_subdirectory(process)
-add_subdirectory(serialization)
-add_subdirectory(time)
-add_subdirectory(testutil)
+
+add_library(velox_test_util TestValue.cpp)
+target_link_libraries(velox_test_util velox_common_base)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/common/testutil/TestValue.cpp
+++ b/velox/common/testutil/TestValue.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/testutil/TestValue.h"
+
+namespace facebook::velox::common::testutil {
+
+std::mutex TestValue::mutex_;
+bool TestValue::enabled_ = false;
+std::unordered_map<std::string, TestValue::Callback> TestValue::injectionMap_;
+
+#ifndef NDEBUG
+void TestValue::enable() {
+  std::lock_guard<std::mutex> l(mutex_);
+  enabled_ = true;
+}
+
+void TestValue::disable() {
+  std::lock_guard<std::mutex> l(mutex_);
+  enabled_ = false;
+}
+
+bool TestValue::enabled() {
+  std::lock_guard<std::mutex> l(mutex_);
+  return enabled_;
+}
+
+void TestValue::clear(const std::string& injectionPoint) {
+  std::lock_guard<std::mutex> l(mutex_);
+  injectionMap_.erase(injectionPoint);
+}
+
+void TestValue::adjust(const std::string& injectionPoint, void* testData) {
+  Callback injectionCb;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (!enabled_ || injectionMap_.count(injectionPoint) == 0) {
+      return;
+    }
+    injectionCb = injectionMap_[injectionPoint];
+  }
+  injectionCb(testData);
+}
+#else
+void TestValue::enable() {}
+void TestValue::disable() {}
+bool TestValue::enabled() {
+  return false;
+}
+void TestValue::clear(const std::string& injectionPoint) {}
+void TestValue::adjust(const std::string& injectionPoint, void* testData) {}
+#endif
+
+} // namespace facebook::velox::common::testutil

--- a/velox/common/testutil/TestValue.h
+++ b/velox/common/testutil/TestValue.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::common::testutil {
+
+/// The test facility used to inject callback hook in production execution point
+/// to get, change and verify various internal execution state for unit test.
+/// The hook injected in production code path will be opt out in release build
+/// and only be executed in debug build. Please follow the example in
+/// TestValueTest.cpp for use.
+class TestValue {
+ public:
+  /// Enable the test value injection.
+  static void enable();
+  /// Disable the test value injection.
+  static void disable();
+  /// Check if the test value injection is enabled or not.
+  static bool enabled();
+
+  /// Invoked by the test code to register a callback hook at the specified
+  /// execution point. 'injectionPoint' is a string to identify the execution
+  /// point which could be formed by concatenating namespace, class name, method
+  /// name plus optional actual action within a method. 'injectionCb' is the
+  /// injected callback hook.
+  template <typename T>
+  static void set(
+      const std::string& injectionPoint,
+      std::function<void(T*)> injectionCb);
+
+  /// Invoked by the test code to unregister a callback hook at the specified
+  /// execution point.
+  static void clear(const std::string& injectionPoint);
+
+  /// Invoked by the production code to try to invoke the test callback hook
+  /// with 'testData' if there is one registered at the specified execution
+  /// point. 'testData' can capture the production execution state.
+  static void adjust(const std::string& injectionPoint, void* testData);
+
+ private:
+  using Callback = std::function<void(void*)>;
+
+  static std::mutex mutex_;
+  static bool enabled_;
+  static std::unordered_map<std::string, Callback> injectionMap_;
+};
+
+class ScopedTestValue {
+ public:
+  template <typename T>
+  ScopedTestValue(const std::string& point, std::function<void(T*)> callback)
+      : point_(point) {
+    VELOX_CHECK_NOT_NULL(callback);
+    VELOX_CHECK(!point_.empty());
+    TestValue::set<T>(point_, std::move(callback));
+  }
+  ~ScopedTestValue() {
+    TestValue::clear(point_);
+  }
+
+ private:
+  const std::string point_;
+};
+
+#ifndef NDEBUG
+template <typename T>
+void TestValue::set(
+    const std::string& injectionPoint,
+    std::function<void(T*)> injectionCb) {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (!enabled_) {
+    return;
+  }
+  injectionMap_[injectionPoint] = [injectionCb](void* testData) {
+    T* typedData = static_cast<T*>(testData);
+    injectionCb(typedData);
+  };
+}
+#else
+template <typename T>
+void TestValue::set(
+    const std::string& injectionPoint,
+    std::function<void(T*)> injectionCb) {}
+#endif
+
+#define VELOX_CONCAT(x, y) __##x##y
+#define VELOX_VARNAME(x) VELOX_CONCAT(x, Obj)
+
+#define SCOPED_TESTVALUE_SET(point, ...) \
+  ScopedTestValue VELOX_VARNAME(__LINE__)(point, ##__VA_ARGS__)
+
+} // namespace facebook::velox::common::testutil

--- a/velox/common/testutil/tests/CMakeLists.txt
+++ b/velox/common/testutil/tests/CMakeLists.txt
@@ -11,12 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(base)
-add_subdirectory(caching)
-add_subdirectory(encode)
-add_subdirectory(file)
-add_subdirectory(memory)
-add_subdirectory(process)
-add_subdirectory(serialization)
-add_subdirectory(time)
-add_subdirectory(testutil)
+include(GoogleTest)
+add_executable(velox_test_util_test TestValueTest.cpp)
+gtest_add_tests(velox_test_util_test "" AUTO)
+
+target_link_libraries(velox_test_util_test velox_test_util velox_exception
+                      gtest gtest_main)

--- a/velox/common/testutil/tests/TestValueTest.cpp
+++ b/velox/common/testutil/tests/TestValueTest.cpp
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/testutil/TestValue.h"
+
+namespace {
+
+using namespace facebook::velox::common::testutil;
+
+class TestObject {
+ public:
+  TestObject() = default;
+
+  void set(int value) {
+    TestValue::adjust("facebook::velox::exec::test::TestObject::set", &value);
+    internalSet(value);
+  }
+
+ private:
+  void internalSet(int value) {
+    if (TestValue::enabled()) {
+      std::pair<int, int> testValue(value, count_);
+      TestValue::adjust(
+          "facebook::velox::exec::test::TestObject::internalSet", &testValue);
+    }
+    ++count_;
+    value_ = value;
+  }
+
+  int count_ = 0;
+  int value_;
+};
+
+TEST(TestValueTest, testValueDisabled) {
+  TestValue::disable();
+  EXPECT_FALSE(TestValue::enabled());
+  int setCount = 0;
+  int setValue = 0;
+  int value = 200;
+  int changeValue = 100;
+  TestValue::set<int>(
+      "facebook::velox::exec::test::TestObject::set", [&](int* testData) {
+        EXPECT_EQ(value, *testData);
+        *testData = changeValue;
+      });
+  TestValue::set<std::pair<int, int>>(
+      "facebook::velox::exec::test::TestObject::internalSet",
+      [&](std::pair<int, int>* testData) {
+        setValue = testData->first;
+        setCount = testData->second;
+      });
+  TestObject obj;
+  obj.set(value);
+  // Since test value has not been enabled, then both 'setValue' and 'setCount'
+  // won't be set.
+  EXPECT_EQ(0, setValue);
+  EXPECT_EQ(0, setCount);
+
+  obj.set(value);
+  EXPECT_EQ(0, setValue);
+  EXPECT_EQ(0, setCount);
+  TestValue::clear("facebook::velox::exec::test::TestObject::set");
+  TestValue::clear("facebook::velox::exec::test::TestObject::internalSet");
+
+  obj.set(value);
+  EXPECT_EQ(0, setValue);
+  EXPECT_EQ(0, setCount);
+}
+
+TEST(TestValueTest, testValueEnabled) {
+  TestValue::enable();
+  EXPECT_TRUE(TestValue::enabled());
+  int setCount = 0;
+  int setValue = 0;
+  int value = 200;
+  int changeValue = 100;
+  TestValue::set<int>(
+      "facebook::velox::exec::test::TestObject::set", [&](int* testData) {
+        EXPECT_EQ(value, *testData);
+        *testData = changeValue;
+      });
+  TestValue::set<std::pair<int, int>>(
+      "facebook::velox::exec::test::TestObject::internalSet",
+      [&](std::pair<int, int>* testData) {
+        setValue = testData->first;
+        setCount = testData->second;
+      });
+  TestObject obj;
+  obj.set(value);
+  EXPECT_EQ(changeValue, setValue);
+  EXPECT_EQ(0, setCount);
+
+  setCount = 0;
+  setValue = 0;
+  obj.set(value);
+  EXPECT_EQ(changeValue, setValue);
+  EXPECT_EQ(1, setCount);
+
+  TestValue::clear("facebook::velox::exec::test::TestObject::set");
+  setCount = 0;
+  setValue = 0;
+  obj.set(value);
+  // The outer test value has been cleared so 'setValue' will be set
+  // method input value.
+  EXPECT_EQ(value, setValue);
+  EXPECT_EQ(2, setCount);
+
+  TestValue::clear("facebook::velox::exec::test::TestObject::internalSet");
+  setCount = 0;
+  setValue = 0;
+  obj.set(value);
+  // The test values have been cleared so both 'setValue' and 'setCount'
+  // won't be set.
+  EXPECT_EQ(0, setValue);
+  EXPECT_EQ(0, setCount);
+}
+
+TEST(TestValueTest, scopeUsageEnabled) {
+  TestValue::enable();
+  EXPECT_TRUE(TestValue::enabled());
+  {
+    // Invalid ctor checks.
+    EXPECT_ANY_THROW(ScopedTestValue(
+        "", std::function<void(void*)>([&](void* /*unused*/) {})));
+    EXPECT_ANY_THROW(
+        ScopedTestValue("dummy", std::function<void(void*)>(nullptr)));
+  }
+  {
+    int setCount = 0;
+    int setValue = 0;
+    int value = 200;
+    int changeValue = 100;
+    TestObject obj;
+    {
+      ScopedTestValue testSet(
+          "facebook::velox::exec::test::TestObject::set",
+          std::function<void(int*)>([&](auto* testData) {
+            EXPECT_EQ(value, *testData);
+            *testData = changeValue;
+          }));
+      ScopedTestValue testInternalSet(
+          "facebook::velox::exec::test::TestObject::internalSet",
+          std::function<void(std::pair<int, int>*)>([&](auto* testData) {
+            setValue = testData->first;
+            setCount = testData->second;
+          }));
+      obj.set(value);
+      EXPECT_EQ(changeValue, setValue);
+      EXPECT_EQ(0, setCount);
+    }
+    // Scoped object dtor will clear the test value settings.
+    setCount = 0;
+    setValue = 0;
+    obj.set(value);
+    EXPECT_EQ(0, setValue);
+    EXPECT_EQ(0, setCount);
+  }
+  {
+    int setCount = 0;
+    int setValue = 0;
+    int value = 200;
+    int changeValue = 100;
+    TestObject obj;
+    {
+      SCOPED_TESTVALUE_SET(
+          "facebook::velox::exec::test::TestObject::set",
+          std::function<void(int*)>([&](auto* testData) {
+            EXPECT_EQ(value, *testData);
+            *testData = changeValue;
+          }));
+      SCOPED_TESTVALUE_SET(
+          "facebook::velox::exec::test::TestObject::internalSet",
+          std::function<void(std::pair<int, int>*)>(([&](auto* testData) {
+            setValue = testData->first;
+            setCount = testData->second;
+          })));
+      obj.set(value);
+      EXPECT_EQ(changeValue, setValue);
+      EXPECT_EQ(0, setCount);
+    }
+    // Scoped object dtor will clear the test value settings.
+    setCount = 0;
+    setValue = 0;
+    obj.set(value);
+    EXPECT_EQ(0, setValue);
+    EXPECT_EQ(0, setCount);
+  }
+}
+
+TEST(TestValueTest, scopeUsage) {
+  TestValue::disable();
+  EXPECT_FALSE(TestValue::enabled());
+  {
+    int setCount = 0;
+    int setValue = 0;
+    int value = 200;
+    int changeValue = 100;
+    TestObject obj;
+    ScopedTestValue testSet(
+        "facebook::velox::exec::test::TestObject::set",
+        std::function<void(int*)>([&](auto* testData) {
+          EXPECT_EQ(value, *testData);
+          *testData = changeValue;
+        }));
+    ScopedTestValue testInternalSet(
+        "facebook::velox::exec::test::TestObject::internalSet",
+        std::function<void(std::pair<int, int>*)>([&](auto* testData) {
+          setValue = testData->first;
+          setCount = testData->second;
+        }));
+    obj.set(value);
+    // If test value has not been enabled, then both 'setValue' and
+    // 'setCount' won't be set.
+    EXPECT_EQ(0, setValue);
+    EXPECT_EQ(0, setCount);
+  }
+
+  {
+    int setCount = 0;
+    int setValue = 0;
+    int value = 200;
+    int changeValue = 100;
+    TestObject obj;
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::test::TestObject::set",
+        std::function<void(int*)>([&](auto* testData) {
+          EXPECT_EQ(value, *testData);
+          *testData = changeValue;
+        }));
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::test::TestObject::internalSet",
+        std::function<void(std::pair<int, int>*)>([&](auto* testData) {
+          setValue = testData->first;
+          setCount = testData->second;
+        }));
+    obj.set(value);
+    // If test value has not been enabled, then both 'setValue' and
+    // 'setCount' won't be set.
+    EXPECT_EQ(0, setValue);
+    EXPECT_EQ(0, setCount);
+  }
+}
+} // namespace


### PR DESCRIPTION
Add testvalue test facility for velox which can help to capture and manipulate the production internal state for unit test purpose.