### PR TITLE
[velox] add folly::init to benchmarks needing it

### DIFF
--- a/velox/benchmarks/basic/ComparisonConjunct.cpp
+++ b/velox/benchmarks/basic/ComparisonConjunct.cpp
@@ -174,6 +174,7 @@ BENCHMARK_MULTI(conjunctsNested, n) {
 } // namespace
 
 int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<ComparisonBenchmark>(1'000'000);

--- a/velox/benchmarks/basic/DecodedVector.cpp
+++ b/velox/benchmarks/basic/DecodedVector.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <gflags/gflags.h>
 
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"

--- a/velox/benchmarks/basic/DecodedVector.cpp
+++ b/velox/benchmarks/basic/DecodedVector.cpp
@@ -181,6 +181,7 @@ BENCHMARK(decodeDictionary5Nested) {
 } // namespace
 
 int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<DecodedVectorBenchmark>(10'000'000);

--- a/velox/benchmarks/basic/FeatureNormalization.cpp
+++ b/velox/benchmarks/basic/FeatureNormalization.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <gflags/gflags.h>
 
 #include "velox/functions/Registerer.h"

--- a/velox/benchmarks/basic/FeatureNormalization.cpp
+++ b/velox/benchmarks/basic/FeatureNormalization.cpp
@@ -112,6 +112,7 @@ BENCHMARK_MULTI(normalizeConstant, n) {
 } // namespace
 
 int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<FeatureNormailzationBenchmark>();

--- a/velox/benchmarks/basic/Preproc.cpp
+++ b/velox/benchmarks/basic/Preproc.cpp
@@ -399,7 +399,9 @@ BENCHMARK_MULTI(allFused, n) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   // Verify that benchmark calculations are correct.
   {
     PreprocBenchmark benchmark;

--- a/velox/benchmarks/basic/SelectivityVector.cpp
+++ b/velox/benchmarks/basic/SelectivityVector.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <gflags/gflags.h>
 
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"

--- a/velox/benchmarks/basic/SelectivityVector.cpp
+++ b/velox/benchmarks/basic/SelectivityVector.cpp
@@ -157,6 +157,7 @@ BENCHMARK_MULTI(sumSelectivity1PerCent) {
 } // namespace
 
 int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<SelectivityVectorBenchmark>(10'000'000);

--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -331,6 +331,7 @@ BENCHMARK_MULTI(plusCheckedLarge, n) {
 } // namespace
 
 int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<SimpleArithmeticBenchmark>();

--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <gflags/gflags.h>
 
 #include "velox/functions/Registerer.h"

--- a/velox/benchmarks/basic/VectorCompare.cpp
+++ b/velox/benchmarks/basic/VectorCompare.cpp
@@ -111,6 +111,7 @@ BENCHMARK_DRAW_LINE();
 } // namespace
 
 int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<VectorCompareBenchmark>(1000);

--- a/velox/benchmarks/basic/VectorCompare.cpp
+++ b/velox/benchmarks/basic/VectorCompare.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <gflags/gflags.h>
 
 #include "velox/common/base/CompareFlags.h"

--- a/velox/benchmarks/basic/VectorFuzzer.cpp
+++ b/velox/benchmarks/basic/VectorFuzzer.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <gflags/gflags.h>
 
 #include "velox/common/memory/Memory.h"

--- a/velox/benchmarks/basic/VectorFuzzer.cpp
+++ b/velox/benchmarks/basic/VectorFuzzer.cpp
@@ -128,6 +128,7 @@ BENCHMARK_RELATIVE_MULTI(flatMapArrayNested, n) {
 } // namespace
 
 int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   folly::runBenchmarks();
   return 0;

--- a/velox/benchmarks/basic/VectorSlice.cpp
+++ b/velox/benchmarks/basic/VectorSlice.cpp
@@ -95,6 +95,7 @@ DEFINE_BENCHMARKS(row)
 } // namespace facebook::velox
 
 int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
   using namespace facebook::velox;
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   VELOX_CHECK_LE(FLAGS_slice_size, kVectorSize);

--- a/velox/benchmarks/basic/VectorSlice.cpp
+++ b/velox/benchmarks/basic/VectorSlice.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <gflags/gflags.h>
 
 #include "velox/vector/fuzzer/VectorFuzzer.h"

