### PR TITLE
Add query mode and a flag to store the results

### DIFF
--- a/velox/expression/tests/ExpressionRunner.h
+++ b/velox/expression/tests/ExpressionRunner.h
@@ -47,7 +47,8 @@ class ExpressionRunner {
       const std::string& sql,
       const std::string& resultPath,
       const std::string& mode,
-      vector_size_t numRows);
+      vector_size_t numRows,
+      const std::string& storeResultPath);
 };
 
 } // namespace facebook::velox::test

--- a/velox/expression/tests/ExpressionRunnerTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerTest.cpp
@@ -18,6 +18,7 @@
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
 #include <gtest/gtest.h>
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/vector/VectorSaver.h"
 
@@ -57,13 +58,37 @@ DEFINE_string(
     "simplified paths.\n"
     "common: evaluate the expression using common path and print out results.\n"
     "simplified: evaluate the expression using simplified path and print out "
-    "results.");
+    "results.\n"
+    "query: evaluate SQL query specified in --sql or --sql_path and print out "
+    "results. If --input_path is specified, the query may reference it as "
+    "table 't'.");
+
+static bool validateMode(const char* flagName, const std::string& value) {
+  static const std::unordered_set<std::string> kModes = {
+      "common", "simplified", "verify", "query"};
+  if (kModes.count(value) != 1) {
+    std::cout << "Invalid value for --" << flagName << ": " << value << ". ";
+    std::cout << "Valid values are: " << folly::join(", ", kModes) << "."
+              << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+DEFINE_validator(mode, &validateMode);
 
 DEFINE_int32(
     num_rows,
     10,
     "Maximum number of rows to process. Zero means 'all rows'. Applies to "
-    "'common' and 'simplified' modes only. Ignord for 'verify' mode.");
+    "'common' and 'simplified' modes only. Ignored for 'verify' mode.");
+
+DEFINE_string(
+    store_result_path,
+    "",
+    "Directory path for storing the results of evaluating SQL expression or "
+    "query in common, simplified or query modes.");
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
@@ -72,18 +97,24 @@ int main(int argc, char** argv) {
   // experience, and initialize glog and gflags.
   folly::init(&argc, &argv);
 
-  VELOX_CHECK(
-      !FLAGS_sql.empty() || !FLAGS_sql_path.empty(),
-      "One of --sql or --sql_path flags must be set.");
+  if (FLAGS_sql.empty() && FLAGS_sql_path.empty()) {
+    std::cout << "One of --sql or --sql_path flags must be set.";
+    exit(1);
+  }
 
   auto sql = FLAGS_sql;
   if (sql.empty()) {
-    VELOX_CHECK(!FLAGS_sql_path.empty());
     sql = facebook::velox::restoreStringFromFile(FLAGS_sql_path.c_str());
     VELOX_CHECK(!sql.empty());
   }
 
   facebook::velox::functions::prestosql::registerAllScalarFunctions();
+  facebook::velox::aggregate::prestosql::registerAllAggregateFunctions();
   facebook::velox::test::ExpressionRunner::run(
-      FLAGS_input_path, sql, FLAGS_result_path, FLAGS_mode, FLAGS_num_rows);
+      FLAGS_input_path,
+      sql,
+      FLAGS_result_path,
+      FLAGS_mode,
+      FLAGS_num_rows,
+      FLAGS_store_result_path);
 }

--- a/velox/expression/tests/ExpressionRunnerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerUnitTest.cpp
@@ -56,8 +56,8 @@ TEST_F(ExpressionRunnerUnitTest, run) {
   saveVectorToFile(inputVector.get(), inputPath);
   saveVectorToFile(resultVector.get(), resultPath);
 
-  EXPECT_NO_THROW(
-      ExpressionRunner::run(inputPath, "length(c0)", resultPath, "verify", 0));
+  EXPECT_NO_THROW(ExpressionRunner::run(
+      inputPath, "length(c0)", resultPath, "verify", 0, ""));
 }
 
 } // namespace facebook::velox::test

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -194,7 +194,7 @@ TypedExprPtr toVeloxExpression(
       return std::make_shared<ConstantTypedExpr>(
           duckdb::toVeloxType(constant->return_type),
           duckdb::duckValueToVariant(
-              constant->value, false /*parseDecimalAsDouble*/));
+              constant->value, true /*parseDecimalAsDouble*/));
     }
     case ::duckdb::ExpressionType::COMPARE_EQUAL:
       return toVeloxComparisonExpression("eq", expression, inputType);


### PR DESCRIPTION
Enhance ExpressionRunner to (1) allow storing the results of expression
evaluation to a file; (2) allow running full query.

- --store_result_path <path> flag requests to save the results of expression or
query evaluation to a file in the specified directory;
- --mode query run the query specified in --sql or --sql_path flag.

Also, add validation for --mode flag.

```
velox_expression_runner_test --sql "SELECT a, a % 2 + 10 FROM UNNEST(array[1, 2, 3]) as _t(a)" --mode=query --logtostderr=1 --store_result_path=/tmp
I20221101 21:38:03.416126 3067189 ExpressionRunner.cpp:139] Registering input vector as table t: ROW<_col0:BIGINT>
Result: ROW<_p0:INTEGER,_p1:INTEGER>
1 | 11
2 | 10
3 | 11
I20221101 21:39:17.492252 3070323 ExpressionRunner.cpp:100] Saved the results in /tmp/velox_vector_oZXIJx. 3 rows: ROW<_p0:INTEGER,_p1:INTEGER>

velox_expression_runner_test --sql "SELECT _p0, _p1, _p0 + _p1 FROM t" --mode=query --logtostderr=1 --input_path=/tmp/velox_vector_oZXIJx
I20221101 21:40:15.153410 3072493 ExpressionRunner.cpp:139] Registering input vector as table t: ROW<_p0:INTEGER,_p1:INTEGER>
Result: ROW<_p:INTEGER,_p0:INTEGER,_p1:INTEGER>
1 | 11 | 12
2 | 10 | 12
3 | 11 | 14

velox_expression_runner_test --sql "SELECT _p1, count(1), avg(_p0) FROM t GROUP BY 1" --mode=query --logtostderr=1 --input_path=/tmp/velox_vector_oZXIJx
I20221101 21:41:05.347342 3074699 ExpressionRunner.cpp:139] Registering input vector as table t: ROW<_p0:INTEGER,_p1:INTEGER>
Result: ROW<_p1:INTEGER,_p2:BIGINT,_p3:DOUBLE>
11 | 2 | 2
10 | 1 | 2

```