### PR TITLE
Fix cast-to-json-in-try caused by mismatch between element rows and top-level rows

### DIFF
--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -25,6 +25,7 @@
 #include "folly/json.h"
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/expression/EvalCtx.h"
 #include "velox/expression/StringWriter.h"
 #include "velox/expression/VectorWriters.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"
@@ -165,8 +166,12 @@ struct AsJson {
       exec::EvalCtx& context,
       const VectorPtr& input,
       const SelectivityVector& rows,
+      const BufferPtr& elementToTopLevelRows,
       bool isMapKey = false)
       : decoded_(context, *input, rows) {
+    exec::EvalCtx::ErrorVectorPtr oldErrors;
+    context.swapErrors(oldErrors);
+
     if (isMapKey && decoded_->mayHaveNulls()) {
       context.applyToSelectedNoThrow(rows, [&](auto row) {
         if (decoded_->isNullAt(row)) {
@@ -178,6 +183,7 @@ struct AsJson {
     if (isJsonType(input->type())) {
       json_ = nullptr;
       jsonStrings_ = decoded_->base()->as<SimpleVector<StringView>>();
+      combineErrors(context, rows, elementToTopLevelRows, oldErrors);
       return;
     }
 
@@ -204,6 +210,7 @@ struct AsJson {
         isMapKey);
 
     jsonStrings_ = flatJsonStrings;
+    combineErrors(context, rows, elementToTopLevelRows, oldErrors);
   }
 
   StringView at(vector_size_t i) const {
@@ -231,6 +238,28 @@ struct AsJson {
     }
   }
 
+ private:
+  // Combine exceptions in oldErrors into context.errors_ with a transformation
+  // of rows mapping provided by elementToTopLevelRows. If there are exceptions
+  // at the same row in both context.errors_ and oldErrors, the one in oldErrors
+  // remains. elementToTopLevelRows can be a nullptr, meaning that the rows in
+  // context.errors_ correspond to rows in oldErrors exactly.
+  void combineErrors(
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const BufferPtr& elementToTopLevelRows,
+      exec::EvalCtx::ErrorVectorPtr& oldErrors) {
+    if (context.errors()) {
+      if (elementToTopLevelRows) {
+        context.addElementErrorsToTopLevel(
+            rows, elementToTopLevelRows, oldErrors);
+      } else {
+        context.addErrors(rows, *context.errorsPtr(), oldErrors);
+      }
+    }
+    context.swapErrors(oldErrors);
+  }
+
   exec::LocalDecodedVector decoded_;
   VectorPtr json_;
   const SimpleVector<StringView>* jsonStrings_;
@@ -247,7 +276,9 @@ void castToJsonFromArray(
   auto elements = inputArray->elements();
   auto elementsRows =
       functions::toElementRows(elements->size(), rows, inputArray);
-  AsJson elementsAsJson{context, elements, elementsRows};
+  auto elementToTopLevelRows = functions::getElementToTopLevelRows(
+      elements->size(), rows, inputArray, context.pool());
+  AsJson elementsAsJson{context, elements, elementsRows, elementToTopLevelRows};
 
   // Estimates an upperbound of the total length of all Json strings for the
   // input according to the length of all elements Json strings and the
@@ -307,11 +338,13 @@ void castToJsonFromMap(
   auto mapKeys = inputMap->mapKeys();
   auto mapValues = inputMap->mapValues();
   auto elementsRows = functions::toElementRows(mapKeys->size(), rows, inputMap);
-
+  auto elementToTopLevelRows = functions::getElementToTopLevelRows(
+      mapKeys->size(), rows, inputMap, context.pool());
   // Maps with unsupported key types should have already been rejected by
   // JsonCastOperator::isSupportedType() beforehand.
-  AsJson keysAsJson{context, mapKeys, elementsRows, true};
-  AsJson valuesAsJson{context, mapValues, elementsRows};
+  AsJson keysAsJson{
+      context, mapKeys, elementsRows, elementToTopLevelRows, true};
+  AsJson valuesAsJson{context, mapValues, elementsRows, elementToTopLevelRows};
 
   // Estimates an upperbound of the total length of all Json strings for the
   // input according to the length of all elements Json strings and the
@@ -387,7 +420,7 @@ void castToJsonFromRow(
   size_t childrenStringSize = 0;
   std::vector<AsJson> childrenAsJson;
   for (int i = 0; i < childrenSize; ++i) {
-    childrenAsJson.emplace_back(context, inputRow->childAt(i), rows);
+    childrenAsJson.emplace_back(context, inputRow->childAt(i), rows, nullptr);
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       if (inputRow->isNullAt(row)) {


### PR DESCRIPTION
Summary:
The evaluation of cast of array or map to JSON process their element vectors
directly. Exceptions are kept in
EvalCtx::errors_ at the same rows as the elements that cause errors if exist. If the
cast is wrapped in a try expression, these exceptions are then turned into
nulls at the same rows in the result vector. This lead to a mismatch because
exceptions are kept at element rows whereas values in the result vector are
at top-level rows. This diff transform EvalCtx::errors_ to map exceptions back
to top-level rows for cast to JSON.

Differential Revision: D40131130

