### PR TITLE
Remove additionalContext parameter from assertEqualVectors

### DIFF
--- a/velox/functions/sparksql/tests/SortArrayTest.cpp
+++ b/velox/functions/sparksql/tests/SortArrayTest.cpp
@@ -24,12 +24,10 @@
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/vector/ComplexVector.h"
 
-namespace facebook::velox::functions::sparksql::test {
-
 using namespace facebook::velox::test;
-namespace {
 
-using facebook::velox::functions::test::FunctionBaseTest;
+namespace facebook::velox::functions::sparksql::test {
+namespace {
 
 class SortArrayTest : public SparkFunctionBaseTest {
  protected:
@@ -38,19 +36,22 @@ class SortArrayTest : public SparkFunctionBaseTest {
       const VectorPtr& expectedAsc,
       const VectorPtr& expectedDesc) {
     // Verify that by default array is sorted in ascending order.
-    std::string expr = "sort_array(c0)";
-    auto result = evaluate<ArrayVector>(expr, makeRowVector({input}));
-    assertEqualVectors(expectedAsc, result, expr);
+    testSortArray("sort_array(c0)", input, expectedAsc);
 
     // Verify sort order with asc flag set to true.
-    expr = "sort_array(c0, true)";
-    auto resultAsc = evaluate<ArrayVector>(expr, makeRowVector({input}));
-    assertEqualVectors(expectedAsc, result, expr);
+    testSortArray("sort_array(c0, true)", input, expectedAsc);
 
     // Verify sort order with asc flag set to false.
-    expr = "sort_array(c0, false)";
-    auto resultDesc = evaluate<ArrayVector>(expr, makeRowVector({input}));
-    assertEqualVectors(expectedDesc, resultDesc, expr);
+    testSortArray("sort_array(c0, false)", input, expectedDesc);
+  }
+
+  void testSortArray(
+      const std::string& expr,
+      const VectorPtr& input,
+      const VectorPtr& expected) {
+    SCOPED_TRACE(expr);
+    auto result = evaluate<ArrayVector>(expr, makeRowVector({input}));
+    assertEqualVectors(expected, result);
   }
 
   template <typename T>

--- a/velox/row/tests/UnsafeRowFuzzTests.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTests.cpp
@@ -79,6 +79,7 @@ TEST_F(UnsafeRowFuzzTests, simpleTypeRoundTripTest) {
 
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;
+  SCOPED_TRACE(fmt::format("seed: {}", seed));
   VectorFuzzer fuzzer(opts, pool_.get(), seed);
 
   const auto iterations = 1000;
@@ -94,8 +95,7 @@ TEST_F(UnsafeRowFuzzTests, simpleTypeRoundTripTest) {
         UnsafeRowDynamicVectorBatchDeserializer::deserializeComplex(
             std::string_view(buffer_, rowSize.value()), rowType, pool_.get());
 
-    assertEqualVectors(
-        inputVector, outputVector, fmt::format(" (seed {}).", seed));
+    assertEqualVectors(inputVector, outputVector);
   }
 }
 

--- a/velox/vector/tests/VectorTestBase.cpp
+++ b/velox/vector/tests/VectorTestBase.cpp
@@ -81,18 +81,15 @@ BufferPtr VectorTestBase::makeNulls(
   return nulls;
 }
 
-void assertEqualVectors(
-    const VectorPtr& expected,
-    const VectorPtr& actual,
-    const std::string& additionalContext) {
-  ASSERT_EQ(expected->size(), actual->size()) << additionalContext;
+void assertEqualVectors(const VectorPtr& expected, const VectorPtr& actual) {
+  ASSERT_EQ(expected->size(), actual->size());
   ASSERT_TRUE(expected->type()->equivalent(*actual->type()))
       << "Expected " << expected->type()->toString() << ", but got "
       << actual->type()->toString();
   for (auto i = 0; i < expected->size(); i++) {
     ASSERT_TRUE(expected->equalValueAt(actual.get(), i, i))
         << "at " << i << ": expected " << expected->toString(i) << ", but got "
-        << actual->toString(i) << additionalContext;
+        << actual->toString(i);
   }
 }
 

--- a/velox/vector/tests/VectorTestBase.h
+++ b/velox/vector/tests/VectorTestBase.h
@@ -26,10 +26,7 @@ namespace facebook::velox::test {
 BufferPtr makeIndicesInReverse(vector_size_t size, memory::MemoryPool* pool);
 
 // TODO: enable ASSERT_EQ for vectors.
-void assertEqualVectors(
-    const VectorPtr& expected,
-    const VectorPtr& actual,
-    const std::string& additionalContext = "");
+void assertEqualVectors(const VectorPtr& expected, const VectorPtr& actual);
 
 /// Verify that 'vector' is copyable, by copying all rows.
 void assertCopyableVector(const VectorPtr& vector);


### PR DESCRIPTION
Summary: Use SCOPED_TRACE from GTest instead: https://github.com/google/googletest/blob/main/docs/advanced.md#adding-traces-to-assertions

Differential Revision: D38615378

