### PR TITLE
Refactor DateTimeFormatter tests

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -500,7 +500,10 @@ std::string getSpecifierName(int enumInt) {
   }
 }
 
-int getMaxDigitConsume(FormatPattern curPattern, bool specifierNext) {
+int getMaxDigitConsume(
+    FormatPattern curPattern,
+    bool specifierNext,
+    bool joda) {
   // Does not support WEEK_YEAR, WEEK_OF_WEEK_YEAR, time zone names
   switch (curPattern.specifier) {
     case DateTimeFormatSpecifier::CENTURY_OF_ERA:
@@ -514,6 +517,11 @@ int getMaxDigitConsume(FormatPattern curPattern, bool specifierNext) {
       if (specifierNext) {
         return curPattern.minRepresentDigits;
       } else {
+        if (!joda) {
+          // MySQL format will try to read in at most 4 digits when supplied a
+          // year, never more.
+          return 4;
+        }
         return curPattern.minRepresentDigits > 9 ? curPattern.minRepresentDigits
                                                  : 9;
       }
@@ -547,7 +555,8 @@ void parseFromPattern(
     const char*& cur,
     const char* end,
     Date& date,
-    bool specifierNext) {
+    bool specifierNext,
+    bool joda) {
   if (curPattern.specifier == DateTimeFormatSpecifier::TIMEZONE_OFFSET_ID) {
     try {
       cur += parseTimezoneOffset(cur, end, date);
@@ -606,7 +615,7 @@ void parseFromPattern(
 
     auto startPos = cur;
     int64_t number = 0;
-    int maxDigitConsume = getMaxDigitConsume(curPattern, specifierNext);
+    int maxDigitConsume = getMaxDigitConsume(curPattern, specifierNext, joda);
 
     if (curPattern.specifier == DateTimeFormatSpecifier::FRACTION_OF_SECOND) {
       int count = 0;
@@ -643,6 +652,10 @@ void parseFromPattern(
         } else if (number >= 0 && number < 70) {
           number += 2000;
         }
+      } else if (!joda) {
+        // In MySQL format, year read in must have exactly two digits, otherwise
+        // throw an error
+        parseFail(input, cur - count + 2, end);
       }
     } else {
       while (cur < end && cur < startPos + maxDigitConsume &&
@@ -1038,7 +1051,9 @@ std::string DateTimeFormatter::format(
   return result;
 }
 
-DateTimeResult DateTimeFormatter::parse(const std::string_view& input) const {
+DateTimeResult DateTimeFormatter::parse(
+    const std::string_view& input,
+    const bool joda) const {
   Date date;
   const char* cur = input.data();
   const char* end = cur + input.size();
@@ -1056,9 +1071,9 @@ DateTimeResult DateTimeFormatter::parse(const std::string_view& input) const {
       case DateTimeToken::Type::kPattern:
         if (i + 1 < tokens_.size() &&
             tokens_[i + 1].type == DateTimeToken::Type::kPattern) {
-          parseFromPattern(tok.pattern, input, cur, end, date, true);
+          parseFromPattern(tok.pattern, input, cur, end, date, true, joda);
         } else {
-          parseFromPattern(tok.pattern, input, cur, end, date, false);
+          parseFromPattern(tok.pattern, input, cur, end, date, false, joda);
         }
         break;
     }

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -169,7 +169,7 @@ class DateTimeFormatter {
     return tokens_;
   }
 
-  DateTimeResult parse(const std::string_view& input) const;
+  DateTimeResult parse(const std::string_view& input, const bool joda) const;
 
   std::string format(
       const Timestamp& timestamp,

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -79,17 +79,22 @@ class DateTimeFormatterTest : public testing::Test {
       const std::string_view& format,
       bool joda = true) {
     if (joda) {
-      return buildJodaDateTimeFormatter(format)->parse(input);
+      return buildJodaDateTimeFormatter(format)->parse(input, true);
     } else {
-      return buildMysqlDateTimeFormatter(format)->parse(input);
+      return buildMysqlDateTimeFormatter(format)->parse(input, false);
     }
   }
 
-  Timestamp parse(
+  Timestamp parseJoda(
       const std::string_view& input,
-      const std::string_view& format,
-      bool joda = true) {
-    return parseAll(input, format, joda).timestamp;
+      const std::string_view& format) {
+    return parseAll(input, format, true).timestamp;
+  }
+
+  Timestamp parseMysql(
+      const std::string_view& input,
+      const std::string_view& format) {
+    return parseAll(input, format, false).timestamp;
   }
 
   // Parses and returns the timezone converted back to string, to ease
@@ -97,7 +102,7 @@ class DateTimeFormatterTest : public testing::Test {
   std::string parseTZ(
       const std::string_view& input,
       const std::string_view& format) {
-    auto result = buildJodaDateTimeFormatter(format)->parse(input);
+    auto result = buildJodaDateTimeFormatter(format)->parse(input, true);
     if (result.timezoneId == 0) {
       return "+00:00";
     }
@@ -375,474 +380,545 @@ TEST_F(JodaDateTimeFormatterTest, invalidJodaBuild) {
 
 TEST_F(JodaDateTimeFormatterTest, invalid) {
   // Parse:
-  EXPECT_THROW(parse("", ""), VeloxUserError);
-  EXPECT_THROW(parse(" ", ""), VeloxUserError);
-  EXPECT_THROW(parse("", " "), VeloxUserError);
-  EXPECT_THROW(parse("", "Y '"), VeloxUserError);
+  EXPECT_THROW(parseJoda("", ""), VeloxUserError);
+  EXPECT_THROW(parseJoda(" ", ""), VeloxUserError);
+  EXPECT_THROW(parseJoda("", " "), VeloxUserError);
+  EXPECT_THROW(parseJoda("", "Y '"), VeloxUserError);
 }
 
-TEST_F(JodaDateTimeFormatterTest, parseEra) {
+TEST_F(JodaDateTimeFormatterTest, parseJodaEra) {
   // Normal era cases
-  EXPECT_EQ(util::fromTimestampString("-100-01-01"), parse("BC 101", "G Y"));
-  EXPECT_EQ(util::fromTimestampString("101-01-01"), parse("AD 101", "G Y"));
-  EXPECT_EQ(util::fromTimestampString("-100-01-01"), parse("bc 101", "G Y"));
-  EXPECT_EQ(util::fromTimestampString("101-01-01"), parse("ad 101", "G Y"));
+  EXPECT_EQ(
+      util::fromTimestampString("-100-01-01"), parseJoda("BC 101", "G Y"));
+  EXPECT_EQ(util::fromTimestampString("101-01-01"), parseJoda("AD 101", "G Y"));
+  EXPECT_EQ(
+      util::fromTimestampString("-100-01-01"), parseJoda("bc 101", "G Y"));
+  EXPECT_EQ(util::fromTimestampString("101-01-01"), parseJoda("ad 101", "G Y"));
 
   // Era specifier with 'y' specifier
-  EXPECT_EQ(util::fromTimestampString("101-01-01"), parse("BC 101", "G y"));
-  EXPECT_EQ(util::fromTimestampString("2012-01-01"), parse("BC 2012", "G y"));
+  EXPECT_EQ(util::fromTimestampString("101-01-01"), parseJoda("BC 101", "G y"));
   EXPECT_EQ(
-      util::fromTimestampString("-101-01-01"), parse("AD 2012 -101", "G Y y"));
+      util::fromTimestampString("2012-01-01"), parseJoda("BC 2012", "G y"));
   EXPECT_EQ(
-      util::fromTimestampString("2012-01-01"), parse("BC 101 2012", "G Y y"));
-  EXPECT_EQ(
-      util::fromTimestampString("-2011-01-01"), parse("BC 2000 2012", "G y Y"));
-  EXPECT_EQ(
-      util::fromTimestampString("-2011-01-01"),
-      parse("BC 2000 2012 BC", "G y Y G"));
-  EXPECT_EQ(
-      util::fromTimestampString("-2014-01-01"),
-      parse("BC 1 BC 2015", "G y G Y"));
-  EXPECT_EQ(
-      util::fromTimestampString("2015-01-01"),
-      parse("BC 0 BC 2015 AD", "G y G Y G"));
-  EXPECT_EQ(
-      util::fromTimestampString("2015-01-01"),
-      parse("AD 0 AD 2015", "G y G Y"));
-  EXPECT_EQ(
-      util::fromTimestampString("-2011-01-01"),
-      parse("BC 0 BC 2015 2 2012 BC", "G y G Y y Y G"));
+      util::fromTimestampString("-101-01-01"),
+      parseJoda("AD 2012 -101", "G Y y"));
   EXPECT_EQ(
       util::fromTimestampString("2012-01-01"),
-      parse("AD 0 AD 2015 2 2012 AD", "G y G Y y Y G"));
+      parseJoda("BC 101 2012", "G Y y"));
+  EXPECT_EQ(
+      util::fromTimestampString("-2011-01-01"),
+      parseJoda("BC 2000 2012", "G y Y"));
+  EXPECT_EQ(
+      util::fromTimestampString("-2011-01-01"),
+      parseJoda("BC 2000 2012 BC", "G y Y G"));
+  EXPECT_EQ(
+      util::fromTimestampString("-2014-01-01"),
+      parseJoda("BC 1 BC 2015", "G y G Y"));
+  EXPECT_EQ(
+      util::fromTimestampString("2015-01-01"),
+      parseJoda("BC 0 BC 2015 AD", "G y G Y G"));
+  EXPECT_EQ(
+      util::fromTimestampString("2015-01-01"),
+      parseJoda("AD 0 AD 2015", "G y G Y"));
+  EXPECT_EQ(
+      util::fromTimestampString("-2011-01-01"),
+      parseJoda("BC 0 BC 2015 2 2012 BC", "G y G Y y Y G"));
+  EXPECT_EQ(
+      util::fromTimestampString("2012-01-01"),
+      parseJoda("AD 0 AD 2015 2 2012 AD", "G y G Y y Y G"));
 
   // Invalid cases
-  EXPECT_THROW(parse("FG", "G"), VeloxUserError);
-  EXPECT_THROW(parse("AC", "G"), VeloxUserError);
-  EXPECT_THROW(parse("BD", "G"), VeloxUserError);
-  EXPECT_THROW(parse("aD", "G"), VeloxUserError);
-  EXPECT_THROW(parse("Ad", "G"), VeloxUserError);
-  EXPECT_THROW(parse("bC", "G"), VeloxUserError);
-  EXPECT_THROW(parse("Bc", "G"), VeloxUserError);
+  EXPECT_THROW(parseJoda("FG", "G"), VeloxUserError);
+  EXPECT_THROW(parseJoda("AC", "G"), VeloxUserError);
+  EXPECT_THROW(parseJoda("BD", "G"), VeloxUserError);
+  EXPECT_THROW(parseJoda("aD", "G"), VeloxUserError);
+  EXPECT_THROW(parseJoda("Ad", "G"), VeloxUserError);
+  EXPECT_THROW(parseJoda("bC", "G"), VeloxUserError);
+  EXPECT_THROW(parseJoda("Bc", "G"), VeloxUserError);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseYearOfEra) {
   // By the default, assume epoch.
-  EXPECT_EQ(util::fromTimestampString("1970-01-01"), parse(" ", " "));
+  EXPECT_EQ(util::fromTimestampString("1970-01-01"), parseJoda(" ", " "));
 
   // Number of times the token is repeated doesn't change the parsing behavior.
-  EXPECT_EQ(util::fromTimestampString("2134-01-01"), parse("2134", "Y"));
-  EXPECT_EQ(util::fromTimestampString("2134-01-01"), parse("2134", "YYYYYYYY"));
+  EXPECT_EQ(util::fromTimestampString("2134-01-01"), parseJoda("2134", "Y"));
+  EXPECT_EQ(
+      util::fromTimestampString("2134-01-01"), parseJoda("2134", "YYYYYYYY"));
 
   // Probe the year of era range. Joda only supports positive years.
-  EXPECT_EQ(util::fromTimestampString("294247-01-01"), parse("294247", "Y"));
-  EXPECT_EQ(util::fromTimestampString("0001-01-01"), parse("1", "Y"));
-  EXPECT_THROW(parse("292278994", "Y"), VeloxUserError);
-  EXPECT_THROW(parse("0", "Y"), VeloxUserError);
-  EXPECT_THROW(parse("-1", "Y"), VeloxUserError);
-  EXPECT_THROW(parse("  ", " Y "), VeloxUserError);
-  EXPECT_THROW(parse(" 1 2", "Y Y"), VeloxUserError);
+  EXPECT_EQ(
+      util::fromTimestampString("294247-01-01"), parseJoda("294247", "Y"));
+  EXPECT_EQ(util::fromTimestampString("0001-01-01"), parseJoda("1", "Y"));
+  EXPECT_THROW(parseJoda("292278994", "Y"), VeloxUserError);
+  EXPECT_THROW(parseJoda("0", "Y"), VeloxUserError);
+  EXPECT_THROW(parseJoda("-1", "Y"), VeloxUserError);
+  EXPECT_THROW(parseJoda("  ", " Y "), VeloxUserError);
+  EXPECT_THROW(parseJoda(" 1 2", "Y Y"), VeloxUserError);
 
   // 2 'Y' token case
-  EXPECT_EQ(util::fromTimestampString("2012-01-01"), parse("12", "YY"));
-  EXPECT_EQ(util::fromTimestampString("2069-01-01"), parse("69", "YY"));
-  EXPECT_EQ(util::fromTimestampString("1970-01-01"), parse("70", "YY"));
-  EXPECT_EQ(util::fromTimestampString("1999-01-01"), parse("99", "YY"));
-  EXPECT_EQ(util::fromTimestampString("0002-01-01"), parse("2", "YY"));
-  EXPECT_EQ(util::fromTimestampString("0210-01-01"), parse("210", "YY"));
-  EXPECT_EQ(util::fromTimestampString("0001-01-01"), parse("1", "YY"));
-  EXPECT_EQ(util::fromTimestampString("2001-01-01"), parse("01", "YY"));
+  EXPECT_EQ(util::fromTimestampString("2012-01-01"), parseJoda("12", "YY"));
+  EXPECT_EQ(util::fromTimestampString("2069-01-01"), parseJoda("69", "YY"));
+  EXPECT_EQ(util::fromTimestampString("1970-01-01"), parseJoda("70", "YY"));
+  EXPECT_EQ(util::fromTimestampString("1999-01-01"), parseJoda("99", "YY"));
+  EXPECT_EQ(util::fromTimestampString("0002-01-01"), parseJoda("2", "YY"));
+  EXPECT_EQ(util::fromTimestampString("0210-01-01"), parseJoda("210", "YY"));
+  EXPECT_EQ(util::fromTimestampString("0001-01-01"), parseJoda("1", "YY"));
+  EXPECT_EQ(util::fromTimestampString("2001-01-01"), parseJoda("01", "YY"));
 
   // Last token read overwrites:
   EXPECT_EQ(
-      util::fromTimestampString("0005-01-01"), parse("1 2 3 4 5", "Y Y Y Y Y"));
+      util::fromTimestampString("0005-01-01"),
+      parseJoda("1 2 3 4 5", "Y Y Y Y Y"));
 
   // Throws on consumption of plus sign
-  EXPECT_THROW(parse("+100", "Y"), VeloxUserError);
+  EXPECT_THROW(parseJoda("+100", "Y"), VeloxUserError);
 }
 
 // Same semantic as YEAR_OF_ERA, except that it accepts zero and negative years.
 TEST_F(JodaDateTimeFormatterTest, parseYear) {
-  EXPECT_EQ(util::fromTimestampString("123-01-01"), parse("123", "y"));
-  EXPECT_EQ(util::fromTimestampString("321-01-01"), parse("321", "yyyyyyyy"));
+  EXPECT_EQ(util::fromTimestampString("123-01-01"), parseJoda("123", "y"));
+  EXPECT_EQ(
+      util::fromTimestampString("321-01-01"), parseJoda("321", "yyyyyyyy"));
 
-  EXPECT_EQ(util::fromTimestampString("0-01-01"), parse("0", "y"));
-  EXPECT_EQ(util::fromTimestampString("-1-01-01"), parse("-1", "y"));
-  EXPECT_EQ(util::fromTimestampString("-1234-01-01"), parse("-1234", "y"));
+  EXPECT_EQ(util::fromTimestampString("0-01-01"), parseJoda("0", "y"));
+  EXPECT_EQ(util::fromTimestampString("-1-01-01"), parseJoda("-1", "y"));
+  EXPECT_EQ(util::fromTimestampString("-1234-01-01"), parseJoda("-1234", "y"));
 
   // Last token read overwrites:
-  EXPECT_EQ(util::fromTimestampString("0-01-01"), parse("123 0", "Y y"));
+  EXPECT_EQ(util::fromTimestampString("0-01-01"), parseJoda("123 0", "Y y"));
 
   // 2 'y' token case
-  EXPECT_EQ(util::fromTimestampString("2012-01-01"), parse("12", "yy"));
-  EXPECT_EQ(util::fromTimestampString("2069-01-01"), parse("69", "yy"));
-  EXPECT_EQ(util::fromTimestampString("1970-01-01"), parse("70", "yy"));
-  EXPECT_EQ(util::fromTimestampString("1999-01-01"), parse("99", "yy"));
-  EXPECT_EQ(util::fromTimestampString("0002-01-01"), parse("2", "yy"));
-  EXPECT_EQ(util::fromTimestampString("0210-01-01"), parse("210", "yy"));
-  EXPECT_EQ(util::fromTimestampString("0001-01-01"), parse("1", "yy"));
-  EXPECT_EQ(util::fromTimestampString("2001-01-01"), parse("01", "yy"));
+  EXPECT_EQ(util::fromTimestampString("2012-01-01"), parseJoda("12", "yy"));
+  EXPECT_EQ(util::fromTimestampString("2069-01-01"), parseJoda("69", "yy"));
+  EXPECT_EQ(util::fromTimestampString("1970-01-01"), parseJoda("70", "yy"));
+  EXPECT_EQ(util::fromTimestampString("1999-01-01"), parseJoda("99", "yy"));
+  EXPECT_EQ(util::fromTimestampString("0002-01-01"), parseJoda("2", "yy"));
+  EXPECT_EQ(util::fromTimestampString("0210-01-01"), parseJoda("210", "yy"));
+  EXPECT_EQ(util::fromTimestampString("0001-01-01"), parseJoda("1", "yy"));
+  EXPECT_EQ(util::fromTimestampString("2001-01-01"), parseJoda("01", "yy"));
 
   // Plus sign consumption valid when y operator is not followed by another
   // specifier
-  EXPECT_EQ(util::fromTimestampString("10-01-01"), parse("+10", "y"));
-  EXPECT_EQ(util::fromTimestampString("99-02-01"), parse("+99 02", "y M"));
-  EXPECT_EQ(util::fromTimestampString("10-10-01"), parse("10 +10", "M y"));
-  EXPECT_EQ(util::fromTimestampString("100-02-01"), parse("2+100", "My"));
-  EXPECT_THROW(parse("+10001", "yM"), VeloxUserError);
-  EXPECT_THROW(parse("++100", "y"), VeloxUserError);
+  EXPECT_EQ(util::fromTimestampString("10-01-01"), parseJoda("+10", "y"));
+  EXPECT_EQ(util::fromTimestampString("99-02-01"), parseJoda("+99 02", "y M"));
+  EXPECT_EQ(util::fromTimestampString("10-10-01"), parseJoda("10 +10", "M y"));
+  EXPECT_EQ(util::fromTimestampString("100-02-01"), parseJoda("2+100", "My"));
+  EXPECT_THROW(parseJoda("+10001", "yM"), VeloxUserError);
+  EXPECT_THROW(parseJoda("++100", "y"), VeloxUserError);
 
   // Probe the year range
-  EXPECT_THROW(parse("-292275056", "y"), VeloxUserError);
-  EXPECT_THROW(parse("292278995", "y"), VeloxUserError);
+  EXPECT_THROW(parseJoda("-292275056", "y"), VeloxUserError);
+  EXPECT_THROW(parseJoda("292278995", "y"), VeloxUserError);
   EXPECT_EQ(
-      util::fromTimestampString("292278994-01-01"), parse("292278994", "y"));
+      util::fromTimestampString("292278994-01-01"),
+      parseJoda("292278994", "y"));
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseWeekYear) {
   // Covers entire range of possible week year start dates (12-29 to 01-04)
   EXPECT_EQ(
-      util::fromTimestampString("1969-12-29 00:00:00"), parse("1970", "x"));
+      util::fromTimestampString("1969-12-29 00:00:00"), parseJoda("1970", "x"));
   EXPECT_EQ(
-      util::fromTimestampString("2024-12-30 00:00:00"), parse("2025", "x"));
+      util::fromTimestampString("2024-12-30 00:00:00"), parseJoda("2025", "x"));
   EXPECT_EQ(
-      util::fromTimestampString("1934-12-31 00:00:00"), parse("1935", "x"));
+      util::fromTimestampString("1934-12-31 00:00:00"), parseJoda("1935", "x"));
   EXPECT_EQ(
-      util::fromTimestampString("1990-01-01 00:00:00"), parse("1990", "x"));
+      util::fromTimestampString("1990-01-01 00:00:00"), parseJoda("1990", "x"));
   EXPECT_EQ(
-      util::fromTimestampString("0204-01-02 00:00:00"), parse("204", "x"));
+      util::fromTimestampString("0204-01-02 00:00:00"), parseJoda("204", "x"));
   EXPECT_EQ(
-      util::fromTimestampString("-0102-01-03 00:00:00"), parse("-102", "x"));
+      util::fromTimestampString("-0102-01-03 00:00:00"),
+      parseJoda("-102", "x"));
   EXPECT_EQ(
-      util::fromTimestampString("-0108-01-04 00:00:00"), parse("-108", "x"));
+      util::fromTimestampString("-0108-01-04 00:00:00"),
+      parseJoda("-108", "x"));
   EXPECT_EQ(
-      util::fromTimestampString("-1002-12-31 00:00:00"), parse("-1001", "x"));
+      util::fromTimestampString("-1002-12-31 00:00:00"),
+      parseJoda("-1001", "x"));
 
   // 2 'x' token case
-  EXPECT_EQ(util::fromTimestampString("2012-01-02"), parse("12", "xx"));
-  EXPECT_EQ(util::fromTimestampString("2068-12-31"), parse("69", "xx"));
-  EXPECT_EQ(util::fromTimestampString("1969-12-29"), parse("70", "xx"));
-  EXPECT_EQ(util::fromTimestampString("1999-01-04"), parse("99", "xx"));
-  EXPECT_EQ(util::fromTimestampString("0001-12-31"), parse("2", "xx"));
-  EXPECT_EQ(util::fromTimestampString("0210-01-01"), parse("210", "xx"));
-  EXPECT_EQ(util::fromTimestampString("0001-01-01"), parse("1", "xx"));
-  EXPECT_EQ(util::fromTimestampString("2001-01-01"), parse("01", "xx"));
+  EXPECT_EQ(util::fromTimestampString("2012-01-02"), parseJoda("12", "xx"));
+  EXPECT_EQ(util::fromTimestampString("2068-12-31"), parseJoda("69", "xx"));
+  EXPECT_EQ(util::fromTimestampString("1969-12-29"), parseJoda("70", "xx"));
+  EXPECT_EQ(util::fromTimestampString("1999-01-04"), parseJoda("99", "xx"));
+  EXPECT_EQ(util::fromTimestampString("0001-12-31"), parseJoda("2", "xx"));
+  EXPECT_EQ(util::fromTimestampString("0210-01-01"), parseJoda("210", "xx"));
+  EXPECT_EQ(util::fromTimestampString("0001-01-01"), parseJoda("1", "xx"));
+  EXPECT_EQ(util::fromTimestampString("2001-01-01"), parseJoda("01", "xx"));
 
   // Plus sign consumption valid when x operator is not followed by another
   // specifier
-  EXPECT_EQ(util::fromTimestampString("10-01-04"), parse("+10", "x"));
-  EXPECT_EQ(util::fromTimestampString("0098-12-29"), parse("+99 01", "x w"));
-  EXPECT_EQ(util::fromTimestampString("0099-01-05"), parse("+99 02", "x w"));
-  EXPECT_EQ(util::fromTimestampString("10-03-08"), parse("10 +10", "w x"));
-  EXPECT_EQ(util::fromTimestampString("100-01-11"), parse("2+100", "wx"));
-  EXPECT_THROW(parse("+10001", "xM"), VeloxUserError);
-  EXPECT_THROW(parse("++100", "x"), VeloxUserError);
+  EXPECT_EQ(util::fromTimestampString("10-01-04"), parseJoda("+10", "x"));
+  EXPECT_EQ(
+      util::fromTimestampString("0098-12-29"), parseJoda("+99 01", "x w"));
+  EXPECT_EQ(
+      util::fromTimestampString("0099-01-05"), parseJoda("+99 02", "x w"));
+  EXPECT_EQ(util::fromTimestampString("10-03-08"), parseJoda("10 +10", "w x"));
+  EXPECT_EQ(util::fromTimestampString("100-01-11"), parseJoda("2+100", "wx"));
+  EXPECT_THROW(parseJoda("+10001", "xM"), VeloxUserError);
+  EXPECT_THROW(parseJoda("++100", "x"), VeloxUserError);
 
   // Probe week year range
-  EXPECT_THROW(parse("-292275055", "x"), VeloxUserError);
-  EXPECT_THROW(parse("292278994", "x"), VeloxUserError);
+  EXPECT_THROW(parseJoda("-292275055", "x"), VeloxUserError);
+  EXPECT_THROW(parseJoda("292278994", "x"), VeloxUserError);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseCenturyOfEra) {
   // Probe century range
   EXPECT_EQ(
       util::fromTimestampString("292278900-01-01 00:00:00"),
-      parse("2922789", "CCCCCCC"));
-  EXPECT_EQ(util::fromTimestampString("00-01-01 00:00:00"), parse("0", "C"));
+      parseJoda("2922789", "CCCCCCC"));
+  EXPECT_EQ(
+      util::fromTimestampString("00-01-01 00:00:00"), parseJoda("0", "C"));
 
   // Invalid century values
-  EXPECT_THROW(parse("-1", "CCCCCCC"), VeloxUserError);
-  EXPECT_THROW(parse("2922790", "CCCCCCC"), VeloxUserError);
+  EXPECT_THROW(parseJoda("-1", "CCCCCCC"), VeloxUserError);
+  EXPECT_THROW(parseJoda("2922790", "CCCCCCC"), VeloxUserError);
 }
 
-TEST_F(JodaDateTimeFormatterTest, parseMonth) {
+TEST_F(JodaDateTimeFormatterTest, parseJodaMonth) {
   // Joda has this weird behavior where if minute or hour is specified, year
   // falls back to 2000, instead of epoch (1970)  ¯\_(ツ)_/¯
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("1", "M"));
-  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parse(" 7", " MM"));
-  EXPECT_EQ(util::fromTimestampString("2000-11-01"), parse("11-", "M-"));
-  EXPECT_EQ(util::fromTimestampString("2000-12-01"), parse("-12-", "-M-"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseJoda("1", "M"));
+  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parseJoda(" 7", " MM"));
+  EXPECT_EQ(util::fromTimestampString("2000-11-01"), parseJoda("11-", "M-"));
+  EXPECT_EQ(util::fromTimestampString("2000-12-01"), parseJoda("-12-", "-M-"));
 
-  EXPECT_THROW(parse("0", "M"), VeloxUserError);
-  EXPECT_THROW(parse("13", "M"), VeloxUserError);
-  EXPECT_THROW(parse("12345", "M"), VeloxUserError);
+  EXPECT_THROW(parseJoda("0", "M"), VeloxUserError);
+  EXPECT_THROW(parseJoda("13", "M"), VeloxUserError);
+  EXPECT_THROW(parseJoda("12345", "M"), VeloxUserError);
 
   // Ensure MMM and MMMM specifiers consume both short- and long-form month
   // names
   for (int i = 0; i < 12; i++) {
     StringView buildString("2000-" + std::to_string(i + 1) + "-01");
     EXPECT_EQ(
-        util::fromTimestampString(buildString), parse(monthsShort[i], "MMM"));
+        util::fromTimestampString(buildString),
+        parseJoda(monthsShort[i], "MMM"));
     EXPECT_EQ(
-        util::fromTimestampString(buildString), parse(monthsFull[i], "MMM"));
+        util::fromTimestampString(buildString),
+        parseJoda(monthsFull[i], "MMM"));
     EXPECT_EQ(
-        util::fromTimestampString(buildString), parse(monthsShort[i], "MMMM"));
+        util::fromTimestampString(buildString),
+        parseJoda(monthsShort[i], "MMMM"));
     EXPECT_EQ(
-        util::fromTimestampString(buildString), parse(monthsFull[i], "MMMM"));
+        util::fromTimestampString(buildString),
+        parseJoda(monthsFull[i], "MMMM"));
   }
 
   // Month name invalid parse
