### PR TITLE
Make BaseVector::toString methods LLDB-friendly

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -510,7 +510,7 @@ std::string BaseVector::toString(vector_size_t index) const {
 std::string BaseVector::toString(
     vector_size_t from,
     vector_size_t to,
-    const std::string& delimiter,
+    const char* delimiter,
     bool includeRowNumbers) const {
   const auto start = std::max(0, std::min<int32_t>(from, length_));
   const auto end = std::max(0, std::min<int32_t>(to, length_));

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -655,18 +655,39 @@ class BaseVector {
   ///
   ///         [DICTIONARY INTEGER: 5 elements, no nulls], [FLAT INTEGER: 10
   ///             elements, no nulls]
-  std::string toString(bool recursive = false) const;
+  std::string toString(bool recursive) const;
+
+  /// Same as toString(false). Provided to allow for easy invocation from LLDB.
+  std::string toString() const {
+    return toString(false);
+  }
 
   /// Returns string representation of the value in the specified row.
   virtual std::string toString(vector_size_t index) const;
 
-  /// Returns a list of values in rows [from, to). By default rows are separated
-  /// by a new line and include row numbers.
+  /// Returns a list of values in rows [from, to).
+  ///
+  /// Automatically adjusts 'from' and 'to' to a range of valid indices. Returns
+  /// empty string if 'from' is greater than or equal to vector size or 'to' is
+  /// less than or equal to zero. Returns values up to the end of the vector if
+  /// 'to' is greater than vector size. Returns values from the start of the
+  /// vector if 'from' is negative.
+  ///
+  /// The type of the 'delimiter' is a const char* and not an std::string to
+  /// allow for invoking this method from LLDB.
   std::string toString(
       vector_size_t from,
       vector_size_t to,
-      const std::string& delimiter = "\n",
+      const char* delimiter,
       bool includeRowNumbers = true) const;
+
+  /// Returns a list of values in rows [from, to). Values are separated by a new
+  /// line and prefixed with a row number.
+  ///
+  /// This method is provided to allow to easy invocation from LLDB.
+  std::string toString(vector_size_t from, vector_size_t to) const {
+    return toString(from, to, "\n");
+  }
 
   void setCodegenOutput() {
     isCodegenOutput_ = true;


### PR DESCRIPTION
Make it easier to print vectors when debugging with LLDB. Change type
of 'delimiter' from std::string to const char*. Provide convenience methods
without default parameters. (LLDB requires specifying all the parameters.)


Enable proper printing of new lines in strings.
```
(lldb) setting set escape-non-printables false
```

Print basic info about the vector: encoding, type, size and null count.
```
(lldb) p dict->toString()
(std::string) $0 = "[DICTIONARY INTEGER: 3 elements, no nulls]"
```
Print basic info for each layer of encoding starting from the top.
```
(lldb) p dict->toString(true)
(std::string) $1 = "[DICTIONARY INTEGER: 3 elements, no nulls], [FLAT INTEGER: 3 elements, no nulls]"
```
Print value in row 0.
```
(lldb) p dict->toString(0)
(std::string) $2 = "[0->2] 3"
```
Print value in row 1.
```
(lldb) p dict->toString(1)
(std::string) $3 = "[1->1] 2"
```
Print values in rows [0, 10) separated by new lines and prefixed with row numbers. Automatically adjust to the vector size.
```
(lldb) p dict->toString(0, 10)
(std::string) $5 = "0: [0->2] 3
1: [1->1] 2
2: [2->0] 1"
```
Print values in rows [0, 10) separated by commas. Useful for flat vectors of primitive types.
```
(lldb) p dict->wrappedVector()->toString(0, 10, ", ", false)
(std::string) $7 = "1, 2, 3"
```