### PR TITLE
Adjust DecodedVector APIs for ease of use

### DIFF
--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -116,7 +116,6 @@ vector_size_t processEncodedFilterResults(
   auto values = decoded.data<uint64_t>();
   auto nulls = decoded.nulls();
   auto indices = decoded.indices();
-  auto nullIndices = decoded.nullIndices();
 
   vector_size_t passed = 0;
   auto* rawSelected = filterEvalCtx.getRawSelectedIndices(size, pool);
@@ -124,8 +123,7 @@ vector_size_t processEncodedFilterResults(
   memset(rawSelectedBits, 0, bits::nbytes(size));
   for (int32_t i = 0; i < size; ++i) {
     auto index = indices[i];
-    auto nullIndex = nullIndices ? nullIndices[i] : i;
-    if ((!nulls || !bits::isBitNull(nulls, nullIndex)) &&
+    if ((!nulls || !bits::isBitNull(nulls, i)) &&
         bits::isBitSet(values, index)) {
       rawSelected[passed++] = i;
       bits::setBit(rawSelectedBits, i);

--- a/velox/expression/BooleanMix.cpp
+++ b/velox/expression/BooleanMix.cpp
@@ -101,11 +101,9 @@ BooleanMix getFlatBool(
       auto values = decoded.data<uint64_t>();
       auto nulls = decoded.nulls();
       auto indices = decoded.indices();
-      auto nullIndices = decoded.nullIndices();
       activeRows.applyToSelected([&](int32_t i) {
         auto index = indices[i];
-        bool isNull =
-            nulls && bits::isBitNull(nulls, nullIndices ? nullIndices[i] : i);
+        bool isNull = nulls && bits::isBitNull(nulls, i);
         if (mergeNullsToValues && nulls) {
           if (!isNull && bits::isBitSet(values, index)) {
             bits::setBit(valuesToSet, i);

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -474,7 +474,7 @@ SelectivityVector* translateToInnerRows(
   // indices for places that a dictionary sets to null are not
   // defined. Null adding dictionaries are not peeled off non
   // null-propagating Exprs.
-  auto flatNulls = decoded.nullIndices() != indices ? decoded.nulls() : nullptr;
+  auto flatNulls = decoded.hasExtraNulls() ? decoded.nulls() : nullptr;
 
   auto* newRows = newRowsHolder.get(baseSize, false);
   rows.applyToSelected([&](vector_size_t row) {

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -194,7 +194,7 @@ void RowVector::copy(
     if (nulls) {
       rows.applyToSelected([&](auto row) {
         auto idx = toSourceRow ? toSourceRow[row] : row;
-        if (bits::isBitNull(nulls, decodedSource.nullIndex(idx))) {
+        if (bits::isBitNull(nulls, idx)) {
           nonNullRows.setValid(row, false);
         }
       });

--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -105,6 +105,7 @@ void DecodedVector::reset(vector_size_t size) {
   indices_ = nullptr;
   data_ = nullptr;
   nulls_ = nullptr;
+  allNulls_.reset();
   baseVector_ = nullptr;
   mayHaveNulls_ = false;
   hasExtraNulls_ = false;
@@ -513,5 +514,35 @@ VectorPtr DecodedVector::wrap(
       std::move(wrapping.indices),
       rows.end(),
       std::move(data));
+}
+
+const uint64_t* DecodedVector::nulls() {
+  if (allNulls_.has_value()) {
+    return allNulls_.value();
+  }
+
+  if (hasExtraNulls_) {
+    allNulls_ = nulls_;
+  } else if (!nulls_ || size_ == 0) {
+    allNulls_ = nullptr;
+  } else {
+    if (isIdentityMapping_) {
+      allNulls_ = nulls_;
+    } else if (isConstantMapping_) {
+      copiedNulls_.resize(0);
+      copiedNulls_.resize(bits::nwords(size_), bits::kNull64);
+      allNulls_ = copiedNulls_.data();
+    } else {
+      // Copy base nulls.
+      copiedNulls_.resize(bits::nwords(size_));
+      auto* rawCopiedNulls = copiedNulls_.data();
+      for (auto i = 0; i < size_; ++i) {
+        bits::setNull(rawCopiedNulls, i, bits::isBitNull(nulls_, indices_[i]));
+      }
+      allNulls_ = copiedNulls_.data();
+    }
+  }
+
+  return allNulls_.value();
 }
 } // namespace facebook::velox

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -453,7 +453,7 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
             << source->toString(sourceIdx);
 
         // We check the same with 'decoded'.
-        if (nulls && bits::isBitNull(nulls, decoded.nullIndex(sourceIdx))) {
+        if (nulls && bits::isBitNull(nulls, sourceIdx)) {
           EXPECT_TRUE(decoded.isNullAt(sourceIdx));
           EXPECT_TRUE(bits::isBitNull(flatNulls, sourceIdx));
           EXPECT_TRUE(target->isNullAt(i));
@@ -468,7 +468,7 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
         EXPECT_TRUE(target->equalValueAt(source.get(), i, oddSource[i]));
         // We check the same with 'decoded'.
         auto sourceIdx = oddSource[i];
-        if (nulls && bits::isBitNull(nulls, decoded.nullIndex(sourceIdx))) {
+        if (nulls && bits::isBitNull(nulls, sourceIdx)) {
           EXPECT_TRUE(bits::isBitNull(flatNulls, sourceIdx));
           EXPECT_TRUE(target->isNullAt(i));
         } else {


### PR DESCRIPTION
* Remove DecodedVector::nullIndices() and nullIndex() methods.
* Change DecodedVector::nulls() method to return null buffer having one bit per
  top-level row. This method may return nullptr if there are no nulls.
* Add more tests.