### PR TITLE
Add Decimal BETWEEN filter

### DIFF
--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -169,15 +169,6 @@ class CastExpr : public SpecialForm {
       const TypePtr& fromType,
       const TypePtr& toType);
 
-  template <typename TInput, typename TOutput>
-  void applyDecimalCastKernel(
-      const SelectivityVector& rows,
-      DecodedVector& input,
-      exec::EvalCtx& context,
-      const TypePtr& fromType,
-      const TypePtr& toType,
-      VectorPtr castResult);
-
   // When enabled the error in casting leads to null being returned.
   const bool nullOnFailure_;
 

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -169,6 +169,15 @@ class CastExpr : public SpecialForm {
       const TypePtr& fromType,
       const TypePtr& toType);
 
+  template <typename TInput, typename TOutput>
+  void applyDecimalCastKernel(
+      const SelectivityVector& rows,
+      DecodedVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& fromType,
+      const TypePtr& toType,
+      VectorPtr castResult);
+
   // When enabled the error in casting leads to null being returned.
   const bool nullOnFailure_;
 

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -162,6 +162,14 @@ class CastExpr : public SpecialForm {
       const RowType& fromType,
       const RowType& toType);
 
+  template <typename T>
+  VectorPtr applyDecimal(
+      const SelectivityVector& rows,
+      DecodedVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& fromType,
+      const TypePtr& toType);
+
   // When enabled the error in casting leads to null being returned.
   const bool nullOnFailure_;
 

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -162,7 +162,6 @@ class CastExpr : public SpecialForm {
       const RowType& fromType,
       const RowType& toType);
 
