### PR TITLE
Collect runtime stats for special form expressions

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -669,9 +669,6 @@ void CastExpr::evalSpecialForm(
   auto fromType = inputs_[0]->type();
   auto toType = std::const_pointer_cast<const Type>(type_);
 
-  stats_.numProcessedVectors += 1;
-  stats_.numProcessedRows += rows.countSelected();
-  auto timer = cpuWallTimer();
   apply(rows, input, context, fromType, toType, result);
   // Return 'input' back to the vector pool in 'context' so it can be reused.
   context.releaseVector(input);

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -428,7 +428,7 @@ void Expr::evalFlatNoNulls(
        topLevel ? (void*)&exprExceptionContext : this});
 
   if (isSpecialForm()) {
-    evalSpecialForm(rows, context, result);
+    evalSpecialFormWithStats(rows, context, result);
     return;
   }
 
@@ -1144,7 +1144,7 @@ void Expr::evalAll(
     return;
   }
   if (isSpecialForm()) {
-    evalSpecialForm(rows, context, result);
+    evalSpecialFormWithStats(rows, context, result);
     return;
   }
   bool tryPeelArgs = deterministic_ ? true : false;
@@ -1392,6 +1392,17 @@ void Expr::applyFunction(
     result->asUnchecked<SimpleVector<StringView>>()->setIsAscii(
         isAscii.value(), rows);
   }
+}
+
+void Expr::evalSpecialFormWithStats(
+    const SelectivityVector& rows,
+    EvalCtx& context,
+    VectorPtr& result) {
+  stats_.numProcessedVectors += 1;
+  stats_.numProcessedRows += rows.countSelected();
+  auto timer = cpuWallTimer();
+
+  evalSpecialForm(rows, context, result);
 }
 
 namespace {

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -388,6 +388,11 @@ class Expr {
       EvalCtx& context,
       VectorPtr& result);
 
+  void evalSpecialFormWithStats(
+      const SelectivityVector& rows,
+      EvalCtx& context,
+      VectorPtr& result);
+
  protected:
   void appendInputs(std::stringstream& stream) const;
 

--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -84,10 +84,10 @@ TEST_F(ExprStatsTest, printWithStats) {
             "multiply .cpu time: .+, rows: 1024, batches: 1. -> BIGINT .#1.\n"
             "   plus .cpu time: .+, rows: 1024, batches: 1. -> BIGINT .#2.\n"
             "      cast.c0 as BIGINT. .cpu time: .+, rows: 1024, batches: 1. -> BIGINT .#3.\n"
-            "         c0 .cpu time: 0ns, rows: 0, batches: 0. -> INTEGER .#4.\n"
-            "      3:BIGINT .cpu time: 0ns, rows: 0, batches: 0. -> BIGINT .#5.\n"
+            "         c0 .cpu time: 0ns, rows: 2048, batches: 2. -> INTEGER .#4.\n"
+            "      3:BIGINT .cpu time: 0ns, rows: 1024, batches: 1. -> BIGINT .#5.\n"
             "   cast.c1 as BIGINT. .cpu time: .+, rows: 1024, batches: 1. -> BIGINT .#6.\n"
-            "      c1 .cpu time: 0ns, rows: 0, batches: 0. -> INTEGER .#7.\n"
+            "      c1 .cpu time: 0ns, rows: 2048, batches: 2. -> INTEGER .#7.\n"
             "\n"
             "eq .cpu time: .+, rows: 1024, batches: 1. -> BOOLEAN .#8.\n"
             "   mod .cpu time: .+, rows: 1024, batches: 1. -> BIGINT .#9.\n"
@@ -95,8 +95,8 @@ TEST_F(ExprStatsTest, printWithStats) {
             "         plus .cpu time: .+, rows: 1024, batches: 1. -> INTEGER .#11.\n"
             "            c0 -> INTEGER .CSE #4.\n"
             "            c1 -> INTEGER .CSE #7.\n"
-            "      2:BIGINT .cpu time: 0ns, rows: 0, batches: 0. -> BIGINT .#12.\n"
-            "   0:BIGINT .cpu time: 0ns, rows: 0, batches: 0. -> BIGINT .#13.\n"));
+            "      2:BIGINT .cpu time: 0ns, rows: 1024, batches: 1. -> BIGINT .#12.\n"
+            "   0:BIGINT .cpu time: 0ns, rows: 1024, batches: 1. -> BIGINT .#13.\n"));
   }
 
   // Verify that common sub-expressions are identified properly.
@@ -110,13 +110,13 @@ TEST_F(ExprStatsTest, printWithStats) {
             "mod .cpu time: .+, rows: 1024, batches: 1. -> BIGINT .#1.\n"
             "   cast.plus as BIGINT. .cpu time: .+, rows: 1024, batches: 1. -> BIGINT .#2.\n"
             "      plus .cpu time: .+, rows: 1024, batches: 1. -> INTEGER .#3.\n"
-            "         c0 .cpu time: 0ns, rows: 0, batches: 0. -> INTEGER .#4.\n"
-            "         c1 .cpu time: 0ns, rows: 0, batches: 0. -> INTEGER .#5.\n"
-            "   5:BIGINT .cpu time: 0ns, rows: 0, batches: 0. -> BIGINT .#6.\n"
+            "         c0 .cpu time: 0ns, rows: 1024, batches: 1. -> INTEGER .#4.\n"
+            "         c1 .cpu time: 0ns, rows: 1024, batches: 1. -> INTEGER .#5.\n"
+            "   5:BIGINT .cpu time: 0ns, rows: 1024, batches: 1. -> BIGINT .#6.\n"
             "\n"
             "mod .cpu time: .+, rows: 1024, batches: 1. -> BIGINT .#7.\n"
             "   cast..plus.c0, c1.. as BIGINT. -> BIGINT .CSE #2.\n"
-            "   3:BIGINT .cpu time: 0ns, rows: 0, batches: 0. -> BIGINT .#8.\n"));
+            "   3:BIGINT .cpu time: 0ns, rows: 1024, batches: 1. -> BIGINT .#8.\n"));
   }
 
   // Use dictionary encoding to repeat each row 5 times.
