### PR TITLE
Refactor MemoryPool passing for ExchangeClient

### DIFF
--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -121,6 +121,7 @@ class MergeExchangeSource : public MergeSource {
       int destination)
       : mergeExchange_(mergeExchange),
         client_(std::make_unique<ExchangeClient>(destination)) {
+    client_->initialize(mergeExchange->pool());
     client_->addRemoteTaskId(taskId);
     client_->noMoreRemoteTasks();
   }

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1290,6 +1290,11 @@ ContinueFuture Task::terminate(TaskState terminalState) {
 
   for (auto& [planNodeId, splits] : remainingRemoteSplits) {
     for (auto& split : splits.first) {
+      if (!exchangeClientByPlanNode_[planNodeId]->pool()) {
+        // If we terminate even before the client's initialization, we
+        // initialize the client with Task's memory pool.
+        exchangeClientByPlanNode_[planNodeId]->initialize(pool_.get());
+      }
       addRemoteSplit(planNodeId, split);
     }
     if (splits.second) {


### PR DESCRIPTION
Setter methods make it difficult to reason about the state of the object. 
Setters are removed and MemoryPool is fed in through creation methods.

