### PR TITLE
Build Protobuf with -Wno-invalid-noreturn

### DIFF
--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -123,6 +123,12 @@ macro(build_protobuf)
       string(APPEND CMAKE_CXX_FLAGS " -Wno-stringop-overflow")
     endif()
 
+    check_cxx_compiler_flag("-Winvalid-noreturn"
+                            COMPILER_HAS_W_INVALID_NORETURN)
+    if(COMPILER_HAS_W_INVALID_NORETURN)
+      string(APPEND CMAKE_CXX_FLAGS " -Wno-invalid-noreturn")
+    endif()
+
     # Fetch the content using previously declared details
     FetchContent_Populate(protobuf)
 


### PR DESCRIPTION
Velox builds with -Werror and -Winvalid-noreturn.  When Protobuf builds it inherits these flags, but at the current release fails this check.  Adding -Wno-invalid-noreturn to skip this check when building Protobuf.

Note that this has been fixed in Protobuf's source, but never made it into a release 
https://github.com/protocolbuffers/protobuf/commit/1e9d43fe711b46bcb9bb82849d495f137c9d1ef8