### PR TITLE
Fix Native Parquet Reader Decimal Type Conversion

### DIFF
--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -129,6 +129,19 @@ class E2EFilterTestBase : public testing::Test {
   void makeAllNulls(const std::string& name);
 
   template <typename T>
+  void makeIntData(
+      const common::Subfield& field,
+      const std::vector<T>& values) {
+    VELOX_CHECK_EQ(batches_.size(), 1);
+    auto numbers = common::getChildBySubfield(batches_[0].get(), field)
+                       ->as<FlatVector<T>>();
+    VELOX_CHECK_EQ(numbers->size(), values.size());
+    for (auto row = 0; row < numbers->size(); ++row) {
+      numbers->set(row, values[row]);
+    }
+  }
+
+  template <typename T>
   void makeIntDistribution(
       const common::Subfield& field,
       T min,
@@ -282,6 +295,13 @@ class E2EFilterTestBase : public testing::Test {
   void testFilterSpecs(const std::vector<common::FilterSpec>& filterSpecs);
 
   void testRowGroupSkip(const std::vector<std::string>& filterable);
+
+  /// Writes input data to in-memory Arrow Parquet format.
+  /// Reads the in-memory Parquet format and verifies against the input data.
+  void testWithInputData(
+      const std::string& columns,
+      size_t size,
+      std::function<void()> addInputData);
 
   void testWithTypes(
       const std::string& columns,

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -261,6 +261,12 @@ TEST_F(E2EFilterTest, shortDecimalDirect) {
         true,
         false);
   }
+
+  testWithInputData("shortdecimal_val:short_decimal(10, 5)", 2, [&]() {
+    makeIntData<UnscaledShortDecimal>(
+        Subfield("shortdecimal_val"),
+        {UnscaledShortDecimal(-479), UnscaledShortDecimal(40000000)});
+  });
 }
 
 TEST_F(E2EFilterTest, longDecimalDictionary) {
@@ -321,6 +327,13 @@ TEST_F(E2EFilterTest, longDecimalDirect) {
         true,
         false);
   }
+
+  testWithInputData("longdecimal_val:long_decimal(30, 10)", 2, [&]() {
+    makeIntData<UnscaledLongDecimal>(
+        Subfield("longdecimal_val"),
+        {UnscaledLongDecimal(-479),
+         UnscaledLongDecimal(buildInt128(1546093991, 4054979645))});
+  });
 }
 
 TEST_F(E2EFilterTest, stringDirect) {


### PR DESCRIPTION
Fix Decimal Type conversion in Native Parquet Reader when the first value
in a batch is a negative value.

Resolves https://github.com/facebookincubator/velox/issues/2900