### PR TITLE
Fix selected rows in SubscriptImpl

### DIFF
--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -300,6 +300,7 @@ class SubscriptImpl : public exec::VectorFunction {
     // Get map keys.
     auto mapKeys = baseMap->mapKeys();
     exec::LocalSelectivityVector allElementRows(context, mapKeys->size());
+    allElementRows->setAll();
     exec::LocalDecodedVector mapKeysHolder(context, *mapKeys, *allElementRows);
     auto decodedMapKeys = mapKeysHolder.get();
 


### PR DESCRIPTION
Summary: LocalSelectivityVector needs to be initialized before being used.

Differential Revision: D38770410