-  EXPECT_THROW(parse("Decembr", "MMM"), VeloxUserError);
-  EXPECT_THROW(parse("Decembr", "MMMM"), VeloxUserError);
-  EXPECT_THROW(parse("Decemberary", "MMM"), VeloxUserError);
-  EXPECT_THROW(parse("Decemberary", "MMMM"), VeloxUserError);
-  EXPECT_THROW(parse("asdf", "MMM"), VeloxUserError);
-  EXPECT_THROW(parse("asdf", "MMMM"), VeloxUserError);
+  EXPECT_THROW(parseJoda("Decembr", "MMM"), VeloxUserError);
+  EXPECT_THROW(parseJoda("Decembr", "MMMM"), VeloxUserError);
+  EXPECT_THROW(parseJoda("Decemberary", "MMM"), VeloxUserError);
+  EXPECT_THROW(parseJoda("Decemberary", "MMMM"), VeloxUserError);
+  EXPECT_THROW(parseJoda("asdf", "MMM"), VeloxUserError);
+  EXPECT_THROW(parseJoda("asdf", "MMMM"), VeloxUserError);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseDayOfMonth) {
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("1", "d"));
-  EXPECT_EQ(util::fromTimestampString("2000-01-07"), parse("7 ", "dd "));
-  EXPECT_EQ(util::fromTimestampString("2000-01-11"), parse("/11", "/dd"));
-  EXPECT_EQ(util::fromTimestampString("2000-01-31"), parse("/31/", "/d/"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseJoda("1", "d"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-07"), parseJoda("7 ", "dd "));
+  EXPECT_EQ(util::fromTimestampString("2000-01-11"), parseJoda("/11", "/dd"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-31"), parseJoda("/31/", "/d/"));
 
-  EXPECT_THROW(parse("0", "d"), VeloxUserError);
-  EXPECT_THROW(parse("32", "d"), VeloxUserError);
-  EXPECT_THROW(parse("12345", "d"), VeloxUserError);
+  EXPECT_THROW(parseJoda("0", "d"), VeloxUserError);
+  EXPECT_THROW(parseJoda("32", "d"), VeloxUserError);
+  EXPECT_THROW(parseJoda("12345", "d"), VeloxUserError);
 
-  EXPECT_THROW(parse("02-31", "M-d"), VeloxUserError);
-  EXPECT_THROW(parse("04-31", "M-d"), VeloxUserError);
+  EXPECT_THROW(parseJoda("02-31", "M-d"), VeloxUserError);
+  EXPECT_THROW(parseJoda("04-31", "M-d"), VeloxUserError);
 
   // Ensure all days of month are checked against final selected month
-  EXPECT_THROW(parse("1 31 20 2", "M d d M"), VeloxUserError);
-  EXPECT_THROW(parse("2 31 20 4", "M d d M"), VeloxUserError);
-  EXPECT_EQ(util::fromTimestampString("2000-01-31"), parse("2 31 1", "M d M"));
+  EXPECT_THROW(parseJoda("1 31 20 2", "M d d M"), VeloxUserError);
+  EXPECT_THROW(parseJoda("2 31 20 4", "M d d M"), VeloxUserError);
+  EXPECT_EQ(
+      util::fromTimestampString("2000-01-31"), parseJoda("2 31 1", "M d M"));
 
   // Probe around leap year.
   EXPECT_EQ(
-      util::fromTimestampString("2000-02-29"), parse("2000-02-29", "Y-M-d"));
-  EXPECT_THROW(parse("2001-02-29", "Y-M-d"), VeloxUserError);
+      util::fromTimestampString("2000-02-29"),
+      parseJoda("2000-02-29", "Y-M-d"));
+  EXPECT_THROW(parseJoda("2001-02-29", "Y-M-d"), VeloxUserError);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseDayOfYear) {
   // Just day of year specifier should default to 2000. Also covers leap year
   // case
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("1", "D"));
-  EXPECT_EQ(util::fromTimestampString("2000-01-07"), parse("7 ", "DD "));
-  EXPECT_EQ(util::fromTimestampString("2000-01-11"), parse("/11", "/DD"));
-  EXPECT_EQ(util::fromTimestampString("2000-01-31"), parse("/31/", "/DDD/"));
-  EXPECT_EQ(util::fromTimestampString("2000-02-01"), parse("32", "D"));
-  EXPECT_EQ(util::fromTimestampString("2000-02-29"), parse("60", "D"));
-  EXPECT_EQ(util::fromTimestampString("2000-12-30"), parse("365", "D"));
-  EXPECT_EQ(util::fromTimestampString("2000-12-31"), parse("366", "D"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseJoda("1", "D"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-07"), parseJoda("7 ", "DD "));
+  EXPECT_EQ(util::fromTimestampString("2000-01-11"), parseJoda("/11", "/DD"));
+  EXPECT_EQ(
+      util::fromTimestampString("2000-01-31"), parseJoda("/31/", "/DDD/"));
+  EXPECT_EQ(util::fromTimestampString("2000-02-01"), parseJoda("32", "D"));
+  EXPECT_EQ(util::fromTimestampString("2000-02-29"), parseJoda("60", "D"));
+  EXPECT_EQ(util::fromTimestampString("2000-12-30"), parseJoda("365", "D"));
+  EXPECT_EQ(util::fromTimestampString("2000-12-31"), parseJoda("366", "D"));
 
   // Year specified cases
-  EXPECT_EQ(util::fromTimestampString("1950-01-01"), parse("1950 1", "y D"));
-  EXPECT_EQ(util::fromTimestampString("1950-01-07"), parse("1950 7 ", "y DD "));
   EXPECT_EQ(
-      util::fromTimestampString("1950-01-11"), parse("1950 /11", "y /DD"));
+      util::fromTimestampString("1950-01-01"), parseJoda("1950 1", "y D"));
   EXPECT_EQ(
-      util::fromTimestampString("1950-01-31"), parse("1950 /31/", "y /DDD/"));
-  EXPECT_EQ(util::fromTimestampString("1950-02-01"), parse("1950 32", "y D"));
-  EXPECT_EQ(util::fromTimestampString("1950-03-01"), parse("1950 60", "y D"));
-  EXPECT_EQ(util::fromTimestampString("1950-12-31"), parse("1950 365", "y D"));
-  EXPECT_THROW(parse("1950 366", "Y D"), VeloxUserError);
+      util::fromTimestampString("1950-01-07"), parseJoda("1950 7 ", "y DD "));
+  EXPECT_EQ(
+      util::fromTimestampString("1950-01-11"), parseJoda("1950 /11", "y /DD"));
+  EXPECT_EQ(
+      util::fromTimestampString("1950-01-31"),
+      parseJoda("1950 /31/", "y /DDD/"));
+  EXPECT_EQ(
+      util::fromTimestampString("1950-02-01"), parseJoda("1950 32", "y D"));
+  EXPECT_EQ(
+      util::fromTimestampString("1950-03-01"), parseJoda("1950 60", "y D"));
+  EXPECT_EQ(
+      util::fromTimestampString("1950-12-31"), parseJoda("1950 365", "y D"));
+  EXPECT_THROW(parseJoda("1950 366", "Y D"), VeloxUserError);
 
   // Negative year specified cases
-  EXPECT_EQ(util::fromTimestampString("-1950-01-01"), parse("-1950 1", "y D"));
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-07"), parse("-1950 7 ", "y DD "));
+      util::fromTimestampString("-1950-01-01"), parseJoda("-1950 1", "y D"));
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-11"), parse("-1950 /11", "y /DD"));
+      util::fromTimestampString("-1950-01-07"), parseJoda("-1950 7 ", "y DD "));
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-31"), parse("-1950 /31/", "y /DDD/"));
-  EXPECT_EQ(util::fromTimestampString("-1950-02-01"), parse("-1950 32", "y D"));
-  EXPECT_EQ(util::fromTimestampString("-1950-03-01"), parse("-1950 60", "y D"));
+      util::fromTimestampString("-1950-01-11"),
+      parseJoda("-1950 /11", "y /DD"));
   EXPECT_EQ(
-      util::fromTimestampString("-1950-12-31"), parse("-1950 365", "y D"));
-  EXPECT_THROW(parse("-1950 366", "Y D"), VeloxUserError);
+      util::fromTimestampString("-1950-01-31"),
+      parseJoda("-1950 /31/", "y /DDD/"));
+  EXPECT_EQ(
+      util::fromTimestampString("-1950-02-01"), parseJoda("-1950 32", "y D"));
+  EXPECT_EQ(
+      util::fromTimestampString("-1950-03-01"), parseJoda("-1950 60", "y D"));
+  EXPECT_EQ(
+      util::fromTimestampString("-1950-12-31"), parseJoda("-1950 365", "y D"));
+  EXPECT_THROW(parseJoda("-1950 366", "Y D"), VeloxUserError);
 
   // Ensure all days of year are checked against final selected year
