### PR TITLE
Fix ExceptionContext to handle messageFunc that throws

### DIFF
--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -55,8 +55,25 @@ struct ExceptionContext {
   /// Calls `messageFunc(arg)` and returns the result. Returns empty string if
   /// `messageFunc` is null.
   std::string message() {
-    return messageFunc ? messageFunc(arg) : "";
+    if (!messageFunc || suspended) {
+      return "";
+    }
+
+    std::string theMessage;
+
+    try {
+      // Make sure not to call messageFunc again in case it throws.
+      suspended = true;
+      theMessage = messageFunc(arg);
+      suspended = false;
+    } catch (...) {
+      return "Failed to produce additional context.";
+    }
+
+    return theMessage;
   }
+
+  bool suspended{false};
 };
 
 /// Returns a reference to thread_local variable that holds a function that can

--- a/velox/common/base/tests/ExceptionTest.cpp
+++ b/velox/common/base/tests/ExceptionTest.cpp
@@ -639,6 +639,28 @@ TEST(ExceptionTest, context) {
       "\nExpression: 1 == 3"
       "\nFunction: operator()"
       "\nFile: ");
+
+  // With message function throwing an exception.
+  auto throwingMessageFunction = [](auto* arg) -> std::string {
+    VELOX_FAIL("Test failure.");
+  };
+  {
+    std::string debuggingInfo = "Debugging info.";
+    facebook::velox::ExceptionContextSetter context(
+        {throwingMessageFunction, debuggingInfo.data()});
+
+    verifyVeloxException(
+        [&]() { VELOX_CHECK_EQ(1, 3); },
+        "Exception: VeloxRuntimeError"
+        "\nError Source: RUNTIME"
+        "\nError Code: INVALID_STATE"
+        "\nReason: (1 vs. 3)"
+        "\nRetriable: False"
+        "\nExpression: 1 == 3"
+        "\nContext: Failed to produce additional context."
+        "\nFunction: operator()"
+        "\nFile: ");
+  }
 }
 
 TEST(ExceptionTest, traceCollectionEnabling) {


### PR DESCRIPTION
The messageFunc callback may throw, triggering the exception handling path that
calls it again, then again, then again,.. Add logic to avoid calling
messageFunc again in case it throws.