### PR TITLE
Disallow maps with duplicate keys in assertEqualResults

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -161,18 +161,18 @@ class ExpressionEvaluator {
   // Evaluates previously compiled expression on the specified rows.
   // Re-uses result vector if it is not null.
   virtual void evaluate(
-      exec::ExprSet* exprSet,
+      exec::ExprSet* FOLLY_NONNULL exprSet,
       const SelectivityVector& rows,
       RowVectorPtr& input,
-      VectorPtr* result) const = 0;
+      VectorPtr* FOLLY_NULLABLE result) const = 0;
 };
 
 class ConnectorQueryCtx {
  public:
   ConnectorQueryCtx(
-      memory::MemoryPool* pool,
+      memory::MemoryPool* FOLLY_NONNULL pool,
       const Config* FOLLY_NONNULL connectorConfig,
-      ExpressionEvaluator* expressionEvaluator,
+      ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator,
       memory::MappedMemory* FOLLY_NONNULL mappedMemory,
       const std::string& taskId,
       const std::string& planNodeId,
@@ -185,21 +185,21 @@ class ConnectorQueryCtx {
         taskId_(taskId),
         driverId_(driverId) {}
 
-  memory::MemoryPool* memoryPool() const {
+  memory::MemoryPool* FOLLY_NONNULL memoryPool() const {
     return pool_;
   }
 
-  const Config* config() const {
+  const Config* FOLLY_NONNULL config() const {
     return config_;
   }
 
-  ExpressionEvaluator* expressionEvaluator() const {
+  ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator() const {
     return expressionEvaluator_;
   }
 
   // MappedMemory for large allocations. Used for caching with
   // CachedBufferedImput if this implements cache::AsyncDataCache.
-  memory::MappedMemory* mappedMemory() const {
+  memory::MappedMemory* FOLLY_NONNULL mappedMemory() const {
     return mappedMemory_;
   }
 
@@ -220,10 +220,10 @@ class ConnectorQueryCtx {
   }
 
  private:
-  memory::MemoryPool* pool_;
-  const Config* config_;
-  ExpressionEvaluator* expressionEvaluator_;
-  memory::MappedMemory* mappedMemory_;
+  memory::MemoryPool* FOLLY_NONNULL pool_;
+  const Config* FOLLY_NONNULL config_;
+  ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator_;
+  memory::MappedMemory* FOLLY_NONNULL mappedMemory_;
   const std::string scanId_;
   const std::string taskId_;
   const int driverId_;
@@ -258,12 +258,12 @@ class Connector {
       const std::unordered_map<
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& columnHandles,
-      ConnectorQueryCtx* connectorQueryCtx) = 0;
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) = 0;
 
   virtual std::shared_ptr<DataSink> createDataSink(
       RowTypePtr inputType,
       std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
-      ConnectorQueryCtx* connectorQueryCtx) = 0;
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) = 0;
 
   // Returns a ScanTracker for 'id'. 'id' uniquely identifies the
   // tracker and different threads will share the same
@@ -274,7 +274,7 @@ class Connector {
       int32_t loadQuantum);
 
  private:
-  static void unregisterTracker(cache::ScanTracker* tracker);
+  static void unregisterTracker(cache::ScanTracker* FOLLY_NONNULL tracker);
 
   const std::string id_;
 
@@ -287,7 +287,7 @@ class Connector {
 
 class ConnectorFactory {
  public:
-  explicit ConnectorFactory(const char* name) : name_(name) {}
+  explicit ConnectorFactory(const char* FOLLY_NONNULL name) : name_(name) {}
 
   virtual ~ConnectorFactory() = default;
 
@@ -298,7 +298,7 @@ class ConnectorFactory {
   virtual std::shared_ptr<Connector> newConnector(
       const std::string& id,
       std::shared_ptr<const Config> properties,
-      folly::Executor* executor = nullptr) = 0;
+      folly::Executor* FOLLY_NULLABLE executor = nullptr) = 0;
 
  private:
   const std::string name_;

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -172,7 +172,7 @@ class ConnectorQueryCtx {
   ConnectorQueryCtx(
       memory::MemoryPool* FOLLY_NONNULL pool,
       const Config* FOLLY_NONNULL connectorConfig,
-      ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator,
+      ExpressionEvaluator* FOLLY_NULLABLE expressionEvaluator,
       memory::MappedMemory* FOLLY_NONNULL mappedMemory,
       const std::string& taskId,
       const std::string& planNodeId,
@@ -193,7 +193,7 @@ class ConnectorQueryCtx {
     return config_;
   }
 
-  ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator() const {
+  ExpressionEvaluator* FOLLY_NULLABLE expressionEvaluator() const {
     return expressionEvaluator_;
   }
 
@@ -222,7 +222,7 @@ class ConnectorQueryCtx {
  private:
   memory::MemoryPool* FOLLY_NONNULL pool_;
   const Config* FOLLY_NONNULL config_;
-  ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator_;
+  ExpressionEvaluator* FOLLY_NULLABLE expressionEvaluator_;
   memory::MappedMemory* FOLLY_NONNULL mappedMemory_;
   const std::string scanId_;
   const std::string taskId_;

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -210,7 +210,7 @@ class HiveDataSink : public DataSink {
 
   const RowTypePtr inputType_;
   const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle_;
-  const ConnectorQueryCtx* connectorQueryCtx_;
+  const ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx_;
   std::vector<std::unique_ptr<dwrf::Writer>> writers_;
 };
 
@@ -316,10 +316,10 @@ class HiveConfig {
  public:
   /// Can new data be inserted into existing partitions or existing
   /// unpartitioned tables
-  static constexpr const char* kImmutablePartitions =
+  static constexpr const char* FOLLY_NONNULL kImmutablePartitions =
       "hive.immutable-partitions";
 
-  static bool isImmutablePartitions(const Config* baseConfig) {
+  static bool isImmutablePartitions(const Config* FOLLY_NONNULL baseConfig) {
     return baseConfig->get<bool>(kImmutablePartitions, true);
   }
 };
@@ -373,13 +373,6 @@ class HiveConnector final : public Connector {
  private:
   FileHandleFactory fileHandleFactory_;
   folly::Executor* FOLLY_NULLABLE executor_;
-
-  static constexpr const char* FOLLY_NONNULL kNodeSelectionStrategy =
-      "node_selection_strategy";
-  static constexpr const char* FOLLY_NONNULL
-      kNodeSelectionStrategyNoPreference = "NO_PREFERENCE";
-  static constexpr const char* FOLLY_NONNULL
-      kNodeSelectionStrategySoftAffinity = "SOFT_AFFINITY";
 };
 
 class HiveConnectorFactory : public ConnectorFactory {

--- a/velox/exec/tests/AssertQueryBuilderTest.cpp
+++ b/velox/exec/tests/AssertQueryBuilderTest.cpp
@@ -198,4 +198,12 @@ TEST_F(AssertQueryBuilderTest, nestedArrayMapResults) {
   assertEqualResults({input}, {input});
 }
 
+TEST_F(AssertQueryBuilderTest, duplicateMapKeys) {
+  auto input = makeRowVector({makeNullableMapVector<int64_t, int64_t>({
+      {{{1, 10}, {1, 12}, {2, 20}}},
+      {{{1, 100}, {1, 112}, {2, 200}}},
+  })});
+
+  EXPECT_ANY_THROW(assertEqualResults({input}, {input}));
+}
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
assertEqualResults used to silently ignore map entries with duplicate keys and
incorrectly report that two maps are equal if they only differ in duplicate
keys.