### PR TITLE
Fix deadlock on allPeersFinished() error

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -35,11 +35,28 @@
 namespace facebook::velox::exec {
 
 namespace {
+
 folly::Synchronized<std::vector<std::shared_ptr<TaskListener>>>& listeners() {
   static folly::Synchronized<std::vector<std::shared_ptr<TaskListener>>>
       kListeners;
   return kListeners;
 }
+
+std::string errorMessageImpl(const std::exception_ptr& exception) {
+  if (!exception) {
+    return "";
+  }
+  std::string message;
+  try {
+    std::rethrow_exception(exception);
+  } catch (const std::exception& e) {
+    message = e.what();
+  } catch (...) {
+    message = "<Unknown exception type>";
+  }
+  return message;
+}
+
 } // namespace
 
 std::atomic<uint64_t> Task::numCreatedTasks_ = 0;
@@ -1086,7 +1103,9 @@ bool Task::allPeersFinished(
     std::vector<std::shared_ptr<Driver>>& peers) {
   std::lock_guard<std::mutex> l(mutex_);
   if (exception_) {
-    VELOX_FAIL("Task is terminating because of error: {}", errorMessage());
+    VELOX_FAIL(
+        "Task is terminating because of error: {}",
+        errorMessageImpl(exception_));
   }
   const auto splitGroupId = caller->driverCtx()->splitGroupId;
   auto& barriers = splitGroupStates_[splitGroupId].barriers;
@@ -1611,16 +1630,7 @@ void Task::setError(const std::string& message) {
 
 std::string Task::errorMessage() const {
   std::lock_guard<std::mutex> l(mutex_);
-  if (!exception_) {
-    return "";
-  }
-  std::string message;
-  try {
-    std::rethrow_exception(exception_);
-  } catch (const std::exception& e) {
-    message = e.what();
-  }
-  return message;
+  return errorMessageImpl(exception_);
 }
 
 StopReason Task::enter(ThreadState& state) {


### PR DESCRIPTION
Summary: `allPeersFinished()` calls `errorMessage()` while holding the mutex. `errorMessage()` in turn tries to acquire the same mutex. So any error reliably turns into a deadlock.

Differential Revision: D40347714

