### PR TITLE
Convert Parquet benchmark to native reader

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -98,7 +98,7 @@ class TpchBenchmark {
     functions::prestosql::registerAllScalarFunctions();
     parse::registerTypeResolver();
     filesystems::registerLocalFileSystem();
-    parquet::registerParquetReaderFactory();
+    parquet::registerParquetReaderFactory(parquet::ParquetReaderType::NATIVE);
     dwrf::registerDwrfReaderFactory();
     auto hiveConnector =
         connector::getConnectorFactory(

--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -922,14 +922,15 @@ class DictionaryColumnVisitor
 
   template <bool hasFilter, bool hasHook, bool scatter>
   void processRle(
-      T value,
-      T delta,
+      typename make_index<T>::type value,
+      typename make_index<T>::type delta,
       int32_t numRows,
       int32_t currentRow,
       const int32_t* scatterRows,
       int32_t* filterHits,
       T* values,
       int32_t& numValues) {
+    auto indices = reinterpret_cast<typename make_index<T>::type*>(values);
     if (sizeof(T) == 8) {
       constexpr int32_t kWidth = xsimd::batch<int64_t>::size;
       for (auto i = 0; i < numRows; i += kWidth) {
@@ -939,7 +940,7 @@ class DictionaryColumnVisitor
                            currentRow) *
                 delta +
             value;
-        numbers.store_unaligned(values + numValues + i);
+        numbers.store_unaligned(indices + numValues + i);
       }
     } else if (sizeof(T) == 4) {
       constexpr int32_t kWidth = xsimd::batch<int32_t>::size;
@@ -949,11 +950,11 @@ class DictionaryColumnVisitor
              currentRow) *
                 static_cast<int32_t>(delta) +
             static_cast<int32_t>(value);
-        numbers.store_unaligned(values + numValues + i);
+        numbers.store_unaligned(indices + numValues + i);
       }
     } else {
       for (auto i = 0; i < numRows; ++i) {
-        values[numValues + i] =
+        indices[numValues + i] =
             (super::rows_[super::rowIndex_ + i] - currentRow) * delta + value;
       }
     }

