### PR TITLE
[Velox To Substrait] Remove hardcode function reference 

### DIFF
--- a/velox/substrait/CMakeLists.txt
+++ b/velox/substrait/CMakeLists.txt
@@ -47,9 +47,13 @@ set(SRCS
     SubstraitToVeloxExpr.cpp
     SubstraitToVeloxPlan.cpp
     TypeUtils.cpp
+    SubstraitExtensionCollector.cpp
+    VeloxToSubstraitCallConverter.cpp
     VeloxToSubstraitExpr.cpp
     VeloxToSubstraitPlan.cpp
-    VeloxToSubstraitType.cpp)
+    VeloxToSubstraitType.cpp
+    VeloxToSubstraitCallConverter.cpp
+    VeloxToSubstraitCallConverter.h)
 
 add_library(velox_substrait_plan_converter ${SRCS})
 target_include_directories(velox_substrait_plan_converter

--- a/velox/substrait/SubstraitExtensionCollector.cpp
+++ b/velox/substrait/SubstraitExtensionCollector.cpp
@@ -50,7 +50,6 @@ void SubstraitExtensionCollector::addExtensionFunctionsToPlan(
   }
 }
 
-
 void SubstraitExtensionCollector::addExtensionTypesToPlan(
     ::substrait::Plan* plan) const {
   using SimpleExtensionURI = ::substrait::extensions::SimpleExtensionURI;
@@ -68,8 +67,7 @@ void SubstraitExtensionCollector::addExtensionTypesToPlan(
       extensionUri = uri->second;
     }
 
-    auto extensionType =
-        plan->add_extensions()->mutable_extension_type();
+    auto extensionType = plan->add_extensions()->mutable_extension_type();
     extensionType->set_extension_uri_reference(
         extensionUri->extension_uri_anchor());
     extensionType->set_type_anchor(referenceNum);

--- a/velox/substrait/SubstraitExtensionCollector.cpp
+++ b/velox/substrait/SubstraitExtensionCollector.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/substrait/SubstraitExtensionCollector.h"
+#include "velox/substrait/TypeUtils.h"
+
+namespace facebook::velox::substrait {
+
+SubstraitExtensionCollector::SubstraitExtensionCollector() {
+  extensionFunctions_ = std::make_shared<BiDirectionHashMap<FunctionId>>();
+  extensionIdResolver_ = std::make_shared<ExtensionIdResolver>();
+}
+
+void SubstraitExtensionCollector::addExtensionFunctionsToPlan(
+    ::substrait::Plan* plan) const {
+  using SimpleExtensionURI = ::substrait::extensions::SimpleExtensionURI;
+  int uriPos = 1;
+  std::unordered_map<std::string, SimpleExtensionURI*> uris;
+  for (auto& [referenceNum, functionId] : extensionFunctions_->forwardMap_) {
+    SimpleExtensionURI* extensionUri;
+    const auto uri = uris.find(functionId.uri);
+    if (uri == uris.end()) {
+      extensionUri = plan->add_extension_uris();
+      extensionUri->set_extension_uri_anchor(++uriPos);
+      extensionUri->set_uri(functionId.uri);
+      uris[functionId.uri] = extensionUri;
+    } else {
+      extensionUri = uri->second;
+    }
+
+    auto extensionFunction =
+        plan->add_extensions()->mutable_extension_function();
+    extensionFunction->set_extension_uri_reference(
+        extensionUri->extension_uri_anchor());
+    extensionFunction->set_function_anchor(referenceNum);
+    extensionFunction->set_name(functionId.signature);
+  }
+}
+
+
+void SubstraitExtensionCollector::addExtensionTypesToPlan(
+    ::substrait::Plan* plan) const {
+  using SimpleExtensionURI = ::substrait::extensions::SimpleExtensionURI;
+  int uriPos = 1;
+  std::unordered_map<std::string, SimpleExtensionURI*> uris;
+  for (auto& [referenceNum, typeId] : extensionTypes_->forwardMap_) {
+    SimpleExtensionURI* extensionUri;
+    const auto uri = uris.find(typeId.uri);
+    if (uri == uris.end()) {
+      extensionUri = plan->add_extension_uris();
+      extensionUri->set_extension_uri_anchor(++uriPos);
+      extensionUri->set_uri(typeId.uri);
+      uris[typeId.uri] = extensionUri;
+    } else {
+      extensionUri = uri->second;
+    }
+
+    auto extensionType =
+        plan->add_extensions()->mutable_extension_type();
+    extensionType->set_extension_uri_reference(
+        extensionUri->extension_uri_anchor());
+    extensionType->set_type_anchor(referenceNum);
+    extensionType->set_name(typeId.name);
+  }
+}
+
+std::optional<int> SubstraitExtensionCollector::getFunctionReference(
+    const std::string& functionName,
+    const std::vector<TypePtr>& arguments) {
+  const auto& functionId =
+      extensionIdResolver_->resolve(functionName, arguments);
+  const auto& anchorReference =
+      extensionFunctions_->reverseMap_.find(functionId);
+  if (anchorReference != extensionFunctions_->reverseMap_.end()) {
+    return std::make_optional(anchorReference->second);
+  }
+  ++functionReference_;
+  extensionFunctions_->put(functionReference_, functionId);
+  return std::make_optional(functionReference_);
+}
+
+template <typename T>
+void SubstraitExtensionCollector::BiDirectionHashMap<T>::put(
+    const int& key,
+    const T& value) {
+  forwardMap_[key] = value;
+  reverseMap_[value] = key;
+}
+
+void SubstraitExtensionCollector::addExtensionsToPlan(
+    ::substrait::Plan* plan) const {
+  addExtensionFunctionsToPlan(plan);
+}
+std::optional<int> SubstraitExtensionCollector::getTypeReference(
+    const TypePtr& type) {
+  const auto& typeId = extensionIdResolver_->resolve(type);
+  const auto& typeReference = extensionTypes_->reverseMap_.find(typeId);
+  if (typeReference != extensionTypes_->reverseMap_.end()) {
+    return std::make_optional(typeReference->second);
+  }
+  ++functionReference_;
+  extensionTypes_->put(functionReference_, typeId);
+  return std::make_optional(functionReference_);
+}
+
+FunctionId ExtensionIdResolver::resolve(
+    const std::string& funcName,
+    const std::vector<TypePtr>& arguments) const {
+  if (!arguments.empty()) {
+    std::vector<std::string> typeSignature;
+    typeSignature.reserve(arguments.size());
+    for (const auto& arg : arguments) {
+      typeSignature.emplace_back(substraitSignature(arg));
+    }
+    std::string signature = funcName + ":" + folly::join("_", typeSignature);
+    return {"", signature};
+  }
+  return {"", funcName};
+}
+
+TypeId ExtensionIdResolver::resolve(const TypePtr& type) const {
+  VELOX_CHECK(type->isUnKnown(), "currently only support velox unknown type");
+  return TypeId{"", "UNKNOWN"};
+}
+
+} // namespace facebook::velox::substrait

--- a/velox/substrait/SubstraitExtensionCollector.h
+++ b/velox/substrait/SubstraitExtensionCollector.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include "velox/substrait/proto/substrait/algebra.pb.h"
+#include "velox/substrait/proto/substrait/plan.pb.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::substrait {
+
+struct FunctionId {
+  /// function uri
+  std::string uri;
+  /// function signature
+  std::string signature;
+
+  bool operator==(const FunctionId& other) const {
+    return (uri == other.uri && signature == other.signature);
+  }
+};
+
+struct TypeId {
+  /// type uri
+  std::string uri;
+  /// type name
+  std::string name;
+
+  bool operator==(const TypeId& other) const {
+    return (uri == other.uri && name == other.name);
+  }
+};
+
+/// A ExtensionIdResolver is intend to used to resolve functionId or typeId
+class ExtensionIdResolver {
+ public:
+  /// resolve functionId by given velox function name and function
+  /// arguments .
+  FunctionId resolve(
+      const std::string& functionName,
+      const std::vector<TypePtr>& arguments) const;
+
+  /// resolve typeId by given velox type
+  TypeId resolve(const TypePtr& type) const;
+};
+
+using ExtensionIdResolverPtr = std::shared_ptr<const ExtensionIdResolver>;
+
+/// Maintains a mapping for function and function reference
+class SubstraitExtensionCollector {
+ public:
+  SubstraitExtensionCollector();
+  /// get function reference by function name and arguments.
+  std::optional<int> getFunctionReference(
+      const std::string& functionName,
+      const std::vector<TypePtr>& arguments);
+
+  /// get function reference by function name and arguments.
+  std::optional<int> getTypeReference(const TypePtr& type);
+
+  /// add extension functions and types to Substrait plan.
+  void addExtensionsToPlan(::substrait::Plan* plan) const;
+
+ private:
+  /// A bi-direction hash map to keep the relation between reference number and
+  /// either function or type anchor.
+  /// @T either FunctionAnchor or TypeAnchor
+  template <class T>
+  class BiDirectionHashMap {
+   public:
+    void put(const int& key, const T& value);
+    std::unordered_map<int, T> forwardMap_;
+    std::unordered_map<T, int> reverseMap_;
+  };
+
+  /// add extension functions to Substrait plan.
+  void addExtensionFunctionsToPlan(::substrait::Plan* plan) const;
+
+  /// add extension types to Substrait plan.
+  void addExtensionTypesToPlan(::substrait::Plan* plan) const;
+
+  /// the count of extension function reference in a substrait plan.
+  int functionReference_ = -1;
+  /// extension function collected in substrait plan.
+  std::shared_ptr<BiDirectionHashMap<FunctionId>> extensionFunctions_;
+  /// extension function collected in substrait plan.
+  std::shared_ptr<BiDirectionHashMap<TypeId>> extensionTypes_;
+
+  ExtensionIdResolverPtr extensionIdResolver_;
+};
+
+using SubstraitExtensionCollectorPtr =
+    std::shared_ptr<SubstraitExtensionCollector>;
+
+} // namespace facebook::velox::substrait
+
+namespace std {
+
+/// hash function of facebook::velox::substrait::FunctionAnchor
+template <>
+struct hash<facebook::velox::substrait::FunctionId> {
+  size_t operator()(const facebook::velox::substrait::FunctionId& k) const {
+    size_t val = hash<std::string>()(k.uri);
+    val = val * 31 + hash<std::string>()(k.signature);
+    return val;
+  }
+};
+
+/// hash function of facebook::velox::substrait::TypeId
+template <>
+struct hash<facebook::velox::substrait::TypeId> {
+  size_t operator()(const facebook::velox::substrait::TypeId& k) const {
+    size_t val = hash<std::string>()(k.uri);
+    val = val * 31 + hash<std::string>()(k.name);
+    return val;
+  }
+};
+
+}; // namespace std

