### PR TITLE
Remove deprecated create function in MemoryUsageTracker

### DIFF
--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -128,22 +128,6 @@ class MemoryUsageTracker
     return create(nullptr, UsageType::kUserMem, config);
   }
 
-  // FIXME(venkatra): Remove this once presto_cpp is updated to use above
-  // function.
-  static std::shared_ptr<MemoryUsageTracker> create(
-      int64_t maxUserMemory,
-      int64_t maxSystemMemory,
-      int64_t maxTotalMemory) {
-    return create(
-        nullptr,
-        UsageType::kUserMem,
-        MemoryUsageConfigBuilder()
-            .maxUserMemory(maxUserMemory)
-            .maxSystemMemory(maxSystemMemory)
-            .maxTotalMemory(maxTotalMemory)
-            .build());
-  }
-
   virtual ~MemoryUsageTracker() = default;
 
   // Increments the reservation for 'this' so that we can allocate at

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -145,7 +145,11 @@ class QueryCtx : public Context {
         kQueryRootMemoryPool);
     static const auto kUnlimited = std::numeric_limits<int64_t>::max();
     pool_->setMemoryUsageTracker(
-        memory::MemoryUsageTracker::create(kUnlimited, kUnlimited, kUnlimited));
+        memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder()
+                                               .maxUserMemory(kUnlimited)
+                                               .maxSystemMemory(kUnlimited)
+                                               .maxTotalMemory(kUnlimited)
+                                               .build()));
   }
 
   static constexpr const char* FOLLY_NONNULL kQueryRootMemoryPool =

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -872,7 +872,11 @@ TEST_F(AggregationTest, spill) {
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = core::QueryCtx::createForTest();
   queryCtx->pool()->setMemoryUsageTracker(
-      memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(0).maxTotalMemory(kMaxBytes).build()));
+      memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder()
+                                             .maxUserMemory(kMaxBytes)
+                                             .maxSystemMemory(0)
+                                             .maxTotalMemory(kMaxBytes)
+                                             .build()));
   auto task =
       AssertQueryBuilder(PlanBuilder()
                              .values(batches)
@@ -966,7 +970,11 @@ TEST_F(AggregationTest, spillWithEmptyPartition) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = core::QueryCtx::createForTest();
     queryCtx->pool()->setMemoryUsageTracker(
-        memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(0).maxTotalMemory(kMaxBytes).build()));
+        memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder()
+                                               .maxUserMemory(kMaxBytes)
+                                               .maxSystemMemory(0)
+                                               .maxTotalMemory(kMaxBytes)
+                                               .build()));
 
 #ifndef NDEBUG
     SCOPED_TESTVALUE_SET(
@@ -1085,7 +1093,11 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = core::QueryCtx::createForTest();
   queryCtx->pool()->setMemoryUsageTracker(
-      memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(0).maxTotalMemory(kMaxBytes).build()));
+      memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder()
+                                             .maxUserMemory(kMaxBytes)
+                                             .maxSystemMemory(0)
+                                             .maxTotalMemory(kMaxBytes)
+                                             .build()));
 
   auto task =
       AssertQueryBuilder(PlanBuilder()

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -872,7 +872,7 @@ TEST_F(AggregationTest, spill) {
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = core::QueryCtx::createForTest();
   queryCtx->pool()->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
+      memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(0).maxTotalMemory(kMaxBytes).build()));
   auto task =
       AssertQueryBuilder(PlanBuilder()
                              .values(batches)
@@ -966,7 +966,7 @@ TEST_F(AggregationTest, spillWithEmptyPartition) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = core::QueryCtx::createForTest();
     queryCtx->pool()->setMemoryUsageTracker(
-        velox::memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
+        memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(0).maxTotalMemory(kMaxBytes).build()));
 
 #ifndef NDEBUG
     SCOPED_TESTVALUE_SET(
@@ -1085,7 +1085,7 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = core::QueryCtx::createForTest();
   queryCtx->pool()->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
+      memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(0).maxTotalMemory(kMaxBytes).build()));
 
   auto task =
       AssertQueryBuilder(PlanBuilder()

--- a/velox/exec/tests/MemoryCapExceededTest.cpp
+++ b/velox/exec/tests/MemoryCapExceededTest.cpp
@@ -60,8 +60,11 @@ TEST_F(MemoryCapExceededTest, singleDriver) {
                   .planNode();
   auto queryCtx = core::QueryCtx::createForTest();
   queryCtx->pool()->setMemoryUsageTracker(
-      memory::MemoryUsageTracker::create(
-          memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(kMaxBytes).maxTotalMemory(kMaxBytes).build()));
+      memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder()
+                                             .maxUserMemory(kMaxBytes)
+                                             .maxSystemMemory(kMaxBytes)
+                                             .maxTotalMemory(kMaxBytes)
+                                             .build()));
   CursorParameters params;
   params.planNode = plan;
   params.queryCtx = queryCtx;