--- a/velox/dwio/common/DirectDecoder.h
+++ b/velox/dwio/common/DirectDecoder.h
@@ -37,10 +37,16 @@ class DirectDecoder : public IntDecoder<isSigned> {
 
   void skip(uint64_t numValues) override;
 
-  void next(int64_t* data, uint64_t numValues, const uint64_t* nulls) override;
+  void next(
+      int64_t* FOLLY_NONNULL data,
+      uint64_t numValues,
+      const uint64_t* FOLLY_NULLABLE nulls) override;
 
   template <bool hasNulls>
-  inline void skip(int32_t numValues, int32_t current, const uint64_t* nulls) {
+  inline void skip(
+      int32_t numValues,
+      int32_t current,
+      const uint64_t* FOLLY_NULLABLE nulls) {
     if (!numValues) {
       return;
     }
@@ -51,7 +57,7 @@ class DirectDecoder : public IntDecoder<isSigned> {
   }
 
   template <bool hasNulls, typename Visitor>
-  void readWithVisitor(const uint64_t* nulls, Visitor visitor) {
+  void readWithVisitor(const uint64_t* FOLLY_NULLABLE nulls, Visitor visitor) {
     if (dwio::common::useFastPath<Visitor, hasNulls>(visitor)) {
       fastPath<hasNulls>(nulls, visitor);
       return;
@@ -78,7 +84,13 @@ class DirectDecoder : public IntDecoder<isSigned> {
           }
         }
       }
-      toSkip = visitor.process(IntDecoder<isSigned>::readLong(), atEnd);
+      if (std::is_same<typename Visitor::DataType, float>::value) {
+        toSkip = visitor.process(readFloat(), atEnd);
+      } else if (std::is_same<typename Visitor::DataType, double>::value) {
+        toSkip = visitor.process(readDouble(), atEnd);
+      } else {
+        toSkip = visitor.process(super::readLong(), atEnd);
+      }
     skip:
       ++current;
       if (toSkip) {
@@ -94,8 +106,38 @@ class DirectDecoder : public IntDecoder<isSigned> {
  private:
   using super = IntDecoder<isSigned>;
 
+  float readFloat() {
+    float temp;
+    auto buffer = readFixed(sizeof(float), &temp);
+    return *reinterpret_cast<const float*>(buffer);
+  }
+
+  double readDouble() {
+    double temp;
+    auto buffer = readFixed(sizeof(double), &temp);
+    return *reinterpret_cast<const double*>(buffer);
+  }
+
+  // Returns a pointer to the next element of 'size' bytes in the
+  // buffer. If the element would straddle buffers, it is copied to
+  // *temp and temp is returned.
+  const void* FOLLY_NONNULL readFixed(int32_t size, void* FOLLY_NONNULL temp) {
+    auto ptr = super::bufferStart;
+    if (ptr && ptr + size <= super::bufferEnd) {
+      super::bufferStart += size;
+      return ptr;
+    }
+    readBytes(
+        size,
+        super::inputStream.get(),
+        temp,
+        super::bufferStart,
+        super::bufferEnd);
+    return temp;
+  }
+
   template <bool hasNulls, typename Visitor>
-  void fastPath(const uint64_t* nulls, Visitor& visitor) {
+  void fastPath(const uint64_t* FOLLY_NULLABLE nulls, Visitor& visitor) {
     using T = typename Visitor::DataType;
     constexpr bool hasFilter =
         !std::is_same<typename Visitor::FilterType, velox::common::AlwaysTrue>::

--- a/velox/dwio/common/IntDecoder.h
+++ b/velox/dwio/common/IntDecoder.h
@@ -181,7 +181,6 @@ class IntDecoder {
   bulkReadRowsFixed(RowSet rows, int32_t initialRow, T* FOLLY_NONNULL result);
 
   signed char readByte();
-
   int64_t readLong();
   uint64_t readVuLong();
   int64_t readVsLong();
@@ -339,6 +338,23 @@ FOLLY_ALWAYS_INLINE int64_t IntDecoder<isSigned>::readVsLong() {
 template <bool isSigned>
 inline int64_t IntDecoder<isSigned>::readLongLE() {
   int64_t result = 0;
+  if (bufferStart && bufferStart + sizeof(int64_t) <= bufferEnd) {
+    bufferStart += numBytes;
+    if (numBytes == 8) {
+      return *reinterpret_cast<const int64_t*>(bufferStart - 8);
+    }
+    if (numBytes == 4) {
+      if (isSigned) {
+        return *reinterpret_cast<const int32_t*>(bufferStart - 4);
+      }
+      return *reinterpret_cast<const uint32_t*>(bufferStart - 4);
+    }
+    if (isSigned) {
+      return *reinterpret_cast<const int16_t*>(bufferStart - 2);
+    }
+    return *reinterpret_cast<const uint16_t*>(bufferStart - 2);
+  }
+
   char b;
   int64_t offset = 0;
   for (uint32_t i = 0; i < numBytes; ++i) {
@@ -346,6 +362,7 @@ inline int64_t IntDecoder<isSigned>::readLongLE() {
     result |= (b & BASE_256_MASK) << offset;
     offset += 8;
   }
+
   if (isSigned && numBytes < 8) {
     if (numBytes == 2) {
       return static_cast<int16_t>(result);

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -164,6 +164,9 @@ void SelectiveColumnReader::getIntValues(
             VELOX_FAIL("Unsupported value size");
         }
         break;
+      case TypeKind::DATE:
+        getFlatValues<Date, Date>(rows, result);
+        break;
       case TypeKind::BIGINT:
         switch (valueSize_) {
           case 8:

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -19,10 +19,12 @@
 #include "velox/dwio/common/ColumnVisitors.h"
 #include "velox/dwio/parquet/reader/StringColumnReader.h"
 #include "velox/dwio/parquet/thrift/ThriftTransport.h"
+#include "velox/vector/FlatVector.h"
 
 #include <arrow/util/rle_encoding.h>
 #include <thrift/protocol/TCompactProtocol.h> //@manual
-#include "velox/vector/FlatVector.h"
+#include <zstd.h>
+#include <zstd_errors.h>
 
 namespace facebook::velox::parquet {
 
@@ -138,13 +140,26 @@ const char* PageReader::readBytes(int32_t size, BufferPtr& copy) {
 
 const char* FOLLY_NONNULL PageReader::uncompressData(
     const char* pageData,
-    uint32_t /*compressedSize*/,
-    uint32_t /*uncompressedSize*/) {
+    uint32_t compressedSize,
+    uint32_t uncompressedSize) {
   switch (codec_) {
     case thrift::CompressionCodec::UNCOMPRESSED:
       return pageData;
-    case thrift::CompressionCodec::GZIP:
-    case thrift::CompressionCodec::ZSTD:
+    case thrift::CompressionCodec::ZSTD: {
+      dwio::common::ensureCapacity<char>(
+          uncompressedData_, uncompressedSize, &pool_);
+
+      auto ret = ZSTD_decompress(
+          uncompressedData_->asMutable<char>(),
+          uncompressedSize,
+          pageData,
+          compressedSize);
+      VELOX_CHECK(
+          !ZSTD_isError(ret),
+          "ZSTD returned an error: ",
+          ZSTD_getErrorName(ret));
+      return uncompressedData_->as<char>();
+    }
     default:
       VELOX_FAIL("Unsupported Parquet compression type ", codec_);
   }
@@ -513,8 +528,16 @@ bool PageReader::rowsForPage(
     // We copy the rows to visit with a bias, so that the first to visit has
     // offset 0.
     rowsCopy_->resize(numToVisit);
-    for (auto i = 0; i < numToVisit; ++i) {
-      (*rowsCopy_)[i] = visitorRows_[i + currentVisitorRow_] - rowNumberBias_;
+    auto copy = rowsCopy_->data();
+    // Subtract 'rowNumberBias_' from the rows to visit on this page.
+    // 'copy' has a writable tail of SIMD width, so no special case for end of
+    // loop.
+    for (auto i = 0; i < numToVisit; i += xsimd::batch<int32_t>::size) {
+      auto numbers = xsimd::batch<int32_t>::load_unaligned(
+                         &visitorRows_[i + currentVisitorRow_]) -
+          rowNumberBias_;
+      numbers.store_unaligned(copy);
+      copy += xsimd::batch<int32_t>::size;
     }
     nulls = readNulls(rowsCopy_->back() + 1, reader.nullsInReadRange());
     rows = folly::Range<const vector_size_t*>(

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -218,7 +218,6 @@ class PageReader {
   const int64_t chunkSize_;
   const char* FOLLY_NULLABLE bufferStart_{nullptr};
   const char* FOLLY_NULLABLE bufferEnd_{nullptr};
-
   BufferPtr tempNulls_;
   BufferPtr nullsInReadRange_;
   BufferPtr multiPageNulls_;

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -42,6 +42,7 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
     case TypeKind::BIGINT:
     case TypeKind::SMALLINT:
     case TypeKind::TINYINT:
+    case TypeKind::DATE:
       return std::make_unique<IntegerColumnReader>(
           dataType, dataType, params, scanSpec);
 

--- a/velox/dwio/parquet/reader/ParquetColumnReader.h
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.h
@@ -26,6 +26,7 @@ inline int32_t parquetSizeOfIntKind(TypeKind kind) {
     case TypeKind::TINYINT:
     case TypeKind::SMALLINT:
     case TypeKind::INTEGER:
+    case TypeKind::DATE:
       return 4;
     case TypeKind::BIGINT:
       return 8;

--- a/velox/dwio/parquet/reader/ParquetTypeWithId.h
+++ b/velox/dwio/parquet/reader/ParquetTypeWithId.h
@@ -24,6 +24,9 @@ namespace facebook::velox::parquet {
 // Describes a Parquet column.
 class ParquetTypeWithId : public dwio::common::TypeWithId {
  public:
+  // Occurs in 'column' for non-leaf nodes.
+  static constexpr uint32_t kNonLeaf = ~0;
+
   ParquetTypeWithId(
       TypePtr type,
       std::vector<std::shared_ptr<const TypeWithId>>&& children,
@@ -45,6 +48,15 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
         precision_(precision),
         scale_(scale),
         typeLength_(typeLength) {}
+
+  bool isLeaf() const {
+    // Negative column ordinal means non-leaf column.
+    return static_cast<int32_t>(column) >= 0;
+  }
+
+  const ParquetTypeWithId& parquetChildAt(uint32_t index) const {
+    return *reinterpret_cast<const ParquetTypeWithId*>(childAt(index).get());
+  }
 
   const std::string name_;
   const std::optional<thrift::Type::type> parquetType_;

--- a/velox/dwio/parquet/reader/RleDecoder.h
+++ b/velox/dwio/parquet/reader/RleDecoder.h
@@ -151,7 +151,7 @@ class RleDecoder : public dwio::common::IntDecoder<isSigned> {
 
       if (repeating_) {
         if (allOnes && value_ && toRead == numValues &&
-            repeating_ >= numValues) {
+            remainingValues_ >= numValues) {
           // The whole read is covered by a RLE of ones and 'allOnes' is
           // provided, so we can shortcut the read.
           remainingValues_ -= toRead;

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -131,8 +131,33 @@ TEST_F(E2EFilterTest, integerDictionary) {
       true);
 }
 
+TEST_F(E2EFilterTest, floatAndDoubleDirect) {
+  writerProperties_ = ::parquet::WriterProperties::Builder()
+                          .disable_dictionary()
+                          ->data_pagesize(4 * 1024)
+                          ->build();
+
+  testWithTypes(
+      "float_val:float,"
+      "double_val:double,"
+      "float_val2:float,"
+      "double_val2:double,"
+      "long_val:bigint,"
+      "float_null:float",
+      [&]() {
+        makeAllNulls("float_null");
+        makeQuantizedFloat<float>(Subfield("float_val2"), 200, true);
+        makeQuantizedFloat<double>(Subfield("double_val2"), 522, true);
+      },
+      false,
+      {"float_val", "double_val", "float_val2", "double_val2", "float_null"},
+      20,
+      true,
+      false);
+}
+
 TEST_F(E2EFilterTest, floatAndDouble) {
-  // float_val and double_val are expected to be direct since the
+  // float_val and double_val may be direct since the
   // values are random.float_val2 and double_val2 are expected to be
   // dictionaries since the values are quantized.
   testWithTypes(
@@ -147,6 +172,14 @@ TEST_F(E2EFilterTest, floatAndDouble) {
         makeAllNulls("float_null");
         makeQuantizedFloat<float>(Subfield("float_val2"), 200, true);
         makeQuantizedFloat<double>(Subfield("double_val2"), 522, true);
+        // Make sure there are RLE's.
+        auto floats = batches_[0]->childAt(2)->as<FlatVector<float>>();
+        auto doubles = batches_[0]->childAt(3)->as<FlatVector<double>>();
+        for (auto i = 100; i < 200; ++i) {
+          // This makes a RLE even if some nulls along the way.
+          floats->set(i, 0.66);
+          doubles->set(i, 0.66);
+        }
       },
       false,
       {"float_val", "double_val", "float_val2", "double_val2", "float_null"},


### PR DESCRIPTION
Make Parquet Complete TPCH Benchmark

Adds a path for Ddate type to common parts of selective column
reader. The type is identical on int32_t except for having a distinct,
but functionally identical vector class.

Considers split limits from row reader options in selecting row groups.

Fixes float/double direct encoding. Fixes slow
IntDecoder::readLongLE. makes DirectDecoder work on float/double so
that we get one path for all machine word width Parquet plain
encodings.

Fixes bad check for Parquet leaf type. Column ordinal is unsigned, hence <= 0 does not work.

Decompresses Zstd pages.


