### PR TITLE
Bumped benchalerts dep to 0.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
             # upgrade python to 3.8 for this job
             yum install -y python38
             pip3.8 install conbench
-            pip3.8 install git+https://github.com/conbench/benchalerts.git@0.1.0
+            pip3.8 install git+https://github.com/conbench/benchalerts.git@0.1.1
             pip3.8 install scripts/veloxbench
       - run:
           name: "Run Benchmarks"


### PR DESCRIPTION
Fixes #2622.

The benchmarks pipeline recently had a few [failures](https://app.circleci.com/pipelines/github/facebookincubator/velox/13774/workflows/eba736b7-c13e-43f5-8404-a0e74d7c2716/jobs/83131) because `benchalerts` tried to compare the commit to its immediate parent (which didn't have any runs), instead of the baseline commit recommended by Conbench.

This version bump includes [this PR](https://github.com/conbench/benchalerts/pull/13), which should fix the issue.