### PR TITLE
Fix decoding multiple levels of dictionaries for empty rows

### DIFF
--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -197,6 +197,11 @@ void DecodedVector::combineWrappers(
 void DecodedVector::applyDictionaryWrapper(
     const BaseVector& dictionaryVector,
     const SelectivityVector& rows) {
+  if (!rows.hasSelections()) {
+    // No further processing is needed.
+    return;
+  }
+
   auto newIndices = dictionaryVector.wrapInfo()->as<vector_size_t>();
   auto newNulls = dictionaryVector.rawNulls();
   if (newNulls) {
@@ -231,6 +236,11 @@ void DecodedVector::applyDictionaryWrapper(
 void DecodedVector::applySequenceWrapper(
     const BaseVector& sequenceVector,
     const SelectivityVector& rows) {
+  if (!rows.hasSelections()) {
+    // No further processing is needed.
+    return;
+  }
+
   const auto* lengths = sequenceVector.wrapInfo()->as<vector_size_t>();
   auto newNulls = sequenceVector.rawNulls();
   if (newNulls) {


### PR DESCRIPTION
Decoding multiple levels of dictionaries for empty rows used to leave
DecodedVector in a bad state where DecodedVector::indices() method would
throw:

DecodedVector::indices_ must be set for non-constant non-consecutive mapping."
error.

This happened because DecodedVector::applyDictionaryWrapper would execute the
following code and set indices_ to null:

```
  if (indicesNotCopied()) {
    copiedIndices_.resize(size_);
    indices_ = copiedIndices_.data();
  }
```

Here, with size_ being 0,  copiedIndices_.data() returns null.