### PR TITLE
Fix RowVector::copy() when source is a null constant

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -189,14 +189,12 @@ void RowVector::copy(
           rowSource->childAt(i)->loadedVector(), nonNullRows, toSourceRow);
     }
   } else {
-    auto nullIndices = decodedSource.nullIndices();
     auto nulls = decodedSource.nulls();
 
     if (nulls) {
       rows.applyToSelected([&](auto row) {
         auto idx = toSourceRow ? toSourceRow[row] : row;
-        idx = nullIndices ? nullIndices[idx] : idx;
-        if (bits::isBitNull(nulls, idx)) {
+        if (bits::isBitNull(nulls, decodedSource.nullIndex(idx))) {
           nonNullRows.setValid(row, false);
         }
       });

--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -91,13 +91,18 @@ class DecodedVector {
 
   /// Returns the raw nulls buffer for the base vector combined with nulls found
   /// in dictionary wrappings. May return nullptr if there are no nulls. Use
-  /// nullIndices() to access individual null flags, e.g.
+  /// nullIndex() to access individual null flags, e.g.
   ///
-  ///  nulls() ? bits::isBitNull(nulls(), nullIndices() ? nullIndices[i] : i) :
-  ///  false
+  ///  nulls() ? bits::isBitNull(nulls(), decoded.nullIndex(i)) : false
   ///
   /// returns the null flag for top-level row 'i' given that 'i' is one of the
   /// rows specified for decoding.
+  ///
+  /// When isConstantMapping() == false, may also use nullIndices() which may be
+  /// a little faster than nullIndex().
+  ///
+  ///  nulls() ? bits::isBitNull(nulls(), nullIndices() ? nullIndices[i] : i) :
+  ///  false
   const uint64_t* nulls() const {
     return nulls_;
   }
@@ -111,12 +116,15 @@ class DecodedVector {
     return &indices_[0];
   }
 
+  /// Available only if isConstantMapping() == false.
   /// Returns the mapping from top-level rows to entries in nulls() buffer.
   /// Returns nullptr if mapping is identity.
   const vector_size_t* nullIndices() {
     if (hasExtraNulls_) {
       return nullptr;
     }
+
+    VELOX_CHECK(!isConstantMapping_);
     return indices_;
   }
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -445,7 +445,6 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     auto base = decoded.base();
     auto nulls = decoded.nulls();
     auto indices = decoded.indices();
-    auto nullIndices = decoded.nullIndices();
     for (int32_t i = 0; i < sourceSize; ++i) {
       if (i % 2 == 0) {
         auto sourceIdx = evenSource[i];
@@ -454,9 +453,7 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
             << source->toString(sourceIdx);
 
         // We check the same with 'decoded'.
-        if (nulls &&
-            bits::isBitNull(
-                nulls, nullIndices ? nullIndices[sourceIdx] : sourceIdx)) {
+        if (nulls && bits::isBitNull(nulls, decoded.nullIndex(sourceIdx))) {
           EXPECT_TRUE(decoded.isNullAt(sourceIdx));
           EXPECT_TRUE(bits::isBitNull(flatNulls, sourceIdx));
           EXPECT_TRUE(target->isNullAt(i));
@@ -471,9 +468,7 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
         EXPECT_TRUE(target->equalValueAt(source.get(), i, oddSource[i]));
         // We check the same with 'decoded'.
         auto sourceIdx = oddSource[i];
-        if (nulls &&
-            bits::isBitNull(
-                nulls, nullIndices ? nullIndices[sourceIdx] : sourceIdx)) {
+        if (nulls && bits::isBitNull(nulls, decoded.nullIndex(sourceIdx))) {
           EXPECT_TRUE(bits::isBitNull(flatNulls, sourceIdx));
           EXPECT_TRUE(target->isNullAt(i));
         } else {
@@ -569,7 +564,7 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
           break;
         }
       }
-      constant = BaseVector::wrapInConstant(firstNull + 20, firstNull, source);
+      constant = BaseVector::wrapInConstant(firstNull + 123, firstNull, source);
       testCopy(constant, level - 1);
     }
 


### PR DESCRIPTION
RowVector::copy() was crashing when copying a null constant vector of size >
64. 

When decoding null constant, 
- DecodedVector::nulls() returns a pointer to a 64-bit buffer
  (&constantNullMask_) regardless of the size of the vector;
- DecodedVector::nullIndices() returns nullptr which indices that to access null
  flag in 'nulls' buffer one should use the top-level row number directly:
  `nulls[row]`

Since nulls buffer has only 64-its, accessing null bit for row number > 64 is
not valid and either causes a crash (if running with ASAN) or incorrect
results.

A fix implemented here is to 
- document that nullIndices() is available only when isConstantMapping() ==
  false and add a check for that;
- update RowVector::copy to use DecodedVector::nullIndex() instead of
  nullIndices.

Updated VectorTest to exercise the code path that used to trigger the bug.