### PR TITLE
Fix flaky HashJoinBridgeTest.multiThreading test timeout

### DIFF
--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -428,11 +428,11 @@ TEST_P(HashJoinBridgeTest, multiThreading) {
             tableFuture.wait();
             tableOr = joinBridge->tableOrFuture(&tableFuture);
             ASSERT_TRUE(tableOr.has_value());
-            if (tableOr.value().antiJoinHasNullKeys) {
-              break;
-            }
-            ASSERT_TRUE(tableOr.value().table != nullptr);
           }
+          if (tableOr.value().antiJoinHasNullKeys) {
+            break;
+          }
+          ASSERT_TRUE(tableOr.value().table != nullptr);
           for (const auto& id : tableOr.value().spillPartitionIds) {
             ASSERT_FALSE(spillPartitionIdSet.contains(id));
             spillPartitionIdSet.insert(id);
@@ -445,7 +445,7 @@ TEST_P(HashJoinBridgeTest, multiThreading) {
           }
 
           if (spillPartitionIdSet.empty()) {
-            return;
+            break;
           }
 
           // Wait for probe to finish.


### PR DESCRIPTION
The probe thread miss the null key check in non-blocking branch.

Verified the fix on meta internal dev server with 1000 iterations in
dev test mode.