### PR TITLE
Remove usage of flatRawNulls from expressions

### DIFF
--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -51,10 +51,16 @@ void CoalesceExpr::evalSpecialForm(
       context.mutableFinalSelection(), &rows, context.isFinalSelection());
   VarSetter isFinalSelection(context.mutableIsFinalSelection(), false);
 
+  exec::LocalDecodedVector decodedVector(context);
   for (int i = 0; i < inputs_.size(); i++) {
     inputs_[i]->eval(*activeRows, context, result);
 
-    const uint64_t* rawNulls = result->flatRawNulls(*activeRows);
+    if (!result->mayHaveNulls()) {
+      // No nulls left.
+    }
+
+    decodedVector.get()->decode(*result, *activeRows);
+    const uint64_t* rawNulls = decodedVector->nulls();
     if (!rawNulls) {
       // No nulls left.
       return;


### PR DESCRIPTION
Replace usage of BaseVector::flatRawNulls() with DecodedVector::nulls() in
CastExpr, CoalesceExpr and Expr::evalSimplifiedImpl(). There are 2 more call
sites in Expr.cpp, but these are not straightforward. I'll take care of these
separately.