### PR TITLE
Document compilation of COALESCE expressions

### DIFF
--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -1332,6 +1332,17 @@ For both simple and vector functions, their names are case insensitive. Function
 names are converted to lower case automatically when the functions are
 registered and when they are resolved for a given expression.
 
+The following names are reserved for special forms and cannot be used as function
+names:
+
+* and
+* or
+* cast
+* if
+* switch
+* coalesce
+* try
+* row_constructor
 
 Function Resolution order
 -------------------------


### PR DESCRIPTION
Update Expression Evaluation documentation to 
- explain that coalesce calls are compiled to CoalesceExpr;
- fix the order of resolution of scalar functions (vector functions take precedence);
- move Constant Folding section after Flattening section (to match the code flow);

Also, update How to add a scalar function? guide to list reserved names that cannot 
be used for scalar functions.