### PR TITLE
Add memory arbitration strategy

### DIFF
--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   ByteStream.cpp
   HashStringAllocator.cpp
   Memory.cpp
+  MemoryManagerStrategy.cpp
   MemoryUsage.cpp
   MappedMemory.cpp
   MmapAllocator.cpp

--- a/velox/common/memory/MappedMemory.cpp
+++ b/velox/common/memory/MappedMemory.cpp
@@ -67,6 +67,7 @@ MachinePageCount MappedMemory::ContiguousAllocation::numPages() const {
 
 // static
 void MappedMemory::destroyTestOnly() {
+  customInstance_ = nullptr;
   instance_ = nullptr;
 }
 

--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -453,6 +453,13 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
         totalLargeAllocateBytes_};
   }
 
+  // clears counters to revert effect of previous tests.
+  static void testingClearAllocateBytesStats() {
+    totalSmallAllocateBytes_ = 0;
+    totalSizeClassAllocateBytes_ = 0;
+    totalLargeAllocateBytes_ = 0;
+  }
+
   virtual Stats stats() const {
     return Stats();
   }

--- a/velox/common/memory/MemoryManagerStrategy.cpp
+++ b/velox/common/memory/MemoryManagerStrategy.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/memory/MemoryManagerStrategy.h"
+#include <unistd.h>
+
+#include <folly/executors/task_queue/UnboundedBlockingQueue.h>
+#include <folly/executors/thread_factory/InitThreadFactory.h>
+
+namespace facebook::velox::memory {
+
+bool MemoryManagerStrategy::initialized_;
+MemoryManagerStrategy::MemoryManagerStrategyFactory
+    MemoryManagerStrategy::factory_;
+
+// static
+MemoryManagerStrategy* MemoryManagerStrategy::instance() {
+  static std::unique_ptr<MemoryManagerStrategy> strategy =
+      (factory_) ? factory_() : createDefault();
+  initialized_ = true;
+  return strategy.get();
+}
+
+std::unique_ptr<MemoryManagerStrategy> MemoryManagerStrategy::createDefault() {
+  return std::make_unique<DefaultMemoryManagerStrategy>();
+}
+
+} // namespace facebook::velox::memory

--- a/velox/common/memory/MemoryManagerStrategy.h
+++ b/velox/common/memory/MemoryManagerStrategy.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/futures/Future.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/memory/MemoryUsageTracker.h"
+
+namespace facebook::velox::memory {
+class MemoryPool;
+class ScopedMemoryPool;
+
+class MemoryConsumer {
+ public:
+  virtual ~MemoryConsumer() {}
+
+  // Returns the tracker with the current usage and limits.
+  virtual memory::MemoryUsageTracker& tracker() const = 0;
+
+  // Returns the number of bytes that may be reclaimable with
+  // reclaim().
+  virtual int64_t reclaimableBytes() const = 0;
+
+  //  Reclaims memory. Implementations may for example spill or evict
+  //  caches. 'size' specifies a target number of bytes to reclaim. The
+  //  actual effect on memory usage is seen in tracker(). This does not
+  //  guarantee any result. Implementations have additional
+  //  requirements for using this method, e.g. a Task must be paused.
+  virtual void reclaim(int64_t size) = 0;
+};
+
+class MemoryManagerStrategy {
+ public:
+  virtual ~MemoryManagerStrategy() {}
+
+  // returns true if this can resize limits of consumers.
+  virtual bool canResize() const = 0;
+
+  // Registers a memory consumer with MemoryManager.
+  virtual void registerConsumer(
+      MemoryConsumer* consumer,
+      const std::weak_ptr<MemoryConsumer>& consumerPtr) = 0;
+
+  // Unregisters a memory consumer with MemoryManager.
+  virtual void unregisterConsumer(MemoryConsumer* consumer) = 0;
+
+  // Tries to reclaim memory so that 'requester' can allocate 'size'
+  // bytes of new memory. Returns true if the user memory limit of
+  // 'requester' was increased by at least 'size'.
+  virtual bool reclaim(
+      std::shared_ptr<MemoryConsumer> requester,
+      int64_t size) = 0;
+
+  static MemoryManagerStrategy* instance();
+
+  using MemoryManagerStrategyFactory =
+      std::function<std::unique_ptr<MemoryManagerStrategy>()>;
+
+  static void registerFactory(MemoryManagerStrategyFactory factory) {
+    VELOX_CHECK(
+        !initialized_,
+        "Registering factory after creating MemoryManagerStrategy object");
+    factory_ = factory;
+  }
+
+ private:
+  static std::unique_ptr<MemoryManagerStrategy> createDefault();
+
+  static MemoryManagerStrategyFactory factory_;
+  static bool initialized_;
+};
+
+class MemoryManagerStrategyBase : public MemoryManagerStrategy {
+ public:
+  MemoryManagerStrategyBase() = default;
+
+  bool canResize() const override {
+    return false;
+  }
+
+  void registerConsumer(
+      MemoryConsumer* consumer,
+      const std::weak_ptr<MemoryConsumer>& consumerPtr) override {
+    std::lock_guard<std::mutex> l(mutex_);
+    consumers_.emplace(consumer, consumerPtr);
+  }
+
+  void unregisterConsumer(MemoryConsumer* consumer) override {
+    std::lock_guard<std::mutex> l(mutex_);
+    consumers_.erase(consumer);
+  }
+
+ protected:
+  using ConsumerMap =
+      std::unordered_map<MemoryConsumer*, std::weak_ptr<MemoryConsumer>>;
+
+  std::mutex mutex_;
+  ConsumerMap consumers_;
+};
+
+class DefaultMemoryManagerStrategy : public MemoryManagerStrategyBase {
+ public:
+  // No op.
+  bool reclaim(std::shared_ptr<MemoryConsumer> /*requester*/, int64_t /*size*/)
+      override {
+    return false;
+  }
+};
+
+} // namespace facebook::velox::memory

