### PR TITLE
Optimize acquireSharedStringBuffers processing

### DIFF
--- a/velox/dwio/dwrf/reader/FlatMapHelper.h
+++ b/velox/dwio/dwrf/reader/FlatMapHelper.h
@@ -56,7 +56,7 @@ void initializeFlatVector(
     auto& flatVector = dynamic_cast<FlatVector<T>&>(*vector);
     detail::resetIfNotWritable(vector, flatVector.nulls(), flatVector.values());
     if (vector) {
-      flatVector.stringBuffers() = stringBuffers;
+      flatVector.setStringBuffers(stringBuffers);
     }
   }
 

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -347,12 +347,10 @@ void read<StringView>(
   readNulls(source, size, flatResult);
 
   int32_t dataSize = source->read<int32_t>();
-  auto& stringBuffers = flatResult->stringBuffers();
+  const auto& stringBuffers = flatResult->stringBuffers();
   BufferPtr strings = findOrAllocateStringBuffer(dataSize, stringBuffers, pool);
+  flatResult->setStringBuffers({strings});
   auto rawStrings = strings->asMutable<uint8_t>();
-
-  stringBuffers.resize(1);
-  stringBuffers[0] = std::move(strings);
 
   source->readBytes(rawStrings, dataSize);
   int32_t previousOffset = 0;

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -330,7 +330,7 @@ void FlatVector<T>::resize(vector_size_t size, bool setNotNull) {
       vector->invalidateIsAscii();
     }
     if (size == 0) {
-      stringBuffers_.clear();
+      clearStringBuffers();
     }
     if (size > previousSize) {
       auto stringViews = reinterpret_cast<StringView*>(rawValues_);

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -197,6 +197,8 @@ void FlatVector<bool>::copyValuesAndNulls(
 
 template <>
 Buffer* FlatVector<StringView>::getBufferWithSpace(vector_size_t size) {
+  VELOX_DCHECK_GE(stringBuffers_.size(), stringBufferSet_.size());
+
   // Check if the last buffer is uniquely referenced and has enough space.
   Buffer* buffer =
       stringBuffers_.empty() ? nullptr : stringBuffers_.back().get();
@@ -209,8 +211,8 @@ Buffer* FlatVector<StringView>::getBufferWithSpace(vector_size_t size) {
   int32_t newSize = std::max(kInitialStringSize, size);
   BufferPtr newBuffer = AlignedBuffer::allocate<char>(newSize, pool());
   newBuffer->setSize(0);
-  stringBuffers_.push_back(newBuffer);
-  return stringBuffers_.back().get();
+  addStringBuffer(newBuffer);
+  return newBuffer.get();
 }
 
 template <>
@@ -231,9 +233,9 @@ void FlatVector<StringView>::prepareForReuse() {
     if (firstBuffer->unique() && firstBuffer->isMutable() &&
         firstBuffer->capacity() <= kMaxStringSizeForReuse) {
       firstBuffer->setSize(0);
-      stringBuffers_.resize(1);
+      setStringBuffers({firstBuffer});
     } else {
-      stringBuffers_.clear();
+      clearStringBuffers();
     }
   }
 
@@ -292,9 +294,7 @@ void FlatVector<T>::acquireSharedStringBuffers(const BaseVector* source) {
     case VectorEncoding::Simple::FLAT: {
       auto* flat = leaf->asUnchecked<FlatVector<StringView>>();
       for (auto& buffer : flat->stringBuffers_) {
-        if (std::find(stringBuffers_.begin(), stringBuffers_.end(), buffer) ==
-            stringBuffers_.end())
-          stringBuffers_.push_back(buffer);
+        addStringBuffer(buffer);
       }
       break;
     }
@@ -302,10 +302,9 @@ void FlatVector<T>::acquireSharedStringBuffers(const BaseVector* source) {
       if (!leaf->isNullAt(0)) {
         auto* constant = leaf->asUnchecked<ConstantVector<StringView>>();
         auto buffer = constant->getStringBuffer();
-        if (buffer &&
-            std::find(stringBuffers_.begin(), stringBuffers_.end(), buffer) ==
-                stringBuffers_.end())
-          stringBuffers_.push_back(buffer);
+        if (buffer != nullptr) {
+          addStringBuffer(buffer);
+        }
       }
       break;
     }


### PR DESCRIPTION
Optimize acquireSharedStringBuffers processing by using folly::F14VectorSet to check
if it is a new buffer to hold the reference. It reduces the time complexity from O(N^2)
down to O(N*LOG(N)) which is necessary if we gather copy from a large number of
source buffers in case of disk spilling which might merge from a large number of spilled
file streams. Some APIs changes made to FlatVector.