### PR TITLE
Fix string casing warning with protobuf builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,10 +308,8 @@ include_directories(SYSTEM ${FOLLY_INCLUDE_DIRS})
 
 if(NOT ${VELOX_BUILD_MINIMAL})
   # Locate or build protobuf.
-  set(protobuf_SOURCE AUTO)
-  resolve_dependency(protobuf)
-
-  find_package(Protobuf 3.21.4 REQUIRED)
+  set(Protobuf_SOURCE AUTO)
+  resolve_dependency(Protobuf REQUIRED_VERSION 3.21.4)
 endif()
 
 # GCC needs to link a library to enable std::filesystem.

--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -113,8 +113,15 @@ macro(build_protobuf)
         OFF
         CACHE BOOL "Disable protobuf tests" FORCE)
     set(CMAKE_CXX_FLAGS_BKP "${CMAKE_CXX_FLAGS}")
-    set(CMAKE_CXX_FLAGS
-        "-Wno-stringop-overflow -Wno-missing-field-initializers")
+
+    # Disable warnings that would fail protobuf compilation.
+    string(APPEND CMAKE_CXX_FLAGS " -Wno-missing-field-initializers")
+
+    check_cxx_compiler_flag("-Wstringop-overflow"
+                            COMPILER_HAS_W_STRINGOP_OVERFLOW)
+    if(COMPILER_HAS_W_STRINGOP_OVERFLOW)
+      string(APPEND CMAKE_CXX_FLAGS " -Wno-stringop-overflow")
+    endif()
 
     # Fetch the content using previously declared details
     FetchContent_Populate(protobuf)
@@ -132,7 +139,7 @@ endmacro()
 macro(build_dependency DEPENDENCY_NAME)
   if("${DEPENDENCY_NAME}" STREQUAL "folly")
     build_folly()
-  elseif("${DEPENDENCY_NAME}" STREQUAL "protobuf")
+  elseif("${DEPENDENCY_NAME}" STREQUAL "Protobuf")
     build_protobuf()
   else()
     message(

--- a/velox/substrait/CMakeLists.txt
+++ b/velox/substrait/CMakeLists.txt
@@ -34,7 +34,7 @@ get_filename_component(PROTO_DIR ${substrait_proto_directory}/, DIRECTORY)
 add_custom_command(
   OUTPUT ${PROTO_OUTPUT_FILES}
   COMMAND
-    ${protobuf_BINARY_DIR}/protoc --proto_path ${CMAKE_SOURCE_DIR}/ --proto_path
+    ${Protobuf_PROTOC_EXECUTABLE} --proto_path ${CMAKE_SOURCE_DIR}/ --proto_path
     ${Protobuf_INCLUDE_DIR} --cpp_out ${CMAKE_SOURCE_DIR} ${PROTO_FILES}
   DEPENDS ${PROTO_DIR}
   COMMENT "Running PROTO compiler"


### PR DESCRIPTION
Fixing a few issues with the new protobuf build:

- Case-sensitivity issue raising warnings in CMake development mode. 
- Removing unnecessary find_package() and enforcing right versioning using resolve_dependency()
- Move `-Wno-stringop-overflow` to a conditional check as clang doesn't seem to have it.
- Use right protoc executable flag