### PR TITLE
Improve VectorFuzzer string speed and add benchmark

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -61,3 +61,7 @@ target_link_libraries(velox_benchmark_basic_preproc ${velox_benchmark_deps}
 add_executable(velox_like_functions_benchmark LikeFunctionsBenchmark.cpp)
 target_link_libraries(velox_like_functions_benchmark ${velox_benchmark_deps}
                       velox_functions_lib velox_tpch_gen velox_vector_test_lib)
+
+add_executable(velox_benchmark_basic_vector_fuzzer VectorFuzzer.cpp)
+target_link_libraries(velox_benchmark_basic_vector_fuzzer
+                      ${velox_benchmark_deps} velox_vector_test_lib)

--- a/velox/benchmarks/basic/VectorFuzzer.cpp
+++ b/velox/benchmarks/basic/VectorFuzzer.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <gflags/gflags.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+namespace {
+
+using namespace facebook::velox;
+
+std::unique_ptr<memory::MemoryPool> pool{memory::getDefaultScopedMemoryPool()};
+
+VectorFuzzer::Options getOpts(size_t n, double nullRatio = 0) {
+  VectorFuzzer::Options opts;
+  opts.vectorSize = n;
+  opts.nullRatio = nullRatio;
+  return opts;
+}
+
+BENCHMARK_MULTI(flatInteger, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(BIGINT()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatIntegerHalfNull, n) {
+  VectorFuzzer fuzzer(getOpts(n, 0.5), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(BIGINT()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatDouble, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(DOUBLE()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatBool, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(BOOLEAN()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatVarcharAscii, n) {
+  auto opts = getOpts(n);
+  opts.charEncodings = {UTF8CharList::ASCII};
+
+  VectorFuzzer fuzzer(opts, pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(VARCHAR()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatVarcharUtf8, n) {
+  auto opts = getOpts(n);
+  opts.charEncodings = {UTF8CharList::EXTENDED_UNICODE};
+
+  VectorFuzzer fuzzer(opts, pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzFlat(VARCHAR()));
+  return n;
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_RELATIVE_MULTI(constantInteger, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzConstant(BIGINT()));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(dictionaryInteger, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  folly::doNotOptimizeAway(fuzzer.fuzzDictionary(fuzzer.fuzzFlat(BIGINT())));
+  return n;
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_RELATIVE_MULTI(flatArray, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  const size_t elementsSize = n * fuzzer.getOptions().containerLength;
+  folly::doNotOptimizeAway(
+      fuzzer.fuzzArray(fuzzer.fuzzFlat(BIGINT(), elementsSize), n));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatMap, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  const size_t elementsSize = n * fuzzer.getOptions().containerLength;
+  folly::doNotOptimizeAway(fuzzer.fuzzMap(
+      fuzzer.fuzzFlat(BIGINT(), elementsSize),
+      fuzzer.fuzzFlat(BIGINT(), elementsSize),
+      n));
+  return n;
+}
+
+BENCHMARK_RELATIVE_MULTI(flatMapArrayNested, n) {
+  VectorFuzzer fuzzer(getOpts(n), pool.get(), FLAGS_fuzzer_seed);
+  const size_t elementsSize = n * fuzzer.getOptions().containerLength;
+
+  folly::doNotOptimizeAway(fuzzer.fuzzMap(
+      fuzzer.fuzzFlat(BIGINT(), elementsSize),
+      fuzzer.fuzzArray(
+          fuzzer.fuzzFlat(BIGINT(), elementsSize * 10), elementsSize),
+      n));
+  return n;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -31,10 +31,10 @@ namespace facebook::velox {
 using FuzzerGenerator = std::mt19937;
 
 enum UTF8CharList {
-  ASCII, /* Ascii character set.*/
-  UNICODE_CASE_SENSITIVE, /* Unicode scripts that support case.*/
-  EXTENDED_UNICODE, /* Extended Unicode: Arabic, Devanagiri etc*/
-  MATHEMATICAL_SYMBOLS /* Mathematical Symbols.*/
+  ASCII = 0, // Ascii character set.
+  UNICODE_CASE_SENSITIVE = 1, // Unicode scripts that support case.
+  EXTENDED_UNICODE = 2, // Extended Unicode: Arabic, Devanagiri etc
+  MATHEMATICAL_SYMBOLS = 3 // Mathematical Symbols.
 };
 
 class VectorFuzzer {
@@ -90,6 +90,10 @@ class VectorFuzzer {
 
   void setOptions(VectorFuzzer::Options options) {
     opts_ = options;
+  }
+
+  const VectorFuzzer::Options& getOptions() {
+    return opts_;
   }
 
   // Returns a "fuzzed" vector, containing randomized data, nulls, and indices


### PR DESCRIPTION
Summary:
Even though VectorFuzzer is only used for synthetic data generation
for tests, we don't want it to be be too slow. I observed VectorFuzzer timed
out unit tests in circleCI that generated larger vectors of strings.
.
This diff/PR makes ascii string generation 1000x faster than before, and UTF8
generation about 4x.
.
Also, adding a micro-benchmark to ensure we don't regress performance on it.
.
Benchmark results on a devserver:
```
============================================================================
velox/benchmarks/basic/VectorFuzzer.cpp     relative  time/iter   iters/s
============================================================================
flatInteger                                                13.74ns    72.77M
flatIntegerHalfNull                             53.728%    25.58ns    39.10M
flatDouble                                      78.501%    17.51ns    57.12M
flatBool                                        55.386%    24.81ns    40.30M
flatVarcharAscii                                2.6108%   526.36ns     1.90M
flatVarcharUtf8                                0.95306%     1.44us   693.53K
----------------------------------------------------------------------------
constantInteger                                    inf%     0.00fs  Infinity
dictionaryInteger                               38.922%    35.31ns    28.32M
----------------------------------------------------------------------------
flatArray                                       10.068%   136.49ns     7.33M
flatMap                                         5.1865%   264.96ns     3.77M
flatMapArrayNested                              0.8455%     1.63us   615.26K
```

Differential Revision: D39898583

