### PR TITLE
Allow wrapping std::exception in VeloxException

### DIFF
--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/base/VeloxException.h"
 
 #include <folly/synchronization/AtomicStruct.h>
+#include <exception>
 
 namespace facebook {
 namespace velox {
@@ -76,6 +77,30 @@ VeloxException::VeloxException(
         state.topLevelContext =
             getTopLevelExceptionContextString(exceptionType, state.context);
         state.isRetriable = isRetriable;
+      })) {}
+
+VeloxException::VeloxException(
+    const std::exception_ptr& e,
+    std::string_view message,
+    std::string_view errorSource,
+    bool isRetriable,
+    Type exceptionType,
+    std::string_view exceptionName)
+    : VeloxException(State::make([&](auto& state) {
+        state.exceptionType = exceptionType;
+        state.exceptionName = exceptionName;
+        state.file = "UNKNOWN";
+        state.line = 0;
+        state.function = "";
+        state.failingExpression = "";
+        state.message = message;
+        state.errorSource = errorSource;
+        state.errorCode = "";
+        state.context = getExceptionContext().message(exceptionType);
+        state.topLevelContext =
+            getTopLevelExceptionContextString(exceptionType, state.context);
+        state.isRetriable = isRetriable;
+        state.wrappedException = e;
       })) {}
 
 namespace {

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -188,9 +188,18 @@ bool SignatureBinderBase::tryBind(
   if (isAny(typeSignature)) {
     return true;
   }
+
   const auto baseName = typeSignature.baseName();
   if (isConcreteType(typeParameters_, integerParameters_, baseName)) {
     auto typeName = boost::algorithm::to_upper_copy(baseName);
+
+    if (auto customType = getType(baseName, {})) {
+      VELOX_CHECK_EQ(
+          typeSignature.parameters().size(),
+          0,
+          "Custom types with parameters are not supported yet");
+      return customType->equivalent(*actualType);
+    }
 
     if (typeName != actualType->kindName()) {
       if (!(isCommonDecimalName(typeName) &&

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(velox_expression_test_utility velox_type
 add_executable(
   velox_expression_test
   ArgumentTypeFuzzerTest.cpp
+  CustomTypeTest.cpp
   ExprEncodingsTest.cpp
   ExprTest.cpp
   ExprCompilerTest.cpp

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::test {
+
+class CustomTypeTest : public functions::test::FunctionBaseTest {};
+
+namespace {
+struct FancyInt {
+  const int64_t n;
+
+  explicit FancyInt(int64_t _n) : n{_n} {}
+};
+
+class FancyIntType : public OpaqueType {
+  FancyIntType() : OpaqueType(std::type_index(typeid(FancyInt))) {}
+
+ public:
+  static const std::shared_ptr<const FancyIntType>& get() {
+    static const std::shared_ptr<const FancyIntType> instance{
+        new FancyIntType()};
+
+    return instance;
+  }
+
+  std::string toString() const override {
+    return "fancy_int";
+  }
+};
+
+class FancyIntTypeFactories : public CustomTypeFactories {
+ public:
+  TypePtr getType(std::vector<TypePtr> /* childTypes */) const override {
+    return FancyIntType::get();
+  }
+
+  exec::CastOperatorPtr getCastOperator() const override {
+    VELOX_UNSUPPORTED();
+  }
+};
+
+class ToFancyIntFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    auto flatInput = args[0]->as<SimpleVector<int64_t>>();
+
+    BaseVector::ensureWritable(rows, outputType, context.pool(), result);
+    auto flatResult = result->asFlatVector<std::shared_ptr<void>>();
+
+    rows.applyToSelected([&](auto row) {
+      flatResult->set(row, std::make_shared<FancyInt>(flatInput->valueAt(row)));
+    });
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    // bigint -> fancy_int
+    return {exec::FunctionSignatureBuilder()
+                .returnType("fancy_int")
+                .argumentType("bigint")
+                .build()};
+  }
+};
+
+class FromFancyIntFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    auto flatInput = args[0]->as<SimpleVector<std::shared_ptr<void>>>();
+
+    BaseVector::ensureWritable(rows, BIGINT(), context.pool(), result);
+    auto flatResult = result->asFlatVector<int64_t>();
+
+    rows.applyToSelected([&](auto row) {
+      flatResult->set(
+          row, std::static_pointer_cast<FancyInt>(flatInput->valueAt(row))->n);
+    });
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    // fancy_int -> bigint
+    return {exec::FunctionSignatureBuilder()
+                .returnType("bigint")
+                .argumentType("fancy_int")
+                .build()};
+  }
+};
+} // namespace
+
+/// Register custom type based on OpaqueType along with a function that produces
+/// this type and another function that consumes this type. Evaluate simple
+/// expressions.
+TEST_F(CustomTypeTest, customType) {
+  registerType("fancy_int", std::make_unique<FancyIntTypeFactories>());
+  exec::registerVectorFunction(
+      "to_fancy_int",
+      ToFancyIntFunction::signatures(),
+      std::make_unique<ToFancyIntFunction>());
+  exec::registerVectorFunction(
+      "from_fancy_int",
+      FromFancyIntFunction::signatures(),
+      std::make_unique<FromFancyIntFunction>());
+
+  auto data = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+
+  auto result =
+      evaluate("from_fancy_int(to_fancy_int(c0))", makeRowVector({data}));
+  assertEqualVectors(data, result);
+
+  result = evaluate(
+      "from_fancy_int(to_fancy_int(c0 + 10)) - 10", makeRowVector({data}));
+  assertEqualVectors(data, result);
+}
+} // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
We can use this to wrap std::exceptions thrown from UDFs and add  useful context
for debugging.

Differential Revision: D40539915

