### PR TITLE
Enhance Expr::propagatesNulls_

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -177,11 +177,11 @@ bool Expr::allSupportFlatNoNullsFastPath(
 }
 
 void Expr::computeMetadata() {
-  // Sets propagatesNulls if all subtrees propagate nulls.
-  // Sets isDeterministic to false if some subtree is non-deterministic.
-  // Sets 'distinctFields_' to be the union of 'distinctFields_' of inputs.
-  // If one of the inputs has the identical set of distinct fields, then
-  // the input's distinct fields are set to empty.
+  // Sets propagatesNulls if all subtrees that depend on at least one input
+  // field propagate nulls. Sets isDeterministic to false if some subtree is
+  // non-deterministic. Sets 'distinctFields_' to be the union of
+  // 'distinctFields_' of inputs. If one of the inputs has the identical set of
+  // distinct fields, then the input's distinct fields are set to empty.
   if (isSpecialForm()) {
     // 'propagatesNulls_' will be adjusted after inputs are processed.
     propagatesNulls_ = true;
@@ -194,7 +194,9 @@ void Expr::computeMetadata() {
   for (auto& input : inputs_) {
     input->computeMetadata();
     deterministic_ &= input->deterministic_;
-    propagatesNulls_ &= input->propagatesNulls_;
+    if (!input->distinctFields_.empty()) {
+      propagatesNulls_ &= input->propagatesNulls_;
+    }
     mergeFields(
         distinctFields_, multiplyReferencedFields_, input->distinctFields_);
   }

--- a/velox/expression/tests/EvalSimplifiedTest.cpp
+++ b/velox/expression/tests/EvalSimplifiedTest.cpp
@@ -68,6 +68,43 @@ class EvalSimplifiedTest : public FunctionBaseTest {
     return makeRowVector(vectors);
   }
 
+  void compareEvals(
+      exec::ExprSet& exprSetCommon,
+      exec::ExprSetSimplified& exprSetSimplified,
+      const RowVectorPtr& rowVector,
+      const SelectivityVector& rows) {
+    exec::EvalCtx evalCtxCommon(&execCtx_, &exprSetCommon, rowVector.get());
+    exec::EvalCtx evalCtxSimplified(
+        &execCtx_, &exprSetSimplified, rowVector.get());
+
+    // Evaluate using both engines.
+    std::vector<VectorPtr> commonEvalResult{nullptr};
+    std::vector<VectorPtr> simplifiedEvalResult{nullptr};
+
+    std::exception_ptr exceptionCommonPtr;
+    std::exception_ptr exceptionSimplifiedPtr;
+
+    try {
+      exprSetCommon.eval(rows, evalCtxCommon, commonEvalResult);
+    } catch (const std::exception& e) {
+      exceptionCommonPtr = std::current_exception();
+    }
+
+    try {
+      exprSetSimplified.eval(rows, evalCtxSimplified, simplifiedEvalResult);
+    } catch (const std::exception& e) {
+      exceptionSimplifiedPtr = std::current_exception();
+    }
+
+    // Compare results or exceptions (if any). Fail is anything is different.
+    if (exceptionCommonPtr || exceptionSimplifiedPtr) {
+      assertExceptions(exceptionCommonPtr, exceptionSimplifiedPtr);
+    } else {
+      assertEqualVectors(
+          commonEvalResult.front(), simplifiedEvalResult.front());
+    }
+  }
+
   void runTest(
       const std::string& exprString,
       const RowTypePtr& types = nullptr) {
@@ -93,36 +130,7 @@ class EvalSimplifiedTest : public FunctionBaseTest {
       // Generate the input vectors.
       auto rowVector = genRowVector(types, fuzzerOpts, rng);
 
-      exec::EvalCtx evalCtxCommon(&execCtx_, &exprSetCommon, rowVector.get());
-      exec::EvalCtx evalCtxSimplified(
-          &execCtx_, &exprSetSimplified, rowVector.get());
-
-      // Evaluate using both engines.
-      std::vector<VectorPtr> commonEvalResult{nullptr};
-      std::vector<VectorPtr> simplifiedEvalResult{nullptr};
-
-      std::exception_ptr exceptionCommonPtr;
-      std::exception_ptr exceptionSimplifiedPtr;
-
-      try {
-        exprSetCommon.eval(rows, evalCtxCommon, commonEvalResult);
-      } catch (const std::exception& e) {
-        exceptionCommonPtr = std::current_exception();
-      }
-
-      try {
-        exprSetSimplified.eval(rows, evalCtxSimplified, simplifiedEvalResult);
-      } catch (const std::exception& e) {
-        exceptionSimplifiedPtr = std::current_exception();
-      }
-
-      // Compare results or exceptions (if any). Fail is anything is different.
-      if (exceptionCommonPtr || exceptionSimplifiedPtr) {
-        assertExceptions(exceptionCommonPtr, exceptionSimplifiedPtr);
-      } else {
-        assertEqualVectors(
-            commonEvalResult.front(), simplifiedEvalResult.front());
-      }
+      compareEvals(exprSetCommon, exprSetSimplified, rowVector, rows);
 
       // Update the seed for the next iteration.
       seed_ = folly::Random::rand32(rng);
@@ -154,6 +162,24 @@ TEST_F(EvalSimplifiedTest, strings) {
 
 TEST_F(EvalSimplifiedTest, doubles) {
   runTest("ceil(c1) * c0", ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
+}
+
+TEST_F(EvalSimplifiedTest, propagateNulls) {
+  auto rowVector = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+      makeConstant<int64_t>(std::nullopt, 3),
+  });
+
+  SelectivityVector rows(rowVector->size());
+
+  auto expr = makeTypedExpr(
+      "distinct_from('x', 'y') < ((c0 / 0) > c1)",
+      asRowType(rowVector->type()));
+
+  exec::ExprSet exprSetCommon({expr}, &execCtx_);
+  exec::ExprSetSimplified exprSetSimplified({expr}, &execCtx_);
+
+  compareEvals(exprSetCommon, exprSetSimplified, rowVector, rows);
 }
 
 // Ensure that the right exprSet object is instantiated if `kExprEvalSimplified`


### PR DESCRIPTION
Before this change Expr::propagatesNulls_ was set to true only if all
sub-expressions propagated nulls. This change sets Expr::propagatesNulls_ to
true if all sub-expressions that depend on at least one input field propagate
nulls. Non-null-propagating constant subexpressions are excluded the
calculation of Expr::propagatesNulls_ flag.

Without this change an expression like `distinct_from('x', 'y') < ((c0 / 0) >c1)` 
applied to constant null c1 evaluates to null using common eval and throws
an exception using simplified eval. Here, distinct_from doesn't have default
null behavior, but it doesn't depend on any input. Common eval constant folds
this sub-expression making the whole expression compatible with default null
behavior. Simplified eval doesn't perform constant folding and marks the whole
expression a not compatible with default null behavior. This prevents
simplified eval from propagating nulls from c1 and skipping evaluation
on c0 / 0.

With this change, both simplified and common evals mark top-level expression 
as compatible with default null behavior, propagate nulls from c0 and skip 
evaluation of c0 / 0. This way evaluation via common and simplified path produces 
the same result.


Fixes #2749