### PR TITLE
Properly process Final Selection in Reduce().

### DIFF
--- a/velox/functions/prestosql/tests/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/FunctionBaseTest.h
@@ -249,6 +249,14 @@ class FunctionBaseTest : public testing::Test,
     return core::Expressions::inferTypes(untyped, rowType, pool());
   }
 
+  std::unique_ptr<exec::ExprSet> compileExpression(
+      const std::string& expr,
+      const RowTypePtr& rowType) {
+    std::vector<core::TypedExprPtr> expressions = {
+        parseExpression(expr, rowType)};
+    return std::make_unique<exec::ExprSet>(std::move(expressions), &execCtx_);
+  }
+
   std::unique_ptr<exec::ExprSet> compileExpressions(
       const std::vector<std::string>& exprs,
       const RowTypePtr& rowType) {

--- a/velox/functions/prestosql/tests/MapFilterTest.cpp
+++ b/velox/functions/prestosql/tests/MapFilterTest.cpp
@@ -23,14 +23,6 @@ using namespace facebook::velox::test;
 
 class MapFilterTest : public functions::test::FunctionBaseTest {
  protected:
-  std::unique_ptr<exec::ExprSet> compileExpression(
-      const std::string& expr,
-      const RowTypePtr& rowType) {
-    std::vector<std::shared_ptr<const core::ITypedExpr>> expressions = {
-        parseExpression(expr, rowType)};
-    return std::make_unique<exec::ExprSet>(std::move(expressions), &execCtx_);
-  }
-
   template <typename K, typename V>
   void checkMapFilter(
       BaseVector* inputMap,

--- a/velox/functions/prestosql/tests/ReduceTest.cpp
+++ b/velox/functions/prestosql/tests/ReduceTest.cpp
@@ -123,3 +123,48 @@ TEST_F(ReduceTest, conditional) {
       nullEvery(11));
   assertEqualVectors(expectedResult, result);
 }
+
+TEST_F(ReduceTest, finalSelection) {
+  vector_size_t size = 1'000;
+  auto inputArray = makeArrayVector<int64_t>(
+      size,
+      modN(5),
+      [](auto row, auto index) { return row + index; },
+      nullEvery(11));
+  auto input = makeRowVector({
+      inputArray,
+      makeFlatVector<int64_t>(
+          size, [](auto row) { return row; }, nullEvery(11)),
+  });
+  registerLambda(
+      "sum_input",
+      rowType("s", BIGINT(), "x", BIGINT()),
+      input->type(),
+      "s + x");
+  registerLambda(
+      "row_output",
+      rowType("s", BIGINT()),
+      input->type(),
+      "row_constructor(s)");
+
+  auto result = evaluate<RowVector>(
+      "if (c1 < 100, row_constructor(c1), "
+      "reduce(c0, 10, function('sum_input'), function('row_output')))",
+      input);
+
+  auto expectedResult = makeRowVector({makeFlatVector<int64_t>(
+      size,
+      [](auto row) -> int64_t {
+        if (row < 100) {
+          return row;
+        } else {
+          int64_t sum = 10;
+          for (auto i = 0; i < row % 5; i++) {
+            sum += row + i;
+          }
+          return sum;
+        }
+      },
+      nullEvery(11))});
+  assertEqualVectors(expectedResult, result);
+}


### PR DESCRIPTION
Summary:
In Reduce() we ignored the fact that Final Selection might have been false before we set it to false ourselves.
In that case we need to use different SelectivityVector.

Differential Revision: D39121620

