### PR TITLE
Pass not nullable context and results by reference

### DIFF
--- a/velox/benchmarks/basic/Preproc.cpp
+++ b/velox/benchmarks/basic/Preproc.cpp
@@ -286,7 +286,7 @@ class PreprocBenchmark : public functions::test::FunctionBenchmarkBase {
     SelectivityVector rows(data->size());
     std::vector<VectorPtr> results(exprSet.exprs().size());
     exec::EvalCtx evalCtx(&execCtx_, &exprSet, data.get());
-    exprSet.eval(rows, &evalCtx, &results);
+    exprSet.eval(rows, evalCtx, results);
     return results;
   }
 
@@ -336,7 +336,7 @@ class PreprocBenchmark : public functions::test::FunctionBenchmarkBase {
     size_t cnt = 0;
     for (auto i = 0; i < times * 1'0000; i++) {
       exec::EvalCtx evalCtx(&execCtx_, &exprSet, data.get());
-      exprSet.eval(rows, &evalCtx, &results);
+      exprSet.eval(rows, evalCtx, results);
       cnt += results[0]->size();
     }
     return cnt;

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -155,7 +155,7 @@ int main(int argc, char** argv) {
   // Voila! Here we do the actual evaluation. When this function returns, the
   // output vectors will be available in the results vector. Note that ExprSet's
   // logic is synchronous and single threaded.
-  exprSet.eval(rows, &evalCtx, &result);
+  exprSet.eval(rows, evalCtx, result);
 
   // Print the output vector, just for fun:
   const auto& outputVector = result.front();

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -325,6 +325,6 @@ VectorPtr evaluate(
 
   exec::ExprSet exprSet({exprPlan}, &execCtx);
   exec::EvalCtx evalCtx(&execCtx, &exprSet, rowVector.get());
-  exprSet.eval(rows, &evalCtx, &result);
+  exprSet.eval(rows, evalCtx, result);
   return result.front();
 }

--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -67,11 +67,11 @@ class FilterProject : public Operator {
   // of the passing rows if only some rows pass the filter. If all or no rows
   // passed the filter filterEvalCtx_.selectedBits and selectedIndices are not
   // updated.
-  vector_size_t filter(EvalCtx* evalCtx, const SelectivityVector& allRows);
+  vector_size_t filter(EvalCtx& evalCtx, const SelectivityVector& allRows);
 
   // Evaluate projections on the specified rows and populate results_.
   // pre-condition: !isIdentityProjection_
-  void project(const SelectivityVector& rows, EvalCtx* evalCtx);
+  void project(const SelectivityVector& rows, EvalCtx& evalCtx);
 
   // If true exprs_[0] is a filter and the other expressions are projections
   const bool hasFilter_{false};

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -545,7 +545,7 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
   filterRows_.setAll();
 
   EvalCtx evalCtx(operatorCtx_->execCtx(), filter_.get(), filterInput_.get());
-  filter_->eval(0, 1, true, filterRows_, &evalCtx, &filterResult_);
+  filter_->eval(0, 1, true, filterRows_, evalCtx, filterResult_);
 
   decodedFilterResult_.decode(*filterResult_[0], filterRows_);
 

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -671,7 +671,7 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
 
 void MergeJoin::evaluateFilter(const SelectivityVector& rows) {
   EvalCtx evalCtx(operatorCtx_->execCtx(), filter_.get(), filterInput_.get());
-  filter_->eval(0, 1, true, rows, &evalCtx, &filterResult_);
+  filter_->eval(0, 1, true, rows, evalCtx, filterResult_);
 
   decodedFilterResult_.decode(*filterResult_[0], rows);
 }

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -45,7 +45,7 @@ class SimpleExpressionEvaluator : public connector::ExpressionEvaluator {
     exec::EvalCtx context(execCtx_, exprSet, input.get());
 
     std::vector<VectorPtr> results = {*result};
-    exprSet->eval(0, 1, true, rows, &context, &results);
+    exprSet->eval(0, 1, true, rows, context, results);
 
     *result = results[0];
   }

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -79,7 +79,7 @@ class VeloxIn10MinDemo : public VectorTestBase {
 
     SelectivityVector rows(input->size());
     std::vector<VectorPtr> result(1);
-    exprSet.eval(rows, &context, &result);
+    exprSet.eval(rows, context, result);
     return result[0];
   }
 

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -471,7 +471,7 @@ class ExpressionCodegenTestBase : public testing::Test {
       facebook::velox::exec::EvalCtx evalCtx(
           execCtx_.get(), &exprSet, rowVector.get());
       std::vector<VectorPtr> result(1);
-      exprSet.eval(*rows, &evalCtx, &result);
+      exprSet.eval(*rows, evalCtx, result);
       auto resultsRows = OutputRowTypeTrait::getBaseVectorsAsViewTupleRows(
           result[0].get(), *rows);
 

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -72,7 +72,7 @@ class CodegenTestCore {
     EvalCtx context(execCtx_.get(), &exprSet, &inputRowBatches);
     std::vector<VectorPtr> results(sizeof...(SQLType));
     exprSet.eval(
-        0, sizeof...(SQLType) - 1, true, selectedRows, &context, &results);
+        0, sizeof...(SQLType) - 1, true, selectedRows, context, results);
     return results;
   }
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1352,14 +1352,14 @@ void ExprSet::eval(
     int32_t end,
     bool initialize,
     const SelectivityVector& rows,
-    EvalCtx* context,
-    std::vector<VectorPtr>* result) {
-  result->resize(exprs_.size());
+    EvalCtx& context,
+    std::vector<VectorPtr>& result) {
+  result.resize(exprs_.size());
   if (initialize) {
     clearSharedSubexprs();
   }
   for (int32_t i = begin; i < end; ++i) {
-    exprs_[i]->eval(rows, *context, (*result)[i]);
+    exprs_[i]->eval(rows, context, result[i]);
   }
 }
 
@@ -1381,14 +1381,14 @@ void ExprSetSimplified::eval(
     int32_t end,
     bool initialize,
     const SelectivityVector& rows,
-    EvalCtx* context,
-    std::vector<VectorPtr>* result) {
-  result->resize(exprs_.size());
+    EvalCtx& context,
+    std::vector<VectorPtr>& result) {
+  result.resize(exprs_.size());
   if (initialize) {
     clearSharedSubexprs();
   }
   for (int32_t i = begin; i < end; ++i) {
-    exprs_[i]->evalSimplified(rows, *context, (*result)[i]);
+    exprs_[i]->evalSimplified(rows, context, result[i]);
   }
 }
 

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -393,8 +393,8 @@ class ExprSet {
   // Initialize and evaluate all expressions available in this ExprSet.
   void eval(
       const SelectivityVector& rows,
-      EvalCtx* FOLLY_NONNULL ctx,
-      std::vector<VectorPtr>* FOLLY_NONNULL result) {
+      EvalCtx& ctx,
+      std::vector<VectorPtr>& result) {
     eval(0, exprs_.size(), true, rows, ctx, result);
   }
 
@@ -404,8 +404,8 @@ class ExprSet {
       int32_t end,
       bool initialize,
       const SelectivityVector& rows,
-      EvalCtx* FOLLY_NONNULL ctx,
-      std::vector<VectorPtr>* FOLLY_NONNULL result);
+      EvalCtx& ctx,
+      std::vector<VectorPtr>& result);
 
   void clear();
 
@@ -463,8 +463,8 @@ class ExprSetSimplified : public ExprSet {
   // Initialize and evaluate all expressions available in this ExprSet.
   void eval(
       const SelectivityVector& rows,
-      EvalCtx* FOLLY_NONNULL ctx,
-      std::vector<VectorPtr>* FOLLY_NONNULL result) {
+      EvalCtx& ctx,
+      std::vector<VectorPtr>& result) {
     eval(0, exprs_.size(), true, rows, ctx, result);
   }
 
@@ -473,8 +473,8 @@ class ExprSetSimplified : public ExprSet {
       int32_t end,
       bool initialize,
       const SelectivityVector& rows,
-      EvalCtx* FOLLY_NONNULL ctx,
-      std::vector<VectorPtr>* FOLLY_NONNULL result) override;
+      EvalCtx& ctx,
+      std::vector<VectorPtr>& result) override;
 };
 
 // Factory method that takes `kExprEvalSimplified` (query parameter) into

--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -35,7 +35,7 @@ VectorPtr toConstant(
 
   SelectivityVector rows(1);
   std::vector<VectorPtr> results(1);
-  exprSet.eval(rows, &evalCtx, &results);
+  exprSet.eval(rows, evalCtx, results);
 
   return results[0];
 }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -114,7 +114,7 @@ class CastExprTest : public functions::test::FunctionBaseTest {
     std::vector<VectorPtr> result(1);
     {
       exec::EvalCtx evalCtx(&execCtx_, &exprSet, rowVector.get());
-      exprSet.eval(rows, &evalCtx, &result);
+      exprSet.eval(rows, evalCtx, result);
 
       assertEqualVectors(expected, result[0]);
     }
@@ -126,7 +126,7 @@ class CastExprTest : public functions::test::FunctionBaseTest {
       auto constantData = BaseVector::wrapInConstant(size, index, data);
       auto constantRow = makeRowVector({constantData});
       exec::EvalCtx evalCtx(&execCtx_, &exprSet, constantRow.get());
-      exprSet.eval(rows, &evalCtx, &result);
+      exprSet.eval(rows, evalCtx, result);
 
       assertEqualVectors(
           BaseVector::wrapInConstant(size, index, expected), result[0]);
@@ -144,7 +144,7 @@ class CastExprTest : public functions::test::FunctionBaseTest {
           nullOnFailure);
       exec::ExprSet dictionaryExprSet({dictionaryCastExpr}, &execCtx_);
       exec::EvalCtx evalCtx(&execCtx_, &dictionaryExprSet, rowVector.get());
-      dictionaryExprSet.eval(rows, &evalCtx, &result);
+      dictionaryExprSet.eval(rows, evalCtx, result);
 
       auto indices = ::makeIndicesInReverse(size, pool());
       assertEqualVectors(wrapInDictionary(indices, size, expected), result[0]);

--- a/velox/expression/tests/EvalSimplifiedTest.cpp
+++ b/velox/expression/tests/EvalSimplifiedTest.cpp
@@ -103,13 +103,13 @@ class EvalSimplifiedTest : public FunctionBaseTest {
       std::exception_ptr exceptionSimplifiedPtr;
 
       try {
-        exprSetCommon.eval(rows, &evalCtxCommon, &commonEvalResult);
+        exprSetCommon.eval(rows, evalCtxCommon, commonEvalResult);
       } catch (const std::exception& e) {
         exceptionCommonPtr = std::current_exception();
       }
 
       try {
-        exprSetSimplified.eval(rows, &evalCtxSimplified, &simplifiedEvalResult);
+        exprSetSimplified.eval(rows, evalCtxSimplified, simplifiedEvalResult);
       } catch (const std::exception& e) {
         exceptionSimplifiedPtr = std::current_exception();
       }

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -412,7 +412,7 @@ class ExprEncodingsTest
       vector_size_t end = size / 3 * 2;
       auto rows = selectRange(begin, end);
       std::vector<VectorPtr> result(1);
-      exprSet->eval(rows, &context, &result);
+      exprSet->eval(rows, context, result);
 
       SCOPED_TRACE(text);
       SCOPED_TRACE(fmt::format("[{} - {})", begin, end));
@@ -424,7 +424,7 @@ class ExprEncodingsTest
       vector_size_t end = size;
       auto rows = selectRange(begin, end);
       std::vector<VectorPtr> result(1);
-      exprSet->eval(0, 1, false, rows, &context, &result);
+      exprSet->eval(0, 1, false, rows, context, result);
 
       SCOPED_TRACE(text);
       SCOPED_TRACE(fmt::format("[{} - {})", begin, end));
@@ -453,7 +453,7 @@ class ExprEncodingsTest
 
       SCOPED_TRACE(text);
       SCOPED_TRACE(fmt::format("[{} - {})", begin, end));
-      ASSERT_THROW(exprs.eval(rows, &context, &result), VeloxException);
+      ASSERT_THROW(exprs.eval(rows, context, result), VeloxException);
     }
 
     begin = size / 3;
@@ -465,7 +465,7 @@ class ExprEncodingsTest
       SCOPED_TRACE(text);
       SCOPED_TRACE(fmt::format("[{} - {})", begin, end));
       ASSERT_THROW(
-          exprs.eval(0, 1, false, rows, &context, &result), VeloxException);
+          exprs.eval(0, 1, false, rows, context, result), VeloxException);
     }
   }
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -71,7 +71,7 @@ class ExprTest : public testing::Test, public VectorTestBase {
 
     SelectivityVector rows(input->size());
     std::vector<VectorPtr> result(expressions.size());
-    exprSet->eval(rows, &context, &result);
+    exprSet->eval(rows, context, result);
     return result;
   }
 
@@ -84,7 +84,7 @@ class ExprTest : public testing::Test, public VectorTestBase {
 
     SelectivityVector rows(input->size());
     std::vector<VectorPtr> result(1);
-    exprSet->eval(rows, &context, &result);
+    exprSet->eval(rows, context, result);
     return result[0];
   }
 
@@ -253,7 +253,7 @@ TEST_F(ExprTest, constantNull) {
 
   exec::ExprSet exprSet({expression}, execCtx_.get());
   exec::EvalCtx context(execCtx_.get(), &exprSet, rowVector.get());
-  exprSet.eval(rows, &context, &result);
+  exprSet.eval(rows, context, result);
 
   auto expected = vectorMaker_.flatVectorNullable<int32_t>(
       {std::nullopt, std::nullopt, std::nullopt});
@@ -280,7 +280,7 @@ TEST_F(ExprTest, validateReturnType) {
       {
         exec::ExprSet exprSet({expression}, execCtx_.get());
         exec::EvalCtx context(execCtx_.get(), &exprSet, rowVector.get());
-        exprSet.eval(rows, &context, &result);
+        exprSet.eval(rows, context, result);
       },
       VeloxUserError);
 }
@@ -342,7 +342,7 @@ TEST_F(ExprTest, constantArray) {
 
   SelectivityVector rows(input->size());
   std::vector<VectorPtr> result(2);
-  exprSet->eval(rows, &context, &result);
+  exprSet->eval(rows, context, result);
 
   ASSERT_TRUE(a->equalValueAt(result[0].get(), 3, 0));
   ASSERT_TRUE(b->equalValueAt(result[1].get(), 5, 0));
@@ -365,7 +365,7 @@ TEST_F(ExprTest, constantComplexNull) {
 
   SelectivityVector rows(size);
   std::vector<VectorPtr> result(3);
-  exprSet->eval(rows, &context, &result);
+  exprSet->eval(rows, context, result);
 
   ASSERT_EQ(VectorEncoding::Simple::CONSTANT, result[0]->encoding());
   ASSERT_EQ(TypeKind::ARRAY, result[0]->typeKind());

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -525,7 +525,7 @@ class ExpressionFuzzer {
       exec::EvalCtx evalCtxCommon(&execCtx_, &exprSetCommon, rowVector.get());
 
       try {
-        exprSetCommon.eval(rows, &evalCtxCommon, &commonEvalResult);
+        exprSetCommon.eval(rows, evalCtxCommon, commonEvalResult);
       } catch (...) {
         if (!canThrow) {
           LOG(ERROR)
@@ -547,7 +547,7 @@ class ExpressionFuzzer {
           &execCtx_, &exprSetSimplified, rowVector.get());
 
       try {
-        exprSetSimplified.eval(rows, &evalCtxSimplified, &simplifiedEvalResult);
+        exprSetSimplified.eval(rows, evalCtxSimplified, simplifiedEvalResult);
       } catch (...) {
         if (!canThrow) {
           LOG(ERROR)

--- a/velox/expression/tests/SimpleFunctionInitTest.cpp
+++ b/velox/expression/tests/SimpleFunctionInitTest.cpp
@@ -106,7 +106,7 @@ TEST_F(SimpleFunctionInitTest, initializationArray) {
         auto eval = [&](RowVectorPtr data, VectorPtr expectedVector) {
           exec::EvalCtx evalCtx(&execCtx_, &expr, data.get());
           std::vector<VectorPtr> results(1);
-          expr.eval(SelectivityVector(1), &evalCtx, &results);
+          expr.eval(SelectivityVector(1), evalCtx, results);
           assertEqualVectors(results[0], expectedVector);
         };
         auto expectedResult = makeVectorWithNullArrays<int32_t>(expected);
@@ -188,7 +188,7 @@ TEST_F(SimpleFunctionInitTest, initializationMap) {
   auto rowPtr = makeRowVector({inputVector});
   exec::EvalCtx evalCtx(&execCtx_, &expr, rowPtr.get());
   std::vector<VectorPtr> results(1);
-  expr.eval(SelectivityVector(3), &evalCtx, &results);
+  expr.eval(SelectivityVector(3), evalCtx, results);
   assertEqualVectors(results[0], expectedResults);
 }
 

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -42,7 +42,7 @@ class FunctionBenchmarkBase {
     SelectivityVector rows(data->size());
     exec::EvalCtx evalCtx(&execCtx_, &exprSet, data.get());
     std::vector<VectorPtr> results(1);
-    exprSet.eval(rows, &evalCtx, &results);
+    exprSet.eval(rows, evalCtx, results);
     return results[0];
   }
 

--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -136,7 +136,7 @@ class FunctionBaseTest : public testing::Test,
 
     facebook::velox::exec::EvalCtx evalCtx(&execCtx_, &exprSet, data.get());
     std::vector<VectorPtr> results{std::move(result)};
-    exprSet.eval(rows, &evalCtx, &results);
+    exprSet.eval(rows, evalCtx, results);
     result = results[0];
 
     return std::dynamic_pointer_cast<T>(results[0]);
@@ -265,7 +265,7 @@ class FunctionBaseTest : public testing::Test,
 
     SelectivityVector rows(input->size());
     std::vector<VectorPtr> result(1);
-    exprSet.eval(rows, &context, &result);
+    exprSet.eval(rows, context, result);
     return result[0];
   }
 
@@ -299,7 +299,7 @@ class FunctionBaseTest : public testing::Test,
 
     ExprSet exprSet({typedExpr}, &execCtx_);
     exec::EvalCtx evalCtx(&execCtx_, &exprSet, data.get());
-    exprSet.eval(*rows, &evalCtx, &results);
+    exprSet.eval(*rows, evalCtx, results);
 
     return results[0];
   }

--- a/velox/functions/sparksql/tests/InTest.cpp
+++ b/velox/functions/sparksql/tests/InTest.cpp
@@ -95,7 +95,7 @@ class InTest : public SparkFunctionBaseTest {
       auto expr = getExpr(asDictonary);
       exec::EvalCtx evalCtx(&execCtx_, &expr, data.get());
       std::vector<VectorPtr> results(1);
-      expr.eval(SelectivityVector(1), &evalCtx, &results);
+      expr.eval(SelectivityVector(1), evalCtx, results);
       // auto last = args.back();
       if (!results[0]->isNullAt(0))
         return results[0]->as<SimpleVector<bool>>()->valueAt(0);


### PR DESCRIPTION
Summary:
Those are always assumed not null and de-referenced with out
checking, hence passing them by reference is more suitable.

Differential Revision: D38946493

