### PR TITLE
Use is_base_of_v instead of is_base_of<>::value

### DIFF
--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -1057,7 +1057,7 @@ template <typename T, typename A>
 struct HalfBatchImpl<
     T,
     A,
-    std::enable_if_t<std::is_base_of<xsimd::avx, A>::value>> {
+    std::enable_if_t<std::is_base_of_v<xsimd::avx, A>>> {
   using Type = xsimd::batch<T, xsimd::sse2>;
 };
 
@@ -1066,8 +1066,8 @@ struct HalfBatchImpl<
     T,
     A,
     std::enable_if_t<
-        std::is_base_of<xsimd::sse2, A>::value ||
-        std::is_base_of<xsimd::neon, A>::value>> {
+        std::is_base_of_v<xsimd::sse2, A> ||
+        std::is_base_of_v<xsimd::neon, A>>> {
   using Type = Batch64<T>;
 };
 

--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -1054,10 +1054,7 @@ xsimd::batch<T, A> iota(const A&) {
 namespace detail {
 
 template <typename T, typename A>
-struct HalfBatchImpl<
-    T,
-    A,
-    std::enable_if_t<std::is_base_of_v<xsimd::avx, A>>> {
+struct HalfBatchImpl<T, A, std::enable_if_t<std::is_base_of_v<xsimd::avx, A>>> {
   using Type = xsimd::batch<T, xsimd::sse2>;
 };
 

--- a/velox/common/serialization/Serializable.h
+++ b/velox/common/serialization/Serializable.h
@@ -101,7 +101,7 @@ class ISerializable {
   // Serialization for clases derived from ISerializable.
   template <
       typename T,
-      typename = std::enable_if_t<std::is_base_of<ISerializable, T>::value>>
+      typename = std::enable_if_t<std::is_base_of_v<ISerializable, T>>>
   static folly::dynamic serialize(std::shared_ptr<const T> serializable) {
     return serializable->serialize();
   }
@@ -170,7 +170,7 @@ class ISerializable {
 
   template <
       class T,
-      typename = std::enable_if_t<std::is_base_of<ISerializable, T>::value>>
+      typename = std::enable_if_t<std::is_base_of_v<ISerializable, T>>>
   static std::shared_ptr<const T> deserialize(const folly::dynamic& obj) {
     VELOX_USER_CHECK(obj.isObject());
     // use the key to lookup creator and call it.

--- a/velox/dwio/common/exception/Exceptions.h
+++ b/velox/dwio/common/exception/Exceptions.h
@@ -100,7 +100,7 @@ class exception_error;
 template <class E>
 class exception_error<
     E,
-    typename std::enable_if<std::is_base_of<std::exception, E>::value>::type> {
+    typename std::enable_if<std::is_base_of_v<std::exception, E>>::type> {
  public:
   explicit exception_error(std::string fmt...) {
     va_list ap;

--- a/velox/exec/TreeOfLosers.h
+++ b/velox/exec/TreeOfLosers.h
@@ -68,7 +68,7 @@ class TreeOfLosers {
 
   explicit TreeOfLosers(std::vector<std::unique_ptr<Stream>> streams)
       : streams_(std::move(streams)) {
-    static_assert(std::is_base_of<MergeStream, Stream>::value);
+    static_assert(std::is_base_of_v<MergeStream, Stream>);
     VELOX_CHECK_LT(streams_.size(), std::numeric_limits<TIndex>::max());
     VELOX_CHECK_GE(streams_.size(), 1);
 
@@ -309,7 +309,7 @@ template <typename Stream>
 class MergeArray {
  public:
   explicit MergeArray(std::vector<std::unique_ptr<Stream>> streams) {
-    static_assert(std::is_base_of<MergeStream, Stream>::value);
+    static_assert(std::is_base_of_v<MergeStream, Stream>);
     for (auto& stream : streams) {
       if (stream->hasData()) {
         streams_.push_back(std::move(stream));

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1984,7 +1984,7 @@ template <typename T>
 class FormatValue<
     std::shared_ptr<T>,
     typename std::enable_if<
-        std::is_base_of<facebook::velox::Type, T>::value>::type> {
+        std::is_base_of_v<facebook::velox::Type, T>>::type> {
  public:
   explicit FormatValue(const std::shared_ptr<const facebook::velox::Type>& type)
       : type_(type) {}

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -97,27 +97,27 @@ class BaseVector {
 
   template <typename T>
   T* as() {
-    static_assert(std::is_base_of<BaseVector, T>::value);
+    static_assert(std::is_base_of_v<BaseVector, T>);
     return dynamic_cast<T*>(this);
   }
 
   template <typename T>
   const T* as() const {
-    static_assert(std::is_base_of<BaseVector, T>::value);
+    static_assert(std::is_base_of_v<BaseVector, T>);
     return dynamic_cast<const T*>(this);
   }
 
   // Use when the type of 'this' is already known. dynamic_cast() is slow.
   template <typename T>
   T* asUnchecked() {
-    static_assert(std::is_base_of<BaseVector, T>::value);
+    static_assert(std::is_base_of_v<BaseVector, T>);
     DCHECK(dynamic_cast<const T*>(this) != nullptr);
     return static_cast<T*>(this);
   }
 
   template <typename T>
   const T* asUnchecked() const {
-    static_assert(std::is_base_of<BaseVector, T>::value);
+    static_assert(std::is_base_of_v<BaseVector, T>);
     DCHECK(dynamic_cast<const T*>(this) != nullptr);
     return static_cast<const T*>(this);
   }


### PR DESCRIPTION
Same as refactor for is_same_v, we should use is_base_of_v instead of is_base_of<>::value