### PR TITLE
Fix bug in to_utf8 presto function

### DIFF
--- a/velox/functions/prestosql/ToUtf8.cpp
+++ b/velox/functions/prestosql/ToUtf8.cpp
@@ -33,16 +33,17 @@ class ToUtf8Function : public exec::VectorFunction {
     if (arg->isConstantEncoding()) {
       auto value = arg->as<ConstantVector<StringView>>()->valueAt(0);
       localResult = std::make_shared<ConstantVector<StringView>>(
-          context.pool(), rows.size(), false, VARBINARY(), std::move(value));
+          context.pool(), rows.end(), false, VARBINARY(), std::move(value));
     } else {
       auto flatInput = arg->asFlatVector<StringView>();
 
       auto stringBuffers = flatInput->stringBuffers();
+      VELOX_CHECK_LE(rows.end(), flatInput->size());
       localResult = std::make_shared<FlatVector<StringView>>(
           context.pool(),
           VARBINARY(),
           nullptr,
-          rows.size(),
+          rows.end(),
           flatInput->values(),
           std::move(stringBuffers));
     }

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1413,6 +1413,19 @@ TEST_F(StringFunctionsTest, toUtf8) {
       "abc",
       evaluateOnce<std::string>(
           "from_hex(to_hex(to_utf8(c0)))", std::optional<std::string>("abc")));
+
+  // This case is a sanity check for the to_utf8 implementation to make sure the
+  // intermediate flat vector created is of the right size. The following
+  // expression reduces the selectivity vector passed to to_utf8('this') to
+  // [0,1,0] (size=3, begin=1, end=2). Then the literal gets evaluated (due to
+  // simplified evaluation the literal is not folded and instead evaluated
+  // during execution) to a vector of size 2 and passed on to to_utf8(). Here,
+  // if the intermediate flat vector is created for a size > 2 then the function
+  // throws.
+  EXPECT_NO_THROW(evaluateSimplified<FlatVector<bool>>(
+      "to_utf8(c0) = to_utf8('this')",
+      makeRowVector({makeNullableFlatVector<StringView>(
+          {std::nullopt, "test"_sv, std::nullopt})})));
 }
 
 namespace {


### PR DESCRIPTION
This patch fixes a bug in to_utf8 presto function's vector function
implementation where it attempts to create a larger sized flat
vector using a smaller sized input vector.

Test Plan:
Added a unit test that triggers the bug in absence of this patch