### PR TITLE
Fix element_at(map, key) Presto function

### DIFF
--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -299,7 +299,8 @@ class SubscriptImpl : public exec::VectorFunction {
 
     // Get map keys.
     auto mapKeys = baseMap->mapKeys();
-    exec::LocalDecodedVector mapKeysHolder(context, *mapKeys, rows);
+    exec::LocalSelectivityVector allElementRows(context, mapKeys->size());
+    exec::LocalDecodedVector mapKeysHolder(context, *mapKeys, *allElementRows);
     auto decodedMapKeys = mapKeysHolder.get();
 
     // Get index vector (second argument).

--- a/velox/vector/tests/VectorTestBase.cpp
+++ b/velox/vector/tests/VectorTestBase.cpp
@@ -36,6 +36,14 @@ VectorPtr VectorTestBase::wrapInDictionary(
       BufferPtr(nullptr), indices, size, vector);
 }
 
+// static
+VectorPtr VectorTestBase::wrapInDictionary(
+    BufferPtr indices,
+    VectorPtr vector) {
+  return wrapInDictionary(
+      indices, indices->size() / sizeof(vector_size_t), vector);
+}
+
 BufferPtr VectorTestBase::makeOddIndices(vector_size_t size) {
   return makeIndices(size, [](vector_size_t i) { return 2 * i + 1; });
 }

--- a/velox/vector/tests/VectorTestBase.h
+++ b/velox/vector/tests/VectorTestBase.h
@@ -608,6 +608,8 @@ class VectorTestBase {
   static VectorPtr
   wrapInDictionary(BufferPtr indices, vector_size_t size, VectorPtr vector);
 
+  static VectorPtr wrapInDictionary(BufferPtr indices, VectorPtr vector);
+
   static VectorPtr flatten(const VectorPtr& vector) {
     return velox::test::VectorMaker::flatten(vector);
   }


### PR DESCRIPTION
Summary:
The element_at Presto function is implemented through `SubscriptImpl` 
that incorrectly decode map keys using the top-level rows instead of the 
element rows. This caused incorrect result or crashes when evaluating 
expressions like `element_at(map(array[...], array[...]))` 
where input map keys to element_at are dictionary-encoded. This diff 
fixes this bug.

Differential Revision: D38602634

