### PR TITLE
Enable fmt::format for Date values

### DIFF
--- a/velox/type/Date.h
+++ b/velox/type/Date.h
@@ -111,8 +111,7 @@ struct fmt::formatter<facebook::velox::Date> {
 
   template <typename FormatContext>
   auto format(const facebook::velox::Date& d, FormatContext& ctx) {
-    auto x = std::to_string(d);
-    return fmt::format_to(ctx.out(), "{}", x);
+    return fmt::format_to(ctx.out(), "{}", std::to_string(d));
   }
 };
 

--- a/velox/type/Date.h
+++ b/velox/type/Date.h
@@ -102,6 +102,20 @@ std::string to_string(const ::facebook::velox::Date& ts);
 
 } // namespace std
 
+template <>
+struct fmt::formatter<facebook::velox::Date> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(const facebook::velox::Date& d, FormatContext& ctx) {
+    auto x = std::to_string(d);
+    return fmt::format_to(ctx.out(), "{}", x);
+  }
+};
+
 namespace folly {
 template <>
 struct hasher<::facebook::velox::Date> {

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -258,18 +258,12 @@ TEST(TypeTest, dateFormat) {
     return returnDate;
   };
 
-  EXPECT_EQ(
-      fmt::format("{}", parseDate("2015-12-24")), std::string("2015-12-24"));
-  EXPECT_EQ(
-      fmt::format("{}", parseDate("1970-01-01")), std::string("1970-01-01"));
-  EXPECT_EQ(
-      fmt::format("{}", parseDate("2000-03-10")), std::string("2000-03-10"));
-  EXPECT_EQ(
-      fmt::format("{}", parseDate("1945-05-20")), std::string("1945-05-20"));
-  EXPECT_EQ(
-      fmt::format("{}", parseDate("2135-11-09")), std::string("2135-11-09"));
-  EXPECT_EQ(
-      fmt::format("{}", parseDate("1812-04-15")), std::string("1812-04-15"));
+  EXPECT_EQ(fmt::format("{}", parseDate("2015-12-24")), "2015-12-24");
+  EXPECT_EQ(fmt::format("{}", parseDate("1970-01-01")), "1970-01-01");
+  EXPECT_EQ(fmt::format("{}", parseDate("2000-03-10")), "2000-03-10");
+  EXPECT_EQ(fmt::format("{}", parseDate("1945-05-20")), "1945-05-20");
+  EXPECT_EQ(fmt::format("{}", parseDate("2135-11-09")), "2135-11-09");
+  EXPECT_EQ(fmt::format("{}", parseDate("1812-04-15")), "1812-04-15");
 }
 
 TEST(TypeTest, map) {

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -251,6 +251,27 @@ TEST(TypeTest, parseStringToDate) {
   EXPECT_EQ(parseDate("2135-11-09").days(), 60577);
 }
 
+TEST(TypeTest, dateFormat) {
+  auto parseDate = [](const std::string& dateStr) {
+    Date returnDate;
+    parseTo(dateStr, returnDate);
+    return returnDate;
+  };
+
+  EXPECT_EQ(
+      fmt::format("{}", parseDate("2015-12-24")), std::string("2015-12-24"));
+  EXPECT_EQ(
+      fmt::format("{}", parseDate("1970-01-01")), std::string("1970-01-01"));
+  EXPECT_EQ(
+      fmt::format("{}", parseDate("2000-03-10")), std::string("2000-03-10"));
+  EXPECT_EQ(
+      fmt::format("{}", parseDate("1945-05-20")), std::string("1945-05-20"));
+  EXPECT_EQ(
+      fmt::format("{}", parseDate("2135-11-09")), std::string("2135-11-09"));
+  EXPECT_EQ(
+      fmt::format("{}", parseDate("1812-04-15")), std::string("1812-04-15"));
+}
+
 TEST(TypeTest, map) {
   auto map0 = MAP(INTEGER(), ARRAY(BIGINT()));
   EXPECT_EQ(map0->toString(), "MAP<INTEGER,ARRAY<BIGINT>>");


### PR DESCRIPTION
Add a formatter for Date class to support Date values with fmt::format.