### PR TITLE
Move reuseStringsFromArg out from SimpleFunctionMetaData

### DIFF
--- a/velox/benchmarks/basic/Preproc.cpp
+++ b/velox/benchmarks/basic/Preproc.cpp
@@ -265,7 +265,7 @@ class PreprocBenchmark : public functions::test::FunctionBenchmarkBase {
           untyped, ROW({"c0"}, {REAL()}), execCtx_.pool());
       typedExprs.push_back(typed);
     }
-    return exec::ExprSet(std::move(typedExprs), &execCtx_);
+    return exec::ExprSet(typedExprs, &execCtx_);
   }
 
   std::string makeExpression(int n, RunConfig config) {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -287,7 +287,9 @@ class ProjectNode : public PlanNode {
     return projections_;
   }
 
-  std::string_view name() const override {
+  // This function is virtual to allow customized projections to inherit from
+  // this class without re-implementing the other functions.
+  virtual std::string_view name() const override {
     return "Project";
   }
 

--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -52,15 +52,6 @@ struct udf_is_default_ascii_behavior<
     util::detail::void_t<decltype(T::is_default_ascii_behavior)>>
     : std::integral_constant<bool, T::is_default_ascii_behavior> {};
 
-template <class T, class = void>
-struct udf_reuse_strings_from_arg : std::integral_constant<int32_t, -1> {};
-
-template <class T>
-struct udf_reuse_strings_from_arg<
-    T,
-    util::detail::void_t<decltype(T::reuse_strings_from_arg)>>
-    : std::integral_constant<int32_t, T::reuse_strings_from_arg> {};
-
 // If a UDF doesn't declare a default help(),
 template <class T, class = void>
 struct udf_help {
@@ -290,7 +281,6 @@ class ISimpleFunctionMetadata {
   virtual std::vector<std::shared_ptr<const Type>> argTypes() const = 0;
   virtual std::string getName() const = 0;
   virtual bool isDeterministic() const = 0;
-  virtual int32_t reuseStringsFromArg() const = 0;
   virtual uint32_t priority() const = 0;
   virtual const std::shared_ptr<exec::FunctionSignature> signature() const = 0;
   virtual std::string helpMessage(const std::string& name) const = 0;
@@ -344,10 +334,6 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
 
   bool isDeterministic() const final {
     return udf_is_deterministic<Fun>();
-  }
-
-  int32_t reuseStringsFromArg() const final {
-    return udf_reuse_strings_from_arg<Fun>();
   }
 
   std::shared_ptr<const Type> returnType() const final {
@@ -490,6 +476,7 @@ class UDFHolder final
   Fun instance_;
 
  public:
+  using udf_struct_t = Fun;
   using Metadata = core::SimpleFunctionMetadata<Fun, TReturn, TArgs...>;
 
   template <typename T>

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -696,9 +696,16 @@ class PlanBuilder {
     return *this;
   }
 
- private:
+ protected:
+  // Users who create customer operators might want to extend the PlanBuilder to
+  // customized extended plan builders, those functions are needed in such
+  // extensions.
   std::string nextPlanNodeId();
 
+  std::shared_ptr<const core::ITypedExpr> inferTypes(
+      const std::shared_ptr<const core::IExpr>& untypedExpr);
+
+ private:
   std::shared_ptr<const core::FieldAccessTypedExpr> field(column_index_t index);
 
   std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> fields(
@@ -732,9 +739,6 @@ class PlanBuilder {
       core::AggregationNode::Step step,
       const core::AggregationNode* partialAggNode);
 
-  core::TypedExprPtr inferTypes(
-      const std::shared_ptr<const core::IExpr>& untypedExpr);
-
   struct ExpressionsAndNames {
     std::vector<std::shared_ptr<const core::CallTypedExpr>> expressions;
     std::vector<std::string> names;
@@ -750,9 +754,12 @@ class PlanBuilder {
       size_t numAggregates,
       const std::vector<std::string>& masks);
 
-  std::shared_ptr<PlanNodeIdGenerator> planNodeIdGenerator_;
+ protected:
   core::PlanNodePtr planNode_;
-  memory::MemoryPool* pool_;
   parse::ParseOptions options_;
+
+ private:
+  std::shared_ptr<PlanNodeIdGenerator> planNodeIdGenerator_;
+  memory::MemoryPool* pool_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1485,12 +1485,12 @@ void Expr::appendInputsSql(std::stringstream& stream) const {
 }
 
 ExprSet::ExprSet(
-    std::vector<core::TypedExprPtr>&& sources,
+    const std::vector<core::TypedExprPtr>& sources,
     core::ExecCtx* execCtx,
     bool enableConstantFolding)
     : execCtx_(execCtx) {
-  exprs_ = compileExpressions(
-      std::move(sources), execCtx, this, enableConstantFolding);
+  exprs_ = compileExpressions(sources, execCtx, this, enableConstantFolding);
+  std::vector<FieldReference*> allDistinctFields;
   for (auto& expr : exprs_) {
     mergeFields(
         distinctFields_, multiplyReferencedFields_, expr->distinctFields());

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -506,7 +506,7 @@ using ExprPtr = std::shared_ptr<Expr>;
 class ExprSet {
  public:
   explicit ExprSet(
-      std::vector<core::TypedExprPtr>&& source,
+      const std::vector<core::TypedExprPtr>& source,
       core::ExecCtx* FOLLY_NONNULL execCtx,
       bool enableConstantFolding = true);
 
@@ -590,9 +590,9 @@ class ExprSet {
 class ExprSetSimplified : public ExprSet {
  public:
   ExprSetSimplified(
-      std::vector<core::TypedExprPtr>&& source,
+      const std::vector<core::TypedExprPtr>& source,
       core::ExecCtx* FOLLY_NONNULL execCtx)
-      : ExprSet(std::move(source), execCtx, /*enableConstantFolding*/ false) {}
+      : ExprSet(source, execCtx, /*enableConstantFolding*/ false) {}
 
   virtual ~ExprSetSimplified() override {}
 

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -549,7 +549,7 @@ std::unordered_set<std::string> collectFlatteningCandidates(
 } // namespace
 
 std::vector<std::shared_ptr<Expr>> compileExpressions(
-    std::vector<TypedExprPtr>&& sources,
+    const std::vector<TypedExprPtr>& sources,
     core::ExecCtx* execCtx,
     ExprSet* exprSet,
     bool enableConstantFolding) {

--- a/velox/expression/ExprCompiler.h
+++ b/velox/expression/ExprCompiler.h
@@ -26,7 +26,7 @@ class Expr;
 class ExprSet;
 
 std::vector<std::shared_ptr<Expr>> compileExpressions(
-    std::vector<core::TypedExprPtr>&& sources,
+    const std::vector<core::TypedExprPtr>& sources,
     core::ExecCtx* execCtx,
     ExprSet* exprSet,
     bool enableConstantFolding = true);


### PR DESCRIPTION
Summary: reuseStringsFromArg() does not need to be part of the meta data. Its only accessed in the adapter during the execution.

Reviewed By: mbasmanova

Differential Revision: D39708751

