### PR TITLE
[Substrait to Velox] Support selecting a subfield from struct

### DIFF
--- a/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
@@ -19,10 +19,9 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/vector/tests/utils/VectorMaker.h"
-
 #include "velox/substrait/SubstraitToVeloxPlan.h"
 #include "velox/substrait/VeloxToSubstraitPlan.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include "velox/substrait/VariantToVectorConverter.h"
 
@@ -505,6 +504,37 @@ TEST_F(VeloxSubstraitRoundTripTest, dateType) {
                   .filter({"c > DATE '1992-01-01'"})
                   .planNode();
   assertPlanConversion(plan, "SELECT * FROM tmp WHERE c > DATE '1992-01-01'");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, subField) {
+  RowVectorPtr data = makeRowVector(
+      {"a", "b", "c"},
+      {
+          makeFlatVector<int64_t>({249, 235, 858}),
+          makeFlatVector<int32_t>({581, -708, -133}),
+          makeFlatVector<double>({0.905, 0.968, 0.632}),
+      });
+  createDuckDbTable({data});
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .project(
+              {"cast(row_constructor(a, b) as row(a bigint, b bigint)) as ab",
+               "a",
+               "b",
+               "c"})
+          .project(
+              {"cast(row_constructor(ab, c) as row(ab row(a bigint, b bigint), c bigint)) as abc",
+               "a",
+               "b"})
+          .project(
+              {"(cast(row_constructor(a, b) as row(a bigint, b bigint))).a",
+               "(abc).ab.a",
+               "(abc).ab.b",
+               "abc.c"})
+          .planNode();
+
+  assertPlanConversion(plan, "SELECT a, a, b, c FROM tmp");
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This PR supports selecting a subfield from struct based on `FieldAccessTypedExpr`. Added a round-trip test.