### PR TITLE
Add support for range mode unbounded window frames

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -498,10 +498,10 @@ void addWindowFunction(
   stream << windowFunction.functionCall->toString() << " ";
   auto frame = windowFunction.frame;
   if (frame.startType == WindowNode::BoundType::kUnboundedFollowing) {
-    VELOX_FAIL("Window frame start cannot be UNBOUNDED FOLLOWING");
+    VELOX_USER_FAIL("Window frame start cannot be UNBOUNDED FOLLOWING");
   }
   if (frame.endType == WindowNode::BoundType::kUnboundedPreceding) {
-    VELOX_FAIL("Window frame end cannot be UNBOUNDED PRECEDING");
+    VELOX_USER_FAIL("Window frame end cannot be UNBOUNDED PRECEDING");
   }
 
   stream << windowTypeString(frame.type) << " between ";

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -497,6 +497,13 @@ void addWindowFunction(
     const WindowNode::Function& windowFunction) {
   stream << windowFunction.functionCall->toString() << " ";
   auto frame = windowFunction.frame;
+  if (frame.startType == WindowNode::BoundType::kUnboundedFollowing) {
+    VELOX_FAIL("Window frame start cannot be UNBOUNDED FOLLOWING");
+  }
+  if (frame.endType == WindowNode::BoundType::kUnboundedPreceding) {
+    VELOX_FAIL("Window frame end cannot be UNBOUNDED PRECEDING");
+  }
+
   stream << windowTypeString(frame.type) << " between ";
   if (frame.startValue) {
     addKeys(stream, {frame.startValue});

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -41,6 +41,7 @@ void initKeyInfo(
   }
 }
 
+// Return the first row of the partition for UNBOUNDED PRECEDING frame bound.
 vector_size_t findRowUnboundedPreceding(
     vector_size_t partitionStartRow,
     vector_size_t /*partitionEndRow*/,
@@ -50,6 +51,8 @@ vector_size_t findRowUnboundedPreceding(
   return partitionStartRow;
 }
 
+// Return the first row of the peer group when frame start is CURRENT ROW in
+// RANGE mode.
 vector_size_t findCurrentRowFrameStart(
     vector_size_t /*partitionStartRow*/,
     vector_size_t /*partitionEndRow*/,
@@ -59,6 +62,8 @@ vector_size_t findCurrentRowFrameStart(
   return peerStartRow;
 }
 
+// Return the last row of the peer group when frame end is CURRENT ROW in
+// RANGE mode.
 vector_size_t findCurrentRowFrameEnd(
     vector_size_t /*partitionStartRow*/,
     vector_size_t /*partitionEndRow*/,
@@ -68,6 +73,7 @@ vector_size_t findCurrentRowFrameEnd(
   return peerEndRow;
 }
 
+// Return the last row of the partition for UNBOUNDED FOLLOWING frame bound.
 vector_size_t findRowUnboundedFollowing(
     vector_size_t /*partitionStartRow*/,
     vector_size_t partitionEndRow,
@@ -77,7 +83,7 @@ vector_size_t findRowUnboundedFollowing(
   return partitionEndRow;
 }
 
-const WindowFrameFunctionPtr getStartFrameFunction(
+WindowFrameFunctionPtr getStartFrameFunction(
     core::WindowNode::BoundType startType,
     core::WindowNode::WindowType type) {
   switch (startType) {
@@ -93,13 +99,12 @@ const WindowFrameFunctionPtr getStartFrameFunction(
     case core::WindowNode::BoundType::kPreceding:
     case core::WindowNode::BoundType::kFollowing:
       VELOX_NYI("Not supported");
-    case core::WindowNode::BoundType::kUnboundedFollowing:
     default:
       VELOX_FAIL("Invalid frame start value");
   }
 }
 
-const WindowFrameFunctionPtr getEndFrameFunction(
+WindowFrameFunctionPtr getEndFrameFunction(
     core::WindowNode::BoundType endType,
     core::WindowNode::WindowType type) {
   switch (endType) {
@@ -115,7 +120,6 @@ const WindowFrameFunctionPtr getEndFrameFunction(
     case core::WindowNode::BoundType::kPreceding:
     case core::WindowNode::BoundType::kFollowing:
       VELOX_NYI("Not supported");
-    case core::WindowNode::BoundType::kUnboundedPreceding:
     default:
       VELOX_FAIL("Invalid frame end value");
   }

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -374,7 +374,7 @@ void Window::callApplyForPartitionRows(
       case core::WindowNode::BoundType::kFollowing:
         VELOX_NYI("Not supported");
       default:
-        VELOX_USER_FAIL("Invalid frame start value");
+        VELOX_USER_FAIL("Invalid frame bound type");
     }
   };
 

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -23,12 +23,12 @@
 namespace facebook::velox::exec {
 
 // Pointer to the function used to compute window frame bounds.
-using WindowFrameFunctionPtr = vector_size_t (*)(
+using WindowFrameFunctionPtr = void (*)(
+    vector_size_t* /*frameBound*/,
     vector_size_t /*partitionStartRow*/,
     vector_size_t /*partitionEndRow*/,
-    vector_size_t /*peerStartRow*/,
-    vector_size_t /*peerEndRow*/,
-    vector_size_t /*currentRow*/);
+    vector_size_t* /*peerGroup*/,
+    vector_size_t /*numRows*/);
 
 /// This is a very simple in-Memory implementation of a Window Operator
 /// to compute window functions.

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -23,7 +23,7 @@
 namespace facebook::velox::exec {
 
 // Pointer to the function used to compute window frame bounds.
-typedef vector_size_t (*WindowFrameFunctionPtr)(
+using WindowFrameFunctionPtr = vector_size_t (*)(
     vector_size_t /*partitionStartRow*/,
     vector_size_t /*partitionEndRow*/,
     vector_size_t /*peerStartRow*/,

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -22,6 +22,14 @@
 
 namespace facebook::velox::exec {
 
+// Pointer to the function used to compute window frame bounds.
+typedef vector_size_t (*WindowFrameFunctionPtr)(
+    vector_size_t /*partitionStartRow*/,
+    vector_size_t /*partitionEndRow*/,
+    vector_size_t /*peerStartRow*/,
+    vector_size_t /*peerEndRow*/,
+    vector_size_t /*currentRow*/);
+
 /// This is a very simple in-Memory implementation of a Window Operator
 /// to compute window functions.
 ///
@@ -65,6 +73,8 @@ class Window : public Operator {
     const core::WindowNode::WindowType type;
     const core::WindowNode::BoundType startType;
     const core::WindowNode::BoundType endType;
+    const WindowFrameFunctionPtr startFrameFunction;
+    const WindowFrameFunctionPtr endFrameFunction;
     const std::optional<column_index_t> startChannel;
     const std::optional<column_index_t> endChannel;
   };
@@ -94,16 +104,6 @@ class Window : public Operator {
   // of a partition adjacent to each other and sorted by the
   // ORDER BY clause.
   void sortPartitions();
-
-  // Helper function to find window frame start and end values for
-  // currentRow of ith window function (in windowFunctions_ list).
-  std::pair<vector_size_t, vector_size_t> findFrameEndPoints(
-      vector_size_t i,
-      vector_size_t partitionStartRow,
-      vector_size_t partitionEndRow,
-      vector_size_t peerStartRow,
-      vector_size_t peerEndRow,
-      vector_size_t currentRow);
 
   // Helper function to call WindowFunction::resetPartition() for
   // all WindowFunctions.

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -22,14 +22,6 @@
 
 namespace facebook::velox::exec {
 
-// Pointer to the function used to compute window frame bounds.
-using WindowFrameFunctionPtr = void (*)(
-    vector_size_t* /*frameBound*/,
-    vector_size_t /*partitionStartRow*/,
-    vector_size_t /*partitionEndRow*/,
-    vector_size_t* /*peerGroup*/,
-    vector_size_t /*numRows*/);
-
 /// This is a very simple in-Memory implementation of a Window Operator
 /// to compute window functions.
 ///
@@ -73,8 +65,6 @@ class Window : public Operator {
     const core::WindowNode::WindowType type;
     const core::WindowNode::BoundType startType;
     const core::WindowNode::BoundType endType;
-    const WindowFrameFunctionPtr startFrameFunction;
-    const WindowFrameFunctionPtr endFrameFunction;
     const std::optional<column_index_t> startChannel;
     const std::optional<column_index_t> endChannel;
   };

--- a/velox/functions/prestosql/window/AggregateWindow.cpp
+++ b/velox/functions/prestosql/window/AggregateWindow.cpp
@@ -153,12 +153,13 @@ class AggregateWindowFunction : public exec::WindowFunction {
     vector_size_t lastRow = rawFrameEnds[0];
 
     bool nonDecreasingFrameEnd = true;
+    bool fixedFirstRow = true;
     for (int i = 1; i < numRows; i++) {
       firstRow = std::min(firstRow, rawFrameStarts[i]);
       lastRow = std::max(lastRow, rawFrameEnds[i]);
+      fixedFirstRow &= rawFrameStarts[i] == firstRow;
       nonDecreasingFrameEnd &= rawFrameEnds[i] >= rawFrameEnds[i - 1];
     }
-    bool fixedFirstRow = rawFrameStarts[0] == rawFrameStarts[numRows - 1];
 
     vector_size_t numFrameRows = lastRow + 1 - firstRow;
     for (int i = 0; i < argIndices_.size(); i++) {

--- a/velox/functions/prestosql/window/AggregateWindow.cpp
+++ b/velox/functions/prestosql/window/AggregateWindow.cpp
@@ -158,7 +158,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
       lastRow = std::max(lastRow, rawFrameEnds[i]);
       nonDecreasingFrameEnd &= rawFrameEnds[i] >= rawFrameEnds[i - 1];
     }
-    bool fixedFirstRow = firstRow == rawFrameStarts[0];
+    bool fixedFirstRow = rawFrameStarts[0] == rawFrameStarts[numRows - 1];
 
     vector_size_t numFrameRows = lastRow + 1 - firstRow;
     for (int i = 0; i < argIndices_.size(); i++) {

--- a/velox/functions/prestosql/window/tests/NthValueTest.cpp
+++ b/velox/functions/prestosql/window/tests/NthValueTest.cpp
@@ -200,5 +200,38 @@ TEST_F(NthValueTest, offsetValues) {
       {vectors}, "nth_value(c0, c2)", overClause, offsetError);
 }
 
+TEST_F(NthValueTest, basicRangeFrames) {
+  auto vectors = makeBasicVectors(50);
+
+  testWindowFunction(
+      {vectors}, "nth_value(c0, c2)", kFrameOverClauses, kRangeFrameClauses);
+  testWindowFunction(
+      {vectors}, "nth_value(c0, 1)", kFrameOverClauses, kRangeFrameClauses);
+  testWindowFunction(
+      {vectors}, "nth_value(c0, 5)", kFrameOverClauses, kRangeFrameClauses);
+}
+
+TEST_F(NthValueTest, singlePartitionRangeFrames) {
+  auto vectors = makeSinglePartitionVectors(400);
+
+  testWindowFunction(
+      {vectors}, "nth_value(c0, c2)", kFrameOverClauses, kRangeFrameClauses);
+  testWindowFunction(
+      {vectors}, "nth_value(c0, 5)", kFrameOverClauses, kRangeFrameClauses);
+}
+
+TEST_F(NthValueTest, multiInputRangeFrames) {
+  auto vectors = makeSinglePartitionVectors(200);
+  auto doubleVectors = {vectors, vectors};
+
+  testWindowFunction(
+      doubleVectors,
+      "nth_value(c0, c2)",
+      kFrameOverClauses,
+      kRangeFrameClauses);
+  testWindowFunction(
+      {vectors}, "nth_value(c0, 5)", kFrameOverClauses, kRangeFrameClauses);
+}
+
 }; // namespace
 }; // namespace facebook::velox::window::test

--- a/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
+++ b/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
@@ -114,6 +114,11 @@ TEST_P(MultiAggregatesTest, basicRangeFrames) {
       {makeBasicVectors(50)}, kFrameOverClauses, kRangeFrameClauses);
 }
 
+TEST_P(MultiAggregatesTest, basicRangeFramesWithSortOrders) {
+  SimpleAggregatesTest::testWindowFunction(
+      {makeBasicVectors(50)}, kSortOrderBasedOverClauses, kRangeFrameClauses);
+}
+
 TEST_P(MultiAggregatesTest, singlePartitionRangeFrames) {
   SimpleAggregatesTest::testWindowFunction(
       {makeSinglePartitionVector(100)}, kFrameOverClauses, kRangeFrameClauses);

--- a/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
+++ b/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
@@ -46,8 +46,10 @@ class SimpleAggregatesTest : public WindowTestBase {
 
   void testWindowFunction(
       const std::vector<RowVectorPtr>& vectors,
-      const std::vector<std::string>& overClauses) {
-    WindowTestBase::testWindowFunction(vectors, function_, overClauses);
+      const std::vector<std::string>& overClauses,
+      const std::vector<std::string>& frameClauses = {""}) {
+    WindowTestBase::testWindowFunction(
+        vectors, function_, overClauses, frameClauses);
   }
 
   const std::string function_;
@@ -105,6 +107,16 @@ TEST_P(MultiAggregatesTest, randomInput) {
   };
 
   testWindowFunction(vectors, overClauses);
+}
+
+TEST_P(MultiAggregatesTest, basicRangeFrames) {
+  SimpleAggregatesTest::testWindowFunction(
+      {makeBasicVectors(50)}, kFrameOverClauses, kRangeFrameClauses);
+}
+
+TEST_P(MultiAggregatesTest, singlePartitionRangeFrames) {
+  SimpleAggregatesTest::testWindowFunction(
+      {makeSinglePartitionVector(100)}, kFrameOverClauses, kRangeFrameClauses);
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/functions/prestosql/window/tests/WindowTestBase.h
+++ b/velox/functions/prestosql/window/tests/WindowTestBase.h
@@ -48,6 +48,32 @@ static std::vector<std::string> kSortOrderBasedOverClauses = {
     "order by c1 desc nulls first, c0 asc nulls first",
 };
 
+/// Common set of window function over clauses for window frame tests to ensure
+/// total ordering for deterministic results in ROW mode.
+static std::vector<std::string> kFrameOverClauses = {
+    "partition by c0 order by c1, c2",
+    "partition by c1 order by c0, c2",
+    "partition by c0 order by c2, c1",
+    "partition by c1 order by c2, c0",
+    // No partition by clause.
+    "order by c0 asc nulls first, c1 desc, c2 asc",
+    "order by c1 asc, c0 desc nulls last, c2 desc",
+    "order by c0 asc, c2 desc, c1 asc nulls last",
+    "order by c2 asc, c1 desc nulls first, c0 asc",
+    // No order by clause.
+    "partition by c0, c1, c2",
+};
+
+/// Common set of window function frame clauses in RANGE mode, with current row,
+/// unbounded preceding, and unbounded following frame combinations.
+static std::vector<std::string> kRangeFrameClauses = {
+    "range unbounded preceding",
+    "range current row",
+    "range between unbounded preceding and current row",
+    "range between current row and unbounded following",
+    "range between unbounded preceding and unbounded following",
+};
+
 class WindowTestBase : public exec::test::OperatorTestBase {
  protected:
   void SetUp() override {
@@ -84,7 +110,8 @@ class WindowTestBase : public exec::test::OperatorTestBase {
   void testWindowFunction(
       const std::vector<RowVectorPtr>& input,
       const std::string& function,
-      const std::vector<std::string>& overClauses);
+      const std::vector<std::string>& overClauses,
+      const std::vector<std::string>& frameClauses = {""});
 
   /// This function tests the SQL query for the window function and overClause
   /// combination with the input RowVectors. It is expected that query execution
@@ -99,6 +126,7 @@ class WindowTestBase : public exec::test::OperatorTestBase {
   void testWindowFunction(
       const std::vector<RowVectorPtr>& input,
       const std::string& function,
-      const std::string& overClause);
+      const std::string& overClause,
+      const std::string& frameClause = "");
 };
 }; // namespace facebook::velox::window::test


### PR DESCRIPTION
Add support for unbounded preceding, unbounded following, and current row frame
bounds in range mode. Follow-up PRs will add support for k preceding, k
following, and current row frame bounds in rows mode.