### PR TITLE
Fix memory tracking when setting memory usage tracker

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -738,8 +738,12 @@ int64_t MemoryPoolImpl<Allocator, ALIGNMENT>::getMaxBytes() const {
 template <typename Allocator, uint16_t ALIGNMENT>
 void MemoryPoolImpl<Allocator, ALIGNMENT>::setMemoryUsageTracker(
     const std::shared_ptr<MemoryUsageTracker>& tracker) {
+  const auto currentBytes = getCurrentBytes();
+  if (memoryUsageTracker_) {
+    memoryUsageTracker_->update(-currentBytes);
+  }
   memoryUsageTracker_ = tracker;
-  memoryUsageTracker_->update(getCurrentBytes());
+  memoryUsageTracker_->update(currentBytes);
 }
 
 template <typename Allocator, uint16_t ALIGNMENT>


### PR DESCRIPTION
Summary:
Addresses 2 issues:
* repeatedly setting the same tracker to the same pool resulted in overcounting.
* when switching tracker, the accounting should be transferred.

Differential Revision: D39883053

