### PR TITLE
Fix Protobuf build in dwio

### DIFF
--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -134,10 +134,15 @@ macro(build_protobuf)
 
     # Set right path to libprotobuf-dev include files.
     set(Protobuf_INCLUDE_DIR "${protobuf_SOURCE_DIR}/src/")
+    set(Protobuf_PROTOC_EXECUTABLE "${protobuf_BINARY_DIR}/protoc")
+    if(CMAKE_BUILD_TYPE MATCHES Debug)
+      set(Protobuf_LIBRARIES "${protobuf_BINARY_DIR}/libprotobufd.a")
+    else()
+      set(Protobuf_LIBRARIES "${protobuf_BINARY_DIR}/libprotobuf.a")
+    endif()
     include_directories("${protobuf_SOURCE_DIR}/src/")
     add_subdirectory(${protobuf_SOURCE_DIR} ${protobuf_BINARY_DIR})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_BKP}")
-    set(Protobuf_LIBRARIES protobuf)
   endif()
 endmacro()
 # ================================ END PROTOBUF ================================

--- a/velox/dwio/dwrf/proto/CMakeLists.txt
+++ b/velox/dwio/dwrf/proto/CMakeLists.txt
@@ -12,20 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-protobuf_generate_cpp(VELOX_DWIO_DWRF_PROTO_SRCS VELOX_DWIO_DWRF_PROTO_HDRS
-                      dwrf_proto.proto)
+# Set up Proto
+file(
+  GLOB PROTO_FILES
+  RELATIVE ${PROJECT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/*.proto)
+foreach(PROTO ${PROTO_FILES})
+  get_filename_component(PROTO_DIR ${PROTO} DIRECTORY)
+  get_filename_component(PROTO_NAME ${PROTO} NAME_WE)
+  list(APPEND PROTO_SRCS
+       "${PROJECT_BINARY_DIR}/${PROTO_DIR}/${PROTO_NAME}.pb.cc")
+  list(APPEND PROTO_HDRS
+       "${PROJECT_BINARY_DIR}/${PROTO_DIR}/${PROTO_NAME}.pb.h")
+endforeach()
+set(PROTO_OUTPUT_FILES ${PROTO_HDRS} ${PROTO_SRCS})
+set_source_files_properties(${PROTO_OUTPUT_FILES} PROPERTIES GENERATED TRUE)
 
-protobuf_generate_cpp(VELOX_DWIO_ORC_PROTO_SRCS VELOX_DWIO_ORC_PROTO_HDRS
-                      orc_proto.proto)
+# Generate source and headers
+add_custom_command(
+  OUTPUT ${PROTO_OUTPUT_FILES}
+  COMMAND
+    ${Protobuf_PROTOC_EXECUTABLE} --proto_path ${CMAKE_SOURCE_DIR}/ --proto_path
+    ${Protobuf_INCLUDE_DIR} --cpp_out ${PROJECT_BINARY_DIR} ${PROTO_FILES}
+  DEPENDS ${Protobuf_PROTOC_EXECUTABLE}
+  COMMENT "Running PROTO compiler"
+  VERBATIM)
+add_custom_target(dwio_proto ALL DEPENDS ${PROTO_OUTPUT_FILES})
 
-add_library(
-  velox_dwio_dwrf_proto
-  ${VELOX_DWIO_DWRF_PROTO_SRCS} ${VELOX_DWIO_DWRF_PROTO_HDRS}
-  ${VELOX_DWIO_ORC_PROTO_SRCS} ${VELOX_DWIO_ORC_PROTO_HDRS})
+add_library(velox_dwio_dwrf_proto ${PROTO_HDRS} ${PROTO_SRCS})
 
 # Access generated proto file with.
 #
 # #include "velox/dwio/dwrf/proto/dwrf_proto.pb.h"
-target_link_libraries(velox_dwio_dwrf_proto protobuf::libprotobuf)
-target_include_directories(velox_dwio_dwrf_proto
-                           PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../../../../)
+target_link_libraries(velox_dwio_dwrf_proto ${Protobuf_LIBRARIES})
+target_include_directories(velox_dwio_dwrf_proto PUBLIC ${PROJECT_BINARY_DIR})


### PR DESCRIPTION
With the recent change to build Protobuf locally, the dwio/dwrf/proto build has started failing in linux-benchmarks-basic-dedicated.

I think this is due to the fact it was still using the protobuf_generate_cpp calls from FindProtobuf.  I suspect this was working in other cases because it was either finding similar Protobuf releases already installed on the machine or using the one built locally because no other was available.

In the case of linux-benchmarks-basic-dedicated it looks like it was finding an older version of Protobuf on the box that was incompatible with the version we built locally.

I rewrote the CMake file to generate the dwio Protobuf code to use the variables exported by the logic to locally build Protobuf and that seems to have fixed it so that it consistently uses the locally built version (both for the compiler and the linked libraries).