### PR TITLE
Enable usage of aggregate functions in window operator

### DIFF
--- a/velox/docs/functions/window.rst
+++ b/velox/docs/functions/window.rst
@@ -115,3 +115,10 @@ Value functions
 Returns the value at the specified offset from the beginning of the window. Offsets start at 1. The offset
 can be any scalar expression. If the offset is null or greater than the number of values in the window, null is
 returned. It is an error for the offset to be zero or negative.
+
+===================
+Aggregate functions
+===================
+
+All aggregate functions can be used as window functions by adding the OVER clause. The aggregate function is computed
+for each row over the rows within the current row's window frame.

--- a/velox/functions/prestosql/window/AggregateWindow.cpp
+++ b/velox/functions/prestosql/window/AggregateWindow.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/WindowFunction.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::window {
+
+namespace {
+
+// A generic way to compute any aggregation used as a window function.
+// Creates an Aggregate function object for the window function invocation.
+// At each row, computes the aggregation across all rows from the frameStart
+// to frameEnd boundaries at that row using singleGroup.
+class AggregateWindowFunction : public exec::WindowFunction {
+ public:
+  AggregateWindowFunction(
+      const std::string& name,
+      const std::vector<exec::WindowFunctionArg>& args,
+      const TypePtr& resultType,
+      velox::memory::MemoryPool* pool)
+      : WindowFunction(resultType, pool) {
+    argTypes_.reserve(args.size());
+    argIndices_.reserve(args.size());
+    argVectors_.reserve(args.size());
+    for (const auto& arg : args) {
+      argTypes_.push_back(arg.type);
+      // TODO : Enhance code to handle constant arguments.
+      VELOX_CHECK_NULL(
+          arg.constantValue,
+          "Constant arguments are not supported in aggregate window functions.");
+      VELOX_CHECK(arg.index.has_value());
+      argIndices_.push_back(arg.index.value());
+      argVectors_.push_back(BaseVector::create(arg.type, 0, pool_));
+    }
+    // Create an Aggregate function object to do result computation. Window
+    // function usage only requires single group aggregation for calculating
+    // the function value for each row.
+    aggregate_ = exec::Aggregate::create(
+        name, core::AggregationNode::Step::kSingle, argTypes_, resultType);
+
+    // Aggregate initialization.
+    // Row layout is:
+    //  - null flags - one bit per aggregate.
+    //  - uint32_t row size,
+    //  - fixed-width accumulators - one per aggregate
+    //
+    // Here we always make space for a row size since we only have one
+    // row and no RowContainer. We also have a single aggregate here, so there
+    // is only one null bit.
+    static const int32_t kNullOffset = 0;
+    static const int32_t kRowSizeOffset = bits::nbytes(1);
+    singleGroupRowSize_ = kRowSizeOffset + sizeof(int32_t);
+    aggregate_->setOffsets(
+        singleGroupRowSize_,
+        exec::RowContainer::nullByte(kNullOffset),
+        exec::RowContainer::nullMask(kNullOffset),
+        /* needed for out of line allocations */ kRowSizeOffset);
+    singleGroupRowSize_ += aggregate_->accumulatorFixedWidthSize();
+
+    // Construct the single row in the MemoryPool.
+    singleGroupRowBufferPtr_ =
+        AlignedBuffer::allocate<char>(singleGroupRowSize_, pool_);
+    rawSingleGroupRow_ = singleGroupRowBufferPtr_->asMutable<char>();
+
+    // Constructing a vector of a single result value used for copying from
+    // the aggregate to the final result.
+    aggregateResultVector_ = BaseVector::create(resultType, 1, pool_);
+  }
+
+  ~AggregateWindowFunction() {
+    // Needed to delete any out-of-line storage for the accumulator in the
+    // group row.
+    std::vector<char*> singleGroupRowVector = {rawSingleGroupRow_};
+    aggregate_->destroy(folly::Range(singleGroupRowVector.data(), 1));
+  }
+
+  void resetPartition(const exec::WindowPartition* partition) override {
+    partition_ = partition;
+  }
+
+  void apply(
+      const BufferPtr& /*peerGroupStarts*/,
+      const BufferPtr& /*peerGroupEnds*/,
+      const BufferPtr& frameStarts,
+      const BufferPtr& frameEnds,
+      vector_size_t resultOffset,
+      const VectorPtr& result) override {
+    int numRows = frameStarts->size() / sizeof(vector_size_t);
+    auto rawFrameStarts = frameStarts->as<vector_size_t>();
+    auto rawFrameEnds = frameEnds->as<vector_size_t>();
+
+    FrameMetadata frameMetadata =
+        fillArgVectors(rawFrameStarts, rawFrameEnds, numRows);
+    if (frameMetadata.fixedFirstRow && frameMetadata.nonDecreasingFrameEnd) {
+      fixedStartAggregation(
+          numRows,
+          frameMetadata.firstRow,
+          frameMetadata.lastRow,
+          rawFrameEnds,
+          resultOffset,
+          result);
+    } else {
+      simpleAggregation(
+          numRows,
+          frameMetadata.firstRow,
+          frameMetadata.lastRow,
+          rawFrameStarts,
+          rawFrameEnds,
+          resultOffset,
+          result);
+    }
+  }
+
+ private:
+  struct FrameMetadata {
+    // Min frame start row required for aggregation.
+    vector_size_t firstRow;
+    // Max frame end required for the aggregation.
+    vector_size_t lastRow;
+    // Set to indicate if all rows require the same start row.
+    bool fixedFirstRow;
+    // Indicates if the frame end values are non-decreasing. If they are
+    // then we can perform optimizations to do incremental aggregation.
+    bool nonDecreasingFrameEnd;
+  };
+
+  FrameMetadata fillArgVectors(
+      const vector_size_t* rawFrameStarts,
+      const vector_size_t* rawFrameEnds,
+      vector_size_t numRows) {
+    // Argument values are needed to compute the aggregate. The aggregate
+    // computation for each row needs the values from its frameStart to frameEnd
+    // indices. So for each apply() we read arguments from the least
+    // frameStart to the highest frameEnd value in the row block.
+    vector_size_t firstRow = rawFrameStarts[0];
+    vector_size_t lastRow = rawFrameEnds[0];
+
+    bool nonDecreasingFrameEnd = true;
+    for (int i = 1; i < numRows; i++) {
+      firstRow = std::min(firstRow, rawFrameStarts[i]);
+      lastRow = std::max(lastRow, rawFrameEnds[i]);
+      nonDecreasingFrameEnd &= rawFrameEnds[i] >= rawFrameEnds[i - 1];
+    }
+    bool fixedFirstRow = firstRow == rawFrameStarts[0];
+
+    vector_size_t numFrameRows = lastRow + 1 - firstRow;
+    for (int i = 0; i < argIndices_.size(); i++) {
+      argVectors_[i]->resize(numRows);
+      partition_->extractColumn(
+          argIndices_[i], firstRow, numFrameRows, 0, argVectors_[i]);
+    }
+
+    return {firstRow, lastRow, fixedFirstRow, nonDecreasingFrameEnd};
+  }
+
+  void computeAggregate(
+      SelectivityVector rows,
+      vector_size_t startFrame,
+      vector_size_t endFrame) {
+    rows.clearAll();
+    rows.setValidRange(startFrame, endFrame, true);
+    rows.updateBounds();
+
+    aggregate_->addSingleGroupRawInput(
+        rawSingleGroupRow_, rows, argVectors_, false);
+    aggregate_->extractValues(&rawSingleGroupRow_, 1, &aggregateResultVector_);
+  }
+
+  void fixedStartAggregation(
+      vector_size_t numRows,
+      vector_size_t startFrame,
+      vector_size_t endFrame,
+      const vector_size_t* rawFrameEnds,
+      vector_size_t resultOffset,
+      const VectorPtr& result) {
+    SelectivityVector rows;
+    rows.resize(endFrame + 1 - startFrame);
+
+    auto singleGroup = std::vector<vector_size_t>{0};
+    // Initialize the aggregate at the beginning of the output block.
+    aggregate_->clear();
+    aggregate_->initializeNewGroups(&rawSingleGroupRow_, singleGroup);
+    auto prevFrameEnd = 0;
+
+    // This is a simple optimization for frames that have a fixed startFrame
+    // and increasing frameEnd values. In that case, we can
+    // incrementally aggregate over the new rows seen in the frame between
+    // the previous and current row.
+    for (int i = 0; i < numRows; i++) {
+      auto currentFrameEnd = rawFrameEnds[i] - startFrame + 1;
+      if (currentFrameEnd > prevFrameEnd) {
+        computeAggregate(rows, prevFrameEnd, currentFrameEnd);
+      }
+
+      result->copy(aggregateResultVector_.get(), resultOffset + i, 0, 1);
+      prevFrameEnd = currentFrameEnd;
+    }
+  }
+
+  void simpleAggregation(
+      vector_size_t numRows,
+      vector_size_t minFrame,
+      vector_size_t maxFrame,
+      const vector_size_t* frameStartsVector,
+      const vector_size_t* frameEndsVector,
+      vector_size_t resultOffset,
+      const VectorPtr& result) {
+    SelectivityVector rows;
+    rows.resize(maxFrame + 1 - minFrame);
+    auto singleGroup = std::vector<vector_size_t>{0};
+    for (int i = 0; i < numRows; i++) {
+      // This is a very naive algorithm.
+      // It evaluates the entire aggregation for each row by iterating over
+      // input rows from frameStart to frameEnd in the SelectivityVector.
+      // TODO : Try to re-use previous computations by advancing and retracting
+      // the aggregation based on the frame changes with each row. This would
+      // require adding new APIs to the Aggregate framework.
+      aggregate_->clear();
+      aggregate_->initializeNewGroups(&rawSingleGroupRow_, singleGroup);
+
+      auto frameStartIndex = frameStartsVector[i] - minFrame;
+      auto frameEndIndex = frameEndsVector[i] - minFrame + 1;
+      computeAggregate(rows, frameStartIndex, frameEndIndex);
+      result->copy(aggregateResultVector_.get(), resultOffset + i, 0, 1);
+    }
+  }
+
+  // Aggregate function object required for this window function evaluation.
+  std::unique_ptr<exec::Aggregate> aggregate_;
+
+  // Current WindowPartition used for accessing rows in the apply method.
+  const exec::WindowPartition* partition_;
+
+  // Args information : their types, column indexes in inputs and vectors
+  // used to populate values to pass to the aggregate function.
+  std::vector<TypePtr> argTypes_;
+  std::vector<column_index_t> argIndices_;
+  std::vector<VectorPtr> argVectors_;
+
+  // This is a single aggregate row needed by the aggregate function for its
+  // computation. These values are for the row and its various components.
+  BufferPtr singleGroupRowBufferPtr_;
+  char* rawSingleGroupRow_;
+  vector_size_t singleGroupRowSize_;
+
+  // Used for per-row aggregate computations.
+  // This vector is used to copy from the aggregate to the result.
+  VectorPtr aggregateResultVector_;
+};
+
+} // namespace
+
+void registerAggregateWindowFunction(const std::string& name) {
+  auto aggregateFunctionSignatures = exec::getAggregateFunctionSignatures(name);
+  if (aggregateFunctionSignatures.has_value()) {
+    // This copy is needed to obtain a vector of the base FunctionSignaturePtr
+    // from the AggregateFunctionSignaturePtr type of
+    // aggregateFunctionSignatures variable.
+    std::vector<exec::FunctionSignaturePtr> signatures(
+        aggregateFunctionSignatures.value().begin(),
+        aggregateFunctionSignatures.value().end());
+
+    exec::registerWindowFunction(
+        name,
+        std::move(signatures),
+        [name](
+            const std::vector<exec::WindowFunctionArg>& args,
+            const TypePtr& resultType,
+            velox::memory::MemoryPool* pool)
+            -> std::unique_ptr<exec::WindowFunction> {
+          return std::make_unique<AggregateWindowFunction>(
+              name, args, resultType, pool);
+        });
+  }
+}
+} // namespace facebook::velox::window

