### PR TITLE
[Substrait to Velox] Refactor SubstraitVeloxExprConverter

### DIFF
--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -29,8 +29,9 @@ class SubstraitVeloxExprConverter {
   /// into recognizable representations. functionMap: A pre-constructed map
   /// storing the relations between the function id and the function name.
   explicit SubstraitVeloxExprConverter(
+      memory::MemoryPool* pool,
       const std::unordered_map<uint64_t, std::string>& functionMap)
-      : functionMap_(functionMap) {}
+      : pool_(pool), functionMap_(functionMap) {}
 
   /// Convert Substrait Field into Velox Field Expression.
   std::shared_ptr<const core::FieldAccessTypedExpr> toVeloxExpr(
@@ -57,6 +58,9 @@ class SubstraitVeloxExprConverter {
       const RowTypePtr& inputType);
 
  private:
+  /// Memory pool.
+  memory::MemoryPool* pool_;
+
   /// The Substrait parser used to convert Substrait representations into
   /// recognizable representations.
   SubstraitParser substraitParser_;

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -25,6 +25,8 @@ namespace facebook::velox::substrait {
 /// This class is used to convert the Substrait plan into Velox plan.
 class SubstraitVeloxPlanConverter {
  public:
+  explicit SubstraitVeloxPlanConverter(memory::MemoryPool* pool)
+      : pool_(pool) {}
   struct SplitInfo {
     /// The Partition index.
     u_int32_t partitionIndex;
@@ -43,19 +45,13 @@ class SubstraitVeloxPlanConverter {
   };
 
   /// Convert Substrait AggregateRel into Velox PlanNode.
-  core::PlanNodePtr toVeloxPlan(
-      const ::substrait::AggregateRel& aggRel,
-      memory::MemoryPool* pool);
+  core::PlanNodePtr toVeloxPlan(const ::substrait::AggregateRel& aggRel);
 
   /// Convert Substrait ProjectRel into Velox PlanNode.
-  core::PlanNodePtr toVeloxPlan(
-      const ::substrait::ProjectRel& projectRel,
-      memory::MemoryPool* pool);
+  core::PlanNodePtr toVeloxPlan(const ::substrait::ProjectRel& projectRel);
 
   /// Convert Substrait FilterRel into Velox PlanNode.
-  core::PlanNodePtr toVeloxPlan(
-      const ::substrait::FilterRel& filterRel,
-      memory::MemoryPool* pool);
+  core::PlanNodePtr toVeloxPlan(const ::substrait::FilterRel& filterRel);
 
   /// Convert Substrait ReadRel into Velox PlanNode.
   /// Index: the index of the partition this item belongs to.
@@ -63,29 +59,21 @@ class SubstraitVeloxPlanConverter {
   /// Lengths: the lengths in byte to read from the items.
   core::PlanNodePtr toVeloxPlan(
       const ::substrait::ReadRel& readRel,
-      memory::MemoryPool* pool,
       std::shared_ptr<SplitInfo>& splitInfo);
 
   /// Convert Substrait ReadRel into Velox Values Node.
   core::PlanNodePtr toVeloxPlan(
       const ::substrait::ReadRel& readRel,
-      memory::MemoryPool* pool,
       const RowTypePtr& type);
 
   /// Convert Substrait Rel into Velox PlanNode.
-  core::PlanNodePtr toVeloxPlan(
-      const ::substrait::Rel& rel,
-      memory::MemoryPool* pool);
+  core::PlanNodePtr toVeloxPlan(const ::substrait::Rel& rel);
 
   /// Convert Substrait RelRoot into Velox PlanNode.
-  core::PlanNodePtr toVeloxPlan(
-      const ::substrait::RelRoot& root,
-      memory::MemoryPool* pool);
+  core::PlanNodePtr toVeloxPlan(const ::substrait::RelRoot& root);
 
   /// Convert Substrait Plan into Velox PlanNode.
-  core::PlanNodePtr toVeloxPlan(
-      const ::substrait::Plan& substraitPlan,
-      memory::MemoryPool* pool);
+  core::PlanNodePtr toVeloxPlan(const ::substrait::Plan& substraitPlan);
 
   /// Check the Substrait type extension only has one unknown extension.
   bool checkTypeExtension(const ::substrait::Plan& substraitPlan);
@@ -151,6 +139,9 @@ class SubstraitVeloxPlanConverter {
   /// Mapping from leaf plan node ID to splits.
   std::unordered_map<core::PlanNodeId, std::shared_ptr<SplitInfo>>
       splitInfoMap_;
+
+  /// Memory pool.
+  memory::MemoryPool* pool_;
 };
 
 } // namespace facebook::velox::substrait

--- a/velox/substrait/tests/FunctionTest.cpp
+++ b/velox/substrait/tests/FunctionTest.cpp
@@ -39,7 +39,7 @@ class FunctionTest : public ::testing::Test {
       std::make_shared<vestrait::SubstraitParser>();
 
   std::shared_ptr<vestrait::SubstraitVeloxPlanConverter> planConverter_ =
-      std::make_shared<vestrait::SubstraitVeloxPlanConverter>();
+      std::make_shared<vestrait::SubstraitVeloxPlanConverter>(pool_.get());
 };
 
 TEST_F(FunctionTest, makeNames) {

--- a/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
+++ b/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
@@ -275,8 +275,9 @@ TEST_F(Substrait2VeloxPlanConversionTest, q6) {
   JsonToProtoConverter::readFromFile(planPath, substraitPlan);
 
   // Convert to Velox PlanNode.
-  facebook::velox::substrait::SubstraitVeloxPlanConverter planConverter;
-  auto planNode = planConverter.toVeloxPlan(substraitPlan, pool_.get());
+  facebook::velox::substrait::SubstraitVeloxPlanConverter planConverter(
+      pool_.get());
+  auto planNode = planConverter.toVeloxPlan(substraitPlan);
 
   auto expectedResult = makeRowVector({
       makeFlatVector<double>(1, [](auto /*row*/) { return 13613.1921; }),

--- a/velox/substrait/tests/Substrait2VeloxValuesNodeConversionTest.cpp
+++ b/velox/substrait/tests/Substrait2VeloxValuesNodeConversionTest.cpp
@@ -32,11 +32,10 @@ using namespace facebook::velox::substrait;
 
 class Substrait2VeloxValuesNodeConversionTest : public OperatorTestBase {
  public:
-  std::shared_ptr<SubstraitVeloxPlanConverter> planConverter_ =
-      std::make_shared<SubstraitVeloxPlanConverter>();
-
   std::unique_ptr<memory::ScopedMemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<SubstraitVeloxPlanConverter> planConverter_ =
+      std::make_shared<SubstraitVeloxPlanConverter>(pool_.get());
 };
 
 // SELECT * FROM tmp
@@ -47,7 +46,7 @@ TEST_F(Substrait2VeloxValuesNodeConversionTest, valuesNode) {
   ::substrait::Plan substraitPlan;
   JsonToProtoConverter::readFromFile(planPath, substraitPlan);
 
-  auto veloxPlan = planConverter_->toVeloxPlan(substraitPlan, pool_.get());
+  auto veloxPlan = planConverter_->toVeloxPlan(substraitPlan);
 
   RowVectorPtr expectedData = makeRowVector(
       {makeFlatVector<int64_t>(

--- a/velox/substrait/tests/VeloxSubstraitRoundTripPlanConverterTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripPlanConverterTest.cpp
@@ -64,17 +64,17 @@ class VeloxSubstraitRoundTripPlanConverterTest : public OperatorTestBase {
     auto substraitPlan = veloxConvertor_->toSubstrait(arena, plan);
 
     // Convert Substrait Plan to the same Velox Plan.
-    auto samePlan =
-        substraitConverter_->toVeloxPlan(substraitPlan, pool_.get());
+    auto samePlan = substraitConverter_->toVeloxPlan(substraitPlan);
 
     // Assert velox again.
     assertQuery(samePlan, duckDbSql);
   }
-
+  std::unique_ptr<memory::ScopedMemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
   std::shared_ptr<VeloxToSubstraitPlanConvertor> veloxConvertor_ =
       std::make_shared<VeloxToSubstraitPlanConvertor>();
   std::shared_ptr<SubstraitVeloxPlanConverter> substraitConverter_ =
-      std::make_shared<SubstraitVeloxPlanConverter>();
+      std::make_shared<SubstraitVeloxPlanConverter>(pool_.get());
 };
 
 TEST_F(VeloxSubstraitRoundTripPlanConverterTest, project) {


### PR DESCRIPTION
Pass memory pool to SubstraitVeloxExprConverter's constructor to avoid passing 
memory pool to all the methods.