### PR TITLE
Fix data races exposed by table scan test in tsan mode

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -274,7 +274,7 @@ class AsyncDataCacheEntry {
   // Set after first use of a prefetched entry. Cleared by
   // getAndClearFirstUseFlag(). Does not require synchronization since used for
   // statistics only.
-  bool isFirstUse_{false};
+  std::atomic<bool> isFirstUse_{false};
 
   // Group id. Used for deciding if 'this' should be written to SSD.
   uint64_t groupId_{0};
@@ -532,11 +532,15 @@ class CacheShard {
 
  private:
   static constexpr int32_t kNoThreshold = std::numeric_limits<int32_t>::max();
+
   void calibrateThreshold();
+
   void removeEntryLocked(AsyncDataCacheEntry* FOLLY_NONNULL entry);
+
   // Returns an unused entry if found. 'size' is a hint for selecting an entry
   // that already has the right amount of memory associated with it.
   std::unique_ptr<AsyncDataCacheEntry> getFreeEntryWithSize(uint64_t sizeHint);
+
   CachePin initEntry(
       RawFileCacheKey key,
       AsyncDataCacheEntry* FOLLY_NONNULL entry);
@@ -758,10 +762,10 @@ class AsyncDataCache : public memory::MappedMemory {
 
   // Approximate counter of bytes allocated to cover misses. When this
   // exceeds 'nextSsdScoreSize_' we update the SSD admission criteria.
-  uint64_t newBytes_{0};
+  std::atomic<uint64_t> newBytes_{0};
 
   // 'newBytes_' value after which SSD admission should be reconsidered.
-  uint64_t nextSsdScoreSize_{};
+  std::atomic<uint64_t> nextSsdScoreSize_{0};
 
   // Approximate counter tracking new entries that could be saved to SSD.
   uint64_t ssdSaveable_{0};

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -217,7 +217,7 @@ class LocalReadFile final : public ReadFile {
       const;
 
   int32_t fd_;
-  mutable long size_ = -1;
+  long size_;
 };
 
 class LocalWriteFile final : public WriteFile {

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -136,7 +136,7 @@ std::vector<CacheRequest*> makeRequestParts(
 
 int32_t adjustedReadPct(const cache::TrackingData& trackingData) {
   // When called, there will be one more reference that read, since references
-  // are counted before readig.
+  // are counted before reading.
   if (trackingData.numReferences < 2) {
     return 0;
   }
@@ -182,7 +182,7 @@ void CachedBufferedInput::load(const LogType) {
             part->ssdPin = ssdFile->find(part->key);
             if (!part->ssdPin.empty() &&
                 part->ssdPin.run().size() < part->size) {
-              LOG(INFO) << "IOERR: Ignorin SSD  shorter than requested: "
+              LOG(INFO) << "IOERR: Ignoring SSD shorter than requested: "
                         << part->ssdPin.run().size() << " vs " << part->size;
               part->ssdPin.clear();
             }

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -268,6 +268,7 @@ RowVectorPtr PartitionedOutput::getOutput() {
       }
     }
   } while (workLeft);
+
   if (blockedDestination) {
     // If we are going off-thread, we may as well make the output in
     // progress for other destinations available, unless it is too

--- a/velox/exec/PartitionedOutputBufferManager.h
+++ b/velox/exec/PartitionedOutputBufferManager.h
@@ -154,7 +154,7 @@ class PartitionedOutputBuffer {
   /// and enqueue data that has been produced so far (e.g. dataToBroadcast_).
   void addBroadcastOutputBuffersLocked(int numBuffers);
 
-  std::shared_ptr<Task> task_;
+  const std::shared_ptr<Task> task_;
   const bool broadcast_;
   /// Total number of drivers expected to produce results. This number will
   /// decrease in the end of grouped execution, when we understand the real


### PR DESCRIPTION
- Fix the data race in concurrent access to the cache entry in AsyncDataCache
   by initializing the affected field under the cache shard lock. This is not a real
   data race;
- Fix the data race in cache stats updates in AsyncDataCache by using atomic
   variables;
- Fix the data race in local read only file get length which is using a volatile
  variable to store the length and only set it on the first size() access. Fix it by
  always setting it in constructor;
- Fix lock order issue in task and output buffer manager by moving the task lock
  acquisition (check if task is running or not) out of the buffer manager's lock

Passed the table scan test 100 times under tsan mode on Meta internal devserver

