### PR TITLE
Optimize countSelected when all selected

### DIFF
--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -300,7 +300,12 @@ class SelectivityVector {
    * Iterate and count the number of selected values in this SelectivityVector
    */
   vector_size_t countSelected() const {
-    return bits::countBits(bits_.data(), begin_, end_);
+    if (allSelected_.has_value() && *allSelected_) {
+      return size();
+    }
+    auto count = bits::countBits(bits_.data(), begin_, end_);
+    allSelected_ = count == size();
+    return count;
   }
 
   vector_size_t size() const {


### PR DESCRIPTION
Summary:
to active evalFlatNoNulls we call countSelected()
which was showing up as 4% in the denseporc benchmark profile. All selected is a common enough case to handle.

Alternatively, we can change the following condition to check rows.size()<1000 instead of countSelected.

````
 if (supportsFlatNoNullsFastPath_ && context.throwOnError() &&
      context.inputFlatNoNulls() && rows.countSelected() < 1'000) {
    evalFlatNoNulls(rows, context, result);
    return;
  }

```
after the change, countSelected does not appear in the profile.

Differential Revision: D38661116

