### PR TITLE
[Velox] Table writer 2: Add write protocol interface

### DIFF
--- a/velox/connectors/CMakeLists.txt
+++ b/velox/connectors/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_connector Connector.cpp)
+add_library(velox_connector Connector.cpp WriteProtocol.cpp)
 
 target_link_libraries(velox_connector velox_config velox_vector)
 

--- a/velox/connectors/WriteProtocol.cpp
+++ b/velox/connectors/WriteProtocol.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/WriteProtocol.h"
+#include "velox/connectors/Connector.h"
+#include "velox/vector/ConstantVector.h"
+
+#include <unordered_map>
+
+namespace facebook::velox::connector {
+
+namespace {
+
+using RegisteredWriteProtocols = std::unordered_map<
+    WriteProtocol::CommitStrategy,
+    std::shared_ptr<WriteProtocol>>;
+
+RegisteredWriteProtocols& registeredWriteProtocols() {
+  // Default write protocol registered
+  static RegisteredWriteProtocols protocols{
+      {WriteProtocol::CommitStrategy::kNoCommit,
+       std::make_shared<DefaultWriteProtocol>()}};
+  return protocols;
+}
+
+} // namespace
+
+// static
+bool WriteProtocol::registerWriteProtocol(
+    WriteProtocol::CommitStrategy commitStrategy,
+    std::shared_ptr<WriteProtocol> writeProtocol) {
+  return registeredWriteProtocols()
+      .insert_or_assign(commitStrategy, writeProtocol)
+      .second;
+}
+
+// static
+std::shared_ptr<WriteProtocol> WriteProtocol::getWriteProtocol(
+    CommitStrategy commitStrategy) {
+  const auto iter = registeredWriteProtocols().find(commitStrategy);
+  // Fail if no WriteProtocol has been registered for the given CommitStrategy.
+  VELOX_CHECK(
+      iter != registeredWriteProtocols().end(),
+      "No write protocol found for commit strategy {}",
+      commitStrategyToString(commitStrategy));
+  return iter->second;
+}
+
+RowVectorPtr DefaultWriteProtocol::commit(
+    const WriteInfo& writeInfo,
+    velox::memory::MemoryPool* FOLLY_NONNULL pool) {
+  return std::make_shared<RowVector>(
+      pool,
+      ROW({"rowCount"}, {BIGINT()}),
+      BufferPtr(nullptr),
+      1,
+      std::vector<VectorPtr>{std::make_shared<ConstantVector<int64_t>>(
+          pool, 1, false, BIGINT(), writeInfo.numWrittenRows())});
+}
+
+} // namespace facebook::velox::connector

