### PR TITLE
Add composable API for Array generation on VectorFuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -532,7 +532,7 @@ class ExpressionFuzzer {
     if (rowVector) {
       LOG(INFO) << rowVector->childrenSize() << " vectors as input:";
       for (const auto& child : rowVector->children()) {
-        LOG(INFO) << "\t" << child->toString();
+        LOG(INFO) << "\t" << child->toString(/*recursive=*/true);
       }
 
       if (VLOG_IS_ON(1)) {

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -116,6 +116,14 @@ class VectorFuzzer {
   // DictionaryVector which has `size` indices.
   VectorPtr fuzzDictionary(const VectorPtr& vector, vector_size_t size);
 
+  // Uses `elements` as the internal elements vector, wrapping them into an
+  // ArrayVector of `size` rows.
+  //
+  // The number of elements per array row is based on the size of the
+  // `elements` vector and `size`, and either fixed or variable (depending on
+  // `opts.containerVariableLength`).
+  ArrayVectorPtr fuzzArray(const VectorPtr& elements, vector_size_t size);
+
   // Returns a "fuzzed" row vector with randomized data and nulls.
   RowVectorPtr fuzzRow(const RowTypePtr& rowType);
 


### PR DESCRIPTION
Summary:
Add API `fuzzArray(vector, size)` to allow a more composable API for
clients generating a specific encoding configuration. Next PR will add support
for Maps and refactor the current fuzz() method to use them.

Reviewed By: mbasmanova

Differential Revision: D39681322

