### PR TITLE
Fix constant expression generation for UNKNOWN type

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -469,10 +469,6 @@ core::TypedExprPtr ExpressionFuzzer::generateArgConstant(const TypePtr& arg) {
     return std::make_shared<core::ConstantTypedExpr>(
         arg, variant::null(arg->kind()));
   }
-  if (arg->isPrimitiveType()) {
-    return std::make_shared<core::ConstantTypedExpr>(
-        vectorFuzzer_.randVariant(arg));
-  }
   return std::make_shared<core::ConstantTypedExpr>(
       vectorFuzzer_.fuzzConstant(arg, 1));
 }

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -214,8 +214,6 @@ class VectorFuzzer {
   // elements.
   RowVectorPtr fuzzInputRow(const RowTypePtr& rowType);
 
-  variant randVariant(const TypePtr& arg);
-
   // Generates a random type, including maps, vectors, and arrays. maxDepth
   // limits the maximum level of nesting for complex types. maxDepth <= 1 means
   // no complex types are allowed.
@@ -273,6 +271,8 @@ class VectorFuzzer {
       size_t mapSize,
       BufferPtr& offsets,
       BufferPtr& sizes);
+
+  variant randVariant(const TypePtr& arg);
 
   VectorFuzzer::Options opts_;
 


### PR DESCRIPTION
Make VectorFuzzer::randVariant method private and replace usage in
ExpressionFuzzer with VectorFuzzer::fuzzConstant. 

Note that randVariant doesn't support UNKNOWN type:

```
VectorFuzzer::fuzzConstant

    if (type->isUnKnown()) {
      return BaseVector::createNullConstant(type, size, pool_);
    } else {
      return BaseVector::createConstant(randVariant(type), size, pool_);
    }
```