### PR TITLE
Decouple vectors from VectorStream.h

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 #include "velox/exec/Exchange.h"
-#include <velox/buffer/Buffer.h>
 #include <velox/common/base/Exceptions.h>
-#include <velox/common/memory/MappedMemory.h>
 #include <velox/common/memory/Memory.h>
 #include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::exec {
 

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -18,6 +18,7 @@
 
 #include <boost/circular_buffer.hpp>
 #include "velox/exec/Merge.h"
+#include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::exec {
 namespace {

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -18,10 +18,9 @@
 #include <folly/Random.h>
 #include "velox/exec/Operator.h"
 #include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::exec {
-
-class PartitionedOutput;
 
 class Destination {
  public:

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -22,7 +22,7 @@
 #include "velox/exec/UnorderedStreamReader.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DecodedVector.h"
-#include "velox/vector/FlatVector.h"
+#include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::exec {
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -37,7 +37,6 @@
 #include "velox/vector/SelectivityVector.h"
 #include "velox/vector/TypeAliases.h"
 #include "velox/vector/VectorEncoding.h"
-#include "velox/vector/VectorStream.h"
 #include "velox/vector/VectorUtil.h"
 
 namespace facebook {

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -451,6 +451,12 @@ void ArrayVectorBase::copyRangesImpl(
 }
 
 namespace {
+
+struct IndexRange {
+  vector_size_t begin;
+  vector_size_t size;
+};
+
 std::optional<int32_t> compareArrays(
     const BaseVector& left,
     const BaseVector& right,

--- a/velox/vector/RowSerde.h
+++ b/velox/vector/RowSerde.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/memory/ByteStream.h"
 #include "velox/vector/DecodedVector.h"
 
 namespace facebook::velox {

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -36,7 +36,7 @@ bool isRegisteredVectorSerde() {
 }
 
 void VectorStreamGroup::createStreamTree(
-    std::shared_ptr<const RowType> type,
+    RowTypePtr type,
     int32_t numRows,
     const VectorSerde::Options* options) {
   VELOX_CHECK(getVectorSerde().get(), "Vector serde is not registered");
@@ -45,7 +45,7 @@ void VectorStreamGroup::createStreamTree(
 }
 
 void VectorStreamGroup::append(
-    std::shared_ptr<RowVector> vector,
+    RowVectorPtr vector,
     const folly::Range<const IndexRange*>& ranges) {
   serializer_->append(vector, ranges);
 }
@@ -56,7 +56,7 @@ void VectorStreamGroup::flush(OutputStream* out) {
 
 // static
 void VectorStreamGroup::estimateSerializedSize(
-    std::shared_ptr<BaseVector> vector,
+    VectorPtr vector,
     const folly::Range<const IndexRange*>& ranges,
     vector_size_t** sizes) {
   VELOX_CHECK(getVectorSerde().get(), "Vector serde is not registered");
@@ -67,8 +67,8 @@ void VectorStreamGroup::estimateSerializedSize(
 void VectorStreamGroup::read(
     ByteStream* source,
     velox::memory::MemoryPool* pool,
-    std::shared_ptr<const RowType> type,
-    std::shared_ptr<RowVector>* result,
+    RowTypePtr type,
+    RowVectorPtr* result,
     const VectorSerde::Options* options) {
   VELOX_CHECK(getVectorSerde().get(), "Vector serde is not registered");
   getVectorSerde()->deserialize(source, pool, type, result, options);

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -20,14 +20,11 @@
 #include "velox/common/memory/MappedMemory.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/StreamArena.h"
-#include "velox/type/Type.h"
-#include "velox/vector/SelectivityVector.h"
+#include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox {
 
-class BaseVector;
 class ByteStream;
-class RowVector;
 
 struct IndexRange {
   vector_size_t begin;
@@ -39,7 +36,7 @@ class VectorSerializer {
   virtual ~VectorSerializer() = default;
 
   virtual void append(
-      std::shared_ptr<RowVector> vector,
+      RowVectorPtr vector,
       const folly::Range<const IndexRange*>& ranges) = 0;
 
   // Writes the contents to 'stream' in wire format
@@ -56,12 +53,12 @@ class VectorSerde {
   };
 
   virtual void estimateSerializedSize(
-      std::shared_ptr<BaseVector> vector,
+      VectorPtr vector,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes) = 0;
 
   virtual std::unique_ptr<VectorSerializer> createSerializer(
-      std::shared_ptr<const RowType> type,
+      RowTypePtr type,
       int32_t numRows,
       StreamArena* streamArena,
       const Options* options = nullptr) = 0;
@@ -69,8 +66,8 @@ class VectorSerde {
   virtual void deserialize(
       ByteStream* source,
       velox::memory::MemoryPool* pool,
-      std::shared_ptr<const RowType> type,
-      std::shared_ptr<RowVector>* result,
+      RowTypePtr type,
+      RowVectorPtr* result,
       const Options* options = nullptr) = 0;
 };
 
@@ -97,17 +94,17 @@ class VectorStreamGroup : public StreamArena {
       : StreamArena(mappedMemory) {}
 
   void createStreamTree(
-      std::shared_ptr<const RowType> type,
+      RowTypePtr type,
       int32_t numRows,
       const VectorSerde::Options* options = nullptr);
 
   static void estimateSerializedSize(
-      std::shared_ptr<BaseVector> vector,
+      VectorPtr vector,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes);
 
   void append(
-      std::shared_ptr<RowVector> vector,
+      RowVectorPtr vector,
       const folly::Range<const IndexRange*>& ranges);
 
   // Writes the contents to 'stream' in wire format.
@@ -117,8 +114,8 @@ class VectorStreamGroup : public StreamArena {
   static void read(
       ByteStream* source,
       velox::memory::MemoryPool* pool,
-      std::shared_ptr<const RowType> type,
-      std::shared_ptr<RowVector>* result,
+      RowTypePtr type,
+      RowVectorPtr* result,
       const VectorSerde::Options* options = nullptr);
 
  private:


### PR DESCRIPTION
VectorStream.h and BaseVector.h had unnecessary circular dependencies. This
change removes #include VectorStream.h from BaseVector.h

Also, updated VectorStream.* to use VectorPtr, RowVectorPtr and TypePtr for
readability.