### PR TITLE
Decimal overflow checks in decimal arithmetic

### DIFF
--- a/velox/common/base/CheckedArithmetic.h
+++ b/velox/common/base/CheckedArithmetic.h
@@ -42,7 +42,7 @@ inline UnscaledShortDecimal checkedPlus(
   int64_t result;
   bool overflow =
       __builtin_add_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
+  if (UNLIKELY(overflow || !UnscaledShortDecimal::valueInRange(result))) {
     VELOX_ARITHMETIC_ERROR(
         "Decimal overflow: {} + {}", a.unscaledValue(), b.unscaledValue());
   }
@@ -80,9 +80,9 @@ inline UnscaledShortDecimal checkedMinus(
   int64_t result;
   bool overflow =
       __builtin_sub_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
+  if (UNLIKELY(overflow || !UnscaledShortDecimal::valueInRange(result))) {
     VELOX_ARITHMETIC_ERROR(
-        "Decimal overflow: {} + {}", a.unscaledValue(), b.unscaledValue());
+        "Decimal overflow: {} - {}", a.unscaledValue(), b.unscaledValue());
   }
   return UnscaledShortDecimal(result);
 }
@@ -96,7 +96,7 @@ inline UnscaledLongDecimal checkedMinus(
       __builtin_sub_overflow(a.unscaledValue(), b.unscaledValue(), &result);
   if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
     VELOX_ARITHMETIC_ERROR(
-        "Decimal overflow: {} + {}", a.unscaledValue(), b.unscaledValue());
+        "Decimal overflow: {} - {}", a.unscaledValue(), b.unscaledValue());
   }
 
   return UnscaledLongDecimal(result);
@@ -119,7 +119,7 @@ inline UnscaledShortDecimal checkedMultiply(
   int64_t result;
   bool overflow =
       __builtin_mul_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow)) {
+  if (UNLIKELY(overflow || !UnscaledShortDecimal::valueInRange(result))) {
     VELOX_ARITHMETIC_ERROR(
         "Decimal overflow: {} * {}", a.unscaledValue(), b.unscaledValue());
   }
@@ -133,31 +133,12 @@ inline UnscaledLongDecimal checkedMultiply(
   int128_t result;
   bool overflow =
       __builtin_mul_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow)) {
+  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
     VELOX_ARITHMETIC_ERROR(
         "Decimal overflow: {} * {}", a.unscaledValue(), b.unscaledValue());
   }
   return UnscaledLongDecimal(result);
 }
-
-template <typename R, typename A>
-struct UnscaledDecimalArithmetic {
-  static_assert(
-      std::is_same<R, UnscaledLongDecimal>::value ||
-      std::is_same<R, UnscaledShortDecimal>::value);
-  static_assert(
-      std::is_same<A, UnscaledLongDecimal>::value ||
-      std::is_same<A, UnscaledShortDecimal>::value);
-
-  static inline R checkedMultiply(const A& a, const int128_t& b) {
-    int128_t result;
-    bool overflow = __builtin_mul_overflow(a.unscaledValue(), b, &result);
-    if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
-      VELOX_ARITHMETIC_ERROR("Decimal overflow: {} * {}", a.unscaledValue(), b);
-    }
-    return R(result);
-  }
-};
 
 template <typename T>
 T checkedDivide(const T& a, const T& b) {

--- a/velox/common/base/CheckedArithmetic.h
+++ b/velox/common/base/CheckedArithmetic.h
@@ -42,11 +42,9 @@ inline UnscaledShortDecimal checkedPlus(
   int64_t result;
   bool overflow =
       __builtin_add_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow)) {
+  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
     VELOX_ARITHMETIC_ERROR(
-        "short decimal plus overflow: {} + {}",
-        a.unscaledValue(),
-        b.unscaledValue());
+        "Decimal overflow: {} + {}", a.unscaledValue(), b.unscaledValue());
   }
   return UnscaledShortDecimal(result);
 }
