### PR TITLE
Fix loading of dictionary wrapped lazy vectors

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -833,9 +833,12 @@ inline BufferPtr allocateIndices(vector_size_t size, memory::MemoryPool* pool) {
 }
 
 // Allocates a buffer to fit at least 'size' null bits and initializes them to
-// not-null.
-inline BufferPtr allocateNulls(vector_size_t size, memory::MemoryPool* pool) {
-  return AlignedBuffer::allocate<bool>(size, pool, bits::kNotNull);
+// the provided 'initValue' which has a default value of non-null.
+inline BufferPtr allocateNulls(
+    vector_size_t size,
+    memory::MemoryPool* pool,
+    bool initValue = bits::kNotNull) {
+  return AlignedBuffer::allocate<bool>(size, pool, initValue);
 }
 
 // Returns a summary of the null bits in the specified buffer and prints out

--- a/velox/vector/LazyVector.cpp
+++ b/velox/vector/LazyVector.cpp
@@ -169,10 +169,9 @@ void LazyVector::ensureLoadedRows(
         // All valid values in 'rows' are nulls. Set the nulls buffer to all
         // nulls to avoid hitting DCHECK when creating a dictionary with a zero
         // sized base vector.
-        nulls =
-            AlignedBuffer::allocate<bool>(rows.end(), vector->pool(), false);
+        nulls = allocateNulls(rows.end(), vector->pool(), bits::kNull);
       } else {
-        nulls = AlignedBuffer::allocate<bool>(rows.end(), vector->pool());
+        nulls = allocateNulls(rows.end(), vector->pool());
         std::memcpy(
             nulls->asMutable<uint64_t>(),
             decoded.nulls(),

--- a/velox/vector/LazyVector.cpp
+++ b/velox/vector/LazyVector.cpp
@@ -157,7 +157,7 @@ void LazyVector::ensureLoadedRows(
     // The loaded base vector may have fewer rows than the original. Make sure
     // there are no indices referring to rows past the end of the base vector.
 
-    BufferPtr indices = allocateIndices(vector->size(), vector->pool());
+    BufferPtr indices = allocateIndices(rows.end(), vector->pool());
     auto rawIndices = indices->asMutable<vector_size_t>();
     auto decodedIndices = decoded.indices();
     rows.applyToSelected(
@@ -165,17 +165,25 @@ void LazyVector::ensureLoadedRows(
 
     BufferPtr nulls = nullptr;
     if (decoded.nulls()) {
-      nulls = AlignedBuffer::allocate<bool>(vector->size(), vector->pool());
-      std::memcpy(
-          nulls->asMutable<uint64_t>(),
-          decoded.nulls(),
-          bits::nbytes(vector->size()));
+      if (!baseRows.hasSelections()) {
+        // All valid values in 'rows' are nulls. Set the nulls buffer to all
+        // nulls to avoid hitting DCHECK when creating a dictionary with a zero
+        // sized base vector.
+        nulls =
+            AlignedBuffer::allocate<bool>(rows.end(), vector->pool(), false);
+      } else {
+        nulls = AlignedBuffer::allocate<bool>(rows.end(), vector->pool());
+        std::memcpy(
+            nulls->asMutable<uint64_t>(),
+            decoded.nulls(),
+            bits::nbytes(rows.end()));
+      }
     }
 
     vector = BaseVector::wrapInDictionary(
         std::move(nulls),
         std::move(indices),
-        vector->size(),
+        rows.end(),
         lazyVector->loadedVectorShared());
     return;
   }

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -204,7 +204,7 @@ TEST_F(LazyVectorTest, lazyInMultipleDictionaryAllResultantNullRows) {
             rows.back() + 1, [](auto row) { return row; });
       }));
   auto wrapped = BaseVector::wrapInDictionary(
-      makeNulls(kVectorSize, [](vector_size_t row) { return true; }),
+      makeNulls(kVectorSize, [](vector_size_t /*row*/) { return true; }),
       makeIndices(kVectorSize, [](auto row) { return row; }),
       kVectorSize,
       lazy);

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -187,3 +187,59 @@ TEST_F(LazyVectorTest, lazySlice) {
     EXPECT_TRUE(slice->equalValueAt(lazy.get(), i, i));
   }
 }
+
+TEST_F(LazyVectorTest, lazyInMultipleDictionaryAllResultantNullRows) {
+  // Verifies that lazy loading works for a lazy vector that is wrapped in
+  // multiple layers of dictionary encoding such that the rows that it needs to
+  // be loaded for all end up pointing to nulls. This results in a zero sized
+  // base vector which when wrapped in a dictionary layer can run into invalid
+  // internal state for row indices that were not asked to be loaded.
+  static constexpr int32_t kVectorSize = 10;
+  auto lazy = std::make_shared<LazyVector>(
+      pool_.get(),
+      INTEGER(),
+      kVectorSize,
+      std::make_unique<test::SimpleVectorLoader>([&](auto rows) {
+        return makeFlatVector<int32_t>(
+            rows.back() + 1, [](auto row) { return row; });
+      }));
+  auto wrapped = BaseVector::wrapInDictionary(
+      makeNulls(kVectorSize, [](vector_size_t row) { return true; }),
+      makeIndices(kVectorSize, [](auto row) { return row; }),
+      kVectorSize,
+      lazy);
+  wrapped = BaseVector::wrapInDictionary(
+      nullptr,
+      makeIndices(kVectorSize, [](auto row) { return row; }),
+      kVectorSize,
+      wrapped);
+  SelectivityVector rows(kVectorSize, true);
+  rows.setValid(1, false);
+  LazyVector::ensureLoadedRows(wrapped, rows);
+  auto expected =
+      BaseVector::createNullConstant(lazy->type(), wrapped->size(), pool());
+  assertEqualVectors(expected, wrapped);
+}
+
+TEST_F(LazyVectorTest, lazyInDictionaryNoRowsToLoad) {
+  // Verifies that lazy loading works for a lazy vector that is wrapped a
+  // dictionary with no extra nulls when loading for 0 selected rows.
+  static constexpr int32_t kVectorSize = 10;
+  auto lazy = std::make_shared<LazyVector>(
+      pool_.get(),
+      INTEGER(),
+      kVectorSize,
+      std::make_unique<test::SimpleVectorLoader>([&](auto rows) {
+        return makeFlatVector<int32_t>(
+            rows.back() + 1, [](auto row) { return row; });
+      }));
+  auto wrapped = BaseVector::wrapInDictionary(
+      nullptr,
+      makeIndices(kVectorSize, [](auto row) { return row; }),
+      kVectorSize,
+      lazy);
+  SelectivityVector rows(kVectorSize, false);
+  LazyVector::ensureLoadedRows(wrapped, rows);
+  auto expected = makeFlatVector<int32_t>(0);
+  assertEqualVectors(expected, wrapped);
+}


### PR DESCRIPTION
Currently, when attempting to load a dictionary wrapped lazy vector,
the resultant dictionary vector can have invalid internal state for
the following two cases:

1. Lazy vector that is wrapped in multiple layers of dictionary
encoding such that the rows that it needs to be loaded for all
end up pointing to nulls. This results in a zero sized base vector
wrapped in a dictionary layer where the rows that were not selected
to be loaded have default values of their index(set to 0) and null
value(set to not null). This violates the invariant that the index
should point to a valid position in the base vector.

2. Lazy vector that is wrapped in a dictionary with no nulls buffer
and being loaded for zero selected rows. This results in a zero
sized base vector wrapped in a dictionary layer of non-zero size
with indices and nulls buffer initialized to default values and
therefore ends up violating the same invariant as above.

This patch fixes both of the above cases.

Test Plan:
Added unit tests