### PR TITLE
Add copyRanges to optimize VARCHAR and complex type vector copy

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -377,7 +377,20 @@ class BaseVector {
       vector_size_t targetIndex,
       vector_size_t sourceIndex,
       vector_size_t count) {
-    VELOX_UNSUPPORTED("Only flat vectors support copy operation");
+    CopyRange range{sourceIndex, targetIndex, count};
+    copyRanges(source, folly::Range(&range, 1));
+  }
+
+  struct CopyRange {
+    vector_size_t sourceIndex;
+    vector_size_t targetIndex;
+    vector_size_t count;
+  };
+
+  virtual void copyRanges(
+      const BaseVector* /*source*/,
+      const folly::Range<const CopyRange*>& /*ranges*/) {
+    VELOX_UNSUPPORTED("Can only copy into flat or complex vectors");
   }
 
   // Construct a zero-copy slice of the vector with the indicated offset and
@@ -712,16 +725,6 @@ class BaseVector {
 
   BufferPtr sliceNulls(vector_size_t offset, vector_size_t length) const {
     return sliceBuffer(*BOOLEAN(), nulls_, offset, length, pool_);
-  }
-
-  BufferPtr
-  ensureIndices(BufferPtr& buf, const vector_size_t*& raw, vector_size_t size) {
-    if (buf && buf->isMutable() &&
-        buf->capacity() >= size * sizeof(vector_size_t)) {
-      return buf;
-    }
-    resizeIndices(size, 0, &buf, &raw);
-    return buf;
   }
 
   const TypePtr type_;

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -261,6 +261,14 @@ class FlatVector final : public SimpleVector<T> {
     copyValuesAndNulls(source, targetIndex, sourceIndex, count);
   }
 
+  void copyRanges(
+      const BaseVector* source,
+      const folly::Range<const BaseVector::CopyRange*>& ranges) override {
+    for (auto& range : ranges) {
+      copy(source, range.targetIndex, range.sourceIndex, range.count);
+    }
+  }
+
   void resize(vector_size_t size, bool setNotNull = true) override;
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
@@ -427,6 +435,11 @@ void FlatVector<StringView>::copy(
     vector_size_t targetIndex,
     vector_size_t sourceIndex,
     vector_size_t count);
+
+template <>
+void FlatVector<StringView>::copyRanges(
+    const BaseVector* source,
+    const folly::Range<const CopyRange*>& ranges);
 
 template <>
 void FlatVector<bool>::copyValuesAndNulls(

--- a/velox/vector/benchmarks/CopyBenchmark.cpp
+++ b/velox/vector/benchmarks/CopyBenchmark.cpp
@@ -166,6 +166,65 @@ BENCHMARK_MULTI(copyArrayTwoAtATime) {
   return runBenchmark(arrayVector, selected, ARRAY(INTEGER()), pool.get(), 2);
 }
 
+BENCHMARK_MULTI(copyArrayOfVarchar) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 50'000;
+  auto offsets = allocateOffsets(size + 1, pool.get());
+  auto sizes = allocateSizes(size, pool.get());
+  auto rawOffsets = offsets->asMutable<vector_size_t>();
+  auto rawSizes = sizes->asMutable<vector_size_t>();
+  for (int i = 0; i < size; ++i) {
+    rawSizes[i] = i % 10;
+    // Leave gap between the ranges so we don't merge them.
+    rawOffsets[i + 1] = rawOffsets[i] + rawSizes[i] + 1;
+  }
+  char string[51];
+  std::fill(std::begin(string), std::prev(std::end(string)), 'x');
+  *std::prev(std::end(string)) = '\0';
+  auto elements = vectorMaker.flatVector<StringView>(
+      rawOffsets[size], [&](auto) { return string; });
+  auto type = ARRAY(VARCHAR());
+  auto arrayVector = std::make_shared<ArrayVector>(
+      pool.get(), type, nullptr, size, offsets, sizes, elements);
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(arrayVector, selected, type, pool.get());
+}
+
+BENCHMARK_MULTI(copyArrayOfArray) {
+  folly::BenchmarkSuspender suspender;
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  test::VectorMaker vectorMaker{pool.get()};
+
+  const vector_size_t size = 1'000;
+  auto offsets = allocateOffsets(size + 1, pool.get());
+  auto sizes = allocateSizes(size, pool.get());
+  auto rawOffsets = offsets->asMutable<vector_size_t>();
+  auto rawSizes = sizes->asMutable<vector_size_t>();
+  for (int i = 0; i < size; ++i) {
+    rawSizes[i] = i % 10;
+    // Leave gap between the ranges so we don't merge them.
+    rawOffsets[i + 1] = rawOffsets[i] + rawSizes[i] + 1;
+  }
+  auto elements = vectorMaker.arrayVector<int32_t>(
+      rawOffsets[size],
+      [](auto row) { return row % 10; },
+      [](auto row) { return row % 23; });
+  auto type = ARRAY(ARRAY(INTEGER()));
+  auto arrayVector = std::make_shared<ArrayVector>(
+      pool.get(), type, nullptr, size, offsets, sizes, elements);
+  SelectivityVector selected(size);
+  suspender.dismiss();
+
+  return runBenchmark(arrayVector, selected, type, pool.get());
+}
+
 BENCHMARK_MULTI(copyMap) {
   folly::BenchmarkSuspender suspender;
   std::unique_ptr<memory::MemoryPool> pool{


### PR DESCRIPTION
Summary:
Currently when we copy `ARRAY(VARCHAR)`, for each array offset, we call
`acquireSharedStringBuffers` and this is relatively expensive.  Similar
inefficiency is also happening when we call `copy` repeatedly while copying
nested ARRAY/MAP.  Add `copyRanges` so that we only need to call them once.

Differential Revision: D38917657

