### PR TITLE
Add is_json_scalar Presto Json function

### DIFF
--- a/velox/docs/functions/json.rst
+++ b/velox/docs/functions/json.rst
@@ -101,6 +101,14 @@ JSON Functions
 
     .. _JSONPath: http://goessner.net/articles/JsonPath/
 
+.. function:: is_json_scalar(json) -> boolean
+
+    Determine if ``json`` is a scalar (i.e. a JSON number, a JSON string,
+    ``true``, ``false`` or ``null``)::
+
+        SELECT is_json_scalar('1'); *-- true*
+        SELECT is_json_scalar('[1, 2, 3]'); *-- false*
+
 ============
 JSON Vectors
 ============

--- a/velox/functions/prestosql/JsonFunctions.h
+++ b/velox/functions/prestosql/JsonFunctions.h
@@ -20,7 +20,7 @@
 namespace facebook::velox::functions {
 
 template <typename T>
-struct isJsonScalarFunction {
+struct IsJsonScalarFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE void call(

--- a/velox/functions/prestosql/JsonFunctions.h
+++ b/velox/functions/prestosql/JsonFunctions.h
@@ -19,6 +19,18 @@
 
 namespace facebook::velox::functions {
 
+template <typename T>
+struct isJsonScalarFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      bool& result,
+      const arg_type<Varchar>& json) {
+    auto parsedJson = folly::parseJson(json);
+    result = parsedJson.isNumber() || parsedJson.isString() || parsedJson.isBool() || parsedJson.isNull();
+  }
+};
+
 // jsonExtractScalar(json, json_path) -> varchar
 // Current implementation support UTF-8 in json, but not in json_path.
 // Like jsonExtract(), but returns the result value as a string (as opposed

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -19,7 +19,7 @@
 
 namespace facebook::velox::functions {
 void registerJsonFunctions() {
-  registerFunction<isJsonScalarFunction, bool, Varchar>({"is_json_scalar"});
+  registerFunction<IsJsonScalarFunction, bool, Varchar>({"is_json_scalar"});
   registerFunction<JsonExtractScalarFunction, Varchar, Varchar, Varchar>(
       {"json_extract_scalar"});
 }

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -15,10 +15,11 @@
  */
 
 #include "velox/functions/Registerer.h"
-#include "velox/functions/prestosql/JsonExtractScalar.h"
+#include "velox/functions/prestosql/JsonFunctions.h"
 
 namespace facebook::velox::functions {
 void registerJsonFunctions() {
+  registerFunction<isJsonScalarFunction, bool, Varchar>({"is_json_scalar"});
   registerFunction<JsonExtractScalarFunction, Varchar, Varchar, Varchar>(
       {"json_extract_scalar"});
 }

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(
   InPredicateTest.cpp
   JsonCastTest.cpp
   JsonExtractScalarTest.cpp
+  JsonFunctionsTest.cpp
   MapConcatTest.cpp
   MapEntriesTest.cpp
   MapFilterTest.cpp

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -33,6 +33,7 @@ TEST_F(JsonFunctionsTest, isJsonScalar) {
   EXPECT_EQ(is_json_scalar(R"(1)"), true);
   EXPECT_EQ(is_json_scalar(R"(123456)"), true);
   EXPECT_EQ(is_json_scalar(R"("hello")"), true);
+  EXPECT_EQ(is_json_scalar(R"("thefoxjumpedoverthefence")"), true);
   EXPECT_EQ(is_json_scalar(R"(1.1)"), true);
   EXPECT_EQ(is_json_scalar(R"("")"), true);
   EXPECT_EQ(is_json_scalar(R"(true)"), true);

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/tests/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+
+namespace facebook::velox::functions::prestosql {
+
+namespace {
+
+class JsonFunctionsTest : public functions::test::FunctionBaseTest {
+ public:
+  std::optional<bool> is_json_scalar(std::optional<std::string> json) {
+    return evaluateOnce<bool>("is_json_scalar(c0)", json);
+  }
+};
+
+TEST_F(JsonFunctionsTest, isJsonScalar) {
+  // Scalars.
+  EXPECT_EQ(is_json_scalar(R"(1)"), true);
+  EXPECT_EQ(is_json_scalar(R"(123456)"), true);
+  EXPECT_EQ(is_json_scalar(R"("hello")"), true);
+  EXPECT_EQ(is_json_scalar(R"(1.1)"), true);
+  EXPECT_EQ(is_json_scalar(R"("")"), true);
+  EXPECT_EQ(is_json_scalar(R"(true)"), true);
+
+  // Lists and maps
+  EXPECT_EQ(is_json_scalar(R"([1,2])"), false);
+  EXPECT_EQ(is_json_scalar(R"({"k1":"v1"})"), false);
+  EXPECT_EQ(is_json_scalar(R"({"k1":[0,1,2]})"), false);
+  EXPECT_EQ(is_json_scalar(R"({"k1":""})"), false);
+}
+
+} // namespace
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -18,7 +18,7 @@
 #include "velox/functions/lib/Re2Functions.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/DateTimeFunctions.h"
-#include "velox/functions/prestosql/JsonExtractScalar.h"
+#include "velox/functions/prestosql/JsonFunctions.h"
 #include "velox/functions/prestosql/Rand.h"
 #include "velox/functions/prestosql/StringFunctions.h"
 #include "velox/functions/sparksql/ArraySort.h"


### PR DESCRIPTION
Adds Json function is_json_scalar to determine if the Json object represents a scalar.