### PR TITLE
Use right intermediate type to init Accumulator for float sum

### DIFF
--- a/velox/functions/prestosql/aggregates/SumAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumAggregate.h
@@ -139,6 +139,18 @@ class SumAggregate
   }
 };
 
+/// Override 'initializeNewGroups' for float values. Make sure to use 'double'
+/// to store the intermediate results in accumulator.
+template <>
+inline void SumAggregate<float, double, float>::initializeNewGroups(
+    char** groups,
+    folly::Range<const vector_size_t*> indices) {
+  exec::Aggregate::setAllNulls(groups, indices);
+  for (auto i : indices) {
+    *exec::Aggregate::value<double>(groups[i]) = 0;
+  }
+}
+
 /// Override 'extractValues' for single aggregation over float values.
 /// Make sure to correctly read 'float' value from 'double' accumulator.
 template <>

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -65,12 +65,26 @@ TEST_F(SumTest, sumTinyint) {
 }
 
 TEST_F(SumTest, sumDouble) {
-  auto rowType = ROW({"c0", "c1"}, {REAL(), DOUBLE()});
-  auto vectors = makeVectors(rowType, 1000, 10);
-  createDuckDbTable(vectors);
+  // Run the test multiple times to ease reproducing the issue:
+  // https://github.com/facebookincubator/velox/issues/2198
+  for (int iter = 0; iter < 3; ++iter) {
+    SCOPED_TRACE(fmt::format("test iterations: {}", iter));
+    auto rowType = ROW({"c0", "c1"}, {REAL(), DOUBLE()});
+    auto vectors = makeVectors(rowType, 1000, 10);
+    createDuckDbTable(vectors);
 
-  testAggregations(
-      vectors, {}, {"sum(c0)", "sum(c1)"}, "SELECT sum(c0), sum(c1) FROM tmp");
+    float sum = 0;
+    for (int i = 0; i < vectors.size(); ++i) {
+      for (int j = 0; j < vectors[0]->size(); ++j) {
+        sum += vectors[i]->childAt(0)->asFlatVector<float>()->valueAt(j);
+      }
+    }
+    testAggregations(
+        vectors,
+        {},
+        {"sum(c0)", "sum(c1)"},
+        "SELECT sum(c0), sum(c1) FROM tmp");
+  }
 }
 
 TEST_F(SumTest, sumWithMask) {


### PR DESCRIPTION
Fix the float sum aggregation by using the right type to initialize the accumulator. The current code uses the result type to initialize the accumulator for float sum which is incorrect. As the result type is float, however the actual accumulator type used to store the intermediate result is double. When we cast a double to float and initialize to zero, we only init the h32 part and l32 part is unchanged, we can easily reproduce this bug in SumDouble by re-running the test iterator multiple times and we see the float sum result just keep bumping up by test iterations: 1 X actual result, 2 X actual result, ...