### PR TITLE
Add column names to RowVector in stuct encoding flat map

### DIFF
--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -693,9 +693,17 @@ void FlatMapStructEncodingColumnReader<T>::next(
     result->setSize(numValues);
     result->setNullCount(nullCount);
   } else {
+    std::vector<std::string> keyNames;
+    keyNames.reserve(keyNodes_.size());
+    std::ranges::transform(
+        keyNodes_, std::back_inserter(keyNames), [](const auto& keyNode) {
+          return keyNode ? folly::to<std::string>(keyNode->getKey().get())
+                         : std::string();
+        });
+
     result = std::make_shared<RowVector>(
         &memoryPool_,
-        ROW(std::vector<std::string>(keyNodes_.size()),
+        ROW(std::move(keyNames),
             std::vector<std::shared_ptr<const Type>>(
                 keyNodes_.size(), requestedType_->type->asMap().valueType())),
         nulls,


### PR DESCRIPTION
Summary:
We want the writer to read keys from the column names, so the reader should populate the fields.

I found what I believe to be a bug and I plan to fix it in a following diff.

Differential Revision: D38218879

