### PR TITLE
Check initializeMapVector input vectors not null

### DIFF
--- a/velox/dwio/dwrf/reader/FlatMapHelper.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapHelper.cpp
@@ -181,6 +181,7 @@ void initializeMapVector(
   std::vector<const BaseVector*> keys;
   std::vector<const BaseVector*> values;
   for (auto vec : vectors) {
+    VELOX_CHECK_NOT_NULL(vec);
     size += vec->size();
     hasNulls = hasNulls || vec->mayHaveNulls();
     auto& map = dynamic_cast<const MapVector&>(*vec);


### PR DESCRIPTION
Summary: Throw if the `vectors` argument to `initializeMapVector()` contains any nullptr

Reviewed By: mbasmanova

Differential Revision: D38556196

