### PR TITLE
pass ExecCtx and result by reference to apply()

### DIFF
--- a/velox/docs/develop/lambda-functions.rst
+++ b/velox/docs/develop/lambda-functions.rst
@@ -48,7 +48,7 @@ to "b":
 .. code-block:: sql
 
     > select filter(a, x -> x >= b)
-    
+
     [3, 4]
     [5, 6, 7]
 
@@ -86,7 +86,7 @@ compact form. In most cases lambda expression is the same for all rows, but it
 is possible for different rows to be associated with different lambdas as we
 have seen above. FunctionVector stores a list of different lambdas along with a
 set of rows each lambda applies to. Each lambda is represented as an object of
-type Callable which allows for evaluating the lambda on a set of rows. 
+type Callable which allows for evaluating the lambda on a set of rows.
 
 .. code-block:: c++
 
@@ -96,9 +96,9 @@ type Callable which allows for evaluating the lambda on a set of rows.
       void apply(
           const SelectivityVector& rows,
           BufferPtr wrapCapture,
-          exec::EvalCtx* context,
+          exec::EvalCtx& context,
           const std::vector<VectorPtr>& args,
-          VectorPtr* result);
+          VectorPtr& result);
     };
 
 The "apply" method of Callable is similar to the "apply" method of
@@ -210,20 +210,20 @@ in a test:
 .. code-block:: c++
 
   auto rowType = ROW({"a", "b"}, {ARRAY(BIGINT()), BIGINT()});
-  
+
   registerLambda("lambda", ROW({"x"}, {BIGINT()}), rowType, "x >= b"));
 
   auto result =
       evaluate<BaseVector>("filter(a, function('lambda'))", data);
 
 The first argument to registerLambda is the name for the lambda. This name can
-later be used to refer to the lambda in a function call. 
+later be used to refer to the lambda in a function call.
 
 The second argument is the signature of the lambda, e.g. the list of lambda
-parameters along with their names and types. 
+parameters along with their names and types.
 
 The third argument is the type of the input data to the overall expression. This
-is used to resolve the types of captures. 
+is used to resolve the types of captures.
 
 The last argument is the lambda body as SQL expression.
 

--- a/velox/docs/monthly-updates/march-2022.rst
+++ b/velox/docs/monthly-updates/march-2022.rst
@@ -133,7 +133,7 @@ Now consider a function that generates Array<int64_t> as an output. The result v
 
     VectorPtr result;
     // Here type is ArrayType(BIGINT()).
-    BaseVector::ensureWritable(rows, type, pool_, &result);
+    BaseVector::ensureWritable(rows, type, pool_, result);
 
     // Define a vector writer. ArrayWriterT is a temp holder. Eventually, Array will be used
     // once old writers are deprecated.

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -274,7 +274,7 @@ void SelectiveStringDictionaryColumnReader::getValues(
 
   if (scanSpec_->makeFlat()) {
     BaseVector::ensureWritable(
-        SelectivityVector::empty(), (*result)->type(), &memoryPool_, result);
+        SelectivityVector::empty(), (*result)->type(), &memoryPool_, *result);
   }
 }
 

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -116,8 +116,8 @@ class MapResolverVectorFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     // We cannot make any assumptions about the encoding of the input vectors.
     // In order to access their data as FlatVectors, we need to decode them
     // first:
@@ -134,8 +134,8 @@ class MapResolverVectorFunction : public exec::VectorFunction {
 
     // Ensure we have an output vector where we can write the output opaqued
     // values.
-    context->ensureWritable(rows, outputType, *result);
-    auto* output = (*result)->as<KindToFlatVector<TypeKind::OPAQUE>::type>();
+    context.ensureWritable(rows, outputType, result);
+    auto* output = result->as<KindToFlatVector<TypeKind::OPAQUE>::type>();
 
     // `applyToSelected()` will execute the lambda below on each row enabled in
     // the input selectivity vector (rows). We don't need to check for null

--- a/velox/exec/tests/FunctionResolutionTest.cpp
+++ b/velox/exec/tests/FunctionResolutionTest.cpp
@@ -41,10 +41,10 @@ class VectorFunctionTwoArgs : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& /*args*/,
       const TypePtr& /*outputType*/,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
-    BaseVector::ensureWritable(rows, BOOLEAN(), context->pool(), result);
-    auto resultVector = (*result)->asUnchecked<FlatVector<bool>>();
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    BaseVector::ensureWritable(rows, BOOLEAN(), context.pool(), result);
+    auto resultVector = result->asUnchecked<FlatVector<bool>>();
 
     rows.applyToSelected([&](auto row) { resultVector->set(row, false); });
   }
@@ -64,8 +64,8 @@ class VectorFunctionOneArg : public VectorFunctionTwoArgs {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& ptr,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 1);
     VectorFunctionTwoArgs::apply(rows, args, ptr, context, result);
   }

--- a/velox/experimental/codegen/benchmark/CodegenBenchmark.h
+++ b/velox/experimental/codegen/benchmark/CodegenBenchmark.h
@@ -319,8 +319,8 @@ class CodegenBenchmark : public CodegenTestCore {
                   arguments, // See D27826068
                   // batch.get()->children(),
                   nullptr,
-                  &context,
-                  &batchResult);
+                  context,
+                  batchResult);
           return batchResult;
         }
 
