### PR TITLE
Fix issues in UNKNOWN vector type processing

### DIFF
--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -101,8 +101,7 @@ void gatherCopy(
     const std::vector<const RowVector*>& sources,
     const std::vector<vector_size_t>& sourceIndices,
     column_index_t sourceChannel) {
-  // TODO: UNKNOWN is not a scalar type and will fix 'isScalar()' next.
-  if (target->isScalar() && target->typeKind() != TypeKind::UNKNOWN) {
+  if (target->isScalar()) {
     VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
         scalarGatherCopy,
         target->type()->kind(),

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -324,7 +324,7 @@ VectorPtr BaseVector::createInternal(
           0 /*nullCount*/);
     }
     case TypeKind::UNKNOWN: {
-      BufferPtr nulls = AlignedBuffer::allocate<bool>(size, pool, true);
+      BufferPtr nulls = AlignedBuffer::allocate<bool>(size, pool, bits::kNull);
       return std::make_shared<FlatVector<UnknownValue>>(
           pool,
           nulls,

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -237,7 +237,8 @@ class ConstantVector final : public SimpleVector<T> {
   }
 
   bool isScalar() const override {
-    return valueVector_ ? valueVector_->isScalar() : true;
+    return valueVector_ ? valueVector_->isScalar()
+                        : (this->typeKind() != TypeKind::UNKNOWN);
   }
 
   const BaseVector* wrappedVector() const override {

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -280,7 +280,7 @@ class FlatVector final : public SimpleVector<T> {
   }
 
   bool isScalar() const override {
-    return true;
+    return this->typeKind() != TypeKind::UNKNOWN;
   }
 
   uint64_t retainedSize() const override {


### PR DESCRIPTION
Fix two issues in UNKOWN vector type processing:
(1) change flat encoded and constant encoded UNKOWN type vector to return isScalar() false
which is consistent with TypeKind definition as well as macros like
VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH handling;
(2) initialize the null flag to true when create flat encoded UNKNOWN vector
Add corresponding tests.