--- a/velox/connectors/WriteProtocol.h
+++ b/velox/connectors/WriteProtocol.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::connector {
+
+class ConnectorInsertTableHandle;
+class ConnectorQueryCtx;
+
+/// Interface to provide key parameters for writers. Ex., write and commit
+/// locations, append or overwrite, etc.
+class WriterParameters {
+ public:
+  virtual ~WriterParameters() = default;
+};
+
+/// Interface that includes all info from write. It will be passed to commit()
+/// of WriteProtocol.
+class WriteInfo {
+ public:
+  virtual ~WriteInfo() = default;
+
+  virtual vector_size_t numWrittenRows() const = 0;
+};
+
+/// Abstraction for write behaviors. Systems register WriteProtocols
+/// by CommitStrategy. Writers call getWriteProtocol() to get the registered
+/// instance of the WriteProtocol when needed.
+class WriteProtocol {
+ public:
+  /// Represents the commit strategy of a write protocol.
+  enum class CommitStrategy {
+    kNoCommit, // No more commit actions are needed.
+    kTaskCommit // Task level commit is needed.
+  };
+
+  virtual ~WriteProtocol() {}
+
+  /// Return the commit strategy of the write protocol. It will be the commit
+  /// strategy that the write protocol registers for.
+  virtual CommitStrategy commitStrategy() const = 0;
+
+  /// Return a string encoding of the given commit strategy.
+  static std::string commitStrategyToString(CommitStrategy commitStrategy) {
+    switch (commitStrategy) {
+      case CommitStrategy::kNoCommit:
+        return "NO_COMMIT";
+      case CommitStrategy::kTaskCommit:
+        return "TASK_COMMIT";
+      default:
+        VELOX_UNREACHABLE();
+    }
+  }
+
+  /// Perform actions of commit. It would be called by the writers and could
+  /// return outputs that would be included in writer outputs. Return nullptr if
+  /// the commit action does not need to add output to the table writer output.
+  virtual RowVectorPtr commit(
+      const WriteInfo& writeInfo,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool) {
+    return nullptr;
+  }
+
+  /// Return parameters for writers. Ex., write and commit locations. Return
+  /// nullptr if the writer does not need parameters from the write protocol.
+  virtual std::shared_ptr<const WriterParameters> getWriterParameters(
+      const std::shared_ptr<const velox::connector::ConnectorInsertTableHandle>&
+          tableHandle,
+      const velox::connector::ConnectorQueryCtx* FOLLY_NONNULL
+          connectorQueryCtx) const = 0;
+
+  /// Register a WriteProtocol implementation for the given CommitStrategy. If
+  /// the CommitStrategy has already been registered, it will replace the old
+  /// WriteProtocol implementation with the new one and return false; otherwise
+  /// return true.
+  static bool registerWriteProtocol(
+      CommitStrategy commitStrategy,
+      std::shared_ptr<WriteProtocol> writeProtocol);
+
+  /// Return the instance of the WriteProtocol registered for
+  /// the given CommitStrategy.
+  static std::shared_ptr<WriteProtocol> getWriteProtocol(
+      CommitStrategy commitStrategy);
+};
+
+class DefaultWriteProtocol : public WriteProtocol {
+ public:
+  ~DefaultWriteProtocol() override {}
+
+  CommitStrategy commitStrategy() const override {
+    return CommitStrategy::kNoCommit;
+  }
+
+  RowVectorPtr commit(
+      const WriteInfo& writeInfo,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool) override;
+
+  std::shared_ptr<const WriterParameters> getWriterParameters(
+      const std::shared_ptr<const velox::connector::ConnectorInsertTableHandle>&
+          tableHandle,
+      const velox::connector::ConnectorQueryCtx* FOLLY_NONNULL
+          connectorQueryCtx) const override {
+    return std::make_shared<WriterParameters>();
+  }
+};
+
+} // namespace facebook::velox::connector

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_hive_connector OBJECT HiveConnector.cpp FileHandle.cpp)
+add_library(velox_hive_connector OBJECT HiveConnector.cpp FileHandle.cpp
+                                        HiveWriteProtocol.cpp)
 
 target_link_libraries(velox_hive_connector velox_connector
                       velox_dwio_dwrf_reader velox_dwio_dwrf_writer velox_file)

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -16,12 +16,17 @@
 
 #include "velox/connectors/hive/HiveConnector.h"
 
+#include "velox/common/base/Fs.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/ReaderFactory.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/type/Conversions.h"
 #include "velox/type/Type.h"
 #include "velox/type/Variant.h"
+
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 #include <memory>
 
