### PR TITLE
Use is_integral_v instead of is_integral<>::value

### DIFF
--- a/velox/common/serialization/Serializable.h
+++ b/velox/common/serialization/Serializable.h
@@ -200,7 +200,7 @@ class ISerializable {
   template <
       class T,
       typename = std::enable_if_t<
-          std::is_integral<T>::value && !std::is_same_v<T, bool>>>
+          std::is_integral_v<T> && !std::is_same_v<T, bool>>>
   static T deserialize(const folly::dynamic& obj) {
     auto raw = obj.asInt();
     VELOX_USER_CHECK_GE(raw, std::numeric_limits<T>::min());

--- a/velox/common/serialization/Serializable.h
+++ b/velox/common/serialization/Serializable.h
@@ -199,8 +199,8 @@ class ISerializable {
 
   template <
       class T,
-      typename = std::enable_if_t<
-          std::is_integral_v<T> && !std::is_same_v<T, bool>>>
+      typename =
+          std::enable_if_t<std::is_integral_v<T> && !std::is_same_v<T, bool>>>
   static T deserialize(const folly::dynamic& obj) {
     auto raw = obj.asInt();
     VELOX_USER_CHECK_GE(raw, std::numeric_limits<T>::min());

--- a/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
+++ b/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
@@ -28,7 +28,7 @@ namespace {
 
 template <
     typename T,
-    typename std::enable_if_t<std::is_integral<T>::value, int> = 0>
+    typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
 auto distribution(unsigned len) {
   return std::uniform_int_distribution<T>(0, len);
 }

--- a/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
+++ b/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
@@ -26,9 +26,7 @@
 namespace facebook::velox::functions::kll::test {
 namespace {
 
-template <
-    typename T,
-    typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
+template <typename T, typename std::enable_if_t<std::is_integral_v<T>, int> = 0>
 auto distribution(unsigned len) {
   return std::uniform_int_distribution<T>(0, len);
 }

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -96,7 +96,7 @@ template <typename T>
 struct CeilFunction {
   template <typename TOutput, typename TInput = TOutput>
   FOLLY_ALWAYS_INLINE void call(TOutput& result, const TInput& a) {
-    if constexpr (std::is_integral<TInput>::value) {
+    if constexpr (std::is_integral_v<TInput>) {
       result = a;
     } else {
       result = ceil(a);
@@ -108,7 +108,7 @@ template <typename T>
 struct FloorFunction {
   template <typename TOutput, typename TInput = TOutput>
   FOLLY_ALWAYS_INLINE void call(TOutput& result, const TInput& a) {
-    if constexpr (std::is_integral<TInput>::value) {
+    if constexpr (std::is_integral_v<TInput>) {
       result = a;
     } else {
       result = floor(a);

--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -30,7 +30,7 @@ FOLLY_ALWAYS_INLINE TNum
 round(const TNum& number, const TDecimals& decimals = 0) {
   static_assert(!std::is_same_v<TNum, bool> && "round not supported for bool");
 
-  if constexpr (std::is_integral<TNum>::value) {
+  if constexpr (std::is_integral_v<TNum>) {
     if constexpr (alwaysRoundNegDec) {
       if (decimals >= 0)
         return number;

--- a/velox/functions/prestosql/VectorArithmetic.cpp
+++ b/velox/functions/prestosql/VectorArithmetic.cpp
@@ -256,7 +256,7 @@ class VectorArithmetic : public VectorFunction {
     // 2) type is integral and is safe to leave the values uninitialized
     // and the number of valid rows is larger than half of the row (heuristic)
     return rows.isAllSelected() ||
-        (std::is_integral<T>::value && Operation::isSafeForUninitialized &&
+        (std::is_integral_v<T> && Operation::isSafeForUninitialized &&
          context->isFinalSelection() && rows.countSelected() > rows.size() / 2);
   }
 };
@@ -270,14 +270,14 @@ class Addition {
 
   template <
       typename T,
-      typename std::enable_if<!std::is_integral<T>::value, int>::type = 0>
+      typename std::enable_if<!std::is_integral_v<T>, int>::type = 0>
   static void apply(T& result, T left, T right) {
     result = left + right;
   }
 
   template <
       typename T,
-      typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+      typename std::enable_if<std::is_integral_v<T>, int>::type = 0>
   static void apply(T& result, T left, T right) {
     bool overflow = __builtin_add_overflow(left, right, &result);
     if (UNLIKELY(overflow)) {
@@ -294,14 +294,14 @@ class Subtraction {
 
   template <
       typename T,
-      typename std::enable_if<!std::is_integral<T>::value, int>::type = 0>
+      typename std::enable_if<!std::is_integral_v<T>, int>::type = 0>
   static void apply(T& result, T left, T right) {
     result = left - right;
   }
 
   template <
       typename T,
-      typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+      typename std::enable_if<std::is_integral_v<T>, int>::type = 0>
   static void apply(T& result, T left, T right) {
     bool overflow = __builtin_sub_overflow(left, right, &result);
     if (UNLIKELY(overflow)) {
@@ -318,7 +318,7 @@ class Multiplication {
 
   template <
       typename T,
-      typename std::enable_if<!std::is_integral<T>::value, int>::type = 0>
+      typename std::enable_if<!std::is_integral_v<T>, int>::type = 0>
 
   static void apply(T& result, T left, T right) {
     result = left * right;
@@ -326,7 +326,7 @@ class Multiplication {
 
   template <
       typename T,
-      typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+      typename std::enable_if<std::is_integral_v<T>, int>::type = 0>
   static void apply(T& result, T left, T right) {
     bool overflow = __builtin_mul_overflow(left, right, &result);
     if (UNLIKELY(overflow)) {

--- a/velox/vector/tests/VectorValueGenerator.h
+++ b/velox/vector/tests/VectorValueGenerator.h
@@ -69,8 +69,7 @@ class VectorValueGenerator {
       std::optional<uint32_t> fixedWidthStringSize = std::nullopt) {
     if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
       return useFullTypeRange ? getRand64(rng) : getRand32(rng);
-    } else if constexpr (
-        std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+    } else if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
       // The other integral cases, signed and unsigned
       auto max = std::numeric_limits<T>::max();
       if (!useFullTypeRange) {

--- a/velox/vector/tests/VectorValueGenerator.h
+++ b/velox/vector/tests/VectorValueGenerator.h
@@ -70,7 +70,7 @@ class VectorValueGenerator {
     if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
       return useFullTypeRange ? getRand64(rng) : getRand32(rng);
     } else if constexpr (
-        std::is_integral<T>::value && !std::is_same_v<T, bool>) {
+        std::is_integral_v<T> && !std::is_same_v<T, bool>) {
       // The other integral cases, signed and unsigned
       auto max = std::numeric_limits<T>::max();
       if (!useFullTypeRange) {


### PR DESCRIPTION
Same as refactor for is_same_v, we should use is_integral_v instead of is_integral<>::value