### PR TITLE
Enable spill testing for min and max aggregate functions

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -40,27 +40,53 @@ struct MinMaxTrait<Timestamp> {
   }
 };
 
-template <typename T, typename ResultType>
-class MinMaxAggregate : public SimpleNumericAggregate<T, T, ResultType> {
-  using BaseAggregate = SimpleNumericAggregate<T, T, ResultType>;
+/// TInput is type of data received by addRawInput() in partial aggregation and
+/// addIntermediateResults() in final or intermediate aggregations.
+///
+/// TAccumulator is type of data returned by extractAccumulators() in partial or
+/// intermediate aggregations and in case of spilling during final or single
+/// aggregations.
+///
+/// TResult is type of data returned by extractValues() in final or single
+/// aggregations.
+///
+/// For example, min(integer) uses the following classes:
+///
+/// Partial aggregation: MinMaxAggregate<int32_t, int64_t, int64_t>.
+/// Final aggregation: MinMaxAggregate<int64_t, int64_t, int32_t>.
+/// Single aggregation: MinMaxAggregate<int32_t, int64_t, int32_t>.
+/// Intermediate aggregation: MinMaxAggregate<int64_t, int64_t, int64_t>.
+template <typename TInput, typename TAccumulator, typename TResult>
+class MinMaxAggregate
+    : public SimpleNumericAggregate<TInput, TAccumulator, TResult> {
+  using BaseAggregate = SimpleNumericAggregate<TInput, TAccumulator, TResult>;
 
  public:
   explicit MinMaxAggregate(TypePtr resultType) : BaseAggregate(resultType) {}
 
   int32_t accumulatorFixedWidthSize() const override {
-    return sizeof(T);
+    return sizeof(TInput);
   }
 
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
-    BaseAggregate::doExtractValues(groups, numGroups, result, [&](char* group) {
-      return *BaseAggregate::Aggregate::template value<T>(group);
-    });
+    BaseAggregate::template doExtractValues<TResult>(
+        groups, numGroups, result, [&](char* group) {
+          return *BaseAggregate::Aggregate::template value<TInput>(group);
+        });
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    BaseAggregate::template doExtractValues<TAccumulator>(
+        groups, numGroups, result, [&](char* group) {
+          return *BaseAggregate::Aggregate::template value<TInput>(group);
+        });
   }
 };
 
 template <>