@@ -336,8 +336,8 @@ class CodegenBenchmark : public CodegenTestCore {
                 arguments, // See D27826068
                 // batch.get()->children(),
                 nullptr,
-                &context,
-                &filterResult);
+                context,
+                filterResult);
 
         auto numOut = facebook::velox::exec::processFilterResults(
             filterResult->as<RowVector>()->childAt(0),
@@ -358,7 +358,7 @@ class CodegenBenchmark : public CodegenTestCore {
         dynamic_cast<facebook::velox::exec::VectorFunction*>(
             info.projectionFunc.get())
             ->apply(
-                rows, batch.get()->children(), nullptr, &context, &batchResult);
+                rows, batch.get()->children(), nullptr, context, batchResult);
 
         if (numOut != batch->size()) {
           batchResult = facebook::velox::exec::wrap(

--- a/velox/expression/DecodedArgs.h
+++ b/velox/expression/DecodedArgs.h
@@ -35,9 +35,9 @@ class DecodedArgs {
   DecodedArgs(
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
-      exec::EvalCtx* FOLLY_NONNULL context) {
+      exec::EvalCtx& context) {
     for (auto& arg : args) {
-      holders_.emplace_back(*context, *arg.get(), rows);
+      holders_.emplace_back(context, *arg, rows);
     }
   }
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -206,18 +206,11 @@ class EvalCtx {
       const SelectivityVector& rows,
       VectorPtr& result) const {
     if (result && !isFinalSelection() && *finalSelection() != rows) {
-      BaseVector::ensureWritable(rows, result->type(), result->pool(), &result);
+      BaseVector::ensureWritable(rows, result->type(), result->pool(), result);
       result->copy(localResult.get(), rows, nullptr);
     } else {
       result = localResult;
     }
-  }
-
-  void moveOrCopyResult(
-      const VectorPtr& localResult,
-      const SelectivityVector& rows,
-      VectorPtr* FOLLY_NONNULL result) const {
-    moveOrCopyResult(localResult, rows, *result);
   }
 
   VectorPool& vectorPool() const {
@@ -243,7 +236,7 @@ class EvalCtx {
       const TypePtr& type,
       VectorPtr& result) {
     BaseVector::ensureWritable(
-        rows, type, execCtx_->pool(), &result, &execCtx_->vectorPool());
+        rows, type, execCtx_->pool(), result, &execCtx_->vectorPool());
   }
 
  private:
@@ -408,9 +401,6 @@ class LocalDecodedVector {
  public:
   explicit LocalDecodedVector(core::ExecCtx& context) : context_(context) {}
 
-  explicit LocalDecodedVector(core::ExecCtx* FOLLY_NONNULL context)
-      : LocalDecodedVector(*context) {}
-
   explicit LocalDecodedVector(EvalCtx& context)
       : context_(*context.execCtx()) {}
 
@@ -425,13 +415,6 @@ class LocalDecodedVector {
       : context_(*context.execCtx()) {
     get()->decode(vector, rows, loadLazy);
   }
-
-  LocalDecodedVector(
-      const EvalCtx* FOLLY_NONNULL context,
-      const BaseVector& vector,
-      const SelectivityVector& rows,
-      bool loadLazy = true)
-      : LocalDecodedVector(*context, vector, rows, loadLazy) {}
 
   LocalDecodedVector(LocalDecodedVector&& other) noexcept
       : context_{other.context_}, vector_{std::move(other.vector_)} {}

--- a/velox/expression/FieldReference.cpp
+++ b/velox/expression/FieldReference.cpp
@@ -98,6 +98,6 @@ void FieldReference::evalSpecialFormSimplified(
 
   auto row = context.row();
   result = row->childAt(index(context));
-  BaseVector::flattenVector(&result, rows.end());
+  BaseVector::flattenVector(result, rows.end());
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -50,7 +50,7 @@ class VectorFunction {
   /// see a null row in any of the arguments. They can safely assume that there
   /// are no nulls in any of the arguments in specified positions.
   ///
-  /// If context->isFinalSelection() is false, the result may have been
+  /// If context.isFinalSelection() is false, the result may have been
   /// partially populated for the positions not specified in rows. The function
   /// must take care not to overwrite these values. This happens when evaluating
   /// conditional expressions. Consider if(a = 1, f(b), g(c)) expression. The
@@ -59,14 +59,14 @@ class VectorFunction {
   /// but g(c) is called with partially populated result which has f(b) values
   /// in some positions. Function g must preserve these values.
   ///
-  /// Use context->isFinalSelection() to determine whether partially populated
+  /// Use context.isFinalSelection() to determine whether partially populated
   /// results must be preserved or not.
   ///
   /// If 'result' is not null, it can be dictionary, constant or sequence
   /// encoded and therefore may be read-only. Call BaseVector::ensureWritable
   /// before writing into the "result", e.g.
   ///
-  ///    BaseVector::ensureWritable(&rows, caller->type(), context->pool(),
+  ///    BaseVector::ensureWritable(&rows, caller->type(), context.pool(),
   ///        result);
   ///
   /// If 'result' is null, the function can allocate a new vector using
@@ -77,8 +77,8 @@ class VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args, // Not using const ref so we can reuse args
       const TypePtr& outputType,
-      EvalCtx* context,
-      VectorPtr* result) const = 0;
+      EvalCtx& context,
+      VectorPtr& result) const = 0;
 
   virtual bool isDeterministic() const {
     return true;

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -63,7 +63,7 @@ class ArrayWriterTest : public functions::test::FunctionBaseTest {
   VectorPtr prepareResult(const TypePtr& arrayType, vector_size_t size = 1) {
     VectorPtr result;
     BaseVector::ensureWritable(
-        SelectivityVector(size), arrayType, this->execCtx_.pool(), &result);
+        SelectivityVector(size), arrayType, this->execCtx_.pool(), result);
     return result;
   }
 
@@ -375,7 +375,7 @@ TEST_F(ArrayWriterTest, nestedArray) {
   auto result = prepareResult(std::make_shared<ArrayType>(elementType));
 
   exec::VectorWriter<Array<Array<int32_t>>> vectorWriter;
-  vectorWriter.init(*result.get()->as<ArrayVector>());
+  vectorWriter.init(*result->as<ArrayVector>());
   vectorWriter.setOffset(0);
   auto& arrayWriter = vectorWriter.current();
   // Only general interface is allowed for nested arrays.
@@ -771,7 +771,7 @@ TEST_F(ArrayWriterTest, finishPostSize) {
   auto result = prepareResult(CppToType<out_t>::create());
 
   exec::VectorWriter<out_t> vectorWriter;
-  vectorWriter.init(*result.get()->as<ArrayVector>());
+  vectorWriter.init(*result->as<ArrayVector>());
   vectorWriter.setOffset(0);
 
   // Add 3 items in top level array and 10 in inner array.

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -40,12 +40,12 @@ class TestingDictionaryFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK(rows.isAllSelected());
     const auto size = rows.size();
-    auto indices = makeIndicesInReverse(size, context->pool());
-    *result = BaseVector::wrapInDictionary(
+    auto indices = makeIndicesInReverse(size, context.pool());
+    result = BaseVector::wrapInDictionary(
         BufferPtr(nullptr), indices, size, args[0]);
   }
 

--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -34,7 +34,7 @@ class GenericWriterTest : public functions::test::FunctionBaseTest {};
 
 TEST_F(GenericWriterTest, boolean) {
   VectorPtr result;
-  BaseVector::ensureWritable(SelectivityVector(5), BOOLEAN(), pool(), &result);
+  BaseVector::ensureWritable(SelectivityVector(5), BOOLEAN(), pool(), result);
 
   VectorWriter<Any> writer;
   writer.init(*result);
@@ -61,7 +61,7 @@ TEST_F(GenericWriterTest, boolean) {
 
 TEST_F(GenericWriterTest, integer) {
   VectorPtr result;
-  BaseVector::ensureWritable(SelectivityVector(100), BIGINT(), pool(), &result);
+  BaseVector::ensureWritable(SelectivityVector(100), BIGINT(), pool(), result);
 
   VectorWriter<Any> writer;
   writer.init(*result);
@@ -82,7 +82,7 @@ TEST_F(GenericWriterTest, integer) {
 
 TEST_F(GenericWriterTest, varchar) {
   VectorPtr result;
-  BaseVector::ensureWritable(SelectivityVector(6), VARCHAR(), pool(), &result);
+  BaseVector::ensureWritable(SelectivityVector(6), VARCHAR(), pool(), result);
 
   VectorWriter<Any> writer;
   writer.init(*result);
@@ -109,7 +109,7 @@ TEST_F(GenericWriterTest, varchar) {
 TEST_F(GenericWriterTest, array) {
   VectorPtr result;
   BaseVector::ensureWritable(
-      SelectivityVector(5), ARRAY(BIGINT()), pool(), &result);
+      SelectivityVector(5), ARRAY(BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
   writer.init(*result);
@@ -143,7 +143,7 @@ TEST_F(GenericWriterTest, array) {
 TEST_F(GenericWriterTest, arrayWriteThenCommitNull) {
   VectorPtr result;
   SelectivityVector rows(2);
-  BaseVector::ensureWritable(rows, ARRAY(BIGINT()), pool(), &result);
+  BaseVector::ensureWritable(rows, ARRAY(BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
   writer.init(*result);
@@ -177,8 +177,7 @@ TEST_F(GenericWriterTest, genericWriteThenCommitNull) {
   SelectivityVector rows(2);
   using test_t = Row<Array<int64_t>>;
 
-  BaseVector::ensureWritable(
-      rows, CppToType<test_t>::create(), pool(), &result);
+  BaseVector::ensureWritable(rows, CppToType<test_t>::create(), pool(), result);
 
   VectorWriter<Any> writer;
   writer.init(*result);
@@ -213,7 +212,7 @@ TEST_F(GenericWriterTest, genericWriteThenCommitNull) {
 TEST_F(GenericWriterTest, map) {
   VectorPtr result;
   BaseVector::ensureWritable(
-      SelectivityVector(4), MAP(VARCHAR(), BIGINT()), pool(), &result);
+      SelectivityVector(4), MAP(VARCHAR(), BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
   writer.init(*result);
@@ -251,7 +250,7 @@ TEST_F(GenericWriterTest, row) {
       SelectivityVector(4),
       ROW({VARCHAR(), BIGINT(), DOUBLE()}),
       pool(),
-      &result);
+      result);
 
   VectorWriter<Any> writer;
   writer.init(*result);
@@ -296,7 +295,7 @@ TEST_F(GenericWriterTest, nested) {
       SelectivityVector(3),
       MAP(BIGINT(), ROW({ARRAY(BIGINT()), TINYINT()})),
       pool(),
-      &result);
+      result);
 
   VectorWriter<Any> writer;
   writer.init(*result);
@@ -366,7 +365,7 @@ TEST_F(GenericWriterTest, nested) {
 
 TEST_F(GenericWriterTest, commitNull) {
   VectorPtr result;
-  BaseVector::ensureWritable(SelectivityVector(3), BIGINT(), pool(), &result);
+  BaseVector::ensureWritable(SelectivityVector(3), BIGINT(), pool(), result);
 
   VectorWriter<Any> writer;
   writer.init(*result);
@@ -396,7 +395,7 @@ TEST_F(GenericWriterTest, handleMisuse) {
   // Test finish without commit.
   VectorPtr result;
   BaseVector::ensureWritable(
-      SelectivityVector(1), ARRAY(BIGINT()), pool(), &result);
+      SelectivityVector(1), ARRAY(BIGINT()), pool(), result);
 
   VectorWriter<Any> writer1;
   initializeAndAddElements(result, writer1);

--- a/velox/expression/tests/MapWriterTest.cpp
+++ b/velox/expression/tests/MapWriterTest.cpp
@@ -78,7 +78,7 @@ class MapWriterTest : public functions::test::FunctionBaseTest {
   VectorPtr prepareResult(const TypePtr& mapType, vector_size_t size = 1) {
     VectorPtr result;
     BaseVector::ensureWritable(
-        SelectivityVector(size), mapType, this->execCtx_.pool(), &result);
+        SelectivityVector(size), mapType, this->execCtx_.pool(), result);
     return result;
   }
 

--- a/velox/expression/tests/RowWriterTest.cpp
+++ b/velox/expression/tests/RowWriterTest.cpp
@@ -53,7 +53,7 @@ class RowWriterTest : public functions::test::FunctionBaseTest {
   VectorPtr prepareResult(const TypePtr& rowType, vector_size_t size = 1) {
     VectorPtr result;
     BaseVector::ensureWritable(
-        SelectivityVector(size), rowType, this->execCtx_.pool(), &result);
+        SelectivityVector(size), rowType, this->execCtx_.pool(), result);
     return result;
   }
 
@@ -503,7 +503,7 @@ TEST_F(RowWriterTest, finishPostSize) {
   auto result = prepareResult(CppToType<out_t>::create());
 
   exec::VectorWriter<out_t> vectorWriter;
-  vectorWriter.init(*result.get()->as<RowVector>());
+  vectorWriter.init(*result->as<RowVector>());
   vectorWriter.setOffset(0);
 
   auto& rowWriter = vectorWriter.current();

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -949,7 +949,7 @@ VectorPtr testVariadicArgReuse(
   exec::EvalCtx evalCtx(execCtx, &exprSet, inputRows.get());
 
   VectorPtr resultPtr;
-  function->apply(rows, inputs, outputType, &evalCtx, &resultPtr);
+  function->apply(rows, inputs, outputType, evalCtx, resultPtr);
 
   return resultPtr;
 }

--- a/velox/expression/tests/TryExprTest.cpp
+++ b/velox/expression/tests/TryExprTest.cpp
@@ -143,13 +143,12 @@ class CreateConstantAndThrow : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& /* args */,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
-    *result =
-        BaseVector::createConstant((int64_t)1, rows.end(), context->pool());
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    result = BaseVector::createConstant((int64_t)1, rows.end(), context.pool());
 
     rows.applyToSelected([&](int row) {
-      context->setError(
+      context.setError(
           row, std::make_exception_ptr(std::invalid_argument("expected")));
     });
   }

--- a/velox/expression/tests/VariadicViewTest.cpp
+++ b/velox/expression/tests/VariadicViewTest.cpp
@@ -64,7 +64,7 @@ class VariadicViewTest : public functions::test::FunctionBaseTest {
     EvalCtx ctx(&execCtx_);
     std::vector<std::optional<LocalDecodedVector>> args;
     for (const auto& vector : vectors) {
-      args.emplace_back(LocalDecodedVector(&ctx, *vector, rows));
+      args.emplace_back(LocalDecodedVector(ctx, *vector, rows));
     }
 
     size_t startIndex = additionalVectors.size();
@@ -140,7 +140,7 @@ class VariadicViewTest : public functions::test::FunctionBaseTest {
     EvalCtx ctx(&execCtx_);
     std::vector<std::optional<LocalDecodedVector>> args;
     for (const auto& vector : vectors) {
-      args.emplace_back(LocalDecodedVector(&ctx, *vector, rows));
+      args.emplace_back(LocalDecodedVector(ctx, *vector, rows));
     }
 
     VectorReader<Variadic<int64_t>> reader(args, 0);
@@ -170,7 +170,7 @@ class VariadicViewTest : public functions::test::FunctionBaseTest {
     EvalCtx ctx(&execCtx_);
     std::vector<std::optional<LocalDecodedVector>> args;
     for (const auto& vector : vectors) {
-      args.emplace_back(LocalDecodedVector(&ctx, *vector, rows));
+      args.emplace_back(LocalDecodedVector(ctx, *vector, rows));
     }
 
     VectorReader<Variadic<int64_t>> reader(args, 0);
@@ -203,7 +203,7 @@ class VariadicViewTest : public functions::test::FunctionBaseTest {
     EvalCtx ctx(&execCtx_);
     std::vector<std::optional<LocalDecodedVector>> args;
     for (const auto& vector : vectors) {
-      args.emplace_back(LocalDecodedVector(&ctx, *vector, rows));
+      args.emplace_back(LocalDecodedVector(ctx, *vector, rows));
     }
 
     VectorReader<Variadic<int64_t>> reader(args, 0);
@@ -235,7 +235,7 @@ class VariadicViewTest : public functions::test::FunctionBaseTest {
     EvalCtx ctx(&execCtx_);
     std::vector<std::optional<LocalDecodedVector>> args;
     for (const auto& vector : vectors) {
-      args.emplace_back(LocalDecodedVector(&ctx, *vector, rows));
+      args.emplace_back(LocalDecodedVector(ctx, *vector, rows));
     }
 
     VectorReader<Variadic<int64_t>> reader(args, 0);
@@ -306,7 +306,7 @@ TEST_F(NullableVariadicViewTest, notNullContainer) {
   EvalCtx ctx(&execCtx_);
   std::vector<std::optional<LocalDecodedVector>> args;
   for (const auto& vector : vectors) {
-    args.emplace_back(LocalDecodedVector(&ctx, *vector, rows));
+    args.emplace_back(LocalDecodedVector(ctx, *vector, rows));
   }
 
   VectorReader<Variadic<int64_t>> reader(args, 0);

--- a/velox/expression/tests/VectorReaderTest.cpp
+++ b/velox/expression/tests/VectorReaderTest.cpp
@@ -462,7 +462,7 @@ TEST_F(VectorReaderTest, variadicContainsNull) {
   exec::EvalCtx ctx(&execCtx_);
   std::vector<std::optional<LocalDecodedVector>> args;
   for (const auto& vector : {field1Vector, field2Vector, field3Vector}) {
-    args.emplace_back(LocalDecodedVector(&ctx, *vector, rows));
+    args.emplace_back(LocalDecodedVector(ctx, *vector, rows));
   }
   exec::VectorReader<Variadic<int32_t>> reader(args, 0);
 
@@ -536,7 +536,7 @@ TEST_F(VectorReaderTest, dictionaryEncodedVariadicContainsNull) {
   exec::EvalCtx ctx(&execCtx_);
   std::vector<std::optional<LocalDecodedVector>> args;
   for (const auto& vector : {field1Vector, field2Vector, field3Vector}) {
-    args.emplace_back(LocalDecodedVector(&ctx, *vector, rows));
+    args.emplace_back(LocalDecodedVector(ctx, *vector, rows));
   }
   exec::VectorReader<Variadic<int32_t>> reader(args, 0);
 

--- a/velox/functions/lib/StringEncodingUtils.cpp
+++ b/velox/functions/lib/StringEncodingUtils.cpp
@@ -20,23 +20,23 @@
 namespace facebook::velox::functions {
 
 bool prepareFlatResultsVector(
-    VectorPtr* result,
+    VectorPtr& result,
     const SelectivityVector& rows,
-    exec::EvalCtx* context,
+    exec::EvalCtx& context,
     VectorPtr& argToReuse) {
-  if (!*result && BaseVector::isReusableFlatVector(argToReuse)) {
+  if (!result && BaseVector::isReusableFlatVector(argToReuse)) {
     // Move input vector to result
     VELOX_CHECK(
         VectorEncoding::isFlat(argToReuse.get()->encoding()) &&
         argToReuse.get()->typeKind() == TypeKind::VARCHAR);
 
-    *result = std::move(argToReuse);
+    result = std::move(argToReuse);
     return true;
   }
   // This will allocate results if not allocated
-  BaseVector::ensureWritable(rows, VARCHAR(), context->pool(), result);
+  BaseVector::ensureWritable(rows, VARCHAR(), context.pool(), result);
 
-  VELOX_CHECK(VectorEncoding::isFlat((*result).get()->encoding()));
+  VELOX_CHECK(VectorEncoding::isFlat(result->encoding()));
   return false;
 }
 

--- a/velox/functions/lib/StringEncodingUtils.h
+++ b/velox/functions/lib/StringEncodingUtils.h
@@ -25,9 +25,9 @@ namespace facebook::velox::functions {
 /// It will use the input argToReuse vector instead of creating new one when
 /// possible. Returns true if argToReuse vector was moved to results
 bool prepareFlatResultsVector(
-    VectorPtr* result,
+    VectorPtr& result,
     const SelectivityVector& rows,
-    exec::EvalCtx* context,
+    exec::EvalCtx& context,
     VectorPtr& argToReuse);
 
 /// Return the string encoding of a vector, if not set UTF8 is returned

--- a/velox/functions/prestosql/ArrayConstructor.cpp
+++ b/velox/functions/prestosql/ArrayConstructor.cpp
@@ -29,13 +29,13 @@ class ArrayConstructor : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     auto numArgs = args.size();
 
-    context->ensureWritable(rows, outputType, *result);
-    (*result)->clearNulls(rows);
-    auto arrayResult = (*result)->as<ArrayVector>();
+    context.ensureWritable(rows, outputType, result);
+    result->clearNulls(rows);
+    auto arrayResult = result->as<ArrayVector>();
     auto sizes = arrayResult->mutableSizes(rows.size());
     auto rawSizes = sizes->asMutable<int32_t>();
     auto offsets = arrayResult->mutableOffsets(rows.size());

--- a/velox/functions/prestosql/ArrayContains.cpp
+++ b/velox/functions/prestosql/ArrayContains.cpp
@@ -160,8 +160,8 @@ class ArrayContainsFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 2);
     const auto& arrayVector = args[0];
     const auto& searchVector = args[1];
@@ -170,8 +170,8 @@ class ArrayContainsFunction : public exec::VectorFunction {
     VELOX_CHECK(arrayVector->type()->asArray().elementType()->kindEquals(
         searchVector->type()));
 
-    context->ensureWritable(rows, BOOLEAN(), *result);
-    auto flatResult = (*result)->asFlatVector<bool>();
+    context.ensureWritable(rows, BOOLEAN(), result);
+    auto flatResult = result->asFlatVector<bool>();
 
     exec::LocalDecodedVector arrayHolder(context, *arrayVector, rows);
     auto elements = arrayHolder.get()->base()->as<ArrayVector>()->elements();

--- a/velox/functions/prestosql/ArrayDistinct.cpp
+++ b/velox/functions/prestosql/ArrayDistinct.cpp
@@ -47,8 +47,8 @@ class ArrayDistinctFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     auto& arg = args[0];
 
     VectorPtr localResult;
@@ -70,14 +70,14 @@ class ArrayDistinctFunction : public exec::VectorFunction {
       localResult = applyFlat(rows, arg, context);
     }
 
-    context->moveOrCopyResult(localResult, rows, result);
+    context.moveOrCopyResult(localResult, rows, result);
   }
 
  private:
   VectorPtr applyFlat(
       const SelectivityVector& rows,
       const VectorPtr& arg,
-      exec::EvalCtx* context) const {
+      exec::EvalCtx& context) const {
     auto arrayVector = arg->as<ArrayVector>();
     auto elementsVector = arrayVector->elements();
     auto elementsRows =
@@ -88,7 +88,7 @@ class ArrayDistinctFunction : public exec::VectorFunction {
     vector_size_t rowCount = arrayVector->size();
 
     // Allocate new vectors for indices, length and offsets.
-    memory::MemoryPool* pool = context->pool();
+    memory::MemoryPool* pool = context.pool();
     BufferPtr newIndices = allocateIndices(elementsCount, pool);
     BufferPtr newLengths = allocateSizes(rowCount, pool);
     BufferPtr newOffsets = allocateOffsets(rowCount, pool);

--- a/velox/functions/prestosql/ArrayDuplicates.cpp
+++ b/velox/functions/prestosql/ArrayDuplicates.cpp
@@ -48,8 +48,8 @@ class ArrayDuplicatesFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args, // Not using const ref so we can reuse args
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     auto& arg = args[0];
 
     VectorPtr localResult;
@@ -71,14 +71,14 @@ class ArrayDuplicatesFunction : public exec::VectorFunction {
       localResult = applyFlat(rows, arg, context);
     }
 
-    context->moveOrCopyResult(localResult, rows, result);
+    context.moveOrCopyResult(localResult, rows, result);
   }
 
  private:
   VectorPtr applyFlat(
       const SelectivityVector& rows,
       const VectorPtr& arg,
-      exec::EvalCtx* context) const {
+      exec::EvalCtx& context) const {
     auto arrayVector = arg->as<ArrayVector>();
     VELOX_CHECK(arrayVector);
     auto elementsVector = arrayVector->elements();
@@ -91,7 +91,7 @@ class ArrayDuplicatesFunction : public exec::VectorFunction {
     vector_size_t numRows = arrayVector->size();
 
     // Allocate new vectors for indices, length and offsets.
-    memory::MemoryPool* pool = context->pool();
+    memory::MemoryPool* pool = context.pool();
     BufferPtr newIndices = allocateIndices(numElements, pool);
     BufferPtr newSizes = allocateSizes(numRows, pool);
     BufferPtr newOffsets = allocateOffsets(numRows, pool);

--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -123,9 +123,9 @@ class ArrayIntersectExceptFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
-    memory::MemoryPool* pool = context->pool();
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    memory::MemoryPool* pool = context.pool();
     BaseVector* left = args[0].get();
     BaseVector* right = args[1].get();
 
@@ -257,7 +257,7 @@ class ArrayIntersectExceptFunction : public exec::VectorFunction {
         newLengths,
         newElements,
         0);
-    context->moveOrCopyResult(resultArray, rows, result);
+    context.moveOrCopyResult(resultArray, rows, result);
   }
 
   // If one of the arrays is constant, this member will store a pointer to the
@@ -281,8 +281,8 @@ class ArraysOverlapFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     BaseVector* left = args[0].get();
     BaseVector* right = args[1].get();
     if (constantSet_.has_value() && isLeftConstant_) {
@@ -294,8 +294,8 @@ class ArraysOverlapFunction : public exec::VectorFunction {
         decodeArrayElements(arrayDecoder, elementsDecoder, rows);
     auto decodedLeftArray = arrayDecoder.get();
     auto baseLeftArray = decodedLeftArray->base()->as<ArrayVector>();
-    context->ensureWritable(rows, BOOLEAN(), *result);
-    auto resultBoolVector = (*result)->template asFlatVector<bool>();
+    context.ensureWritable(rows, BOOLEAN(), result);
+    auto resultBoolVector = result->template asFlatVector<bool>();
     auto processRow = [&](auto row, const SetWithNull<T>& rightSet) {
       auto idx = decodedLeftArray->index(row);
       auto offset = baseLeftArray->offsetAt(idx);

--- a/velox/functions/prestosql/ArrayPosition.cpp
+++ b/velox/functions/prestosql/ArrayPosition.cpp
@@ -344,16 +344,16 @@ class ArrayPositionFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     const auto& arrayVector = args[0];
     const auto& searchVector = args[1];
     VELOX_CHECK(arrayVector->type()->isArray());
     VELOX_CHECK(arrayVector->type()->asArray().elementType()->kindEquals(
         searchVector->type()));
 
-    context->ensureWritable(rows, BIGINT(), *result);
-    auto flatResult = (*result)->asFlatVector<int64_t>();
+    context.ensureWritable(rows, BIGINT(), result);
+    auto flatResult = result->asFlatVector<int64_t>();
 
     exec::DecodedArgs decodedArgs(rows, args, context);
     auto elements = decodedArgs.at(0)->base()->as<ArrayVector>()->elements();

--- a/velox/functions/prestosql/ArraySum.cpp
+++ b/velox/functions/prestosql/ArraySum.cpp
@@ -102,11 +102,11 @@ class ArraySumFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args, // Not using const ref so we can reuse args
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     // Prepare result vector for writing
-    BaseVector::ensureWritable(rows, outputType, context->pool(), result);
-    auto resultValues = (*result)->template asFlatVector<TOutput>();
+    BaseVector::ensureWritable(rows, outputType, context.pool(), result);
+    auto resultValues = result->template asFlatVector<TOutput>();
 
     // Acquire the array elements vector.
     auto arrayVector = args[0]->as<ArrayVector>();

--- a/velox/functions/prestosql/FromUnixTime.cpp
+++ b/velox/functions/prestosql/FromUnixTime.cpp
@@ -30,15 +30,15 @@ class FromUnixtimeFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     exec::DecodedArgs decodedArgs(rows, args, context);
 
     auto unixtimes = decodedArgs.at(0);
     auto timezoneNames = decodedArgs.at(1);
 
     const auto size = rows.end();
-    auto* pool = context->pool();
+    auto* pool = context.pool();
 
     auto timestamps = BaseVector::create(BIGINT(), size, pool);
     auto* rawTimestamps =
@@ -77,7 +77,7 @@ class FromUnixtimeFunction : public exec::VectorFunction {
         std::vector<VectorPtr>{timestamps, timezones},
         0 /*nullCount*/);
 
-    context->moveOrCopyResult(localResult, rows, result);
+    context.moveOrCopyResult(localResult, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/prestosql/GreatestLeast.cpp
+++ b/velox/functions/prestosql/GreatestLeast.cpp
@@ -65,11 +65,11 @@ class ExtremeValueFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const {
-    context->ensureWritable(rows, outputType, *result);
+      exec::EvalCtx& context,
+      VectorPtr& result) const {
+    context.ensureWritable(rows, outputType, result);
     BufferPtr resultValues =
-        (*result)->as<FlatVector<T>>()->mutableValues(rows.end());
+        result->as<FlatVector<T>>()->mutableValues(rows.end());
     T* __restrict rawResult = resultValues->asMutable<T>();
 
     exec::DecodedArgs decodedArgs(rows, args, context);
@@ -96,7 +96,7 @@ class ExtremeValueFunction : public exec::VectorFunction {
 
     if constexpr (std::
                       is_same_v<T, TypeTraits<TypeKind::VARCHAR>::NativeType>) {
-      auto* flatResult = (*result)->as<FlatVector<T>>();
+      auto* flatResult = result->as<FlatVector<T>>();
       for (auto index : usedInputs) {
         flatResult->acquireSharedStringBuffers(args[index].get());
       }
@@ -108,8 +108,8 @@ class ExtremeValueFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     switch (outputType.get()->kind()) {
       case TypeKind::BIGINT:
         applyTyped<TypeTraits<TypeKind::BIGINT>::NativeType>(

--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -26,8 +26,8 @@ class MapFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 2);
 
     auto keys = args[0];
@@ -58,7 +58,7 @@ class MapFunction : public exec::VectorFunction {
       });
 
       mapVector = std::make_shared<MapVector>(
-          context->pool(),
+          context.pool(),
           outputType,
           BufferPtr(nullptr),
           rows.size(),
@@ -87,16 +87,16 @@ class MapFunction : public exec::VectorFunction {
         totalElements += keysArray->sizeAt(keyIndices[row]);
       });
 
-      BufferPtr offsets = allocateOffsets(rows.size(), context->pool());
+      BufferPtr offsets = allocateOffsets(rows.size(), context.pool());
       auto rawOffsets = offsets->asMutable<vector_size_t>();
 
-      BufferPtr sizes = allocateSizes(rows.size(), context->pool());
+      BufferPtr sizes = allocateSizes(rows.size(), context.pool());
       auto rawSizes = sizes->asMutable<vector_size_t>();
 
-      BufferPtr valuesIndices = allocateIndices(totalElements, context->pool());
+      BufferPtr valuesIndices = allocateIndices(totalElements, context.pool());
       auto rawValuesIndices = valuesIndices->asMutable<vector_size_t>();
 
-      BufferPtr keysIndices = allocateIndices(totalElements, context->pool());
+      BufferPtr keysIndices = allocateIndices(totalElements, context.pool());
       auto rawKeysIndices = keysIndices->asMutable<vector_size_t>();
 
       vector_size_t offset = 0;
@@ -128,7 +128,7 @@ class MapFunction : public exec::VectorFunction {
           valuesArray->elements());
 
       mapVector = std::make_shared<MapVector>(
-          context->pool(),
+          context.pool(),
           outputType,
           BufferPtr(nullptr),
           rows.size(),
@@ -158,7 +158,7 @@ class MapFunction : public exec::VectorFunction {
         }
       });
     }
-    context->moveOrCopyResult(mapVector, rows, result);
+    context.moveOrCopyResult(mapVector, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/prestosql/MapEntries.cpp
+++ b/velox/functions/prestosql/MapEntries.cpp
@@ -26,8 +26,8 @@ class MapEntriesFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     auto& arg = args[0];
 
     VectorPtr localResult;
@@ -49,7 +49,7 @@ class MapEntriesFunction : public exec::VectorFunction {
       localResult = applyFlat(rows, arg, outputType, context);
     }
 
-    context->moveOrCopyResult(localResult, rows, result);
+    context.moveOrCopyResult(localResult, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
@@ -67,18 +67,18 @@ class MapEntriesFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       const VectorPtr& arg,
       const TypePtr& outputType,
-      exec::EvalCtx* context) const {
+      exec::EvalCtx& context) const {
     const auto inputMap = arg->as<MapVector>();
 
     VectorPtr resultElements = std::make_shared<RowVector>(
-        context->pool(),
+        context.pool(),
         outputType->childAt(0),
         BufferPtr(nullptr),
         inputMap->mapKeys()->size(),
         std::vector<VectorPtr>{inputMap->mapKeys(), inputMap->mapValues()});
 
     return std::make_shared<ArrayVector>(
-        context->pool(),
+        context.pool(),
         outputType,
         inputMap->nulls(),
         rows.size(),

--- a/velox/functions/prestosql/RowFunction.cpp
+++ b/velox/functions/prestosql/RowFunction.cpp
@@ -25,17 +25,17 @@ class RowFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     auto argsCopy = args;
     RowVectorPtr row = std::make_shared<RowVector>(
-        context->pool(),
+        context.pool(),
         outputType,
         BufferPtr(nullptr),
         rows.size(),
         std::move(argsCopy),
         0 /*nullCount*/);
-    context->moveOrCopyResult(row, rows, *result);
+    context.moveOrCopyResult(row, rows, result);
   }
 
   bool isDefaultNullBehavior() const override {

--- a/velox/functions/prestosql/ToUtf8.cpp
+++ b/velox/functions/prestosql/ToUtf8.cpp
@@ -24,8 +24,8 @@ class ToUtf8Function : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VectorPtr localResult;
 
     // Input can be constant or flat.
@@ -33,13 +33,13 @@ class ToUtf8Function : public exec::VectorFunction {
     if (arg->isConstantEncoding()) {
       auto value = arg->as<ConstantVector<StringView>>()->valueAt(0);
       localResult = std::make_shared<ConstantVector<StringView>>(
-          context->pool(), rows.size(), false, VARBINARY(), std::move(value));
+          context.pool(), rows.size(), false, VARBINARY(), std::move(value));
     } else {
       auto flatInput = arg->asFlatVector<StringView>();
 
       auto stringBuffers = flatInput->stringBuffers();
       localResult = std::make_shared<FlatVector<StringView>>(
-          context->pool(),
+          context.pool(),
           VARBINARY(),
           nullptr,
           rows.size(),
@@ -47,7 +47,7 @@ class ToUtf8Function : public exec::VectorFunction {
           std::move(stringBuffers));
     }
 
-    context->moveOrCopyResult(localResult, rows, result);
+    context.moveOrCopyResult(localResult, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/prestosql/Transform.cpp
+++ b/velox/functions/prestosql/Transform.cpp
@@ -36,8 +36,8 @@ class TransformFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 2);
 
     // Flatten input array.
@@ -50,9 +50,9 @@ class TransformFunction : public exec::VectorFunction {
     auto newNumElements = flatArray->elements()->size();
 
     SelectivityVector finalSelection;
-    if (!context->isFinalSelection()) {
+    if (!context.isFinalSelection()) {
       finalSelection = toElementRows<ArrayVector>(
-          newNumElements, *context->finalSelection(), flatArray.get());
+          newNumElements, *context.finalSelection(), flatArray.get());
     }
 
     // transformed elements
@@ -71,7 +71,7 @@ class TransformFunction : public exec::VectorFunction {
           elementRows,
           finalSelection,
           wrapCapture,
-          context,
+          &context,
           lambdaArgs,
           &newElements);
     }
@@ -84,7 +84,7 @@ class TransformFunction : public exec::VectorFunction {
         flatArray->offsets(),
         flatArray->sizes(),
         newElements);
-    context->moveOrCopyResult(localResult, rows, result);
+    context.moveOrCopyResult(localResult, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/prestosql/TransformKeys.cpp
+++ b/velox/functions/prestosql/TransformKeys.cpp
@@ -36,8 +36,8 @@ class TransformKeysFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 2);
 
     // Flatten input map.
@@ -51,9 +51,9 @@ class TransformKeysFunction : public exec::VectorFunction {
     auto numKeys = flatMap->mapKeys()->size();
 
     SelectivityVector finalSelection;
-    if (!context->isFinalSelection()) {
+    if (!context.isFinalSelection()) {
       finalSelection = toElementRows<MapVector>(
-          numKeys, *context->finalSelection(), flatMap.get());
+          numKeys, *context.finalSelection(), flatMap.get());
     }
 
     VectorPtr transformedKeys;
@@ -71,7 +71,7 @@ class TransformKeysFunction : public exec::VectorFunction {
           keyRows,
           finalSelection,
           wrapCapture,
-          context,
+          &context,
           lambdaArgs,
           &transformedKeys);
     }
@@ -88,7 +88,7 @@ class TransformKeysFunction : public exec::VectorFunction {
 
     checkDuplicateKeys(localResult, rows);
 
-    context->moveOrCopyResult(localResult, rows, result);
+    context.moveOrCopyResult(localResult, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/prestosql/TransformValues.cpp
+++ b/velox/functions/prestosql/TransformValues.cpp
@@ -36,8 +36,8 @@ class TransformValuesFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 2);
 
     // Flatten input map.
@@ -51,9 +51,9 @@ class TransformValuesFunction : public exec::VectorFunction {
     auto numValues = flatMap->mapValues()->size();
 
     SelectivityVector finalSelection;
-    if (!context->isFinalSelection()) {
+    if (!context.isFinalSelection()) {
       finalSelection = toElementRows<MapVector>(
-          numValues, *context->finalSelection(), flatMap.get());
+          numValues, *context.finalSelection(), flatMap.get());
     }
 
     VectorPtr transformedValues;
@@ -71,7 +71,7 @@ class TransformValuesFunction : public exec::VectorFunction {
           valueRows,
           finalSelection,
           wrapCapture,
-          context,
+          &context,
           lambdaArgs,
           &transformedValues);
     }
@@ -85,7 +85,7 @@ class TransformValuesFunction : public exec::VectorFunction {
         flatMap->sizes(),
         flatMap->mapKeys(),
         transformedValues);
-    context->moveOrCopyResult(localResult, rows, result);
+    context.moveOrCopyResult(localResult, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/prestosql/WidthBucketArray.cpp
+++ b/velox/functions/prestosql/WidthBucketArray.cpp
@@ -60,10 +60,10 @@ class WidthBucketArrayFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
-    context->ensureWritable(rows, BIGINT(), *result);
-    auto flatResult = (*result)->asFlatVector<int64_t>()->mutableRawValues();
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, BIGINT(), result);
+    auto flatResult = result->asFlatVector<int64_t>()->mutableRawValues();
 
     exec::DecodedArgs decodedArgs(rows, args, context);
     auto operand = decodedArgs.at(0);
@@ -86,7 +86,7 @@ class WidthBucketArrayFunction : public exec::VectorFunction {
         flatResult[row] = widthBucket<T>(
             operand->valueAt<double>(row), *elementsHolder.get(), offset, size);
       } catch (const std::exception& e) {
-        context->setError(row, std::current_exception());
+        context.setError(row, std::current_exception());
       }
     });
   }
@@ -101,10 +101,10 @@ class WidthBucketArrayFunctionConstantBins : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
-    context->ensureWritable(rows, BIGINT(), *result);
-    auto flatResult = (*result)->asFlatVector<int64_t>()->mutableRawValues();
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, BIGINT(), result);
+    auto flatResult = result->asFlatVector<int64_t>()->mutableRawValues();
 
     exec::DecodedArgs decodedArgs(rows, args, context);
     auto operand = decodedArgs.at(0);
@@ -113,7 +113,7 @@ class WidthBucketArrayFunctionConstantBins : public exec::VectorFunction {
       try {
         flatResult[row] = widthBucket(operand->valueAt<double>(row), bins_);
       } catch (const std::exception& e) {
-        context->setError(row, std::current_exception());
+        context.setError(row, std::current_exception());
       }
     });
   }

--- a/velox/functions/prestosql/Zip.cpp
+++ b/velox/functions/prestosql/Zip.cpp
@@ -64,8 +64,8 @@ class ZipFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     validateInputTypes(args);
     const vector_size_t numInputArrays = args.size();
 
@@ -84,7 +84,7 @@ class ZipFunction : public exec::VectorFunction {
 
     // Size of elements in result vector.
     vector_size_t resultElementsSize = 0;
-    auto pool = context->pool();
+    auto* pool = context.pool();
     // This is true if for all rows, all the arrays within a row are the same
     // size.
     bool allSameSize = true;
@@ -146,7 +146,7 @@ class ZipFunction : public exec::VectorFunction {
             resultArraySizesBuffer,
             std::move(rowVector));
 
-        context->moveOrCopyResult(arrayVector, rows, result);
+        context.moveOrCopyResult(arrayVector, rows, result);
 
         return;
       }
@@ -224,7 +224,7 @@ class ZipFunction : public exec::VectorFunction {
         resultArraySizesBuffer,
         std::move(rowVector));
 
-    context->moveOrCopyResult(arrayVector, rows, result);
+    context.moveOrCopyResult(arrayVector, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.h
+++ b/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.h
@@ -215,8 +215,8 @@ class ArrayMinMaxFunctionBasic : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 1);
     auto arrayVector = args[0]->asUnchecked<ArrayVector>();
 
@@ -226,7 +226,7 @@ class ArrayMinMaxFunctionBasic : public exec::VectorFunction {
         context, *elementsVector, *elementsRows.get());
 
     BaseVector::ensureWritable(
-        rows, elementsVector->type(), context->pool(), result);
+        rows, elementsVector->type(), context.pool(), result);
 
     VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
         applyTyped,
@@ -235,7 +235,7 @@ class ArrayMinMaxFunctionBasic : public exec::VectorFunction {
         rows,
         *arrayVector,
         *elementsHolder.get(),
-        *result);
+        result);
   }
 };
 

--- a/velox/functions/prestosql/benchmarks/ArrayPositionBasic.h
+++ b/velox/functions/prestosql/benchmarks/ArrayPositionBasic.h
@@ -207,16 +207,16 @@ class ArrayPositionFunctionBasic : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     const auto& arrayVector = args[0];
     const auto& searchVector = args[1];
     VELOX_CHECK(arrayVector->type()->isArray());
     VELOX_CHECK(arrayVector->type()->asArray().elementType()->kindEquals(
         searchVector->type()));
 
-    context->ensureWritable(rows, BIGINT(), *result);
-    auto flatResult = (*result)->asFlatVector<int64_t>();
+    context.ensureWritable(rows, BIGINT(), result);
+    auto flatResult = result->asFlatVector<int64_t>();
 
     exec::DecodedArgs decodedArgs(rows, args, context);
     auto elements = decodedArgs.at(0)->base()->as<ArrayVector>()->elements();

--- a/velox/functions/prestosql/benchmarks/ArrayWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayWriterBenchmark.cpp
@@ -35,13 +35,13 @@ class VectorFunctionImpl : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     LocalDecodedVector decoded_(context, *args[0], rows); // NOLINT
 
     // Prepare results.
-    BaseVector::ensureWritable(rows, ARRAY(BIGINT()), context->pool(), result);
-    auto flatResult = (*result)->as<ArrayVector>();
+    BaseVector::ensureWritable(rows, ARRAY(BIGINT()), context.pool(), result);
+    auto flatResult = result->as<ArrayVector>();
     auto currentOffset = 0;
     auto elementsFlat = flatResult->elements()->asFlatVector<int64_t>();
 

--- a/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
@@ -44,20 +44,20 @@ class HourFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 1);
     const auto* timestamps =
         static_cast<const Timestamp*>(args[0]->valuesAsVoid());
 
     // Initialize flat results vector.
-    BaseVector::ensureWritable(rows, BIGINT(), context->pool(), result);
-    auto rawResults = (*result)->as<FlatVector<int64_t>>()->mutableRawValues();
+    BaseVector::ensureWritable(rows, BIGINT(), context.pool(), result);
+    auto rawResults = result->as<FlatVector<int64_t>>()->mutableRawValues();
 
     // Check if we need to adjust the current UTC timestamps to
     // the user provided session timezone.
     const auto* timeZone =
-        getTimeZoneIfNeeded(context->execCtx()->queryCtx()->config());
+        getTimeZoneIfNeeded(context.execCtx()->queryCtx()->config());
     if (timeZone != nullptr) {
       rows.applyToSelected([&](int row) {
         auto timestamp = timestamps[row];

--- a/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
@@ -33,8 +33,8 @@ class MapSumValuesAndKeysVector : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     auto arg = args.at(0);
 
     exec::LocalDecodedVector mapHolder(context, *arg, rows);
@@ -55,8 +55,8 @@ class MapSumValuesAndKeysVector : public exec::VectorFunction {
     auto rawOffsets = mapVector->rawOffsets();
     auto rawSizes = mapVector->rawSizes();
 
-    BaseVector::ensureWritable(rows, BIGINT(), context->pool(), result);
-    auto flatResult = (*result)->asFlatVector<int64_t>();
+    BaseVector::ensureWritable(rows, BIGINT(), context.pool(), result);
+    auto flatResult = result->asFlatVector<int64_t>();
 
     rows.applyToSelected([&](vector_size_t row) {
       size_t mapIndex = mapIndices[row];
@@ -79,8 +79,8 @@ class NestedMapSumValuesAndKeysVector : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     auto arg = args.at(0);
 
     exec::LocalDecodedVector mapHolder(context, *arg, rows);
@@ -126,8 +126,8 @@ class NestedMapSumValuesAndKeysVector : public exec::VectorFunction {
     auto innerRawSizes = innerMapVector->rawSizes();
 
     // Prepare results
-    BaseVector::ensureWritable(rows, BIGINT(), context->pool(), result);
-    auto flatResult = (*result)->asFlatVector<int64_t>();
+    BaseVector::ensureWritable(rows, BIGINT(), context.pool(), result);
+    auto flatResult = result->asFlatVector<int64_t>();
 
     rows.applyToSelected([&](vector_size_t row) {
       size_t mapIndex = mapIndices[row];
@@ -163,16 +163,16 @@ class NestedMapWithMapView : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     LocalDecodedVector decoded_(context, *args[0], rows);
     using exec_in_t = typename VectorExec::template resolver<
         Map<int64_t, Map<int64_t, int64_t>>>::in_type;
     VectorReader<Map<int64_t, Map<int64_t, int64_t>>> reader{decoded_.get()};
 
     // Prepare results
-    BaseVector::ensureWritable(rows, BIGINT(), context->pool(), result);
-    auto flatResult = (*result)->asFlatVector<int64_t>();
+    BaseVector::ensureWritable(rows, BIGINT(), context.pool(), result);
+    auto flatResult = result->asFlatVector<int64_t>();
 
     rows.applyToSelected([&](vector_size_t row) {
       auto sum = 0;

--- a/velox/functions/prestosql/benchmarks/MapWriterBenchmarks.cpp
+++ b/velox/functions/prestosql/benchmarks/MapWriterBenchmarks.cpp
@@ -37,15 +37,15 @@ class VectorFunctionImpl : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     LocalDecodedVector decoded_(context, *args[0], rows); // NOLINT
 
     // Prepare results.
     BaseVector::ensureWritable(
-        rows, MAP(BIGINT(), BIGINT()), context->pool(), result);
+        rows, MAP(BIGINT(), BIGINT()), context.pool(), result);
 
-    auto flatResult = (*result)->as<MapVector>();
+    auto flatResult = result->as<MapVector>();
     auto currentOffset = 0;
     auto keysFlat = flatResult->mapKeys()->asFlatVector<int64_t>();
     auto valuesFlat = flatResult->mapValues()->asFlatVector<int64_t>();

--- a/velox/functions/prestosql/benchmarks/NestedArrayWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/NestedArrayWriterBenchmark.cpp
@@ -35,20 +35,17 @@ class VectorFunctionImpl : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     LocalDecodedVector decoded_(context, *args[0], rows); // NOLINT
 
     // Prepare results
     auto elementType =
         ArrayType(std::make_shared<ArrayType>(ArrayType(BIGINT())));
     BaseVector::ensureWritable(
-        rows,
-        std::make_shared<ArrayType>(elementType),
-        context->pool(),
-        result);
+        rows, std::make_shared<ArrayType>(elementType), context.pool(), result);
 
-    auto arrayVectorOuter = (*result)->as<ArrayVector>();
+    auto arrayVectorOuter = result->as<ArrayVector>();
     auto arrayVectorInner = arrayVectorOuter->elements()->as<ArrayVector>();
     auto flatElements = arrayVectorInner->elements()->as<FlatVector<int64_t>>();
 

--- a/velox/functions/prestosql/benchmarks/RowWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/RowWriterBenchmark.cpp
@@ -31,15 +31,15 @@ class VectorFunctionImpl : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     LocalDecodedVector decoded_(context, *args[0], rows); // NOLINT
 
     // Prepare results.
     BaseVector::ensureWritable(
-        rows, ROW({BIGINT(), BIGINT()}), context->pool(), result);
+        rows, ROW({BIGINT(), BIGINT()}), context.pool(), result);
 
-    auto rowVector = (*result)->as<RowVector>();
+    auto rowVector = result->as<RowVector>();
     rowVector->childAt(0)->resize(rows.size());
     rowVector->childAt(1)->resize(rows.size());
     auto flat1 = rowVector->childAt(0)->asFlatVector<int64_t>();

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1089,8 +1089,7 @@ void StringFunctionsTest::testReplaceInPlace(
     ExprSet exprSet({}, &execCtx_);
     RowVectorPtr inputRows = makeRowVector({});
     exec::EvalCtx evalCtx(&execCtx_, &exprSet, inputRows.get());
-    replaceFunction->apply(
-        rows, functionInputs, VARCHAR(), &evalCtx, &resultPtr);
+    replaceFunction->apply(rows, functionInputs, VARCHAR(), evalCtx, resultPtr);
   };
 
   std::vector<VectorPtr> functionInputs = {
@@ -1422,9 +1421,9 @@ class MultiStringFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* /*context*/,
-      VectorPtr* result) const override {
-    *result = BaseVector::wrapInConstant(rows.size(), 0, args[0]);
+      exec::EvalCtx& /*context*/,
+      VectorPtr& result) const override {
+    result = BaseVector::wrapInConstant(rows.size(), 0, args[0]);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
@@ -1577,9 +1576,9 @@ class InputModifyingFunction : public MultiStringFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* ctx,
-      VectorPtr* result) const override {
-    MultiStringFunction::apply(rows, args, outputType, ctx, result);
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    MultiStringFunction::apply(rows, args, outputType, context, result);
 
     // Modify args and remove its asciness
     for (auto& arg : args) {

--- a/velox/functions/sparksql/ArraySort.h
+++ b/velox/functions/sparksql/ArraySort.h
@@ -37,14 +37,14 @@ class ArraySort : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override;
+      exec::EvalCtx& context,
+      VectorPtr& result) const override;
 
  private:
   VectorPtr applyFlat(
       const SelectivityVector& rows,
       const VectorPtr& arg,
-      exec::EvalCtx* context) const;
+      exec::EvalCtx& context) const;
 
   const bool ascending_;
   const bool nullsFirst_;

--- a/velox/functions/sparksql/CompareFunctionsNullSafe.cpp
+++ b/velox/functions/sparksql/CompareFunctionsNullSafe.cpp
@@ -30,7 +30,7 @@ void applyTyped(
     std::vector<VectorPtr>& args,
     DecodedVector* decoded0,
     DecodedVector* decoded1,
-    exec::EvalCtx* context,
+    exec::EvalCtx& context,
     FlatVector<bool>* flatResult) {
   using T = typename TypeTraits<kind>::NativeType;
 
@@ -64,7 +64,7 @@ void applyTyped<TypeKind::ARRAY>(
     std::vector<VectorPtr>& /* args */,
     DecodedVector* /* decoded0 */,
     DecodedVector* /* decoded1 */,
-    exec::EvalCtx* /* context */,
+    exec::EvalCtx& /* context */,
     FlatVector<bool>* /* flatResult */) {
   VELOX_NYI("equalnullsafe does not support arrays.");
 }
@@ -75,7 +75,7 @@ void applyTyped<TypeKind::MAP>(
     std::vector<VectorPtr>& /* args */,
     DecodedVector* /* decoded0 */,
     DecodedVector* /* decoded1 */,
-    exec::EvalCtx* /* context */,
+    exec::EvalCtx& /* context */,
     FlatVector<bool>* /* flatResult */) {
   VELOX_NYI("equalnullsafe does not support maps.");
 }
@@ -86,7 +86,7 @@ void applyTyped<TypeKind::ROW>(
     std::vector<VectorPtr>& /* args */,
     DecodedVector* /* decoded0 */,
     DecodedVector* /* decoded1 */,
-    exec::EvalCtx* /* context */,
+    exec::EvalCtx& /* context */,
     FlatVector<bool>* /* flatResult */) {
   VELOX_NYI("equalnullsafe does not support structs.");
 }
@@ -101,14 +101,14 @@ class EqualtoNullSafe final : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     exec::DecodedArgs decodedArgs(rows, args, context);
 
     DecodedVector* decoded0 = decodedArgs.at(0);
     DecodedVector* decoded1 = decodedArgs.at(1);
-    context->ensureWritable(rows, BOOLEAN(), *result);
-    FlatVector<bool>* flatResult = (*result)->asFlatVector<bool>();
+    context.ensureWritable(rows, BOOLEAN(), result);
+    auto* flatResult = result->asFlatVector<bool>();
     flatResult->mutableRawValues<int64_t>();
 
     VELOX_DYNAMIC_TYPE_DISPATCH(

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -115,13 +115,13 @@ class HashFunction final : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args, // Not using const ref so we can reuse args
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* resultRef) const final {
+      exec::EvalCtx& context,
+      VectorPtr& resultRef) const final {
     constexpr int32_t kSeed = 42;
 
-    context->ensureWritable(rows, INTEGER(), *resultRef);
+    context.ensureWritable(rows, INTEGER(), resultRef);
 
-    FlatVector<int32_t>& result = *(*resultRef)->as<FlatVector<int32_t>>();
+    FlatVector<int32_t>& result = *resultRef->as<FlatVector<int32_t>>();
     rows.applyToSelected([&](int row) { result.set(row, kSeed); });
 
     exec::LocalSelectivityVector selectedMinusNulls(context);

--- a/velox/functions/sparksql/LeastGreatest.cpp
+++ b/velox/functions/sparksql/LeastGreatest.cpp
@@ -35,14 +35,14 @@ class LeastGreatestFunction final : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     const size_t nargs = args.size();
     const auto nrows = rows.end();
 
     // Setup result vector.
-    context->ensureWritable(rows, outputType, *result);
-    FlatVector<T>& flatResult = *(*result)->as<FlatVector<T>>();
+    context.ensureWritable(rows, outputType, result);
+    FlatVector<T>& flatResult = *result->as<FlatVector<T>>();
 
     // NULL all elements.
     rows.applyToSelected(

--- a/velox/functions/sparksql/Map.cpp
+++ b/velox/functions/sparksql/Map.cpp
@@ -37,7 +37,7 @@ void setKeysResultTyped(
     vector_size_t mapSize,
     std::vector<VectorPtr>& args,
     const VectorPtr& keysResult,
-    exec::EvalCtx* context,
+    exec::EvalCtx& context,
     const SelectivityVector& rows) {
   using T = typename KindToFlatVector<kind>::WrapperType;
   auto flatKeys = keysResult->asFlatVector<T>()
@@ -60,7 +60,7 @@ void setValuesResultTyped(
     vector_size_t mapSize,
     std::vector<VectorPtr>& args,
     const VectorPtr& valuesResult,
-    exec::EvalCtx* context,
+    exec::EvalCtx& context,
     const SelectivityVector& rows) {
   using T = typename KindToFlatVector<kind>::WrapperType;
   auto flatValues = valuesResult->asFlatVector<T>()
@@ -90,8 +90,8 @@ class MapFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /*outputType*/,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK(
         args.size() >= 2 && args.size() % 2 == 0,
         "Map function must take an even number of arguments");
@@ -113,10 +113,10 @@ class MapFunction : public exec::VectorFunction {
     }
 
     // Initializing input
-    context->ensureWritable(
-        rows, std::make_shared<MapType>(keyType, valueType), *result);
+    context.ensureWritable(
+        rows, std::make_shared<MapType>(keyType, valueType), result);
 
-    auto mapResult = (*result)->as<MapVector>();
+    auto mapResult = result->as<MapVector>();
     auto sizes = mapResult->mutableSizes(rows.size());
     auto rawSizes = sizes->asMutable<int32_t>();
     auto offsets = mapResult->mutableOffsets(rows.size());

--- a/velox/functions/sparksql/SplitFunctions.cpp
+++ b/velox/functions/sparksql/SplitFunctions.cpp
@@ -37,14 +37,14 @@ class SplitCharacter final : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     exec::LocalDecodedVector input(context, *args[0], rows);
 
     ArrayBuilder<Varchar> builder(
         /*numArrays=*/rows.size(),
         /*estimatedNumElements=*/rows.countSelected() * 3,
-        context->pool());
+        context.pool());
 
     rows.applyToSelected([&](vector_size_t row) {
       ArrayBuilder<Varchar>::Ref array = builder.startArray(row);
@@ -62,8 +62,8 @@ class SplitCharacter final : public exec::VectorFunction {
     builder.setStringBuffers(
         args[0]->asFlatVector<StringView>()->stringBuffers());
     std::shared_ptr<ArrayVector> arrayVector =
-        std::move(builder).finish(context->pool());
-    context->moveOrCopyResult(arrayVector, rows, result);
+        std::move(builder).finish(context.pool());
+    context.moveOrCopyResult(arrayVector, rows, result);
   }
 
  private:
@@ -80,8 +80,8 @@ class Split final : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     auto delimiterVector = args[1]->as<ConstantVector<StringView>>();
     VELOX_CHECK(
         delimiterVector, "Split function supports only constant delimiter");

--- a/velox/functions/sparksql/String.cpp
+++ b/velox/functions/sparksql/String.cpp
@@ -44,15 +44,15 @@ class Instr : public exec::VectorFunction {
       const SelectivityVector& selected,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 2);
     VELOX_CHECK_EQ(args[0]->typeKind(), TypeKind::VARCHAR);
     VELOX_CHECK_EQ(args[1]->typeKind(), TypeKind::VARCHAR);
     exec::LocalDecodedVector haystack(context, *args[0], selected);
     exec::LocalDecodedVector needle(context, *args[1], selected);
-    context->ensureWritable(selected, INTEGER(), *result);
-    auto* output = (*result)->as<FlatVector<int32_t>>();
+    context.ensureWritable(selected, INTEGER(), result);
+    auto* output = result->as<FlatVector<int32_t>>();
 
     if (isAscii(args[0].get(), selected)) {
       selected.applyToSelected([&](vector_size_t row) {
@@ -83,15 +83,15 @@ class Length : public exec::VectorFunction {
       const SelectivityVector& selected,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 1);
     VELOX_CHECK(
         args[0]->typeKind() == TypeKind::VARCHAR ||
         args[0]->typeKind() == TypeKind::VARBINARY);
     exec::LocalDecodedVector input(context, *args[0], selected);
-    context->ensureWritable(selected, INTEGER(), *result);
-    auto* output = (*result)->as<FlatVector<int32_t>>();
+    context.ensureWritable(selected, INTEGER(), result);
+    auto* output = result->as<FlatVector<int32_t>>();
 
     if (args[0]->typeKind() == TypeKind::VARCHAR &&
         !isAscii(args[0].get(), selected)) {

--- a/velox/functions/sparksql/tests/InTest.cpp
+++ b/velox/functions/sparksql/tests/InTest.cpp
@@ -39,12 +39,12 @@ class TestingDictionaryFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /* outputType */,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK(rows.isAllSelected());
     const auto size = rows.size();
-    auto indices = allocateIndices(size, context->pool());
-    *result = BaseVector::wrapInDictionary(nullptr, indices, size, args[0]);
+    auto indices = allocateIndices(size, context.pool());
+    result = BaseVector::wrapInDictionary(nullptr, indices, size, args[0]);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -100,8 +100,8 @@ class VectorFuncOne : public velox::exec::VectorFunction {
       const velox::SelectivityVector& /* rows */,
       std::vector<velox::VectorPtr>& /* args */,
       const TypePtr& /* outputType */,
-      velox::exec::EvalCtx* /* context */,
-      velox::VectorPtr* /* result */) const override {}
+      velox::exec::EvalCtx& /* context */,
+      velox::VectorPtr& /* result */) const override {}
 
   static std::vector<std::shared_ptr<velox::exec::FunctionSignature>>
   signatures() {
@@ -119,8 +119,8 @@ class VectorFuncTwo : public velox::exec::VectorFunction {
       const velox::SelectivityVector& /* rows */,
       std::vector<velox::VectorPtr>& /* args */,
       const TypePtr& /* outputType */,
-      velox::exec::EvalCtx* /* context */,
-      velox::VectorPtr* /* result */) const override {}
+      velox::exec::EvalCtx& /* context */,
+      velox::VectorPtr& /* result */) const override {}
 
   static std::vector<std::shared_ptr<velox::exec::FunctionSignature>>
   signatures() {
@@ -138,8 +138,8 @@ class VectorFuncThree : public velox::exec::VectorFunction {
       const velox::SelectivityVector& /* rows */,
       std::vector<velox::VectorPtr>& /* args */,
       const TypePtr& /* outputType */,
-      velox::exec::EvalCtx* /* context */,
-      velox::VectorPtr* /* result */) const override {}
+      velox::exec::EvalCtx& /* context */,
+      velox::VectorPtr& /* result */) const override {}
 
   static std::vector<std::shared_ptr<velox::exec::FunctionSignature>>
   signatures() {
@@ -157,8 +157,8 @@ class VectorFuncFour : public velox::exec::VectorFunction {
       const velox::SelectivityVector& /* rows */,
       std::vector<velox::VectorPtr>& /* args */,
       const TypePtr& /* outputType */,
-      velox::exec::EvalCtx* /* context */,
-      velox::VectorPtr* /* result */) const override {}
+      velox::exec::EvalCtx& /* context */,
+      velox::VectorPtr& /* result */) const override {}
 
   static std::vector<std::shared_ptr<velox::exec::FunctionSignature>>
   signatures() {

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -453,7 +453,7 @@ class BaseVector {
       const SelectivityVector& rows,
       const TypePtr& type,
       velox::memory::MemoryPool* pool,
-      std::shared_ptr<BaseVector>* result,
+      std::shared_ptr<BaseVector>& result,
       VectorPool* vectorPool = nullptr);
 
   virtual void ensureWritable(const SelectivityVector& rows);
@@ -466,12 +466,12 @@ class BaseVector {
   //
   // We don't necessarily need (b) if we only want to flatten vectors.
   static void flattenVector(
-      std::shared_ptr<BaseVector>* vector,
+      std::shared_ptr<BaseVector>& vector,
       size_t vectorSize) {
     BaseVector::ensureWritable(
         SelectivityVector::empty(vectorSize),
-        (*vector)->type(),
-        (*vector)->pool(),
+        vector->type(),
+        vector->pool(),
         vector);
   }
 

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -163,7 +163,7 @@ void RowVector::copy(
     const vector_size_t* toSourceRow) {
   for (auto i = 0; i < children_.size(); ++i) {
     BaseVector::ensureWritable(
-        rows, type()->asRow().childAt(i), pool(), &children_[i]);
+        rows, type()->asRow().childAt(i), pool(), children_[i]);
   }
 
   // Copy non-null values.
@@ -278,7 +278,7 @@ void RowVector::ensureWritable(const SelectivityVector& rows) {
   for (int i = 0; i < childrenSize_; i++) {
     if (children_[i]) {
       BaseVector::ensureWritable(
-          rows, children_[i]->type(), BaseVector::pool_, &children_[i]);
+          rows, children_[i]->type(), BaseVector::pool_, children_[i]);
     }
   }
   BaseVector::ensureWritable(rows);
@@ -339,13 +339,13 @@ void ArrayVectorBase::copyRangesImpl(
         SelectivityVector::empty(),
         targetKeys->get()->type(),
         pool(),
-        targetKeys);
+        *targetKeys);
   } else {
     BaseVector::ensureWritable(
         SelectivityVector::empty(),
         targetValues->get()->type(),
         pool(),
-        targetValues);
+        *targetValues);
   }
   auto setNotNulls = mayHaveNulls() || source->mayHaveNulls();
   auto wantWidth = type()->isFixedWidth() ? type()->fixedElementsWidth() : 0;
@@ -625,7 +625,7 @@ void ArrayVector::ensureWritable(const SelectivityVector& rows) {
       SelectivityVector::empty(),
       type()->childAt(0),
       BaseVector::pool_,
-      &elements_);
+      elements_);
   BaseVector::ensureWritable(rows);
 }
 
@@ -886,15 +886,12 @@ void MapVector::ensureWritable(const SelectivityVector& rows) {
   // Vectors are write-once and nested elements are append only,
   // hence, all values already written must be preserved.
   BaseVector::ensureWritable(
-      SelectivityVector::empty(),
-      type()->childAt(0),
-      BaseVector::pool_,
-      &keys_);
+      SelectivityVector::empty(), type()->childAt(0), BaseVector::pool_, keys_);
   BaseVector::ensureWritable(
       SelectivityVector::empty(),
       type()->childAt(1),
       BaseVector::pool_,
-      &values_);
+      values_);
   BaseVector::ensureWritable(rows);
 }
 

--- a/velox/vector/benchmarks/CopyBenchmark.cpp
+++ b/velox/vector/benchmarks/CopyBenchmark.cpp
@@ -43,7 +43,7 @@ size_t runBenchmark(
     vector_size_t copyBatchSize) {
   VectorPtr result;
   folly::BenchmarkSuspender suspender;
-  BaseVector::ensureWritable(selected, type, pool, &result);
+  BaseVector::ensureWritable(selected, type, pool, result);
   suspender.dismiss();
 
   size_t numIters = 100;

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -34,7 +34,7 @@ TEST_F(EnsureWritableVectorTest, flat) {
   SelectivityVector rows(1'000);
 
   VectorPtr result;
-  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), &result);
+  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), result);
   ASSERT_TRUE(result);
   ASSERT_EQ(rows.size(), result->size());
   ASSERT_EQ(TypeKind::BIGINT, result->typeKind());
@@ -53,14 +53,14 @@ TEST_F(EnsureWritableVectorTest, flat) {
   // as-is
   auto* rawNulls = flatResult->nulls().get();
   auto* rawValues = flatResult->values().get();
-  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), &result);
+  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), result);
   ASSERT_EQ(flatResult, result.get());
   ASSERT_EQ(rawNulls, flatResult->nulls().get());
   ASSERT_EQ(rawValues, flatResult->values().get());
 
   // Resize upwards singly-referenced vector with singly referenced buffers
   rows.resize(2'000);
-  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), &result);
+  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), result);
   ASSERT_EQ(rows.size(), result->size());
   ASSERT_EQ(flatResult, result.get());
   rawNulls = flatResult->nulls().get();
@@ -76,7 +76,7 @@ TEST_F(EnsureWritableVectorTest, flat) {
 
   // Resize downwards
   rows.resize(1'024);
-  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), &result);
+  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), result);
   ASSERT_EQ(2'000, result->size());
   ASSERT_EQ(rawNulls, flatResult->nulls().get());
   ASSERT_EQ(rawValues, flatResult->values().get());
@@ -84,7 +84,7 @@ TEST_F(EnsureWritableVectorTest, flat) {
   // Add second reference to the vector -> new vector should be allocated
   auto resultCopy = result;
 
-  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), &result);
+  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), result);
   ASSERT_NE(flatResult, result.get());
   flatResult = result->asFlatVector<int64_t>();
   ASSERT_NE(rawNulls, flatResult->nulls().get());
@@ -115,7 +115,7 @@ TEST_F(EnsureWritableVectorTest, flat) {
   resultCopy.reset();
   auto nullsCopy = result->nulls();
 
-  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), &result);
+  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), result);
   ASSERT_EQ(flatResult, result.get());
   ASSERT_NE(rawNulls, flatResult->nulls().get());
   rawNulls = flatResult->nulls().get();
@@ -137,7 +137,7 @@ TEST_F(EnsureWritableVectorTest, flat) {
   // Add a reference to values buffer
   auto valuesCopy = result->values();
 
-  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), &result);
+  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), result);
   ASSERT_EQ(flatResult, result.get());
   ASSERT_EQ(rawNulls, flatResult->nulls().get());
   ASSERT_NE(rawValues, flatResult->values().get());
@@ -162,7 +162,7 @@ TEST_F(EnsureWritableVectorTest, flatStrings) {
   SelectivityVector rows(1'000);
 
   VectorPtr result;
-  BaseVector::ensureWritable(rows, VARCHAR(), pool_.get(), &result);
+  BaseVector::ensureWritable(rows, VARCHAR(), pool_.get(), result);
   ASSERT_TRUE(result);
   ASSERT_EQ(rows.size(), result->size());
   ASSERT_EQ(TypeKind::VARCHAR, result->typeKind());
@@ -176,7 +176,7 @@ TEST_F(EnsureWritableVectorTest, flatStrings) {
   // buffer.
   auto valuesCopy = result->values();
 
-  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), &result);
+  BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), result);
   ASSERT_TRUE(result);
   ASSERT_EQ(rows.size(), result->size());
   ASSERT_EQ(TypeKind::VARCHAR, result->typeKind());
@@ -390,7 +390,7 @@ TEST_F(EnsureWritableVectorTest, dictionary) {
       BufferPtr(nullptr), indices, size, dictionary);
 
   auto oddRows = selectOddRows(size);
-  BaseVector::ensureWritable(oddRows, BIGINT(), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, BIGINT(), pool_.get(), result);
   ASSERT_EQ(size, result->size());
   ASSERT_EQ(TypeKind::BIGINT, result->typeKind());
   ASSERT_EQ(VectorEncoding::Simple::FLAT, result->encoding());
@@ -414,7 +414,7 @@ TEST_F(EnsureWritableVectorTest, constant) {
     auto constant = BaseVector::createConstant(
         variant::create<TypeKind::BIGINT>(123), size, pool_.get());
     BaseVector::ensureWritable(
-        SelectivityVector::empty(), BIGINT(), pool_.get(), &constant);
+        SelectivityVector::empty(), BIGINT(), pool_.get(), constant);
     EXPECT_EQ(VectorEncoding::Simple::FLAT, constant->encoding());
     EXPECT_EQ(size, constant->size());
   }
@@ -429,7 +429,7 @@ TEST_F(EnsureWritableVectorTest, constant) {
         SelectivityVector::empty(selectivityVectorSize),
         BIGINT(),
         pool_.get(),
-        &constant);
+        constant);
     EXPECT_EQ(VectorEncoding::Simple::FLAT, constant->encoding());
     EXPECT_EQ(selectivityVectorSize, constant->size());
   }
@@ -447,7 +447,7 @@ TEST_F(EnsureWritableVectorTest, constant) {
         SelectivityVector::empty(selectivityVectorSize),
         BIGINT(),
         pool_.get(),
-        &constant);
+        constant);
     EXPECT_EQ(VectorEncoding::Simple::FLAT, constant->encoding());
     EXPECT_EQ(constantVectorSize, constant->size());
   }
@@ -469,7 +469,7 @@ TEST_F(EnsureWritableVectorTest, array) {
 
   SelectivityVector rows(size);
   VectorPtr result;
-  BaseVector::ensureWritable(rows, ARRAY(INTEGER()), pool_.get(), &result);
+  BaseVector::ensureWritable(rows, ARRAY(INTEGER()), pool_.get(), result);
   ASSERT_EQ(size, result->size());
   ASSERT_TRUE(ARRAY(INTEGER())->kindEquals(result->type()));
   ASSERT_EQ(VectorEncoding::Simple::ARRAY, result->encoding());
@@ -481,7 +481,7 @@ TEST_F(EnsureWritableVectorTest, array) {
   ASSERT_FALSE(result.unique());
 
   auto oddRows = selectOddRows(size);
-  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), result);
   ASSERT_TRUE(result.unique());
   ASSERT_NE(resultCopy.get(), result.get());
 
@@ -510,7 +510,7 @@ TEST_F(EnsureWritableVectorTest, array) {
   pointers.setElementsUnique(false);
   pointers.assertUnique(result);
 
-  BaseVector::ensureWritable(oddRows, ARRAY(INTEGER()), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, ARRAY(INTEGER()), pool_.get(), result);
   pointers.assertPointers(result);
 
   // Verify that even rows were copied over
@@ -540,7 +540,7 @@ TEST_F(EnsureWritableVectorTest, array) {
   pointers.setOffsetsUnique(false);
   pointers.assertUnique(result);
 
-  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), result);
   pointers.assertPointers(result);
 
   result->copy(b.get(), oddRows, nullptr);
@@ -562,7 +562,7 @@ TEST_F(EnsureWritableVectorTest, array) {
   pointers.setSizesUnique(false);
   pointers.assertUnique(result);
 
-  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), result);
   pointers.assertPointers(result);
 
   result->copy(b.get(), oddRows, nullptr);
@@ -595,7 +595,7 @@ TEST_F(EnsureWritableVectorTest, map) {
   SelectivityVector rows(size);
   VectorPtr result;
   BaseVector::ensureWritable(
-      rows, MAP(INTEGER(), INTEGER()), pool_.get(), &result);
+      rows, MAP(INTEGER(), INTEGER()), pool_.get(), result);
   ASSERT_EQ(size, result->size());
   ASSERT_TRUE(MAP(INTEGER(), INTEGER())->kindEquals(result->type()));
   ASSERT_EQ(VectorEncoding::Simple::MAP, result->encoding());
@@ -607,7 +607,7 @@ TEST_F(EnsureWritableVectorTest, map) {
   ASSERT_FALSE(result.unique());
 
   auto oddRows = selectOddRows(size);
-  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), result);
   ASSERT_TRUE(result.unique());
   ASSERT_NE(resultCopy.get(), result.get());
 
@@ -636,7 +636,7 @@ TEST_F(EnsureWritableVectorTest, map) {
   pointers.setKeysUnique(false);
   pointers.assertUnique(result);
 
-  BaseVector::ensureWritable(oddRows, ARRAY(INTEGER()), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, ARRAY(INTEGER()), pool_.get(), result);
   pointers.assertPointers(result);
 
   // Verify that even rows were copied over
@@ -665,7 +665,7 @@ TEST_F(EnsureWritableVectorTest, map) {
   pointers.setValuesUnique(false);
   pointers.assertUnique(result);
 
-  BaseVector::ensureWritable(oddRows, ARRAY(INTEGER()), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, ARRAY(INTEGER()), pool_.get(), result);
   pointers.assertPointers(result);
 
   // Verify that even rows were copied over
@@ -695,7 +695,7 @@ TEST_F(EnsureWritableVectorTest, map) {
   pointers.setOffsetsUnique(false);
   pointers.assertUnique(result);
 
-  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), result);
   pointers.assertPointers(result);
 
   result->copy(b.get(), oddRows, nullptr);
@@ -717,7 +717,7 @@ TEST_F(EnsureWritableVectorTest, map) {
   pointers.setSizesUnique(false);
   pointers.assertUnique(result);
 
-  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), result);
   pointers.assertPointers(result);
 
   result->copy(b.get(), oddRows, nullptr);
@@ -742,7 +742,7 @@ TEST_F(EnsureWritableVectorTest, allNullArray) {
   VectorPtr result = vectorMaker_->allNullArrayVector(size, BIGINT());
 
   SelectivityVector oddRows = selectOddRows(size);
-  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), result);
 
   result->copy(a.get(), oddRows, nullptr);
 
@@ -758,7 +758,7 @@ TEST_F(EnsureWritableVectorTest, allNullArray) {
   result = vectorMaker_->allNullArrayVector(size, BIGINT());
   auto resultCopy = result;
 
-  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), result);
   ASSERT_NE(resultCopy.get(), result.get());
 
   result->copy(a.get(), oddRows, nullptr);
@@ -786,7 +786,7 @@ TEST_F(EnsureWritableVectorTest, allNullMap) {
   VectorPtr result = vectorMaker_->allNullMapVector(size, BIGINT(), VARCHAR());
 
   SelectivityVector oddRows = selectOddRows(size);
-  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), result);
 
   result->copy(a.get(), oddRows, nullptr);
 
@@ -802,7 +802,7 @@ TEST_F(EnsureWritableVectorTest, allNullMap) {
   result = vectorMaker_->allNullMapVector(size, BIGINT(), VARCHAR());
   auto resultCopy = result;
 
-  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), &result);
+  BaseVector::ensureWritable(oddRows, result->type(), pool_.get(), result);
   ASSERT_NE(resultCopy.get(), result.get());
 
   result->copy(a.get(), oddRows, nullptr);

--- a/velox/vector/tests/TestingDictionaryFunction.h
+++ b/velox/vector/tests/TestingDictionaryFunction.h
@@ -31,12 +31,12 @@ class TestingDictionaryFunction : public exec::VectorFunction {
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
       const TypePtr& /*outputType*/,
-      exec::EvalCtx* context,
-      VectorPtr* result) const override {
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
     VELOX_CHECK(rows.isAllSelected());
     const auto size = rows.size();
-    auto indices = makeIndicesInReverse(size, context->pool());
-    *result = BaseVector::wrapInDictionary(
+    auto indices = makeIndicesInReverse(size, context.pool());
+    result = BaseVector::wrapInDictionary(
         BufferPtr(nullptr), indices, size, args[0]);
   }
 


### PR DESCRIPTION
Summary:
instead of passing pointer to VectorPtr and pointer to context
the change pass those by ref, since they should never be passed as null.

For the same reason, the diff also make the result vector argument of ensureWritable a reference instead of a pointer to pointer and also
construction arguments of LocalDecodedVectors

Differential Revision: D38968157

