### PR TITLE
scripts: Allow `setup-adapters.sh` to be run on Ubuntu

### DIFF
--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -61,7 +61,14 @@ cd "${DEPENDENCY_DIR}" || exit
 # aws-sdk-cpp missing dependencies
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-   yum -y install libxml2-devel libgsasl-devel libuuid-devel
+   # /etc/os-release is a standard way to query various distribution
+   # information and is available everywhere
+   LINUX_DISTRIBUTION=$(. /etc/os-release && echo ${ID})
+   if [[ "$LINUX_DISTRIBUTION" == "ubuntu" ]]; then
+      apt install -y --no-install-recommends libxml2-dev libgsasl-dev uuid-dev
+   else # Assume Fedora/CentOS
+      yum -y install libxml2-devel libgsasl-devel libuuid-devel
+   fi
 fi
 
 if [[ "$OSTYPE" == darwin* ]]; then


### PR DESCRIPTION
Use `/etc/os-release` file to parse distribution information since it is the standard way for all linux distributions.

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>