### PR TITLE
Add Parquet Floating Point Readers

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -20,6 +20,7 @@
 #include "velox/common/base/SimdUtil.h"
 #include "velox/dwio/common/DecoderUtil.h"
 #include "velox/dwio/common/SelectiveColumnReader.h"
+#include "velox/dwio/common/TypeUtil.h"
 
 namespace facebook::velox::dwio::common {
 
@@ -514,6 +515,13 @@ struct LoadIndices<int32_t, A> {
 };
 
 template <typename A>
+struct LoadIndices<float, A> {
+  static xsimd::batch<int32_t, A> apply(const float* values, const A&) {
+    return xsimd::load_unaligned<A>(reinterpret_cast<const int32_t*>(values));
+  }
+};
+
+template <typename A>
 struct LoadIndices<int16_t, A> {
   static xsimd::batch<int32_t, A> apply(
       const int16_t* values,
@@ -546,6 +554,16 @@ struct LoadIndices<int64_t, A> {
   }
 };
 
+template <typename A>
+struct LoadIndices<double, A> {
+  static xsimd::batch<int32_t, A> apply(const double* values, const A& arch) {
+    return simd::gather<int32_t, int32_t, 8>(
+        reinterpret_cast<const int32_t*>(values),
+        simd::iota<int32_t>(arch),
+        arch);
+  }
+};
+
 } // namespace detail
 
 template <typename T, typename A = xsimd::default_arch>
@@ -570,15 +588,23 @@ inline void storeTranslatePermute(
     int8_t numBits,
     const T* dict,
     T* values) {
+  using TIndex = typename make_index<T>::type;
   auto selectedIndices = simd::byteSetBits(selected);
   auto inDict = simd::toBitMask(dictMask);
   for (auto i = 0; i < numBits; ++i) {
-    auto value = input[inputIndex + selectedIndices[i]];
     if (inDict & (1 << selectedIndices[i])) {
-      value = dict[value];
+      auto index = reinterpret_cast<const TIndex*>(
+          input)[inputIndex + selectedIndices[i]];
+      if (sizeof(T) == 2) {
+        index &= 0xffff;
+      }
+      auto value = dict[index];
+      values[i] = value;
+    } else {
+      auto value = input[inputIndex + selectedIndices[i]];
+      values[i] = value;
     }
-    values[i] = value;
-  }
+    }
 }
 
 template <>
@@ -606,14 +632,17 @@ inline void storeTranslate(
     xsimd::batch_bool<int32_t> dictMask,
     const T* dict,
     T* values) {
+  using TIndex = typename make_index<T>::type;
   auto inDict = simd::toBitMask(dictMask);
   for (auto i = 0; i < dictMask.size; ++i) {
-    auto value = input[inputIndex + i];
     if (inDict & (1 << i)) {
-      value = dict[value];
+      auto index = reinterpret_cast<const TIndex*>(input)[inputIndex + i];
+      values[i] = dict[index];
+    } else {
+      auto value = input[inputIndex + i];
+      values[i] = value;
     }
-    values[i] = value;
-  }
+    }
 }
 
 template <>
@@ -673,45 +702,46 @@ class DictionaryColumnVisitor
     return true;
   }
 
