### PR TITLE
Avoid use of GTEST_SKIP() in ExprEncodingsTest

### DIFF
--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -577,10 +577,11 @@ TEST_P(ExprEncodingsTest, errors) {
   prepareTestData();
 
   if (isAllNulls(testData_.bigint2.vector)) {
-    GTEST_SKIP() << "This test requires input that is not all-null";
+    LOG(WARNING)
+        << "This test requires input that is not all-null. Skipping it.";
+  } else {
+    runWithError("bigint2 % 0");
   }
-
-  runWithError("bigint2 % 0");
 }
 
 TEST_P(ExprEncodingsTest, maskedErrors) {


### PR DESCRIPTION
Summary:
GTEST_SKIP() not only pollutes testpilot outputs but also triggers
internal alerts in Sandcastle. If there's nothing to test in the test suite for
a particular parametrized input, just do nothing.

Differential Revision: D38286027

