### PR TITLE
Improve getDecimalPrecisionScale API

### DIFF
--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -77,8 +77,7 @@ bool SignatureBinder::tryBind(
     if (isDecimalKind(actualType->kind()) && isCommonDecimalName(typeName)) {
       const auto& variables = typeSignature.variables();
       VELOX_CHECK_EQ(variables.size(), 2);
-      int precision, scale;
-      getDecimalPrecisionScale(*actualType.get(), precision, scale);
+      const auto& [precision, scale] = getDecimalPrecisionScale(*actualType);
       variables_.emplace(variables[0], precision);
       variables_.emplace(variables[1], scale);
       return true;

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -121,18 +121,14 @@ std::string mapTypeKindToName(const TypeKind& typeKind) {
   return found->second;
 }
 
-void getDecimalPrecisionScale(const Type& type, int& precision, int& scale) {
-  VELOX_CHECK(isDecimalKind(type.kind()));
-  if (type.kind() == TypeKind::SHORT_DECIMAL) {
-    const ShortDecimalType* decimalType =
-        static_cast<const ShortDecimalType*>(&type);
-    precision = decimalType->precision();
-    scale = decimalType->scale();
+const std::pair<int, int> getDecimalPrecisionScale(const Type& type) {
+  VELOX_CHECK(type.isShortDecimal() || type.isLongDecimal());
+  if (type.isShortDecimal()) {
+    const auto& decimalType = type.asShortDecimal();
+    return {decimalType.precision(), decimalType.scale()};
   } else {
-    const LongDecimalType* decimalType =
-        static_cast<const LongDecimalType*>(&type);
-    precision = decimalType->precision();
-    scale = decimalType->scale();
+    const auto& decimalType = type.asLongDecimal();
+    return {decimalType.precision(), decimalType.scale()};
   }
 }
 

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -121,7 +121,7 @@ std::string mapTypeKindToName(const TypeKind& typeKind) {
   return found->second;
 }
 
-const std::pair<int, int> getDecimalPrecisionScale(const Type& type) {
+std::pair<int, int> getDecimalPrecisionScale(const Type& type) {
   VELOX_CHECK(type.isShortDecimal() || type.isLongDecimal());
   if (type.isShortDecimal()) {
     const auto& decimalType = type.asShortDecimal();

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -678,7 +678,7 @@ inline bool isDecimalName(const std::string& typeName) {
   return (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL");
 }
 
-void getDecimalPrecisionScale(const Type& type, int& precision, int& scale);
+const std::pair<int, int> getDecimalPrecisionScale(const Type& type);
 
 class UnknownType : public TypeBase<TypeKind::UNKNOWN> {
  public:

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -678,7 +678,7 @@ inline bool isDecimalName(const std::string& typeName) {
   return (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL");
 }
 
-const std::pair<int, int> getDecimalPrecisionScale(const Type& type);
+std::pair<int, int> getDecimalPrecisionScale(const Type& type);
 
 class UnknownType : public TypeBase<TypeKind::UNKNOWN> {
  public:


### PR DESCRIPTION
getDecimalPrecisionScale now returns a `std::pair<precision, scale>`