### PR TITLE
Add support for lazy vector generation to expression fuzzer

### DIFF
--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -84,7 +84,7 @@ target_link_libraries(
 add_library(velox_expression_verifier ExpressionVerifier.cpp)
 
 target_link_libraries(velox_expression_verifier velox_vector_test_lib
-                      velox_type)
+                      velox_vector_fuzzer velox_type)
 
 add_library(velox_expression_fuzzer ExpressionFuzzer.cpp)
 

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -38,21 +38,28 @@ class ExpressionVerifier {
       ExpressionVerifierOptions options)
       : execCtx_(execCtx), options_(options) {}
 
-  // Executes an expression and verifies the results/exceptions from common
-  // execution path vs simple execution path. Returns:
-  //
+  // Executes an expression both using common path (all evaluation
+  // optimizations) and simplified path. Additionally, a sorted list of column
+  // indices can be passed via 'columnsToWarpInLazy' which specify the
+  // columns/children in the input row vector that should be wrapped in a lazy
+  // layer before running it through the common evaluation path.
+  // Returns:
   //  - true if both paths succeeded and returned the exact same results.
-  //  - false if both paths failed with compatible exceptions.
+  //  - false if both failed with compatible exceptions.
   //  - throws otherwise (incompatible exceptions or different results).
   bool verify(
       const core::TypedExprPtr& plan,
       const RowVectorPtr& rowVector,
       VectorPtr&& resultVector,
-      bool canThrow);
+      bool canThrow,
+      std::vector<column_index_t> columnsToWarpInLazy = {});
 
  private:
+  // Utility method used to serialize the relevant data required to repro a
+  // crash.
   void persistReproInfo(
       const VectorPtr& inputVector,
+      std::vector<column_index_t> columnsToWarpInLazy,
       const VectorPtr& resultVector,
       const std::string& sql);
 

--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -774,4 +774,31 @@ std::optional<std::string> generateFilePath(
   }
   return path;
 }
+
+std::optional<std::string> generateFolderPath(
+    const char* basePath,
+    const char* prefix) {
+  auto path = fmt::format("{}/velox_{}_XXXXXX", basePath, prefix);
+  auto createdPath = mkdtemp(path.data());
+  if (createdPath == nullptr) {
+    return std::nullopt;
+  }
+  return path;
+}
+
+template <typename T>
+void saveVectorTofile(const std::vector<T>& list, const char* filePath) {
+  std::ofstream outputFile(filePath, std::ofstream::binary);
+  // Size of the vector
+  write<int32_t>(list.size(), outputFile);
+
+  for (auto element : list) {
+    write<T>(element, outputFile);
+  }
+  outputFile.close();
+}
+
+template void saveVectorTofile<column_index_t>(
+    const std::vector<column_index_t>& list,
+    const char* filePath);
 } // namespace facebook::velox

--- a/velox/vector/VectorSaver.h
+++ b/velox/vector/VectorSaver.h
@@ -61,9 +61,23 @@ VectorPtr restoreVectorFromFile(
 /// Reads a string from a file stored by saveStringToFile() method
 std::string restoreStringFromFile(const char* FOLLY_NONNULL filePath);
 
-/// Generates a file path in specified directory. Returns std::nullopt on
-/// failure.
+/// Generates a file path in specified directory and creates it. Returns
+/// std::nullopt on failure.
 std::optional<std::string> generateFilePath(
     const char* FOLLY_NONNULL basePath,
     const char* FOLLY_NONNULL prefix);
+
+/// Generates a folder path in specified directory and creates it. Returns
+/// std::nullopt on failure.
+std::optional<std::string> generateFolderPath(
+    const char* FOLLY_NONNULL basePath,
+    const char* FOLLY_NONNULL prefix);
+
+// Write the vector to a file. Contents would include the size of the list
+// followed by all the values.
+template <typename T>
+void saveVectorTofile(
+    const std::vector<T>& list,
+    const char* FOLLY_NONNULL filePath);
+
 } // namespace facebook::velox


### PR DESCRIPTION
This patch leverages the ability to wrap a vector in lazy encoding
that was recently added in the VectorFuzzer and enables it to run
the same input in both the common and simplified evaluation path
but with the common path having some inputs wrapped in lazy
encoding. The columns to be wrapped are randomly chosen with a
probability that can be specified by a gflag
"lazy_vector_generation_ratio".

Additionally
- context about which columns were chosen to be wrapped are also
seriazlized with other data required to repro in case of an error.
- The repro data is now stored in a newly generated folder with a
unique name.