### PR TITLE
disk spilling support for hash probe

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -126,8 +126,12 @@ enum class BlockingReason {
   kWaitForSplit,
   kWaitForExchange,
   kWaitForJoinBuild,
-  /// Build operator is blocked waiting for the probe operators to finish
-  /// probing before build the next hash table from the previously spilled data.
+  /// For a build operator, it is blocked waiting for the probe operators to
+  /// finish probing before build the next hash table from one of the previously
+  /// spilled partition data.
+  /// For a probe operator, it is blocked waiting for all its peer probe
+  /// operators to finish probing before notifying the build operators to build
+  /// the next hash table from the previously spilled data.
   kWaitForJoinProbe,
   kWaitForMemory,
   kWaitForConnector,

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -880,11 +880,11 @@ void HashBuild::setRunning() {
 }
 
 void HashBuild::setState(State state) {
-  stateTransitionCheck(state);
+  checkStateTransition(state);
   state_ = state;
 }
 
-void HashBuild::stateTransitionCheck(State state) {
+void HashBuild::checkStateTransition(State state) {
   VELOX_CHECK_NE(state_, state);
   switch (state) {
     case State::kRunning:

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -81,7 +81,7 @@ class HashBuild final : public Operator {
 
  private:
   void setState(State state);
-  void stateTransitionCheck(State state);
+  void checkStateTransition(State state);
 
   void setRunning();
   bool isRunning() const;

--- a/velox/exec/SpillOperatorGroup.h
+++ b/velox/exec/SpillOperatorGroup.h
@@ -38,7 +38,7 @@ class SpillOperatorGroup {
  public:
   /// Define the internal execution state of a spill group. The valid state
   /// transition is depicted as below:
-
+  ///
   ///       kInit --->  kRunning  --->  kStopped
   ///                      ^               |
   ///                      |               v


### PR DESCRIPTION
The added hash probe procedure works as follow:
1. hash probe operator waits for table built by hash build operators
    to join
2. hash probe operator prepare for spilling: (1) setup spiller to spill
    input rows which corresponding partitions have been spilled at the
    build side.
4. hash probe operator process inputs and joins with the table
5. after all the hash probe operators have finished processing inputs,
    the last operator will do last probe if the join type needs, and
    notify the hash build operators of the next table to build from the
    spill data if there is remaining spill data to restore.
    Otherwise finish the probe operator processing.
7. Go back to step1 to start the next round of hash probe processing.
    
Unit tests are added in HashJoinTest to make each existing test case
to run test with spilling and different spilling levels.

This PR also fixes the issue that clears the output row map when the
build side table is empty detected by left join types when running
recursive spilling.

The followup will add spilling stats for HashProbe



