### PR TITLE
Replace move() with std::move()

### DIFF
--- a/velox/core/Context.cpp
+++ b/velox/core/Context.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<const ConfigStack> ConfigStack::stack(
   }
   std::vector<std::shared_ptr<const Config>> configs(configs_);
   configs.push_back(config);
-  return std::make_shared<const ConfigStack>(move(configs));
+  return std::make_shared<const ConfigStack>(std::move(configs));
 }
 
 std::shared_ptr<const ConfigStack> ConfigStack::stack(
@@ -79,9 +79,9 @@ std::shared_ptr<const ConfigStack> ConfigStack::stack(
     throw std::invalid_argument(
         "Null Config or ConfigStack are not supported for stacking");
   }
-  std::vector<std::shared_ptr<const Config>> configs(move(configs_));
+  std::vector<std::shared_ptr<const Config>> configs(std::move(configs_));
   configs.push_back(config);
-  return std::make_shared<const ConfigStack>(move(configs));
+  return std::make_shared<const ConfigStack>(std::move(configs));
 }
 
 std::shared_ptr<const ConfigStack> ConfigStackHelper::stack(
@@ -94,7 +94,7 @@ std::shared_ptr<const ConfigStack> ConfigStackHelper::stack(
     return configStack->stack(config2);
   }
   std::vector<std::shared_ptr<const Config>> configs{config1, config2};
-  return std::make_shared<const ConfigStack>(move(configs));
+  return std::make_shared<const ConfigStack>(std::move(configs));
 }
 
 Context::Context(

--- a/velox/core/Context.h
+++ b/velox/core/Context.h
@@ -88,7 +88,7 @@ class MemConfig : public Config {
   explicit MemConfig() : values_{} {}
 
   explicit MemConfig(std::unordered_map<std::string, std::string>&& values)
-      : values_(move(values)) {}
+      : values_(std::move(values)) {}
 
   folly::Optional<std::string> get(const std::string& key) const override;
 
@@ -113,7 +113,7 @@ class ConfigStack : public Config {
   }
 
   explicit ConfigStack(std::vector<std::shared_ptr<const Config>>&& configs)
-      : configs_(move(configs)) {
+      : configs_(std::move(configs)) {
     for (const auto& config : configs_) {
       VELOX_USER_CHECK_NOT_NULL(config);
     }
@@ -169,7 +169,7 @@ class BaseConfigManager {
   void setConfigOverrides(
       std::unordered_map<std::string, std::string>&& configOverrides) {
     setConfigOverrides(
-        std::make_shared<const MemConfig>(move(configOverrides)));
+        std::make_shared<const MemConfig>(std::move(configOverrides)));
   }
 
   // template<class T> set(shared_ptr<const T>& obj) {}
@@ -285,7 +285,7 @@ class RawConfigUpdate {
   }
 
   const std::shared_ptr<const Config>&& getConfig() && {
-    return move(config_);
+    return std::move(config_);
   }
 
  private:

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -222,7 +222,9 @@ class FieldAccessTypedExpr : public ITypedExpr {
  public:
   /// Used as a leaf in an expression tree specifying input column by name.
   FieldAccessTypedExpr(TypePtr type, std::string name)
-      : ITypedExpr{std::move(type)}, name_(std::move(name)), isInputColumn_(true) {}
+      : ITypedExpr{std::move(type)},
+        name_(std::move(name)),
+        isInputColumn_(true) {}
 
   /// Used as a dereference expression which selects a subfield in a struct by
   /// name.

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -222,12 +222,12 @@ class FieldAccessTypedExpr : public ITypedExpr {
  public:
   /// Used as a leaf in an expression tree specifying input column by name.
   FieldAccessTypedExpr(TypePtr type, std::string name)
-      : ITypedExpr{move(type)}, name_(std::move(name)), isInputColumn_(true) {}
+      : ITypedExpr{std::move(type)}, name_(std::move(name)), isInputColumn_(true) {}
 
   /// Used as a dereference expression which selects a subfield in a struct by
   /// name.
   FieldAccessTypedExpr(TypePtr type, TypedExprPtr input, std::string name)
-      : ITypedExpr{move(type), {move(input)}},
+      : ITypedExpr{std::move(type), {std::move(input)}},
         name_(std::move(name)),
         isInputColumn_(dynamic_cast<const InputTypedExpr*>(inputs()[0].get())) {
   }
@@ -353,7 +353,7 @@ class ConcatTypedExpr : public ITypedExpr {
       namesCopy.push_back(names.at(i));
       children.push_back(expressions.at(i)->type());
     }
-    return ROW(move(namesCopy), move(children));
+    return ROW(std::move(namesCopy), std::move(children));
   }
 };
 

--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -23,7 +23,8 @@ namespace facebook::velox::core {
 /* a strongly-typed expression, such as literal, function call, etc... */
 class ITypedExpr {
  public:
-  ITypedExpr(std::shared_ptr<const Type> type) : type_{std::move(type)}, inputs_{} {}
+  ITypedExpr(std::shared_ptr<const Type> type)
+      : type_{std::move(type)}, inputs_{} {}
 
   ITypedExpr(
       std::shared_ptr<const Type> type,

--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -23,7 +23,7 @@ namespace facebook::velox::core {
 /* a strongly-typed expression, such as literal, function call, etc... */
 class ITypedExpr {
  public:
-  ITypedExpr(std::shared_ptr<const Type> type)
+  explicit ITypedExpr(std::shared_ptr<const Type> type)
       : type_{std::move(type)}, inputs_{} {}
 
   ITypedExpr(

--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -23,12 +23,12 @@ namespace facebook::velox::core {
 /* a strongly-typed expression, such as literal, function call, etc... */
 class ITypedExpr {
  public:
-  ITypedExpr(std::shared_ptr<const Type> type) : type_{move(type)}, inputs_{} {}
+  ITypedExpr(std::shared_ptr<const Type> type) : type_{std::move(type)}, inputs_{} {}
 
   ITypedExpr(
       std::shared_ptr<const Type> type,
       std::vector<std::shared_ptr<const ITypedExpr>> inputs)
-      : type_{move(type)}, inputs_{move(inputs)} {}
+      : type_{std::move(type)}, inputs_{std::move(inputs)} {}
 
   const std::shared_ptr<const Type>& type() const {
     return type_;

--- a/velox/core/tests/TestMetafunctions.cpp
+++ b/velox/core/tests/TestMetafunctions.cpp
@@ -29,6 +29,6 @@ TEST(Metafunctions, ForEachWithIndex) {
         result += folly::to<std::string>(elem);
         result += ";";
       },
-      move(tup));
+      std::move(tup));
   ASSERT_EQ(result, "0:1;1:hello;2:3.1;");
 }

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -170,7 +170,7 @@ TypedExprPtr createWithImplicitCast(
   }
   auto type = resolveTypeImpl(inputs, expr, false /*nullOnFailure*/);
   return std::make_shared<CallTypedExpr>(
-      type, move(inputs), std::string{expr->getFunctionName()});
+      type, std::move(inputs), std::string{expr->getFunctionName()});
 }
 } // namespace
 
@@ -220,7 +220,7 @@ TypedExprPtr Expressions::inferTypes(
         std::string{fae->getFieldName()});
   }
   if (auto fun = std::dynamic_pointer_cast<const CallExpr>(expr)) {
-    return createWithImplicitCast(move(fun), move(children));
+    return createWithImplicitCast(std::move(fun), std::move(children));
   }
   if (auto input = std::dynamic_pointer_cast<const InputExpr>(expr)) {
     return std::make_shared<const InputTypedExpr>(inputRow);
@@ -241,7 +241,7 @@ TypedExprPtr Expressions::inferTypes(
   }
   if (auto cast = std::dynamic_pointer_cast<const CastExpr>(expr)) {
     return std::make_shared<const CastTypedExpr>(
-        cast->type(), move(children), cast->nullOnFailure());
+        cast->type(), std::move(children), cast->nullOnFailure());
   }
   if (auto alreadyTyped = std::dynamic_pointer_cast<const ITypedExpr>(expr)) {
     return alreadyTyped;

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -288,7 +288,8 @@ class CallExpr : public core::IExpr {
 
   std::shared_ptr<const IExpr> withInputs(
       std::vector<std::shared_ptr<const IExpr>> inputs) const override {
-    return std::make_shared<CallExpr>(std::string{name_}, std::move(inputs), alias_);
+    return std::make_shared<CallExpr>(
+        std::string{name_}, std::move(inputs), alias_);
   }
 
   std::string toString() const override {

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -132,14 +132,14 @@ class FieldAccessExpr : public core::IExpr {
       std::vector<std::shared_ptr<const IExpr>>&& inputs =
           std::vector<std::shared_ptr<const IExpr>>{
               std::make_shared<const InputExpr>()})
-      : IExpr{std::move(alias)}, name_{name}, inputs_{move(inputs)} {
+      : IExpr{std::move(alias)}, name_{name}, inputs_{std::move(inputs)} {
     CHECK_EQ(inputs_.size(), 1);
   }
 
   std::shared_ptr<const IExpr> withInputs(
       std::vector<std::shared_ptr<const IExpr>> inputs) const override {
     return std::make_shared<FieldAccessExpr>(
-        std::string{name_}, alias_, move(inputs));
+        std::string{name_}, alias_, std::move(inputs));
   }
 
   const std::string& getFieldName() const {
@@ -180,12 +180,12 @@ class FieldAccessExpr : public core::IExpr {
     auto inputs = ISerializable::deserialize<std::vector<IExpr>>(obj["inputs"]);
 
     return std::make_shared<const FieldAccessExpr>(
-        move(fieldName), std::nullopt, move(inputs));
+        std::move(fieldName), std::nullopt, std::move(inputs));
   }
 
   static std::shared_ptr<const FieldAccessExpr> column(std::string columnName) {
     return std::make_shared<const FieldAccessExpr>(
-        move(columnName), std::nullopt);
+        std::move(columnName), std::nullopt);
   }
 
   bool equalsNonRecursive(const IExpr& other) const override {
@@ -218,14 +218,14 @@ class SortExpr : public core::IExpr {
   SortExpr(
       std::vector<bool>&& orders,
       std::vector<std::shared_ptr<const IExpr>>&& inputs)
-      : orders_(move(orders)), inputs_{move(inputs)} {
+      : orders_(std::move(orders)), inputs_{std::move(inputs)} {
     CHECK_EQ(inputs_.size(), orders_.size());
   }
 
   std::shared_ptr<const IExpr> withInputs(
       std::vector<std::shared_ptr<const IExpr>> inputs) const override {
     return std::make_shared<SortExpr>(
-        std::vector<bool>(this->orders_), move(inputs));
+        std::vector<bool>(this->orders_), std::move(inputs));
   }
 
   const std::vector<bool>& getOrders() const {
@@ -277,8 +277,8 @@ class CallExpr : public core::IExpr {
       std::vector<std::shared_ptr<const IExpr>>&& inputs,
       std::optional<std::string> alias)
       : core::IExpr{std::move(alias)},
-        name_{move(funcName)},
-        inputs_{move(inputs)} {
+        name_{std::move(funcName)},
+        inputs_{std::move(inputs)} {
     VELOX_CHECK(!name_.empty());
   }
 
@@ -288,7 +288,7 @@ class CallExpr : public core::IExpr {
 
   std::shared_ptr<const IExpr> withInputs(
       std::vector<std::shared_ptr<const IExpr>> inputs) const override {
-    return std::make_shared<CallExpr>(std::string{name_}, move(inputs), alias_);
+    return std::make_shared<CallExpr>(std::string{name_}, std::move(inputs), alias_);
   }
 
   std::string toString() const override {
@@ -324,7 +324,7 @@ class CallExpr : public core::IExpr {
     auto inputs = ISerializable::deserialize<std::vector<IExpr>>(obj["inputs"]);
 
     return std::make_shared<const CallExpr>(
-        move(functionName), move(inputs), std::nullopt);
+        std::move(functionName), std::move(inputs), std::nullopt);
   }
 
   template <typename... T>


### PR DESCRIPTION
Replace move() with std::move() to comply with coding style and best practices.