--- a/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
+++ b/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
@@ -285,6 +285,7 @@ BENCHMARK_RELATIVE(dateManyRowsManyBuckets) {
 } // namespace
 
 int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmarkFew = std::make_unique<HivePartitionFunctionBenchmark>(1'000);

--- a/velox/dwio/common/tests/DataBufferBenchmark.cpp
+++ b/velox/dwio/common/tests/DataBufferBenchmark.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include "folly/init/Init.h"
 #include "velox/dwio/common/ChainedBuffer.h"
 

--- a/velox/exec/benchmarks/MergeBenchmark.cpp
+++ b/velox/exec/benchmarks/MergeBenchmark.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <gflags/gflags.h>
 
 #include "velox/exec/TreeOfLosers.h"

--- a/velox/exec/benchmarks/MergeBenchmark.cpp
+++ b/velox/exec/benchmarks/MergeBenchmark.cpp
@@ -54,6 +54,7 @@ BENCHMARK_RELATIVE(wideArray) {
 }
 
 int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   MergeTestBase test;
   test.seed(1);

--- a/velox/experimental/codegen/benchmark/CodegenBenchmark.h
+++ b/velox/experimental/codegen/benchmark/CodegenBenchmark.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <algorithm>
 #include "velox/common/base/Exceptions.h"
 #include "velox/exec/OperatorUtils.h"

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -19,6 +19,8 @@
 #include <gtest/gtest.h>
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <optional>
 #include "velox/core/PlanNode.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"

--- a/velox/expression/benchmarks/CallNullFreeBenchmark.cpp
+++ b/velox/expression/benchmarks/CallNullFreeBenchmark.cpp
@@ -311,7 +311,8 @@ BENCHMARK_MULTI(simpleMinIntegerNullFreeFastPath) {
 } // namespace
 } // namespace facebook::velox::functions
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
   facebook::velox::functions::CallNullFreeBenchmark benchmark;
   benchmark.test();
   folly::runBenchmarks();

--- a/velox/expression/benchmarks/TryBenchmark.cpp
+++ b/velox/expression/benchmarks/TryBenchmark.cpp
@@ -184,7 +184,9 @@ BENCHMARK_MULTI(divideAllExceptions) {
 }
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/expression/benchmarks/VariadicBenchmark.cpp
+++ b/velox/expression/benchmarks/VariadicBenchmark.cpp
@@ -193,7 +193,8 @@ BENCHMARK_MULTI(simpleVariadicLotsOfArgs) {
 } // namespace
 } // namespace facebook::velox::functions
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
   facebook::velox::functions::VariadicBenchmark benchmark;
   benchmark.test();
   folly::runBenchmarks();

--- a/velox/functions/lib/benchmarks/ApproxMostFrequentStreamSummaryBenchmark.cpp
+++ b/velox/functions/lib/benchmarks/ApproxMostFrequentStreamSummaryBenchmark.cpp
@@ -115,6 +115,7 @@ BENCHMARK_NAMED_PARAM(merge, capacity2048, 1e6, 2048)
 } // namespace facebook::velox::functions
 
 int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/lib/benchmarks/ApproxMostFrequentStreamSummaryBenchmark.cpp
+++ b/velox/functions/lib/benchmarks/ApproxMostFrequentStreamSummaryBenchmark.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <folly/Random.h>
 
 #include "velox/functions/lib/ApproxMostFrequentStreamSummary.h"

--- a/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
+++ b/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
@@ -17,6 +17,8 @@
 #include <random>
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <folly/Random.h>
 #include <folly/portability/GFlags.h>
 #include <folly/stats/TDigest.h>

--- a/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
+++ b/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
@@ -188,6 +188,7 @@ BENCHMARK_RELATIVE_NAMED_PARAM(mergeKllSketch, 1e6x80, 1e6, 80);
 } // namespace facebook::velox::functions::kll::test
 
 int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/ArraySum.cpp
+++ b/velox/functions/prestosql/ArraySum.cpp
@@ -16,7 +16,6 @@
 
 #include <folly/container/F14Set.h>
 
