### PR TITLE
Disable partial output flush for global aggregation

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -296,15 +296,11 @@ void GroupingSet::initializeGlobalAggregation() {
   }
 
   lookup_->hits[0] = rows_.allocateFixed(offset);
-  resetGlobalAggregation();
-  globalAggregationInitialized_ = true;
-}
-
-void GroupingSet::resetGlobalAggregation() {
   const auto singleGroup = std::vector<vector_size_t>{0};
   for (auto& aggregate : aggregates_) {
     aggregate->initializeNewGroups(lookup_->hits.data(), singleGroup);
   }
+  globalAggregationInitialized_ = true;
 }
 
 void GroupingSet::addGlobalAggregationInput(
@@ -446,9 +442,6 @@ void GroupingSet::extractGroups(
 void GroupingSet::resetPartial() {
   if (table_ != nullptr) {
     table_->clear();
-  }
-  if (isGlobal_ && globalAggregationInitialized_) {
-    resetGlobalAggregation();
   }
 }
 

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -63,10 +63,6 @@ class GroupingSet {
 
   void resetPartial();
 
-  /// Invoked to reset the intermediate aggregation state on init or partial
-  /// output flush.
-  void resetGlobalAggregation();
-
   const HashLookup& hashLookup() const;
 
   /// Spills content until under 'targetRows' and under 'targetBytes'

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -159,7 +159,10 @@ void HashAggregation::addInput(RowVectorPtr input) {
   stats_.spilledBytes = spilled.first;
   stats_.spilledRows = spilled.second;
 
-  if (isPartialOutput_ &&
+  // NOTE: we should not trigger partial output flush in case of global
+  // aggregation as the final aggregator will handle it the same way as the
+  // partial aggregator. Hence, we have to use more memory anyway.
+  if (isPartialOutput_ && !isGlobal_ &&
       groupingSet_->allocatedBytes() > maxPartialAggregationMemoryUsage_) {
     partialFull_ = true;
   }
@@ -185,10 +188,11 @@ void HashAggregation::prepareOutput(vector_size_t size) {
   }
 }
 
-void HashAggregation::flushPartialOutputIfNeed() {
+void HashAggregation::resetPartialOutputIfNeed() {
   if (!partialFull_) {
     return;
   }
+  VELOX_DCHECK(!isGlobal_);
   stats().addRuntimeStat("flushRowCount", RuntimeCounter(numOutputRows_));
   groupingSet_->resetPartial();
   partialFull_ = false;
@@ -233,7 +237,7 @@ RowVectorPtr HashAggregation::getOutput() {
     // allow for memory reuse.
     input_ = nullptr;
 
-    flushPartialOutputIfNeed();
+    resetPartialOutputIfNeed();
     return output;
   }
 
@@ -245,7 +249,7 @@ RowVectorPtr HashAggregation::getOutput() {
   bool hasData = groupingSet_->getOutput(batchSize, resultIterator_, output_);
   if (!hasData) {
     resultIterator_.reset();
-    flushPartialOutputIfNeed();
+    resetPartialOutputIfNeed();
 
     if (noMoreInput_) {
       finished_ = true;

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -53,7 +53,10 @@ class HashAggregation : public Operator {
 
  private:
   void prepareOutput(vector_size_t size);
-  void flushPartialOutputIfNeed();
+
+  /// Invoked to reset partial aggregation state if it was full and has been
+  /// flushed.
+  void resetPartialOutputIfNeed();
 
   /// Maximum number of rows in the output batch.
   const uint32_t outputBatchSize_;

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -804,18 +804,11 @@ TEST_F(AggregationTest, partialAggregationMemoryLimit) {
                        .finalAggregation()
                        .planNode())
              .assertResults("SELECT sum(c0) FROM tmp");
-  EXPECT_GT(
+  EXPECT_EQ(
+      0,
       toPlanStats(task->taskStats())
           .at(aggNodeId)
-          .customStats.at("flushRowCount")
-          .count,
-      0);
-  EXPECT_GT(
-      toPlanStats(task->taskStats())
-          .at(aggNodeId)
-          .customStats.at("flushRowCount")
-          .max,
-      0);
+          .customStats.count("flushRowCount"));
 }
 
 // Validates partial aggregate output types for SUM/MIN/MAX.


### PR DESCRIPTION
Disables the partial output flush for global aggregation as it doesn't help and
final aggregator treat is the same way as the partial aggregator. We have to
use more memory in that case anyway.