### PR TITLE
Make Fuzzer consistent across platforms

### DIFF
--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -101,8 +101,8 @@ class SimpleArithmeticBenchmark
     inputType_ = ROW({
         {"a", DOUBLE()},
         {"b", DOUBLE()},
-        {"c", BIGINT()},
-        {"d", BIGINT()},
+        {"c", INTEGER()},
+        {"d", INTEGER()},
         {"constant", DOUBLE()},
         {"half_null", DOUBLE()},
     });
@@ -122,8 +122,8 @@ class SimpleArithmeticBenchmark
     std::vector<VectorPtr> children;
     children.emplace_back(fuzzer.fuzzFlat(DOUBLE())); // A
     children.emplace_back(fuzzer.fuzzFlat(DOUBLE())); // B
-    children.emplace_back(fuzzer.fuzzFlat(BIGINT())); // C
-    children.emplace_back(fuzzer.fuzzFlat(BIGINT())); // D
+    children.emplace_back(fuzzer.fuzzFlat(INTEGER())); // C
+    children.emplace_back(fuzzer.fuzzFlat(INTEGER())); // D
     children.emplace_back(fuzzer.fuzzConstant(DOUBLE())); // Constant
 
     opts.nullRatio = 0.5; // 50%

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -2665,7 +2665,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithFilters) {
 TEST_P(MultiThreadedHashJoinTest, noSpillLevelLimit) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_)
       .numDrivers(numDrivers_)
