### PR TITLE
Add to support trigger order by spill based on memory limit

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -128,6 +128,11 @@ class QueryConfig {
   static constexpr const char* kAggregationSpillMemoryThreshold =
       "aggregation_spill_memory_threshold";
 
+  /// The max memory that an order by can use before spilling. If it 0, then
+  /// there is no limit.
+  static constexpr const char* kOrderBySpillMemoryThreshold =
+      "order_by_spill_memory_threshold";
+
   static constexpr const char* kTestingSpillPct = "testing.spill-pct";
 
   static constexpr const char* kSpillStartPartitionBit =
@@ -159,6 +164,11 @@ class QueryConfig {
   double partialAggregationGoodPct() const {
     static constexpr double kDefault = 0.5;
     return get<double>(kPartialAggregationGoodPct, kDefault);
+  }
+
+  uint64_t orderBySpillMemoryThreshold() const {
+    static constexpr uint64_t kDefault = 0;
+    return get<uint64_t>(kOrderBySpillMemoryThreshold, kDefault);
   }
 
   // Returns the target size for a Task's buffered output. The

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -82,6 +82,10 @@ class OrderBy : public Operator {
 
   const int32_t numSortKeys_;
 
+  // The maximum memory usage that an order by can hold before spilling.
+  // If it is zero, then there is no such limit.
+  const uint64_t spillMemoryThreshold_;
+
   // Filesystem path for spill files, empty if spilling is disabled.
   // The disk spilling related configs if spilling is enabled, otherwise null.
   const std::optional<Spiller::Config> spillConfig_;


### PR DESCRIPTION
This helps to run through large query that needs spill before memory
arbitration is ready.