### PR TITLE
Fix dedictionarizing a Parquet string

### DIFF
--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -122,6 +122,10 @@ class ParquetData : public dwio::common::FormatData {
     return reader_->dictionaryValues();
   }
 
+  void clearDictionary() {
+    reader_->clearDictionary();
+  }
+
   bool hasDictionary() const {
     return reader_->isDictionary();
   }


### PR DESCRIPTION
A dictionary encoded Parquet string column is returned as a string dictionary
vector. If the encoding is switched in mid-scan to direct, values that have
been accumulated as dictionary indices need to be flattened out so that the
scan can continue adding values.

Adds a test case for the scenario. Dedictionarizing can only occur in multipage
reads at the start of a non-first page. In this situation, nulls for the
dictionary vector are not in the vector but in the null concatenation that
collects a multipage null bitmap. Leave the concatenation in place but put the
nulls back into the reader before calling dedictionarize.

Fixes #2808