### PR TITLE
Add checks to JsonToProtoConverter::readFromFile

### DIFF
--- a/velox/substrait/tests/JsonToProtoConverter.cpp
+++ b/velox/substrait/tests/JsonToProtoConverter.cpp
@@ -17,14 +17,22 @@
 #include "velox/substrait/tests/JsonToProtoConverter.h"
 #include <fstream>
 #include <sstream>
+#include "velox/common/base/Exceptions.h"
 
 void JsonToProtoConverter::readFromFile(
     const std::string& msgPath,
     google::protobuf::Message& msg) {
   // Read json file and resume the Substrait plan.
   std::ifstream msgJson(msgPath);
+  VELOX_CHECK(
+      !msgJson.fail(), "Failed to open file: {}. {}", msgPath, strerror(errno));
   std::stringstream buffer;
   buffer << msgJson.rdbuf();
   std::string msgData = buffer.str();
-  google::protobuf::util::JsonStringToMessage(msgData, &msg);
+  auto status = google::protobuf::util::JsonStringToMessage(msgData, &msg);
+  VELOX_CHECK(
+      status.ok(),
+      "Failed to parse Substrait JSON: {} {}",
+      status.code(),
+      status.message());
 }


### PR DESCRIPTION
Check and fail with clear error message if file cannot be read or JSON cannot be parsed.