### PR TITLE
Add Decimal Type support for Between and Equality scalar functions

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -26,10 +26,11 @@
 #include "velox/type/Type.h"
 #include "velox/type/Variant.h"
 
+inline constexpr char kPrecisionVariable[] = "a_precision";
+inline constexpr char kScaleVariable[] = "a_scale";
+
 namespace facebook::velox::core {
 
-static std::string kPrecisionVariable = "a_precision";
-static std::string kScaleVariable = "a_scale";
 // Most UDFs are deterministic, hence this default value.
 template <class T, class = void>
 struct udf_is_deterministic : std::true_type {};

--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -186,8 +186,14 @@ struct TypeAnalysis {
         CppToType<T>::isPrimitiveType ||
         CppToType<T>::typeKind == TypeKind::OPAQUE);
     results.stats.concreteCount++;
-    results.out << boost::algorithm::to_lower_copy(
-        std::string(CppToType<T>::name));
+    if (isDecimalKind(CppToType<T>::typeKind)) {
+      results.out << boost::algorithm::to_lower_copy(
+                         std::string(CppToType<T>::name))
+                  << "(a_precision,a_scale)";
+    } else {
+      results.out << boost::algorithm::to_lower_copy(
+          std::string(CppToType<T>::name));
+    }
   }
 };
 

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -54,6 +54,18 @@ void registerComparisonFunctions() {
   registerFunction<BetweenFunction, bool, Varchar, Varchar, Varchar>(
       {"between"});
   registerFunction<BetweenFunction, bool, Date, Date, Date>({"between"});
+  registerFunction<
+      BetweenFunction,
+      bool,
+      UnscaledShortDecimal,
+      UnscaledShortDecimal,
+      UnscaledShortDecimal>({"between"});
+  registerFunction<
+      BetweenFunction,
+      bool,
+      UnscaledLongDecimal,
+      UnscaledLongDecimal,
+      UnscaledLongDecimal>({"between"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -117,16 +117,9 @@ TEST_F(ComparisonsTest, betweenDecimal) {
       {100, 250, 300, 500, std::nullopt}, DECIMAL(20, 2));
 
   // Comparing LONG_DECIMAL and SHORT_DECIMAL must throw error.
-  try {
-    runAndCompare("c0 between 2.00 and 3.00", longFlat, expectedResult);
-    FAIL();
-  } catch (VeloxUserError& ex) {
-    ASSERT_TRUE(
-        ex.message().find(
-            "Scalar function signature is not supported: "
-            "between(LONG_DECIMAL(20,2), SHORT_DECIMAL(3,2), SHORT_DECIMAL(3,2))") !=
-        std::string::npos);
-  }
+  VELOX_ASSERT_THROW(
+      runAndCompare("c0 between 2.00 and 3.00", longFlat, expectedResult),
+      "Scalar function signature is not supported: between(LONG_DECIMAL(20,2), SHORT_DECIMAL(3,2), SHORT_DECIMAL(3,2)).");
 }
 
 TEST_F(ComparisonsTest, eqDecimal) {
@@ -152,15 +145,9 @@ TEST_F(ComparisonsTest, eqDecimal) {
   inputs = {
       makeShortDecimalFlatVector({1}, DECIMAL(10, 5)),
       makeShortDecimalFlatVector({1}, DECIMAL(10, 4))};
-  try {
-    runAndCompare("c0 == c1", inputs, expected);
-    FAIL();
-  } catch (VeloxUserError& ex) {
-    ASSERT_TRUE(
-        ex.message().find("Scalar function signature is not supported: "
-                          "eq(SHORT_DECIMAL(10,5), SHORT_DECIMAL(10,4))") !=
-        std::string::npos);
-  }
+  VELOX_ASSERT_THROW(
+      runAndCompare("c0 == c1", inputs, expected),
+      "Scalar function signature is not supported: eq(SHORT_DECIMAL(10,5), SHORT_DECIMAL(10,4))");
 }
 
 TEST_F(ComparisonsTest, eqArray) {

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -147,7 +147,8 @@ TEST_F(ComparisonsTest, eqDecimal) {
       makeShortDecimalFlatVector({1}, DECIMAL(10, 4))};
   VELOX_ASSERT_THROW(
       runAndCompare("c0 == c1", inputs, expected),
-      "Scalar function signature is not supported: eq(SHORT_DECIMAL(10,5), SHORT_DECIMAL(10,4))");
+      "Scalar function signature is not supported: eq(SHORT_DECIMAL(10,5),"
+      "SHORT_DECIMAL(10,4))");
 }
 
 TEST_F(ComparisonsTest, eqArray) {

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -21,7 +21,7 @@ using namespace facebook::velox;
 
 class ComparisonsTest : public functions::test::FunctionBaseTest {
  public:
-  ComparisonsTest() {
+  void SetUp() override {
     this->options_.parseDecimalAsDouble = false;
   }
 

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -148,7 +148,7 @@ TEST_F(ComparisonsTest, eqDecimal) {
   VELOX_ASSERT_THROW(
       runAndCompare("c0 == c1", inputs, expected),
       "Scalar function signature is not supported: eq(SHORT_DECIMAL(10,5),"
-      "SHORT_DECIMAL(10,4))");
+      " SHORT_DECIMAL(10,4))");
 }
 
 TEST_F(ComparisonsTest, eqArray) {

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -42,7 +42,18 @@ namespace facebook::velox {
 
 bool isDecimalName(const std::string& typeName) {
   auto typeNameUpper = boost::algorithm::to_upper_copy(typeName);
-  return (typeNameUpper == "SHORT_DECIMAL" || typeNameUpper == "LONG_DECIMAL");
+  return (
+      typeNameUpper == TypeTraits<TypeKind::SHORT_DECIMAL>::name ||
+      typeNameUpper == TypeTraits<TypeKind::LONG_DECIMAL>::name);
+}
+
+bool isDecimalTypeSignature(const std::string& arg) {
+  auto upper = boost::algorithm::to_upper_copy(arg);
+  return (
+      upper.find(TypeTraits<TypeKind::SHORT_DECIMAL>::name) !=
+          std::string::npos ||
+      upper.find(TypeTraits<TypeKind::LONG_DECIMAL>::name) !=
+          std::string::npos);
 }
 
 // Static variable intialization is not thread safe for non

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -40,6 +40,11 @@ bool isColumnNameRequiringEscaping(const std::string& name) {
 
 namespace facebook::velox {
 
+bool isDecimalName(const std::string& typeName) {
+  auto typeNameUpper = boost::algorithm::to_upper_copy(typeName);
+  return (typeNameUpper == "SHORT_DECIMAL" || typeNameUpper == "LONG_DECIMAL");
+}
+
 // Static variable intialization is not thread safe for non
 // constant-initialization, but scoped static initialization is thread safe.
 const std::unordered_map<std::string, TypeKind>& getTypeStringMap() {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <boost/algorithm/string.hpp>
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <folly/Format.h>
@@ -675,7 +676,8 @@ inline bool isDecimalKind(TypeKind typeKind) {
 }
 
 inline bool isDecimalName(const std::string& typeName) {
-  return (typeName == "SHORT_DECIMAL" || typeName == "LONG_DECIMAL");
+  auto typeNameUpper = boost::algorithm::to_upper_copy(typeName);
+  return (typeNameUpper == "SHORT_DECIMAL" || typeNameUpper == "LONG_DECIMAL");
 }
 
 std::pair<int, int> getDecimalPrecisionScale(const Type& type);

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -676,6 +676,8 @@ inline bool isDecimalKind(TypeKind typeKind) {
 
 bool isDecimalName(const std::string& typeName);
 
+bool isDecimalTypeSignature(const std::string& arg);
+
 std::pair<int, int> getDecimalPrecisionScale(const Type& type);
 
 class UnknownType : public TypeBase<TypeKind::UNKNOWN> {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include <boost/algorithm/string.hpp>
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <folly/Format.h>
@@ -675,10 +674,7 @@ inline bool isDecimalKind(TypeKind typeKind) {
       typeKind == TypeKind::LONG_DECIMAL);
 }
 
-inline bool isDecimalName(const std::string& typeName) {
-  auto typeNameUpper = boost::algorithm::to_upper_copy(typeName);
-  return (typeNameUpper == "SHORT_DECIMAL" || typeNameUpper == "LONG_DECIMAL");
-}
+bool isDecimalName(const std::string& typeName);
 
 std::pair<int, int> getDecimalPrecisionScale(const Type& type);
 

--- a/velox/type/UnscaledLongDecimal.h
+++ b/velox/type/UnscaledLongDecimal.h
@@ -104,10 +104,6 @@ struct UnscaledLongDecimal {
     return unscaledValue_ < other.unscaledValue_;
   }
 
-  bool operator>=(const UnscaledLongDecimal& other) const {
-    return unscaledValue_ >= other.unscaledValue_;
-  }
-
   bool operator<=(const UnscaledLongDecimal& other) const {
     return unscaledValue_ <= other.unscaledValue_;
   }

--- a/velox/type/UnscaledLongDecimal.h
+++ b/velox/type/UnscaledLongDecimal.h
@@ -104,6 +104,10 @@ struct UnscaledLongDecimal {
     return unscaledValue_ < other.unscaledValue_;
   }
 
+  bool operator>=(const UnscaledLongDecimal& other) const {
+    return unscaledValue_ >= other.unscaledValue_;
+  }
+
   bool operator<=(const UnscaledLongDecimal& other) const {
     return unscaledValue_ <= other.unscaledValue_;
   }


### PR DESCRIPTION
**BETWEEN SCALAR Function**
VectorFunction registration provides means to specify a Decimal Type signature.
Example: the DecimalArithemtic::Add has 
```
exec::FunctionSignatureBuilder()
    .returnType("DECIMAL(r_precision, r_scale)")
    .argumentType("DECIMAL(a_precision, a_scale)")
    .argumentType("DECIMAL(b_precision, b_scale)")
    .variableConstraint(
        "r_precision",
        "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
    .variableConstraint("r_scale", "max(a_scale, b_scale)")
```
However, scalar functions are registered using the CPP types and do not provide an 
API to specify a signature. The function signature is automatically deduced using TypeAnalysis 
in the registration code. Decimal types cannot be inferred from the CPP type alone due to 
missing precision and scale values. 

In this PR, we introduce a way to declare SCALAR functions for one or more decimal type inputs with same precision and scale. To achieve this, we inject default signatures `SHORT_DECIMAL(a_precision,a_scale)`,
 `LONG_DECIMAL(a_precision,a_scale)`  for all decimal types in the TypeAnalysis phase.
Here `a_precision` and `a_scale` represent precision and scale. These keywords will be same for all decimal input types indicating that they must evaluate to same values at the time of Signature Binding. Any rescaling must be done explicitly using the decimal cast function.
The Between function has been extended with this approach.
Note that a default `DECIMAL(a_precision,a_scale)` signature cannot be used here since the signature binder
needs to pick the right scalar function version (UnscaledShortDecimal vs UnscaledLongDecimal).

**EQUALITY**
The equality function is already implemented as a Generic function, which also supports DECIMALs.
Added some unit tests for equality on decimal type.