### PR TITLE
Fix HashTable inlining and simdize hash join result listing

### DIFF
--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -404,6 +404,13 @@ class HashTable : public BaseHashTable {
 
   void setHashMode(HashMode mode, int32_t numNew) override;
 
+  // Fast path for join results when there are no duplicates in the table.
+  int32_t listJoinResultsNoDuplicates(
+      JoinResultIterator& iter,
+      bool includeMisses,
+      folly::Range<vector_size_t*> inputRows,
+      folly::Range<char**> hits);
+
   /// Tries to use as many range hashers as can in a normalized key situation.
   void enableRangeWhereCan(
       const std::vector<uint64_t>& rangeSizes,
@@ -511,6 +518,9 @@ class HashTable : public BaseHashTable {
 
   template <bool isJoin>
   void fullProbe(HashLookup& lookup, ProbeState& state, bool extraCheck);
+
+  // Shortcut for probe with normalized keys.
+  void joinNormalizedKeyProbe(HashLookup& lookup);
 
   // Adds a row to a hash join table in kArray hash mode. Returns true
   // if a new entry was made and false if the row was added to an

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1217,7 +1217,8 @@ TEST_F(HashJoinTest, nullAwareAntiJoinWithFilterAndNullKey) {
   createDuckDbTable("t", {leftVectors});
   createDuckDbTable("u", {rightVectors});
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  for (const std::string& filter : {"u1 > t1", "u1 * t1 > 0"}) {
+  std::vector<std::string> filters = {"u1 > t1", "u1 * t1 > 0"};
+  for (const std::string& filter : filters) {
     auto sql = fmt::format(
         "SELECT t.* FROM t WHERE t0 NOT IN (SELECT u0 FROM u WHERE {})",
         filter);


### PR DESCRIPTION
- Simdize retrieving hash join result rows.

- Special inline path for normalized key hash join probe.

- faster mixing of bits for normalized key to hash number conversion.

Code covered in HashjoinTest.* and HashTableTest.*, no new functionality is introduced.

Drops single thread time for velox_tpch_benchmark from 40s to 36s with 10G uncompressed Parquet dataset.