-#include <velox/vector/TypeAliases.h>
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
@@ -29,44 +28,9 @@ namespace {
 /// Implements the array_sum function.
 /// See documentation at https://prestodb.io/docs/current/functions/array.html
 ///
-
 template <typename TInput, typename TOutput>
 class ArraySumFunction : public exec::VectorFunction {
  public:
-  template <bool mayHaveNulls, typename DataAtFunc, typename IsNullFunc>
-  void applyCore(
-      const SelectivityVector& rows,
-      ArrayVector* arrayVector,
-      FlatVector<TOutput>* resultValues,
-      DataAtFunc&& dataAtFunc,
-      IsNullFunc&& isNullFunc) const {
-    rows.template applyToSelected([&](vector_size_t row) {
-      auto start = arrayVector->offsetAt(row);
-      auto end = start + arrayVector->sizeAt(row);
-      TOutput sum = 0;
-
-      auto addElement = [](TOutput& sum, TInput value) {
-        if constexpr (std::is_same_v<TOutput, int64_t>) {
-          sum = checkedPlus<TOutput>(sum, value);
-        } else {
-          sum += value;
-        }
-      };
-
-      for (auto i = start; i < end; i++) {
-        if constexpr (mayHaveNulls) {
-          bool isNull = isNullFunc(i);
-          if (!isNull) {
-            addElement(sum, dataAtFunc(i));
-          }
-        } else {
-          addElement(sum, dataAtFunc(i));
-        }
-      }
-      resultValues->set(row, sum);
-    });
-  }
-
   template <bool mayHaveNulls>
   void applyFlat(
       const SelectivityVector& rows,
@@ -74,12 +38,30 @@ class ArraySumFunction : public exec::VectorFunction {
       const uint64_t* rawNulls,
       const TInput* rawElements,
       FlatVector<TOutput>* resultValues) const {
-    applyCore<mayHaveNulls>(
-        rows,
-        arrayVector,
-        resultValues,
-        [&](vector_size_t index) { return rawElements[index]; },
-        [&](vector_size_t index) { return bits::isBitNull(rawNulls, index); });
+    rows.template applyToSelected([&](vector_size_t row) {
+      auto start = arrayVector->offsetAt(row);
+      auto end = start + arrayVector->sizeAt(row);
+      TOutput sum = 0;
+      for (; start < end; start++) {
+        if constexpr (mayHaveNulls) {
+          bool isNull = bits::isBitNull(rawNulls, start);
+          if (!isNull) {
+            if constexpr (std::is_same<TOutput, int64_t>::value) {
+              sum = checkedPlus<TOutput>(sum, rawElements[start]);
+            } else {
+              sum += rawElements[start];
+            }
+          }
+        } else {
+          if constexpr (std::is_same<TOutput, int64_t>::value) {
+            sum = checkedPlus<TOutput>(sum, rawElements[start]);
+          } else {
+            sum += rawElements[start];
+          }
+        }
+      }
+      resultValues->set(row, sum);
+    });
   }
 
   template <bool mayHaveNulls>
@@ -88,14 +70,31 @@ class ArraySumFunction : public exec::VectorFunction {
       ArrayVector* arrayVector,
       exec::LocalDecodedVector& elements,
       FlatVector<TOutput>* resultValues) const {
-    applyCore<mayHaveNulls>(
-        rows,
-        arrayVector,
-        resultValues,
-        [&](vector_size_t index) {
-          return elements->template valueAt<TInput>(index);
-        },
-        [&](vector_size_t index) { return elements->isNullAt(index); });
+    rows.template applyToSelected([&](vector_size_t row) {
+      auto start = arrayVector->offsetAt(row);
+      auto end = start + arrayVector->sizeAt(row);
+      TOutput sum = 0;
+      for (; start < end; start++) {
+        if constexpr (mayHaveNulls) {
+          if (!elements->isNullAt(start)) {
+            if constexpr (std::is_same<TOutput, int64_t>::value) {
+              sum = checkedPlus<TOutput>(
+                  sum, elements->template valueAt<TInput>(start));
+            } else {
+              sum += elements->template valueAt<TInput>(start);
+            }
+          }
+        } else {
+          if constexpr (std::is_same<TOutput, int64_t>::value) {
+            sum = checkedPlus<TOutput>(
+                sum, elements->template valueAt<TInput>(start));
+          } else {
+            sum += elements->template valueAt<TInput>(start);
+          }
+        }
+      }
+      resultValues->set(row, sum);
+    });
   }
 
   void apply(

--- a/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
@@ -145,7 +145,9 @@ BENCHMARK_RELATIVE(vectorFunctionInteger) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
@@ -130,7 +130,9 @@ BENCHMARK_MULTI(prestoSQLArrayMin) {
 } // namespace
 } // namespace facebook::velox::functions
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/ArrayPositionBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayPositionBenchmark.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
 
 #include "velox/functions/Macros.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
@@ -222,7 +223,9 @@ BENCHMARK_RELATIVE(vectorBasicIntegerWithInstance) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/ArraySumBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArraySumBenchmark.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include "velox/functions/lib/LambdaFunctionUtil.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/functions/prestosql/ArrayFunctions.h"
@@ -98,7 +100,9 @@ BENCHMARK_RELATIVE(VectorFunctionNulls) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/ArrayWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayWriterBenchmark.cpp
@@ -274,7 +274,9 @@ BENCHMARK_MULTI(std_reference) {
 } // namespace
 } // namespace facebook::velox::exec
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   facebook::velox::exec::ArrayWriterBenchmark benchmark;
   benchmark.test();
   folly::runBenchmarks();

--- a/velox/functions/prestosql/benchmarks/ArrayWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayWriterBenchmark.cpp
@@ -130,7 +130,7 @@ class ArrayWriterBenchmark : public functions::test::FunctionBenchmarkBase {
  public:
   ArrayWriterBenchmark() : FunctionBenchmarkBase() {
     registerFunction<SimpleFunctionResize, Array<int64_t>, int64_t>(
-        {"simpl_resize"});
+        {"simple_resize"});
     registerFunction<SimpleFunctionPushBack, Array<int64_t>, int64_t>(
         {"simple_push_back"});
     registerFunction<SimpleGeneralInterface, Array<int64_t>, int64_t>(

--- a/velox/functions/prestosql/benchmarks/BitwiseBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/BitwiseBenchmark.cpp
@@ -153,7 +153,9 @@ BENCHMARK_RELATIVE(bitwise_shift_left) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/CardinalityBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/CardinalityBenchmark.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include <memory>
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
@@ -230,7 +232,9 @@ BENCHMARK(vectorConditional) {
   benchmark.runConditional(kIterationCount, "cardinality_v");
 }
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   LOG(ERROR) << "Seed: " << seed;
   {
     CardinalityBenchmark benchmark(seed);

--- a/velox/functions/prestosql/benchmarks/CompareBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/CompareBenchmark.cpp
@@ -179,7 +179,9 @@ BENCHMARK_MULTI(Gt_Velox) {
 } // namespace
 } // namespace facebook::velox::functions::test
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/ComparisonsBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ComparisonsBenchmark.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
@@ -106,7 +108,9 @@ BENCHMARK_RELATIVE(simd_tinyint_eq) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/ConcatBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ConcatBenchmark.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -134,7 +136,9 @@ BENCHMARK_MULTI(flattenAndConstantFold, n) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   LOG(ERROR) << "Seed: " << seed;
   {
     ConcatBenchmark benchmark(seed);

--- a/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
@@ -199,7 +199,9 @@ BENCHMARK(second) {
 }
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/InBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/InBenchmark.cpp
@@ -128,7 +128,9 @@ BENCHMARK_RELATIVE(in1K) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
@@ -441,7 +441,9 @@ BENCHMARK_MULTI(nestedMapSumVectorFunctionMapView) {
 }
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   MapInputBenchmark benchmark;
   if (benchmark.testMapSum() && benchmark.testNestedMapSum()) {
     folly::runBenchmarks();

--- a/velox/functions/prestosql/benchmarks/MapWriterBenchmarks.cpp
+++ b/velox/functions/prestosql/benchmarks/MapWriterBenchmarks.cpp
@@ -254,7 +254,9 @@ BENCHMARK(simple_general, n) {
 } // namespace
 } // namespace facebook::velox::exec
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   facebook::velox::exec::MapWriterBenchmark benchmark;
   benchmark.test();
   folly::runBenchmarks();

--- a/velox/functions/prestosql/benchmarks/NestedArrayWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/NestedArrayWriterBenchmark.cpp
@@ -193,7 +193,9 @@ BENCHMARK_MULTI(simple) {
 } // namespace
 } // namespace facebook::velox::exec
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   facebook::velox::exec::NestedArrayWriterBenchmark benchmark;
   benchmark.test();
   folly::runBenchmarks();

--- a/velox/functions/prestosql/benchmarks/NotBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/NotBenchmark.cpp
@@ -78,7 +78,9 @@ BENCHMARK_RELATIVE(vectorizedNot) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/Row.cpp
+++ b/velox/functions/prestosql/benchmarks/Row.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include "velox/functions/Macros.h"
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
@@ -70,7 +72,9 @@ BENCHMARK(copyMostlyConst) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/RowWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/RowWriterBenchmark.cpp
@@ -219,7 +219,9 @@ BENCHMARK_MULTI(complex_row) {
 } // namespace
 } // namespace facebook::velox::exec
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   facebook::velox::exec::RowWriterBenchmark benchmark;
   benchmark.test();
   folly::runBenchmarks();

--- a/velox/functions/prestosql/benchmarks/StringAsciiUTFFunctionBenchmarks.cpp
+++ b/velox/functions/prestosql/benchmarks/StringAsciiUTFFunctionBenchmarks.cpp
@@ -184,7 +184,9 @@ BENCHMARK_RELATIVE(aciiRPad) {
 // utfUpper                                                    67.75ms    14.76
 // asciiUpper                                        98.22%    68.98ms    14.50
 //============================================================================
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/StringWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/StringWriterBenchmark.cpp
@@ -177,7 +177,9 @@ BENCHMARK_MULTI(array_of_string) {
 } // namespace
 } // namespace facebook::velox::exec
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   facebook::velox::exec::StringWriterBenchmark benchmark;
   benchmark.test();
   folly::runBenchmarks();

--- a/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
@@ -296,7 +296,9 @@ BENCHMARK_RELATIVE(velox_param) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/WidthBucketBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/WidthBucketBenchmark.cpp
@@ -110,7 +110,9 @@ BENCHMARK_RELATIVE(widthBucket) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/ZipBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ZipBenchmark.cpp
@@ -110,7 +110,9 @@ BENCHMARK_MULTI(NeqSizeFlatFlat) {
 } // namespace
 } // namespace facebook::velox::functions::test
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/ZipWithBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ZipWithBenchmark.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -133,7 +135,9 @@ BENCHMARK_MULTI(fast, n) {
 
 } // namespace
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   LOG(ERROR) << "Seed: " << seed;
   {
     ZipWithBenchmark benchmark(seed);

--- a/velox/type/tests/NegatedBigintRangeBenchmark.cpp
+++ b/velox/type/tests/NegatedBigintRangeBenchmark.cpp
@@ -118,6 +118,7 @@ DEFINE_RANGE_BENCHMARKS(9000)
 DEFINE_RANGE_BENCHMARKS(9900)
 
 int32_t main(int32_t argc, char* argv[]) {
+  folly::init(&argc, &argv);
   constexpr int32_t kNumValues = 1000000;
   constexpr int64_t distinctVals = 20001; // -10000 to 10000
   const std::vector<int64_t> pctZeros = {0, 1, 5, 10, 50, 90, 95, 99, 100};

--- a/velox/type/tests/NegatedBytesRangeBenchmark.cpp
+++ b/velox/type/tests/NegatedBytesRangeBenchmark.cpp
@@ -128,7 +128,8 @@ DEFINE_BENCHMARKS(100, 90)
 DEFINE_BENCHMARKS(100, 94)
 DEFINE_BENCHMARKS(100, 98)
 
-int32_t main(int32_t /* argc unused */, char** /* argv unused */) {
+int32_t main(int32_t argc, char** argv) {
+  folly::init(&argc, &argv);
   constexpr int32_t kNumValues = 1000000;
   constexpr int32_t kStringPoolSize = 20000;
   const std::vector<int32_t> stringLengths = {2, 3, 5, 10, 100};

--- a/velox/type/tests/NegatedBytesValuesBenchmark.cpp
+++ b/velox/type/tests/NegatedBytesValuesBenchmark.cpp
@@ -121,6 +121,7 @@ DEFINE_BENCHMARKS(100, 1000)
 DEFINE_BENCHMARKS(100, 10000)
 
 int32_t main(int32_t argc, char* argv[]) {
+  folly::init(&argc, &argv);
   constexpr int32_t k_num_values = 1000000;
   constexpr int32_t k_string_pool_size = 20000;
   const std::vector<int32_t> string_lengths = {1, 2, 5, 10, 100};

--- a/velox/vector/benchmarks/CopyBenchmark.cpp
+++ b/velox/vector/benchmarks/CopyBenchmark.cpp
@@ -338,7 +338,9 @@ BENCHMARK_MULTI(copyMapTwoAtATime) {
 } // namespace
 } // namespace facebook::velox
 
-int main(int /*argc*/, char** /*argv*/) {
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
   folly::runBenchmarks();
   return 0;
 }


### PR DESCRIPTION
Summary:
Manually add `folly::init` to files the prior sed didn't fix via:
```
~/directories/velox
? find . -type f -exec grep -q "folly/Benchmark.h" {} ';' ! -exec grep -q "folly::init" {} ';' -print | xargs your-editor-of-choice
# manual copy paste magic
# run linter to clean up copy paste magic
```

Differential Revision: D40170467

