### PR TITLE
Speed up copy in MapVector & ArrayVector

### DIFF
--- a/velox/vector/benchmarks/CMakeLists.txt
+++ b/velox/vector/benchmarks/CMakeLists.txt
@@ -21,3 +21,8 @@ add_executable(velox_vector_selectivity_vector_benchmark
 
 target_link_libraries(velox_vector_selectivity_vector_benchmark velox_vector
                       ${FOLLY_WITH_DEPENDENCIES} ${FOLLY_BENCHMARK})
+
+add_executable(copy_benchmark CopyBenchmark.cpp)
+
+target_link_libraries(copy_benchmark velox_vector_test_lib
+                      ${FOLLY_WITH_DEPENDENCIES} ${FOLLY_BENCHMARK})

--- a/velox/vector/benchmarks/CopyBenchmark.cpp
+++ b/velox/vector/benchmarks/CopyBenchmark.cpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/vector/tests/VectorMaker.h"
+
+namespace facebook::velox {
+namespace {
+BufferPtr makeIndices(
+    vector_size_t size,
+    memory::MemoryPool* pool,
+    std::function<vector_size_t(vector_size_t)> indexAt) {
+  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, pool);
+  auto rawIndices = indices->asMutable<vector_size_t>();
+
+  for (vector_size_t i = 0; i < size; i++) {
+    rawIndices[i] = indexAt(i);
+  }
+
+  return indices;
+}
+
+size_t runBenchmark(
+    const VectorPtr& data,
+    const SelectivityVector& selected,
+    const TypePtr& type,
+    memory::MemoryPool* pool,
+    vector_size_t copyBatchSize) {
+  VectorPtr result;
+  folly::BenchmarkSuspender suspender;
+  BaseVector::ensureWritable(selected, type, pool, &result);
+  suspender.dismiss();
+
+  size_t numIters = 100;
+  vector_size_t size = data->size();
+  for (auto i = 0; i < numIters; i++) {
+    BaseVector::prepareForReuse(result, size);
+    for (int j = 0; j < data->size(); j += copyBatchSize) {
+      result->copy(data.get(), j, j, copyBatchSize);
+    }
+  }
+
+  return size * numIters;
+}
+
+size_t runBenchmark(
+    const VectorPtr& data,
+    const SelectivityVector& selected,
+    const TypePtr& type,
+    memory::MemoryPool* pool) {
+  return runBenchmark(data, selected, type, pool, data->size());
+}
+
+BENCHMARK_MULTI(copyArray) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 1'000;
+  auto arrayVector = vectorMaker.arrayVector<int32_t>(
+      size,
+      [](auto row) { return row % 10; },
+      [](auto row) { return row % 23; });
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(arrayVector, selected, ARRAY(INTEGER()), pool.get());
+}
+
+BENCHMARK_MULTI(copyArrayWithNulls) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 1'000;
+  auto arrayVector = vectorMaker.arrayVector<int32_t>(
+      size,
+      [](auto row) { return row % 10; },
+      [](auto row) { return row % 23; },
+      [](auto row) { return row % 13 == 0; });
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(arrayVector, selected, ARRAY(INTEGER()), pool.get());
+}
+
+BENCHMARK_MULTI(copyArrayDictionaryEncoded) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 1'000;
+  const vector_size_t numElements = size / 10 * 45; // 0 + 1 + 2 + ... + 9 = 45
+  auto elements = vectorMaker.flatVector<int32_t>(
+      numElements, [](auto row) { return row % 23; });
+  auto indices = makeIndices(numElements, pool.get(), [numElements](auto row) {
+    return (row * 13) % numElements; // 13 and numElements are coprime so this
+                                     // should shuffle them.
+  });
+  auto elementsDictionaryEncoded = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, numElements, elements);
+  std::vector<vector_size_t> offsets;
+  vector_size_t offset = 0;
+  for (int i = 0; i < size + 1; i++) {
+    offsets.push_back(offset);
+    offset += i % 10;
+  }
+  auto arrayVector =
+      vectorMaker.arrayVector(offsets, elementsDictionaryEncoded);
+
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(arrayVector, selected, ARRAY(INTEGER()), pool.get());
+}
+
+BENCHMARK_MULTI(copyArrayOneAtATime) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 1'000;
+  auto arrayVector = vectorMaker.arrayVector<int32_t>(
+      size,
+      [](auto row) { return row % 10; },
+      [](auto row) { return row % 23; });
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(arrayVector, selected, ARRAY(INTEGER()), pool.get(), 1);
+}
+
+BENCHMARK_MULTI(copyArrayTwoAtATime) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 1'000;
+  auto arrayVector = vectorMaker.arrayVector<int32_t>(
+      size,
+      [](auto row) { return row % 10; },
+      [](auto row) { return row % 23; });
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(arrayVector, selected, ARRAY(INTEGER()), pool.get(), 2);
+}
+
+BENCHMARK_MULTI(copyMap) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 1'000;
+  auto mapVector = vectorMaker.mapVector<int32_t, int32_t>(
+      size,
+      [](auto row) { return row % 10; },
+      [](auto row) { return row % 23; },
+      [](auto row) { return row % 37; });
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(
+      mapVector, selected, MAP(INTEGER(), INTEGER()), pool.get());
+}
+
+BENCHMARK_MULTI(copyMapWithNulls) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 1'000;
+  auto mapVector = vectorMaker.mapVector<int32_t, int32_t>(
+      size,
+      [](auto row) { return row % 10; },
+      [](auto row) { return row % 23; },
+      [](auto row) { return row % 37; },
+      [](auto row) { return row % 13 == 0; });
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(
+      mapVector, selected, MAP(INTEGER(), INTEGER()), pool.get());
+}
+
+BENCHMARK_MULTI(copyMapDictionaryEncoded) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 1'000;
+  const vector_size_t numElements = size / 10 * 45; // 0 + 1 + 2 + ... + 9 = 45
+  auto values = vectorMaker.flatVector<int32_t>(
+      numElements, [](auto row) { return row % 23; });
+  auto indices = makeIndices(numElements, pool.get(), [numElements](auto row) {
+    return (row * 13) % numElements; // 13 and numElements are coprime so this
+                                     // should shuffle them.
+  });
+  auto keysDictionaryEncoded = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, numElements, values);
+  auto valuesDictionaryEncoded = BaseVector::wrapInDictionary(
+      BufferPtr(nullptr), indices, numElements, values);
+  std::vector<vector_size_t> offsets;
+  vector_size_t offset = 0;
+  for (int i = 0; i < size + 1; i++) {
+    offsets.push_back(offset);
+    offset += i % 10;
+  }
+  auto mapVector = vectorMaker.mapVector(
+      offsets, keysDictionaryEncoded, valuesDictionaryEncoded);
+
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(
+      mapVector, selected, MAP(INTEGER(), INTEGER()), pool.get());
+}
+
+BENCHMARK_MULTI(copyMapOneAtATime) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 1'000;
+  auto mapVector = vectorMaker.mapVector<int32_t, int32_t>(
+      size,
+      [](auto row) { return row % 10; },
+      [](auto row) { return row % 23; },
+      [](auto row) { return row % 37; });
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(
+      mapVector, selected, MAP(INTEGER(), INTEGER()), pool.get(), 1);
+}
+
+BENCHMARK_MULTI(copyMapTwoAtATime) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 1'000;
+  auto mapVector = vectorMaker.mapVector<int32_t, int32_t>(
+      size,
+      [](auto row) { return row % 10; },
+      [](auto row) { return row % 23; },
+      [](auto row) { return row % 37; });
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(
+      mapVector, selected, MAP(INTEGER(), INTEGER()), pool.get(), 2);
+}
+} // namespace
+} // namespace facebook::velox
+
+int main(int /*argc*/, char** /*argv*/) {
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
Today, the implementations of copy in MapVector and ArrayVector operate sequentially resizing the child
Vectors one map/array at a time and copying data one map/array at a time.

These leads to unnecessary overhead and can be optimized especially in the case where the maps/arrays
being copied point to sequential elements in the child Vectors.

This diff makes 3 changes to these functions:
* We do a pass over all the maps/arrays to be copied to determine the total amount we need to grow the
child vectors by and does a single resize.
* We collect the ranges of elements in the child vectors to copy and merge adjacent ranges that appear
consecutively.
* We special case copying a single map/array (these changes added significant overhead >10% in the
case of copying a single map/array, and special casing this makes the change neutral in this case).

On a side note I also considered making a map of ranges keyed on the end offset, but this would not work
in the rare case that the maps/arrays pointed to two or more overlapping ranges that ended at the same \
offset, so I relied on just checking adjacent ranges (this seems like the more likely case anyway).

I added a benchmark to verify the changes yielded improvements.

Original results:
```
============================================================================
velox/vector/benchmarks/CopyBenchmark.cpp     relative  time/iter   iters/s
============================================================================
copyArray                                                  19.75ns    50.64M
copyArrayWithNulls                                         22.74ns    43.98M
copyArrayDictionaryEncoded                                 44.73ns    22.36M
copyArrayOneAtATime                                        60.52ns    16.52M
copyArrayTwoAtATime                                        40.43ns    24.73M
copyMap                                                    36.37ns    27.49M
copyMapWithNulls                                           38.84ns    25.75M
copyMapDictionaryEncoded                                   88.00ns    11.36M
copyMapOneAtATime                                          76.89ns    13.00M
copyMapTwoAtATime                                          57.24ns    17.47M
```

After these changes:
```
============================================================================
velox/vector/benchmarks/CopyBenchmark.cpp     relative  time/iter   iters/s
============================================================================
copyArray                                                   5.57ns   179.60M
copyArrayWithNulls                                          8.54ns   117.14M
copyArrayDictionaryEncoded                                 28.09ns    35.60M
copyArrayOneAtATime                                        57.87ns    17.28M
copyArrayTwoAtATime                                        39.23ns    25.49M
copyMap                                                     8.19ns   122.04M
copyMapWithNulls                                           10.40ns    96.15M
copyMapDictionaryEncoded                                   53.80ns    18.59M
copyMapOneAtATime                                          73.76ns    13.56M
copyMapTwoAtATime                                          46.20ns    21.65M
```

For copying maps/arrays laid out consecutively, there's a ~4x improvement.  Even for copying
maps/arrays laid out non-consecutively (dictionary encoded) there's a ~40% improvement.

For copying a single map/array or two arrays, there's no change.

For copying two maps we see a 20% improvement.

Differential Revision: D38248521

