### PR TITLE
Expose external memory reservation interface for MappedMemory

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/caching/AsyncDataCache.h"
+#include <velox/common/memory/MappedMemory.h>
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/SsdCache.h"
 
@@ -498,6 +499,15 @@ CachePin AsyncDataCache::findOrCreate(
 bool AsyncDataCache::exists(RawFileCacheKey key) const {
   int shard = std::hash<RawFileCacheKey>()(key) & (kShardMask);
   return shards_[shard]->exists(key);
+}
+
+bool AsyncDataCache::externalReserve(MachinePageCount numPages) {
+  return makeSpace(
+      numPages, [&]() { return mappedMemory_->externalReserve(numPages); });
+}
+
+void AsyncDataCache::externalRelease(MachinePageCount numPages) {
+  mappedMemory_->externalRelease(numPages);
 }
 
 bool AsyncDataCache::makeSpace(

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -603,6 +603,10 @@ class AsyncDataCache : public memory::MappedMemory {
   // Returns true if there is an entry for 'key'. Updates access time.
   bool exists(RawFileCacheKey key) const;
 
+  bool externalReserve(memory::MachinePageCount numPages) override;
+
+  void externalRelease(memory::MachinePageCount numPages) override;
+
   bool allocate(
       memory::MachinePageCount numPages,
       int32_t owner,

--- a/velox/common/memory/MappedMemory.cpp
+++ b/velox/common/memory/MappedMemory.cpp
@@ -147,6 +147,19 @@ class MappedMemoryImpl : public MappedMemory {
         allocation.size(), [&]() { freeContiguousImpl(allocation); });
   }
 
+  bool externalReserve(MachinePageCount numPages) override {
+    numAllocated_ += numPages;
+    numMapped_ += numPages;
+    return true;
+  }
+
+  void externalRelease(MachinePageCount numPages) override {
+    VELOX_CHECK_GE(numAllocated_, numPages);
+    VELOX_CHECK_GE(numMapped_, numPages);
+    numAllocated_ -= numPages;
+    numMapped_ -= numPages;
+  }
+
   MachinePageCount numAllocated() const override {
     return numAllocated_;
   }

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -81,6 +81,10 @@ class MmapAllocator : public MappedMemory {
         allocation.size(), [&]() { freeContiguousImpl(allocation); });
   }
 
+  bool externalReserve(MachinePageCount numPages) override;
+
+  void externalRelease(MachinePageCount numPages) override;
+
   // Checks internal consistency of allocation data
   // structures. Returns true if OK. May return false if there are
   // concurrent alocations and frees during the consistency check. This
@@ -319,7 +323,7 @@ class MmapAllocator : public MappedMemory {
   std::atomic<MachinePageCount> numMapped_;
 
   // Number of pages allocated and explicitly mmap'd by the
-  // application via allocateContiguous, outside of
+  // application via allocateContiguous, or externalReserve outside of
   // 'sizeClasses'. These pages are counted in 'numAllocated_' and
   // 'numMapped_'. Allocation requests are decided against
   // 'numAllocated_' and 'numMapped_'. This counter is informational

--- a/velox/common/memory/tests/MappedMemoryTest.cpp
+++ b/velox/common/memory/tests/MappedMemoryTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/memory/MappedMemory.h"
+#include <velox/common/base/VeloxException.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/AllocationPool.h"
 #include "velox/common/memory/MmapAllocator.h"
@@ -429,6 +430,22 @@ TEST_P(MappedMemoryTest, increasingSizeWithThreadsTest) {
 
 TEST_P(MappedMemoryTest, scopedMemoryUsageTracking) {
   const int32_t numPages = 32;
+  const int32_t numReservedPages = 32;
+
+  {
+    // Test reserving exceeding tracker limit.
+    auto tracker = MemoryUsageTracker::create(
+        {MappedMemory::kPageSize,
+         MappedMemory::kPageSize,
+         MappedMemory::kPageSize});
+    auto mappedMemory = instance_->addChild(tracker);
+    EXPECT_THROW(
+        mappedMemory->externalReserve(numReservedPages), VeloxException);
+    EXPECT_EQ(mappedMemory->numAllocated(), 0);
+    EXPECT_EQ(mappedMemory->numMapped(), 0);
+    EXPECT_EQ(0, tracker->getCurrentUserBytes());
+  }
+
   {
     auto tracker = MemoryUsageTracker::create();
     auto mappedMemory = instance_->addChild(tracker);
@@ -437,11 +454,18 @@ TEST_P(MappedMemoryTest, scopedMemoryUsageTracking) {
 
     mappedMemory->allocate(numPages, 0, result);
     EXPECT_GE(result.numPages(), numPages);
+    EXPECT_EQ(mappedMemory->numAllocated(), result.numPages());
+
+    EXPECT_TRUE(mappedMemory->externalReserve(numReservedPages));
     EXPECT_EQ(
-        result.numPages() * MappedMemory::kPageSize,
+        mappedMemory->numAllocated(), result.numPages() + numReservedPages);
+    EXPECT_EQ(
+        (result.numPages() + numReservedPages) * MappedMemory::kPageSize,
         tracker->getCurrentUserBytes());
     mappedMemory->free(result);
+    mappedMemory->externalRelease(numReservedPages);
     EXPECT_EQ(0, tracker->getCurrentUserBytes());
+    EXPECT_EQ(mappedMemory->numAllocated(), 0);
   }
 
   auto tracker = MemoryUsageTracker::create();
@@ -488,6 +512,46 @@ TEST_P(MappedMemoryTest, minSizeClass) {
       tracker->getCurrentUserBytes());
   mappedMemory->free(result);
   EXPECT_EQ(0, tracker->getCurrentUserBytes());
+}
+
+TEST_P(MappedMemoryTest, externalReserve) {
+  constexpr int32_t kReserveSizeUnit = 16;
+  constexpr int32_t kNumReserves = 100;
+  EXPECT_TRUE(instance_->checkConsistency());
+
+  uint64_t totalReserved = 0;
+  uint64_t counter = 0;
+  for (int i = 1; i <= kNumReserves; i++) {
+    auto toReserve = kReserveSizeUnit * i;
+    if (totalReserved + toReserve > kCapacity) {
+      if (useMmap_) {
+        // Memory exceeding mapped memory cap will trigger first, as mmap
+        // allocator has a hard cap.
+        EXPECT_FALSE(instance_->externalReserve(toReserve));
+      } else {
+        // Memory exceeding memory tracker cap will trigger, as default mmap
+        // impl does not have a hard cap.
+        EXPECT_THROW(instance_->externalReserve(toReserve), VeloxException);
+      }
+      break;
+    }
+    EXPECT_TRUE(instance_->externalReserve(toReserve));
+    counter++;
+    totalReserved += toReserve;
+    EXPECT_EQ(instance_->numMapped(), totalReserved);
+    EXPECT_EQ(instance_->numAllocated(), totalReserved);
+    EXPECT_TRUE(instance_->checkConsistency());
+  }
+
+  for (int i = 1; i <= counter; i++) {
+    auto toReserve = kReserveSizeUnit * i;
+    EXPECT_NO_THROW(instance_->externalRelease(toReserve));
+    totalReserved -= toReserve;
+    EXPECT_EQ(instance_->numMapped(), totalReserved);
+    EXPECT_EQ(instance_->numAllocated(), totalReserved);
+    EXPECT_TRUE(instance_->checkConsistency());
+  }
+  EXPECT_THROW(instance_->externalRelease(kReserveSizeUnit), VeloxException);
 }
 
 TEST_P(MappedMemoryTest, externalAdvise) {


### PR DESCRIPTION
Summary: Adds externalReserve(pages) API to allocators. This allows tracking externally allocated memory without sparing resources to do actual allocations.

Differential Revision: D38255367

