### PR TITLE
Fix TSAN issues in DriverTest.terminate test

### DIFF
--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -353,7 +353,7 @@ TEST_F(DriverTest, cancel) {
   int32_t numRead = 0;
   try {
     readResults(params, ResultOperation::kCancel, 1'000'000, &numRead);
-    EXPECT_TRUE(false) << "Expected exception";
+    FAIL() << "Expected exception";
   } catch (const VeloxRuntimeError& e) {
     EXPECT_EQ("Cancelled", e.message());
   }
@@ -385,6 +385,11 @@ TEST_F(DriverTest, terminate) {
     // If this is an exception, it will be a cancellation.
     EXPECT_TRUE(strstr(e.what(), "Aborted") != nullptr) << e.what();
   }
+
+  ASSERT_TRUE(cancelFuture_.valid());
+  auto& executor = folly::QueuedImmediateExecutor::instance();
+  std::move(cancelFuture_).via(&executor).wait();
+
   EXPECT_GE(numRead, 1'000'000);
   EXPECT_TRUE(stateFutures_.at(0).isReady());
   EXPECT_EQ(tasks_[0]->state(), TaskState::kAborted);


### PR DESCRIPTION
Summary:
The test didn't wait for all threads to finish processing before tear down. This
cause MemoryManager to be destroyed while still being referenced (by raw
pointer).

```ThreadSanitizer: data race on vptr (ctor/dtor vs virtual call) velox/common/memory/Memory.h:207 in facebook::velox::memory::ScopedMemoryPool::getPreferredSize(unsigned long)
==================
pure virtual method called
terminate called recursively
ThreadSanitizer: reported 3 warnings
```

Differential Revision: D39313989

