### PR TITLE
Revert the change of adding folly::set_once that broke Velox build

### DIFF
--- a/velox/common/process/StackTrace.cpp
+++ b/velox/common/process/StackTrace.cpp
@@ -49,11 +49,11 @@ StackTrace::StackTrace(const StackTrace& other) {
   bt_pointers_ = other.bt_pointers_;
   if (folly::test_once(other.bt_vector_flag_)) {
     bt_vector_ = other.bt_vector_;
-    folly::set_once(bt_vector_flag_);
+    folly::call_once(bt_vector_flag_, [] {}); // Set the flag.
   }
   if (folly::test_once(other.bt_flag_)) {
     bt_ = other.bt_;
-    folly::set_once(bt_flag_);
+    folly::call_once(bt_flag_, [] {}); // Set the flag.
   }
 }
 


### PR DESCRIPTION
Differential Revision: D40289092

