### PR TITLE
Fix cast(varchar as date) when truncate flag is true

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -309,26 +309,29 @@ TEST_F(CastExprTest, timestampAdjustToTimezoneInvalid) {
 }
 
 TEST_F(CastExprTest, date) {
-  testCast<std::string, Date>(
-      "date",
-      {
-          "1970-01-01",
-          "2020-01-01",
-          "2135-11-09",
-          "1969-12-27",
-          "1812-04-15",
-          "1920-01-02",
-          std::nullopt,
-      },
-      {
-          Date(0),
-          Date(18262),
-          Date(60577),
-          Date(-5),
-          Date(-57604),
-          Date(-18262),
-          std::nullopt,
-      });
+  std::vector<std::optional<std::string>> input{
+      "1970-01-01",
+      "2020-01-01",
+      "2135-11-09",
+      "1969-12-27",
+      "1812-04-15",
+      "1920-01-02",
+      std::nullopt,
+  };
+  std::vector<std::optional<Date>> result{
+      Date(0),
+      Date(18262),
+      Date(60577),
+      Date(-5),
+      Date(-57604),
+      Date(-18262),
+      std::nullopt,
+  };
+
+  testCast<std::string, Date>("date", input, result);
+
+  setCastIntByTruncate(true);
+  testCast<std::string, Date>("date", input, result);
 }
 
 TEST_F(CastExprTest, invalidDate) {

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -408,8 +408,8 @@ struct Converter<TypeKind::TIMESTAMP> {
 };
 
 // Allow conversions from string to DATE type.
-template <>
-struct Converter<TypeKind::DATE> {
+template <bool TRUNCATE>
+struct Converter<TypeKind::DATE, void, TRUNCATE> {
   using T = typename TypeTraits<TypeKind::DATE>::NativeType;
   template <typename From>
   static T cast(const From& /* v */, bool& nullOutput) {


### PR DESCRIPTION
Summary:
This diff fix an issue found by the OSS community: https://github.com/facebookincubator/velox/issues/2567.

cast(varchar as date) is implemented through a Converter<TypeKind::DATE> struct. 
Before this fix, Converter<TypeKind::DATE> is a specialization of a struct template 
for KIND == TypeKind::DATE && TRUNCATE == false. When the truncate flag is set 
to true, the original struct template Converter<KIND, void, TRUNCATE> is  incorrectly 
used and hence exception throws.

Differential Revision: D39951704

