### PR TITLE
[velox] Table writer 3: Refactor table writer to use write protocol

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -33,6 +33,8 @@ namespace facebook::velox::exec {
 class ExprSet;
 }
 namespace facebook::velox::connector {
+class ConnectorCommitInfo;
+class WriteProtocol;
 
 // A split represents a chunk of data that a connector should load and return
 // as a RowVectorPtr, potentially after processing pushdowns.
@@ -92,6 +94,10 @@ class ConnectorInsertTableHandle {
 class DataSink {
  public:
   virtual ~DataSink() = default;
+
+  // Get commit info of the connector.
+  virtual std::shared_ptr<ConnectorCommitInfo> getConnectorCommitInfo()
+      const = 0;
 
   // Add the next data (vector) to be written. This call is blocking
   // TODO maybe at some point we want to make it async
@@ -263,7 +269,8 @@ class Connector {
   virtual std::shared_ptr<DataSink> createDataSink(
       RowTypePtr inputType,
       std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
-      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) = 0;
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx,
+      std::shared_ptr<WriteProtocol> writeProtocol) = 0;
 
   // Returns a ScanTracker for 'id'. 'id' uniquely identifies the
   // tracker and different threads will share the same

--- a/velox/connectors/WriteProtocol.cpp
+++ b/velox/connectors/WriteProtocol.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<WriteProtocol> WriteProtocol::getWriteProtocol(
 }
 
 RowVectorPtr DefaultWriteProtocol::commit(
-    const WriteInfo& writeInfo,
+    const CommitInfo& commitInfo,
     velox::memory::MemoryPool* FOLLY_NONNULL pool) {
   return std::make_shared<RowVector>(
       pool,
@@ -68,7 +68,7 @@ RowVectorPtr DefaultWriteProtocol::commit(
       BufferPtr(nullptr),
       1,
       std::vector<VectorPtr>{std::make_shared<ConstantVector<int64_t>>(
-          pool, 1, false, BIGINT(), writeInfo.numWrittenRows())});
+          pool, 1, false, BIGINT(), commitInfo.numWrittenRows())});
 }
 
 } // namespace facebook::velox::connector

--- a/velox/connectors/hive/HiveWriteProtocol.h
+++ b/velox/connectors/hive/HiveWriteProtocol.h
@@ -94,12 +94,33 @@ class HiveWriterParameters : public WriterParameters {
   const std::string writeDirectory_;
 };
 
