### PR TITLE
Rename kLeftSemi and kRightSemi to kLeftSemiFilter and kRightSemiFilter

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -926,8 +926,8 @@ enum class JoinType {
   kLeft,
   kRight,
   kFull,
-  kLeftSemi,
-  kRightSemi,
+  kLeftSemiFilter,
+  kRightSemiFilter,
   kNullAwareAnti,
   kAnti,
 };
@@ -942,10 +942,10 @@ inline const char* joinTypeName(JoinType joinType) {
       return "RIGHT";
     case JoinType::kFull:
       return "FULL";
-    case JoinType::kLeftSemi:
-      return "LEFT SEMI";
-    case JoinType::kRightSemi:
-      return "RIGHT SEMI";
+    case JoinType::kLeftSemiFilter:
+      return "LEFT SEMI (FILTER)";
+    case JoinType::kRightSemiFilter:
+      return "RIGHT SEMI (FILTER)";
     case JoinType::kNullAwareAnti:
       return "NULL-AWARE ANTI";
     case JoinType::kAnti:
@@ -970,12 +970,12 @@ inline bool isFullJoin(JoinType joinType) {
   return joinType == JoinType::kFull;
 }
 
-inline bool isLeftSemiJoin(JoinType joinType) {
-  return joinType == JoinType::kLeftSemi;
+inline bool isLeftSemiFilterJoin(JoinType joinType) {
+  return joinType == JoinType::kLeftSemiFilter;
 }
 
-inline bool isRightSemiJoin(JoinType joinType) {
-  return joinType == JoinType::kRightSemi;
+inline bool isRightSemiFilterJoin(JoinType joinType) {
+  return joinType == JoinType::kRightSemiFilter;
 }
 
 inline bool isNullAwareAntiJoin(JoinType joinType) {
@@ -1032,12 +1032,12 @@ class AbstractJoinNode : public PlanNode {
     return joinType_ == JoinType::kFull;
   }
 
-  bool isLeftSemiJoin() const {
-    return joinType_ == JoinType::kLeftSemi;
+  bool isLeftSemiFilterJoin() const {
+    return joinType_ == JoinType::kLeftSemiFilter;
   }
 
-  bool isRightSemiJoin() const {
-    return joinType_ == JoinType::kRightSemi;
+  bool isRightSemiFilterJoin() const {
+    return joinType_ == JoinType::kRightSemiFilter;
   }
 
   bool isNullAwareAntiJoin() const {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -136,9 +136,9 @@ void HashBuild::setupTable() {
     // (Left) semi and anti join with no extra filter only needs to know whether
     // there is a match. Hence, no need to store entries with duplicate keys.
     const bool dropDuplicates = !joinNode_->filter() &&
-        (joinNode_->isLeftSemiJoin() || isAntiJoins(joinType_));
+        (joinNode_->isLeftSemiFilterJoin() || isAntiJoins(joinType_));
     // Right semi join needs to tag build rows that were probed.
-    const bool needProbedFlag = joinNode_->isRightSemiJoin();
+    const bool needProbedFlag = joinNode_->isRightSemiFilterJoin();
     if (isNullAwareAntiJoinWithFilter(joinNode_)) {
       // We need to check null key rows in build side in case of null-aware anti
       // join with filter set.


### PR DESCRIPTION
Rename kLeftSemi and kRightSemi join types to kLeftSemiFilter and
kRightSemiFilter. A follow-up PR #3068 will introduce kLeftSemiProject and
kRightSemiProject join types.