### PR TITLE
Update coding style with test method annotation

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -57,7 +57,11 @@ line width, indentation and ordering (for includes, using directives and etc). 
 * Use **snake_case** for namespace names and build targets
 * Use **UPPER_SNAKE_CASE** for macros.
 * Use **kPascalCase** for static constants and enumerators.
-
+* Use **testing** prefix for test only class methods, e.g. obj.testingFoo().
+  As much as possible, refrain from adding test methods, and test objects using
+  their public APIs. Only use test methods in rare edge cases where this is not
+  possible. For example, MemoryAllocator::testingSetFailureInjection() is used
+  to to inject various memory allocation failures to test error handling paths.
 
 ## Comments
 


### PR DESCRIPTION
Update coding style with test method annotation, e.g. if we want to add a test method say 'foo' to an object, we will name it with prefix TEST, TEST_foo.