### PR TITLE
Add disk spilling support for hash join build side

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -652,10 +652,14 @@ std::string blockingReasonToString(BlockingReason reason) {
       return "kWaitForExchange";
     case BlockingReason::kWaitForJoinBuild:
       return "kWaitForJoinBuild";
+    case BlockingReason::kWaitForJoinProbe:
+      return "kWaitForJoinProbe";
     case BlockingReason::kWaitForMemory:
       return "kWaitForMemory";
     case BlockingReason::kWaitForConnector:
       return "kWaitForConnector";
+    case BlockingReason::kWaitForSpill:
+      return "kWaitForSpill";
   }
   VELOX_UNREACHABLE();
   return "";

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -124,8 +124,14 @@ enum class BlockingReason {
   kWaitForSplit,
   kWaitForExchange,
   kWaitForJoinBuild,
+  /// Build operator is blocked waiting for the probe operators to finish
+  /// probing before build the next hash table from the previously spilled data.
+  kWaitForJoinProbe,
   kWaitForMemory,
   kWaitForConnector,
+  /// Build operator is blocked waiting for all its peers to stop to run group
+  /// spill on all of them.
+  kWaitForSpill,
 };
 
 std::string blockingReasonToString(BlockingReason reason);

--- a/velox/exec/HashBitRange.h
+++ b/velox/exec/HashBitRange.h
@@ -25,7 +25,10 @@ namespace facebook::velox::exec {
 class HashBitRange {
  public:
   HashBitRange(uint8_t begin, uint8_t end)
-      : begin_(begin), end_(end), fieldMask_(bits::lowMask(end - begin)) {}
+      : begin_(begin), end_(end), fieldMask_(bits::lowMask(end - begin)) {
+    VELOX_CHECK_LE(begin_, end_);
+    VELOX_CHECK_LE(end_, 64);
+  }
   HashBitRange() : HashBitRange(0, 0) {}
 
   int32_t partition(uint64_t hash, int32_t numPartitions) const {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -19,6 +19,25 @@
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
+namespace {
+// Map HashBuild 'state' to the corresponding driver blocking reason.
+BlockingReason fromStateToBlockingReason(HashBuild::State state) {
+  switch (state) {
+    case HashBuild::State::kRunning:
+      FOLLY_FALLTHROUGH;
+    case HashBuild::State::kFinish:
+      return BlockingReason::kNotBlocked;
+    case HashBuild::State::kWaitForSpill:
+      return BlockingReason::kWaitForSpill;
+    case HashBuild::State::kWaitForBuild:
+      return BlockingReason::kWaitForJoinBuild;
+    case HashBuild::State::kWaitForProbe:
+      return BlockingReason::kWaitForJoinProbe;
+    default:
+      VELOX_UNREACHABLE(HashBuild::stateName(state));
+  }
+}
+} // namespace
 
 HashBuild::HashBuild(
     int32_t operatorId,
@@ -26,13 +45,22 @@ HashBuild::HashBuild(
     std::shared_ptr<const core::HashJoinNode> joinNode)
     : Operator(driverCtx, nullptr, operatorId, joinNode->id(), "HashBuild"),
       joinNode_(std::move(joinNode)),
-      joinType_(joinNode_->joinType()),
-      joinBridge_(operatorCtx_->task()->getHashJoinBridgeLocked(
+      joinType_{joinNode_->joinType()},
+      mappedMemory_(operatorCtx_->mappedMemory()),
+      joinBride_(operatorCtx_->task()->getHashJoinBridgeLocked(
           operatorCtx_->driverCtx()->splitGroupId,
           planNodeId())),
-      mappedMemory_(operatorCtx_->mappedMemory()) {
-  VELOX_CHECK_NOT_NULL(joinBridge_);
-  joinBridge_->addBuilder();
+      spillConfig_(makeOperatorSpillConfig(
+          *operatorCtx_->task()->queryCtx(),
+          *operatorCtx_,
+          operatorId)),
+      spillGroup_(
+          spillEnabled() ? operatorCtx_->task()->getSpillOperatorGroupLocked(
+                               operatorCtx_->driverCtx()->splitGroupId,
+                               planNodeId())
+                         : nullptr) {
+  VELOX_CHECK_NOT_NULL(joinBride_);
+  joinBride_->addBuilder();
 
   auto outputType = joinNode_->sources()[1]->outputType();
 
@@ -68,6 +96,7 @@ HashBuild::HashBuild(
 
   tableType_ = ROW(std::move(names), std::move(types));
   setupTable();
+  setupSpiller();
 }
 
 void HashBuild::setupTable() {
@@ -113,7 +142,72 @@ void HashBuild::setupTable() {
   analyzeKeys_ = table_->hashMode() != BaseHashTable::HashMode::kHash;
 }
 
+void HashBuild::setupSpiller(SpillPartition* spillPartition) {
+  VELOX_CHECK_NULL(spiller_);
+  VELOX_CHECK_NULL(spillInputReader_);
+
+  if (!spillEnabled()) {
+    return;
+  }
+
+  const auto& spillConfig = spillConfig_.value();
+  HashBitRange hashBits = spillConfig.hashBitRange;
+  if (spillPartition != nullptr) {
+    const auto startBit = spillPartition->id().partitionBitOffset() +
+        spillConfig.hashBitRange.numBits();
+    hashBits =
+        HashBitRange(startBit, startBit + spillConfig.hashBitRange.numBits());
+  }
+  spiller_ = std::make_unique<Spiller>(
+      Spiller::Type::kHashJoinBuild,
+      table_->rows(),
+      [&](folly::Range<char**> rows) { table_->rows()->eraseRows(rows); },
+      tableType_,
+      std::move(hashBits),
+      keyChannels_.size(),
+      std::vector<CompareFlags>(),
+      spillConfig.filePath,
+      operatorCtx_->task()
+              ->queryCtx()
+              ->pool()
+              ->getMemoryUsageTracker()
+              ->maxTotalBytes() *
+          spillConfig.fileSizeFactor,
+      Spiller::spillPool(),
+      spillConfig.executor);
+
+  if (spillPartition == nullptr) {
+    spillGroup_->addOperator(
+        *this,
+        [&](const std::vector<Operator*>& operators) { runSpill(operators); });
+  } else {
+    spillInputReader_ = spillPartition->createReader();
+  }
+  const int32_t numPartitions = spiller_->hashBits().numPartitions();
+  spillInputIndicesBuffers_.resize(numPartitions);
+  rawSpillInputIndicesBuffers_.resize(numPartitions);
+  numSpillInputs_.resize(numPartitions, 0);
+  spillChildVectors_.resize(tableType_->size());
+}
+
+bool HashBuild::isInputFromSpill() const {
+  return spillInputReader_ != nullptr;
+}
+
+RowTypePtr HashBuild::inputType() const {
+  return isInputFromSpill() ? tableType_
+                            : joinNode_->sources()[1]->outputType();
+}
+
 void HashBuild::addInput(RowVectorPtr input) {
+  checkRunning();
+
+  if (!ensureInputFits(input)) {
+    VELOX_CHECK_NOT_NULL(input_);
+    VELOX_CHECK(future_.valid());
+    return;
+  }
+
   activeRows_.resize(input->size());
   activeRows_.setAll();
 
@@ -138,8 +232,13 @@ void HashBuild::addInput(RowVectorPtr input) {
     }
   }
 
-  if (analyzeKeys_ && hashes_.size() < activeRows_.size()) {
-    hashes_.resize(activeRows_.size());
+  spillInput(input);
+  if (!activeRows_.hasSelections()) {
+    return;
+  }
+
+  if (analyzeKeys_ && hashes_.size() < activeRows_.end()) {
+    hashes_.resize(activeRows_.end());
   }
 
   // As long as analyzeKeys is true, we keep running the keys through
@@ -178,12 +277,316 @@ void HashBuild::addInput(RowVectorPtr input) {
   });
 }
 
-void HashBuild::noMoreInput() {
-  if (noMoreInput_) {
+bool HashBuild::ensureInputFits(RowVectorPtr& input) {
+  // NOTE: we don't need memory reservation if all the partitions are spilling
+  // as we spill all the input rows to disk directly.
+  if (!spillEnabled() || spiller_->isAllSpilled()) {
+    return true;
+  }
+
+  // NOTE: we simply reserve memory all inputs even though some of them are
+  // spilling directly. It is okay as we will accumulate the extra reservation
+  // in the operator's memory pool, and won't make any new reservation if there
+  // is already sufficient reservations.
+  if (!reserveMemory(input)) {
+    if (!requestSpill(input)) {
+      return false;
+    }
+  } else {
+    // Check if any other peer operator has requested group spill.
+    if (waitSpill(input)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool HashBuild::reserveMemory(const RowVectorPtr& input) {
+  VELOX_CHECK(spillEnabled());
+
+  numSpillRows_ = 0;
+  numSpillBytes_ = 0;
+
+  auto rows = table_->rows();
+  auto numRows = rows->numRows();
+  if (numRows == 0) {
+    // Skip the memory reservation for the first input as we are lack of memory
+    // usage stats for estimation. It is safe to skip as the query should have
+    // sufficient memory initially.
+    return true;
+  }
+
+  auto [freeRows, outOfLineFreeBytes] = rows->freeSpace();
+  auto outOfLineBytes =
+      rows->stringAllocator().retainedSize() - outOfLineFreeBytes;
+  auto outOfLineBytesPerRow = std::max<uint64_t>(1, outOfLineBytes / numRows);
+  int64_t flatBytes = input->estimateFlatSize();
+
+  // Test-only spill path.
+  if (testingTriggerSpill()) {
+    numSpillRows_ = std::max<int64_t>(1, numRows / 10);
+    numSpillBytes_ = numSpillRows_ * outOfLineBytesPerRow;
+    return false;
+  }
+
+  if (freeRows > input->size() &&
+      (outOfLineBytes == 0 || outOfLineFreeBytes >= flatBytes)) {
+    // Enough free rows for input rows and enough variable length free
+    // space for the flat size of the whole vector. If outOfLineBytes
+    // is 0 there is no need for variable length space.
+    return true;
+  }
+
+  // If there is variable length data we take the flat size of the
+  // input as a cap on the new variable length data needed.
+  const auto increment =
+      rows->sizeIncrement(input->size(), outOfLineBytes ? flatBytes : 0);
+
+  auto tracker = CHECK_NOTNULL(mappedMemory_->tracker());
+  // There must be at least 2x the increments in reservation.
+  if (tracker->getAvailableReservation() > 2 * increment) {
+    return true;
+  }
+
+  // Check if we can increase reservation. The increment is the larger of
+  // twice the maximum increment from this input and
+  // 'spillableReservationGrowthPct_' of the current reservation.
+  auto targetIncrement = std::max<int64_t>(
+      increment * 2,
+      tracker->getCurrentUserBytes() *
+          spillConfig()->spillableReservationGrowthPct / 100);
+  if (tracker->maybeReserve(targetIncrement)) {
+    return true;
+  }
+  numSpillRows_ = std::max<int64_t>(
+      1, targetIncrement / (rows->fixedRowSize() + outOfLineBytesPerRow));
+  numSpillBytes_ = numSpillRows_ * outOfLineBytesPerRow;
+  return false;
+}
+
+void HashBuild::spillInput(const RowVectorPtr& input) {
+  VELOX_CHECK_EQ(input->size(), activeRows_.size());
+
+  if (!spillEnabled() || !spiller_->isAnySpilled() ||
+      !activeRows_.hasSelections()) {
     return;
   }
 
+  const auto numInput = input->size();
+  prepareInputIndicesBuffers(numInput, spiller_->spilledPartitionSet());
+  computeSpillPartitions(input);
+
+  vector_size_t numSpillInputs = 0;
+  for (auto row = 0; row < numInput; ++row) {
+    const auto partition = spillPartitions_[row];
+    if (FOLLY_UNLIKELY(!activeRows_.isValid(row))) {
+      continue;
+    }
+    if (!spiller_->isSpilled(partition)) {
+      continue;
+    }
+    activeRows_.setValid(row, false);
+    ++numSpillInputs;
+    rawSpillInputIndicesBuffers_[partition][numSpillInputs_[partition]++] = row;
+  }
+  if (numSpillInputs == 0) {
+    return;
+  }
+
+  maybeSetupSpillChildVectors(input);
+
+  for (uint32_t partition = 0; partition < numSpillInputs_.size();
+       ++partition) {
+    const int numInputs = numSpillInputs_[partition];
+    if (numInputs == 0) {
+      continue;
+    }
+    VELOX_CHECK(spiller_->isSpilled(partition));
+    spillPartition(
+        partition, numInputs, spillInputIndicesBuffers_[partition], input);
+  }
+  activeRows_.updateBounds();
+}
+
+void HashBuild::maybeSetupSpillChildVectors(const RowVectorPtr& input) {
+  if (isInputFromSpill()) {
+    return;
+  }
+  int32_t spillChannel = 0;
+  for (const auto& channel : keyChannels_) {
+    spillChildVectors_[spillChannel++] = input->childAt(channel);
+  }
+  for (const auto& channel : dependentChannels_) {
+    spillChildVectors_[spillChannel++] = input->childAt(channel);
+  }
+}
+
+void HashBuild::prepareInputIndicesBuffers(
+    vector_size_t numInput,
+    const SpillPartitionNumSet& spillPartitions) {
+  for (const auto& partition : spillPartitions) {
+    if (spillInputIndicesBuffers_[partition] == nullptr ||
+        (spillInputIndicesBuffers_[partition]->size() < numInput)) {
+      spillInputIndicesBuffers_[partition] = allocateIndices(numInput, pool());
+      rawSpillInputIndicesBuffers_[partition] =
+          spillInputIndicesBuffers_[partition]->asMutable<vector_size_t>();
+    }
+  }
+  std::fill(numSpillInputs_.begin(), numSpillInputs_.end(), 0);
+}
+
+void HashBuild::computeSpillPartitions(const RowVectorPtr& input) {
+  if (hashes_.size() < activeRows_.end()) {
+    hashes_.resize(activeRows_.end());
+  }
+  const auto& hashers = table_->hashers();
+  for (auto i = 0; i < hashers.size(); ++i) {
+    auto& hasher = hashers[i];
+    if (hasher->channel() != kConstantChannel) {
+      hashers[i]->hash(activeRows_, i > 0, hashes_);
+    } else {
+      hashers[i]->hashPrecomputed(activeRows_, i > 0, hashes_);
+    }
+  }
+
+  spillPartitions_.resize(input->size());
+  for (auto i = 0; i < spillPartitions_.size(); ++i) {
+    spillPartitions_[i] = spiller_->hashBits().partition(hashes_[i]);
+  }
+}
+
+void HashBuild::spillPartition(
+    uint32_t partition,
+    vector_size_t size,
+    const BufferPtr& indices,
+    const RowVectorPtr& input) {
+  VELOX_DCHECK(spillEnabled());
+
+  if (isInputFromSpill()) {
+    spiller_->spill(partition, wrap(size, indices, input));
+  } else {
+    spiller_->spill(
+        partition,
+        wrap(size, indices, tableType_, spillChildVectors_, input->pool()));
+  }
+}
+
+bool HashBuild::requestSpill(RowVectorPtr& input) {
+  VELOX_CHECK_GT(numSpillRows_, 0);
+  VELOX_CHECK_GT(numSpillBytes_, 0);
+
+  input_ = std::move(input);
+  if (spillGroup_->requestSpill(*this, future_)) {
+    VELOX_CHECK(future_.valid());
+    setState(State::kWaitForSpill);
+    return false;
+  }
+  input = std::move(input_);
+  return true;
+}
+
+bool HashBuild::waitSpill(RowVectorPtr& input) {
+  if (!spillGroup_->needSpill()) {
+    return false;
+  }
+
+  if (spillGroup_->waitSpill(*this, future_)) {
+    VELOX_CHECK(future_.valid());
+    input_ = std::move(input);
+    setState(State::kWaitForSpill);
+    return true;
+  }
+  return false;
+}
+
+void HashBuild::runSpill(const std::vector<Operator*>& spillOperators) {
+  VELOX_CHECK(spillEnabled());
+  VELOX_CHECK(!spiller_->state().isAllPartitionSpilled());
+
+  uint64_t targetRows = 0;
+  uint64_t targetBytes = 0;
+  std::vector<Spiller*> spillers;
+  spillers.reserve(spillOperators.size());
+  for (auto& spillOp : spillOperators) {
+    HashBuild* build = dynamic_cast<HashBuild*>(spillOp);
+    VELOX_CHECK_NOT_NULL(build);
+    spillers.push_back(build->spiller_.get());
+    build->addAndClearSpillTarget(targetRows, targetBytes);
+  }
+  VELOX_CHECK_GT(targetRows, 0);
+  VELOX_CHECK_GT(targetBytes, 0);
+
+  std::vector<Spiller::SpillableStats> spillableStats(
+      spiller_->hashBits().numPartitions());
+  for (auto* spiller : spillers) {
+    spiller->fillSpillRuns(spillableStats);
+  }
+
+  // Sort the partitions based on the amount of spillable data.
+  SpillPartitionNumSet partitionsToSpill;
+  std::vector<int32_t> partitionIndices(spillableStats.size());
+  std::iota(partitionIndices.begin(), partitionIndices.end(), 0);
+  std::sort(
+      partitionIndices.begin(),
+      partitionIndices.end(),
+      [&](int32_t lhs, int32_t rhs) {
+        return spillableStats[lhs].numBytes > spillableStats[rhs].numBytes;
+      });
+  int64_t numRows = 0;
+  int64_t numBytes = 0;
+  for (auto partitionNum : partitionIndices) {
+    if (spillableStats[partitionNum].numBytes == 0) {
+      break;
+    }
+    partitionsToSpill.insert(partitionNum);
+    numRows += spillableStats[partitionNum].numRows;
+    numBytes += spillableStats[partitionNum].numBytes;
+    if (numRows >= targetRows && numBytes >= targetBytes) {
+      break;
+    }
+  }
+  VELOX_CHECK(!partitionsToSpill.empty());
+
+  // TODO: consider to offload the partition spill processing to an executor to
+  // run in parallel.
+  for (auto* spiller : spillers) {
+    spiller->spill(partitionsToSpill);
+  }
+}
+
+void HashBuild::addAndClearSpillTarget(uint64_t& numRows, uint64_t& numBytes) {
+  numRows += numSpillRows_;
+  numSpillRows_ = 0;
+  numBytes += numSpillBytes_;
+  numSpillBytes_ = 0;
+}
+
+void HashBuild::noMoreInput() {
+  checkRunning();
+
+  if (noMoreInput_) {
+    return;
+  }
   Operator::noMoreInput();
+
+  noMoreInputInternal();
+}
+
+void HashBuild::noMoreInputInternal() {
+  if (spillEnabled()) {
+    spillGroup_->operatorStopped(*this);
+  }
+
+  if (!finishHashBuild()) {
+    return;
+  }
+
+  postHashBuildProcess();
+}
+
+bool HashBuild::finishHashBuild() {
+  checkRunning();
+
   std::vector<ContinuePromise> promises;
   std::vector<std::shared_ptr<Driver>> peers;
   // The last Driver to hit HashBuild::finish gathers the data from
@@ -193,12 +596,14 @@ void HashBuild::noMoreInput() {
   // build pipeline.
   if (!operatorCtx_->task()->allPeersFinished(
           planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
-    return;
+    setState(State::kWaitForBuild);
+    return false;
   }
 
   std::vector<std::unique_ptr<BaseHashTable>> otherTables;
   otherTables.reserve(peers.size());
-
+  SpillPartitionSet spillPartitions;
+  Spiller::Stats spillStats;
   if (!antiJoinHasNullKeys_) {
     for (auto& peer : peers) {
       auto op = peer->findOperator(planNodeId());
@@ -209,7 +614,40 @@ void HashBuild::noMoreInput() {
         break;
       }
       otherTables.push_back(std::move(build->table_));
+      if (build->spiller_ != nullptr) {
+        spillStats += build->spiller_->stats();
+        build->spiller_->finishSpill(spillPartitions);
+      }
     }
+
+    if (spiller_ != nullptr) {
+      spillStats += spiller_->stats();
+
+      stats_.spilledBytes = spillStats.spilledBytes;
+      stats_.spilledRows = spillStats.spilledRows;
+      stats_.spilledPartitions = spillStats.spilledPartitions;
+
+      spiller_->finishSpill(spillPartitions);
+
+      // Remove empty partitions.
+      auto iter = spillPartitions.begin();
+      while (iter != spillPartitions.end()) {
+        if (iter->second->numFiles() == 0) {
+          iter = spillPartitions.erase(iter);
+        } else {
+          ++iter;
+        }
+      }
+    }
+    table_->prepareJoinTable(std::move(otherTables));
+
+    addRuntimeStats();
+    if (joinBride_->setHashTable(
+            std::move(table_), std::move(spillPartitions))) {
+      spillGroup_->restart();
+    }
+  } else {
+    joinBride_->setAntiJoinHasNullKeys();
   }
 
   // Realize the promises so that the other Drivers (which were not
@@ -218,18 +656,67 @@ void HashBuild::noMoreInput() {
   for (auto& promise : promises) {
     promise.setValue();
   }
+  return true;
+}
 
-  if (antiJoinHasNullKeys_) {
-    joinBridge_->setAntiJoinHasNullKeys();
-  } else {
-    bool hasOthers = !otherTables.empty();
-    table_->prepareJoinTable(
-        std::move(otherTables),
-        hasOthers ? operatorCtx_->task()->queryCtx()->executor() : nullptr);
+void HashBuild::postHashBuildProcess() {
+  checkRunning();
 
-    addRuntimeStats();
-    joinBridge_->setHashTable(std::move(table_), {});
+  // Release the unused memory reservation since we have finished the table
+  // build.
+  operatorCtx_->mappedMemory()->tracker()->release();
+
+  if (!spillEnabled()) {
+    setState(State::kFinish);
+    return;
   }
+
+  auto spillInput = joinBride_->spillInputOrFuture(&future_);
+  if (!spillInput.has_value()) {
+    VELOX_CHECK(future_.valid());
+    setState(State::kWaitForProbe);
+    return;
+  }
+  setupSpillInput(std::move(spillInput.value()));
+}
+
+void HashBuild::setupSpillInput(HashJoinBridge::SpillInput spillInput) {
+  checkRunning();
+
+  if (spillInput.spillPartition == nullptr) {
+    setState(State::kFinish);
+    return;
+  }
+
+  table_.reset();
+  spiller_.reset();
+  spillInputReader_.reset();
+
+  // Reset the key and dependent channels as the spilled data columns have
+  // already been ordered.
+  std::iota(keyChannels_.begin(), keyChannels_.end(), 0);
+  std::iota(
+      dependentChannels_.begin(),
+      dependentChannels_.end(),
+      keyChannels_.size());
+
+  setupTable();
+  setupSpiller(spillInput.spillPartition.get());
+
+  // Start to process spill input.
+  processSpillInput();
+}
+
+void HashBuild::processSpillInput() {
+  checkRunning();
+
+  while (spillInputReader_->nextBatch(input_)) {
+    addInput(std::move(input_));
+    if (!isRunning()) {
+      return;
+    }
+  }
+  noMoreInputInternal();
 }
 
 void HashBuild::addRuntimeStats() {
@@ -251,15 +738,110 @@ void HashBuild::addRuntimeStats() {
 }
 
 BlockingReason HashBuild::isBlocked(ContinueFuture* future) {
-  if (!future_.valid()) {
-    return BlockingReason::kNotBlocked;
+  switch (state_) {
+    case State::kRunning:
+      if (isInputFromSpill()) {
+        processSpillInput();
+      }
+      break;
+    case State::kFinish:
+      break;
+    case State::kWaitForSpill:
+      if (!future_.valid()) {
+        setRunning();
+        VELOX_CHECK_NOT_NULL(input_);
+        addInput(std::move(input_));
+      }
+      break;
+    case State::kWaitForBuild:
+      FOLLY_FALLTHROUGH;
+    case State::kWaitForProbe:
+      if (!future_.valid()) {
+        setRunning();
+        postHashBuildProcess();
+      }
+      break;
+    default:
+      VELOX_UNREACHABLE("Unexpected state: {}", stateName(state_));
+      break;
   }
-  *future = std::move(future_);
-  return BlockingReason::kWaitForJoinBuild;
+  if (future_.valid()) {
+    VELOX_CHECK(!isRunning() && !isFinished());
+    *future = std::move(future_);
+  }
+  return fromStateToBlockingReason(state_);
 }
 
 bool HashBuild::isFinished() {
-  return !future_.valid() && noMoreInput_;
+  return state_ == State::kFinish;
+}
+
+bool HashBuild::isRunning() const {
+  return state_ == State::kRunning;
+}
+
+void HashBuild::checkRunning() const {
+  VELOX_CHECK(isRunning(), stateName(state_));
+}
+
+void HashBuild::setRunning() {
+  setState(State::kRunning);
+}
+
+void HashBuild::setState(State state) {
+  stateTransitionCheck(state);
+  state_ = state;
+}
+
+void HashBuild::stateTransitionCheck(State state) {
+  VELOX_CHECK_NE(state_, state);
+  switch (state) {
+    case State::kRunning:
+      if (!spillEnabled()) {
+        VELOX_CHECK_EQ(state_, State::kWaitForBuild);
+      } else {
+        VELOX_CHECK_NE(state_, State::kFinish);
+      }
+      break;
+    case State::kWaitForBuild:
+      FOLLY_FALLTHROUGH;
+    case State::kWaitForSpill:
+      FOLLY_FALLTHROUGH;
+    case State::kWaitForProbe:
+      FOLLY_FALLTHROUGH;
+    case State::kFinish:
+      VELOX_CHECK_EQ(state_, State::kRunning);
+      break;
+    default:
+      VELOX_UNREACHABLE(stateName(state_));
+      break;
+  }
+}
+
+std::string HashBuild::stateName(State state) {
+  switch (state) {
+    case State::kRunning:
+      return "RUNNING";
+    case State::kWaitForSpill:
+      return "WAIT_FOR_SPILL";
+    case State::kWaitForBuild:
+      return "WAIT_FOR_BUILD";
+    case State::kWaitForProbe:
+      return "WAIT_FOR_PROBE";
+    case State::kFinish:
+      return "FINISH";
+    default:
+      return fmt::format("UNKNOWN: {}", static_cast<int>(state));
+  }
+}
+
+bool HashBuild::testingTriggerSpill() {
+  // Test-only spill path.
+  if (spillConfig()->testSpillPct == 0) {
+    return false;
+  }
+  return folly::hasher<uint64_t>()(++spillTestCounter_) % 100 <=
+      spillConfig()->testSpillPct;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -19,6 +19,9 @@
 #include "velox/exec/HashTable.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/Spill.h"
+#include "velox/exec/SpillOperatorGroup.h"
+#include "velox/exec/Spiller.h"
+#include "velox/exec/UnorderedStreamReader.h"
 #include "velox/exec/VectorHasher.h"
 #include "velox/expression/Expr.h"
 
@@ -35,6 +38,24 @@ namespace facebook::velox::exec {
 // their state.
 class HashBuild final : public Operator {
  public:
+  /// Define the internal execution state for hash build.
+  enum class State {
+    /// The running state.
+    kRunning = 1,
+    /// The state that waits for the pending group spill to finish. This state
+    /// only applies if disk spilling is enabled.
+    kWaitForSpill = 2,
+    /// The state that waits for the hash tables to be merged together.
+    kWaitForBuild = 3,
+    /// The state that waits for the hash probe to finish before start to build
+    /// the hash table for one of previously spilled partition. This state only
+    /// applies if disk spilling is enabled.
+    kWaitForProbe = 4,
+    /// The finishing state.
+    kFinish = 5,
+  };
+  static std::string stateName(State state);
+
   HashBuild(
       int32_t operatorId,
       DriverCtx* FOLLY_NONNULL driverCtx,
@@ -59,10 +80,140 @@ class HashBuild final : public Operator {
   void close() override {}
 
  private:
-  // Invoked to setup hash table to build.
+  void setState(State state);
+  void stateTransitionCheck(State state);
+
+  void setRunning();
+  bool isRunning() const;
+  void checkRunning() const;
+
+  // Invoked to set up hash table to build.
   void setupTable();
 
+  // Invoked when operator has finished processing the build input and wait for
+  // all the other drivers to finish the processing. The last driver that
+  // reaches to the hash build barrier, is responsible to build the hash table
+  // merged from all the other drivers. If the disk spilling is enabled, the
+  // last driver will also restart 'spillGroup_' and add a new hash build
+  // barrier for the next round of hash table build operation if it needs.
+  bool finishHashBuild();
+
+  // Invoked after the hash table has been built. It waits for any spill data to
+  // process after the probe side has finished processing the previously built
+  // hash table. If disk spilling is not enabled or there is no more spill data,
+  // then the operator will transition to 'kFinish' state to finish. Otherwise,
+  // it will transition to 'kWaitForProbe' to wait for the next spill data to
+  // process which will be set by the join probe side.
+  void postHashBuildProcess();
+
+  bool spillEnabled() const {
+    return spillConfig_.has_value();
+  }
+
+  const Spiller::Config* FOLLY_NULLABLE spillConfig() const {
+    return spillConfig_.has_value() ? &spillConfig_.value() : nullptr;
+  }
+
+  // Indicates if the input is read from spill data or not.
+  bool isInputFromSpill() const;
+
+  // Returns the type of data fed into 'addInput()'. The column orders will be
+  // different from the build source data type if the input is read from spill
+  // data during restoring.
+  RowTypePtr inputType() const;
+
+  // Invoked to setup spiller if disk spilling is enabled. If 'spillPartition'
+  // is not null, then the input is from the spilled data instead of from build
+  // source. The function will need to setup a spill input reader to read input
+  // from the spilled data for restoring. If the spilled data can't still fit
+  // in memory, then we will recursively spill part(s) of its data on disk.
+  void setupSpiller(SpillPartition* FOLLY_NULLABLE spillPartition = nullptr);
+
+  // Invoked when either there is no more input from the build source or from
+  // the spill input reader during the restoring.
+  void noMoreInputInternal();
+
+  // Invoked to ensure there is a sufficient memory to process 'input' by
+  // reserving a sufficient amount of memory in advance if disk spilling is
+  // enabled. The function returns true if the disk spilling is not enabled, or
+  // the memory reservation succeeds. If the memory reservation fails, the
+  // function will trigger a group spill which needs coordination among the
+  // other build drivers in the same group. The function returns true if the
+  // group spill has been inline executed which could happen if there is only
+  // one driver in the group, or it happens that all the other drivers have
+  // also requested group spill and this driver is the last one to reach the
+  // group spill barrier. Otherwise, the function returns false to wait for the
+  // group spill to run. The operator will transition to 'kWaitForSpill' state
+  // accordingly.
+  bool ensureInputFits(RowVectorPtr& input);
+
+  // Invoked to reserve memory for 'input' if disk spilling is enabled. The
+  // function returns true on success, otherwise false.
+  bool reserveMemory(const RowVectorPtr& input);
+
+  // Invoked to compute spill partitions numbers for each row 'input' and spill
+  // rows to spiller directly if the associated partition(s) is spilling. The
+  // function will skip processing if disk spilling is not enabled or there is
+  // no spilling partition.
+  void spillInput(const RowVectorPtr& input);
+
+  // Invoked to spill a number of rows from 'input' to a spill 'partition'.
+  // 'size' is the number of rows. 'indices' is the row indices in 'input'.
+  void spillPartition(
+      uint32_t partition,
+      vector_size_t size,
+      const BufferPtr& indices,
+      const RowVectorPtr& input);
+
+  // Invoked to compute spill partition numbers for 'input' if disk spilling is
+  // enabled. The computed partition numbers are stored in 'spillPartitions_'.
+  void computeSpillPartitions(const RowVectorPtr& input);
+
+  // Invoked to set up 'spillChildVectors_' for spill if 'input' is from build
+  // source.
+  void maybeSetupSpillChildVectors(const RowVectorPtr& input);
+
+  // Invoked to prepare indices buffers for input spill processing.
+  void prepareInputIndicesBuffers(
+      vector_size_t numInput,
+      const SpillPartitionNumSet& spillPartitions);
+
+  // Invoked to send group spill request to 'spillGroup_'. The function returns
+  // true if group spill has been inline executed, otherwise returns false. In
+  // the latter case, the operator will transition to 'kWaitForSpill' state and
+  // 'input' will be saved in 'input_' to be processed after the group spill has
+  // been executed.
+  bool requestSpill(RowVectorPtr& input);
+
+  // Invoked to check if it needs to wait for any pending group spill to run.
+  // The function returns true if it needs to wait, otherwise false. The latter
+  // case is either because there is no pending group spill or this operator is
+  // the last one to reach to the group spill barrier and execute the group
+  // spill inline.
+  bool waitSpill(RowVectorPtr& input);
+
+  // The callback registered to 'spillGroup_' to run group spill on
+  // 'spillOperators'.
+  void runSpill(const std::vector<Operator*>& spillOperators);
+
+  // Invoked by 'runSpill' to sum up the spill targets from all the operators in
+  // 'numRows' and 'numBytes'.
+  void addAndClearSpillTarget(uint64_t& numRows, uint64_t& numBytes);
+
+  // Invoked to reset the operator state to restore previously spilled data. It
+  // setup (recursive) spiller and spill input reader from 'spillInput' received
+  // from 'joinBride_'. 'spillInput' contains a shard of previously spilled
+  // partition data. 'spillInput' also indicates if there is no more spill data,
+  // then this operator will transition to 'kFinish' state to finish.
+  void setupSpillInput(HashJoinBridge::SpillInput spillInput);
+
+  // Invoked to process data from spill input reader on restoring.
+  void processSpillInput();
+
   void addRuntimeStats();
+
+  // Invoked to check if it needs to trigger spilling for test purpose only.
+  bool testingTriggerSpill();
 
   const std::shared_ptr<const core::HashJoinNode> joinNode_;
 
@@ -71,7 +222,15 @@ class HashBuild final : public Operator {
   const std::shared_ptr<HashJoinBridge> joinBridge_;
 
   // Holds the areas in RowContainer of 'table_'
-  memory::MappedMemory* FOLLY_NONNULL const mappedMemory_; // Not owned.
+  memory::MappedMemory* const FOLLY_NONNULL mappedMemory_;
+
+  const std::shared_ptr<HashJoinBridge> joinBride_;
+
+  const std::optional<Spiller::Config> spillConfig_;
+
+  SpillOperatorGroup* const FOLLY_NULLABLE spillGroup_{nullptr};
+
+  State state_{State::kRunning};
 
   // The row type used for hash table build and disk spilling.
   RowTypePtr tableType_;
@@ -105,6 +264,33 @@ class HashBuild final : public Operator {
   // True if this is a build side of an anti join and has at least one entry
   // with null join keys.
   bool antiJoinHasNullKeys_{false};
+
+  // Counts input batches and triggers spilling if folly hash of this % 100 <=
+  // 'testSpillPct_';.
+  uint64_t spillTestCounter_{0};
+
+  // The spill targets set by 'requestSpill()' to request group spill.
+  uint64_t numSpillRows_{0};
+  uint64_t numSpillBytes_{0};
+
+  std::unique_ptr<Spiller> spiller_;
+
+  // Used to read input from previously spilled data for restoring.
+  std::unique_ptr<UnorderedStreamReader<BatchStream>> spillInputReader_;
+
+  // Reusable memory for spill partition calculation for input data.
+  std::vector<uint32_t> spillPartitions_;
+
+  // Reusable memory for input spilling processing.
+  std::vector<vector_size_t> numSpillInputs_;
+  std::vector<BufferPtr> spillInputIndicesBuffers_;
+  std::vector<vector_size_t*> rawSpillInputIndicesBuffers_;
+  std::vector<VectorPtr> spillChildVectors_;
 };
+
+inline std::ostream& operator<<(std::ostream& os, HashBuild::State state) {
+  os << HashBuild::stateName(state);
+  return os;
+}
 
 } // namespace facebook::velox::exec

--- a/velox/exec/SpillOperatorGroup.h
+++ b/velox/exec/SpillOperatorGroup.h
@@ -39,15 +39,15 @@ class SpillOperatorGroup {
   /// Define the internal execution state of a spill group. The valid state
   /// transition is depicted as below:
 
-  ///       INIT --->  RUNNING  --->  STOPPED
-  ///                     ^             |
-  ///                     |             v
-  ///                     +-------------+
+  ///       kInit --->  kRunning  --->  kStopped
+  ///                      ^               |
+  ///                      |               v
+  ///                      +---------------+
   ///
   enum class State {
-    INIT = 0,
-    RUNNING = 1,
-    STOPPED = 2,
+    kInit = 0,
+    kRunning = 1,
+    kStopped = 2,
   };
   static std::string stateName(State state);
 
@@ -58,7 +58,7 @@ class SpillOperatorGroup {
       : taskId_(taskId),
         splitGroupId_(splitGroupId),
         planNodeId_(planNodeId),
-        state_(State::INIT){};
+        state_(State::kInit) {}
 
   State state();
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -396,6 +396,10 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
+  SpillOperatorGroup* FOLLY_NONNULL getSpillOperatorGroupLocked(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
+
   // Transitions this to kFinished state if all Drivers are
   // finished. Otherwise sets a flag so that the last Driver to finish
   // will transition the state.

--- a/velox/exec/tests/HashBitRangeTest.cpp
+++ b/velox/exec/tests/HashBitRangeTest.cpp
@@ -24,17 +24,22 @@ class HashRangeBitTest : public test::VectorTestBase, public testing::Test {};
 
 TEST_F(HashRangeBitTest, hashBitRange) {
   HashBitRange bitRange(29, 31);
-  EXPECT_EQ(29, bitRange.begin());
-  EXPECT_EQ(4, bitRange.numPartitions());
-  EXPECT_EQ(2, bitRange.numBits());
-  EXPECT_EQ(31, bitRange.end());
-  EXPECT_EQ(bitRange, bitRange);
+  ASSERT_EQ(29, bitRange.begin());
+  ASSERT_EQ(4, bitRange.numPartitions());
+  ASSERT_EQ(2, bitRange.numBits());
+  ASSERT_EQ(31, bitRange.end());
+  ASSERT_EQ(bitRange, bitRange);
 
   HashBitRange defaultRange;
-  EXPECT_EQ(0, defaultRange.begin());
-  EXPECT_EQ(1, defaultRange.numPartitions());
-  EXPECT_EQ(0, defaultRange.numBits());
-  EXPECT_EQ(0, defaultRange.end());
-  EXPECT_EQ(defaultRange, defaultRange);
-  EXPECT_NE(defaultRange, bitRange);
+  ASSERT_EQ(0, defaultRange.begin());
+  ASSERT_EQ(1, defaultRange.numPartitions());
+  ASSERT_EQ(0, defaultRange.numBits());
+  ASSERT_EQ(0, defaultRange.end());
+  ASSERT_EQ(defaultRange, defaultRange);
+  ASSERT_NE(defaultRange, bitRange);
+
+  // Error test cases.
+  HashBitRange validRange(63, 64);
+  ASSERT_ANY_THROW(HashBitRange(63, 65));
+  ASSERT_ANY_THROW(HashBitRange(65, 65));
 }

--- a/velox/exec/tests/SpillOperatorGroupTest.cpp
+++ b/velox/exec/tests/SpillOperatorGroupTest.cpp
@@ -129,13 +129,13 @@ class SpillOperatorGroupTest : public testing::Test {
       ops.push_back(newSpillOperator(spillGroup_.get()));
     }
     spillOps_ = std::move(ops);
-    ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::INIT);
+    ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::kInit);
   }
 
   void setupSpillGroup() {
     spillGroup_ = std::make_unique<SpillOperatorGroup>(
         taskId_, splitGroupId_++, planNodeId_);
-    ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::INIT);
+    ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::kInit);
     numSpillRuns_ = 0;
 
     setupSpillOperators();
@@ -187,9 +187,9 @@ class SpillOperatorGroupTest : public testing::Test {
 
     ASSERT_FALSE(spillGroup_->needSpill());
     if (hasRunningOperators()) {
-      ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::RUNNING);
+      ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::kRunning);
     } else {
-      ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::STOPPED);
+      ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::kStopped);
     }
     if (spillTriggered) {
       ++numSpillRuns_;
@@ -243,7 +243,7 @@ class SpillOperatorGroupTest : public testing::Test {
   }
 
   void startSpillGroup() {
-    if (spillGroup_->state() != SpillOperatorGroup::State::STOPPED) {
+    if (spillGroup_->state() != SpillOperatorGroup::State::kStopped) {
       spillGroup_->start();
       return;
     }
@@ -252,7 +252,7 @@ class SpillOperatorGroupTest : public testing::Test {
       op->restartSpill();
     }
     spillGroup_->restart();
-    ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::RUNNING);
+    ASSERT_EQ(spillGroup_->state(), SpillOperatorGroup::State::kRunning);
   }
 
   uint32_t randInt(uint32_t n) {


### PR DESCRIPTION
Add disk spilling support for hash join. It mainly works as follows:
(1) task will create spill operator group before driver creation;
(2) hash build operator add into spill operator group and hash join bridge
on construction;
(3) hash build operator create spiller on construction and we could
optimize this to create on demand;
(4) task starts spill operator group;
(5) hash build operator add to reserve memory for new input if disk
spilling is enabled. If it fails to reserve memory and it will send request
to spill operator group to run group spill;
(6) hash build operators wait for group spill to run which pickup the
spill partitions and flush out all the buffered rows into spill files;
(7) hash build operator split the new input by writing rows to spill file
directly if the corresponding partitions are spilling, and then update
row selection vector to continue the regular path with non-spilling rows;
(8) after all the operators finishes processing data, the last build operator
will collect spilled partitions from all the builders and set it into the hash
bridge along with the built table;
(9) if there is no more spill data, then build operator finish, otherwise wait
for spill input from the prober side, and the prober side will set it after it
finishes the processing (in followup);
(10) once get the spill input from the prober side, the build operator will
reset the spiller and create spill input reader to process spilled data which
pretty much follow the previous steps as process data from the build source.
The difference is that the input is processed in loop until reaches the end
of the spill data or run out of memory that waits for recursive group spill.

This PR adds simple test with empty probe to verify that the spill has been
triggered from the build side. The followup with prober side change will
turn on spilling test coverage on all the existing test cases in HashJoinTest
plus some dedicated test cases.