### PR TITLE
Fix formatting in SWITCH documentation

### DIFF
--- a/velox/docs/develop/expression-evaluation.rst
+++ b/velox/docs/develop/expression-evaluation.rst
@@ -394,6 +394,7 @@ Evaluation of IF, SWITCH
 ````````````````````````
 
 SWITCH expression evaluation goes through the following steps:
+
 * Evaluate the first condition on all rows.
 * Evaluate the first “then” clause on a subset of rows where the first condition is true and produce a partially populated result vector.
 * Evaluate the second condition on rows where the first condition is not true.


### PR DESCRIPTION
Fix the formatting in "Evaluation of IF, SWITCH" section of the "Expression Evaluation" 
document.