### PR TITLE
Fix memory leak by explicit calling on plan frament dtor in task

### DIFF
--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -67,7 +67,7 @@ template <typename Exception, typename StringType>
       "BUG: we should not pass std::string by value to veloxCheckFail");
   LOG(ERROR) << "Line: " << args.file << ":" << args.line
              << ", Function:" << args.function
-             << ", Expression: " << args.expression << s
+             << ", Expression: " << args.expression << " " << s
              << ", Source: " << args.errorSource
              << ", ErrorCode: " << args.errorCode;
 

--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -141,8 +141,6 @@ void MemoryUsageTracker::incrementUsage(UsageType type, int64_t size) {
                       .fetch_add(size, std::memory_order_relaxed) +
       size;
 
-  usage(cumulativeBytes_, type) += size;
-
   // We track the peak usage of total memory independent of user and
   // system memory since freed user memory can be reallocated as system
   // memory and vice versa.
@@ -166,6 +164,7 @@ void MemoryUsageTracker::incrementUsage(UsageType type, int64_t size) {
       VELOX_MEM_CAP_EXCEEDED(errorMessage);
     }
   }
+  usage(cumulativeBytes_, type) += size;
   maySetMax(type, newUsage);
   maySetMax(UsageType::kTotalMem, totalBytes);
   checkNonNegativeSizes("after update");

--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -200,7 +200,7 @@ class MemoryUsageTracker
   }
 
   int64_t getCumulativeBytes() const {
-    return total(cumulativeBytes_);
+    return user(cumulativeBytes_) + system(cumulativeBytes_);
   }
 
   // Returns the total size including unused reservation.
@@ -256,7 +256,7 @@ class MemoryUsageTracker
  protected:
   static constexpr int64_t kMB = 1 << 20;
 
