### PR TITLE
Allow restricting the level of nesting in fuzzer-generated expressions.

### DIFF
--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -206,7 +206,11 @@ bool SignatureBinderBase::tryBind(
         integerParameters_.count(params[0].baseName()) != 0) {
       return tryBindIntegerParameters(params, actualType);
     }
+
     // Type Parameters can recurse.
+    if (params.size() != actualType->size()) {
+      return false;
+    }
     for (auto i = 0; i < params.size(); i++) {
       if (!tryBind(params[i], actualType->childAt(i))) {
         return false;

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -38,7 +38,8 @@ class SignatureBinderBase {
   }
 
   /// Return true if actualType can bind to typeSignature and update bindings_
-  /// accordingly.
+  /// accordingly. The number of parameters in typeSignature and actualType must
+  /// match. Return false otherwise.
   bool tryBind(
       const exec::TypeSignature& typeSignature,
       const TypePtr& actualType);

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -440,6 +440,34 @@ TEST(SignatureBinderTest, unresolvable) {
     assertCannotResolve(signature, {BIGINT()});
     assertCannotResolve(signature, {INTEGER(), BIGINT()});
   }
+
+  // row(bigint, varchar) -> bigint
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("bigint")
+                         .argumentType("row(bigint, varchar)")
+                         .build();
+
+    testSignatureBinder(signature, {ROW({BIGINT(), VARCHAR()})}, BIGINT());
+
+    // wrong type
+    assertCannotResolve(signature, {ROW({BIGINT()})});
+    assertCannotResolve(signature, {ROW({BIGINT(), VARCHAR(), BOOLEAN()})});
+  }
+
+  // array(row(boolean)) -> bigint
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("bigint")
+                         .argumentType("array(row(boolean))")
+                         .build();
+
+    testSignatureBinder(signature, {ARRAY(ROW({BOOLEAN()}))}, BIGINT());
+
+    // wrong type
+    assertCannotResolve(signature, {ARRAY(ROW({BOOLEAN(), BIGINT()}))});
+    assertCannotResolve(signature, {ARRAY(ROW({BIGINT()}))});
+  }
 }
 
 TEST(SignatureBinderTest, tryResolveTypeNullOutput) {

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -67,6 +67,7 @@ TEST_F(VectorFuzzerTest, flatPrimitive) {
       DATE(),
       TIMESTAMP(),
       INTERVAL_DAY_TIME(),
+      UNKNOWN(),
   };
 
   for (const auto& type : types) {
@@ -194,6 +195,13 @@ TEST_F(VectorFuzzerTest, constants) {
   ASSERT_TRUE(vector->type()->kindEquals(ROW({ARRAY(BIGINT()), SMALLINT()})));
   ASSERT_EQ(VectorEncoding::Simple::CONSTANT, vector->encoding());
   ASSERT_FALSE(vector->mayHaveNulls());
+
+  // Fuzzer should produce null constant for UNKNOWN type even if nullRatio is
+  // 0.
+  vector = fuzzer.fuzzConstant(UNKNOWN());
+  ASSERT_TRUE(vector->type()->kindEquals(UNKNOWN()));
+  ASSERT_EQ(VectorEncoding::Simple::CONSTANT, vector->encoding());
+  ASSERT_TRUE(vector->mayHaveNulls());
 }
 
 TEST_F(VectorFuzzerTest, constantsNull) {
@@ -204,6 +212,11 @@ TEST_F(VectorFuzzerTest, constantsNull) {
   // Null constants.
   auto vector = fuzzer.fuzzConstant(REAL());
   ASSERT_TRUE(vector->type()->kindEquals(REAL()));
+  ASSERT_EQ(VectorEncoding::Simple::CONSTANT, vector->encoding());
+  ASSERT_TRUE(vector->mayHaveNulls());
+
+  vector = fuzzer.fuzzConstant(UNKNOWN());
+  ASSERT_TRUE(vector->type()->kindEquals(UNKNOWN()));
   ASSERT_EQ(VectorEncoding::Simple::CONSTANT, vector->encoding());
   ASSERT_TRUE(vector->mayHaveNulls());
 


### PR DESCRIPTION
Summary:
This diff add a feature that allows to restrict the level of nesting in the expressions
generated by ExpressionFuzzer. Default max level of nesting is 10.

Differential Revision: D40203066