-  EXPECT_THROW(parse("2000 366 2001", "y D y"), VeloxUserError);
+  EXPECT_THROW(parseJoda("2000 366 2001", "y D y"), VeloxUserError);
   EXPECT_EQ(
-      util::fromTimestampString("2000-12-31"), parse("2001 366 2000", "y D y"));
+      util::fromTimestampString("2000-12-31"),
+      parseJoda("2001 366 2000", "y D y"));
 
-  EXPECT_THROW(parse("0", "d"), VeloxUserError);
-  EXPECT_THROW(parse("367", "d"), VeloxUserError);
+  EXPECT_THROW(parseJoda("0", "d"), VeloxUserError);
+  EXPECT_THROW(parseJoda("367", "d"), VeloxUserError);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseHourOfDay) {
-  EXPECT_EQ(util::fromTimestampString("1970-01-01 07:00:00"), parse("7", "H"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 23:00:00"), parse("23", "HH"));
+      util::fromTimestampString("1970-01-01 07:00:00"), parseJoda("7", "H"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("0", "HHH"));
+      util::fromTimestampString("1970-01-01 23:00:00"), parseJoda("23", "HH"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 00:00:00"), parseJoda("0", "HHH"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 10:00:00"),
-      parse("10", "HHHHHHHH"));
+      parseJoda("10", "HHHHHHHH"));
 
   // Hour of day invalid
-  EXPECT_THROW(parse("24", "H"), VeloxUserError);
-  EXPECT_THROW(parse("-1", "H"), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "H"), VeloxUserError);
+  EXPECT_THROW(parseJoda("24", "H"), VeloxUserError);
+  EXPECT_THROW(parseJoda("-1", "H"), VeloxUserError);
+  EXPECT_THROW(parseJoda("123456789", "H"), VeloxUserError);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseClockHourOfDay) {
-  EXPECT_EQ(util::fromTimestampString("1970-01-01 07:00:00"), parse("7", "k"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("24", "kk"));
+      util::fromTimestampString("1970-01-01 07:00:00"), parseJoda("7", "k"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"), parse("1", "kkk"));
+      util::fromTimestampString("1970-01-01 00:00:00"), parseJoda("24", "kk"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 01:00:00"), parseJoda("1", "kkk"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 10:00:00"),
-      parse("10", "kkkkkkkk"));
+      parseJoda("10", "kkkkkkkk"));
 
   // Clock hour of day invalid
-  EXPECT_THROW(parse("25", "k"), VeloxUserError);
-  EXPECT_THROW(parse("0", "k"), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "k"), VeloxUserError);
+  EXPECT_THROW(parseJoda("25", "k"), VeloxUserError);
+  EXPECT_THROW(parseJoda("0", "k"), VeloxUserError);
+  EXPECT_THROW(parseJoda("123456789", "k"), VeloxUserError);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseHourOfHalfDay) {
-  EXPECT_EQ(util::fromTimestampString("1970-01-01 07:00:00"), parse("7", "K"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 11:00:00"), parse("11", "KK"));
+      util::fromTimestampString("1970-01-01 07:00:00"), parseJoda("7", "K"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("0", "KKK"));
+      util::fromTimestampString("1970-01-01 11:00:00"), parseJoda("11", "KK"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 00:00:00"), parseJoda("0", "KKK"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 10:00:00"),
-      parse("10", "KKKKKKKK"));
+      parseJoda("10", "KKKKKKKK"));
 
   // Hour of half day invalid
-  EXPECT_THROW(parse("12", "K"), VeloxUserError);
-  EXPECT_THROW(parse("-1", "K"), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "K"), VeloxUserError);
+  EXPECT_THROW(parseJoda("12", "K"), VeloxUserError);
+  EXPECT_THROW(parseJoda("-1", "K"), VeloxUserError);
+  EXPECT_THROW(parseJoda("123456789", "K"), VeloxUserError);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseClockHourOfHalfDay) {
-  EXPECT_EQ(util::fromTimestampString("1970-01-01 07:00:00"), parse("7", "h"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("12", "hh"));
+      util::fromTimestampString("1970-01-01 07:00:00"), parseJoda("7", "h"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"), parse("1", "hhh"));
+      util::fromTimestampString("1970-01-01 00:00:00"), parseJoda("12", "hh"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 01:00:00"), parseJoda("1", "hhh"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 10:00:00"),
-      parse("10", "hhhhhhhh"));
+      parseJoda("10", "hhhhhhhh"));
 
   // Clock hour of half day invalid
-  EXPECT_THROW(parse("13", "h"), VeloxUserError);
-  EXPECT_THROW(parse("0", "h"), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "h"), VeloxUserError);
+  EXPECT_THROW(parseJoda("13", "h"), VeloxUserError);
+  EXPECT_THROW(parseJoda("0", "h"), VeloxUserError);
+  EXPECT_THROW(parseJoda("123456789", "h"), VeloxUserError);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseHalfOfDay) {
   // Half of day has no effect if hour or clockhour of day is provided
   // hour of day tests
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parse("7 PM", "H a"));
+      util::fromTimestampString("1970-01-01 07:00:00"),
+      parseJoda("7 PM", "H a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parse("7 AM", "H a"));
+      util::fromTimestampString("1970-01-01 07:00:00"),
+      parseJoda("7 AM", "H a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parse("7 pm", "H a"));
+      util::fromTimestampString("1970-01-01 07:00:00"),
+      parseJoda("7 pm", "H a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parse("7 am", "H a"));
+      util::fromTimestampString("1970-01-01 07:00:00"),
+      parseJoda("7 am", "H a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("0 PM", "H a"));
+      util::fromTimestampString("1970-01-01 00:00:00"),
+      parseJoda("0 PM", "H a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("0 AM", "H a"));
+      util::fromTimestampString("1970-01-01 00:00:00"),
+      parseJoda("0 AM", "H a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("0 pm", "H a"));
+      util::fromTimestampString("1970-01-01 00:00:00"),
+      parseJoda("0 pm", "H a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("0 am", "H a"));
+      util::fromTimestampString("1970-01-01 00:00:00"),
+      parseJoda("0 am", "H a"));
 
   // clock hour of day tests
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parse("7 PM", "k a"));
+      util::fromTimestampString("1970-01-01 07:00:00"),
+      parseJoda("7 PM", "k a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parse("7 AM", "k a"));
+      util::fromTimestampString("1970-01-01 07:00:00"),
+      parseJoda("7 AM", "k a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parse("7 pm", "k a"));
+      util::fromTimestampString("1970-01-01 07:00:00"),
+      parseJoda("7 pm", "k a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"), parse("7 am", "k a"));
+      util::fromTimestampString("1970-01-01 07:00:00"),
+      parseJoda("7 am", "k a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("24 PM", "k a"));
+      util::fromTimestampString("1970-01-01 00:00:00"),
+      parseJoda("24 PM", "k a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("24 AM", "k a"));
+      util::fromTimestampString("1970-01-01 00:00:00"),
+      parseJoda("24 AM", "k a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("24 pm", "k a"));
+      util::fromTimestampString("1970-01-01 00:00:00"),
+      parseJoda("24 pm", "k a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("24 am", "k a"));
+      util::fromTimestampString("1970-01-01 00:00:00"),
+      parseJoda("24 am", "k a"));
 
   // Half of day has effect if hour or clockhour of halfday is provided
   // hour of halfday tests
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 12:00:00"), parse("0 PM", "K a"));
+      util::fromTimestampString("1970-01-01 12:00:00"),
+      parseJoda("0 PM", "K a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("0 AM", "K a"));
+      util::fromTimestampString("1970-01-01 00:00:00"),
+      parseJoda("0 AM", "K a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 18:00:00"), parse("6 PM", "K a"));
+      util::fromTimestampString("1970-01-01 18:00:00"),
+      parseJoda("6 PM", "K a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 06:00:00"), parse("6 AM", "K a"));
+      util::fromTimestampString("1970-01-01 06:00:00"),
+      parseJoda("6 AM", "K a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 23:00:00"), parse("11 PM", "K a"));
+      util::fromTimestampString("1970-01-01 23:00:00"),
+      parseJoda("11 PM", "K a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 11:00:00"), parse("11 AM", "K a"));
+      util::fromTimestampString("1970-01-01 11:00:00"),
+      parseJoda("11 AM", "K a"));
 
   // clockhour of halfday tests
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 13:00:00"), parse("1 PM", "h a"));
+      util::fromTimestampString("1970-01-01 13:00:00"),
+      parseJoda("1 PM", "h a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"), parse("1 AM", "h a"));
+      util::fromTimestampString("1970-01-01 01:00:00"),
+      parseJoda("1 AM", "h a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 18:00:00"), parse("6 PM", "h a"));
+      util::fromTimestampString("1970-01-01 18:00:00"),
+      parseJoda("6 PM", "h a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 06:00:00"), parse("6 AM", "h a"));
+      util::fromTimestampString("1970-01-01 06:00:00"),
+      parseJoda("6 AM", "h a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 12:00:00"), parse("12 PM", "h a"));
+      util::fromTimestampString("1970-01-01 12:00:00"),
+      parseJoda("12 PM", "h a"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("12 AM", "h a"));
+      util::fromTimestampString("1970-01-01 00:00:00"),
+      parseJoda("12 AM", "h a"));
 
   // time gives precendent to most recent time specifier
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 01:00:00"),
-      parse("0 1 AM", "H h a"));
+      parseJoda("0 1 AM", "H h a"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 13:00:00"),
-      parse("12 1 PM", "H h a"));
+      parseJoda("12 1 PM", "H h a"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("1 AM 0", "h a H"));
+      parseJoda("1 AM 0", "h a H"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 12:00:00"),
-      parse("1 AM 12", "h a H"));
+      parseJoda("1 AM 12", "h a H"));
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseMinute) {
-  EXPECT_EQ(util::fromTimestampString("1970-01-01 00:08:00"), parse("8", "m"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:59:00"), parse("59", "mm"));
+      util::fromTimestampString("1970-01-01 00:08:00"), parseJoda("8", "m"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("0/", "mmm/"));
+      util::fromTimestampString("1970-01-01 00:59:00"), parseJoda("59", "mm"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 00:00:00"),
+      parseJoda("0/", "mmm/"));
 
-  EXPECT_THROW(parse("60", "m"), VeloxUserError);
-  EXPECT_THROW(parse("-1", "m"), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "m"), VeloxUserError);
+  EXPECT_THROW(parseJoda("60", "m"), VeloxUserError);
+  EXPECT_THROW(parseJoda("-1", "m"), VeloxUserError);
+  EXPECT_THROW(parseJoda("123456789", "m"), VeloxUserError);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseSecond) {
-  EXPECT_EQ(util::fromTimestampString("1970-01-01 00:00:09"), parse("9", "s"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:58"), parse("58", "ss"));
+      util::fromTimestampString("1970-01-01 00:00:09"), parseJoda("9", "s"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"), parse("0/", "s/"));
+      util::fromTimestampString("1970-01-01 00:00:58"), parseJoda("58", "ss"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 00:00:00"), parseJoda("0/", "s/"));
 
-  EXPECT_THROW(parse("60", "s"), VeloxUserError);
-  EXPECT_THROW(parse("-1", "s"), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "s"), VeloxUserError);
+  EXPECT_THROW(parseJoda("60", "s"), VeloxUserError);
+  EXPECT_THROW(parseJoda("-1", "s"), VeloxUserError);
+  EXPECT_THROW(parseJoda("123456789", "s"), VeloxUserError);
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseTimezone) {
   // Broken timezone offfsets; allowed formats are either "+00:00" or "+00".
-  EXPECT_THROW(parse("", "ZZ"), VeloxUserError);
-  EXPECT_THROW(parse("0", "ZZ"), VeloxUserError);
-  EXPECT_THROW(parse("00", "ZZ"), VeloxUserError);
-  EXPECT_THROW(parse(":00", "ZZ"), VeloxUserError);
-  EXPECT_THROW(parse("+0", "ZZ"), VeloxUserError);
-  EXPECT_THROW(parse("+00:", "ZZ"), VeloxUserError);
-  EXPECT_THROW(parse("+00:0", "ZZ"), VeloxUserError);
-  EXPECT_THROW(parse("12", "YYZZ"), VeloxUserError);
-  EXPECT_THROW(parse("ZZ", "Z"), VeloxUserError);
-  EXPECT_THROW(parse("ZZ", "ZZ"), VeloxUserError);
+  EXPECT_THROW(parseJoda("", "ZZ"), VeloxUserError);
+  EXPECT_THROW(parseJoda("0", "ZZ"), VeloxUserError);
+  EXPECT_THROW(parseJoda("00", "ZZ"), VeloxUserError);
+  EXPECT_THROW(parseJoda(":00", "ZZ"), VeloxUserError);
+  EXPECT_THROW(parseJoda("+0", "ZZ"), VeloxUserError);
+  EXPECT_THROW(parseJoda("+00:", "ZZ"), VeloxUserError);
+  EXPECT_THROW(parseJoda("+00:0", "ZZ"), VeloxUserError);
+  EXPECT_THROW(parseJoda("12", "YYZZ"), VeloxUserError);
+  EXPECT_THROW(parseJoda("ZZ", "Z"), VeloxUserError);
+  EXPECT_THROW(parseJoda("ZZ", "ZZ"), VeloxUserError);
 
   // GMT
   EXPECT_EQ("+00:00", parseTZ("+00:00", "ZZ"));
@@ -897,16 +973,16 @@ TEST_F(JodaDateTimeFormatterTest, parseMixedYMDFormat) {
   // Common patterns found.
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 23:00:00"),
-      parse("2021-01-04+23:00", "YYYY-MM-dd+HH:mm"));
+      parseJoda("2021-01-04+23:00", "YYYY-MM-dd+HH:mm"));
 
   EXPECT_EQ(
       util::fromTimestampString("2019-07-03 11:04:10"),
-      parse("2019-07-03 11:04:10", "YYYY-MM-dd HH:mm:ss"));
+      parseJoda("2019-07-03 11:04:10", "YYYY-MM-dd HH:mm:ss"));
 
   // Backwards, just for fun:
   EXPECT_EQ(
       util::fromTimestampString("2019-07-03 11:04:10"),
-      parse("10:04:11 03-07-2019", "ss:mm:HH dd-MM-YYYY"));
+      parseJoda("10:04:11 03-07-2019", "ss:mm:HH dd-MM-YYYY"));
 
   // Include timezone.
   auto result = parseAll("2021-11-05+01:00+09:00", "YYYY-MM-dd+HH:mmZZ");
@@ -926,114 +1002,114 @@ TEST_F(JodaDateTimeFormatterTest, parseMixedYMDFormat) {
   // Z in the input means GMT in Joda.
   EXPECT_EQ(
       util::fromTimestampString("2022-07-29 20:03:54.667"),
-      parse("2022-07-29T20:03:54.667Z", "yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
+      parseJoda("2022-07-29T20:03:54.667Z", "yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseMixedWeekFormat) {
   // Common patterns found.
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 1 13:29:21.213", "x w e HH:mm:ss.SSS"));
+      parseJoda("2021 1 1 13:29:21.213", "x w e HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 1 13:29:21.213", "x w e HH:mm:ss.SSS"));
+      parseJoda("2021 22 1 13:29:21.213", "x w e HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 4 13:29:21.213", "x w e HH:mm:ss.SSS"));
+      parseJoda("2021 22 4 13:29:21.213", "x w e HH:mm:ss.SSS"));
 
   // Day of week short text normal capitlization
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 Mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
+      parseJoda("2021 1 Mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 Mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
+      parseJoda("2021 22 Mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 Thu 13:29:21.213", "x w E HH:mm:ss.SSS"));
+      parseJoda("2021 22 Thu 13:29:21.213", "x w E HH:mm:ss.SSS"));
 
   // Day of week long text normal capitlization
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 Monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+      parseJoda("2021 1 Monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 Monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+      parseJoda("2021 22 Monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 Thursday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+      parseJoda("2021 22 Thursday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
 
   // Day of week short text upper case
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 MON 13:29:21.213", "x w E HH:mm:ss.SSS"));
+      parseJoda("2021 1 MON 13:29:21.213", "x w E HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 MON 13:29:21.213", "x w E HH:mm:ss.SSS"));
+      parseJoda("2021 22 MON 13:29:21.213", "x w E HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 THU 13:29:21.213", "x w E HH:mm:ss.SSS"));
+      parseJoda("2021 22 THU 13:29:21.213", "x w E HH:mm:ss.SSS"));
 
   // Day of week long text upper case
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 MONDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+      parseJoda("2021 1 MONDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 MONDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+      parseJoda("2021 22 MONDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 THURSDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+      parseJoda("2021 22 THURSDAY 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
 
   // Day of week short text lower case
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
+      parseJoda("2021 1 mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
+      parseJoda("2021 22 mon 13:29:21.213", "x w E HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 thu 13:29:21.213", "x w E HH:mm:ss.SSS"));
+      parseJoda("2021 22 thu 13:29:21.213", "x w E HH:mm:ss.SSS"));
 
   // Day of week long text lower case
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+      parseJoda("2021 1 monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+      parseJoda("2021 22 monday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 thursday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
+      parseJoda("2021 22 thursday 13:29:21.213", "x w EEE HH:mm:ss.SSS"));
 
   // Invalid day of week throw cases
-  EXPECT_THROW(parse("mOn", "E"), VeloxUserError);
-  EXPECT_THROW(parse("tuE", "E"), VeloxUserError);
-  EXPECT_THROW(parse("WeD", "E"), VeloxUserError);
-  EXPECT_THROW(parse("WEd", "E"), VeloxUserError);
-  EXPECT_THROW(parse("MONday", "EEE"), VeloxUserError);
-  EXPECT_THROW(parse("monDAY", "EEE"), VeloxUserError);
-  EXPECT_THROW(parse("frIday", "EEE"), VeloxUserError);
+  EXPECT_THROW(parseJoda("mOn", "E"), VeloxUserError);
+  EXPECT_THROW(parseJoda("tuE", "E"), VeloxUserError);
+  EXPECT_THROW(parseJoda("WeD", "E"), VeloxUserError);
+  EXPECT_THROW(parseJoda("WEd", "E"), VeloxUserError);
+  EXPECT_THROW(parseJoda("MONday", "EEE"), VeloxUserError);
+  EXPECT_THROW(parseJoda("monDAY", "EEE"), VeloxUserError);
+  EXPECT_THROW(parseJoda("frIday", "EEE"), VeloxUserError);
 
   // Backwards, just for fun:
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("213.21:29:13 1 22 2021", "SSS.ss:mm:HH e w x"));
+      parseJoda("213.21:29:13 1 22 2021", "SSS.ss:mm:HH e w x"));
 
   // Include timezone.
   auto result =
