### PR TITLE
Make order by store key columns first in RowContainer column order

### DIFF
--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -60,13 +60,30 @@ class OrderBy : public Operator {
  private:
   static const int32_t kBatchSizeInBytes{2 * 1024 * 1024};
 
+  /// Prepare the reusable output buffer based on the output batch size and the
+  /// remaining rows to return.
+  void prepareOutput();
+
+  const int32_t numSortKeys_;
+
+  /// The map from input column channel to the corresponding one stored in
+  /// 'data_'. The input column channel might be reordered to ensure the sorting
+  /// key columns stored first in 'data_'.
+  std::vector<IdentityProjection> columnMap_;
+  std::vector<CompareFlags> keyCompareFlags_;
+
   std::unique_ptr<RowContainer> data_;
-  std::vector<std::pair<column_index_t, core::SortOrder>> keyInfo_;
+
+  /// Maximum number of rows in the output batch.
+  uint32_t outputBatchSize_;
 
   size_t numRows_ = 0;
   size_t numRowsReturned_ = 0;
   std::vector<char*> returningRows_;
 
   bool finished_ = false;
+
+  /// Possibly reusable output vector.
+  RowVectorPtr output_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -104,8 +104,9 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
   }
 
   template <typename T>
-  void testCompareFloats(TypePtr type, bool ascending) {
-    auto rowContainer = makeRowContainer({type}, {type});
+  void testCompareFloats(TypePtr type, bool ascending, bool nullsFirst) {
+    // NOTE: set 'isJoinBuild' to true to enable nullable sort key in test.
+    auto rowContainer = makeRowContainer({type}, {type}, false);
     auto lowest = std::numeric_limits<T>::lowest();
     auto min = std::numeric_limits<T>::min();
     auto max = std::numeric_limits<T>::max();
@@ -113,8 +114,8 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     auto inf = std::numeric_limits<T>::infinity();
 
     facebook::velox::test::VectorMaker vectorMaker{pool_.get()};
-    VectorPtr values =
-        vectorMaker.flatVector<T>({max, inf, 0.0, nan, lowest, min});
+    VectorPtr values = vectorMaker.flatVectorNullable<T>(
+        {std::nullopt, max, inf, 0.0, nan, lowest, min});
     int numRows = values->size();
 
     SelectivityVector allRows(numRows);
@@ -127,38 +128,97 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
       indexedRows[i] = std::make_pair(i, rows[i]);
     }
 
-    std::vector<T> expectedOrder = {lowest, 0.0, min, max, inf, nan};
+    std::vector<std::optional<T>> expectedOrder = {
+        std::nullopt, lowest, 0.0, min, max, inf, nan};
     if (!ascending) {
-      std::reverse(expectedOrder.begin(), expectedOrder.end());
+      if (nullsFirst) {
+        std::reverse(expectedOrder.begin() + 1, expectedOrder.end());
+      } else {
+        std::reverse(expectedOrder.begin(), expectedOrder.end());
+      }
+    } else {
+      if (!nullsFirst) {
+        for (int i = 0; i < expectedOrder.size() - 1; ++i) {
+          expectedOrder[i] = expectedOrder[i + 1];
+        }
+        expectedOrder[expectedOrder.size() - 1] = std::nullopt;
+      }
     }
-    VectorPtr expected = vectorMaker.flatVector<T>(expectedOrder);
-
-    // Verify compare method with two rows as input
-    std::sort(rows.begin(), rows.end(), [&](const char* l, const char* r) {
-      return rowContainer->compare(l, r, 0, {true, ascending}) < 0;
-    });
-    VectorPtr result = BaseVector::create(type, numRows, pool_.get());
-    rowContainer->extractColumn(rows.data(), numRows, 0, result);
-    assertEqualVectors(expected, result);
+    VectorPtr expected = vectorMaker.flatVectorNullable<T>(expectedOrder);
+    {
+      // Verify compare method with two rows as input
+      std::sort(rows.begin(), rows.end(), [&](const char* l, const char* r) {
+        return rowContainer->compare(l, r, 0, {nullsFirst, ascending}) < 0;
+      });
+      VectorPtr result = BaseVector::create(type, numRows, pool_.get());
+      rowContainer->extractColumn(rows.data(), numRows, 0, result);
+      assertEqualVectors(expected, result);
+    }
 
     // Verify compare method with row and decoded vector as input
-    std::sort(
-        indexedRows.begin(),
-        indexedRows.end(),
-        [&](const std::pair<int, char*>& l, const std::pair<int, char*>& r) {
-          return rowContainer->compare(
-                     l.second,
-                     rowContainer->columnAt(0),
-                     decoded,
-                     r.first,
-                     {true, ascending}) < 0;
-        });
-    std::vector<T> sorted;
-    for (const auto& irow : indexedRows) {
-      sorted.push_back(decoded.valueAt<T>(irow.first));
+    {
+      std::sort(
+          indexedRows.begin(),
+          indexedRows.end(),
+          [&](const std::pair<int, char*>& l, const std::pair<int, char*>& r) {
+            return rowContainer->compare(
+                       l.second,
+                       rowContainer->columnAt(0),
+                       decoded,
+                       r.first,
+                       {nullsFirst, ascending}) < 0;
+          });
+      std::vector<std::optional<T>> sorted;
+      for (const auto& irow : indexedRows) {
+        if (decoded.isNullAt(irow.first)) {
+          sorted.push_back(std::nullopt);
+        } else {
+          sorted.push_back(decoded.valueAt<T>(irow.first));
+        }
+      }
+      VectorPtr result = vectorMaker.template flatVectorNullable<T>(sorted);
+      assertEqualVectors(expected, result);
     }
-    result = vectorMaker.flatVector<T>(sorted);
-    assertEqualVectors(expected, result);
+
+    // Verify compareRows method with row as input.
+    {
+      std::sort(
+          indexedRows.begin(),
+          indexedRows.end(),
+          [&](const std::pair<int, char*>& l, const std::pair<int, char*>& r) {
+            return rowContainer->compareRows(
+                       l.second, r.second, {{nullsFirst, ascending}}) < 0;
+          });
+      std::vector<std::optional<T>> sorted;
+      for (const auto& irow : indexedRows) {
+        if (decoded.isNullAt(irow.first)) {
+          sorted.push_back(std::nullopt);
+        } else {
+          sorted.push_back(decoded.valueAt<T>(irow.first));
+        }
+      }
+      VectorPtr result = vectorMaker.template flatVectorNullable<T>(sorted);
+      assertEqualVectors(expected, result);
+    }
+    // Verify compareRows method with default compare flags.
+    if (ascending && nullsFirst) {
+      std::sort(
+          indexedRows.begin(),
+          indexedRows.end(),
+          [&](const std::pair<int, char*>& l, const std::pair<int, char*>& r) {
+            return rowContainer->compareRows(l.second, r.second) < 0;
+          });
+      std::vector<std::optional<T>> sorted;
+      for (const auto& irow : indexedRows) {
+        if (decoded.isNullAt(irow.first)) {
+          sorted.push_back(std::nullopt);
+        } else {
+          sorted.push_back(decoded.valueAt<T>(irow.first));
+        }
+      }
+      VectorPtr result = vectorMaker.template flatVectorNullable<T>(sorted);
+      assertEqualVectors(expected, result);
+    }
   }
 };
 
