### PR TITLE
scripts: Bump AWS SDK version to mitigate OpenSSL 3.0 compatibility issues

### DIFF
--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -25,7 +25,7 @@ DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 
 function install_aws-sdk-cpp {
   local AWS_REPO_NAME="aws/aws-sdk-cpp"
-  local AWS_SDK_VERSION="1.9.96"
+  local AWS_SDK_VERSION="1.9.308"
 
   github_checkout $AWS_REPO_NAME $AWS_SDK_VERSION --depth 1 --recurse-submodules
   cmake_install -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" -DCMAKE_INSTALL_PREFIX="${DEPENDENCY_DIR}/install"


### PR DESCRIPTION
Switch to a more recent AWS SDK version to incorporate important fixes to be able to build it with OpenSSL 3.0.

Please see https://github.com/aws/aws-sdk-cpp/pull/1986 for details (eliminates uses of APIs that were marked as deprecated in OpenSSL 3.0 branch).

Signed-off-by: Pavel Solodovnikov <pavel.al.solodovnikov@gmail.com>