### PR TITLE
Add support for lambdas to SignatureBinder

### DIFF
--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -140,12 +140,17 @@ bool SignatureBinder::tryBind() {
     }
   }
 
+  bool allBound = true;
   for (auto i = 0; i < formalArgsCnt && i < actualTypes_.size(); i++) {
-    if (!tryBind(formalArgs[i], actualTypes_[i])) {
-      return false;
+    if (actualTypes_[i]) {
+      if (!tryBind(formalArgs[i], actualTypes_[i])) {
+        allBound = false;
+      }
+    } else {
+      allBound = false;
     }
   }
-  return true;
+  return allBound;
 }
 
 bool SignatureBinder::checkOrSetIntegerParameter(

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -24,6 +24,10 @@ namespace facebook::velox::exec {
 /// types. E.g. given function signature array(T) -> T and input type
 /// array(bigint), resolves T to bigint. If type resolution is successful,
 /// calculates the actual return type, e.g. bigint in the previous example.
+///
+/// Supports function signatures with lambdas via partial resolution. The
+/// constructor allows some types in 'actualTypes' to be null (the one
+/// corresponding to lambda inputs).
 class SignatureBinder {
  public:
   SignatureBinder(


### PR DESCRIPTION
To resolve lambda functions, SignatureBinders needs to support partial
resolution based on a subset of input arguments.