### PR TITLE
Fix tsan race in AsyncSource and advanceSpill

### DIFF
--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -305,9 +305,12 @@ void Spiller::advanceSpill() {
     }
   });
 
+  std::vector<std::unique_ptr<SpillStatus>> results;
+  results.reserve(writes.size());
   for (auto& write : writes) {
-    const auto result = write->move();
-
+    results.push_back(write->move());
+  }
+  for (auto& result : results) {
     if (result->error) {
       std::rethrow_exception(result->error);
     }


### PR DESCRIPTION
- AsyncSource prepare() set item_ without lock protection. It is not a real race
   in practice as make_ reset and making_ flag will prevent move() to access 
   item_ while it is making by prepare(). This PR also (1) avoids set promise_ under
   the lock, and (2) set exception_ under the lock.
- advanceSpill() dispatch multiple partition spilling jobs into a threadpool running
   at the background. Then it (the main dispatch thread) goes to a loop to wait for
   the partition spilling completes and then erase the spilled rows from the row
   container. There is no real race here but the tsan detects the potential data race
   between the main dispatch thread which erase rows from the hash table and
   the background thread to access rows for spilling even though they are touching
   different set of rows. Also note the spilling thread doesn't really scan the row
   container to get the rows to spill but simply access rows from the cached row pointers
   in the spill runs. The fix is to split the loop into two loops: first wait for all the partition
   spilling to complete and then do spilled row erase.
    
   
   Verified the fixes in tsan mode running on fb devserver and there is no failures in
   SpillerTest
