### PR TITLE
Populate outputXxx stats for the last operator in single-threaded execution

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -412,6 +412,10 @@ StopReason Driver::runInternal(
                   "Operator::getOutput() must return nullptr or a non-empty vector: {}",
                   op->stats().operatorType);
 
+              op->stats().outputVectors += 1;
+              op->stats().outputPositions += result->size();
+              op->stats().outputBytes += result->estimateFlatSize();
+
               // This code path is used only in single-threaded execution.
               blockingReason_ = BlockingReason::kWaitForConsumer;
               guard.notThrown();


### PR DESCRIPTION
The Driver didn't populate outputXxx statistics for the last operator in the
pipeline during single-threaded execution initiated via Task::next.