### PR TITLE
Fix from_unixtime for NaN input

### DIFF
--- a/velox/functions/prestosql/FromUnixTime.cpp
+++ b/velox/functions/prestosql/FromUnixTime.cpp
@@ -21,6 +21,9 @@ namespace facebook::velox::functions {
 namespace {
 
 inline int64_t toMillis(double unixtime) {
+  if (UNLIKELY(std::isnan(unixtime))) {
+    return 0;
+  }
   return std::floor(unixtime * 1'000);
 }
 


### PR DESCRIPTION
from_unixtime(NaN, '<timezone>') should return zero. Before the fix it was crashing under UBSAN:

```
velox/functions/prestosql/FromUnixTime.cpp:24:10: runtime error: nan is outside the range of representable values of type 'long'

SUMMARY: UndefinedBehaviorSanitizer: float-cast-overflow velox/functions/prestosql/FromUnixTime.cpp:24:10 in 
```

Fixes #2791