### PR TITLE
Parallelize Join Hash Table Build

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 #ifdef __BMI2__
 #include <x86intrin.h>
@@ -855,6 +856,24 @@ inline uint32_t rotateLeft(uint32_t a, int shift) {
 #else
   return (a << shift) | (a >> (32 - shift));
 #endif
+}
+
+/// Pads bytes starting at 'pointer + padIndex' up until the next
+/// offset from 'pointer' that is a multiple of 'alignment'. If
+/// 'padIndex' is 5 and alignment is 16, writes 11 zero bytes to
+/// [pointer + 5 ... pointer + 15 inclusive. Does not write past
+/// 'pointer' + 'size' in any case. Used to initialize memory that may
+/// be partly filled for use with valgring/asan.
+inline void padToAlignment(
+    void* pointer,
+    int32_t size,
+    int32_t padIndex,
+    int32_t alignment) {
+  auto roundEnd = std::min<int32_t>(size, bits::roundUp(padIndex, alignment));
+  if (roundEnd > padIndex) {
+    std::memset(
+        reinterpret_cast<char*>(pointer) + padIndex, 0, roundEnd - padIndex);
+  }
 }
 
 } // namespace bits

--- a/velox/common/base/tests/BitUtilTest.cpp
+++ b/velox/common/base/tests/BitUtilTest.cpp
@@ -687,6 +687,28 @@ TEST_F(BitUtilTest, crc) {
   EXPECT_EQ(boostCrc, follyCrc);
 }
 
+TEST_F(BitUtilTest, pad) {
+  char bytes[100];
+  memset(bytes, 1, sizeof(bytes));
+  bits::padToAlignment(&bytes[11], 30, 7, 16);
+  // We expect a 0 in bytes[11 +7] ... bytes[11 + 15].
+  EXPECT_EQ(1, bytes[11 + 6]);
+  for (auto i = 11 + 7; i < 11 + 16; ++i) {
+    EXPECT_EQ(0, bytes[i]);
+  }
+  EXPECT_EQ(1, bytes[11 + 16]);
+
+  // Test with end of data before next aligned address.
+  memset(bytes, 1, sizeof(bytes));
+  bits::padToAlignment(&bytes[11], 12, 7, 16);
+  // We expect a 0 in bytes[11 +7] ... bytes[11 + 12].
+  EXPECT_EQ(1, bytes[11 + 6]);
+  for (auto i = 11 + 7; i < 11 + 12; ++i) {
+    EXPECT_EQ(0, bytes[i]);
+  }
+  EXPECT_EQ(1, bytes[11 + 13]);
+}
+
 } // namespace bits
 } // namespace velox
 } // namespace facebook

