### PR TITLE
Fix array_intersect/except for dictionary encoded or null input

### DIFF
--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -178,7 +178,7 @@ class ArrayIntersectExceptFunction : public exec::VectorFunction {
       auto offset = baseLeftArray->offsetAt(idx);
 
       outputSet.reset();
-      *rawNewOffsets = indicesCursor;
+      rawNewOffsets[row] = indicesCursor;
 
       // Scans the array elements on the left-hand side.
       for (vector_size_t i = offset; i < (offset + size); ++i) {
@@ -217,9 +217,7 @@ class ArrayIntersectExceptFunction : public exec::VectorFunction {
           }
         }
       }
-      *rawNewLengths = indicesCursor - *rawNewOffsets;
-      ++rawNewLengths;
-      ++rawNewOffsets;
+      rawNewLengths[row] = indicesCursor - rawNewOffsets[row];
     };
 
     SetWithNull<T> outputSet;

--- a/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
@@ -55,22 +55,25 @@ class ArrayIntersectTest : public FunctionBaseTest {
   template <typename T>
   void testInt() {
     auto array1 = makeNullableArrayVector<T>({
-        {1, -2, 3, std::nullopt, 4, 5, 6, std::nullopt},
-        {1, 2, -2, 1},
-        {3, 8, std::nullopt},
-        {1, 1, -2, -2, -2, 4, 8},
+        {{1, -2, 3, std::nullopt, 4, 5, 6, std::nullopt}},
+        {{1, 2, -2, 1}},
+        {{3, 8, std::nullopt}},
+        std::nullopt,
+        {{1, 1, -2, -2, -2, 4, 8}},
     });
     auto array2 = makeNullableArrayVector<T>({
         {1, -2, 4},
         {1, -2, 4},
         {1, -2, 4},
+        {1, 2},
         {1, -2, 4},
     });
     auto expected = makeNullableArrayVector<T>({
-        {1, -2, 4},
-        {1, -2},
-        {},
-        {1, -2, 4},
+        {{1, -2, 4}},
+        {{1, -2}},
+        {{}},
+        std::nullopt,
+        {{1, -2, 4}},
     });
     testExpr(expected, "array_intersect(C0, C1)", {array1, array2});
     testExpr(expected, "array_intersect(C1, C0)", {array1, array2});
@@ -80,13 +83,15 @@ class ArrayIntersectTest : public FunctionBaseTest {
         {10, -24, 43},
         {std::nullopt, -2, 2},
         {std::nullopt, std::nullopt, std::nullopt},
+        {0, 0, 0},
         {8, 1, 8, 1},
     });
     expected = makeNullableArrayVector<T>({
-        {},
-        {2, -2},
-        {std::nullopt},
-        {1, 8},
+        {{}},
+        {{2, -2}},
+        {std::vector<std::optional<T>>{std::nullopt}},
+        std::nullopt,
+        {{1, 8}},
     });
     testExpr(expected, "array_intersect(C0, C1)", {array1, array2});
   }


### PR DESCRIPTION
The array_intersect and array_expect functions didn't work properly if invoked 
for a subset of rows, e.g when input was dictionary encoded or contained nulls.

Fixes #2794