### PR TITLE
Fix `unsigned >= 0` assertions in StringCore and ByteStream

### DIFF
--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -174,8 +174,9 @@ class ByteStream {
   // input is consecutive ByteRanges in 'ranges_' for the base class
   // but any view over external buffers can be made by specialization.
   virtual void next(bool throwIfPastEnd = true) {
+    VELOX_CHECK(current_ >= &ranges_[0]);
     size_t position = current_ - &ranges_[0];
-    VELOX_CHECK(position >= 0 && position < ranges_.size());
+    VELOX_CHECK(position < ranges_.size());
     if (position == ranges_.size() - 1) {
       if (throwIfPastEnd) {
         throw std::runtime_error("Reading past end of ByteStream");

--- a/velox/functions/lib/string/StringCore.h
+++ b/velox/functions/lib/string/StringCore.h
@@ -76,9 +76,10 @@ reverseUnicode(char* output, const char* input, size_t length) {
     // continue reverse invalid sequence byte by byte.
     assert(
         size > 0 && "UNLIKELY: could not get size of invalid utf8 code point");
+    assert(outputIdx >= size && "access out of bound");
     outputIdx -= size;
 
-    assert(outputIdx >= 0 && outputIdx < length && "access out of bound");
+    assert(outputIdx < length && "access out of bound");
     std::memcpy(&output[outputIdx], &input[inputIdx], size);
     inputIdx += size;
   }


### PR DESCRIPTION
Summary:
# Problem

In two places we're saving difference to unsigned value and asserting the value is nonegative. This is obviously wrong.

# Fix

Change assertions to be pre subtraction and verify that minuend >= subtraend.

Reviewed By: mbasmanova

Differential Revision: D38904624

