### PR TITLE
Move IOUtils to velox/common/base

### DIFF
--- a/velox/common/base/IOUtils.h
+++ b/velox/common/base/IOUtils.h
@@ -15,7 +15,10 @@
  */
 #pragma once
 
-namespace facebook::velox::aggregate {
+#include <cstdint>
+#include <cstring>
+
+namespace facebook::velox::common {
 struct OutputByteStream {
   explicit OutputByteStream(char* data, int32_t offset = 0)
       : data_(data), offset_{offset} {}
@@ -74,4 +77,4 @@ struct InputByteStream {
   const char* data_;
   int32_t offset_{0};
 };
-} // namespace facebook::velox::aggregate
+} // namespace facebook::velox::common

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/IOUtils.h"
 #include "velox/common/base/Macros.h"
 #include "velox/common/base/RandomUtil.h"
 #include "velox/common/memory/HashStringAllocator.h"
@@ -20,7 +21,6 @@
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/KllSketch.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
-#include "velox/functions/prestosql/aggregates/IOUtils.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
 
@@ -422,7 +422,7 @@ class ApproxPercentileAggregate : public exec::Aggregate {
         sizeof percentile_ + sizeof accuracy_ + digest.serializedByteSize();
     Buffer* buffer = result->getBufferWithSpace(size);
     char* data = buffer->asMutable<char>() + buffer->size();
-    OutputByteStream stream(data);
+    common::OutputByteStream stream(data);
     stream.appendOne(percentile_);
     stream.appendOne(accuracy_);
     digest.serialize(data + stream.offset());
@@ -432,7 +432,7 @@ class ApproxPercentileAggregate : public exec::Aggregate {
 
   const char* getDeserializedDigest(vector_size_t row) {
     auto data = decodedDigest_.valueAt<StringView>(row);
-    InputByteStream stream(data.data());
+    common::InputByteStream stream(data.data());
     auto percentile = stream.read<double>();
     checkSetPercentile(percentile);
     if (auto accuracy = stream.read<double>();

--- a/velox/functions/prestosql/hyperloglog/DenseHll.cpp
+++ b/velox/functions/prestosql/hyperloglog/DenseHll.cpp
@@ -16,7 +16,7 @@
 #include "velox/functions/prestosql/hyperloglog/DenseHll.h"
 #include <exception>
 #include <sstream>
-#include "velox/functions/prestosql/aggregates/IOUtils.h"
+#include "velox/common/base/IOUtils.h"
 #include "velox/functions/prestosql/hyperloglog/BiasCorrection.h"
 #include "velox/functions/prestosql/hyperloglog/HllUtils.h"
 
@@ -231,7 +231,7 @@ int64_t cardinalityImpl(const DenseHllView& hll) {
 }
 
 DenseHllView deserialize(const char* serialized) {
-  InputByteStream stream(serialized);
+  common::InputByteStream stream(serialized);
 
   auto version = stream.read<int8_t>();
   VELOX_CHECK_EQ(kPrestoDenseV2, version);
@@ -406,7 +406,7 @@ bool DenseHll::canDeserialize(const char* input, int size) {
     return false;
   }
 
-  InputByteStream stream(input);
+  common::InputByteStream stream(input);
   auto version = stream.read<int8_t>();
   if (kPrestoDenseV2 != version) {
     return false;
@@ -460,7 +460,7 @@ bool DenseHll::canDeserialize(const char* input, int size) {
 
 // static
 int8_t DenseHll::deserializeIndexBitLength(const char* input) {
-  InputByteStream stream(input);
+  common::InputByteStream stream(input);
   stream.read<int8_t>();
   return stream.read<int8_t>();
 }
@@ -477,7 +477,7 @@ void DenseHll::serialize(char* output) {
   // sort overflow arrays to get consistent serialization for equivalent HLLs
   sortOverflows();
 
-  OutputByteStream stream(output);
+  common::OutputByteStream stream(output);
   stream.appendOne(kPrestoDenseV2);
   stream.appendOne(indexBitLength_);
   stream.appendOne(baseline_);
@@ -540,7 +540,7 @@ void DenseHll::mergeWith(const DenseHll& other) {
 }
 
 void DenseHll::mergeWith(const char* serialized) {
-  InputByteStream stream(serialized);
+  common::InputByteStream stream(serialized);
 
   auto version = stream.read<int8_t>();
   VELOX_CHECK_EQ(kPrestoDenseV2, version);

--- a/velox/functions/prestosql/hyperloglog/SparseHll.cpp
+++ b/velox/functions/prestosql/hyperloglog/SparseHll.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/functions/prestosql/hyperloglog/SparseHll.h"
-#include "velox/functions/prestosql/aggregates/IOUtils.h"
+#include "velox/common/base/IOUtils.h"
 #include "velox/functions/prestosql/hyperloglog/HllUtils.h"
 
 namespace facebook::velox::aggregate::hll {
@@ -57,8 +57,8 @@ int searchIndex(
   return -(low + 1);
 }
 
-InputByteStream initializeInputStream(const char* serialized) {
-  InputByteStream stream(serialized);
+common::InputByteStream initializeInputStream(const char* serialized) {
+  common::InputByteStream stream(serialized);
 
   auto version = stream.read<int8_t>();
   VELOX_CHECK_EQ(kPrestoSparseV2, version);
@@ -111,7 +111,7 @@ int64_t SparseHll::cardinality(const char* serialized) {
 }
 
 void SparseHll::serialize(int8_t indexBitLength, char* output) const {
-  OutputByteStream stream(output);
+  common::OutputByteStream stream(output);
   stream.appendOne(kPrestoSparseV2);
   stream.appendOne(indexBitLength);
   stream.appendOne((int16_t)entries_.size());
@@ -127,7 +127,7 @@ std::string SparseHll::serializeEmpty(int8_t indexBitLength) {
   std::string serialized;
   serialized.resize(kSize);
 
-  OutputByteStream stream(serialized.data());
+  common::OutputByteStream stream(serialized.data());
   stream.appendOne(kPrestoSparseV2);
   stream.appendOne(indexBitLength);
   stream.appendOne((int16_t)0);


### PR DESCRIPTION
Summary: Move the dependency of `velox/functions/hyperloglog/...` to `velox/common/base/...` first.

Differential Revision: D38348583