@@ -1073,39 +1149,59 @@ TEST_F(JodaDateTimeFormatterTest, parseFractionOfSecond) {
   // Valid milliseconds.
   EXPECT_EQ(
       util::fromTimestampString("2022-02-24 02:19:33.283"),
-      parse("2022-02-24 02:19:33.283", "yyyy-MM-dd HH:mm:ss.SSS"));
+      parseJoda("2022-02-24 02:19:33.283", "yyyy-MM-dd HH:mm:ss.SSS"));
 
   // Test without milliseconds.
   EXPECT_EQ(
       util::fromTimestampString("2022-02-23 20:30:00"),
-      parse("2022-02-23T20:30:00", "yyyy-MM-dd'T'HH:mm:ss"));
+      parseJoda("2022-02-23T20:30:00", "yyyy-MM-dd'T'HH:mm:ss"));
 
   // Assert on difference in milliseconds.
   EXPECT_NE(
       util::fromTimestampString("2022-02-23 12:15:00.223"),
-      parse("2022-02-23T12:15:00.776", "yyyy-MM-dd'T'HH:mm:ss.SSS"));
+      parseJoda("2022-02-23T12:15:00.776", "yyyy-MM-dd'T'HH:mm:ss.SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00.000"),
-      parse("000", "SSS"));
+      parseJoda("000", "SSS"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00.001"),
-      parse("001", "SSS"));
+      parseJoda("001", "SSS"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00.999"),
-      parse("999", "SSS"));
+      parseJoda("999", "SSS"));
 
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00.045"),
-      parse("045", "SSS"));
-  EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00.450"), parse("45", "SS"));
+      parseJoda("045", "SSS"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00.450"),
-      parse("45", "SSSS"));
+      parseJoda("45", "SS"));
+  EXPECT_EQ(
+      util::fromTimestampString("1970-01-01 00:00:00.450"),
+      parseJoda("45", "SSSS"));
 
