### PR TITLE
Fix flaky `StreamingAggregationTest`

### DIFF
--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -103,12 +103,13 @@ StreamingAggregation::StreamingAggregation(
       ContainerRowSerde::instance());
 }
 
-StreamingAggregation::~StreamingAggregation() {
+void StreamingAggregation::close() {
   for (int32_t i = 0; i < aggregates_.size(); ++i) {
     if (aggregates_[i]->accumulatorUsesExternalMemory()) {
       aggregates_[i]->destroy(folly::Range(groups_.data(), groups_.size()));
     }
   }
+  Operator::close();
 }
 
 void StreamingAggregation::addInput(RowVectorPtr input) {

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -30,8 +30,6 @@ class StreamingAggregation : public Operator {
       DriverCtx* driverCtx,
       const std::shared_ptr<const core::AggregationNode>& aggregationNode);
 
-  ~StreamingAggregation();
-
   void addInput(RowVectorPtr input) override;
 
   RowVectorPtr getOutput() override;
@@ -45,6 +43,8 @@ class StreamingAggregation : public Operator {
   }
 
   bool isFinished() override;
+
+  void close() override;
 
  private:
   // Returns the rows to aggregate with masking applied if applicable.


### PR DESCRIPTION
Summary:
Currently we destroy aggregations in the destuctor of
`StreamingAggregation` operator.  This causes non-deterministic behavior and was
failing the unit tests from time to time.  Moving the cleanup code to `close()`
to get deterministic behavior.  This also aligns the cleanup behavior of
`StreamingAggregation` and `HashAggregation`.

Differential Revision: D40304401

