### PR TITLE
Add an assert to StringView ctor to ensure valid use and resolve memcpy ub issue

### DIFF
--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -24,6 +24,7 @@
 #include <folly/dynamic.h>
 
 #include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox {
 
@@ -51,11 +52,12 @@ struct StringView {
   }
 
   explicit StringView(uint32_t size) : size_(size) {
+    VELOX_DCHECK(isInline(size));
     memset(prefix_, 0, kPrefixSize);
     value_.data = nullptr;
   }
   StringView(const char* data, size_t len) : size_(len) {
-    assert(data || size_ == 0);
+    VELOX_DCHECK(data || size_ == 0);
     if (isInline()) {
       // Zero the inline part.
       // this makes sure that inline strings can be compared for equality with 2


### PR DESCRIPTION
Summary:
The `StringView(size)` ctor only makes since if `size` is inlined, which makes it effectively a string buffer, the only use case of it is
https://fburl.com/code/7c0swd59, where it was validly used.
Therefore, adding the `assert` can make sure it's used validly and also resolve the issue of potentially feeding `nullptr` to `memcpy`
https://github.com/facebookincubator/velox/issues/2865

Differential Revision: D40478967

