### PR TITLE
Add spill config object to manage the spilling related config options

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -106,6 +106,9 @@ class QueryConfig {
 
   static constexpr const char* kTestingSpillPct = "testing.spill-pct";
 
+  static constexpr const char* kSpillStartPartitionBit =
+      "spiller-start-partition-bit";
+
   static constexpr const char* kSpillPartitionBits = "spiller-partition-bits";
 
   static constexpr const char* kSpillFileSizeFactor =
@@ -217,6 +220,13 @@ class QueryConfig {
   // will be forced to spill for testing. 0 means no extra spilling.
   int32_t testingSpillPct() const {
     return get<int32_t>(kTestingSpillPct, 0);
+  }
+
+  /// Returns the start partition bit which is used with 'kSpillPartitionBits'
+  /// together to calculate the spilling partition number.
+  uint8_t spillStartPartitionBit() const {
+    constexpr uint8_t kDefaultStartBit = 29;
+    return get<uint8_t>(kSpillStartPartitionBit, kDefaultStartBit);
   }
 
   /// Returns the number of bits used to calculate the spilling partition

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -61,7 +61,8 @@ GroupingSet::GroupingSet(
     bool ignoreNullKeys,
     bool isPartial,
     bool isRawInput,
-    OperatorCtx* FOLLY_NONNULL operatorCtx)
+    const Spiller::Config* spillConfig,
+    OperatorCtx* operatorCtx)
     : preGroupedKeyChannels_(std::move(preGroupedKeys)),
       hashers_(std::move(hashers)),
       isGlobal_(hashers_.empty()),
@@ -73,23 +74,13 @@ GroupingSet::GroupingSet(
       constantLists_(std::move(constantLists)),
       intermediateTypes_(std::move(intermediateTypes)),
       ignoreNullKeys_(ignoreNullKeys),
-      spillableReservationGrowthPct_(operatorCtx->driverCtx()
-                                         ->queryConfig()
-                                         .spillableReservationGrowthPct()),
-      spillPartitionBits_(
-          operatorCtx->driverCtx()->queryConfig().spillPartitionBits()),
-      spillFileSizeFactor_(
-          operatorCtx->driverCtx()->queryConfig().spillFileSizeFactor()),
       mappedMemory_(operatorCtx->mappedMemory()),
+      spillConfig_(spillConfig),
       stringAllocator_(mappedMemory_),
       rows_(mappedMemory_),
       isAdaptive_(
           operatorCtx->task()->queryCtx()->config().hashAdaptivityEnabled()),
-      spillPath_(makeSpillPath(isPartial, *operatorCtx)),
-      pool_(*operatorCtx->pool()),
-      spillExecutor_(operatorCtx->task()->queryCtx()->spillExecutor()),
-      testSpillPct_(
-          operatorCtx->task()->queryCtx()->config().testingSpillPct()) {
+      pool_(*operatorCtx->pool()) {
   for (auto& hasher : hashers_) {
     keyChannels_.push_back(hasher->channel());
   }
@@ -470,7 +461,7 @@ const HashLookup& GroupingSet::hashLookup() const {
 void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   // Spilling is considered if this is a final or single aggregation and
   // spillPath is set.
-  if (isPartial_ || !spillPath_.has_value()) {
+  if (isPartial_ || spillConfig_ == nullptr) {
     return;
   }
   auto numDistinct = table_->numDistinct();
@@ -491,8 +482,10 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   int64_t flatBytes = input->estimateFlatSize();
 
   // Test-only spill path.
-  if (testSpillPct_ &&
-      (folly::hasher<uint64_t>()(++spillTestCounter_)) % 100 <= testSpillPct_) {
+
+  if (spillConfig_->testSpillPct > 0 &&
+      (folly::hasher<uint64_t>()(++spillTestCounter_)) % 100 <=
+          spillConfig_->testSpillPct) {
     const auto rowsToSpill = std::max<int64_t>(1, numDistinct / 10);
     spill(
         numDistinct - rowsToSpill,
@@ -522,7 +515,8 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   // 'spillableReservationGrowthPct_' of the current reservation.
   auto targetIncrement = std::max<int64_t>(
       increment * 2,
-      tracker->getCurrentUserBytes() * spillableReservationGrowthPct_ / 100);
+      tracker->getCurrentUserBytes() *
+          spillConfig_->spillableReservationGrowthPct / 100);
   if (tracker->maybeReserve(targetIncrement)) {
     return;
   }
@@ -545,8 +539,8 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
       names.push_back(fmt::format("s{}", i));
     }
     assert(mappedMemory_->tracker()); // lint
-    const auto fileSize =
-        mappedMemory_->tracker()->getCurrentUserBytes() * spillFileSizeFactor_;
+    const auto fileSize = mappedMemory_->tracker()->getCurrentUserBytes() *
+        spillConfig_->fileSizeFactor;
     spiller_ = std::make_unique<Spiller>(
         Spiller::Type::kAggregate,
         *rows,
@@ -554,13 +548,13 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
         ROW(std::move(names), std::move(types)),
         // Spill up to 8 partitions based on bits starting from 29th of the hash
         // number. Any from one to three bits would do.
-        HashBitRange(29, 29 + spillPartitionBits_),
+        spillConfig_->hashBitRange,
         rows->keyTypes().size(),
         std::vector<CompareFlags>(),
-        spillPath_.value(),
+        spillConfig_->filePath,
         fileSize,
         Spiller::spillPool(),
-        spillExecutor_);
+        spillConfig_->executor);
   }
   spiller_->spill(targetRows, targetBytes);
 }

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -38,6 +38,7 @@ class GroupingSet {
       bool ignoreNullKeys,
       bool isPartial,
       bool isRawInput,
+      const Spiller::Config* FOLLY_NULLABLE spillConfig,
       OperatorCtx* FOLLY_NONNULL operatorCtx);
 
   void addInput(const RowVectorPtr& input, bool mayPushdown);
@@ -173,15 +174,9 @@ class GroupingSet {
 
   const bool ignoreNullKeys_;
 
-  // The spillable memory reservation growth percentage of the current
-  // reservation size.
-  const int32_t spillableReservationGrowthPct_;
-
-  // Parameters used for spilling control.
-  const int32_t spillPartitionBits_;
-  const double spillFileSizeFactor_;
-
   memory::MappedMemory* FOLLY_NONNULL const mappedMemory_;
+
+  const Spiller::Config* FOLLY_NULLABLE const spillConfig_; // Not owned.
 
   // Boolean indicating whether accumulators for a global aggregation (i.e.
   // aggregation with no grouping keys) have been initialized.
@@ -217,9 +212,6 @@ class GroupingSet {
 
   uint64_t maxBatchBytes_;
 
-  // Filesystem path for spill files, empty if spilling is disabled.
-  const std::optional<std::string> spillPath_;
-
   std::unique_ptr<Spiller> spiller_;
   std::unique_ptr<TreeOfLosers<SpillMergeStream>> merge_;
 
@@ -252,16 +244,9 @@ class GroupingSet {
   // Pool of the OperatorCtx. Used for spilling.
   memory::MemoryPool& pool_;
 
-  // Executor for spilling. If nullptr spilling writes on the Driver's thread.
-  folly::Executor* FOLLY_NULLABLE const spillExecutor_;
-
   // The RowContainer of 'table_' is moved here before freeing
   // 'table_' when starting to read spill output.
   std::unique_ptr<RowContainer> rowsWhileReadingSpill_;
-
-  // Percentage of input batches to be spilled for testing. 0 means no spilling
-  // for test.
-  const int32_t testSpillPct_;
 
   // Counts input batches and triggers spilling if folly hash of this % 100 <=
   // 'testSpillPct_';.

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -16,6 +16,7 @@
 #include "velox/exec/HashAggregation.h"
 #include <optional>
 #include "velox/exec/Aggregate.h"
+#include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
@@ -41,6 +42,10 @@ HashAggregation::HashAggregation(
           driverCtx->queryConfig().partialAggregationGoodPct()),
       maxExtendedPartialAggregationMemoryUsage_(
           driverCtx->queryConfig().maxExtendedPartialAggregationMemoryUsage()),
+      spillConfig_(makeOperatorSpillConfig(
+          *operatorCtx_->task()->queryCtx(),
+          *operatorCtx_,
+          operatorId)),
       maxPartialAggregationMemoryUsage_(
           driverCtx->queryConfig().maxPartialAggregationMemoryUsage()) {
   VELOX_CHECK_NOT_NULL(memoryTracker_, "Memory usage tracker is not set");
@@ -152,6 +157,7 @@ HashAggregation::HashAggregation(
       aggregationNode->ignoreNullKeys(),
       isPartialOutput_,
       isRawInput(aggregationNode->step()),
+      spillConfig_.has_value() ? &spillConfig_.value() : nullptr,
       operatorCtx_.get());
 }
 

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -73,6 +73,7 @@ class HashAggregation : public Operator {
   const std::shared_ptr<memory::MemoryUsageTracker> memoryTracker_;
   const double partialAggregationGoodPct_;
   const int64_t maxExtendedPartialAggregationMemoryUsage_;
+  const std::optional<Spiller::Config> spillConfig_;
 
   int64_t maxPartialAggregationMemoryUsage_;
   std::unique_ptr<GroupingSet> groupingSet_;

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -332,4 +332,29 @@ std::string makeOperatorSpillPath(
   return fmt::format("{}/{}_{}_{}", spillPath, taskId, driverId, operatorId);
 }
 
+std::optional<Spiller::Config> makeOperatorSpillConfig(
+    const core::QueryCtx& queryCtx,
+    const OperatorCtx& operatorCtx,
+    int32_t operatorId) {
+  const auto& queryConfig = queryCtx.config();
+  if (!queryConfig.spillPath().has_value()) {
+    return std::nullopt;
+  }
+
+  return Spiller::Config(
+      makeOperatorSpillPath(
+          queryConfig.spillPath().value(),
+          operatorCtx.taskId(),
+          operatorCtx.driverCtx()->driverId,
+          operatorId),
+      queryConfig.spillFileSizeFactor(),
+      queryCtx.spillExecutor(),
+      queryConfig.spillableReservationGrowthPct(),
+      HashBitRange(
+          queryConfig.spillStartPartitionBit(),
+          queryConfig.spillStartPartitionBit() +
+              queryConfig.spillPartitionBits()),
+      queryConfig.testingSpillPct());
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/exec/Operator.h"
+#include "velox/exec/Spiller.h"
 
 namespace facebook::velox::exec {
 
@@ -92,7 +93,7 @@ void gatherCopy(
     const std::vector<vector_size_t>& sourceIndices,
     const std::vector<IdentityProjection>& columnMap = {});
 
-/// Generate the system-wide unique disk spill file path for an operator. It
+/// Generates the system-wide unique disk spill file path for an operator. It
 /// will be the directory on fs with namespace support or common file prefix if
 /// not. It is assumed that the disk spilling file hierarchy for an operator is
 /// flat.
@@ -100,6 +101,13 @@ std::string makeOperatorSpillPath(
     const std::string& spillPath,
     const std::string& taskId,
     int driverId,
+    int32_t operatorId);
+
+/// Generates the spiller config for a given operator if the disk spilling is
+/// enabled, otherwise returns null.
+std::optional<Spiller::Config> makeOperatorSpillConfig(
+    const core::QueryCtx& queryCtx,
+    const OperatorCtx& operatorCtx,
     int32_t operatorId);
 
 } // namespace facebook::velox::exec

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -71,10 +71,6 @@ class OrderBy : public Operator {
   void getOutputWithoutSpill();
   void getOutputWithSpill();
 
-  // Returns the disk spill file path. The function returns null if disk
-  // spilling is disabled or not configured.
-  std::optional<std::string> makeSpillPath(int32_t operatorId) const;
-
   // Spills content until under 'targetRows' and under 'targetBytes' of out of
   // line data are left. If 'targetRows' is 0, spills everything and physically
   // frees the data in the 'data_'. This is called by ensureInputFits or by
@@ -87,20 +83,8 @@ class OrderBy : public Operator {
   const int32_t numSortKeys_;
 
   // Filesystem path for spill files, empty if spilling is disabled.
-  const std::optional<std::string> spillPath_;
-
-  // Executor for spilling. If nullptr spilling writes on the Driver's thread.
-  folly::Executor* FOLLY_NULLABLE const spillExecutor_;
-
-  // Percentage of input batches to be spilled for testing. 0 means no spilling
-  // for test.
-  const int32_t testSpillPct_;
-
-  // The spillable memory reservation growth percentage of the current
-  // reservation size.
-  const int32_t spillableReservationGrowthPct_;
-
-  const double spillFileSizeFactor_;
+  // The disk spilling related configs if spilling is enabled, otherwise null.
+  const std::optional<Spiller::Config> spillConfig_;
 
   // The map from column channel in 'output_' to the corresponding one stored in
   // 'data_'. The column channel might be reordered to ensure the sorting key

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -242,7 +242,7 @@ class SpillMergeStream : public MergeStream {
     return compare(other) < 0;
   }
 
-  int32_t compare(const MergeStream& other) const {
+  int32_t compare(const MergeStream& other) const override {
     auto& otherStream = static_cast<const SpillMergeStream&>(other);
     auto& children = rowVector_->children();
     auto& otherChildren = otherStream.current().children();
@@ -365,7 +365,7 @@ class FileSpillMergeStream : public SpillMergeStream {
   }
 
  private:
-  FileSpillMergeStream(std::unique_ptr<SpillFile> spillFile)
+  explicit FileSpillMergeStream(std::unique_ptr<SpillFile> spillFile)
       : spillFile_(std::move(spillFile)) {
     VELOX_CHECK_NOT_NULL(spillFile_);
   }
@@ -411,7 +411,7 @@ class FileSpillBatchStream : public BatchStream {
   }
 
  private:
-  FileSpillBatchStream(std::unique_ptr<SpillFile> spillFile)
+  explicit FileSpillBatchStream(std::unique_ptr<SpillFile> spillFile)
       : isFileOpened_(false), spillFile_(std::move(spillFile)) {
     VELOX_CHECK_NOT_NULL(spillFile_);
   }

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -78,6 +78,8 @@ Spiller::Spiller(
           spillMappedMemory()),
       pool_(pool),
       executor_(executor) {
+  TestValue::notify("facebook::velox::exec::Spiller", &bits_);
+
   // TODO: add to support kHashJoin type later.
   VELOX_CHECK_NE(
       type_,

--- a/velox/exec/UnorderedStreamReader.h
+++ b/velox/exec/UnorderedStreamReader.h
@@ -36,8 +36,8 @@ class BatchStream {
   virtual bool nextBatch(RowVectorPtr& batch) = 0;
 };
 
-/// Implements a union reader to read from a group of streams with one at a time
-/// in batch. The union reader owns the streams. At each call of nextBatch(), it
+/// Implements a unordered reader to read from a group of streams with one at a
+/// time in batch. The reader owns the streams. At each call of nextBatch(), it
 /// returns the next batch from the current reading stream, and the reader will
 /// switch to the next stream internally if the current stream reaches to the
 /// end.

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/HashAggregation.h"
@@ -29,6 +30,7 @@
 using facebook::velox::core::QueryConfig;
 using facebook::velox::exec::Aggregate;
 using facebook::velox::test::BatchMaker;
+using namespace facebook::velox::common::testutil;
 
 namespace facebook::velox::exec::test {
 namespace {
@@ -259,6 +261,11 @@ class AggregateFunc : public Aggregate {
 
 class AggregationTest : public OperatorTestBase {
  protected:
+  static void SetUpTestCase() {
+    OperatorTestBase::SetUpTestCase();
+    TestValue::enable();
+  }
+
   void SetUp() override {
     filesystems::registerLocalFileSystem();
     mappedMemory_ = memory::MappedMemory::getInstance();
@@ -1040,8 +1047,10 @@ TEST_F(AggregationTest, spillWithEmptyPartition) {
   constexpr int64_t kMaxBytes = 20LL << 20; // 20 MB
   rowType_ = ROW({"c0", "a"}, {INTEGER(), VARCHAR()});
   // Used to calculate the aggregation spilling partition number.
+  const int kPartitionStartBit = 29;
   const int kPartitionsBits = 2;
-  const HashBitRange hashBits{29, 31};
+  const HashBitRange hashBits{
+      kPartitionStartBit, kPartitionStartBit + kPartitionsBits};
   const int kNumPartitions = hashBits.numPartitions();
   std::vector<uint64_t> hashes(1);
 
@@ -1113,6 +1122,17 @@ TEST_F(AggregationTest, spillWithEmptyPartition) {
     queryCtx->pool()->setMemoryUsageTracker(
         velox::memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
 
+#ifndef NDEBUG
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::test::TestObject::set",
+        std::function<void(const HashBitRange*)>(
+            ([&](const HashBitRange* spillerBitRange) {
+              ASSERT_EQ(kPartitionStartBit, spillerBitRange->begin());
+              ASSERT_EQ(
+                  kPartitionStartBit + kPartitionsBits, spillerBitRange->end());
+            })));
+#endif
+
     auto task =
         AssertQueryBuilder(PlanBuilder()
                                .values(batches)
@@ -1123,6 +1143,9 @@ TEST_F(AggregationTest, spillWithEmptyPartition) {
             .config(
                 QueryConfig::kSpillPartitionBits,
                 std::to_string(kPartitionsBits))
+            .config(
+                QueryConfig::kSpillStartPartitionBit,
+                std::to_string(kPartitionStartBit))
             .assertResults(results);
 
     auto stats = task->taskStats().pipelineStats;


### PR DESCRIPTION
- Add spill config object to manage the spilling related config options
  and apply it to OrderBy and Aggregate operators.
- Add to support to configure start hash bit offset which is required to
  support recursive spilling support for hash join