### PR TITLE
Allow fuzzer to persist repro data on disk upon failure

### DIFF
--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -82,8 +82,9 @@ target_link_libraries(
 
 add_library(velox_expression_fuzzer ExpressionFuzzer.cpp)
 
-target_link_libraries(velox_expression_fuzzer velox_type velox_vector_fuzzer
-                      velox_vector_test_lib velox_function_registry)
+target_link_libraries(
+  velox_expression_fuzzer velox_parse_parser velox_type velox_vector_fuzzer
+  velox_vector_test_lib velox_function_registry)
 
 add_executable(velox_expression_fuzzer_test ExpressionFuzzerTest.cpp)
 


### PR DESCRIPTION
### Summary
Adds functionalities to:
* allow fuzzer to persist problematic repro data (both input and result vector) 
  and expression on disk. 
* allow fuzzer to read from on-disk repro data and expression to reproduce 
  error.

### Tests:

Initial run to get failed run, persisting on disk:
`/Users/jtan6/git-repos/presto/presto-native-execution/cmake-build-debug/velox/velox/expression/tests/velox_expression_fuzzer_test --repro_persist_path /tmp/abc --seed 1813425897 --v=1 --logtostderr=1`

Run log:
https://gist.github.com/tanjialiang/c97820551da3dd14a9a73625a1b5615a

Second run with first run's data:
`/Users/jtan6/git-repos/presto/presto-native-execution/cmake-build-debug/velox/velox/expression/tests/velox_expression_fuzzer_test --repro_data_restore_path /tmp/abc/velox_vector_Fh7WYR --repro_sql_restore_path /tmp/abc/velox_sql_ZjSKgw --steps 1 --v=1 --logtostderr=1`
 
Run log:
https://gist.github.com/tanjialiang/f4b4d70a416d1ff0ca280309496cf878