### PR TITLE
hash Join Optimization Collection

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -192,6 +192,32 @@ inline void forEachWord(
   }
 }
 
+/// Variant of forEachWord with a single callable for more concise
+/// invocation for cases with a long callable.
+template <typename PartialWordFunc>
+inline void
+forEachWord(int32_t begin, int32_t end, PartialWordFunc partialWordFunc) {
+  if (begin >= end) {
+    return;
+  }
+  int32_t firstWord = roundUp(begin, 64);
+  int32_t lastWord = end & ~63L;
+  if (lastWord < firstWord) {
+    partialWordFunc(
+        lastWord / 64, lowMask(end - lastWord) & highMask(firstWord - begin));
+    return;
+  }
+  if (begin != firstWord) {
+    partialWordFunc(begin / 64, highMask(firstWord - begin));
+  }
+  for (int32_t i = firstWord; i + 64 <= lastWord; i += 64) {
+    partialWordFunc(i / 64, ~0ULL);
+  }
+  if (end != lastWord) {
+    partialWordFunc(lastWord / 64, lowMask(end - lastWord));
+  }
+}
+
 /// Invokes a function for each batch of bits (partial or full words)
 /// in a given range in descending order of address.
 ///

--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -294,7 +294,8 @@ inline bool copyNextWord(void*& to, const void*& from, int32_t& bytes) {
 } // namespace detail
 
 template <typename A>