-  EXPECT_THROW(parse("-1", "S"), VeloxUserError);
-  EXPECT_THROW(parse("999", "S"), VeloxUserError);
+  EXPECT_THROW(parseJoda("-1", "S"), VeloxUserError);
+  EXPECT_THROW(parseJoda("999", "S"), VeloxUserError);
+}
+
+TEST_F(JodaDateTimeFormatterTest, parseConsecutiveSpecifiers) {
+  EXPECT_EQ(util::fromTimestampString("2012-12-01"), parseJoda("1212", "YYM"));
+  EXPECT_EQ(util::fromTimestampString("0012-12-01"), parseJoda("1212", "MY"));
+  EXPECT_THROW(parseJoda("1212", "YM"), VeloxUserError);
+
+  EXPECT_EQ(
+      util::fromTimestampString("2012-01-01 12:00:00"),
+      parseJoda("1212", "YYH"));
+  EXPECT_EQ(
+      util::fromTimestampString("0012-01-01 12:00:00"),
+      parseJoda("1212", "HY"));
+  EXPECT_THROW(parseJoda("1212", "YH"), VeloxUserError);
+
+  EXPECT_EQ(
+      util::fromTimestampString("2012-01-01 12:00:00"),
+      parseJoda("1212", "yyH"));
+  EXPECT_THROW(parseJoda("12312", "yyH"), VeloxUserError);
 }
 
 class MysqlDateTimeTest : public DateTimeFormatterTest {};
@@ -1534,121 +1630,117 @@ TEST_F(MysqlDateTimeTest, formatCompositeTime) {
 
 // Same semantic as YEAR_OF_ERA, except that it accepts zero and negative years.
 TEST_F(MysqlDateTimeTest, parseFourDigitYear) {
-  EXPECT_EQ(util::fromTimestampString("123-01-01"), parse("123", "%Y", false));
-  EXPECT_EQ(util::fromTimestampString("321-01-01"), parse("321", "%Y", false));
+  EXPECT_EQ(util::fromTimestampString("123-01-01"), parseMysql("123", "%Y"));
+  EXPECT_EQ(util::fromTimestampString("321-01-01"), parseMysql("321", "%Y"));
 
-  EXPECT_EQ(util::fromTimestampString("0-01-01"), parse("0", "%Y", false));
-  EXPECT_EQ(util::fromTimestampString("-1-01-01"), parse("-1", "%Y", false));
+  EXPECT_EQ(util::fromTimestampString("0-01-01"), parseMysql("0", "%Y"));
+  EXPECT_EQ(util::fromTimestampString("-1-01-01"), parseMysql("-1", "%Y"));
   EXPECT_EQ(
-      util::fromTimestampString("-1234-01-01"), parse("-1234", "%Y", false));
+      util::fromTimestampString("-1234-01-01"), parseMysql("-1234", "%Y"));
 
   // Last token read overwrites:
-  EXPECT_EQ(
-      util::fromTimestampString("0-01-01"), parse("123 0", "%Y %Y", false));
+  EXPECT_EQ(util::fromTimestampString("0-01-01"), parseMysql("123 0", "%Y %Y"));
 
   // Plus sign consumption valid when %Y operator is not followed by another
   // specifier
-  EXPECT_EQ(util::fromTimestampString("10-01-01"), parse("+10", "%Y", false));
+  EXPECT_EQ(util::fromTimestampString("10-01-01"), parseMysql("+10", "%Y"));
   EXPECT_EQ(
-      util::fromTimestampString("99-02-01"), parse("+99 02", "%Y %m", false));
+      util::fromTimestampString("99-02-01"), parseMysql("+99 02", "%Y %m"));
   EXPECT_EQ(
-      util::fromTimestampString("10-10-01"), parse("10 +10", "%m %Y", false));
+      util::fromTimestampString("10-10-01"), parseMysql("10 +10", "%m %Y"));
   EXPECT_EQ(
-      util::fromTimestampString("100-02-01"), parse("2+100", "%m%Y", false));
-  EXPECT_THROW(parse("+10001", "%Y%m", false), VeloxUserError);
-  EXPECT_THROW(parse("++100", "%Y", false), VeloxUserError);
+      util::fromTimestampString("100-02-01"), parseMysql("2+100", "%m%Y"));
+  EXPECT_THROW(parseMysql("+10001", "%Y%m"), VeloxUserError);
+  EXPECT_THROW(parseMysql("++100", "%Y"), VeloxUserError);
 
   // Probe the year range
-  EXPECT_THROW(parse("-10000", "%Y"), VeloxUserError);
-  EXPECT_THROW(parse("10000", "%Y"), VeloxUserError);
+  EXPECT_THROW(parseMysql("-10000", "%Y"), VeloxUserError);
+  EXPECT_THROW(parseMysql("10000", "%Y"), VeloxUserError);
+  EXPECT_EQ(util::fromTimestampString("9999-01-01"), parseMysql("9999", "%Y"));
 }
 
 TEST_F(MysqlDateTimeTest, parseTwoDigitYear) {
-  EXPECT_EQ(util::fromTimestampString("1970-01-01"), parse("70", "%y", false));
-  EXPECT_EQ(util::fromTimestampString("2069-01-01"), parse("69", "%y", false));
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("00", "%y", false));
+  EXPECT_EQ(util::fromTimestampString("1970-01-01"), parseMysql("70", "%y"));
+  EXPECT_EQ(util::fromTimestampString("2069-01-01"), parseMysql("69", "%y"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("00", "%y"));
 
   // Last token read overwrites:
   EXPECT_EQ(
-      util::fromTimestampString("2030-01-01"), parse("80 30", "%y %y", false));
+      util::fromTimestampString("2030-01-01"), parseMysql("80 30", "%y %y"));
 }
 
 TEST_F(MysqlDateTimeTest, parseWeekYear) {
   // Covers entire range of possible week year start dates (12-29 to 01-04)
   EXPECT_EQ(
       util::fromTimestampString("1969-12-29 00:00:00"),
-      parse("1970", "%x", false));
+      parseMysql("1970", "%x"));
   EXPECT_EQ(
       util::fromTimestampString("2024-12-30 00:00:00"),
-      parse("2025", "%x", false));
+      parseMysql("2025", "%x"));
   EXPECT_EQ(
       util::fromTimestampString("1934-12-31 00:00:00"),
-      parse("1935", "%x", false));
+      parseMysql("1935", "%x"));
   EXPECT_EQ(
       util::fromTimestampString("1990-01-01 00:00:00"),
-      parse("1990", "%x", false));
+      parseMysql("1990", "%x"));
   EXPECT_EQ(
       util::fromTimestampString("0204-01-02 00:00:00"),
-      parse("204", "%x", false));
+      parseMysql("204", "%x"));
   EXPECT_EQ(
       util::fromTimestampString("-0102-01-03 00:00:00"),
-      parse("-102", "%x", false));
+      parseMysql("-102", "%x"));
   EXPECT_EQ(
       util::fromTimestampString("-0108-01-04 00:00:00"),
-      parse("-108", "%x", false));
+      parseMysql("-108", "%x"));
   EXPECT_EQ(
       util::fromTimestampString("-1002-12-31 00:00:00"),
-      parse("-1001", "%x", false));
+      parseMysql("-1001", "%x"));
 
   // Plus sign consumption valid when %x operator is not followed by another
   // specifier
