### PR TITLE
Move registration of a test specific UDF to its appropriate test file

### DIFF
--- a/velox/functions/prestosql/benchmarks/ArraySumBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArraySumBenchmark.cpp
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 #include <folly/Benchmark.h>
-#include "velox/expression/VectorFunction.h"
-#include "velox/functions/Macros.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/ArrayFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 
 using namespace facebook::velox;
@@ -30,7 +29,8 @@ class ArraySumBenchmark : public functions::test::FunctionBenchmarkBase {
  public:
   ArraySumBenchmark() : FunctionBenchmarkBase() {
     functions::prestosql::registerArrayFunctions();
-    functions::prestosql::registerGeneralFunctions();
+    registerFunction<ArraySumFunction, int64_t, Array<int32_t>>(
+        {"array_sum_alt"});
   }
 
   void runInteger(const std::string& functionName) {

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -25,11 +25,6 @@ inline void registerArrayMinMaxFunctions() {
   registerFunction<ArrayMaxFunction, T, Array<T>>({"array_max"});
 }
 
-template <typename OT, typename IT>
-inline void registerArraySumFunction() {
-  registerFunction<ArraySumFunction, OT, IT>({"array_sum_alt"});
-}
-
 template <typename T>
 inline void registerArrayJoinFunctions() {
   registerFunction<
@@ -94,13 +89,6 @@ void registerArrayFunctions() {
   registerArrayJoinFunctions<Varchar>();
   registerArrayJoinFunctions<Timestamp>();
   registerArrayJoinFunctions<Date>();
-
-  registerArraySumFunction<int64_t, Array<int8_t>>();
-  registerArraySumFunction<int64_t, Array<int16_t>>();
-  registerArraySumFunction<int64_t, Array<int32_t>>();
-  registerArraySumFunction<int64_t, Array<int64_t>>();
-  registerArraySumFunction<double, Array<float>>();
-  registerArraySumFunction<double, Array<double>>();
 
   registerArrayCombinationsFunctions<int8_t>();
   registerArrayCombinationsFunctions<int16_t>();


### PR DESCRIPTION
This patch moves the registration of array_sum_alt UDF out from the
general registration mechanism (where it is exposed to public clients
of the library) and into the benchmark (where it is confined only to
the benchmark) for which it was implemented in the first place.