### PR TITLE
Extract PlanNodeIdGenerator into its own header

### DIFF
--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -232,8 +232,7 @@ TEST_F(TpchConnectorTest, multipleSplits) {
 
 // Join nation and region.
 TEST_F(TpchConnectorTest, join) {
-  auto planNodeIdGenerator =
-      std::make_shared<exec::test::PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId nationScanId;
   core::PlanNodeId regionScanId;
   auto plan =

--- a/velox/exec/tests/AssertQueryBuilderTest.cpp
+++ b/velox/exec/tests/AssertQueryBuilderTest.cpp
@@ -101,7 +101,7 @@ TEST_F(AssertQueryBuilderTest, hiveSplits) {
   auto buildFile = TempFilePath::create();
   writeToFile(buildFile->path, {buildData});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId probeScanId;
   core::PlanNodeId buildScanId;
   auto joinPlan = PlanBuilder(planNodeIdGenerator)

--- a/velox/exec/tests/CrossJoinTest.cpp
+++ b/velox/exec/tests/CrossJoinTest.cpp
@@ -58,7 +58,7 @@ TEST_F(CrossJoinTest, basic) {
   createDuckDbTable("u", {rightVectors});
 
   // All x 13. Join output vectors contains multiple probe rows each.
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .crossJoin(
@@ -170,7 +170,7 @@ TEST_F(CrossJoinTest, lazyVectors) {
   createDuckDbTable("t", {makeRowVector({sequence<int32_t>(1117)})});
   createDuckDbTable("u", {makeRowVector({sequence<int32_t>(1121)})});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .crossJoin(
@@ -202,7 +202,7 @@ TEST_F(CrossJoinTest, zeroColumnBuild) {
   createDuckDbTable("t", {leftVectors});
 
   // Build side has > 1 row.
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .crossJoin(
@@ -244,7 +244,7 @@ TEST_F(CrossJoinTest, parallelism) {
   auto left = {makeRowVector({sequence<int32_t>(2)})};
   auto right = {makeRowVector({"u_c0"}, {sequence<int32_t>(3)})};
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   CursorParameters params;
   params.maxDrivers = 5;
   params.planNode =

--- a/velox/exec/tests/CustomJoinTest.cpp
+++ b/velox/exec/tests/CustomJoinTest.cpp
@@ -290,7 +290,7 @@ class CustomJoinTest : public OperatorTestBase {
       const std::string& referenceQuery) {
     createDuckDbTable("t", {leftBatch});
 
-    auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     auto leftNode =
         PlanBuilder(planNodeIdGenerator).values({leftBatch}, true).planNode();
     auto rightNode =

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -797,7 +797,7 @@ TEST_F(DriverTest, driverCreationThrow) {
 
   auto rows = makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3})});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
   auto plan = PlanBuilder(planNodeIdGenerator)
                   .values({rows}, true)

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -106,7 +106,7 @@ class HashJoinTest : public HiveConnectorTestBase {
       core::JoinType joinType,
       bool injectSpill) {
     CursorParameters params;
-    auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     params.planNode = PlanBuilder(planNodeIdGenerator)
                           .values(leftBatches, isLeftParallelizable)
                           .hashJoin(
@@ -606,7 +606,7 @@ TEST_F(HashJoinTest, joinSidesDifferentSchema) {
       "  u.c2 > 10 AND ltrim(t.c1) = 'a%'";
   // In this hash join the 2 tables have a common key which is the
   // first channel in both tables.
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto planNode =
       PlanBuilder(planNodeIdGenerator)
           .values({leftVectors})
@@ -646,7 +646,7 @@ TEST_F(HashJoinTest, memory) {
         BatchMaker::createBatch(rightType, 800, *pool_)));
   }
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
   CursorParameters params;
   params.planNode = PlanBuilder(planNodeIdGenerator)
@@ -694,7 +694,7 @@ TEST_F(HashJoinTest, lazyVectors) {
   writeToFile(rightFile->path, rightVectors);
   createDuckDbTable("u", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId leftScanId;
   core::PlanNodeId rightScanId;
   auto op = PlanBuilder(planNodeIdGenerator)
@@ -717,7 +717,7 @@ TEST_F(HashJoinTest, lazyVectors) {
       .split(leftScanId, makeHiveConnectorSplit(leftFile->path))
       .assertResults("SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0");
 
-  planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   op = PlanBuilder(planNodeIdGenerator)
            .tableScan(
                ROW({"c0", "c1", "c2", "c3"},
@@ -782,7 +782,7 @@ TEST_F(HashJoinTest, arrayBasedLookup) {
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op =
       PlanBuilder(planNodeIdGenerator)
           .values(leftVectors)
@@ -812,7 +812,7 @@ TEST_F(HashJoinTest, innerJoinWithEmptyBuild) {
   auto rightVectors = makeRowVector({makeFlatVector<int32_t>(
       123, [](auto row) { return row % 5; }, nullEvery(7))});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .hashJoin(
@@ -845,7 +845,7 @@ TEST_F(HashJoinTest, leftSemiJoin) {
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .hashJoin(
@@ -899,7 +899,7 @@ TEST_F(HashJoinTest, leftSemiJoinWithFilter) {
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .hashJoin(
@@ -955,7 +955,7 @@ TEST_F(HashJoinTest, rightSemiJoin) {
   createDuckDbTable("u", {leftVectors});
   createDuckDbTable("t", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .hashJoin(
@@ -1025,7 +1025,7 @@ TEST_F(HashJoinTest, rightSemiJoinWithFilter) {
   createDuckDbTable("u", {leftVectors});
   createDuckDbTable("t", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId hashJoinId;
   auto plan = [&](const std::string& filter) -> core::PlanNodePtr {
     return PlanBuilder(planNodeIdGenerator)
@@ -1092,7 +1092,7 @@ TEST_F(HashJoinTest, antiJoin) {
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .hashJoin(
@@ -1167,7 +1167,7 @@ TEST_F(HashJoinTest, nullAwareAntiJoinWithFilter) {
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
                 .hashJoin(
@@ -1216,7 +1216,7 @@ TEST_F(HashJoinTest, nullAwareAntiJoinWithFilterAndNullKey) {
       });
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   for (const std::string& filter : {"u1 > t1", "u1 * t1 > 0"}) {
     auto sql = fmt::format(
         "SELECT t.* FROM t WHERE t0 NOT IN (SELECT u0 FROM u WHERE {})",
@@ -1247,7 +1247,7 @@ TEST_F(HashJoinTest, nullAwareAntiJoinWithFilterOnNullableColumn) {
     auto right = makeRowVector({"u0", "u1"}, rightColumns);
     createDuckDbTable("t", {left});
     createDuckDbTable("u", {right});
-    auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     auto op =
         PlanBuilder(planNodeIdGenerator)
             .values({left})
@@ -1320,7 +1320,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
   auto probeType = ROW({"c0", "c1"}, {INTEGER(), BIGINT()});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
   auto buildSide = PlanBuilder(planNodeIdGenerator)
                        .values(rightVectors)
@@ -1664,7 +1664,7 @@ TEST_F(HashJoinTest, leftJoin) {
   createDuckDbTable("t", leftVectors);
   createDuckDbTable("u", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto buildSide = PlanBuilder(planNodeIdGenerator)
                        .values({rightVectors})
                        .project({"c0 AS u_c0", "c1 AS u_c1"})
@@ -1807,7 +1807,7 @@ TEST_F(HashJoinTest, leftJoinWithNullableFilter) {
   createDuckDbTable("t", leftVectors);
   createDuckDbTable("u", rightVectors);
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
   auto buildSide = PlanBuilder(planNodeIdGenerator)
                        .values(rightVectors)
@@ -1855,7 +1855,7 @@ TEST_F(HashJoinTest, rightJoin) {
   createDuckDbTable("t", leftVectors);
   createDuckDbTable("u", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
   auto buildSide = PlanBuilder(planNodeIdGenerator)
                        .values({rightVectors})
@@ -1975,7 +1975,7 @@ TEST_F(HashJoinTest, fullJoin) {
   createDuckDbTable("t", leftVectors);
   createDuckDbTable("u", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
   auto buildSide = PlanBuilder(planNodeIdGenerator)
                        .values({rightVectors})
@@ -2092,7 +2092,7 @@ TEST_F(HashJoinTest, memoryUsage) {
 
   core::PlanNodeId joinNodeId;
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan =
       PlanBuilder(planNodeIdGenerator)
           .values(probeData)
@@ -2143,7 +2143,7 @@ TEST_F(HashJoinTest, smallOutputBatchSize) {
   createDuckDbTable("u", {buildData});
 
   // Plan hash inner join with a filter.
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan =
       PlanBuilder(planNodeIdGenerator)
           .values({probeData})

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -90,7 +90,7 @@ TEST_F(LocalPartitionTest, gather) {
       makeRowVector({makeFlatSequence<int32_t>(-71, 100)}),
   };
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
   auto valuesNode = [&](int index) {
     return PlanBuilder(planNodeIdGenerator).values({vectors[index]}).planNode();
@@ -154,7 +154,7 @@ TEST_F(LocalPartitionTest, partition) {
 
   auto rowType = getRowType(vectors[0]);
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
   std::vector<core::PlanNodeId> scanNodeIds;
 
@@ -197,7 +197,7 @@ TEST_F(LocalPartitionTest, maxBufferSizeGather) {
         100, [i](auto row) { return -71 + i * 10 + row; })}));
   }
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
   auto valuesNode = [&](int start, int end) {
     return PlanBuilder(planNodeIdGenerator)
@@ -237,7 +237,7 @@ TEST_F(LocalPartitionTest, maxBufferSizePartition) {
 
   auto rowType = getRowType(vectors[0]);
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
   std::vector<core::PlanNodeId> scanNodeIds;
 
@@ -299,7 +299,7 @@ TEST_F(LocalPartitionTest, multipleExchanges) {
 
   auto rowType = getRowType(vectors[0]);
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   std::vector<core::PlanNodeId> scanNodeIds;
 
   auto tableScanNode = [&]() {
@@ -350,7 +350,7 @@ TEST_F(LocalPartitionTest, earlyCompletion) {
       makeRowVector({makeFlatSequence(13, 100)}),
   };
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan =
       PlanBuilder(planNodeIdGenerator)
           .localPartition(
@@ -375,7 +375,7 @@ TEST_F(LocalPartitionTest, earlyCancelation) {
       makeRowVector({makeFlatSequence(13, 100)}),
   };
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan =
       PlanBuilder(planNodeIdGenerator)
           .localPartition(
@@ -424,7 +424,7 @@ TEST_F(LocalPartitionTest, producerError) {
       makeRowVector({makeFlatSequence(-13, 100)}),
   };
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan = PlanBuilder(planNodeIdGenerator)
                   .localPartition(
                       {},
@@ -463,7 +463,7 @@ TEST_F(LocalPartitionTest, unionAll) {
       {makeFlatVector<int32_t>({20, 21}),
        makeFlatVector<StringView>({"z", "w"})});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan = PlanBuilder(planNodeIdGenerator)
                   .localPartition(
                       {},
@@ -488,7 +488,7 @@ TEST_F(LocalPartitionTest, unionAllLocalExchange) {
   auto data1 = makeRowVector({"d0"}, {makeFlatVector<StringView>({"x"})});
   auto data2 = makeRowVector({"e0"}, {makeFlatVector<StringView>({"y"})});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan = PlanBuilder(planNodeIdGenerator)
                   .localPartitionRoundRobin(
                       {PlanBuilder(planNodeIdGenerator)

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -120,7 +120,7 @@ class MergeJoinTest : public HiveConnectorTestBase {
     createDuckDbTable("u", right);
 
     // Test INNER join.
-    auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     auto plan = PlanBuilder(planNodeIdGenerator)
                     .values(left)
                     .mergeJoin(
@@ -151,7 +151,7 @@ class MergeJoinTest : public HiveConnectorTestBase {
         "SELECT t.c0, t.c1, u.c1 FROM t, u WHERE t.c0 = u.c0");
 
     // Test LEFT join.
-    planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+    planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     plan = PlanBuilder(planNodeIdGenerator)
                .values(left)
                .mergeJoin(
@@ -222,7 +222,7 @@ TEST_F(MergeJoinTest, aggregationOverJoin) {
       makeRowVector({"t_c0"}, {makeFlatVector<int32_t>({1, 2, 3, 4, 5})});
   auto right = makeRowVector({"u_c0"}, {makeFlatVector<int32_t>({2, 4, 6})});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan =
       PlanBuilder(planNodeIdGenerator)
           .values({left})
@@ -255,7 +255,7 @@ TEST_F(MergeJoinTest, nonFirstJoinKeys) {
           makeFlatVector<int32_t>({2, 4, 6}),
       });
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan =
       PlanBuilder(planNodeIdGenerator)
           .values({left})
@@ -297,7 +297,7 @@ TEST_F(MergeJoinTest, innerJoinFilter) {
   createDuckDbTable("u", {right});
 
   auto plan = [&](const std::string& filter) {
-    auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     return PlanBuilder(planNodeIdGenerator)
         .values({left})
         .mergeJoin(
@@ -362,7 +362,7 @@ TEST_F(MergeJoinTest, leftJoinFilter) {
   createDuckDbTable("t", {left});
   createDuckDbTable("u", {right});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan = [&](const std::string& filter) {
     return PlanBuilder(planNodeIdGenerator)
         .values({left})
@@ -423,7 +423,7 @@ TEST_F(MergeJoinTest, numDrivers) {
   auto left = makeRowVector({"t_c0"}, {makeFlatVector<int32_t>({1, 2, 3})});
   auto right = makeRowVector({"u_c0"}, {makeFlatVector<int32_t>({0, 2, 5})});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan =
       PlanBuilder(planNodeIdGenerator)
           .values({left}, true)
@@ -474,7 +474,7 @@ TEST_F(MergeJoinTest, lazyVectors) {
   writeToFile(rightFile->path, rightVectors);
   createDuckDbTable("u", {rightVectors});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId leftScanId;
   core::PlanNodeId rightScanId;
   auto op = PlanBuilder(planNodeIdGenerator)

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -31,7 +31,7 @@ class MergeTest : public OperatorTestBase {
 
     for (const auto& sortOrderSql : sortOrderSqls) {
       const auto orderByClause = fmt::format("{} {}", key, sortOrderSql);
-      auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+      auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
       auto plan = PlanBuilder(planNodeIdGenerator)
                       .localMerge(
                           {orderByClause},
@@ -89,7 +89,8 @@ class MergeTest : public OperatorTestBase {
             fmt::format("{} {}", key2, sortOrderSqls[j])};
         const auto orderBySql = fmt::format(
             "ORDER BY {}, {}", orderByClauses[0], orderByClauses[1]);
-        auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+        auto planNodeIdGenerator =
+            std::make_shared<core::PlanNodeIdGenerator>();
         auto plan = PlanBuilder(planNodeIdGenerator)
                         .localMerge(
                             orderByClauses,
@@ -161,7 +162,7 @@ TEST_F(MergeTest, offByOne) {
       makeFlatVector<int64_t>({2, 3, 4, 5}),
   });
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
   auto plan =
       PlanBuilder(planNodeIdGenerator)

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -255,7 +255,7 @@ TEST_F(MultiFragmentTest, mergeExchange) {
   for (int i = 0; i < 2; ++i) {
     auto sortTaskId = makeTaskId("orderby", tasks.size());
     partialSortTaskIds.push_back(sortTaskId);
-    auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     auto partialSortPlan = PlanBuilder(planNodeIdGenerator)
                                .localMerge(
                                    {"c0"},
@@ -568,7 +568,7 @@ namespace {
 core::PlanNodePtr makeJoinOverExchangePlan(
     const RowTypePtr& exchangeType,
     const RowVectorPtr& buildData) {
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   return PlanBuilder(planNodeIdGenerator)
       .exchange(exchangeType)
       .hashJoin(
@@ -756,7 +756,7 @@ TEST_F(MultiFragmentTest, earlyCompletionMerge) {
           {"u_c0"}, {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6})});
     }
 
-    auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     auto joinPlan =
         PlanBuilder(planNodeIdGenerator)
             .mergeExchange(asRowType(data->type()), {"c0"})

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -76,7 +76,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
   }
   auto probeType = ROW({"c0", "c1"}, {INTEGER(), BIGINT()});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   // 100 key values in [35, 233] range.
   auto rightKey = makeFlatVector<int32_t>(
       numRowsBuild, [](auto row) { return 35 + row * 2; });

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -390,7 +390,7 @@ TEST_F(TaskTest, testTerminateDeadlock) {
   auto rightBatch = makeRowVector(
       {makeFlatVector<int32_t>(10, [](auto row) { return row; })});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto leftNode =
       PlanBuilder(planNodeIdGenerator).values({leftBatch}, true).planNode();
   auto rightNode =
@@ -525,7 +525,7 @@ TEST_F(TaskTest, singleThreadedHashJoin) {
   auto rightPath = TempFilePath::create();
   writeToFile(rightPath->path, {right});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId leftScanId;
   core::PlanNodeId rightScanId;
   auto plan = PlanBuilder(planNodeIdGenerator)
@@ -565,7 +565,7 @@ TEST_F(TaskTest, singleThreadedCrossJoin) {
   auto rightPath = TempFilePath::create();
   writeToFile(rightPath->path, {right});
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId leftScanId;
   core::PlanNodeId rightScanId;
   auto plan = PlanBuilder(planNodeIdGenerator)
@@ -617,7 +617,7 @@ DEBUG_ONLY_TEST_F(TaskTest, outputDriverFinishEarly) {
 
   // Create a query plan fragment with one input pipeline and one output
   // pipeline and both have only one driver.
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto plan =
       PlanBuilder(planNodeIdGenerator)
           .localMerge(

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -247,7 +247,7 @@ void VeloxIn10MinDemo::run() {
   // build side. We are going to use PlanNodeIdGenerator to ensure that all plan
   // nodes in the final plan have unique IDs.
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId nationScanId;
   core::PlanNodeId regionScanId;
   plan = PlanBuilder(planNodeIdGenerator)

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1259,8 +1259,8 @@ PlanBuilder& PlanBuilder::window(
   return *this;
 }
 
-std::string PlanBuilder::nextPlanNodeId() {
-  return fmt::format("{}", planNodeIdGenerator_->next());
+core::PlanNodeId PlanBuilder::nextPlanNodeId() {
+  return planNodeIdGenerator_->next();
 }
 
 // static

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -231,7 +231,7 @@ TpchPlan TpchQueryBuilder::getQ3Plan() const {
       formatDateFilter(shipDate, lineitemSelectedRowType, "'1995-03-15'", "");
   auto customerFilter = "c_mktsegment = 'BUILDING'";
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId lineitemPlanNodeId;
   core::PlanNodeId ordersPlanNodeId;
   core::PlanNodeId customerPlanNodeId;
@@ -326,7 +326,7 @@ TpchPlan TpchQueryBuilder::getQ5Plan() const {
   std::string orderDateFilter = formatDateFilter(
       orderDate, ordersSelectedRowType, "'1994-01-01'", "'1994-12-31'");
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId customerScanNodeId;
   core::PlanNodeId ordersScanNodeId;
   core::PlanNodeId lineitemScanNodeId;
@@ -483,7 +483,7 @@ TpchPlan TpchQueryBuilder::getQ7Plan() const {
   auto shipDateFilter = formatDateFilter(
       "l_shipdate", lineitemSelectedRowType, "'1995-01-01'", "'1996-12-31'");
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId supplierScanNodeId;
   core::PlanNodeId lineitemScanNodeId;
   core::PlanNodeId ordersScanNodeId;
@@ -631,7 +631,7 @@ TpchPlan TpchQueryBuilder::getQ8Plan() const {
   const auto orderDateFilter = formatDateFilter(
       "o_orderdate", ordersSelectedRowType, "'1995-01-01'", "'1996-12-31'");
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId partScanNodeId;
   core::PlanNodeId supplierScanNodeId;
   core::PlanNodeId lineitemScanNodeId;
@@ -804,7 +804,7 @@ TpchPlan TpchQueryBuilder::getQ9Plan() const {
   auto nationSelectedRowType = getRowType(kNation, nationColumns);
   const auto& nationFileColumns = getFileColumnNames(kNation);
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId partScanNodeId;
   core::PlanNodeId supplierScanNodeId;
   core::PlanNodeId lineitemScanNodeId;
@@ -939,7 +939,7 @@ TpchPlan TpchQueryBuilder::getQ10Plan() const {
   const std::vector<std::string> customerOutputColumns = {
       "c_name", "c_acctbal", "c_phone", "c_address", "c_custkey", "c_comment"};
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId customerScanNodeId;
   core::PlanNodeId nationScanNodeId;
   core::PlanNodeId lineitemScanNodeId;
@@ -1044,7 +1044,7 @@ TpchPlan TpchQueryBuilder::getQ12Plan() const {
   auto lineitemSelectedRowType = getRowType(kLineitem, lineitemColumns);
   const auto& lineitemFileColumns = getFileColumnNames(kLineitem);
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId ordersScanNodeId;
   core::PlanNodeId lineitemScanNodeId;
 
@@ -1111,7 +1111,7 @@ TpchPlan TpchQueryBuilder::getQ13Plan() const {
   const auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
   const auto& customerFileColumns = getFileColumnNames(kCustomer);
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId customerScanNodeId;
   core::PlanNodeId ordersScanNodeId;
 
@@ -1167,7 +1167,7 @@ TpchPlan TpchQueryBuilder::getQ14Plan() const {
   const std::string shipDateFilter = formatDateFilter(
       shipDate, lineitemSelectedRowType, "'1995-09-01'", "'1995-09-30'");
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId lineitemScanNodeId;
   core::PlanNodeId partScanNodeId;
 
@@ -1230,7 +1230,7 @@ TpchPlan TpchQueryBuilder::getQ15Plan() const {
   const std::string shipDateFilter = formatDateFilter(
       "l_shipdate", lineitemSelectedRowType, "'1996-01-01'", "'1996-03-31'");
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId lineitemScanNodeIdSubQuery;
   core::PlanNodeId lineitemScanNodeId;
   core::PlanNodeId supplierScanNodeId;
@@ -1311,7 +1311,7 @@ TpchPlan TpchQueryBuilder::getQ16Plan() const {
   const auto partsuppSelectedRowType = getRowType(kPartsupp, partsuppColumns);
   const auto& partsuppFileColumns = getFileColumnNames(kPartsupp);
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId partScanNodeId;
   core::PlanNodeId supplierScanNodeId;
   core::PlanNodeId partsuppScanNodeId;
@@ -1396,7 +1396,7 @@ TpchPlan TpchQueryBuilder::getQ18Plan() const {
   const auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
   const auto& customerFileColumns = getFileColumnNames(kCustomer);
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId customerScanNodeId;
   core::PlanNodeId ordersScanNodeId;
   core::PlanNodeId lineitemScanNodeId;
@@ -1473,7 +1473,7 @@ TpchPlan TpchQueryBuilder::getQ19Plan() const {
   auto partSelectedRowType = getRowType(kPart, partColumns);
   const auto& partFileColumns = getFileColumnNames(kPart);
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId lineitemScanNodeId;
   core::PlanNodeId partScanNodeId;
 
@@ -1548,7 +1548,7 @@ TpchPlan TpchQueryBuilder::getQ22Plan() const {
   const std::string phoneFilter =
       "substr(c_phone, 1, 2) IN ('13', '31', '23', '29', '30', '18', '17')";
 
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId customerScanNodeId;
   core::PlanNodeId customerScanNodeIdWithKey;
   core::PlanNodeId ordersScanNodeId;

--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -289,7 +289,7 @@ TEST_F(ApproxPercentileTest, partialFull) {
 TEST_F(ApproxPercentileTest, finalAggregateAccuracy) {
   auto batch = makeRowVector(
       {makeFlatVector<int32_t>(1000, [](auto row) { return row; })});
-  auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   std::vector<std::shared_ptr<const core::PlanNode>> sources;
   for (int i = 0; i < 10; ++i) {
     sources.push_back(

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -156,8 +156,7 @@ void SumTest::testAggregateOverflow(
   // output into a final aggregate plan node. Each of those input fragments
   // only have a single input value under the max limit which when added in
   // the final step causes a potential overflow.
-  auto planNodeIdGenerator =
-      std::make_shared<exec::test::PlanNodeIdGenerator>();
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   aggsToTest.push_back(
       {PlanBuilder(planNodeIdGenerator)
            .localPartition(

--- a/velox/parse/PlanNodeIdGenerator.h
+++ b/velox/parse/PlanNodeIdGenerator.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::core {
+
+/// Generates unique sequential plan node IDs starting with zero or specified
+/// value.
+class PlanNodeIdGenerator {
+ public:
+  explicit PlanNodeIdGenerator(int startId = 0) : nextId_{startId} {}
+
+  PlanNodeId next() {
+    return fmt::format("{}", nextId_++);
+  }
+
+  void reset(int startId = 0) {
+    nextId_ = startId;
+  }
+
+ private:
+  int nextId_;
+};
+
+} // namespace facebook::velox::core


### PR DESCRIPTION
Extract PlanNodeIdGenerator from PlanBuilder.cpp into 
velox/parse/PlanNodeIdGenerator.h to allow for reuse.