### PR TITLE
Updated parse_datetime to use DateTimeFormatter framework

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -15,13 +15,56 @@
  */
 
 #include "velox/functions/lib/DateTimeFormatter.h"
+#include <folly/String.h>
+#include <velox/common/base/Exceptions.h>
+#include <velox/type/Date.h>
+#include <cstring>
+#include <stdexcept>
 #include "velox/external/date/date.h"
 #include "velox/external/date/tz.h"
 #include "velox/functions/lib/DateTimeFormatterBuilder.h"
+#include "velox/type/TimestampConversion.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions {
 
+static thread_local std::string timezoneBuffer = "+00:00";
+static const char* defaultTrailingOffset = "00";
+
 namespace {
+
+struct Date {
+  int32_t year = 1970;
+  int32_t month = 1;
+  int32_t day = 1;
+  bool isAd = true; // AD -> true, BC -> false.
+
+  int32_t week = 1;
+  int32_t dayOfWeek = 1;
+  bool weekDateFormat = false;
+
+  int32_t dayOfYear = 1;
+  bool dayOfYearFormat = false;
+
+  bool centuryFormat = false;
+
+  bool isYearOfEra = false; // Year of era cannot be zero or negative.
+  bool hasYear = false; // Whether year was explicitly specified.
+
+  int32_t hour = 0;
+  int32_t minute = 0;
+  int32_t second = 0;
+  int32_t microsecond = 0;
+  bool isAm = true; // AM -> true, PM -> false
+  int64_t timezoneId = -1;
+
+  bool isClockHour = false; // Whether most recent hour specifier is clockhour
+  bool isHourOfHalfDay =
+      false; // Whether most recent hour specifier is of half day.
+
+  std::vector<int32_t> dayOfMonthValues;
+  std::vector<int32_t> dayOfYearValues;
+};
 
 constexpr std::string_view weekdaysFull[] = {
     "Sunday",
@@ -61,6 +104,7 @@ constexpr std::string_view monthsShort[] = {
     "Nov",
     "Dec",
 };
+constexpr int monthsFullLength[] = {7, 8, 5, 5, 3, 4, 4, 6, 9, 7, 8, 8};
 
 /// Pads the content with desired padding characters. E.g. if we need to pad 999
 /// with three 0s in front, the result will be '000999'
@@ -151,6 +195,543 @@ int64_t numLiteralChars(
     }
   }
   return count;
+}
+
+inline bool characterIsDigit(char c) {
+  return c >= '0' && c <= '9';
+}
+
+bool specAllowsNegative(DateTimeFormatSpecifier s) {
+  switch (s) {
+    case DateTimeFormatSpecifier::YEAR:
+    case DateTimeFormatSpecifier::WEEK_YEAR:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool specAllowsPlusSign(DateTimeFormatSpecifier s, bool specifierNext) {
+  if (specifierNext) {
+    return false;
+  } else {
+    switch (s) {
+      case DateTimeFormatSpecifier::YEAR:
+      case DateTimeFormatSpecifier::WEEK_YEAR:
+        return true;
+      default:
+        return false;
+    }
+  }
+}
+
+void parseFail(
+    const std::string_view& input,
+    const char* cur,
+    const char* end) {
+  VELOX_USER_FAIL(
+      "Invalid format: \"{}\" is malformed at \"{}\"",
+      input,
+      std::string_view(cur, end - cur));
+}
+
+int64_t parseTimezoneOffset(const char* cur, const char* end, Date& date) {
+  // For timezone offset ids, there are three formats allowed by Joda:
+  //
+  // 1. '+' or '-' followed by two digits: "+00"
+  // 2. '+' or '-' followed by two digits, ":", then two more digits:
+  //    "+00:00"
+  // 3. '+' or '-' followed by four digits:
+  //    "+0000"
+  if (cur < end && (*cur == '-' || *cur == '+')) {
+    // Long format: "+00:00"
+    if ((end - cur) >= 6 && *(cur + 3) == ':') {
+      // Fast path for the common case ("+00:00" or "-00:00"), to prevent
+      // calling getTimeZoneID(), which does a map lookup.
+      if (std::strncmp(cur + 1, "00:00", 5) == 0) {
+        date.timezoneId = 0;
+      } else {
+        date.timezoneId = util::getTimeZoneID(std::string_view(cur, 6));
+      }
+      return 6;
+    }
+    // Long format without colon: "+0000"
+    else if ((end - cur) >= 5 && *(cur + 3) != ':') {
+      // Same fast path described above.
+      if (std::strncmp(cur + 1, "0000", 4) == 0) {
+        date.timezoneId = 0;
+      } else {
+        // We need to concatenate the 3 first chars with ":" followed by the
+        // last 2 chars before calling getTimeZoneID, so we use a static
+        // thread_local buffer to prevent extra allocations.
+        std::memcpy(&timezoneBuffer[0], cur, 3);
+        std::memcpy(&timezoneBuffer[4], cur + 3, 2);
+
+        date.timezoneId = util::getTimeZoneID(timezoneBuffer);
+      }
+      return 5;
+    }
+    // Short format: "+00"
+    else if ((end - cur) >= 3) {
+      // Same fast path described above.
+      if (std::strncmp(cur + 1, "00", 2) == 0) {
+        date.timezoneId = 0;
+      } else {
+        // We need to concatenate the 3 first chars with a trailing ":00" before
+        // calling getTimeZoneID, so we use a static thread_local buffer to
+        // prevent extra allocations.
+        std::memcpy(&timezoneBuffer[0], cur, 3);
+        std::memcpy(&timezoneBuffer[4], defaultTrailingOffset, 2);
+        date.timezoneId = util::getTimeZoneID(timezoneBuffer);
+      }
+      return 3;
+    }
+  }
+  throw std::runtime_error("Unable to parse timezone offset id.");
+}
+
+int64_t parseEra(const char* cur, const char* end, Date& date) {
+  if ((end - cur) >= 2) {
+    if (std::strncmp(cur, "AD", 2) == 0 || std::strncmp(cur, "ad", 2) == 0) {
+      date.isAd = true;
+      return 2;
+    } else if (
+        std::strncmp(cur, "BC", 2) == 0 || std::strncmp(cur, "bc", 2) == 0) {
+      date.isAd = false;
+      return 2;
+    } else {
+      throw std::runtime_error("Unable to parse era.");
+    }
+  } else {
+    throw std::runtime_error("Unable to parse era.");
+  }
+}
+
+int64_t parseMonthText(const char* cur, const char* end, Date& date) {
+  if ((end - cur) >= 3) {
+    for (int i = 0; i < 12; i++) {
+      if (std::strncmp(cur, monthsShort[i].data(), 3) == 0) {
+        auto length = monthsFullLength[i];
+        date.month = i + 1;
+        if ((end - cur) >= length &&
+            std::strncmp(cur, monthsFull[i].data(), length) == 0) {
+          return length;
+        } else {
+          return 3;
+        }
+      }
+    }
+    throw std::runtime_error("Unable to parse month.");
+  } else {
+    throw std::runtime_error("Unable to parse month.");
+  }
+}
+
+int64_t parseHalfDayOfDay(const char* cur, const char* end, Date& date) {
+  if ((end - cur) >= 2) {
+    if (std::strncmp(cur, "AM", 2) == 0 || std::strncmp(cur, "am", 2) == 0) {
+      date.isAm = true;
+      return 2;
+    } else if (
+        std::strncmp(cur, "PM", 2) == 0 || std::strncmp(cur, "pm", 2) == 0) {
+      date.isAm = false;
+      return 2;
+    } else {
+      throw std::runtime_error("Unable to parse halfday of day.");
+    }
+  } else {
+    throw std::runtime_error("Unable to parse halfday of day.");
+  }
+}
+
+// According to DateTimeFormatSpecifier enum class
+std::string getSpecifierName(int enumInt) {
+  switch (enumInt) {
+    case 0:
+      return "ERA";
+    case 1:
+      return "CENTURY_OF_ERA";
+    case 2:
+      return "YEAR_OF_ERA";
+    case 3:
+      return "WEEK_YEAR";
+    case 4:
+      return "WEEK_OF_WEEK_YEAR";
+    case 5:
+      return "DAY_OF_WEEK_0_BASED";
+    case 6:
+      return "DAY_OF_WEEK_1_BASED";
+    case 7:
+      return "DAY_OF_WEEK_TEXT";
+    case 8:
+      return "YEAR";
+    case 9:
+      return "DAY_OF_YEAR";
+    case 10:
+      return "MONTH_OF_YEAR";
+    case 11:
+      return "MONTH_OF_YEAR_TEXT";
+    case 12:
+      return "DAY_OF_MONTH";
+    case 13:
+      return "HALFDAY_OF_DAY";
+    case 14:
+      return "HOUR_OF_HALFDAY";
+    case 15:
+      return "CLOCK_HOUR_OF_HALFDAY";
+    case 16:
+      return "HOUR_OF_DAY";
+    case 17:
+      return "CLOCK_HOUR_OF_DAY";
+    case 18:
+      return "MINUTE_OF_HOUR";
+    case 19:
+      return "SECOND_OF_MINUTE";
+    case 20:
+      return "FRACTION_OF_SECOND";
+    case 21:
+      return "TIMEZONE";
+    case 22:
+      return "TIMEZONE_OFFSET_ID";
+    case 23:
+      return "LITERAL_PERCENT";
+    default:
+      return "[Specifier not updated to conversion function yet]";
+  }
+}
+
+int getMaxDigitConsume(FormatPattern curPattern, bool specifierNext) {
+  // Does not support WEEK_YEAR, WEEK_OF_WEEK_YEAR, time zone names
+  switch (curPattern.specifier) {
+    case DateTimeFormatSpecifier::CENTURY_OF_ERA:
+    case DateTimeFormatSpecifier::DAY_OF_WEEK_1_BASED:
+    case DateTimeFormatSpecifier::FRACTION_OF_SECOND:
+      return curPattern.minRepresentDigits;
+
+    case DateTimeFormatSpecifier::YEAR_OF_ERA:
+    case DateTimeFormatSpecifier::YEAR:
+    case DateTimeFormatSpecifier::WEEK_YEAR:
+      if (specifierNext) {
+        return curPattern.minRepresentDigits;
+      } else {
+        return curPattern.minRepresentDigits > 9 ? curPattern.minRepresentDigits
+                                                 : 9;
+      }
+
+    case DateTimeFormatSpecifier::MONTH_OF_YEAR:
+      return 2;
+
+    case DateTimeFormatSpecifier::DAY_OF_YEAR:
+      return curPattern.minRepresentDigits > 3 ? curPattern.minRepresentDigits
+                                               : 3;
+
+    case DateTimeFormatSpecifier::DAY_OF_MONTH:
+    case DateTimeFormatSpecifier::WEEK_OF_WEEK_YEAR:
+    case DateTimeFormatSpecifier::HOUR_OF_HALFDAY:
+    case DateTimeFormatSpecifier::CLOCK_HOUR_OF_HALFDAY:
+    case DateTimeFormatSpecifier::HOUR_OF_DAY:
+    case DateTimeFormatSpecifier::CLOCK_HOUR_OF_DAY:
+    case DateTimeFormatSpecifier::MINUTE_OF_HOUR:
+    case DateTimeFormatSpecifier::SECOND_OF_MINUTE:
+      return curPattern.minRepresentDigits > 2 ? curPattern.minRepresentDigits
+                                               : 2;
+
+    default:
+      return 1;
+  }
+}
+
+void parseFromPattern(
+    FormatPattern curPattern,
+    const std::string_view& input,
+    const char*& cur,
+    const char* end,
+    Date& date,
+    bool specifierNext) {
+  if (curPattern.specifier == DateTimeFormatSpecifier::TIMEZONE_OFFSET_ID) {
+    try {
+      cur += parseTimezoneOffset(cur, end, date);
+    } catch (...) {
+      parseFail(input, cur, end);
+    }
+  } else if (curPattern.specifier == DateTimeFormatSpecifier::ERA) {
+    try {
+      cur += parseEra(cur, end, date);
+    } catch (...) {
+      parseFail(input, cur, end);
+    }
+  } else if (
+      curPattern.specifier == DateTimeFormatSpecifier::MONTH_OF_YEAR_TEXT) {
+    try {
+      cur += parseMonthText(cur, end, date);
+      if (!date.hasYear) {
+        date.hasYear = true;
+        date.year = 2000;
+      }
+    } catch (...) {
+      parseFail(input, cur, end);
+    }
+  } else if (curPattern.specifier == DateTimeFormatSpecifier::HALFDAY_OF_DAY) {
+    try {
+      cur += parseHalfDayOfDay(cur, end, date);
+    } catch (...) {
+      parseFail(input, cur, end);
+    }
+  } else {
+    // Numeric specifier case
+    bool negative = false;
+
+    if (cur < end && specAllowsNegative(curPattern.specifier) && *cur == '-') {
+      negative = true;
+      ++cur;
+    } else if (
+        cur < end && specAllowsPlusSign(curPattern.specifier, specifierNext) &&
+        *cur == '+') {
+      negative = false;
+      ++cur;
+    }
+
+    auto startPos = cur;
+    int64_t number = 0;
+    int maxDigitConsume = getMaxDigitConsume(curPattern, specifierNext);
+
+    if (curPattern.specifier == DateTimeFormatSpecifier::FRACTION_OF_SECOND) {
+      int count = 0;
+      while (cur < end && cur < startPos + maxDigitConsume &&
+             characterIsDigit(*cur)) {
+        if (count < 3) {
+          number = number * 10 + (*cur - '0');
+        }
+        ++cur;
+        ++count;
+      }
+      number *= std::pow(10, 3 - count);
+    } else if (
+        curPattern.specifier == DateTimeFormatSpecifier::YEAR &&
+        curPattern.minRepresentDigits == 2) {
+      int count = 0;
+      while (cur < end && cur < startPos + maxDigitConsume &&
+             characterIsDigit(*cur)) {
+        number = number * 10 + (*cur - '0');
+        ++cur;
+        ++count;
+      }
+      if (count == 2) {
+        if (number >= 70) {
+          number += 1900;
+        } else if (number >= 0 && number < 70) {
+          number += 2000;
+        }
+      }
+    } else {
+      while (cur < end && cur < startPos + maxDigitConsume &&
+             characterIsDigit(*cur)) {
+        number = number * 10 + (*cur - '0');
+        ++cur;
+      }
+    }
+
+    // Need to have read at least one digit.
+    if (cur <= startPos) {
+      parseFail(input, cur, end);
+    }
+
+    if (negative) {
+      number *= -1L;
+    }
+
+    switch (curPattern.specifier) {
+      case DateTimeFormatSpecifier::CENTURY_OF_ERA:
+        // Enforce Joda's year range if year was specified as "century of year".
+        if (number < 0 || number > 2922789) {
+          VELOX_USER_FAIL(
+              "Value {} for year must be in the range [0,2922789]", number);
+        }
+        date.centuryFormat = true;
+        date.year = number * 100;
+        date.hasYear = true;
+        break;
+
+      case DateTimeFormatSpecifier::YEAR:
+      case DateTimeFormatSpecifier::YEAR_OF_ERA:
+        date.centuryFormat = false;
+        date.isYearOfEra =
+            (curPattern.specifier == DateTimeFormatSpecifier::YEAR_OF_ERA);
+        // Enforce Joda's year range if year was specified as "year of era".
+        if (date.isYearOfEra && (number > 292278993 || number < 1)) {
+          VELOX_USER_FAIL(
+              "Value {} for yearOfEra must be in the range [1,292278993]",
+              number);
+        }
+        // Enforce Joda's year range if year was specified as "year".
+        if (!date.isYearOfEra && (number > 292278994 || number < -292275055)) {
+          VELOX_USER_FAIL(
+              "Value {} for year must be in the range [-292275055,292278994]",
+              number);
+        }
+        date.hasYear = true;
+        date.year = number;
+        break;
+
+      case DateTimeFormatSpecifier::MONTH_OF_YEAR:
+        if (number < 1 || number > 12) {
+          VELOX_USER_FAIL(
+              "Value {} for monthOfYear must be in the range [1,12]", number);
+        }
+        date.month = number;
+        date.weekDateFormat = false;
+        date.dayOfYearFormat = false;
+        // Joda has this weird behavior where it returns 1970 as the year by
+        // default (if no year is specified), but if either day or month are
+        // specified, it fallsback to 2000.
+        if (!date.hasYear) {
+          date.hasYear = true;
+          date.year = 2000;
+        }
+        break;
+
+      case DateTimeFormatSpecifier::DAY_OF_MONTH:
+        date.dayOfMonthValues.push_back(number);
+        date.day = number;
+        date.weekDateFormat = false;
+        date.dayOfYearFormat = false;
+        // Joda has this weird behavior where it returns 1970 as the year by
+        // default (if no year is specified), but if either day or month are
+        // specified, it fallsback to 2000.
+        if (!date.hasYear) {
+          date.hasYear = true;
+          date.year = 2000;
+        }
+        break;
+
+      case DateTimeFormatSpecifier::DAY_OF_YEAR:
+        date.dayOfYearValues.push_back(number);
+        date.dayOfYear = number;
+        date.dayOfYearFormat = true;
+        date.weekDateFormat = false;
+        // Joda has this weird behavior where it returns 1970 as the year by
+        // default (if no year is specified), but if either day or month are
+        // specified, it fallsback to 2000.
+        if (!date.hasYear) {
+          date.hasYear = true;
+          date.year = 2000;
+        }
+        break;
+
+      case DateTimeFormatSpecifier::CLOCK_HOUR_OF_DAY:
+        if (number > 24 || number < 1) {
+          VELOX_USER_FAIL(
+              "Value {} for clockHourOfDay must be in the range [1,24]",
+              number);
+        }
+        date.isClockHour = true;
+        date.isHourOfHalfDay = false;
+        date.hour = number % 24;
+        break;
+
+      case DateTimeFormatSpecifier::HOUR_OF_DAY:
+        if (number > 23 || number < 0) {
+          VELOX_USER_FAIL(
+              "Value {} for clockHourOfDay must be in the range [0,23]",
+              number);
+        }
+        date.isClockHour = false;
+        date.isHourOfHalfDay = false;
+        date.hour = number;
+        break;
+
+      case DateTimeFormatSpecifier::CLOCK_HOUR_OF_HALFDAY:
+        if (number > 12 || number < 1) {
+          VELOX_USER_FAIL(
+              "Value {} for clockHourOfHalfDay must be in the range [1,12]",
+              number);
+        }
+        date.isClockHour = true;
+        date.isHourOfHalfDay = true;
+        date.hour = number % 12;
+        break;
+
+      case DateTimeFormatSpecifier::HOUR_OF_HALFDAY:
+        if (number > 11 || number < 0) {
+          VELOX_USER_FAIL(
+              "Value {} for hourOfHalfDay must be in the range [0,11]", number);
+        }
+        date.isClockHour = false;
+        date.isHourOfHalfDay = true;
+        date.hour = number;
+        break;
+
+      case DateTimeFormatSpecifier::MINUTE_OF_HOUR:
+        if (number > 59 || number < 0) {
+          VELOX_USER_FAIL(
+              "Value {} for minuteOfHour must be in the range [0,59]", number);
+        }
+        date.minute = number;
+        break;
+
+      case DateTimeFormatSpecifier::SECOND_OF_MINUTE:
+        if (number > 59 || number < 0) {
+          VELOX_USER_FAIL(
+              "Value {} for secondOfMinute must be in the range [0,59]",
+              number);
+        }
+        date.second = number;
+        break;
+
+      case DateTimeFormatSpecifier::FRACTION_OF_SECOND:
+        date.microsecond = number * util::kMicrosPerMsec;
+        break;
+
+      case DateTimeFormatSpecifier::WEEK_YEAR:
+        // Enforce Joda's year range if year was specified as "week year".
+        if (number < -292275054 || number > 292278993) {
+          VELOX_USER_FAIL(
+              "Value {} for year must be in the range [-292275054,292278993]",
+              number);
+        }
+        date.year = number;
+        date.weekDateFormat = true;
+        date.dayOfYearFormat = false;
+        date.centuryFormat = false;
+        date.hasYear = true;
+        break;
+
+      case DateTimeFormatSpecifier::WEEK_OF_WEEK_YEAR:
+        if (number < 1 || number > 52) {
+          VELOX_USER_FAIL(
+              "Value {} for weekOfWeekYear must be in the range [1,52]",
+              number);
+        }
+        date.week = number;
+        date.weekDateFormat = true;
+        date.dayOfYearFormat = false;
+        if (!date.hasYear) {
+          date.hasYear = true;
+          date.year = 2000;
+        }
+        break;
+
+      case DateTimeFormatSpecifier::DAY_OF_WEEK_1_BASED:
+        if (number < 1 || number > 7) {
+          VELOX_USER_FAIL(
+              "Value {} for weekOfWeekYear must be in the range [1,7]", number);
+        }
+        date.dayOfWeek = number;
+        date.weekDateFormat = true;
+        date.dayOfYearFormat = false;
+        if (!date.hasYear) {
+          date.hasYear = true;
+          date.year = 2000;
+        }
+        break;
+
+      default:
+        VELOX_NYI(
+            "Numeric Joda specifier DateTimeFormatSpecifier::" +
+            getSpecifierName(static_cast<int>(curPattern.specifier)) +
+            " not implemented yet.");
+    }
+  }
 }
 
 } // namespace
@@ -334,6 +915,87 @@ std::string DateTimeFormatter::format(
     }
   }
   return result;