@@ -58,11 +56,9 @@ inline UnscaledLongDecimal checkedPlus(
   int128_t result;
   bool overflow =
       __builtin_add_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow)) {
+  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
     VELOX_ARITHMETIC_ERROR(
-        "long decimal plus overflow: {} + {}",
-        a.unscaledValue(),
-        b.unscaledValue());
+        "Decimal overflow: {} + {}", a.unscaledValue(), b.unscaledValue());
   }
   return UnscaledLongDecimal(result);
 }
@@ -75,6 +71,35 @@ T checkedMinus(const T& a, const T& b) {
     VELOX_ARITHMETIC_ERROR("integer overflow: {} - {}", a, b);
   }
   return result;
+}
+
+template <>
+inline UnscaledShortDecimal checkedMinus(
+    const UnscaledShortDecimal& a,
+    const UnscaledShortDecimal& b) {
+  int64_t result;
+  bool overflow =
+      __builtin_sub_overflow(a.unscaledValue(), b.unscaledValue(), &result);
+  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
+    VELOX_ARITHMETIC_ERROR(
+        "Decimal overflow: {} + {}", a.unscaledValue(), b.unscaledValue());
+  }
+  return UnscaledShortDecimal(result);
+}
+
+template <>
+inline UnscaledLongDecimal checkedMinus(
+    const UnscaledLongDecimal& a,
+    const UnscaledLongDecimal& b) {
+  int128_t result;
+  bool overflow =
+      __builtin_sub_overflow(a.unscaledValue(), b.unscaledValue(), &result);
+  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
+    VELOX_ARITHMETIC_ERROR(
+        "Decimal overflow: {} + {}", a.unscaledValue(), b.unscaledValue());
+  }
+
+  return UnscaledLongDecimal(result);
 }
 
 template <typename T>
@@ -114,6 +139,25 @@ inline UnscaledLongDecimal checkedMultiply(
   }
   return UnscaledLongDecimal(result);
 }
