### PR TITLE
Fix aarch64 with latest xsimd import

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -673,7 +673,7 @@ inline xsimd::batch<int64_t> cvtU32toI64(
 inline xsimd::batch<int64_t> cvtU32toI64(simd::Batch64<int32_t> values) {
   int64_t lo = static_cast<uint32_t>(values.data[0]);
   int64_t hi = static_cast<uint32_t>(values.data[1]);
-  return xsimd::batch<int64_t>({lo, hi});
+  return xsimd::batch<int64_t>(lo, hi);
 }
 #endif
 


### PR DESCRIPTION
Summary:
D39106883 brought in a new xsimd and this was not caught as
it's hidden behind sse2 or neon

Reviewed By: pallab-zz, kgpai

Differential Revision: D39161222

