### PR TITLE
Remove redundant methods from ExprTest

### DIFF
--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -575,52 +575,6 @@ class ExprTest : public testing::Test, public VectorTestBase {
         std::make_shared<ConstantVector<T>>(execCtx_->pool(), 1, index, base));
   }
 
-  VectorPtr makeConstantVector(variant value, vector_size_t size) {
-    return BaseVector::createConstant(value, size, execCtx_->pool());
-  }
-
-  template <typename T>
-  FlatVectorPtr<T> makeFlatVector(const std::vector<T>& data) {
-    return vectorMaker_->flatVector<T>(data);
-  }
-
-  template <typename T>
-  FlatVectorPtr<T> makeFlatVector(
-      vector_size_t size,
-      std::function<T(vector_size_t /*row*/)> valueAt,
-      std::function<bool(vector_size_t /*row*/)> isNullAt = nullptr) {
-    return vectorMaker_->flatVector<T>(size, valueAt, isNullAt);
-  }
-
-  FlatVectorPtr<StringView> makeFlatVector(
-      const std::vector<std::string>& data) {
-    return vectorMaker_->flatVector(data);
-  }
-
-  template <typename T>
-  FlatVectorPtr<T> makeAllNullFlatVector(vector_size_t size) {
-    return vectorMaker_->allNullFlatVector<T>(size);
-  }
-
-  template <typename T>
-  ArrayVectorPtr makeArrayVector(
-      vector_size_t size,
-      std::function<vector_size_t(vector_size_t /* row */)> sizeAt,
-      std::function<T(vector_size_t /* idx */)> valueAt,
-      std::function<bool(vector_size_t /*row */)> isNullAt = nullptr) {
-    return vectorMaker_->arrayVector(size, sizeAt, valueAt, isNullAt);
-  }
-
-  template <typename T>
-  ArrayVectorPtr makeArrayVector(
-      vector_size_t size,
-      std::function<vector_size_t(vector_size_t /* row */)> sizeAt,
-      std::function<T(vector_size_t /* idx */, vector_size_t /*index */)>
-          valueAt,
-      std::function<bool(vector_size_t /*row */)> isNullAt = nullptr) {
-    return vectorMaker_->arrayVector(size, sizeAt, valueAt, isNullAt);
-  }
-
   // Create LazyVector that produces a flat vector and asserts that is is being
   // loaded for a specific set of rows.
   template <typename T>
@@ -640,7 +594,7 @@ class ExprTest : public testing::Test, public VectorTestBase {
           for (auto i = 0; i < rows.size(); i++) {
             VELOX_CHECK_EQ(rows[i], expectedRowAt(i));
           }
-          return vectorMaker_->flatVector<T>(size, valueAt, isNullAt);
+          return vectorMaker_.flatVector<T>(size, valueAt, isNullAt);
         }));
   }
 
@@ -650,46 +604,10 @@ class ExprTest : public testing::Test, public VectorTestBase {
         vector->type(),
         vector->size(),
         std::make_unique<SimpleVectorLoader>([=](RowSet /*rows*/) {
-          auto indices = makeIndices(
-              vector->size(), [](vector_size_t row) { return row; });
-          return BaseVector::wrapInDictionary(
-              nullptr, indices, vector->size(), vector);
+          auto indices =
+              makeIndices(vector->size(), [](auto row) { return row; });
+          return wrapInDictionary(indices, vector->size(), vector);
         }));
