### PR TITLE
Disable consistency check at MemoryPoolImpl destruction

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -424,17 +424,20 @@ class MemoryPoolImpl : public MemoryPoolBase {
       int64_t cap = kMaxMemory);
 
   ~MemoryPoolImpl() {
-    if (const auto& tracker = getMemoryUsageTracker()) {
-      auto remainingBytes = tracker->getCurrentUserBytes();
-      VELOX_CHECK_EQ(
-          0,
-          remainingBytes,
-          "Memory pool should be destroyed only after all allocated memory "
-          "has been freed. Remaining bytes allocated: {}, cumulative bytes allocated: {}, number of allocations: {}",
-          remainingBytes,
-          tracker->getCumulativeBytes(),
-          tracker->getNumAllocs());
-    }
+    // TODO(xiaoxmeng): Inconsistency discovered by following check when
+    // running with Prestissmo. Re-enable this check after the issue gets fixed.
+    //
+    // if (const auto& tracker = getMemoryUsageTracker()) {
+    //   auto remainingBytes = tracker->getCurrentUserBytes();
+    //   VELOX_CHECK_EQ(
+    //       0,
+    //       remainingBytes,
+    //       "Memory pool should be destroyed only after all allocated memory "
+    //       "has been freed. Remaining bytes allocated: {}, cumulative bytes
+    //       allocated: {}, number of allocations: {}", remainingBytes,
+    //       tracker->getCumulativeBytes(),
+    //       tracker->getNumAllocs());
+    // }
   }
 
   // Actual memory allocation operations. Can be delegated.

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2051,18 +2051,24 @@ TEST_F(VectorTest, mapSliceMutability) {
       std::dynamic_pointer_cast<MapVector>(createMap(vectorSize_, false)));
 }
 
-// Demonstrates incorrect usage of the memory pool. The pool is destroyed while
-// the vector allocated from it is still alive.
-TEST_F(VectorTest, lifetime) {
-  ASSERT_DEATH(
-      {
-        auto childPool = pool_->addScopedChild("test");
-        auto v = BaseVector::create(INTEGER(), 10, childPool.get());
+// TODO(xiaoxmeng): Inconsistency discovered by following check when
+// running with Prestissmo. Re-enable this check after the issue gets fixed.
+//
+// // Demonstrates incorrect usage of the memory pool. The pool is destroyed
+// while
+// // the vector allocated from it is still alive.
+// TEST_F(VectorTest, lifetime) {
+//   ASSERT_DEATH(
+//       {
+//         auto childPool = pool_->addScopedChild("test");
+//         auto v = BaseVector::create(INTEGER(), 10, childPool.get());
 
-        // BUG: Memory pool needs to stay alive until all memory allocated from
-        // it is freed.
-        childPool.reset();
-        v.reset();
-      },
-      "Memory pool should be destroyed only after all allocated memory has been freed.");
-}
+//         // BUG: Memory pool needs to stay alive until all memory allocated
+//         from
+//         // it is freed.
+//         childPool.reset();
+//         v.reset();
+//       },
+//       "Memory pool should be destroyed only after all allocated memory has
+//       been freed.");
+// }


### PR DESCRIPTION
Summary: Some undiscovered memory issue is making the current consistency check fail, crashing the server. Disable it until root cause is found.

Reviewed By: xiaoxmeng

Differential Revision: D40117127

