### PR TITLE
Fix data race in exchange request detected by tsan

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -90,9 +90,7 @@ class LocalExchangeSource : public ExchangeSource {
     if (atEnd_) {
       return false;
     }
-    bool pending = requestPending_;
-    requestPending_ = true;
-    return !pending;
+    return !requestPending_.exchange(true);
   }
 
   void request() override {

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -278,7 +278,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   const int destination_;
   int64_t sequence_ = 0;
   std::shared_ptr<ExchangeQueue> queue_;
-  bool requestPending_ = false;
+  std::atomic<bool> requestPending_{false};
   bool atEnd_ = false;
 
  protected:


### PR DESCRIPTION
It is not a real data race and fix the tsan failure by changing
'requestPending_' flag in ExchangeSource to atomic type.

Verified the fix by running through
MultiFragmentTest.earlyCompletionBroadcast 100 iterations
under tsan mode on meta internal devserver