### PR TITLE
Add benchmark for concat Presto function

### DIFF
--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -142,3 +142,7 @@ add_executable(velox_functions_prestosql_benchmarks_comparisons
                ComparisonsBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_comparisons
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_concat ConcatBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_concat
+                      ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/ConcatBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ConcatBenchmark.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+
+class ConcatBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  explicit ConcatBenchmark(uint32_t seed)
+      : FunctionBenchmarkBase(), seed_{seed} {
+    functions::prestosql::registerStringFunctions();
+  }
+
+  RowVectorPtr generateData() {
+    VectorFuzzer::Options options;
+    options.vectorSize = 10'024;
+    options.stringVariableLength = true;
+    options.stringLength = 64;
+
+    VectorFuzzer fuzzer(options, pool(), seed_);
+
+    return vectorMaker_.rowVector(
+        {fuzzer.fuzzFlat(VARCHAR()), fuzzer.fuzzFlat(VARCHAR())});
+  }
+
+  size_t runBasic(size_t times) {
+    folly::BenchmarkSuspender suspender;
+    auto data = generateData();
+    auto exprSet = compileExpression(
+        "concat(c0, concat(', ', concat(c1, concat(',', concat('567', concat(',', concat('129', concat(',', '987654321'))))))))",
+        asRowType(data->type()));
+    suspender.dismiss();
+
+    return doRun(exprSet, data, times);
+  }
+
+  size_t runFlattened(size_t times) {
+    folly::BenchmarkSuspender suspender;
+    auto data = generateData();
+    auto exprSet = compileExpression(
+        "concat(c0, ', ', c1, ',', '567', ',', '129', ',', '987654321')",
+        asRowType(data->type()));
+    suspender.dismiss();
+
+    return doRun(exprSet, data, times);
+  }
+
+  size_t runFlattenedAndConstantFolded(size_t times) {
+    folly::BenchmarkSuspender suspender;
+    auto data = generateData();
+    auto exprSet = compileExpression(
+        "concat(c0, ', ', c1, ',567,129,987654321')", asRowType(data->type()));
+    suspender.dismiss();
+
+    return doRun(exprSet, data, times);
+  }
+
+  size_t doRun(ExprSet& exprSet, const RowVectorPtr& rowVector, size_t times) {
+    int cnt = 0;
+    for (auto i = 0; i < times * 1'000; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    return cnt;
+  }
+
+  const uint32_t seed_;
+};
+
+const uint32_t seed = folly::Random::rand32();
+
+BENCHMARK_MULTI(basic, n) {
+  ConcatBenchmark benchmark(seed);
+  return benchmark.runBasic(n);
+}
+
+BENCHMARK_MULTI(flatten, n) {
+  ConcatBenchmark benchmark(seed);
+  return benchmark.runFlattened(n);
+}
+
+BENCHMARK_MULTI(flattenAndConstantFold, n) {
+  ConcatBenchmark benchmark(seed);
+  return benchmark.runFlattenedAndConstantFolded(n);
+}
+
+} // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+  LOG(ERROR) << "Seed: " << seed;
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
Add benchmark to evaluate performance of concatenating multiple strings some of which are constants. The benchmark uses a concat expression with 2 data columns and 7 constants. This expression is inspired by a set of production pipelines.

* basic: concat(c0, concat(', ', concat(c1, concat(',', concat('567', concat(',', concat('129', concat(',', '987654321'))))))))
* flatten: concat(c0, ', ', c1, ',', '567', ',', '129', ',', '987654321')
* flattenAndConstantFold: concat(c0, ', ', c1, ',567,129,987654321')

Basic and flatten show the same performance because the expression evaluation
engine now flattens concat calls automatically.

FlattenAndConstantFold is almost 2 times faster. I'll investigate and figure out
how to optimize the engine for this use case as a follow-up.

```
============================================================================
[...]stosql/benchmarks/ConcatBenchmark.cpp     relative  time/iter   iters/s
============================================================================
basic                                                     176.31ns     5.67M
flatten                                                   172.56ns     5.79M
flattenAndConstantFold                                     99.07ns    10.09M
```

Differential Revision: D39619045

