### PR TITLE
Bring back OBJECT to add_library(velox_hive_connector).

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_hive_connector HiveConnector.cpp FileHandle.cpp)
+add_library(velox_hive_connector OBJECT HiveConnector.cpp FileHandle.cpp)
 
 target_link_libraries(velox_hive_connector velox_connector
                       velox_dwio_dwrf_reader velox_dwio_dwrf_writer velox_file)


### PR DESCRIPTION
Summary:
Removing OBJECT breaks build of executables with errors like below.
  undefined reference to HiveTableHandle::HiveTableHandle()
We suspect it is because some unused symbols get removed from
the *.a library and later cannot be found when linking an executable.

The PR that broke this:
https://github.com/facebookincubator/velox/pull/2809
Example of the linking error:
https://github.com/prestodb/presto/actions/runs/3285240930/jobs/5412120705

Reviewed By: mbasmanova

Differential Revision: D40538062

