### PR TITLE
Add disk spilling test coverage for MinMaxBy and some simplication

### DIFF
--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -100,7 +100,7 @@ class OrderBy : public Operator {
   // reservation size.
   const int32_t spillableReservationGrowthPct_;
 
-  const int32_t spillFileSizeFactor_;
+  const double spillFileSizeFactor_;
 
   // The map from column channel in 'output_' to the corresponding one stored in
   // 'data_'. The column channel might be reordered to ensure the sorting key

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.h
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.h
@@ -111,10 +111,15 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& postAggregationProjections,
       const std::vector<RowVectorPtr>& expectedResult);
 
-  /// Specifies that all aggregate functions used in this test are not sensitive
+  /// Specifies that aggregate functions used in this test are not sensitive
   /// to the order of inputs.
   void allowInputShuffle() {
     allowInputShuffle_ = true;
+  }
+  /// Specifies that aggregate functions used in this test are sensitive
+  /// to the order of inputs.
+  void disallowInputShuffle() {
+    allowInputShuffle_ = false;
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(
   velox_functions_lib
   velox_hive_connector
   velox_type
+  velox_vector_fuzzer
   ${gflags_LIBRARIES}
   gtest
   gtest_main)

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -774,4 +774,39 @@ exec::CastOperatorPtr getCastOperator(const std::string& name) {
   return nullptr;
 }
 
+TypePtr fromKindToScalerType(TypeKind kind) {
+  switch (kind) {
+    case TypeKind::TINYINT:
+      return TINYINT();
+    case TypeKind::BOOLEAN:
+      return BOOLEAN();
+    case TypeKind::SMALLINT:
+      return SMALLINT();
+    case TypeKind::BIGINT:
+      return BIGINT();
+    case TypeKind::INTEGER:
+      return INTEGER();
+    case TypeKind::REAL:
+      return REAL();
+    case TypeKind::VARCHAR:
+      return VARCHAR();
+    case TypeKind::VARBINARY:
+      return VARBINARY();
+    case TypeKind::TIMESTAMP:
+      return TIMESTAMP();
+    case TypeKind::DOUBLE:
+      return DOUBLE();
+    case TypeKind::DATE:
+      return DATE();
+    case TypeKind::INTERVAL_DAY_TIME:
+      return INTERVAL_DAY_TIME();
+    case TypeKind::UNKNOWN:
+      return UNKNOWN();
+    default:
+      VELOX_UNSUPPORTED(
+          "Kind is not a scalar type: {}", mapTypeKindToName(kind));
+      return nullptr;
+  }
+}
+
 } // namespace facebook::velox

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1956,6 +1956,9 @@ struct CastTypeChecker<Row<T...>> {
   }
 };
 
+/// Return the scalar type for a given 'kind'.
+TypePtr fromKindToScalerType(TypeKind kind);
+
 } // namespace facebook::velox
 
 namespace folly {

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -664,3 +664,37 @@ TEST(TypeTest, isVariadicType) {
   EXPECT_FALSE(isVariadicType<bool>::value);
   EXPECT_FALSE((isVariadicType<Map<int8_t, Date>>::value));
 }
+
+TEST(TypeTest, fromKindToScalerType) {
+  for (const TypeKind& kind :
+       {TypeKind::BOOLEAN,
+        TypeKind::TINYINT,
+        TypeKind::SMALLINT,
+        TypeKind::INTEGER,
+        TypeKind::BIGINT,
+        TypeKind::REAL,
+        TypeKind::DOUBLE,
+        TypeKind::VARCHAR,
+        TypeKind::VARBINARY,
+        TypeKind::TIMESTAMP,
+        TypeKind::DATE,
+        TypeKind::INTERVAL_DAY_TIME,
+        TypeKind::UNKNOWN}) {
+    SCOPED_TRACE(mapTypeKindToName(kind));
+    auto type = fromKindToScalerType(kind);
+    ASSERT_EQ(type->kind(), kind);
+  }
+
+  for (const TypeKind& kind :
+       {TypeKind::SHORT_DECIMAL,
+        TypeKind::LONG_DECIMAL,
+        TypeKind::ARRAY,
+        TypeKind::MAP,
+        TypeKind::ROW,
+        TypeKind::OPAQUE,
+        TypeKind::FUNCTION,
+        TypeKind::INVALID}) {
+    SCOPED_TRACE(mapTypeKindToName(kind));
+    EXPECT_ANY_THROW(fromKindToScalerType(kind));
+  }
+}


### PR DESCRIPTION
Add disk spilling test coverage for MinMaxBy by using distinct comparison values.
Also simplify the test by removing the partial test case which has already been
covered by testAggregations.