### PR TITLE
Data race in `variant`

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -22,10 +22,13 @@
 namespace facebook::velox {
 
 namespace {
-folly::json::serialization_opts& getOpts() {
-  static folly::json::serialization_opts opts;
-  opts.sort_keys = true;
-  return opts;
+const folly::json::serialization_opts& getOpts() {
+  static const folly::json::serialization_opts opts_ = []() {
+    folly::json::serialization_opts opts;
+    opts.sort_keys = true;
+    return opts;
+  }();
+  return opts_;
 }
 } // namespace
 


### PR DESCRIPTION
Summary:
# Problem
There is a data race in using `toJson()` method in `variant`. It accesses `getOpts()` function to access the singleton and __update the value__. If this happens in multiple threads, this update can happen simultaneously.

We are updating to a fixed value, so I don't think it would break anything. But this is unnecessary risk, and I'm not sure why it even returns modifiable reference.

Let's initialize it with the construction of static memory, and prevent any modification.

Differential Revision: D40725553

