### PR TITLE
Combine multiple code paths of casting for different types

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -43,9 +43,11 @@ namespace {
 template <typename To, typename From, bool Truncate>
 void applyCastKernel(
     vector_size_t row,
-    const DecodedVector& input,
+    const BaseVector& input,
     FlatVector<To>* resultFlatVector,
     bool& nullOutput) {
+  auto* flatInput = input.asUnchecked<SimpleVector<From>>();
+
   // Special handling for string target type
   if constexpr (CppToType<To>::typeKind == TypeKind::VARCHAR) {
     if (nullOutput) {
@@ -53,7 +55,7 @@ void applyCastKernel(
     } else {
       auto output =
           util::Converter<CppToType<To>::typeKind, void, Truncate>::cast(
-              input.valueAt<From>(row), nullOutput);
+              flatInput->valueAt(row), nullOutput);
       // Write the result output to the output vector
       auto writer = exec::StringWriter<>(resultFlatVector, row);
       writer.resize(output.size());
@@ -65,7 +67,7 @@ void applyCastKernel(
   } else {
     auto result =
         util::Converter<CppToType<To>::typeKind, void, Truncate>::cast(
-            input.valueAt<From>(row), nullOutput);
+            flatInput->valueAt(row), nullOutput);
     if (nullOutput) {
       resultFlatVector->setNull(row, true);
     } else {
@@ -88,14 +90,14 @@ void populateNestedRows(
 }
 
 std::string makeErrorMessage(
-    const DecodedVector& input,
+    const BaseVector& input,
     vector_size_t row,
     const TypePtr& toType) {
   return fmt::format(
       "Failed to cast from {} to {}: {}.",
-      input.base()->type()->toString(),
+      input.type()->toString(),
       toType->toString(),
-      input.base()->toString(input.index(row)));
+      input.toString(row));
 }
 
 template <typename TInput, typename TOutput>
@@ -133,7 +135,7 @@ template <typename To, typename From>
 void CastExpr::applyCastWithTry(
     const SelectivityVector& rows,
     exec::EvalCtx& context,
-    const DecodedVector& input,
+    const BaseVector& input,
     FlatVector<To>* resultFlatVector) {
   const auto& queryConfig = context.execCtx()->queryCtx()->config();
   auto isCastIntByTruncate = queryConfig.isCastIntByTruncate();
@@ -241,18 +243,20 @@ void CastExpr::applyCastWithTry(
 
 template <TypeKind Kind>
 void CastExpr::applyCast(
-    const TypeKind fromType,
+    const TypePtr& fromType,
+    const TypePtr& toType,
     const SelectivityVector& rows,
     exec::EvalCtx& context,
-    const DecodedVector& input,
+    const BaseVector& input,
     VectorPtr& result) {
   using To = typename TypeTraits<Kind>::NativeType;
+  context.ensureWritable(rows, toType, result);
   auto* resultFlatVector = result->as<FlatVector<To>>();
 
   // Unwrapping fromType pointer. VERY IMPORTANT: dynamic type pointer and
   // static type templates in each cast must match exactly
   // @TODO Add support for needed complex types in T74045702
-  switch (fromType) {
+  switch (fromType->kind()) {
     case TypeKind::TINYINT: {
       return applyCastWithTry<To, int8_t>(
           rows, context, input, resultFlatVector);
@@ -627,74 +631,65 @@ void CastExpr::apply(
         nullOnFailure_,
         result);
   } else {
-    if (toType->isArray() || toType->isMap() || toType->isRow() ||
-        isDecimalKind(toType->kind())) {
-      LocalSelectivityVector translatedRows(
-          *context.execCtx(), decoded->base()->size());
-      translatedRows->clearAll();
-      nonNullRows->applyToSelected([&](auto row) {
-        translatedRows->setValid(decoded->index(row), true);
-      });
-      translatedRows->updateBounds();
+    LocalSelectivityVector translatedRows(
+        *context.execCtx(), decoded->base()->size());
+    translatedRows->clearAll();
+    nonNullRows->applyToSelected(
+        [&](auto row) { translatedRows->setValid(decoded->index(row), true); });
+    translatedRows->updateBounds();
 
-      VectorPtr localResult;
+    VectorPtr localResult;
 
-      switch (toType->kind()) {
-        // Handle complex type conversions
-        case TypeKind::MAP:
-          localResult = applyMap(
-              *translatedRows,
-              decoded->base()->asUnchecked<MapVector>(),
-              context,
-              fromType->asMap(),
-              toType->asMap());
-          break;
-        case TypeKind::ARRAY:
-          localResult = applyArray(
-              *translatedRows,
-              decoded->base()->asUnchecked<ArrayVector>(),
-              context,
-              fromType->asArray(),
-              toType->asArray());
-          break;
-        case TypeKind::ROW:
-          localResult = applyRow(
-              *translatedRows,
-              decoded->base()->asUnchecked<RowVector>(),
-              context,
-              fromType->asRow(),
-              toType->asRow());
-          break;
-        case TypeKind::SHORT_DECIMAL:
-        case TypeKind::LONG_DECIMAL:
-          localResult = applyDecimal(
-              *translatedRows, *decoded, context, fromType, toType);
-          break;
-        default: {
-          VELOX_UNREACHABLE();
-        }
+    switch (toType->kind()) {
+      // Handle complex type conversions
+      case TypeKind::MAP:
+        localResult = applyMap(
+            *translatedRows,
+            decoded->base()->asUnchecked<MapVector>(),
+            context,
+            fromType->asMap(),
+            toType->asMap());
+        break;
+      case TypeKind::ARRAY:
+        localResult = applyArray(
+            *translatedRows,
+            decoded->base()->asUnchecked<ArrayVector>(),
+            context,
+            fromType->asArray(),
+            toType->asArray());
+        break;
+      case TypeKind::ROW:
+        localResult = applyRow(
+            *translatedRows,
+            decoded->base()->asUnchecked<RowVector>(),
+            context,
+            fromType->asRow(),
+            toType->asRow());
+        break;
+      case TypeKind::SHORT_DECIMAL:
+      case TypeKind::LONG_DECIMAL:
+        localResult =
+            applyDecimal(*translatedRows, *decoded, context, fromType, toType);
+        break;
+      default: {
+        // Handle primitive type conversions.
+        VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+            applyCast,
+            toType->kind(),
+            fromType,
+            toType,
+            *translatedRows,
+            context,
+            *decoded->base(),
+            localResult);
       }
-
-      if (!decoded->isIdentityMapping()) {
-        localResult = decoded->wrap(localResult, *input, rows);
-      }
-
-      context.moveOrCopyResult(localResult, rows, result);
-      context.releaseVector(localResult);
-    } else {
-      // Handling primitive type conversions
-      context.ensureWritable(rows, toType, result);
-      // Unwrapping toType pointer. VERY IMPORTANT: dynamic type pointer and
-      // static type templates in each cast must match exactly
-      VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-          applyCast,
-          toType->kind(),
-          fromType->kind(),
-          *nonNullRows,
-          context,
-          *decoded,
-          result);
     }
+
+    if (!decoded->isIdentityMapping()) {
+      localResult = decoded->wrap(localResult, *input, rows);
+    }
+    context.moveOrCopyResult(localResult, rows, result);
+    context.releaseVector(localResult);
   }
 
   // Copy nulls from "input".

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -524,63 +524,71 @@ VectorPtr CastExpr::applyDecimal(
   return castResult;
 }
 
-/// Apply casting between a custom type and another type.
-/// @param castTo The boolean indicating whether to cast an input to the custom
-/// type or from the custom type
-/// @param input The input vector
-/// @param allRows The selectivity vector of all rows in input
-/// @param nonNullRows The selectivity vector of non-null rows in input
-/// @param castOperator The cast operator for the custom type
-/// @param thisType The custom type
-/// @param otherType The other type involved in this casting
-/// @param context The context
-/// @param nullOnFailure Whether this is a cast or try_cast operation
-/// @param result The output vector
-template <bool castTo>
-void applyCustomTypeCast(
-    VectorPtr& input,
-    DecodedVector& inputDecoded,
-    const SelectivityVector& allRows,
-    const SelectivityVector& nonNullRows,
-    const CastOperatorPtr& castOperator,
-    const TypePtr& thisType,
-    const TypePtr& otherType,
+void CastExpr::applyPeeled(
+    const SelectivityVector& rows,
+    const BaseVector& input,
     exec::EvalCtx& context,
-    bool nullOnFailure,
+    const TypePtr& fromType,
+    const TypePtr& toType,
     VectorPtr& result) {
-  VELOX_CHECK_NE(
-      thisType,
-      otherType,
-      "Attempting to cast from {} to itself.",
-      thisType->toString());
+  if (castFromOperator_ || castToOperator_) {
+    VELOX_CHECK_NE(
+        fromType,
+        toType,
+        "Attempting to cast from {} to itself.",
+        fromType->toString());
+    context.ensureWritable(rows, toType, result);
 
-  exec::LocalSelectivityVector baseRows(
-      *context.execCtx(), inputDecoded.base()->size());
-  baseRows->clearAll();
-  context.applyToSelectedNoThrow(nonNullRows, [&](auto row) {
-    baseRows->setValid(inputDecoded.index(row), true);
-  });
-  baseRows->updateBounds();
-
-  VectorPtr localResult;
-  if constexpr (castTo) {
-    context.ensureWritable(*baseRows, thisType, localResult);
-
-    castOperator->castTo(
-        *inputDecoded.base(), context, *baseRows, nullOnFailure, *localResult);
+    if (castToOperator_) {
+      castToOperator_->castTo(input, context, rows, nullOnFailure_, *result);
+    } else {
+      castFromOperator_->castFrom(
+          input, context, rows, nullOnFailure_, *result);
+    }
   } else {
-    context.ensureWritable(*baseRows, otherType, localResult);
-
-    castOperator->castFrom(
-        *inputDecoded.base(), context, *baseRows, nullOnFailure, *localResult);
+    switch (toType->kind()) {
+      case TypeKind::MAP:
+        result = applyMap(
+            rows,
+            input.asUnchecked<MapVector>(),
+            context,
+            fromType->asMap(),
+            toType->asMap());
+        break;
+      case TypeKind::ARRAY:
+        result = applyArray(
+            rows,
+            input.asUnchecked<ArrayVector>(),
+            context,
+            fromType->asArray(),
+            toType->asArray());
+        break;
+      case TypeKind::ROW:
+        result = applyRow(
+            rows,
+            input.asUnchecked<RowVector>(),
+            context,
+            fromType->asRow(),
+            toType->asRow());
+        break;
+      case TypeKind::SHORT_DECIMAL:
+      case TypeKind::LONG_DECIMAL:
+        result = applyDecimal(rows, input, context, fromType, toType);
+        break;
+      default: {
+        // Handle primitive type conversions.
+        VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+            applyCast,
+            toType->kind(),
+            fromType,
+            toType,
+            rows,
+            context,
+            input,
+            result);
+      }
+    }
   }
-
-  if (!inputDecoded.isIdentityMapping()) {
-    localResult = inputDecoded.wrap(localResult, *input, allRows);
-  }
-
-  context.moveOrCopyResult(localResult, nonNullRows, result);
-  context.releaseVector(localResult);
 }
 
 void CastExpr::apply(
@@ -606,91 +614,36 @@ void CastExpr::apply(
     nullRows->deselectNonNulls(rawNulls, rows.begin(), rows.end());
   }
 
-  if (castToOperator_) {
-    applyCustomTypeCast<true>(
-        input,
-        *decoded,
-        rows,
-        *nonNullRows,
-        castToOperator_,
-        toType,
-        fromType,
-        context,
-        nullOnFailure_,
-        result);
-  } else if (castFromOperator_) {
-    applyCustomTypeCast<false>(
-        input,
-        *decoded,
-        rows,
-        *nonNullRows,
-        castFromOperator_,
-        fromType,
-        toType,
-        context,
-        nullOnFailure_,
-        result);
+  VectorPtr localResult;
+  if (decoded->isIdentityMapping()) {
+    applyPeeled(
+        *nonNullRows, *decoded->base(), context, fromType, toType, localResult);
   } else {
     LocalSelectivityVector translatedRows(
         *context.execCtx(), decoded->base()->size());
     translatedRows->clearAll();
-    nonNullRows->applyToSelected(
-        [&](auto row) { translatedRows->setValid(decoded->index(row), true); });
+
+    if (decoded->isConstantMapping()) {
+      translatedRows->setValid(decoded->index(0), true);
+    } else {
+      nonNullRows->applyToSelected([&](auto row) {
+        translatedRows->setValid(decoded->index(row), true);
+      });
+    }
     translatedRows->updateBounds();
 
-    VectorPtr localResult;
+    applyPeeled(
+        *translatedRows,
+        *decoded->base(),
+        context,
+        fromType,
+        toType,
+        localResult);
 
-    switch (toType->kind()) {
-      // Handle complex type conversions
-      case TypeKind::MAP:
-        localResult = applyMap(
-            *translatedRows,
-            decoded->base()->asUnchecked<MapVector>(),
-            context,
-            fromType->asMap(),
-            toType->asMap());
-        break;
-      case TypeKind::ARRAY:
-        localResult = applyArray(
-            *translatedRows,
-            decoded->base()->asUnchecked<ArrayVector>(),
-            context,
-            fromType->asArray(),
-            toType->asArray());
-        break;
-      case TypeKind::ROW:
-        localResult = applyRow(
-            *translatedRows,
-            decoded->base()->asUnchecked<RowVector>(),
-            context,
-            fromType->asRow(),
-            toType->asRow());
-        break;
-      case TypeKind::SHORT_DECIMAL:
-      case TypeKind::LONG_DECIMAL:
-        localResult = applyDecimal(
-            *translatedRows, *decoded->base(), context, fromType, toType);
-        break;
-      default: {
-        // Handle primitive type conversions.
-        VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-            applyCast,
-            toType->kind(),
-            fromType,
-            toType,
-            *translatedRows,
-            context,
-            *decoded->base(),
-            localResult);
-      }
-    }
-
-    if (!decoded->isIdentityMapping()) {
-      localResult = decoded->wrap(localResult, *input, rows);
-    }
-    context.moveOrCopyResult(localResult, rows, result);
-    context.releaseVector(localResult);
+    localResult = decoded->wrap(localResult, *input, rows);
   }
+  context.moveOrCopyResult(localResult, rows, result);
+  context.releaseVector(localResult);
 
   // Copy nulls from "input".
   if (nullRows->hasSelections()) {

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -103,13 +103,13 @@ std::string makeErrorMessage(
 template <typename TInput, typename TOutput>
 void applyDecimalCastKernel(
     const SelectivityVector& rows,
-    DecodedVector& input,
+    const BaseVector& input,
     exec::EvalCtx& context,
     const TypePtr& fromType,
     const TypePtr& toType,
     VectorPtr castResult,
     const bool nullOnFailure) {
-  auto sourceVector = input.base()->as<SimpleVector<TInput>>();
+  auto sourceVector = input.as<SimpleVector<TInput>>();
   auto castResultRawBuffer =
       castResult->asUnchecked<FlatVector<TOutput>>()->mutableRawValues();
   const auto& fromPrecisionScale = getDecimalPrecisionScale(*fromType);
@@ -487,7 +487,7 @@ VectorPtr CastExpr::applyRow(
 
 VectorPtr CastExpr::applyDecimal(
     const SelectivityVector& rows,
-    DecodedVector& input,
+    const BaseVector& input,
     exec::EvalCtx& context,
     const TypePtr& fromType,
     const TypePtr& toType) {
@@ -668,8 +668,8 @@ void CastExpr::apply(
         break;
       case TypeKind::SHORT_DECIMAL:
       case TypeKind::LONG_DECIMAL:
-        localResult =
-            applyDecimal(*translatedRows, *decoded, context, fromType, toType);
+        localResult = applyDecimal(
+            *translatedRows, *decoded->base(), context, fromType, toType);
         break;
       default: {
         // Handle primitive type conversions.

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -109,21 +109,23 @@ class CastExpr : public SpecialForm {
   void applyCastWithTry(
       const SelectivityVector& rows,
       exec::EvalCtx& context,
-      const DecodedVector& input,
+      const BaseVector& input,
       FlatVector<To>* resultFlatVector);
 
   /// @tparam To The target template
   /// @param fromType The source type pointer
+  /// @param toType The target type pointer
   /// @param rows The list of rows
   /// @param context The context
   /// @param input The input vector (of type From)
   /// @param result The output vector (of type To)
   template <TypeKind To>
   void applyCast(
-      const TypeKind fromType,
+      const TypePtr& fromType,
+      const TypePtr& toType,
       const SelectivityVector& rows,
       exec::EvalCtx& context,
-      const DecodedVector& input,
+      const BaseVector& input,
       VectorPtr& result);
 
   /// Apply the cast after generating the input vectors

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -164,9 +164,13 @@ class CastExpr : public SpecialForm {
       const RowType& fromType,
       const RowType& toType);
 
+  /// Apply the cast between decimal vectors.
+  /// @param rows Non-null rows of the input vector.
+  /// @param input The input decimal vector. It is guaranteed to be flat or
+  /// constant.
   VectorPtr applyDecimal(
       const SelectivityVector& rows,
-      DecodedVector& input,
+      const BaseVector& input,
       exec::EvalCtx& context,
       const TypePtr& fromType,
       const TypePtr& toType);

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -175,6 +175,16 @@ class CastExpr : public SpecialForm {
       const TypePtr& fromType,
       const TypePtr& toType);
 
+  // Apply the cast to a vector after vector encodings being peeled off. The
+  // input vector is guaranteed to be flat or constant.
+  void applyPeeled(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& fromType,
+      const TypePtr& toType,
+      VectorPtr& result);
+
   // When enabled the error in casting leads to null being returned.
   const bool nullOnFailure_;
 

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -185,26 +185,16 @@ class CastExprTest : public functions::test::FunctionBaseTest {
     std::string castFunction = tryCast ? "try_cast" : "cast";
     if (expectFailure) {
       EXPECT_THROW(
-          evaluate<FlatVector<typename CppToType<TTo>::NativeType>>(
-              castFunction + "(c0 as " + typeString + ")", rowVector),
+          evaluate(
+              fmt::format("{}(c0 as {})", castFunction, typeString), rowVector),
           VeloxException);
       return;
     }
     // run try cast and get the result vector
-    auto result = evaluate<FlatVector<typename CppToType<TTo>::NativeType>>(
-        castFunction + "(c0 as " + typeString + ")", rowVector);
-
-    std::string msg;
-    // Compare the values and nulls in the output with expected
-    for (int index = 0; index < input.size(); index++) {
-      if (expectedResult[index].has_value()) {
-        EXPECT_TRUE(
-            compareValues(result->valueAt(index), expectedResult[index], msg))
-            << "values at index " << index << " do not match!" << msg;
-      } else {
-        EXPECT_TRUE(result->isNullAt(index)) << " at index " << index;
-      }
-    }
+    auto result =
+        evaluate(castFunction + "(c0 as " + typeString + ")", rowVector);
+    auto expected = makeNullableFlatVector<TTo>(expectedResult);
+    assertEqualVectors(expected, result);
   }
 };
 


### PR DESCRIPTION
Summary: Casting primitive, complex, and custom types all peel off input
encodings before processing the data, but through separate code. This diff
combines their code paths to reduce code duplicates. This refactoring is 
needed for the next diff of fixing cast in try expression caused by the peeling.

Differential Revision: D39158830

