### PR TITLE
Add missing bison and flex dependencies on setup-ubuntu.sh

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -49,7 +49,9 @@ sudo apt install -y \
   libre2-dev \
   libsnappy-dev \
   liblzo2-dev \
-  protobuf-compiler
+  protobuf-compiler \
+  bison \
+  flex
 
 function run_and_time {
   time "$@"


### PR DESCRIPTION
It seems that when adding the bison and flex dependencies on this PR https://github.com/facebookincubator/velox/pull/1693 we missed to update the setup-ubuntu.sh script.
I have found the following errors when building locally:
```
CMake Error at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find BISON (missing: BISON_EXECUTABLE) (Required is at least
  version "3.0.4")
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.22/Modules/FindBISON.cmake:306 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:361 (find_package)

```
and
```
CMake Error at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find FLEX (missing: FLEX_EXECUTABLE) (Required is at least
  version "2.5.13")
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.22/Modules/FindFLEX.cmake:264 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:362 (find_package)

```
The patch solves the issue.