### PR TITLE
Refactor Window function tests to simplify the combinations

### DIFF
--- a/velox/functions/prestosql/window/tests/WindowTestBase.h
+++ b/velox/functions/prestosql/window/tests/WindowTestBase.h
@@ -18,6 +18,36 @@
 
 namespace facebook::velox::window::test {
 
+/// Common set of window function over clauses using a combination of two
+/// columns.
+static std::vector<std::string> kBasicOverClauses = {
+    "partition by c0 order by c1",
+    "partition by c1 order by c0",
+    "partition by c0 order by c1 desc",
+    "partition by c1 order by c0 desc",
+    // No partition by clause.
+    "order by c0, c1",
+    "order by c1, c0",
+    "order by c0 asc, c1 desc",
+    "order by c1 asc, c0 desc",
+    // No order by clause.
+    "partition by c0, c1",
+};
+
+/// Common set of window function over clauses with different sort orders
+/// using a combination of two columns.
+static std::vector<std::string> kSortOrderBasedOverClauses = {
+    "partition by c0 order by c1 nulls first",
+    "partition by c1 order by c0 nulls first",
+    "partition by c0 order by c1 desc nulls first",
+    "partition by c1 order by c0 desc nulls first",
+    // No partition by clause.
+    "order by c0 asc nulls first, c1 desc nulls first",
+    "order by c1 asc nulls first, c0 desc nulls first",
+    "order by c0 desc nulls first, c1 asc nulls first",
+    "order by c1 desc nulls first, c0 asc nulls first",
+};
+
 class WindowTestBase : public exec::test::OperatorTestBase {
  protected:
   void SetUp() override {
@@ -25,39 +55,45 @@ class WindowTestBase : public exec::test::OperatorTestBase {
     velox::window::registerWindowFunctions();
   }
 
-  std::vector<RowVectorPtr> makeVectors(
+  /// This function generates a simple two integer column RowVector for tests.
+  /// The first integer column has row number % 5 values.
+  /// The second integer column has row number % 7 values.
+  RowVectorPtr makeSimpleVector(vector_size_t size);
+
+  /// This function generates a two integer column RowVector for tests.
+  /// The intention here is that the first column has a constant value of 1.
+  /// The second column has a value of the row number.
+  /// This tests the case where all data is in a single partition.
+  RowVectorPtr makeSinglePartitionVector(vector_size_t size);
+
+  /// This function generates a two integer column RowVector for tests.
+  /// Both the first and second column of each data row is the row number.
+  RowVectorPtr makeSingleRowPartitionsVector(vector_size_t size);
+
+  /// This function generates test data using the VectorFuzzer.
+  std::vector<RowVectorPtr> makeFuzzVectors(
       const RowTypePtr& rowType,
       vector_size_t size,
       int numVectors,
       float nullRatio = 0.0);
 
-  // This function tests SQL queries for the window function and
-  // the specified overClauses with the input RowVectors.
-  // Note : 'function' should be a full window function invocation string
-  // including input parameters and open/close braces. e.g. rank(), ntile(5)
+  /// This function tests SQL queries for the window function and
+  /// the specified overClauses with the input RowVectors.
+  /// Note : 'function' should be a full window function invocation string
+  /// including input parameters and open/close braces. e.g. rank(), ntile(5)
   void testWindowFunction(
       const std::vector<RowVectorPtr>& input,
       const std::string& function,
       const std::vector<std::string>& overClauses);
 
-  // This function tests the SQL query for the window function and overClause
-  // combination with the input RowVectors. It is expected that query execution
-  // will throw an exception with the errorMessage specified.
+  /// This function tests the SQL query for the window function and overClause
+  /// combination with the input RowVectors. It is expected that query execution
+  /// will throw an exception with the errorMessage specified.
   void assertWindowFunctionError(
       const std::vector<RowVectorPtr>& input,
       const std::string& function,
       const std::string& overClause,
       const std::string& errorMessage);
-
-  // This function operates on input RowVectors that have at least 2 columns.
-  // It verifies (for the windowFunction) SQL queries with varying over
-  // clauses. The over clauses covers all combinations of partition by
-  // and order by of the first two input columns.
-  // Note : 'windowFunction' should be a full window function invocation string
-  // including input parameters and open/close braces. e.g. rank(), ntile(5)
-  void testTwoColumnOverClauses(
-      const std::vector<RowVectorPtr>& input,
-      const std::string& windowFunction);
 
  private:
   void testWindowFunction(


### PR DESCRIPTION
Removed the expensive testTwoColumnOverClauses method and replaced it with a
simpler test API that takes a combination of (data, function, overClauses) to
do the important tests. Common sets of data functions, overClauses are moved to
the WindowTestBase for reuse. This new refactoring will make it easier to add
the frameClauses also to the testing.