@@ -476,18 +536,22 @@ TEST_F(RowContainerTest, rowSize) {
   EXPECT_EQ(rows, rowsFromContainer);
 }
 
-// Verify comparison of fringe float values
+// Verify comparison of fringe float valuesg
 TEST_F(RowContainerTest, compareFloat) {
   // Verify ascending order
-  testCompareFloats<float>(REAL(), true);
-  // Verify descending order
-  testCompareFloats<float>(REAL(), false);
+  testCompareFloats<float>(REAL(), true, true);
+  testCompareFloats<float>(REAL(), true, false);
+  //  Verify descending order
+  testCompareFloats<float>(REAL(), false, true);
+  testCompareFloats<float>(REAL(), false, false);
 }
 
 // Verify comparison of fringe double values
 TEST_F(RowContainerTest, compareDouble) {
   // Verify ascending order
-  testCompareFloats<double>(DOUBLE(), true);
+  testCompareFloats<double>(DOUBLE(), true, true);
+  testCompareFloats<double>(DOUBLE(), true, false);
   // Verify descending order
-  testCompareFloats<double>(DOUBLE(), false);
+  testCompareFloats<double>(DOUBLE(), false, true);
+  testCompareFloats<double>(DOUBLE(), false, false);
 }


### PR DESCRIPTION
(1) Make order by store key columns first in RowContainer column order;
(2) Extends RowContainer's compareRows method to take compare flags
to control sort order;
(3) Add reusable output buffer;
(4) Configure the output batch size based on preferredOutputBatchSize
query config.
