### PR TITLE
Fix debug compilation for protobuf in case of compiler not supporting -Winvalid-noreturn

### DIFF
--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -129,6 +129,7 @@ macro(build_protobuf)
     if(COMPILER_HAS_W_INVALID_NORETURN)
       string(APPEND CMAKE_CXX_FLAGS " -Wno-invalid-noreturn")
     else()
+      # Currently reproduced on Ubuntu 22.04 with clang 14
       string(APPEND CMAKE_CXX_FLAGS " -Wno-error")
     endif()
 

--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -125,8 +125,11 @@ macro(build_protobuf)
 
     check_cxx_compiler_flag("-Winvalid-noreturn"
                             COMPILER_HAS_W_INVALID_NORETURN)
+
     if(COMPILER_HAS_W_INVALID_NORETURN)
       string(APPEND CMAKE_CXX_FLAGS " -Wno-invalid-noreturn")
+    else()
+      string(APPEND CMAKE_CXX_FLAGS " -Wno-error")
     endif()
 
     # Fetch the content using previously declared details


### PR DESCRIPTION

fixes https://github.com/facebookincubator/velox/issues/3019

I have tested locally on a docker container modifying the default command to `make debug`. This PR will ignore treating warnings as errors and will just print the warnings but build will be successful:
```
[310/1452] Building CXX object _deps/protobuf-build/CMakeFiles/libprotobuf-lite.dir/src/google/protobuf/generated_message_tctable_lite.cc.o
In file included from /velox/_build/debug/_deps/protobuf-src/src/google/protobuf/generated_message_tctable_lite.cc:36:
/velox/_build/debug/_deps/protobuf-src/src/google/protobuf/generated_message_tctable_impl.h: In function 'void google::protobuf::internal::AlignFail(uintptr_t) [with long unsigned int align = 4]':
/velox/_build/debug/_deps/protobuf-src/src/google/protobuf/generated_message_tctable_impl.h:256:1: warning: 'noreturn' function does return
  256 | }
      | ^
/velox/_build/debug/_deps/protobuf-src/src/google/protobuf/generated_message_tctable_impl.h: In function 'void google::protobuf::internal::AlignFail(uintptr_t) [with long unsigned int align = 8]':
/velox/_build/debug/_deps/protobuf-src/src/google/protobuf/generated_message_tctable_impl.h:256:1: warning: 'noreturn' function does return
[349/1452] Building CXX object _deps/protobuf-build/CMakeFiles/libprotobuf.dir/src/google/protobuf/generated_message_tctable_lite.cc.o
In file included from /velox/_build/debug/_deps/protobuf-src/src/google/protobuf/generated_message_tctable_lite.cc:36:
/velox/_build/debug/_deps/protobuf-src/src/google/protobuf/generated_message_tctable_impl.h: In function 'void google::protobuf::internal::AlignFail(uintptr_t) [with long unsigned int align = 4]':
/velox/_build/debug/_deps/protobuf-src/src/google/protobuf/generated_message_tctable_impl.h:256:1: warning: 'noreturn' function does return
  256 | }
      | ^
/velox/_build/debug/_deps/protobuf-src/src/google/protobuf/generated_message_tctable_impl.h: In function 'void google::protobuf::internal::AlignFail(uintptr_t) [with long unsigned int align = 8]':
/velox/_build/debug/_deps/protobuf-src/src/google/protobuf/generated_message_tctable_impl.h:256:1: warning: 'noreturn' function does return

```