### PR TITLE
Fix and make Expr::addNulls() a static function for code reuse

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -908,26 +908,36 @@ bool Expr::removeSureNulls(
   return false;
 }
 
+// static
 void Expr::addNulls(
     const SelectivityVector& rows,
     const uint64_t* rawNulls,
     EvalCtx& context,
+    const TypePtr& type,
     VectorPtr& result) {
   // If there's no `result` yet, return a NULL ContantVector.
   if (!result) {
-    result =
-        BaseVector::createNullConstant(type(), rows.size(), context.pool());
+    result = BaseVector::createNullConstant(type, rows.size(), context.pool());
     return;
   }
 
-  // If result is already a NULL ConstantVector, do nothing.
-  if (result->isConstantEncoding() && result->mayHaveNulls()) {
+  // If result is already a NULL ConstantVector, resize the vector if necessary,
+  // or do nothing otherwise.
+  if (result->isConstantEncoding() && result->isNullAt(0)) {
+    if (result->size() < rows.end()) {
+      if (result.unique()) {
+        result->resize(rows.end());
+      } else {
+        result =
+            BaseVector::createNullConstant(type, rows.size(), context.pool());
+      }
+    }
     return;
   }
 
   if (!result.unique() || !result->isNullsWritable()) {
     BaseVector::ensureWritable(
-        SelectivityVector::empty(), type(), context.pool(), result);
+        SelectivityVector::empty(), type, context.pool(), result);
   }
 
   if (result->size() < rows.end()) {
@@ -935,6 +945,14 @@ void Expr::addNulls(
   }
 
   result->addNulls(rawNulls, rows);
+}
+
+void Expr::addNulls(
+    const SelectivityVector& rows,
+    const uint64_t* FOLLY_NULLABLE rawNulls,
+    EvalCtx& context,
+    VectorPtr& result) {
+  addNulls(rows, rawNulls, context, type(), result);
 }
 
 void Expr::evalWithNulls(

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -246,6 +246,13 @@ class Expr {
   // 'rows'. Ensures that '*result' is writable, of sufficient size
   // and that it can take nulls. Makes a new '*result' when
   // appropriate.
+  static void addNulls(
+      const SelectivityVector& rows,
+      const uint64_t* FOLLY_NULLABLE rawNulls,
+      EvalCtx& context,
+      const TypePtr& type,
+      VectorPtr& result);
+
   void addNulls(
       const SelectivityVector& rows,
       const uint64_t* FOLLY_NULLABLE rawNulls,

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -18,6 +18,8 @@
 #include "glog/logging.h"
 #include "gtest/gtest.h"
 
+#include "velox/expression/Expr.h"
+
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
@@ -2781,4 +2783,87 @@ TEST_F(ExprTest, peelWithDefaultNull) {
   auto expected =
       makeNullableFlatVector<bool>({true, true, true, true, true, true});
   assertEqualVectors(expected, result);
+}
+
+TEST_F(ExprTest, addNulls) {
+  const vector_size_t kSize = 6;
+  SelectivityVector rows{kSize};
+
+  auto nulls = allocateNulls(kSize, pool());
+  auto* rawNulls = nulls->asMutable<uint64_t>();
+  bits::setNull(rawNulls, kSize - 1);
+
+  exec::EvalCtx context(execCtx_.get());
+
+  auto checkConstantResult = [&](const VectorPtr& vector) {
+    ASSERT_TRUE(vector->isConstantEncoding());
+    ASSERT_EQ(vector->size(), kSize);
+    ASSERT_TRUE(vector->isNullAt(0));
+  };
+
+  // Test vector that is nullptr.
+  {
+    VectorPtr vector;
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    ASSERT_NE(vector, nullptr);
+    checkConstantResult(vector);
+  }
+
+  // Test vector that is already a constant null vector and is uniquely
+  // referenced.
+  {
+    auto vector = makeNullConstant(TypeKind::BIGINT, kSize - 1);
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    checkConstantResult(vector);
+  }
+
+  // Test vector that is already a constant null vector and is not uniquely
+  // referenced.
+  {
+    auto vector = makeNullConstant(TypeKind::BIGINT, kSize - 1);
+    auto another = vector;
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    checkConstantResult(vector);
+  }
+
+  // Test vector that is a non-null constant vector.
+  {
+    auto vector = makeConstant<int64_t>(100, kSize - 1);
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    ASSERT_TRUE(vector->isFlatEncoding());
+    ASSERT_EQ(vector->size(), kSize);
+    for (auto i = 0; i < kSize - 1; ++i) {
+      ASSERT_FALSE(vector->isNullAt(i));
+      ASSERT_EQ(vector->asFlatVector<int64_t>()->valueAt(i), 100);
+    }
+    ASSERT_TRUE(vector->isNullAt(kSize - 1));
+  }
+
+  auto checkResult = [&](const VectorPtr& vector) {
+    ASSERT_EQ(vector->size(), kSize);
+    for (auto i = 0; i < kSize - 1; ++i) {
+      ASSERT_FALSE(vector->isNullAt(i));
+      ASSERT_EQ(vector->asFlatVector<int64_t>()->valueAt(i), i);
+    }
+    ASSERT_TRUE(vector->isNullAt(kSize - 1));
+  };
+
+  // Test vector that is not uniquely referenced.
+  {
+    VectorPtr vector =
+        makeFlatVector<int64_t>(kSize - 1, [](auto row) { return row; });
+    auto another = vector;
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+
+    checkResult(vector);
+  }
+
+  // Test vector that is uniquely referenced.
+  {
+    VectorPtr vector =
+        makeFlatVector<int64_t>(kSize - 1, [](auto row) { return row; });
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+
+    checkResult(vector);
+  }
 }


### PR DESCRIPTION
Summary:
Expr::addNulls() provides a common logic for adding nulls to a vector and handles
all kinds of cases of input. It is useful when we evaluate an expression on only non-
null rows and want to add remaining nulls to the result. This logic is needed in
CastExpr too, so we make it a static function to make the code reuse possible.

Differential Revision: D40530240

