### PR TITLE
Include masks in AggregationNode::toString() output

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -146,6 +146,9 @@ void AggregationNode::addDetails(std::stringstream& stream) const {
       stream << ", ";
     }
     stream << aggregateNames_[i] << " := " << aggregates_[i]->toString();
+    if (aggregateMasks_.size() > i && aggregateMasks_[i]) {
+      stream << " mask: " << aggregateMasks_[i]->name();
+    }
   }
 }
 


### PR DESCRIPTION
This gap was discovered while running the new Aggregation Fuzzer.