@@ -137,10 +137,10 @@ TEST_F(ExprStatsTest, printWithStats) {
             "multiply .cpu time: .+, rows: 205, batches: 1. -> BIGINT .#1.\n"
             "   plus .cpu time: .+, rows: 205, batches: 1. -> BIGINT .#2.\n"
             "      cast.c0 as BIGINT. .cpu time: .+, rows: 205, batches: 1. -> BIGINT .#3.\n"
-            "         c0 .cpu time: 0ns, rows: 0, batches: 0. -> INTEGER .#4.\n"
-            "      3:BIGINT .cpu time: 0ns, rows: 0, batches: 0. -> BIGINT .#5.\n"
+            "         c0 .cpu time: 0ns, rows: 410, batches: 2. -> INTEGER .#4.\n"
+            "      3:BIGINT .cpu time: 0ns, rows: 205, batches: 1. -> BIGINT .#5.\n"
             "   cast.c1 as BIGINT. .cpu time: .+, rows: 205, batches: 1. -> BIGINT .#6.\n"
-            "      c1 .cpu time: 0ns, rows: 0, batches: 0. -> INTEGER .#7.\n"
+            "      c1 .cpu time: 0ns, rows: 410, batches: 2. -> INTEGER .#7.\n"
             "\n"
             "eq .cpu time: .+, rows: 205, batches: 1. -> BOOLEAN .#8.\n"
             "   mod .cpu time: .+, rows: 205, batches: 1. -> BIGINT .#9.\n"
@@ -148,8 +148,8 @@ TEST_F(ExprStatsTest, printWithStats) {
             "         plus .cpu time: .+, rows: 205, batches: 1. -> INTEGER .#11.\n"
             "            c0 -> INTEGER .CSE #4.\n"
             "            c1 -> INTEGER .CSE #7.\n"
-            "      2:BIGINT .cpu time: 0ns, rows: 0, batches: 0. -> BIGINT .#12.\n"
-            "   0:BIGINT .cpu time: 0ns, rows: 0, batches: 0. -> BIGINT .#13.\n"));
+            "      2:BIGINT .cpu time: 0ns, rows: 205, batches: 1. -> BIGINT .#12.\n"
+            "   0:BIGINT .cpu time: 0ns, rows: 205, batches: 1. -> BIGINT .#13.\n"));
   }
 }
 
@@ -293,6 +293,67 @@ TEST_F(ExprStatsTest, listener) {
     evaluate(*exprSet, data);
   }
   ASSERT_EQ(3, events.size());
+}
+
+TEST_F(ExprStatsTest, specialForms) {
+  vector_size_t size = 1'024;
+
+  // Register a listener to receive stats on ExprSet destruction.
+  std::vector<Event> events;
+  std::vector<std::string> exceptions;
+  auto listener = std::make_shared<TestListener>(events, exceptions);
+  ASSERT_TRUE(exec::registerExprSetListener(listener));
+
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 7; }),
+  });
+
+  // AND.
+  evaluate("c0 > 5 and c1 > 5", data);
+  ASSERT_EQ(1, events.size());
+  auto stats = events.back().stats;
+
+  ASSERT_EQ(1, stats.at("and").numProcessedVectors);
+  ASSERT_EQ(1024, stats.at("and").numProcessedRows);
+
+  // OR.
+  events.clear();
+  evaluate("c0 > 5 or c1 > 5", data);
+  ASSERT_EQ(1, events.size());
+  stats = events.back().stats;
+
+  ASSERT_EQ(1, stats.at("or").numProcessedVectors);
+  ASSERT_EQ(1024, stats.at("or").numProcessedRows);
+
+  // TRY.
+  events.clear();
+  evaluate("try(c0 / c1)", data);
+  ASSERT_EQ(1, events.size());
+  stats = events.back().stats;
+
+  ASSERT_EQ(1, stats.at("try").numProcessedVectors);
+  ASSERT_EQ(1024, stats.at("try").numProcessedRows);
+
+  // COALESCE.
+  events.clear();
+  evaluate("coalesce(c0, c1)", data);
+  ASSERT_EQ(1, events.size());
+  stats = events.back().stats;
+
+  ASSERT_EQ(1, stats.at("coalesce").numProcessedVectors);
+  ASSERT_EQ(1024, stats.at("coalesce").numProcessedRows);
+
+  // SWITCH.
+  events.clear();
+  evaluate("case c0 when 7 then 1 when 11 then 2 else 0 end", data);
+  ASSERT_EQ(1, events.size());
+  stats = events.back().stats;
+
+  ASSERT_EQ(1, stats.at("switch").numProcessedVectors);
+  ASSERT_EQ(1024, stats.at("switch").numProcessedRows);
+
+  ASSERT_TRUE(exec::unregisterExprSetListener(listener));
 }
 
 TEST_F(ExprStatsTest, errorLog) {


### PR DESCRIPTION
Before this change, runtime stats collection was limited to function calls and
CAST expressions. This change enables runtime stats collection for all special
forms, i.e. AND, OR, TRY, SWITCH, COALESCE.