### PR TITLE
Add pybind support 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ option(VELOX_ENABLE_HDFS "Build Hdfs Connector" OFF)
 option(VELOX_ENABLE_PARQUET "Enable Parquet support" OFF)
 option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
 option(VELOX_BUILD_TEST_UTILS "Enable Velox test utilities" OFF)
+option(VELOX_BUILD_PYTHON_PACKAGE "Enable Velox Python bindings" OFF)
 
 if(${VELOX_BUILD_MINIMAL})
   # Enable and disable components for velox base build
@@ -288,6 +289,12 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   find_package(ICU REQUIRED)
   include_directories(${ICU_INCLUDE_DIRS})
   link_directories("${ICU_INCLUDE_DIRS}/../lib")
+endif()
+
+if(VELOX_BUILD_PYTHON_PACKAGE)
+  message(STATUS "Adding pybind11")
+  set(pybind11_SOURCE AUTO)
+  resolve_dependency(pybind11 REQUIRED_VERSION 2.10.0)
 endif()
 
 # Locate or build folly.

--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -156,17 +156,29 @@ if(DEFINED ENV{VELOX_PYBIND11_URL})
   set(PYBIND11_SOURCE_URL "$ENV{VELOX_PYBIND11_URL}")
 else()
   set(VELOX_PYBIND11_BUILD_VERSION 2.10.0)
-  string(
-          CONCAT
-          PROTOBUF_SOURCE_URL
-          "https://github.com/pybind/pybind11/archive/refs/tags/"
-          "v${VELOX_PROTOBUF_BUILD_VERSION}.tar.gz"
-  )
+  string(CONCAT PYBIND11_SOURCE_URL
+                "https://github.com/pybind/pybind11/archive/refs/tags/"
+                "v${VELOX_PYBIND11_BUILD_VERSION}.tar.gz")
   set(VELOX_PYBIND11_BUILD_SHA256_CHECKSUM
-          6c5e1b0788afba4569aeebb2cfe205cb154aa01deacaba0cd26442f3b761a836)
+      eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec)
 endif()
 
+macro(build_pybind11)
+  message(STATUS "Building Pybind11 from source")
 
+  FetchContent_Declare(
+    pybind11
+    URL ${PYBIND11_SOURCE_URL}
+    URL_HASH SHA256=${VELOX_PYBIND11_BUILD_SHA256_CHECKSUM})
+
+  if(NOT pybind11_POPULATED)
+
+    # Fetch the content using previously declared details
+    FetchContent_Populate(pybind11)
+
+    add_subdirectory(${pybind11_SOURCE_DIR})
+  endif()
+endmacro()
 
 # ================================ END PYBIND11 ================================
 
@@ -175,6 +187,8 @@ macro(build_dependency DEPENDENCY_NAME)
     build_folly()
   elseif("${DEPENDENCY_NAME}" STREQUAL "Protobuf")
     build_protobuf()
+  elseif("${DEPENDENCY_NAME}" STREQUAL "pybind11")
+    build_pybind11()
   else()
     message(
       FATAL_ERROR "Unknown thirdparty dependency to build: ${DEPENDENCY_NAME}")

--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -151,6 +151,25 @@ macro(build_protobuf)
 endmacro()
 # ================================ END PROTOBUF ================================
 
+# ================================== PYBIND11 ==================================
+if(DEFINED ENV{VELOX_PYBIND11_URL})
+  set(PYBIND11_SOURCE_URL "$ENV{VELOX_PYBIND11_URL}")
+else()
+  set(VELOX_PYBIND11_BUILD_VERSION 2.10.0)
+  string(
+          CONCAT
+          PROTOBUF_SOURCE_URL
+          "https://github.com/pybind/pybind11/archive/refs/tags/"
+          "v${VELOX_PROTOBUF_BUILD_VERSION}.tar.gz"
+  )
+  set(VELOX_PYBIND11_BUILD_SHA256_CHECKSUM
+          6c5e1b0788afba4569aeebb2cfe205cb154aa01deacaba0cd26442f3b761a836)
+endif()
+
+
+
+# ================================ END PYBIND11 ================================
+
 macro(build_dependency DEPENDENCY_NAME)
   if("${DEPENDENCY_NAME}" STREQUAL "folly")
     build_folly()


### PR DESCRIPTION
Pybind11 support is required for velox python bindings. This initial PR adds support for getting pybind. Subsequent PRs will use pybind11 and setup the bindings. 
Note: The expectation is that most of the times the python package will not be built and hence its not required to add pybind as a submodule. 