### PR TITLE
Fix all nulls in an IN list

### DIFF
--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -132,6 +132,12 @@ class InPredicateTest : public FunctionBaseTest {
     rowVector = makeRowVector({dict});
     result = evaluate<SimpleVector<bool>>("c0 IN (2, 5, 9)", rowVector);
     assertEqualVectors(expected, result);
+
+    // an in list with nulls only is always null.
+    result = evaluate<SimpleVector<bool>>("c0 IN (null)", rowVector);
+    auto expectedConstant =
+        BaseVector::createNullConstant(BOOLEAN(), size, pool_.get());
+    assertEqualVectors(expectedConstant, result);
   }
 
   template <typename T>


### PR DESCRIPTION
An in list in Presto may consist of a single null. If this is the case the predicate is always null for any input. A in list with nulls only is OK, a values list with no elements is an error.

Adds a signature with unknown type for the case of an all null in list.