### PR TITLE
Fix min_by and max_by aggregate functions for DATE inputs

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -41,7 +41,8 @@ const std::unordered_set<TypeKind> kSupportedTypes = {
     TypeKind::BIGINT,
     TypeKind::REAL,
     TypeKind::DOUBLE,
-    TypeKind::VARCHAR};
+    TypeKind::VARCHAR,
+    TypeKind::DATE};
 
 std::vector<TestParam> getTestParams() {
   std::vector<TestParam> params;
@@ -77,6 +78,9 @@ std::vector<TestParam> getTestParams() {
       case TypeKind::VARCHAR:                                        \
         testFunc<valueType, StringView>();                           \
         break;                                                       \
+      case TypeKind::DATE:                                           \
+        testFunc<valueType, Date>();                                 \
+        break;                                                       \
       default:                                                       \
         LOG(FATAL) << "Unsupported comparison type of minmax_by(): " \
                    << mapTypeKindToName(GetParam().comparisonType);  \
@@ -107,6 +111,9 @@ std::vector<TestParam> getTestParams() {
       case TypeKind::VARCHAR:                                   \
         EXECUTE_TEST_BY_VALUE_TYPE(testFunc, StringView);       \
         break;                                                  \
+      case TypeKind::DATE:                                      \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, Date);             \
+        break;                                                  \
       default:                                                  \
         LOG(FATAL) << "Unsupported value type of minmax_by(): " \
                    << mapTypeKindToName(GetParam().valueType);  \
@@ -115,7 +122,7 @@ std::vector<TestParam> getTestParams() {
 
 class MinMaxByAggregationTestBase : public AggregationTestBase {
  protected:
-  MinMaxByAggregationTestBase() : numValues_(6) {}
+  MinMaxByAggregationTestBase() : numValues_(7) {}
 
   void SetUp() override;
 
@@ -165,14 +172,15 @@ class MinMaxByAggregationTestBase : public AggregationTestBase {
       folly::Range<const int*> values);
 
   const RowTypePtr rowType_{
-      ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6"},
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6", "c7"},
           {TINYINT(),
            SMALLINT(),
            INTEGER(),
            BIGINT(),
            REAL(),
            DOUBLE(),
-           VARCHAR()})};
+           VARCHAR(),
+           DATE()})};
   // Specify the number of values in each typed data vector in
   // 'dataVectorsByType_'.
   const int numValues_;
@@ -223,6 +231,8 @@ VectorPtr MinMaxByAggregationTestBase::buildDataVector(
       return buildDataVector<double>(size, values);
     case TypeKind::VARCHAR:
       return buildDataVector<StringView>(size, values);
+    case TypeKind::DATE:
+      return buildDataVector<Date>(size, values);
     default:
       LOG(FATAL) << "Unsupported value/comparison type of minmax_by(): "
                  << mapTypeKindToName(kind);
@@ -252,6 +262,9 @@ void MinMaxByAggregationTestBase::SetUp() {
         break;
       case TypeKind::DOUBLE:
         dataVectorsByType_.emplace(type, buildDataVector<double>(numValues_));
+        break;
+      case TypeKind::DATE:
+        dataVectorsByType_.emplace(type, buildDataVector<Date>(numValues_));
         break;
       case TypeKind::VARCHAR:
         dataVectorsByType_.emplace(

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -122,7 +122,7 @@ std::vector<TestParam> getTestParams() {
 
 class MinMaxByAggregationTestBase : public AggregationTestBase {
  protected:
-  MinMaxByAggregationTestBase() : numValues_(7) {}
+  MinMaxByAggregationTestBase() : numValues_(6) {}
 
   void SetUp() override;
 


### PR DESCRIPTION
The min and max bounds used in min_by, max_by aggregate functions for DATE
datatype are both initialized to zero. This incorrect initialization is fixed in this PR
and the min, max bounds are initialized to minimum and maximum values 
possible for DATE respectively.