### PR TITLE
Fix batch size when get output from spilling plus code cleanup

### DIFF
--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -124,16 +124,17 @@ class GroupingSet {
   // otherwise.
   void extractGroups(folly::Range<char**> groups, const RowVectorPtr& result);
 
-  /// Produces output in if spilling has occurred. First produces data
-  /// from non-spilled partitions, then merges spill runs and
-  /// unspilled data form spilled partitions. Returns nullptr when at
-  /// end.
-  bool getOutputWithSpill(const RowVectorPtr& result);
+  // Produces output in if spilling has occurred. First produces data
+  // from non-spilled partitions, then merges spill runs and unspilled data
+  // form spilled partitions. Returns nullptr when at end. 'batchSize' specifies
+  // the max number of output rows in 'result'.
+  bool getOutputWithSpill(int32_t batchSize, const RowVectorPtr& result);
 
-  /// Reads rows from the current spilled partition until producing a batch of
-  /// final results in 'result'. Returns false and leaves 'result' empty when
-  /// the partition is fully read.
-  bool mergeNext(const RowVectorPtr& result);
+  // Reads rows from the current spilled partition until producing a batch of
+  // final results in 'result'. Returns false and leaves 'result' empty when
+  // the partition is fully read. 'batchSize' specifies the max number of output
+  // rows in 'result'.
+  bool mergeNext(int32_t batchSize, const RowVectorPtr& result);
 
   // Initializes a new row in 'mergeRows' with the keys from the
   // current element from 'keys'. Accumulators are left in the initial
@@ -218,8 +219,6 @@ class GroupingSet {
   /// The value of mayPushdown flag specified in addInput() for the
   /// 'remainingInput_'.
   bool remainingMayPushdown_;
-
-  uint64_t maxBatchBytes_;
 
   std::unique_ptr<Spiller> spiller_;
   std::unique_ptr<TreeOfLosers<SpillMergeStream>> merge_;

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -297,7 +297,7 @@ RowVectorPtr HashAggregation::getOutput() {
     return output;
   }
 
-  auto batchSize = isGlobal_ ? 1 : outputBatchSize_;
+  const auto batchSize = isGlobal_ ? 1 : outputBatchSize_;
 
   // Reuse output vectors if possible.
   prepareOutput(batchSize);

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <folly/Math.h>
+
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TestValue.h"
@@ -1241,6 +1243,52 @@ TEST_F(AggregationTest, groupingSets) {
   assertQuery(
       plan,
       "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY ROLLUP (k1, k2)");
+}
+
+TEST_F(AggregationTest, outputBatchSizeCheckWithSpill) {
+  rowType_ = ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), INTEGER()});
+  VectorFuzzer::Options options;
+  options.vectorSize = 10;
+  VectorFuzzer fuzzer(options, pool());
+  const int32_t numBatches = 10;
+  std::vector<RowVectorPtr> batches;
+  for (int32_t i = 0; i < numBatches; ++i) {
+    batches.push_back(fuzzer.fuzzRow(rowType_));
+  }
+  std::vector<uint32_t> outputBufferSizes({1, 10, 1'000'000});
+  for (const auto& outputBufferSize : outputBufferSizes) {
+    SCOPED_TRACE(fmt::format("outputBufferSize: {}", outputBufferSize));
+
+    auto results =
+        AssertQueryBuilder(PlanBuilder()
+                               .values(batches)
+                               .singleAggregation({"c0", "c1"}, {"sum(c2)"})
+                               .planNode())
+            .copyResults(pool_.get());
+
+    auto tempDirectory = exec::test::TempDirectoryPath::create();
+    auto task =
+        AssertQueryBuilder(PlanBuilder()
+                               .values(batches)
+                               .singleAggregation({"c0", "c1"}, {"sum(c2)"})
+                               .planNode())
+            .config(QueryConfig::kSpillEnabled, "true")
+            .config(QueryConfig::kAggregationSpillEnabled, "true")
+            // Set one spill partition to avoid the test flakiness.
+            .config(QueryConfig::kSpillPartitionBits, "0")
+            .config(QueryConfig::kSpillPath, tempDirectory->path)
+            .config(
+                QueryConfig::kPreferredOutputBatchSize,
+                std::to_string(outputBufferSize))
+            // Set the memory trigger limit to be a very small value.
+            .config(QueryConfig::kAggregationSpillMemoryThreshold, "1")
+            .assertResults(results);
+
+    const auto opStats = task->taskStats().pipelineStats[0].operatorStats[1];
+    ASSERT_EQ(
+        folly::divCeil(opStats.outputPositions, outputBufferSize),
+        opStats.outputVectors);
+  }
 }
 
 } // namespace

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2097,24 +2097,18 @@ TEST_F(VectorTest, mapSliceMutability) {
       std::dynamic_pointer_cast<MapVector>(createMap(vectorSize_, false)));
 }
 
-// TODO(xiaoxmeng): Inconsistency discovered by following check when
-// running with Prestissmo. Re-enable this check after the issue gets fixed.
-//
-// // Demonstrates incorrect usage of the memory pool. The pool is destroyed
-// while
-// // the vector allocated from it is still alive.
-// TEST_F(VectorTest, lifetime) {
-//   ASSERT_DEATH(
-//       {
-//         auto childPool = pool_->addScopedChild("test");
-//         auto v = BaseVector::create(INTEGER(), 10, childPool.get());
+// Demonstrates incorrect usage of the memory pool. The pool is destroyed
+// while the vector allocated from it is still alive.
+TEST_F(VectorTest, lifetime) {
+  ASSERT_DEATH(
+      {
+        auto childPool = pool_->addScopedChild("test");
+        auto v = BaseVector::create(INTEGER(), 10, childPool.get());
 
-//         // BUG: Memory pool needs to stay alive until all memory allocated
-//         from
-//         // it is freed.
-//         childPool.reset();
-//         v.reset();
-//       },
-//       "Memory pool should be destroyed only after all allocated memory has
-//       been freed.");
-// }
+        // BUG: Memory pool needs to stay alive until all memory allocated from
+        // it is freed.
+        childPool.reset();
+        v.reset();
+      },
+      "Memory pool should be destroyed only after all allocated memory has been freed.");
+}


### PR DESCRIPTION
maxBatchBytes_ is not set in GroupingSet which will cause the
spilling restore path process one group at a time. Fix the issue
by removing maxBatchBytes_ and use the batch size passed by
HashAggregation operator. Also change the other spilling output
path to use the batch size passed from the hash aggregation
operator and the batch size is a number of rows limit instead of
number of bytes limit.

Also enable a memory pool test case in VectorTest
