### PR TITLE
Improve 'Duplicate map keys are not allowed' error message

### DIFF
--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -39,7 +39,8 @@ class MapFunction : public exec::VectorFunction {
 
     static const char* kArrayLengthsMismatch =
         "Key and value arrays must be the same length";
-    static const char* kDuplicateKey = "Duplicate map keys are not allowed";
+    static const char* kDuplicateKey =
+        "Duplicate map keys ({}) are not allowed";
 
     MapVectorPtr mapVector;
     if (decodedKeys->isIdentityMapping() &&
@@ -150,7 +151,9 @@ class MapFunction : public exec::VectorFunction {
         for (vector_size_t i = 1; i < size; i++) {
           if (mapKeys->equalValueAt(
                   mapKeys.get(), offset + i, offset + i - 1)) {
-            VELOX_USER_FAIL("{}", kDuplicateKey);
+            auto duplicateKey = mapKeys->wrappedVector()->toString(
+                mapKeys->wrappedIndex(offset + i));
+            VELOX_USER_FAIL(kDuplicateKey, duplicateKey);
           }
         }
       });

--- a/velox/functions/prestosql/TransformKeys.cpp
+++ b/velox/functions/prestosql/TransformKeys.cpp
@@ -96,7 +96,8 @@ class TransformKeysFunction : public exec::VectorFunction {
   void checkDuplicateKeys(
       const MapVectorPtr& mapVector,
       const SelectivityVector& rows) const {
-    static const char* kDuplicateKey = "Duplicate map keys are not allowed";
+    static const char* kDuplicateKey =
+        "Duplicate map keys ({}) are not allowed";
 
     MapVector::canonicalize(mapVector);
 
@@ -108,7 +109,9 @@ class TransformKeysFunction : public exec::VectorFunction {
       auto size = sizes[row];
       for (auto i = 1; i < size; i++) {
         if (mapKeys->equalValueAt(mapKeys.get(), offset + i, offset + i - 1)) {
-          VELOX_USER_FAIL("{}", kDuplicateKey);
+          auto duplicateKey = mapKeys->wrappedVector()->toString(
+              mapKeys->wrappedIndex(offset + i));
+          VELOX_USER_FAIL(kDuplicateKey, duplicateKey);
         }
       }
     });

--- a/velox/functions/prestosql/tests/TransformKeysTest.cpp
+++ b/velox/functions/prestosql/tests/TransformKeysTest.cpp
@@ -77,14 +77,15 @@ TEST_F(TransformKeysTest, duplicateKeys) {
           nullEvery(13)),
   });
   registerLambda(
-      "mod2",
+      "10_plus_mod2",
       rowType("x", BIGINT(), "unused", INTEGER()),
       input->type(),
-      "x % 2");
+      "10 + x % 2");
 
   VELOX_ASSERT_THROW(
-      evaluate<MapVector>("transform_keys(c0, function('mod2'))", input),
-      "Duplicate map keys are not allowed");
+      evaluate<MapVector>(
+          "transform_keys(c0, function('10_plus_mod2'))", input),
+      "Duplicate map keys (11) are not allowed");
 }
 
 TEST_F(TransformKeysTest, differentResultType) {


### PR DESCRIPTION
Include the value of the duplicate key in the message.