### PR TITLE
Small changes to close vector/simple gap for preproc

### DIFF
--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -511,10 +511,14 @@ class SimpleFunctionAdapter : public VectorFunction {
 
     // Compute allNotNull.
     bool allNotNull;
-    if (applyContext.context.nullsPruned()) {
+    if constexpr (FUNC::is_default_null_behavior) {
       allNotNull = true;
     } else {
-      allNotNull = (!readers.mayHaveNulls() && ...);
+      if (applyContext.context.nullsPruned()) {
+        allNotNull = true;
+      } else {
+        allNotNull = (!readers.mayHaveNulls() && ...);
+      }
     }
 
     // Iterate the rows.

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -38,9 +38,13 @@ struct VectorWriter {
   using exec_out_t = typename VectorExec::template resolver<T>::out_type;
   using vector_t = typename TypeToFlatVector<T>::type;
 
-  void init(vector_t& vector) {
+  void init(vector_t& vector, bool uniqueAndMutable = false) {
     vector_ = &vector;
-    data_ = vector.mutableRawValues();
+    if (!uniqueAndMutable || vector.rawValues() == nullptr) {
+      data_ = vector.mutableRawValues();
+    } else {
+      data_ = const_cast<exec_out_t*>(vector.rawValues());
+    }
   }
 
   void finish() {}
@@ -355,7 +359,7 @@ struct VectorWriter<
   using vector_t = typename TypeToFlatVector<T>::type;
   using exec_out_t = StringWriter<>;
 
-  void init(vector_t& vector) {
+  void init(vector_t& vector, bool uniqueAndMutable = false) {
     proxy_.vector_ = &vector;
   }
 
@@ -402,7 +406,7 @@ struct VectorWriter<T, std::enable_if_t<std::is_same_v<T, bool>>> {
   using vector_t = typename TypeToFlatVector<T>::type;
   using exec_out_t = bool;
 
-  void init(vector_t& vector) {
+  void init(vector_t& vector, bool uniqueAndMutable = false) {
     vector_ = &vector;
   }
 


### PR DESCRIPTION
Summary:
1. In the fast path iteration no need to call mutableRawValues() to retrieve data
since it's already cached in the vector writer. This reduces the call of checking
the uniqueness of the shared_ptr.
2. Find reusable args do not need to check nonflat inputs since we know they are not flat,
3. The change reduces the cost of dynamic dispatch and the cost of checking shared_ptr uniqueness.
4. No need to move results to themselves when input is not re-used.
5. No need to clear nulls when the function is default null behavior and input is reused since we know the input is not null for rows in that case.
6. When initializing the vector writer with the results vector, we call mutableRawValues, which does some checks. However, those checks are guaranteed to be satisfied when an input vector is re-used.
so we avoid those checks by passing a flag of weather input that was reused for the initialize function.

Differential Revision: D39550910

