### PR TITLE
Fix TSAN errors in MmapAllocator

### DIFF
--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -333,10 +333,10 @@ class MmapAllocator : public MappedMemory {
 
   std::vector<std::unique_ptr<SizeClass>> sizeClasses_;
 
-  // Statistics. Not atomic.
-  uint64_t numAllocations_ = 0;
-  uint64_t numAllocatedPages_ = 0;
-  uint64_t numAdvisedPages_ = 0;
+  // Statistics.
+  std::atomic<uint64_t> numAllocations_ = 0;
+  std::atomic<uint64_t> numAllocatedPages_ = 0;
+  std::atomic<uint64_t> numAdvisedPages_ = 0;
   Failure injectedFailure_{Failure::kNone};
   Stats stats_;
 };

--- a/velox/common/memory/tests/MappedMemoryTest.cpp
+++ b/velox/common/memory/tests/MappedMemoryTest.cpp
@@ -412,6 +412,8 @@ TEST_P(MappedMemoryTest, increasingSizeWithThreadsTest) {
   threads.reserve(numThreads);
   for (int32_t i = 0; i < numThreads; ++i) {
     allocations.emplace_back(makeEmptyAllocations(500));
+  }
+  for (int32_t i = 0; i < numThreads; ++i) {
     threads.push_back(std::thread([this, &allocations, i]() {
       allocateIncreasing(10, 1000, 1000, allocations[i]);
     }));


### PR DESCRIPTION
Summary:
TSAN was showing two sources of issues in MappedMemoryTest

The statistics variables in MmapAllocator are not atomic and written outside of a
mutex.  Based on the comment this looks like it was intentional, although the
reasoning wasn't documented.  I assume the reasoning was for performance
since their correctness won't impact the correctness of the program.  It looks like
everywhere they're updated other atomics are read/updated repeatedly, so I don't
think it should significantly hurt performance.  I don't see anywhere these
statistics are ever used so we can also safely remove them if we don't plan to use
them.

In the test itself we were allocating elements in a vector as we were spinning up
threads that read from the vector.  Although we were accessing the data in a
thread safe way, the size of the vector was being read/written in different threads
which was detected as a data race.  Creating the vector before spinning up the
threads fixes it.

Differential Revision: D39357067

