### PR TITLE
Combine DuckDB query parsing and planning with Velox execution

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(
   SpillTest.cpp
   SpillOperatorGroupTest.cpp
   SpillerTest.cpp
+  SqlTest.cpp
   StreamingAggregationTest.cpp
   TableScanTest.cpp
   TableWriteTest.cpp

--- a/velox/exec/tests/SqlTest.cpp
+++ b/velox/exec/tests/SqlTest.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/parse/QueryPlanner.h"
+
+namespace facebook::velox::exec::test {
+
+class SqlTest : public OperatorTestBase {
+ protected:
+  void assertSql(const std::string& sql, const std::string& duckSql = "") {
+    auto plan = planner_.plan(sql);
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults(duckSql.empty() ? sql : duckSql);
+  }
+
+  core::DuckDbQueryPlanner planner_{pool()};
+};
+
+TEST_F(SqlTest, values) {
+  assertSql("SELECT x, x + 5 FROM UNNEST([1, 2, 3]) as t(x)");
+  assertSql("SELECT avg(x), count(*) FROM UNNEST([1, 2, 3]) as t(x)");
+  assertSql("SELECT x % 5, avg(x) FROM UNNEST([1, 2, 3]) as t(x) GROUP BY 1");
+  assertSql("SELECT avg(x * 4) FROM UNNEST([1, 2, 3]) as t(x)");
+  assertSql(
+      "SELECT x / 5, avg(x * 4) FROM UNNEST([1, 2, 3]) as t(x) GROUP BY 1");
+}
+
+TEST_F(SqlTest, customScalarFunctions) {
+  planner_.registerScalarFunction(
+      "array_join", {ARRAY(BIGINT()), VARCHAR()}, VARCHAR());
+
+  assertSql("SELECT array_join([1, 2, 3], '-')", "SELECT '1-2-3'");
+}
+
+TEST_F(SqlTest, customAggregateFunctions) {
+  planner_.registerAggregateFunction("count_if", {BOOLEAN()}, BIGINT());
+
+  assertSql(
+      "SELECT count_if(x > 2) FROM UNNEST([1, 2, 3]) as t(x)", "SELECT 1");
+  assertSql(
+      "SELECT x % 2, count_if(x > 0) FROM UNNEST([1, 2, 3]) as t(x) GROUP BY 1",
+      "VALUES (0, 1), (1, 2)");
+}
+
+TEST_F(SqlTest, tableScan) {
+  std::unordered_map<std::string, std::vector<RowVectorPtr>> data = {
+      {"t",
+       {makeRowVector(
+           {"a", "b", "c"},
+           {
+               makeFlatVector<int64_t>({1, 2, 3, 1, 2, 3}),
+               makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6}),
+               makeFlatVector<int16_t>({3, 6, 8, 2, 9, 10}),
+           })}},
+      {"u",
+       {makeRowVector(
+           {"a", "b"},
+           {
+               makeFlatVector<int64_t>({1, 2, 3, 4, 5, 1}),
+               makeFlatVector<double>({1.1, 2.2, 3.3, 4.4, 5.5, 1.2}),
+           })}},
+  };
+
+  createDuckDbTable("t", data.at("t"));
+  createDuckDbTable("u", data.at("u"));
+
+  planner_.registerTable("t", data.at("t"));
+  planner_.registerTable("u", data.at("u"));
+
+  assertSql("SELECT a, avg(b) FROM t WHERE c > 5 GROUP BY 1");
+  assertSql("SELECT * FROM t, u WHERE t.a = u.a");
+  assertSql("SELECT t.a, t.b, t.c, u.b FROM t, u WHERE t.a = u.a");
+}
+} // namespace facebook::velox::exec::test

