### PR TITLE
Optimize clamp function

### DIFF
--- a/velox/docs/functions/math.rst
+++ b/velox/docs/functions/math.rst
@@ -21,7 +21,11 @@ Mathematical Functions
 .. function:: clamp(x, low, high) -> [same as x]
 
     Returns ``low`` if ``x`` is less than ``low``. Returns ``high`` if ``x`` is greater than ``high``.
-    Returns ``x`` otherwise. ``low`` must be less than or equal to ``high``.
+    Returns ``x`` otherwise.
+
+    ``low`` is expected to be less than or equal to ``high``. This expection is not
+    verified for performance reasons. Returns ``high`` for all values of ``x``
+    when ``low`` is greater than ``high``.
 
 .. function:: degrees(x) -> double
 

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -171,7 +171,6 @@ struct ClampFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void
   call(TInput& result, const TInput& v, const TInput& lo, const TInput& hi) {
-    VELOX_USER_CHECK_LE(lo, hi, "Lo > hi in clamp.");
     // std::clamp emits less efficient ASM
     const TInput& a = v < lo ? lo : v;
     result = a > hi ? hi : a;

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -618,8 +618,16 @@ TEST_F(ArithmeticTest, clamp) {
   EXPECT_EQ(1, clamp(1, -1, 1));
   // lo == hi != v => lo.
   EXPECT_EQ(-1, clamp(2, -1, -1));
-  // lo > hi => VeloxUserError.
-  EXPECT_THROW(clamp(0, 1, -1), VeloxUserError);
+  // lo == hi == v => v.
+  EXPECT_EQ(-1, clamp(-1, -1, -1));
+
+  // lo > hi -> hi.
+  EXPECT_EQ(clamp(-123, 1, -1), -1);
+  EXPECT_EQ(clamp(-1, 1, -1), -1);
+  EXPECT_EQ(clamp(0, 1, -1), -1);
+  EXPECT_EQ(clamp(1, 1, -1), -1);
+  EXPECT_EQ(clamp(2, 1, -1), -1);
+  EXPECT_EQ(clamp(123456, 1, -1), -1);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Checking that low <= high is expensive. Removing that check speeds up preproc
benchmark by 40%: 47ns -> 34ns (oneHot).

Removed the check and update the documentation to clarify the behavior if low >
high. The function returns high for all values in that case.

Differential Revision: D39533533

