### PR TITLE
Use relative path in the check.py script

### DIFF
--- a/scripts/check.py
+++ b/scripts/check.py
@@ -185,7 +185,7 @@ def get_files(commit, path):
 
     if commit != "":
         status, stdout, stderr = util.run(
-            f"git diff --name-only --diff-filter='ACM' {commit}"
+            f"git diff --relative --name-only --diff-filter='ACM' {commit}"
         )
         filelist = stdout.splitlines()
     else:


### PR DESCRIPTION
Use relative path in check.py which makes the check scripts more friendly to those project using velox that does NOT resides in git root. Previously the check script checks all files changes under the git root which may contain files from other components which may have non-compliant files.
One example is the native execution component under presto https://github.com/prestodb/presto/tree/master/presto-native-execution.