### PR TITLE
Hash table variants and optimizations

### DIFF
--- a/velox/common/base/Portability.h
+++ b/velox/common/base/Portability.h
@@ -19,6 +19,8 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace facebook::velox {
+
 inline size_t count_trailing_zeros(uint64_t x) {
   return x == 0 ? 64 : __builtin_ctzll(x);
 }
@@ -32,3 +34,21 @@ inline size_t count_leading_zeros(uint64_t x) {
 #else
 #define INLINE_LAMBDA
 #endif
+
+/// Define asan_atomic<T> to be std::atomic<T> with asan and just T
+/// otherwise. Applies to counters that do not need atomicity and are
+/// not serialized on any mutex but generate warnings with asan.
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+template <typename T>
+using asan_atomic = std::atomic<T>;
+#else
+template <typename T>
+using asan_atomic = T;
+#endif
+#else
+template <typename T>
+using asan_atomic = T;
+#endif
+
+} // namespace facebook::velox

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -77,67 +77,60 @@ class ProbeState {
   static constexpr uint8_t kTombstoneTag = 0x7f;
   static constexpr int32_t kFullMask = 0xffff;
 
-  static inline int32_t tagsByteOffset(uint64_t hash, uint64_t sizeMask) {
-    return (hash & sizeMask) & ~(sizeof(BaseHashTable::TagVector) - 1);
-  }
-
   int32_t row() const {
     return row_;
   }
 
   // Use one instruction to load 16 tags
   // Use another instruction to make 16 copies of the tag being searched for
-  inline void
-  preProbe(uint8_t* tags, uint64_t sizeMask, uint64_t hash, int32_t row) {
+  template <typename Table>
+  inline void preProbe(const Table& table, uint64_t hash, int32_t row) {
     row_ = row;
-    tagIndex_ = tagsByteOffset(hash, sizeMask);
-    tagsInTable_ = BaseHashTable::loadTags(tags, tagIndex_);
+    tagIndex_ = table.tagVectorOffset(hash);
+    tagsInTable_ = BaseHashTable::loadTags(table.tags_, tagIndex_);
     auto tag = BaseHashTable::hashTag(hash);
     wantedTags_ = BaseHashTable::TagVector::broadcast(tag);
     group_ = nullptr;
     indexInTags_ = kNotSet;
+    table.incrementTagLoad();
   }
 
   // Use one instruction to compare the tag being searched for to 16 tags
   // If there is a match, load corresponding data from the table
-  template <Operation op = Operation::kProbe>
-  inline void firstProbe(char** table, int32_t firstKey) {
+  template <Operation op = Operation::kProbe, typename Table>
+  inline void firstProbe(const Table& table, int32_t firstKey) {
     hits_ = simd::toBitMask(tagsInTable_ == wantedTags_);
     if (hits_) {
       loadNextHit<op>(table, firstKey);
     }
   }
 
-  template <Operation op, typename Compare, typename Insert>
+  template <Operation op, typename Compare, typename Insert, typename Table>
   inline char* FOLLY_NULLABLE fullProbe(
-      uint8_t* tags,
-      char** table,
-      uint64_t sizeMask,
+      Table& table,
       int32_t firstKey,
       Compare compare,
       Insert insert,
       bool extraCheck = false) {
     if (group_ && compare(group_, row_)) {
       if (op == Operation::kErase) {
-        eraseHit(tags);
+        eraseHit(table);
       }
+      table.incrementHit();
       return group_;
     }
 
     auto alreadyChecked = group_;
     if (extraCheck) {
-      tagsInTable_ = BaseHashTable::loadTags(tags, tagIndex_);
+      tagsInTable_ = table.loadTags(tagIndex_);
       hits_ = simd::toBitMask(tagsInTable_ == wantedTags_);
     }
 
     int32_t insertTagIndex = -1;
-    const auto kTombstoneGroup =
-        BaseHashTable::TagVector::broadcast(kTombstoneTag);
     const auto kEmptyGroup = BaseHashTable::TagVector::broadcast(0);
     for (;;) {
       if (!hits_) {
-        uint16_t empty =
-            simd::toBitMask(tagsInTable_ == kEmptyGroup) & kFullMask;
+        uint16_t empty = simd::toBitMask(tagsInTable_ == kEmptyGroup);
         if (empty) {
           if (op == Operation::kProbe) {
             return nullptr;
@@ -154,11 +147,16 @@ class ProbeState {
           return insert(row_, tagIndex_ + pos);
         } else if (op == Operation::kInsert && indexInTags_ == kNotSet) {
           // We passed through a full group.
-          uint16_t tombstones =
-              simd::toBitMask(tagsInTable_ == kTombstoneGroup) & kFullMask;
-          if (tombstones) {
-            insertTagIndex = tagIndex_;
-            indexInTags_ = bits::getAndClearLastSetBit(tombstones);
+          if (table.hasTombstones_) {
+            const auto kTombstoneGroup =
+                BaseHashTable::TagVector::broadcast(kTombstoneTag);
+
+            uint16_t tombstones =
+                simd::toBitMask(tagsInTable_ == kTombstoneGroup);
+            if (tombstones) {
+              insertTagIndex = tagIndex_;
+              indexInTags_ = bits::getAndClearLastSetBit(tombstones);
+            }
           }
         }
       } else {
@@ -166,43 +164,44 @@ class ProbeState {
         if (!(extraCheck && group_ == alreadyChecked) &&
             compare(group_, row_)) {
           if (op == Operation::kErase) {
-            eraseHit(tags);
+            eraseHit(table);
           }
+          table.incrementHit();
           return group_;
         }
         continue;
       }
-      tagIndex_ = (tagIndex_ + sizeof(BaseHashTable::TagVector)) & sizeMask;
-      tagsInTable_ = BaseHashTable::loadTags(tags, tagIndex_);
-      hits_ = simd::toBitMask(tagsInTable_ == wantedTags_) & kFullMask;
+      tagIndex_ = table.nextTagVectorOffset(tagIndex_);
+      tagsInTable_ = table.loadTags(tagIndex_);
+      hits_ = simd::toBitMask(tagsInTable_ == wantedTags_);
     }
   }
 
-  FOLLY_ALWAYS_INLINE char* FOLLY_NULLABLE joinNormalizedKeyFullProbe(
-      uint8_t* tags,
-      char** table,
-      uint64_t sizeMask,
-      const uint64_t* keys) {
+  template <typename Table>
+  FOLLY_ALWAYS_INLINE char* FOLLY_NULLABLE
+  joinNormalizedKeyFullProbe(const Table& table, const uint64_t* keys) {
     if (group_ && RowContainer::normalizedKey(group_) == keys[row_]) {
+      table.incrementHit();
       return group_;
     }
     const auto kEmptyGroup = BaseHashTable::TagVector::broadcast(0);
     for (;;) {
       if (!hits_) {
-        uint16_t empty =
-            simd::toBitMask(tagsInTable_ == kEmptyGroup) & kFullMask;
+        uint16_t empty = simd::toBitMask(tagsInTable_ == kEmptyGroup);
         if (empty) {
           return nullptr;
         }
       } else {
-        loadNextHit<Operation::kProbe>(table, 0);
+        loadNextHit<Operation::kProbe>(
+            table, -static_cast<int32_t>(sizeof(normalized_key_t)));
         if (RowContainer::normalizedKey(group_) == keys[row_]) {
+          table.incrementHit();
           return group_;
         }
         continue;
       }
-      tagIndex_ = (tagIndex_ + sizeof(BaseHashTable::TagVector)) & sizeMask;
-      tagsInTable_ = BaseHashTable::loadTags(tags, tagIndex_);
+      tagIndex_ = table.nextTagVectorOffset(tagIndex_);
+      tagsInTable_ = BaseHashTable::loadTags(table.tags_, tagIndex_);
       hits_ = simd::toBitMask(tagsInTable_ == wantedTags_) & kFullMask;
     }
   }
@@ -210,23 +209,28 @@ class ProbeState {
  private:
   static constexpr uint8_t kNotSet = 0xff;
 
-  template <Operation op>
-  inline void loadNextHit(char** table, int32_t firstKey) {
+  template <Operation op, typename Table>
+  inline void loadNextHit(Table& table, int32_t firstKey) {
     int32_t hit = bits::getAndClearLastSetBit(hits_);
 
     if (op == Operation::kErase) {
       indexInTags_ = hit;
     }
-    group_ = BaseHashTable::loadRow(table, tagIndex_ + hit);
+    group_ = table.row(tagIndex_, hit);
     __builtin_prefetch(group_ + firstKey);
+    table.incrementRowLoad();
   }
 
-  void eraseHit(uint8_t* tags) {
+  template <typename Table>
+  void eraseHit(Table& table) {
     const auto kEmptyGroup = BaseHashTable::TagVector::broadcast(0);
     auto empty = simd::toBitMask(tagsInTable_ == kEmptyGroup);
 
+    if (!empty) {
+      table.hasTombstones_ = true;
+    }
     BaseHashTable::storeTag(
-        tags, tagIndex_ + indexInTags_, empty ? 0 : kTombstoneTag);
+        table.tags_, tagIndex_ + indexInTags_, empty ? 0 : kTombstoneTag);
   }
 
   char* group_;
@@ -264,6 +268,23 @@ void HashTable<ignoreNullKeys>::storeRowPointer(
     char* row) {
   if (hashMode_ != HashMode::kArray) {
     tags_[index] = hashTag(hash);
+    if (kInterleaveRows) {
+      // The pointer is in slot (index - start_of_group) after the
+      // tags. We first get the base address of the tag/pointer
+      // group. We add the size of the tags. Then we add pointer size
+      // * index of the tag in the tags vector. This is the address of
+      // a 6 byte pointer to the row.
+      int groupOffset = index & ~(kTagRowGroupSize - 1);
+      uint64_t* pointer = reinterpret_cast<uint64_t*>(
+          tags_ + sizeof(TagVector) + groupOffset +
+          (kBytesInPointer * (index - groupOffset)));
+
+      // We store 48 bits, preserving the high 16 bits of the word, which belong
+      // to the next pointer.
+      auto previous = *pointer & ~kPointerMask;
+      *pointer = reinterpret_cast<uint64_t>(row) | previous;
+      return;
+    }
   }
   table_[index] = row;
 }
@@ -322,19 +343,17 @@ bool HashTable<ignoreNullKeys>::compareKeys(
 }
 
 template <bool ignoreNullKeys>
-template <bool isJoin>
+template <bool isJoin, bool isNormalizedKey>
 FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::fullProbe(
     HashLookup& lookup,
     ProbeState& state,
     bool extraCheck) {
   constexpr ProbeState::Operation op =
       isJoin ? ProbeState::Operation::kProbe : ProbeState::Operation::kInsert;
-  if (hashMode_ == HashMode::kNormalizedKey) {
+  if constexpr (isNormalizedKey) {
     // NOLINT
     lookup.hits[state.row()] = state.fullProbe<op>(
-        tags_,
-        table_,
-        sizeMask_,
+        *this,
         -static_cast<int32_t>(sizeof(normalized_key_t)),
         [&](char* group, int32_t row) INLINE_LAMBDA {
           return RowContainer::normalizedKey(group) ==
@@ -348,9 +367,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::fullProbe(
   }
   // NOLINT
   lookup.hits[state.row()] = state.fullProbe<op>(
-      tags_,
-      table_,
-      sizeMask_,
+      *this,
       0,
       [&](char* group, int32_t row) { return compareKeys(group, lookup, row); },
       [&](int32_t index, int32_t row) {
@@ -392,6 +409,10 @@ void populateNormalizedKeys(HashLookup& lookup, int8_t sizeBits) {
 
 template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::groupProbe(HashLookup& lookup) {
+  if (kTrackLoads) {
+    numProbe_ += lookup.rows.size();
+  }
+
   if (hashMode_ == HashMode::kArray) {
     arrayGroupProbe(lookup);
     return;
@@ -401,6 +422,8 @@ void HashTable<ignoreNullKeys>::groupProbe(HashLookup& lookup) {
   checkSize(lookup.rows.size());
   if (hashMode_ == HashMode::kNormalizedKey) {
     populateNormalizedKeys(lookup, sizeBits_);
+    groupNormalizedKeyProbe(lookup);
+    return;
   }
   ProbeState state1;
   ProbeState state2;
@@ -411,17 +434,17 @@ void HashTable<ignoreNullKeys>::groupProbe(HashLookup& lookup) {
   auto rows = lookup.rows.data();
   for (; probeIndex + 4 <= numProbes; probeIndex += 4) {
     int32_t row = rows[probeIndex];
-    state1.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
+    state1.preProbe(*this, lookup.hashes[row], row);
     row = rows[probeIndex + 1];
-    state2.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
+    state2.preProbe(*this, lookup.hashes[row], row);
     row = rows[probeIndex + 2];
-    state3.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
+    state3.preProbe(*this, lookup.hashes[row], row);
     row = rows[probeIndex + 3];
-    state4.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
-    state1.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
-    state2.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
-    state3.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
-    state4.firstProbe<ProbeState::Operation::kInsert>(table_, 0);
+    state4.preProbe(*this, lookup.hashes[row], row);
+    state1.firstProbe<ProbeState::Operation::kInsert>(*this, 0);
+    state2.firstProbe<ProbeState::Operation::kInsert>(*this, 0);
+    state3.firstProbe<ProbeState::Operation::kInsert>(*this, 0);
+    state4.firstProbe<ProbeState::Operation::kInsert>(*this, 0);
     fullProbe<false>(lookup, state1, false);
     fullProbe<false>(lookup, state2, true);
     fullProbe<false>(lookup, state3, true);
@@ -429,9 +452,46 @@ void HashTable<ignoreNullKeys>::groupProbe(HashLookup& lookup) {
   }
   for (; probeIndex < numProbes; ++probeIndex) {
     int32_t row = rows[probeIndex];
-    state1.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
-    state1.firstProbe(table_, 0);
+    state1.preProbe(*this, lookup.hashes[row], row);
+    state1.firstProbe(*this, 0);
     fullProbe<false>(lookup, state1, false);
+  }
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::groupNormalizedKeyProbe(HashLookup& lookup) {
+  ProbeState state1;
+  ProbeState state2;
+  ProbeState state3;
+  ProbeState state4;
+  int32_t probeIndex = 0;
+  int32_t numProbes = lookup.rows.size();
+  auto rows = lookup.rows.data();
+  constexpr int32_t kKeyOffset =
+      -static_cast<int32_t>(sizeof(normalized_key_t));
+  for (; probeIndex + 4 <= numProbes; probeIndex += 4) {
+    int32_t row = rows[probeIndex];
+    state1.preProbe(*this, lookup.hashes[row], row);
+    row = rows[probeIndex + 1];
+    state2.preProbe(*this, lookup.hashes[row], row);
+    row = rows[probeIndex + 2];
+    state3.preProbe(*this, lookup.hashes[row], row);
+    row = rows[probeIndex + 3];
+    state4.preProbe(*this, lookup.hashes[row], row);
+    state1.firstProbe<ProbeState::Operation::kInsert>(*this, kKeyOffset);
+    state2.firstProbe<ProbeState::Operation::kInsert>(*this, kKeyOffset);
+    state3.firstProbe<ProbeState::Operation::kInsert>(*this, kKeyOffset);
+    state4.firstProbe<ProbeState::Operation::kInsert>(*this, kKeyOffset);
+    fullProbe<false, true>(lookup, state1, false);
+    fullProbe<false, true>(lookup, state2, true);
+    fullProbe<false, true>(lookup, state3, true);
+    fullProbe<false, true>(lookup, state4, true);
+  }
+  for (; probeIndex < numProbes; ++probeIndex) {
+    int32_t row = rows[probeIndex];
+    state1.preProbe(*this, lookup.hashes[row], row);
+    state1.firstProbe(*this, kKeyOffset);
+    fullProbe<false, true>(lookup, state1, false);
   }
 }
 
@@ -488,12 +548,11 @@ void HashTable<ignoreNullKeys>::arrayGroupProbe(HashLookup& lookup) {
 
 template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::joinProbe(HashLookup& lookup) {
+  if (kTrackLoads) {
+    numProbe_ += lookup.rows.size();
+  }
   if (hashMode_ == HashMode::kArray) {
-    for (auto row : lookup.rows) {
-      auto index = lookup.hashes[row];
-      DCHECK_LT(index, size_);
-      lookup.hits[row] = table_[index]; // NOLINT
-    }
+    arrayJoinProbe(lookup);
     return;
   }
   if (hashMode_ == HashMode::kNormalizedKey) {
@@ -510,17 +569,17 @@ void HashTable<ignoreNullKeys>::joinProbe(HashLookup& lookup) {
   ProbeState state4;
   for (; probeIndex + 4 <= numProbes; probeIndex += 4) {
     int32_t row = rows[probeIndex];
-    state1.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
+    state1.preProbe(*this, lookup.hashes[row], row);
     row = rows[probeIndex + 1];
-    state2.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
+    state2.preProbe(*this, lookup.hashes[row], row);
     row = rows[probeIndex + 2];
-    state3.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
+    state3.preProbe(*this, lookup.hashes[row], row);
     row = rows[probeIndex + 3];
-    state4.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
-    state1.firstProbe(table_, 0);
-    state2.firstProbe(table_, 0);
-    state3.firstProbe(table_, 0);
-    state4.firstProbe(table_, 0);
+    state4.preProbe(*this, lookup.hashes[row], row);
+    state1.firstProbe(*this, 0);
+    state2.firstProbe(*this, 0);
+    state3.firstProbe(*this, 0);
+    state4.firstProbe(*this, 0);
     fullProbe<true>(lookup, state1, false);
     fullProbe<true>(lookup, state2, false);
     fullProbe<true>(lookup, state3, false);
@@ -528,9 +587,51 @@ void HashTable<ignoreNullKeys>::joinProbe(HashLookup& lookup) {
   }
   for (; probeIndex < numProbes; ++probeIndex) {
     int32_t row = rows[probeIndex];
-    state1.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
-    state1.firstProbe(table_, 0);
+    state1.preProbe(*this, lookup.hashes[row], row);
+    state1.firstProbe(*this, 0);
     fullProbe<true>(lookup, state1, false);
+  }
+}
+
+template <bool ignoreNullKeys>
+void HashTable<ignoreNullKeys>::arrayJoinProbe(HashLookup& lookup) {
+  // Rows are nearly always consecutive.
+  auto& rows = lookup.rows;
+  auto hashes = lookup.hashes.data();
+  auto hits = lookup.hits.data();
+  auto numRows = rows.size();
+  int32_t i = 0;
+  constexpr int32_t kBatchSize = xsimd::batch<int64_t>::size;
+  constexpr int32_t kStep = kBatchSize * 2;
+  // We loop 2 vectors at a time for fewer switches. The rows are in practice
+  // always contiguous.
+  for (; i + kStep <= numRows; i += kStep) {
+    auto firstRow = rows[i];
+    if (rows[i + kStep - 1] - firstRow == kStep - 1) {
+      // kStep consecutive.
+      simd::gather(
+          reinterpret_cast<const int64_t*>(table_),
+          reinterpret_cast<const int64_t*>(hashes + firstRow))
+          .store_unaligned(reinterpret_cast<int64_t*>(hits) + firstRow);
+      simd::gather(
+          reinterpret_cast<const int64_t*>(table_),
+          reinterpret_cast<const int64_t*>(hashes + firstRow + kBatchSize))
+          .store_unaligned(
+              reinterpret_cast<int64_t*>(hits) + firstRow + kBatchSize);
+    } else {
+      for (auto j = i; j < i + kStep; ++j) {
+        auto row = rows[j];
+        auto index = hashes[row];
+        DCHECK(index < size_);
+        hits[row] = table_[index]; // NOLINT
+      }
+    }
+  }
+  for (; i < numRows; ++i) {
+    auto row = rows[i];
+    auto index = hashes[row];
+    DCHECK(index < size_);
+    hits[row] = table_[index]; // NOLINT
   }
 }
 
@@ -546,34 +647,31 @@ void HashTable<ignoreNullKeys>::joinNormalizedKeyProbe(HashLookup& lookup) {
   const uint64_t* keys = lookup.normalizedKeys.data();
   const uint64_t* hashes = lookup.hashes.data();
   char** hits = lookup.hits.data();
+  constexpr int32_t kKeyOffset =
+      -static_cast<int32_t>(sizeof(normalized_key_t));
   for (; probeIndex + 4 <= numProbes; probeIndex += 4) {
     int32_t row = rows[probeIndex];
-    state1.preProbe(tags_, sizeMask_, hashes[row], row);
+    state1.preProbe(*this, hashes[row], row);
     row = rows[probeIndex + 1];
-    state2.preProbe(tags_, sizeMask_, hashes[row], row);
+    state2.preProbe(*this, hashes[row], row);
     row = rows[probeIndex + 2];
-    state3.preProbe(tags_, sizeMask_, hashes[row], row);
+    state3.preProbe(*this, hashes[row], row);
     row = rows[probeIndex + 3];
-    state4.preProbe(tags_, sizeMask_, hashes[row], row);
-    state1.firstProbe(table_, 0);
-    state2.firstProbe(table_, 0);
-    state3.firstProbe(table_, 0);
-    state4.firstProbe(table_, 0);
-    hits[state1.row()] =
-        state1.joinNormalizedKeyFullProbe(tags_, table_, sizeMask_, keys);
-    hits[state2.row()] =
-        state2.joinNormalizedKeyFullProbe(tags_, table_, sizeMask_, keys);
-    hits[state3.row()] =
-        state3.joinNormalizedKeyFullProbe(tags_, table_, sizeMask_, keys);
-    hits[state4.row()] =
-        state4.joinNormalizedKeyFullProbe(tags_, table_, sizeMask_, keys);
+    state4.preProbe(*this, hashes[row], row);
+    state1.firstProbe(*this, kKeyOffset);
+    state2.firstProbe(*this, kKeyOffset);
+    state3.firstProbe(*this, kKeyOffset);
+    state4.firstProbe(*this, kKeyOffset);
+    hits[state1.row()] = state1.joinNormalizedKeyFullProbe(*this, keys);
+    hits[state2.row()] = state2.joinNormalizedKeyFullProbe(*this, keys);
+    hits[state3.row()] = state3.joinNormalizedKeyFullProbe(*this, keys);
+    hits[state4.row()] = state4.joinNormalizedKeyFullProbe(*this, keys);
   }
   for (; probeIndex < numProbes; ++probeIndex) {
     int32_t row = rows[probeIndex];
-    state1.preProbe(tags_, sizeMask_, lookup.hashes[row], row);
-    state1.firstProbe(table_, 0);
-    hits[row] =
-        state1.joinNormalizedKeyFullProbe(tags_, table_, sizeMask_, keys);
+    state1.preProbe(*this, lookup.hashes[row], row);
+    state1.firstProbe(*this, 0);
+    hits[row] = state1.joinNormalizedKeyFullProbe(*this, keys);
   }
 }
 
@@ -581,22 +679,35 @@ template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::allocateTables(uint64_t size) {
   VELOX_CHECK(bits::isPowerOfTwo(size), "Size is not a power of two: {}", size);
   if (size > 0) {
-    size_ = size;
-    sizeMask_ = size_ - 1;
-    sizeBits_ = __builtin_popcountll(sizeMask_);
+    setSize(size);
     constexpr auto kPageSize = memory::MappedMemory::kPageSize;
-    // The total size is 9 bytes per slot, 8 in the pointers table and 1 in the
-    // tags table.
-    auto numPages = bits::roundUp(size * 9, kPageSize) / kPageSize;
-    if (!rows_->mappedMemory()->allocateContiguous(
-            numPages, nullptr, tableAllocation_)) {
-      VELOX_FAIL("Could not allocate join/group by hash table");
+    if (kInterleaveRows) {
+      // The total size is 8 bytes per slot, in groups of 16 slots
+      // with 16 bytes of tags and 16 * 6 bytes of pointers and a
+      // padding of 16 bytes to round up the cache line.
+      auto numPages =
+          bits::roundUp(size * sizeof(char*), kPageSize) / kPageSize;
+      if (!rows_->mappedMemory()->allocateContiguous(
+              numPages, nullptr, tableAllocation_)) {
+        VELOX_FAIL("Could not allocate join/group by hash table");
+      }
+      tags_ = tableAllocation_.data<uint8_t>();
+      table_ = nullptr;
+      memset(tags_, 0, size_ * sizeof(char*));
+    } else {
+      // The total size is 9 bytes per slot, 8 in the pointers table and 1 in
+      // the tags table.
+      auto numPages = bits::roundUp(size * 9, kPageSize) / kPageSize;
+      if (!rows_->mappedMemory()->allocateContiguous(
+              numPages, nullptr, tableAllocation_)) {
+        VELOX_FAIL("Could not allocate join/group by hash table");
+      }
+      table_ = tableAllocation_.data<char*>();
+      tags_ = reinterpret_cast<uint8_t*>(table_ + size);
+      memset(tags_, 0, size_);
+      // Not strictly necessary to clear 'table_' but more debuggable.
+      memset(table_, 0, size_ * sizeof(char*));
     }
-    table_ = tableAllocation_.data<char*>();
-    tags_ = reinterpret_cast<uint8_t*>(table_ + size);
-    memset(tags_, 0, size_);
-    // Not strictly necessary to clear 'table_' but more debuggable.
-    memset(table_, 0, size_ * sizeof(char*));
   }
 }
 
@@ -604,7 +715,7 @@ template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::clear() {
   rows_->clear();
   if (hashMode_ != HashMode::kArray && tags_) {
-    memset(tags_, 0, size_);
+    memset(tags_, 0, kInterleaveRows ? size_ * sizeof(char*) : size_);
   }
   if (table_) {
     memset(table_, 0, sizeof(char*) * size_);
@@ -614,7 +725,7 @@ void HashTable<ignoreNullKeys>::clear() {
 
 template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::checkSize(int32_t numNew) {
-  if (!table_ || !size_) {
+  if (!tags_ || !size_) {
     // Initial guess of cardinality is double the first input batch or at
     // least 2K entries.
     // numDistinct_ is non-0 when switching from HashMode::kArray to regular
@@ -732,13 +843,16 @@ void HashTable<ignoreNullKeys>::parallelJoinBuild() {
       buildPartitionBounds_.begin(),
       buildPartitionBounds_.begin() + buildPartitionBounds_.capacity(),
       std::numeric_limits<int32_t>::max());
+  // The partitioning is in terms of ranges of tag vector index. The stride is
+  // different depending on kInterleaveRows.
+  int64_t tagIndexEnd = sizeMask_ + 1;
   for (auto i = 0; i < numPartitions; ++i) {
     // The bounds are rounded up to cache line size.
     buildPartitionBounds_[i] = bits::roundUp(
-        (size_ / numPartitions) * i,
+        (tagIndexEnd / numPartitions) * i,
         folly::hardware_destructive_interference_size);
   }
-  buildPartitionBounds_.back() = size_;
+  buildPartitionBounds_.back() = tagIndexEnd;
   std::vector<std::shared_ptr<AsyncSource<bool>>> partitionSteps;
   std::vector<std::shared_ptr<AsyncSource<bool>>> buildSteps;
   auto sync = folly::makeGuard([&]() {
@@ -787,7 +901,12 @@ void HashTable<ignoreNullKeys>::parallelJoinBuild() {
         false,
         hashes);
     insertForJoin(
-        overflows.data(), hashes.data(), overflows.size(), 0, size_, nullptr);
+        overflows.data(),
+        hashes.data(),
+        overflows.size(),
+        0,
+        tagIndexEnd,
+        nullptr);
     auto table = i == 0 ? this : otherTables_[i - 1].get();
     VELOX_CHECK_EQ(table->rows()->numRows(), table->numParallelBuildRows_);
   }
@@ -828,7 +947,7 @@ void HashTable<ignoreNullKeys>::partitionRows(
         buildPartitionBounds_.capacity() % xsimd::batch<int32_t>::size,
         "partition bounds must be padded to SIMD width");
     for (auto i = 0; i < numRows; ++i) {
-      auto index = ProbeState::tagsByteOffset(hashes[i], sizeMask_);
+      auto index = tagVectorOffset(hashes[i]);
       partitions[i] = findPartition(
           index, buildPartitionBounds_.data(), buildPartitionBounds_.size());
     }
@@ -892,22 +1011,63 @@ void HashTable<ignoreNullKeys>::insertForGroupBy(
       table_[index] = groups[i];
     }
   } else {
-    for (int32_t i = 0; i < numGroups; ++i) {
-      auto hash = hashes[i];
-      auto tagIndex = ProbeState::tagsByteOffset(hash, sizeMask_);
-      auto tagsInTable = BaseHashTable::loadTags(tags_, tagIndex);
-      for (;;) {
-        MaskType free =
-            ~simd::toBitMask(
-                BaseHashTable::TagVector::batch_bool_type(tagsInTable)) &
-            ProbeState::kFullMask;
+    constexpr int32_t kBatchSize = TagVector::size;
+    for (int32_t base = 0; base < numGroups; base += kBatchSize) {
+      char** pointers[kBatchSize];
+      auto batchEnd = std::min(base + kBatchSize, numGroups);
+      for (auto j = base; j < batchEnd; ++j) {
+        auto hash = hashes[j];
+        auto tagIndex = tagVectorOffset(hash);
+        auto tagsInTable = BaseHashTable::loadTags(tags_, tagIndex);
+        MaskType free = ~simd::toBitMask(
+            BaseHashTable::TagVector::batch_bool_type(tagsInTable));
         if (free) {
-          auto freeOffset = bits::getAndClearLastSetBit(free);
-          storeRowPointer(tagIndex + freeOffset, hash, groups[i]);
-          break;
+          int freeOffset = __builtin_ctz(free);
+          tags_[tagIndex + freeOffset] = BaseHashTable::hashTag(hash);
+          char** pointer;
+          if (kInterleaveRows) {
+            pointer = reinterpret_cast<char**>(
+                tags_ + tagIndex + sizeof(TagVector) +
+                kBytesInPointer * freeOffset);
+          } else {
+            pointer = table_ + tagIndex + freeOffset;
+          }
+          __builtin_prefetch(pointer);
+          pointers[j - base] = pointer;
+        } else {
+          pointers[j - base] = nullptr;
         }
-        tagIndex = (tagIndex + sizeof(TagVector)) & sizeMask_;
-        tagsInTable = loadTags(tags_, tagIndex);
+      }
+      for (auto j = base; j < batchEnd; ++j) {
+        auto pointer = pointers[j - base];
+        if (pointer) {
+          if (kInterleaveRows) {
+            auto previous =
+                reinterpret_cast<uint64_t>(*pointer) & ~kPointerMask;
+            *pointer = reinterpret_cast<char*>(
+                previous | reinterpret_cast<uint64_t>(groups[j]));
+          } else {
+            *pointer = groups[j];
+          }
+          continue;
+        }
+        // The place in the table was not determined on the first loop. Loop
+        // until finding a free tag.
+        auto hash = hashes[j] +
+            (kInterleaveRows ? kTagRowGroupSize : sizeof(TagVector));
+        auto tagIndex = tagVectorOffset(hash);
+        auto tagsInTable = BaseHashTable::loadTags(tags_, tagIndex);
+        for (;;) {
+          MaskType free = ~simd::toBitMask(
+              BaseHashTable::TagVector::batch_bool_type(tagsInTable));
+          if (free) {
+            auto freeOffset = bits::getAndClearLastSetBit(free);
+            storeRowPointer(tagIndex + freeOffset, hash, groups[j]);
+            break;
+          }
+          tagIndex = nextTagVectorOffset(tagIndex);
+          tagsInTable = loadTags(tagIndex);
+        }
       }
     }
   }
@@ -950,9 +1110,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
     std::vector<char*>* FOLLY_NULLABLE overflows) {
   if (hashMode_ == HashMode::kNormalizedKey) {
     state.fullProbe<ProbeState::Operation::kInsert>(
-        tags_,
-        table_,
-        sizeMask_,
+        *this,
         -static_cast<int32_t>(sizeof(normalized_key_t)),
         [&](char* group, int32_t /*row*/) {
           if (RowContainer::normalizedKey(group) ==
@@ -975,9 +1133,7 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
         extraCheck);
   } else {
     state.fullProbe<ProbeState::Operation::kInsert>(
-        tags_,
-        table_,
-        sizeMask_,
+        *this,
         0,
         [&](char* group, int32_t /*row*/) {
           if (compareKeys(group, inserted)) {
@@ -1021,8 +1177,9 @@ void HashTable<ignoreNullKeys>::insertForJoin(
 
   ProbeState state1;
   for (auto i = 0; i < numGroups; ++i) {
-    state1.preProbe(tags_, sizeMask_, hashes[i], i);
-    state1.firstProbe(table_, 0);
+    state1.preProbe(*this, hashes[i], i);
+    state1.firstProbe(*this, 0);
+
     buildFullProbe(
         state1,
         hashes[i],
@@ -1270,8 +1427,8 @@ void HashTable<ignoreNullKeys>::decideHashMode(int32_t numNew) {
     return;
   }
   if (hashers_.size() == 1 && distinctsWithReserve > 10000) {
-    // A single part group by that does not go by range or become an array does
-    // not make sense as a normalized key unless it is very small.
+    // A single part group by that does not go by range or become an array
+    // does not make sense as a normalized key unless it is very small.
     setHashMode(HashMode::kHash, numNew);
     return;
   }
@@ -1315,6 +1472,30 @@ std::string HashTable<ignoreNullKeys>::toString() {
   }
   for (auto& hasher : hashers_) {
     out << hasher->toString();
+  }
+  if (kTrackLoads) {
+    out << std::endl;
+    out << fmt::format(
+        "{} probes {} tag loads {} row loads {} hits",
+        numProbe_,
+        numTagLoad_,
+        numRowLoad_,
+        numHit_);
+  }
+  if (hashMode_ != HashMode::kArray) {
+    // Count of groups indexed by number of non-empty slots.
+    int32_t numGroups[sizeof(TagVector) + 1] = {};
+    int32_t tagIndex = 0;
+    for (auto i = 0; i < size_; i += sizeof(TagVector)) {
+      auto tags = loadTags(tagIndex);
+      auto filled = simd::toBitMask(tags != TagVector::broadcast(0));
+      ++numGroups[__builtin_popcount(filled)];
+      tagIndex = nextTagVectorOffset(tagIndex);
+    }
+    out << std::endl;
+    for (auto i = 0; i < sizeof(numGroups) / sizeof(numGroups[0]); ++i) {
+      out << numGroups[i] << " groups with " << i << " entries" << std::endl;
+    }
   }
   return out.str();
 }
@@ -1595,13 +1776,11 @@ void HashTable<ignoreNullKeys>::eraseWithHashes(
 
     ProbeState state;
     for (auto i = 0; i < numRows; ++i) {
-      state.preProbe(tags_, sizeMask_, hashes[i], i);
+      state.preProbe(*this, hashes[i], i);
 
-      state.firstProbe<ProbeState::Operation::kErase>(table_, 0);
+      state.firstProbe<ProbeState::Operation::kErase>(*this, 0);
       state.fullProbe<ProbeState::Operation::kErase>(
-          tags_,
-          table_,
-          sizeMask_,
+          *this,
           0,
           [&](const char* group, int32_t row) { return rows[row] == group; },
           [&](int32_t /*index*/, int32_t /*row*/) { return nullptr; },

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/base/Portability.h"
 #include "velox/common/memory/MappedMemory.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/Operator.h"
@@ -252,12 +253,6 @@ class BaseHashTable {
 #endif
   }
 
-  /// Loads the payload row pointer corresponding to the tag at 'index'.
-  static char* FOLLY_NULLABLE
-  loadRow(char* FOLLY_NULLABLE* FOLLY_NULLABLE table, int32_t index) {
-    return table[index];
-  }
-
  protected:
   virtual void setHashMode(HashMode mode, int32_t numNew) = 0;
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
@@ -269,6 +264,26 @@ class ProbeState;
 template <bool ignoreNullKeys>
 class HashTable : public BaseHashTable {
  public:
+  // Enables debug stats for collisions. Should be false for normal operation.
+#ifdef NDEBUG
+  static constexpr bool kTrackLoads = false;
+#else
+  static constexpr bool kTrackLoads = true;
+#endif
+  // If true, tags and pointers to payload are interleaved (16x8 bit
+  // tags, 16*48bit pointers) like in F14. If false, tags and pointers
+  // are stored in separate arrays (like absl Swiss table). Join
+  // tables that miss frequently and have tags but not tags and
+  // pointers fitting in cache may benefit from
+  // non-interleaved. Interleaved tables are slightly smaller and are
+  // more local since half the time the tag and corresponding payload
+  // pointer are in the same cache line.
+  static constexpr bool kInterleaveRows = true;
+
+  // size of a group of 16 tags and 16 48-bit pointers to the
+  // corresponding rows. Applies to interleaved mode.
+  static constexpr uint64_t kTagRowGroupSize = 128;
+
   // Can be used for aggregation or join. An aggregation hash table
   // can also double as a join build side. 'isJoinBuild' is true if
   // this is a build side. 'allowDuplicates' is false for a build side if
@@ -315,8 +330,6 @@ class HashTable : public BaseHashTable {
         hasProbedFlag,
         memory);
   }
-
-  virtual ~HashTable() override = default;
 
   void groupProbe(HashLookup& lookup) override;
 
@@ -404,6 +417,10 @@ class HashTable : public BaseHashTable {
   std::string toString() override;
 
  private:
+  // When interleaving tags ad pointers we store 48 bits per pointer.
+  static constexpr int32_t kBytesInPointer = 6;
+  static constexpr uint64_t kPointerMask = bits::lowMask(8 * kBytesInPointer);
+
   // Returns the number of entries after which the table gets rehashed.
   static uint64_t rehashSize(int64_t size) {
     // This implements the F14 load factor: Resize if less than 1/8 unoccupied.
@@ -521,6 +538,13 @@ class HashTable : public BaseHashTable {
   // Assigns a partition to each row of 'subtable' in RowPartitions of
   // subtable's RowContainer. If 'hashMode_' is kNormalizedKeys, records the
   // normalized key of each row below the row in its container.
+  void partitionRows(
+      HashTable<ignoreNullKeys>& subtable,
+      uint8_t numPartitions);
+
+  // Assigns a partition to each row of 'subtable' in RowPartitions of
+  // subtable's RowContainer. If 'hashMode_' is kNormalizedKeys, records the
+  // normalized key of each row below the row in its container.
   void partitionRows(HashTable<ignoreNullKeys>& subtable);
 
   // Calculates hashes for 'rows' and returns them in 'hashes'. If
@@ -547,8 +571,14 @@ class HashTable : public BaseHashTable {
       const char* FOLLY_NULLABLE group,
       const char* FOLLY_NULLABLE inserted);
 
-  template <bool isJoin>
+  template <bool isJoin, bool isNormalizedKey = false>
   void fullProbe(HashLookup& lookup, ProbeState& state, bool extraCheck);
+
+  // Shortcut path for group by with normalized keys.
+  void groupNormalizedKeyProbe(HashLookup& lookup);
+
+  // Array probe with SIMD.
+  void arrayJoinProbe(HashLookup& lookup);
 
   // Shortcut for probe with normalized keys.
   void joinNormalizedKeyProbe(HashLookup& lookup);
@@ -591,6 +621,72 @@ class HashTable : public BaseHashTable {
     return isJoinBuild_ ? 0 : 50;
   }
 
+  // Sets the size and dependent bit masks. The size must be a power
+  // of two and gives the number of tag bytes and the corresponding
+  // row pointers in the table.
+  void setSize(int32_t size) {
+    size_ = size;
+    if (kInterleaveRows) {
+      sizeMask_ = (size_ * sizeof(void*)) - 1;
+      sizeBits_ = __builtin_popcountll(sizeMask_);
+      tagOffsetMask_ = sizeMask_ & ~(kTagRowGroupSize - 1);
+    } else {
+      sizeMask_ = size_ - 1;
+      sizeBits_ = __builtin_popcountll(sizeMask_);
+      VELOX_CHECK_LE(
+          sizeBits_, 31, "Exceeding signed int range for hash table indices");
+      tagOffsetMask_ = sizeMask_ & ~(sizeof(TagVector) - 1);
+    }
+  }
+
+  // Returns the offset in bytes of the tag word for 'hash'. The offset is
+  // from 'tags_'.
+  int32_t tagVectorOffset(uint64_t hash) const {
+    return hash & tagOffsetMask_;
+  }
+
+  // Returns the offset of the next tag vector from 'offset'. Wraps around at
+  // the end of the table.
+  int32_t nextTagVectorOffset(int32_t offset) const {
+    return sizeMask_ &
+        (offset + (kInterleaveRows ? kTagRowGroupSize : sizeof(TagVector)));
+  }
+
+  TagVector loadTags(int32_t tagIndex) const {
+    return BaseHashTable::loadTags(tags_, tagIndex);
+  }
+
+  // Returns the row pointer for the 'tagIndex'th tag in the tag vector at
+  // offset 'tagVectorOffset'.
+  char* row(int32_t tagVectorOffset, int32_t tagIndex) const {
+    if (kInterleaveRows) {
+      return reinterpret_cast<char*>(
+          kPointerMask &
+          *reinterpret_cast<uint64_t*>(
+              tags_ + tagVectorOffset + sizeof(TagVector) +
+              kBytesInPointer * tagIndex));
+    }
+    return table_[tagVectorOffset + tagIndex];
+  }
+
+  void incrementTagLoad() const {
+    if (kTrackLoads) {
+      ++numTagLoad_;
+    }
+  }
+
+  void incrementRowLoad() const {
+    if (kTrackLoads) {
+      ++numRowLoad_;
+    }
+  }
+
+  void incrementHit() const {
+    if (kTrackLoads) {
+      ++numHit_;
+    }
+  }
+
   int8_t sizeBits_;
   bool isJoinBuild_ = false;
 
@@ -598,6 +694,10 @@ class HashTable : public BaseHashTable {
   // the join can be cardinality increasing. Atomic for tsan because
   // many threads can set this.
   std::atomic<bool> hasDuplicates_{false};
+
+  // True if tombstones need to be checked. An erase from a group with no
+  // empties makes a tombstone.
+  bool hasTombstones_{false};
 
   // Offset of next row link for join build side, 0 if none. Copied
   // from 'rows_'.
@@ -607,11 +707,32 @@ class HashTable : public BaseHashTable {
   memory::MappedMemory::ContiguousAllocation tableAllocation_;
   int64_t size_ = 0;
   int64_t sizeMask_ = 0;
+
+  // Mask to and to hash number to get offset of the corresponding
+  // tag vector from the start of the tag vectors array. For
+  // interleaved mode, the offset is in the combined tags/row pointers
+  // array.
+  int64_t tagOffsetMask_{0};
   int64_t numDistinct_ = 0;
   HashMode hashMode_ = HashMode::kArray;
   // Owns the memory of multiple build side hash join tables that are
   // combined into a single probe hash table.
   std::vector<std::unique_ptr<HashTable<ignoreNullKeys>>> otherTables_;
+  // Statistics maintained if kTrackCollisions is set.
+
+  // Number of times a row is looked up or inserted.
+  mutable asan_atomic<int64_t> numProbe_{0};
+
+  // Number of times a word of 16 tags is accessed. at least once per probe.
+  mutable asan_atomic<int64_t> numTagLoad_{0};
+
+  // Number of times a row of payload is accessed. At leadst once per hit.
+  mutable asan_atomic<int64_t> numRowLoad_{0};
+
+  // Number of times a match is found.
+  mutable asan_atomic<int64_t> numHit_{0};
+
+  friend class ProbeState;
 
   // Bounds of independently buildable index ranges in the table. The
   // range of partition i starts at [i] and ends at [i +1]. Bounds are multiple


### PR DESCRIPTION
Hash table variants and optimizations

Introduces an alternative F14 style interleave layour for
HashTable. This layout alternates tags and pointers to payload. Each
group takes two cache lines: 16 bytes of tags, 8 * 48 bytes of
pointers in the first cache line and 8*48 bits of pointers in the
second cache line. A hash table that is expected to hit frequently,
i.e. a group by table, will benefit from this layout since the tags
and pointers most often share one cache miss and always share the TLB
lookup.

Adds optional counters for hash lookups and collisions.

simplifies the hashProbe concept by passing the table as an argument
as opposed to different fields of the table.


Uses SIMD for an array hash table probe. Previously this was limited
to group by tables.



Before this change, optimized build on devserver

TPCH 30G dataset in Parquet.
./tpch --data_path=tpchpq30links  --num_splits_per_file=4 --num_drivers=14

velox/benchmarks/tpch/TpchBenchmark.cpp     relative  time/iter   iters/s
============================================================================
q1                                                           1.27s   785.53m
q3                                                           1.95s   512.91m
q5                                                           2.17s   461.62m
q6                                                           1.39s   720.91m
q7                                                           2.30s   435.01m
q8                                                           2.35s   424.85m
q9                                                           6.93s   144.33m
q10                                                          5.96s   167.90m
q12                                                          1.92s   520.29m
q13                                                         10.47s    95.55m
q14                                                          2.22s   450.48m
q15                                                          2.04s   489.87m
q16                                                       998.81ms      1.00
q18                                                          3.97s   251.97m
q19                                                          2.15s   465.10m
q22                                                          3.04s   329.25m

real	0m52.517s
user	5m4.079s
sys	1m41.267s

After this change, all hash tables interleaved

q1                                                           1.31s   761.65m
q3                                                           1.92s   521.60m
q5                                                           2.53s   395.92m
q6                                                        369.27ms      2.71
q7                                                           1.34s   745.68m
q8                                                           2.42s   413.91m
q9                                                           6.12s   163.30m
q10                                                          6.34s   157.69m
q12                                                          1.97s   508.39m
q13                                                          8.73s   114.58m
q14                                                          2.28s   439.46m
q15                                                          1.06s   939.13m
q16                                                          1.28s   782.58m
q18                                                          3.98s   251.51m
q19                                                          2.13s   469.96m
q22                                                          2.87s   348.84m

real	0m47.766s
user	4m55.719s
sys	1m49.795s