@@ -80,29 +85,49 @@ std::string HiveTableHandle::toString() const {
 }
 
 HiveDataSink::HiveDataSink(
-    std::shared_ptr<const RowType> inputType,
-    const std::string& filePath,
-    velox::memory::MemoryPool* memoryPool)
-    : inputType_(inputType) {
+    RowTypePtr inputType,
+    std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+    const ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx)
+    : inputType_(std::move(inputType)),
+      insertTableHandle_(std::move(insertTableHandle)),
+      connectorQueryCtx_(connectorQueryCtx) {
+  if (!insertTableHandle_->isPartitioned()) {
+    writers_.emplace_back(createWriter());
+  }
+}
+
+void HiveDataSink::appendData(VectorPtr input) {
+  // For the time being the hive data sink supports one file.
+  // To extend it we can create a new writer for every
+  // partition.
+  if (writers_.empty()) {
+    writers_.emplace_back(createWriter());
+  }
+  writers_[0]->write(input);
+}
+
+void HiveDataSink::close() {
+  for (const auto& writer : writers_) {
+    writer->close();
+  }
+}
+
+std::unique_ptr<velox::dwrf::Writer> HiveDataSink::createWriter() {
   auto config = std::make_shared<WriterConfig>();
   // TODO: Wire up serde properties to writer configs.
 
   facebook::velox::dwrf::WriterOptions options;
   options.config = config;
-  options.schema = inputType;
+  options.schema = inputType_;
   // Without explicitly setting flush policy, the default memory based flush
   // policy is used.
 
-  auto sink = facebook::velox::dwio::common::DataSink::create(filePath);
-  writer_ = std::make_unique<Writer>(options, std::move(sink), *memoryPool);
-}
-
-void HiveDataSink::appendData(VectorPtr input) {
-  writer_->write(input);
-}
-
-void HiveDataSink::close() {
-  writer_->close();
+  auto fileName =
+      boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+  auto sink = dwio::common::DataSink::create(
+      fs::path(insertTableHandle_->locationHandle()->writePath()) / fileName);
+  return std::make_unique<Writer>(
+      options, std::move(sink), *connectorQueryCtx_->memoryPool());
 }
 
 namespace {
@@ -163,7 +188,7 @@ static void makeFieldSpecs(
 
 std::shared_ptr<common::ScanSpec> makeScanSpec(
     const SubfieldFilters& filters,
-    const std::shared_ptr<const RowType>& rowType) {
+    const RowTypePtr& rowType) {
   auto spec = std::make_shared<common::ScanSpec>("root");
   makeFieldSpecs("", 0, rowType, spec.get());
 
@@ -186,7 +211,7 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
 } // namespace
 
 HiveDataSource::HiveDataSource(
-    const std::shared_ptr<const RowType>& outputType,
+    const RowTypePtr& outputType,
     const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
     const std::unordered_map<
         std::string,
@@ -490,7 +515,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
   std::shared_ptr<dwio::common::ColumnSelector> cs;
   if (columnNames.empty()) {
-    static const std::shared_ptr<const RowType> kEmpty{ROW({}, {})};
+    static const RowTypePtr kEmpty{ROW({}, {})};
     cs = std::make_shared<dwio::common::ColumnSelector>(kEmpty);
   } else {
     cs = std::make_shared<dwio::common::ColumnSelector>(fileType, columnNames);

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -51,6 +51,10 @@ class HiveColumnHandle : public ColumnHandle {
     return dataType_;
   }
 
+  bool isPartitionKey() const {
+    return columnType_ == ColumnType::kPartitionKey;
+  }
+
  private:
   const std::string name_;
   const ColumnType columnType_;
@@ -92,38 +96,122 @@ class HiveTableHandle : public ConnectorTableHandle {
   const core::TypedExprPtr remainingFilter_;
 };
 
+/// Location related properties of the Hive table to be written
+class LocationHandle {
+ public:
+  enum class TableType {
+    kNew, // Write to a new table to be created.
+    kExisting, // Write to an existing table.
+    kTemporary, // Write to a temporary table.
+  };
+
+  enum class WriteMode {
+    // Write to a staging directory and then move to the target directory
+    // after write finishes.
+    kStageAndMoveToTargetDirectory,
+    // Directly write to the target directory to be created.
+    kDirectToTargetNewDirectory,
+    // Directly write to the existing target directory.
+    kDirectToTargetExistingDirectory,
+  };
+
+  LocationHandle(
+      std::string targetPath,
+      std::string writePath,
+      TableType tableType,
+      WriteMode writeMode)
+      : targetPath_(std::move(targetPath)),
+        writePath_(std::move(writePath)),
+        tableType_(tableType),
+        writeMode_(writeMode) {}
+
+  const std::string& targetPath() const {
+    return targetPath_;
+  }
+
+  const std::string& writePath() const {
+    return writePath_;
+  }
+
+  TableType tableType() const {
+    return tableType_;
+  }
+
+  WriteMode writeMode() const {
+    return writeMode_;
+  }
+
+ private:
+  // Target directory path.
+  const std::string targetPath_;
+  // Staging directory path.
+  const std::string writePath_;
+  // Whether the table to be written is new, already existing or temporary.
+  const TableType tableType_;
+  // How the target path and directory path could be used.
+  const WriteMode writeMode_;
+};
+
 /**
  * Represents a request for Hive write
  */
 class HiveInsertTableHandle : public ConnectorInsertTableHandle {
  public:
-  explicit HiveInsertTableHandle(const std::string& filePath)
-      : filePath_(filePath) {}
+  HiveInsertTableHandle(
+      std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns,
+      std::shared_ptr<const LocationHandle> locationHandle)
+      : inputColumns_(std::move(inputColumns)),
+        locationHandle_(std::move(locationHandle)) {}
 
-  const std::string& filePath() const {
-    return filePath_;
+  virtual ~HiveInsertTableHandle() = default;
+
+  const std::vector<std::shared_ptr<const HiveColumnHandle>>& inputColumns()
+      const {
+    return inputColumns_;
   }
 
-  virtual ~HiveInsertTableHandle() {}
+  const std::shared_ptr<const LocationHandle>& locationHandle() const {
+    return locationHandle_;
+  }
+
+  bool isPartitioned() const {
+    return std::any_of(
+        inputColumns_.begin(), inputColumns_.end(), [](auto column) {
+          return column->isPartitionKey();
+        });
+  }
+
+  bool isCreateTable() const {
+    return locationHandle_->tableType() == LocationHandle::TableType::kNew;
+  }
+
+  bool isInsertTable() const {
+    return locationHandle_->tableType() == LocationHandle::TableType::kExisting;
+  }
 
  private:
-  const std::string filePath_;
+  const std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns_;
+  const std::shared_ptr<const LocationHandle> locationHandle_;
 };
 
 class HiveDataSink : public DataSink {
  public:
   explicit HiveDataSink(
-      std::shared_ptr<const RowType> inputType,
-      const std::string& filePath,
-      velox::memory::MemoryPool* FOLLY_NONNULL memoryPool);
+      RowTypePtr inputType,
+      std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+      const ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx);
 
   void appendData(VectorPtr input) override;
 
   void close() override;
 
  private:
-  const std::shared_ptr<const RowType> inputType_;
-  std::unique_ptr<facebook::velox::dwrf::Writer> writer_;
+  std::unique_ptr<dwrf::Writer> createWriter();
+
+  const RowTypePtr inputType_;
+  const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle_;
+  const ConnectorQueryCtx* connectorQueryCtx_;
+  std::vector<std::unique_ptr<dwrf::Writer>> writers_;
 };
 
 class HiveConnector;
@@ -131,7 +219,7 @@ class HiveConnector;
 class HiveDataSource : public DataSource {
  public:
   HiveDataSource(
-      const std::shared_ptr<const RowType>& outputType,
+      const RowTypePtr& outputType,
       const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
       const std::unordered_map<
           std::string,
@@ -187,7 +275,7 @@ class HiveDataSource : public DataSource {
   /// Clear split_, reader_ and rowReader_ after split has been fully processed.
   void resetSplit();
 
-  const std::shared_ptr<const RowType> outputType_;
+  const RowTypePtr outputType_;
   // Column handles for the partition key columns keyed on partition key column
   // name.
   std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>
@@ -203,7 +291,7 @@ class HiveDataSource : public DataSource {
   std::unique_ptr<dwio::common::Reader> reader_;
   std::unique_ptr<dwio::common::RowReader> rowReader_;
   std::unique_ptr<exec::ExprSet> remainingFilterExprSet_;
-  std::shared_ptr<const RowType> readerOutputType_;
+  RowTypePtr readerOutputType_;
   bool emptySplit_;
 
   dwio::common::RuntimeStatistics runtimeStats_;
@@ -235,7 +323,7 @@ class HiveConnector final : public Connector {
   }
 
   std::shared_ptr<DataSource> createDataSource(
-      const std::shared_ptr<const RowType>& outputType,
+      const RowTypePtr& outputType,
       const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
       const std::unordered_map<
           std::string,
@@ -254,18 +342,15 @@ class HiveConnector final : public Connector {
   }
 
   std::shared_ptr<DataSink> createDataSink(
-      std::shared_ptr<const RowType> inputType,
+      RowTypePtr inputType,
       std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
       ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) override final {
     auto hiveInsertHandle = std::dynamic_pointer_cast<HiveInsertTableHandle>(
         connectorInsertTableHandle);
-    VELOX_CHECK(
-        hiveInsertHandle != nullptr,
-        "Hive connector expecting hive write handle!");
+    VELOX_CHECK_NOT_NULL(
+        hiveInsertHandle, "Hive connector expecting hive write handle!");
     return std::make_shared<HiveDataSink>(
-        inputType,
-        hiveInsertHandle->filePath(),
-        connectorQueryCtx->memoryPool());
+        inputType, hiveInsertHandle, connectorQueryCtx);
   }
 
   folly::Executor* FOLLY_NULLABLE executor() {

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -311,6 +311,19 @@ class HiveDataSource : public DataSource {
   folly::Executor* FOLLY_NULLABLE executor_;
 };
 
+/// Hive connector configs
+class HiveConfig {
+ public:
+  /// Can new data be inserted into existing partitions or existing
+  /// unpartitioned tables
+  static constexpr const char* kImmutablePartitions =
+      "hive.immutable-partitions";
+
+  static bool isImmutablePartitions(const Config* baseConfig) {
+    return baseConfig->get<bool>(kImmutablePartitions, true);
+  }
+};
+
 class HiveConnector final : public Connector {
  public:
   explicit HiveConnector(

--- a/velox/connectors/hive/HiveWriteProtocol.cpp
+++ b/velox/connectors/hive/HiveWriteProtocol.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/HiveWriteProtocol.h"
+#include "velox/connectors/hive/HiveConnector.h"
+
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+namespace facebook::velox::connector::hive {
+
+namespace {
+
+std::string makeUuid() {
+  return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+}
+
+} // namespace
+
+std::shared_ptr<const WriterParameters>
+HiveNoCommitWriteProtocol::getWriterParameters(
+    const std::shared_ptr<const ConnectorInsertTableHandle>& tableWriteHandle,
+    const ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) const {
+  auto hiveTableWriteHandle =
+      std::dynamic_pointer_cast<const HiveInsertTableHandle>(tableWriteHandle);
+  VELOX_CHECK_NOT_NULL(
+      hiveTableWriteHandle,
+      "This write protocol cannot be used for non-Hive connector");
+  VELOX_USER_CHECK(
+      !hiveTableWriteHandle->isPartitioned(),
+      "Getting write parameters for partitioned Hive tables is not implemented yet.");
+  VELOX_USER_CHECK(
+      hiveTableWriteHandle->isCreateTable() ||
+          !HiveConfig::isImmutablePartitions(connectorQueryCtx->config()),
+      "Unpartitioned Hive tables are immutable");
+
+  auto targetFileName = fmt::format(
+      "{}_{}_{}",
+      connectorQueryCtx->taskId(),
+      connectorQueryCtx->driverId(),
+      makeUuid());
+
+  return std::make_shared<HiveWriterParameters>(
+      hiveTableWriteHandle->isCreateTable()
+          ? HiveWriterParameters::UpdateMode::kNew
+          : HiveWriterParameters::UpdateMode::kAppend,
+      targetFileName,
+      hiveTableWriteHandle->locationHandle()->targetPath(),
+      targetFileName,
+      hiveTableWriteHandle->locationHandle()->writePath());
+}
+
+std::shared_ptr<const WriterParameters>
+HiveTaskCommitWriteProtocol::getWriterParameters(
+    const std::shared_ptr<const ConnectorInsertTableHandle>& tableWriteHandle,
+    const ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) const {
+  auto hiveTableWriteHandle =
+      std::dynamic_pointer_cast<const HiveInsertTableHandle>(tableWriteHandle);
+  VELOX_CHECK_NOT_NULL(
+      hiveTableWriteHandle,
+      "This write protocol cannot be used for non-Hive connector");
+  VELOX_USER_CHECK(
+      !hiveTableWriteHandle->isPartitioned(),
+      "Getting write parameters for partitioned Hive tables is not implemented yet.");
+  VELOX_USER_CHECK(
+      hiveTableWriteHandle->isCreateTable() ||
+          !HiveConfig::isImmutablePartitions(connectorQueryCtx->config()),
+      "Unpartitioned Hive tables are immutable");
+
+  auto targetFileName = fmt::format(
+      "{}_{}_{}",
+      connectorQueryCtx->taskId(),
+      connectorQueryCtx->driverId(),
+      0);
+  auto writeFileName =
+      fmt::format(".tmp.velox.{}_{}", targetFileName, makeUuid());
+
+  return std::make_shared<HiveWriterParameters>(
+      hiveTableWriteHandle->isCreateTable()
+          ? HiveWriterParameters::UpdateMode::kNew
+          : HiveWriterParameters::UpdateMode::kAppend,
+      targetFileName,
+      hiveTableWriteHandle->locationHandle()->targetPath(),
+      writeFileName,
+      hiveTableWriteHandle->locationHandle()->writePath());
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveWriteProtocol.h
+++ b/velox/connectors/hive/HiveWriteProtocol.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/WriteProtocol.h"
+
+namespace facebook::velox::connector::hive {
+
+/// Parameters for Hive writers.
+class HiveWriterParameters : public WriterParameters {
+ public:
+  enum class UpdateMode {
+    kNew, // Write files to a new directory.
+    kAppend, // Append files to an existing directory.
+    kOverwrite, // Overwrite an existing directory.
+  };
+
+  /// @param updateMode Write the files to a new directory, or append to an
+  /// existing directory or overwrite an existing directory.
+  /// @param targetFileName The final name of a file after committing.
+  /// @param targetDirectory The final directory that a file should be in after
+  /// committing.
+  /// @param writeFileName The temporary name of the file that a running writer
+  /// writes to. If a running writer writes directory to the target file, set
+  /// writeFileName to targetFileName by default.
+  /// @param writeDirectory The temporary directory that a running writer writes
+  /// to. If a running writer writes directory to the target directory, set
+  /// writeDirectory to targetDirectory by default.
+  HiveWriterParameters(
+      UpdateMode updateMode,
+      std::string targetFileName,
+      std::string targetDirectory,
+      std::optional<std::string> writeFileName = std::nullopt,
+      std::optional<std::string> writeDirectory = std::nullopt)
+      : WriterParameters(),
+        updateMode_(updateMode),
+        targetFileName_(std::move(targetFileName)),
+        targetDirectory_(std::move(targetDirectory)),
+        writeFileName_(writeFileName.value_or(targetFileName_)),
+        writeDirectory_(writeDirectory.value_or(targetDirectory_)) {}
+
+  UpdateMode updateMode() const {
+    return updateMode_;
+  }
+
+  static std::string updateModeToString(UpdateMode updateMode) {
+    switch (updateMode) {
+      case UpdateMode::kNew:
+        return "NEW";
+      case UpdateMode::kAppend:
+        return "APPEND";
+      case UpdateMode::kOverwrite:
+        return "OVERWRITE";
+      default:
+        VELOX_UNSUPPORTED("Unsupported update mode.");
+    }
+  }
+
+  const std::string& targetFileName() const {
+    return targetFileName_;
+  }
+
+  const std::string& writeFileName() const {
+    return writeFileName_;
+  }
+
+  const std::string& targetDirectory() const {
+    return targetDirectory_;
+  }
+
+  const std::string& writeDirectory() const {
+    return writeDirectory_;
+  }
+
+ private:
+  const UpdateMode updateMode_;
+  const std::string targetFileName_;
+  const std::string targetDirectory_;
+  const std::string writeFileName_;
+  const std::string writeDirectory_;
+};
+
+/// WriteProtocol base implementation for Hive writes. WriterParameters have the
+/// write file name the same as the target file name, so no commit is needed for
+/// file move.
+class HiveNoCommitWriteProtocol : public DefaultWriteProtocol {
+ public:
+  ~HiveNoCommitWriteProtocol() override {}
+
+  CommitStrategy commitStrategy() const override {
+    return CommitStrategy::kNoCommit;
+  }
+
+  std::shared_ptr<const WriterParameters> getWriterParameters(
+      const std::shared_ptr<const velox::connector::ConnectorInsertTableHandle>&
+          tableHandle,
+      const velox::connector::ConnectorQueryCtx* FOLLY_NONNULL
+          connectorQueryCtx) const override;
+
+  static bool registerProtocol() {
+    return registerWriteProtocol(
+        CommitStrategy::kNoCommit,
+        std::make_shared<HiveNoCommitWriteProtocol>());
+  }
+};
+
+/// WriteProtocol implementation for Hive writes. WriterParameters have the
+/// write file name different from the target file name. So commit is needed to
+/// move write file to the target location.
+class HiveTaskCommitWriteProtocol : public DefaultWriteProtocol {
+ public:
+  ~HiveTaskCommitWriteProtocol() override {}
+
+  CommitStrategy commitStrategy() const override {
+    return CommitStrategy::kTaskCommit;
+  }
+
+  std::shared_ptr<const WriterParameters> getWriterParameters(
+      const std::shared_ptr<const velox::connector::ConnectorInsertTableHandle>&
+          tableHandle,
+      const velox::connector::ConnectorQueryCtx* FOLLY_NONNULL
+          connectorQueryCtx) const override;
+
+  static bool registerProtocol() {
+    return registerWriteProtocol(
+        CommitStrategy::kTaskCommit,
+        std::make_shared<HiveTaskCommitWriteProtocol>());
+  }
+};
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_hive_connector_test HivePartitionFunctionTest.cpp
-                                         FileHandleTest.cpp)
+add_executable(
+  velox_hive_connector_test HivePartitionFunctionTest.cpp FileHandleTest.cpp
+                            HiveWriteProtocolTest.cpp)
 add_test(velox_hive_connector_test velox_hive_connector_test)
 
 target_link_libraries(

--- a/velox/connectors/hive/tests/HiveWriteProtocolTest.cpp
+++ b/velox/connectors/hive/tests/HiveWriteProtocolTest.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/HiveWriteProtocol.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/core/QueryCtx.h"
+
+#include "gtest/gtest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector;
+using namespace facebook::velox::connector::hive;
+using namespace facebook::velox::core;
+
+TEST(HiveWriteProtocolTest, writerParameters) {
+  HiveNoCommitWriteProtocol::registerProtocol();
+  HiveTaskCommitWriteProtocol::registerProtocol();
+
+  auto queryCtx = QueryCtx::createForTest();
+  ConnectorQueryCtx connectorQueryCtx(
+      queryCtx->pool(),
+      queryCtx->getConnectorConfig(HiveConnectorFactory::kHiveConnectorName),
+      nullptr,
+      queryCtx->mappedMemory(),
+      "test_task_id",
+      "test_plan_node_id",
+      0);
+  std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns{
+      std::make_shared<const HiveColumnHandle>(
+          "col", HiveColumnHandle::ColumnType::kRegular, BIGINT())};
+  auto insertTableHandle = std::make_shared<HiveInsertTableHandle>(
+      inputColumns,
+      std::make_shared<LocationHandle>(
+          "test_table_directory",
+          "test_table_directory",
+          LocationHandle::TableType::kNew,
+          LocationHandle::WriteMode::kDirectToTargetNewDirectory));
+
+  auto noCommitWriteProtocol =
+      WriteProtocol::getWriteProtocol(WriteProtocol::CommitStrategy::kNoCommit);
+  auto noCommitWriterParameters =
+      std::dynamic_pointer_cast<const HiveWriterParameters>(
+          noCommitWriteProtocol->getWriterParameters(
+              insertTableHandle, &connectorQueryCtx));
+  ASSERT_EQ(
+      noCommitWriterParameters->writeFileName(),
+      noCommitWriterParameters->targetFileName());
+
+  auto taskCommitWriteProtocol = WriteProtocol::getWriteProtocol(
+      WriteProtocol::CommitStrategy::kTaskCommit);
+  auto taskCommitWriterParameters =
+      std::dynamic_pointer_cast<const HiveWriterParameters>(
+          taskCommitWriteProtocol->getWriterParameters(
+              insertTableHandle, &connectorQueryCtx));
+  ASSERT_NE(
+      taskCommitWriterParameters->writeFileName(),
+      taskCommitWriterParameters->targetFileName());
+}

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -83,7 +83,9 @@ OperatorCtx::createConnectorQueryCtx(
       driverCtx_->task->queryCtx()->getConnectorConfig(connectorId),
       expressionEvaluator_.get(),
       driverCtx_->task->queryCtx()->mappedMemory(),
-      fmt::format("{}.{}", driverCtx_->task->taskId(), planNodeId));
+      taskId(),
+      planNodeId,
+      driverCtx_->driverId);
 }
 
 std::optional<Spiller::Config> OperatorCtx::makeSpillConfig(

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -44,4 +44,5 @@ target_link_libraries(
   velox_tpch_connector
   velox_presto_serializer
   velox_functions_prestosql
-  velox_aggregates)
+  velox_aggregates
+  velox_vector_test_lib)

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -152,6 +152,38 @@ HiveConnectorTestBase::makeHiveConnectorSplit(
       .build();
 }
 
+// static
+std::shared_ptr<connector::hive::HiveInsertTableHandle>
+HiveConnectorTestBase::makeHiveInsertTableHandle(
+    const std::vector<std::string>& tableColumnNames,
+    const std::vector<TypePtr>& tableColumnTypes,
+    const std::vector<std::string>& partitionedBy,
+    std::shared_ptr<connector::hive::LocationHandle> locationHandle) {
+  std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
+      columnHandles;
+  for (int i = 0; i < tableColumnNames.size(); ++i) {
+    if (std::find(
+            partitionedBy.cbegin(),
+            partitionedBy.cend(),
+            tableColumnNames.at(i)) != partitionedBy.cend()) {
+      columnHandles.push_back(
+          std::make_shared<connector::hive::HiveColumnHandle>(
+              tableColumnNames.at(i),
+              connector::hive::HiveColumnHandle::ColumnType::kPartitionKey,
+              tableColumnTypes.at(i)));
+    } else {
+      columnHandles.push_back(
+          std::make_shared<connector::hive::HiveColumnHandle>(
+              tableColumnNames.at(i),
+              connector::hive::HiveColumnHandle::ColumnType::kRegular,
+              tableColumnTypes.at(i)));
+    }
+  }
+
+  return std::make_shared<connector::hive::HiveInsertTableHandle>(
+      columnHandles, locationHandle);
+}
+
 std::shared_ptr<connector::hive::HiveColumnHandle>
 HiveConnectorTestBase::regularColumn(
     const std::string& name,

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -86,6 +86,39 @@ class HiveConnectorTestBase : public OperatorTestBase {
         remainingFilter);
   }
 
+  /// @param targetDirectory Final directory of the target table after commit.
+  /// @param writeDirectory Write directory of the target table before commit.
+  /// @param tableType Whether to create a new table, insert into an existing
+  /// table, or write a temporary table.
+  /// @param writeMode How to write to the target directory.
+  static std::shared_ptr<connector::hive::LocationHandle> makeLocationHandle(
+      std::string targetDirectory,
+      std::optional<std::string> writeDirectory = std::nullopt,
+      connector::hive::LocationHandle::TableType tableType =
+          connector::hive::LocationHandle::TableType::kNew,
+      connector::hive::LocationHandle::WriteMode writeMode = connector::hive::
+          LocationHandle::WriteMode::kDirectToTargetNewDirectory) {
+    return std::make_shared<connector::hive::LocationHandle>(
+        targetDirectory,
+        writeDirectory.value_or(targetDirectory),
+        tableType,
+        writeMode);
+  }
+
+  /// Build a HiveInsertTableHandle.
+  /// @param tableColumnNames Column names of the target table. Corresponding
+  /// type of tableColumnNames[i] is tableColumnTypes[i].
+  /// @param tableColumnTypes Column types of the target table. Corresponding
+  /// name of tableColumnTypes[i] is tableColumnNames[i].
+  /// @param partitionedBy A list of partition columns of the target table.
+  /// @param locationHandle Location handle for the table write.
+  static std::shared_ptr<connector::hive::HiveInsertTableHandle>
+  makeHiveInsertTableHandle(
+      const std::vector<std::string>& tableColumnNames,
+      const std::vector<TypePtr>& tableColumnTypes,
+      const std::vector<std::string>& partitionedBy,
+      std::shared_ptr<connector::hive::LocationHandle> locationHandle);
+
   static std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(
       const std::string& name,
       const TypePtr& type);


### PR DESCRIPTION
Add WriteProtocol interface to allow systems to implement different
write and commit behaviors, including write & target directories
and file names, commit actions and output, etc. Support registering
WriteProtocols by CommitStrategy.

Add two base implementations of WriteProtocols for Hive connector.
getWriterParameters() is where table writer can get required parameters
including write & target directories and file names.
commit() can be extended to perform commit actions.