### PR TITLE
Optimize memory allocations in 'concat' Presto function

### DIFF
--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -103,21 +103,6 @@ void concatStatic(TOutString& output, const Args&... inputs) {
   }...);
 }
 
-/// Concat function that operates on a dynamic number of inputs packed in vector
-template <typename TOutString, typename TInString>
-void concatDynamic(TOutString& output, const std::vector<TInString>& inputs) {
-  for (const auto& curInput : inputs) {
-    if (curInput.size() == 0) {
-      continue;
-    }
-    applyAppendersRecursive(output, [&](TOutString& out) {
-      auto writeOffset = out.size();
-      out.resize(out.size() + curInput.size());
-      std::memcpy(out.data() + writeOffset, curInput.data(), curInput.size());
-    });
-  }
-}
-
 /// Return length of the input string in chars
 template <bool isAscii, typename T>
 FOLLY_ALWAYS_INLINE int64_t length(const T& input) {

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -121,29 +121,6 @@ TEST_F(StringImplTest, lowerUnicode) {
   }
 }
 
-TEST_F(StringImplTest, concatDynamic) {
-  core::StringWriter output;
-
-  concatDynamic(output, std::vector<std::string>{"AA"});
-  ASSERT_EQ(StringView("AA"), output);
-
-  output.resize(0);
-  concatDynamic(output, std::vector<std::string>{"AA", "BB"});
-  ASSERT_EQ(StringView("AABB"), output);
-
-  output.resize(0);
-  concatDynamic(output, std::vector<std::string>{"AA", "BB", "CC"});
-  ASSERT_EQ(StringView("AABBCC"), output);
-
-  output.resize(0);
-  concatDynamic(output, std::vector<std::string>{"AA", "", "CC"});
-  ASSERT_EQ(StringView("AACC"), output);
-
-  output.resize(0);
-  concatDynamic(output, std::vector<std::string>{"hello na\u00EFve", " world"});
-  ASSERT_EQ(StringView("hello na\u00EFve world"), output);
-}
-
 TEST_F(StringImplTest, concatLazy) {
   core::StringWriter output;
 

--- a/velox/vector/tests/VectorTestBase.h
+++ b/velox/vector/tests/VectorTestBase.h
@@ -33,6 +33,10 @@ void assertCopyableVector(const VectorPtr& vector);
 
 class VectorTestBase {
  protected:
+  VectorTestBase() {
+    pool_->setMemoryUsageTracker(memory::MemoryUsageTracker::create());
+  }
+
   template <typename T>
   using EvalType = typename CppToType<T>::NativeType;
 


### PR DESCRIPTION
Calculate the total size of the combined strings and allocate a sufficiently
large string buffer. Then, copy the strings into the buffer.

Previous implementation allocated memory incrementally in 32KB chunks.