### PR TITLE
Update Conbench check to use the Checks API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ commands:
             # Calculate ccache key.
             git show -s --format=%cd --date="format:%Y%m%d" $(git merge-base origin/main HEAD) | tee merge-base-date
 
-            # Set up xml gtest output. 
+            # Set up xml gtest output.
             mkdir -p /tmp/test_xml_output/
             echo "export XML_OUTPUT_FILE=\"/tmp/test_xml_output/\"" >> $BASH_ENV
 
@@ -236,7 +236,7 @@ jobs:
             # upgrade python to 3.8 for this job
             yum install -y python38
             pip3.8 install conbench
-            pip3.8 install git+https://github.com/conbench/benchalerts.git@0.2.1
+            pip3.8 install git+https://github.com/conbench/benchalerts.git@0.3.1
             pip3.8 install scripts/veloxbench
       - run:
           name: "Run Benchmarks"

--- a/scripts/benchmark-github-status.py
+++ b/scripts/benchmark-github-status.py
@@ -16,21 +16,23 @@
 import argparse
 import os
 
-from benchalerts import update_github_status_based_on_regressions
+from benchalerts import update_github_check_based_on_regressions
 
 
 description = """
-Analyze benchmark runs and post a GitHub Status whether there was a regression or not.
+Analyze benchmark runs and post a GitHub Check whether there was a regression or not.
 
 Required environment variables:
-    GITHUB_API_TOKEN - a GitHub PAT with "repo:status" permission
+    GITHUB_APP_ID - the ID of a GitHub App installed to this repo
+    GITHUB_APP_PRIVATE_KEY - the private key file contents of the GitHub App
     CONBENCH_URL - the URL to the Conbench server where benchmark results are stored
 
-(see https://circleci.com/docs/env-vars#built-in-environment-variables for these)
+(see https://circleci.com/docs/built-in-environment-variables for these)
     CIRCLE_SHA1
     CIRCLE_PROJECT_USERNAME
     CIRCLE_PROJECT_REPONAME
     CIRCLE_BUILD_URL
+    CIRCLE_PULL_REQUEST (optional)
 """
 parser = argparse.ArgumentParser(
     description=description, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -49,10 +51,12 @@ contender_sha = os.environ["CIRCLE_SHA1"]
 org = os.environ["CIRCLE_PROJECT_USERNAME"]
 repo = os.environ["CIRCLE_PROJECT_REPONAME"]
 os.environ["BUILD_URL"] = os.environ["CIRCLE_BUILD_URL"]
+is_pull_request = bool(os.getenv("CIRCLE_PULL_REQUEST"))
 
-res = update_github_status_based_on_regressions(
+res = update_github_check_based_on_regressions(
     contender_sha=contender_sha,
     z_score_threshold=args.z_score_threshold,
+    warn_if_baseline_isnt_parent=not is_pull_request,
     repo=f"{org}/{repo}",
 )
 print(res)


### PR DESCRIPTION
This PR upgrades the `linux-benchmarks-basic` check run on every commit to use the GitHub Checks API for the `conbench` check instead of the Status API. This enables more features, including a rich Markdown report detailing what happened regarding possible benchmark regressions.