@@ -100,8 +103,11 @@ TEST_F(MemoryCapExceededTest, multipleDrivers) {
                   .planNode();
   auto queryCtx = core::QueryCtx::createForTest();
   queryCtx->pool()->setMemoryUsageTracker(
-      memory::MemoryUsageTracker::create(
-          memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(kMaxBytes).maxTotalMemory(kMaxBytes).build()));
+      memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder()
+                                             .maxUserMemory(kMaxBytes)
+                                             .maxSystemMemory(kMaxBytes)
+                                             .maxTotalMemory(kMaxBytes)
+                                             .build()));
 
   CursorParameters params;
   params.planNode = plan;

--- a/velox/exec/tests/MemoryCapExceededTest.cpp
+++ b/velox/exec/tests/MemoryCapExceededTest.cpp
@@ -60,8 +60,8 @@ TEST_F(MemoryCapExceededTest, singleDriver) {
                   .planNode();
   auto queryCtx = core::QueryCtx::createForTest();
   queryCtx->pool()->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(
-          kMaxBytes, kMaxBytes, kMaxBytes));
+      memory::MemoryUsageTracker::create(
+          memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(kMaxBytes).maxTotalMemory(kMaxBytes).build()));
   CursorParameters params;
   params.planNode = plan;
   params.queryCtx = queryCtx;
@@ -100,8 +100,8 @@ TEST_F(MemoryCapExceededTest, multipleDrivers) {
                   .planNode();
   auto queryCtx = core::QueryCtx::createForTest();
   queryCtx->pool()->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(
-          kMaxBytes, kMaxBytes, kMaxBytes));
+      memory::MemoryUsageTracker::create(
+          memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(kMaxBytes).maxTotalMemory(kMaxBytes).build()));
 
   CursorParameters params;
   params.planNode = plan;

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -423,7 +423,7 @@ TEST_F(OrderByTest, spill) {
   auto queryCtx = core::QueryCtx::createForTest();
   constexpr int64_t kMaxBytes = 20LL << 20; // 20 MB
   queryCtx->pool()->setMemoryUsageTracker(
-      memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
+      memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(0).maxTotalMemory(kMaxBytes).build()));
   // Set 'kSpillableReservationGrowthPct' to an extreme large value to trigger
   // disk spilling by failed memory growth reservation.
   queryCtx->setConfigOverridesUnsafe(

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -423,7 +423,11 @@ TEST_F(OrderByTest, spill) {
   auto queryCtx = core::QueryCtx::createForTest();
   constexpr int64_t kMaxBytes = 20LL << 20; // 20 MB
   queryCtx->pool()->setMemoryUsageTracker(
-      memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder().maxUserMemory(kMaxBytes).maxSystemMemory(0).maxTotalMemory(kMaxBytes).build()));
+      memory::MemoryUsageTracker::create(memory::MemoryUsageConfigBuilder()
+                                             .maxUserMemory(kMaxBytes)
+                                             .maxSystemMemory(0)
+                                             .maxTotalMemory(kMaxBytes)
+                                             .build()));
   // Set 'kSpillableReservationGrowthPct' to an extreme large value to trigger
   // disk spilling by failed memory growth reservation.
   queryCtx->setConfigOverridesUnsafe(


### PR DESCRIPTION
Remove deprecated MemoryUsageTracker::create(int64_t maxUserMemory, int64_t maxSystemMemory,int64_t maxTotalMemory), and use MemoryUsageTracker::create(const MemoryUsageConfig& config) instead.

This PR depend on https://github.com/prestodb/presto/pull/18398