### PR TITLE
Add BaseVector::toString(bool) API to print all layers of encodings

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -68,7 +68,7 @@ void printResults(const std::vector<RowVectorPtr>& results) {
       std::cout << vector->type()->asRow().toString() << std::endl;
       printType = false;
     }
-    for (size_t i = 0; i < vector->size(); ++i) {
+    for (vector_size_t i = 0; i < vector->size(); ++i) {
       std::cout << vector->toString(i) << std::endl;
     }
   }

--- a/velox/dwio/parquet/tests/ParquetReaderTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetReaderTestBase.h
@@ -60,10 +60,10 @@ class ParquetReaderTestBase : public testing::Test {
   void assertEqualVectorPart(
       const VectorPtr& expected,
       const VectorPtr& actual,
-      size_t offset) {
+      vector_size_t offset) {
     ASSERT_GE(expected->size(), actual->size() + offset);
     ASSERT_EQ(expected->typeKind(), actual->typeKind());
-    for (auto i = 0; i < actual->size(); i++) {
+    for (vector_size_t i = 0; i < actual->size(); i++) {
       ASSERT_TRUE(expected->equalValueAt(actual.get(), i + offset, i))
           << "at " << (i + offset) << ": expected "
           << expected->toString(i + offset) << ", but got "

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -159,7 +159,7 @@ int main(int argc, char** argv) {
 
   // Print the output vector, just for fun:
   const auto& outputVector = result.front();
-  for (size_t i = 0; i < outputVector->size(); ++i) {
+  for (vector_size_t i = 0; i < outputVector->size(); ++i) {
     LOG(INFO) << outputVector->toString(i);
   }
 

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
 
   // For fun, let's print the shuffled data to stdout.
   LOG(INFO) << "Input vector generated:";
-  for (size_t i = 0; i < rowVector->size(); ++i) {
+  for (vector_size_t i = 0; i < rowVector->size(); ++i) {
     LOG(INFO) << rowVector->toString(i);
   }
 
@@ -182,7 +182,7 @@ int main(int argc, char** argv) {
   // Read output vectors and print them.
   while (auto result = readTask->next()) {
     LOG(INFO) << "Vector available after processing (scan + sort):";
-    for (size_t i = 0; i < result->size(); ++i) {
+    for (vector_size_t i = 0; i < result->size(); ++i) {
       LOG(INFO) << result->toString(i);
     }
   }

--- a/velox/examples/ScanOrc.cpp
+++ b/velox/examples/ScanOrc.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
   auto rowReader = reader->createRowReader(rowReaderOptions);
   while (rowReader->next(500, batch)) {
     auto rowVector = batch->as<RowVector>();
-    for (size_t i = 0; i < rowVector->size(); ++i) {
+    for (vector_size_t i = 0; i < rowVector->size(); ++i) {
       std::cout << rowVector->toString(i) << std::endl;
     }
   }

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -48,7 +48,7 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     auto result = BaseVector::create(expected->type(), size, pool_.get());
     container.extractColumn(oddRows.data(), size, column, result);
     EXPECT_EQ(size, result->size());
-    for (size_t row = 0; row < size; ++row) {
+    for (vector_size_t row = 0; row < size; ++row) {
       if (row % 2 == 0) {
         EXPECT_TRUE(result->isNullAt(row)) << "at " << row;
       } else {
@@ -68,12 +68,8 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
 
     auto result = BaseVector::create(expected->type(), size, pool_.get());
     container.extractColumn(rows.data(), size, column, result);
-    EXPECT_EQ(size, result->size());
-    for (size_t row = 0; row < size; ++row) {
-      EXPECT_TRUE(expected->equalValueAt(result.get(), row, row))
-          << "at " << row << ": expected " << expected->toString(row)
-          << ", got " << result->toString(row);
-    }
+
+    assertEqualVectors(expected, result);
   }
 
   void checkSizes(std::vector<char*>& rows, RowContainer& data) {

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -311,7 +311,7 @@ class ExprEncodingsTest
       const SelectivityVector& rows) {
     ASSERT_GE(actual->size(), rows.end());
     ASSERT_EQ(expected->typeKind(), actual->typeKind());
-    rows.applyToSelected([&](auto row) {
+    rows.applyToSelected([&](vector_size_t row) {
       ASSERT_TRUE(expected->equalValueAt(actual.get(), row, row))
           << "at " << row << ": expected " << expected->toString(row)
           << ", but got " << actual->toString(row);

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -339,7 +339,7 @@ class ExpressionFuzzer {
     LOG(INFO) << "RowVector contents (" << rowVector->type()->toString()
               << "):";
 
-    for (size_t i = 0; i < rowVector->size(); ++i) {
+    for (vector_size_t i = 0; i < rowVector->size(); ++i) {
       LOG(INFO) << "\tAt " << i << ": " << rowVector->toString(i);
     }
   }

--- a/velox/tpch/gen/tests/TpchGenTest.cpp
+++ b/velox/tpch/gen/tests/TpchGenTest.cpp
@@ -292,7 +292,7 @@ TEST(TpchGenTestLineItem, batches) {
   EXPECT_EQ("1996-03-13"_sv, shipDate->valueAt(0));
   LOG(INFO) << rowVector1->toString(0);
 
-  size_t lastRow = rowVector1->size() - 1;
+  vector_size_t lastRow = rowVector1->size() - 1;
   EXPECT_EQ(388, orderKey->valueAt(lastRow));
   EXPECT_EQ("1992-12-24"_sv, shipDate->valueAt(lastRow));
   LOG(INFO) << rowVector1->toString(lastRow);

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -427,7 +427,7 @@ void BaseVector::resizeIndices(
   *raw = indices->get()->asMutable<vector_size_t>();
 }
 
-std::string BaseVector::toString() const {
+std::string BaseVector::toSummaryString() const {
   std::stringstream out;
   out << "[" << encoding() << " " << type_->toString() << ": " << length_
       << " elements, ";
@@ -437,6 +437,27 @@ std::string BaseVector::toString() const {
     out << countNulls(nulls_, 0, length_) << " nulls";
   }
   out << "]";
+  return out.str();
+}
+
+std::string BaseVector::toString(bool recursive) const {
+  std::stringstream out;
+  out << toSummaryString();
+
+  if (recursive) {
+    switch (encoding()) {
+      case VectorEncoding::Simple::DICTIONARY:
+      case VectorEncoding::Simple::SEQUENCE:
+      case VectorEncoding::Simple::CONSTANT:
+        if (valueVector() != nullptr) {
+          out << ", " << valueVector()->toString(true);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
   return out.str();
 }
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -635,10 +635,25 @@ class BaseVector {
     return left == right || right == TypeKind::UNKNOWN;
   }
 
-  virtual std::string toString() const;
+  /// Returns a brief summary of the vector. If 'recursive' is true, includes a
+  /// summary of all the layers of encodings starting with the top layer.
+  ///
+  /// For example,
+  ///     with recursive 'false':
+  ///
+  ///         [DICTIONARY INTEGER: 5 elements, no nulls]
+  ///
+  ///     with recursive 'true':
+  ///
+  ///         [DICTIONARY INTEGER: 5 elements, no nulls], [FLAT INTEGER: 10
+  ///             elements, no nulls]
+  std::string toString(bool recursive = false) const;
 
+  /// Returns string representation of the value in the specified row.
   virtual std::string toString(vector_size_t index) const;
 
+  /// Returns a list of values in rows [from, to). By default rows are separated
+  /// by a new line and include row numbers.
   std::string toString(
       vector_size_t from,
       vector_size_t to,
@@ -654,6 +669,14 @@ class BaseVector {
   }
 
  protected:
+  /// Returns a brief summary of the vector. The default implementation includes
+  /// encoding, type, number of rows and number of nulls.
+  ///
+  /// For example,
+  ///     [FLAT INTEGER: 3 elements, no nulls]
+  ///     [DICTIONARY INTEGER: 5 elements, 1 nulls]
+  virtual std::string toSummaryString() const;
+
   /*
    * Allocates or reallocates nulls_ with the given size if nulls_ hasn't
    * been allocated yet or has been allocated with a smaller capacity.

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -314,19 +314,21 @@ class ConstantVector final : public SimpleVector<T> {
     return SimpleVector<T>::compare(other, index, otherIndex, flags);
   }
 
-  std::string toString() const override {
-    std::stringstream out;
-    out << "[" << BaseVector::encoding() << " " << this->type()->toString()
-        << ": " << toString(index_) << " value, " << this->size() << " size]";
-    return out.str();
-  }
-
   std::string toString(vector_size_t index) const override {
     if (isScalar()) {
       return SimpleVector<T>::toString(index);
     }
 
     return valueVector_->toString(index_);
+  }
+
+ protected:
+  std::string toSummaryString() const override {
+    std::stringstream out;
+    out << "[" << BaseVector::encoding() << " "
+        << BaseVector::type()->toString() << ": " << BaseVector::size()
+        << " elements, " << toString(index_) << "]";
+    return out.str();
   }
 
  private:

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1299,15 +1299,7 @@ class VectorCreateConstantTest : public VectorTest {
       }
     }
 
-    auto expectedStr = fmt::format(
-        "[CONSTANT {}: {} value, {} size]",
-        type->toString(),
-        baseVector->toString(0),
-        size_);
-    EXPECT_EQ(expectedStr, baseVector->toString());
-    for (auto i = 1; i < baseVector->size(); ++i) {
-      EXPECT_EQ(baseVector->toString(0), baseVector->toString(i));
-    }
+    verifyConstantToString(type, baseVector);
   }
 
   template <TypeKind KIND>
@@ -1326,14 +1318,18 @@ class VectorCreateConstantTest : public VectorTest {
       ASSERT_TRUE(vector->equalValueAt(baseVector.get(), 0, i));
     }
 
+    verifyConstantToString(type, baseVector);
+  }
+
+  void verifyConstantToString(const TypePtr& type, const VectorPtr& constant) {
     auto expectedStr = fmt::format(
-        "[CONSTANT {}: {} value, {} size]",
+        "[CONSTANT {}: {} elements, {}]",
         type->toString(),
-        vector->toString(0),
-        size_);
-    EXPECT_EQ(expectedStr, baseVector->toString());
-    for (auto i = 1; i < baseVector->size(); ++i) {
-      EXPECT_EQ(baseVector->toString(0), baseVector->toString(i));
+        size_,
+        constant->toString(0));
+    EXPECT_EQ(expectedStr, constant->toString());
+    for (auto i = 1; i < constant->size(); ++i) {
+      EXPECT_EQ(constant->toString(0), constant->toString(i));
     }
   }
 
@@ -1354,7 +1350,7 @@ class VectorCreateConstantTest : public VectorTest {
     }
 
     auto expectedStr = fmt::format(
-        "[CONSTANT {}: null value, {} size]", type->toString(), size_);
+        "[CONSTANT {}: {} elements, null]", type->toString(), size_);
     EXPECT_EQ(expectedStr, baseVector->toString());
     for (auto i = 1; i < baseVector->size(); ++i) {
       EXPECT_EQ(baseVector->toString(0), baseVector->toString(i));


### PR DESCRIPTION
Add BaseVector::toString(bool recursive) API to print all layers of encodings for the vector.

For example,

vector->toString() returns:

```
[DICTIONARY INTEGER: 5 elements, no nulls]
```

while vector->toString(true) returns:

```
[DICTIONARY INTEGER: 5 elements, no nulls], [FLAT INTEGER: 10 elements, no nulls]
```