### PR TITLE
Add SpillOperatorGroup to coordinate spill one a group of operators

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -29,8 +29,6 @@ add_library(
   HashBuild.cpp
   HashPartitionFunction.cpp
   HashProbe.cpp
-  Spill.cpp
-  Spiller.cpp
   HashTable.cpp
   JoinBridge.cpp
   Limit.cpp
@@ -46,6 +44,8 @@ add_library(
   PartitionedOutputBufferManager.cpp
   PlanNodeStats.cpp
   RowContainer.cpp
+  Spill.cpp
+  SpillOperatorGroup.cpp
   Spiller.cpp
   StreamingAggregation.cpp
   TableScan.cpp

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -109,6 +109,17 @@ Operator::Operator(
   }
 }
 
+Operator::Operator(
+    int32_t operatorId,
+    int32_t pipelineId,
+    std::string planNodeId,
+    std::string operatorType)
+    : stats_(
+          operatorId,
+          pipelineId,
+          std::move(planNodeId),
+          std::move(operatorType)) {}
+
 std::vector<std::unique_ptr<Operator::PlanNodeTranslator>>&
 Operator::translators() {
   static std::vector<std::unique_ptr<PlanNodeTranslator>> translators;

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -253,6 +253,13 @@ class Operator {
       std::string planNodeId,
       std::string operatorType);
 
+  /// This is only used by test to create mock operator.
+  Operator(
+      int32_t operatorId,
+      int32_t pipelineId,
+      std::string planNodeId,
+      std::string operatorType);
+
   virtual ~Operator() = default;
 
   // Returns true if 'this' can accept input. Not used if operator is a source

--- a/velox/exec/SpillOperatorGroup.cpp
+++ b/velox/exec/SpillOperatorGroup.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/SpillOperatorGroup.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+SpillOperatorGroup::State SpillOperatorGroup::state() {
+  std::lock_guard<std::mutex> l(mutex_);
+  return state_;
+}
+
+std::string SpillOperatorGroup::stateName(State state) {
+  switch (state) {
+    case State::INIT:
+      return "INIT";
+    case State::RUNNING:
+      return "RUNNING";
+    case State::STOPPED:
+      return "STOPPED";
+    default:
+      return fmt::format("UNKNOWN STATE: {}", static_cast<int>(state));
+  }
+}
+
+void SpillOperatorGroup::addOperator(
+    Operator& op,
+    SpillOperatorGroup::SpillRunner runner) {
+  VELOX_CHECK_NOT_NULL(runner);
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_EQ(
+      state_,
+      State::INIT,
+      "Can only add an operator before group starts: {}",
+      toStringLocked());
+  operators_.push_back(&op);
+  // Set 'spillRunner_' to the callback provided by the first added operator.
+  if (spillRunner_ == nullptr) {
+    spillRunner_ = std::move(runner);
+  }
+}
+
+void SpillOperatorGroup::operatorStopped(const Operator& op) {
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK_EQ(
+        state_,
+        State::RUNNING,
+        "Can only stop an operator when group is running: {}",
+        toStringLocked());
+    VELOX_CHECK(!stoppedOperators_.contains(&op));
+    stoppedOperators_.insert(&op);
+    VELOX_CHECK_LE(stoppedOperators_.size(), operators_.size());
+    if (stoppedOperators_.size() == operators_.size()) {
+      state_ = State::STOPPED;
+      checkStoppedStateLocked();
+      return;
+    }
+    if (!needSpill_) {
+      return;
+    }
+    // NOTE: the stopping operator doesn't need to wait for spill to run.
+    if (numWaitingOperators_ < numActiveOperatorsLocked()) {
+      return;
+    }
+    promises = std::move(promises_);
+  }
+  runSpill(promises);
+}
+
+void SpillOperatorGroup::start() {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_EQ(
+      state_, State::INIT, "Can only start a group once: {}", toStringLocked());
+  state_ = State::RUNNING;
+}
+
+void SpillOperatorGroup::restart() {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_EQ(
+      state_,
+      State::STOPPED,
+      "Can only restart a stopped group: {}",
+      toStringLocked());
+  checkStoppedStateLocked();
+  stoppedOperators_.clear();
+  state_ = State::RUNNING;
+}
+
+bool SpillOperatorGroup::requestSpill(Operator& op, ContinueFuture& future) {
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK_EQ(
+        state_,
+        State::RUNNING,
+        "Can only request spill when group is running: {}",
+        toStringLocked());
+    VELOX_CHECK_LT(numWaitingOperators_, numActiveOperatorsLocked());
+    VELOX_CHECK_LT(stoppedOperators_.size(), operators_.size());
+    needSpill_ = true;
+    if (waitSpillLocked(op, promises, future)) {
+      VELOX_CHECK(future.valid());
+      return true;
+    }
+  }
+  runSpill(promises);
+  return false;
+}
+
+bool SpillOperatorGroup::waitSpill(Operator& op, ContinueFuture& future) {
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK_EQ(
+        state_,
+        State::RUNNING,
+        "Can only wait spill when group is running: {}",
+        toStringLocked());
+    VELOX_CHECK_LT(stoppedOperators_.size(), operators_.size());
+    if (!needSpill_) {
+      VELOX_CHECK_EQ(numWaitingOperators_, 0);
+      return false;
+    }
+    if (waitSpillLocked(op, promises, future)) {
+      return true;
+    }
+  }
+  runSpill(promises);
+  return false;
+}
+
+bool SpillOperatorGroup::waitSpillLocked(
+    Operator& op,
+    std::vector<ContinuePromise>& promises,
+    ContinueFuture& future) {
+  VELOX_CHECK_LT(numWaitingOperators_, numActiveOperatorsLocked());
+  if (++numWaitingOperators_ == numActiveOperatorsLocked()) {
+    promises = std::move(promises_);
+    return false;
+  }
+  promises_.emplace_back(ContinuePromise(fmt::format(
+      "SpillOperatorGroup::waitSpillLocked {}/{}/{}/{}",
+      taskId_,
+      planNodeId_,
+      splitGroupId_,
+      op.stats().operatorId)));
+  future = promises_.back().getSemiFuture();
+  return true;
+}
+
+void SpillOperatorGroup::runSpill(std::vector<ContinuePromise>& promises) {
+  VELOX_CHECK(needSpill_);
+  spillRunner_(operators_);
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK_EQ(
+        state_,
+        State::RUNNING,
+        "Can only run spill when group is running: {}",
+        toStringLocked());
+    needSpill_ = false;
+    numWaitingOperators_ = 0;
+  }
+  for (auto& promise : promises) {
+    promise.setValue();
+  }
+}
+
+void SpillOperatorGroup::checkStoppedStateLocked() const {
+  CHECK_EQ(state_, State::STOPPED);
+  VELOX_CHECK_EQ(stoppedOperators_.size(), operators_.size());
+  // Reset this coordinator state if all the participated operators have
+  // finished memory intensive operations and won't trigger any more spill.
+  VELOX_CHECK(!needSpill_);
+  VELOX_CHECK_EQ(numWaitingOperators_, 0);
+  VELOX_CHECK(promises_.empty());
+}
+
+std::string SpillOperatorGroup::toStringLocked() const {
+  return fmt::format(
+      "[STATE:{}, NUM_OPS:{}, NUM_WAITING_OPS:{}, NUM_STOPPED_OPS:{}]",
+      stateName(state_),
+      operators_.size(),
+      numWaitingOperators_,
+      stoppedOperators_.size());
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/SpillOperatorGroup.h
+++ b/velox/exec/SpillOperatorGroup.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/container/F14Set.h>
+#include <stdint.h>
+#include <functional>
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::exec {
+
+class Operator;
+
+/// Used to coordinate the disk spill operation among multiple operator
+/// instances of the same plan node within a task (split group). Take hash
+/// build for example, when any one of the build operator needs to spill, then
+/// all its peer operators' drivers will stop execution for spill, and one of
+/// them will be selected (the last one reaches to group spill barrier) as the
+/// coordinator to run spill on all the operators, and then resume all the
+/// driver executions after that.
+///
+/// NOTE: as for now, only hash build operators needs to group spill
+/// coordination.
+class SpillOperatorGroup {
+ public:
+  /// Define the internal execution state of a spill group. The valid state
+  /// transition is depicted as below:
+
+  ///       INIT --->  RUNNING  --->  STOPPED
+  ///                     ^             |
+  ///                     |             v
+  ///                     +-------------+
+  ///
+  enum class State {
+    INIT = 0,
+    RUNNING = 1,
+    STOPPED = 2,
+  };
+  static std::string stateName(State state);
+
+  SpillOperatorGroup(
+      const std::string taskId,
+      const uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId)
+      : taskId_(taskId),
+        splitGroupId_(splitGroupId),
+        planNodeId_(planNodeId),
+        state_(State::INIT){};
+
+  State state();
+
+  using SpillRunner = std::function<void(const std::vector<Operator*>& ops)>;
+
+  /// Invoked by an operator on construction to add to this spill group.
+  /// 'spillRunner' is the operator specific callback to run spill on the
+  /// group of operators together.
+  ///
+  /// NOTE: the group of operators are instantiated from the same plan node in a
+  /// task pipeline, such as all the build operators for a hash join node.
+  void addOperator(Operator& op, SpillRunner spillRunner);
+
+  /// Invoked to indicate a driver won't trigger any more spill request and
+  /// it will also not involve in the future group spill operation. The function
+  /// will put this 'op' into 'stoppedOperators_'. This function will also help
+  /// to check if the group spill is ready to run if there is a pending one.
+  void operatorStopped(const Operator& op);
+
+  /// Invoked by the task framework to start this spilling group, and the
+  /// operator needs to add to a group before it is started.
+  void start();
+
+  /// Invoked to restart this spill group to support recursive spilling. For
+  /// example, the hassh build operator might need to trigger recursive spilling
+  /// while building the hash table from a previously spilled partition.
+  ///
+  /// NOTE: a spill group will be stopped after all the operators call
+  /// 'operatorStopped()' to indicates that there will be no more spill request
+  /// from that operator. For example, a hash build operator will call
+  /// 'operatorStopped()' after finishing build the hash table as there will be
+  /// no more memory consumption after that.
+  void restart();
+
+  /// Indicates if this group needs spill or not.
+  bool needSpill() const {
+    return needSpill_;
+  }
+
+  /// Invoked to request a new spill operation on the group. The function
+  /// returns true if it needs to wait for spill to run, otherwise the spill has
+  /// been inline executed and returns false.
+  bool requestSpill(Operator& op, ContinueFuture& future);
+
+  /// Invoked to check if 'op' needs to wait for any pending group spill to run.
+  /// The function returns true if it needs to wait, otherwise it returns false.
+  /// The latter case is either because there is no pending spill or 'op' is the
+  /// last one that reaches to the spill barrier and has inline executed the
+  /// spill for the group.
+  bool waitSpill(Operator& op, ContinueFuture& future);
+
+ private:
+  void checkStoppedStateLocked() const;
+
+  // Return the number of non-stopped operators which includes both running and
+  // waiting ones.
+  uint32_t numActiveOperatorsLocked() const {
+    return operators_.size() - stoppedOperators_.size();
+  }
+
+  // Invoked to run spill runner callback on all the spill operators, and after
+  // that the function will also resume the waiting operators' executions by
+  // fulfilling 'promises'.
+  void runSpill(std::vector<ContinuePromise>& promises);
+
+  bool waitSpillLocked(
+      Operator& op,
+      std::vector<ContinuePromise>& promises,
+      ContinueFuture& future);
+
+  std::string toStringLocked() const;
+
+  const std::string taskId_;
+  const uint32_t splitGroupId_;
+  const core::PlanNodeId& planNodeId_;
+
+  std::mutex mutex_;
+  State state_;
+
+  // The participating spill operators which won't change after starts the
+  // group.
+  std::vector<Operator*> operators_;
+  // Invoked to run spill on all 'operators_' no matter it has stopped or not.
+  SpillRunner spillRunner_;
+
+  // Indicates if the group needs to spill or not.
+  std::atomic<bool> needSpill_{false};
+
+  // Counts the number of operators to wait for the pending spill to run. Once
+  // the counter matches the number of non-stopped operators, then the last
+  // wait operator will act as the coordinator to run the spill for all the
+  // operators.
+  int32_t numWaitingOperators_{0};
+
+  // The promises created for each waiting spill operator except the last one.
+  std::vector<ContinuePromise> promises_;
+
+  // The set of stopped operators which will not trigger any more spill
+  // operation such as hash build operators which have finished the table build.
+  //
+  // NOTE: once all the operators in the group have been stopped, then the group
+  // will transit to STOPPED state until it has been restarted. The set will be
+  // also been cleared by the group restart. A spill group will be restarted to
+  // support recursive spill operation as required by hash join build.
+  folly::F14FastSet<const Operator*> stoppedOperators_;
+};
+
+inline std::ostream& operator<<(
+    std::ostream& os,
+    SpillOperatorGroup::State state) {
+  os << SpillOperatorGroup::stateName(state);
+  return os;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(
   RowContainerTest.cpp
   MemoryCapExceededTest.cpp
   SpillTest.cpp
+  SpillOperatorGroupTest.cpp
   SpillerTest.cpp
   StreamingAggregationTest.cpp
   TableScanTest.cpp

--- a/velox/exec/tests/SpillOperatorGroupTest.cpp
+++ b/velox/exec/tests/SpillOperatorGroupTest.cpp
@@ -1,0 +1,456 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/SpillOperatorGroup.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/Driver.h"
+#include "velox/exec/Operator.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+class SpillOperatorGroupTest : public testing::Test {
+ protected:
+  SpillOperatorGroupTest(int32_t numOperators = 1)
+      : numOperators_(numOperators) {}
+
+  void SetUp() override {
+    rng_.seed(1245);
+    taskId_ = "SpillTask";
+    operatorId_ = 0;
+    splitGroupId_ = 0;
+    planNodeId_ = "SpillNode";
+  }
+
+  void TearDown() override {}
+
+  class MockOperator : public Operator {
+   public:
+    explicit MockOperator(
+        int32_t operatorId,
+        SpillOperatorGroup* FOLLY_NONNULL spillGroup)
+        : Operator(operatorId, 0, "SpillNode", "SpillOperator"),
+          spillGroup_(spillGroup),
+          spillFuture_(ContinueFuture::makeEmpty()) {
+      spillGroup_->addOperator(*this, [&](const std::vector<Operator*>& ops) {
+        std::unordered_set<uint32_t> opIds;
+        for (const auto& op : ops) {
+          opIds.insert(op->stats().operatorId);
+        }
+        ASSERT_EQ(opIds.size(), ops.size());
+        for (auto& op : ops) {
+          MockOperator* spillOp = dynamic_cast<MockOperator*>(op);
+          ++spillOp->numSpillRuns_;
+        }
+      });
+    }
+
+    bool needsInput() const override {
+      return false;
+    }
+
+    void addInput(RowVectorPtr input) override {}
+
+    void noMoreInput() override {
+      Operator::noMoreInput();
+    }
+
+    RowVectorPtr getOutput() override {
+      return nullptr;
+    }
+
+    BlockingReason isBlocked(ContinueFuture* future) override {
+      return BlockingReason::kNotBlocked;
+    }
+
+    bool isFinished() override {
+      return false;
+    }
+
+    /// Methods used for spill test.
+    bool requestSpill() {
+      return spillGroup_->requestSpill(*this, spillFuture_);
+    }
+
+    bool waitSpill() {
+      return spillGroup_->waitSpill(*this, spillFuture_);
+    }
+
+    void stopSpill() {
+      spillStopped_ = true;
+      spillGroup_->operatorStopped(*this);
+    }
+
+    bool spillStopped() const {
+      return spillStopped_;
+    }
+
+    void restartSpill() {
+      spillStopped_ = false;
+    }
+
+    int32_t numSpillRuns() const {
+      return numSpillRuns_;
+    }
+
+    ContinueFuture& spillFuture() {
+      return spillFuture_;
+    }
+
+   private:
+    SpillOperatorGroup* const spillGroup_; // Not owned.
+
+    bool spillStopped_{false};
+    ContinueFuture spillFuture_;
+    int32_t numSpillRuns_{0};
+  };
+
+  std::unique_ptr<MockOperator> newSpillOperator(
+      SpillOperatorGroup* FOLLY_NONNULL spillGroup) {
+    return std::make_unique<MockOperator>(operatorId_++, spillGroup);
+  }
+
+  void setupSpillOperators() {
+    std::vector<std::unique_ptr<SpillOperatorGroupTest::MockOperator>> ops;
+    ops.reserve(numOperators_);
+    for (int32_t i = 0; i < numOperators_; ++i) {
+      ops.push_back(newSpillOperator(spillGroup_.get()));
+    }
+    spillOps_ = std::move(ops);
+    ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::INIT);
+  }
+
+  void setupSpillGroup() {
+    spillGroup_ = std::make_unique<SpillOperatorGroup>(
+        taskId_, splitGroupId_++, planNodeId_);
+    ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::INIT);
+    numSpillRuns_ = 0;
+
+    setupSpillOperators();
+  }
+
+  void runSpillOperators(
+      bool triggerSpill = true,
+      bool operatorStopped = false) {
+    SCOPED_TRACE(fmt::format(
+        "triggerSpill:{}, operatorStopped:{}", triggerSpill, operatorStopped));
+    ASSERT_TRUE(hasRunningOperators());
+
+    auto numRunningOpsLeft = numRunningOperators();
+    bool spillTriggered = false;
+    for (int32_t i = 0; i < spillOps_.size(); ++i) {
+      auto* op = spillOps_[i].get();
+      if (op->spillStopped()) {
+        continue;
+      }
+
+      --numRunningOpsLeft;
+      bool wait;
+      if (operatorStopped && oneIn(2)) {
+        op->stopSpill();
+        continue;
+      }
+      if (triggerSpill && (!spillTriggered || oneIn(3))) {
+        spillTriggered = true;
+        wait = op->requestSpill();
+      } else {
+        wait = op->waitSpill();
+      }
+      if (spillTriggered) {
+        if (numRunningOpsLeft != 0) {
+          ASSERT_TRUE(spillGroup_->needSpill());
+          ASSERT_TRUE(wait);
+          ASSERT_TRUE(op->spillFuture().valid());
+        } else {
+          ASSERT_FALSE(spillGroup_->needSpill());
+          ASSERT_FALSE(wait);
+          ASSERT_FALSE(op->spillFuture().valid());
+        }
+      } else {
+        ASSERT_FALSE(spillGroup_->needSpill());
+        ASSERT_FALSE(wait);
+        ASSERT_FALSE(op->spillFuture().valid());
+      }
+    }
+
+    ASSERT_FALSE(spillGroup_->needSpill());
+    if (hasRunningOperators()) {
+      ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::RUNNING);
+    } else {
+      ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::STOPPED);
+    }
+    if (spillTriggered) {
+      ++numSpillRuns_;
+      waitSpillOperators();
+    }
+    checkSpillOperators();
+  }
+
+  void checkSpillOperators() {
+    for (auto& op : spillOps_) {
+      ASSERT_EQ(op->numSpillRuns(), numSpillRuns_);
+    }
+  }
+
+  void waitSpillOperators() {
+    int32_t numNonWaitOperators = 0;
+    int32_t numStoppedOperators = 0;
+    for (auto& op : spillOps_) {
+      if (op->spillStopped()) {
+        ++numStoppedOperators;
+        ASSERT_FALSE(op->spillFuture().valid());
+        continue;
+      }
+      auto future = std::move(op->spillFuture());
+      if (future.valid()) {
+        future.wait();
+      } else {
+        ++numNonWaitOperators;
+      }
+    }
+    // NOTE: at most one spill operator doesn't need to wait.
+    if (numNonWaitOperators == 0) {
+      ASSERT_GT(numStoppedOperators, 0);
+    } else {
+      ASSERT_EQ(numNonWaitOperators, 1);
+    }
+  }
+
+  bool hasRunningOperators() const {
+    return numRunningOperators() != 0;
+  }
+
+  int32_t numRunningOperators() const {
+    int32_t numRunningOps = 0;
+    for (auto& op : spillOps_) {
+      if (!op->spillStopped()) {
+        ++numRunningOps;
+      }
+    }
+    return numRunningOps;
+  }
+
+  void startSpillGroup() {
+    if (spillGroup_->state() != SpillOperatorGroup::State::STOPPED) {
+      spillGroup_->start();
+      return;
+    }
+    for (auto& op : spillOps_) {
+      ASSERT_TRUE(op->spillStopped());
+      op->restartSpill();
+    }
+    spillGroup_->restart();
+    ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::RUNNING);
+  }
+
+  uint32_t randInt(uint32_t n) {
+    return folly::Random().rand64(rng_) % (n + 1);
+  }
+
+  bool oneIn(uint32_t n) {
+    return folly::Random().oneIn(n, rng_);
+  }
+
+  const int32_t numOperators_;
+
+  folly::Random::DefaultGenerator rng_;
+
+  uint32_t operatorId_;
+  std::string taskId_;
+  uint32_t splitGroupId_;
+  core::PlanNodeId planNodeId_;
+  int32_t numSpillRuns_{0};
+  std::unique_ptr<SpillOperatorGroup> spillGroup_;
+  std::vector<std::unique_ptr<MockOperator>> spillOps_;
+};
+
+struct TestParam {
+  int32_t numOperators;
+};
+
+class MultiSpillOperatorGroupTest
+    : public SpillOperatorGroupTest,
+      public testing::WithParamInterface<TestParam> {
+ public:
+  MultiSpillOperatorGroupTest()
+      : SpillOperatorGroupTest(GetParam().numOperators) {}
+
+  static std::vector<TestParam> getTestParams() {
+    return std::vector<TestParam>({TestParam{1}, TestParam{4}, TestParam{32}});
+    // return std::vector<TestParam>({TestParam{1}, TestParam{4},
+    // TestParam{32}});
+  }
+};
+
+TEST_P(MultiSpillOperatorGroupTest, spillRun) {
+  setupSpillGroup();
+
+  int32_t numRestarts = 0;
+  while (numRestarts++ < 3) {
+    SCOPED_TRACE(fmt::format("numRestarts: {}", numRestarts - 1));
+    startSpillGroup();
+
+    // The initial spill runs with all the operators involved.
+    for (int32_t run = 0; run < 4; ++run) {
+      ASSERT_FALSE(spillGroup_->needSpill());
+
+      // No spill triggered.
+      runSpillOperators(false);
+
+      // Spill triggered.
+      runSpillOperators(true);
+    }
+
+    // Continue run spills until all the operators have stopped.
+    while (hasRunningOperators()) {
+      runSpillOperators(true, true);
+    }
+  }
+}
+
+TEST_P(MultiSpillOperatorGroupTest, noSpillRun) {
+  setupSpillGroup();
+  startSpillGroup();
+  // Run test without triggering spill.
+  while (hasRunningOperators()) {
+    runSpillOperators(false, true);
+  }
+}
+
+TEST_P(MultiSpillOperatorGroupTest, error) {
+  setupSpillGroup();
+  startSpillGroup();
+
+  // Can't start spill group twice.
+  ASSERT_ANY_THROW(startSpillGroup());
+
+  // Can't add spill operator after the group started.
+  ASSERT_ANY_THROW(setupSpillOperators());
+
+  // Can't restart if the group is not stopped.
+  ASSERT_ANY_THROW(spillGroup_->restart());
+
+  for (auto& op : spillOps_) {
+    op->stopSpill();
+    // Can only stop an operator once.
+    ASSERT_ANY_THROW(op->stopSpill());
+  }
+
+  // Can't add op after the group has stopped.
+  ASSERT_ANY_THROW(newSpillOperator(spillGroup_.get()));
+
+  // Can't request spill or wait after the group has stopped.
+  for (auto& op : spillOps_) {
+    ASSERT_ANY_THROW(op->requestSpill());
+  }
+  for (auto& op : spillOps_) {
+    ASSERT_ANY_THROW(op->waitSpill());
+  }
+
+  // Restart the spill group and everything works fine.
+  startSpillGroup();
+  for (auto& op : spillOps_) {
+    op->waitSpill();
+  }
+  for (auto& op : spillOps_) {
+    op->requestSpill();
+  }
+}
+
+TEST_P(MultiSpillOperatorGroupTest, multiThreading) {
+  setupSpillGroup();
+  startSpillGroup();
+
+  std::vector<std::thread> opThreads;
+  opThreads.reserve(numOperators_);
+
+  struct BarrierState {
+    int32_t numRequested{0};
+    std::vector<ContinuePromise> promises;
+  };
+  const int32_t numIterations = 100;
+  std::mutex barrierLock;
+  std::vector<BarrierState> barriers(numIterations);
+
+  // Start one thread per each spill operator and then stop and sync at the end
+  // of each test iteration by BarrierState. Then restart the spill group to run
+  // the next test iteration.
+  for (size_t i = 0; i < numOperators_; ++i) {
+    auto* op = spillOps_[i].get();
+    opThreads.emplace_back([&, op]() {
+      for (int32_t iter = 0; iter < numIterations; ++iter) {
+        const auto maxNumActions = 1 + randInt(6);
+        int32_t action = 0;
+        while (++action < maxNumActions) {
+          if (oneIn(6)) {
+            op->stopSpill();
+            break;
+          }
+          bool wait;
+          if (oneIn(3)) {
+            wait = op->requestSpill();
+          } else {
+            wait = op->waitSpill();
+          }
+          auto future = std::move(op->spillFuture());
+          if (wait) {
+            ASSERT_TRUE(future.valid());
+            future.wait();
+          } else {
+            ASSERT_FALSE(future.valid());
+          }
+        }
+        if (!op->spillStopped()) {
+          op->stopSpill();
+        }
+
+        // Wait for peers.
+        std::vector<ContinuePromise> promises;
+        ContinueFuture future(ContinueFuture::makeEmpty());
+        {
+          std::lock_guard<std::mutex> l(barrierLock);
+          auto& barrier = barriers[iter];
+          if (++barrier.numRequested < numOperators_) {
+            barrier.promises.emplace_back(
+                "SpillOperatorGroupTest::multiThreading");
+            future = barrier.promises.back().getSemiFuture();
+          } else {
+            promises = std::move(barrier.promises);
+          }
+        }
+        if (future.valid()) {
+          future.wait();
+        } else {
+          startSpillGroup();
+
+          for (auto& promise : promises) {
+            promise.setValue();
+          }
+        }
+      }
+    });
+  }
+
+  for (auto& th : opThreads) {
+    th.join();
+  }
+  numSpillRuns_ = spillOps_[0]->numSpillRuns();
+  checkSpillOperators();
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    SpillOperatorGroupTest,
+    MultiSpillOperatorGroupTest,
+    testing::ValuesIn(MultiSpillOperatorGroupTest::getTestParams()));


