### PR TITLE
Typo: Fix some typos about IO

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -818,7 +818,7 @@ T percentile(Next next, int32_t numSamples, int percent) {
 // read.
 //
 // Returns the number of distinct IOs, the number of bytes loaded into pins and
-// the number of extr bytes read.
+// the number of extra bytes read.
 CoalesceIoStats readPins(
     const std::vector<CachePin>& pins,
     int32_t maxGap,

--- a/velox/common/caching/ScanTracker.h
+++ b/velox/common/caching/ScanTracker.h
@@ -186,7 +186,7 @@ class ScanTracker {
   folly::F14FastMap<TrackingId, TrackingData> data_;
   TrackingData sum_;
   // Maximum size of a read. 10MB would count as two references
-  // if the quantim were 8MB. At the same time this would count as a
+  // if the quantum were 8MB. At the same time this would count as a
   // single 10MB reference for 'fileGroupStats_'. 0 means the read
   // size is unlimited.
   const int32_t loadQuantum_;

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -60,7 +60,7 @@ class BufferedInput {
     std::unique_ptr<SeekableInputStream> ret = readBuffer(offset, length);
     if (!ret) {
       VLOG(1) << "Unplanned read. Offset: " << offset << ", Length: " << length;
-      // We cannot do enqueue/load here because load() clears previously laoded
+      // We cannot do enqueue/load here because load() clears previously loaded
       // data. TODO: figure out how we can use the data cache for
       // this access.
       ret = std::make_unique<SeekableFileInputStream>(

--- a/velox/dwio/common/CachedBufferedInput.h
+++ b/velox/dwio/common/CachedBufferedInput.h
@@ -41,7 +41,7 @@ class AbstractInputStreamHolder {
 };
 
 // Function type for making copies of InputStream for running
-// parammel loads. We cannot pass the one non-owned InputStream to
+// parallel loads. We cannot pass the one non-owned InputStream to
 // other threads because the BufferedInput and its owner could be
 // destroyed out of sequence and the streams are owned via
 // unique_ptr. TODO: Make all streams owned via shared_ptr.


### PR DESCRIPTION
When gothrough the code about IO, I found some typos. This patch just fixes them.