### PR TITLE
Add query config to control the spillable memory reservation growth

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -111,6 +111,9 @@ class QueryConfig {
   static constexpr const char* kSpillFileSizeFactor =
       "spiller-file-size-factor";
 
+  static constexpr const char* kSpillableReservationGrowthPct =
+      "spillable-reservation-growth-pct";
+
   uint64_t maxPartialAggregationMemoryUsage() const {
     static constexpr uint64_t kDefault = 1L << 24;
     return get<uint64_t>(kMaxPartialAggregationMemory, kDefault);
@@ -233,6 +236,15 @@ class QueryConfig {
   int32_t spillFileSizeFactor() const {
     constexpr int32_t kDefaultFactor = 4;
     return get<int32_t>(kSpillFileSizeFactor, kDefaultFactor);
+  }
+
+  /// Returns the spillable memory reservation growth percentage of the previous
+  /// memory reservation size. 25 means exponential growth along a series of
+  /// integer powers of 5/4. The reservation grows by this much until it no
+  /// longer can, after which it starts spilling.
+  int32_t spillableReservationGrowthPct() const {
+    constexpr int32_t kDefaultPct = 25;
+    return get<double>(kSpillableReservationGrowthPct, kDefaultPct);
   }
 
   bool exprTrackCpuUsage() const {

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -74,10 +74,9 @@ class GroupingSet {
   /// of this will be in a paused state and off thread.
   void spill(int64_t targetRows, int64_t targetBytes);
 
-  /// Returns the total bytes and rows spilled so far.
-  std::pair<int64_t, int64_t> spilledBytesAndRows() const {
-    return spiller_ ? spiller_->spilledBytesAndRows()
-                    : std::pair<int64_t, int64_t>(0, 0);
+  /// Returns the spiller stats including total bytes and rows spilled so far.
+  Spiller::Stats spilledStats() const {
+    return spiller_ != nullptr ? spiller_->stats() : Spiller::Stats{};
   }
 
   /// Return the number of rows kept in memory.
@@ -174,7 +173,11 @@ class GroupingSet {
 
   const bool ignoreNullKeys_;
 
-  /// Parameters used for spilling control.
+  // The spillable memory reservation growth percentage of the current
+  // reservation size.
+  const double spillableReservationGrowthPct_;
+
+  // Parameters used for spilling control.
   const int32_t spillPartitionBits_;
   const int32_t spillFileSizeFactor_;
 

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -162,9 +162,10 @@ void HashAggregation::addInput(RowVectorPtr input) {
   }
   groupingSet_->addInput(input, mayPushdown_);
   numInputRows_ += input->size();
-  auto spilled = groupingSet_->spilledBytesAndRows();
-  stats_.spilledBytes = spilled.first;
-  stats_.spilledRows = spilled.second;
+  auto spilledStats = groupingSet_->spilledStats();
+  stats_.spilledBytes = spilledStats.spilledBytes;
+  stats_.spilledRows = spilledStats.spilledRows;
+  stats_.spilledPartitions = spilledStats.spilledPartitions;
 
   // NOTE: we should not trigger partial output flush in case of global
   // aggregation as the final aggregator will handle it the same way as the

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -306,6 +306,7 @@ void OperatorStats::add(const OperatorStats& other) {
   numDrivers += other.numDrivers;
   spilledBytes += other.spilledBytes;
   spilledRows += other.spilledRows;
+  spilledPartitions += other.spilledPartitions;
 }
 
 void OperatorStats::clear() {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -132,6 +132,9 @@ struct OperatorStats {
   // Total rows written for spilling.
   uint64_t spilledRows{0};
 
+  // Total spilled partitions.
+  uint32_t spilledPartitions{0};
+
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
 
   int numDrivers = 0;

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -128,8 +128,8 @@ void SpillFileList::finishFile() {
   }
 }
 
-int64_t SpillFileList::spilledBytes() const {
-  int64_t bytes = 0;
+uint64_t SpillFileList::spilledBytes() const {
+  uint64_t bytes = 0;
   for (auto& file : files_) {
     bytes += file->size();
   }
@@ -191,14 +191,24 @@ std::unique_ptr<TreeOfLosers<SpillStream>> SpillState::startMerge(
   return std::make_unique<TreeOfLosers<SpillStream>>(std::move(result));
 }
 
-int64_t SpillState::spilledBytes() const {
-  int64_t bytes = 0;
+uint64_t SpillState::spilledBytes() const {
+  uint64_t bytes = 0;
   for (auto& list : files_) {
     if (list) {
       bytes += list->spilledBytes();
     }
   }
   return bytes;
+}
+
+uint32_t SpillState::spilledPartitions() const {
+  uint32_t numSpilledPartitions = 0;
+  for (int i = 0; i < isPartitionSpilled_.size(); ++i) {
+    if (isPartitionSpilled_[i]) {
+      ++numSpilledPartitions;
+    }
+  }
+  return numSpilledPartitions;
 }
 
 int64_t SpillState::spilledFiles() const {

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -281,7 +281,7 @@ class SpillFileList {
     return std::move(files_);
   }
 
-  int64_t spilledBytes() const;
+  uint64_t spilledBytes() const;
 
   int64_t spilledFiles() const {
     return files_.size();
@@ -379,7 +379,9 @@ class SpillState {
     return partition < files_.size() && files_[partition];
   }
 
-  int64_t spilledBytes() const;
+  uint64_t spilledBytes() const;
+
+  uint32_t spilledPartitions() const;
 
   int64_t spilledFiles() const;
 

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -326,6 +326,12 @@ void Spiller::spill(uint64_t targetRows, uint64_t targetBytes) {
     while (rowsLeft > 0 && (rowsLeft > targetRows || spaceLeft > targetBytes)) {
       const int32_t partition = pickNextPartitionToSpill();
       if (partition == -1) {
+        VELOX_FAIL(
+            "No partition has no spillable data but still doesn't reach the spill target, target rows {}, target bytes {}, rows left {}, bytes left {}",
+            targetRows,
+            targetBytes,
+            rowsLeft,
+            spaceLeft);
         break;
       }
       if (!state_.isPartitionSpilled(partition)) {

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -117,9 +117,26 @@ class Spiller {
     return state_.startMerge(partition, spillStreamOverRows(partition));
   }
 
-  std::pair<int64_t, int64_t> spilledBytesAndRows() const {
-    return std::make_pair<int64_t, int64_t>(
-        state_.spilledBytes(), spilledRows_);
+  // Define the spiller stats.
+  struct Stats {
+    uint64_t spilledBytes = 0;
+    uint64_t spilledRows = 0;
+    uint32_t spilledPartitions = 0;
+
+    Stats(
+        uint64_t _spilledBytes,
+        uint64_t _spilledRows,
+        uint32_t _spilledPartitions)
+        : spilledBytes(_spilledBytes),
+          spilledRows(_spilledRows),
+          spilledPartitions(_spilledPartitions) {}
+
+    Stats() = default;
+  };
+
+  Stats stats() const {
+    return Stats{
+        state_.spilledBytes(), spilledRows_, state_.spilledPartitions()};
   }
 
   int64_t spilledFiles() const {

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -76,6 +76,7 @@ class SpillTest : public testing::Test,
           *mappedMemory_);
       EXPECT_EQ(targetFileSize, state.targetFileSize());
       EXPECT_EQ(numPartitions, state.maxPartitions());
+      EXPECT_EQ(0, state.spilledPartitions());
 
       for (auto partition = 0; partition < state.maxPartitions(); ++partition) {
         EXPECT_FALSE(state.isPartitionSpilled(partition));
@@ -111,6 +112,7 @@ class SpillTest : public testing::Test,
           EXPECT_TRUE(state.hasFiles(partition));
         }
       }
+      EXPECT_EQ(numPartitions, state.spilledPartitions());
       EXPECT_LT(
           2 * numPartitions * numBatches * sizeof(int64_t),
           state.spilledBytes());

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -131,6 +131,9 @@ class SpillerTest : public exec::test::RowContainerTestBase,
     if (spillPct == 100) {
       EXPECT_TRUE(unspilledPartitionRows.empty());
       EXPECT_EQ(0, rowContainer_->numRows());
+      EXPECT_EQ(numPartitions_, spiller_->stats().spilledPartitions);
+    } else {
+      EXPECT_GE(numPartitions_, spiller_->stats().spilledPartitions);
     }
 
     verifySpillData();
@@ -445,7 +448,7 @@ TEST_P(SpillerTest, spillWithEmptyPartitions) {
     // Expect no non-spilling partitions.
     EXPECT_TRUE(spiller_->finishSpill().empty());
     verifySpillData();
-    EXPECT_EQ(numRows, spiller_->spilledBytesAndRows().second);
+    EXPECT_EQ(numRows, spiller_->stats().spilledRows);
   }
 }
 
@@ -509,8 +512,8 @@ TEST_P(SpillerTest, spillWithNonSpillingPartitions) {
     // Expect non-spilling partition.
     EXPECT_FALSE(spiller_->finishSpill().empty());
     verifySpillData();
-    EXPECT_LT(0, spiller_->spilledBytesAndRows().second);
-    EXPECT_GT(numRows, spiller_->spilledBytesAndRows().second);
+    EXPECT_LT(0, spiller_->stats().spilledRows);
+    EXPECT_GT(numRows, spiller_->stats().spilledRows);
   }
 }
 


### PR DESCRIPTION
(1) Add query config to control the spillable memory reservation growth percentage which will
be used in hash join build as well
(2) Add dedicated aggregation test case with non-spilling partition to trigger the bug in grouping set;
(3) Add Spiller::Stats to include all the spiller related stats and add spilled partitions.