### PR TITLE
[Substrait to Velox] Add support for ROW type

### DIFF
--- a/velox/substrait/TypeUtils.cpp
+++ b/velox/substrait/TypeUtils.cpp
@@ -17,45 +17,93 @@
 #include "velox/type/Type.h"
 
 namespace facebook::velox::substrait {
-
-bool isString(const TypePtr& type) {
-  switch (type->kind()) {
-    case TypeKind::VARCHAR:
-    case TypeKind::VARBINARY:
-      return true;
-    default:
-      break;
+namespace {
+std::vector<std::string_view> getRowTypesFromCompoundName(
+    std::string_view compoundName) {
+  // CompoundName is like ROW<BIGINT,DOUBLE>
+  // or ROW<BIGINT,ROW<DOUBLE,BIGINT>,ROW<DOUBLE,BIGINT>>
+  // the position of then delimiter is where the number of leftAngleBracket
+  // equals rightAngleBracket need to split.
+  std::vector<std::string_view> types;
+  std::vector<int> angleBracketNumEqualPos;
+  auto leftAngleBracketPos = compoundName.find("<");
+  auto rightAngleBracketPos = compoundName.rfind(">");
+  auto typesName = compoundName.substr(
+      leftAngleBracketPos + 1, rightAngleBracketPos - leftAngleBracketPos - 1);
+  int leftAngleBracketNum = 0;
+  int rightAngleBracketNum = 0;
+  for (auto index = 0; index < typesName.length(); index++) {
+    if (typesName[index] == '<') {
+      leftAngleBracketNum++;
+    }
+    if (typesName[index] == '>') {
+      rightAngleBracketNum++;
+    }
+    if (typesName[index] == ',' &&
+        rightAngleBracketNum == leftAngleBracketNum) {
+      angleBracketNumEqualPos.push_back(index);
+    }
   }
-  return false;
+  int startPos = 0;
+  for (auto delimeterPos : angleBracketNumEqualPos) {
+    types.emplace_back(typesName.substr(startPos, delimeterPos - startPos));
+    startPos = delimeterPos + 1;
+  }
+  types.emplace_back(std::string_view(
+      typesName.data() + startPos, typesName.length() - startPos));
+  return types;
 }
 
-int64_t bytesOfType(const TypePtr& type) {
-  auto typeKind = type->kind();
-  switch (typeKind) {
-    case TypeKind::INTEGER:
-      return 4;
-    case TypeKind::BIGINT:
-    case TypeKind::REAL:
-    case TypeKind::DOUBLE:
-      return 8;
-    default:
-      VELOX_NYI("Returning bytes of Type not supported for type {}.", typeKind);
+// TODO Refactor using Bison.
+std::string_view getNameBeforeDelimiter(
+    const std::string& compoundName,
+    const std::string& delimiter) {
+  std::size_t pos = compoundName.find(delimiter);
+  if (pos == std::string::npos) {
+    return compoundName;
   }
+  return std::string_view(compoundName.data(), pos);
 }
+} // namespace
 
 TypePtr toVeloxType(const std::string& typeName) {
-  auto typeKind = mapNameToTypeKind(typeName);
+  VELOX_CHECK(!typeName.empty(), "Cannot convert empty string to Velox type.");
+
+  auto type = getNameBeforeDelimiter(typeName, "<");
+  auto typeKind = mapNameToTypeKind(std::string(type));
   switch (typeKind) {
     case TypeKind::BOOLEAN:
       return BOOLEAN();
-    case TypeKind::DOUBLE:
-      return DOUBLE();
-    case TypeKind::VARCHAR:
-      return VARCHAR();
+    case TypeKind::TINYINT:
+      return TINYINT();
+    case TypeKind::SMALLINT:
+      return SMALLINT();
     case TypeKind::INTEGER:
       return INTEGER();
     case TypeKind::BIGINT:
       return BIGINT();
+    case TypeKind::REAL:
+      return REAL();
+    case TypeKind::DOUBLE:
+      return DOUBLE();
+    case TypeKind::VARCHAR:
+      return VARCHAR();
+    case TypeKind::VARBINARY:
+      return VARBINARY();
+    case TypeKind::ROW: {
+      auto fieldNames = getRowTypesFromCompoundName(typeName);
+      VELOX_CHECK(
+          !fieldNames.empty(),
+          "Converting empty ROW type from Substrait to Velox is not supported.");
+
+      std::vector<TypePtr> types;
+      std::vector<std::string> names;
+      for (int idx = 0; idx < fieldNames.size(); idx++) {
+        names.emplace_back("col_" + std::to_string(idx));
+        types.emplace_back(toVeloxType(std::string(fieldNames[idx])));
+      }
+      return ROW(std::move(names), std::move(types));
+    }
     case TypeKind::UNKNOWN:
       return UNKNOWN();
     default:

--- a/velox/substrait/TypeUtils.h
+++ b/velox/substrait/TypeUtils.h
@@ -18,12 +18,6 @@
 
 namespace facebook::velox::substrait {
 
-/// Return whether the type is String type.
-bool isString(const TypePtr& type);
-
-/// Return the occupied bytes for a variable of this type.
-int64_t bytesOfType(const TypePtr& type);
-
 /// Return the Velox type according to the typename.
 TypePtr toVeloxType(const std::string& typeName);
 

--- a/velox/substrait/VeloxToSubstraitType.cpp
+++ b/velox/substrait/VeloxToSubstraitType.cpp
@@ -87,12 +87,12 @@ const ::substrait::Type& VeloxToSubstraitTypeConvertor::toSubstraitType(
       break;
     }
     case velox::TypeKind::VARCHAR: {
-      auto substraitVarChar =
-          google::protobuf::Arena::CreateMessage<::substrait::Type_VarChar>(
+      auto substraitString =
+          google::protobuf::Arena::CreateMessage<::substrait::Type_String>(
               &arena);
-      substraitVarChar->set_nullability(
+      substraitString->set_nullability(
           ::substrait::Type_Nullability_NULLABILITY_NULLABLE);
-      substraitType->set_allocated_varchar(substraitVarChar);
+      substraitType->set_allocated_string(substraitString);
       break;
     }
     case velox::TypeKind::VARBINARY: {
@@ -142,6 +142,20 @@ const ::substrait::Type& VeloxToSubstraitTypeConvertor::toSubstraitType(
 
       substraitType->set_allocated_map(substraitMap);
 
+      break;
+    }
+    case velox::TypeKind::ROW: {
+      ::substrait::Type_Struct* substraitStruct =
+          google::protobuf::Arena::CreateMessage<::substrait::Type_Struct>(
+              &arena);
+      for (const auto& child : type->asRow().children()) {
+        substraitStruct->set_nullability(
+            ::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+        substraitStruct->add_types()->MergeFrom(toSubstraitType(arena, child));
+      }
+      substraitStruct->set_nullability(
+          ::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+      substraitType->set_allocated_struct_(substraitStruct);
       break;
     }
     case velox::TypeKind::UNKNOWN: {

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 add_executable(
   velox_plan_conversion_test
-  Substrait2VeloxPlanConversionTest.cpp
+  VeloxToSubstraitTypeTest.cpp Substrait2VeloxPlanConversionTest.cpp
   Substrait2VeloxValuesNodeConversionTest.cpp FunctionTest.cpp
   JsonToProtoConverter.cpp VeloxSubstraitRoundTripPlanConverterTest.cpp)
 

--- a/velox/substrait/tests/VeloxToSubstraitTypeTest.cpp
+++ b/velox/substrait/tests/VeloxToSubstraitTypeTest.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+
+#include "velox/substrait/SubstraitParser.h"
+#include "velox/substrait/TypeUtils.h"
+#include "velox/substrait/VeloxToSubstraitType.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::substrait;
+
+namespace facebook::velox::substrait::test {
+
+class VeloxToSubstraitTypeTest : public ::testing::Test {
+ protected:
+  void testTypeConversion(const TypePtr& type) {
+    SCOPED_TRACE(type->toString());
+
+    google::protobuf::Arena arena;
+    auto substraitType = typeConvertor_->toSubstraitType(arena, type);
+    auto sameType =
+        toVeloxType(substraitParser_->parseType(substraitType)->type);
+    ASSERT_TRUE(sameType->kindEquals(type))
+        << "Expected: " << type->toString()
+        << ", but got: " << sameType->toString();
+  }
+
+  std::shared_ptr<VeloxToSubstraitTypeConvertor> typeConvertor_;
+
+  std::shared_ptr<SubstraitParser> substraitParser_ =
+      std::make_shared<SubstraitParser>();
+};
+
+TEST_F(VeloxToSubstraitTypeTest, basic) {
+  testTypeConversion(BOOLEAN());
+
+  testTypeConversion(TINYINT());
+  testTypeConversion(SMALLINT());
+  testTypeConversion(INTEGER());
+  testTypeConversion(BIGINT());
+
+  testTypeConversion(REAL());
+  testTypeConversion(DOUBLE());
+
+  testTypeConversion(VARCHAR());
+  testTypeConversion(VARBINARY());
+
+  // Array type is not supported yet.
+  ASSERT_ANY_THROW(testTypeConversion(ARRAY(BIGINT())));
+
+  // Map type is not supported yet.
+  ASSERT_ANY_THROW(testTypeConversion(MAP(BIGINT(), DOUBLE())));
+
+  testTypeConversion(ROW({"a", "b", "c"}, {BIGINT(), BOOLEAN(), VARCHAR()}));
+  testTypeConversion(
+      ROW({"a", "b", "c"},
+          {BIGINT(), ROW({"x", "y"}, {BOOLEAN(), VARCHAR()}), REAL()}));
+  ASSERT_ANY_THROW(testTypeConversion(ROW({}, {})));
+}
+} // namespace facebook::velox::substrait::test


### PR DESCRIPTION
Add support for converting primitive types and ROW type. Add tests.

The support for ROW type is an extract from #1978.