### PR TITLE
Use is_trivially_constructible_v instead of is_trivially_constructible<>::value

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -395,8 +395,7 @@ class OptionalAccessor {
 
 template <typename T, typename U>
 typename std::enable_if<
-    std::is_trivially_constructible<typename VectorReader<U>::exec_in_t, T>::
-        value,
+    std::is_trivially_constructible_v<typename VectorReader<U>::exec_in_t, T>,
     bool>::type
 operator==(const std::optional<T>& lhs, const OptionalAccessor<U>& rhs) {
   if (lhs.has_value() != rhs.has_value()) {
@@ -412,8 +411,7 @@ operator==(const std::optional<T>& lhs, const OptionalAccessor<U>& rhs) {
 
 template <typename U, typename T>
 typename std::enable_if<
-    std::is_trivially_constructible<typename VectorReader<U>::exec_in_t, T>::
-        value,
+    std::is_trivially_constructible_v<typename VectorReader<U>::exec_in_t, T>,
     bool>::type
 operator==(const OptionalAccessor<U>& lhs, const std::optional<T>& rhs) {
   return rhs == lhs;
@@ -421,8 +419,7 @@ operator==(const OptionalAccessor<U>& lhs, const std::optional<T>& rhs) {
 
 template <typename T, typename U>
 typename std::enable_if<
-    std::is_trivially_constructible<typename VectorReader<U>::exec_in_t, T>::
-        value,
+    std::is_trivially_constructible_v<typename VectorReader<U>::exec_in_t, T>,
     bool>::type
 operator!=(const std::optional<T>& lhs, const OptionalAccessor<U>& rhs) {
   return !(lhs == rhs);
@@ -430,8 +427,7 @@ operator!=(const std::optional<T>& lhs, const OptionalAccessor<U>& rhs) {
 
 template <typename U, typename T>
 typename std::enable_if<
-    std::is_trivially_constructible<typename VectorReader<U>::exec_in_t, T>::
-        value,
+    std::is_trivially_constructible_v<typename VectorReader<U>::exec_in_t, T>,
     bool>::type
 operator!=(const OptionalAccessor<U>& lhs, const std::optional<T>& rhs) {
   return !(lhs == rhs);
@@ -460,8 +456,7 @@ bool operator!=(const OptionalAccessor<T>& lhs, std::nullopt_t) {
 // Allow comparing OptionalAccessor<T> with T::exec_t.
 template <typename T, typename U>
 typename std::enable_if<
-    std::is_trivially_constructible<typename VectorReader<U>::exec_in_t, T>::
-        value,
+    std::is_trivially_constructible_v<typename VectorReader<U>::exec_in_t, T>,
     bool>::type
 operator==(const T& lhs, const OptionalAccessor<U>& rhs) {
   return rhs.has_value() && (*rhs == lhs);
@@ -469,8 +464,7 @@ operator==(const T& lhs, const OptionalAccessor<U>& rhs) {
 
 template <typename U, typename T>
 typename std::enable_if<
-    std::is_trivially_constructible<typename VectorReader<U>::exec_in_t, T>::
-        value,
+    std::is_trivially_constructible_v<typename VectorReader<U>::exec_in_t, T>,
     bool>::type
 operator==(const OptionalAccessor<U>& lhs, const T& rhs) {
   return rhs == lhs;
@@ -478,8 +472,7 @@ operator==(const OptionalAccessor<U>& lhs, const T& rhs) {
 
 template <typename T, typename U>
 typename std::enable_if<
-    std::is_trivially_constructible<typename VectorReader<U>::exec_in_t, T>::
-        value,
+    std::is_trivially_constructible_v<typename VectorReader<U>::exec_in_t, T>,
     bool>::type
 operator!=(const T& lhs, const OptionalAccessor<U>& rhs) {
   return !(lhs == rhs);
@@ -487,8 +480,7 @@ operator!=(const T& lhs, const OptionalAccessor<U>& rhs) {
 
 template <typename U, typename T>
 typename std::enable_if<
-    std::is_trivially_constructible<typename VectorReader<U>::exec_in_t, T>::
-        value,
+    std::is_trivially_constructible_v<typename VectorReader<U>::exec_in_t, T>,
     bool>::type
 operator!=(const OptionalAccessor<U>& lhs, const T& rhs) {
   return !(lhs == rhs);


### PR DESCRIPTION
Same as refactor for is_same_v, we should use is_trivially_constructible_v instead of is_trivially_constructible<>::value