+/// Commit info of Hive connector.
+class HiveConnectorCommitInfo : public ConnectorCommitInfo {
+ public:
+  /// @param writerParameters Parameters provided for writers. Hive connector
+  /// will pass this info to commit.
+  explicit HiveConnectorCommitInfo(
+      std::vector<std::shared_ptr<const HiveWriterParameters>> writerParameters)
+      : writeParameters_(std::move(writerParameters)) {}
+
+  ~HiveConnectorCommitInfo() override = default;
+
+  const std::vector<std::shared_ptr<const HiveWriterParameters>>&
+  writerParameters() const {
+    return writeParameters_;
+  }
+
+ private:
+  const std::vector<std::shared_ptr<const HiveWriterParameters>>
+      writeParameters_;
+};
+
 /// WriteProtocol base implementation for Hive writes. WriterParameters have the
 /// write file name the same as the target file name, so no commit is needed for
 /// file move.
 class HiveNoCommitWriteProtocol : public DefaultWriteProtocol {
  public:
-  ~HiveNoCommitWriteProtocol() override {}
+  ~HiveNoCommitWriteProtocol() override = default;
 
   CommitStrategy commitStrategy() const override {
     return CommitStrategy::kNoCommit;
@@ -123,7 +144,7 @@ class HiveNoCommitWriteProtocol : public DefaultWriteProtocol {
 /// move write file to the target location.
 class HiveTaskCommitWriteProtocol : public DefaultWriteProtocol {
  public:
-  ~HiveTaskCommitWriteProtocol() override {}
+  ~HiveTaskCommitWriteProtocol() override = default;
 
   CommitStrategy commitStrategy() const override {
     return CommitStrategy::kTaskCommit;

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -149,10 +149,11 @@ class TpchConnector final : public Connector {
   }
 
   std::shared_ptr<DataSink> createDataSink(
-      std::shared_ptr<const RowType> /*inputType*/,
+      RowTypePtr /*inputType*/,
       std::shared_ptr<
           ConnectorInsertTableHandle> /*connectorInsertTableHandle*/,
-      ConnectorQueryCtx* FOLLY_NONNULL /*connectorQueryCtx*/) override final {
+      ConnectorQueryCtx* FOLLY_NONNULL /*connectorQueryCtx*/,
+      std::shared_ptr<WriteProtocol> /*writeProtocol*/) override final {
     VELOX_NYI("TpchConnector does not support data sink.");
   }
 };

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -73,6 +73,7 @@ class TableWriter : public Operator {
   std::shared_ptr<connector::Connector> connector_;
   std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
   std::shared_ptr<connector::DataSink> dataSink_;
+  std::shared_ptr<connector::WriteProtocol> writeProtocol_;
   std::shared_ptr<connector::ConnectorInsertTableHandle> insertTableHandle_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -15,12 +15,14 @@
  */
 #include <folly/experimental/FunctionScheduler.h>
 #include "velox/connectors/Connector.h"
+#include "velox/connectors/WriteProtocol.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::connector;
 using namespace facebook::velox::test;
 
 namespace facebook::velox::exec::test {
@@ -146,10 +148,11 @@ class TestConnector : public connector::Connector {
   }
 
   std::shared_ptr<connector::DataSink> createDataSink(
-      RowTypePtr /* inputType */,
-      std::shared_ptr<connector::ConnectorInsertTableHandle>
-      /* connectorInsertTableHandle */,
-      connector::ConnectorQueryCtx* /* connectorQueryCtx */) override {
+      RowTypePtr /*inputType*/,
+      std::shared_ptr<
+          ConnectorInsertTableHandle> /*connectorInsertTableHandle*/,
+      ConnectorQueryCtx* FOLLY_NONNULL /*connectorQueryCtx*/,
+      std::shared_ptr<WriteProtocol> /*writeProtocol*/) override final {
     VELOX_NYI();
   }
 };

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "velox/common/base/Fs.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/WriteProtocol.h"
+#include "velox/connectors/hive/HiveWriteProtocol.h"
 #include "velox/dwio/common/DataSink.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -29,6 +32,7 @@ class TableWriteTest : public HiveConnectorTestBase {
  protected:
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
+    HiveNoCommitWriteProtocol::registerProtocol();
   }
 
   VectorPtr createConstant(variant value, vector_size_t size) const {
@@ -58,10 +62,9 @@ TEST_F(TableWriteTest, scanFilterProjectWrite) {
     writeToFile(filePaths[i]->path, vectors[i]);
   }
 
-  auto outputDirectory = TempDirectoryPath::create();
-
   createDuckDbTable(vectors);
 
+  auto outputDirectory = TempDirectoryPath::create();
   auto planBuilder = PlanBuilder();
   auto project = planBuilder.tableScan(rowType_)
                      .filter("c0 <> 0")
@@ -80,6 +83,7 @@ TEST_F(TableWriteTest, scanFilterProjectWrite) {
                               rowType_->children(),
                               {},
                               makeLocationHandle(outputDirectory->path))),
+                      WriteProtocol::CommitStrategy::kNoCommit,
                       "rows")
                   .project({"rows"})
                   .planNode();
@@ -107,11 +111,10 @@ TEST_F(TableWriteTest, renameAndReorderColumns) {
     writeToFile(filePaths[i]->path, vectors[i]);
   }
 
-  auto outputDirectory = TempDirectoryPath::create();
   createDuckDbTable(vectors);
 
+  auto outputDirectory = TempDirectoryPath::create();
   auto tableRowType = ROW({"d", "c", "b"}, {VARCHAR(), DOUBLE(), INTEGER()});
-
   auto plan = PlanBuilder()
                   .tableScan(rowType)
                   .tableWrite(
@@ -124,6 +127,7 @@ TEST_F(TableWriteTest, renameAndReorderColumns) {
                               tableRowType->children(),
                               {},
                               makeLocationHandle(outputDirectory->path))),
+                      WriteProtocol::CommitStrategy::kNoCommit,
                       "rows")
                   .project({"rows"})
                   .planNode();
@@ -146,8 +150,9 @@ TEST_F(TableWriteTest, directReadWrite) {
     writeToFile(filePaths[i]->path, vectors[i]);
   }
 
-  auto outputDirectory = TempDirectoryPath::create();
   createDuckDbTable(vectors);
+
+  auto outputDirectory = TempDirectoryPath::create();
   auto plan = PlanBuilder()
                   .tableScan(rowType_)
                   .tableWrite(
@@ -159,6 +164,7 @@ TEST_F(TableWriteTest, directReadWrite) {
                               rowType_->children(),
                               {},
                               makeLocationHandle(outputDirectory->path))),
+                      WriteProtocol::CommitStrategy::kNoCommit,
                       "rows")
                   .project({"rows"})
                   .planNode();
@@ -212,6 +218,7 @@ TEST_F(TableWriteTest, constantVectors) {
                             rowType_->children(),
                             {},
                             makeLocationHandle(outputDirectory->path))),
