### PR TITLE
Use fixed spill file size limit in query config

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -147,15 +147,15 @@ class QueryConfig {
   /// partition bits (see kSpillPartitionBits) at the end. The max spill level
   /// is used in production to prevent some bad user queries from using too much
   /// io and cpu resources.
-  static constexpr const char* kMaxSpillLevel = "max_spill_level";
+  static constexpr const char* kMaxSpillLevel = "max-spill-level";
+
+  /// The max allowed spill file size. If it is zero, then there is no limit.
+  static constexpr const char* kMaxSpillFileSize = "max-spill-file-size";
 
   static constexpr const char* kSpillStartPartitionBit =
       "spiller-start-partition-bit";
 
   static constexpr const char* kSpillPartitionBits = "spiller-partition-bits";
-
-  static constexpr const char* kSpillFileSizeFactor =
-      "spiller-file-size-factor";
 
   static constexpr const char* kSpillableReservationGrowthPct =
       "spillable-reservation-growth-pct";
@@ -322,13 +322,9 @@ class QueryConfig {
     return std::min(kMaxBits, get<int32_t>(kSpillPartitionBits, kDefaultBits));
   }
 
-  /// Returns the factor used to determine the target spill file size based on
-  /// the spilling operator's memory usage. For instance, if the spilling
-  /// operator has used 1GB memory and this factor is 0.5, then the target spill
-  /// file size will be set to 512MB.
-  double spillFileSizeFactor() const {
-    constexpr double kDefaultFactor = 0.25;
-    return get<double>(kSpillFileSizeFactor, kDefaultFactor);
+  uint64_t maxSpillFileSize() const {
+    constexpr uint64_t kDefaultMaxFileSize = 0;
+    return get<double>(kMaxSpillFileSize, kDefaultMaxFileSize);
   }
 
   /// Returns the spillable memory reservation growth percentage of the previous

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -39,7 +39,8 @@ class GroupingSet {
       bool isPartial,
       bool isRawInput,
       const Spiller::Config* FOLLY_NULLABLE spillConfig,
-      OperatorCtx* FOLLY_NONNULL operatorCtx);
+      OperatorCtx* FOLLY_NONNULL operatorCtx,
+      OperatorStats& stats);
 
   ~GroupingSet();
 
@@ -251,6 +252,8 @@ class GroupingSet {
   size_t nonSpilledIndex_ = 0;
   // Pool of the OperatorCtx. Used for spilling.
   memory::MemoryPool& pool_;
+
+  OperatorStats& stats_;
 
   // The RowContainer of 'table_' is moved here before freeing
   // 'table_' when starting to read spill output.

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -160,7 +160,8 @@ HashAggregation::HashAggregation(
       isPartialOutput_,
       isRawInput(aggregationNode->step()),
       spillConfig_.has_value() ? &spillConfig_.value() : nullptr,
-      operatorCtx_.get());
+      operatorCtx_.get(),
+      stats_);
 }
 
 void HashAggregation::addInput(RowVectorPtr input) {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -198,13 +198,9 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
       keyChannels_.size(),
       std::vector<CompareFlags>(),
       spillConfig.filePath,
-      operatorCtx_->task()
-              ->queryCtx()
-              ->pool()
-              ->getMemoryUsageTracker()
-              ->maxTotalBytes() *
-          spillConfig.fileSizeFactor,
+      spillConfig.maxFileSize,
       Spiller::spillPool(),
+      stats().runtimeStats,
       spillConfig.executor);
 
   const int32_t numPartitions = spiller_->hashBits().numPartitions();

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -259,13 +259,9 @@ void HashProbe::maybeSetupSpillInput(
           spillInputPartitionIds_.begin()->partitionBitOffset() +
               spillConfig.hashBitRange.numBits()),
       spillConfig.filePath,
