### PR TITLE
Register sumnonpod test aggregate function explicitly

### DIFF
--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -111,11 +111,10 @@ class AggregationTest : public OperatorTestBase {
   }
 
   void SetUp() override {
+    OperatorTestBase::SetUp();
     filesystems::registerLocalFileSystem();
     mappedMemory_ = memory::MappedMemory::getInstance();
-    if (!isRegisteredVectorSerde()) {
-      this->registerVectorSerde();
-    }
+    registerSumNonPODAggregate("sumnonpod");
   }
 
   std::vector<RowVectorPtr>

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -22,6 +22,11 @@ using namespace facebook::velox::exec::test;
 
 class StreamingAggregationTest : public OperatorTestBase {
  protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    registerSumNonPODAggregate("sumnonpod");
+  }
+
   static CursorParameters makeCursorParameters(
       const std::shared_ptr<const core::PlanNode>& planNode,
       uint32_t preferredOutputBatchSize) {

--- a/velox/exec/tests/utils/SumNonPODAggregate.cpp
+++ b/velox/exec/tests/utils/SumNonPODAggregate.cpp
@@ -130,6 +130,7 @@ class SumNonPODAggregate : public Aggregate {
 
   void finalize(char** /*groups*/, int32_t /*numGroups*/) override {}
 };
+} // namespace
 
 bool registerSumNonPODAggregate(const std::string& name) {
   std::vector<std::shared_ptr<velox::exec::AggregateFunctionSignature>>
@@ -154,7 +155,4 @@ bool registerSumNonPODAggregate(const std::string& name) {
   return true;
 }
 
-static bool FB_ANONYMOUS_VARIABLE(g_AggregateFunction) =
-    registerSumNonPODAggregate("sumnonpod");
-} // namespace
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/SumNonPODAggregate.h
+++ b/velox/exec/tests/utils/SumNonPODAggregate.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace facebook::velox::exec::test {
 
@@ -45,4 +46,7 @@ struct NonPODInt64 {
   NonPODInt64& operator=(const NonPODInt64&) = delete;
   NonPODInt64& operator=(NonPODInt64&&) = delete;
 };
+
+bool registerSumNonPODAggregate(const std::string& name);
+
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Do not use static variable to auto-register the aggregate function.