### PR TITLE
Fix memory tracker count leak when actual memory allocation fails

### DIFF
--- a/velox/buffer/tests/CMakeLists.txt
+++ b/velox/buffer/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(
   velox_buffer_test
   velox_memory
   velox_buffer
+  velox_test_util
   gtest
   gtest_main
   gmock

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -592,7 +592,7 @@ bool AsyncDataCache::allocate(
     MachinePageCount numPages,
     int32_t owner,
     Allocation& out,
-    std::function<void(int64_t)> beforeAllocCB,
+    std::function<void(int64_t, bool)> beforeAllocCB,
     MachinePageCount minSizeClass) {
   free(out);
   return makeSpace(numPages, [&]() {
@@ -605,7 +605,7 @@ bool AsyncDataCache::allocateContiguous(
     MachinePageCount numPages,
     Allocation* collateral,
     ContiguousAllocation& allocation,
-    std::function<void(int64_t)> beforeAllocCB) {
+    std::function<void(int64_t, bool)> beforeAllocCB) {
   return makeSpace(numPages, [&]() {
     return mappedMemory_->allocateContiguous(
         numPages, collateral, allocation, beforeAllocCB);

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -611,7 +611,7 @@ class AsyncDataCache : public memory::MappedMemory {
       memory::MachinePageCount numPages,
       int32_t owner,
       Allocation& out,
-      std::function<void(int64_t)> beforeAllocCB = nullptr,
+      std::function<void(int64_t, bool)> beforeAllocCB = nullptr,
       memory::MachinePageCount minSizeClass = 0) override;
 
   int64_t free(Allocation& allocation) override {
@@ -622,7 +622,7 @@ class AsyncDataCache : public memory::MappedMemory {
       memory::MachinePageCount numPages,
       Allocation* FOLLY_NULLABLE collateral,
       ContiguousAllocation& allocation,
-      std::function<void(int64_t)> beforeAllocCB = nullptr) override;
+      std::function<void(int64_t, bool)> beforeAllocCB = nullptr) override;
 
   void freeContiguous(ContiguousAllocation& allocation) override {
     mappedMemory_->freeContiguous(allocation);

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -28,8 +28,9 @@ add_library(
   MemoryUsageTracker.cpp
   StreamArena.cpp)
 
-target_link_libraries(velox_memory velox_flag_definitions velox_common_base
-                      velox_exception ${FOLLY_WITH_DEPENDENCIES})
+target_link_libraries(
+  velox_memory velox_flag_definitions velox_common_base velox_exception
+  velox_test_util ${FOLLY_WITH_DEPENDENCIES})
 
 if(NOT VELOX_DISABLE_GOOGLETEST)
   target_link_libraries(velox_memory gtest)

--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -362,42 +362,45 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
   // process-wide default instance.
   static void setDefaultInstance(MappedMemory* FOLLY_NULLABLE instance);
 
-  /// Allocates one or more runs that add up to at least 'numPages',
-  /// with the smallest run being at least 'minSizeClass'
-  /// pages. 'minSizeClass' must be <= the size of the largest size
-  /// class. The new memory is returned in 'out' and any memory
-  /// formerly referenced by 'out' is freed. 'beforeAllocCb' is called
-  /// before making the allocation. Returns true if the allocation
-  /// succeeded. If returning false, 'out' references no memory and
-  /// any partially allocated memory is freed.
+  /// Allocates one or more runs that add up to at least 'numPages', with the
+  /// smallest run being at least 'minSizeClass' pages. 'minSizeClass' must be
+  /// <= the size of the largest size class. The new memory is returned in 'out'
+  /// and any memory formerly referenced by 'out' is freed. 'userAllocCB' is
+  /// called with the actual allocation bytes and a flag indicating if it is
+  /// called for pre-allocation or post-allocation failure. The flag is true for
+  /// pre-allocation call and false for post-allocation failure call. The latter
+  /// is to let user have a chance to rollback if needed. For instance,
+  /// 'ScopedMappedMemory' object will make memory counting reservation in
+  /// 'userAllocCB' before the actual memory allocation so it needs to release
+  /// the reservation if the actual allocation fails. The function returns true
+  /// if the allocation succeeded. If returning false, 'out' references no
+  /// memory and any partially allocated memory is freed.
   virtual bool allocate(
       MachinePageCount numPages,
       int32_t owner,
       Allocation& out,
-      std::function<void(int64_t)> beforeAllocCB = nullptr,
+      std::function<void(int64_t, bool)> userAllocCB = nullptr,
       MachinePageCount minSizeClass = 0) = 0;
 
   // Returns the number of freed bytes.
   virtual int64_t free(Allocation& allocation) = 0;
 
-  // Makes a contiguous mmap of 'numPages'. Advises away the required
-  // number of free pages so as not to have resident size exceed the
-  // capacity if capacity is bounded. Returns false if sufficient free
-  // pages do not exist. 'collateral' and 'allocation' are freed and
-  // unmapped or advised away to provide pages to back the new
-  // 'allocation'. This will always succeed if collateral and
-  // allocation together cover the new size of
-  // allocation. 'allocation' is newly mapped and hence zeroed. The
-  // contents of 'allocation' and 'collateral' are freed in all cases,
-  // also if the allocation fails. 'beforeAllocCB can be used to
-  // update trackers. It may throw and the end state will be
-  // consistent, with no new allocation and 'allocation' and
-  // 'collateral' cleared.
+  /// Makes a contiguous mmap of 'numPages'. Advises away the required number of
+  /// free pages so as not to have resident size exceed the capacity if capacity
+  /// is bounded. Returns false if sufficient free pages do not exist.
+  /// 'collateral' and 'allocation' are freed and unmapped or advised away to
+  /// provide pages to back the new 'allocation'. This will always succeed if
+  /// collateral and allocation together cover the new size of allocation.
+  /// 'allocation' is newly mapped and hence zeroed. The contents of
+  /// 'allocation' and 'collateral' are freed in all cases, also if the
+  /// allocation fails. 'userAllocCB' is used in the same way as allocate does.
+  /// It may throw and the end state will be consistent, with no new allocation
+  /// and 'allocation' and 'collateral' cleared.
   virtual bool allocateContiguous(
       MachinePageCount numPages,
       Allocation* FOLLY_NULLABLE collateral,
       ContiguousAllocation& allocation,
-      std::function<void(int64_t)> beforeAllocCB = nullptr) = 0;
+      std::function<void(int64_t, bool)> userAllocCB = nullptr) = 0;
 
   virtual void freeContiguous(ContiguousAllocation& allocation) = 0;
 
@@ -535,7 +538,7 @@ class ScopedMappedMemory final : public MappedMemory {
       MachinePageCount numPages,
       int32_t owner,
       Allocation& out,
-      std::function<void(int64_t)> beforeAllocCB,
+      std::function<void(int64_t, bool)> userAllocCB,
       MachinePageCount minSizeClass) override;
 
   int64_t free(Allocation& allocation) override {
@@ -550,7 +553,7 @@ class ScopedMappedMemory final : public MappedMemory {
       MachinePageCount numPages,
       Allocation* FOLLY_NULLABLE collateral,
       ContiguousAllocation& allocation,
-      std::function<void(int64_t)> beforeAllocCB = nullptr) override;
+      std::function<void(int64_t, bool)> userAllocCB = nullptr) override;
 
   void freeContiguous(ContiguousAllocation& allocation) override {
     int64_t size = allocation.size();

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -424,9 +424,6 @@ class MemoryPoolImpl : public MemoryPoolBase {
       int64_t cap = kMaxMemory);
 
   ~MemoryPoolImpl() {
-    // TODO(xiaoxmeng): enable this in release build after fix the issue exposed
-    // by Prestissmo in real cluster.
-#ifndef NDEBUG
     if (const auto& tracker = getMemoryUsageTracker()) {
       auto remainingBytes = tracker->getCurrentUserBytes();
       VELOX_CHECK_EQ(
@@ -437,7 +434,6 @@ class MemoryPoolImpl : public MemoryPoolBase {
           tracker->getCumulativeBytes(),
           tracker->getNumAllocs());
     }
-#endif
   }
 
   // Actual memory allocation operations. Can be delegated.

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -70,7 +70,7 @@ class MmapAllocator : public MappedMemory {
       MachinePageCount numPages,
       int32_t owner,
       Allocation& out,
-      std::function<void(int64_t)> beforeAllocCB = nullptr,
+      std::function<void(int64_t, bool)> userAllocCB = nullptr,
       MachinePageCount minSizeClass = 0) override;
 
   int64_t free(Allocation& allocation) override;
@@ -79,11 +79,11 @@ class MmapAllocator : public MappedMemory {
       MachinePageCount numPages,
       Allocation* FOLLY_NULLABLE collateral,
       ContiguousAllocation& allocation,
-      std::function<void(int64_t)> beforeAllocCB = nullptr) override {
+      std::function<void(int64_t, bool)> userAllocCB = nullptr) override {
     bool result;
     stats_.recordAllocate(numPages * kPageSize, 1, [&]() {
-      result = allocateContiguousImpl(
-          numPages, collateral, allocation, beforeAllocCB);
+      result =
+          allocateContiguousImpl(numPages, collateral, allocation, userAllocCB);
     });
     return result;
   }
@@ -300,7 +300,7 @@ class MmapAllocator : public MappedMemory {
       MachinePageCount numPages,
       Allocation* FOLLY_NULLABLE collateral,
       ContiguousAllocation& allocation,
-      std::function<void(int64_t)> beforeAllocCB);
+      std::function<void(int64_t, bool)> userAllocCB);
 
   void freeContiguousImpl(ContiguousAllocation& allocation);
 

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(
   velox_memory_test
   velox_memory
   velox_exception
+  velox_test_util
   gtest
   gtest_main
   ${gflags_LIBRARIES}

--- a/velox/common/testutil/TestValue.cpp
+++ b/velox/common/testutil/TestValue.cpp
@@ -43,9 +43,7 @@ void TestValue::clear(const std::string& injectionPoint) {
   injectionMap_.erase(injectionPoint);
 }
 
-void TestValue::notify(
-    const std::string& injectionPoint,
-    const void* testData) {
+void TestValue::adjust(const std::string& injectionPoint, void* testData) {
   Callback injectionCb;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -63,9 +61,7 @@ bool TestValue::enabled() {
   return false;
 }
 void TestValue::clear(const std::string& injectionPoint) {}
-void TestValue::notify(
-    const std::string& injectionPoint,
-    const void* testData) {}
+void TestValue::adjust(const std::string& injectionPoint, void* testData) {}
 #endif
 
 } // namespace facebook::velox::common::testutil

--- a/velox/common/testutil/tests/TestValueTest.cpp
+++ b/velox/common/testutil/tests/TestValueTest.cpp
@@ -29,8 +29,8 @@ class TestObject {
   void set(int value) {
     ++count_;
     value_ = value;
-    const std::pair<int, int> testValue(value_, count_);
-    TestValue::notify(
+    std::pair<int, int> testValue(value_, count_);
+    TestValue::adjust(
         "facebook::velox::exec::test::TestObject::set", &testValue);
   }
 

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -100,7 +100,7 @@ BlockingReason Merge::isBlocked(ContinueFuture* future) {
 }
 
 bool Merge::isFinished() {
-  TestValue::notify("facebook::velox::exec::Merge::isFinished", &finished_);
+  TestValue::adjust("facebook::velox::exec::Merge::isFinished", &finished_);
   return finished_;
 }
 

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -103,7 +103,8 @@ Spiller::Spiller(
           spillMappedMemory()),
       pool_(pool),
       executor_(executor) {
-  TestValue::notify("facebook::velox::exec::Spiller", &bits_);
+  TestValue::adjust(
+      "facebook::velox::exec::Spiller", const_cast<HashBitRange*>(&bits_));
 
   VELOX_CHECK_EQ(container_ == nullptr, type_ == Type::kHashJoinProbe);
   // kOrderBy spiller type must only have one partition.

--- a/velox/exec/Values.cpp
+++ b/velox/exec/Values.cpp
@@ -41,7 +41,7 @@ Values::Values(
 }
 
 RowVectorPtr Values::getOutput() {
-  TestValue::notify("facebook::velox::exec::Values::getOutput", &current_);
+  TestValue::adjust("facebook::velox::exec::Values::getOutput", &current_);
   if (current_ >= values_.size()) {
     return nullptr;
   }


### PR DESCRIPTION
Fix the memory tracker counting leak when used with ScopedMappedMemory
which will update the memory tracker before the actual memory allocation.
The non-contiguous memory allocation path doesn't have the rollback when
the actual memory allocation failure. Found this issue by memory tracker counting
check failure on the associated memory pool destruction.

Verify this fix by both unit tests and production workload replay on Prestissmo
staging cluster.

This PR also change test value notify method to adjust which captures a mutable
production execution state which allows to inject an allocation failure easily in
test.