### PR TITLE
Extend makeNullableNestedArrayVector testing API and add cast-in-try unit test

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -37,8 +37,9 @@ add_library(
   SwitchExpr.cpp
   TryExpr.cpp)
 
-target_link_libraries(velox_expression velox_core velox_vector
-                      velox_common_base velox_expression_functions)
+target_link_libraries(
+  velox_expression velox_core velox_vector velox_common_base
+  velox_expression_functions velox_functions_util)
 
 add_subdirectory(type_calculation)
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -116,6 +116,13 @@ class EvalCtx {
       const std::exception_ptr& exceptionPtr,
       ErrorVectorPtr& errorsPtr) const;
 
+  // Given a mapping from element rows to top-level rows, add element-level
+  // errors in errors_ to topLevelErrors.
+  void addElementErrorsToTopLevel(
+      const SelectivityVector& elementRows,
+      const BufferPtr& elementToTopLevelRows,
+      ErrorVectorPtr& topLevelErrors);
+
   // Returns the vector of errors or nullptr if no errors. This is
   // intentionally a raw pointer to signify that the caller may not
   // retain references to this.

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -403,7 +403,8 @@ TEST_F(ArrayWriterTest, nestedArray) {
   array_type array3 = {{1, std::nullopt, 2}};
 
   assertEqualVectors(
-      result, makeNestedArrayVector<int32_t>({{array1, array2, array3}}));
+      result,
+      makeNullableNestedArrayVector<int32_t>({{{array1, array2, array3}}}));
 }
 
 // Creates a matrix of size n*n with numbers 1 to n^2-1 for every input n,