### PR DESCRIPTION
SpillOperatorGroup is used to coordinate spill on a group of operators
of the same query node. It basically works as follows:

- (1) the task framework will create a spill group for each query node
   which needs group spill such has hash build. This happens when.
   we create split group state before the actual driver instance creation;
- (2) each operator instance created for the query node will join the
   spill group by passing its operator pointer;
- (3) the task framework will start the spill group after all the operator
   instances has joined the group. This happens after all the drivers have
   been created. No operator can't join this group afterwards;
- (4) during the query execution, if any node detects need spill, it will call
   requestSpill() method of group object to initiate a group spill request;
   Then all the operators needs to stop driver execution to run  the group
   spill. The operator will check the pending spill using needSpill() and
   waitSpill() whenever it starts a batch input processing;
- (5) when all the operator drivers have stopped execution, the last one that
   reaches to the group spill barrier will act as the coordinator to run operator
   specific spill callback on all the operators in the group;
- (6) when an operator reaches to a point that won't trigger spill anymore like
   hash build finishes building table, it will call stopOperator() to indicate it
   is more involved in the followup group spill operations, and it won't be counted
   in the spill group barrier;
- (7) when all the operators have called stopOperator(), the spill group will
   transition to stopped state which won't accept any more spill request;
- (8) a stopped group can be restart to support recursive spilling. For example,
   a hash build operator might trigger spilling while building the table from a
   previously spilled partition.