### PR TITLE
Don't call ensureWritable on children when copying MapVectors/ArrayVectors

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -446,8 +446,6 @@ void ArrayVector::copy(
   VELOX_CHECK_EQ(sourceValue->encoding(), VectorEncoding::Simple::ARRAY);
   auto sourceArray = sourceValue->asUnchecked<ArrayVector>();
   VELOX_DCHECK(BaseVector::length_ >= targetIndex + count);
-  BaseVector::ensureWritable(
-      SelectivityVector::empty(), elements_->type(), pool(), &elements_);
   auto setNotNulls = mayHaveNulls() || source->mayHaveNulls();
   auto wantWidth = type()->isFixedWidth() ? type()->fixedElementsWidth() : 0;
   auto* mutableOffsets = offsets_->asMutable<vector_size_t>();
@@ -724,8 +722,6 @@ void MapVector::copy(
   VELOX_CHECK_EQ(sourceValue->encoding(), VectorEncoding::Simple::MAP);
   VELOX_DCHECK(BaseVector::length_ >= targetIndex + count);
   auto sourceMap = sourceValue->asUnchecked<MapVector>();
-  BaseVector::ensureWritable(
-      SelectivityVector::empty(), keys_->type(), pool(), &keys_);
   auto setNotNulls = mayHaveNulls() || source->mayHaveNulls();
   auto* mutableOffsets = offsets_->asMutable<vector_size_t>();
   auto* mutableSizes = sizes_->asMutable<vector_size_t>();


### PR DESCRIPTION
Summary:
Today, in the implementations of the copy function in MapVectors/ArrayVectors we (mostly) call
ensureWritable on the children first.

This gets very expensive, especially when calling copy on nested Maps/Arrays, we end up calling
ensureWritable many times on the same vectors.

I don't think it's unreasonable to expect the user to call ensureWritable on the MapVectors/ArrayVectors
before calling copy (we expect the same when calling other write operations).  They're in a better
position to ensure it's only called once.

I also noticed that MapVector calls ensureWritable on the keys but not the values, which makes me think
that users are already handling it themselves.

I did not make the same change in RowVector because unlike Arrays and Maps are fixed length, so
RowVectors copy function relies on ensureWritable to resize the children vectors (ArrayVectors and
MapVectors call ensureWritable with a size of 0 today and explicitly resize later).

CopyBenchmark before:
```
============================================================================
velox/vector/benchmarks/CopyBenchmark.cpp     relative  time/iter   iters/s
============================================================================
copyArray                                                   5.73ns   174.48M
copyArrayWithNulls                                          9.83ns   101.72M
copyArrayDictionaryEncoded                                 28.51ns    35.08M
copyArrayOneAtATime                                        58.40ns    17.12M
copyArrayTwoAtATime                                        35.69ns    28.02M
copyMap                                                     7.23ns   138.36M
copyMapWithNulls                                            9.67ns   103.45M
copyMapDictionaryEncoded                                   51.55ns    19.40M
copyMapOneAtATime                                          73.31ns    13.64M
copyMapTwoAtATime                                          45.61ns    21.93M
```

CopyBenchmark after:
```
============================================================================
velox/vector/benchmarks/CopyBenchmark.cpp     relative  time/iter   iters/s
============================================================================
copyArray                                                   5.45ns   183.51M
copyArrayWithNulls                                          8.88ns   112.63M
copyArrayDictionaryEncoded                                 27.56ns    36.28M
copyArrayOneAtATime                                        26.98ns    37.07M
copyArrayTwoAtATime                                        21.96ns    45.53M
copyMap                                                     7.30ns   136.90M
copyMapWithNulls                                            9.49ns   105.33M
copyMapDictionaryEncoded                                   51.62ns    19.37M
copyMapOneAtATime                                          40.65ns    24.60M
copyMapTwoAtATime                                          29.05ns    34.42M
```

Note that copyArrayOneAtATime is >2x faster.  copyMapOneAtATime is a little less than 2x faster, but I
suspect if it correctly called ensureWritable on the values before it would be significantly more so.

Differential Revision: D38291699