--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -56,6 +56,11 @@ class SubstraitVeloxExprConverter {
       const ::substrait::Expression& substraitExpr,
       const RowTypePtr& inputType);
 
+  /// Convert Substrait IfThen into Velox Expression.
+  std::shared_ptr<const core::ITypedExpr> toVeloxExpr(
+      const ::substrait::Expression::IfThen& substraitIfThen,
+      const RowTypePtr& inputType);
+
  private:
   /// The Substrait parser used to convert Substrait representations into
   /// recognizable representations.

--- a/velox/substrait/TypeUtils.cpp
+++ b/velox/substrait/TypeUtils.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/type/Type.h"
+#include "velox/substrait/TypeUtils.h"
 
 namespace facebook::velox::substrait {
 namespace {
@@ -122,6 +122,50 @@ TypePtr toVeloxType(const std::string& typeName) {
       return UNKNOWN();
     default:
       VELOX_NYI("Velox type conversion not supported for type {}.", typeName);
+  }
+}
+
+std::string substraitSignature(const TypePtr& type) {
+  const auto& typeKind = type->kind();
+  switch (typeKind) {
+    case TypeKind::BOOLEAN:
+      return "bool";
+    case TypeKind::TINYINT:
+      return "i8";
+    case TypeKind::SMALLINT:
+      return "i16";
+    case TypeKind::INTEGER:
+      return "i32";
+    case TypeKind::BIGINT:
+      return "i64";
+    case TypeKind::REAL:
+      return "fp32";
+    case TypeKind::DOUBLE:
+      return "fp64";
+    case TypeKind::VARCHAR:
+      return "str";
+    case TypeKind::VARBINARY:
+      return "vbin";
+    case TypeKind::TIMESTAMP:
+      return "ts";
+    case TypeKind::DATE:
+      return "date";
+    case TypeKind::SHORT_DECIMAL:
+      return "dec";
+    case TypeKind::LONG_DECIMAL:
+      return "dec";
+    case TypeKind::ARRAY:
+      return "list";
+    case TypeKind::MAP:
+      return "map";
+    case TypeKind::ROW:
+      return "struct";
+    case TypeKind::UNKNOWN:
+      return "u!name";
+    default:
+      VELOX_NYI(
+          "Substrait type signature conversion not supported for type {}.",
+          type->toString());
   }
 }
 

--- a/velox/substrait/TypeUtils.h
+++ b/velox/substrait/TypeUtils.h
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
+#include <core/Expressions.h>
 #include "velox/type/Type.h"
 
 namespace facebook::velox::substrait {
 
 /// Return the Velox type according to the typename.
 TypePtr toVeloxType(const std::string& typeName);
+
+/// Return the Substrait type signature according to the type
+std::string substraitSignature(const TypePtr& type);
 
 } // namespace facebook::velox::substrait

--- a/velox/substrait/VeloxToSubstraitCallConverter.cpp
+++ b/velox/substrait/VeloxToSubstraitCallConverter.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/substrait/VeloxToSubstraitCallConverter.h"
+
+namespace facebook::velox::substrait {
+
+const std::optional<::substrait::Expression*>
+VeloxToSubstraitIfThenConverter::convert(
+    const core::CallTypedExprPtr& callTypeExpr,
+    google::protobuf::Arena& arena,
+    SubstraitExprConverter& topLevelConverter) const {
+  if (callTypeExpr->name() == "if" && callTypeExpr->name() == "switch") {
+    if (callTypeExpr->inputs().size() % 2 != 1) {
+      VELOX_NYI(
+          "Number of arguments are always going to be odd for if/then expression");
+    }
+
+    auto* substraitExpr =
+        google::protobuf::Arena::CreateMessage<::substrait::Expression>(&arena);
+    auto ifThenExpr = substraitExpr->mutable_if_then();
+
+    auto last = callTypeExpr->inputs().size() - 1;
+    for (int i = 0; i < last; i += 2) {
+      auto ifClauseExpr = ifThenExpr->add_ifs();
+      ifClauseExpr->mutable_if_()->MergeFrom(
+          topLevelConverter(callTypeExpr->inputs().at(i)));
+
+      ifClauseExpr->mutable_then()->MergeFrom(
+          topLevelConverter(callTypeExpr->inputs().at(i + 1)));
+    }
+    ifThenExpr->mutable_else_()->MergeFrom(
+        topLevelConverter(callTypeExpr->inputs().at(last)));
+    return std::make_optional(substraitExpr);
+  }
+  return std::nullopt;
+}
+
+const std::optional<::substrait::Expression*>
+VeloxToSubstraitScalarFunctionConverter::convert(
+    const core::CallTypedExprPtr& callTypeExpr,
+    google::protobuf::Arena& arena,
+    SubstraitExprConverter& topLevelConverter) const {
+  auto* substraitExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression>(&arena);
+  auto scalarExpr = substraitExpr->mutable_scalar_function();
+
+  std::vector<TypePtr> arguments;
+  arguments.reserve(callTypeExpr->inputs().size());
+  for (const auto& input : callTypeExpr->inputs()) {
+    arguments.emplace_back(input->type());
+  }
+
+  const auto& referenceId = extensionCollector_->getFunctionReference(
+      callTypeExpr->name(), arguments);
+
+  VELOX_CHECK(
+      referenceId.has_value(),
+      "Fail to get function reference for call typed expression, {}",
+      callTypeExpr->toString());
+  scalarExpr->set_function_reference(referenceId.value());
+
+  for (auto& arg : callTypeExpr->inputs()) {
+    const auto& message = topLevelConverter(arg);
+    scalarExpr->add_args()->MergeFrom(message);
+  }
+  scalarExpr->mutable_output_type()->MergeFrom(
+      typeConvertor_->toSubstraitType(arena, callTypeExpr->type()));
+
+  return std::make_optional(substraitExpr);
+}
+
+} // namespace facebook::velox::substrait

--- a/velox/substrait/VeloxToSubstraitCallConverter.h
+++ b/velox/substrait/VeloxToSubstraitCallConverter.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "optional"
+#include "velox/expression/Expr.h"
+#include "velox/substrait/SubstraitExtensionCollector.h"
+#include "velox/substrait/TypeUtils.h"
+#include "velox/substrait/VeloxToSubstraitType.h"
+#include "velox/substrait/proto/substrait/algebra.pb.h"
+
+namespace facebook::velox::substrait {
+
+using SubstraitExprConverter =
+    std::function<::substrait::Expression(const core::TypedExprPtr&)>;
+
+// This class is used to convert the velox CallTypedExpr into substrait scalar
+// function expression.
+class VeloxToSubstraitCallConverter {
+ public:
+  /// convert callTypedExpr to substrait Expression.
+  virtual const std::optional<::substrait::Expression*> convert(
+      const core::CallTypedExprPtr& callTypeExpr,
+      google::protobuf::Arena& arena,
+      SubstraitExprConverter& topLevelConverter) const = 0;
+};
+
+using VeloxToSubstraitCallConverterPtr =
+    std::shared_ptr<const VeloxToSubstraitCallConverter>;
+
+/// convert 'if/switch' CallTypedExpr to substrait ifThen expression.
+class VeloxToSubstraitIfThenConverter : public VeloxToSubstraitCallConverter {
+ public:
+  const std::optional<::substrait::Expression*> convert(
+      const core::CallTypedExprPtr& callTypeExpr,
+      google::protobuf::Arena& arena,
+      SubstraitExprConverter& topLevelConverter) const override;
+};
+
+/// convert callTypedExpr to substrait expression except 'if/switch'
+class VeloxToSubstraitScalarFunctionConverter
+    : public VeloxToSubstraitCallConverter {
+ public:
+  VeloxToSubstraitScalarFunctionConverter(
+      const SubstraitExtensionCollectorPtr& extensionCollector,
+      const VeloxToSubstraitTypeConvertorPtr typeConvertor)
+      : extensionCollector_(extensionCollector),
+        typeConvertor_(typeConvertor) {}
+
+  const std::optional<::substrait::Expression*> convert(
+      const core::CallTypedExprPtr& callTypeExpr,
+      google::protobuf::Arena& arena,
+      SubstraitExprConverter& topLevelConverter) const override;
+
+ private:
+  SubstraitExtensionCollectorPtr extensionCollector_;
+  VeloxToSubstraitTypeConvertorPtr typeConvertor_;
+};
+
+} // namespace facebook::velox::substrait

--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -129,34 +129,18 @@ const ::substrait::Expression& VeloxToSubstraitExprConvertor::toSubstraitExpr(
     google::protobuf::Arena& arena,
     const std::shared_ptr<const core::CallTypedExpr>& callTypeExpr,
     const RowTypePtr& inputType) {
-  ::substrait::Expression* substraitExpr =
-      google::protobuf::Arena::CreateMessage<::substrait::Expression>(&arena);
-
-  auto inputs = callTypeExpr->inputs();
-  auto& functionName = callTypeExpr->name();
-
-  // The processing is different for different function names.
-  // TODO add support for if Expr and switch Expr
-  if (functionName != "if" && functionName != "switch") {
-    ::substrait::Expression_ScalarFunction* scalarExpr =
-        substraitExpr->mutable_scalar_function();
-
-    // TODO need to change yaml file to register function, now is dummy.
-
-    scalarExpr->set_function_reference(functionMap_[functionName]);
-
-    for (auto& arg : inputs) {
-      scalarExpr->add_args()->MergeFrom(toSubstraitExpr(arena, arg, inputType));
+  SubstraitExprConverter topLevelConverter =
+      [&](const core::TypedExprPtr& typeExpr) {
+        return this->toSubstraitExpr(arena, typeExpr, inputType);
+      };
+  for (const auto& cc : callConverters_) {
+    auto expressionOption = cc->convert(callTypeExpr, arena, topLevelConverter);
+    if (expressionOption.has_value()) {
+      return *expressionOption.value();
     }
-
-    scalarExpr->mutable_output_type()->MergeFrom(
-        typeConvertor_->toSubstraitType(arena, callTypeExpr->type()));
-
-  } else {
-    VELOX_NYI("Unsupported function name '{}'", functionName);
   }
 
-  return *substraitExpr;
+  VELOX_NYI("Unsupported function name '{}'", callTypeExpr->name());
 }
 
 const ::substrait::Expression_Literal&

--- a/velox/substrait/VeloxToSubstraitExpr.h
+++ b/velox/substrait/VeloxToSubstraitExpr.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/core/PlanNode.h"
-
+#include "velox/substrait/VeloxToSubstraitCallConverter.h"
 #include "velox/substrait/VeloxToSubstraitType.h"
 #include "velox/substrait/proto/substrait/algebra.pb.h"
 
@@ -25,11 +25,13 @@ namespace facebook::velox::substrait {
 
 class VeloxToSubstraitExprConvertor {
  public:
-  /// @param functionMap: A pre-constructed map
-  /// storing the relations between the function name and the function id.
+  /// @param callConverters: A collection of CallConverter
+  /// each of which is responsible for convert Velox CallTypedExpr into
+  /// Corresponding Substrait Expression.
   explicit VeloxToSubstraitExprConvertor(
-      const std::unordered_map<std::string, uint64_t>& functionMap)
-      : functionMap_(functionMap) {}
+      const VeloxToSubstraitTypeConvertorPtr& typeConvertor,
+      const std::vector<VeloxToSubstraitCallConverterPtr>& callConverters)
+      : typeConvertor_(typeConvertor), callConverters_(callConverters) {}
 
   /// Convert Velox Expression to Substrait Expression.
   /// @param arena Arena to use for allocating Substrait plan objects.
@@ -95,11 +97,11 @@ class VeloxToSubstraitExprConvertor {
       google::protobuf::Arena& arena,
       const velox::variant& variantValue);
 
-  std::shared_ptr<VeloxToSubstraitTypeConvertor> typeConvertor_;
-
-  /// The map storing the relations between the function name and the function
-  /// id.
-  std::unordered_map<std::string, uint64_t> functionMap_;
+  const VeloxToSubstraitTypeConvertorPtr typeConvertor_;
+  const std::vector<VeloxToSubstraitCallConverterPtr> callConverters_;
 };
+
+using VeloxToSubstraitExprConvertorPtr =
+    std::shared_ptr<VeloxToSubstraitExprConvertor>;
 
 } // namespace facebook::velox::substrait

--- a/velox/substrait/VeloxToSubstraitPlan.h
+++ b/velox/substrait/VeloxToSubstraitPlan.h
@@ -19,19 +19,25 @@
 #include <google/protobuf/arena.h>
 #include <string>
 #include <typeinfo>
-
 #include "velox/core/PlanNode.h"
-#include "velox/type/Type.h"
-
+#include "velox/substrait/SubstraitExtensionCollector.h"
 #include "velox/substrait/VeloxToSubstraitExpr.h"
 #include "velox/substrait/proto/substrait/algebra.pb.h"
 #include "velox/substrait/proto/substrait/plan.pb.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::substrait {
 
 /// Convert the Velox plan into Substrait plan.
 class VeloxToSubstraitPlanConvertor {
  public:
+  /// constructor VeloxToSubstraitPlanConvertor
+  VeloxToSubstraitPlanConvertor();
+
+  /// constructor VeloxToSubstraitPlanConvertor with given extensionCollector.
+  VeloxToSubstraitPlanConvertor(
+      const SubstraitExtensionCollectorPtr& extensionCollector);
+
   /// Convert Velox PlanNode into Substrait Plan.
   /// @param vPlan Velox query plan to convert.
   /// @param arena Arena to use for allocating Substrait plan objects.
@@ -72,21 +78,16 @@ class VeloxToSubstraitPlanConvertor {
       const std::shared_ptr<const core::AggregationNode>& aggregateNode,
       ::substrait::AggregateRel* aggregateRel);
 
-  /// Construct the function map between the Velox function name and index.
-  void constructFunctionMap();
-
-  ///  Fetch all functions from Velox's registry and create Substrait extensions
-  ///  for these.
-  ::substrait::Plan& addExtensionFunc(google::protobuf::Arena& arena);
-
   /// The Expression converter used to convert Velox representations into
   /// Substrait expressions.
-  std::shared_ptr<VeloxToSubstraitExprConvertor> exprConvertor_;
+  VeloxToSubstraitExprConvertorPtr exprConvertor_;
 
-  std::shared_ptr<VeloxToSubstraitTypeConvertor> typeConvertor_;
+  /// The Type converter used to conver velox representation into Substrait
+  /// type.
+  VeloxToSubstraitTypeConvertorPtr typeConvertor_;
 
-  /// The map storing the relations between the function name and the function
-  /// id. Will be constructed based on the Velox representation.
-  std::unordered_map<std::string, uint64_t> functionMap_;
+  /// The extension Collector used to collect function & type reference.
+  SubstraitExtensionCollectorPtr extensionCollector_;
 };
+
 } // namespace facebook::velox::substrait

--- a/velox/substrait/VeloxToSubstraitType.h
+++ b/velox/substrait/VeloxToSubstraitType.h
@@ -18,6 +18,7 @@
 
 #include "velox/core/PlanNode.h"
 
+#include "velox/substrait/SubstraitExtensionCollector.h"
 #include "velox/substrait/proto/substrait/algebra.pb.h"
 #include "velox/substrait/proto/substrait/type.pb.h"
 
@@ -25,15 +26,25 @@ namespace facebook::velox::substrait {
 
 class VeloxToSubstraitTypeConvertor {
  public:
+  VeloxToSubstraitTypeConvertor(
+      const SubstraitExtensionCollectorPtr& extensionCollector)
+      : extensionCollector_(extensionCollector) {}
   /// Convert Velox RowType to Substrait NamedStruct.
   const ::substrait::NamedStruct& toSubstraitNamedStruct(
       google::protobuf::Arena& arena,
-      const velox::RowTypePtr& rowType);
+      const velox::RowTypePtr& rowType) const;
 
   /// Convert Velox Type to Substrait Type.
   const ::substrait::Type& toSubstraitType(
       google::protobuf::Arena& arena,
-      const velox::TypePtr& type);
+      const velox::TypePtr& type) const;
+
+ private:
+  /// The function Collector used to collect the type reference.
+  const SubstraitExtensionCollectorPtr extensionCollector_;
 };
