### PR TITLE
Add check on the memory usage is zero on pool/tracker destruction

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -385,6 +385,10 @@ class MemoryPoolImpl : public MemoryPoolBase {
       std::weak_ptr<MemoryPool> parent,
       int64_t cap = kMaxMemory);
 
+  ~MemoryPoolImpl() {
+    VELOX_CHECK_EQ(localMemoryUsage_.getCurrentBytes(), 0);
+  }
+
   // Actual memory allocation operations. Can be delegated.
   // Access global MemoryManager to check usage of current node and enforce
   // memory cap accordingly. Since MemoryManager walks the MemoryPoolImpl

--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -32,6 +32,13 @@ std::shared_ptr<MemoryUsageTracker> MemoryUsageTracker::create(
   return std::make_shared<SharedMemoryUsageTracker>(parent, type, config);
 }
 
+MemoryUsageTracker::~MemoryUsageTracker() {
+  VELOX_CHECK_EQ(reservation_, 0);
+  VELOX_CHECK_EQ(usedReservation_, 0);
+  VELOX_CHECK_EQ(minReservation_, 0);
+  VELOX_CHECK_EQ(total(currentUsageInBytes_), 0);
+}
+
 void MemoryUsageTracker::checkAndPropagateReservationIncrement(
     int64_t increment,
     bool updateMinReservation) {

--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -94,6 +94,8 @@ class MemoryUsageTracker
  public:
   enum class UsageType : int { kUserMem = 0, kSystemMem = 1, kTotalMem = 2 };
 
+  ~MemoryUsageTracker();
+
   // Function to increase a MemoryUsageTracker's limits. This is called when an
   // allocation would exceed the tracker's size limit. The usage in
   // 'tracker' at the time of call is as if the allocation had
@@ -161,7 +163,6 @@ class MemoryUsageTracker
       remaining = reservation_ - usedReservation_;
       reservation_ = 0;
       minReservation_ = 0;
-      usedReservation_ = 0;
     }
     if (remaining) {
       decrementUsage(type_, remaining);


### PR DESCRIPTION
Add check on the memory usages are zero on pool/tracker destruction