### PR TITLE
Make peer values offset from the beginning of the partition

### DIFF
--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -341,8 +341,10 @@ void Window::callApplyForPartitionRows(
       }
     }
 
-    rawPeerStarts[j] = peerStartRow_;
-    rawPeerEnds[j] = peerEndRow_ - 1;
+    // Peer buffer values should be offsets from the start of the partition
+    // as WindowFunction only sees one partition at a time.
+    rawPeerStarts[j] = peerStartRow_ - firstPartitionRow;
+    rawPeerEnds[j] = peerEndRow_ - 1 - firstPartitionRow;
 
     // TODO: Calculate frame buffer values.
   }


### PR DESCRIPTION
Peer values were relative to sortedRows_ before. 