### PR TITLE
Added onClearCb to SerializedPage for memory cleaning purpose (#824)

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/caching/AsyncDataCache.h"
+#include <velox/common/memory/MappedMemory.h>
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/SsdCache.h"
 
@@ -498,6 +499,15 @@ CachePin AsyncDataCache::findOrCreate(
 bool AsyncDataCache::exists(RawFileCacheKey key) const {
   int shard = std::hash<RawFileCacheKey>()(key) & (kShardMask);
   return shards_[shard]->exists(key);
+}
+
+bool AsyncDataCache::externalReserve(MachinePageCount numPages) {
+  return makeSpace(
+      numPages, [&]() { return mappedMemory_->externalReserve(numPages); });
+}
+
+void AsyncDataCache::externalRelease(MachinePageCount numPages) {
+  mappedMemory_->externalRelease(numPages);
 }
 
 bool AsyncDataCache::makeSpace(

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -603,6 +603,10 @@ class AsyncDataCache : public memory::MappedMemory {
   // Returns true if there is an entry for 'key'. Updates access time.
   bool exists(RawFileCacheKey key) const;
 
+  bool externalReserve(memory::MachinePageCount numPages) override;
+
+  void externalRelease(memory::MachinePageCount numPages) override;
+
   bool allocate(
       memory::MachinePageCount numPages,
       int32_t owner,

--- a/velox/common/memory/MappedMemory.cpp
+++ b/velox/common/memory/MappedMemory.cpp
@@ -147,6 +147,19 @@ class MappedMemoryImpl : public MappedMemory {
         allocation.size(), [&]() { freeContiguousImpl(allocation); });
   }
 
+  bool externalReserve(MachinePageCount numPages) override {
+    numAllocated_ += numPages;
+    numMapped_ += numPages;
+    return true;
+  }
+
+  void externalRelease(MachinePageCount numPages) override {
+    VELOX_CHECK_GE(numAllocated_, numPages);
+    VELOX_CHECK_GE(numMapped_, numPages);
+    numAllocated_ -= numPages;
+    numMapped_ -= numPages;
+  }
+
   MachinePageCount numAllocated() const override {
     return numAllocated_;
   }

--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -418,6 +418,16 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
       uint64_t size,
       uint64_t maxMallocSize = kMaxMallocBytes) noexcept;
 
+  // Reserves memory in page unit that is allocated externally. No actual
+  // allocations will be performed. Only the internal memory usage counters are
+  // increased according to the reservation request to indicate memory
+  // consumption so that additional reservations/allocations will respect this
+  // "taken" resource. Returns true if reservation is successful.
+  virtual bool externalReserve(MachinePageCount numPages) = 0;
+
+  // Paired with externalReserve() to release the reserved memory.
+  virtual void externalRelease(MachinePageCount numPages) = 0;
+
   // Checks internal consistency of allocation data
   // structures. Returns true if OK.
   virtual bool checkConsistency() const = 0;
@@ -549,6 +559,28 @@ class ScopedMappedMemory final : public MappedMemory {
     parent_->freeContiguous(allocation);
     if (tracker_) {
       tracker_->update(-size);
+    }
+  }
+
+  bool externalReserve(MachinePageCount numPages) override {
+    if (parent_->externalReserve(numPages)) {
+      if (tracker_) {
+        try {
+          tracker_->update(numPages * kPageSize);
+        } catch (const std::exception& e) {
+          parent_->externalRelease(numPages);
+          std::rethrow_exception(std::current_exception());
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  void externalRelease(MachinePageCount numPages) override {
+    parent_->externalRelease(numPages);
+    if (tracker_) {
+      tracker_->update(-numPages * kPageSize);
     }
   }
 

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -81,6 +81,10 @@ class MmapAllocator : public MappedMemory {
         allocation.size(), [&]() { freeContiguousImpl(allocation); });
   }
 
+  bool externalReserve(MachinePageCount numPages) override;
+
+  void externalRelease(MachinePageCount numPages) override;
+
   // Checks internal consistency of allocation data
   // structures. Returns true if OK. May return false if there are
   // concurrent alocations and frees during the consistency check. This
@@ -319,7 +323,7 @@ class MmapAllocator : public MappedMemory {
   std::atomic<MachinePageCount> numMapped_;
 
   // Number of pages allocated and explicitly mmap'd by the
-  // application via allocateContiguous, outside of
+  // application via allocateContiguous, or externalReserve outside of
   // 'sizeClasses'. These pages are counted in 'numAllocated_' and
   // 'numMapped_'. Allocation requests are decided against
   // 'numAllocated_' and 'numMapped_'. This counter is informational

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -34,7 +34,8 @@ class SerializedPage {
   // TODO: consider to enforce setting memory pool if possible.
   explicit SerializedPage(
       std::unique_ptr<folly::IOBuf> iobuf,
-      memory::MemoryPool* pool = nullptr);
+      memory::MemoryPool* pool = nullptr,
+      std::function<void()> onClearCb = nullptr);
 
   ~SerializedPage();
 
@@ -69,6 +70,7 @@ class SerializedPage {
   // Number of payload bytes in 'iobuf_'.
   const int64_t iobufBytes_;
   memory::MemoryPool* pool_{nullptr};
+  std::function<void()> onClearCb_{nullptr};
 };
 
 // Queue of results retrieved from source. Owned by shared_ptr by


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/presto_cpp/pull/824

Allow callers to provide a callback for cleaning up any uncleaned memory usage from the iobuf. This will be used to support memory tracking.

Differential Revision: D38255368

