### PR TITLE
Fix issues exposed by emptyProbe test

### DIFF
--- a/velox/common/base/tests/GTestUtils.h
+++ b/velox/common/base/tests/GTestUtils.h
@@ -44,7 +44,15 @@
 
 #ifndef NDEBUG
 #define DEBUG_ONLY_TEST(test_fixture, test_name) TEST(test_fixture, test_name)
+#define DEBUG_ONLY_TEST_F(test_fixture, test_name) \
+  TEST_F(test_fixture, test_name)
+#define DEBUG_ONLY_TEST_P(test_fixture, test_name) \
+  TEST_P(test_fixture, test_name)
 #else
 #define DEBUG_ONLY_TEST(test_fixture, test_name) \
   TEST(test_fixture, DISABLED_##test_name)
+#define DEBUG_ONLY_TEST_F(test_fixture, test_name) \
+  TEST_F(test_fixture, DISABLED_test_name)
+#define DEBUG_ONLY_TEST_P(test_fixture, test_name) \
+  TEST_P(test_fixture, DISABLED_test_name)
 #endif

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -219,16 +219,14 @@ class HashBuild final : public Operator {
 
   const core::JoinType joinType_;
 
-  const std::shared_ptr<HashJoinBridge> joinBridge_;
-
   // Holds the areas in RowContainer of 'table_'
   memory::MappedMemory* const FOLLY_NONNULL mappedMemory_;
 
-  const std::shared_ptr<HashJoinBridge> joinBride_;
+  const std::shared_ptr<HashJoinBridge> joinBridge_;
 
   const std::optional<Spiller::Config> spillConfig_;
 
-  SpillOperatorGroup* const FOLLY_NULLABLE spillGroup_{nullptr};
+  const std::shared_ptr<SpillOperatorGroup> spillGroup_;
 
   State state_{State::kRunning};
 

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -15,7 +15,10 @@
  */
 
 #include "velox/exec/Merge.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/exec/Task.h"
+
+using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
 
@@ -97,6 +100,7 @@ BlockingReason Merge::isBlocked(ContinueFuture* future) {
 }
 
 bool Merge::isFinished() {
+  TestValue::notify("facebook::velox::exec::Merge::isFinished", &finished_);
   return finished_;
 }
 

--- a/velox/exec/SpillOperatorGroup.h
+++ b/velox/exec/SpillOperatorGroup.h
@@ -133,7 +133,7 @@ class SpillOperatorGroup {
 
   const std::string taskId_;
   const uint32_t splitGroupId_;
-  const core::PlanNodeId& planNodeId_;
+  const core::PlanNodeId planNodeId_;
 
   std::mutex mutex_;
   State state_;

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1915,13 +1915,13 @@ static std::string getQueryMemoryUsageString(memory::MemoryPool* queryPool) {
   return out.str();
 }
 
-SpillOperatorGroup* Task::getSpillOperatorGroupLocked(
+std::shared_ptr<SpillOperatorGroup> Task::getSpillOperatorGroupLocked(
     uint32_t splitGroupId,
     const core::PlanNodeId& planNodeId) {
   auto& groups = splitGroupStates_[splitGroupId].spillOperatorGroups;
   auto it = groups.find(planNodeId);
   VELOX_CHECK(it != groups.end(), "Split group is not set {}", splitGroupId);
-  SpillOperatorGroup* group = it->second.get();
+  auto group = it->second;
   VELOX_CHECK_NOT_NULL(
       group,
       "Spill group for plan node ID {} is not set in split group {}",

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -396,7 +396,7 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
-  SpillOperatorGroup* FOLLY_NONNULL getSpillOperatorGroupLocked(
+  std::shared_ptr<SpillOperatorGroup> getSpillOperatorGroupLocked(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -80,7 +80,7 @@ struct SplitGroupState {
 
   /// Map from the plan node id to the associated spill operator group if disk
   /// spill is enabled for the corresponding plan operator.
-  std::unordered_map<core::PlanNodeId, std::unique_ptr<SpillOperatorGroup>>
+  std::unordered_map<core::PlanNodeId, std::shared_ptr<SpillOperatorGroup>>
       spillOperatorGroups;
 
   /// Holds states for Task::allPeersFinished.

--- a/velox/exec/Values.cpp
+++ b/velox/exec/Values.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #include "velox/exec/Values.h"
+#include "velox/common/testutil/TestValue.h"
+
+using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
 
@@ -38,6 +41,7 @@ Values::Values(
 }
 
 RowVectorPtr Values::getOutput() {
+  TestValue::notify("facebook::velox::exec::Values::getOutput", &current_);
   if (current_ >= values_.size()) {
     return nullptr;
   }

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
@@ -826,69 +827,6 @@ TEST_F(AggregationTest, partialAggregationMaybeReservationReleaseCheck) {
       task->pool()->getMemoryUsageTracker()->getCurrentTotalBytes());
 }
 
-TEST_F(AggregationTest, spill) {
-  constexpr int32_t kNumDistinct = 200000;
-  constexpr int64_t kMaxBytes = 24LL << 20; // 24 MB
-  rng_.seed(1);
-  rowType_ = ROW({"c0", "c1", "a"}, {INTEGER(), VARCHAR(), VARCHAR()});
-  // The input batch has kNumDistinct distinct keys. The repeat count of a key
-  // is given by min(1, (k % 100) - 90). The batch is repeated 3 times, each
-  // time in a different order.
-  RowVectorPtr rows = std::static_pointer_cast<RowVector>(
-      BaseVector::create(rowType_, kNumDistinct, pool_.get()));
-  folly::F14FastSet<uint64_t> order1;
-  folly::F14FastSet<uint64_t> order2;
-  folly::F14FastSet<uint64_t> order3;
-  auto c0 = rows->childAt(0)->as<FlatVector<int32_t>>();
-  c0->resize(kNumDistinct);
-  auto c1 = rows->childAt(1)->as<FlatVector<StringView>>();
-  c1->resize(kNumDistinct);
-  int32_t totalCount = 0;
-  for (int32_t i = 0; i < kNumDistinct; ++i) {
-    c0->set(i, i);
-    std::string str = fmt::format("{}{}", i, i);
-    c1->set(i, StringView(str));
-    auto numRepeats = std::max(1, (i % 100) - 90);
-    // We make random permutations of the data by adding the indices into a set
-    // with a random 6 high bits followed by a serial number. These are inlined
-    // in the F14FastSet in an order that depends on the hash number.
-    for (auto j = 0; j < numRepeats; ++j) {
-      ++totalCount;
-      insertRandomOrder(i, totalCount, order1);
-      insertRandomOrder(i, totalCount, order2);
-      insertRandomOrder(i, totalCount, order3);
-    }
-  }
-  std::vector<RowVectorPtr> batches;
-  makeBatches(rows, order1, batches);
-  makeBatches(rows, order2, batches);
-  makeBatches(rows, order3, batches);
-  auto results =
-      AssertQueryBuilder(PlanBuilder()
-                             .values(batches)
-                             .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
-                             .planNode())
-          .copyResults(pool_.get());
-
-  auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = core::QueryCtx::createForTest();
-  queryCtx->pool()->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
-  auto task =
-      AssertQueryBuilder(PlanBuilder()
-                             .values(batches)
-                             .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
-                             .planNode())
-          .queryCtx(queryCtx)
-          .config(QueryConfig::kSpillPath, tempDirectory->path)
-          .assertResults(results);
-
-  auto stats = task->taskStats().pipelineStats;
-
-  // Over 20MB spilled.
-  EXPECT_LT(20 << 20, stats[0].operatorStats[1].spilledBytes);
-}
-
 TEST_F(AggregationTest, spillWithMemoryLimit) {
   constexpr int32_t kNumDistinct = 2000;
   constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
@@ -948,7 +886,7 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
   }
 }
 
-TEST_F(AggregationTest, spillWithEmptyPartition) {
+DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
   constexpr int32_t kNumDistinct = 100'000;
   constexpr int64_t kMaxBytes = 20LL << 20; // 20 MB
   rowType_ = ROW({"c0", "a"}, {INTEGER(), VARCHAR()});
@@ -1028,16 +966,14 @@ TEST_F(AggregationTest, spillWithEmptyPartition) {
     queryCtx->pool()->setMemoryUsageTracker(
         velox::memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
 
-#ifndef NDEBUG
     SCOPED_TESTVALUE_SET(
-        "facebook::velox::exec::test::TestObject::set",
+        "facebook::velox::exec::Spiller",
         std::function<void(const HashBitRange*)>(
             ([&](const HashBitRange* spillerBitRange) {
               ASSERT_EQ(kPartitionStartBit, spillerBitRange->begin());
               ASSERT_EQ(
                   kPartitionStartBit + kPartitionsBits, spillerBitRange->end());
             })));
-#endif
 
     auto task =
         AssertQueryBuilder(PlanBuilder()

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/DataSink.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/PartitionedOutputBufferManager.h"
@@ -25,6 +26,8 @@
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/serializers/PrestoSerializer.h"
+
+using namespace facebook::velox::common::testutil;
 
 namespace facebook::velox::exec::test {
 
@@ -61,6 +64,7 @@ void OperatorTestBase::SetUp() {
 
 void OperatorTestBase::SetUpTestCase() {
   functions::prestosql::registerAllScalarFunctions();
+  TestValue::enable();
 }
 
 std::shared_ptr<Task> OperatorTestBase::assertQuery(


### PR DESCRIPTION
(1) fix the memory reference issue in SpillOperatorGroup;
(2) use shared pointer to access the task shared states from operator
to avoid use-after-free issue if output pipeline finish early and the shared
state cleanup by the task terminate procedure;
(3) add a test case to cover the race condition that output pipeline finish
early and make sure the basic execution path like cross object references
work properly such as the running input pipeline driver will hold a reference
on the task to prevent it from destroying;
(4) Some code cleanup and test fix in AggregationTest and remove a over-designed
aggregation spill test which took >4min found by @mbasmanova

NOTE: will enabale emptyProbe test case after fix the file system instance race
detected by Meta's internal asan test mode.