### PR TITLE
Add kLeftSemiProject and kRightSemiProject join types

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -926,8 +926,10 @@ enum class JoinType {
   kLeft,
   kRight,
   kFull,
-  kLeftSemi,
-  kRightSemi,
+  kLeftSemi, // TODO Remove after updating Prestissimo.
+  kLeftSemiFilter,
+  kRightSemi, // TODO Remove after updating Prestissimo.
+  kRightSemiFilter,
   kNullAwareAnti,
   kAnti,
 };
@@ -943,9 +945,11 @@ inline const char* joinTypeName(JoinType joinType) {
     case JoinType::kFull:
       return "FULL";
     case JoinType::kLeftSemi:
-      return "LEFT SEMI";
+    case JoinType::kLeftSemiFilter:
+      return "LEFT SEMI (FILTER)";
     case JoinType::kRightSemi:
-      return "RIGHT SEMI";
+    case JoinType::kRightSemiFilter:
+      return "RIGHT SEMI (FILTER)";
     case JoinType::kNullAwareAnti:
       return "NULL-AWARE ANTI";
     case JoinType::kAnti:
@@ -970,12 +974,14 @@ inline bool isFullJoin(JoinType joinType) {
   return joinType == JoinType::kFull;
 }
 
-inline bool isLeftSemiJoin(JoinType joinType) {
-  return joinType == JoinType::kLeftSemi;
+inline bool isLeftSemiFilterJoin(JoinType joinType) {
+  return joinType == JoinType::kLeftSemiFilter ||
+      joinType == JoinType::kLeftSemi;
 }
 
-inline bool isRightSemiJoin(JoinType joinType) {
-  return joinType == JoinType::kRightSemi;
+inline bool isRightSemiFilterJoin(JoinType joinType) {
+  return joinType == JoinType::kRightSemiFilter ||
+      joinType == JoinType::kRightSemi;
 }
 
 inline bool isNullAwareAntiJoin(JoinType joinType) {
@@ -1032,12 +1038,12 @@ class AbstractJoinNode : public PlanNode {
     return joinType_ == JoinType::kFull;
   }
 
-  bool isLeftSemiJoin() const {
-    return joinType_ == JoinType::kLeftSemi;
+  bool isLeftSemiFilterJoin() const {
+    return joinType_ == JoinType::kLeftSemiFilter;
   }
 
-  bool isRightSemiJoin() const {
-    return joinType_ == JoinType::kRightSemi;
+  bool isRightSemiFilterJoin() const {
+    return joinType_ == JoinType::kRightSemiFilter;
   }
 
   bool isNullAwareAntiJoin() const {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -136,9 +136,9 @@ void HashBuild::setupTable() {
     // (Left) semi and anti join with no extra filter only needs to know whether
     // there is a match. Hence, no need to store entries with duplicate keys.
     const bool dropDuplicates = !joinNode_->filter() &&
-        (joinNode_->isLeftSemiJoin() || isAntiJoins(joinType_));
+        (joinNode_->isLeftSemiFilterJoin() || isAntiJoins(joinType_));
     // Right semi join needs to tag build rows that were probed.
-    const bool needProbedFlag = joinNode_->isRightSemiJoin();
+    const bool needProbedFlag = joinNode_->isRightSemiFilterJoin();
     if (isNullAwareAntiJoinWithFilter(joinNode_)) {
       // We need to check null key rows in build side in case of null-aware anti
       // join with filter set.

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -124,7 +124,8 @@ void HashBuild::setupTable() {
   for (int i = numKeys; i < tableType_->size(); ++i) {
     dependentTypes.emplace_back(tableType_->childAt(i));
   }
-  if (joinNode_->isRightJoin() || joinNode_->isFullJoin()) {
+  if (joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
+      joinNode_->isRightSemiProjectJoin()) {
     // Do not ignore null keys.
     table_ = HashTable<false>::createForJoin(
         std::move(keyHashers),
@@ -136,7 +137,8 @@ void HashBuild::setupTable() {
     // (Left) semi and anti join with no extra filter only needs to know whether
     // there is a match. Hence, no need to store entries with duplicate keys.
     const bool dropDuplicates = !joinNode_->filter() &&
-        (joinNode_->isLeftSemiFilterJoin() || isAntiJoins(joinType_));
+        (joinNode_->isLeftSemiFilterJoin() ||
+         joinNode_->isLeftSemiProjectJoin() || isAntiJoins(joinType_));
     // Right semi join needs to tag build rows that were probed.
     const bool needProbedFlag = joinNode_->isRightSemiFilterJoin();
     if (isNullAwareAntiJoinWithFilter(joinNode_)) {

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1539,6 +1539,15 @@ int32_t HashTable<ignoreNullKeys>::listProbedRows(
 }
 
 template <bool ignoreNullKeys>
+int32_t HashTable<ignoreNullKeys>::listAllRows(
+    RowsIterator* iter,
+    int32_t maxRows,
+    uint64_t maxBytes,
+    char** rows) {
+  return listRows<RowContainer::ProbeType::kAll>(iter, maxRows, maxBytes, rows);
+}
+
+template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::erase(folly::Range<char**> rows) {
   auto numRows = rows.size();
   raw_vector<uint64_t> hashes;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -144,6 +144,13 @@ class BaseHashTable {
       uint64_t maxBytes,
       char* FOLLY_NULLABLE* FOLLY_NULLABLE rows) = 0;
 
+  /// Returns all rows. Used by the right semi join project.
+  virtual int32_t listAllRows(
+      RowsIterator* FOLLY_NULLABLE iter,
+      int32_t maxRows,
+      uint64_t maxBytes,
+      char* FOLLY_NULLABLE* FOLLY_NULLABLE rows) = 0;
+
   virtual void prepareJoinTable(
       std::vector<std::unique_ptr<BaseHashTable>> tables,
       folly::Executor* FOLLY_NULLABLE executor = nullptr) = 0;
@@ -328,6 +335,12 @@ class HashTable : public BaseHashTable {
       char* FOLLY_NULLABLE* FOLLY_NULLABLE rows) override;
 
   int32_t listProbedRows(
+      RowsIterator* FOLLY_NULLABLE iter,
+      int32_t maxRows,
+      uint64_t maxBytes,
+      char* FOLLY_NULLABLE* FOLLY_NULLABLE rows) override;
+
+  int32_t listAllRows(
       RowsIterator* FOLLY_NULLABLE iter,
       int32_t maxRows,
       uint64_t maxBytes,

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -525,6 +525,18 @@ void RowContainer::setProbedFlag(char** rows, int32_t numRows) {
   }
 }
 
+void RowContainer::extractProbedFlags(
+    const char* FOLLY_NONNULL const* FOLLY_NONNULL rows,
+    int32_t numRows,
+    const VectorPtr& result) {
+  result->resize(numRows);
+  auto flatResult = result->as<FlatVector<bool>>();
+  auto* rawValues = flatResult->mutableRawValues<uint64_t>();
+  for (auto i = 0; i < numRows; ++i) {
+    bits::setBit(rawValues, i, bits::isBitSet(rows[i], probedFlagOffset_));
+  }
+}
+
 int64_t RowContainer::sizeIncrement(
     vector_size_t numRows,
     int64_t variableLengthBytes) const {

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -304,6 +304,13 @@ class RowContainer {
         rows, rowNumbers, columnAt(columnIndex), resultOffset, result);
   }
 
+  /// Copies the 'probed' flags for the specified rows into 'result'.
+  /// The 'result' is expected to be flat vector of type boolean.
+  void extractProbedFlags(
+      const char* FOLLY_NONNULL const* FOLLY_NONNULL rows,
+      int32_t numRows,
+      const VectorPtr& result);
+
   static inline int32_t nullByte(int32_t nullOffset) {
     return nullOffset / 8;
   }

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -29,7 +29,8 @@
 
 namespace facebook::velox::exec::test {
 
-class RowContainerTestBase : public testing::Test {
+class RowContainerTestBase : public testing::Test,
+                             public velox::test::VectorTestBase {
  protected:
   void SetUp() override {
     pool_ = memory::getDefaultScopedMemoryPool();


### PR DESCRIPTION
Semi joins are used to implement correlated IN and EXISTS subqueries.

For example, the following query can be implemented as a semi join. In this case semi
join acts as a filter. It returns a subset of the left-side rows that have a
match on the right side. This is a kLeftSemiFilter join type.

`SELECT * FROM t WHERE EXISTS (SELECT * FROM u WHERE u.key = t.key)`

If left side is much smaller than the right side, it is more efficient to build
hash table from the left side. This can be achieved by using kRightSemiFilter
join type. kLeftSemiFilter and kRightSemiFilter joins are symmetrical, i.e.
`kLeftSemiFilter(A, B) == kRightSemiFilter(B, A)`. Similar to how 
`kLeft(A, B) == kRight(B, A)`.

A semi join may have an additional non-equi filter.

`SELECT * FROM t WHERE EXISTS (SELECT * FROM u WHERE u.key = t.key AND u.x >
t.y)`

Furthermore, the semi join may be combined with another filter using a conjunct
other than AND.

`SELECT * FROM t WHERE t.y > 10 OR EXISTS (SELECT * FROM u WHERE u.key =
t.key)`

One way to implement this query is to use semi join as a project, i.e. return
all left-side rows with an additional boolean flag that indicates whether there is a
match on the right side, then use that boolean to evaluate the filter: 
`t.y > 10 OR match`. This is a kLeftSemiProject join type. Both Spark and Presto 
plan correlated subqueries this way.

Similarly to kLeftSemiFilter join type, if left side is much smaller than the right side, 
it is more efficient to build hash table from the left side. This can be achieved by using
kRightSemiProject join type. kLeftSemiProject and kRightSemiProject joins are
symmetrical: `kLeftSemiProject(A, B) == kRightSemiProject(B, A)`.

Fixes #2877