### PR TITLE
Add support to calculate hash partition number with specified bits

### DIFF
--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -15,35 +15,10 @@
  */
 #pragma once
 
+#include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/RowContainer.h"
 
 namespace facebook::velox::exec {
-
-// Describes a bit range inside a 64 bit hash number for use in
-// partitioning data over multiple sets of spill files.
-class HashBitRange {
- public:
-  HashBitRange(uint8_t begin, uint8_t end)
-      : begin_(begin), end_(end), fieldMask_(bits::lowMask(end - begin)) {}
-  HashBitRange() : HashBitRange(0, 0) {}
-
-  int32_t partition(uint64_t hash, int32_t numPartitions) const {
-    int32_t number = (hash >> begin_) & fieldMask_;
-    return number < numPartitions ? number : -1;
-  }
-
-  int32_t numPartitions() const {
-    return 1 << (end_ - begin_);
-  }
-
- private:
-  // Low bit number of hash number bit range.
-  const uint8_t begin_;
-  // Bit number of first bit above the hash number bit range.
-  const uint8_t end_;
-
-  const uint64_t fieldMask_;
-};
 
 // Manages spilling data from a RowContainer.
 class Spiller {

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   FunctionResolutionTest.cpp
   FunctionSignatureBuilderTest.cpp
   HashJoinTest.cpp
+  HashPartitionFunctionTest.cpp
   HashTableTest.cpp
   LimitTest.cpp
   LocalPartitionTest.cpp

--- a/velox/exec/tests/HashPartitionFunctionTest.cpp
+++ b/velox/exec/tests/HashPartitionFunctionTest.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/HashPartitionFunction.h"
+#include "velox/vector/tests/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+class HashPartitionFunctionTest : public test::VectorTestBase,
+                                  public testing::Test {};
+
+TEST_F(HashPartitionFunctionTest, HashPartitionFunction) {
+  const int numRows = 10'000;
+  RowVectorPtr vector = makeRowVector(
+      {makeFlatVector<int32_t>(numRows, [](auto row) { return row * 100 / 3; }),
+       makeFlatVector<int32_t>(
+           numRows, [](auto row) { return row * 1274364; })});
+  RowTypePtr rowType = asRowType(vector->type());
+
+  // The test case the two hash partition functions having the same config.
+  {
+    std::vector<uint32_t> partitonsWithoutBits(numRows);
+    HashPartitionFunction functionWithoutBits(4, rowType, {0});
+    functionWithoutBits.partition(*vector, partitonsWithoutBits);
+
+    std::vector<uint32_t> partitonsWithBits(numRows);
+    HashPartitionFunction functionWithBits(HashBitRange{0, 2}, rowType, {0});
+    functionWithBits.partition(*vector, partitonsWithBits);
+    EXPECT_EQ(partitonsWithoutBits, partitonsWithBits);
+  }
+
+  // The test case the two hash partition functions with different configs.
+  {
+    std::vector<uint32_t> partitonsWithoutBits(numRows);
+    HashPartitionFunction functionWithoutBits(4, rowType, {0});
+    functionWithoutBits.partition(*vector, partitonsWithoutBits);
+
+    std::vector<uint32_t> partitonsWithBits(numRows);
+    HashPartitionFunction functionWithBits(HashBitRange{0, 3}, rowType, {0});
+    functionWithBits.partition(*vector, partitonsWithBits);
+    EXPECT_NE(partitonsWithoutBits, partitonsWithBits);
+  }
+
+  // The test case the two hash partition functions with different configs.
+  {
+    std::vector<uint32_t> partitonsWithoutBits(numRows);
+    HashPartitionFunction functionWithoutBits(4, rowType, {0});
+    functionWithoutBits.partition(*vector, partitonsWithoutBits);
+
+    std::vector<uint32_t> partitonsWithBits(numRows);
+    HashPartitionFunction functionWithBits(HashBitRange{29, 31}, rowType, {0});
+    functionWithBits.partition(*vector, partitonsWithBits);
+    EXPECT_NE(partitonsWithoutBits, partitonsWithBits);
+  }
+
+  // The test case the two hash partition functions with different configs.
+  {
+    std::vector<uint32_t> partitonsWithBits1(numRows);
+    HashPartitionFunction functionWithBits1(HashBitRange{40, 42}, rowType, {0});
+    functionWithBits1.partition(*vector, partitonsWithBits1);
+
+    std::vector<uint32_t> partitonsWithBits2(numRows);
+    HashPartitionFunction functionWithBits2(HashBitRange{29, 31}, rowType, {0});
+    functionWithBits2.partition(*vector, partitonsWithBits2);
+    EXPECT_NE(partitonsWithBits1, partitonsWithBits2);
+  }
+
+  // The test case the two hash partition functions with different configs.
+  {
+    std::vector<uint32_t> partitonsWithBits1(numRows);
+    HashPartitionFunction functionWithBits1(HashBitRange{20, 31}, rowType, {0});
+    functionWithBits1.partition(*vector, partitonsWithBits1);
+
+    std::vector<uint32_t> partitonsWithBits2(numRows);
+    HashPartitionFunction functionWithBits2(HashBitRange{29, 31}, rowType, {0});
+    functionWithBits2.partition(*vector, partitonsWithBits2);
+    EXPECT_NE(partitonsWithBits1, partitonsWithBits2);
+  }
+
+  // The test case the two hash partition functions having the same config.
+  {
+    std::vector<uint32_t> partitonsWithBits1(numRows);
+    HashPartitionFunction functionWithBits1(HashBitRange{29, 31}, rowType, {0});
+    functionWithBits1.partition(*vector, partitonsWithBits1);
+
+    std::vector<uint32_t> partitonsWithBits2(numRows);
+    HashPartitionFunction functionWithBits2(HashBitRange{29, 31}, rowType, {0});
+    functionWithBits2.partition(*vector, partitonsWithBits2);
+    EXPECT_EQ(partitonsWithBits1, partitonsWithBits2);
+  }
+}


### PR DESCRIPTION
Add support to calculate hash partition number with specified bits.
Move HashBitRange initially designed for spilling partition number
calculation into HashBitRange and integrate into HashPartitionFunction
plus unit test coverage.