### PR TITLE
Implemented flatmap struct encoding column writer in writeRow()

### DIFF
--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
@@ -135,6 +135,24 @@ class ValueWriter {
     return 0;
   }
 
+  // used for struct encoding writer
+  uint64_t writeBuffers(
+      const VectorPtr& values,
+      const Ranges& nonNullRanges,
+      const BufferPtr& inMapBuffer /* all 1 */) {
+    if (nonNullRanges.size()) {
+      inMap_->add(
+          inMapBuffer->as<char>(),
+          Ranges::of(0, nonNullRanges.size()),
+          nullptr);
+    }
+
+    if (values) {
+      return columnWriter_->write(values, nonNullRanges);
+    }
+    return 0;
+  }
+
   void backfill(uint32_t count) {
     if (count == 0) {
       return;
@@ -250,6 +268,10 @@ class FlatMapColumnWriter : public BaseColumnWriter {
   void setEncoding(proto::ColumnEncoding& encoding) const override;
 
   ValueWriter& getValueWriter(KeyType key, uint32_t inMapSize);
+
+  // write() calls writeMap() or writeRow() depending on input type
+  uint64_t writeMap(const VectorPtr& slice, const Ranges& ranges);
+  uint64_t writeRow(const VectorPtr& slice, const Ranges& ranges);
 
   void clearNodes();
 


### PR DESCRIPTION
Summary: Map input writing was pulled out into writeMap(), and writeRow() was implemented to handle struct encoding input. The base write() will choose between writeMap() and writeRow() depending on what type it is passed. This writeRow() will not be enabled until some other details are completed: encoding handling, passing keys in writer context, testing.

Differential Revision: D38224871

