### PR TITLE
Bump benchalerts to 0.3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
             # upgrade python to 3.8 for this job
             yum install -y python38
             pip3.8 install conbench
-            pip3.8 install git+https://github.com/conbench/benchalerts.git@0.3.1
+            pip3.8 install git+https://github.com/conbench/benchalerts.git@0.3.2
             pip3.8 install scripts/veloxbench
       - run:
           name: "Run Benchmarks"


### PR DESCRIPTION
This PR bumps the `conbench` `benchalerts` dependency to 0.3.2, which fixes links in check results like [this one](https://github.com/facebookincubator/velox/pull/2919/checks?check_run_id=9042721811).