### PR TITLE
Simdize integer range VectorHasher value ids

### DIFF
--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -378,7 +378,8 @@ void VectorHasher::lookupValueIdsTyped(
     const DecodedVector& decoded,
     SelectivityVector& rows,
     raw_vector<uint64_t>& hashes,
-    uint64_t* result) const {
+    uint64_t* result,
+    bool noNulls) const {
   using T = typename TypeTraits<Kind>::NativeType;
   if (decoded.isConstantMapping()) {
     if (decoded.isNullAt(rows.begin())) {
@@ -398,21 +399,27 @@ void VectorHasher::lookupValueIdsTyped(
       });
     }
   } else if (decoded.isIdentityMapping()) {
-    rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
-      if (decoded.isNullAt(row)) {
-        if (multiplier_ == 1) {
-          result[row] = 0;
+    if (Kind == TypeKind::BIGINT && isRange_ && noNulls) {
+      lookupIdsRangeSimd<int64_t>(decoded, rows, result);
+    } else if (Kind == TypeKind::INTEGER && isRange_ && noNulls) {
+      lookupIdsRangeSimd<int32_t>(decoded, rows, result);
+    } else {
+      rows.applyToSelected([&](vector_size_t row) INLINE_LAMBDA {
+        if (decoded.isNullAt(row)) {
+          if (multiplier_ == 1) {
+            result[row] = 0;
+          }
+          return;
         }
-        return;
-      }
-      T value = decoded.valueAt<T>(row);
-      uint64_t id = lookupValueId(value);
-      if (id == kUnmappable) {
-        rows.setValid(row, false);
-        return;
-      }
-      result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
-    });
+        T value = decoded.valueAt<T>(row);
+        uint64_t id = lookupValueId(value);
+        if (id == kUnmappable) {
+          rows.setValid(row, false);
+          return;
+        }
+        result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
+      });
+    }
     rows.updateBounds();
   } else {
     hashes.resize(decoded.base()->size());
@@ -441,11 +448,68 @@ void VectorHasher::lookupValueIdsTyped(
   }
 }
 
+template <typename T>
+void VectorHasher::lookupIdsRangeSimd(
+    const DecodedVector& decoded,
+    SelectivityVector& rows,
+    uint64_t* result) const {
+  static_assert(sizeof(T) == 8 || sizeof(T) == 4);
+  auto lower = xsimd::batch<T>::broadcast(min_);
+  auto upper = xsimd::batch<T>::broadcast(max_);
+  auto data = decoded.data<T>();
+  uint64_t offset = min_ - 1;
+  auto bits = rows.asMutableRange().bits();
+  bits::forBatches<xsimd::batch<T>::size>(
+      bits, rows.begin(), rows.end(), [&](auto index, auto mask) {
+        auto values = xsimd::batch<T>::load_unaligned(data + index);
+        uint64_t outOfRange =
+            simd::toBitMask(lower > values) | simd::toBitMask(values > upper);
+        if (outOfRange) {
+          bits[index / 64] &= ~(outOfRange << (index & 63));
+        }
+        if (outOfRange != bits::lowMask(xsimd::batch<T>::size)) {
+          if constexpr (sizeof(T) == 8) {
+            auto unsignedValues =
+                static_cast<xsimd::batch<typename std::make_unsigned<T>::type>>(
+                    values);
+            if (multiplier_ == 1) {
+              (unsignedValues - offset).store_unaligned(result + index);
+            } else {
+              (xsimd::batch<uint64_t>::load_unaligned(result + index) +
+               ((unsignedValues - offset) * multiplier_))
+                  .store_unaligned(result + index);
+            }
+          } else {
+            // Widen 8 to 2 x 4 since result is always 64 wide.
+            auto first4 = static_cast<xsimd::batch<uint64_t>>(
+                              simd::getHalf<int64_t, 0>(values)) -
+                offset;
+            auto next4 = static_cast<xsimd::batch<uint64_t>>(
+                             simd::getHalf<int64_t, 1>(values)) -
+                offset;
+            if (multiplier_ == 1) {
+              first4.store_unaligned(result + index);
+              next4.store_unaligned(result + index + first4.size);
+            } else {
+              (xsimd::batch<uint64_t>::load_unaligned(result + index) +
+               (first4 * multiplier_))
+                  .store_unaligned(result + index);
+              (xsimd::batch<uint64_t>::load_unaligned(
+                   result + index + first4.size) +
+               (next4 * multiplier_))
+                  .store_unaligned(result + index + first4.size);
+            }
+          }
+        }
+      });
+}
+
 void VectorHasher::lookupValueIds(
     const BaseVector& values,
     SelectivityVector& rows,
     ScratchMemory& scratchMemory,
-    raw_vector<uint64_t>& result) const {
+    raw_vector<uint64_t>& result,
+    bool noNulls) const {
   scratchMemory.decoded.decode(values, rows);
   VALUE_ID_TYPE_DISPATCH(
       lookupValueIdsTyped,
@@ -453,7 +517,8 @@ void VectorHasher::lookupValueIds(
       scratchMemory.decoded,
       rows,
       scratchMemory.hashes,
-      result.data());
+      result.data(),
+      noNulls);
 }
 
 void VectorHasher::hash(
@@ -594,8 +659,8 @@ void extendRange(int64_t reserve, int64_t& min, int64_t& max) {
   }
 }
 
