### PR TITLE
Extend spiller to support hash join spilling

### DIFF
--- a/velox/common/base/AsyncSource.h
+++ b/velox/common/base/AsyncSource.h
@@ -73,9 +73,8 @@ class AsyncSource {
     ContinueFuture wait;
     {
       std::lock_guard<std::mutex> l(mutex_);
-      // 'making_' can be read atomically, 'exception)' maybe
-      // not. Sotest 'making' so as not to read half-assigned
-      // 'exception_'.
+      // 'making_' can be read atomically, 'exception' maybe not. So test
+      // 'making' so as not to read half-assigned 'exception_'.
       if (!making_ && exception_) {
         std::rethrow_exception(exception_);
       }

--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -95,7 +95,8 @@ class LocalFileSystem : public FileSystem {
         path.find(kFileScheme) == 0 ? path.substr(kFileScheme.length()) : path;
     int32_t rc = ::remove(std::string(file).c_str());
     if (rc < 0) {
-      VELOX_USER_FAIL("Failed to delete file {} with errno {}", file, errno);
+      VELOX_USER_FAIL(
+          "Failed to delete file {} with errno {}", file, strerror(errno));
     }
   }
 

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -562,7 +562,7 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
         spillConfig_->fileSizeFactor;
     spiller_ = std::make_unique<Spiller>(
         Spiller::Type::kAggregate,
-        *rows,
+        rows,
         [&](folly::Range<char**> rows) { table_->erase(rows); },
         ROW(std::move(names), std::move(types)),
         // Spill up to 8 partitions based on bits starting from 29th of the hash

--- a/velox/exec/HashBitRange.h
+++ b/velox/exec/HashBitRange.h
@@ -53,12 +53,21 @@ class HashBitRange {
     return 1 << numBits();
   }
 
+  inline bool operator==(const HashBitRange& other) const {
+    return std::tie(begin_, end_) == std::tie(other.begin_, other.end_);
+  }
+
+  inline bool operator!=(const HashBitRange& other) const {
+    return !(*this == other);
+  }
+
  private:
   // Low bit number of hash number bit range.
-  const uint8_t begin_;
-  // Bit number of first bit above the hash number bit range.
-  const uint8_t end_;
+  uint8_t begin_;
 
-  const uint64_t fieldMask_;
+  // Bit number of first bit above the hash number bit range.
+  uint8_t end_;
+
+  uint64_t fieldMask_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -199,7 +199,7 @@ void OrderBy::spill(int64_t targetRows, int64_t targetBytes) {
         spillConfig.fileSizeFactor;
     spiller_ = std::make_unique<Spiller>(
         Spiller::Type::kOrderBy,
-        *data_,
+        data_.get(),
         [&](folly::Range<char**> rows) { data_->eraseRows(rows); },
         internalStoreType_,
         data_->keyTypes().size(),

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -214,6 +214,10 @@ uint32_t SpillState::spilledPartitions() const {
   return spilledPartitionSet_.size();
 }
 
+const SpillPartitionNumSet& SpillState::spilledPartitionSet() const {
+  return spilledPartitionSet_;
+}
+
 int64_t SpillState::spilledFiles() const {
   int64_t numFiles = 0;
   for (const auto& list : files_) {
@@ -236,6 +240,18 @@ std::vector<std::string> SpillState::testingSpilledFilePaths() const {
     }
   }
   return spilledFiles;
+}
+
+std::unique_ptr<UnorderedStreamReader<BatchStream>>
+SpillPartition::createReader() {
+  std::vector<std::unique_ptr<BatchStream>> streams;
+  streams.reserve(files_.size());
+  for (auto& file : files_) {
+    streams.push_back(FileSpillBatchStream::create(std::move(file)));
+  }
+  files_.clear();
+  return std::make_unique<UnorderedStreamReader<BatchStream>>(
+      std::move(streams));
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/HashBitRangeTest.cpp
+++ b/velox/exec/tests/HashBitRangeTest.cpp
@@ -28,10 +28,13 @@ TEST_F(HashRangeBitTest, hashBitRange) {
   EXPECT_EQ(4, bitRange.numPartitions());
   EXPECT_EQ(2, bitRange.numBits());
   EXPECT_EQ(31, bitRange.end());
+  EXPECT_EQ(bitRange, bitRange);
 
   HashBitRange defaultRange;
   EXPECT_EQ(0, defaultRange.begin());
   EXPECT_EQ(1, defaultRange.numPartitions());
   EXPECT_EQ(0, defaultRange.numBits());
   EXPECT_EQ(0, defaultRange.end());
+  EXPECT_EQ(defaultRange, defaultRange);
+  EXPECT_NE(defaultRange, bitRange);
 }

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -25,17 +25,160 @@
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::filesystems;
+using facebook::velox::exec::test::TempDirectoryPath;
 
 class SpillTest : public testing::Test,
                   public facebook::velox::test::VectorTestBase {
  protected:
   void SetUp() override {
     mappedMemory_ = memory::MappedMemory::getInstance();
+    tempDir_ = exec::test::TempDirectoryPath::create();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
     }
     filesystems::registerLocalFileSystem();
+    rng_.seed(1);
+  }
+
+  uint8_t randPartitionBitOffset() {
+    return folly::Random::rand32(rng_) % std::numeric_limits<uint8_t>::max();
+  }
+  uint32_t randPartitionNum() {
+    return folly::Random::rand32(rng_) % std::numeric_limits<uint32_t>::max();
+  }
+  SpillPartitionId randPartitionId() {
+    return SpillPartitionId(randPartitionBitOffset(), randPartitionNum());
+  }
+
+  void setupSpillState(
+      int64_t targetFileSize,
+      int numPartitions,
+      int numBatches,
+      int numRowsPerBatch = 1000,
+      int numDuplicates = 1,
+      const std::vector<CompareFlags>& compareFlags = {}) {
+    ASSERT_TRUE(compareFlags.empty() || compareFlags.size() == 1);
+    ASSERT_EQ(numBatches % 2, 0);
+
+    state_.reset();
+    batchesByPartition_.clear();
+    values_.clear();
+
+    spillPath_ = tempDir_->path + "/test";
+    values_.resize(numBatches * numRowsPerBatch);
+    // Create a sequence of sorted 'values' in ascending order starting at -10.
+    // Each distinct value occurs 'numDuplicates' times. The sequence total has
+    // numBatches * kNumRowsPerBatch item. Each batch created in the test below,
+    // contains a subsequence with index mod being equal to its batch number.
+    const int kNumNulls = numBatches;
+    for (int i = 0, value = -10; i < numRowsPerBatch * numBatches;) {
+      while (i < kNumNulls) {
+        values_[i++] = std::nullopt;
+      }
+      for (int j = 0; j < numDuplicates; ++j) {
+        values_[i++] = value++;
+      }
+    }
+    const bool nullsFirst =
+        compareFlags.empty() ? true : compareFlags[0].nullsFirst;
+    const bool ascending =
+        compareFlags.empty() ? true : compareFlags[0].ascending;
+
+    if (!ascending) {
+      if (nullsFirst) {
+        std::reverse(values_.begin() + kNumNulls, values_.end());
+      } else {
+        std::reverse(values_.begin(), values_.end());
+        assert(!values_.back().has_value());
+      }
+    } else {
+      if (!nullsFirst) {
+        for (int i = 0; i < values_.size(); ++i) {
+          if (i < values_.size() - kNumNulls) {
+            values_[i] = values_[i + kNumNulls];
+          } else {
+            values_[i] = std::nullopt;
+          }
+        }
+      }
+    }
+    batchesByPartition_.resize(numPartitions);
+
+    // Setup state that has 'numPartitions' partitions, each with its own
+    // file list. We write 'numBatches' sorted vectors in each partition. The
+    // vectors have the ith element = i * 'numBatches' + batch, where batch is
+    // the batch number of the vector in the partition. When read back, both
+    // partitions produce an ascending sequence of integers without gaps.
+    state_ = std::make_unique<SpillState>(
+        spillPath_,
+        numPartitions,
+        1,
+        compareFlags,
+        targetFileSize,
+        *pool(),
+        *mappedMemory_);
+    EXPECT_EQ(targetFileSize, state_->targetFileSize());
+    EXPECT_EQ(numPartitions, state_->maxPartitions());
+    EXPECT_EQ(0, state_->spilledPartitions());
+    EXPECT_TRUE(state_->spilledPartitionSet().empty());
+
+    for (auto partition = 0; partition < state_->maxPartitions(); ++partition) {
+      EXPECT_FALSE(state_->isPartitionSpilled(partition));
+      // Expect an exception if partition is not set to spill.
+      {
+        RowVectorPtr dummyInput;
+        EXPECT_ANY_THROW(state_->appendToPartition(partition, dummyInput));
+      }
+      state_->setPartitionSpilled(partition);
+      EXPECT_TRUE(state_->isPartitionSpilled(partition));
+      EXPECT_FALSE(state_->hasFiles(partition));
+      for (auto iter = 0; iter < numBatches / 2; ++iter) {
+        batchesByPartition_[partition].push_back(
+            makeRowVector({makeFlatVector<int64_t>(
+                numRowsPerBatch,
+                [&](auto row) {
+                  return values_[row * numBatches / 2 + iter].has_value()
+                      ? values_[row * numBatches / 2 + iter].value()
+                      : 0;
+                },
+                [&](auto row) {
+                  return !values_[row * numBatches / 2 + iter].has_value();
+                })}));
+        state_->appendToPartition(
+            partition, batchesByPartition_[partition].back());
+        EXPECT_TRUE(state_->hasFiles(partition));
+
+        batchesByPartition_[partition].push_back(makeRowVector({makeFlatVector<
+            int64_t>(
+            numRowsPerBatch,
+            [&](auto row) {
+              return values_[(numRowsPerBatch + row) * numBatches / 2 + iter]
+                         .has_value()
+                  ? values_[(numRowsPerBatch + row) * numBatches / 2 + iter]
+                        .value()
+                  : 0;
+            },
+            [&](auto row) {
+              return !values_[(numRowsPerBatch + row) * numBatches / 2 + iter]
+                          .has_value();
+            })}));
+        state_->appendToPartition(
+            partition, batchesByPartition_[partition].back());
+        EXPECT_TRUE(state_->hasFiles(partition));
+
+        // Indicates that the next additions to 'partition' are not sorted
+        // with respect to the values added so far.
+        state_->finishWrite(partition);
+        EXPECT_TRUE(state_->hasFiles(partition));
+      }
+    }
+    EXPECT_EQ(numPartitions, state_->spilledPartitions());
+    for (int i = 0; i < numPartitions; ++i) {
+      EXPECT_TRUE(state_->spilledPartitionSet().contains(i));
+    }
+    EXPECT_LT(
+        numPartitions * numBatches * sizeof(int64_t), state_->spilledBytes());
   }
 
   // 'numDuplicates' specifies the number of duplicates generated for each
@@ -47,6 +190,7 @@ class SpillTest : public testing::Test,
       int numDuplicates,
       const std::vector<CompareFlags>& compareFlags,
       int64_t expectedNumSpilledFiles) {
+    const int numRowsPerBatch = 20'000;
     SCOPED_TRACE(fmt::format(
         "targetFileSize: {}, numPartitions: {}, numBatches: {}, numDuplicates: {}, nullsFirst: {}, ascending: {}",
         targetFileSize,
@@ -55,181 +199,68 @@ class SpillTest : public testing::Test,
         numDuplicates,
         compareFlags.empty() ? true : compareFlags[0].nullsFirst,
         compareFlags.empty() ? true : compareFlags[0].ascending));
-    ASSERT_TRUE(compareFlags.empty() || compareFlags.size() == 1);
-    auto tempDirectory = exec::test::TempDirectoryPath::create();
-    const std::string kSpillPath = tempDirectory->path + "/test";
-    std::shared_ptr<FileSystem> fs;
-    std::vector<std::string> spilledFiles;
-    const int kNumRowsPerBatch = 200'000;
-    ASSERT_EQ(kNumRowsPerBatch % 2, 0);
-    std::vector<std::optional<int64_t>> values(numBatches * kNumRowsPerBatch);
-    // Create a sequence of sorted 'values' in ascending order starting at -10.
-    // Each distinct value occurs 'numDuplicates' times. The sequence total has
-    // numBatches * kNumRowsPerBatch item. Each batch created in the test below,
-    // contains a subsequence with index mod being equal to its batch number.
-    const int kNumNulls = numBatches;
-    for (int i = 0, value = -10; i < kNumRowsPerBatch * numBatches; ++value) {
-      while (i < kNumNulls) {
-        values[i++] = std::nullopt;
-      }
-      for (int j = 0; j < numDuplicates; ++j, ++i) {
-        values[i] = value;
-      }
+    setupSpillState(
+        targetFileSize,
+        numPartitions,
+        numBatches,
+        numRowsPerBatch,
+        numDuplicates,
+        compareFlags);
+
+    ASSERT_EQ(expectedNumSpilledFiles, state_->spilledFiles());
+    std::vector<std::string> spilledFiles = state_->testingSpilledFilePaths();
+    std::unordered_set<std::string> spilledFileSet(
+        spilledFiles.begin(), spilledFiles.end());
+    EXPECT_EQ(spilledFileSet.size(), spilledFiles.size());
+    EXPECT_EQ(expectedNumSpilledFiles, spilledFileSet.size());
+    // Verify the spilled file exist on file system.
+    std::shared_ptr<FileSystem> fs =
+        filesystems::getFileSystem(tempDir_->path, nullptr);
+    for (const auto& spilledFile : spilledFileSet) {
+      auto readFile = fs->openFileForRead(spilledFile);
+      EXPECT_NE(readFile.get(), nullptr);
     }
-    const bool nullsFirst =
-        compareFlags.empty() ? true : compareFlags[0].nullsFirst;
-    const bool ascending =
-        compareFlags.empty() ? true : compareFlags[0].ascending;
 
-    if (!ascending) {
-      if (nullsFirst) {
-        std::reverse(values.begin() + kNumNulls, values.end());
-      } else {
-        std::reverse(values.begin(), values.end());
-        assert(!values.back().has_value());
-      }
-    } else {
-      if (!nullsFirst) {
-        for (int i = 0; i < values.size(); ++i) {
-          if (i < values.size() - kNumNulls) {
-            values[i] = values[i + kNumNulls];
-          } else {
-            values[i] = std::nullopt;
-          }
+    for (auto partition = 0; partition < state_->maxPartitions(); ++partition) {
+      int numReadBatches = 0;
+      auto merge = state_->startMerge(partition, nullptr);
+      // We expect all the rows in dense increasing order.
+      for (auto i = 0; i < numBatches * numRowsPerBatch; ++i) {
+        auto stream = merge->next();
+        ASSERT_NE(nullptr, stream);
+        bool isLastBatch = false;
+        if (values_[i].has_value()) {
+          ASSERT_EQ(
+              values_[i].value(),
+              stream->current()
+                  .childAt(0)
+                  ->asUnchecked<FlatVector<int64_t>>()
+                  ->valueAt(stream->currentIndex(&isLastBatch)))
+              << i;
+          ASSERT_EQ(
+              values_[i].value(),
+              stream->decoded(0).valueAt<int64_t>(stream->currentIndex()))
+              << i;
+        } else {
+          ASSERT_TRUE(stream->current()
+                          .childAt(0)
+                          ->asUnchecked<FlatVector<int64_t>>()
+                          ->isNullAt(stream->currentIndex(&isLastBatch)))
+              << i;
+          ASSERT_TRUE(stream->decoded(0).isNullAt(stream->currentIndex())) << i;
+        }
+        stream->pop();
+        if (isLastBatch) {
+          ++numReadBatches;
         }
       }
+      ASSERT_EQ(nullptr, merge->next());
+      // We do two append writes per each input batch.
+      ASSERT_EQ(numBatches, numReadBatches);
     }
-    {
-      // We make a state that has 'numPartitions' partitions, each with its own
-      // file list. We write 'numBatches' sorted vectors in each partition. The
-      // vectors have the ith element = i * 'numBatches' + batch, where batch is
-      // the batch number of the vector in the partition. When read back, both
-      // partitions produce an ascending sequence of integers without gaps.
-      SpillState state(
-          kSpillPath,
-          numPartitions,
-          1,
-          compareFlags,
-          targetFileSize,
-          *pool(),
-          *mappedMemory_);
-      EXPECT_EQ(targetFileSize, state.targetFileSize());
-      EXPECT_EQ(numPartitions, state.maxPartitions());
-      EXPECT_EQ(0, state.spilledPartitions());
-
-      for (auto partition = 0; partition < state.maxPartitions(); ++partition) {
-        EXPECT_FALSE(state.isPartitionSpilled(partition));
-        // Expect an exception if partition is not set to spill.
-        {
-          RowVectorPtr dummyInput;
-          EXPECT_ANY_THROW(state.appendToPartition(partition, dummyInput));
-        }
-        state.setPartitionSpilled(partition);
-        EXPECT_TRUE(state.isPartitionSpilled(partition));
-        EXPECT_FALSE(state.hasFiles(partition));
-        for (auto batch = 0; batch < numBatches; ++batch) {
-          state.appendToPartition(
-              partition,
-              makeRowVector({makeFlatVector<int64_t>(
-                  kNumRowsPerBatch / 2,
-                  [&](auto row) {
-                    return values[row * numBatches + batch].has_value()
-                        ? values[row * numBatches + batch].value()
-                        : 0;
-                  },
-                  [&](auto row) {
-                    return !values[row * numBatches + batch].has_value();
-                  })}));
-          EXPECT_TRUE(state.hasFiles(partition));
-
-          state.appendToPartition(
-              partition,
-              makeRowVector({makeFlatVector<int64_t>(
-                  kNumRowsPerBatch / 2,
-                  [&](auto row) {
-                    return values
-                               [(kNumRowsPerBatch / 2 + row) * numBatches +
-                                batch]
-                                   .has_value()
-                        ? values
-                              [(kNumRowsPerBatch / 2 + row) * numBatches +
-                               batch]
-                                  .value()
-                        : 0;
-                  },
-                  [&](auto row) {
-                    return !values
-                                [(kNumRowsPerBatch / 2 + row) * numBatches +
-                                 batch]
-                                    .has_value();
-                  })}));
-          EXPECT_TRUE(state.hasFiles(partition));
-
-          // Indicates that the next additions to 'partition' are not sorted
-          // with respect to the values added so far.
-          state.finishWrite(partition);
-          EXPECT_TRUE(state.hasFiles(partition));
-        }
-      }
-      EXPECT_EQ(numPartitions, state.spilledPartitions());
-      EXPECT_LT(
-          2 * numPartitions * numBatches * sizeof(int64_t),
-          state.spilledBytes());
-      EXPECT_EQ(expectedNumSpilledFiles, state.spilledFiles());
-      spilledFiles = state.testingSpilledFilePaths();
-      std::unordered_set<std::string> spilledFileSet(
-          spilledFiles.begin(), spilledFiles.end());
-      EXPECT_EQ(spilledFileSet.size(), spilledFiles.size());
-      EXPECT_EQ(expectedNumSpilledFiles, spilledFileSet.size());
-      // Verify the spilled file exist on file system.
-      fs = filesystems::getFileSystem(tempDirectory->path, nullptr);
-      for (const auto& spilledFile : spilledFileSet) {
-        auto readFile = fs->openFileForRead(spilledFile);
-        EXPECT_NE(readFile.get(), nullptr);
-      }
-
-      for (auto partition = 0; partition < state.maxPartitions(); ++partition) {
-        int numReadBatches = 0;
-        auto merge = state.startMerge(partition, nullptr);
-        // We expect all the rows in dense increasing order.
-        for (auto i = 0; i < numBatches * kNumRowsPerBatch; ++i) {
-          auto stream = merge->next();
-          ASSERT_NE(nullptr, stream);
-          bool isLastBatch = false;
-          if (values[i].has_value()) {
-            EXPECT_EQ(
-                values[i].value(),
-                stream->current()
-                    .childAt(0)
-                    ->asUnchecked<FlatVector<int64_t>>()
-                    ->valueAt(stream->currentIndex(&isLastBatch)))
-                << i;
-            EXPECT_EQ(
-                values[i].value(),
-                stream->decoded(0).valueAt<int64_t>(stream->currentIndex()))
-                << i;
-          } else {
-            EXPECT_TRUE(stream->current()
-                            .childAt(0)
-                            ->asUnchecked<FlatVector<int64_t>>()
-                            ->isNullAt(stream->currentIndex(&isLastBatch)))
-                << i;
-            EXPECT_TRUE(stream->decoded(0).isNullAt(stream->currentIndex()))
-                << i;
-          }
-          stream->pop();
-          if (isLastBatch) {
-            ++numReadBatches;
-          }
-        }
-        ASSERT_EQ(nullptr, merge->next());
-        // We do two append writes per each input batch.
-        ASSERT_EQ(2 * numBatches, numReadBatches);
-      }
-      // Both spilled bytes and files stats are cleared after merge read.
-      EXPECT_EQ(0, state.spilledBytes());
-      EXPECT_EQ(0, state.spilledFiles());
-    }
+    // Both spilled bytes and files stats are cleared after merge read.
+    EXPECT_EQ(0, state_->spilledBytes());
+    EXPECT_EQ(0, state_->spilledFiles());
     // Verify the spilled file has been removed from file system after spill
     // state destruction.
     for (const auto& spilledFile : spilledFiles) {
@@ -237,7 +268,13 @@ class SpillTest : public testing::Test,
     }
   }
 
+  folly::Random::DefaultGenerator rng_;
+  std::shared_ptr<TempDirectoryPath> tempDir_;
   memory::MappedMemory* mappedMemory_;
+  std::vector<std::optional<int64_t>> values_;
+  std::vector<std::vector<RowVectorPtr>> batchesByPartition_;
+  std::string spillPath_;
+  std::unique_ptr<SpillState> state_;
 };
 
 TEST_F(SpillTest, spillState) {
@@ -245,19 +282,18 @@ TEST_F(SpillTest, spillState) {
   // triggered by batch write.
 
   // Test with distinct sort keys.
-  spillStateTest(1'000'000'000, 2, 10, 1, {CompareFlags{true, true}}, 2 * 10);
-  spillStateTest(1'000'000'000, 2, 10, 1, {CompareFlags{true, false}}, 2 * 10);
-  spillStateTest(1'000'000'000, 2, 10, 1, {CompareFlags{false, true}}, 2 * 10);
-  spillStateTest(1'000'000'000, 2, 10, 1, {CompareFlags{false, false}}, 2 * 10);
-  spillStateTest(1'000'000'000, 2, 10, 1, {}, 2 * 10);
+  spillStateTest(1'000'000'000, 2, 10, 1, {CompareFlags{true, true}}, 10);
+  spillStateTest(1'000'000'000, 2, 10, 1, {CompareFlags{true, false}}, 10);
+  spillStateTest(1'000'000'000, 2, 10, 1, {CompareFlags{false, true}}, 10);
+  spillStateTest(1'000'000'000, 2, 10, 1, {CompareFlags{false, false}}, 10);
+  spillStateTest(1'000'000'000, 2, 10, 1, {}, 10);
 
   // Test with duplicate sort keys.
-  spillStateTest(1'000'000'000, 2, 10, 10, {CompareFlags{true, true}}, 2 * 10);
-  spillStateTest(1'000'000'000, 2, 10, 10, {CompareFlags{true, false}}, 2 * 10);
-  spillStateTest(1'000'000'000, 2, 10, 10, {CompareFlags{false, true}}, 2 * 10);
-  spillStateTest(
-      1'000'000'000, 2, 10, 10, {CompareFlags{false, false}}, 2 * 10);
-  spillStateTest(1'000'000'000, 2, 10, 10, {}, 2 * 10);
+  spillStateTest(1'000'000'000, 2, 10, 10, {CompareFlags{true, true}}, 10);
+  spillStateTest(1'000'000'000, 2, 10, 10, {CompareFlags{true, false}}, 10);
+  spillStateTest(1'000'000'000, 2, 10, 10, {CompareFlags{false, true}}, 10);
+  spillStateTest(1'000'000'000, 2, 10, 10, {CompareFlags{false, false}}, 10);
+  spillStateTest(1'000'000'000, 2, 10, 10, {}, 10);
 }
 
 TEST_F(SpillTest, spillStateWithSmallTargetFileSize) {
@@ -265,16 +301,160 @@ TEST_F(SpillTest, spillStateWithSmallTargetFileSize) {
   // write.
 
   // Test with distinct sort keys.
-  spillStateTest(1, 2, 10, 1, {CompareFlags{true, true}}, 2 * 10 * 2);
-  spillStateTest(1, 2, 10, 1, {CompareFlags{true, false}}, 2 * 10 * 2);
-  spillStateTest(1, 2, 10, 1, {CompareFlags{false, true}}, 2 * 10 * 2);
-  spillStateTest(1, 2, 10, 1, {CompareFlags{false, false}}, 2 * 10 * 2);
-  spillStateTest(1, 2, 10, 1, {}, 2 * 10 * 2);
+  spillStateTest(1, 2, 10, 1, {CompareFlags{true, true}}, 10 * 2);
+  spillStateTest(1, 2, 10, 1, {CompareFlags{true, false}}, 10 * 2);
+  spillStateTest(1, 2, 10, 1, {CompareFlags{false, true}}, 10 * 2);
+  spillStateTest(1, 2, 10, 1, {CompareFlags{false, false}}, 10 * 2);
+  spillStateTest(1, 2, 10, 1, {}, 10 * 2);
 
   // Test with duplicated sort keys.
-  spillStateTest(1, 2, 10, 10, {CompareFlags{true, false}}, 2 * 10 * 2);
-  spillStateTest(1, 2, 10, 10, {CompareFlags{true, true}}, 2 * 10 * 2);
-  spillStateTest(1, 2, 10, 10, {CompareFlags{false, false}}, 2 * 10 * 2);
-  spillStateTest(1, 2, 10, 10, {CompareFlags{false, true}}, 2 * 10 * 2);
-  spillStateTest(1, 2, 10, 10, {}, 2 * 10 * 2);
+  spillStateTest(1, 2, 10, 10, {CompareFlags{true, false}}, 10 * 2);
+  spillStateTest(1, 2, 10, 10, {CompareFlags{true, true}}, 10 * 2);
+  spillStateTest(1, 2, 10, 10, {CompareFlags{false, false}}, 10 * 2);
+  spillStateTest(1, 2, 10, 10, {CompareFlags{false, true}}, 10 * 2);
+  spillStateTest(1, 2, 10, 10, {}, 10 * 2);
+}
+
+TEST_F(SpillTest, spillPartitionId) {
+  SpillPartitionId invalidPartitionId;
+  ASSERT_FALSE(invalidPartitionId.valid());
+
+  SpillPartitionId partitionId1_2(1, 2);
+  ASSERT_TRUE(partitionId1_2.valid());
+  ASSERT_EQ(partitionId1_2.partitionBitOffset, 1);
+  ASSERT_EQ(partitionId1_2.partitionNumber, 2);
+  ASSERT_EQ(partitionId1_2.toString(), "[1,2]");
+
+  SpillPartitionId partitionId1_2_dup(1, 2);
+  ASSERT_EQ(partitionId1_2, partitionId1_2_dup);
+
+  SpillPartitionId partitionId1_3(1, 3);
+  ASSERT_NE(partitionId1_2, partitionId1_3);
+  ASSERT_LT(partitionId1_2, partitionId1_3);
+
+  for (int iter = 0; iter < 5; ++iter) {
+    folly::Random::DefaultGenerator rng;
+    rng.seed(iter);
+    const int numIds = std::max<int>(1024, folly::Random::rand64(rng) % 4096);
+    std::vector<SpillPartitionId> spillPartitionIds;
+    spillPartitionIds.reserve(numIds);
+    for (int i = 0; i < numIds; ++i) {
+      spillPartitionIds.push_back(randPartitionId());
+    }
+
+    std::sort(spillPartitionIds.begin(), spillPartitionIds.end());
+    std::vector<SpillPartitionId> distinctSpillPartitionIds;
+    distinctSpillPartitionIds.reserve(numIds);
+    distinctSpillPartitionIds.push_back(spillPartitionIds[0]);
+    for (int i = 0; i < numIds - 1; ++i) {
+      ASSERT_GE(
+          spillPartitionIds[i].partitionBitOffset,
+          spillPartitionIds[i + 1].partitionBitOffset);
+      if (spillPartitionIds[i].partitionBitOffset ==
+          spillPartitionIds[i + 1].partitionBitOffset) {
+        ASSERT_LE(
+            spillPartitionIds[i].partitionNumber,
+            spillPartitionIds[i + 1].partitionNumber);
+      }
+      if (distinctSpillPartitionIds.back() != spillPartitionIds[i + 1]) {
+        distinctSpillPartitionIds.push_back(spillPartitionIds[i + 1]);
+      }
+    }
+    SpillPartitionIdSet partitionIdSet(
+        spillPartitionIds.begin(), spillPartitionIds.end());
+    ASSERT_EQ(partitionIdSet.size(), distinctSpillPartitionIds.size());
+  }
+}
+
+TEST_F(SpillTest, spillPartitionSet) {
+  for (int iter = 0; iter < 5; ++iter) {
+    folly::Random::DefaultGenerator rng;
+    rng.seed(iter);
+    const int numPartitions =
+        std::max<int>(128, folly::Random::rand64(rng) % 256);
+    std::vector<std::unique_ptr<SpillPartition>> spillPartitions;
+    spillPartitions.reserve(numPartitions);
+    SpillPartitionIdSet partitionIdSet;
+    partitionIdSet.reserve(numPartitions);
+    RowVectorPtr output;
+    while (spillPartitions.size() < numPartitions) {
+      const SpillPartitionId id = randPartitionId();
+      if (partitionIdSet.contains(id)) {
+        continue;
+      }
+      spillPartitions.push_back(std::make_unique<SpillPartition>(id));
+      ASSERT_EQ(id, spillPartitions.back()->id());
+      // Expect an empty reader.
+      auto reader = spillPartitions.back()->createReader();
+      ASSERT_FALSE(reader->nextBatch(output));
+    }
+
+    // Check if partition set is sorted as expected.
+    SpillPartitionSet partitionSet;
+    for (auto& partition : spillPartitions) {
+      const auto id = partition->id();
+      partitionSet.emplace(id, std::move(partition));
+    }
+    SpillPartitionId prevId;
+    for (auto& partitionEntry : partitionSet) {
+      if (prevId.valid()) {
+        ASSERT_LT(prevId, partitionEntry.first);
+      }
+      prevId = partitionEntry.first;
+    }
+  }
+
+  // Spill partition with files test.
+  const int numSpillers = 10;
+  const int numPartitions = 4;
+  std::vector<std::vector<RowVectorPtr>> batchesByPartition(numPartitions);
+  std::vector<std::unique_ptr<SpillPartition>> spillPartitions;
+  int numBatchesPerPartition = 0;
+  const int numRowsPerPartition = 100;
+  for (int iter = 0; iter < numSpillers; ++iter) {
+    folly::Random::DefaultGenerator rng;
+    rng.seed(iter);
+    int numBatches = 2 * (1 + folly::Random::rand32(rng) % 16);
+    setupSpillState(
+        iter % 2 ? 1 : 1'000'000'000,
+        numPartitions,
+        numBatches,
+        numRowsPerPartition);
+    numBatchesPerPartition += numBatches;
+    for (int i = 0; i < numPartitions; ++i) {
+      const SpillPartitionId id(0, i);
+      if (iter == 0) {
+        spillPartitions.emplace_back(
+            std::make_unique<SpillPartition>(id, state_->files(i)));
+      } else {
+        spillPartitions[i]->addFiles(state_->files(i));
+      }
+      std::copy(
+          batchesByPartition_[i].begin(),
+          batchesByPartition_[i].end(),
+          std::back_inserter(batchesByPartition[i]));
+    }
+  }
+  // Read verification.
+  for (int i = 0; i < numPartitions; ++i) {
+    RowVectorPtr output;
+    {
+      auto reader = spillPartitions[i]->createReader();
+      for (int j = 0; j < numBatchesPerPartition; ++j) {
+        ASSERT_TRUE(reader->nextBatch(output));
+        for (int row = 0; row < numRowsPerPartition; ++row) {
+          ASSERT_EQ(
+              0,
+              output->compare(
+                  batchesByPartition[i][j].get(), row, row, CompareFlags{}));
+        }
+      }
+    }
+    // Check spill partition state after creating the reader.
+    ASSERT_EQ(0, spillPartitions[i]->numFiles());
+    {
+      auto reader = spillPartitions[i]->createReader();
+      ASSERT_FALSE(reader->nextBatch(output));
+    }
+  }
 }


### PR DESCRIPTION
- Extend spiller to support spill a set of partitions, a vector (which bypass
  the row buffering which are required for hash build and probe side spilling
- Extend spiller to allow take a null row container which is required for hash probe
  side spilling.
- Extend spiller to trigger spill runs from the spilling operator and report
   spillable stats.
- Add spill partition id which identifies a spill partition when recursive spilling is
   enabled.
- Add SpillPartition object which contains spill id and a set of spill files. It allows
   to create an unordered reader to read sequentially from the set of spill files in
   batch
- Reduce SpillTest and SpillerTest test time 10x times by reducing the number of
   rows per vector which doesn't affect the test coverage
- Add perror stats in local file system exception message