### PR TITLE
Fix signatures for array_xxx functions

### DIFF
--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -32,6 +32,24 @@ std::string sanitizeFunctionName(const std::string& name) {
   return sanitizedName;
 }
 
+const std::vector<std::string> primitiveTypeNames() {
+  static const std::vector<std::string> kPrimitiveTypeNames = {
+      "boolean",
+      "bigint",
+      "integer",
+      "smallint",
+      "tinyint",
+      "real",
+      "double",
+      "varchar",
+      "varbinary",
+      "timestamp",
+      "date",
+  };
+
+  return kPrimitiveTypeNames;
+}
+
 void toAppend(
     const facebook::velox::exec::TypeSignature& signature,
     std::string* result) {
@@ -225,5 +243,4 @@ AggregateFunctionSignatureBuilder::build() {
       std::move(argumentTypes_),
       variableArity_);
 }
-
 } // namespace facebook::velox::exec

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -28,6 +28,9 @@ inline bool isCommonDecimalName(const std::string& typeName) {
   return (typeName == "DECIMAL");
 }
 
+/// Return a list of primitive type names.
+const std::vector<std::string> primitiveTypeNames();
+
 enum class ParameterType : int8_t { kTypeParameter, kIntegerParameter };
 
 /// TypeVariableConstraint holds both, type parameters (e.g. K or V in map(K,

--- a/velox/functions/prestosql/ArrayDistinct.cpp
+++ b/velox/functions/prestosql/ArrayDistinct.cpp
@@ -179,11 +179,14 @@ std::shared_ptr<exec::VectorFunction> create(
 // Define function signature.
 std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
   // array(T) -> array(T)
-  return {exec::FunctionSignatureBuilder()
-              .typeVariable("T")
-              .returnType("array(T)")
-              .argumentType("array(T)")
-              .build()};
+  std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+  for (const auto& type : exec::primitiveTypeNames()) {
+    signatures.push_back(exec::FunctionSignatureBuilder()
+                             .returnType(fmt::format("array({})", type))
+                             .argumentType(fmt::format("array({})", type))
+                             .build());
+  }
+  return signatures;
 }
 
 } // namespace

--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -459,13 +459,18 @@ std::shared_ptr<exec::VectorFunction> createArrayExcept(
 }
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> signatures(
-    const std::string& returnType) {
-  return {exec::FunctionSignatureBuilder()
-              .typeVariable("T")
-              .returnType(returnType)
-              .argumentType("array(T)")
-              .argumentType("array(T)")
-              .build()};
+    const std::string& returnTypeTemplate) {
+  std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+  for (const auto& type : exec::primitiveTypeNames()) {
+    signatures.push_back(
+        exec::FunctionSignatureBuilder()
+            .returnType(
+                fmt::format(fmt::runtime(returnTypeTemplate.c_str()), type))
+            .argumentType(fmt::format("array({})", type))
+            .argumentType(fmt::format("array({})", type))
+            .build());
+  }
+  return signatures;
 }
 
 template <TypeKind kind>
@@ -503,11 +508,11 @@ VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
 
 VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
     udf_array_intersect,
-    signatures("array(T)"),
+    signatures("array({})"),
     createArrayIntersect);
 
 VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
     udf_array_except,
-    signatures("array(T)"),
+    signatures("array({})"),
     createArrayExcept);
 } // namespace facebook::velox::functions


### PR DESCRIPTION
array_distinct, array_intersect, array_except, and array_overlap functions are
implemented only for primitive types, but their signatures declare support for
all types. This causes the Fuzzer to generate expressions where array_xxx
functions applied to arrays of complex types.