### PR TITLE
Close exchange sources for tasks that complete early

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -360,13 +360,15 @@ struct DriverFactory {
     return nullptr;
   }
 
-  bool needsExchangeClient() const {
+  /// Returns Exchange plan node ID if the pipeline receives data from an
+  /// exchange.
+  std::optional<core::PlanNodeId> needsExchangeClient() const {
     VELOX_CHECK(!planNodes.empty());
     if (auto exchangeNode = std::dynamic_pointer_cast<const core::ExchangeNode>(
             planNodes.front())) {
-      return true;
+      return exchangeNode->id();
     }
-    return false;
+    return std::nullopt;
   }
 
   /// Returns LocalPartition plan node ID if the pipeline gets data from a local

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -44,6 +44,8 @@ class Merge : public SourceOperator {
 
   RowVectorPtr getOutput() override;
 
+  void close() override;
+
   const RowTypePtr& outputType() const {
     return outputType_;
   }

--- a/velox/exec/MergeSource.h
+++ b/velox/exec/MergeSource.h
@@ -31,12 +31,15 @@ class MergeSource {
       RowVectorPtr input,
       ContinueFuture* future) = 0;
 
+  virtual void close() = 0;
+
   // Factory methods to create MergeSources.
   static std::shared_ptr<MergeSource> createLocalMergeSource();
 
   static std::shared_ptr<MergeSource> createMergeExchangeSource(
       MergeExchange* mergeExchange,
-      const std::string& taskId);
+      const std::string& taskId,
+      int destination);
 };
 
 /// Coordinates data transfer between single producer and single consumer. Used


### PR DESCRIPTION
A task may finish early before fetching all the data from all the upstream
tasks. This may happen if a Limit operator receives enough rows or if HashProbe
operator receives an empty hash table. In these change an Exchange or
MergeExchange operator may not even have a change to do any processing or may
have processed some splits, but not all. In these cases it is necessary to
notify the upstream tasks that data is no longer needed, otherwise, these tasks
may block forever waiting for the data to be fetched. This is actually
happening when running the following query using Prestissimo and 3000 scale
TPC-H dataset:

```
select count(*) 
from customer_3k c, nation_3k n, region_3k r 
where c.nationkey =  n.nationkey and r.regionkey = n.regionkey and r.name = 'ASIA';
```

This problem applies to all types of exchange including partitioned, broadcast and 
merge exchange.

To notify upstream tasks we need to make sure to process all remote splits. This
logic cannot be part of the exchange operators since these may not even have a
chance to run before task completes. Hence, this logic goes into Task and
includes the following pieces:

* Add remote tasks to the ExchangeClient for splits added after the task
  completed (Task::addSplit and Task::addSplitWithSequence).
* Add remote tasks to the ExchangeClient for splits remaining unclaimed when
  task is transitioning to completion (Task::terminate).
* Call ExchangeClient::noMoreRemoteTask() upon receiving no-more-splits message
  after task has completed (Task::noMoreSplits).

Also,
* modify PartitionedOutputBuffer::enqueue to handle the case when some of
the buffers have been closed due to downstream tasks finishing early.
* fix MergeExchange operator to use Tasks's destination value when creating 
  exchange sources instead of hard-coded zero.

Add tests to orchestrate early completion of the downstream tasks to
MultiFragmentTest. These tests are hanging without the changes.

Fixes #1634