### PR TITLE
Optimize context building in VeloxException

### DIFF
--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -29,20 +29,25 @@ ExceptionContext& getExceptionContext() {
 // Retrieves the message of the top-level ancestor of the current exception
 // context. If the top-level context message is not empty and is the same as the
 // current one, returns a string indicating they are the same.
-std::string getTopLevelExceptionContextString() {
+std::string getTopLevelExceptionContextString(
+    const std::string& currentMessage) {
   auto* context = &getExceptionContext();
-  auto currentMessage = context->message();
-
-  while (context->parent && context->parent->parent) {
-    context = context->parent;
+  if (context->parent && context->parent->parent) {
+    while (context->parent && context->parent->parent) {
+      context = context->parent;
+    }
+    auto topLevelMessage = context->message();
+    if (!topLevelMessage.empty() && topLevelMessage == currentMessage) {
+      return "Same as context.";
+    } else {
+      return topLevelMessage;
+    }
   }
-  auto topLevelMessage = context->message();
 
-  if (!topLevelMessage.empty() && topLevelMessage == currentMessage) {
+  if (!currentMessage.empty()) {
     return "Same as context.";
-  } else {
-    return topLevelMessage;
   }
+  return "";
 }
 
 VeloxException::VeloxException(
@@ -67,7 +72,8 @@ VeloxException::VeloxException(
         state.errorSource = errorSource;
         state.errorCode = errorCode;
         state.context = getExceptionContext().message();
-        state.topLevelContext = getTopLevelExceptionContextString();
+        state.topLevelContext =
+            getTopLevelExceptionContextString(state.context);
         state.isRetriable = isRetriable;
       })) {}
 

--- a/velox/common/base/tests/ExceptionTest.cpp
+++ b/velox/common/base/tests/ExceptionTest.cpp
@@ -573,24 +573,35 @@ TEST(ExceptionTest, context) {
       "\nFile: ");
 
   // With context.
-  auto messageFunction = [](auto* arg) {
-    return std::string(static_cast<char*>(arg));
+  int callCount = 0;
+
+  struct MessageFunctionArg {
+    std::string message;
+    int* callCount;
+  };
+
+  auto messageFunction = [](void* untypedArg) {
+    auto arg = static_cast<MessageFunctionArg*>(untypedArg);
+    ++(*arg->callCount);
+    return arg->message;
   };
 
   {
     // Create multi-layer contexts.
-    std::string topLevelTroubleshootingAid = "Top-level troubleshooting aid.";
+    MessageFunctionArg topLevelTroubleshootingAid{
+        "Top-level troubleshooting aid.", &callCount};
     facebook::velox::ExceptionContextSetter topLevelContext(
-        {messageFunction, topLevelTroubleshootingAid.data()});
+        {messageFunction, &topLevelTroubleshootingAid});
 
-    std::string midLevelTroubleshootingAid = "Mid-level troubleshooting aid.";
+    MessageFunctionArg midLevelTroubleshootingAid{
+        "Mid-level troubleshooting aid.", &callCount};
     facebook::velox::ExceptionContextSetter midLevelContext(
-        {messageFunction, midLevelTroubleshootingAid.data()});
+        {messageFunction, &midLevelTroubleshootingAid});
 
-    std::string innerLevelTroubleshootingAid =
-        "Inner-level troubleshooting aid.";
+    MessageFunctionArg innerLevelTroubleshootingAid{
+        "Inner-level troubleshooting aid.", &callCount};
     facebook::velox::ExceptionContextSetter innerLevelContext(
-        {messageFunction, innerLevelTroubleshootingAid.data()});
+        {messageFunction, &innerLevelTroubleshootingAid});
 
     verifyVeloxException(
         [&]() { VELOX_CHECK_EQ(1, 3); },
@@ -604,15 +615,19 @@ TEST(ExceptionTest, context) {
         "\nTop-Level Context: Top-level troubleshooting aid."
         "\nFunction: operator()"
         "\nFile: ");
+
+    EXPECT_EQ(2, callCount);
   }
 
   // Different context.
   {
+    callCount = 0;
+
     // Create a single layer of context. Context and top-level context are
     // expected to be the same.
-    std::string debuggingInfo = "Debugging info.";
+    MessageFunctionArg debuggingInfo{"Debugging info.", &callCount};
     facebook::velox::ExceptionContextSetter context(
-        {messageFunction, debuggingInfo.data()});
+        {messageFunction, &debuggingInfo});
 
     verifyVeloxException(
         [&]() { VELOX_CHECK_EQ(1, 3); },
@@ -626,7 +641,11 @@ TEST(ExceptionTest, context) {
         "\nTop-Level Context: Same as context."
         "\nFunction: operator()"
         "\nFile: ");
+
+    EXPECT_EQ(1, callCount);
   }
+
+  callCount = 0;
 
   // No context.
   verifyVeloxException(
@@ -640,14 +659,18 @@ TEST(ExceptionTest, context) {
       "\nFunction: operator()"
       "\nFile: ");
 
+  EXPECT_EQ(0, callCount);
+
   // With message function throwing an exception.
-  auto throwingMessageFunction = [](auto* arg) -> std::string {
+  auto throwingMessageFunction = [](void* untypedArg) -> std::string {
+    auto arg = static_cast<MessageFunctionArg*>(untypedArg);
+    ++(*arg->callCount);
     VELOX_FAIL("Test failure.");
   };
   {
-    std::string debuggingInfo = "Debugging info.";
+    MessageFunctionArg debuggingInfo{"Debugging info.", &callCount};
     facebook::velox::ExceptionContextSetter context(
-        {throwingMessageFunction, debuggingInfo.data()});
+        {throwingMessageFunction, &debuggingInfo});
 
     verifyVeloxException(
         [&]() { VELOX_CHECK_EQ(1, 3); },
@@ -658,8 +681,11 @@ TEST(ExceptionTest, context) {
         "\nRetriable: False"
         "\nExpression: 1 == 3"
         "\nContext: Failed to produce additional context."
+        "\nTop-Level Context: Same as context."
         "\nFunction: operator()"
         "\nFile: ");
+
+    EXPECT_EQ(1, callCount);
   }
 }
 


### PR DESCRIPTION
VeloxException constructor used to call ExceptionContext::message 3 times. Once
to generate current context. Then, two more times to generate top-level
context. The second call is the same as first, hence, redundant. The third call
is needed only if current context is not the top-level context. 

This change removes unnecessary calls.