### PR TITLE
Improve performance of RowVector::copyRanges

### DIFF
--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -123,18 +123,14 @@ class RowVector : public BaseVector {
       vector_size_t sourceIndex,
       vector_size_t count) override;
 
-  void copyRanges(
-      const BaseVector* source,
-      const folly::Range<const CopyRange*>& ranges) override {
-    for (auto& range : ranges) {
-      copy(source, range.targetIndex, range.sourceIndex, range.count);
-    }
-  }
-
   void copy(
       const BaseVector* source,
       const SelectivityVector& rows,
       const vector_size_t* toSourceRow) override;
+
+  void copyRanges(
+      const BaseVector* source,
+      const folly::Range<const CopyRange*>& ranges) override;
 
   uint64_t retainedSize() const override {
     auto size = BaseVector::retainedSize();

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -505,6 +505,16 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
       EXPECT_TRUE(source->equalValueAt(target.get(), i, sourceSize + i));
     }
 
+    std::vector<BaseVector::CopyRange> ranges = {
+        {0, 0, sourceSize},
+        {0, sourceSize, sourceSize},
+    };
+    target->copyRanges(source.get(), ranges);
+    for (int32_t i = 0; i < sourceSize; ++i) {
+      EXPECT_TRUE(source->equalValueAt(target.get(), i, i));
+      EXPECT_TRUE(source->equalValueAt(target.get(), i, sourceSize + i));
+    }
+
     // Check that uninitialized is copyable.
     target->resize(target->size() + 100);
     target->copy(target.get(), target->size() - 50, target->size() - 100, 50);


### PR DESCRIPTION
Summary:
Currently the code copies the ranges one at a time.  Optimize it to
accumulate the ranges and run copy only once in each children.

Benchmark shows more than 13 times faster improvement.

Before:
```
============================================================================
velox/vector/benchmarks/CopyBenchmark.cpp     relative  time/iter   iters/s
============================================================================
copyStructNonContiguous                                   223.55ns     4.47M
```

After:
```
============================================================================
velox/vector/benchmarks/CopyBenchmark.cpp     relative  time/iter   iters/s
============================================================================
copyStructNonContiguous                                    16.16ns    61.89M
```

Differential Revision: D40993608

