### PR TITLE
Fix rare 'Output buffers for task not found' error

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -978,6 +978,18 @@ void Task::updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers) {
       "Unable to initialize task. "
       "PartitionedOutputBufferManager was already destructed");
 
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (noMoreBroadcastBuffers_) {
+      // Ignore messages received after no-more-buffers message.
+      return;
+    }
+
+    if (noMoreBuffers) {
+      noMoreBroadcastBuffers_ = true;
+    }
+  }
+
   bufferManager->updateBroadcastOutputBuffers(
       taskId_, numBuffers, noMoreBuffers);
 }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -186,7 +186,8 @@ class Task : public std::enable_shared_from_this<Task> {
   /// subsequent calls.
   /// @param noMoreBuffers A flag indicating that numBuffers is the final number
   /// of buffers. No more calls are expected after the call with noMoreBuffers
-  /// == true.
+  /// == true, but occasionally the caller might resend it, so calls
+  /// received after a call with noMoreBuffers == true are ignored.
   void updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers);
 
   /// Returns true if state is 'running'.
@@ -739,6 +740,10 @@ class Task : public std::enable_shared_from_this<Task> {
   std::unordered_map<uint32_t, SplitGroupState> splitGroupStates_;
 
   std::weak_ptr<PartitionedOutputBufferManager> bufferManager_;
+
+  /// Boolean indicating that we have already recieved no-more-broadcast-buffers
+  /// message. Subsequent messagees will be ignored.
+  bool noMoreBroadcastBuffers_{false};
 
   // Thread counts and cancellation -related state.
   //

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -420,6 +420,10 @@ TEST_F(MultiFragmentTest, broadcast) {
   for (auto& task : tasks) {
     ASSERT_TRUE(waitForTaskCompletion(task.get())) << task->taskId();
   }
+
+  // Make sure duplicate 'updateBroadcastOutputBuffers' message after task
+  // completion doesn't cause an error.
+  leafTask->updateBroadcastOutputBuffers(finalAggTaskIds.size(), true);
 }
 
 TEST_F(MultiFragmentTest, replicateNullsAndAny) {


### PR DESCRIPTION
Occasionally, Prestissimo query using broadcast shuffle fails with an error:

VeloxRuntimeError: it != buffers.end() Output buffers for task not found: 20220907_072939_02883_iuzrj.3.0.4
     at Unknown.# 2  facebook::velox::exec::PartitionedOutputBufferManager::getBuffer
     at Unknown.# 3  facebook::velox::exec::PartitionedOutputBufferManager::updateBroadcastOutputBuffers
     at Unknown.# 4  facebook::velox::exec::Task::updateBroadcastOutputBuffers
     at Unknown.# 5  facebook::presto::TaskManager::createOrUpdateTask

I'm not able to reproduce this, but I believe this happens when coordinator
sends a duplicate updateBroadcastOutputBuffers with noMoreBuffers set to true.
The first call makes the task complete and the buffers being deleted. The
second call hits "Output buffers for task not found".

The fix is to ignore updateBroadcastOutputBuffers messages after receiving
no-more-buffers message.