### PR TITLE
Simplify LocalPartitionNode

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -727,8 +727,7 @@ using PartitionFunctionFactory =
 
 /// Partitions data using specified partition function. The number of partitions
 /// is determined by the parallelism of the upstream pipeline. Can be used to
-/// gather data from multiple sources. The order of columns in the output may be
-/// different from input.
+/// gather data from multiple sources.
 class LocalPartitionNode : public PlanNode {
  public:
   enum class Type {
@@ -742,35 +741,35 @@ class LocalPartitionNode : public PlanNode {
       const PlanNodeId& id,
       Type type,
       PartitionFunctionFactory partitionFunctionFactory,
-      RowTypePtr outputType,
-      std::vector<PlanNodePtr> sources,
-      RowTypePtr inputTypeFromSource)
+      std::vector<PlanNodePtr> sources)
       : PlanNode(id),
         type_{type},
         sources_{std::move(sources)},
-        partitionFunctionFactory_{std::move(partitionFunctionFactory)},
-        outputType_{std::move(outputType)},
-        inputTypeFromSource_{std::move(inputTypeFromSource)} {
+        partitionFunctionFactory_{std::move(partitionFunctionFactory)} {
     VELOX_CHECK_GT(
         sources_.size(),
         0,
         "Local repartitioning node requires at least one source");
+
+    for (auto i = 1; i < sources_.size(); ++i) {
+      VELOX_CHECK(
+          *sources_[i]->outputType() == *sources_[0]->outputType(),
+          "All sources of the LocalPartitionedNode must have the same output type: {} vs. {}.",
+          sources_[i]->outputType()->toString(),
+          sources_[0]->outputType()->toString());
+    }
   }
 
   static std::shared_ptr<LocalPartitionNode> gather(
       const PlanNodeId& id,
-      RowTypePtr outputType,
-      std::vector<PlanNodePtr> sources,
-      RowTypePtr inputTypeFromSource) {
+      std::vector<PlanNodePtr> sources) {
     return std::make_shared<LocalPartitionNode>(
         id,
         Type::kGather,
         [](auto /*numPartitions*/) -> std::unique_ptr<PartitionFunction> {
           VELOX_UNREACHABLE();
         },
-        std::move(outputType),
-        std::move(sources),
-        std::move(inputTypeFromSource));
+        std::move(sources));
   }
 
   Type type() const {
@@ -778,15 +777,11 @@ class LocalPartitionNode : public PlanNode {
   }
 
   const RowTypePtr& outputType() const override {
-    return outputType_;
+    return sources_[0]->outputType();
   }
 
   const std::vector<PlanNodePtr>& sources() const override {
     return sources_;
-  }
-
-  const RowTypePtr& inputTypeFromSource() const {
-    return inputTypeFromSource_;
   }
 
   const PartitionFunctionFactory& partitionFunctionFactory() const {
@@ -803,13 +798,6 @@ class LocalPartitionNode : public PlanNode {
   const Type type_;
   const std::vector<PlanNodePtr> sources_;
   const PartitionFunctionFactory partitionFunctionFactory_;
-  const RowTypePtr outputType_;
-  /// Input layout from source, describing how data should be fed to our node.
-  /// For all sources the layout should be the same, so we store only one (we
-  /// use the 1st source for that).
-  /// This layout and the output layout for the 1st source would be used to
-  /// created the column mapping in the operator.
-  const RowTypePtr inputTypeFromSource_;
 };
 
 class PartitionedOutputNode : public PlanNode {

--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -191,16 +191,9 @@ class LocalPartition : public Operator {
   }
 
  private:
-  BlockingReason
-  enqueue(int32_t partition, RowVectorPtr data, ContinueFuture* future);
-
   const std::vector<std::shared_ptr<LocalExchangeQueue>> queues_;
   const size_t numPartitions_;
   std::unique_ptr<core::PartitionFunction> partitionFunction_;
-  /// Mapping of sources' output columns to our output columns.
-  /// One for all sources.
-  /// Empty if column order in the output is exactly the same as in input.
-  std::vector<column_index_t> sourceOutputChannels_;
 
   uint32_t numBlockedPartitions_{0};
   std::vector<BlockingReason> blockingReasons_;

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -548,40 +548,25 @@ class PlanBuilder {
   /// @param keys Partitioning keys. May be empty, in which case all input will
   /// be places in a single partition.
   /// @param sources One or more plan nodes that produce input data.
-  /// @param outputLayout Optional output layout in case it is different then
-  /// the input. Output columns may appear in different order from the input,
-  /// some input columns may be missing in the output, some columns may be
-  /// duplicated in the output. Supports "col AS alias" syntax to change the
-  /// names for the input columns.
   PlanBuilder& localPartition(
       const std::vector<std::string>& keys,
-      const std::vector<core::PlanNodePtr>& sources,
-      const std::vector<std::string>& outputLayout = {});
+      const std::vector<core::PlanNodePtr>& sources);
 
   /// A convenience method to add a LocalPartitionNode with a single source (the
   /// current plan node).
-  PlanBuilder& localPartition(
-      const std::vector<std::string>& keys,
-      const std::vector<std::string>& outputLayout = {});
+  PlanBuilder& localPartition(const std::vector<std::string>& keys);
 
   /// Add a LocalPartitionNode to partition the input using row-wise
   /// round-robin. Number of partitions is determined at runtime based on
   /// parallelism of the downstream pipeline.
   ///
   /// @param sources One or more plan nodes that produce input data.
-  /// @param outputLayout Optional output layout in case it is different then
-  /// the input. Output columns may appear in different order from the input,
-  /// some input columns may be missing in the output, some columns may be
-  /// duplicated in the output. Supports "col AS alias" syntax to change the
-  /// names for the input columns.
   PlanBuilder& localPartitionRoundRobin(
-      const std::vector<core::PlanNodePtr>& sources,
-      const std::vector<std::string>& outputLayout = {});
+      const std::vector<core::PlanNodePtr>& sources);
 
   /// A convenience method to add a LocalPartitionNode with a single source (the
   /// current plan node).
-  PlanBuilder& localPartitionRoundRobin(
-      const std::vector<std::string>& outputLayout = {});
+  PlanBuilder& localPartitionRoundRobin();
 
   /// Add a HashJoinNode to join two inputs using one or more join keys and an
   /// optional filter.


### PR DESCRIPTION
Simplify LocalPartitionNode by requiring that all source nodes have the same
output type and using that as the output of the LocalPartitionNode itself.