### PR TITLE
Fix bison and flex dependencies in MacOS CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,11 +125,11 @@ jobs:
       - run:
           name: "Build on MacOS"
           command: |
-            export PATH=~/deps/bin:${PATH}
+            export PATH=~/deps/bin:~/deps/opt/bison/bin:~/deps/opt/flex/bin:${PATH}
             mkdir -p .ccache
             export CCACHE_DIR=$(pwd)/.ccache
             ccache -sz -M 5Gi
-            cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=~/deps -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            cmake -B _build/debug -GNinja -DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=~/deps -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DFLEX_INCLUDE_DIR=~/deps/opt/flex/include
             ninja -C _build/debug
             ccache -s
           no_output_timeout: 1h


### PR DESCRIPTION
Bison and flex come standard with MacOS.  Out of caution, homebrew will not install the executables from these kegs into the bin directory on MacOS.

Due to this, the versions of bison and flex we've been using in CircleCI on MacOS have been the ones installed with the OS not the ones we installed with homebrew.

This change fixes the PATH we use when building to include the directories where homebrew installs the executables for these two libraries.  It also updates the FLEX_INCLUDE_DIR environment variable used in cmake to point to the include directory for flex installed by homebrew.

I think we've been getting away with this because the versions that came with our MacOS image were new enough that they worked for our build, but now our dependencies require newer versions of the libraries.