### PR TITLE
Adjust spilling session properties.

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -128,6 +128,11 @@ class QueryConfig {
   static constexpr const char* kAggregationSpillMemoryThreshold =
       "aggregation_spill_memory_threshold";
 
+  /// The max memory that a hash join can use before spilling. If it 0, then
+  /// there is no limit.
+  static constexpr const char* kJoinSpillMemoryThreshold =
+      "join_spill_memory_threshold";
+
   /// The max memory that an order by can use before spilling. If it 0, then
   /// there is no limit.
   static constexpr const char* kOrderBySpillMemoryThreshold =
@@ -164,6 +169,11 @@ class QueryConfig {
   double partialAggregationGoodPct() const {
     static constexpr double kDefault = 0.5;
     return get<double>(kPartialAggregationGoodPct, kDefault);
+  }
+
+  uint64_t joinSpillMemoryThreshold() const {
+    static constexpr uint64_t kDefault = 0;
+    return get<uint64_t>(kJoinSpillMemoryThreshold, kDefault);
   }
 
   uint64_t orderBySpillMemoryThreshold() const {
@@ -261,19 +271,19 @@ class QueryConfig {
   /// Returns 'is aggregation spilling enabled' flag. Must also check the
   /// spillEnabled()!
   bool aggregationSpillEnabled() const {
-    return get<bool>(kAggregationSpillEnabled, false);
+    return get<bool>(kAggregationSpillEnabled, true);
   }
 
   /// Returns 'is join spilling enabled' flag. Must also check the
   /// spillEnabled()!
   bool joinSpillEnabled() const {
-    return get<bool>(kJoinSpillEnabled, false);
+    return get<bool>(kJoinSpillEnabled, true);
   }
 
   /// Returns 'is orderby spilling enabled' flag. Must also check the
   /// spillEnabled()!
   bool orderBySpillEnabled() const {
-    return get<bool>(kOrderBySpillEnabled, false);
+    return get<bool>(kOrderBySpillEnabled, true);
   }
 
   // Returns a percentage of aggregation or join input batches that


### PR DESCRIPTION
Summary:
Add 'join_spill_memory_threshold'.
Make 'aggregation_spill_enabled', 'join_spill_enabled' and
'order_by_spill_enabled' true by default (Presto's behavior).

Reviewed By: xiaoxmeng

Differential Revision: D40597088

