### PR TITLE
Disable arrow support for nightly fuzzer tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ jobs:
       - run:
           name: Build
           command: |
-            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
             ccache -s
           no_output_timeout: 1h
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,7 @@ jobs:
           # the job output for context.
           name: "Run Fuzzer Tests"
           command: |
-            make fuzzertest NUM_THREADS=16 FUZZER_DURATION_SEC=600 FUZZER_SEED=${RANDOM} \
+            make fuzzertest NUM_THREADS=8 FUZZER_DURATION_SEC=600 FUZZER_SEED=${RANDOM} \
               > /tmp/fuzzer.log 2>&1 || ( \
                 tail -n 1000 /tmp/fuzzer.log;
                 echo "FAIL: Fuzzer run failed, logs saved to \"/tmp/fuzzer.log\" and uploaded" \


### PR DESCRIPTION
At the moment enabling arrow doesnt seem to play well with cmake folly leading to recompilation. Disabling while we try and find a fix. cc #2758 