### PR TITLE
Add persistence functionality to Fuzzer to persist repro info

### DIFF
--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/vector/VectorSaver.h"
+#include <fstream>
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
 
@@ -620,6 +621,22 @@ void saveVector(const BaseVector& vector, std::ostream& out) {
       VELOX_UNSUPPORTED(
           "Unsupported encoding: {}", mapSimpleToName(vector.encoding()));
   }
+}
+
+void saveVectorToFile(
+    const BaseVector* FOLLY_NONNULL vector,
+    const char* FOLLY_NONNULL filePath) {
+  std::ofstream outputFile(filePath, std::ofstream::binary);
+  saveVector(*vector, outputFile);
+  outputFile.close();
+}
+
+void saveStringToFile(
+    const std::string& content,
+    const char* FOLLY_NONNULL filePath) {
+  std::ofstream outputFile(filePath, std::ofstream::binary);
+  outputFile.write(content.data(), content.size());
+  outputFile.close();
 }
 
 VectorPtr restoreVector(std::istream& in, memory::MemoryPool* pool) {

--- a/velox/vector/VectorSaver.h
+++ b/velox/vector/VectorSaver.h
@@ -34,12 +34,25 @@ TypePtr restoreType(std::istream& in);
 /// output stream. The serialiation preserved encoding.
 void saveVector(const BaseVector& vector, std::ostream& out);
 
+/// Serializes the vector into binary format and writes it to a new file in
+/// 'filePath'. The serialization preserved encoding. Exceptions will be thrown
+/// if any error occurs while writing.
+void saveVectorToFile(
+    const BaseVector* FOLLY_NONNULL vector,
+    const char* FOLLY_NONNULL filePath);
+
+/// Writes 'content' to a new file in 'filePath'. Exceptions will be thrown if
+/// any error occurs while writing.
+void saveStringToFile(
+    const std::string& content,
+    const char* FOLLY_NONNULL filePath);
+
 /// Deserializes a vector serialized by 'save' from the provided input stream.
 VectorPtr restoreVector(std::istream& in, memory::MemoryPool* pool);
 
 /// Generates a file path in specified directory. Returns std::nullopt on
 /// failure.
 std::optional<std::string> generateFilePath(
-    const char* basePath,
-    const char* prefix);
+    const char* FOLLY_NONNULL basePath,
+    const char* FOLLY_NONNULL prefix);
 } // namespace facebook::velox


### PR DESCRIPTION
Add an option to allow user to specify whether to persist repro data to disk when fuzzer run fails. Repro data includes input vector, sql, and result vector if not null. 