### PR TITLE
Add to split spill partition to support parallel spill restore

### DIFF
--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -625,9 +625,9 @@ class SpillerTest : public exec::test::RowContainerTestBase {
     ASSERT_EQ(spillPartitionSet.size(), spillPartitionNumSet.size());
 
     for (auto& spillPartitionEntry : spillPartitionSet) {
-      const int partition = spillPartitionEntry.first.partitionNumber;
+      const int partition = spillPartitionEntry.first.partitionNumber();
       ASSERT_EQ(
-          hashBits_.begin(), spillPartitionEntry.first.partitionBitOffset);
+          hashBits_.begin(), spillPartitionEntry.first.partitionBitOffset());
       auto reader = spillPartitionEntry.second->createReader();
       if (type_ == Spiller::Type::kHashJoinProbe) {
         // For hash probe type, we append each input vector as one batch in


### PR DESCRIPTION
Add split method in SpillPartition to split the M spill files from a
spill partition into N shards, and each shard have M/N. It is to
parallelize the spill partition restore. N will be the number of 
build operators in a hash join.