### PR TITLE
Add DECIMAL types to VELOX_DYNAMIC_TYPE_DISPATCH_METHOD_ALL macro

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1339,6 +1339,12 @@ std::shared_ptr<const OpaqueType> OPAQUE() {
     } else if ((typeKind) == ::facebook::velox::TypeKind::OPAQUE) {         \
       return CLASS_NAME<::facebook::velox::TypeKind::OPAQUE>::METHOD_NAME(  \
           __VA_ARGS__);                                                     \
+    } else if ((typeKind) == ::facebook::velox::TypeKind::SHORT_DECIMAL) {  \
+      return CLASS_NAME<::facebook::velox::TypeKind::SHORT_DECIMAL>::       \
+          METHOD_NAME(__VA_ARGS__);                                         \
+    } else if ((typeKind) == ::facebook::velox::TypeKind::LONG_DECIMAL) {   \
+      return CLASS_NAME<::facebook::velox::TypeKind::LONG_DECIMAL>::        \
+          METHOD_NAME(__VA_ARGS__);                                         \
     } else {                                                                \
       return VELOX_DYNAMIC_TYPE_DISPATCH_IMPL(                              \
           CLASS_NAME, ::METHOD_NAME, typeKind, __VA_ARGS__);                \


### PR DESCRIPTION
Summary: Looks like we missed adding SHORT_DECIMAL and LONG_DECIMAL branches to this macro when we added Decimal types before. This diff simply adds those to be consistent.

Differential Revision: D38444369

