### PR TITLE
Support complex types in expression fuzzer

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -284,7 +284,11 @@ void Expr::evalSimplifiedImpl(
     inputs_[i]->evalSimplified(remainingRows, context, inputValue);
 
     BaseVector::flattenVector(inputValue, rows.end());
-    VELOX_CHECK_EQ(VectorEncoding::Simple::FLAT, inputValue->encoding());
+    VELOX_CHECK(
+        inputValue->encoding() == VectorEncoding::Simple::FLAT ||
+        inputValue->encoding() == VectorEncoding::Simple::ARRAY ||
+        inputValue->encoding() == VectorEncoding::Simple::MAP ||
+        inputValue->encoding() == VectorEncoding::Simple::ROW);
 
     // If the resulting vector has nulls, merge them into our current remaining
     // rows bitmap.

--- a/velox/expression/tests/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzer.cpp
@@ -30,6 +30,7 @@ namespace {
 // TODO: Extend this function to return arbitrary random types including nested
 // complex types.
 TypePtr randomType(std::mt19937& seed) {
+  // Decimal types are not supported because VectorFuzzer doesn't support them.
   static std::vector<TypePtr> kSupportedTypes{
       BOOLEAN(),
       TINYINT(),
@@ -40,23 +41,21 @@ TypePtr randomType(std::mt19937& seed) {
       DOUBLE(),
       TIMESTAMP(),
       DATE(),
-      INTERVAL_DAY_TIME(),
-      SHORT_DECIMAL(10, 5),
-      LONG_DECIMAL(20, 10)};
+      INTERVAL_DAY_TIME()};
   auto index = folly::Random::rand32(kSupportedTypes.size(), seed);
   return kSupportedTypes[index];
 }
 
-std::string fromTypeToBaseName(const TypePtr& type) {
+} // namespace
+
+std::string typeToBaseName(const TypePtr& type) {
   return boost::algorithm::to_lower_copy(std::string{type->kindName()});
 }
 
-std::optional<TypeKind> fromBaseNameToTypeKind(std::string& typeName) {
+std::optional<TypeKind> baseNameToTypeKind(const std::string& typeName) {
   auto kindName = boost::algorithm::to_upper_copy(typeName);
   return tryMapNameToTypeKind(kindName);
 }
-
-} // namespace
 
 void ArgumentTypeFuzzer::determineUnboundedTypeVariables() {
   for (auto& binding : bindings_) {

--- a/velox/expression/tests/ArgumentTypeFuzzer.h
+++ b/velox/expression/tests/ArgumentTypeFuzzer.h
@@ -65,4 +65,11 @@ class ArgumentTypeFuzzer {
   std::mt19937& seed_;
 };
 
+/// Return the kind name of type in lower case. This is expected to match the
+/// TypeSignature::baseName_ corresponding to type.
+std::string typeToBaseName(const TypePtr& type);
+
+/// Return the TypeKind that corresponds to typeName.
+std::optional<TypeKind> baseNameToTypeKind(const std::string& typeName);
+
 } // namespace facebook::velox::test

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -89,8 +89,13 @@ target_link_libraries(velox_expression_verifier velox_vector_test_lib
 add_library(velox_expression_fuzzer ExpressionFuzzer.cpp)
 
 target_link_libraries(
-  velox_expression_fuzzer velox_expression_verifier velox_type
-  velox_vector_fuzzer velox_vector_test_lib velox_function_registry)
+  velox_expression_fuzzer
+  velox_expression_verifier
+  velox_type
+  velox_vector_fuzzer
+  velox_vector_test_lib
+  velox_function_registry
+  velox_expression_test_utility)
 
 add_executable(velox_expression_fuzzer_unit_test ExpressionFuzzerUnitTest.cpp)
 


### PR DESCRIPTION
Summary:
Support testing functions whose signatures contain complex types or type
variables (e.g., foo(array(T), bigint) -> T). This is a work in progress.

This diff also fixes bugs of creating ConstantTypedExpr for complex types
that is required by the expression fuzzer.

Differential Revision: D38798637

