### PR TITLE
Add a unit test and fix for the task not found issue (#3009)

### DIFF
--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/dwio/common/DataSink.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Exchange.h"
+#include "velox/exec/PartitionedOutputBufferManager.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -375,6 +376,22 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
     auto op = PlanBuilder().exchange(intermediatePlan->outputType()).planNode();
 
     assertQuery(op, intermediateTaskIds, "SELECT c3, c0, c2 FROM tmp");
+
+    ASSERT_TRUE(waitForTaskCompletion(leafTask.get())) << leafTask->taskId();
+  }
+
+  // Test asynchronously deleting task buffer (due to abort from downstream)
+  {
+    auto leafTaskId = makeTaskId("leaf", 0);
+    auto leafPlan = PlanBuilder()
+                        .values(vectors_)
+                        .partitionedOutput({}, 1, {"c0", "c1"})
+                        .planNode();
+    auto leafTask = makeTask(leafTaskId, leafPlan, 0);
+    Task::start(leafTask, 4);
+    auto bufferMgr = PartitionedOutputBufferManager::getInstance().lock();
+    // Deletes the results asynchronously to simulate abort from downstream
+    bufferMgr->deleteResults(leafTaskId, 0);
 
     ASSERT_TRUE(waitForTaskCompletion(leafTask.get())) << leafTask->taskId();
   }


### PR DESCRIPTION
https://github.com/facebookincubator/velox/issues/3009 This models the case where the downstream prematurely aborts and calls abortTask of the upstream. The abortTask delete the task asynchronously from the buffers. This causes and exception due to VELOX_CHECK in the following call tree (because the buffers does not have the entry for the taskId any more)
```
Driver.runInternal
  -> PartitionOutput.getOutput()
  -> Destination.flush() (if (blockedDestination) {} path)
  -> PartitionedOutputBufferManager.enqueue()
  -> PartitionedOutputBufferManager.getBuffer()  <- Exception here
```

In the case I've seen, the abort would happen between the flush() and getBuffer()

This unit test currently fails with:
```
unknown file: Failure
C++ exception with description "Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Output buffers for task not found: local://leaf-0
Retriable: False
Expression: it != buffers.end()
Function: operator()
```