### PR TITLE
Fix greatest/least returning wrong results given dirty result vector

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -52,8 +52,6 @@ int main(int argc, char** argv) {
       // cardinality passing a VARBINARY (since HLL's implementation uses an
       // alias to VARBINARY).
       "cardinality",
-      "greatest",
-      "least",
       "neq"};
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(FLAGS_only, initialSeed, skipFunctions);

--- a/velox/functions/prestosql/GreatestLeast.cpp
+++ b/velox/functions/prestosql/GreatestLeast.cpp
@@ -68,6 +68,7 @@ class ExtremeValueFunction : public exec::VectorFunction {
       exec::EvalCtx& context,
       VectorPtr& result) const {
     context.ensureWritable(rows, outputType, result);
+    result->clearAllNulls();
     BufferPtr resultValues =
         result->as<FlatVector<T>>()->mutableValues(rows.end());
     T* __restrict rawResult = resultValues->asMutable<T>();


### PR DESCRIPTION
Summary:
GreatestLeast does not clean up nulls in result vector before writing values to
it. If the result vector passed in is a dirty vector with nulls set, these
nulls will not be cleaned up before writing actual values. This will result in
additional null values returned by GreatestLeast.

Reviewed By: mbasmanova

Differential Revision: D39868422

