### PR TITLE
Fix ConstantExpr::toSql for negative numbers, dates and nulls

### DIFF
--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -233,10 +233,10 @@ TEST_F(ExprStatsTest, listener) {
 
   ASSERT_EQ(2, sqls.size());
   ASSERT_EQ(
-      "\"multiply\"(\"plus\"(cast((\"c0\") as BIGINT), 3::BIGINT), cast((\"c1\") as BIGINT))",
+      "\"multiply\"(\"plus\"(cast((\"c0\") as BIGINT), '3'::BIGINT), cast((\"c1\") as BIGINT))",
       sqls.front());
   ASSERT_EQ(
-      "\"eq\"(\"mod\"(cast((\"plus\"(\"c0\", \"c1\")) as BIGINT), 2::BIGINT), 0::BIGINT)",
+      "\"eq\"(\"mod\"(cast((\"plus\"(\"c0\", \"c1\")) as BIGINT), '2'::BIGINT), '0'::BIGINT)",
       sqls.back());
 
   ASSERT_EQ(2, stats.at("plus").numProcessedVectors);


### PR DESCRIPTION
Negative numbers and date literals need to be wrapped in single quotes,
otherwise '-' characters are interpreted as negation or minus operators.

Also, null literals need to specify the type. Otherwise, these are parsed as 
nulls of UNKNOWN type.

Enhanced ExprTest::constantToSql to evaluate the SQL and compare the 
results with evaluating the original expression.