### PR TITLE
Fix handling of common sub expressions and encoded input

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -50,7 +50,7 @@ EvalCtx::EvalCtx(core::ExecCtx* execCtx)
 }
 
 VectorPtr EvalCtx::applyWrapToPeeledResult(
-    Expr* FOLLY_NONNULL expr,
+    const TypePtr& outputType,
     VectorPtr peeledResult,
     const SelectivityVector& rows) {
   VectorPtr wrappedResult;
@@ -58,7 +58,7 @@ VectorPtr EvalCtx::applyWrapToPeeledResult(
     if (!peeledResult) {
       // If all rows are null, make a constant null vector of the right type.
       wrappedResult =
-          BaseVector::createNullConstant(expr->type(), rows.size(), pool());
+          BaseVector::createNullConstant(outputType, rows.size(), pool());
     } else {
       BufferPtr nulls;
       if (!rows.isAllSelected()) {

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -49,16 +49,15 @@ EvalCtx::EvalCtx(core::ExecCtx* execCtx)
   VELOX_CHECK_NOT_NULL(execCtx);
 }
 
-void EvalCtx::setWrapped(
+VectorPtr EvalCtx::applyWrapToPeeledResult(
     Expr* FOLLY_NONNULL expr,
-    VectorPtr source,
-    const SelectivityVector& rows,
-    VectorPtr& result) {
-  VectorPtr localResult;
+    VectorPtr peeledResult,
+    const SelectivityVector& rows) {
+  VectorPtr wrappedResult;
   if (wrapEncoding_ == VectorEncoding::Simple::DICTIONARY) {
-    if (!source) {
+    if (!peeledResult) {
       // If all rows are null, make a constant null vector of the right type.
-      localResult =
+      wrappedResult =
           BaseVector::createNullConstant(expr->type(), rows.size(), pool());
     } else {
       BufferPtr nulls;
@@ -87,17 +86,16 @@ void EvalCtx::setWrapped(
       } else {
         nulls = wrapNulls_;
       }
-      localResult = BaseVector::wrapInDictionary(
-          std::move(nulls), wrap_, rows.end(), std::move(source));
+      wrappedResult = BaseVector::wrapInDictionary(
+          std::move(nulls), wrap_, rows.end(), std::move(peeledResult));
     }
   } else if (wrapEncoding_ == VectorEncoding::Simple::CONSTANT) {
-    localResult = BaseVector::wrapInConstant(
-        rows.size(), constantWrapIndex_, std::move(source));
+    wrappedResult = BaseVector::wrapInConstant(
+        rows.size(), constantWrapIndex_, std::move(peeledResult));
   } else {
     VELOX_FAIL("Bad expression wrap encoding {}", wrapEncoding_);
   }
-
-  moveOrCopyResult(localResult, rows, result);
+  return wrappedResult;
 }
 
 void EvalCtx::saveAndReset(ContextSaver& saver, const SelectivityVector& rows) {

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -77,7 +77,7 @@ class EvalCtx {
   // Wraps the 'peeledResult' in the wrap produced by the last peeling in
   // EvalEncoding() and returns the vector created as a result.
   VectorPtr applyWrapToPeeledResult(
-      Expr* FOLLY_NONNULL expr,
+      const TypePtr& outputType,
       VectorPtr peeledResult,
       const SelectivityVector& rows);
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -74,16 +74,12 @@ class EvalCtx {
 
   void restore(ContextSaver& saver);
 
-  // Creates or updates *result according to 'source'. The
-  // 'source' position corresponding to each position in 'rows' is
-  // given by the wrap produced by the last peeling in
-  // EvalEncoding. If '*result' existed, positions not in 'rows' are
-  // not changed.
-  void setWrapped(
+  // Wraps the 'peeledResult' in the wrap produced by the last peeling in
+  // EvalEncoding() and returns the vector created as a result.
+  VectorPtr applyWrapToPeeledResult(
       Expr* FOLLY_NONNULL expr,
-      VectorPtr source,
-      const SelectivityVector& rows,
-      VectorPtr& result);
+      VectorPtr peeledResult,
+      const SelectivityVector& rows);
 
   void setError(vector_size_t index, const std::exception_ptr& exceptionPtr);
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -417,7 +417,7 @@ bool Expr::checkGetSharedSubexprValues(
   if (!rows.isSubset(*sharedSubexprRows_)) {
     LocalSelectivityVector missingRowsHolder(context, rows);
     auto missingRows = missingRowsHolder.get();
-    VELOX_DCHECK(missingRows); // lint
+    VELOX_DCHECK(missingRows);
     missingRows->deselect(*sharedSubexprRows_);
 
     // Add the missingRows to sharedSubexprRows_ that will eventually be
@@ -428,11 +428,11 @@ bool Expr::checkGetSharedSubexprValues(
     LocalSelectivityVector newFinalSelectionHolder(
         context, *sharedSubexprRows_);
     auto newFinalSelection = newFinalSelectionHolder.get();
-    VELOX_DCHECK(newFinalSelection); // lint
+    VELOX_DCHECK(newFinalSelection);
     if (!context.isFinalSelection()) {
       // In case currently set finalSelection does not include all rows in
       // sharedSubexprRows_.
-      VELOX_DCHECK(context.finalSelection() != nullptr);
+      VELOX_DCHECK_NOT_NULL(context.finalSelection());
       newFinalSelection->select(*context.finalSelection());
     }
     VarSetter finalSelectionPreservePrecomputedValues(

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -417,7 +417,7 @@ bool Expr::checkGetSharedSubexprValues(
   if (!rows.isSubset(*sharedSubexprRows_)) {
     LocalSelectivityVector missingRowsHolder(context, rows);
     auto missingRows = missingRowsHolder.get();
-    VELOX_DCHECK(missingRows != nullptr);
+    VELOX_DCHECK(missingRows); // lint
     missingRows->deselect(*sharedSubexprRows_);
 
     // Add the missingRows to sharedSubexprRows_ that will eventually be
@@ -428,7 +428,7 @@ bool Expr::checkGetSharedSubexprValues(
     LocalSelectivityVector newFinalSelectionHolder(
         context, *sharedSubexprRows_);
     auto newFinalSelection = newFinalSelectionHolder.get();
-    assert(newFinalSelection); // lint
+    VELOX_DCHECK(newFinalSelection); // lint
     if (context.finalSelection() != nullptr) {
       // In case currently set finalSelection does not include all rows in
       // sharedSubexprRows_.

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -417,7 +417,7 @@ bool Expr::checkGetSharedSubexprValues(
   if (!rows.isSubset(*sharedSubexprRows_)) {
     LocalSelectivityVector missingRowsHolder(context, rows);
     auto missingRows = missingRowsHolder.get();
-    VELOX_DCHECK(missingRows);
+    VELOX_DCHECK_NOT_NULL(missingRows);
     missingRows->deselect(*sharedSubexprRows_);
 
     // Add the missingRows to sharedSubexprRows_ that will eventually be
@@ -428,7 +428,7 @@ bool Expr::checkGetSharedSubexprValues(
     LocalSelectivityVector newFinalSelectionHolder(
         context, *sharedSubexprRows_);
     auto newFinalSelection = newFinalSelectionHolder.get();
-    VELOX_DCHECK(newFinalSelection);
+    VELOX_DCHECK_NOT_NULL(newFinalSelection);
     if (!context.isFinalSelection()) {
       // In case currently set finalSelection does not include all rows in
       // sharedSubexprRows_.
@@ -710,7 +710,7 @@ void Expr::evalEncodings(
             }
           }
           wrappedResult =
-              context.applyWrapToPeeledResult(this, peeledResult, rows);
+              context.applyWrapToPeeledResult(this->type(), peeledResult, rows);
         }
       }
       if (wrappedResult != nullptr) {
@@ -1215,7 +1215,7 @@ bool Expr::applyFunctionWithPeeling(
   VectorPtr peeledResult;
   applyFunction(*newRows, context, peeledResult);
   VectorPtr wrappedResult =
-      context.applyWrapToPeeledResult(this, peeledResult, rows);
+      context.applyWrapToPeeledResult(this->type(), peeledResult, rows);
   context.moveOrCopyResult(wrappedResult, rows, result);
   return true;
 }

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -429,9 +429,10 @@ bool Expr::checkGetSharedSubexprValues(
         context, *sharedSubexprRows_);
     auto newFinalSelection = newFinalSelectionHolder.get();
     VELOX_DCHECK(newFinalSelection); // lint
-    if (context.finalSelection() != nullptr) {
+    if (!context.isFinalSelection()) {
       // In case currently set finalSelection does not include all rows in
       // sharedSubexprRows_.
+      VELOX_DCHECK(context.finalSelection() != nullptr);
       newFinalSelection->select(*context.finalSelection());
     }
     VarSetter finalSelectionPreservePrecomputedValues(

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -420,14 +420,17 @@ bool Expr::checkGetSharedSubexprValues(
     VELOX_DCHECK(missingRows != nullptr);
     missingRows->deselect(*sharedSubexprRows_);
 
-    // Fix finalSelection at "rows" if missingRows is a strict subset to avoid
-    // losing values outside of missingRows.
-    bool updateFinalSelection = context.isFinalSelection() &&
-        (missingRows->countSelected() < rows.countSelected());
-    VarSetter finalSelectionOr(
-        context.mutableFinalSelection(), &rows, updateFinalSelection);
-    VarSetter isFinalSelectionOr(
-        context.mutableIsFinalSelection(), false, updateFinalSelection);
+    // Add the missingRows to sharedSubexprRows_ that will eventually be
+    // evaluated and added to sharedSubexprValues_.
+    sharedSubexprRows_->select(*missingRows);
+    // Fix finalSelection to the updated sharedSubexprRows_ to avoid
+    // losing values outside missingRows.
+    VarSetter finalSelectionPreservePrecomputedValues(
+        context.mutableFinalSelection(),
+        const_cast<const SelectivityVector*>(sharedSubexprRows_.get()),
+        context.isFinalSelection());
+    VarSetter isFinalSelectionPreservePrecomputedValues(
+        context.mutableIsFinalSelection(), false, context.isFinalSelection());
 
     evalEncodings(*missingRows, context, sharedSubexprValues_);
   }
@@ -670,31 +673,39 @@ void Expr::evalEncodings(
     }
 
     if (hasNonFlat) {
-      LocalSelectivityVector newRowsHolder(context);
-      LocalSelectivityVector finalRowsHolder(context);
-      ContextSaver saveContext;
-      LocalDecodedVector decodedHolder(context);
-      auto peelEncodingsResult = peelEncodings(
-          context,
-          saveContext,
-          rows,
-          decodedHolder,
-          newRowsHolder,
-          finalRowsHolder);
-      auto* newRows = peelEncodingsResult.newRows;
-      if (newRows) {
-        VectorPtr peeledResult;
-        // peelEncodings() can potentially produce an empty selectivity vector
-        // if all selected values we are waiting for are nulls. So, here we
-        // check for such a case.
-        if (newRows->hasSelections()) {
-          if (peelEncodingsResult.mayCache) {
-            evalWithMemo(*newRows, context, peeledResult);
-          } else {
-            evalWithNulls(*newRows, context, peeledResult);
+      VectorPtr wrappedResult;
+      // Attempt peeling and bound the scope of the context used for it.
+      {
+        ContextSaver saveContext;
+        LocalSelectivityVector newRowsHolder(context);
+        LocalSelectivityVector finalRowsHolder(context);
+        LocalDecodedVector decodedHolder(context);
+        auto peelEncodingsResult = peelEncodings(
+            context,
+            saveContext,
+            rows,
+            decodedHolder,
+            newRowsHolder,
+            finalRowsHolder);
+        auto* newRows = peelEncodingsResult.newRows;
+        if (newRows) {
+          VectorPtr peeledResult;
+          // peelEncodings() can potentially produce an empty selectivity vector
+          // if all selected values we are waiting for are nulls. So, here we
+          // check for such a case.
+          if (newRows->hasSelections()) {
+            if (peelEncodingsResult.mayCache) {
+              evalWithMemo(*newRows, context, peeledResult);
+            } else {
+              evalWithNulls(*newRows, context, peeledResult);
+            }
           }
+          wrappedResult =
+              context.applyWrapToPeeledResult(this, peeledResult, rows);
         }
-        context.setWrapped(this, peeledResult, rows, result);
+      }
+      if (wrappedResult != nullptr) {
+        context.moveOrCopyResult(wrappedResult, rows, result);
         return;
       }
     }
@@ -1193,7 +1204,9 @@ bool Expr::applyFunctionWithPeeling(
 
   VectorPtr peeledResult;
   applyFunction(*newRows, context, peeledResult);
-  context.setWrapped(this, peeledResult, rows, result);
+  VectorPtr wrappedResult =
+      context.applyWrapToPeeledResult(this, peeledResult, rows);
+  context.moveOrCopyResult(wrappedResult, rows, result);
   return true;
 }
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2240,7 +2240,6 @@ TEST_F(ExprTest, flatNoNullsFastPath) {
 TEST_F(ExprTest, commonSubExpressionWithEncodedInput) {
   // This test case does a sanity check of the code path that re-uses
   // precomputed results for common sub-expressions.
-  // TODO: consider adding metrics that expose use of optimizations like this.
   auto data = makeRowVector(
       {makeFlatVector<int64_t>({1, 1, 2, 2}),
        makeFlatVector<int64_t>({10, 10, 20, 20}),

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -26,7 +26,6 @@
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
-#include "velox/vector/VectorEncoding.h"
 #include "velox/vector/tests/VectorTestBase.h"
 
 using namespace facebook::velox;
@@ -2236,4 +2235,61 @@ TEST_F(ExprTest, flatNoNullsFastPath) {
   ASSERT_EQ(1, exprSet->exprs().size());
   ASSERT_FALSE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath())
       << exprSet->toString();
+}
+
+TEST_F(ExprTest, commonSubExpressionWithEncodedInput) {
+  // This test case does a sanity check of the code path that re-uses
+  // precomputed results for common sub-expressions.
+  // TODO: consider adding metrics that expose use of optimizations like this.
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 1, 2, 2}),
+       makeFlatVector<int64_t>({10, 10, 20, 20}),
+       wrapInDictionary(
+           makeIndices({0, 1, 2, 3}),
+           4,
+           wrapInDictionary(
+               makeIndices({0, 1, 1, 0}),
+               4,
+               makeFlatVector<int64_t>({1, 2, 3, 4}))),
+       makeConstant<int64_t>(1, 4)});
+
+  // c2 > 1 is a common sub-expression. It is used in 3 top-level expressions.
+  // In the first expression, c2 > 1 is evaluated for rows 3, 4.
+  // In the second expression, c2 > 1 is evaluated for rows 0, 1.
+  // In the third expression. c2 > 1 returns pre-computed results for rows 3, 4
+  auto results = makeRowVector(evaluateMultiple(
+      {"c0 = 2 AND c2 > 1", "c0 = 1 AND c2 > 1", "c1 = 20 AND c2 > 1"}, data));
+  auto expectedResults = makeRowVector(
+      {makeFlatVector<bool>({false, false, true, false}),
+       makeFlatVector<bool>({false, true, false, false}),
+       makeFlatVector<bool>({false, false, true, false})});
+  assertEqualVectors(expectedResults, results);
+
+  // Similarly, for when the input to the common subexpression is constant.
+  results = makeRowVector(evaluateMultiple(
+      {"c0 = 2 AND c3 > 3", "c0 = 1 AND c3 > 3", "c1 = 20 AND c3 > 3"}, data));
+  expectedResults = makeRowVector(
+      {makeFlatVector<bool>({false, false, false, false}),
+       makeFlatVector<bool>({false, false, false, false}),
+       makeFlatVector<bool>({false, false, false, false})});
+  assertEqualVectors(expectedResults, results);
+}
+
+TEST_F(ExprTest, preservePartialResultsWithEncodedInput) {
+  // This test verifies that partially populated results are preserved when the
+  // input contains an encoded vector. We do this by using an if statement where
+  // partial results are passed between its children expressions based on the
+  // condition.
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6}),
+      wrapInDictionary(
+          makeIndices({0, 1, 2, 0, 1, 2}),
+          6,
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6})),
+  });
+
+  // Create an expression which divides the input to be processed equally
+  // between two different expressions.
+  auto result = evaluate("if(c0 > 3, 7, c1 + 100)", data);
+  assertEqualVectors(makeFlatVector<int64_t>({101, 102, 103, 7, 7, 7}), result);
 }


### PR DESCRIPTION
This patch fixes the following:
- Handling common sub expressions running over disjoint set of
  active rows
- Tracking of rows that have been pre-computed by the common
  expressions
- Handling evaluation of encoded input

Test Plan:
Added unit tests