### PR TITLE
Fix issues in disk spilling control logic

### DIFF
--- a/velox/common/testutil/TestValue.cpp
+++ b/velox/common/testutil/TestValue.cpp
@@ -43,7 +43,9 @@ void TestValue::clear(const std::string& injectionPoint) {
   injectionMap_.erase(injectionPoint);
 }
 
-void TestValue::adjust(const std::string& injectionPoint, void* testData) {
+void TestValue::notify(
+    const std::string& injectionPoint,
+    const void* testData) {
   Callback injectionCb;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -61,7 +63,9 @@ bool TestValue::enabled() {
   return false;
 }
 void TestValue::clear(const std::string& injectionPoint) {}
-void TestValue::adjust(const std::string& injectionPoint, void* testData) {}
+void TestValue::notify(
+    const std::string& injectionPoint,
+    const void* testData) {}
 #endif
 
 } // namespace facebook::velox::common::testutil

--- a/velox/common/testutil/TestValue.h
+++ b/velox/common/testutil/TestValue.h
@@ -45,7 +45,7 @@ class TestValue {
   template <typename T>
   static void set(
       const std::string& injectionPoint,
-      std::function<void(T*)> injectionCb);
+      std::function<void(const T*)> injectionCb);
 
   /// Invoked by the test code to unregister a callback hook at the specified
   /// execution point.
@@ -53,11 +53,11 @@ class TestValue {
 
   /// Invoked by the production code to try to invoke the test callback hook
   /// with 'testData' if there is one registered at the specified execution
-  /// point. 'testData' can capture the production execution state.
-  static void adjust(const std::string& injectionPoint, void* testData);
+  /// point. 'testData' capture the production execution state in readonly mode.
+  static void notify(const std::string& injectionPoint, const void* testData);
 
  private:
-  using Callback = std::function<void(void*)>;
+  using Callback = std::function<void(const void*)>;
 
   static std::mutex mutex_;
   static bool enabled_;
@@ -67,7 +67,9 @@ class TestValue {
 class ScopedTestValue {
  public:
   template <typename T>
-  ScopedTestValue(const std::string& point, std::function<void(T*)> callback)
+  ScopedTestValue(
+      const std::string& point,
+      std::function<void(const T*)> callback)
       : point_(point) {
     VELOX_CHECK_NOT_NULL(callback);
     VELOX_CHECK(!point_.empty());
@@ -85,13 +87,13 @@ class ScopedTestValue {
 template <typename T>
 void TestValue::set(
     const std::string& injectionPoint,
-    std::function<void(T*)> injectionCb) {
+    std::function<void(const T*)> injectionCb) {
   std::lock_guard<std::mutex> l(mutex_);
   if (!enabled_) {
     return;
   }
-  injectionMap_[injectionPoint] = [injectionCb](void* testData) {
-    T* typedData = static_cast<T*>(testData);
+  injectionMap_[injectionPoint] = [injectionCb](const void* testData) {
+    const T* typedData = static_cast<const T*>(testData);
     injectionCb(typedData);
   };
 }
@@ -99,7 +101,7 @@ void TestValue::set(
 template <typename T>
 void TestValue::set(
     const std::string& injectionPoint,
-    std::function<void(T*)> injectionCb) {}
+    std::function<void(const T*)> injectionCb) {}
 #endif
 
 #define VELOX_CONCAT(x, y) __##x##y

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -66,7 +66,8 @@ target_link_libraries(
   velox_connector
   velox_time
   velox_codegen
-  velox_common_base)
+  velox_common_base
+  velox_test_util)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -174,6 +174,10 @@ std::unique_ptr<TreeOfLosers<SpillStream>> SpillState::startMerge(
   if (extra) {
     result.push_back(std::move(extra));
   }
+  // Check if the partition is empty or not.
+  if (FOLLY_UNLIKELY(result.empty())) {
+    return nullptr;
+  }
   return std::make_unique<TreeOfLosers<SpillStream>>(std::move(result));
 }
 

--- a/velox/exec/TreeOfLosers.h
+++ b/velox/exec/TreeOfLosers.h
@@ -207,6 +207,7 @@ class TreeOfLosers {
 
   IndexAndFlag firstWithEquals(TIndex node) {
     if (node >= firstStream_) {
+      VELOX_DCHECK_LT(node - firstStream_, streams_.size());
       return indexAndFlag(
           streams_[node - firstStream_]->hasData() ? node - firstStream_
                                                    : kEmpty,
@@ -230,7 +231,7 @@ class TreeOfLosers {
         return left;
       } else {
         values_[node] = left.first;
-        equals_[node] = right.second;
+        equals_[node] = left.second;
         return right;
       }
     }
@@ -289,6 +290,7 @@ class TreeOfLosers {
   static TIndex rightChild(TIndex node) {
     return node * 2 + 2;
   }
+
   std::vector<TIndex> values_;
   // 'true' if the corresponding element of 'values_' has met an equal
   // element on its way to its present position. Used only in nextWithEquals().

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(
   velox_functions_lib
   velox_functions_prestosql
   velox_hive_connector
+  velox_test_util
   velox_type
   velox_serialization
   velox_exec_test_util


### PR DESCRIPTION
Fix a coupe of issues related to disk spilling:
(1) the current disk spilling control logic (Spiller::spill) will bump up spillRuns_
size to maxPartitions on the first run which is unexpected. Instead, we  shall
incrementally bump up its size to numPartitions tracked by SpillState. The 
latter is then bumped up whenever we reaches the end of row container when
fill rows to spill;
(2) if Spiller::fillSpillRuns has done full sweep but hasn't find any partition with
sufficient large number of rows to spill, then it will start enough partitions to start.
Currently it always return false which might cause disk spilling hanging as there
is a case that all the rows from the spilling partitions have been spilled so even
though we try kick off spill on any spilling partitions but there is no row to spill.
The Spiller::spill will be stuck a loop. Fix the logic to return true if there are no rows
to spill in that case. Then we can bump up the spilling partition accordingly. Both
issues can be reproduced using existing SpillerTest and verified;
(3) using rowsWhileReadingSpill_ to calculate the row size as the hash table has
been reset at that time;
(4) handle the empty or unspilled partition properly on the spill finish code path;
(5) fix the min/max heap update issue in TreeOfLosers.h


