### PR TITLE
Allow wildcard % to match newline in like() Presto function

### DIFF
--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -470,6 +470,14 @@ TEST_F(Re2FunctionsTest, likePatternWildcard) {
   EXPECT_FALSE(like(
       generateString(kLikePatternCharacterSet),
       generateString(kSingleWildcardCharacter, 65)));
+
+  // Test that % matches newline.
+  EXPECT_TRUE(like("\nabcde\n", "%bcd%"));
+  EXPECT_TRUE(like("\nabcd", "%bcd"));
+  EXPECT_TRUE(like("bcde\n", "bcd%"));
+  EXPECT_FALSE(like("\nabcde\n", "bcd%"));
+  EXPECT_FALSE(like("\nabcde\n", "%bcd"));
+  EXPECT_FALSE(like("\nabcde\n", "%bcf%"));
 }
 
 TEST_F(Re2FunctionsTest, likePatternFixed) {
@@ -526,6 +534,9 @@ TEST_F(Re2FunctionsTest, likePatternPrefix) {
   EXPECT_FALSE(like("ABCDE", "abc%"));
   EXPECT_FALSE(like("abcde", "ad%%"));
   EXPECT_FALSE(like("ABCDE", "abc_%"));
+  EXPECT_TRUE(like("ABC\n", "ABC_"));
+  EXPECT_TRUE(like("ABC\n", "ABC_%"));
+  EXPECT_TRUE(like("\nABC\n", "_ABC%"));
 
   std::string input = generateString(kLikePatternCharacterSet, 66);
   EXPECT_TRUE(like(input, input + generateString(kAnyWildcardCharacter)));


### PR DESCRIPTION
The like() function is implemented via RE2 and the wildcard `%` is translated to RE2's 
wildcard `.` before processing. RE2's wildcard doesn't match newline character by 
default. To enable the match, we need to call `set_dot_nl(true)`. See the example at 
https://github.com/google/re2/blob/5aec8b553863350e32d13bbf745eae81adcdce93/re2/testing/re2_test.cc#L1349-L1356.

Differential Revision: D40194438

