### PR TITLE
Extend ExpressionRunner to better support debugging workflow

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -510,6 +510,19 @@ std::shared_ptr<const core::IExpr> parseExpr(
   return parseExpr(*parsedExpressions.front(), options);
 }
 
+std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
+    const std::string& exprString,
+    const ParseOptions& options) {
+  auto parsedExpressions = parseExpression(exprString);
+  VELOX_CHECK_GT(parsedExpressions.size(), 0);
+  std::vector<std::shared_ptr<const core::IExpr>> exprs;
+  exprs.reserve(parsedExpressions.size());
+  for (const auto& parsedExpr : parsedExpressions) {
+    exprs.push_back(parseExpr(*parsedExpr, options));
+  }
+  return exprs;
+}
+
 namespace {
 bool isAscending(::duckdb::OrderType orderType, const std::string& exprString) {
   switch (orderType) {

--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -42,6 +42,10 @@ std::shared_ptr<const core::IExpr> parseExpr(
     const std::string& exprString,
     const ParseOptions& options);
 
+std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
+    const std::string& exprString,
+    const ParseOptions& options);
+
 // Parses an ORDER BY clause using DuckDB's internal postgresql-based parser,
 // converting it to a pair of an IExpr tree and a core::SortOrder. Uses ASC
 // NULLS LAST as the default sort order.

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -912,4 +912,11 @@ void assertEqualResults(
   }
 }
 
+void printResults(const RowVectorPtr& result, std::ostream& out) {
+  auto materializedRows = materialize(result);
+  for (const auto& row : materializedRows) {
+    out << toString(row) << std::endl;
+  }
+}
+
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -171,4 +171,6 @@ void assertEqualResults(
     const std::vector<RowVectorPtr>& expected,
     const std::vector<RowVectorPtr>& actual);
 
+void printResults(const RowVectorPtr& result, std::ostream& out);
+
 } // namespace facebook::velox::exec::test

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -113,8 +113,9 @@ target_link_libraries(velox_expression_runner velox_expression_verifier
                       velox_functions_prestosql velox_parse_parser gtest)
 
 add_executable(velox_expression_runner_test ExpressionRunnerTest.cpp)
