### PR TITLE
Parquet nested structure decoder 

### DIFF
--- a/velox/common/hyperloglog/tests/CMakeLists.txt
+++ b/velox/common/hyperloglog/tests/CMakeLists.txt
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_common_hyperloglog_test DenseHllTest.cpp
-                                             SparseHllTest.cpp)
+add_executable(velox_common_hyperloglog_test DenseHllTest.cpp SparseHllTest.cpp)
 
 add_test(NAME velox_common_hyperloglog_test
          COMMAND velox_common_hyperloglog_test)
 
-target_link_libraries(
-  velox_common_hyperloglog_test velox_common_hyperloglog velox_encode
-  ${gflags_LIBRARIES} gtest gtest_main)
+target_link_libraries(velox_common_hyperloglog_test velox_common_hyperloglog
+                      velox_encode ${gflags_LIBRARIES} gtest gtest_main)

--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -14,14 +14,15 @@
 
 add_library(
   velox_dwio_native_parquet_reader
+  NestedStructureDecoder.cpp
   ParquetReader.cpp
   PageReader.cpp
   ParquetData.cpp
   ParquetColumnReader.cpp
+  RleBpDecoder.cpp
   Statistics.cpp
   StructColumnReader.cpp
-  StringColumnReader.cpp
-  RleBpDecoder.cpp)
+  StringColumnReader.cpp)
 
 target_link_libraries(
   velox_dwio_native_parquet_reader

--- a/velox/dwio/parquet/reader/NestedStructureDecoder.cpp
+++ b/velox/dwio/parquet/reader/NestedStructureDecoder.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/parquet/reader/NestedStructureDecoder.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/dwio/common/BufferUtil.h"
+
+namespace facebook::velox::parquet {
+
+int64_t NestedStructureDecoder::readOffsetsAndNulls(
+    const uint8_t* definitionLevels,
+    const uint8_t* repetitionLevels,
+    int64_t numValues,
+    uint8_t maxDefinition,
+    uint8_t maxRepeat,
+    BufferPtr& offsetsBuffer,
+    BufferPtr& lengthsBuffer,
+    BufferPtr& nullsBuffer,
+    memory::MemoryPool& pool) {
+  dwio::common::ensureCapacity<uint8_t>(
+      nullsBuffer, bits::nbytes(numValues), &pool);
+  dwio::common::ensureCapacity<vector_size_t>(
+      offsetsBuffer, numValues + 1, &pool);
+  dwio::common::ensureCapacity<vector_size_t>(lengthsBuffer, numValues, &pool);
+
+  auto offsets = offsetsBuffer->asMutable<vector_size_t>();
+  auto lengths = lengthsBuffer->asMutable<vector_size_t>();
+  auto nulls = nullsBuffer->asMutable<uint64_t>();
+
+  int64_t offset = 0;
+  int64_t lastOffset = 0;
+  bool wasLastCollectionNull = definitionLevels[0] == (maxDefinition - 1);
+  bits::setNull(nulls, 0, wasLastCollectionNull);
+  offsets[0] = 0;
+
+  int64_t outputIndex = 1;
+  for (int64_t i = 1; i < numValues; ++i) {
+    uint8_t definitionLevel = definitionLevels[i];
+    uint8_t repetitionLevel = repetitionLevels[i];
+
+    // empty means it belongs to a row that is null in one of its ancestor
+    // levels.
+    bool isEmpty = definitionLevel < (maxDefinition - 1);
+    bool isNull = definitionLevel == (maxDefinition - 1);
+    bool isCollectionBegin = (repetitionLevel < maxRepeat) & !isEmpty;
+    bool isEntryBegin = (repetitionLevel <= maxRepeat) & !isEmpty;
+
+    offset += isEntryBegin & !wasLastCollectionNull;
+    offsets[outputIndex] = offset;
+    lengths[outputIndex - 1] = offset - offsets[outputIndex - 1];
+    bits::setNull(nulls, outputIndex, isNull);
+
+    // Always update the outputs, but only increase the outputIndex when the
+    // current entry is the begin of a new collection, and it's not empty.
+    // Benchmark shows skipping non-collection-begin rows is worse than this
+    // solution by nearly 2x because of extra branchings added for skipping.
+    outputIndex += isCollectionBegin;
+    wasLastCollectionNull = isEmpty ? wasLastCollectionNull : isNull;
+    lastOffset = isCollectionBegin ? offset : lastOffset;
+  }
+
+  offset += !wasLastCollectionNull;
+  offsets[outputIndex] = offset;
+  lengths[outputIndex - 1] = offset - lastOffset;
+
+  return outputIndex;
+}
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/NestedStructureDecoder.h
+++ b/velox/dwio/parquet/reader/NestedStructureDecoder.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/buffer/Buffer.h"
+
+namespace facebook::velox::parquet {
+
+class NestedStructureDecoder {
+ public:
+  /// This function constructs the offsets, lengths and nulls arrays for the
+  /// current level for complext types including ARRAY and MAP. The level is
+  /// identified by the max definition level and repetition level for that
+  /// level. For example, ARRAY<ARRAY<INTEGER>> has the following max definition
+  /// and repetition levels:
+  ///
+  /// type    | ARRAY | ARRAY | INTEGER
+  /// level   |   1   |   2   |   3
+  /// maxDef  |   1   |   3   |   5
+  /// maxRep  |   1   |   2   |   2
+  ///
+  /// If maxDefinition = 3 and maxRepeat = 2, this function will output
+  /// offsets/lengths/nulls for the second level ARRAY.
+  ///
+  /// @param definitionLevels The definition levels for the leaf level
+  /// @param repetitionLevels The repetition levels for the leaf level
+  /// @param numValues The number of elements in definitionLevels or
+  /// repetitionLevels
+  /// @param maxDefinition The maximum possible definition level for this nested
+  /// level
+  /// @param maxRepeat The maximum possible repetition level for this nested
+  /// level
+  /// @param offsetsBuffer The output buffer for the offsets integer array.
+  /// @param lengthsBuffer The output buffer for the lengths integer array. The
+  /// elements are the number of elements in the designated level of collection.
+  /// @param nullsBuffer The output buffer for the nulls bitmap.
+  /// @return The number of elements for the current nested level.
+  static int64_t readOffsetsAndNulls(
+      const uint8_t* definitionLevels,
+      const uint8_t* repetitionLevels,
+      int64_t numValues,
+      uint8_t maxDefinition,
+      uint8_t maxRepeat,
+      BufferPtr& offsetsBuffer,
+      BufferPtr& lengthsBuffer,
+      BufferPtr& nullsBuffer,
+      memory::MemoryPool& pool);
+
+ private:
+  NestedStructureDecoder() {}
+};
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -44,3 +44,20 @@ target_link_libraries(
   velox_hive_connector
   ${FOLLY_WITH_DEPENDENCIES}
   ${FOLLY_BENCHMARK})
+
+add_executable(velox_dwio_parquet_structure_decoder_test
+               NestedStructureDecoderTest.cpp)
+add_test(
+  NAME velox_dwio_parquet_structure_decoder_test
+  COMMAND velox_dwio_parquet_structure_decoder_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(
+  velox_dwio_parquet_structure_decoder_test velox_dwio_native_parquet_reader
+  ${VELOX_LINK_LIBS} ${TEST_LINK_LIBS})
+
+add_executable(velox_dwio_parquet_structure_decoder_benchmark
+               NestedStructureDecoderBenchmark.cpp)
+target_link_libraries(
+  velox_dwio_parquet_structure_decoder_benchmark
+  velox_dwio_native_parquet_reader ${FOLLY_WITH_DEPENDENCIES}
+  ${FOLLY_BENCHMARK})

--- a/velox/dwio/parquet/tests/reader/NestedStructureDecoderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/NestedStructureDecoderBenchmark.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/buffer/Buffer.h"
+#include "velox/dwio/common/BufferUtil.h"
+#include "velox/dwio/parquet/reader/NestedStructureDecoder.h"
+#include "velox/vector/TypeAliases.h"
+
+#include <folly/Benchmark.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::parquet;
+
+class NestedStructureDecoderBenchmark {
+ public:
+  NestedStructureDecoderBenchmark(uint64_t numValues)
+      : numValues_(numValues),
+        definitionLevels_(new unsigned char[numValues]()),
+        repetitionLevels_(new unsigned char[numValues]()),
+        pool_(memory::getDefaultScopedMemoryPool()) {}
+
+  void setUp(uint16_t maxDefinition, uint16_t maxRepetition) {
+    dwio::common::ensureCapacity<uint64_t>(
+        nullsBuffer_, numValues_ / 64 + 1, pool_.get());
+    dwio::common::ensureCapacity<vector_size_t>(
+        offsetsBuffer_, numValues_ + 1, pool_.get());
+    dwio::common::ensureCapacity<vector_size_t>(
+        lengthsBuffer_, numValues_, pool_.get());
+
+    populateInputs(maxDefinition, maxRepetition);
+  }
+
+  uint64_t numValues_;
+
+  std::unique_ptr<uint8_t> definitionLevels_;
+  std::unique_ptr<uint8_t> repetitionLevels_;
+  std::unique_ptr<memory::MemoryPool> pool_;
+
+  BufferPtr offsetsBuffer_;
+  BufferPtr lengthsBuffer_;
+  BufferPtr nullsBuffer_;
+
+ private:
+  void populateInputs(uint16_t maxDefinition, uint16_t maxRepetition) {
+    auto def = definitionLevels_.get();
+    auto rep = repetitionLevels_.get();
+    for (int i = 0; i < numValues_; i++) {
+      def[i] = rand() % maxDefinition;
+      rep[i] = rand() % maxRepetition;
+    }
+  }
+};
+
+BENCHMARK(randomDefs) {
+  folly::BenchmarkSuspender suspender;
+
+  auto numValues = 1'000'000;
+  auto maxDefinition = 9;
+  auto maxRepetition = 4;
+
+  NestedStructureDecoderBenchmark benchmark(numValues);
+  benchmark.setUp(maxDefinition, maxRepetition);
+
+  suspender.dismiss();
+
+  int64_t numCollections = NestedStructureDecoder::readOffsetsAndNulls(
+      benchmark.definitionLevels_.get(),
+      benchmark.repetitionLevels_.get(),
+      numValues,
+      maxDefinition / 2,
+      maxRepetition / 2,
+      benchmark.offsetsBuffer_,
+      benchmark.lengthsBuffer_,
+      benchmark.nullsBuffer_,
+      *benchmark.pool_);
+
+  folly::doNotOptimizeAway(numCollections);
+}
+
+int main(int /*argc*/, char** /*argv*/) {
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/dwio/parquet/tests/reader/NestedStructureDecoderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/NestedStructureDecoderTest.cpp
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/parquet/reader/NestedStructureDecoder.h"
+#include "velox/buffer/Buffer.h"
+#include "velox/dwio/common/BufferUtil.h"
+#include "velox/vector/TypeAliases.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::parquet;
+
+class NestedStructureDecoderTest : public testing::Test {
+ protected:
+  static constexpr int32_t kMaxNumValues = 10'000;
+
+ protected:
+  void SetUp() override {
+    pool_ = memory::getDefaultScopedMemoryPool();
+
+    dwio::common::ensureCapacity<bool>(
+        nullsBuffer_, kMaxNumValues, pool_.get());
+    dwio::common::ensureCapacity<vector_size_t>(
+        offsetsBuffer_, kMaxNumValues + 1, pool_.get());
+    dwio::common::ensureCapacity<vector_size_t>(
+        lengthsBuffer_, kMaxNumValues, pool_.get());
+  }
+
+  void assertStructure(
+      const uint8_t* definitionLevels,
+      const uint8_t* repetitionLevels,
+      int64_t numValues,
+      uint8_t maxDefinition,
+      uint8_t maxRepeat,
+      std::vector<vector_size_t> expectedOffsets,
+      std::vector<vector_size_t> expectedLengths,
+      std::vector<bool> expectedNulls) {
+    int64_t numCollections = NestedStructureDecoder::readOffsetsAndNulls(
+        definitionLevels,
+        repetitionLevels,
+        numValues,
+        maxDefinition,
+        maxRepeat,
+        offsetsBuffer_,
+        lengthsBuffer_,
+        nullsBuffer_,
+        *pool_);
+
+    assertBufferContent<vector_size_t>(
+        offsetsBuffer_, numCollections + 1, expectedOffsets);
+    assertBufferContent<vector_size_t>(
+        lengthsBuffer_, numCollections, expectedLengths);
+    assertNulls(nullsBuffer_, numCollections, expectedNulls);
+  }
+
+ private:
+  template <typename T>
+  void assertBufferContent(
+      BufferPtr actual,
+      size_t actualSize,
+      std::vector<T> expected) {
+    ASSERT_EQ(actualSize, expected.size());
+
+    for (int i = 0; i < actualSize; ++i) {
+      EXPECT_EQ(actual->as<T>()[i], expected[i]);
+    }
+  }
+
+  template <typename T>
+  void printArray(const T* values, int numValues) {
+    std::cout << numValues << std::endl;
+    for (int i = 0; i < numValues; i++) {
+      std::cout << values[i] << " ";
+    }
+    std::cout << std::endl;
+  }
+
+  void
+  assertNulls(BufferPtr actual, size_t actualSize, std::vector<bool> expected) {
+    ASSERT_EQ(actualSize, expected.size());
+
+    auto nullsBuffer = actual->as<uint64_t>();
+    for (int i = 0; i < actualSize; ++i) {
+      EXPECT_EQ(bits::isBitNull(nullsBuffer, i), expected[i]);
+    }
+  }
+
+  std::unique_ptr<memory::MemoryPool> pool_;
+  BufferPtr offsetsBuffer_;
+  BufferPtr lengthsBuffer_;
+  BufferPtr nullsBuffer_;
+};
+
+// ------------------------
+// ARRAY<INTEGER>
+// [1, 2, 3, 4]
+// [2,3]
+// [null, 3, null]
+// NULL
+// [null]
+// [null, null]
+// [7, 8, 9]
+// [8]
+// [null]
+TEST_F(NestedStructureDecoderTest, oneLevel) {
+  uint8_t defs[] = {3, 3, 3, 3, 3, 3, 2, 3, 2, 0, 2, 2, 2, 3, 3, 3, 3, 2};
+  uint8_t reps[] = {0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0};
+  std::vector<vector_size_t> expectedOffsets(
+      {0, 4, 6, 9, 9, 10, 12, 15, 16, 17});
+  std::vector<vector_size_t> expectedLengths({4, 2, 3, 0, 1, 2, 3, 1, 1});
+  std::vector<bool> expectedNulls(
+      {false, false, false, true, false, false, false, false, false});
+
+  assertStructure(
+      defs, reps, 18, 1, 1, expectedOffsets, expectedLengths, expectedNulls);
+}
+
+//---------------------------
+// ARRAY<ARRAY<INTEGER>>
+// [[1], [2, 3]]
+// [[2, null], [2]]
+// [[3, null], null, [4, 5]]
+// [[4, null], null, null]
+// null
+// [null, [null], null, [6]]
+// [[7], null, [7]]
+// [null, [8, 9]]
+// This test would construct offsets/lengths/nulls for the second level ARRAY
+TEST_F(NestedStructureDecoderTest, secondLevelInTwo) {
+  uint8_t defs[] = {5, 5, 5, 5, 4, 5, 5, 4, 2, 5, 5, 5, 4,
+                    2, 2, 0, 2, 4, 2, 5, 5, 2, 5, 2, 5, 5};
+  uint8_t reps[] = {0, 1, 2, 0, 2, 1, 0, 2, 1, 1, 2, 0, 2,
+                    1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 0, 1, 2};
+  std::vector<vector_size_t> expectedOffsets({0,  1,  3,  5,  6,  8,  8,
+                                              10, 12, 12, 12, 12, 13, 13,
+                                              14, 15, 15, 16, 16, 18});
+  std::vector<vector_size_t> expectedLengths(
+      {1, 2, 2, 1, 2, 0, 2, 2, 0, 0, 0, 1, 0, 1, 1, 0, 1, 0, 2});
+  std::vector<bool> expectedNulls(
+      {false,
+       false,
+       false,
+       false,
+       false,
+       true,
+       false,
+       false,
+       true,
+       true,
+       true,
+       false,
+       true,
+       false,
+       false,
+       true,
+       false,
+       true,
+       false});
+
+  // tests the second level, where maxDefinition = 3 and maxRepeat = 2
+  assertStructure(
+      defs, reps, 26, 3, 2, expectedOffsets, expectedLengths, expectedNulls);
+}
+
+//---------------------------
+// ARRAY<ARRAY<INTEGER>>
+// [[2, null], [2]]
+// [[3, null], null, [4, 5]]
+// [[4, null], null, null]
+// null
+// [null, [null], null, [6]]
+// [[7], null, [7]]
+// [null, [8, 9]]
+// [null]
+// This test would construct offsets/lengths/nulls for the top level
+TEST_F(NestedStructureDecoderTest, firstLevelInTwo) {
+  uint8_t defs[] = {5, 4, 5, 5, 4, 2, 5, 5, 5, 4, 2, 2,
+                    0, 2, 4, 2, 5, 5, 2, 5, 2, 5, 5, 2};
+  uint8_t reps[] = {0, 2, 1, 0, 2, 1, 1, 2, 0, 2, 1, 1,
+                    0, 0, 1, 1, 1, 0, 1, 1, 0, 1, 2, 0};
+  std::vector<vector_size_t> expectedOffsets({0, 2, 5, 8, 8, 12, 15, 17, 18});
+  std::vector<vector_size_t> expectedLengths({2, 3, 3, 0, 4, 3, 2, 1});
+  std::vector<bool> expectedNulls({
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+  });
+
+  // tests the second level, where maxDefinition = 1 and maxRepeat = 1
+  assertStructure(
+      defs, reps, 24, 1, 1, expectedOffsets, expectedLengths, expectedNulls);
+}
+
+// ------------------------
+// ARRAY<ARRAY<INTEGER>>
+// [[1, null], null, [2]]
+// null   -- Empty row
+// null   -- Empty row
+// [[3]]
+// This test would construct offsets/lengths/nulls for the second level
+TEST_F(NestedStructureDecoderTest, emptyRowsInTheMiddle) {
+  uint8_t defs[] = {5, 4, 2, 5, 0, 0, 5};
+  uint8_t reps[] = {0, 2, 1, 1, 0, 0, 0};
+  std::vector<vector_size_t> expectedOffsets({0, 2, 2, 3, 4});
+  std::vector<vector_size_t> expectedLengths({2, 0, 1, 1});
+  std::vector<bool> expectedNulls({false, true, false, false});
+
+  // tests the second level, where maxDefinition = 3 and maxRepeat = 2
+  assertStructure(
+      defs, reps, 7, 3, 2, expectedOffsets, expectedLengths, expectedNulls);
+}
+
+// ------------------------
+// ARRAY<ARRAY<INTEGER>>
+// [[1, null], null]
+// null   -- Empty row
+// [[2]]
+// This test would construct offsets/lengths/nulls for the second level
+TEST_F(NestedStructureDecoderTest, emptyRowAfterNull) {
+  uint8_t defs[] = {5, 4, 2, 0, 5};
+  uint8_t reps[] = {0, 2, 1, 0, 0};
+  std::vector<vector_size_t> expectedOffsets({0, 2, 2, 3});
+  std::vector<vector_size_t> expectedLengths({2, 0, 1});
+  std::vector<bool> expectedNulls({false, true, false});
+
+  // tests the second level, where maxDefinition = 3 and maxRepeat = 2
+  assertStructure(
+      defs, reps, 5, 3, 2, expectedOffsets, expectedLengths, expectedNulls);
+}
+
+// ------------------------
+// ARRAY<ARRAY<INTEGER>>
+// [[1, null], null]
+// null   -- Empty row
+// This test would construct offsets/lengths/nulls for the second level
+TEST_F(NestedStructureDecoderTest, emptyRowAtEnd) {
+  uint8_t defs[] = {5, 4, 2, 0};
+  uint8_t reps[] = {0, 2, 1, 0};
+  std::vector<vector_size_t> expectedOffsets({0, 2, 2});
+  std::vector<vector_size_t> expectedLengths({2, 0});
+  std::vector<bool> expectedNulls({false, true});
+
+  // tests the second level, where maxDefinition = 3 and maxRepeat = 2
+  assertStructure(
+      defs, reps, 4, 3, 2, expectedOffsets, expectedLengths, expectedNulls);
+}


### PR DESCRIPTION
Parquet uses "repetition levels" and "definition levels" to identify the nested structures like ARRAY and MAP. This PR decodes these data to create `offsets` and `nulls` data for a given nested level, which is identified by the "max repetition level" and "max definition level".