### PR TITLE
Fix ConjunctExpr::toSql()

### DIFF
--- a/velox/expression/ConjunctExpr.cpp
+++ b/velox/expression/ConjunctExpr.cpp
@@ -279,9 +279,10 @@ void ConjunctExpr::updateResult(
 
 std::string ConjunctExpr::toSql() const {
   std::stringstream out;
-  out << inputs_[0]->toSql();
+  out << "(" << inputs_[0]->toSql() << ")";
   for (auto i = 1; i < inputs_.size(); ++i) {
-    out << " " << name_ << " " << inputs_[i]->toSql();
+    out << " " << name_ << " "
+        << "(" << inputs_[i]->toSql() << ")";
   }
   return out.str();
 }

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2214,6 +2214,7 @@ TEST_F(ExprTest, toSql) {
   testToSql("a > 0 AND b < 100", rowType);
   testToSql("a > 0 AND b / a < 100", rowType);
   testToSql("is_null(a) OR is_null(b)", rowType);
+  testToSql("a > 10 AND (b > 100 OR a < 0) AND b < 3", rowType);
 
   // COALESCE.
   testToSql("coalesce(a::bigint, b, 123)", rowType);


### PR DESCRIPTION
Add parenthesis around conjuncts in AND / OR expressions.