### PR TITLE
Allow mock memory updates

### DIFF
--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -143,7 +143,12 @@ SimpleMemoryTracker::SimpleMemoryTracker(const MemoryUsageConfig& config)
     : MemoryUsageTracker{nullptr, UsageType::kUserMem, config},
       userMemoryQuota_{config.maxUserMemory.value_or(kMaxMemory)} {}
 
-void SimpleMemoryTracker::update(int64_t size) {
+// Simple memory tracker wants to be accurate for its memory accounting, so
+// it ignores mock updates.
+void SimpleMemoryTracker::update(int64_t size, bool mock) {
+  if (mock) {
+    return;
+  }
   int64_t previousUsage =
       totalUserMemory_.fetch_add(size, std::memory_order_relaxed);
   if (previousUsage + size > userMemoryQuota_) {

--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -185,7 +185,10 @@ class MemoryUsageTracker
   // allocation and negative for free. If there is no reservation or
   // the new allocated amount exceeds the reservation, propagates the
   // change upward.
-  virtual void update(int64_t size) {
+  // Sometimes the memory pool wants to mock an update for quota
+  // accounting purposes and different memory usage trackers can
+  // choose to accommodate this differently.
+  virtual void update(int64_t size, bool /* mock */ = false) {
     if (size > 0) {
       int64_t increment = 0;
       {
@@ -461,7 +464,7 @@ class SimpleMemoryTracker : public MemoryUsageTracker {
   explicit SimpleMemoryTracker(const MemoryUsageConfig& config);
   virtual ~SimpleMemoryTracker() override = default;
 
-  virtual void update(int64_t size) override;
+  virtual void update(int64_t size, bool mock = false) override;
   virtual int64_t getCurrentUserBytes() const override;
 
   static std::shared_ptr<SimpleMemoryTracker> create(


### PR DESCRIPTION
Summary:
We introduced `SimpleMemoryTracker` to accommodate for the trabant memory protection use case where we just rely on a more accurate and simpler accounting for writer coordination.

This diff further splits the behavior of the `SimpleMemoryTracker` and `MemoryUsageTracker` by treating the mock quota shrinks upon shrink reallocation differently, to make `SimpleMemoryTracker` truly accurate.

Reviewed By: nickolay5

Differential Revision: D39422721

