### PR TITLE
[Substrait to Velox] Add tests to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ workflows:
     jobs:
       - linux-build
       - linux-build-options
-      - linux-parquet-hive-storage-adapters-build
+      - linux-adapters
       - macos-build
       - format-check
       - header-check
@@ -59,7 +59,7 @@ workflows:
       - linux-build
       - linux-build-release
       - linux-build-options
-      - linux-parquet-hive-storage-adapters-build
+      - linux-adapters
       - macos-build
 
 executors:
@@ -390,17 +390,6 @@ jobs:
             make debug EXTRA_CMAKE_FLAGS="-DVELOX_BUILD_TESTING=OFF" NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=16
             ccache -s
           no_output_timeout: 1h
-      - run:
-          name: Build velox with substrait
-          command: |
-            mkdir -p .ccache
-            export CCACHE_DIR=$(realpath .ccache)
-            ccache -sz -M 5Gi
-            source /opt/rh/gcc-toolset-9/enable
-            make clean
-            make debug EXTRA_CMAKE_FLAGS="-DVELOX_BUILD_TESTING=OFF -DVELOX_ENABLE_SUBSTRAIT=ON" NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=16
-            ccache -s
-          no_output_timeout: 1h
       - store_artifacts:
           path: '_build/debug/.ninja_log'
       - save_cache:
@@ -409,7 +398,7 @@ jobs:
           paths:
             - .ccache/
 
-  linux-parquet-hive-storage-adapters-build:
+  linux-adapters:
     executor: build
     steps:
       - checkout
@@ -456,7 +445,7 @@ jobs:
             export CCACHE_DIR=$(realpath .ccache)
             ccache -sz -M 5Gi
             source /opt/rh/gcc-toolset-9/enable
-            make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_HDFS=ON -DVELOX_ENABLE_S3=ON" AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
+            make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_HDFS=ON -DVELOX_ENABLE_S3=ON -DVELOX_ENABLE_SUBSTRAIT=ON" AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
             ccache -s
           no_output_timeout: 1h
       - store_artifacts:

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -46,6 +46,17 @@ function install_libhdfs3 {
   cmake_install
 }
 
+function install_protobuf {
+  #yum -y install gcc-c++
+  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz
+  tar -xzf protobuf-all-21.4.tar.gz --no-same-owner
+  cd protobuf-21.4
+  ./configure --prefix=/usr
+  make "-j$(nproc)"
+  make install
+  ldconfig
+}
+
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 cd "${DEPENDENCY_DIR}" || exit
 # aws-sdk-cpp missing dependencies
@@ -57,7 +68,7 @@ fi
 if [[ "$OSTYPE" == darwin* ]]; then
    brew install libxml2 gsasl
 fi
-
+install_protobuf
 install_aws-sdk-cpp
 install_libhdfs3
 

--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -31,7 +31,7 @@ dnf_install epel-release dnf-plugins-core # For ccache, ninja
 dnf config-manager --set-enabled powertools
 dnf_install ninja-build ccache gcc-toolset-9 git wget which libevent-devel \
   openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
-  protobuf-devel libdwarf-devel curl-devel
+  libdwarf-devel curl-devel
 
 dnf remove -y gflags
 
@@ -71,6 +71,7 @@ wget_and_untar https://github.com/facebook/folly/archive/v2022.07.11.00.tar.gz f
 wget_and_untar https://github.com/fmtlib/fmt/archive/8.0.0.tar.gz fmt &
 #  wget_and_untar https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz ranges-v3 &
 wget_and_untar https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz hadoop
+wget_and_untar https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz protobuf &
 
 wait  # For cmake and source downloads to complete.
 
@@ -88,6 +89,14 @@ cp -a hadoop /usr/local/
   cd boost
   ./bootstrap.sh --prefix=/usr/local
   ./b2 "-j$(nproc)" -d0 install threading=multi
+)
+
+(
+  cd protobuf
+  ./configure --prefix=/usr
+  make "-j${NPROC}"
+  make install
+  ldconfig
 )
 
 cmake_install gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON -DLIB_SUFFIX=64 -DCMAKE_INSTALL_PREFIX:PATH=/usr

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -43,13 +43,11 @@ sudo --preserve-env apt install -y \
   libgtest-dev \
   libgmock-dev \
   libevent-dev \
-  libprotobuf-dev \
   liblz4-dev \
   libzstd-dev \
   libre2-dev \
   libsnappy-dev \
   liblzo2-dev \
-  protobuf-compiler \
   bison \
   flex \
   tzdata
@@ -84,9 +82,20 @@ function install_folly {
   cmake_install -DBUILD_TESTS=OFF
 }
 
