### PR TITLE
Use is_same_v instead of is_same<>::value

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -960,7 +960,7 @@ class Allocator {
 
   template <typename T1>
   bool operator==(const Allocator<T1>& rhs) const {
-    if constexpr (std::is_same<T, T1>::value) {
+    if constexpr (std::is_same_v<T, T1>) {
       return &this->pool == &rhs.pool;
     }
     return false;

--- a/velox/common/serialization/Serializable.h
+++ b/velox/common/serialization/Serializable.h
@@ -64,9 +64,9 @@ using objCreateType = T(const folly::dynamic&);
 template <class T>
 struct has_static_obj_create_type<
     T,
-    std::enable_if_t<std::is_same<
-        decltype(T::create(std::declval<folly::dynamic>())),
-        T>::value>> : std::true_type {};
+    std::enable_if_t<
+        std::is_same_v<decltype(T::create(std::declval<folly::dynamic>())), T>>>
+    : std::true_type {};
 
 template <class>
 struct vector_type {
@@ -90,9 +90,9 @@ struct has_serialize_type : std::false_type {};
 template <class T>
 struct has_serialize_type<
     T,
-    std::enable_if_t<std::is_same<
+    std::enable_if_t<std::is_same_v<
         decltype(std::declval<T>().serialize()),
-        serilizationformat>::value>> : std::true_type {};
+        serilizationformat>>> : std::true_type {};
 
 class ISerializable {
  public:
@@ -143,7 +143,7 @@ class ISerializable {
   template <
       class T,
       std::enable_if_t<
-          std::is_same<T, folly::Optional<typename T::value_type>>::value>>
+          std::is_same_v<T, folly::Optional<typename T::value_type>>>>
   static folly::dynamic serialize(const folly::Optional<T>& val) {
     if (!val.hasValue()) {
       return nullptr;
@@ -200,7 +200,7 @@ class ISerializable {
   template <
       class T,
       typename = std::enable_if_t<
-          std::is_integral<T>::value && !std::is_same<T, bool>::value>>
+          std::is_integral<T>::value && !std::is_same_v<T, bool>>>
   static T deserialize(const folly::dynamic& obj) {
     auto raw = obj.asInt();
     VELOX_USER_CHECK_GE(raw, std::numeric_limits<T>::min());
@@ -208,21 +208,21 @@ class ISerializable {
     return (T)raw;
   }
 
-  template <class T, typename = std::enable_if_t<std::is_same<T, bool>::value>>
+  template <class T, typename = std::enable_if_t<std::is_same_v<T, bool>>>
   static bool deserialize(const folly::dynamic& obj) {
     return obj.asBool();
   }
 
   template <
       class T,
-      typename = std::enable_if_t<std::is_same<T, double>::value>>
+      typename = std::enable_if_t<std::is_same_v<T, double>>>
   static double deserialize(const folly::dynamic& obj) {
     return obj.asDouble();
   }
 
   template <
       class T,
-      typename = std::enable_if_t<std::is_same<T, std::string>::value>>
+      typename = std::enable_if_t<std::is_same_v<T, std::string>>>
   static std::string deserialize(const folly::dynamic& obj) {
     return obj.asString();
   }
@@ -230,7 +230,7 @@ class ISerializable {
   template <
       class T,
       typename = std::enable_if_t<
-          std::is_same<T, folly::Optional<typename T::value_type>>::value>>
+          std::is_same_v<T, folly::Optional<typename T::value_type>>>>
   static folly::Optional<
       decltype(ISerializable::deserialize<typename T::value_type>(
           std::declval<folly::dynamic>()))>
@@ -266,9 +266,9 @@ class ISerializable {
 
   template <
       class T,
-      typename = std::enable_if_t<std::is_same<
+      typename = std::enable_if_t<std::is_same_v<
           T,
-          std::map<typename T::key_type, typename T::mapped_type>>::value>>
+          std::map<typename T::key_type, typename T::mapped_type>>>>
   static std::map<
       decltype(ISerializable::deserialize<typename T::key_type>(
           std::declval<folly::dynamic>())),

--- a/velox/common/serialization/Serializable.h
+++ b/velox/common/serialization/Serializable.h
@@ -213,9 +213,7 @@ class ISerializable {
     return obj.asBool();
   }
 
-  template <
-      class T,
-      typename = std::enable_if_t<std::is_same_v<T, double>>>
+  template <class T, typename = std::enable_if_t<std::is_same_v<T, double>>>
   static double deserialize(const folly::dynamic& obj) {
     return obj.asDouble();
   }

--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -194,7 +194,7 @@ struct TypeAnalysis {
 template <typename T>
 struct TypeAnalysis<Generic<T>> {
   void run(TypeAnalysisResults& results) {
-    if constexpr (std::is_same<T, AnyType>::value) {
+    if constexpr (std::is_same_v<T, AnyType>) {
       results.out << "any";
     } else {
       auto variableType = fmt::format("__user_T{}", T::getId());

--- a/velox/dwio/dwrf/common/FloatingPointDecoder.h
+++ b/velox/dwio/dwrf/common/FloatingPointDecoder.h
@@ -63,7 +63,7 @@ class FloatingPointDecoder {
 
   template <bool hasNulls, typename Visitor>
   void readWithVisitor(const uint64_t* nulls, Visitor visitor) {
-    if (std::is_same<TData, TRequested>::value &&
+    if (std::is_same_v<TData, TRequested> &&
         dwio::common::useFastPath<Visitor, hasNulls>(visitor)) {
       fastPath<hasNulls>(nulls, visitor);
       return;
@@ -103,11 +103,11 @@ class FloatingPointDecoder {
   template <bool hasNulls, typename Visitor>
   void fastPath(const uint64_t* nulls, Visitor& visitor) {
     constexpr bool hasFilter =
-        !std::is_same<typename Visitor::FilterType, common::AlwaysTrue>::value;
+        !std::is_same_v<typename Visitor::FilterType, common::AlwaysTrue>;
     constexpr bool filterOnly =
-        std::is_same<typename Visitor::Extract, DropValues>::value;
+        std::is_same_v<typename Visitor::Extract, DropValues>;
     constexpr bool hasHook =
-        !std::is_same<typename Visitor::HookType, dwio::common::NoHook>::value;
+        !std::is_same_v<typename Visitor::HookType, dwio::common::NoHook>;
     int32_t numValues = 0;
     auto rows = visitor.rows();
     auto numRows = visitor.numRows();

--- a/velox/dwio/dwrf/common/RLEv1.h
+++ b/velox/dwio/dwrf/common/RLEv1.h
@@ -325,9 +325,9 @@ class RleDecoderV1 : public dwio::common::IntDecoder<isSigned> {
   template <bool hasNulls, typename Visitor>
   void fastPath(const uint64_t* nulls, Visitor& visitor) {
     constexpr bool hasFilter =
-        !std::is_same<typename Visitor::FilterType, common::AlwaysTrue>::value;
+        !std::is_same_v<typename Visitor::FilterType, common::AlwaysTrue>;
     constexpr bool hasHook =
-        !std::is_same<typename Visitor::HookType, dwio::common::NoHook>::value;
+        !std::is_same_v<typename Visitor::HookType, dwio::common::NoHook>;
     auto rows = visitor.rows();
     auto numRows = visitor.numRows();
     auto rowsAsRange = folly::Range<const int32_t*>(rows, numRows);

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -162,10 +162,10 @@ void SelectiveByteRleColumnReader::processFilter(
       filterNulls<int8_t>(
           rows,
           true,
-          !std::is_same<decltype(extractValues), DropValues>::value);
+          !std::is_same_v<decltype(extractValues), DropValues>);
       break;
     case FilterKind::kIsNotNull:
-      if (std::is_same<decltype(extractValues), DropValues>::value) {
+      if (std::is_same_v<decltype(extractValues), DropValues>) {
         filterNulls<int8_t>(rows, false, false);
       } else {
         readHelper<common::IsNotNull, isDense>(filter, rows, extractValues);

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -160,9 +160,7 @@ void SelectiveByteRleColumnReader::processFilter(
       break;
     case FilterKind::kIsNull:
       filterNulls<int8_t>(
-          rows,
-          true,
-          !std::is_same_v<decltype(extractValues), DropValues>);
+          rows, true, !std::is_same_v<decltype(extractValues), DropValues>);
       break;
     case FilterKind::kIsNotNull:
       if (std::is_same_v<decltype(extractValues), DropValues>) {

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -140,10 +140,10 @@ void SelectiveStringDictionaryColumnReader::processFilter(
       filterNulls<int32_t>(
           rows,
           true,
-          !std::is_same<decltype(extractValues), DropValues>::value);
+          !std::is_same_v<decltype(extractValues), DropValues>);
       break;
     case common::FilterKind::kIsNotNull:
-      if (std::is_same<decltype(extractValues), DropValues>::value) {
+      if (std::is_same_v<decltype(extractValues), DropValues>) {
         filterNulls<int32_t>(rows, false, false);
       } else {
         readHelper<common::IsNotNull, isDense>(filter, rows, extractValues);

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -138,9 +138,7 @@ void SelectiveStringDictionaryColumnReader::processFilter(
       break;
     case common::FilterKind::kIsNull:
       filterNulls<int32_t>(
-          rows,
-          true,
-          !std::is_same_v<decltype(extractValues), DropValues>);
+          rows, true, !std::is_same_v<decltype(extractValues), DropValues>);
       break;
     case common::FilterKind::kIsNotNull:
       if (std::is_same_v<decltype(extractValues), DropValues>) {

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -315,11 +315,10 @@ void SelectiveStringDirectColumnReader::readWithVisitor(
   vector_size_t numRows = rows.back() + 1;
   int32_t current = visitor.start();
   constexpr bool isExtract =
-      std::is_same<typename TVisitor::FilterType, common::AlwaysTrue>::value &&
-      std::is_same<
+      std::is_same_v<typename TVisitor::FilterType, common::AlwaysTrue> &&
+      std::is_same_v<
           typename TVisitor::Extract,
-          dwio::common::ExtractToReader<SelectiveStringDirectColumnReader>>::
-          value;
+          dwio::common::ExtractToReader<SelectiveStringDirectColumnReader>>;
   auto nulls = nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
 
   if (process::hasAvx2() && isExtract) {
@@ -387,10 +386,10 @@ void SelectiveStringDirectColumnReader::processFilter(
       filterNulls<StringView>(
           rows,
           true,
-          !std::is_same<decltype(extractValues), DropValues>::value);
+          !std::is_same_v<decltype(extractValues), DropValues>);
       break;
     case common::FilterKind::kIsNotNull:
-      if (std::is_same<decltype(extractValues), DropValues>::value) {
+      if (std::is_same_v<decltype(extractValues), DropValues>) {
         filterNulls<StringView>(rows, false, false);
       } else {
         readHelper<common::IsNotNull, isDense>(filter, rows, extractValues);

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -384,9 +384,7 @@ void SelectiveStringDirectColumnReader::processFilter(
       break;
     case common::FilterKind::kIsNull:
       filterNulls<StringView>(
-          rows,
-          true,
-          !std::is_same_v<decltype(extractValues), DropValues>);
+          rows, true, !std::is_same_v<decltype(extractValues), DropValues>);
       break;
     case common::FilterKind::kIsNotNull:
       if (std::is_same_v<decltype(extractValues), DropValues>) {

--- a/velox/exec/AggregationHook.h
+++ b/velox/exec/AggregationHook.h
@@ -100,8 +100,7 @@ namespace {
 template <typename TOutput, typename TInput>
 inline void updateSingleValue(TOutput& result, TInput value) {
   if constexpr (
-      std::is_same_v<TOutput, double> ||
-      std::is_same_v<TOutput, float>) {
+      std::is_same_v<TOutput, double> || std::is_same_v<TOutput, float>) {
     result += value;
   } else {
     result = checkedPlus<TOutput>(result, value);

--- a/velox/exec/AggregationHook.h
+++ b/velox/exec/AggregationHook.h
@@ -100,8 +100,8 @@ namespace {
 template <typename TOutput, typename TInput>
 inline void updateSingleValue(TOutput& result, TInput value) {
   if constexpr (
-      std::is_same<TOutput, double>::value ||
-      std::is_same<TOutput, float>::value) {
+      std::is_same_v<TOutput, double> ||
+      std::is_same_v<TOutput, float>) {
     result += value;
   } else {
     result = checkedPlus<TOutput>(result, value);
@@ -121,18 +121,18 @@ class SumHook final : public AggregationHook {
       : AggregationHook(offset, nullByte, nullMask, groups, numNulls) {}
 
   Kind kind() const override {
-    if (std::is_same<TAggregate, double>::value) {
-      if (std::is_same<TValue, double>::value) {
+    if (std::is_same_v<TAggregate, double>) {
+      if (std::is_same_v<TValue, double>) {
         return kSumDoubleToDouble;
       }
-      if (std::is_same<TValue, float>::value) {
+      if (std::is_same_v<TValue, float>) {
         return kSumFloatToDouble;
       }
-    } else if (std::is_same<TAggregate, int64_t>::value) {
-      if (std::is_same<TValue, int32_t>::value) {
+    } else if (std::is_same_v<TAggregate, int64_t>) {
+      if (std::is_same_v<TValue, int32_t>) {
         return kSumIntegerToBigint;
       }
-      if (std::is_same<TValue, int64_t>::value) {
+      if (std::is_same_v<TValue, int64_t>) {
         return kSumBigintToBigint;
       }
     }
@@ -190,23 +190,23 @@ class MinMaxHook final : public AggregationHook {
 
   Kind kind() const override {
     if (isMin) {
-      if (std::is_same<T, int64_t>::value) {
+      if (std::is_same_v<T, int64_t>) {
         return kBigintMin;
       }
-      if (std::is_same<T, float>::value) {
+      if (std::is_same_v<T, float>) {
         return kFloatMin;
       }
-      if (std::is_same<T, double>::value) {
+      if (std::is_same_v<T, double>) {
         return kDoubleMin;
       }
     } else {
-      if (std::is_same<T, int64_t>::value) {
+      if (std::is_same_v<T, int64_t>) {
         return kBigintMax;
       }
-      if (std::is_same<T, float>::value) {
+      if (std::is_same_v<T, float>) {
         return kFloatMax;
       }
-      if (std::is_same<T, double>::value) {
+      if (std::is_same_v<T, double>) {
         return kDoubleMax;
       }
     }

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -528,7 +528,7 @@ class RowContainer {
       return;
     }
     *reinterpret_cast<T*>(row + offset) = decoded.valueAt<T>(index);
-    if constexpr (std::is_same<T, StringView>::value) {
+    if constexpr (std::is_same_v<T, StringView>) {
       RowSizeTracker tracker(row[rowSizeOffset_], stringAllocator_);
       stringAllocator_.copyMultipart(row, offset);
     }
@@ -542,7 +542,7 @@ class RowContainer {
       int32_t offset) {
     using T = typename TypeTraits<Kind>::NativeType;
     *reinterpret_cast<T*>(group + offset) = decoded.valueAt<T>(index);
-    if constexpr (std::is_same<T, StringView>::value) {
+    if constexpr (std::is_same_v<T, StringView>) {
       RowSizeTracker tracker(group[rowSizeOffset_], stringAllocator_);
       stringAllocator_.copyMultipart(group, offset);
     }

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -131,11 +131,11 @@ struct RowTypeTrait {
     if constexpr (index == sizeof...(T)) {
       return;
     } else {
-      if constexpr (std::is_same<
+      if constexpr (std::is_same_v<
                         TempStringNullable<TempsAllocator>,
                         typename std::tuple_element<
                             index,
-                            CodegenTupleWritersType>::type>::value) {
+                            CodegenTupleWritersType>::type>) {
         if (std::get<index>(viewTuple).has_value()) {
           std::get<index>(out) = InputReferenceStringNullable{
               InputReferenceString{*std::get<index>(viewTuple)}};
@@ -164,11 +164,11 @@ struct RowTypeTrait {
       return;
 
     } else {
-      if constexpr (std::is_same<
+      if constexpr (std::is_same_v<
                         TempStringNullable<TempsAllocator>,
                         typename std::tuple_element<
                             index,
-                            CodegenTupleWritersType>::type>::value) {
+                            CodegenTupleWritersType>::type>) {
         if (std::get<index>(writers).has_value()) {
           auto& tempString = *std::get<index>(writers);
           std::get<index>(out) = {

--- a/velox/experimental/codegen/functions/CastFunctionStub.h
+++ b/velox/experimental/codegen/functions/CastFunctionStub.h
@@ -27,7 +27,7 @@ struct CodegenConversionStub {
 
   template <typename T>
   static ReturnType<T> cast(const T& arg) {
-    if constexpr (std::is_same<codegen::TempString<TempsAllocator>, T>::value) {
+    if constexpr (std::is_same_v<codegen::TempString<TempsAllocator>, T>) {
       return util::Converter<kind, void, castByTruncate>::cast(
           folly::StringPiece(arg.data(), arg.size()));
     } else {

--- a/velox/experimental/codegen/functions/HashFunctionStub.h
+++ b/velox/experimental/codegen/functions/HashFunctionStub.h
@@ -38,7 +38,7 @@ namespace facebook::velox::codegen {
 
 template <typename T>
 FOLLY_ALWAYS_INLINE int64_t computeHashStub(const T& arg) {
-  if constexpr (std::is_same<codegen::TempString<TempsAllocator>, T>::value) {
+  if constexpr (std::is_same_v<codegen::TempString<TempsAllocator>, T>) {
     //   std::cerr << std::string_view(arg.data(), arg.size());
     return functions::computeHash(std::string_view(arg.data(), arg.size()));
   } else {

--- a/velox/experimental/codegen/vector_function/StringTypes.h
+++ b/velox/experimental/codegen/vector_function/StringTypes.h
@@ -194,8 +194,8 @@ struct TempString {
 
   template <typename T>
   typename std::enable_if<
-      std::is_same<T, InputReferenceString>::value ||
-          std::is_same<T, ConstantString>::value,
+      std::is_same_v<T, InputReferenceString> ||
+          std::is_same_v<T, ConstantString>,
       void>::type
   operator=(const T& other_) {
     auto& other = other_.get();
@@ -252,8 +252,8 @@ struct TempStringNullable {
   // Assigns temp to inputRef or to constant
   template <typename T>
   typename std::enable_if<
-      std::is_same<T, InputReferenceStringNullable>::value ||
-          std::is_same<T, ConstantStringNullable>::value,
+      std::is_same_v<T, InputReferenceStringNullable> ||
+          std::is_same_v<T, ConstantStringNullable>,
       void>::type
   operator=(const T& other) {
     if UNLIKELY (!other.has_value()) {

--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -68,13 +68,13 @@ struct PrimitiveWriter {
 
 template <typename V>
 bool constexpr provide_std_interface =
-    CppToType<V>::isPrimitiveType && !std::is_same<Varchar, V>::value &&
-    !std::is_same<Varbinary, V>::value && !std::is_same<Any, V>::value;
+    CppToType<V>::isPrimitiveType && !std::is_same_v<Varchar, V> &&
+    !std::is_same_v<Varbinary, V> && !std::is_same_v<Any, V>;
 
 // bool is an exception, it requires commit but also provides std::interface.
 template <typename V>
 bool constexpr requires_commit =
-    !provide_std_interface<V> || std::is_same<bool, V>::value;
+    !provide_std_interface<V> || std::is_same_v<bool, V>;
 
 // The object passed to the simple function interface that represent a single
 // array entry.

--- a/velox/expression/tests/SimpleFunctionPresetNullsTest.cpp
+++ b/velox/expression/tests/SimpleFunctionPresetNullsTest.cpp
@@ -47,9 +47,9 @@ class SimpleFunctionPresetNullsTest : public functions::test::FunctionBaseTest {
     struct udf {
       VELOX_DEFINE_FUNCTION_TYPES(ExecEnv);
       bool call(out_type<T>& out, const arg_type<T>& in) {
-        if constexpr (std::is_same<T, Varchar>::value) {
+        if constexpr (std::is_same_v<T, Varchar>) {
           out.setEmpty();
-        } else if constexpr (std::is_same<T, Array<int64_t>>::value) {
+        } else if constexpr (std::is_same_v<T, Array<int64_t>>) {
           out.push_back(1);
         } else {
           out = in;
@@ -67,14 +67,14 @@ class SimpleFunctionPresetNullsTest : public functions::test::FunctionBaseTest {
   // Create vector of type T as input with arbitrary data.
   template <typename T>
   RowVectorPtr createInput(vector_size_t size) {
-    if constexpr (std::is_same<T, Varchar>::value) {
+    if constexpr (std::is_same_v<T, Varchar>) {
       auto flatInput = makeFlatVector<StringView>(size);
 
       for (auto i = 0; i < flatInput->size(); i++) {
         flatInput->set(i, "test"_sv);
       }
       return makeRowVector({flatInput});
-    } else if constexpr (std::is_same<T, Array<int64_t>>::value) {
+    } else if constexpr (std::is_same_v<T, Array<int64_t>>) {
       std::vector<std::vector<int64_t>> arrayData{(unsigned int)size, {1}};
       auto input = vectorMaker_.arrayVector(arrayData);
       return makeRowVector({input});
@@ -91,9 +91,9 @@ class SimpleFunctionPresetNullsTest : public functions::test::FunctionBaseTest {
   template <typename T>
   VectorPtr createResults(vector_size_t size) {
     VectorPtr result;
-    if constexpr (std::is_same<T, Varchar>::value) {
+    if constexpr (std::is_same_v<T, Varchar>) {
       result = makeFlatVector<StringView>(size);
-    } else if constexpr (std::is_same<T, Array<int64_t>>::value) {
+    } else if constexpr (std::is_same_v<T, Array<int64_t>>) {
       std::vector<std::vector<int64_t>> arrayData{(unsigned int)size, {1}};
       result = vectorMaker_.arrayVector(arrayData);
     } else {

--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -29,7 +29,7 @@ template <typename TNum, typename TDecimals, bool alwaysRoundNegDec = false>
 FOLLY_ALWAYS_INLINE TNum
 round(const TNum& number, const TDecimals& decimals = 0) {
   static_assert(
-      !std::is_same<TNum, bool>::value && "round not supported for bool");
+      !std::is_same_v<TNum, bool> && "round not supported for bool");
 
   if constexpr (std::is_integral<TNum>::value) {
     if constexpr (alwaysRoundNegDec) {

--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -28,8 +28,7 @@ namespace facebook::velox::functions {
 template <typename TNum, typename TDecimals, bool alwaysRoundNegDec = false>
 FOLLY_ALWAYS_INLINE TNum
 round(const TNum& number, const TDecimals& decimals = 0) {
-  static_assert(
-      !std::is_same_v<TNum, bool> && "round not supported for bool");
+  static_assert(!std::is_same_v<TNum, bool> && "round not supported for bool");
 
   if constexpr (std::is_integral<TNum>::value) {
     if constexpr (alwaysRoundNegDec) {

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -219,7 +219,7 @@ struct CombinationsFunction {
         innerArray.add_null();
         continue;
       }
-      if constexpr (std::is_same<T, Varchar>::value) {
+      if constexpr (std::is_same_v<T, Varchar>) {
         innerArray.add_item().setNoCopy(array[idx].value());
       } else {
         innerArray.add_item() = array[idx].value();

--- a/velox/functions/prestosql/Bitwise.h
+++ b/velox/functions/prestosql/Bitwise.h
@@ -112,11 +112,11 @@ template <typename T>
 struct BitwiseLeftShiftFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, TInput number, TInput shift) {
-    if constexpr (std::is_same<TInput, int8_t>::value) {
+    if constexpr (std::is_same_v<TInput, int8_t>) {
       return bitwiseLeftShift<TInput, 8>(result, number, shift);
-    } else if constexpr (std::is_same<TInput, int16_t>::value) {
+    } else if constexpr (std::is_same_v<TInput, int16_t>) {
       return bitwiseLeftShift<TInput, 16>(result, number, shift);
-    } else if constexpr (std::is_same<TInput, int32_t>::value) {
+    } else if constexpr (std::is_same_v<TInput, int32_t>) {
       return bitwiseLeftShift<TInput, 32>(result, number, shift);
     } else {
       return bitwiseLeftShift<TInput, 64>(result, number, shift);
@@ -140,11 +140,11 @@ template <typename T>
 struct BitwiseRightShiftFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, TInput number, TInput shift) {
-    if constexpr (std::is_same<TInput, int8_t>::value) {
+    if constexpr (std::is_same_v<TInput, int8_t>) {
       return bitwiseRightShift<int8_t, uint8_t, 8>(result, number, shift);
-    } else if constexpr (std::is_same<TInput, int16_t>::value) {
+    } else if constexpr (std::is_same_v<TInput, int16_t>) {
       return bitwiseRightShift<int16_t, uint16_t, 16>(result, number, shift);
-    } else if constexpr (std::is_same<TInput, int32_t>::value) {
+    } else if constexpr (std::is_same_v<TInput, int32_t>) {
       return bitwiseRightShift<int32_t, uint32_t, 32>(result, number, shift);
     } else {
       return bitwiseRightShift<int64_t, uint64_t, 64>(result, number, shift);
@@ -177,12 +177,12 @@ struct BitwiseRightShiftArithmeticFunction {
     }
 
     // clang-format off
-    if constexpr (std::is_same<TInput, int8_t>::value) {
+    if constexpr (std::is_same_v<TInput, int8_t>) {
       result = preserveSign<int8_t, 0b11111111L, 0b10000000L>(number) >> shift;
-    } else if constexpr (std::is_same<TInput, int16_t>::value) {
+    } else if constexpr (std::is_same_v<TInput, int16_t>) {
       result = preserveSign<int16_t, 0b1111111111111111L, 0b1000000000000000L>(number)
                 >> shift;
-    } else if constexpr (std::is_same<TInput, int32_t>::value) {
+    } else if constexpr (std::is_same_v<TInput, int32_t>) {
       result = preserveSign<int32_t, 0x00000000ffffffffL, 0x000000000080000000L>(number)
                 >> shift;
     } else {

--- a/velox/functions/prestosql/GreatestLeast.cpp
+++ b/velox/functions/prestosql/GreatestLeast.cpp
@@ -94,7 +94,8 @@ class ExtremeValueFunction : public exec::VectorFunction {
       rawResult[row] = currentValue;
     });
 
-    if constexpr (std::is_same_v<T, TypeTraits<TypeKind::VARCHAR>::NativeType>) {
+    if constexpr (std::
+                      is_same_v<T, TypeTraits<TypeKind::VARCHAR>::NativeType>) {
       auto* flatResult = (*result)->as<FlatVector<T>>();
       for (auto index : usedInputs) {
         flatResult->acquireSharedStringBuffers(args[index].get());

--- a/velox/functions/prestosql/GreatestLeast.cpp
+++ b/velox/functions/prestosql/GreatestLeast.cpp
@@ -52,8 +52,7 @@ class ExtremeValueFunction : public exec::VectorFunction {
   // For double, presto should throw error if input is Nan
   template <typename T>
   void checkNan(const T& value) const {
-    if constexpr (std::is_same<T, TypeTraits<TypeKind::DOUBLE>::NativeType>::
-                      value) {
+    if constexpr (std::is_same_v<T, TypeTraits<TypeKind::DOUBLE>::NativeType>) {
       if (std::isnan(value)) {
         VELOX_USER_FAIL(
             "Invalid argument to {}: NaN", isLeast ? "least()" : "greatest()");
@@ -95,8 +94,7 @@ class ExtremeValueFunction : public exec::VectorFunction {
       rawResult[row] = currentValue;
     });
 
-    if constexpr (std::is_same<T, TypeTraits<TypeKind::VARCHAR>::NativeType>::
-                      value) {
+    if constexpr (std::is_same_v<T, TypeTraits<TypeKind::VARCHAR>::NativeType>) {
       auto* flatResult = (*result)->as<FlatVector<T>>();
       for (auto index : usedInputs) {
         flatResult->acquireSharedStringBuffers(args[index].get());

--- a/velox/functions/sparksql/ArraySort.cpp
+++ b/velox/functions/sparksql/ArraySort.cpp
@@ -73,7 +73,7 @@ inline void swapWithNull(
     vector_size_t nullIndex) {
   // Values are already present in vector stringBuffers. Don't create additional
   // copy.
-  if constexpr (std::is_same<T, StringView>::value) {
+  if constexpr (std::is_same_v<T, StringView>) {
     vector->setNoCopy(nullIndex, vector->valueAt(index));
   } else {
     vector->set(nullIndex, vector->valueAt(index));

--- a/velox/parse/tests/VariantToVectorTest.cpp
+++ b/velox/parse/tests/VariantToVectorTest.cpp
@@ -48,7 +48,7 @@ class VariantToVectorTest : public testing::Test {
       auto& var = inputArray[i];
       if (var.isNull()) {
         ASSERT_TRUE(elements->isNullAt(i));
-      } else if constexpr (std::is_same<TCpp, StringView>::value) {
+      } else if constexpr (std::is_same_v<TCpp, StringView>) {
         ASSERT_EQ(
             var.template value<KIND>(), std::string(elements->valueAt(i)));
       } else {

--- a/velox/row/UnsafeRowParser.h
+++ b/velox/row/UnsafeRowParser.h
@@ -39,7 +39,7 @@ struct UnsafeRowStaticUtilities {
    */
   template <typename SqlType>
   constexpr static inline TypeKind simpleSqlTypeToTypeKind() {
-    if constexpr (std::is_same<SqlType, BooleanType>::value) {
+    if constexpr (std::is_same_v<SqlType, BooleanType>) {
       return TypeKind::BOOLEAN;
     } else if constexpr (std::is_same_v<SqlType, TinyintType>) {
       return TypeKind::TINYINT;

--- a/velox/row/UnsafeRowSerializer.h
+++ b/velox/row/UnsafeRowSerializer.h
@@ -89,8 +89,8 @@ struct UnsafeRowSerializer {
           UnsafeRowStaticUtilities::simpleSqlTypeToTypeKind<SqlType>()>(
           data, buffer, idx);
     } else if constexpr (
-        std::is_same<SqlType, VarcharType>::value ||
-        std::is_same<SqlType, VarbinaryType>::value) {
+        std::is_same_v<SqlType, VarcharType> ||
+        std::is_same_v<SqlType, VarbinaryType>) {
       return serializeStringView(data, buffer, idx);
     } else {
       return ComplexTypeSerializer<SqlType>::serialize(data, buffer);
@@ -124,8 +124,8 @@ struct UnsafeRowSerializer {
   serializeComplexVectors(const DataType& data, char* buffer, size_t idx = 0) {
     if constexpr (
         UnsafeRowStaticUtilities::isFixedWidth<SqlType>() ||
-        std::is_same<SqlType, VarcharType>::value ||
-        std::is_same<SqlType, VarbinaryType>::value) {
+        std::is_same_v<SqlType, VarcharType> ||
+        std::is_same_v<SqlType, VarbinaryType>) {
       return serialize<SqlType, DataType>(data, buffer, idx);
     } else {
       /// Although we support Row<T...> in the static serializer, we do not

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -922,7 +922,7 @@ void serializeFlatVector(
           continue;
         }
         stream->appendNonNull();
-        if (std::is_same<T, StringView>::value) {
+        if (std::is_same_v<T, StringView>) {
           // Bunching consecutive non-nulls into one append does not work with
           // strings because the lengths will then get out of order with the
           // zero lengths produced by nulls.
@@ -940,7 +940,7 @@ void serializeFlatVector(
         }
       }
     }
-    if (firstNonNull != -1 && !std::is_same<T, StringView>::value) {
+    if (firstNonNull != -1 && !std::is_same_v<T, StringView>) {
       stream->append<T>(folly::Range(
           &rawValues[firstNonNull], 1 + lastNonNull - firstNonNull));
     }
@@ -1382,7 +1382,7 @@ void estimateConstantSerializedSize(
   int32_t elementSize = sizeof(T);
   if (constantVector->isNullAt(0)) {
     elementSize = 1;
-  } else if (std::is_same<T, StringView>::value) {
+  } else if (std::is_same_v<T, StringView>) {
     auto value = constantVector->valueAt(0);
     auto string = reinterpret_cast<const StringView*>(&value);
     elementSize = string->size();

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1025,7 +1025,7 @@ class FloatingPointRange final : public AbstractRange {
             upperUnbounded,
             upperExclusive,
             nullAllowed,
-            (std::is_same<T, double>::value) ? FilterKind::kDoubleRange
+            (std::is_same_v<T, double>) ? FilterKind::kDoubleRange
                                              : FilterKind::kFloatRange),
         lower_(lower),
         upper_(upper) {
@@ -1040,7 +1040,7 @@ class FloatingPointRange final : public AbstractRange {
             other.upperUnbounded_,
             other.upperExclusive_,
             nullAllowed,
-            (std::is_same<T, double>::value) ? FilterKind::kDoubleRange
+            (std::is_same_v<T, double>) ? FilterKind::kDoubleRange
                                              : FilterKind::kFloatRange),
         lower_(other.lower_),
         upper_(other.upper_) {
@@ -1662,14 +1662,14 @@ class MultiRange final : public Filter {
 // Helper for applying filters to different types
 template <typename TFilter, typename T>
 static inline bool applyFilter(TFilter& filter, T value) {
-  if (std::is_same<T, int8_t>::value || std::is_same<T, int16_t>::value ||
-      std::is_same<T, int32_t>::value || std::is_same<T, int64_t>::value) {
+  if (std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t> ||
+      std::is_same_v<T, int32_t> || std::is_same_v<T, int64_t>) {
     return filter.testInt64(value);
-  } else if (std::is_same<T, float>::value) {
+  } else if (std::is_same_v<T, float>) {
     return filter.testFloat(value);
-  } else if (std::is_same<T, double>::value) {
+  } else if (std::is_same_v<T, double>) {
     return filter.testDouble(value);
-  } else if (std::is_same<T, bool>::value) {
+  } else if (std::is_same_v<T, bool>) {
     return filter.testBool(value);
   } else {
     VELOX_CHECK(false, "Bad argument type to filter");

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1026,7 +1026,7 @@ class FloatingPointRange final : public AbstractRange {
             upperExclusive,
             nullAllowed,
             (std::is_same_v<T, double>) ? FilterKind::kDoubleRange
-                                             : FilterKind::kFloatRange),
+                                        : FilterKind::kFloatRange),
         lower_(lower),
         upper_(upper) {
     VELOX_CHECK(lowerUnbounded || !std::isnan(lower_));
@@ -1041,7 +1041,7 @@ class FloatingPointRange final : public AbstractRange {
             other.upperExclusive_,
             nullAllowed,
             (std::is_same_v<T, double>) ? FilterKind::kDoubleRange
-                                             : FilterKind::kFloatRange),
+                                        : FilterKind::kFloatRange),
         lower_(other.lower_),
         upper_(other.upper_) {
     VELOX_CHECK(lowerUnbounded_ || !std::isnan(lower_));

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -295,8 +295,7 @@ class variant {
   template <
       typename T = long long,
       std::enable_if_t<
-          std::is_same<T, long long>::value &&
-              !std::is_same<long long, int64_t>::value,
+          std::is_same_v<T, long long> && !std::is_same_v<long long, int64_t>,
           bool> = true>
   /* implicit */ variant(const T& v) : variant(static_cast<int64_t>(v)) {}
 

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -235,7 +235,7 @@ static VectorPtr createEmpty(
   using T = typename TypeTraits<kind>::NativeType;
 
   BufferPtr values;
-  if constexpr (std::is_same<T, StringView>::value) {
+  if constexpr (std::is_same_v<T, StringView>) {
     // Make sure to initialize StringView values so they can be safely accessed.
     values = AlignedBuffer::allocate<T>(size, pool, T());
   } else {

--- a/velox/vector/BiasVector-inl.h
+++ b/velox/vector/BiasVector-inl.h
@@ -111,7 +111,7 @@ const T BiasVector<T>::valueAtFast(vector_size_t idx) const {
 
 template <typename T>
 xsimd::batch<T> BiasVector<T>::loadSIMDValueBufferAt(size_t index) const {
-  if constexpr (std::is_same<T, int64_t>::value) {
+  if constexpr (std::is_same_v<T, int64_t>) {
     switch (valueType_) {
       case TypeKind::INTEGER:
         return biasBuffer_ + loadSIMDInternal<int32_t>(index);
@@ -122,7 +122,7 @@ xsimd::batch<T> BiasVector<T>::loadSIMDValueBufferAt(size_t index) const {
       default:
         VELOX_UNSUPPORTED("Invalid type");
     }
-  } else if constexpr (std::is_same<T, int32_t>::value) {
+  } else if constexpr (std::is_same_v<T, int32_t>) {
     switch (valueType_) {
       case TypeKind::SMALLINT:
         return biasBuffer_ + loadSIMDInternal<int16_t>(index);
@@ -131,7 +131,7 @@ xsimd::batch<T> BiasVector<T>::loadSIMDValueBufferAt(size_t index) const {
       default:
         VELOX_UNSUPPORTED("Invalid type");
     }
-  } else if constexpr (std::is_same<T, int16_t>::value) {
+  } else if constexpr (std::is_same_v<T, int16_t>) {
     switch (valueType_) {
       case TypeKind::TINYINT:
         return biasBuffer_ + loadSIMDInternal<int8_t>(index);

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -93,8 +93,8 @@ class BiasVector : public SimpleVector<T> {
 
  public:
   static constexpr bool can_simd =
-      (std::is_same<T, int64_t>::value || std::is_same<T, int32_t>::value ||
-       std::is_same<T, int16_t>::value);
+      (std::is_same_v<T, int64_t> || std::is_same_v<T, int32_t> ||
+       std::is_same_v<T, int16_t>);
 
   BiasVector(
       velox::memory::MemoryPool* pool,

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -36,9 +36,9 @@ template <typename T>
 class ConstantVector final : public SimpleVector<T> {
  public:
   static constexpr bool can_simd =
-      (std::is_same<T, int64_t>::value || std::is_same<T, int32_t>::value ||
-       std::is_same<T, int16_t>::value || std::is_same<T, int8_t>::value ||
-       std::is_same<T, bool>::value || std::is_same<T, size_t>::value);
+      (std::is_same_v<T, int64_t> || std::is_same_v<T, int32_t> ||
+       std::is_same_v<T, int16_t> || std::is_same_v<T, int8_t> ||
+       std::is_same_v<T, bool> || std::is_same_v<T, size_t>);
 
   ConstantVector(
       velox::memory::MemoryPool* pool,
@@ -90,7 +90,7 @@ class ConstantVector final : public SimpleVector<T> {
       valueVector_ = BaseVector::create(type, 1, pool);
       valueVector_->setNull(0, true);
     }
-    if (!isNull_ && std::is_same<T, StringView>::value) {
+    if (!isNull_ && std::is_same_v<T, StringView>) {
       // Copy string value.
       StringView* valuePtr = reinterpret_cast<StringView*>(&value_);
       setValue(std::string(valuePtr->data(), valuePtr->size()));
@@ -344,7 +344,7 @@ class ConstantVector final : public SimpleVector<T> {
       isNull_ = simple->isNullAt(index_);
       if (!isNull_) {
         value_ = simple->valueAt(index_);
-        if constexpr (std::is_same<T, StringView>::value) {
+        if constexpr (std::is_same_v<T, StringView>) {
           // Copy string value.
           StringView* valuePtr = reinterpret_cast<StringView*>(&value_);
           setValue(std::string(valuePtr->data(), valuePtr->size()));

--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -59,8 +59,7 @@ void DictionaryVector<T>::setInternalState() {
   if (dictionaryValues_->isScalar()) {
     scalarDictionaryValues_ =
         reinterpret_cast<SimpleVector<T>*>(dictionaryValues_->loadedVector());
-    if (scalarDictionaryValues_->isFlatEncoding() &&
-        !std::is_same_v<T, bool>) {
+    if (scalarDictionaryValues_->isFlatEncoding() && !std::is_same_v<T, bool>) {
       rawDictionaryValues_ =
           reinterpret_cast<FlatVector<T>*>(scalarDictionaryValues_)
               ->rawValues();

--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -60,7 +60,7 @@ void DictionaryVector<T>::setInternalState() {
     scalarDictionaryValues_ =
         reinterpret_cast<SimpleVector<T>*>(dictionaryValues_->loadedVector());
     if (scalarDictionaryValues_->isFlatEncoding() &&
-        !std::is_same<T, bool>::value) {
+        !std::is_same_v<T, bool>) {
       rawDictionaryValues_ =
           reinterpret_cast<FlatVector<T>*>(scalarDictionaryValues_)
               ->rawValues();

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -31,7 +31,7 @@ namespace velox {
 template <typename T>
 class DictionaryVector : public SimpleVector<T> {
  public:
-  static constexpr bool can_simd = std::is_same<T, int64_t>::value;
+  static constexpr bool can_simd = std::is_same_v<T, int64_t>;
 
   // Creates dictionary vector using base vector (dictionaryValues) and a set
   // of indices (dictionaryIndexArray).

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -324,7 +324,7 @@ void FlatVector<T>::resize(vector_size_t size, bool setNotNull) {
   }
   values_->setSize(minBytes);
 
-  if (std::is_same<T, StringView>::value) {
+  if (std::is_same_v<T, StringView>) {
     if (size < previousSize) {
       auto vector = this->template asUnchecked<SimpleVector<StringView>>();
       vector->invalidateIsAscii();
@@ -346,7 +346,7 @@ void FlatVector<T>::ensureWritable(const SelectivityVector& rows) {
   auto newSize = std::max<vector_size_t>(rows.size(), BaseVector::length_);
   if (values_ && !(values_->unique() && values_->isMutable())) {
     BufferPtr newValues;
-    if constexpr (std::is_same<T, StringView>::value) {
+    if constexpr (std::is_same_v<T, StringView>) {
       // Make sure to initialize StringView values so they can be safely
       // accessed.
       newValues = AlignedBuffer::allocate<T>(newSize, BaseVector::pool_, T());

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -38,9 +38,9 @@ class FlatVector final : public SimpleVector<T> {
   using value_type = T;
 
   static constexpr bool can_simd =
-      (std::is_same<T, int64_t>::value || std::is_same<T, int32_t>::value ||
-       std::is_same<T, int16_t>::value || std::is_same<T, int8_t>::value ||
-       std::is_same<T, bool>::value || std::is_same<T, size_t>::value);
+      (std::is_same_v<T, int64_t> || std::is_same_v<T, int32_t> ||
+       std::is_same_v<T, int16_t> || std::is_same_v<T, int8_t> ||
+       std::is_same_v<T, bool> || std::is_same_v<T, size_t>);
 
   // Minimum size of a string buffer. 32 KB value is chosen to ensure that a
   // single buffer is sufficient for a "typical" vector: 1K rows, medium size

--- a/velox/vector/SequenceVector-inl.h
+++ b/velox/vector/SequenceVector-inl.h
@@ -125,7 +125,7 @@ std::unique_ptr<SimpleVector<uint64_t>> SequenceVector<T>::hashAll() const {
 template <typename T>
 xsimd::batch<T> SequenceVector<T>::loadSIMDValueBufferAt(
     size_t byteOffset) const {
-  if constexpr (std::is_same<T, bool>::value) {
+  if constexpr (std::is_same_v<T, bool>) {
     throw std::runtime_error(
         "Sequence encoding only supports SIMD operations on integers");
   } else {

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -35,9 +35,9 @@ template <typename T>
 class SequenceVector : public SimpleVector<T> {
  public:
   static constexpr bool can_simd =
-      (std::is_same<T, int64_t>::value || std::is_same<T, int32_t>::value ||
-       std::is_same<T, int16_t>::value || std::is_same<T, int8_t>::value ||
-       std::is_same<T, size_t>::value);
+      (std::is_same_v<T, int64_t> || std::is_same_v<T, int32_t> ||
+       std::is_same_v<T, int16_t> || std::is_same_v<T, int8_t> ||
+       std::is_same_v<T, size_t>);
 
   SequenceVector(
       velox::memory::MemoryPool* pool,

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -203,8 +203,8 @@ class SimpleVector : public BaseVector {
   /// rows. If rowMappings is null then we revert to indexes in the
   /// SelectivityVector.
   template <typename U = T>
-  typename std::
-      enable_if<std::is_same_v<U, StringView>, std::optional<bool>>::type
+  typename std::enable_if<std::is_same_v<U, StringView>, std::optional<bool>>::
+      type
       isAscii(
           const SelectivityVector& rows,
           const vector_size_t* rowMappings = nullptr) const {
@@ -227,8 +227,8 @@ class SimpleVector : public BaseVector {
   /// 2. False if the string at that index is not ASCII
   /// 3. std::nullopt if we havent computed ASCII'ness at that index.
   template <typename U = T>
-  typename std::
-      enable_if<std::is_same_v<U, StringView>, std::optional<bool>>::type
+  typename std::enable_if<std::is_same_v<U, StringView>, std::optional<bool>>::
+      type
       isAscii(vector_size_t index) const {
     VELOX_CHECK_GE(index, 0)
     if (asciiSetRows_.size() > index && asciiSetRows_.isValid(index)) {
@@ -276,8 +276,9 @@ class SimpleVector : public BaseVector {
 
   /// Explicitly set asciness.
   template <typename U = T>
-  typename std::enable_if<std::is_same_v<U, StringView>, void>::type
-  setIsAscii(bool ascii, const SelectivityVector& rows) {
+  typename std::enable_if<std::is_same_v<U, StringView>, void>::type setIsAscii(
+      bool ascii,
+      const SelectivityVector& rows) {
     ensureIsAsciiCapacity(rows.end());
     if (asciiSetRows_.hasSelections() && !asciiSetRows_.isSubset(rows)) {
       isAllAscii_ &= ascii;

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -180,11 +180,11 @@ class SimpleVector : public BaseVector {
     if (isNullAt(index)) {
       out << "null";
     } else {
-      if constexpr (std::is_same<T, std::shared_ptr<void>>::value) {
+      if constexpr (std::is_same_v<T, std::shared_ptr<void>>) {
         out << "<opaque>";
       } else if constexpr (
-          std::is_same<T, UnscaledShortDecimal>::value ||
-          std::is_same<T, UnscaledLongDecimal>::value) {
+          std::is_same_v<T, UnscaledShortDecimal> ||
+          std::is_same_v<T, UnscaledLongDecimal>) {
         out << DecimalUtil::toString(valueAt(index), type());
       } else {
         out << velox::to<std::string>(valueAt(index));
@@ -204,7 +204,7 @@ class SimpleVector : public BaseVector {
   /// SelectivityVector.
   template <typename U = T>
   typename std::
-      enable_if<std::is_same<U, StringView>::value, std::optional<bool>>::type
+      enable_if<std::is_same_v<U, StringView>, std::optional<bool>>::type
       isAscii(
           const SelectivityVector& rows,
           const vector_size_t* rowMappings = nullptr) const {
@@ -228,7 +228,7 @@ class SimpleVector : public BaseVector {
   /// 3. std::nullopt if we havent computed ASCII'ness at that index.
   template <typename U = T>
   typename std::
-      enable_if<std::is_same<U, StringView>::value, std::optional<bool>>::type
+      enable_if<std::is_same_v<U, StringView>, std::optional<bool>>::type
       isAscii(vector_size_t index) const {
     VELOX_CHECK_GE(index, 0)
     if (asciiSetRows_.size() > index && asciiSetRows_.isValid(index)) {
@@ -240,7 +240,7 @@ class SimpleVector : public BaseVector {
   /// Computes and saves is-ascii flag for a given set of rows if not already
   /// present. Returns computed value.
   template <typename U = T>
-  typename std::enable_if<std::is_same<U, StringView>::value, bool>::type
+  typename std::enable_if<std::is_same_v<U, StringView>, bool>::type
   computeAndSetIsAscii(const SelectivityVector& rows) {
     if (rows.isSubset(asciiSetRows_)) {
       return isAllAscii_;
@@ -268,7 +268,7 @@ class SimpleVector : public BaseVector {
 
   /// Clears asciiness state.
   template <typename U = T>
-  typename std::enable_if<std::is_same<U, StringView>::value, void>::type
+  typename std::enable_if<std::is_same_v<U, StringView>, void>::type
   invalidateIsAscii() {
     asciiSetRows_.clearAll();
     isAllAscii_ = false;
@@ -276,7 +276,7 @@ class SimpleVector : public BaseVector {
 
   /// Explicitly set asciness.
   template <typename U = T>
-  typename std::enable_if<std::is_same<U, StringView>::value, void>::type
+  typename std::enable_if<std::is_same_v<U, StringView>, void>::type
   setIsAscii(bool ascii, const SelectivityVector& rows) {
     ensureIsAsciiCapacity(rows.end());
     if (asciiSetRows_.hasSelections() && !asciiSetRows_.isSubset(rows)) {
@@ -289,7 +289,7 @@ class SimpleVector : public BaseVector {
   }
 
   template <typename U = T>
-  typename std::enable_if<std::is_same<U, StringView>::value, void>::type
+  typename std::enable_if<std::is_same_v<U, StringView>, void>::type
   setAllIsAscii(bool ascii) {
     ensureIsAsciiCapacity(length_);
     isAllAscii_ = ascii;
@@ -298,7 +298,7 @@ class SimpleVector : public BaseVector {
 
  protected:
   template <typename U = T>
-  typename std::enable_if<std::is_same<U, StringView>::value, void>::type
+  typename std::enable_if<std::is_same_v<U, StringView>, void>::type
   ensureIsAsciiCapacity(vector_size_t size) {
     if (asciiSetRows_.size() < size) {
       asciiSetRows_.resize(size, false);

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -700,7 +700,7 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
         nullCount++;
       } else {
         bits::clearNull(rawNulls, i);
-        if constexpr (std::is_same<T, bool>::value) {
+        if constexpr (std::is_same_v<T, bool>) {
           bits::setBit(rawValues, i, *inputValues[i]);
         } else {
           rawValues[i] = *inputValues[i];

--- a/velox/vector/tests/BiasVectorTest.cpp
+++ b/velox/vector/tests/BiasVectorTest.cpp
@@ -106,7 +106,7 @@ TYPED_TEST(BiasVectorOverflowTest, maxOverflowTest_delta_int8) {
 
 TYPED_TEST(BiasVectorOverflowTest, maxOverflowTest_delta_int16) {
   size_t delta = std::numeric_limits<int16_t>::max();
-  if constexpr (std::is_same<TypeParam, int16_t>::value) {
+  if constexpr (std::is_same_v<TypeParam, int16_t>) {
     delta = std::numeric_limits<int8_t>::max();
   }
   this->runMaxOverflowTest(delta);
@@ -115,11 +115,11 @@ TYPED_TEST(BiasVectorOverflowTest, maxOverflowTest_delta_int16) {
 TYPED_TEST(BiasVectorOverflowTest, maxOverflowTest_delta_int32) {
   using T = TypeParam;
   size_t delta = std::numeric_limits<int32_t>::max();
-  if constexpr (std::is_same<T, int16_t>::value) {
+  if constexpr (std::is_same_v<T, int16_t>) {
     delta = std::numeric_limits<int8_t>::max();
   }
 
-  if constexpr (std::is_same<T, int32_t>::value) {
+  if constexpr (std::is_same_v<T, int32_t>) {
     delta = std::numeric_limits<int16_t>::max();
   }
 
@@ -132,7 +132,7 @@ TYPED_TEST(BiasVectorOverflowTest, minOverflowTest_delta_int8) {
 
 TYPED_TEST(BiasVectorOverflowTest, minOverflowTest_delta_int16) {
   size_t delta = std::numeric_limits<int16_t>::max();
-  if constexpr (std::is_same<TypeParam, int16_t>::value) {
+  if constexpr (std::is_same_v<TypeParam, int16_t>) {
     delta = std::numeric_limits<int8_t>::max();
   }
   delta++;
@@ -142,11 +142,11 @@ TYPED_TEST(BiasVectorOverflowTest, minOverflowTest_delta_int16) {
 TYPED_TEST(BiasVectorOverflowTest, minOverflowTest_delta_int32) {
   using T = TypeParam;
   size_t delta = std::numeric_limits<int32_t>::max();
-  if constexpr (std::is_same<T, int16_t>::value) {
+  if constexpr (std::is_same_v<T, int16_t>) {
     delta = std::numeric_limits<int8_t>::max();
   }
   // delta++;
-  if constexpr (std::is_same<T, int32_t>::value) {
+  if constexpr (std::is_same_v<T, int32_t>) {
     delta = std::numeric_limits<int16_t>::max();
   }
   delta++;

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1448,12 +1448,12 @@ class VectorCreateConstantTest : public VectorTest {
     ASSERT_TRUE(simpleVector->isScalar());
 
     for (auto i = 0; i < simpleVector->size(); i++) {
-      if constexpr (std::is_same<TCpp, StringView>::value) {
+      if constexpr (std::is_same_v<TCpp, StringView>) {
         ASSERT_EQ(
             var.template value<KIND>(), std::string(simpleVector->valueAt(i)));
       } else if constexpr (
-          std::is_same<TCpp, UnscaledShortDecimal>::value ||
-          std::is_same<TCpp, UnscaledLongDecimal>::value) {
+          std::is_same_v<TCpp, UnscaledShortDecimal> ||
+          std::is_same_v<TCpp, UnscaledLongDecimal>) {
         const auto& value = var.template value<KIND>().value();
         ASSERT_EQ(value, simpleVector->valueAt(i));
       } else {

--- a/velox/vector/tests/VectorValueGenerator.h
+++ b/velox/vector/tests/VectorValueGenerator.h
@@ -68,35 +68,35 @@ class VectorValueGenerator {
       StringViewBufferHolder& stringViewBufferHolder,
       std::optional<uint32_t> fixedWidthStringSize = std::nullopt) {
     if constexpr (
-        std::is_same<T, int64_t>::value || std::is_same<T, uint64_t>::value) {
+        std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
       return useFullTypeRange ? getRand64(rng) : getRand32(rng);
     } else if constexpr (
-        std::is_integral<T>::value && !std::is_same<T, bool>::value) {
+        std::is_integral<T>::value && !std::is_same_v<T, bool>) {
       // The other integral cases, signed and unsigned
       auto max = std::numeric_limits<T>::max();
       if (!useFullTypeRange) {
         if constexpr (
-            std::is_same<T, int32_t>::value ||
-            std::is_same<T, uint32_t>::value) {
+            std::is_same_v<T, int32_t> ||
+            std::is_same_v<T, uint32_t>) {
           max = std::numeric_limits<int16_t>::max();
         } else if constexpr (
-            std::is_same<T, int16_t>::value ||
-            std::is_same<T, uint16_t>::value) {
+            std::is_same_v<T, int16_t> ||
+            std::is_same_v<T, uint16_t>) {
           max = std::numeric_limits<int8_t>::max();
         } else {
           max = std::numeric_limits<int8_t>::max() / 2;
         }
       }
       return getRand32(rng, max);
-    } else if constexpr (std::is_same<T, double>::value) {
+    } else if constexpr (std::is_same_v<T, double>) {
       return getRandDouble(rng);
-    } else if constexpr (std::is_same<T, StringView>::value) {
+    } else if constexpr (std::is_same_v<T, StringView>) {
       auto str = std::string(
           fixedWidthStringSize.has_value() ? fixedWidthStringSize.value()
                                            : getRand32(rng) % 100 + 1,
           'a' + (getRand32(rng) % 26));
       return stringViewBufferHolder.getOwnedValue(StringView(str));
-    } else if constexpr (std::is_same<T, bool>::value) {
+    } else if constexpr (std::is_same_v<T, bool>) {
       return getRand32(rng) % 2 == 0;
     } else {
       VELOX_UNSUPPORTED("Invalid type");
@@ -108,7 +108,7 @@ class VectorValueGenerator {
     if constexpr (std::is_arithmetic<T>::value) {
       // integers, double and bool
       return T{};
-    } else if constexpr (std::is_same<T, StringView>::value) {
+    } else if constexpr (std::is_same_v<T, StringView>) {
       return StringView();
     } else {
       VELOX_UNSUPPORTED("Invalid type");

--- a/velox/vector/tests/VectorValueGenerator.h
+++ b/velox/vector/tests/VectorValueGenerator.h
@@ -67,8 +67,7 @@ class VectorValueGenerator {
       std::optional<folly::Random::DefaultGenerator>& rng,
       StringViewBufferHolder& stringViewBufferHolder,
       std::optional<uint32_t> fixedWidthStringSize = std::nullopt) {
-    if constexpr (
-        std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
+    if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
       return useFullTypeRange ? getRand64(rng) : getRand32(rng);
     } else if constexpr (
         std::is_integral<T>::value && !std::is_same_v<T, bool>) {
@@ -76,12 +75,10 @@ class VectorValueGenerator {
       auto max = std::numeric_limits<T>::max();
       if (!useFullTypeRange) {
         if constexpr (
-            std::is_same_v<T, int32_t> ||
-            std::is_same_v<T, uint32_t>) {
+            std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t>) {
           max = std::numeric_limits<int16_t>::max();
         } else if constexpr (
-            std::is_same_v<T, int16_t> ||
-            std::is_same_v<T, uint16_t>) {
+            std::is_same_v<T, int16_t> || std::is_same_v<T, uint16_t>) {
           max = std::numeric_limits<int8_t>::max();
         } else {
           max = std::numeric_limits<int8_t>::max() / 2;


### PR DESCRIPTION
For code clean and consistency, we should use is_same_v instead of is_same<>::value