### PR TITLE
Move the ownership of driver executor out of QueryCtx

### DIFF
--- a/velox/core/tests/TestQueryConfig.cpp
+++ b/velox/core/tests/TestQueryConfig.cpp
@@ -26,8 +26,7 @@ using ::facebook::velox::core::QueryCtx;
 TEST(TestQueryConfig, emptyConfig) {
   std::unordered_map<std::string, std::string> configData;
   auto queryCtxConfig = std::make_shared<MemConfig>(configData);
-  auto queryCtx = std::make_shared<QueryCtx>(
-      std::shared_ptr<folly::Executor>(nullptr), queryCtxConfig);
+  auto queryCtx = std::make_shared<QueryCtx>(nullptr, queryCtxConfig);
   const QueryConfig& config = queryCtx->config();
 
   ASSERT_FALSE(config.codegenEnabled());
@@ -41,8 +40,7 @@ TEST(TestQueryConfig, setConfig) {
       {{QueryConfig::kCodegenEnabled, "true"},
        {QueryConfig::kCodegenConfigurationFilePath, path}});
   auto queryCtxConfig = std::make_shared<MemConfig>(configData);
-  auto queryCtx = std::make_shared<QueryCtx>(
-      std::shared_ptr<folly::Executor>(nullptr), queryCtxConfig);
+  auto queryCtx = std::make_shared<QueryCtx>(nullptr, queryCtxConfig);
   const QueryConfig& config = queryCtx->config();
 
   ASSERT_TRUE(config.codegenEnabled());

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -794,7 +794,7 @@ TEST_F(AggregationTest, partialAggregationMaybeReservationReleaseCheck) {
   const int64_t kMaxUserMemoryUsage = 2 * kMaxPartialMemoryUsage;
   // Make sure partial aggregation runs out of memory after first batch.
   CursorParameters params;
-  params.queryCtx = core::QueryCtx::createForTest();
+  params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   params.queryCtx->setConfigOverridesUnsafe({
       {QueryConfig::kMaxPartialAggregationMemory,
        std::to_string(kMaxPartialMemoryUsage)},
@@ -859,7 +859,7 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
     SCOPED_TRACE(testData.debugString());
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = core::QueryCtx::createForTest();
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->pool()->setMemoryUsageTracker(
         velox::memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
     auto results = AssertQueryBuilder(
@@ -964,7 +964,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
             .copyResults(pool_.get());
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = core::QueryCtx::createForTest();
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->pool()->setMemoryUsageTracker(
         velox::memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
 
@@ -1084,7 +1084,7 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
           .copyResults(pool_.get());
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->pool()->setMemoryUsageTracker(
       velox::memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
 

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -448,10 +448,11 @@ TEST_F(DriverTest, pause) {
       [](int64_t num) { return num % 10 > 0; },
       &hits);
   params.maxDrivers = 10;
-  params.queryCtx =
-      core::QueryCtx::createForTest(std::make_shared<core::MemConfig>(
+  params.queryCtx = std::make_shared<core::QueryCtx>(
+      executor_.get(),
+      // Make sure CPU usage tracking is enabled.
+      std::make_shared<core::MemConfig>(
           std::unordered_map<std::string, std::string>{
-              // Make sure CPU usage tracking is enabled.
               {core::QueryConfig::kOperatorTrackCpuUsage, "true"}}));
   int32_t numRead = 0;
   readResults(params, ResultOperation::kPause, 370'000'000, &numRead);

--- a/velox/exec/tests/MemoryCapExceededTest.cpp
+++ b/velox/exec/tests/MemoryCapExceededTest.cpp
@@ -67,7 +67,7 @@ TEST_F(MemoryCapExceededTest, singleDriver) {
                   .singleAggregation({"c0"}, {"sum(p1)"})
                   .orderBy({"c0"}, false)
                   .planNode();
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->pool()->setMemoryUsageTracker(
       velox::memory::MemoryUsageTracker::create(
           kMaxBytes, kMaxBytes, kMaxBytes));
@@ -112,7 +112,7 @@ TEST_F(MemoryCapExceededTest, multipleDrivers) {
                   .values(data, true)
                   .singleAggregation({"c0"}, {"sum(c1)"})
                   .planNode();
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->pool()->setMemoryUsageTracker(
       velox::memory::MemoryUsageTracker::create(
           kMaxBytes, kMaxBytes, kMaxBytes));

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -26,16 +26,16 @@ class MergeJoinTest : public HiveConnectorTestBase {
  protected:
   using OperatorTestBase::assertQuery;
 
-  static CursorParameters makeCursorParameters(
+  CursorParameters makeCursorParameters(
       const std::shared_ptr<const core::PlanNode>& planNode,
       uint32_t preferredOutputBatchSize) {
-    auto queryCtx = core::QueryCtx::createForTest();
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kCreateEmptyFiles, "true"}});
 
     CursorParameters params;
     params.planNode = planNode;
-    params.queryCtx = core::QueryCtx::createForTest();
+    params.queryCtx = queryCtx;
     params.queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kPreferredOutputBatchSize,
           std::to_string(preferredOutputBatchSize)}});

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -176,7 +176,7 @@ TEST_F(MergeTest, offByOne) {
 
   CursorParameters params;
   params.planNode = plan;
-  params.queryCtx = core::QueryCtx::createForTest();
+  params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   params.queryCtx->setConfigOverridesUnsafe(
       {{core::QueryConfig::kPreferredOutputBatchSize, "6"}});
   assertQueryOrdered(params, "VALUES (0), (1), (2), (3), (4), (5), (10)", {0});

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -40,8 +40,8 @@ class MultiFragmentTest : public HiveConnectorTestBase {
       const std::string& taskId,
       std::shared_ptr<const core::PlanNode> planNode,
       int destination) {
-    auto queryCtx = core::QueryCtx::createForTest(
-        std::make_shared<core::MemConfig>(configSettings_));
+    auto queryCtx = std::make_shared<core::QueryCtx>(
+        executor_.get(), std::make_shared<core::MemConfig>(configSettings_));
     core::PlanFragment planFragment{planNode};
     return std::make_shared<Task>(
         taskId, std::move(planFragment), destination, std::move(queryCtx));

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -164,7 +164,7 @@ class OrderByTest : public OperatorTestBase {
     {
       SCOPED_TRACE("run with spilling");
       auto spillDirectory = exec::test::TempDirectoryPath::create();
-      auto queryCtx = core::QueryCtx::createForTest();
+      auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
       queryCtx->setConfigOverridesUnsafe({
           {core::QueryConfig::kTestingSpillPct, "100"},
           {core::QueryConfig::kSpillEnabled, "true"},
@@ -390,7 +390,7 @@ TEST_F(OrderByTest, outputBatchSize) {
                     .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
                     .capturePlanNodeId(orderById)
                     .planNode();
-    auto queryCtx = core::QueryCtx::createForTest();
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kPreferredOutputBatchSize,
           std::to_string(testData.preferredOutBatchSize)}});
@@ -423,7 +423,7 @@ TEST_F(OrderByTest, spill) {
                   .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
                   .planNode();
   auto spillDirectory = exec::test::TempDirectoryPath::create();
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   constexpr int64_t kMaxBytes = 20LL << 20; // 20 MB
   queryCtx->pool()->setMemoryUsageTracker(
       memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
@@ -475,7 +475,7 @@ TEST_F(OrderByTest, spillWithMemoryLimit) {
     SCOPED_TRACE(testData.debugString());
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryCtx = core::QueryCtx::createForTest();
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->pool()->setMemoryUsageTracker(
         memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
     auto results =

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -54,7 +54,10 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
                                 BatchMaker::createBatch(rowType, 100, *pool_))})
                             .planFragment();
     auto task = std::make_shared<Task>(
-        taskId, std::move(planFragment), 0, core::QueryCtx::createForTest());
+        taskId,
+        std::move(planFragment),
+        0,
+        std::make_shared<core::QueryCtx>(executor_.get()));
 
     bufferManager_->initializeTask(task, false, numDestinations, numDrivers);
     return task;
@@ -224,6 +227,9 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
     EXPECT_FALSE(receivedData) << "for destination " << destination;
   }
 
+  std::shared_ptr<folly::Executor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency())};
   std::unique_ptr<facebook::velox::memory::ScopedMemoryPool> pool_;
   memory::MappedMemory* mappedMemory_;
   std::shared_ptr<PartitionedOutputBufferManager> bufferManager_;

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -27,12 +27,12 @@ class StreamingAggregationTest : public OperatorTestBase {
     registerSumNonPODAggregate("sumnonpod");
   }
 
-  static CursorParameters makeCursorParameters(
+  CursorParameters makeCursorParameters(
       const std::shared_ptr<const core::PlanNode>& planNode,
       uint32_t preferredOutputBatchSize) {
     CursorParameters params;
     params.planNode = planNode;
-    params.queryCtx = core::QueryCtx::createForTest();
+    params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     params.queryCtx->setConfigOverridesUnsafe(
         {{core::QueryConfig::kPreferredOutputBatchSize,
           std::to_string(preferredOutputBatchSize)}});

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1914,7 +1914,7 @@ TEST_F(TableScanTest, groupedExecutionWithOutputBuffer) {
           .planFragment();
   planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
   planFragment.numSplitGroups = 10;
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   auto task = std::make_shared<exec::Task>(
       "0", std::move(planFragment), 0, std::move(queryCtx));
   // 3 drivers max and 1 concurrent split group.

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -242,19 +242,18 @@ TEST_F(TableWriteTest, writeEmptyFile) {
                       "rows")
                   .planNode();
 
-  auto execute = [](const std::shared_ptr<const core::PlanNode>& plan,
-                    std::shared_ptr<core::QueryCtx> queryCtx =
-                        core::QueryCtx::createForTest()) {
+  auto execute = [&](const std::shared_ptr<const core::PlanNode>& plan,
+                     std::shared_ptr<core::QueryCtx> queryCtx) {
     CursorParameters params;
     params.planNode = plan;
     params.queryCtx = queryCtx;
     readCursor(params, [&](Task* task) { task->noMoreSplits("0"); });
   };
 
-  execute(plan);
+  execute(plan, std::make_shared<core::QueryCtx>(executor_.get()));
   ASSERT_TRUE(fs::is_empty(outputDirectory->path));
 
-  auto queryCtx = core::QueryCtx::createForTest();
+  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->setConfigOverridesUnsafe(
       {{core::QueryConfig::kCreateEmptyFiles, "true"}});
   execute(plan, queryCtx);

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -87,7 +87,10 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
                   .planFragment();
 
   exec::Task task(
-      "task-1", std::move(plan), 0, core::QueryCtx::createForTest());
+      "task-1",
+      std::move(plan),
+      0,
+      std::make_shared<core::QueryCtx>(executor_.get()));
 
   // Add split for the source node.
   task.addSplit("0", exec::Split(folly::copy(connectorSplit)));
@@ -136,7 +139,10 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
           .planFragment();
 
   exec::Task valuesTask(
-      "task-2", std::move(plan), 0, core::QueryCtx::createForTest());
+      "task-2",
+      std::move(plan),
+      0,
+      std::make_shared<core::QueryCtx>(executor_.get()));
   errorMessage =
       "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 0 doesn't refer to such plan node.";
   VELOX_ASSERT_THROW(
@@ -158,7 +164,11 @@ TEST_F(TaskTest, duplicatePlanNodeIds) {
                   .planFragment();
 
   VELOX_ASSERT_THROW(
-      exec::Task("task-1", std::move(plan), 0, core::QueryCtx::createForTest()),
+      exec::Task(
+          "task-1",
+          std::move(plan),
+          0,
+          std::make_shared<core::QueryCtx>(executor_.get())),
       "Plan node IDs must be unique. Found duplicate ID: 0.")
 }
 
@@ -676,7 +686,7 @@ DEBUG_ONLY_TEST_F(TaskTest, outputDriverFinishEarly) {
 
   CursorParameters params;
   params.planNode = plan;
-  params.queryCtx = core::QueryCtx::createForTest();
+  params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   params.queryCtx->setConfigOverridesUnsafe(
       {{core::QueryConfig::kPreferredOutputBatchSize, "1"}});
   auto task = assertQueryOrdered(params, "VALUES (0)", {0});

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -96,7 +96,11 @@ class VeloxIn10MinDemo : public VectorTestBase {
   /// Run the demo.
   void run();
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  std::shared_ptr<folly::Executor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency())};
+  std::shared_ptr<core::QueryCtx> queryCtx_{
+      std::make_shared<core::QueryCtx>(executor_.get())};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
 };

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -42,7 +42,8 @@ AssertQueryBuilder::AssertQueryBuilder(
 AssertQueryBuilder::AssertQueryBuilder(DuckDbQueryRunner& duckDbQueryRunner)
     : duckDbQueryRunner_{&duckDbQueryRunner} {}
 
-AssertQueryBuilder::AssertQueryBuilder(const core::PlanNodePtr& plan) {
+AssertQueryBuilder::AssertQueryBuilder(const core::PlanNodePtr& plan)
+    : duckDbQueryRunner_(nullptr) {
   params_.planNode = plan;
 }
 
@@ -182,7 +183,9 @@ AssertQueryBuilder::readCursor() {
 
   if (!configs_.empty()) {
     if (!params_.queryCtx) {
-      params_.queryCtx = core::QueryCtx::createForTest();
+      // NOTE: the destructor of 'executor_' will wait for all the async task
+      // activities to finish on AssertQueryBuilder dtor.
+      params_.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     }
     params_.queryCtx->setConfigOverridesUnsafe(std::move(configs_));
   }

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -101,15 +101,18 @@ class AssertQueryBuilder {
 
   /// Run the query and collect all results into a single vector. Throws if
   /// query returns empty result.
-  RowVectorPtr copyResults(memory::MemoryPool* pool);
+  RowVectorPtr copyResults(memory::MemoryPool* FOLLY_NONNULL pool);
 
  private:
   std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
   readCursor();
 
+  // Used by the created task as the default driver executor.
+  std::unique_ptr<folly::Executor> executor_{
+      new folly::CPUThreadPoolExecutor(std::thread::hardware_concurrency())};
+  DuckDbQueryRunner* FOLLY_NULLABLE const duckDbQueryRunner_;
   CursorParameters params_;
   std::unordered_map<std::string, std::string> configs_;
   std::unordered_map<core::PlanNodeId, std::vector<Split>> splits_;
-  DuckDbQueryRunner* duckDbQueryRunner_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -113,7 +113,11 @@ TaskCursor::TaskCursor(const CursorParameters& params)
   if (params.queryCtx) {
     queryCtx = params.queryCtx;
   } else {
-    queryCtx = core::QueryCtx::createForTest();
+    // NOTE: the destructor of 'executor_' will wait for all the async task
+    // activities to finish on TaskCursor destruction.
+    executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(
+        std::thread::hardware_concurrency());
+    queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   }
 
   queue_ = std::make_shared<TaskQueue>(params.bufferedBytes);

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -127,14 +127,17 @@ class TaskCursor {
   }
 
  private:
+  static std::atomic<int32_t> serial_;
+
   const int32_t maxDrivers_;
   const int32_t numConcurrentSplitGroups_;
   const int32_t numSplitGroups_;
+
+  std::shared_ptr<folly::Executor> executor_;
   bool started_ = false;
   std::shared_ptr<TaskQueue> queue_;
   std::shared_ptr<exec::Task> task_;
   RowVectorPtr current_;
-  static std::atomic<int32_t> serial_;
   bool atEnd_{false};
 };
 

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -105,7 +105,7 @@ class CodegenTestCore {
             useSymbolForArithmetic_,
             eventSequence_);
     pool_ = memory::getDefaultScopedMemoryPool();
-    queryCtx_ = core::QueryCtx::createForTest();
+    queryCtx_ = std::make_shared<core::QueryCtx>(executor_.get());
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
 
     parse::registerTypeResolver();
@@ -281,6 +281,9 @@ class CodegenTestCore {
     return failed;
   }
 
+  std::shared_ptr<folly::Executor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency())};
   std::unique_ptr<CodegenCompiledExpressionTransform> codegenTransformation_;
   std::unique_ptr<facebook::velox::memory::MemoryPool> pool_;
   std::unique_ptr<core::ExecCtx> execCtx_;

--- a/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
@@ -145,7 +145,7 @@ class SimpleAggregatesBenchmark : public HiveConnectorTestBase {
         "t",
         std::move(plan),
         0,
-        core::QueryCtx::createForTest(),
+        std::make_shared<core::QueryCtx>(executor_.get()),
         [&](auto vector, auto* /*future*/) {
           if (vector) {
             numResultRows += vector->size();

--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -251,7 +251,7 @@ TEST_F(ApproxPercentileTest, largeWeightsGroupBy) {
 TEST_F(ApproxPercentileTest, partialFull) {
   // Make sure partial aggregation runs out of memory after first batch.
   CursorParameters params;
-  params.queryCtx = core::QueryCtx::createForTest();
+  params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   params.queryCtx->setConfigOverridesUnsafe({
       {core::QueryConfig::kMaxPartialAggregationMemory, "300000"},
   });

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -253,7 +253,8 @@ class FunctionBaseTest : public testing::Test,
     return result[0];
   }
 
-  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::createForTest()};
+  std::shared_ptr<core::QueryCtx> queryCtx_{
+      std::make_shared<core::QueryCtx>(executor_.get())};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   parse::ParseOptions options_;
 

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -15,6 +15,9 @@
  */
 #pragma once
 
+#include <folly/Executor.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
@@ -704,6 +707,9 @@ class VectorTestBase {
   std::unique_ptr<memory::MemoryPool> pool_{
       memory::getDefaultScopedMemoryPool()};
   velox::test::VectorMaker vectorMaker_{pool_.get()};
+  std::shared_ptr<folly::Executor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency())};
 };
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
There is a deadlock in async Task destruction code path:
The last driver destruction runs executed by the driver thread
triggers the task destruction. The task destruction drops the
last reference on the query context. The query context destruction
drops the last reference on the driver thread pool. The driver
thread pool destruction blocks to wait for the queued callbacks to
finish and the driver destruction is current running callback. So
this forms a circle dependency and task destruction hangs forever.
This PR fixes the problem by moving the ownership of the driver
thread pool out of query context and let the user like Presto CPP
to own the driver executor so the task destruction will not block on
the driver executor's destruction to break the dependency circle.

- Remove QueryCtx::createForTest method
- Remove the hack in Task destructor to reset plan fragment
- Change the warning in testingWaitForAllTasksToBeDeleted to a
   CHECK failure
- Check all tasks to be deleted in each test case derived from
  VectorTestBase
- Some code cleanup CMakefile fix