### PR TITLE
Extract expression execution code out from fuzzer for reuse

### DIFF
--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -80,10 +80,16 @@ target_link_libraries(
   glog::glog
   ${FMT})
 
+add_library(velox_expression_verifier ExpressionVerifier.cpp)
+
+target_link_libraries(velox_expression_verifier velox_vector_test_lib
+                      velox_type)
+
 add_library(velox_expression_fuzzer ExpressionFuzzer.cpp)
 
-target_link_libraries(velox_expression_fuzzer velox_type velox_vector_fuzzer
-                      velox_vector_test_lib velox_function_registry)
+target_link_libraries(
+  velox_expression_fuzzer velox_expression_verifier velox_type
+  velox_vector_fuzzer velox_vector_test_lib velox_function_registry)
 
 add_executable(velox_expression_fuzzer_unit_test ExpressionFuzzerUnitTest.cpp)
 

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -19,7 +19,6 @@
 #include <glog/logging.h>
 #include <exception>
 
-#include "velox/buffer/Buffer.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/FunctionSignature.h"
@@ -29,9 +28,7 @@
 #include "velox/expression/tests/ExpressionFuzzer.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
-#include "velox/vector/VectorSaver.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
-#include "velox/vector/tests/utils/VectorMaker.h"
 
 DEFINE_int32(steps, 10, "Number of expressions to generate and execute.");
 
