### PR TITLE
Use images from ghcr for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,17 +150,17 @@ commands:
 executors:
   build:
     docker:
-      - image : prestocpp/velox-avx-circleci:kpai-20221017
+      - image : ghcr.io/facebookincubator/velox-dev:circleci-avx
     resource_class: 2xlarge
     environment:
         CC:  /opt/rh/gcc-toolset-9/root/bin/gcc
         CXX: /opt/rh/gcc-toolset-9/root/bin/g++
   check:
     docker:
-      - image : prestocpp/velox-check:mikesh-20210609
+      - image : ghcr.io/facebookincubator/velox-dev:check-avx
   doc-gen:
     docker:
-      - image : prestocpp/velox-circleci:sagarm-20220131
+      - image : ghcr.io/facebookincubator/velox-dev:circleci-avx
 
 jobs:
   macos-build:


### PR DESCRIPTION
This PR uses the docker images from #2608 for the ci. Any changes to the images can simply be done via PR without access to docker hub credentials. 

Note: It is possible that the images get updated (e.g. a system dependency removed because it was converted to fetchContent) during long running PRs and potential cause CI errors. Integrating the changes via merge/rebase will solve those issues. 