### PR TITLE
Optimize like function for fixed patterns with wildcards

### DIFF
--- a/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
@@ -90,6 +90,10 @@ class LikeFunctionsBenchmark : public FunctionBaseTest,
         auto fixedPatternString = inputString.substr(fixedPatternStartIdx, 10);
         return generateRandomString(kAnyWildcardCharacter) + fixedPatternString;
       }
+      case PatternKind::kMiddleWildcards: {
+        auto anyWildcardString = generateRandomString(kAnyWildcardCharacter);
+        return anyWildcardString + inputString + anyWildcardString;
+      }
       default:
         return inputString;
     }
@@ -195,6 +199,10 @@ BENCHMARK_MULTI(prefixPattern) {
 
 BENCHMARK_MULTI(suffixPattern) {
   return benchmark->run(PatternKind::kSuffix);
+}
+
+BENCHMARK_MULTI(fixedPatternsWithWildcards) {
+  return benchmark->run(PatternKind::kMiddleWildcards);
 }
 
 BENCHMARK_DRAW_LINE();

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -52,13 +52,11 @@ struct PatternMetadata {
       const PatternKind& patternKindArg,
       vector_size_t numSingleWildcardsArg,
       vector_size_t reducedPatternLengthArg,
-      vector_size_t numFixedPatternsArg,
       const std::optional<std::vector<std::string>>& fixedPatternsArg =
           std::nullopt)
       : patternKind(patternKindArg),
         numSingleWildcards(numSingleWildcardsArg),
         reducedPatternLength(reducedPatternLengthArg),
-        numFixedPatterns(numFixedPatternsArg),
         fixedPatterns(fixedPatternsArg) {}
 
   const PatternKind patternKind;
@@ -66,8 +64,6 @@ struct PatternMetadata {
   const vector_size_t numSingleWildcards;
   // Length of the fixed pattern in kFixed, kPrefix, and kSuffix patterns.
   const vector_size_t reducedPatternLength;
-  // Number of fixed patterns in kMiddleWildcard patterns.
-  const vector_size_t numFixedPatterns;
   // Vector of fixed patterns in kMiddleWildcard patterns.
   const std::optional<std::vector<std::string>> fixedPatterns;
 };

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -412,7 +412,7 @@ TEST_F(Re2FunctionsTest, likeDeterminePatternKind) {
           case PatternKind::kAtLeastN: {
             EXPECT_EQ(patternParameters.numSingleWildcards, length);
             EXPECT_EQ(patternParameters.reducedPatternLength, NULL);
-            EXPECT_EQ(patternParameters.numFixedPatterns, NULL);
+            EXPECT_FALSE(patternParameters.fixedPatterns);
             break;
           }
           case PatternKind::kFixed:
@@ -420,11 +420,10 @@ TEST_F(Re2FunctionsTest, likeDeterminePatternKind) {
           case PatternKind::kSuffix: {
             EXPECT_EQ(patternParameters.reducedPatternLength, length);
             EXPECT_EQ(patternParameters.numSingleWildcards, NULL);
-            EXPECT_EQ(patternParameters.numFixedPatterns, NULL);
+            EXPECT_FALSE(patternParameters.fixedPatterns);
             break;
           }
           case PatternKind::kMiddleWildcards: {
-            EXPECT_EQ(patternParameters.numFixedPatterns, length);
             EXPECT_TRUE(patternParameters.fixedPatterns);
             EXPECT_EQ(patternParameters.fixedPatterns.value().size(), length);
             EXPECT_EQ(patternParameters.reducedPatternLength, NULL);
@@ -432,7 +431,7 @@ TEST_F(Re2FunctionsTest, likeDeterminePatternKind) {
             break;
           }
           case PatternKind::kGeneric: {
-            EXPECT_EQ(patternParameters.numFixedPatterns, NULL);
+            EXPECT_FALSE(patternParameters.fixedPatterns);
             EXPECT_EQ(patternParameters.reducedPatternLength, NULL);
             EXPECT_EQ(patternParameters.numSingleWildcards, NULL);
             break;


### PR DESCRIPTION
Optimize like function for the case where pattern consists of fixed patterns interspersed with wildcard character '%', and does not belong to any of the types from #1763. These cases are most common in TPC-H queries, seen in queries 9, 13, and 16. When an escape character is involved in the like function, the default Re2 matcher is used. The following benchmarks were obtained with the optimization:
```
| No. of rows | Pattern Kind / Query Number | With PR (time/row in ns) | Without PR (time/row in ns) | % Change |   
|:-----------:|:---------------------------:|:------------------------:|:---------------------------:|:--------:|
|    10000    |  fixedPatternsWithWildcards |           287.7          |            669.78           |   57.05  |   
|             |          tpchQuery9         |          181.24          |            511.06           |   64.54  |   
|             |         tpchQuery13         |          223.96          |            635.12           |   64.74  |   
|             |     tpchQuery16Supplier     |          236.21          |            748.08           |   68.42  |
```