### PR TITLE
Add printNulls(nulls) function for easier debugging

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -847,5 +847,25 @@ BufferPtr BaseVector::sliceBuffer(
   return ans;
 }
 
+std::string printNulls(const BufferPtr& nulls, vector_size_t maxBitsToPrint) {
+  VELOX_CHECK_GE(maxBitsToPrint, 0);
+
+  vector_size_t totalCount = nulls->size() * 8;
+  auto* rawNulls = nulls->as<uint64_t>();
+  auto nullCount = bits::countNulls(rawNulls, 0, totalCount);
+
+  std::stringstream out;
+  out << nullCount << " out of " << totalCount << " rows are null";
+
+  if (nullCount) {
+    out << ": ";
+    for (auto i = 0; i < maxBitsToPrint && i < totalCount; ++i) {
+      out << (bits::isBitNull(rawNulls, i) ? "n" : ".");
+    }
+  }
+
+  return out.str();
+}
+
 } // namespace velox
 } // namespace facebook

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -811,6 +811,15 @@ inline BufferPtr allocateIndices(vector_size_t size, memory::MemoryPool* pool) {
 inline BufferPtr allocateNulls(vector_size_t size, memory::MemoryPool* pool) {
   return AlignedBuffer::allocate<bool>(size, pool, bits::kNotNull);
 }
+
+// Returns a summary of the null bits in the specified buffer and prints out
+// first 'maxBitsToPrint' bits. Automatically adjusts if 'maxBitsToPrint' is
+// greater than total number of bits available.
+// For example: 3 out of 8 rows are null: .nn.n...
+std::string printNulls(
+    const BufferPtr& nulls,
+    vector_size_t maxBitsToPrint = 30);
+
 } // namespace velox
 } // namespace facebook
 

--- a/velox/vector/tests/VectorToStringTest.cpp
+++ b/velox/vector/tests/VectorToStringTest.cpp
@@ -234,4 +234,41 @@ TEST_F(VectorToStringTest, dictionary) {
       "[CONSTANT INTEGER: 100 elements, 75]");
 }
 
+TEST_F(VectorToStringTest, printNulls) {
+  // No nulls.
+  BufferPtr nulls = allocateNulls(1024, pool());
+  EXPECT_EQ(printNulls(nulls), "0 out of 1024 rows are null");
+
+  // Some nulls.
+  for (auto i = 3; i < 1024; i += 7) {
+    bits::setNull(nulls->asMutable<uint64_t>(), i);
+  }
+  EXPECT_EQ(
+      printNulls(nulls),
+      "146 out of 1024 rows are null: ...n......n......n......n.....");
+
+  EXPECT_EQ(
+      printNulls(nulls, 15), "146 out of 1024 rows are null: ...n......n....");
+
+  EXPECT_EQ(
+      printNulls(nulls, 50),
+      "146 out of 1024 rows are null: "
+      "...n......n......n......n......n......n......n....");
+
+  // All nulls.
+  for (auto i = 0; i < 1024; ++i) {
+    bits::setNull(nulls->asMutable<uint64_t>(), i);
+  }
+  EXPECT_EQ(
+      printNulls(nulls),
+      "1024 out of 1024 rows are null: nnnnnnnnnnnnnnnnnnnnnnnnnnnnnn");
+
+  // Short buffer.
+  nulls = allocateNulls(5, pool());
+  bits::setNull(nulls->asMutable<uint64_t>(), 1);
+  bits::setNull(nulls->asMutable<uint64_t>(), 2);
+  bits::setNull(nulls->asMutable<uint64_t>(), 4);
+  EXPECT_EQ(printNulls(nulls), "3 out of 8 rows are null: .nn.n...");
+}
+
 } // namespace facebook::velox::test


### PR DESCRIPTION
Add a helper function to print the contents of the nulls buffer. 

For example, 

`3 out of 8 rows are null: .nn.n...`

`146 out of 1024 rows are null: ...n......n......n......n.....`

The new function can be invoked in LLDB debugger as 

`p facebook::velox::printNulls(nulls, 30)`