### PR TITLE
Avoid ref increment in accessing function metadata

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -417,13 +417,13 @@ ExprPtr compileExpression(
     } else if (
         auto simpleFunctionEntry =
             SimpleFunctions().resolveFunction(call->name(), inputTypes)) {
-      auto metadata = simpleFunctionEntry->getMetadata();
+      const auto& metadata = simpleFunctionEntry->getMetadata();
       VELOX_USER_CHECK(
-          resultType->kindEquals(metadata->returnType()),
+          resultType->kindEquals(metadata.returnType()),
           "Found incompatible return types for '{}' ({} vs. {}) "
           "for input types ({}).",
           call->name(),
-          metadata->returnType(),
+          metadata.returnType(),
           resultType,
           folly::join(", ", inputTypes));
       auto func = simpleFunctionEntry->createFunction()->createVectorFunction(

--- a/velox/expression/FunctionRegistry.h
+++ b/velox/expression/FunctionRegistry.h
@@ -37,8 +37,8 @@ struct FunctionEntry {
       const FunctionFactory& factory)
       : metadata_{metadata}, factory_{factory} {}
 
-  std::shared_ptr<const Metadata> getMetadata() const {
-    return metadata_;
+  const Metadata& getMetadata() const {
+    return *metadata_;
   }
 
   std::unique_ptr<Function> createFunction() const {
@@ -107,8 +107,8 @@ class FunctionRegistry {
         if (SignatureBinder(candidateSignature, argTypes).tryBind()) {
           auto* currentCandidate = functionEntry.get();
           if (!selectedCandidate ||
-              currentCandidate->getMetadata()->priority() <
-                  selectedCandidate->getMetadata()->priority()) {
+              currentCandidate->getMetadata().priority() <
+                  selectedCandidate->getMetadata().priority()) {
             selectedCandidate = currentCandidate;
           }
         }

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -163,7 +163,7 @@ std::optional<bool> isDeterministic(
   // Check if this is a simple function.
   if (auto simpleFunctionEntry =
           exec::SimpleFunctions().resolveFunction(functionName, argTypes)) {
-    return simpleFunctionEntry->getMetadata()->isDeterministic();
+    return simpleFunctionEntry->getMetadata().isDeterministic();
   }
 
   // Vector functions are a bit more complicated. We need to fetch the list of

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -95,7 +95,7 @@ std::shared_ptr<const Type> resolveSimpleFunction(
       exec::SimpleFunctions().resolveFunction(functionName, argTypes);
 
   if (resolvedFunction) {
-    return resolvedFunction->getMetadata()->returnType();
+    return resolvedFunction->getMetadata().returnType();
   }
 
   return nullptr;


### PR DESCRIPTION
Summary:
# Problem
Function metadata access doing unnecessary ownership handling, which could have been just referencing. Probably we would not see any production impact on this, but it would be nice to get addressed.

Differential Revision: D39362954

