### PR TITLE
Fix compiler error on uninitialized warning

### DIFF
--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -656,7 +656,7 @@ TEST_F(AggregationTest, setNull) {
       RowContainer::nullByte(nullOffset),
       RowContainer::nullMask(nullOffset),
       0);
-  char group = 0;
+  char group{0};
   aggregate.clearNullTest(&group);
   EXPECT_FALSE(aggregate.isNullTest(&group));
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -656,7 +656,7 @@ TEST_F(AggregationTest, setNull) {
       RowContainer::nullByte(nullOffset),
       RowContainer::nullMask(nullOffset),
       0);
-  char group;
+  char group = 0;
   aggregate.clearNullTest(&group);
   EXPECT_FALSE(aggregate.isNullTest(&group));
 


### PR DESCRIPTION
Hi,
I've already pushed a minor PR to add a couple of missing dependencies to `setup-ubuntu.sh` here: https://github.com/facebookincubator/velox/pull/2177
I am building VELOX from main using the following on Ubuntu 22.04 :
```
$ ./scripts/setup-ubuntu.sh
$ make
```
and I am getting this error:
```
/velox/velox/exec/tests/AggregationTest.cpp:659:8: error: 'group' is used uninitialized [-Werror=uninitialized]
  659 |   char group;
      |        ^~~~~
```
The test here https://github.com/facebookincubator/velox/blob/main/velox/exec/tests/AggregationTest.cpp#L651-L670 is not initializing the char and we are using `-Werror=uninitialized`. I could change CMake to add `-Wno-uninitialized` on the `KNOWN_COMPILER_SPECIFIC_WARNINGS` here: https://github.com/facebookincubator/velox/blob/main/CMakeLists.txt#L209 but I think the fix should just be:
```
diff --git a/velox/exec/tests/AggregationTest.cpp b/velox/exec/tests/AggregationTest.cpp
index 57f8478..8e78acb 100644
--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -656,7 +656,7 @@ TEST_F(AggregationTest, setNull) {
       RowContainer::nullByte(nullOffset),
       RowContainer::nullMask(nullOffset),
       0);
-  char group;
+  char group = 0;
   aggregate.clearNullTest(&group);
   EXPECT_FALSE(aggregate.isNullTest(&group));
```
My CPP skills aren't the best. Let me know if you think there is a better approach to fix this.
Thanks,
Raúl