### PR TITLE
Fix peeling off encodings from intermediate results some more

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1368,7 +1368,7 @@ bool Expr::applyFunctionWithPeeling(
     // numbers may be larger than rows.end(). Hence, we need to resize constant
     // inputs.
     if (newRows->end() > rows.end() && numConstant) {
-      for (int i = 0; i < numConstant; ++i) {
+      for (int i = 0; i < constantArgs.size(); ++i) {
         if (!constantArgs.empty() && constantArgs[i]) {
           inputValues_[i] =
               BaseVector::wrapInConstant(newRows->end(), 0, inputValues_[i]);

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2668,7 +2668,7 @@ TEST_F(ExprTest, preservePartialResultsWithEncodedInput) {
 // translated set of rows now contains row numbers > N, hence, constant input
 // needs to be resized, otherwise, accessing rows numbers > N will cause an
 // error.
-TEST_F(ExprTest, a) {
+TEST_F(ExprTest, peelIntermediateResults) {
   auto data = makeRowVector({makeArrayVector<int32_t>({
       {0, 1, 2, 3, 4, 5, 6, 7},
       {0, 1, 2, 33, 4, 5, 6, 7, 8},
@@ -2682,6 +2682,16 @@ TEST_F(ExprTest, a) {
   auto expected = makeNullableArrayVector<int32_t>({
       {std::nullopt, 3},
       {std::nullopt, 33},
+  });
+  assertEqualVectors(expected, result);
+
+  // Change the order of arguments.
+  result = evaluate(
+      "array_constructor(element_at(c0, 4), element_at(c0, 200))", data);
+
+  expected = makeNullableArrayVector<int32_t>({
+      {3, std::nullopt},
+      {33, std::nullopt},
   });
   assertEqualVectors(expected, result);
 }


### PR DESCRIPTION
The previous fix in #2592 covered the case when constant argument was at the
beginning of the argument list, but not in the middle or the end. This change
is to cover these cases.