### PR TITLE
Add hostname to DWRF user metadata

### DIFF
--- a/velox/dwio/dwrf/common/Common.h
+++ b/velox/dwio/dwrf/common/Common.h
@@ -32,6 +32,7 @@ namespace facebook::velox::dwrf {
 // Writer version
 constexpr folly::StringPiece WRITER_NAME_KEY{"orc.writer.name"};
 constexpr folly::StringPiece WRITER_VERSION_KEY{"orc.writer.version"};
+constexpr folly::StringPiece WRITER_HOSTNAME_KEY{"orc.writer.host"};
 constexpr folly::StringPiece kDwioWriter{"dwio"};
 constexpr folly::StringPiece kPrestoWriter{"presto"};
 

--- a/velox/dwio/dwrf/test/WriterTests.cpp
+++ b/velox/dwio/dwrf/test/WriterTests.cpp
@@ -136,7 +136,7 @@ TEST_F(WriterTest, WriteFooter) {
     ASSERT_EQ(stripe.numberOfRows(), 123);
   }
   ASSERT_EQ(footer.typesSize(), 4);
-  ASSERT_EQ(footer.metadataSize(), 4);
+  ASSERT_EQ(footer.metadataSize(), 5);
   for (size_t i = 0; i < 4; ++i) {
     auto item = footer.metadata(i);
     if (item.name() == WRITER_NAME_KEY) {
@@ -144,6 +144,8 @@ TEST_F(WriterTest, WriteFooter) {
     } else if (item.name() == WRITER_VERSION_KEY) {
       ASSERT_EQ(
           item.value(), folly::to<std::string>(reader->getWriterVersion()));
+    } else if (item.name() == WRITER_HOSTNAME_KEY) {
+      ASSERT_EQ(item.value(), process::getHostName());
     } else {
       ASSERT_EQ(
           folly::to<size_t>(item.name()) + 1, folly::to<size_t>(item.value()));

--- a/velox/dwio/dwrf/writer/CMakeLists.txt
+++ b/velox/dwio/dwrf/writer/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(
   velox_dwio_common
   velox_dwio_dwrf_common
   velox_dwio_dwrf_utils
+  velox_process
   velox_time
   velox_vector
   ${LZ4}

--- a/velox/dwio/dwrf/writer/WriterBase.cpp
+++ b/velox/dwio/dwrf/writer/WriterBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/dwrf/writer/WriterBase.h"
+#include "velox/common/process/ProcessBase.h"
 #include "velox/dwio/dwrf/utils/ProtoUtils.h"
 
 namespace facebook::velox::dwrf {
@@ -81,6 +82,7 @@ void WriterBase::writeUserMetadata(uint32_t writerVersion) {
   userMetadata_[std::string{WRITER_NAME_KEY}] = kDwioWriter;
   userMetadata_[std::string{WRITER_VERSION_KEY}] =
       folly::to<std::string>(writerVersion);
+  userMetadata_[std::string{WRITER_HOSTNAME_KEY}] = process::getHostName();
   std::for_each(userMetadata_.begin(), userMetadata_.end(), [&](auto& pair) {
     auto item = footer_.add_metadata();
     item->set_name(pair.first);


### PR DESCRIPTION
Summary: Add the writer's hostname to the DWRF user metadata to simplify troubleshooting of corrupted files.

Differential Revision: D38819077

