### PR TITLE
Make CPU Operator Stats Optional

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -58,6 +58,11 @@ class QueryConfig {
   static constexpr const char* kExprTrackCpuUsage =
       "expression.track_cpu_usage";
 
+  // Whether to track CPU usage for stages of individual operators. True by
+  // default. Can be expensive when processing small batches, e.g. < 10K rows.
+  static constexpr const char* kOperatorTrackCpuUsage =
+      "driver.track_operator_cpu_usage";
+
   // Flags used to configure the CAST operator:
 
   // This flag makes the Row conversion to by applied
@@ -269,6 +274,10 @@ class QueryConfig {
 
   bool exprTrackCpuUsage() const {
     return get<bool>(kExprTrackCpuUsage, false);
+  }
+
+  bool operatorTrackCpuUsage() const {
+    return get<bool>(kOperatorTrackCpuUsage, true);
   }
 
   template <typename T>

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -448,6 +448,11 @@ TEST_F(DriverTest, pause) {
       [](int64_t num) { return num % 10 > 0; },
       &hits);
   params.maxDrivers = 10;
+  params.queryCtx =
+      core::QueryCtx::createForTest(std::make_shared<core::MemConfig>(
+          std::unordered_map<std::string, std::string>{
+              // Make sure CPU usage tracking is enabled.
+              {core::QueryConfig::kOperatorTrackCpuUsage, "true"}}));
   int32_t numRead = 0;
   readResults(params, ResultOperation::kPause, 370'000'000, &numRead);
   // Each thread will fully read the 1M rows in values.


### PR DESCRIPTION
Summary:
Similar to what https://github.com/facebookincubator/velox/pull/1534 did for Expressions, this adds a configuration property
"driver.track_operator_cpu_usage" to control whether cpu usage tracking for operators is on of off. The default is off.

We have seen in use cases with very small batches (128 or less) measuring the CPU time can itself account for ~10% of the CPU spent in processing
batches.

For example, running the SimpleArithmetic benchmark with batches of 100 rows

With CPU usage tracking:
```
multiplySmall                                               4.58ns   218.29M
multiplySameColumnSmall                                     4.37ns   228.67M
multiplyHalfNullSmall                                       7.86ns   127.17M
multiplyConstantSmall                                       5.08ns   196.67M
multiplyNestedSmall                                         6.80ns   147.16M
multiplyNestedDeepSmall                                    12.06ns    82.89M
```
Without CPU usage tracking:
```
multiplySmall                                               4.22ns   236.99M
multiplySameColumnSmall                                     3.99ns   250.70M
multiplyHalfNullSmall                                       7.12ns   140.39M
multiplyConstantSmall                                       4.67ns   214.27M
multiplyNestedSmall                                         5.94ns   168.39M
multiplyNestedDeepSmall                                    11.03ns    90.65M
```

Differential Revision: D39753640

