### PR TITLE
Fix Bug: copy from view types.

### DIFF
--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -471,6 +471,7 @@ class MapWriter {
     keysVector_ = &keysWriter_->vector();
     valuesVector_ = &valuesWriter_->vector();
 
+    innerOffset_ = std::max(keysVector_->size(), valuesVector_->size());
     // Keys can never be null.
     keysVector_->resetNulls();
 

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -128,8 +128,6 @@ struct VectorWriter<Array<V>> {
   void ensureSize(size_t size) {
     if (size > arrayVector_->size()) {
       arrayVector_->resize(size);
-      childWriter_.init(
-          static_cast<child_vector_t&>(*arrayVector_->elements()));
     }
   }
 
@@ -212,7 +210,6 @@ struct VectorWriter<Map<K, V>> {
   void ensureSize(size_t size) {
     if (size > mapVector_->size()) {
       mapVector_->resize(size);
-      init(vector());
     }
   }
 


### PR DESCRIPTION
Summary:
Before this diff, copy_from view types into a writer a type
used to utilize the vector copy operation.
There is two problems with that when used with nested complex types:
1. The recursive copy operation performs an append operation to the child vectors, (i.e: elements of array).
However, the writers will have it larger than needed does
since it does exp growth for those and tracks the actual used index. Meaning things will be written with
gaps, furthermore if an add_item was called after the copy_from, it won't be appended to the end but on
the tracked offset causing bugs.

2. The recursive copy operation does not update the sizes in the nested writers.

Reviewed By: kagamiori

Differential Revision: D40732089

