### PR TITLE
Pre-load lazy vectors that are referenced by multiple sub expressions

### DIFF
--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -159,19 +159,6 @@ RowVectorPtr FilterProject::getOutput() {
 }
 
 void FilterProject::project(const SelectivityVector& rows, EvalCtx& evalCtx) {
-  // Make sure LazyVectors are loaded for all the "rows".
-  //
-  // Consider projection with 2 expressions: f(a) AND g(b), h(b)
-  // If b is a LazyVector and f(a) AND g(b) expression is evaluated first, it
-  // will load b only for rows where f(a) is true. However, h(b) projection
-  // needs all rows for "b".
-  //
-  // This works, but may load more rows than necessary. E.g. if we only have
-  // f(a) AND g(b) expression and b is not used anywhere else, it is sufficient
-  // to load b for a subset of rows where f(a) is true.
-  *evalCtx.mutableIsFinalSelection() = false;
-  *evalCtx.mutableFinalSelection() = &rows;
-
   exprs_->eval(
       hasFilter_ ? 1 : 0, numExprs_, !hasFilter_, rows, evalCtx, results_);
 }

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1830,6 +1830,28 @@ TEST_F(TableScanTest, structLazy) {
   assertQuery(op, {filePath}, "select c0 % 3 from tmp");
 }
 
