### PR TITLE
Add Parquet string direct and dictionary read

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -137,6 +137,9 @@ class ExtractToGenericHook {
 template <typename T, typename TFilter, typename ExtractValues, bool isDense>
 class DictionaryColumnVisitor;
 
+template <typename TFilter, typename ExtractValues, bool isDense>
+class StringDictionaryColumnVisitor;
+
 // Template parameter for controlling filtering and action on a set of rows.
 template <typename T, typename TFilter, typename ExtractValues, bool isDense>
 class ColumnVisitor {
@@ -445,6 +448,9 @@ class ColumnVisitor {
 
   DictionaryColumnVisitor<T, TFilter, ExtractValues, isDense>
   toDictionaryColumnVisitor();
+
+  StringDictionaryColumnVisitor<TFilter, ExtractValues, isDense>
+  toStringDictionaryColumnVisitor();
 
   // Use for replacing *coall rows with non-null rows for fast path with
   // processRun and processRle.
@@ -1065,6 +1071,16 @@ ColumnVisitor<T, TFilter, ExtractValues, isDense>::toDictionaryColumnVisitor() {
   auto result = DictionaryColumnVisitor<T, TFilter, ExtractValues, isDense>(
       filter_, reader_, RowSet(rows_ + rowIndex_, numRows_), values_);
   result.numValuesBias_ = numValuesBias_;
+  return result;
+}
+
+template <typename T, typename TFilter, typename ExtractValues, bool isDense>
+StringDictionaryColumnVisitor<TFilter, ExtractValues, isDense>
+ColumnVisitor<T, TFilter, ExtractValues, isDense>::
+    toStringDictionaryColumnVisitor() {
+  auto result = StringDictionaryColumnVisitor<TFilter, ExtractValues, isDense>(
+      filter_, reader_, RowSet(rows_ + rowIndex_, numRows_), values_);
+  result.setNumValuesBias(numValuesBias_);
   return result;
 }
 

--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -14,8 +14,13 @@
 
 add_library(
   velox_dwio_native_parquet_reader
-  ParquetReader.cpp PageReader.cpp ParquetData.cpp ParquetColumnReader.cpp
-  Statistics.cpp StructColumnReader.cpp)
+  ParquetReader.cpp
+  PageReader.cpp
+  ParquetData.cpp
+  ParquetColumnReader.cpp
+  Statistics.cpp
+  StructColumnReader.cpp
+  StringColumnReader.cpp)
 
 target_link_libraries(
   velox_dwio_native_parquet_reader

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -22,6 +22,7 @@
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 #include "velox/dwio/parquet/reader/FloatingPointColumnReader.h"
 #include "velox/dwio/parquet/reader/IntegerColumnReader.h"
+#include "velox/dwio/parquet/reader/StringColumnReader.h"
 #include "velox/dwio/parquet/reader/StructColumnReader.h"
 
 #include "velox/dwio/parquet/reader/Statistics.h"
@@ -54,11 +55,14 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
     case TypeKind::ROW:
       return std::make_unique<StructColumnReader>(dataType, params, scanSpec);
 
+    case TypeKind::VARBINARY:
+    case TypeKind::VARCHAR:
+      return std::make_unique<StringColumnReader>(dataType, params, scanSpec);
+
     case TypeKind::BOOLEAN:
     case TypeKind::ARRAY:
     case TypeKind::MAP:
-    case TypeKind::VARBINARY:
-    case TypeKind::VARCHAR:
+
       VELOX_UNSUPPORTED("Type is not supported: ", dataType->type->kind());
     default:
       VELOX_FAIL(

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -116,6 +116,10 @@ class ParquetData : public dwio::common::FormatData {
     reader_->readWithVisitor(visitor);
   }
 
+  const VectorPtr& dictionaryValues() {
+    return reader_->dictionaryValues();
+  }
+
  protected:
   memory::MemoryPool& pool_;
   std::shared_ptr<const ParquetTypeWithId> type_;

--- a/velox/dwio/parquet/reader/Statistics.cpp
+++ b/velox/dwio/parquet/reader/Statistics.cpp
@@ -91,6 +91,17 @@ std::unique_ptr<dwio::common::ColumnStatistics> buildColumnStatisticsFromThrift(
           getMin<double>(columnChunkStats),
           getMax<double>(columnChunkStats),
           std::nullopt);
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY:
+      return std::make_unique<dwio::common::StringColumnStatistics>(
+          valueCount,
+          hasNull,
+          std::nullopt,
+          std::nullopt,
+          getMin<std::string>(columnChunkStats),
+          getMax<std::string>(columnChunkStats),
+          std::nullopt);
+
     default:
       return std::make_unique<dwio::common::ColumnStatistics>(
           valueCount, hasNull, std::nullopt, std::nullopt);

--- a/velox/dwio/parquet/reader/Statistics.h
+++ b/velox/dwio/parquet/reader/Statistics.h
@@ -49,6 +49,24 @@ inline std::optional<T> getMax(const thrift::Statistics& columnChunkStats) {
              : std::nullopt);
 }
 
+template <>
+inline std::optional<std::string> getMin(
+    const thrift::Statistics& columnChunkStats) {
+  return columnChunkStats.__isset.min_value
+      ? std::optional(columnChunkStats.min_value)
+      : (columnChunkStats.__isset.min ? std::optional(columnChunkStats.min)
+                                      : std::nullopt);
+}
+
+template <>
+inline std::optional<std::string> getMax(
+    const thrift::Statistics& columnChunkStats) {
+  return columnChunkStats.__isset.max_value
+      ? std::optional(columnChunkStats.max_value)
+      : (columnChunkStats.__isset.max ? std::optional(columnChunkStats.max)
+                                      : std::nullopt);
+}
+
 std::unique_ptr<dwio::common::ColumnStatistics> buildColumnStatisticsFromThrift(
     const thrift::Statistics& columnChunkStats,
     const velox::Type& type,

--- a/velox/dwio/parquet/reader/StringColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StringColumnReader.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/parquet/reader/StringColumnReader.h"
+#include "velox/dwio/common/BufferUtil.h"
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
+
+namespace facebook::velox::parquet {
+
+StringColumnReader::StringColumnReader(
+    const std::shared_ptr<const dwio::common::TypeWithId>& nodeType,
+    ParquetParams& params,
+    common::ScanSpec& scanSpec)
+    : SelectiveColumnReader(nodeType, params, scanSpec, nodeType->type) {}
+
+uint64_t StringColumnReader::skip(uint64_t numValues) {
+  formatData_->skip(numValues);
+  return numValues;
+}
+
+template <typename TFilter, bool isDense, typename ExtractValues>
+void StringColumnReader::readHelper(
+    common::Filter* filter,
+    RowSet rows,
+    ExtractValues extractValues) {
+  formatData_->as<ParquetData>().readWithVisitor(
+      dwio::common::
+          ColumnVisitor<folly::StringPiece, TFilter, ExtractValues, isDense>(
+              *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
+  readOffset_ += rows.back() + 1;
+}
+
+template <bool isDense, typename ExtractValues>
+void StringColumnReader::processFilter(
+    common::Filter* filter,
+    RowSet rows,
+    ExtractValues extractValues) {
+  switch (filter ? filter->kind() : common::FilterKind::kAlwaysTrue) {
+    case common::FilterKind::kAlwaysTrue:
+      readHelper<common::AlwaysTrue, isDense>(filter, rows, extractValues);
+      break;
+    case common::FilterKind::kIsNull:
+      filterNulls<StringView>(
+          rows,
+          true,
+          !std::is_same<decltype(extractValues), dwio::common::DropValues>::
+              value);
+      break;
+    case common::FilterKind::kIsNotNull:
+      if (std::is_same<decltype(extractValues), dwio::common::DropValues>::
+              value) {
+        filterNulls<StringView>(rows, false, false);
+      } else {
+        readHelper<common::IsNotNull, isDense>(filter, rows, extractValues);
+      }
+      break;
+    case common::FilterKind::kBytesRange:
+      readHelper<common::BytesRange, isDense>(filter, rows, extractValues);
+      break;
+    case common::FilterKind::kNegatedBytesRange:
+      readHelper<common::NegatedBytesRange, isDense>(
+          filter, rows, extractValues);
+      break;
+    case common::FilterKind::kBytesValues:
+      readHelper<common::BytesValues, isDense>(filter, rows, extractValues);
+      break;
+    case common::FilterKind::kNegatedBytesValues:
+      readHelper<common::NegatedBytesValues, isDense>(
+          filter, rows, extractValues);
+      break;
+    default:
+      readHelper<common::Filter, isDense>(filter, rows, extractValues);
+      break;
+  }
+}
+
+void StringColumnReader::read(
+    vector_size_t offset,
+    RowSet rows,
+    const uint64_t* incomingNulls) {
+  prepareRead<folly::StringPiece>(offset, rows, incomingNulls);
+  bool isDense = rows.back() == rows.size() - 1;
+
+  auto end = rows.back() + 1;
+  if (scanSpec_->keepValues()) {
+    if (scanSpec_->valueHook()) {
+      if (isDense) {
+        readHelper<common::AlwaysTrue, true>(
+            &dwio::common::alwaysTrue(),
+            rows,
+            dwio::common::ExtractToGenericHook(scanSpec_->valueHook()));
+      } else {
+        readHelper<common::AlwaysTrue, false>(
+            &dwio::common::alwaysTrue(),
+            rows,
+            dwio::common::ExtractToGenericHook(scanSpec_->valueHook()));
+      }
+      return;
+    }
+    if (isDense) {
+      processFilter<true>(
+          scanSpec_->filter(), rows, dwio::common::ExtractToReader(this));
+    } else {
+      processFilter<false>(
+          scanSpec_->filter(), rows, dwio::common::ExtractToReader(this));
+    }
+  } else {
+    if (isDense) {
+      processFilter<true>(
+          scanSpec_->filter(), rows, dwio::common::DropValues());
+    } else {
+      processFilter<false>(
+          scanSpec_->filter(), rows, dwio::common::DropValues());
+    }
+  }
+}
+
+void StringColumnReader::getValues(RowSet rows, VectorPtr* result) {
+  if (scanState_.dictionary.values) {
+    auto dictionaryValues = formatData_->as<ParquetData>().dictionaryValues();
+    compactScalarValues<int32_t, int32_t>(rows, false);
+
+    *result = std::make_shared<DictionaryVector<StringView>>(
+        &memoryPool_,
+        !anyNulls_               ? nullptr
+            : returnReaderNulls_ ? nullsInReadRange_
+                                 : resultNulls_,
+        numValues_,
+        dictionaryValues,
+        values_);
+    return;
+  }
+  rawStringBuffer_ = nullptr;
+  rawStringSize_ = 0;
+  rawStringUsed_ = 0;
+  getFlatValues<StringView, StringView>(rows, result, type_);
+}
+
+void StringColumnReader::dedictionarize() {
+  auto dict = formatData_->as<ParquetData>()
+                  .dictionaryValues()
+                  ->as<FlatVector<StringView>>();
+  auto indicesBuffer = std::move(values_);
+  auto indices = reinterpret_cast<const vector_size_t*>(rawValues_);
+  rawValues_ = nullptr;
+  auto numValues = numValues_;
+  numValues_ = 0;
+  scanState_.clear();
+  rawStringBuffer_ = nullptr;
+  rawStringSize_ = 0;
+  rawStringUsed_ = 0;
+  for (auto i = 0; i < numValues; ++i) {
+    if (anyNulls_ && bits::isBitNull(rawResultNulls_, i)) {
+      ++numValues_;
+      continue;
+    }
+    auto& view = dict->valueAt(indices[i]);
+    addStringValue(folly::StringPiece(view.data(), view.size()));
+  }
+}
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/StringColumnReader.h
+++ b/velox/dwio/parquet/reader/StringColumnReader.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
+#include "velox/dwio/parquet/reader/ParquetData.h"
+
+namespace facebook::velox::parquet {
+
+class StringColumnReader : public dwio::common::SelectiveColumnReader {
+ public:
+  using ValueType = StringView;
+  StringColumnReader(
+      const std::shared_ptr<const dwio::common::TypeWithId>& nodeType,
+      ParquetParams& params,
+      common::ScanSpec& scanSpec);
+
+  bool hasBulkPath() const override {
+    //  Non-dictionary encodings do not have fast path.
+    return scanState_.dictionary.values != nullptr;
+  }
+
+  void seekToRowGroup(uint32_t index) override {
+    scanState().clear();
+    readOffset_ = 0;
+    formatData_->as<ParquetData>().seekToRowGroup(index);
+  }
+
+  uint64_t skip(uint64_t numValues) override;
+
+  void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
+      override;
+
+  void getValues(RowSet rows, VectorPtr* result) override;
+
+  void dedictionarize() override;
+
+ private:
+  template <bool hasNulls>
+  void skipInDecode(int32_t numValues, int32_t current, const uint64_t* nulls);
+
+  folly::StringPiece readValue(int32_t length);
+
+  template <bool hasNulls, typename Visitor>
+  void decode(const uint64_t* nulls, Visitor visitor);
+
+  template <typename TVisitor>
+  void readWithVisitor(RowSet rows, TVisitor visitor);
+
+  template <typename TFilter, bool isDense, typename ExtractValues>
+  void readHelper(common::Filter* filter, RowSet rows, ExtractValues values);
+
+  template <bool isDense, typename ExtractValues>
+  void processFilter(
+      common::Filter* filter,
+      RowSet rows,
+      ExtractValues extractValues);
+};
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/StringDecoder.h
+++ b/velox/dwio/parquet/reader/StringDecoder.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/GTestMacros.h"
+#include "velox/common/base/Nulls.h"
+#include "velox/dwio/common/DecoderUtil.h"
+#include "velox/dwio/common/IntDecoder.h"
+#include "velox/dwio/common/TypeUtil.h"
+
+namespace facebook::velox::parquet {
+
+class StringDecoder {
+ public:
+  StringDecoder(const char* FOLLY_NONNULL start, const char* FOLLY_NONNULL end)
+      : bufferStart_(start),
+        bufferEnd_(end),
+
+        lastSafeWord_(end - simd::kPadding) {}
+
+  void skip(uint64_t numValues) {
+    skip<false>(numValues, 0, nullptr);
+  }
+
+  template <bool hasNulls>
+  inline void skip(int32_t numValues, int32_t current, const uint64_t* nulls) {
+    if (hasNulls) {
+      numValues = bits::countNonNulls(nulls, current, current + numValues);
+    }
+    for (auto i = 0; i < numValues; ++i) {
+      bufferStart_ += lengthAt(bufferStart_) + sizeof(int32_t);
+    }
+  }
+
+  template <bool hasNulls, typename Visitor>
+  void readWithVisitor(const uint64_t* nulls, Visitor visitor) {
+    int32_t current = visitor.start();
+    skip<hasNulls>(current, 0, nulls);
+    int32_t toSkip;
+    bool atEnd = false;
+    const bool allowNulls = hasNulls && visitor.allowNulls();
+    for (;;) {
+      if (hasNulls && allowNulls && bits::isBitNull(nulls, current)) {
+        toSkip = visitor.processNull(atEnd);
+      } else {
+        if (hasNulls && !allowNulls) {
+          toSkip = visitor.checkAndSkipNulls(nulls, current, atEnd);
+          if (!Visitor::dense) {
+            skip<false>(toSkip, current, nullptr);
+          }
+          if (atEnd) {
+            return;
+          }
+        }
+
+        // We are at a non-null value on a row to visit.
+        toSkip = visitor.process(readString(), atEnd);
+      }
+      ++current;
+      if (toSkip) {
+        skip<hasNulls>(toSkip, current, nulls);
+        current += toSkip;
+      }
+      if (atEnd) {
+        return;
+      }
+    }
+  }
+
+ private:
+  int32_t lengthAt(const char* buffer) {
+    return *reinterpret_cast<const int32_t*>(buffer);
+  }
+
+  folly::StringPiece readString() {
+    auto length = lengthAt(bufferStart_);
+    bufferStart_ += length + sizeof(int32_t);
+    return folly::StringPiece(bufferStart_ - length, length);
+  }
+  const char* FOLLY_NONNULL bufferStart_;
+  const char* FOLLY_NONNULL bufferEnd_;
+  const char* FOLLY_NONNULL const lastSafeWord_;
+};
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -154,3 +154,36 @@ TEST_F(E2EFilterTest, floatAndDouble) {
       true,
       false);
 }
+
+TEST_F(E2EFilterTest, stringDirect) {
+  writerProperties_ = ::parquet::WriterProperties::Builder()
+                          .disable_dictionary()
+                          ->data_pagesize(4 * 1024)
+                          ->build();
+
+  testWithTypes(
+      "string_val:string,"
+      "string_val_2:string",
+      [&]() {
+        makeStringUnique(Subfield("string_val"));
+        makeStringUnique(Subfield("string_val_2"));
+      },
+      false,
+      {"string_val", "string_val_2"},
+      20,
+      true);
+}
+
+TEST_F(E2EFilterTest, stringDictionary) {
+  testWithTypes(
+      "string_val:string,"
+      "string_val_2:string",
+      [&]() {
+        makeStringDistribution(Subfield("string_val"), 100, true, false);
+        makeStringDistribution(Subfield("string_val_2"), 170, false, true);
+      },
+      false,
+      {"string_val", "string_val_2"},
+      20,
+      true);
+}


### PR DESCRIPTION
Adds a Parquet plain direct string decoder.

Moves dictionary handling fromm the inlined PageReader readWithVisitor
template to a utility function.

Specializes invoking the readWithVisitor of the decoder by content
type, so that all templates do not have to be instantiable for all
types.