### PR TITLE
Add support for S3 FileSystem compatible schemes 's3a' and 'oss'

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -30,13 +30,32 @@ namespace facebook::velox {
 
 namespace {
 constexpr std::string_view kSep{"/"};
+// AWS S3 EMRFS, Hadoop block storage filesystem on-top of Amazon S3 buckets.
 constexpr std::string_view kS3Scheme{"s3://"};
+// This should not be mixed with s3 nor the s3a.
+// S3A Hadoop 3.x (previous connectors "s3" and "s3n" are deprecated).
+constexpr std::string_view kS3aScheme{"s3a://"};
+// OSS Alibaba support S3 format, usage only with SSL.
+constexpr std::string_view kOssScheme{"oss://"};
 // From AWS documentation
 constexpr int kS3MaxKeySize{1024};
 } // namespace
 
+inline bool isS3AwsFile(const std::string_view filename) {
+  return filename.substr(0, kS3Scheme.size()) == kS3Scheme;
+}
+
+inline bool isS3aFile(const std::string_view filename) {
+  return filename.substr(0, kS3aScheme.size()) == kS3aScheme;
+}
+
+inline bool isOssFile(const std::string_view filename) {
+  return filename.substr(0, kOssScheme.size()) == kOssScheme;
+}
+
 inline bool isS3File(const std::string_view filename) {
-  return (filename.substr(0, kS3Scheme.size()) == kS3Scheme);
+  // TODO: Each implementation should be registered as separate filesystem
+  return isS3AwsFile(filename) || isS3aFile(filename) || isOssFile(filename);
 }
 
 inline void bucketAndKeyFromS3Path(
@@ -57,8 +76,17 @@ inline std::string s3URI(const std::string& bucket, const std::string& key) {
 }
 
 inline std::string s3Path(const std::string_view& path) {
-  // Remove the prefix S3:// from the given path
-  return std::string(path.substr(kS3Scheme.length()));
+  // Remove one of the prefixes 's3://', 'oss://', 's3a://' if any from the
+  // given path.
+  // TODO: Each implementation should be registered as separate filesystem
+  if (isS3AwsFile(path)) {
+    return std::string(path.substr(kS3Scheme.length()));
+  } else if (isS3aFile(path)) {
+    return std::string(path.substr(kS3aScheme.length()));
+  } else if (isOssFile(path)) {
+    return std::string(path.substr(kOssScheme.length()));
+  }
+  return std::string(path);
 }
 
 inline Aws::String awsString(const std::string& s) {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -54,7 +54,7 @@ inline bool isOssFile(const std::string_view filename) {
 }
 
 inline bool isS3File(const std::string_view filename) {
-  // TODO: Each implementation should be registered as separate filesystem
+  // TODO: Each prefix should be implemented as its own filesystem.
   return isS3AwsFile(filename) || isS3aFile(filename) || isOssFile(filename);
 }
 
@@ -67,6 +67,13 @@ inline void bucketAndKeyFromS3Path(
   key = path.substr(firstSep + 1);
 }
 
+// TODO: Correctness check for bucket name.
+// 1. Length between 3 and 63:
+//    3 < length(bucket) < 63
+// 2. Mandatory label notation - regexp:
+//    regexp="(^[a-z0-9])([.-]?[a-z0-9]+){2,62}([/]?$)"
+// 3. Disallowed IPv4 notation - regexp:
+//    regexp="^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}[/]?$"
 inline std::string s3URI(const std::string& bucket) {
   return std::string(kS3Scheme) + bucket;
 }
@@ -78,7 +85,7 @@ inline std::string s3URI(const std::string& bucket, const std::string& key) {
 inline std::string s3Path(const std::string_view& path) {
   // Remove one of the prefixes 's3://', 'oss://', 's3a://' if any from the
   // given path.
-  // TODO: Each implementation should be registered as separate filesystem
+  // TODO: Each prefix should be implemented as its own filesystem.
   if (isS3AwsFile(path)) {
     return std::string(path.substr(kS3Scheme.length()));
   } else if (isS3aFile(path)) {

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -20,16 +20,50 @@
 
 using namespace facebook::velox;
 
+// TODO: Each prefix should be implemented as its own filesystem.
 TEST(S3UtilTest, isS3File) {
-  EXPECT_FALSE(isS3File("s3:"));
+  EXPECT_FALSE(isS3File("ss3://"));
+  EXPECT_FALSE(isS3File("s3:/"));
+  EXPECT_FALSE(isS3File("oss:"));
+  EXPECT_FALSE(isS3File("S3A://bucket/some/file.txt"));
+  EXPECT_FALSE(isS3File("OSS://other-bucket/some/file.txt"));
   EXPECT_FALSE(isS3File("s3::/bucket"));
   EXPECT_FALSE(isS3File("s3:/bucket"));
+  EXPECT_FALSE(isS3File("file://bucket"));
   EXPECT_TRUE(isS3File("s3://bucket/file.txt"));
 }
 
+TEST(S3UtilTest, isS3AwsFile) {
+  EXPECT_FALSE(isS3AwsFile("s3:"));
+  EXPECT_FALSE(isS3AwsFile("s3::/bucket"));
+  EXPECT_FALSE(isS3AwsFile("s3:/bucket"));
+  EXPECT_TRUE(isS3AwsFile("s3://bucket/file.txt"));
+}
+
+TEST(S3UtilTest, isS3aFile) {
+  EXPECT_FALSE(isS3aFile("s3a:"));
+  EXPECT_FALSE(isS3aFile("s3a::/bucket"));
+  EXPECT_FALSE(isS3aFile("s3a:/bucket"));
+  EXPECT_FALSE(isS3aFile("S3A://bucket-name/file.txt"));
+  EXPECT_TRUE(isS3aFile("s3a://bucket/file.txt"));
+}
+
+TEST(S3UtilTest, isOssFile) {
+  EXPECT_FALSE(isOssFile("oss:"));
+  EXPECT_FALSE(isOssFile("oss::/bucket"));
+  EXPECT_FALSE(isOssFile("oss:/bucket"));
+  EXPECT_FALSE(isOssFile("OSS://BUCKET/sub-key/file.txt"));
+  EXPECT_TRUE(isOssFile("oss://bucket/file.txt"));
+}
+
+// TODO: Each prefix should be implemented as its own filesystem.
 TEST(S3UtilTest, s3Path) {
-  auto path = s3Path("s3://bucket/file.txt");
-  EXPECT_EQ(path, "bucket/file.txt");
+  auto path_0 = s3Path("s3://bucket/file.txt");
+  auto path_1 = s3Path("oss://bucket-name/file.txt");
+  auto path_2 = s3Path("S3A://bucket-NAME/sub-PATH/my-file.txt");
+  EXPECT_EQ(path_0, "bucket/file.txt");
+  EXPECT_EQ(path_1, "bucket-name/file.txt");
+  EXPECT_NE(path_2, "bucket-NAME/sub-PATH/my-file.txt");
 }
 
 TEST(S3UtilTest, bucketAndKeyFromS3Path) {


### PR DESCRIPTION
# Pull-request proposed changes

## AWS S3 compatible implementations (S3Util.h)

Detection made by prefix in file path was extended by two more compatible prefixes
- S3A implementation with `s3a://` prefix added to hive connectors
- OSS implementation with `oss://` prefix added to hive connectors

## Test cases added for S3 filesystems S3A and OSS (S3UtilTest.cpp)

Functional test cases added for proposed vendor specific implementations
of Amazon AWS S3 protocol. Paths and prefixes correctness is being tested.
Future development should register each implementation as independent
filesystem instance for each specified prefix. This is not mandatory now,
as current Velox implementation only implements files reading for S3
based subsystems.

**TODO:** Correctness check for bucket name:
source: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html
1. Length between 3 and 63
   `3 < length(bucket) < 63`
2. Mandatory label notation regexp:
   `regexp="(^[a-z0-9])([.-]?[a-z0-9]+){2,62}([/]?$)"`
3. Disallowed IPv4 notation:
   `regexp="^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}[/]?$"`

----

# Reference and knowledge base

## Accept S3a and OSS as S3 filesystem

This pull request introduce acceptance of `S3a://` and `oss://` prefixes as supported and compatible `S3` implementations. Alluxio basic implementation and compatibility could also be implemented in an easy way just by sending rest requests to proper API `/api/v1/s3/`

## Difference - s3 vs s3a vs s3n

Naming convention that is being used as prefix for S3 bucket based distributed storage is a big mess this days. Accepting only connections with endpoints identification based on `S3://` protocol prefix only can lead user to incorrect assumptions - that  connection or Velox build is not working correctly. 


Hadoop (Apache) based implementations of AWS S3 protocol started from native block implementation in form of  `s3://` and  `s3n://` which are now deprecated and should not be used and starting from Hadoop 3.x only `s3a://` is supported. 
Amazon on the other hand was using block storage based S3 implementation as `s3bfs://` which is deprecated and now recommended protocol name prefix is `s3://`, so one can not easily distinguish between both implementations only using prefix.

## AWS, Apache, Alibaba

All above formats - as from compatibility and possibility of accessing data implementation - are in most cases interchangeable, it is obvious that data accessing time will be very different. Allowing the use of compatibility protocols like `s3a://` and `oss://` can greatly extend number of people interested in this project.

## Future development consideration - addressing style

Removing prefix from URL may not be enough for some cases, as there are differences between addressing style of `virtual` and `path-style`.

### Hadoop - some older Apache site archives links:

- https://web.archive.org/web/20220531044252/https://cwiki.apache.org/confluence/display/HADOOP2/AmazonS3
- https://web.archive.org/web/20170706121643/https://wiki.apache.org/hadoop/AmazonS3

### AWS Documents:

- https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-file-systems.html#emr-dev-access-file-systems

### OSS compatibility page:

- https://www.alibabacloud.com/help/en/object-storage-service/latest/seamlessly-migrate-data-from-amazon-s3-to-alibaba-cloud-oss
- 
### Addressing styles formats for S3:

- https://documentation.commvault.com/cds/126304_path_style_vs_virtual_hosted_style_requests.html
