### PR TITLE
Add isVectorWritable function to BaseVector

### DIFF
--- a/velox/benchmarks/basic/Preproc.cpp
+++ b/velox/benchmarks/basic/Preproc.cpp
@@ -79,10 +79,10 @@ class BaseFunction : public exec::VectorFunction {
 
       T* rawResults = nullptr;
       if (!result) {
-        if (BaseVector::isReusableFlatVector(args[0])) {
+        if (BaseVector::isVectorWritable(args[0])) {
           rawResults = rawA;
           result = std::move(args[0]);
-        } else if (BaseVector::isReusableFlatVector(args[1])) {
+        } else if (BaseVector::isVectorWritable(args[1])) {
           rawResults = rawB;
           result = std::move(args[1]);
         }
@@ -131,7 +131,7 @@ class BaseFunction : public exec::VectorFunction {
       VectorPtr& result) const {
     // Check if input can be reused for results.
     T* rawResults;
-    if (!result && BaseVector::isReusableFlatVector(flat)) {
+    if (!result && BaseVector::isVectorWritable(flat)) {
       rawResults = rawValues;
       result = std::move(flat);
     } else {

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -60,7 +60,8 @@ void extractColumns(
   for (auto projection : projections) {
     auto& child = result->childAt(projection.outputChannel);
     // TODO: Consider reuse of complex types.
-    if (!child || !BaseVector::isReusableFlatVector(child)) {
+    if (!child || !BaseVector::isVectorWritable(child) ||
+        !child->isFlatEncoding()) {
       child = BaseVector::create(
           result->type()->childAt(projection.outputChannel), rows.size(), pool);
     }

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -123,7 +123,8 @@ class Expr {
     if (sharedSubexprRows_) {
       sharedSubexprRows_->clearAll();
     }
-    if (BaseVector::isReusableFlatVector(sharedSubexprValues_)) {
+    if (BaseVector::isVectorWritable(sharedSubexprValues_) &&
+        sharedSubexprValues_->isFlatEncoding()) {
       sharedSubexprValues_->resize(0);
     } else {
       sharedSubexprValues_ = nullptr;

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -223,7 +223,7 @@ class SimpleFunctionAdapter : public VectorFunction {
           CppToType<typename arg_at<POSITION>::underlying_type>::typeKind ==
           return_type_traits::typeKind) {
         for (auto i = POSITION; i < args.size(); i++) {
-          if (BaseVector::isReusableFlatVector(args[i])) {
+          if (BaseVector::isVectorWritable(args[i])) {
             return &args[i];
           }
         }
@@ -233,7 +233,7 @@ class SimpleFunctionAdapter : public VectorFunction {
       return nullptr;
     } else if constexpr (
         CppToType<arg_at<POSITION>>::typeKind == return_type_traits::typeKind) {
-      if (BaseVector::isReusableFlatVector(args[POSITION])) {
+      if (BaseVector::isVectorWritable(args[POSITION])) {
         // Re-use arg for result. We rely on the fact that for each row
         // we read arguments before computing and writing out the
         // result.

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -155,10 +155,6 @@ class BiasVector : public SimpleVector<T> {
     return true;
   }
 
-  bool isNullsWritable() const override {
-    return true;
-  }
-
   VectorPtr slice(vector_size_t, vector_size_t) const override {
     VELOX_NYI();
   }

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -154,6 +154,8 @@ class RowVector : public BaseVector {
 
   void ensureWritable(const SelectivityVector& rows) override;
 
+  bool isWritable() const override;
+
   /// Calls BaseVector::prepareForReuse() to check and reset nulls buffer if
   /// needed, then calls BaseVector::prepareForReuse(child, 0) for all children.
   void prepareForReuse() override;
@@ -430,6 +432,8 @@ class ArrayVector : public ArrayVectorBase {
 
   void ensureWritable(const SelectivityVector& rows) override;
 
+  bool isWritable() const override;
+
   /// Calls BaseVector::prepareForReuse() to check and reset nulls buffer if
   /// needed, checks and resets offsets and sizes buffers, zeros out offsets and
   /// sizes if reusable, calls BaseVector::prepareForReuse(elements, 0) for the
@@ -577,6 +581,8 @@ class MapVector : public ArrayVectorBase {
   std::vector<vector_size_t> sortedKeyIndices(vector_size_t index) const;
 
   void ensureWritable(const SelectivityVector& rows) override;
+
+  bool isWritable() const override;
 
   /// Calls BaseVector::prepareForReuse() to check and reset nulls buffer if
   /// needed, checks and resets offsets and sizes buffers, zeros out offsets and

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -320,6 +320,10 @@ class ConstantVector final : public SimpleVector<T> {
     return valueVector_->toString(index_);
   }
 
+  bool isNullsWritable() const override {
+    return false;
+  }
+
  protected:
   std::string toSummaryString() const override {
     std::stringstream out;

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -176,10 +176,6 @@ class DictionaryVector : public SimpleVector<T> {
     return dictionaryValues_->wrappedIndex(rawIndices_[index]);
   }
 
-  bool isNullsWritable() const override {
-    return true;
-  }
-
   std::string toString(vector_size_t index) const override {
     if (BaseVector::isNullAt(index)) {
       return "null";

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -177,6 +177,10 @@ class SequenceVector : public SimpleVector<T> {
     VELOX_NYI();
   }
 
+  bool isNullsWritable() const override {
+    return false;
+  }
+
  private:
   // Prepares for use after construction.
   void setInternalState();

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -169,10 +169,6 @@ class SimpleVector : public BaseVector {
     return elementSize_;
   }
 
-  bool isNullsWritable() const override {
-    return false;
-  }
-
   using BaseVector::toString;
 
   std::string toString(vector_size_t index) const override {

--- a/velox/vector/VectorPool.cpp
+++ b/velox/vector/VectorPool.cpp
@@ -56,7 +56,9 @@ size_t VectorPool::release(std::vector<VectorPtr>& vectors) {
 }
 
 bool VectorPool::TypePool::maybePushBack(VectorPtr& vector) {
-  if (!vector->isRecyclable()) {
+  // Check that this is a Flat Vector with an initialized, unique, and mutable
+  // values Buffer and an uninitialized or unique and mutable nulls Buffer.
+  if (!vector->isWritable() || !vector->isFlatEncoding() || !vector->values()) {
     return false;
   }
   if (size >= kNumPerType) {

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -778,7 +778,7 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
     // buffer, depending on the string sizes, in which case the buffers could be
     // reusable. So we don't check them in here.
     if constexpr (!std::is_same_v<T, std::string>) {
-      EXPECT_FALSE(BaseVector::isReusableFlatVector(output));
+      EXPECT_FALSE(BaseVector::isVectorWritable(output));
     }
   }
 

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
   DecodedVectorTest.cpp
   SelectivityVectorTest.cpp
   EnsureWritableVectorTest.cpp
+  IsWritableVectorTest.cpp
   LazyVectorTest.cpp
   MayHaveNullsRecursiveTest.cpp)
 

--- a/velox/vector/tests/IsWritableVectorTest.cpp
+++ b/velox/vector/tests/IsWritableVectorTest.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <velox/buffer/Buffer.h>
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/tests/VectorMaker.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+class IsWritableVectorTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = memory::getDefaultScopedMemoryPool();
+    vectorMaker_ = std::make_unique<VectorMaker>(pool_.get());
+  }
+
+  // We use templates here to avoid the compiler automatically creating new
+  // shared_ptrs which it would do if we used VectorPtr.
+  template <typename T, typename V>
+  void testChildVector(
+      const std::shared_ptr<T>& vector,
+      const std::shared_ptr<V>& childVector) {
+    ASSERT_TRUE(vector->isNullsWritable());
+    ASSERT_TRUE(BaseVector::isVectorWritable(vector));
+
+    {
+      // Make a copy of childVector so it's no longer writable.
+      auto copy = childVector;
+      ASSERT_TRUE(vector->isNullsWritable());
+      ASSERT_FALSE(BaseVector::isVectorWritable(vector));
+    }
+  }
+
+  // We use templates here to avoid the compiler automatically creating new
+  // shared_ptrs which it would do if we used VectorPtr.
+  template <typename T>
+  void testBufferPtr(
+      const std::shared_ptr<T>& vector,
+      const BufferPtr& buffer) {
+    ASSERT_TRUE(vector->isNullsWritable());
+    ASSERT_TRUE(BaseVector::isVectorWritable(vector));
+
+    {
+      // Make a copy of buffer so it's no longer mutable.
+      auto copy = buffer;
+      ASSERT_TRUE(vector->isNullsWritable());
+      ASSERT_FALSE(BaseVector::isVectorWritable(vector));
+    }
+
+    // Set buffer to no longer be mutable.
+    buffer->setIsMutable(false);
+    ASSERT_TRUE(vector->isNullsWritable());
+    ASSERT_FALSE(BaseVector::isVectorWritable(vector));
+
+    buffer->setIsMutable(true);
+
+    // Make sure nothing gets left unwritable.
+    ASSERT_TRUE(vector->isNullsWritable());
+    ASSERT_TRUE(BaseVector::isVectorWritable(vector));
+  }
+
+  // We use templates here to avoid the compiler automatically creating new
+  // shared_ptrs which it would do if we used VectorPtr.
+  template <typename T>
+  void basicTest(const std::shared_ptr<T>& vector) {
+    ASSERT_TRUE(vector->isNullsWritable());
+    ASSERT_TRUE(BaseVector::isVectorWritable(vector));
+
+    {
+      auto copy = vector;
+      ASSERT_TRUE(vector->isNullsWritable());
+      // The Vector is not uniquely referenced.
+      ASSERT_FALSE(BaseVector::isVectorWritable(vector));
+    }
+
+    // Hack to ensure nulls are allocated.
+    vector->mutableRawNulls();
+    ASSERT_TRUE(vector->isNullsWritable());
+    ASSERT_TRUE(BaseVector::isVectorWritable(vector));
+
+    {
+      // Make a copy of nulls so it's no longer mutable.
+      auto nulls = vector->nulls();
+      ASSERT_FALSE(vector->isNullsWritable());
+      ASSERT_FALSE(BaseVector::isVectorWritable(vector));
+    }
+  }
+
+  std::unique_ptr<memory::MemoryPool> pool_;
+  std::unique_ptr<VectorMaker> vectorMaker_;
+};
+
+TEST_F(IsWritableVectorTest, flatVector) {
+  auto flatVector = vectorMaker_->flatVector(std::vector<int32_t>{1, 2, 3});
+
+  basicTest(flatVector);
+  testBufferPtr(flatVector, flatVector->values());
+}
+
+TEST_F(IsWritableVectorTest, arrayVector) {
+  auto arrayVector =
+      vectorMaker_->arrayVector<int32_t>({{1, 2}, {3, 4}, {5, 6}});
+
+  basicTest(arrayVector);
+  testBufferPtr(arrayVector, arrayVector->offsets());
+  testBufferPtr(arrayVector, arrayVector->sizes());
+  testChildVector(arrayVector, arrayVector->elements());
+}
+
+TEST_F(IsWritableVectorTest, mapVector) {
+  auto mapVector = vectorMaker_->mapVector(
+      {0, 2, 4, 6},
+      vectorMaker_->flatVector<int32_t>({1, 2, 3, 4, 5, 6}),
+      vectorMaker_->flatVector<int32_t>({1, 2, 3, 4, 5, 6}));
+
+  basicTest(mapVector);
+  testBufferPtr(mapVector, mapVector->offsets());
+  testBufferPtr(mapVector, mapVector->sizes());
+  testChildVector(mapVector, mapVector->mapKeys());
+  testChildVector(mapVector, mapVector->mapValues());
+}
+
+TEST_F(IsWritableVectorTest, rowVector) {
+  auto rowVector = vectorMaker_->rowVector(
+      {vectorMaker_->flatVector<int32_t>({1, 2, 3, 4, 5, 6}),
+       vectorMaker_->flatVector<int32_t>({1, 2, 3, 4, 5, 6}),
+       vectorMaker_->flatVector<int32_t>({1, 2, 3, 4, 5, 6})});
+
+  basicTest(rowVector);
+  testChildVector(rowVector, rowVector->childAt(0));
+  testChildVector(rowVector, rowVector->childAt(1));
+  testChildVector(rowVector, rowVector->childAt(2));
+}


### PR DESCRIPTION
Summary:
This diff adds isVectorWritable to BaseVector.  This is a utility function that checks
that it is safe to write to the Vector.

It checks the following conditions
* The vector is singly referenced.
* The vector has a Flat-like encoding (Flat, Array, Map, Row).
* Any child Buffers are mutable (this also means they are singly referenced).
* All of these conditions hold for child Vectors recursively.

As part of this, I also modified isNullsWritable.  Previously, it would simply return
true if the Vector was not a Constant or Sequence Vector.  To be consistent both
with the naming and the way it is used, it now also checks that the nulls Buffer is
mutable.

I also modified the isMutable() function in Buffer.  Based on comments in the code,
it seems like a Buffer that is not unique should not be mutable (e.g. you can't call
setIsMutable(true) on a non-unique Buffer).  Further, I saw in the tests that before
creating a second reference to a Buffer, they would call setIsMutable(false) on the
Buffer (presumably to maintain consistency).  In order to guarantee we can't end up
in an inconsistent state, I modified isMutable() to return false whenever the Buffer is
not unique.  I added a comment to the field indicating mutable_ only applies when
the Buffer is unique.  This also allows us to simplify the many places where we
check buffer->isUnique() && buffer->isMutable().

These two latter changes allowed me to simplify the implementation of
isVectorWritable.

I plan to leverage this new function in
D38291699
https://github.com/facebookincubator/velox/pull/2167
in an assert to verify ensureWritable does not need to be called.

Differential Revision: D38515249