@@ -441,9 +442,9 @@ TEST_F(ArrayWriterTest, nestedArrayE2E) {
   // Build the expected output.
   using matrix_row = std::vector<std::optional<int64_t>>;
   using matrix_type = std::vector<std::optional<matrix_row>>;
-  std::vector<matrix_type> expected;
+  std::vector<std::optional<matrix_type>> expected;
   for (auto k = 1; k <= 10; k++) {
-    auto& expectedMatrix = *expected.insert(expected.end(), matrix_type());
+    auto& expectedMatrix = **expected.insert(expected.end(), matrix_type());
     auto n = k;
     int count = 0;
 
@@ -465,7 +466,7 @@ TEST_F(ArrayWriterTest, nestedArrayE2E) {
     }
   }
 
-  assertEqualVectors(result, makeNestedArrayVector<int64_t>(expected));
+  assertEqualVectors(result, makeNullableNestedArrayVector<int64_t>(expected));
 }
 
 TEST_F(ArrayWriterTest, copyFromEmptyArray) {
@@ -535,7 +536,8 @@ TEST_F(ArrayWriterTest, copyFromNestedArray) {
   array_type array3 = {{1}};
 
   assertEqualVectors(
-      result, makeNestedArrayVector<int64_t>({{array1, array2, array3}}));
+      result,
+      makeNullableNestedArrayVector<int64_t>({{{array1, array2, array3}}}));
 }
 
 auto makeCopyFromTestData() {

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -780,6 +780,14 @@ TEST_F(CastExprTest, castInTry) {
       ARRAY(BIGINT()),
       makeRowVector({BaseVector::wrapInConstant(3, 0, array)}),
       arrayExpected);
+
+  auto nested = makeRowVector({makeNullableNestedArrayVector<StringView>(
+      {{{{{"1"_sv, "2"_sv}}, {{"3"_sv}}, {{"4a"_sv, "5"_sv}}}},
+       {{{{"6"_sv, "7"_sv}}}}})});
+  auto nestedExpected =
+      makeNullableNestedArrayVector<int64_t>({std::nullopt, {{{{6, 7}}}}});
+  evaluateAndVerifyCastInTryDictEncoding(
+      ARRAY(ARRAY(VARCHAR())), ARRAY(ARRAY(BIGINT())), nested, nestedExpected);
 }
 
 TEST_F(CastExprTest, primitiveNullConstant) {

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -17,6 +17,10 @@ add_library(velox_is_null_functions IsNull.cpp)
 
 target_link_libraries(velox_is_null_functions velox_expression)
 
+add_library(velox_functions_util LambdaFunctionUtil.cpp)
+
+target_link_libraries(velox_functions_util velox_vector)
+
 add_library(
   velox_functions_lib
   DateTimeFormatter.cpp

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(velox_is_null_functions velox_expression)
 
 add_library(velox_functions_util LambdaFunctionUtil.cpp)
 
-target_link_libraries(velox_functions_util velox_vector)
+target_link_libraries(velox_functions_util velox_vector velox_common_base)
 
 add_library(
   velox_functions_lib

--- a/velox/functions/lib/LambdaFunctionUtil.h
+++ b/velox/functions/lib/LambdaFunctionUtil.h
@@ -38,34 +38,6 @@ vector_size_t countElements(
   return count;
 }
 
-// Returns SelectivityVector for the nested vector with all rows corresponding
-// to specified top-level rows selected. The optional topLevelRowMapping is
-// used to pass the dictionary indices if the topLevelVector is dictionary
-// encoded.
-template <typename T>
-SelectivityVector toElementRows(
-    vector_size_t size,
-    const SelectivityVector& topLevelRows,
-    const T* topLevelVector,
-    const vector_size_t* topLevelRowMapping = nullptr) {
-  auto rawNulls = topLevelVector->rawNulls();
-  auto rawSizes = topLevelVector->rawSizes();
-  auto rawOffsets = topLevelVector->rawOffsets();
-
-  SelectivityVector elementRows(size, false);
-  topLevelRows.applyToSelected([&](vector_size_t row) {
-    auto index = topLevelRowMapping ? topLevelRowMapping[row] : row;
-    if (rawNulls && bits::isBitNull(rawNulls, index)) {
-      return;
-    }
-    auto size = rawSizes[index];
-    auto offset = rawOffsets[index];
-    elementRows.setValidRange(offset, offset + size, true);
-  });
-  elementRows.updateBounds();
-  return elementRows;
-}
-
 // Returns an array of indices that allows aligning captures with the nested
 // elements of an array or vector. For each top-level row, the index equal to
 // the row number is repeated for each of the nested rows.

--- a/velox/functions/lib/RowsTranslationUtil.h
+++ b/velox/functions/lib/RowsTranslationUtil.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/vector/SelectivityVector.h"
+
+namespace facebook::velox::functions {
+
+/// Returns SelectivityVector for the nested vector with all rows corresponding
+/// to specified top-level rows selected. The optional topLevelRowMapping is
+/// used to pass the dictionary indices if the topLevelVector is dictionary
+/// encoded.
+template <typename T>
+SelectivityVector toElementRows(
+    vector_size_t size,
+    const SelectivityVector& topLevelRows,
+    const T* topLevelVector,
+    const vector_size_t* topLevelRowMapping = nullptr) {
+  auto rawNulls = topLevelVector->rawNulls();
+  auto rawSizes = topLevelVector->rawSizes();
+  auto rawOffsets = topLevelVector->rawOffsets();
+
+  SelectivityVector elementRows(size, false);
+  topLevelRows.applyToSelected([&](vector_size_t row) {
+    auto index = topLevelRowMapping ? topLevelRowMapping[row] : row;
+    if (rawNulls && bits::isBitNull(rawNulls, index)) {
+      return;
+    }
+    auto size = rawSizes[index];
+    auto offset = rawOffsets[index];
+    elementRows.setValidRange(offset, offset + size, true);
+  });
+  elementRows.updateBounds();
+  return elementRows;
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/ArrayDistinct.cpp
+++ b/velox/functions/prestosql/ArrayDistinct.cpp
@@ -19,7 +19,7 @@
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 
 namespace facebook::velox::functions {
 namespace {

--- a/velox/functions/prestosql/ArrayDuplicates.cpp
+++ b/velox/functions/prestosql/ArrayDuplicates.cpp
@@ -20,7 +20,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/ComparatorUtil.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 
 namespace facebook::velox::functions {
 namespace {

--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 
 namespace facebook::velox::functions {
 namespace {

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -19,7 +19,7 @@
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 
 namespace facebook::velox::functions {
 namespace {

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -63,7 +63,8 @@ target_link_libraries(
   velox_expression
   md5
   velox_type_tz
-  velox_presto_types)
+  velox_presto_types
+  velox_functions_util)
 
 set_property(TARGET velox_functions_prestosql_impl PROPERTY JOB_POOL_COMPILE
                                                             high_memory_pool)

--- a/velox/functions/prestosql/FilterFunctions.cpp
+++ b/velox/functions/prestosql/FilterFunctions.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/FunctionVector.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/Transform.cpp
+++ b/velox/functions/prestosql/Transform.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/FunctionVector.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/TransformKeys.cpp
+++ b/velox/functions/prestosql/TransformKeys.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/FunctionVector.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/TransformValues.cpp
+++ b/velox/functions/prestosql/TransformValues.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/FunctionVector.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/WidthBucketArray.cpp
+++ b/velox/functions/prestosql/WidthBucketArray.cpp
@@ -16,7 +16,7 @@
 #include "velox/functions/prestosql/WidthBucketArray.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/DecodedVector.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -44,8 +44,13 @@ add_library(
   RegisterAggregateFunctions.cpp)
 
 target_link_libraries(
-  velox_aggregates velox_common_hyperloglog velox_exec velox_presto_serializer
-  velox_functions_lib ${FOLLY_WITH_DEPENDENCIES})
+  velox_aggregates
+  velox_common_hyperloglog
+  velox_exec
+  velox_presto_serializer
+  velox_functions_lib
+  velox_functions_util
+  ${FOLLY_WITH_DEPENDENCIES})
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/aggregates/PrestoHasher.cpp
+++ b/velox/functions/prestosql/aggregates/PrestoHasher.cpp
@@ -18,7 +18,7 @@
 #define XXH_INLINE_ALL
 #include <xxhash.h>
 
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::aggregate {

--- a/velox/functions/prestosql/tests/ArrayCombinationsTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayCombinationsTest.cpp
@@ -38,11 +38,11 @@ class ArrayCombinationsTest : public FunctionBaseTest {
     auto arrayVector = makeArrayVector<T>(
         {{0, 1, 2, 3}, {0, 1, 2, 3}, {0, 1, 2, 3}, {0, 1, 2, 3}});
     auto comboLengthVector = makeFlatVector<int32_t>({0, 3, 4, 5});
-    auto expected = makeNestedArrayVector<T>(
-        {{{std::vector<std::optional<T>>()}},
-         {{{0, 1, 2}}, {{0, 1, 3}}, {{0, 2, 3}}, {{1, 2, 3}}},
-         {{{0, 1, 2, 3}}},
-         {}});
+    auto expected = makeNullableNestedArrayVector<T>(
+        {{{{std::vector<std::optional<T>>()}}},
+         {{{{0, 1, 2}}, {{0, 1, 3}}, {{0, 2, 3}}, {{1, 2, 3}}}},
+         {{{{0, 1, 2, 3}}}},
+         {{}}});
     testExpr(
         expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
   }
@@ -55,20 +55,20 @@ class ArrayCombinationsTest : public FunctionBaseTest {
          {0, 1, std::nullopt, 3},
          {0, 1, std::nullopt, 3}});
     auto comboLengthVector = makeFlatVector<int32_t>({0, 3, 4, 5});
-    auto expected = makeNestedArrayVector<T>({
-        {
+    auto expected = makeNullableNestedArrayVector<T>({
+        {{
             {std::vector<std::optional<T>>()},
-        },
-        {
+        }},
+        {{
             {{0, 1, std::nullopt}},
             {{0, 1, 3}},
             {{0, std::nullopt, 3}},
             {{1, std::nullopt, 3}},
-        },
-        {
+        }},
+        {{
             {{0, 1, std::nullopt, 3}},
-        },
-        {},
+        }},
+        {{}},
     });
     testExpr(
         expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
@@ -135,17 +135,17 @@ TEST_F(ArrayCombinationsTest, inlineVarcharArrays) {
   });
   auto comboLengthVector = makeFlatVector<int32_t>({0, 1, 1, 2, 4, 5});
 
-  auto expected = makeNestedArrayVector<S>(
-      {{{std::vector<std::optional<S>>()}},
-       {{{""}}},
-       {{{std::optional<S>(std::nullopt)}}},
-       {{{"aa", std::nullopt}}, {{"aa", "bb"}}, {{std::nullopt, "bb"}}},
-       {{{"bb", "aa", "cc", "aa"}},
-        {{"bb", "aa", "cc", "ddd"}},
-        {{"bb", "aa", "aa", "ddd"}},
-        {{"bb", "cc", "aa", "ddd"}},
-        {{"aa", "cc", "aa", "ddd"}}},
-       {}});
+  auto expected = makeNullableNestedArrayVector<S>(
+      {{{{std::vector<std::optional<S>>()}}},
+       {{{{""}}}},
+       {{{{std::optional<S>(std::nullopt)}}}},
+       {{{{"aa", std::nullopt}}, {{"aa", "bb"}}, {{std::nullopt, "bb"}}}},
+       {{{{"bb", "aa", "cc", "aa"}},
+         {{"bb", "aa", "cc", "ddd"}},
+         {{"bb", "aa", "aa", "ddd"}},
+         {{"bb", "cc", "aa", "ddd"}},
+         {{"aa", "cc", "aa", "ddd"}}}},
+       {{}}});
   testExpr(expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
 }
 
@@ -165,34 +165,34 @@ TEST_F(ArrayCombinationsTest, varcharArrays) {
   });
   auto comboLengthVector = makeFlatVector<int32_t>({0, 1, 1, 2, 4, 5});
 
-  auto expected = makeNestedArrayVector<S>(
-      {{{std::vector<std::optional<S>>()}},
-       {{{""}}},
-       {{{std::optional<S>(std::nullopt)}}},
-       {{{"red shiny car ahead", std::nullopt}},
-        {{"red shiny car ahead", "blue clear sky above"}},
-        {{std::nullopt, "blue clear sky above"}}},
-       {{{"blue clear sky above",
-          "red shiny car ahead",
-          "yellow rose flowers",
-          "red shiny car ahead"}},
-        {{"blue clear sky above",
-          "red shiny car ahead",
-          "yellow rose flowers",
-          "purple is an elegant color"}},
-        {{"blue clear sky above",
-          "red shiny car ahead",
-          "red shiny car ahead",
-          "purple is an elegant color"}},
-        {{"blue clear sky above",
-          "yellow rose flowers",
-          "red shiny car ahead",
-          "purple is an elegant color"}},
-        {{"red shiny car ahead",
-          "yellow rose flowers",
-          "red shiny car ahead",
-          "purple is an elegant color"}}},
-       {}});
+  auto expected = makeNullableNestedArrayVector<S>(
+      {{{{std::vector<std::optional<S>>()}}},
+       {{{{""}}}},
+       {{{{std::optional<S>(std::nullopt)}}}},
+       {{{{"red shiny car ahead", std::nullopt}},
+         {{"red shiny car ahead", "blue clear sky above"}},
+         {{std::nullopt, "blue clear sky above"}}}},
+       {{{{"blue clear sky above",
+           "red shiny car ahead",
+           "yellow rose flowers",
+           "red shiny car ahead"}},
+         {{"blue clear sky above",
+           "red shiny car ahead",
+           "yellow rose flowers",
+           "purple is an elegant color"}},
+         {{"blue clear sky above",
+           "red shiny car ahead",
+           "red shiny car ahead",
+           "purple is an elegant color"}},
+         {{"blue clear sky above",
+           "yellow rose flowers",
+           "red shiny car ahead",
+           "purple is an elegant color"}},
+         {{"red shiny car ahead",
+           "yellow rose flowers",
+           "red shiny car ahead",
+           "purple is an elegant color"}}}},
+       {{}}});
   testExpr(expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
 }
 
@@ -206,16 +206,16 @@ TEST_F(ArrayCombinationsTest, boolNullableArrays) {
   });
   auto comboLengthVector = makeFlatVector<int32_t>({0, 1, 2, 4, 5});
 
-  auto expected = makeNestedArrayVector<bool>(
-      {{{std::vector<std::optional<bool>>()}},
-       {{{std::optional<bool>(std::nullopt)}}},
-       {{{true, std::nullopt}}, {{true, false}}, {{std::nullopt, false}}},
-       {{{false, true, false, true}},
-        {{false, true, false, true}},
-        {{false, true, true, true}},
-        {{false, false, true, true}},
-        {{true, false, true, true}}},
-       {}});
+  auto expected = makeNullableNestedArrayVector<bool>(
+      {{{{std::vector<std::optional<bool>>()}}},
+       {{{{std::optional<bool>(std::nullopt)}}}},
+       {{{{true, std::nullopt}}, {{true, false}}, {{std::nullopt, false}}}},
+       {{{{false, true, false, true}},
+         {{false, true, false, true}},
+         {{false, true, true, true}},
+         {{false, false, true, true}},
+         {{true, false, true, true}}}},
+       {{}}});
   testExpr(expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
 }
 
@@ -229,15 +229,15 @@ TEST_F(ArrayCombinationsTest, boolArrays) {
   });
   auto comboLengthVector = makeFlatVector<int32_t>({0, 1, 2, 4, 5});
 
-  auto expected = makeNestedArrayVector<bool>(
-      {{{std::vector<std::optional<bool>>()}},
-       {{{true}}},
-       {{{true, true}}, {{true, false}}, {{true, false}}},
-       {{{false, true, false, true}},
-        {{false, true, false, true}},
-        {{false, true, true, true}},
-        {{false, false, true, true}},
-        {{true, false, true, true}}},
-       {}});
+  auto expected = makeNullableNestedArrayVector<bool>(
+      {{{{std::vector<std::optional<bool>>()}}},
+       {{{{true}}}},
+       {{{{true, true}}, {{true, false}}, {{true, false}}}},
+       {{{{false, true, false, true}},
+         {{false, true, false, true}},
+         {{false, true, true, true}},
+         {{false, false, true, true}},
+         {{true, false, true, true}}}},
+       {{}}});
   testExpr(expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
 }

--- a/velox/functions/prestosql/tests/ArrayPositionTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayPositionTest.cpp
@@ -385,22 +385,18 @@ TEST_F(ArrayPositionTest, row) {
 }
 
 TEST_F(ArrayPositionTest, array) {
-  auto O = [](const std::vector<std::optional<int64_t>>& data) {
-    return std::make_optional(data);
-  };
-
   std::vector<std::optional<int64_t>> a{1, 2, 3};
   std::vector<std::optional<int64_t>> b{4, 5};
   std::vector<std::optional<int64_t>> c{6, 7, 8};
   std::vector<std::optional<int64_t>> d{1, 2};
   std::vector<std::optional<int64_t>> e{4, 3};
-  auto arrayVector = makeNestedArrayVector<int64_t>(
-      {{O(a), O(b), O(c)},
-       {O(d), O(e)},
-       {O(d), O(a), O(b)},
-       {O(c), O(e)},
-       {O({})},
-       {O({std::nullopt})}});
+  auto arrayVector = makeNullableNestedArrayVector<int64_t>(
+      {{{{a}, {b}, {c}}},
+       {{{d}, {e}}},
+       {{{d}, {a}, {b}}},
+       {{{c}, {e}}},
+       {{{{}}}},
+       {{{std::vector<std::optional<int64_t>>{std::nullopt}}}}});
 
   auto testPositionOfArray =
       [&](const TwoDimVector<int64_t>& search,
@@ -683,22 +679,18 @@ TEST_F(ArrayPositionTest, rowWithInstance) {
 }
 
 TEST_F(ArrayPositionTest, arrayWithInstance) {
-  auto O = [](const std::vector<std::optional<int64_t>>& data) {
-    return std::make_optional(data);
-  };
-
   std::vector<std::optional<int64_t>> a{1, 2, 3};
   std::vector<std::optional<int64_t>> b{4, 5};
   std::vector<std::optional<int64_t>> c{6, 7, 8};
   std::vector<std::optional<int64_t>> d{1, 2};
   std::vector<std::optional<int64_t>> e{4, 3};
-  auto arrayVector = makeNestedArrayVector<int64_t>(
-      {{O(a), O(b), O(a)},
-       {O(d), O(e)},
-       {O(d), O(a), O(a)},
-       {O(c), O(c)},
-       {O({})},
-       {O({std::nullopt})}});
+  auto arrayVector = makeNullableNestedArrayVector<int64_t>(
+      {{{{a}, {b}, {a}}},
+       {{{d}, {e}}},
+       {{{d}, {a}, {a}}},
+       {{{c}, {c}}},
+       {{{{}}}},
+       {{{std::vector<std::optional<int64_t>>{std::nullopt}}}}});
 
   auto testPositionOfArray =
       [&](const TwoDimVector<int64_t>& search,

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -298,12 +298,13 @@ ArrayVectorPtr ArraySortTest::arrayVector<TestMapType>(
 template <>
 ArrayVectorPtr ArraySortTest::arrayVector<TestArrayType>(
     const std::vector<std::optional<TestArrayType>>& inputValues) {
-  std::vector<std::vector<std::optional<TestArrayType>>> inputVectors;
+  std::vector<std::optional<std::vector<std::optional<TestArrayType>>>>
+      inputVectors;
   inputVectors.reserve(numVectors_);
   for (int i = 0; i < numVectors_; ++i) {
     inputVectors.push_back(inputValues);
   }
-  return makeNestedArrayVector<StringView>(inputVectors);
+  return makeNullableNestedArrayVector<StringView>(inputVectors);
 }
 
 template <>

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -367,7 +367,8 @@ TEST_F(ComparisonsTest, eqNestedComplex) {
   array_type array2 = {{}};
   array_type array3 = {{1, 100, 2}};
 
-  auto vector1 = makeNestedArrayVector<int64_t>({{array1, array2, array3}});
+  auto vector1 =
+      makeNullableNestedArrayVector<int64_t>({{{array1, array2, array3}}});
   auto vector2 = makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6});
   auto vector3 = makeMapVector<int64_t, int64_t>({{{1, 2}, {3, 4}}});
   auto row1 = makeRowVector({vector1, vector2, vector3});

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -973,11 +973,11 @@ TEST_F(JsonCastTest, toNested) {
   auto array = makeNullableFlatVector<Json>(
       {R"([[1,2],[3]])"_sv, R"([[null,null,4]])"_sv, "[[]]"_sv, "[]"_sv},
       JSON());
-  auto arrayExpected = makeNestedArrayVector<StringView>(
-      {{{{"1"_sv, "2"_sv}}, {{"3"_sv}}},
-       {{{std::nullopt, std::nullopt, "4"_sv}}},
-       {{{}}},
-       {}});
+  auto arrayExpected = makeNullableNestedArrayVector<StringView>(
+      {{{{{"1"_sv, "2"_sv}}, {{"3"_sv}}}},
+       {{{{std::nullopt, std::nullopt, "4"_sv}}}},
+       {{{{}}}},
+       {{}}});
 
   testCast<ComplexType>(JSON(), ARRAY(ARRAY(VARCHAR())), array, arrayExpected);
 

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -13,4 +13,5 @@
 # limitations under the License.
 add_library(velox_presto_types JsonType.cpp)
 
-target_link_libraries(velox_presto_types velox_memory velox_expression)
+target_link_libraries(velox_presto_types velox_memory velox_expression
+                      velox_functions_util)

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -27,7 +27,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/StringWriter.h"
 #include "velox/expression/VectorWriters.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox {

--- a/velox/functions/sparksql/ArraySort.cpp
+++ b/velox/functions/sparksql/ArraySort.cpp
@@ -20,7 +20,7 @@
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/functions/sparksql/Comparisons.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(
 
 target_link_libraries(
   velox_functions_spark velox_functions_lib velox_functions_prestosql_impl
-  velox_is_null_functions ${FOLLY_WITH_DEPENDENCIES})
+  velox_is_null_functions velox_functions_util ${FOLLY_WITH_DEPENDENCIES})
 
 set_property(TARGET velox_functions_spark PROPERTY JOB_POOL_COMPILE
                                                    high_memory_pool)

--- a/velox/functions/sparksql/tests/ArraySortTest.cpp
+++ b/velox/functions/sparksql/tests/ArraySortTest.cpp
@@ -100,8 +100,8 @@ TEST_F(ArraySortTest, bool) {
 }
 
 TEST_F(ArraySortTest, array) {
-  auto input = makeNestedArrayVector(arrayInput());
-  auto expected = makeNestedArrayVector(arrayAscNullLargest());
+  auto input = makeNullableNestedArrayVector(arrayInput());
+  auto expected = makeNullableNestedArrayVector(arrayAscNullLargest());
   testArraySort(input, expected);
 }
 

--- a/velox/functions/sparksql/tests/ArraySortTestData.h
+++ b/velox/functions/sparksql/tests/ArraySortTestData.h
@@ -57,6 +57,15 @@ inline NestedVector<T> reverseNested(NestedVector<T> data) {
 }
 
 template <typename T>
+inline std::vector<std::optional<std::vector<T>>> reverseNested(
+    std::vector<std::optional<std::vector<T>>> data) {
+  for (auto& v : data) {
+    std::reverse(v->begin(), v->end());
+  }
+  return data;
+}
+
+template <typename T>
 inline NestedVector<std::optional<T>> intInput() {
   return NestedVector<std::optional<T>>{
       {},
@@ -227,44 +236,47 @@ inline NestedVector<std::optional<bool>> boolAscNullLargest() {
   };
 }
 
-inline NestedVector<std::optional<std::vector<std::optional<int32_t>>>>
+inline std::vector<std::optional<
+    std::vector<std::optional<std::vector<std::optional<int32_t>>>>>>
 arrayInput() {
   using A = std::vector<std::optional<int32_t>>;
-  return NestedVector<std::optional<A>>{
+  return std::vector<std::optional<std::vector<std::optional<A>>>>{
       // Empty.
-      {},
+      {{}},
       // All nulls.
-      {std::nullopt, std::nullopt},
+      {{std::nullopt, std::nullopt}},
       // Same prefix.
-      {A({1, 3}), A({2, 1}), A({1, 3, 5})},
+      {{A({1, 3}), A({2, 1}), A({1, 3, 5})}},
       // Top level null elements.
-      {A({1, 3}), std::nullopt, A({2, 1})},
+      {{A({1, 3}), std::nullopt, A({2, 1})}},
       // Array with null values.
-      {A({std::nullopt, 6}), A({3, std::nullopt}), A({std::nullopt, 8})},
+      {{A({std::nullopt, 6}), A({3, std::nullopt}), A({std::nullopt, 8})}},
   };
 }
 
-inline NestedVector<std::optional<std::vector<std::optional<int32_t>>>>
+inline std::vector<std::optional<
+    std::vector<std::optional<std::vector<std::optional<int32_t>>>>>>
 arrayAscNullSmallest() {
   using A = std::vector<std::optional<int32_t>>;
-  return NestedVector<std::optional<A>>{
-      {},
-      {std::nullopt, std::nullopt},
-      {A({1, 3}), A({1, 3, 5}), A({2, 1})},
-      {std::nullopt, A({1, 3}), A({2, 1})},
-      {A({std::nullopt, 6}), A({std::nullopt, 8}), A({3, std::nullopt})},
+  return std::vector<std::optional<std::vector<std::optional<A>>>>{
+      {{}},
+      {{std::nullopt, std::nullopt}},
+      {{A({1, 3}), A({1, 3, 5}), A({2, 1})}},
+      {{std::nullopt, A({1, 3}), A({2, 1})}},
+      {{A({std::nullopt, 6}), A({std::nullopt, 8}), A({3, std::nullopt})}},
   };
 }
 
-inline NestedVector<std::optional<std::vector<std::optional<int32_t>>>>
+inline std::vector<std::optional<
+    std::vector<std::optional<std::vector<std::optional<int32_t>>>>>>
 arrayAscNullLargest() {
   using A = std::vector<std::optional<int32_t>>;
-  return NestedVector<std::optional<A>>{
-      {},
-      {std::nullopt, std::nullopt},
-      {A({1, 3}), A({1, 3, 5}), A({2, 1})},
-      {A({1, 3}), A({2, 1}), std::nullopt},
-      {A({3, std::nullopt}), A({std::nullopt, 6}), A({std::nullopt, 8})},
+  return std::vector<std::optional<std::vector<std::optional<A>>>>{
+      {{}},
+      {{std::nullopt, std::nullopt}},
+      {{A({1, 3}), A({1, 3, 5}), A({2, 1})}},
+      {{A({1, 3}), A({2, 1}), std::nullopt}},
+      {{A({3, std::nullopt}), A({std::nullopt, 6}), A({std::nullopt, 8})}},
   };
 }
 

--- a/velox/functions/sparksql/tests/SortArrayTest.cpp
+++ b/velox/functions/sparksql/tests/SortArrayTest.cpp
@@ -145,12 +145,12 @@ TEST_F(SortArrayTest, bool) {
 }
 
 TEST_F(SortArrayTest, array) {
-  auto input = makeNestedArrayVector(arrayInput());
+  auto input = makeNullableNestedArrayVector(arrayInput());
   auto expected = arrayAscNullSmallest();
   testSortArray(
       input,
-      makeNestedArrayVector(expected),
-      makeNestedArrayVector(reverseNested(expected)));
+      makeNullableNestedArrayVector(expected),
+      makeNullableNestedArrayVector(reverseNested(expected)));
 }
 
 TEST_F(SortArrayTest, map) {


### PR DESCRIPTION
Summary:
This diff adds a test of casting nested array in try expression. To avoid
boilerplate, it also extend the makeNestedArrayVector() testing API to
allow top-level nulls and rename it as makeNullableNestedArrayVector().

Differential Revision: D39901341

