### PR TITLE
Bump benchalerts to 0.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
             # upgrade python to 3.8 for this job
             yum install -y python38
             pip3.8 install conbench
-            pip3.8 install git+https://github.com/conbench/benchalerts.git@0.1.1
+            pip3.8 install git+https://github.com/conbench/benchalerts.git@0.2.1
             pip3.8 install scripts/veloxbench
       - run:
           name: "Run Benchmarks"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,9 @@ jobs:
             conbench cpp-micro --run-name="$run_name" --run-reason="$run_reason"
       - run:
           name: "Analyze benchmark regressions and post to Github"
-          command: python3.8 scripts/benchmark-github-status.py --z-score-threshold 50
+          command: |
+            export GITHUB_APP_PRIVATE_KEY=$(echo $GITHUB_APP_PRIVATE_KEY_ENCODED | base64 -d)
+            python3.8 scripts/benchmark-github-status.py --z-score-threshold 50
       - store_artifacts:
           path: '_build/debug/.ninja_log'
       - save_cache:


### PR DESCRIPTION
This PR bumps the CI benchmarking's `benchalerts` dependency to 0.2.1. This includes https://github.com/conbench/benchalerts/pull/10, which enables authentication using a GitHub App instead of a PAT.