### PR TITLE
Add IntegerVariable support for FunctionSignature and Binding

### DIFF
--- a/velox/exec/tests/ParseTypeSignatureTest.cpp
+++ b/velox/exec/tests/ParseTypeSignatureTest.cpp
@@ -28,7 +28,7 @@ std::string roundTrip(const std::string& typeSignature) {
 
 void testScalarType(const std::string& typeSignature) {
   auto signature = parseTypeSignature(typeSignature);
-  ASSERT_EQ(signature.baseType(), typeSignature);
+  ASSERT_EQ(signature.baseName(), typeSignature);
   ASSERT_EQ(signature.parameters().size(), 0);
 }
 } // namespace
@@ -45,25 +45,25 @@ TEST(ParseTypeSignatureTest, scalar) {
 
 TEST(ParseTypeSignatureTest, array) {
   auto signature = parseTypeSignature("array(bigint)");
-  ASSERT_EQ(signature.baseType(), "array");
+  ASSERT_EQ(signature.baseName(), "array");
   ASSERT_EQ(signature.parameters().size(), 1);
 
   auto param = signature.parameters()[0];
-  ASSERT_EQ(param.baseType(), "bigint");
+  ASSERT_EQ(param.baseName(), "bigint");
   ASSERT_EQ(param.parameters().size(), 0);
 }
 
 TEST(ParseTypeSignatureTest, map) {
   auto signature = parseTypeSignature("map(bigint, double)");
-  ASSERT_EQ(signature.baseType(), "map");
+  ASSERT_EQ(signature.baseName(), "map");
   ASSERT_EQ(signature.parameters().size(), 2);
 
   auto key = signature.parameters()[0];
-  ASSERT_EQ(key.baseType(), "bigint");
+  ASSERT_EQ(key.baseName(), "bigint");
   ASSERT_EQ(key.parameters().size(), 0);
 
   auto value = signature.parameters()[1];
-  ASSERT_EQ(value.baseType(), "double");
+  ASSERT_EQ(value.baseName(), "double");
   ASSERT_EQ(value.parameters().size(), 0);
 }
 

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -28,13 +28,17 @@ inline bool isCommonDecimalName(const std::string& typeName) {
   return (typeName == "DECIMAL");
 }
 
-// A type name (e.g. K or V in map(K, V)) and optionally constraints, e.g.
-// expression over the variable, etc.
+enum class ParameterType { TYPE_PARAMETER, INTEGER_PARAMETER };
+
+/// TypeVariableConstraint holds both, type parameters (e.g. K or V in map(K,
+/// V)), and integer parameters with optional constraints (e.g. "r_precision =
+/// a_precision + b_precision" in decimals).
 class TypeVariableConstraint {
  public:
-  explicit TypeVariableConstraint(std::string name) : name_{std::move(name)} {}
-  TypeVariableConstraint(std::string name, std::string constraint)
-      : name_{std::move(name)}, constraint_{std::move(constraint)} {}
+  explicit TypeVariableConstraint(
+      std::string name,
+      std::optional<std::string> constraint,
+      ParameterType type);
 
   const std::string& name() const {
     return name_;
@@ -44,56 +48,54 @@ class TypeVariableConstraint {
     return constraint_;
   }
 
+  bool isTypeParameter() const {
+    return type_ == ParameterType::TYPE_PARAMETER;
+  }
+
+  bool isIntegerParameter() const {
+    return type_ == ParameterType::INTEGER_PARAMETER;
+  }
+
   bool operator==(const TypeVariableConstraint& rhs) const {
-    return name_ == rhs.name_;
+    return type_ == rhs.type_ && name_ == rhs.name_ &&
+        constraint_ == rhs.constraint_;
   }
 
  private:
   const std::string name_;
   const std::string constraint_;
+  const ParameterType type_;
 };
 
 // Base type (e.g. map) and optional parameters (e.g. K, V).
+// All parameters must be of the same ParameterType.
 class TypeSignature {
  public:
-  TypeSignature(std::string baseType, std::vector<TypeSignature> parameters)
-      : baseType_{std::move(baseType)}, parameters_{std::move(parameters)} {}
-  TypeSignature(
-      std::string baseType,
-      std::vector<TypeSignature> parameters,
-      std::vector<std::string> variables)
-      : baseType_{std::move(baseType)},
-        parameters_{std::move(parameters)},
-        variables_{std::move(variables)} {}
+  TypeSignature(std::string baseName, std::vector<TypeSignature> parameters)
+      : baseName_{std::move(baseName)}, parameters_{std::move(parameters)} {}
 
-  const std::string& baseType() const {
-    return baseType_;
+  const std::string& baseName() const {
+    return baseName_;
   }
 
   const std::vector<TypeSignature>& parameters() const {
     return parameters_;
   }
 
-  const std::vector<std::string>& variables() const {
-    return variables_;
-  }
-
   std::string toString() const;
 
   bool operator==(const TypeSignature& rhs) const {
-    return baseType_ == rhs.baseType_ && parameters_ == rhs.parameters_;
+    return baseName_ == rhs.baseName_ && parameters_ == rhs.parameters_;
   }
 
  private:
-  const std::string baseType_;
+  const std::string baseName_;
   const std::vector<TypeSignature> parameters_;
-  // Decimals types have variables (precision, scale)
-  const std::vector<std::string> variables_;
 };
 
 class FunctionSignature {
  public:
-  /// @param typeVariableConstants Generic type names used in return type and
+  /// @param typeVariableConstraints Generic type names used in return type and
   /// argument types (and constraints if necessary).
   /// @param returnType Return type. May use generic type names, e.g. array(T).
   /// @param argumentTypes Argument types. May use generic type names, e.g.
@@ -106,24 +108,13 @@ class FunctionSignature {
   /// specified in the last entry of 'argumentTypes'. Variable arity arguments
   /// can appear zero or more times.
   FunctionSignature(
-      std::vector<TypeVariableConstraint> typeVariableConstants,
+      std::vector<TypeVariableConstraint> typeVariableConstraints,
       TypeSignature returnType,
       std::vector<TypeSignature> argumentTypes,
       bool variableArity);
 
-  FunctionSignature(
-      std::vector<TypeVariableConstraint> typeVariableConstants,
-      std::vector<TypeVariableConstraint> variables,
-      TypeSignature returnType,
-      std::vector<TypeSignature> argumentTypes,
-      bool variableArity);
-
-  const std::vector<TypeVariableConstraint>& typeVariableConstants() const {
-    return typeVariableConstants_;
-  }
-
-  const std::vector<TypeVariableConstraint>& variables() const {
-    return variables_;
+  const std::vector<TypeVariableConstraint>& typeVariableConstraints() const {
+    return typeVariableConstraints_;
   }
 
   const TypeSignature& returnType() const {
@@ -141,18 +132,17 @@ class FunctionSignature {
   std::string toString() const;
 
   // This tests syntactic equality not semantic equality
-  // For example, even if only the names of the typeVariableConstants are
+  // For example, even if only the names of the typeVariableConstraints are
   // different the signatures are considered not equal (array(K) != array(V))
   bool operator==(const FunctionSignature& rhs) const {
-    return typeVariableConstants_ == rhs.typeVariableConstants_ &&
+    return typeVariableConstraints_ == rhs.typeVariableConstraints_ &&
         returnType_ == rhs.returnType_ &&
         argumentTypes_ == rhs.argumentTypes_ &&
         variableArity_ == rhs.variableArity_;
   }
 
  private:
-  const std::vector<TypeVariableConstraint> typeVariableConstants_;
-  const std::vector<TypeVariableConstraint> variables_;
+  const std::vector<TypeVariableConstraint> typeVariableConstraints_;
   const TypeSignature returnType_;
   const std::vector<TypeSignature> argumentTypes_;
   const bool variableArity_;
@@ -163,28 +153,13 @@ using FunctionSignaturePtr = std::shared_ptr<FunctionSignature>;
 class AggregateFunctionSignature : public FunctionSignature {
  public:
   AggregateFunctionSignature(
-      std::vector<TypeVariableConstraint> typeVariableConstants,
+      std::vector<TypeVariableConstraint> typeVariableConstraints,
       TypeSignature returnType,
       TypeSignature intermediateType,
       std::vector<TypeSignature> argumentTypes,
       bool variableArity)
       : FunctionSignature(
-            std::move(typeVariableConstants),
-            std::move(returnType),
-            std::move(argumentTypes),
-            variableArity),
-        intermediateType_{std::move(intermediateType)} {}
-
-  AggregateFunctionSignature(
-      std::vector<TypeVariableConstraint> typeVariableConstants,
-      std::vector<TypeVariableConstraint> variables,
-      TypeSignature returnType,
-      TypeSignature intermediateType,
-      std::vector<TypeSignature> argumentTypes,
-      bool variableArity)
-      : FunctionSignature(
-            std::move(typeVariableConstants),
-            std::move(variables),
+            std::move(typeVariableConstraints),
             std::move(returnType),
             std::move(argumentTypes),
             variableArity),
@@ -230,14 +205,16 @@ TypeSignature parseTypeSignature(const std::string& signature);
 class FunctionSignatureBuilder {
  public:
   FunctionSignatureBuilder& typeVariable(std::string name) {
-    typeVariableConstants_.emplace_back(name);
+    typeVariableConstraints_.emplace_back(
+        name, "", ParameterType::TYPE_PARAMETER);
     return *this;
   }
 
-  FunctionSignatureBuilder& variableConstraint(
+  FunctionSignatureBuilder& integerVariable(
       std::string name,
-      std::string constraint) {
-    variables_.emplace_back(name, constraint);
+      std::optional<std::string> constraint = std::nullopt) {
+    typeVariableConstraints_.emplace_back(
+        name, constraint, ParameterType::INTEGER_PARAMETER);
     return *this;
   }
 
@@ -259,8 +236,7 @@ class FunctionSignatureBuilder {
   FunctionSignaturePtr build();
 
  private:
-  std::vector<TypeVariableConstraint> typeVariableConstants_;
-  std::vector<TypeVariableConstraint> variables_;
+  std::vector<TypeVariableConstraint> typeVariableConstraints_;
   std::optional<TypeSignature> returnType_;
   std::vector<TypeSignature> argumentTypes_;
   bool variableArity_{false};
@@ -280,7 +256,16 @@ class FunctionSignatureBuilder {
 class AggregateFunctionSignatureBuilder {
  public:
   AggregateFunctionSignatureBuilder& typeVariable(std::string name) {
-    typeVariableConstants_.emplace_back(name);
+    typeVariableConstraints_.emplace_back(
+        name, "", ParameterType::TYPE_PARAMETER);
+    return *this;
+  }
+
+  AggregateFunctionSignatureBuilder& integerVariable(
+      std::string name,
+      std::optional<std::string> constraint = std::nullopt) {
+    typeVariableConstraints_.emplace_back(
+        name, constraint, ParameterType::INTEGER_PARAMETER);
     return *this;
   }
 
@@ -304,21 +289,13 @@ class AggregateFunctionSignatureBuilder {
     return *this;
   }
 
-  AggregateFunctionSignatureBuilder& variableConstraint(
-      std::string name,
-      std::string constraint) {
-    variables_.emplace_back(name, constraint);
-    return *this;
-  }
-
   std::shared_ptr<AggregateFunctionSignature> build();
 
  private:
-  std::vector<TypeVariableConstraint> typeVariableConstants_;
+  std::vector<TypeVariableConstraint> typeVariableConstraints_;
   std::optional<TypeSignature> returnType_;
   std::optional<TypeSignature> intermediateType_;
   std::vector<TypeSignature> argumentTypes_;
-  std::vector<TypeVariableConstraint> variables_;
   bool variableArity_{false};
 };
 
@@ -342,12 +319,9 @@ struct hash<facebook::velox::exec::TypeSignature> {
   using result_type = std::size_t;
 
   result_type operator()(const argument_type& key) const noexcept {
-    size_t val = std::hash<std::string>{}(key.baseType());
+    size_t val = std::hash<std::string>{}(key.baseName());
     for (const auto& parameter : key.parameters()) {
       val = val * 31 + this->operator()(parameter);
-    }
-    for (const auto& variable : key.variables()) {
-      val = val * 31 + std::hash<std::string>{}(variable);
     }
     return val;
   }
@@ -365,12 +339,8 @@ struct hash<facebook::velox::exec::FunctionSignature> {
         std::hash<facebook::velox::exec::TypeSignature>{};
 
     size_t val = 0;
-    for (const auto& constraint : key.typeVariableConstants()) {
+    for (const auto& constraint : key.typeVariableConstraints()) {
       val = val * 31 + typeVariableConstraintHasher(constraint);
-    }
-
-    for (const auto& variable : key.variables()) {
-      val = val * 31 + typeVariableConstraintHasher(variable);
     }
 
     val = val * 31 + typeSignatureHasher(key.returnType());

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -28,7 +28,7 @@ inline bool isCommonDecimalName(const std::string& typeName) {
   return (typeName == "DECIMAL");
 }
 
-enum class ParameterType { TYPE_PARAMETER, INTEGER_PARAMETER };
+enum class ParameterType : int8_t { kTypeParameter, kIntegerParameter };
 
 /// TypeVariableConstraint holds both, type parameters (e.g. K or V in map(K,
 /// V)), and integer parameters with optional constraints (e.g. "r_precision =
@@ -49,11 +49,11 @@ class TypeVariableConstraint {
   }
 
   bool isTypeParameter() const {
-    return type_ == ParameterType::TYPE_PARAMETER;
+    return type_ == ParameterType::kTypeParameter;
   }
 
   bool isIntegerParameter() const {
-    return type_ == ParameterType::INTEGER_PARAMETER;
+    return type_ == ParameterType::kIntegerParameter;
   }
 
   bool operator==(const TypeVariableConstraint& rhs) const {
@@ -206,7 +206,7 @@ class FunctionSignatureBuilder {
  public:
   FunctionSignatureBuilder& typeVariable(std::string name) {
     typeVariableConstraints_.emplace_back(
-        name, "", ParameterType::TYPE_PARAMETER);
+        name, "", ParameterType::kTypeParameter);
     return *this;
   }
 
@@ -214,7 +214,7 @@ class FunctionSignatureBuilder {
       std::string name,
       std::optional<std::string> constraint = std::nullopt) {
     typeVariableConstraints_.emplace_back(
-        name, constraint, ParameterType::INTEGER_PARAMETER);
+        name, constraint, ParameterType::kIntegerParameter);
     return *this;
   }
 
@@ -257,7 +257,7 @@ class AggregateFunctionSignatureBuilder {
  public:
   AggregateFunctionSignatureBuilder& typeVariable(std::string name) {
     typeVariableConstraints_.emplace_back(
-        name, "", ParameterType::TYPE_PARAMETER);
+        name, "", ParameterType::kTypeParameter);
     return *this;
   }
 
@@ -265,7 +265,7 @@ class AggregateFunctionSignatureBuilder {
       std::string name,
       std::optional<std::string> constraint = std::nullopt) {
     typeVariableConstraints_.emplace_back(
-        name, constraint, ParameterType::INTEGER_PARAMETER);
+        name, constraint, ParameterType::kIntegerParameter);
     return *this;
   }
 

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -22,7 +22,7 @@ namespace facebook::velox::exec {
 
 namespace {
 bool isAny(const TypeSignature& typeSignature) {
-  return typeSignature.baseType() == "any";
+  return typeSignature.baseName() == "any";
 }
 
 /// Returns true only if 'str' contains digits.
@@ -33,58 +33,69 @@ bool isPositiveInteger(const std::string& str) {
       }) == str.end();
 }
 
-std::string buildCalculation(
-    const std::string& variable,
-    const std::string& calculation) {
-  return fmt::format("{}={}", variable, calculation);
-}
-
 TypePtr inferDecimalType(
     const exec::TypeSignature& typeSignature,
-    std::unordered_map<std::string, int>& variables,
+    const std::unordered_map<std::string, std::optional<int>>&
+        integerParameters,
     const std::unordered_map<std::string, std::string>& constraints) {
-  const auto& precisionVar = typeSignature.variables()[0];
-  const auto& scaleVar = typeSignature.variables()[1];
+  if (typeSignature.parameters().size() != 2) {
+    // Decimals must have two parameters.
+    return nullptr;
+  }
+  const auto& precisionVar = typeSignature.parameters()[0].baseName();
+  const auto& scaleVar = typeSignature.parameters()[1].baseName();
   int precision = 0;
   int scale = 0;
   // Determine precision.
   if (isPositiveInteger(precisionVar)) {
     // Handle constant.
     precision = atoi(precisionVar.c_str());
-  } else if (variables.find(precisionVar) != variables.end()) {
-    // Check if variable is already computed.
-    precision = variables[precisionVar];
+  } else if (integerParameters.count(precisionVar) > 0) {
+    const auto it = integerParameters.at(precisionVar);
+    // Check if it is already computed.
+    if (it.has_value()) {
+      precision = it.value();
+    } else if (constraints.count(precisionVar) > 0) {
+      // Check constraints and evaluate.
+      precision = expression::calculation::evaluate(
+          constraints.at(precisionVar), integerParameters);
+    } else {
+      // Cannot evaluate further.
+      return nullptr;
+    }
   } else {
-    // Check constraints and evaluate.
-    const auto& precisionConstraint = constraints.find(precisionVar);
-    VELOX_CHECK(
-        precisionConstraint != constraints.end(),
-        "Missing constraint for variable {}",
-        precisionVar);
-    auto precisionCalculation =
-        buildCalculation(precisionVar, precisionConstraint->second);
-    expression::calculation::evaluate(precisionCalculation, variables);
-    precision = variables[precisionVar];
+    return nullptr;
   }
   // Determine scale.
   if (isPositiveInteger(scaleVar)) {
     // Handle constant.
     scale = atoi(scaleVar.c_str());
-  } else if (variables.find(scaleVar) != variables.end()) {
-    // Check if variable is already computed.
-    scale = variables[scaleVar];
+  } else if (integerParameters.count(scaleVar) > 0) {
+    const auto it = integerParameters.at(scaleVar);
+    // Check if it is already computed.
+    if (it.has_value()) {
+      scale = it.value();
+    } else if (constraints.count(scaleVar) > 0) {
+      // Check constraints and evaluate.
+      scale = expression::calculation::evaluate(
+          constraints.at(scaleVar), integerParameters);
+    } else {
+      // Cannot evaluate further.
+      return nullptr;
+    }
   } else {
-    // Check constraints and evaluate.
-    const auto& scaleConstraint = constraints.find(scaleVar);
-    VELOX_CHECK(
-        scaleConstraint != constraints.end(),
-        "Missing constraint for variable {}",
-        scaleVar);
-    auto scaleCalculation = buildCalculation(scaleVar, scaleConstraint->second);
-    expression::calculation::evaluate(scaleCalculation, variables);
-    scale = variables[scaleVar];
+    return nullptr;
   }
   return DECIMAL(precision, scale);
+}
+
+bool isConcreteType(
+    const std::unordered_map<std::string, TypePtr>& typeParameters,
+    const std::unordered_map<std::string, std::optional<int>>&
+        integerParameters,
+    const std::string& name) {
+  return (typeParameters.count(name) == 0) &&
+      (integerParameters.count(name) == 0);
 }
 } // namespace
 
@@ -122,90 +133,114 @@ bool SignatureBinder::tryBind() {
   return true;
 }
 
+bool SignatureBinder::checkOrSetIntegerParameter(
+    const std::string& parameterName,
+    int value) {
+  auto it = integerParameters_.find(parameterName);
+  // Return false if the parameter is not found.
+  if (it == integerParameters_.end()) {
+    return false;
+  }
+  // Return false if the parameter is found with a different value.
+  if (it->second.has_value() && it->second.value() != value) {
+    return false;
+  }
+  it->second = value;
+  return true;
+}
+
+bool SignatureBinder::tryBindIntegerParameters(
+    const std::vector<exec::TypeSignature>& parameters,
+    const TypePtr& actualType) {
+  // Decimal types
+  if (actualType->isShortDecimal() || actualType->isLongDecimal()) {
+    VELOX_CHECK_EQ(parameters.size(), 2);
+    const auto& [precision, scale] = getDecimalPrecisionScale(*actualType);
+    return checkOrSetIntegerParameter(parameters[0].baseName(), precision) &&
+        checkOrSetIntegerParameter(parameters[1].baseName(), scale);
+  }
+  return false;
+}
+
 bool SignatureBinder::tryBind(
     const exec::TypeSignature& typeSignature,
     const TypePtr& actualType) {
   if (isAny(typeSignature)) {
     return true;
   }
-
-  auto it = bindings_.find(typeSignature.baseType());
-  if (it == bindings_.end()) {
-    // concrete type
-    auto typeName = boost::algorithm::to_upper_copy(typeSignature.baseType());
-    if (isDecimalName(typeName)) {
-      VELOX_USER_FAIL("Use 'DECIMAL' in the signature.");
-    }
-    if (isDecimalKind(actualType->kind()) && isCommonDecimalName(typeName)) {
-      const auto& variables = typeSignature.variables();
-      VELOX_CHECK_EQ(variables.size(), 2);
-      const auto& [precision, scale] = getDecimalPrecisionScale(*actualType);
-      variables_.emplace(variables[0], precision);
-      variables_.emplace(variables[1], scale);
-      return true;
-    }
+  const auto baseName = typeSignature.baseName();
+  if (isConcreteType(typeParameters_, integerParameters_, baseName)) {
+    auto typeName = boost::algorithm::to_upper_copy(baseName);
 
     if (typeName != actualType->kindName()) {
-      return false;
+      if (!(isCommonDecimalName(typeName) &&
+            (actualType->isLongDecimal() || actualType->isShortDecimal()))) {
+        return false;
+      }
     }
 
     const auto& params = typeSignature.parameters();
-    if (params.size() != actualType->size()) {
-      return false;
+    // Integer parameters have to be resolved here.
+    if (params.size() > 0 &&
+        integerParameters_.count(params[0].baseName()) != 0) {
+      return tryBindIntegerParameters(params, actualType);
     }
-
+    // Type Parameters can recurse.
     for (auto i = 0; i < params.size(); i++) {
       if (!tryBind(params[i], actualType->childAt(i))) {
         return false;
       }
     }
-
     return true;
   }
 
-  // generic type
+  // Variables cannot have further parameters.
   VELOX_CHECK_EQ(
       typeSignature.parameters().size(),
       0,
-      "Generic types with parameters are not supported");
-  if (it->second == nullptr) {
-    it->second = actualType;
-    return true;
-  }
+      "Variables with parameters are not supported");
 
-  return it->second->equivalent(*actualType);
+  // Resolve type parameters parameters.
+  if (typeParameters_.count(baseName) != 0) {
+    auto it = typeParameters_.find(baseName);
+    if (it->second == nullptr) {
+      it->second = actualType;
+      return true;
+    }
+    return it->second->equivalent(*actualType);
+  }
+  return false;
 }
 
 TypePtr SignatureBinder::tryResolveType(
     const exec::TypeSignature& typeSignature) {
-  return tryResolveType(typeSignature, bindings_, variables_, constraints_);
+  return tryResolveType(
+      typeSignature, typeParameters_, integerParameters_, constraints_);
 }
 
 // static
 TypePtr SignatureBinder::tryResolveType(
     const exec::TypeSignature& typeSignature,
-    const std::unordered_map<std::string, TypePtr>& bindings,
-    std::unordered_map<std::string, int>& variables,
+    const std::unordered_map<std::string, TypePtr>& typeParameters,
+    const std::unordered_map<std::string, std::optional<int>>&
+        integerParameters,
     const std::unordered_map<std::string, std::string>& constraints) {
-  const auto& params = typeSignature.parameters();
-
-  std::vector<TypePtr> children;
-  children.reserve(params.size());
-  for (auto& param : params) {
-    auto type = tryResolveType(param, bindings);
-    if (!type) {
-      return nullptr;
+  const auto baseName = typeSignature.baseName();
+  if (isConcreteType(typeParameters, integerParameters, baseName)) {
+    auto typeName = boost::algorithm::to_upper_copy(baseName);
+    if (isDecimalName(typeName) || isCommonDecimalName(typeName)) {
+      return inferDecimalType(typeSignature, integerParameters, constraints);
     }
-    children.emplace_back(type);
-  }
-
-  auto it = bindings.find(typeSignature.baseType());
-  if (it == bindings.end()) {
-    // concrete type
-    auto typeName = boost::algorithm::to_upper_copy(typeSignature.baseType());
-
-    if (isCommonDecimalName(typeName)) {
-      return inferDecimalType(typeSignature, variables, constraints);
+    const auto& params = typeSignature.parameters();
+    std::vector<TypePtr> children;
+    children.reserve(params.size());
+    for (auto& param : params) {
+      auto type =
+          tryResolveType(param, typeParameters, integerParameters, constraints);
+      if (!type) {
+        return nullptr;
+      }
+      children.emplace_back(type);
     }
 
     if (auto type = getType(typeName, children)) {
@@ -229,8 +264,9 @@ TypePtr SignatureBinder::tryResolveType(
       return OpaqueType::create<void>();
     }
     return createType(*typeKind, std::move(children));
+  } else if (typeParameters.count(baseName) != 0) {
+    return typeParameters.at(baseName);
   }
-
-  return it->second;
+  return nullptr;
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -30,10 +30,13 @@ class SignatureBinder {
       const exec::FunctionSignature& signature,
       const std::vector<TypePtr>& actualTypes)
       : signature_{signature}, actualTypes_{actualTypes} {
-    for (auto& variable : signature.typeVariableConstants()) {
-      bindings_.insert({variable.name(), nullptr});
-    }
-    for (auto& variable : signature.variables()) {
+    for (auto& variable : signature.typeVariableConstraints()) {
+      // Integer parameters are updated during bind.
+      if (variable.isTypeParameter()) {
+        typeParameters_.insert({variable.name(), nullptr});
+      } else if (variable.isIntegerParameter()) {
+        integerParameters_.insert({variable.name(), {}});
+      }
       if (!variable.constraint().empty()) {
         constraints_.insert({variable.name(), variable.constraint()});
       }
@@ -52,26 +55,38 @@ class SignatureBinder {
 
   static TypePtr tryResolveType(
       const exec::TypeSignature& typeSignature,
-      const std::unordered_map<std::string, TypePtr>& bindings) {
-    std::unordered_map<std::string, int> variables;
-    return tryResolveType(typeSignature, bindings, variables);
+      const std::unordered_map<std::string, TypePtr>& typeParameters) {
+    const std::unordered_map<std::string, std::optional<int>> integerParameters;
+    const std::unordered_map<std::string, std::string> constraints;
+    return tryResolveType(
+        typeSignature, typeParameters, integerParameters, constraints);
   }
   // Returns concrete return type or null if couldn't fully resolve.
   static TypePtr tryResolveType(
       const exec::TypeSignature& typeSignature,
-      const std::unordered_map<std::string, TypePtr>& bindings,
-      std::unordered_map<std::string, int>& variables,
-      const std::unordered_map<std::string, std::string>& constraints = {});
+      const std::unordered_map<std::string, TypePtr>& typeParameters,
+      const std::unordered_map<std::string, std::optional<int>>&
+          integerParameters,
+      const std::unordered_map<std::string, std::string>& constraints);
 
  private:
   bool tryBind(
       const exec::TypeSignature& typeSignature,
       const TypePtr& actualType);
 
+  // If the integer parameter is set, then it must match with value.
+  // Returns false if values do not match or the parameter does not exist.
+  bool checkOrSetIntegerParameter(const std::string& parameterName, int value);
+
+  // Try to bind the integer parameter from the actualType.
+  bool tryBindIntegerParameters(
+      const std::vector<exec::TypeSignature>& parameters,
+      const TypePtr& actualType);
+
   const exec::FunctionSignature& signature_;
   const std::vector<TypePtr>& actualTypes_;
-  std::unordered_map<std::string, TypePtr> bindings_;
-  std::unordered_map<std::string, int> variables_;
+  std::unordered_map<std::string, TypePtr> typeParameters_;
+  std::unordered_map<std::string, std::optional<int>> integerParameters_;
   std::unordered_map<std::string, std::string> constraints_;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -56,18 +56,17 @@ class SignatureBinder {
   static TypePtr tryResolveType(
       const exec::TypeSignature& typeSignature,
       const std::unordered_map<std::string, TypePtr>& typeParameters) {
-    const std::unordered_map<std::string, std::optional<int>> integerParameters;
     const std::unordered_map<std::string, std::string> constraints;
+    std::unordered_map<std::string, std::optional<int>> integerParameters;
     return tryResolveType(
-        typeSignature, typeParameters, integerParameters, constraints);
+        typeSignature, typeParameters, constraints, integerParameters);
   }
   // Returns concrete return type or null if couldn't fully resolve.
   static TypePtr tryResolveType(
       const exec::TypeSignature& typeSignature,
       const std::unordered_map<std::string, TypePtr>& typeParameters,
-      const std::unordered_map<std::string, std::optional<int>>&
-          integerParameters,
-      const std::unordered_map<std::string, std::string>& constraints);
+      const std::unordered_map<std::string, std::string>& constraints,
+      std::unordered_map<std::string, std::optional<int>>& integerParameters);
 
  private:
   bool tryBind(

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -232,10 +232,10 @@ struct CallableSignature {
 std::optional<CallableSignature> processSignature(
     const std::string& functionName,
     const exec::FunctionSignature& signature) {
-  // Don't support functions with parametrized signatures or variable number of
+  // Don't support functions with parameterized signatures or variable number of
   // arguments yet.
-  if (!signature.typeVariableConstants().empty() || signature.variableArity() ||
-      !signature.variables().empty()) {
+  if (!signature.typeVariableConstraints().empty() ||
+      signature.variableArity()) {
     LOG(WARNING) << "Skipping unsupported signature: " << functionName
                  << signature.toString();
     return std::nullopt;

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -262,7 +262,7 @@ TEST(SignatureBinderTest, decimals) {
     {
       VELOX_ASSERT_THROW(
           exec::TypeVariableConstraint(
-              "TypeName", "a = b", exec::ParameterType::TYPE_PARAMETER),
+              "TypeName", "a = b", exec::ParameterType::kTypeParameter),
           "Type parameters cannot have constraints");
     }
   }

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/expression/SignatureBinder.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 
 using namespace facebook::velox;
 
@@ -42,20 +43,24 @@ TEST(SignatureBinderTest, decimals) {
   {
     auto signature =
         exec::FunctionSignatureBuilder()
+            .integerVariable("a_precision")
+            .integerVariable("a_scale")
+            .integerVariable("b_precision")
+            .integerVariable("b_scale")
+            .integerVariable(
+                "r_precision",
+                "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
+            .integerVariable("r_scale", "max(a_scale, b_scale)")
             .returnType("decimal(r_precision, r_scale)")
             .argumentType("decimal(a_precision, a_scale)")
             .argumentType("DECIMAL(b_precision, b_scale)")
-            .variableConstraint(
-                "r_precision",
-                "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
-            .variableConstraint("r_scale", "max(a_scale, b_scale)")
             .build();
     ASSERT_EQ(
         signature->argumentTypes()[0].toString(),
-        "decimal(a_precision, a_scale)");
+        "decimal(a_precision,a_scale)");
     ASSERT_EQ(
         signature->argumentTypes()[1].toString(),
-        "DECIMAL(b_precision, b_scale)");
+        "DECIMAL(b_precision,b_scale)");
     testSignatureBinder(
         signature, {DECIMAL(11, 5), DECIMAL(10, 6)}, DECIMAL(13, 6));
   }
@@ -64,12 +69,16 @@ TEST(SignatureBinderTest, decimals) {
   {
     auto signature =
         exec::FunctionSignatureBuilder()
+            .integerVariable("a_precision")
+            .integerVariable("a_scale")
+            .integerVariable("b_precision")
+            .integerVariable("b_scale")
+            .integerVariable(
+                "r_precision", "min(38, a_precision + b_precision)")
+            .integerVariable("r_scale", "a_scale + b_scale")
             .returnType("DECIMAL(r_precision, r_scale)")
             .argumentType("decimal(a_precision, a_scale)")
             .argumentType("decimal(b_precision, b_scale)")
-            .variableConstraint(
-                "r_precision", "min(38, a_precision + b_precision)")
-            .variableConstraint("r_scale", "a_scale + b_scale")
             .build();
 
     testSignatureBinder(
@@ -80,13 +89,17 @@ TEST(SignatureBinderTest, decimals) {
   {
     auto signature =
         exec::FunctionSignatureBuilder()
+            .integerVariable("a_precision")
+            .integerVariable("a_scale")
+            .integerVariable("b_precision")
+            .integerVariable("b_scale")
+            .integerVariable(
+                "r_precision",
+                "min(38, a_precision + b_scale + max(b_scale - a_scale, 0))")
+            .integerVariable("r_scale", "max(a_scale, b_scale)")
             .returnType("DECIMAL(r_precision, r_scale)")
             .argumentType("DECIMAL(a_precision, a_scale)")
             .argumentType("DECIMAL(b_precision, b_scale)")
-            .variableConstraint(
-                "r_precision",
-                "min(38, a_precision + b_scale + max(b_scale - a_scale, 0))")
-            .variableConstraint("r_scale", "max(a_scale, b_scale)")
             .build();
 
     testSignatureBinder(
@@ -97,13 +110,17 @@ TEST(SignatureBinderTest, decimals) {
   {
     auto signature =
         exec::FunctionSignatureBuilder()
+            .integerVariable("a_precision")
+            .integerVariable("a_scale")
+            .integerVariable("b_precision")
+            .integerVariable("b_scale")
+            .integerVariable(
+                "r_precision",
+                "min(b_precision - b_scale, a_precision - a_scale) + max(a_scale, b_scale)")
+            .integerVariable("r_scale", "max(a_scale, b_scale)")
             .returnType("DECIMAL(r_precision, r_scale)")
             .argumentType("DECIMAL(a_precision, a_scale)")
             .argumentType("DECIMAL(b_precision, b_scale)")
-            .variableConstraint(
-                "r_precision",
-                "min(b_precision - b_scale, a_precision - a_scale) + max(a_scale, b_scale)")
-            .variableConstraint("r_scale", "max(a_scale, b_scale)")
             .build();
 
     testSignatureBinder(
@@ -114,6 +131,8 @@ TEST(SignatureBinderTest, decimals) {
   // Aggregate Sum.
   {
     auto signature = exec::AggregateFunctionSignatureBuilder()
+                         .integerVariable("a_precision")
+                         .integerVariable("a_scale")
                          .argumentType("DECIMAL(a_precision, a_scale)")
                          .intermediateType("DECIMAL(38, a_scale)")
                          .returnType("DECIMAL(38, a_scale)")
@@ -131,9 +150,15 @@ TEST(SignatureBinderTest, decimals) {
     ASSERT_TRUE(returnType != nullptr);
     ASSERT_TRUE(DECIMAL(38, 4)->equivalent(*returnType));
   }
-  // Error: missing constraint
+  // missing constraint returns nullptr.
   {
     auto signature = exec::FunctionSignatureBuilder()
+                         .integerVariable("a_precision")
+                         .integerVariable("a_scale")
+                         .integerVariable("b_precision")
+                         .integerVariable("b_scale")
+                         .integerVariable("r_precision")
+                         .integerVariable("r_scale")
                          .returnType("decimal(r_precision, r_scale)")
                          .argumentType("decimal(a_precision, a_scale)")
                          .argumentType("DECIMAL(b_precision, b_scale)")
@@ -141,24 +166,105 @@ TEST(SignatureBinderTest, decimals) {
     const std::vector<TypePtr> argTypes{DECIMAL(11, 5), DECIMAL(10, 6)};
     exec::SignatureBinder binder(*signature, argTypes);
     ASSERT_TRUE(binder.tryBind());
-    try {
-      binder.tryResolveReturnType();
-      FAIL();
-    } catch (const VeloxRuntimeError& e) {
-      ASSERT_EQ(e.message(), "Missing constraint for variable r_precision");
-    }
+    ASSERT_TRUE(binder.tryResolveReturnType() == nullptr);
   }
-  // Error: Do not use short_decimal or long_decimal
+  // Scalar function signature, same precision and scale.
   {
-    try {
-      auto signature = exec::FunctionSignatureBuilder()
-                           .returnType("decimal(r_precision, r_scale)")
-                           .argumentType("short_decimal(a_precision, a_scale)")
-                           .argumentType("DECIMAL(b_precision, b_scale)")
-                           .build();
-      FAIL();
-    } catch (const VeloxUserError& e) {
-      ASSERT_EQ(e.message(), "Use 'DECIMAL' in the signature.");
+    auto shortSignature =
+        exec::FunctionSignatureBuilder()
+            .integerVariable("a_precision")
+            .integerVariable("a_scale")
+            .returnType("boolean")
+            .argumentType("SHORT_DECIMAL(a_precision, a_scale)")
+            .argumentType("SHORT_DECIMAL(a_precision, a_scale)")
+            .build();
+    auto longSignature = exec::FunctionSignatureBuilder()
+                             .integerVariable("a_precision")
+                             .integerVariable("a_scale")
+                             .returnType("boolean")
+                             .argumentType("LONG_DECIMAL(a_precision, a_scale)")
+                             .argumentType("LONG_DECIMAL(a_precision, a_scale)")
+                             .build();
+    {
+      const std::vector<TypePtr> argTypes{DECIMAL(11, 5), DECIMAL(11, 5)};
+      exec::SignatureBinder binder(*shortSignature, argTypes);
+      ASSERT_TRUE(binder.tryBind());
+      auto returnType = binder.tryResolveReturnType();
+      ASSERT_TRUE(returnType != nullptr);
+      ASSERT_TRUE(BOOLEAN()->equivalent(*returnType));
+
+      // Long decimal argument types must fail binding.
+      const std::vector<TypePtr> argTypes1{DECIMAL(21, 4), DECIMAL(21, 4)};
+      exec::SignatureBinder binder1(*shortSignature, argTypes1);
+      ASSERT_FALSE(binder1.tryBind());
+    }
+
+    {
+      const std::vector<TypePtr> argTypes{DECIMAL(28, 5), DECIMAL(28, 5)};
+      exec::SignatureBinder binder(*longSignature, argTypes);
+      ASSERT_TRUE(binder.tryBind());
+      auto returnType = binder.tryResolveReturnType();
+      ASSERT_TRUE(returnType != nullptr);
+      ASSERT_TRUE(BOOLEAN()->equivalent(*returnType));
+
+      // Short decimal argument types must fail binding.
+      const std::vector<TypePtr> argTypes1{DECIMAL(14, 4), DECIMAL(14, 4)};
+      exec::SignatureBinder binder1(*longSignature, argTypes1);
+      ASSERT_FALSE(binder1.tryBind());
+    }
+
+    // Long decimal scalar function signature with precision/scale mismatch.
+    {
+      const std::vector<TypePtr> argTypes{DECIMAL(28, 5), DECIMAL(29, 5)};
+      exec::SignatureBinder binder(*longSignature, argTypes);
+      ASSERT_FALSE(binder.tryBind());
+
+      const std::vector<TypePtr> argTypes1{DECIMAL(28, 7), DECIMAL(28, 5)};
+      exec::SignatureBinder binder1(*longSignature, argTypes1);
+      ASSERT_FALSE(binder1.tryBind());
+    }
+
+    // Short decimal scalar function signature with precision/scale mismatch.
+    {
+      const std::vector<TypePtr> argTypes{DECIMAL(14, 5), DECIMAL(15, 5)};
+      exec::SignatureBinder binder(*shortSignature, argTypes);
+      ASSERT_FALSE(binder.tryBind());
+
+      const std::vector<TypePtr> argTypes1{DECIMAL(14, 5), DECIMAL(14, 6)};
+      exec::SignatureBinder binder1(*shortSignature, argTypes1);
+      ASSERT_FALSE(binder1.tryBind());
+    }
+
+    // Resolving invalid ShortDecimal/LongDecimal arguments returns nullptr.
+    {
+      // Missing constraints.
+      const auto typeSignature = shortSignature->argumentTypes()[0];
+      ASSERT_EQ(
+          exec::SignatureBinder::tryResolveType(typeSignature, {}), nullptr);
+      ASSERT_EQ(
+          exec::SignatureBinder::tryResolveType(
+              longSignature->argumentTypes()[0], {}),
+          nullptr);
+      // Missing parameters.
+      ASSERT_EQ(
+          exec::SignatureBinder::tryResolveType(
+              exec::TypeSignature("DECIMAL", {}), {}),
+          nullptr);
+      // Missing constraint value.
+      ASSERT_EQ(
+          exec::SignatureBinder::tryResolveType(
+              typeSignature,
+              {},
+              {{typeSignature.parameters()[0].baseName(), {}}},
+              {}),
+          nullptr);
+    }
+    // Type parameter + constraint = error.
+    {
+      VELOX_ASSERT_THROW(
+          exec::TypeVariableConstraint(
+              "TypeName", "a = b", exec::ParameterType::TYPE_PARAMETER),
+          "Type parameters cannot have constraints");
     }
   }
 }

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -251,12 +251,11 @@ TEST(SignatureBinderTest, decimals) {
               exec::TypeSignature("DECIMAL", {}), {}),
           nullptr);
       // Missing constraint value.
+      std::unordered_map<std::string, std::optional<int>> integerVariable;
+      integerVariable[typeSignature.parameters()[0].baseName()] = {};
       ASSERT_EQ(
           exec::SignatureBinder::tryResolveType(
-              typeSignature,
-              {},
-              {{typeSignature.parameters()[0].baseName(), {}}},
-              {}),
+              typeSignature, {}, {}, integerVariable),
           nullptr);
     }
     // Type parameter + constraint = error.

--- a/velox/expression/type_calculation/Scanner.h
+++ b/velox/expression/type_calculation/Scanner.h
@@ -30,13 +30,12 @@ class Scanner : public yyFlexLexer {
   Scanner(
       std::istream& arg_yyin,
       std::ostream& arg_yyout,
-      const std::unordered_map<std::string, std::optional<int>>& values,
-      int& result)
-      : yyFlexLexer(&arg_yyin, &arg_yyout), values_(values), result_(result){};
+      std::unordered_map<std::string, std::optional<int>>& values)
+      : yyFlexLexer(&arg_yyin, &arg_yyout), values_(values){};
   int lex(Parser::semantic_type* yylval);
 
-  void setResult(int value) {
-    result_ = value;
+  void setValue(const std::string& varName, int value) {
+    values_[varName] = value;
   }
 
   int getValue(const std::string& varName) const {
@@ -46,8 +45,7 @@ class Scanner : public yyFlexLexer {
   }
 
  private:
-  const std::unordered_map<std::string, std::optional<int>>& values_;
-  int& result_;
+  std::unordered_map<std::string, std::optional<int>>& values_;
 };
 
 } // namespace facebook::velox::expression::calculate

--- a/velox/expression/type_calculation/Scanner.h
+++ b/velox/expression/type_calculation/Scanner.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include "velox/common/base/Exceptions.h"
+
 #include <cmath>
 #include <iostream>
 #include <sstream>
@@ -28,18 +30,24 @@ class Scanner : public yyFlexLexer {
   Scanner(
       std::istream& arg_yyin,
       std::ostream& arg_yyout,
-      std::unordered_map<std::string, int>& values)
-      : yyFlexLexer(&arg_yyin, &arg_yyout), values_(values){};
+      const std::unordered_map<std::string, std::optional<int>>& values,
+      int& result)
+      : yyFlexLexer(&arg_yyin, &arg_yyout), values_(values), result_(result){};
   int lex(Parser::semantic_type* yylval);
-  void setValue(const std::string& varName, int value) {
-    values_[varName] = value;
+
+  void setResult(int value) {
+    result_ = value;
   }
+
   int getValue(const std::string& varName) const {
-    return values_.at(varName);
+    VELOX_CHECK(
+        values_.at(varName).has_value(), "Variable {} is not defined", varName);
+    return values_.at(varName).value();
   }
 
  private:
-  std::unordered_map<std::string, int>& values_;
+  const std::unordered_map<std::string, std::optional<int>>& values_;
+  int& result_;
 };
 
 } // namespace facebook::velox::expression::calculate

--- a/velox/expression/type_calculation/TypeCalculation.h
+++ b/velox/expression/type_calculation/TypeCalculation.h
@@ -20,7 +20,7 @@
 #include <unordered_map>
 
 namespace facebook::velox::expression::calculation {
-void evaluate(
+int evaluate(
     const std::string& calculation,
-    std::unordered_map<std::string, int>& variables);
+    const std::unordered_map<std::string, std::optional<int>>& variables);
 }

--- a/velox/expression/type_calculation/TypeCalculation.h
+++ b/velox/expression/type_calculation/TypeCalculation.h
@@ -20,7 +20,7 @@
 #include <unordered_map>
 
 namespace facebook::velox::expression::calculation {
-int evaluate(
+void evaluate(
     const std::string& calculation,
-    const std::unordered_map<std::string, std::optional<int>>& variables);
+    std::unordered_map<std::string, std::optional<int>>& variables);
 }

--- a/velox/expression/type_calculation/TypeCalculation.ll
+++ b/velox/expression/type_calculation/TypeCalculation.ll
@@ -35,11 +35,9 @@ int yyFlexLexer::yylex() {
 
 #include "velox/expression/type_calculation/TypeCalculation.h"
 
-int facebook::velox::expression::calculation::evaluate(const std::string& calculation, const std::unordered_map<std::string, std::optional<int>>& variables) {
+void facebook::velox::expression::calculation::evaluate(const std::string& calculation, std::unordered_map<std::string, std::optional<int>>& variables) {
     std::istringstream is(calculation);
-    int result;
-    facebook::velox::expression::calculate::Scanner scanner{ is, std::cerr, variables, result};
+    facebook::velox::expression::calculate::Scanner scanner{ is, std::cerr, variables};
     facebook::velox::expression::calculate::Parser parser{ &scanner };
     parser.parse();
-    return result;
 }

--- a/velox/expression/type_calculation/TypeCalculation.ll
+++ b/velox/expression/type_calculation/TypeCalculation.ll
@@ -35,9 +35,11 @@ int yyFlexLexer::yylex() {
 
 #include "velox/expression/type_calculation/TypeCalculation.h"
 
-void facebook::velox::expression::calculation::evaluate(const std::string& calculation, std::unordered_map<std::string, int>& variables) {
+int facebook::velox::expression::calculation::evaluate(const std::string& calculation, const std::unordered_map<std::string, std::optional<int>>& variables) {
     std::istringstream is(calculation);
-    facebook::velox::expression::calculate::Scanner scanner{ is, std::cerr, variables };
+    int result;
+    facebook::velox::expression::calculate::Scanner scanner{ is, std::cerr, variables, result};
     facebook::velox::expression::calculate::Parser parser{ &scanner };
     parser.parse();
+    return result;
 }

--- a/velox/expression/type_calculation/TypeCalculation.yy
+++ b/velox/expression/type_calculation/TypeCalculation.yy
@@ -38,7 +38,7 @@
 
 %%
 
-calc    : VAR ASSIGN iexp           { scanner->setValue($1, $3); }
+calc    :  iexp                     { scanner->setResult($1); }
         | error                     { yyerrok; }
         ;
 

--- a/velox/expression/type_calculation/TypeCalculation.yy
+++ b/velox/expression/type_calculation/TypeCalculation.yy
@@ -38,7 +38,7 @@
 
 %%
 
-calc    :  iexp                     { scanner->setResult($1); }
+calc    : VAR ASSIGN iexp           { scanner->setValue($1, $3); }
         | error                     { yyerrok; }
         ;
 

--- a/velox/functions/prestosql/DecimalArithmetic.cpp
+++ b/velox/functions/prestosql/DecimalArithmetic.cpp
@@ -265,13 +265,17 @@ decimalAddSubtractSignature() {
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> decimalDivideSignature() {
   return {exec::FunctionSignatureBuilder()
+              .integerVariable("a_precision")
+              .integerVariable("a_scale")
+              .integerVariable("b_precision")
+              .integerVariable("b_scale")
+              .integerVariable(
+                  "r_precision",
+                  "min(38, a_precision + b_scale + max(0, b_scale - a_scale))")
+              .integerVariable("r_scale", "max(a_scale, b_scale)")
               .returnType("DECIMAL(r_precision, r_scale)")
               .argumentType("DECIMAL(a_precision, a_scale)")
               .argumentType("DECIMAL(b_precision, b_scale)")
-              .variableConstraint(
-                  "r_precision",
-                  "min(38, a_precision + b_scale + max(0, b_scale - a_scale))")
-              .variableConstraint("r_scale", "max(a_scale, b_scale)")
               .build()};
 }
 

--- a/velox/functions/prestosql/DecimalArithmetic.cpp
+++ b/velox/functions/prestosql/DecimalArithmetic.cpp
@@ -231,27 +231,35 @@ class Divide {
 
 std::vector<std::shared_ptr<exec::FunctionSignature>>
 decimalMultiplySignature() {
-  return {exec::FunctionSignatureBuilder()
-              .returnType("DECIMAL(r_precision, r_scale)")
-              .argumentType("DECIMAL(a_precision, a_scale)")
-              .argumentType("DECIMAL(b_precision, b_scale)")
-              .variableConstraint(
-                  "r_precision", "min(38, a_precision + b_precision)")
-              .variableConstraint("r_scale", "a_scale + b_scale")
-              .build()};
+  return {
+      exec::FunctionSignatureBuilder()
+          .integerVariable("a_precision")
+          .integerVariable("a_scale")
+          .integerVariable("b_precision")
+          .integerVariable("b_scale")
+          .integerVariable("r_precision", "min(38, a_precision + b_precision)")
+          .integerVariable("r_scale", "a_scale + b_scale")
+          .returnType("DECIMAL(r_precision, r_scale)")
+          .argumentType("DECIMAL(a_precision, a_scale)")
+          .argumentType("DECIMAL(b_precision, b_scale)")
+          .build()};
 }
 
 std::vector<std::shared_ptr<exec::FunctionSignature>>
 decimalAddSubtractSignature() {
   return {
       exec::FunctionSignatureBuilder()
+          .integerVariable("a_precision")
+          .integerVariable("a_scale")
+          .integerVariable("b_precision")
+          .integerVariable("b_scale")
+          .integerVariable(
+              "r_precision",
+              "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
+          .integerVariable("r_scale", "max(a_scale, b_scale)")
           .returnType("DECIMAL(r_precision, r_scale)")
           .argumentType("DECIMAL(a_precision, a_scale)")
           .argumentType("DECIMAL(b_precision, b_scale)")
-          .variableConstraint(
-              "r_precision",
-              "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
-          .variableConstraint("r_scale", "max(a_scale, b_scale)")
           .build()};
 }
 

--- a/velox/functions/prestosql/aggregates/SumAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumAggregate.h
@@ -244,6 +244,8 @@ bool registerSumAggregate(const std::string& name) {
           .argumentType("double")
           .build(),
       exec::AggregateFunctionSignatureBuilder()
+          .integerVariable("a_precision")
+          .integerVariable("a_scale")
           .argumentType("DECIMAL(a_precision, a_scale)")
           .intermediateType("DECIMAL(38, a_scale)")
           .returnType("DECIMAL(38, a_scale)")


### PR DESCRIPTION
FunctionSignature and SignatureBinding have been extended to support integer variables.
This removes the need for special casing decimals and introduces a more general framework to
handle type parameters as well as integer parameters.

Resolves https://github.com/facebookincubator/velox/issues/2534