-  }
-
-  static std::function<bool(vector_size_t /*row*/)> nullEvery(
-      int n,
-      int startingFrom = 0) {
-    return test::VectorMaker::nullEvery(n, startingFrom);
-  }
-
-  static VectorPtr
-  wrapInDictionary(BufferPtr indices, vector_size_t size, VectorPtr vector) {
-    return BaseVector::wrapInDictionary(
-        BufferPtr(nullptr), std::move(indices), size, std::move(vector));
-  }
-
-  BufferPtr makeIndices(
-      vector_size_t size,
-      const std::function<vector_size_t(vector_size_t)>& indexAt) const {
-    BufferPtr indices =
-        AlignedBuffer::allocate<vector_size_t>(size, execCtx_->pool());
-    auto rawIndices = indices->asMutable<vector_size_t>();
-    for (int i = 0; i < size; i++) {
-      rawIndices[i] = indexAt(i);
-    }
-    return indices;
-  }
-
-  BufferPtr makeIndices(const std::vector<vector_size_t>& indices) const {
-    auto size = indices.size();
-    BufferPtr indicesBuffer =
-        AlignedBuffer::allocate<vector_size_t>(size, execCtx_->pool());
-    auto rawIndices = indicesBuffer->asMutable<vector_size_t>();
-    for (int i = 0; i < size; i++) {
-      rawIndices[i] = indices[i];
-    }
-    return indicesBuffer;
   }
 
   void assertError(
@@ -709,12 +627,8 @@ class ExprTest : public testing::Test, public VectorTestBase {
   }
 
   std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
-  std::unique_ptr<test::VectorMaker> vectorMaker_{
-      std::make_unique<test::VectorMaker>(pool_.get())};
   TestData testData_;
   RowTypePtr testDataType_;
   std::unique_ptr<exec::ExprSet> exprs_;
@@ -904,7 +818,7 @@ TEST_F(ExprTest, moreEncodings) {
   const vector_size_t size = 1'000;
   std::vector<std::string> fruits = {"apple", "pear", "grapes", "pineapple"};
   VectorPtr a = makeFlatVector<int64_t>(size, [](auto row) { return row; });
-  VectorPtr b = vectorMaker_->flatVector(fruits);
+  VectorPtr b = vectorMaker_.flatVector(fruits);
 
   // Wrap b in a dictionary.
   auto indices =
@@ -990,7 +904,7 @@ TEST_F(ExprTest, constantNull) {
       "plus");
 
   // Execute it and check it returns all null results.
-  auto vector = vectorMaker_->flatVectorNullable<int32_t>({1, std::nullopt, 3});
+  auto vector = vectorMaker_.flatVectorNullable<int32_t>({1, std::nullopt, 3});
   auto rowVector = makeRowVector({vector});
   SelectivityVector rows(rowVector->size());
   std::vector<VectorPtr> result(1);
@@ -999,7 +913,7 @@ TEST_F(ExprTest, constantNull) {
   exec::EvalCtx context(execCtx_.get(), &exprSet, rowVector.get());
   exprSet.eval(rows, &context, &result);
 
-  auto expected = vectorMaker_->flatVectorNullable<int32_t>(
+  auto expected = vectorMaker_.flatVectorNullable<int32_t>(
       {std::nullopt, std::nullopt, std::nullopt});
   assertEqualVectors(expected, result.front());
 }
@@ -1015,7 +929,7 @@ TEST_F(ExprTest, validateReturnType) {
       INTEGER(), std::vector<core::TypedExprPtr>{inputExpr, inputExpr}, "eq");
 
   // Execute it and check it returns all null results.
-  auto vector = vectorMaker_->flatVectorNullable<int32_t>({1, 2, 3});
+  auto vector = vectorMaker_.flatVectorNullable<int32_t>({1, 2, 3});
   auto rowVector = makeRowVector({vector});
   SelectivityVector rows(rowVector->size());
   std::vector<VectorPtr> result(1);
@@ -1081,7 +995,7 @@ TEST_F(ExprTest, constantArray) {
       std::make_unique<exec::ExprSet>(std::move(expressions), execCtx_.get());
 
   const vector_size_t size = 1'000;
-  auto input = vectorMaker_->rowVector(ROW({}), size);
+  auto input = vectorMaker_.rowVector(ROW({}), size);
   exec::EvalCtx context(execCtx_.get(), exprSet.get(), input.get());
 
   SelectivityVector rows(input->size());
@@ -1217,7 +1131,7 @@ TEST_F(ExprTest, dictionaryAndConstantOverLazy) {
   auto isNullAt = [](vector_size_t row) { return row % 5 == 0; };
 
   const auto lazyVector =
-      vectorMaker_->lazyFlatVector<int32_t>(size, valueAt, isNullAt);
+      vectorMaker_.lazyFlatVector<int32_t>(size, valueAt, isNullAt);
   auto row = makeRowVector({lazyVector});
   auto result = evaluate("plus5(c0)", row);
 
@@ -1264,7 +1178,7 @@ TEST_F(ExprTest, vectorFunctionOnConstantInput) {
 
   auto row = makeRowVector(
       {makeFlatVector<int64_t>(size, [](auto row) { return row; }),
-       makeConstantVector(3, size)});
+       makeConstant(3, size)});
 
   VectorPtr expected = makeFlatVector<int32_t>(
       size, [](auto row) { return row > 5 ? 3 + 5 : 0; });
@@ -1272,7 +1186,7 @@ TEST_F(ExprTest, vectorFunctionOnConstantInput) {
   assertEqualVectors(expected, result);
 
   result = evaluate("is_null(c1)", row);
-  expected = makeConstantVector(false, size);
+  expected = makeConstant(false, size);
   assertEqualVectors(expected, result);
 }
 
@@ -1327,7 +1241,7 @@ TEST_F(ExprTest, nonDeterministicVectorFunctionOnConstantInput) {
       std::make_unique<PlusRandomIntegerFunction>());
 
   const vector_size_t size = 1'000;
-  auto row = makeRowVector({makeConstantVector(10, size)});
+  auto row = makeRowVector({makeConstant(10, size)});
 
   auto result = evaluate("plus_random(c0)", row);
 
@@ -1345,7 +1259,7 @@ TEST_F(ExprTest, nonDeterministicConstantFolding) {
       std::make_unique<PlusRandomIntegerFunction>());
 
   const vector_size_t size = 1'000;
-  auto emptyRow = vectorMaker_->rowVector(ROW({}, {}), size);
+  auto emptyRow = vectorMaker_.rowVector(ROW({}, {}), size);
 
   auto result = evaluate("plus_random(cast(23 as integer))", emptyRow);
 
@@ -1358,16 +1272,16 @@ TEST_F(ExprTest, nonDeterministicConstantFolding) {
 TEST_F(ExprTest, shortCircuit) {
   vector_size_t size = 4;
 
-  auto a = makeConstantVector(10, size);
+  auto a = makeConstant(10, size);
   auto b = makeFlatVector<int32_t>({-1, -2, -3, -4});
 
   auto result = evaluate("c0 > 0 OR c1 > 0", makeRowVector({a, b}));
-  auto expectedResult = makeConstantVector(true, size);
+  auto expectedResult = makeConstant(true, size);
 
   assertEqualVectors(expectedResult, result);
 
   result = evaluate("c0 < 0 AND c1 < 0", makeRowVector({a, b}));
-  expectedResult = makeConstantVector(false, size);
+  expectedResult = makeConstant(false, size);
 
   assertEqualVectors(expectedResult, result);
 }
@@ -1395,7 +1309,8 @@ TEST_F(ExprTest, cseEncodings) {
 
   auto indices = makeIndices({0, 0, 0, 1, 1});
   auto b = wrapInDictionary(indices, 5, makeFlatVector<int32_t>({11, 15}));
-  auto c = wrapInDictionary(indices, 5, makeFlatVector({"apple", "banana"}));
+  auto c = wrapInDictionary(
+      indices, 5, makeFlatVector<std::string>({"apple", "banana"}));
 
   auto results = evaluateMultiple(
       {"if (c0 > 0 AND c2 = 'apple', 10, 3)",
@@ -1457,16 +1372,18 @@ TEST_F(ExprTest, csePartialEvaluation) {
       std::make_unique<AddSuffixFunction>("_xx"));
 
   auto a = makeFlatVector<int32_t>({1, 2, 3, 4, 5});
-  auto b = makeFlatVector({"a", "b", "c", "d", "e"});
+  auto b = makeFlatVector<std::string>({"a", "b", "c", "d", "e"});
 
   auto results = evaluateMultiple(
       {"if (c0 >= 3, add_suffix(c1), 'n/a')", "add_suffix(c1)"},
       makeRowVector({a, b}));
 
-  auto expected = makeFlatVector({"n/a", "n/a", "c_xx", "d_xx", "e_xx"});
+  auto expected =
+      makeFlatVector<std::string>({"n/a", "n/a", "c_xx", "d_xx", "e_xx"});
   assertEqualVectors(expected, results[0]);
 
-  expected = makeFlatVector({"a_xx", "b_xx", "c_xx", "d_xx", "e_xx"});
+  expected =
+      makeFlatVector<std::string>({"a_xx", "b_xx", "c_xx", "d_xx", "e_xx"});
   assertEqualVectors(expected, results[1]);
 }
 
@@ -1528,7 +1445,7 @@ TEST_F(ExprTest, lazyVectors) {
 
   // Make LazyVector with no nulls
   auto valueAt = [](auto row) { return row; };
-  auto vector = vectorMaker_->lazyFlatVector<int64_t>(size, valueAt);
+  auto vector = vectorMaker_.lazyFlatVector<int64_t>(size, valueAt);
   auto row = makeRowVector({vector});
 
   auto result = evaluate("c0 + coalesce(c0, 1)", row);
@@ -1539,7 +1456,7 @@ TEST_F(ExprTest, lazyVectors) {
 
   // Make LazyVector with nulls
   auto isNullAt = [](auto row) { return row % 5 == 0; };
-  vector = vectorMaker_->lazyFlatVector<int64_t>(size, valueAt, isNullAt);
+  vector = vectorMaker_.lazyFlatVector<int64_t>(size, valueAt, isNullAt);
   row = makeRowVector({vector});
 
   result = evaluate("c0 + coalesce(c0, 1)", row);
@@ -1553,7 +1470,7 @@ TEST_F(ExprTest, lazyVectors) {
 TEST_F(ExprTest, lazyLoading) {
   const vector_size_t size = 1'000;
   VectorPtr vector =
-      vectorMaker_->flatVector<int64_t>(size, [](auto row) { return row % 5; });
+      vectorMaker_.flatVector<int64_t>(size, [](auto row) { return row % 5; });
   VectorPtr lazyVector = std::make_shared<LazyVector>(
       execCtx_->pool(),
       BIGINT(),
@@ -1584,7 +1501,7 @@ TEST_F(ExprTest, lazyLoading) {
 
   result = evaluate(
       "if(c0 = 10, c1 + 5, c0 - 5)", makeRowVector({vector, lazyVector}));
-  expected = vectorMaker_->flatVector<int64_t>(
+  expected = vectorMaker_.flatVector<int64_t>(
       size,
       [](auto row) { return (row / 2) % 5 - 5; },
       [](auto row) { return (row / 2) % 7 == 0; });
@@ -1997,7 +1914,7 @@ TEST_F(ExprTest, ifWithConstant) {
   vector_size_t size = 4;
 
   auto a = makeFlatVector<int32_t>({-1, -2, -3, -4});
-  auto b = makeConstantVector(variant(TypeKind::INTEGER), size); // 4 nulls
+  auto b = makeConstant(variant(TypeKind::INTEGER), size); // 4 nulls
   auto result = evaluate("is_null(if(c0 > 0, c0, c1))", makeRowVector({a, b}));
   EXPECT_EQ(VectorEncoding::Simple::CONSTANT, result->encoding());
   EXPECT_EQ(true, result->as<ConstantVector<bool>>()->valueAt(0));
@@ -2500,7 +2417,7 @@ TEST_F(ExprTest, accessNestedConstantEncoding) {
 
   auto result = evaluate(exprSet.get(), level3);
 
-  assertEqualVectors(makeConstantVector(3, 5), result);
+  assertEqualVectors(makeConstant(3, 5), result);
 }
 
 TEST_F(ExprTest, testEmptyVectors) {
@@ -2592,7 +2509,7 @@ TEST_F(ExprTest, exceptionContext) {
 
 /// Verify the output of ConstantExpr::toString().
 TEST_F(ExprTest, constantToString) {
-  auto arrayVector = vectorMaker_->arrayVectorNullable<float>(
+  auto arrayVector = vectorMaker_.arrayVectorNullable<float>(
       {{{1.2, 3.4, std::nullopt, 5.6}}});
 
   exec::ExprSet exprSet(
@@ -2700,7 +2617,7 @@ TEST_F(ExprTest, tryWithConstantFailure) {
   // EvalCtx this results in reading uninitialized memory triggering ASAN
   // errors.
   registerFunction<AlwaysThrowsFunction, Varchar, Varchar>({"always_throws"});
-  auto c0 = makeConstantVector("test", 5);
+  auto c0 = makeConstant("test", 5);
   auto c1 = makeFlatVector<int64_t>(5, [](vector_size_t row) { return row; });
   auto rowVector = makeRowVector({c0, c1});
 
@@ -2717,14 +2634,14 @@ TEST_F(ExprTest, tryWithConstantFailure) {
 TEST_F(ExprTest, castExceptionContext) {
   assertError(
       "cast(c0 as bigint)",
-      makeFlatVector({"1a"}),
+      makeFlatVector<std::string>({"1a"}),
       "cast((c0) as BIGINT)",
       "Same as context.",
       "Failed to cast from VARCHAR to BIGINT: 1a. Non-whitespace character found after end of conversion: \"a\"");
 
   assertError(
       "cast(c0 as timestamp)",
-      makeFlatVector<int8_t>({1}),
+      makeFlatVector(std::vector<int8_t>{1}),
       "cast((c0) as TIMESTAMP)",
       "Same as context.",
       "Failed to cast from TINYINT to TIMESTAMP: 1. ");
@@ -2733,7 +2650,7 @@ TEST_F(ExprTest, castExceptionContext) {
 TEST_F(ExprTest, switchExceptionContext) {
   assertError(
       "case c0 when 7 then c0 / 0 else 0 end",
-      makeFlatVector<int64_t>({7}),
+      makeFlatVector(std::vector<int64_t>{7}),
       "divide(c0, 0:BIGINT)",
       "switch(eq(c0, 7:BIGINT), divide(c0, 0:BIGINT), 0:BIGINT)",
       "division by zero");
@@ -2811,7 +2728,7 @@ TEST_F(ExprTest, invalidInputs) {
 TEST_F(ExprTest, lambdaWithRowField) {
   auto array = makeArrayVector<int64_t>(
       10, [](auto /*row*/) { return 5; }, [](auto row) { return row * 3; });
-  auto row = vectorMaker_->rowVector(
+  auto row = vectorMaker_.rowVector(
       {"val"},
       {makeFlatVector<int64_t>(10, [](vector_size_t row) { return row; })});
   core::Expressions::registerLambda(
@@ -2821,7 +2738,7 @@ TEST_F(ExprTest, lambdaWithRowField) {
       parse::parseExpr("x + c0.val >= 0"),
       execCtx_->pool());
 
-  auto rowVector = vectorMaker_->rowVector({"c0", "c1"}, {row, array});
+  auto rowVector = vectorMaker_.rowVector({"c0", "c1"}, {row, array});
 
   // We use strpos and c1 to ensure that the constant is peeled before calling
   // always_throws, not before the try.

--- a/velox/vector/tests/VectorTestBase.cpp
+++ b/velox/vector/tests/VectorTestBase.cpp
@@ -44,10 +44,9 @@ BufferPtr VectorTestBase::makeEvenIndices(vector_size_t size) {
   return makeIndices(size, [](vector_size_t i) { return 2 * i; });
 }
 
-// static
 BufferPtr VectorTestBase::makeIndices(
     vector_size_t size,
-    std::function<vector_size_t(vector_size_t)> indexAt) {
+    std::function<vector_size_t(vector_size_t)> indexAt) const {
   BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, pool());
   auto rawIndices = indices->asMutable<vector_size_t>();
 
@@ -56,6 +55,19 @@ BufferPtr VectorTestBase::makeIndices(
   }
 
   return indices;
+}
+
+BufferPtr VectorTestBase::makeIndices(
+    const std::vector<vector_size_t>& indices) const {
+  auto size = indices.size();
+  BufferPtr indicesBuffer =
+      AlignedBuffer::allocate<vector_size_t>(size, pool());
+  auto rawIndices = indicesBuffer->asMutable<vector_size_t>();
+
+  for (int i = 0; i < size; i++) {
+    rawIndices[i] = indices[i];
+  }
+  return indicesBuffer;
 }
 
 BufferPtr VectorTestBase::makeNulls(

--- a/velox/vector/tests/VectorTestBase.h
+++ b/velox/vector/tests/VectorTestBase.h
@@ -166,6 +166,11 @@ class VectorTestBase {
     return vectorMaker_.flatVector<T>(size, type);
   }
 
+  template <typename T>
+  FlatVectorPtr<T> makeAllNullFlatVector(vector_size_t size) {
+    return vectorMaker_.allNullFlatVector<T>(size);
+  }
+
   FlatVectorPtr<ShortDecimal> makeShortDecimalFlatVector(
       const std::vector<int64_t>& unscaledValues,
       const TypePtr& type) {
@@ -587,7 +592,9 @@ class VectorTestBase {
 
   BufferPtr makeIndices(
       vector_size_t size,
-      std::function<vector_size_t(vector_size_t)> indexAt);
+      std::function<vector_size_t(vector_size_t)> indexAt) const;
+
+  BufferPtr makeIndices(const std::vector<vector_size_t>& indices) const;
 
   BufferPtr makeOddIndices(vector_size_t size);
 


### PR DESCRIPTION
Remove methods that are available in the base class VectorTestBase.