### PR TITLE
Add ExpressionRunner for failure reproduction

### DIFF
--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -102,6 +102,26 @@ target_link_libraries(
   gtest
   gtest_main)
 
+add_library(velox_expression_runner ExpressionRunner.cpp)
+target_link_libraries(velox_expression_runner velox_expression_verifier
+                      velox_functions_prestosql velox_parse_parser gtest)
+
+add_executable(velox_expression_runner_test ExpressionRunnerTest.cpp)
+target_link_libraries(velox_expression_runner_test velox_expression_runner
+                      velox_function_registry gtest gtest_main)
+
+add_executable(velox_expression_runner_unit_test ExpressionRunnerUnitTest.cpp)
+target_link_libraries(
+  velox_expression_runner_unit_test
+  velox_dwio_common_test_utils
+  velox_expression_runner
+  velox_expression_fuzzer
+  velox_expression_verifier
+  velox_function_registry
+  velox_temp_path
+  gtest
+  gtest_main)
+
 add_executable(velox_expression_fuzzer_test ExpressionFuzzerTest.cpp)
 
 target_link_libraries(velox_expression_fuzzer_test velox_expression_fuzzer

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/expression/tests/ExpressionRunner.h"
+#include "velox/expression/tests/ExpressionVerifier.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/VectorSaver.h"
+
+namespace facebook::velox::test {
+
+using namespace facebook::velox;
+
+void ExpressionRunner::run(
+    const std::string& inputPath,
+    const std::string& sqlPath,
+    const std::string& resultPath,
+    const std::string& mode) {
+  std::shared_ptr<core::QueryCtx> queryCtx{core::QueryCtx::createForTest()};
+  std::unique_ptr<memory::MemoryPool> pool{
+      memory::getDefaultScopedMemoryPool()};
+  core::ExecCtx execCtx{pool.get(), queryCtx.get()};
+
+  VELOX_CHECK(!inputPath.empty());
+  VELOX_CHECK(!sqlPath.empty());
+
+  auto inputVector = std::dynamic_pointer_cast<RowVector>(
+      restoreVectorFromFile(inputPath.c_str(), pool.get()));
+  VELOX_CHECK_NOT_NULL(inputVector, "Input vector is not a RowVector");
+  auto sql = restoreStringFromFile(sqlPath.c_str());
+
+  parse::registerTypeResolver();
+  parse::ParseOptions options;
+  auto typedExpr = core::Expressions::inferTypes(
+      parse::parseExpr(sql, options), inputVector->type(), pool.get());
+  VectorPtr resultVector;
+  if (!resultPath.empty()) {
+    resultVector = restoreVectorFromFile(resultPath.c_str(), pool.get());
+  }
+
+  if (mode == "verify") {
+    test::ExpressionVerifier(&execCtx, {false, ""})
+        .verify(typedExpr, inputVector, std::move(resultVector), true);
+  } else {
+    LOG(ERROR) << "Unknown expression runner mode '" << mode << "'.";
+  }
+}
+
+} // namespace facebook::velox::test

--- a/velox/expression/tests/ExpressionRunner.h
+++ b/velox/expression/tests/ExpressionRunner.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+
+namespace facebook::velox::test {
+
+/// Utility class that helps to run any expressions standalone. It takes input
+/// data, SQL, and dirty result vector if any from disk and run the expression
+/// described by SQL. It supports 3 modes:
+///    - "verify": run expression and compare results between common and
+///                simplified path
+///    - "common": run expression only using common paths. (to be supported)
+///    - "simplified": run expression only using simplified path. (to be
+///                supported)
+class ExpressionRunner {
+ public:
+  /// \param inputPath The path to the on-disk vector that will be used as input
+  ///        to feed to the expression.
+  /// \param sqlPath The path to the on-disk SQL that will be used to describe
+  ///        the expression. \param resultPath The path to the on-disk vector
+  ///        that will be used as the result buffer to which the expression
+  ///        evaluation results will be written.
+  /// \param mode The expression evaluation mode, one of ["verify", "common",
+  ///        "simplified"]
+  ///
+  /// User can refer to 'VectorSaver' class to see how to serialize/preserve
+  /// vectors to disk.
+  static void run(
+      const std::string& inputPath,
+      const std::string& sqlPath,
+      const std::string& resultPath,
+      const std::string& mode);
+};
+
+} // namespace facebook::velox::test

--- a/velox/expression/tests/ExpressionRunnerTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerTest.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/tests/ExpressionRunner.h"
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+DEFINE_string(
+    input_path,
+    "",
+    "Path for vector to be restored from disk. This will enable single run "
+    "of the fuzzer with the on-disk persisted repro information. This has to "
+    "be set with sql_path and optionally result_path.");
+
+DEFINE_string(
+    sql_path,
+    "",
+    "Path for expression SQL to be restored from disk. This will enable "
+    "single run of the fuzzer with the on-disk persisted repro information. "
+    "This has to be set with input_path and optionally result_path.");
+
+DEFINE_string(
+    result_path,
+    "",
+    "Path for result vector to restore from disk. This is optional for "
+    "on-disk reproduction. Don't set if the initial repro result vector is "
+    "nullptr");
+
+// TODO(jtan6): Support common mode and simplified mode.
+DEFINE_string(
+    mode,
+    "verify",
+    "Mode for expression runner: \n"
+    "verify: run expression and compare results between common and simplified "
+    "path.\n"
+    "common: run expression only using common paths. (to be supported)\n"
+    "simplified: run expression only using simplified path. (to be supported)");
+
+int main(int argc, char** argv) {
+  facebook::velox::functions::prestosql::registerAllScalarFunctions();
+
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // Calls common init functions in the necessary order, initializing
+  // singletons, installing proper signal handlers for better debugging
+  // experience, and initialize glog and gflags.
+  folly::init(&argc, &argv);
+  facebook::velox::test::ExpressionRunner::run(
+      FLAGS_input_path, FLAGS_sql_path, FLAGS_result_path, FLAGS_mode);
+}

--- a/velox/expression/tests/ExpressionRunnerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerUnitTest.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "FuzzerRunner.h"
+#include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/exec/tests/utils/TempFilePath.h"
+#include "velox/expression/SignatureBinder.h"
+#include "velox/expression/tests/ExpressionFuzzer.h"
+#include "velox/expression/tests/ExpressionRunner.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/vector/VectorSaver.h"
+
+namespace facebook::velox::test {
+
+class ExpressionRunnerUnitTest : public testing::Test {
+ public:
+  void SetUp() override {
+    velox::functions::prestosql::registerAllScalarFunctions();
+  }
+
+ protected:
+  std::unique_ptr<memory::MemoryPool> pool_{
+      memory::getDefaultScopedMemoryPool()};
+};
+
+TEST_F(ExpressionRunnerUnitTest, run) {
+  auto inputFile = exec::test::TempFilePath::create();
+  auto sqlFile = exec::test::TempFilePath::create();
+  auto resultFile = exec::test::TempFilePath::create();
+  const char* inputPath = inputFile->path.data();
+  const char* sqlPath = sqlFile->path.data();
+  const char* resultPath = resultFile->path.data();
+  const int vectorSize = 100;
+
+  VectorMaker vectorMaker(pool_.get());
+  auto inputVector = vectorMaker.rowVector(
+      {"c0"}, {vectorMaker.flatVector<StringView>(vectorSize, [](auto) {
+        return "abc";
+      })});
+  auto resultVector = vectorMaker.flatVector<int64_t>(
+      vectorSize, [](auto row) { return row * 100; });
+  saveVectorToFile(inputVector.get(), inputPath);
+  saveVectorToFile(resultVector.get(), resultPath);
+
+  std::string sql = "length(\"c0\")";
+  saveStringToFile(sql, sqlPath);
+  EXPECT_NO_THROW(
+      ExpressionRunner::run(inputPath, sqlPath, resultPath, "verify"));
+}
+
+} // namespace facebook::velox::test

--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -668,6 +668,40 @@ VectorPtr restoreVector(std::istream& in, memory::MemoryPool* pool) {
   }
 }
 
