### PR TITLE
Rename kAnti to kNullAwareAnti

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -938,7 +938,7 @@ enum class JoinType {
   kFull,
   kLeftSemi,
   kRightSemi,
-  kAnti
+  kNullAwareAnti,
 };
 
 inline const char* joinTypeName(JoinType joinType) {
@@ -955,8 +955,8 @@ inline const char* joinTypeName(JoinType joinType) {
       return "LEFT SEMI";
     case JoinType::kRightSemi:
       return "RIGHT SEMI";
-    case JoinType::kAnti:
-      return "ANTI";
+    case JoinType::kNullAwareAnti:
+      return "NULL-AWARE ANTI";
   }
   VELOX_UNREACHABLE();
 }
@@ -985,8 +985,8 @@ inline bool isRightSemiJoin(JoinType joinType) {
   return joinType == JoinType::kRightSemi;
 }
 
-inline bool isAntiJoin(JoinType joinType) {
-  return joinType == JoinType::kAnti;
+inline bool isNullAwareAntiJoin(JoinType joinType) {
+  return joinType == JoinType::kNullAwareAnti;
 }
 
 /// Abstract class representing inner/outer/semi/anti joins. Used as a base
@@ -1039,8 +1039,8 @@ class AbstractJoinNode : public PlanNode {
     return joinType_ == JoinType::kRightSemi;
   }
 
-  bool isAntiJoin() const {
-    return joinType_ == JoinType::kAnti;
+  bool isNullAwareAntiJoin() const {
+    return joinType_ == JoinType::kNullAwareAnti;
   }
 
   const std::vector<FieldAccessTypedExprPtr>& leftKeys() const {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -134,7 +134,7 @@ void HashBuild::setupTable() {
     // (Left) semi and anti join with no extra filter only needs to know whether
     // there is a match. Hence, no need to store entries with duplicate keys.
     const bool dropDuplicates = !joinNode_->filter() &&
-        (joinNode_->isLeftSemiJoin() || joinNode_->isAntiJoin());
+        (joinNode_->isLeftSemiJoin() || joinNode_->isNullAwareAntiJoin());
     // Right semi join needs to tag build rows that were probed.
     const bool needProbedFlag = joinNode_->isRightSemiJoin();
     // Ignore null keys
@@ -163,9 +163,9 @@ void HashBuild::addInput(RowVectorPtr input) {
     deselectRowsWithNulls(hashers, activeRows_);
   }
 
-  if (joinType_ == core::JoinType::kAnti) {
-    // Anti join returns no rows if build side has nulls in join keys. Hence, we
-    // can stop processing on first null.
+  if (joinType_ == core::JoinType::kNullAwareAnti) {
+    // Null-aware anti join returns no rows if build side has nulls in join
+    // keys. Hence, we can stop processing on first null.
     if (activeRows_.countSelected() < input->size()) {
       antiJoinHasNullKeys_ = true;
       noMoreInput();

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -195,7 +195,7 @@ BlockingReason HashProbe::isBlocked(ContinueFuture* future) {
 
   if (hashBuildResult->antiJoinHasNullKeys) {
     // Anti join with null keys on the build side always returns nothing.
-    VELOX_CHECK(isAntiJoin(joinType_));
+    VELOX_CHECK(isNullAwareAntiJoin(joinType_));
     finished_ = true;
   } else {
     table_ = hashBuildResult->table;
@@ -254,7 +254,7 @@ void HashProbe::addInput(RowVectorPtr input) {
     // Build side is empty. This state is valid only for anti, left and full
     // joins.
     VELOX_CHECK(
-        isAntiJoin(joinType_) || isLeftJoin(joinType_) ||
+        isNullAwareAntiJoin(joinType_) || isLeftJoin(joinType_) ||
         isFullJoin(joinType_));
     return;
   }
@@ -295,7 +295,8 @@ void HashProbe::addInput(RowVectorPtr input) {
   }
 
   passingInputRowsInitialized_ = false;
-  if (isLeftJoin(joinType_) || isFullJoin(joinType_) || isAntiJoin(joinType_)) {
+  if (isLeftJoin(joinType_) || isFullJoin(joinType_) ||
+      isNullAwareAntiJoin(joinType_)) {
     // Make sure to allocate an entry in 'hits' for every input row to allow for
     // including rows without a match in the output. Also, make sure to
     // initialize all 'hits' to nullptr as HashTable::joinProbe will only
@@ -438,7 +439,7 @@ RowVectorPtr HashProbe::getOutput() {
   }
 
   const bool isLeftSemiOrAntiJoinNoFilter = !filter_ &&
-      (core::isLeftSemiJoin(joinType_) || core::isAntiJoin(joinType_));
+      (core::isLeftSemiJoin(joinType_) || core::isNullAwareAntiJoin(joinType_));
 
   const bool emptyBuildSide = (table_->numDistinct() == 0);
 
@@ -460,7 +461,7 @@ RowVectorPtr HashProbe::getOutput() {
       // rows, including ones with null join keys.
       std::iota(mapping.begin(), mapping.end(), 0);
       numOut = inputSize;
-    } else if (isAntiJoin(joinType_) && !filter_) {
+    } else if (isNullAwareAntiJoin(joinType_) && !filter_) {
       // When build side is not empty, anti join without a filter returns probe
       // rows with no nulls in the join key and no match in the build side.
       for (auto i = 0; i < inputSize; i++) {
@@ -474,7 +475,7 @@ RowVectorPtr HashProbe::getOutput() {
       numOut = table_->listJoinResults(
           results_,
           isLeftJoin(joinType_) || isFullJoin(joinType_) ||
-              isAntiJoin(joinType_),
+              isNullAwareAntiJoin(joinType_),
           mapping,
           folly::Range(outputRows_.data(), outputRows_.size()));
     }
@@ -585,7 +586,7 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
     if (results_.atEnd()) {
       leftSemiJoinTracker_.finish(addLastMatch);
     }
-  } else if (isAntiJoin(joinType_)) {
+  } else if (isNullAwareAntiJoin(joinType_)) {
     // Identify probe rows with no matches.
     auto addMiss = [&](auto row) {
       outputRows_[numPassed] = nullptr;
@@ -612,7 +613,7 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
 }
 
 void HashProbe::ensureLoadedIfNotAtEnd(column_index_t channel) {
-  if (core::isLeftSemiJoin(joinType_) || core::isAntiJoin(joinType_) ||
+  if (core::isLeftSemiJoin(joinType_) || core::isNullAwareAntiJoin(joinType_) ||
       results_.atEnd()) {
     return;
   }

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -468,7 +468,7 @@ TEST_P(MultiThreadedHashJoinTest, antiJoinWithNull) {
         "SELECT t_k1, t_k2 FROM t WHERE t.t_k2 NOT IN (SELECT u_k2 FROM u)",
         "",
         {"t_k1", "t_k2"},
-        core::JoinType::kAnti);
+        core::JoinType::kNullAwareAnti);
   }
 }
 
@@ -1012,7 +1012,7 @@ TEST_F(HashJoinTest, antiJoin) {
                         .planNode(),
                     "",
                     {"c1"},
-                    core::JoinType::kAnti)
+                    core::JoinType::kNullAwareAnti)
                 .planNode();
 
   assertQuery(
@@ -1032,7 +1032,7 @@ TEST_F(HashJoinTest, antiJoin) {
                    .planNode(),
                "",
                {"c1"},
-               core::JoinType::kAnti)
+               core::JoinType::kNullAwareAnti)
            .planNode();
 
   assertQuery(
@@ -1051,7 +1051,7 @@ TEST_F(HashJoinTest, antiJoin) {
                    .planNode(),
                "",
                {"c1"},
-               core::JoinType::kAnti)
+               core::JoinType::kNullAwareAnti)
            .planNode();
 
   assertQuery(op, "SELECT t.c1 FROM t WHERE t.c0 NOT IN (SELECT c0 FROM u)");
@@ -1086,7 +1086,7 @@ TEST_F(HashJoinTest, antiJoinWithFilter) {
                         .planNode(),
                     "",
                     {"t0", "t1"},
-                    core::JoinType::kAnti)
+                    core::JoinType::kNullAwareAnti)
                 .planNode();
 
   assertQuery(
@@ -1102,7 +1102,7 @@ TEST_F(HashJoinTest, antiJoinWithFilter) {
                    .planNode(),
                "t1 != u1",
                {"t0", "t1"},
-               core::JoinType::kAnti)
+               core::JoinType::kNullAwareAnti)
            .planNode();
 
   assertQuery(

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -1035,7 +1035,7 @@ TpchPlan TpchQueryBuilder::getQ16Plan() const {
               supplier,
               "",
               {"ps_suppkey", "p_brand", "p_type", "p_size"},
-              core::JoinType::kAnti)
+              core::JoinType::kNullAwareAnti)
           // Empty aggregate is used here to get the distinct count of
           // ps_suppkey.
           // approx_distinct could be used instead for getting the count of
@@ -1272,7 +1272,7 @@ TpchPlan TpchQueryBuilder::getQ22Plan() const {
               orders,
               "",
               {"c_acctbal", "c_phone"},
-              core::JoinType::kAnti)
+              core::JoinType::kNullAwareAnti)
           .project({"substr(c_phone, 1, 2) AS country_code", "c_acctbal"})
           .partialAggregation(
               {"country_code"},


### PR DESCRIPTION
Summary:
This is the first step to add regular anti join.  Rename the join type
name to better reflect the properties of the join.

Differential Revision: D39514817

