### PR TITLE
Update DateTimeFormatter format logic to support two digit year, week_year, and year_of_era

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -507,8 +507,16 @@ void parseFromPattern(
       }
       number *= std::pow(10, 3 - count);
     } else if (
-        curPattern.specifier == DateTimeFormatSpecifier::YEAR &&
+        (curPattern.specifier == DateTimeFormatSpecifier::YEAR ||
+         curPattern.specifier == DateTimeFormatSpecifier::YEAR_OF_ERA ||
+         curPattern.specifier == DateTimeFormatSpecifier::WEEK_YEAR) &&
         curPattern.minRepresentDigits == 2) {
+      // If abbreviated two year digit is provided in format string, try to read
+      // in two digits of year and convert to appropriate full length year The
+      // two-digit mapping is as follows: [00, 69] -> [2000, 2069]
+      //                                  [70, 99] -> [1970, 1999]
+      // If more than two digits are provided, then simply read in full year
+      // normally without conversion
       int count = 0;
       while (cur < end && cur < startPos + maxDigitConsume &&
              characterIsDigit(*cur)) {
@@ -978,6 +986,13 @@ DateTimeResult DateTimeFormatter::parse(const std::string_view& input) const {
           util::isLeapYear(date.year) ? 366 : 365);
     }
   }
+
+  LOG(INFO) << "START LOG" << std::endl;
+  LOG(INFO) << "INPUT: " << input << std::endl;
+  LOG(INFO) << "YEAR: " << date.year << std::endl;
+  LOG(INFO) << "MONTH: " << date.month << std::endl;
+  LOG(INFO) << "DAY: " << date.day << std::endl;
+  LOG(INFO) << "END LOG" << std::endl << std::endl;
 
   // Convert the parsed date/time into a timestamp.
   int64_t daysSinceEpoch;

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -435,6 +435,16 @@ TEST_F(JodaDateTimeFormatterTest, parseYearOfEra) {
   EXPECT_THROW(parse("  ", " Y "), VeloxUserError);
   EXPECT_THROW(parse(" 1 2", "Y Y"), VeloxUserError);
 
+  // 2 'Y' token case
+  EXPECT_EQ(util::fromTimestampString("2012-01-01"), parse("12", "YY"));
+  EXPECT_EQ(util::fromTimestampString("2069-01-01"), parse("69", "YY"));
+  EXPECT_EQ(util::fromTimestampString("1970-01-01"), parse("70", "YY"));
+  EXPECT_EQ(util::fromTimestampString("1999-01-01"), parse("99", "YY"));
+  EXPECT_EQ(util::fromTimestampString("0002-01-01"), parse("2", "YY"));
+  EXPECT_EQ(util::fromTimestampString("0210-01-01"), parse("210", "YY"));
+  EXPECT_EQ(util::fromTimestampString("0001-01-01"), parse("1", "YY"));
+  EXPECT_EQ(util::fromTimestampString("2001-01-01"), parse("01", "YY"));
+
   // Last token read overwrites:
   EXPECT_EQ(
       util::fromTimestampString("0005-01-01"), parse("1 2 3 4 5", "Y Y Y Y Y"));
@@ -499,6 +509,16 @@ TEST_F(JodaDateTimeFormatterTest, parseWeekYear) {
       util::fromTimestampString("-0108-01-04 00:00:00"), parse("-108", "x"));
   EXPECT_EQ(
       util::fromTimestampString("-1002-12-31 00:00:00"), parse("-1001", "x"));
+
+  // 2 'x' token case
+  EXPECT_EQ(util::fromTimestampString("2012-01-02"), parse("12", "xx"));
+  EXPECT_EQ(util::fromTimestampString("2068-12-31"), parse("69", "xx"));
+  EXPECT_EQ(util::fromTimestampString("1969-12-29"), parse("70", "xx"));
+  EXPECT_EQ(util::fromTimestampString("1999-01-04"), parse("99", "xx"));
+  EXPECT_EQ(util::fromTimestampString("0001-12-31"), parse("2", "xx"));
+  EXPECT_EQ(util::fromTimestampString("0210-01-01"), parse("210", "xx"));
+  EXPECT_EQ(util::fromTimestampString("0001-01-01"), parse("1", "xx"));
+  EXPECT_EQ(util::fromTimestampString("2001-01-01"), parse("01", "xx"));
 
   // Plus sign consumption valid when x operator is not followed by another
   // specifier


### PR DESCRIPTION
Summary: Updated DateTimeFormatter.cpp parse logic to support two digit abbreviations for week_year and year_of_era tokens, in addition to the year token which already supported two digit abbreviations.

Reviewed By: tanjialiang

Differential Revision: D38524803

