### PR TITLE
Fix memoryUsageTracker::release

### DIFF
--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -453,6 +453,13 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
         totalLargeAllocateBytes_};
   }
 
+  // clears counters to revert effect of previous tests.
+  static void testingClearAllocateBytesStats() {
+    totalSmallAllocateBytes_ = 0;
+    totalSizeClassAllocateBytes_ = 0;
+    totalLargeAllocateBytes_ = 0;
+  }
+
   virtual Stats stats() const {
     return Stats();
   }

--- a/velox/common/memory/tests/MappedMemoryTest.cpp
+++ b/velox/common/memory/tests/MappedMemoryTest.cpp
@@ -38,6 +38,7 @@ static constexpr MachinePageCount kCapacity =
 class MappedMemoryTest : public testing::TestWithParam<bool> {
  protected:
   void SetUp() override {
+    MappedMemory::destroyTestOnly();
     auto tracker = MemoryUsageTracker::create(
         MemoryUsageConfigBuilder().maxTotalMemory(kMaxMappedMemory).build());
     useMmap_ = GetParam();
@@ -615,6 +616,7 @@ TEST_P(MappedMemoryTest, allocContiguousFail) {
 
 TEST_P(MappedMemoryTest, allocateBytes) {
   constexpr int32_t kNumAllocs = 50;
+  MappedMemory::testingClearAllocateBytesStats();
   // Different sizes, including below minimum and above largest size class.
   std::vector<MachinePageCount> sizes = {
       MappedMemory::kMaxMallocBytes / 2,


### PR DESCRIPTION
Fix memoryUsageTracker::release


The meaning of reserve() is to increase the accounted usage so as to
guarantee that at least the reserved amount can be allocated (recorded
with update()).  The meaning of release() is to revert the effect of
the previous reserve(), if any.

In other words, if we are above the reserved amount, release() just
forgets the reservation. If we are below the reserved amount,
release() computes the reservation as it would be if no explicit
reserve had been made and adjustts the usage to this and then forgets
the explicit reservation.

Adds a test documenting this behavior.

The previous behavior was to set the used amount to 0, wich is
obviously wrong. This function has not been used outside of the spill
path, hence we expect the fix not to affect applications.

***

The meaning of getNumAllocs() is the cumulative count of direct
allocations since construction of the tracker. This was however
counting the number of quantized reservation increments. Note that
this counter is meaningful only for leaf trackers.

***

Fix test order dependences in velox_memory_test. Deleted MmapAllocator
instances could otherwise be used in some test orders, as test order
is not defined.
