### PR TITLE
Fix common sub-expression evaluation

### DIFF
--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -54,22 +54,27 @@ class ExprTest : public testing::Test, public VectorTestBase {
         std::move(expressions), execCtx_.get());
   }
 
-  std::vector<VectorPtr> evaluateMultiple(
+  std::unique_ptr<exec::ExprSet> compileMultiple(
       const std::vector<std::string>& texts,
-      const RowVectorPtr& input) {
-    auto rowType = std::dynamic_pointer_cast<const RowType>(input->type());
+      const RowTypePtr& rowType) {
     std::vector<std::shared_ptr<const core::ITypedExpr>> expressions;
     expressions.reserve(texts.size());
     for (const auto& text : texts) {
       expressions.emplace_back(parseExpression(text, rowType));
     }
-    auto exprSet =
-        std::make_unique<exec::ExprSet>(std::move(expressions), execCtx_.get());
+    return std::make_unique<exec::ExprSet>(
+        std::move(expressions), execCtx_.get());
+  }
+
+  std::vector<VectorPtr> evaluateMultiple(
+      const std::vector<std::string>& texts,
+      const RowVectorPtr& input) {
+    auto exprSet = compileMultiple(texts, asRowType(input->type()));
 
     exec::EvalCtx context(execCtx_.get(), exprSet.get(), input.get());
 
     SelectivityVector rows(input->size());
-    std::vector<VectorPtr> result(expressions.size());
+    std::vector<VectorPtr> result(texts.size());
     exprSet->eval(rows, context, result);
     return result;
   }
@@ -758,6 +763,56 @@ TEST_F(ExprTest, csePartialEvaluation) {
   expected =
       makeFlatVector<std::string>({"a_xx", "b_xx", "c_xx", "d_xx", "e_xx"});
   assertEqualVectors(expected, results[1]);
+}
+
+TEST_F(ExprTest, csePartialEvaluationWithEncodings) {
+  auto data = makeRowVector(
+      {wrapInDictionary(
+           makeIndicesInReverse(5),
+           wrapInDictionary(
+               makeIndicesInReverse(5),
+               makeFlatVector<int64_t>({0, 10, 20, 30, 40}))),
+       makeFlatVector<int64_t>({3, 33, 333, 3333, 33333})});
+
+  // Compile the expressions once, then execute two times. First time, evaluate
+  // on 2 rows (0, 1). Seconds time, one 4 rows (0, 1, 2, 3).
+  auto exprSet = compileMultiple(
+      {
+          "concat(concat(cast(c0 as varchar), ',', cast(c1 as varchar)), 'xxx')",
+          "concat(concat(cast(c0 as varchar), ',', cast(c1 as varchar)), 'yyy')",
+      },
+      asRowType(data->type()));
+
+  std::vector<VectorPtr> results(2);
+  {
+    SelectivityVector rows(2);
+    exec::EvalCtx context(execCtx_.get(), exprSet.get(), data.get());
+    exprSet->eval(rows, context, results);
+
+    std::vector<VectorPtr> expectedResults = {
+        makeFlatVector<StringView>({"0,3xxx", "10,33xxx"}),
+        makeFlatVector<StringView>({"0,3yyy", "10,33yyy"}),
+    };
+
+    assertEqualVectors(expectedResults[0], results[0]);
+    assertEqualVectors(expectedResults[1], results[1]);
+  }
+
+  {
+    SelectivityVector rows(4);
+    exec::EvalCtx context(execCtx_.get(), exprSet.get(), data.get());
+    exprSet->eval(rows, context, results);
+
+    std::vector<VectorPtr> expectedResults = {
+        makeFlatVector<StringView>(
+            {"0,3xxx", "10,33xxx", "20,333xxx", "30,3333xxx"}),
+        makeFlatVector<StringView>(
+            {"0,3yyy", "10,33yyy", "20,333yyy", "30,3333yyy"}),
+    };
+
+    assertEqualVectors(expectedResults[0], results[0]);
+    assertEqualVectors(expectedResults[1], results[1]);
+  }
 }
 
 // Checks that vector function registry overwrites if multiple registry

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -252,12 +252,14 @@ class SelectivityVector {
         nulls->asMutable<uint64_t>(), bits_.data(), begin_, end_);
   }
 
-  /**
-   * Merges the valid vector of another SelectivityVector by or'ing
-   * them together. This is used to support memoization where a state
-   * may acquire new values over time.
-   */
+  /// Merges the valid vector of another SelectivityVector by or'ing
+  /// them together. This is used to support memoization where a state
+  /// may acquire new values over time. Grows 'this' if size of 'other' exceeds
+  /// this size.
   void select(const SelectivityVector& other) {
+    if (size_ < other.size()) {
+      resize(other.size(), false);
+    }
     bits::orBits(
         bits_.data(), other.bits_.data(), 0, std::min(size_, other.size()));
     updateBounds();

--- a/velox/vector/tests/SelectivityVectorTest.cpp
+++ b/velox/vector/tests/SelectivityVectorTest.cpp
@@ -446,7 +446,7 @@ TEST(SelectivityVectorTest, select) {
 
   SelectivityVector empty(0);
   empty.select(first);
-  ASSERT_FALSE(empty.isAllSelected());
+  ASSERT_EQ(empty, first);
 
   SelectivityVector bitAfter2(8);
   bitAfter2.setValid(0, false);
@@ -456,6 +456,41 @@ TEST(SelectivityVectorTest, select) {
   bitAfterCheck.setValid(3, true);
   bitAfterCheck.select(bitAfter2);
   assertIsValid(2, 8, bitAfterCheck, true);
+}
+
+TEST(SelectivityVectorTest, selectAndGrow) {
+  {
+    SelectivityVector a(5);
+    SelectivityVector b(7);
+    a.select(b);
+    ASSERT_EQ(a, b);
+  }
+
+  {
+    SelectivityVector a(5);
+    SelectivityVector b(10);
+    b.setValid(7, false);
+    b.updateBounds();
+
+    a.select(b);
+    ASSERT_EQ(a, b);
+  }
+
+  {
+    SelectivityVector a(5);
+    SelectivityVector b(10);
+    b.setValid(2, false);
+    b.setValid(7, false);
+    b.updateBounds();
+
+    a.select(b);
+
+    SelectivityVector expected(10);
+    expected.setValid(7, false);
+    expected.updateBounds();
+
+    ASSERT_EQ(a, expected);
+  }
 }
 
 // Sanity check for toString() method. Primarily to ensure the method doesn't


### PR DESCRIPTION
Expr::checkGetSharedSubexprValues used SelectivityVector::select to add rows
to 'sharedSubexprRows_'.

Turns out SelectivityVector::select doesn't add rows past the current size of
the vector. The following code results in 'x' having just 5 rows selected, not 7.

```
SelectivityVector x(5);
SelectivityVector y(7);
x.select(y);
```

This resulted in Expr::checkGetSharedSubexprValues setting
EvalCtx::finalSelected to a set of rows smaller than current set of rows and causing 
all sorts of trouble.

The fix here is to update SelectivityVector::select to grow the vector if needed.

Also, included a test for expression evaluation that used to fail without the fix.