### PR TITLE
Map() can only take fast path if vectors have enough size

### DIFF
--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -44,14 +44,11 @@ class MapFunction : public exec::VectorFunction {
 
     MapVectorPtr mapVector;
 
-    // Take the fast path only if:
-    // - both keys and values are identity mapping (no other indirections).
-    // - the offsets in both keys and values vectors are the same.
-    //
-    // (if sizes are different keys and values the function will throw).
+    // If both vectors have identity mapping, check if we can take the zero-copy
+    // fast-path.
     if (decodedKeys->isIdentityMapping() &&
         decodedValues->isIdentityMapping() &&
-        offsetsAligned(
+        canTakeFastPath(
             keys->as<ArrayVector>(), values->as<ArrayVector>(), rows)) {
       auto keysArray = keys->as<ArrayVector>();
       auto valuesArray = values->as<ArrayVector>();
@@ -181,14 +178,19 @@ class MapFunction : public exec::VectorFunction {
   }
 
  private:
-  // Given two ArrayVectors, return whether their offset buffer values are the
-  // same.
-  bool offsetsAligned(
+  // Can only take the fast path if:
+  // - the offsets in both keys and values vectors are the same.
+  // - if the number of elements is equal or larger than rows.end().
+  //
+  // (if element sizes are different keys and values the Map function will
+  // throw).
+  bool canTakeFastPath(
       ArrayVector* keys,
       ArrayVector* values,
       const SelectivityVector& rows) const {
-    VELOX_CHECK_GE(keys->size(), rows.size());
-    VELOX_CHECK_GE(values->size(), rows.size());
+    if (keys->size() < rows.end() || values->size(), rows.end()) {
+      return false;
+    }
     return rows.testSelected([&](vector_size_t row) {
       return keys->offsetAt(row) == values->offsetAt(row);
     });

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -367,14 +367,18 @@ class SelectivityVector {
   }
 
  private:
-  // the vector of bits for what is selected vs not (1 is selected)
+  // The vector of bits for what is selected vs not (1 is selected).
   std::vector<uint64_t> bits_;
+
   // The number of leading bits used in 'bits_'.
   vector_size_t size_ = 0;
-  // the minimum index of a selected value, if there are any selected
+
+  // The minimum index of a selected value, if there are any selected.
   vector_size_t begin_ = 0;
-  // one past the last selected value, if there are any selected
+
+  // One past the last selected value, if there are any selected.
   vector_size_t end_ = 0;
+
   mutable std::optional<bool> allSelected_;
 
   friend class SelectivityIterator;


### PR DESCRIPTION
Summary:
It is legit for a function to take vectors as input which are smaller
than the number of records active in `rows`. In such cases, Map() shouldn't
fail, but rather fallback to the slow path.

Differential Revision: D40788721

