### PR TITLE
Add Decimal variant hash function

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -555,7 +555,14 @@ uint64_t variant::hash() const {
       return folly::Hash{}(
           timestampValue.getSeconds(), timestampValue.getNanos());
     }
-
+    case TypeKind::SHORT_DECIMAL: {
+      auto shortDecimalCapsule = value<TypeKind::SHORT_DECIMAL>();
+      return shortDecimalCapsule.hash();
+    }
+    case TypeKind::LONG_DECIMAL: {
+      auto longDecimalCapsule = value<TypeKind::LONG_DECIMAL>();
+      return longDecimalCapsule.hash();
+    }
     case TypeKind::MAP: {
       auto hasher = folly::Hash{};
       auto& mapVariant = value<TypeKind::MAP>();

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -562,11 +562,11 @@ uint64_t variant::hash() const {
           timestampValue.getSeconds(), timestampValue.getNanos());
     }
     case TypeKind::SHORT_DECIMAL: {
-      auto shortDecimalCapsule = value<TypeKind::SHORT_DECIMAL>();
+      auto& shortDecimalCapsule = value<TypeKind::SHORT_DECIMAL>();
       return shortDecimalCapsule.hash();
     }
     case TypeKind::LONG_DECIMAL: {
-      auto longDecimalCapsule = value<TypeKind::LONG_DECIMAL>();
+      auto& longDecimalCapsule = value<TypeKind::LONG_DECIMAL>();
       return longDecimalCapsule.hash();
     }
     case TypeKind::MAP: {

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -562,12 +562,10 @@ uint64_t variant::hash() const {
           timestampValue.getSeconds(), timestampValue.getNanos());
     }
     case TypeKind::SHORT_DECIMAL: {
-      auto& shortDecimalCapsule = value<TypeKind::SHORT_DECIMAL>();
-      return shortDecimalCapsule.hash();
+      return value<TypeKind::SHORT_DECIMAL>().hash();
     }
     case TypeKind::LONG_DECIMAL: {
-      auto& longDecimalCapsule = value<TypeKind::LONG_DECIMAL>();
-      return longDecimalCapsule.hash();
+      return value<TypeKind::LONG_DECIMAL>().hash();
     }
     case TypeKind::MAP: {
       auto hasher = folly::Hash{};

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -502,6 +502,12 @@ variant variant::create(const folly::dynamic& variantobj) {
 uint64_t variant::hash() const {
   uint64_t hash = 0;
   if (isNull()) {
+    if (kind_ == TypeKind::SHORT_DECIMAL) {
+      return value<TypeKind::SHORT_DECIMAL>().hash();
+    }
+    if (kind_ == TypeKind::LONG_DECIMAL) {
+      return value<TypeKind::LONG_DECIMAL>().hash();
+    }
     return folly::Hash{}(static_cast<int32_t>(kind_));
   }
 

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -161,7 +161,6 @@ struct DecimalCapsule {
       hash = folly::hash::hash_combine_generic(hasher, hasher(value()), hash);
     }
     return hash;
-    ;
   }
 };
 

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -154,10 +154,8 @@ struct DecimalCapsule {
   }
 
   size_t hash() const {
-    VELOX_CHECK(
-        unscaledValue.has_value(), "Unscaled value must be initialized");
     auto hasher = folly::Hash{};
-    auto unscaledValHash = hasher(unscaledValue.value());
+    auto unscaledValHash = hasValue() ? hasher(value()) : 0;
     auto precisionHash = hasher(precision);
     auto scaleHash = hasher(scale);
     auto combinedPrecisionScaleHash =

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -155,13 +155,13 @@ struct DecimalCapsule {
 
   size_t hash() const {
     auto hasher = folly::Hash{};
-    auto unscaledValHash = hasValue() ? hasher(value()) : 0;
-    auto precisionHash = hasher(precision);
-    auto scaleHash = hasher(scale);
-    auto combinedPrecisionScaleHash =
-        folly::hash::hash_combine_generic(hasher, precisionHash, scaleHash);
-    return folly::hash::hash_combine_generic(
-        hasher, unscaledValHash, combinedPrecisionScaleHash);
+    auto hash = folly::hash::hash_combine_generic(
+        hasher, hasher(precision), hasher(scale));
+    if (hasValue()) {
+      hash = folly::hash::hash_combine_generic(hasher, hasher(value()), hash);
+    }
+    return hash;
+    ;
   }
 };
 

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -152,6 +152,19 @@ struct DecimalCapsule {
     }
     return lhsIntegral < rhsIntegral;
   }
+
+  size_t hash() const {
+    VELOX_CHECK(
+        unscaledValue.has_value(), "Unscaled value must be initialized");
+    auto hasher = folly::Hash{};
+    auto unscaledValHash = hasher(unscaledValue.value());
+    auto precisionHash = hasher(precision);
+    auto scaleHash = hasher(scale);
+    auto combinedPrecisionScaleHash =
+        folly::hash::hash_combine_generic(hasher, precisionHash, scaleHash);
+    return folly::hash::hash_combine_generic(
+        hasher, unscaledValHash, combinedPrecisionScaleHash);
+  }
 };
 
 using ShortDecimalCapsule = DecimalCapsule<ShortDecimal>;

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -102,60 +102,66 @@ TEST(VariantTest, shortDecimal) {
   EXPECT_EQ(*v.inferType(), *shortDecimalType);
   EXPECT_EQ(v.toJson(), "1.234");
   // 1.2345
-  variant u1 = variant::shortDecimal(12345, DECIMAL(10, 4));
+  auto u1 = variant::shortDecimal(12345, DECIMAL(10, 4));
   // 1.2345 > 1.234
   EXPECT_LT(
       v.value<TypeKind::SHORT_DECIMAL>(), u1.value<TypeKind::SHORT_DECIMAL>());
   // 0.1234
-  variant u2 = variant::shortDecimal(1234, DECIMAL(10, 4));
+  auto u2 = variant::shortDecimal(1234, DECIMAL(10, 4));
   // 0.1234 < 1.234
   EXPECT_LT(
       u2.value<TypeKind::SHORT_DECIMAL>(), v.value<TypeKind::SHORT_DECIMAL>());
+}
 
