### PR TITLE
Fix the regression by re-enabling parallel hash table build

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -721,7 +721,11 @@ bool HashBuild::finishHashBuild() {
         VELOX_CHECK_GT(spillPartitionEntry.second->numFiles(), 0);
       }
     }
-    table_->prepareJoinTable(std::move(otherTables));
+
+    const bool hasOthers = !otherTables.empty();
+    table_->prepareJoinTable(
+        std::move(otherTables),
+        hasOthers ? operatorCtx_->task()->queryCtx()->executor() : nullptr);
 
     addRuntimeStats();
     if (joinBridge_->setHashTable(

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -477,6 +477,16 @@ class HashTable : public BaseHashTable {
       uint64_t* FOLLY_NULLABLE hashes,
       int32_t numGroups);
 
+  /// Checks if we can apply parallel table build optimization for hash join.
+  /// The function returns true if all of the following conditions:
+  /// 1. the hash table is built for parallel join;
+  /// 2. there is more than one sub-tables;
+  /// 3. the build executor has been set;
+  /// 4. the table is not in kArray mode;
+  /// 5. the number of table entries per each parallel build shard is no less
+  ///    than a pre-defined threshold: 1000 for now.
+  bool canApplyParallelJoinBuild() const;
+
   // Builds a join table with '1 + otherTables_.size()' independent
   // threads using 'executor_'. First all RowContainers get partition
   // numbers assigned to each row. Next, all threads pick all rows

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -844,6 +844,23 @@ TEST_P(MultiThreadedHashJoinTest, normalizedKeyOverflow) {
       .run();
 }
 
+DEBUG_ONLY_TEST_P(MultiThreadedHashJoinTest, parallelJoinBuildCheck) {
+  std::atomic<bool> isParallelBuild{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::HashTable::parallelJoinBuild",
+      std::function<void(void*)>([&](void*) { isParallelBuild = true; }));
+  HashJoinBuilder(*pool_, duckDbQueryRunner_)
+      .numDrivers(numDrivers_)
+      .keyTypes({BIGINT(), VARCHAR()})
+      .probeVectors(1600, 5)
+      .buildVectors(1500, 5)
+      .referenceQuery(
+          "SELECT t_k0, t_k1, t_data, u_k0, u_k1, u_data FROM t, u WHERE t_k0 = u_k0 AND t_k1 = u_k1")
+      .injectSpill(false)
+      .run();
+  ASSERT_EQ(numDrivers_ == 1, !isParallelBuild);
+}
+
 TEST_P(MultiThreadedHashJoinTest, allTypes) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_)
       .keyTypes(


### PR DESCRIPTION
The parallel hash build is accidentally disabled by
https://github.com/facebookincubator/velox/pull/2573 
This PR re-enable it and will add a unit test to ensure this
behavior.