### PR TITLE
Change spillFileSizeFactor to double type

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -231,11 +231,11 @@ class QueryConfig {
 
   /// Returns the factor used to determine the target spill file size based on
   /// the spilling operator's memory usage. For instance, if the spilling
-  /// operator has used 1GB memory and this factor is 2, then the target spill
+  /// operator has used 1GB memory and this factor is 0.5, then the target spill
   /// file size will be set to 512MB.
-  int32_t spillFileSizeFactor() const {
-    constexpr int32_t kDefaultFactor = 4;
-    return get<int32_t>(kSpillFileSizeFactor, kDefaultFactor);
+  double spillFileSizeFactor() const {
+    constexpr double kDefaultFactor = 0.25;
+    return get<double>(kSpillFileSizeFactor, kDefaultFactor);
   }
 
   /// Returns the spillable memory reservation growth percentage of the previous

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -539,7 +539,7 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
     }
     assert(mappedMemory_->tracker()); // lint
     const auto fileSize =
-        mappedMemory_->tracker()->getCurrentUserBytes() / spillFileSizeFactor_;
+        mappedMemory_->tracker()->getCurrentUserBytes() * spillFileSizeFactor_;
     spiller_ = std::make_unique<Spiller>(
         Spiller::Type::kAggregate,
         *rows,

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -179,7 +179,7 @@ class GroupingSet {
 
   // Parameters used for spilling control.
   const int32_t spillPartitionBits_;
-  const int32_t spillFileSizeFactor_;
+  const double spillFileSizeFactor_;
 
   memory::MappedMemory* FOLLY_NONNULL const mappedMemory_;
 


### PR DESCRIPTION
Change spillFileSizeFactor to a double type and use it as factor of memory usage to calculate the spill file size