### PR TITLE
Fix  UnscaledLongDecimals Presto Serialization

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -997,14 +997,19 @@ inline void VectorStream::append(
     int128_t val = value.unscaledValue();
     // Presto Java UnscaledDecimal128 representation uses signed magnitude
     // representation. Only negative values differ in this representation.
-    // Due to this difference in representation, the UnscaledLongDecimal minimum
-    // value cannot be represented as a Presto UnscaledDecimal128 value. We
-    // throw an error in this case.
+    // Convert 2's complement value to signed magnitude value.
     if (val < 0) {
-      if (value == std::numeric_limits<UnscaledLongDecimal>::min()) {
-        VELOX_FAIL(
-            "Cannot serialize '{}' as a Presto UnscaledDecimal128 value", val);
-      }
+      // The UnscaledLongDecimal minimum value cannot be represented as
+      // a Presto UnscaledDecimal128 value.
+      // However, LongDecimal Type minimum value is limited by the maximum
+      // precision 38, i.e: (-10^38 + 1) and is greater than
+      // std::numeric_limits<UnscaledLongDecimal>::min().
+      // Ideally, for LongDecimal Types this check should not be required.
+      // For safety, we keep this check.
+      VELOX_CHECK(
+          value != std::numeric_limits<UnscaledLongDecimal>::min(),
+          "Cannot serialize '{}' as a Presto UnscaledDecimal128 value",
+          val);
       val *= -1;
       val |= kInt128SerializeMask;
     }

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -299,3 +299,20 @@ TEST_F(PrestoSerializerTest, timestampWithNanosecondPrecision) {
   auto deserialized = deserialize(rowType, out.str(), {});
   assertEqualVectors(deserialized, expectedOutputWithLostPrecision);
 }
+
+TEST_F(PrestoSerializerTest, unscaledLongDecimal) {
+  std::vector<int128_t> decimalValues(100);
+  for (int row = 0; row < 100; row++) {
+    decimalValues[row] = row - 50;
+  }
+  auto vector =
+      vectorMaker_->longDecimalFlatVector(decimalValues, DECIMAL(20, 5));
+
+  testRoundTrip(vector);
+
+  // Add some nulls.
+  for (auto i = 0; i < 100; i += 7) {
+    vector->setNull(i, true);
+  }
+  testRoundTrip(vector);
+}

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -16,6 +16,7 @@
 #include "velox/serializers/PrestoSerializer.h"
 #include <folly/Random.h>
 #include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/ByteStream.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/BaseVector.h"
@@ -301,18 +302,25 @@ TEST_F(PrestoSerializerTest, timestampWithNanosecondPrecision) {
 }
 
 TEST_F(PrestoSerializerTest, unscaledLongDecimal) {
-  std::vector<int128_t> decimalValues(100);
+  std::vector<int128_t> decimalValues(101);
   for (int row = 0; row < 100; row++) {
     decimalValues[row] = row - 50;
   }
+  decimalValues[100] = std::numeric_limits<int128_t>::max();
   auto vector =
       vectorMaker_->longDecimalFlatVector(decimalValues, DECIMAL(20, 5));
 
   testRoundTrip(vector);
 
   // Add some nulls.
-  for (auto i = 0; i < 100; i += 7) {
+  for (auto i = 0; i < 101; i += 7) {
     vector->setNull(i, true);
   }
   testRoundTrip(vector);
+
+  // std::numeric_limits<UnscaledLongDecimal>::min() will throw an error.
+  vector->set(100, std::numeric_limits<UnscaledLongDecimal>::min());
+  VELOX_ASSERT_THROW(
+      testRoundTrip(vector),
+      "Cannot serialize '-170141183460469231731687303715884105728' as a Presto UnscaledDecimal128 value");
 }


### PR DESCRIPTION
Presto Java UnscaledDecimal128 representation uses the signed magnitude representation. See https://github.com/prestodb/presto/blob/master/presto-common/src/main/java/com/facebook/presto/common/type/UnscaledDecimal128Arithmetic.java#L36
Velox UnscaledLongDecimal uses int128_t which is a 2's complement representation.
PrestoSerializer must specialize UnscaledLongDecimal handling and transform values between these
two representations.

Resolves https://github.com/facebookincubator/velox/issues/2440