### PR TITLE
Optimize map_zip_with for maps with sorted keys

### DIFF
--- a/velox/docs/functions/map.rst
+++ b/velox/docs/functions/map.rst
@@ -60,6 +60,21 @@ Map Functions
 
     SELECT name_to_age_map['Bob'] AS bob_age;
 
+.. function:: map_zip_with(map(K,V1), map(K,V2), function(K,V1,V2,V3)) -> map(K,V3)
+
+    Merges the two given maps into a single map by applying ``function`` to the pair of values with the same key.
+    For keys only presented in one map, NULL will be passed as the value for the missing key. ::
+
+        SELECT map_zip_with(MAP(ARRAY[1, 2, 3], ARRAY['a', 'b', 'c']), -- {1 -> ad, 2 -> be, 3 -> cf}
+                            MAP(ARRAY[1, 2, 3], ARRAY['d', 'e', 'f']),
+                            (k, v1, v2) -> concat(v1, v2));
+        SELECT map_zip_with(MAP(ARRAY['k1', 'k2'], ARRAY[1, 2]), -- {k1 -> ROW(1, null), k2 -> ROW(2, 4), k3 -> ROW(null, 9)}
+                            MAP(ARRAY['k2', 'k3'], ARRAY[4, 9]),
+                            (k, v1, v2) -> (v1, v2));
+        SELECT map_zip_with(MAP(ARRAY['a', 'b', 'c'], ARRAY[1, 8, 27]), -- {a -> a1, b -> b4, c -> c9}
+                            MAP(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]),
+                            (k, v1, v2) -> k || CAST(v1/v2 AS VARCHAR));
+
 .. function:: transform_keys(map(K1,V), function(K1,V,K2)) -> map(K2,V)
 
     Returns a map that applies ``function`` to each entry of ``map`` and transforms the keys::

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(
   MapConcat.cpp
   MapEntries.cpp
   MapKeysAndValues.cpp
+  MapZipWith.cpp
   Not.cpp
   Reduce.cpp
   Reverse.cpp

--- a/velox/functions/prestosql/MapZipWith.cpp
+++ b/velox/functions/prestosql/MapZipWith.cpp
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/Expr.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/vector/FunctionVector.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+// See documentation at
+// https://prestodb.io/docs/current/functions/map.html#map_zip_with
+class MapZipWithFunction : public exec::VectorFunction {
+ public:
+  bool isDefaultNullBehavior() const override {
+    // map_zip_with is null preserving for the map, but since an
+    // expr tree with a lambda depends on all named fields, including
+    // captures, a null in a capture does not automatically make a
+    // null result.
+    return false;
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 3);
+    exec::DecodedArgs decodedArgs(rows, {args[0], args[1]}, context);
+    auto decodedLeft = decodedArgs.at(0);
+    auto decodedRight = decodedArgs.at(1);
+    auto* baseLeft = decodedLeft->base()->asUnchecked<MapVector>();
+    auto* baseRight = decodedRight->base()->asUnchecked<MapVector>();
+
+    // Merge two maps. Allocate nulls, offsets and sizes buffers for the merged
+    // maps.
+    BufferPtr newNulls = allocateNulls(rows.end(), context.pool());
+    auto* rawNewNulls = newNulls->asMutable<uint64_t>();
+    BufferPtr newOffsets = allocateIndices(rows.end(), context.pool());
+    auto* rawNewOffsets = newOffsets->asMutable<vector_size_t>();
+    BufferPtr newSizes = allocateIndices(rows.end(), context.pool());
+    auto* rawNewSizes = newSizes->asMutable<vector_size_t>();
+
+    auto numLeftElements = countElements<MapVector>(rows, *decodedLeft);
+    auto numRightElements = countElements<MapVector>(rows, *decodedRight);
+
+    // The total number of elements in the merged maps will not exceed the total
+    // sum of elements in the input maps.
+    auto maxElements = numLeftElements + numRightElements;
+
+    BufferPtr leftIndices = allocateIndices(maxElements, context.pool());
+    auto* rawLeftIndices = leftIndices->asMutable<vector_size_t>();
+    BufferPtr leftNulls = allocateNulls(maxElements, context.pool());
+    auto* rawLeftNulls = leftNulls->asMutable<uint64_t>();
+
+    BufferPtr rightIndices = allocateIndices(maxElements, context.pool());
+    auto* rawRightIndices = rightIndices->asMutable<vector_size_t>();
+    BufferPtr rightNulls = allocateNulls(maxElements, context.pool());
+    auto* rawRightNulls = rightNulls->asMutable<uint64_t>();
+
+    auto leftKeys = baseLeft->mapKeys();
+    auto rightKeys = baseRight->mapKeys();
+
+    vector_size_t index = 0;
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decodedLeft->isNullAt(row) || decodedRight->isNullAt(row)) {
+        bits::setNull(rawNewNulls, row);
+        return;
+      }
+
+      rawNewOffsets[row] = index;
+
+      auto leftRow = decodedLeft->index(row);
+      auto rightRow = decodedRight->index(row);
+
+      auto leftSorted = baseLeft->sortedKeyIndices(leftRow);
+      auto rightSorted = baseRight->sortedKeyIndices(rightRow);
+
+      mergeKeys(
+          leftKeys,
+          rightKeys,
+          leftSorted,
+          rightSorted,
+          rawLeftNulls,
+          rawRightNulls,
+          rawLeftIndices,
+          rawRightIndices,
+          index);
+
+      rawNewSizes[row] = index - rawNewOffsets[row];
+    });
+
+    auto mergedLeftValues = BaseVector::wrapInDictionary(
+        leftNulls, leftIndices, index, baseLeft->mapValues());
+    auto mergedRightValues = BaseVector::wrapInDictionary(
+        rightNulls, rightIndices, index, baseRight->mapValues());
+
+    // Merge keys.
+    auto mergedKeys =
+        BaseVector::create(leftKeys->type(), index, context.pool());
+    for (auto i = 0; i < index; ++i) {
+      if (bits::isBitNull(rawLeftNulls, i)) {
+        // Copy right key.
+        mergedKeys->copy(rightKeys.get(), i, rawRightIndices[i], 1);
+      } else {
+        // Copy left key.
+        mergedKeys->copy(leftKeys.get(), i, rawLeftIndices[i], 1);
+      }
+    }
+
+    std::vector<VectorPtr> lambdaArgs = {
+        mergedKeys, mergedLeftValues, mergedRightValues};
+
+    const SelectivityVector allElementRows(index);
+
+    VectorPtr mergedValues;
+
+    // Loop over lambda functions and apply these to (mergedKeys,
+    // mergedLeftValues, mergedRightValues). In most cases there will be only
+    // one function and the loop will run once.
+    auto it = args[2]->asUnchecked<FunctionVector>()->iterator(&rows);
+    while (auto entry = it.next()) {
+      SelectivityVector elementRows(index, false);
+      entry.rows->applyToSelected([&](auto row) {
+        elementRows.setValidRange(
+            rawNewOffsets[row], rawNewOffsets[row] + rawNewSizes[row], true);
+      });
+      elementRows.updateBounds();
+
+      BufferPtr wrapCapture;
+      if (entry.callable->hasCapture()) {
+        wrapCapture =
+            makeWrapCapture(*entry.rows, index, rawNewSizes, context.pool());
+      }
+
+      // Make sure already populated entries in newElements do not get
+      // overwritten.
+      exec::ScopedFinalSelectionSetter(context, &allElementRows, true, true);
+
+      entry.callable->apply(
+          elementRows,
+          allElementRows,
+          wrapCapture,
+          &context,
+          lambdaArgs,
+          &mergedValues);
+    }
+
+    auto localResult = std::make_shared<MapVector>(
+        context.pool(),
+        outputType,
+        newNulls,
+        rows.end(),
+        newOffsets,
+        newSizes,
+        mergedKeys,
+        mergedValues);
+    context.moveOrCopyResult(localResult, rows, result);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    // map(K, V1), map(K, V2), function(K, V1, V2, V3) -> map(K, V3)
+    return {exec::FunctionSignatureBuilder()
+                .typeVariable("K")
+                .typeVariable("V1")
+                .typeVariable("V2")
+                .typeVariable("V3")
+                .returnType("map(K,V3)")
+                .argumentType("map(K,V1)")
+                .argumentType("map(K,V2)")
+                .argumentType("function(K,V1,V2,V3)")
+                .build()};
+  }
+
+ private:
+  static void mergeKeys(
+      const VectorPtr& leftKeys,
+      const VectorPtr& rightKeys,
+      const std::vector<vector_size_t>& leftSorted,
+      const std::vector<vector_size_t>& rightSorted,
+      uint64_t* rawLeftNulls,
+      uint64_t* rawRightNulls,
+      vector_size_t* rawLeftIndices,
+      vector_size_t* rawRightIndices,
+      vector_size_t& index) {
+    const auto numLeft = leftSorted.size();
+    const auto numRight = rightSorted.size();
+
+    vector_size_t leftIndex = 0;
+    vector_size_t rightIndex = 0;
+    while (leftIndex < numLeft && rightIndex < numRight) {
+      auto compare = leftKeys->compare(
+          rightKeys.get(), leftSorted[leftIndex], rightSorted[rightIndex]);
+      if (compare == 0) {
+        // Left key == right key.
+        rawLeftIndices[index] = leftSorted[leftIndex];
+        rawRightIndices[index] = rightSorted[rightIndex];
+        ++leftIndex;
+        ++rightIndex;
+      } else if (compare < 0) {
+        // Left key < right key.
+        rawLeftIndices[index] = leftSorted[leftIndex];
+        bits::setNull(rawRightNulls, index);
+        ++leftIndex;
+      } else {
+        // Left key > right key.
+        bits::setNull(rawLeftNulls, index);
+        rawRightIndices[index] = rightSorted[rightIndex];
+        ++rightIndex;
+      }
+      ++index;
+    }
+
+    for (; leftIndex < numLeft; ++leftIndex) {
+      rawLeftIndices[index] = leftSorted[leftIndex];
+      bits::setNull(rawRightNulls, index);
+      ++index;
+    }
+
+    for (; rightIndex < numRight; ++rightIndex) {
+      bits::setNull(rawLeftNulls, index);
+      rawRightIndices[index] = rightSorted[rightIndex];
+      ++index;
+    }
+  }
+
+  static BufferPtr makeWrapCapture(
+      const SelectivityVector& rows,
+      vector_size_t size,
+      vector_size_t* rawSizes,
+      memory::MemoryPool* pool) {
+    BufferPtr wrapCapture = allocateIndices(size, pool);
+    auto rawWrapCaptures = wrapCapture->asMutable<vector_size_t>();
+
+    vector_size_t offset = 0;
+    rows.applyToSelected([&](auto row) {
+      auto size = rawSizes[row];
+      std::fill(rawWrapCaptures + offset, rawWrapCaptures + offset + size, row);
+      offset += size;
+    });
+
+    return wrapCapture;
+  }
+};
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_map_zip_with,
+    MapZipWithFunction::signatures(),
+    std::make_unique<MapZipWithFunction>());
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -151,3 +151,8 @@ add_executable(velox_functions_prestosql_benchmarks_zip_with
                ZipWithBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_zip_with
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_map_zip_with
+               MapZipWithBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_map_zip_with
+                      ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/MapZipWithBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapZipWithBenchmark.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -45,6 +46,12 @@ class MapZipWithBenchmark : public functions::test::FunctionBenchmarkBase {
     flatKeysMap_ = BaseVector::create(
         dictionaryKeysMap_->type(), options.vectorSize, pool());
     flatKeysMap_->copy(dictionaryKeysMap_.get(), 0, 0, options.vectorSize);
+
+    auto sortedKeysMap = std::dynamic_pointer_cast<MapVector>(
+        BaseVector::create(flatKeysMap_->type(), options.vectorSize, pool()));
+    sortedKeysMap->copy(flatKeysMap_.get(), 0, 0, options.vectorSize);
+    MapVector::canonicalize(sortedKeysMap);
+    sortedKeysMap_ = std::move(sortedKeysMap);
   }
 
   void test() {
@@ -56,36 +63,36 @@ class MapZipWithBenchmark : public functions::test::FunctionBenchmarkBase {
   }
 
   size_t runFlatKeys(size_t times) {
-    folly::BenchmarkSuspender suspender;
-    auto data = vectorMaker_.rowVector({flatKeysMap_});
-    auto exprSet = compileExpression(kBasicExpression, asRowType(data->type()));
-    suspender.dismiss();
+    return run(flatKeysMap_, times);
+  }
 
-    return doRun(exprSet, data, times);
+  size_t runSortedKeys(size_t times) {
+    return run(sortedKeysMap_, times);
   }
 
   size_t runDictionaryKeys(size_t times) {
-    folly::BenchmarkSuspender suspender;
-    auto data = vectorMaker_.rowVector({dictionaryKeysMap_});
-    auto exprSet = compileExpression(kBasicExpression, asRowType(data->type()));
-    suspender.dismiss();
-
-    return doRun(exprSet, data, times);
+    return run(dictionaryKeysMap_, times);
   }
 
  private:
   static const std::string kBasicExpression;
 
-  size_t doRun(ExprSet& exprSet, const RowVectorPtr& rowVector, size_t times) {
+  size_t run(const VectorPtr& vector, size_t times) {
+    folly::BenchmarkSuspender suspender;
+    auto data = vectorMaker_.rowVector({vector});
+    auto exprSet = compileExpression(kBasicExpression, asRowType(data->type()));
+    suspender.dismiss();
+
     int cnt = 0;
     for (auto i = 0; i < times * 1'000; i++) {
-      cnt += evaluate(exprSet, rowVector)->size();
+      cnt += evaluate(exprSet, data)->size();
     }
     return cnt;
   }
 
   const uint32_t seed_;
   VectorPtr flatKeysMap_;
+  VectorPtr sortedKeysMap_;
   VectorPtr dictionaryKeysMap_;
 };
 
@@ -94,11 +101,20 @@ const std::string MapZipWithBenchmark::kBasicExpression =
 
 const uint32_t seed = folly::Random::rand32();
 
+// Use flat map with flat keys and values. No nulls.
 BENCHMARK_MULTI(flatKeys, n) {
   MapZipWithBenchmark benchmark(seed);
   return benchmark.runFlatKeys(n);
 }
 
+// Use flat map with sorted keys. Keys and values will be dictionary encoded as
+// a result of sorting.
+BENCHMARK_MULTI(sortedKeys, n) {
+  MapZipWithBenchmark benchmark(seed);
+  return benchmark.runSortedKeys(n);
+}
+
+// Use flat map with dictionary encoded keys and flat values.
 BENCHMARK_MULTI(dictionaryKeys, n) {
   MapZipWithBenchmark benchmark(seed);
   return benchmark.runDictionaryKeys(n);
@@ -106,7 +122,9 @@ BENCHMARK_MULTI(dictionaryKeys, n) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   LOG(ERROR) << "Seed: " << seed;
   {
     MapZipWithBenchmark benchmark(seed);

--- a/velox/functions/prestosql/benchmarks/MapZipWithBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapZipWithBenchmark.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+
+class MapZipWithBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  explicit MapZipWithBenchmark(uint32_t seed)
+      : FunctionBenchmarkBase(), seed_{seed} {
+    functions::prestosql::registerAllScalarFunctions();
+
+    VectorFuzzer::Options options;
+    options.vectorSize = 10'024;
+
+    VectorFuzzer fuzzer(options, pool(), seed_);
+    dictionaryKeysMap_ = fuzzer.fuzzMap(
+        fuzzer.fuzzDictionary(
+            fuzzer.fuzzFlat(INTEGER(), 100),
+            options.vectorSize * options.containerLength),
+        fuzzer.fuzzFlat(BIGINT(), options.vectorSize * options.containerLength),
+        options.vectorSize);
+
+    flatKeysMap_ = BaseVector::create(
+        dictionaryKeysMap_->type(), options.vectorSize, pool());
+    flatKeysMap_->copy(dictionaryKeysMap_.get(), 0, 0, options.vectorSize);
+  }
+
+  void test() {
+    auto flatResult =
+        evaluate(kBasicExpression, vectorMaker_.rowVector({flatKeysMap_}));
+    auto dictionaryResult = evaluate(
+        kBasicExpression, vectorMaker_.rowVector({dictionaryKeysMap_}));
+    test::assertEqualVectors(flatResult, dictionaryResult);
+  }
+
+  size_t runFlatKeys(size_t times) {
+    folly::BenchmarkSuspender suspender;
+    auto data = vectorMaker_.rowVector({flatKeysMap_});
+    auto exprSet = compileExpression(kBasicExpression, asRowType(data->type()));
+    suspender.dismiss();
+
+    return doRun(exprSet, data, times);
+  }
+
+  size_t runDictionaryKeys(size_t times) {
+    folly::BenchmarkSuspender suspender;
+    auto data = vectorMaker_.rowVector({dictionaryKeysMap_});
+    auto exprSet = compileExpression(kBasicExpression, asRowType(data->type()));
+    suspender.dismiss();
+
+    return doRun(exprSet, data, times);
+  }
+
+ private:
+  static const std::string kBasicExpression;
+
+  size_t doRun(ExprSet& exprSet, const RowVectorPtr& rowVector, size_t times) {
+    int cnt = 0;
+    for (auto i = 0; i < times * 1'000; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    return cnt;
+  }
+
+  const uint32_t seed_;
+  VectorPtr flatKeysMap_;
+  VectorPtr dictionaryKeysMap_;
+};
+
+const std::string MapZipWithBenchmark::kBasicExpression =
+    "map_zip_with(c0, c0, (k, v1, v2) -> v1 + v2)";
+
+const uint32_t seed = folly::Random::rand32();
+
+BENCHMARK_MULTI(flatKeys, n) {
+  MapZipWithBenchmark benchmark(seed);
+  return benchmark.runFlatKeys(n);
+}
+
+BENCHMARK_MULTI(dictionaryKeys, n) {
+  MapZipWithBenchmark benchmark(seed);
+  return benchmark.runDictionaryKeys(n);
+}
+
+} // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+  LOG(ERROR) << "Seed: " << seed;
+  {
+    MapZipWithBenchmark benchmark(seed);
+    benchmark.test();
+  }
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -29,6 +29,7 @@ void registerMapFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_values, "map_values");
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_map_concat_empty_null, "map_concat_empty_nulls");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_zip_with, "map_zip_with");
 }
 
 void registerMapAllowingDuplicates(const std::string& name) {

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(
   MapFilterTest.cpp
   MapKeysAndValuesTest.cpp
   MapTest.cpp
+  MapZipWithTest.cpp
   NotTest.cpp
   ReduceTest.cpp
   RegexpReplaceTest.cpp

--- a/velox/functions/prestosql/tests/MapZipWithTest.cpp
+++ b/velox/functions/prestosql/tests/MapZipWithTest.cpp
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions::test;
+
+namespace {
+
+class MapZipWithTest : public FunctionBaseTest {};
+
+TEST_F(MapZipWithTest, basic) {
+  auto data = makeRowVector({
+      makeMapVector<int64_t, int64_t>({
+          {{2, 20}, {1, 10}, {3, 30}},
+          {{3, 30}, {1, 10}, {7, 70}, {5, 50}},
+          {},
+          {{5, 50}},
+          {},
+      }),
+      makeMapVector<int64_t, int64_t>({
+          {{1, 11}, {2, 21}, {3, 31}},
+          {{1, 11}, {3, 31}, {2, 21}},
+          {{1, 11}, {2, 21}},
+          {{2, 21}, {1, 11}, {3, 31}},
+          {},
+      }),
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+  });
+
+  // No capture. Default null behavior for the lambda: v1 + v2.
+  auto expected = makeMapVector<int64_t, int64_t>({
+      {{1, 21}, {2, 41}, {3, 61}},
+      {{1, 21},
+       {2, std::nullopt},
+       {3, 61},
+       {5, std::nullopt},
+       {7, std::nullopt}},
+      {{1, std::nullopt}, {2, std::nullopt}},
+      {{1, std::nullopt},
+       {2, std::nullopt},
+       {3, std::nullopt},
+       {5, std::nullopt}},
+      {},
+  });
+
+  auto result = evaluate("map_zip_with(c0, c1, (k, v1, v2) -> v1 + v2)", data);
+  assertEqualVectors(expected, result);
+
+  result = evaluate("map_zip_with(c1, c0, (k, v1, v2) -> v1 + v2)", data);
+  assertEqualVectors(expected, result);
+
+  // No capture. Non-default null behavior for the lambda: coalesce(v1, 0) +
+  // coalesce(v2, 0).
+  expected = makeMapVector<int64_t, int64_t>({
+      {{1, 21}, {2, 41}, {3, 61}},
+      {{1, 21}, {2, 21}, {3, 61}, {5, 50}, {7, 70}},
+      {{1, 11}, {2, 21}},
+      {{1, 11}, {2, 21}, {3, 31}, {5, 50}},
+      {},
+  });
+
+  result = evaluate(
+      "map_zip_with(c0, c1, (k, v1, v2) -> coalesce(v1, 0) + coalesce(v2, 0))",
+      data);
+  assertEqualVectors(expected, result);
+
+  result = evaluate(
+      "map_zip_with(c1, c0, (k, v1, v2) -> coalesce(v1, 0) + coalesce(v2, 0))",
+      data);
+  assertEqualVectors(expected, result);
+
+  // With capture.
+  expected = makeMapVector<int64_t, int64_t>({
+      {{1, 21}, {2, 41}, {3, 61}},
+      {{1, 21 * 2},
+       {2, std::nullopt},
+       {3, 61 * 2},
+       {5, std::nullopt},
+       {7, std::nullopt}},
+      {{1, std::nullopt}, {2, std::nullopt}},
+      {{1, std::nullopt},
+       {2, std::nullopt},
+       {3, std::nullopt},
+       {5, std::nullopt}},
+      {},
+  });
+
+  result =
+      evaluate("map_zip_with(c0, c1, (k, v1, v2) -> (v1 + v2) * c2)", data);
+  assertEqualVectors(expected, result);
+
+  result =
+      evaluate("map_zip_with(c1, c0, (k, v1, v2) -> (v1 + v2) * c2)", data);
+  assertEqualVectors(expected, result);
+
+  expected = makeMapVector<int64_t, int64_t>({
+      {{1, 21}, {2, 41}, {3, 61}},
+      {{1, 21 * 2}, {2, 21 * 2}, {3, 61 * 2}, {5, 50 * 2}, {7, 70 * 2}},
+      {{1, 11 * 3}, {2, 21 * 3}},
+      {{1, 11 * 4}, {2, 21 * 4}, {3, 31 * 4}, {5, 50 * 4}},
+      {},
+  });
+
+  result = evaluate(
+      "map_zip_with(c0, c1, (k, v1, v2) -> c2 * (coalesce(v1, 0) + coalesce(v2, 0)))",
+      data);
+  assertEqualVectors(expected, result);
+
+  result = evaluate(
+      "map_zip_with(c1, c0, (k, v1, v2) -> c2 * (coalesce(v1, 0) + coalesce(v2, 0)))",
+      data);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(MapZipWithTest, nulls) {
+  auto data = makeRowVector({
+      makeNullableMapVector<int64_t, int64_t>({
+          {{{2, 20}, {1, 10}, {3, 30}}},
+          {{{1, 10}, {2, 20}, {3, 30}}},
+          std::nullopt,
+          std::nullopt,
+          {},
+          {{{2, 20}, {1, std::nullopt}, {3, 30}}},
+      }),
+      makeNullableMapVector<int64_t, int64_t>({
+          {{{3, 31}, {1, 11}, {2, 21}}},
+          std::nullopt,
+          {{{1, 11}, {2, 21}, {3, 31}}},
+          std::nullopt,
+          {},
+          {{{2, std::nullopt}, {1, 11}, {3, 31}}},
+      }),
+  });
+
+  auto expected = makeNullableMapVector<int64_t, int64_t>({
+      {{{1, 21}, {2, 41}, {3, 61}}},
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      {},
+      {{{1, std::nullopt}, {2, std::nullopt}, {3, 61}}},
+  });
+
+  auto result = evaluate("map_zip_with(c0, c1, (k, v1, v2) -> v1 + v2)", data);
+  assertEqualVectors(expected, result);
+
+  result = evaluate("map_zip_with(c1, c0, (k, v1, v2) -> v1 + v2)", data);
+  assertEqualVectors(expected, result);
+
+  expected = makeNullableMapVector<int64_t, int64_t>({
+      {{{1, 21}, {2, 41}, {3, 61}}},
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      {},
+      {{{1, 11}, {2, 20}, {3, 61}}},
+  });
+
+  result = evaluate(
+      "map_zip_with(c0, c1, (k, v1, v2) -> coalesce(v1, 0) + coalesce(v2, 0))",
+      data);
+  assertEqualVectors(expected, result);
+
+  result = evaluate(
+      "map_zip_with(c1, c0, (k, v1, v2) -> coalesce(v1, 0) + coalesce(v2, 0))",
+      data);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(MapZipWithTest, conditional) {
+  auto data = makeRowVector({
+      makeMapVector<int64_t, int64_t>({
+          {{2, 20}, {1, 10}, {3, 30}},
+          {{3, 30}, {1, 10}, {7, 70}, {5, 50}},
+          {},
+          {{5, 50}},
+          {},
+      }),
+      makeMapVector<int64_t, int64_t>({
+          {{1, 11}, {2, 21}, {3, 31}},
+          {{1, 11}, {3, 31}, {2, 21}},
+          {{1, 11}, {2, 21}},
+          {{2, 21}, {1, 11}, {3, 31}},
+          {},
+      }),
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+  });
+
+  auto result = evaluate(
+      "if (c2 % 2 = 0, "
+      "   map_zip_with(c0, c1, (k, v1, v2) -> v1 + v2), "
+      "   map_zip_with(c0, c1, (k, v1, v2) -> v1 - v2))",
+      data);
+  auto expected = makeMapVector<int64_t, int64_t>({
+      {{1, -1}, {2, -1}, {3, -1}},
+      {{1, 21},
+       {2, std::nullopt},
+       {3, 61},
+       {5, std::nullopt},
+       {7, std::nullopt}},
+      {{1, std::nullopt}, {2, std::nullopt}},
+      {{1, std::nullopt},
+       {2, std::nullopt},
+       {3, std::nullopt},
+       {5, std::nullopt}},
+      {},
+  });
+  assertEqualVectors(expected, result);
+
+  result = evaluate(
+      "map_zip_with(c0, c1, "
+      "   if (c2 % 2 = 0, (k, v1, v2) -> v1 + v2, (k, v1, v2) -> v1 - v2))",
+      data);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(MapZipWithTest, fuzz) {
+  auto baseData = makeRowVector({
+      makeMapVector<int64_t, int64_t>({
+          {{2, 20}, {1, 10}, {3, 30}},
+          {{3, 30}, {1, 10}, {7, 70}, {5, 50}},
+          {},
+          {{5, 50}},
+          {},
+      }),
+      makeMapVector<int64_t, int64_t>({
+          {{1, 11}, {2, 21}, {3, 31}},
+          {{1, 11}, {3, 31}, {2, 21}},
+          {{1, 11}, {2, 21}},
+          {{2, 21}, {1, 11}, {3, 31}},
+          {},
+      }),
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+  });
+
+  VectorFuzzer::Options options;
+  options.vectorSize = 1024;
+  options.nullRatio = 0.1;
+
+  VectorFuzzer fuzzer(options, pool());
+
+  for (auto i = 0; i < 10; ++i) {
+    auto data = makeRowVector({
+        fuzzer.fuzzDictionary(baseData->childAt(0), options.vectorSize),
+        fuzzer.fuzzDictionary(baseData->childAt(1), options.vectorSize),
+        fuzzer.fuzzDictionary(baseData->childAt(2), options.vectorSize),
+    });
+    auto flatData = flatten<RowVector>(data);
+
+    auto result =
+        evaluate("map_zip_with(c0, c1, (k, v1, v2) -> v1 + v2)", data);
+    auto expected =
+        evaluate("map_zip_with(c0, c1, (k, v1, v2) -> v1 + v2)", flatData);
+    assertEqualVectors(expected, result);
+
+    result =
+        evaluate("map_zip_with(c0, c1, (k, v1, v2) -> c2 * (v1 + v2))", data);
+    expected = evaluate(
+        "map_zip_with(c0, c1, (k, v1, v2) -> c2 * (v1 + v2))", flatData);
+    assertEqualVectors(expected, result);
+
+    result = evaluate(
+        "map_zip_with(c0, c1, (k, v1, v2) -> coalesce(v1, 0) + coalesce(v2, 0))",
+        data);
+    expected = evaluate(
+        "map_zip_with(c0, c1, (k, v1, v2) -> coalesce(v1, 0) + coalesce(v2, 0))",
+        flatData);
+    assertEqualVectors(expected, result);
+
+    result = evaluate(
+        "map_zip_with(c0, c1, (k, v1, v2) -> c2 * (coalesce(v1, 0) + coalesce(v2, 0)))",
+        data);
+    expected = evaluate(
+        "map_zip_with(c0, c1, (k, v1, v2) -> c2 * (coalesce(v1, 0) + coalesce(v2, 0)))",
+        flatData);
+    assertEqualVectors(expected, result);
+  }
+}
+} // namespace

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -267,6 +267,20 @@ class BaseVector {
         });
   }
 
+  /// Sort values at specified 'indices' after applying the 'mapping'. Used to
+  /// sort map keys.
+  virtual void sortIndices(
+      std::vector<vector_size_t>& indices,
+      const vector_size_t* mapping,
+      CompareFlags flags) const {
+    std::sort(
+        indices.begin(),
+        indices.end(),
+        [&](vector_size_t left, vector_size_t right) {
+          return compare(this, mapping[left], mapping[right], flags) < 0;
+        });
+  }
+
   /**
    * @return the hash of the value at the given index in this vector
    */

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -530,6 +530,10 @@ class MapVector : public ArrayVectorBase {
     return values_;
   }
 
+  bool hasSortedKeys() const {
+    return sortedKeys_;
+  }
+
   vector_size_t reserveMap(vector_size_t offset, vector_size_t size);
 
   void setKeysAndValues(VectorPtr keys, VectorPtr values) {


### PR DESCRIPTION
Summary:
Skip sorting if keys in input map are already sorted.

Also, reuse the vectors of sorted key indices.

Add benchmark to compare evaluating map_zip_with over sorted and unsorted maps.

```
$ buck run mode/opt velox/functions/prestosql/benchmarks:map_zip_with

============================================================================
[...]ql/benchmarks/MapZipWithBenchmark.cpp     relative  time/iter   iters/s
============================================================================
flatKeys                                                  604.46ns     1.65M
sortedKeys                                                448.50ns     2.23M
dictionaryKeys                                            845.92ns     1.18M
```

Differential Revision: D40079881

