### PR TITLE
Fix loop over temporary in HashTableTest.cpp

### DIFF
--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1217,7 +1217,8 @@ TEST_F(HashJoinTest, nullAwareAntiJoinWithFilterAndNullKey) {
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
   auto planNodeIdGenerator = std::make_shared<PlanNodeIdGenerator>();
-  for (const std::string& filter : {"u1 > t1", "u1 * t1 > 0"}) {
+  std::vector<std::string> filters = {"u1 > t1", "u1 * t1 > 0"};
+  for (const std::string& filter : filters) {
     auto sql = fmt::format(
         "SELECT t.* FROM t WHERE t0 NOT IN (SELECT u0 FROM u WHERE {})",
         filter);


### PR DESCRIPTION
g++ (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9) does not compile the loop over filters if the temporary vector has the scope of the loop. See diff.