### PR TITLE
Ci/Cd hadoop path correcting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -439,15 +439,11 @@ jobs:
             cd ~/adapter-deps/install/bin/
             wget https://dl.min.io/server/minio/release/linux-amd64/archive/minio-20220526054841.0.0.x86_64.rpm
             rpm -i minio-20220526054841.0.0.x86_64.rpm
+            rm minio-20220526054841.0.0.x86_64.rpm
       - run:
           name: "Install Hadoop dependency"
           command: |
             set -xu
-            cd ~/adapter-deps/install/bin/
-            wget https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz
-            tar xf hadoop-2.10.1.tar.gz
-            chmod +x hadoop-2.10.1
-            cp -a hadoop-2.10.1 /usr/local/
             yum -y install java-1.8.0-openjdk
       - run:
           name: Build
@@ -472,7 +468,8 @@ jobs:
             export JAVA_HOME=/usr/lib/jvm/jre-1.8.0-openjdk
             export HADOOP_ROOT_LOGGER="WARN,DRFA"
             export LIBHDFS3_CONF=$(pwd)/.circleci/hdfs-client.xml
-            export PATH=~/adapter-deps/install/bin:~/adapter-deps/install/hadoop-2.10.1/bin:${PATH}
+            export HADOOP_HOME='/usr/local/hadoop'
+            export PATH=~/adapter-deps/install/bin:/usr/local/hadoop/bin:${PATH}
             cd _build/release && ctest -j 16 -VV --output-on-failure
           no_output_timeout: 1h
 


### PR DESCRIPTION
Minor bug in task path exporting, as in ""Install Hadoop dependency" task the hadoop is downloaded on top of bin folder after change dir : 
```yaml
- run:
     name: "Install Hadoop dependency"
     command: |
       set -xu
       cd ~/adapter-deps/install/bin/
       wget https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz
       tar xf hadoop-2.10.1.tar.gz
       chmod +x hadoop-2.10.1
       cp -a hadoop-2.10.1 /usr/local/
       yum -y install java-1.8.0-openjdk
```
Bug had no effect, as the same archive is present in `/usr/local/` path after copy.