### PR TITLE
Add ConstantExpr::toSql support for TIMESTAMP and INTERVAL DAY TO SECOND 

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -130,6 +130,8 @@ TypePtr toVeloxType(LogicalType type) {
       return DATE();
     case LogicalTypeId::TIMESTAMP:
       return TIMESTAMP();
+    case LogicalTypeId::INTERVAL:
+      return INTERVAL_DAY_TIME();
     case LogicalTypeId::BLOB:
       return VARBINARY();
     case LogicalTypeId::LIST: {

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -207,6 +207,28 @@ TEST(DuckParserTest, between) {
       parseExpr("c0 between 0 and 1 and c0 > 10")->toString());
 }
 
+TEST(DuckParserTest, interval) {
+  EXPECT_EQ("\"0 05:00:00.000\"", parseExpr("INTERVAL 5 HOURS")->toString());
+  EXPECT_EQ("\"0 00:36:00.000\"", parseExpr("INTERVAL 36 MINUTES")->toString());
+  EXPECT_EQ("\"0 00:00:07.000\"", parseExpr("INTERVAL 7 SECONDS")->toString());
+  EXPECT_EQ(
+      "\"0 00:00:00.123\"", parseExpr("INTERVAL 123 MILLISECONDS")->toString());
+
+  EXPECT_EQ(
+      "\"0 00:00:12.345\"",
+      parseExpr("INTERVAL 12345 MILLISECONDS")->toString());
+  EXPECT_EQ(
+      "\"0 03:25:45.678\"",
+      parseExpr("INTERVAL 12345678 MILLISECONDS")->toString());
+  EXPECT_EQ(
+      "\"1 03:48:20.100\"",
+      parseExpr("INTERVAL 100100100 MILLISECONDS")->toString());
+
+  EXPECT_EQ(
+      "\"0 00:00:00.011\" AS x",
+      parseExpr("INTERVAL 11 MILLISECONDS AS x")->toString());
+}
+
 TEST(DuckParserTest, cast) {
   EXPECT_EQ(
       "cast(\"1\", BIGINT)", parseExpr("cast('1' as bigint)")->toString());
@@ -235,6 +257,10 @@ TEST(DuckParserTest, cast) {
   EXPECT_EQ(
       "cast(\"str_col\", DATE)",
       parseExpr("cast(str_col as date)")->toString());
+
+  EXPECT_EQ(
+      "cast(\"str_col\", INTERVAL DAY TO SECOND)",
+      parseExpr("cast(str_col as interval day to second)")->toString());
 
   // Unsupported casts for now.
   EXPECT_THROW(parseExpr("cast('2020-01-01' as TIME)"), std::runtime_error);

--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -161,11 +161,17 @@ void appendSqlLiteral(
     case TypeKind::INTEGER:
     case TypeKind::BIGINT:
     case TypeKind::DATE:
+    case TypeKind::TIMESTAMP:
     case TypeKind::REAL:
     case TypeKind::DOUBLE:
       out << "'" << vector.wrappedVector()->toString(vector.wrappedIndex(row))
           << "'::" << vector.type()->toString();
       break;
+    case TypeKind::INTERVAL_DAY_TIME: {
+      auto interval = vector.as<SimpleVector<IntervalDayTime>>()->valueAt(row);
+      out << "INTERVAL " << interval.milliseconds() << " MILLISECONDS";
+      break;
+    }
     case TypeKind::VARCHAR:
       appendSqlString(
           vector.wrappedVector()->toString(vector.wrappedIndex(row)), out);

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -32,6 +32,7 @@
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
+#include "velox/type/IntervalDayTime.h"
 #include "velox/vector/VectorSaver.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -2338,6 +2339,16 @@ TEST_F(ExprTest, constantToSql) {
 
   ASSERT_EQ(toSql(Date(18'506)), "'2020-09-01'::DATE");
   ASSERT_EQ(toSql(variant::null(TypeKind::DATE)), "NULL::DATE");
+
+  ASSERT_EQ(
+      toSql(Timestamp(123'456, 123'000)),
+      "'1970-01-02T10:17:36.000123000'::TIMESTAMP");
+  ASSERT_EQ(toSql(variant::null(TypeKind::TIMESTAMP)), "NULL::TIMESTAMP");
+
+  ASSERT_EQ(toSql(IntervalDayTime(123'456)), "INTERVAL 123456 MILLISECONDS");
+  ASSERT_EQ(
+      toSql(variant::null(TypeKind::INTERVAL_DAY_TIME)),
+      "NULL::INTERVAL DAY TO SECOND");
 
   ASSERT_EQ(toSql(1.5f), "'1.5'::REAL");
   ASSERT_EQ(toSql(variant::null(TypeKind::REAL)), "NULL::REAL");


### PR DESCRIPTION
This allows to generate SQL for expressions that use TIMESTAMP and INTERVAL DAY TO SECOND constants.

Fixes #2993