+VectorPtr restoreVectorFromFile(
+    const char* FOLLY_NONNULL filePath,
+    memory::MemoryPool* FOLLY_NONNULL pool) {
+  std::ifstream inputFile(filePath, std::ifstream::binary);
+  VELOX_CHECK(!inputFile.fail(), "Cannot open file: {}", filePath);
+
+  auto result = restoreVector(inputFile, pool);
+  inputFile.close();
+  return result;
+}
+
+std::string restoreStringFromFile(const char* FOLLY_NONNULL filePath) {
+  std::ifstream inputFile(filePath, std::ifstream::binary);
+
+  // Find out file size.
+  auto begin = inputFile.tellg();
+  inputFile.seekg(0, std::ios::end);
+  auto end = inputFile.tellg();
+
+  auto fileSize = end - begin;
+  if (fileSize == 0) {
+    return "";
+  }
+
+  // Read the file.
+  std::string result;
+  result.resize(fileSize);
+
+  inputFile.seekg(begin);
+  inputFile.read(result.data(), fileSize);
+  inputFile.close();
+  return result;
+}
+
 std::optional<std::string> generateFilePath(
     const char* basePath,
     const char* prefix) {

--- a/velox/vector/VectorSaver.h
+++ b/velox/vector/VectorSaver.h
@@ -50,7 +50,16 @@ void saveStringToFile(
 /// Deserializes a vector serialized by 'save' from the provided input stream.
 VectorPtr restoreVector(
     std::istream& in,
-    memory::MemoryPool* FOLLY_NULLABLE pool);
+    memory::MemoryPool* FOLLY_NONNULL pool);
+
+/// Reads and deserializes a vector from a file stored by saveVectorToFile()
+/// method call
+VectorPtr restoreVectorFromFile(
+    const char* FOLLY_NONNULL filePath,
+    memory::MemoryPool* FOLLY_NONNULL pool);
+
+/// Reads a string from a file stored by saveStringToFile() method
+std::string restoreStringFromFile(const char* FOLLY_NONNULL filePath);
 
 /// Generates a file path in specified directory. Returns std::nullopt on
 /// failure.


### PR DESCRIPTION
Expression runner is used to run custom expressions with custom input data. 
One of the use case scenarios is when ExpressionFuzzer run fails, it preserves 
the failed expression and its input data to disk. This expression runner can then
be used to reproduce the failure for debugging purposes.