+                    WriteProtocol::CommitStrategy::kNoCommit,
                     "rows")
                 .project({"rows"})
                 .planNode();
@@ -224,8 +231,51 @@ TEST_F(TableWriteTest, constantVectors) {
       "SELECT * FROM tmp");
 }
 
-// Test TableWriter create empty ORC or not based on the config
-TEST_F(TableWriteTest, writeEmptyFile) {
+TEST_F(TableWriteTest, TestCommitStrategy) {
+  auto filePaths = makeFilePaths(10);
+  auto vectors = makeVectors(rowType_, filePaths.size(), 1000);
+  for (int i = 0; i < filePaths.size(); i++) {
+    writeToFile(filePaths[i]->path, vectors[i]);
+  }
+
+  createDuckDbTable(vectors);
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .tableScan(rowType_)
+                  .tableWrite(
+                      rowType_->names(),
+                      std::make_shared<core::InsertTableHandle>(
+                          kHiveConnectorId,
+                          makeHiveInsertTableHandle(
+                              rowType_->names(),
+                              rowType_->children(),
+                              {},
+                              makeLocationHandle(outputDirectory->path))),
+                      WriteProtocol::CommitStrategy::kTaskCommit,
+                      "rows")
+                  .project({"rows"})
+                  .planNode();
+
+  // No write protocol is registered for CommitStrategy::kTaskCommit.
+  VELOX_ASSERT_THROW(
+      assertQuery(plan, filePaths, "SELECT count(*) FROM tmp"),
+      "No write protocol found for commit strategy TASK_COMMIT");
+
+  // HiveTaskCommitWriteProtocol is registered for CommitStrategy::kTaskCommit.
+  HiveTaskCommitWriteProtocol::registerProtocol();
+  assertQuery(plan, filePaths, "SELECT count(*) FROM tmp");
+
+  // HiveTaskCommitWriteProtocol writes to dot-prefixed file in the
+  // outputDirectory which is still picked up by table scan.
+  assertQuery(
+      PlanBuilder().tableScan(rowType_).planNode(),
+      makeHiveConnectorSplits(outputDirectory),
+      "SELECT * FROM tmp");
+}
+
+// Test TableWriter does not create a file if input is empty.
+TEST_F(TableWriteTest, writeNoFile) {
   auto outputDirectory = TempDirectoryPath::create();
   auto plan = PlanBuilder()
                   .tableScan(rowType_)
@@ -239,6 +289,7 @@ TEST_F(TableWriteTest, writeEmptyFile) {
                               rowType_->children(),
                               {},
                               makeLocationHandle(outputDirectory->path))),
+                      WriteProtocol::CommitStrategy::kNoCommit,
                       "rows")
                   .planNode();
 