--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -33,9 +33,14 @@ std::shared_ptr<MemoryUsageTracker> MemoryUsageTracker::create(
   return std::make_shared<SharedMemoryUsageTracker>(parent, type, config);
 }
 
+MemoryUsageTracker::~MemoryUsageTracker() {}
+
 void MemoryUsageTracker::checkAndPropagateReservationIncrement(
     int64_t increment,
     bool updateMinReservation) {
+  if (!increment) {
+    return;
+  }
   std::exception_ptr exception;
   try {
     incrementUsage(type_, increment);
@@ -137,6 +142,17 @@ bool MemoryUsageTracker::maybeReserve(int64_t increment) {
     candidate = candidate->parent_.get();
   }
   return false;
+}
+
+std::string MemoryUsageTracker::toString() const {
+  std::stringstream out;
+  out << "<tracker total " << (getCurrentTotalBytes() >> 20) << " available "
+      << (getAvailableReservation() >> 20);
+  if (maxTotalBytes() != kMaxMemory) {
+    out << "limit " << (maxTotalBytes() >> 20);
+  }
+  out << ">";
+  return out.str();
 }
 
 SimpleMemoryTracker::SimpleMemoryTracker(const MemoryUsageConfig& config)

--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -144,7 +144,7 @@ class MemoryUsageTracker
             .build());
   }
 
-  virtual ~MemoryUsageTracker() = default;
+  virtual ~MemoryUsageTracker();
 
   // Increments the reservation for 'this' so that we can allocate at
   // least 'size' bytes on top of the current allocation. This is used
@@ -158,26 +158,33 @@ class MemoryUsageTracker
     {
       std::lock_guard<std::mutex> l(mutex_);
       increment = reserveLocked(size);
-      minReservation_ += increment;
+      minReservation_ = reservation_.load();
     }
     if (increment) {
       checkAndPropagateReservationIncrement(increment, true);
     }
   }
 
