### PR TITLE
Add support for GZIP compression in native parquet reader

### DIFF
--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -17,14 +17,13 @@
 #include "velox/dwio/parquet/reader/PageReader.h"
 #include "velox/dwio/common/BufferUtil.h"
 #include "velox/dwio/common/ColumnVisitors.h"
-#include "velox/dwio/parquet/reader/StringColumnReader.h"
 #include "velox/dwio/parquet/thrift/ThriftTransport.h"
 #include "velox/vector/FlatVector.h"
 
 #include <arrow/util/rle_encoding.h>
 #include <thrift/protocol/TCompactProtocol.h> //@manual
+#include <zlib.h>
 #include <zstd.h>
-#include <zstd_errors.h>
 
 namespace facebook::velox::parquet {
 
@@ -160,8 +159,36 @@ const char* FOLLY_NONNULL PageReader::uncompressData(
           ZSTD_getErrorName(ret));
       return uncompressedData_->as<char>();
     }
+    case thrift::CompressionCodec::GZIP: {
+      dwio::common::ensureCapacity<char>(
+          uncompressedData_, uncompressedSize, &pool_);
+      z_stream stream;
+      memset(&stream, 0, sizeof(stream));
+      constexpr int WINDOW_BITS = 15;
+      // Determine if this is libz or gzip from header.
+      constexpr int DETECT_CODEC = 32;
+      // Initialize decompressor.
+      auto ret = inflateInit2(&stream, WINDOW_BITS | DETECT_CODEC);
+      VELOX_CHECK(
+          (ret == Z_OK),
+          "zlib inflateInit failed: {}",
+          stream.msg ? stream.msg : "");
+      // Decompress.
+      stream.next_in =
+          const_cast<Bytef*>(reinterpret_cast<const Bytef*>(pageData));
+      stream.avail_in = static_cast<uInt>(compressedSize);
+      stream.next_out =
+          reinterpret_cast<Bytef*>(uncompressedData_->asMutable<char>());
+      stream.avail_out = static_cast<uInt>(uncompressedSize);
+      ret = inflate(&stream, Z_FINISH);
+      VELOX_CHECK(
+          ret == Z_STREAM_END,
+          "GZipCodec failed: {}",
+          stream.msg ? stream.msg : "");
+      return uncompressedData_->as<char>();
+    }
     default:
-      VELOX_FAIL("Unsupported Parquet compression type ", codec_);
+      VELOX_FAIL("Unsupported Parquet compression type '{}'", codec_);
   }
 }
 
@@ -257,8 +284,12 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       dictionaryEncoding_ == Encoding::PLAIN_DICTIONARY ||
       dictionaryEncoding_ == Encoding::PLAIN);
 
