### PR TITLE
Optmizing StripeStream with folly utilities

### DIFF
--- a/velox/dwio/dwrf/reader/BinaryStreamReader.h
+++ b/velox/dwio/dwrf/reader/BinaryStreamReader.h
@@ -58,8 +58,8 @@ class BinaryStripeStreams {
   StripeInformationWrapper stripeInfo_;
   dwio::common::RowReaderOptions options_;
   StripeStreamsImpl stripeStreams_;
-  std::unordered_map<uint32_t, std::vector<uint32_t>> encodingKeys_;
-  std::unordered_map<uint32_t, std::vector<DwrfStreamIdentifier>>
+  folly::F14FastMap<uint32_t, std::vector<uint32_t>> encodingKeys_;
+  folly::F14FastMap<uint32_t, std::vector<DwrfStreamIdentifier>>
       nodeToStreamIdMap_;
 };
 

--- a/velox/dwio/dwrf/reader/StripeStream.cpp
+++ b/velox/dwio/dwrf/reader/StripeStream.cpp
@@ -230,14 +230,14 @@ StripeStreamsImpl::getCompressedStream(const DwrfStreamIdentifier& si) const {
   return streamRead;
 }
 
-std::unordered_map<uint32_t, std::vector<uint32_t>>
+folly::F14FastMap<uint32_t, std::vector<uint32_t>>
 StripeStreamsImpl::getEncodingKeys() const {
   DWIO_ENSURE_EQ(
       decryptedEncodings_.size(),
       0,
       "Not supported for reader with encryption");
 
-  std::unordered_map<uint32_t, std::vector<uint32_t>> encodingKeys;
+  folly::F14FastMap<uint32_t, std::vector<uint32_t>> encodingKeys;
   for (const auto& kv : encodings_) {
     const auto ek = kv.first;
     encodingKeys[ek.node].push_back(ek.sequence);
@@ -246,9 +246,9 @@ StripeStreamsImpl::getEncodingKeys() const {
   return encodingKeys;
 }
 
-std::unordered_map<uint32_t, std::vector<DwrfStreamIdentifier>>
+folly::F14FastMap<uint32_t, std::vector<DwrfStreamIdentifier>>
 StripeStreamsImpl::getStreamIdentifiers() const {
-  std::unordered_map<uint32_t, std::vector<DwrfStreamIdentifier>>
+  folly::F14FastMap<uint32_t, std::vector<DwrfStreamIdentifier>>
       nodeToStreamIdMap;
 
   for (const auto& kv : streams_) {

--- a/velox/dwio/dwrf/reader/StripeStream.h
+++ b/velox/dwio/dwrf/reader/StripeStream.h
@@ -212,13 +212,13 @@ class StripeStreamsImpl : public StripeStreamsBase {
   void loadStreams();
 
   // map of stream id -> stream information
-  std::unordered_map<
+  folly::F14FastMap<
       DwrfStreamIdentifier,
       StreamInformationImpl,
       dwio::common::StreamIdentifierHash>
       streams_;
-  std::unordered_map<EncodingKey, uint32_t, EncodingKeyHash> encodings_;
-  std::unordered_map<EncodingKey, proto::ColumnEncoding, EncodingKeyHash>
+  folly::F14FastMap<EncodingKey, uint32_t, EncodingKeyHash> encodings_;
+  folly::F14FastMap<EncodingKey, proto::ColumnEncoding, EncodingKeyHash>
       decryptedEncodings_;
 
  public:
@@ -278,9 +278,9 @@ class StripeStreamsImpl : public StripeStreamsBase {
     return getStreamInfo(si).getLength();
   }
 
-  std::unordered_map<uint32_t, std::vector<uint32_t>> getEncodingKeys() const;
+  folly::F14FastMap<uint32_t, std::vector<uint32_t>> getEncodingKeys() const;
 
-  std::unordered_map<uint32_t, std::vector<DwrfStreamIdentifier>>
+  folly::F14FastMap<uint32_t, std::vector<DwrfStreamIdentifier>>
   getStreamIdentifiers() const;
 
   std::unique_ptr<dwio::common::SeekableInputStream> getStream(


### PR DESCRIPTION
Summary: Updated 'BinaryStreamReader' and 'StripeStreamImpl' to replace std::unordered_map hashes with folly::F14FastMap

Differential Revision: D40690217

