### PR TITLE
Use double type for TPC-H Connector scaleFactor

### DIFF
--- a/velox/connectors/tpch/TpchConnector.cpp
+++ b/velox/connectors/tpch/TpchConnector.cpp
@@ -27,7 +27,7 @@ RowVectorPtr getTpchData(
     Table table,
     size_t maxRows,
     size_t offset,
-    size_t scaleFactor,
+    double scaleFactor,
     memory::MemoryPool* pool) {
   switch (table) {
     case Table::TBL_PART:

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -43,10 +43,12 @@ class TpchTableHandle : public ConnectorTableHandle {
   explicit TpchTableHandle(
       std::string connectorId,
       velox::tpch::Table table,
-      size_t scaleFactor = 1)
+      double scaleFactor = 1.0)
       : ConnectorTableHandle(std::move(connectorId)),
         table_(table),
-        scaleFactor_(scaleFactor) {}
+        scaleFactor_(scaleFactor) {
+    VELOX_CHECK_GE(scaleFactor, 0, "Tpch scale factor must be non-negative");
+  }
 
   ~TpchTableHandle() override {}
 
@@ -56,13 +58,13 @@ class TpchTableHandle : public ConnectorTableHandle {
     return table_;
   }
 
-  size_t getScaleFactor() const {
+  double getScaleFactor() const {
     return scaleFactor_;
   }
 
  private:
   const velox::tpch::Table table_;
-  size_t scaleFactor_;
+  double scaleFactor_;
 };
 
 class TpchDataSource : public DataSource {
@@ -103,7 +105,7 @@ class TpchDataSource : public DataSource {
   RowVectorPtr projectOutputColumns(RowVectorPtr vector);
 
   velox::tpch::Table tpchTable_;
-  size_t scaleFactor_{1};
+  double scaleFactor_{1.0};
   size_t tpchTableRowCount_{0};
   RowTypePtr outputType_;
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -138,7 +138,7 @@ PlanBuilder& PlanBuilder::tableScan(
 PlanBuilder& PlanBuilder::tableScan(
     tpch::Table table,
     std::vector<std::string>&& columnNames,
-    size_t scaleFactor) {
+    double scaleFactor) {
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
       assignmentsMap;
   std::vector<TypePtr> outputTypes;

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -171,7 +171,7 @@ class PlanBuilder {
   PlanBuilder& tableScan(
       tpch::Table table,
       std::vector<std::string>&& columnNames,
-      size_t scaleFactor = 1);
+      double scaleFactor = 1);
 
   /// Add a ValuesNode using specified data.
   ///

--- a/velox/tpch/gen/DBGenIterator.cpp
+++ b/velox/tpch/gen/DBGenIterator.cpp
@@ -48,10 +48,14 @@ static folly::Singleton<DBGenBackend> DBGenBackendSingleton;
 
 } // namespace
 
-DBGenIterator::DBGenIterator(size_t scaleFactor) {
+DBGenIterator::DBGenIterator(double scaleFactor) {
   auto dbgenBackend = DBGenBackendSingleton.try_get();
   VELOX_CHECK_NOT_NULL(dbgenBackend, "Unable to initialize dbgen's dbgunk.");
-  dbgenCtx_.scale_factor = scaleFactor;
+  if (scaleFactor < MIN_SCALE && scaleFactor > 0) {
+    dbgenCtx_.scale_factor = 1;
+  } else {
+    dbgenCtx_.scale_factor = static_cast<long>(scaleFactor);
+  }
 }
 
 void DBGenIterator::initNation(size_t offset) {

--- a/velox/tpch/gen/DBGenIterator.h
+++ b/velox/tpch/gen/DBGenIterator.h
@@ -28,7 +28,7 @@ namespace facebook::velox::tpch {
 /// synthetically generated data, backed by DBGEN.
 class DBGenIterator {
  public:
-  explicit DBGenIterator(size_t scaleFactor);
+  explicit DBGenIterator(double scaleFactor);
 
   // Before generating records using the gen*() functions below, call the
   // appropriate init*() function to correctly initialize the seed given the

--- a/velox/tpch/gen/TpchGen.cpp
+++ b/velox/tpch/gen/TpchGen.cpp
@@ -29,8 +29,9 @@ namespace {
 // the number of lineitems in an order is chosen at random with an average of
 // four. This function contains the row count for all authorized scale factors
 // (as described by the TPC-H spec), and approximates the remaining.
-constexpr size_t getLineItemRowCount(size_t scaleFactor) {
-  switch (scaleFactor) {
+constexpr size_t getLineItemRowCount(double scaleFactor) {
+  auto longScaleFactor = static_cast<long>(scaleFactor);
+  switch (longScaleFactor) {
     case 1:
       return 6'001'215;
     case 10:
@@ -125,7 +126,8 @@ Table fromTableName(std::string_view tableName) {
       fmt::format("Invalid TPC-H table name: '{}'", tableName));
 }
 
-size_t getRowCount(Table table, size_t scaleFactor) {
+size_t getRowCount(Table table, double scaleFactor) {
+  VELOX_CHECK_GE(scaleFactor, 0, "Tpch scale factor must be non-negative");
   switch (table) {
     case Table::TBL_PART:
       return 200'000 * scaleFactor;
@@ -352,8 +354,9 @@ TypePtr resolveTpchColumn(Table table, const std::string& columnName) {
 RowVectorPtr genTpchOrders(
     size_t maxRows,
     size_t offset,
-    size_t scaleFactor,
+    double scaleFactor,
     memory::MemoryPool* pool) {
+  VELOX_CHECK_GE(scaleFactor, 0, "Tpch scale factor must be non-negative");
   // Create schema and allocate vectors.
   auto ordersRowType = getTableSchema(Table::TBL_ORDERS);
   size_t vectorSize = getVectorSize(
@@ -397,8 +400,9 @@ RowVectorPtr genTpchOrders(
 RowVectorPtr genTpchLineItem(
     size_t maxOrderRows,
     size_t ordersOffset,
-    size_t scaleFactor,
+    double scaleFactor,
     memory::MemoryPool* pool) {
+  VELOX_CHECK_GE(scaleFactor, 0, "Tpch scale factor must be non-negative");
   // We control the buffer size based on the orders table, then allocate the
   // underlying buffer using the worst case (orderVectorSize * 7).
   size_t orderVectorSize = getVectorSize(
@@ -490,8 +494,9 @@ RowVectorPtr genTpchLineItem(
 RowVectorPtr genTpchPart(
     size_t maxRows,
     size_t offset,
-    size_t scaleFactor,
+    double scaleFactor,
     memory::MemoryPool* pool) {
+  VELOX_CHECK_GE(scaleFactor, 0, "Tpch scale factor must be non-negative");
   // Create schema and allocate vectors.
   auto partRowType = getTableSchema(Table::TBL_PART);
   size_t vectorSize =
@@ -534,8 +539,9 @@ RowVectorPtr genTpchPart(
 RowVectorPtr genTpchSupplier(
     size_t maxRows,
     size_t offset,
-    size_t scaleFactor,
+    double scaleFactor,
     memory::MemoryPool* pool) {
+  VELOX_CHECK_GE(scaleFactor, 0, "Tpch scale factor must be non-negative");
   // Create schema and allocate vectors.
   auto supplierRowType = getTableSchema(Table::TBL_SUPPLIER);
   size_t vectorSize = getVectorSize(
@@ -578,8 +584,9 @@ RowVectorPtr genTpchSupplier(
 RowVectorPtr genTpchPartSupp(
     size_t maxRows,
     size_t offset,
-    size_t scaleFactor,
+    double scaleFactor,
     memory::MemoryPool* pool) {
+  VELOX_CHECK_GE(scaleFactor, 0, "Tpch scale factor must be non-negative");
   // Create schema and allocate vectors.
   auto partSuppRowType = getTableSchema(Table::TBL_PARTSUPP);
   size_t vectorSize = getVectorSize(
@@ -638,8 +645,9 @@ RowVectorPtr genTpchPartSupp(
 RowVectorPtr genTpchCustomer(
     size_t maxRows,
     size_t offset,
-    size_t scaleFactor,
+    double scaleFactor,
     memory::MemoryPool* pool) {
+  VELOX_CHECK_GE(scaleFactor, 0, "Tpch scale factor must be non-negative");
   // Create schema and allocate vectors.
   auto customerRowType = getTableSchema(Table::TBL_CUSTOMER);
   size_t vectorSize = getVectorSize(
@@ -685,8 +693,9 @@ RowVectorPtr genTpchCustomer(
 RowVectorPtr genTpchNation(
     size_t maxRows,
     size_t offset,
-    size_t scaleFactor,
+    double scaleFactor,
     memory::MemoryPool* pool) {
+  VELOX_CHECK_GE(scaleFactor, 0, "Tpch scale factor must be non-negative");
   // Create schema and allocate vectors.
   auto nationRowType = getTableSchema(Table::TBL_NATION);
   size_t vectorSize = getVectorSize(
@@ -719,8 +728,9 @@ RowVectorPtr genTpchNation(
 RowVectorPtr genTpchRegion(
     size_t maxRows,
     size_t offset,
-    size_t scaleFactor,
+    double scaleFactor,
     memory::MemoryPool* pool) {
+  VELOX_CHECK_GE(scaleFactor, 0, "Tpch scale factor must be non-negative");
   // Create schema and allocate vectors.
   auto regionRowType = getTableSchema(Table::TBL_REGION);
   size_t vectorSize = getVectorSize(

--- a/velox/tpch/gen/TpchGen.h
+++ b/velox/tpch/gen/TpchGen.h
@@ -56,7 +56,7 @@ Table fromTableName(std::string_view tableName);
 /// defined in the spec available at:
 ///
 ///  https://www.tpc.org/tpch/
-size_t getRowCount(Table table, size_t scaleFactor);
+size_t getRowCount(Table table, double scaleFactor);
 
 /// Returns the schema (RowType) for a particular TPC-H table.
 RowTypePtr getTableSchema(Table table);
@@ -82,7 +82,7 @@ TypePtr resolveTpchColumn(Table table, const std::string& columnName);
 RowVectorPtr genTpchOrders(
     size_t maxRows = 10000,
     size_t offset = 0,
-    size_t scaleFactor = 1,
+    double scaleFactor = 1,
     memory::MemoryPool* pool =
         &velox::memory::getProcessDefaultMemoryManager().getRoot());
 
@@ -121,7 +121,7 @@ RowVectorPtr genTpchOrders(
 RowVectorPtr genTpchLineItem(
     size_t maxOrdersRows = 10000,
     size_t ordersOffset = 0,
-    size_t scaleFactor = 1,
+    double scaleFactor = 1,
     memory::MemoryPool* pool =
         &velox::memory::getProcessDefaultMemoryManager().getRoot());
 
@@ -142,7 +142,7 @@ RowVectorPtr genTpchLineItem(
 RowVectorPtr genTpchPart(
     size_t maxRows = 10000,
     size_t offset = 0,
-    size_t scaleFactor = 1,
+    double scaleFactor = 1,
     memory::MemoryPool* pool =
         &velox::memory::getProcessDefaultMemoryManager().getRoot());
 
@@ -161,7 +161,7 @@ RowVectorPtr genTpchPart(
 RowVectorPtr genTpchSupplier(
     size_t maxRows = 10000,
     size_t offset = 0,
-    size_t scaleFactor = 1,
+    double scaleFactor = 1,
     memory::MemoryPool* pool =
         &velox::memory::getProcessDefaultMemoryManager().getRoot());
 
@@ -178,7 +178,7 @@ RowVectorPtr genTpchSupplier(
 RowVectorPtr genTpchPartSupp(
     size_t maxRows = 10000,
     size_t offset = 0,
-    size_t scaleFactor = 1,
+    double scaleFactor = 1,
     memory::MemoryPool* pool =
         &velox::memory::getProcessDefaultMemoryManager().getRoot());
 
@@ -198,7 +198,7 @@ RowVectorPtr genTpchPartSupp(
 RowVectorPtr genTpchCustomer(
     size_t maxRows = 10000,
     size_t offset = 0,
-    size_t scaleFactor = 1,
+    double scaleFactor = 1,
     memory::MemoryPool* pool =
         &velox::memory::getProcessDefaultMemoryManager().getRoot());
 
@@ -214,7 +214,7 @@ RowVectorPtr genTpchCustomer(
 RowVectorPtr genTpchNation(
     size_t maxRows = 10000,
     size_t offset = 0,
-    size_t scaleFactor = 1,
+    double scaleFactor = 1,
     memory::MemoryPool* pool =
         &velox::memory::getProcessDefaultMemoryManager().getRoot());
 
@@ -229,7 +229,7 @@ RowVectorPtr genTpchNation(
 RowVectorPtr genTpchRegion(
     size_t maxRows = 10000,
     size_t offset = 0,
-    size_t scaleFactor = 1,
+    double scaleFactor = 1,
     memory::MemoryPool* pool =
         &velox::memory::getProcessDefaultMemoryManager().getRoot());
 


### PR DESCRIPTION
The scaleFactor type has been changed from `size_t` to `double` to 
facilitate the generation of smaller data sets.

Resolves https://github.com/facebookincubator/velox/issues/2612