### PR TITLE
Add Expr::toSql() method

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -685,4 +685,11 @@ std::string CastExpr::toString(bool recursive) const {
   return out.str();
 }
 
+std::string CastExpr::toSql() const {
+  std::stringstream out;
+  out << "cast(";
+  appendInputsSql(out);
+  out << " as " << type_->toString() << ")";
+  return out.str();
+}
 } // namespace facebook::velox::exec

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -102,6 +102,8 @@ class CastExpr : public SpecialForm {
 
   std::string toString(bool recursive = true) const override;
 
+  std::string toSql() const override;
+
  private:
   /// @tparam To The cast target type
   /// @tparam From The expression type

--- a/velox/expression/ConjunctExpr.cpp
+++ b/velox/expression/ConjunctExpr.cpp
@@ -276,4 +276,13 @@ void ConjunctExpr::updateResult(
     }
   }
 }
+
+std::string ConjunctExpr::toSql() const {
+  std::stringstream out;
+  out << inputs_[0]->toSql();
+  for (auto i = 1; i < inputs_.size(); ++i) {
+    out << " " << name_ << " " << inputs_[i]->toSql();
+  }
+  return out.str();
+}
 } // namespace facebook::velox::exec

--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -56,6 +56,8 @@ class ConjunctExpr : public SpecialForm {
     return selectivity_[inputOrder_[index]];
   }
 
+  std::string toSql() const override;
+
  private:
   void maybeReorderInputs();
   void updateResult(

--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -72,4 +72,117 @@ std::string ConstantExpr::toString(bool /*recursive*/) const {
         "{}:{}", sharedSubexprValues_->toString(0), type()->toString());
   }
 }
+
+namespace {
+void appendSqlLiteral(
+    const BaseVector& vector,
+    vector_size_t row,
+    std::ostream& out);
+
+void appendSqlLiteralList(
+    const BaseVector& vector,
+    vector_size_t offset,
+    vector_size_t size,
+    std::ostream& out) {
+  for (auto i = offset; i < offset + size; ++i) {
+    if (i > offset) {
+      out << ", ";
+    }
+    appendSqlLiteral(vector, i, out);
+  }
+}
+
+void appendSqlString(const std::string& value, std::ostream& out) {
+  // Escape single quotes: ' -> ''.
+  static constexpr char kSingleQuote = '\'';
+
+  out << kSingleQuote;
+  auto prevPos = 0;
+  auto pos = value.find(kSingleQuote);
+  while (pos != std::string::npos) {
+    out << value.substr(prevPos, pos - prevPos) << kSingleQuote;
+    prevPos = pos;
+    pos = value.find(kSingleQuote, prevPos + 1);
+  }
+  out << value.substr(prevPos, pos) << kSingleQuote;
+  return;
+}
+
+void appendSqlLiteral(
+    const BaseVector& vector,
+    vector_size_t row,
+    std::ostream& out) {
+  if (vector.isNullAt(row)) {
+    out << "NULL";
+    return;
+  }
+
+  switch (vector.typeKind()) {
+    case TypeKind::BOOLEAN: {
+      auto value = vector.as<SimpleVector<bool>>()->valueAt(row);
+      out << (value ? "TRUE" : "FALSE");
+      break;
+    }
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::INTEGER:
+    case TypeKind::BIGINT:
+    case TypeKind::REAL:
+    case TypeKind::DOUBLE:
+      out << vector.wrappedVector()->toString(vector.wrappedIndex(row))
+          << "::" << vector.type()->toString();
+      break;
+    case TypeKind::VARCHAR: {
+      appendSqlString(
+          vector.wrappedVector()->toString(vector.wrappedIndex(row)), out);
+      break;
+    }
+    case TypeKind::ARRAY: {
+      out << "ARRAY[";
+      auto arrayVector = vector.wrappedVector()->as<ArrayVector>();
+      auto arrayRow = vector.wrappedIndex(row);
+      auto offset = arrayVector->offsetAt(arrayRow);
+      auto size = arrayVector->sizeAt(arrayRow);
+      appendSqlLiteralList(*arrayVector->elements(), offset, size, out);
+      out << "]";
+      break;
+    }
+    case TypeKind::MAP: {
+      out << "map(ARRAY[";
+      auto mapVector = vector.wrappedVector()->as<MapVector>();
+      auto mapRow = vector.wrappedIndex(row);
+      auto offset = mapVector->offsetAt(mapRow);
+      auto size = mapVector->sizeAt(mapRow);
+      appendSqlLiteralList(*mapVector->mapKeys(), offset, size, out);
+      out << "], ARRAY[";
+      appendSqlLiteralList(*mapVector->mapValues(), offset, size, out);
+      out << "])";
+      break;
+    }
+    case TypeKind::ROW: {
+      out << "row_constructor(";
+      auto rowVector = vector.wrappedVector()->as<RowVector>();
+      auto baseRow = vector.wrappedIndex(row);
+      for (auto i = 0; i < rowVector->childrenSize(); ++i) {
+        if (i > 0) {
+          out << ", ";
+        }
+        appendSqlLiteral(*rowVector->childAt(i), baseRow, out);
+      }
+      out << ")";
+      break;
+    }
+    default:
+      VELOX_UNSUPPORTED(
+          "Type not supported yet: {}", vector.type()->toString());
+  }
+}
+} // namespace
+
+std::string ConstantExpr::toSql() const {
+  VELOX_CHECK_NOT_NULL(sharedSubexprValues_);
+  std::ostringstream out;
+  appendSqlLiteral(*sharedSubexprValues_, 0, out);
+  return out.str();
+}
 } // namespace facebook::velox::exec

