### PR TITLE
Enable spill tests for avg and variance aggregate functions

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -24,6 +24,11 @@ namespace {
 
 class AverageAggregationTest : public AggregationTestBase {
  protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    allowInputShuffle();
+  }
+
   RowTypePtr rowType_{
       ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
           {BIGINT(), SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()})};

--- a/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
@@ -38,6 +38,11 @@ std::string genAggr(const char* aggrName, const char* colName) {
 // The test class.
 class VarianceAggregationTest : public AggregationTestBase {
  protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    allowInputShuffle();
+  }
+
   RowTypePtr rowType_{
       ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
           {BIGINT(), SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()})};

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/type/Variant.h"
+#include <cfloat>
 #include "common/encode/Base64.h"
 #include "folly/json.h"
 
@@ -577,19 +578,41 @@ uint64_t variant::hash() const {
   }
 }
 
-/*static*/ bool variant::equalsFloatingPointWithEpsilon(
-    const variant& a,
-    const variant& b) {
+namespace {
+
+// Compare floating point numbers using relative epsilon comparison.
+// See
+// https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+// for details.
+template <TypeKind KIND, typename TFloat>
+bool equalsFloatingPointWithEpsilonTyped(const variant& a, const variant& b) {
+  TFloat f1 = a.value<KIND>();
+  TFloat f2 = b.value<KIND>();
+
+  // Check if the numbers are really close -- needed
+  // when comparing numbers near zero.
+  if (fabs(f1 - f2) < kEpsilon) {
+    return true;
+  }
+
+  TFloat largest = std::max(abs(f1), abs(f2));
+
+  return fabs(f1 - f2) <= largest * 2 * FLT_EPSILON;
+}
+
+bool equalsFloatingPointWithEpsilon(const variant& a, const variant& b) {
   if (a.isNull() or b.isNull()) {
     return false;
   }
-  if (a.kind_ == TypeKind::REAL) {
-    return fabs(a.value<TypeKind::REAL>() - b.value<TypeKind::REAL>()) <
-        kEpsilon;
+
+  if (a.kind() == TypeKind::REAL) {
+    return equalsFloatingPointWithEpsilonTyped<TypeKind::REAL, float>(a, b);
+  } else {
+    VELOX_CHECK_EQ(a.kind(), TypeKind::DOUBLE);
+    return equalsFloatingPointWithEpsilonTyped<TypeKind::DOUBLE, double>(a, b);
   }
-  return fabs(a.value<TypeKind::DOUBLE>() - b.value<TypeKind::DOUBLE>()) <
-      kEpsilon;
 }
+} // namespace
 
 bool variant::lessThanWithEpsilon(const variant& other) const {
   if (other.kind_ != this->kind_) {

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -665,12 +665,6 @@ class variant {
     return stream;
   }
 
-  // Compares REAL and DOUBLE (only) types for equality using kEpsilon.
-  // For testing purposes.
-  static bool equalsFloatingPointWithEpsilon(
-      const variant& a,
-      const variant& b);
-
   // Uses kEpsilon to compare floating point types (REAL and DOUBLE).
   // For testing purposes.
   bool lessThanWithEpsilon(const variant& other) const;


### PR DESCRIPTION
Enhance variant::equalsWithEpsilon to use relative epsilon comparison for floats
and doubles based on
https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/