### PR TITLE
Add benchmark for slice

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -46,6 +46,10 @@ add_executable(velox_benchmark_basic_vector_compare VectorCompare.cpp)
 target_link_libraries(velox_benchmark_basic_vector_compare
                       ${velox_benchmark_deps} velox_vector_test_lib)
 
+add_executable(velox_benchmark_basic_vector_slice VectorSlice.cpp)
+target_link_libraries(velox_benchmark_basic_vector_slice
+                      ${velox_benchmark_deps} velox_vector_test_lib)
+
 add_executable(velox_benchmark_feature_normalization FeatureNormalization.cpp)
 target_link_libraries(velox_benchmark_feature_normalization
                       ${velox_benchmark_deps} velox_functions_prestosql)

--- a/velox/benchmarks/basic/VectorSlice.cpp
+++ b/velox/benchmarks/basic/VectorSlice.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <gflags/gflags.h>
+
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 1, "Seed for random input dataset generator");
+DEFINE_int32(slice_size, 512, "Slice size");
+
+namespace facebook::velox {
+namespace {
+
+constexpr int kVectorSize = 16 << 10;
+
+struct BenchmarkData {
+  BenchmarkData() : pool_(memory::getDefaultScopedMemoryPool()) {
+    VectorFuzzer::Options opts;
+    opts.nullRatio = 0.01;
+    opts.vectorSize = kVectorSize;
+    VectorFuzzer fuzzer(opts, pool_.get(), FLAGS_fuzzer_seed);
+    flatVector = fuzzer.fuzzFlat(BIGINT());
+    arrayVector = fuzzer.fuzzFlat(ARRAY(BIGINT()));
+    mapVector = fuzzer.fuzzFlat(MAP(BIGINT(), BIGINT()));
+    rowVector = fuzzer.fuzzFlat(ROW({BIGINT(), BIGINT(), BIGINT()}));
+  }
+
+ private:
+  std::unique_ptr<memory::MemoryPool> pool_;
+
+ public:
+  VectorPtr flatVector;
+  VectorPtr arrayVector;
+  VectorPtr mapVector;
+  VectorPtr rowVector;
+};
+
+std::unique_ptr<BenchmarkData> data;
+
+int runSlice(const BaseVector& vec, vector_size_t offset) {
+  int count = 0;
+  for (int i = offset; i + FLAGS_slice_size < vec.size();
+       i += FLAGS_slice_size) {
+    auto slice = vec.slice(i, FLAGS_slice_size);
+    folly::doNotOptimizeAway(slice);
+    ++count;
+  }
+  return count;
+}
+
+int runCopy(const BaseVector& vec) {
+  int count = 0;
+  for (int i = 0; i + FLAGS_slice_size < vec.size(); i += FLAGS_slice_size) {
+    auto copy = BaseVector::create(vec.type(), FLAGS_slice_size, vec.pool());
+    copy->copy(&vec, 0, i, FLAGS_slice_size);
+    folly::doNotOptimizeAway(copy);
+    ++count;
+  }
+  return count;
+}
+
+#define DEFINE_BENCHMARKS(name)                    \
+  BENCHMARK_MULTI(name##Slice) {                   \
+    return runSlice(*data->name##Vector, 0);       \
+  }                                                \
+  BENCHMARK_RELATIVE_MULTI(name##SliceUnaligned) { \
+    return runSlice(*data->name##Vector, 1);       \
+  }                                                \
+  BENCHMARK_RELATIVE_MULTI(name##Copy) {           \
+    return runCopy(*data->name##Vector);           \
+  }
+
+DEFINE_BENCHMARKS(flat)
+DEFINE_BENCHMARKS(array)
+DEFINE_BENCHMARKS(map)
+DEFINE_BENCHMARKS(row)
+
+} // namespace
+} // namespace facebook::velox
+
+int main(int argc, char* argv[]) {
+  using namespace facebook::velox;
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  VELOX_CHECK_LE(FLAGS_slice_size, kVectorSize);
+  data = std::make_unique<BenchmarkData>();
+  folly::runBenchmarks();
+  data.reset();
+  return 0;
+}


### PR DESCRIPTION
Summary:
```
buck run @mode/opt //velox/benchmarks/basic:vector_slice
============================================================================
velox/benchmarks/basic/VectorSlice.cpp     relative  time/iter   iters/s
============================================================================
flatSlice                                                 281.84ns     3.55M
flatSliceUnaligned                              92.626%   304.28ns     3.29M
flatCopy                                        74.341%   379.12ns     2.64M
arraySlice                                                442.03ns     2.26M
arraySliceUnaligned                               95.3%   463.83ns     2.16M
arrayCopy                                       3.8662%    11.43us    87.46K
mapSlice                                                  478.80ns     2.09M
mapSliceUnaligned                               90.899%   526.74ns     1.90M
mapCopy                                         2.9986%    15.97us    62.63K
rowSlice                                                    1.01us   990.48K
rowSliceUnaligned                               85.632%     1.18us   848.17K
rowCopy                                         13.166%     7.67us   130.40K
```

Differential Revision: D38801565