--- a/velox/parse/DuckLogicalOperator.h
+++ b/velox/parse/DuckLogicalOperator.h
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+// This file contains the definitions of the logical plan nodes extracted from
+// the duckdb-internal.hpp file. It is not possible to include
+// duckdb-internal.hpp directly because it contains an incompatible / outdated
+// copy of fmt/format.h.
+
+/*
+Copyright 2018-2022 Stichting DuckDB Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "velox/external/duckdb/duckdb.hpp"
+
+namespace duckdb {
+
+//! LogicalDummyScan represents a dummy scan returning a single row
+class LogicalDummyScan : public LogicalOperator {
+ public:
+  explicit LogicalDummyScan(idx_t table_index)
+      : LogicalOperator(LogicalOperatorType::LOGICAL_DUMMY_SCAN),
+        table_index(table_index) {}
+
+  idx_t table_index;
+
+ public:
+  vector<ColumnBinding> GetColumnBindings() override {
+    return {ColumnBinding(table_index, 0)};
+  }
+
+  idx_t EstimateCardinality(ClientContext& context) override {
+    return 1;
+  }
+
+ protected:
+  void ResolveTypes() override {
+    if (types.size() == 0) {
+      types.emplace_back(LogicalType::INTEGER);
+    }
+  }
+};
+
+//! LogicalGet represents a scan operation from a data source
+class LogicalGet : public LogicalOperator {
+ public:
+  LogicalGet(
+      idx_t table_index,
+      TableFunction function,
+      unique_ptr<FunctionData> bind_data,
+      vector<LogicalType> returned_types,
+      vector<string> returned_names);
+
+  //! The table index in the current bind context
+  idx_t table_index;
+  //! The function that is called
+  TableFunction function;
+  //! The bind data of the function
+  unique_ptr<FunctionData> bind_data;
+  //! The types of ALL columns that can be returned by the table function
+  vector<LogicalType> returned_types;
+  //! The names of ALL columns that can be returned by the table function
+  vector<string> names;
+  //! Bound column IDs
+  vector<column_t> column_ids;
+  //! Filters pushed down for table scan
+  TableFilterSet table_filters;
+
+  string GetName() const override;
+  string ParamsToString() const override;
+  //! Returns the underlying table that is being scanned, or nullptr if there is
+  //! none
+  TableCatalogEntry* GetTable() const;
+
+ public:
+  vector<ColumnBinding> GetColumnBindings() override;
+
+  idx_t EstimateCardinality(ClientContext& context) override;
+
+ protected:
+  void ResolveTypes() override;
+};
+
+//! LogicalFilter represents a filter operation (e.g. WHERE or HAVING clause)
+class LogicalFilter : public LogicalOperator {
+ public:
+  explicit LogicalFilter(unique_ptr<Expression> expression);
+  LogicalFilter();
+
+  vector<idx_t> projection_map;
+
+ public:
+  vector<ColumnBinding> GetColumnBindings() override;
+
+  bool SplitPredicates() {
+    return SplitPredicates(expressions);
+  }
+  //! Splits up the predicates of the LogicalFilter into a set of predicates
+  //! separated by AND Returns whether or not any splits were made
+  static bool SplitPredicates(vector<unique_ptr<Expression>>& expressions);
+
+ protected:
+  void ResolveTypes() override;
+};
+
+//! LogicalProjection represents the projection list in a SELECT clause
+class LogicalProjection : public LogicalOperator {
+ public:
+  LogicalProjection(
+      idx_t table_index,
+      vector<unique_ptr<Expression>> select_list);
+
+  idx_t table_index;
+
+ public:
+  vector<ColumnBinding> GetColumnBindings() override;
+
+ protected:
+  void ResolveTypes() override;
+};
+
+using GroupingSet = set<idx_t>;
+
+//! LogicalAggregate represents an aggregate operation with (optional) GROUP BY
+//! operator.
+class LogicalAggregate : public LogicalOperator {
+ public:
+  LogicalAggregate(
+      idx_t group_index,
+      idx_t aggregate_index,
+      vector<unique_ptr<Expression>> select_list);
+
+  //! The table index for the groups of the LogicalAggregate
+  idx_t group_index;
+  //! The table index for the aggregates of the LogicalAggregate
+  idx_t aggregate_index;
+  //! The table index for the GROUPING function calls of the LogicalAggregate
+  idx_t groupings_index;
+  //! The set of groups (optional).
+  vector<unique_ptr<Expression>> groups;
+  //! The set of grouping sets (optional).
+  vector<GroupingSet> grouping_sets;
+  //! The list of grouping function calls (optional)
+  vector<vector<idx_t>> grouping_functions;
+  //! Group statistics (optional)
+  vector<unique_ptr<BaseStatistics>> group_stats;
+
+ public:
+  string ParamsToString() const override;
+
+  vector<ColumnBinding> GetColumnBindings() override;
+
+ protected:
+  void ResolveTypes() override;
+};
+
+//! LogicalCrossProduct represents a cross product between two relations
+class LogicalCrossProduct : public LogicalOperator {
+ public:
+  LogicalCrossProduct();
+
+ public:
+  vector<ColumnBinding> GetColumnBindings() override;
+
+ protected:
+  void ResolveTypes() override;
+};
+} // namespace duckdb

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -1,0 +1,565 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/parse/QueryPlanner.h"
+#include "velox/duckdb/conversion/DuckConversion.h"
+#include "velox/external/duckdb/duckdb.hpp"
+#include "velox/parse/DuckLogicalOperator.h"
+
+namespace facebook::velox::core {
+
+namespace {
+
+class ColumnNameGenerator {
+ public:
+  std::string next(const std::string& prefix = "_c") {
+    if (names_.count(prefix)) {
+      auto name = fmt::format("{}{}", prefix, nextId_++);
+      names_.insert(name);
+      return name;
+    }
+
+    names_.insert(prefix);
+    return prefix;
+  }
+
+ private:
+  std::unordered_set<std::string> names_;
+  int nextId_{0};
+};
+
+struct QueryContext {
+  PlanNodeIdGenerator planNodeIdGenerator;
+  ColumnNameGenerator columnNameGenerator;
+  const std::unordered_map<std::string, std::vector<RowVectorPtr>>&
+      inMemoryTables;
+
+  QueryContext(const std::unordered_map<std::string, std::vector<RowVectorPtr>>&
+                   _inMemoryTables)
+      : inMemoryTables{_inMemoryTables} {}
+
+  std::string nextNodeId() {
+    return planNodeIdGenerator.next();
+  }
+
+  std::string nextColumnName() {
+    return columnNameGenerator.next();
+  }
+
+  std::string nextColumnName(const std::string& prefix) {
+    return columnNameGenerator.next(prefix);
+  }
+};
+
+std::string mapScalarFunctionName(const std::string& name) {
+  static const std::unordered_map<std::string, std::string> kMapping = {
+      {"+", "plus"},
+      {"-", "minus"},
+      {"*", "multiply"},
+      {"/", "divide"},
+      {"%", "mod"},
+      {"list_value", "array_constructor"},
+  };
+
+  auto it = kMapping.find(name);
+  if (it != kMapping.end()) {
+    return it->second;
+  }
+
+  return name;
+}
+
+std::string mapAggregateFunctionName(const std::string& name) {
+  static const std::unordered_map<std::string, std::string> kMapping = {
+      {"count_star", "count"},
+  };
+
+  auto it = kMapping.find(name);
+  if (it != kMapping.end()) {
+    return it->second;
+  }
+
+  return name;
+}
+
+PlanNodePtr toVeloxPlan(
+    ::duckdb::LogicalDummyScan& logicalDummyScan,
+    memory::MemoryPool* pool,
+    QueryContext& queryContext) {
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  for (auto i = 0; i < logicalDummyScan.types.size(); ++i) {
+    names.push_back(queryContext.nextColumnName());
+    types.push_back(duckdb::toVeloxType(logicalDummyScan.types[i]));
+  }
+
+  auto rowType = ROW(std::move(names), std::move(types));
+
+  std::vector<RowVectorPtr> vectors = {std::make_shared<RowVector>(
+      pool, rowType, nullptr, 1, std::vector<VectorPtr>{})};
+  return std::make_shared<ValuesNode>(queryContext.nextNodeId(), vectors);
+}
+
+PlanNodePtr toVeloxPlan(
+    ::duckdb::LogicalGet& logicalGet,
+    memory::MemoryPool* pool,
+    std::vector<PlanNodePtr> sources,
+    QueryContext& queryContext) {
+  if (logicalGet.function.name == "unnest") {
+    VELOX_CHECK_EQ(1, sources.size());
+    return std::make_shared<UnnestNode>(
+        queryContext.nextNodeId(),
+        std::vector<FieldAccessTypedExprPtr>{}, // replicateVariables
+        std::vector<FieldAccessTypedExprPtr>{
+            std::make_shared<FieldAccessTypedExpr>(
+                sources[0]->outputType()->childAt(0),
+                sources[0]->outputType()->asRow().nameOf(0))},
+        std::vector<std::string>{"a"},
+        std::nullopt, // ordinalityName
+        std::move(sources[0]));
+  }
+
+  VELOX_CHECK_EQ(logicalGet.function.name, "seq_scan");
+  VELOX_CHECK_EQ(0, sources.size());
+
+  const auto& columnIds = logicalGet.column_ids;
+  std::vector<std::string> names(columnIds.size());
+  std::vector<TypePtr> types(columnIds.size());
+
+  for (auto i = 0; i < columnIds.size(); ++i) {
+    names[i] = queryContext.nextColumnName(logicalGet.names[columnIds[i]]);
+    types[i] = duckdb::toVeloxType(logicalGet.returned_types[columnIds[i]]);
+  }
+
+  auto rowType = ROW(std::move(names), std::move(types));
+
+  auto tableName = logicalGet.function.to_string(logicalGet.bind_data.get());
+  auto it = queryContext.inMemoryTables.find(tableName);
+  VELOX_CHECK(
+      it != queryContext.inMemoryTables.end(),
+      "Can't find in-memory table: {}",
+      tableName);
+
+  std::vector<RowVectorPtr> data;
+  for (auto& rowVector : it->second) {
+    std::vector<VectorPtr> children;
+    if (rowVector->size() > 0) {
+      for (auto i = 0; i < columnIds.size(); ++i) {
+        children.push_back(rowVector->childAt(columnIds[i]));
+      }
+    }
+    data.push_back(std::make_shared<RowVector>(
+        pool, rowType, nullptr, rowVector->size(), children));
+  }
+
+  return std::make_shared<ValuesNode>(queryContext.nextNodeId(), data);
+}
+
+TypedExprPtr toVeloxExpression(
+    ::duckdb::Expression& expression,
+    const TypePtr& inputType);
+
+TypedExprPtr toVeloxComparisonExpression(
+    const std::string& name,
+    ::duckdb::Expression& expression,
+    const TypePtr& inputType) {
+  auto* comparison =
+      dynamic_cast<::duckdb::BoundComparisonExpression*>(&expression);
+  std::vector<TypedExprPtr> children{
+      toVeloxExpression(*comparison->left, inputType),
+      toVeloxExpression(*comparison->right, inputType)};
+
+  return std::make_shared<CallTypedExpr>(BOOLEAN(), std::move(children), name);
+}
+
+TypedExprPtr toVeloxExpression(
+    ::duckdb::Expression& expression,
+    const TypePtr& inputType) {
+  switch (expression.type) {
+    case ::duckdb::ExpressionType::VALUE_CONSTANT: {
+      auto* constant =
+          dynamic_cast<::duckdb::BoundConstantExpression*>(&expression);
+      return std::make_shared<ConstantTypedExpr>(
+          duckdb::toVeloxType(constant->return_type),
+          duckdb::duckValueToVariant(
+              constant->value, false /*parseDecimalAsDouble*/));
+    }
+    case ::duckdb::ExpressionType::COMPARE_EQUAL:
+      return toVeloxComparisonExpression("eq", expression, inputType);
+    case ::duckdb::ExpressionType::COMPARE_GREATERTHAN:
+      return toVeloxComparisonExpression("gt", expression, inputType);
+    case ::duckdb::ExpressionType::OPERATOR_CAST: {
+      auto* cast = dynamic_cast<::duckdb::BoundCastExpression*>(&expression);
+      return std::make_shared<CastTypedExpr>(
+          duckdb::toVeloxType(cast->return_type),
+          std::vector<TypedExprPtr>{toVeloxExpression(*cast->child, inputType)},
+          cast->try_cast);
+    }
+    case ::duckdb::ExpressionType::BOUND_FUNCTION: {
+      auto* func =
+          dynamic_cast<::duckdb::BoundFunctionExpression*>(&expression);
+
+      std::vector<TypedExprPtr> children;
+      for (auto& child : func->children) {
+        children.push_back(toVeloxExpression(*child, inputType));
+      }
+
+      return std::make_shared<CallTypedExpr>(
+          duckdb::toVeloxType(func->function.return_type),
+          std::move(children),
+          mapScalarFunctionName(func->function.name));
+    }
+    case ::duckdb::ExpressionType::BOUND_REF: {
+      auto* ref =
+          dynamic_cast<::duckdb::BoundReferenceExpression*>(&expression);
+      return std::make_shared<FieldAccessTypedExpr>(
+          duckdb::toVeloxType(ref->return_type),
+          inputType->asRow().nameOf(ref->index));
+    }
+    case ::duckdb::ExpressionType::BOUND_AGGREGATE: {
+      auto* agg =
+          dynamic_cast<::duckdb::BoundAggregateExpression*>(&expression);
+
+      std::vector<TypedExprPtr> children;
+      for (auto& child : agg->children) {
+        children.push_back(toVeloxExpression(*child, inputType));
+      }
+
+      return std::make_shared<CallTypedExpr>(
+          duckdb::toVeloxType(agg->return_type),
+          std::move(children),
+          mapAggregateFunctionName(agg->function.name));
+    }
+    default:
+      VELOX_NYI(
+          "Expression type {} is not supported yet: {}",
+          ::duckdb::ExpressionTypeToString(expression.type),
+          expression.ToString());
+  }
+}
+
+PlanNodePtr toVeloxPlan(
+    ::duckdb::LogicalFilter& logicalFilter,
+    memory::MemoryPool* pool,
+    std::vector<PlanNodePtr> sources,
+    QueryContext& queryContext) {
+  VELOX_CHECK_EQ(1, logicalFilter.expressions.size())
+  auto filter = toVeloxExpression(
+      *logicalFilter.expressions.front(), sources[0]->outputType());
+  return std::make_shared<FilterNode>(
+      queryContext.nextNodeId(), std::move(filter), std::move(sources[0]));
+}
+
+PlanNodePtr toVeloxPlan(
+    ::duckdb::LogicalProjection& logicalProjection,
+    memory::MemoryPool* pool,
+    std::vector<PlanNodePtr> sources,
+    QueryContext& queryContext) {
+  std::vector<TypedExprPtr> projections;
+  for (auto& expression : logicalProjection.expressions) {
+    projections.push_back(
+        toVeloxExpression(*expression, sources[0]->outputType()));
+  }
+
+  // TODO Figure out how to use these.
+  auto columnBindings = logicalProjection.GetColumnBindings();
+
+  std::vector<std::string> names;
+  for (auto i = 0; i < projections.size(); ++i) {
+    names.push_back(queryContext.nextColumnName("_p"));
+  }
+  return std::make_shared<ProjectNode>(
+      queryContext.nextNodeId(),
+      std::move(names),
+      std::move(projections),
+      std::move(sources[0]));
+}
+
+PlanNodePtr toVeloxPlan(
+    ::duckdb::LogicalAggregate& logicalAggregate,
+    memory::MemoryPool* pool,
+    std::vector<PlanNodePtr> sources,
+    QueryContext& queryContext) {
+  std::vector<CallTypedExprPtr> aggregates;
+
+  std::vector<std::string> projectNames;
+  std::vector<TypedExprPtr> projections;
+
+  bool identityProjection = true;
+  for (auto& expression : logicalAggregate.expressions) {
+    auto call = std::dynamic_pointer_cast<const CallTypedExpr>(
+        toVeloxExpression(*expression, sources[0]->outputType()));
+    std::vector<TypedExprPtr> fieldInputs;
+
+    for (auto& input : call->inputs()) {
+      projections.push_back(input);
+
+      if (auto field =
+              std::dynamic_pointer_cast<const FieldAccessTypedExpr>(input)) {
+        projectNames.push_back(field->name());
+        fieldInputs.push_back(field);
+      } else {
+        identityProjection = false;
+        projectNames.push_back(queryContext.nextColumnName("_p"));
+        fieldInputs.push_back(std::make_shared<FieldAccessTypedExpr>(
+            input->type(), projectNames.back()));
+      }
+    }
+
+    aggregates.push_back(std::make_shared<CallTypedExpr>(
+        call->type(), fieldInputs, call->name()));
+  }
+
+  std::vector<FieldAccessTypedExprPtr> groupingKeys;
+  for (auto& expression : logicalAggregate.groups) {
+    auto groupingExpr =
+        toVeloxExpression(*expression, sources[0]->outputType());
+    projections.push_back(groupingExpr);
+    if (auto field = std::dynamic_pointer_cast<const FieldAccessTypedExpr>(
+            groupingExpr)) {
+      projectNames.push_back(field->name());
+      groupingKeys.push_back(field);
+    } else {
+      identityProjection = false;
+      projectNames.push_back(queryContext.nextColumnName("_p"));
+      groupingKeys.push_back(std::make_shared<FieldAccessTypedExpr>(
+          groupingExpr->type(), projectNames.back()));
+    }
+  }
+
+  auto source = sources[0];
+
+  if (!identityProjection) {
+    source = std::make_shared<ProjectNode>(
+        queryContext.nextNodeId(),
+        std::move(projectNames),
+        std::move(projections),
+        std::move(sources[0]));
+  }
+
+  std::vector<std::string> names;
+  for (auto i = 0; i < aggregates.size(); ++i) {
+    names.push_back(queryContext.nextColumnName("_a"));
+  }
+
+  return std::make_shared<AggregationNode>(
+      queryContext.nextNodeId(),
+      AggregationNode::Step::kSingle,
+      groupingKeys,
+      std::vector<FieldAccessTypedExprPtr>{}, // preGroupedKeys
+      names,
+      aggregates,
+      std::vector<FieldAccessTypedExprPtr>{}, // aggregateMasks
+      false, // ignoreNullKeys
+      source);
+}
+
+PlanNodePtr toVeloxPlan(
+    ::duckdb::LogicalCrossProduct& logicalCrossProduct,
+    memory::MemoryPool* pool,
+    std::vector<PlanNodePtr> sources,
+    QueryContext& queryContext) {
+  VELOX_CHECK_EQ(2, sources.size());
+
+  const auto& leftInputType = sources[0]->outputType()->asRow();
+  const auto& rightInputType = sources[1]->outputType()->asRow();
+
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  for (auto i = 0; i < leftInputType.size(); ++i) {
+    names.push_back(leftInputType.nameOf(i));
+    types.push_back(leftInputType.childAt(i));
+  }
+  for (auto i = 0; i < rightInputType.size(); ++i) {
+    names.push_back(rightInputType.nameOf(i));
+    types.push_back(rightInputType.childAt(i));
+  }
+
+  return std::make_shared<CrossJoinNode>(
+      queryContext.nextNodeId(),
+      std::move(sources[0]),
+      std::move(sources[1]),
+      ROW(std::move(names), std::move(types)));
+}
+
+PlanNodePtr toVeloxPlan(
+    ::duckdb::LogicalOperator& plan,
+    memory::MemoryPool* pool,
+    QueryContext& queryContext) {
+  std::vector<PlanNodePtr> sources;
+  for (auto& child : plan.children) {
+    sources.push_back(toVeloxPlan(*child, pool, queryContext));
+  }
+
+  switch (plan.type) {
+    case ::duckdb::LogicalOperatorType::LOGICAL_DUMMY_SCAN:
+      return toVeloxPlan(
+          dynamic_cast<::duckdb::LogicalDummyScan&>(plan), pool, queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_GET:
+      return toVeloxPlan(
+          dynamic_cast<::duckdb::LogicalGet&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_FILTER:
+      return toVeloxPlan(
+          dynamic_cast<::duckdb::LogicalFilter&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_PROJECTION:
+      return toVeloxPlan(
+          dynamic_cast<::duckdb::LogicalProjection&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_AGGREGATE_AND_GROUP_BY:
+      return toVeloxPlan(
+          dynamic_cast<::duckdb::LogicalAggregate&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_CROSS_PRODUCT:
+      return toVeloxPlan(
+          dynamic_cast<::duckdb::LogicalCrossProduct&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    default:
+      VELOX_NYI(
+          "Plan node is not supported yet: {}",
+          ::duckdb::LogicalOperatorToString(plan.type));
+  }
+}
+
+static void customScalarFunction(
+    ::duckdb::DataChunk& args,
+    ::duckdb::ExpressionState& state,
+    ::duckdb::Vector& result) {
+  VELOX_UNREACHABLE();
+}
+
+static ::duckdb::idx_t customAggregateState() {
+  VELOX_UNREACHABLE();
+}
+
+static void customAggregateInitialize(::duckdb::data_ptr_t) {
+  VELOX_UNREACHABLE();
+}
+
+static void customAggregateUpdate(
+    ::duckdb::Vector inputs[],
+    ::duckdb::AggregateInputData& aggr_input_data,
+    ::duckdb::idx_t input_count,
+    ::duckdb::Vector& state,
+    ::duckdb::idx_t count) {
+  VELOX_UNREACHABLE();
+}
+
+static void customAggregateCombine(
+    ::duckdb::Vector& state,
+    ::duckdb::Vector& combined,
+    ::duckdb::AggregateInputData& aggr_input_data,
+    ::duckdb::idx_t count) {
+  VELOX_UNREACHABLE();
+}
+
+static void customAggregateFinalize(
+    ::duckdb::Vector& state,
+    ::duckdb::AggregateInputData& aggr_input_data,
+    ::duckdb::Vector& result,
+    ::duckdb::idx_t count,
+    ::duckdb::idx_t offset) {
+  VELOX_UNREACHABLE();
+}
+
+} // namespace
+
+PlanNodePtr parseQuery(
+    const std::string& sql,
+    memory::MemoryPool* pool,
+    const std::unordered_map<std::string, std::vector<RowVectorPtr>>&
+        inMemoryTables) {
+  DuckDbQueryPlanner planner(pool);
+
+  for (auto& [name, data] : inMemoryTables) {
+    planner.registerTable(name, data);
+  }
+
+  return planner.plan(sql);
+}
+
+void DuckDbQueryPlanner::registerTable(
+    const std::string& name,
+    const std::vector<RowVectorPtr>& data) {
+  VELOX_CHECK_EQ(
+      0, tables_.count(name), "Table is already registered: {}", name);
+
+  auto createTableSql =
+      duckdb::makeCreateTableSql(name, *asRowType(data[0]->type()));
+  auto res = conn_.Query(createTableSql);
+  VELOX_CHECK(res->success, "Failed to create DuckDB table: {}", res->error);
+
+  tables_.insert({name, data});
+}
+
+void DuckDbQueryPlanner::registerScalarFunction(
+    const std::string& name,
+    const std::vector<TypePtr>& argTypes,
+    const TypePtr& returnType) {
+  std::vector<::duckdb::LogicalType> argDuckTypes;
+  for (auto& type : argTypes) {
+    argDuckTypes.push_back(duckdb::fromVeloxType(type));
+  }
+
+  conn_.CreateVectorizedFunction(
+      name,
+      argDuckTypes,
+      duckdb::fromVeloxType(returnType),
+      customScalarFunction);
+}
+
+void DuckDbQueryPlanner::registerAggregateFunction(
+    const std::string& name,
+    const std::vector<TypePtr>& argTypes,
+    const TypePtr& returnType) {
+  std::vector<::duckdb::LogicalType> argDuckTypes;
+  for (auto& type : argTypes) {
+    argDuckTypes.push_back(duckdb::fromVeloxType(type));
+  }
+
+  conn_.CreateAggregateFunction(
+      name,
+      argDuckTypes,
+      duckdb::fromVeloxType(returnType),
+      customAggregateState,
+      customAggregateInitialize,
+      customAggregateUpdate,
+      customAggregateCombine,
+      customAggregateFinalize);
+}
+
+PlanNodePtr DuckDbQueryPlanner::plan(const std::string& sql) {
+  // Disable the optimizer. Otherwise, the filter over table scan gets pushdown
+  // as a callback that is impossible to recover.
+  conn_.Query("PRAGMA disable_optimizer");
+
+  auto plan = conn_.ExtractPlan(sql);
+
+  QueryContext queryContext{tables_};
+  return toVeloxPlan(*plan, pool_, queryContext);
+}
+
+} // namespace facebook::velox::core

--- a/velox/parse/QueryPlanner.h
+++ b/velox/parse/QueryPlanner.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/external/duckdb/duckdb.hpp"
+#include "velox/parse/PlanNodeIdGenerator.h"
+
+namespace facebook::velox::core {
+
+class DuckDbQueryPlanner {
+ public:
+  DuckDbQueryPlanner(memory::MemoryPool* pool) : pool_{pool} {}
+
+  void registerTable(
+      const std::string& name,
+      const std::vector<RowVectorPtr>& data);
+
+  void registerScalarFunction(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes,
+      const TypePtr& returnType);
+
+  // TODO Allow replacing built-in DuckDB functions. Currently, replacing "sum"
+  // causes a crash (a bug in DuckDB). Replacing existing functions is useful
+  // when signatures don't match.
+  void registerAggregateFunction(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes,
+      const TypePtr& returnType);
+
+  PlanNodePtr plan(const std::string& sql);
+
+ private:
+  ::duckdb::DuckDB db_;
+  ::duckdb::Connection conn_{db_};
+  memory::MemoryPool* pool_;
+  std::unordered_map<std::string, std::vector<RowVectorPtr>> tables_;
+};
+
+PlanNodePtr parseQuery(
+    const std::string& sql,
+    memory::MemoryPool* pool,
+    const std::unordered_map<std::string, std::vector<RowVectorPtr>>&
+        inMemoryTables = {});
+
+} // namespace facebook::velox::core

--- a/velox/parse/tests/CMakeLists.txt
+++ b/velox/parse/tests/CMakeLists.txt
@@ -11,18 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_parse_expression Expressions.cpp)
-target_link_libraries(velox_parse_expression velox_type velox_parse_utils
-                      velox_expression)
 
-add_library(velox_parse_parser ExpressionsParser.cpp QueryPlanner.cpp)
-target_link_libraries(velox_parse_parser velox_parse_expression velox_type
-                      velox_duckdb_parser)
+add_executable(velox_parse_test QueryPlannerTest.cpp)
 
-add_library(velox_parse_utils TypeResolver.cpp)
-target_link_libraries(velox_parse_utils velox_buffer velox_type velox_vector
-                      velox_function_registry)
+add_test(velox_parse_test velox_parse_test)
 
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-endif()
+target_link_libraries(velox_parse_test velox_parse_parser gtest gtest_main
+                      ${gflags_LIBRARIES})

--- a/velox/parse/tests/QueryPlannerTest.cpp
+++ b/velox/parse/tests/QueryPlannerTest.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/parse/QueryPlanner.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::velox::core::test {
+
+class QueryPlannerTest : public testing::Test {
+ protected:
+  void assertPlan(
+      const std::string& sql,
+      const std::unordered_map<std::string, std::vector<RowVectorPtr>>&
+          inMemoryTables,
+      const std::string& expectedPlan) {
+    SCOPED_TRACE(sql);
+    auto plan = parseQuery(sql, pool_.get(), inMemoryTables);
+    ASSERT_EQ(expectedPlan, plan->toString(false, true));
+  }
+
+  void assertPlanError(const std::string& sql, const char* expectedMessage) {
+    SCOPED_TRACE(sql);
+    SCOPED_TRACE(expectedMessage);
+    try {
+      parseQuery(sql, pool_.get());
+      FAIL() << "Expected an exception: " << expectedMessage;
+    } catch (std::exception& e) {
+      ASSERT_TRUE(strstr(e.what(), expectedMessage) != nullptr) << e.what();
+    }
+  }
+
+  void assertPlan(const std::string& sql, const std::string& expectedPlan) {
+    assertPlan(sql, {}, expectedPlan);
+  }
+
+  RowVectorPtr makeEmptyRowVector(const RowTypePtr& rowType) {
+    return std::make_shared<RowVector>(
+        pool_.get(),
+        rowType,
+        nullptr, // nulls
+        0,
+        std::vector<VectorPtr>{});
+  }
+
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+};
+
+TEST_F(QueryPlannerTest, values) {
+  assertPlan(
+      "SELECT x, x + 5 FROM UNNEST([1, 2, 3]) as t(x)",
+      "-- Project\n"
+      "  -- Unnest\n"
+      "    -- Project\n"
+      "      -- Values\n");
+
+  assertPlan(
+      "SELECT sum(x) FROM UNNEST([1, 2, 3]) as t(x)",
+      "-- Project\n"
+      "  -- Aggregation\n"
+      "    -- Unnest\n"
+      "      -- Project\n"
+      "        -- Values\n");
+
+  assertPlan(
+      "SELECT x % 5, sum(x) FROM UNNEST([1, 2, 3]) as t(x) GROUP BY 1",
+      "-- Project\n"
+      "  -- Aggregation\n"
+      "    -- Project\n"
+      "      -- Unnest\n"
+      "        -- Project\n"
+      "          -- Values\n");
+
+  assertPlan(
+      "SELECT sum(x * 4) FROM UNNEST([1, 2, 3]) as t(x)",
+      "-- Project\n"
+      "  -- Aggregation\n"
+      "    -- Project\n"
+      "      -- Unnest\n"
+      "        -- Project\n"
+      "          -- Values\n");
+}
+
+TEST_F(QueryPlannerTest, tableScan) {
+  std::unordered_map<std::string, std::vector<RowVectorPtr>> inMemoryTables = {
+      {"t",
+       {makeEmptyRowVector(
+           ROW({"a", "b", "c"}, {BIGINT(), INTEGER(), SMALLINT()}))}},
+      {"u", {makeEmptyRowVector(ROW({"a", "b"}, {BIGINT(), DOUBLE()}))}},
+  };
+
+  assertPlan(
+      "SELECT a, sum(b) FROM t WHERE c > 5 GROUP BY 1",
+      inMemoryTables,
+      "-- Project\n"
+      "  -- Aggregation\n"
+      "    -- Filter\n"
+      "      -- Values\n");
+
+  assertPlan(
+      "SELECT t.a, t.b, t.c, u.b FROM t, u WHERE t.a = u.a",
+      inMemoryTables,
+      "-- Project\n"
+      "  -- Filter\n"
+      "    -- CrossJoin\n"
+      "      -- Values\n"
+      "      -- Values\n");
+}
+
+TEST_F(QueryPlannerTest, customScalarFunctions) {
+  DuckDbQueryPlanner planner(pool_.get());
+  planner.registerScalarFunction("foo", {BIGINT()}, BOOLEAN());
+  planner.registerScalarFunction("bar", {ARRAY(BIGINT())}, BIGINT());
+
+  auto plan =
+      planner.plan("SELECT foo(x), bar([x]) FROM UNNEST([1, 2, 3]) as t(x)");
+  ASSERT_EQ(
+      plan->toString(false, true),
+      "-- Project\n"
+      "  -- Unnest\n"
+      "    -- Project\n"
+      "      -- Values\n");
+}
+
+TEST_F(QueryPlannerTest, customAggregateFunctions) {
+  DuckDbQueryPlanner planner(pool_.get());
+
+  planner.registerAggregateFunction("foo_agg", {BIGINT(), BIGINT()}, DOUBLE());
+  planner.registerAggregateFunction(
+      "bar_agg", {ARRAY(BIGINT()), BIGINT()}, ARRAY(BIGINT()));
+
+  auto plan = planner.plan(
+      "SELECT foo_agg(x, x + 5), bar_agg([x], 1) FROM UNNEST([1, 2, 3]) as t(x)");
+  ASSERT_EQ(
+      plan->toString(false, true),
+      "-- Project\n"
+      "  -- Aggregation\n"
+      "    -- Project\n"
+      "      -- Unnest\n"
+      "        -- Project\n"
+      "          -- Values\n");
+}
+
+TEST_F(QueryPlannerTest, error) {
+  assertPlanError(
+      "SELECT * FROM my_table", "Table with name my_table does not exist");
+  assertPlanError(
+      "SELECT my_function(1)",
+      "Scalar Function with name my_function does not exist");
+  // DuckDB gives the same error regardless of whether scalar or aggregate
+  // function is missing.
+  assertPlanError(
+      "SELECT x % 5, my_agg(x) FROM UNNEST([1, 2, 3]) as t(x) GROUP BY 1",
+      "Scalar Function with name my_agg does not exist");
+  assertPlanError("SELECT 'test ", "unterminated quoted string");
+}
+
+} // namespace facebook::velox::core::test


### PR DESCRIPTION
DuckDB provides an API that takes SQL query and returns a logical plan.

```
DuckDB db;
Connection conn(db);

unique_ptr<LogicalOperator> plan = conn.ExtractPlan(sql);
```

The new DuckDbQueryPlanner class uses this API to convert SQL to a logical
DuckDB plan, then convert it to Velox plan.

```
DuckDbQueryPlanner planner(pool);

PlanNodePtr plan = planner.plan("SELECT a, avg(b) FROM t GROUP BY 1");
```

By default, ExtractPlan API creates an optimized plan. However, when there is
filter on top of table scan, the filter gets pushed down into the table scan as
a callback making it impossible to recover the filter expression for conversion
to Velox plan.

DuckDbQueryPlanner disables the optimizer using PRAGMA statement:
```
conn_.Query("PRAGMA disable_optimizer");
```

Since the optimizer is disabled, the logical plan is very basic. For example, a
join is expressed as a Filter (a = b) over CrossJoin.

DuckDB allows registering custom scalar and aggregate functions using
CreateVectorizedFunction and CreateAggregateFunction APIs. DuckDbQueryPlanner
uses these to allow registering PrestoSQL functions.

I couldn't find a way to unregister built-in DuckDB functions though. The "sum"
aggregate function in DuckDB has a signature different from PrestoSQL. sum
(bigint) returns bigint in PrestoSQL and double in DuckDB. I tried
registering "sum" with PrestoSQL, but the process crashed. It looks like there
is a bug in DuckDB where updating registry entry for scalar function works, but
for aggregate function crashes.

DuckDbQueryPlanner allows to register in-memory tables. It creates empty tables
with matching name and schema in DuckDB to allow the planner to recognize these
tables. It then replaces TableScan over these tables with ValuesNode.

I'd like to add support for querying TPC-H tables using TPC-H connector in a follow-up.

The new SqlTest shows how to execute SQL query using Velox and DuckDB.