### PR TITLE
Add run name to conbench runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ jobs:
             echo "url: https://velox-conbench.voltrondata.run/" >> .conbench
             echo "email: $CONBENCH_EMAIL" >> .conbench
             echo "password: $CONBENCH_PASSWORD" >> .conbench
-            echo "host_name: CricleCI-runner" >> .conbench
+            echo "host_name: CircleCI-runner" >> .conbench
 
             conbench cpp-micro
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,7 @@ jobs:
             echo "password: $CONBENCH_PASSWORD" >> .conbench
             echo "host_name: CircleCI-runner" >> .conbench
 
-            conbench cpp-micro
+            conbench cpp-micro --run-name="commit: $(git rev-parse HEAD)" --run-reason="commit"
       - store_artifacts:
           path: '_build/debug/.ninja_log'
       - save_cache:

--- a/scripts/benchmark-runner.py
+++ b/scripts/benchmark-runner.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 
 
-_FIND_BINARIES_CMD = "find %s -maxdepth 1 -type f -executable"
+_FIND_BINARIES_CMD = "find %s -maxdepth 1 -type f -perm +111"
 _FIND_JSON_CMD = "find %s -maxdepth 1 -name '*.json' -type f"
 _BENCHMARK_CMD = "%s --bm_max_secs 10 --bm_max_trials 1000000"
 _BENCHMARK_WITH_DUMP_CMD = _BENCHMARK_CMD + " --bm_json_verbose %s"

--- a/scripts/benchmark-runner.py
+++ b/scripts/benchmark-runner.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 
 
-_FIND_BINARIES_CMD = "find %s -maxdepth 1 -type f -perm +111"
+_FIND_BINARIES_CMD = "find %s -maxdepth 1 -type f -executable"
 _FIND_JSON_CMD = "find %s -maxdepth 1 -name '*.json' -type f"
 _BENCHMARK_CMD = "%s --bm_max_secs 10 --bm_max_trials 1000000"
 _BENCHMARK_WITH_DUMP_CMD = _BENCHMARK_CMD + " --bm_json_verbose %s"


### PR DESCRIPTION
In #2193 we added pushing to conbench, but I should have also added the run name and run reason. The name is needed (currently) for calculating history of the main branch. After this is merged we should start seeing the history plots on runs.

I've also added a small fix for a typo in the runner name.