### PR TITLE
Fix ExchangeClient not properly release ExchangeQueue issue upon close

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -223,14 +223,11 @@ void ExchangeClient::noMoreRemoteTasks() {
 
 void ExchangeClient::close() {
   std::vector<std::shared_ptr<ExchangeSource>> sources;
-
   {
     std::lock_guard<std::mutex> l(queue_->mutex());
-
     if (closed_) {
       return;
     }
-
     closed_ = true;
     sources = std::move(sources_);
   }
@@ -238,6 +235,10 @@ void ExchangeClient::close() {
   // Outside of mutex.
   for (auto& source : sources) {
     source->close();
+  }
+  {
+    std::lock_guard<std::mutex> l(queue_->mutex());
+    queue_->closeLocked();
   }
 }
 

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -173,6 +173,10 @@ class ExchangeQueue {
     checkComplete();
   }
 
+  void closeLocked() {
+    queue_.clear();
+  }
+
  private:
   void checkComplete() {
     if (noMoreSources_ && numCompleted_ == numSources_) {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -141,10 +141,10 @@ Task::Task(
       planFragment_(std::move(planFragment)),
       destination_(destination),
       queryCtx_(std::move(queryCtx)),
+      pool_(queryCtx_->pool()->addScopedChild("task_root")),
       splitPlanNodeIds_(collectSplitPlanNodeIds(planFragment_.planNode)),
       consumerSupplier_(std::move(consumerSupplier)),
       onError_(onError),
-      pool_(queryCtx_->pool()->addScopedChild("task_root")),
       bufferManager_(PartitionedOutputBufferManager::getInstance()) {
   auto memoryUsageTracker = pool_->getMemoryUsageTracker();
   if (memoryUsageTracker) {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -637,6 +637,19 @@ class Task : public std::enable_shared_from_this<Task> {
   const int destination_;
   const std::shared_ptr<core::QueryCtx> queryCtx_;
 
+  /// Root MemoryPool for this Task. All member variables that hold references
+  /// to pool_ must be defined after pool_, childPools_, and
+  /// childMappedMemories_
+  std::unique_ptr<memory::MemoryPool> pool_;
+
+  /// Keep driver and operator memory pools alive for the duration of the task
+  /// to allow for sharing vectors across drivers without copy.
+  std::vector<std::unique_ptr<memory::MemoryPool>> childPools_;
+
+  /// Keep operator MappedMemory instances alive for the duration of the task to
+  /// allow for sharing data without copy.
+  std::vector<std::shared_ptr<memory::MappedMemory>> childMappedMemories_;
+
   /// A set of IDs of leaf plan nodes that require splits. Used to check plan
   /// node IDs specified in split management methods.
   const std::unordered_set<core::PlanNodeId> splitPlanNodeIds_;
@@ -720,15 +733,6 @@ class Task : public std::enable_shared_from_this<Task> {
   std::vector<ContinuePromise> stateChangePromises_;
 
   TaskStats taskStats_;
-  std::unique_ptr<memory::MemoryPool> pool_;
-
-  // Keep driver and operator memory pools alive for the duration of the task to
-  // allow for sharing vectors across drivers without copy.
-  std::vector<std::unique_ptr<memory::MemoryPool>> childPools_;
-
-  // Keep operator MappedMemory instances alive for the duration of the task to
-  // allow for sharing data without copy.
-  std::vector<std::shared_ptr<memory::MappedMemory>> childMappedMemories_;
 
   /// Stores inter-operator state (exchange, bridges) per split group.
   /// During ungrouped execution we use the [0] entry in this vector.


### PR DESCRIPTION
When Task terminates and cleans up resource, close() is called for 
ExchangeClient. But close() omits to gracefully clean up resources in 
ExchangeQueue when there is a MemoryPool provided in SerializedPage.

Crash will happen when there is still unprocessed SerializedPage in 
ExchangeQueue in ExchangeClient when Task is destructed. This is because of the 
destruction order of fields in Task: MemoryPool is destructed before 
ExchangeClient, making ExchangeClient not able to properly use MemoryPool to 
cleanup upon the invocation of its destructor.