### PR TITLE
Ensure closure of flush policy in writer close

### DIFF
--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/dwrf/writer/Writer.h"
 
+#include <folly/ScopeGuard.h>
+
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/utils/ProtoUtils.h"
@@ -633,8 +635,8 @@ void Writer::flush() {
 }
 
 void Writer::close() {
+  auto exitGuard = folly::makeGuard([this]() { flushPolicy_->onClose(); });
   flushInternal(true);
-  flushPolicy_->onClose();
   WriterBase::close();
 }
 


### PR DESCRIPTION
Summary:
In its current state, `flushPolicy_->onClose()` can be skipped when there are exceptions in either flushing the last stripe or closing the writer base.

This diff ensures closure of flush policy when closing the writer. This is an important guarantee for multithreaded coordination.

Future work would be to try and call onClose() in the flush policy destructor instead. Currently if we do that in the multithreaded test suite we see dead locks, and we don't want to invest too much time on making it perfect right now.

Differential Revision: D39842357

