### PR TITLE
Fix linker's warnings about visibility.

### DIFF
--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -59,6 +59,7 @@ function get_cxx_flags {
   OS=$(uname)
   local MACHINE
   MACHINE=$(uname -m)
+  ADDITIONAL_FLAGS=""
 
   if [ -z "$CPU_ARCH" ]; then
 
@@ -78,6 +79,9 @@ function get_cxx_flags {
         # Apple silicon.
         CPU_ARCH="arm64"
       fi
+
+    # On MacOs prevent the flood of translation visibility settings warnings.
+    ADDITIONAL_FLAGS="-fvisibility=hidden -fvisibility-inlines-hidden"
     else [ "$OS" = "Linux" ];
 
       local CPU_CAPABILITIES
@@ -96,19 +100,19 @@ function get_cxx_flags {
   case $CPU_ARCH in
 
     "arm64")
-      echo -n "-mcpu=apple-m1+crc -std=c++17"
+      echo -n "-mcpu=apple-m1+crc -std=c++17 -fvisibility=hidden $ADDITIONAL_FLAGS"
     ;;
 
     "avx")
-      echo -n "-mavx2 -mfma -mavx -mf16c -mlzcnt -mbmi2 -std=c++17"
+      echo -n "-mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17 -mbmi2 $ADDITIONAL_FLAGS"
     ;;
 
     "sse")
-      echo -n "-msse4.2 -std=c++17"
+      echo -n "-msse4.2 -std=c++17 $ADDITIONAL_FLAGS"
     ;;
 
     "aarch64")
-      echo -n "-mcpu=neoverse-n1 -std=c++17"
+      echo -n "-mcpu=neoverse-n1 -std=c++17 $ADDITIONAL_FLAGS"
     ;;
   *)
     echo -n "Architecture not supported!"


### PR DESCRIPTION
Stop the flood of compiler warnings on Mac:

`ld: warning: direct access in function 'fmt::v7::appender fmt::v7::detail::write<char, fmt::v7::appender, unsigned long long, 0>(fmt::v7::appender, unsigned long long, fmt::v7::basic_format_specs<char> const&, fmt::v7::detail::locale_ref)' from file '/usr/local/lib/libfmt.a(format.cc.o)' to global weak symbol 'fmt::v7::detail::basic_data<void>::left_padding_shifts' from file '/usr/local/lib/libfolly.a(Singleton.cpp.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.`

Related to #1688. 
I re-built and re-installed all dependencies with these flags and no longer see the warnings. 