-  // Release unused reservation. Used reservation will be released as the
-  // allocations are freed.
+  // If a minimum reservation has been set with reserve(), resets the
+  // minimum reservation. If the current usage is below the minimum
+  // reservation, decreases reservation and usage down to the rounded
+  // actual usage.
   void release() {
-    int64_t remaining;
+    int64_t freeable;
     {
+      if (!minReservation_) {
+        return;
+      }
       std::lock_guard<std::mutex> l(mutex_);
-      remaining = reservation_ - usedReservation_;
-      reservation_ = 0;
+      auto reservationByUsage = quantizedSize(usedReservation_);
+      freeable = reservation_ - reservationByUsage;
+      if (reservation_ > reservationByUsage) {
+        reservation_ = reservationByUsage;
+      }
       minReservation_ = 0;
-      usedReservation_ = 0;
     }
-    if (remaining) {
-      decrementUsage(type_, remaining);
+    if (freeable) {
+      decrementUsage(type_, freeable);
     }
   }
 
@@ -298,6 +305,8 @@ class MemoryUsageTracker
   /// unlikely. Otherwise attempts the reservation increment and returns
   /// true if succeeded.
   bool maybeReserve(int64_t increment);
+
+  std::string toString() const;
 
  protected:
   static constexpr int64_t kMB = 1 << 20;

--- a/velox/common/memory/tests/MappedMemoryTest.cpp
+++ b/velox/common/memory/tests/MappedMemoryTest.cpp
@@ -38,6 +38,7 @@ static constexpr MachinePageCount kCapacity =
 class MappedMemoryTest : public testing::TestWithParam<bool> {
  protected:
   void SetUp() override {
+    MappedMemory::destroyTestOnly();
     auto tracker = MemoryUsageTracker::create(
         MemoryUsageConfigBuilder().maxTotalMemory(kMaxMappedMemory).build());
     useMmap_ = GetParam();
@@ -615,6 +616,7 @@ TEST_P(MappedMemoryTest, allocContiguousFail) {
 
 TEST_P(MappedMemoryTest, allocateBytes) {
   constexpr int32_t kNumAllocs = 50;
+  MappedMemory::testingClearAllocateBytesStats();
   // Different sizes, including below minimum and above largest size class.
   std::vector<MachinePageCount> sizes = {
       MappedMemory::kMaxMallocBytes / 2,

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(
   TableScan.cpp
   TableWriter.cpp
   Task.cpp
+  TaskMemoryStrategy.cpp
   TopN.cpp
   Unnest.cpp
   Values.cpp

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -373,6 +373,17 @@ class Operator {
     return stats_.planNodeId;
   }
 
+  // Returns an estimate of the maximum number of bytes that could be
+  // freed by calling spill().
+  virtual int64_t reclaimableBytes() const {
+    return 0;
+  }
+
+  // Tries to shrink the memory footprint of 'this' by at least
+  // 'minMemoryToReclaim' bytes. See the trackers of the different pools for the
+  // effect.
+  virtual void spill(int64_t /* minMemoryToReclaim */) {}
+
   // Registers 'translator' for mapping user defined PlanNode subclass instances
   // to user-defined Operators.
   static void registerOperator(std::unique_ptr<PlanNodeTranslator> translator);

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -144,7 +144,7 @@ void OrderBy::ensureInputFits(const RowVectorPtr& input) {
       (folly::hasher<uint64_t>()(++spillTestCounter_)) % 100 <=
           spillConfig.testSpillPct) {
     const int64_t rowsToSpill = std::max<int64_t>(1, numRows / 10);
-    spill(
+    spillRows(
         numRows - rowsToSpill,
         outOfLineBytes - (rowsToSpill * outOfLineBytesPerRow));
     return;
@@ -182,13 +182,13 @@ void OrderBy::ensureInputFits(const RowVectorPtr& input) {
   }
   const int64_t rowsToSpill = std::max<int64_t>(
       1, targetIncrementBytes / (data_->fixedRowSize() + outOfLineBytesPerRow));
-  spill(
+  spillRows(
       std::max<int64_t>(0, numRows - rowsToSpill),
       std::max<int64_t>(
           0, outOfLineBytes - (rowsToSpill * outOfLineBytesPerRow)));
 }
 
-void OrderBy::spill(int64_t targetRows, int64_t targetBytes) {
+void OrderBy::spillRows(int64_t targetRows, int64_t targetBytes) {
   VELOX_CHECK_GE(targetRows, 0);
   VELOX_CHECK_GE(targetBytes, 0);
 

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -76,7 +76,7 @@ class OrderBy : public Operator {
   // frees the data in the 'data_'. This is called by ensureInputFits or by
   // external memory management. In the latter case, the Driver of this will be
   // in a paused state and off thread.
-  void spill(int64_t targetRows, int64_t targetBytes);
+  void spillRows(int64_t targetRows, int64_t targetBytes);
 
   memory::MappedMemory* FOLLY_NONNULL const mappedMemory_;
 


### PR DESCRIPTION
Addd memory arbitration strategy

Adds a process-wide MemoryManagerStrategy instance and an abstract
base class MemoryConsumer. The strategy keeps a list of consumers.
the consumers each have a top level MemoryUsageTracker that gives
their current usage and limit. The consumers have a method for that
returns an estimate of the memory they can free when requested. The
reclaim() method attempts to free a requested amount of memory. The
actually freed memory is reflected in the tracker.


Adds a TaskMemoryStrategy that arbitrates memory asks between
Tasks. The strategy is invoked via the growCallback of the Task top
level MemoryUsageTracker. The top tracker sees the caps of the Task
level trackers as allocations. It is not a direct parent of these
since its allocated bytes reflects the sum of the caps as opposed to
the sum of the allocations.


TaskMemoryStrategy::reclaim first checks if
the process-wide top tracker has capacity and if so, increases the
limit of the requester by the requested amount. If not enough capacity
is available, this does a dirty read of all running Task's reclaimable
memory and sortrs the potential memory donors largest first. This then
pauses the candidates one after the other and forces enough of them to
release memory to meet the demand. The paused tasks are then resumed.

The requested part of the memory ask is used to increase the limit of
the requester and anything left over is added as available in the top
tracker.  Adds a test with a custom operator that keeps growing a
reservation and can be made to decrese the reservation by contending
users.

In the case of a single Task, when any Driver causes the Task total to
go above Task the cap, the strategy is invoked and since there is only one
Task, the Task is stopped and its operators are made to shrink.

Note that in the test the stop and shrink takes place at the initial
reservation of the MemoryComsumer operator. This is a legitimate place
for calling spill on the requesting operator itself. Once the reservation is obtained, we expect the operator to complete processing its batch before checking for pausing. Whenever an operator goes off-thread as a response to a pause request, it must be in a state where spill() can be safely called on it.

However, if it were to exceed its reservation, then it would invoke
the memory arbitration. This in turn could call spill on the calling
operator, which typically would have bad consequences. For example, a
group by would get spilled in the middle of an update, which could
corrupt its state.  Therefore a spill-protect section must be added as
a follow-up.