+
+using VeloxToSubstraitTypeConvertorPtr =
+    std::shared_ptr<const VeloxToSubstraitTypeConvertor>;
 
 } // namespace facebook::velox::substrait

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -16,7 +16,8 @@ add_executable(
   velox_plan_conversion_test
   VeloxToSubstraitTypeTest.cpp Substrait2VeloxPlanConversionTest.cpp
   Substrait2VeloxValuesNodeConversionTest.cpp FunctionTest.cpp
-  JsonToProtoConverter.cpp VeloxSubstraitRoundTripPlanConverterTest.cpp)
+  JsonToProtoConverter.cpp VeloxSubstraitRoundTripPlanConverterTest.cpp
+  VeloxToSubstraitTypeTest.cpp TypeUtilsTest.cpp)
 
 add_dependencies(velox_plan_conversion_test velox_substrait_plan_converter)
 

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -14,10 +14,14 @@
 
 add_executable(
   velox_plan_conversion_test
-  VeloxToSubstraitTypeTest.cpp Substrait2VeloxPlanConversionTest.cpp
-  Substrait2VeloxValuesNodeConversionTest.cpp FunctionTest.cpp
-  JsonToProtoConverter.cpp VeloxSubstraitRoundTripPlanConverterTest.cpp
-  VeloxToSubstraitTypeTest.cpp TypeUtilsTest.cpp)
+  VeloxToSubstraitTypeTest.cpp
+  Substrait2VeloxPlanConversionTest.cpp
+  Substrait2VeloxValuesNodeConversionTest.cpp
+  FunctionTest.cpp
+  JsonToProtoConverter.cpp
+  VeloxSubstraitRoundTripPlanConverterTest.cpp
+  VeloxToSubstraitTypeTest.cpp
+  TypeUtilsTest.cpp)
 
 add_dependencies(velox_plan_conversion_test velox_substrait_plan_converter)
 

