### PR TITLE
Fix lambda-in-try expression

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -37,8 +37,9 @@ add_library(
   SwitchExpr.cpp
   TryExpr.cpp)
 
-target_link_libraries(velox_expression velox_core velox_vector
-                      velox_common_base velox_expression_functions)
+target_link_libraries(
+  velox_expression velox_core velox_vector velox_common_base
+  velox_expression_functions velox_functions_util)
 
 add_subdirectory(type_calculation)
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -116,6 +116,15 @@ class EvalCtx {
       const std::exception_ptr& exceptionPtr,
       ErrorVectorPtr& errorsPtr) const;
 
+  /// Copy std::exception_ptr in fromErrors at rows to the corresponding rows in
+  /// toErrors. If there are existing exceptions in toErrors, these exceptions
+  /// are preserved and those at the corresponding rows in fromErrors are
+  /// ignored.
+  void addErrors(
+      const SelectivityVector& rows,
+      const ErrorVectorPtr& fromErrors,
+      ErrorVectorPtr& toErrors) const;
+
   // Given a mapping from element rows to top-level rows, add element-level
   // errors in errors_ to topLevelErrors.
   void addElementErrorsToTopLevel(

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -116,6 +116,13 @@ class EvalCtx {
       const std::exception_ptr& exceptionPtr,
       ErrorVectorPtr& errorsPtr) const;
 
+  // Given a mapping from element rows to top-level rows, add element-level
+  // errors in errors_ to topLevelErrors.
+  void addElementErrorsToTopLevel(
+      const SelectivityVector& elementRows,
+      const BufferPtr& elementToTopLevelRows,
+      ErrorVectorPtr& topLevelErrors);
+
   // Returns the vector of errors or nullptr if no errors. This is
   // intentionally a raw pointer to signify that the caller may not
   // retain references to this.

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -403,7 +403,8 @@ TEST_F(ArrayWriterTest, nestedArray) {
   array_type array3 = {{1, std::nullopt, 2}};
 
   assertEqualVectors(
-      result, makeNestedArrayVector<int32_t>({{array1, array2, array3}}));
+      result,
+      makeNullableNestedArrayVector<int32_t>({{{array1, array2, array3}}}));
 }
 
 // Creates a matrix of size n*n with numbers 1 to n^2-1 for every input n,
@@ -441,9 +442,9 @@ TEST_F(ArrayWriterTest, nestedArrayE2E) {
   // Build the expected output.
   using matrix_row = std::vector<std::optional<int64_t>>;
   using matrix_type = std::vector<std::optional<matrix_row>>;
-  std::vector<matrix_type> expected;
+  std::vector<std::optional<matrix_type>> expected;
   for (auto k = 1; k <= 10; k++) {
-    auto& expectedMatrix = *expected.insert(expected.end(), matrix_type());
+    auto& expectedMatrix = **expected.insert(expected.end(), matrix_type());
     auto n = k;
     int count = 0;
 
@@ -465,7 +466,7 @@ TEST_F(ArrayWriterTest, nestedArrayE2E) {
     }
   }
 
-  assertEqualVectors(result, makeNestedArrayVector<int64_t>(expected));
+  assertEqualVectors(result, makeNullableNestedArrayVector<int64_t>(expected));
 }
 
 TEST_F(ArrayWriterTest, copyFromEmptyArray) {
@@ -535,7 +536,8 @@ TEST_F(ArrayWriterTest, copyFromNestedArray) {
   array_type array3 = {{1}};
 
   assertEqualVectors(
-      result, makeNestedArrayVector<int64_t>({{array1, array2, array3}}));
+      result,
+      makeNullableNestedArrayVector<int64_t>({{{array1, array2, array3}}}));
 }
 
 auto makeCopyFromTestData() {

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -780,6 +780,14 @@ TEST_F(CastExprTest, castInTry) {
       ARRAY(BIGINT()),
       makeRowVector({BaseVector::wrapInConstant(3, 0, array)}),
       arrayExpected);
+
+  auto nested = makeRowVector({makeNullableNestedArrayVector<StringView>(
+      {{{{{"1"_sv, "2"_sv}}, {{"3"_sv}}, {{"4a"_sv, "5"_sv}}}},
+       {{{{"6"_sv, "7"_sv}}}}})});
+  auto nestedExpected =
+      makeNullableNestedArrayVector<int64_t>({std::nullopt, {{{{6, 7}}}}});
+  evaluateAndVerifyCastInTryDictEncoding(
+      ARRAY(ARRAY(VARCHAR())), ARRAY(ARRAY(BIGINT())), nested, nestedExpected);
 }
 
 TEST_F(CastExprTest, primitiveNullConstant) {

--- a/velox/expression/tests/EvalCtxTest.cpp
+++ b/velox/expression/tests/EvalCtxTest.cpp
@@ -148,3 +148,45 @@ TEST_F(EvalCtxTest, setErrors) {
     }
   }
 }
+
+TEST_F(EvalCtxTest, addErrorsPreserveOldErrors) {
+  // Add two invalid_argument to context.errors().
+  EvalCtx context(&execCtx_);
+  std::invalid_argument argumentError{"invalid argument"};
+  *context.mutableThrowOnError() = false;
+  context.addError(
+      0, std::make_exception_ptr(argumentError), *context.errorsPtr());
+  context.addError(
+      3, std::make_exception_ptr(argumentError), *context.errorsPtr());
+  ASSERT_EQ(BaseVector::countNulls(context.errors()->nulls(), 4), 2);
+
+  // Add two out_of_range to anotherErrors.
+  EvalCtx::ErrorVectorPtr anotherErrors;
+  std::out_of_range rangeError{"out of range"};
+  context.addError(0, std::make_exception_ptr(rangeError), anotherErrors);
+  context.addError(4, std::make_exception_ptr(rangeError), anotherErrors);
+  ASSERT_EQ(BaseVector::countNulls(anotherErrors->nulls(), 5), 3);
+
+  // Add errors in anotherErrors to context.errors() and check that the original
+  // error at index 0 is preserved.
+  SelectivityVector rows{5};
+  context.addErrors(rows, anotherErrors, *context.errorsPtr());
+  ASSERT_EQ(context.errors()->size(), 5);
+  ASSERT_EQ(BaseVector::countNulls(context.errors()->nulls(), 5), 2);
+
+  auto checkErrors = [&](vector_size_t index, const char* message) {
+    ASSERT_GT(context.errors()->size(), index);
+    try {
+      std::static_pointer_cast<std::exception_ptr>(
+          context.errors()->valueAt(index));
+    } catch (const std::exception& e) {
+      ASSERT_NE(std::strstr(e.what(), message), nullptr);
+    }
+  };
+
+  checkErrors(0, "invalid argument");
+  checkErrors(3, "invalid argument");
+  checkErrors(4, "out of range");
+  ASSERT_TRUE(context.errors()->isNullAt(1));
+  ASSERT_TRUE(context.errors()->isNullAt(2));
+}

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(velox_is_null_functions IsNull.cpp)
 
 target_link_libraries(velox_is_null_functions velox_expression)
 
