### PR TITLE
Disallow spilling for null-aware anti-join with filter set

### DIFF
--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -106,6 +106,14 @@ class HashBuild final : public Operator {
   // process which will be set by the join probe side.
   void postHashBuildProcess();
 
+  // Checks if the spilling is allowed for this hash join. As for now, we don't
+  // allow spilling for null-aware anti-join with filter set. It requires to
+  // cross join the null-key probe rows with all the build-side rows for filter
+  // evaluation which is not supported under spilling.
+  bool isSpillAllowed() const {
+    return !isNullAwareAntiJoinWithFilter(joinNode_);
+  }
+
   bool spillEnabled() const {
     return spillConfig_.has_value();
   }
@@ -310,5 +318,4 @@ inline std::ostream& operator<<(std::ostream& os, HashBuild::State state) {
   os << HashBuild::stateName(state);
   return os;
 }
-
 } // namespace facebook::velox::exec

--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -162,4 +162,9 @@ std::optional<HashJoinBridge::SpillInput> HashJoinBridge::spillInputOrFuture(
   return SpillInput(std::move(spillShard));
 }
 
+bool isNullAwareAntiJoinWithFilter(
+    const std::shared_ptr<const core::HashJoinNode>& joinNode) {
+  return isNullAwareAntiJoin(joinNode->joinType()) &&
+      (joinNode->filter() != nullptr);
+}
 } // namespace facebook::velox::exec

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -127,4 +127,8 @@ class HashJoinBridge : public JoinBridge {
   // memory and engages in recursive spilling.
   SpillPartitionSet spillPartitionSets_;
 };
+
+// Indicates if 'joinNode' is null-aware anti-join type and has filter set.
+bool isNullAwareAntiJoinWithFilter(
+    const std::shared_ptr<const core::HashJoinNode>& joinNode);
 } // namespace facebook::velox::exec

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -177,6 +177,14 @@ class HashProbe : public Operator {
   // partitions have been spilled at the build side.
   bool skipProbeOnEmptyBuild() const;
 
+  // Checks if the spilling is allowed for this hash join. As for now, we don't
+  // allow spilling for null-aware anti-join with filter set. It requires to
+  // cross join the null-key probe rows with all the build-side rows for filter
+  // evaluation which is not supported under spilling.
+  bool isSpillAllowed() const {
+    return !isNullAwareAntiJoinWithFilter(joinNode_);
+  }
+
   bool spillEnabled() const;
 
   // Indicates if the probe input is read from spilled data or not.
@@ -222,6 +230,8 @@ class HashProbe : public Operator {
 
   // TODO: Define batch size as bytes based on RowContainer row sizes.
   const uint32_t outputBatchSize_;
+
+  const std::shared_ptr<const core::HashJoinNode> joinNode_;
 
   const core::JoinType joinType_;
 


### PR DESCRIPTION
We can't do spilling in case of null-aware anti join with filter set.
The reason is that the join requires to cross-join null-key probe
rows with all the build-side rows for filter evaluation. This PR
disables this with test covered.