### PR TITLE
Use PROJECT_SOURCE_DIR as the substrait proto_path

### DIFF
--- a/velox/substrait/CMakeLists.txt
+++ b/velox/substrait/CMakeLists.txt
@@ -34,8 +34,9 @@ get_filename_component(PROTO_DIR ${substrait_proto_directory}/, DIRECTORY)
 add_custom_command(
   OUTPUT ${PROTO_OUTPUT_FILES}
   COMMAND
-    ${Protobuf_PROTOC_EXECUTABLE} --proto_path ${CMAKE_SOURCE_DIR}/ --proto_path
-    ${Protobuf_INCLUDE_DIR} --cpp_out ${CMAKE_SOURCE_DIR} ${PROTO_FILES}
+    ${Protobuf_PROTOC_EXECUTABLE} --proto_path ${PROJECT_SOURCE_DIR}/
+    --proto_path ${Protobuf_INCLUDE_DIR} --cpp_out ${PROJECT_SOURCE_DIR}
+    ${PROTO_FILES}
   DEPENDS ${PROTO_DIR}
   COMMENT "Running PROTO compiler"
   VERBATIM)


### PR DESCRIPTION
`velox/substrait/CMakeLists.txt` uses `CMAKE_SOURCE_DIR` as the `proto_path`, which is `$VeloxDir`. It does not work when it is used as a submodule (eg, `add_subdirectory(velox)`), in which the `proto_path` is `$ProjectDir` and has one more level relative directory  to make the protobuf compilation fail. For example the following imports in the algebra.proto will fail,

```protobuf
import "velox/substrait/proto/substrait/extensions/extensions.proto";
import "velox/substrait/proto/substrait/type.proto";
```

`Use PROJECT_SOURCE_DIR` should be more robust and works fine in both velox project, and in the scenario that other projects use velox as a submodule that the `proto_path` would be `$ProjectDir/velox`.