### PR TITLE
Fix DecodedVector::dictionaryWrapping()

### DIFF
--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -487,7 +487,11 @@ DecodedVector::DictionaryWrapping DecodedVector::dictionaryWrapping(
   } else {
     // Make a copy of the indices and nulls buffers.
     BufferPtr indices = copyIndicesBuffer(indices_, rows.end(), wrapper.pool());
-    BufferPtr nulls = copyNullsBuffer(nulls_, rows.end(), wrapper.pool());
+    // Only copy nulls if we have nulls coming from one of the wrappers, don't
+    // do it if nulls are missing or from the base vector.
+    BufferPtr nulls = hasExtraNulls_
+        ? copyNullsBuffer(nulls_, rows.end(), wrapper.pool())
+        : nullptr;
     return {std::move(indices), std::move(nulls)};
   }
 }


### PR DESCRIPTION
Summary:
DecodedVector::dictionaryWrapping() was returning nulls_ in all cases when there was more than one wrapper.
After that the nulls vector was used in forming a new wrapper areound the base vector which lead to nulls being incorrectly applied and wrong results.
In case when all the wrappers we have are without nulls (hasExtraNulls_ is false) we should return no nulls byffer (nullptr).
This fix does exactly that.

Differential Revision: D39918799