-add_library(velox_functions_util LambdaFunctionUtil.cpp)
+add_library(velox_functions_util LambdaFunctionUtil.cpp RowsTranslationUtil.cpp)
 
 target_link_libraries(velox_functions_util velox_vector velox_common_base)
 

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -17,6 +17,10 @@ add_library(velox_is_null_functions IsNull.cpp)
 
 target_link_libraries(velox_is_null_functions velox_expression)
 
+add_library(velox_functions_util LambdaFunctionUtil.cpp)
+
+target_link_libraries(velox_functions_util velox_vector)
+
 add_library(
   velox_functions_lib
   DateTimeFormatter.cpp

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(velox_is_null_functions velox_expression)
 
 add_library(velox_functions_util LambdaFunctionUtil.cpp)
 
-target_link_libraries(velox_functions_util velox_vector)
+target_link_libraries(velox_functions_util velox_vector velox_common_base)
 
 add_library(
   velox_functions_lib

--- a/velox/functions/lib/LambdaFunctionUtil.h
+++ b/velox/functions/lib/LambdaFunctionUtil.h
@@ -38,34 +38,6 @@ vector_size_t countElements(
   return count;
 }
 
-// Returns SelectivityVector for the nested vector with all rows corresponding
-// to specified top-level rows selected. The optional topLevelRowMapping is
-// used to pass the dictionary indices if the topLevelVector is dictionary
-// encoded.
-template <typename T>
-SelectivityVector toElementRows(
-    vector_size_t size,
-    const SelectivityVector& topLevelRows,
-    const T* topLevelVector,
-    const vector_size_t* topLevelRowMapping = nullptr) {
-  auto rawNulls = topLevelVector->rawNulls();
-  auto rawSizes = topLevelVector->rawSizes();
-  auto rawOffsets = topLevelVector->rawOffsets();
-
-  SelectivityVector elementRows(size, false);
-  topLevelRows.applyToSelected([&](vector_size_t row) {
-    auto index = topLevelRowMapping ? topLevelRowMapping[row] : row;
-    if (rawNulls && bits::isBitNull(rawNulls, index)) {
-      return;
-    }
-    auto size = rawSizes[index];
-    auto offset = rawOffsets[index];
-    elementRows.setValidRange(offset, offset + size, true);
-  });
-  elementRows.updateBounds();
-  return elementRows;
-}
-
 // Returns an array of indices that allows aligning captures with the nested
 // elements of an array or vector. For each top-level row, the index equal to
 // the row number is repeated for each of the nested rows.

--- a/velox/functions/lib/RowsTranslationUtil.cpp
+++ b/velox/functions/lib/RowsTranslationUtil.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/lib/RowsTranslationUtil.h"
+
+namespace facebook::velox::functions {
+
+BufferPtr getElementToTopLevelRows(
+    vector_size_t numElements,
+    const SelectivityVector& topLevelRows,
+    const vector_size_t* rawOffsets,
+    const vector_size_t* rawSizes,
+    const uint64_t* rawNulls,
+    memory::MemoryPool* pool) {
+  auto toTopLevelRows = allocateIndices(numElements, pool);
+  auto rawToTopLevelRows = toTopLevelRows->asMutable<vector_size_t>();
+  topLevelRows.applyToSelected([&](vector_size_t row) {
+    if (rawNulls && bits::isBitNull(rawNulls, row)) {
+      return;
+    }
+    auto size = rawSizes[row];
+    auto offset = rawOffsets[row];
+    for (int i = 0; i < size; ++i) {
+      rawToTopLevelRows[offset + i] = row;
+    }
+  });
+  return toTopLevelRows;
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/RowsTranslationUtil.h
+++ b/velox/functions/lib/RowsTranslationUtil.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/vector/SelectivityVector.h"
+
+namespace facebook::velox::functions {
+
+/// Returns SelectivityVector for the nested vector with all rows corresponding
+/// to specified top-level rows selected. The optional topLevelRowMapping is
+/// used to pass the dictionary indices if the topLevelVector is dictionary
+/// encoded.
+template <typename T>
+SelectivityVector toElementRows(
+    vector_size_t size,
+    const SelectivityVector& topLevelRows,
+    const T* topLevelVector,
+    const vector_size_t* topLevelRowMapping = nullptr) {
+  auto rawNulls = topLevelVector->rawNulls();
+  auto rawSizes = topLevelVector->rawSizes();
+  auto rawOffsets = topLevelVector->rawOffsets();
+
+  SelectivityVector elementRows(size, false);
+  topLevelRows.applyToSelected([&](vector_size_t row) {
+    auto index = topLevelRowMapping ? topLevelRowMapping[row] : row;
+    if (rawNulls && bits::isBitNull(rawNulls, index)) {
+      return;
+    }
+    auto size = rawSizes[index];
+    auto offset = rawOffsets[index];
+    elementRows.setValidRange(offset, offset + size, true);
+  });
+  elementRows.updateBounds();
+  return elementRows;
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/ArrayDistinct.cpp
+++ b/velox/functions/prestosql/ArrayDistinct.cpp
@@ -19,7 +19,7 @@
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 
 namespace facebook::velox::functions {
 namespace {

--- a/velox/functions/prestosql/ArrayDuplicates.cpp
+++ b/velox/functions/prestosql/ArrayDuplicates.cpp
@@ -20,7 +20,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/ComparatorUtil.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 
 namespace facebook::velox::functions {
 namespace {

--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 
 namespace facebook::velox::functions {
 namespace {

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -19,7 +19,7 @@
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 
 namespace facebook::velox::functions {
 namespace {

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -63,7 +63,8 @@ target_link_libraries(
   velox_expression
   md5
   velox_type_tz
-  velox_presto_types)
+  velox_presto_types
+  velox_functions_util)
 
 set_property(TARGET velox_functions_prestosql_impl PROPERTY JOB_POOL_COMPILE
                                                             high_memory_pool)

--- a/velox/functions/prestosql/FilterFunctions.cpp
+++ b/velox/functions/prestosql/FilterFunctions.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/FunctionVector.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/MapZipWith.cpp
+++ b/velox/functions/prestosql/MapZipWith.cpp
@@ -17,6 +17,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/FunctionVector.h"
 
 namespace facebook::velox::functions {
@@ -150,6 +151,14 @@ class MapZipWithFunction : public exec::VectorFunction {
 
     VectorPtr mergedValues;
 
+    auto elementToTopLevelRows = getElementToTopLevelRows(
+        index,
+        rows,
+        mergeResults.rawNewOffsets,
+        mergeResults.rawNewSizes,
+        nullptr,
+        context.pool());
+
     // Loop over lambda functions and apply these to (mergedKeys,
     // mergedLeftValues, mergedRightValues). In most cases there will be only
     // one function and the loop will run once.
@@ -180,6 +189,7 @@ class MapZipWithFunction : public exec::VectorFunction {
           wrapCapture,
           &context,
           lambdaArgs,
+          elementToTopLevelRows,
           &mergedValues);
     }
 

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -147,6 +147,7 @@ class ReduceFunction : public exec::VectorFunction {
             nullptr,
             &context,
             lambdaArgs,
+            nullptr,
             &partialResult);
         state = partialResult;
         n++;
@@ -163,6 +164,7 @@ class ReduceFunction : public exec::VectorFunction {
           nullptr,
           &context,
           lambdaArgs,
+          nullptr,
           &result);
     }
   }

--- a/velox/functions/prestosql/Transform.cpp
+++ b/velox/functions/prestosql/Transform.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/FunctionVector.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/Transform.cpp
+++ b/velox/functions/prestosql/Transform.cpp
@@ -59,6 +59,9 @@ class TransformFunction : public exec::VectorFunction {
     // transformed elements
     VectorPtr newElements;
 
+    auto elementToTopLevelRows = getElementToTopLevelRows(
+        newNumElements, rows, flatArray.get(), context.pool());
+
     // loop over lambda functions and apply these to elements of the base array;
     // in most cases there will be only one function and the loop will run once
     auto it = args[1]->asUnchecked<FunctionVector>()->iterator(&rows);
@@ -74,6 +77,7 @@ class TransformFunction : public exec::VectorFunction {
           wrapCapture,
           &context,
           lambdaArgs,
+          elementToTopLevelRows,
           &newElements);
     }
 

--- a/velox/functions/prestosql/TransformKeys.cpp
+++ b/velox/functions/prestosql/TransformKeys.cpp
@@ -59,6 +59,9 @@ class TransformKeysFunction : public exec::VectorFunction {
 
     VectorPtr transformedKeys;
 
+    auto elementToTopLevelRows =
+        getElementToTopLevelRows(numKeys, rows, flatMap.get(), context.pool());
+
     // Loop over lambda functions and apply these to keys of the map.
     // In most cases there will be only one function and the loop will run once.
     auto it = args[1]->asUnchecked<FunctionVector>()->iterator(&rows);
@@ -74,6 +77,7 @@ class TransformKeysFunction : public exec::VectorFunction {
           wrapCapture,
           &context,
           lambdaArgs,
+          elementToTopLevelRows,
           &transformedKeys);
     }
 

--- a/velox/functions/prestosql/TransformKeys.cpp
+++ b/velox/functions/prestosql/TransformKeys.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/FunctionVector.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/TransformValues.cpp
+++ b/velox/functions/prestosql/TransformValues.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/FunctionVector.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/TransformValues.cpp
+++ b/velox/functions/prestosql/TransformValues.cpp
@@ -59,6 +59,9 @@ class TransformValuesFunction : public exec::VectorFunction {
 
     VectorPtr transformedValues;
 
+    auto elementToTopLevelRows = getElementToTopLevelRows(
+        numValues, rows, flatMap.get(), context.pool());
+
     // Loop over lambda functions and apply these to values of the map.
     // In most cases there will be only one function and the loop will run once.
     auto it = args[1]->asUnchecked<FunctionVector>()->iterator(&rows);
@@ -74,6 +77,7 @@ class TransformValuesFunction : public exec::VectorFunction {
           wrapCapture,
           &context,
           lambdaArgs,
+          elementToTopLevelRows,
           &transformedValues);
     }
 

--- a/velox/functions/prestosql/WidthBucketArray.cpp
+++ b/velox/functions/prestosql/WidthBucketArray.cpp
@@ -16,7 +16,7 @@
 #include "velox/functions/prestosql/WidthBucketArray.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/DecodedVector.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/ZipWith.cpp
+++ b/velox/functions/prestosql/ZipWith.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/FunctionVector.h"
 
 namespace facebook::velox::functions {
@@ -95,6 +96,9 @@ class ZipWithFunction : public exec::VectorFunction {
 
     VectorPtr newElements;
 
+    auto elementToTopLevelRows = getElementToTopLevelRows(
+        numResultElements, rows, rawOffsets, rawSizes, nullptr, context.pool());
+
     // Loop over lambda functions and apply these to (leftElements,
     // rightElements). In most cases there will be only one function and the
     // loop will run once.
@@ -135,6 +139,7 @@ class ZipWithFunction : public exec::VectorFunction {
           wrapCapture,
           &context,
           lambdaArgs,
+          elementToTopLevelRows,
           &newElements);
     }
 

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -44,8 +44,13 @@ add_library(
   RegisterAggregateFunctions.cpp)
 
 target_link_libraries(
-  velox_aggregates velox_common_hyperloglog velox_exec velox_presto_serializer
-  velox_functions_lib ${FOLLY_WITH_DEPENDENCIES})
+  velox_aggregates
+  velox_common_hyperloglog
+  velox_exec
+  velox_presto_serializer
+  velox_functions_lib
+  velox_functions_util
+  ${FOLLY_WITH_DEPENDENCIES})
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/aggregates/PrestoHasher.cpp
+++ b/velox/functions/prestosql/aggregates/PrestoHasher.cpp
@@ -18,7 +18,7 @@
 #define XXH_INLINE_ALL
 #include <xxhash.h>
 
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::aggregate {

--- a/velox/functions/prestosql/tests/ArrayCombinationsTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayCombinationsTest.cpp
@@ -38,11 +38,11 @@ class ArrayCombinationsTest : public FunctionBaseTest {
     auto arrayVector = makeArrayVector<T>(
         {{0, 1, 2, 3}, {0, 1, 2, 3}, {0, 1, 2, 3}, {0, 1, 2, 3}});
     auto comboLengthVector = makeFlatVector<int32_t>({0, 3, 4, 5});
-    auto expected = makeNestedArrayVector<T>(
-        {{{std::vector<std::optional<T>>()}},
-         {{{0, 1, 2}}, {{0, 1, 3}}, {{0, 2, 3}}, {{1, 2, 3}}},
-         {{{0, 1, 2, 3}}},
-         {}});
+    auto expected = makeNullableNestedArrayVector<T>(
+        {{{{std::vector<std::optional<T>>()}}},
+         {{{{0, 1, 2}}, {{0, 1, 3}}, {{0, 2, 3}}, {{1, 2, 3}}}},
+         {{{{0, 1, 2, 3}}}},
+         {{}}});
     testExpr(
         expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
   }
@@ -55,20 +55,20 @@ class ArrayCombinationsTest : public FunctionBaseTest {
          {0, 1, std::nullopt, 3},
          {0, 1, std::nullopt, 3}});
     auto comboLengthVector = makeFlatVector<int32_t>({0, 3, 4, 5});
-    auto expected = makeNestedArrayVector<T>({
-        {
+    auto expected = makeNullableNestedArrayVector<T>({
+        {{
             {std::vector<std::optional<T>>()},
-        },
-        {
+        }},
+        {{
             {{0, 1, std::nullopt}},
             {{0, 1, 3}},
             {{0, std::nullopt, 3}},
             {{1, std::nullopt, 3}},
-        },
-        {
+        }},
+        {{
             {{0, 1, std::nullopt, 3}},
-        },
-        {},
+        }},
+        {{}},
     });
     testExpr(
         expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
@@ -135,17 +135,17 @@ TEST_F(ArrayCombinationsTest, inlineVarcharArrays) {
   });
   auto comboLengthVector = makeFlatVector<int32_t>({0, 1, 1, 2, 4, 5});
 
-  auto expected = makeNestedArrayVector<S>(
-      {{{std::vector<std::optional<S>>()}},
-       {{{""}}},
-       {{{std::optional<S>(std::nullopt)}}},
-       {{{"aa", std::nullopt}}, {{"aa", "bb"}}, {{std::nullopt, "bb"}}},
-       {{{"bb", "aa", "cc", "aa"}},
-        {{"bb", "aa", "cc", "ddd"}},
-        {{"bb", "aa", "aa", "ddd"}},
-        {{"bb", "cc", "aa", "ddd"}},
-        {{"aa", "cc", "aa", "ddd"}}},
-       {}});
+  auto expected = makeNullableNestedArrayVector<S>(
+      {{{{std::vector<std::optional<S>>()}}},
+       {{{{""}}}},
+       {{{{std::optional<S>(std::nullopt)}}}},
+       {{{{"aa", std::nullopt}}, {{"aa", "bb"}}, {{std::nullopt, "bb"}}}},
+       {{{{"bb", "aa", "cc", "aa"}},
+         {{"bb", "aa", "cc", "ddd"}},
+         {{"bb", "aa", "aa", "ddd"}},
+         {{"bb", "cc", "aa", "ddd"}},
+         {{"aa", "cc", "aa", "ddd"}}}},
+       {{}}});
   testExpr(expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
 }
 
@@ -165,34 +165,34 @@ TEST_F(ArrayCombinationsTest, varcharArrays) {
   });
   auto comboLengthVector = makeFlatVector<int32_t>({0, 1, 1, 2, 4, 5});
 
-  auto expected = makeNestedArrayVector<S>(
-      {{{std::vector<std::optional<S>>()}},
-       {{{""}}},
-       {{{std::optional<S>(std::nullopt)}}},
-       {{{"red shiny car ahead", std::nullopt}},
-        {{"red shiny car ahead", "blue clear sky above"}},
-        {{std::nullopt, "blue clear sky above"}}},
-       {{{"blue clear sky above",
-          "red shiny car ahead",
-          "yellow rose flowers",
-          "red shiny car ahead"}},
-        {{"blue clear sky above",
-          "red shiny car ahead",
-          "yellow rose flowers",
-          "purple is an elegant color"}},
-        {{"blue clear sky above",
-          "red shiny car ahead",
-          "red shiny car ahead",
-          "purple is an elegant color"}},
-        {{"blue clear sky above",
-          "yellow rose flowers",
-          "red shiny car ahead",
-          "purple is an elegant color"}},
-        {{"red shiny car ahead",
-          "yellow rose flowers",
-          "red shiny car ahead",
-          "purple is an elegant color"}}},
-       {}});
+  auto expected = makeNullableNestedArrayVector<S>(
+      {{{{std::vector<std::optional<S>>()}}},
+       {{{{""}}}},
+       {{{{std::optional<S>(std::nullopt)}}}},
+       {{{{"red shiny car ahead", std::nullopt}},
+         {{"red shiny car ahead", "blue clear sky above"}},
+         {{std::nullopt, "blue clear sky above"}}}},
+       {{{{"blue clear sky above",
+           "red shiny car ahead",
+           "yellow rose flowers",
+           "red shiny car ahead"}},
+         {{"blue clear sky above",
+           "red shiny car ahead",
+           "yellow rose flowers",
+           "purple is an elegant color"}},
+         {{"blue clear sky above",
+           "red shiny car ahead",
+           "red shiny car ahead",
+           "purple is an elegant color"}},
+         {{"blue clear sky above",
+           "yellow rose flowers",
+           "red shiny car ahead",
+           "purple is an elegant color"}},
+         {{"red shiny car ahead",
+           "yellow rose flowers",
+           "red shiny car ahead",
+           "purple is an elegant color"}}}},
+       {{}}});
   testExpr(expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
 }
 
@@ -206,16 +206,16 @@ TEST_F(ArrayCombinationsTest, boolNullableArrays) {
   });
   auto comboLengthVector = makeFlatVector<int32_t>({0, 1, 2, 4, 5});
 
-  auto expected = makeNestedArrayVector<bool>(
-      {{{std::vector<std::optional<bool>>()}},
-       {{{std::optional<bool>(std::nullopt)}}},
-       {{{true, std::nullopt}}, {{true, false}}, {{std::nullopt, false}}},
-       {{{false, true, false, true}},
-        {{false, true, false, true}},
-        {{false, true, true, true}},
-        {{false, false, true, true}},
-        {{true, false, true, true}}},
-       {}});
+  auto expected = makeNullableNestedArrayVector<bool>(
+      {{{{std::vector<std::optional<bool>>()}}},
+       {{{{std::optional<bool>(std::nullopt)}}}},
+       {{{{true, std::nullopt}}, {{true, false}}, {{std::nullopt, false}}}},
+       {{{{false, true, false, true}},
+         {{false, true, false, true}},
+         {{false, true, true, true}},
+         {{false, false, true, true}},
+         {{true, false, true, true}}}},
+       {{}}});
   testExpr(expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
 }
 
@@ -229,15 +229,15 @@ TEST_F(ArrayCombinationsTest, boolArrays) {
   });
   auto comboLengthVector = makeFlatVector<int32_t>({0, 1, 2, 4, 5});
 
-  auto expected = makeNestedArrayVector<bool>(
-      {{{std::vector<std::optional<bool>>()}},
-       {{{true}}},
-       {{{true, true}}, {{true, false}}, {{true, false}}},
-       {{{false, true, false, true}},
-        {{false, true, false, true}},
-        {{false, true, true, true}},
-        {{false, false, true, true}},
-        {{true, false, true, true}}},
-       {}});
+  auto expected = makeNullableNestedArrayVector<bool>(
+      {{{{std::vector<std::optional<bool>>()}}},
+       {{{{true}}}},
+       {{{{true, true}}, {{true, false}}, {{true, false}}}},
+       {{{{false, true, false, true}},
+         {{false, true, false, true}},
+         {{false, true, true, true}},
+         {{false, false, true, true}},
+         {{true, false, true, true}}}},
+       {{}}});
   testExpr(expected, "combinations(C0, C1)", {arrayVector, comboLengthVector});
 }

--- a/velox/functions/prestosql/tests/ArrayFilterTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayFilterTest.cpp
@@ -212,3 +212,24 @@ TEST_F(ArrayFilterTest, dictionaryWithDuplicates) {
 
   assertEqualVectors(expectedResult, result);
 }
+
+TEST_F(ArrayFilterTest, try) {
+  auto data = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2},
+          {3, 0, 5},
+          {6, 7, 8, 9},
+          {10, 11, 12, 13},
+      }),
+  });
+
+  ASSERT_THROW(
+      evaluate<BaseVector>("filter(c0, x -> (100 / x > 0))", data),
+      std::exception);
+
+  auto result =
+      evaluate<BaseVector>("try(filter(c0, x -> (100 / x > 0)))", data);
+  auto expected = vectorMaker_.arrayVectorNullable<int64_t>(
+      {{{1, 2}}, std::nullopt, {{6, 7, 8, 9}}, {{10, 11, 12, 13}}});
+  assertEqualVectors(expected, result);
+}

--- a/velox/functions/prestosql/tests/ArrayPositionTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayPositionTest.cpp
@@ -385,22 +385,18 @@ TEST_F(ArrayPositionTest, row) {
 }
 
 TEST_F(ArrayPositionTest, array) {
-  auto O = [](const std::vector<std::optional<int64_t>>& data) {
-    return std::make_optional(data);
-  };
-
   std::vector<std::optional<int64_t>> a{1, 2, 3};
   std::vector<std::optional<int64_t>> b{4, 5};
   std::vector<std::optional<int64_t>> c{6, 7, 8};
   std::vector<std::optional<int64_t>> d{1, 2};
   std::vector<std::optional<int64_t>> e{4, 3};
-  auto arrayVector = makeNestedArrayVector<int64_t>(
-      {{O(a), O(b), O(c)},
-       {O(d), O(e)},
-       {O(d), O(a), O(b)},
-       {O(c), O(e)},
-       {O({})},
-       {O({std::nullopt})}});
+  auto arrayVector = makeNullableNestedArrayVector<int64_t>(
+      {{{{a}, {b}, {c}}},
+       {{{d}, {e}}},
+       {{{d}, {a}, {b}}},
+       {{{c}, {e}}},
+       {{{{}}}},
+       {{{std::vector<std::optional<int64_t>>{std::nullopt}}}}});
 
   auto testPositionOfArray =
       [&](const TwoDimVector<int64_t>& search,
@@ -683,22 +679,18 @@ TEST_F(ArrayPositionTest, rowWithInstance) {
 }
 
 TEST_F(ArrayPositionTest, arrayWithInstance) {
-  auto O = [](const std::vector<std::optional<int64_t>>& data) {
-    return std::make_optional(data);
-  };
-
   std::vector<std::optional<int64_t>> a{1, 2, 3};
   std::vector<std::optional<int64_t>> b{4, 5};
   std::vector<std::optional<int64_t>> c{6, 7, 8};
   std::vector<std::optional<int64_t>> d{1, 2};
   std::vector<std::optional<int64_t>> e{4, 3};
-  auto arrayVector = makeNestedArrayVector<int64_t>(
-      {{O(a), O(b), O(a)},
-       {O(d), O(e)},
-       {O(d), O(a), O(a)},
-       {O(c), O(c)},
-       {O({})},
-       {O({std::nullopt})}});
+  auto arrayVector = makeNullableNestedArrayVector<int64_t>(
+      {{{{a}, {b}, {a}}},
+       {{{d}, {e}}},
+       {{{d}, {a}, {a}}},
+       {{{c}, {c}}},
+       {{{{}}}},
+       {{{std::vector<std::optional<int64_t>>{std::nullopt}}}}});
 
   auto testPositionOfArray =
       [&](const TwoDimVector<int64_t>& search,

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -298,12 +298,13 @@ ArrayVectorPtr ArraySortTest::arrayVector<TestMapType>(
 template <>
 ArrayVectorPtr ArraySortTest::arrayVector<TestArrayType>(
     const std::vector<std::optional<TestArrayType>>& inputValues) {
-  std::vector<std::vector<std::optional<TestArrayType>>> inputVectors;
+  std::vector<std::optional<std::vector<std::optional<TestArrayType>>>>
+      inputVectors;
   inputVectors.reserve(numVectors_);
   for (int i = 0; i < numVectors_; ++i) {
     inputVectors.push_back(inputValues);
   }
-  return makeNestedArrayVector<StringView>(inputVectors);
+  return makeNullableNestedArrayVector<StringView>(inputVectors);
 }
 
 template <>

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -367,7 +367,8 @@ TEST_F(ComparisonsTest, eqNestedComplex) {
   array_type array2 = {{}};
   array_type array3 = {{1, 100, 2}};
 
-  auto vector1 = makeNestedArrayVector<int64_t>({{array1, array2, array3}});
+  auto vector1 =
+      makeNullableNestedArrayVector<int64_t>({{{array1, array2, array3}}});
   auto vector2 = makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6});
   auto vector3 = makeMapVector<int64_t, int64_t>({{{1, 2}, {3, 4}}});
   auto row1 = makeRowVector({vector1, vector2, vector3});

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -973,11 +973,11 @@ TEST_F(JsonCastTest, toNested) {
   auto array = makeNullableFlatVector<Json>(
       {R"([[1,2],[3]])"_sv, R"([[null,null,4]])"_sv, "[[]]"_sv, "[]"_sv},
       JSON());
-  auto arrayExpected = makeNestedArrayVector<StringView>(
-      {{{{"1"_sv, "2"_sv}}, {{"3"_sv}}},
-       {{{std::nullopt, std::nullopt, "4"_sv}}},
-       {{{}}},
-       {}});
+  auto arrayExpected = makeNullableNestedArrayVector<StringView>(
+      {{{{{"1"_sv, "2"_sv}}, {{"3"_sv}}}},
+       {{{{std::nullopt, std::nullopt, "4"_sv}}}},
+       {{{{}}}},
+       {{}}});
 
   testCast<ComplexType>(JSON(), ARRAY(ARRAY(VARCHAR())), array, arrayExpected);
 

--- a/velox/functions/prestosql/tests/MapZipWithTest.cpp
+++ b/velox/functions/prestosql/tests/MapZipWithTest.cpp
@@ -293,4 +293,29 @@ TEST_F(MapZipWithTest, fuzz) {
     assertEqualVectors(expected, result);
   }
 }
+
+TEST_F(MapZipWithTest, try) {
+  auto data = makeRowVector(
+      {makeMapVector<int64_t, int64_t>(
+           {{{1, 10}, {3, 30}, {2, 20}}, {{3, 30}, {4, 40}}, {{5, 50}}, {}}),
+       makeMapVector<int64_t, int64_t>(
+           {{{1, 1}, {2, 2}, {3, 0}},
+            {{3, 30}, {4, 40}, {0, 0}},
+            {},
+            {{2, 2}}})});
+
+  ASSERT_THROW(
+      evaluate("map_zip_with(c0, c1, (k, v1, v2) -> v1 / v2)", data),
+      std::exception);
+
+  auto result =
+      evaluate("try(map_zip_with(c0, c1, (k, v1, v2) -> v1 / v2))", data);
+
+  auto expected = makeNullableMapVector<int64_t, int64_t>(
+      {std::nullopt,
+       {{{0, std::nullopt}, {3, 1}, {4, 1}}},
+       {{{5, std::nullopt}}},
+       {{{2, std::nullopt}}}});
+  assertEqualVectors(expected, result);
+}
 } // namespace

--- a/velox/functions/prestosql/tests/TransformKeysTest.cpp
+++ b/velox/functions/prestosql/tests/TransformKeysTest.cpp
@@ -201,3 +201,21 @@ TEST_F(TransformKeysTest, dictionaryWithDuplicates) {
 
   assertEqualVectors(expectedResult, result);
 }
+
+TEST_F(TransformKeysTest, try) {
+  auto input = makeRowVector({
+      makeMapVector<int64_t, int64_t>(
+          {{{1, 2}, {3, 9}}, {{4, 16}, {5, 25}}, {{6, 36}, {0, 10}}}),
+  });
+
+  ASSERT_THROW(
+      evaluate<MapVector>("transform_keys(c0, (k, v) -> v / k)", input),
+      std::exception);
+
+  auto result =
+      evaluate<MapVector>("try(transform_keys(c0, (k, v) -> v / k))", input);
+
+  auto expectedResult = makeNullableMapVector<int64_t, int64_t>(
+      {{{{2, 2}, {3, 9}}}, {{{4, 16}, {5, 25}}}, std::nullopt});
+  assertEqualVectors(expectedResult, result);
+}

--- a/velox/functions/prestosql/tests/TransformTest.cpp
+++ b/velox/functions/prestosql/tests/TransformTest.cpp
@@ -135,3 +135,27 @@ TEST_F(TransformTest, dictionaryWithDuplicates) {
 
   assertEqualVectors(expectedResult, result);
 }
+
+TEST_F(TransformTest, try) {
+  auto input = makeRowVector({
+      makeArrayVector<int64_t>({
+          {6, 4},
+          {2, 0},
+          {-2, -4},
+      }),
+  });
+
+  ASSERT_THROW(
+      evaluate<ArrayVector>("transform(c0, x -> x / (x - 2))", input),
+      std::exception);
+
+  auto result =
+      evaluate<ArrayVector>("try(transform(c0, x -> x / (x - 2)))", input);
+
+  auto expectedResult = vectorMaker_.arrayVectorNullable<int64_t>({
+      {{1, 2}},
+      std::nullopt,
+      {{0, 0}},
+  });
+  assertEqualVectors(expectedResult, result);
+}

--- a/velox/functions/prestosql/tests/TransformValuesTest.cpp
+++ b/velox/functions/prestosql/tests/TransformValuesTest.cpp
@@ -184,3 +184,21 @@ TEST_F(TransformValuesTest, dictionaryWithDuplicates) {
 
   assertEqualVectors(expectedResult, result);
 }
+
+TEST_F(TransformValuesTest, try) {
+  auto input = makeRowVector({
+      makeMapVector<int64_t, int64_t>(
+          {{{1, 2}, {3, 9}}, {{4, 16}, {5, 25}}, {{6, 36}, {0, 10}}}),
+  });
+
+  ASSERT_THROW(
+      evaluate<MapVector>("transform_values(c0, (k, v) -> v / k)", input),
+      std::exception);
+
+  auto result =
+      evaluate<MapVector>("try(transform_values(c0, (k, v) -> v / k))", input);
+
+  auto expectedResult = makeNullableMapVector<int64_t, int64_t>(
+      {{{{1, 2}, {3, 3}}}, {{{4, 4}, {5, 5}}}, std::nullopt});
+  assertEqualVectors(expectedResult, result);
+}

--- a/velox/functions/prestosql/tests/ZipWithTest.cpp
+++ b/velox/functions/prestosql/tests/ZipWithTest.cpp
@@ -380,4 +380,23 @@ TEST_F(ZipWithTest, fuzzVariableLengthWithNulls) {
     assertEqualVectors(expectedResult, result);
   }
 }
+
+TEST_F(ZipWithTest, try) {
+  auto data = makeRowVector(
+      {makeArrayVector<int64_t>({{1, 2, 3}, {0, 5}, {6, 7, 0}, {}}),
+       makeArrayVector<int64_t>(
+           {{10, 20, 30}, {40, 50, 60}, {60, 70}, {100, 110}})});
+
+  ASSERT_THROW(
+      evaluate("zip_with(c0, c1, (x, y) -> y / x)", data), std::exception);
+
+  auto result = evaluate("try(zip_with(c0, c1, (x, y) -> y / x))", data);
+
+  auto expected = vectorMaker_.arrayVectorNullable<int64_t>(
+      {{{10, 10, 10}},
+       std::nullopt,
+       {{10, 10, std::nullopt}},
+       {{std::nullopt, std::nullopt}}});
+  assertEqualVectors(expected, result);
+}
 } // namespace

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -13,4 +13,5 @@
 # limitations under the License.
 add_library(velox_presto_types JsonType.cpp)
 
-target_link_libraries(velox_presto_types velox_memory velox_expression)
+target_link_libraries(velox_presto_types velox_memory velox_expression
+                      velox_functions_util)

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -27,7 +27,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/StringWriter.h"
 #include "velox/expression/VectorWriters.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox {

--- a/velox/functions/sparksql/ArraySort.cpp
+++ b/velox/functions/sparksql/ArraySort.cpp
@@ -20,7 +20,7 @@
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/functions/sparksql/Comparisons.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(
 
 target_link_libraries(
   velox_functions_spark velox_functions_lib velox_functions_prestosql_impl
-  velox_is_null_functions ${FOLLY_WITH_DEPENDENCIES})
+  velox_is_null_functions velox_functions_util ${FOLLY_WITH_DEPENDENCIES})
 
 set_property(TARGET velox_functions_spark PROPERTY JOB_POOL_COMPILE
                                                    high_memory_pool)

--- a/velox/functions/sparksql/tests/ArraySortTest.cpp
+++ b/velox/functions/sparksql/tests/ArraySortTest.cpp
@@ -100,8 +100,8 @@ TEST_F(ArraySortTest, bool) {
 }
 
 TEST_F(ArraySortTest, array) {
-  auto input = makeNestedArrayVector(arrayInput());
-  auto expected = makeNestedArrayVector(arrayAscNullLargest());
+  auto input = makeNullableNestedArrayVector(arrayInput());
+  auto expected = makeNullableNestedArrayVector(arrayAscNullLargest());
   testArraySort(input, expected);
 }
 

--- a/velox/functions/sparksql/tests/ArraySortTestData.h
+++ b/velox/functions/sparksql/tests/ArraySortTestData.h
@@ -57,6 +57,15 @@ inline NestedVector<T> reverseNested(NestedVector<T> data) {
 }
 
 template <typename T>
+inline std::vector<std::optional<std::vector<T>>> reverseNested(
+    std::vector<std::optional<std::vector<T>>> data) {
+  for (auto& v : data) {
+    std::reverse(v->begin(), v->end());
+  }
+  return data;
+}
+
+template <typename T>
 inline NestedVector<std::optional<T>> intInput() {
   return NestedVector<std::optional<T>>{
       {},
@@ -227,44 +236,47 @@ inline NestedVector<std::optional<bool>> boolAscNullLargest() {
   };
 }
 
-inline NestedVector<std::optional<std::vector<std::optional<int32_t>>>>
+inline std::vector<std::optional<
+    std::vector<std::optional<std::vector<std::optional<int32_t>>>>>>
 arrayInput() {
   using A = std::vector<std::optional<int32_t>>;
-  return NestedVector<std::optional<A>>{
+  return std::vector<std::optional<std::vector<std::optional<A>>>>{
       // Empty.
-      {},
+      {{}},
       // All nulls.
-      {std::nullopt, std::nullopt},
+      {{std::nullopt, std::nullopt}},
       // Same prefix.
-      {A({1, 3}), A({2, 1}), A({1, 3, 5})},
+      {{A({1, 3}), A({2, 1}), A({1, 3, 5})}},
       // Top level null elements.
-      {A({1, 3}), std::nullopt, A({2, 1})},
+      {{A({1, 3}), std::nullopt, A({2, 1})}},
       // Array with null values.
-      {A({std::nullopt, 6}), A({3, std::nullopt}), A({std::nullopt, 8})},
+      {{A({std::nullopt, 6}), A({3, std::nullopt}), A({std::nullopt, 8})}},
   };
 }
 
-inline NestedVector<std::optional<std::vector<std::optional<int32_t>>>>
+inline std::vector<std::optional<
+    std::vector<std::optional<std::vector<std::optional<int32_t>>>>>>
 arrayAscNullSmallest() {
   using A = std::vector<std::optional<int32_t>>;
-  return NestedVector<std::optional<A>>{
-      {},
-      {std::nullopt, std::nullopt},
-      {A({1, 3}), A({1, 3, 5}), A({2, 1})},
-      {std::nullopt, A({1, 3}), A({2, 1})},
-      {A({std::nullopt, 6}), A({std::nullopt, 8}), A({3, std::nullopt})},
+  return std::vector<std::optional<std::vector<std::optional<A>>>>{
+      {{}},
+      {{std::nullopt, std::nullopt}},
+      {{A({1, 3}), A({1, 3, 5}), A({2, 1})}},
+      {{std::nullopt, A({1, 3}), A({2, 1})}},
+      {{A({std::nullopt, 6}), A({std::nullopt, 8}), A({3, std::nullopt})}},
   };
 }
 
-inline NestedVector<std::optional<std::vector<std::optional<int32_t>>>>
+inline std::vector<std::optional<
+    std::vector<std::optional<std::vector<std::optional<int32_t>>>>>>
 arrayAscNullLargest() {
   using A = std::vector<std::optional<int32_t>>;
-  return NestedVector<std::optional<A>>{
-      {},
-      {std::nullopt, std::nullopt},
-      {A({1, 3}), A({1, 3, 5}), A({2, 1})},
-      {A({1, 3}), A({2, 1}), std::nullopt},
-      {A({3, std::nullopt}), A({std::nullopt, 6}), A({std::nullopt, 8})},
+  return std::vector<std::optional<std::vector<std::optional<A>>>>{
+      {{}},
+      {{std::nullopt, std::nullopt}},
+      {{A({1, 3}), A({1, 3, 5}), A({2, 1})}},
+      {{A({1, 3}), A({2, 1}), std::nullopt}},
+      {{A({3, std::nullopt}), A({std::nullopt, 6}), A({std::nullopt, 8})}},
   };
 }
 

--- a/velox/functions/sparksql/tests/SortArrayTest.cpp
+++ b/velox/functions/sparksql/tests/SortArrayTest.cpp
@@ -145,12 +145,12 @@ TEST_F(SortArrayTest, bool) {
 }
 
 TEST_F(SortArrayTest, array) {
-  auto input = makeNestedArrayVector(arrayInput());
+  auto input = makeNullableNestedArrayVector(arrayInput());
   auto expected = arrayAscNullSmallest();
   testSortArray(
       input,
-      makeNestedArrayVector(expected),
-      makeNestedArrayVector(reverseNested(expected)));
+      makeNullableNestedArrayVector(expected),
+      makeNullableNestedArrayVector(reverseNested(expected)));
 }
 
 TEST_F(SortArrayTest, map) {

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -30,23 +30,30 @@ class Callable {
 
   virtual bool hasCapture() const = 0;
 
-  // Applies 'this' to 'args' for 'rows' and returns the result in
-  // '*result'.  'wrapCapture' translates row numbers in 'rows' to the
-  // corresponding numbers for captured variables, i.e. is an indices
-  // vector that is used for wrapping captured variables in a
-  // dictionary before passing these to the function. The typical use
-  // case of lambdas applies a function to elements of repeated types,
-  // so that the values of the arguments and captures are not
-  // aligned. This serves to align these. If nullptr, the captures are
-  // passed as is.
-  // 'finalSelection' can be empty when context->isFinalSelection() is true
-  // and must be a valid selectivity vector otherwise.
+  /// Applies 'this' to 'args' for 'rows' and returns the result in
+  /// '*result'.
+  /// @param rows The rows that this callable applies to. It is the element rows
+  /// of the complex-typed input of the lambda function.
+  /// @param wrapCapture A mapping that translates row numbers in 'rows' to the
+  /// corresponding numbers for captured variables, i.e. is an indices vector
+  /// that is used for wrapping captured variables in a dictionary before
+  /// passing these to the function. The typical use case of lambdas applies a
+  /// function to elements of repeated types, so that the values of the
+  /// arguments and captures are not aligned. This serves to align these. If
+  /// nullptr, the captures are passed as is.
+  /// @param finalSelection It can be empty when context->isFinalSelection() is
+  /// true and must be a valid selectivity vector otherwise.
+  /// @param elementToTopLevelRows A mapping from element rows (i.e., the rows
+  /// argument) to top-level rows of the complex-typed input of the lambda
+  /// function. elementToTopLevelRows could be a nullptr, meaning the element
+  /// rows are identical to top-level rows.
   virtual void apply(
       const SelectivityVector& rows,
       const SelectivityVector& finalSelection,
-      BufferPtr wrapCapture,
+      const BufferPtr& wrapCapture,
       exec::EvalCtx* context,
       const std::vector<VectorPtr>& args,
+      const BufferPtr& elementToTopLevelRows,
       VectorPtr* result) = 0;
 };
 


### PR DESCRIPTION
Summary:
Lambda expression inside Try expression used to not subpress errors but throw
them immediately because of the inproper setting of lambdaCtx::throwOnError_.
This diff fixes lambda-in-try for existing Presto lambda functions:
https://github.com/facebookincubator/velox/issues/2605.

Differential Revision: D39992324

