### PR TITLE
Fix parsing of count()

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -73,6 +73,7 @@ std::string normalizeFuncName(std::string input) {
       {"like_escape", "like"},
       {"not_like_escape", "notlike"},
       {"IS DISTINCT FROM", "distinct_from"},
+      {"count_star", "count"},
   };
   auto it = kLookup.find(input);
   return (it == kLookup.end()) ? input : it->second;

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -375,6 +375,13 @@ TEST(DuckParserTest, notLike) {
       parseExpr("name NOT LIKE '%#_%' ESCAPE '#'")->toString());
 }
 
+TEST(DuckParserTest, count) {
+  EXPECT_EQ("count()", parseExpr("count()")->toString());
+  EXPECT_EQ("count(1)", parseExpr("count(1)")->toString());
+  EXPECT_EQ("count()", parseExpr("count(*)")->toString());
+  EXPECT_EQ("count(\"a\")", parseExpr("count(a)")->toString());
+}
+
 TEST(DuckParserTest, orderBy) {
   auto parse = [](const auto& expr) {
     auto orderBy = parseOrderByExpr(expr);

--- a/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
@@ -22,7 +22,7 @@ namespace facebook::velox::aggregate::test {
 
 namespace {
 
-class CountAggregation : public AggregationTestBase {
+class CountAggregationTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
@@ -41,9 +41,11 @@ class CountAggregation : public AggregationTestBase {
            TINYINT()})};
 };
 
-TEST_F(CountAggregation, count) {
+TEST_F(CountAggregationTest, count) {
   auto vectors = makeVectors(rowType_, 10, 100);
   createDuckDbTable(vectors);
+
+  testAggregations(vectors, {}, {"count()"}, "SELECT count(1) FROM tmp");
 
   testAggregations(vectors, {}, {"count(1)"}, "SELECT count(1) FROM tmp");
 


### PR DESCRIPTION
DuckDB parses "count()" as "count_star()", but Velox doesn't have count_star
function. Update the function mapping in the parser to map count_star to count.

This issue was found by running the new Aggregation Fuzzer.

Also, fixed CountAggregation class name to CountAggregationTest for consistency.