### PR TITLE
Switched to requirements file for benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,13 +276,11 @@ jobs:
       - pre-steps
       - build-benchmarks
       - run:
-          name: "Install Conbench, Benchalerts, and Veloxbench"
+          name: "Install benchmark dependencies"
           command: |
             # upgrade python to 3.8 for this job
             yum install -y python38
-            pip3.8 install conbench
-            pip3.8 install git+https://github.com/conbench/benchalerts.git@0.3.2
-            pip3.8 install scripts/veloxbench
+            pip3.8 install -r scripts/benchmark-requirements.txt
       - run-benchmarks
       # TODO: Disabling conbench github notifications for now until results are more stable.
       #- run:
@@ -310,11 +308,9 @@ jobs:
       - setup-environment
       - build-benchmarks
       - run:
-          name: "Install Conbench, Benchalerts, and Veloxbench"
+          name: "Install benchmark dependencies"
           command: |
-            pip3 install conbench
-            pip3 install git+https://github.com/conbench/benchalerts.git@0.3.1
-            pip3 install scripts/veloxbench
+            pip3 install -r scripts/benchmark-requirements.txt
       - run-benchmarks
       # TODO: Disabling conbench github notifications for now until results are more stable.
       #- run:

--- a/scripts/benchmark-requirements.txt
+++ b/scripts/benchmark-requirements.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To be installed from the root of the repo
+
+conbench
+git+https://github.com/conbench/benchalerts.git@0.4.0
+./scripts/veloxbench


### PR DESCRIPTION
This PR switches the CircleCI benchmark jobs to using a requirements.txt file instead of hardcoding the dependencies required for benchmarking.