### PR TITLE
Add to close file on LocalReadFile

### DIFF
--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -195,6 +195,8 @@ class LocalReadFile final : public ReadFile {
 
   explicit LocalReadFile(int32_t fd);
 
+  ~LocalReadFile();
+
   std::string_view
   pread(uint64_t offset, uint64_t length, void* FOLLY_NONNULL buf) const final;
 

--- a/velox/core/Context.h
+++ b/velox/core/Context.h
@@ -265,7 +265,6 @@ class BaseConfigManager {
     return SubscriptionHandle{typeid(T), subscription};
   }
 
-  //  std::atomic<shared_ptr<const Config>> config_;
   std::shared_ptr<const Config> config_;
 
   mutable folly::SharedMutex mutex_;


### PR DESCRIPTION
Add to close file on LocalReadFile which might
run out of system open file descriptor for long
running service like Prestissmo. Found this issue
in hash join test as we run too many rounds