### PR TITLE
Add max spill level for recursive spilling in hash join

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -135,6 +135,15 @@ class QueryConfig {
 
   static constexpr const char* kTestingSpillPct = "testing.spill-pct";
 
+  /// The max allowed spilling level with zero being the initial spilling level.
+  /// This only applies for hash build spilling which might trigger recursive
+  /// spilling when the build table is too big. If it is set to -1, then there
+  /// is no limit and then some extreme large query might run out of spilling
+  /// partition bits (see kSpillPartitionBits) at the end. The max spill level
+  /// is used in production to prevent some bad user queries from using too much
+  /// io and cpu resources.
+  static constexpr const char* kMaxSpillLevel = "max_spill_level";
+
   static constexpr const char* kSpillStartPartitionBit =
       "spiller-start-partition-bit";
 
@@ -280,6 +289,10 @@ class QueryConfig {
   // will be forced to spill for testing. 0 means no extra spilling.
   int32_t testingSpillPct() const {
     return get<int32_t>(kTestingSpillPct, 0);
+  }
+
+  int32_t maxSpillLevel() const {
+    return get<int32_t>(kMaxSpillLevel, 4);
   }
 
   /// Returns the start partition bit which is used with 'kSpillPartitionBits'

--- a/velox/docs/develop/joins.rst
+++ b/velox/docs/develop/joins.rst
@@ -268,6 +268,9 @@ down.
 * dynamicFiltersProduced - number of dynamic filters generated (at most one per
   join key)
 
+* maxSpillLevel - the max spill level that has been triggered with zero for the
+initial spill.
+
 TableScan operator reports the number of dynamic filters it received and passed
 to HiveConnector.
 

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -15,9 +15,12 @@
  */
 
 #include "velox/exec/HashBuild.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 #include "velox/expression/FieldReference.h"
+
+using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
 namespace {
@@ -166,15 +169,27 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
   if (!spillEnabled()) {
     return;
   }
-
   const auto& spillConfig = spillConfig_.value();
   HashBitRange hashBits = spillConfig.hashBitRange;
-  if (spillPartition != nullptr) {
+
+  if (spillPartition == nullptr) {
+    spillGroup_->addOperator(
+        *this,
+        [&](const std::vector<Operator*>& operators) { runSpill(operators); });
+  } else {
+    spillInputReader_ = spillPartition->createReader();
+
     const auto startBit = spillPartition->id().partitionBitOffset() +
         spillConfig.hashBitRange.numBits();
+    // Disable spilling if exceeding the max spill level and the query might run
+    // out of memory if the restored partition still can't fit in memory.
+    if (spillConfig.exceedSpillLevelLimit(startBit)) {
+      return;
+    }
     hashBits =
         HashBitRange(startBit, startBit + spillConfig.hashBitRange.numBits());
   }
+
   spiller_ = std::make_unique<Spiller>(
       Spiller::Type::kHashJoinBuild,
       table_->rows(),
@@ -193,13 +208,6 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
       Spiller::spillPool(),
       spillConfig.executor);
 
-  if (spillPartition == nullptr) {
-    spillGroup_->addOperator(
-        *this,
-        [&](const std::vector<Operator*>& operators) { runSpill(operators); });
-  } else {
-    spillInputReader_ = spillPartition->createReader();
-  }
   const int32_t numPartitions = spiller_->hashBits().numPartitions();
   spillInputIndicesBuffers_.resize(numPartitions);
   rawSpillInputIndicesBuffers_.resize(numPartitions);
@@ -357,7 +365,7 @@ void HashBuild::addInput(RowVectorPtr input) {
 bool HashBuild::ensureInputFits(RowVectorPtr& input) {
   // NOTE: we don't need memory reservation if all the partitions are spilling
   // as we spill all the input rows to disk directly.
-  if (!spillEnabled() || spiller_->isAllSpilled()) {
+  if (!spillEnabled() || spiller_ == nullptr || spiller_->isAllSpilled()) {
     return true;
   }
 
@@ -444,7 +452,7 @@ bool HashBuild::reserveMemory(const RowVectorPtr& input) {
 void HashBuild::spillInput(const RowVectorPtr& input) {
   VELOX_CHECK_EQ(input->size(), activeRows_.size());
 
-  if (!spillEnabled() || !spiller_->isAnySpilled() ||
+  if (!spillEnabled() || spiller_ == nullptr || !spiller_->isAnySpilled() ||
       !activeRows_.hasSelections()) {
     return;
   }
@@ -501,9 +509,11 @@ void HashBuild::maybeSetupSpillChildVectors(const RowVectorPtr& input) {
 void HashBuild::prepareInputIndicesBuffers(
     vector_size_t numInput,
     const SpillPartitionNumSet& spillPartitions) {
+  const auto maxIndicesBufferBytes = numInput * sizeof(vector_size_t);
   for (const auto& partition : spillPartitions) {
     if (spillInputIndicesBuffers_[partition] == nullptr ||
-        (spillInputIndicesBuffers_[partition]->size() < numInput)) {
+        (spillInputIndicesBuffers_[partition]->size() <
+         maxIndicesBufferBytes)) {
       spillInputIndicesBuffers_[partition] = allocateIndices(numInput, pool());
       rawSpillInputIndicesBuffers_[partition] =
           spillInputIndicesBuffers_[partition]->asMutable<vector_size_t>();
@@ -700,9 +710,9 @@ bool HashBuild::finishHashBuild() {
     if (spiller_ != nullptr) {
       spillStats += spiller_->stats();
 
-      stats_.spilledBytes = spillStats.spilledBytes;
-      stats_.spilledRows = spillStats.spilledRows;
-      stats_.spilledPartitions = spillStats.spilledPartitions;
+      stats_.spilledBytes += spillStats.spilledBytes;
+      stats_.spilledRows += spillStats.spilledRows;
+      stats_.spilledPartitions += spillStats.spilledPartitions;
 
       spiller_->finishSpill(spillPartitions);
 
@@ -811,6 +821,13 @@ void HashBuild::addRuntimeStats() {
       stats_.addRuntimeStat(
           fmt::format("distinctKey{}", i), RuntimeCounter(asDistinct));
     }
+  }
+  // Add max spilling level stats if spilling has been triggered.
+  if (spiller_ != nullptr && spiller_->isAnySpilled()) {
+    stats_.addRuntimeStat(
+        "maxSpillLevel",
+        RuntimeCounter(
+            spillConfig()->spillLevel(spiller_->hashBits().begin())));
   }
 }
 

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -89,6 +89,10 @@ class BaseHashTable {
   struct RowsIterator {
     int32_t hashTableIndex_{-1};
     RowContainerIterator rowContainerIterator_;
+
+    void reset() {
+      *this = {};
+    }
   };
 
   /// Takes ownership of 'hashers'. These are used to keep key-level

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -371,6 +371,7 @@ std::optional<Spiller::Config> makeOperatorSpillConfig(
           queryConfig.spillStartPartitionBit(),
           queryConfig.spillStartPartitionBit() +
               queryConfig.spillPartitionBits()),
+      queryConfig.maxSpillLevel(),
       queryConfig.testingSpillPct());
 }
 


### PR DESCRIPTION
- Add max spill level query config
- Add max spill level check utility and integrate into the hash
- build side.
- Add runtime stats for max spill level with documentation.
- 

The followup with probe side change will cover the testing
of the max spill level.