### PR TITLE
Cleanup use of aggregates_ in HashTable.

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -219,9 +219,14 @@ void GroupingSet::addInputForActiveRows(
 
   table_->groupProbe(*lookup_);
   masks_.addInput(input, activeRows_);
-  for (auto i = 0; i < aggregates_.size(); ++i) {
-    const auto& rows = getSelectivityVector(i);
 
+  for (auto i = 0; i < aggregates_.size(); ++i) {
+    if (!lookup_->newGroups.empty()) {
+      aggregates_[i]->initializeNewGroups(
+          lookup_->hits.data(), lookup_->newGroups);
+    }
+
+    const auto& rows = getSelectivityVector(i);
     // Check is mask is false for all rows.
     if (!rows.hasSelections()) {
       continue;

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -33,7 +33,6 @@ HashTable<ignoreNullKeys>::HashTable(
     bool hasProbedFlag,
     memory::MappedMemory* mappedMemory)
     : BaseHashTable(std::move(hashers)),
-      aggregates_(aggregates),
       isJoinBuild_(isJoinBuild) {
   std::vector<TypePtr> keys;
   for (auto& hasher : hashers_) {
@@ -391,7 +390,6 @@ void HashTable<ignoreNullKeys>::groupProbe(HashLookup& lookup) {
     state1.firstProbe(table_, 0);
     fullProbe<false>(lookup, state1, false);
   }
-  initializeNewGroups(lookup);
 }
 
 template <bool ignoreNullKeys>
@@ -443,7 +441,6 @@ void HashTable<ignoreNullKeys>::arrayGroupProbe(HashLookup& lookup) {
     groups[row] = group;
     lookup.hits[row] = group; // NOLINT
   }
-  initializeNewGroups(lookup);
 }
 
 template <bool ignoreNullKeys>
@@ -489,16 +486,6 @@ void HashTable<ignoreNullKeys>::joinProbe(HashLookup& lookup) {
     state1.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
     state1.firstProbe(table_, 0);
     fullProbe<true>(lookup, state1, false);
-  }
-}
-
-template <bool ignoreNullKeys>
-void HashTable<ignoreNullKeys>::initializeNewGroups(HashLookup& lookup) {
-  if (lookup.newGroups.empty()) {
-    return;
-  }
-  for (auto& aggregate : aggregates_) {
-    aggregate->initializeNewGroups(lookup.hits.data(), lookup.newGroups);
   }
 }
 

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -399,7 +399,6 @@ class HashTable : public BaseHashTable {
   void clearUseRange(std::vector<bool>& useRange);
 
   void rehash();
-  void initializeNewGroups(HashLookup& lookup);
   void storeKeys(HashLookup& lookup, vector_size_t row);
 
   void storeRowPointer(int32_t index, uint64_t hash, char* row);
@@ -466,7 +465,6 @@ class HashTable : public BaseHashTable {
     return isJoinBuild_ ? 0 : 50;
   }
 
-  const std::vector<std::unique_ptr<Aggregate>>& aggregates_;
   int8_t sizeBits_;
   bool isJoinBuild_ = false;
 


### PR DESCRIPTION
The Hashtable maintains a list of aggregate functions for 2 purposes :

i) These functions were pass-through to the RowContainer which needed
them for sizing rows.

ii) The HashTable initialized new groups in these aggregates when it
detected during lookups. These lookups only happened through the
GroupingSet.

The aggregate initialization for new groups is better in the GroupingSet
logic than HashTable. The HashTable is then limited to do pure lookups and
sets up the required info in the HashLookup for use by the Operator.

HashTable continues to pass through the aggregates to the RowContainer only. So
we can remove this member variable also.