### PR TITLE
[WIP] Remove gflags dependency and use boost program options.

### DIFF
--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "velox/common/base/VeloxException.h"
-
 #include <folly/synchronization/AtomicStruct.h>
+#include "velox/flag_definitions/flags.h"
 
 namespace facebook {
 namespace velox {
@@ -78,15 +78,17 @@ namespace {
 bool isStackTraceEnabled(VeloxException::Type type) {
   using namespace std::literals::chrono_literals;
   const bool isSysException = type == VeloxException::Type::kSystem;
-  if ((isSysException && !FLAGS_velox_exception_system_stacktrace_enabled) ||
-      (!isSysException && !FLAGS_velox_exception_user_stacktrace_enabled)) {
+  if ((isSysException &&
+       !flags::getInstance().getVeloxExceptionSystemStackTraceEnabled()) ||
+      (!isSysException &&
+       !flags::getInstance().getVeloxExceptionUserStackTraceEnabled())) {
     // VeloxException stacktraces are disabled.
     return false;
   }
 
   const int32_t rateLimitMs = isSysException
-      ? FLAGS_velox_exception_system_stacktrace_rate_limit_ms
-      : FLAGS_velox_exception_user_stacktrace_rate_limit_ms;
+      ? flags::getInstance().getVeloxExceptionSystemStackTraceRateLimitMs()
+      : flags::getInstance().getVeloxExceptionUserStackTraceRateLimitMs();
   // not static so the gflag can be manipulated at runtime
   if (0 == rateLimitMs) {
     // VeloxException stacktraces are not rate-limited

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -28,11 +28,6 @@
 
 #include "velox/common/process/StackTrace.h"
 
-DECLARE_bool(velox_exception_user_stacktrace_enabled);
-DECLARE_bool(velox_exception_system_stacktrace_enabled);
-
-DECLARE_int32(velox_exception_user_stacktrace_rate_limit_ms);
-DECLARE_int32(velox_exception_system_stacktrace_rate_limit_ms);
 
 namespace facebook {
 namespace velox {

--- a/velox/common/base/benchmarks/BitUtilBenchmark.cpp
+++ b/velox/common/base/benchmarks/BitUtilBenchmark.cpp
@@ -20,7 +20,7 @@
 #include <optional>
 
 #include "velox/common/base/BitUtil.h"
-DECLARE_bool(bmi2); // NOLINT
+#include "velox/flag_definitions/flags.h"
 
 namespace facebook {
 namespace velox {
@@ -123,7 +123,8 @@ void runScatterBits(int32_t n, bool isSimple) {
   std::vector<uint64_t> mask;
   std::vector<uint64_t> target;
   BENCHMARK_SUSPEND {
-    FLAGS_bmi2 = !isSimple; // NOLINT
+    flags::getInstance().init({{"bmi2", "false"}});
+
     setupScatterBits(source, numSource, mask, target);
   }
   auto sourceBits = reinterpret_cast<const char*>(source.data());
@@ -132,7 +133,10 @@ void runScatterBits(int32_t n, bool isSimple) {
     bits::scatterBits(
         numSource, target.size() * 64, sourceBits, mask.data(), targetBits);
   }
-  FLAGS_bmi2 = true; // NOLINT
+
+  BENCHMARK_SUSPEND {
+    flags::getInstance().init({{"bmi2", "true"}});
+  };
 }
 
 BENCHMARK(BM_scatterBitsSimple, n) {

--- a/velox/common/base/tests/BitUtilTest.cpp
+++ b/velox/common/base/tests/BitUtilTest.cpp
@@ -15,14 +15,12 @@
  */
 
 #include "velox/common/base/BitUtil.h"
+#include "velox/flag_definitions/flags.h"
 
 #include <unordered_set>
 
 #include <folly/Random.h>
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
-
-DECLARE_bool(bmi2); // NOLINT
 
 namespace facebook {
 namespace velox {
@@ -649,10 +647,13 @@ TEST_F(BitUtilTest, scatterBits) {
   std::vector<char> reference(kSize * 8);
   auto sourceAsChar = reinterpret_cast<char*>(source.data());
   scatterBits(numInMask, kNumBits, sourceAsChar, maskData, test.data());
+  auto setBMI = [](bool flag) {
+    flags::getInstance().init({{"bmi2", std::to_string(flag)}});
+  };
   // Generate the reference output with the non-BMI implementation.
-  FLAGS_bmi2 = false; // NOLINT
+  setBMI(false);
   scatterBits(numInMask, kNumBits, sourceAsChar, maskData, reference.data());
-  FLAGS_bmi2 = true; // NOLINT
+  setBMI(true);
   EXPECT_EQ(reference, test);
   // Repeat the same in place.
   scatterBits(numInMask, kNumBits, sourceAsChar, maskData, sourceAsChar);

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/caching/SsdCache.h"
 #include "velox/common/memory/MmapAllocator.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/flag_definitions/flags.h"
 
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <folly/executors/QueuedImmediateExecutor.h>
@@ -528,7 +529,9 @@ TEST_F(AsyncDataCacheTest, pin) {
 
 TEST_F(AsyncDataCacheTest, replace) {
   constexpr int64_t kMaxBytes = 64 << 20;
-  FLAGS_velox_exception_user_stacktrace_enabled = false;
+  facebook::velox::flags::getInstance().init({
+      {"velox_exception_user_stacktrace_enabled", "false"},
+  });
   initializeCache(kMaxBytes);
   // Load 10x the max size, inject an error every 21 batches.
   loadLoop(0, kMaxBytes * 10, 21);
@@ -595,7 +598,9 @@ void corruptFile(const std::string& path) {
 TEST_F(AsyncDataCacheTest, ssd) {
   constexpr uint64_t kRamBytes = 32 << 20;
   constexpr uint64_t kSsdBytes = 512UL << 20;
-  FLAGS_velox_exception_user_stacktrace_enabled = false;
+  facebook::velox::flags::getInstance().init({
+      {"velox_exception_user_stacktrace_enabled", "false"},
+  });
   initializeCache(kRamBytes, kSsdBytes);
   cache_->setVerifyHook(
       [&](const AsyncDataCacheEntry& entry) { checkContents(entry); });

--- a/velox/common/memory/MappedMemory.cpp
+++ b/velox/common/memory/MappedMemory.cpp
@@ -193,8 +193,9 @@ bool MappedMemoryImpl::allocate(
   free(out);
 
   auto mix = allocationSize(numPages, minSizeClass);
+  auto veloxUseMalloc = flags::getInstance().getVeloxUseMalloc();
 
-  if (FLAGS_velox_use_malloc) {
+  if (veloxUseMalloc) {
     if (beforeAllocCB) {
       uint64_t bytesAllocated = 0;
       for (int32_t i = 0; i < mix.numSizes; ++i) {
@@ -293,7 +294,8 @@ int64_t MappedMemoryImpl::free(Allocation& allocation) {
     return 0;
   }
   MachinePageCount numFreed = 0;
-  if (FLAGS_velox_use_malloc) {
+  auto veloxUseMalloc = flags::getInstance().getVeloxUseMalloc();
+  if (veloxUseMalloc) {
     for (int32_t i = 0; i < allocation.numRuns(); ++i) {
       PageRun run = allocation.runAt(i);
       numFreed += run.numPages();
@@ -333,7 +335,8 @@ void MappedMemoryImpl::freeContiguousImpl(ContiguousAllocation& allocation) {
 }
 
 bool MappedMemoryImpl::checkConsistency() const {
-  if (FLAGS_velox_use_malloc) {
+  auto veloxUseMalloc = flags::getInstance().getVeloxUseMalloc();
+  if (veloxUseMalloc) {
     return true;
   }
   throw std::runtime_error("Not implemented");

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -40,7 +40,6 @@
 #include "velox/common/memory/MemoryUsage.h"
 #include "velox/common/memory/MemoryUsageTracker.h"
 
-DECLARE_int32(memory_usage_aggregation_interval_millis);
 
 namespace facebook {
 namespace velox {

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/memory/MmapAllocator.h"
 #include "velox/common/base/Portability.h"
+#include "velox/flag_definitions/flags.h"
 
 #include <sys/mman.h>
 
@@ -137,7 +138,8 @@ MachinePageCount MmapAllocator::freeInternal(Allocation& allocation) {
       ClockTimer timer(clocks);
       pages = sizeClass->free(allocation);
     }
-    if (pages && FLAGS_velox_time_allocations) {
+    auto veloxTimeAllocation = flags::getInstance().getVeloxTimeAllocations();
+    if (pages && veloxTimeAllocation) {
       // Increment the free time only if the allocation contained
       // pages in the class. Note that size class indices in the
       // allocator are not necessarily the same as in the stats.

--- a/velox/common/memory/tests/MappedMemoryTest.cpp
+++ b/velox/common/memory/tests/MappedMemoryTest.cpp
@@ -26,8 +26,6 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
-DECLARE_int32(velox_memory_pool_mb);
-
 namespace facebook::velox::memory {
 
 static constexpr uint64_t kMaxMappedMemory = 128UL * 1024 * 1024;

--- a/velox/common/process/ProcessBase.cpp
+++ b/velox/common/process/ProcessBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/process/ProcessBase.h"
+#include "velox/flag_definitions/flags.h"
 
 #include <limits.h>
 #include <stdlib.h>
@@ -23,14 +24,9 @@
 
 #include <folly/CpuId.h>
 #include <folly/FileUtil.h>
-#include <folly/String.h>
-#include <gflags/gflags.h>
 
 constexpr const char* kProcSelfCmdline = "/proc/self/cmdline";
 
-DECLARE_bool(avx2); // Enables use of AVX2 when available NOLINT
-
-DECLARE_bool(bmi2); // Enables use of BMI2 when available NOLINT
 
 namespace facebook {
 namespace velox {
@@ -112,7 +108,7 @@ bool avx2CpuFlag = folly::CpuId().avx2();
 
 bool hasAvx2() {
 #ifdef __AVX2__
-  return avx2CpuFlag && FLAGS_avx2;
+  return avx2CpuFlag && flags::getInstance().avx2();
 #else
   return false;
 #endif
@@ -120,7 +116,7 @@ bool hasAvx2() {
 
 bool hasBmi2() {
 #ifdef __BMI2__
-  return bmi2CpuFlag && FLAGS_bmi2;
+  return bmi2CpuFlag && flags::getInstance().bmi2();
 #else
   return false;
 #endif

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -18,6 +18,7 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/flag_definitions/flags.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
@@ -133,7 +134,9 @@ class ExprEncodingsTest
  protected:
   void SetUp() override {
     // This test throws a lot of exceptions, so turn off stack trace capturing.
-    FLAGS_velox_exception_user_stacktrace_enabled = false;
+    facebook::velox::flags::getInstance().init({
+        {"velox_exception_user_stacktrace_enabled", "false"},
+    });
 
     functions::prestosql::registerAllScalarFunctions();
     parse::registerTypeResolver();

--- a/velox/flag_definitions/CMakeLists.txt
+++ b/velox/flag_definitions/CMakeLists.txt
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 add_library(velox_flag_definitions OBJECT flags.cpp)
-target_link_libraries(velox_flag_definitions gflags)
+target_link_libraries(velox_flag_definitions ${BOOST_LIBRARIES})

--- a/velox/flag_definitions/flags.h
+++ b/velox/flag_definitions/flags.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <boost/program_options.hpp>
+
+namespace facebook::velox::flags {
+
+/// Configuration flags for Velox.
+class VeloxFlags {
+ public:
+  // Initialization using command line arguments
+  void init(int argc, const char* const argv[]);
+
+  // Initialization using map.
+  void init(std::map<std::string, std::string> options);
+
+  bool avx2() {
+    return vm_["avx2"].as<bool>();
+  }
+
+  bool bmi2() {
+    return vm_["bmi2"].as<bool>();
+  }
+
+  // Used in velox/builder/SimpleVectorBuilder.cpp
+  int32_t getMaxBlockValueSetLength() {
+    return vm_["max_block_value_set_length"].as<int32_t>();
+  }
+
+  // Used in velox/common/memory/Memory.cpp
+  int32_t getMemoryUsageAggregationIntervalMillis() {
+    return vm_["memory_usage_aggregation_interval_millis"].as<int32_t>();
+  }
+
+  // Used in velox/common/memory/MappedMemory.cpp
+  int32_t getVeloxMemoryPoolMb() {
+    return vm_["velox_memory_pool_mb"].as<int32_t>();
+  }
+
+  bool getVeloxUseMalloc() {
+    return vm_["velox_use_malloc"].as<bool>();
+  }
+
+  bool getVeloxTimeAllocations() {
+    return vm_["velox_time_allocations"].as<bool>();
+  }
+
+  // Used in common/base/VeloxException.cpp
+  bool getVeloxExceptionUserStackTraceEnabled() {
+    return vm_["velox_exception_user_stacktrace_enabled"].as<bool>();
+  }
+
+  bool getVeloxExceptionSystemStackTraceEnabled() {
+    return vm_["velox_exception_system_stacktrace_enabled"].as<bool>();
+  }
+
+  int32_t getVeloxExceptionUserStackTraceRateLimitMs() {
+    return vm_["velox_exception_user_stacktrace_rate_limit_ms"].as<int32_t>();
+  }
+
+  int32_t getVeloxExceptionSystemStackTraceRateLimitMs() {
+    return vm_["velox_exception_system_stacktrace_rate_limit_ms"].as<int32_t>();
+  }
+
+  friend VeloxFlags& getInstance();
+
+ private:
+  VeloxFlags();
+  boost::program_options::options_description addOptions();
+  boost::program_options::variables_map vm_;
+};
+
+VeloxFlags& getInstance();
+} // namespace facebook::velox::flags


### PR DESCRIPTION
Gflags doesnt allow flags to be loaded multiple times; This can happen sometimes when you have to dynamically load other libraries that depend on Velox (say in Python). See Issue #2521 for details. 
