### PR TITLE
Removed config variable MAP_FLAT_STRUCT_COLS

### DIFF
--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -141,12 +141,6 @@ Config::Entry<const std::vector<uint32_t>> Config::MAP_FLAT_COLS(
       return result;
     });
 
-Config::Entry<folly::dynamic> Config::MAP_FLAT_STRUCT_COLS(
-    "orc.map.flat.struct.cols",
-    folly::dynamic::object,
-    [](const folly::dynamic& val) { return folly::toJson(val); },
-    [](const std::string& val) { return folly::parseJson(val); });
-
 Config::Entry<uint32_t> Config::MAP_FLAT_MAX_KEYS(
     "orc.map.flat.max.keys",
     20000);

--- a/velox/dwio/dwrf/common/Config.h
+++ b/velox/dwio/dwrf/common/Config.h
@@ -106,7 +106,6 @@ class Config {
   static Entry<bool> MAP_FLAT_DISABLE_DICT_ENCODING_STRING;
   static Entry<bool> MAP_FLAT_DICT_SHARE;
   static Entry<const std::vector<uint32_t>> MAP_FLAT_COLS;
-  static Entry<folly::dynamic> MAP_FLAT_STRUCT_COLS;
   static Entry<uint32_t> MAP_FLAT_MAX_KEYS;
   static Entry<uint64_t> MAX_DICTIONARY_SIZE;
   static Entry<uint64_t> STRIPE_SIZE;

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -20,7 +20,6 @@
 #include <algorithm>
 #include <optional>
 #include <vector>
-#include "folly/DynamicConverter.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/IntDecoder.h"
 #include "velox/dwio/common/MemoryInputStream.h"
@@ -792,7 +791,6 @@ void mapToStruct(
            index < endOffset;
            index++) {
         ASSERT_FALSE(flatKeys->isNullAt(index));
-        // ASSERT_TRUE(!flatValues->isNullAt(offsets[i] + sizes[j]));
         // set value in correct row
         auto key = flatKeys->valueAt(index);
         auto element = std::dynamic_pointer_cast<FlatVector<TVALUE>>(
@@ -832,22 +830,9 @@ void testMapWriter(
       auto structs = batches;
       std::vector<TKEY> uniqueKeys;
       ASSERT_NO_FATAL_FAILURE(getUniqueKeys<TKEY>(uniqueKeys, batches));
-      // for (int i = 0; i < uniqueKeys.size(); i++) {
-      //   LOG(INFO) << "key " << i << ": " << uniqueKeys[i];
-      // }
-
       ASSERT_NO_FATAL_FAILURE(
           (mapToStruct<TKEY, TVALUE>(pool, structs, uniqueKeys)));
       // printStructs(structs);
-
-      // TODO: add config variable, create config map, serialize map, set config
-      // std::map<uint32_t, std::vector<TKEY>> structConfig;
-      // structConfig[0] = uniqueKeys;
-      folly::dynamic structConfig =
-          folly::toDynamic<std::map<std::string, std::vector<TKEY>>>(
-              {{"0", uniqueKeys}});
-
-      config->set(Config::MAP_FLAT_STRUCT_COLS, structConfig);
     }
 
     config->set(Config::FLATTEN_MAP, true);


### PR DESCRIPTION
Summary: We are no longer passing keys through the config. They will be stringified as column names and passed directly in the type_ member of the BaseVector class. Config and usage in tests was removed.

Differential Revision: D38212778

