### PR TITLE
Fix decode range in HivePartitionFunction

### DIFF
--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -234,12 +234,10 @@ void HivePartitionFunction::partition(
     std::vector<uint32_t>& partitions) {
   const auto numRows = input.size();
 
+  rows_.resize(numRows, true);
   if (numRows > hashes_.size()) {
-    rows_.resize(numRows);
-    rows_.setAll();
     hashes_.resize(numRows);
   }
-
   partitions.resize(numRows);
   for (auto i = 0; i < keyChannels_.size(); ++i) {
     if (keyChannels_[i] != kConstantChannel) {

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -15,17 +15,18 @@
  */
 #include "velox/connectors/hive/HivePartitionFunction.h"
 #include "gtest/gtest.h"
-#include "velox/vector/tests/utils/VectorMaker.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox;
 
-class HivePartitionFunctionTest : public ::testing::Test {
+class HivePartitionFunctionTest : public ::testing::Test,
+                                  public test::VectorTestBase {
  protected:
   void assertPartitions(
       const VectorPtr& vector,
       int bucketCount,
       const std::vector<uint32_t>& expectedPartitions) {
-    auto rowVector = vm_.rowVector({vector});
+    auto rowVector = makeRowVector({vector});
 
     auto size = rowVector->size();
 
@@ -35,11 +36,28 @@ class HivePartitionFunctionTest : public ::testing::Test {
     keyChannels.emplace_back(0);
     connector::hive::HivePartitionFunction partitionFunction(
         bucketCount, bucketToPartition, keyChannels);
-
     std::vector<uint32_t> partitions(size);
     partitionFunction.partition(*rowVector, partitions);
     for (auto i = 0; i < size; ++i) {
       EXPECT_EQ(expectedPartitions[i], partitions[i])
+          << "at " << i << ": " << vector->toString(i);
+    }
+
+    // Retry the same with nested dictionaries where indices out of range
+    // indices are bad. Ensure that out of scope indices are not accessed.
+    auto innerIndices = makeIndicesInReverse(size);
+    auto outerIndices = makeIndices(size, [](auto i) { return i; });
+    outerIndices->asMutable<vector_size_t>()[size - 1] =
+        std::numeric_limits<int32_t>().max();
+    auto dictValues = BaseVector::wrapInDictionary(
+        nullptr,
+        outerIndices,
+        size - 1,
+        BaseVector::wrapInDictionary(nullptr, innerIndices, size, vector));
+    rowVector = makeRowVector({dictValues});
+    partitionFunction.partition(*rowVector, partitions);
+    for (auto i = 0; i < size - 1; ++i) {
+      EXPECT_EQ(expectedPartitions[size - 1 - i], partitions[i])
           << "at " << i << ": " << vector->toString(i);
     }
   }
@@ -50,19 +68,21 @@ class HivePartitionFunctionTest : public ::testing::Test {
   void assertPartitionsWithConstChannel(
       const VectorPtr& vector,
       int bucketCount) {
-    auto column2 = vm_.flatVector<int64_t>(
+    auto column2 = makeFlatVector<int64_t>(
         vector->size(), [](auto /*row*/) { return 13; });
-    auto column3 = vm_.flatVector<int64_t>(
+    auto column3 = makeFlatVector<int64_t>(
         vector->size(), [](auto /*row*/) { return 97; });
-    auto rowVector = vm_.rowVector({vector, column2, column3});
+    auto rowVector = makeRowVector({vector, column2, column3});
 
     auto size = rowVector->size();
     std::vector<VectorPtr> constValues{
-        vm_.flatVector<int64_t>({13}), vm_.flatVector<int64_t>({97})};
+        // Must declare the literal as std::vector, else function
+        // resolves to makeFlatVector(size_t).
+        makeFlatVector<int64_t>(std::vector<int64_t>{13}),
+        makeFlatVector<int64_t>(std::vector<int64_t>{97})};
 
     std::vector<int> bucketToPartition(bucketCount);
     std::iota(bucketToPartition.begin(), bucketToPartition.end(), 0);
-
     std::vector<column_index_t> keyChannelsNorm{0, 1, 2};
     connector::hive::HivePartitionFunction partitionFunctionNorm(
         bucketCount, bucketToPartition, keyChannelsNorm);
@@ -78,14 +98,10 @@ class HivePartitionFunctionTest : public ::testing::Test {
     partitionFunctionConst.partition(*rowVector, partitionsConst);
     EXPECT_EQ(partitionsNorm, partitionsConst);
   }
-
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
-  test::VectorMaker vm_{pool_.get()};
 };
 
 TEST_F(HivePartitionFunctionTest, bigint) {
-  auto values = vm_.flatVectorNullable<int64_t>(
+  auto values = makeNullableFlatVector<int64_t>(
       {std::nullopt,
        300'000'000'000,
        std::numeric_limits<int64_t>::min(),
@@ -103,7 +119,7 @@ TEST_F(HivePartitionFunctionTest, bigint) {
 }
 
 TEST_F(HivePartitionFunctionTest, varchar) {
-  auto values = vm_.flatVectorNullable<std::string>(
+  auto values = makeNullableFlatVector<std::string>(
       {std::nullopt,
        "",
        "test string",
@@ -122,7 +138,7 @@ TEST_F(HivePartitionFunctionTest, varchar) {
 
 TEST_F(HivePartitionFunctionTest, boolean) {
   auto values =
-      vm_.flatVectorNullable<bool>({std::nullopt, true, false, false, true});
+      makeNullableFlatVector<bool>({std::nullopt, true, false, false, true});
 
   assertPartitions(values, 1, {0, 0, 0, 0, 0});
   assertPartitions(values, 2, {0, 1, 0, 0, 1});
@@ -136,7 +152,7 @@ TEST_F(HivePartitionFunctionTest, boolean) {
 }
 
 TEST_F(HivePartitionFunctionTest, tinyint) {
-  auto values = vm_.flatVectorNullable<int8_t>(
+  auto values = makeNullableFlatVector<int8_t>(
       {std::nullopt,
        64,
        std::numeric_limits<int8_t>::min(),
@@ -154,7 +170,7 @@ TEST_F(HivePartitionFunctionTest, tinyint) {
 }
 
 TEST_F(HivePartitionFunctionTest, smallint) {
-  auto values = vm_.flatVectorNullable<int16_t>(
+  auto values = makeNullableFlatVector<int16_t>(
       {std::nullopt,
        30'000,
        std::numeric_limits<int16_t>::min(),
@@ -172,7 +188,7 @@ TEST_F(HivePartitionFunctionTest, smallint) {
 }
 
 TEST_F(HivePartitionFunctionTest, integer) {
-  auto values = vm_.flatVectorNullable<int32_t>(
+  auto values = makeNullableFlatVector<int32_t>(
       {std::nullopt,
        2'000'000'000,
        std::numeric_limits<int32_t>::min(),
@@ -190,7 +206,7 @@ TEST_F(HivePartitionFunctionTest, integer) {
 }
 
 TEST_F(HivePartitionFunctionTest, real) {
-  auto values = vm_.flatVectorNullable<float>(
+  auto values = makeNullableFlatVector<float>(
       {std::nullopt,
        2'000'000'000.0,
        std::numeric_limits<float>::lowest(),
@@ -208,7 +224,7 @@ TEST_F(HivePartitionFunctionTest, real) {
 }
 
 TEST_F(HivePartitionFunctionTest, double) {
-  auto values = vm_.flatVectorNullable<double>(
+  auto values = makeNullableFlatVector<double>(
       {std::nullopt,
        300'000'000'000.5,
        std::numeric_limits<double>::lowest(),
@@ -226,7 +242,7 @@ TEST_F(HivePartitionFunctionTest, double) {
 }
 
 TEST_F(HivePartitionFunctionTest, timestamp) {
-  auto values = vm_.flatVectorNullable<Timestamp>(
+  auto values = makeNullableFlatVector<Timestamp>(
       {std::nullopt,
        Timestamp(100'000, 900'000),
        Timestamp(
@@ -248,7 +264,7 @@ TEST_F(HivePartitionFunctionTest, timestamp) {
 }
 
 TEST_F(HivePartitionFunctionTest, date) {
-  auto values = vm_.flatVectorNullable<Date>(
+  auto values = makeNullableFlatVector<Date>(
       {std::nullopt,
        Date(2'000'000'000),
        Date(std::numeric_limits<int32_t>::min()),


### PR DESCRIPTION
If inputs of HivePartitionFunction are multilevel dictionaries, these could get
decoded for extra rows. This would produce read of uninitialized in cases of
loading lazies for selected rows.