--- a/velox/expression/ConstantExpr.h
+++ b/velox/expression/ConstantExpr.h
@@ -61,6 +61,8 @@ class ConstantExpr : public SpecialForm {
 
   std::string toString(bool recursive = true) const override;
 
+  std::string toSql() const override;
+
  private:
   const variant value_;
   bool needToSetIsAscii_;

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1328,6 +1328,13 @@ std::string Expr::toString(bool recursive) const {
   return name_;
 }
 
+std::string Expr::toSql() const {
+  std::stringstream out;
+  out << "\"" << name_ << "\"";
+  appendInputsSql(out);
+  return out.str();
+}
+
 void Expr::appendInputs(std::stringstream& stream) const {
   if (!inputs_.empty()) {
     stream << "(";
@@ -1336,6 +1343,19 @@ void Expr::appendInputs(std::stringstream& stream) const {
         stream << ", ";
       }
       stream << inputs_[i]->toString();
+    }
+    stream << ")";
+  }
+}
+
+void Expr::appendInputsSql(std::stringstream& stream) const {
+  if (!inputs_.empty()) {
+    stream << "(";
+    for (auto i = 0; i < inputs_.size(); ++i) {
+      if (i > 0) {
+        stream << ", ";
+      }
+      stream << inputs_[i]->toSql();
     }
     stream << ")";
   }

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -202,6 +202,9 @@ class Expr {
   /// their inputs recursively.
   virtual std::string toString(bool recursive = true) const;
 
+  /// Return the expression as SQL string.
+  virtual std::string toSql() const;
+
   const ExprStats& stats() const {
     return stats_;
   }
@@ -313,6 +316,8 @@ class Expr {
 
  protected:
   void appendInputs(std::stringstream& stream) const;
+
+  void appendInputsSql(std::stringstream& stream) const;
 
   /// Release 'inputValues_' back to vector pool in 'evalCtx' so they can be
   /// reused.

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -211,7 +211,7 @@ ExprPtr getRowConstructorExpr(
       type,
       std::move(compiledChildren),
       rowConstructorVectorFunction,
-      "row",
+      "row_constructor",
       trackCpuUsage);
 }
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -97,7 +97,12 @@ class ExprTest : public testing::Test, public VectorTestBase {
       const VectorPtr& base,
       vector_size_t index) {
     return std::make_shared<core::ConstantTypedExpr>(
-        std::make_shared<ConstantVector<T>>(execCtx_->pool(), 1, index, base));
+        BaseVector::wrapInConstant(1, index, base));
+  }
+
+  /// Create constant expression from a variant of primitive type.
+  std::shared_ptr<core::ConstantTypedExpr> makeConstantExpr(variant value) {
+    return std::make_shared<core::ConstantTypedExpr>(std::move(value));
   }
 
   // Create LazyVector that produces a flat vector and asserts that is is being
@@ -149,6 +154,15 @@ class ExprTest : public testing::Test, public VectorTestBase {
       ASSERT_EQ(topLevelContext, e.topLevelContext());
       ASSERT_EQ(message, e.message());
     }
+  }
+
+  void testToSql(const std::string& expression, const RowTypePtr& rowType) {
+    auto exprSet = compileExpression(expression, rowType);
+    auto sql = exprSet->expr(0)->toSql();
+    auto copy = compileExpression(sql, rowType);
+    ASSERT_EQ(
+        exprSet->toString(false /*compact*/), copy->toString(false /*compact*/))
+        << sql;
   }
 
   std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