-  // Hash test.
+TEST(VariantTest, shortDecimalHash) {
+  auto shortDecimalType = DECIMAL(10, 3);
+  auto v = variant::shortDecimal(1234, shortDecimalType);
   auto vValue = v.value<TypeKind::SHORT_DECIMAL>();
   auto vHash = v.hash();
-  // u2 and v differ in only precision.
-  EXPECT_NE(vHash, u2.hash());
 
-  // v2 and v differ only in scale.
+  // v and v1 differ in precision.
+  auto v1 =
+      variant::shortDecimal(vValue.value().unscaledValue(), DECIMAL(11, 3));
+  EXPECT_NE(vHash, v1.hash());
+
+  // v and v2 differ in scale.
   auto v2 =
       variant::shortDecimal(vValue.value().unscaledValue(), DECIMAL(10, 4));
-  EXPECT_NE(v2.hash(), vHash);
+  EXPECT_NE(vHash, v2.hash());
 
-  // v2 and v differ only in value.
-  v2 = variant::shortDecimal(123456, shortDecimalType);
-  EXPECT_NE(v2.hash(), vHash);
+  // v and v3 differ in value.
+  auto v3 = variant::shortDecimal(123456, shortDecimalType);
+  EXPECT_NE(vHash, v3.hash());
 
-  // v2 and v are exactly same.
-  v2 = variant::shortDecimal(vValue.value().unscaledValue(), shortDecimalType);
-  EXPECT_EQ(v2.hash(), vHash);
+  // v and v4 are exactly same.
+  auto v4 = v;
+  EXPECT_EQ(vHash, v4.hash());
 }
 
 TEST(VariantTest, shortDecimalNull) {
-  variant n1 = variant::shortDecimal(std::nullopt, DECIMAL(10, 5));
-  EXPECT_TRUE(n1.isNull());
-  EXPECT_EQ(n1.toJson(), "null");
-  EXPECT_EQ(*n1.inferType(), *DECIMAL(10, 5));
+  variant n = variant::shortDecimal(std::nullopt, DECIMAL(10, 5));
+  EXPECT_TRUE(n.isNull());
+  EXPECT_EQ(n.toJson(), "null");
+  EXPECT_EQ(*n.inferType(), *DECIMAL(10, 5));
   EXPECT_THROW(variant::null(TypeKind::SHORT_DECIMAL), VeloxException);
+  auto nHash = n.hash();
 
-  auto n1Hash = n1.hash();
-  // n1 and n2 differ only in scale.
+  // n and n1 differ in precision.
+  auto n1 = variant::shortDecimal(std::nullopt, DECIMAL(11, 5));
+  EXPECT_NE(nHash, n1.hash());
+
+  // n and n2 differ in scale.
   auto n2 = variant::shortDecimal(std::nullopt, DECIMAL(10, 4));
-  EXPECT_NE(n1Hash, n2.hash());
+  EXPECT_NE(nHash, n2.hash());
 
-  // n1 and n2 differ only in precision.
-  n2 = variant::shortDecimal(std::nullopt, DECIMAL(11, 5));
-  EXPECT_NE(n1Hash, n2.hash());
-
-  // n1 and n2 have same precision and scale.
-  n2 = variant::shortDecimal(std::nullopt, n1.inferType());
-  EXPECT_EQ(n1Hash, n2.hash());
+  // n and n3 have same precision and scale.
+  auto n3 = n;
+  EXPECT_EQ(nHash, n3.hash());
 }
 
 TEST(VariantTest, longDecimal) {
   auto longDecimalType = DECIMAL(20, 3);
-  variant v = variant::longDecimal(12345, longDecimalType);
+  auto v = variant::longDecimal(12345, longDecimalType);
   EXPECT_TRUE(v.hasValue());
   EXPECT_EQ(TypeKind::LONG_DECIMAL, v.kind());
   EXPECT_EQ(12345, v.value<TypeKind::LONG_DECIMAL>().value().unscaledValue());
@@ -164,55 +170,61 @@ TEST(VariantTest, longDecimal) {
   EXPECT_EQ(*v.inferType(), *longDecimalType);
   EXPECT_EQ(v.toJson(), "12.345");
   // 1.2345
-  variant u1 = variant::longDecimal(12345, DECIMAL(20, 4));
+  auto u1 = variant::longDecimal(12345, DECIMAL(20, 4));
   // 1.2345 < 12.345
   EXPECT_LT(
       u1.value<TypeKind::LONG_DECIMAL>(), v.value<TypeKind::LONG_DECIMAL>());
   // 12.3456
-  variant u2 = variant::longDecimal(123456, DECIMAL(20, 4));
+  auto u2 = variant::longDecimal(123456, DECIMAL(20, 4));
   // 12.3456 > 12.345
   EXPECT_LT(
       v.value<TypeKind::LONG_DECIMAL>(), u2.value<TypeKind::LONG_DECIMAL>());
+}
 
-  // Hash test.
+TEST(VariantTest, longDecimalHash) {
+  auto longDecimalType = DECIMAL(20, 3);
+  auto v = variant::longDecimal(12345, longDecimalType);
   auto vValue = v.value<TypeKind::LONG_DECIMAL>();
   auto vHash = vValue.hash();
-  // u1 and v differ in only precision.
-  EXPECT_NE(vHash, u1.hash());
 
-  // v2 and v differ only in scale.
+  // v and v1 differ in precision.
+  auto v1 =
+      variant::longDecimal(vValue.value().unscaledValue(), DECIMAL(21, 3));
+  EXPECT_NE(vHash, v1.hash());
+
+  // v and v2 differ in scale.
   auto v2 =
       variant::longDecimal(vValue.value().unscaledValue(), DECIMAL(20, 4));
-  EXPECT_NE(v2.hash(), vHash);
+  EXPECT_NE(vHash, v2.hash());
 
-  // v2 and v differ only in value.
-  v2 = variant::longDecimal(123456, longDecimalType);
-  EXPECT_NE(v2.hash(), vHash);
+  // v and v3 differ in value.
+  auto v3 = variant::longDecimal(123456, longDecimalType);
+  EXPECT_NE(vHash, v3.hash());
 
-  // v2 and v are exactly same.
-  v2 = variant::longDecimal(vValue.value().unscaledValue(), longDecimalType);
-  EXPECT_EQ(v2.hash(), vHash);
+  // v and v4 are exactly same.
+  auto v4 = v;
+  EXPECT_EQ(vHash, v4.hash());
 }
 
 TEST(VariantTest, longDecimalNull) {
-  variant n1 = variant::longDecimal(std::nullopt, DECIMAL(20, 5));
-  EXPECT_TRUE(n1.isNull());
-  EXPECT_EQ(n1.toJson(), "null");
-  EXPECT_EQ(*n1.inferType(), *DECIMAL(20, 5));
+  auto n = variant::longDecimal(std::nullopt, DECIMAL(20, 5));
+  EXPECT_TRUE(n.isNull());
+  EXPECT_EQ(n.toJson(), "null");
+  EXPECT_EQ(*n.inferType(), *DECIMAL(20, 5));
   EXPECT_THROW(variant::null(TypeKind::LONG_DECIMAL), VeloxException);
+  auto nHash = n.hash();
 
-  // n1 and n2 differ only in scale.
-  auto n1Hash = n1.hash();
+  // n and n1 differ only in precision.
+  auto n1 = variant::longDecimal(std::nullopt, DECIMAL(21, 5));
+  EXPECT_NE(nHash, n1.hash());
+
+  // n and n2 differ only in scale.
   auto n2 = variant::longDecimal(std::nullopt, DECIMAL(20, 4));
-  EXPECT_NE(n1Hash, n2.hash());
+  EXPECT_NE(nHash, n2.hash());
 
-  // n1 and n2 differ only in precision.
-  n2 = variant::longDecimal(std::nullopt, DECIMAL(21, 5));
-  EXPECT_NE(n1Hash, n2.hash());
-
-  // n1 and n2 have same precision and scale.
-  n2 = variant::longDecimal(std::nullopt, n1.inferType());
-  EXPECT_EQ(n1Hash, n2.hash());
+  // n and n3 have same precision and scale.
+  auto n3 = n;
+  EXPECT_EQ(nHash, n3.hash());
 }
 
 /// Test variant::equalsWithEpsilon by summing up large 64-bit integers (> 15

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -139,7 +139,7 @@ TEST(VariantTest, shortDecimalHash) {
 }
 
 TEST(VariantTest, shortDecimalNull) {
-  variant n = variant::shortDecimal(std::nullopt, DECIMAL(10, 5));
+  auto n = variant::shortDecimal(std::nullopt, DECIMAL(10, 5));
   EXPECT_TRUE(n.isNull());
   EXPECT_EQ(n.toJson(), "null");
   EXPECT_EQ(*n.inferType(), *DECIMAL(10, 5));
@@ -214,11 +214,11 @@ TEST(VariantTest, longDecimalNull) {
   EXPECT_THROW(variant::null(TypeKind::LONG_DECIMAL), VeloxException);
   auto nHash = n.hash();
 
-  // n and n1 differ only in precision.
+  // n and n1 differ in precision.
   auto n1 = variant::longDecimal(std::nullopt, DECIMAL(21, 5));
   EXPECT_NE(nHash, n1.hash());
 
-  // n and n2 differ only in scale.
+  // n and n2 differ in scale.
   auto n2 = variant::longDecimal(std::nullopt, DECIMAL(20, 4));
   EXPECT_NE(nHash, n2.hash());
 

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -114,32 +114,43 @@ TEST(VariantTest, shortDecimal) {
 
   // Hash test.
   auto vValue = v.value<TypeKind::SHORT_DECIMAL>();
-  auto vHash = vValue.hash();
-  auto u2Hash = u2.value<TypeKind::SHORT_DECIMAL>().hash();
+  auto vHash = v.hash();
+  auto u2Hash = u2.hash();
   // u2 and v differ in only precision.
   EXPECT_NE(vHash, u2Hash);
 
   // v2 and v differ only in scale.
   variant v2 =
       variant::shortDecimal(vValue.value().unscaledValue(), DECIMAL(10, 4));
-  EXPECT_NE(v2.value<TypeKind::SHORT_DECIMAL>().hash(), vHash);
+  EXPECT_NE(v2.hash(), vHash);
 
   // v2 and v differ only in value.
   v2 = variant::shortDecimal(123456, shortDecimalType);
-  EXPECT_NE(v2.value<TypeKind::SHORT_DECIMAL>().hash(), vHash);
+  EXPECT_NE(v2.hash(), vHash);
 
   // v2 and v are exactly same.
   v2 = variant::shortDecimal(vValue.value().unscaledValue(), shortDecimalType);
-  EXPECT_EQ(v2.value<TypeKind::SHORT_DECIMAL>().hash(), vHash);
+  EXPECT_EQ(v2.hash(), vHash);
 }
 
 TEST(VariantTest, shortDecimalNull) {
-  variant null = variant::shortDecimal(std::nullopt, DECIMAL(10, 5));
-  EXPECT_TRUE(null.isNull());
-  EXPECT_EQ(null.toJson(), "null");
-  EXPECT_EQ(*null.inferType(), *DECIMAL(10, 5));
+  variant n1 = variant::shortDecimal(std::nullopt, DECIMAL(10, 5));
+  EXPECT_TRUE(n1.isNull());
+  EXPECT_EQ(n1.toJson(), "null");
+  EXPECT_EQ(*n1.inferType(), *DECIMAL(10, 5));
   EXPECT_THROW(variant::null(TypeKind::SHORT_DECIMAL), VeloxException);
-  EXPECT_THROW(null.value<TypeKind::SHORT_DECIMAL>().hash(), VeloxException);
+
+  // n1 and n2 differ only in scale.
+  variant n2 = variant::shortDecimal(std::nullopt, DECIMAL(10, 4));
+  EXPECT_NE(n1.hash(), n2.hash());
+
+  // n1 and n2 differ only in precision.
+  n2 = variant::shortDecimal(std::nullopt, DECIMAL(11, 5));
+  EXPECT_NE(n1.hash(), n2.hash());
+
+  // n1 and n2 have same precision and scale.
+  n2 = variant::shortDecimal(std::nullopt, n1.inferType());
+  EXPECT_EQ(n1.hash(), n2.hash());
 }
 
 TEST(VariantTest, longDecimal) {
@@ -167,29 +178,40 @@ TEST(VariantTest, longDecimal) {
   auto vValue = v.value<TypeKind::LONG_DECIMAL>();
   auto vHash = vValue.hash();
   // u1 and v differ in only precision.
-  EXPECT_NE(vHash, u1.value<TypeKind::LONG_DECIMAL>().hash());
+  EXPECT_NE(vHash, u1.hash());
 
   // v2 and v differ only in scale.
   variant v2 =
       variant::longDecimal(vValue.value().unscaledValue(), DECIMAL(20, 4));
-  EXPECT_NE(v2.value<TypeKind::LONG_DECIMAL>().hash(), vHash);
+  EXPECT_NE(v2.hash(), vHash);
 
   // v2 and v differ only in value.
   v2 = variant::longDecimal(123456, longDecimalType);
-  EXPECT_NE(v2.value<TypeKind::LONG_DECIMAL>().hash(), vHash);
+  EXPECT_NE(v2.hash(), vHash);
 
   // v2 and v are exactly same.
   v2 = variant::longDecimal(vValue.value().unscaledValue(), longDecimalType);
-  EXPECT_EQ(v2.value<TypeKind::LONG_DECIMAL>().hash(), vHash);
+  EXPECT_EQ(v2.hash(), vHash);
 }
 
 TEST(VariantTest, longDecimalNull) {
-  variant null = variant::longDecimal(std::nullopt, DECIMAL(20, 5));
-  EXPECT_TRUE(null.isNull());
-  EXPECT_EQ(null.toJson(), "null");
-  EXPECT_EQ(*null.inferType(), *DECIMAL(20, 5));
+  variant n1 = variant::longDecimal(std::nullopt, DECIMAL(20, 5));
+  EXPECT_TRUE(n1.isNull());
+  EXPECT_EQ(n1.toJson(), "null");
+  EXPECT_EQ(*n1.inferType(), *DECIMAL(20, 5));
   EXPECT_THROW(variant::null(TypeKind::LONG_DECIMAL), VeloxException);
-  EXPECT_THROW(null.value<TypeKind::LONG_DECIMAL>().hash(), VeloxException);
+
+  // n1 and n2 differ only in scale.
+  variant n2 = variant::longDecimal(std::nullopt, DECIMAL(20, 4));
+  EXPECT_NE(n1.hash(), n2.hash());
+
+  // n1 and n2 differ only in precision.
+  n2 = variant::longDecimal(std::nullopt, DECIMAL(21, 5));
+  EXPECT_NE(n1.hash(), n2.hash());
+
+  // n1 and n2 have same precision and scale.
+  n2 = variant::longDecimal(std::nullopt, n1.inferType());
+  EXPECT_EQ(n1.hash(), n2.hash());
 }
 
 /// Test variant::equalsWithEpsilon by summing up large 64-bit integers (> 15

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -111,6 +111,26 @@ TEST(VariantTest, shortDecimal) {
   // 0.1234 < 1.234
   EXPECT_LT(
       u2.value<TypeKind::SHORT_DECIMAL>(), v.value<TypeKind::SHORT_DECIMAL>());
+
+  // Hash test.
+  auto vValue = v.value<TypeKind::SHORT_DECIMAL>();
+  auto vHash = vValue.hash();
+  auto u2Hash = u2.value<TypeKind::SHORT_DECIMAL>().hash();
+  // u2 and v differ in only precision.
+  EXPECT_NE(vHash, u2Hash);
+
+  // v2 and v differ only in scale.
+  variant v2 =
+      variant::shortDecimal(vValue.value().unscaledValue(), DECIMAL(10, 4));
+  EXPECT_NE(v2.value<TypeKind::SHORT_DECIMAL>().hash(), vHash);
+
+  // v2 and v differ only in value.
+  v2 = variant::shortDecimal(123456, shortDecimalType);
+  EXPECT_NE(v2.value<TypeKind::SHORT_DECIMAL>().hash(), vHash);
+
+  // v2 and v are exactly same.
+  v2 = variant::shortDecimal(vValue.value().unscaledValue(), shortDecimalType);
+  EXPECT_EQ(v2.value<TypeKind::SHORT_DECIMAL>().hash(), vHash);
 }
 
 TEST(VariantTest, shortDecimalNull) {
@@ -119,6 +139,7 @@ TEST(VariantTest, shortDecimalNull) {
   EXPECT_EQ(null.toJson(), "null");
   EXPECT_EQ(*null.inferType(), *DECIMAL(10, 5));
   EXPECT_THROW(variant::null(TypeKind::SHORT_DECIMAL), VeloxException);
+  EXPECT_THROW(null.value<TypeKind::SHORT_DECIMAL>().hash(), VeloxException);
 }
 
 TEST(VariantTest, longDecimal) {
@@ -141,6 +162,25 @@ TEST(VariantTest, longDecimal) {
   // 12.3456 > 12.345
   EXPECT_LT(
       v.value<TypeKind::LONG_DECIMAL>(), u2.value<TypeKind::LONG_DECIMAL>());
+
+  // Hash test.
+  auto vValue = v.value<TypeKind::LONG_DECIMAL>();
+  auto vHash = vValue.hash();
+  // u1 and v differ in only precision.
+  EXPECT_NE(vHash, u1.value<TypeKind::LONG_DECIMAL>().hash());
+
+  // v2 and v differ only in scale.
+  variant v2 =
+      variant::longDecimal(vValue.value().unscaledValue(), DECIMAL(20, 4));
+  EXPECT_NE(v2.value<TypeKind::LONG_DECIMAL>().hash(), vHash);
+
+  // v2 and v differ only in value.
+  v2 = variant::longDecimal(123456, longDecimalType);
+  EXPECT_NE(v2.value<TypeKind::LONG_DECIMAL>().hash(), vHash);
+
+  // v2 and v are exactly same.
+  v2 = variant::longDecimal(vValue.value().unscaledValue(), longDecimalType);
+  EXPECT_EQ(v2.value<TypeKind::LONG_DECIMAL>().hash(), vHash);
 }
 
 TEST(VariantTest, longDecimalNull) {
@@ -149,6 +189,7 @@ TEST(VariantTest, longDecimalNull) {
   EXPECT_EQ(null.toJson(), "null");
   EXPECT_EQ(*null.inferType(), *DECIMAL(20, 5));
   EXPECT_THROW(variant::null(TypeKind::LONG_DECIMAL), VeloxException);
+  EXPECT_THROW(null.value<TypeKind::LONG_DECIMAL>().hash(), VeloxException);
 }
 
 /// Test variant::equalsWithEpsilon by summing up large 64-bit integers (> 15

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -115,12 +115,11 @@ TEST(VariantTest, shortDecimal) {
   // Hash test.
   auto vValue = v.value<TypeKind::SHORT_DECIMAL>();
   auto vHash = v.hash();
-  auto u2Hash = u2.hash();
   // u2 and v differ in only precision.
-  EXPECT_NE(vHash, u2Hash);
+  EXPECT_NE(vHash, u2.hash());
 
   // v2 and v differ only in scale.
-  variant v2 =
+  auto v2 =
       variant::shortDecimal(vValue.value().unscaledValue(), DECIMAL(10, 4));
   EXPECT_NE(v2.hash(), vHash);
 
@@ -140,17 +139,18 @@ TEST(VariantTest, shortDecimalNull) {
   EXPECT_EQ(*n1.inferType(), *DECIMAL(10, 5));
   EXPECT_THROW(variant::null(TypeKind::SHORT_DECIMAL), VeloxException);
 
+  auto n1Hash = n1.hash();
   // n1 and n2 differ only in scale.
-  variant n2 = variant::shortDecimal(std::nullopt, DECIMAL(10, 4));
-  EXPECT_NE(n1.hash(), n2.hash());
+  auto n2 = variant::shortDecimal(std::nullopt, DECIMAL(10, 4));
+  EXPECT_NE(n1Hash, n2.hash());
 
   // n1 and n2 differ only in precision.
   n2 = variant::shortDecimal(std::nullopt, DECIMAL(11, 5));
-  EXPECT_NE(n1.hash(), n2.hash());
+  EXPECT_NE(n1Hash, n2.hash());
 
   // n1 and n2 have same precision and scale.
   n2 = variant::shortDecimal(std::nullopt, n1.inferType());
-  EXPECT_EQ(n1.hash(), n2.hash());
+  EXPECT_EQ(n1Hash, n2.hash());
 }
 
 TEST(VariantTest, longDecimal) {
@@ -181,7 +181,7 @@ TEST(VariantTest, longDecimal) {
   EXPECT_NE(vHash, u1.hash());
 
   // v2 and v differ only in scale.
-  variant v2 =
+  auto v2 =
       variant::longDecimal(vValue.value().unscaledValue(), DECIMAL(20, 4));
   EXPECT_NE(v2.hash(), vHash);
 
@@ -202,16 +202,17 @@ TEST(VariantTest, longDecimalNull) {
   EXPECT_THROW(variant::null(TypeKind::LONG_DECIMAL), VeloxException);
 
   // n1 and n2 differ only in scale.
-  variant n2 = variant::longDecimal(std::nullopt, DECIMAL(20, 4));
-  EXPECT_NE(n1.hash(), n2.hash());
+  auto n1Hash = n1.hash();
+  auto n2 = variant::longDecimal(std::nullopt, DECIMAL(20, 4));
+  EXPECT_NE(n1Hash, n2.hash());
 
   // n1 and n2 differ only in precision.
   n2 = variant::longDecimal(std::nullopt, DECIMAL(21, 5));
-  EXPECT_NE(n1.hash(), n2.hash());
+  EXPECT_NE(n1Hash, n2.hash());
 
   // n1 and n2 have same precision and scale.
   n2 = variant::longDecimal(std::nullopt, n1.inferType());
-  EXPECT_EQ(n1.hash(), n2.hash());
+  EXPECT_EQ(n1Hash, n2.hash());
 }
 
 /// Test variant::equalsWithEpsilon by summing up large 64-bit integers (> 15


### PR DESCRIPTION
The decimal variant hash function is required for the evaluation of ConstantTypedExpr.

