### PR TITLE
cmake: fix the compatibility with recent cmake versions

### DIFF
--- a/velox/experimental/codegen/code_generator/CMakeLists.txt
+++ b/velox/experimental/codegen/code_generator/CMakeLists.txt
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_all_link STATIC)
+add_library(velox_all_link INTERFACE)
 target_link_libraries(
   velox_all_link
-  velox_codegen_code_generator
-  velox_codegen_utils_resource_path
-  velox_core
-  velox_parse_parser
-  velox_exec_test_lib
-  velox_functions_lib
-  velox_functions_prestosql_impl
-  ${FOLLY_WITH_DEPENDENCIES}
-  gtest
-  gtest_main
-  ${GFLAGS_LIBRARIES}
-  glog::glog
-  ${FMT})
+  INTERFACE velox_codegen_code_generator
+            velox_codegen_utils_resource_path
+            velox_core
+            velox_parse_parser
+            velox_exec_test_lib
+            velox_functions_lib
+            velox_functions_prestosql_impl
+            ${FOLLY_WITH_DEPENDENCIES}
+            gtest
+            gtest_main
+            ${GFLAGS_LIBRARIES}
+            glog::glog
+            ${FMT})
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/experimental/codegen/code_generator/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/code_generator/tests/CMakeLists.txt
@@ -14,7 +14,6 @@
 
 # write all cmake var in a file for post-processing
 
-set(CODEGEN_LINK_PATH "$<TARGET_FILE:velox_all_link>")
 get_directory_property(DEFINED_VARIABLE VARIABLES)
 foreach(VR IN LISTS DEFINED_VARIABLE)
   set(CMAKE_VARS "${CMAKE_VARS}\n${VR}=${${VR}}")

--- a/velox/experimental/codegen/utils/resources/CMakeLists.txt
+++ b/velox/experimental/codegen/utils/resources/CMakeLists.txt
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(CODEGEN_LINK_PATH "$<TARGET_FILE:velox_all_link>")
 get_directory_property(DEFINED_VARIABLE VARIABLES)
 foreach(VR IN LISTS DEFINED_VARIABLE)
   set(CMAKE_VARS "${CMAKE_VARS}\n${VR}=${${VR}}")


### PR DESCRIPTION
`add_library` without no sources has been not supported for a long time, as it should be a bug: https://gitlab.kitware.com/cmake/cmake/-/issues/17978

By the way `CODEGEN_LINK_PATH` hasn't been used anywhere.