### PR TITLE
Some code refactors to support hash join spill in followup

### DIFF
--- a/velox/exec/HashBitRange.h
+++ b/velox/exec/HashBitRange.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <velox/exec/VectorHasher.h>
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::exec {
+
+// Describes a bit range inside a 64 bit hash number for use in
+// partitioning data.
+class HashBitRange {
+ public:
+  HashBitRange(uint8_t begin, uint8_t end)
+      : begin_(begin), end_(end), fieldMask_(bits::lowMask(end - begin)) {}
+  HashBitRange() : HashBitRange(0, 0) {}
+
+  int32_t partition(uint64_t hash, int32_t numPartitions) const {
+    int32_t number = (hash >> begin_) & fieldMask_;
+    return number < numPartitions ? number : -1;
+  }
+
+  int32_t partition(uint64_t hash) const {
+    return (hash >> begin_) & fieldMask_;
+  }
+
+  uint8_t begin() const {
+    return begin_;
+  }
+
+  uint8_t end() const {
+    return end_;
+  }
+
+  uint8_t numBits() const {
+    return end_ - begin_;
+  }
+
+  int32_t numPartitions() const {
+    return 1 << numBits();
+  }
+
+ private:
+  // Low bit number of hash number bit range.
+  const uint8_t begin_;
+  // Bit number of first bit above the hash number bit range.
+  const uint8_t end_;
+
+  const uint64_t fieldMask_;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -84,9 +84,20 @@ class HashBuild final : public Operator {
   void close() override {}
 
  private:
+  // Invoked to setup hash table to build.
+  void setupTable();
+
   void addRuntimeStats();
 
+  const std::shared_ptr<const core::HashJoinNode> joinNode_;
+
   const core::JoinType joinType_;
+
+  // Holds the areas in RowContainer of 'table_'
+  memory::MappedMemory* const mappedMemory_; // Not owned.
+
+  // The row type used for hash table build and disk spilling.
+  RowTypePtr tableType_;
 
   // Container for the rows being accumulated.
   std::unique_ptr<BaseHashTable> table_;
@@ -99,9 +110,6 @@ class HashBuild final : public Operator {
 
   // Corresponds 1:1 to 'dependentChannels_'.
   std::vector<std::unique_ptr<DecodedVector>> decoders_;
-
-  // Holds the areas in RowContainer of 'table_'
-  memory::MappedMemory* mappedMemory_;
 
   // Future for synchronizing with other Drivers of the same pipeline. All build
   // Drivers must be completed before making the hash table.

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "velox/exec/HashPartitionFunction.h"
+#include "velox/exec/HashBitRange.h"
 #include "velox/exec/RowContainer.h"
 
 namespace facebook::velox::exec {

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   FunctionResolutionTest.cpp
   FunctionSignatureBuilderTest.cpp
   HashJoinTest.cpp
+  HashBitRangeTest.cpp
   HashPartitionFunctionTest.cpp
   HashTableTest.cpp
   LimitTest.cpp

--- a/velox/exec/tests/HashBitRangeTest.cpp
+++ b/velox/exec/tests/HashBitRangeTest.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/HashBitRange.h"
+#include "velox/vector/tests/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+class HashRangeBitTest : public test::VectorTestBase, public testing::Test {};
+
+TEST_F(HashRangeBitTest, hashBitRange) {
+  HashBitRange bitRange(29, 31);
+  EXPECT_EQ(29, bitRange.begin());
+  EXPECT_EQ(4, bitRange.numPartitions());
+  EXPECT_EQ(2, bitRange.numBits());
+  EXPECT_EQ(31, bitRange.end());
+
+  HashBitRange defaultRange;
+  EXPECT_EQ(0, defaultRange.begin());
+  EXPECT_EQ(1, defaultRange.numPartitions());
+  EXPECT_EQ(0, defaultRange.numBits());
+  EXPECT_EQ(0, defaultRange.end());
+}

--- a/velox/exec/tests/HashPartitionFunctionTest.cpp
+++ b/velox/exec/tests/HashPartitionFunctionTest.cpp
@@ -27,8 +27,7 @@ TEST_F(HashPartitionFunctionTest, HashPartitionFunction) {
   const int numRows = 10'000;
   RowVectorPtr vector = makeRowVector(
       {makeFlatVector<int32_t>(numRows, [](auto row) { return row * 100 / 3; }),
-       makeFlatVector<int32_t>(
-           numRows, [](auto row) { return row * 1274364; })});
+       makeFlatVector<int32_t>(numRows, [](auto row) { return row * 1024; })});
   RowTypePtr rowType = asRowType(vector->type());
 
   // The test case the two hash partition functions having the same config.
@@ -36,11 +35,13 @@ TEST_F(HashPartitionFunctionTest, HashPartitionFunction) {
     std::vector<uint32_t> partitonsWithoutBits(numRows);
     HashPartitionFunction functionWithoutBits(4, rowType, {0});
     functionWithoutBits.partition(*vector, partitonsWithoutBits);
+    EXPECT_EQ(4, functionWithoutBits.numPartitions());
 
     std::vector<uint32_t> partitonsWithBits(numRows);
     HashPartitionFunction functionWithBits(HashBitRange{0, 2}, rowType, {0});
     functionWithBits.partition(*vector, partitonsWithBits);
     EXPECT_EQ(partitonsWithoutBits, partitonsWithBits);
+    EXPECT_EQ(4, functionWithBits.numPartitions());
   }
 
   // The test case the two hash partition functions with different configs.
@@ -48,11 +49,13 @@ TEST_F(HashPartitionFunctionTest, HashPartitionFunction) {
     std::vector<uint32_t> partitonsWithoutBits(numRows);
     HashPartitionFunction functionWithoutBits(4, rowType, {0});
     functionWithoutBits.partition(*vector, partitonsWithoutBits);
+    EXPECT_EQ(4, functionWithoutBits.numPartitions());
 
     std::vector<uint32_t> partitonsWithBits(numRows);
     HashPartitionFunction functionWithBits(HashBitRange{0, 3}, rowType, {0});
     functionWithBits.partition(*vector, partitonsWithBits);
     EXPECT_NE(partitonsWithoutBits, partitonsWithBits);
+    EXPECT_EQ(8, functionWithBits.numPartitions());
   }
 
   // The test case the two hash partition functions with different configs.
@@ -60,11 +63,13 @@ TEST_F(HashPartitionFunctionTest, HashPartitionFunction) {
     std::vector<uint32_t> partitonsWithoutBits(numRows);
     HashPartitionFunction functionWithoutBits(4, rowType, {0});
     functionWithoutBits.partition(*vector, partitonsWithoutBits);
+    EXPECT_EQ(4, functionWithoutBits.numPartitions());
 
     std::vector<uint32_t> partitonsWithBits(numRows);
     HashPartitionFunction functionWithBits(HashBitRange{29, 31}, rowType, {0});
     functionWithBits.partition(*vector, partitonsWithBits);
     EXPECT_NE(partitonsWithoutBits, partitonsWithBits);
+    EXPECT_EQ(4, functionWithBits.numPartitions());
   }
 
   // The test case the two hash partition functions with different configs.
@@ -72,11 +77,13 @@ TEST_F(HashPartitionFunctionTest, HashPartitionFunction) {
     std::vector<uint32_t> partitonsWithBits1(numRows);
     HashPartitionFunction functionWithBits1(HashBitRange{40, 42}, rowType, {0});
     functionWithBits1.partition(*vector, partitonsWithBits1);
+    EXPECT_EQ(4, functionWithBits1.numPartitions());
 
     std::vector<uint32_t> partitonsWithBits2(numRows);
     HashPartitionFunction functionWithBits2(HashBitRange{29, 31}, rowType, {0});
     functionWithBits2.partition(*vector, partitonsWithBits2);
     EXPECT_NE(partitonsWithBits1, partitonsWithBits2);
+    EXPECT_EQ(4, functionWithBits2.numPartitions());
   }
 
   // The test case the two hash partition functions with different configs.
@@ -84,11 +91,13 @@ TEST_F(HashPartitionFunctionTest, HashPartitionFunction) {
     std::vector<uint32_t> partitonsWithBits1(numRows);
     HashPartitionFunction functionWithBits1(HashBitRange{20, 31}, rowType, {0});
     functionWithBits1.partition(*vector, partitonsWithBits1);
+    EXPECT_EQ(1 << 11, functionWithBits1.numPartitions());
 
     std::vector<uint32_t> partitonsWithBits2(numRows);
     HashPartitionFunction functionWithBits2(HashBitRange{29, 31}, rowType, {0});
     functionWithBits2.partition(*vector, partitonsWithBits2);
     EXPECT_NE(partitonsWithBits1, partitonsWithBits2);
+    EXPECT_EQ(4, functionWithBits2.numPartitions());
   }
 
   // The test case the two hash partition functions having the same config.
@@ -96,10 +105,12 @@ TEST_F(HashPartitionFunctionTest, HashPartitionFunction) {
     std::vector<uint32_t> partitonsWithBits1(numRows);
     HashPartitionFunction functionWithBits1(HashBitRange{29, 31}, rowType, {0});
     functionWithBits1.partition(*vector, partitonsWithBits1);
+    EXPECT_EQ(4, functionWithBits1.numPartitions());
 
     std::vector<uint32_t> partitonsWithBits2(numRows);
     HashPartitionFunction functionWithBits2(HashBitRange{29, 31}, rowType, {0});
     functionWithBits2.partition(*vector, partitonsWithBits2);
     EXPECT_EQ(partitonsWithBits1, partitonsWithBits2);
+    EXPECT_EQ(4, functionWithBits2.numPartitions());
   }
 }


### PR DESCRIPTION
- Add to expose some fields in hash function which will be used for recursive
  hash control later
- Refactor HashBuild a bit by putting hash table build logic into a separate function
  which will be reused in partition restore path