### PR TITLE
Use new set of properties to regulate spilling.

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -85,11 +85,6 @@ class QueryConfig {
   static constexpr const char* kMaxExtendedPartialAggregationMemory =
       "max_extended_partial_aggregation_memory";
 
-  /// The max memory that a final aggregation can use before spilling. If it 0,
-  /// then there is no limit.
-  static constexpr const char* kAggregationSpillMemoryThreshold =
-      "aggregation_spill_memory_threshold";
-
   /// Output volume as percentage of input volume below which we will not seek
   /// to increase reduction by using more memory. the data volume is measured as
   /// the number of rows.
@@ -112,7 +107,26 @@ class QueryConfig {
 
   static constexpr const char* kCreateEmptyFiles = "driver.create_empty_files";
 
+  /// Global enable spilling flag.
+  static constexpr const char* kSpillEnabled = "spill_enabled";
+
+  /// Spill path. "/tmp" by default.
   static constexpr const char* kSpillPath = "spiller-spill-path";
+
+  /// Aggregation spilling flag, only applies if "spill_enabled" flag is set.
+  static constexpr const char* kAggregationSpillEnabled =
+      "aggregation_spill_enabled";
+
+  /// Join spilling flag, only applies if "spill_enabled" flag is set.
+  static constexpr const char* kJoinSpillEnabled = "join_spill_enabled";
+
+  /// OrderBy spilling flag, only applies if "spill_enabled" flag is set.
+  static constexpr const char* kOrderBySpillEnabled = "order_by_spill_enabled";
+
+  /// The max memory that a final aggregation can use before spilling. If it 0,
+  /// then there is no limit.
+  static constexpr const char* kAggregationSpillMemoryThreshold =
+      "aggregation_spill_memory_threshold";
 
   static constexpr const char* kTestingSpillPct = "testing.spill-pct";
 
@@ -219,16 +233,37 @@ class QueryConfig {
     return get<bool>(kExprEvalSimplified, false);
   }
 
-  /// Returns a path for writing spill files. If empty, spilling is
-  /// disabled. The path should be interpretable by
-  /// filesystems::getFileSystem and may refer to any writable
-  /// location. Actual file names are composed by appending '/' and a
-  /// filename composed of Task id and serial numbers. The files are
-  /// automatically deleted when no longer needed. Files may be left
-  /// behind after crashes but are identifiable based on the Task id in
-  /// the name.
+  /// Returns true if spilling is enabled.
+  bool spillEnabled() const {
+    return get<bool>(kSpillEnabled, false);
+  }
+
+  /// Returns the path for writing spill files. The path should be
+  /// interpretable by filesystems::getFileSystem and may refer to any writable
+  /// location. Actual file names are composed by appending '/' and a filename
+  /// composed of Task id and serial numbers. The files are automatically
+  /// deleted when no longer needed. Files may be left behind after crashes but
+  /// are identifiable based on the Task id in the name.
   std::optional<std::string> spillPath() const {
-    return get<std::string>(kSpillPath);
+    return get<std::string>(kSpillPath, "/tmp");
+  }
+
+  /// Returns 'is aggregation spilling enabled' flag. Must also check the
+  /// spillEnabled()!
+  bool aggregationSpillEnabled() const {
+    return get<bool>(kAggregationSpillEnabled, false);
+  }
+
+  /// Returns 'is join spilling enabled' flag. Must also check the
+  /// spillEnabled()!
+  bool joinSpillEnabled() const {
+    return get<bool>(kJoinSpillEnabled, false);
+  }
+
+  /// Returns 'is orderby spilling enabled' flag. Must also check the
+  /// spillEnabled()!
+  bool orderBySpillEnabled() const {
+    return get<bool>(kOrderBySpillEnabled, false);
   }
 
   // Returns a percentage of aggregation or join input batches that

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -35,19 +35,6 @@ bool areAllLazyNotLoaded(const std::vector<VectorPtr>& vectors) {
     return isLazyNotLoaded(*vector);
   });
 }
