### PR TITLE
Fix nightly fuzzer run timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,16 +403,19 @@ jobs:
           # the job output for context.
           name: "Run Fuzzer Tests"
           command: |
-            make fuzzertest NUM_THREADS=8 FUZZER_DURATION_SEC=600 FUZZER_SEED=${RANDOM} \
-              > /tmp/fuzzer.log 2>&1 || ( \
+            echo -e "The logs will be saved to \"/tmp/fuzzer.log\" and uploaded" \
+                    "as a job artifact (check the \"Artifacts\" tab above)."
+            _build/debug/velox/expression/tests/velox_expression_fuzzer_test \
+                --seed ${RANDOM} \
+                --duration_sec 600 \
+                --logtostderr=1 \
+                --minloglevel=0 \
+              2>&1 | tee /tmp/fuzzer.log || ( \
                 tail -n 1000 /tmp/fuzzer.log;
-                echo "FAIL: Fuzzer run failed, logs saved to \"/tmp/fuzzer.log\" and uploaded" \
-                     "as job artifact (check the \"Artifacts\" tab above).";
+                echo "FAIL: Fuzzer run failed";
                 exit 1; \
               )
-            tail -n 1000 /tmp/fuzzer.log
-            echo -e "\n\nFuzzer run finished successfully. Logs saved as job artifact " \
-                 "(check the \"Artifacts\" tab above)."
+            echo -e "\n\nFuzzer run finished successfully."
           no_output_timeout: 20m
       - store_artifacts:
           path: '/tmp/fuzzer.log'


### PR DESCRIPTION
The nightly fuzzer run has been timing out with "Too long with no output (exceeded 20m0s): context deadline exceeded"

The problem is that when we run "make fuzzertest", internally it runs "make debug".  Even though we just ran "make debug" in the previous step, it partially rebuilds.   Between this and the 10 minute fuzzer tests it exceeds the 20 minute limit.  Note that since we pipe all output to a file, the 20 minute timer starts right away.

I changed the config for this step to execute the velox_expression_fuzzer_test directly rather than calling "make fuzzertest" since this avoids the build.  I could have increased the time limit, but rebuilding seemed like a waste anyway.

I also used tee to pipe the output to stdout while also writing it to a file (if the fuzzer test succeeds the output gets truncated in the CircleCI logs, but it's helpful to have it readily available if something goes wrong, and this allows us to watch the output at the beginning in realtime (e.g. so I could immediately see that it was rebuilding).  (I moved the message that we're writing everything to an artifact to the top so it doesn't get cut off).