### PR TITLE
Add printIndices(indices) function for easier debugging

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -867,5 +867,31 @@ std::string printNulls(const BufferPtr& nulls, vector_size_t maxBitsToPrint) {
   return out.str();
 }
 
+std::string printIndices(
+    const BufferPtr& indices,
+    vector_size_t maxIndicesToPrint) {
+  VELOX_CHECK_GE(maxIndicesToPrint, 0);
+
+  auto* rawIndices = indices->as<vector_size_t>();
+
+  vector_size_t size = indices->size() / sizeof(vector_size_t);
+
+  std::unordered_set<vector_size_t> uniqueIndices;
+  for (auto i = 0; i < size; ++i) {
+    uniqueIndices.insert(rawIndices[i]);
+  }
+
+  std::stringstream out;
+  out << uniqueIndices.size() << " unique indices out of " << size << ": ";
+  for (auto i = 0; i < maxIndicesToPrint && i < size; ++i) {
+    if (i > 0) {
+      out << ", ";
+    }
+    out << rawIndices[i];
+  }
+
+  return out.str();
+}
+
 } // namespace velox
 } // namespace facebook

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -820,6 +820,14 @@ std::string printNulls(
     const BufferPtr& nulls,
     vector_size_t maxBitsToPrint = 30);
 
+// Returns a summary of the indices buffer and prints out first
+// 'maxIndicesToPrint' indices. Automatically adjusts if 'maxIndicesToPrint' is
+// greater than total number of indices available.
+// For example: 5 unique indices out of 6: 34, 79, 11, 0, 0, 33.
+std::string printIndices(
+    const BufferPtr& indices,
+    vector_size_t maxIndicesToPrint = 10);
+
 } // namespace velox
 } // namespace facebook
 

--- a/velox/vector/tests/VectorToStringTest.cpp
+++ b/velox/vector/tests/VectorToStringTest.cpp
@@ -271,4 +271,35 @@ TEST_F(VectorToStringTest, printNulls) {
   EXPECT_EQ(printNulls(nulls), "3 out of 8 rows are null: .nn.n...");
 }
 
+TEST_F(VectorToStringTest, printIndices) {
+  BufferPtr indices = allocateIndices(1024, pool());
+  EXPECT_EQ(
+      printIndices(indices),
+      "1 unique indices out of 1024: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0");
+
+  indices = makeIndices(1024, [](auto row) { return row / 3; });
+  EXPECT_EQ(
+      printIndices(indices),
+      "342 unique indices out of 1024: 0, 0, 0, 1, 1, 1, 2, 2, 2, 3");
+
+  indices = makeIndices(1024, [](auto row) { return row % 7; });
+  EXPECT_EQ(
+      printIndices(indices),
+      "7 unique indices out of 1024: 0, 1, 2, 3, 4, 5, 6, 0, 1, 2");
+
+  indices = makeIndices(1024, [](auto row) { return row; });
+  EXPECT_EQ(
+      printIndices(indices),
+      "1024 unique indices out of 1024: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9");
+
+  indices = makeIndices(1024, [](auto row) { return row; });
+  EXPECT_EQ(
+      printIndices(indices, 15),
+      "1024 unique indices out of 1024: "
+      "0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14");
+
+  indices = makeIndices({34, 79, 11, 0, 0, 33});
+  EXPECT_EQ(
+      printIndices(indices), "5 unique indices out of 6: 34, 79, 11, 0, 0, 33");
+}
 } // namespace facebook::velox::test


### PR DESCRIPTION
Add a helper function to print the contents of the indices buffer.

For example,

`5 unique indices out of 6: 34, 79, 11, 0, 0, 33`

`342 unique indices out of 1024: 0, 0, 0, 1, 1, 1, 2, 2, 2, 3`

The new function can be invoked in LLDB debugger as

`p facebook::velox::printIndices(indices, 10)`