-  template <typename T>
   VectorPtr applyDecimal(
       const SelectivityVector& rows,
       DecodedVector& input,

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -739,4 +739,20 @@ TEST_F(CastExprTest, decimalToDecimal) {
 
   // nullOnFailure is true.
   testComplexCast("c0", longFlat, expectedShort, true);
+
+  // long to short, big numbers.
+  longFlat = makeNullableLongDecimalFlatVector(
+      {buildInt128(10, 100),
+       buildInt128(-2, 200),
+       buildInt128(-1, 300),
+       buildInt128(0, 400),
+       buildInt128(1, 500),
+       std::nullopt},
+      DECIMAL(23, 8));
+
+  // 00000000000000000000000011001000
+  // 36893488147419103432
+  expectedShort = makeNullableShortDecimalFlatVector(
+      {-368934881474, -184467440737, 0, 184467440737, std::nullopt},
+      DECIMAL(12, 0));
 }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -697,7 +697,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
 
   // long to long, scale up.
   auto expectedLong = makeLongDecimalFlatVector(
-      {-20100000000, -10900000000, 0, 1050000000, 20800000000},
+      {-20'100'000'000, -10'900'000'000, 0, 1'050'000'000, 20800000000},
       DECIMAL(20, 10));
   testComplexCast("c0", longFlat, expectedShort);
   // long to long, scale down.
@@ -722,4 +722,11 @@ TEST_F(CastExprTest, decimalToDecimal) {
       makeShortDecimalFlatVector({-20500, -190, 12345, 19999}, DECIMAL(6, 4));
   expectedLong = makeLongDecimalFlatVector({-20, 0, 12, 20}, DECIMAL(20, 1));
   testComplexCast("c0", shortFlat, expectedLong);
+
+  // NULLs and overflow.
+  longFlat = makeNullableLongDecimalFlatVector(
+      {-20'000, -1'000'000, 10'000, std::nullopt}, DECIMAL(20, 3));
+  expectedShort = makeNullableShortDecimalFlatVector(
+      {-200'000, std::nullopt, 100'000, std::nullopt}, DECIMAL(6, 4));
+  testComplexCast("c0", longFlat, expectedShort);
 }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -676,7 +676,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
   auto shortFlat =
       makeShortDecimalFlatVector({-3, -2, -1, 0, 55, 69, 72}, DECIMAL(2, 2));
   auto expectedShort = makeShortDecimalFlatVector(
-      {-300, -200, -100, 0, 5500, 6900, 7200}, DECIMAL(4, 4));
+      {-300, -200, -100, 0, 5'500, 6'900, 7'200}, DECIMAL(4, 4));
   testComplexCast("c0", shortFlat, expectedShort);
   // short to short, scale down.
   expectedShort =

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -17,6 +17,7 @@
 #include <limits>
 #include "velox/buffer/Buffer.h"
 #include "velox/common/base/VeloxException.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
@@ -678,6 +679,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
   auto expectedShort = makeShortDecimalFlatVector(
       {-300, -200, -100, 0, 5'500, 6'900, 7'200}, DECIMAL(4, 4));
   testComplexCast("c0", shortFlat, expectedShort);
+
   // short to short, scale down.
   expectedShort =
       makeShortDecimalFlatVector({0, 0, 0, 0, 6, 7, 7}, DECIMAL(4, 1));
@@ -689,6 +691,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
   expectedShort = makeShortDecimalFlatVector(
       {-201'000, -109'000, 0, 105'000, 208'000}, DECIMAL(10, 5));
   testComplexCast("c0", longFlat, expectedShort);
+
   // long to short, scale down.
   expectedShort =
       makeShortDecimalFlatVector({-20, -11, 0, 11, 21}, DECIMAL(10, 1));
@@ -699,6 +702,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
       {-20'100'000'000, -10'900'000'000, 0, 1'050'000'000, 20'800'000'000},
       DECIMAL(20, 10));
   testComplexCast("c0", longFlat, expectedShort);
+
   // long to long, scale down.
   expectedLong =
       makeLongDecimalFlatVector({-20, -11, 0, 11, 21}, DECIMAL(20, 1));
@@ -727,8 +731,12 @@ TEST_F(CastExprTest, decimalToDecimal) {
       {-20'000, -1'000'000, 10'000, std::nullopt}, DECIMAL(20, 3));
   expectedShort = makeNullableShortDecimalFlatVector(
       {-200'000, std::nullopt, 100'000, std::nullopt}, DECIMAL(6, 4));
+
   // Throws exception if CAST fails.
-  EXPECT_THROW(testComplexCast("c0", longFlat, expectedShort), VeloxException);
+  VELOX_ASSERT_THROW(
+      testComplexCast("c0", longFlat, expectedShort),
+      "Cannot cast DECIMAL '-1000.000' to DECIMAL(6,4)");
+
   // nullOnFailure is true.
   testComplexCast("c0", longFlat, expectedShort, true);
 }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -44,7 +44,6 @@ class TestingDictionaryFunction : public exec::VectorFunction {
     VELOX_CHECK(rows.isAllSelected());
     const auto size = rows.size();
     auto indices = makeIndicesInReverse(size, context->pool());
-    auto resultFalt = args[0]->asFlatVector<ShortDecimal>();
     *result = BaseVector::wrapInDictionary(
         BufferPtr(nullptr), indices, size, args[0]);
   }
@@ -688,7 +687,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
   auto longFlat =
       makeLongDecimalFlatVector({-201, -109, 0, 105, 208}, DECIMAL(20, 2));
   expectedShort = makeShortDecimalFlatVector(
-      {-201000, -109000, 0, 105000, 208000}, DECIMAL(10, 5));
+      {-201'000, -109'000, 0, 105'000, 208'000}, DECIMAL(10, 5));
   testComplexCast("c0", longFlat, expectedShort);
   // long to short, scale down.
   expectedShort =
@@ -697,7 +696,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
 
   // long to long, scale up.
   auto expectedLong = makeLongDecimalFlatVector(
-      {-20'100'000'000, -10'900'000'000, 0, 1'050'000'000, 20800000000},
+      {-20'100'000'000, -10'900'000'000, 0, 1'050'000'000, 20'800'000'000},
       DECIMAL(20, 10));
   testComplexCast("c0", longFlat, expectedShort);
   // long to long, scale down.
@@ -707,19 +706,19 @@ TEST_F(CastExprTest, decimalToDecimal) {
 
   // short to long, scale up.
   expectedLong = makeLongDecimalFlatVector(
-      {-3000000000,
-       -2000000000,
-       -1000000000,
+      {-3'000'000'000,
+       -2'000'000'000,
+       -1'000'000'000,
        0,
-       55000000000,
-       69000000000,
-       72000000000},
+       55'000'000'000,
+       69'000'000'000,
+       72'000'000'000},
       DECIMAL(20, 11));
   testComplexCast("c0", shortFlat, expectedLong);
 
   // short to long, scale down.
-  shortFlat =
-      makeShortDecimalFlatVector({-20500, -190, 12345, 19999}, DECIMAL(6, 4));
+  shortFlat = makeShortDecimalFlatVector(
+      {-20'500, -190, 12'345, 19'999}, DECIMAL(6, 4));
   expectedLong = makeLongDecimalFlatVector({-20, 0, 12, 20}, DECIMAL(20, 1));
   testComplexCast("c0", shortFlat, expectedLong);
 
@@ -728,5 +727,8 @@ TEST_F(CastExprTest, decimalToDecimal) {
       {-20'000, -1'000'000, 10'000, std::nullopt}, DECIMAL(20, 3));
   expectedShort = makeNullableShortDecimalFlatVector(
       {-200'000, std::nullopt, 100'000, std::nullopt}, DECIMAL(6, 4));
-  testComplexCast("c0", longFlat, expectedShort);
+  // Throws exception if CAST fails.
+  EXPECT_THROW(testComplexCast("c0", longFlat, expectedShort), VeloxException);
+  // nullOnFailure is true.
+  testComplexCast("c0", longFlat, expectedShort, true);
 }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -680,7 +680,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
   testComplexCast("c0", shortFlat, expectedShort);
   // short to short, scale down.
   expectedShort =
-      makeShortDecimalFlatVector({0, 0, 0, 0, 5, 7, 7}, DECIMAL(4, 1));
+      makeShortDecimalFlatVector({0, 0, 0, 0, 6, 7, 7}, DECIMAL(4, 1));
   testComplexCast("c0", shortFlat, expectedShort);
 
   // long to short, scale up.
@@ -691,7 +691,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
   testComplexCast("c0", longFlat, expectedShort);
   // long to short, scale down.
   expectedShort =
-      makeShortDecimalFlatVector({-20, -11, 0, 10, 21}, DECIMAL(10, 1));
+      makeShortDecimalFlatVector({-20, -11, 0, 11, 21}, DECIMAL(10, 1));
   testComplexCast("c0", longFlat, expectedShort);
 
   // long to long, scale up.
@@ -701,7 +701,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
   testComplexCast("c0", longFlat, expectedShort);
   // long to long, scale down.
   expectedLong =
-      makeLongDecimalFlatVector({-20, -11, 0, 10, 21}, DECIMAL(20, 1));
+      makeLongDecimalFlatVector({-20, -11, 0, 11, 21}, DECIMAL(20, 1));
   testComplexCast("c0", longFlat, expectedLong);
 
   // short to long, scale up.
@@ -719,7 +719,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
   // short to long, scale down.
   shortFlat = makeShortDecimalFlatVector(
       {-20'500, -190, 12'345, 19'999}, DECIMAL(6, 4));
-  expectedLong = makeLongDecimalFlatVector({-20, 0, 12, 20}, DECIMAL(20, 1));
+  expectedLong = makeLongDecimalFlatVector({-21, 0, 12, 20}, DECIMAL(20, 1));
   testComplexCast("c0", shortFlat, expectedLong);
 
   // NULLs and overflow.

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -43,6 +43,12 @@ void registerComparisonFunctions() {
   registerFunction<BetweenFunction, bool, Varchar, Varchar, Varchar>(
       {"between"});
   registerFunction<BetweenFunction, bool, Date, Date, Date>({"between"});
+  registerFunction<
+      BetweenFunction,
+      bool,
+      Generic<T1>,
+      Generic<T2>,
+      Generic<T3>>({"between"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -307,11 +307,12 @@ TEST_F(ComparisonsTest, betweenDecimal) {
   shortFlat = makeNullableShortDecimalFlatVector({100}, DECIMAL(3, 3));
   EXPECT_THROW(
       evaluate<SimpleVector<bool>>(
-          "c0 between 2.00 and 3.00", makeRowVector({shortFlat})),
+          "c0 between 2.00::decimal(3,2) and 3.00::decimal(3,2)", makeRowVector({shortFlat})),
       VeloxRuntimeError);
   shortFlat = makeNullableShortDecimalFlatVector({100}, DECIMAL(4, 2));
   EXPECT_THROW(
       evaluate<SimpleVector<bool>>(
-          "c0 between 2.00 and 3.00", makeRowVector({shortFlat})),
+          "c0 between 2.00::decimal(3,2) and 3.00::decimal(3,2)",
+          makeRowVector({shortFlat})),
       VeloxRuntimeError);
 }

--- a/velox/type/DecimalUtil.cpp
+++ b/velox/type/DecimalUtil.cpp
@@ -48,34 +48,6 @@ std::string formatDecimal(uint8_t scale, int128_t unscaledValue) {
   return fmt::format(
       "{}{}{}", isNegative ? "-" : "", integralPart, fractionString);
 }
-
-int128_t rescale(
-    const int128_t& unscaledValue,
-    const uint8_t fromScale,
-    const std::pair<uint8_t, uint8_t>& toPrecisionScale) {
-  auto rescaledValue = unscaledValue;
-  auto rf = toPrecisionScale.second - fromScale;
-  if (rf >= 0) {
-    rescaledValue = unscaledValue * DecimalUtil::kPowersOfTen[rf];
-  } else {
-    rf = -1 * rf;
-    rescaledValue = unscaledValue / DecimalUtil::kPowersOfTen[rf];
-    int128_t remainder = unscaledValue % DecimalUtil::kPowersOfTen[rf];
-    if (unscaledValue >= 0) {
-      if (remainder > DecimalUtil::kPowersOfTen[rf] / 2) {
-        rescaledValue++;
-      }
-    } else {
-      if (remainder < -DecimalUtil::kPowersOfTen[rf] / 2) {
-        rescaledValue--;
-      }
-    }
-  }
-  // Check overflowing
-  VELOX_CHECK_LE(
-      rescaledValue, DecimalUtil::kPowersOfTen[toPrecisionScale.first]);
-  return rescaledValue;
-}
 } // namespace
 
 const int128_t DecimalUtil::kPowersOfTen[]{
@@ -132,23 +104,5 @@ std::string DecimalUtil::toString<ShortDecimal>(
     const TypePtr& type) {
   auto decimalType = type->asShortDecimal();
   return formatDecimal(decimalType.scale(), value.unscaledValue());
-}
-
-template <>
-void DecimalUtil::rescaleWithRoundUp(
-    ShortDecimal& output,
-    const int128_t& unscaledValue,
-    const uint8_t fromScale,
-    const std::pair<uint8_t, uint8_t>& toPrecisionScale) {
-  output.setUnscaledValue(rescale(unscaledValue, fromScale, toPrecisionScale));
-}
-
-template <>
-void DecimalUtil::rescaleWithRoundUp(
-    LongDecimal& output,
-    const int128_t& unscaledValue,
-    const uint8_t fromScale,
-    const std::pair<uint8_t, uint8_t>& toPrecisionScale) {
-  output.setUnscaledValue(rescale(unscaledValue, fromScale, toPrecisionScale));
 }
 } // namespace facebook::velox

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -32,5 +32,12 @@ class DecimalUtil {
   /// Helper function to convert a decimal value to string.
   template <typename T>
   static std::string toString(const T& value, const TypePtr& type);
+
+  template <class T>
+  static void rescaleWithRoundUp(
+      T& output,
+      const int128_t& unscaledValue,
+      const uint8_t fromScale,
+      const std::pair<uint8_t, uint8_t>& toPrecisionScale);
 };
 } // namespace facebook::velox

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -41,7 +41,7 @@ class DecimalUtil {
       const int toPrecision,
       const int toScale,
       const bool nullOnFailure) {
-    TOutput rescaledValue(inputValue.unscaledValue());
+    int128_t rescaledValue = inputValue.unscaledValue();
     auto scaleDifference = toScale - fromScale;
     if (scaleDifference >= 0) {
       rescaledValue *= DecimalUtil::kPowersOfTen[scaleDifference];
@@ -69,7 +69,11 @@ class DecimalUtil {
           toPrecision,
           toScale);
     }
-    return rescaledValue;
+    if constexpr (std::is_same_v<TOutput, ShortDecimal>) {
+      return ShortDecimal(static_cast<int64_t>(rescaledValue));
+    } else {
+      return LongDecimal(rescaledValue);
+    }
   }
 };
 } // namespace facebook::velox

--- a/velox/type/LongDecimal.h
+++ b/velox/type/LongDecimal.h
@@ -57,8 +57,44 @@ struct LongDecimal {
     return unscaledValue_ < other.unscaledValue_;
   }
 
+  bool operator<(const int128_t& other) const {
+    return unscaledValue_ < other;
+  }
+
   bool operator<=(const LongDecimal& other) const {
     return unscaledValue_ <= other.unscaledValue_;
+  }
+
+  bool operator>(const int128_t& other) const {
+    return unscaledValue_ > other;
+  }
+
+  bool operator>=(const int other) const {
+    return unscaledValue_ >= other;
+  }
+
+  const LongDecimal& operator*=(const int128_t& rhs) {
+    unscaledValue_ *= rhs;
+    return *this;
+  }
+
+  LongDecimal& operator/=(const int128_t& rhs) {
+    unscaledValue_ /= rhs;
+    return *this;
+  }
+
+  int128_t operator%(const int128_t& rhs) const {
+    return this->unscaledValue_ % rhs;
+  }
+
+  LongDecimal& operator++() {
+    ++this->unscaledValue_;
+    return *this;
+  }
+
+  LongDecimal& operator--() {
+    --this->unscaledValue_;
+    return *this;
   }
 
  private:

--- a/velox/type/LongDecimal.h
+++ b/velox/type/LongDecimal.h
@@ -73,7 +73,7 @@ struct LongDecimal {
     return unscaledValue_ >= other;
   }
 
-  const LongDecimal& operator*=(const int128_t& rhs) {
+  LongDecimal& operator*=(const int128_t& rhs) {
     unscaledValue_ *= rhs;
     return *this;
   }
@@ -84,16 +84,16 @@ struct LongDecimal {
   }
 
   int128_t operator%(const int128_t& rhs) const {
-    return this->unscaledValue_ % rhs;
+    return unscaledValue_ % rhs;
   }
 
   LongDecimal& operator++() {
-    ++this->unscaledValue_;
+    unscaledValue_++;
     return *this;
   }
 
   LongDecimal& operator--() {
-    --this->unscaledValue_;
+    unscaledValue_--;
     return *this;
   }
 

--- a/velox/type/LongDecimal.h
+++ b/velox/type/LongDecimal.h
@@ -57,44 +57,16 @@ struct LongDecimal {
     return unscaledValue_ < other.unscaledValue_;
   }
 
-  bool operator<(const int128_t& other) const {
-    return unscaledValue_ < other;
-  }
-
   bool operator<=(const LongDecimal& other) const {
     return unscaledValue_ <= other.unscaledValue_;
-  }
-
-  bool operator>(const int128_t& other) const {
-    return unscaledValue_ > other;
   }
 
   bool operator>=(const int other) const {
     return unscaledValue_ >= other;
   }
 
-  LongDecimal& operator*=(const int128_t& rhs) {
-    unscaledValue_ *= rhs;
-    return *this;
-  }
-
-  LongDecimal& operator/=(const int128_t& rhs) {
-    unscaledValue_ /= rhs;
-    return *this;
-  }
-
   int128_t operator%(const int128_t& rhs) const {
     return unscaledValue_ % rhs;
-  }
-
-  LongDecimal& operator++() {
-    unscaledValue_++;
-    return *this;
-  }
-
-  LongDecimal& operator--() {
-    unscaledValue_--;
-    return *this;
   }
 
  private:

--- a/velox/type/ShortDecimal.h
+++ b/velox/type/ShortDecimal.h
@@ -74,26 +74,26 @@ struct ShortDecimal {
   }
 
   ShortDecimal& operator*=(const int128_t& rhs) {
-    this->unscaledValue_ *= rhs;
+    unscaledValue_ *= rhs;
     return *this;
   }
 
   ShortDecimal& operator/=(const int128_t& rhs) {
-    this->unscaledValue_ /= rhs;
+    unscaledValue_ /= rhs;
     return *this;
   }
 
   int128_t operator%(const int128_t& rhs) const {
-    return this->unscaledValue_ % rhs;
+    return unscaledValue_ % rhs;
   }
 
   ShortDecimal& operator++() {
-    ++this->unscaledValue_;
+    unscaledValue_++;
     return *this;
   }
 
   ShortDecimal& operator--() {
-    --this->unscaledValue_;
+    unscaledValue_--;
     return *this;
   }
 

--- a/velox/type/ShortDecimal.h
+++ b/velox/type/ShortDecimal.h
@@ -49,10 +49,6 @@ struct ShortDecimal {
     return unscaledValue_ < other.unscaledValue_;
   }
 
-  bool operator<(const int128_t& other) const {
-    return unscaledValue_ < other;
-  }
-
   bool operator<=(const ShortDecimal& other) const {
     return unscaledValue_ <= other.unscaledValue_;
   }
@@ -61,11 +57,7 @@ struct ShortDecimal {
     return unscaledValue_ > other.unscaledValue_;
   }
 
-  bool operator>(const int128_t& other) const {
-    return unscaledValue_ > other;
-  }
-
-  bool operator>=(const ShortDecimal other) const {
+  bool operator>=(const ShortDecimal& other) const {
     return unscaledValue_ >= other.unscaledValue_;
   }
 
@@ -73,28 +65,8 @@ struct ShortDecimal {
     return unscaledValue_ >= other;
   }
 
-  ShortDecimal& operator*=(const int128_t& rhs) {
-    unscaledValue_ *= rhs;
-    return *this;
-  }
-
-  ShortDecimal& operator/=(const int128_t& rhs) {
-    unscaledValue_ /= rhs;
-    return *this;
-  }
-
   int128_t operator%(const int128_t& rhs) const {
     return unscaledValue_ % rhs;
-  }
-
-  ShortDecimal& operator++() {
-    unscaledValue_++;
-    return *this;
-  }
-
-  ShortDecimal& operator--() {
-    unscaledValue_--;
-    return *this;
   }
 
  private:

--- a/velox/type/ShortDecimal.h
+++ b/velox/type/ShortDecimal.h
@@ -49,6 +49,10 @@ struct ShortDecimal {
     return unscaledValue_ < other.unscaledValue_;
   }
 
+  bool operator<(const int128_t& other) const {
+    return unscaledValue_ < other;
+  }
+
   bool operator<=(const ShortDecimal& other) const {
     return unscaledValue_ <= other.unscaledValue_;
   }
@@ -57,8 +61,40 @@ struct ShortDecimal {
     return unscaledValue_ > other.unscaledValue_;
   }
 
-  bool operator>=(const ShortDecimal& other) const {
+  bool operator>(const int128_t& other) const {
+    return unscaledValue_ > other;
+  }
+
+  bool operator>=(const ShortDecimal other) const {
     return unscaledValue_ >= other.unscaledValue_;
+  }
+
+  bool operator>=(const int other) const {
+    return unscaledValue_ >= other;
+  }
+
+  ShortDecimal& operator*=(const int128_t& rhs) {
+    this->unscaledValue_ *= rhs;
+    return *this;
+  }
+
+  ShortDecimal& operator/=(const int128_t& rhs) {
+    this->unscaledValue_ /= rhs;
+    return *this;
+  }
+
+  int128_t operator%(const int128_t& rhs) const {
+    return this->unscaledValue_ % rhs;
+  }
+
+  ShortDecimal& operator++() {
+    ++this->unscaledValue_;
+    return *this;
+  }
+
+  ShortDecimal& operator--() {
+    --this->unscaledValue_;
+    return *this;
   }
 
  private:


### PR DESCRIPTION
The Between functionality for DECIMALS is implemented using the Generic type support in VELOX. The current implementation expects the user to CAST all params to BETWEEN function to the same type.