### PR TITLE
Rename makeVectorWithNullArrays to makeNullableArrayVector

### DIFF
--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -478,7 +478,7 @@ TEST_F(ArrayWriterTest, copyFromEmptyArray) {
   vectorWriter->commit();
   vectorWriter->finish();
 
-  assertEqualVectors(result, makeNullableArrayVector<int64_t>({{}}));
+  assertEqualVectors(result, makeArrayVector<int64_t>({{}}));
 }
 
 TEST_F(ArrayWriterTest, copyFromIntArray) {

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -744,9 +744,9 @@ TEST_F(CastExprTest, castInTry) {
   // wrapped in dictinary encoding. The row of ["2a"] should trigger an error
   // during casting and the try expression should turn this error into a null at
   // this row.
-  auto input = makeRowVector({makeVectorWithNullArrays<StringView>(
+  auto input = makeRowVector({makeNullableArrayVector<StringView>(
       {{{"1"_sv}}, {{"2a"_sv}}, std::nullopt, std::nullopt})});
-  auto expected = makeVectorWithNullArrays<int64_t>(
+  auto expected = makeNullableArrayVector<int64_t>(
       {{{1}}, std::nullopt, std::nullopt, std::nullopt});
 
   evaluateAndVerifyCastInTryDictEncoding(

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2227,7 +2227,7 @@ TEST_F(ExprTest, exceptionContext) {
 /// Verify the output of ConstantExpr::toString().
 TEST_F(ExprTest, constantToString) {
   auto arrayVector =
-      makeNullableArrayVector<float>({{{1.2, 3.4, std::nullopt, 5.6}}});
+      makeNullableArrayVector<float>({{1.2, 3.4, std::nullopt, 5.6}});
 
   exec::ExprSet exprSet(
       {std::make_shared<core::ConstantTypedExpr>(23),

--- a/velox/expression/tests/RowWriterTest.cpp
+++ b/velox/expression/tests/RowWriterTest.cpp
@@ -456,10 +456,14 @@ TEST_F(RowWriterTest, copyFromRowOfArrays) {
 
   assertEqualVectors(
       result,
-      makeRowVector(
-          {makeNullableArrayVector<int64_t>({expected1}),
-           makeNullableArrayVector<double>({expected2}),
-           makeNullableArrayVector<bool>({expected3})}));
+      makeRowVector({
+          makeNullableArrayVector(
+              std::vector<std::vector<std::optional<int64_t>>>{expected1}),
+          makeNullableArrayVector(
+              std::vector<std::vector<std::optional<double>>>{expected2}),
+          makeNullableArrayVector(
+              std::vector<std::vector<std::optional<bool>>>{expected3}),
+      }));
 }
 
 TEST_F(RowWriterTest, copyFromArrayOfRow) {

--- a/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
+++ b/velox/expression/tests/SimpleFunctionCallNullFreeTest.cpp
@@ -48,7 +48,7 @@ TEST_F(SimpleFunctionCallNullFreeTest, defaultContainsNullsBehavior) {
       {"default_contains_nulls_behavior"});
 
   // Make a vector with some null arrays, and some arrays containing nulls.
-  auto arrayVector = makeVectorWithNullArrays<int32_t>(
+  auto arrayVector = makeNullableArrayVector<int32_t>(
       {std::nullopt, {{1, std::nullopt}}, {{std::nullopt, 2}}, {{1, 2, 3}}});
 
   // Check that default contains nulls behavior functions don't get called on a
@@ -104,11 +104,11 @@ TEST_F(SimpleFunctionCallNullFreeTest, nonDefaultBehavior) {
       {"non_default_behavior"});
 
   // Make a vector with a NULL.
-  auto arrayVectorWithNull = makeVectorWithNullArrays<int32_t>(
+  auto arrayVectorWithNull = makeNullableArrayVector<int32_t>(
       {std::nullopt, {{1, 2}}, {{3, 2}}, {{2, 2, 3}}});
   // Make a vector with an array that contains NULL.
-  auto arrayVectorContainsNull = makeVectorWithNullArrays<int32_t>(
-      {{{4, std::nullopt}}, {{1, 2}}, {{3, 2}}, {{2, 2, 3}}});
+  auto arrayVectorContainsNull = makeNullableArrayVector<int32_t>(
+      {{4, std::nullopt}, {1, 2}, {3, 2}, {2, 2, 3}});
   // Make a vector that's NULL-free.
   auto arrayVectorNullFree =
       makeArrayVector<int32_t>({{4, 5}, {1, 2}, {3, 2}, {2, 2, 3}});

--- a/velox/expression/tests/SimpleFunctionInitTest.cpp
+++ b/velox/expression/tests/SimpleFunctionInitTest.cpp
@@ -96,7 +96,8 @@ TEST_F(SimpleFunctionInitTest, initializationArray) {
         args.push_back(
             std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"));
 
-        auto rhsArrayVector = makeNullableArrayVector<int32_t>({second});
+        auto rhsArrayVector = makeNullableArrayVector(
+            std::vector<std::vector<std::optional<int32_t>>>{second});
         args.push_back(std::make_shared<core::ConstantTypedExpr>(
             BaseVector::wrapInConstant(1, 0, rhsArrayVector)));
         exec::ExprSet expr(
@@ -109,7 +110,7 @@ TEST_F(SimpleFunctionInitTest, initializationArray) {
           expr.eval(SelectivityVector(1), evalCtx, results);
           assertEqualVectors(results[0], expectedVector);
         };
-        auto expectedResult = makeVectorWithNullArrays<int32_t>(expected);
+        auto expectedResult = makeNullableArrayVector<int32_t>(expected);
         eval(
             makeRowVector({makeNullableFlatVector(std::vector{first})}),
             expectedResult);

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -161,24 +161,25 @@ TEST_F(ChecksumAggregateTest, varchars) {
 }
 
 TEST_F(ChecksumAggregateTest, arrays) {
-  auto arrayVector = makeVectorWithNullArrays<int64_t>({
-      {{1, 2}},
-      {{3, 4}},
+  auto arrayVector = makeArrayVector<int64_t>({
+      {1, 2},
+      {3, 4},
   });
-
   assertChecksum(arrayVector, "/jjpuD6xkXs=");
 
-  arrayVector = makeVectorWithNullArrays<int64_t>({{{12, std::nullopt}}});
+  arrayVector = makeNullableArrayVector<int64_t>({{12, std::nullopt}});
   assertChecksum(arrayVector, "sr3HNuzc+7Y=");
-  arrayVector = makeVectorWithNullArrays<int64_t>({{{1, 2}}, std::nullopt});
+
+  arrayVector = makeNullableArrayVector<int64_t>({{{1, 2}}, std::nullopt});
   assertChecksum(arrayVector, "Nlzernkj88A=");
+
   arrayVector =
-      makeVectorWithNullArrays<int64_t>({{{1, 2}}, std::nullopt, {{}}});
+      makeNullableArrayVector<int64_t>({{{1, 2}}, std::nullopt, {{}}});
   assertChecksum(arrayVector, "Nlzernkj88A=");
 
   // Array of arrays.
-  auto baseArrayVector = makeVectorWithNullArrays<int64_t>(
-      {{{1, 2}}, {{3, 4}}, {{4, std::nullopt}}, {{}}});
+  auto baseArrayVector =
+      makeNullableArrayVector<int64_t>({{1, 2}, {3, 4}, {4, std::nullopt}, {}});
   auto arrayOfArrayVector = makeArrayVector({0, 2}, baseArrayVector);
   assertChecksum(arrayOfArrayVector, "Wp67EOfWZPA=");
 }

--- a/velox/functions/prestosql/tests/ArrayCombinationsTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayCombinationsTest.cpp
@@ -76,12 +76,14 @@ class ArrayCombinationsTest : public FunctionBaseTest {
 
   template <typename T>
   void testError(
-      const std::vector<std::optional<T>>& inputArray,
+      const std::vector<T>& inputArray,
       const int combinationLength,
       const std::string& expectedError) {
-    auto arrayVector = makeNullableArrayVector<T>({inputArray});
+    auto arrayVector = makeArrayVector<T>({
+        inputArray,
+    });
     auto comboLengthVector =
-        makeFlatVector<int32_t>(std::vector<int32_t>({combinationLength}));
+        makeFlatVector(std::vector<int32_t>({combinationLength}));
     VELOX_ASSERT_THROW(
         evaluate<ArrayVector>(
             "combinations(C0, C1)",
@@ -112,11 +114,11 @@ TEST_F(ArrayCombinationsTest, errorCases) {
       {0, 1, 2, 3}, -1, "combination size must not be negative: -1");
   testError<int32_t>({0, 1, 2, 3}, 8, "combination size must not exceed 5: 8");
   testError<int32_t>(
-      std::vector<std::optional<int32_t>>(100001, 1),
+      std::vector<int32_t>(100001, 1),
       3,
       "combinations exceed max size of 100000");
   testError<int32_t>(
-      std::vector<std::optional<int32_t>>(99999, 1),
+      std::vector<int32_t>(99999, 1),
       3,
       "combinations exceed max size of 100000");
 }

--- a/velox/functions/prestosql/tests/ArrayExceptTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayExceptTest.cpp
@@ -175,7 +175,7 @@ TEST_F(ArrayExceptTest, boolArrays) {
 
   testExpr(expected, "array_except(C0, C1)", {array1, array2});
 
-  expected = makeNullableArrayVector<bool>({{}, {}, {}, {}, {}, {}, {}, {}});
+  expected = makeArrayVector<bool>({{}, {}, {}, {}, {}, {}, {}, {}});
   testExpr(expected, "array_except(C1, C0)", {array1, array2});
 }
 
@@ -241,7 +241,7 @@ TEST_F(ArrayExceptTest, longStrArrays) {
       {S("purple is an elegant color")},
   });
   testExpr(expected, "array_except(C0, C1)", {array1, array2});
-  expected = makeNullableArrayVector<StringView>({
+  expected = makeArrayVector<StringView>({
       {},
       {},
       {},

--- a/velox/functions/prestosql/tests/ArrayJoinTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayJoinTest.cpp
@@ -39,9 +39,10 @@ class ArrayJoinTest : public FunctionBaseTest {
       std::vector<std::optional<T>> array,
       const StringView& delimiter,
       const StringView& expected) {
-    auto arrayVector = makeNullableArrayVector<T>({array});
-    auto delimiterVector = makeNullableFlatVector<StringView>({delimiter});
-    auto expectedVector = makeNullableFlatVector<StringView>({expected});
+    auto arrayVector = makeNullableArrayVector(
+        std::vector<std::vector<std::optional<T>>>{array});
+    auto delimiterVector = makeFlatVector<StringView>({delimiter});
+    auto expectedVector = makeFlatVector<StringView>({expected});
     testExpr(
         expectedVector, "array_join(c0, c1)", {arrayVector, delimiterVector});
   }
@@ -52,10 +53,11 @@ class ArrayJoinTest : public FunctionBaseTest {
       const StringView& delimiter,
       const StringView& replacement,
       const StringView& expected) {
-    auto arrayVector = makeNullableArrayVector<T>({array});
-    auto delimiterVector = makeNullableFlatVector<StringView>({delimiter});
-    auto replacementVector = makeNullableFlatVector<StringView>({replacement});
-    auto expectedVector = makeNullableFlatVector<StringView>({expected});
+    auto arrayVector = makeNullableArrayVector(
+        std::vector<std::vector<std::optional<T>>>{array});
+    auto delimiterVector = makeFlatVector<StringView>({delimiter});
+    auto replacementVector = makeFlatVector<StringView>({replacement});
+    auto expectedVector = makeFlatVector<StringView>({expected});
     testExpr(
         expectedVector,
         "array_join(c0, c1, c2)",
@@ -65,65 +67,38 @@ class ArrayJoinTest : public FunctionBaseTest {
 
 TEST_F(ArrayJoinTest, intTest) {
   testArrayJoinNoReplacement<int64_t>(
-      std::vector<std::optional<int64_t>>{1, 2, std::nullopt, 3},
-      ","_sv,
-      "1,2,3"_sv);
+      {1, 2, std::nullopt, 3}, ","_sv, "1,2,3"_sv);
   testArrayJoinNoReplacement<int32_t>(
-      std::vector<std::optional<int32_t>>{1, 2, std::nullopt, 3},
-      ","_sv,
-      "1,2,3"_sv);
+      {1, 2, std::nullopt, 3}, ","_sv, "1,2,3"_sv);
   testArrayJoinNoReplacement<int16_t>(
-      std::vector<std::optional<int16_t>>{1, 2, std::nullopt, 3},
-      ","_sv,
-      "1,2,3"_sv);
+      {1, 2, std::nullopt, 3}, ","_sv, "1,2,3"_sv);
   testArrayJoinNoReplacement<int8_t>(
-      std::vector<std::optional<int8_t>>{1, 2, std::nullopt, 3},
-      ","_sv,
-      "1,2,3"_sv);
-  // Test single element
-  testArrayJoinNoReplacement<int8_t>(
-      std::vector<std::optional<int8_t>>{1}, ","_sv, "1"_sv);
-  // Test empty array
-  testArrayJoinNoReplacement<int8_t>(
-      std::vector<std::optional<int8_t>>{}, ","_sv, ""_sv);
-  testArrayJoinNoReplacement<int8_t>(
-      std::vector<std::optional<int8_t>>{std::nullopt}, ","_sv, ""_sv);
+      {1, 2, std::nullopt, 3}, ","_sv, "1,2,3"_sv);
+  // Test single element.
+  testArrayJoinNoReplacement<int8_t>({1}, ","_sv, "1"_sv);
+  // Test empty array.
+  testArrayJoinNoReplacement<int8_t>({}, ","_sv, ""_sv);
+  testArrayJoinNoReplacement<int8_t>({std::nullopt}, ","_sv, ""_sv);
 
   testArrayJoinReplacement<int64_t>(
-      std::vector<std::optional<int64_t>>{1, 2, std::nullopt, 3},
-      ","_sv,
-      "0"_sv,
-      "1,2,0,3"_sv);
+      {1, 2, std::nullopt, 3}, ","_sv, "0"_sv, "1,2,0,3"_sv);
 }
 
 TEST_F(ArrayJoinTest, varcharTest) {
   testArrayJoinNoReplacement<StringView>(
-      std::vector<std::optional<StringView>>{
-          "a"_sv, "b"_sv, std::nullopt, "c"_sv},
-      "-"_sv,
-      "a-b-c"_sv);
-  testArrayJoinNoReplacement<StringView>(
-      std::vector<std::optional<StringView>>{}, "-"_sv, ""_sv);
+      {"a"_sv, "b"_sv, std::nullopt, "c"_sv}, "-"_sv, "a-b-c"_sv);
+  testArrayJoinNoReplacement<StringView>({}, "-"_sv, ""_sv);
 
   testArrayJoinReplacement<StringView>(
-      std::vector<std::optional<StringView>>{
-          "a"_sv, "b"_sv, std::nullopt, "c"_sv},
-      "-"_sv,
-      "z"_sv,
-      "a-b-z-c"_sv);
+      {"a"_sv, "b"_sv, std::nullopt, "c"_sv}, "-"_sv, "z"_sv, "a-b-z-c"_sv);
 }
 
 TEST_F(ArrayJoinTest, boolTest) {
   testArrayJoinNoReplacement<bool>(
-      std::vector<std::optional<bool>>{true, std::nullopt, false},
-      StringView(","),
-      StringView("true,false"));
+      {true, std::nullopt, false}, ","_sv, "true,false"_sv);
 
   testArrayJoinReplacement<bool>(
-      std::vector<std::optional<bool>>{true, std::nullopt, false},
-      StringView(","),
-      StringView("apple"),
-      StringView("true,apple,false"));
+      {true, std::nullopt, false}, ","_sv, "apple"_sv, "true,apple,false"_sv);
 }
 
 } // namespace

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   ArrayDuplicatesTest.cpp
   ArrayExceptTest.cpp
   ArrayFilterTest.cpp
+  ArrayJoinTest.cpp
   ArrayIntersectTest.cpp
   ArrayMaxTest.cpp
   ArrayMinTest.cpp

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -858,7 +858,7 @@ TEST_F(JsonCastTest, toArray) {
        "[]"_sv,
        "null"_sv},
       JSON());
-  auto expected = makeVectorWithNullArrays<StringView>(
+  auto expected = makeNullableArrayVector<StringView>(
       {{{"red"_sv, "blue"_sv}},
        {{std::nullopt, std::nullopt, "purple"_sv}},
        {{}},
@@ -869,7 +869,7 @@ TEST_F(JsonCastTest, toArray) {
   // Tests array that has null at every row.
   data = makeNullableFlatVector<Json>(
       {"null"_sv, "null"_sv, "null"_sv, "null"_sv, std::nullopt});
-  expected = makeVectorWithNullArrays<int64_t>(
+  expected = makeNullableArrayVector<int64_t>(
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
 
   testCast<ComplexType>(JSON(), ARRAY(BIGINT()), data, expected);
@@ -985,7 +985,7 @@ TEST_F(JsonCastTest, toNested) {
       {R"({"1":[1.1,1.2],"2":[2,2.1]})"_sv, R"({"3":null,"4":[4.1,4.2]})"_sv});
   auto keys =
       makeNullableFlatVector<StringView>({"1"_sv, "2"_sv, "3"_sv, "4"_sv});
-  auto innerArray = makeVectorWithNullArrays<double>(
+  auto innerArray = makeNullableArrayVector<double>(
       {{{1.1, 1.2}}, {{2.0, 2.1}}, std::nullopt, {{4.1, 4.2}}});
 
   auto offsets = AlignedBuffer::allocate<vector_size_t>(2, pool());

--- a/velox/functions/prestosql/tests/ReverseTest.cpp
+++ b/velox/functions/prestosql/tests/ReverseTest.cpp
@@ -93,7 +93,7 @@ TEST_F(ReverseTest, nestedArray) {
   auto createArrayOfArrays =
       [&](std::vector<std::optional<std::vector<std::optional<int32_t>>>>
               data) {
-        auto baseArray = makeVectorWithNullArrays<int32_t>(data);
+        auto baseArray = makeNullableArrayVector<int32_t>(data);
 
         vector_size_t size = data.size() / 2;
         BufferPtr offsets =
@@ -160,9 +160,9 @@ TEST_F(ReverseTest, nullArray) {
   auto reverseNullVec = std::make_optional<std::vector<std::optional<int32_t>>>(
       {std::nullopt, 2, 1});
   auto nullArray =
-      makeVectorWithNullArrays<int32_t>({vecWithNull, std::nullopt});
+      makeNullableArrayVector<int32_t>({vecWithNull, std::nullopt});
   auto reverseNullArray =
-      makeVectorWithNullArrays<int32_t>({reverseNullVec, std::nullopt});
+      makeNullableArrayVector<int32_t>({reverseNullVec, std::nullopt});
 
   testExpr<ArrayVector>(reverseNullArray, nullArray);
 }

--- a/velox/functions/prestosql/tests/ZipTest.cpp
+++ b/velox/functions/prestosql/tests/ZipTest.cpp
@@ -89,14 +89,17 @@ TEST_F(ZipTest, combineInt) {
 
 /// Test if we can zip with vectors containing null and empty Arrays
 TEST_F(ZipTest, nullEmptyArray) {
-  auto O = [](std::vector<std::optional<int32_t>> data) {
-    return std::make_optional(data);
-  };
+  auto firstVector = makeNullableArrayVector<int32_t>({
+      {{1, 1, 1, 1}},
+      {{}},
+      std::nullopt,
+  });
 
-  auto firstVector =
-      makeVectorWithNullArrays<int32_t>({O({1, 1, 1, 1}), O({}), std::nullopt});
-
-  auto secondVector = makeArrayVector<int32_t>({{0, 0, 0}, {4, 4}, {5, 5}});
+  auto secondVector = makeArrayVector<int32_t>({
+      {0, 0, 0},
+      {4, 4},
+      {5, 5},
+  });
 
   auto result = evaluate<ArrayVector>(
       "zip(c0, c1)",

--- a/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
@@ -262,14 +262,14 @@ TEST_F(LastAggregateTest, arrayGroupBy) {
 // Verify global aggregation for ARRAY.
 TEST_F(LastAggregateTest, arrayGlobal) {
   auto vectors = {makeRowVector({
-      makeVectorWithNullArrays<int64_t>(
+      makeNullableArrayVector<int64_t>(
           {std::nullopt, {{1, 2}}, {{3, 4}}, std::nullopt}),
       makeConstant<bool>(true, 4),
       makeConstant<bool>(false, 4),
   })};
 
   auto expectedTrue = {makeRowVector({
-      makeVectorWithNullArrays<int64_t>({{{3, 4}}}),
+      makeArrayVector<int64_t>({{3, 4}}),
   })};
 
   // Verify when ignoreNull is true.
@@ -277,7 +277,7 @@ TEST_F(LastAggregateTest, arrayGlobal) {
 
   // Verify when ignoreNull is false.
   auto expectedFalse = {makeRowVector({
-      makeVectorWithNullArrays<int64_t>({std::nullopt}),
+      makeNullableArrayVector<int64_t>({std::nullopt}),
   })};
   testAggregations(vectors, {}, {"last(c0, c2)"}, expectedFalse);
 

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -280,7 +280,7 @@ class VectorTestBase {
     }
 
     // Create the underlying vector.
-    auto baseArray = makeVectorWithNullArrays<T>(flattenedData);
+    auto baseArray = makeNullableArrayVector<T>(flattenedData);
 
     // Build and return a second-level of ArrayVector on top of baseArray.
     return std::make_shared<ArrayVector>(
@@ -410,8 +410,16 @@ class VectorTestBase {
     return vectorMaker_.arrayVectorNullable<T>(convData, type);
   }
 
+  // Just like makeNullableArrayVector above, but allows specifying null arrays.
+  //
+  //  Example:
+  //   auto arrayVector = makeNullableArrayVector<int64_t>({
+  //       {{1, 2, std::nullopt, 4}},
+  //       {{}},
+  //       std::nullopt,
+  //   });
   template <typename T>
-  ArrayVectorPtr makeVectorWithNullArrays(
+  ArrayVectorPtr makeNullableArrayVector(
       const std::vector<std::optional<std::vector<std::optional<T>>>>& data) {
     return vectorMaker_.arrayVectorNullable<T>(data);
   }
@@ -654,7 +662,7 @@ class VectorTestBase {
       }
     }
 
-    auto mapValues = makeVectorWithNullArrays(values);
+    auto mapValues = makeNullableArrayVector(values);
     auto mapKeys = makeNullableFlatVector<K>(keys);
     auto size = maps.size();
 


### PR DESCRIPTION
Renamed makeVectorWithNullArrays to makeNullableArrayVector for 
better consistency and readability. 