### PR TITLE
Add full support for lambda expressions in tests

### DIFF
--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -218,30 +218,6 @@ class FunctionBaseTest : public testing::Test,
     }
   }
 
-  /// Register a lambda expression with a name that can later be used to refer
-  /// to the lambda in a function call, e.g. foo(a, b,
-  /// function('<lanbda-name>')).
-  ///
-  /// @param name Name to use when referring to the lambda expression from a
-  /// function call.
-  /// @param signature A list of names and types of inputs for the lambda
-  /// expression.
-  /// @param rowType The type of the input data used to resolve types of
-  /// captures used in the lambda expression.
-  /// @param body Body of the lambda as SQL expression.
-  void registerLambda(
-      const std::string& name,
-      const RowTypePtr& signature,
-      TypePtr rowType,
-      const std::string& body) {
-    core::Expressions::registerLambda(
-        name,
-        signature,
-        rowType,
-        parse::parseExpr(body, options_),
-        execCtx_.pool());
-  }
-
   core::TypedExprPtr parseExpression(
       const std::string& text,
       const RowTypePtr& rowType) {

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/Expressions.h"
 #include "velox/expression/SimpleFunctionRegistry.h"
+#include "velox/functions/FunctionRegistry.h"
 #include "velox/parse/VariantToVector.h"
 #include "velox/type/Type.h"
 #include "velox/vector/ConstantVector.h"
@@ -25,13 +26,6 @@ namespace facebook::velox::core {
 
 // static
 Expressions::TypeResolverHook Expressions::resolverHook_;
-
-std::unordered_map<std::string, std::shared_ptr<core::LambdaTypedExpr>>&
-Expressions::lambdaRegistry() {
-  static std::unordered_map<std::string, std::shared_ptr<core::LambdaTypedExpr>>
-      lambdas;
-  return lambdas;
-}
 
 namespace {
 std::vector<TypePtr> getTypes(const std::vector<TypedExprPtr>& inputs) {
@@ -162,8 +156,8 @@ std::string toString(
 }
 
 TypedExprPtr createWithImplicitCast(
-    std::shared_ptr<const core::CallExpr> expr,
-    std::vector<TypedExprPtr> inputs) {
+    const std::shared_ptr<const core::CallExpr>& expr,
+    const std::vector<TypedExprPtr>& inputs) {
   auto adjusted = adjustLastNArguments(inputs, expr, inputs.size());
   if (adjusted) {
     return adjusted;
@@ -172,40 +166,55 @@ TypedExprPtr createWithImplicitCast(
   return std::make_shared<CallTypedExpr>(
       type, std::move(inputs), std::string{expr->getFunctionName()});
 }
-} // namespace
 
-std::shared_ptr<const LambdaTypedExpr> Expressions::lookupLambdaExpr(
-    std::shared_ptr<const IExpr> expr) {
-  if (auto callExpr = std::dynamic_pointer_cast<const CallExpr>(expr)) {
-    if ("function" == callExpr->getFunctionName()) {
-      auto inputs = callExpr->getInputs();
-      if (inputs.size() != 1) {
-        return nullptr;
-      }
-      if (auto constant =
-              std::dynamic_pointer_cast<const ConstantExpr>(inputs[0])) {
-        auto it = lambdaRegistry().find(constant->value().value<std::string>());
-        if (it != lambdaRegistry().end()) {
-          return it->second;
-        }
-      }
-    }
-  }
-  return nullptr;
+bool isLambdaArgument(const exec::TypeSignature& typeSignature) {
+  return typeSignature.baseName() == "function";
 }
 
+bool hasLambdaArgument(const exec::FunctionSignature& signature) {
+  for (const auto& type : signature.argumentTypes()) {
+    if (isLambdaArgument(type)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+} // namespace
+
+// static
 TypedExprPtr Expressions::inferTypes(
     const std::shared_ptr<const core::IExpr>& expr,
     const TypePtr& inputRow,
     memory::MemoryPool* pool) {
+  return inferTypes(expr, inputRow, {}, pool);
+}
+
+// static
+TypedExprPtr Expressions::inferTypes(
+    const std::shared_ptr<const core::IExpr>& expr,
+    const TypePtr& inputRow,
+    const std::vector<TypePtr>& lambdaInputTypes,
+    memory::MemoryPool* pool) {
   VELOX_CHECK_NOT_NULL(expr);
-  if (auto lambdaExpr = lookupLambdaExpr(expr)) {
-    return lambdaExpr;
+
+  if (auto lambdaExpr = std::dynamic_pointer_cast<const LambdaExpr>(expr)) {
+    return resolveLambdaExpr(lambdaExpr, inputRow, lambdaInputTypes, pool);
   }
+
+  if (auto call = std::dynamic_pointer_cast<const CallExpr>(expr)) {
+    if (!expr->getInputs().empty()) {
+      if (auto returnType = tryResolveCallWithLambdas(call, inputRow, pool)) {
+        return returnType;
+      }
+    }
+  }
+
   std::vector<TypedExprPtr> children;
   for (auto& child : expr->getInputs()) {
-    children.push_back(inferTypes(child, inputRow, pool));
+    children.push_back(inferTypes(child, inputRow, lambdaInputTypes, pool));
   }
+
   if (auto fae = std::dynamic_pointer_cast<const FieldAccessExpr>(expr)) {
     VELOX_CHECK(
         !fae->getFieldName().empty(), "Anonymous columns are not supported");
@@ -220,7 +229,7 @@ TypedExprPtr Expressions::inferTypes(
         std::string{fae->getFieldName()});
   }
   if (auto fun = std::dynamic_pointer_cast<const CallExpr>(expr)) {
-    return createWithImplicitCast(std::move(fun), std::move(children));
+    return createWithImplicitCast(fun, std::move(children));
   }
   if (auto input = std::dynamic_pointer_cast<const InputExpr>(expr)) {
     return std::make_shared<const InputTypedExpr>(inputRow);
@@ -248,6 +257,109 @@ TypedExprPtr Expressions::inferTypes(
   }
 
   VELOX_FAIL("Unknown expression type: {}", expr->toString());
+}
+
+// static
+TypedExprPtr Expressions::resolveLambdaExpr(
+    const std::shared_ptr<const core::LambdaExpr>& lambdaExpr,
+    const TypePtr& inputRow,
+    const std::vector<TypePtr>& lambdaInputTypes,
+    memory::MemoryPool* pool) {
+  auto names = lambdaExpr->inputNames();
+  auto body = lambdaExpr->body();
+
+  VELOX_CHECK_LE(names.size(), lambdaInputTypes.size());
+  std::vector<TypePtr> types;
+  for (auto i = 0; i < names.size(); ++i) {
+    types.push_back(lambdaInputTypes[i]);
+  }
+
+  auto signature = ROW(std::move(names), std::move(types));
+
+  names = inputRow->asRow().names();
+  types = inputRow->asRow().children();
+  for (auto i = 0; i < signature->size(); ++i) {
+    names.push_back(signature->names()[i]);
+    types.push_back(signature->childAt(i));
+  }
+
+  auto lambdaRow = ROW(std::move(names), std::move(types));
+
+  return std::make_shared<LambdaTypedExpr>(
+      signature, inferTypes(body, lambdaRow, pool));
+}
+
+// static
+TypedExprPtr Expressions::tryResolveCallWithLambdas(
+    const std::shared_ptr<const CallExpr>& callExpr,
+    const TypePtr& inputRow,
+    memory::MemoryPool* pool) {
+  auto allSignatures = getFunctionSignatures();
+  auto it = allSignatures.find(callExpr->getFunctionName());
+  if (it == allSignatures.end()) {
+    return nullptr;
+  }
+
+  const auto& signatures = it->second;
+  for (const auto& signature : signatures) {
+    if (!hasLambdaArgument(*signature)) {
+      return nullptr;
+    }
+
+    VELOX_CHECK_EQ(
+        1,
+        signatures.size(),
+        "Lambda functions with multiple signatures are not supported. "
+        "Lambda function {} has {} signatures.",
+        callExpr->getFunctionName(),
+        signatures.size());
+
+    VELOX_CHECK_EQ(
+        signature->argumentTypes().size(),
+        callExpr->getInputs().size(),
+        "Lambda function signature is not supported: {}({} arguments)."
+        "Supported signature has {} arguments: {}.",
+        callExpr->getFunctionName(),
+        callExpr->getInputs().size(),
+        signature->argumentTypes().size(),
+        signature->toString());
+
+    // Resolve non-lambda arguments first.
+    auto numArgs = callExpr->getInputs().size();
+    std::vector<TypedExprPtr> children(numArgs);
+    std::vector<TypePtr> childTypes(numArgs);
+    for (auto i = 0; i < numArgs; ++i) {
+      if (!isLambdaArgument(signature->argumentTypes()[i])) {
+        children[i] = inferTypes(callExpr->getInputs()[i], inputRow, pool);
+        childTypes[i] = children[i]->type();
+      }
+    }
+
+    // Resolve lambda arguments.
+    exec::SignatureBinder binder(*signature, childTypes);
+    binder.tryBind();
+    for (auto i = 0; i < numArgs; ++i) {
+      auto argSignature = signature->argumentTypes()[i];
+      if (isLambdaArgument(argSignature)) {
+        std::vector<TypePtr> lambdaTypes;
+        for (auto j = 0; j < argSignature.parameters().size() - 1; ++j) {
+          auto type = binder.tryResolveType(argSignature.parameters()[j]);
+          VELOX_CHECK_NOT_NULL(
+              type,
+              "Cannot resolve lambda argument type: {}.",
+              argSignature.toString());
+          lambdaTypes.push_back(type);
+        }
+
+        children[i] =
+            inferTypes(callExpr->getInputs()[i], inputRow, lambdaTypes, pool);
+      }
+    }
+
+    return createWithImplicitCast(callExpr, std::move(children));
+  }
+
+  return nullptr;
 }
 
 // This method returns null if the expression doesn't depend on any input row.

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -28,6 +28,7 @@
 namespace facebook::velox::core {
 
 class CallExpr;
+class LambdaExpr;
 
 class Expressions {
  public:
@@ -51,36 +52,25 @@ class Expressions {
     return resolverHook_;
   }
 
-  // Infers types for a single argument lambda. 'rowType' gives the
-  // names and types of columns available for capture. The lambda can
-  // be referenced with function(name) in a different expression.
-  static void registerLambda(
-      const std::string& name,
-      const std::shared_ptr<const RowType>& signature,
-      TypePtr rowType,
-      std::shared_ptr<const core::IExpr> body,
-      memory::MemoryPool* pool) {
-    auto types = rowType->as<TypeKind::ROW>().children();
-    types.insert(
-        types.end(),
-        signature->children().begin(),
-        signature->children().end());
-    auto names = rowType->as<TypeKind::ROW>().names();
-    names.insert(
-        names.end(), signature->names().begin(), signature->names().end());
-    auto lambdaRowType = ROW(std::move(names), std::move(types));
-    auto typedBody = inferTypes(body, lambdaRowType, pool);
-    lambdaRegistry()[name] =
-        std::make_shared<LambdaTypedExpr>(signature, typedBody);
-  }
-
  private:
-  static std::shared_ptr<const LambdaTypedExpr> lookupLambdaExpr(
-      std::shared_ptr<const IExpr> expr);
+  static TypedExprPtr inferTypes(
+      const std::shared_ptr<const IExpr>& expr,
+      const TypePtr& input,
+      const std::vector<TypePtr>& lambdaInputTypes,
+      memory::MemoryPool* pool);
+
+  static TypedExprPtr resolveLambdaExpr(
+      const std::shared_ptr<const core::LambdaExpr>& lambdaExpr,
+      const TypePtr& inputRow,
+      const std::vector<TypePtr>& lambdaInputTypes,
+      memory::MemoryPool* pool);
+
+  static TypedExprPtr tryResolveCallWithLambdas(
+      const std::shared_ptr<const CallExpr>& expr,
+      const TypePtr& input,
+      memory::MemoryPool* pool);
+
   static TypeResolverHook resolverHook_;
-  static std::
-      unordered_map<std::string, std::shared_ptr<core::LambdaTypedExpr>>&
-      lambdaRegistry();
 };
 
 class InputExpr : public core::IExpr {


### PR DESCRIPTION
Allow for writing tests to evaluate lambda functions: 

`evaluate("filter(array_val, x -> (x > long_val))", data);`

Depends on #2652 and #2655