### PR TITLE
Fix handling of dictionary-added nulls in CastExpr

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -646,7 +646,8 @@ void CastExpr::apply(
         toType,
         localResult);
 
-    localResult = context.applyWrapToPeeledResult(toType, localResult, rows);
+    localResult =
+        context.applyWrapToPeeledResult(toType, localResult, *nonNullRows);
   }
   context.moveOrCopyResult(localResult, rows, result);
   context.releaseVector(localResult);
@@ -654,9 +655,8 @@ void CastExpr::apply(
   // If we have a mix of null and non-null in input, add nulls to the result.
   VELOX_CHECK_NOT_NULL(result);
   if (nullRows->hasSelections() && nonNullRows->hasSelections()) {
-    auto targetNulls = result->mutableRawNulls();
-    nullRows->applyToSelected(
-        [&](auto row) { bits::setNull(targetNulls, row, true); });
+    Expr::addNulls(
+        rows, nonNullRows->asRange().bits(), context, toType, result);
   }
 }
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -908,26 +908,36 @@ bool Expr::removeSureNulls(
   return false;
 }
 
+// static
 void Expr::addNulls(
     const SelectivityVector& rows,
     const uint64_t* rawNulls,
     EvalCtx& context,
+    const TypePtr& type,
     VectorPtr& result) {
   // If there's no `result` yet, return a NULL ContantVector.
   if (!result) {
-    result =
-        BaseVector::createNullConstant(type(), rows.size(), context.pool());
+    result = BaseVector::createNullConstant(type, rows.size(), context.pool());
     return;
   }
 
-  // If result is already a NULL ConstantVector, do nothing.
-  if (result->isConstantEncoding() && result->mayHaveNulls()) {
+  // If result is already a NULL ConstantVector, resize the vector if necessary,
+  // or do nothing otherwise.
+  if (result->isConstantEncoding() && result->isNullAt(0)) {
+    if (result->size() < rows.end()) {
+      if (result.unique()) {
+        result->resize(rows.end());
+      } else {
+        result =
+            BaseVector::createNullConstant(type, rows.size(), context.pool());
+      }
+    }
     return;
   }
 
   if (!result.unique() || !result->isNullsWritable()) {
     BaseVector::ensureWritable(
-        SelectivityVector::empty(), type(), context.pool(), result);
+        SelectivityVector::empty(), type, context.pool(), result);
   }
 
   if (result->size() < rows.end()) {
@@ -935,6 +945,14 @@ void Expr::addNulls(
   }
 
   result->addNulls(rawNulls, rows);
+}
+
+void Expr::addNulls(
+    const SelectivityVector& rows,
+    const uint64_t* FOLLY_NULLABLE rawNulls,
+    EvalCtx& context,
+    VectorPtr& result) {
+  addNulls(rows, rawNulls, context, type(), result);
 }
 
 void Expr::evalWithNulls(

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -246,6 +246,13 @@ class Expr {
   // 'rows'. Ensures that '*result' is writable, of sufficient size
   // and that it can take nulls. Makes a new '*result' when
   // appropriate.
+  static void addNulls(
+      const SelectivityVector& rows,
+      const uint64_t* FOLLY_NULLABLE rawNulls,
+      EvalCtx& context,
+      const TypePtr& type,
+      VectorPtr& result);
+
   void addNulls(
       const SelectivityVector& rows,
       const uint64_t* FOLLY_NULLABLE rawNulls,

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -18,6 +18,8 @@
 #include "glog/logging.h"
 #include "gtest/gtest.h"
 
+#include "velox/expression/Expr.h"
+
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
@@ -2781,4 +2783,87 @@ TEST_F(ExprTest, peelWithDefaultNull) {
   auto expected =
       makeNullableFlatVector<bool>({true, true, true, true, true, true});
   assertEqualVectors(expected, result);
+}
+
+TEST_F(ExprTest, addNulls) {
+  const vector_size_t kSize = 6;
+  SelectivityVector rows{kSize};
+
+  auto nulls = allocateNulls(kSize, pool());
+  auto* rawNulls = nulls->asMutable<uint64_t>();
+  bits::setNull(rawNulls, kSize - 1);
+
+  exec::EvalCtx context(execCtx_.get());
+
+  auto checkConstantResult = [&](const VectorPtr& vector) {
+    ASSERT_TRUE(vector->isConstantEncoding());
+    ASSERT_EQ(vector->size(), kSize);
+    ASSERT_TRUE(vector->isNullAt(0));
+  };
+
+  // Test vector that is nullptr.
+  {
+    VectorPtr vector;
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    ASSERT_NE(vector, nullptr);
+    checkConstantResult(vector);
+  }
+
+  // Test vector that is already a constant null vector and is uniquely
+  // referenced.
+  {
+    auto vector = makeNullConstant(TypeKind::BIGINT, kSize - 1);
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    checkConstantResult(vector);
+  }
+
+  // Test vector that is already a constant null vector and is not uniquely
+  // referenced.
+  {
+    auto vector = makeNullConstant(TypeKind::BIGINT, kSize - 1);
+    auto another = vector;
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    checkConstantResult(vector);
+  }
+
+  // Test vector that is a non-null constant vector.
+  {
+    auto vector = makeConstant<int64_t>(100, kSize - 1);
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    ASSERT_TRUE(vector->isFlatEncoding());
+    ASSERT_EQ(vector->size(), kSize);
+    for (auto i = 0; i < kSize - 1; ++i) {
+      ASSERT_FALSE(vector->isNullAt(i));
+      ASSERT_EQ(vector->asFlatVector<int64_t>()->valueAt(i), 100);
+    }
+    ASSERT_TRUE(vector->isNullAt(kSize - 1));
+  }
+
+  auto checkResult = [&](const VectorPtr& vector) {
+    ASSERT_EQ(vector->size(), kSize);
+    for (auto i = 0; i < kSize - 1; ++i) {
+      ASSERT_FALSE(vector->isNullAt(i));
+      ASSERT_EQ(vector->asFlatVector<int64_t>()->valueAt(i), i);
+    }
+    ASSERT_TRUE(vector->isNullAt(kSize - 1));
+  };
+
+  // Test vector that is not uniquely referenced.
+  {
+    VectorPtr vector =
+        makeFlatVector<int64_t>(kSize - 1, [](auto row) { return row; });
+    auto another = vector;
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+
+    checkResult(vector);
+  }
+
+  // Test vector that is uniquely referenced.
+  {
+    VectorPtr vector =
+        makeFlatVector<int64_t>(kSize - 1, [](auto row) { return row; });
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+
+    checkResult(vector);
+  }
 }


### PR DESCRIPTION
Summary: CastExpr peels off input encoding, processes the base vector at non-null rows (i.e., `nonNullRows`), and wraps the local result again with the peeled wrapping. Before this fix, it uses a SelectivityVector of all rows (i.e., `rows`) when wrapping the result. This caused an issue because the peeled wrapping is of the length `nonNullRows.end()` that could be smaller than `rows.end()`, which is not allowed by DictionaryVector's constructor. This diff fixes this bug.

Differential Revision: D40500476

