### PR TITLE
Change the encoded batchPosition to uint64_t

### DIFF
--- a/velox/dwio/common/tests/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/E2EFilterTestBase.cpp
@@ -223,7 +223,7 @@ void E2EFilterTestBase::readWithoutFilter(
 void E2EFilterTestBase::readWithFilter(
     std::shared_ptr<ScanSpec> spec,
     const std::vector<RowVectorPtr>& batches,
-    const std::vector<uint32_t>& hitRows,
+    const std::vector<uint64_t>& hitRows,
     uint64_t& time,
     bool useValueHook,
     bool skipCheck) {
@@ -280,7 +280,7 @@ void E2EFilterTestBase::readWithFilter(
     }
     // Outside of timed section.
     for (int32_t i = 0; i < batch->size(); ++i) {
-      uint32_t hit = hitRows[rowIndex++];
+      uint64_t hit = hitRows[rowIndex++];
       auto expectedBatch = batches[batchNumber(hit)].get();
       auto expectedRow = batchRow(hit);
       // We compare column by column, skipping over filter-only columns.
@@ -311,7 +311,7 @@ bool E2EFilterTestBase::loadWithHook(
     RowVector* batch,
     int32_t columnIndex,
     VectorPtr child,
-    const std::vector<uint32_t>& hitRows,
+    const std::vector<uint64_t>& hitRows,
     int32_t rowIndex) {
   auto kind = child->typeKind();
   if (kind == TypeKind::ROW || kind == TypeKind::ARRAY ||
@@ -324,7 +324,7 @@ bool E2EFilterTestBase::loadWithHook(
 
 void E2EFilterTestBase::testFilterSpecs(
     const std::vector<FilterSpec>& filterSpecs) {
-  std::vector<uint32_t> hitRows;
+  std::vector<uint64_t> hitRows;
   auto filters =
       filterGenerator->makeSubfieldFilters(filterSpecs, batches_, hitRows);
   auto spec = filterGenerator->makeScanSpec(std::move(filters));

--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -240,7 +240,7 @@ class E2EFilterTestBase : public testing::Test {
   void readWithFilter(
       std::shared_ptr<common::ScanSpec> spec,
       const std::vector<RowVectorPtr>& batches,
-      const std::vector<uint32_t>& hitRows,
+      const std::vector<uint64_t>& hitRows,
       uint64_t& time,
       bool useValueHook,
       bool skipCheck = false);
@@ -254,7 +254,7 @@ class E2EFilterTestBase : public testing::Test {
       RowVector* batch,
       int32_t columnIndex,
       VectorPtr child,
-      const std::vector<uint32_t>& hitRows,
+      const std::vector<uint64_t>& hitRows,
       int32_t rowIndex) {
     using T = typename TypeTraits<Kind>::NativeType;
     std::vector<vector_size_t> rows;
@@ -289,7 +289,7 @@ class E2EFilterTestBase : public testing::Test {
       RowVector* batch,
       int32_t columnIndex,
       VectorPtr child,
-      const std::vector<uint32_t>& hitRows,
+      const std::vector<uint64_t>& hitRows,
       int32_t rowIndex);
 
   void testFilterSpecs(const std::vector<common::FilterSpec>& filterSpecs);

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -28,16 +28,16 @@ using namespace facebook::velox;
 using namespace facebook::velox::common;
 
 // Encodes a batch number and an index into the batch into an int32_t
-uint32_t batchPosition(uint32_t batchNumber, vector_size_t batchRow) {
-  return batchNumber << 16 | batchRow;
+uint64_t batchPosition(uint32_t batchNumber, vector_size_t batchRow) {
+  return (uint64_t)batchNumber << 32 | (uint64_t)batchRow;
 }
 
-uint32_t batchNumber(uint32_t position) {
-  return position >> 16;
+uint32_t batchNumber(uint64_t position) {
+  return position >> 32;
 }
 
-vector_size_t batchRow(uint32_t position) {
-  return position & 0xffff;
+vector_size_t batchRow(uint64_t position) {
+  return position & 0xffffffff;
 }
 
 VectorPtr getChildBySubfield(
@@ -422,7 +422,7 @@ std::shared_ptr<ScanSpec> FilterGenerator::makeScanSpec(
 SubfieldFilters FilterGenerator::makeSubfieldFilters(
     const std::vector<FilterSpec>& filterSpecs,
     const std::vector<RowVectorPtr>& batches,
-    std::vector<uint32_t>& hitRows) {
+    std::vector<uint64_t>& hitRows) {
   vector_size_t totalSize = 0;
   for (auto& batch : batches) {
     totalSize += batch->size();


### PR DESCRIPTION
Initially, the encoded batchPosition was uint32_t the max batch row is 64k. However, some tests require larger batch size. So this commit changes the encoded batchPosition to uint64_t.

Fix https://github.com/facebookincubator/velox/issues/2844