### PR TITLE
Add ArgumentTypeFuzzer utility class

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_expression_functions FunctionRegistry.h FunctionSignature.cpp
-                                       SignatureBinder.cpp)
+add_library(
+  velox_expression_functions FunctionSignature.cpp SignatureBinder.cpp
+                             ReverseSignatureBinder.cpp)
 
 target_link_libraries(velox_expression_functions velox_common_base
                       velox_type_calculation)

--- a/velox/expression/ReverseSignatureBinder.cpp
+++ b/velox/expression/ReverseSignatureBinder.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ReverseSignatureBinder.h"
+#include "FunctionSignature.h"
+
+namespace facebook::velox::exec {
+
+bool ReverseSignatureBinder::isConstrainedType(
+    const TypeSignature& type) const {
+  if (type.parameters().empty()) {
+    return constraints_.find(type.baseName()) != constraints_.end();
+  }
+
+  auto parameters = type.parameters();
+  for (const auto& parameter : parameters) {
+    if (isConstrainedType(parameter)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ReverseSignatureBinder::tryBind() {
+  if (isConstrainedType(signature_.returnType())) {
+    return false;
+  }
+  return SignatureBinderBase::tryBind(signature_.returnType(), returnType_);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ReverseSignatureBinder.h
+++ b/velox/expression/ReverseSignatureBinder.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/FunctionSignature.h"
+#include "velox/expression/SignatureBinder.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::exec {
+
+/// Bind a function signature with a concrete return type. bindings() return a
+/// map from each type variable in the signature to the corresponding concrete
+/// type if determined, or a nullptr if the type variable cannot be determined
+/// by the return type.
+class ReverseSignatureBinder : private SignatureBinderBase {
+ public:
+  ReverseSignatureBinder(
+      const exec::FunctionSignature& signature,
+      const TypePtr& returnType)
+      : SignatureBinderBase{signature}, returnType_{returnType} {}
+
+  /// Try bind returnType_ to the return type of the function signature. Return
+  /// true if the binding succeeds, or false otherwise.
+  bool tryBind();
+
+  /// Return the determined bindings. This function should be called after
+  /// tryBind() and only if tryBind() returns true. If a type variable is not
+  /// determined by tryBind(), it maps to a nullptr.
+  const std::unordered_map<std::string, TypePtr>& bindings() const {
+    return typeParameters_;
+  }
+
+ private:
+  /// Return whether there is a constraint on the type in the function
+  /// signature.
+  bool isConstrainedType(const TypeSignature& type) const;
+
+  const TypePtr returnType_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -141,14 +141,14 @@ bool SignatureBinder::tryBind() {
   }
 
   for (auto i = 0; i < formalArgsCnt && i < actualTypes_.size(); i++) {
-    if (!tryBind(formalArgs[i], actualTypes_[i])) {
+    if (!SignatureBinderBase::tryBind(formalArgs[i], actualTypes_[i])) {
       return false;
     }
   }
   return true;
 }
 
-bool SignatureBinder::checkOrSetIntegerParameter(
+bool SignatureBinderBase::checkOrSetIntegerParameter(
     const std::string& parameterName,
     int value) {
   auto it = integerParameters_.find(parameterName);
@@ -164,7 +164,7 @@ bool SignatureBinder::checkOrSetIntegerParameter(
   return true;
 }
 
-bool SignatureBinder::tryBindIntegerParameters(
+bool SignatureBinderBase::tryBindIntegerParameters(
     const std::vector<exec::TypeSignature>& parameters,
     const TypePtr& actualType) {
   // Decimal types
@@ -177,7 +177,7 @@ bool SignatureBinder::tryBindIntegerParameters(
   return false;
 }
 
-bool SignatureBinder::tryBind(
+bool SignatureBinderBase::tryBind(
     const exec::TypeSignature& typeSignature,
     const TypePtr& actualType) {
   if (isAny(typeSignature)) {

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -20,16 +20,10 @@
 
 namespace facebook::velox::exec {
 
-/// Resolves generic type names in the function signature using actual input
-/// types. E.g. given function signature array(T) -> T and input type
-/// array(bigint), resolves T to bigint. If type resolution is successful,
-/// calculates the actual return type, e.g. bigint in the previous example.
-class SignatureBinder {
- public:
-  SignatureBinder(
-      const exec::FunctionSignature& signature,
-      const std::vector<TypePtr>& actualTypes)
-      : signature_{signature}, actualTypes_{actualTypes} {
+class SignatureBinderBase {
+ protected:
+  explicit SignatureBinderBase(const exec::FunctionSignature& signature)
+      : signature_{signature} {
     for (auto& variable : signature.typeVariableConstraints()) {
       // Integer parameters are updated during bind.
       if (variable.isTypeParameter()) {
@@ -43,10 +37,43 @@ class SignatureBinder {
     }
   }
 
-  // Returns true if successfully resolved all generic type names.
+  /// Return true if actualType can bind to typeSignature and update bindings_
+  /// accordingly.
+  bool tryBind(
+      const exec::TypeSignature& typeSignature,
+      const TypePtr& actualType);
+
+  const exec::FunctionSignature& signature_;
+  std::unordered_map<std::string, TypePtr> typeParameters_;
+  std::unordered_map<std::string, std::optional<int>> integerParameters_;
+  std::unordered_map<std::string, std::string> constraints_;
+
+ private:
+  /// If the integer parameter is set, then it must match with value.
+  /// Returns false if values do not match or the parameter does not exist.
+  bool checkOrSetIntegerParameter(const std::string& parameterName, int value);
+
+  /// Try to bind the integer parameter from the actualType.
+  bool tryBindIntegerParameters(
+      const std::vector<exec::TypeSignature>& parameters,
+      const TypePtr& actualType);
+};
+
+/// Resolves generic type names in the function signature using actual input
+/// types. E.g. given function signature array(T) -> T and input type
+/// array(bigint), resolves T to bigint. If type resolution is successful,
+/// calculates the actual return type, e.g. bigint in the previous example.
+class SignatureBinder : private SignatureBinderBase {
+ public:
+  SignatureBinder(
+      const exec::FunctionSignature& signature,
+      const std::vector<TypePtr>& actualTypes)
+      : SignatureBinderBase{signature}, actualTypes_{actualTypes} {}
+
+  /// Returns true if successfully resolved all generic type names.
   bool tryBind();
 
-  // Returns concrete return type or null if couldn't fully resolve.
+  /// Returns concrete return type or null if couldn't fully resolve.
   TypePtr tryResolveReturnType() {
     return tryResolveType(signature_.returnType());
   }
@@ -61,7 +88,7 @@ class SignatureBinder {
     return tryResolveType(
         typeSignature, typeParameters, constraints, integerParameters);
   }
-  // Returns concrete return type or null if couldn't fully resolve.
+  /// Returns concrete return type or null if couldn't fully resolve.
   static TypePtr tryResolveType(
       const exec::TypeSignature& typeSignature,
       const std::unordered_map<std::string, TypePtr>& typeParameters,
@@ -69,23 +96,6 @@ class SignatureBinder {
       std::unordered_map<std::string, std::optional<int>>& integerParameters);
 
  private:
-  bool tryBind(
-      const exec::TypeSignature& typeSignature,
-      const TypePtr& actualType);
-
-  // If the integer parameter is set, then it must match with value.
-  // Returns false if values do not match or the parameter does not exist.
-  bool checkOrSetIntegerParameter(const std::string& parameterName, int value);
-
-  // Try to bind the integer parameter from the actualType.
-  bool tryBindIntegerParameters(
-      const std::vector<exec::TypeSignature>& parameters,
-      const TypePtr& actualType);
-
-  const exec::FunctionSignature& signature_;
   const std::vector<TypePtr>& actualTypes_;
-  std::unordered_map<std::string, TypePtr> typeParameters_;
-  std::unordered_map<std::string, std::optional<int>> integerParameters_;
-  std::unordered_map<std::string, std::string> constraints_;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzer.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/tests/ArgumentTypeFuzzer.h"
+
+#include <boost/algorithm/string.hpp>
+
+#include "velox/expression/ReverseSignatureBinder.h"
+#include "velox/expression/SignatureBinder.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::test {
+
+namespace {
+
+// Return a random type among those in kSupportedTypes determined by seed.
+// TODO: Extend this function to return arbitrary random types including nested
+// complex types.
+TypePtr randomType(std::mt19937& seed) {
+  static std::vector<TypePtr> kSupportedTypes{
+      BOOLEAN(),
+      TINYINT(),
+      SMALLINT(),
+      INTEGER(),
+      BIGINT(),
+      REAL(),
+      DOUBLE(),
+      TIMESTAMP(),
+      DATE(),
+      INTERVAL_DAY_TIME(),
+      SHORT_DECIMAL(10, 5),
+      LONG_DECIMAL(20, 10)};
+  auto index = folly::Random::rand32(kSupportedTypes.size(), seed);
+  return kSupportedTypes[index];
+}
+
+std::string fromTypeToBaseName(const TypePtr& type) {
+  return boost::algorithm::to_lower_copy(std::string{type->kindName()});
+}
+
+std::optional<TypeKind> fromBaseNameToTypeKind(std::string& typeName) {
+  auto kindName = boost::algorithm::to_upper_copy(typeName);
+  return tryMapNameToTypeKind(kindName);
+}
+
+} // namespace
+
+void ArgumentTypeFuzzer::determineUnboundedTypeVariables() {
+  for (auto& binding : bindings_) {
+    if (!binding.second) {
+      binding.second = randomType(seed_);
+    }
+  }
+}
+
+bool ArgumentTypeFuzzer::fuzzArgumentTypes() {
+  const auto& formalArgs = signature_.argumentTypes();
+  auto formalArgsCnt = formalArgs.size();
+
+  exec::ReverseSignatureBinder binder{signature_, returnType_};
+  if (!binder.tryBind()) {
+    return false;
+  }
+  bindings_ = binder.bindings();
+
+  determineUnboundedTypeVariables();
+  for (auto i = 0; i < formalArgsCnt; i++) {
+    TypePtr actualArg;
+    if (formalArgs[i].baseName() == "any") {
+      actualArg = randomType(seed_);
+    } else {
+      actualArg =
+          exec::SignatureBinder::tryResolveType(formalArgs[i], bindings_);
+      VELOX_CHECK(actualArg != nullptr);
+    }
+    argumentTypes_.push_back(actualArg);
+  }
+
+  // Generate random repeats of the last argument type if the signature is
+  // variadic.
+  if (signature_.variableArity()) {
+    auto repeat = folly::Random::rand32(5, seed_);
+    auto last = argumentTypes_[formalArgsCnt - 1];
+    for (int i = 0; i < repeat; ++i) {
+      argumentTypes_.push_back(last);
+    }
+  }
+
+  return true;
+}
+
+} // namespace facebook::velox::test

--- a/velox/expression/tests/ArgumentTypeFuzzer.h
+++ b/velox/expression/tests/ArgumentTypeFuzzer.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/Random.h>
+
+#include "velox/expression/FunctionSignature.h"
+#include "velox/expression/SignatureBinder.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::test {
+
+/// For function signatures containing type variables, try generate a list of
+/// arguments types such that the function taking these arugments returns the
+/// given type. If there are type variables unbounded by the return type,
+/// generate a random type for them with seed_.
+class ArgumentTypeFuzzer {
+ public:
+  ArgumentTypeFuzzer(
+      const exec::FunctionSignature& signature,
+      const TypePtr& returnType,
+      std::mt19937& seed)
+      : signature_{signature}, returnType_{returnType}, seed_{seed} {}
+
+  /// Generate random argument types if returnType_ can be bound to the return
+  /// type of signature_. Return true if the generation succeeds, false
+  /// otherwise.
+  bool fuzzArgumentTypes();
+
+  /// Return the generated list of argument types. This function should be
+  /// called after fuzzArgumentTypes() is called and returns true.
+  const std::vector<TypePtr>& argumentTypes() const {
+    return argumentTypes_;
+  }
+
+ private:
+  /// Bind each type variable that is not determined by the return type to a
+  /// randomly generated type.
+  void determineUnboundedTypeVariables();
+
+  const exec::FunctionSignature& signature_;
+
+  const TypePtr returnType_;
+
+  std::vector<TypePtr> argumentTypes_;
+
+  /// Bindings between type variables and their actual types.
+  std::unordered_map<std::string, TypePtr> bindings_;
+
+  /// Seed to generate random types for unbounded type variables when necessary.
+  std::mt19937& seed_;
+};
+
+} // namespace facebook::velox::test

--- a/velox/expression/tests/ArgumentTypeFuzzerTest.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzerTest.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/tests/ArgumentTypeFuzzer.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/expression/SignatureBinder.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::test {
+
+class ArgumentTypeFuzzerTest : public testing::Test {
+ protected:
+  void testFuzzingSuccess(
+      const std::shared_ptr<exec::FunctionSignature>& signature,
+      const TypePtr& returnType,
+      const std::vector<TypePtr>& expectedArgumentTypes) {
+    std::mt19937 seed{0};
+    ArgumentTypeFuzzer fuzzer{*signature, returnType, seed};
+    ASSERT_TRUE(fuzzer.fuzzArgumentTypes());
+
+    auto& argumentTypes = fuzzer.argumentTypes();
+    ASSERT_LE(expectedArgumentTypes.size(), argumentTypes.size());
+
+    auto& argumentSignatures = signature->argumentTypes();
+    int i;
+    for (i = 0; i < expectedArgumentTypes.size(); ++i) {
+      ASSERT_TRUE(expectedArgumentTypes[i]->equivalent(*argumentTypes[i]));
+    }
+
+    if (i < argumentTypes.size()) {
+      ASSERT_TRUE(signature->variableArity());
+      for (int j = i; j < argumentTypes.size(); ++j) {
+        ASSERT_TRUE(argumentTypes[j]->equivalent(*argumentTypes[i - 1]));
+      }
+    }
+  }
+
+  void testFuzzingFailure(
+      const std::shared_ptr<exec::FunctionSignature>& signature,
+      const TypePtr& returnType) {
+    std::mt19937 seed{0};
+    ArgumentTypeFuzzer fuzzer{*signature, returnType, seed};
+    ASSERT_FALSE(fuzzer.fuzzArgumentTypes());
+  }
+};
+
+TEST_F(ArgumentTypeFuzzerTest, concreteSignature) {
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("bigint")
+                         .argumentType("varchar")
+                         .argumentType("array(boolean)")
+                         .build();
+
+    testFuzzingSuccess(signature, BIGINT(), {VARCHAR(), ARRAY(BOOLEAN())});
+    testFuzzingFailure(signature, SMALLINT());
+  }
+
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("array(array(double))")
+                         .argumentType("array(bigint)")
+                         .argumentType("double")
+                         .build();
+
+    testFuzzingSuccess(
+        signature, ARRAY(ARRAY(DOUBLE())), {ARRAY(BIGINT()), DOUBLE()});
+    testFuzzingFailure(signature, ARRAY(ARRAY(REAL())));
+    testFuzzingFailure(signature, ARRAY(DOUBLE()));
+  }
+}
+
+TEST_F(ArgumentTypeFuzzerTest, signatureTemplate) {
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .typeVariable("T")
+                         .returnType("T")
+                         .argumentType("T")
+                         .argumentType("array(T)")
+                         .build();
+
+    testFuzzingSuccess(signature, BIGINT(), {BIGINT(), ARRAY(BIGINT())});
+    testFuzzingSuccess(
+        signature, ARRAY(DOUBLE()), {ARRAY(DOUBLE()), ARRAY(ARRAY(DOUBLE()))});
+    testFuzzingSuccess(
+        signature, ROW({DOUBLE()}), {ROW({DOUBLE()}), ARRAY(ROW({DOUBLE()}))});
+  }
+
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .typeVariable("T")
+                         .returnType("array(T)")
+                         .argumentType("T")
+                         .argumentType("bigint")
+                         .build();
+
+    testFuzzingSuccess(
+        signature, ARRAY(ARRAY(DOUBLE())), {ARRAY(DOUBLE()), BIGINT()});
+    testFuzzingSuccess(signature, ARRAY(VARCHAR()), {VARCHAR(), BIGINT()});
+    testFuzzingFailure(signature, BIGINT());
+    testFuzzingFailure(signature, MAP(VARCHAR(), BIGINT()));
+  }
+
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .typeVariable("K")
+                         .typeVariable("V")
+                         .returnType("K")
+                         .argumentType("array(K)")
+                         .argumentType("array(V)")
+                         .build();
+
+    auto verifyArgumentTypes = [&](const TypePtr& returnType,
+                                   const TypePtr& firstArg) {
+      std::mt19937 seed{0};
+      ArgumentTypeFuzzer fuzzer{*signature, returnType, seed};
+      ASSERT_TRUE(fuzzer.fuzzArgumentTypes());
+
+      auto& argumentTypes = fuzzer.argumentTypes();
+      ASSERT_TRUE(argumentTypes[0]->equivalent(*firstArg));
+      // Only check the top-level type because the child type is randomly
+      // generated.
+      ASSERT_TRUE(argumentTypes[1]->isArray());
+    };
+
+    verifyArgumentTypes(SHORT_DECIMAL(10, 5), ARRAY(SHORT_DECIMAL(10, 5)));
+    verifyArgumentTypes(ARRAY(DOUBLE()), ARRAY(ARRAY(DOUBLE())));
+  }
+
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .typeVariable("K")
+                         .typeVariable("V")
+                         .returnType("bigint")
+                         .argumentType("array(K)")
+                         .argumentType("array(V)")
+                         .build();
+
+    {
+      std::mt19937 seed{0};
+      ArgumentTypeFuzzer fuzzer{*signature, BIGINT(), seed};
+      ASSERT_TRUE(fuzzer.fuzzArgumentTypes());
+
+      auto& argumentTypes = fuzzer.argumentTypes();
+      // Only check the top-level type because the children types are randomly
+      // generated.
+      ASSERT_TRUE(argumentTypes[0]->isArray());
+      ASSERT_TRUE(argumentTypes[1]->isArray());
+    }
+
+    testFuzzingFailure(signature, DOUBLE());
+  }
+}
+
+TEST_F(ArgumentTypeFuzzerTest, variableArity) {
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .typeVariable("X")
+                         .returnType("X")
+                         .argumentType("X")
+                         .argumentType("bigint")
+                         .variableArity()
+                         .build();
+
+    testFuzzingSuccess(signature, VARCHAR(), {VARCHAR(), BIGINT()});
+  }
+
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .typeVariable("K")
+                         .returnType("bigint")
+                         .argumentType("K")
+                         .variableArity()
+                         .build();
+    std::mt19937 seed{0};
+    ArgumentTypeFuzzer fuzzer{*signature, BIGINT(), seed};
+    ASSERT_TRUE(fuzzer.fuzzArgumentTypes());
+
+    auto& argumentTypes = fuzzer.argumentTypes();
+    auto& firstArg = argumentTypes[0];
+    for (const auto& argument : argumentTypes) {
+      ASSERT_TRUE(argument->equivalent(*firstArg));
+    }
+  }
+}
+
+TEST_F(ArgumentTypeFuzzerTest, any) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .returnType("bigint")
+                       .argumentType("any")
+                       .build();
+  std::mt19937 seed{0};
+  ArgumentTypeFuzzer fuzzer{*signature, BIGINT(), seed};
+  ASSERT_TRUE(fuzzer.fuzzArgumentTypes());
+
+  auto& argumentTypes = fuzzer.argumentTypes();
+  ASSERT_EQ(argumentTypes.size(), 1);
+  ASSERT_TRUE(argumentTypes[0] != nullptr);
+}
+
+TEST_F(ArgumentTypeFuzzerTest, unsupported) {
+  // Constraints on the return type is not supported.
+  auto signature =
+      exec::FunctionSignatureBuilder()
+          .integerVariable("a_scale")
+          .integerVariable("b_scale")
+          .integerVariable("a_precision")
+          .integerVariable("b_precision")
+          .integerVariable(
+              "r_precision",
+              "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
+          .integerVariable("r_scale", "max(a_scale, b_scale)")
+          .returnType("row(array(decimal(r_precision, r_scale)))")
+          .argumentType("decimal(a_precision, a_scale)")
+          .argumentType("decimal(b_precision, b_scale)")
+          .build();
+
+  testFuzzingFailure(signature, DECIMAL(13, 6));
+}
+
+} // namespace facebook::velox::test

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   ConstantFlatVectorReaderTest.cpp
   MapWriterTest.cpp
   ArrayWriterTest.cpp
+  ReverseSignatureBinderTest.cpp
   RowWriterTest.cpp
   EvalSimplifiedTest.cpp
   SignatureBinderTest.cpp

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_library(velox_expression_test_utility ArgumentTypeFuzzer.cpp)
+
+target_link_libraries(velox_expression_test_utility velox_type
+                      velox_expression_functions)
+
 add_executable(
   velox_expression_test
+  ArgumentTypeFuzzerTest.cpp
   ExprEncodingsTest.cpp
   ExprTest.cpp
   ExprCompilerTest.cpp
@@ -57,6 +63,7 @@ target_link_libraries(
   velox_dwio_common_exception
   velox_exec_test_lib
   velox_expression
+  velox_expression_test_utility
   velox_functions_lib
   velox_functions_prestosql
   velox_functions_test_lib

--- a/velox/expression/tests/ReverseSignatureBinderTest.cpp
+++ b/velox/expression/tests/ReverseSignatureBinderTest.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/ReverseSignatureBinder.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox {
+namespace {
+
+class ReverseSignatureBinderTest : public testing::Test {
+ protected:
+  void testBindingSuccess(
+      const std::shared_ptr<exec::FunctionSignature>& signature,
+      const TypePtr& returnType,
+      const std::vector<std::pair<std::string, TypePtr>>& expectedBindings) {
+    exec::ReverseSignatureBinder binder{*signature, returnType};
+    ASSERT_TRUE(binder.tryBind());
+
+    auto actualBindings = binder.bindings();
+    ASSERT_EQ(actualBindings.size(), expectedBindings.size());
+
+    for (const auto& pair : expectedBindings) {
+      ASSERT_EQ(actualBindings.count(pair.first), 1);
+      if (pair.second) {
+        ASSERT_TRUE(pair.second->equivalent(*actualBindings[pair.first]));
+      } else {
+        ASSERT_TRUE(actualBindings[pair.first] == nullptr);
+      }
+    }
+  }
+
+  void testBindingFailure(
+      const std::shared_ptr<exec::FunctionSignature>& signature,
+      const TypePtr& returnType) {
+    exec::ReverseSignatureBinder binder{*signature, returnType};
+    ASSERT_FALSE(binder.tryBind());
+  }
+};
+
+TEST_F(ReverseSignatureBinderTest, concreteSignature) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .returnType("array(varchar)")
+                       .argumentType("varchar")
+                       .argumentType("bigint")
+                       .build();
+
+  testBindingSuccess(signature, ARRAY(VARCHAR()), {});
+  testBindingFailure(signature, VARCHAR());
+}
+
+TEST_F(ReverseSignatureBinderTest, any) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .returnType("array(any)")
+                       .argumentType("varchar")
+                       .argumentType("bigint")
+                       .build();
+
+  testBindingSuccess(signature, ARRAY(VARCHAR()), {});
+  testBindingFailure(signature, VARCHAR());
+}
+
+TEST_F(ReverseSignatureBinderTest, signatureTemplateFullBinding) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .typeVariable("K")
+                       .typeVariable("V")
+                       .returnType("map(K, V)")
+                       .argumentType("K")
+                       .argumentType("V")
+                       .build();
+
+  testBindingSuccess(
+      signature, MAP(VARCHAR(), BIGINT()), {{"K", VARCHAR()}, {"V", BIGINT()}});
+  testBindingFailure(signature, VARCHAR());
+}
+
+TEST_F(ReverseSignatureBinderTest, signatureTemplatePartialBinding) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .typeVariable("K")
+                       .typeVariable("V")
+                       .returnType("array(K)")
+                       .argumentType("K")
+                       .argumentType("V")
+                       .build();
+
+  testBindingSuccess(
+      signature, ARRAY(VARCHAR()), {{"K", VARCHAR()}, {"V", nullptr}});
+  testBindingFailure(signature, VARCHAR());
+}
+
+TEST_F(ReverseSignatureBinderTest, unsupported) {
+  // Constraints on the return type is not supported.
+  auto signature =
+      exec::FunctionSignatureBuilder()
+          .integerVariable("a_scale")
+          .integerVariable("b_scale")
+          .integerVariable("a_precision")
+          .integerVariable("b_precision")
+          .integerVariable(
+              "r_precision",
+              "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
+          .integerVariable("r_scale", "max(a_scale, b_scale)")
+          .returnType("row(array(decimal(r_precision, r_scale)))")
+          .argumentType("decimal(a_precision, a_scale)")
+          .argumentType("decimal(b_precision, b_scale)")
+          .build();
+
+  testBindingFailure(signature, DECIMAL(13, 6));
+}
+
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
Summary: Add ArgumentTypeFuzzer that can be used to generate a random list of 
argument types for a function such that the function returns a given type. This class 
is useful for enabling complex types in expression fuzzer.

Differential Revision: D39231330

