### PR TITLE
Add percentiles array support for approx_percentile

### DIFF
--- a/velox/docs/functions/aggregate.rst
+++ b/velox/docs/functions/aggregate.rst
@@ -174,6 +174,17 @@ __ https://www.cse.ust.hk/~raywong/comp5331/References/EfficientComputationOfFre
     underlying implementation is KLL sketch thus has a stronger
     guarantee for accuracy than T-Digest.
 
+.. function:: approx_percentile(x, percentages) -> array<[same as x]>
+
+    Returns the approximate percentile for all input values of ``x`` at each of
+    the specified percentages. Each element of the ``percentages`` array must be
+    between zero and one, and the array must be constant for all input rows.
+
+.. function:: approx_percentile(x, percentages, accuracy) -> array<[same as x]>
+
+    As ``approx_percentile(x, percentages)``, but with a maximum rank error of
+    ``accuracy``.
+
 .. function:: approx_percentile(x, w, percentage) -> [same as x]
 
     Returns the approximate weighed percentile for all input values of ``x``
@@ -186,6 +197,20 @@ __ https://www.cse.ust.hk/~raywong/comp5331/References/EfficientComputationOfFre
 
     As ``approx_percentile(x, w, percentage)``, but with a maximum
     rank error of ``accuracy``.
+
+.. function:: approx_percentile(x, w, percentages) -> array<[same as x]>
+
+    Returns the approximate weighed percentile for all input values of ``x``
+    using the per-item weight ``w`` at each of the given percentages specified
+    in the array. The weight must be an integer value of at least one. It is
+    effectively a replication count for the value ``x`` in the percentile
+    set. Each element of the array must be between zero and one, and the array
+    must be constant for all input rows.
+
+.. function:: approx_percentile(x, w, percentages, accuracy) -> array<[same as x]>
+
+    As ``approx_percentile(x, w, percentages)``, but with a maximum rank error
+    of ``accuracy``.
 
 Statistical Aggregate Functions
 -------------------------------

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -90,8 +90,13 @@ HashAggregation::HashAggregation(
       channels.push_back(exprToChannel(arg.get(), inputType));
       if (channels.back() == kConstantChannel) {
         auto constant = dynamic_cast<const core::ConstantTypedExpr*>(arg.get());
-        constants.push_back(BaseVector::createConstant(
-            constant->value(), 1, operatorCtx_->pool()));
+        if (constant->hasValueVector()) {
+          constants.push_back(
+              BaseVector::wrapInConstant(1, 0, constant->valueVector()));
+        } else {
+          constants.push_back(BaseVector::createConstant(
+              constant->value(), 1, operatorCtx_->pool()));
+        }
       } else {
         constants.push_back(nullptr);
       }

--- a/velox/functions/lib/KllSketch.h
+++ b/velox/functions/lib/KllSketch.h
@@ -88,6 +88,17 @@ struct KllSketch {
   std::vector<T, Allocator> estimateQuantiles(
       const folly::Range<Iter>& quantiles) const;
 
+  /// Estimate the values of the given quantiles.  This is more
+  /// efficient than calling estimateQuantile(double) repeatedly.
+  /// @tparam Iter Iterator type dereferenceable to double
+  /// @param quantiles Range of quantiles in [0, 1] to be estimated
+  /// @param out Pre-allocated memory to hold the result, must be at least as
+  ///  large as `quantiles`
+  template <typename Iter>
+  void estimateQuantiles(
+      const folly::Range<Iter>& quantiles,
+      T* FOLLY_NONNULL out) const;
+
   /// The total number of values being added to the sketch.
   size_t totalCount() const {
     return n_;
@@ -98,11 +109,11 @@ struct KllSketch {
 
   /// Serialize the sketch into bytes.
   /// @param out Pre-allocated memory at least serializedByteSize() in size
-  void serialize(char* out) const;
+  void serialize(char* FOLLY_NONNULL out) const;
 
   /// Deserialize a sketch from bytes.
   static KllSketch<T, Allocator, Compare> deserialize(
-      const char* data,
+      const char* FOLLY_NONNULL data,
       const Allocator& = Allocator(),
       uint32_t seed = folly::Random::rand32());
 
@@ -124,7 +135,7 @@ struct KllSketch {
 
   /// Merge with another deserialized sketch.  This is more efficient
   /// than deserialize then merge.
-  void mergeDeserialized(const char* data);
+  void mergeDeserialized(const char* FOLLY_NONNULL data);
 
   /// Get frequencies of items being tracked.  The result is sorted by item.
   std::vector<std::pair<T, uint64_t>> getFrequencies() const;
@@ -136,9 +147,6 @@ struct KllSketch {
   int findLevelToCompact() const;
   void addEmptyTopLevelToCompletelyFullSketch();
   void shiftItems(uint32_t delta);
-
-  template <typename Iter>
-  void estimateQuantiles(const folly::Range<Iter>& fractions, T* out) const;
 
   uint8_t numLevels() const {
     return levels_.size() - 1;
@@ -168,7 +176,7 @@ struct KllSketch {
       return level < numLevels() ? levels[level + 1] - levels[level] : 0;
     }
 
-    void deserialize(const char*);
+    void deserialize(const char* FOLLY_NONNULL);
   };
 
   View toView() const;


### PR DESCRIPTION
Differential Revision: D39148353

`approx_percentile` now supports taking an array of percentiles and calculate the values of them in one single pass.
