### PR TITLE
Fix aggregate function registration

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_hive_connector OBJECT HiveConnector.cpp FileHandle.cpp)
+add_library(velox_hive_connector HiveConnector.cpp FileHandle.cpp)
 
 target_link_libraries(velox_hive_connector velox_connector
                       velox_dwio_dwrf_reader velox_dwio_dwrf_writer velox_file)

--- a/velox/dwio/parquet/tests/ParquetTpchTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTpchTestBase.h
@@ -25,6 +25,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/exec/tests/utils/TpchQueryBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/TypeResolver.h"
 
@@ -50,6 +51,8 @@ class ParquetTpchTestBase : public testing::Test {
       duckDb_->initializeTpch(kTpchScaleFactor);
     }
     functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+
     parse::registerTypeResolver();
     filesystems::registerLocalFileSystem();
     registerParquetReaderFactory(parquetReaderType_);

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -43,4 +43,5 @@ target_link_libraries(
   velox_hive_connector
   velox_tpch_connector
   velox_presto_serializer
-  velox_functions_prestosql)
+  velox_functions_prestosql
+  velox_aggregates)

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -21,6 +21,7 @@
 #include "velox/exec/Exchange.h"
 #include "velox/exec/PartitionedOutputBufferManager.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
@@ -68,6 +69,7 @@ void OperatorTestBase::SetUp() {
 
 void OperatorTestBase::SetUpTestCase() {
   functions::prestosql::registerAllScalarFunctions();
+  aggregate::prestosql::registerAllAggregateFunctions();
   TestValue::enable();
 }
 

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -16,7 +16,7 @@ add_subdirectory(types)
 add_subdirectory(window)
 
 add_library(
-  velox_functions_prestosql_impl OBJECT
+  velox_functions_prestosql_impl
   ArrayConstructor.cpp
   ArrayContains.cpp
   ArrayDistinct.cpp

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -29,7 +29,8 @@
 using facebook::velox::common::hll::DenseHll;
 using facebook::velox::common::hll::SparseHll;
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
+
 namespace {
 
 struct HllAccumulator {
@@ -452,13 +453,12 @@ bool registerApproxDistinct(
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerApproxDistinct(kApproxDistinct, false, false);
-
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerApproxDistinct(kApproxSet, true, false);
-
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerApproxDistinct(kMerge, true, true);
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerApproxDistinctAggregates() {
+  registerApproxDistinct(kApproxDistinct, false, false);
+  registerApproxDistinct(kApproxSet, true, false);
+  registerApproxDistinct(kMerge, true, true);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -20,7 +20,8 @@
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/vector/FlatVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
+
 namespace {
 
 template <typename T>
@@ -345,8 +346,10 @@ bool registerApproxMostFrequent(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerApproxMostFrequent(kApproxMostFrequent);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerApproxMostFrequentAggregate() {
+  registerApproxMostFrequent(kApproxMostFrequent);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -24,7 +24,8 @@
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
+
 namespace {
 
 template <typename T>
@@ -788,8 +789,10 @@ bool registerApproxPercentile(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerApproxPercentile(kApproxPercentile);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerApproxPercentileAggregate() {
+  registerApproxPercentile(kApproxPercentile);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -21,7 +21,7 @@
 #include "velox/functions/prestosql/aggregates/SingleValueAccumulator.h"
 #include "velox/vector/DecodedVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
@@ -298,8 +298,10 @@ bool registerArbitraryAggregate(const std::string& name) {
       });
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerArbitraryAggregate(kArbitrary);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerArbitraryAggregate() {
+  registerArbitraryAggregate(kArbitrary);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -19,7 +19,7 @@
 #include "velox/functions/prestosql/aggregates/ValueList.h"
 #include "velox/vector/ComplexVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 namespace {
 
 struct ArrayAccumulator {
@@ -198,8 +198,10 @@ bool registerArrayAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerArrayAggregate(kArrayAgg);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerArrayAggregate() {
+  registerArrayAggregate(kArrayAgg);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -20,7 +20,7 @@
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
@@ -368,7 +368,10 @@ bool registerAverageAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerAverageAggregate(kAvg);
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerAverageAggregate() {
+  registerAverageAggregate(kAvg);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
@@ -19,7 +19,7 @@
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/SimpleNumericAggregate.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
@@ -188,10 +188,11 @@ bool registerBitwiseAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerBitwiseAggregate<BitwiseOrAggregate>(kBitwiseOr);
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerBitwiseAggregate<BitwiseAndAggregate>(kBitwiseAnd);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerBitwiseAggregates() {
+  registerBitwiseAggregate<BitwiseOrAggregate>(kBitwiseOr);
+  registerBitwiseAggregate<BitwiseAndAggregate>(kBitwiseAnd);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -20,7 +20,7 @@
 #include "velox/functions/prestosql/aggregates/SimpleNumericAggregate.h"
 #include "velox/vector/FlatVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
@@ -207,14 +207,12 @@ bool registerBoolAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerBoolAggregate<BoolAndAggregate>(kBoolAnd);
-
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerBoolAggregate<BoolAndAggregate>(kEvery);
-
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerBoolAggregate<BoolOrAggregate>(kBoolOr);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerBoolAggregates() {
+  registerBoolAggregate<BoolAndAggregate>(kBoolAnd);
+  registerBoolAggregate<BoolAndAggregate>(kEvery);
+  registerBoolAggregate<BoolOrAggregate>(kBoolOr);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(
-  velox_aggregates OBJECT
+  velox_aggregates
   AggregateNames.h
   ApproxDistinctAggregate.cpp
   ApproxMostFrequentAggregate.cpp
@@ -40,10 +40,12 @@ add_library(
   SumAggregate.h
   ValueList.cpp
   VarianceAggregates.cpp
-  MaxSizeForStatsAggregate.cpp)
+  MaxSizeForStatsAggregate.cpp
+  RegisterAggregateFunctions.cpp)
 
-target_link_libraries(velox_aggregates velox_common_hyperloglog velox_exec
-                      velox_presto_serializer ${FOLLY_WITH_DEPENDENCIES})
+target_link_libraries(
+  velox_aggregates velox_common_hyperloglog velox_exec velox_presto_serializer
+  velox_functions_lib ${FOLLY_WITH_DEPENDENCIES})
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -23,7 +23,7 @@
 #include "velox/functions/prestosql/aggregates/PrestoHasher.h"
 #include "velox/vector/FlatVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
@@ -238,7 +238,10 @@ bool registerChecksumAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_checksumAggregateFunction) =
-    registerChecksumAggregate(kChecksum);
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerChecksumAggregate() {
+  registerChecksumAggregate(kChecksum);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -18,7 +18,7 @@
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/SumAggregate.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
@@ -175,8 +175,10 @@ bool registerCountAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerCountAggregate(kCount);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerCountAggregate() {
+  registerCountAggregate(kCount);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -21,7 +21,9 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/SimpleVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
+
+namespace {
 
 class CountIfAggregate : public exec::Aggregate {
  public:
@@ -201,7 +203,10 @@ bool registerCountIfAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerCountIfAggregate(kCountIf);
+} // namespace
 
-} // namespace facebook::velox::aggregate
+void registerCountIfAggregate() {
+  registerCountIfAggregate(kCountIf);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
@@ -19,7 +19,8 @@
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
+
 namespace {
 // Indices into RowType representing intermediate results of covar_samp and
 // covar_pop. Columns appear in alphabetical order.
@@ -498,25 +499,24 @@ bool registerCovarianceAggregate(const std::string& name) {
       });
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerCovarianceAggregate<
-        CovarAccumulator,
-        CovarIntermediateInput,
-        CovarIntermediateResult,
-        CovarPopResultAccessor>(kCovarPop);
-
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerCovarianceAggregate<
-        CovarAccumulator,
-        CovarIntermediateInput,
-        CovarIntermediateResult,
-        CovarSampResultAccessor>(kCovarSamp);
-
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerCovarianceAggregate<
-        CorrAccumulator,
-        CorrIntermediateInput,
-        CorrIntermediateResult,
-        CorrResultAccessor>(kCorr);
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerCovarianceAggregates() {
+  registerCovarianceAggregate<
+      CovarAccumulator,
+      CovarIntermediateInput,
+      CovarIntermediateResult,
+      CovarPopResultAccessor>(kCovarPop);
+  registerCovarianceAggregate<
+      CovarAccumulator,
+      CovarIntermediateInput,
+      CovarIntermediateResult,
+      CovarSampResultAccessor>(kCovarSamp);
+  registerCovarianceAggregate<
+      CorrAccumulator,
+      CorrIntermediateInput,
+      CorrIntermediateResult,
+      CorrResultAccessor>(kCorr);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -22,7 +22,8 @@
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/vector/FlatVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
+
 namespace {
 
 template <typename T>
@@ -272,8 +273,10 @@ bool registerHistogramAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerHistogramAggregate(kHistogram);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerHistogramAggregate() {
+  registerHistogramAggregate(kHistogram);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -15,7 +15,8 @@
  */
 #include "velox/functions/prestosql/aggregates/MapAggregateBase.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
+
 namespace {
 // See documentation at
 // https://prestodb.io/docs/current/functions/aggregate.html
@@ -94,7 +95,10 @@ bool registerMapAggAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerMapAggAggregate(kMapAgg);
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerMapAggAggregate() {
+  registerMapAggAggregate(kMapAgg);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -15,7 +15,8 @@
  */
 #include "velox/functions/prestosql/aggregates/MapAggregateBase.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
+
 namespace {
 // See documentation at
 // https://prestodb.io/docs/current/functions/aggregate.html
@@ -68,7 +69,10 @@ bool registerMapUnionAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerMapUnionAggregate(kMapUnion);
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerMapUnionAggregate() {
+  registerMapUnionAggregate(kMapUnion);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -21,7 +21,7 @@
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/vector/DecodedVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 std::unique_ptr<VectorSerde>& getVectorSerde() {
@@ -29,9 +29,6 @@ std::unique_ptr<VectorSerde>& getVectorSerde() {
       std::make_unique<serializer::presto::PrestoVectorSerde>();
   return serde;
 }
-} // namespace
-
-namespace {
 
 class MaxSizeForStatsAggregate
     : public SimpleNumericAggregate<int64_t, int64_t, int64_t> {
@@ -236,8 +233,10 @@ bool registerMaxSizeForStatsAggregate(const std::string& name) {
       });
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerMaxSizeForStatsAggregate(kMaxSizeForStats);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerMaxSizeForStatsAggregate() {
+  registerMaxSizeForStatsAggregate(kMaxSizeForStats);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -22,7 +22,7 @@
 #include "velox/functions/prestosql/aggregates/SimpleNumericAggregate.h"
 #include "velox/functions/prestosql/aggregates/SingleValueAccumulator.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
@@ -497,10 +497,11 @@ bool registerMinMaxAggregate(const std::string& name) {
       });
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerMinMaxAggregate<MinAggregate, NonNumericMinAggregate>(kMin);
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerMinMaxAggregate<MaxAggregate, NonNumericMaxAggregate>(kMax);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerMinMaxAggregates() {
+  registerMinMaxAggregate<MinAggregate, NonNumericMinAggregate>(kMin);
+  registerMinMaxAggregate<MaxAggregate, NonNumericMaxAggregate>(kMax);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -21,7 +21,7 @@
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
@@ -746,10 +746,11 @@ bool registerMinMaxByAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerMinMaxByAggregate<MaxByAggregate>(kMaxBy);
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerMinMaxByAggregate<MinByAggregate>(kMinBy);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerMinMaxByAggregates() {
+  registerMinMaxByAggregate<MaxByAggregate>(kMaxBy);
+  registerMinMaxByAggregate<MinByAggregate>(kMinBy);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+extern void registerApproxDistinctAggregates();
+extern void registerApproxMostFrequentAggregate();
+extern void registerApproxPercentileAggregate();
+extern void registerArbitraryAggregate();
+extern void registerArrayAggregate();
+extern void registerAverageAggregate();
+extern void registerBitwiseAggregates();
+extern void registerBoolAggregates();
+extern void registerChecksumAggregate();
+extern void registerCountAggregate();
+extern void registerCountIfAggregate();
+extern void registerCovarianceAggregates();
+extern void registerHistogramAggregate();
+extern void registerMapAggAggregate();
+extern void registerMapUnionAggregate();
+extern void registerMaxSizeForStatsAggregate();
+extern void registerMinMaxAggregates();
+extern void registerMinMaxByAggregates();
+extern void registerSumAggregate();
+extern void registerVarianceAggregates();
+
+void registerAllAggregateFunctions() {
+  registerApproxDistinctAggregates();
+  registerApproxMostFrequentAggregate();
+  registerApproxPercentileAggregate();
+  registerArbitraryAggregate();
+  registerArrayAggregate();
+  registerAverageAggregate();
+  registerBitwiseAggregates();
+  registerBoolAggregates();
+  registerChecksumAggregate();
+  registerCountAggregate();
+  registerCountIfAggregate();
+  registerCovarianceAggregates();
+  registerHistogramAggregate();
+  registerMapAggAggregate();
+  registerMapUnionAggregate();
+  registerMaxSizeForStatsAggregate();
+  registerMinMaxAggregates();
+  registerMinMaxByAggregates();
+  registerSumAggregate();
+  registerVarianceAggregates();
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
@@ -13,13 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/aggregates/SumAggregate.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#pragma once
 
 namespace facebook::velox::aggregate::prestosql {
-
-void registerSumAggregate() {
-  registerSumAggregate<SumAggregate>(kSum);
-}
+void registerAllAggregateFunctions();
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumAggregate.h
@@ -19,7 +19,7 @@
 #include "velox/functions/prestosql/CheckedArithmeticImpl.h"
 #include "velox/functions/prestosql/aggregates/SimpleNumericAggregate.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 
 template <typename TInput, typename TAccumulator, typename ResultType>
 class SumAggregate
@@ -308,4 +308,4 @@ bool registerSumAggregate(const std::string& name) {
       });
 }
 
-} // namespace facebook::velox::aggregate
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
@@ -20,7 +20,7 @@
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
@@ -512,23 +512,15 @@ bool registerVarianceAggregate(const std::string& name) {
       });
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerVarianceAggregate<StdDevSampAggregate>(kStdDev);
-
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerVarianceAggregate<StdDevPopAggregate>(kStdDevPop);
-
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerVarianceAggregate<StdDevSampAggregate>(kStdDevSamp);
-
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerVarianceAggregate<VarSampAggregate>(kVariance);
-
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerVarianceAggregate<VarPopAggregate>(kVarPop);
-
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerVarianceAggregate<VarSampAggregate>(kVarSamp);
-
 } // namespace
-} // namespace facebook::velox::aggregate
+
+void registerVarianceAggregates() {
+  registerVarianceAggregate<StdDevSampAggregate>(kStdDev);
+  registerVarianceAggregate<StdDevPopAggregate>(kStdDevPop);
+  registerVarianceAggregate<StdDevSampAggregate>(kStdDevSamp);
+  registerVarianceAggregate<VarSampAggregate>(kVariance);
+  registerVarianceAggregate<VarPopAggregate>(kVarPop);
+  registerVarianceAggregate<VarSampAggregate>(kVarSamp);
+}
+
+} // namespace facebook::velox::aggregate::prestosql


### PR DESCRIPTION
* This PR compile aggregate function as static library. to fix https://github.com/facebookincubator/velox/issues/1047
* Code design is follow registerAllScalarFunctions part. If some codes want to use aggregate function,  just #include RegisterAggregateFunction.h and register it.