### PR TITLE
Add decimal average function

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -438,6 +438,9 @@ velox::variant rowVariantAt(const VectorPtr& vector, vector_size_t row) {
       values.push_back(arrayVariantAt(child, row));
     } else if (child->typeKind() == TypeKind::MAP) {
       values.push_back(mapVariantAt(child, row));
+    } else if (child->typeKind() == TypeKind::LONG_DECIMAL) {
+      auto value = variantAt<TypeKind::LONG_DECIMAL>(child, row);
+      values.push_back(value);
     } else {
       auto value = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
           variantAt, child->typeKind(), child, row);

--- a/velox/functions/prestosql/DecimalArithmetic.cpp
+++ b/velox/functions/prestosql/DecimalArithmetic.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::functions {
 namespace {
@@ -213,26 +214,7 @@ class Divide {
   template <typename R, typename A, typename B>
   inline static void
   apply(R& r, const A& a, const B& b, uint8_t aRescale, uint8_t /*bRescale*/) {
-    VELOX_CHECK_NE(b.unscaledValue(), 0, "Division by zero");
-    int resultSign = 1;
-    R unsignedDividendRescaled(a);
-    if (a < 0) {
-      resultSign = -1;
-      unsignedDividendRescaled *= -1;
-    }
-    R unsignedDivisor(b);
-    if (b < 0) {
-      resultSign *= -1;
-      unsignedDivisor *= -1;
-    }
-    unsignedDividendRescaled = checkedMultiply<R>(
-        unsignedDividendRescaled, R(DecimalUtil::kPowersOfTen[aRescale]));
-    R quotient = unsignedDividendRescaled / unsignedDivisor;
-    R remainder = unsignedDividendRescaled % unsignedDivisor;
-    if (remainder * 2 >= unsignedDivisor) {
-      ++quotient;
-    }
-    r = quotient * resultSign;
+    DecimalUtil::divideWithRoundUp<R, A, B>(r, a, b, aRescale, 0);
   }
 
   inline static uint8_t

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -314,8 +314,12 @@ class AverageAggregate : public exec::Aggregate {
                                   TResult,
                                   UnscaledShortDecimal>)&&std::
                                  is_same_v<TAccumulator, int128_t>) {
-          DecimalUtil::divideWithRoundUp<TResult, int128_t, TResult>(
-              rawValues[i], sumCount->sum, TResult(sumCount->count), 0, 0);
+          // Need to perform integer division here as the intermediate sums may
+          // overflow decimal limits.
+          int128_t result = 0;
+          DecimalUtil::divideWithRoundUp<int128_t, int128_t, int64_t>(
+              result, sumCount->sum, sumCount->count, 0, 0);
+          rawValues[i] = TResult(result);
         }
       }
     }

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -243,9 +243,17 @@ TEST_F(AverageAggregationTest, avgDecimal) {
   shortExpected = makeShortDecimalFlatVector({337}, DECIMAL(3, 2));
   runAndCompare("avg(c0)", {shortDecimal}, shortExpected);
 
+  // Decimal average when total sum crosses decimal limits but not integer
+  // limits.
   longDecimal = makeLongDecimalFlatVector(
       {UnscaledLongDecimal::max().unscaledValue(), 1}, DECIMAL(38, 0));
-  // runAndCompare("avg(c0)", {longDecimal}, shortExpected);
+  // Average result is 50000000000000000000000000000000000000.
+  runAndCompare(
+      "avg(c0)",
+      {longDecimal},
+      makeLongDecimalFlatVector(
+          {buildInt128(0x259DA6542D43623D, 0x04C5112000000000)},
+          DECIMAL(38, 0)));
 }
 } // namespace
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -210,9 +210,11 @@ TEST_F(AverageAggregationTest, avgDecimal) {
                            std::vector<VectorPtr> input,
                            VectorPtr expectedResult,
                            bool isSingle = true) {
+    // Decimal average cannot be directly compared with duckdb decimal
+    // average whose return type is double. Hence, cannot use testAggregations.
     // Need to use PlanBuilder as it registers a AggregateTypeResolver Vs
-    // evaluate which would compile the expressions through Simple/Vector
-    // function resolvers.
+    // evaluate<ReturnType> which would compile the expressions through
+    // Simple/Vector function resolvers.
     PlanBuilder builder;
     builder.values({makeRowVector(input)});
     if (isSingle) {

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -88,7 +88,7 @@ class DecimalUtil {
       const B& b,
       uint8_t aRescale,
       uint8_t /*bRescale*/) {
-    VELOX_CHECK_NE(b.unscaledValue(), 0, "Division by zero");
+    VELOX_CHECK_NE(b, 0, "Division by zero");
     int resultSign = 1;
     R unsignedDividendRescaled(a);
     if (a < 0) {

--- a/velox/type/UnscaledLongDecimal.cpp
+++ b/velox/type/UnscaledLongDecimal.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/type/UnscaledLongDecimal.h"
+#include "velox/common/base/CheckedArithmetic.h"
 
 namespace std {
 
@@ -36,3 +37,18 @@ string to_string(facebook::velox::int128_t x) {
 }
 
 } // namespace std
+
+namespace facebook::velox {
+
+UnscaledLongDecimal& UnscaledLongDecimal::operator+=(
+    const UnscaledLongDecimal& value) {
+  *this = checkedPlus<UnscaledLongDecimal>(*this, UnscaledLongDecimal(value));
+  return *this;
+}
+
+UnscaledLongDecimal& UnscaledLongDecimal::operator+=(
+    const UnscaledShortDecimal& value) {
+  *this = checkedPlus<UnscaledLongDecimal>(*this, UnscaledLongDecimal(value));
+  return *this;
+}
+} // namespace facebook::velox

--- a/velox/type/UnscaledLongDecimal.h
+++ b/velox/type/UnscaledLongDecimal.h
@@ -76,12 +76,6 @@ struct UnscaledLongDecimal {
   explicit UnscaledLongDecimal(UnscaledShortDecimal value)
       : unscaledValue_(value.unscaledValue()) {}
 
-  // explicit UnscaledLongDecimal(const UnscaledShortDecimal& value)
-  //     : unscaledValue_(value.unscaledValue()) {}
-
-  // explicit UnscaledLongDecimal(const UnscaledLongDecimal& value)
-  //     : unscaledValue_(value.unscaledValue()) {}
-
   static UnscaledLongDecimal min() {
     return UnscaledLongDecimal(kMin);
   }
@@ -142,15 +136,9 @@ struct UnscaledLongDecimal {
     return UnscaledLongDecimal(static_cast<int64_t>(value));
   }
 
-  UnscaledLongDecimal& operator+=(const UnscaledLongDecimal& value) {
-    unscaledValue_ += value.unscaledValue_;
-    return *this;
-  }
+  UnscaledLongDecimal& operator+=(const UnscaledLongDecimal& value);
 
-  UnscaledLongDecimal& operator+=(const UnscaledShortDecimal& value) {
-    unscaledValue_ += value.unscaledValue();
-    return *this;
-  }
+  UnscaledLongDecimal& operator+=(const UnscaledShortDecimal& value);
 
   UnscaledLongDecimal& operator*=(int value) {
     unscaledValue_ *= value;

--- a/velox/type/UnscaledLongDecimal.h
+++ b/velox/type/UnscaledLongDecimal.h
@@ -76,6 +76,12 @@ struct UnscaledLongDecimal {
   explicit UnscaledLongDecimal(UnscaledShortDecimal value)
       : unscaledValue_(value.unscaledValue()) {}
 
+  // explicit UnscaledLongDecimal(const UnscaledShortDecimal& value)
+  //     : unscaledValue_(value.unscaledValue()) {}
+
+  // explicit UnscaledLongDecimal(const UnscaledLongDecimal& value)
+  //     : unscaledValue_(value.unscaledValue()) {}
+
   static UnscaledLongDecimal min() {
     return UnscaledLongDecimal(kMin);
   }
@@ -98,6 +104,10 @@ struct UnscaledLongDecimal {
 
   bool operator!=(const UnscaledLongDecimal& other) const {
     return unscaledValue_ != other.unscaledValue_;
+  }
+
+  bool operator!=(int other) const {
+    return unscaledValue_ != other;
   }
 
   bool operator<(const UnscaledLongDecimal& other) const {
@@ -221,3 +231,20 @@ class numeric_limits<facebook::velox::UnscaledLongDecimal> {
   }
 };
 } // namespace std
+
+/// fmt::formatter<> specialization required for error message formatting
+/// in VELOX checks.
+template <>
+struct fmt::formatter<facebook::velox::UnscaledLongDecimal> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(
+      const facebook::velox::UnscaledLongDecimal& d,
+      FormatContext& ctx) {
+    return fmt::format_to(ctx.out(), "{}", std::to_string(d.unscaledValue()));
+  }
+};

--- a/velox/type/UnscaledLongDecimal.h
+++ b/velox/type/UnscaledLongDecimal.h
@@ -132,6 +132,16 @@ struct UnscaledLongDecimal {
     return UnscaledLongDecimal(static_cast<int64_t>(value));
   }
 
+  UnscaledLongDecimal& operator+=(const UnscaledLongDecimal& value) {
+    unscaledValue_ += value.unscaledValue_;
+    return *this;
+  }
+
+  UnscaledLongDecimal& operator+=(const UnscaledShortDecimal& value) {
+    unscaledValue_ += value.unscaledValue();
+    return *this;
+  }
+
   UnscaledLongDecimal& operator*=(int value) {
     unscaledValue_ *= value;
     return *this;

--- a/velox/type/UnscaledShortDecimal.h
+++ b/velox/type/UnscaledShortDecimal.h
@@ -58,6 +58,10 @@ struct UnscaledShortDecimal {
     return unscaledValue_ != other.unscaledValue_;
   }
 
+  bool operator!=(int other) const {
+    return unscaledValue_ != other;
+  }
+
   bool operator<(const UnscaledShortDecimal& other) const {
     return unscaledValue_ < other.unscaledValue_;
   }
@@ -162,3 +166,20 @@ class numeric_limits<facebook::velox::UnscaledShortDecimal> {
   }
 };
 } // namespace std
+
+/// fmt::formatter<> specialization required for error message formatting
+/// in VELOX checks.
+template <>
+struct fmt::formatter<facebook::velox::UnscaledShortDecimal> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(
+      const facebook::velox::UnscaledShortDecimal& d,
+      FormatContext& ctx) {
+    return fmt::format_to(ctx.out(), "{}", std::to_string(d.unscaledValue()));
+  }
+};

--- a/velox/type/UnscaledShortDecimal.h
+++ b/velox/type/UnscaledShortDecimal.h
@@ -50,11 +50,6 @@ struct UnscaledShortDecimal {
   int64_t unscaledValue() const {
     return unscaledValue_;
   }
-
-  void setUnscaledValue(const int64_t unscaledValue) {
-    unscaledValue_ = unscaledValue;
-  }
-
   bool operator==(const UnscaledShortDecimal& other) const {
     return unscaledValue_ == other.unscaledValue_;
   }
@@ -89,6 +84,11 @@ struct UnscaledShortDecimal {
 
   UnscaledShortDecimal operator*(int value) const {
     return UnscaledShortDecimal(unscaledValue_ * value);
+  }
+
+  UnscaledShortDecimal& operator+=(const UnscaledShortDecimal& value) {
+    unscaledValue_ += value.unscaledValue_;
+    return *this;
   }
 
   UnscaledShortDecimal& operator*=(int value) {


### PR DESCRIPTION
Decimal Average function returns a DECIMAL type as output and the precision and scale match input columns precision/scale.

Today, the `AverageAggregate`  class expects the Intermediate/Accumulator and Final aggregation types to be DOUBLE or REAL. But for this class to handle DECIMAL types, the accumulator and final aggregations needs to be `SHORT_DECIMAL or LONG_DECIMALS`. This PR refactors existing `AverageAggregate` class to be a template function in-order to extend the class to handle DECIMALS as well.

|     TYPE                     |      Partial Aggregate type   |    Final Aggregate type  |
----------------------|---------------------------|------------------------- |
SHORT_DECIMAL(a_precision, a_scale)       |          LONG_DECIMAL(38, a_scale)       |       SHORT_DECIMAL(a_precision, a_scale)     |
LONG_DECIMAL(a_precision, a_scale)       |          LONG_DECIMAL(38, a_scale)       |       LONG_DECIMAL(a_precision, a_scale)     |