@@ -252,10 +303,4 @@ TEST_F(TableWriteTest, writeEmptyFile) {
 
   execute(plan, std::make_shared<core::QueryCtx>(executor_.get()));
   ASSERT_TRUE(fs::is_empty(outputDirectory->path));
-
-  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  queryCtx->setConfigOverridesUnsafe(
-      {{core::QueryConfig::kCreateEmptyFiles, "true"}});
-  execute(plan, queryCtx);
-  ASSERT_FALSE(fs::is_empty(outputDirectory->path));
 }

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -30,6 +30,7 @@
 #include "velox/parse/ExpressionsParser.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::connector;
 using namespace facebook::velox::connector::hive;
 
 namespace facebook::velox::exec::test {
@@ -267,25 +268,30 @@ PlanBuilder& PlanBuilder::filter(const std::string& filter) {
 PlanBuilder& PlanBuilder::tableWrite(
     const std::vector<std::string>& columnNames,
     const std::shared_ptr<core::InsertTableHandle>& insertHandle,
+    WriteProtocol::CommitStrategy commitStrategy,
     const std::string& rowCountColumnName) {
   return tableWrite(
-      planNode_->outputType(), columnNames, insertHandle, rowCountColumnName);
+      planNode_->outputType(),
+      columnNames,
+      insertHandle,
+      commitStrategy,
+      rowCountColumnName);
 }
 
 PlanBuilder& PlanBuilder::tableWrite(
     const RowTypePtr& inputColumns,
     const std::vector<std::string>& tableColumnNames,
     const std::shared_ptr<core::InsertTableHandle>& insertHandle,
+    WriteProtocol::CommitStrategy commitStrategy,
     const std::string& rowCountColumnName) {
-  auto outputType =
-      ROW({rowCountColumnName, "fragments", "commitcontext"},
-          {BIGINT(), VARBINARY(), VARBINARY()});
+  auto outputType = ROW({rowCountColumnName}, {BIGINT()});
   planNode_ = std::make_shared<core::TableWriteNode>(
       nextPlanNodeId(),
       inputColumns,
       tableColumnNames,
       insertHandle,
       outputType,
+      commitStrategy,
       planNode_);
   return *this;
 }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -19,6 +19,7 @@
 #include <velox/core/PlanFragment.h>
 #include <velox/core/PlanNode.h>
 #include "velox/common/memory/Memory.h"
+#include "velox/connectors/WriteProtocol.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
 
@@ -234,6 +235,8 @@ class PlanBuilder {
       const RowTypePtr& inputColumns,
       const std::vector<std::string>& tableColumnNames,
       const std::shared_ptr<core::InsertTableHandle>& insertHandle,
+      connector::WriteProtocol::CommitStrategy commitStrategy =
+          connector::WriteProtocol::CommitStrategy::kNoCommit,
       const std::string& rowCountColumnName = "rowCount");
 
   /// Add a TableWriteNode assuming that input columns names match column names
@@ -246,6 +249,8 @@ class PlanBuilder {
   PlanBuilder& tableWrite(
       const std::vector<std::string>& columnNames,
       const std::shared_ptr<core::InsertTableHandle>& insertHandle,
+      connector::WriteProtocol::CommitStrategy commitStrategy =
+          connector::WriteProtocol::CommitStrategy::kNoCommit,
       const std::string& rowCountColumnName = "rowCount");
 
   /// Add an AggregationNode representing partial aggregation with the

--- a/velox/experimental/codegen/CodegenCompiledExpressionTransform.h
+++ b/velox/experimental/codegen/CodegenCompiledExpressionTransform.h
@@ -84,6 +84,7 @@ class CompiledExpressionTransformVisitor {
           std::placeholders::_1,
           std::placeholders::_1,
           std::placeholders::_1,
+          std::placeholders::_1,
           *ranges::begin(transformedChildren));
     };
 

--- a/velox/experimental/codegen/transform/utils/adapters.h
+++ b/velox/experimental/codegen/transform/utils/adapters.h
@@ -181,6 +181,7 @@ struct TableWriteNodeReader {
         node.columnNames(),
         node.insertTableHandle(),
         node.outputType(),
+        node.commitStrategy(),
         node.sources()[0]);
   }
 };


### PR DESCRIPTION
Refactor TableWriter to take WriteProtocol. WriteProtocol can be
used to to configure write and commit, which will be applied
in the change that follows.

Pass WriteProtocol to DataSink that is used by TableWriter.
DataSink can get the WriterParameters for writers from WriteProtocol,
keep track of them  and includes them in the ConnectorCommitInfo.
TableWriter assembles CommitInfo with ConnectorCommitInfo and more
generic info for commit().

TableWriter getOutputs() also calls on WriteProtocol commit() to perform
protocol particular commit() actions. It would also include
the particular format of outputs that commit() returns.

Make the Velox example ScanAndSort.cpp use HiveNoCommitWriteProtocol,
with no behavior change.