### PR TITLE
Fix test generating umbounded float filters

### DIFF
--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -99,6 +99,10 @@ std::unique_ptr<Filter> ColumnStats<float>::makeRangeFilter(
   float upper = valueAtPct(startPct + selectPct);
   bool lowerUnbounded = std::isnan(lower);
   bool upperUnbounded = std::isnan(upper);
+  if (lowerUnbounded && upperUnbounded) {
+    return std::make_unique<velox::common::IsNotNull>();
+  }
+
   return std::make_unique<velox::common::FloatRange>(
       lower,
       lowerUnbounded,
@@ -120,6 +124,9 @@ std::unique_ptr<Filter> ColumnStats<double>::makeRangeFilter(
   double upper = valueAtPct(startPct + selectPct);
   bool lowerUnbounded = std::isnan(lower);
   bool upperUnbounded = std::isnan(upper);
+  if (lowerUnbounded && upperUnbounded) {
+    return std::make_unique<velox::common::IsNotNull>();
+  }
   return std::make_unique<velox::common::DoubleRange>(
       lower,
       lowerUnbounded,

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -984,7 +984,11 @@ class AbstractRange : public Filter {
         lowerUnbounded_(lowerUnbounded),
         lowerExclusive_(lowerExclusive),
         upperUnbounded_(upperUnbounded),
-        upperExclusive_(upperExclusive) {}
+        upperExclusive_(upperExclusive) {
+    VELOX_CHECK(
+        !lowerUnbounded_ || !upperUnbounded_,
+        "A range filter must have  a lower or upper  bound");
+  }
 
  protected:
   const bool lowerUnbounded_;


### PR DESCRIPTION
Summary:
testValues and testDouble/testFloat of a float Filter with no bounds
produce different results. We check that a float filter has at least
one bound at construction since range filter with no bounds does not
make sense.

We fix FilterGenerator to generate a not null instead of a
float/double range if the bounds of the range would both be #nan.

Reviewed By: Yuhta

Differential Revision: D37327248

