### PR TITLE
Fix lock order issue detected by tsan in LocalPartition

### DIFF
--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -31,7 +31,10 @@ class LocalExchangeMemoryManager {
   /// will be complete when memory usage is update to be below the limit.
   bool increaseMemoryUsage(ContinueFuture* future, int64_t added);
 
-  void decreaseMemoryUsage(int64_t removed);
+  /// Decreases the memory usage by 'removed' bytes. If the memory usage goes
+  /// below the limit after the decrease, the function returns 'promises_' to
+  /// caller to fulfill.
+  std::vector<ContinuePromise> decreaseMemoryUsage(int64_t removed);
 
  private:
   const int64_t maxBufferSize_;


### PR DESCRIPTION
There is a lock order issue detected by tsan in LocalPartitionTest.maxBufferSizeGather
We fulfill the promises in LocalExchangeMemoryManager under the
LocalPartitionExchange's lock and the continuation of the promise is executed inline
which will grab the task lock. This is in reverse to the lock ordering on task startup which
grab LocalPartitionExchange's lock to add producer while holding the task lock.

Verified the fix by running LocalPartitionTest.maxBufferSizeGather under tsan mode on
meta internal devserver for 100 iterations.