### PR TITLE
virtual dtor for WriterContext

### DIFF
--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -74,6 +74,8 @@ class WriterContext : public CompressionBufferPool {
         generalPool_, compressionBlockSize + PAGE_HEADER_SIZE);
   }
 
+  virtual ~WriterContext() = default;
+
   bool hasStream(const DwrfStreamIdentifier& stream) const {
     return streams_.find(stream) != streams_.end();
   }


### PR DESCRIPTION
Summary: There isn't a current call site for deleting the WriterContext via a CompressionBufferPool pointer so it's not an active issue, but this would be a nasty surprise when we do.

Differential Revision: D39373297

