### PR TITLE
Prevent split() from hanging on empty delimiter

### DIFF
--- a/velox/functions/prestosql/Split.cpp
+++ b/velox/functions/prestosql/Split.cpp
@@ -219,8 +219,14 @@ class SplitFunction : public exec::VectorFunction {
       // Find the byte of the 1st delimiter.
       auto byteIndex = sinput.find(sdelim, 0);
 
+      // Special case for empty delimiters. Split character by character with an
+      // empty string at the end.
+      if (sdelim.empty()) {
+        byteIndex++;
+      }
+
       // Delimiter is not found, leave the loop.
-      if (byteIndex == std::string_view::npos) {
+      if (byteIndex > sinput.size()) {
         break;
       }
 

--- a/velox/functions/prestosql/tests/SplitTest.cpp
+++ b/velox/functions/prestosql/tests/SplitTest.cpp
@@ -241,6 +241,15 @@ TEST_F(SplitTest, split) {
     }
   }
 
+  // Check the empty delimiter special case.
+  delim = "";
+  auto expected = makeArrayVector<StringView>({
+      {"I", ",", "h", "e", ",", "s", "h", "e", ",", "t", "h", "e", "y", ""},
+      {"o", "n", "e", ",", ",", ",", "f", "o", "u", "r", ",", ""},
+      {""},
+  });
+  assertEqualVectors(expected, run(inputStrings, delim, "split(C0, C1)"));
+
   // Non-ascii, flat strings, flat delimiter, no limit.
   delim = "లేదా";
   inputStrings = std::vector<std::string>{


### PR DESCRIPTION
Summary: split() function got into an infinite loop for empty delimiters.

Reviewed By: kgpai, mbasmanova

Differential Revision:
D40789716

LaMa Project: L1134559

