### PR TITLE
Add custom sort and batch copy support for SpillStream

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -549,6 +549,7 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
         // number. Any from one to three bits would do.
         HashBitRange(29, 29 + spillPartitionBits_),
         rows->keyTypes().size(),
+        std::vector<CompareFlags>(),
         spillPath_.value(),
         fileSize,
         Spiller::spillPool(),

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -77,4 +77,19 @@ wrap(vector_size_t size, BufferPtr mapping, const RowVectorPtr& vector);
 // Ensures that all LazyVectors reachable from 'input' are loaded for all rows.
 void loadColumns(const RowVectorPtr& input, core::ExecCtx& execCtx);
 
+/// Scatter copy from multiple source row vectors into the target row vector.
+/// 'targetIndex' is first row in 'target' to copy to. 'count' specifies how
+/// many rows to copy from the sources. 'sources' and 'sourceIndices' specify
+/// the source rows to copy from. If 'columnMap' is not empty, it provides the
+/// column channel mappings between target row vector and source row vectors.
+///
+/// NOTE: all the source row vectors must have the same data type.
+void gatherCopy(
+    RowVector* target,
+    vector_size_t targetIndex,
+    vector_size_t count,
+    const std::vector<const RowVector*>& sources,
+    const std::vector<vector_size_t>& sourceIndices,
+    const std::vector<IdentityProjection>& columnMap = {});
+
 } // namespace facebook::velox::exec

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -84,6 +84,7 @@ WriteFile& SpillFileList::currentOutput() {
     files_.push_back(std::make_unique<SpillFile>(
         type_,
         numSortingKeys_,
+        sortCompareFlags_,
         fmt::format("{}-{}", path_, files_.size()),
         pool_));
   }
@@ -136,10 +137,10 @@ uint64_t SpillFileList::spilledBytes() const {
   return bytes;
 }
 
