### PR TITLE
Remove usage of flatRawNulls from operators

### DIFF
--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -198,8 +198,6 @@ class GroupingSet {
   AllocationPool rows_;
   const bool isAdaptive_;
 
-  core::ExecCtx& execCtx_;
-
   bool noMoreInput_{false};
 
   /// In case of partial streaming aggregation, the input vector passed to

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -125,9 +125,16 @@ HashBuild::HashBuild(
 void HashBuild::addInput(RowVectorPtr input) {
   activeRows_.resize(input->size());
   activeRows_.setAll();
+
+  auto& hashers = table_->hashers();
+
+  for (auto i = 0; i < hashers.size(); ++i) {
+    auto key = input->childAt(hashers[i]->channel())->loadedVector();
+    hashers[i]->decode(*key, activeRows_);
+  }
+
   if (!isRightJoin(joinType_) && !isFullJoin(joinType_)) {
-    deselectRowsWithNulls(
-        *input, keyChannels_, activeRows_, *operatorCtx_->execCtx());
+    deselectRowsWithNulls(hashers, activeRows_);
   }
 
   if (joinType_ == core::JoinType::kAnti) {
@@ -144,8 +151,6 @@ void HashBuild::addInput(RowVectorPtr input) {
     hashes_.resize(activeRows_.size());
   }
 
-  auto& hashers = table_->hashers();
-
   // As long as analyzeKeys is true, we keep running the keys through
   // the Vectorhashers so that we get a possible mapping of the keys
   // to small ints for array or normalized key. When mayUseValueIds is
@@ -155,14 +160,8 @@ void HashBuild::addInput(RowVectorPtr input) {
   for (auto& hasher : hashers) {
     // TODO: Load only for active rows, except if right/full outer join.
     if (analyzeKeys_) {
-      hasher->computeValueIds(
-          *input->childAt(hasher->channel())->loadedVector(),
-          activeRows_,
-          hashes_);
+      hasher->computeValueIds(activeRows_, hashes_);
       analyzeKeys_ = hasher->mayUseValueIds();
-    } else {
-      hasher->decode(
-          *input->childAt(hasher->channel())->loadedVector(), activeRows_);
     }
   }
   for (auto i = 0; i < dependentChannels_.size(); ++i) {

--- a/velox/exec/HashPartitionFunction.cpp
+++ b/velox/exec/HashPartitionFunction.cpp
@@ -49,8 +49,8 @@ void HashPartitionFunction::partition(
   for (auto i = 0; i < hashers_.size(); ++i) {
     auto& hasher = hashers_[i];
     if (hasher->channel() != kConstantChannel) {
-      hashers_[i]->hash(
-          *input.childAt(hasher->channel()), rows_, i > 0, hashes_);
+      hashers_[i]->decode(*input.childAt(hasher->channel()), rows_);
+      hashers_[i]->hash(rows_, i > 0, hashes_);
     } else {
       hashers_[i]->hashPrecomputed(rows_, i > 0, hashes_);
     }

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -19,13 +19,13 @@
 
 namespace facebook::velox::exec {
 
-// Deselects rows from 'rows' where any of the 'input' children
-// in 'channels' has a null.
+class VectorHasher;
+
+// Deselects rows from 'rows' where any of the vectors managed by the 'hashers'
+// has a null.
 void deselectRowsWithNulls(
-    const RowVector& input,
-    const std::vector<column_index_t>& channels,
-    SelectivityVector& rows,
-    core::ExecCtx& execCtx);
+    const std::vector<std::unique_ptr<VectorHasher>>& hashers,
+    SelectivityVector& rows);
 
 // Reusable memory needed for processing filter results.
 struct FilterEvalCtx {

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -324,10 +324,8 @@ bool VectorHasher::makeValueIdsDecoded<bool, false>(
 }
 
 bool VectorHasher::computeValueIds(
-    const BaseVector& values,
     const SelectivityVector& rows,
     raw_vector<uint64_t>& result) {
-  decoded_.decode(values, rows);
   return VALUE_ID_TYPE_DISPATCH(makeValueIds, typeKind_, rows, result.data());
 }
 
@@ -459,11 +457,9 @@ void VectorHasher::lookupValueIds(
 }
 
 void VectorHasher::hash(
-    const BaseVector& values,
     const SelectivityVector& rows,
     bool mix,
     raw_vector<uint64_t>& result) {
-  decoded_.decode(values, rows);
   VELOX_DYNAMIC_TYPE_DISPATCH(hashValues, typeKind_, rows, mix, result.data());
 }
 

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -175,13 +175,22 @@ class VectorHasher {
 
   static constexpr uint64_t kNullHash = BaseVector::kNullHash;
 
-  // Computes a hash for 'rows' in 'values' and stores it in 'result'.
-  // If 'mix' is true, mixes the hash with existing value in 'result'.
-  void hash(
-      const BaseVector& values,
-      const SelectivityVector& rows,
-      bool mix,
-      raw_vector<uint64_t>& result);
+  // Decodes the 'vector' in preparation for calling hash() or
+  // computeValueIds(). The decoded vector can be accessed via decodedVector()
+  // getter.
+  void decode(const BaseVector& vector, const SelectivityVector& rows) {
+    decoded_.decode(vector, rows);
+  }
+
+  DecodedVector& decodedVector() {
+    return decoded_;
+  }
+
+  // Computes a hash for 'rows' in the vector previously decoded via decode()
+  // call and stores it in 'result'. If 'mix' is true, mixes the hash with
+  // existing value in 'result'.
+  void
+  hash(const SelectivityVector& rows, bool mix, raw_vector<uint64_t>& result);
 
   // Computes a hash for 'rows' using precomputedHash_ (just like from a const
   // vector) and stores it in 'result'.
@@ -195,16 +204,15 @@ class VectorHasher {
   // precomputedHash_. Used for constant partition keys.
   void precompute(const BaseVector& value);
 
-  // Computes a normalized key for 'rows' in 'values' and stores this
-  // in 'result'. If this is not the first hasher with normalized
-  // keys, updates the partially computed normalized key in
+  // Computes a normalized key for 'rows' in the vector previously decoded via
+  // decode() call and stores this in 'result'. If this is not the first hasher
+  // with normalized keys, updates the partially computed normalized key in
   // 'result'. Returns true if all the values could be mapped to the
   // normalized key range. If some values could not be mapped
   // the statistics are updated to reflect the new values. This
   // behavior corresponds to group by, where we must rehash if all the
   // new keys could not be represented.
   bool computeValueIds(
-      const BaseVector& values,
       const SelectivityVector& rows,
       raw_vector<uint64_t>& result);
 
@@ -282,14 +290,6 @@ class VectorHasher {
 
   bool isRange() const {
     return isRange_;
-  }
-
-  void decode(const BaseVector& vector, const SelectivityVector& rows) {
-    decoded_.decode(vector, rows);
-  }
-
-  const DecodedVector& decodedVector() const {
-    return decoded_;
   }
 
   static bool typeKindSupportsValueIds(TypeKind kind) {

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -70,12 +70,14 @@ void benchmarkComputeValueIds(bool withNulls) {
 
   raw_vector<uint64_t> hashes(size);
   SelectivityVector rows(size);
-  hasher.computeValueIds(*values, rows, hashes);
+  hasher.decode(*values, rows);
+  hasher.computeValueIds(rows, hashes);
   hasher.enableValueRange(1, 0);
   suspender.dismiss();
 
   for (int i = 0; i < 10'000; i++) {
-    bool ok = hasher.computeValueIds(*values, rows, hashes);
+    hasher.decode(*values, rows);
+    bool ok = hasher.computeValueIds(rows, hashes);
     folly::doNotOptimizeAway(ok);
   }
 }
@@ -148,7 +150,8 @@ void benchmarkComputeValueIdsForStrings(bool flattenDictionaries) {
   for (int i = 0; i < 4; i++) {
     auto hasher = hashers[i].get();
     raw_vector<uint64_t> result(size);
-    auto ok = hasher->computeValueIds(*vectors[i], allRows, result);
+    hasher->decode(*vectors[i], allRows);
+    auto ok = hasher->computeValueIds(allRows, result);
     folly::doNotOptimizeAway(ok);
 
     multiplier = hasher->enableValueIds(multiplier, 0);
@@ -160,7 +163,8 @@ void benchmarkComputeValueIdsForStrings(bool flattenDictionaries) {
     for (int j = 0; j < 4; j++) {
       auto hasher = hashers[j].get();
       auto vector = vectors[j];
-      bool ok = hasher->computeValueIds(*vector, allRows, result);
+      hasher->decode(*vector, allRows);
+      bool ok = hasher->computeValueIds(allRows, result);
       folly::doNotOptimizeAway(ok);
     }
   }

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -167,12 +167,13 @@ class HashTableTest : public testing::Test {
     bool rehash = false;
     for (int32_t i = 0; i < hashers.size(); ++i) {
       auto key = input.childAt(hashers[i]->channel());
+      hashers[i]->decode(*key, rows);
       if (mode != BaseHashTable::HashMode::kHash) {
-        if (!hashers[i]->computeValueIds(*key, rows, lookup.hashes)) {
+        if (!hashers[i]->computeValueIds(rows, lookup.hashes)) {
           rehash = true;
         }
       } else {
-        hashers[i]->hash(*key, rows, i > 0, lookup.hashes);
+        hashers[i]->hash(rows, i > 0, lookup.hashes);
       }
     }
 
@@ -241,7 +242,8 @@ class HashTableTest : public testing::Test {
           if (table->hashMode() != BaseHashTable::HashMode::kHash) {
             auto hasher = table->hashers()[i].get();
             if (hasher->mayUseValueIds()) {
-              hasher->computeValueIds(*batch->childAt(i), insertedRows, dummy);
+              hasher->decode(*batch->childAt(i), insertedRows);
+              hasher->computeValueIds(insertedRows, dummy);
             }
           }
         }
@@ -362,7 +364,8 @@ class HashTableTest : public testing::Test {
             hashers[i]->lookupValueIds(
                 *key, rows, scratchMemory, lookup->hashes);
           } else {
-            hashers[i]->hash(*key, rows, i > 0, lookup->hashes);
+            hashers[i]->decode(*key, rows);
+            hashers[i]->hash(rows, i > 0, lookup->hashes);
           }
         }
       }

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -321,7 +321,8 @@ TEST_F(RowContainerTest, types) {
     auto source = batch->childAt(column);
     auto columnType = batch->type()->as<TypeKind::ROW>().childAt(column);
     VectorHasher hasher(columnType, column);
-    hasher.hash(*source, allRows, false, hashes);
+    hasher.decode(*source, allRows);
+    hasher.hash(allRows, false, hashes);
     DecodedVector decoded(*extracted, allRows);
     std::vector<uint64_t> rowHashes(kNumRows);
     data->hash(


### PR DESCRIPTION
Hash join and aggregation opertors used BaseVector::flatRawNulls via
deselectRowsWithNulls helper function defined in OperatorUtils.h. These
operators were looking up nulls in join and group by keys. Each key has a
corresponding VectorHasher instance which contains a DecodedVector instance. To
re-use that DecodedVector instance in deselectRowsWithNulls I modified the
interface of VectorHasher to remove decoding logic from hash() and
computeValueIds() methods and expect the caller to first call
VectorHasher::decode(). This way, the callers can decoded the keys, process
null rows, then call VectorHasher::computeValueIds() and hash().