### PR TITLE
Enable more testing for min and max aggregate functions

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -83,6 +83,18 @@ void MinMaxAggregate<Timestamp, int64_t>::extractValues(
       });
 }
 
+template <>
+void MinMaxAggregate<Timestamp, Timestamp>::extractValues(
+    char** groups,
+    int32_t numGroups,
+    VectorPtr* result) {
+  BaseAggregate::template doExtractValues<Timestamp>(
+      groups, numGroups, result, [&](char* group) {
+        auto ts = *BaseAggregate::Aggregate::template value<Timestamp>(group);
+        return Timestamp::fromMillis(ts.toMillis());
+      });
+}
+
 template <typename T, typename ResultType>
 class MaxAggregate : public MinMaxAggregate<T, ResultType> {
   using BaseAggregate = SimpleNumericAggregate<T, T, ResultType>;


### PR DESCRIPTION
Fix a bug in single aggregation over timestamp values uncovered by additional tests.

With spilling enabled multiple tests fail. I'll investigate, fix failures and enable spill testing in a follow up PR.