-std::vector<std::string> SpillFileList::TEST_spilledFiles() const {
+std::vector<std::string> SpillFileList::testingSpilledFilePaths() const {
   std::vector<std::string> spilledFiles;
   for (auto& file : files_) {
-    spilledFiles.push_back(file->TEST_filePath());
+    spilledFiles.push_back(file->testingFilePath());
   }
   return spilledFiles;
 }
@@ -159,6 +160,7 @@ void SpillState::appendToPartition(
     files_[partition] = std::make_unique<SpillFileList>(
         std::static_pointer_cast<const RowType>(rows->type()),
         numSortingKeys_,
+        sortCompareFlags_,
         fmt::format("{}-spill-{}", path_, partition),
         targetFileSize_,
         pool_,
@@ -181,7 +183,7 @@ std::unique_ptr<TreeOfLosers<SpillStream>> SpillState::startMerge(
     }
   }
   VELOX_DCHECK_EQ(!result.empty(), isPartitionSpilled(partition));
-  if (extra) {
+  if (extra != nullptr) {
     result.push_back(std::move(extra));
   }
   // Check if the partition is empty or not.
@@ -221,11 +223,11 @@ int64_t SpillState::spilledFiles() const {
   return numFiles;
 }
 
-std::vector<std::string> SpillState::TEST_spilledFiles() const {
+std::vector<std::string> SpillState::testingSpilledFilePaths() const {
   std::vector<std::string> spilledFiles;
   for (const auto& list : files_) {
     if (list != nullptr) {
-      const auto spilledFilesFromList = list->TEST_spilledFiles();
+      const auto spilledFilesFromList = list->testingSpilledFilePaths();
       spilledFiles.insert(
           spilledFiles.end(),
           spilledFilesFromList.begin(),

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -70,6 +70,7 @@ class Spiller {
       RowContainer::Eraser eraser,
       RowTypePtr rowType,
       int32_t numSortingKeys,
+      const std::vector<CompareFlags>& sortCompareFlags,
       const std::string& path,
       int64_t targetFileSize,
       memory::MemoryPool& pool,
@@ -82,6 +83,7 @@ class Spiller {
       RowTypePtr rowType,
       HashBitRange bits,
       int32_t numSortingKeys,
+      const std::vector<CompareFlags>& sortCompareFlags,
       const std::string& path,
       int64_t targetFileSize,
       memory::MemoryPool& pool,
@@ -249,8 +251,8 @@ class Spiller {
   RowContainer& container_;
   const RowContainer::Eraser eraser_;
   const HashBitRange bits_;
+  const RowTypePtr rowType_;
 
-  RowTypePtr rowType_;
   SpillState state_;
 
   // Indices into 'spillRuns_' that are currently getting spilled.

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -15,11 +15,94 @@
  */
 #include "velox/exec/OperatorUtils.h"
 #include <gtest/gtest.h>
+#include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/exec/Operator.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
 
 class OperatorUtilsTest : public ::testing::Test {
  protected:
+  void gatherCopyTest(
+      const std::shared_ptr<const RowType>& targetType,
+      const std::shared_ptr<const RowType>& sourceType,
+      int numSources) {
+    folly::Random::DefaultGenerator rng(1);
+    const int kNumRows = 500;
+    const int kNumColumns = sourceType->size();
+
+    // Build source vectors with nulls.
+    std::vector<RowVectorPtr> sources;
+    for (int i = 0; i < numSources; ++i) {
+      sources.push_back(std::static_pointer_cast<RowVector>(
+          BatchMaker::createBatch(sourceType, kNumRows, *pool_)));
+      for (int j = 0; j < kNumColumns; ++j) {
+        auto vector = sources.back()->childAt(j);
+        int nullRow = (folly::Random::rand32() % kNumRows) / 4;
+        while (nullRow < kNumRows) {
+          vector->setNull(nullRow, true);
+          nullRow +=
+              std::max<int>(1, (folly::Random::rand32() % kNumColumns) / 4);
+        }
+      }
+    }
+
+    std::vector<IdentityProjection> columnMap;
+    if (sourceType != targetType) {
+      for (column_index_t sourceChannel = 0; sourceChannel < kNumColumns;
+           ++sourceChannel) {
+        const auto columnName = sourceType->nameOf(sourceChannel);
+        const column_index_t targetChannel =
+            targetType->getChildIdx(columnName);
+        columnMap.emplace_back(sourceChannel, targetChannel);
+      }
+    }
+
+    std::vector<const RowVector*> sourcesVectors(kNumRows);
+    std::vector<vector_size_t> sourceIndices(kNumRows);
+    for (int iter = 0; iter < 5; ++iter) {
+      const int count =
+          folly::Random::oneIn(10) ? 0 : folly::Random::rand32() % kNumRows;
+      const int targetIndex = folly::Random::rand32() % (kNumRows - count);
+      for (int i = 0; i < count; ++i) {
+        sourcesVectors[i] = sources[folly::Random::rand32() % numSources].get();
+        sourceIndices[i] = sourceIndices[folly::Random::rand32() % kNumRows];
+      }
+      auto targetVector =
+          BaseVector::create<RowVector>(targetType, kNumRows, pool_.get());
+      for (int32_t childIdx = 0; childIdx < targetVector->childrenSize();
+           ++childIdx) {
+        targetVector->childAt(childIdx)->resize(kNumRows);
+      }
+      gatherCopy(
+          targetVector.get(),
+          targetIndex,
+          count,
+          sourcesVectors,
+          sourceIndices,
+          columnMap);
+
+      // Verify the copied data in target.
+      for (int i = 0; i < kNumColumns; ++i) {
+        const column_index_t sourceColumnChannel =
+            columnMap.empty() ? i : columnMap[i].inputChannel;
+        const column_index_t targetColumnChannel =
+            columnMap.empty() ? i : columnMap[i].outputChannel;
+        auto vector = targetVector->childAt(targetColumnChannel);
+        for (int j = 0; j < count; ++j) {
+          auto source = sourcesVectors[j]->childAt(sourceColumnChannel).get();
+          if (vector->isNullAt(targetIndex + j)) {
+            ASSERT_TRUE(source->isNullAt(sourceIndices[j]));
+          } else {
+            ASSERT_TRUE(vector->equalValueAt(
+                source, targetIndex + j, sourceIndices[j]));
+          }
+        }
+      }
+    }
+  }
+
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
 };
@@ -37,4 +120,54 @@ TEST_F(OperatorUtilsTest, wrapChildConstant) {
   ASSERT_EQ(wrapped->size(), 1'234);
   ASSERT_TRUE(wrapped->isConstantEncoding());
   ASSERT_TRUE(wrapped->equalValueAt(constant.get(), 100, 100));
+}
+
+TEST_F(OperatorUtilsTest, gatherCopy) {
+  std::shared_ptr<const RowType> rowType;
+  std::shared_ptr<const RowType> reversedRowType;
+  {
+    std::vector<std::string> names = {
+        "bool_val",
+        "tiny_val",
+        "small_val",
+        "int_val",
+        "long_val",
+        "ordinal",
+        "float_val",
+        "double_val",
+        "string_val",
+        "array_val",
+        "struct_val",
+        "map_val"};
+    std::vector<std::string> reversedNames = names;
+    std::reverse(reversedNames.begin(), reversedNames.end());
+
+    std::vector<std::shared_ptr<const Type>> types = {
+        BOOLEAN(),
+        TINYINT(),
+        SMALLINT(),
+        INTEGER(),
+        BIGINT(),
+        BIGINT(),
+        REAL(),
+        DOUBLE(),
+        VARCHAR(),
+        ARRAY(VARCHAR()),
+        ROW({{"s_int", INTEGER()}, {"s_array", ARRAY(REAL())}}),
+        MAP(VARCHAR(),
+            MAP(BIGINT(),
+                ROW({{"s2_int", INTEGER()}, {"s2_string", VARCHAR()}})))};
+    std::vector<std::shared_ptr<const Type>> reversedTypes = types;
+    std::reverse(reversedTypes.begin(), reversedTypes.end());
+
+    rowType = ROW(std::move(names), std::move(types));
+    reversedRowType = ROW(std::move(reversedNames), std::move(reversedTypes));
+  }
+
+  // Gather copy with identical column mapping.
+  gatherCopyTest(rowType, rowType, 1);
+  gatherCopyTest(rowType, rowType, 5);
+  // Gather copy with non-identical column mapping.
+  gatherCopyTest(rowType, reversedRowType, 1);
+  gatherCopyTest(rowType, reversedRowType, 5);
 }


### PR DESCRIPTION
(1) add to specify the sorting order in SpillStream object to use in case of OrderBy, which makes
Spiller use the same sort order as the OrderBy operator. Correspondingly, allow the Spiller object
 to specify the sorting order which pass it to the created SpillFile and RowContainerSpillStream.
(2) support batch copy from SpillStream object by exposing endOfBatch flag to indicate if a stream
has reached to the end of the current input batch. There is a demonstration how to do batch copy
from multiple streams in SpillerTest as an example.
(3) support batch copy from SpillStream object by adding a scatterCopy utility to do scatter copy
from multiple source vectors.