--- a/velox/functions/prestosql/window/CMakeLists.txt
+++ b/velox/functions/prestosql/window/CMakeLists.txt
@@ -15,8 +15,8 @@ if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-add_library(velox_window OBJECT CumeDist.cpp NthValue.cpp Rank.cpp
-                                RowNumber.cpp WindowFunctionsRegistration.cpp)
+add_library(velox_window AggregateWindow.cpp CumeDist.cpp NthValue.cpp Rank.cpp
+                         RowNumber.cpp WindowFunctionsRegistration.cpp)
 
 target_link_libraries(velox_window velox_buffer velox_exec
                       ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/functions/prestosql/window/WindowFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/window/WindowFunctionsRegistration.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
+#include "velox/exec/Aggregate.h"
 
 namespace facebook::velox::window {
 
@@ -23,6 +24,7 @@ extern void registerDenseRank(const std::string& name);
 extern void registerPercentRank(const std::string& name);
 extern void registerCumeDist(const std::string& name);
 extern void registerNthValue(const std::string& name);
+extern void registerAggregateWindowFunction(const std::string& name);
 
 void registerWindowFunctions() {
   window::registerRowNumber("row_number");
@@ -31,6 +33,12 @@ void registerWindowFunctions() {
   window::registerPercentRank("percent_rank");
   window::registerCumeDist("cume_dist");
   window::registerNthValue("nth_value");
+
+  // Register all aggregate functions as window functions.
+  const auto& aggregateFunctions = exec::aggregateFunctions();
+  for (const auto& aggregateEntry : aggregateFunctions) {
+    window::registerAggregateWindowFunction(aggregateEntry.first);
+  }
 }
 
 } // namespace facebook::velox::window

--- a/velox/functions/prestosql/window/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/window/tests/CMakeLists.txt
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_windows_test Main.cpp NthValueTest.cpp RankTest.cpp
-                                  RowNumberTest.cpp WindowTestBase.cpp)
+
+add_executable(
+  velox_windows_test Main.cpp NthValueTest.cpp RankTest.cpp RowNumberTest.cpp
+                     SimpleAggregatesTest.cpp WindowTestBase.cpp)
 
 add_test(
   NAME velox_windows_test

--- a/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
+++ b/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/window/tests/WindowTestBase.h"
+
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::window::test {
+
+namespace {
+
+class SimpleAggregatesTest : public WindowTestBase {
+ protected:
+  explicit SimpleAggregatesTest(const std::string& function)
+      : function_(function) {}
+
+  RowVectorPtr makeBasicVectors(vector_size_t size) {
+    return makeRowVector({
+        makeFlatVector<int32_t>(
+            size, [](auto row) -> int32_t { return row % 10; }),
+        makeFlatVector<int32_t>(
+            size, [](auto row) -> int32_t { return row % 7; }),
+        makeFlatVector<int32_t>(size, [](auto row) -> int32_t { return row; }),
+    });
+  }
+
+  RowVectorPtr makeSinglePartitionVector(vector_size_t size) {
+    return makeRowVector({
+        makeFlatVector<int32_t>(size, [](auto /* row */) { return 1; }),
+        makeFlatVector<int32_t>(size, [](auto row) { return row % 50; }),
+        makeFlatVector<int32_t>(size, [](auto row) -> int32_t { return row; }),
+    });
+  }
+
+  void testWindowFunction(
+      const std::vector<RowVectorPtr>& vectors,
+      const std::vector<std::string>& overClauses) {
+    WindowTestBase::testWindowFunction(vectors, function_, overClauses);
+  }
+
+  const std::string function_;
+};
+
+class MultiAggregatesTest : public SimpleAggregatesTest,
+                            public testing::WithParamInterface<std::string> {
+ public:
+  MultiAggregatesTest() : SimpleAggregatesTest(GetParam()) {}
+};
+
+TEST_P(MultiAggregatesTest, basic) {
+  SimpleAggregatesTest::testWindowFunction(
+      {makeBasicVectors(10)}, kBasicOverClauses);
+}
+
+TEST_P(MultiAggregatesTest, basicWithSortOrders) {
+  SimpleAggregatesTest::testWindowFunction(
+      {makeBasicVectors(10)}, kSortOrderBasedOverClauses);
+}
+
+TEST_P(MultiAggregatesTest, singlePartition) {
+  // Test all input rows in a single partition.
+  SimpleAggregatesTest::testWindowFunction(
+      {makeSinglePartitionVector(100)}, kBasicOverClauses);
+}
+
+TEST_P(MultiAggregatesTest, singlePartitionWithSortOrders) {
+  SimpleAggregatesTest::testWindowFunction(
+      {makeSinglePartitionVector(100)}, kSortOrderBasedOverClauses);
+}
+
+TEST_P(MultiAggregatesTest, randomInput) {
+  auto vectors = makeFuzzVectors(
+      ROW({"c0", "c1", "c2", "c3"},
+          {BIGINT(), SMALLINT(), INTEGER(), BIGINT()}),
+      10,
+      2);
+  createDuckDbTable(vectors);
+
+  std::vector<std::string> overClauses = {
+      "partition by c0 order by c1, c2, c3",
+      "partition by c1 order by c0, c2, c3",
+      "partition by c0 order by c1 desc, c2, c3",
+      "partition by c1 order by c0 desc, c2, c3",
+      "partition by c0 order by c1",
+      "partition by c0 order by c2",
+      "partition by c0 order by c3",
+      "partition by c1 order by c0 desc",
+      "partition by c0, c1 order by c2, c3",
+      "partition by c0, c1 order by c2",
+      "partition by c0, c1 order by c2 desc",
+      "order by c0, c1, c2, c3",
+      "partition by c0, c1, c2, c3",
+  };
+
+  testWindowFunction(vectors, overClauses);
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    SimpleAggregatesTest,
+    MultiAggregatesTest,
+    testing::ValuesIn({
+        std::string("sum(c2)"),
+        std::string("min(c2)"),
+        std::string("max(c2)"),
+        std::string("count(c2)"),
+        std::string("avg(c2)"),
+    }));
+
+}; // namespace
+}; // namespace facebook::velox::window::test


### PR DESCRIPTION
Wrap an aggregate function in a window function using singleGroup APIs to
compute results for each row (from frameStart to frameEnd). Add an optimization
to perform incremental aggregation if frameStart is a fixed value and frameEnd
is never decreasing.

TODO: Add support for constant parameters. TODO: Register each aggregate
function as a window function (by default). 