### PR TITLE
Copied flatmap column writer into new files for struct version

### DIFF
--- a/velox/dwio/dwrf/writer/FlatMapStructEncodingColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/FlatMapStructEncodingColumnWriter.cpp
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/dwrf/writer/FlatMapStructEncodingColumnWriter.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::dwrf {
+
+using dwio::common::TypeWithId;
+using proto::KeyInfo;
+
+template <TypeKind K>
+FlatMapStructEncodingColumnWriter<K>::FlatMapStructEncodingColumnWriter(
+    WriterContext& context,
+    const TypeWithId& type,
+    const uint32_t sequence)
+    : BaseColumnWriter{context, type, sequence, nullptr},
+      keyType_{*type.childAt(0)},
+      valueType_{*type.childAt(1)},
+      maxKeyCount_{context_.getConfig(Config::MAP_FLAT_MAX_KEYS)} {
+  auto options = StatisticsBuilderOptions::fromConfig(context.getConfigs());
+  keyFileStatsBuilder_ =
+      std::unique_ptr<typename TypeInfo<K>::StatisticsBuilder>(
+          dynamic_cast<typename TypeInfo<K>::StatisticsBuilder*>(
+              StatisticsBuilder::create(*keyType_.type, options).release()));
+  valueFileStatsBuilder_ = ValueStatisticsBuilder::create(context_, valueType_);
+  reset();
+}
+
+template <TypeKind K>
+void FlatMapStructEncodingColumnWriter<K>::setEncoding(
+    proto::ColumnEncoding& encoding) const {
+  BaseColumnWriter::setEncoding(encoding);
+  encoding.set_kind(proto::ColumnEncoding_Kind::ColumnEncoding_Kind_MAP_FLAT);
+}
+
+template <TypeKind K>
+void FlatMapStructEncodingColumnWriter<K>::flush(
+    std::function<proto::ColumnEncoding&(uint32_t)> encodingFactory,
+    std::function<void(proto::ColumnEncoding&)> encodingOverride) {
+  BaseColumnWriter::flush(encodingFactory, encodingOverride);
+
+  for (auto& pair : valueWriters_) {
+    pair.second.flush(encodingFactory);
+  }
+
+  // Reset is being called after flush, so no need to explicitly
+  // reset internal stripe state
+}
+
+template <TypeKind K>
+void FlatMapStructEncodingColumnWriter<K>::createIndexEntry() {
+  // Aggregate value writer index stats into map writer index stats before
+  // merging into file stats.
+  auto& mapStatsBuilder =
+      dynamic_cast<MapStatisticsBuilder&>(*indexStatsBuilder_);
+  for (auto& pair : valueWriters_) {
+    pair.second.createIndexEntry(*valueFileStatsBuilder_, mapStatsBuilder);
+  }
+  BaseColumnWriter::createIndexEntry();
+  rowsInStrides_.push_back(rowsInCurrentStride_);
+  rowsInCurrentStride_ = 0;
+}
+
+template <TypeKind K>
+uint64_t FlatMapStructEncodingColumnWriter<K>::writeFileStats(
+    std::function<proto::ColumnStatistics&(uint32_t)> statsFactory) const {
+  auto& stats = statsFactory(id_);
+  fileStatsBuilder_->toProto(stats);
+  uint64_t size = context_.getNodeSize(id_);
+
+  auto& keyStats = statsFactory(keyType_.id);
+  keyFileStatsBuilder_->toProto(keyStats);
+  auto keySize = context_.getNodeSize(keyType_.id);
+  keyStats.set_size(keySize);
+
+  size += keySize;
+  size += valueFileStatsBuilder_->writeFileStats(statsFactory);
+  stats.set_size(size);
+  return size;
+}
+
+template <TypeKind K>
+void FlatMapStructEncodingColumnWriter<K>::clearNodes() {
+  // TODO: If we are writing shared dictionaries, the shared dictionary data
+  // stream should be reused. Even when the stream is not actually used, we
+  // should keep it around in case of future encoding decision changes.
+  context_.removeAllIntDictionaryEncodersOnNode([this](uint32_t nodeId) {
+    return nodeId >= valueType_.id && nodeId <= valueType_.maxId;
+  });
+
+  context_.removeStreams([this](const DwrfStreamIdentifier& identifier) {
+    return identifier.encodingKey().node >= valueType_.id &&
+        identifier.encodingKey().node <= valueType_.maxId &&
+        (identifier.kind() == StreamKind::StreamKind_DICTIONARY_DATA ||
+         identifier.encodingKey().sequence > 0);
+  });
+}
+
+template <TypeKind K>
+void FlatMapStructEncodingColumnWriter<K>::reset() {
+  BaseColumnWriter::reset();
+  clearNodes();
+  valueWriters_.clear();
+  rowsInStrides_.clear();
+  rowsInCurrentStride_ = 0;
+}
+
+KeyInfo getKeyInfo(int64_t key) {
+  KeyInfo keyInfo;
+  keyInfo.set_intkey(key);
+  return keyInfo;
+}
+
+KeyInfo getKeyInfo(StringView key) {
+  KeyInfo keyInfo;
+  keyInfo.set_byteskey(key.data(), key.size());
+  return keyInfo;
+}
+
+template <TypeKind K>
+ValueWriter& FlatMapStructEncodingColumnWriter<K>::getValueWriter(
+    KeyType key,
+    uint32_t inMapSize) {
+  auto it = valueWriters_.find(key);
+  if (it != valueWriters_.end()) {
+    return it->second;
+  }
+
+  if (valueWriters_.size() >= maxKeyCount_) {
+    DWIO_RAISE("Too many map keys requested. Allowed: ", maxKeyCount_);
+  }
+
+  auto keyInfo = getKeyInfo(key);
+
+  it = valueWriters_
+           .emplace(
+               std::piecewise_construct,
+               std::forward_as_tuple(key),
+               std::forward_as_tuple(
+                   valueWriters_.size() + 1, /* sequence */
+                   keyInfo,
+                   this->context_,
+                   this->valueType_,
+                   inMapSize))
+           .first;
+
+  ValueWriter& valueWriter = it->second;
+
+  auto& mapStatsBuilder =
+      dynamic_cast<MapStatisticsBuilder&>(*fileStatsBuilder_);
+  // Back fill previous strides with not-in-map indication
+  for (auto& rows : rowsInStrides_) {
+    valueWriter.backfill(rows);
+    valueWriter.createIndexEntry(*valueFileStatsBuilder_, mapStatsBuilder);
+  }
+
+  // Back fill current (partial) stride with not-in-map indication
+  valueWriter.backfill(rowsInCurrentStride_);
+
+  return valueWriter;
+}
+
+template <TypeKind K>
+uint32_t updateKeyStatistics(
+    typename TypeInfo<K>::StatisticsBuilder& keyStatsBuilder,
+    typename TypeTraits<K>::NativeType value) {
+  keyStatsBuilder.addValues(value);
+  return sizeof(typename TypeTraits<K>::NativeType);
+}
+
+template <>
+uint32_t updateKeyStatistics<TypeKind::VARCHAR>(
+    StringStatisticsBuilder& keyStatsBuilder,
+    StringView value) {
+  auto size = value.size();
+  keyStatsBuilder.addValues(folly::StringPiece{value.data(), size});
+  return size;
+}
+
+template <>
+uint32_t updateKeyStatistics<TypeKind::VARBINARY>(
+    BinaryStatisticsBuilder& keyStatsBuilder,
+    StringView value) {
+  auto size = value.size();
+  keyStatsBuilder.addValues(size);
+  return size;
+}
+
+namespace {
+
+// Adapters to handle flat or decoded vector using same interfaces. For usages
+// when type is not important (ie. we don't call valueAt()), we can rely on the
+// default type.
+template <typename T = int8_t>
+class Flat {
+ public:
+  explicit Flat(const VectorPtr& vector)
+      : vector_{vector}, nulls_{vector_->rawNulls()} {
+    auto casted = vector->asFlatVector<T>();
+    values_ = casted ? casted->rawValues() : nullptr;
+  }
+
+  bool hasNulls() const {
+    return vector_->mayHaveNulls();
+  }
+
+  bool isNullAt(vector_size_t index) const {
+    return bits::isBitNull(nulls_, index);
+  }
+
+  T valueAt(vector_size_t index) const {
+    return values_[index];
+  }
+
+  vector_size_t index(vector_size_t index) const {
+    return index;
+  }
+
+ private:
+  const VectorPtr& vector_;
+  const uint64_t* nulls_;
+  const T* values_;
+};
+
+template <typename T = int8_t>
+class Decoded {
+ public:
+  explicit Decoded(const DecodedVector& decoded) : decoded_{decoded} {}
+
+  bool hasNulls() const {
+    return decoded_.mayHaveNulls();
+  }
+
+  bool isNullAt(vector_size_t index) const {
+    return decoded_.isNullAt(index);
+  }
+
+  T valueAt(vector_size_t index) const {
+    return decoded_.valueAt<T>(index);
+  }
+
+  vector_size_t index(vector_size_t index) const {
+    return decoded_.index(index);
+  }
+
+ private:
+  const DecodedVector& decoded_;
+};
+
+template <typename Map, typename MapOp>
+uint64_t iterateMaps(const Ranges& ranges, const Map& map, const MapOp& mapOp) {
+  uint64_t nullCount = 0;
+  if (map.hasNulls()) {
+    for (auto& index : ranges) {
+      if (map.isNullAt(index)) {
+        ++nullCount;
+      } else {
+        mapOp(map.index(index));
+      }
+    }
+  } else {
+    for (auto& index : ranges) {
+      mapOp(map.index(index));
+    }
+  }
+  return nullCount;
+}
+
+} // namespace
+
+template <TypeKind K>
+uint64_t FlatMapStructEncodingColumnWriter<K>::write(
+    const VectorPtr& slice,
+    const Ranges& ranges) {
+  // Define variables captured and used by below lambdas.
+  const vector_size_t* offsets;
+  const vector_size_t* lengths;
+  uint64_t rawSize = 0;
+  uint64_t mapCount = 0;
+  Ranges keyRanges;
+
+  // Lambda that iterates keys of a map and records the offsets to write to
+  // particular value node.
+  auto processMap = [&](uint64_t offsetIndex, const auto& keysVector) {
+    auto begin = offsets[offsetIndex];
+    auto end = begin + lengths[offsetIndex];
+
+    for (auto i = begin; i < end; ++i) {
+      auto key = keysVector.valueAt(i);
+      ValueWriter& valueWriter = getValueWriter(key, ranges.size());
+      valueWriter.addOffset(i, mapCount);
+      auto keySize = updateKeyStatistics<K>(*keyFileStatsBuilder_, key);
+      keyFileStatsBuilder_->increaseRawSize(keySize);
+      rawSize += keySize;
+    }
+
+    ++mapCount;
+  };
+
+  // Lambda that calculates child ranges
+  auto computeKeyRanges = [&](uint64_t offsetIndex) {
+    auto begin = offsets[offsetIndex];
+    keyRanges.add(begin, begin + lengths[offsetIndex]);
+  };
+
+  // Lambda that process the batch
+  auto processBatch = [&](const auto& map, const auto& mapSlice) {
+    auto& mapKeys = mapSlice->mapKeys();
+    auto keysFlat = mapKeys->template asFlatVector<KeyType>();
+    if (keysFlat) {
+      // Keys are flat
+      Flat<KeyType> keysVector{mapKeys};
+      return iterateMaps(
+          ranges, map, [&](auto offset) { processMap(offset, keysVector); });
+    } else {
+      // Keys are encoded. Decode.
+      iterateMaps(ranges, map, computeKeyRanges);
+      auto localDecodedKeys = decode(mapKeys, keyRanges);
+      auto& decodedKeys = localDecodedKeys.get();
+      Decoded<KeyType> keysVector{decodedKeys};
+      return iterateMaps(
+          ranges, map, [&](auto offset) { processMap(offset, keysVector); });
+    }
+  };
+
+  // Reset all existing value writer buffers
+  // This includes existing value writers that are not used in this batch
+  // (their buffers will be set to empty buffers)
+  for (auto& pair : valueWriters_) {
+    pair.second.resizeBuffers(ranges.size());
+  }
+
+  // Fill value buffers per key
+  uint64_t nullCount = 0;
+  const MapVector* mapSlice = slice->as<MapVector>();
+  if (mapSlice) {
+    // Map is flat
+    writeNulls(slice, ranges);
+    offsets = mapSlice->rawOffsets();
+    lengths = mapSlice->rawSizes();
+    nullCount = processBatch(Flat{slice}, mapSlice);
+  } else {
+    // Map is encoded. Decode.
+    auto localDecodedMap = decode(slice, ranges);
+    auto& decodedMap = localDecodedMap.get();
+    writeNulls(decodedMap, ranges);
+    mapSlice = decodedMap.base()->template as<MapVector>();
+    DWIO_ENSURE(mapSlice, "unexpected vector type");
+
+    offsets = mapSlice->rawOffsets();
+    lengths = mapSlice->rawSizes();
+    nullCount = processBatch(Decoded{decodedMap}, mapSlice);
+  }
+
+  auto& values = mapSlice->mapValues();
+  // Write all accumulated buffers (this includes value writers that weren't
+  // used in this write. This is how we backfill unused value writers)
+  for (auto& pair : valueWriters_) {
+    rawSize += pair.second.writeBuffers(values, mapCount);
+  }
+
+  if (nullCount > 0) {
+    indexStatsBuilder_->setHasNull();
+    rawSize += nullCount * NULL_SIZE;
+  }
+  rowsInCurrentStride_ += mapCount;
+  indexStatsBuilder_->increaseValueCount(mapCount);
+  indexStatsBuilder_->increaseRawSize(rawSize);
+  return rawSize;
+}
+
+template class FlatMapStructEncodingColumnWriter<TypeKind::TINYINT>;
+template class FlatMapStructEncodingColumnWriter<TypeKind::SMALLINT>;
+template class FlatMapStructEncodingColumnWriter<TypeKind::INTEGER>;
+template class FlatMapStructEncodingColumnWriter<TypeKind::BIGINT>;
+template class FlatMapStructEncodingColumnWriter<TypeKind::VARCHAR>;
+template class FlatMapStructEncodingColumnWriter<TypeKind::VARBINARY>;
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/FlatMapStructEncodingColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapStructEncodingColumnWriter.h
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/dwrf/writer/ColumnWriter.h"
+
+namespace facebook::velox::dwrf {
+
+// This class aggregates statistics of all value writers.
+// Since a map value column can be complex (it is a tree of nodes), we need to
+// aggregae every level of the tree, across all value writers.
+class ValueStatisticsBuilder {
+ public:
+  ValueStatisticsBuilder(
+      WriterContext& context,
+      uint32_t id,
+      std::unique_ptr<StatisticsBuilder> statisticsBuilder,
+      std::vector<std::unique_ptr<ValueStatisticsBuilder>> children)
+      : context_{context},
+        id_{id},
+        statisticsBuilder_{std::move(statisticsBuilder)},
+        children_{std::move(children)} {}
+
+  static std::unique_ptr<const ValueStatisticsBuilder> create(
+      WriterContext& context,
+      const dwio::common::TypeWithId& root) {
+    auto options = StatisticsBuilderOptions::fromConfig(context.getConfigs());
+    return create_(context, root, options);
+  }
+
+  void merge(const BaseColumnWriter& writer) const {
+    statisticsBuilder_->merge(*writer.indexStatsBuilder_);
+    DWIO_ENSURE(
+        children_.size() == writer.children_.size(),
+        "Value statistics writer children mismatch");
+    for (int32_t i = 0; i < children_.size(); ++i) {
+      children_[i]->merge(*writer.children_[i]);
+    }
+  }
+
+  uint64_t writeFileStats(
+      std::function<proto::ColumnStatistics&(uint32_t)> statsFactory) const {
+    auto& stats = statsFactory(id_);
+    statisticsBuilder_->toProto(stats);
+    uint64_t size = context_.getNodeSize(id_);
+    for (int32_t i = 0; i < children_.size(); ++i) {
+      size += children_[i]->writeFileStats(statsFactory);
+    }
+    stats.set_size(size);
+    return size;
+  }
+
+ private:
+  static std::unique_ptr<ValueStatisticsBuilder> create_(
+      WriterContext& context,
+      const dwio::common::TypeWithId& type,
+      const StatisticsBuilderOptions& options) {
+    auto builder = StatisticsBuilder::create(*type.type, options);
+
+    std::vector<std::unique_ptr<ValueStatisticsBuilder>> children{};
+    for (size_t i = 0; i < type.size(); ++i) {
+      children.push_back(create_(context, *type.childAt(i), options));
+    }
+
+    return std::make_unique<ValueStatisticsBuilder>(
+        context, type.id, std::move(builder), std::move(children));
+  }
+
+  WriterContext& context_;
+  const uint32_t id_;
+  const std::unique_ptr<StatisticsBuilder> statisticsBuilder_;
+  const std::vector<std::unique_ptr<ValueStatisticsBuilder>> children_;
+};
+
+// ValueWriter is used to write flat-map value columns.
+// It holds a column writer to write the values and an in-map encoder to
+// indicate if a value exists in the map (to distinguish null values from
+// not-in-map values)
+class ValueWriter {
+ public:
+  ValueWriter(
+      const uint32_t sequence,
+      const proto::KeyInfo& keyInfo,
+      WriterContext& context,
+      const dwio::common::TypeWithId& type,
+      uint32_t inMapSize)
+      : sequence_{sequence},
+        keyInfo_{keyInfo},
+        inMap_{createBooleanRleEncoder(context.newStream(
+            {type.id, sequence, 0, StreamKind::StreamKind_IN_MAP}))},
+        columnWriter_{BaseColumnWriter::create(
+            context,
+            type,
+            sequence,
+            [this](auto& indexBuilder) {
+              inMap_->recordPosition(indexBuilder);
+            })},
+        inMapBuffer_{
+            context.getMemoryPool(MemoryUsageCategory::GENERAL),
+            inMapSize},
+        ranges_{},
+        collectMapStats_{context.getConfig(Config::MAP_STATISTICS)} {}
+
+  void addOffset(uint64_t offset, uint64_t inMapIndex) {
+    if (UNLIKELY(inMapBuffer_[inMapIndex])) {
+      DWIO_RAISE("Duplicate key in map");
+    }
+
+    ranges_.add(offset, offset + 1);
+    inMapBuffer_[inMapIndex] = 1;
+  }
+
+  uint64_t writeBuffers(const VectorPtr& values, uint32_t mapCount) {
+    if (mapCount) {
+      inMap_->add(inMapBuffer_.data(), Ranges::of(0, mapCount), nullptr);
+    }
+
+    if (values) {
+      return columnWriter_->write(values, ranges_);
+    }
+    return 0;
+  }
+
+  void backfill(uint32_t count) {
+    if (count == 0) {
+      return;
+    }
+
+    inMapBuffer_.reserve(count);
+    std::memset(inMapBuffer_.data(), 0, count);
+    inMap_->add(inMapBuffer_.data(), Ranges::of(0, count), nullptr);
+  }
+
+  uint32_t getSequence() const {
+    return sequence_;
+  }
+
+  void createIndexEntry(
+      const ValueStatisticsBuilder& valueStatsBuilder,
+      MapStatisticsBuilder& mapStatsBuilder) {
+    if (collectMapStats_) {
+      mapStatsBuilder.addValues(keyInfo_, *columnWriter_->indexStatsBuilder_);
+    }
+    valueStatsBuilder.merge(*columnWriter_);
+    columnWriter_->createIndexEntry();
+  }
+
+  void flush(std::function<proto::ColumnEncoding&(uint32_t)> encodingFactory) {
+    inMap_->flush();
+    columnWriter_->flush(encodingFactory, [&](auto& encoding) {
+      *encoding.mutable_key() = keyInfo_;
+    });
+  }
+
+  void reset() {
+    columnWriter_->reset();
+  }
+
+  void resizeBuffers(size_t inMap) {
+    inMapBuffer_.reserve(inMap);
+    std::memset(inMapBuffer_.data(), 0, inMap);
+    ranges_.clear();
+  }
+
+ private:
+  uint32_t sequence_;
+  const proto::KeyInfo keyInfo_;
+  std::unique_ptr<ByteRleEncoder> inMap_;
+  std::unique_ptr<BaseColumnWriter> columnWriter_;
+  dwio::common::DataBuffer<char> inMapBuffer_;
+  Ranges ranges_;
+  const bool collectMapStats_;
+};
+
+namespace {
+
+template <TypeKind K>
+struct TypeInfo {};
+
+template <>
+struct TypeInfo<TypeKind::TINYINT> {
+  using StatisticsBuilder = IntegerStatisticsBuilder;
+};
+
+template <>
+struct TypeInfo<TypeKind::SMALLINT> {
+  using StatisticsBuilder = IntegerStatisticsBuilder;
+};
+
+template <>
+struct TypeInfo<TypeKind::INTEGER> {
+  using StatisticsBuilder = IntegerStatisticsBuilder;
+};
+
+template <>
+struct TypeInfo<TypeKind::BIGINT> {
+  using StatisticsBuilder = IntegerStatisticsBuilder;
+};
+
+template <>
+struct TypeInfo<TypeKind::VARCHAR> {
+  using StatisticsBuilder = StringStatisticsBuilder;
+};
+
+template <>
+struct TypeInfo<TypeKind::VARBINARY> {
+  using StatisticsBuilder = BinaryStatisticsBuilder;
+};
+
+} // namespace
+
+template <TypeKind K>
+class FlatMapStructEncodingColumnWriter : public BaseColumnWriter {
+ public:
+  FlatMapStructEncodingColumnWriter(
+      WriterContext& context,
+      const dwio::common::TypeWithId& type,
+      const uint32_t sequence);
+
+  uint64_t write(const VectorPtr& slice, const Ranges& ranges) override;
+
+  void flush(
+      std::function<proto::ColumnEncoding&(uint32_t)> encodingFactory,
+      std::function<void(proto::ColumnEncoding&)> encodingOverride) override;
+
+  void createIndexEntry() override;
+
+  void reset() override;
+
+  uint64_t writeFileStats(std::function<proto::ColumnStatistics&(uint32_t)>
+                              statsFactory) const override;
+
+ private:
+  using KeyType = typename TypeTraits<K>::NativeType;
+
+  void setEncoding(proto::ColumnEncoding& encoding) const override;
+
+  ValueWriter& getValueWriter(KeyType key, uint32_t inMapSize);
+
+  void clearNodes();
+
+  // Map of value writers for each key in the dictionary. Needs referential
+  // stability because a member variable is captured by reference by lambda
+  // function passed to another class.
+  folly::F14NodeMap<KeyType, ValueWriter, folly::Hash> valueWriters_;
+
+  // Captures row count for each completed stride in current stripe
+  std::vector<size_t> rowsInStrides_;
+
+  // Captures current row count for current (incomplete) stride
+  size_t rowsInCurrentStride_{0};
+
+  // Remember key and value types. Needed for constructing value writers
+  const dwio::common::TypeWithId& keyType_;
+  const dwio::common::TypeWithId& valueType_;
+
+  std::unique_ptr<typename TypeInfo<K>::StatisticsBuilder> keyFileStatsBuilder_;
+  std::unique_ptr<const ValueStatisticsBuilder> valueFileStatsBuilder_;
+  const uint32_t maxKeyCount_;
+};
+
+template <>
+class FlatMapStructEncodingColumnWriter<TypeKind::INVALID> {
+ public:
+  static std::unique_ptr<BaseColumnWriter> create(
+      WriterContext& context,
+      const dwio::common::TypeWithId& type,
+      const uint32_t sequence) {
+    DWIO_ENSURE_EQ(type.size(), 2, "Map should have exactly two children");
+
+    auto kind = type.childAt(0)->type->kind();
+    switch (kind) {
+      case TypeKind::TINYINT:
+        return std::make_unique<
+            FlatMapStructEncodingColumnWriter<TypeKind::TINYINT>>(
+            context, type, sequence);
+      case TypeKind::SMALLINT:
+        return std::make_unique<
+            FlatMapStructEncodingColumnWriter<TypeKind::SMALLINT>>(
+            context, type, sequence);
+      case TypeKind::INTEGER:
+        return std::make_unique<
+            FlatMapStructEncodingColumnWriter<TypeKind::INTEGER>>(
+            context, type, sequence);
+      case TypeKind::BIGINT:
+        return std::make_unique<
+            FlatMapStructEncodingColumnWriter<TypeKind::BIGINT>>(
+            context, type, sequence);
+      case TypeKind::VARBINARY:
+        return std::make_unique<
+            FlatMapStructEncodingColumnWriter<TypeKind::VARBINARY>>(
+            context, type, sequence);
+      case TypeKind::VARCHAR:
+        return std::make_unique<
+            FlatMapStructEncodingColumnWriter<TypeKind::VARCHAR>>(
+            context, type, sequence);
+      default:
+        DWIO_RAISE("Not supported key type: ", kind);
+    }
+  }
+};
+
+} // namespace facebook::velox::dwrf


### PR DESCRIPTION
Summary: Duplicated FlatMapColumnWriter.h and FlatMapColumnWriter.cpp into new files to convert into the FlatMapStructEncodingColumnWriter. Committing this first, so I can see any changes in future diffs.

Differential Revision: D38094062

