### PR TITLE
Use meaningful Memory Pool names.

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -36,14 +36,15 @@ DriverCtx::DriverCtx(
       splitGroupId(_splitGroupId),
       partitionId(_partitionId),
       task(_task),
-      pool(task->addDriverPool()) {}
+      pool(task->addDriverPool(pipelineId, driverId)) {}
 
 const core::QueryConfig& DriverCtx::queryConfig() const {
   return task->queryCtx()->config();
 }
 
-velox::memory::MemoryPool* FOLLY_NONNULL DriverCtx::addOperatorPool() {
-  return task->addOperatorPool(pool);
+velox::memory::MemoryPool* FOLLY_NONNULL
+DriverCtx::addOperatorPool(const std::string& operatorType) {
+  return task->addOperatorPool(pool, operatorType);
 }
 
 std::atomic_uint64_t BlockingState::numBlockedDrivers_{0};

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -197,7 +197,8 @@ struct DriverCtx {
 
   const core::QueryConfig& queryConfig() const;
 
-  velox::memory::MemoryPool* FOLLY_NONNULL addOperatorPool();
+  velox::memory::MemoryPool* FOLLY_NONNULL
+  addOperatorPool(const std::string& operatorType = "");
 };
 
 class Driver : public std::enable_shared_from_this<Driver> {

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -54,8 +54,8 @@ class SimpleExpressionEvaluator : public connector::ExpressionEvaluator {
 };
 } // namespace
 
-OperatorCtx::OperatorCtx(DriverCtx* driverCtx)
-    : driverCtx_(driverCtx), pool_(driverCtx_->addOperatorPool()) {}
+OperatorCtx::OperatorCtx(DriverCtx* driverCtx, const std::string& operatorType)
+    : driverCtx_(driverCtx), pool_(driverCtx_->addOperatorPool(operatorType)) {}
 
 core::ExecCtx* OperatorCtx::execCtx() const {
   if (!execCtx_) {
@@ -87,7 +87,7 @@ Operator::Operator(
     int32_t operatorId,
     std::string planNodeId,
     std::string operatorType)
-    : operatorCtx_(std::make_unique<OperatorCtx>(driverCtx)),
+    : operatorCtx_(std::make_unique<OperatorCtx>(driverCtx, operatorType)),
       stats_(
           operatorId,
           driverCtx->pipelineId,

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -164,7 +164,9 @@ struct OperatorStats {
 
 class OperatorCtx {
  public:
-  explicit OperatorCtx(DriverCtx* driverCtx);
+  explicit OperatorCtx(
+      DriverCtx* driverCtx,
+      const std::string& operatorType = "");
 
   const std::shared_ptr<Task>& task() const {
     return driverCtx_->task;

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -260,13 +260,14 @@ class Task : public std::enable_shared_from_this<Task> {
   /// library components (Driver, Operator, etc.) and should not be called by
   /// the library users.
 
-  memory::MemoryPool* FOLLY_NONNULL addDriverPool();
+  memory::MemoryPool* FOLLY_NONNULL addDriverPool(int pipelineId, int driverId);
 
   /// Creates new instance of MemoryPool, stores it in the task to ensure
   /// lifetime and returns a raw pointer. Not thread safe, e.g. must be called
   /// from the Operator's constructor.
-  memory::MemoryPool* FOLLY_NONNULL
-  addOperatorPool(memory::MemoryPool* FOLLY_NONNULL driverPool);
+  memory::MemoryPool* FOLLY_NONNULL addOperatorPool(
+      memory::MemoryPool* FOLLY_NONNULL driverPool,
+      const std::string& operatorType = "");
 
   /// Creates new instance of MappedMemory, stores it in the task to ensure
   /// lifetime and returns a raw pointer. Not thread safe, e.g. must be called


### PR DESCRIPTION
Summary:
Use meaningful, more informative Memory Pool names for Query, Task, Driver and Operator.
This is planned to be used to generate a message similar to the below for errors of hitting query memory limit.
  query.20220920_231930_00015_jbxgr: bytes 7511998464
      task.20220920_231930_00015_jbxgr.1.0.49: bytes 6437208064
          pipe 0: min 0, max: 374145024, total: 5594611712
              op.PartitionedOutput: min: 0, max: 0, total: 0
              op.FilterProject: min: 0, max: 0, total: 0
              op.Aggregation: min: 0, max: 374145024, total: 5594611712
              op.LocalExchange: min: 0, max: 0, total: 0
          pipe 1: min 0, max: 75250863, total: 86346671
              op.LocalPartition: min: 0, max: 45056, total: 196608
              op.Exchange: min: 0, max: 75250863, total: 86150063
      task.20220920_231930_00015_jbxgr.2.0.13: bytes 1074790400
          pipe 0: min 0, max: 39780352, total: 985705551
              op.PartitionedOutput: min: 0, max: 39780352, total: 516775936
              op.PartialAggregation: min: 0, max: 18447488, total: 157649792
              op.FilterProject: min: 0, max: 716480, total: 12252480
              op.TableScan: min: 0, max: 21431775, total: 299027343

Differential Revision: D39742781

