### PR TITLE
Add encoding preserving serialization for vectors

### DIFF
--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   LazyVector.cpp
   SelectivityVector.cpp
   SequenceVector.cpp
+  VectorSaver.cpp
   VectorEncoding.cpp
   VectorPool.cpp
   VectorStream.cpp)

--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -1,0 +1,653 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/vector/VectorSaver.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox {
+
+namespace {
+
+enum class Encoding : int8_t {
+  kFlat = 0,
+  kConstant = 1,
+  kDictionary = 2,
+};
+
+template <typename T>
+void write(const T& value, std::ostream& out) {
+  out.write((char*)&value, sizeof(T));
+}
+
+template <>
+void write<bool>(const bool& value, std::ostream& out) {
+  write<int8_t>(value ? 1 : 0, out);
+}
+
+template <>
+void write<std::string>(const std::string& value, std::ostream& out) {
+  write<int32_t>(value.size(), out);
+  out.write(value.data(), value.size());
+}
+
+template <typename T>
+T read(std::istream& in) {
+  T value;
+  in.read((char*)&value, sizeof(T));
+  return value;
+}
+
+template <>
+bool read<bool>(std::istream& in) {
+  int8_t value = read<int8_t>(in);
+  return value != 0;
+}
+
+template <>
+std::string read<std::string>(std::istream& in) {
+  auto size = read<int32_t>(in);
+  std::string data;
+  data.resize(size);
+  in.read(data.data(), size);
+  return data;
+}
+
+void writeEncoding(VectorEncoding::Simple encoding, std::ostream& out) {
+  switch (encoding) {
+    case VectorEncoding::Simple::FLAT:
+    case VectorEncoding::Simple::ROW:
+    case VectorEncoding::Simple::ARRAY:
+    case VectorEncoding::Simple::MAP:
+      write<int32_t>((int8_t)Encoding::kFlat, out);
+      return;
+    case VectorEncoding::Simple::CONSTANT:
+      write<int32_t>((int8_t)Encoding::kConstant, out);
+      return;
+    case VectorEncoding::Simple::DICTIONARY:
+      write<int32_t>((int8_t)Encoding::kDictionary, out);
+      return;
+    default:
+      VELOX_UNSUPPORTED("Unsupported encoding: {}", mapSimpleToName(encoding));
+  }
+}
+
+Encoding readEncoding(std::istream& in) {
+  auto encoding = Encoding(read<int32_t>(in));
+  switch (encoding) {
+    case Encoding::kFlat:
+    case Encoding::kConstant:
+    case Encoding::kDictionary:
+      return encoding;
+    default:
+      VELOX_UNSUPPORTED("Unsupported encoding: {}", encoding);
+  }
+}
+
+void writeBuffer(const BufferPtr& buffer, std::ostream& out) {
+  write<int32_t>(buffer->size(), out);
+  out.write(buffer->as<char>(), buffer->size());
+}
+
+void writeOptionalBuffer(const BufferPtr& buffer, std::ostream& out) {
+  if (buffer) {
+    write<bool>(true, out);
+    writeBuffer(buffer, out);
+  } else {
+    write<bool>(false, out);
+  }
+}
+
+BufferPtr readBuffer(std::istream& in, memory::MemoryPool* pool) {
+  auto numBytes = read<int32_t>(in);
+  auto buffer = AlignedBuffer::allocate<char>(numBytes, pool);
+  auto rawBuffer = buffer->asMutable<char>();
+  in.read(rawBuffer, numBytes);
+  return buffer;
+}
+
+BufferPtr readOptionalBuffer(std::istream& in, memory::MemoryPool* pool) {
+  bool hasBuffer = read<bool>(in);
+  if (hasBuffer) {
+    return readBuffer(in, pool);
+  }
+
+  return nullptr;
+}
+
+template <TypeKind kind>
+VectorPtr createFlat(
+    const TypePtr& type,
+    vector_size_t size,
+    velox::memory::MemoryPool* pool,
+    BufferPtr nulls,
+    BufferPtr values,
+    std::vector<BufferPtr> stringBuffers) {
+  using T = typename TypeTraits<kind>::NativeType;
+
+  return std::make_shared<FlatVector<T>>(
+      pool,
+      type,
+      std::move(nulls),
+      size,
+      std::move(values),
+      std::move(stringBuffers));
+}
+
+int32_t computeStringOffset(
+    StringView value,
+    const std::vector<BufferPtr>& stringBuffers) {
+  int32_t offset = 0;
+  for (const auto& buffer : stringBuffers) {
+    auto start = buffer->as<char>();
+
+    if (value.data() >= start && value.data() < start + buffer->size()) {
+      return (value.data() - start) + offset;
+    }
+
+    offset += buffer->size();
+  }
+
+  VELOX_FAIL("String view points outside of the string buffers");
+}
+
+const char* computeStringPointer(
+    int32_t offset,
+    const std::vector<BufferPtr>& stringBuffers) {
+  int32_t totalOffset = 0;
+  for (const auto& buffer : stringBuffers) {
+    auto size = buffer->size();
+    if (offset >= totalOffset && offset < totalOffset + size) {
+      return buffer->as<char>() + offset - totalOffset;
+    }
+
+    totalOffset += buffer->size();
+  }
+
+  VELOX_FAIL("String offset is outside of the string buffers: {}", offset);
+}
+
+void writeStringViews(
+    vector_size_t size,
+    const BufferPtr& strings,
+    const std::vector<BufferPtr>& stringBuffers,
+    std::ostream& out) {
+  write<int32_t>(strings->size(), out);
+
+  auto rawBytes = strings->as<char>();
+  auto rawValues = strings->as<StringView>();
+  for (auto i = 0; i < size; ++i) {
+    auto stringView = rawValues[i];
+    if (stringView.isInline()) {
+      out.write(rawBytes + i * sizeof(StringView), sizeof(StringView));
+    } else {
+      // Size.
+      write<int32_t>(stringView.size(), out);
+
+      // 4 bytes of zeros for prefix. We'll fill this in appropriately when
+      // deserializing.
+      write<int32_t>(0, out);
+
+      // Offset.
+      auto offset = computeStringOffset(stringView, stringBuffers);
+      write<int64_t>(offset, out);
+    }
+  }
+}
+
+void restoreVectorStringViews(
+    vector_size_t size,
+    const BufferPtr& strings,
+    const std::vector<BufferPtr>& stringBuffers) {
+  auto rawBytes = strings->as<char>();
+  auto rawValues = strings->asMutable<StringView>();
+  for (auto i = 0; i < size; ++i) {
+    auto value = rawValues[i];
+    if (!value.isInline()) {
+      auto offset = *reinterpret_cast<const int64_t*>(
+          rawBytes + i * sizeof(StringView) + 8);
+      rawValues[i] =
+          StringView(computeStringPointer(offset, stringBuffers), value.size());
+    }
+  }
+}
+
+bool isVarcharOrVarbinary(const BaseVector& vector) {
+  return vector.typeKind() == TypeKind::VARCHAR ||
+      vector.typeKind() == TypeKind::VARBINARY;
+}
+
+void writeFlatVector(const BaseVector& vector, std::ostream& out) {
+  // Nulls buffer.
+  writeOptionalBuffer(vector.nulls(), out);
+
+  // Values buffer.
+  if (isVarcharOrVarbinary(vector)) {
+    const auto& values = vector.values();
+    if (values) {
+      write<bool>(true, out);
+
+      const auto& stringBuffers =
+          vector.asFlatVector<StringView>()->stringBuffers();
+      writeStringViews(vector.size(), values, stringBuffers, out);
+    } else {
+      write<bool>(false, out);
+    }
+  } else {
+    writeOptionalBuffer(vector.values(), out);
+  }
+
+  // String buffers.
+  if (isVarcharOrVarbinary(vector)) {
+    const auto& stringBuffers =
+        vector.asFlatVector<StringView>()->stringBuffers();
+    write<int32_t>(stringBuffers.size(), out);
+
+    for (const auto& buffer : stringBuffers) {
+      writeBuffer(buffer, out);
+    }
+  }
+}
+
+VectorPtr readFlatVector(
+    const TypePtr& type,
+    vector_size_t size,
+    std::istream& in,
+    memory::MemoryPool* pool) {
+  // Nulls buffer.
+  BufferPtr nulls = readOptionalBuffer(in, pool);
+
+  // Values buffer.
+  BufferPtr values = readOptionalBuffer(in, pool);
+
+  // String buffers.
+  std::vector<BufferPtr> stringBuffers;
+  if (type->isVarchar() || type->isVarbinary()) {
+    int32_t numStringBuffers = read<int32_t>(in);
+    for (auto i = 0; i < numStringBuffers; ++i) {
+      stringBuffers.push_back(readBuffer(in, pool));
+    }
+
+    // Update the pointers in the StringViews.
+    if (values) {
+      restoreVectorStringViews(size, values, stringBuffers);
+    }
+  }
+
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
+      createFlat, type->kind(), type, size, pool, nulls, values, stringBuffers);
+}
+
+template <TypeKind kind>
+void writeScalarConstant(const BaseVector& vector, std::ostream& out) {
+  using T = typename TypeTraits<kind>::NativeType;
+
+  auto value = vector.as<ConstantVector<T>>()->valueAt(0);
+  out.write((const char*)&value, sizeof(T));
+
+  if constexpr (std::is_same_v<T, StringView>) {
+    if (!value.isInline()) {
+      write<int32_t>(value.size(), out);
+      out.write(value.data(), value.size());
+    }
+  }
+}
+
+void writeConstantVector(const BaseVector& vector, std::ostream& out) {
+  bool isNull = vector.isNullAt(0);
+  write<bool>(isNull, out);
+
+  if (isNull) {
+    return;
+  }
+
+  auto baseVector = vector.valueVector();
+  write<bool>(baseVector == nullptr, out);
+
+  if (baseVector) {
+    saveVector(*baseVector, out);
+    write<int32_t>(vector.as<ConstantVector<ComplexType>>()->index(), out);
+  } else {
+    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
+        writeScalarConstant, vector.typeKind(), vector, out);
+  }
+}
+
+template <TypeKind kind>
+VectorPtr readConstant(
+    const TypePtr& /* type */,
+    vector_size_t size,
+    velox::memory::MemoryPool* pool,
+    std::istream& in) {
+  using T = typename TypeTraits<kind>::NativeType;
+
+  T value = read<T>(in);
+
+  if constexpr (std::is_same_v<T, StringView>) {
+    if (!value.isInline()) {
+      auto stringSize = read<int32_t>(in);
+      BufferPtr stringBuffer = AlignedBuffer::allocate<char>(stringSize, pool);
+      in.read(stringBuffer->template asMutable<char>(), stringSize);
+
+      return std::make_shared<ConstantVector<T>>(
+          pool, size, false, StringView(stringBuffer->as<char>(), stringSize));
+    }
+  }
+
+  return std::make_shared<ConstantVector<T>>(
+      pool, size, false, std::move(value));
+}
+
+VectorPtr readConstantVector(
+    const TypePtr& type,
+    vector_size_t size,
+    std::istream& in,
+    memory::MemoryPool* pool) {
+  // Is-null flag.
+  auto isNull = read<bool>(in);
+
+  if (isNull) {
+    return BaseVector::createNullConstant(type, size, pool);
+  }
+
+  bool scalar = read<bool>(in);
+  if (scalar) {
+    return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
+        readConstant, type->kind(), type, size, pool, in);
+  }
+
+  auto baseVector = restoreVector(in, pool);
+  auto baseIndex = read<int32_t>(in);
+
+  return BaseVector::wrapInConstant(size, baseIndex, baseVector);
+}
+
+void writeDictionaryVector(const BaseVector& vector, std::ostream& out) {
+  // Nulls buffer.
+  writeOptionalBuffer(vector.nulls(), out);
+
+  // Indices buffer.
+  writeBuffer(vector.wrapInfo(), out);
+
+  // Base vector.
+  saveVector(*vector.valueVector(), out);
+}
+
+VectorPtr readDictionaryVector(
+    const TypePtr& /*type*/,
+    vector_size_t size,
+    std::istream& in,
+    memory::MemoryPool* pool) {
+  // Nulls buffer.
+  BufferPtr nulls = readOptionalBuffer(in, pool);
+
+  // Indices buffer.
+  BufferPtr indices = readBuffer(in, pool);
+
+  // Base vector.
+  auto baseVector = restoreVector(in, pool);
+
+  return BaseVector::wrapInDictionary(nulls, indices, size, baseVector);
+}
+
+void writeRowVector(const BaseVector& vector, std::ostream& out) {
+  // Nulls buffer.
+  writeOptionalBuffer(vector.nulls(), out);
+
+  auto rowVector = vector.as<RowVector>();
+
+  // Child vectors.
+  auto numChildren = rowVector->childrenSize();
+  write<int32_t>(numChildren, out);
+
+  for (auto i = 0; i < numChildren; ++i) {
+    const auto& child = rowVector->childAt(i);
+
+    write<bool>(child != nullptr, out);
+    if (child) {
+      saveVector(*child, out);
+    }
+  }
+}
+
+VectorPtr readRowVector(
+    const TypePtr& type,
+    vector_size_t size,
+    std::istream& in,
+    memory::MemoryPool* pool) {
+  // Nulls buffer.
+  BufferPtr nulls = readOptionalBuffer(in, pool);
+
+  // Child vectors.
+  auto numChildren = read<int32_t>(in);
+  std::vector<VectorPtr> children;
+  children.reserve(numChildren);
+  for (auto i = 0; i < numChildren; ++i) {
+    bool present = read<bool>(in);
+    if (present) {
+      children.push_back(restoreVector(in, pool));
+    } else {
+      children.push_back(nullptr);
+    }
+  }
+
+  return std::make_shared<RowVector>(pool, type, nulls, size, children);
+}
+
+void writeArrayVector(const BaseVector& vector, std::ostream& out) {
+  // Nulls buffer.
+  writeOptionalBuffer(vector.nulls(), out);
+
+  // Offsets and sizes.
+  auto arrayVector = vector.as<ArrayVector>();
+  writeBuffer(arrayVector->offsets(), out);
+  writeBuffer(arrayVector->sizes(), out);
+
+  // Elements vector.
+  saveVector(*arrayVector->elements(), out);
+}
+
+VectorPtr readArrayVector(
+    const TypePtr& type,
+    vector_size_t size,
+    std::istream& in,
+    memory::MemoryPool* pool) {
+  // Nulls buffer.
+  BufferPtr nulls = readOptionalBuffer(in, pool);
+
+  BufferPtr offsets = readBuffer(in, pool);
+  BufferPtr sizes = readBuffer(in, pool);
+
+  auto elements = restoreVector(in, pool);
+
+  return std::make_shared<ArrayVector>(
+      pool, type, nulls, size, offsets, sizes, elements);
+}
+
+void writeMapVector(const BaseVector& vector, std::ostream& out) {
+  // Nulls buffer.
+  writeOptionalBuffer(vector.nulls(), out);
+
+  // Offsets and sizes.
+  auto mapVector = vector.as<MapVector>();
+  writeBuffer(mapVector->offsets(), out);
+  writeBuffer(mapVector->sizes(), out);
+
+  // Keys and values vectors.
+  saveVector(*mapVector->mapKeys(), out);
+  saveVector(*mapVector->mapValues(), out);
+}
+
+VectorPtr readMapVector(
+    const TypePtr& type,
+    vector_size_t size,
+    std::istream& in,
+    memory::MemoryPool* pool) {
+  // Nulls buffer.
+  BufferPtr nulls = readOptionalBuffer(in, pool);
+
+  BufferPtr offsets = readBuffer(in, pool);
+  BufferPtr sizes = readBuffer(in, pool);
+
+  auto keys = restoreVector(in, pool);
+  auto values = restoreVector(in, pool);
+
+  return std::make_shared<MapVector>(
+      pool, type, nulls, size, offsets, sizes, keys, values);
+}
+} // namespace
+
+void saveType(const TypePtr& type, std::ostream& out) {
+  // Type kind.
+  write(static_cast<int>(type->kind()), out);
+
+  switch (type->kind()) {
+    case TypeKind::BOOLEAN:
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::INTEGER:
+    case TypeKind::BIGINT:
+    case TypeKind::REAL:
+    case TypeKind::DOUBLE:
+    case TypeKind::VARCHAR:
+    case TypeKind::VARBINARY:
+    case TypeKind::TIMESTAMP:
+    case TypeKind::DATE:
+    case TypeKind::UNKNOWN:
+      break;
+    case TypeKind::ROW: {
+      // Number of children.
+      write<int32_t>(type->size(), out);
+
+      // Child types.
+      const auto& names = type->asRow().names();
+      for (auto i = 0; i < type->size(); ++i) {
+        write<int32_t>(names[i].size(), out);
+        out.write(names[i].data(), names[i].size());
+        saveType(type->childAt(i), out);
+      }
+      break;
+    }
+    case TypeKind::ARRAY:
+      saveType(type->childAt(0), out);
+      break;
+    case TypeKind::MAP:
+      saveType(type->childAt(0), out);
+      saveType(type->childAt(1), out);
+      break;
+    default:
+      VELOX_UNSUPPORTED("Unsupported type: {}", type->toString());
+  }
+}
+
+TypePtr restoreType(std::istream& in) {
+  // Type kind.
+  auto typeKind = TypeKind(read<int32_t>(in));
+
+  if (typeKind == TypeKind::UNKNOWN) {
+    return UNKNOWN();
+  }
+
+  if (typeKind == TypeKind::ROW) {
+    // Number of children.
+    auto numChildren = read<int32_t>(in);
+
+    std::vector<std::string> names;
+    std::vector<TypePtr> types;
+    for (auto i = 0; i < numChildren; ++i) {
+      names.push_back(read<std::string>(in));
+      types.push_back(restoreType(in));
+    }
+
+    return ROW(std::move(names), std::move(types));
+  }
+
+  if (typeKind == TypeKind::ARRAY) {
+    return ARRAY(restoreType(in));
+  }
+
+  if (typeKind == TypeKind::MAP) {
+    auto keyType = restoreType(in);
+    auto valueType = restoreType(in);
+    return MAP(keyType, valueType);
+  }
+
+  return createScalarType(typeKind);
+}
+
+void saveVector(const BaseVector& vector, std::ostream& out) {
+  // Encoding.
+  writeEncoding(vector.encoding(), out);
+
+  // Type kind.
+  saveType(vector.type(), out);
+
+  // Vector size.
+  write(vector.size(), out);
+
+  switch (vector.encoding()) {
+    case VectorEncoding::Simple::FLAT:
+      writeFlatVector(vector, out);
+      return;
+    case VectorEncoding::Simple::CONSTANT:
+      writeConstantVector(vector, out);
+      return;
+    case VectorEncoding::Simple::DICTIONARY:
+      writeDictionaryVector(vector, out);
+      return;
+    case VectorEncoding::Simple::ROW:
+      writeRowVector(vector, out);
+      return;
+    case VectorEncoding::Simple::ARRAY:
+      writeArrayVector(vector, out);
+      return;
+    case VectorEncoding::Simple::MAP:
+      writeMapVector(vector, out);
+      return;
+    default:
+      VELOX_UNSUPPORTED(
+          "Unsupported encoding: {}", mapSimpleToName(vector.encoding()));
+  }
+}
+
+VectorPtr restoreVector(std::istream& in, memory::MemoryPool* pool) {
+  // Encoding.
+  auto encoding = readEncoding(in);
+
+  // Type kind.
+  auto type = restoreType(in);
+
+  // Vector size.
+  auto size = read<int32_t>(in);
+
+  switch (encoding) {
+    case Encoding::kFlat:
+      if (type->isRow()) {
+        return readRowVector(type, size, in, pool);
+      } else if (type->isArray()) {
+        return readArrayVector(type, size, in, pool);
+      } else if (type->isMap()) {
+        return readMapVector(type, size, in, pool);
+      }
+      return readFlatVector(type, size, in, pool);
+    case Encoding::kConstant:
+      return readConstantVector(type, size, in, pool);
+    case Encoding::kDictionary:
+      return readDictionaryVector(type, size, in, pool);
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+} // namespace facebook::velox

--- a/velox/vector/VectorSaver.h
+++ b/velox/vector/VectorSaver.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox {
+
+/// Serializes the type into binary format and writes it to the provided
+/// output stream. Used for testing.
+void saveType(const TypePtr& type, std::ostream& out);
+
+/// Deserializes a type serialized by 'saveType' from the provided input stream.
+/// Used for testing.
+TypePtr restoreType(std::istream& in);
+
+/// Serializes the vector into binary format and writes it to the provided
+/// output stream. The serialiation preserved encoding.
+void saveVector(const BaseVector& vector, std::ostream& out);
+
+/// Deserializes a vector serialized by 'save' from the provided input stream.
+VectorPtr restoreVector(std::istream& in, memory::MemoryPool* pool);
+} // namespace facebook::velox

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_subdirectory(utils)
 add_executable(
   velox_vector_test
   VectorCompareTest.cpp
+  VectorSaverTest.cpp
   VectorMakerTest.cpp
   VectorPoolTest.cpp
   VectorTest.cpp
@@ -39,6 +40,8 @@ target_link_libraries(
   velox_serialization
   velox_memory
   velox_presto_serializer
+  velox_temp_path
+  velox_vector_fuzzer
   ${Boost_ATOMIC_LIBRARIES}
   ${Boost_CONTEXT_LIBRARIES}
   ${Boost_DATE_TIME_LIBRARIES}

--- a/velox/vector/tests/VectorSaverTest.cpp
+++ b/velox/vector/tests/VectorSaverTest.cpp
@@ -1,0 +1,515 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/vector/VectorSaver.h"
+#include <fstream>
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/exec/tests/utils/TempFilePath.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::test {
+
+class VectorSaverTest : public testing::Test, public VectorTestBase {
+ protected:
+  void SetUp() override {
+    LOG(ERROR) << "Seed: " << seed_;
+  }
+
+  void assertEqualEncodings(
+      const VectorPtr& expected,
+      const VectorPtr& actual) {
+    ASSERT_EQ(expected->encoding(), actual->encoding());
+    ASSERT_EQ(*expected->type(), *actual->type());
+    assertEqualVectors(expected, actual);
+
+    // Recursively compare inner vectors to ensure that all layers of wrappings
+    // are the same.
+    switch (expected->encoding()) {
+      case VectorEncoding::Simple::CONSTANT:
+      case VectorEncoding::Simple::DICTIONARY:
+        if (expected->valueVector()) {
+          ASSERT_TRUE(actual->valueVector() != nullptr);
+          assertEqualEncodings(expected->valueVector(), actual->valueVector());
+        } else {
+          ASSERT_TRUE(actual->valueVector() == nullptr);
+        }
+        break;
+      case VectorEncoding::Simple::ARRAY:
+        assertEqualEncodings(
+            expected->as<ArrayVector>()->elements(),
+            actual->as<ArrayVector>()->elements());
+        break;
+      case VectorEncoding::Simple::MAP:
+        assertEqualEncodings(
+            expected->as<MapVector>()->mapKeys(),
+            actual->as<MapVector>()->mapKeys());
+        assertEqualEncodings(
+            expected->as<MapVector>()->mapValues(),
+            actual->as<MapVector>()->mapValues());
+        break;
+      case VectorEncoding::Simple::ROW: {
+        auto expectedRow = expected->as<RowVector>();
+        auto actualRow = actual->as<RowVector>();
+        for (auto i = 0; i < expectedRow->childrenSize(); ++i) {
+          ASSERT_EQ(
+              expectedRow->childAt(i) != nullptr,
+              actualRow->childAt(i) != nullptr);
+          if (expectedRow->childAt(i)) {
+            assertEqualEncodings(
+                expectedRow->childAt(i), actualRow->childAt(i));
+          }
+        }
+        break;
+      }
+      default:
+          // Do nothing.
+          ;
+    }
+  }
+
+  VectorFuzzer::Options fuzzerOptions() {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = 128;
+    opts.stringVariableLength = true;
+    opts.stringLength = 64;
+    return opts;
+  }
+
+  void testRoundTrip(VectorFuzzer::Options options, const TypePtr& type) {
+    SCOPED_TRACE(fmt::format("seed: {}", seed_));
+    VectorFuzzer fuzzer(options, pool(), seed_);
+    testRoundTrip(fuzzer.fuzzFlat(type));
+  }
+
+  void testRoundTrip(const VectorPtr& vector) {
+    auto path = exec::test::TempFilePath::create();
+
+    std::ofstream outputFile(path->path, std::ofstream::binary);
+    saveVector(*vector, outputFile);
+    outputFile.close();
+
+    std::ifstream inputFile(path->path, std::ifstream::binary);
+    auto copy = restoreVector(inputFile, pool());
+    inputFile.close();
+
+    // Verify encodings and data recursively.
+    assertEqualEncodings(vector, copy);
+  }
+
+  void testTypeRoundTrip(const TypePtr& type) {
+    auto path = exec::test::TempFilePath::create();
+
+    std::ofstream outputFile(path->path, std::ofstream::binary);
+    saveType(type, outputFile);
+    outputFile.close();
+
+    std::ifstream inputFile(path->path, std::ifstream::binary);
+    auto copy = restoreType(inputFile);
+    inputFile.close();
+
+    ASSERT_EQ(*type, *copy)
+        << "Expected: " << type->toString() << ". Got: " << copy->toString();
+  }
+
+  template <typename T>
+  void testFlatIntegers() {
+    // No nulls.
+    testRoundTrip(makeFlatVector<T>({1, 2, 3, 4, 5}));
+
+    // Some nulls.
+    testRoundTrip(
+        makeNullableFlatVector<T>({1, std::nullopt, 3, std::nullopt, 5}));
+
+    // Empty vector.
+    testRoundTrip(BaseVector::create(CppToType<T>::create(), 0, pool()));
+
+    // Long vector.
+    testRoundTrip(makeFlatVector<T>(10'000, [](auto row) { return row; }));
+
+    // Long vector with nulls.
+    testRoundTrip(makeFlatVector<T>(
+        10'000, [](auto row) { return row; }, nullEvery(17)));
+  }
+
+  const uint32_t seed_{folly::Random::rand32()};
+};
+
+TEST_F(VectorSaverTest, types) {
+  testTypeRoundTrip(BOOLEAN());
+
+  testTypeRoundTrip(TINYINT());
+  testTypeRoundTrip(SMALLINT());
+  testTypeRoundTrip(INTEGER());
+  testTypeRoundTrip(BIGINT());
+
+  testTypeRoundTrip(REAL());
+  testTypeRoundTrip(DOUBLE());
+
+  testTypeRoundTrip(VARCHAR());
+  testTypeRoundTrip(VARBINARY());
+
+  testTypeRoundTrip(TIMESTAMP());
+  testTypeRoundTrip(DATE());
+
+  testTypeRoundTrip(ARRAY(BIGINT()));
+  testTypeRoundTrip(ARRAY(ARRAY(VARCHAR())));
+
+  testTypeRoundTrip(MAP(INTEGER(), REAL()));
+  testTypeRoundTrip(MAP(VARCHAR(), ARRAY(BIGINT())));
+  testTypeRoundTrip(MAP(BIGINT(), MAP(INTEGER(), DOUBLE())));
+
+  testTypeRoundTrip(ROW({}, {}));
+  testTypeRoundTrip(ROW({"a", "b", "c"}, {INTEGER(), BOOLEAN(), VARCHAR()}));
+  testTypeRoundTrip(
+      ROW({"a", "b", "c"},
+          {INTEGER(), ARRAY(BOOLEAN()), MAP(VARCHAR(), VARCHAR())}));
+  testTypeRoundTrip(
+      ROW({"a", "b"}, {ROW({"c", "d"}, {VARCHAR(), DATE()}), INTEGER()}));
+
+  testTypeRoundTrip(UNKNOWN());
+
+  ASSERT_THROW(testTypeRoundTrip(OPAQUE<std::string>()), VeloxUserError);
+}
+
+TEST_F(VectorSaverTest, flatBigint) {
+  testFlatIntegers<int64_t>();
+}
+
+TEST_F(VectorSaverTest, flatInteger) {
+  testFlatIntegers<int32_t>();
+}
+
+TEST_F(VectorSaverTest, flatSmallint) {
+  testFlatIntegers<int16_t>();
+}
+
+TEST_F(VectorSaverTest, flatTinyint) {
+  testFlatIntegers<int8_t>();
+}
+
+TEST_F(VectorSaverTest, flatBoolean) {
+  // No nulls.
+  testRoundTrip(makeFlatVector<bool>({true, false, true, true, false}));
+
+  // Some nulls.
+  testRoundTrip(makeNullableFlatVector<bool>(
+      {true, std::nullopt, true, std::nullopt, false}));
+
+  // Empty vector.
+  testRoundTrip(BaseVector::create(BOOLEAN(), 0, pool()));
+
+  // Long vector.
+  testRoundTrip(
+      makeFlatVector<bool>(10'000, [](auto row) { return row % 7 == 2; }));
+
+  // Long vector with nulls.
+  testRoundTrip(makeFlatVector<bool>(
+      10'000, [](auto row) { return row % 2 == 1; }, nullEvery(17)));
+}
+
+TEST_F(VectorSaverTest, flatVarchar) {
+  VectorFuzzer::Options opts = fuzzerOptions();
+
+  testRoundTrip(opts, VARCHAR());
+
+  // Add some nulls.
+  opts.nullRatio = 0.1;
+  testRoundTrip(opts, VARCHAR());
+
+  // Make short strings only.
+  opts.stringLength = 6;
+  opts.vectorSize = 1024;
+  testRoundTrip(opts, VARCHAR());
+}
+
+TEST_F(VectorSaverTest, row) {
+  auto opts = fuzzerOptions();
+
+  auto flatRowType =
+      ROW({"a_i8", "b_i16", "c_i32", "d_i64", "e_bool", "f_varchar"},
+          {TINYINT(), SMALLINT(), INTEGER(), BIGINT(), BOOLEAN(), VARCHAR()});
+  auto nestedRowType =
+      ROW({"a", "b"},
+          {INTEGER(), ROW({"b1", "b2", "b3"}, {BIGINT(), REAL(), DOUBLE()})});
+
+  testRoundTrip(opts, flatRowType);
+  testRoundTrip(opts, nestedRowType);
+
+  // Add some nulls.
+  opts.nullRatio = 0.1;
+  testRoundTrip(opts, flatRowType);
+  testRoundTrip(opts, nestedRowType);
+}
+
+TEST_F(VectorSaverTest, array) {
+  auto opts = fuzzerOptions();
+
+  testRoundTrip(opts, ARRAY(BIGINT()));
+  testRoundTrip(opts, ARRAY(VARCHAR()));
+
+  // Add some nulls.
+  opts.nullRatio = 0.1;
+  testRoundTrip(opts, ARRAY(BIGINT()));
+  testRoundTrip(opts, ARRAY(VARCHAR()));
+}
+
+TEST_F(VectorSaverTest, map) {
+  auto opts = fuzzerOptions();
+
+  testRoundTrip(opts, MAP(INTEGER(), REAL()));
+  testRoundTrip(opts, MAP(BIGINT(), VARCHAR()));
+
+  // Add some nulls.
+  opts.nullRatio = 0.1;
+  testRoundTrip(opts, MAP(INTEGER(), REAL()));
+  testRoundTrip(opts, MAP(BIGINT(), VARCHAR()));
+}
+
+TEST_F(VectorSaverTest, constantInteger) {
+  testRoundTrip(makeConstant<int64_t>(-1234987634, 100));
+  testRoundTrip(makeConstant<int32_t>(12389, 100));
+  testRoundTrip(makeConstant<int16_t>(1032, 100));
+  testRoundTrip(makeConstant<int8_t>(78, 100));
+
+  // Nulls.
+  testRoundTrip(makeConstant<int64_t>(std::nullopt, 100));
+  testRoundTrip(makeConstant<int32_t>(std::nullopt, 100));
+  testRoundTrip(makeConstant<int16_t>(std::nullopt, 100));
+  testRoundTrip(makeConstant<int8_t>(std::nullopt, 100));
+}
+
+TEST_F(VectorSaverTest, constantBoolean) {
+  testRoundTrip(makeConstant<bool>(true, 100));
+  testRoundTrip(makeConstant<bool>(false, 100));
+
+  // Null.
+  testRoundTrip(makeConstant<bool>(std::nullopt, 100));
+}
+
+TEST_F(VectorSaverTest, constantString) {
+  testRoundTrip(makeConstant<std::string>("", 100));
+  testRoundTrip(makeConstant<std::string>("Short.", 100));
+  testRoundTrip(
+      makeConstant<std::string>("This is somewhat longer string.", 100));
+
+  // Null.
+  testRoundTrip(makeConstant<std::string>(std::nullopt, 100));
+}
+
+TEST_F(VectorSaverTest, constantUnknown) {
+  testRoundTrip(BaseVector::createNullConstant(UNKNOWN(), 100, pool()));
+}
+
+TEST_F(VectorSaverTest, constantMap) {
+  auto opts = fuzzerOptions();
+  SCOPED_TRACE(fmt::format("seed: {}", seed_));
+
+  VectorFuzzer fuzzer(opts, pool(), seed_);
+  auto mapType = MAP(INTEGER(), VARCHAR());
+  auto flatVector = fuzzer.fuzzFlat(mapType);
+  testRoundTrip(BaseVector::wrapInConstant(100, 17, flatVector));
+
+  // Null.
+  testRoundTrip(BaseVector::createNullConstant(mapType, 100, pool()));
+}
+
+TEST_F(VectorSaverTest, constantArray) {
+  auto opts = fuzzerOptions();
+  SCOPED_TRACE(fmt::format("seed: {}", seed_));
+
+  VectorFuzzer fuzzer(opts, pool(), seed_);
+  auto arrayType = ARRAY(BIGINT());
+  auto flatVector = fuzzer.fuzzFlat(arrayType);
+  testRoundTrip(BaseVector::wrapInConstant(100, 23, flatVector));
+
+  // Null.
+  testRoundTrip(BaseVector::createNullConstant(arrayType, 100, pool()));
+}
+
+TEST_F(VectorSaverTest, constantRow) {
+  auto opts = fuzzerOptions();
+  SCOPED_TRACE(fmt::format("seed: {}", seed_));
+
+  VectorFuzzer fuzzer(opts, pool(), seed_);
+  auto rowType = ROW({"a", "b"}, {INTEGER(), REAL()});
+  auto flatVector = fuzzer.fuzzRow(rowType);
+  testRoundTrip(BaseVector::wrapInConstant(100, 51, flatVector));
+
+  // Null.
+  testRoundTrip(BaseVector::createNullConstant(rowType, 100, pool()));
+}
+
+TEST_F(VectorSaverTest, dictionaryBigint) {
+  // No nulls. One level.
+  auto data = wrapInDictionary(
+      makeIndicesInReverse(5), makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5}));
+  testRoundTrip(data);
+
+  // No nulls. 2 levels.
+  data = wrapInDictionary(
+      makeIndicesInReverse(5),
+      wrapInDictionary(
+          makeIndicesInReverse(5),
+          makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5})));
+  testRoundTrip(data);
+
+  // Nulls.
+  data = BaseVector::wrapInDictionary(
+      makeNulls(100, nullEvery(7)),
+      makeIndicesInReverse(100),
+      100,
+      makeFlatVector<int64_t>(100, [](auto row) { return row; }));
+  testRoundTrip(data);
+
+  data = wrapInDictionary(
+      makeOddIndices(40),
+      BaseVector::wrapInDictionary(
+          makeNulls(100, nullEvery(7)),
+          makeIndicesInReverse(100),
+          100,
+          makeFlatVector<int64_t>(100, [](auto row) { return row; })));
+  testRoundTrip(data);
+
+  // All-nulls dictionary vector over empty base vector.
+  data = std::make_shared<DictionaryVector<int64_t>>(
+      pool(),
+      makeNulls(100, nullEvery(1)),
+      100,
+      BaseVector::create(BIGINT(), 0, pool()),
+      makeIndices(100, [](auto /* row */) { return 0; }));
+  testRoundTrip(data);
+}
+
+TEST_F(VectorSaverTest, dictionaryArray) {
+  auto opts = fuzzerOptions();
+  SCOPED_TRACE(fmt::format("seed: {}", seed_));
+
+  VectorFuzzer fuzzer(opts, pool(), seed_);
+  auto flatVector = fuzzer.fuzzFlat(ARRAY(INTEGER()));
+
+  testRoundTrip(fuzzer.fuzzDictionary(flatVector));
+  testRoundTrip(fuzzer.fuzzDictionary(flatVector, 64));
+  testRoundTrip(fuzzer.fuzzDictionary(flatVector, 512));
+
+  // 2 levels of dictionary.
+  testRoundTrip(fuzzer.fuzzDictionary(fuzzer.fuzzDictionary(flatVector)));
+
+  // Array vector with dictionary-encoded elements vector.
+  auto elementsVector = fuzzer.fuzzDictionary(fuzzer.fuzzFlat(INTEGER()));
+  // 0, 2, 4,...
+  auto offsets = makeEvenIndices(64);
+  auto sizes = makeIndices(64, [](auto /* row */) { return 2; });
+
+  testRoundTrip(std::make_shared<ArrayVector>(
+      pool(),
+      ARRAY(INTEGER()),
+      makeNulls(64, nullEvery(7)),
+      64,
+      offsets,
+      sizes,
+      elementsVector));
+}
+
+TEST_F(VectorSaverTest, dictionaryMap) {
+  auto opts = fuzzerOptions();
+  SCOPED_TRACE(fmt::format("seed: {}", seed_));
+
+  VectorFuzzer fuzzer(opts, pool(), seed_);
+  auto flatVector = fuzzer.fuzzFlat(MAP(INTEGER(), VARCHAR()));
+
+  testRoundTrip(fuzzer.fuzzDictionary(flatVector));
+  testRoundTrip(fuzzer.fuzzDictionary(flatVector, 64));
+  testRoundTrip(fuzzer.fuzzDictionary(flatVector, 512));
+
+  // 2 levels of dictionary.
+  testRoundTrip(fuzzer.fuzzDictionary(fuzzer.fuzzDictionary(flatVector)));
+}
+
+TEST_F(VectorSaverTest, dictionaryRow) {
+  auto opts = fuzzerOptions();
+  SCOPED_TRACE(fmt::format("seed: {}", seed_));
+
+  VectorFuzzer fuzzer(opts, pool(), seed_);
+  auto flatVector =
+      fuzzer.fuzzFlat(ROW({"a", "b", "c"}, {INTEGER(), REAL(), BOOLEAN()}));
+
+  testRoundTrip(fuzzer.fuzzDictionary(flatVector));
+  testRoundTrip(fuzzer.fuzzDictionary(flatVector, 64));
+  testRoundTrip(fuzzer.fuzzDictionary(flatVector, 512));
+
+  // 2 levels of dictionary.
+  testRoundTrip(fuzzer.fuzzDictionary(fuzzer.fuzzDictionary(flatVector)));
+}
+
+namespace {
+struct VectorSaverInfo {
+  // Path to directory where to store the vector.
+  const char* path;
+
+  // Vector to store.
+  BaseVector* vector;
+};
+
+/// Generates a file path in specified directory. Returns std::nullopt on
+/// failure.
+std::optional<std::string> generateFilePath(const char* basePath) {
+  auto path = fmt::format("{}/velox_vector_XXXXXX", basePath);
+  auto fd = mkstemp(path.data());
+  if (fd == -1) {
+    return std::nullopt;
+  }
+  return path;
+}
+} // namespace
+
+/// A demonstration of using VectorSaver to save 'current' vector being
+/// processed to disk in case of an exception.
+TEST_F(VectorSaverTest, exceptionContext) {
+  auto tempDirectory = exec::test::TempDirectoryPath::create();
+
+  auto messageFunction = [](auto* arg) -> std::string {
+    auto* info = static_cast<VectorSaverInfo*>(arg);
+    auto filePath = generateFilePath(info->path);
+    if (!filePath.has_value()) {
+      return "Cannot generate file path to store the vector.";
+    }
+
+    std::ofstream outputFile(filePath.value(), std::ofstream::binary);
+    saveVector(*info->vector, outputFile);
+    outputFile.close();
+
+    return filePath.value();
+  };
+
+  VectorPtr data = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  VectorSaverInfo info{tempDirectory.get()->path.c_str(), data.get()};
+  {
+    ExceptionContextSetter context({messageFunction, &info});
+    try {
+      VELOX_FAIL("Test failure.");
+    } catch (VeloxRuntimeError& e) {
+      auto path = e.context();
+      std::ifstream inputFile(path, std::ifstream::binary);
+      ASSERT_FALSE(inputFile.fail()) << "Cannot open file: " << path;
+      auto copy = restoreVector(inputFile, pool());
+      inputFile.close();
+
+      // Verify encodings and data recursively.
+      assertEqualEncodings(data, copy);
+    }
+  }
+}
+} // namespace facebook::velox::test


### PR DESCRIPTION
Add VectorSaver utility to save vectors with possibly multiple layers of
encodings to disk and restore these back in a different process.

This PR includes support for flat, constant and dictionary vectors of 
scalar and complex data types.

We can integrate this tool with expression evaluation to save the input vector 
on exception. We already use ExceptionContextSetter to add expression text 
in the Context field of the exception. We can extend it to also include the path 
of the file that has the input data. Here is an example:

```
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: (8 vs. 12) Malformed dictionary, index array is shorter than DictionaryVector
Retriable: False
Expression: dictionaryIndices->size() >= length * sizeof(vector_size_t)
Context: concat(cast((c0) as VARCHAR), ,:VARCHAR). Input: /tmp/velox_vector_f7dneH.
Function: DictionaryVector
File: .../velox/vector/DictionaryVector-inl.h
Line: 107
```

“Input: /tmp/velox_vector_f7dneH” in the Context: field shows the file path that 
contains the input data for the expression..

We can read it in a unit test:

```
#include <fstream>
#include "velox/vector/VectorSaver.h"

std::ifstream inputFile("/tmp/velox_vector_f7dneH", std::ifstream::binary);
auto data = restoreVector(inputFile, pool());
inputFile.close();
  
std::cout << data->toString() << std::endl;
std::cout << data->toString(0, 5) << std::endl;
```

“concat(cast((c0) as VARCHAR), ,:VARCHAR)” 
shows the expression. We can evaluate it (with minimal tweaking to replace ,:VARCHAR with ‘,’):

```
  auto result = evaluate(
      "concat(cast((c0) as VARCHAR), ',')",
      std::dynamic_pointer_cast<RowVector>(data));
```