### PR TITLE
Fix null handling in `map_concat_empty_nulls`

### DIFF
--- a/velox/functions/lib/MapConcat.cpp
+++ b/velox/functions/lib/MapConcat.cpp
@@ -51,6 +51,9 @@ class MapConcatFunction : public exec::VectorFunction {
       auto inputMap = decodedArg->base()->as<MapVector>();
       auto rawSizes = inputMap->rawSizes();
       rows.applyToSelected([&](vector_size_t row) {
+        if (EmptyForNull && decodedArg->isNullAt(row)) {
+          return;
+        }
         maxSize += rawSizes[decodedArg->index(row)];
       });
     }

--- a/velox/functions/lib/tests/MapConcatTest.cpp
+++ b/velox/functions/lib/tests/MapConcatTest.cpp
@@ -263,3 +263,23 @@ TEST_F(MapConcatTest, partiallyPopulated) {
         << result->toString(i);
   }
 }
+
+TEST_F(MapConcatTest, nullEntry) {
+  auto offsets = allocateOffsets(1, pool());
+  auto sizes = AlignedBuffer::allocate<vector_size_t>(1, pool(), 1000);
+  auto keys = BaseVector::create(BIGINT(), 0, pool());
+  auto values = BaseVector::create(DOUBLE(), 0, pool());
+  auto nulls = AlignedBuffer::allocate<bool>(1, pool(), bits::kNull);
+  auto map = std::make_shared<MapVector>(
+      pool(), MAP(BIGINT(), DOUBLE()), nulls, 1, offsets, sizes, keys, values);
+  auto dict = BaseVector::wrapInDictionary(nulls, sizes, 1, map);
+  auto rows = std::make_shared<RowVector>(
+      pool(),
+      ROW({"c0", "c1"}, {dict->type(), map->type()}),
+      nullptr,
+      1,
+      std::vector<VectorPtr>({dict, map}));
+  auto result = evaluate<MapVector>("map_concat_empty_nulls(c0, c1)", rows);
+  ASSERT_EQ(result->size(), 1);
+  EXPECT_EQ(result->sizeAt(0), 0);
+}


### PR DESCRIPTION
Summary:
Null is not checked when adding sizes.

Fix https://github.com/facebookincubator/velox/issues/3042

Differential Revision: D40959273

