### PR TITLE
Add support for decimal types in HiveTypeParser

### DIFF
--- a/velox/dwio/dwrf/utils/test/ProtoUtilsTests.cpp
+++ b/velox/dwio/dwrf/utils/test/ProtoUtilsTests.cpp
@@ -40,17 +40,6 @@ TEST(ProtoUtilsTests, AllTypes) {
   }
 }
 
-TEST(ProtoUtilsTests, UnionDeprecation) {
-  std::vector<std::string> types{
-      "struct<a:uniontype<int,string>>",
-      "struct<a:map<int,array<struct<a:map<string,int>,b:array<int>,c:uniontype<int,float>>>>>"};
-
-  for (auto& type : types) {
-    HiveTypeParser parser;
-    EXPECT_THROW(parser.parse(type), std::invalid_argument);
-  }
-}
-
 TEST(ProtoUtilsTests, Projection) {
   HiveTypeParser parser;
   auto schema = parser.parse(

--- a/velox/dwio/type/fbhive/CMakeLists.txt
+++ b/velox/dwio/type/fbhive/CMakeLists.txt
@@ -12,4 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(fbhive)
+add_library(velox_dwio_type_fbhive HiveTypeParser.cpp HiveTypeSerializer.cpp)
+
+target_link_libraries(velox_dwio_type_fbhive velox_dwio_common)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/dwio/type/fbhive/HiveTypeParser.cpp
+++ b/velox/dwio/type/fbhive/HiveTypeParser.cpp
@@ -26,11 +26,22 @@
 using facebook::velox::Type;
 using facebook::velox::TypeKind;
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace type {
-namespace fbhive {
+#define VELOX_THROW_CONDITION(condition, error) \
+  if ((condition)) {                            \
+    throw std::invalid_argument(error);         \
+  }
+
+namespace {
+/// Returns true only if 'str' contains digits.
+bool isPositiveInteger(const std::string& str) {
+  return !str.empty() &&
+      std::find_if(str.begin(), str.end(), [](unsigned char c) {
+        return !std::isdigit(c);
+      }) == str.end();
+}
+} // namespace
+
+namespace facebook::velox::dwio::type::fbhive {
 
 HiveTypeParser::HiveTypeParser() {
   metadata_.resize(static_cast<size_t>(TokenType::MaxTokenType) + 1);
@@ -41,6 +52,9 @@ HiveTypeParser::HiveTypeParser() {
   setupMetadata<TokenType::Long, TypeKind::BIGINT>("bigint");
   setupMetadata<TokenType::Float, TypeKind::REAL>({"float", "real"});
   setupMetadata<TokenType::Double, TypeKind::DOUBLE>("double");
+  setupMetadata<TokenType::ShortDecimal, TypeKind::SHORT_DECIMAL>(
+      "short_decimal");
+  setupMetadata<TokenType::LongDecimal, TypeKind::LONG_DECIMAL>("long_decimal");
   setupMetadata<TokenType::String, TypeKind::VARCHAR>({"string", "varchar"});
   setupMetadata<TokenType::Binary, TypeKind::VARBINARY>(
       {"binary", "varbinary"});
@@ -52,6 +66,8 @@ HiveTypeParser::HiveTypeParser() {
   setupMetadata<TokenType::EndSubType, TypeKind::INVALID>(">");
   setupMetadata<TokenType::Colon, TypeKind::INVALID>(":");
   setupMetadata<TokenType::Comma, TypeKind::INVALID>(",");
+  setupMetadata<TokenType::LeftRoundBracket, TypeKind::INVALID>("(");
+  setupMetadata<TokenType::RightRoundBracket, TypeKind::INVALID>(")");
   setupMetadata<TokenType::Number, TypeKind::INVALID>();
   setupMetadata<TokenType::Identifier, TypeKind::INVALID>();
   setupMetadata<TokenType::EndOfStream, TypeKind::INVALID>();
@@ -60,17 +76,31 @@ HiveTypeParser::HiveTypeParser() {
 std::shared_ptr<const Type> HiveTypeParser::parse(const std::string& ser) {
   remaining_ = folly::StringPiece(ser);
   Result result = parseType();
-  if (remaining_.size() != 0 && (TokenType::EndOfStream != lookAhead())) {
-    throw std::invalid_argument("Input remaining after type parsing");
-  }
+  VELOX_THROW_CONDITION(
+      remaining_.size() != 0 && (TokenType::EndOfStream != lookAhead()),
+      "Input remaining after type parsing");
   return result.type;
 }
 
 Result HiveTypeParser::parseType() {
   Token nt = nextToken();
-  if (nt.isEOS()) {
-    throw std::invalid_argument("Unexpected end of stream parsing type!!!");
-  } else if (nt.isValidType() && nt.isPrimitiveType()) {
+  VELOX_THROW_CONDITION(nt.isEOS(), "Unexpected end of stream parsing type!!!");
+  if (nt.isValidType() && nt.isPrimitiveType()) {
+    if (isDecimalKind(nt.typeKind())) {
+      eatToken(TokenType::LeftRoundBracket);
+      Token precision = nextToken();
+      VELOX_THROW_CONDITION(
+          !isPositiveInteger(precision.value.toString()),
+          "Decimal precision must be a positive integer");
+      eatToken(TokenType::Comma);
+      Token scale = nextToken();
+      VELOX_THROW_CONDITION(
+          !isPositiveInteger(scale.value.toString()),
+          "Decimal scale must be a positive integer");
+      eatToken(TokenType::RightRoundBracket);
+      return Result{DECIMAL(
+          std::atoi(precision.value.data()), std::atoi(scale.value.data()))};
+    }
     auto scalarType = createScalarType(nt.typeKind());
     DWIO_ENSURE_NOT_NULL(
         scalarType, "Returned a null scalar type for ", nt.typeKind());
@@ -82,16 +112,16 @@ Result HiveTypeParser::parseType() {
         return Result{velox::ROW(
             std::move(resultList.names), std::move(resultList.typelist))};
       case velox::TypeKind::MAP: {
-        if (resultList.typelist.size() != 2) {
-          throw std::invalid_argument{"wrong param count for map type def"};
-        }
+        VELOX_THROW_CONDITION(
+            resultList.typelist.size() != 2,
+            "wrong param count for map type def");
         return Result{
             velox::MAP(resultList.typelist.at(0), resultList.typelist.at(1))};
       }
       case velox::TypeKind::ARRAY: {
-        if (resultList.typelist.size() != 1) {
-          throw std::invalid_argument{"wrong param count for array type def"};
-        }
+        VELOX_THROW_CONDITION(
+            resultList.typelist.size() != 1,
+            "wrong param count for array type def");
         return Result{velox::ARRAY(resultList.typelist.at(0))};
       }
       default:
@@ -229,8 +259,4 @@ TokenMetadata* HiveTypeParser::getMetadata(TokenType type) const {
   return value.get();
 }
 
-} // namespace fbhive
-} // namespace type
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::type::fbhive

--- a/velox/dwio/type/fbhive/HiveTypeParser.h
+++ b/velox/dwio/type/fbhive/HiveTypeParser.h
@@ -25,11 +25,7 @@
 #include "folly/Range.h"
 #include "velox/dwio/type/TypeParser.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace type {
-namespace fbhive {
+namespace facebook::velox::dwio::type::fbhive {
 
 // TODO : Find out what to do with these types
 // NUMERIC, INTERVAL, VARCHAR, VOID
@@ -54,7 +50,11 @@ enum class TokenType {
   Number = 17,
   Identifier = 18,
   EndOfStream = 19,
-  MaxTokenType = 19
+  ShortDecimal = 20,
+  LongDecimal = 21,
+  LeftRoundBracket = 22,
+  RightRoundBracket = 23,
+  MaxTokenType = 23
 };
 
 struct TokenMetadata {
@@ -152,8 +152,4 @@ class HiveTypeParser : public type::TypeParser {
   folly::StringPiece remaining_;
 };
 
-} // namespace fbhive
-} // namespace type
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::type::fbhive

--- a/velox/dwio/type/fbhive/tests/CMakeLists.txt
+++ b/velox/dwio/type/fbhive/tests/CMakeLists.txt
@@ -12,4 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(fbhive)
+add_executable(velox_dwio_type_fbhive_test HiveTypeParserTests.cpp)
+
+add_test(
+  NAME velox_dwio_type_fbhive_test
+  COMMAND velox_dwio_type_fbhive_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(velox_dwio_type_fbhive_test velox_dwio_type_fbhive
+                      velox_type gtest gtest_main gmock)


### PR DESCRIPTION
Add support for decimal types in HiveTypeParser. 
Enable HiveTypeParserTest.
Use VELOX_CHECK, VELOX_FAIL in HiveTypeParser.