### PR TITLE
Add min spill run size config to avoid generating small spill files

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -152,6 +152,15 @@ class QueryConfig {
   /// The max allowed spill file size. If it is zero, then there is no limit.
   static constexpr const char* kMaxSpillFileSize = "max-spill-file-size";
 
+  /// The min spill run size limit used to select partitions for spilling. The
+  /// spiller tries to spill a previously spilled partitions if its data size
+  /// exceeds this limit, otherwise it spills the partition with most data.
+  /// If the limit is zero, then the spiller always spill a previously spilled
+  /// partition if it has any data. This is to avoid spill from a partition with
+  /// a small amount of data which might result in generating too many small
+  /// spilled files.
+  static constexpr const char* kMinSpillRunSize = "min-spill-run-size";
+
   static constexpr const char* kSpillStartPartitionBit =
       "spiller-start-partition-bit";
 
@@ -324,7 +333,12 @@ class QueryConfig {
 
   uint64_t maxSpillFileSize() const {
     constexpr uint64_t kDefaultMaxFileSize = 0;
-    return get<double>(kMaxSpillFileSize, kDefaultMaxFileSize);
+    return get<uint64_t>(kMaxSpillFileSize, kDefaultMaxFileSize);
+  }
+
+  uint64_t minSpillRunSize() const {
+    constexpr uint64_t kDefaultMinSpillRunSize = 256 << 20; // 256MB.
+    return get<uint64_t>(kMinSpillRunSize, kDefaultMinSpillRunSize);
   }
 
   /// Returns the spillable memory reservation growth percentage of the previous

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -108,3 +108,17 @@ can be used to prevent a query from using too much io and cpu resources.
     * **Default value:** ``0``
 
 The maximum allowed spill file size. Zero means unlimited.
+
+``min-spill-run-size``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``integer``
+    * **Default value:** ``256MB``
+
+The minimum spill run size (bytes) limit used to select partitions for
+spilling. The spiller tries to spill a previously spilled partitions if its
+data size exceeds this limit, otherwise it spills the partition with most data.
+If the limit is zero, then the spiller always spills a previously spilled
+partition if it has any data. This is to avoid spill from a partition with a
+small amount of data which might result in generating too many small spilled
+files.

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -576,6 +576,7 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
         std::vector<CompareFlags>(),
         spillConfig_->filePath,
         spillConfig_->maxFileSize,
+        spillConfig_->minSpillRunSize,
         Spiller::spillPool(),
         stats_.runtimeStats,
         spillConfig_->executor);

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -199,6 +199,7 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
       std::vector<CompareFlags>(),
       spillConfig.filePath,
       spillConfig.maxFileSize,
+      spillConfig.minSpillRunSize,
       Spiller::spillPool(),
       stats().runtimeStats,
       spillConfig.executor);

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -260,6 +260,7 @@ void HashProbe::maybeSetupSpillInput(
               spillConfig.hashBitRange.numBits()),
       spillConfig.filePath,
       spillConfig.maxFileSize,
+      spillConfig.minSpillRunSize,
       Spiller::spillPool(),
       stats().runtimeStats,
       spillConfig.executor);

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -127,6 +127,7 @@ std::optional<Spiller::Config> OperatorCtx::makeSpillConfig(
           driverCtx()->driverId,
           operatorId_),
       queryConfig.maxSpillFileSize(),
+      queryConfig.minSpillRunSize(),
       driverCtx_->task->queryCtx()->spillExecutor(),
       queryConfig.spillableReservationGrowthPct(),
       HashBitRange(

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -216,6 +216,7 @@ void OrderBy::spill(int64_t targetRows, int64_t targetBytes) {
         keyCompareFlags_,
         spillConfig.filePath,
         spillConfig.maxFileSize,
+        spillConfig.minSpillRunSize,
         Spiller::spillPool(),
         stats().runtimeStats,
         spillConfig.executor);

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -35,7 +35,8 @@ Spiller::Spiller(
     int32_t numSortingKeys,
     const std::vector<CompareFlags>& sortCompareFlags,
     const std::string& path,
-    int64_t targetFileSize,
+    uint64_t targetFileSize,
+    uint64_t minSpillRunSize,
     memory::MemoryPool& pool,
     std::unordered_map<std::string, RuntimeMetric>& stats,
     folly::Executor* executor)
@@ -49,6 +50,7 @@ Spiller::Spiller(
           sortCompareFlags,
           path,
           targetFileSize,
+          minSpillRunSize,
           pool,
           stats,
           executor) {
@@ -60,7 +62,8 @@ Spiller::Spiller(
     RowTypePtr rowType,
     HashBitRange bits,
     const std::string& path,
-    int64_t targetFileSize,
+    uint64_t targetFileSize,
+    uint64_t minSpillRunSize,
     memory::MemoryPool& pool,
     std::unordered_map<std::string, RuntimeMetric>& stats,
     folly::Executor* FOLLY_NULLABLE executor)
@@ -74,6 +77,7 @@ Spiller::Spiller(
           {},
           path,
           targetFileSize,
+          minSpillRunSize,
           pool,
           stats,
           executor) {
@@ -89,7 +93,8 @@ Spiller::Spiller(
     int32_t numSortingKeys,
     const std::vector<CompareFlags>& sortCompareFlags,
     const std::string& path,
-    int64_t targetFileSize,
+    uint64_t targetFileSize,
+    uint64_t minSpillRunSize,
     memory::MemoryPool& pool,
     std::unordered_map<std::string, RuntimeMetric>& stats,
     folly::Executor* executor)
@@ -98,6 +103,7 @@ Spiller::Spiller(
       eraser_(eraser),
       bits_(bits),
       rowType_(std::move(rowType)),
+      minSpillRunSize_(minSpillRunSize),
       state_(
           path,
           bits.numPartitions(),
@@ -470,6 +476,18 @@ int32_t Spiller::pickNextPartitionToSpill() {
       partitionIndices.begin(),
       partitionIndices.end(),
       [&](int32_t lhs, int32_t rhs) {
+        // If one of the partition has been spilled, then select the spilled one
+        // if its number of bytes exceeds 'minSpillRunSize_' limit.
+        if (state_.isPartitionSpilled(lhs) != state_.isPartitionSpilled(rhs)) {
+          if (state_.isPartitionSpilled(lhs) &&
+              spillRuns_[lhs].numBytes > minSpillRunSize_) {
+            return true;
+          }
+          if (state_.isPartitionSpilled(rhs) &&
+              spillRuns_[rhs].numBytes > minSpillRunSize_) {
+            return false;
+          }
+        }
         return spillRuns_[lhs].numBytes > spillRuns_[rhs].numBytes;
       });
   for (auto partition : partitionIndices) {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -985,6 +985,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
             .config(QueryConfig::kSpillEnabled, "true")
             .config(QueryConfig::kAggregationSpillEnabled, "true")
             .config(QueryConfig::kSpillPath, tempDirectory->path)
+            .config(QueryConfig::kMinSpillRunSize, std::to_string(1000'000'000))
             .config(
                 QueryConfig::kSpillPartitionBits,
                 std::to_string(kPartitionsBits))

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -23,7 +23,6 @@
 #include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
-#include "velox/vector/tests/utils/VectorMaker.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;


### PR DESCRIPTION
Add query config of min spill run size limit to select partitions for spilling.
The spiller tries to spill a previously spilled partitions if its data size exceeds
this limit, otherwise it spills the partition with most data. If the limit is zero,
then the spiller always spill a previously spilled partition if it has any data.
This is to avoid spill from a partition with a small amount of data which might
result in generating too many small spilled files.
Unit test and document updated.