### PR TITLE
Extend HashJoinBridge object to support hash join spill

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -747,7 +747,6 @@ class AsyncDataCache : public memory::MappedMemory {
   // for memory arbitration to work.
   bool makeSpace(
       memory::MachinePageCount numPages,
-
       std::function<bool()> allocate);
 
   std::shared_ptr<memory::MappedMemory> mappedMemory_;

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(
   GroupingSet.cpp
   HashAggregation.cpp
   HashBuild.cpp
+  HashJoinBridge.cpp
   HashPartitionFunction.cpp
   HashProbe.cpp
   HashTable.cpp

--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/HashJoinBridge.h"
+
+namespace facebook::velox::exec {
+
+void HashJoinBridge::start() {
+  std::lock_guard<std::mutex> l(mutex_);
+  started_ = true;
+  VELOX_CHECK_GT(numBuilders_, 0);
+}
+
+void HashJoinBridge::addBuilder() {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK(!started_);
+  ++numBuilders_;
+}
+
+bool HashJoinBridge::setHashTable(
+    std::unique_ptr<BaseHashTable> table,
+    SpillPartitionSet spillPartitionSet) {
+  VELOX_CHECK_NOT_NULL(table, "setHashTable called with null table");
+
+  auto spillPartitionIdSet = toSpillPartitionIdSet(spillPartitionSet);
+
+  bool hasSpillData;
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK(started_);
+    VELOX_CHECK(!buildResult_.has_value());
+    VELOX_CHECK(restoringSpillShards_.empty());
+
+    if (restoringSpillPartitionId_.has_value()) {
+      for (const auto& id : spillPartitionIdSet) {
+        VELOX_DCHECK_LT(
+            restoringSpillPartitionId_->partitionBitOffset(),
+            id.partitionBitOffset());
+      }
+    }
+
+    for (auto& partitionEntry : spillPartitionSet) {
+      const auto id = partitionEntry.first;
+      VELOX_CHECK_EQ(spillPartitionSets_.count(id), 0);
+      spillPartitionSets_.emplace(id, std::move(partitionEntry.second));
+    }
+    buildResult_ = HashBuildResult(
+        std::move(table),
+        std::move(restoringSpillPartitionId_),
+        std::move(spillPartitionIdSet));
+    restoringSpillPartitionId_.reset();
+
+    hasSpillData = !spillPartitionSets_.empty();
+    promises = std::move(promises_);
+  }
+  notify(std::move(promises));
+  return hasSpillData;
+}
+
+void HashJoinBridge::setAntiJoinHasNullKeys() {
+  std::vector<ContinuePromise> promises;
+  SpillPartitionSet spillPartitions;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK(started_);
+    VELOX_CHECK(!buildResult_.has_value());
+    VELOX_CHECK(restoringSpillShards_.empty());
+
+    buildResult_ = HashBuildResult{};
+    restoringSpillPartitionId_.reset();
+    spillPartitions.swap(spillPartitionSets_);
+    promises = std::move(promises_);
+  }
+  notify(std::move(promises));
+}
+
+std::optional<HashJoinBridge::HashBuildResult> HashJoinBridge::tableOrFuture(
+    ContinueFuture* future) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK(started_);
+  VELOX_CHECK(!cancelled_, "Getting hash table after join is aborted");
+  VELOX_CHECK(
+      !buildResult_.has_value() ||
+      (!restoringSpillPartitionId_.has_value() &&
+       restoringSpillShards_.empty()));
+
+  if (buildResult_.has_value()) {
+    return buildResult_.value();
+  }
+  promises_.emplace_back("HashJoinBridge::tableOrFuture");
+  *future = promises_.back().getSemiFuture();
+  return std::nullopt;
+}
+
+bool HashJoinBridge::probeFinished() {
+  std::vector<ContinuePromise> promises;
+  bool hasSpillInput = false;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK(started_);
+    VELOX_CHECK(buildResult_.has_value());
+    VELOX_CHECK(
+        !restoringSpillPartitionId_.has_value() &&
+        restoringSpillShards_.empty());
+    VELOX_CHECK_GT(numBuilders_, 0);
+
+    // NOTE: we are clearing the hash table as it has been fully processed and
+    // not needed anymore. We'll wait for the HashBuild operator to build a new
+    // table from the next spill partition now.
+    buildResult_.reset();
+
+    if (!spillPartitionSets_.empty()) {
+      hasSpillInput = true;
+      restoringSpillPartitionId_ = spillPartitionSets_.begin()->first;
+      restoringSpillShards_ =
+          spillPartitionSets_.begin()->second->split(numBuilders_);
+      VELOX_CHECK_EQ(restoringSpillShards_.size(), numBuilders_);
+      spillPartitionSets_.erase(spillPartitionSets_.begin());
+      promises = std::move(promises_);
+    } else {
+      VELOX_CHECK(promises_.empty());
+    }
+  }
+  notify(std::move(promises));
+  return hasSpillInput;
+}
+
+std::optional<HashJoinBridge::SpillInput> HashJoinBridge::spillInputOrFuture(
+    ContinueFuture* future) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK(started_);
+  VELOX_CHECK(!cancelled_, "Getting spill input after join is aborted");
+  VELOX_DCHECK(
+      !restoringSpillPartitionId_.has_value() || !buildResult_.has_value());
+
+  if (!restoringSpillPartitionId_.has_value()) {
+    if (spillPartitionSets_.empty()) {
+      return HashJoinBridge::SpillInput{};
+    } else {
+      promises_.emplace_back("HashJoinBridge::spillInputOrFuture");
+      *future = promises_.back().getSemiFuture();
+      return std::nullopt;
+    }
+  }
+  VELOX_CHECK(!restoringSpillShards_.empty());
+  auto spillShard = std::move(restoringSpillShards_.back());
+  restoringSpillShards_.pop_back();
+  return SpillInput(std::move(spillShard));
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/HashTable.h"
+#include "velox/exec/JoinBridge.h"
+#include "velox/exec/Spill.h"
+
+namespace facebook::velox::exec {
+
+/// Hands over a hash table from a multi-threaded build pipeline to a
+/// multi-threaded probe pipeline. This is owned by shared_ptr by all the build
+/// and probe Operator instances concerned. Corresponds to the Presto concept of
+/// the same name.
+class HashJoinBridge : public JoinBridge {
+ public:
+  void start() override;
+
+  /// Invoked by HashBuild operator ctor to add to this bridge by incrementing
+  /// 'numBuilders_'. The latter is used to split the spill partition data among
+  /// HashBuild operators to parallelize the restoring operation.
+  void addBuilder();
+
+  /// 'spillPartitionSet' contains the spilled partitions while building
+  /// 'table'. The function returns true if there is spill data to restore
+  /// after HashProbe operators process 'table', otherwise false. This only
+  /// applies if the disk spilling is enabled.
+  bool setHashTable(
+      std::unique_ptr<BaseHashTable> table,
+      SpillPartitionSet spillPartitionSet);
+
+  void setAntiJoinHasNullKeys();
+
+  /// Represents the result of HashBuild operators: a hash table, an optional
+  /// restored spill partition id associated with the table, and the spilled
+  /// partitions while building the table if not empty. In case of an anti join,
+  /// a build side entry with a null in a join key makes the join return
+  /// nothing. In this case, HashBuild operators finishes early without
+  /// processing all the input and without finishing building the hash table.
+  struct HashBuildResult {
+    HashBuildResult(
+        std::shared_ptr<BaseHashTable> _table,
+        std::optional<SpillPartitionId> _restoredPartitionId,
+        SpillPartitionIdSet _spillPartitionIds)
+        : antiJoinHasNullKeys(false),
+          table(std::move(_table)),
+          restoredPartitionId(std::move(_restoredPartitionId)),
+          spillPartitionIds(std::move(_spillPartitionIds)) {}
+
+    HashBuildResult() : antiJoinHasNullKeys(true) {}
+
+    bool antiJoinHasNullKeys{false};
+    std::shared_ptr<BaseHashTable> table;
+    std::optional<SpillPartitionId> restoredPartitionId;
+    SpillPartitionIdSet spillPartitionIds;
+  };
+
+  /// Invoked by HashProbe operator to get the table to probe which is built by
+  /// HashBuild operators. If HashProbe operator calls this early, 'future' will
+  /// be set to wait asynchronously, otherwise the built table along with
+  /// optional spilling related information will be returned in HashBuildResult.
+  std::optional<HashBuildResult> tableOrFuture(
+      ContinueFuture* FOLLY_NONNULL future);
+
+  /// Invoked by HashProbe operator after finishes probing the built table to
+  /// set one of the previously spilled partition to restore. The HashBuild
+  /// operators will then build the next hash table from the selected spilled
+  /// one. The function returns true if there is spill data to be restored by
+  /// HashBuild operators next.
+  bool probeFinished();
+
+  /// Contains the spill input for one HashBuild operator: a shard of previously
+  /// spilled partition data. 'spillPartition' is null if there is no more spill
+  /// data to restore.
+  struct SpillInput {
+    explicit SpillInput(
+        std::unique_ptr<SpillPartition> spillPartition = nullptr)
+        : spillPartition(std::move(spillPartition)) {}
+
+    std::unique_ptr<SpillPartition> spillPartition;
+  };
+
+  /// Invoked by HashBuild operator to get one of previously spilled partition
+  /// shard to restore. The spilled partition to restore is set by HashProbe
+  /// operator after finishes probing on the previously built hash table.
+  /// If HashBuild operator calls this early, 'future' will be set to wait
+  /// asynchronously. If there is no more spill data to restore, then
+  /// 'spillPartition' will be set to null in the returned SpillInput.
+  std::optional<SpillInput> spillInputOrFuture(
+      ContinueFuture* FOLLY_NONNULL future);
+
+ private:
+  uint32_t numBuilders_{0};
+
+  std::optional<HashBuildResult> buildResult_;
+
+  // restoringSpillPartitionXxx member variables are populated by the
+  // bridge itself. When probe side finished processing, the bridge picks the
+  // first partition from 'spillPartitionSets_', splits it into "even" shards
+  // among the HashBuild operators and notifies these operators that they can
+  // start building HashTables from these shards.
+
+  // If not null, set to the currently restoring spill partition id.
+  std::optional<SpillPartitionId> restoringSpillPartitionId_;
+
+  // If 'restoringSpillPartitionId_' is not null, this set to the restoring
+  // spill partition data shards. Each shard is expected to have the same number
+  // of spill files and will be processed by one of the HashBuild operator.
+  std::vector<std::unique_ptr<SpillPartition>> restoringSpillShards_;
+
+  // The spill partitions remaining to restore. This set is populated using
+  // information provided by the HashBuild operators if spilling is enabled.
+  // This set can grow if HashBuild operator cannot load full partition in
+  // memory and engages in recursive spilling.
+  SpillPartitionSet spillPartitionSets_;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/JoinBridge.cpp
+++ b/velox/exec/JoinBridge.cpp
@@ -23,6 +23,11 @@ void JoinBridge::notify(std::vector<ContinuePromise> promises) {
   }
 }
 
+void JoinBridge::start() {
+  std::lock_guard<std::mutex> l(mutex_);
+  started_ = true;
+}
+
 void JoinBridge::cancel() {
   std::vector<ContinuePromise> promises;
   {

--- a/velox/exec/JoinBridge.h
+++ b/velox/exec/JoinBridge.h
@@ -23,14 +23,19 @@ class JoinBridge {
  public:
   virtual ~JoinBridge() = default;
 
-  // Sets this to a cancelled state and unblocks any waiting activity. This may
-  // happen asynchronously before or after the result has been set.
+  /// Invoked by the associated task after the driver creations to start this
+  /// join bridge before starting task execution.
+  virtual void start();
+
+  /// Sets this to a cancelled state and unblocks any waiting activity. This may
+  /// happen asynchronously before or after the result has been set.
   void cancel();
 
  protected:
   static void notify(std::vector<ContinuePromise> promises);
 
   std::mutex mutex_;
+  bool started_{false};
   std::vector<ContinuePromise> promises_;
   bool cancelled_{false};
 };

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -283,4 +283,14 @@ SpillPartition::createReader() {
   return std::make_unique<UnorderedStreamReader<BatchStream>>(
       std::move(streams));
 }
+
+SpillPartitionIdSet toSpillPartitionIdSet(
+    const SpillPartitionSet& partitionSet) {
+  SpillPartitionIdSet partitionIdSet;
+  partitionIdSet.reserve(partitionSet.size());
+  for (auto& partitionEntry : partitionSet) {
+    partitionIdSet.insert(partitionEntry.first);
+  }
+  return partitionIdSet;
+}
 } // namespace facebook::velox::exec

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -654,6 +654,10 @@ class SpillState {
   std::vector<std::unique_ptr<SpillFileList>> files_;
 };
 
+/// Generate partition id set from given spill partition set.
+SpillPartitionIdSet toSpillPartitionIdSet(
+    const SpillPartitionSet& partitionSet);
+
 } // namespace facebook::velox::exec
 
 // Adding the custom hash for SpillPartitionId to std::hash to make it usable

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -382,6 +382,10 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
+  std::shared_ptr<HashJoinBridge> getHashJoinBridgeLocked(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
+
   // Returns a CrossJoinBridge for 'planNodeId'.
   std::shared_ptr<CrossJoinBridge> getCrossJoinBridge(
       uint32_t splitGroupId,
@@ -486,6 +490,11 @@ class Task : public std::enable_shared_from_this<Task> {
 
   template <class TBridgeType>
   std::shared_ptr<TBridgeType> getJoinBridgeInternal(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
+
+  template <class TBridgeType>
+  std::shared_ptr<TBridgeType> getJoinBridgeInternalLocked(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
   FilterProjectTest.cpp
   FunctionResolutionTest.cpp
   FunctionSignatureBuilderTest.cpp
+  HashJoinBridgeTest.cpp
   HashJoinTest.cpp
   HashBitRangeTest.cpp
   HashPartitionFunctionTest.cpp

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/HashJoinBridge.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/HashTable.h"
+#include "velox/exec/Spill.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using facebook::velox::exec::test::TempDirectoryPath;
+
+struct TestParam {
+  int32_t numProbers{1};
+  int32_t numBuilders{1};
+};
+
+class HashJoinBridgeTest : public testing::Test,
+                           public testing::WithParamInterface<TestParam> {
+ public:
+  static std::vector<TestParam> getTestParams() {
+    return std::vector<TestParam>(
+        {TestParam{1, 4}, TestParam{4, 1}, TestParam{4, 4}, TestParam{1, 1}});
+  }
+
+ protected:
+  static void SetUpTestCase() {
+    filesystems::registerLocalFileSystem();
+  }
+
+  HashJoinBridgeTest()
+      : rowType_(ROW({"k1", "k2"}, {BIGINT(), BIGINT()})),
+        numBuilders_(GetParam().numBuilders),
+        numProbers_(GetParam().numProbers) {}
+
+  void SetUp() override {
+    rng_.seed(1245);
+    tempDir_ = exec::test::TempDirectoryPath::create();
+  }
+
+  void TearDown() override {}
+
+  uint32_t randInt(uint32_t n) {
+    std::lock_guard<std::mutex> l(mutex_);
+    return folly::Random().rand64(rng_) % (n + 1);
+  }
+
+  bool oneIn(uint32_t n) {
+    std::lock_guard<std::mutex> l(mutex_);
+    return folly::Random().oneIn(n, rng_);
+  }
+
+  std::shared_ptr<HashJoinBridge> createJoinBridge() const {
+    return std::make_shared<HashJoinBridge>();
+  }
+
+  std::unique_ptr<BaseHashTable> createFakeHashTable() {
+    std::vector<std::unique_ptr<VectorHasher>> keyHashers;
+    for (auto channel = 0; channel < rowType_->size(); ++channel) {
+      keyHashers.emplace_back(
+          std::make_unique<VectorHasher>(rowType_->childAt(channel), channel));
+    }
+    return HashTable<true>::createForJoin(
+        std::move(keyHashers), {}, true, false, mappedMemory_);
+  }
+
+  std::vector<ContinueFuture> createEmptyFutures(int32_t count) {
+    std::vector<ContinueFuture> futures;
+    futures.reserve(count);
+    for (int32_t i = 0; i < count; ++i) {
+      futures.push_back(ContinueFuture::makeEmpty());
+    }
+    return futures;
+  }
+
+  void createFile(const std::string& filePath) {
+    auto fs = filesystems::getFileSystem(filePath, nullptr);
+    // File object dtor will close the file.
+    auto file = fs->openFileForWrite(filePath);
+  }
+
+  SpillFiles makeFakeSpillFiles(int32_t numFiles) {
+    SpillFiles files;
+    files.reserve(numFiles);
+    for (int32_t i = 0; i < numFiles; ++i) {
+      files.push_back(std::make_unique<SpillFile>(
+          rowType_,
+          1,
+          std::vector<CompareFlags>({}),
+          tempDir_->path + "/Spill",
+          *pool_));
+      // Create a fake file to avoid too many exception logs in test when spill
+      // file deletion fails.
+      createFile(files.back()->testingFilePath());
+    }
+    return files;
+  }
+
+  SpillPartitionSet makeFakeSpillPartitionSet(uint8_t partitionBitOffset) {
+    SpillPartitionSet partitionSet;
+    const int32_t numPartitions =
+        std::max<int32_t>(1, randInt(maxNumPartitions_));
+    for (int32_t partition = 0; partition < numPartitions; ++partition) {
+      const SpillPartitionId id(partitionBitOffset, partition);
+      partitionSet.emplace(
+          id,
+          std::make_unique<SpillPartition>(
+              id, makeFakeSpillFiles(numSpillFilesPerPartition_)));
+    }
+    return partitionSet;
+  }
+
+  int32_t getSpillLevel(uint8_t partitionBitOffset) {
+    return (partitionBitOffset - startPartitionBitOffset_) / numPartitionBits_;
+  }
+
+  const RowTypePtr rowType_;
+  const int32_t numBuilders_;
+  const int32_t numProbers_;
+  const uint8_t startPartitionBitOffset_{0};
+  const uint32_t numPartitionBits_{2};
+  const uint32_t maxNumPartitions_{8};
+  const uint32_t numSpillFilesPerPartition_{20};
+
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  memory::MappedMemory* mappedMemory_{memory::MappedMemory::getInstance()};
+  std::shared_ptr<TempDirectoryPath> tempDir_;
+
+  std::mutex mutex_;
+  folly::Random::DefaultGenerator rng_;
+};
+
+TEST_P(HashJoinBridgeTest, withoutSpill) {
+  for (const bool hasNullKeys : {false, true}) {
+    SCOPED_TRACE(fmt::format("hasNullKeys: {}", hasNullKeys));
+    auto futures = createEmptyFutures(numProbers_);
+
+    auto joinBridge = createJoinBridge();
+    // Can't call any other APIs except addBuilder() before start a join bridge
+    // first.
+    ASSERT_ANY_THROW(joinBridge->setHashTable(createFakeHashTable(), {}));
+    ASSERT_ANY_THROW(joinBridge->setAntiJoinHasNullKeys());
+    ASSERT_ANY_THROW(joinBridge->probeFinished());
+    ASSERT_ANY_THROW(joinBridge->tableOrFuture(&futures[0]));
+    ASSERT_ANY_THROW(joinBridge->spillInputOrFuture(&futures[0]));
+
+    // Can't start a bridge without any builders.
+    ASSERT_ANY_THROW(joinBridge->start());
+
+    joinBridge = createJoinBridge();
+
+    for (int32_t i = 0; i < numBuilders_; ++i) {
+      joinBridge->addBuilder();
+    }
+    joinBridge->start();
+
+    for (int32_t i = 0; i < numProbers_; ++i) {
+      auto tableOr = joinBridge->tableOrFuture(&futures[i]);
+      ASSERT_FALSE(tableOr.has_value());
+      ASSERT_TRUE(futures[i].valid());
+    }
+
+    BaseHashTable* rawTable = nullptr;
+    if (hasNullKeys) {
+      joinBridge->setAntiJoinHasNullKeys();
+      ASSERT_ANY_THROW(joinBridge->setAntiJoinHasNullKeys());
+    } else {
+      auto table = createFakeHashTable();
+      rawTable = table.get();
+      joinBridge->setHashTable(std::move(table), {});
+      ASSERT_ANY_THROW(joinBridge->setHashTable(createFakeHashTable(), {}));
+    }
+
+    for (int32_t i = 0; i < numProbers_; ++i) {
+      futures[i].wait();
+    }
+
+    // Check build results.
+    futures = createEmptyFutures(numProbers_ * 2);
+    for (int32_t i = 0; i < numProbers_ * 2; ++i) {
+      auto tableOr = joinBridge->tableOrFuture(&futures[i]);
+      ASSERT_TRUE(tableOr.has_value());
+      ASSERT_FALSE(futures[i].valid());
+      if (hasNullKeys) {
+        ASSERT_TRUE(tableOr.value().antiJoinHasNullKeys);
+        ASSERT_TRUE(tableOr.value().table == nullptr);
+        ASSERT_FALSE(tableOr.value().restoredPartitionId.has_value());
+        ASSERT_TRUE(tableOr.value().spillPartitionIds.empty());
+      } else {
+        ASSERT_FALSE(tableOr.value().antiJoinHasNullKeys);
+        ASSERT_FALSE(tableOr.value().table == nullptr);
+        ASSERT_EQ(tableOr.value().table.get(), rawTable);
+        ASSERT_FALSE(tableOr.value().restoredPartitionId.has_value());
+        ASSERT_TRUE(tableOr.value().spillPartitionIds.empty());
+      }
+    }
+
+    // Verify builder will see no spill input.
+    auto inputOr = joinBridge->spillInputOrFuture(&futures[0]);
+    ASSERT_TRUE(inputOr.has_value());
+    ASSERT_FALSE(futures[0].valid());
+    ASSERT_TRUE(inputOr.value().spillPartition == nullptr);
+
+    // Probe side completion.
+    ASSERT_FALSE(joinBridge->probeFinished());
+    ASSERT_ANY_THROW(joinBridge->probeFinished());
+  }
+}
+
+TEST_P(HashJoinBridgeTest, withSpill) {
+  struct {
+    int32_t spillLevel;
+    bool endWithNull;
+
+    std::string debugString() const {
+      return fmt::format(
+          "spillLevel:{}, endWithNull:{}", spillLevel, endWithNull);
+    }
+  } testSettings[] = {
+      {0, true}, {0, false}, {1, true}, {1, false}, {3, true}, {3, false}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    auto buildFutures = createEmptyFutures(numBuilders_);
+    auto probeFutures = createEmptyFutures(numProbers_);
+
+    auto joinBridge = createJoinBridge();
+
+    for (int32_t i = 0; i < numBuilders_; ++i) {
+      joinBridge->addBuilder();
+    }
+    joinBridge->start();
+
+    std::optional<SpillPartitionId> restoringPartitionId;
+    int32_t numSpilledPartitions = 0;
+    int32_t numRestoredPartitions = 0;
+    while (true) {
+      // Wait for build table from probe side.
+      for (int32_t i = 0; i < numProbers_; ++i) {
+        ASSERT_FALSE(joinBridge->tableOrFuture(&probeFutures[i]).has_value());
+      }
+      // Finish build table.
+      SpillPartitionSet spillPartitionSet;
+      SpillPartitionIdSet spillPartitionIdSet;
+      int32_t spillLevel = -1;
+      if (restoringPartitionId.has_value()) {
+        ++numRestoredPartitions;
+        spillLevel =
+            getSpillLevel(restoringPartitionId.value().partitionBitOffset());
+        if (spillLevel < testData.spillLevel) {
+          spillPartitionSet = makeFakeSpillPartitionSet(
+              restoringPartitionId.value().partitionBitOffset() +
+              numPartitionBits_);
+        }
+      } else {
+        spillPartitionSet = makeFakeSpillPartitionSet(startPartitionBitOffset_);
+      }
+      bool hasMoreSpill;
+      if (spillLevel >= testData.spillLevel && testData.endWithNull) {
+        joinBridge->setAntiJoinHasNullKeys();
+        hasMoreSpill = false;
+      } else {
+        numSpilledPartitions += spillPartitionSet.size();
+        spillPartitionIdSet = toSpillPartitionIdSet(spillPartitionSet);
+        hasMoreSpill = joinBridge->setHashTable(
+            createFakeHashTable(), std::move(spillPartitionSet));
+      }
+
+      // Get built table from probe side.
+      for (int32_t i = 0; i < numProbers_; ++i) {
+        probeFutures[i].wait();
+        auto tableOr = joinBridge->tableOrFuture(&probeFutures[i]);
+        ASSERT_TRUE(tableOr.has_value());
+        if (!hasMoreSpill && testData.endWithNull) {
+          ASSERT_TRUE(tableOr.value().antiJoinHasNullKeys);
+          ASSERT_TRUE(tableOr.value().table == nullptr);
+        } else {
+          ASSERT_FALSE(tableOr.value().antiJoinHasNullKeys);
+          ASSERT_TRUE(tableOr.value().table != nullptr);
+          ASSERT_EQ(tableOr.value().spillPartitionIds, spillPartitionIdSet);
+        }
+      }
+
+      // Wait for probe to complete from build side.
+      if (!hasMoreSpill) {
+        for (int32_t i = 0; i < numBuilders_; ++i) {
+          auto inputOr = joinBridge->spillInputOrFuture(&buildFutures[i]);
+          ASSERT_TRUE(inputOr.has_value());
+          ASSERT_TRUE(inputOr.value().spillPartition == nullptr);
+        }
+      } else {
+        for (int32_t i = 0; i < numBuilders_; ++i) {
+          ASSERT_FALSE(
+              joinBridge->spillInputOrFuture(&buildFutures[i]).has_value());
+        }
+      }
+
+      // Probe table.
+      ASSERT_EQ(hasMoreSpill, joinBridge->probeFinished());
+      if (!hasMoreSpill) {
+        break;
+      }
+
+      // Resume build side for the next round.
+      int32_t numSpilledFiles = 0;
+      for (int32_t i = 0; i < numBuilders_; ++i) {
+        auto inputOr = joinBridge->spillInputOrFuture(&buildFutures[i]);
+        ASSERT_TRUE(inputOr.has_value());
+        ASSERT_TRUE(inputOr.value().spillPartition != nullptr);
+        restoringPartitionId = inputOr.value().spillPartition->id();
+        numSpilledFiles += inputOr.value().spillPartition->numFiles();
+      }
+      ASSERT_EQ(numSpilledFiles, numSpillFilesPerPartition_);
+      ASSERT_ANY_THROW(joinBridge->spillInputOrFuture(&buildFutures[0]));
+    }
+    if (testData.endWithNull) {
+      ASSERT_GE(numSpilledPartitions, numRestoredPartitions);
+    } else {
+      ASSERT_EQ(numSpilledPartitions, numRestoredPartitions);
+    }
+  }
+}
+
+TEST_P(HashJoinBridgeTest, multiThreading) {
+  for (int32_t iter = 0; iter < 10; ++iter) {
+    std::vector<std::thread> builderThreads;
+    builderThreads.reserve(numBuilders_);
+
+    std::vector<std::thread> proberThreads;
+    proberThreads.reserve(numProbers_);
+
+    struct BarrierState {
+      int32_t numRequested{0};
+      std::vector<ContinuePromise> promises;
+    };
+    std::mutex barrierLock;
+    std::unique_ptr<BarrierState> proberBarrier(new BarrierState());
+    std::unique_ptr<BarrierState> builderBarrier(new BarrierState());
+
+    auto joinBridge = createJoinBridge();
+    for (size_t i = 0; i < numBuilders_; ++i) {
+      joinBridge->addBuilder();
+    }
+    joinBridge->start();
+
+    // Start one thread on behalf of a build operator execution.
+    for (size_t i = 0; i < numBuilders_; ++i) {
+      builderThreads.emplace_back([&]() {
+        std::optional<SpillPartitionId> restoringPartitionId;
+        while (true) {
+          // Wait for peers to reach hash table build barrier.
+          std::vector<ContinuePromise> promises;
+          ContinueFuture future(ContinueFuture::makeEmpty());
+          {
+            std::lock_guard<std::mutex> l(barrierLock);
+            if (++builderBarrier->numRequested < numBuilders_) {
+              builderBarrier->promises.emplace_back(
+                  "HashJoinBridgeTest::multiThreading");
+              future = builderBarrier->promises.back().getSemiFuture();
+            } else {
+              promises = std::move(builderBarrier->promises);
+            }
+          }
+          if (future.valid()) {
+            future.wait();
+          } else {
+            builderBarrier.reset(new BarrierState());
+            if (oneIn(10)) {
+              joinBridge->setAntiJoinHasNullKeys();
+            } else {
+              auto partitionBitOffset = restoringPartitionId.has_value()
+                  ? restoringPartitionId->partitionBitOffset() +
+                      numPartitionBits_
+                  : startPartitionBitOffset_;
+              if (partitionBitOffset < 64 && oneIn(2)) {
+                auto spillPartitionSet =
+                    makeFakeSpillPartitionSet(partitionBitOffset);
+                joinBridge->setHashTable(
+                    createFakeHashTable(), std::move(spillPartitionSet));
+              } else {
+                joinBridge->setHashTable(createFakeHashTable(), {});
+              }
+            }
+            for (auto& promise : promises) {
+              promise.setValue();
+            }
+          }
+
+          auto inputOr = joinBridge->spillInputOrFuture(&future);
+          if (!inputOr.has_value()) {
+            future.wait();
+            inputOr = joinBridge->spillInputOrFuture(&future);
+            ASSERT_TRUE(inputOr.has_value());
+          }
+          if (inputOr->spillPartition == nullptr) {
+            break;
+          }
+          restoringPartitionId = inputOr->spillPartition->id();
+        }
+      });
+    }
+
+    // Start one thread on behalf of a probe operator execution.
+    for (size_t i = 0; i < numProbers_; ++i) {
+      proberThreads.emplace_back([&]() {
+        SpillPartitionIdSet spillPartitionIdSet;
+        while (true) {
+          // Wait for build tables.
+          ContinueFuture tableFuture(ContinueFuture::makeEmpty());
+
+          auto tableOr = joinBridge->tableOrFuture(&tableFuture);
+          if (!tableOr.has_value()) {
+            tableFuture.wait();
+            tableOr = joinBridge->tableOrFuture(&tableFuture);
+            ASSERT_TRUE(tableOr.has_value());
+            if (tableOr.value().antiJoinHasNullKeys) {
+              break;
+            }
+            ASSERT_TRUE(tableOr.value().table != nullptr);
+          }
+          for (const auto& id : tableOr.value().spillPartitionIds) {
+            ASSERT_FALSE(spillPartitionIdSet.contains(id));
+            spillPartitionIdSet.insert(id);
+          }
+          if (tableOr.value().restoredPartitionId.has_value()) {
+            ASSERT_TRUE(spillPartitionIdSet.contains(
+                tableOr.value().restoredPartitionId.value()));
+            spillPartitionIdSet.erase(
+                tableOr.value().restoredPartitionId.value());
+          }
+
+          if (spillPartitionIdSet.empty()) {
+            return;
+          }
+
+          // Wait for probe to finish.
+          ContinueFuture probeFuture(ContinueFuture::makeEmpty());
+          ASSERT_FALSE(probeFuture.valid());
+          std::vector<ContinuePromise> promises;
+          {
+            std::lock_guard<std::mutex> l(barrierLock);
+            if (++proberBarrier->numRequested < numProbers_) {
+              proberBarrier->promises.emplace_back(
+                  "HashJoinBridgeTest::multiThreading");
+              probeFuture = proberBarrier->promises.back().getSemiFuture();
+            } else {
+              promises = std::move(proberBarrier->promises);
+            }
+          }
+          if (probeFuture.valid()) {
+            probeFuture.wait();
+          } else {
+            proberBarrier.reset(new BarrierState());
+            ASSERT_TRUE(joinBridge->probeFinished());
+            for (auto& promise : promises) {
+              promise.setValue();
+            }
+          }
+        }
+      });
+    }
+
+    for (auto& th : builderThreads) {
+      th.join();
+    }
+    for (auto& th : proberThreads) {
+      th.join();
+    }
+  }
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    HashJoinBridgeTest,
+    HashJoinBridgeTest,
+    testing::ValuesIn(HashJoinBridgeTest::getTestParams()));

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -310,10 +310,6 @@ class MultiThreadedHashJoinTest
       public testing::WithParamInterface<TestParam> {
  public:
   MultiThreadedHashJoinTest() : HashJoinTest(GetParam()) {}
-
-  static std::vector<TestParam> getTestParams() {
-    return std::vector<TestParam>({TestParam{1}, TestParam{4}});
-  }
 };
 
 TEST_P(MultiThreadedHashJoinTest, bigintArray) {
@@ -506,7 +502,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinWithLargeOutput) {
 VELOX_INSTANTIATE_TEST_SUITE_P(
     HashJoinTest,
     MultiThreadedHashJoinTest,
-    testing::ValuesIn(MultiThreadedHashJoinTest::getTestParams()));
+    testing::ValuesIn({TestParam{1}, TestParam{4}}));
 
 // TODO: try to parallelize the following test cases if possible.
 

--- a/velox/exec/tests/SpillOperatorGroupTest.cpp
+++ b/velox/exec/tests/SpillOperatorGroupTest.cpp
@@ -279,22 +279,11 @@ class SpillOperatorGroupTest : public testing::Test {
   std::vector<std::unique_ptr<MockOperator>> spillOps_;
 };
 
-struct TestParam {
-  int32_t numOperators;
-};
-
 class MultiSpillOperatorGroupTest
     : public SpillOperatorGroupTest,
-      public testing::WithParamInterface<TestParam> {
+      public testing::WithParamInterface<int32_t> {
  public:
-  MultiSpillOperatorGroupTest()
-      : SpillOperatorGroupTest(GetParam().numOperators) {}
-
-  static std::vector<TestParam> getTestParams() {
-    return std::vector<TestParam>({TestParam{1}, TestParam{4}, TestParam{32}});
-    // return std::vector<TestParam>({TestParam{1}, TestParam{4},
-    // TestParam{32}});
-  }
+  MultiSpillOperatorGroupTest() : SpillOperatorGroupTest(GetParam()) {}
 };
 
 TEST_P(MultiSpillOperatorGroupTest, spillRun) {
@@ -456,4 +445,4 @@ TEST_P(MultiSpillOperatorGroupTest, multiThreading) {
 VELOX_INSTANTIATE_TEST_SUITE_P(
     SpillOperatorGroupTest,
     MultiSpillOperatorGroupTest,
-    testing::ValuesIn(MultiSpillOperatorGroupTest::getTestParams()));
+    testing::ValuesIn({1, 4, 32}));

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -417,6 +417,7 @@ TEST_F(SpillTest, spillPartitionSet) {
       if (partitionIdSet.contains(id)) {
         continue;
       }
+      partitionIdSet.insert(id);
       spillPartitions.push_back(std::make_unique<SpillPartition>(id));
       ASSERT_EQ(id, spillPartitions.back()->id());
       // Expect an empty reader.
@@ -430,6 +431,10 @@ TEST_F(SpillTest, spillPartitionSet) {
       const auto id = partition->id();
       partitionSet.emplace(id, std::move(partition));
     }
+    const SpillPartitionIdSet generatedPartitionIdSet =
+        toSpillPartitionIdSet(partitionSet);
+    ASSERT_EQ(partitionIdSet, generatedPartitionIdSet);
+
     std::unique_ptr<SpillPartitionId> prevId;
     for (auto& partitionEntry : partitionSet) {
       if (prevId != nullptr) {


### PR DESCRIPTION
Extend HashJoinBridge:
(1) extend existing API to set spilled partition set along with the table from
build side. Inside the HashJoinBride, it store the spilled partition set in an
ordered map to ensure ordered spill partition restore: the recursive spilled
partition to be restored first;
(2) add new API to set to inform the build side about the next spilled partition
to restore and split the spill partition data into a number of equally sized
(in measure of files) shard with one per each hash build to parallelize the spill
partition restore process at build side;
(3) add new API to get next spill input (the spill partition data shard) to restore
from build side;
Add sort of mock test to coverage all use cases under concurrency.