### PR TITLE
Add a step in test to wait all tasks to be deleted

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -42,6 +42,9 @@ folly::Synchronized<std::vector<std::shared_ptr<TaskListener>>>& listeners() {
 }
 } // namespace
 
+std::atomic<uint64_t> Task::numCreatedTasks_ = 0;
+std::atomic<uint64_t> Task::numDeletedTasks_ = 0;
+
 bool registerTaskListener(std::shared_ptr<TaskListener> listener) {
   return listeners().withWLock([&](auto& listeners) {
     for (const auto& existingListener : listeners) {

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -413,7 +413,7 @@ TEST_P(MultiThreadedHashJoinTest, emptyBuild) {
       "  WHERE t_k0 = u_k0");
 }
 
-TEST_P(MultiThreadedHashJoinTest, DISABLED_emptyProbe) {
+TEST_P(MultiThreadedHashJoinTest, emptyProbe) {
   testJoin(
       {BIGINT()},
       0,

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -443,10 +443,14 @@ TEST_F(TaskTest, singleThreadedExecution) {
       makeFlatVector<int64_t>(100, [](auto row) { return row + 5; }),
   });
 
+  uint64_t numCreatedTasks = Task::numCreatedTasks();
+  uint64_t numDeletedTasks = Task::numDeletedTasks();
   {
     auto [task, results] = executeSingleThreaded(plan);
     assertEqualResults({expectedResult, expectedResult}, results);
   }
+  ASSERT_EQ(numCreatedTasks + 1, Task::numCreatedTasks());
+  ASSERT_EQ(numDeletedTasks + 1, Task::numDeletedTasks());
 
   // Project + Aggregation.
   plan = PlanBuilder()
@@ -471,10 +475,14 @@ TEST_F(TaskTest, singleThreadedExecution) {
            995 / 2.0 + 4}),
   });
 
+  ++numCreatedTasks;
+  ++numDeletedTasks;
   {
     auto [task, results] = executeSingleThreaded(plan);
     assertEqualResults({expectedResult}, results);
   }
+  ASSERT_EQ(numCreatedTasks + 1, Task::numCreatedTasks());
+  ASSERT_EQ(numDeletedTasks + 1, Task::numDeletedTasks());
 
   // Project + Aggregation over TableScan.
   auto filePath = TempFilePath::create();

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -41,6 +41,8 @@ class OperatorTestBase : public testing::Test,
 
   static void SetUpTestCase();
 
+  static void TearDownTestCase();
+
   void createDuckDbTable(const std::vector<RowVectorPtr>& data) {
     duckDbQueryRunner_.createTable("tmp", data);
   }
@@ -128,6 +130,12 @@ class OperatorTestBase : public testing::Test,
       const std::string& text,
       RowTypePtr rowType,
       const parse::ParseOptions& options = {});
+
+  /// Invoked to wait for all the tasks created by the test to be deleted.
+  ///
+  /// NOTE: it is assumed that there is no more task to be created after or
+  /// during this wait call.gi
+  static void waitForAllTasksToBeDeleted(uint64_t maxWaitUs = 3'000'000);
 
   DuckDbQueryRunner duckDbQueryRunner_;
 


### PR DESCRIPTION
Some tests might finish with pending tasks which have terminated
but the destructor has not been called yet. This can expose race
condition related to static variable destruction which is detected by
asan in emptyProbe test. The static file system instance (shared_ptr)
has been released and the pending task destructor tries to grab the
released shared pointer again on spill file destruction. Some memory 
leaking problems might be also due to this.
This PR fixes the issue by adding a step in OperatorTestBase dtor to
wait for all the tasks to be deleted. To enable this, add two global (static)
atomic counters in Task class plus a tiny helper class to track the
number of created and deleted tasks.
