### PR TITLE
[Build] Add missing `wget` install for `setup-ubuntu.sh`

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -50,7 +50,8 @@ sudo --preserve-env apt install -y \
   liblzo2-dev \
   bison \
   flex \
-  tzdata
+  tzdata \
+  wget
 
 function run_and_time {
   time "$@"


### PR DESCRIPTION
The patch fixes a build regression introduced in the following commit: https://github.com/facebookincubator/velox/pull/2383/commits/eebdd357c192d4a22e879bbbf87878b53d2278ac

`setup-ubuntu.sh` now makes some calls to `wget` utility, but it can happen that `wget` is not installed yet, for example:

The script does not run cleanly when building a development container via `docker-compose build ubuntu-cpp`, failing with the following error message:

```
+ run_and_time install_protobuf
+ install_protobuf
+ Finished running install_folly
+ wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz
/velox/scripts/setup-ubuntu.sh: line 86: wget: command not found

real    0m0.001s
user    0m0.000s
sys     0m0.001s
ERROR: Service 'ubuntu-cpp' failed to build: The command '/bin/bash -o pipefail -c /velox/scripts/setup-ubuntu.sh' returned a non-zero code: 127
```

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>