-target_link_libraries(velox_expression_runner_test velox_expression_runner
-                      velox_function_registry gtest gtest_main)
+target_link_libraries(
+  velox_expression_runner_test velox_expression_runner velox_exec_test_lib
+  velox_function_registry gtest gtest_main)
 
 add_executable(velox_expression_runner_unit_test ExpressionRunnerUnitTest.cpp)
 target_link_libraries(
@@ -125,6 +126,7 @@ target_link_libraries(
   velox_expression_verifier
   velox_function_registry
   velox_temp_path
+  velox_exec_test_lib
   gtest
   gtest_main)
 

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -18,6 +18,8 @@
 
 #include "velox/common/memory/Memory.h"
 #include "velox/core/QueryCtx.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/expression/Expr.h"
 #include "velox/expression/tests/ExpressionRunner.h"
 #include "velox/expression/tests/ExpressionVerifier.h"
 #include "velox/parse/Expressions.h"
@@ -27,40 +29,116 @@
 
 namespace facebook::velox::test {
 
-using namespace facebook::velox;
+namespace {
+/// Parse comma-separated SQL expressions.
+std::vector<core::TypedExprPtr> parseSql(
+    const std::string& sql,
+    const TypePtr& inputType,
+    memory::MemoryPool* pool) {
+  auto exprs = parse::parseMultipleExpressions(sql, {});
+
+  std::vector<core::TypedExprPtr> typedExprs;
+  typedExprs.reserve(exprs.size());
+  for (const auto& expr : exprs) {
+    typedExprs.push_back(core::Expressions::inferTypes(expr, inputType, pool));
+  }
+  return typedExprs;
+}
+
+/// Creates a RowVector from a list of child vectors. Uses _col0, _col1,..
+/// auto-generated names for the RowType.
+RowVectorPtr createRowVector(
+    const std::vector<VectorPtr>& vectors,
+    vector_size_t size,
+    memory::MemoryPool* pool) {
+  auto n = vectors.size();
+
+  std::vector<std::string> names;
+  names.reserve(n);
+  std::vector<TypePtr> types;
+  types.reserve(n);
+  for (auto i = 0; i < n; ++i) {
+    names.push_back(fmt::format("_col{}", i));
+    types.push_back(vectors[i]->type());
+  }
+
+  return std::make_shared<RowVector>(
+      pool, ROW(std::move(names), std::move(types)), nullptr, size, vectors);
+}
+
+void evaluateAndPrintResults(
+    exec::ExprSet& exprSet,
+    const RowVectorPtr& data,
+    const SelectivityVector& rows,
+    core::ExecCtx& execCtx) {
+  exec::EvalCtx evalCtx(&execCtx, &exprSet, data.get());
+
+  std::vector<VectorPtr> results(1);
+  exprSet.eval(rows, evalCtx, results);
+
+  // Print the results.
+  auto rowResult = createRowVector(results, rows.size(), execCtx.pool());
+  std::cout << "Result: " << rowResult->type()->toString() << std::endl;
+  exec::test::printResults(rowResult, std::cout);
+}
+
+vector_size_t adjustNumRows(vector_size_t numRows, vector_size_t size) {
+  return numRows > 0 && numRows < size ? numRows : size;
+}
+} // namespace
 
 void ExpressionRunner::run(
     const std::string& inputPath,
-    const std::string& sqlPath,
+    const std::string& sql,
     const std::string& resultPath,
-    const std::string& mode) {
+    const std::string& mode,
+    vector_size_t numRows) {
+  VELOX_CHECK(!sql.empty());
+
   std::shared_ptr<core::QueryCtx> queryCtx{core::QueryCtx::createForTest()};
   std::unique_ptr<memory::MemoryPool> pool{
       memory::getDefaultScopedMemoryPool()};
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
-  VELOX_CHECK(!inputPath.empty());
-  VELOX_CHECK(!sqlPath.empty());
-
-  auto inputVector = std::dynamic_pointer_cast<RowVector>(
-      restoreVectorFromFile(inputPath.c_str(), pool.get()));
-  VELOX_CHECK_NOT_NULL(inputVector, "Input vector is not a RowVector");
-  auto sql = restoreStringFromFile(sqlPath.c_str());
+  RowVectorPtr inputVector;
+  if (inputPath.empty()) {
+    inputVector = std::make_shared<RowVector>(
+        pool.get(), ROW({}), nullptr, 1, std::vector<VectorPtr>{});
+  } else {
+    inputVector = std::dynamic_pointer_cast<RowVector>(
+        restoreVectorFromFile(inputPath.c_str(), pool.get()));
+    VELOX_CHECK_NOT_NULL(
+        inputVector,
+        "Input vector is not a RowVector: {}",
+        inputVector->toString());
+    VELOX_CHECK_GT(inputVector->size(), 0, "Input vector must not be empty.");
+  }
 
   parse::registerTypeResolver();
-  parse::ParseOptions options;
-  auto typedExpr = core::Expressions::inferTypes(
-      parse::parseExpr(sql, options), inputVector->type(), pool.get());
+  auto typedExprs = parseSql(sql, inputVector->type(), pool.get());
+
   VectorPtr resultVector;
   if (!resultPath.empty()) {
     resultVector = restoreVectorFromFile(resultPath.c_str(), pool.get());
   }
 
+  SelectivityVector rows(adjustNumRows(numRows, inputVector->size()));
+
+  LOG(INFO) << "Evaluating SQL expression(s): " << sql;
+
   if (mode == "verify") {
+    VELOX_CHECK_EQ(
+        1, typedExprs.size(), "'verify' mode supports only one SQL expression");
     test::ExpressionVerifier(&execCtx, {false, ""})
-        .verify(typedExpr, inputVector, std::move(resultVector), true);
+        .verify(typedExprs[0], inputVector, std::move(resultVector), true);
+  } else if (mode == "common") {
+    exec::ExprSet exprSet(typedExprs, &execCtx);
+    evaluateAndPrintResults(exprSet, inputVector, rows, execCtx);
+  } else if (mode == "simplified") {
+    exec::ExprSetSimplified exprSet(typedExprs, &execCtx);
+    evaluateAndPrintResults(exprSet, inputVector, rows, execCtx);
   } else {
-    LOG(ERROR) << "Unknown expression runner mode '" << mode << "'.";
+    VELOX_FAIL("Unknown expression runner mode: [{}].", mode);
   }
 }
 

--- a/velox/expression/tests/ExpressionRunner.h
+++ b/velox/expression/tests/ExpressionRunner.h
@@ -15,6 +15,7 @@
  */
 
 #include <string>
+#include "velox/vector/TypeAliases.h"
 
 namespace facebook::velox::test {
 
@@ -28,22 +29,25 @@ namespace facebook::velox::test {
 ///                supported)
 class ExpressionRunner {
  public:
-  /// \param inputPath The path to the on-disk vector that will be used as input
+  /// @param inputPath The path to the on-disk vector that will be used as input
   ///        to feed to the expression.
-  /// \param sqlPath The path to the on-disk SQL that will be used to describe
-  ///        the expression. \param resultPath The path to the on-disk vector
+  /// @param sql Comma-separated SQL expressions.
+  /// @param resultPath The path to the on-disk vector
   ///        that will be used as the result buffer to which the expression
   ///        evaluation results will be written.
-  /// \param mode The expression evaluation mode, one of ["verify", "common",
+  /// @param mode The expression evaluation mode, one of ["verify", "common",
   ///        "simplified"]
+  /// @param numRows Maximum number of rows to process. 0 means 'all' rows.
+  ///         Applies to "common" and "simplified" modes only.
   ///
   /// User can refer to 'VectorSaver' class to see how to serialize/preserve
   /// vectors to disk.
   static void run(
       const std::string& inputPath,
-      const std::string& sqlPath,
+      const std::string& sql,
       const std::string& resultPath,
-      const std::string& mode);
+      const std::string& mode,
+      vector_size_t numRows);
 };
 
 } // namespace facebook::velox::test

--- a/velox/expression/tests/ExpressionRunnerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerUnitTest.cpp
@@ -56,10 +56,8 @@ TEST_F(ExpressionRunnerUnitTest, run) {
   saveVectorToFile(inputVector.get(), inputPath);
   saveVectorToFile(resultVector.get(), resultPath);
 
-  std::string sql = "length(\"c0\")";
-  saveStringToFile(sql, sqlPath);
   EXPECT_NO_THROW(
-      ExpressionRunner::run(inputPath, sqlPath, resultPath, "verify"));
+      ExpressionRunner::run(inputPath, "length(c0)", resultPath, "verify", 0));
 }
 
 } // namespace facebook::velox::test

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -26,6 +26,15 @@ std::shared_ptr<const core::IExpr> parseExpr(
   return facebook::velox::duckdb::parseExpr(expr, duckConversionOptions);
 }
 
