### PR TITLE
Add a flag to persist repro info before evaluation

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -81,6 +81,13 @@ DEFINE_string(
     "Directory path for persistence of data and SQL when fuzzer fails for "
     "future reproduction. Empty string disables this feature.");
 
+DEFINE_bool(
+    persist_and_run_once,
+    false,
+    "Persist repro info before evaluation and only run one iteration. "
+    "This is to rerun with the seed number and persist repro info upon a "
+    "crash failure. Only effective if repro_persist_path is set.");
+
 DEFINE_int32(
     velox_fuzzer_max_level_of_nesting,
     10,
@@ -259,7 +266,9 @@ ExpressionFuzzer::ExpressionFuzzer(
     : remainingLevelOfNesting_(std::max(1, maxLevelOfNesting)),
       verifier_(
           &execCtx_,
-          {FLAGS_disable_constant_folding, FLAGS_repro_persist_path}),
+          {FLAGS_disable_constant_folding,
+           FLAGS_repro_persist_path,
+           FLAGS_persist_and_run_once}),
       vectorFuzzer_(getFuzzerOptions(), execCtx_.pool()) {
   seed(initialSeed);
 

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -28,6 +28,7 @@ namespace facebook::velox::test {
 struct ExpressionVerifierOptions {
   bool disableConstantFolding{false};
   std::string reproPersistPath;
+  bool persistAndRunOnce{false};
 };
 
 class ExpressionVerifier {


### PR DESCRIPTION
Summary:
Addressing https://github.com/facebookincubator/velox/issues/2991
Upon crashing, you can now use the seed number of the crashed iteration to return with `--persist_and_run_once` in order to persist the repro files

Differential Revision: D40949609

