### PR TITLE
Revamp VectorFuzzer API, refactor, and document it

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -61,3 +61,7 @@ target_link_libraries(velox_benchmark_basic_preproc ${velox_benchmark_deps}
 add_executable(velox_like_functions_benchmark LikeFunctionsBenchmark.cpp)
 target_link_libraries(velox_like_functions_benchmark ${velox_benchmark_deps}
                       velox_functions_lib velox_tpch_gen velox_vector_test_lib)
+
+add_executable(velox_benchmark_basic_vector_fuzzer VectorFuzzer.cpp)
+target_link_libraries(velox_benchmark_basic_vector_fuzzer
+                      ${velox_benchmark_deps} velox_vector_test_lib)

--- a/velox/benchmarks/basic/VectorFuzzer.cpp
+++ b/velox/benchmarks/basic/VectorFuzzer.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <gflags/gflags.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+namespace {
+
+using namespace facebook::velox;
+
+std::unique_ptr<memory::MemoryPool> pool{memory::getDefaultScopedMemoryPool()};
+
+VectorFuzzer::Options getOpts(size_t n, double nullRatio = 0) {
+  VectorFuzzer::Options opts;
+  opts.vectorSize = n;
+  opts.nullRatio = nullRatio;
+  return opts;
+}
+
+BENCHMARK_MULTI(flatInteger, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(BIGINT()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatIntegerHalfNull, n) {
+  VectorFuzzer fuzzer(getOpts(n, 0.5), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(BIGINT()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatDouble, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(DOUBLE()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatBool, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(BOOLEAN()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatVarcharAscii, n) {
+  auto opts = getOpts(n);
+  opts.charEncodings = {UTF8CharList::ASCII};
+
+  VectorFuzzer fuzzer(opts, pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(VARCHAR()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatVarcharUtf8, n) {
+  auto opts = getOpts(n);
+  opts.charEncodings = {UTF8CharList::EXTENDED_UNICODE};
+
+  VectorFuzzer fuzzer(opts, pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(VARCHAR()));
+  return n;
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_RELATIVE_MULTI(constantInteger, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzConstant(BIGINT()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(dictionaryInteger, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzDictionary(fuzzer.fuzzFlat(BIGINT())));
+  return n;
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_RELATIVE_MULTI(flatArray, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  const size_t elementsSize = n * fuzzer.getOptions().containerLength;
+  folly::doNotOptimizeAway(
+      fuzzer.fuzzArray(fuzzer.fuzzFlat(BIGINT(), elementsSize), n));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatMap, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  const size_t elementsSize = n * fuzzer.getOptions().containerLength;
+  folly::doNotOptimizeAway(fuzzer.fuzzMap(
+      fuzzer.fuzzFlat(BIGINT(), elementsSize),
+      fuzzer.fuzzFlat(BIGINT(), elementsSize),
+      n));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatMapArrayNested, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  const size_t elementsSize = n * fuzzer.getOptions().containerLength;
+
+  folly::doNotOptimizeAway(fuzzer.fuzzMap(
+      fuzzer.fuzzFlat(BIGINT(), elementsSize),
+      fuzzer.fuzzArray(
+          fuzzer.fuzzFlat(BIGINT(), elementsSize * 10), elementsSize),
+      n));
+  return n;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -31,10 +31,10 @@ namespace facebook::velox {
 using FuzzerGenerator = std::mt19937;
 
 enum UTF8CharList {
-  ASCII, /* Ascii character set.*/
-  UNICODE_CASE_SENSITIVE, /* Unicode scripts that support case.*/
-  EXTENDED_UNICODE, /* Extended Unicode: Arabic, Devanagiri etc*/
-  MATHEMATICAL_SYMBOLS /* Mathematical Symbols.*/
+  ASCII = 0, // Ascii character set.
+  UNICODE_CASE_SENSITIVE = 1, // Unicode scripts that support case.
+  EXTENDED_UNICODE = 2, // Extended Unicode: Arabic, Devanagiri etc
+  MATHEMATICAL_SYMBOLS = 3 // Mathematical Symbols.
 };
 
 class VectorFuzzer {
@@ -90,6 +90,10 @@ class VectorFuzzer {
 
   void setOptions(VectorFuzzer::Options options) {
     opts_ = options;
+  }
+
+  const VectorFuzzer::Options& getOptions() {
+    return opts_;
   }
 
   // Returns a "fuzzed" vector, containing randomized data, nulls, and indices

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -25,9 +25,6 @@
 
 namespace facebook::velox {
 
-// Helper class to generate randomized vectors with random (and potentially
-// nested) encodings. Use the constructor seed to make it deterministic.
-
 using FuzzerGenerator = std::mt19937;
 
 enum UTF8CharList {
@@ -37,6 +34,50 @@ enum UTF8CharList {
   MATHEMATICAL_SYMBOLS = 3 // Mathematical Symbols.
 };
 
+/// VectorFuzzer is a helper class that generates randomized vectors and their
+/// data for testing, with a high degree of entropy.
+///
+/// `Options` can be used to customize its behavior, and a seed passed to the
+/// constructor can make it deterministic.
+///
+/// There a three main ways in which VectorFuzzer can be used:
+///
+/// #1.
+///
+/// The `fuzz(type)` method provides the highest degree of entropy. It randomly
+/// generates different types of (possibly nested) encodings given the input
+/// type, including constants, dictionaries, sliced vectors, and more. It
+/// accepts any primitive, complex, or nested types:
+///
+///   auto vector1 = fuzzer.fuzz(INTEGER());
+///   auto vector2 = fuzzer.fuzz(MAP(ARRAY(INTEGER()), ROW({REAL(), BIGINT()}));
+///   auto vector3 = fuzzer.fuzz(ROW({SMALLINT(), DOUBLE()}));
+///
+/// #2.
+///
+/// The `fuzzFlat(type)` method provides a similar API, except that generated
+/// vectors are guaranteed to be flat. It accepts complex types like arrays,
+/// maps, and rows:
+///
+///   auto vector1 = fuzzer.fuzzFlat(TINYINT());
+///   auto vector2 = fuzzer.fuzzFlat(
+///                     MAP(ARRAY(INTEGER()), ROW({REAL(), BIGINT()}));
+///
+/// #3.
+///
+/// For more control over the generated encodings, VectorFuzzer also provides
+/// composable APIs to let users specify the generated encodings. For instance,
+/// to generate a map where the key is a dictionary wrapped around a flat
+/// vector, and the value an array with an internal constant vector, you can
+/// use:
+///
+///   auto vector = fuzzer.fuzzMap(
+///      fuzzer.fuzzDictionary(
+///          fuzzer.fuzzFlat(INTEGER(), 10), 100),
+///      fuzzer.fuzzArray(
+///          fuzzer.fuzzConstant(DOUBLE(), 40), 100),
+///      10);
+///
 class VectorFuzzer {
  public:
   struct Options {
@@ -97,22 +138,24 @@ class VectorFuzzer {
   }
 
   // Returns a "fuzzed" vector, containing randomized data, nulls, and indices
-  // vector (dictionary).
+  // vector (dictionary). Returns a vector of `opts_.vectorSize` size.
   VectorPtr fuzz(const TypePtr& type);
+
+  // Same as above, but returns a vector of `size` size.
+  VectorPtr fuzz(const TypePtr& type, vector_size_t size);
 
   // Returns a flat vector or a complex vector with flat children with
   // randomized data and nulls. Returns a vector of `opts_.vectorSize` size.
   VectorPtr fuzzFlat(const TypePtr& type);
 
-  // Returns a flat vector or a complex vector with flat children with
-  // randomized data and nulls. Returns a vector of `size` size.
+  // Same as above, but returns a vector of `size` size.
   VectorPtr fuzzFlat(const TypePtr& type, vector_size_t size);
 
-  // Returns a random constant vector (which could be a null constant).
+  // Returns a random constant vector (which could be a null constant). Returns
+  // a vector with size set to `opts_.vectorSize`.
   VectorPtr fuzzConstant(const TypePtr& type);
 
-  // Returns a random constant vector (which could be a null constant). The
-  // returned vector has `size` set as size.
+  // Same as above, but returns a vector of `size` size.
   VectorPtr fuzzConstant(const TypePtr& type, vector_size_t size);
 
   // Wraps `vector` using a randomized indices vector, returning a
@@ -120,8 +163,7 @@ class VectorFuzzer {
   // `vector` size.
   VectorPtr fuzzDictionary(const VectorPtr& vector);
 
-  // Wraps `vector` using a randomized indices vector, returning a
-  // DictionaryVector which has `size` indices.
+  // Same as above, but returns a dictionary vector of `size` size.
   VectorPtr fuzzDictionary(const VectorPtr& vector, vector_size_t size);
 
   // Uses `elements` as the internal elements vector, wrapping them into an
@@ -143,6 +185,10 @@ class VectorFuzzer {
 
   // Returns a "fuzzed" row vector with randomized data and nulls.
   RowVectorPtr fuzzRow(const RowTypePtr& rowType);
+
+  // Returns a RowVector based on the provided vectors, fuzzing its top-level
+  // null buffer.
+  RowVectorPtr fuzzRow(std::vector<VectorPtr>&& children, vector_size_t size);
 
   // Same as the function above, but never return nulls for the top-level row
   // elements.
@@ -171,23 +217,17 @@ class VectorFuzzer {
   }
 
  private:
-  VectorPtr
-  fuzz(const TypePtr& type, vector_size_t size, bool flatEncoding = false);
+  // Generates a flat vector for primitive types.
+  VectorPtr fuzzFlatPrimitive(const TypePtr& type, vector_size_t size);
 
   // Returns a complex vector with randomized data and nulls.  The children and
   // all other descendant vectors will randomly use constant, dictionary, or
   // flat encodings if flatEncoding is set to false, otherwise they will all be
   // flat.
-  VectorPtr fuzzComplex(
-      const TypePtr& type,
-      vector_size_t size,
-      bool flatEncoding = false);
+  VectorPtr fuzzComplex(const TypePtr& type, vector_size_t size);
 
-  RowVectorPtr fuzzRow(
-      const RowTypePtr& rowType,
-      vector_size_t size,
-      bool rowHasNulls,
-      bool flatEncoding = false);
+  RowVectorPtr
+  fuzzRow(const RowTypePtr& rowType, vector_size_t size, bool rowHasNulls);
 
   // Generate a random null buffer.
   BufferPtr fuzzNulls(vector_size_t size);


### PR DESCRIPTION
Summary:
Revamp VectorFuzzer API to support more clearer and better defined
usage modes, adding more unit tests and a header comment.

Differential Revision: D39745016

