### PR TITLE
Add regex to check image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ executors:
         CXX: /opt/rh/gcc-toolset-9/root/bin/g++
   check:
     docker:
-      - image : prestocpp/velox-check:mikesh-20210609
+      - image : ghcr.io/assignuser/velox-dev:check-avx
   doc-gen:
     docker:
       - image : prestocpp/velox-circleci:sagarm-20220131

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ executors:
         CXX: /opt/rh/gcc-toolset-9/root/bin/g++
   check:
     docker:
-      - image : ghcr.io/assignuser/velox-dev:check-avx
+      - image : prestocpp/velox-check:mikesh-20210609
   doc-gen:
     docker:
       - image : prestocpp/velox-circleci:sagarm-20220131

--- a/scripts/setup-check.sh
+++ b/scripts/setup-check.sh
@@ -19,7 +19,7 @@ set -x
 export DEBIAN_FRONTEND=noninteractive
 apt update
 apt install --no-install-recommends -y clang-format-12 python3-pip git make ssh
-pip3 install cmake_format black
+pip3 install cmake_format black regex
 pip3 cache purge
 apt purge --auto-remove -y python3-pip
 update-alternatives --install /usr/bin/clang-format clang-format "$(command -v clang-format-12)" 12


### PR DESCRIPTION
The check image was missing `regex` and erroring on circleci: https://app.circleci.com/pipelines/github/facebookincubator/velox/15735/workflows/7c469b6a-ae4d-4aa9-931b-0daa5ff72377/jobs/96490

I split this off from #3052 to avoid broken images at any time.