### PR TITLE
Remove FLAGS_verbose from E2EFilterTestBase.cpp

### DIFF
--- a/velox/dwio/common/tests/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/E2EFilterTestBase.cpp
@@ -16,8 +16,11 @@
 
 #include "velox/dwio/common/tests/E2EFilterTestBase.h"
 
+// Set FLAGS_minloglevel to a value in {1,2,3} to disable logging at the
+// INFO(=0) level.
+// Set FLAGS_logtostderr = true to log messages to stderr instead of logfiles
+// Set FLAGS_timing_repeats = n to run timing filter tests n times
 DEFINE_int32(timing_repeats, 0, "Count of repeats for timing filter tests");
-DEFINE_bool(verbose, false, "Print filter test times");
 
 namespace facebook::velox::dwio::common {
 
@@ -333,14 +336,13 @@ void E2EFilterTestBase::testFilterSpecs(
     for (auto i = 0; i < FLAGS_timing_repeats; ++i) {
       readWithFilter(spec, batches_, hitRows, timeWithFilter, false, true);
     }
-    if (FLAGS_verbose) {
-      LOG(INFO) << fmt::format(
-          "    {} hits in {} us, {} input rows/s\n",
-          hitRows.size(),
-          timeWithFilter,
-          batches_[0]->size() * batches_.size() * FLAGS_timing_repeats /
-              (timeWithFilter / 1000000.0));
-    }
+
+    LOG(INFO) << fmt::format(
+        "    {} hits in {} us, {} input rows/s\n",
+        hitRows.size(),
+        timeWithFilter,
+        batches_[0]->size() * batches_.size() * FLAGS_timing_repeats /
+            (timeWithFilter / 1000000.0));
   }
   // Redo the test with LazyVectors for non-filtered columns.
   timeWithFilter = 0;
@@ -401,11 +403,8 @@ void E2EFilterTestBase::testWithTypes(
   for (int32_t noVInts = 0; noVInts < (tryNoVInts ? 2 : 1); ++noVInts) {
     useVInts_ = !noVInts;
     for (int32_t noNulls = 0; noNulls < (tryNoNulls ? 2 : 1); ++noNulls) {
-      if (FLAGS_verbose) {
-        LOG(INFO) << "Running with " << (noNulls ? " no nulls " : "nulls")
-                  << " and " << (noVInts ? " no VInts " : " VInts ")
-                  << std::endl;
-      }
+      LOG(INFO) << "Running with " << (noNulls ? " no nulls " : "nulls")
+                << " and " << (noVInts ? " no VInts " : " VInts ") << std::endl;
       filterGenerator->reseedRng();
 
       auto newCustomize = customize;
@@ -421,10 +420,8 @@ void E2EFilterTestBase::testWithTypes(
       for (auto i = 0; i < numCombinations; ++i) {
         std::vector<FilterSpec> specs =
             filterGenerator->makeRandomSpecs(filterable, 125);
-        if (FLAGS_verbose) {
-          LOG(INFO) << i << ": " << FilterGenerator::specsToString(specs)
-                    << std::endl;
-        }
+        LOG(INFO) << i << ": " << FilterGenerator::specsToString(specs)
+                  << std::endl;
         testFilterSpecs(specs);
       }
       makeDataset(customize, true);


### PR DESCRIPTION
Logging at INFO level (=0) is by default and can be changed by setting
FLAGS_minloglevel to a value in {1,2,3}. This commit removes the
definition of FLAGS_verbose to prepare for the upcoming Parquet reader
benchmarks.