### PR TITLE
Add null specifiers to Exchange.*

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -68,7 +68,7 @@ std::shared_ptr<ExchangeSource> ExchangeSource::create(
   VELOX_FAIL("No ExchangeSource factory matches {}", taskId);
 }
 
-void ExchangeSource::setMemoryPool(memory::MemoryPool* pool) {
+void ExchangeSource::setMemoryPool(memory::MemoryPool* FOLLY_NULLABLE pool) {
   pool_ = pool;
 }
 
@@ -178,7 +178,8 @@ std::unique_ptr<ExchangeSource> createLocalExchangeSource(
 
 } // namespace
 
-void ExchangeClient::maybeSetMemoryPool(memory::MemoryPool* pool) {
+void ExchangeClient::maybeSetMemoryPool(
+    memory::MemoryPool* FOLLY_NONNULL pool) {
   // ExchangeClient could be shared by the same exchange operators from
   // different drivers so we only need to set it on the first operator setup.
   if (pool_ == nullptr) {
@@ -288,7 +289,7 @@ std::string ExchangeClient::toString() {
   return out.str();
 }
 
-bool Exchange::getSplits(ContinueFuture* future) {
+bool Exchange::getSplits(ContinueFuture* FOLLY_NONNULL future) {
   if (operatorCtx_->driverCtx()->driverId != 0) {
     // When there are multiple pipelines, a single operator, the one from
     // pipeline 0, is responsible for feeding splits into shared ExchangeClient.
@@ -322,7 +323,7 @@ bool Exchange::getSplits(ContinueFuture* future) {
   }
 }
 
-BlockingReason Exchange::isBlocked(ContinueFuture* future) {
+BlockingReason Exchange::isBlocked(ContinueFuture* FOLLY_NONNULL future) {
   if (currentPage_ || atEnd_) {
     return BlockingReason::kNotBlocked;
   }

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -35,7 +35,7 @@ class SerializedPage {
   // TODO: consider to enforce setting memory pool if possible.
   explicit SerializedPage(
       std::unique_ptr<folly::IOBuf> iobuf,
-      memory::MemoryPool* pool = nullptr,
+      memory::MemoryPool* FOLLY_NULLABLE pool = nullptr,
       std::function<void(folly::IOBuf&)> onDestructionCb = nullptr);
 
   ~SerializedPage();
@@ -47,7 +47,7 @@ class SerializedPage {
 
   // Makes 'input' ready for deserializing 'this' with
   // VectorStreamGroup::read().
-  void prepareStreamForDeserialize(ByteStream* input);
+  void prepareStreamForDeserialize(ByteStream* FOLLY_NONNULL input);
 
   std::unique_ptr<folly::IOBuf> getIOBuf() const {
     return iobuf_->clone();
@@ -70,7 +70,7 @@ class SerializedPage {
 
   // Number of payload bytes in 'iobuf_'.
   const int64_t iobufBytes_;
-  memory::MemoryPool* pool_{nullptr};
+  memory::MemoryPool* FOLLY_NULLABLE pool_;
 
   // Callback that will be called on destruction of the SerializedPage,
   // primarily used to free externally allocated memory backing folly::IOBuf
@@ -126,7 +126,9 @@ class ExchangeQueue {
     clearAllPromises();
   }
 
-  std::unique_ptr<SerializedPage> dequeue(bool* atEnd, ContinueFuture* future) {
+  std::unique_ptr<SerializedPage> dequeue(
+      bool* FOLLY_NONNULL atEnd,
+      ContinueFuture* FOLLY_NONNULL future) {
     VELOX_CHECK(future);
     if (!error_.empty()) {
       *atEnd = true;
@@ -260,7 +262,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
 
   static std::vector<Factory>& factories();
 
-  void setMemoryPool(memory::MemoryPool* pool);
+  void setMemoryPool(memory::MemoryPool* FOLLY_NULLABLE pool);
   // ID of the task producing data
   const std::string taskId_;
   // Destination number of 'this' on producer
@@ -271,7 +273,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   bool atEnd_ = false;
 
  protected:
-  memory::MemoryPool* pool_{nullptr};
+  memory::MemoryPool* FOLLY_NULLABLE pool_{nullptr};
 };
 
 struct RemoteConnectorSplit : public connector::ConnectorSplit {
@@ -298,11 +300,11 @@ class ExchangeClient {
 
   ~ExchangeClient();
 
-  memory::MemoryPool* pool() const {
+  memory::MemoryPool* FOLLY_NULLABLE pool() const {
     return pool_;
   }
 
-  void maybeSetMemoryPool(memory::MemoryPool* pool);
+  void maybeSetMemoryPool(memory::MemoryPool* FOLLY_NONNULL pool);
 
   // Creates an exchange source and starts fetching data from the specified
   // upstream task. If 'close' has been called already, creates an exchange
@@ -319,7 +321,9 @@ class ExchangeClient {
     return queue_;
   }
 
-  std::unique_ptr<SerializedPage> next(bool* atEnd, ContinueFuture* future);
+  std::unique_ptr<SerializedPage> next(
+      bool* FOLLY_NONNULL atEnd,
+      ContinueFuture* FOLLY_NONNULL future);
 
   std::string toString();
 
@@ -328,7 +332,7 @@ class ExchangeClient {
   std::shared_ptr<ExchangeQueue> queue_;
   std::unordered_set<std::string> taskIds_;
   std::vector<std::shared_ptr<ExchangeSource>> sources_;
-  memory::MemoryPool* pool_{nullptr};
+  memory::MemoryPool* FOLLY_NULLABLE pool_{nullptr};
   bool closed_{false};
 };
 
@@ -336,7 +340,7 @@ class Exchange : public SourceOperator {
  public:
   Exchange(
       int32_t operatorId,
-      DriverCtx* ctx,
+      DriverCtx* FOLLY_NONNULL ctx,
       const std::shared_ptr<const core::ExchangeNode>& exchangeNode,
       std::shared_ptr<ExchangeClient> exchangeClient)
       : SourceOperator(
@@ -366,7 +370,7 @@ class Exchange : public SourceOperator {
     exchangeClient_ = nullptr;
   }
 
-  BlockingReason isBlocked(ContinueFuture* future) override;
+  BlockingReason isBlocked(ContinueFuture* FOLLY_NONNULL future) override;
 
   bool isFinished() override;
 
@@ -378,7 +382,7 @@ class Exchange : public SourceOperator {
   /// this operator is not the first operator in the pipeline and therefore is
   /// not responsible for fetching splits and adding them to the
   /// exchangeClient_.
-  bool getSplits(ContinueFuture* future);
+  bool getSplits(ContinueFuture* FOLLY_NONNULL future);
 
   const core::PlanNodeId planNodeId_;
   bool noMoreSplits_ = false;


### PR DESCRIPTION
Existing implementations in Exchange.h/cpp does not have null specifiers for 
null pointer parameters/fields. Adding null specifiers to eliminate compilation 
warnings.