### PR TITLE
Avoid GTEST_SKIP in SpillerTest

### DIFF
--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -34,7 +34,7 @@ class Spiller {
     // Used for order by.
     kOrderBy = 3,
   };
-  static constexpr int kNumTypes = 3;
+  static constexpr int kNumTypes = 4;
   static std::string typeName(Type);
 
   // Specifies the config for spilling.


### PR DESCRIPTION
Summary:
This change modifies SpillerTest to avoid invoking GTEST_SKIP by clearly defining
the set of Spiller::Types each test supports in the parameter sets.

The advantage of this is that it's at least as clear from looking at the test output
what's being tested and what's not.  In particular, it's clearer in cases where we
weren't using GTEST_SKIP, but rather just returning immediately without testing
anything.

The disadvantage is that it requires explicitly specifying each combination, but at
this point there's only 3 including the set of all Types.

Differential Revision: D39279876

