### PR TITLE
Add coalesce and if to Fuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -136,7 +136,11 @@ std::optional<bool> isDeterministic(
                  << "' is deterministic or not. Assuming it is.";
     return true;
   }
-  return std::nullopt;
+
+  // functionName must be a special form.
+  LOG(WARNING) << "Unable to determine if '" << functionName
+               << "' is deterministic or not. Assuming it is.";
+  return true;
 }
 
 VectorFuzzer::Options getFuzzerOptions() {
@@ -331,9 +335,6 @@ ExpressionFuzzer::ExpressionFuzzer(
       unsupportedFunctionSignatures,
       (double)unsupportedFunctionSignatures / totalFunctionSignatures * 100);
 
-  // Add additional signatures that are not in function registry.
-  appendConjunctSignatures();
-
   // We sort the available signatures before inserting them into
   // signaturesMap_. The purpose of this step is to ensure the vector of
   // function signatures associated with each key in signaturesMap_ has a
@@ -447,18 +448,6 @@ void ExpressionFuzzer::sortSignatureTemplates() {
         }
         return lhs.functionName < rhs.functionName;
       });
-}
-
-void ExpressionFuzzer::appendConjunctSignatures() {
-  CallableSignature conjunctSignature;
-  conjunctSignature.name = "and";
-  conjunctSignature.returnType = BOOLEAN();
-  conjunctSignature.args = {BOOLEAN(), BOOLEAN()};
-  conjunctSignature.variableArity = true;
-  signatures_.emplace_back(conjunctSignature);
-
-  conjunctSignature.name = "or";
-  signatures_.emplace_back(conjunctSignature);
 }
 
 RowVectorPtr ExpressionFuzzer::generateRowVector() {
@@ -704,7 +693,7 @@ void ExpressionFuzzer::go() {
     VELOX_CHECK(inputRowTypes_.empty());
     VELOX_CHECK(inputRowNames_.empty());
 
-    // Pick a random signature to chose the root return type.
+    // Pick a random signature to choose the root return type.
     size_t idx = folly::Random::rand32(signatures_.size(), rng_);
     const auto& rootType = signatures_[idx].returnType;
 

--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -34,6 +34,12 @@ DEFINE_string(
     "this comma separated list of function names "
     "(e.g: --only \"split\" or --only \"substr,ltrim\").");
 
+DEFINE_string(
+    special_forms,
+    "and,or",
+    "Comma-separated list of special forms to use in generated expression. "
+    "Supported special forms: and, or, coalesce, if.");
+
 int main(int argc, char** argv) {
   facebook::velox::functions::prestosql::registerAllScalarFunctions();
 
@@ -54,5 +60,6 @@ int main(int argc, char** argv) {
       "cardinality",
       "neq"};
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
-  return FuzzerRunner::run(FLAGS_only, initialSeed, skipFunctions);
+  return FuzzerRunner::run(
+      FLAGS_only, initialSeed, skipFunctions, FLAGS_special_forms);
 }

--- a/velox/expression/tests/FuzzerRunner.h
+++ b/velox/expression/tests/FuzzerRunner.h
@@ -60,7 +60,21 @@
 ///         --only "substr,trim"
 
 class FuzzerRunner {
-  // Parse the comma separated list of funciton names, and use it to filter the
+  static std::unordered_set<std::string> splitNames(const std::string& names) {
+    // Parse, lower case and trim it.
+    std::vector<folly::StringPiece> nameList;
+    folly::split(',', names, nameList);
+    std::unordered_set<std::string> nameSet;
+
+    for (const auto& it : nameList) {
+      auto str = folly::trimWhitespace(it).toString();
+      folly::toLowerAscii(str);
+      nameSet.insert(str);
+    }
+    return nameSet;
+  }
+
+  // Parse the comma separated list of function names, and use it to filter the
   // input signatures.
   static facebook::velox::FunctionSignatureMap filterSignatures(
       const facebook::velox::FunctionSignatureMap& input,
@@ -80,15 +94,7 @@ class FuzzerRunner {
     }
 
     // Parse, lower case and trim it.
-    std::vector<folly::StringPiece> nameList;
-    folly::split(',', onlyFunctions, nameList);
-    std::unordered_set<std::string> nameSet;
-
-    for (const auto& it : nameList) {
-      auto str = folly::trimWhitespace(it).toString();
-      folly::toLowerAscii(str);
-      nameSet.insert(str);
-    }
+    auto nameSet = splitNames(onlyFunctions);
 
     // Use the generated set to filter the input signatures.
     facebook::velox::FunctionSignatureMap output;
@@ -100,17 +106,95 @@ class FuzzerRunner {
     return output;
   }
 
+  static const std::unordered_map<
+      std::string,
+      std::vector<facebook::velox::exec::FunctionSignaturePtr>>
+      kSpecialForms;
+
+  static void appendSpecialForms(
+      const std::string& specialForms,
+      facebook::velox::FunctionSignatureMap& signatureMap) {
+    auto specialFormNames = splitNames(specialForms);
+    for (const auto& [name, signatures] : kSpecialForms) {
+      if (specialFormNames.count(name) == 0) {
+        LOG(INFO) << "Skipping special form: " << name;
+        continue;
+      }
+      std::vector<const facebook::velox::exec::FunctionSignature*>
+          rawSignatures;
+      for (const auto& signature : signatures) {
+        rawSignatures.push_back(signature.get());
+      }
+      signatureMap.insert({name, rawSignatures});
+    }
+  }
+
  public:
   static int run(
       const std::string& onlyFunctions,
       size_t seed,
-      const std::unordered_set<std::string>& skipFunctions) {
+      const std::unordered_set<std::string>& skipFunctions,
+      const std::string& specialForms) {
+    auto signatures = facebook::velox::getFunctionSignatures();
+    appendSpecialForms(specialForms, signatures);
     facebook::velox::test::expressionFuzzer(
-        filterSignatures(
-            facebook::velox::getFunctionSignatures(),
-            onlyFunctions,
-            skipFunctions),
-        seed);
+        filterSignatures(signatures, onlyFunctions, skipFunctions), seed);
     return RUN_ALL_TESTS();
   }
+};
+
+// static
+const std::unordered_map<
+    std::string,
+    std::vector<facebook::velox::exec::FunctionSignaturePtr>>
+    FuzzerRunner::kSpecialForms = {
+        {"and",
+         std::vector<facebook::velox::exec::FunctionSignaturePtr>{
+             // and: boolean, boolean,.. -> boolean
+             facebook::velox::exec::FunctionSignatureBuilder()
+                 .argumentType("boolean")
+                 .argumentType("boolean")
+                 .variableArity()
+                 .returnType("boolean")
+                 .build()}},
+        {"or",
+         std::vector<facebook::velox::exec::FunctionSignaturePtr>{
+             // or: boolean, boolean,.. -> boolean
+             facebook::velox::exec::FunctionSignatureBuilder()
+                 .argumentType("boolean")
+                 .argumentType("boolean")
+                 .variableArity()
+                 .returnType("boolean")
+                 .build()}},
+        {"coalesce",
+         std::vector<facebook::velox::exec::FunctionSignaturePtr>{
+             // coalesce: T, T,.. -> T
+             facebook::velox::exec::FunctionSignatureBuilder()
+                 .typeVariable("T")
+                 .argumentType("T")
+                 .argumentType("T")
+                 .variableArity()
+                 .returnType("T")
+                 .build()}},
+        {
+            "if",
+            std::vector<facebook::velox::exec::FunctionSignaturePtr>{
+                // if (condition, then): boolean, T -> T
+                facebook::velox::exec::FunctionSignatureBuilder()
+                    .typeVariable("T")
+                    .argumentType("boolean")
+                    .argumentType("T")
+                    .argumentType("T")
+                    .returnType("T")
+                    .build(),
+                // if (condition, then, else): boolean, T -> T
+                facebook::velox::exec::FunctionSignatureBuilder()
+                    .typeVariable("T")
+                    .argumentType("boolean")
+                    .argumentType("T")
+                    .argumentType("T")
+                    .argumentType("T")
+                    .returnType("T")
+                    .build()},
+        },
 };


### PR DESCRIPTION
Add --special_form flag to Fuzzer to allow for specifying a subset of special
forms to include in the expressions. Supported special forms are: AND, OR, IF,
COALESCE.

Make sure --only applies to special forms as well as functions.

By default, enable only AND/OR special forms (as before the change).