### PR TITLE
Implement date_parse

### DIFF
--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -935,6 +935,93 @@ TEST_F(JodaDateTimeFormatterTest, parseMixedWeekFormat) {
       util::fromTimestampString("2021-06-03 13:29:21.213"),
       parse("2021 22 4 13:29:21.213", "x w e HH:mm:ss.SSS"));
 
+  // Day of week short text normal capitlization
+  EXPECT_EQ(
+      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      parse("2021 1 Mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      parse("2021 22 Mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      parse("2021 22 Thu 13:29:21.213", "x w E HH:mm:ss.SSS"));
+
+  // Day of week long text normal capitlization
+  EXPECT_EQ(
+      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      parse("2021 1 Monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      parse("2021 22 Monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      parse("2021 22 Thursday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+
+  // Day of week short text upper case
+  EXPECT_EQ(
+      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      parse("2021 1 MON 13:29:21.213", "x w E HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      parse("2021 22 MON 13:29:21.213", "x w E HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      parse("2021 22 THU 13:29:21.213", "x w E HH:mm:ss.SSS"));
+
+  // Day of week long text upper case
+  EXPECT_EQ(
+      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      parse("2021 1 MONDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      parse("2021 22 MONDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      parse("2021 22 THURSDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+
+  // Day of week short text lower case
+  EXPECT_EQ(
+      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      parse("2021 1 mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      parse("2021 22 mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      parse("2021 22 thu 13:29:21.213", "x w E HH:mm:ss.SSS"));
+
+  // Day of week long text lower case
+  EXPECT_EQ(
+      util::fromTimestampString("2021-01-04 13:29:21.213"),
+      parse("2021 1 monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-05-31 13:29:21.213"),
+      parse("2021 22 monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+
+  EXPECT_EQ(
+      util::fromTimestampString("2021-06-03 13:29:21.213"),
+      parse("2021 22 thursday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+
+  // Invalid day of week throw cases
+  EXPECT_THROW(parse("mOn", "E"), VeloxUserError);
+  EXPECT_THROW(parse("tuE", "E"), VeloxUserError);
+  EXPECT_THROW(parse("WeD", "E"), VeloxUserError);
+  EXPECT_THROW(parse("WEd", "E"), VeloxUserError);
+  EXPECT_THROW(parse("MONday", "EEE"), VeloxUserError);
+  EXPECT_THROW(parse("monDAY", "EEE"), VeloxUserError);
+  EXPECT_THROW(parse("frIday", "EEE"), VeloxUserError);
+
   // Backwards, just for fun:
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <velox/type/Timestamp.h>
+#include <string_view>
 #include "velox/core/QueryConfig.h"
 #include "velox/external/date/tz.h"
 #include "velox/functions/Macros.h"
@@ -840,29 +841,19 @@ struct DateFormatFunction {
 template <typename T>
 struct DateParseFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
-  static constexpr folly::StringPiece supportedFormat{"%Y-%m-%d"};
-  static constexpr folly::StringPiece correspondingJodaFormat{"YYYY-MM-dd"};
 
-  std::optional<JodaFormatter> format_;
+  std::shared_ptr<DateTimeFormatter> format_;
   std::optional<int64_t> sessionTzID_;
-
-  void validateFormat(const velox::StringView& format) {
-    if (format != supportedFormat) {
-      VELOX_USER_FAIL(
-          "'date_parse' function currently only supports '%Y-%m-%d' format but "
-          "'",
-          format,
-          "' is provided");
-    }
-  }
+  bool isConstFormat_ = false;
 
   FOLLY_ALWAYS_INLINE void initialize(
       const core::QueryConfig& config,
       const arg_type<Varchar>* /*input*/,
       const arg_type<Varchar>* formatString) {
     if (formatString != nullptr) {
-      validateFormat(*formatString);
-      format_.emplace(correspondingJodaFormat.data());
+      format_ = buildMysqlDateTimeFormatter(
+          std::string_view(formatString->data(), formatString->size()));
+      isConstFormat_ = true;
     }
 
     auto sessionTzName = config.sessionTimezone();
@@ -872,17 +863,22 @@ struct DateParseFunction {
   }
 
   FOLLY_ALWAYS_INLINE bool call(
-      out_type<Timestamp>& result,
+      out_type<TimestampWithTimezone>& result,
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& format) {
-    validateFormat(format);
-    if (!format_.has_value()) {
-      format_.emplace(correspondingJodaFormat.data());
+    if (!isConstFormat_) {
+      format_ = buildMysqlDateTimeFormatter(
+          std::string_view(format.data(), format.size()));
     }
-    auto jodaResult = format_->parse(input);
+
+    auto dateTimeResult =
+        format_->parse(std::string_view(input.data(), input.size()));
+
+    // Since MySql format has no timezone specifier, simply check if session
+    // timezone was provided. If not, fallback to 0 (GMT).
     int16_t timezoneId = sessionTzID_.value_or(0);
-    jodaResult.timestamp.toGMT(timezoneId);
-    result = jodaResult.timestamp;
+    dateTimeResult.timestamp.toGMT(timezoneId);
+    result = std::make_tuple(dateTimeResult.timestamp.toMillis(), timezoneId);
     return true;
   }
 };

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -92,7 +92,7 @@ void registerSimpleFunctions() {
       TimestampWithTimezone,
       Varchar,
       Varchar>({"parse_datetime"});
-  registerFunction<DateParseFunction, Timestamp, Varchar, Varchar>(
+  registerFunction<DateParseFunction, TimestampWithTimezone, Varchar, Varchar>(
       {"date_parse"});
 }
 } // namespace

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -112,7 +112,7 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
         rowVector->children()[1]->as<SimpleVector<int16_t>>()->valueAt(0)};
   }
 
-  std::optional<Timestamp> dateParse(
+  std::optional<TimestampWithTimezone> dateParse(
       const std::optional<std::string>& input,
       const std::optional<std::string>& format) {
     auto resultVector = evaluate(
@@ -125,7 +125,10 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
     if (resultVector->isNullAt(0)) {
       return std::nullopt;
     }
-    return resultVector->as<SimpleVector<Timestamp>>()->valueAt(0);
+    auto rowVector = resultVector->as<RowVector>();
+    return TimestampWithTimezone{
+        rowVector->children()[0]->as<SimpleVector<int64_t>>()->valueAt(0),
+        rowVector->children()[1]->as<SimpleVector<int16_t>>()->valueAt(0)};
   }
 
   std::optional<std::string> dateFormat(
@@ -2279,15 +2282,51 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
 }
 
 TEST_F(DateTimeFunctionsTest, dateParse) {
-  EXPECT_EQ(Timestamp(86400, 0), dateParse("1970-01-02", "%Y-%m-%d"));
-  EXPECT_EQ(Timestamp(0, 0), dateParse("1970-01-01", "%Y-%m-%d"));
-
   // Check null behavior.
   EXPECT_EQ(std::nullopt, dateParse("1970-01-01", std::nullopt));
-  EXPECT_EQ(std::nullopt, dateParse(std::nullopt, "%Y-%m-%d"));
+  EXPECT_EQ(std::nullopt, dateParse(std::nullopt, "YYYY-MM-dd"));
   EXPECT_EQ(std::nullopt, dateParse(std::nullopt, std::nullopt));
 
-  // Ensure it throws.
-  EXPECT_THROW(dateParse("", ""), VeloxUserError);
-  EXPECT_THROW(dateParse("1999-01-01-Jan", "%Y-%m-%d-%M"), VeloxUserError);
+  // Simple tests. More exhaustive tests are provided in DateTimeFormatterTest.
+  EXPECT_EQ(
+      TimestampWithTimezone(86400000, 0), dateParse("1970-01-02", "%Y-%m-%d"));
+  EXPECT_EQ(TimestampWithTimezone(0, 0), dateParse("1970-01-01", "%Y-%m-%d"));
+  EXPECT_EQ(
+      TimestampWithTimezone(86400000, 0), dateParse("19700102", "%Y%m%d"));
+
+  // Tests for differing query timezones
+  // 118860000 is the number of milliseconds since epoch at 1970-01-02
+  // 09:01:00.000 UTC.
+  EXPECT_EQ(
+      TimestampWithTimezone(118860000, 0),
+      dateParse("1970-01-02+09:01", "%Y-%m-%d+%H:%i"));
+
+  setQueryTimeZone("America/Los_Angeles");
+  EXPECT_EQ(
+      TimestampWithTimezone(
+          118860000, util::getTimeZoneID("America/Los_Angeles")),
+      dateParse("1970-01-02+01:01", "%Y-%m-%d+%H:%i"));
+
+  setQueryTimeZone("America/Noronha");
+  EXPECT_EQ(
+      TimestampWithTimezone(118860000, util::getTimeZoneID("America/Noronha")),
+      dateParse("1970-01-02+07:01", "%Y-%m-%d+%H:%i"));
+
+  setQueryTimeZone("+04:00");
+  EXPECT_EQ(
+      TimestampWithTimezone(118860000, util::getTimeZoneID("+04:00")),
+      dateParse("1970-01-02+13:01", "%Y-%m-%d+%H:%i"));
+
+  setQueryTimeZone("Asia/Kolkata");
+  // 66600000 is the number of millisecond since epoch at 1970-01-01
+  // 18:30:00.000 UTC.
+  EXPECT_EQ(
+      TimestampWithTimezone(66600000, util::getTimeZoneID("Asia/Kolkata")),
+      dateParse("1970-01-02+00:00", "%Y-%m-%d+%H:%i"));
+
+  // -66600000 is the number of millisecond since epoch at 1969-12-31
+  // 05:30:00.000 UTC.
+  EXPECT_EQ(
+      TimestampWithTimezone(-66600000, util::getTimeZoneID("Asia/Kolkata")),
+      dateParse("1969-12-31+11:00", "%Y-%m-%d+%H:%i"));
 }


### PR DESCRIPTION
Summary: Implemented parsing for MySql format. This implementation uses the existing DateTimeFormatter class to build a vector of tokens used to parse the inputted string into a timestamp.

Reviewed By: tanjialiang

Differential Revision: D38219049

