### PR TITLE
Add new RowContainer::extractColumn APIs

### DIFF
--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -388,27 +388,6 @@ void RowContainer::storeComplexType(
       StringView(reinterpret_cast<char*>(position.position), stream.size());
 }
 
-void RowContainer::extractComplexType(
-    const char* const* rows,
-    int32_t numRows,
-    RowColumn column,
-    VectorPtr result) {
-  ByteStream stream;
-  auto nullByte = column.nullByte();
-  auto nullMask = column.nullMask();
-  auto offset = column.offset();
-  result->resize(numRows);
-  for (int i = 0; i < numRows; ++i) {
-    auto row = rows[i];
-    if (!row || row[nullByte] & nullMask) {
-      result->setNull(i, true);
-    } else {
-      prepareRead(row, offset, stream);
-      ContainerRowSerde::instance().deserialize(stream, i, result.get());
-    }
-  }
-}
-
 //   static
 int32_t RowContainer::compareStringAsc(
     StringView left,

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -254,7 +254,8 @@ class RowContainer {
   /// Copies the values from the array pointed to by 'rows' at 'col' into
   /// 'result' (starting at 'resultOffset') for the rows at positions in
   /// the 'rowNumbers' array. If a 'row' is null, sets
-  /// corresponding row in 'result' to null.
+  /// corresponding row in 'result' to null. The positions in 'rowNumbers'
+  /// array can repeat and also appear out of order.
   static void extractColumn(
       const char* FOLLY_NONNULL const* FOLLY_NONNULL rows,
       folly::Range<const vector_size_t*> rowNumbers,

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -61,7 +61,8 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
       assertEqualVectors(expected, result);
 
       // Test extractColumn from offset.
-      container.extractColumn(rows.data(), size, column, offset, result);
+      container.extractColumn(
+          rows.data(), size - offset, column, offset, result);
       EXPECT_EQ(result->compare(expected.get(), offset, 0), 0);
     };
 

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -69,8 +69,8 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     };
 
     auto testBasic = [&]() {
-      // Test the legacy API that didn't use the offset parameter and copied to
-      // the start of the result vector.
+      // Test the extractColumn API that didn't use the offset parameter and
+      // copied to the start of the result vector.
       auto result = BaseVector::create(expected->type(), size, pool_.get());
       container.extractColumn(rows.data(), size, column, result);
       assertEqualVectors(expected, result);

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -37,6 +37,33 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
       const std::vector<char*>& rows,
       int column,
       const VectorPtr& expected) {
+    auto verifyResults = [&](const VectorPtr& result) {
+      auto size = rows.size();
+      EXPECT_EQ(size, result->size());
+      for (vector_size_t row = 0; row < size; ++row) {
+        if (row % 2 == 0) {
+          EXPECT_TRUE(result->isNullAt(row)) << "at " << row;
+        } else {
+          EXPECT_TRUE(expected->equalValueAt(result.get(), row, row))
+              << "at " << row << ": expected " << expected->toString(row)
+              << ", got " << result->toString();
+        }
+      }
+    };
+
+    auto result =
+        testExtractColumnBasicForOddRows(container, rows, column, expected);
+    verifyResults(result);
+    auto resultRowNumbers = testExtractColumnRowNumbersForOddRows(
+        container, rows, column, expected);
+    verifyResults(resultRowNumbers);
+  }
+
+  VectorPtr testExtractColumnBasicForOddRows(
+      RowContainer& container,
+      const std::vector<char*>& rows,
+      int column,
+      const VectorPtr& expected) {
     auto size = rows.size();
 
     // Extract only odd rows.
@@ -47,29 +74,102 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
 
     auto result = BaseVector::create(expected->type(), size, pool_.get());
     container.extractColumn(oddRows.data(), size, column, result);
-    EXPECT_EQ(size, result->size());
-    for (vector_size_t row = 0; row < size; ++row) {
-      if (row % 2 == 0) {
-        EXPECT_TRUE(result->isNullAt(row)) << "at " << row;
-      } else {
-        EXPECT_TRUE(expected->equalValueAt(result.get(), row, row))
-            << "at " << row << ": expected " << expected->toString(row)
-            << ", got " << result->toString();
-      }
-    }
+    return result;
   }
 
-  void testExtractColumnForAllRows(
+  VectorPtr testExtractColumnRowNumbersForOddRows(
       RowContainer& container,
       const std::vector<char*>& rows,
       int column,
       const VectorPtr& expected) {
     auto size = rows.size();
 
+    // Set the first row in 'oddRows' to be null, and all the
+    // even row numbers point to it.
+    std::vector<char*> oddRows(size, nullptr);
+    for (auto i = 1; i < size; i++) {
+      oddRows[i] = rows[i];
+    }
+
+    // Extract only odd rows.
+    // Test using extractColumn (with rowNumbers) API.
+    // The rowNumbersBuffer has values like 0, 1, 0, 3, 0, 5, 0, 7, etc
+    // This tests the case that the rowNumber values are repeated and are
+    // also out of order.
+    std::vector<vector_size_t> rowNumbersVector;
+    rowNumbersVector.resize(size);
+    for (int i = 0; i < size; i++) {
+      if (i % 2 == 0) {
+        rowNumbersVector[i] = 0;
+      } else {
+        rowNumbersVector[i] = i;
+      }
+    }
+
+    auto result = BaseVector::create(expected->type(), size, pool_.get());
+    folly::Range<const vector_size_t*> rowNumbersVectorRange =
+        folly::Range(rowNumbersVector.data(), size);
+    container.extractColumn(
+        oddRows.data(), rowNumbersVectorRange, column, 0, result);
+    return result;
+  }
+
+  void testExtractColumnForAllRows(
+      RowContainer& container,
+      const std::vector<char*>& rows,
+      int column,
+      const VectorPtr& expected,
+      int offset = 0) {
+    auto size = rows.size();
+
+    // Test using extractColumn API.
     auto result = BaseVector::create(expected->type(), size, pool_.get());
     container.extractColumn(rows.data(), size, column, result);
-
     assertEqualVectors(expected, result);
+
+    // Test using extractColumn API (with offset).
+    if (size >= offset) {
+      auto result2 =
+          BaseVector::create(expected->type(), size + offset, pool_.get());
+      container.extractColumn(rows.data(), size, column, offset, result2);
+      EXPECT_EQ(result2->compare(expected.get(), offset, 0), 0);
+    }
+
+    // Test using extractColumn (with rowNumbers) API.
+    std::vector<vector_size_t> rowNumbersVector;
+    rowNumbersVector.resize(size);
+    for (int i = 0; i < size; i++) {
+      rowNumbersVector[i] = i;
+    }
+    auto resultForRowNumbers =
+        BaseVector::create(expected->type(), size, pool_.get());
+    folly::Range<const vector_size_t*> rowNumbersVectorRange =
+        folly::Range(rowNumbersVector.data(), size);
+    container.extractColumn(
+        rows.data(), rowNumbersVectorRange, column, 0, resultForRowNumbers);
+    assertEqualVectors(expected, resultForRowNumbers);
+
+    // Test using extractColumn (with rowNumbers and a non-zero result vector
+    // offset).
+    if (size >= offset) {
+      std::vector<vector_size_t> rowNumbersVector2;
+      rowNumbersVector2.resize(size - offset);
+      for (int i = 0; i < size - offset; i++) {
+        rowNumbersVector2[i] = i + offset;
+      }
+      auto resultForRowNumbers2 =
+          BaseVector::create(expected->type(), size, pool_.get());
+      folly::Range<const vector_size_t*> rowNumbersVectorRange2 =
+          folly::Range(rowNumbersVector2.data(), size - offset);
+      container.extractColumn(
+          rows.data(),
+          rowNumbersVectorRange2,
+          column,
+          offset,
+          resultForRowNumbers2);
+      EXPECT_EQ(
+          expected->compare(resultForRowNumbers2.get(), offset, offset), 0);
+    }
   }
 
   void checkSizes(std::vector<char*>& rows, RowContainer& data) {
@@ -280,6 +380,9 @@ TEST_F(RowContainerTest, storeExtractArrayOfVarchar) {
 
 TEST_F(RowContainerTest, types) {
   constexpr int32_t kNumRows = 100;
+  // This value is used when testing extractColumn with a row offset
+  // value. This number should be < kNumRows for triggering the test.
+  const int32_t kOffset = 10;
   auto batch = makeDataset(
       ROW(
           {{"bool_val", BOOLEAN()},
@@ -372,7 +475,8 @@ TEST_F(RowContainerTest, types) {
   auto copy = std::static_pointer_cast<RowVector>(
       BaseVector::create(batch->type(), batch->size(), pool_.get()));
   for (auto column = 0; column < batch->childrenSize(); ++column) {
-    testExtractColumnForAllRows(*data, rows, column, batch->childAt(column));
+    testExtractColumnForAllRows(
+        *data, rows, column, batch->childAt(column), kOffset);
     testExtractColumnForOddRows(*data, rows, column, batch->childAt(column));
 
     auto extracted = copy->childAt(column);


### PR DESCRIPTION
This PR adds 2 variations of the RowContainer::extractColumn API :

i) Value window functions like nth_value need to copy from a RowContainer into a result vector. The rows being copied need not be contiguous. So we are adding a new API similar to extractColumns where we specify in an offsets buffer
the indexes of the rows to be copied.

ii) Another version of the extractColumn APIs used in window functions requires to copy contiguous rows but at a non-0 offset in the resultVector.