+
+template <typename R, typename A>
+struct UnscaledDecimalArithmetic {
+  static_assert(
+      std::is_same<R, UnscaledLongDecimal>::value ||
+      std::is_same<R, UnscaledShortDecimal>::value);
+  static_assert(
+      std::is_same<A, UnscaledLongDecimal>::value ||
+      std::is_same<A, UnscaledShortDecimal>::value);
+
+  static inline R checkedMultiply(const A& a, const int128_t& b) {
+    int128_t result;
+    bool overflow = __builtin_mul_overflow(a.unscaledValue(), b, &result);
+    if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
+      VELOX_ARITHMETIC_ERROR("Decimal overflow: {} * {}", a.unscaledValue(), b);
+    }
+    return R(result);
+  }
+};
 
 template <typename T>
 T checkedDivide(const T& a, const T& b) {

--- a/velox/functions/prestosql/DecimalArithmetic.cpp
+++ b/velox/functions/prestosql/DecimalArithmetic.cpp
@@ -107,9 +107,11 @@ class Addition {
 #endif
 #endif
   {
-    r.setUnscaledValue(
-        a.unscaledValue() * DecimalUtil::kPowersOfTen[aRescale] +
-        b.unscaledValue() * DecimalUtil::kPowersOfTen[bRescale]);
+    r = checkedPlus<R>(
+        UnscaledDecimalArithmetic<R, A>::checkedMultiply(
+            a, DecimalUtil::kPowersOfTen[aRescale]),
+        UnscaledDecimalArithmetic<R, B>::checkedMultiply(
+            b, DecimalUtil::kPowersOfTen[bRescale]));
   }
 
   inline static uint8_t
@@ -142,9 +144,11 @@ class Subtraction {
 #endif
 #endif
   {
-    r.setUnscaledValue(
-        a.unscaledValue() * DecimalUtil::kPowersOfTen[aRescale] -
-        b.unscaledValue() * DecimalUtil::kPowersOfTen[bRescale]);
+    r = checkedMinus<R>(
+        UnscaledDecimalArithmetic<R, A>::checkedMultiply(
+            a, DecimalUtil::kPowersOfTen[aRescale]),
+        UnscaledDecimalArithmetic<R, B>::checkedMultiply(
+            b, DecimalUtil::kPowersOfTen[bRescale]));
   }
 
   inline static uint8_t
@@ -167,9 +171,9 @@ class Multiply {
   template <typename R, typename A, typename B>
   inline static void
   apply(R& r, const A& a, const B& b, uint8_t aRescale, uint8_t bRescale) {
-    r.setUnscaledValue(checkedMultiply<int128_t>(
-        checkedMultiply<int128_t>(a.unscaledValue(), b.unscaledValue()),
-        DecimalUtil::kPowersOfTen[aRescale + bRescale]));
+    r = UnscaledDecimalArithmetic<R, R>::checkedMultiply(
+        UnscaledDecimalArithmetic<R, A>::checkedMultiply(a, b.unscaledValue()),
+        DecimalUtil::kPowersOfTen[aRescale + bRescale]);
   }
 
   inline static uint8_t

--- a/velox/functions/prestosql/DecimalArithmetic.cpp
+++ b/velox/functions/prestosql/DecimalArithmetic.cpp
@@ -107,9 +107,20 @@ class Addition {
 #endif
 #endif
   {
-    r = checkedPlus<R>(
-        checkedMultiply<R>(R(a), R(DecimalUtil::kPowersOfTen[aRescale])),
-        checkedMultiply<R>(R(b), R(DecimalUtil::kPowersOfTen[bRescale])));
+    int128_t aRescaled;
+    int128_t bRescaled;
+    if (__builtin_mul_overflow(
+            a.unscaledValue(),
+            DecimalUtil::kPowersOfTen[aRescale],
+            &aRescaled) ||
+        __builtin_mul_overflow(
+            b.unscaledValue(),
+            DecimalUtil::kPowersOfTen[bRescale],
+            &bRescaled)) {
+      VELOX_ARITHMETIC_ERROR(
+          "Decimal overflow: {} + {}", a.unscaledValue(), b.unscaledValue());
+    }
+    r = checkedPlus<R>(R(aRescaled), R(bRescaled));
   }
 
   inline static uint8_t
@@ -142,9 +153,20 @@ class Subtraction {
 #endif
 #endif
   {
-    r = checkedMinus<R>(
-        checkedMultiply<R>(R(a), R(DecimalUtil::kPowersOfTen[aRescale])),
-        checkedMultiply<R>(R(b), R(DecimalUtil::kPowersOfTen[bRescale])));
+    int128_t aRescaled;
+    int128_t bRescaled;
+    if (__builtin_mul_overflow(
+            a.unscaledValue(),
+            DecimalUtil::kPowersOfTen[aRescale],
+            &aRescaled) ||
+        __builtin_mul_overflow(
+            b.unscaledValue(),
+            DecimalUtil::kPowersOfTen[bRescale],
+            &bRescaled)) {
+      VELOX_ARITHMETIC_ERROR(
+          "Decimal overflow: {} - {}", a.unscaledValue(), b.unscaledValue());
+    }
+    r = checkedMinus<R>(R(aRescaled), R(bRescaled));
   }
 
   inline static uint8_t

--- a/velox/functions/prestosql/DecimalArithmetic.cpp
+++ b/velox/functions/prestosql/DecimalArithmetic.cpp
@@ -108,10 +108,8 @@ class Addition {
 #endif
   {
     r = checkedPlus<R>(
-        UnscaledDecimalArithmetic<R, A>::checkedMultiply(
-            a, DecimalUtil::kPowersOfTen[aRescale]),
-        UnscaledDecimalArithmetic<R, B>::checkedMultiply(
-            b, DecimalUtil::kPowersOfTen[bRescale]));
+        checkedMultiply<R>(R(a), R(DecimalUtil::kPowersOfTen[aRescale])),
+        checkedMultiply<R>(R(b), R(DecimalUtil::kPowersOfTen[bRescale])));
   }
 
   inline static uint8_t
@@ -145,10 +143,8 @@ class Subtraction {
 #endif
   {
     r = checkedMinus<R>(
-        UnscaledDecimalArithmetic<R, A>::checkedMultiply(
-            a, DecimalUtil::kPowersOfTen[aRescale]),
-        UnscaledDecimalArithmetic<R, B>::checkedMultiply(
-            b, DecimalUtil::kPowersOfTen[bRescale]));
+        checkedMultiply<R>(R(a), R(DecimalUtil::kPowersOfTen[aRescale])),
+        checkedMultiply<R>(R(b), R(DecimalUtil::kPowersOfTen[bRescale])));
   }
 
   inline static uint8_t
@@ -171,9 +167,9 @@ class Multiply {
   template <typename R, typename A, typename B>
   inline static void
   apply(R& r, const A& a, const B& b, uint8_t aRescale, uint8_t bRescale) {
-    r = UnscaledDecimalArithmetic<R, R>::checkedMultiply(
-        UnscaledDecimalArithmetic<R, A>::checkedMultiply(a, b.unscaledValue()),
-        DecimalUtil::kPowersOfTen[aRescale + bRescale]);
+    r = checkedMultiply<R>(
+        checkedMultiply<R>(R(a), R(b)),
+        R(DecimalUtil::kPowersOfTen[aRescale + bRescale]));
   }
 
   inline static uint8_t

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -119,10 +119,10 @@ TEST_F(DecimalArithmeticTest, add) {
   VELOX_ASSERT_THROW(
       testDecimalExpr<TypeKind::LONG_DECIMAL>(
           {},
-          "c0 + 1.00",
+          "c0 + cast(1.00 as decimal(2,0))",
           {makeLongDecimalFlatVector(
               {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
-      "Decimal overflow");
+      "Decimal overflow: 99999999999999999999999999999999999999 + 1");
 }
 
 TEST_F(DecimalArithmeticTest, subtract) {
@@ -185,10 +185,10 @@ TEST_F(DecimalArithmeticTest, subtract) {
   VELOX_ASSERT_THROW(
       testDecimalExpr<TypeKind::LONG_DECIMAL>(
           {},
-          "c0 - 1.00",
+          "c0 - cast(1.00 as decimal(2,0))",
           {makeLongDecimalFlatVector(
               {UnscaledLongDecimal::min().unscaledValue()}, DECIMAL(38, 0))}),
-      "Decimal overflow");
+      "Decimal overflow: -99999999999999999999999999999999999999 - 1");
 }
 
 TEST_F(DecimalArithmeticTest, multiply) {
@@ -237,9 +237,9 @@ TEST_F(DecimalArithmeticTest, multiply) {
           {},
           "c0 * cast(10.00 as decimal(2,0))",
           {makeLongDecimalFlatVector(
-              {buildInt128(0x0AFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)},
+              {buildInt128(0x08FFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)},
               DECIMAL(38, 0))}),
-      "Decimal overflow");
+      "Decimal overflow: 11963051962064242856134263542523101183 * 10");
 }
 
 TEST_F(DecimalArithmeticTest, decimalDivTest) {

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -123,6 +123,14 @@ TEST_F(DecimalArithmeticTest, add) {
           {makeLongDecimalFlatVector(
               {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
       "Decimal overflow: 99999999999999999999999999999999999999 + 1");
+
+  VELOX_ASSERT_THROW(
+      testDecimalExpr<TypeKind::LONG_DECIMAL>(
+          {},
+          "c0 + 0.01",
+          {makeLongDecimalFlatVector(
+              {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
+      "Decimal overflow: 99999999999999999999999999999999999999 * 100");
 }
 
 TEST_F(DecimalArithmeticTest, subtract) {

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -131,7 +131,7 @@ TEST_F(DecimalArithmeticTest, add) {
           "c0 + 0.01",
           {makeLongDecimalFlatVector(
               {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
-      "Decimal overflow: 99999999999999999999999999999999999999 * 100");
+      "Decimal overflow: 99999999999999999999999999999999999999 + 1");
   // Rescaling RHS overflows.
   VELOX_ASSERT_THROW(
       testDecimalExpr<TypeKind::LONG_DECIMAL>(
@@ -139,7 +139,7 @@ TEST_F(DecimalArithmeticTest, add) {
           "0.01 + c0",
           {makeLongDecimalFlatVector(
               {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
-      "Decimal overflow: 99999999999999999999999999999999999999 * 100");
+      "Decimal overflow: 1 + 99999999999999999999999999999999999999");
 }
 
 TEST_F(DecimalArithmeticTest, subtract) {
@@ -213,15 +213,15 @@ TEST_F(DecimalArithmeticTest, subtract) {
           "c0 - 0.01",
           {makeLongDecimalFlatVector(
               {UnscaledLongDecimal::min().unscaledValue()}, DECIMAL(38, 0))}),
-      "Decimal overflow: -99999999999999999999999999999999999999 * 100");
+      "Decimal overflow: -99999999999999999999999999999999999999 - 1");
   // Rescaling RHS overflows.
   VELOX_ASSERT_THROW(
       testDecimalExpr<TypeKind::LONG_DECIMAL>(
           {},
           "0.01 - c0",
           {makeLongDecimalFlatVector(
-              {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
-      "Decimal overflow: 99999999999999999999999999999999999999 * 100");
+              {UnscaledLongDecimal::min().unscaledValue()}, DECIMAL(38, 0))}),
+      "Decimal overflow: 1 - -99999999999999999999999999999999999999");
 }
 
 TEST_F(DecimalArithmeticTest, multiply) {

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -114,9 +114,18 @@ TEST_F(DecimalArithmeticTest, add) {
            {1, 2, std::nullopt, 6, std::nullopt}, DECIMAL(10, 3)),
        makeNullableShortDecimalFlatVector(
            {1, 2, 5, std::nullopt, std::nullopt}, DECIMAL(10, 3))});
+
+  // Addition overflow.
+  VELOX_ASSERT_THROW(
+      testDecimalExpr<TypeKind::LONG_DECIMAL>(
+          {},
+          "c0 + 1.00",
+          {makeLongDecimalFlatVector(
+              {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
+      "Decimal overflow");
 }
 
-TEST_F(DecimalArithmeticTest, decimalSubTest) {
+TEST_F(DecimalArithmeticTest, subtract) {
   auto shortFlatA = makeShortDecimalFlatVector({1000, 2000}, DECIMAL(18, 3));
   // Subtract short and short, returning long.
   testDecimalExpr<TypeKind::LONG_DECIMAL>(
@@ -171,9 +180,18 @@ TEST_F(DecimalArithmeticTest, decimalSubTest) {
            {3, 6, std::nullopt, 6, std::nullopt}, DECIMAL(10, 3)),
        makeNullableShortDecimalFlatVector(
            {1, 2, 5, std::nullopt, std::nullopt}, DECIMAL(10, 3))});
+
+  // Subtraction overflow.
+  VELOX_ASSERT_THROW(
+      testDecimalExpr<TypeKind::LONG_DECIMAL>(
+          {},
+          "c0 - 1.00",
+          {makeLongDecimalFlatVector(
+              {UnscaledLongDecimal::min().unscaledValue()}, DECIMAL(38, 0))}),
+      "Decimal overflow");
 }
 
-TEST_F(DecimalArithmeticTest, decimalMultiplyTest) {
+TEST_F(DecimalArithmeticTest, multiply) {
   auto shortFlat = makeShortDecimalFlatVector({1000, 2000}, DECIMAL(17, 3));
   // Multiply short and short, returning long.
   testDecimalExpr<TypeKind::LONG_DECIMAL>(
@@ -217,18 +235,11 @@ TEST_F(DecimalArithmeticTest, decimalMultiplyTest) {
   VELOX_ASSERT_THROW(
       testDecimalExpr<TypeKind::LONG_DECIMAL>(
           {},
-          "c0 * 10.00",
+          "c0 * cast(10.00 as decimal(2,0))",
           {makeLongDecimalFlatVector(
-              {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
-      "integer overflow: 99999999999999999999999999999999999999 * 1000");
-
-  VELOX_ASSERT_THROW(
-      testDecimalExpr<TypeKind::LONG_DECIMAL>(
-          {},
-          "c0 * 10.00",
-          {makeLongDecimalFlatVector(
-              {UnscaledLongDecimal::min().unscaledValue()}, DECIMAL(38, 0))}),
-      "integer overflow: -99999999999999999999999999999999999999 * 1000");
+              {buildInt128(0x0AFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)},
+              DECIMAL(38, 0))}),
+      "Decimal overflow");
 }
 
 TEST_F(DecimalArithmeticTest, decimalDivTest) {

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -124,10 +124,19 @@ TEST_F(DecimalArithmeticTest, add) {
               {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
       "Decimal overflow: 99999999999999999999999999999999999999 + 1");
 
+  // Rescaling LHS overflows.
   VELOX_ASSERT_THROW(
       testDecimalExpr<TypeKind::LONG_DECIMAL>(
           {},
           "c0 + 0.01",
+          {makeLongDecimalFlatVector(
+              {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
+      "Decimal overflow: 99999999999999999999999999999999999999 * 100");
+  // Rescaling RHS overflows.
+  VELOX_ASSERT_THROW(
+      testDecimalExpr<TypeKind::LONG_DECIMAL>(
+          {},
+          "0.01 + c0",
           {makeLongDecimalFlatVector(
               {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
       "Decimal overflow: 99999999999999999999999999999999999999 * 100");
@@ -197,6 +206,22 @@ TEST_F(DecimalArithmeticTest, subtract) {
           {makeLongDecimalFlatVector(
               {UnscaledLongDecimal::min().unscaledValue()}, DECIMAL(38, 0))}),
       "Decimal overflow: -99999999999999999999999999999999999999 - 1");
+  // Rescaling LHS overflows.
+  VELOX_ASSERT_THROW(
+      testDecimalExpr<TypeKind::LONG_DECIMAL>(
+          {},
+          "c0 - 0.01",
+          {makeLongDecimalFlatVector(
+              {UnscaledLongDecimal::min().unscaledValue()}, DECIMAL(38, 0))}),
+      "Decimal overflow: -99999999999999999999999999999999999999 * 100");
+  // Rescaling RHS overflows.
+  VELOX_ASSERT_THROW(
+      testDecimalExpr<TypeKind::LONG_DECIMAL>(
+          {},
+          "0.01 - c0",
+          {makeLongDecimalFlatVector(
+              {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
+      "Decimal overflow: 99999999999999999999999999999999999999 * 100");
 }
 
 TEST_F(DecimalArithmeticTest, multiply) {
@@ -244,6 +269,16 @@ TEST_F(DecimalArithmeticTest, multiply) {
       testDecimalExpr<TypeKind::LONG_DECIMAL>(
           {},
           "c0 * cast(10.00 as decimal(2,0))",
+          {makeLongDecimalFlatVector(
+              {buildInt128(0x08FFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)},
+              DECIMAL(38, 0))}),
+      "Decimal overflow: 11963051962064242856134263542523101183 * 10");
+
+  // Rescaling the final result overflows.
+  VELOX_ASSERT_THROW(
+      testDecimalExpr<TypeKind::LONG_DECIMAL>(
+          {},
+          "c0 * cast(1.00 as decimal(2,1))",
           {makeLongDecimalFlatVector(
               {buildInt128(0x08FFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)},
               DECIMAL(38, 0))}),


### PR DESCRIPTION
The decimal arithmetic operations must verify that the result is within the Long decimal numeric limits.
That is  -10^38 + 1 to 10^38 -1.

Testing:
Added test cases for overflow conditions.