### PR TITLE
Change DuckDB default null order to NULLS LAST in tests

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -585,6 +585,9 @@ void DuckDbQueryRunner::initializeTpch(double scaleFactor) {
 
 DuckDBQueryResult DuckDbQueryRunner::execute(const std::string& sql) {
   ::duckdb::Connection con(db_);
+  // Changing the default null order of NULLS FIRST used by DuckDB. Velox uses
+  // NULLS LAST.
+  con.Query("PRAGMA default_null_order='NULLS LAST'");
   auto duckDbResult = con.Query(sql);
   verifyDuckDBResult(duckDbResult, sql);
   return duckDbResult;

--- a/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
@@ -48,7 +48,7 @@ class LastAggregateTest : public aggregate::test::AggregationTestBase {
         vectors,
         {"c0"},
         {"last(c1, c2)"},
-        "SELECT c0, last(c1 ORDER BY c1) FROM tmp GROUP BY c0");
+        "SELECT c0, last(c1 ORDER BY c1 NULLS FIRST) FROM tmp GROUP BY c0");
 
     // Verify when ignoreNull is false.
     // Expected result should have last 7 rows [91..98) including nulls.
@@ -170,7 +170,7 @@ TEST_F(LastAggregateTest, varcharGroupBy) {
       vectors,
       {"c0"},
       {"last(c1, c2)"},
-      "SELECT c0, last(c1 ORDER BY c1) FROM tmp WHERE c1 IS NOT NULL GROUP BY c0");
+      "SELECT c0, last(c1 ORDER BY c1 NULLS FIRST) FROM tmp WHERE c1 IS NOT NULL GROUP BY c0");
 
   // Verify when ignoreNull is false.
   // Expected result should have last 7 rows [91..98) including nulls.


### PR DESCRIPTION
Velox PlanBuilder uses a default of NULLS LAST to be consistent with Presto.