-  EXPECT_EQ(util::fromTimestampString("10-01-04"), parse("+10", "%x", false));
+  EXPECT_EQ(util::fromTimestampString("10-01-04"), parseMysql("+10", "%x"));
   EXPECT_EQ(
-      util::fromTimestampString("0098-12-29"), parse("+99 01", "%x %v", false));
+      util::fromTimestampString("0098-12-29"), parseMysql("+99 01", "%x %v"));
   EXPECT_EQ(
-      util::fromTimestampString("0099-01-05"), parse("+99 02", "%x %v", false));
+      util::fromTimestampString("0099-01-05"), parseMysql("+99 02", "%x %v"));
   EXPECT_EQ(
-      util::fromTimestampString("10-03-08"), parse("10 +10", "%v %x", false));
+      util::fromTimestampString("10-03-08"), parseMysql("10 +10", "%v %x"));
   EXPECT_EQ(
-      util::fromTimestampString("100-01-11"), parse("2+100", "%v%x", false));
-  EXPECT_THROW(parse("+10001", "%x%m", false), VeloxUserError);
-  EXPECT_THROW(parse("++100", "%x", false), VeloxUserError);
+      util::fromTimestampString("100-01-11"), parseMysql("2+100", "%v%x"));
+  EXPECT_THROW(parseMysql("+10001", "%x%m"), VeloxUserError);
+  EXPECT_THROW(parseMysql("++100", "%x"), VeloxUserError);
 
   // Probe week year range
-  EXPECT_THROW(parse("-292275055", "%x", false), VeloxUserError);
-  EXPECT_THROW(parse("292278994", "%x", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("-292275055", "%x"), VeloxUserError);
+  EXPECT_THROW(parseMysql("292278994", "%x"), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, parseMonth) {
   // Joda has this weird behavior where if minute or hour is specified, year
   // falls back to 2000, instead of epoch (1970)  ¯\_(ツ)_/¯
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("1", "%m", false));
-  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parse(" 7", " %m", false));
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("01", "%m", false));
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("1", "%m"));
+  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parseMysql(" 7", " %m"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("01", "%m"));
+  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parseMysql(" 07", " %m"));
+  EXPECT_EQ(util::fromTimestampString("2000-11-01"), parseMysql("11-", "%m-"));
   EXPECT_EQ(
-      util::fromTimestampString("2000-07-01"), parse(" 07", " %m", false));
-  EXPECT_EQ(
-      util::fromTimestampString("2000-11-01"), parse("11-", "%m-", false));
-  EXPECT_EQ(
-      util::fromTimestampString("2000-12-01"), parse("-12-", "-%m-", false));
+      util::fromTimestampString("2000-12-01"), parseMysql("-12-", "-%m-"));
 
-  EXPECT_THROW(parse("0", "%m", false), VeloxUserError);
-  EXPECT_THROW(parse("13", "%m", false), VeloxUserError);
-  EXPECT_THROW(parse("12345", "%m", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("0", "%m"), VeloxUserError);
+  EXPECT_THROW(parseMysql("13", "%m"), VeloxUserError);
+  EXPECT_THROW(parseMysql("12345", "%m"), VeloxUserError);
 
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("1", "%c", false));
-  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parse(" 7", " %c", false));
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("01", "%c", false));
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("1", "%c"));
+  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parseMysql(" 7", " %c"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("01", "%c"));
+  EXPECT_EQ(util::fromTimestampString("2000-07-01"), parseMysql(" 07", " %c"));
+  EXPECT_EQ(util::fromTimestampString("2000-11-01"), parseMysql("11-", "%c-"));
   EXPECT_EQ(
-      util::fromTimestampString("2000-07-01"), parse(" 07", " %c", false));
-  EXPECT_EQ(
-      util::fromTimestampString("2000-11-01"), parse("11-", "%c-", false));
-  EXPECT_EQ(
-      util::fromTimestampString("2000-12-01"), parse("-12-", "-%c-", false));
+      util::fromTimestampString("2000-12-01"), parseMysql("-12-", "-%c-"));
 
-  EXPECT_THROW(parse("0", "%c", false), VeloxUserError);
-  EXPECT_THROW(parse("13", "%c", false), VeloxUserError);
-  EXPECT_THROW(parse("12345", "%c", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("0", "%c"), VeloxUserError);
+  EXPECT_THROW(parseMysql("13", "%c"), VeloxUserError);
+  EXPECT_THROW(parseMysql("12345", "%c"), VeloxUserError);
 
   // Ensure %b and %M specifiers consume both short- and long-form month
   // names
@@ -1656,219 +1748,192 @@ TEST_F(MysqlDateTimeTest, parseMonth) {
     StringView buildString("2000-" + std::to_string(i + 1) + "-01");
     EXPECT_EQ(
         util::fromTimestampString(buildString),
-        parse(monthsShort[i], "%b", false));
+        parseMysql(monthsShort[i], "%b"));
     EXPECT_EQ(
         util::fromTimestampString(buildString),
-        parse(monthsFull[i], "%b", false));
+        parseMysql(monthsFull[i], "%b"));
     EXPECT_EQ(
         util::fromTimestampString(buildString),
-        parse(monthsShort[i], "%M", false));
+        parseMysql(monthsShort[i], "%M"));
     EXPECT_EQ(
         util::fromTimestampString(buildString),
-        parse(monthsFull[i], "%M", false));
+        parseMysql(monthsFull[i], "%M"));
   }
 
   // Month name invalid parse
-  EXPECT_THROW(parse("Decembr", "%b", false), VeloxUserError);
-  EXPECT_THROW(parse("Decembr", "%M", false), VeloxUserError);
-  EXPECT_THROW(parse("Decemberary", "%b", false), VeloxUserError);
-  EXPECT_THROW(parse("Decemberary", "%M", false), VeloxUserError);
-  EXPECT_THROW(parse("asdf", "%b", false), VeloxUserError);
-  EXPECT_THROW(parse("asdf", "%M", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("Decembr", "%b"), VeloxUserError);
+  EXPECT_THROW(parseMysql("Decembr", "%M"), VeloxUserError);
+  EXPECT_THROW(parseMysql("Decemberary", "%b"), VeloxUserError);
+  EXPECT_THROW(parseMysql("Decemberary", "%M"), VeloxUserError);
+  EXPECT_THROW(parseMysql("asdf", "%b"), VeloxUserError);
+  EXPECT_THROW(parseMysql("asdf", "%M"), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, parseDayOfMonth) {
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("1", "%d", false));
-  EXPECT_EQ(util::fromTimestampString("2000-01-07"), parse("7 ", "%d ", false));
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("1", "%d"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-07"), parseMysql("7 ", "%d "));
+  EXPECT_EQ(util::fromTimestampString("2000-01-11"), parseMysql("/11", "/%d"));
   EXPECT_EQ(
-      util::fromTimestampString("2000-01-11"), parse("/11", "/%d", false));
-  EXPECT_EQ(
-      util::fromTimestampString("2000-01-31"), parse("/31/", "/%d/", false));
+      util::fromTimestampString("2000-01-31"), parseMysql("/31/", "/%d/"));
 
-  EXPECT_THROW(parse("0", "%d", false), VeloxUserError);
-  EXPECT_THROW(parse("32", "%d", false), VeloxUserError);
-  EXPECT_THROW(parse("12345", "%d", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("0", "%d"), VeloxUserError);
+  EXPECT_THROW(parseMysql("32", "%d"), VeloxUserError);
+  EXPECT_THROW(parseMysql("12345", "%d"), VeloxUserError);
 
-  EXPECT_THROW(parse("02-31", "%m-%d", false), VeloxUserError);
-  EXPECT_THROW(parse("04-31", "%m-%d", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("02-31", "%m-%d"), VeloxUserError);
+  EXPECT_THROW(parseMysql("04-31", "%m-%d"), VeloxUserError);
 
   // Ensure all days of month are checked against final selected month
-  EXPECT_THROW(parse("1 31 20 2", "%m %d %d %m", false), VeloxUserError);
-  EXPECT_THROW(parse("2 31 20 4", "%m %d %d %m", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("1 31 20 2", "%m %d %d %m"), VeloxUserError);
+  EXPECT_THROW(parseMysql("2 31 20 4", "%m %d %d %m"), VeloxUserError);
   EXPECT_EQ(
       util::fromTimestampString("2000-01-31"),
-      parse("2 31 1", "%m %d %m", false));
+      parseMysql("2 31 1", "%m %d %m"));
 
   // Probe around leap year.
   EXPECT_EQ(
       util::fromTimestampString("2000-02-29"),
-      parse("2000-02-29", "%Y-%m-%d", false));
-  EXPECT_THROW(parse("2001-02-29", "%Y-%m-%d", false), VeloxUserError);
+      parseMysql("2000-02-29", "%Y-%m-%d"));
+  EXPECT_THROW(parseMysql("2001-02-29", "%Y-%m-%d"), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, parseDayOfYear) {
   // Just day of year specifier should default to 2000. Also covers leap year
   // case
-  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parse("1", "%j", false));
-  EXPECT_EQ(util::fromTimestampString("2000-01-07"), parse("7 ", "%j ", false));
+  EXPECT_EQ(util::fromTimestampString("2000-01-01"), parseMysql("1", "%j"));
+  EXPECT_EQ(util::fromTimestampString("2000-01-07"), parseMysql("7 ", "%j "));
+  EXPECT_EQ(util::fromTimestampString("2000-01-11"), parseMysql("/11", "/%j"));
   EXPECT_EQ(
-      util::fromTimestampString("2000-01-11"), parse("/11", "/%j", false));
-  EXPECT_EQ(
-      util::fromTimestampString("2000-01-31"), parse("/31/", "/%j/", false));
-  EXPECT_EQ(util::fromTimestampString("2000-02-01"), parse("32", "%j", false));
-  EXPECT_EQ(util::fromTimestampString("2000-02-29"), parse("60", "%j", false));
-  EXPECT_EQ(util::fromTimestampString("2000-12-30"), parse("365", "%j", false));
-  EXPECT_EQ(util::fromTimestampString("2000-12-31"), parse("366", "%j", false));
+      util::fromTimestampString("2000-01-31"), parseMysql("/31/", "/%j/"));
+  EXPECT_EQ(util::fromTimestampString("2000-02-01"), parseMysql("32", "%j"));
+  EXPECT_EQ(util::fromTimestampString("2000-02-29"), parseMysql("60", "%j"));
+  EXPECT_EQ(util::fromTimestampString("2000-12-30"), parseMysql("365", "%j"));
+  EXPECT_EQ(util::fromTimestampString("2000-12-31"), parseMysql("366", "%j"));
 
   // Year specified cases
   EXPECT_EQ(
-      util::fromTimestampString("1950-01-01"), parse("1950 1", "%Y %j", false));
+      util::fromTimestampString("1950-01-01"), parseMysql("1950 1", "%Y %j"));
   EXPECT_EQ(
-      util::fromTimestampString("1950-01-07"),
-      parse("1950 7 ", "%Y %j ", false));
+      util::fromTimestampString("1950-01-07"), parseMysql("1950 7 ", "%Y %j "));
   EXPECT_EQ(
       util::fromTimestampString("1950-01-11"),
-      parse("1950 /11", "%Y /%j", false));
+      parseMysql("1950 /11", "%Y /%j"));
   EXPECT_EQ(
       util::fromTimestampString("1950-01-31"),
-      parse("1950 /31/", "%Y /%j/", false));
+      parseMysql("1950 /31/", "%Y /%j/"));
   EXPECT_EQ(
-      util::fromTimestampString("1950-02-01"),
-      parse("1950 32", "%Y %j", false));
+      util::fromTimestampString("1950-02-01"), parseMysql("1950 32", "%Y %j"));
   EXPECT_EQ(
-      util::fromTimestampString("1950-03-01"),
-      parse("1950 60", "%Y %j", false));
+      util::fromTimestampString("1950-03-01"), parseMysql("1950 60", "%Y %j"));
   EXPECT_EQ(
-      util::fromTimestampString("1950-12-31"),
-      parse("1950 365", "%Y %j", false));
-  EXPECT_THROW(parse("1950 366", "%Y %j"), VeloxUserError);
+      util::fromTimestampString("1950-12-31"), parseMysql("1950 365", "%Y %j"));
+  EXPECT_THROW(parseMysql("1950 366", "%Y %j"), VeloxUserError);
 
   // Negative year specified cases
   EXPECT_EQ(
-      util::fromTimestampString("-1950-01-01"),
-      parse("-1950 1", "%Y %j", false));
+      util::fromTimestampString("-1950-01-01"), parseMysql("-1950 1", "%Y %j"));
   EXPECT_EQ(
       util::fromTimestampString("-1950-01-07"),
-      parse("-1950 7 ", "%Y %j ", false));
+      parseMysql("-1950 7 ", "%Y %j "));
   EXPECT_EQ(
       util::fromTimestampString("-1950-01-11"),
-      parse("-1950 /11", "%Y /%j", false));
+      parseMysql("-1950 /11", "%Y /%j"));
   EXPECT_EQ(
       util::fromTimestampString("-1950-01-31"),
-      parse("-1950 /31/", "%Y /%j/", false));
+      parseMysql("-1950 /31/", "%Y /%j/"));
   EXPECT_EQ(
       util::fromTimestampString("-1950-02-01"),
-      parse("-1950 32", "%Y %j", false));
+      parseMysql("-1950 32", "%Y %j"));
   EXPECT_EQ(
       util::fromTimestampString("-1950-03-01"),
-      parse("-1950 60", "%Y %j", false));
+      parseMysql("-1950 60", "%Y %j"));
   EXPECT_EQ(
       util::fromTimestampString("-1950-12-31"),
-      parse("-1950 365", "%Y %j", false));
-  EXPECT_THROW(parse("-1950 366", "%Y %j", false), VeloxUserError);
+      parseMysql("-1950 365", "%Y %j"));
+  EXPECT_THROW(parseMysql("-1950 366", "%Y %j"), VeloxUserError);
 
   // Ensure all days of year are checked against final selected year
