### PR TITLE
Support write file sink for hdfs

### DIFF
--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
@@ -422,7 +422,7 @@ std::unique_ptr<facebook::velox::dwrf::Writer> createDwrfWriter(
     facebook::velox::memory::MemoryPool& memoryPool) {
   auto writeFileSink =
       facebook::velox::dwio::common::WriteFileSink::createWriteFileSink(
-          "hdfs://localhost:7878" + path, &configurationValues);
+          "hdfs://localhost:7878" + path, configurationValues);
 
   auto config = std::make_shared<facebook::velox::dwrf::Config>();
   config->set(
@@ -475,8 +475,8 @@ TEST_F(HdfsFileSystemTest, E2EHdfsReadWriteDwrf) {
   auto& memoryPool = scopedPool->getPool();
 
   const std::string path = "/b.txt";
-  const char* s = "aaaaaaaaaaaaaaaaaaaaaa";
-  const facebook::velox::StringView sv(s, strlen(s));
+  const std::string str = "aaaaaaaaaaaaaaaaaaaaaa";
+  const facebook::velox::StringView sv(str.c_str(), str.size());
   BufferPtr buffer =
       AlignedBuffer::allocate<facebook::velox::StringView>(1, &memoryPool, sv);
   auto flat = std::make_shared<
@@ -502,6 +502,6 @@ TEST_F(HdfsFileSystemTest, E2EHdfsReadWriteDwrf) {
   auto child = root->childAt(0);
   ASSERT_EQ(child->encoding(), VectorEncoding::Simple::FLAT);
   auto flatVector = child->as<facebook::velox::FlatVector<StringView>>();
-  facebook::velox::StringView v1 = flatVector->valueAt(0);
-  ASSERT_EQ(v1, "aaaaaaaaaaaaaaaaaaaaaa");
+  facebook::velox::StringView v = flatVector->valueAt(0);
+  ASSERT_EQ(std::string(v), str);
 }

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(
   velox_dwio_common_exception
   velox_exception
   velox_memory
+  velox_core
   Boost::regex
   ${FOLLY_WITH_DEPENDENCIES}
   glog::glog)

--- a/velox/dwio/common/DataSink.h
+++ b/velox/dwio/common/DataSink.h
@@ -233,7 +233,7 @@ class WriteFileSink : public DataSink {
   /// @param stats The io statistics.
   static std::unique_ptr<DataSink> createWriteFileSink(
       const std::string& filePath,
-      const std::unordered_map<std::string, std::string>* props = nullptr,
+      const std::unordered_map<std::string, std::string>& props = {},
       const MetricsLogPtr& metricsLog = MetricsLog::voidLog(),
       IoStatistics* stats = nullptr);
 


### PR DESCRIPTION
### Support  write file sink for hdfs
1. Implement a write sink for hdfs file in DataSink.cpp base on implement of HdfsWriteFile(#3021), the class name is WriteFileSink, which can also support to write local file.
2. Implement a e2e test to read and write dwrf format file from hdfs in HdfsFilesytemTest.cpp, which shows the usage of this wirte file sink for hdfs.