### PR TITLE
Make repro info convenient to use

### DIFF
--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -152,8 +152,14 @@ bool ExpressionVerifier::verify(
     std::vector<core::TypedExprPtr> typedExprs = {plan};
     // Disabling constant folding in order to preserver the original
     // expression
-    sql =
-        exec::ExprSet(std::move(typedExprs), execCtx_, false).expr(0)->toSql();
+    try {
+      sql = exec::ExprSet(std::move(typedExprs), execCtx_, false)
+                .expr(0)
+                ->toSql();
+    } catch (const std::exception& e) {
+      LOG(WARNING) << "Failed to generate SQL: " << e.what();
+      sql = "<failed to generate>";
+    }
   }
 
   // Execute expression plan using both common and simplified evals.
@@ -285,11 +291,11 @@ void ExpressionVerifier::persistReproInfo(
   }
 
   std::stringstream ss;
-  ss << "Persisted input at '" << inputPath;
+  ss << "Persisted input: --input_path " << inputPath;
   if (resultVector) {
-    ss << "' and result at '" << resultPath;
+    ss << " --result_path " << resultPath;
   }
-  ss << "' and sql at '" << sqlPath << "'";
+  ss << " --sql_path " << sqlPath;
   LOG(INFO) << ss.str();
 }
 


### PR DESCRIPTION
Modify the ExpressionFuzzer to print repro information in a way that's convenient to use:

```
Persisted input: --input_path=<path> --result_path=<path> --sql_path=<sql_path>
```

This way the output can be copy-pasted easily into the repro command line.

Also, suppress failures to generate SQL for repro.

Examples:

```
I20221031 08:20:25.754529 26014986 ExpressionVerifier.cpp:298] Persisted input: --input_path /tmp/b/velox_vector_S52ofQ --sql_path /tmp/b/velox_sql_U3pUSM

W20221031 08:20:25.668462 26014986 ExpressionVerifier.cpp:159] Failed to generate SQL: Exception: VeloxUserError
Error Source: USER
Error Code: UNSUPPORTED
Reason: Type not supported yet: VARBINARY
Retriable: False
Function: appendSqlLiteral
File: /Users/mbasmanova/cpp/velox-1/velox/expression/ConstantExpr.cpp
Line: 210
```