@@ -2057,6 +2071,124 @@ TEST_F(ExprTest, constantToString) {
   ASSERT_EQ(
       "4 elements starting at 0 {1.2000000476837158, 3.4000000953674316, null, 5.599999904632568}:ARRAY<REAL>",
       exprSet.exprs()[2]->toString());
+}
+
+TEST_F(ExprTest, constantToSql) {
+  auto toSql = [&](const variant& value) {
+    exec::ExprSet exprSet({makeConstantExpr(value)}, execCtx_.get());
+    return exprSet.expr(0)->toSql();
+  };
+
+  ASSERT_EQ(toSql(true), "TRUE");
+  ASSERT_EQ(toSql(false), "FALSE");
+  ASSERT_EQ(toSql(variant::null(TypeKind::BOOLEAN)), "NULL");
+
+  ASSERT_EQ(toSql((int8_t)23), "23::TINYINT");
+  ASSERT_EQ(toSql(variant::null(TypeKind::TINYINT)), "NULL");
+
+  ASSERT_EQ(toSql((int16_t)23), "23::SMALLINT");
+  ASSERT_EQ(toSql(variant::null(TypeKind::SMALLINT)), "NULL");
+
+  ASSERT_EQ(toSql(23), "23::INTEGER");
+  ASSERT_EQ(toSql(variant::null(TypeKind::INTEGER)), "NULL");
+
+  ASSERT_EQ(toSql(2134456LL), "2134456::BIGINT");
+  ASSERT_EQ(toSql(variant::null(TypeKind::BIGINT)), "NULL");
+
+  ASSERT_EQ(toSql(1.5f), "1.5::REAL");
+  ASSERT_EQ(toSql(variant::null(TypeKind::REAL)), "NULL");
+
+  ASSERT_EQ(toSql(-78.456), "-78.456::DOUBLE");
+  ASSERT_EQ(toSql(variant::null(TypeKind::DOUBLE)), "NULL");
+
+  ASSERT_EQ(toSql("This is a test."), "'This is a test.'");
+  ASSERT_EQ(
+      toSql("This is a \'test\' with single quotes."),
+      "'This is a \'\'test\'\' with single quotes.'");
+  ASSERT_EQ(toSql(variant::null(TypeKind::VARCHAR)), "NULL");
+
+  auto toSqlComplex = [&](const VectorPtr& vector, vector_size_t index = 0) {
+    exec::ExprSet exprSet({makeConstantExpr(vector, index)}, execCtx_.get());
+    return exprSet.expr(0)->toSql();
+  };
+
+  ASSERT_EQ(
+      toSqlComplex(makeArrayVector<int32_t>({{1, 2, 3}})),
+      "ARRAY[1::INTEGER, 2::INTEGER, 3::INTEGER]");
+  ASSERT_EQ(
+      toSqlComplex(makeArrayVector<int32_t>({{1, 2, 3}, {4, 5, 6}}), 1),
+      "ARRAY[4::INTEGER, 5::INTEGER, 6::INTEGER]");
+  ASSERT_EQ(toSql(variant::null(TypeKind::ARRAY)), "NULL");
+
+  ASSERT_EQ(
+      toSqlComplex(makeMapVector<int32_t, int32_t>({
+          {{1, 10}, {2, 20}, {3, 30}},
+      })),
+      "map(ARRAY[1::INTEGER, 2::INTEGER, 3::INTEGER], ARRAY[10::INTEGER, 20::INTEGER, 30::INTEGER])");
+  ASSERT_EQ(
+      toSqlComplex(
+          makeMapVector<int32_t, int32_t>({
+              {{1, 11}, {2, 12}},
+              {{1, 10}, {2, 20}, {3, 30}},
+          }),
+          1),
+      "map(ARRAY[1::INTEGER, 2::INTEGER, 3::INTEGER], ARRAY[10::INTEGER, 20::INTEGER, 30::INTEGER])");
+  ASSERT_EQ(
+      toSqlComplex(BaseVector::createNullConstant(
+          MAP(INTEGER(), VARCHAR()), 10, pool())),
+      "NULL");
+
+  ASSERT_EQ(
+      toSqlComplex(makeRowVector({
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<bool>({true, false, true}),
+      })),
+      "row_constructor(1::INTEGER, TRUE)");
+  ASSERT_EQ(
+      toSqlComplex(BaseVector::createNullConstant(
+          ROW({"a", "b"}, {BOOLEAN(), DOUBLE()}), 10, pool())),
+      "NULL");
+}
+
+TEST_F(ExprTest, toSql) {
+  auto rowType = ROW({"a", "b", "c.d"}, {INTEGER(), BIGINT(), VARCHAR()});
+
+  // CAST.
+  testToSql("a + 3", rowType);
+  testToSql("a * b", rowType);
+  testToSql("a * 1.5", rowType);
+
+  // SWITCH.
+  testToSql("if(a > 0, 1, 10)", rowType);
+  testToSql("if(a = 10, true, false)", rowType);
+  testToSql("case a when 7 then 1 when 11 then 2 else 0 end", rowType);
+  testToSql("case a when 7 then 1 when 11 then 2 when 17 then 3 end", rowType);
+  testToSql(
+      "case a when b + 3 then 1 when b * 11 then 2 when b - 17 then a + b end",
+      rowType);
+
+  // AND / OR.
+  testToSql("a > 0 AND b < 100", rowType);
+  testToSql("a > 0 AND b / a < 100", rowType);
+  testToSql("is_null(a) OR is_null(b)", rowType);
+
+  // COALESCE.
+  testToSql("coalesce(a::bigint, b, 123)", rowType);
+
+  // TRY.
+  testToSql("try(a / b)", rowType);
+
+  // String literals.
+  testToSql("length(\"c.d\")", rowType);
+  testToSql("concat(a::varchar, ',', b::varchar, '\'\'')", rowType);
+
+  // Array, map and row literals.
+  testToSql("contains(array[1, 2, 3], a)", rowType);
+  testToSql("map(array[a, b, 5], array[10, 20, 30])", rowType);
+  testToSql(
+      "element_at(map(array[1, 2, 3], array['a', 'b', 'c']), a)", rowType);
+  testToSql("row_constructor(a, b, 'test')", rowType);
+  testToSql("row_constructor(true, 1.5, 'abc', array[1, 2, 3])", rowType);
 }
 
 namespace {


### PR DESCRIPTION
Add Expr::toSql() method to get SQL string for the expression.

When an error happens during expression evaluation, we save the input vector to
a file and include the file path along with the output of Expr::toString() in
the exception message. The output of Expr::toString() is not exactly valid SQL,
hence, needs to be tweaked to reproduce the error. It would be more convenient
to also write SQL for the failed expression to another file and include that
file path in the exception message. Then, reproducing the error would require
just reading the vector from one file, reading the SQL from another, then
evaluating the expression. No more manual editing of the expression string.