-// Adds 'reservePct' % to either end of the range between 'min' and 'max' while
-// staying in the range of 'kind'.
+// Adds 'reservePct' % to either end of the range between 'min' and 'max'
+// while staying in the range of 'kind'.
 void extendRange(
     TypeKind kind,
     int32_t reservePct,

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -236,12 +236,14 @@ class VectorHasher {
   // have a miss if any of the keys has a value that is not represented.
   //
   // This method can be called concurrently from multiple threads. To allow for
-  // that the caller must provide 'scratchMemory'.
+  // that the caller must provide 'scratchMemory'. 'noNulls' means that the
+  // positions in 'rows' are not checked for null values.
   void lookupValueIds(
       const BaseVector& values,
       SelectivityVector& rows,
       ScratchMemory& scratchMemory,
-      raw_vector<uint64_t>& result) const;
+      raw_vector<uint64_t>& result,
+      bool noNulls = true) const;
 
   // Returns true if either range or distinct values have not overflowed.
   bool mayUseValueIds() const {
@@ -386,6 +388,14 @@ class VectorHasher {
       const DecodedVector& decoded,
       SelectivityVector& rows,
       raw_vector<uint64_t>& hashes,
+      uint64_t* result,
+      bool noNulls) const;
+
+  // Fast path for range mapping of int64/int32 keys.
+  template <typename T>
+  void lookupIdsRangeSimd(
+      const DecodedVector& decoded,
+      SelectivityVector& rows,
       uint64_t* result) const;
 
   template <TypeKind Kind>

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1217,7 +1217,8 @@ TEST_F(HashJoinTest, nullAwareAntiJoinWithFilterAndNullKey) {
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  for (const std::string& filter : {"u1 > t1", "u1 * t1 > 0"}) {
+  std::vector<std::string> filters = {"u1 > t1", "u1 * t1 > 0"};
+  for (const std::string& filter : filters) {
     auto sql = fmt::format(
         "SELECT t.* FROM t WHERE t0 NOT IN (SELECT u0 FROM u WHERE {})",
         filter);


### PR DESCRIPTION
Uses SIMD to compare and scale integer range value ids.  Value ids for rows that are not selected can be written into the result of computeValueIds with no ill effect. This happens when doing a SIMD store where only some of the values are selected by SelectivityVector.

Adds a utility for looping over SIMD batches that have at least one selected item (bits::forBatches).