--- a/velox/common/memory/MappedMemory.cpp
+++ b/velox/common/memory/MappedMemory.cpp
@@ -47,7 +47,7 @@ void MappedMemory::Allocation::append(uint8_t* address, int32_t numPages) {
 void MappedMemory::Allocation::findRun(
     uint64_t offset,
     int32_t* index,
-    int32_t* offsetInRun) {
+    int32_t* offsetInRun) const {
   uint64_t skipped = 0;
   for (int32_t i = 0; i < runs_.size(); ++i) {
     uint64_t size = runs_[i].numPages() * kPageSize;

--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -266,7 +266,7 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
     void findRun(
         uint64_t offset,
         int32_t* FOLLY_NONNULL index,
-        int32_t* FOLLY_NONNULL offsetInRun);
+        int32_t* FOLLY_NONNULL offsetInRun) const;
 
    private:
     MappedMemory* FOLLY_NONNULL mappedMemory_;

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -260,7 +260,10 @@ void HashBuild::noMoreInput() {
             operatorCtx_->driverCtx()->splitGroupId, planNodeId())
         ->setAntiJoinHasNullKeys();
   } else {
-    table_->prepareJoinTable(std::move(otherTables));
+    bool hasOthers = !otherTables.empty();
+    table_->prepareJoinTable(
+        std::move(otherTables),
+        hasOthers ? operatorCtx_->task()->queryCtx()->executor() : nullptr);
 
     addRuntimeStats();
 

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/HashTable.h"
+#include "velox/common/base/AsyncSource.h"
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/process/ProcessBase.h"
@@ -544,21 +545,31 @@ void HashTable<ignoreNullKeys>::checkSize(int32_t numNew) {
 }
 
 template <bool ignoreNullKeys>
-bool HashTable<ignoreNullKeys>::insertBatch(
-    char** groups,
-    int32_t numGroups,
+bool HashTable<ignoreNullKeys>::hashRows(
+    folly::Range<char**> rows,
+    bool initNormalizedKeys,
     raw_vector<uint64_t>& hashes) {
+  if (rows.empty()) {
+    return true;
+  }
+  if (!initNormalizedKeys && hashMode_ == HashMode::kNormalizedKey) {
+    for (auto i = 0; i < rows.size(); ++i) {
+      hashes[i] =
+          mixNormalizedKey(RowContainer::normalizedKey(rows[i]), sizeBits_);
+    }
+    return true;
+  }
+
   for (int32_t i = 0; i < hashers_.size(); ++i) {
     auto& hasher = hashers_[i];
     if (hashMode_ == HashMode::kHash) {
-      rows_->hash(
-          i, folly::Range<char**>(groups, numGroups), i > 0, hashes.data());
+      rows_->hash(i, rows, i > 0, hashes.data());
     } else {
       // Array or normalized key.
       auto column = rows_->columnAt(i);
       if (!hasher->computeValueIdsForRows(
-              groups,
-              numGroups,
+              rows.data(),
+              rows.size(),
               column.offset(),
               column.nullByte(),
               ignoreNullKeys ? 0 : column.nullMask(),
@@ -567,6 +578,188 @@ bool HashTable<ignoreNullKeys>::insertBatch(
         return false;
       }
     }
+  }
+  if (hashMode_ == HashMode::kNormalizedKey && initNormalizedKeys) {
+    for (auto i = 0; i < rows.size(); ++i) {
+      RowContainer::normalizedKey(rows[i]) = hashes[i];
+      hashes[i] = mixNormalizedKey(hashes[i], sizeBits_);
+    }
+  }
+  return true;
+}
+
+namespace {
+template <typename Source>
+void syncWorkItems(
+    std::vector<std::shared_ptr<Source>>& items,
+    std::exception_ptr& error,
+    bool log = false) {
+  // All items must be synced also in case of error because the items
+  // hold references to the table and rows which could be destructed
+  // if unwinding the stack did ont pause to sync.
+  for (auto& item : items) {
+    try {
+      item->move();
+    } catch (const std::exception& e) {
+      if (log) {
+        LOG(ERROR) << "Error in async hash build: " << e.what();
+      }
+      error = std::current_exception();
+    }
+  }
+}
+} // namespace
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::parallelJoinBuild() {
+  int32_t numPartitions = 1 + otherTables_.size();
+  VELOX_CHECK_GT(
+      size_ / numPartitions,
+      160,
+      "Less than 160 entries per partition for parallel build");
+  buildPartitionBounds_.resize(numPartitions + 1);
+  // Pad the tail of buildPartitionBounds_ to max int.
+  std::fill(
+      buildPartitionBounds_.begin(),
+      buildPartitionBounds_.begin() + buildPartitionBounds_.capacity(),
+      std::numeric_limits<int32_t>::max());
+  for (auto i = 0; i < numPartitions; ++i) {
+    // The bounds are rounded up to cache line size.
+    buildPartitionBounds_[i] = bits::roundUp(
+        (size_ / numPartitions) * i,
+        folly::hardware_destructive_interference_size);
+  }
+  buildPartitionBounds_.back() = size_;
+  std::vector<std::shared_ptr<AsyncSource<bool>>> partitionSteps;
+  std::vector<std::shared_ptr<AsyncSource<bool>>> buildSteps;
+  auto sync = folly::makeGuard([&]() {
+    // This is executed on returning path, possibly in unwinding, so must not
+    // throw.
+    std::exception_ptr error;
+    syncWorkItems(partitionSteps, error, true);
+    syncWorkItems(buildSteps, error, true);
+  });
+
+  for (auto i = 0; i < numPartitions; ++i) {
+    auto table = i == 0 ? this : otherTables_[i - 1].get();
+    partitionSteps.push_back(
+        std::make_shared<AsyncSource<bool>>([this, table, numPartitions]() {
+          partitionRows(*table, numPartitions);
+          return std::make_unique<bool>(true);
+        }));
+    buildExecutor_->add([step = partitionSteps.back()]() { step->prepare(); });
+  }
+  std::exception_ptr error;
+  syncWorkItems(partitionSteps, error);
+  if (error) {
+    std::rethrow_exception(error);
+  }
+  std::vector<std::vector<char*>> overflowPerPartition(numPartitions);
+  for (auto i = 0; i < numPartitions; ++i) {
+    buildSteps.push_back(
+        std::make_shared<AsyncSource<bool>>([i, &overflowPerPartition, this]() {
+          buildJoinPartition(i, overflowPerPartition[i]);
+          return std::make_unique<bool>(true);
+        }));
+    buildExecutor_->add([step = buildSteps.back()]() { step->prepare(); });
+  }
+  syncWorkItems(buildSteps, error);
+  if (error) {
+    std::rethrow_exception(error);
+  }
+  raw_vector<uint64_t> hashes;
+  for (auto i = 0; i < numPartitions; ++i) {
+    auto& overflows = overflowPerPartition[i];
+    hashes.resize(overflows.size());
+    hashRows(
+        folly::Range<char**>(overflows.data(), overflows.size()),
+        false,
+        hashes);
+    insertForJoin(
+        overflows.data(), hashes.data(), overflows.size(), 0, size_, nullptr);
+    auto table = i == 0 ? this : otherTables_[i - 1].get();
+    VELOX_CHECK_EQ(table->rows()->numRows(), table->numParallelBuildRows_);
+  }
+}
+
+namespace {
+// Returns an index into 'buildPartitionBounds_' given an index into tags of the
+// HashTable.
+int32_t
+findPartition(int32_t index, const int32_t* bounds, int32_t numPartitions) {
+  // The partition bounds are padded to batch size.
+  constexpr int32_t kBatch = xsimd::batch<int32_t>::size;
+  auto indexVector = xsimd::batch<int32_t>::broadcast(index);
+  for (auto i = 1; i < numPartitions; i += kBatch) {
+    uint8_t bits = simd::toBitMask(
+        indexVector < xsimd::batch<int32_t>::load_unaligned(bounds + i));
+    if (bits) {
+      return i + __builtin_ctz(bits) - 1;
+    }
+  }
+  VELOX_UNREACHABLE("Partition index out of range");
+}
+} // namespace
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::partitionRows(
+    HashTable<ignoreNullKeys>& subtable,
+    uint8_t numPartitions) {
+  constexpr int32_t kBatch = 1024;
+  raw_vector<char*> rows(kBatch);
+  raw_vector<uint64_t> hashes(kBatch);
+  raw_vector<uint8_t> partitions(kBatch);
+  RowContainerIterator iter;
+  while (auto numRows = subtable.rows_->listRows(
+             &iter, kBatch, RowContainer::kUnlimited, rows.data())) {
+    hashRows(folly::Range<char**>(rows.data(), numRows), true, hashes);
+    VELOX_DCHECK_EQ(
+        0,
+        buildPartitionBounds_.capacity() % xsimd::batch<int32_t>::size,
+        "partition bounds must be padded to SIMD width");
+    for (auto i = 0; i < numRows; ++i) {
+      auto index = ProbeState::tagsByteOffset(hashes[i], sizeMask_);
+      partitions[i] = findPartition(
+          index, buildPartitionBounds_.data(), buildPartitionBounds_.size());
+    }
+    subtable.rows_->partitions().appendPartitions(
+        folly::Range<const uint8_t*>(partitions.data(), numRows));
+  }
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::buildJoinPartition(
+    uint8_t partition,
+    std::vector<char*>& overflow) {
+  constexpr int32_t kBatch = 1024;
+  raw_vector<char*> rows(kBatch);
+  raw_vector<uint64_t> hashes(kBatch);
+  int32_t numPartitions = 1 + otherTables_.size();
+  for (auto i = 0; i < numPartitions; ++i) {
+    auto table = i == 0 ? this : otherTables_[i - 1].get();
+    RowContainerIterator iter;
+    while (auto numRows = table->rows_->listPartitionRows(
+               iter, partition, kBatch, rows.data())) {
+      hashRows(folly::Range(rows.data(), numRows), false, hashes);
+      insertForJoin(
+          rows.data(),
+          hashes.data(),
+          numRows,
+          buildPartitionBounds_[partition],
+          buildPartitionBounds_[partition + 1],
+          &overflow);
+      table->numParallelBuildRows_ += numRows;
+    }
+  }
+}
+
+template <bool ignoreNullKeys>
+bool HashTable<ignoreNullKeys>::insertBatch(
+    char** groups,
+    int32_t numGroups,
+    raw_vector<uint64_t>& hashes) {
+  if (!hashRows(folly::Range(groups, numGroups), true, hashes)) {
+    return false;
   }
   if (isJoinBuild_) {
     insertForJoin(groups, hashes.data(), numGroups);
@@ -589,15 +782,6 @@ void HashTable<ignoreNullKeys>::insertForGroupBy(
       table_[index] = groups[i];
     }
   } else {
-    if (hashMode_ == HashMode::kNormalizedKey) {
-      for (int i = 0; i < numGroups; ++i) {
-        auto hash = hashes[i];
-        // Write the normalized key below the row.
-        RowContainer::normalizedKey(groups[i]) = hash;
-        // Shuffle the bits im the normalized key.
-        hashes[i] = mixNormalizedKey(hash, sizeBits_);
-      }
-    }
     for (int32_t i = 0; i < numGroups; ++i) {
       auto hash = hashes[i];
       auto tagIndex = ProbeState::tagsByteOffset(hash, sizeMask_);
@@ -650,7 +834,10 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
     ProbeState& state,
     uint64_t hash,
     char* inserted,
-    bool extraCheck) {
+    bool extraCheck,
+    int32_t partitionBegin,
+    int32_t partitionEnd,
+    std::vector<char*>* FOLLY_NULLABLE overflows) {
   if (hashMode_ == HashMode::kNormalizedKey) {
     state.fullProbe<ProbeState::Operation::kInsert>(
         tags_,
@@ -668,6 +855,10 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
           return false;
         },
         [&](int32_t /*row*/, int32_t index) {
+          if (index < partitionBegin || index > partitionEnd) {
+            overflows->push_back(inserted);
+            return nullptr;
+          }
           storeRowPointer(index, hash, inserted);
           return nullptr;
         },
@@ -688,6 +879,10 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
           return false;
         },
         [&](int32_t /*row*/, int32_t index) {
+          if (index < partitionBegin || index > partitionEnd) {
+            overflows->push_back(inserted);
+            return nullptr;
+          }
           storeRowPointer(index, hash, inserted);
           return nullptr;
         },
@@ -699,7 +894,10 @@ template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::insertForJoin(
     char** groups,
     uint64_t* hashes,
-    int32_t numGroups) {
+    int32_t numGroups,
+    int32_t partitionBegin,
+    int32_t partitionEnd,
+    std::vector<char*>* overflow) {
   // The insertable rows are in the table, all get put in the hash
   // table or array.
   if (hashMode_ == HashMode::kArray) {
@@ -711,21 +909,18 @@ void HashTable<ignoreNullKeys>::insertForJoin(
     return;
   }
 
-  if (hashMode_ == HashMode::kNormalizedKey) {
-    // Write the normalized key below each row. The key is only known
-    // at the time of insert, so cannot be filled in at the time of
-    // accumulating the build rows.
-    for (auto i = 0; i < numGroups; ++i) {
-      RowContainer::normalizedKey(groups[i]) = hashes[i];
-      hashes[i] = mixNormalizedKey(hashes[i], sizeBits_);
-    }
-  }
-
   ProbeState state1;
   for (auto i = 0; i < numGroups; ++i) {
     state1.preProbe(tags_, sizeMask_, hashes[i], i);
     state1.firstProbe(table_, 0);
-    buildFullProbe(state1, hashes[i], groups[i], i);
+    buildFullProbe(
+        state1,
+        hashes[i],
+        groups[i],
+        i,
+        partitionBegin,
+        partitionEnd,
+        overflow);
   }
 }
 
@@ -733,6 +928,11 @@ template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::rehash() {
   constexpr int32_t kHashBatchSize = 1024;
   // @lint-ignore CLANGTIDY
+  if (buildExecutor_ && hashMode_ != HashMode::kArray &&
+      !otherTables_.empty() && size_ / (1 + otherTables_.size()) > 1000) {
+    parallelJoinBuild();
+    return;
+  }
   raw_vector<uint64_t> hashes;
   hashes.resize(kHashBatchSize);
   char* groups[kHashBatchSize];
@@ -1027,7 +1227,9 @@ bool mayUseValueIds(const BaseHashTable& table) {
 
 template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::prepareJoinTable(
-    std::vector<std::unique_ptr<BaseHashTable>> tables) {
+    std::vector<std::unique_ptr<BaseHashTable>> tables,
+    folly::Executor* FOLLY_NULLABLE executor) {
+  buildExecutor_ = executor;
   otherTables_.reserve(tables.size());
   for (auto& table : tables) {
     otherTables_.emplace_back(std::unique_ptr<HashTable<ignoreNullKeys>>(

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -141,7 +141,8 @@ class BaseHashTable {
       char** rows) = 0;
 
   virtual void prepareJoinTable(
-      std::vector<std::unique_ptr<BaseHashTable>> tables) = 0;
+      std::vector<std::unique_ptr<BaseHashTable>> tables,
+      folly::Executor* FOLLY_NULLABLE executor = nullptr) = 0;
 
   /// Returns the memory footprint in bytes for any data structures
   /// owned by 'this'.
@@ -348,7 +349,8 @@ class HashTable : public BaseHashTable {
   // with prepareJoinTable. This then takes ownership of all the data
   // and VectorHashers and decides the hash mode and representation.
   void prepareJoinTable(
-      std::vector<std::unique_ptr<BaseHashTable>> tables) override;
+      std::vector<std::unique_ptr<BaseHashTable>> tables,
+      folly::Executor* FOLLY_NULLABLE executor = nullptr) override;
 
   uint64_t hashTableSizeIncrease(int32_t numNewDistinct) const override {
     if (numDistinct_ + numNewDistinct > rehashSize()) {
@@ -416,17 +418,59 @@ class HashTable : public BaseHashTable {
   insertBatch(char** groups, int32_t numGroups, raw_vector<uint64_t>& hashes);
 
   // Inserts 'numGroups' entries into 'this'. 'groups' point to
-  // contents in a RowContainer owned by 'this'. 'hashes' are te hash
+  // contents in a RowContainer owned by 'this'. 'hashes' are the hash
   // numbers or array indices (if kArray mode) for each
-  // group. Duplicate key rows are chained via their next link.
-  void insertForJoin(char** groups, uint64_t* hashes, int32_t numGroups);
+  // group. Duplicate key rows are chained via their next link. if
+  // parallel build, partitionEnd is the index of the first entry
+  // after the partition being inserted. If a row would be inserted to
+  // the right of the end, it is not inserted but rather added to the
+  // end of 'overflows'.
+  void insertForJoin(
+      char** groups,
+      uint64_t* hashes,
+      int32_t numGroups,
+      int32_t partitionBegin = 0,
+      int32_t partitionEnd = std::numeric_limits<int32_t>::max(),
+      std::vector<char*>* FOLLY_NULLABLE overflows = nullptr);
 
   // Inserts 'numGroups' entries into 'this'. 'groups' point to
-  // contents in a RowContainer owned by 'this'. 'hashes' are te hash
+  // contents in a RowContainer owned by 'this'. 'hashes' are the hash
   // numbers or array indices (if kArray mode) for each
-  // group. 'groups' is expectedd to have no duplicate keys.
-
+  // group. 'groups' is expected to have no duplicate keys.
   void insertForGroupBy(char** groups, uint64_t* hashes, int32_t numGroups);
+
+  // Builds a join table with '1 + otherTables_.size()' independent
+  // threads using 'executor_'. First all RowContainers get partition
+  // numbers assigned to each row. Next, all threads pick all rows
+  // assigned to their thread-specific partition and insert these. If
+  // a row would overflow past the end of its partition it is added to
+  // a set of overflow rows that are sequentially inserted after all
+  // else.
+  void parallelJoinBuild();
+
+  // Inserts the rows in 'partition' from this and 'otherTables' into 'this'.
+  // The rows that would have gone past the end of the partition are returned in
+  // 'overflow'.
+  void buildJoinPartition(uint8_t partition, std::vector<char*>& overflow);
+
+  // Assigns a partition to each row of 'subtable' in RowPartitions of
+  // subtable's RowContainer. If 'hashMode_' is kNormalizedKeys, records the
+  // normalized key of each row below the row in its container.
+  void partitionRows(
+      HashTable<ignoreNullKeys>& subtable,
+      uint8_t numPartitions);
+
+  // Calculates hashes for 'rows' and returns them in 'hashes'. If
+  // 'initNormalizedKeys' is true, the normalized keys are stored
+  // below each row in the container. If 'initNormalizedKeys' is false
+  // and the table is in normalized keys mode, the keys are retrieved
+  // from the row and the hash is made from this, without recomputing
+  // the normalized key. Returns false if the hash keys are not mappable via the
+  // VectorHashers.
+  bool hashRows(
+      folly::Range<char**> rows,
+      bool initNormalizedKeys,
+      raw_vector<uint64_t>& hashes);
 
   char* insertEntry(HashLookup& lookup, int32_t index, vector_size_t row);
 
@@ -446,9 +490,17 @@ class HashTable : public BaseHashTable {
   // with the same key.
   void pushNext(char* row, char* next);
 
-  // Finishes inserting an entry into a join hash table.
-  void
-  buildFullProbe(ProbeState& state, uint64_t hash, char* row, bool extraCheck);
+  // Finishes inserting an entry into a join hash table. If the insert
+  // would fall outside of 'partitionBegin' ... 'partitionEnd', the
+  // insert is not made but the row is instead added to 'overflow'.
+  void buildFullProbe(
+      ProbeState& state,
+      uint64_t hash,
+      char* row,
+      bool extraCheck,
+      int32_t partitionBegin,
+      int32_t partitionEnd,
+      std::vector<char*>* FOLLY_NULLABLE overflows);
 
   // Updates 'hashers_' to correspond to the keys in the
   // content. Returns true if all hashers offer a mapping to value ids
@@ -485,6 +537,20 @@ class HashTable : public BaseHashTable {
   // Owns the memory of multiple build side hash join tables that are
   // combined into a single probe hash table.
   std::vector<std::unique_ptr<HashTable<ignoreNullKeys>>> otherTables_;
+
+  // Bounds of independently buildable index ranges in the table. The
+  // range of partition i starts at [i] and ends at [i +1]. Bounds are multiple
+  // of cache line  size.
+  raw_vector<int32_t> buildPartitionBounds_;
+
+  // Executor for parallelizing hash join build. This may be the
+  // executor for Drivers. If this executor is indefinitely taken by
+  // other work, the thread of prepareJoinTables() will sequentially
+  // execute the parallel build steps.
+  folly::Executor* FOLLY_NULLABLE buildExecutor_{nullptr};
+
+  //  Counts parallel build rows. Used for consistency check.
+  std::atomic<int64_t> numParallelBuildRows_{0};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -181,6 +181,8 @@ RowContainer::RowContainer(
 
 char* RowContainer::newRow() {
   char* row;
+  VELOX_DCHECK(
+      !partitions_, "Rows may not be added after partitions() has been called");
   ++numRows_;
   if (firstFreeRow_) {
     row = firstFreeRow_;
@@ -543,6 +545,179 @@ int64_t RowContainer::sizeIncrement(
       std::min<int64_t>(0, variableLengthBytes - stringAllocator_.freeSpace());
   return bits::roundUp(needRows * fixedRowSize_, kAllocUnit) +
       bits::roundUp(needBytes, kAllocUnit);
+}
+
+void RowContainer::skip(RowContainerIterator& iter, int32_t numRows) {
+  VELOX_DCHECK_LE(0, numRows);
+  if (!iter.endOfRun) {
+    // Set to first row.
+    VELOX_DCHECK_EQ(0, iter.rowNumber);
+    VELOX_DCHECK_EQ(0, iter.allocationIndex);
+    iter.normalizedKeysLeft = numRowsWithNormalizedKey_;
+    auto run = rows_.allocationAt(0)->runAt(0);
+    iter.rowBegin = run.data<char>();
+    iter.endOfRun = iter.rowBegin + run.numBytes();
+  }
+  if (iter.rowNumber + numRows >= numRows_) {
+    iter.rowNumber = numRows_;
+    iter.rowBegin = nullptr;
+    return;
+  }
+  int32_t rowSize = fixedRowSize_ +
+      (iter.normalizedKeysLeft > 0 ? sizeof(normalized_key_t) : 0);
+  auto toSkip = numRows;
+  if (iter.normalizedKeysLeft && iter.normalizedKeysLeft < numRows) {
+    toSkip -= iter.normalizedKeysLeft;
+    skip(iter, iter.normalizedKeysLeft);
+    rowSize = fixedRowSize_;
+  }
+  while (toSkip) {
+    if (iter.rowBegin &&
+        toSkip * rowSize <= (iter.endOfRun - iter.rowBegin) - rowSize) {
+      iter.rowBegin += toSkip * rowSize;
+      break;
+    }
+    int32_t rowsInRun = (iter.endOfRun - iter.rowBegin) / rowSize;
+    toSkip -= rowsInRun;
+    auto numRuns = rows_.allocationAt(iter.allocationIndex)->numRuns();
+    if (iter.runIndex >= numRuns - 1) {
+      ++iter.allocationIndex;
+      iter.runIndex = 0;
+    } else {
+      ++iter.runIndex;
+    }
+    auto run = rows_.allocationAt(iter.allocationIndex)->runAt(iter.runIndex);
+    if (iter.allocationIndex == rows_.numSmallAllocations() - 1 &&
+        iter.runIndex ==
+            rows_.allocationAt(iter.allocationIndex)->numRuns() - 1) {
+      iter.endOfRun = run.data<char>() + rows_.currentOffset();
+    } else {
+      iter.endOfRun = run.data<char>() + run.numBytes();
+    }
+    iter.rowBegin = run.data<char>();
+  }
+  if (iter.normalizedKeysLeft) {
+    iter.normalizedKeysLeft -= numRows;
+  }
+  iter.rowNumber += numRows;
+}
+
+RowPartitions& RowContainer::partitions() {
+  if (!partitions_) {
+    partitions_ =
+        std::make_unique<RowPartitions>(numRows_, *rows_.mappedMemory());
+  }
+  return *partitions_;
+}
+
+int32_t RowContainer::listPartitionRows(
+    RowContainerIterator& iter,
+    uint8_t partition,
+    int32_t maxRows,
+    char** result) {
+  if (!numRows_) {
+    return 0;
+  }
+  VELOX_CHECK(
+      partitions_, "partitions() must be called before listPartitionRows()");
+  VELOX_CHECK_EQ(
+      partitions_->size(), numRows_, "All rows must have a partition");
+  auto partitionNumberVector = xsimd::batch<uint8_t>::broadcast(partition);
+  auto& allocation = partitions_->allocation();
+  auto numRuns = allocation.numRuns();
+  int32_t numResults = 0;
+  while (numResults < maxRows && iter.rowNumber < numRows_) {
+    constexpr int32_t kBatch = xsimd::batch<uint8_t>::size;
+    // Start at multiple of kBatch.
+    auto startRow = iter.rowNumber / kBatch * kBatch;
+    // Ignore the possible hits at or below iter.rowNumber.
+    uint32_t firstBatchMask = ~bits::lowMask(iter.rowNumber - startRow);
+    int32_t runIndex;
+    int32_t offsetInRun;
+    VELOX_CHECK_LT(startRow, numRows_);
+    allocation.findRun(startRow, &runIndex, &offsetInRun);
+    auto run = allocation.runAt(runIndex);
+    auto runEnd = run.numBytes();
+    auto runBytes = run.data<uint8_t>();
+    for (; offsetInRun < runEnd; offsetInRun += kBatch) {
+      auto bits =
+          simd::toBitMask(
+              partitionNumberVector ==
+              xsimd::batch<uint8_t>::load_unaligned(runBytes + offsetInRun)) &
+          firstBatchMask;
+      firstBatchMask = ~0;
+      bool atEnd = false;
+      if (startRow + kBatch >= numRows_) {
+        // Clear bits that are for rows past numRows_ - 1.
+        bits &= bits::lowMask(numRows_ - startRow);
+        atEnd = true;
+      }
+      while (bits) {
+        int32_t hit = __builtin_ctz(bits);
+        auto distance = hit + startRow - iter.rowNumber;
+        skip(iter, distance);
+        result[numResults++] = iter.currentRow();
+        if (numResults == maxRows) {
+          skip(iter, 1);
+          return numResults;
+        }
+        // Clear last set bit in 'bits'.
+        bits &= bits - 1;
+      }
+      startRow += kBatch;
+      // The last batch of 32 bytes may have been partly filled. If so, we could
+      // have skipped past end.
+      if (atEnd) {
+        iter.rowNumber = numRows_;
+        return numResults;
+      }
+
+      if (iter.rowNumber != startRow) {
+        skip(iter, startRow - iter.rowNumber);
+      }
+    }
+  }
+  return numResults;
+}
+
+RowPartitions::RowPartitions(
+    int32_t numRows,
+    memory::MappedMemory& mappedMemory)
+    : capacity_(numRows), allocation_(&mappedMemory) {
+  auto numPages = bits::roundUp(capacity_, memory::MappedMemory::kPageSize) /
+      memory::MappedMemory::kPageSize;
+  if (!mappedMemory.allocate(numPages, 0, allocation_)) {
+    VELOX_FAIL(
+        "Failed to allocate RowContainer partitions: {} pages", numPages);
+  }
+}
+
+void RowPartitions::appendPartitions(folly::Range<const uint8_t*> partitions) {
+  int32_t toAdd = partitions.size();
+  int index = 0;
+  VELOX_CHECK_LE(size_ + toAdd, capacity_);
+  while (toAdd) {
+    int32_t run;
+    int32_t offset;
+    allocation_.findRun(size_, &run, &offset);
+    auto runSize = allocation_.runAt(run).numBytes();
+    auto copySize = std::min<int32_t>(toAdd, runSize - offset);
+    memcpy(
+        allocation_.runAt(run).data<uint8_t>() + offset,
+        &partitions[index],
+        copySize);
+    size_ += copySize;
+    index += copySize;
+    toAdd -= copySize;
+    // Zero out to the next multiple of SIMD width for asan/valgring.
+    if (!toAdd) {
+      bits::padToAlignment(
+          allocation_.runAt(run).data<uint8_t>(),
+          runSize,
+          offset + copySize,
+          xsimd::batch<uint8_t>::size);
+    }
+  }
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -34,12 +34,59 @@ struct RowContainerIterator {
   // normalized key. Set in listRows() on first call.
   int64_t normalizedKeysLeft = 0;
 
+  // Ordinal position of 'currentRow' in RowContainer.
+  int32_t rowNumber{0};
+  char* FOLLY_NULLABLE rowBegin{nullptr};
+  // First byte after the end of the PageRun containing 'currentRow'.
+  char* FOLLY_NULLABLE endOfRun{nullptr};
+
+  // Returns the current row, skipping a possible normalized key below the first
+  // byte of row.
+  inline char* FOLLY_NULLABLE currentRow() const {
+    return (rowBegin && normalizedKeysLeft)
+        ? rowBegin + sizeof(normalized_key_t)
+        : rowBegin;
+  }
+
   void reset() {
     allocationIndex = 0;
     runIndex = 0;
     rowOffset = 0;
     normalizedKeysLeft = 0;
+    rowBegin = nullptr;
+    rowNumber = 0;
+    endOfRun = nullptr;
   }
+};
+
+/// Container with a 8-bit partition number field for each row in a
+/// RowContainer. The partition number bytes correspond 1:1 to rows. Used only
+/// for parallel hash join build.
+class RowPartitions {
+ public:
+  /// Initializes this to hold up to 'numRows'.
+  RowPartitions(int32_t numRows, memory::MappedMemory& mappedMemory);
+
+  /// Appends 'partitions' to the end of 'this'. Throws if adding more than the
+  /// capacity given at construction.
+  void appendPartitions(folly::Range<const uint8_t*> partitions);
+
+  auto& allocation() const {
+    return allocation_;
+  }
+
+  int32_t size() const {
+    return size_;
+  }
+
+ private:
+  const int32_t capacity_;
+
+  // Number of partition numbers added.
+  int32_t size_{0};
+
+  // Partition numbers. 1 byte each.
+  memory::MappedMemory::Allocation allocation_;
 };
 
 // Packed representation of offset, null byte offset and null mask for
@@ -473,6 +520,26 @@ class RowContainer {
     return (row[nullByte] & nullMask) != 0;
   }
 
+  /// Retrieves rows from 'iterator' whose partition equals
+  /// 'partition'. Writes up to 'maxRows' pointers to the rows in
+  /// 'result'. Returns the number of rows retrieved, 0 when no more
+  /// rows are found. 'iterator' is expected to be in initial state
+  /// on first call.
+  int32_t listPartitionRows(
+      RowContainerIterator& iterator,
+      uint8_t partition,
+      int32_t maxRows,
+      char* FOLLY_NONNULL* FOLLY_NONNULL result);
+
+  /// Returns a container with a partition number for each row. This
+  /// is created on first use. The caller is responsible for filling
+  /// this.
+  RowPartitions& partitions();
+
+  /// Advances 'iterator' by 'numRows'. The current row after skip is
+  /// in iter.currentRow(). This is null if past end. Public for testing.
+  void skip(RowContainerIterator& iterator, int32_t numRows);
+
  private:
   // Offset of the pointer to the next free row on a free row.
   static constexpr int32_t kNextFreeOffset = 0;
@@ -834,6 +901,9 @@ class RowContainer {
 
   AllocationPool rows_;
   HashStringAllocator stringAllocator_;
+
+  // Partition number for each row. Used only in parallel hash join build.
+  std::unique_ptr<RowPartitions> partitions_;
 
   const RowSerde& serde_;
   // RowContainer requires a valid reference to a vector of aggregates. We use

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -16,9 +16,11 @@
 
 #include "velox/exec/HashTable.h"
 #include "velox/common/base/SelectivityInfo.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/VectorHasher.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <gtest/gtest.h>
 #include <memory>
 
@@ -33,8 +35,14 @@ using namespace facebook::velox::test;
 // measures the time for computing hashes/value ids vs the time spent
 // probing the table. Covers kArray, kNormalizedKey and kHash hash
 // modes.
-class HashTableTest : public testing::Test {
+class HashTableTest : public testing::TestWithParam<bool> {
  protected:
+  void SetUp() override {
+    if (GetParam()) {
+      executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(16);
+    }
+  }
+
   void testCycle(
       BaseHashTable::HashMode mode,
       int32_t size,
@@ -81,7 +89,7 @@ class HashTableTest : public testing::Test {
       batches_.insert(batches_.end(), batches.begin(), batches.end());
       startOffset += size;
     }
-    topTable_->prepareJoinTable(std::move(otherTables));
+    topTable_->prepareJoinTable(std::move(otherTables), executor_.get());
     EXPECT_EQ(topTable_->hashMode(), mode);
     LOG(INFO) << "Made table " << describeTable();
     testProbe();
@@ -444,60 +452,61 @@ class HashTableTest : public testing::Test {
   int32_t insertPct_ = 100;
   // Spacing between consecutive generated keys. Affects whether
   // Vectorhashers make ranges or ids of distinct values.
-  int32_t keySpacing_ = 1;
+  int64_t keySpacing_ = 1;
+  std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
 };
 
-TEST_F(HashTableTest, int2DenseArray) {
+TEST_P(HashTableTest, int2DenseArray) {
   auto type = ROW({"k1", "k2"}, {BIGINT(), BIGINT()});
   testCycle(BaseHashTable::HashMode::kArray, 500, 2, type, 2);
 }
 
-TEST_F(HashTableTest, string1DenseArray) {
+TEST_P(HashTableTest, string1DenseArray) {
   auto type = ROW({"k1"}, {VARCHAR()});
   testCycle(BaseHashTable::HashMode::kArray, 500, 2, type, 1);
 }
 
-TEST_F(HashTableTest, string2Normalized) {
+TEST_P(HashTableTest, string2Normalized) {
   auto type = ROW({"k1", "k2"}, {VARCHAR(), VARCHAR()});
-  testCycle(BaseHashTable::HashMode::kNormalizedKey, 50000, 2, type, 2);
+  testCycle(BaseHashTable::HashMode::kNormalizedKey, 5000, 19, type, 2);
 }
 
-TEST_F(HashTableTest, int2SparseArray) {
+TEST_P(HashTableTest, int2SparseArray) {
   auto type = ROW({"k1", "k2"}, {BIGINT(), BIGINT()});
   keySpacing_ = 1000;
   testCycle(BaseHashTable::HashMode::kArray, 500, 2, type, 2);
 }
 
-TEST_F(HashTableTest, int2SparseNormalized) {
+TEST_P(HashTableTest, int2SparseNormalized) {
   auto type = ROW({"k1", "k2"}, {BIGINT(), BIGINT()});
   keySpacing_ = 1000;
   testCycle(BaseHashTable::HashMode::kNormalizedKey, 10000, 2, type, 2);
 }
 
-TEST_F(HashTableTest, int2SparseNormalizedMostMiss) {
+TEST_P(HashTableTest, int2SparseNormalizedMostMiss) {
   auto type = ROW({"k1", "k2"}, {BIGINT(), BIGINT()});
   keySpacing_ = 1000;
   insertPct_ = 10;
   testCycle(BaseHashTable::HashMode::kNormalizedKey, 100000, 2, type, 2);
 }
 
-TEST_F(HashTableTest, structKey) {
+TEST_P(HashTableTest, structKey) {
   auto type =
       ROW({"key"}, {ROW({"k1", "k2", "k3"}, {BIGINT(), VARCHAR(), BIGINT()})});
   keySpacing_ = 1000;
   testCycle(BaseHashTable::HashMode::kHash, 100000, 2, type, 1);
 }
 
-TEST_F(HashTableTest, mixed6Sparse) {
+TEST_P(HashTableTest, mixed6Sparse) {
   auto type =
       ROW({"k1", "k2", "k3", "k4", "k5", "k6"},
           {BIGINT(), BIGINT(), BIGINT(), BIGINT(), BIGINT(), VARCHAR()});
   keySpacing_ = 1000;
-  testCycle(BaseHashTable::HashMode::kHash, 1000000, 2, type, 6);
+  testCycle(BaseHashTable::HashMode::kHash, 1000000, 5, type, 6);
 }
 
 // It should be safe to call clear() before we insert any data into HashTable
-TEST_F(HashTableTest, clear) {
+TEST_P(HashTableTest, clear) {
   std::vector<std::unique_ptr<VectorHasher>> keyHashers;
   keyHashers.push_back(std::make_unique<VectorHasher>(BIGINT(), 0 /*channel*/));
   std::vector<std::unique_ptr<Aggregate>> aggregates;
@@ -513,7 +522,7 @@ TEST_F(HashTableTest, clear) {
 
 /// Test edge case that used to trigger a rounding error in
 /// HashTable::enableRangeWhereCan.
-TEST_F(HashTableTest, enableRangeWhereCan) {
+TEST_P(HashTableTest, enableRangeWhereCan) {
   auto rowType = ROW({"a", "b", "c"}, {BIGINT(), VARCHAR(), VARCHAR()});
   auto table = createHashTableForAggregation(rowType, 3);
   auto lookup = std::make_unique<HashLookup>(table->hashers());
@@ -553,7 +562,7 @@ TEST_F(HashTableTest, enableRangeWhereCan) {
   insertGroups(*data, *lookup, *table);
 }
 
-TEST_F(HashTableTest, arrayProbeNormalizedKey) {
+TEST_P(HashTableTest, arrayProbeNormalizedKey) {
   auto table = createHashTableForAggregation(ROW({"a"}, {BIGINT()}), 1);
   auto lookup = std::make_unique<HashLookup>(table->hashers());
 
@@ -575,3 +584,8 @@ TEST_F(HashTableTest, arrayProbeNormalizedKey) {
 
   ASSERT_TRUE(table->hashMode() == BaseHashTable::HashMode::kNormalizedKey);
 }
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    HashTableTests,
+    HashTableTest,
+    testing::Values(true, false));

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -81,26 +81,27 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     EXPECT_EQ(usage, sum);
   }
 
-  // Stores the input vector in Row Container, extracts it and compares.
-  void roundTrip(const VectorPtr& input) {
+  // Stores the input vector in Row Container, extracts it and compares. Returns
+  // the container.
+  std::unique_ptr<RowContainer> roundTrip(const VectorPtr& input) {
     // Create row container.
     std::vector<TypePtr> types{input->type()};
-    auto data = makeRowContainer(types, std::vector<TypePtr>{});
 
     // Store the vector in the rowContainer.
-    RowContainer rowContainer(types, mappedMemory_);
+    auto rowContainer = std::make_unique<RowContainer>(types, mappedMemory_);
     auto size = input->size();
     SelectivityVector allRows(size);
     std::vector<char*> rows(size);
     DecodedVector decoded(*input, allRows);
     for (size_t row = 0; row < size; ++row) {
-      rows[row] = rowContainer.newRow();
-      rowContainer.store(decoded, row, rows[row], 0);
+      rows[row] = rowContainer->newRow();
+      rowContainer->store(decoded, row, rows[row], 0);
     }
 
-    testExtractColumnForAllRows(rowContainer, rows, 0, input);
+    testExtractColumnForAllRows(*rowContainer, rows, 0, input);
 
-    testExtractColumnForOddRows(rowContainer, rows, 0, input);
+    testExtractColumnForOddRows(*rowContainer, rows, 0, input);
+    return rowContainer;
   }
 
   template <typename T>
@@ -554,4 +555,64 @@ TEST_F(RowContainerTest, compareDouble) {
   // Verify descending order
   testCompareFloats<double>(DOUBLE(), false, true);
   testCompareFloats<double>(DOUBLE(), false, false);
+}
+
+TEST_F(RowContainerTest, partition) {
+  // We assign an arbitrary partition number to each row and iterate
+  // over the rows a partition at a time.
+  constexpr int32_t kNumRows = 100019;
+  constexpr uint8_t kNumPartitions = 16;
+  auto batch = makeDataset(
+      ROW(
+          {{"int_val", INTEGER()},
+           {"long_val", BIGINT()},
+           {"string_val", VARCHAR()}}),
+      kNumRows,
+      [](RowVectorPtr rows) {});
+
+  auto data = roundTrip(batch);
+  std::vector<char*> rows(kNumRows);
+  RowContainerIterator iter;
+  data->listRows(&iter, kNumRows, RowContainer::kUnlimited, rows.data());
+
+  // Test random skipping of RowContainerIterator.
+  for (auto count = 0; count < 100; ++count) {
+    auto index = (count * 121) % kNumRows;
+    iter.reset();
+    data->skip(iter, index);
+    EXPECT_EQ(iter.currentRow(), rows[index]);
+    if (index + count < kNumRows) {
+      data->skip(iter, count);
+      EXPECT_EQ(iter.currentRow(), rows[index + count]);
+    }
+  }
+
+  auto& partitions = data->partitions();
+  std::vector<uint8_t> rowPartitions(kNumRows);
+  // Assign a partition to each row based on  modulo of first column.
+  std::vector<std::vector<char*>> partitionRows(kNumPartitions);
+  auto column = batch->childAt(0)->as<FlatVector<int32_t>>();
+  for (auto i = 0; i < kNumRows; ++i) {
+    uint8_t partition =
+        static_cast<uint32_t>(column->valueAt(i)) % kNumPartitions;
+    rowPartitions[i] = partition;
+    partitionRows[partition].push_back(rows[i]);
+  }
+  partitions.appendPartitions(
+      folly::Range<const uint8_t*>(rowPartitions.data(), kNumRows));
+  for (auto partition = 0; partition < kNumPartitions; ++partition) {
+    std::vector<char*> result(partitionRows[partition].size() + 10);
+    iter.reset();
+    int32_t numFound = 0;
+    int32_t resultBatch = 1;
+    // Read the rows in multiple batches.
+    while (auto numResults = data->listPartitionRows(
+               iter, partition, resultBatch, result.data() + numFound)) {
+      numFound += numResults;
+      resultBatch += 13;
+    }
+    EXPECT_EQ(numFound, partitionRows[partition].size());
+    result.resize(numFound);
+    EXPECT_EQ(partitionRows[partition], result);
+  }
 }


### PR DESCRIPTION
The majority of wall time in some TPC-H queries is taken by single threaded hash join build.
We parallelize hash join build as follows:

Compute a partition for each row to insert. The partition is a range
of hash table tag groups. The partition of each row is kept in a
RowPartitions object in RowContainer.

Build the hash table one thread per partition. Each thread reads all
the partition bytes and picks the rows for which the partition matches
the thread. This is fast because all the partition numbers are
contiguous and only the rows that ar to be inserted are touched by
each thread.

If a linear insert into the last tag group of a partition would not
fit and spill into the first group of the next partition, the insert
is recorded as an overflow and the overflows are inserted on a single
thread after the parallel portion. In this way each partition is
guaranteed a single writer.