### PR TITLE
Fix "Output buffers for task not found" in PartitionedOutputBufferManager

### DIFF
--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -532,8 +532,8 @@ void PartitionedOutputBufferManager::deleteResults(
         }
         return it->second;
       });
-  if (buffer && buffer->deleteResults(destination)) {
-    buffers_.withLock([&](auto& buffers) { buffers.erase(taskId); });
+  if (buffer) {
+    buffer->deleteResults(destination);
   }
 }
 

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -380,7 +380,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
     ASSERT_TRUE(waitForTaskCompletion(leafTask.get())) << leafTask->taskId();
   }
 
-  // Test asynchronously deleting task buffer (due to abort from downstream)
+  // Test asynchronously deleting task buffer (due to abort from downstream).
   {
     auto leafTaskId = makeTaskId("leaf", 0);
     auto leafPlan = PlanBuilder()
@@ -390,7 +390,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
     Task::start(leafTask, 4);
     auto bufferMgr = PartitionedOutputBufferManager::getInstance().lock();
-    // Deletes the results asynchronously to simulate abort from downstream
+    // Delete the results asynchronously to simulate abort from downstream.
     bufferMgr->deleteResults(leafTaskId, 0);
 
     ASSERT_TRUE(waitForTaskCompletion(leafTask.get())) << leafTask->taskId();

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/dwio/common/DataSink.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Exchange.h"
+#include "velox/exec/PartitionedOutputBufferManager.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -375,6 +376,22 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
     auto op = PlanBuilder().exchange(intermediatePlan->outputType()).planNode();
 
     assertQuery(op, intermediateTaskIds, "SELECT c3, c0, c2 FROM tmp");
+
+    ASSERT_TRUE(waitForTaskCompletion(leafTask.get())) << leafTask->taskId();
+  }
+
+  // Test asynchronously deleting task buffer (due to abort from downstream)
+  {
+    auto leafTaskId = makeTaskId("leaf", 0);
+    auto leafPlan = PlanBuilder()
+                        .values(vectors_)
+                        .partitionedOutput({}, 1, {"c0", "c1"})
+                        .planNode();
+    auto leafTask = makeTask(leafTaskId, leafPlan, 0);
+    Task::start(leafTask, 4);
+    auto bufferMgr = PartitionedOutputBufferManager::getInstance().lock();
+    // Deletes the results asynchronously to simulate abort from downstream
+    bufferMgr->deleteResults(leafTaskId, 0);
 
     ASSERT_TRUE(waitForTaskCompletion(leafTask.get())) << leafTask->taskId();
   }

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -290,7 +290,7 @@ TEST_F(PartitionedOutputBufferManagerTest, basic) {
   EXPECT_TRUE(task->isRunning());
   deleteResults(taskId, 3);
   fetchEndMarker(taskId, 4, 2);
-
+  bufferManager_->removeTask(taskId);
   EXPECT_TRUE(task->isFinished());
 }
 
@@ -323,6 +323,7 @@ TEST_F(PartitionedOutputBufferManagerTest, maxBytes) {
   for (int destination = 2; destination < 5; destination++) {
     fetchEndMarker(taskId, destination, 0);
   }
+  bufferManager_->removeTask(taskId);
 }
 
 TEST_F(PartitionedOutputBufferManagerTest, outOfOrderAcks) {


### PR DESCRIPTION
This is the case where the downstream prematurely aborts and calls abortTask of
the upstream. The abortTask delete the task asynchronously from the buffers.
This causes and exception due to VELOX_CHECK in the following call tree
(because the buffers does not have the entry for the taskId any more)

Driver.runInternal
  -> PartitionOutput.getOutput()
  -> Destination.flush() (if (blockedDestination) {} path)
  -> PartitionedOutputBufferManager.enqueue()
  -> PartitionedOutputBufferManager.getBuffer()  <- Exception here

In the case I've seen, the abort would happen between the flush() and getBuffer()

The fix is to delete the code that deletes the buffer for the task. The buffer
for the task will be removed in Task::terminate() as part of the normal Task
lifecycle.

Fixes #3009