### PR TITLE
[CMake] Modernize boost package uses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,17 +227,15 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(Boost_USE_MULTITHREADED TRUE)
 find_package(
-  Boost
-  1.66.0
-  REQUIRED
-  program_options
-  context
-  filesystem
-  regex
-  thread
-  system
-  date_time
-  atomic)
+  Boost 1.66.0 REQUIRED
+  COMPONENTS program_options
+             context
+             filesystem
+             regex
+             thread
+             system
+             date_time
+             atomic)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 # Range-v3 will be enable when the codegen code actually lands keeping it here

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -87,14 +87,14 @@ target_link_libraries(
   velox_vector_fuzzer
   velox_memory
   velox_dwio_common_exception
-  ${Boost_ATOMIC_LIBRARIES}
-  ${Boost_CONTEXT_LIBRARIES}
-  ${Boost_DATE_TIME_LIBRARIES}
-  ${Boost_FILESYSTEM_LIBRARIES}
-  ${Boost_PROGRAM_OPTIONS_LIBRARIES}
-  ${Boost_REGEX_LIBRARIES}
-  ${Boost_THREAD_LIBRARIES}
-  ${Boost_SYSTEM_LIBRARIES}
+  Boost::atomic
+  Boost::context
+  Boost::date_time
+  Boost::filesystem
+  Boost::program_options
+  Boost::regex
+  Boost::thread
+  Boost::system
   gtest
   gtest_main
   gmock

--- a/velox/experimental/codegen/benchmark/CMakeLists.txt
+++ b/velox/experimental/codegen/benchmark/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(
   velox_hive_connector
   ${FOLLY_BENCHMARK}
   ${FOLLY_WITH_DEPENDENCIES}
-  ${Boost_FILESYSTEM_LIBRARIES}
+  Boost::filesystem
   gtest
   gtest_main
   ${GFLAGS_LIBRARIES}
@@ -89,7 +89,7 @@ target_link_libraries(
   velox_codegen_code_generator
   ${FOLLY_BENCHMARK}
   ${FOLLY_WITH_DEPENDENCIES}
-  ${Boost_FILESYSTEM_LIBRARIES}
+  Boost::filesystem
   gtest
   gtest_main
   ${GFLAGS_LIBRARIES}

--- a/velox/experimental/codegen/compiler_utils/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/compiler_utils/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(
   velox_transform_utils
   velox_codegen_proto
   velox_exception
-  ${Boost_FILESYSTEM_LIBRARIES}
+  Boost::filesystem
   gtest
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}

--- a/velox/experimental/codegen/external_process/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/external_process/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(
   gtest
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}
-  ${Boost_FILESYSTEM_LIBRARIES}
+  Boost::filesystem
   ${DOUBLE_CONVERSION}
   ${GFLAGS_LIBRARIES}
   glog::glog

--- a/velox/experimental/codegen/transform/utils/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/transform/utils/tests/CMakeLists.txt
@@ -25,14 +25,14 @@ target_link_libraries(
   velox_transform_utils_test
   velox_transform_utils
   ${ANTLR4_RUNTIME}
-  ${Boost_ATOMIC_LIBRARIES}
-  ${Boost_CONTEXT_LIBRARIES}
-  ${Boost_DATE_TIME_LIBRARIES}
-  ${Boost_FILESYSTEM_LIBRARIES}
-  ${Boost_PROGRAM_OPTIONS_LIBRARIES}
-  ${Boost_REGEX_LIBRARIES}
-  ${Boost_THREAD_LIBRARIES}
-  ${Boost_SYSTEM_LIBRARIES}
+  Boost::atomic
+  Boost::context
+  Boost::date_time
+  Boost::filesystem
+  Boost::program_options
+  Boost::regex
+  Boost::thread
+  Boost::system
   ${gflags_LIBRARIES}
   gtest
   gtest_main

--- a/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
@@ -42,14 +42,14 @@ target_link_libraries(
   velox_presto_serializer
   velox_transform_utils
   ${ANTLR4_RUNTIME}
-  ${Boost_ATOMIC_LIBRARIES}
-  ${Boost_CONTEXT_LIBRARIES}
-  ${Boost_DATE_TIME_LIBRARIES}
-  ${Boost_FILESYSTEM_LIBRARIES}
-  ${Boost_PROGRAM_OPTIONS_LIBRARIES}
-  ${Boost_REGEX_LIBRARIES}
-  ${Boost_THREAD_LIBRARIES}
-  ${Boost_SYSTEM_LIBRARIES}
+  Boost::atomic
+  Boost::context
+  Boost::date_time
+  Boost::filesystem
+  Boost::program_options
+  Boost::regex
+  Boost::thread
+  Boost::system
   ${gflags_LIBRARIES}
   gtest
   gtest_main

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -48,14 +48,14 @@ target_link_libraries(
   velox_vector
   velox_memory
   velox_dwio_common_exception
-  ${Boost_ATOMIC_LIBRARIES}
-  ${Boost_CONTEXT_LIBRARIES}
-  ${Boost_DATE_TIME_LIBRARIES}
-  ${Boost_FILESYSTEM_LIBRARIES}
-  ${Boost_PROGRAM_OPTIONS_LIBRARIES}
-  ${Boost_REGEX_LIBRARIES}
-  ${Boost_THREAD_LIBRARIES}
-  ${Boost_SYSTEM_LIBRARIES}
+  Boost::atomic
+  Boost::context
+  Boost::date_time
+  Boost::filesystem
+  Boost::program_options
+  Boost::regex
+  Boost::thread
+  Boost::system
   gtest
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -39,5 +39,5 @@ target_link_libraries(
   velox_exception
   velox_serialization
   velox_external_date
-  ${Boost_REGEX_LIBRARIES}
+  Boost::regex
   ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/type/tz/CMakeLists.txt
+++ b/velox/type/tz/CMakeLists.txt
@@ -16,5 +16,5 @@ if(${VELOX_BUILD_TESTING})
 endif()
 add_library(velox_type_tz TimeZoneMap.h TimeZoneDatabase.cpp TimeZoneMap.cpp)
 
-target_link_libraries(velox_type_tz ${Boost_REGEX_LIBRARIES} ${FMT}
+target_link_libraries(velox_type_tz Boost::regex ${FMT}
                       ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -42,14 +42,14 @@ target_link_libraries(
   velox_presto_serializer
   velox_temp_path
   velox_vector_fuzzer
-  ${Boost_ATOMIC_LIBRARIES}
-  ${Boost_CONTEXT_LIBRARIES}
-  ${Boost_DATE_TIME_LIBRARIES}
-  ${Boost_FILESYSTEM_LIBRARIES}
-  ${Boost_PROGRAM_OPTIONS_LIBRARIES}
-  ${Boost_REGEX_LIBRARIES}
-  ${Boost_THREAD_LIBRARIES}
-  ${Boost_SYSTEM_LIBRARIES}
+  Boost::atomic
+  Boost::context
+  Boost::date_time
+  Boost::filesystem
+  Boost::program_options
+  Boost::regex
+  Boost::thread
+  Boost::system
   gtest
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}


### PR DESCRIPTION
Use `Boost::`-prefixed imported targets when linking boost libraries to velox libs instead of using old-style `Boost_XYZ_LIBRARIES` variables.

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>