### PR TITLE
Getting struct writing tests working and using new config for keys

### DIFF
--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
@@ -293,6 +293,12 @@ class FlatMapColumnWriter : public BaseColumnWriter {
   std::unique_ptr<typename TypeInfo<K>::StatisticsBuilder> keyFileStatsBuilder_;
   std::unique_ptr<const ValueStatisticsBuilder> valueFileStatsBuilder_;
   const uint32_t maxKeyCount_;
+
+  // Stores column keys as string in case of StringView pointers
+  std::vector<std::string> stringKeys_;
+
+  // Stores column keys if writing with RowVector input
+  std::vector<KeyType> structKeys_;
 };
 
 template <>


### PR DESCRIPTION
Summary: Fixed defaulting of non-empty map {{}} bug in testMapWriter. Also fixed a bug where preceding optional arguments were not set. Added pBatches pointer to iterate either original batches or structs depending on what the input to the writer will be. Added structKeys_ member to hold the vector of keys for the column that the writer is created for. parseKeys() converts from string to KeyType.

Differential Revision: D38524066

