### PR TITLE
Minor fix on building protobuf from CMake

### DIFF
--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -124,6 +124,7 @@ macro(build_protobuf)
     include_directories("${protobuf_SOURCE_DIR}/src/")
     add_subdirectory(${protobuf_SOURCE_DIR} ${protobuf_BINARY_DIR})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_BKP}")
+    set(Protobuf_LIBRARIES protobuf)
   endif()
 endmacro()
 # ================================ END PROTOBUF ================================


### PR DESCRIPTION
As discussed on https://github.com/facebookincubator/velox/pull/2907 I was facing an issue when building with Protobuf from CMake:
```
CMake Error at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Protobuf (missing: Protobuf_LIBRARIES) (found suitable
  version "3.21.4", minimum required is "3.21.4")
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.22/Modules/FindProtobuf.cmake:650 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:314 (find_package)


-- Configuring incomplete, errors occurred!
```
was reproduced by:
```
$ docker-compose build --no-cache ubuntu-cpp
$ docker-compose run --rm ubuntu-cpp
```
With this change I tested building downloads and builds Protobuf from source:
```
-- Building Protobuf from source
-- 
-- 3.21.4.0
-- Performing Test protobuf_HAVE_LD_VERSION_SCRIPT
-- Performing Test protobuf_HAVE_LD_VERSION_SCRIPT - Success
-- Performing Test protobuf_HAVE_BUILTIN_ATOMICS
-- Performing Test protobuf_HAVE_BUILTIN_ATOMICS - Success
-- Found Protobuf: protobuf (found suitable version "3.21.4", minimum required is "3.21.4") 

```
And tests are successful:
```
100% tests passed, 0 tests failed out of 144
```