### PR TITLE
Remove usage of flatRawNulls from SparkSQL functions

### DIFF
--- a/velox/functions/sparksql/CompareFunctionsNullSafe.cpp
+++ b/velox/functions/sparksql/CompareFunctionsNullSafe.cpp
@@ -43,9 +43,9 @@ void applyTyped(
     });
   } else {
     // (isnull(a) AND isnull(b)) || (a == b)
-    // When flatRawNulls is null it means there are no nulls.
-    auto* rawNulls0 = args[0]->flatRawNulls(rows);
-    auto* rawNulls1 = args[1]->flatRawNulls(rows);
+    // When DecodedVector::nulls() is null it means there are no nulls.
+    auto* rawNulls0 = decoded0->nulls();
+    auto* rawNulls1 = decoded1->nulls();
     rows.applyToSelected([&](vector_size_t i) {
       auto isNull0 = rawNulls0 && bits::isBitNull(rawNulls0, i);
       auto isNull1 = rawNulls1 && bits::isBitNull(rawNulls1, i);

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -132,7 +132,7 @@ class HashFunction final : public exec::VectorFunction {
       if (arg->mayHaveNulls()) {
         *selectedMinusNulls.get(rows.end()) = rows;
         selectedMinusNulls->deselectNulls(
-            arg->flatRawNulls(rows), rows.begin(), rows.end());
+            decoded->nulls(), rows.begin(), rows.end());
         selected = selectedMinusNulls.get();
       }
       switch (arg->type()->kind()) {


### PR DESCRIPTION
Replace usage of BaseVector::flatRawNulls() with DecodedVector::nulls().

See https://github.com/facebookincubator/velox/discussions/2202 for context.