### PR TITLE
Add support for Decimal Types in Aggregate Function Signature

### DIFF
--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -234,6 +234,7 @@ AggregateFunctionSignatureBuilder::build() {
   VELOX_CHECK(intermediateType_.has_value());
   return std::make_shared<AggregateFunctionSignature>(
       std::move(typeVariableConstants_),
+      std::move(variables_),
       returnType_.value(),
       intermediateType_.value(),
       std::move(argumentTypes_),

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -175,6 +175,21 @@ class AggregateFunctionSignature : public FunctionSignature {
             variableArity),
         intermediateType_{std::move(intermediateType)} {}
 
+  AggregateFunctionSignature(
+      std::vector<TypeVariableConstraint> typeVariableConstants,
+      std::vector<TypeVariableConstraint> variables,
+      TypeSignature returnType,
+      TypeSignature intermediateType,
+      std::vector<TypeSignature> argumentTypes,
+      bool variableArity)
+      : FunctionSignature(
+            std::move(typeVariableConstants),
+            std::move(variables),
+            std::move(returnType),
+            std::move(argumentTypes),
+            variableArity),
+        intermediateType_{std::move(intermediateType)} {}
+
   const TypeSignature& intermediateType() const {
     return intermediateType_;
   }
@@ -289,6 +304,13 @@ class AggregateFunctionSignatureBuilder {
     return *this;
   }
 
+  AggregateFunctionSignatureBuilder& variableConstraint(
+      std::string name,
+      std::string constraint) {
+    variables_.emplace_back(name, constraint);
+    return *this;
+  }
+
   std::shared_ptr<AggregateFunctionSignature> build();
 
  private:
@@ -296,6 +318,7 @@ class AggregateFunctionSignatureBuilder {
   std::optional<TypeSignature> returnType_;
   std::optional<TypeSignature> intermediateType_;
   std::vector<TypeSignature> argumentTypes_;
+  std::vector<TypeVariableConstraint> variables_;
   bool variableArity_{false};
 };
 

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -25,7 +25,8 @@ bool isAny(const TypeSignature& typeSignature) {
   return typeSignature.baseType() == "any";
 }
 
-bool isNumber(const std::string& str) {
+/// Returns true only if 'str' contains digits.
+bool isPositiveInteger(const std::string& str) {
   return !str.empty() &&
       std::find_if(str.begin(), str.end(), [](unsigned char c) {
         return !std::isdigit(c);
@@ -52,12 +53,13 @@ TypePtr inferDecimalType(
   int scale = 0;
   // Determine precision.
   // Handle constant.
-  if (isNumber(precisionVar)) {
+  if (isPositiveInteger(precisionVar)) {
     precision = atoi(precisionVar.c_str());
   } else {
-    if (precisionConstraint == constraints.end()) {
-      VELOX_FAIL("Missing constraint for variable {}", precisionVar);
-    }
+    VELOX_CHECK(
+        precisionConstraint != constraints.end(),
+        "Missing constraint for variable {}",
+        precisionVar);
     auto precisionCalculation =
         buildCalculation(precisionVar, precisionConstraint->second);
     expression::calculation::evaluate(precisionCalculation, variables);
@@ -65,12 +67,13 @@ TypePtr inferDecimalType(
   }
   // Determine scale.
   // Handle constant.
-  if (isNumber(scaleVar)) {
+  if (isPositiveInteger(scaleVar)) {
     scale = atoi(scaleVar.c_str());
   } else {
-    if (scaleConstraint == constraints.end()) {
-      VELOX_FAIL("Missing constraint for variable {}", scaleVar);
-    }
+    VELOX_CHECK(
+        scaleConstraint != constraints.end(),
+        "Missing constraint for variable {}",
+        scaleVar);
     auto scaleCalculation = buildCalculation(scaleVar, scaleConstraint->second);
     expression::calculation::evaluate(scaleCalculation, variables);
     scale = variables[scaleVar];

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -27,7 +27,7 @@ void testSignatureBinder(
 
   auto returnType = binder.tryResolveReturnType();
   ASSERT_TRUE(returnType != nullptr);
-  ASSERT_TRUE(expectedReturnType->kindEquals(returnType));
+  ASSERT_TRUE(expectedReturnType->equivalent(*returnType));
 }
 
 void assertCannotResolve(
@@ -57,7 +57,7 @@ TEST(SignatureBinderTest, decimals) {
         signature->argumentTypes()[1].toString(),
         "DECIMAL(b_precision, b_scale)");
     testSignatureBinder(
-        signature, {DECIMAL(11, 5), DECIMAL(10, 6)}, DECIMAL(12, 6));
+        signature, {DECIMAL(11, 5), DECIMAL(10, 6)}, DECIMAL(13, 6));
   }
 
   // Decimal Multiply.
@@ -110,6 +110,28 @@ TEST(SignatureBinderTest, decimals) {
         signature,
         {SHORT_DECIMAL(11, 5), SHORT_DECIMAL(10, 6)},
         DECIMAL(10, 6));
+  }
+  // Aggregate Sum
+  {
+    auto signature = exec::AggregateFunctionSignatureBuilder()
+                         .argumentType("DECIMAL(a_precision, a_scale)")
+                         .intermediateType("DECIMAL(32, i_scale)")
+                         .variableConstraint("i_scale", "a_scale")
+                         .returnType("DECIMAL(32, r_scale)")
+                         .variableConstraint("r_scale", "a_scale")
+                         .build();
+
+    const std::vector<TypePtr> actualTypes{DECIMAL(10, 4)};
+    exec::SignatureBinder binder(*signature, actualTypes);
+    ASSERT_TRUE(binder.tryBind());
+
+    auto intermediateType =
+        binder.tryResolveType(signature->intermediateType());
+    ASSERT_TRUE(intermediateType != nullptr);
+    ASSERT_TRUE(DECIMAL(32, 4)->equivalent(*intermediateType));
+    auto returnType = binder.tryResolveReturnType();
+    ASSERT_TRUE(returnType != nullptr);
+    ASSERT_TRUE(DECIMAL(32, 4)->equivalent(*returnType));
   }
   // Error: missing constraint
   {

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -111,13 +111,13 @@ TEST(SignatureBinderTest, decimals) {
         {SHORT_DECIMAL(11, 5), SHORT_DECIMAL(10, 6)},
         DECIMAL(10, 6));
   }
-  // Aggregate Sum
+  // Aggregate Sum.
   {
     auto signature = exec::AggregateFunctionSignatureBuilder()
                          .argumentType("DECIMAL(a_precision, a_scale)")
-                         .intermediateType("DECIMAL(32, i_scale)")
+                         .intermediateType("DECIMAL(38, i_scale)")
                          .variableConstraint("i_scale", "a_scale")
-                         .returnType("DECIMAL(32, r_scale)")
+                         .returnType("DECIMAL(38, r_scale)")
                          .variableConstraint("r_scale", "a_scale")
                          .build();
 
@@ -128,10 +128,10 @@ TEST(SignatureBinderTest, decimals) {
     auto intermediateType =
         binder.tryResolveType(signature->intermediateType());
     ASSERT_TRUE(intermediateType != nullptr);
-    ASSERT_TRUE(DECIMAL(32, 4)->equivalent(*intermediateType));
+    ASSERT_TRUE(DECIMAL(38, 4)->equivalent(*intermediateType));
     auto returnType = binder.tryResolveReturnType();
     ASSERT_TRUE(returnType != nullptr);
-    ASSERT_TRUE(DECIMAL(32, 4)->equivalent(*returnType));
+    ASSERT_TRUE(DECIMAL(38, 4)->equivalent(*returnType));
   }
   // Error: missing constraint
   {


### PR DESCRIPTION
Extend Aggregate Function Signature to handle Decimal Types.
Add support for constants in the Decimal Type signature.
Example: `DECIMAL(38, i_scale)`
Fix a bug that was caught as the type check changed from `kindEquals -> equivalent`.
`equivalent` verifies decimal precision and scale values.