### PR TITLE
Fix signed integer overflow in Timestamp::toMillis()

### DIFF
--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -2394,6 +2394,11 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
   // Check null behaviors
   EXPECT_EQ(std::nullopt, dateFormatOnce(std::nullopt, "%Y"));
 
+  // Check handling of arithmatic overflow.
+  EXPECT_THROW(
+      dateFormatOnce(Timestamp(9223372036854776, 100), "%Y-%m-%d"),
+      VeloxUserError);
+
   // Normal cases
   EXPECT_EQ(
       "1970-01-01", dateFormat(fromTimestampString("1970-01-01"), "%Y-%m-%d"));

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -15,13 +15,14 @@
  */
 #pragma once
 
-#include "velox/type/StringView.h"
-
 #include <iomanip>
 #include <sstream>
 #include <string>
 
 #include <folly/dynamic.h>
+
+#include "velox/common/base/CheckedArithmetic.h"
+#include "velox/type/StringView.h"
 
 namespace date {
 class time_zone;
@@ -49,7 +50,9 @@ struct Timestamp {
   }
 
   int64_t toMillis() const {
-    return seconds_ * 1'000 + nanos_ / 1'000'000;
+    // The addition cannot overflow because the product will be promoted to
+    // uint64_t first and its value is at most UINT64_MAX / 2.
+    return checkedMultiply(seconds_, (int64_t)1'000) + nanos_ / 1'000'000;
   }
 
   int64_t toMicros() const {


### PR DESCRIPTION
Summary: Fuzzer found a bug in Timestamp::toMillis() when Timestamp::seconds_ * 1000 exceeds the maximum of int64_t (https://github.com/facebookincubator/velox/issues/3038). This diff fix this bug.

Differential Revision: D40878945

