### PR TITLE
Move flat map struct encoding info out from config

### DIFF
--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -141,6 +141,36 @@ Config::Entry<const std::vector<uint32_t>> Config::MAP_FLAT_COLS(
       return result;
     });
 
+Config::Entry<const std::vector<std::vector<std::string>>>
+    Config::MAP_FLAT_COLS_STRUCT_KEYS(
+        "orc.map.flat.cols.struct.keys",
+        {},
+        [](const std::vector<std::vector<std::string>>& val) {
+          std::vector<std::string> columns;
+          columns.reserve(val.size());
+          std::transform(
+              val.cbegin(),
+              val.cend(),
+              std::back_inserter(columns),
+              [](const auto& v) { return folly::join(",", v); });
+          return folly::join(";", columns);
+        },
+        [](const std::string& val) {
+          std::vector<std::string> partialResult;
+          folly::split(";", val, partialResult);
+          std::vector<std::vector<std::string>> result;
+          std::transform(
+              partialResult.cbegin(),
+              partialResult.cend(),
+              std::back_inserter(result),
+              [](const auto& str) {
+                std::vector<std::string> res;
+                folly::split(",", str, res);
+                return res;
+              });
+          return result;
+        });
+
 Config::Entry<uint32_t> Config::MAP_FLAT_MAX_KEYS(
     "orc.map.flat.max.keys",
     20000);

--- a/velox/dwio/dwrf/common/Config.h
+++ b/velox/dwio/dwrf/common/Config.h
@@ -106,6 +106,8 @@ class Config {
   static Entry<bool> MAP_FLAT_DISABLE_DICT_ENCODING_STRING;
   static Entry<bool> MAP_FLAT_DICT_SHARE;
   static Entry<const std::vector<uint32_t>> MAP_FLAT_COLS;
+  static Entry<const std::vector<std::vector<std::string>>>
+      MAP_FLAT_COLS_STRUCT_KEYS;
   static Entry<uint32_t> MAP_FLAT_MAX_KEYS;
   static Entry<uint64_t> MAX_DICTIONARY_SIZE;
   static Entry<uint64_t> STRIPE_SIZE;


### PR DESCRIPTION
Summary: I realized that we shouldn't be passing this argument in the config, because the config is meant for values that are stored in the table metadata, while this value is runtime.

Differential Revision: D38183826

