### PR TITLE
Fix resizing bug in DecodedVector wrapping a ConstantVector

### DIFF
--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -496,7 +496,11 @@ VectorPtr DecodedVector::wrap(
     VectorPtr data,
     const BaseVector& wrapper,
     const SelectivityVector& rows) {
-  if (data->isConstantEncoding()) {
+  // Return `data` as is if it is constant encoded and the vector size matches
+  // exactly with the selection size. Otherwise, the constant vector will need
+  // to be resized to match it. The resizing will be done in the wrapping code
+  // later.
+  if (data->isConstantEncoding() && rows.countSelected() == data->size()) {
     return data;
   }
   if (wrapper.isConstantEncoding()) {


### PR DESCRIPTION
Summary:
The wrapping code in DecodedVector currently short circuits when the input vector that is being wrapped is constant encoded. This condition in itself is insufficient because the size of the input vector is being ignored and returned as is, irrespective of the size of the selection.

In this change, I updated the short circuit condition to reflect the size check as the resizing of constant vector logic already exists in dictionary wrapping logic. Added a test to show this condition and validated that it fails on size check before the fix.

Differential Revision: D39917906

