### PR TITLE
Move protobuf build to use resolve_dependency()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   link_directories("${ICU_INCLUDE_DIRS}/../lib")
 endif()
 
+# Locate or build folly.
 set(folly_SOURCE AUTO)
 resolve_dependency(folly)
 
@@ -306,6 +307,10 @@ endif()
 include_directories(SYSTEM ${FOLLY_INCLUDE_DIRS})
 
 if(NOT ${VELOX_BUILD_MINIMAL})
+  # Locate or build protobuf.
+  set(protobuf_SOURCE AUTO)
+  resolve_dependency(protobuf)
+
   find_package(Protobuf 3.21.4 REQUIRED)
 endif()
 

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -46,16 +46,6 @@ function install_libhdfs3 {
   cmake_install
 }
 
-function install_protobuf {
-  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz
-  tar -xzf protobuf-all-21.4.tar.gz --no-same-owner
-  cd protobuf-21.4
-  ./configure --prefix=/usr
-  make "-j$(nproc)"
-  make install
-  ldconfig
-}
-
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 cd "${DEPENDENCY_DIR}" || exit
 # aws-sdk-cpp missing dependencies
@@ -74,7 +64,6 @@ fi
 if [[ "$OSTYPE" == darwin* ]]; then
    brew install libxml2 gsasl
 fi
-install_protobuf
 install_aws-sdk-cpp
 install_libhdfs3
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -72,19 +72,8 @@ function install_fmt {
   cmake_install -DFMT_TEST=OFF
 }
 
-function install_protobuf {
-  wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz
-  tar -xzf protobuf-all-21.4.tar.gz
-  cd protobuf-21.4
-  ./configure --prefix=/usr
-  make "-j$(nproc)"
-  make install
-  ldconfig
-}
-
 function install_velox_deps {
   run_and_time install_fmt
-  run_and_time install_protobuf
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.

--- a/velox/substrait/CMakeLists.txt
+++ b/velox/substrait/CMakeLists.txt
@@ -33,8 +33,9 @@ get_filename_component(PROTO_DIR ${substrait_proto_directory}/, DIRECTORY)
 # Generate Substrait hearders
 add_custom_command(
   OUTPUT ${PROTO_OUTPUT_FILES}
-  COMMAND protoc --proto_path ${CMAKE_SOURCE_DIR}/ --cpp_out ${CMAKE_SOURCE_DIR}
-          ${PROTO_FILES}
+  COMMAND
+    ${protobuf_BINARY_DIR}/protoc --proto_path ${CMAKE_SOURCE_DIR}/ --proto_path
+    ${Protobuf_INCLUDE_DIR} --cpp_out ${CMAKE_SOURCE_DIR} ${PROTO_FILES}
   DEPENDS ${PROTO_DIR}
   COMMENT "Running PROTO compiler"
   VERBATIM)


### PR DESCRIPTION
Moving protobuf to use resolve_dependency() so it doesn't need to be compiled and installed manually in the user's root system. It also allows us to have more control about the exact version of protoc and libprotobub-dev being used. 