-  if (pageHeader.compressed_page_size != pageHeader.uncompressed_page_size) {
-    VELOX_NYI("Compressed dictionary");
+  if (codec_ != thrift::CompressionCodec::UNCOMPRESSED) {
+    pageData_ = readBytes(pageHeader.compressed_page_size, pageBuffer_);
+    pageData_ = uncompressData(
+        pageData_,
+        pageHeader.compressed_page_size,
+        pageHeader.uncompressed_page_size);
   }
 
   auto parquetType = type_->parquetType_.value();
@@ -273,12 +304,16 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
           : sizeof(double);
       auto numBytes = dictionary_.numValues * typeSize;
       dictionary_.values = AlignedBuffer::allocate<char>(numBytes, &pool_);
-      dwio::common::readBytes(
-          numBytes,
-          inputStream_.get(),
-          dictionary_.values->asMutable<char>(),
-          bufferStart_,
-          bufferEnd_);
+      if (pageData_) {
+        memcpy(dictionary_.values->asMutable<char>(), pageData_, numBytes);
+      } else {
+        dwio::common::readBytes(
+            numBytes,
+            inputStream_.get(),
+            dictionary_.values->asMutable<char>(),
+            bufferStart_,
+            bufferEnd_);
+      }
       break;
     }
     case thrift::Type::BYTE_ARRAY: {
@@ -288,8 +323,12 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       auto values = dictionary_.values->asMutable<StringView>();
       dictionary_.strings = AlignedBuffer::allocate<char>(numBytes, &pool_);
       auto strings = dictionary_.strings->asMutable<char>();
-      dwio::common::readBytes(
-          numBytes, inputStream_.get(), strings, bufferStart_, bufferEnd_);
+      if (pageData_) {
+        memcpy(strings, pageData_, numBytes);
+      } else {
+        dwio::common::readBytes(
+            numBytes, inputStream_.get(), strings, bufferStart_, bufferEnd_);
+      }
       auto header = strings;
       for (auto i = 0; i < dictionary_.numValues; ++i) {
         auto length = *reinterpret_cast<const int32_t*>(header);

--- a/velox/dwio/parquet/reader/ParquetData.cpp
+++ b/velox/dwio/parquet/reader/ParquetData.cpp
@@ -85,9 +85,8 @@ void ParquetData::enqueueRowGroup(
   }
   VELOX_CHECK_GE(chunkReadOffset, 0);
 
-  uint64_t readSize = (metaData.total_uncompressed_size > 0)
-      ? std::min(
-            metaData.total_compressed_size, metaData.total_uncompressed_size)
+  uint64_t readSize = (metaData.codec == thrift::CompressionCodec::UNCOMPRESSED)
+      ? metaData.total_uncompressed_size
       : metaData.total_compressed_size;
 
   auto id = dwio::common::StreamIdentifier(type_->column);

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -504,31 +504,26 @@ ParquetRowReader::ParquetRowReader(
 
 //
 void ParquetRowReader::filterRowGroups() {
-  auto scanSpec = options_.getScanSpec();
   auto rowGroups = readerBase_->fileMetaData().row_groups;
-  int32_t rangeBegin = -1;
-  int32_t rangeEnd = -1;
-  for (auto i = 0; i < rowGroups_.size(); ++i) {
-    VELOX_CHECK(rowGroups_[i].__isset.file_offset);
-    auto fileOffset = rowGroups_[i].file_offset;
-    if (fileOffset >= options_.getOffset() &&
-        fileOffset < options_.getLimit()) {
-      if (rangeBegin == -1) {
-        rangeBegin = i;
-      }
-      rangeEnd = i + 1;
-    }
-  }
   rowGroupIds_.reserve(rowGroups.size());
   auto excluded =
       columnReader_->filterRowGroups(0, dwio::common::StatsContext());
+
   for (auto i = 0; i < rowGroups.size(); i++) {
-    if (i >= rangeBegin && i < rangeEnd) {
-      if (std::find(excluded.begin(), excluded.end(), i) == excluded.end()) {
-        rowGroupIds_.push_back(i);
-      } else {
-        ++skippedRowGroups_;
-      }
+    VELOX_CHECK_GT(rowGroups_[i].columns.size(), 0);
+    auto fileOffset = rowGroups_[i].__isset.file_offset
+        ? rowGroups_[i].file_offset
+        : rowGroups_[i].columns[0].file_offset;
+    VELOX_CHECK_GT(fileOffset, 0);
+    auto rowGroupInRange =
+        (fileOffset >= options_.getOffset() &&
+         fileOffset < options_.getLimit());
+    // A skipped row group is one that is in range and is in the excluded list.
+    if (rowGroupInRange &&
+        (std::find(excluded.begin(), excluded.end(), i) == excluded.end())) {
+      rowGroupIds_.push_back(i);
+    } else {
+      ++skippedRowGroups_;
     }
   }
 }

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -87,48 +87,55 @@ TEST_F(E2EFilterTest, integerDirect) {
 }
 
 TEST_F(E2EFilterTest, integerDictionary) {
-  writerProperties_ =
-      ::parquet::WriterProperties::Builder().data_pagesize(4 * 1024)->build();
+  for (const auto compression :
+       {::parquet::Compression::ZSTD,
+        ::parquet::Compression::GZIP,
+        ::parquet::Compression::UNCOMPRESSED}) {
+    writerProperties_ = ::parquet::WriterProperties::Builder()
+                            .data_pagesize(4 * 1024)
+                            ->compression(compression)
+                            ->build();
 
-  testWithTypes(
-      "short_val:smallint,"
-      "int_val:int,"
-      "long_val:bigint",
-      [&]() {
-        makeIntDistribution<int64_t>(
-            Subfield("long_val"),
-            10, // min
-            100, // max
-            22, // repeats
-            19, // rareFrequency
-            -9999, // rareMin
-            10000000000, // rareMax
-            true); // keepNulls
+    testWithTypes(
+        "short_val:smallint,"
+        "int_val:int,"
+        "long_val:bigint",
+        [&]() {
+          makeIntDistribution<int64_t>(
+              Subfield("long_val"),
+              10, // min
+              100, // max
+              22, // repeats
+              19, // rareFrequency
+              -9999, // rareMin
+              10000000000, // rareMax
+              true); // keepNulls
 
-        makeIntDistribution<int32_t>(
-            Subfield("int_val"),
-            10, // min
-            100, // max
-            22, // repeats
-            19, // rareFrequency
-            -9999, // rareMin
-            100000000, // rareMax
-            false); // keepNulls
+          makeIntDistribution<int32_t>(
+              Subfield("int_val"),
+              10, // min
+              100, // max
+              22, // repeats
+              19, // rareFrequency
+              -9999, // rareMin
+              100000000, // rareMax
+              false); // keepNulls
 
-        makeIntDistribution<int16_t>(
-            Subfield("short_val"),
-            10, // min
-            100, // max
-            22, // repeats
-            19, // rareFrequency
-            -999, // rareMin
-            30000, // rareMax
-            true); // keepNulls
-      },
-      false,
-      {"short_val", "int_val", "long_val"},
-      20,
-      true);
+          makeIntDistribution<int16_t>(
+              Subfield("short_val"),
+              10, // min
+              100, // max
+              22, // repeats
+              19, // rareFrequency
+              -999, // rareMin
+              30000, // rareMax
+              true); // keepNulls
+        },
+        false,
+        {"short_val", "int_val", "long_val"},
+        20,
+        true);
+  }
 }
 
 TEST_F(E2EFilterTest, floatAndDoubleDirect) {

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -91,6 +91,10 @@ TEST_F(E2EFilterTest, integerDictionary) {
        {::parquet::Compression::ZSTD,
         ::parquet::Compression::GZIP,
         ::parquet::Compression::UNCOMPRESSED}) {
+    if (!arrow::util::Codec::IsAvailable(compression)) {
+      continue;
+    }
+
     writerProperties_ = ::parquet::WriterProperties::Builder()
                             .data_pagesize(4 * 1024)
                             ->compression(compression)


### PR DESCRIPTION
Include support for compressed dictionary pages.
Extend E2EFilterTest::integerDictionary with ZSTD, GZIP compression.
Enable reading Presto-generated Parquet files.