### PR TITLE
Fix directory creation to be successful if already exist

### DIFF
--- a/velox/common/base/Fs.cpp
+++ b/velox/common/base/Fs.cpp
@@ -22,7 +22,7 @@ namespace facebook::velox::common {
 bool generateFileDirectory(const char* dirPath) {
   std::error_code errorCode;
   auto success = fs::create_directories(dirPath, errorCode);
-  if (!success) {
+  if (!success && errorCode.value() != 0) {
     LOG(ERROR) << "Failed to create file directory '" << dirPath
                << "'. Error: " << errorCode.message() << " errno "
                << errorCode.value();

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
   BloomFilterTest.cpp
   CoalesceIoTest.cpp
   ExceptionTest.cpp
+  FsTest.cpp
   RangeTest.cpp
   RawVectorTest.cpp
   SimdUtilTest.cpp

--- a/velox/common/base/tests/FsTest.cpp
+++ b/velox/common/base/tests/FsTest.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/Fs.h"
+#include <gtest/gtest.h>
+#include "boost/filesystem.hpp"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+
+namespace facebook::velox::common {
+
+class FsTest : public testing::Test {};
+
+TEST_F(FsTest, createDirectory) {
+  auto rootPath = exec::test::TempDirectoryPath::createTempDirectory();
+  auto tmpDirectoryPath = rootPath + "/first/second/third";
+  // First time should generate directory successfully.
+  EXPECT_FALSE(fs::exists(tmpDirectoryPath.c_str()));
+  EXPECT_TRUE(generateFileDirectory(tmpDirectoryPath.c_str()));
+  EXPECT_TRUE(fs::exists(tmpDirectoryPath.c_str()));
+
+  // Directory already exist, not creating but should return success.
+  EXPECT_TRUE(generateFileDirectory(tmpDirectoryPath.c_str()));
+  EXPECT_TRUE(fs::exists(tmpDirectoryPath.c_str()));
+  boost::filesystem::remove_all(rootPath);
+  EXPECT_FALSE(fs::exists(rootPath.c_str()));
+}
+
+} // namespace facebook::velox::common


### PR DESCRIPTION
Current if directory already exists the creation of directory will return unsuccessful. Change the behavior to be successful.