+TEST_F(TableScanTest, lazyVectorAccessTwiceWithDifferentRows) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, 1, 1, std::nullopt}),
+      makeNullableFlatVector<int64_t>({0, 1, 2, 3}),
+  });
+
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, {data});
+  createDuckDbTable({data});
+
+  auto plan =
+      PlanBuilder()
+          .tableScan(asRowType(data->type()))
+          .filter(
+              "element_at(array_constructor(c0 + c1, if(c1 >= 0, c1, 0)), 1) > 0")
+          .planNode();
+  assertQuery(
+      plan,
+      {filePath},
+      "SELECT c0, c1 from tmp where ([c0 + c1, if(c1 >= 0, c1, 0)])[1] > 0");
+}
+
 TEST_F(TableScanTest, structInArrayOrMap) {
   vector_size_t size = 1'000;
 

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -217,11 +217,6 @@ VectorPtr EvalCtx::ensureFieldLoaded(
     const SelectivityVector& rows) {
   auto field = getField(index);
   if (isLazyNotLoaded(*field)) {
-    // Remain the usage of "finalSelection_". if ExprSet::eval invoked with
-    // partial rows more than once, LazyVector need to load for all
-    // the *finalSelection_. you can see the example usage in
-    // ExprEncodingsTest::run. ExprSet::eval invoked with the first 2/3 rows,
-    // and then invoked with the last 2/3 rows.
     const auto& rowsToLoad = isFinalSelection_ ? rows : *finalSelection_;
 
     LocalDecodedVector holder(*this);

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -217,6 +217,11 @@ VectorPtr EvalCtx::ensureFieldLoaded(
     const SelectivityVector& rows) {
   auto field = getField(index);
   if (isLazyNotLoaded(*field)) {
+    // Remain the usage of "finalSelection_". if ExprSet::eval invoked with
+    // partial rows more than once, LazyVector need to load for all
+    // the *finalSelection_. you can see the example usage in
+    // ExprEncodingsTest::run. ExprSet::eval invoked with the first 2/3 rows,
+    // and then invoked with the last 2/3 rows.
     const auto& rowsToLoad = isFinalSelection_ ? rows : *finalSelection_;
 
     LocalDecodedVector holder(*this);

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1409,7 +1409,7 @@ void ExprSet::eval(
   // will load b only for rows where f(a) is true. However, h(b) projection
   // needs all rows for "b".
   for (const auto& field : multiplyReferencedFields_) {
-    context->ensureFieldLoaded(field->index(*context), rows);
+    context.ensureFieldLoaded(field->index(context), rows);
   }
 
   for (int32_t i = begin; i < end; ++i) {

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -336,6 +336,10 @@ class Expr {
   // parent Expr.
   std::vector<FieldReference * FOLLY_NONNULL> distinctFields_;
 
+  // Fields referenced by multiple inputs, which is subset of distinctFields_.
+  // used to determine pre-loading of lazy vectors at current expr
+  std::set<FieldReference * FOLLY_NONNULL> multiRefFields_;
+
   // True if a null in any of 'distinctFields_' causes 'this' to be
   // null for the row.
   bool propagatesNulls_ = false;
@@ -442,6 +446,8 @@ class ExprSet {
   void clearSharedSubexprs();
 
   std::vector<std::shared_ptr<Expr>> exprs_;
+
+  std::set<FieldReference * FOLLY_NONNULL> multiRefFields_;
 
   // Distinct Exprs reachable from 'exprs_' for which reset() needs to
   // be called at the start of eval().

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -338,7 +338,7 @@ class Expr {
 
   // Fields referenced by multiple inputs, which is subset of distinctFields_.
   // Used to determine pre-loading of lazy vectors at current expr.
-  std::unordered_set<FieldReference * FOLLY_NONNULL> multiRefFields_;
+  std::unordered_set<FieldReference * FOLLY_NONNULL> multiplyReferencedFields_;
 
   // True if a null in any of 'distinctFields_' causes 'this' to be
   // null for the row.
@@ -448,7 +448,7 @@ class ExprSet {
   std::vector<std::shared_ptr<Expr>> exprs_;
 
   // Fields referenced by multiple expressions in ExprSet.
-  std::unordered_set<FieldReference * FOLLY_NONNULL> multiRefFields_;
+  std::unordered_set<FieldReference * FOLLY_NONNULL> multiplyReferencedFields_;
 
   // Distinct Exprs reachable from 'exprs_' for which reset() needs to
   // be called at the start of eval().

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -337,8 +337,8 @@ class Expr {
   std::vector<FieldReference * FOLLY_NONNULL> distinctFields_;
 
   // Fields referenced by multiple inputs, which is subset of distinctFields_.
-  // used to determine pre-loading of lazy vectors at current expr
-  std::set<FieldReference * FOLLY_NONNULL> multiRefFields_;
+  // Used to determine pre-loading of lazy vectors at current expr.
+  std::unordered_set<FieldReference * FOLLY_NONNULL> multiRefFields_;
 
   // True if a null in any of 'distinctFields_' causes 'this' to be
   // null for the row.
@@ -447,7 +447,8 @@ class ExprSet {
 
   std::vector<std::shared_ptr<Expr>> exprs_;
 
-  std::set<FieldReference * FOLLY_NONNULL> multiRefFields_;
+  // Fields referenced by multiple expressions in ExprSet.
+  std::unordered_set<FieldReference * FOLLY_NONNULL> multiRefFields_;
 
   // Distinct Exprs reachable from 'exprs_' for which reset() needs to
   // be called at the start of eval().

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -970,8 +970,8 @@ TEST_F(ExprTest, lazyVectorAccessTwiceWithDifferentRows) {
 TEST_F(ExprTest, lazyVectorAccessTwiceInDifferentExpressions) {
   const vector_size_t size = 1'000;
 
-  // Fields referenced by multiple expressions.
-  // load lazy vector immediately in ExprSet::eval().
+  // Fields referenced by multiple expressions will load lazy vector
+  // immediately in ExprSet::eval().
   auto isNullAtColA = [](auto row) { return row % 2 == 0; };
   auto isNullAtColC = [](auto row) { return row % 4 == 0; };
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -972,8 +972,8 @@ TEST_F(ExprTest, lazyVectorAccessTwiceInDifferentExpressions) {
 
   // Fields referenced by multiple expressions will load lazy vector
   // immediately in ExprSet::eval().
-  auto isNullAtColA = [](auto row) { return row % 2 == 0; };
-  auto isNullAtColC = [](auto row) { return row % 4 == 0; };
+  auto isNullAtColA = [](auto row) { return row % 4 == 0; };
+  auto isNullAtColC = [](auto row) { return row % 2 == 0; };
 
   auto a = makeLazyFlatVector<int64_t>(
       size,
@@ -999,11 +999,11 @@ TEST_F(ExprTest, lazyVectorAccessTwiceInDifferentExpressions) {
       makeRowVector({a, b, c}));
 
   auto expected = makeFlatVector<int64_t>(
-      size, [](auto row) { return row % 2 == 0 ? row * 2 : row; });
+      size, [](auto row) { return row % 4 == 0 ? row * 2 : row; });
   assertEqualVectors(expected, result[0]);
 
   expected = makeFlatVector<int64_t>(
-      size, [](auto row) { return row % 4 == 0 ? row * 2 : row; });
+      size, [](auto row) { return row % 2 == 0 ? row * 2 : row; });
   assertEqualVectors(expected, result[1]);
 }
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -942,12 +942,11 @@ TEST_F(ExprTest, selectiveLazyLoadingOr) {
 TEST_F(ExprTest, lazyVectorAccessTwiceWithDifferentRows) {
   const vector_size_t size = 4;
 
-  // [1, 1, 1, null]
-  auto inputC0 = makeNullableFlatVector<int64_t>({1, 1, 1, std::nullopt});
+  auto c0 = makeNullableFlatVector<int64_t>({1, 1, 1, std::nullopt});
   // [0, 1, 2, 3] if fully loaded
   std::vector<vector_size_t> loadedRows;
   auto valueAt = [](auto row) { return row; };
-  VectorPtr inputC1 = std::make_shared<LazyVector>(
+  VectorPtr c1 = std::make_shared<LazyVector>(
       pool_.get(),
       BIGINT(),
       size,
@@ -958,17 +957,12 @@ TEST_F(ExprTest, lazyVectorAccessTwiceWithDifferentRows) {
         return makeFlatVector<int64_t>(rows.back() + 1, valueAt);
       }));
 
-  // isFinalSelection_ == true
   auto result = evaluate(
-      "row_constructor(c0 + c1, if (c1 >= 0, c1, 0))",
-      makeRowVector({inputC0, inputC1}));
+      "row_constructor(c0 + c1, if (c1 >= 0, c1, 0))", makeRowVector({c0, c1}));
 
-  // [1, 2, 3, null]
-  auto outputCol0 = makeNullableFlatVector<int64_t>({1, 2, 3, std::nullopt});
-  // [0, 1, 2, 3]
-  auto outputCol1 = makeNullableFlatVector<int64_t>({0, 1, 2, 3});
-  // [(1, 0), (2, 1), (3, 2), (null, 3)]
-  auto expected = ExprTest::makeRowVector({outputCol0, outputCol1});
+  auto expected = makeRowVector(
+      {makeNullableFlatVector<int64_t>({1, 2, 3, std::nullopt}),
+       makeNullableFlatVector<int64_t>({0, 1, 2, 3})});
 
   assertEqualVectors(expected, result);
 }


### PR DESCRIPTION
Multiply-referenced LazyVector may load for different sets of rows due to
conditional expression with short circuit semantics.  e.g.` f(a) AND g(b), h(b)`. 
If b is a LazyVector and `f(a) AND g(b)` expression is evaluated first,
it will load b only for rows where `f(a)` is true. However, `h(b)` projection
needs all rows for "b".  Previous solution is to set final selection to false
in `FilterProject::project` method. LazyVector always loads for all rows with
final selection flag is false.   

However, the problem also occurs within a single expression that contains
multiple expressions under a non-null-propagating expression. e.g.
`array_constructor(c0 + c1, if(c1 >= 0, c1, 0)) `. array_constuctor is the
non-null-propagating expression with two sub-expressions: c0 + c1 and if
(c1 >= 0, c1, 0). First sub-expression is evaluated for a subset of rows when
c0 is not null, but second sub-expression needs to be evaluated for all rows. 

Current fix: 1) In Expr::computeMetadata(), identify fields multiply referenced
by input expressions. Load multiply referenced fields at the start of
evaluation in Expr::eval(). 2) Similar to (1), identify multiply referenced
fields references by expressions in ExprSet. Load multiply referenced fields in
ExprSet::eval(). 3) Remove the existing workaround, setting isFinalSelection to
false, from FilterProject::project().

