### PR TITLE
Fix probe scan bug in right semi join

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -505,7 +505,9 @@ RowVectorPtr HashProbe::getOutput() {
     // Right semi join only returns the build side output when the probe side
     // is fully complete. Do not return anything here.
     if (isRightSemiJoin(joinType_)) {
-      input_ = nullptr;
+      if (results_.atEnd()) {
+        input_ = nullptr;
+      }
       return nullptr;
     }
 

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -32,6 +32,17 @@ static int32_t typeKindSize(TypeKind kind) {
 
   return VELOX_DYNAMIC_TYPE_DISPATCH(kindSize, kind);
 }
+
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+__attribute__((__no_sanitize__("thread")))
+#endif
+#endif
+inline void
+setBit(char* bits, uint32_t idx) {
+  auto bitsAs8Bit = reinterpret_cast<uint8_t*>(bits);
+  bitsAs8Bit[idx / 8] |= (1 << (idx % 8));
+}
 } // namespace
 
 RowContainer::RowContainer(
@@ -530,7 +541,7 @@ void RowContainer::setProbedFlag(char** rows, int32_t numRows) {
   for (auto i = 0; i < numRows; i++) {
     // Row may be null in case of a FULL join.
     if (rows[i]) {
-      bits::setBit(rows[i], probedFlagOffset_);
+      setBit(rows[i], probedFlagOffset_);
     }
   }
 }


### PR DESCRIPTION
When right semi join probe more than the output buffer size,
it stops probing and also clear the input_ buffer without checking
if the probe iterator has reached to the end or not. We shall not
reset input buffer if the probe iterator still has more rows to scan.
Verify the fix with unit test.