### PR TITLE
[Velox] Bring back OBJECT to velox_hive_connector

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_hive_connector HiveConnector.cpp FileHandle.cpp
-                                 HiveWriteProtocol.cpp)
+add_library(velox_hive_connector OBJECT HiveConnector.cpp FileHandle.cpp
+                                        HiveWriteProtocol.cpp)
 
 target_link_libraries(velox_hive_connector velox_connector
                       velox_dwio_dwrf_reader velox_dwio_dwrf_writer velox_file)


### PR DESCRIPTION
Without OBJECT label for velox_hive_conector, build of presto_server sees error like undefined reference to
HiveTableHandle::HiveTableHandle().

https://github.com/facebookincubator/velox/pull/2897 added OBJECT, but the next PR https://github.com/facebookincubator/velox/pull/2845 removed it according to change history.

Actually PR https://github.com/facebookincubator/velox/pull/2845 did not touch OBJECT according to the PR page. It is likely due to change merge of CMakeList.txt on GitHub.