-void MinMaxAggregate<int64_t, Timestamp>::extractValues(
+void MinMaxAggregate<int64_t, int64_t, Timestamp>::extractValues(
     char** groups,
     int32_t numGroups,
     VectorPtr* result) {
@@ -72,7 +98,7 @@ void MinMaxAggregate<int64_t, Timestamp>::extractValues(
 }
 
 template <>
-void MinMaxAggregate<Timestamp, int64_t>::extractValues(
+void MinMaxAggregate<Timestamp, int64_t, int64_t>::extractValues(
     char** groups,
     int32_t numGroups,
     VectorPtr* result) {
@@ -84,7 +110,7 @@ void MinMaxAggregate<Timestamp, int64_t>::extractValues(
 }
 
 template <>
-void MinMaxAggregate<Timestamp, Timestamp>::extractValues(
+void MinMaxAggregate<Timestamp, int64_t, Timestamp>::extractValues(
     char** groups,
     int32_t numGroups,
     VectorPtr* result) {
@@ -95,20 +121,44 @@ void MinMaxAggregate<Timestamp, Timestamp>::extractValues(
       });
 }
 
-template <typename T, typename ResultType>
-class MaxAggregate : public MinMaxAggregate<T, ResultType> {
-  using BaseAggregate = SimpleNumericAggregate<T, T, ResultType>;
+template <>
+void MinMaxAggregate<Timestamp, int64_t, int64_t>::extractAccumulators(
+    char** groups,
+    int32_t numGroups,
+    VectorPtr* result) {
+  BaseAggregate::template doExtractValues<int64_t>(
+      groups, numGroups, result, [&](char* group) {
+        auto ts = *BaseAggregate::Aggregate::template value<Timestamp>(group);
+        return ts.toMillis();
+      });
+}
+
+template <>
+void MinMaxAggregate<Timestamp, int64_t, Timestamp>::extractAccumulators(
+    char** groups,
+    int32_t numGroups,
+    VectorPtr* result) {
+  BaseAggregate::template doExtractValues<int64_t>(
+      groups, numGroups, result, [&](char* group) {
+        auto ts = *BaseAggregate::Aggregate::template value<Timestamp>(group);
+        return ts.toMillis();
+      });
+}
+
+template <typename TInput, typename TAccumulator, typename TResult>
+class MaxAggregate : public MinMaxAggregate<TInput, TAccumulator, TResult> {
+  using BaseAggregate = SimpleNumericAggregate<TInput, TAccumulator, TResult>;
 
  public:
   explicit MaxAggregate(TypePtr resultType)
-      : MinMaxAggregate<T, ResultType>(resultType) {}
+      : MinMaxAggregate<TInput, TAccumulator, TResult>(resultType) {}
 
   void initializeNewGroups(
       char** groups,
       folly::Range<const vector_size_t*> indices) override {
     exec::Aggregate::setAllNulls(groups, indices);
     for (auto i : indices) {
-      *exec::Aggregate::value<T>(groups[i]) = kInitialValue_;
+      *exec::Aggregate::value<TInput>(groups[i]) = kInitialValue_;
     }
   }
 
@@ -118,16 +168,16 @@ class MaxAggregate : public MinMaxAggregate<T, ResultType> {
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     if (mayPushdown && args[0]->isLazy() &&
-        std::is_same<T, ResultType>::value) {
-      BaseAggregate::template pushdown<MinMaxHook<T, false>>(
+        std::is_same<TInput, TResult>::value) {
+      BaseAggregate::template pushdown<MinMaxHook<TInput, false>>(
           groups, rows, args[0]);
       return;
     }
-    BaseAggregate::template updateGroups<true, T>(
+    BaseAggregate::template updateGroups<true, TInput>(
         groups,
         rows,
         args[0],
-        [](T& result, T value) {
+        [](TInput& result, TInput value) {
           if (result < value) {
             result = value;
           }
@@ -152,8 +202,10 @@ class MaxAggregate : public MinMaxAggregate<T, ResultType> {
         group,
         rows,
         args[0],
-        [](T& result, T value) { result = result > value ? result : value; },
-        [](T& result, T value, int /* unused */) { result = value; },
+        [](TInput& result, TInput value) {
+          result = result > value ? result : value;
+        },
+        [](TInput& result, TInput value, int /* unused */) { result = value; },
         mayPushdown,
         kInitialValue_);
   }
@@ -167,23 +219,23 @@ class MaxAggregate : public MinMaxAggregate<T, ResultType> {
   }
 
  private:
-  static constexpr T kInitialValue_{MinMaxTrait<T>::min()};
+  static constexpr TInput kInitialValue_{MinMaxTrait<TInput>::min()};
 };
 
-template <typename T, typename ResultType>
-class MinAggregate : public MinMaxAggregate<T, ResultType> {
-  using BaseAggregate = SimpleNumericAggregate<T, T, ResultType>;
+template <typename TInput, typename TAccumulator, typename TResult>
+class MinAggregate : public MinMaxAggregate<TInput, TAccumulator, TResult> {
+  using BaseAggregate = SimpleNumericAggregate<TInput, TAccumulator, TResult>;
 
  public:
   explicit MinAggregate(TypePtr resultType)
-      : MinMaxAggregate<T, ResultType>(resultType) {}
+      : MinMaxAggregate<TInput, TAccumulator, TResult>(resultType) {}
 
   void initializeNewGroups(
       char** groups,
       folly::Range<const vector_size_t*> indices) override {
     exec::Aggregate::setAllNulls(groups, indices);
     for (auto i : indices) {
-      *exec::Aggregate::value<T>(groups[i]) = kInitialValue_;
+      *exec::Aggregate::value<TInput>(groups[i]) = kInitialValue_;
     }
   }
 
@@ -193,16 +245,16 @@ class MinAggregate : public MinMaxAggregate<T, ResultType> {
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     if (mayPushdown && args[0]->isLazy() &&
-        std::is_same<T, ResultType>::value) {
-      BaseAggregate::template pushdown<MinMaxHook<T, true>>(
+        std::is_same<TInput, TResult>::value) {
+      BaseAggregate::template pushdown<MinMaxHook<TInput, true>>(
           groups, rows, args[0]);
       return;
     }
-    BaseAggregate::template updateGroups<true, T>(
+    BaseAggregate::template updateGroups<true, TInput>(
         groups,
         rows,
         args[0],
-        [](T& result, T value) {
+        [](TInput& result, TInput value) {
           if (result > value) {
             result = value;
           }
@@ -227,8 +279,10 @@ class MinAggregate : public MinMaxAggregate<T, ResultType> {
         group,
         rows,
         args[0],
-        [](T& result, T value) { result = result < value ? result : value; },
-        [](T& result, T value, int /* unused */) { result = value; },
+        [](TInput& result, TInput value) {
+          result = result < value ? result : value;
+        },
+        [](TInput& result, TInput value, int /* unused */) { result = value; },
         mayPushdown,
         kInitialValue_);
   }
@@ -242,7 +296,7 @@ class MinAggregate : public MinMaxAggregate<T, ResultType> {
   }
 
  private:
-  static constexpr T kInitialValue_{MinMaxTrait<T>::max()};
+  static constexpr TInput kInitialValue_{MinMaxTrait<TInput>::max()};
 };
 
 class NonNumericMinMaxAggregateBase : public exec::Aggregate {
@@ -453,23 +507,26 @@ class NonNumericMinAggregate : public NonNumericMinMaxAggregateBase {
   }
 };
 
-template <typename TInput, template <typename U, typename V> class TNumeric>
+template <
+    typename TInput,
+    template <typename T, typename U, typename V>
+    class TNumeric>
 std::unique_ptr<exec::Aggregate> createMinMaxIntegralAggregate(
     const std::string& name,
     const TypePtr& resultType) {
   switch (resultType->kind()) {
     case TypeKind::TINYINT:
-      return std::make_unique<TNumeric<TInput, int8_t>>(resultType);
+      return std::make_unique<TNumeric<TInput, int64_t, int8_t>>(resultType);
     case TypeKind::SMALLINT:
-      return std::make_unique<TNumeric<TInput, int16_t>>(resultType);
+      return std::make_unique<TNumeric<TInput, int64_t, int16_t>>(resultType);
     case TypeKind::INTEGER:
-      return std::make_unique<TNumeric<TInput, int32_t>>(resultType);
+      return std::make_unique<TNumeric<TInput, int64_t, int32_t>>(resultType);
     case TypeKind::BIGINT:
-      return std::make_unique<TNumeric<TInput, int64_t>>(resultType);
+      return std::make_unique<TNumeric<TInput, int64_t, int64_t>>(resultType);
     case TypeKind::REAL:
-      return std::make_unique<TNumeric<TInput, float>>(resultType);
+      return std::make_unique<TNumeric<TInput, float, float>>(resultType);
     case TypeKind::DOUBLE:
-      return std::make_unique<TNumeric<TInput, double>>(resultType);
+      return std::make_unique<TNumeric<TInput, double, double>>(resultType);
     default:
       VELOX_FAIL(
           "Unknown result type for {} aggregation with integral input type: {}",
@@ -478,15 +535,18 @@ std::unique_ptr<exec::Aggregate> createMinMaxIntegralAggregate(
   }
 }
 
-template <typename TInput, template <typename U, typename V> class TNumeric>
+template <
+    typename TInput,
+    template <typename T, typename U, typename V>
+    class TNumeric>
 std::unique_ptr<exec::Aggregate> createMinMaxTimestampAggregate(
     const std::string& name,
     const TypePtr& resultType) {
   switch (resultType->kind()) {
     case TypeKind::BIGINT:
-      return std::make_unique<TNumeric<TInput, int64_t>>(resultType);
+      return std::make_unique<TNumeric<TInput, int64_t, int64_t>>(resultType);
     case TypeKind::TIMESTAMP:
-      return std::make_unique<TNumeric<TInput, Timestamp>>(resultType);
+      return std::make_unique<TNumeric<TInput, int64_t, Timestamp>>(resultType);
     default:
       VELOX_FAIL(
           "Unknown result type for {} aggregation with timestamp input type: {}",
@@ -495,13 +555,13 @@ std::unique_ptr<exec::Aggregate> createMinMaxTimestampAggregate(
   }
 }
 
-template <template <typename U, typename V> class TNumeric>
+template <template <typename T, typename U, typename V> class TNumeric>
 std::unique_ptr<exec::Aggregate> createMinMaxDateAggregate(
     const std::string& name,
     const TypePtr& resultType) {
   switch (resultType->kind()) {
     case TypeKind::DATE:
-      return std::make_unique<TNumeric<Date, Date>>(resultType);
+      return std::make_unique<TNumeric<Date, Date, Date>>(resultType);
     default:
       VELOX_FAIL(
           "Unknown result type for {} aggregation with date input type: {}",
@@ -510,17 +570,20 @@ std::unique_ptr<exec::Aggregate> createMinMaxDateAggregate(
   }
 }
 
-template <typename TInput, template <typename U, typename V> class TNumeric>
+template <
+    typename TInput,
+    template <typename T, typename U, typename V>
+    class TNumeric>
 std::unique_ptr<exec::Aggregate> createMinMaxFloatingPointAggregate(
     const std::string& name,
     const TypePtr& resultType) {
   switch (resultType->kind()) {
     case TypeKind::REAL:
-      return std::make_unique<TNumeric<TInput, float>>(resultType);
+      return std::make_unique<TNumeric<TInput, float, float>>(resultType);
     case TypeKind::DOUBLE:
-      return std::make_unique<TNumeric<TInput, double>>(resultType);
+      return std::make_unique<TNumeric<TInput, double, double>>(resultType);
     case TypeKind::BIGINT:
-      return std::make_unique<TNumeric<TInput, int64_t>>(resultType);
+      return std::make_unique<TNumeric<TInput, int64_t, int64_t>>(resultType);
     default:
       VELOX_FAIL(
           "Unknown result type for {} aggregation with floating point input type: {}",
@@ -530,7 +593,7 @@ std::unique_ptr<exec::Aggregate> createMinMaxFloatingPointAggregate(
 }
 
 template <
-    template <typename U, typename V>
+    template <typename T, typename U, typename V>
     class TNumeric,
     typename TNonNumeric>
 bool registerMinMaxAggregate(const std::string& name) {
@@ -573,7 +636,8 @@ bool registerMinMaxAggregate(const std::string& name) {
                 name, resultType);
           case TypeKind::BIGINT:
             if (resultType->isTimestamp()) {
-              return std::make_unique<TNumeric<int64_t, Timestamp>>(resultType);
+              return std::make_unique<TNumeric<int64_t, int64_t, Timestamp>>(
+                  resultType);
             }
             return createMinMaxIntegralAggregate<int64_t, TNumeric>(
                 name, resultType);

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -150,7 +150,7 @@ void AggregationTestBase::testAggregations(
   }
 
   if (!groupingKeys.empty() && allowInputShuffle_) {
-    SCOPED_TRACE("Run single with spilling");
+    SCOPED_TRACE("Run partial + final with spilling");
     PlanBuilder builder;
     makeSource(builder);
 


### PR DESCRIPTION
Spilling introduces a new code path that wasn't considered before:
extractAccumulators() is called during single and final aggregations. 

With spilling enabled, the original implementation of min/max aggregations over
tinyint, smallint, integer and timestamp types failed with "Unexpected type of
the result vector: BIGINT".

Min and max aggregation functions use intermediate types that match Presto Java
implementation. These types are rather inconvenient. For tinyint, smallint,
integer, bigint and timestamp inputs, intermediate type is bigint and final
result type is same as input type. For all other input types intermediate and
final result types match input type.

MinMaxAggregate class has 2 template parameters: T, ResultType. T is the type of
input, ResultType is the type of result. T is also used as an accumulator
type.

Consider min(integer).

Partial: T = integer, ResultType = bigint, AccumulatorType = T = integer
Final: T = bigint, ResultType = integer, AccumulatorType = T = bigint
Single: T = integer, ResultType = integer, AccumulatorType = T = integer

extractAccumulators() is implemented with only partial aggregation in mind. It
simply calls extractValues().

extractValues() is implemented to read accumulator value and cast it to
ResultType.

Partial: extractAccumulators() == extractValues(): cast integer to bigint
Final: extractValues(): cast bigint to integer
Single: extractValues(): cast integer to integer

Spilling calls extractAccumulators() in Final and Single aggregations and
expects a result of type bigint.

Final: extractAccumulators() == extractValues(): cast bigint to integer - This is a problem. integer != bigint
Single: extractAccumulators() == extractValues(): cast integer to integer - Same problem. integer != bigint

A solution implemented here is to (1) add a third template parameter
TAccumulator; (2) decouple extractAccumulators() from extractValues() and
implement it to cast accumulator value to TAccumulator type. The actual type of
the accumulator remains as before (i.e. TInput).

Partial: TInput = integer, TAccumulator = bigint, TResult = bigint
Final: TInput = bigint, TAccumulator = bigint, TResult = integer
Single: TInput = integer, TAccumulator = bigint, TResult = integer

extractAccumulators() reads TInput value from accumulator and casts it to TAccumulator.

extractValues() reads TInput value from accumulator and casts it to TResult.
