### PR TITLE
Add ReverseSignatureBinder utility class

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_expression_functions FunctionRegistry.h FunctionSignature.cpp
-                                       SignatureBinder.cpp)
+add_library(
+  velox_expression_functions FunctionSignature.cpp SignatureBinder.cpp
+                             ReverseSignatureBinder.cpp)
 
 target_link_libraries(velox_expression_functions velox_common_base
                       velox_type_calculation)

--- a/velox/expression/ReverseSignatureBinder.cpp
+++ b/velox/expression/ReverseSignatureBinder.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/ReverseSignatureBinder.h"
+#include "FunctionSignature.h"
+
+namespace facebook::velox::exec {
+
+bool ReverseSignatureBinder::isConstrainedType(
+    const TypeSignature& type) const {
+  if (type.parameters().empty()) {
+    return constraints_.find(type.baseName()) != constraints_.end();
+  }
+
+  auto parameters = type.parameters();
+  for (const auto& parameter : parameters) {
+    if (isConstrainedType(parameter)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ReverseSignatureBinder::tryBind() {
+  if (isConstrainedType(signature_.returnType())) {
+    return false;
+  }
+  return SignatureBinderBase::tryBind(signature_.returnType(), returnType_);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/ReverseSignatureBinder.h
+++ b/velox/expression/ReverseSignatureBinder.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/FunctionSignature.h"
+#include "velox/expression/SignatureBinder.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::exec {
+
+/// Bind a function signature with a concrete return type. bindings() return a
+/// map from each type variable in the signature to the corresponding concrete
+/// type if determined, or a nullptr if the type variable cannot be determined
+/// by the return type.
+class ReverseSignatureBinder : private SignatureBinderBase {
+ public:
+  ReverseSignatureBinder(
+      const exec::FunctionSignature& signature,
+      const TypePtr& returnType)
+      : SignatureBinderBase{signature}, returnType_{returnType} {}
+
+  /// Try bind returnType_ to the return type of the function signature. Return
+  /// true if the binding succeeds, or false otherwise.
+  bool tryBind();
+
+  /// Return the determined bindings. This function should be called after
+  /// tryBind() and only if tryBind() returns true. If a type variable is not
+  /// determined by tryBind(), it maps to a nullptr.
+  const std::unordered_map<std::string, TypePtr>& bindings() const {
+    return typeParameters_;
+  }
+
+ private:
+  /// Return whether there is a constraint on the type in the function
+  /// signature.
+  bool isConstrainedType(const TypeSignature& type) const;
+
+  const TypePtr returnType_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -141,14 +141,14 @@ bool SignatureBinder::tryBind() {
   }
 
   for (auto i = 0; i < formalArgsCnt && i < actualTypes_.size(); i++) {
-    if (!tryBind(formalArgs[i], actualTypes_[i])) {
+    if (!SignatureBinderBase::tryBind(formalArgs[i], actualTypes_[i])) {
       return false;
     }
   }
   return true;
 }
 
-bool SignatureBinder::checkOrSetIntegerParameter(
+bool SignatureBinderBase::checkOrSetIntegerParameter(
     const std::string& parameterName,
     int value) {
   auto it = integerParameters_.find(parameterName);
@@ -164,7 +164,7 @@ bool SignatureBinder::checkOrSetIntegerParameter(
   return true;
 }
 
-bool SignatureBinder::tryBindIntegerParameters(
+bool SignatureBinderBase::tryBindIntegerParameters(
     const std::vector<exec::TypeSignature>& parameters,
     const TypePtr& actualType) {
   // Decimal types
@@ -177,7 +177,7 @@ bool SignatureBinder::tryBindIntegerParameters(
   return false;
 }
 
-bool SignatureBinder::tryBind(
+bool SignatureBinderBase::tryBind(
     const exec::TypeSignature& typeSignature,
     const TypePtr& actualType) {
   if (isAny(typeSignature)) {

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -20,16 +20,10 @@
 
 namespace facebook::velox::exec {
 
-/// Resolves generic type names in the function signature using actual input
-/// types. E.g. given function signature array(T) -> T and input type
-/// array(bigint), resolves T to bigint. If type resolution is successful,
-/// calculates the actual return type, e.g. bigint in the previous example.
-class SignatureBinder {
- public:
-  SignatureBinder(
-      const exec::FunctionSignature& signature,
-      const std::vector<TypePtr>& actualTypes)
-      : signature_{signature}, actualTypes_{actualTypes} {
+class SignatureBinderBase {
+ protected:
+  explicit SignatureBinderBase(const exec::FunctionSignature& signature)
+      : signature_{signature} {
     for (auto& variable : signature.typeVariableConstraints()) {
       // Integer parameters are updated during bind.
       if (variable.isTypeParameter()) {
@@ -43,10 +37,43 @@ class SignatureBinder {
     }
   }
 
-  // Returns true if successfully resolved all generic type names.
+  /// Return true if actualType can bind to typeSignature and update bindings_
+  /// accordingly.
+  bool tryBind(
+      const exec::TypeSignature& typeSignature,
+      const TypePtr& actualType);
+
+  const exec::FunctionSignature& signature_;
+  std::unordered_map<std::string, TypePtr> typeParameters_;
+  std::unordered_map<std::string, std::optional<int>> integerParameters_;
+  std::unordered_map<std::string, std::string> constraints_;
+
+ private:
+  /// If the integer parameter is set, then it must match with value.
+  /// Returns false if values do not match or the parameter does not exist.
+  bool checkOrSetIntegerParameter(const std::string& parameterName, int value);
+
+  /// Try to bind the integer parameter from the actualType.
+  bool tryBindIntegerParameters(
+      const std::vector<exec::TypeSignature>& parameters,
+      const TypePtr& actualType);
+};
+
+/// Resolves generic type names in the function signature using actual input
+/// types. E.g. given function signature array(T) -> T and input type
+/// array(bigint), resolves T to bigint. If type resolution is successful,
+/// calculates the actual return type, e.g. bigint in the previous example.
+class SignatureBinder : private SignatureBinderBase {
+ public:
+  SignatureBinder(
+      const exec::FunctionSignature& signature,
+      const std::vector<TypePtr>& actualTypes)
+      : SignatureBinderBase{signature}, actualTypes_{actualTypes} {}
+
+  /// Returns true if successfully resolved all generic type names.
   bool tryBind();
 
-  // Returns concrete return type or null if couldn't fully resolve.
+  /// Returns concrete return type or null if couldn't fully resolve.
   TypePtr tryResolveReturnType() {
     return tryResolveType(signature_.returnType());
   }
@@ -61,7 +88,7 @@ class SignatureBinder {
     return tryResolveType(
         typeSignature, typeParameters, constraints, integerParameters);
   }
-  // Returns concrete return type or null if couldn't fully resolve.
+  /// Returns concrete return type or null if couldn't fully resolve.
   static TypePtr tryResolveType(
       const exec::TypeSignature& typeSignature,
       const std::unordered_map<std::string, TypePtr>& typeParameters,
@@ -69,23 +96,6 @@ class SignatureBinder {
       std::unordered_map<std::string, std::optional<int>>& integerParameters);
 
  private:
-  bool tryBind(
-      const exec::TypeSignature& typeSignature,
-      const TypePtr& actualType);
-
-  // If the integer parameter is set, then it must match with value.
-  // Returns false if values do not match or the parameter does not exist.
-  bool checkOrSetIntegerParameter(const std::string& parameterName, int value);
-
-  // Try to bind the integer parameter from the actualType.
-  bool tryBindIntegerParameters(
-      const std::vector<exec::TypeSignature>& parameters,
-      const TypePtr& actualType);
-
-  const exec::FunctionSignature& signature_;
   const std::vector<TypePtr>& actualTypes_;
-  std::unordered_map<std::string, TypePtr> typeParameters_;
-  std::unordered_map<std::string, std::optional<int>> integerParameters_;
-  std::unordered_map<std::string, std::string> constraints_;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   ConstantFlatVectorReaderTest.cpp
   MapWriterTest.cpp
   ArrayWriterTest.cpp
+  ReverseSignatureBinderTest.cpp
   RowWriterTest.cpp
   EvalSimplifiedTest.cpp
   SignatureBinderTest.cpp

--- a/velox/expression/tests/ReverseSignatureBinderTest.cpp
+++ b/velox/expression/tests/ReverseSignatureBinderTest.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/ReverseSignatureBinder.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox {
+namespace {
+
+class ReverseSignatureBinderTest : public testing::Test {
+ protected:
+  void testBindingSuccess(
+      const std::shared_ptr<exec::FunctionSignature>& signature,
+      const TypePtr& returnType,
+      const std::vector<std::pair<std::string, TypePtr>>& expectedBindings) {
+    exec::ReverseSignatureBinder binder{*signature, returnType};
+    ASSERT_TRUE(binder.tryBind());
+
+    auto actualBindings = binder.bindings();
+    ASSERT_EQ(actualBindings.size(), expectedBindings.size());
+
+    for (const auto& pair : expectedBindings) {
+      ASSERT_EQ(actualBindings.count(pair.first), 1);
+      if (pair.second) {
+        ASSERT_TRUE(pair.second->equivalent(*actualBindings[pair.first]));
+      } else {
+        ASSERT_TRUE(actualBindings[pair.first] == nullptr);
+      }
+    }
+  }
+
+  void testBindingFailure(
+      const std::shared_ptr<exec::FunctionSignature>& signature,
+      const TypePtr& returnType) {
+    exec::ReverseSignatureBinder binder{*signature, returnType};
+    ASSERT_FALSE(binder.tryBind());
+  }
+};
+
+TEST_F(ReverseSignatureBinderTest, concreteSignature) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .returnType("array(varchar)")
+                       .argumentType("varchar")
+                       .argumentType("bigint")
+                       .build();
+
+  testBindingSuccess(signature, ARRAY(VARCHAR()), {});
+  testBindingFailure(signature, VARCHAR());
+}
+
+TEST_F(ReverseSignatureBinderTest, any) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .returnType("array(any)")
+                       .argumentType("varchar")
+                       .argumentType("bigint")
+                       .build();
+
+  testBindingSuccess(signature, ARRAY(VARCHAR()), {});
+  testBindingFailure(signature, VARCHAR());
+}
+
+TEST_F(ReverseSignatureBinderTest, signatureTemplateFullBinding) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .typeVariable("K")
+                       .typeVariable("V")
+                       .returnType("map(K, V)")
+                       .argumentType("K")
+                       .argumentType("V")
+                       .build();
+
+  testBindingSuccess(
+      signature, MAP(VARCHAR(), BIGINT()), {{"K", VARCHAR()}, {"V", BIGINT()}});
+  testBindingFailure(signature, VARCHAR());
+}
+
+TEST_F(ReverseSignatureBinderTest, signatureTemplatePartialBinding) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .typeVariable("K")
+                       .typeVariable("V")
+                       .returnType("array(K)")
+                       .argumentType("K")
+                       .argumentType("V")
+                       .build();
+
+  testBindingSuccess(
+      signature, ARRAY(VARCHAR()), {{"K", VARCHAR()}, {"V", nullptr}});
+  testBindingFailure(signature, VARCHAR());
+}
+
+TEST_F(ReverseSignatureBinderTest, unsupported) {
+  // Constraints on the return type is not supported.
+  auto signature =
+      exec::FunctionSignatureBuilder()
+          .integerVariable("a_scale")
+          .integerVariable("b_scale")
+          .integerVariable("a_precision")
+          .integerVariable("b_precision")
+          .integerVariable(
+              "r_precision",
+              "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
+          .integerVariable("r_scale", "max(a_scale, b_scale)")
+          .returnType("row(array(decimal(r_precision, r_scale)))")
+          .argumentType("decimal(a_precision, a_scale)")
+          .argumentType("decimal(b_precision, b_scale)")
+          .build();
+
+  testBindingFailure(signature, DECIMAL(13, 6));
+}
+
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
Summary: Add ReverseSignatureBinder that bind a given return type with a given function signature and determine the bindings of type variables in the signature. Type variables that cannot be determined by the return type map to nullptrs. This class will be used in supporting complex type in expression fuzzer.

Differential Revision: D39392090

