### PR TITLE
Task listener issue with stats

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1447,8 +1447,7 @@ void Task::onTaskCompletion() {
     }
 
     for (auto& listener : listeners) {
-      listener->onTaskCompletion(
-          uuid_, taskId_, state, exception, std::move(stats));
+      listener->onTaskCompletion(uuid_, taskId_, state, exception, stats);
     }
   });
 }


### PR DESCRIPTION
Summary:
# Problem
If there are many listeners, the first one would get the right `stats` since the value would be moved. All other listeners would copy moved-out `stats`, and not sure exactly what would happen there. One thing obvious is the containers would not have anything.

Differential Revision: D40681179

