### PR TITLE
Dump fuzzer repro info to CircleCI Artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,8 +194,12 @@ jobs:
       - run:
           name: "Run Fuzzer Tests"
           command: |
-            make fuzzertest NUM_THREADS=10
+            mkdir -p /tmp/fuzzer_repro/
+            chmod -R 777 /tmp/fuzzer_repro
+            make fuzzertest NUM_THREADS=10 FUZZER_REPRO_PERSIST_PATH="/tmp/fuzzer_repro"
           no_output_timeout: 5m
+      - store_artifacts:
+          path: '/tmp/fuzzer_repro'
       - run:
          name: "Run Example Binaries"
          command: |

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ fuzzertest: debug
 	$(BUILD_BASE_DIR)/debug/velox/expression/tests/velox_expression_fuzzer_test \
 		--seed $(FUZZER_SEED) \
 		--duration_sec $(FUZZER_DURATION_SEC) \
+		--repro_persist_path $(FUZZER_REPRO_PERSIST_PATH) \
 		--logtostderr=1 \
 		--minloglevel=0
 

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -23,8 +23,14 @@ target_link_libraries(
   ${GFLAGS_LIBRARIES})
 
 add_library(
-  velox_common_base BitUtil.cpp RandomUtil.cpp RawVector.cpp RuntimeMetrics.cpp
-                    SimdUtil.cpp SuccinctPrinter.cpp)
+  velox_common_base
+  BitUtil.cpp
+  Fs.cpp
+  RandomUtil.cpp
+  RawVector.cpp
+  RuntimeMetrics.cpp
+  SimdUtil.cpp
+  SuccinctPrinter.cpp)
 
 target_link_libraries(velox_common_base velox_exception velox_process xsimd)
 

--- a/velox/common/base/Fs.cpp
+++ b/velox/common/base/Fs.cpp
@@ -13,23 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
 
-#if __has_include("filesystem")
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
+#include "velox/common/base/Fs.h"
+#include <glog/logging.h>
 
 namespace facebook::velox::common {
 
-/// Generates a file directory specified by 'dirPath'. The generation will be
-/// recursive. Non-exist parent directories will also be created. Returns true
-/// if creation is successful, false otherwise. Error message will be printed if
-/// creation is unsuccessful, but already created directories will not be
-/// removed.
-bool generateFileDirectory(const char* dirPath);
+bool generateFileDirectory(const char* dirPath) {
+  std::error_code errorCode;
+  auto success = fs::create_directories(dirPath, errorCode);
+  if (!success) {
+    LOG(ERROR) << "Failed to create file directory '" << dirPath
+               << "'. Error: " << errorCode.message() << " errno "
+               << errorCode.value();
+    return false;
+  }
+  return true;
+}
 
 } // namespace facebook::velox::common

--- a/velox/common/base/Fs.h
+++ b/velox/common/base/Fs.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <optional>
+
 #if __has_include("filesystem")
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -31,5 +33,14 @@ namespace facebook::velox::common {
 /// creation is unsuccessful, but already created directories will not be
 /// removed.
 bool generateFileDirectory(const char* dirPath);
+
+/// Creates a file with a generated file name in provided 'basePath'. The
+/// generated file will have random chars in the file name to avoid duplication.
+/// The full path of the file will be of the pattern
+/// {basePath}/velox_{prefix}_XXXXXX where 'XXXXXX' is the randomly generated
+/// chars. A nullopt will be returned if file creation fails.
+std::optional<std::string> generateFilePath(
+    const char* basePath,
+    const char* prefix);
 
 } // namespace facebook::velox::common

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -19,6 +19,7 @@
 #include <fstream>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/base/Fs.h"
 #include "velox/common/base/SuccinctPrinter.h"
 #include "velox/core/Expressions.h"
 #include "velox/expression/ConstantExpr.h"
