### PR TITLE
Add explicit not null API on VectorFuzzer

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -34,6 +34,32 @@ namespace {
 // the dependency on DWRF.
 constexpr int64_t MAX_NANOS = 1'000'000'000;
 
+// Structure to help temporary changes to Options. This objects saves the
+// current state of the Options object, and restores it when it's destructed.
+// For instance, if you would like to temporarily disable nulls for a particular
+// recursive call:
+//
+//  {
+//    ScopedOptionsRestorer(this);
+//    opts_.nullRatio = 0;
+//    // perhaps change other opts_ values.
+//    vector = fuzzFlat(...);
+//  }
+//  // At this point, opts_ would have the original values again.
+//
+struct ScopedOptionsRestorer {
+  ScopedOptionsRestorer(VectorFuzzer* fuzzer)
+      : fuzzer(fuzzer), savedOpts(fuzzer->getOptions()) {}
+
+  ~ScopedOptionsRestorer() {
+    fuzzer->setOptions(savedOpts);
+  }
+
+  // Stores a copy of Options so we can restore at destruction time.
+  VectorFuzzer* fuzzer;
+  VectorFuzzer::Options savedOpts;
+};
+
 // Generate random values for the different supported types.
 template <typename T>
 T rand(FuzzerGenerator&) {
@@ -271,6 +297,20 @@ VectorPtr VectorFuzzer::fuzz(const TypePtr& type) {
   return fuzz(type, opts_.vectorSize, opts_.allowLazyVector);
 }
 
+VectorPtr VectorFuzzer::fuzz(const TypePtr& type, vector_size_t size) {
+  return fuzz(type, size, opts_.allowLazyVector);
+}
+
+VectorPtr VectorFuzzer::fuzzNotNull(const TypePtr& type) {
+  return fuzzNotNull(type, opts_.vectorSize);
+}
+
+VectorPtr VectorFuzzer::fuzzNotNull(const TypePtr& type, vector_size_t size) {
+  ScopedOptionsRestorer restorer(this);
+  opts_.nullRatio = 0;
+  return fuzz(type, size);
+}
+
 VectorPtr
 VectorFuzzer::fuzz(const TypePtr& type, vector_size_t size, bool canBeLazy) {
   VectorPtr vector;
@@ -349,6 +389,18 @@ VectorPtr VectorFuzzer::fuzzConstant(const TypePtr& type, vector_size_t size) {
 
 VectorPtr VectorFuzzer::fuzzFlat(const TypePtr& type) {
   return fuzzFlat(type, opts_.vectorSize);
+}
+
+VectorPtr VectorFuzzer::fuzzFlatNotNull(const TypePtr& type) {
+  return fuzzFlatNotNull(type, opts_.vectorSize);
+}
+
+VectorPtr VectorFuzzer::fuzzFlatNotNull(
+    const TypePtr& type,
+    vector_size_t size) {
+  ScopedOptionsRestorer restorer(this);
+  opts_.nullRatio = 0;
+  return fuzzFlat(type, size);
 }
 
 VectorPtr VectorFuzzer::fuzzFlat(const TypePtr& type, vector_size_t size) {

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -44,12 +44,12 @@ enum UTF8CharList {
 ///
 /// #1.
 ///
-/// The `fuzz(type, canBeLazy)` method provides the highest degree of entropy.
-/// It randomly generates different types of (possibly nested) encodings given
-/// the input type, including constants, dictionaries, sliced vectors, and more.
-/// It accepts any primitive, complex, or nested types. Additionally,
-/// 'canBeLazy' can be set to true to enable a chance of generating a lazy
-/// vector:
+/// The `fuzz(type)` method provides the highest degree of entropy. It randomly
+/// generates different types of (possibly nested) encodings given the input
+/// type, including constants, dictionaries, sliced vectors, and more. It
+/// accepts any primitive, complex, or nested types. Additionally,
+/// 'opt.allowLazyVector' can be set to true to enable a chance of generating a
+/// lazy vector:
 ///
 ///   auto vector1 = fuzzer.fuzz(INTEGER(), true);
 ///   auto vector2 =
@@ -147,29 +147,36 @@ class VectorFuzzer {
   }
 
   // Returns a "fuzzed" vector, containing randomized data, nulls, and indices
-  // vector (dictionary). Returns a vector of `opts_.vectorSize` size.
+  // vector (dictionary). Returns a vector containing `opts_.vectorSize` or
+  // `size` elements.
   VectorPtr fuzz(const TypePtr& type);
+  VectorPtr fuzz(const TypePtr& type, vector_size_t size);
+
+  // Same as above, but returns a vector without nulls (regardless of the value
+  // of opts.nullRatio).
+  VectorPtr fuzzNotNull(const TypePtr& type);
+  VectorPtr fuzzNotNull(const TypePtr& type, vector_size_t size);
 
   // Returns a flat vector or a complex vector with flat children with
-  // randomized data and nulls. Returns a vector of `opts_.vectorSize` size.
+  // randomized data and nulls. Returns a vector containing `opts_.vectorSize`
+  // or `size` elements.
   VectorPtr fuzzFlat(const TypePtr& type);
-
-  // Same as above, but returns a vector of `size` size.
   VectorPtr fuzzFlat(const TypePtr& type, vector_size_t size);
 
-  // Returns a random constant vector (which could be a null constant). Returns
-  // a vector with size set to `opts_.vectorSize`.
-  VectorPtr fuzzConstant(const TypePtr& type);
+  // Same as above, but returns a vector without nulls (regardless of the value
+  // of opts.nullRatio).
+  VectorPtr fuzzFlatNotNull(const TypePtr& type);
+  VectorPtr fuzzFlatNotNull(const TypePtr& type, vector_size_t size);
 
-  // Same as above, but returns a vector of `size` size.
+  // Returns a random constant vector (which could be a null constant). Returns
+  // a vector with size set to `opts_.vectorSize` or 'size'.
+  VectorPtr fuzzConstant(const TypePtr& type);
   VectorPtr fuzzConstant(const TypePtr& type, vector_size_t size);
 
   // Wraps `vector` using a randomized indices vector, returning a
   // DictionaryVector which has same number of indices as the underlying
   // `vector` size.
   VectorPtr fuzzDictionary(const VectorPtr& vector);
-
-  // Same as above, but returns a dictionary vector of `size` size.
   VectorPtr fuzzDictionary(const VectorPtr& vector, vector_size_t size);
 
   // Uses `elements` as the internal elements vector, wrapping them into an
@@ -232,8 +239,9 @@ class VectorFuzzer {
   RowVectorPtr fuzzRowChildrenToLazy(RowVectorPtr rowVector);
 
  private:
-  // Same as above, but returns a vector of `size` size. Additionally, If
-  // 'canBeLazy' is true then the returned vector can be a lazy vector.
+  // Returns a "fuzzed" vector, containing randomized data, nulls, and indices
+  // vector (dictionary). Additionally, if 'canBeLazy' is true then the returned
+  // vector can be a lazy vector.
   VectorPtr fuzz(const TypePtr& type, vector_size_t size, bool canBeLazy);
 
   // Generates a flat vector for primitive types.


### PR DESCRIPTION
Summary:
This API will be useful as we refactor how maps are composed (next
PR/diff).

Differential Revision:
D40785445

LaMa Project: L1134559

