### PR TITLE
Save input vector to a file when expression evaluation fails

### DIFF
--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -76,3 +76,11 @@ DEFINE_int32(
 DEFINE_bool(avx2, true, "Enables use of AVX2 when available");
 
 DEFINE_bool(bmi2, true, "Enables use of BMI2 when available");
+
+// Used in exec/Expr.cpp
+
+DEFINE_string(
+    velox_save_input_on_expression_failure_path,
+    "",
+    "Enable saving input vector on expression evaluation failure. "
+    "Specifies the directory to use for storing the vectors.");


### PR DESCRIPTION
When an error occurs during expression evaluation, it is useful to save the
input vector as well as the expression to enable reproducing and debugging the
error in isolation. The expression is already included in the Context: field of
the expression. This change adds logic to save the input vector (EvalCtx::row()) 
to a file in a directory specified by gflag
velox_save_input_on_expression_failure_path. 

This functionality is disabled by default. To enable, specify a path to an existing 
writable directory via the velox_save_input_on_expression_failure_path gflag.

```
--velox_save_input_on_expression_failure_path=/tmp
```