### PR TITLE
Backtrack when arg type is an invalid map with unknown keys.

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -58,7 +58,12 @@ int main(int argc, char** argv) {
       // cardinality passing a VARBINARY (since HLL's implementation uses an
       // alias to VARBINARY).
       "cardinality",
-      "neq"};
+      "neq",
+      "in",
+      "array_sort",
+      "array_intersect",
+      "map_concat_empty_nulls",
+      "width_bucket"};
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(
       FLAGS_only, initialSeed, skipFunctions, FLAGS_special_forms);


### PR DESCRIPTION
Summary:
solve issues  #3046
The fuzzer works as the following:
1. pick a return type.
2. find an expression that can return this type.
3. determine types of args.
4. repeat for type of args.

Consider a situation where 1 selected Array<unknown>, in that
case 2 could be  map_keys function since it returns T and T can
bound to Array<unknown>.

Then 3 would determine that the input should be map<unknown, X>
and hence that would be an invalid input.

This diff capture such thing and back track so a different expression
can be selected.

We can potentially move the checks to chooseRandomSignatureTemplate as well,
but i found this more cleaner.
The other approach will look like this: D40923723

Differential Revision: D40923057