-  explicit MemoryUsageTracker(
+  MemoryUsageTracker(
       const std::shared_ptr<MemoryUsageTracker>& parent,
       UsageType type,
       const MemoryUsageConfig& config)

--- a/velox/common/memory/tests/MemoryUsageTrackerTest.cpp
+++ b/velox/common/memory/tests/MemoryUsageTrackerTest.cpp
@@ -48,32 +48,43 @@ TEST(MemoryUsageTrackerTest, update) {
   auto child1 = parent->addChild();
   auto child2 = parent->addChild();
 
-  EXPECT_THROW(child1->reserve(2 * kMaxSize), VeloxRuntimeError);
+  ASSERT_THROW(child1->reserve(2 * kMaxSize), VeloxRuntimeError);
 
-  EXPECT_EQ(0, parent->getCurrentTotalBytes());
+  ASSERT_EQ(0, parent->getCurrentTotalBytes());
+  ASSERT_EQ(0, parent->getCumulativeBytes());
   child1->update(1000);
-  EXPECT_EQ(kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(kMB - 1000, child1->getAvailableReservation());
+  ASSERT_EQ(kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(kMB, parent->getCumulativeBytes());
+  ASSERT_EQ(kMB - 1000, child1->getAvailableReservation());
   child1->update(1000);
-  EXPECT_EQ(kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(kMB, parent->getCumulativeBytes());
   child1->update(kMB);
-  EXPECT_EQ(2 * kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(2 * kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(2 * kMB, parent->getCumulativeBytes());
+
   child1->update(100 * kMB);
   // Larger sizes round up to next 8MB.
-  EXPECT_EQ(104 * kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(104 * kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
   child1->update(-kMB);
   // 1MB less does not decrease the reservation.
-  EXPECT_EQ(104 * kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(104 * kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
 
   child1->update(-7 * kMB);
-  EXPECT_EQ(96 * kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(96 * kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
   child1->update(-92 * kMB);
-  EXPECT_EQ(2 * kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(2 * kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
   child1->update(-kMB);
-  EXPECT_EQ(kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(kMB, parent->getCurrentTotalBytes());
+  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
 
   child1->update(-2000);
-  EXPECT_EQ(0, parent->getCurrentTotalBytes());
+  ASSERT_EQ(0, parent->getCurrentTotalBytes());
+  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
 }
 
 TEST(MemoryUsageTrackerTest, reserve) {

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -191,13 +191,13 @@ class Writer : public WriterBase {
       const std::shared_ptr<velox::memory::MemoryUsageTracker>& tracker) {
     getContext()
         .getMemoryPool(velox::dwrf::MemoryUsageCategory::DICTIONARY)
-        .setMemoryUsageTracker(tracker);
+        .setMemoryUsageTracker(tracker->addChild());
     getContext()
         .getMemoryPool(velox::dwrf::MemoryUsageCategory::GENERAL)
-        .setMemoryUsageTracker(tracker);
+        .setMemoryUsageTracker(tracker->addChild());
     getContext()
         .getMemoryPool(velox::dwrf::MemoryUsageCategory::OUTPUT_STREAM)
-        .setMemoryUsageTracker(tracker);
+        .setMemoryUsageTracker(tracker->addChild());
   }
 
  protected:

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -171,6 +171,10 @@ Task::~Task() {
   } catch (const std::exception& e) {
     LOG(WARNING) << "Caught exception in ~Task(): " << e.what();
   }
+  // NOTE: this is a hack to enforce destruction on 'planFragment_'. We found in
+  // some case the task dtor doesn't call 'planFragment_' dtor which cause the
+  // memory leak of the vectors held by the plan node such as Value node.
+  planFragment_.planNode.reset();
 }
 
 velox::memory::MemoryPool* FOLLY_NONNULL

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -86,6 +86,15 @@ class DriverTest : public OperatorTestBase {
   }
 
   void TearDown() override {
+    for (auto& task : tasks_) {
+      if (task != nullptr) {
+        waitForTaskCompletion(task.get(), 1'000'000);
+      }
+    }
+    // NOTE: destroy the tasks first to release all the allocated memory held
+    // by the plan nodes (Values) in tasks.
+    tasks_.clear();
+
     if (wakeupInitialized_) {
       wakeupCancelled_ = true;
       wakeupThread_.join();
@@ -347,8 +356,8 @@ TEST_F(DriverTest, cancel) {
       rowType_,
       "m1 % 10 > 0",
       "m1 % 3 + m2 % 5 + m3 % 7 + m4 % 11 + m5 % 13 + m6 % 17 + m7 % 19",
-      100,
-      100'000);
+      1'000,
+      1'000);
   params.maxDrivers = 10;
   int32_t numRead = 0;
   try {
@@ -374,8 +383,8 @@ TEST_F(DriverTest, terminate) {
       rowType_,
       "m1 % 10 > 0",
       "m1 % 3 + m2 % 5 + m3 % 7 + m4 % 11 + m5 % 13 + m6 % 17 + m7 % 19",
-      100,
-      100'000);
+      1'000,
+      1'000);
   params.maxDrivers = 10;
   int32_t numRead = 0;
   try {
@@ -434,8 +443,8 @@ TEST_F(DriverTest, pause) {
       rowType_,
       "m1 % 10 > 0",
       "m1 % 3 + m2 % 5 + m3 % 7 + m4 % 11 + m5 % 13 + m6 % 17 + m7 % 19",
-      100,
-      10'000,
+      1'000,
+      1'000,
       [](int64_t num) { return num % 10 > 0; },
       &hits);
   params.maxDrivers = 10;

--- a/velox/vector/tests/utils/VectorTestBase.cpp
+++ b/velox/vector/tests/utils/VectorTestBase.cpp
@@ -27,6 +27,24 @@ BufferPtr makeIndicesInReverse(vector_size_t size, memory::MemoryPool* pool) {
   return indices;
 }
 
+VectorTestBase::~VectorTestBase() {
+  auto tracker = pool_->getMemoryUsageTracker();
+  if (tracker == nullptr) {
+    return;
+  }
+  // Wait for current user bytes count dropping to zero as there might be async
+  // event still running at the background like the last task reference dropped
+  // at the background.
+  const uint64_t kMaxWaitUs = 3'000'000;
+  while (tracker->getCurrentUserBytes() != 0) {
+    const uint64_t kWaitIntervalUs = 100'000;
+    LOG(WARNING) << "Memory pool has " << tracker->getCurrentUserBytes()
+                 << " current user bytes, wait " << kWaitIntervalUs
+                 << " us for the pending usage to be released";
+    std::this_thread::sleep_for(std::chrono::microseconds(kWaitIntervalUs));
+  }
+}
+
 // static
 VectorPtr VectorTestBase::wrapInDictionary(
     BufferPtr indices,

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -37,6 +37,8 @@ class VectorTestBase {
     pool_->setMemoryUsageTracker(memory::MemoryUsageTracker::create());
   }
 
+  ~VectorTestBase();
+
   template <typename T>
   using EvalType = typename CppToType<T>::NativeType;
 


### PR DESCRIPTION
- In some edge case, task destruction doesn't call planFragment_ dtor
   which will hold the vectors in plan node such as Values. The latter
   can cause memory leak which can be detected by the memory tracker.
   The subclass member destruction should be called auto by compiler
   generated code so we don't know in that case it is not invoked.
   This PR fixes the problem by explicitly call planFragment_ dtor, and
   verified the fix with ApproxDistinctTest.groupByIntegers test.

- Fix the memory leak in DriverTest and Meta internal test cases by adding
   a up to 3 seconds wait in VectorTestBase dtor to wait for any pending
   references to drop.

- Fix memory tracker settings in dwrf writer which allows the memory
   memory leak check added by this PR.

- Fix cumulative allocation bytes counting with unit test covered

- Also reduce DriverTest execution time from >1min down to 40 seconds
  by adjusting the data size.
 
- Also include memory leak check PR#2606 from @mbasmanova 