### PR TITLE
Simplify the spiller by picking up the partition with most data first

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -106,6 +106,11 @@ class QueryConfig {
 
   static constexpr const char* kTestingSpillPct = "testing.spill-pct";
 
+  static constexpr const char* kSpillPartitionBits = "spiller-partition-bits";
+
+  static constexpr const char* kSpillFileSizeFactor =
+      "spiller-file-size-factor";
+
   uint64_t maxPartialAggregationMemoryUsage() const {
     static constexpr uint64_t kDefault = 1L << 24;
     return get<uint64_t>(kMaxPartialAggregationMemory, kDefault);
@@ -209,6 +214,25 @@ class QueryConfig {
   // will be forced to spill for testing. 0 means no extra spilling.
   int32_t testingSpillPct() const {
     return get<int32_t>(kTestingSpillPct, 0);
+  }
+
+  /// Returns the number of bits used to calculate the spilling partition
+  /// number. The number of spilling partitions will be power of two.
+  ///
+  /// NOTE: as for now, we only support up to 8-way spill partitioning.
+  int32_t spillPartitionBits() const {
+    constexpr int32_t kDefaultBits = 2;
+    constexpr int32_t kMaxBits = 3;
+    return std::min(kMaxBits, get<int32_t>(kSpillPartitionBits, kDefaultBits));
+  }
+
+  /// Returns the factor used to determine the target spill file size based on
+  /// the spilling operator's memory usage. For instance, if the spilling
+  /// operator has used 1GB memory and this factor is 2, then the target spill
+  /// file size will be set to 512MB.
+  int32_t spillFileSizeFactor() const {
+    constexpr int32_t kDefaultFactor = 4;
+    return get<int32_t>(kSpillFileSizeFactor, kDefaultFactor);
   }
 
   bool exprTrackCpuUsage() const {

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -173,6 +173,11 @@ class GroupingSet {
   const std::vector<TypePtr> intermediateTypes_;
 
   const bool ignoreNullKeys_;
+
+  /// Parameters used for spilling control.
+  const int32_t spillPartitionBits_;
+  const int32_t spillFileSizeFactor_;
+
   memory::MappedMemory* FOLLY_NONNULL const mappedMemory_;
 
   // Boolean indicating whether accumulators for a global aggregation (i.e.
@@ -216,7 +221,6 @@ class GroupingSet {
 
   std::unique_ptr<Spiller> spiller_;
   std::unique_ptr<TreeOfLosers<SpillStream>> merge_;
-  RowContainerIterator spillIterator_;
 
   // Container for materializing batches of output from spilling.
   std::unique_ptr<RowContainer> mergeRows_;

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -136,15 +136,24 @@ int64_t SpillFileList::spilledBytes() const {
   return bytes;
 }
 
-void SpillState::setNumPartitions(int32_t numPartitions) {
-  VELOX_CHECK_LE(numPartitions, maxPartitions());
-  VELOX_CHECK_GT(numPartitions, numPartitions_, "May only add partitions");
-  numPartitions_ = numPartitions;
+std::vector<std::string> SpillFileList::TEST_spilledFiles() const {
+  std::vector<std::string> spilledFiles;
+  for (auto& file : files_) {
+    spilledFiles.push_back(file->TEST_filePath());
+  }
+  return spilledFiles;
+}
+
+void SpillState::setPartitionSpilled(int32_t partition) {
+  VELOX_DCHECK_LT(partition, maxPartitions_);
+  VELOX_DCHECK(!isPartitionSpilled_[partition]);
+  isPartitionSpilled_[partition] = true;
 }
 
 void SpillState::appendToPartition(
     int32_t partition,
     const RowVectorPtr& rows) {
+  VELOX_CHECK(isPartitionSpilled(partition));
   // Ensure that partition exist before writing.
   if (!files_.at(partition)) {
     files_[partition] = std::make_unique<SpillFileList>(
@@ -171,6 +180,7 @@ std::unique_ptr<TreeOfLosers<SpillStream>> SpillState::startMerge(
       result.push_back(std::move(file));
     }
   }
+  VELOX_DCHECK_EQ(!result.empty(), isPartitionSpilled(partition));
   if (extra) {
     result.push_back(std::move(extra));
   }
@@ -189,6 +199,30 @@ int64_t SpillState::spilledBytes() const {
     }
   }
   return bytes;
+}
+
+int64_t SpillState::spilledFiles() const {
+  int64_t numFiles = 0;
+  for (const auto& list : files_) {
+    if (list != nullptr) {
+      numFiles += list->spilledFiles();
+    }
+  }
+  return numFiles;
+}
+
+std::vector<std::string> SpillState::TEST_spilledFiles() const {
+  std::vector<std::string> spilledFiles;
+  for (const auto& list : files_) {
+    if (list != nullptr) {
+      const auto spilledFilesFromList = list->TEST_spilledFiles();
+      spilledFiles.insert(
+          spilledFiles.end(),
+          spilledFilesFromList.begin(),
+          spilledFilesFromList.end());
+    }
+  }
+  return spilledFiles;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1098,10 +1098,9 @@ TEST_F(AggregationTest, spillWithEmptyPartition) {
   constexpr int64_t kMaxBytes = 20LL << 20; // 20 MB
   rowType_ = ROW({"c0", "a"}, {INTEGER(), VARCHAR()});
   // Used to calculate the aggregation spilling partition number.
-  //
-  // TODO: make the partition parameters configurable through query config.
-  const int kNumPartitions = 4;
+  const int kPartitionsBits = 2;
   const HashBitRange hashBits{29, 31};
+  const int kNumPartitions = hashBits.numPartitions();
   std::vector<uint64_t> hashes(1);
 
   for (int emptyPartitionNum : {0, 1, 3}) {
@@ -1179,6 +1178,9 @@ TEST_F(AggregationTest, spillWithEmptyPartition) {
                                .planNode())
             .queryCtx(queryCtx)
             .config(QueryConfig::kSpillPath, tempDirectory->path)
+            .config(
+                QueryConfig::kSpillPartitionBits,
+                std::to_string(kPartitionsBits))
             .assertResults(results);
 
     auto stats = task->taskStats().pipelineStats;

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -22,183 +22,334 @@
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
 using namespace facebook::velox::common::testutil;
+using facebook::velox::filesystems::FileSystem;
+
+namespace {
+struct TestParam {
+  Spiller::Type type;
+  // Specifies the spill executor pool size. If the size is zero, then spill
+  // write path is executed inline with spiller control code path.
+  int poolSize;
+
+  TestParam(Spiller::Type _type, int _poolSize)
+      : type(_type), poolSize(_poolSize) {}
+};
+
+std::vector<TestParam> getTestParams() {
+  std::vector<TestParam> params;
+  for (int i = 0; i < Spiller::kNumTypes; ++i) {
+    const auto type = static_cast<Spiller::Type>(i);
+    // TODO: add to test kHashJoin after it is supported.
+    if (type == Spiller::Type::kHashJoin) {
+      continue;
+    }
+    for (int poolSize : {0, 8}) {
+      params.emplace_back(type, poolSize);
+    }
+  }
+  return params;
+}
+
+// Set sequential value in a given child vector. 'value' is the starting value.
+void setSequentialValue(
+    RowVectorPtr rowVector,
+    column_index_t childIndex,
+    int64_t value = 0) {
+  auto valueVector = rowVector->childAt(childIndex)->as<FlatVector<int64_t>>();
+  for (auto i = 0; i < valueVector->size(); ++i) {
+    valueVector->set(i, value + i);
+  }
+}
+} // namespace
 
 class SpillerTest : public exec::test::RowContainerTestBase,
-                    public testing::WithParamInterface<int> {
+                    public testing::WithParamInterface<TestParam> {
  public:
   static void SetUpTestCase() {
     TestValue::enable();
   }
 
+  SpillerTest()
+      : type_(GetParam().type),
+        executorPoolSize_(GetParam().poolSize),
+        hashBits_(0, type_ == Spiller::Type::kOrderBy ? 0 : 2),
+        numPartitions_(hashBits_.numPartitions()) {}
+
+  void SetUp() override {
+    RowContainerTestBase::SetUp();
+    tempDirPath_ = exec::test::TempDirectoryPath::create();
+    fs_ = filesystems::getFileSystem(tempDirPath_->path, nullptr);
+  }
+
  protected:
   void testSpill(int32_t spillPct, bool makeError = false) {
-    constexpr int32_t kNumRows = 100000;
-    std::vector<char*> rows(kNumRows);
-    RowVectorPtr batch;
-    auto data = makeSpillData(kNumRows, rows, batch);
-    std::vector<uint64_t> hashes(kNumRows);
-    auto keys = data->keyTypes();
-    // Calculate a hash for every key in 'rows'.
-    for (auto i = 0; i < keys.size(); ++i) {
-      data->hash(
-          i, folly::Range<char**>(rows.data(), kNumRows), i > 0, hashes.data());
+    constexpr int32_t kNumRows = 100'000;
+    std::shared_ptr<const RowType> rowType = ROW({
+        {"bool_val", BOOLEAN()},
+        {"tiny_val", TINYINT()},
+        {"small_val", SMALLINT()},
+        {"int_val", INTEGER()},
+        {"long_val", BIGINT()},
+        {"ordinal", BIGINT()},
+        {"float_val", REAL()},
+        {"double_val", DOUBLE()},
+        {"string_val", VARCHAR()},
+        {"array_val", ARRAY(VARCHAR())},
+        {"struct_val", ROW({{"s_int", INTEGER()}, {"s_array", ARRAY(REAL())}})},
+        {"map_val",
+         MAP(VARCHAR(),
+             MAP(BIGINT(),
+                 ROW({{"s2_int", INTEGER()}, {"s2_string", VARCHAR()}})))},
+    });
+    setupSpillData(rowType, 6, kNumRows, [&](RowVectorPtr rows) {
+      // Set ordinal so that the sorted order is unambiguous.
+      setSequentialValue(rows, 5);
+    });
+    sortSpillData();
+
+    setupSpiller(2'000'000, makeError);
+
+    // We spill spillPct% of the data in 10% increments.
+    runSpill(spillPct, 10, makeError);
+    if (makeError) {
+      return;
+    }
+    // Verify the spilled file exist on file system.
+    const int numSpilledFiles = spiller_->spilledFiles();
+    EXPECT_GT(numSpilledFiles, 0);
+    const auto spilledFileSet = spiller_->state().TEST_spilledFiles();
+    EXPECT_EQ(numSpilledFiles, spilledFileSet.size());
+
+    for (auto spilledFile : spilledFileSet) {
+      auto readFile = fs_->openFileForRead(spilledFile);
+      EXPECT_NE(readFile.get(), nullptr);
     }
 
-    // We divide the rows in 4 partitions according to 2 low bits of the hash.
-    std::vector<std::vector<int32_t>> partitions(4);
-    for (auto i = 0; i < kNumRows; ++i) {
-      partitions[hashes[i] & 3].push_back(i);
+    Spiller::SpillRows unspilledPartitionRows = spiller_->finishSpill();
+    if (spillPct == 100) {
+      EXPECT_TRUE(unspilledPartitionRows.empty());
+      EXPECT_EQ(0, rowContainer_->numRows());
+    }
+
+    verifySpillData();
+
+    spiller_.reset();
+    // Verify the spilled file has been removed from file system after spiller
+    // destruction.
+    for (auto spilledFile : spilledFileSet) {
+      EXPECT_ANY_THROW(fs_->openFileForRead(spilledFile));
+    }
+  }
+
+  void setupSpillData(
+      std::shared_ptr<const RowType> rowType,
+      int32_t numKeys,
+      int32_t numRows,
+      std::function<void(RowVectorPtr)> customizeData = {},
+      std::vector<int> numRowsPerPartition = {}) {
+    if (!numRowsPerPartition.empty()) {
+      int32_t totalCount = 0;
+      for (auto count : numRowsPerPartition) {
+        totalCount += count;
+      }
+      VELOX_CHECK_EQ(totalCount, numRows);
+    }
+
+    rowVector_ = BaseVector::create<RowVector>(rowType, numRows, pool_.get());
+
+    const SelectivityVector allRows(numRows);
+
+    const auto& childTypes = rowType->children();
+    std::vector<TypePtr> keys(childTypes.begin(), childTypes.begin() + numKeys);
+    std::vector<TypePtr> dependents;
+    if (numKeys < childTypes.size()) {
+      dependents.insert(
+          dependents.end(), childTypes.begin() + numKeys, childTypes.end());
+    }
+    // Make non-join build container so that spill runs are sorted. Note
+    // that a distinct or group by hash table can have dependents if
+    // some keys are known to be unique by themselves. Aggregation
+    // spilling will be tested separately.
+    rowContainer_ = makeRowContainer(keys, dependents, false);
+
+    // Setup temporary row to check spilling partition number.
+    char* testRow = rowContainer_->newRow();
+    std::vector<char*> testRows(1, testRow);
+    const auto testRowSet = folly::Range<char**>(testRows.data(), 1);
+    std::vector<uint64_t> hashes(1);
+
+    int numFilledRows = 0;
+    do {
+      RowVectorPtr batch = makeDataset(rowType, numRows, customizeData);
+      if (!numRowsPerPartition.empty()) {
+        SelectivityVector selectedRows(numRows);
+        for (int index = 0; index < numRows; ++index) {
+          for (int i = 0; i < keys.size(); ++i) {
+            DecodedVector decodedVector(*batch->childAt(i), allRows);
+            rowContainer_->store(decodedVector, index, testRow, i);
+            // Calculate hashes for this batch of spill candidates.
+            rowContainer_->hash(i, testRowSet, i > 0, hashes.data());
+          }
+          const int partitionNum =
+              hashBits_.partition(hashes[0], numPartitions_);
+          if (numRowsPerPartition[partitionNum] == 0) {
+            selectedRows.setValid(index, false);
+            continue;
+          }
+          --numRowsPerPartition[partitionNum];
+        }
+        selectedRows.updateBounds();
+        selectedRows.applyToSelected([&](auto row) {
+          rowVector_->copy(batch.get(), numFilledRows++, row, 1);
+        });
+      } else {
+        rowVector_ = batch;
+        numFilledRows += numRows;
+      }
+    } while (numFilledRows < numRows);
+    rowContainer_->clear();
+
+    rows_.resize(numRows);
+    for (int i = 0; i < numRows; ++i) {
+      rows_[i] = rowContainer_->newRow();
+    }
+
+    for (auto column = 0; column < rowVector_->childrenSize(); ++column) {
+      DecodedVector decoded(*rowVector_->childAt(column), allRows);
+      for (auto index = 0; index < numRows; ++index) {
+        rowContainer_->store(decoded, index, rows_[index], column);
+      }
+    }
+  }
+
+  void sortSpillData() {
+    partitions_.clear();
+    const auto numRows = rows_.size();
+    ASSERT_EQ(numRows, rowContainer_->numRows());
+    std::vector<uint64_t> hashes(numRows);
+    const auto& keys = rowContainer_->keyTypes();
+    // Calculate a hash for every key in 'rows'.
+    for (auto i = 0; i < keys.size(); ++i) {
+      rowContainer_->hash(
+          i, folly::Range<char**>(rows_.data(), numRows), i > 0, hashes.data());
+    }
+
+    partitions_.resize(numPartitions_);
+    for (auto i = 0; i < rowContainer_->numRows(); ++i) {
+      partitions_[hashBits_.partition(hashes[i], numPartitions_)].push_back(i);
     }
 
     // We sort the rows in each partition in key order.
-    for (auto& partition : partitions) {
+    for (auto& partition : partitions_) {
       std::sort(
           partition.begin(),
           partition.end(),
           [&](int32_t leftIndex, int32_t rightIndex) {
-            return data->compareRows(rows[leftIndex], rows[rightIndex]) < 0;
+            return rowContainer_->compareRows(
+                       rows_[leftIndex], rows_[rightIndex]) < 0;
           });
     }
+  }
 
-    auto tempDirectory = exec::test::TempDirectoryPath::create();
-    // We spill 'data' in 4 sorted partitions.
-    auto spiller = std::make_unique<Spiller>(
-        *data,
-        [&](folly::Range<char**> rows) { data->eraseRows(rows); },
-        std::static_pointer_cast<const RowType>(batch->type()),
-        HashBitRange(0, 2),
-        keys.size(),
-        makeError ? "/bad/path" : tempDirectory->path,
-        2000000,
+  void setupSpiller(int64_t targetFileSize, bool makeError) {
+    // We spill 'data' in one partition in type of kOrderBy, otherwise in 4
+    // partitions.
+    spiller_ = std::make_unique<Spiller>(
+        type_,
+        *rowContainer_,
+        [&](folly::Range<char**> rows) { rowContainer_->eraseRows(rows); },
+        asRowType(rowVector_->type()),
+        hashBits_,
+        rowContainer_->keyTypes().size(),
+        makeError ? "/bad/path" : tempDirPath_->path,
+        targetFileSize,
         *pool_,
         executor());
+    EXPECT_EQ(numPartitions_, spiller_->state().maxPartitions());
+  }
 
-    // We have a bit range of two bits , so up to 4 spilled partitions.
-    EXPECT_EQ(4, spiller->state().maxPartitions());
-
-    RowContainerIterator iter;
-
+  void runSpill(int32_t spillPct, int32_t incPct, bool expectedError) {
     // We spill spillPct% of the data in 10% increments.
-    auto initialBytes = data->allocatedBytes();
-    auto initialRows = data->numRows();
-    for (int32_t pct = 10; pct <= spillPct; pct += 10) {
+    auto initialBytes = rowContainer_->allocatedBytes();
+    auto initialRows = rowContainer_->numRows();
+    for (int32_t pct = incPct; pct <= spillPct; pct += incPct) {
       try {
-        spiller->spill(
+        spiller_->spill(
             initialRows - (initialRows * pct / 100),
-            initialBytes - (initialBytes * pct / 100),
-            iter);
-        EXPECT_FALSE(makeError);
+            initialBytes - (initialBytes * pct / 100));
+        EXPECT_FALSE(expectedError);
       } catch (const std::exception& e) {
-        if (!makeError) {
+        if (!expectedError) {
           throw;
         }
         return;
       }
     }
-    auto unspilledPartitionRows = spiller->finishSpill();
-    if (spillPct == 100) {
-      EXPECT_TRUE(unspilledPartitionRows.empty());
-      EXPECT_EQ(0, data->numRows());
-    }
+  }
+
+  void verifySpillData() {
     // We read back the spilled and not spilled data in each of the
     // partitions. We check that the data comes back in key order.
-    for (auto partitionIndex = 0; partitionIndex < 4; ++partitionIndex) {
-      if (!spiller->isSpilled(partitionIndex)) {
+    for (auto partitionIndex = 0; partitionIndex < numPartitions_;
+         ++partitionIndex) {
+      if (!spiller_->isSpilled(partitionIndex)) {
         continue;
       }
       // We make a merge reader that merges the spill files and the rows that
       // are still in the RowContainer.
-      auto merge = spiller->startMerge(partitionIndex);
+      auto merge = spiller_->startMerge(partitionIndex);
 
       // We read the spilled data back and check that it matches the sorted
       // order of the partition.
-      auto& indices = partitions[partitionIndex];
+      auto& indices = partitions_[partitionIndex];
       for (auto i = 0; i < indices.size(); ++i) {
         auto stream = merge->next();
         if (!stream) {
           FAIL() << "Stream ends after " << i << " entries";
           break;
         }
-        EXPECT_TRUE(batch->equalValueAt(
+        EXPECT_TRUE(rowVector_->equalValueAt(
             &stream->current(), indices[i], stream->currentIndex()));
         stream->pop();
       }
     }
   }
 
-  std::unique_ptr<RowContainer> makeSpillData(
-      int32_t numRows,
-      std::vector<char*>& rows,
-      RowVectorPtr& batch) {
-    batch = makeDataset(
-        ROW({
-            {"bool_val", BOOLEAN()},
-            {"tiny_val", TINYINT()},
-            {"small_val", SMALLINT()},
-            {"int_val", INTEGER()},
-            {"long_val", BIGINT()},
-            {"ordinal", BIGINT()},
-            {"float_val", REAL()},
-            {"double_val", DOUBLE()},
-            {"string_val", VARCHAR()},
-            {"array_val", ARRAY(VARCHAR())},
-            {"struct_val",
-             ROW({{"s_int", INTEGER()}, {"s_array", ARRAY(REAL())}})},
-            {"map_val",
-             MAP(VARCHAR(),
-                 MAP(BIGINT(),
-                     ROW({{"s2_int", INTEGER()}, {"s2_string", VARCHAR()}})))},
-        }),
-        numRows,
-        [](RowVectorPtr /*rows&*/) {});
-    const auto& types = batch->type()->as<TypeKind::ROW>().children();
-    std::vector<TypePtr> keys;
-    keys.insert(keys.begin(), types.begin(), types.begin() + 6);
-
-    std::vector<TypePtr> dependents;
-    dependents.insert(dependents.begin(), types.begin() + 6, types.end());
-    // Set ordinal so that the sorted order is unambiguous
-
-    auto ordinal = batch->childAt(5)->as<FlatVector<int64_t>>();
-    for (auto i = 0; i < numRows; ++i) {
-      ordinal->set(i, i);
-    }
-    // Make non-join build container so that spill runs are sorted. Note
-    // that a distinct or group by hash table can have dependents if
-    // some keys are known to be unique by themselves. Aggregation
-    // spilling will be tested separately.
-    auto data = makeRowContainer(keys, dependents, false);
-    rows.resize(numRows);
-    for (int i = 0; i < numRows; ++i) {
-      rows[i] = data->newRow();
-    }
-
-    SelectivityVector allRows(numRows);
-    for (auto column = 0; column < batch->childrenSize(); ++column) {
-      DecodedVector decoded(*batch->childAt(column), allRows);
-      for (auto index = 0; index < numRows; ++index) {
-        data->store(decoded, index, rows[index], column);
-      }
-    }
-
-    return data;
-  }
-
   folly::IOThreadPoolExecutor* executor() {
     static std::mutex mutex;
     std::lock_guard<std::mutex> l(mutex);
-    if (GetParam() == 0) {
+    if (executorPoolSize_ == 0) {
       return nullptr;
     }
     if (executor_ == nullptr) {
-      executor_ = std::make_unique<folly::IOThreadPoolExecutor>(GetParam());
+      executor_ =
+          std::make_unique<folly::IOThreadPoolExecutor>(executorPoolSize_);
     }
     return executor_.get();
   }
 
-  const int numPartitions_ = 4;
+  void reset() {
+    spiller_.reset();
+    rowContainer_.reset();
+    rowVector_.reset();
+    rows_.clear();
+    partitions_.clear();
+  }
+
+  const Spiller::Type type_;
+  const int executorPoolSize_;
+  const HashBitRange hashBits_;
+  const int numPartitions_;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
+  std::shared_ptr<TempDirectoryPath> tempDirPath_;
+  std::shared_ptr<FileSystem> fs_;
+  std::unique_ptr<RowContainer> rowContainer_;
+  RowVectorPtr rowVector_;
+  std::vector<char*> rows_;
+  std::vector<std::vector<int32_t>> partitions_;
+  std::unique_ptr<Spiller> spiller_;
 };
 
 TEST_P(SpillerTest, spilFew) {
@@ -217,28 +368,129 @@ TEST_P(SpillerTest, error) {
   testSpill(100, true);
 }
 
-#ifndef NDEBUG
-/// This test verifies if the spilling partition is incrementally added.
-TEST_P(SpillerTest, incrementalSpillRunCheck) {
-  if (GetParam() != 8) {
-    // Test with spill execution pool size of 8 is sufficient and skip the other
-    // test settings.
+TEST_P(SpillerTest, spillWithEmptyPartitions) {
+  if (type_ == Spiller::Type::kOrderBy) {
+    // kOrderBy type which has only one partition, is not relevant for this
+    // test.
     GTEST_SKIP();
   }
-  std::set<int> spillRunSizeSet;
-  SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::Spiller::spill",
-      std::function<void(const int*)>(
-          [&](const int* runSize) { spillRunSizeSet.emplace(*runSize); }));
-  testSpill(100);
-  // Spill all the data and expect the spill runs has been built up with one
-  // partition at a time.
-  EXPECT_EQ(numPartitions_, spillRunSizeSet.size());
-  EXPECT_EQ(1, *spillRunSizeSet.begin());
-  EXPECT_EQ(numPartitions_, *spillRunSizeSet.rbegin());
-}
-#endif
+  auto rowType = ROW({{"long_val", BIGINT()}, {"string_val", VARCHAR()}});
+  struct {
+    std::vector<int> rowsPerPartition;
 
-// Test with different spill executor pool size. If the size is zero, then spill
-// write path is executed inline with spiller control code path.
-VELOX_INSTANTIATE_TEST_SUITE_P(SpillerTest, SpillerTest, testing::Values(0, 8));
+    std::string debugString() const {
+      return fmt::format(
+          "rowsPerPartition: [{}]", folly::join(':', rowsPerPartition));
+    }
+  } testSettings[] = {
+      {{5000, 0, 0, 0}},
+      {{5'000, 5'000, 0, 1'000}},
+      {{5'000, 0, 5'000, 1'000}},
+      {{5'000, 1'000, 5'000, 0}}};
+  for (auto testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    reset();
+    int32_t numRows = 0;
+    for (const auto partitionRows : testData.rowsPerPartition) {
+      numRows += partitionRows;
+    }
+    int64_t outputIndex = 0;
+    setupSpillData(
+        rowType,
+        1,
+        numRows,
+        [&](RowVectorPtr rowVector) {
+          // Set ordinal so that the sorted order is unambiguous.
+          setSequentialValue(rowVector, 0, outputIndex);
+          outputIndex += rowVector->size();
+        },
+        testData.rowsPerPartition);
+    sortSpillData();
+    // Setup a large target file size and spill only once to ensure the number
+    // of spilled files matches the number of spilled partitions.
+    setupSpiller(2'000'000'000, false);
+    // We spill spillPct% of the data all at once.
+    runSpill(100, 100, false);
+
+    int32_t numNonEmptyPartitions = 0;
+    for (int partition = 0; partition < numPartitions_; ++partition) {
+      if (testData.rowsPerPartition[partition] != 0) {
+        ASSERT_TRUE(spiller_->state().isPartitionSpilled(partition));
+        ++numNonEmptyPartitions;
+      } else {
+        ASSERT_FALSE(spiller_->state().isPartitionSpilled(partition))
+            << partition;
+      }
+    }
+    const int numSpilledFiles = spiller_->spilledFiles();
+    ASSERT_EQ(numNonEmptyPartitions, numSpilledFiles);
+    // Expect no non-spilling partitions.
+    EXPECT_TRUE(spiller_->finishSpill().empty());
+    verifySpillData();
+    EXPECT_EQ(numRows, spiller_->spilledBytesAndRows().second);
+  }
+}
+
+TEST_P(SpillerTest, spillWithNonSpillingPartitions) {
+  if (type_ == Spiller::Type::kOrderBy) {
+    // kOrderBy type which has only one partition, is un-relevant for this test.
+    GTEST_SKIP();
+  }
+  std::shared_ptr<const RowType> rowType =
+      ROW({{"long_val", BIGINT()}, {"string_val", VARCHAR()}});
+  struct {
+    std::vector<int> rowsPerPartition;
+    int expectedSpillPartitionIndex;
+
+    std::string debugString() const {
+      return fmt::format(
+          "rowsPerPartition: [{}], expectedSpillPartitionIndex: {}",
+          folly::join(':', rowsPerPartition),
+          expectedSpillPartitionIndex);
+    }
+  } testSettings[] = {{{5'000, 1, 0, 0}, 0}, {{1, 1, 1, 5000}, 3}};
+  for (auto testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    reset();
+    int32_t numRows = 0;
+    for (const auto partitionRows : testData.rowsPerPartition) {
+      numRows += partitionRows;
+    }
+    int64_t outputIndex = 0;
+    setupSpillData(
+        rowType,
+        1,
+        numRows,
+        [&](RowVectorPtr rowVector) {
+          // Set ordinal so that the sorted order is unambiguous.
+          setSequentialValue(rowVector, 0, outputIndex);
+          outputIndex += rowVector->size();
+        },
+        testData.rowsPerPartition);
+    sortSpillData();
+    // Setup a large target file size and spill only once to ensure the number
+    // of spilled files matches the number of spilled partitions.
+    setupSpiller(2'000'000'000, false);
+    // We spill spillPct% of the data all at once.
+    runSpill(20, 20, false);
+
+    for (int partition = 0; partition < numPartitions_; ++partition) {
+      EXPECT_EQ(
+          testData.expectedSpillPartitionIndex == partition,
+          spiller_->state().isPartitionSpilled(partition));
+    }
+    ASSERT_EQ(1, spiller_->spilledFiles());
+    // Expect non-spilling partition.
+    EXPECT_FALSE(spiller_->finishSpill().empty());
+    verifySpillData();
+    EXPECT_LT(0, spiller_->spilledBytesAndRows().second);
+    EXPECT_GT(numRows, spiller_->spilledBytesAndRows().second);
+  }
+}
+
+// TODO: add duplicated sort key test cases.
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    SpillerTest,
+    SpillerTest,
+    testing::ValuesIn(getTestParams()));


### PR DESCRIPTION
Simplify and improve the spiller control:
(1) add spiller type to tell the different spilling use cases: kAggregate, kOrderBy, kHashJoin.
(2) skip sort for kHashJoin type of spilling
(3) skip the partition hash calculation as kOrderBy only uses one partition
(4) add query parameters to configure the number of partitions and the target spilling file size
(5) instead of incrementally selecting partition to spill based on partition number one at a time,
change to always select the one with most spillable data. Also for kHashJoin type, we will try to
be stick with spilling partition and only spill non-spilling partition if the existing ones have no
spillable data.

Improve the spilling related tests:
(1) add spilled files and cleanup check in SpillTest and SpillerTest
(2) add empty partition and non-spilling partition test cases in SpillerTest

Update coding style to add the naming convention for class test methods, e.g. TEST_foo()