### PR TITLE
Fix loss of precision in timestamp when spilling

### DIFF
--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -16,8 +16,17 @@
 
 #include "velox/exec/Spill.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/serializers/PrestoSerializer.h"
 
 namespace facebook::velox::exec {
+
+// Spilling currently uses the default PrestoSerializer which by default
+// serializes timestamp with millisecond precision to maintain compatibility
+// with presto. Since velox's native timestamp implementation supports
+// nanosecond precision, we use this serde option to ensure the serializer
+// preserves precision.
+static const serializer::presto::PrestoVectorSerde::PrestoOptions
+    kDefaultSerdeOptions(/*useLosslessTimestamp*/ true);
 
 std::atomic<int32_t> SpillFile::ordinalCounter_;
 
@@ -68,7 +77,8 @@ bool SpillFile::nextBatch(RowVectorPtr& rowVector) {
   if (input_->atEnd()) {
     return false;
   }
-  VectorStreamGroup::read(input_.get(), &pool_, type_, &rowVector);
+  VectorStreamGroup::read(
+      input_.get(), &pool_, type_, &rowVector, &kDefaultSerdeOptions);
   return true;
 }
 
@@ -109,7 +119,9 @@ void SpillFileList::write(
   if (!batch_) {
     batch_ = std::make_unique<VectorStreamGroup>(&mappedMemory_);
     batch_->createStreamTree(
-        std::static_pointer_cast<const RowType>(rows->type()), 1000);
+        std::static_pointer_cast<const RowType>(rows->type()),
+        1000,
+        &kDefaultSerdeOptions);
   }
   batch_->append(rows, indices);
 

--- a/velox/functions/prestosql/aggregates/tests/HistogramTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/HistogramTest.cpp
@@ -129,24 +129,22 @@ TEST_F(HistogramTest, groupByDouble) {
 TEST_F(HistogramTest, groupByTimestamp) {
   vector_size_t num = 10;
 
-  // Use milliseconds for timestamps as spilling currently looses nanoseconds.
-
   auto vector1 = makeFlatVector<int32_t>(
       num, [](vector_size_t row) { return row % 3; }, nullEvery(4));
   auto vector2 = makeFlatVector<Timestamp>(
       num,
       [](vector_size_t row) {
-        return Timestamp{row % 2, 17'000'000};
+        return Timestamp{row % 2, 17'123'456};
       },
       nullEvery(5));
 
   auto expected = makeRowVector(
       {makeNullableFlatVector<int32_t>({std::nullopt, 0, 1, 2}),
        makeMapVector<Timestamp, int64_t>(
-           {{{Timestamp{0, 17'000'000}, 2}},
-            {{Timestamp{0, 17'000'000}, 1}, {Timestamp{1, 17'000'000}, 2}},
-            {{Timestamp{1, 17'000'000}, 2}},
-            {{Timestamp{0, 17'000'000}, 1}}})});
+           {{{Timestamp{0, 17'123'456}, 2}},
+            {{Timestamp{0, 17'123'456}, 1}, {Timestamp{1, 17'123'456}, 2}},
+            {{Timestamp{1, 17'123'456}, 2}},
+            {{Timestamp{0, 17'123'456}, 1}}})});
 
   testHistogram("histogram(c1)", {"c0"}, vector1, vector2, expected);
 }

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -43,6 +43,11 @@ struct Timestamp {
     return nanos_;
   }
 
+  int64_t toNanos() const {
+    // int64 can store around 292 years in nanos ~ till 2262-04-12
+    return seconds_ * 1'000'000'000 + nanos_;
+  }
+
   int64_t toMillis() const {
     return seconds_ * 1'000 + nanos_ / 1'000'000;
   }
@@ -66,6 +71,15 @@ struct Timestamp {
     }
     auto second = micros / 1'000'000 - 1;
     auto nano = ((micros - second * 1'000'000) % 1'000'000) * 1'000;
+    return Timestamp(second, nano);
+  }
+
+  static Timestamp fromNanos(int64_t nanos) {
+    if (nanos >= 0 || nanos % 1'000'000'000 == 0) {
+      return Timestamp(nanos / 1'000'000'000, nanos % 1'000'000'000);
+    }
+    auto second = nanos / 1'000'000'000 - 1;
+    auto nano = (nanos - second * 1'000'000'000) % 1'000'000'000;
     return Timestamp(second, nano);
   }
 

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -49,5 +49,25 @@ TEST(TimestampTest, fromMillisAndMicros) {
   EXPECT_EQ(ts3, Timestamp::fromMicros(ts3.toMicros()));
 }
 
+TEST(TimestampTest, fromNanos) {
+  int64_t positiveSecond = 10'000;
+  int64_t negativeSecond = -10'000;
+  uint64_t nano = 123'456'789;
+
+  Timestamp ts1(positiveSecond, nano);
+  int64_t positiveNanos = positiveSecond * 1'000'000'000 + nano;
+  EXPECT_EQ(ts1, Timestamp::fromNanos(positiveNanos));
+  EXPECT_EQ(ts1, Timestamp::fromNanos(ts1.toNanos()));
+
+  Timestamp ts2(negativeSecond, nano);
+  int64_t negativeNanos = negativeSecond * 1'000'000'000 + nano;
+  EXPECT_EQ(ts2, Timestamp::fromNanos(negativeNanos));
+  EXPECT_EQ(ts2, Timestamp::fromNanos(ts2.toNanos()));
+
+  Timestamp ts3(negativeSecond, 0);
+  EXPECT_EQ(ts3, Timestamp::fromNanos(negativeSecond * 1'000'000'000));
+  EXPECT_EQ(ts3, Timestamp::fromNanos(ts3.toNanos()));
+}
+
 } // namespace
 } // namespace facebook::velox

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -37,9 +37,11 @@ bool isRegisteredVectorSerde() {
 
 void VectorStreamGroup::createStreamTree(
     std::shared_ptr<const RowType> type,
-    int32_t numRows) {
+    int32_t numRows,
+    const VectorSerde::Options* options) {
   VELOX_CHECK(getVectorSerde().get(), "Vector serde is not registered");
-  serializer_ = getVectorSerde()->createSerializer(type, numRows, this);
+  serializer_ =
+      getVectorSerde()->createSerializer(type, numRows, this, options);
 }
 
 void VectorStreamGroup::append(
@@ -66,9 +68,10 @@ void VectorStreamGroup::read(
     ByteStream* source,
     velox::memory::MemoryPool* pool,
     std::shared_ptr<const RowType> type,
-    std::shared_ptr<RowVector>* result) {
+    std::shared_ptr<RowVector>* result,
+    const VectorSerde::Options* options) {
   VELOX_CHECK(getVectorSerde().get(), "Vector serde is not registered");
-  getVectorSerde()->deserialize(source, pool, type, result);
+  getVectorSerde()->deserialize(source, pool, type, result, options);
 }
 
 } // namespace facebook::velox


### PR DESCRIPTION
Currently we use a presto compatible serializer when spilling which
serializes timestamp to millisecond precision. This results in loss
of precision for velox timestamp type since velox stores it in
nanosecond precision. This patch ensures that precision is maintained
when spilling occurs. It introduces a new 'Options' input parameter
to the VectorSerde interface which is a map of key-value pairs. This
allows the PrestoSerializer to support serialization with both
precisions by allowing the caller to toggle between the two via the
input parameter.

Additionally, this also removes a hack inside the test suite which
by default downgrades timestamp precision to millisecond when
comparing results in order to be compatible with duckDB which is
used to verify correctness in some tests.

Test Plan
Added unit tests