### PR TITLE
Fix wrapping of peeled encodings in presense of default nulls

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1383,7 +1383,7 @@ bool Expr::applyFunctionWithPeeling(
   VectorPtr peeledResult;
   applyFunction(*newRows, context, peeledResult);
   VectorPtr wrappedResult =
-      context.applyWrapToPeeledResult(this->type(), peeledResult, rows);
+      context.applyWrapToPeeledResult(this->type(), peeledResult, applyRows);
   context.moveOrCopyResult(wrappedResult, rows, result);
   return true;
 }


### PR DESCRIPTION
Summary:
This diff fixes a bug found by fuzzer: https://github.com/facebookincubator/velox/issues/2668.

This test evaluates an expression "distinct_from(to_utf8('xB60ChtE03'),to_utf8(c0))".
The content in the c0 is [null, "b", null, "a", null, null].
Expr::applyFunctionWithPeeling() deselects nulls and then peels off the
dictionary encoding before evaluating the to_utf8 function. As the result,
to_utf8 is evaluated only one row 1 and row 3, and returns a result vector
of length 2. Expr::applyFunctionWithPeeling() then wraps the result with
the dictionary encoding. However, it incorrectly does the wrapping with
all rows (i.e., rows 1--6), including row 2 and row 5 that points to index 2.
Since there is no index 2 in the result of to_utf8, an exception throws.

Differential Revision: D39906600

