### PR TITLE
Fix signatures of simple functions using custom types

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -272,6 +272,14 @@ struct TypeAnalysis<Row<T...>> {
   }
 };
 
+template <typename T>
+struct TypeAnalysis<CustomType<T>> {
+  void run(TypeAnalysisResults& results) {
+    results.stats.concreteCount++;
+    results.out << T::typeName;
+  }
+};
+
 // todo(youknowjack): need a better story for types for UDFs. Mapping
 //                    c++ types <-> Velox types is imprecise (e.g. string vs
 //                    binary) and difficult to change.

--- a/velox/expression/UdfTypeResolver.h
+++ b/velox/expression/UdfTypeResolver.h
@@ -133,6 +133,14 @@ struct resolver<Generic<T>> {
   using null_free_in_type = in_type;
   using out_type = void; // Not supported as output type yet.
 };
+
+template <typename T>
+struct resolver<CustomType<T>> {
+  using in_type = typename resolver<typename T::type>::in_type;
+  using null_free_in_type =
+      typename resolver<typename T::type>::null_free_in_type;
+  using out_type = typename resolver<typename T::type>::out_type;
+};
 } // namespace detail
 
 struct VectorExec {

--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -700,4 +700,10 @@ struct VectorReader<Generic<T>> {
   mutable TypePtr castType_ = nullptr;
 };
 
+template <typename T>
+struct VectorReader<CustomType<T>> : public VectorReader<typename T::type> {
+  explicit VectorReader(const DecodedVector* decoded)
+      : VectorReader<typename T::type>(decoded) {}
+};
+
 } // namespace facebook::velox::exec

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -734,4 +734,7 @@ struct VectorWriter<DynamicRow, void> {
   vector_t* rowVector_ = nullptr;
 };
 
+template <typename T>
+struct VectorWriter<CustomType<T>> : public VectorWriter<typename T::type> {};
+
 } // namespace facebook::velox::exec

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -105,11 +105,11 @@ void registerSimpleFunctions() {
 } // namespace
 
 void registerDateTimeFunctions() {
-  registerSimpleFunctions();
-
   registerType(
       "timestamp with time zone",
       std::make_unique<const TimestampWithTimeZoneTypeFactories>());
+
+  registerSimpleFunctions();
   VELOX_REGISTER_VECTOR_FUNCTION(udf_from_unixtime, "from_unixtime");
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -51,7 +51,12 @@ TIMESTAMP_WITH_TIME_ZONE() {
 }
 
 // Type used for function registration.
-using TimestampWithTimezone = Row<int64_t, int16_t>;
+struct TimestampWithTimezoneT {
+  using type = Row<int64_t, int16_t>;
+  static constexpr const char* typeName = "timestamp with time zone";
+};
+
+using TimestampWithTimezone = CustomType<TimestampWithTimezoneT>;
 
 class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
  public:

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1578,6 +1578,14 @@ struct DynamicRow {
   DynamicRow() {}
 };
 
+// T must be a struct with T::type being a built-in type and T::typeName
+// type name to use in FunctionSignature.
+template <typename T>
+struct CustomType {
+ private:
+  CustomType() {}
+};
+
 template <typename T>
 struct CppToType {};
 
@@ -1728,6 +1736,13 @@ struct CppToType<UnscaledLongDecimal>
 
 template <>
 struct CppToType<UnknownValue> : public CppToTypeBase<TypeKind::UNKNOWN> {};
+
+template <typename T>
+struct CppToType<CustomType<T>> : public CppToType<typename T::type> {
+  static auto create() {
+    return CppToType<typename T::type>::create();
+  }
+};
 
 // todo: remaining cpp2type
 


### PR DESCRIPTION
Custom Velox types define special C++ types that can be used to define simple
functions. These types are then used to generate FunctionSignature entries in
the function registry. Before this change, these C++ types were limited to
built-in Velox types. It was possible to give them nice names
(e.g.  TimestampWithTimezone vs. Row<int64_t, int16_t>), but it was not
possible to generate nice function signatures (e.g. "timestamp with time zone"
vs "row(bigint,smallint)").

This change introduces a CustomType<T> template that can be used to define
custom type and specify the corresponding Velox type as well as a type name for
use in the function signature.

Before:

```
using TimestampWithTimezone = Row<int64_t, int16_t>;

template <typename T>
struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {

 void call(
      out_type<TimestampWithTimezone>& result,
      const arg_type<Varchar>& unitString,
      const arg_type<TimestampWithTimezone>& timestampWithTimezone) {...}
}

registerFunction<
      DateTruncFunction,
      TimestampWithTimezone,
      Varchar,
      TimestampWithTimezone>({"date_trunc"});
```

The signature of date_trunc was `(varchar,row(bigint,smallint)) -> row(bigint,smallint)`.

After:

```
struct TimestampWithTimezoneT {
  using velox_type = Row<int64_t, int16_t>;
  static constexpr const char* typeName = "timestamp with time zone";
};

using TimestampWithTimezone = CustomType<TimestampWithTimezoneT>;

<the rest is the same as above>
```

The signature of date_trunc is `(varchar,timestamp with time zone) -> timestamp with time zone`.

Follow-up diffs with update Json and HyperLogLog custom types.