### PR TITLE
Revert "Rename rowGroupMatches to stripeMatches (#2398)"

### DIFF
--- a/velox/dwio/common/FormatData.h
+++ b/velox/dwio/common/FormatData.h
@@ -98,13 +98,13 @@ class FormatData {
       uint64_t rowsPerRowGroup,
       const StatsContext& writerContext) = 0;
 
-  /// Test if the 'i'th Stripe (RowGroup for Parquet) can potentially match the
-  /// 'filter' using the Stripe's statistics on all columns. Returns true if all
-  /// columns in this Stripe matches the filter, false otherwise. A column is
-  /// said to match the filter if its ColumnStatistics passes the filter, or the
-  /// filter for that column is NULL.
-  virtual bool stripeMatches(
-      uint32_t stripeIndex,
+  /// Test if the 'i'th RowGroup can potentially match the 'filter' using the
+  /// RowGroup's statistics on all columns. Returns true if all columns in this
+  /// RowGroup matches the filter, false otherwise. A column is said to match
+  /// the filter if its ColumnStatistics passes the filter, or the filter for
+  /// that column is NULL.
+  virtual bool rowGroupMatches(
+      uint32_t rowGroupId,
       velox::common::Filter* FOLLY_NULLABLE filter) = 0;
 };
 

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -59,8 +59,8 @@ std::vector<uint32_t> SelectiveColumnReader::filterRowGroups(
   return formatData_->filterRowGroups(*scanSpec_, rowGroupSize, context);
 }
 
-bool SelectiveColumnReader::stripeMatches(uint32_t stripeIndex) const {
-  return formatData_->stripeMatches(stripeIndex, scanSpec_->filter());
+bool SelectiveColumnReader::rowGroupMatches(uint32_t rowGroupId) const {
+  return formatData_->rowGroupMatches(rowGroupId, scanSpec_->filter());
 }
 
 void SelectiveColumnReader::seekTo(vector_size_t offset, bool readsNullsOnly) {

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -345,7 +345,7 @@ class SelectiveColumnReader {
     initTimeClocks_ = 0;
   }
 
-  virtual bool stripeMatches(uint32_t stripeIndex) const;
+  virtual bool rowGroupMatches(uint32_t rowGroupId) const;
 
   virtual std::vector<uint32_t> filterRowGroups(
       uint64_t rowGroupSize,

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -43,9 +43,9 @@ std::vector<uint32_t> SelectiveStructColumnReader::filterRowGroups(
   return stridesToSkip;
 }
 
-bool SelectiveStructColumnReader::stripeMatches(uint32_t stripeIndex) const {
+bool SelectiveStructColumnReader::rowGroupMatches(uint32_t rowGroupId) const {
   for (const auto& child : children_) {
-    if (!child->stripeMatches(stripeIndex)) {
+    if (!child->rowGroupMatches(rowGroupId)) {
       return false;
     }
   }

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -48,7 +48,7 @@ class SelectiveStructColumnReader : public SelectiveColumnReader {
       uint64_t rowGroupSize,
       const dwio::common::StatsContext& context) const override;
 
-  bool stripeMatches(uint32_t stripeIndex) const override;
+  bool rowGroupMatches(uint32_t rowGroupId) const override;
 
   void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
       override;

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -55,10 +55,10 @@ class DwrfData : public dwio::common::FormatData {
       uint64_t rowsPerRowGroup,
       const dwio::common::StatsContext& writerContext) override;
 
-  // TODO: Refactor filterRowGroups() and implement stripeMatches() for DWRF.
-  virtual bool stripeMatches(
-      uint32_t /*stripeIndex*/,
-      velox::common::Filter* FOLLY_NULLABLE /*filter*/) override {
+  // TODO: Refactor filterRowGroups() and implement rowGroupMatches() for DWRF.
+  virtual bool rowGroupMatches(
+      uint32_t rowGroupId,
+      velox::common::Filter* FOLLY_NULLABLE filter) override {
     VELOX_UNREACHABLE();
   }
 

--- a/velox/dwio/parquet/reader/ParquetData.cpp
+++ b/velox/dwio/parquet/reader/ParquetData.cpp
@@ -36,14 +36,14 @@ std::vector<uint32_t> ParquetData::filterRowGroups(
   }
   std::vector<uint32_t> toSkip;
   for (auto i = 0; i < rowGroups_.size(); ++i) {
-    if (!stripeMatches(i, scanSpec.filter())) {
+    if (!rowGroupMatches(i, scanSpec.filter())) {
       toSkip.push_back(i);
     }
   }
   return toSkip;
 }
 
-bool ParquetData::stripeMatches(
+bool ParquetData::rowGroupMatches(
     uint32_t rowGroupId,
     common::Filter* FOLLY_NULLABLE filter) {
   auto column = type_->column;

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -61,8 +61,9 @@ class ParquetData : public dwio::common::FormatData {
 
   /// True if 'filter' may have hits for the column of 'this' according to the
   /// stats in 'rowGroup'.
-  bool stripeMatches(uint32_t rowGroupId, common::Filter* FOLLY_NULLABLE filter)
-      override;
+  bool rowGroupMatches(
+      uint32_t rowGroupId,
+      common::Filter* FOLLY_NULLABLE filter) override;
 
   std::vector<uint32_t> filterRowGroups(
       const common::ScanSpec& scanSpec,
@@ -81,7 +82,7 @@ class ParquetData : public dwio::common::FormatData {
 
   void readNulls(
       vector_size_t numValues,
-      const uint64_t* FOLLY_NULLABLE /*incomingNulls*/,
+      const uint64_t* FOLLY_NULLABLE incomingNulls,
       BufferPtr& nulls,
       bool nullsOnly = false) override {
     // If the query accesses only nulls, read the nulls from the pages in range.

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -518,7 +518,7 @@ void ParquetRowReader::filterRowGroups() {
          fileOffset < options_.getLimit());
     // A skipped row group is one that is in range and is in the excluded list.
     if (rowGroupInRange) {
-      if (columnReader_->stripeMatches(i)) {
+      if (columnReader_->rowGroupMatches(i)) {
         rowGroupIds_.push_back(i);
       } else {
         ++skippedRowGroups_;


### PR DESCRIPTION
This reverts commit bf57c9a95facf012e0dc288363ffa3ae8e94cf32.

Stripe is a specific structure in DWRF and ORC, and each stripe has
multiple RowGroups, or called "strides", which are 10000 continuous
rows. Parquet doesn't have Stripe concept, but just RowGroups. A
Parquet file can also be considerred as a file with only 1 Stripe.
Similar to filterRowGroups(), rowGroupMatches() is also meant for
eliminating specific RowGroups in either DWRF or Parquet, NOT Stripes.