### PR TITLE
FlatVector::copyValuesAndNulls should properly handle Unknown

### DIFF
--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -157,9 +157,9 @@ void FlatVector<T>::copyValuesAndNulls(
   }
 
   if (source->isFlatEncoding()) {
-    auto flat = source->asUnchecked<FlatVector<T>>();
-    auto* sourceValues =
-        source->typeKind() != TypeKind::UNKNOWN ? flat->rawValues() : nullptr;
+    auto* sourceValues = source->typeKind() != TypeKind::UNKNOWN
+        ? source->asUnchecked<FlatVector<T>>()->rawValues()
+        : nullptr;
     if (toSourceRow) {
       rows.applyToSelected([&](auto row) {
         auto sourceRow = toSourceRow[row];
@@ -238,12 +238,13 @@ void FlatVector<T>::copyValuesAndNulls(
   }
 
   if (source->isFlatEncoding()) {
-    auto flat = source->asUnchecked<FlatVector<T>>();
-    if (!flat->values() || flat->values()->size() == 0) {
+    if (!source->values() || source->values()->size() == 0) {
       // The vector must have all-null values.
       VELOX_CHECK_EQ(
-          BaseVector::countNulls(flat->nulls(), 0, flat->size()), flat->size());
+          BaseVector::countNulls(source->nulls(), 0, source->size()),
+          source->size());
     } else if (source->typeKind() != TypeKind::UNKNOWN) {
+      auto flat = source->asUnchecked<FlatVector<T>>();
       if (Buffer::is_pod_like_v<T>) {
         memcpy(
             &rawValues_[targetIndex],

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1049,6 +1049,7 @@ TEST_F(VectorTest, map) {
 }
 
 TEST_F(VectorTest, unknown) {
+  // Creates a const UNKNOWN vector.
   auto constUnknownVector =
       BaseVector::createConstant(variant(TypeKind::UNKNOWN), 123, pool_.get());
   ASSERT_FALSE(constUnknownVector->isScalar());
@@ -1058,6 +1059,7 @@ TEST_F(VectorTest, unknown) {
     ASSERT_TRUE(constUnknownVector->isNullAt(i));
   }
 
+  // Create an int vector and copy UNKNOWN const vector into it.
   auto intVector = BaseVector::create(BIGINT(), 10, pool_.get());
   ASSERT_FALSE(intVector->isNullAt(0));
   ASSERT_FALSE(intVector->mayHaveNulls());
@@ -1087,6 +1089,17 @@ TEST_F(VectorTest, unknown) {
   }
   // Can't copy to UNKNOWN vector.
   EXPECT_ANY_THROW(unknownVector->copy(intVector.get(), rows, nullptr));
+
+  // Copying flat UNKNOWN into integer vector nulls out all the source.
+  ASSERT_FALSE(intVector->isNullAt(3));
+  intVector->copy(unknownVector.get(), 3, 3, 1);
+  ASSERT_TRUE(intVector->isNullAt(3));
+
+  rows.resize(intVector->size());
+  intVector->copy(unknownVector.get(), rows, nullptr);
+  for (int i = 0; i < intVector->size(); ++i) {
+    ASSERT_TRUE(intVector->isNullAt(i));
+  }
 
   // It is okay to copy to a non-constant UNKNOWN vector.
   unknownVector->copy(constUnknownVector.get(), rows, nullptr);


### PR DESCRIPTION
Summary:
FlatVector::copyValuesAndNulls() was trying to cast FlatVector<Unknown> into FlatVector<T>. Fixing and adding tests.

Differential Revision:
D40706991

LaMa Project: L1134559