-  FOLLY_ALWAYS_INLINE vector_size_t process(T value, bool& atEnd) {
+  FOLLY_ALWAYS_INLINE vector_size_t
+  process(typename make_index<T>::type value, bool& atEnd) {
     if (!isInDict()) {
       // If reading fixed width values, the not in dictionary value will be read
       // as unsigned at the width of the type. Integer columns are signed, so
       // sign extend the value here.
+      T signedValue;
       if (LIKELY(width_ == 8)) {
-        // No action. This should be the most common case.
+        signedValue = value;
       } else if (width_ == 4) {
-        value = static_cast<int32_t>(value);
+        signedValue = static_cast<int32_t>(value);
       } else {
-        value = static_cast<int16_t>(value);
+        signedValue = static_cast<int16_t>(value);
       }
-      return super::process(value, atEnd);
+      return super::process(signedValue, atEnd);
     }
     vector_size_t previous =
         isDense && TFilter::deterministic ? 0 : super::currentRow();
-    std::make_unsigned_t<T> index = value;
-    T valueInDictionary = dict()[index];
+    T valueInDictionary = dict()[value];
     if (std::is_same<TFilter, velox::common::AlwaysTrue>::value) {
       super::filterPassed(valueInDictionary);
     } else {
       // check the dictionary cache
       if (TFilter::deterministic &&
-          filterCache()[index] == FilterResult::kSuccess) {
+          filterCache()[value] == FilterResult::kSuccess) {
         super::filterPassed(valueInDictionary);
       } else if (
           TFilter::deterministic &&
-          filterCache()[index] == FilterResult::kFailure) {
+          filterCache()[value] == FilterResult::kFailure) {
         super::filterFailed();
       } else {
-        if (super::filter_.testInt64(valueInDictionary)) {
+        if (velox::common::applyFilter(super::filter_, valueInDictionary)) {
           super::filterPassed(valueInDictionary);
           if (TFilter::deterministic) {
-            filterCache()[index] = FilterResult::kSuccess;
+            filterCache()[value] = FilterResult::kSuccess;
           }
         } else {
           super::filterFailed();
           if (TFilter::deterministic) {
-            filterCache()[index] = FilterResult::kFailure;
+            filterCache()[value] = FilterResult::kFailure;
           }
         }
       }
@@ -815,9 +845,10 @@ class DictionaryColumnVisitor
         uint16_t bits = unknowns;
         // Ranges only over inputs that are in dictionary, the not in dictionary
         // were masked off in 'dictMask'.
+        using TIndex = typename make_index<T>::type;
         while (bits) {
           int index = bits::getAndClearLastSetBit(bits);
-          auto value = input[i + index];
+          auto value = reinterpret_cast<const TIndex*>(input)[i + index];
           if (applyFilter(super::filter_, dict()[value])) {
             filterCache()[value] = FilterResult::kSuccess;
             passed |= 1 << index;
@@ -938,17 +969,20 @@ class DictionaryColumnVisitor
       const int32_t* scatterRows,
       int32_t numValues,
       T* values) {
+    using TIndex = typename make_index<T>::type;
+
     for (int32_t i = numInput - 1; i >= 0; --i) {
-      using U = typename std::make_unsigned<T>::type;
-      T value = input[i];
+      T value;
       if (hasInDict) {
         if (bits::isBitSet(inDict(), super::rows_[super::rowIndex_ + i])) {
-          value = dict()[static_cast<U>(value)];
+          value = dict()[reinterpret_cast<const TIndex*>(input)[i]];
         } else if (!scatter) {
           continue;
+        } else {
+          value = input[i];
         }
       } else {
-        value = dict()[static_cast<U>(value)];
+        value = dict()[reinterpret_cast<const TIndex*>(input)[i]];
       }
       if (scatter) {
         values[scatterRows[super::rowIndex_ + i]] = value;
@@ -979,9 +1013,10 @@ class DictionaryColumnVisitor
   }
 
   void translateByDict(const T* values, int numValues, T* out) {
+    using TIndex = typename make_index<T>::type;
     if (!inDict()) {
       for (auto i = 0; i < numValues; ++i) {
-        out[i] = dict()[values[i]];
+        out[i] = dict()[reinterpret_cast<const TIndex*>(values)[i]];
       }
     } else if (super::dense) {
       bits::forEachSetBit(
@@ -990,13 +1025,14 @@ class DictionaryColumnVisitor
           super::rowIndex_ + numValues,
           [&](int row) {
             auto valueIndex = row - super::rowIndex_;
-            out[valueIndex] = dict()[values[valueIndex]];
+            out[valueIndex] =
+                dict()[reinterpret_cast<const TIndex*>(values)[valueIndex]];
             return true;
           });
     } else {
       for (auto i = 0; i < numValues; ++i) {
         if (bits::isBitSet(inDict(), super::rows_[super::rowIndex_ + i])) {
-          out[i] = dict()[values[i]];
+          out[i] = dict()[reinterpret_cast<const TIndex*>(values)[i]];
         }
       }
     }

--- a/velox/dwio/common/IntDecoder.h
+++ b/velox/dwio/common/IntDecoder.h
@@ -371,4 +371,72 @@ inline int64_t IntDecoder<isSigned>::readLong() {
   }
 }
 
+template <>
+template <>
+inline void IntDecoder<false>::bulkRead(
+    uint64_t size,
+    double* FOLLY_NONNULL result) {
+  VELOX_UNREACHABLE();
+}
+
+template <>
+template <>
+inline void IntDecoder<false>::bulkReadRows(
+    RowSet rows,
+    double* FOLLY_NONNULL result,
+    int32_t initialRow) {
+  VELOX_UNREACHABLE();
+}
+
+template <>
+template <>
+inline void IntDecoder<true>::bulkRead(
+    uint64_t size,
+    double* FOLLY_NONNULL result) {
+  VELOX_UNREACHABLE();
+}
+
+template <>
+template <>
+inline void IntDecoder<true>::bulkReadRows(
+    RowSet rows,
+    double* FOLLY_NONNULL result,
+    int32_t initialRow) {
+  VELOX_UNREACHABLE();
+}
+
+template <>
+template <>
+inline void IntDecoder<false>::bulkRead(
+    uint64_t size,
+    float* FOLLY_NONNULL result) {
+  VELOX_UNREACHABLE();
+}
+
+template <>
+template <>
+inline void IntDecoder<false>::bulkReadRows(
+    RowSet rows,
+    float* FOLLY_NONNULL result,
+    int32_t initialRow) {
+  VELOX_UNREACHABLE();
+}
+
+template <>
+template <>
+inline void IntDecoder<true>::bulkRead(
+    uint64_t size,
+    float* FOLLY_NONNULL result) {
+  VELOX_UNREACHABLE();
+}
+
+template <>
+template <>
+inline void IntDecoder<true>::bulkReadRows(
+    RowSet rows,
+    float* FOLLY_NONNULL result,
+    int32_t initialRow) {
+  VELOX_UNREACHABLE();
+}
+
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/TypeUtil.h
+++ b/velox/dwio/common/TypeUtil.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::dwio::common {
+
+// Converts signed/unsigned int 16/32/64 and float/double to unsigned int of the
+// same size. Used to make a dictionary index from a type.
+template <typename T>
+struct make_index {};
+
+template <>
+struct make_index<int16_t> {
+  using type = uint16_t;
+};
+
+template <>
+struct make_index<uint16_t> {
+  using type = uint16_t;
+};
+
+template <>
+struct make_index<int32_t> {
+  using type = uint32_t;
+};
+
+template <>
+struct make_index<uint32_t> {
+  using type = uint32_t;
+};
+
+template <>
+struct make_index<int64_t> {
+  using type = uint64_t;
+};
+
+template <>
+struct make_index<uint64_t> {
+  using type = uint64_t;
+};
+
+template <>
+struct make_index<float> {
+  using type = uint32_t;
+};
+
+template <>
+struct make_index<double> {
+  using type = uint64_t;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -168,6 +168,24 @@ class E2EFilterTestBase : public testing::Test {
     }
   }
 
+  template <typename T>
+  void makeQuantizedFloat(
+      const common::Subfield& field,
+      int64_t buckets,
+      bool keepNulls) {
+    for (RowVectorPtr batch : batches_) {
+      auto numbers =
+          common::getChildBySubfield(batch.get(), field)->as<FlatVector<T>>();
+      for (auto row = 0; row < numbers->size(); ++row) {
+        if (numbers->isNullAt(row)) {
+          continue;
+        }
+        T value = numbers->valueAt(row);
+        numbers->set(row, ceil(value * buckets) / buckets);
+      }
+    }
+  }
+
   // Makes strings with an ascending sequence of S<n>, followed by
   // random values with the given cardinality, then repeated
   // values. This is intended to hit different RLE encodings,

--- a/velox/dwio/parquet/reader/FloatingPointColumnReader.h
+++ b/velox/dwio/parquet/reader/FloatingPointColumnReader.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/SelectiveFloatingPointColumnReader.h"
+
+namespace facebook::velox::parquet {
+
+template <typename TData, typename TRequested>
+class FloatingPointColumnReader
+    : public dwio::common::
+          SelectiveFloatingPointColumnReader<TData, TRequested> {
+ public:
+  using ValueType = TRequested;
+
+  using root = dwio::common::SelectiveColumnReader;
+  using base =
+      dwio::common::SelectiveFloatingPointColumnReader<TData, TRequested>;
+
+  FloatingPointColumnReader(
+      std::shared_ptr<const dwio::common::TypeWithId> nodeType,
+      ParquetParams& params,
+      common::ScanSpec& scanSpec);
+
+  void seekToRowGroup(uint32_t index) override {
+    root::scanState().clear();
+    root::readOffset_ = 0;
+    root::formatData_->as<ParquetData>().seekToRowGroup(index);
+  }
+
+  uint64_t skip(uint64_t numValues) override;
+
+  void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
+      override {
+    using T = FloatingPointColumnReader<TData, TRequested>;
+    base::template readCommon<T>(offset, rows, incomingNulls);
+  }
+
+  template <typename TVisitor>
+  void readWithVisitor(RowSet rows, TVisitor visitor);
+};
+
+template <typename TData, typename TRequested>
+FloatingPointColumnReader<TData, TRequested>::FloatingPointColumnReader(
+    std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+    ParquetParams& params,
+    common::ScanSpec& scanSpec)
+    : dwio::common::SelectiveFloatingPointColumnReader<TData, TRequested>(
+          std::move(requestedType),
+          params,
+          scanSpec) {}
+
+template <typename TData, typename TRequested>
+uint64_t FloatingPointColumnReader<TData, TRequested>::skip(
+    uint64_t numValues) {
+  return root::formatData_->skip(numValues);
+}
+
+template <typename TData, typename TRequested>
+template <typename TVisitor>
+void FloatingPointColumnReader<TData, TRequested>::readWithVisitor(
+    RowSet rows,
+    TVisitor visitor) {
+  root::formatData_->as<ParquetData>().readWithVisitor(visitor);
+  root::readOffset_ += rows.back() + 1;
+}
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -20,6 +20,7 @@
 
 #include "velox/dwio/parquet/reader/ParquetColumnReader.h"
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
+#include "velox/dwio/parquet/reader/FloatingPointColumnReader.h"
 #include "velox/dwio/parquet/reader/IntegerColumnReader.h"
 #include "velox/dwio/parquet/reader/StructColumnReader.h"
 
@@ -42,11 +43,17 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
     case TypeKind::TINYINT:
       return std::make_unique<IntegerColumnReader>(
           dataType, dataType, params, scanSpec);
+
+    case TypeKind::REAL:
+      return std::make_unique<FloatingPointColumnReader<float, float>>(
+          dataType, params, scanSpec);
+    case TypeKind::DOUBLE:
+      return std::make_unique<FloatingPointColumnReader<double, double>>(
+          dataType, params, scanSpec);
+
     case TypeKind::ROW:
       return std::make_unique<StructColumnReader>(dataType, params, scanSpec);
 
-    case TypeKind::REAL:
-    case TypeKind::DOUBLE:
     case TypeKind::BOOLEAN:
     case TypeKind::ARRAY:
     case TypeKind::MAP:

--- a/velox/dwio/parquet/reader/RleDecoder.h
+++ b/velox/dwio/parquet/reader/RleDecoder.h
@@ -20,6 +20,7 @@
 #include "velox/common/base/Nulls.h"
 #include "velox/dwio/common/DecoderUtil.h"
 #include "velox/dwio/common/IntDecoder.h"
+#include "velox/dwio/common/TypeUtil.h"
 
 namespace facebook::velox::parquet {
 
@@ -246,6 +247,9 @@ class RleDecoder : public dwio::common::IntDecoder<isSigned> {
     auto numBits = bitOffset_ +
         (rows[rowIndex + numRows - 1] + 1 - currentRow) * bitWidth_;
 
+    using TValues = typename std::remove_reference<decltype(values[0])>::type;
+    using TIndex = typename std::make_signed_t<
+        typename dwio::common::make_index<TValues>::type>;
     super::decodeBitsLE(
         reinterpret_cast<const uint64_t*>(super::bufferStart),
         bitOffset_,
@@ -253,7 +257,7 @@ class RleDecoder : public dwio::common::IntDecoder<isSigned> {
         currentRow,
         bitWidth_,
         super::bufferEnd,
-        values + numValues);
+        reinterpret_cast<TIndex*>(values) + numValues);
     super::bufferStart += numBits >> 3;
     bitOffset_ = numBits & 7;
     visitor.template processRun<hasFilter, hasHook, scatter>(

--- a/velox/dwio/parquet/reader/Statistics.cpp
+++ b/velox/dwio/parquet/reader/Statistics.cpp
@@ -74,6 +74,14 @@ std::unique_ptr<dwio::common::ColumnStatistics> buildColumnStatisticsFromThrift(
           getMax<int64_t>(columnChunkStats),
           std::nullopt);
     case TypeKind::REAL:
+      return std::make_unique<dwio::common::DoubleColumnStatistics>(
+          valueCount,
+          hasNull,
+          std::nullopt,
+          std::nullopt,
+          getMin<float>(columnChunkStats),
+          getMax<float>(columnChunkStats),
+          std::nullopt);
     case TypeKind::DOUBLE:
       return std::make_unique<dwio::common::DoubleColumnStatistics>(
           valueCount,

--- a/velox/dwio/parquet/reader/Statistics.h
+++ b/velox/dwio/parquet/reader/Statistics.h
@@ -34,18 +34,18 @@ inline const T load(const char* ptr) {
 template <typename T>
 inline std::optional<T> getMin(const thrift::Statistics& columnChunkStats) {
   return columnChunkStats.__isset.min_value
-      ? load<T>(columnChunkStats.min_value.c_str())
+      ? load<T>(columnChunkStats.min_value.data())
       : (columnChunkStats.__isset.min
-             ? std::optional<T>(load<T>(columnChunkStats.min.c_str()))
+             ? std::optional<T>(load<T>(columnChunkStats.min.data()))
              : std::nullopt);
 }
 
 template <typename T>
 inline std::optional<T> getMax(const thrift::Statistics& columnChunkStats) {
   return columnChunkStats.__isset.max_value
-      ? std::optional<T>(load<T>(columnChunkStats.max_value.c_str()))
+      ? std::optional<T>(load<T>(columnChunkStats.max_value.data()))
       : (columnChunkStats.__isset.max
-             ? std::optional<T>(load<T>(columnChunkStats.max.c_str()))
+             ? std::optional<T>(load<T>(columnChunkStats.max.data()))
              : std::nullopt);
 }
 

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -130,3 +130,27 @@ TEST_F(E2EFilterTest, integerDictionary) {
       20,
       true);
 }
+
+TEST_F(E2EFilterTest, floatAndDouble) {
+  // float_val and double_val are expected to be direct since the
+  // values are random.float_val2 and double_val2 are expected to be
+  // dictionaries since the values are quantized.
+  testWithTypes(
+      "float_val:float,"
+      "double_val:double,"
+      "float_val2:float,"
+      "double_val2:double,"
+
+      "long_val:bigint,"
+      "float_null:float",
+      [&]() {
+        makeAllNulls("float_null");
+        makeQuantizedFloat<float>(Subfield("float_val2"), 200, true);
+        makeQuantizedFloat<double>(Subfield("double_val2"), 522, true);
+      },
+      false,
+      {"float_val", "double_val", "float_val2", "double_val2", "float_null"},
+      20,
+      true,
+      false);
+}


### PR DESCRIPTION
Adds Parquet  floating point direct and dictionary read.

Generalizes DictionaryColumnVisitor to translate indices of
floats/doubles to floats/doubles. Adds TypeUtil.h for some extra type
logic. Allows use of the fixed width path of IntDecoder for
floats/doubles and adds an empty template specialization for the
varint path for floats/doubles.

Fixes float stats reading.