### PR TITLE
Fix build failure caused by undefined reference to registerAllAggregateFunctions()

### DIFF
--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -43,4 +43,5 @@ target_link_libraries(
   velox_hive_connector
   velox_tpch_connector
   velox_presto_serializer
-  velox_functions_prestosql)
+  velox_functions_prestosql
+  velox_aggregates)


### PR DESCRIPTION
Differential Revision: D40371142

