### PR TITLE
Extend class to add api to return aggregate functions

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -61,6 +61,21 @@ bool registerAggregateFunction(
   return true;
 }
 
+std::unordered_map<
+    std::string,
+    std::vector<std::shared_ptr<AggregateFunctionSignature>>>
+getAggregateFunctionSignatures() {
+  std::unordered_map<
+      std::string,
+      std::vector<std::shared_ptr<AggregateFunctionSignature>>>
+      map;
+  auto aggregateFunctions = exec::aggregateFunctions();
+  for (const auto& aggregateFunction : aggregateFunctions) {
+    map[aggregateFunction.first] = aggregateFunction.second.signatures;
+  }
+  return map;
+}
+
 std::optional<std::vector<std::shared_ptr<AggregateFunctionSignature>>>
 getAggregateFunctionSignatures(const std::string& name) {
   if (auto func = getAggregateFunctionEntry(name)) {

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -329,6 +329,13 @@ bool registerAggregateFunction(
 std::optional<std::vector<std::shared_ptr<AggregateFunctionSignature>>>
 getAggregateFunctionSignatures(const std::string& name);
 
+/// Returns a mapping of all Aggregate functions in registry.
+/// The mapping is function name -> list of function signatures.
+std::unordered_map<
+    std::string,
+    std::vector<std::shared_ptr<AggregateFunctionSignature>>>
+getAggregateFunctionSignatures();
+
 struct AggregateFunctionEntry {
   std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures;
   AggregateFunctionFactory factory;


### PR DESCRIPTION
Summary:
As per title, the changes in this diff adds an api to FunctionRegistry.cpp
 * getAggregateFunctionSignatures which returns function signatures for all aggregate functions registered

The logic could have been added to getFunctionSignatures (returns all scalar function signatures) but we want a separation of scalar vs aggregate function signatures.

Differential Revision: D39713014

