### PR TITLE
Mitigate POISONED by IO_THROTTLED: WSE_SERVICE_OUT_OF_RESOURCE

### DIFF
--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -188,9 +188,10 @@ Config::Entry<uint64_t> Config::MAX_DICTIONARY_SIZE(
     "hive.exec.orc.max.dictionary.size",
     80L * 1024L * 1024L);
 
+// Decreased from 256MB to 72MB until we fix T136142244
 Config::Entry<uint64_t> Config::STRIPE_SIZE(
     "hive.exec.orc.stripe.size",
-    256L * 1024L * 1024L);
+    72L * 1024L * 1024L);
 
 Config::Entry<bool> Config::FORCE_LOW_MEMORY_MODE(
     "hive.exec.orc.low.memory",


### PR DESCRIPTION
Summary:
For some reason, being investigated in T136142244, our max stripe size ends up being up to 3x the value set in this property, causing service out of resource.

Let's set it to 256MB/3=85MB -> ~72MB (an ideal size for writing to WS) while we fix this to mitigate the problem for everybody.

Differential Revision: D40857332

