### PR TITLE
Change the intermediate type of approx_percentile to `ROW`

### DIFF
--- a/velox/docs/develop/aggregate-functions.rst
+++ b/velox/docs/develop/aggregate-functions.rst
@@ -580,3 +580,18 @@ To confirm that aggregate function works end to end as part of query, update tes
 .. code-block:: java
 
     assertQuery("SELECT orderkey, array_agg(linenumber) FROM lineitem GROUP BY 1");
+
+Overwrite Intermediate Type in Presto
+-------------------------------------
+
+Sometimes we need to change the intermediate type of aggregation function in
+Presto, due to the differences in implementation or in the type information
+worker node receives.  This is done in Presto class
+``com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager``.  When
+``FeaturesConfig.isUseAlternativeFunctionSignatures()`` is enabled, we can
+register a different set of function signatures used specifically by Velox.  An
+example of how to create such alternative function signatures from scratch can
+be found in
+``com.facebook.presto.operator.aggregation.AlternativeApproxPercentile``.  An
+example pull request can be found at
+https://github.com/prestodb/presto/pull/18386.

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -125,7 +125,7 @@ void AggregationTestBase::testAggregations(
         assertResults) {
   {
     SCOPED_TRACE("Run partial + final");
-    PlanBuilder builder;
+    PlanBuilder builder(pool());
     makeSource(builder);
     builder.partialAggregation(groupingKeys, aggregates).finalAggregation();
     if (!postAggregationProjections.empty()) {
@@ -138,7 +138,7 @@ void AggregationTestBase::testAggregations(
 
   {
     SCOPED_TRACE("Run single");
-    PlanBuilder builder;
+    PlanBuilder builder(pool());
     makeSource(builder);
     builder.singleAggregation(groupingKeys, aggregates);
     if (!postAggregationProjections.empty()) {
@@ -151,7 +151,7 @@ void AggregationTestBase::testAggregations(
 
   if (!groupingKeys.empty() && allowInputShuffle_) {
     SCOPED_TRACE("Run partial + final with spilling");
-    PlanBuilder builder;
+    PlanBuilder builder(pool());
     makeSource(builder);
 
     // Spilling needs at least 2 batches of input. Use round-robin
@@ -187,7 +187,7 @@ void AggregationTestBase::testAggregations(
 
   {
     SCOPED_TRACE("Run partial + intermediate + final");
-    PlanBuilder builder;
+    PlanBuilder builder(pool());
     makeSource(builder);
 
     builder.partialAggregation(groupingKeys, aggregates)
@@ -204,7 +204,7 @@ void AggregationTestBase::testAggregations(
 
   if (!groupingKeys.empty()) {
     SCOPED_TRACE("Run partial + local exchange + final");
-    PlanBuilder builder;
+    PlanBuilder builder(pool());
     makeSource(builder);
 
     builder.partialAggregation(groupingKeys, aggregates)
@@ -222,7 +222,7 @@ void AggregationTestBase::testAggregations(
   {
     SCOPED_TRACE(
         "Run partial + local exchange + intermediate + local exchange + final");
-    PlanBuilder builder;
+    PlanBuilder builder(pool());
     makeSource(builder);
 
     builder.partialAggregation(groupingKeys, aggregates);


### PR DESCRIPTION
Summary:
Before this change, intermediate aggregation node for `approx_percentile` in worker only sees a type signature of `VARBINARY -> VARBINARY`, thus not be able to figure out the actual value type and cannot perform the merge properly when the value type is not `DOUBLE`.

This fix changes the intermediate result type to `ROW` so that we can get the value type from it and instantiate accumulator with proper type.

Fix https://github.com/facebookincubator/velox/issues/2430

Differential Revision: D39733152

