### PR TITLE
[Velox] Remove velox_vector_test_lib from link list of velox_exec_test_lib

### DIFF
--- a/velox/examples/CMakeLists.txt
+++ b/velox/examples/CMakeLists.txt
@@ -37,7 +37,8 @@ target_link_libraries(
   velox_exec
   velox_exec_test_lib
   velox_hive_connector
-  velox_memory)
+  velox_memory
+  velox_vector_test_lib)
 
 add_executable(velox_example_scan_orc ScanOrc.cpp)
 

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -44,5 +44,4 @@ target_link_libraries(
   velox_tpch_connector
   velox_presto_serializer
   velox_functions_prestosql
-  velox_aggregates
-  velox_vector_test_lib)
+  velox_aggregates)


### PR DESCRIPTION
velox_vector_test_lib was added to the linked libraries of
velox_exec_test_lib recently, but is not used anymore.