### PR TITLE
Fix velox with substrait build

### DIFF
--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -55,9 +55,9 @@ SubstraitVeloxExprConverter::toVeloxExpr(
     const ::substrait::Expression::ScalarFunction& substraitFunc,
     const RowTypePtr& inputType) {
   std::vector<std::shared_ptr<const core::ITypedExpr>> params;
-  params.reserve(substraitFunc.args().size());
-  for (const auto& sArg : substraitFunc.args()) {
-    params.emplace_back(toVeloxExpr(sArg, inputType));
+  params.reserve(substraitFunc.arguments_size());
+  for (const auto& sArg : substraitFunc.arguments()) {
+    params.emplace_back(toVeloxExpr(sArg.value(), inputType));
   }
   const auto& veloxFunction = substraitParser_.findVeloxFunction(
       functionMap_, substraitFunc.function_reference());

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -138,9 +138,10 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
     auto aggFunction = measure.measure();
     // Get the params of this Aggregate function.
     std::vector<core::TypedExprPtr> aggParams;
-    auto args = aggFunction.args();
+    auto args = aggFunction.arguments();
     aggParams.reserve(args.size());
-    for (auto arg : args) {
+    for (auto funcArg : args) {
+      auto arg = funcArg.value();
       auto typeCase = arg.rex_type_case();
       switch (typeCase) {
         case ::substrait::Expression::RexTypeCase::kSelection: {
@@ -601,7 +602,8 @@ connector::hive::SubfieldFilters SubstraitVeloxPlanConverter::toVeloxFilter(
     int32_t colIdx;
     // TODO: Add different types' support here.
     double val;
-    for (auto& param : scalarFunction.args()) {
+    for (auto& funcParam : scalarFunction.arguments()) {
+      auto param = funcParam.value();
       auto typeCase = param.rex_type_case();
       switch (typeCase) {
         case ::substrait::Expression::RexTypeCase::kSelection: {
@@ -685,8 +687,8 @@ void SubstraitVeloxPlanConverter::flattenConditions(
           functionMap_, sFunc.function_reference());
       // TODO: Only and relation is supported here.
       if (substraitParser_->getFunctionName(filterNameSpec) == "and") {
-        for (const auto& sCondition : sFunc.args()) {
-          flattenConditions(sCondition, scalarFunctions);
+        for (const auto& sCondition : sFunc.arguments()) {
+          flattenConditions(sCondition.value(), scalarFunctions);
         }
       } else {
         scalarFunctions.emplace_back(sFunc);

--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -146,7 +146,7 @@ const ::substrait::Expression& VeloxToSubstraitExprConvertor::toSubstraitExpr(
     scalarExpr->set_function_reference(functionMap_[functionName]);
 
     for (auto& arg : inputs) {
-      scalarExpr->add_args()->MergeFrom(toSubstraitExpr(arena, arg, inputType));
+      scalarExpr->add_arguments()->mutable_value()->MergeFrom(toSubstraitExpr(arena, arg, inputType));
     }
 
     scalarExpr->mutable_output_type()->MergeFrom(

--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -146,7 +146,8 @@ const ::substrait::Expression& VeloxToSubstraitExprConvertor::toSubstraitExpr(
     scalarExpr->set_function_reference(functionMap_[functionName]);
 
     for (auto& arg : inputs) {
-      scalarExpr->add_arguments()->mutable_value()->MergeFrom(toSubstraitExpr(arena, arg, inputType));
+      scalarExpr->add_arguments()->mutable_value()->MergeFrom(
+          toSubstraitExpr(arena, arg, inputType));
     }
 
     scalarExpr->mutable_output_type()->MergeFrom(

--- a/velox/substrait/VeloxToSubstraitPlan.cpp
+++ b/velox/substrait/VeloxToSubstraitPlan.cpp
@@ -284,7 +284,7 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
               std::dynamic_pointer_cast<const core::CallTypedExpr>(expr)) {
         VELOX_NYI("In Velox Plan, the aggregates type cannot be CallTypedExpr");
       } else {
-        aggFunction->add_args()->MergeFrom(
+        aggFunction->add_arguments()->mutable_value()->MergeFrom(
             exprConvertor_->toSubstraitExpr(arena, expr, inputType));
       }
     }


### PR DESCRIPTION
When I execute the command `CPU_TARGET="arm64"  make debug EXTRA_CMAKE_FLAGS="-DVELOX_BUILD_TESTING=OFF -DVELOX_ENABLE_SUBSTRAIT=ON" NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=16` on my M1 MacBook Pro, I got the following errors:
[logs.txt](https://github.com/facebookincubator/velox/files/9380116/logs3.txt)

And I try to use Intel CPU device to build velox with substrait, using the following Dockerfile to build velox with substrait in a ubuntu 22.04 environment.
[Dockerfile.txt](https://github.com/facebookincubator/velox/files/9380137/Dockerfile.txt)
I still got the same error.

See also in #2332 .

Therefore, I propose this PR to fix this issue. With this change, I can build velox with substrait successfully.