-      .keyTypes({BIGINT()})
+      .keyTypes({INTEGER()})
       .probeVectors(1600, 5)
       .buildVectors(1500, 5)
       .referenceQuery(

--- a/velox/expression/tests/ArgumentTypeFuzzer.h
+++ b/velox/expression/tests/ArgumentTypeFuzzer.h
@@ -15,8 +15,7 @@
  */
 #pragma once
 
-#include <folly/Random.h>
-
+#include <random>
 #include "velox/expression/FunctionSignature.h"
 #include "velox/expression/SignatureBinder.h"
 #include "velox/type/Type.h"
@@ -24,16 +23,16 @@
 namespace facebook::velox::test {
 
 /// For function signatures containing type variables, try generate a list of
-/// arguments types such that the function taking these arugments returns the
+/// arguments types such that the function taking these arguments returns the
 /// given type. If there are type variables unbounded by the return type,
-/// generate a random type for them with seed_.
+/// generate a random type for them with rng_.
 class ArgumentTypeFuzzer {
  public:
   ArgumentTypeFuzzer(
       const exec::FunctionSignature& signature,
       const TypePtr& returnType,
-      std::mt19937& seed)
-      : signature_{signature}, returnType_{returnType}, seed_{seed} {}
+      std::mt19937& rng)
+      : signature_{signature}, returnType_{returnType}, rng_{rng} {}
 
   /// Generate random argument types if returnType_ can be bound to the return
   /// type of signature_. Return true if the generation succeeds, false
@@ -61,8 +60,8 @@ class ArgumentTypeFuzzer {
   /// Bindings between type variables and their actual types.
   std::unordered_map<std::string, TypePtr> bindings_;
 
-  /// Seed to generate random types for unbounded type variables when necessary.
-  std::mt19937& seed_;
+  /// RNG to generate random types for unbounded type variables when necessary.
+  std::mt19937& rng_;
 };
 
 /// Return the kind name of type in lower case. This is expected to match the

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <folly/Random.h>
+#include <boost/random/uniform_int_distribution.hpp>
 #include <folly/ScopeGuard.h>
 #include <glog/logging.h>
 #include <exception>
@@ -389,7 +389,7 @@ void ExpressionFuzzer::seed(size_t seed) {
 }
 
 void ExpressionFuzzer::reSeed() {
-  seed(folly::Random::rand32(rng_));
+  seed(rng_());
 }
 
 void ExpressionFuzzer::sortConcreteSignatures() {
@@ -474,7 +474,8 @@ core::TypedExprPtr ExpressionFuzzer::generateArgColumn(const TypePtr& arg) {
 }
 
 core::TypedExprPtr ExpressionFuzzer::generateArg(const TypePtr& arg) {
-  size_t argClass = folly::Random::rand32(4, rng_);
+  size_t argClass =
+      boost::random::uniform_int_distribution<uint32_t>(0, 3)(rng_);
 
   // Toss a coin and choose between a constant, a column reference, or another
   // expression (function).
@@ -488,7 +489,7 @@ core::TypedExprPtr ExpressionFuzzer::generateArg(const TypePtr& arg) {
     if (remainingLevelOfNesting_ > 0) {
       return generateExpression(arg);
     }
-    argClass = folly::Random::rand32(2, rng_);
+    argClass = boost::random::uniform_int_distribution<uint32_t>(0, 1)(rng_);
   }
 
   if (argClass == kArgConstant) {
@@ -503,7 +504,8 @@ std::vector<core::TypedExprPtr> ExpressionFuzzer::generateArgs(
   std::vector<core::TypedExprPtr> inputExpressions;
   auto numVarArgs = !input.variableArity
       ? 0
-      : folly::Random::rand32(FLAGS_max_num_varargs + 1, rng_);
+      : boost::random::uniform_int_distribution<uint32_t>(
+            0, FLAGS_max_num_varargs)(rng_);
   inputExpressions.reserve(input.args.size() + numVarArgs);
 
   for (const auto& arg : input.args) {
@@ -562,7 +564,8 @@ core::TypedExprPtr ExpressionFuzzer::generateExpression(
   auto secondAttempt =
       &ExpressionFuzzer::generateExpressionFromSignatureTemplate;
 
-  size_t useSignatureTemplate = folly::Random::rand32(2, rng_);
+  size_t useSignatureTemplate =
+      boost::random::uniform_int_distribution<uint32_t>(0, 1)(rng_);
   if (FLAGS_velox_fuzzer_enable_complex_types && useSignatureTemplate) {
     std::swap(firstAttempt, secondAttempt);
   }
@@ -613,7 +616,8 @@ core::TypedExprPtr ExpressionFuzzer::generateExpressionFromConcreteSignatures(
   }
 
   // Randomly pick a function that can return `returnType`.
-  size_t idx = folly::Random::rand32(eligible.size(), rng_);
+  size_t idx = boost::random::uniform_int_distribution<uint32_t>(
+      0, eligible.size() - 1)(rng_);
   const auto& chosen = eligible[idx];
 
   return getCallExprFromCallable(*chosen);
@@ -643,7 +647,8 @@ ExpressionFuzzer::chooseRandomSignatureTemplate(
     return nullptr;
   }
 
-  auto idx = folly::Random::rand32(eligible.size(), rng_);
+  auto idx = boost::random::uniform_int_distribution<uint32_t>(
+      0, eligible.size() - 1)(rng_);
   return eligible[idx];
 }
 
@@ -695,7 +700,8 @@ void ExpressionFuzzer::go() {
     VELOX_CHECK(inputRowNames_.empty());
 
     // Pick a random signature to choose the root return type.
-    size_t idx = folly::Random::rand32(signatures_.size(), rng_);
+    size_t idx = boost::random::uniform_int_distribution<uint32_t>(
+        0, signatures_.size() - 1)(rng_);
     const auto& rootType = signatures_[idx].returnType;
 
     // Generate expression tree and input data vectors.

--- a/velox/functions/prestosql/tests/ZipWithTest.cpp
+++ b/velox/functions/prestosql/tests/ZipWithTest.cpp
@@ -322,7 +322,7 @@ TEST_F(ZipWithTest, fuzzSameSizeNoNulls) {
   options.vectorSize = 1024;
 
   auto rowType =
-      ROW({"c0", "c1", "c2"}, {ARRAY(BIGINT()), ARRAY(INTEGER()), SMALLINT()});
+      ROW({"c0", "c1", "c2"}, {ARRAY(INTEGER()), ARRAY(INTEGER()), SMALLINT()});
 
   VectorFuzzer fuzzer(options, pool());
   for (auto i = 0; i < 10; ++i) {
@@ -331,19 +331,22 @@ TEST_F(ZipWithTest, fuzzSameSizeNoNulls) {
     auto data = fuzzer.fuzzInputRow(rowType);
     auto flatData = flatten<RowVector>(data);
 
-    auto result = evaluate("zip_with(c0, c1, (x, y) -> x + y)", data);
+    auto result =
+        evaluate("zip_with(c0, c1, (x, y) -> cast(x as bigint) + y)", data);
     auto expectedResult =
-        evaluate("zip_with(c0, c1, (x, y) -> x + y)", flatData);
+        evaluate("zip_with(c0, c1, (x, y) -> cast(x as bigint) + y)", flatData);
     assertEqualVectors(expectedResult, result);
 
-    result = evaluate("zip_with(c0, c1, (x, y) -> (x + y) * c2)", data);
-    expectedResult =
-        evaluate("zip_with(c0, c1, (x, y) -> (x + y) * c2)", flatData);
+    result = evaluate(
+        "zip_with(c0, c1, (x, y) -> (cast(x as bigint) + y) * c2)", data);
+    expectedResult = evaluate(
+        "zip_with(c0, c1, (x, y) -> (cast(x as bigint) + y) * c2)", flatData);
     assertEqualVectors(expectedResult, result);
 
     // Sanity Check with possible lazy inputs.
     data = fuzzer.fuzzRowChildrenToLazy(data);
-    result = evaluate("zip_with(c0, c1, (x, y) -> (x + y) * c2)", data);
+    result = evaluate(
+        "zip_with(c0, c1, (x, y) -> (cast(x as bigint) + y) * c2)", data);
     assertEqualVectors(expectedResult, result);
   }
 }
@@ -355,7 +358,7 @@ TEST_F(ZipWithTest, fuzzVariableLengthWithNulls) {
   options.nullRatio = 0.1;
 
   auto rowType =
-      ROW({"c0", "c1", "c2"}, {ARRAY(BIGINT()), ARRAY(INTEGER()), SMALLINT()});
+      ROW({"c0", "c1", "c2"}, {ARRAY(INTEGER()), ARRAY(INTEGER()), SMALLINT()});
 
   VectorFuzzer fuzzer(options, pool());
   for (auto i = 0; i < 10; ++i) {
@@ -364,19 +367,22 @@ TEST_F(ZipWithTest, fuzzVariableLengthWithNulls) {
     auto data = fuzzer.fuzzInputRow(rowType);
     auto flatData = flatten<RowVector>(data);
 
-    auto result = evaluate("zip_with(c0, c1, (x, y) -> x + y)", data);
+    auto result =
+        evaluate("zip_with(c0, c1, (x, y) -> cast(x as bigint) + y)", data);
     auto expectedResult =
-        evaluate("zip_with(c0, c1, (x, y) -> x + y)", flatData);
+        evaluate("zip_with(c0, c1, (x, y) -> cast(x as bigint) + y)", flatData);
     assertEqualVectors(expectedResult, result);
 
-    result = evaluate("zip_with(c0, c1, (x, y) -> (x + y) * c2)", data);
-    expectedResult =
-        evaluate("zip_with(c0, c1, (x, y) -> (x + y) * c2)", flatData);
+    result = evaluate(
+        "zip_with(c0, c1, (x, y) -> (cast(x as bigint) + y) * c2)", data);
+    expectedResult = evaluate(
+        "zip_with(c0, c1, (x, y) -> (cast(x as bigint) + y) * c2)", flatData);
     assertEqualVectors(expectedResult, result);
 
     // Sanity Check with possible lazy inputs.
     data = fuzzer.fuzzRowChildrenToLazy(data);
-    result = evaluate("zip_with(c0, c1, (x, y) -> (x + y) * c2)", data);
+    result = evaluate(
+        "zip_with(c0, c1, (x, y) -> (cast(x as bigint) + y) * c2)", data);
     assertEqualVectors(expectedResult, result);
   }
 }

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <folly/Random.h>
+#include <boost/random/uniform_01.hpp>
 #include <random>
 
 #include "velox/type/Type.h"
@@ -229,7 +229,7 @@ class VectorFuzzer {
 
   /// Returns true n% of times (`n` is a double between 0 and 1).
   bool coinToss(double n) {
-    return folly::Random::randDouble01(rng_) < n;
+    return boost::random::uniform_01<double>()(rng_) < n;
   }
 
   // Wraps the given vector in a LazyVector.


### PR DESCRIPTION
ExpressionFuzzer and VectorFuzzer rely on folly::Random to generate pseudo random values.  Internally, this library uses std::uniform_int_distribution which can produce inconsistent results across platforms.

Switching to the boost::random library produces consistent results across platforms.

To test this I ran the linux-fuzzer-run CI job.
E.g. https://app.circleci.com/pipelines/github/facebookincubator/velox/15778/workflows/77357685-16fa-46a3-ae89-2b02be91c31c/jobs/96837

With trunk I am unable to reproduce the same expressions given the same seeds on my local Mac.  After this change, I'm able to verify I'm seeing the same expressions, the same constants, and vectors with the same properties.