-  EXPECT_THROW(parse("2000 366 2001", "%Y %j %Y", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("2000 366 2001", "%Y %j %Y"), VeloxUserError);
   EXPECT_EQ(
       util::fromTimestampString("2000-12-31"),
-      parse("2001 366 2000", "%Y %j %Y", false));
+      parseMysql("2001 366 2000", "%Y %j %Y"));
 
-  EXPECT_THROW(parse("0", "%j", false), VeloxUserError);
-  EXPECT_THROW(parse("367", "%j", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("0", "%j"), VeloxUserError);
+  EXPECT_THROW(parseMysql("367", "%j"), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, parseHourOfDay) {
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7", "%H", false));
+      util::fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%H"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 23:00:00"),
-      parse("23", "%H", false));
+      util::fromTimestampString("1970-01-01 23:00:00"), parseMysql("23", "%H"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0", "%H", false));
+      util::fromTimestampString("1970-01-01 00:00:00"), parseMysql("0", "%H"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"),
-      parse("10", "%H", false));
+      util::fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%H"));
 
   // Hour of day invalid
-  EXPECT_THROW(parse("24", "%H", false), VeloxUserError);
-  EXPECT_THROW(parse("-1", "%H", false), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "%H", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("24", "%H"), VeloxUserError);
+  EXPECT_THROW(parseMysql("-1", "%H"), VeloxUserError);
+  EXPECT_THROW(parseMysql("123456789", "%H"), VeloxUserError);
 
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7", "%k", false));
+      util::fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%k"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 23:00:00"),
-      parse("23", "%k", false));
+      util::fromTimestampString("1970-01-01 23:00:00"), parseMysql("23", "%k"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0", "%k", false));
+      util::fromTimestampString("1970-01-01 00:00:00"), parseMysql("0", "%k"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"),
-      parse("10", "%k", false));
+      util::fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%k"));
 
   // Hour of day invalid
-  EXPECT_THROW(parse("24", "%k", false), VeloxUserError);
-  EXPECT_THROW(parse("-1", "%k", false), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "%k", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("24", "%k"), VeloxUserError);
+  EXPECT_THROW(parseMysql("-1", "%k"), VeloxUserError);
+  EXPECT_THROW(parseMysql("123456789", "%k"), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, parseClockHourOfHalfDay) {
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7", "%h", false));
+      util::fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%h"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("12", "%h", false));
+      util::fromTimestampString("1970-01-01 00:00:00"), parseMysql("12", "%h"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"),
-      parse("1", "%h", false));
+      util::fromTimestampString("1970-01-01 01:00:00"), parseMysql("1", "%h"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"),
-      parse("10", "%h", false));
+      util::fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%h"));
 
   // Clock hour of half day invalid
-  EXPECT_THROW(parse("13", "%h", false), VeloxUserError);
-  EXPECT_THROW(parse("0", "%h", false), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "%h", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("13", "%h"), VeloxUserError);
+  EXPECT_THROW(parseMysql("0", "%h"), VeloxUserError);
+  EXPECT_THROW(parseMysql("123456789", "%h"), VeloxUserError);
 
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7", "%I", false));
+      util::fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%I"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("12", "%I", false));
+      util::fromTimestampString("1970-01-01 00:00:00"), parseMysql("12", "%I"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"),
-      parse("1", "%I", false));
+      util::fromTimestampString("1970-01-01 01:00:00"), parseMysql("1", "%I"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"),
-      parse("10", "%I", false));
+      util::fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%I"));
 
   // Clock hour of half day invalid
-  EXPECT_THROW(parse("13", "%l", false), VeloxUserError);
-  EXPECT_THROW(parse("0", "%l", false), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "%l", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("13", "%l"), VeloxUserError);
+  EXPECT_THROW(parseMysql("0", "%l"), VeloxUserError);
+  EXPECT_THROW(parseMysql("123456789", "%l"), VeloxUserError);
 
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7", "%l", false));
+      util::fromTimestampString("1970-01-01 07:00:00"), parseMysql("7", "%l"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("12", "%l", false));
+      util::fromTimestampString("1970-01-01 00:00:00"), parseMysql("12", "%l"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 01:00:00"),
-      parse("1", "%l", false));
+      util::fromTimestampString("1970-01-01 01:00:00"), parseMysql("1", "%l"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 10:00:00"),
-      parse("10", "%l", false));
+      util::fromTimestampString("1970-01-01 10:00:00"), parseMysql("10", "%l"));
 
   // Clock hour of half day invalid
-  EXPECT_THROW(parse("13", "%l", false), VeloxUserError);
-  EXPECT_THROW(parse("0", "%l", false), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "%l", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("13", "%l"), VeloxUserError);
+  EXPECT_THROW(parseMysql("0", "%l"), VeloxUserError);
+  EXPECT_THROW(parseMysql("123456789", "%l"), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, parseHalfOfDay) {
@@ -1876,320 +1941,330 @@ TEST_F(MysqlDateTimeTest, parseHalfOfDay) {
   // hour of day tests
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7 PM", "%H %p", false));
+      parseMysql("7 PM", "%H %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7 AM", "%H %p", false));
+      parseMysql("7 AM", "%H %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7 pm", "%H %p", false));
+      parseMysql("7 pm", "%H %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7 am", "%H %p", false));
+      parseMysql("7 am", "%H %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0 PM", "%H %p", false));
+      parseMysql("0 PM", "%H %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0 AM", "%H %p", false));
+      parseMysql("0 AM", "%H %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0 pm", "%H %p", false));
+      parseMysql("0 pm", "%H %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0 am", "%H %p", false));
+      parseMysql("0 am", "%H %p"));
 
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7 PM", "%k %p", false));
+      parseMysql("7 PM", "%k %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7 AM", "%k %p", false));
+      parseMysql("7 AM", "%k %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7 pm", "%k %p", false));
+      parseMysql("7 pm", "%k %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 07:00:00"),
-      parse("7 am", "%k %p", false));
+      parseMysql("7 am", "%k %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0 PM", "%k %p", false));
+      parseMysql("0 PM", "%k %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0 AM", "%k %p", false));
+      parseMysql("0 AM", "%k %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0 pm", "%k %p", false));
+      parseMysql("0 pm", "%k %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0 am", "%k %p", false));
+      parseMysql("0 am", "%k %p"));
 
   // Half of day has effect if clockhour of halfday is provided
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 13:00:00"),
-      parse("1 PM", "%h %p", false));
+      parseMysql("1 PM", "%h %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 01:00:00"),
-      parse("1 AM", "%h %p", false));
+      parseMysql("1 AM", "%h %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 18:00:00"),
-      parse("6 PM", "%h %p", false));
+      parseMysql("6 PM", "%h %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 06:00:00"),
-      parse("6 AM", "%h %p", false));
+      parseMysql("6 AM", "%h %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 12:00:00"),
-      parse("12 PM", "%h %p", false));
+      parseMysql("12 PM", "%h %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("12 AM", "%h %p", false));
+      parseMysql("12 AM", "%h %p"));
 
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 13:00:00"),
-      parse("1 PM", "%I %p", false));
+      parseMysql("1 PM", "%I %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 01:00:00"),
-      parse("1 AM", "%I %p", false));
+      parseMysql("1 AM", "%I %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 18:00:00"),
-      parse("6 PM", "%I %p", false));
+      parseMysql("6 PM", "%I %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 06:00:00"),
-      parse("6 AM", "%I %p", false));
+      parseMysql("6 AM", "%I %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 12:00:00"),
-      parse("12 PM", "%I %p", false));
+      parseMysql("12 PM", "%I %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("12 AM", "%I %p", false));
+      parseMysql("12 AM", "%I %p"));
 
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 13:00:00"),
-      parse("1 PM", "%l %p", false));
+      parseMysql("1 PM", "%l %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 01:00:00"),
-      parse("1 AM", "%l %p", false));
+      parseMysql("1 AM", "%l %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 18:00:00"),
-      parse("6 PM", "%l %p", false));
+      parseMysql("6 PM", "%l %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 06:00:00"),
-      parse("6 AM", "%l %p", false));
+      parseMysql("6 AM", "%l %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 12:00:00"),
-      parse("12 PM", "%l %p", false));
+      parseMysql("12 PM", "%l %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("12 AM", "%l %p", false));
+      parseMysql("12 AM", "%l %p"));
 
   // time gives precendent to most recent time specifier
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 01:00:00"),
-      parse("0 1 AM", "%H %h %p", false));
+      parseMysql("0 1 AM", "%H %h %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 13:00:00"),
-      parse("12 1 PM", "%H %h %p", false));
+      parseMysql("12 1 PM", "%H %h %p"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("1 AM 0", "%h %p %H", false));
+      parseMysql("1 AM 0", "%h %p %H"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 12:00:00"),
-      parse("1 AM 12", "%h %p %H", false));
+      parseMysql("1 AM 12", "%h %p %H"));
 }
 
 TEST_F(MysqlDateTimeTest, parseMinute) {
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:08:00"),
-      parse("8", "%i", false));
+      util::fromTimestampString("1970-01-01 00:08:00"), parseMysql("8", "%i"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:59:00"),
-      parse("59", "%i", false));
+      util::fromTimestampString("1970-01-01 00:59:00"), parseMysql("59", "%i"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0/", "%i/", false));
+      parseMysql("0/", "%i/"));
 
-  EXPECT_THROW(parse("60", "%i", false), VeloxUserError);
-  EXPECT_THROW(parse("-1", "%i", false), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "%i", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("60", "%i"), VeloxUserError);
+  EXPECT_THROW(parseMysql("-1", "%i"), VeloxUserError);
+  EXPECT_THROW(parseMysql("123456789", "%i"), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, parseSecond) {
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:09"),
-      parse("9", "%s", false));
+      util::fromTimestampString("1970-01-01 00:00:09"), parseMysql("9", "%s"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:58"),
-      parse("58", "%s", false));
+      util::fromTimestampString("1970-01-01 00:00:58"), parseMysql("58", "%s"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0/", "%s/", false));
+      parseMysql("0/", "%s/"));
 
-  EXPECT_THROW(parse("60", "%s", false), VeloxUserError);
-  EXPECT_THROW(parse("-1", "%s", false), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "%s", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("60", "%s"), VeloxUserError);
+  EXPECT_THROW(parseMysql("-1", "%s"), VeloxUserError);
+  EXPECT_THROW(parseMysql("123456789", "%s"), VeloxUserError);
 
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:09"),
-      parse("9", "%S", false));
+      util::fromTimestampString("1970-01-01 00:00:09"), parseMysql("9", "%S"));
   EXPECT_EQ(
-      util::fromTimestampString("1970-01-01 00:00:58"),
-      parse("58", "%S", false));
+      util::fromTimestampString("1970-01-01 00:00:58"), parseMysql("58", "%S"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00"),
-      parse("0/", "%S/", false));
+      parseMysql("0/", "%S/"));
 