-
-std::optional<std::string> makeSpillPath(
-    bool isPartial,
-    const OperatorCtx& operatorCtx) {
-  if (isPartial) {
-    return std::nullopt;
-  }
-  auto path = operatorCtx.task()->queryCtx()->config().spillPath();
-  if (path.has_value()) {
-    return path.value() + "/" + operatorCtx.task()->taskId();
-  }
-  return std::nullopt;
-}
 } // namespace
 
 GroupingSet::GroupingSet(

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -45,6 +45,7 @@ HashAggregation::HashAggregation(
       spillConfig_(makeOperatorSpillConfig(
           *operatorCtx_->task()->queryCtx(),
           *operatorCtx_,
+          core::QueryConfig::kAggregationSpillEnabled,
           operatorId)),
       maxPartialAggregationMemoryUsage_(
           driverCtx->queryConfig().maxPartialAggregationMemoryUsage()) {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -54,6 +54,7 @@ HashBuild::HashBuild(
       spillConfig_(makeOperatorSpillConfig(
           *operatorCtx_->task()->queryCtx(),
           *operatorCtx_,
+          core::QueryConfig::kJoinSpillEnabled,
           operatorId)),
       spillGroup_(
           spillEnabled() ? operatorCtx_->task()->getSpillOperatorGroupLocked(

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -347,8 +347,13 @@ std::string makeOperatorSpillPath(
 std::optional<Spiller::Config> makeOperatorSpillConfig(
     const core::QueryCtx& queryCtx,
     const OperatorCtx& operatorCtx,
+    const char* spillConfigPropertyName,
     int32_t operatorId) {
   const auto& queryConfig = queryCtx.config();
+  if (not queryConfig.spillEnabled() or
+      not queryConfig.get<bool>(spillConfigPropertyName, false)) {
+    return std::nullopt;
+  }
   if (!queryConfig.spillPath().has_value()) {
     return std::nullopt;
   }

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -121,6 +121,7 @@ std::string makeOperatorSpillPath(
 std::optional<Spiller::Config> makeOperatorSpillConfig(
     const core::QueryCtx& queryCtx,
     const OperatorCtx& operatorCtx,
+    const char* spillConfigPropertyName,
     int32_t operatorId);
 
 } // namespace facebook::velox::exec

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -41,6 +41,7 @@ OrderBy::OrderBy(
       spillConfig_(makeOperatorSpillConfig(
           *operatorCtx_->task()->queryCtx(),
           *operatorCtx_,
+          core::QueryConfig::kOrderBySpillEnabled,
           operatorId)) {
   std::vector<TypePtr> keyTypes;
   std::vector<TypePtr> dependentTypes;

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -874,11 +874,12 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
                         .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
                         .planNode())
                     .queryCtx(queryCtx)
+                    .config(QueryConfig::kSpillEnabled, "true")
+                    .config(QueryConfig::kAggregationSpillEnabled, "true")
                     .config(QueryConfig::kSpillPath, tempDirectory->path)
                     .config(
                         QueryConfig::kAggregationSpillMemoryThreshold,
                         std::to_string(testData.aggregationMemLimit))
-                    .config(QueryConfig::kSpillPath, tempDirectory->path)
                     .assertResults(results);
 
     auto stats = task->taskStats().pipelineStats;
@@ -981,6 +982,8 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
                                .singleAggregation({"c0"}, {"array_agg(c1)"})
                                .planNode())
             .queryCtx(queryCtx)
+            .config(QueryConfig::kSpillEnabled, "true")
+            .config(QueryConfig::kAggregationSpillEnabled, "true")
             .config(QueryConfig::kSpillPath, tempDirectory->path)
             .config(
                 QueryConfig::kSpillPartitionBits,
@@ -1089,6 +1092,8 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
                              .singleAggregation({"c0"}, {"array_agg(c1)"})
                              .planNode())
           .queryCtx(queryCtx)
+          .config(QueryConfig::kSpillEnabled, "true")
+          .config(QueryConfig::kAggregationSpillEnabled, "true")
           .config(QueryConfig::kSpillPath, tempDirectory->path)
           .config(
               QueryConfig::kSpillPartitionBits, std::to_string(kPartitionsBits))

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -127,6 +127,8 @@ class HashJoinTest : public HiveConnectorTestBase {
       params.queryCtx = core::QueryCtx::createForTest();
       params.queryCtx->setConfigOverridesUnsafe({
           {core::QueryConfig::kTestingSpillPct, "100"},
+          {core::QueryConfig::kSpillEnabled, "true"},
+          {core::QueryConfig::kJoinSpillEnabled, "true"},
           {core::QueryConfig::kSpillPath, spillDirectory->path},
       });
     }

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -165,9 +165,12 @@ class OrderByTest : public OperatorTestBase {
       SCOPED_TRACE("run with spilling");
       auto spillDirectory = exec::test::TempDirectoryPath::create();
       auto queryCtx = core::QueryCtx::createForTest();
-      queryCtx->setConfigOverridesUnsafe(
-          {{core::QueryConfig::kTestingSpillPct, "100"},
-           {core::QueryConfig::kSpillPath, spillDirectory->path}});
+      queryCtx->setConfigOverridesUnsafe({
+          {core::QueryConfig::kTestingSpillPct, "100"},
+          {core::QueryConfig::kSpillEnabled, "true"},
+          {core::QueryConfig::kOrderBySpillEnabled, "true"},
+          {core::QueryConfig::kSpillPath, spillDirectory->path},
+      });
       CursorParameters params;
       params.planNode = planNode;
       params.queryCtx = queryCtx;
@@ -426,9 +429,12 @@ TEST_F(OrderByTest, spill) {
       memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
   // Set 'kSpillableReservationGrowthPct' to an extreme large value to trigger
   // disk spilling by failed memory growth reservation.
-  queryCtx->setConfigOverridesUnsafe(
-      {{core::QueryConfig::kSpillPath, spillDirectory->path},
-       {core::QueryConfig::kSpillableReservationGrowthPct, "1000"}});
+  queryCtx->setConfigOverridesUnsafe({
+      {core::QueryConfig::kSpillPath, spillDirectory->path},
+      {core::QueryConfig::kSpillEnabled, "true"},
+      {core::QueryConfig::kOrderBySpillEnabled, "true"},
+      {core::QueryConfig::kSpillableReservationGrowthPct, "1000"},
+  });
   CursorParameters params;
   params.planNode = plan;
   params.queryCtx = queryCtx;

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -305,7 +305,7 @@ TEST_F(SpillTest, spillTimestamp) {
   // read back.
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   std::vector<CompareFlags> emptyCompareFlags;
-  const std::string kSpillPath = tempDirectory->path + "/test";
+  const std::string spillPath = tempDirectory->path + "/test";
   std::vector<Timestamp> timeValues = {
       Timestamp{0, 0},
       Timestamp{12, 0},
@@ -313,7 +313,7 @@ TEST_F(SpillTest, spillTimestamp) {
       Timestamp{1, 17'123'456},
       Timestamp{-1, 17'123'456}};
   SpillState state(
-      kSpillPath, 1, 1, emptyCompareFlags, 1024, *pool(), *mappedMemory_);
+      spillPath, 1, 1, emptyCompareFlags, 1024, *pool(), *mappedMemory_);
   int partitionIndex = 0;
   state.setPartitionSpilled(partitionIndex);
   EXPECT_TRUE(state.isPartitionSpilled(partitionIndex));

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -171,6 +171,8 @@ void AggregationTestBase::testAggregations(
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
     queryBuilder.config(core::QueryConfig::kTestingSpillPct, "100")
+        .config(core::QueryConfig::kSpillEnabled, "true")
+        .config(core::QueryConfig::kAggregationSpillEnabled, "true")
         .config(core::QueryConfig::kSpillPath, spillDirectory->path)
         .maxDrivers(4);
 


### PR DESCRIPTION
Summary:
This set of properties reflects what Presto has.
This way it would also be easier to granularly control the spilling.
Also setting the default spilling path to "/tmp".
The spilling path no longer controlls the spilling enabling.

Reviewed By: xiaoxmeng

Differential Revision: D40320549

