### PR TITLE
Expose ExpressionFuzzer::generateExpression and add unit test

### DIFF
--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -206,7 +206,11 @@ bool SignatureBinderBase::tryBind(
         integerParameters_.count(params[0].baseName()) != 0) {
       return tryBindIntegerParameters(params, actualType);
     }
+
     // Type Parameters can recurse.
+    if (params.size() != actualType->size()) {
+      return false;
+    }
     for (auto i = 0; i < params.size(); i++) {
       if (!tryBind(params[i], actualType->childAt(i))) {
         return false;

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -38,7 +38,8 @@ class SignatureBinderBase {
   }
 
   /// Return true if actualType can bind to typeSignature and update bindings_
-  /// accordingly.
+  /// accordingly. The number of parameters in typeSignature and actualType must
+  /// match. Return false otherwise.
   bool tryBind(
       const exec::TypeSignature& typeSignature,
       const TypePtr& actualType);

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -85,6 +85,17 @@ add_library(velox_expression_fuzzer ExpressionFuzzer.cpp)
 target_link_libraries(velox_expression_fuzzer velox_type velox_vector_fuzzer
                       velox_vector_test_lib velox_function_registry)
 
+add_executable(velox_expression_fuzzer_unit_test ExpressionFuzzerUnitTest.cpp)
+
+target_link_libraries(
+  velox_expression_fuzzer_unit_test
+  velox_expression_fuzzer
+  velox_functions_prestosql
+  velox_core
+  velox_expression
+  gtest
+  gtest_main)
+
 add_executable(velox_expression_fuzzer_test ExpressionFuzzerTest.cpp)
 
 target_link_libraries(velox_expression_fuzzer_test velox_expression_fuzzer

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -16,12 +16,139 @@
 
 #pragma once
 
+#include "velox/core/ITypedExpr.h"
+#include "velox/core/QueryCtx.h"
 #include "velox/functions/FunctionRegistry.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+DECLARE_int32(velox_fuzzer_max_level_of_nesting);
 
 namespace facebook::velox::test {
 
 // Generates random expressions based on `signatures`, random input data (via
 // VectorFuzzer), and executes them.
 void expressionFuzzer(FunctionSignatureMap signatureMap, size_t seed);
+
+// Represents one available function signature.
+struct CallableSignature {
+  // Function name.
+  std::string name;
+
+  // Input arguments and return type.
+  std::vector<TypePtr> args;
+  bool variableArity{false};
+  TypePtr returnType;
+
+  // Convenience print function.
+  std::string toString() const;
+};
+
+class ExpressionFuzzer {
+ public:
+  ExpressionFuzzer(
+      FunctionSignatureMap signatureMap,
+      size_t initialSeed,
+      int32_t maxLevelOfNesting = FLAGS_velox_fuzzer_max_level_of_nesting);
+
+  template <typename TFunc>
+  void registerFuncOverride(TFunc func, const std::string& name);
+
+  void go();
+
+  /// Return a random legit expression that returns returnType.
+  core::TypedExprPtr generateExpression(const TypePtr& returnType);
+
+ private:
+  enum ArgumentKind { kArgConstant = 0, kArgColumn = 1, kArgExpression = 2 };
+
+  void seed(size_t seed);
+
+  void reSeed();
+
+  void printRowVector(const RowVectorPtr& rowVector);
+
+  void appendConjunctSignatures();
+
+  RowVectorPtr generateRowVector();
+
+  core::TypedExprPtr generateArgConstant(const TypePtr& arg);
+
+  core::TypedExprPtr generateArgColumn(const TypePtr& arg);
+
+  core::TypedExprPtr generateArg(const TypePtr& arg);
+
+  std::vector<core::TypedExprPtr> generateArgs(const CallableSignature& input);
+
+  // Specialization for the "like" function: second and third (optional)
+  // parameters always need to be constant.
+  std::vector<core::TypedExprPtr> generateLikeArgs(
+      const CallableSignature& input);
+
+  // Specialization for the "empty_approx_set" function: first optional
+  // parameter needs to be constant.
+  std::vector<core::TypedExprPtr> generateEmptyApproxSetArgs(
+      const CallableSignature& input);
+
+  // Specialization for the "regexp_replace" function: second and third
+  // (optional) parameters always need to be constant.
+  std::vector<core::TypedExprPtr> generateRegexpReplaceArgs(
+      const CallableSignature& input);
+
+  void persistReproInfo(
+      const VectorPtr& inputVector,
+      const VectorPtr& resultVector,
+      const std::string& sql);
+
+  // Executes an expression. Returns:
+  //
+  //  - true if both succeeded and returned the exact same results.
+  //  - false if both failed with compatible exceptions.
+  //  - throws otherwise (incompatible exceptions or different results).
+  bool executeExpression(
+      const core::TypedExprPtr& plan,
+      const RowVectorPtr& rowVector,
+      VectorPtr&& resultVector,
+      bool canThrow);
+
+  // If --duration_sec > 0, check if we expired the time budget. Otherwise,
+  // check if we expired the number of iterations (--steps).
+  template <typename T>
+  bool isDone(size_t i, T startTime) const;
+
+  FuzzerGenerator rng_;
+  size_t currentSeed_{0};
+
+  std::vector<CallableSignature> signatures_;
+
+  // Maps a given type to the functions that return that type.
+  std::unordered_map<TypeKind, std::vector<const CallableSignature*>>
+      signaturesMap_;
+
+  // The remaining levels of expression nesting. It's initialized by
+  // FLAGS_max_level_of_nesting and updated in generateExpression(). When its
+  // value decreases to 0, we don't generate subexpressions anymore.
+  int32_t remainingLevelOfNesting_;
+
+  // We allow the arg generation routine to be specialized for particular
+  // functions. This map stores the mapping between function name and the
+  // overridden method.
+  using ArgsOverrideFunc = std::function<std::vector<core::TypedExprPtr>(
+      const CallableSignature& input)>;
+  std::unordered_map<std::string, ArgsOverrideFunc> funcArgOverrides_;
+
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+  core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
+
+  test::VectorMaker vectorMaker_{execCtx_.pool()};
+  VectorFuzzer vectorFuzzer_;
+
+  // Contains the input column references that need to be generated for one
+  // particular iteration.
+  std::vector<TypePtr> inputRowTypes_;
+  std::vector<std::string> inputRowNames_;
+};
 
 } // namespace facebook::velox::test

--- a/velox/expression/tests/ExpressionFuzzerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerUnitTest.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/expression/tests/ExpressionFuzzer.h"
+
+#include "velox/core/ITypedExpr.h"
+#include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+namespace facebook::velox::test {
+class ExpressionFuzzerUnitTest : public testing::Test {
+ protected:
+  uint32_t countLevelOfNesting(core::TypedExprPtr expression) {
+    if (expression->inputs().empty()) {
+      return 0;
+    }
+
+    uint32_t maxLevelOfNesting = 1;
+    for (const auto& child : expression->inputs()) {
+      maxLevelOfNesting =
+          std::max(maxLevelOfNesting, 1 + countLevelOfNesting(child));
+    }
+    return maxLevelOfNesting;
+  }
+
+  TypePtr randomType(std::mt19937& seed) {
+    static std::vector<TypePtr> kSupportedTypes{
+        BOOLEAN(),
+        TINYINT(),
+        SMALLINT(),
+        INTEGER(),
+        BIGINT(),
+        REAL(),
+        DOUBLE(),
+        TIMESTAMP(),
+        DATE(),
+        INTERVAL_DAY_TIME()};
+    auto index = folly::Random::rand32(kSupportedTypes.size(), seed);
+    return kSupportedTypes[index];
+  }
+};
+
+TEST_F(ExpressionFuzzerUnitTest, restrictedLevelOfNesting) {
+  velox::functions::prestosql::registerAllScalarFunctions();
+  std::mt19937 seed{0};
+
+  auto testLevelOfNesting = [&](int32_t maxLevelOfNesting) {
+    ExpressionFuzzer fuzzer{
+        velox::getFunctionSignatures(), 0, maxLevelOfNesting};
+
+    for (int i = 0; i < 5000; ++i) {
+      auto expression = fuzzer.generateExpression(randomType(seed));
+      EXPECT_LE(countLevelOfNesting(expression), std::max(1, maxLevelOfNesting))
+          << fmt::format(
+                 "Expression {} exceeds max level of nesting {} (original {})",
+                 expression->toString(),
+                 std::max(1, maxLevelOfNesting),
+                 maxLevelOfNesting);
+    }
+  };
+
+  testLevelOfNesting(10);
+
+  testLevelOfNesting(5);
+
+  testLevelOfNesting(2);
+
+  testLevelOfNesting(1);
+
+  testLevelOfNesting(0);
+
+  testLevelOfNesting(-1);
+}
+} // namespace facebook::velox::test

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -440,6 +440,34 @@ TEST(SignatureBinderTest, unresolvable) {
     assertCannotResolve(signature, {BIGINT()});
     assertCannotResolve(signature, {INTEGER(), BIGINT()});
   }
+
+  // row(bigint, varchar) -> bigint
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("bigint")
+                         .argumentType("row(bigint, varchar)")
+                         .build();
+
+    testSignatureBinder(signature, {ROW({BIGINT(), VARCHAR()})}, BIGINT());
+
+    // wrong type
+    assertCannotResolve(signature, {ROW({BIGINT()})});
+    assertCannotResolve(signature, {ROW({BIGINT(), VARCHAR(), BOOLEAN()})});
+  }
+
+  // array(row(boolean)) -> bigint
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("bigint")
+                         .argumentType("array(row(boolean))")
+                         .build();
+
+    testSignatureBinder(signature, {ARRAY(ROW({BOOLEAN()}))}, BIGINT());
+
+    // wrong type
+    assertCannotResolve(signature, {ARRAY(ROW({BOOLEAN(), BIGINT()}))});
+    assertCannotResolve(signature, {ARRAY(ROW({BIGINT()}))});
+  }
 }
 
 TEST(SignatureBinderTest, tryResolveTypeNullOutput) {

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -67,6 +67,7 @@ TEST_F(VectorFuzzerTest, flatPrimitive) {
       DATE(),
       TIMESTAMP(),
       INTERVAL_DAY_TIME(),
+      UNKNOWN(),
   };
 
   for (const auto& type : types) {
@@ -194,6 +195,13 @@ TEST_F(VectorFuzzerTest, constants) {
   ASSERT_TRUE(vector->type()->kindEquals(ROW({ARRAY(BIGINT()), SMALLINT()})));
   ASSERT_EQ(VectorEncoding::Simple::CONSTANT, vector->encoding());
   ASSERT_FALSE(vector->mayHaveNulls());
+
+  // Fuzzer should produce null constant for UNKNOWN type even if nullRatio is
+  // 0.
+  vector = fuzzer.fuzzConstant(UNKNOWN());
+  ASSERT_TRUE(vector->type()->kindEquals(UNKNOWN()));
+  ASSERT_EQ(VectorEncoding::Simple::CONSTANT, vector->encoding());
+  ASSERT_TRUE(vector->mayHaveNulls());
 }
 
 TEST_F(VectorFuzzerTest, constantsNull) {
@@ -204,6 +212,11 @@ TEST_F(VectorFuzzerTest, constantsNull) {
   // Null constants.
   auto vector = fuzzer.fuzzConstant(REAL());
   ASSERT_TRUE(vector->type()->kindEquals(REAL()));
+  ASSERT_EQ(VectorEncoding::Simple::CONSTANT, vector->encoding());
+  ASSERT_TRUE(vector->mayHaveNulls());
+
+  vector = fuzzer.fuzzConstant(UNKNOWN());
+  ASSERT_TRUE(vector->type()->kindEquals(UNKNOWN()));
   ASSERT_EQ(VectorEncoding::Simple::CONSTANT, vector->encoding());
   ASSERT_TRUE(vector->mayHaveNulls());
 


### PR DESCRIPTION
Summary: Add a unit test for the max levels of nesting in fuzzer-generated expressions. To add this test, this diff also move the declaration of ExpressionFuzzer to the header file and make the generateExpression() interface public.

Reviewed By: xiaoxmeng

Differential Revision: D40245876

