### PR TITLE
Fix TSAN errors in AsyncSource

### DIFF
--- a/velox/common/base/AsyncSource.h
+++ b/velox/common/base/AsyncSource.h
@@ -108,6 +108,7 @@ class AsyncSource {
       try {
         return make();
       } catch (const std::exception& e) {
+        std::lock_guard<std::mutex> l(mutex_);
         exception_ = std::current_exception();
         throw;
       }


### PR DESCRIPTION
Summary:
AsyncSource makes an effort to call make() to generate items outside of the
mutex_, probably to avoid creating contention if make() takes a long time.

The way this is done it ends up writing to the variables make_ and exception_
outside of mutex_ which can lead to data races between reads inside of the
mutex_ and writes outside.

This diff fixes this by ensuring we only write to make_ and exception_ while inside
mutex_.  Either by grabbing mutex_ when it won't lead to repeated
locking/unlocking, or assigning to temp variables and writing to make_ and
exception_ inside of the next block where we already hold mutex_ (in this case I
ensured we still write to the variables in the same order to prevent
inconsistencies).

Differential Revision: D39355536

