### PR TITLE
Add consistency checks in map and array vectors

### DIFF
--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -278,8 +278,9 @@ struct ArrayVectorBase : BaseVector {
         sizes_(std::move(lengths)),
         rawSizes_(sizes_->as<vector_size_t>()) {
     VELOX_CHECK_GE(
-        offsets_->size(), BaseVector::length_ * sizeof(vector_size_t));
-    VELOX_CHECK_GE(sizes_->size(), BaseVector::length_ * sizeof(vector_size_t));
+        offsets_->capacity(), BaseVector::length_ * sizeof(vector_size_t));
+    VELOX_CHECK_GE(
+        sizes_->capacity(), BaseVector::length_ * sizeof(vector_size_t));
   }
 
   void copyRangesImpl(
@@ -289,38 +290,6 @@ struct ArrayVectorBase : BaseVector {
       const BaseVector* sourceValues,
       VectorPtr* targetKeys,
       const BaseVector* sourceKeys);
-
-  /// Checks whether offsets and sizes are valid values and point to valid
-  /// indices in the child vectors(elements for array, keys and values for
-  /// map.
-  void checkConsistency(size_t childVectorSize) {
-#ifndef NDEBUG
-    for (auto i = 0; i < BaseVector::length_; ++i) {
-      const bool isNull =
-          BaseVector::rawNulls_ && bits::isBitNull(BaseVector::rawNulls_, i);
-      if (isNull) {
-        continue;
-      }
-      auto offset = rawOffsets_[i];
-      auto size = rawSizes_[i];
-      if (size == 0) {
-        // Represents empty entry.
-        continue;
-      }
-      // Verify index for a non-null position. It must be >= 0 and < size of the
-      // base vector.
-      VELOX_DCHECK_GE(size, 0, "Sizes must be non-negative. Index: {}.", i);
-      VELOX_DCHECK_GE(
-          offset, 0, "Offset index must be non-negative. Index: {}.", i);
-      VELOX_DCHECK_LE(
-          offset + size,
-          childVectorSize,
-          "Offset and size must point to valid indices in the children "
-          "vectors. Index: {}.",
-          i);
-    }
-#endif
-  }
 
  private:
   BufferPtr
@@ -370,7 +339,6 @@ class ArrayVector : public ArrayVectorBase {
         "Unexpected element type: {}. Expected: {}",
         elements_->type()->toString(),
         type->childAt(0)->toString());
-    ArrayVectorBase::checkConsistency(elements_->size());
 
     if (type->isFixedWidth()) { // and thus must be FixedSizeArrayType
       // Ensure all elements have the same width as our type.
@@ -531,7 +499,6 @@ class MapVector : public ArrayVectorBase {
         "Unexpected value type: {}. Expected: {}",
         values_->type()->toString(),
         type->childAt(1)->toString());
-    ArrayVectorBase::checkConsistency(std::min(keys_->size(), values_->size()));
   }
 
   virtual ~MapVector() override {}
@@ -579,7 +546,6 @@ class MapVector : public ArrayVectorBase {
         std::move(keys), type()->childAt(0), pool_);
     values_ = BaseVector::getOrCreateEmpty(
         std::move(values), type()->childAt(1), pool_);
-    ArrayVectorBase::checkConsistency(std::min(keys_->size(), values_->size()));
   }
 
   void copyRanges(


### PR DESCRIPTION
This adds consistency checks to both map and array vectors that
ensure that the sizes of the offset and size buffers are valid.
Moreover, adds a more through check that only fires in debug
builds which checks whether the values in the offset and size
buffers are valid.