### PR TITLE
Optimize MapVector::compare

### DIFF
--- a/velox/benchmarks/basic/VectorCompare.cpp
+++ b/velox/benchmarks/basic/VectorCompare.cpp
@@ -41,14 +41,11 @@ class VectorCompareBenchmark : public functions::test::FunctionBenchmarkBase {
 
     flatVector_ = fuzzer.fuzzFlat(BIGINT());
 
-    arrayVector_ =
-        fuzzer.fuzzFlat(std::make_shared<ArrayType>(ArrayType(BIGINT())));
+    arrayVector_ = fuzzer.fuzzFlat(ARRAY(BIGINT()));
 
-    mapVector_ =
-        fuzzer.fuzzFlat(std::make_shared<MapType>(MapType(BIGINT(), BIGINT())));
+    mapVector_ = fuzzer.fuzzFlat(MAP(BIGINT(), BIGINT()));
 
-    rowVector_ =
-        fuzzer.fuzzFlat(vectorMaker_.rowType({BIGINT(), BIGINT(), BIGINT()}));
+    rowVector_ = fuzzer.fuzzFlat(ROW({BIGINT(), BIGINT(), BIGINT()}));
   }
 
   size_t run(const VectorPtr& vector) {
@@ -99,11 +96,11 @@ BENCHMARK_MULTI(compareSimilarArray) {
   return benchmark->run(benchmark->arrayVector_);
 }
 
-BENCHMARK_MULTI(CompareSimilarMap) {
+BENCHMARK_MULTI(compareSimilarMap) {
   return benchmark->run(benchmark->mapVector_);
 }
 
-BENCHMARK_MULTI(CompareSimilarRow) {
+BENCHMARK_MULTI(compareSimilarRow) {
   return benchmark->run(benchmark->rowVector_);
 }
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -255,6 +255,18 @@ class BaseVector {
       vector_size_t otherIndex,
       CompareFlags flags) const = 0;
 
+  /// Sort values at specified 'indices'. Used to sort map keys.
+  virtual void sortIndices(
+      std::vector<vector_size_t>& indices,
+      CompareFlags flags) const {
+    std::sort(
+        indices.begin(),
+        indices.end(),
+        [&](vector_size_t left, vector_size_t right) {
+          return compare(this, left, right, flags) < 0;
+        });
+  }
+
   /**
    * @return the hash of the value at the given index in this vector
    */

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -847,12 +847,7 @@ std::vector<vector_size_t> MapVector::sortedKeyIndices(
   std::vector<vector_size_t> indices(rawSizes_[index]);
   std::iota(indices.begin(), indices.end(), rawOffsets_[index]);
   if (!sortedKeys_) {
-    std::sort(
-        indices.begin(),
-        indices.end(),
-        [&](vector_size_t left, vector_size_t right) {
-          return keys_->compare(keys_.get(), left, right) < 0;
-        });
+    keys_->sortIndices(indices, CompareFlags());
   }
   return indices;
 }


### PR DESCRIPTION
Summary:
MapVector::compare sorts map entries by key using std::sort and
BaseVector::compare:

```
    std::sort(
        indices.begin(),
        indices.end(),
        [&](vector_size_t left, vector_size_t right) {
          return keys_->compare(keys_.get(), left, right) < 0;
        });
```

This is very slow. An optimization is to add BaseVector::sortIndices method and
specialize it for flat vectors so that type-dispatch happens only once per map.

Before:

```
============================================================================
velox/benchmarks/basic/VectorCompare.cpp     relative  time/iter   iters/s
============================================================================
compareSimilarSimpleFlat                                    6.58ns   151.94M
compareSimilarSimpleFlatNoDispatch                          2.31ns   432.64M
compareSimilarArray                                        90.45ns    11.06M
CompareSimilarMap                                           1.06us   940.21K
CompareSimilarRow                                          64.53ns    15.50M
----------------------------------------------------------------------------
```

After:

```
============================================================================
velox/benchmarks/basic/VectorCompare.cpp     relative  time/iter   iters/s
============================================================================
compareSimilarSimpleFlat                                    6.58ns   151.92M
compareSimilarSimpleFlatNoDispatch                          2.40ns   417.03M
compareSimilarArray                                        98.63ns    10.14M
compareSimilarMap                                         635.94ns     1.57M
compareSimilarRow                                          53.80ns    18.59M
----------------------------------------------------------------------------
```

Differential Revision: D40035913

