### PR TITLE
Add support for RLE encoding in Presto deserializer

### DIFF
--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -42,6 +42,13 @@ class PrestoVectorSerde : public VectorSerde {
       StreamArena* streamArena,
       const Options* options) override;
 
+  /// Serializes a RowVector with a constant children.
+  void serializeConstants(
+      const RowVectorPtr& vector,
+      StreamArena* streamArena,
+      const Options* options,
+      OutputStream* out);
+
   void deserialize(
       ByteStream* source,
       velox::memory::MemoryPool* pool,


### PR DESCRIPTION
Summary: Support RLE encoding in Velox Presto page deserializer.

Differential Revision: D39521537

