### PR TITLE
Add 'query memory tree print out' to memory exception message.

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -100,7 +100,7 @@ Operator::Operator(
         [&](memory::MemoryUsageTracker& tracker) {
           VELOX_DCHECK(pool()->getMemoryUsageTracker().get() == &tracker);
           std::stringstream out;
-          out << "Failed Operator: " << stats_.operatorType << "_#"
+          out << "\nFailed Operator: " << stats_.operatorType << "."
               << stats_.operatorId << ": "
               << succinctBytes(tracker.getCurrentTotalBytes());
           return out.str();

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -16,6 +16,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <string>
 
 #include "velox/codegen/Codegen.h"
 #include "velox/common/base/SuccinctPrinter.h"
@@ -1744,86 +1745,139 @@ void Task::TaskCompletionNotifier::notify() {
   }
 }
 
-std::string Task::getErrorMsgOnMemCapExceeded(
-    memory::MemoryUsageTracker& tracker) {
+namespace {
+// Describes memory usage stats of a Memory Pool (optionally aggregated).
+struct MemoryUsage {
+  int64_t totalBytes{0};
+  int64_t minBytes{std::numeric_limits<int64_t>::max()};
+  int64_t maxBytes{0};
+  size_t numEntries{0};
+
+  void update(int64_t bytes) {
+    maxBytes = std::max(maxBytes, bytes);
+    minBytes = std::min(minBytes, bytes);
+    totalBytes += bytes;
+    ++numEntries;
+  }
+
+  void toString(std::stringstream& out, const char* entriesName = "entries")
+      const {
+    out << succinctBytes(totalBytes) << " in " << numEntries << " "
+        << entriesName << ", min " << succinctBytes(minBytes) << ", max "
+        << succinctBytes(maxBytes);
+  }
+};
+
+// Aggregated memory usage stats of a single Task Pipeline Memory Pool.
+struct PipelineMemoryUsage {
+  MemoryUsage total;
+  std::unordered_map<std::string, MemoryUsage> operators;
+};
+
+// Aggregated memory usage stats of a single Task Pipeline Memory Pool.
+struct TaskMemoryUsage {
+  std::string taskId;
+  MemoryUsage total;
+  std::vector<PipelineMemoryUsage> pipelines;
+
+  void toString(std::stringstream& out) const {
+    // Using 4 spaces for indent in the output.
+    out << "\n    ";
+    out << taskId;
+    out << ": ";
+    total.toString(out, "drivers");
+    for (auto i = 0; i < pipelines.size(); ++i) {
+      const auto& pipelineMemoryUsage = pipelines[i];
+      out << "\n        pipe.";
+      out << folly::to<std::string>(i);
+      out << ": ";
+      pipelineMemoryUsage.total.toString(out, "operators");
+      for (const auto& it : pipelineMemoryUsage.operators) {
+        const MemoryUsage& operatorMemoryUsage = it.second;
+        out << "\n            ";
+        out << it.first;
+        out << ": ";
+        operatorMemoryUsage.toString(out, "instances");
+      }
+    }
+  }
+};
+} // namespace
+
+static void collectOperatorMemoryUsage(
+    PipelineMemoryUsage& pipelineMemoryUsage,
+    memory::MemoryPool* operatorPool) {
+  const auto numBytes =
+      operatorPool->getMemoryUsageTracker()->getCurrentTotalBytes();
+  pipelineMemoryUsage.total.update(numBytes);
+  auto& operatorMemoryUsage =
+      pipelineMemoryUsage.operators[operatorPool->getName()];
+  operatorMemoryUsage.update(numBytes);
+}
+
+static void collectDriverMemoryUsage(
+    TaskMemoryUsage& taskMemoryUsage,
+    memory::MemoryPool* driverPool) {
+  // Update task's stats from each driver.
+  taskMemoryUsage.total.update(
+      driverPool->getMemoryUsageTracker()->getCurrentTotalBytes());
+
+  // Figure out the pipeline and ensure we have stats struct allocated for it.
+  const auto& poolName = driverPool->getName();
+  // In case of troubles figuring out pipeline id, dump all into the pipeline 0.
+  size_t pipelineId{0};
+  const auto firstDot = poolName.find('.');
+  if (firstDot != std::string::npos) {
+    const auto secondDot = poolName.find('.', firstDot + 1);
+    if (secondDot != std::string::npos) {
+      pipelineId = folly::tryTo<size_t>(
+                       poolName.substr(firstDot + 1, secondDot - firstDot - 1))
+                       .value_or(0);
+    }
+  }
+  taskMemoryUsage.pipelines.resize(pipelineId + 1);
+  auto& pipelineMemoryUsage = taskMemoryUsage.pipelines[pipelineId];
+
+  // Run through the operator pools and update operator stats for the
+  // pipeline.
+  driverPool->visitChildren(
+      [&pipelineMemoryUsage](memory::MemoryPool* operPool) {
+        collectOperatorMemoryUsage(pipelineMemoryUsage, operPool);
+      });
+}
+
+static void collectTaskMemoryUsage(
+    TaskMemoryUsage& taskMemoryUsage,
+    memory::MemoryPool* taskPool) {
+  taskMemoryUsage.taskId = taskPool->getName();
+  taskPool->visitChildren([&taskMemoryUsage](memory::MemoryPool* driverPool) {
+    collectDriverMemoryUsage(taskMemoryUsage, driverPool);
+  });
+}
+
+static std::string getQueryMemoryUsageString(memory::MemoryPool* queryPool) {
+  std::vector<TaskMemoryUsage> taskMemoryUsages;
+  taskMemoryUsages.reserve(queryPool->getChildCount());
+  queryPool->visitChildren([&taskMemoryUsages](memory::MemoryPool* taskPool) {
+    taskMemoryUsages.emplace_back(TaskMemoryUsage{});
+    collectTaskMemoryUsage(taskMemoryUsages.back(), taskPool);
+  });
+
   std::stringstream out;
-  out << "Task total: " << succinctBytes(tracker.getCurrentTotalBytes())
-      << " Peak: " << succinctBytes(tracker.getPeakTotalBytes()) << ".";
-  // Aggregate relevant metrics for each operator across all drivers.
-  struct MemoryUsageStats {
-    int operatorId{0};
-    std::string operatorType;
-    int64_t cumulativeTotalBytes{0};
-    int64_t peakTotalBytes{0};
-    int numInstances{0};
-
-    MemoryUsageStats() = default;
-    explicit MemoryUsageStats(Operator* op) {
-      operatorId = op->stats().operatorId;
-      operatorType = op->stats().operatorType;
-    }
-
-    void add(const std::shared_ptr<memory::MemoryUsageTracker>& tracker) {
-      this->cumulativeTotalBytes += tracker->getCurrentTotalBytes();
-      this->peakTotalBytes =
-          std::max(this->peakTotalBytes, tracker->getPeakTotalBytes());
-      this->numInstances++;
-    }
-  };
-  std::unordered_map<int32_t, MemoryUsageStats> operatorStats;
-  {
-    std::lock_guard<std::mutex> l(mutex_);
-    for (auto& driver : drivers_) {
-      if (!driver) {
-        continue;
-      }
-      auto operators = driver->operators();
-      for (auto op : operators) {
-        auto it = operatorStats.find(op->stats().operatorId);
-        if (it == operatorStats.end()) {
-          it = operatorStats
-                   .insert({op->stats().operatorId, MemoryUsageStats(op)})
-                   .first;
-        }
-        it->second.add(op->pool()->getMemoryUsageTracker());
-      }
-    }
-  }
-  std::vector<MemoryUsageStats> operatorStatsArray;
-  operatorStatsArray.reserve(operatorStats.size());
-  for (auto& [operatorId, stats] : operatorStats) {
-    operatorStatsArray.push_back(std::move(stats));
-  }
-  static auto compareByCumulativeTotalBytes =
-      [](const MemoryUsageStats& left, const MemoryUsageStats& right) {
-        return left.cumulativeTotalBytes > right.cumulativeTotalBytes;
-      };
-  // Get the top 3.
-  if (operatorStatsArray.size() > 3) {
-    std::nth_element(
-        operatorStatsArray.begin(),
-        operatorStatsArray.begin() + 2,
-        operatorStatsArray.end(),
-        compareByCumulativeTotalBytes);
-    operatorStatsArray.resize(3);
-  }
-  std::sort(
-      operatorStatsArray.begin(),
-      operatorStatsArray.end(),
-      compareByCumulativeTotalBytes);
-  out << " Top " << operatorStatsArray.size()
-      << " Operators (by aggregate usage across all drivers): ";
-  int remainingStatsToAdd = operatorStatsArray.size();
-  for (auto& stats : operatorStatsArray) {
-    out << stats.operatorType << "_#" << stats.operatorId << "_x"
-        << stats.numInstances << ": "
-        << succinctBytes(stats.cumulativeTotalBytes)
-        << " Peak: " << succinctBytes(stats.peakTotalBytes);
-    remainingStatsToAdd--;
-    if (remainingStatsToAdd > 0) {
-      out << ", ";
-    }
+  out << "\n";
+  out << queryPool->getName();
+  out << ": total: ";
+  out << succinctBytes(
+      queryPool->getMemoryUsageTracker()->getCurrentTotalBytes());
+  for (const auto& taskMemoryUsage : taskMemoryUsages) {
+    taskMemoryUsage.toString(out);
   }
   return out.str();
 }
+
+std::string Task::getErrorMsgOnMemCapExceeded(
+    memory::MemoryUsageTracker& /*tracker*/) {
+  return getQueryMemoryUsageString(queryCtx()->pool());
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -588,14 +588,32 @@ class Task : public std::enable_shared_from_this<Task> {
   int getOutputPipelineId() const;
 
   /// Callback function added to the MemoryUsageTracker to return a descriptive
-  /// message to be added to the error when a MEM_CAP_EXCEEDED error is
-  /// encountered.
+  /// message about query memory usage to be added to the error when a
+  /// MEM_CAP_EXCEEDED error is encountered.
   /// Example Error Message generated:
-  /// Exceeded memory cap of 12.00MB when requesting 1.00MB. Task total: 8.00MB
-  /// Peak: 12.00MB. Top 3 Operators (by aggregate usage across all drivers):
-  /// Aggregation_#1_x6: 168.00KB Peak: 1.00MB, TableScan_#0_x6: 51.46KB
-  /// Peak: 1.00MB, CallbackSink_#2_x6: 0B Peak: 0B. Failed Operator:
-  /// Aggregation_#1: 0B
+  /// Query 20220923_033248_00003_xney3 failed:
+  ///   Exceeded memory cap of 7.00GB when requesting 4.00MB.
+  /// query.20220923_033248_00003_xney3: total: 7.00GB
+  ///     task.20220923_033248_00003_xney3.1.0.25: : 5.88GB in 30 drivers,
+  ///       min 2.00MB, max 400.00MB
+  ///         pipe.0: : 5.74GB in 60 operators, min 0B, max 393.81MB
+  ///             op.PartitionedOutput: : 0B in 15 instances, min 0B, max 0B
+  ///             op.FilterProject: : 0B in 15 instances, min 0B, max 0B
+  ///             op.Aggregation: : 5GB in 15 instances, min 384MB, max 393MB
+  ///             op.LocalExchange: : 0B in 15 instances, min 0B, max 0B
+  ///         pipe.1: : 32.75MB in 30 operators, min 4.00KB, max 14.65MB
+  ///             op.LocalPartition: : 508KB in 15 instances, min 4KB, max 63KB
+  ///             op.Exchange: : 32.25MB in 15 instances, min 107KB, max 14MB
+  ///     task.20220923_033248_00003_xney3.2.0.19: : 1.12GB in 15 drivers,
+  ///       min 61.00MB, max 91.00MB
+  ///         pipe.0: : 1.03GB in 75 operators, min 149.00KB, max 39.38MB
+  ///             op.PartitionedOutput: : 446.71MB in 15 instances,
+  ///               min 12.02MB, max 39.38MB
+  ///             op.PartialAggregation: : 300.03MB in 15 instances,
+  ///               min 1.48MB, max 25.59MB
+  ///             op.FilterProject: : 32MB in 30 instances, min 149KB, max 2MB
+  ///             op.TableScan: : 278MB in 15 instances, min 9.05MB, max 27MB.
+  /// Failed Operator: PartialAggregation.3: 11.98MB
   std::string getErrorMsgOnMemCapExceeded(memory::MemoryUsageTracker& tracker);
 
   // RAII helper class to satisfy 'stateChangePromises_' and notify listeners


### PR DESCRIPTION
Summary:
Add 'query memory tree print out' to memory exception message.
The message now looks like this:

  Query 20220923_033248_00003_xney3 failed:  Exceeded memory cap of 7.00GB when requesting 4.00MB.
  query.20220923_033248_00003_xney3: total: 7.00GB
      task.20220923_033248_00003_xney3.1.0.25: 5.88GB in 30 drivers, min 2.00MB, max 400.00MB
          pipe.0: 5.74GB in 60 operators, min 0B, max 393.81MB
              op.PartitionedOutput: 0B in 15 instances, min 0B, max 0B
              op.FilterProject: 0B in 15 instances, min 0B, max 0B
              op.Aggregation: 5.74GB in 15 instances, min 384.00MB, max 393.81MB
              op.LocalExchange: 0B in 15 instances, min 0B, max 0B
          pipe.1: 32.75MB in 30 operators, min 4.00KB, max 14.65MB
              op.LocalPartition: 508.50KB in 15 instances, min 4.00KB, max 63.00KB
              op.Exchange: 32.25MB in 15 instances, min 107.00KB, max 14.65MB
      task.20220923_033248_00003_xney3.2.0.19: 1.12GB in 15 drivers, min 61.00MB, max 91.00MB
          pipe.0: 1.03GB in 75 operators, min 149.00KB, max 39.38MB
              op.PartitionedOutput: 446.71MB in 15 instances, min 12.02MB, max 39.38MB
              op.PartialAggregation: 300.03MB in 15 instances, min 1.48MB, max 25.59MB
              op.FilterProject: 32.02MB in 30 instances, min 149.00KB, max 2.00MB
              op.TableScan: 278.23MB in 15 instances, min 9.05MB, max 27.59MB.
  Failed Operator: PartialAggregation_#3: 11.98MB

Differential Revision: D39773807

