### PR TITLE
Change format of window function call in WindowTestBase

### DIFF
--- a/velox/functions/prestosql/window/tests/RankTest.cpp
+++ b/velox/functions/prestosql/window/tests/RankTest.cpp
@@ -33,9 +33,9 @@ TEST_F(RankTest, basic) {
           size, [](auto row) -> int32_t { return row % 7; }),
   });
 
-  testTwoColumnInput({vectors}, "rank");
-  testTwoColumnInput({vectors}, "dense_rank");
-  testTwoColumnInput({vectors}, "percent_rank");
+  testTwoColumnInput({vectors}, "rank()");
+  testTwoColumnInput({vectors}, "dense_rank()");
+  testTwoColumnInput({vectors}, "percent_rank()");
 }
 
 TEST_F(RankTest, singlePartition) {
@@ -47,9 +47,9 @@ TEST_F(RankTest, singlePartition) {
       makeFlatVector<int32_t>(size, [](auto row) { return row % 50; }),
   });
 
-  testTwoColumnInput({vectors}, "rank");
-  testTwoColumnInput({vectors}, "dense_rank");
-  testTwoColumnInput({vectors}, "percent_rank");
+  testTwoColumnInput({vectors}, "rank()");
+  testTwoColumnInput({vectors}, "dense_rank()");
+  testTwoColumnInput({vectors}, "percent_rank()");
 }
 
 TEST_F(RankTest, singleRowPartitions) {
@@ -59,9 +59,9 @@ TEST_F(RankTest, singleRowPartitions) {
       makeFlatVector<int32_t>(size, [](auto row) { return row; }),
   });
 
-  testTwoColumnInput({vectors}, "rank");
-  testTwoColumnInput({vectors}, "dense_rank");
-  testTwoColumnInput({vectors}, "percent_rank");
+  testTwoColumnInput({vectors}, "rank()");
+  testTwoColumnInput({vectors}, "dense_rank()");
+  testTwoColumnInput({vectors}, "percent_rank()");
 }
 
 TEST_F(RankTest, randomInput) {
@@ -88,9 +88,9 @@ TEST_F(RankTest, randomInput) {
       "partition by c0, c1, c2, c3",
   };
 
-  testWindowFunction(vectors, "rank", overClauses);
-  testWindowFunction(vectors, "dense_rank", overClauses);
-  testWindowFunction(vectors, "percent_rank", overClauses);
+  testWindowFunction(vectors, "rank()", overClauses);
+  testWindowFunction(vectors, "dense_rank()", overClauses);
+  testWindowFunction(vectors, "percent_rank()", overClauses);
 }
 
 }; // namespace

--- a/velox/functions/prestosql/window/tests/RowNumberTest.cpp
+++ b/velox/functions/prestosql/window/tests/RowNumberTest.cpp
@@ -33,7 +33,7 @@ TEST_F(RowNumberTest, basic) {
           size, [](auto row) -> int32_t { return row % 7; }),
   });
 
-  testTwoColumnInput({vectors}, "row_number");
+  testTwoColumnInput({vectors}, "row_number()");
 }
 
 TEST_F(RowNumberTest, singlePartition) {
@@ -45,7 +45,7 @@ TEST_F(RowNumberTest, singlePartition) {
       makeFlatVector<int32_t>(size, [](auto row) { return row; }),
   });
 
-  testTwoColumnInput({vectors}, "row_number");
+  testTwoColumnInput({vectors}, "row_number()");
 }
 
 TEST_F(RowNumberTest, randomInput) {
@@ -65,7 +65,7 @@ TEST_F(RowNumberTest, randomInput) {
       "partition by c0, c1, c2, c3",
   };
 
-  testWindowFunction(vectors, "row_number", overClauses);
+  testWindowFunction(vectors, "row_number()", overClauses);
 }
 
 }; // namespace

--- a/velox/functions/prestosql/window/tests/WindowTestBase.cpp
+++ b/velox/functions/prestosql/window/tests/WindowTestBase.cpp
@@ -42,7 +42,7 @@ void WindowTestBase::testWindowFunction(
     const std::vector<RowVectorPtr>& input,
     const std::string& function,
     const std::string& overClause) {
-  auto functionSql = fmt::format("{}() over ({})", function, overClause);
+  auto functionSql = fmt::format("{} over ({})", function, overClause);
 
   SCOPED_TRACE(functionSql);
   auto op = PlanBuilder().values(input).window({functionSql}).planNode();

--- a/velox/functions/prestosql/window/tests/WindowTestBase.h
+++ b/velox/functions/prestosql/window/tests/WindowTestBase.h
@@ -30,6 +30,8 @@ class WindowTestBase : public exec::test::OperatorTestBase {
 
   // This function tests SQL queries for the window function and
   // the specified overClauses with the input RowVectors.
+  // Note : 'function' should be a full window function invocation string
+  // including input parameters and open/close braces. e.g. rank(), ntile(5)
   void testWindowFunction(
       const std::vector<RowVectorPtr>& input,
       const std::string& function,
@@ -39,6 +41,8 @@ class WindowTestBase : public exec::test::OperatorTestBase {
   // It verifies (for the windowFunction) SQL queries with varying over
   // clauses. The over clauses covers all combinations of partition by
   // and order by of the two input columns.
+  // Note : 'windowFunction' should be a full window function invocation string
+  // including input parameters and open/close braces. e.g. rank(), ntile(5)
   void testTwoColumnInput(
       const std::vector<RowVectorPtr>& input,
       const std::string& windowFunction);


### PR DESCRIPTION
The new format is better for functions with input args.