### PR TITLE
Move velox/dwio/dwrf/common/Range class into velox/dwio/common

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(
   IoStatistics.cpp
   MemoryInputStream.cpp
   Options.cpp
+  Range.cpp
   ReaderFactory.cpp
   ScanSpec.cpp
   ColumnLoader.cpp

--- a/velox/dwio/common/Range.cpp
+++ b/velox/dwio/common/Range.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/dwrf/common/Range.h"
+#include "velox/dwio/common/Range.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::common {
 
 Ranges Ranges::filter(std::function<bool(size_t)> func) const {
   Ranges ret;
@@ -43,4 +43,4 @@ Ranges Ranges::filter(std::function<bool(size_t)> func) const {
   return ret;
 }
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::common

--- a/velox/dwio/common/Range.h
+++ b/velox/dwio/common/Range.h
@@ -19,7 +19,7 @@
 #include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/common/exception/Exception.h"
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::common {
 
 /** Utility class to represent ranges of input used by DWRF writer.
 This class does not dedepe overlapping ranges because for encoded input, the
@@ -124,4 +124,4 @@ class Ranges {
   VELOX_FRIEND_TEST(RangeTests, Filter);
 };
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::common

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   DataBufferTests.cpp
   DecoderUtilTest.cpp
   LoggedExceptionTest.cpp
+  RangeTests.cpp
   RetryTests.cpp
   TestBufferedInput.cpp
   TestColumnSelector.cpp

--- a/velox/dwio/common/tests/RangeTests.cpp
+++ b/velox/dwio/common/tests/RangeTests.cpp
@@ -16,12 +16,12 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "velox/dwio/dwrf/common/Range.h"
+#include "velox/dwio/common/Range.h"
 
 using namespace ::testing;
 using namespace facebook::velox::dwio::common;
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::common {
 
 TEST(RangeTests, Add) {
   Ranges ranges;
@@ -92,4 +92,4 @@ TEST(RangeTests, Filter) {
           std::tuple<size_t, size_t>{26, 30}));
 }
 
-} // namespace facebook::velox::dwrf
+} // namespace facebook::velox::common

--- a/velox/dwio/dwrf/common/ByteRLE.cpp
+++ b/velox/dwio/dwrf/common/ByteRLE.cpp
@@ -32,17 +32,19 @@ class ByteRleEncoderImpl : public ByteRleEncoder {
         bufferLength{0},
         buffer{nullptr} {}
 
-  uint64_t add(const char* data, const Ranges& ranges, const uint64_t* nulls)
-      override;
+  uint64_t add(
+      const char* data,
+      const common::Ranges& ranges,
+      const uint64_t* nulls) override;
 
   uint64_t add(
       const std::function<char(vector_size_t)>& valueAt,
-      const Ranges& ranges,
+      const common::Ranges& ranges,
       const std::function<bool(vector_size_t)>& isNullAt) override;
 
   uint64_t addBits(
       const uint64_t* data,
-      const Ranges& ranges,
+      const common::Ranges& ranges,
       const uint64_t* nulls,
       bool invert) override {
     throw std::runtime_error("addBits is only for bool stream");
@@ -50,7 +52,7 @@ class ByteRleEncoderImpl : public ByteRleEncoder {
 
   uint64_t addBits(
       const std::function<bool(vector_size_t)>& isNullAt,
-      const Ranges& ranges,
+      const common::Ranges& ranges,
       const std::function<bool(vector_size_t)>& valueAt,
       bool invert) override {
     throw std::runtime_error("addBits is only for bool stream");
@@ -94,7 +96,7 @@ void ByteRleEncoderImpl::writeByte(char c) {
 
 uint64_t ByteRleEncoderImpl::add(
     const char* data,
-    const Ranges& ranges,
+    const common::Ranges& ranges,
     const uint64_t* nulls) {
   uint64_t count = 0;
   if (nulls) {
@@ -115,7 +117,7 @@ uint64_t ByteRleEncoderImpl::add(
 
 uint64_t ByteRleEncoderImpl::add(
     const std::function<char(vector_size_t)>& valueAt,
-    const Ranges& ranges,
+    const common::Ranges& ranges,
     const std::function<bool(vector_size_t)>& isNullAt) {
   uint64_t count = 0;
   if (isNullAt) {
@@ -214,18 +216,20 @@ class BooleanRleEncoderImpl : public ByteRleEncoderImpl {
   explicit BooleanRleEncoderImpl(std::unique_ptr<BufferedOutputStream> output)
       : ByteRleEncoderImpl{std::move(output)}, bitsRemained{8}, current{0} {}
 
-  uint64_t add(const char* data, const Ranges& ranges, const uint64_t* nulls)
-      override;
+  uint64_t add(
+      const char* data,
+      const common::Ranges& ranges,
+      const uint64_t* nulls) override;
 
   uint64_t addBits(
       const uint64_t* data,
-      const Ranges& ranges,
+      const common::Ranges& ranges,
       const uint64_t* nulls,
       bool invert) override;
 
   uint64_t addBits(
       const std::function<bool(vector_size_t)>& isNullAt,
-      const Ranges& ranges,
+      const common::Ranges& ranges,
       const std::function<bool(vector_size_t)>& valueAt,
       bool invert) override;
 
@@ -263,7 +267,7 @@ class BooleanRleEncoderImpl : public ByteRleEncoderImpl {
 
 uint64_t BooleanRleEncoderImpl::add(
     const char* data,
-    const Ranges& ranges,
+    const common::Ranges& ranges,
     const uint64_t* nulls) {
   uint64_t count = 0;
   if (nulls) {
@@ -284,7 +288,7 @@ uint64_t BooleanRleEncoderImpl::add(
 
 uint64_t BooleanRleEncoderImpl::addBits(
     const uint64_t* data,
-    const Ranges& ranges,
+    const common::Ranges& ranges,
     const uint64_t* nulls,
     bool invert) {
   uint64_t count = 0;
@@ -308,7 +312,7 @@ uint64_t BooleanRleEncoderImpl::addBits(
 
 uint64_t BooleanRleEncoderImpl::addBits(
     const std::function<bool(vector_size_t)>& valueAt,
-    const Ranges& ranges,
+    const common::Ranges& ranges,
     const std::function<bool(vector_size_t)>& isNullAt,
     bool invert) {
   uint64_t count = 0;

--- a/velox/dwio/dwrf/common/ByteRLE.h
+++ b/velox/dwio/dwrf/common/ByteRLE.h
@@ -20,10 +20,10 @@
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Nulls.h"
 #include "velox/dwio/common/IntCodecCommon.h"
+#include "velox/dwio/common/Range.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/common/OutputStream.h"
-#include "velox/dwio/dwrf/common/Range.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/vector/TypeAliases.h"
 
@@ -40,12 +40,14 @@ class ByteRleEncoder {
    * @param nulls If the pointer is null, all values are added. If the
    *    pointer is not null, positions that are true are skipped.
    */
-  virtual uint64_t
-  add(const char* data, const Ranges& ranges, const uint64_t* nulls) = 0;
+  virtual uint64_t add(
+      const char* data,
+      const common::Ranges& ranges,
+      const uint64_t* nulls) = 0;
 
   virtual uint64_t add(
       const std::function<char(vector_size_t)>& valueAt,
-      const Ranges& ranges,
+      const common::Ranges& ranges,
       const std::function<bool(vector_size_t)>& isNullAt) = 0;
 
   /**
@@ -58,13 +60,13 @@ class ByteRleEncoder {
    */
   virtual uint64_t addBits(
       const uint64_t* data,
-      const Ranges& ranges,
+      const common::Ranges& ranges,
       const uint64_t* nulls,
       bool invert) = 0;
 
   virtual uint64_t addBits(
       const std::function<bool(vector_size_t)>& valueAt,
-      const Ranges& ranges,
+      const common::Ranges& ranges,
       const std::function<bool(vector_size_t)>& isNullAt,
       bool invert) = 0;
 

--- a/velox/dwio/dwrf/common/CMakeLists.txt
+++ b/velox/dwio/dwrf/common/CMakeLists.txt
@@ -29,7 +29,6 @@ add_library(
   PagedOutputStream.cpp
   RLEv1.cpp
   RLEv2.cpp
-  Range.cpp
   Statistics.cpp
   wrap/dwrf-proto-wrapper.cpp
   wrap/orc-proto-wrapper.cpp)

--- a/velox/dwio/dwrf/common/IntEncoder.h
+++ b/velox/dwio/dwrf/common/IntEncoder.h
@@ -22,9 +22,9 @@
 #include "velox/common/base/Nulls.h"
 #include "velox/common/encode/Coding.h"
 #include "velox/dwio/common/IntCodecCommon.h"
+#include "velox/dwio/common/Range.h"
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/common/OutputStream.h"
-#include "velox/dwio/dwrf/common/Range.h"
 
 namespace facebook::velox::dwrf {
 
@@ -51,8 +51,10 @@ class IntEncoder {
    * @param nulls If the pointer is null, all values are read. If the
    *    pointer is not null, positions that are true are skipped.
    */
-  virtual uint64_t
-  add(const int64_t* data, const Ranges& ranges, const uint64_t* nulls) {
+  virtual uint64_t add(
+      const int64_t* data,
+      const common::Ranges& ranges,
+      const uint64_t* nulls) {
     return addImpl(data, ranges, nulls);
   }
 
@@ -61,23 +63,31 @@ class IntEncoder {
   // but may contain both unsigned (for dictionary offsets) and signed (for
   // original values), having both interfaces allows us to avoid casting signed
   // to unsigned then to int64_t.
-  virtual uint64_t
-  add(const int32_t* data, const Ranges& ranges, const uint64_t* nulls) {
+  virtual uint64_t add(
+      const int32_t* data,
+      const common::Ranges& ranges,
+      const uint64_t* nulls) {
     return addImpl(data, ranges, nulls);
   }
 
-  virtual uint64_t
-  add(const uint32_t* data, const Ranges& ranges, const uint64_t* nulls) {
+  virtual uint64_t add(
+      const uint32_t* data,
+      const common::Ranges& ranges,
+      const uint64_t* nulls) {
     return addImpl(data, ranges, nulls);
   }
 
-  virtual uint64_t
-  add(const int16_t* data, const Ranges& ranges, const uint64_t* nulls) {
+  virtual uint64_t add(
+      const int16_t* data,
+      const common::Ranges& ranges,
+      const uint64_t* nulls) {
     return addImpl(data, ranges, nulls);
   }
 
-  virtual uint64_t
-  add(const uint16_t* data, const Ranges& ranges, const uint64_t* nulls) {
+  virtual uint64_t add(
+      const uint16_t* data,
+      const common::Ranges& ranges,
+      const uint64_t* nulls) {
     return addImpl(data, ranges, nulls);
   }
 
@@ -169,7 +179,8 @@ class IntEncoder {
 
  private:
   template <typename T>
-  uint64_t addImpl(const T* data, const Ranges& ranges, const uint64_t* nulls);
+  uint64_t
+  addImpl(const T* data, const common::Ranges& ranges, const uint64_t* nulls);
 
   FOLLY_ALWAYS_INLINE void writeBuffer(char* start, char* end) {
     int32_t valsToWrite = end - start;
@@ -238,7 +249,7 @@ template <bool isSigned>
 template <typename T>
 uint64_t IntEncoder<isSigned>::addImpl(
     const T* data,
-    const Ranges& ranges,
+    const common::Ranges& ranges,
     const uint64_t* nulls) {
   if (!useVInts_) {
     WRITE_INTS(writeLongLE);

--- a/velox/dwio/dwrf/common/RLEv1.h
+++ b/velox/dwio/dwrf/common/RLEv1.h
@@ -44,31 +44,37 @@ class RleEncoderV1 : public IntEncoder<isSigned> {
   // For 64 bit Integers, only signed type is supported. writeVuLong only
   // supports int64_t and it needs to support uint64_t before this method
   // can support uint64_t overload.
-  uint64_t add(const int64_t* data, const Ranges& ranges, const uint64_t* nulls)
-      override {
+  uint64_t add(
+      const int64_t* data,
+      const common::Ranges& ranges,
+      const uint64_t* nulls) override {
     return addImpl(data, ranges, nulls);
   }
 
-  uint64_t add(const int32_t* data, const Ranges& ranges, const uint64_t* nulls)
-      override {
+  uint64_t add(
+      const int32_t* data,
+      const common::Ranges& ranges,
+      const uint64_t* nulls) override {
     return addImpl(data, ranges, nulls);
   }
 
   uint64_t add(
       const uint32_t* data,
-      const Ranges& ranges,
+      const common::Ranges& ranges,
       const uint64_t* nulls) override {
     return addImpl(data, ranges, nulls);
   }
 
-  uint64_t add(const int16_t* data, const Ranges& ranges, const uint64_t* nulls)
-      override {
+  uint64_t add(
+      const int16_t* data,
+      const common::Ranges& ranges,
+      const uint64_t* nulls) override {
     return addImpl(data, ranges, nulls);
   }
 
   uint64_t add(
       const uint16_t* data,
-      const Ranges& ranges,
+      const common::Ranges& ranges,
       const uint64_t* nulls) override {
     return addImpl(data, ranges, nulls);
   }
@@ -152,7 +158,8 @@ class RleEncoderV1 : public IntEncoder<isSigned> {
   void writeValues();
 
   template <typename T>
-  uint64_t addImpl(const T* data, const Ranges& ranges, const uint64_t* nulls);
+  uint64_t
+  addImpl(const T* data, const common::Ranges& ranges, const uint64_t* nulls);
 
   template <typename Integer>
   FOLLY_ALWAYS_INLINE bool isRunRepeating(const Integer& value) {
@@ -206,7 +213,7 @@ template <bool isSigned>
 template <typename T>
 uint64_t RleEncoderV1<isSigned>::addImpl(
     const T* data,
-    const Ranges& ranges,
+    const common::Ranges& ranges,
     const uint64_t* nulls) {
   uint64_t count = 0;
   if (nulls) {

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -203,12 +203,6 @@ target_link_libraries(
   velox_dwio_dwrf_data_buffer_holder_test ${VELOX_LINK_LIBS}
   ${DOUBLE_CONVERSION} ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
 
-add_executable(velox_dwio_dwrf_range_test RangeTests.cpp)
-add_test(velox_dwio_dwrf_range_test velox_dwio_dwrf_range_test)
-
-target_link_libraries(velox_dwio_dwrf_range_test ${VELOX_LINK_LIBS}
-                      ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
-
 add_executable(velox_dwio_dwrf_layout_planner_test LayoutPlannerTests.cpp)
 add_test(velox_dwio_dwrf_layout_planner_test
          velox_dwio_dwrf_layout_planner_test)

--- a/velox/dwio/dwrf/test/ColumnWriterIndexTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterIndexTests.cpp
@@ -329,7 +329,7 @@ class WriterEncodingIndexTest2 {
     // Indices are captured the same way for all stripes in the derived tests.
     for (size_t j = 0; j != stripeCount; ++j) {
       for (size_t i = 0; i != pageCount; ++i) {
-        columnWriter->write(batch, Ranges::of(0, 1000));
+        columnWriter->write(batch, common::Ranges::of(0, 1000));
         for (auto n = 0; n < mocks.size(); ++n) {
           EXPECT_CALL(*mocks.at(n), addEntry(_))
               .WillOnce(Invoke([&, k = n](const StatisticsBuilder& builder) {
@@ -733,7 +733,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
               break;
             }
           }
-          columnWriter->write(batch, Ranges::of(0, 1000));
+          columnWriter->write(batch, common::Ranges::of(0, 1000));
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
               .WillOnce(Invoke([&](const StatisticsBuilder& builder) {
                 auto stats = builder.build();
@@ -748,7 +748,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
 
         // The rest of the strides are all written directly in direct encoding.
         for (size_t i = currentPage + 1; i < pageCount; ++i) {
-          columnWriter->write(batch, Ranges::of(0, 1000));
+          columnWriter->write(batch, common::Ranges::of(0, 1000));
           if (abandonDict_) {
             if (callAbandonDict(j, i)) {
               // These calls should essentially be no-ops.
@@ -786,7 +786,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
             });
       } else {
         for (size_t i = 0; i != pageCount; ++i) {
-          columnWriter->write(batch, Ranges::of(0, 1000));
+          columnWriter->write(batch, common::Ranges::of(0, 1000));
           if (abandonDict_) {
             if (callAbandonDict(j, i)) {
               // These calls should essentially be no-ops.
@@ -900,7 +900,7 @@ class StringColumnWriterDictionaryEncodingIndexTest : public testing::Test {
     // encoding.
     for (size_t j = 0; j != stripeCount; ++j) {
       for (size_t i = 0; i != pageCount; ++i) {
-        columnWriter->write(batch, Ranges::of(0, 1000));
+        columnWriter->write(batch, common::Ranges::of(0, 1000));
         EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
             .WillOnce(Invoke([&](const StatisticsBuilder& builder) {
               auto stats = builder.build();
@@ -1022,7 +1022,7 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
               break;
             }
           }
-          columnWriter->write(batch, Ranges::of(0, 1000));
+          columnWriter->write(batch, common::Ranges::of(0, 1000));
           EXPECT_CALL(*mockIndexBuilderPtr, addEntry(_))
               .WillOnce(Invoke([&](const StatisticsBuilder& builder) {
                 auto stats = builder.build();
@@ -1037,7 +1037,7 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
 
         // The rest of the strides are all written directly in direct encoding.
         for (size_t i = currentPage + 1; i < pageCount; ++i) {
-          columnWriter->write(batch, Ranges::of(0, 1000));
+          columnWriter->write(batch, common::Ranges::of(0, 1000));
           if (abandonDict_) {
             if (callAbandonDict(j, i)) {
               // These calls should essentially be no-ops.
@@ -1075,7 +1075,7 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
             });
       } else {
         for (size_t i = 0; i != pageCount; ++i) {
-          columnWriter->write(batch, Ranges::of(0, 1000));
+          columnWriter->write(batch, common::Ranges::of(0, 1000));
           if (abandonDict_) {
             if (callAbandonDict(j, i)) {
               // These calls should essentially be no-ops.

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -323,7 +323,7 @@ void testDataTypeWriter(
   for (auto stripeI = 0; stripeI < stripeCount; ++stripeI) {
     proto::StripeFooter sf;
     for (auto strideI = 0; strideI < strideCount; ++strideI) {
-      writer->write(batch, Ranges::of(0, size));
+      writer->write(batch, common::Ranges::of(0, size));
       writer->createIndexEntry();
     }
     writer->flush([&sf](uint32_t /* unused */) -> proto::ColumnEncoding& {
@@ -911,7 +911,7 @@ void testMapWriter(
           toWrite = wrapInDictionary(toWrite, strideI, pool);
         }
       }
-      writer->write(toWrite, Ranges::of(0, toWrite->size()));
+      writer->write(toWrite, common::Ranges::of(0, toWrite->size()));
       writer->createIndexEntry();
       writtenBatches.push_back(toWrite);
     }
@@ -1044,7 +1044,7 @@ void testMapWriterRow(
     if (testEncoded) {
       toWrite = wrapInDictionaryRow(toWrite, pool);
     }
-    writer->write(toWrite, Ranges::of(0, toWrite->size()));
+    writer->write(toWrite, common::Ranges::of(0, toWrite->size()));
     writer->createIndexEntry();
     writtenBatches.push_back(toWrite);
 
@@ -1995,7 +1995,7 @@ struct IntegerColumnWriterTypedTestCase {
     for (size_t i = 0; i != flushCount; ++i) {
       proto::StripeFooter stripeFooter;
       for (size_t j = 0; j != repetitionCount; ++j) {
-        columnWriter->write(batch, Ranges::of(0, batch->size()));
+        columnWriter->write(batch, common::Ranges::of(0, batch->size()));
         postProcess(*columnWriter, i, j);
         columnWriter->createIndexEntry();
       }
@@ -3227,7 +3227,7 @@ struct StringColumnWriterTestCase {
       // Write Stride
       for (size_t j = 0; j != repetitionCount; ++j) {
         // TODO: break the batch into multiple strides.
-        columnWriter->write(batches[j], Ranges::of(0, size));
+        columnWriter->write(batches[j], common::Ranges::of(0, size));
         postProcess(*columnWriter, i, j);
         columnWriter->createIndexEntry();
       }
@@ -4057,7 +4057,7 @@ TEST(ColumnWriterTests, IntDictWriterDirectValueOverflow) {
   auto vector = populateBatch<int32_t>(data, &pool);
 
   auto writer = BaseColumnWriter::create(context, *typeWithId, 0);
-  writer->write(vector, Ranges::of(0, size));
+  writer->write(vector, common::Ranges::of(0, size));
   writer->createIndexEntry();
   proto::StripeFooter sf;
   writer->flush([&sf](auto /* unused */) -> proto::ColumnEncoding& {
@@ -4103,7 +4103,7 @@ TEST(ColumnWriterTests, ShortDictWriterDictValueOverflow) {
   auto vector = populateBatch<int16_t>(data, &pool);
 
   auto writer = BaseColumnWriter::create(context, *typeWithId, 0);
-  writer->write(vector, Ranges::of(0, size));
+  writer->write(vector, common::Ranges::of(0, size));
   writer->createIndexEntry();
   proto::StripeFooter sf;
   writer->flush([&sf](auto /* unused */) -> proto::ColumnEncoding& {
@@ -4145,7 +4145,7 @@ TEST(ColumnWriterTests, RemovePresentStream) {
   // write
   auto writer = BaseColumnWriter::create(context, *typeWithId, 0);
 
-  writer->write(vector, Ranges::of(0, size));
+  writer->write(vector, common::Ranges::of(0, size));
   writer->createIndexEntry();
   proto::StripeFooter sf;
   writer->flush([&sf](auto /* unused */) -> proto::ColumnEncoding& {
@@ -4183,7 +4183,7 @@ TEST(ColumnWriterTests, ColumnIdInStream) {
   // write
   auto writer = BaseColumnWriter::create(context, *typeWithId, 0);
 
-  writer->write(vector, Ranges::of(0, size));
+  writer->write(vector, common::Ranges::of(0, size));
   writer->createIndexEntry();
   proto::StripeFooter sf;
   writer->flush([&sf](auto /* unused */) -> proto::ColumnEncoding& {
@@ -4310,7 +4310,7 @@ struct DictColumnWriterTestCase {
     if (writeDirect_) {
       writer->tryAbandonDictionaries(true);
     }
-    writer->write(batch, Ranges::of(0, batch->size()));
+    writer->write(batch, common::Ranges::of(0, batch->size()));
     writer->createIndexEntry();
 
     proto::StripeFooter sf;

--- a/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
+++ b/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
@@ -81,7 +81,7 @@ void FloatColumnWriterBenchmarkbase() {
     WriterContext context{config, memory::getDefaultScopedMemoryPool()};
     auto writer = BaseColumnWriter::create(context, *typeWithId, 0);
     braces.dismiss();
-    writer->write(vector, Ranges::of(0, size));
+    writer->write(vector, common::Ranges::of(0, size));
   }
 }
 

--- a/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
+++ b/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
@@ -18,10 +18,10 @@
 #include <folly/Varint.h>
 #include <folly/init/Init.h>
 #include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/Range.h"
 #include "velox/dwio/dwrf/common/DataBufferHolder.h"
 #include "velox/dwio/dwrf/common/EncoderUtil.h"
 #include "velox/dwio/dwrf/common/IntEncoder.h"
-#include "velox/dwio/dwrf/common/Range.h"
 
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox;
@@ -58,7 +58,7 @@ static size_t generateAutoId2(int64_t startId, int64_t count) {
     for (int64_t i = 0; i < bufCount; ++i) {
       buffer[i] = currentId++;
     }
-    encoder->add(buffer, Ranges::of(0, bufCount), nullptr);
+    encoder->add(buffer, common::Ranges::of(0, bufCount), nullptr);
     countRemaining -= bufCount;
   }
   return encoder->flush();

--- a/velox/dwio/dwrf/test/TestByteRLEEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestByteRLEEncoder.cpp
@@ -124,7 +124,7 @@ TEST(ByteRleEncoder, random_chars) {
 
   char* data = new char[102400];
   generateData(102400, data);
-  encoder->add(data, Ranges::of(0, 102400), nullptr);
+  encoder->add(data, common::Ranges::of(0, 102400), nullptr);
   encoder->flush();
 
   decodeAndVerify(memSink, data, 102400, nullptr);
@@ -146,7 +146,7 @@ TEST(ByteRleEncoder, random_chars_with_null) {
   uint64_t* nulls = new uint64_t[1600];
   char* data = new char[102400];
   generateData(102400, data, 377, nulls);
-  encoder->add(data, Ranges::of(0, 102400), nulls);
+  encoder->add(data, common::Ranges::of(0, 102400), nulls);
   encoder->flush();
 
   decodeAndVerify(memSink, data, 102400, nulls);
@@ -168,7 +168,7 @@ TEST(BooleanRleEncoder, random_bits_not_aligned) {
 
   char* data = new char[1779];
   generateBoolData(1779, data);
-  encoder->add(data, Ranges::of(0, 1779), nullptr);
+  encoder->add(data, common::Ranges::of(0, 1779), nullptr);
   encoder->flush();
 
   decodeAndVerifyBoolean(memSink, data, 1779, nullptr);
@@ -189,7 +189,7 @@ TEST(BooleanRleEncoder, random_bits_aligned) {
 
   char* data = new char[8000];
   generateBoolData(8000, data);
-  encoder->add(data, Ranges::of(0, 8000), nullptr);
+  encoder->add(data, common::Ranges::of(0, 8000), nullptr);
   encoder->flush();
 
   decodeAndVerifyBoolean(memSink, data, 8000, nullptr);
@@ -211,7 +211,7 @@ TEST(BooleanRleEncoder, random_bits_aligned_with_null) {
   uint64_t* nulls = new uint64_t[125];
   char* data = new char[8000];
   generateBoolData(8000, data, 515, nulls);
-  encoder->add(data, Ranges::of(0, 8000), nulls);
+  encoder->add(data, common::Ranges::of(0, 8000), nulls);
   encoder->flush();
 
   decodeAndVerifyBoolean(memSink, data, 8000, nulls);

--- a/velox/dwio/dwrf/test/TestIntDirect.cpp
+++ b/velox/dwio/dwrf/test/TestIntDirect.cpp
@@ -48,7 +48,7 @@ void testInts(std::function<T()> generator) {
   auto encoder =
       createDirectEncoder<isSigned>(std::move(output), vInt, sizeof(T));
 
-  encoder->add(buffer.data(), Ranges::of(0, count), nulls.data());
+  encoder->add(buffer.data(), common::Ranges::of(0, count), nulls.data());
 
   TestPositionRecorder recorder;
   recorder.addEntry();

--- a/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
+++ b/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
@@ -100,10 +100,10 @@ TEST(RleEncoderV1Test, encodeMinAndMax) {
       std::make_unique<BufferedOutputStream>(holder), true, 8);
 
   auto data = folly::make_array(INT64_MIN, INT64_MAX, INT64_MIN);
-  encoder.add(data.data(), Ranges::of(0, 2), nullptr);
+  encoder.add(data.data(), common::Ranges::of(0, 2), nullptr);
   EXPECT_TRUE(encoder.isOverflow);
 
-  encoder.add(data.data(), Ranges::of(2, 3), nullptr);
+  encoder.add(data.data(), common::Ranges::of(2, 3), nullptr);
   EXPECT_TRUE(encoder.isOverflow);
   encoder.flush();
 
@@ -122,10 +122,10 @@ TEST(RleEncoderV1Test, encodeMinAndMaxint32) {
       std::make_unique<BufferedOutputStream>(holder), true, 8);
 
   auto data = folly::make_array(INT32_MIN, INT32_MAX, INT32_MIN);
-  encoder.add(data.data(), Ranges::of(0, 2), nullptr);
+  encoder.add(data.data(), common::Ranges::of(0, 2), nullptr);
   EXPECT_FALSE(encoder.isOverflow);
 
-  encoder.add(data.data(), Ranges::of(2, 3), nullptr);
+  encoder.add(data.data(), common::Ranges::of(2, 3), nullptr);
   EXPECT_FALSE(encoder.isOverflow);
 
   encoder.flush();
@@ -146,7 +146,7 @@ TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsigned) {
 
   int64_t* data = new int64_t[1024];
   generateData(1024, 0, 1, false, data);
-  encoder.add(data, Ranges::of(0, 1024), nullptr);
+  encoder.add(data, common::Ranges::of(0, 1024), nullptr);
   encoder.flush();
 
   decodeAndVerify<false>(memSink, data, 1024, nullptr);
@@ -167,7 +167,7 @@ TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsignedNull) {
   uint64_t* nulls = new uint64_t[256];
   int64_t* data = new int64_t[1024];
   generateData(1024, 0, 1, false, data, 100, nulls);
-  encoder.add(data, Ranges::of(0, 1024), nulls);
+  encoder.add(data, common::Ranges::of(0, 1024), nulls);
   encoder.flush();
 
   decodeAndVerify<false>(memSink, data, 1024, nulls);
@@ -188,7 +188,7 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceUnsigned) {
 
   int64_t* data = new int64_t[1024];
   generateData(1024, 5000, -3, false, data);
-  encoder.add(data, Ranges::of(0, 1024), nullptr);
+  encoder.add(data, common::Ranges::of(0, 1024), nullptr);
   encoder.flush();
 
   decodeAndVerify<false>(memSink, data, 1024, nullptr);
@@ -208,7 +208,7 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceSigned) {
 
   int64_t* data = new int64_t[1024];
   generateData(1024, 100, -3, false, data);
-  encoder.add(data, Ranges::of(0, 1024), nullptr);
+  encoder.add(data, common::Ranges::of(0, 1024), nullptr);
   encoder.flush();
 
   decodeAndVerify<true>(memSink, data, 1024, nullptr);
@@ -229,7 +229,7 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceSignedNull) {
   uint64_t* nulls = new uint64_t[256];
   int64_t* data = new int64_t[1024];
   generateData(1024, 100, -3, false, data, 500, nulls);
-  encoder.add(data, Ranges::of(0, 1024), nulls);
+  encoder.add(data, common::Ranges::of(0, 1024), nulls);
   encoder.flush();
 
   decodeAndVerify<true>(memSink, data, 1024, nulls);
@@ -250,7 +250,7 @@ TEST(RleEncoderV1Test, randomSequanceSigned) {
 
   int64_t* data = new int64_t[1024];
   generateData(1024, 0, 0, true, data);
-  encoder.add(data, Ranges::of(0, 1024), nullptr);
+  encoder.add(data, common::Ranges::of(0, 1024), nullptr);
   encoder.flush();
 
   decodeAndVerify<true>(memSink, data, 1024, nullptr);
@@ -271,7 +271,7 @@ TEST(RleEncoderV1Test, allNull) {
   uint64_t* nulls = new uint64_t[256];
   int64_t* data = new int64_t[1024];
   generateData(1024, 100, -3, false, data, 1024, nulls);
-  encoder.add(data, Ranges::of(0, 1024), nulls);
+  encoder.add(data, common::Ranges::of(0, 1024), nulls);
   encoder.flush();
 
   decodeAndVerify<true>(memSink, data, 1024, nulls);
@@ -293,7 +293,7 @@ TEST(RleEncoderV1Test, recordPosition) {
   constexpr size_t size = 256;
   std::array<int64_t, size> data;
   generateData(size, 100, 1, false, data.data());
-  encoder.add(data.data(), Ranges::of(0, size), nullptr);
+  encoder.add(data.data(), common::Ranges::of(0, size), nullptr);
 
   TestPositionRecorder recorder;
   encoder.recordPosition(recorder);
@@ -316,7 +316,7 @@ TEST(RleEncoderV1Test, backfillPosition) {
   constexpr size_t size = 256;
   std::array<int64_t, size> data;
   generateData(size, 100, 1, false, data.data());
-  encoder.add(data.data(), Ranges::of(0, size), nullptr);
+  encoder.add(data.data(), common::Ranges::of(0, size), nullptr);
 
   TestPositionRecorder recorder;
   encoder.recordPosition(recorder);
@@ -334,7 +334,7 @@ TEST(RleEncoderV1Test, backfillPosition) {
   }
   std::array<int64_t, size * 2> moreData;
   generateData(size * 2, 200, 1, false, moreData.data());
-  encoder.add(moreData.data(), Ranges::of(0, size * 2), nullptr);
+  encoder.add(moreData.data(), common::Ranges::of(0, size * 2), nullptr);
   recorder.addEntry();
   encoder.recordPosition(recorder, 2);
   {

--- a/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
+++ b/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
@@ -73,7 +73,7 @@ TEST(TestStatisticsBuilderUtils, addIntegerValues) {
   auto vec = makeFlatVectorNoNulls<int32_t>(&pool, size, values);
   {
     StatisticsBuilderUtils::addValues<int32_t>(
-        builder, vec, Ranges::of(0, size));
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     auto intStats = dynamic_cast<IntegerColumnStatistics*>(stats.get());
     EXPECT_EQ(10, intStats->getNumberOfValues());
@@ -91,7 +91,7 @@ TEST(TestStatisticsBuilderUtils, addIntegerValues) {
 
   {
     StatisticsBuilderUtils::addValues<int32_t>(
-        builder, vec, Ranges::of(0, size));
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     auto intStats = dynamic_cast<IntegerColumnStatistics*>(stats.get());
     EXPECT_EQ(19, intStats->getNumberOfValues());
@@ -118,7 +118,8 @@ TEST(TestStatisticsBuilderUtils, addDoubleValues) {
 
   {
     auto vec = makeFlatVectorNoNulls<float>(&pool, size, values);
-    StatisticsBuilderUtils::addValues<float>(builder, vec, Ranges::of(0, size));
+    StatisticsBuilderUtils::addValues<float>(
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     auto doubleStats = dynamic_cast<DoubleColumnStatistics*>(stats.get());
     EXPECT_EQ(10, doubleStats->getNumberOfValues());
@@ -135,7 +136,8 @@ TEST(TestStatisticsBuilderUtils, addDoubleValues) {
   {
     auto vec = makeFlatVector<float>(&pool, nulls, 1, size, values);
 
-    StatisticsBuilderUtils::addValues<float>(builder, vec, Ranges::of(0, size));
+    StatisticsBuilderUtils::addValues<float>(
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     auto doubleStats = dynamic_cast<DoubleColumnStatistics*>(stats.get());
     EXPECT_EQ(19, doubleStats->getNumberOfValues());
@@ -162,7 +164,8 @@ TEST(TestStatisticsBuilderUtils, addStringValues) {
 
   {
     auto vec = makeFlatVectorNoNulls<StringView>(&pool, size, values);
-    StatisticsBuilderUtils::addValues(builder, vec, Ranges::of(0, size));
+    StatisticsBuilderUtils::addValues(
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     auto strStats = dynamic_cast<StringColumnStatistics*>(stats.get());
     EXPECT_EQ(10, strStats->getNumberOfValues());
@@ -178,7 +181,8 @@ TEST(TestStatisticsBuilderUtils, addStringValues) {
 
   {
     auto vec = makeFlatVector<StringView>(&pool, nulls, 1, size, values);
-    StatisticsBuilderUtils::addValues(builder, vec, Ranges::of(0, size));
+    StatisticsBuilderUtils::addValues(
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     auto strStats = dynamic_cast<StringColumnStatistics*>(stats.get());
     EXPECT_EQ(19, strStats->getNumberOfValues());
@@ -207,7 +211,8 @@ TEST(TestStatisticsBuilderUtils, addBooleanValues) {
   {
     auto vec = makeFlatVectorNoNulls<bool>(&pool, size, values);
 
-    StatisticsBuilderUtils::addValues(builder, vec, Ranges::of(0, size));
+    StatisticsBuilderUtils::addValues(
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     auto boolStats = dynamic_cast<BooleanColumnStatistics*>(stats.get());
     EXPECT_EQ(9, boolStats->getTrueCount().value());
@@ -222,7 +227,8 @@ TEST(TestStatisticsBuilderUtils, addBooleanValues) {
   {
     auto vec = makeFlatVector<bool>(&pool, nulls, 1, size, values);
 
-    StatisticsBuilderUtils::addValues(builder, vec, Ranges::of(0, size));
+    StatisticsBuilderUtils::addValues(
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     auto boolStats = dynamic_cast<BooleanColumnStatistics*>(stats.get());
     EXPECT_EQ(17, boolStats->getTrueCount().value());
@@ -244,7 +250,8 @@ TEST(TestStatisticsBuilderUtils, addValues) {
   {
     auto vec = makeFlatVectorNoNulls<bool>(&pool, size, values);
 
-    StatisticsBuilderUtils::addValues(builder, vec, Ranges::of(0, size));
+    StatisticsBuilderUtils::addValues(
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     EXPECT_EQ(10, stats->getNumberOfValues());
     EXPECT_FALSE(stats->hasNull().value());
@@ -257,7 +264,8 @@ TEST(TestStatisticsBuilderUtils, addValues) {
   {
     auto vec = makeFlatVector<bool>(&pool, nulls, 1, size, values);
 
-    StatisticsBuilderUtils::addValues(builder, vec, Ranges::of(0, size));
+    StatisticsBuilderUtils::addValues(
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     EXPECT_EQ(19, stats->getNumberOfValues());
     EXPECT_TRUE(stats->hasNull().value());
@@ -286,7 +294,8 @@ TEST(TestStatisticsBuilderUtils, addBinaryValues) {
   {
     auto vec = makeFlatVectorNoNulls<StringView>(&pool, size, values);
 
-    StatisticsBuilderUtils::addValues(builder, vec, Ranges::of(0, size));
+    StatisticsBuilderUtils::addValues(
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     auto binStats = dynamic_cast<BinaryColumnStatistics*>(stats.get());
     EXPECT_EQ(10, binStats->getNumberOfValues());
@@ -301,7 +310,8 @@ TEST(TestStatisticsBuilderUtils, addBinaryValues) {
   {
     auto vec = makeFlatVector<StringView>(&pool, nulls, 1, size, values);
 
-    StatisticsBuilderUtils::addValues(builder, vec, Ranges::of(0, size));
+    StatisticsBuilderUtils::addValues(
+        builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
     auto binStats = dynamic_cast<BinaryColumnStatistics*>(stats.get());
     EXPECT_EQ(19, binStats->getNumberOfValues());

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -36,7 +36,9 @@ class ColumnWriter {
  public:
   virtual ~ColumnWriter() = default;
 
-  virtual uint64_t write(const VectorPtr& slice, const Ranges& ranges) = 0;
+  virtual uint64_t write(
+      const VectorPtr& slice,
+      const common::Ranges& ranges) = 0;
 
   virtual void createIndexEntry() = 0;
 
@@ -169,7 +171,7 @@ class BaseColumnWriter : public ColumnWriter {
     fileStatsBuilder_ = StatisticsBuilder::create(*type.type, options);
   }
 
-  uint64_t writeNulls(const VectorPtr& slice, const Ranges& ranges) {
+  uint64_t writeNulls(const VectorPtr& slice, const common::Ranges& ranges) {
     if (UNLIKELY(ranges.size() == 0)) {
       return 0;
     }
@@ -183,7 +185,9 @@ class BaseColumnWriter : public ColumnWriter {
   }
 
   // Function used only for the cases dealing with Dictionary vectors
-  uint64_t writeNulls(const DecodedVector& decoded, const Ranges& ranges) {
+  uint64_t writeNulls(
+      const DecodedVector& decoded,
+      const common::Ranges& ranges) {
     if (UNLIKELY(ranges.size() == 0)) {
       return 0;
     }
@@ -248,7 +252,7 @@ class BaseColumnWriter : public ColumnWriter {
 
   WriterContext::LocalDecodedVector decode(
       const VectorPtr& slice,
-      const Ranges& ranges);
+      const common::Ranges& ranges);
 
   const dwio::common::TypeWithId& type_;
   std::vector<std::unique_ptr<BaseColumnWriter>> children_;

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
@@ -302,7 +302,8 @@ class Decoded {
 };
 
 template <typename Map, typename MapOp>
-uint64_t iterateMaps(const Ranges& ranges, const Map& map, const MapOp& mapOp) {
+uint64_t
+iterateMaps(const common::Ranges& ranges, const Map& map, const MapOp& mapOp) {
   uint64_t nullCount = 0;
   if (map.hasNulls()) {
     for (auto& index : ranges) {
@@ -325,7 +326,7 @@ uint64_t iterateMaps(const Ranges& ranges, const Map& map, const MapOp& mapOp) {
 template <TypeKind K>
 uint64_t FlatMapColumnWriter<K>::write(
     const VectorPtr& slice,
-    const Ranges& ranges) {
+    const common::Ranges& ranges) {
   switch (slice->typeKind()) {
     case TypeKind::MAP:
       return writeMap(slice, ranges);
@@ -344,13 +345,13 @@ uint64_t FlatMapColumnWriter<K>::write(
 template <TypeKind K>
 uint64_t FlatMapColumnWriter<K>::writeMap(
     const VectorPtr& slice,
-    const Ranges& ranges) {
+    const common::Ranges& ranges) {
   // Define variables captured and used by below lambdas.
   const vector_size_t* offsets;
   const vector_size_t* lengths;
   uint64_t rawSize = 0;
   uint64_t mapCount = 0;
-  Ranges keyRanges;
+  common::Ranges keyRanges;
 
   // Lambda that iterates keys of a map and records the offsets to write to
   // particular value node.
@@ -443,8 +444,8 @@ uint64_t FlatMapColumnWriter<K>::writeMap(
 }
 
 template <typename Row>
-Ranges getNonNullRanges(const Ranges& ranges, const Row& row) {
-  Ranges nonNullRanges;
+common::Ranges getNonNullRanges(const common::Ranges& ranges, const Row& row) {
+  common::Ranges nonNullRanges;
   if (row.hasNulls()) {
     for (auto& index : ranges) {
       if (!row.isNullAt(index)) {
@@ -460,9 +461,9 @@ Ranges getNonNullRanges(const Ranges& ranges, const Row& row) {
 template <TypeKind K>
 uint64_t FlatMapColumnWriter<K>::writeRow(
     const VectorPtr& slice,
-    const Ranges& ranges) {
+    const common::Ranges& ranges) {
   uint64_t rawSize = 0;
-  Ranges nonNullRanges;
+  common::Ranges nonNullRanges;
 
   const RowVector* rowSlice = slice->as<RowVector>();
   if (rowSlice) {

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
@@ -126,7 +126,8 @@ class ValueWriter {
 
   uint64_t writeBuffers(const VectorPtr& values, uint32_t mapCount) {
     if (mapCount) {
-      inMap_->add(inMapBuffer_.data(), Ranges::of(0, mapCount), nullptr);
+      inMap_->add(
+          inMapBuffer_.data(), common::Ranges::of(0, mapCount), nullptr);
     }
 
     if (values) {
@@ -138,12 +139,12 @@ class ValueWriter {
   // used for struct encoding writer
   uint64_t writeBuffers(
       const VectorPtr& values,
-      const Ranges& nonNullRanges,
+      const common::Ranges& nonNullRanges,
       const BufferPtr& inMapBuffer /* all 1 */) {
     if (nonNullRanges.size()) {
       inMap_->add(
           inMapBuffer->as<char>(),
-          Ranges::of(0, nonNullRanges.size()),
+          common::Ranges::of(0, nonNullRanges.size()),
           nullptr);
     }
 
@@ -160,7 +161,7 @@ class ValueWriter {
 
     inMapBuffer_.reserve(count);
     std::memset(inMapBuffer_.data(), 0, count);
-    inMap_->add(inMapBuffer_.data(), Ranges::of(0, count), nullptr);
+    inMap_->add(inMapBuffer_.data(), common::Ranges::of(0, count), nullptr);
   }
 
   uint32_t getSequence() const {
@@ -200,7 +201,7 @@ class ValueWriter {
   std::unique_ptr<ByteRleEncoder> inMap_;
   std::unique_ptr<BaseColumnWriter> columnWriter_;
   dwio::common::DataBuffer<char> inMapBuffer_;
-  Ranges ranges_;
+  common::Ranges ranges_;
   const bool collectMapStats_;
 };
 
@@ -249,7 +250,7 @@ class FlatMapColumnWriter : public BaseColumnWriter {
       const dwio::common::TypeWithId& type,
       const uint32_t sequence);
 
-  uint64_t write(const VectorPtr& slice, const Ranges& ranges) override;
+  uint64_t write(const VectorPtr& slice, const common::Ranges& ranges) override;
 
   void flush(
       std::function<proto::ColumnEncoding&(uint32_t)> encodingFactory,
@@ -270,8 +271,8 @@ class FlatMapColumnWriter : public BaseColumnWriter {
   ValueWriter& getValueWriter(KeyType key, uint32_t inMapSize);
 
   // write() calls writeMap() or writeRow() depending on input type
-  uint64_t writeMap(const VectorPtr& slice, const Ranges& ranges);
-  uint64_t writeRow(const VectorPtr& slice, const Ranges& ranges);
+  uint64_t writeMap(const VectorPtr& slice, const common::Ranges& ranges);
+  uint64_t writeRow(const VectorPtr& slice, const common::Ranges& ranges);
 
   void clearNodes();
 

--- a/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
+++ b/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
@@ -241,7 +241,7 @@ class IntegerDictionaryEncoder : public AbstractIntegerDictionaryEncoder {
             [dictDataWriter = dictDataWriter_.get()](
                 Integer* const buf, const uint32_t size) mutable {
               if (dictDataWriter) {
-                dictDataWriter->add(buf, Ranges::of(0, size), nullptr);
+                dictDataWriter->add(buf, common::Ranges::of(0, size), nullptr);
                 dictDataWriter->flush();
               }
             });

--- a/velox/dwio/dwrf/writer/StatisticsBuilderUtils.cpp
+++ b/velox/dwio/dwrf/writer/StatisticsBuilderUtils.cpp
@@ -21,7 +21,7 @@ namespace facebook::velox::dwrf {
 void StatisticsBuilderUtils::addValues(
     StatisticsBuilder& builder,
     const VectorPtr& vector,
-    const Ranges& ranges) {
+    const common::Ranges& ranges) {
   auto nulls = vector->rawNulls();
   if (vector->mayHaveNulls()) {
     for (auto& pos : ranges) {
@@ -39,7 +39,7 @@ void StatisticsBuilderUtils::addValues(
 void StatisticsBuilderUtils::addValues(
     BooleanStatisticsBuilder& builder,
     const VectorPtr& vector,
-    const Ranges& ranges) {
+    const common::Ranges& ranges) {
   auto nulls = vector->rawNulls();
   auto vals = vector->as<FlatVector<bool>>()->asRange();
   if (vector->mayHaveNulls()) {
@@ -60,7 +60,7 @@ void StatisticsBuilderUtils::addValues(
 void StatisticsBuilderUtils::addValues(
     BooleanStatisticsBuilder& builder,
     const DecodedVector& vector,
-    const Ranges& ranges) {
+    const common::Ranges& ranges) {
   if (vector.mayHaveNulls()) {
     for (auto& pos : ranges) {
       if (vector.isNullAt(pos)) {
@@ -79,7 +79,7 @@ void StatisticsBuilderUtils::addValues(
 void StatisticsBuilderUtils::addValues(
     StringStatisticsBuilder& builder,
     const VectorPtr& vector,
-    const Ranges& ranges) {
+    const common::Ranges& ranges) {
   auto nulls = vector->rawNulls();
   auto data = vector->asFlatVector<StringView>()->rawValues();
   if (vector->mayHaveNulls()) {
@@ -100,7 +100,7 @@ void StatisticsBuilderUtils::addValues(
 void StatisticsBuilderUtils::addValues(
     BinaryStatisticsBuilder& builder,
     const VectorPtr& vector,
-    const Ranges& ranges) {
+    const common::Ranges& ranges) {
   auto nulls = vector->rawNulls();
   auto data = vector->asFlatVector<StringView>()->rawValues();
   if (vector->mayHaveNulls()) {

--- a/velox/dwio/dwrf/writer/StatisticsBuilderUtils.h
+++ b/velox/dwio/dwrf/writer/StatisticsBuilderUtils.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "velox/dwio/dwrf/common/Range.h"
+#include "velox/dwio/common/Range.h"
 #include "velox/dwio/dwrf/writer/StatisticsBuilder.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
@@ -28,52 +28,52 @@ class StatisticsBuilderUtils {
   static void addValues(
       StatisticsBuilder& builder,
       const VectorPtr& vector,
-      const Ranges& ranges);
+      const common::Ranges& ranges);
 
   static void addValues(
       BooleanStatisticsBuilder& builder,
       const VectorPtr& vector,
-      const Ranges& ranges);
+      const common::Ranges& ranges);
 
   static void addValues(
       BooleanStatisticsBuilder& builder,
       const DecodedVector& vector,
-      const Ranges& ranges);
+      const common::Ranges& ranges);
 
   template <typename INT>
   static void addValues(
       IntegerStatisticsBuilder& builder,
       const VectorPtr& vector,
-      const Ranges& ranges);
+      const common::Ranges& ranges);
 
   template <typename INT>
   static void addValues(
       IntegerStatisticsBuilder& builder,
       const DecodedVector& vector,
-      const Ranges& ranges);
+      const common::Ranges& ranges);
 
   template <typename FLOAT>
   static void addValues(
       DoubleStatisticsBuilder& builder,
       const VectorPtr& vector,
-      const Ranges& ranges);
+      const common::Ranges& ranges);
 
   static void addValues(
       StringStatisticsBuilder& builder,
       const VectorPtr& vector,
-      const Ranges& ranges);
+      const common::Ranges& ranges);
 
   static void addValues(
       BinaryStatisticsBuilder& builder,
       const VectorPtr& vector,
-      const Ranges& ranges);
+      const common::Ranges& ranges);
 };
 
 template <typename INT>
 void StatisticsBuilderUtils::addValues(
     IntegerStatisticsBuilder& builder,
     const VectorPtr& vector,
-    const Ranges& ranges) {
+    const common::Ranges& ranges) {
   auto nulls = vector->rawNulls();
   auto vals = vector->asFlatVector<INT>()->rawValues();
   if (vector->mayHaveNulls()) {
@@ -95,7 +95,7 @@ template <typename INT>
 void StatisticsBuilderUtils::addValues(
     IntegerStatisticsBuilder& builder,
     const DecodedVector& vector,
-    const Ranges& ranges) {
+    const common::Ranges& ranges) {
   if (vector.mayHaveNulls()) {
     for (auto& pos : ranges) {
       if (vector.isNullAt(pos)) {
@@ -115,7 +115,7 @@ template <typename FLOAT>
 void StatisticsBuilderUtils::addValues(
     DoubleStatisticsBuilder& builder,
     const VectorPtr& vector,
-    const Ranges& ranges) {
+    const common::Ranges& ranges) {
   auto nulls = vector->rawNulls();
   auto vals = vector->asFlatVector<FLOAT>()->rawValues();
   if (vector->mayHaveNulls()) {

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -240,7 +240,8 @@ void Writer::write(const VectorPtr& slice) {
       }
     }
 
-    auto rawSize = writer_->write(slice, Ranges::of(offset, offset + length));
+    auto rawSize =
+        writer_->write(slice, common::Ranges::of(offset, offset + length));
     offset += length;
     getContext().incRawSize(rawSize);
 


### PR DESCRIPTION
Summary: Move `velox/dwio/dwrf/common/Range` class into `velox/dwio/common` so that it can be more readily used by classes outside of `velox/dwio/dwrf`.

Differential Revision: D40422064

