### PR TITLE
Add MmapArena to main code path

### DIFF
--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -74,7 +74,8 @@ class AsyncDataCacheTest : public testing::Test {
           executor(),
           ssdBytes / 20);
     }
-    memory::MmapAllocatorOptions options = {maxBytes};
+    memory::MmapAllocatorOptions options;
+    options.capacity = maxBytes;
     cache_ = std::make_shared<AsyncDataCache>(
         std::make_shared<memory::MmapAllocator>(options),
         maxBytes,

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -26,6 +26,7 @@
 
 #include "velox/common/base/SimdUtil.h"
 #include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MmapArena.h"
 
 namespace facebook::velox::memory {
 
@@ -36,6 +37,15 @@ using ClassPageCount = int32_t;
 struct MmapAllocatorOptions {
   //  Capacity in bytes, default 512MB
   uint64_t capacity = 1L << 29;
+
+  // If set true, allocations larger than largest size class size will be
+  // delegated to ManagedMmapArena. Otherwise a system mmap call will be
+  // issued for each such allocation.
+  bool useMmapArena = false;
+
+  // Used to determine MmapArena capacity. The ratio represents system memory
+  // capacity to single MmapArena capacity ratio.
+  int32_t mmapArenaCapacityRatio = 10;
 };
 
 // Implementation of MappedMemory with mmap and madvise. Each size
@@ -339,6 +349,17 @@ class MmapAllocator : public MappedMemory {
   std::atomic<uint64_t> numAllocations_ = 0;
   std::atomic<uint64_t> numAllocatedPages_ = 0;
   std::atomic<uint64_t> numAdvisedPages_ = 0;
+
+  // Allocations that are larger than largest size classes will be delegated to
+  // ManagedMmapArenas, to avoid calling mmap on every allocation.
+  std::mutex arenaMutex_;
+  std::unique_ptr<ManagedMmapArenas> managedArenas_;
+
+  // If set true, allocations larger than largest size class size will be
+  // delegated to ManagedMmapArena. Otherwise a system mmap call will be
+  // issued for each such allocation.
+  bool useMmapArena_;
+
   Failure injectedFailure_{Failure::kNone};
   Stats stats_;
 };

--- a/velox/common/memory/MmapArena.h
+++ b/velox/common/memory/MmapArena.h
@@ -25,10 +25,16 @@
 
 namespace facebook::velox::memory {
 
-static constexpr uint64_t kMinGrainSizeBytes = 1024 * 1024;
-
 class MmapArena {
  public:
+  // Single MmapArena capacity is determined by mmap_arena_capacity_ratio ratio
+  // but the capacity should be at least kMinCapacityBytes if the calculated
+  // capacity from the ratio is too small to serve large allocations.
+  static constexpr int64_t kMinCapacityBytes = 128 * 1024 * 1024; // 128M
+
+  // MmapArena capacity should be multiple of kMinGrainSizeBytes.
+  static constexpr uint64_t kMinGrainSizeBytes = 1024 * 1024; // 1M
+
   MmapArena(size_t capacityBytes);
   ~MmapArena();
 

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -27,7 +27,8 @@ class ByteStreamTest : public testing::TestWithParam<bool> {
  protected:
   void SetUp() override {
     constexpr uint64_t kMaxMappedMemory = 64 << 20;
-    MmapAllocatorOptions options = {kMaxMappedMemory};
+    MmapAllocatorOptions options;
+    options.capacity = kMaxMappedMemory;
     mmapAllocator_ = std::make_shared<MmapAllocator>(options);
     MappedMemory::setDefaultInstance(mmapAllocator_.get());
   }

--- a/velox/common/memory/tests/MappedMemoryTest.cpp
+++ b/velox/common/memory/tests/MappedMemoryTest.cpp
@@ -42,7 +42,8 @@ class MappedMemoryTest : public testing::TestWithParam<bool> {
         MemoryUsageConfigBuilder().maxTotalMemory(kMaxMappedMemory).build());
     useMmap_ = GetParam();
     if (useMmap_) {
-      MmapAllocatorOptions options = {kMaxMappedMemory};
+      MmapAllocatorOptions options;
+      options.capacity = kMaxMappedMemory;
       mmapAllocator_ = std::make_shared<MmapAllocator>(options);
       MappedMemory::setDefaultInstance(mmapAllocator_.get());
     } else {

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -332,14 +332,16 @@ void testMmapMemoryAllocation(
 }
 
 TEST(MemoryPoolTest, SmallMmapMemoryAllocation) {
-  MmapAllocatorOptions options = {8 * GB};
+  MmapAllocatorOptions options;
+  options.capacity = 8 * GB;
   auto mmapAllocator = std::make_unique<memory::MmapAllocator>(options);
   MappedMemory::setDefaultInstance(mmapAllocator.get());
   testMmapMemoryAllocation(mmapAllocator.get(), 6, 100);
 }
 
 TEST(MemoryPoolTest, BigMmapMemoryAllocation) {
-  MmapAllocatorOptions options = {8 * GB};
+  MmapAllocatorOptions options;
+  options.capacity = 8 * GB;
   auto mmapAllocator = std::make_unique<memory::MmapAllocator>(options);
   MappedMemory::setDefaultInstance(mmapAllocator.get());
   testMmapMemoryAllocation(

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -131,7 +131,8 @@ class CacheTest : public testing::Test {
           executor_.get());
       groupStats_ = &ssd->groupStats();
     }
-    memory::MmapAllocatorOptions options = {maxBytes};
+    memory::MmapAllocatorOptions options;
+    options.capacity = maxBytes;
     cache_ = std::make_shared<AsyncDataCache>(
         std::make_shared<memory::MmapAllocator>(options),
         maxBytes,


### PR DESCRIPTION
Summary:
* Add memory pool to use mmap allocator as an option in MmapAllocatorOptions
* Hook up MmapArena to main allocation code path.

Reviewed By: oerling

Differential Revision: D37131566