--- a/velox/substrait/tests/TypeUtilsTest.cpp
+++ b/velox/substrait/tests/TypeUtilsTest.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/substrait/TypeUtils.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::substrait;
+
+namespace facebook::velox::substrait::test {
+
+class TypeUtilsTest : public ::testing::Test {
+ protected:
+  static void testToSubstraitType(
+      const TypePtr& type,
+      const std::string& expectedType) {
+    SCOPED_TRACE(type->toString());
+    auto substraitType = substraitSignature(type);
+    ASSERT_EQ(substraitType, expectedType);
+  }
+};
+
+TEST_F(TypeUtilsTest, basic) {
+  testToSubstraitType(BOOLEAN(), "bool");
+
+  testToSubstraitType(TINYINT(), "i8");
+  testToSubstraitType(SMALLINT(), "i16");
+  testToSubstraitType(INTEGER(), "i32");
+  testToSubstraitType(BIGINT(), "i64");
+
+  testToSubstraitType(REAL(), "fp32");
+  testToSubstraitType(DOUBLE(), "fp64");
+
+  testToSubstraitType(VARCHAR(), "str");
+  testToSubstraitType(VARBINARY(), "vbin");
+
+  testToSubstraitType(TIMESTAMP(), "ts");
+  testToSubstraitType(DATE(), "date");
+
+  testToSubstraitType(SHORT_DECIMAL(18, 2), "dec");
+  testToSubstraitType(LONG_DECIMAL(18, 2), "dec");
+
+  testToSubstraitType(ARRAY(BOOLEAN()), "list");
+  testToSubstraitType(ARRAY(INTEGER()), "list");
+
+  testToSubstraitType(MAP(INTEGER(), BIGINT()), "map");
+
+  testToSubstraitType(ROW({INTEGER(), BIGINT()}), "struct");
+  testToSubstraitType(ROW({ARRAY(INTEGER())}), "struct");
+  testToSubstraitType(ROW({MAP(INTEGER(), INTEGER())}), "struct");
+  testToSubstraitType(ROW({ROW({INTEGER()})}), "struct");
+
+  testToSubstraitType(UNKNOWN(), "u!name");
+
+  ASSERT_ANY_THROW(testToSubstraitType(INTERVAL_DAY_TIME(), "iday"));
+}
+
+} // namespace facebook::velox::substrait::test

