### PR TITLE
Document max_extended_partial_aggregation_memory config

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -16,6 +16,35 @@ this value can result in less network transfer and lower CPU utilization by
 allowing more groups to be kept locally before being flushed, at the cost of
 additional memory usage.
 
+``max_extended_partial_aggregation_memory``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``integer``
+    * **Default value:** ``16MB``
+
+Maximum amount of memory in bytes for partial aggregation results if cardinality
+reduction is below `partial_aggregation_reduction_ratio_threshold`. Every time partial
+aggregate results size reaches `max_partial_aggregation_memory` bytes, the results
+are flushed. If cardinality reduction is below `partial_aggregation_reduction_ratio_threshold`,
+i.e. `number of result rows / number of input rows > partial_aggregation_reduction_ratio_threshold`,
+memory limit for partial aggregation is automatically doubled up to
+`max_extended_partial_aggregation_memory`. This adaptation is disabled by default, since
+the value of `max_extended_partial_aggregation_memory` equals the value of
+`max_partial_aggregation_memory`. Specify higher value for `max_extended_partial_aggregation_memory`
+to enable.
+
+``partial_aggregation_reduction_ratio_threshold``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``double``
+    * **Default value:** ``0.5``
+
+Cardinality reduction threshold for partial aggregation to enable adaptive memory limit increase
+up to `max_extended_partial_aggregation_memory`. Valid values are between 0 and 1. If
+partial aggregation results reach `max_partial_aggregation_memory` limit and
+`number of result rows / number of input rows > partial_aggregation_reduction_ratio_threshold`
+the limit is automatically doubled up to `max_extended_partial_aggregation_memory`.
+
 Spilling
 --------
 

--- a/velox/docs/develop/spilling.rst
+++ b/velox/docs/develop/spilling.rst
@@ -43,7 +43,8 @@ Spill Objects
 The spilling framework consists of the following major software objects:
 
 `Spiller <https://github.com/facebookincubator/velox/blob/main/velox/exec/Spiller.h#L24>`_
-^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The Spiller object provides the spilling functions for all the operators
 and helps them manage their spilled state on disk. There is one Spiller object
 created for each operator. The Spiller object takes a row container object on
@@ -146,7 +147,8 @@ hash join spilling section.
     void Spiller::spill(uint32_t partition, const RowVectorPtr& spillVector);
 
 `SpillFileList <https://github.com/facebookincubator/velox/blob/main/velox/exec/Spill.h#L155>`_ and `SpillFile <https://github.com/facebookincubator/velox/blob/main/velox/exec/Spill.h#L58>`_
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 SpillFileList object manages spill files for a single partition. Each spill
 file is managed by one SpillFile object which provides the low level io
 operations with the storage system through Velox file system interface. On the
@@ -481,7 +483,8 @@ requires to cross join null-key probe rows with all build-side rows for filter
 evaluation to check if the null-key probe rows can be added to output or not.
 
 `HashJoinBridge <https://github.com/facebookincubator/velox/blob/main/velox/exec/HashJoinBridge.h#L28>`_
-^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The HashJoinBridge object includes the following extensions to support the
 spilling:
 


### PR DESCRIPTION
Document configuration properties used to control adaptive memory limit increase for partial aggregation.

Also, fix Sphinx warnings for spilling.rst.