### PR TITLE
Fix max_by UDF returning empty with non-positive DOUBLE comparison values

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -470,7 +470,7 @@ class MaxByAggregate : public MinMaxByAggregate<T, U> {
       typename AccumulatorTypeTraits<U>::AccumulatorType;
 
   explicit MaxByAggregate(TypePtr resultType)
-      : MinMaxByAggregate<T, U>(resultType, std::numeric_limits<U>::min()) {}
+      : MinMaxByAggregate<T, U>(resultType, std::numeric_limits<U>::lowest()) {}
 
   void addRawInput(
       char** groups,

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -122,7 +122,7 @@ class MinMaxByAggregationTestBase : public AggregationTestBase {
   // returned flat vector is in ascending order.
   template <typename T>
   FlatVectorPtr<T> buildDataVector() {
-    return makeFlatVector<T>(numValues_, [](auto row) { return row + 1; });
+    return makeFlatVector<T>(numValues_, [](auto row) { return row - 3; });
   }
 
   template <typename T>


### PR DESCRIPTION
The initialValue_ data member of MaxByAggregate is initialized to
std::numeric_limits<U>::min(), which is positive min instead of negative
min in the case of DOUBLE. This results in the max_by UDF returning empty
value if the comparison values/2nd param are all non-positive. This change
is to initialize initialValue_ to std::numeric_limits<U>::lowest()
which is negative min for all types.