### PR TITLE
[Velox] Table writer 1: Pass LocationHandle to HiveInsertTableHandle

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -16,12 +16,17 @@
 
 #include "velox/connectors/hive/HiveConnector.h"
 
+#include "velox/common/base/Fs.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/ReaderFactory.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/type/Conversions.h"
 #include "velox/type/Type.h"
 #include "velox/type/Variant.h"
+
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 #include <memory>
 
@@ -80,29 +85,49 @@ std::string HiveTableHandle::toString() const {
 }
 
 HiveDataSink::HiveDataSink(
-    std::shared_ptr<const RowType> inputType,
-    const std::string& filePath,
-    velox::memory::MemoryPool* memoryPool)
-    : inputType_(inputType) {
+    RowTypePtr inputType,
+    std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+    const ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx)
+    : inputType_(std::move(inputType)),
+      insertTableHandle_(std::move(insertTableHandle)),
+      connectorQueryCtx_(connectorQueryCtx) {
+  if (!insertTableHandle_->isPartitioned()) {
+    writers_.emplace_back(createWriter());
+  }
+}
+
+void HiveDataSink::appendData(VectorPtr input) {
+  // For the time being the hive data sink supports one file.
+  // To extend it we can create a new writer for every
+  // partition.
+  if (writers_.empty()) {
+    writers_.emplace_back(createWriter());
+  }
+  writers_[0]->write(input);
+}
+
+void HiveDataSink::close() {
+  for (const auto& writer : writers_) {
+    writer->close();
+  }
+}
+
+std::unique_ptr<velox::dwrf::Writer> HiveDataSink::createWriter() {
   auto config = std::make_shared<WriterConfig>();
   // TODO: Wire up serde properties to writer configs.
 
   facebook::velox::dwrf::WriterOptions options;
   options.config = config;
-  options.schema = inputType;
+  options.schema = inputType_;
   // Without explicitly setting flush policy, the default memory based flush
   // policy is used.
 
-  auto sink = facebook::velox::dwio::common::DataSink::create(filePath);
-  writer_ = std::make_unique<Writer>(options, std::move(sink), *memoryPool);
-}
-
-void HiveDataSink::appendData(VectorPtr input) {
-  writer_->write(input);
-}
-
-void HiveDataSink::close() {
-  writer_->close();
+  auto fileName =
+      boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+  auto sink = dwio::common::DataSink::create(
+      fs::path(insertTableHandle_->locationHandle()->writePath()) / fileName);
+  return std::make_unique<Writer>(
+      options, std::move(sink), *connectorQueryCtx_->memoryPool());
 }
 
 namespace {
@@ -163,7 +188,7 @@ static void makeFieldSpecs(
 
 std::shared_ptr<common::ScanSpec> makeScanSpec(
     const SubfieldFilters& filters,
-    const std::shared_ptr<const RowType>& rowType) {
+    const RowTypePtr& rowType) {
   auto spec = std::make_shared<common::ScanSpec>("root");
   makeFieldSpecs("", 0, rowType, spec.get());
 
@@ -186,7 +211,7 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
 } // namespace
 
 HiveDataSource::HiveDataSource(
-    const std::shared_ptr<const RowType>& outputType,
+    const RowTypePtr& outputType,
     const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
     const std::unordered_map<
         std::string,
@@ -490,7 +515,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
   std::shared_ptr<dwio::common::ColumnSelector> cs;
   if (columnNames.empty()) {
-    static const std::shared_ptr<const RowType> kEmpty{ROW({}, {})};
+    static const RowTypePtr kEmpty{ROW({}, {})};
     cs = std::make_shared<dwio::common::ColumnSelector>(kEmpty);
   } else {
     cs = std::make_shared<dwio::common::ColumnSelector>(fileType, columnNames);

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -51,6 +51,10 @@ class HiveColumnHandle : public ColumnHandle {
     return dataType_;
   }
 
+  bool isPartitionKey() const {
+    return columnType_ == ColumnType::kPartitionKey;
+  }
+
  private:
   const std::string name_;
   const ColumnType columnType_;
@@ -92,38 +96,122 @@ class HiveTableHandle : public ConnectorTableHandle {
   const core::TypedExprPtr remainingFilter_;
 };
 
+/// Location related properties of the Hive table to be written
+class LocationHandle {
+ public:
+  enum class TableType {
+    kNew, // Write to a new table to be created.
+    kExisting, // Write to an existing table.
+    kTemporary, // Write to a temporary table.
+  };
+
+  enum class WriteMode {
+    // Write to a staging directory and then move to the target directory
+    // after write finishes.
+    kStageAndMoveToTargetDirectory,
+    // Directly write to the target directory to be created.
+    kDirectToTargetNewDirectory,
+    // Directly write to the existing target directory.
+    kDirectToTargetExistingDirectory,
+  };
+
+  LocationHandle(
+      std::string targetPath,
+      std::string writePath,
+      TableType tableType,
+      WriteMode writeMode)
+      : targetPath_(std::move(targetPath)),
+        writePath_(std::move(writePath)),
+        tableType_(tableType),
+        writeMode_(writeMode) {}
+
+  const std::string& targetPath() const {
+    return targetPath_;
+  }
+
+  const std::string& writePath() const {
+    return writePath_;
+  }
+
+  TableType tableType() const {
+    return tableType_;
+  }
+
+  WriteMode writeMode() const {
+    return writeMode_;
+  }
+
+ private:
+  // Target directory path.
+  const std::string targetPath_;
+  // Staging directory path.
+  const std::string writePath_;
+  // Whether the table to be written is new, already existing or temporary.
+  const TableType tableType_;
+  // How the target path and directory path could be used.
+  const WriteMode writeMode_;
+};
+
 /**
  * Represents a request for Hive write
  */
 class HiveInsertTableHandle : public ConnectorInsertTableHandle {
  public:
-  explicit HiveInsertTableHandle(const std::string& filePath)
-      : filePath_(filePath) {}
+  HiveInsertTableHandle(
+      std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns,
+      std::shared_ptr<const LocationHandle> locationHandle)
+      : inputColumns_(std::move(inputColumns)),
+        locationHandle_(std::move(locationHandle)) {}
 
-  const std::string& filePath() const {
-    return filePath_;
+  virtual ~HiveInsertTableHandle() = default;
+
+  const std::vector<std::shared_ptr<const HiveColumnHandle>>& inputColumns()
+      const {
+    return inputColumns_;
   }
 
-  virtual ~HiveInsertTableHandle() {}
+  const std::shared_ptr<const LocationHandle>& locationHandle() const {
+    return locationHandle_;
+  }
+
+  bool isPartitioned() const {
+    return std::any_of(
+        inputColumns_.begin(), inputColumns_.end(), [](auto column) {
+          return column->isPartitionKey();
+        });
+  }
+
+  bool isCreateTable() const {
+    return locationHandle_->tableType() == LocationHandle::TableType::kNew;
+  }
+
+  bool isInsertTable() const {
+    return locationHandle_->tableType() == LocationHandle::TableType::kExisting;
+  }
 
  private:
-  const std::string filePath_;
+  const std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns_;
+  const std::shared_ptr<const LocationHandle> locationHandle_;
 };
 
 class HiveDataSink : public DataSink {
  public:
   explicit HiveDataSink(
-      std::shared_ptr<const RowType> inputType,
-      const std::string& filePath,
-      velox::memory::MemoryPool* FOLLY_NONNULL memoryPool);
+      RowTypePtr inputType,
+      std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+      const ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx);
 
   void appendData(VectorPtr input) override;
 
   void close() override;
 
  private:
-  const std::shared_ptr<const RowType> inputType_;
-  std::unique_ptr<facebook::velox::dwrf::Writer> writer_;
+  std::unique_ptr<dwrf::Writer> createWriter();
+
+  const RowTypePtr inputType_;
+  const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle_;
+  const ConnectorQueryCtx* connectorQueryCtx_;
+  std::vector<std::unique_ptr<dwrf::Writer>> writers_;
 };
 
 class HiveConnector;
@@ -131,7 +219,7 @@ class HiveConnector;
 class HiveDataSource : public DataSource {
  public:
   HiveDataSource(
-      const std::shared_ptr<const RowType>& outputType,
+      const RowTypePtr& outputType,
       const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
       const std::unordered_map<
           std::string,
@@ -187,7 +275,7 @@ class HiveDataSource : public DataSource {
   /// Clear split_, reader_ and rowReader_ after split has been fully processed.
   void resetSplit();
 
-  const std::shared_ptr<const RowType> outputType_;
+  const RowTypePtr outputType_;
   // Column handles for the partition key columns keyed on partition key column
   // name.
   std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>
@@ -203,7 +291,7 @@ class HiveDataSource : public DataSource {
   std::unique_ptr<dwio::common::Reader> reader_;
   std::unique_ptr<dwio::common::RowReader> rowReader_;
   std::unique_ptr<exec::ExprSet> remainingFilterExprSet_;
-  std::shared_ptr<const RowType> readerOutputType_;
+  RowTypePtr readerOutputType_;
   bool emptySplit_;
 
   dwio::common::RuntimeStatistics runtimeStats_;
@@ -235,7 +323,7 @@ class HiveConnector final : public Connector {
   }
 
   std::shared_ptr<DataSource> createDataSource(
-      const std::shared_ptr<const RowType>& outputType,
+      const RowTypePtr& outputType,
       const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
       const std::unordered_map<
           std::string,
@@ -254,18 +342,15 @@ class HiveConnector final : public Connector {
   }
 
   std::shared_ptr<DataSink> createDataSink(
-      std::shared_ptr<const RowType> inputType,
+      RowTypePtr inputType,
       std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
       ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) override final {
     auto hiveInsertHandle = std::dynamic_pointer_cast<HiveInsertTableHandle>(
         connectorInsertTableHandle);
-    VELOX_CHECK(
-        hiveInsertHandle != nullptr,
-        "Hive connector expecting hive write handle!");
+    VELOX_CHECK_NOT_NULL(
+        hiveInsertHandle, "Hive connector expecting hive write handle!");
     return std::make_shared<HiveDataSink>(
-        inputType,
-        hiveInsertHandle->filePath(),
-        connectorQueryCtx->memoryPool());
+        inputType, hiveInsertHandle, connectorQueryCtx);
   }
 
   folly::Executor* FOLLY_NULLABLE executor() {

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -83,7 +83,9 @@ OperatorCtx::createConnectorQueryCtx(
       driverCtx_->task->queryCtx()->getConnectorConfig(connectorId),
       expressionEvaluator_.get(),
       driverCtx_->task->queryCtx()->mappedMemory(),
-      fmt::format("{}.{}", driverCtx_->task->taskId(), planNodeId));
+      taskId(),
+      planNodeId,
+      driverCtx_->driverId);
 }
 
 std::optional<Spiller::Config> OperatorCtx::makeSpillConfig(

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -44,4 +44,5 @@ target_link_libraries(
   velox_tpch_connector
   velox_presto_serializer
   velox_functions_prestosql
-  velox_aggregates)
+  velox_aggregates
+  velox_vector_test_lib)

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -152,6 +152,38 @@ HiveConnectorTestBase::makeHiveConnectorSplit(
       .build();
 }
 
+// static
+std::shared_ptr<connector::hive::HiveInsertTableHandle>
+HiveConnectorTestBase::makeHiveInsertTableHandle(
+    const std::vector<std::string>& tableColumnNames,
+    const std::vector<TypePtr>& tableColumnTypes,
+    const std::vector<std::string>& partitionedBy,
+    std::shared_ptr<connector::hive::LocationHandle> locationHandle) {
+  std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
+      columnHandles;
+  for (int i = 0; i < tableColumnNames.size(); ++i) {
+    if (std::find(
+            partitionedBy.cbegin(),
+            partitionedBy.cend(),
+            tableColumnNames.at(i)) != partitionedBy.cend()) {
+      columnHandles.push_back(
+          std::make_shared<connector::hive::HiveColumnHandle>(
+              tableColumnNames.at(i),
+              connector::hive::HiveColumnHandle::ColumnType::kPartitionKey,
+              tableColumnTypes.at(i)));
+    } else {
+      columnHandles.push_back(
+          std::make_shared<connector::hive::HiveColumnHandle>(
+              tableColumnNames.at(i),
+              connector::hive::HiveColumnHandle::ColumnType::kRegular,
+              tableColumnTypes.at(i)));
+    }
+  }
+
+  return std::make_shared<connector::hive::HiveInsertTableHandle>(
+      columnHandles, locationHandle);
+}
+
 std::shared_ptr<connector::hive::HiveColumnHandle>
 HiveConnectorTestBase::regularColumn(
     const std::string& name,

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -86,6 +86,39 @@ class HiveConnectorTestBase : public OperatorTestBase {
         remainingFilter);
   }
 
+  /// @param targetDirectory Final directory of the target table after commit.
+  /// @param writeDirectory Write directory of the target table before commit.
+  /// @param tableType Whether to create a new table, insert into an existing
+  /// table, or write a temporary table.
+  /// @param writeMode How to write to the target directory.
+  static std::shared_ptr<connector::hive::LocationHandle> makeLocationHandle(
+      std::string targetDirectory,
+      std::optional<std::string> writeDirectory = std::nullopt,
+      connector::hive::LocationHandle::TableType tableType =
+          connector::hive::LocationHandle::TableType::kNew,
+      connector::hive::LocationHandle::WriteMode writeMode = connector::hive::
+          LocationHandle::WriteMode::kDirectToTargetNewDirectory) {
+    return std::make_shared<connector::hive::LocationHandle>(
+        targetDirectory,
+        writeDirectory.value_or(targetDirectory),
+        tableType,
+        writeMode);
+  }
+
+  /// Build a HiveInsertTableHandle.
+  /// @param tableColumnNames Column names of the target table. Corresponding
+  /// type of tableColumnNames[i] is tableColumnTypes[i].
+  /// @param tableColumnTypes Column types of the target table. Corresponding
+  /// name of tableColumnTypes[i] is tableColumnNames[i].
+  /// @param partitionedBy A list of partition columns of the target table.
+  /// @param locationHandle Location handle for the table write.
+  static std::shared_ptr<connector::hive::HiveInsertTableHandle>
+  makeHiveInsertTableHandle(
+      const std::vector<std::string>& tableColumnNames,
+      const std::vector<TypePtr>& tableColumnTypes,
+      const std::vector<std::string>& partitionedBy,
+      std::shared_ptr<connector::hive::LocationHandle> locationHandle);
+
   static std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(
       const std::string& name,
       const TypePtr& type);


### PR DESCRIPTION
Pass LocationHandle to HiveInsertTableHandle, and
pass HiveInsertTableHandle instead of an actual write file name
to HiveDataSink. This allows Velox callers to pass more info
to HiveDataSink that is used by TableWriter. Thus this gets
TableWriter ready for more flexible write and commit strategies.

Allow multiple writers in HiveDataSink, to make HiveDataSink
and TableWriter ready for partitioned table writing. For now
we only keep one writer.

Also make HiveDataSink generate a random file name interally,
rather than relying Velox callers to pass in a file name. Users
could extend this behavior with WriteProtocols, whose support
will come in next.