### PR TITLE
Fix PagedInputStream seek to uncompressed

### DIFF
--- a/velox/dwio/dwrf/common/PagedInputStream.h
+++ b/velox/dwio/dwrf/common/PagedInputStream.h
@@ -139,6 +139,9 @@ class PagedInputStream : public dwio::common::SeekableInputStream {
   // bytes returned by this stream
   uint64_t bytesReturned_{0};
 
+  // Size returned by the previous call to Next().
+  int32_t lastWindowSize_{0};
+
   // decompressor
   std::unique_ptr<Decompressor> decompressor_;
 


### PR DESCRIPTION
PagedinputStream returns data in chunkds delimited by headers. The
data belonging to a header is decrypted/decompressed and returned as a
contiguous window by Next. If the data is not compressed or encrypted
the data is returned in teh windows returned by the underlying
input. In the latter case, these windows are broken by compression
headers.  The window is returned up to the next header, then the data
between the next header and the next after tat is returned and so
on. The window of the original stream may divide the space between
headers.

Suppose a layout like:

header
10000 bytes
header
6000 bytes
window bound
4000 bytes
header
3000 bytes
window bound
7000 bytes
header
....

'window bound' marks the bound of windows returned by Next of the underlying input.

Now seek to the 24000th byte. This is 1000 bytes  into the run of 7000 bytes.
Then seek to the 22000th byte. This is  2000 bytes into the run of 3000 bytes.

This seek can't be made by subtracting
from the pointer because this would cross a window boundary from the underlying stream. So we seek must seek te underlying stream.

Therefore we add a member to track the last returned window size by
Next of PagedInputStream. If operating on uncompressed runs, we cannot
back up further than that but seek the underlying stream instead. If
operating on a decompression buffer, we can back up the length of the
decompression buffer.

Adds a test that checks various seeks inside and between windows
returned by PagedInputStream over uncompressed runs.