### PR TITLE
Fix Final Selection logic in Lambdas.

### DIFF
--- a/velox/expression/LambdaExpr.cpp
+++ b/velox/expression/LambdaExpr.cpp
@@ -41,6 +41,7 @@ class ExprCallable : public Callable {
 
   void apply(
       const SelectivityVector& rows,
+      const SelectivityVector& finalSelection,
       BufferPtr wrapCapture,
       EvalCtx* context,
       const std::vector<VectorPtr>& args,
@@ -63,7 +64,7 @@ class ExprCallable : public Callable {
     EvalCtx lambdaCtx(context->execCtx(), context->exprSet(), row.get());
     if (!context->isFinalSelection()) {
       *lambdaCtx.mutableIsFinalSelection() = false;
-      *lambdaCtx.mutableFinalSelection() = context->finalSelection();
+      *lambdaCtx.mutableFinalSelection() = &finalSelection;
     }
     body_->eval(rows, lambdaCtx, *result);
   }

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -132,7 +132,7 @@ class ReduceFunction : public exec::VectorFunction {
 
         std::vector<VectorPtr> lambdaArgs = {state, nthElement};
         entry.callable->apply(
-            arrayRows, nullptr, context, lambdaArgs, &partialResult);
+            arrayRows, rows, nullptr, context, lambdaArgs, &partialResult);
         state = partialResult;
         n++;
       }
@@ -142,7 +142,8 @@ class ReduceFunction : public exec::VectorFunction {
     auto outputFuncIt = args[3]->asUnchecked<FunctionVector>()->iterator(&rows);
     while (auto entry = outputFuncIt.next()) {
       std::vector<VectorPtr> lambdaArgs = {partialResult};
-      entry.callable->apply(*entry.rows, nullptr, context, lambdaArgs, result);
+      entry.callable->apply(
+          *entry.rows, rows, nullptr, context, lambdaArgs, result);
     }
   }
 

--- a/velox/functions/prestosql/Transform.cpp
+++ b/velox/functions/prestosql/Transform.cpp
@@ -49,6 +49,12 @@ class TransformFunction : public exec::VectorFunction {
     std::vector<VectorPtr> lambdaArgs = {flatArray->elements()};
     auto newNumElements = flatArray->elements()->size();
 
+    SelectivityVector finalSelection;
+    if (!context->isFinalSelection()) {
+      finalSelection = toElementRows<ArrayVector>(
+          newNumElements, *context->finalSelection(), flatArray.get());
+    }
+
     // transformed elements
     VectorPtr newElements;
 
@@ -62,7 +68,12 @@ class TransformFunction : public exec::VectorFunction {
           newNumElements, entry.callable, *entry.rows, flatArray);
 
       entry.callable->apply(
-          elementRows, wrapCapture, context, lambdaArgs, &newElements);
+          elementRows,
+          finalSelection,
+          wrapCapture,
+          context,
+          lambdaArgs,
+          &newElements);
     }
 
     VectorPtr localResult = std::make_shared<ArrayVector>(

--- a/velox/functions/prestosql/tests/MapFilterTest.cpp
+++ b/velox/functions/prestosql/tests/MapFilterTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/expression/VarSetter.h"
 #include "velox/functions/prestosql/tests/FunctionBaseTest.h"
 
 using namespace facebook::velox;
@@ -22,6 +23,14 @@ using namespace facebook::velox::test;
 
 class MapFilterTest : public functions::test::FunctionBaseTest {
  protected:
+  std::unique_ptr<exec::ExprSet> compileExpression(
+      const std::string& expr,
+      const RowTypePtr& rowType) {
+    std::vector<std::shared_ptr<const core::ITypedExpr>> expressions = {
+        parseExpression(expr, rowType)};
+    return std::make_unique<exec::ExprSet>(std::move(expressions), &execCtx_);
+  }
+
   template <typename K, typename V>
   void checkMapFilter(
       BaseVector* inputMap,
@@ -232,4 +241,48 @@ TEST_F(MapFilterTest, dictionaryWithDuplicates) {
       evaluate<BaseVector>("map_filter(c1, function('filter'))", input);
 
   assertEqualVectors(expectedResult, result);
+}
+
+TEST_F(MapFilterTest, lambdaSelectivityVector) {
+  auto data = makeRowVector({
+      wrapInDictionary(
+          makeIndices({0}),
+          1,
+          makeFlatVector<int64_t>(std::vector<int64_t>{10})),
+  });
+
+  // Register lambda as DuckDb parser does not support converting it into Velox
+  // lambda expression.
+  parse::ParseOptions options;
+  core::Expressions::registerLambda(
+      "inn",
+      ROW({"k", "v"}, {BIGINT(), BIGINT()}),
+      ROW({"long_val", "map_val"}, {BIGINT(), MAP(BIGINT(), BIGINT())}),
+      parse::parseExpr("v IS NOT NULL", options),
+      pool_.get());
+
+  // Our expression. Use large numbers to trigger asan if things go wrong.
+  auto exprSet = compileExpression(
+      "map_filter("
+      "MAP(ARRAY[233439836560246536, 398885052601874414, 213334509704047604],"
+      "ARRAY[c0, c0, c0]),"
+      "function('inn'))",
+      asRowType(data->type()));
+
+  // Ensure that our context would have 'final selection' false.
+  exec::EvalCtx context(&execCtx_, exprSet.get(), data.get());
+  const SelectivityVector allRows(data->size());
+  VarSetter finalSelection(context.mutableFinalSelection(), &allRows);
+  VarSetter isFinalSelection(context.mutableIsFinalSelection(), false);
+
+  // Evaluate. Result would be overwritten.
+  std::vector<VectorPtr> result = {
+      makeFlatVector<int64_t>(std::vector<int64_t>{1})};
+  exprSet->eval(allRows, &context, &result);
+
+  auto expectedKeys = makeFlatVector<int64_t>(
+      {233439836560246536, 398885052601874414, 213334509704047604});
+  auto expectedValues = makeFlatVector<int64_t>({10, 10, 10});
+  auto expected = makeMapVector({0}, expectedKeys, expectedValues);
+  assertEqualVectors(expected, result[0]);
 }

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -39,8 +39,11 @@ class Callable {
   // so that the values of the arguments and captures are not
   // aligned. This serves to align these. If nullptr, the captures are
   // passed as is.
+  // 'finalSelection' can be empty when context->isFinalSelection() is true
+  // and must be a valid selectivity vector otherwise.
   virtual void apply(
       const SelectivityVector& rows,
+      const SelectivityVector& finalSelection,
       BufferPtr wrapCapture,
       exec::EvalCtx* context,
       const std::vector<VectorPtr>& args,


### PR DESCRIPTION
Summary:
The fix changes how we work with the Final Selection around ExprCallable::apply().
At this border our context changes and the lambda uses different rows, not the rows the context above it was running on.

Imagine 100 rows with a map column and the expression has map_filter(map, lambda).
We were running expression eval on these 100 rows R1 with some rows (maybe) filtered out.

When we descend into the lambda we run its expression (stored in the body_ member).
But we run it on the rows R2, which is received by exploding all elements of maps in all 100 rows - basically we generate R2 based on R1 and how many elements maps have in each row in R1.

Previously we didn't generate finalSelection in the same way and used the original finalSelection from the outer context.
That lead (further down the line) into decoding only R1 number of rows and then processing R2 number of rows with R1 generally being less than R2. Which lead to access uninitialized memory in decoded indices and to invalid results or crashes.

This change converts finalSelection selectivity vector to lambda's space in the same way  we convert the current selectivity vector.

The test also checks that a lazy vector captured in the lambda is being loaded before using it. I believe this needs to be extended by multiple lambdas running on different rows, which we will work right after fixing this issue.

Differential Revision: D39007820

