### PR TITLE
Fix expression evaluation over lazy vectors

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -214,7 +214,9 @@ const VectorPtr& EvalCtx::getField(int32_t index) const {
   return *field;
 }
 
-void EvalCtx::ensureFieldLoaded(int32_t index, const SelectivityVector& rows) {
+VectorPtr EvalCtx::ensureFieldLoaded(
+    int32_t index,
+    const SelectivityVector& rows) {
   auto field = getField(index);
   if (isLazyNotLoaded(*field)) {
     const auto& rowsToLoad = isFinalSelection_ ? rows : *finalSelection_;
@@ -237,6 +239,8 @@ void EvalCtx::ensureFieldLoaded(int32_t index, const SelectivityVector& rows) {
     // they contain a loaded lazyVector.
     field->loadedVector();
   }
+
+  return field;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -58,7 +58,7 @@ class EvalCtx {
   // peeled off fields.
   const VectorPtr& getField(int32_t index) const;
 
-  void ensureFieldLoaded(int32_t index, const SelectivityVector& rows);
+  VectorPtr ensureFieldLoaded(int32_t index, const SelectivityVector& rows);
 
   void setPeeled(int32_t index, const VectorPtr& vector) {
     if (peeledFields_.size() <= index) {

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -547,11 +547,6 @@ TEST_P(ExprEncodingsTest, basic) {
 TEST_P(ExprEncodingsTest, conditional) {
   prepareTestData();
 
-  // TODO This test fails when using lazy vectors. Fix and re-enable.
-  if (std::get<2>(GetParam())) {
-    GTEST_SKIP();
-  }
-
   run<int64_t>(
       "if(bigint1 % 2 = 0, 2 * bigint1 + 10, 3 * bigint2) + 11",
       [&](int32_t row) {
@@ -564,11 +559,6 @@ TEST_P(ExprEncodingsTest, conditional) {
 
 TEST_P(ExprEncodingsTest, moreConditional) {
   prepareTestData();
-
-  // TODO This test fails when using lazy vectors. Fix and re-enable.
-  if (std::get<2>(GetParam())) {
-    GTEST_SKIP();
-  }
 
   run<int64_t>(
       "if(bigint1 % 2 = 0 and bigint2 < 1000 and bigint1 + bigint2 > 0,"
@@ -596,11 +586,6 @@ TEST_P(ExprEncodingsTest, errors) {
 TEST_P(ExprEncodingsTest, maskedErrors) {
   prepareTestData();
 
-  // TODO This test fails when using lazy vectors. Fix and re-enable.
-  if (std::get<2>(GetParam())) {
-    GTEST_SKIP();
-  }
-
   // Produce an error if bigint1 is a multiple of 3 or bigint2 is a multiple
   // of 13. Then mask this error by a false. Return 1 for true and 0 for
   // false.
@@ -617,11 +602,6 @@ TEST_P(ExprEncodingsTest, maskedErrors) {
 
 TEST_P(ExprEncodingsTest, commonSubExpressions) {
   prepareTestData();
-
-  // TODO This test fails when using lazy vectors. Fix and re-enable.
-  if (std::get<2>(GetParam())) {
-    GTEST_SKIP();
-  }
 
   // Test common subexpressions at top level and inside conditionals.
   run<int64_t>(

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -231,7 +231,7 @@ class LazyVector : public BaseVector {
   }
 
   bool isScalar() const override {
-    return loadedVector()->isScalar();
+    return type()->isPrimitiveType() || type()->isOpaque();
   }
 
   bool mayHaveNulls() const override {


### PR DESCRIPTION
Fix a few bugs and enable all tests in ExprEncodingsTest.

- Disable peeling off nulls for inputs that a not-loaded yet lazy vectors.
- Enable LazyVector::isScalar() without loading lazy vector.
- Make sure to update the vector pointer after calling
  EvalCtx::ensureFieldLoaded. 

Without these change, expression evaluation over lazy vectors wrapped in
dictionaries and sequences would fail. 

First, Expr::evalWithNulls or Expr::removeSureNulls would try calling
DictionaryVector::mayHaveNulls on a Dict(Lazy) and hit `VELOX_DCHECK
(initialized_);`.

Second, evaluating over dictionary that adds nulls for all positions reaches a
path in Expr::peelEncodings where leaf->isConstant(rows) is true. In this case,
the Dict(Lazy) gets loaded via context.ensureFieldLoaded(fieldIndex, rows), but
the resulting vector is a different dictionary. Hence, the original 'leaf' is
still uninitialized and triggers the same check as above further down in
BaseVector::wrapInConstant.

Finally, wrapping lazy vector in a dictionary and a sequence (e.g. creating 
Seq(Dict(Lazy))) triggers SequenceVector::isScalar(), which calls
DictionaryVector::isScalar(), which calls LazyVector::isScalar(), which loads
the vector from underneath the dictionary and leaves the dictionary in an
inconsistent state. 