### PR TITLE
Use is_same_v instead of is_same<>::value

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -377,14 +377,14 @@ class ColumnVisitor {
 
   void filterPassed(T value) {
     addResult(value);
-    if (!std::is_same<TFilter, velox::common::AlwaysTrue>::value) {
+    if (!std::is_same_v<TFilter, velox::common::AlwaysTrue>) {
       addOutputRow(currentRow());
     }
   }
 
   inline void filterPassedForNull() {
     addNull();
-    if (!std::is_same<TFilter, velox::common::AlwaysTrue>::value) {
+    if (!std::is_same_v<TFilter, velox::common::AlwaysTrue>) {
       addOutputRow(currentRow());
     }
   }
@@ -408,7 +408,7 @@ class ColumnVisitor {
 
   void setNumValues(int32_t size) {
     reader_->setNumValues(numValuesBias_ + size);
-    if (!std::is_same<TFilter, velox::common::AlwaysTrue>::value) {
+    if (!std::is_same_v<TFilter, velox::common::AlwaysTrue>) {
       reader_->setNumRows(numValuesBias_ + size);
     }
   }
@@ -727,7 +727,7 @@ class DictionaryColumnVisitor
     vector_size_t previous =
         isDense && TFilter::deterministic ? 0 : super::currentRow();
     T valueInDictionary = dict()[value];
-    if (std::is_same<TFilter, velox::common::AlwaysTrue>::value) {
+    if (std::is_same_v<TFilter, velox::common::AlwaysTrue>) {
       super::filterPassed(valueInDictionary);
     } else {
       // check the dictionary cache
@@ -818,7 +818,7 @@ class DictionaryColumnVisitor
     // permute the passing values to the left of a vector register and
     // write  the whole register to the end of 'values'
     constexpr bool kFilterOnly =
-        std::is_same<typename super::Extract, DropValues>::value;
+        std::is_same_v<typename super::Extract, DropValues>;
     constexpr int32_t kWidth = xsimd::batch<int32_t>::size;
     int32_t last = numInput & ~(kWidth - 1);
     for (auto i = 0; i < numInput; i += kWidth) {
@@ -1112,7 +1112,7 @@ class StringDictionaryColumnVisitor
     }
     vector_size_t previous =
         isDense && TFilter::deterministic ? 0 : super::currentRow();
-    if (std::is_same<TFilter, velox::common::AlwaysTrue>::value) {
+    if (std::is_same_v<TFilter, velox::common::AlwaysTrue>) {
       super::filterPassed(index);
     } else {
       // check the dictionary cache
@@ -1186,7 +1186,7 @@ class StringDictionaryColumnVisitor
       return;
     }
     constexpr bool filterOnly =
-        std::is_same<typename super::Extract, DropValues>::value;
+        std::is_same_v<typename super::Extract, DropValues>;
     constexpr int32_t kWidth = xsimd::batch<int32_t>::size;
     for (auto i = 0; i < numInput; i += kWidth) {
       auto indices = xsimd::load_unaligned(input + i);
@@ -1402,7 +1402,7 @@ class DirectRleColumnVisitor
       int32_t& numValues) {
     DCHECK_EQ(input, values + numValues);
     constexpr bool filterOnly =
-        std::is_same<typename super::Extract, DropValues>::value;
+        std::is_same_v<typename super::Extract, DropValues>;
 
     dwio::common::processFixedWidthRun<T, filterOnly, scatter, isDense>(
         folly::Range<const vector_size_t*>(super::rows_, super::numRows_),

--- a/velox/dwio/common/DataBuffer.h
+++ b/velox/dwio/common/DataBuffer.h
@@ -28,7 +28,7 @@ namespace velox {
 namespace dwio {
 namespace common {
 
-template <typename T, typename = std::enable_if_t<std::is_trivial<T>::value>>
+template <typename T, typename = std::enable_if_t<std::is_trivial_v<T>>>
 class DataBuffer final {
  private:
   velox::memory::AbstractMemoryPool& pool_;

--- a/velox/dwio/common/DecoderUtil.h
+++ b/velox/dwio/common/DecoderUtil.h
@@ -168,8 +168,8 @@ void fixedWidthScan(
   constexpr bool is16 = sizeof(T) == 2;
   constexpr int32_t kStep = is16 ? 16 : 8;
   constexpr bool hasFilter =
-      !std::is_same<TFilter, velox::common::AlwaysTrue>::value;
-  constexpr bool hasHook = !std::is_same<THook, NoHook>::value;
+      !std::is_same_v<TFilter, velox::common::AlwaysTrue>;
+  constexpr bool hasHook = !std::is_same_v<THook, NoHook>;
   auto rawValues = reinterpret_cast<T*>(voidValues);
   loopOverBuffers<T>(
       rows,
@@ -393,10 +393,10 @@ template <typename Visitor, bool hasNulls>
 bool useFastPath(Visitor& visitor) {
   return process::hasAvx2() && Visitor::FilterType::deterministic &&
       Visitor::kHasBulkPath &&
-      (std::is_same<typename Visitor::FilterType, velox::common::AlwaysTrue>::
-           value ||
+      (std::
+           is_same_v<typename Visitor::FilterType, velox::common::AlwaysTrue> ||
        !hasNulls || !visitor.allowNulls()) &&
-      (std::is_same<typename Visitor::HookType, NoHook>::value || !hasNulls ||
+      (std::is_same_v<typename Visitor::HookType, NoHook> || !hasNulls ||
        Visitor::HookType::kSkipNulls);
 }
 
@@ -449,8 +449,8 @@ void processFixedWidthRun(
     THook& hook) {
   constexpr int32_t kWidth = xsimd::batch<T>::size;
   constexpr bool hasFilter =
-      !std::is_same<TFilter, velox::common::AlwaysTrue>::value;
-  constexpr bool hasHook = !std::is_same<THook, NoHook>::value;
+      !std::is_same_v<TFilter, velox::common::AlwaysTrue>;
+  constexpr bool hasHook = !std::is_same_v<THook, NoHook>;
   if (!hasFilter) {
     if (hasHook) {
       hook.addValues(scatterRows + rowIndex, values, rows.size(), sizeof(T));

--- a/velox/dwio/common/DirectDecoder.h
+++ b/velox/dwio/common/DirectDecoder.h
@@ -84,9 +84,9 @@ class DirectDecoder : public IntDecoder<isSigned> {
           }
         }
       }
-      if (std::is_same<typename Visitor::DataType, float>::value) {
+      if (std::is_same_v<typename Visitor::DataType, float>) {
         toSkip = visitor.process(readFloat(), atEnd);
-      } else if (std::is_same<typename Visitor::DataType, double>::value) {
+      } else if (std::is_same_v<typename Visitor::DataType, double>) {
         toSkip = visitor.process(readDouble(), atEnd);
       } else {
         toSkip = visitor.process(super::readLong(), atEnd);
@@ -140,12 +140,12 @@ class DirectDecoder : public IntDecoder<isSigned> {
   void fastPath(const uint64_t* FOLLY_NULLABLE nulls, Visitor& visitor) {
     using T = typename Visitor::DataType;
     constexpr bool hasFilter =
-        !std::is_same<typename Visitor::FilterType, velox::common::AlwaysTrue>::
-            value;
+        !std::
+            is_same_v<typename Visitor::FilterType, velox::common::AlwaysTrue>;
     constexpr bool filterOnly =
-        std::is_same<typename Visitor::Extract, DropValues>::value;
+        std::is_same_v<typename Visitor::Extract, DropValues>;
     constexpr bool hasHook =
-        !std::is_same<typename Visitor::HookType, dwio::common::NoHook>::value;
+        !std::is_same_v<typename Visitor::HookType, dwio::common::NoHook>;
 
     int32_t numValues = 0;
     auto rows = visitor.rows();

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -298,7 +298,7 @@ class SelectiveColumnReader {
   inline void addValue(const T value) {
     // @lint-ignore-every HOWTOEVEN ConstantArgumentPassByValue
     static_assert(
-        std::is_pod<T>::value,
+        std::is_pod_v<T>,
         "General case of addValue is only for primitive types");
     VELOX_DCHECK_LE(
         rawValues_ && (numValues_ + 1) * sizeof(T), values_->capacity());

--- a/velox/dwio/common/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/common/SelectiveFloatingPointColumnReader.h
@@ -36,7 +36,7 @@ class SelectiveFloatingPointColumnReader : public SelectiveColumnReader {
 
   // Offers fast path only if data and result widths match.
   bool hasBulkPath() const override {
-    return std::is_same<TData, TRequested>::value;
+    return std::is_same_v<TData, TRequested>;
   }
 
   template <typename Reader>
@@ -95,12 +95,10 @@ void SelectiveFloatingPointColumnReader<TData, TRequested>::processFilter(
       break;
     case velox::common::FilterKind::kIsNull:
       filterNulls<TRequested>(
-          rows,
-          true,
-          !std::is_same<decltype(extractValues), DropValues>::value);
+          rows, true, !std::is_same_v<decltype(extractValues), DropValues>);
       break;
     case velox::common::FilterKind::kIsNotNull:
-      if (std::is_same<decltype(extractValues), DropValues>::value) {
+      if (std::is_same_v<decltype(extractValues), DropValues>) {
         filterNulls<TRequested>(rows, false, false);
       } else {
         readHelper<Reader, velox::common::IsNotNull, isDense>(

--- a/velox/dwio/common/SelectiveIntegerColumnReader.h
+++ b/velox/dwio/common/SelectiveIntegerColumnReader.h
@@ -118,12 +118,10 @@ void SelectiveIntegerColumnReader::processFilter(
       break;
     case velox::common::FilterKind::kIsNull:
       filterNulls<int64_t>(
-          rows,
-          true,
-          !std::is_same<decltype(extractValues), DropValues>::value);
+          rows, true, !std::is_same_v<decltype(extractValues), DropValues>);
       break;
     case velox::common::FilterKind::kIsNotNull:
-      if (std::is_same<decltype(extractValues), DropValues>::value) {
+      if (std::is_same_v<decltype(extractValues), DropValues>) {
         filterNulls<int64_t>(rows, false, false);
       } else {
         readHelper<Reader, velox::common::IsNotNull, isDense>(

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -276,7 +276,7 @@ void verifyBatch(
       ASSERT_FALSE(out->isNullAt(index))
           << "null mismatch with index, seed " << index << seed;
 
-      if constexpr (std::is_floating_point<T>::value) {
+      if constexpr (std::is_floating_point_v<T>) {
         // for floating point nan != nan
         if (std::isnan(val.value())) {
           ASSERT_TRUE(std::isnan(outFv->rawValues()[index]))

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -156,7 +156,7 @@ class PageReader {
   template <
       typename Visitor,
       typename std::enable_if<
-          !std::is_same<typename Visitor::DataType, folly::StringPiece>::value,
+          !std::is_same_v<typename Visitor::DataType, folly::StringPiece>,
           int>::type = 0>
   void callDecoder(
       const uint64_t* FOLLY_NULLABLE nulls,
@@ -183,7 +183,7 @@ class PageReader {
   template <
       typename Visitor,
       typename std::enable_if<
-          std::is_same<typename Visitor::DataType, folly::StringPiece>::value,
+          std::is_same_v<typename Visitor::DataType, folly::StringPiece>,
           int>::type = 0>
   void callDecoder(
       const uint64_t* FOLLY_NULLABLE nulls,
@@ -305,9 +305,9 @@ class PageReader {
 template <typename Visitor>
 void PageReader::readWithVisitor(Visitor& visitor) {
   constexpr bool hasFilter =
-      !std::is_same<typename Visitor::FilterType, common::AlwaysTrue>::value;
+      !std::is_same_v<typename Visitor::FilterType, common::AlwaysTrue>;
   constexpr bool filterOnly =
-      std::is_same<typename Visitor::Extract, dwio::common::DropValues>::value;
+      std::is_same_v<typename Visitor::Extract, dwio::common::DropValues>;
   bool mayProduceNulls = !filterOnly && visitor.allowNulls();
   auto rows = visitor.rows();
   auto numRows = visitor.numRows();

--- a/velox/dwio/parquet/reader/RleDecoder.h
+++ b/velox/dwio/parquet/reader/RleDecoder.h
@@ -191,9 +191,9 @@ class RleDecoder : public dwio::common::IntDecoder<isSigned> {
   template <bool hasNulls, typename Visitor>
   void fastPath(const uint64_t* FOLLY_NULLABLE nulls, Visitor& visitor) {
     constexpr bool hasFilter =
-        !std::is_same<typename Visitor::FilterType, common::AlwaysTrue>::value;
+        !std::is_same_v<typename Visitor::FilterType, common::AlwaysTrue>;
     constexpr bool hasHook =
-        !std::is_same<typename Visitor::HookType, dwio::common::NoHook>::value;
+        !std::is_same_v<typename Visitor::HookType, dwio::common::NoHook>;
     auto rows = visitor.rows();
     auto numRows = visitor.numRows();
     auto rowsAsRange = folly::Range<const int32_t*>(rows, numRows);

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -289,7 +289,7 @@ struct ArraySumFunction {
     TOutput sum = 0;
     for (const auto& item : array) {
       if (item.has_value()) {
-        if constexpr (std::is_same<TOutput, int64_t>::value) {
+        if constexpr (std::is_same_v<TOutput, int64_t>) {
           sum = checkedPlus<TOutput>(sum, *item);
         } else {
           sum += *item;
@@ -305,7 +305,7 @@ struct ArraySumFunction {
     // Not nulls path
     TOutput sum = 0;
     for (const auto& item : array) {
-      if constexpr (std::is_same<TOutput, int64_t>::value) {
+      if constexpr (std::is_same_v<TOutput, int64_t>) {
         sum = checkedPlus<TOutput>(sum, item);
       } else {
         sum += item;

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -373,7 +373,7 @@ void read(
   auto nullCount = readNulls(source, size, flatResult);
 
   BufferPtr values = flatResult->mutableValues(size);
-  if constexpr (std::is_same<T, Timestamp>::value) {
+  if constexpr (std::is_same_v<T, Timestamp>) {
     if (useLosslessTimestamp) {
       readLosslessTimestampValues(
           source, size, flatResult->nulls(), nullCount, values);


### PR DESCRIPTION
For clean code and consistency, we should use `is_same_v` instead of `is_same<>::value`
A couple of other `::value` have been replaced with `_v`