-  EXPECT_THROW(parse("60", "%S", false), VeloxUserError);
-  EXPECT_THROW(parse("-1", "%S", false), VeloxUserError);
-  EXPECT_THROW(parse("123456789", "%S", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("60", "%S"), VeloxUserError);
+  EXPECT_THROW(parseMysql("-1", "%S"), VeloxUserError);
+  EXPECT_THROW(parseMysql("123456789", "%S"), VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, parseMixedYMDFormat) {
   // Common patterns found.
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 23:00:00"),
-      parse("2021-01-04+23:00:00", "%Y-%m-%d+%H:%i:%s", false));
+      parseMysql("2021-01-04+23:00:00", "%Y-%m-%d+%H:%i:%s"));
 
   EXPECT_EQ(
       util::fromTimestampString("2019-07-03 11:04:10"),
-      parse("2019-07-03 11:04:10", "%Y-%m-%d %H:%i:%s", false));
+      parseMysql("2019-07-03 11:04:10", "%Y-%m-%d %H:%i:%s"));
 
   // Backwards, just for fun:
   EXPECT_EQ(
       util::fromTimestampString("2019-07-03 11:04:10"),
-      parse("10:04:11 03-07-2019", "%s:%i:%H %d-%m-%Y", false));
+      parseMysql("10:04:11 03-07-2019", "%s:%i:%H %d-%m-%Y"));
 }
 
 TEST_F(MysqlDateTimeTest, parseMixedWeekFormat) {
   // Common patterns found.
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 13:29:21.213", "%x %v %H:%i:%s.%f", false));
+      parseMysql("2021 1 13:29:21.213", "%x %v %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 13:29:21.213", "%x %v %H:%i:%s.%f", false));
+      parseMysql("2021 22 13:29:21.213", "%x %v %H:%i:%s.%f"));
 
   // Day of week short text normal capitlization
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 Mon 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 1 Mon 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 Mon 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 Mon 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 Thu 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 Thu 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Day of week long text normal capitlization
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 Monday 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 1 Monday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 Monday 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 Monday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 Thursday 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 Thursday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Day of week short text upper case
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 MON 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 1 MON 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 MON 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 MON 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 THU 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 THU 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Day of week long text upper case
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 MONDAY 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 1 MONDAY 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 MONDAY 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 MONDAY 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 THURSDAY 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 THURSDAY 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Day of week short text lower case
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 mon 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 1 mon 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 mon 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 mon 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 thu 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 thu 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Day of week long text lower case
   EXPECT_EQ(
       util::fromTimestampString("2021-01-04 13:29:21.213"),
-      parse("2021 1 monday 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 1 monday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("2021 22 monday 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 monday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("2021-06-03 13:29:21.213"),
-      parse("2021 22 thursday 13:29:21.213", "%x %v %W %H:%i:%s.%f", false));
+      parseMysql("2021 22 thursday 13:29:21.213", "%x %v %W %H:%i:%s.%f"));
 
   // Invalid day of week throw cases
-  EXPECT_THROW(parse("mOn", "E"), VeloxUserError);
-  EXPECT_THROW(parse("tuE", "E"), VeloxUserError);
-  EXPECT_THROW(parse("WeD", "E"), VeloxUserError);
-  EXPECT_THROW(parse("WEd", "E"), VeloxUserError);
-  EXPECT_THROW(parse("MONday", "EEE"), VeloxUserError);
-  EXPECT_THROW(parse("monDAY", "EEE"), VeloxUserError);
-  EXPECT_THROW(parse("frIday", "EEE"), VeloxUserError);
+  EXPECT_THROW(parseMysql("mOn", "E"), VeloxUserError);
+  EXPECT_THROW(parseMysql("tuE", "E"), VeloxUserError);
+  EXPECT_THROW(parseMysql("WeD", "E"), VeloxUserError);
+  EXPECT_THROW(parseMysql("WEd", "E"), VeloxUserError);
+  EXPECT_THROW(parseMysql("MONday", "EEE"), VeloxUserError);
+  EXPECT_THROW(parseMysql("monDAY", "EEE"), VeloxUserError);
+  EXPECT_THROW(parseMysql("frIday", "EEE"), VeloxUserError);
 
   // Backwards, just for fun:
   EXPECT_EQ(
       util::fromTimestampString("2021-05-31 13:29:21.213"),
-      parse("213.21:29:13 22 2021", "%f.%s:%i:%H %v %x", false));
+      parseMysql("213.21:29:13 22 2021", "%f.%s:%i:%H %v %x"));
 }
 
 TEST_F(MysqlDateTimeTest, parseFractionOfSecond) {
   // Assert on difference in milliseconds.
   EXPECT_NE(
       util::fromTimestampString("2022-02-23 12:15:00.223"),
-      parse("2022-02-23T12:15:00.776", "%Y-%m-%dT%H:%i:%s.%f", false));
+      parseMysql("2022-02-23T12:15:00.776", "%Y-%m-%dT%H:%i:%s.%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00.000"),
-      parse("000", "%f", false));
+      parseMysql("000", "%f"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00.001"),
-      parse("001", "%f", false));
+      parseMysql("001", "%f"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00.999"),
-      parse("999", "%f", false));
+      parseMysql("999", "%f"));
 
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00.045"),
-      parse("045", "%f", false));
+      parseMysql("045", "%f"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00.450"),
-      parse("45", "%f", false));
+      parseMysql("45", "%f"));
   EXPECT_EQ(
       util::fromTimestampString("1970-01-01 00:00:00.450"),
-      parse("45", "%f", false));
+      parseMysql("45", "%f"));
 
-  EXPECT_THROW(parse("-1", "%f", false), VeloxUserError);
-  EXPECT_THROW(parse("9999999", "%f", false), VeloxUserError);
+  EXPECT_THROW(parseMysql("-1", "%f"), VeloxUserError);
+  EXPECT_THROW(parseMysql("9999999", "%f"), VeloxUserError);
+}
+
+TEST_F(MysqlDateTimeTest, parseConsecutiveSpecifiers) {
+  EXPECT_EQ(
+      util::fromTimestampString("2012-12-01"), parseMysql("1212", "%y%m"));
+  EXPECT_EQ(
+      util::fromTimestampString("0012-12-01"), parseMysql("1212", "%m%Y"));
+  EXPECT_THROW(parseMysql("1212", "%Y%m"), VeloxUserError);
+
+  EXPECT_EQ(
+      util::fromTimestampString("2012-01-01 12:00:00"),
+      parseMysql("1212", "%y%H"));
+  EXPECT_EQ(
+      util::fromTimestampString("0012-01-01 12:00:00"),
+      parseMysql("1212", "%H%Y"));
+  EXPECT_THROW(parseMysql("1212", "%Y%H"), VeloxUserError);
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -904,7 +904,7 @@ struct DateParseFunction {
   }
 
   FOLLY_ALWAYS_INLINE bool call(
-      out_type<TimestampWithTimezone>& result,
+      out_type<Timestamp>& result,
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& format) {
     if (!isConstFormat_) {
@@ -919,7 +919,7 @@ struct DateParseFunction {
     // timezone was provided. If not, fallback to 0 (GMT).
     int16_t timezoneId = sessionTzID_.value_or(0);
     dateTimeResult.timestamp.toGMT(timezoneId);
-    result = std::make_tuple(dateTimeResult.timestamp.toMillis(), timezoneId);
+    result = dateTimeResult.timestamp;
     return true;
   }
 };

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -913,7 +913,7 @@ struct DateParseFunction {
     }
 
     auto dateTimeResult =
-        format_->parse(std::string_view(input.data(), input.size()));
+        format_->parse(std::string_view(input.data(), input.size()), false);
 
     // Since MySql format has no timezone specifier, simply check if session
     // timezone was provided. If not, fallback to 0 (GMT).
@@ -996,7 +996,7 @@ struct ParseDateTimeFunction {
           std::string_view(format.data(), format.size()));
     }
     auto dateTimeResult =
-        format_->parse(std::string_view(input.data(), input.size()));
+        format_->parse(std::string_view(input.data(), input.size()), true);
 
     // If timezone was not parsed, fallback to the session timezone. If there's
     // no session timezone, fallback to 0 (GMT).

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -97,7 +97,7 @@ void registerSimpleFunctions() {
       TimestampWithTimezone,
       Varchar,
       Varchar>({"parse_datetime"});
-  registerFunction<DateParseFunction, TimestampWithTimezone, Varchar, Varchar>(
+  registerFunction<DateParseFunction, Timestamp, Varchar, Varchar>(
       {"date_parse"});
 }
 } // namespace

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -114,7 +114,7 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
         rowVector->children()[1]->as<SimpleVector<int16_t>>()->valueAt(0)};
   }
 
-  std::optional<TimestampWithTimezone> dateParse(
+  std::optional<Timestamp> dateParse(
       const std::optional<std::string>& input,
       const std::optional<std::string>& format) {
     auto resultVector = evaluate(
@@ -127,10 +127,7 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
     if (resultVector->isNullAt(0)) {
       return std::nullopt;
     }
-    auto rowVector = resultVector->as<RowVector>();
-    return TimestampWithTimezone{
-        rowVector->children()[0]->as<SimpleVector<int64_t>>()->valueAt(0),
-        rowVector->children()[1]->as<SimpleVector<int16_t>>()->valueAt(0)};
+    return resultVector->as<SimpleVector<Timestamp>>()->valueAt(0);
   }
 
   std::optional<std::string> dateFormat(
@@ -2567,45 +2564,36 @@ TEST_F(DateTimeFunctionsTest, dateParse) {
   EXPECT_EQ(std::nullopt, dateParse(std::nullopt, std::nullopt));
 
   // Simple tests. More exhaustive tests are provided in DateTimeFormatterTest.
-  EXPECT_EQ(
-      TimestampWithTimezone(86400000, 0), dateParse("1970-01-02", "%Y-%m-%d"));
-  EXPECT_EQ(TimestampWithTimezone(0, 0), dateParse("1970-01-01", "%Y-%m-%d"));
-  EXPECT_EQ(
-      TimestampWithTimezone(86400000, 0), dateParse("19700102", "%Y%m%d"));
+  EXPECT_EQ(Timestamp(86400, 0), dateParse("1970-01-02", "%Y-%m-%d"));
+  EXPECT_EQ(Timestamp(0, 0), dateParse("1970-01-01", "%Y-%m-%d"));
+  EXPECT_EQ(Timestamp(86400, 0), dateParse("19700102", "%Y%m%d"));
 
   // Tests for differing query timezones
   // 118860000 is the number of milliseconds since epoch at 1970-01-02
   // 09:01:00.000 UTC.
   EXPECT_EQ(
-      TimestampWithTimezone(118860000, 0),
-      dateParse("1970-01-02+09:01", "%Y-%m-%d+%H:%i"));
+      Timestamp(118860, 0), dateParse("1970-01-02+09:01", "%Y-%m-%d+%H:%i"));
 
   setQueryTimeZone("America/Los_Angeles");
   EXPECT_EQ(
-      TimestampWithTimezone(
-          118860000, util::getTimeZoneID("America/Los_Angeles")),
-      dateParse("1970-01-02+01:01", "%Y-%m-%d+%H:%i"));
+      Timestamp(118860, 0), dateParse("1970-01-02+01:01", "%Y-%m-%d+%H:%i"));
 
   setQueryTimeZone("America/Noronha");
   EXPECT_EQ(
-      TimestampWithTimezone(118860000, util::getTimeZoneID("America/Noronha")),
-      dateParse("1970-01-02+07:01", "%Y-%m-%d+%H:%i"));
+      Timestamp(118860, 0), dateParse("1970-01-02+07:01", "%Y-%m-%d+%H:%i"));
 
   setQueryTimeZone("+04:00");
   EXPECT_EQ(
-      TimestampWithTimezone(118860000, util::getTimeZoneID("+04:00")),
-      dateParse("1970-01-02+13:01", "%Y-%m-%d+%H:%i"));
+      Timestamp(118860, 0), dateParse("1970-01-02+13:01", "%Y-%m-%d+%H:%i"));
 
   setQueryTimeZone("Asia/Kolkata");
   // 66600000 is the number of millisecond since epoch at 1970-01-01
   // 18:30:00.000 UTC.
   EXPECT_EQ(
-      TimestampWithTimezone(66600000, util::getTimeZoneID("Asia/Kolkata")),
-      dateParse("1970-01-02+00:00", "%Y-%m-%d+%H:%i"));
+      Timestamp(66600, 0), dateParse("1970-01-02+00:00", "%Y-%m-%d+%H:%i"));
 
   // -66600000 is the number of millisecond since epoch at 1969-12-31
   // 05:30:00.000 UTC.
   EXPECT_EQ(
-      TimestampWithTimezone(-66600000, util::getTimeZoneID("Asia/Kolkata")),
-      dateParse("1969-12-31+11:00", "%Y-%m-%d+%H:%i"));
+      Timestamp(-66600, 0), dateParse("1969-12-31+11:00", "%Y-%m-%d+%H:%i"));
 }


### PR DESCRIPTION
Summary: Refactored DateTimeFormatterTest to use clearer naming convention, so it's obvious when Joda standard is used and when MySQL standard is used.

Differential Revision: D38717415

