### PR TITLE
Use relative path for cmake_modules

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
-                      "${CMAKE_SOURCE_DIR}/third_party/cmake_modules/")
+                      "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 
 include(ExternalProject)
 


### PR DESCRIPTION
The path to cmake_modules has been changed to a relative path 
so that it can be used as a submodule in other projects such as presto_cpp.