### PR TITLE
Fix UniqueValueHasher

### DIFF
--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -89,16 +89,16 @@ struct UniqueValueHasher {
   size_t operator()(const UniqueValue& value) const {
     auto size = value.size();
     if (size <= sizeof(int64_t)) {
-      return simd::crc32U64(value.data(), 1);
+      return simd::crc32U64(0, value.data());
     }
 
-    uint64_t hash = 1;
+    uint32_t hash = 0;
     auto data = reinterpret_cast<const uint64_t*>(value.data());
 
     size_t wordIndex = 0;
     auto numFullWords = size / 8;
     for (; wordIndex < numFullWords; ++wordIndex) {
-      hash = simd::crc32U64(*(data + wordIndex), hash);
+      hash = simd::crc32U64(hash, *(data + wordIndex));
     }
 
     auto numBytesRemaining = size - wordIndex * 8;
@@ -106,7 +106,7 @@ struct UniqueValueHasher {
       auto lastWord = bits::loadPartialWord(
           reinterpret_cast<const uint8_t*>(data + wordIndex),
           numBytesRemaining);
-      hash = simd::crc32U64(lastWord, hash);
+      hash = simd::crc32U64(hash, lastWord);
     }
 
     return hash;

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -860,3 +860,11 @@ TEST_F(VectorHasherTest, endOfRange) {
   }
   EXPECT_EQ(tinyData->size(), uniques.size());
 }
+
+TEST_F(VectorHasherTest, hashCollision) {
+  constexpr int kValue = 42;
+  UniqueValue x(kValue);
+  UniqueValue y(kValue | (1ull << 32));
+  UniqueValueHasher h;
+  EXPECT_NE(h(x), h(y));
+}


### PR DESCRIPTION
Summary: The currently implementation calls CRC32 with wrong parameter order and resulting in truncation and more hash collision than expected.  Fix [issue #2303](https://github.com/facebookincubator/velox/issues/2303).

Differential Revision: D38743458