+function install_protobuf {
+  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz
+  tar -xzf protobuf-all-21.4.tar.gz
+  cd protobuf-21.4
+  ./configure --prefix=/usr
+  make "-j$(nproc)"
+  make install
+  ldconfig
+}
+
 function install_velox_deps {
   run_and_time install_fmt
   run_and_time install_folly
+  run_and_time install_protobuf
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.

--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -55,9 +55,9 @@ SubstraitVeloxExprConverter::toVeloxExpr(
     const ::substrait::Expression::ScalarFunction& substraitFunc,
     const RowTypePtr& inputType) {
   std::vector<std::shared_ptr<const core::ITypedExpr>> params;
-  params.reserve(substraitFunc.args().size());
-  for (const auto& sArg : substraitFunc.args()) {
-    params.emplace_back(toVeloxExpr(sArg, inputType));
+  params.reserve(substraitFunc.arguments().size());
+  for (const auto& sArg : substraitFunc.arguments()) {
+    params.emplace_back(toVeloxExpr(sArg.value(), inputType));
   }
   const auto& veloxFunction = substraitParser_.findVeloxFunction(
       functionMap_, substraitFunc.function_reference());

--- a/velox/substrait/TypeUtils.cpp
+++ b/velox/substrait/TypeUtils.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/substrait/TypeUtils.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox::substrait {

--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -142,11 +142,11 @@ const ::substrait::Expression& VeloxToSubstraitExprConvertor::toSubstraitExpr(
         substraitExpr->mutable_scalar_function();
 
     // TODO need to change yaml file to register function, now is dummy.
-
     scalarExpr->set_function_reference(functionMap_[functionName]);
 
     for (auto& arg : inputs) {
-      scalarExpr->add_args()->MergeFrom(toSubstraitExpr(arena, arg, inputType));
+      scalarExpr->add_arguments()->mutable_value()->MergeFrom(
+          toSubstraitExpr(arena, arg, inputType));
     }
 
     scalarExpr->mutable_output_type()->MergeFrom(

--- a/velox/substrait/VeloxToSubstraitPlan.cpp
+++ b/velox/substrait/VeloxToSubstraitPlan.cpp
@@ -284,7 +284,7 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
               std::dynamic_pointer_cast<const core::CallTypedExpr>(expr)) {
         VELOX_NYI("In Velox Plan, the aggregates type cannot be CallTypedExpr");
       } else {
-        aggFunction->add_args()->MergeFrom(
+        aggFunction->add_arguments()->mutable_value()->MergeFrom(
             exprConvertor_->toSubstraitExpr(arena, expr, inputType));
       }
     }

--- a/velox/substrait/tests/data/q1_first_stage.json
+++ b/velox/substrait/tests/data/q1_first_stage.json
@@ -1,720 +1,770 @@
 {
- "extension_uris": [],
- "extensions": [
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 1,
-    "name": "lte:fp64_fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 6,
-    "name": "sum:opt_fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 3,
-    "name": "subtract:opt_fp64_fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 0,
-    "name": "is_not_null:fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 2,
-    "name": "and:bool_bool"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 5,
-    "name": "add:opt_fp64_fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 7,
-    "name": "avg:opt_fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 4,
-    "name": "multiply:opt_fp64_fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 8,
-    "name": "count:opt_i32"
-   }
-  }
- ],
- "relations": [
-  {
-   "root": {
-    "input": {
-     "aggregate": {
-      "common": {
-       "direct": {}
-      },
-      "input": {
-       "project": {
-        "common": {
-         "direct": {}
+    "extension_uris": [],
+    "extensions": [
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 1,
+                "name": "lte:fp64_fp64"
+            }
         },
-        "input": {
-         "project": {
-          "common": {
-           "direct": {}
-          },
-          "input": {
-           "read": {
-            "common": {
-             "direct": {}
-            },
-            "base_schema": {
-             "names": [
-              "l_quantity",
-              "l_extendedprice",
-              "l_discount",
-              "l_tax",
-              "l_returnflag",
-              "l_linestatus",
-              "l_shipdate"
-             ],
-             "struct": {
-              "types": [
-               {
-                "fp64": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               },
-               {
-                "fp64": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               },
-               {
-                "fp64": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               },
-               {
-                "fp64": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               },
-               {
-                "string": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               },
-               {
-                "string": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               },
-               {
-                "fp64": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               }
-              ],
-              "type_variation_reference": 0,
-              "nullability": "NULLABILITY_UNSPECIFIED"
-             }
-            },
-            "filter": {
-             "scalar_function": {
-              "function_reference": 2,
-              "args": [
-               {
-                "scalar_function": {
-                 "function_reference": 0,
-                 "args": [
-                  {
-                   "selection": {
-                    "direct_reference": {
-                     "struct_field": {
-                      "field": 6
-                     }
-                    }
-                   }
-                  }
-                 ],
-                 "output_type": {
-                  "bool": {
-                   "type_variation_reference": 0,
-                   "nullability": "NULLABILITY_NULLABLE"
-                  }
-                 }
-                }
-               },
-               {
-                "scalar_function": {
-                 "function_reference": 1,
-                 "args": [
-                  {
-                   "selection": {
-                    "direct_reference": {
-                     "struct_field": {
-                      "field": 6
-                     }
-                    }
-                   }
-                  },
-                  {
-                   "literal": {
-                    "nullable": false,
-                    "fp64": 10471
-                   }
-                  }
-                 ],
-                 "output_type": {
-                  "bool": {
-                   "type_variation_reference": 0,
-                   "nullability": "NULLABILITY_NULLABLE"
-                  }
-                 }
-                }
-               }
-              ],
-              "output_type": {
-               "bool": {
-                "type_variation_reference": 0,
-                "nullability": "NULLABILITY_NULLABLE"
-               }
-              }
-             }
-            },
-            "local_files": {
-             "items": [
-              {
-               "orc": {},
-               "partition_index": "0",
-               "start": "0",
-               "length": "3719",
-               "uri_file": "/mock_lineitem.orc"
-              }
-             ]
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 6,
+                "name": "sum:opt_fp64"
             }
-           }
-          },
-          "expressions": [
-           {
-            "selection": {
-             "direct_reference": {
-              "struct_field": {
-               "field": 0
-              }
-             }
-            }
-           },
-           {
-            "selection": {
-             "direct_reference": {
-              "struct_field": {
-               "field": 1
-              }
-             }
-            }
-           },
-           {
-            "selection": {
-             "direct_reference": {
-              "struct_field": {
-               "field": 2
-              }
-             }
-            }
-           },
-           {
-            "selection": {
-             "direct_reference": {
-              "struct_field": {
-               "field": 3
-              }
-             }
-            }
-           },
-           {
-            "selection": {
-             "direct_reference": {
-              "struct_field": {
-               "field": 4
-              }
-             }
-            }
-           },
-           {
-            "selection": {
-             "direct_reference": {
-              "struct_field": {
-               "field": 5
-              }
-             }
-            }
-           }
-          ]
-         }
         },
-        "expressions": [
-         {
-          "selection": {
-           "direct_reference": {
-            "struct_field": {
-             "field": 4
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 3,
+                "name": "subtract:opt_fp64_fp64"
             }
-           }
-          }
-         },
-         {
-          "selection": {
-           "direct_reference": {
-            "struct_field": {
-             "field": 5
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 0,
+                "name": "is_not_null:fp64"
             }
-           }
-          }
-         },
-         {
-          "selection": {
-           "direct_reference": {
-            "struct_field": {
-             "field": 0
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 2,
+                "name": "and:bool_bool"
             }
-           }
-          }
-         },
-         {
-          "selection": {
-           "direct_reference": {
-            "struct_field": {
-             "field": 1
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 5,
+                "name": "add:opt_fp64_fp64"
             }
-           }
-          }
-         },
-         {
-          "scalar_function": {
-           "function_reference": 4,
-           "args": [
-            {
-             "selection": {
-              "direct_reference": {
-               "struct_field": {
-                "field": 1
-               }
-              }
-             }
-            },
-            {
-             "scalar_function": {
-              "function_reference": 3,
-              "args": [
-               {
-                "literal": {
-                 "nullable": false,
-                 "fp64": 1
-                }
-               },
-               {
-                "selection": {
-                 "direct_reference": {
-                  "struct_field": {
-                   "field": 2
-                  }
-                 }
-                }
-               }
-              ],
-              "output_type": {
-               "fp64": {
-                "type_variation_reference": 0,
-                "nullability": "NULLABILITY_NULLABLE"
-               }
-              }
-             }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 7,
+                "name": "avg:opt_fp64"
             }
-           ],
-           "output_type": {
-            "fp64": {
-             "type_variation_reference": 0,
-             "nullability": "NULLABILITY_NULLABLE"
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 4,
+                "name": "multiply:opt_fp64_fp64"
             }
-           }
-          }
-         },
-         {
-          "scalar_function": {
-           "function_reference": 4,
-           "args": [
-            {
-             "scalar_function": {
-              "function_reference": 4,
-              "args": [
-               {
-                "selection": {
-                 "direct_reference": {
-                  "struct_field": {
-                   "field": 1
-                  }
-                 }
-                }
-               },
-               {
-                "scalar_function": {
-                 "function_reference": 3,
-                 "args": [
-                  {
-                   "literal": {
-                    "nullable": false,
-                    "fp64": 1
-                   }
-                  },
-                  {
-                   "selection": {
-                    "direct_reference": {
-                     "struct_field": {
-                      "field": 2
-                     }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 8,
+                "name": "count:opt_i32"
+            }
+        }
+    ],
+    "relations": [
+        {
+            "root": {
+                "input": {
+                    "aggregate": {
+                        "common": {
+                            "direct": {}
+                        },
+                        "input": {
+                            "project": {
+                                "common": {
+                                    "direct": {}
+                                },
+                                "input": {
+                                    "project": {
+                                        "common": {
+                                            "direct": {}
+                                        },
+                                        "input": {
+                                            "read": {
+                                                "common": {
+                                                    "direct": {}
+                                                },
+                                                "base_schema": {
+                                                    "names": [
+                                                        "l_quantity",
+                                                        "l_extendedprice",
+                                                        "l_discount",
+                                                        "l_tax",
+                                                        "l_returnflag",
+                                                        "l_linestatus",
+                                                        "l_shipdate"
+                                                    ],
+                                                    "struct": {
+                                                        "types": [
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "string": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "string": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "type_variation_reference": 0,
+                                                        "nullability": "NULLABILITY_UNSPECIFIED"
+                                                    }
+                                                },
+                                                "filter": {
+                                                    "scalar_function": {
+                                                        "function_reference": 2,
+                                                        "arguments": [
+                                                            {
+                                                                "value": {
+                                                                    "scalar_function": {
+                                                                        "function_reference": 0,
+                                                                        "arguments": [
+                                                                            {
+                                                                                "value": {
+                                                                                    "selection": {
+                                                                                        "direct_reference": {
+                                                                                            "struct_field": {
+                                                                                                "field": 6
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "output_type": {
+                                                                            "bool": {
+                                                                                "type_variation_reference": 0,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            {
+                                                                "value": {
+                                                                    "scalar_function": {
+                                                                        "function_reference": 1,
+                                                                        "arguments": [
+                                                                            {
+                                                                                "value": {
+                                                                                    "selection": {
+                                                                                        "direct_reference": {
+                                                                                            "struct_field": {
+                                                                                                "field": 6
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "value": {
+                                                                                    "literal": {
+                                                                                        "nullable": false,
+                                                                                        "fp64": 10471
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "output_type": {
+                                                                            "bool": {
+                                                                                "type_variation_reference": 0,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "output_type": {
+                                                            "bool": {
+                                                                "type_variation_reference": 0,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "local_files": {
+                                                    "items": [
+                                                        {
+                                                            "orc": {},
+                                                            "partition_index": "0",
+                                                            "start": "0",
+                                                            "length": "3719",
+                                                            "uri_file": "/mock_lineitem.orc"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "expressions": [
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 0
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 1
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 2
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 3
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 4
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 5
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "expressions": [
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 4
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 5
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 0
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 1
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "scalar_function": {
+                                            "function_reference": 4,
+                                            "arguments": [
+                                                {
+                                                    "value": {
+                                                        "selection": {
+                                                            "direct_reference": {
+                                                                "struct_field": {
+                                                                    "field": 1
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "value": {
+                                                        "scalar_function": {
+                                                            "function_reference": 3,
+                                                            "arguments": [
+                                                                {
+                                                                    "value": {
+                                                                        "literal": {
+                                                                            "nullable": false,
+                                                                            "fp64": 1
+                                                                        }
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "value": {
+                                                                        "selection": {
+                                                                            "direct_reference": {
+                                                                                "struct_field": {
+                                                                                    "field": 2
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "output_type": {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "output_type": {
+                                                "fp64": {
+                                                    "type_variation_reference": 0,
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "scalar_function": {
+                                            "function_reference": 4,
+                                            "arguments": [
+                                                {
+                                                    "value": {
+                                                        "scalar_function": {
+                                                            "function_reference": 4,
+                                                            "arguments": [
+                                                                {
+                                                                    "value": {
+                                                                        "selection": {
+                                                                            "direct_reference": {
+                                                                                "struct_field": {
+                                                                                    "field": 1
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "value": {
+                                                                        "scalar_function": {
+                                                                            "function_reference": 3,
+                                                                            "arguments": [
+                                                                                {
+                                                                                    "value": {
+                                                                                        "literal": {
+                                                                                            "nullable": false,
+                                                                                            "fp64": 1
+                                                                                        }
+                                                                                    }
+                                                                                },
+                                                                                {
+                                                                                    "value": {
+                                                                                        "selection": {
+                                                                                            "direct_reference": {
+                                                                                                "struct_field": {
+                                                                                                    "field": 2
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            ],
+                                                                            "output_type": {
+                                                                                "fp64": {
+                                                                                    "type_variation_reference": 0,
+                                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "output_type": {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "value": {
+                                                        "scalar_function": {
+                                                            "function_reference": 5,
+                                                            "arguments": [
+                                                                {
+                                                                    "value": {
+                                                                        "literal": {
+                                                                            "nullable": false,
+                                                                            "fp64": 1
+                                                                        }
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "value": {
+                                                                        "selection": {
+                                                                            "direct_reference": {
+                                                                                "struct_field": {
+                                                                                    "field": 3
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "output_type": {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "output_type": {
+                                                "fp64": {
+                                                    "type_variation_reference": 0,
+                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 2
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "literal": {
+                                            "nullable": false,
+                                            "i32": 1
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "groupings": [
+                            {
+                                "grouping_expressions": [
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 0
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 1
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "measures": [
+                            {
+                                "measure": {
+                                    "function_reference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 2
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 3
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 4
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 6,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 5
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 7,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 2
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 7,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 3
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 7,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 6
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "measure": {
+                                    "function_reference": 8,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "selection": {
+                                                    "direct_reference": {
+                                                        "struct_field": {
+                                                            "field": 7
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "i64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_REQUIRED"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
                     }
-                   }
-                  }
-                 ],
-                 "output_type": {
-                  "fp64": {
-                   "type_variation_reference": 0,
-                   "nullability": "NULLABILITY_NULLABLE"
-                  }
-                 }
-                }
-               }
-              ],
-              "output_type": {
-               "fp64": {
-                "type_variation_reference": 0,
-                "nullability": "NULLABILITY_NULLABLE"
-               }
-              }
-             }
-            },
-            {
-             "scalar_function": {
-              "function_reference": 5,
-              "args": [
-               {
-                "literal": {
-                 "nullable": false,
-                 "fp64": 1
-                }
-               },
-               {
-                "selection": {
-                 "direct_reference": {
-                  "struct_field": {
-                   "field": 3
-                  }
-                 }
-                }
-               }
-              ],
-              "output_type": {
-               "fp64": {
-                "type_variation_reference": 0,
-                "nullability": "NULLABILITY_NULLABLE"
-               }
-              }
-             }
+                },
+                "names": [
+                    "real_arrow_output",
+                    "l_returnflag",
+                    "l_linestatus",
+                    "sum",
+                    "sum",
+                    "sum",
+                    "sum",
+                    "sum",
+                    "count",
+                    "sum",
+                    "count",
+                    "sum",
+                    "count",
+                    "count"
+                ]
             }
-           ],
-           "output_type": {
-            "fp64": {
-             "type_variation_reference": 0,
-             "nullability": "NULLABILITY_NULLABLE"
-            }
-           }
-          }
-         },
-         {
-          "selection": {
-           "direct_reference": {
-            "struct_field": {
-             "field": 2
-            }
-           }
-          }
-         },
-         {
-          "literal": {
-           "nullable": false,
-           "i32": 1
-          }
-         }
-        ]
-       }
-      },
-      "groupings": [
-       {
-        "grouping_expressions": [
-         {
-          "selection": {
-           "direct_reference": {
-            "struct_field": {
-             "field": 0
-            }
-           }
-          }
-         },
-         {
-          "selection": {
-           "direct_reference": {
-            "struct_field": {
-             "field": 1
-            }
-           }
-          }
-         }
-        ]
-       }
-      ],
-      "measures": [
-       {
-        "measure": {
-         "function_reference": 6,
-         "args": [
-          {
-           "selection": {
-            "direct_reference": {
-             "struct_field": {
-              "field": 2
-             }
-            }
-           }
-          }
-         ],
-         "sorts": [],
-         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
-         "output_type": {
-          "fp64": {
-           "type_variation_reference": 0,
-           "nullability": "NULLABILITY_NULLABLE"
-          }
-         }
         }
-       },
-       {
-        "measure": {
-         "function_reference": 6,
-         "args": [
-          {
-           "selection": {
-            "direct_reference": {
-             "struct_field": {
-              "field": 3
-             }
-            }
-           }
-          }
-         ],
-         "sorts": [],
-         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
-         "output_type": {
-          "fp64": {
-           "type_variation_reference": 0,
-           "nullability": "NULLABILITY_NULLABLE"
-          }
-         }
-        }
-       },
-       {
-        "measure": {
-         "function_reference": 6,
-         "args": [
-          {
-           "selection": {
-            "direct_reference": {
-             "struct_field": {
-              "field": 4
-             }
-            }
-           }
-          }
-         ],
-         "sorts": [],
-         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
-         "output_type": {
-          "fp64": {
-           "type_variation_reference": 0,
-           "nullability": "NULLABILITY_NULLABLE"
-          }
-         }
-        }
-       },
-       {
-        "measure": {
-         "function_reference": 6,
-         "args": [
-          {
-           "selection": {
-            "direct_reference": {
-             "struct_field": {
-              "field": 5
-             }
-            }
-           }
-          }
-         ],
-         "sorts": [],
-         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
-         "output_type": {
-          "fp64": {
-           "type_variation_reference": 0,
-           "nullability": "NULLABILITY_NULLABLE"
-          }
-         }
-        }
-       },
-       {
-        "measure": {
-         "function_reference": 7,
-         "args": [
-          {
-           "selection": {
-            "direct_reference": {
-             "struct_field": {
-              "field": 2
-             }
-            }
-           }
-          }
-         ],
-         "sorts": [],
-         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
-         "output_type": {
-          "fp64": {
-           "type_variation_reference": 0,
-           "nullability": "NULLABILITY_NULLABLE"
-          }
-         }
-        }
-       },
-       {
-        "measure": {
-         "function_reference": 7,
-         "args": [
-          {
-           "selection": {
-            "direct_reference": {
-             "struct_field": {
-              "field": 3
-             }
-            }
-           }
-          }
-         ],
-         "sorts": [],
-         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
-         "output_type": {
-          "fp64": {
-           "type_variation_reference": 0,
-           "nullability": "NULLABILITY_NULLABLE"
-          }
-         }
-        }
-       },
-       {
-        "measure": {
-         "function_reference": 7,
-         "args": [
-          {
-           "selection": {
-            "direct_reference": {
-             "struct_field": {
-              "field": 6
-             }
-            }
-           }
-          }
-         ],
-         "sorts": [],
-         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
-         "output_type": {
-          "fp64": {
-           "type_variation_reference": 0,
-           "nullability": "NULLABILITY_NULLABLE"
-          }
-         }
-        }
-       },
-       {
-        "measure": {
-         "function_reference": 8,
-         "args": [
-          {
-           "selection": {
-            "direct_reference": {
-             "struct_field": {
-              "field": 7
-             }
-            }
-           }
-          }
-         ],
-         "sorts": [],
-         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
-         "output_type": {
-          "i64": {
-           "type_variation_reference": 0,
-           "nullability": "NULLABILITY_REQUIRED"
-          }
-         }
-        }
-       }
-      ]
-     }
-    },
-    "names": [
-     "real_arrow_output",
-     "l_returnflag",
-     "l_linestatus",
-     "sum",
-     "sum",
-     "sum",
-     "sum",
-     "sum",
-     "count",
-     "sum",
-     "count",
-     "sum",
-     "count",
-     "count"
-    ]
-   }
-  }
- ],
- "expected_type_urls": []
+    ],
+    "expected_type_urls": []
 }

--- a/velox/substrait/tests/data/q6_first_stage.json
+++ b/velox/substrait/tests/data/q6_first_stage.json
@@ -1,701 +1,797 @@
 {
- "extension_uris": [],
- "extensions": [
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 4,
-    "name": "lte:fp64_fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 5,
-    "name": "sum:opt_fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 3,
-    "name": "lt:fp64_fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 0,
-    "name": "is_not_null:fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 1,
-    "name": "and:bool_bool"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 2,
-    "name": "gte:fp64_fp64"
-   }
-  },
-  {
-   "extension_function": {
-    "extension_uri_reference": 0,
-    "function_anchor": 6,
-    "name": "multiply:opt_fp64_fp64"
-   }
-  }
- ],
- "relations": [
-  {
-   "root": {
-    "input": {
-     "aggregate": {
-      "common": {
-       "direct": {}
-      },
-      "input": {
-       "project": {
-        "common": {
-         "direct": {}
+    "extension_uris": [],
+    "extensions": [
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 4,
+                "name": "lte:fp64_fp64"
+            }
         },
-        "input": {
-         "filter": {
-          "common": {
-           "direct": {}
-          },
-          "input": {
-           "read": {
-            "common": {
-             "direct": {}
-            },
-            "base_schema": {
-             "names": [
-              "l_quantity",
-              "l_extendedprice",
-              "l_discount",
-              "l_shipdate_new"
-             ],
-             "struct": {
-              "types": [
-               {
-                "fp64": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               },
-               {
-                "fp64": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               },
-               {
-                "fp64": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               },
-               {
-                "fp64": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               }
-              ],
-              "type_variation_reference": 0,
-              "nullability": "NULLABILITY_UNSPECIFIED"
-             }
-            },
-            "filter": {
-             "scalar_function": {
-              "function_reference": 1,
-              "args": [
-               {
-                "scalar_function": {
-                 "function_reference": 1,
-                 "args": [
-                  {
-                   "scalar_function": {
-                    "function_reference": 1,
-                    "args": [
-                     {
-                      "scalar_function": {
-                       "function_reference": 1,
-                       "args": [
-                        {
-                         "scalar_function": {
-                          "function_reference": 1,
-                          "args": [
-                           {
-                            "scalar_function": {
-                             "function_reference": 1,
-                             "args": [
-                              {
-                               "scalar_function": {
-                                "function_reference": 1,
-                                "args": [
-                                 {
-                                  "scalar_function": {
-                                   "function_reference": 0,
-                                   "args": [
-                                    {
-                                     "selection": {
-                                      "direct_reference": {
-                                       "struct_field": {
-                                        "field": 3
-                                       }
-                                      }
-                                     }
-                                    }
-                                   ],
-                                   "output_type": {
-                                    "bool": {
-                                     "type_variation_reference": 0,
-                                     "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                   }
-                                  }
-                                 },
-                                 {
-                                  "scalar_function": {
-                                   "function_reference": 0,
-                                   "args": [
-                                    {
-                                     "selection": {
-                                      "direct_reference": {
-                                       "struct_field": {
-                                        "field": 2
-                                       }
-                                      }
-                                     }
-                                    }
-                                   ],
-                                   "output_type": {
-                                    "bool": {
-                                     "type_variation_reference": 0,
-                                     "nullability": "NULLABILITY_NULLABLE"
-                                    }
-                                   }
-                                  }
-                                 }
-                                ],
-                                "output_type": {
-                                 "bool": {
-                                  "type_variation_reference": 0,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                 }
-                                }
-                               }
-                              },
-                              {
-                               "scalar_function": {
-                                "function_reference": 0,
-                                "args": [
-                                 {
-                                  "selection": {
-                                   "direct_reference": {
-                                    "struct_field": {
-                                     "field": 0
-                                    }
-                                   }
-                                  }
-                                 }
-                                ],
-                                "output_type": {
-                                 "bool": {
-                                  "type_variation_reference": 0,
-                                  "nullability": "NULLABILITY_NULLABLE"
-                                 }
-                                }
-                               }
-                              }
-                             ],
-                             "output_type": {
-                              "bool": {
-                               "type_variation_reference": 0,
-                               "nullability": "NULLABILITY_NULLABLE"
-                              }
-                             }
-                            }
-                           },
-                           {
-                            "scalar_function": {
-                             "function_reference": 2,
-                             "args": [
-                              {
-                               "selection": {
-                                "direct_reference": {
-                                 "struct_field": {
-                                  "field": 3
-                                 }
-                                }
-                               }
-                              },
-                              {
-                               "literal": {
-                                "nullable": false,
-                                "fp64": 8766
-                               }
-                              }
-                             ],
-                             "output_type": {
-                              "bool": {
-                               "type_variation_reference": 0,
-                               "nullability": "NULLABILITY_NULLABLE"
-                              }
-                             }
-                            }
-                           }
-                          ],
-                          "output_type": {
-                           "bool": {
-                            "type_variation_reference": 0,
-                            "nullability": "NULLABILITY_NULLABLE"
-                           }
-                          }
-                         }
-                        },
-                        {
-                         "scalar_function": {
-                          "function_reference": 3,
-                          "args": [
-                           {
-                            "selection": {
-                             "direct_reference": {
-                              "struct_field": {
-                               "field": 3
-                              }
-                             }
-                            }
-                           },
-                           {
-                            "literal": {
-                             "nullable": false,
-                             "fp64": 9131
-                            }
-                           }
-                          ],
-                          "output_type": {
-                           "bool": {
-                            "type_variation_reference": 0,
-                            "nullability": "NULLABILITY_NULLABLE"
-                           }
-                          }
-                         }
-                        }
-                       ],
-                       "output_type": {
-                        "bool": {
-                         "type_variation_reference": 0,
-                         "nullability": "NULLABILITY_NULLABLE"
-                        }
-                       }
-                      }
-                     },
-                     {
-                      "scalar_function": {
-                       "function_reference": 2,
-                       "args": [
-                        {
-                         "selection": {
-                          "direct_reference": {
-                           "struct_field": {
-                            "field": 2
-                           }
-                          }
-                         }
-                        },
-                        {
-                         "literal": {
-                          "nullable": false,
-                          "fp64": 0.05
-                         }
-                        }
-                       ],
-                       "output_type": {
-                        "bool": {
-                         "type_variation_reference": 0,
-                         "nullability": "NULLABILITY_NULLABLE"
-                        }
-                       }
-                      }
-                     }
-                    ],
-                    "output_type": {
-                     "bool": {
-                      "type_variation_reference": 0,
-                      "nullability": "NULLABILITY_NULLABLE"
-                     }
-                    }
-                   }
-                  },
-                  {
-                   "scalar_function": {
-                    "function_reference": 4,
-                    "args": [
-                     {
-                      "selection": {
-                       "direct_reference": {
-                        "struct_field": {
-                         "field": 2
-                        }
-                       }
-                      }
-                     },
-                     {
-                      "literal": {
-                       "nullable": false,
-                       "fp64": 0.07
-                      }
-                     }
-                    ],
-                    "output_type": {
-                     "bool": {
-                      "type_variation_reference": 0,
-                      "nullability": "NULLABILITY_NULLABLE"
-                     }
-                    }
-                   }
-                  }
-                 ],
-                 "output_type": {
-                  "bool": {
-                   "type_variation_reference": 0,
-                   "nullability": "NULLABILITY_NULLABLE"
-                  }
-                 }
-                }
-               },
-               {
-                "scalar_function": {
-                 "function_reference": 3,
-                 "args": [
-                  {
-                   "selection": {
-                    "direct_reference": {
-                     "struct_field": {
-                      "field": 0
-                     }
-                    }
-                   }
-                  },
-                  {
-                   "literal": {
-                    "nullable": false,
-                    "fp64": 24
-                   }
-                  }
-                 ],
-                 "output_type": {
-                  "bool": {
-                   "type_variation_reference": 0,
-                   "nullability": "NULLABILITY_NULLABLE"
-                  }
-                 }
-                }
-               }
-              ],
-              "output_type": {
-               "bool": {
-                "type_variation_reference": 0,
-                "nullability": "NULLABILITY_NULLABLE"
-               }
-              }
-             }
-            },
-            "local_files": {
-             "items": [
-              {
-               "partition_index": "0",
-               "start": "0",
-               "length": "3719",
-               "uri_file": "/mock_lineitem.orc",
-               "orc": {}
-              }
-             ]
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 5,
+                "name": "sum:opt_fp64"
             }
-           }
-          },
-          "condition": {
-           "scalar_function": {
-            "function_reference": 1,
-            "args": [
-             {
-              "scalar_function": {
-               "function_reference": 1,
-               "args": [
-                {
-                 "scalar_function": {
-                  "function_reference": 1,
-                  "args": [
-                   {
-                    "scalar_function": {
-                     "function_reference": 1,
-                     "args": [
-                      {
-                       "scalar_function": {
-                        "function_reference": 2,
-                        "args": [
-                         {
-                          "selection": {
-                           "direct_reference": {
-                            "struct_field": {
-                             "field": 3
-                            }
-                           }
-                          }
-                         },
-                         {
-                          "literal": {
-                           "nullable": false,
-                           "fp64": 8766
-                          }
-                         }
-                        ],
-                        "output_type": {
-                         "bool": {
-                          "type_variation_reference": 0,
-                          "nullability": "NULLABILITY_NULLABLE"
-                         }
-                        }
-                       }
-                      },
-                      {
-                       "scalar_function": {
-                        "function_reference": 3,
-                        "args": [
-                         {
-                          "selection": {
-                           "direct_reference": {
-                            "struct_field": {
-                             "field": 3
-                            }
-                           }
-                          }
-                         },
-                         {
-                          "literal": {
-                           "nullable": false,
-                           "fp64": 9131
-                          }
-                         }
-                        ],
-                        "output_type": {
-                         "bool": {
-                          "type_variation_reference": 0,
-                          "nullability": "NULLABILITY_NULLABLE"
-                         }
-                        }
-                       }
-                      }
-                     ],
-                     "output_type": {
-                      "bool": {
-                       "type_variation_reference": 0,
-                       "nullability": "NULLABILITY_NULLABLE"
-                      }
-                     }
-                    }
-                   },
-                   {
-                    "scalar_function": {
-                     "function_reference": 2,
-                     "args": [
-                      {
-                       "selection": {
-                        "direct_reference": {
-                         "struct_field": {
-                          "field": 2
-                         }
-                        }
-                       }
-                      },
-                      {
-                       "literal": {
-                        "nullable": false,
-                        "fp64": 0.05
-                       }
-                      }
-                     ],
-                     "output_type": {
-                      "bool": {
-                       "type_variation_reference": 0,
-                       "nullability": "NULLABILITY_NULLABLE"
-                      }
-                     }
-                    }
-                   }
-                  ],
-                  "output_type": {
-                   "bool": {
-                    "type_variation_reference": 0,
-                    "nullability": "NULLABILITY_NULLABLE"
-                   }
-                  }
-                 }
-                },
-                {
-                 "scalar_function": {
-                  "function_reference": 4,
-                  "args": [
-                   {
-                    "selection": {
-                     "direct_reference": {
-                      "struct_field": {
-                       "field": 2
-                      }
-                     }
-                    }
-                   },
-                   {
-                    "literal": {
-                     "nullable": false,
-                     "fp64": 0.07
-                    }
-                   }
-                  ],
-                  "output_type": {
-                   "bool": {
-                    "type_variation_reference": 0,
-                    "nullability": "NULLABILITY_NULLABLE"
-                   }
-                  }
-                 }
-                }
-               ],
-               "output_type": {
-                "bool": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               }
-              }
-             },
-             {
-              "scalar_function": {
-               "function_reference": 3,
-               "args": [
-                {
-                 "selection": {
-                  "direct_reference": {
-                   "struct_field": {
-                    "field": 0
-                   }
-                  }
-                 }
-                },
-                {
-                 "literal": {
-                  "nullable": false,
-                  "fp64": 24
-                 }
-                }
-               ],
-               "output_type": {
-                "bool": {
-                 "type_variation_reference": 0,
-                 "nullability": "NULLABILITY_NULLABLE"
-                }
-               }
-              }
-             }
-            ],
-            "output_type": {
-             "bool": {
-              "type_variation_reference": 0,
-              "nullability": "NULLABILITY_NULLABLE"
-             }
-            }
-           }
-          }
-         }
         },
-        "expressions": [
-         {
-          "selection": {
-           "direct_reference": {
-            "struct_field": {
-             "field": 1
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 3,
+                "name": "lt:fp64_fp64"
             }
-           }
-          }
-         },
-         {
-          "selection": {
-           "direct_reference": {
-            "struct_field": {
-             "field": 2
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 0,
+                "name": "is_not_null:fp64"
             }
-           }
-          }
-         }
-        ]
-       }
-      },
-      "groupings": [
-       {
-        "grouping_expressions": []
-       }
-      ],
-      "measures": [
-       {
-        "measure": {
-         "function_reference": 5,
-         "args": [
-          {
-           "scalar_function": {
-            "function_reference": 6,
-            "args": [
-             {
-              "selection": {
-               "direct_reference": {
-                "struct_field": {
-                 "field": 0
-                }
-               }
-              }
-             },
-             {
-              "selection": {
-               "direct_reference": {
-                "struct_field": {
-                 "field": 1
-                }
-               }
-              }
-             }
-            ],
-            "output_type": {
-             "fp64": {
-              "type_variation_reference": 0,
-              "nullability": "NULLABILITY_NULLABLE"
-             }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 1,
+                "name": "and:bool_bool"
             }
-           }
-          }
-         ],
-         "sorts": [],
-         "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
-         "output_type": {
-          "fp64": {
-           "type_variation_reference": 0,
-           "nullability": "NULLABILITY_NULLABLE"
-          }
-         }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 2,
+                "name": "gte:fp64_fp64"
+            }
+        },
+        {
+            "extension_function": {
+                "extension_uri_reference": 0,
+                "function_anchor": 6,
+                "name": "multiply:opt_fp64_fp64"
+            }
         }
-       }
-      ]
-     }
-    },
-    "names": []
-   }
-  }
- ],
- "expected_type_urls": []
+    ],
+    "relations": [
+        {
+            "root": {
+                "input": {
+                    "aggregate": {
+                        "common": {
+                            "direct": {}
+                        },
+                        "input": {
+                            "project": {
+                                "common": {
+                                    "direct": {}
+                                },
+                                "input": {
+                                    "filter": {
+                                        "common": {
+                                            "direct": {}
+                                        },
+                                        "input": {
+                                            "read": {
+                                                "common": {
+                                                    "direct": {}
+                                                },
+                                                "base_schema": {
+                                                    "names": [
+                                                        "l_quantity",
+                                                        "l_extendedprice",
+                                                        "l_discount",
+                                                        "l_shipdate_new"
+                                                    ],
+                                                    "struct": {
+                                                        "types": [
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            },
+                                                            {
+                                                                "fp64": {
+                                                                    "type_variation_reference": 0,
+                                                                    "nullability": "NULLABILITY_NULLABLE"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "type_variation_reference": 0,
+                                                        "nullability": "NULLABILITY_UNSPECIFIED"
+                                                    }
+                                                },
+                                                "filter": {
+                                                    "scalar_function": {
+                                                        "function_reference": 1,
+                                                        "arguments": [
+                                                            {
+                                                                "value": {
+                                                                    "scalar_function": {
+                                                                        "function_reference": 1,
+                                                                        "arguments": [
+                                                                            {
+                                                                                "value": {
+                                                                                    "scalar_function": {
+                                                                                        "function_reference": 1,
+                                                                                        "arguments": [
+                                                                                            {
+                                                                                                "value": {
+                                                                                                    "scalar_function": {
+                                                                                                        "function_reference": 1,
+                                                                                                        "arguments": [
+                                                                                                            {
+                                                                                                                "value": {
+                                                                                                                    "scalar_function": {
+                                                                                                                        "function_reference": 1,
+                                                                                                                        "arguments": [
+                                                                                                                            {
+                                                                                                                                "value": {
+                                                                                                                                    "scalar_function": {
+                                                                                                                                        "function_reference": 1,
+                                                                                                                                        "arguments": [
+                                                                                                                                            {
+                                                                                                                                                "value": {
+                                                                                                                                                    "scalar_function": {
+                                                                                                                                                        "function_reference": 1,
+                                                                                                                                                        "arguments": [
+                                                                                                                                                            {
+                                                                                                                                                                "value": {
+                                                                                                                                                                    "scalar_function": {
+                                                                                                                                                                        "function_reference": 0,
+                                                                                                                                                                        "arguments": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "value": {
+                                                                                                                                                                                    "selection": {
+                                                                                                                                                                                        "direct_reference": {
+                                                                                                                                                                                            "struct_field": {
+                                                                                                                                                                                                "field": 3
+                                                                                                                                                                                            }
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ],
+                                                                                                                                                                        "output_type": {
+                                                                                                                                                                            "bool": {
+                                                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            },
+                                                                                                                                                            {
+                                                                                                                                                                "value": {
+                                                                                                                                                                    "scalar_function": {
+                                                                                                                                                                        "function_reference": 0,
+                                                                                                                                                                        "arguments": [
+                                                                                                                                                                            {
+                                                                                                                                                                                "value": {
+                                                                                                                                                                                    "selection": {
+                                                                                                                                                                                        "direct_reference": {
+                                                                                                                                                                                            "struct_field": {
+                                                                                                                                                                                                "field": 2
+                                                                                                                                                                                            }
+                                                                                                                                                                                        }
+                                                                                                                                                                                    }
+                                                                                                                                                                                }
+                                                                                                                                                                            }
+                                                                                                                                                                        ],
+                                                                                                                                                                        "output_type": {
+                                                                                                                                                                            "bool": {
+                                                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ],
+                                                                                                                                                        "output_type": {
+                                                                                                                                                            "bool": {
+                                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "value": {
+                                                                                                                                                    "scalar_function": {
+                                                                                                                                                        "function_reference": 0,
+                                                                                                                                                        "arguments": [
+                                                                                                                                                            {
+                                                                                                                                                                "value": {
+                                                                                                                                                                    "selection": {
+                                                                                                                                                                        "direct_reference": {
+                                                                                                                                                                            "struct_field": {
+                                                                                                                                                                                "field": 0
+                                                                                                                                                                            }
+                                                                                                                                                                        }
+                                                                                                                                                                    }
+                                                                                                                                                                }
+                                                                                                                                                            }
+                                                                                                                                                        ],
+                                                                                                                                                        "output_type": {
+                                                                                                                                                            "bool": {
+                                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ],
+                                                                                                                                        "output_type": {
+                                                                                                                                            "bool": {
+                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "value": {
+                                                                                                                                    "scalar_function": {
+                                                                                                                                        "function_reference": 2,
+                                                                                                                                        "arguments": [
+                                                                                                                                            {
+                                                                                                                                                "value": {
+                                                                                                                                                    "selection": {
+                                                                                                                                                        "direct_reference": {
+                                                                                                                                                            "struct_field": {
+                                                                                                                                                                "field": 3
+                                                                                                                                                            }
+                                                                                                                                                        }
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                "value": {
+                                                                                                                                                    "literal": {
+                                                                                                                                                        "nullable": false,
+                                                                                                                                                        "fp64": 8766
+                                                                                                                                                    }
+                                                                                                                                                }
+                                                                                                                                            }
+                                                                                                                                        ],
+                                                                                                                                        "output_type": {
+                                                                                                                                            "bool": {
+                                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ],
+                                                                                                                        "output_type": {
+                                                                                                                            "bool": {
+                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "value": {
+                                                                                                                    "scalar_function": {
+                                                                                                                        "function_reference": 3,
+                                                                                                                        "arguments": [
+                                                                                                                            {
+                                                                                                                                "value": {
+                                                                                                                                    "selection": {
+                                                                                                                                        "direct_reference": {
+                                                                                                                                            "struct_field": {
+                                                                                                                                                "field": 3
+                                                                                                                                            }
+                                                                                                                                        }
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            },
+                                                                                                                            {
+                                                                                                                                "value": {
+                                                                                                                                    "literal": {
+                                                                                                                                        "nullable": false,
+                                                                                                                                        "fp64": 9131
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        ],
+                                                                                                                        "output_type": {
+                                                                                                                            "bool": {
+                                                                                                                                "type_variation_reference": 0,
+                                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ],
+                                                                                                        "output_type": {
+                                                                                                            "bool": {
+                                                                                                                "type_variation_reference": 0,
+                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "value": {
+                                                                                                    "scalar_function": {
+                                                                                                        "function_reference": 2,
+                                                                                                        "arguments": [
+                                                                                                            {
+                                                                                                                "value": {
+                                                                                                                    "selection": {
+                                                                                                                        "direct_reference": {
+                                                                                                                            "struct_field": {
+                                                                                                                                "field": 2
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "value": {
+                                                                                                                    "literal": {
+                                                                                                                        "nullable": false,
+                                                                                                                        "fp64": 0.05
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ],
+                                                                                                        "output_type": {
+                                                                                                            "bool": {
+                                                                                                                "type_variation_reference": 0,
+                                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        ],
+                                                                                        "output_type": {
+                                                                                            "bool": {
+                                                                                                "type_variation_reference": 0,
+                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "value": {
+                                                                                    "scalar_function": {
+                                                                                        "function_reference": 4,
+                                                                                        "arguments": [
+                                                                                            {
+                                                                                                "value": {
+                                                                                                    "selection": {
+                                                                                                        "direct_reference": {
+                                                                                                            "struct_field": {
+                                                                                                                "field": 2
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            },
+                                                                                            {
+                                                                                                "value": {
+                                                                                                    "literal": {
+                                                                                                        "nullable": false,
+                                                                                                        "fp64": 0.07
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        ],
+                                                                                        "output_type": {
+                                                                                            "bool": {
+                                                                                                "type_variation_reference": 0,
+                                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "output_type": {
+                                                                            "bool": {
+                                                                                "type_variation_reference": 0,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            {
+                                                                "value": {
+                                                                    "scalar_function": {
+                                                                        "function_reference": 3,
+                                                                        "arguments": [
+                                                                            {
+                                                                                "value": {
+                                                                                    "selection": {
+                                                                                        "direct_reference": {
+                                                                                            "struct_field": {
+                                                                                                "field": 0
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "value": {
+                                                                                    "literal": {
+                                                                                        "nullable": false,
+                                                                                        "fp64": 24
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "output_type": {
+                                                                            "bool": {
+                                                                                "type_variation_reference": 0,
+                                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "output_type": {
+                                                            "bool": {
+                                                                "type_variation_reference": 0,
+                                                                "nullability": "NULLABILITY_NULLABLE"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "local_files": {
+                                                    "items": [
+                                                        {
+                                                            "partition_index": "0",
+                                                            "start": "0",
+                                                            "length": "3719",
+                                                            "uri_file": "/mock_lineitem.orc",
+                                                            "orc": {}
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "condition": {
+                                            "scalar_function": {
+                                                "function_reference": 1,
+                                                "arguments": [
+                                                    {
+                                                        "value": {
+                                                            "scalar_function": {
+                                                                "function_reference": 1,
+                                                                "arguments": [
+                                                                    {
+                                                                        "value": {
+                                                                            "scalar_function": {
+                                                                                "function_reference": 1,
+                                                                                "arguments": [
+                                                                                    {
+                                                                                        "value": {
+                                                                                            "scalar_function": {
+                                                                                                "function_reference": 1,
+                                                                                                "arguments": [
+                                                                                                    {
+                                                                                                        "value": {
+                                                                                                            "scalar_function": {
+                                                                                                                "function_reference": 2,
+                                                                                                                "arguments": [
+                                                                                                                    {
+                                                                                                                        "value": {
+                                                                                                                            "selection": {
+                                                                                                                                "direct_reference": {
+                                                                                                                                    "struct_field": {
+                                                                                                                                        "field": 3
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "value": {
+                                                                                                                            "literal": {
+                                                                                                                                "nullable": false,
+                                                                                                                                "fp64": 8766
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ],
+                                                                                                                "output_type": {
+                                                                                                                    "bool": {
+                                                                                                                        "type_variation_reference": 0,
+                                                                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": {
+                                                                                                            "scalar_function": {
+                                                                                                                "function_reference": 3,
+                                                                                                                "arguments": [
+                                                                                                                    {
+                                                                                                                        "value": {
+                                                                                                                            "selection": {
+                                                                                                                                "direct_reference": {
+                                                                                                                                    "struct_field": {
+                                                                                                                                        "field": 3
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        "value": {
+                                                                                                                            "literal": {
+                                                                                                                                "nullable": false,
+                                                                                                                                "fp64": 9131
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                ],
+                                                                                                                "output_type": {
+                                                                                                                    "bool": {
+                                                                                                                        "type_variation_reference": 0,
+                                                                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                ],
+                                                                                                "output_type": {
+                                                                                                    "bool": {
+                                                                                                        "type_variation_reference": 0,
+                                                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "value": {
+                                                                                            "scalar_function": {
+                                                                                                "function_reference": 2,
+                                                                                                "arguments": [
+                                                                                                    {
+                                                                                                        "value": {
+                                                                                                            "selection": {
+                                                                                                                "direct_reference": {
+                                                                                                                    "struct_field": {
+                                                                                                                        "field": 2
+                                                                                                                    }
+                                                                                                                }
+                                                                                                            }
+                                                                                                        }
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": {
+                                                                                                            "literal": {
+                                                                                                                "nullable": false,
+                                                                                                                "fp64": 0.05
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                ],
+                                                                                                "output_type": {
+                                                                                                    "bool": {
+                                                                                                        "type_variation_reference": 0,
+                                                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                ],
+                                                                                "output_type": {
+                                                                                    "bool": {
+                                                                                        "type_variation_reference": 0,
+                                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "value": {
+                                                                            "scalar_function": {
+                                                                                "function_reference": 4,
+                                                                                "arguments": [
+                                                                                    {
+                                                                                        "value": {
+                                                                                            "selection": {
+                                                                                                "direct_reference": {
+                                                                                                    "struct_field": {
+                                                                                                        "field": 2
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "value": {
+                                                                                            "literal": {
+                                                                                                "nullable": false,
+                                                                                                "fp64": 0.07
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                ],
+                                                                                "output_type": {
+                                                                                    "bool": {
+                                                                                        "type_variation_reference": 0,
+                                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ],
+                                                                "output_type": {
+                                                                    "bool": {
+                                                                        "type_variation_reference": 0,
+                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "value": {
+                                                            "scalar_function": {
+                                                                "function_reference": 3,
+                                                                "arguments": [
+                                                                    {
+                                                                        "value": {
+                                                                            "selection": {
+                                                                                "direct_reference": {
+                                                                                    "struct_field": {
+                                                                                        "field": 0
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "value": {
+                                                                            "literal": {
+                                                                                "nullable": false,
+                                                                                "fp64": 24
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                ],
+                                                                "output_type": {
+                                                                    "bool": {
+                                                                        "type_variation_reference": 0,
+                                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                ],
+                                                "output_type": {
+                                                    "bool": {
+                                                        "type_variation_reference": 0,
+                                                        "nullability": "NULLABILITY_NULLABLE"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "expressions": [
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 1
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "direct_reference": {
+                                                "struct_field": {
+                                                    "field": 2
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "groupings": [
+                            {
+                                "grouping_expressions": []
+                            }
+                        ],
+                        "measures": [
+                            {
+                                "measure": {
+                                    "function_reference": 5,
+                                    "arguments": [
+                                        {
+                                            "value": {
+                                                "scalar_function": {
+                                                    "function_reference": 6,
+                                                    "arguments": [
+                                                        {
+                                                            "value": {
+                                                                "selection": {
+                                                                    "direct_reference": {
+                                                                        "struct_field": {
+                                                                            "field": 0
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "value": {
+                                                                "selection": {
+                                                                    "direct_reference": {
+                                                                        "struct_field": {
+                                                                            "field": 1
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    ],
+                                                    "output_type": {
+                                                        "fp64": {
+                                                            "type_variation_reference": 0,
+                                                            "nullability": "NULLABILITY_NULLABLE"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "sorts": [],
+                                    "phase": "AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE",
+                                    "output_type": {
+                                        "fp64": {
+                                            "type_variation_reference": 0,
+                                            "nullability": "NULLABILITY_NULLABLE"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "names": []
+            }
+        }
+    ],
+    "expected_type_urls": []
 }


### PR DESCRIPTION
* Upgrade protobuf version to 3.21.4
* Remove usage of deprecated Substrait APIs. Update velox/substrait/tests/data/*.json files to use the latest Substrait format.
* Rename "linux-parquet-hive-storage-adapters-build" to "linux-adapters".
* Add install_protobuf to setup-adapters.sh. 
* Add Substrait tests to CircleCI job **linux-adapters.**
