### PR TITLE
Fix Reduce::apply() bug.

### DIFF
--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -120,6 +120,12 @@ class ReduceFunction : public exec::VectorFunction {
 
       vector_size_t n = 0;
       while (true) {
+        // 'state' might use the 'elementIndices', in that case we need to
+        // reallocate them to avoid overwriting.
+        if (not elementIndices->unique()) {
+          elementIndices = allocateIndices(flatArray->size(), context.pool());
+        }
+
         // Sets arrayRows[row] to true if array at that row has n-th element, to
         // false otherwise.
         // Set elementIndices[row] to the index of the n-th element in the

--- a/velox/functions/prestosql/tests/ReduceTest.cpp
+++ b/velox/functions/prestosql/tests/ReduceTest.cpp
@@ -168,3 +168,22 @@ TEST_F(ReduceTest, finalSelection) {
       nullEvery(11))});
   assertEqualVectors(expectedResult, result);
 }
+
+TEST_F(ReduceTest, elementIndicesOverwrite) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeFlatVector<int64_t>({3, 4}),
+  });
+
+  registerLambda(
+      "input",
+      rowType("s", BIGINT(), "x", BIGINT()),
+      ROW({ARRAY(BIGINT())}),
+      "s + x");
+  registerLambda("output", rowType("s", BIGINT()), ROW({ARRAY(BIGINT())}), "s");
+
+  auto result = evaluate(
+      "reduce(array[c0, c1], 100, function('input'), function('output'))",
+      data);
+  assertEqualVectors(makeFlatVector<int64_t>({104, 106}), result);
+}


### PR DESCRIPTION
Summary:
The issue was detected in a E2E test.
A recent fix D39068619 (https://github.com/facebookincubator/velox/commit/a785bc97a643aaa7fe866f6b31bb32f9aa94764f) (https://github.com/facebookincubator/velox/pull/2389) exposed a bug in Reduce::apply() where we could overwrite 'elementIndices' while them being used in the intermediate result vector.

Differential Revision: D39494265

