### PR TITLE
Fix handling of lazy vectors in FilterProject operator

### DIFF
--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -80,14 +80,14 @@ FilterProject::FilterProject(
   if (numExprs_ > 0 && !identityProjections_.empty()) {
     auto inputType = project ? project->sources()[0]->outputType()
                              : filter->sources()[0]->outputType();
-    std::unordered_set<uint32_t> distinctFieldIndexes;
+    std::unordered_set<uint32_t> distinctFieldIndices;
     for (auto field : exprs_->distinctFields()) {
       auto fieldIndex = inputType->getChildIdx(field->name());
-      distinctFieldIndexes.insert(fieldIndex);
+      distinctFieldIndices.insert(fieldIndex);
     }
     for (auto identityField : identityProjections_) {
-      if (distinctFieldIndexes.find(identityField.inputChannel) !=
-          distinctFieldIndexes.end()) {
+      if (distinctFieldIndices.find(identityField.inputChannel) !=
+          distinctFieldIndices.end()) {
         multiplyReferencedFieldIndices_.push_back(identityField.inputChannel);
       }
     }
@@ -132,6 +132,7 @@ RowVectorPtr FilterProject::getOutput() {
   vector_size_t size = input_->size();
   LocalSelectivityVector localRows(*operatorCtx_->execCtx(), size);
   auto* rows = localRows.get();
+  VELOX_DCHECK_NOT_NULL(rows)
   rows->setAll();
   EvalCtx evalCtx(operatorCtx_->execCtx(), exprs_.get(), input_.get());
 

--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -16,6 +16,7 @@
 #include "velox/exec/FilterProject.h"
 #include "velox/core/Expressions.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/FieldReference.h"
 
 namespace facebook::velox::exec {
 namespace {
@@ -75,6 +76,22 @@ FilterProject::FilterProject(
   }
   numExprs_ = allExprs.size();
   exprs_ = makeExprSetFromFlag(std::move(allExprs), operatorCtx_->execCtx());
+
+  if (numExprs_ > 0 && !identityProjections_.empty()) {
+    auto inputType = project ? project->sources()[0]->outputType()
+                             : filter->sources()[0]->outputType();
+    std::unordered_set<uint32_t> distinctFieldIndexes;
+    for (auto field : exprs_->distinctFields()) {
+      auto fieldIndex = inputType->getChildIdx(field->name());
+      distinctFieldIndexes.insert(fieldIndex);
+    }
+    for (auto identityField : identityProjections_) {
+      if (distinctFieldIndexes.find(identityField.inputChannel) !=
+          distinctFieldIndexes.end()) {
+        multiplyReferencedFieldIndices_.push_back(identityField.inputChannel);
+      }
+    }
+  }
 }
 
 void FilterProject::addInput(RowVectorPtr input) {
@@ -117,6 +134,13 @@ RowVectorPtr FilterProject::getOutput() {
   auto* rows = localRows.get();
   rows->setAll();
   EvalCtx evalCtx(operatorCtx_->execCtx(), exprs_.get(), input_.get());
+
+  // Pre-load lazy vectors which are referenced by both expressions and identity
+  // projections.
+  for (auto fieldIdx : multiplyReferencedFieldIndices_) {
+    evalCtx.ensureFieldLoaded(fieldIdx, *rows);
+  }
+
   if (!hasFilter_) {
     numProcessedInputRows_ = size;
     VELOX_CHECK(!isIdentityProjection_);

--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -81,5 +81,15 @@ class FilterProject : public Operator {
   FilterEvalCtx filterEvalCtx_;
 
   vector_size_t numProcessedInputRows_{0};
+
+  // Indices for fields/input columns that are both an identity projection and
+  // are referenced by either a filter or project expression. This is used to
+  // identify fields that need to be preloaded before evaluating filters or
+  // projections.
+  // Consider projection with 2 expressions: f(c0) AND g(c1), c1
+  // If c1 is a LazyVector and f(c0) AND g(c1) expression is evaluated first, it
+  // will load c1 only for rows where f(c0) is true. However, c1 identity
+  // projection needs all rows.
+  std::vector<int32_t> multiplyReferencedFieldIndices_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -90,6 +90,6 @@ class FilterProject : public Operator {
   // If c1 is a LazyVector and f(c0) AND g(c1) expression is evaluated first, it
   // will load c1 only for rows where f(c0) is true. However, c1 identity
   // projection needs all rows.
-  std::vector<int32_t> multiplyReferencedFieldIndices_;
+  std::vector<column_index_t> multiplyReferencedFieldIndices_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/FilterProjectTest.cpp
+++ b/velox/exec/tests/FilterProjectTest.cpp
@@ -308,3 +308,28 @@ TEST_F(FilterProjectTest, filterProjectFused) {
       plan,
       "SELECT c0, c1, c0 %100 + c1 % 50, c0 % 100 FROM tmp WHERE c0 % 10 < 5");
 }
+
+TEST_F(FilterProjectTest, projectAndIdentityOverLazy) {
+  // Verify that a lazy column which is a part of both an identity projection
+  // and a regular projection is loaded correctly. This is done by running a
+  // projection that only operates over a subset of the rows of the lazy vector.
+  vector_size_t size = 20;
+  auto valueAt = [](auto row) -> int32_t { return row; };
+  auto lazyVectors = makeRowVector({
+      makeFlatVector<int32_t>(size, valueAt),
+      vectorMaker_.lazyFlatVector<int32_t>(size, valueAt),
+  });
+
+  auto vectors = makeRowVector({
+      makeFlatVector<int32_t>(size, valueAt),
+      makeFlatVector<int32_t>(size, valueAt),
+  });
+
+  createDuckDbTable({vectors});
+
+  auto plan = PlanBuilder()
+                  .values({lazyVectors})
+                  .project({"c0 < 10 AND c1 < 10", "c1"})
+                  .planNode();
+  assertQuery(plan, "SELECT c0 < 10 AND c1 < 10, c1 FROM tmp");
+}

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1321,10 +1321,9 @@ ExprSet::ExprSet(
     : execCtx_(execCtx) {
   exprs_ = compileExpressions(
       std::move(sources), execCtx, this, enableConstantFolding);
-  std::vector<FieldReference*> allDistinctFields;
   for (auto& expr : exprs_) {
     mergeFields(
-        allDistinctFields, multiplyReferencedFields_, expr->distinctFields());
+        distinctFields_, multiplyReferencedFields_, expr->distinctFields());
   }
 }
 
@@ -1428,6 +1427,7 @@ void ExprSet::clear() {
   for (auto* memo : memoizingExprs_) {
     memo->clearMemo();
   }
+  distinctFields_.clear();
   multiplyReferencedFields_.clear();
 }
 

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -386,6 +386,12 @@ using ExprPtr = std::shared_ptr<Expr>;
 // can be deduplicated. This is the top level handle on an expression
 // and is used also if only one Expr is to be evaluated. TODO: Rename to
 // ExprList.
+// Note: Caller must ensure that lazy vectors associated with field references
+// used by the expressions in this ExprSet are pre-loaded (before running
+// evaluation on them) if they are also used/referenced outside the context of
+// this ExprSet. If however such an association cannot be made with certainty,
+// then its advisable to pre-load all lazy vectors to avoid issues associated
+// with partial loading.
 class ExprSet {
  public:
   explicit ExprSet(

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -426,6 +426,10 @@ class ExprSet {
     return exprs_[index];
   }
 
+  const std::vector<FieldReference*>& distinctFields() const {
+    return distinctFields_;
+  }
+
   // Flags a shared subexpression which needs to be reset (e.g. previously
   // computed results must be deleted) when evaluating new batch of data.
   void addToReset(const std::shared_ptr<Expr>& expr) {
@@ -446,6 +450,9 @@ class ExprSet {
   void clearSharedSubexprs();
 
   std::vector<std::shared_ptr<Expr>> exprs_;
+
+  // The distinct references to input columns among all expressions in ExprSet.
+  std::vector<FieldReference * FOLLY_NONNULL> distinctFields_;
 
   // Fields referenced by multiple expressions in ExprSet.
   std::unordered_set<FieldReference * FOLLY_NONNULL> multiplyReferencedFields_;


### PR DESCRIPTION
Currently the expression evaluation via ExprSet keeps track of all
input fields that are multiply referenced among all expressions
and pre-loads them before starting evaluation. However, a
FilterProject operator can have a field that is singly referenced
among its filter and projection expressions but is also an identity
projection. This patch makes sure that these kind of fields are
identified and pre-loaded to avoid running into issues of partially
loaded lazy vectors.

Test Plan:
Added unit test