### PR TITLE
Fix hardcoded values in MMapAllocator to work with M1 Mac

### DIFF
--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -486,7 +486,7 @@ bool isAllZero(xsimd::batch<uint64_t> bits) {
 } // namespace
 
 int32_t MmapAllocator::SizeClass::findMappedFreeGroup() {
-  constexpr int32_t kWidth = 4;
+  constexpr int32_t kWidth = SIMD_WORD_COUNT;
   int32_t index = lastLookupIndex_;
   if (index == kNoLastLookup) {
     index = 0;
@@ -522,7 +522,7 @@ xsimd::batch<uint64_t> MmapAllocator::SizeClass::mappedFreeBits(int32_t index) {
 void MmapAllocator::SizeClass::allocateFromMappdFree(
     int32_t numPages,
     Allocation& allocation) {
-  constexpr int32_t kWidth = 4;
+  constexpr int32_t kWidth = SIMD_WORD_COUNT;
   constexpr int32_t kWordsPerGroup = kPagesPerLookupBit / 64;
   int needed = numPages;
   for (;;) {

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -486,7 +486,7 @@ bool isAllZero(xsimd::batch<uint64_t> bits) {
 } // namespace
 
 int32_t MmapAllocator::SizeClass::findMappedFreeGroup() {
-  constexpr int32_t kWidth = SIMD_WORD_COUNT;
+  constexpr int32_t kWidth = xsimd::batch<int64_t>::size;
   int32_t index = lastLookupIndex_;
   if (index == kNoLastLookup) {
     index = 0;
@@ -522,7 +522,7 @@ xsimd::batch<uint64_t> MmapAllocator::SizeClass::mappedFreeBits(int32_t index) {
 void MmapAllocator::SizeClass::allocateFromMappdFree(
     int32_t numPages,
     Allocation& allocation) {
-  constexpr int32_t kWidth = SIMD_WORD_COUNT;
+  constexpr int32_t kWidth = xsimd::batch<int64_t>::size;
   constexpr int32_t kWordsPerGroup = kPagesPerLookupBit / 64;
   int needed = numPages;
   for (;;) {

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -28,6 +28,12 @@
 #include "velox/common/memory/MappedMemory.h"
 #include "velox/common/memory/MmapArena.h"
 
+#if XSIMD_WITH_AVX2
+#define SIMD_WORD_COUNT 4
+#else
+#define SIMD_WORD_COUNT 2
+#endif
+
 namespace facebook::velox::memory {
 
 // Denotes a number of pages of one size class, i.e. one page consists
@@ -189,7 +195,7 @@ class MmapAllocator : public MappedMemory {
     static constexpr int32_t kNoLastLookup = -1;
     // Number of bits in 'mappedPages_' for one bit in
     // 'mappedFreeLookup_'.
-    static constexpr int32_t kPagesPerLookupBit = 512;
+    static constexpr int32_t kPagesPerLookupBit = SIMD_WORD_COUNT * 128;
     // Number of extra 0 uint64's at te end of allocation bitmaps for SIMD
     // checks.
     static constexpr int32_t kSimdTail = 8;

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -28,12 +28,6 @@
 #include "velox/common/memory/MappedMemory.h"
 #include "velox/common/memory/MmapArena.h"
 
-#if XSIMD_WITH_AVX2
-#define SIMD_WORD_COUNT 4
-#else
-#define SIMD_WORD_COUNT 2
-#endif
-
 namespace facebook::velox::memory {
 
 // Denotes a number of pages of one size class, i.e. one page consists
@@ -195,7 +189,8 @@ class MmapAllocator : public MappedMemory {
     static constexpr int32_t kNoLastLookup = -1;
     // Number of bits in 'mappedPages_' for one bit in
     // 'mappedFreeLookup_'.
-    static constexpr int32_t kPagesPerLookupBit = SIMD_WORD_COUNT * 128;
+    static constexpr int32_t kPagesPerLookupBit =
+        xsimd::batch<int64_t>::size * 128;
     // Number of extra 0 uint64's at te end of allocation bitmaps for SIMD
     // checks.
     static constexpr int32_t kSimdTail = 8;


### PR DESCRIPTION
Fix for https://github.com/facebookincubator/velox/issues/2676
