### PR TITLE
Fix velox_tpch_benchmark build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,9 +319,9 @@ jobs:
             set -xu
             yum -y install java-1.8.0-openjdk
       - run:
-          name: Build
+          name: Build including all Benchmarks
           command: |
-            make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_HDFS=ON -DVELOX_ENABLE_S3=ON -DVELOX_ENABLE_SUBSTRAIT=ON" AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
+            make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_BENCHMARKS=ON -DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_HDFS=ON -DVELOX_ENABLE_S3=ON -DVELOX_ENABLE_SUBSTRAIT=ON" AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
             ccache -s
           no_output_timeout: 1h
       - run:

--- a/velox/benchmarks/tpch/CMakeLists.txt
+++ b/velox/benchmarks/tpch/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(
   velox_encode
   velox_type
   velox_caching
-  velox_vector
+  velox_vector_test_lib
   ${FOLLY_WITH_DEPENDENCIES}
   ${FOLLY_BENCHMARK}
   ${FMT})


### PR DESCRIPTION
Fix build failure of velox_tpch_benchmark
Build all benchmarks as part of linux-adapters CI