+std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
+    const std::string& expr,
+    const ParseOptions& options) {
+  facebook::velox::duckdb::ParseOptions duckConversionOptions;
+  duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
+  return facebook::velox::duckdb::parseMultipleExpressions(
+      expr, duckConversionOptions);
+}
+
 std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
     const std::string& expr) {
   return facebook::velox::duckdb::parseOrderByExpr(expr);

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -35,4 +35,8 @@ std::shared_ptr<const core::IExpr> parseExpr(
 std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
     const std::string& expr);
 
+std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
+    const std::string& expr,
+    const ParseOptions& options);
+
 } // namespace facebook::velox::parse


### PR DESCRIPTION
When debugging fuzzer-found bugs, it is often beneficial to try to simplify the
expression and reduce the set of rows for evaluation. The new --sql option
allows to try different expressions without editing files. The new --num_rows
flag allows to specify maximum number of rows to process.

It is also helpful to evaluate the expression and print out the results. This is
now possible using --mode=common or --mode=simplified.

- Add common and simplified modes to evaluate expression using common and
  simplified paths and print out the results.
- Add --sql flag to allow specifying SQL expressions in the command line. Add
  support for multiple comma-separated expressions in common and simplified
  modes.
- Add --num_rows flag to allow restricting the number of rows to process.
  Default: 10 rows.