### PR TITLE
Update memory tracker with current pool memory usage

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -739,6 +739,7 @@ template <typename Allocator, uint16_t ALIGNMENT>
 void MemoryPoolImpl<Allocator, ALIGNMENT>::setMemoryUsageTracker(
     const std::shared_ptr<MemoryUsageTracker>& tracker) {
   memoryUsageTracker_ = tracker;
+  memoryUsageTracker_->update(getCurrentBytes());
 }
 
 template <typename Allocator, uint16_t ALIGNMENT>


### PR DESCRIPTION
Summary: Fix an accounting bug where if we attach the memory usage tracker to a memory pool that already tracks allocations, we could end up with negative memory tracking due to tracking the frees afterward but not the initial allocations.

Differential Revision: D39789103