-      operatorCtx_->task()
-              ->queryCtx()
-              ->pool()
-              ->getMemoryUsageTracker()
-              ->maxTotalBytes() *
-          spillConfig.fileSizeFactor,
+      spillConfig.maxFileSize,
       Spiller::spillPool(),
+      stats().runtimeStats,
       spillConfig.executor);
   // Set the spill partitions to the corresponding ones at the build side. The
   // hash probe operator itself won't trigger any spilling.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -126,7 +126,7 @@ std::optional<Spiller::Config> OperatorCtx::makeSpillConfig(
           taskId(),
           driverCtx()->driverId,
           operatorId_),
-      queryConfig.spillFileSizeFactor(),
+      queryConfig.maxSpillFileSize(),
       driverCtx_->task->queryCtx()->spillExecutor(),
       queryConfig.spillableReservationGrowthPct(),
       HashBitRange(
@@ -365,6 +365,12 @@ std::vector<column_index_t> calculateOutputChannels(
     outputChannels.clear();
   }
   return outputChannels;
+}
+
+void OperatorStats::addRuntimeStat(
+    const std::string& name,
+    const RuntimeCounter& value) {
+  addOperatorRuntimeStats(name, value, runtimeStats);
 }
 
 void OperatorStats::add(const OperatorStats& other) {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -150,15 +150,7 @@ struct OperatorStats {
         planNodeId(std::move(_planNodeId)),
         operatorType(std::move(_operatorType)) {}
 
-  void addRuntimeStat(const std::string& name, const RuntimeCounter& value) {
-    if (UNLIKELY(runtimeStats.count(name) == 0)) {
-      runtimeStats.insert(std::pair(name, RuntimeMetric(value.unit)));
-    } else {
-      VELOX_CHECK_EQ(runtimeStats.at(name).unit, value.unit);
-    }
-    runtimeStats.at(name).addValue(value.value);
-  }
-
+  void addRuntimeStat(const std::string& name, const RuntimeCounter& value);
   void add(const OperatorStats& other);
   void clear();
 };

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -343,4 +343,17 @@ std::string makeOperatorSpillPath(
   VELOX_CHECK(!spillPath.empty());
   return fmt::format("{}/{}_{}_{}", spillPath, taskId, driverId, operatorId);
 }
+
+void addOperatorRuntimeStats(
+    const std::string& name,
+    const RuntimeCounter& value,
+    std::unordered_map<std::string, RuntimeMetric>& stats) {
+  if (UNLIKELY(stats.count(name) == 0)) {
+    stats.insert(std::pair(name, RuntimeMetric(value.unit)));
+  } else {
+    VELOX_CHECK_EQ(stats.at(name).unit, value.unit);
+  }
+  stats.at(name).addValue(value.value);
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -115,4 +115,10 @@ std::string makeOperatorSpillPath(
     const std::string& taskId,
     int driverId,
     int32_t operatorId);
+
+/// Add a named runtime metric to operator 'stats'.
+void addOperatorRuntimeStats(
+    const std::string& name,
+    const RuntimeCounter& value,
+    std::unordered_map<std::string, RuntimeMetric>& stats);
 } // namespace facebook::velox::exec

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -207,8 +207,6 @@ void OrderBy::spill(int64_t targetRows, int64_t targetBytes) {
   if (spiller_ == nullptr) {
     VELOX_DCHECK(mappedMemory_->tracker() != nullptr);
     const auto& spillConfig = spillConfig_.value();
-    const auto spillFileSize = mappedMemory_->tracker()->getCurrentUserBytes() *
-        spillConfig.fileSizeFactor;
     spiller_ = std::make_unique<Spiller>(
         Spiller::Type::kOrderBy,
         data_.get(),
@@ -217,8 +215,9 @@ void OrderBy::spill(int64_t targetRows, int64_t targetBytes) {
         data_->keyTypes().size(),
         keyCompareFlags_,
         spillConfig.filePath,
-        spillFileSize,
+        spillConfig.maxFileSize,
         Spiller::spillPool(),
+        stats().runtimeStats,
         spillConfig.executor);
     VELOX_CHECK_EQ(spiller_->state().maxPartitions(), 1);
   }

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -254,3 +254,27 @@ TEST_F(OperatorUtilsTest, wrap) {
     ASSERT_EQ(wrapVector->size(), 0);
   }
 }
+
+TEST_F(OperatorUtilsTest, addOperatorRuntimeStats) {
+  std::unordered_map<std::string, RuntimeMetric> stats;
+  const std::string statsName("stats");
+  const RuntimeCounter minStatsValue(100, RuntimeCounter::Unit::kBytes);
+  const RuntimeCounter maxStatsValue(200, RuntimeCounter::Unit::kBytes);
+  addOperatorRuntimeStats(statsName, minStatsValue, stats);
+  ASSERT_EQ(stats[statsName].count, 1);
+  ASSERT_EQ(stats[statsName].sum, 100);
+  ASSERT_EQ(stats[statsName].max, 100);
+  ASSERT_EQ(stats[statsName].min, 100);
+
+  addOperatorRuntimeStats(statsName, maxStatsValue, stats);
+  ASSERT_EQ(stats[statsName].count, 2);
+  ASSERT_EQ(stats[statsName].sum, 300);
+  ASSERT_EQ(stats[statsName].max, 200);
+  ASSERT_EQ(stats[statsName].min, 100);
+
+  addOperatorRuntimeStats(statsName, maxStatsValue, stats);
+  ASSERT_EQ(stats[statsName].count, 3);
+  ASSERT_EQ(stats[statsName].sum, 500);
+  ASSERT_EQ(stats[statsName].max, 200);
+  ASSERT_EQ(stats[statsName].min, 100);
+}

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -322,6 +322,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
 
   void
   setupSpiller(int64_t targetFileSize, bool makeError, bool ascending = true) {
+    stats_.clear();
     if (type_ == Spiller::Type::kHashJoinProbe) {
       // kHashJoinProbe doesn't have associated row container.
       spiller_ = std::make_unique<Spiller>(
@@ -331,6 +332,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
           makeError ? "/bad/path" : tempDirPath_->path,
           targetFileSize,
           *pool_,
+          stats_,
           executor());
     } else if (type_ == Spiller::Type::kOrderBy) {
       // We spill 'data' in one partition in type of kOrderBy, otherwise in 4
@@ -345,6 +347,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
           makeError ? "/bad/path" : tempDirPath_->path,
           targetFileSize,
           *pool_,
+          stats_,
           executor());
     } else {
       spiller_ = std::make_unique<Spiller>(
@@ -358,6 +361,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
           makeError ? "/bad/path" : tempDirPath_->path,
           targetFileSize,
           *pool_,
+          stats_,
           executor());
     }
     if (type_ == Spiller::Type::kOrderBy) {
@@ -701,15 +705,16 @@ class SpillerTest : public exec::test::RowContainerTestBase {
 
   const TestParam param_;
   const Spiller::Type type_;
-  const int executorPoolSize_;
+  const int32_t executorPoolSize_;
   const HashBitRange hashBits_;
-  const int numPartitions_;
+  const int32_t numPartitions_;
+  std::unordered_map<std::string, RuntimeMetric> stats_;
   folly::Random::DefaultGenerator rng_;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
   std::shared_ptr<TempDirectoryPath> tempDirPath_;
   std::shared_ptr<FileSystem> fs_;
   RowTypePtr rowType_;
-  int numKeys_;
+  int32_t numKeys_;
   std::vector<column_index_t> keyChannels_;
   std::vector<uint32_t> spillPartitions_;
   std::vector<BufferPtr> spillIndicesBuffers_;


### PR DESCRIPTION
Add a query config to put a size limit on spill file size
and remove the old file size factor query config.
Also pass operator's runtime stats into Spiller object
to help record the spilling's internal execution stats.