### PR TITLE
Put arithmetic functions in anonymous namespace

### DIFF
--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -38,6 +38,8 @@ inline constexpr char digits[36] = {
     'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
     'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
 
+namespace {
+
 template <typename T>
 struct PlusFunction {
   template <typename TInput>
@@ -482,4 +484,5 @@ struct EulerConstantFunction {
     result = M_E;
   }
 };
+} // namespace
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
This makes the compiler to better optimize the functions.
it is safe since those are not objects that are passed across compilation units
but rather configurations used for template expansion.

Reviewed By: Yuhta

Differential Revision: D38620162

