### PR TITLE
Move fmt to use resolve_dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,7 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 find_package(gflags COMPONENTS shared)
 find_package(glog REQUIRED)
 
-set(fmt_SOURCE AUTO)
+set_source(fmt)
 resolve_dependency(fmt)
 
 find_library(EVENT event)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.18)
+
+# the policy allows us to change options without caching
+cmake_policy(SET CMP0077 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+# the policy allows us to change set(CACHE) without caching
+if(POLICY CMP0126)
+  cmake_policy(SET CMP0126 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
+endif()
+
+# The policy uses the download time for timestamp, instead of the timestamp in
+# the archive. This allows for proper rebuilds when a projects url changes
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+endif()
+
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 
 # set the project name
@@ -294,7 +312,8 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 find_package(gflags COMPONENTS shared)
 find_package(glog REQUIRED)
 
-find_library(FMT fmt)
+set(fmt_SOURCE AUTO)
+resolve_dependency(fmt)
 
 find_library(EVENT event)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,24 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.14)
 
 # the policy allows us to change options without caching
 cmake_policy(SET CMP0077 NEW)
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-
-# the policy allows us to change set(CACHE) without caching
-if(POLICY CMP0126)
-  cmake_policy(SET CMP0126 NEW)
-  set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
-endif()
-
-# The policy uses the download time for timestamp, instead of the timestamp in
-# the archive. This allows for proper rebuilds when a projects url changes
-if(POLICY CMP0135)
-  cmake_policy(SET CMP0135 NEW)
-  set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
-endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 

--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -181,6 +181,31 @@ macro(build_pybind11)
 endmacro()
 
 # ================================ END PYBIND11 ================================
+# ================================ FMT =========================================
+if(DEFINED ENV{VELOX_FMT_URL})
+  set(VELOX_FMT_SOURCE_URL "$ENV{VELOX_FMT_URL}")
+else()
+  set(VELOX_FMT_VERSION 8.0.1)
+  set(VELOX_FMT_SOURCE_URL
+      "https://github.com/fmtlib/fmt/archive/${VELOX_FMT_VERSION}.tar.gz")
+  set(VELOX_FMT_BUILD_SHA256_CHECKSUM
+      b06ca3130158c625848f3fb7418f235155a4d389b2abc3a6245fb01cb0eb1e01)
+endif()
+
+macro(build_fmt)
+  message(STATUS "Building fmt from source")
+  FetchContent_Declare(
+    fmt
+    URL ${VELOX_FMT_SOURCE_URL}
+    URL_HASH SHA256=${VELOX_FMT_BUILD_SHA256_CHECKSUM})
+
+  # Force fmt to create fmt-config.cmake which can be found by other dependecies
+  # (e.g. folly)
+  set(FMT_INSTALL ON)
+  set(fmt_BUILD_TESTS OFF)
+  FetchContent_MakeAvailable(fmt)
+endmacro()
+# ================================ END FMT ================================
 
 macro(build_dependency DEPENDENCY_NAME)
   if("${DEPENDENCY_NAME}" STREQUAL "folly")
@@ -189,6 +214,8 @@ macro(build_dependency DEPENDENCY_NAME)
     build_protobuf()
   elseif("${DEPENDENCY_NAME}" STREQUAL "pybind11")
     build_pybind11()
+  elseif("${DEPENDENCY_NAME}" STREQUAL "fmt")
+    build_fmt()
   else()
     message(
       FATAL_ERROR "Unknown thirdparty dependency to build: ${DEPENDENCY_NAME}")


### PR DESCRIPTION
This PR moves fmt to use resolve_dependency and makes the dependency source (optionally) configurable via envvar. This enables the CI to test correctly with fmt from source even with system fmt installed.