+}
+
+DateTimeResult DateTimeFormatter::parse(const std::string_view& input) const {
+  Date date;
+  const char* cur = input.data();
+  const char* end = cur + input.size();
+
+  for (int i = 0; i < tokens_.size(); i++) {
+    auto& tok = tokens_[i];
+    switch (tok.type) {
+      case DateTimeToken::Type::kLiteral:
+        if (tok.literal.size() > end - cur ||
+            std::memcmp(cur, tok.literal.data(), tok.literal.size()) != 0) {
+          parseFail(input, cur, end);
+        }
+        cur += tok.literal.size();
+        break;
+      case DateTimeToken::Type::kPattern:
+        if (i + 1 < tokens_.size() &&
+            tokens_[i + 1].type == DateTimeToken::Type::kPattern) {
+          parseFromPattern(tok.pattern, input, cur, end, date, true);
+        } else {
+          parseFromPattern(tok.pattern, input, cur, end, date, false);
+        }
+        break;
+    }
+  }
+
+  // Ensure all input was consumed.
+  if (cur < end) {
+    parseFail(input, cur, end);
+  }
+
+  // Era is BC and year of era is provided
+  if (date.isYearOfEra && !date.isAd) {
+    date.year = -1 * (date.year - 1);
+  }
+
+  if (date.isHourOfHalfDay) {
+    if (!date.isAm) {
+      date.hour += 12;
+    }
+  }
+
+  // Ensure all day of month values are valid for ending month value
+  for (int i = 0; i < date.dayOfMonthValues.size(); i++) {
+    if (!util::isValidDate(date.year, date.month, date.dayOfMonthValues[i])) {
+      VELOX_USER_FAIL(
+          "Value {} for dayOfMonth must be in the range [1,{}]",
+          date.dayOfMonthValues[i],
+          util::getMaxDayOfMonth(date.year, date.month));
+    }
+  }
+
+  // Ensure all day of year values are valid for ending year value
+  for (int i = 0; i < date.dayOfYearValues.size(); i++) {
+    if (!util::isValidDayOfYear(date.year, date.dayOfYearValues[i])) {
+      VELOX_USER_FAIL(
+          "Value {} for dayOfMonth must be in the range [1,{}]",
+          date.dayOfYearValues[i],
+          util::isLeapYear(date.year) ? 366 : 365);
+    }
+  }
+
+  // Convert the parsed date/time into a timestamp.
+  int64_t daysSinceEpoch;
+  if (date.weekDateFormat) {
+    daysSinceEpoch =
+        util::daysSinceEpochFromWeekDate(date.year, date.week, date.dayOfWeek);
+  } else if (date.dayOfYearFormat) {
+    daysSinceEpoch =
+        util::daysSinceEpochFromDayOfYear(date.year, date.dayOfYear);
+  } else {
+    daysSinceEpoch =
+        util::daysSinceEpochFromDate(date.year, date.month, date.day);
+  }
+
+  int64_t microsSinceMidnight =
+      util::fromTime(date.hour, date.minute, date.second, date.microsecond);
+  return {
+      util::fromDatetime(daysSinceEpoch, microsSinceMidnight), date.timezoneId};
 }
 
 std::shared_ptr<DateTimeFormatter> buildMysqlDateTimeFormatter(

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -169,9 +169,7 @@ class DateTimeFormatter {
     return tokens_;
   }
 
-  Timestamp parse(const std::string_view& /* input */) const {
-    VELOX_NYI("date time parsing not implemented yet");
-  }
+  DateTimeResult parse(const std::string_view& input) const;
 
   std::string format(
       const Timestamp& timestamp,

--- a/velox/functions/lib/JodaDateTime.cpp
+++ b/velox/functions/lib/JodaDateTime.cpp
@@ -530,7 +530,7 @@ JodaResult JodaFormatter::parse(const std::string& input) {
   }
 
   // Convert the parsed date/time into a timestamp.
-  int32_t daysSinceEpoch = util::fromDate(
+  int32_t daysSinceEpoch = util::daysSinceEpochFromDate(
       jodaDate.getYear(), jodaDate.getMonth(), jodaDate.getDay());
   int64_t microsSinceMidnight = util::fromTime(
       jodaDate.hour, jodaDate.minute, jodaDate.second, jodaDate.microsecond);

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1846,6 +1846,17 @@ TEST_F(DateTimeFunctionsTest, parseDatetime) {
   EXPECT_EQ(
       TimestampWithTimezone(86400000, 0),
       parseDatetime("1970-01-02", "YYYY-MM-dd"));
+  EXPECT_EQ(
+      TimestampWithTimezone(86400000, 0),
+      parseDatetime("19700102", "YYYYMMdd"));
+  EXPECT_EQ(
+      TimestampWithTimezone(86400000, 0), parseDatetime("19700102", "YYYYMdd"));
+  EXPECT_EQ(
+      TimestampWithTimezone(86400000, 0), parseDatetime("19700102", "YYYYMMd"));
+  EXPECT_EQ(
+      TimestampWithTimezone(86400000, 0), parseDatetime("19700102", "YYYYMd"));
+  EXPECT_EQ(
+      TimestampWithTimezone(86400000, 0), parseDatetime("19700102", "YYYYMd"));
 
   // 118860000 is the number of milliseconds since epoch at 1970-01-02
   // 09:01:00.000 UTC.

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "velox/type/Timestamp.h"
 
 namespace facebook::velox::util {
@@ -35,28 +36,53 @@ constexpr const int64_t kNanosPerMicro{1000};
 constexpr const int32_t kSecsPerHour{kSecsPerMinute * kMinsPerHour};
 constexpr const int32_t kSecsPerDay{kSecsPerHour * kHoursPerDay};
 
-constexpr const int32_t kMinYear{-290307};
-constexpr const int32_t kMaxYear{294247};
+// Max and min year correspond to Joda datetime min and max
+constexpr const int32_t kMinYear{-292275055};
+constexpr const int32_t kMaxYear{292278994};
 
 constexpr const int32_t kYearInterval{400};
 constexpr const int32_t kDaysPerYearInterval{146097};
+
+// Returns true if leap year, false otherwise
+bool isLeapYear(int32_t year);
+
+// Returns true if year, month, day corresponds to valid date, false otherwise
+bool isValidDate(int32_t year, int32_t month, int32_t day);
+
+// Returns true if yday of year is valid for given year
+bool isValidDayOfYear(int32_t year, int32_t dayOfYear);
+
+// Returns max day of month for inputted month of inputted year
+int32_t getMaxDayOfMonth(int32_t year, int32_t month);
 
 /// Date conversions.
 
 /// Returns the (signed) number of days since unix epoch (1970-01-01).
 /// Throws VeloxUserError if the date is invalid.
-int32_t fromDate(int32_t year, int32_t month, int32_t day);
+int64_t daysSinceEpochFromDate(int32_t year, int32_t month, int32_t day);
+
+/// Returns the (signed) number of days since unix epoch (1970-01-01).
+int64_t daysSinceEpochFromWeekDate(
+    int32_t weekYear,
+    int32_t weekOfYear,
+    int32_t dayOfWeek);
+
+/// Returns the (signed) number of days since unix epoch (1970-01-01).
+int64_t daysSinceEpochFromDayOfYear(int32_t year, int32_t dayOfYear);
 
 /// Returns the (signed) number of days since unix epoch (1970-01-01), following
 /// the "YYYY-MM-DD" format (ISO 8601). ' ', '/' and '\' are also acceptable
 /// separators. Negative years and a trailing "(BC)" are also supported.
 ///
 /// Throws VeloxUserError if the format or date is invalid.
-int32_t fromDateString(const char* buf, size_t len);
+int64_t fromDateString(const char* buf, size_t len);
 
-inline int32_t fromDateString(const StringView& str) {
+inline int64_t fromDateString(const StringView& str) {
   return fromDateString(str.data(), str.size());
 }
+
+// Extracts the day of the week from the number of days since epoch
+int32_t extractISODayOfTheWeek(int32_t daysSinceEpoch);
 
 /// Time conversions.
 
@@ -85,6 +111,6 @@ inline Timestamp fromTimestampString(const StringView& str) {
   return fromTimestampString(str.data(), str.size());
 }
 
-Timestamp fromDatetime(int32_t daysSinceEpoch, int64_t microsSinceMidnight);
+Timestamp fromDatetime(int64_t daysSinceEpoch, int64_t microsSinceMidnight);
 
 } // namespace facebook::velox::util

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -26,34 +26,35 @@ namespace facebook::velox::util {
 namespace {
 
 TEST(DateTimeUtilTest, fromDate) {
-  EXPECT_EQ(0, fromDate(1970, 1, 1));
-  EXPECT_EQ(1, fromDate(1970, 1, 2));
-  EXPECT_EQ(365, fromDate(1971, 1, 1));
-  EXPECT_EQ(730, fromDate(1972, 1, 1)); // leap year.
-  EXPECT_EQ(1096, fromDate(1973, 1, 1));
+  EXPECT_EQ(0, daysSinceEpochFromDate(1970, 1, 1));
+  EXPECT_EQ(1, daysSinceEpochFromDate(1970, 1, 2));
+  EXPECT_EQ(365, daysSinceEpochFromDate(1971, 1, 1));
+  EXPECT_EQ(730, daysSinceEpochFromDate(1972, 1, 1)); // leap year.
+  EXPECT_EQ(1096, daysSinceEpochFromDate(1973, 1, 1));
 
-  EXPECT_EQ(10957, fromDate(2000, 1, 1));
-  EXPECT_EQ(18474, fromDate(2020, 7, 31));
+  EXPECT_EQ(10957, daysSinceEpochFromDate(2000, 1, 1));
+  EXPECT_EQ(18474, daysSinceEpochFromDate(2020, 7, 31));
 
   // Before unix epoch.
-  EXPECT_EQ(-1, fromDate(1969, 12, 31));
-  EXPECT_EQ(-365, fromDate(1969, 1, 1));
-  EXPECT_EQ(-731, fromDate(1968, 1, 1)); // leap year.
-  EXPECT_EQ(-719528, fromDate(0, 1, 1));
+  EXPECT_EQ(-1, daysSinceEpochFromDate(1969, 12, 31));
+  EXPECT_EQ(-365, daysSinceEpochFromDate(1969, 1, 1));
+  EXPECT_EQ(-731, daysSinceEpochFromDate(1968, 1, 1)); // leap year.
+  EXPECT_EQ(-719528, daysSinceEpochFromDate(0, 1, 1));
 
   // Negative year - BC.
-  EXPECT_EQ(-719529, fromDate(-1, 12, 31));
-  EXPECT_EQ(-719893, fromDate(-1, 1, 1));
+  EXPECT_EQ(-719529, daysSinceEpochFromDate(-1, 12, 31));
+  EXPECT_EQ(-719893, daysSinceEpochFromDate(-1, 1, 1));
 }
 
 TEST(DateTimeUtilTest, fromDateInvalid) {
-  EXPECT_THROW(fromDate(1970, 1, -1), VeloxUserError);
-  EXPECT_THROW(fromDate(1970, -1, 1), VeloxUserError);
-  EXPECT_THROW(fromDate(1970, 0, 1), VeloxUserError);
-  EXPECT_THROW(fromDate(1970, 13, 1), VeloxUserError);
-  EXPECT_THROW(fromDate(1970, 1, 32), VeloxUserError);
-  EXPECT_THROW(fromDate(1970, 2, 29), VeloxUserError); // non-leap.
-  EXPECT_THROW(fromDate(1970, 6, 31), VeloxUserError);
+  EXPECT_THROW(daysSinceEpochFromDate(1970, 1, -1), VeloxUserError);
+  EXPECT_THROW(daysSinceEpochFromDate(1970, -1, 1), VeloxUserError);
+  EXPECT_THROW(daysSinceEpochFromDate(1970, 0, 1), VeloxUserError);
+  EXPECT_THROW(daysSinceEpochFromDate(1970, 13, 1), VeloxUserError);
+  EXPECT_THROW(daysSinceEpochFromDate(1970, 1, 32), VeloxUserError);
+  EXPECT_THROW(
+      daysSinceEpochFromDate(1970, 2, 29), VeloxUserError); // non-leap.
+  EXPECT_THROW(daysSinceEpochFromDate(1970, 6, 31), VeloxUserError);
 }
 
 TEST(DateTimeUtilTest, fromDateString) {


### PR DESCRIPTION
Summary:
The parse_datetime functionality was originally implemented in JodaDateTime.cpp and only supported Joda standard dates. Moreover, the previous implementation did not support many of the standard Joda specifiers. This implementation updates the old implementation to use the newly created DateTimeFormatter class which was designed to support both Joda and MySql datetime standards. Specifically, this implementation uses the DateTimeFormatter class to create a vector of DateTimeSpecifier tokens from the inputted format string, then uses this vector of tokens to parse  the datetime string into a timestamp.

However, this implementation differs from the standard Joda implementation in a few ways, namely when there are conflicting specifiers. You can read about the considerations of this implementation and how it differs from the standard Joda implementation [here](https://docs.google.com/document/d/1v-Pdu9Ngrc6T37FR3UjNK_ME9hLpOkERuy3NEKZ_3HI/edit).

This diff also implements tests to ensure the correctness of the new implementation.

Reviewed By: tanjialiang

Differential Revision: D37932597

