### PR TITLE
Fix approx_most_frequent to handle empty input

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -710,8 +710,9 @@ void assertResultsOrdered(
 std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
     const CursorParameters& params,
     std::function<void(exec::Task*)> addSplits) {
-  std::vector<RowVectorPtr> result;
   auto cursor = std::make_unique<TaskCursor>(params);
+  // 'result' borrows memory from cursor so the life cycle must be shorter.
+  std::vector<RowVectorPtr> result;
   auto* task = cursor->task().get();
   addSplits(task);
 

--- a/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
@@ -119,8 +119,7 @@ TYPED_TEST(ApproxMostFrequentTest, grouped) {
       {this->makeRowVector({groupKeys, expected})});
 }
 
-// TODO This test crashes. Fix and re-enable.
-TYPED_TEST(ApproxMostFrequentTest, DISABLED_emptyGroup) {
+TYPED_TEST(ApproxMostFrequentTest, emptyGroup) {
   auto values = this->makeValuesWithNulls();
   auto keys = this->makeKeys();
   auto groupKeys = this->makeGroupKeys();


### PR DESCRIPTION
Summary: Currently when `​​​extractValues` is called on the accumulator, if there is no data ever added, it will crash.  This change fix this corner case.

Differential Revision: D38256694

