### PR TITLE
Fix Merge operators to return null output instead of empty

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -353,6 +353,10 @@ StopReason Driver::runInternal(
               CpuWallTimer timer(op->stats().getOutputTiming);
               result = op->getOutput();
               if (result) {
+                VELOX_CHECK(
+                    result->size() > 0,
+                    "Operator::getOutput() must return nullptr or a non-empty vector: {}",
+                    op->stats().operatorType);
                 op->stats().outputVectors += 1;
                 op->stats().outputPositions += result->size();
                 resultBytes = result->estimateFlatSize();
@@ -405,6 +409,11 @@ StopReason Driver::runInternal(
             CpuWallTimer timer(op->stats().getOutputTiming);
             result = op->getOutput();
             if (result) {
+              VELOX_CHECK(
+                  result->size() > 0,
+                  "Operator::getOutput() must return nullptr or a non-empty vector: {}",
+                  op->stats().operatorType);
+
               // This code path is used only in single-threaded execution.
               blockingReason_ = BlockingReason::kWaitForConsumer;
               guard.notThrown();

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -133,8 +133,14 @@ RowVectorPtr Merge::getOutput() {
     auto stream = treeOfLosers_->next();
 
     if (!stream) {
-      output_->resize(outputSize_);
       finished_ = true;
+
+      // Return nullptr if there is no data.
+      if (outputSize_ == 0) {
+        return nullptr;
+      }
+
+      output_->resize(outputSize_);
       return std::move(output_);
     }
 

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -261,6 +261,7 @@ class Operator {
 
   // Adds input. Not used if operator is a source operator, e.g. the first
   // operator in the pipeline.
+  // @param input Non-empty input vector.
   virtual void addInput(RowVectorPtr input) = 0;
 
   // Informs 'this' that addInput will no longer be called. This means
@@ -276,6 +277,7 @@ class Operator {
   // for outside causes. isBlocked distinguishes between the
   // cases. Sink operator, e.g. the last operator in the pipeline, must return
   // nullptr and pass results to the consumer through a custom mechanism.
+  // @return nullptr or a non-empty output vector.
   virtual RowVectorPtr getOutput() = 0;
 
   // Returns kNotBlocked if 'this' is not prevented from

--- a/velox/exec/tests/CustomJoinTest.cpp
+++ b/velox/exec/tests/CustomJoinTest.cpp
@@ -194,6 +194,12 @@ class CustomJoinProbe : public Operator {
       return output;
     }
 
+    // Return nullptr if there is no data to return.
+    if (remainingLimit_ == 0) {
+      input_.reset();
+      return nullptr;
+    }
+
     auto output = std::make_shared<RowVector>(
         input_->pool(),
         input_->type(),


### PR DESCRIPTION
Fix Merge::getOutput() to return null instead of an empty vector. Operators
expect non-empty vectors as input, hence, output must be null or non-empty.
Merge operator used to sometimes return empty vectors causing a crash in
HashAggregation operator downstream.

Added a check for Operator::getOutput() being null or non-empty to the Driver.