### PR TITLE
Use Folly CRC

### DIFF
--- a/velox/common/base/Crc.h
+++ b/velox/common/base/Crc.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/hash/Checksum.h>
+namespace facebook::velox::bits {
+
+// A boost compatible CRC32 calculator.
+class Crc32 {
+ public:
+  void process_bytes(const void* data, int32_t size) {
+    checksum_ =
+        folly::crc32(reinterpret_cast<const uint8_t*>(data), size, checksum_);
+  }
+
+  uint32_t checksum() const {
+    return ~checksum_;
+  }
+
+  void reset() {
+    checksum_ = ~0U;
+  }
+
+ private:
+  uint32_t checksum_{~0U};
+};
+
+} // namespace facebook::velox::bits

--- a/velox/common/base/tests/BitUtilTest.cpp
+++ b/velox/common/base/tests/BitUtilTest.cpp
@@ -15,10 +15,13 @@
  */
 
 #include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Crc.h"
 
 #include <unordered_set>
 
+#include <boost/crc.hpp>
 #include <folly/Random.h>
+#include <folly/hash/Checksum.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
@@ -667,6 +670,23 @@ TEST_F(BitUtilTest, hashMix) {
   EXPECT_EQ(
       bits::commutativeHashMix(123, 321), bits::commutativeHashMix(321, 123));
 }
+
+TEST_F(BitUtilTest, crc) {
+  const char* text =
+      "We were sailing on the sloop John B., ny grandfather and me...";
+  const char* text2 = "around old Nassau we would rowm";
+  boost::crc_32_type crc32;
+  crc32.process_bytes(text, sizeof(text));
+  crc32.process_bytes(text2, sizeof(text2));
+  auto boostCrc = crc32.checksum();
+  bits::Crc32 crc;
+  crc.process_bytes(text, sizeof(text));
+  crc.process_bytes(text2, sizeof(text2));
+  auto follyCrc = crc.checksum();
+
+  EXPECT_EQ(boostCrc, follyCrc);
+}
+
 } // namespace bits
 } // namespace velox
 } // namespace facebook

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/serializers/PrestoSerializer.h"
+#include "velox/common/base/Crc.h"
 #include "velox/common/memory/ByteStream.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/Date.h"
@@ -34,7 +35,7 @@ int64_t computeChecksum(
     int codecMarker,
     int numRows,
     int uncompressedSize) {
-  boost::crc_32_type result = listener->crc();
+  auto result = listener->crc();
   result.process_bytes(&codecMarker, 1);
   result.process_bytes(&numRows, 4);
   result.process_bytes(&uncompressedSize, 4);
@@ -47,7 +48,7 @@ int64_t computeChecksum(
     int numRows,
     int uncompressedSize) {
   auto offset = source->tellp();
-  boost::crc_32_type crc32;
+  bits::Crc32 crc32;
 
   auto remainingBytes = uncompressedSize;
   while (remainingBytes > 0) {

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #pragma once
-#include <boost/crc.hpp>
+#include "velox/common/base/Crc.h"
 #include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::serializer::presto {
@@ -55,7 +55,7 @@ class PrestoOutputStreamListener : public OutputStreamListener {
     paused_ = false;
   }
 
-  boost::crc_32_type crc() const {
+  auto crc() const {
     return crc_;
   }
 
@@ -65,6 +65,6 @@ class PrestoOutputStreamListener : public OutputStreamListener {
 
  private:
   bool paused_{false};
-  boost::crc_32_type crc_;
+  bits::Crc32 crc_;
 };
 } // namespace facebook::velox::serializer::presto

--- a/velox/serializers/tests/PrestoOutputStreamListenerTest.cpp
+++ b/velox/serializers/tests/PrestoOutputStreamListenerTest.cpp
@@ -38,7 +38,7 @@ TEST_F(PrestoOutputStreamListenerTest, basic) {
       os->listener());
   EXPECT_TRUE(listener != nullptr);
 
-  boost::crc_32_type crc;
+  bits::Crc32 crc;
   crc.process_bytes(&codec, sizeof(codec));
   crc.process_bytes(&length, sizeof(length));
   crc.process_bytes(str1.data(), str1.size());


### PR DESCRIPTION
boost CRC32 is top of profile in running big shuffles in Presto. This
replaces it with the Folly equivalent. See benchmarks in //folly for
comparisons.