### PR TITLE
Change extractColumn result argument type to BaseVector

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -450,7 +450,7 @@ void GroupingSet::extractGroups(
   auto totalKeys = rows.keyTypes().size();
   for (int32_t i = 0; i < totalKeys; ++i) {
     auto keyVector = result->childAt(i);
-    rows.extractColumn(groups.data(), groups.size(), i, keyVector);
+    rows.extractColumn(groups.data(), groups.size(), i, *keyVector.get());
   }
   for (int32_t i = 0; i < aggregates_.size(); ++i) {
     aggregates_[i]->finalize(groups.data(), groups.size());

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -67,7 +67,7 @@ void extractColumns(
     }
     child->resize(rows.size());
     table->rows()->extractColumn(
-        rows.data(), rows.size(), projection.inputChannel, child);
+        rows.data(), rows.size(), projection.inputChannel, *child.get());
   }
 }
 

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -282,7 +282,7 @@ void OrderBy::getOutputWithoutSpill() {
         returningRows_.data() + numRowsReturned_,
         output_->size(),
         columnProjection.inputChannel,
-        output_->childAt(columnProjection.outputChannel));
+        *output_->childAt(columnProjection.outputChannel).get());
   }
   numRowsReturned_ += output_->size();
 }

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -125,7 +125,8 @@ void Spiller::extractSpill(folly::Range<char**> rows, RowVectorPtr& resultPtr) {
   auto result = resultPtr.get();
   auto& types = container_->columnTypes();
   for (auto i = 0; i < types.size(); ++i) {
-    container_->extractColumn(rows.data(), rows.size(), i, result->childAt(i));
+    container_->extractColumn(
+        rows.data(), rows.size(), i, *result->childAt(i).get());
   }
   auto& aggregates = container_->aggregates();
   auto numKeys = types.size();

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -162,7 +162,8 @@ RowVectorPtr StreamingAggregation::createOutput(size_t numGroups) {
       BaseVector::create(outputType_, numGroups, pool()));
 
   for (auto i = 0; i < groupingKeys_.size(); ++i) {
-    rows_->extractColumn(groups_.data(), numGroups, i, output->childAt(i));
+    rows_->extractColumn(
+        groups_.data(), numGroups, i, *output->childAt(i).get());
   }
 
   auto numKeys = groupingKeys_.size();

--- a/velox/exec/TopN.cpp
+++ b/velox/exec/TopN.cpp
@@ -105,7 +105,7 @@ RowVectorPtr TopN::getOutput() {
         rows_.data() + numRowsReturned_,
         numRowsToReturn,
         i,
-        result->childAt(i));
+        *result->childAt(i).get());
   }
   numRowsReturned_ += numRowsToReturn;
   finished_ = (numRowsReturned_ == rows_.size());

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -417,7 +417,7 @@ RowVectorPtr Window::getOutput() {
         sortedRows_.data() + numProcessedRows_,
         numOutputRows,
         i,
-        result->childAt(i));
+        *result->childAt(i).get());
   }
 
   // Construct vectors for the window function output columns.

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -72,7 +72,7 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
       // Test the extractColumn API that didn't use the offset parameter and
       // copied to the start of the result vector.
       auto result = BaseVector::create(expected->type(), size, pool_.get());
-      container.extractColumn(rows.data(), size, column, result);
+      container.extractColumn(rows.data(), size, column, *result.get());
       assertEqualVectors(expected, result);
     };
 
@@ -80,7 +80,7 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
       // Test extractColumn from offset.
       auto result = BaseVector::create(expected->type(), size, pool_.get());
       container.extractColumn(
-          rows.data(), size - offset, column, offset, result);
+          rows.data(), size - offset, column, offset, *result.get());
       testEqualVectors(result, expected, offset, 0);
     };
 
@@ -95,7 +95,7 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
       folly::Range<const vector_size_t*> rowNumbersRange =
           folly::Range(rowNumbers.data(), size - offset);
       container.extractColumn(
-          rows.data(), rowNumbersRange, column, offset, result);
+          rows.data(), rowNumbersRange, column, offset, *result.get());
       testEqualVectors(result, expected, offset, offset);
     };
 
@@ -146,12 +146,12 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
       // Test the extractColumn API that didn't use the offset parameter
       // and copies to the start of the result vector.
       auto result = BaseVector::create(expected->type(), size, pool_.get());
-      container.extractColumn(input.data(), size, column, result);
+      container.extractColumn(input.data(), size, column, *result.get());
       verifyResults(result);
 
       // Test extractColumn from offset.
       container.extractColumn(
-          input.data() + offset, size - offset, column, offset, result);
+          input.data() + offset, size - offset, column, offset, *result.get());
       verifyResults(result, offset);
     };
 
@@ -179,7 +179,7 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
       folly::Range<const vector_size_t*> rowNumbersRange =
           folly::Range(rowNumbers.data(), rowNumbersSize);
       container.extractColumn(
-          input.data(), rowNumbersRange, column, offset, result);
+          input.data(), rowNumbersRange, column, offset, *result.get());
       verifyResults(result, offset);
     };
 
@@ -265,7 +265,7 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
         return rowContainer->compare(l, r, 0, {nullsFirst, ascending}) < 0;
       });
       VectorPtr result = BaseVector::create(type, numRows, pool_.get());
-      rowContainer->extractColumn(rows.data(), numRows, 0, result);
+      rowContainer->extractColumn(rows.data(), numRows, 0, *result.get());
       assertEqualVectors(expected, result);
     }
 
@@ -489,7 +489,7 @@ TEST_F(RowContainerTest, types) {
 
     auto extracted = copy->childAt(column);
     extracted->resize(kNumRows);
-    data->extractColumn(rows.data(), rows.size(), column, extracted);
+    data->extractColumn(rows.data(), rows.size(), column, *extracted.get());
     raw_vector<uint64_t> hashes(kNumRows);
     auto source = batch->childAt(column);
     auto columnType = batch->type()->as<TypeKind::ROW>().childAt(column);


### PR DESCRIPTION
extractColumn result can be represented by a BaseVector instead of a VectorPtr.