### PR TITLE
Add disk spilling support for order by

### DIFF
--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -175,7 +175,7 @@ class GroupingSet {
 
   // The spillable memory reservation growth percentage of the current
   // reservation size.
-  const double spillableReservationGrowthPct_;
+  const int32_t spillableReservationGrowthPct_;
 
   // Parameters used for spilling control.
   const int32_t spillPartitionBits_;

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -101,7 +101,8 @@ void gatherCopy(
     const std::vector<const RowVector*>& sources,
     const std::vector<vector_size_t>& sourceIndices,
     column_index_t sourceChannel) {
-  if (target->isScalar()) {
+  // TODO: UNKNOWN is not a scalar type and will fix 'isScalar()' next.
+  if (target->isScalar() && target->typeKind() != TypeKind::UNKNOWN) {
     VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
         scalarGatherCopy,
         target->type()->kind(),
@@ -321,6 +322,15 @@ void gatherCopy(
           i);
     }
   }
+}
+
+std::string makeOperatorSpillPath(
+    const std::string& spillPath,
+    const std::string& taskId,
+    int driverId,
+    int32_t operatorId) {
+  VELOX_CHECK(!spillPath.empty());
+  return fmt::format("{}/{}_{}_{}", spillPath, taskId, driverId, operatorId);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -92,4 +92,14 @@ void gatherCopy(
     const std::vector<vector_size_t>& sourceIndices,
     const std::vector<IdentityProjection>& columnMap = {});
 
+/// Generate the system-wide unique disk spill file path for an operator. It
+/// will be the directory on fs with namespace support or common file prefix if
+/// not. It is assumed that the disk spilling file hierarchy for an operator is
+/// flat.
+std::string makeOperatorSpillPath(
+    const std::string& spillPath,
+    const std::string& taskId,
+    int driverId,
+    int32_t operatorId);
+
 } // namespace facebook::velox::exec

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include "velox/exec/OrderBy.h"
+#include "velox/exec/OperatorUtils.h"
+#include "velox/exec/Task.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::exec {
@@ -34,9 +36,21 @@ OrderBy::OrderBy(
           operatorId,
           orderByNode->id(),
           "OrderBy"),
-      numSortKeys_(orderByNode->sortingKeys().size()) {
+      mappedMemory_(operatorCtx_->mappedMemory()),
+      numSortKeys_(orderByNode->sortingKeys().size()),
+      spillPath_(makeSpillPath(operatorId)),
+      spillExecutor_(operatorCtx_->task()->queryCtx()->spillExecutor()),
+      testSpillPct_(
+          operatorCtx_->execCtx()->queryCtx()->config().testingSpillPct()),
+      spillableReservationGrowthPct_(operatorCtx_->driverCtx()
+                                         ->queryConfig()
+                                         .spillableReservationGrowthPct()),
+      spillFileSizeFactor_(
+          operatorCtx_->driverCtx()->queryConfig().spillFileSizeFactor()) {
   std::vector<TypePtr> keyTypes;
   std::vector<TypePtr> dependentTypes;
+  std::vector<TypePtr> types;
+  std::vector<std::string> names;
   // Setup column projections to store sort key columns in row container first.
   // This enables to use the sorting facility provided by the row container. It
   // also facilitates the sort merge read handling required by disk spilling.
@@ -49,27 +63,37 @@ OrderBy::OrderBy(
     VELOX_CHECK(
         channel != kConstantChannel,
         "OrderBy doesn't allow constant sorting keys");
-    columnMap_.emplace_back(channel, i);
+    columnMap_.emplace_back(i, channel);
     keyTypes.push_back(outputType_->childAt(channel));
+    types.push_back(keyTypes.back());
+    names.push_back(outputType_->nameOf(channel));
     keyCompareFlags_.push_back(
         fromSortOrderToCompareFlags(orderByNode->sortingOrders()[i]));
     keyChannelSet.emplace(channel);
   }
 
   // Store non-sort key columns as dependents in row container.
-  for (column_index_t inputChannel = 0, nextOutputChannel = numSortKeys_;
-       inputChannel < outputType_->size();
-       ++inputChannel) {
-    if (keyChannelSet.count(inputChannel) != 0) {
+  for (column_index_t outputChannel = 0, nextInputChannel = numSortKeys_;
+       outputChannel < outputType_->size();
+       ++outputChannel) {
+    if (keyChannelSet.count(outputChannel) != 0) {
       continue;
     }
-    columnMap_.emplace_back(inputChannel, nextOutputChannel++);
-    dependentTypes.push_back(outputType_->childAt(inputChannel));
+    columnMap_.emplace_back(nextInputChannel++, outputChannel);
+    dependentTypes.push_back(outputType_->childAt(outputChannel));
+    types.push_back(dependentTypes.back());
+    names.push_back(outputType_->nameOf(outputChannel));
   }
 
   // Create row container.
   data_ = std::make_unique<RowContainer>(
       keyTypes, dependentTypes, operatorCtx_->mappedMemory());
+  internalStoreType_ = ROW(std::move(names), std::move(types));
+#ifndef NDEBUG
+  for (int i = 0; i < internalStoreType_->children().size(); ++i) {
+    VELOX_DCHECK_EQ(internalStoreType_->childAt(i), data_->columnTypes()[i]);
+  }
+#endif
 
   outputBatchSize_ = std::max<uint32_t>(
       operatorCtx_->execCtx()->queryCtx()->config().preferredOutputBatchSize(),
@@ -77,6 +101,8 @@ OrderBy::OrderBy(
 }
 
 void OrderBy::addInput(RowVectorPtr input) {
+  ensureInputFits(input);
+
   SelectivityVector allRows(input->size());
   std::vector<char*> rows(input->size());
   for (int row = 0; row < input->size(); ++row) {
@@ -84,13 +110,108 @@ void OrderBy::addInput(RowVectorPtr input) {
   }
   for (const auto& columnProjection : columnMap_) {
     DecodedVector decoded(
-        *input->childAt(columnProjection.inputChannel), allRows);
+        *input->childAt(columnProjection.outputChannel), allRows);
     for (int i = 0; i < input->size(); ++i) {
-      data_->store(decoded, i, rows[i], columnProjection.outputChannel);
+      data_->store(decoded, i, rows[i], columnProjection.inputChannel);
     }
   }
 
   numRows_ += allRows.size();
+  if (spiller_ != nullptr) {
+    const auto stats = spiller_->stats();
+    stats_.spilledBytes = stats.spilledBytes;
+    stats_.spilledRows = stats.spilledRows;
+    stats_.spilledPartitions = stats.spilledPartitions;
+    VELOX_DCHECK_LE(stats_.spilledPartitions, 1);
+  }
+}
+
+void OrderBy::ensureInputFits(const RowVectorPtr& input) {
+  // Check if spilling is enabled or not.
+  if (!spillPath_.has_value()) {
+    return;
+  }
+
+  const int64_t numRows = data_->numRows();
+  if (numRows == 0) {
+    // 'data_' is empty. Nothing to spill.
+    return;
+  }
+  auto [freeRows, outOfLineFreeBytes] = data_->freeSpace();
+  const auto outOfLineBytes =
+      data_->stringAllocator().retainedSize() - outOfLineFreeBytes;
+  const int64_t outOfLineBytesPerRow = outOfLineBytes / numRows;
+  const int64_t flatInputBytes = input->estimateFlatSize();
+
+  // Test-only spill path.
+  if (numRows > 0 && testSpillPct_ &&
+      (folly::hasher<uint64_t>()(++spillTestCounter_)) % 100 <= testSpillPct_) {
+    const int64_t rowsToSpill = std::max<int64_t>(1, numRows / 10);
+    spill(
+        numRows - rowsToSpill,
+        outOfLineBytes - (rowsToSpill * outOfLineBytesPerRow));
+    return;
+  }
+
+  if (freeRows > input->size() &&
+      (outOfLineBytes == 0 || outOfLineFreeBytes >= flatInputBytes)) {
+    // Enough free rows for input rows and enough variable length free
+    // space for the flat size of the whole vector. If outOfLineBytes
+    // is 0 there is no need for variable length space.
+    return;
+  }
+
+  // If there is variable length data we take the flat size of the input as a
+  // cap on the new variable length data needed.
+  const int64_t incrementBytes =
+      data_->sizeIncrement(input->size(), outOfLineBytes ? flatInputBytes : 0);
+
+  auto tracker = mappedMemory_->tracker();
+  VELOX_CHECK_NOT_NULL(tracker);
+  // There must be at least 2x the increment in reservation.
+  if (tracker->getAvailableReservation() > 2 * incrementBytes) {
+    return;
+  }
+
+  // Check if can increase reservation. The increment is the larger of twice the
+  // maximum increment from this input and 'spillableReservationGrowthPct_' of
+  // the current reservation.
+  const auto targetIncrementBytes = std::max<int64_t>(
+      incrementBytes * 2,
+      tracker->getCurrentUserBytes() * spillableReservationGrowthPct_ / 100);
+  if (tracker->maybeReserve(targetIncrementBytes)) {
+    return;
+  }
+  const int64_t rowsToSpill = std::max<int64_t>(
+      1, targetIncrementBytes / (data_->fixedRowSize() + outOfLineBytesPerRow));
+  spill(
+      std::max<int64_t>(0, numRows - rowsToSpill),
+      std::max<int64_t>(
+          0, outOfLineBytes - (rowsToSpill * outOfLineBytesPerRow)));
+}
+
+void OrderBy::spill(int64_t targetRows, int64_t targetBytes) {
+  VELOX_CHECK_GE(targetRows, 0);
+  VELOX_CHECK_GE(targetBytes, 0);
+
+  if (spiller_ == nullptr) {
+    assert(mappedMemory_->tracker()); // lint
+    const auto spillFileSize =
+        mappedMemory_->tracker()->getCurrentUserBytes() * spillFileSizeFactor_;
+    spiller_ = std::make_unique<Spiller>(
+        Spiller::Type::kOrderBy,
+        *data_,
+        [&](folly::Range<char**> rows) { data_->eraseRows(rows); },
+        internalStoreType_,
+        data_->keyTypes().size(),
+        keyCompareFlags_,
+        spillPath_.value(),
+        spillFileSize,
+        Spiller::spillPool(),
+        spillExecutor_);
+    VELOX_CHECK_EQ(spiller_->state().maxPartitions(), 1);
+  }
+  spiller_->spill(targetRows, targetBytes);
 }
 
 void OrderBy::noMoreInput() {
@@ -102,44 +223,121 @@ void OrderBy::noMoreInput() {
     return;
   }
 
-  VELOX_CHECK_EQ(numRows_, data_->numRows());
-  // Sort the pointers to the rows in RowContainer (data_) instead of sorting
-  // the rows.
-  returningRows_.resize(numRows_);
-  RowContainerIterator iter;
-  data_->listRows(&iter, numRows_, returningRows_.data());
-  std::sort(
-      returningRows_.begin(),
-      returningRows_.end(),
-      [this](const char* leftRow, const char* rightRow) {
-        for (vector_size_t index = 0; index < numSortKeys_; ++index) {
-          if (auto result = data_->compare(
-                  leftRow, rightRow, index, keyCompareFlags_[index])) {
-            return result < 0;
+  if (spiller_ == nullptr) {
+    VELOX_CHECK_EQ(numRows_, data_->numRows());
+    // Sort the pointers to the rows in RowContainer (data_) instead of sorting
+    // the rows.
+    returningRows_.resize(numRows_);
+    RowContainerIterator iter;
+    data_->listRows(&iter, numRows_, returningRows_.data());
+    std::sort(
+        returningRows_.begin(),
+        returningRows_.end(),
+        [this](const char* leftRow, const char* rightRow) {
+          for (vector_size_t index = 0; index < numSortKeys_; ++index) {
+            if (auto result = data_->compare(
+                    leftRow, rightRow, index, keyCompareFlags_[index])) {
+              return result < 0;
+            }
           }
-        }
-        return false;
-      });
+          return false;
+        });
+
+  } else {
+    // Finish spill, and we shouldn't get any rows from non-spilled partition as
+    // there is only one hash partition for orderBy operator.
+    Spiller::SpillRows nonSpilledRows = spiller_->finishSpill();
+    VELOX_CHECK(nonSpilledRows.empty());
+    VELOX_CHECK_NULL(spillMerge_);
+
+    spillMerge_ = spiller_->startMerge(0);
+    spillSources_.resize(outputBatchSize_);
+    spillSourceRows_.resize(outputBatchSize_);
+  }
 }
 
 RowVectorPtr OrderBy::getOutput() {
   if (finished_ || !noMoreInput_ || numRows_ == numRowsReturned_) {
     return nullptr;
   }
-
   prepareOutput();
 
-  for (const auto& identityProjection : columnMap_) {
+  if (spiller_ != nullptr) {
+    getOutputWithSpill();
+  } else {
+    getOutputWithoutSpill();
+  }
+  finished_ = (numRowsReturned_ == numRows_);
+  return output_;
+}
+
+void OrderBy::getOutputWithoutSpill() {
+  VELOX_CHECK_GT(output_->size(), 0);
+  VELOX_DCHECK_LE(output_->size(), outputBatchSize_);
+  VELOX_CHECK_LE(output_->size() + numRowsReturned_, numRows_);
+  VELOX_DCHECK_EQ(numRows_, returningRows_.size());
+  VELOX_DCHECK(!finished_);
+
+  for (const auto& columnProjection : columnMap_) {
     data_->extractColumn(
         returningRows_.data() + numRowsReturned_,
         output_->size(),
-        identityProjection.outputChannel,
-        output_->childAt(identityProjection.inputChannel));
+        columnProjection.inputChannel,
+        output_->childAt(columnProjection.outputChannel));
   }
   numRowsReturned_ += output_->size();
+}
 
-  finished_ = (numRowsReturned_ == numRows_);
-  return output_;
+void OrderBy::getOutputWithSpill() {
+  VELOX_CHECK_NOT_NULL(spillMerge_);
+  VELOX_DCHECK(!finished_);
+  VELOX_DCHECK_EQ(returningRows_.size(), 0);
+  VELOX_DCHECK_EQ(spillSources_.size(), outputBatchSize_);
+  VELOX_DCHECK_EQ(spillSourceRows_.size(), outputBatchSize_);
+
+  int32_t outputRow = 0;
+  int32_t outputSize = 0;
+  bool isEndOfBatch = false;
+  while (outputRow + outputSize < output_->size()) {
+    VELOX_DCHECK_LT(outputRow, output_->size());
+    VELOX_DCHECK_LT(outputRow + outputSize, output_->size());
+
+    SpillStream* stream = spillMerge_->next();
+    VELOX_CHECK_NOT_NULL(stream);
+
+    spillSources_[outputSize] = &stream->current();
+    spillSourceRows_[outputSize] = stream->currentIndex(&isEndOfBatch);
+    ++outputSize;
+    if (FOLLY_UNLIKELY(isEndOfBatch)) {
+      // The stream is at end of input batch. Need to copy out the rows before
+      // fetching next batch in 'pop'.
+      gatherCopy(
+          output_.get(),
+          outputRow,
+          outputSize,
+          spillSources_,
+          spillSourceRows_,
+          columnMap_);
+      outputRow += outputSize;
+      outputSize = 0;
+    }
+
+    // Advance the stream.
+    stream->pop();
+  }
+  VELOX_CHECK_EQ(outputRow + outputSize, output_->size());
+
+  if (FOLLY_LIKELY(outputSize != 0)) {
+    gatherCopy(
+        output_.get(),
+        outputRow,
+        outputSize,
+        spillSources_,
+        spillSourceRows_,
+        columnMap_);
+  }
+
+  numRowsReturned_ += output_->size();
 }
 
 void OrderBy::prepareOutput() {
@@ -159,6 +357,18 @@ void OrderBy::prepareOutput() {
   for (auto& child : output_->children()) {
     child->resize(batchSize);
   }
+}
+
+std::optional<std::string> OrderBy::makeSpillPath(int32_t operatorId) const {
+  auto basePath = operatorCtx_->task()->queryCtx()->config().spillPath();
+  if (!basePath.has_value()) {
+    return std::nullopt;
+  }
+  return makeOperatorSpillPath(
+      basePath.value(),
+      operatorCtx_->task()->taskId(),
+      operatorCtx_->driverCtx()->driverId,
+      operatorId);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -13,27 +13,57 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/file/FileSystems.h"
+#include "velox/core/QueryConfig.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/Spiller.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/vector/tests/VectorMaker.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::core;
 using namespace facebook::velox::exec::test;
+
+namespace {
+// Returns aggregated spilled stats by 'task'.
+Spiller::Stats spilledStats(const exec::Task& task) {
+  Spiller::Stats spilledStats;
+  auto stats = task.taskStats();
+  for (auto& pipeline : stats.pipelineStats) {
+    for (auto op : pipeline.operatorStats) {
+      spilledStats.spilledBytes += op.spilledBytes;
+      spilledStats.spilledRows += op.spilledRows;
+      spilledStats.spilledPartitions += op.spilledPartitions;
+    }
+  }
+  return spilledStats;
+}
+} // namespace
 
 class OrderByTest : public OperatorTestBase {
  protected:
+  void SetUp() override {
+    filesystems::registerLocalFileSystem();
+  }
+
   void testSingleKey(
       const std::vector<RowVectorPtr>& input,
       const std::string& key) {
+    core::PlanNodeId orderById;
     auto keyIndex = input[0]->type()->asRow().getChildIdx(key);
     auto plan = PlanBuilder()
                     .values(input)
                     .orderBy({fmt::format("{} ASC NULLS LAST", key)}, false)
+                    .capturePlanNodeId(orderById)
                     .planNode();
-
-    assertQueryOrdered(
+    runTest(
         plan,
+        orderById,
         fmt::format("SELECT * FROM tmp ORDER BY {} NULLS LAST", key),
         {keyIndex});
 
@@ -41,9 +71,9 @@ class OrderByTest : public OperatorTestBase {
                .values(input)
                .orderBy({fmt::format("{} DESC NULLS FIRST", key)}, false)
                .planNode();
-
-    assertQueryOrdered(
+    runTest(
         plan,
+        orderById,
         fmt::format("SELECT * FROM tmp ORDER BY {} DESC NULLS FIRST", key),
         {keyIndex});
   }
@@ -52,15 +82,17 @@ class OrderByTest : public OperatorTestBase {
       const std::vector<RowVectorPtr>& input,
       const std::string& key,
       const std::string& filter) {
+    core::PlanNodeId orderById;
     auto keyIndex = input[0]->type()->asRow().getChildIdx(key);
     auto plan = PlanBuilder()
                     .values(input)
                     .filter(filter)
                     .orderBy({fmt::format("{} ASC NULLS LAST", key)}, false)
+                    .capturePlanNodeId(orderById)
                     .planNode();
-
-    assertQueryOrdered(
+    runTest(
         plan,
+        orderById,
         fmt::format(
             "SELECT * FROM tmp WHERE {} ORDER BY {} NULLS LAST", filter, key),
         {keyIndex});
@@ -69,10 +101,11 @@ class OrderByTest : public OperatorTestBase {
                .values(input)
                .filter(filter)
                .orderBy({fmt::format("{} DESC NULLS FIRST", key)}, false)
+               .capturePlanNodeId(orderById)
                .planNode();
-
-    assertQueryOrdered(
+    runTest(
         plan,
+        orderById,
         fmt::format(
             "SELECT * FROM tmp WHERE {} ORDER BY {} DESC NULLS FIRST",
             filter,
@@ -93,16 +126,18 @@ class OrderByTest : public OperatorTestBase {
 
     for (int i = 0; i < sortOrders.size(); i++) {
       for (int j = 0; j < sortOrders.size(); j++) {
+        core::PlanNodeId orderById;
         auto plan = PlanBuilder()
                         .values(input)
                         .orderBy(
                             {fmt::format("{} {}", key1, sortOrderSqls[i]),
                              fmt::format("{} {}", key2, sortOrderSqls[j])},
                             false)
+                        .capturePlanNodeId(orderById)
                         .planNode();
-
-        assertQueryOrdered(
+        runTest(
             plan,
+            orderById,
             fmt::format(
                 "SELECT * FROM tmp ORDER BY {} {}, {} {}",
                 key1,
@@ -110,6 +145,38 @@ class OrderByTest : public OperatorTestBase {
                 key2,
                 sortOrderSqls[j]),
             keyIndices);
+      }
+    }
+  }
+
+  void runTest(
+      core::PlanNodePtr planNode,
+      const core::PlanNodeId& orderById,
+      const std::string& duckDbSql,
+      const std::vector<uint32_t>& sortingKeys) {
+    {
+      SCOPED_TRACE("run without spilling");
+      assertQueryOrdered(planNode, duckDbSql, sortingKeys);
+    }
+    {
+      SCOPED_TRACE("run with spilling");
+      auto spillDirectory = exec::test::TempDirectoryPath::create();
+      auto queryCtx = core::QueryCtx::createForTest();
+      queryCtx->setConfigOverridesUnsafe(
+          {{core::QueryConfig::kTestingSpillPct, "100"},
+           {core::QueryConfig::kSpillPath, spillDirectory->path}});
+      CursorParameters params;
+      params.planNode = planNode;
+      params.queryCtx = queryCtx;
+      auto task = assertQueryOrdered(params, duckDbSql, sortingKeys);
+      auto inputRows = toPlanStats(task->taskStats()).at(orderById).inputRows;
+      if (inputRows > 0) {
+        EXPECT_LT(0, spilledStats(*task).spilledBytes);
+        EXPECT_EQ(1, spilledStats(*task).spilledPartitions);
+        // NOTE: the last input batch won't go spilling.
+        EXPECT_GT(inputRows, spilledStats(*task).spilledRows);
+      } else {
+        EXPECT_EQ(0, spilledStats(*task).spilledBytes);
       }
     }
   }
@@ -155,20 +222,21 @@ TEST_F(OrderByTest, singleKey) {
   // parser doesn't support "is not null" expression, hence, using c0 % 2 >= 0
   testSingleKey(vectors, "c0", "c0 % 2 >= 0");
 
+  core::PlanNodeId orderById;
   auto plan = PlanBuilder()
                   .values(vectors)
                   .orderBy({"c0 DESC NULLS LAST"}, false)
+                  .capturePlanNodeId(orderById)
                   .planNode();
-
-  assertQueryOrdered(
-      plan, "SELECT * FROM tmp ORDER BY c0 DESC NULLS LAST", {0});
+  runTest(
+      plan, orderById, "SELECT * FROM tmp ORDER BY c0 DESC NULLS LAST", {0});
 
   plan = PlanBuilder()
              .values(vectors)
              .orderBy({"c0 ASC NULLS FIRST"}, false)
+             .capturePlanNodeId(orderById)
              .planNode();
-
-  assertQueryOrdered(plan, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST", {0});
+  runTest(plan, orderById, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST", {0});
 }
 
 TEST_F(OrderByTest, multipleKeys) {
@@ -188,21 +256,26 @@ TEST_F(OrderByTest, multipleKeys) {
 
   testTwoKeys(vectors, "c0", "c1");
 
+  core::PlanNodeId orderById;
   auto plan = PlanBuilder()
                   .values(vectors)
                   .orderBy({"c0 ASC NULLS FIRST", "c1 ASC NULLS LAST"}, false)
+                  .capturePlanNodeId(orderById)
                   .planNode();
-
-  assertQueryOrdered(
-      plan, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST, c1 NULLS LAST", {0, 1});
+  runTest(
+      plan,
+      orderById,
+      "SELECT * FROM tmp ORDER BY c0 NULLS FIRST, c1 NULLS LAST",
+      {0, 1});
 
   plan = PlanBuilder()
              .values(vectors)
              .orderBy({"c0 DESC NULLS LAST", "c1 DESC NULLS FIRST"}, false)
+             .capturePlanNodeId(orderById)
              .planNode();
-
-  assertQueryOrdered(
+  runTest(
       plan,
+      orderById,
       "SELECT * FROM tmp ORDER BY c0 DESC NULLS LAST, c1 DESC NULLS FIRST",
       {0, 1});
 }
@@ -255,15 +328,21 @@ TEST_F(OrderByTest, unknown) {
            variant(TypeKind::UNKNOWN), size, pool_.get())});
 
   // Exclude "UNKNOWN" column as DuckDB doesn't understand UNKNOWN type
-  createDuckDbTable({makeRowVector({vector->childAt(0)})});
+  createDuckDbTable(
+      {makeRowVector({vector->childAt(0)}),
+       makeRowVector({vector->childAt(0)})});
 
+  core::PlanNodeId orderById;
   auto plan = PlanBuilder()
-                  .values({vector})
+                  .values({vector, vector})
                   .orderBy({"c0 DESC NULLS LAST"}, false)
+                  .capturePlanNodeId(orderById)
                   .planNode();
-
-  assertQueryOrdered(
-      plan, "SELECT *, null FROM tmp ORDER BY c0 DESC NULLS LAST", {0});
+  runTest(
+      plan,
+      orderById,
+      "SELECT *, null FROM tmp ORDER BY c0 DESC NULLS LAST",
+      {0});
 }
 
 /// Verifies that Order By output batch sizes correspond to
@@ -318,4 +397,43 @@ TEST_F(OrderByTest, outputBatchSize) {
         testData.expectedOutputVectors,
         toPlanStats(task->taskStats()).at(orderById).outputVectors);
   }
+}
+
+TEST_F(OrderByTest, spill) {
+  const int kNumBatches = 3;
+  const int kNumRows = 100'000;
+  std::vector<RowVectorPtr> batches;
+  for (int i = 0; i < kNumBatches; ++i) {
+    batches.push_back(makeRowVector(
+        {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row * 3; }),
+         makeFlatVector<StringView>(kNumRows, [](auto row) {
+           return StringView(std::to_string(row * 3));
+         })}));
+  }
+  createDuckDbTable(batches);
+
+  auto plan = PlanBuilder()
+                  .values(batches)
+                  .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                  .planNode();
+  auto spillDirectory = exec::test::TempDirectoryPath::create();
+  auto queryCtx = core::QueryCtx::createForTest();
+  constexpr int64_t kMaxBytes = 20LL << 20; // 20 MB
+  queryCtx->pool()->setMemoryUsageTracker(
+      memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
+  // Set 'kSpillableReservationGrowthPct' to an extreme large value to trigger
+  // disk spilling by failed memory growth reservation.
+  queryCtx->setConfigOverridesUnsafe(
+      {{core::QueryConfig::kSpillPath, spillDirectory->path},
+       {core::QueryConfig::kSpillableReservationGrowthPct, "1000"}});
+  CursorParameters params;
+  params.planNode = plan;
+  params.queryCtx = queryCtx;
+  auto task = assertQueryOrdered(
+      params, "SELECT * FROM tmp ORDER BY c0 ASC NULLS LAST", {0});
+  auto stats = task->taskStats().pipelineStats;
+  EXPECT_LT(0, stats[0].operatorStats[1].spilledRows);
+  EXPECT_GT(kNumBatches * kNumRows, stats[0].operatorStats[1].spilledRows);
+  EXPECT_LT(0, stats[0].operatorStats[1].spilledBytes);
+  EXPECT_EQ(1, stats[0].operatorStats[1].spilledPartitions);
 }


### PR DESCRIPTION
Add disk spilling support for order by with unit test coverage.
The spilling algorithm is as follows:
(1) add input batch can't reserve enough growth memory to trigger spilling;
(2) there is one partition for spilling and the spiller just spill enough to meet
the spilling target;
(3) no more input method finishes the spilling and setup merge reader to
prepare unspilling;
(4) get output method use merge reader to read back both in-memory and
on disk spilled data in given sort order.
Both spilling file size and memory reservation growth can be configured through
the query configs. The columns stored on spilled disk are in sort key orders.

Also fix a UNKNOWN type issue in gatherCopy;