### PR TITLE
Make vector serde registration flexible in OperatorTestBase

### DIFF
--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -269,6 +269,9 @@ class AggregationTest : public OperatorTestBase {
   void SetUp() override {
     filesystems::registerLocalFileSystem();
     mappedMemory_ = memory::MappedMemory::getInstance();
+    if (!isRegisteredVectorSerde()) {
+      this->registerVectorSerde();
+    }
   }
 
   std::vector<RowVectorPtr>

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -49,6 +49,9 @@ class OrderByTest : public OperatorTestBase {
  protected:
   void SetUp() override {
     filesystems::registerLocalFileSystem();
+    if (!isRegisteredVectorSerde()) {
+      this->registerVectorSerde();
+    }
   }
 
   void testSingleKey(

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -34,10 +34,11 @@ std::shared_ptr<cache::AsyncDataCache> OperatorTestBase::asyncDataCache_;
 OperatorTestBase::OperatorTestBase() {
   using memory::MappedMemory;
   facebook::velox::exec::ExchangeSource::registerFactory();
-  if (!isRegisteredVectorSerde()) {
-    velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
-  }
   parse::registerTypeResolver();
+}
+
+void OperatorTestBase::registerVectorSerde() {
+  velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
 }
 
 OperatorTestBase::~OperatorTestBase() {
@@ -53,6 +54,9 @@ void OperatorTestBase::SetUp() {
         memory::MappedMemory::createDefaultInstance(), 4UL << 30);
   }
   memory::MappedMemory::setDefaultInstance(asyncDataCache_.get());
+  if (!isRegisteredVectorSerde()) {
+    this->registerVectorSerde();
+  }
 }
 
 void OperatorTestBase::SetUpTestCase() {

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -35,6 +35,10 @@ class OperatorTestBase : public testing::Test,
 
   void SetUp() override;
 
+  /// Allow base classes to register custom vector serde.
+  /// By default, registers Presto-compatible serde.
+  virtual void registerVectorSerde();
+
   static void SetUpTestCase();
 
   void createDuckDbTable(const std::vector<RowVectorPtr>& data) {


### PR DESCRIPTION
This allows tests derived from it to have the flexibility to register their own vector serde.