### PR TITLE
Remove duplicated code for decimal types

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1341,12 +1341,6 @@ std::shared_ptr<const OpaqueType> OPAQUE() {
     } else if ((typeKind) == ::facebook::velox::TypeKind::OPAQUE) {         \
       return CLASS_NAME<::facebook::velox::TypeKind::OPAQUE>::METHOD_NAME(  \
           __VA_ARGS__);                                                     \
-    } else if ((typeKind) == ::facebook::velox::TypeKind::SHORT_DECIMAL) {  \
-      return CLASS_NAME<::facebook::velox::TypeKind::SHORT_DECIMAL>::       \
-          METHOD_NAME(__VA_ARGS__);                                         \
-    } else if ((typeKind) == ::facebook::velox::TypeKind::LONG_DECIMAL) {   \
-      return CLASS_NAME<::facebook::velox::TypeKind::LONG_DECIMAL>::        \
-          METHOD_NAME(__VA_ARGS__);                                         \
     } else {                                                                \
       return VELOX_DYNAMIC_TYPE_DISPATCH_IMPL(                              \
           CLASS_NAME, ::METHOD_NAME, typeKind, __VA_ARGS__);                \


### PR DESCRIPTION
`VELOX_DYNAMIC_TYPE_DISPATCH_IMPL` macro already supports decimal types in https://github.com/facebookincubator/velox/pull/2307, so there is also no need to specialize decimal types in
`VELOX_DYNAMIC_TYPE_DISPATCH_METHOD_ALL` macro.