### PR TITLE
ArrayConstructor should clearNulls when reusing result

### DIFF
--- a/velox/functions/prestosql/ArrayConstructor.cpp
+++ b/velox/functions/prestosql/ArrayConstructor.cpp
@@ -34,6 +34,7 @@ class ArrayConstructor : public exec::VectorFunction {
     auto numArgs = args.size();
 
     BaseVector::ensureWritable(rows, outputType, context->pool(), result);
+    (*result)->clearNulls(rows);
     auto arrayResult = (*result)->as<ArrayVector>();
     auto sizes = arrayResult->mutableSizes(rows.size());
     auto rawSizes = sizes->asMutable<int32_t>();


### PR DESCRIPTION
Summary:
The Vector result passed into ArrayConstructor may have some values set to null.  Since the UDF currently doesn't touch result's null buffer these get incorrectly returned as null.

Fixed by clearing out nulls for selected rows.

Differential Revision: D38119857