@@ -91,95 +88,6 @@ namespace facebook::velox::test {
 namespace {
 
 using exec::SignatureBinder;
-
-void compareExceptions(const VeloxException& ve1, const VeloxException& ve2) {
-  // Error messages sometimes differ; check at least error codes.
-  // Since the common path may peel the input encoding off, whereas the
-  // simplified path flatten input vectors, the common and the simplified
-  // paths may evaluate the input rows in different orders and hence throw
-  // different exceptions depending on which bad input they come across
-  // first. We have seen this happen for the format_datetime Presto function
-  // that leads to unmatched error codes UNSUPPORTED vs. INVALID_ARGUMENT.
-  // Therefore, we intentionally relax the comparision here.
-  VELOX_CHECK(
-      ve1.errorCode() == ve2.errorCode() ||
-      (ve1.errorCode() == "INVALID_ARGUMENT" &&
-       ve2.errorCode() == "UNSUPPORTED") ||
-      (ve2.errorCode() == "INVALID_ARGUMENT" &&
-       ve1.errorCode() == "UNSUPPORTED"));
-  VELOX_CHECK_EQ(ve1.errorSource(), ve2.errorSource());
-  VELOX_CHECK_EQ(ve1.exceptionName(), ve2.exceptionName());
-  if (ve1.message() != ve2.message()) {
-    LOG(WARNING) << "Two different VeloxExceptions were thrown:\n\t"
-                 << ve1.message() << "\nand\n\t" << ve2.message();
-  }
-}
-
-// Called if at least one of the ptrs has an exception.
-void compareExceptions(
-    std::exception_ptr commonPtr,
-    std::exception_ptr simplifiedPtr) {
-  // If we don't have two exceptions, fail.
-  if (!commonPtr || !simplifiedPtr) {
-    if (!commonPtr) {
-      LOG(ERROR) << "Only simplified path threw exception:";
-      std::rethrow_exception(simplifiedPtr);
-    }
-    LOG(ERROR) << "Only common path threw exception:";
-    std::rethrow_exception(commonPtr);
-  }
-
-  // Otherwise, make sure the exceptions are the same.
-  try {
-    std::rethrow_exception(commonPtr);
-  } catch (const VeloxException& ve1) {
-    try {
-      std::rethrow_exception(simplifiedPtr);
-    } catch (const VeloxException& ve2) {
-      compareExceptions(ve1, ve2);
-      return;
-    } catch (const std::exception& e2) {
-      LOG(WARNING) << "Two different exceptions were thrown:\n\t"
-                   << ve1.message() << "\nand\n\t" << e2.what();
-    }
-  } catch (const std::exception& e1) {
-    try {
-      std::rethrow_exception(simplifiedPtr);
-    } catch (const std::exception& e2) {
-      if (e1.what() != e2.what()) {
-        LOG(WARNING) << "Two different std::exceptions were thrown:\n\t"
-                     << e1.what() << "\nand\n\t" << e2.what();
-      }
-      return;
-    }
-  }
-  VELOX_FAIL("Got two incompatible exceptions.");
-}
-
-void compareVectors(const VectorPtr& vec1, const VectorPtr& vec2) {
-  VELOX_CHECK_EQ(vec1->size(), vec2->size());
-
-  // Print vector contents if in verbose mode.
-  size_t vectorSize = vec1->size();
-  if (VLOG_IS_ON(1)) {
-    LOG(INFO) << "== Result contents (common vs. simple): ";
-    for (auto i = 0; i < vectorSize; i++) {
-      LOG(INFO) << "At " << i << ": [" << vec1->toString(i) << " vs "
-                << vec2->toString(i) << "]";
-    }
-    LOG(INFO) << "===================";
-  }
-
-  for (auto i = 0; i < vectorSize; i++) {
-    VELOX_CHECK(
-        vec1->equalValueAt(vec2.get(), i, i),
-        "Different results at idx '{}': '{}' vs. '{}'",
-        i,
-        vec1->toString(i),
-        vec2->toString(i));
-  }
-  LOG(INFO) << "All results match.";
-}
 
 /// Returns if `functionName` with the given `argTypes` is deterministic.
 /// Returns std::nullopt if the function was not found.
@@ -308,6 +216,9 @@ ExpressionFuzzer::ExpressionFuzzer(
     size_t initialSeed,
     int32_t maxLevelOfNesting)
     : remainingLevelOfNesting_(std::max(1, maxLevelOfNesting)),
+      verifier_(
+          &execCtx_,
+          {FLAGS_disable_constant_folding, FLAGS_repro_persist_path}),
       vectorFuzzer_(getFuzzerOptions(), execCtx_.pool()) {
   seed(initialSeed);
 
@@ -421,14 +332,6 @@ void ExpressionFuzzer::seed(size_t seed) {
 
 void ExpressionFuzzer::reSeed() {
   seed(folly::Random::rand32(rng_));
-}
-
-void ExpressionFuzzer::printRowVector(const RowVectorPtr& rowVector) {
-  LOG(INFO) << "RowVector contents (" << rowVector->type()->toString() << "):";
-
-  for (vector_size_t i = 0; i < rowVector->size(); ++i) {
-    LOG(INFO) << "\tAt " << i << ": " << rowVector->toString(i);
-  }
 }
 
 void ExpressionFuzzer::appendConjunctSignatures() {
@@ -573,177 +476,6 @@ core::TypedExprPtr ExpressionFuzzer::generateExpression(
       chosen->returnType, args, chosen->name);
 }
 
-void ExpressionFuzzer::persistReproInfo(
-    const VectorPtr& inputVector,
-    const VectorPtr& resultVector,
-    const std::string& sql) {
-  std::string inputPath;
-  std::string resultPath;
-  std::string sqlPath;
-
-  // Save input vector.
-  auto inputPathOpt =
-      generateFilePath(FLAGS_repro_persist_path.c_str(), "vector");
-  if (!inputPathOpt.has_value()) {
-    inputPath = "Failed to create file for saving input vector.";
-  } else {
-    inputPath = inputPathOpt.value();
-    try {
-      saveVectorToFile(inputVector.get(), inputPath.c_str());
-    } catch (std::exception& e) {
-      inputPath = e.what();
-    }
-  }
-
-  // Save result vector.
-  if (resultVector) {
-    auto resultPathOpt =
-        generateFilePath(FLAGS_repro_persist_path.c_str(), "vector");
-    if (!resultPathOpt.has_value()) {
-      resultPath = "Failed to create file for saving result vector.";
-    } else {
-      resultPath = resultPathOpt.value();
-      try {
-        saveVectorToFile(resultVector.get(), resultPath.c_str());
-      } catch (std::exception& e) {
-        resultPath = e.what();
-      }
-    }
-  }
-
-  // Save SQL.
-  auto sqlPathOpt = generateFilePath(FLAGS_repro_persist_path.c_str(), "sql");
-  if (!sqlPathOpt.has_value()) {
-    sqlPath = "Failed to create file for saving SQL.";
-  } else {
-    sqlPath = sqlPathOpt.value();
-    try {
-      saveStringToFile(sql, sqlPath.c_str());
-    } catch (std::exception& e) {
-      sqlPath = e.what();
-    }
-  }
-
-  std::stringstream ss;
-  ss << "Persisted input at '" << inputPath;
-  if (resultVector) {
-    ss << "' and result at '" << resultPath;
-  }
-  ss << "' and sql at '" << sqlPath << "'";
-  LOG(INFO) << ss.str();
-}
-
-// Executes an expression. Returns:
-//
-//  - true if both succeeded and returned the exact same results.
-//  - false if both failed with compatible exceptions.
-//  - throws otherwise (incompatible exceptions or different results).
-bool ExpressionFuzzer::executeExpression(
-    const core::TypedExprPtr& plan,
-    const RowVectorPtr& rowVector,
-    VectorPtr&& resultVector,
-    bool canThrow) {
-  LOG(INFO) << "Executing expression: " << plan->toString();
-
-  if (rowVector) {
-    LOG(INFO) << rowVector->childrenSize() << " vectors as input:";
-    for (const auto& child : rowVector->children()) {
-      LOG(INFO) << "\t" << child->toString(/*recursive=*/true);
-    }
-
-    if (VLOG_IS_ON(1)) {
-      printRowVector(rowVector);
-    }
-  }
-
-  // Store data and expression for reproduction.
-  VectorPtr copiedResult;
-  std::string sql;
-  // Deep copy to preserve the initial state of result vector.
-  if (!FLAGS_repro_persist_path.empty()) {
-    if (resultVector) {
-      copiedResult = BaseVector::copy(*resultVector);
-    }
-    std::vector<core::TypedExprPtr> typedExprs = {plan};
-    // Disable constant folding in order to preserve the original expression
-    sql =
-        exec::ExprSet(std::move(typedExprs), &execCtx_, false).expr(0)->toSql();
-  }
-
-  // Execute expression plan using both common and simplified evals.
-  std::vector<VectorPtr> commonEvalResult(1);
-  std::vector<VectorPtr> simplifiedEvalResult(1);
-
-  commonEvalResult[0] = resultVector;
-
-  std::exception_ptr exceptionCommonPtr;
-  std::exception_ptr exceptionSimplifiedPtr;
-
-  VLOG(1) << "Starting common eval execution.";
-  SelectivityVector rows{rowVector ? rowVector->size() : 1};
-
-  // Execute with common expression eval path.
-  try {
-    exec::ExprSet exprSetCommon(
-        {plan}, &execCtx_, !FLAGS_disable_constant_folding);
-    exec::EvalCtx evalCtxCommon(&execCtx_, &exprSetCommon, rowVector.get());
-
-    try {
-      exprSetCommon.eval(rows, evalCtxCommon, commonEvalResult);
-    } catch (...) {
-      if (!canThrow) {
-        LOG(ERROR)
-            << "Common eval wasn't supposed to throw, but it did. Aborting.";
-        throw;
-      }
-      exceptionCommonPtr = std::current_exception();
-    }
-  } catch (...) {
-    exceptionCommonPtr = std::current_exception();
-  }
-
-  VLOG(1) << "Starting simplified eval execution.";
-
-  // Execute with simplified expression eval path.
-  try {
-    exec::ExprSetSimplified exprSetSimplified({plan}, &execCtx_);
-    exec::EvalCtx evalCtxSimplified(
-        &execCtx_, &exprSetSimplified, rowVector.get());
-
-    try {
-      exprSetSimplified.eval(rows, evalCtxSimplified, simplifiedEvalResult);
-    } catch (...) {
-      if (!canThrow) {
-        LOG(ERROR)
-            << "Simplified eval wasn't supposed to throw, but it did. Aborting.";
-        throw;
-      }
-      exceptionSimplifiedPtr = std::current_exception();
-    }
-  } catch (...) {
-    exceptionSimplifiedPtr = std::current_exception();
-  }
-
-  try {
-    // Compare results or exceptions (if any). Fail is anything is different.
-    if (exceptionCommonPtr || exceptionSimplifiedPtr) {
-      // Throws in case exceptions are not compatible. If they are compatible,
-      // return false to signal that the expression failed.
-      compareExceptions(exceptionCommonPtr, exceptionSimplifiedPtr);
-      return false;
-    } else {
-      // Throws in case output is different.
-      compareVectors(commonEvalResult.front(), simplifiedEvalResult.front());
-    }
-  } catch (...) {
-    if (!FLAGS_repro_persist_path.empty()) {
-      persistReproInfo(rowVector, copiedResult, sql);
-    }
-    throw;
-  }
-  return true;
-}
-
 template <typename T>
 bool ExpressionFuzzer::isDone(size_t i, T startTime) const {
   if (FLAGS_duration_sec > 0) {
@@ -787,7 +519,7 @@ void ExpressionFuzzer::go() {
     // If both paths threw compatible exceptions, we add a try() function to
     // the expression's root and execute it again. This time the expression
     // cannot throw.
-    if (!executeExpression(
+    if (!verifier_.verify(
             plan,
             rowVector,
             resultVector ? BaseVector::copy(*resultVector) : nullptr,
@@ -800,7 +532,7 @@ void ExpressionFuzzer::go() {
           plan->type(), std::vector<core::TypedExprPtr>{plan}, "try");
 
       // At this point, the function throws if anything goes wrong.
-      executeExpression(
+      verifier_.verify(
           plan,
           rowVector,
           resultVector ? BaseVector::copy(*resultVector) : nullptr,

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -18,6 +18,7 @@
 
 #include "velox/core/ITypedExpr.h"
 #include "velox/core/QueryCtx.h"
+#include "velox/expression/tests/ExpressionVerifier.h"
 #include "velox/functions/FunctionRegistry.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
@@ -66,8 +67,6 @@ class ExpressionFuzzer {
 
   void reSeed();
 
-  void printRowVector(const RowVectorPtr& rowVector);
-
   void appendConjunctSignatures();
 
   RowVectorPtr generateRowVector();
@@ -94,22 +93,6 @@ class ExpressionFuzzer {
   // (optional) parameters always need to be constant.
   std::vector<core::TypedExprPtr> generateRegexpReplaceArgs(
       const CallableSignature& input);
-
-  void persistReproInfo(
-      const VectorPtr& inputVector,
-      const VectorPtr& resultVector,
-      const std::string& sql);
-
-  // Executes an expression. Returns:
-  //
-  //  - true if both succeeded and returned the exact same results.
-  //  - false if both failed with compatible exceptions.
-  //  - throws otherwise (incompatible exceptions or different results).
-  bool executeExpression(
-      const core::TypedExprPtr& plan,
-      const RowVectorPtr& rowVector,
-      VectorPtr&& resultVector,
-      bool canThrow);
 
   // If --duration_sec > 0, check if we expired the time budget. Otherwise,
   // check if we expired the number of iterations (--steps).
@@ -141,6 +124,7 @@ class ExpressionFuzzer {
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
+  test::ExpressionVerifier verifier_;
 
   test::VectorMaker vectorMaker_{execCtx_.pool()};
   VectorFuzzer vectorFuzzer_;

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/tests/ExpressionVerifier.h"
+#include "velox/expression/Expr.h"
+#include "velox/vector/VectorSaver.h"
+
+namespace facebook::velox::test {
+
+namespace {
+
+void printRowVector(const RowVectorPtr& rowVector) {
+  LOG(INFO) << "RowVector contents (" << rowVector->type()->toString() << "):";
+
+  for (vector_size_t i = 0; i < rowVector->size(); ++i) {
+    LOG(INFO) << "\tAt " << i << ": " << rowVector->toString(i);
+  }
+}
+
+void compareExceptions(
+    const VeloxException& left,
+    const VeloxException& right) {
+  // Error messages sometimes differ; check at least error codes.
+  // Since the common path may peel the input encoding off, whereas the
+  // simplified path flatten input vectors, the common and the simplified
+  // paths may evaluate the input rows in different orders and hence throw
+  // different exceptions depending on which bad input they come across
+  // first. We have seen this happen for the format_datetime Presto function
+  // that leads to unmatched error codes UNSUPPORTED vs. INVALID_ARGUMENT.
+  // Therefore, we intentionally relax the comparision here.
+  VELOX_CHECK(
+      left.errorCode() == right.errorCode() ||
+      (left.errorCode() == "INVALID_ARGUMENT" &&
+       right.errorCode() == "UNSUPPORTED") ||
+      (right.errorCode() == "INVALID_ARGUMENT" &&
+       left.errorCode() == "UNSUPPORTED"));
+  VELOX_CHECK_EQ(left.errorSource(), right.errorSource());
+  VELOX_CHECK_EQ(left.exceptionName(), right.exceptionName());
+  if (left.message() != right.message()) {
+    LOG(WARNING) << "Two different VeloxExceptions were thrown:\n\t"
+                 << left.message() << "\nand\n\t" << right.message();
+  }
+}
+
+void compareExceptions(
+    std::exception_ptr commonPtr,
+    std::exception_ptr simplifiedPtr) {
+  // If we don't have two exceptions, fail.
+  if (!commonPtr || !simplifiedPtr) {
+    if (!commonPtr) {
+      LOG(ERROR) << "Only simplified path threw exception:";
+      std::rethrow_exception(simplifiedPtr);
+    }
+    LOG(ERROR) << "Only common path threw exception:";
+    std::rethrow_exception(commonPtr);
+  }
+
+  // Otherwise, make sure the exceptions are the same.
+  try {
+    std::rethrow_exception(commonPtr);
+  } catch (const VeloxException& ve1) {
+    try {
+      std::rethrow_exception(simplifiedPtr);
+    } catch (const VeloxException& ve2) {
+      compareExceptions(ve1, ve2);
+      return;
+    } catch (const std::exception& e2) {
+      LOG(WARNING) << "Two different exceptions were thrown:\n\t"
+                   << ve1.message() << "\nand\n\t" << e2.what();
+    }
+  } catch (const std::exception& e1) {
+    try {
+      std::rethrow_exception(simplifiedPtr);
+    } catch (const std::exception& e2) {
+      if (e1.what() != e2.what()) {
+        LOG(WARNING) << "Two different std::exceptions were thrown:\n\t"
+                     << e1.what() << "\nand\n\t" << e2.what();
+      }
+      return;
+    }
+  }
+  VELOX_FAIL("Got two incompatible exceptions.");
+}
+
+void compareVectors(const VectorPtr& left, const VectorPtr& right) {
+  VELOX_CHECK_EQ(left->size(), right->size());
+
+  // Print vector contents if in verbose mode.
+  size_t vectorSize = left->size();
+  if (VLOG_IS_ON(1)) {
+    LOG(INFO) << "== Result contents (common vs. simple): ";
+    for (auto i = 0; i < vectorSize; i++) {
+      LOG(INFO) << "At " << i << ": [" << left->toString(i) << " vs "
+                << right->toString(i) << "]";
+    }
+    LOG(INFO) << "===================";
+  }
+
+  for (auto i = 0; i < vectorSize; i++) {
+    VELOX_CHECK(
+        left->equalValueAt(right.get(), i, i),
+        "Different results at idx '{}': '{}' vs. '{}'",
+        i,
+        left->toString(i),
+        right->toString(i));
+  }
+  LOG(INFO) << "All results match.";
+}
+
+} // namespace
+
+bool ExpressionVerifier::verify(
+    const core::TypedExprPtr& plan,
+    const RowVectorPtr& rowVector,
+    VectorPtr&& resultVector,
+    bool canThrow) {
+  LOG(INFO) << "Executing expression: " << plan->toString();
+
+  if (rowVector) {
+    LOG(INFO) << rowVector->childrenSize() << " vectors as input:";
+    for (const auto& child : rowVector->children()) {
+      LOG(INFO) << "\t" << child->toString(/*recursive=*/true);
+    }
+
+    if (VLOG_IS_ON(1)) {
+      printRowVector(rowVector);
+    }
+  }
+
+  // Store data and expression in case of reproduction.
+  VectorPtr copiedResult;
+  std::string sql;
+  // Deep copy to preserve the initial state of result vector.
+  if (!options_.reproPersistPath.empty()) {
+    if (resultVector) {
+      copiedResult = BaseVector::copy(*resultVector);
+    }
+    std::vector<core::TypedExprPtr> typedExprs = {plan};
+    // Disabling constant folding in order to preserver the original
+    // expression
+    sql =
+        exec::ExprSet(std::move(typedExprs), execCtx_, false).expr(0)->toSql();
+  }
+
+  // Execute expression plan using both common and simplified evals.
+  std::vector<VectorPtr> commonEvalResult(1);
+  std::vector<VectorPtr> simplifiedEvalResult(1);
+
+  commonEvalResult[0] = resultVector;
+
+  std::exception_ptr exceptionCommonPtr;
+  std::exception_ptr exceptionSimplifiedPtr;
+
+  VLOG(1) << "Starting common eval execution.";
+  SelectivityVector rows{rowVector ? rowVector->size() : 1};
+
+  // Execute with common expression eval path.
+  try {
+    exec::ExprSet exprSetCommon(
+        {plan}, execCtx_, !options_.disableConstantFolding);
+    exec::EvalCtx evalCtxCommon(execCtx_, &exprSetCommon, rowVector.get());
+
+    try {
+      exprSetCommon.eval(rows, evalCtxCommon, commonEvalResult);
+    } catch (...) {
+      if (!canThrow) {
+        LOG(ERROR)
+            << "Common eval wasn't supposed to throw, but it did. Aborting.";
+        throw;
+      }
+      exceptionCommonPtr = std::current_exception();
+    }
+  } catch (...) {
+    exceptionCommonPtr = std::current_exception();
+  }
+
+  VLOG(1) << "Starting simplified eval execution.";
+
+  // Execute with simplified expression eval path.
+  try {
+    exec::ExprSetSimplified exprSetSimplified({plan}, execCtx_);
+    exec::EvalCtx evalCtxSimplified(
+        execCtx_, &exprSetSimplified, rowVector.get());
+
+    try {
+      exprSetSimplified.eval(rows, evalCtxSimplified, simplifiedEvalResult);
+    } catch (...) {
+      if (!canThrow) {
+        LOG(ERROR)
+            << "Simplified eval wasn't supposed to throw, but it did. Aborting.";
+        throw;
+      }
+      exceptionSimplifiedPtr = std::current_exception();
+    }
+  } catch (...) {
+    exceptionSimplifiedPtr = std::current_exception();
+  }
+
+  try {
+    // Compare results or exceptions (if any). Fail is anything is different.
+    if (exceptionCommonPtr || exceptionSimplifiedPtr) {
+      // Throws in case exceptions are not compatible. If they are compatible,
+      // return false to signal that the expression failed.
+      compareExceptions(exceptionCommonPtr, exceptionSimplifiedPtr);
+      return false;
+    } else {
+      // Throws in case output is different.
+      compareVectors(commonEvalResult.front(), simplifiedEvalResult.front());
+    }
+  } catch (...) {
+    if (!options_.reproPersistPath.empty()) {
+      persistReproInfo(rowVector, copiedResult, sql);
+    }
+    throw;
+  }
+  return true;
+}
+
+void ExpressionVerifier::persistReproInfo(
+    const VectorPtr& inputVector,
+    const VectorPtr& resultVector,
+    const std::string& sql) {
+  std::string inputPath;
+  std::string resultPath;
+  std::string sqlPath;
+
+  const auto basePath = options_.reproPersistPath.c_str();
+  // Saving input vector
+  auto inputPathOpt = generateFilePath(basePath, "vector");
+  if (!inputPathOpt.has_value()) {
+    inputPath = "Failed to create file for saving input vector.";
+  } else {
+    inputPath = inputPathOpt.value();
+    try {
+      saveVectorToFile(inputVector.get(), inputPath.c_str());
+    } catch (std::exception& e) {
+      inputPath = e.what();
+    }
+  }
+
+  // Saving result vector
+  if (resultVector) {
+    auto resultPathOpt = generateFilePath(basePath, "vector");
+    if (!resultPathOpt.has_value()) {
+      resultPath = "Failed to create file for saving result vector.";
+    } else {
+      resultPath = resultPathOpt.value();
+      try {
+        saveVectorToFile(resultVector.get(), resultPath.c_str());
+      } catch (std::exception& e) {
+        resultPath = e.what();
+      }
+    }
+  }
+
+  // Saving sql
+  auto sqlPathOpt = generateFilePath(basePath, "sql");
+  if (!sqlPathOpt.has_value()) {
+    sqlPath = "Failed to create file for saving SQL.";
+  } else {
+    sqlPath = sqlPathOpt.value();
+    try {
+      saveStringToFile(sql, sqlPath.c_str());
+    } catch (std::exception& e) {
+      resultPath = e.what();
+    }
+  }
+
+  std::stringstream ss;
+  ss << "Persisted input at '" << inputPath;
+  if (resultVector) {
+    ss << "' and result at '" << resultPath;
+  }
+  ss << "' and sql at '" << sqlPath << "'";
+  LOG(INFO) << ss.str();
+}
+
+} // namespace facebook::velox::test

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/core/ITypedExpr.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/functions/FunctionRegistry.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::test {
+
+struct ExpressionVerifierOptions {
+  bool disableConstantFolding{false};
+  std::string reproPersistPath;
+};
+
+class ExpressionVerifier {
+ public:
+  ExpressionVerifier(
+      core::ExecCtx* FOLLY_NONNULL execCtx,
+      ExpressionVerifierOptions options)
+      : execCtx_(execCtx), options_(options) {}
+
+  // Executes an expression and verifies the results/exceptions from common
+  // execution path vs simple execution path. Returns:
+  //
+  //  - true if both paths succeeded and returned the exact same results.
+  //  - false if both paths failed with compatible exceptions.
+  //  - throws otherwise (incompatible exceptions or different results).
+  bool verify(
+      const core::TypedExprPtr& plan,
+      const RowVectorPtr& rowVector,
+      VectorPtr&& resultVector,
+      bool canThrow);
+
+ private:
+  void persistReproInfo(
+      const VectorPtr& inputVector,
+      const VectorPtr& resultVector,
+      const std::string& sql);
+
+ private:
+  core::ExecCtx* FOLLY_NONNULL execCtx_;
+  const ExpressionVerifierOptions options_;
+};
+
+} // namespace facebook::velox::test


### PR DESCRIPTION
Execution part of the fuzzer codebase is a common piece that could also be used 
for later to be introduced ExpressionRunner. Extract them out to be a commonly 
reusable module. 

Ran fuzzer with command options:
--repro_persist_path /tmp/abc --seed 1813425897 --v=1 --logtostderr=1

Logs: https://gist.github.com/tanjialiang/9d65f74626adfc0e7059c6363e089523

On local computer persist path:
```
jtan6-mbp:abc jtan6$ ls
velox_sql_JQSq1m	velox_vector_7nFQ1b
```