### PR TITLE
Consolidate task state transitions into Task::terminate

### DIFF
--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -508,9 +508,12 @@ class Task : public std::enable_shared_from_this<Task> {
 
   void driverClosedLocked();
 
-  /// Returns true if Task is in kRunning state, but all drivers finished
+  /// Returns true if Task is in kRunning state, but all output drivers finished
   /// processing and all output has been consumed. In other words, returns true
   /// if task should transition to kFinished state.
+  ///
+  /// In case of grouped execution, checks that all drivers, not just output
+  /// drivers finished processing.
   bool checkIfFinishedLocked();
 
   /// Check if we have no more split groups coming and adjust the total number

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -752,7 +752,7 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
     addSplits(task);
   }
 
-  EXPECT_TRUE(waitForTaskCompletion(task));
+  EXPECT_TRUE(waitForTaskCompletion(task)) << task->taskId();
   return {std::move(cursor), std::move(result)};
 }
 
@@ -813,7 +813,7 @@ std::shared_ptr<Task> assertQuery(
   }
   auto task = cursor->task();
 
-  EXPECT_TRUE(waitForTaskCompletion(task.get()));
+  EXPECT_TRUE(waitForTaskCompletion(task.get())) << task->taskId();
 
   return task;
 }


### PR DESCRIPTION
Task::checkIfFinishedLocked used to transition task to kFinished state bypassing
many cleanups implemented in Task::terminate. This change updates
checkIfFinishedLocked to only check and return whether the task should
transition to kFinished and updates the callers to call Task::terminate
(kFinished).