### PR TITLE
Fix peeling off encodings from intermediate results

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1239,6 +1239,18 @@ bool Expr::applyFunctionWithPeeling(
     newRows = translateToInnerRows(applyRows, *decoded, newRowsHolder);
     context.saveAndReset(saver, rows);
     setDictionaryWrapping(*decoded, rows, *firstWrapper, context);
+
+    // 'newRows' comes from the set of row numbers in the base vector. These
+    // numbers may be larger than rows.end(). Hence, we need to resize constant
+    // inputs.
+    if (newRows->end() > rows.end() && numConstant) {
+      for (int i = 0; i < numConstant; ++i) {
+        if (!constantArgs.empty() && constantArgs[i]) {
+          inputValues_[i] =
+              BaseVector::wrapInConstant(newRows->end(), 0, inputValues_[i]);
+        }
+      }
+    }
   }
 
   VectorPtr peeledResult;


### PR DESCRIPTION
Fix Expr::applyFunctionWithPeeling for the case when one input is a constant of
size N, while another input is a dictionary of size N over base vector with
size > N. After peeling encodings, first input has size N, while second input
has size > N (the size of the base vector). The translated set of rows now
contains row numbers > N, hence, constant input needs to be resized, otherwise,
accessing rows numbers > N will cause an error.

The error before the fix:

```
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: (351 vs. 879016)
Retriable: False
Expression: source->size() >= sourceIndex + count
Context: array_constructor(element_at(xxx.dense_features, 5555:INTEGER), element_at(xxx.dense_features, 5556:INTEGER)). Input: /tmp/velox_vector_FFRg1X.
Top-Level Context: Same as context.
Function: copyValuesAndNulls
File: .../velox/vector/FlatVector-inl.h
Line: 228
```

Note: I used the new mechanism from #2591 to save input vector on expression evaluation 
failure and create a standalone repro.

```
TEST_F(ExprTest, repro) {
  auto data = restoreVector("/tmp/velox_vector_TzZotH");

  auto result = evaluate(
      "array_constructor(element_at(\"xxx.dense_features\", 5555::INTEGER), element_at(\"xxx.dense_features\", 5556::INTEGER))",
      std::dynamic_pointer_cast<RowVector>(data));
}
```