### PR TITLE
Optimize concat Presto function with consecutive constant inputs

### DIFF
--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -263,6 +263,13 @@ bool registerStatefulVectorFunction(
         (name), (signatures), (function));                                \
   }
 
+#define VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION_WITH_METADATA(    \
+    tag, signatures, metadata, function)                         \
+  void _VELOX_REGISTER_FUNC_NAME(tag)(const std::string& name) { \
+    facebook::velox::exec::registerStatefulVectorFunction(       \
+        (name), (signatures), (function), (metadata));           \
+  }
+
 // Registers a vectorized UDF associated with a given tag.
 // This should be used in the same namespace the declare macro is used in.
 #define VELOX_REGISTER_VECTOR_FUNCTION(tag, name)                   \

--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -143,6 +143,53 @@ class UpperLowerTemplateFunction : public exec::VectorFunction {
  * */
 class ConcatFunction : public exec::VectorFunction {
  public:
+  ConcatFunction(
+      const std::string& /* name */,
+      const std::vector<exec::VectorFunctionArg>& inputArgs) {
+    auto numArgs = inputArgs.size();
+
+    // Save constant values to constantStrings_.
+    // Identify and combine consecutive constant inputs.
+    argMapping_.reserve(numArgs);
+    constantStrings_.reserve(numArgs);
+
+    for (auto i = 0; i < numArgs; ++i) {
+      argMapping_.push_back(i);
+
+      const auto& arg = inputArgs[i];
+      if (arg.constantValue) {
+        std::string value = arg.constantValue->as<ConstantVector<StringView>>()
+                                ->valueAt(0)
+                                .str();
+
+        column_index_t j = i + 1;
+        for (; j < inputArgs.size(); ++j) {
+          if (!inputArgs[j].constantValue) {
+            break;
+          }
+
+          value += inputArgs[j]
+                       .constantValue->as<ConstantVector<StringView>>()
+                       ->valueAt(0)
+                       .str();
+        }
+
+        constantStrings_.push_back(std::string(value.data(), value.size()));
+
+        i = j - 1;
+      } else {
+        constantStrings_.push_back(std::string());
+      }
+    }
+
+    // Create StringViews for constant strings.
+    constantStringViews_.reserve(numArgs);
+    for (const auto& constantString : constantStrings_) {
+      constantStringViews_.push_back(
+          StringView(constantString.data(), constantString.size()));
+    }
+  }
+
   bool propagateStringEncodingFromAllInputs() const override {
     return true;
   }
@@ -156,14 +203,31 @@ class ConcatFunction : public exec::VectorFunction {
     context.ensureWritable(rows, VARCHAR(), result);
     auto flatResult = result->asFlatVector<StringView>();
 
-    exec::DecodedArgs decodedArgs(rows, args, context);
+    auto numArgs = argMapping_.size();
+
+    std::vector<exec::LocalDecodedVector> decodedArgs;
+    decodedArgs.reserve(numArgs);
+
+    for (auto i = 0; i < numArgs; ++i) {
+      auto index = argMapping_[i];
+      if (constantStringViews_[i].empty()) {
+        decodedArgs.emplace_back(context, *args[index], rows);
+      } else {
+        // Do not decode constant inputs.
+        decodedArgs.emplace_back(context);
+      }
+    }
 
     // Calculate the combined size of the result strings.
     size_t totalResultBytes = 0;
     rows.applyToSelected([&](int row) {
-      for (int i = 0; i < args.size(); i++) {
-        auto value = decodedArgs.at(i)->valueAt<StringView>(row);
-        totalResultBytes += value.size();
+      for (int i = 0; i < numArgs; i++) {
+        if (constantStringViews_[i].empty()) {
+          auto value = decodedArgs[i]->valueAt<StringView>(row);
+          totalResultBytes += value.size();
+        } else {
+          totalResultBytes += constantStringViews_[i].size();
+        }
       }
     });
 
@@ -176,8 +240,13 @@ class ConcatFunction : public exec::VectorFunction {
       const char* start = rawBuffer + offset;
 
       size_t combinedSize = 0;
-      for (int i = 0; i < args.size(); i++) {
-        auto value = decodedArgs.at(i)->valueAt<StringView>(row);
+      for (int i = 0; i < numArgs; i++) {
+        StringView value;
+        if (constantStringViews_[i].empty()) {
+          value = decodedArgs[i]->valueAt<StringView>(row);
+        } else {
+          value = constantStringViews_[i];
+        }
         auto size = value.size();
         if (size > 0) {
           memcpy(rawBuffer + offset, value.data(), size);
@@ -202,6 +271,11 @@ class ConcatFunction : public exec::VectorFunction {
   static exec::VectorFunctionMetadata metadata() {
     return {true /* supportsFlattening */};
   }
+
+ private:
+  std::vector<column_index_t> argMapping_;
+  std::vector<std::string> constantStrings_;
+  std::vector<StringView> constantStringViews_;
 };
 
 /**
@@ -495,11 +569,13 @@ VELOX_DECLARE_VECTOR_FUNCTION(
     UpperLowerTemplateFunction<true /*isLower*/>::signatures(),
     std::make_unique<UpperLowerTemplateFunction<true /*isLower*/>>());
 
-VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION_WITH_METADATA(
     udf_concat,
     ConcatFunction::signatures(),
     ConcatFunction::metadata(),
-    std::make_unique<ConcatFunction>());
+    [](const auto& name, const auto& inputs) {
+      return std::make_unique<ConcatFunction>(name, inputs);
+    });
 
 VELOX_DECLARE_VECTOR_FUNCTION(
     udf_strpos,

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -38,7 +38,7 @@ std::string generateRandomString(size_t length) {
 
   std::string randomString;
   for (std::size_t i = 0; i < length; ++i) {
-    randomString += chars[rand() % chars.size()];
+    randomString += chars[folly::Random::rand32() % chars.size()];
   }
   return randomString;
 }
@@ -771,7 +771,8 @@ TEST_F(StringFunctionsTest, concat) {
     // Fill the table
     for (int row = 0; row < rowCount; row++) {
       for (int col = 0; col < argsCount; col++) {
-        inputTable[row][col] = generateRandomString(rand() % maxStringLength);
+        inputTable[row][col] =
+            generateRandomString(folly::Random::rand32() % maxStringLength);
       }
     }
 
@@ -780,13 +781,72 @@ TEST_F(StringFunctionsTest, concat) {
   }
 
   // Test constant input vector with 2 args
-  auto rows = makeRowVector(makeRowType({VARCHAR(), VARCHAR()}), 10);
-  auto c0 = generateRandomString(20);
-  auto c1 = generateRandomString(20);
-  auto result = evaluate<SimpleVector<StringView>>(
-      fmt::format("concat('{}', '{}')", c0, c1), rows);
-  for (int i = 0; i < 10; ++i) {
-    EXPECT_EQ(result->valueAt(i), StringView(c0 + c1));
+  {
+    auto rows = makeRowVector(makeRowType({VARCHAR(), VARCHAR()}), 10);
+    auto c0 = generateRandomString(20);
+    auto c1 = generateRandomString(20);
+    auto result = evaluate<SimpleVector<StringView>>(
+        fmt::format("concat('{}', '{}')", c0, c1), rows);
+    for (int i = 0; i < 10; ++i) {
+      EXPECT_EQ(result->valueAt(i), StringView(c0 + c1));
+    }
+  }
+
+  // Multiple consecutive constant inputs.
+  {
+    std::string value;
+    auto data = makeRowVector({
+        makeFlatVector<StringView>(
+            1'000,
+            [&](auto /* row */) {
+              value = generateRandomString(
+                  folly::Random::rand32() % maxStringLength);
+              return StringView(value);
+            }),
+        makeFlatVector<StringView>(
+            1'000,
+            [&](auto /* row */) {
+              value = generateRandomString(
+                  folly::Random::rand32() % maxStringLength);
+              return StringView(value);
+            }),
+    });
+
+    auto c0 = data->childAt(0)->as<FlatVector<StringView>>()->rawValues();
+    auto c1 = data->childAt(1)->as<FlatVector<StringView>>()->rawValues();
+
+    auto result = evaluate<SimpleVector<StringView>>(
+        "concat(c0, ',', c1, ',', 'foo', ',', 'bar')", data);
+
+    auto expected = makeFlatVector<StringView>(1'000, [&](auto row) {
+      value = c0[row].str() + "," + c1[row].str() + ",foo,bar";
+      return StringView(value);
+    });
+
+    test::assertEqualVectors(expected, result);
+
+    result = evaluate<SimpleVector<StringView>>(
+        "concat('aaa', ',', 'bbb', ',', c0, ',', 'ccc', ',', 'ddd', ',', c1, ',', 'eee', ',', 'fff')",
+        data);
+
+    expected = makeFlatVector<StringView>(1'000, [&](auto row) {
+      value =
+          "aaa,bbb," + c0[row].str() + ",ccc,ddd," + c1[row].str() + ",eee,fff";
+      return StringView(value);
+    });
+    test::assertEqualVectors(expected, result);
+
+    result = evaluate<SimpleVector<StringView>>(
+        "concat(c0, ',', c1, ',', 'A somewhat long string.', ',', 'bar')",
+        data);
+
+    expected = makeFlatVector<StringView>(1'000, [&](auto row) {
+      value =
+          c0[row].str() + "," + c1[row].str() + ",A somewhat long string.,bar";
+      return StringView(value);
+    });
+
+    test::assertEqualVectors(expected, result);
   }
 }
 


### PR DESCRIPTION
Summary:
concat(c0, ',', c1, ',', '100', ',', '200) was 2x slower than concat
(c0, ',', c1, ',100,200'). This change is to optimize concat function
implementation to detect consecutive constant inputs and combine these into
single value. The function is now a stateful vector function.

Before:

```
============================================================================
[...]stosql/benchmarks/ConcatBenchmark.cpp     relative  time/iter   iters/s
============================================================================
basic                                                     176.31ns     5.67M
flatten                                                   172.56ns     5.79M
flattenAndConstantFold                                     99.07ns    10.09M
```

After:

```
============================================================================
[...]stosql/benchmarks/ConcatBenchmark.cpp     relative  time/iter   iters/s
============================================================================
basic                                                      70.25ns    14.24M
flatten                                                    71.88ns    13.91M
flattenAndConstantFold                                     71.83ns    13.92M
```

Differential Revision: D39622939

