### PR TITLE
Refactor DateTimeFormatter tests (#2297)

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -22,6 +22,8 @@
 
 namespace facebook::velox::functions {
 
+enum class DateTimeFormatterType { JODA, MYSQL, UNKNOWN };
+
 enum class DateTimeFormatSpecifier : uint8_t {
   // Era, e.g: "AD"
   ERA = 0,
@@ -152,10 +154,12 @@ class DateTimeFormatter {
   explicit DateTimeFormatter(
       std::unique_ptr<char[]>&& literalBuf,
       size_t bufSize,
-      std::vector<DateTimeToken>&& tokens)
+      std::vector<DateTimeToken>&& tokens,
+      DateTimeFormatterType type)
       : literalBuf_(std::move(literalBuf)),
         bufSize_(bufSize),
-        tokens_(std::move(tokens)) {}
+        tokens_(std::move(tokens)),
+        type_(type) {}
 
   const std::unique_ptr<char[]>& literalBuf() const {
     return literalBuf_;
@@ -179,6 +183,7 @@ class DateTimeFormatter {
   std::unique_ptr<char[]> literalBuf_;
   size_t bufSize_;
   std::vector<DateTimeToken> tokens_;
+  DateTimeFormatterType type_;
 };
 
 std::shared_ptr<DateTimeFormatter> buildMysqlDateTimeFormatter(

--- a/velox/functions/lib/DateTimeFormatterBuilder.cpp
+++ b/velox/functions/lib/DateTimeFormatterBuilder.cpp
@@ -203,9 +203,16 @@ DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendLiteral(
   return *this;
 }
 
+DateTimeFormatterBuilder& DateTimeFormatterBuilder::setType(
+    DateTimeFormatterType type) {
+  type_ = type;
+  return *this;
+}
+
 std::shared_ptr<DateTimeFormatter> DateTimeFormatterBuilder::build() {
+  VELOX_CHECK_NE(type_, DateTimeFormatterType::UNKNOWN);
   return std::make_shared<DateTimeFormatter>(
-      std::move(literalBuf_), bufEnd_, std::move(tokens_));
+      std::move(literalBuf_), bufEnd_, std::move(tokens_), type_);
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/DateTimeFormatterBuilder.h
+++ b/velox/functions/lib/DateTimeFormatterBuilder.h
@@ -18,10 +18,12 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "velox/functions/lib/DateTimeFormatter.h"
 
 namespace facebook::velox::functions {
 
 class DateTimeFormatter;
+enum class DateTimeFormatterType;
 struct DateTimeToken;
 
 /// Builder class that builds DateTimeFormatter object. For example, let's
@@ -260,12 +262,15 @@ class DateTimeFormatterBuilder {
       const char* literalStart,
       size_t literalSize);
 
+  DateTimeFormatterBuilder& setType(DateTimeFormatterType type);
+
   std::shared_ptr<DateTimeFormatter> build();
 
  private:
   std::unique_ptr<char[]> literalBuf_;
   size_t bufEnd_{0};
   std::vector<DateTimeToken> tokens_;
+  DateTimeFormatterType type_{DateTimeFormatterType::UNKNOWN};
 };
 
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/velox/pull/2297

Refactored DateTimeFormatterTest to use clearer naming convention, so it's obvious when Joda standard is used and when MySQL standard is used.

Reviewed By: spershin

Differential Revision: D38717415

