### PR TITLE
Improve MemoryUsageTracker thread safety

### DIFF
--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -203,7 +203,7 @@ class MemoryUsageTracker
     {
       std::lock_guard<std::mutex> l(mutex_);
       auto newUsed = usedReservation_ += size;
-      auto newCap = std::max(minReservation_, newUsed);
+      auto newCap = std::max(minReservation_.load(), newUsed);
       auto newQuantized = quantizedSize(newCap);
       if (newQuantized != reservation_) {
         decrement = reservation_ - newQuantized;
@@ -397,10 +397,10 @@ class MemoryUsageTracker
   std::array<std::atomic<int64_t>, 3> numAllocs_{};
   std::array<std::atomic<int64_t>, 3> cumulativeBytes_{};
 
-  int64_t reservation_{0};
+  std::atomic<int64_t> reservation_{0};
 
   // Minimum amount of reserved memory to hold until explicit release().
-  int64_t minReservation_{0};
+  std::atomic<int64_t> minReservation_{0};
   std::atomic<int64_t> usedReservation_{};
 
   GrowCallback growCallback_{};


### PR DESCRIPTION
Summary:
MemoryUsageTracker's reservation_ variable is guarded by locks on writes, but not on reads.  This can lead to data races exposed by running with TSAN enabled.

Making reservation_ atomic simplifies maintaining thread safety of the variable, though locks are still needed in some cases where the values of one or more variables is read, modified, and written on separate lines.

I also made minReservation_ atomic for simplicity, although currently this isn't strictly needed as it is always read/written while holding a lock.

Previously running the tests under functions/prestosql/aggregates/tests with TSAN showed hundreds of errors, now there are only a few which are fixed by a separate change.

Differential Revision: D39317544

