### PR TITLE
Fix DateTimeFormatter fraction of second formatting logic

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -444,6 +444,33 @@ int64_t parseHalfDayOfDay(const char* cur, const char* end, Date& date) {
   }
 }
 
+std::string formatFractionOfSecond(
+    uint16_t subseconds,
+    size_t minRepresentDigits) {
+  char toAdd[minRepresentDigits > 3 ? minRepresentDigits + 1 : 4];
+
+  if (subseconds < 10) {
+    toAdd[0] = '0';
+    toAdd[1] = '0';
+    toAdd[2] = char(subseconds + '0');
+  } else if (subseconds < 100) {
+    toAdd[2] = char(subseconds % 10 + '0');
+    toAdd[1] = char((subseconds / 10) % 10 + '0');
+    toAdd[0] = '0';
+  } else {
+    toAdd[2] = char(subseconds % 10 + '0');
+    toAdd[1] = char((subseconds / 10) % 10 + '0');
+    toAdd[0] = char((subseconds / 100) % 10 + '0');
+  }
+
+  if (minRepresentDigits > 3) {
+    memset(toAdd + 3, '0', minRepresentDigits - 3);
+  }
+
+  toAdd[minRepresentDigits] = '\0';
+  return toAdd;
+}
+
 // According to DateTimeFormatSpecifier enum class
 std::string getSpecifierName(int enumInt) {
   switch (enumInt) {
@@ -1003,14 +1030,13 @@ std::string DateTimeFormatter::format(
               token.pattern.minRepresentDigits);
           break;
 
-        case DateTimeFormatSpecifier::FRACTION_OF_SECOND:
-          result += padContent(
-                        durationInTheDay.subseconds().count(),
-                        '0',
-                        token.pattern.minRepresentDigits,
-                        false)
-                        .substr(0, token.pattern.minRepresentDigits);
+        case DateTimeFormatSpecifier::FRACTION_OF_SECOND: {
+          result += formatFractionOfSecond(
+              durationInTheDay.subseconds().count(),
+              token.pattern.minRepresentDigits);
           break;
+        }
+
         case DateTimeFormatSpecifier::TIMEZONE:
           // TODO: implement short name time zone, need a map from full name to
           // short name

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -1397,6 +1397,26 @@ TEST_F(MysqlDateTimeTest, formatFractionOfSecond) {
       buildMysqlDateTimeFormatter("%f")->format(
           util::fromTimestampString("2000-02-01 00:00:00.987654"), timezone),
       "987000");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%f")->format(
+          util::fromTimestampString("2000-02-01 00:00:00.900654"), timezone),
+      "900000");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%f")->format(
+          util::fromTimestampString("2000-02-01 00:00:00.090654"), timezone),
+      "090000");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%f")->format(
+          util::fromTimestampString("2000-02-01 00:00:00.009654"), timezone),
+      "009000");
+
+  EXPECT_EQ(
+      buildMysqlDateTimeFormatter("%f")->format(
+          util::fromTimestampString("2000-02-01 00:00:00.000654"), timezone),
+      "000000");
 }
 
 TEST_F(MysqlDateTimeTest, formatHour) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -2246,6 +2246,12 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
       "12300000",
       formatDatetime(
           fromTimestampString("2022-01-01 03:30:30.123"), "SSSSSSSS"));
+  EXPECT_EQ(
+      "0990",
+      formatDatetime(fromTimestampString("2022-01-01 03:30:30.099"), "SSSS"));
+  EXPECT_EQ(
+      "0010",
+      formatDatetime(fromTimestampString("2022-01-01 03:30:30.001"), "SSSS"));
 
   // time zone test cases - 'z'
   setQueryTimeZone("Asia/Kolkata");
@@ -2412,6 +2418,12 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
   EXPECT_EQ(
       "123000",
       dateFormat(fromTimestampString("2022-01-01 03:30:30.123"), "%f"));
+  EXPECT_EQ(
+      "099000",
+      dateFormat(fromTimestampString("2022-01-01 03:30:30.099"), "%f"));
+  EXPECT_EQ(
+      "001000",
+      dateFormat(fromTimestampString("2022-01-01 03:30:30.001234"), "%f"));
 
   // Hour cases
   for (int i = 0; i < 24; i++) {


### PR DESCRIPTION
Summary: DateTimeFormatter class did not properly take into account leading zeroes when formatting the fraction of second of the time. For example, 0.1 seconds and 0.01 seconds both get formatted to 100 milliseconds, which is an incorrect formatting. Updated logic to preserve leading 0s in formatting.

Differential Revision: D38511334