@@ -340,7 +341,7 @@ class ExprExceptionContext {
 
     // Persist vector to disk
     try {
-      auto dataPathOpt = generateFilePath(basePath, "vector");
+      auto dataPathOpt = common::generateFilePath(basePath, "vector");
       if (!dataPathOpt.has_value()) {
         dataPath_ = "Failed to create file for saving input vector.";
         return;
@@ -355,7 +356,7 @@ class ExprExceptionContext {
     // Persist sql to disk
     auto sql = expr_->toSql();
     try {
-      auto sqlPathOpt = generateFilePath(basePath, "sql");
+      auto sqlPathOpt = common::generateFilePath(basePath, "sql");
       if (!sqlPathOpt.has_value()) {
         sqlPath_ = "Failed to create file for saving SQL.";
         return;

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/expression/tests/ExpressionVerifier.h"
+#include "velox/common/base/Fs.h"
 #include "velox/expression/Expr.h"
 #include "velox/vector/VectorSaver.h"
 
@@ -238,6 +239,10 @@ void ExpressionVerifier::persistReproInfo(
   std::string sqlPath;
 
   const auto basePath = options_.reproPersistPath.c_str();
+  if (!common::generateFileDirectory(options_.reproPersistPath.c_str())) {
+    return;
+  }
+
   // Saving input vector
   auto inputPathOpt = generateFilePath(basePath, "vector");
   if (!inputPathOpt.has_value()) {

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -220,6 +220,7 @@ bool ExpressionVerifier::verify(
     } else {
       // Throws in case output is different.
       compareVectors(commonEvalResult.front(), simplifiedEvalResult.front());
+      VELOX_FAIL("STRATEGIC DEBUG FAIL"); // DEBUG, TO BE DELETED
     }
   } catch (...) {
     if (!options_.reproPersistPath.empty()) {
@@ -244,7 +245,7 @@ void ExpressionVerifier::persistReproInfo(
   }
 
   // Saving input vector
-  auto inputPathOpt = generateFilePath(basePath, "vector");
+  auto inputPathOpt = common::generateFilePath(basePath, "input_vector");
   if (!inputPathOpt.has_value()) {
     inputPath = "Failed to create file for saving input vector.";
   } else {
@@ -258,7 +259,7 @@ void ExpressionVerifier::persistReproInfo(
 
   // Saving result vector
   if (resultVector) {
-    auto resultPathOpt = generateFilePath(basePath, "vector");
+    auto resultPathOpt = common::generateFilePath(basePath, "result_vector");
     if (!resultPathOpt.has_value()) {
       resultPath = "Failed to create file for saving result vector.";
     } else {
@@ -272,7 +273,7 @@ void ExpressionVerifier::persistReproInfo(
   }
 
   // Saving sql
-  auto sqlPathOpt = generateFilePath(basePath, "sql");
+  auto sqlPathOpt = common::generateFilePath(basePath, "expression_sql");
   if (!sqlPathOpt.has_value()) {
     sqlPath = "Failed to create file for saving SQL.";
   } else {

--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -761,15 +761,4 @@ std::string restoreStringFromFile(const char* FOLLY_NONNULL filePath) {
   inputFile.close();
   return result;
 }
-
-std::optional<std::string> generateFilePath(
-    const char* basePath,
-    const char* prefix) {
-  auto path = fmt::format("{}/velox_{}_XXXXXX", basePath, prefix);
-  auto fd = mkstemp(path.data());
-  if (fd == -1) {
-    return std::nullopt;
-  }
-  return path;
-}
 } // namespace facebook::velox

--- a/velox/vector/VectorSaver.h
+++ b/velox/vector/VectorSaver.h
@@ -61,9 +61,4 @@ VectorPtr restoreVectorFromFile(
 /// Reads a string from a file stored by saveStringToFile() method
 std::string restoreStringFromFile(const char* FOLLY_NONNULL filePath);
 
-/// Generates a file path in specified directory. Returns std::nullopt on
-/// failure.
-std::optional<std::string> generateFilePath(
-    const char* FOLLY_NONNULL basePath,
-    const char* FOLLY_NONNULL prefix);
 } // namespace facebook::velox

--- a/velox/vector/tests/VectorSaverTest.cpp
+++ b/velox/vector/tests/VectorSaverTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/vector/VectorSaver.h"
 #include <fstream>
+#include "velox/common/base/Fs.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
@@ -541,7 +542,7 @@ TEST_F(VectorSaverTest, exceptionContext) {
   auto messageFunction = [](VeloxException::Type /*exceptionType*/,
                             auto* arg) -> std::string {
     auto* info = static_cast<VectorSaverInfo*>(arg);
-    auto filePath = generateFilePath(info->path, "vector");
+    auto filePath = common::generateFilePath(info->path, "vector");
     if (!filePath.has_value()) {
       return "Cannot generate file path to store the vector.";
     }


### PR DESCRIPTION
Allow circle ci to dump repro info upon fuzzer failure to Artifacts.

Test:
Manually created failure in fuzzer and observed repro files dumped to Artifacts.
![Screen Shot 2022-10-28 at 2 24 09 PM](https://user-images.githubusercontent.com/9097144/198746451-d2ecf184-824f-4711-a925-241087e12e1b.png)
