### PR TITLE
Do not cap memory on memory release

### DIFF
--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -92,6 +92,9 @@ inline constexpr auto kMemCapExceeded = "MEM_CAP_EXCEEDED"_fs;
 // Error caused by failing to allocate cache buffer space for IO.
 inline constexpr auto kNoCacheSpace = "NO_CACHE_SPACE"_fs;
 
+// Errors indicating file read corruptions.
+inline constexpr auto kFileCorruption = "FILE_CORRUPTION"_fs;
+
 // We do not know how to classify it yet.
 inline constexpr auto kUnknown = "UNKNOWN"_fs;
 } // namespace error_code

--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -244,7 +244,7 @@ void SimpleMemoryTracker::update(int64_t size, bool mock) {
   }
   int64_t previousUsage =
       totalUserMemory_.fetch_add(size, std::memory_order_relaxed);
-  if (previousUsage + size > userMemoryQuota_) {
+  if (size > 0 && previousUsage + size > userMemoryQuota_) {
     VELOX_MEM_CAP_EXCEEDED(userMemoryQuota_);
   }
 }


### PR DESCRIPTION
Summary:
We discovered that in an extremely unhappy case, memory coordination
can fail and the process can be stuck in a memory capping mode that it couldn't
get out of. This diff helps minimize that scenario.

Differential Revision:
D40950193

LaMa Project: L1156649

