### PR TITLE
Fix null-aware anti join with filter and null in the join key

### DIFF
--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -215,6 +215,13 @@ class HashBuild final : public Operator {
   // Invoked to check if it needs to trigger spilling for test purpose only.
   bool testingTriggerSpill();
 
+  // Check and store properties of the filter.
+  void setupFilter(const folly::F14FastMap<column_index_t, column_index_t>&);
+
+  // When prepare for null-aware anti join with null-propagating filter,
+  // deselect the rows when there is null in filter input columns.
+  void removeFilterInputNullRows();
+
   const std::shared_ptr<const core::HashJoinNode> joinNode_;
 
   const core::JoinType joinType_;
@@ -284,6 +291,13 @@ class HashBuild final : public Operator {
   std::vector<BufferPtr> spillInputIndicesBuffers_;
   std::vector<vector_size_t*> rawSpillInputIndicesBuffers_;
   std::vector<VectorPtr> spillChildVectors_;
+
+  // Whether the filter is null-propagating.
+  bool filterPropagatesNulls_{false};
+
+  // Indices of columns used by filter in build side table.
+  std::vector<column_index_t> keyFilterChannels_;
+  std::vector<column_index_t> dependentFilterChannels_;
 };
 
 inline std::ostream& operator<<(std::ostream& os, HashBuild::State state) {


### PR DESCRIPTION
This change fixes a bug in null-aware anti join that if a key is null in probe
side, we include it in the result regardless of the filter.

The basic logic in `HashProbe` for null-aware anti join with filter is changed
to this:

1. If the key columns are all non-null on probe side, we check the filter
   evaluation result on joined rows.  If none of the rows match, we do a cross
   join for the current probe side row with all the rows that having any null in
   key columns on build side, and check if any of the result rows pass the
   filter.  We only keep the result if none of these rows pass the filter.

2. If there is any null in key columns on probe side, we do a cross join for the
   current probe side row with all the rows on build side, and check if any
   result pass the filter.  Same as above, we only keep the result if none of
   these rows pass the filter.  In this case we also skip the filter evaluation
   on hash join result beforehand as an optimization.

For null-propagating filter, some optimizations are added:

1. On build side, we filter out all the rows that have null in filter columns,
   since they will never pass the filter.

2. On probe side, if the current row have null in filter columns, we directly
   add it to the result.

Differential Revision: D39596348

