### PR TITLE
Add handling of immutable buffers during vector resizing

### DIFF
--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2963,6 +2963,7 @@ TEST_F(ExprTest, addNulls) {
     VectorPtr vector =
         makeFlatVector<int64_t>(kSize, [](auto row) { return row; });
     auto slicedVector = vector->slice(0, kSize - 1);
+    ASSERT_FALSE(slicedVector->values()->isMutable());
     exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), slicedVector);
 
     checkResult(slicedVector);

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2955,4 +2955,16 @@ TEST_F(ExprTest, addNulls) {
 
     checkResult(vector);
   }
+
+  // Test flat vector which has a shared values buffer. This is done by first
+  // slicing the vector which creates buffer views of its nulls and values
+  // buffer which are immutable.
+  {
+    VectorPtr vector =
+        makeFlatVector<int64_t>(kSize, [](auto row) { return row; });
+    auto slicedVector = vector->slice(0, kSize - 1);
+    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), slicedVector);
+
+    checkResult(slicedVector);
+  }
 }

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -100,7 +100,7 @@ uint64_t BaseVector::byteSize<bool>(vector_size_t count) {
 void BaseVector::resize(vector_size_t size, bool setNotNull) {
   if (nulls_) {
     auto bytes = byteSize<bool>(size);
-    if (length_ < size) {
+    if (length_ < size || !nulls_->isMutable()) {
       ensureNullsCapacity(size, setNotNull);
     }
     nulls_->setSize(bytes);

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -67,10 +67,18 @@ BaseVector::BaseVector(
 void BaseVector::ensureNullsCapacity(vector_size_t size, bool setNotNull) {
   auto fill = setNotNull ? bits::kNotNull : bits::kNull;
   if (nulls_ && nulls_->isMutable()) {
-    if (nulls_->capacity() >= bits::nbytes(size)) {
-      return;
+    if (nulls_->capacity() < bits::nbytes(size)) {
+      AlignedBuffer::reallocate<bool>(&nulls_, size, fill);
     }
-    AlignedBuffer::reallocate<bool>(&nulls_, size, fill);
+    // ensure that the newly added positions have the right initial value for
+    // the case where changes in size don't result in change in the size of
+    // the underlying buffer.
+    // TODO: move this inside reallocate.
+    rawNulls_ = nulls_->as<uint64_t>();
+    if (setNotNull && length_ < size) {
+      bits::fillBits(
+          const_cast<uint64_t*>(rawNulls_), length_, size, bits::kNotNull);
+    }
   } else {
     auto newNulls = AlignedBuffer::allocate<bool>(size, pool_, fill);
     if (nulls_) {
@@ -80,8 +88,8 @@ void BaseVector::ensureNullsCapacity(vector_size_t size, bool setNotNull) {
           byteSize<bool>(std::min(length_, size)));
     }
     nulls_ = std::move(newNulls);
+    rawNulls_ = nulls_->as<uint64_t>();
   }
-  rawNulls_ = nulls_->as<uint64_t>();
 }
 
 template <>
@@ -93,14 +101,7 @@ void BaseVector::resize(vector_size_t size, bool setNotNull) {
   if (nulls_) {
     auto bytes = byteSize<bool>(size);
     if (length_ < size) {
-      if (nulls_->size() < bytes) {
-        AlignedBuffer::reallocate<char>(&nulls_, bytes);
-        rawNulls_ = nulls_->as<uint64_t>();
-      }
-      if (setNotNull && size > length_) {
-        bits::fillBits(
-            const_cast<uint64_t*>(rawNulls_), length_, size, bits::kNotNull);
-      }
+      ensureNullsCapacity(size, setNotNull);
     }
     nulls_->setSize(bytes);
   }
@@ -444,7 +445,8 @@ void BaseVector::resizeIndices(
     BufferPtr* indices,
     const vector_size_t** raw) {
   if (indices->get() && indices->get()->isMutable()) {
-    if (indices->get()->size() < size * sizeof(vector_size_t)) {
+    auto newByteSize = byteSize<vector_size_t>(size);
+    if (indices->get()->size() < newByteSize) {
       AlignedBuffer::reallocate<vector_size_t>(indices, size, initialValue);
     }
   } else {

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -365,7 +365,7 @@ class BaseVector {
     clearNulls(0, size());
   }
 
-  // Sets the size to 'size' and ensures there is space for the
+  // Sets the size to 'newSize' and ensures there is space for the
   // indicated number of nulls and top level values (eg. values for Flat,
   // indices for Dictionary, etc). Any immutable buffers that need to be resized
   // are copied. 'setNotNull' indicates if nulls in range [oldSize, newSize]

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -366,9 +366,11 @@ class BaseVector {
   }
 
   // Sets the size to 'size' and ensures there is space for the
-  // indicated number of nulls and top level values.
-  // 'setNotNull' indicates if nulls in range [oldSize, newSize) should be set
-  // to not null.
+  // indicated number of nulls and top level values (eg. values for Flat,
+  // indices for Dictionary, etc). Any immutable buffers that need to be resized
+  // are copied. 'setNotNull' indicates if nulls in range [oldSize, newSize]
+  // should be set to not null.
+  // Note: caller must ensure that the vector is singly referenced.
   virtual void resize(vector_size_t newSize, bool setNotNull = true);
 
   // Sets the rows of 'this' given by 'rows' to

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -449,12 +449,10 @@ class FlatVector final : public SimpleVector<T> {
       vector_size_t sourceIndex,
       vector_size_t count);
 
-  // Ensures that '*indices' has space for 'newSize' elements and is mutable.
-  // Sets elements between the old and new sizes to 'initialValue' if the new
-  // size > old size.
+  // Ensures that the values buffer has space for 'newSize' elements and is
+  // mutable. Sets elements between the old and new sizes to 'initialValue' if
+  // the new size > old size.
   void resizeValues(
-      BufferPtr* buffer,
-      velox::memory::MemoryPool* pool,
       vector_size_t newSize,
       const std::optional<T>& initialValue);
 

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -265,7 +265,7 @@ class FlatVector final : public SimpleVector<T> {
     }
   }
 
-  void resize(vector_size_t size, bool setNotNull = true) override;
+  void resize(vector_size_t newSize, bool setNotNull = true) override;
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
 
@@ -448,6 +448,15 @@ class FlatVector final : public SimpleVector<T> {
       vector_size_t targetIndex,
       vector_size_t sourceIndex,
       vector_size_t count);
+
+  // Ensures that '*indices' has space for 'newSize' elements and is mutable.
+  // Sets elements between the old and new sizes to 'initialValue' if the new
+  // size > old size.
+  void resizeValues(
+      BufferPtr* buffer,
+      velox::memory::MemoryPool* pool,
+      vector_size_t newSize,
+      const std::optional<T>& initialValue);
 
   // Contiguous values.
   // If strings, these are velox::StringViews into memory held by

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -355,6 +355,15 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     // Check that type kind is preserved in cases where T is the same with.
     EXPECT_EQ(
         flat->typeKind(), BaseVector::wrapInConstant(100, 0, flat)->typeKind());
+
+    // Test that resize works even when the underlying values buffer is
+    // immutable. This is done by first slicing the vector which creates buffer
+    // views of its nulls and values buffer which are immutable.
+    auto slicedFlat = flat->slice(0, size);
+    slicedFlat->resize(2 * size);
+    EXPECT_EQ(slicedFlat->size(), size * 2);
+    EXPECT_GE(
+        slicedFlat->values()->capacity(), BaseVector::byteSize<T>(size * 2));
   }
 
   static SelectivityVector selectEven(vector_size_t size) {


### PR DESCRIPTION
A recent change of adding slicing to vectors allowed vectors to have
buffer views over any of their internal buffers (nulls, values,
indices etc). This caused failure during vector resizing as the
resize() method did not handle some of the buffers being immutable.
This patch adds support for that for the nulls buffer in BaseVector
and the values buffer in FlatVector. Other buffers like indices,
sizes and offsets are already supported.

Test Plan:
Added unit tests