### PR TITLE
Add utility docker and docker-compose way of building VELOX

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ Note that,
   * On ARM
     * Neon
 
+### Building Velox with docker-compose
+
+If you don't want to install the system dependencies required to build Velox,
+you can also build and run tests for Velox on a docker container
+using [docker-compose](https://docs.docker.com/compose/).
+Use the following commands:
+
+```shell
+$ docker-compose build ubuntu-cpp
+$ docker-compose run ubuntu-cpp
+```
+
 ## Contributing
 
 Check our [contributing guide](CONTRIBUTING.md) to learn about how to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.5'
+
+services:  
+  ubuntu-cpp:
+    # Usage:
+    #   docker-compose build ubuntu-cpp
+    #   docker-compose run --rm ubuntu-cpp
+    # Parameters:
+    #   ARCH: amd64, arm64v8, s390x, ...
+    #   UBUNTU: 18.04, 20.04
+    image: facebookincubator/velox:amd64-ubuntu-22.04-cpp
+    build:
+      context: .
+      dockerfile: scripts/ubuntu-22.04-cpp.dockerfile
+    volumes:
+      - .:/velox:delegated
+    command: &cpp-command >
+      /bin/bash -c "
+        make && cd _build/release && ctest -j 16 -VV --output-on-failure"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 version: '3.5'
 
 services:  
@@ -16,4 +29,6 @@ services:
       - .:/velox:delegated
     command: &cpp-command >
       /bin/bash -c "
-        make && cd _build/release && ctest -j 16 -VV --output-on-failure"
+        make &&
+        cd _build/release &&
+        ctest -j 16 -VV --output-on-failure"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,6 @@ services:
     # Usage:
     #   docker-compose build ubuntu-cpp
     #   docker-compose run --rm ubuntu-cpp
-    # Parameters:
-    #   ARCH: amd64, arm64v8, s390x, ...
-    #   UBUNTU: 18.04, 20.04
     image: facebookincubator/velox:amd64-ubuntu-22.04-cpp
     build:
       context: .

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -27,7 +27,7 @@ NPROC=$(getconf _NPROCESSORS_ONLN)
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 
 # Install all velox and folly dependencies.
-sudo apt install -y \
+sudo --preserve-env apt install -y \
   g++ \
   cmake \
   ccache \
@@ -51,7 +51,8 @@ sudo apt install -y \
   liblzo2-dev \
   protobuf-compiler \
   bison \
-  flex
+  flex \
+  tzdata
 
 function run_and_time {
   time "$@"

--- a/scripts/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/ubuntu-22.04-cpp.dockerfile
@@ -12,14 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG base=amd64/ubuntu:22.04
+# Set a default timezone, can be overriden via ARG
+ARG tz="Europe/Madrid"
+
 FROM ${base}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && \
-      apt-get -y install sudo tzdata
+      apt-get -y install sudo
 
 ADD scripts /velox/scripts/
+
+# TZ and DEBIAN_FRONTEND="noninteractive"
+# are required to avoid tzdata installation
+# to prompt for region selection.
+ENV DEBIAN_FRONTEND="noninteractive" TZ=${tz}
 RUN /velox/scripts/setup-ubuntu.sh
 
 WORKDIR /velox

--- a/scripts/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/ubuntu-22.04-cpp.dockerfile
@@ -1,20 +1,16 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# Copyright (c) Facebook, Inc. and its affiliates.
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ARG base=amd64/ubuntu:22.04
 FROM ${base}
 

--- a/scripts/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/ubuntu-22.04-cpp.dockerfile
@@ -17,7 +17,7 @@ FROM ${base}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update && \
-      apt-get -y install sudo
+      apt-get -y install sudo tzdata
 
 ADD scripts /velox/scripts/
 RUN /velox/scripts/setup-ubuntu.sh

--- a/scripts/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/ubuntu-22.04-cpp.dockerfile
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG base=amd64/ubuntu:22.04
+FROM ${base}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+      apt-get -y install sudo
+
+ADD scripts /velox/scripts/
+RUN /velox/scripts/setup-ubuntu.sh
+
+WORKDIR /velox


### PR DESCRIPTION
This PR tries to add a utility docker and docker-compose way of building velox and running tests.
As a user I don't want to install system dependencies on my local machine. I would like to be able to build VELOX on a Docker container.

This PR requires the changes on:
https://github.com/facebookincubator/velox/pull/2177
and
https://github.com/facebookincubator/velox/pull/2180