### PR TITLE
Remove BaseVector::flatRawNulls method

### DIFF
--- a/velox/experimental/codegen/vector_function/GeneratedVectorFunction-inl.h
+++ b/velox/experimental/codegen/vector_function/GeneratedVectorFunction-inl.h
@@ -246,9 +246,11 @@ class GeneratedVectorFunction : public GeneratedVectorFunctionBase {
       auto rowsNotNull = rows;
 
       auto deselectNull = [&rowsNotNull, &rows](const VectorPtr& arg) {
-        if (arg->mayHaveNulls() && arg->getNullCount() != 0) {
-          rowsNotNull.deselectNulls(
-              arg->flatRawNulls(rows), rows.begin(), rows.end());
+        if (arg->mayHaveNulls()) {
+          exec::LocalDecodedVector decodedVector(context, *arg, rowsNotNull);
+          if (auto* rawNulls = decodedVector->nulls()) {
+            rowsNotNull.deselectNulls(rawNulls, rows.begin(), rows.end());
+          }
         }
       };
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -80,26 +80,14 @@ class BaseVector {
   }
 
   // Returns false if vector has no nulls. Return true if vector may have nulls.
-  // When this method returns true, flatRawNulls is guaranteed to return
-  // non-null.
   virtual bool mayHaveNulls() const {
     return rawNulls_;
   }
 
   // Returns false if this vector and all of its children have no nulls. Returns
   // true if this vector or any of its children may have nulls.
-  // When this method returns true, flatRawNulls called on this vector or any
-  // of its children is guaranteed to return non-null.
   virtual bool mayHaveNullsRecursive() const {
     return mayHaveNulls();
-  }
-
-  // Returns raw nulls or nullptr with one bit per logical position in
-  // the vector, with valid values at least for the rows selected in
-  // 'rows'. Dictionaries, sequences and constants may calculate this on
-  // demand.
-  virtual const uint64_t* flatRawNulls(const SelectivityVector& rows) {
-    return rawNulls_;
   }
 
   inline bool isIndexInRange(vector_size_t index) const {

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -163,21 +163,6 @@ class ConstantVector final : public SimpleVector<T> {
     VELOX_FAIL("setNull not supported on ConstantVector");
   }
 
-  const uint64_t* flatRawNulls(const SelectivityVector& rows) override {
-    VELOX_DCHECK(initialized_);
-    if (isNull_) {
-      if (BaseVector::nulls_ &&
-          BaseVector::nulls_->capacity() / 8 >= rows.size()) {
-        return BaseVector::rawNulls_;
-      }
-      BaseVector::nulls_ = AlignedBuffer::allocate<bool>(
-          rows.size(), BaseVector::pool(), bits::kNull);
-      BaseVector::rawNulls_ = BaseVector::nulls_->as<uint64_t>();
-      return BaseVector::rawNulls_;
-    }
-    return nullptr;
-  }
-
   const T valueAtFast(vector_size_t /*idx*/) const {
     VELOX_DCHECK(initialized_);
     return value_;

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -77,8 +77,6 @@ class DictionaryVector : public SimpleVector<T> {
 
   bool isNullAt(vector_size_t idx) const override;
 
-  const uint64_t* flatRawNulls(const SelectivityVector& rows) override;
-
   const T valueAtFast(vector_size_t idx) const;
 
   /**
@@ -128,8 +126,7 @@ class DictionaryVector : public SimpleVector<T> {
 
   uint64_t retainedSize() const override {
     return BaseVector::retainedSize() + dictionaryValues_->retainedSize() +
-        indices_->capacity() +
-        (flatNullsBuffer_ ? flatNullsBuffer_->capacity() : 0);
+        indices_->capacity();
   }
 
   bool isConstant(const SelectivityVector& rows) const override {
@@ -182,21 +179,6 @@ class DictionaryVector : public SimpleVector<T> {
     return true;
   }
 
-  void addNulls(const uint64_t* bits, const SelectivityVector& rows) override {
-    flatNullsBuffer_ = nullptr;
-    BaseVector::addNulls(bits, rows);
-  }
-
-  void clearNulls(const SelectivityVector& rows) override {
-    flatNullsBuffer_ = nullptr;
-    BaseVector::clearNulls(rows);
-  }
-
-  void clearNulls(vector_size_t begin, vector_size_t end) override {
-    flatNullsBuffer_ = nullptr;
-    BaseVector::clearNulls(begin, end);
-  }
-
   std::string toString(vector_size_t index) const override {
     if (BaseVector::isNullAt(index)) {
       return "null";
@@ -242,7 +224,6 @@ class DictionaryVector : public SimpleVector<T> {
   // Caches 'scalarDictionaryValues_->getRawValues()' if 'dictionaryValues_'
   // is a FlatVector<T>.
   const T* rawDictionaryValues_ = nullptr;
-  BufferPtr flatNullsBuffer_;
   bool initialized_{false};
 };
 

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -246,10 +246,6 @@ class LazyVector : public BaseVector {
     return loadedVector()->isNullAt(index);
   }
 
-  const uint64_t* flatRawNulls(const SelectivityVector& rows) override {
-    return loadedVector()->flatRawNulls(rows);
-  }
-
   uint64_t retainedSize() const override {
     return isLoaded() ? loadedVector()->retainedSize()
                       : BaseVector::retainedSize();

--- a/velox/vector/SequenceVector-inl.h
+++ b/velox/vector/SequenceVector-inl.h
@@ -198,25 +198,5 @@ static inline vector_size_t offsetOfIndex(
   return *lastIndex;
 }
 
-template <typename T>
-const uint64_t* SequenceVector<T>::computeFlatNulls(
-    const SelectivityVector& rows) {
-  int32_t bytes = BaseVector::byteSize<bool>(BaseVector::length_);
-  flatNullsBuffer_ = AlignedBuffer::allocate<char>(bytes, BaseVector::pool_);
-  auto flatNulls = flatNullsBuffer_->asMutable<uint64_t>();
-  int32_t current = 0;
-  auto numLengths = numSequences();
-  for (int32_t i = 0; i < numLengths; ++i) {
-    VELOX_CHECK(current < bytes * 8);
-    bits::fillBits(
-        flatNulls,
-        current,
-        current + lengths_[i],
-        !sequenceValues_->isNullAt(i));
-    current += lengths_[i];
-  }
-  return flatNulls;
-}
-
 } // namespace velox
 } // namespace facebook

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -62,17 +62,6 @@ class SequenceVector : public SimpleVector<T> {
     return sequenceValues_->mayHaveNullsRecursive();
   }
 
-  const uint64_t* flatRawNulls(const SelectivityVector& rows) override {
-    if (flatNullsBuffer_) {
-      return flatNullsBuffer_->as<uint64_t>();
-    }
-    loadedVector();
-    if (!sequenceValues_->mayHaveNulls()) {
-      return nullptr;
-    }
-    return computeFlatNulls(rows);
-  }
-
   bool isNullAtFast(vector_size_t idx) const;
 
   bool isNullAt(vector_size_t idx) const override {
@@ -188,13 +177,10 @@ class SequenceVector : public SimpleVector<T> {
   // Prepares for use after construction.
   void setInternalState();
 
-  const uint64_t* computeFlatNulls(const SelectivityVector& rows);
-
   bool checkLoadRange(size_t idx, size_t count) const;
 
   std::shared_ptr<BaseVector> sequenceValues_;
   SimpleVector<T>* scalarSequenceValues_ = nullptr;
-  BufferPtr flatNullsBuffer_;
   BufferPtr sequenceLengths_;
   // Caches 'sequenceLengths_->as<vector_size_t>()'
   const vector_size_t* lengths_ = nullptr;

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -441,7 +441,6 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     // on the wrapping and via the translation of DecodedVector.
     SelectivityVector allRows(sourceSize);
     DecodedVector decoded(*source, allRows);
-    auto flatNulls = source->flatRawNulls(allRows);
     auto base = decoded.base();
     auto nulls = decoded.nulls();
     auto indices = decoded.indices();
@@ -453,12 +452,12 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
             << source->toString(sourceIdx);
 
         // We check the same with 'decoded'.
-        if (nulls && bits::isBitNull(nulls, sourceIdx)) {
+        if (source->isNullAt(sourceIdx)) {
           EXPECT_TRUE(decoded.isNullAt(sourceIdx));
-          EXPECT_TRUE(bits::isBitNull(flatNulls, sourceIdx));
+          EXPECT_TRUE(nulls && bits::isBitNull(nulls, sourceIdx));
           EXPECT_TRUE(target->isNullAt(i));
         } else {
-          EXPECT_FALSE(flatNulls && bits::isBitNull(flatNulls, sourceIdx));
+          EXPECT_FALSE(nulls && bits::isBitNull(nulls, sourceIdx));
           EXPECT_FALSE(decoded.isNullAt(sourceIdx));
           EXPECT_FALSE(target->isNullAt(i));
           EXPECT_TRUE(target->equalValueAt(
@@ -468,11 +467,11 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
         EXPECT_TRUE(target->equalValueAt(source.get(), i, oddSource[i]));
         // We check the same with 'decoded'.
         auto sourceIdx = oddSource[i];
-        if (nulls && bits::isBitNull(nulls, sourceIdx)) {
-          EXPECT_TRUE(bits::isBitNull(flatNulls, sourceIdx));
+        if (source->isNullAt(sourceIdx)) {
+          EXPECT_TRUE(nulls && bits::isBitNull(nulls, sourceIdx));
           EXPECT_TRUE(target->isNullAt(i));
         } else {
-          EXPECT_FALSE(flatNulls && bits::isBitNull(flatNulls, sourceIdx));
+          EXPECT_FALSE(nulls && bits::isBitNull(nulls, sourceIdx));
           EXPECT_FALSE(target->isNullAt(i));
           EXPECT_TRUE(target->equalValueAt(
               base, i, indices ? indices[sourceIdx] : sourceIdx));


### PR DESCRIPTION
BaseVector::flatRawNulls() has been replaced with DecodedVector::nulls().