-void memcpy(void* to, const void* from, int32_t bytes, const A& arch) {
+FOLLY_ALWAYS_INLINE void
+memcpy(void* to, const void* from, int32_t bytes, const A& arch) {
   while (bytes >= batchByteSize(arch)) {
     if (!detail::copyNextWord<xsimd::batch<int8_t, A>, A>(to, from, bytes)) {
       return;

--- a/velox/common/base/tests/SimdUtilTest.cpp
+++ b/velox/common/base/tests/SimdUtilTest.cpp
@@ -333,3 +333,7 @@ TEST_F(SimdUtilTest, Batch64_memory) {
 }
 
 } // namespace
+
+void cpyf(void* d, void* s, int c) {
+  facebook::velox::simd::memcpy(d, s, c);
+}

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -56,6 +56,14 @@ HashTable<ignoreNullKeys>::HashTable(
   nextOffset_ = rows_->nextOffset();
 }
 
+struct ProbeContext {
+  char** table;
+  uint8_t* tags;
+  int32_t sizeMask;
+  int32_t groupsLoaded;
+  int32_t rowsLoaded;
+};
+
 class ProbeState {
  public:
   enum class Operation { kProbe, kInsert, kErase };
@@ -163,6 +171,35 @@ class ProbeState {
           if (op == Operation::kErase) {
             eraseHit(tags);
           }
+          return group_;
+        }
+        continue;
+      }
+      tagIndex_ = (tagIndex_ + sizeof(BaseHashTable::TagVector)) & sizeMask;
+      tagsInTable_ = BaseHashTable::loadTags(tags, tagIndex_);
+      hits_ = simd::toBitMask(tagsInTable_ == wantedTags_) & kFullMask;
+    }
+  }
+
+  FOLLY_ALWAYS_INLINE char* FOLLY_NULLABLE joinNormalizedKeyFullProbe(
+      uint8_t* tags,
+      char** table,
+      uint64_t sizeMask,
+      const uint64_t* keys) {
+    if (group_ && RowContainer::normalizedKey(group_) == keys[row_]) {
+      return group_;
+    }
+    const auto kEmptyGroup = BaseHashTable::TagVector::broadcast(0);
+    for (;;) {
+      if (!hits_) {
+        uint16_t empty =
+            simd::toBitMask(tagsInTable_ == kEmptyGroup) & kFullMask;
+        if (empty) {
+          return nullptr;
+        }
+      } else {
+        loadNextHit<Operation::kProbe>(table, 0);
+        if (RowContainer::normalizedKey(group_) == keys[row_]) {
           return group_;
         }
         continue;
@@ -326,23 +363,35 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::fullProbe(
 }
 
 namespace {
-// A normalized key is spread evenly over 64 bits. This mixes the bits
-// so that they affect the low 'bits', which are actually used for
-// indexing the hash table.
+// Normalized keys have non0-random bits. Bits need to be propagated
+// up to make a tag byte and down so that non-lowest bits of
+// normalized key affect the hash table index.
 inline uint64_t mixNormalizedKey(uint64_t k, uint8_t bits) {
   constexpr uint64_t prime1 = 0xc6a4a7935bd1e995UL; // M from Murmurhash.
   constexpr uint64_t prime2 = 527729;
   constexpr uint64_t prime3 = 28047;
-  auto h = (k ^ ((k >> 32))) * prime1;
-  return h + (h >> bits) * prime2 + (h >> (2 * bits)) * prime3;
+  auto h = k * prime1;
+  return h + (k ^ (h >> 32));
 }
 
 void populateNormalizedKeys(HashLookup& lookup, int8_t sizeBits) {
   lookup.normalizedKeys.resize(lookup.rows.back() + 1);
-  auto hashes = lookup.hashes.data();
+  uint64_t* __restrict hashes = lookup.hashes.data();
+  uint64_t* __restrict keys = lookup.normalizedKeys.data();
+  int32_t end = lookup.rows.back() + 1;
+  if (end / 4 < lookup.rows.size()) {
+    // For more than 1/4 of the positions in use, run the loop on all
+    // elements, since the loop will do 4 at a time.
+    for (auto row = 0; row < end; ++row) {
+      auto hash = hashes[row];
+      keys[row] = hash; // NOLINT
+      hashes[row] = mixNormalizedKey(hash, sizeBits);
+    }
+    return;
+  }
   for (auto row : lookup.rows) {
     auto hash = hashes[row];
-    lookup.normalizedKeys[row] = hash; // NOLINT
+    keys[row] = hash; // NOLINT
     hashes[row] = mixNormalizedKey(hash, sizeBits);
   }
 }
@@ -458,6 +507,8 @@ void HashTable<ignoreNullKeys>::joinProbe(HashLookup& lookup) {
   }
   if (hashMode_ == HashMode::kNormalizedKey) {
     populateNormalizedKeys(lookup, sizeBits_);
+    joinNormalizedKeyProbe(lookup);
+    return;
   }
   int32_t probeIndex = 0;
   int32_t numProbes = lookup.rows.size();
@@ -489,6 +540,49 @@ void HashTable<ignoreNullKeys>::joinProbe(HashLookup& lookup) {
     state1.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
     state1.firstProbe(table_, 0);
     fullProbe<true>(lookup, state1, false);
+  }
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::joinNormalizedKeyProbe(HashLookup& lookup) {
+  int32_t probeIndex = 0;
+  int32_t numProbes = lookup.rows.size();
+  const vector_size_t* rows = lookup.rows.data();
+  ProbeState state1;
+  ProbeState state2;
+  ProbeState state3;
+  ProbeState state4;
+  const uint64_t* keys = lookup.normalizedKeys.data();
+  const uint64_t* hashes = lookup.hashes.data();
+  char** hits = lookup.hits.data();
+  for (; probeIndex + 4 <= numProbes; probeIndex += 4) {
+    int32_t row = rows[probeIndex];
+    state1.preProbe(tags_, sizeMask_, hashes[row], row);
+    row = rows[probeIndex + 1];
+    state2.preProbe(tags_, sizeMask_, hashes[row], row);
+    row = rows[probeIndex + 2];
+    state3.preProbe(tags_, sizeMask_, hashes[row], row);
+    row = rows[probeIndex + 3];
+    state4.preProbe(tags_, sizeMask_, hashes[row], row);
+    state1.firstProbe(table_, 0);
+    state2.firstProbe(table_, 0);
+    state3.firstProbe(table_, 0);
+    state4.firstProbe(table_, 0);
+    hits[state1.row()] =
+        state1.joinNormalizedKeyFullProbe(tags_, table_, sizeMask_, keys);
+    hits[state2.row()] =
+        state2.joinNormalizedKeyFullProbe(tags_, table_, sizeMask_, keys);
+    hits[state3.row()] =
+        state3.joinNormalizedKeyFullProbe(tags_, table_, sizeMask_, keys);
+    hits[state4.row()] =
+        state4.joinNormalizedKeyFullProbe(tags_, table_, sizeMask_, keys);
+  }
+  for (; probeIndex < numProbes; ++probeIndex) {
+    int32_t row = rows[probeIndex];
+    state1.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
+    state1.firstProbe(table_, 0);
+    hits[row] =
+        state1.joinNormalizedKeyFullProbe(tags_, table_, sizeMask_, keys);
   }
 }
 
@@ -1091,6 +1185,9 @@ int32_t HashTable<ignoreNullKeys>::listJoinResults(
     folly::Range<vector_size_t*> inputRows,
     folly::Range<char**> hits) {
   VELOX_CHECK_LE(inputRows.size(), hits.size());
+  if (!hasDuplicates_) {
+    return listJoinResultsNoDuplicates(iter, includeMisses, inputRows, hits);
+  }
   int numOut = 0;
   auto maxOut = inputRows.size();
   while (iter.lastRowIndex < iter.rows->size()) {
@@ -1131,6 +1228,61 @@ int32_t HashTable<ignoreNullKeys>::listJoinResults(
       }
     }
   }
+  return numOut;
+}
+
+template <bool ignoreNullKeys>
+int32_t HashTable<ignoreNullKeys>::listJoinResultsNoDuplicates(
+    JoinResultIterator& iter,
+    bool includeMisses,
+    folly::Range<vector_size_t*> inputRows,
+    folly::Range<char**> hits) {
+  int32_t numOut = 0;
+  auto maxOut = inputRows.size();
+  int32_t i = iter.lastRowIndex;
+  auto numRows = iter.rows->size();
+
+  constexpr int32_t kWidth = xsimd::batch<int64_t>::size;
+  auto sourceHits = reinterpret_cast<int64_t*>(iter.hits->data());
+  auto sourceRows = iter.rows->data();
+  // We pass the pointers as int64_t's in 'hitWords'.
+  auto resultHits = reinterpret_cast<int64_t*>(hits.data());
+  auto resultRows = inputRows.data();
+  int32_t outLimit = maxOut - kWidth;
+  for (; i + kWidth <= numRows && numOut < outLimit; i += kWidth) {
+    auto indices = simd::loadGatherIndices<int64_t, int32_t>(sourceRows + i);
+    auto hitWords = simd::gather(sourceHits, indices);
+    auto misses = includeMisses ? 0 : simd::toBitMask(hitWords == 0);
+    if (misses == 0xf) {
+      continue;
+    }
+    if (!misses) {
+      hitWords.store_unaligned(resultHits + numOut);
+      indices.store_unaligned(resultRows + numOut);
+      numOut += kWidth;
+      continue;
+    }
+    auto matches = misses ^ bits::lowMask(kWidth);
+    simd::filter<int64_t>(hitWords, matches, xsimd::default_arch{})
+        .store_unaligned(resultHits + numOut);
+    simd::filter<int32_t>(indices, matches, xsimd::default_arch{})
+        .store_unaligned(resultRows + numOut);
+    numOut += __builtin_popcount(matches);
+  }
+  for (; i < numRows; ++i) {
+    auto row = sourceRows[i];
+    if (includeMisses || sourceHits[row]) {
+      resultHits[numOut] = sourceHits[row];
+      resultRows[numOut] = row;
+      ++numOut;
+      if (numOut >= maxOut) {
+        ++i;
+        break;
+      }
+    }
+  }
+
+  iter.lastRowIndex = i;
   return numOut;
 }
 

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -380,6 +380,13 @@ class HashTable : public BaseHashTable {
 
   void setHashMode(HashMode mode, int32_t numNew) override;
 
+  // Fast path for join results when there are no duplicates in the table.
+  int32_t listJoinResultsNoDuplicates(
+      JoinResultIterator& iter,
+      bool includeMisses,
+      folly::Range<vector_size_t*> inputRows,
+      folly::Range<char**> hits);
+
   /// Tries to use as many range hashers as can in a normalized key situation.
   void enableRangeWhereCan(
       const std::vector<uint64_t>& rangeSizes,
@@ -437,6 +444,9 @@ class HashTable : public BaseHashTable {
 
   template <bool isJoin>
   void fullProbe(HashLookup& lookup, ProbeState& state, bool extraCheck);
+
+  // Shortcut for probe with normalized keys.
+  void joinNormalizedKeyProbe(HashLookup& lookup);
 
   // Adds a row to a hash join table in kArray hash mode. Returns true
   // if a new entry was made and false if the row was added to an

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -378,7 +378,8 @@ void VectorHasher::lookupValueIdsTyped(
     const DecodedVector& decoded,
     SelectivityVector& rows,
     raw_vector<uint64_t>& hashes,
-    uint64_t* result) const {
+    uint64_t* result,
+    bool noNulls) const {
   using T = typename TypeTraits<Kind>::NativeType;
   if (decoded.isConstantMapping()) {
     if (decoded.isNullAt(rows.begin())) {
@@ -398,21 +399,25 @@ void VectorHasher::lookupValueIdsTyped(
       });
     }
   } else if (decoded.isIdentityMapping()) {
-    rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
-      if (decoded.isNullAt(row)) {
-        if (multiplier_ == 1) {
-          result[row] = 0;
+    if (Kind == TypeKind::BIGINT && isRange_ && noNulls) {
+      lookupIdsRange64(decoded, rows, result);
+    } else {
+      rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
+        if (decoded.isNullAt(row)) {
+          if (multiplier_ == 1) {
+            result[row] = 0;
+          }
+          return;
         }
-        return;
-      }
-      T value = decoded.valueAt<T>(row);
-      uint64_t id = lookupValueId(value);
-      if (id == kUnmappable) {
-        rows.setValid(row, false);
-        return;
-      }
-      result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
-    });
+        T value = decoded.valueAt<T>(row);
+        uint64_t id = lookupValueId(value);
+        if (id == kUnmappable) {
+          rows.setValid(row, false);
+          return;
+        }
+        result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
+      });
+    }
     rows.updateBounds();
   } else {
     hashes.resize(decoded.base()->size());
@@ -441,11 +446,89 @@ void VectorHasher::lookupValueIdsTyped(
   }
 }
 
+template <int8_t kWidth, typename Callable>
+void forBatches(const SelectivityVector& rows, Callable func) {
+  constexpr int32_t unitMask = (1 << kWidth) - 1;
+  auto bits = rows.asRange().bits();
+  bits::forEachWord(
+      rows.begin(),
+      rows.end(),
+      [&](auto index, uint64_t mask) {
+        uint64_t active = bits[index] & mask;
+        if (!active) {
+          return;
+        }
+        int32_t skip = (__builtin_ctzll(active) / kWidth) * kWidth;
+        active >>= skip;
+        auto first = skip;
+        while (active) {
+          if (active & unitMask) {
+            func(index * 64 + first, active & unitMask);
+            first += kWidth;
+            active >>= kWidth;
+          } else {
+            skip = (__builtin_ctzll(active) / kWidth) * kWidth;
+            active >>= skip;
+            first += skip;
+          }
+        }
+      },
+      [&](auto index) {
+        uint64_t active = bits[index];
+        if (!active) {
+          return;
+        }
+        int32_t skip = (__builtin_ctzll(active) / kWidth) * kWidth;
+        active >>= skip;
+        auto first = skip;
+        while (active) {
+          if (active & unitMask) {
+            func(index * 64 + first, active & unitMask);
+            first += kWidth;
+            active >>= kWidth;
+          } else {
+            skip = (__builtin_ctzll(active) / kWidth) * kWidth;
+            active >>= skip;
+            first += skip;
+          }
+        }
+      });
+}
+
+void VectorHasher::lookupIdsRange64(
+    const DecodedVector& decoded,
+    SelectivityVector& rows,
+    uint64_t* result) const {
+  auto lower = xsimd::batch<int64_t>::broadcast(min_);
+  auto upper = xsimd::batch<int64_t>::broadcast(max_);
+  auto data = decoded.data<int64_t>();
+  auto offset = lower - 1;
+  auto bits = rows.asMutableRange().bits();
+  forBatches<4>(rows, [&](auto index, auto mask) {
+    auto values = xsimd::batch<int64_t>::load_unaligned(data + index);
+    uint64_t outOfRange = simd::toBitMask((lower > values) | (values > upper));
+    if (outOfRange) {
+      bits[index / 64] &= ~(outOfRange << (index & 63));
+    }
+    if (outOfRange != 0xf) {
+      if (multiplier_ == 1) {
+        (values - offset).store_unaligned(result + index);
+      } else {
+        (xsimd::batch<int64_t>::load_unaligned(result + index) *
+             xsimd::batch<int64_t>::broadcast(multiplier_) +
+         (values - offset))
+            .store_unaligned(result + index);
+      }
+    }
+  });
+}
+
 void VectorHasher::lookupValueIds(
     const BaseVector& values,
     SelectivityVector& rows,
     ScratchMemory& scratchMemory,
-    raw_vector<uint64_t>& result) const {
+    raw_vector<uint64_t>& result,
+    bool noNulls) const {
   scratchMemory.decoded.decode(values, rows);
   VALUE_ID_TYPE_DISPATCH(
       lookupValueIdsTyped,
@@ -453,7 +536,8 @@ void VectorHasher::lookupValueIds(
       scratchMemory.decoded,
       rows,
       scratchMemory.hashes,
-      result.data());
+      result.data(),
+      noNulls);
 }
 
 void VectorHasher::hash(
@@ -591,8 +675,8 @@ void extendRange(int64_t reserve, int64_t& min, int64_t& max) {
   }
 }
 
-// Adds 'reservePct' % to either end of the range between 'min' and 'max' while
-// staying in the range of 'kind'.
+// Adds 'reservePct' % to either end of the range between 'min' and 'max'
+// while staying in the range of 'kind'.
 void extendRange(
     TypeKind kind,
     int32_t reservePct,

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -236,12 +236,14 @@ class VectorHasher {
   // have a miss if any of the keys has a value that is not represented.
   //
   // This method can be called concurrently from multiple threads. To allow for
-  // that the caller must provide 'scratchMemory'.
+  // that the caller must provide 'scratchMemory'. 'noNulls' means that the
+  // positions in 'rows' are not checked for null values.
   void lookupValueIds(
       const BaseVector& values,
       SelectivityVector& rows,
       ScratchMemory& scratchMemory,
-      raw_vector<uint64_t>& result) const;
+      raw_vector<uint64_t>& result,
+      bool noNulls = true) const;
 
   // Returns true if either range or distinct values have not overflowed.
   bool mayUseValueIds() const {
@@ -386,6 +388,13 @@ class VectorHasher {
       const DecodedVector& decoded,
       SelectivityVector& rows,
       raw_vector<uint64_t>& hashes,
+      uint64_t* result,
+      bool noNulls) const;
+
+  // Shortcut for range mapping of int64 keys.
+  void lookupIdsRange64(
+      const DecodedVector& decoded,
+      SelectivityVector& rows,
       uint64_t* result) const;
 
   template <TypeKind Kind>


### PR DESCRIPTION
- Simdize Vectorhasher int64 range path.

- Simdize retrieving hash join result rows.

- Special inline path for normalized key hash join probe.

- faster mixing of bits for normalized key to hash number conversion.

Drops single thread time for velox_tpch_benchmark from 40s to 36s with
10G uncompressed Parquet dataset.