### PR TITLE
Set end for base rows in lazy vector

### DIFF
--- a/velox/vector/LazyVector.cpp
+++ b/velox/vector/LazyVector.cpp
@@ -133,11 +133,11 @@ void LazyVector::ensureLoadedRows(
   } else {
     baseRows.resize(0);
     baseRows.resize(lazyVector->size(), false);
-    rows.applyToSelected([&](auto row) {
-      if (!decoded.isNullAt(row)) {
-        baseRows.setValid(decoded.index(row), true);
-      }
-    });
+    rows.applyToSelected(
+        [&](auto row) { baseRows.setValid(decoded.index(row), true); });
+    // Manually mark the last item to be selected to ensure end
+    // being no less than the expected size.
+    baseRows.setValid(lazyVector->size() - 1, true);
     baseRows.updateBounds();
 
     rowNumbers.resize(baseRows.end());


### PR DESCRIPTION
We found the loaded vector can have smaller size than expected, which caused invalid access to the base vector in our test. Through debugging, we found the `baseRows.end()` can become less than `lazyVector->size()`. As a result, the size of vector loaded with `rowSet = RowSet(rowNumbers)` from columnar loader was smaller than `lazyVector->size()`. Details can also be seen in https://github.com/facebookincubator/velox/issues/2237.

To avoid the failure, this PR set the end of base rows to ensure all rows could be loaded in columnar loader. But it may cause incorrect result in this case.