--- a/velox/substrait/tests/VeloxSubstraitRoundTripPlanConverterTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripPlanConverterTest.cpp
@@ -93,6 +93,53 @@ TEST_F(VeloxSubstraitRoundTripPlanConverterTest, filter) {
   assertPlanConversion(plan, "SELECT * FROM tmp WHERE c2 < 1000");
 }
 
+TEST_F(VeloxSubstraitRoundTripPlanConverterTest, scalarFunc_string_test) {
+  std::vector<RowVectorPtr> vectors;
+  vectors.reserve(1);
+  auto dow = makeFlatVector<std::string>(
+      {"monday",
+       "tuesday",
+       "wednesday",
+       "thursday",
+       "friday",
+       "saturday",
+       "sunday"});
+  auto rowVector = makeRowVector({"dow"}, {dow});
+  vectors.emplace_back(rowVector);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).filter("dow like 's%'").planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp where dow like 's%'");
+  plan = PlanBuilder().values(vectors).project({"substr(dow,1,3)"}).planNode();
+  assertPlanConversion(plan, "SELECT substr(dow,1,3) FROM tmp ");
+}
+
+TEST_F(VeloxSubstraitRoundTripPlanConverterTest, scalarFunc_boolean_test) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+
+  auto plan =
+      PlanBuilder().values(vectors).filter("c0 < 100 and c2 < 1000").planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp WHERE c0 < 100 and c2 < 1000");
+
+  plan =
+      PlanBuilder().values(vectors).filter("c0 < 100 or c2 < 1000").planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp WHERE c0 < 100 or c2 < 1000");
+
+  plan = PlanBuilder().values(vectors).filter("not c0 < 100").planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp WHERE not c0 < 100");
+}
+
+TEST_F(VeloxSubstraitRoundTripPlanConverterTest, scalarFunc_compare_test) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .filter("c0 between 100 and 1000")
+                  .planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp WHERE c0 between 100 and 1000");
+}
+
 TEST_F(VeloxSubstraitRoundTripPlanConverterTest, null) {
   auto vectors = makeRowVector(ROW({}, {}), 1);
   auto plan = PlanBuilder().values({vectors}).project({"NULL"}).planNode();
@@ -174,6 +221,19 @@ TEST_F(VeloxSubstraitRoundTripPlanConverterTest, sumAndCount) {
   assertPlanConversion(plan, "SELECT sum(c1), count(c4) FROM tmp");
 }
 
+TEST_F(VeloxSubstraitRoundTripPlanConverterTest, avgAndCount) {
+  auto vectors = makeVectors(2, 7, 3);
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .partialAggregation({}, {"avg(c1)", "count(c4)"})
+                  .finalAggregation()
+                  .planNode();
+
+  assertPlanConversion(plan, "SELECT avg(c1), count(c4) FROM tmp");
+}
+
 TEST_F(VeloxSubstraitRoundTripPlanConverterTest, sumGlobal) {
   auto vectors = makeVectors(2, 7, 3);
   createDuckDbTable(vectors);
@@ -207,6 +267,32 @@ TEST_F(VeloxSubstraitRoundTripPlanConverterTest, sumMask) {
       "SELECT sum(c0) FILTER (WHERE c2 % 2 < 10), "
       "sum(c0) FILTER (WHERE c3 % 3 = 0), sum(c1) FILTER (WHERE c3 % 3 = 0) "
       "FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripPlanConverterTest, caseWhen) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .project({"case when 1=1 then 1 else 0  end as x"})
+                  .planNode();
+  assertPlanConversion(
+      plan, "SELECT case when 1=1 then 1 else 0  end as x  FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripPlanConverterTest, cast) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).project({"true"}).planNode();
+  assertPlanConversion(plan, "SELECT true  FROM tmp");
+}
+
+TEST_F(VeloxSubstraitRoundTripPlanConverterTest, ifThen) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan =
+      PlanBuilder().values(vectors).project({"if (1=1, 0,1) as x"}).planNode();
+  assertPlanConversion(plan, "SELECT if (1=1, 0,1) as x  FROM tmp");
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
For each function signature in a velox plan, if we saw its signature in a map, then return its reference id, otherwise increase referenceId and return it