### PR TITLE
Remove unnecessary installation of GTest on scripts

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -35,7 +35,6 @@ sudo --preserve-env apt install -y \
   libgoogle-glog-dev \
   libbz2-dev \
   libgflags-dev \
-  libgtest-dev \
   libgmock-dev \
   libevent-dev \
   liblz4-dev \

--- a/scripts/setup-velox-torcharrow.sh
+++ b/scripts/setup-velox-torcharrow.sh
@@ -31,7 +31,6 @@ yum -y install double-conversion-devel
 yum -y install glog-devel
 yum -y install bzip2-devel
 yum -y install gflags-devel
-yum -y install gtest-devel
 yum -y install libevent-devel
 yum -y install lz4-devel
 yum -y install libzstd-devel


### PR DESCRIPTION
GTest was moved to a submodule on this PR: https://github.com/facebookincubator/velox/pull/1298
It is not required to be installed as a system dependency anymore.