### PR TITLE
Optimize like function for generic patterns

### DIFF
--- a/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
@@ -90,6 +90,10 @@ class LikeFunctionsBenchmark : public FunctionBaseTest,
         auto fixedPatternString = inputString.substr(fixedPatternStartIdx, 10);
         return generateRandomString(kAnyWildcardCharacter) + fixedPatternString;
       }
+      case PatternKind::kGeneric: {
+        return generateRandomString(kAnyWildcardCharacter) + inputString +
+            generateRandomString(kAnyWildcardCharacter);
+      }
       default:
         return inputString;
     }
@@ -195,6 +199,10 @@ BENCHMARK_MULTI(prefixPattern) {
 
 BENCHMARK_MULTI(suffixPattern) {
   return benchmark->run(PatternKind::kSuffix);
+}
+
+BENCHMARK_MULTI(genericPattern) {
+  return benchmark->run(PatternKind::kGeneric);
 }
 
 BENCHMARK_DRAW_LINE();

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -562,6 +562,34 @@ TEST_F(Re2FunctionsTest, likePatternSuffix) {
   EXPECT_TRUE(like(input, generateString(kAnyWildcardCharacter) + input));
 }
 
+TEST_F(Re2FunctionsTest, likePatternGeneric) {
+  auto like = [&](std::string str, std::string pattern) {
+    auto likeResult = evaluateOnce<bool>(
+        fmt::format("like(c0, '{}')", pattern), std::make_optional(str));
+    VELOX_CHECK(likeResult, "Like operator evaluation failed");
+    return *likeResult;
+  };
+
+  EXPECT_TRUE(like("a", "%_%"));
+  EXPECT_TRUE(like("abcde", "%b_de"));
+  EXPECT_TRUE(like("ABCDE", "%C_E"));
+  EXPECT_TRUE(like("abcde", "%_cde"));
+  EXPECT_TRUE(like("ABCDE", "%_DE"));
+  EXPECT_TRUE(like("abcde", "_%de"));
+  EXPECT_TRUE(like("ABCDE", "_%DE"));
+  EXPECT_TRUE(like("abcde", "_%e"));
+  EXPECT_TRUE(like("ABCDE", "%_E"));
+  EXPECT_FALSE(like("", "%_"));
+  EXPECT_FALSE(like("abcde", "%c_de"));
+  EXPECT_FALSE(like("ABCDE", "%B_E"));
+  EXPECT_FALSE(like("abcde", "_%c_de"));
+  EXPECT_FALSE(like("ABCDE", "_%B_E"));
+  EXPECT_FALSE(like("abcde", "%be"));
+  EXPECT_FALSE(like("ABCDE", "__de"));
+  EXPECT_FALSE(like("abcde", "%_ce"));
+  EXPECT_FALSE(like("ABCDE", "%b_e"));
+}
+
 TEST_F(Re2FunctionsTest, likePatternAndEscape) {
   auto like = ([&](std::optional<std::string> str,
                    std::optional<std::string> pattern,


### PR DESCRIPTION
Below benchmarks are with only ```%``` in the wildcard character set. When the wildcard character set also includes ```_```, a larger improvement is seen (benchmark computation takes a long time and will be updated soon).
Without changes (Re2 matcher):
```
============================================================================
[...]arks/basic/LikeFunctionsBenchmark.cpp     relative  time/iter   iters/s
============================================================================
genericPattern                                            750.11ns     1.33M
```

With changes (recursive matching):
```
============================================================================
[...]arks/basic/LikeFunctionsBenchmark.cpp     relative  time/iter   iters/s
============================================================================
genericPattern                                            262.51ns     3.81M
```