### PR TITLE
Fix the order of grouping keys in GroupIdNode's output

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -154,7 +154,7 @@ void AggregationNode::addDetails(std::stringstream& stream) const {
 
 namespace {
 RowTypePtr getGroupIdOutputType(
-    const std::map<int, std::shared_ptr<GroupIdNode::OutputGroupingKeyInfo>>&
+    const std::vector<GroupIdNode::OutputGroupingKeyInfo>&
         outputGroupingKeyInfos,
     const std::vector<FieldAccessTypedExprPtr>& aggregationInputs,
     const std::string& groupIdName) {
@@ -170,9 +170,9 @@ RowTypePtr getGroupIdOutputType(
   names.reserve(numOutputs);
   types.reserve(numOutputs);
 
-  for (const auto& [id, groupingKeyInfo] : outputGroupingKeyInfos) {
-    names.push_back(groupingKeyInfo->name);
-    types.push_back(groupingKeyInfo->field->type());
+  for (const auto& groupingKeyInfo : outputGroupingKeyInfos) {
+    names.push_back(groupingKeyInfo.name);
+    types.push_back(groupingKeyInfo.field->type());
   }
 
   for (const auto& input : aggregationInputs) {
@@ -190,8 +190,7 @@ RowTypePtr getGroupIdOutputType(
 GroupIdNode::GroupIdNode(
     PlanNodeId id,
     std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets,
-    std::map<int, std::shared_ptr<OutputGroupingKeyInfo>>
-        outputGroupingKeyInfos,
+    std::vector<GroupIdNode::OutputGroupingKeyInfo> outputGroupingKeyInfos,
     std::vector<FieldAccessTypedExprPtr> aggregationInputs,
     std::string groupIdName,
     PlanNodePtr source)

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -154,14 +154,13 @@ void AggregationNode::addDetails(std::stringstream& stream) const {
 
 namespace {
 RowTypePtr getGroupIdOutputType(
-    const std::vector<GroupIdNode::GroupingKeyInfo>& outputGroupingKeyInfos,
+    const std::vector<GroupIdNode::GroupingKeyInfo>& groupingKeyInfos,
     const std::vector<FieldAccessTypedExprPtr>& aggregationInputs,
     const std::string& groupIdName) {
   // Grouping keys come first, followed by aggregation inputs and groupId
   // column.
 
-  auto numOutputs =
-      outputGroupingKeyInfos.size() + aggregationInputs.size() + 1;
+  auto numOutputs = groupingKeyInfos.size() + aggregationInputs.size() + 1;
 
   std::vector<std::string> names;
   std::vector<TypePtr> types;
@@ -169,7 +168,7 @@ RowTypePtr getGroupIdOutputType(
   names.reserve(numOutputs);
   types.reserve(numOutputs);
 
-  for (const auto& groupingKeyInfo : outputGroupingKeyInfos) {
+  for (const auto& groupingKeyInfo : groupingKeyInfos) {
     names.push_back(groupingKeyInfo.output);
     types.push_back(groupingKeyInfo.input->type());
   }
@@ -189,18 +188,18 @@ RowTypePtr getGroupIdOutputType(
 GroupIdNode::GroupIdNode(
     PlanNodeId id,
     std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets,
-    std::vector<GroupIdNode::GroupingKeyInfo> outputGroupingKeyInfos,
+    std::vector<GroupIdNode::GroupingKeyInfo> groupingKeyInfos,
     std::vector<FieldAccessTypedExprPtr> aggregationInputs,
     std::string groupIdName,
     PlanNodePtr source)
     : PlanNode(std::move(id)),
       sources_{source},
       outputType_(getGroupIdOutputType(
-          outputGroupingKeyInfos,
+          groupingKeyInfos,
           aggregationInputs,
           groupIdName)),
       groupingSets_(std::move(groupingSets)),
-      outputGroupingKeyInfos_(std::move(outputGroupingKeyInfos)),
+      groupingKeyInfos_(std::move(groupingKeyInfos)),
       aggregationInputs_(std::move(aggregationInputs)),
       groupIdName_(std::move(groupIdName)) {
   VELOX_CHECK_GE(

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -154,8 +154,7 @@ void AggregationNode::addDetails(std::stringstream& stream) const {
 
 namespace {
 RowTypePtr getGroupIdOutputType(
-    const std::vector<GroupIdNode::OutputGroupingKeyInfo>&
-        outputGroupingKeyInfos,
+    const std::vector<GroupIdNode::GroupingKeyInfo>& outputGroupingKeyInfos,
     const std::vector<FieldAccessTypedExprPtr>& aggregationInputs,
     const std::string& groupIdName) {
   // Grouping keys come first, followed by aggregation inputs and groupId
@@ -171,8 +170,8 @@ RowTypePtr getGroupIdOutputType(
   types.reserve(numOutputs);
 
   for (const auto& groupingKeyInfo : outputGroupingKeyInfos) {
-    names.push_back(groupingKeyInfo.name);
-    types.push_back(groupingKeyInfo.field->type());
+    names.push_back(groupingKeyInfo.output);
+    types.push_back(groupingKeyInfo.input->type());
   }
 
   for (const auto& input : aggregationInputs) {
@@ -190,7 +189,7 @@ RowTypePtr getGroupIdOutputType(
 GroupIdNode::GroupIdNode(
     PlanNodeId id,
     std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets,
-    std::vector<GroupIdNode::OutputGroupingKeyInfo> outputGroupingKeyInfos,
+    std::vector<GroupIdNode::GroupingKeyInfo> outputGroupingKeyInfos,
     std::vector<FieldAccessTypedExprPtr> aggregationInputs,
     std::string groupIdName,
     PlanNodePtr source)

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -554,10 +554,15 @@ inline std::string mapAggregationStepToName(const AggregationNode::Step& step) {
 /// The rest of the grouping key columns are filled in with nulls.
 class GroupIdNode : public PlanNode {
  public:
+  struct OutputGroupingKeyInfo {
+    std::string name;
+    FieldAccessTypedExprPtr field;
+  };
+
   /// @param id Plan node ID.
   /// @param groupingSets A list of grouping key sets. Grouping keys within the
   /// set must be unique, but grouping keys across sets may repeat.
-  /// @param outputGroupingKeyNames Output names for the grouping keys.
+  /// @param outputGroupingKeyInfos Output infos for the grouping keys.
   /// @param aggregationInputs Columns that contain inputs to the aggregate
   /// functions.
   /// @param groupIdName Name of the column that will contain the grouping set
@@ -566,7 +571,8 @@ class GroupIdNode : public PlanNode {
   GroupIdNode(
       PlanNodeId id,
       std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets,
-      std::map<std::string, FieldAccessTypedExprPtr> outputGroupingKeyNames,
+      std::map<int, std::shared_ptr<OutputGroupingKeyInfo>>
+          outputGroupingKeyInfos,
       std::vector<FieldAccessTypedExprPtr> aggregationInputs,
       std::string groupIdName,
       PlanNodePtr source);
@@ -584,9 +590,9 @@ class GroupIdNode : public PlanNode {
     return groupingSets_;
   }
 
-  const std::map<std::string, FieldAccessTypedExprPtr>& outputGroupingKeyNames()
-      const {
-    return outputGroupingKeyNames_;
+  const std::map<int, std::shared_ptr<OutputGroupingKeyInfo>>&
+  outputGroupingKeyInfos() const {
+    return outputGroupingKeyInfos_;
   }
 
   const std::vector<FieldAccessTypedExprPtr>& aggregationInputs() const {
@@ -611,7 +617,8 @@ class GroupIdNode : public PlanNode {
   const std::vector<PlanNodePtr> sources_;
   const RowTypePtr outputType_;
   const std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets_;
-  const std::map<std::string, FieldAccessTypedExprPtr> outputGroupingKeyNames_;
+  const std::map<int, std::shared_ptr<OutputGroupingKeyInfo>>
+      outputGroupingKeyInfos_;
   const std::vector<FieldAccessTypedExprPtr> aggregationInputs_;
   const std::string groupIdName_;
 };

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -554,9 +554,11 @@ inline std::string mapAggregationStepToName(const AggregationNode::Step& step) {
 /// The rest of the grouping key columns are filled in with nulls.
 class GroupIdNode : public PlanNode {
  public:
-  struct OutputGroupingKeyInfo {
-    std::string name;
-    FieldAccessTypedExprPtr field;
+  struct GroupingKeyInfo {
+    // The name to use in the output.
+    std::string output;
+    // The input field.
+    FieldAccessTypedExprPtr input;
   };
 
   /// @param id Plan node ID.
@@ -571,7 +573,7 @@ class GroupIdNode : public PlanNode {
   GroupIdNode(
       PlanNodeId id,
       std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets,
-      std::vector<OutputGroupingKeyInfo> outputGroupingKeyInfos,
+      std::vector<GroupingKeyInfo> outputGroupingKeyInfos,
       std::vector<FieldAccessTypedExprPtr> aggregationInputs,
       std::string groupIdName,
       PlanNodePtr source);
@@ -589,7 +591,7 @@ class GroupIdNode : public PlanNode {
     return groupingSets_;
   }
 
-  const std::vector<OutputGroupingKeyInfo>& outputGroupingKeyInfos() const {
+  const std::vector<GroupingKeyInfo>& outputGroupingKeyInfos() const {
     return outputGroupingKeyInfos_;
   }
 
@@ -615,7 +617,7 @@ class GroupIdNode : public PlanNode {
   const std::vector<PlanNodePtr> sources_;
   const RowTypePtr outputType_;
   const std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets_;
-  const std::vector<OutputGroupingKeyInfo> outputGroupingKeyInfos_;
+  const std::vector<GroupingKeyInfo> outputGroupingKeyInfos_;
   const std::vector<FieldAccessTypedExprPtr> aggregationInputs_;
   const std::string groupIdName_;
 };

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -564,7 +564,8 @@ class GroupIdNode : public PlanNode {
   /// @param id Plan node ID.
   /// @param groupingSets A list of grouping key sets. Grouping keys within the
   /// set must be unique, but grouping keys across sets may repeat.
-  /// @param outputGroupingKeyInfos Output infos for the grouping keys.
+  /// @param groupingKeyInfos The names and order of the grouping keys in the
+  /// output.
   /// @param aggregationInputs Columns that contain inputs to the aggregate
   /// functions.
   /// @param groupIdName Name of the column that will contain the grouping set
@@ -573,7 +574,7 @@ class GroupIdNode : public PlanNode {
   GroupIdNode(
       PlanNodeId id,
       std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets,
-      std::vector<GroupingKeyInfo> outputGroupingKeyInfos,
+      std::vector<GroupingKeyInfo> groupingKeyInfos,
       std::vector<FieldAccessTypedExprPtr> aggregationInputs,
       std::string groupIdName,
       PlanNodePtr source);
@@ -591,8 +592,8 @@ class GroupIdNode : public PlanNode {
     return groupingSets_;
   }
 
-  const std::vector<GroupingKeyInfo>& outputGroupingKeyInfos() const {
-    return outputGroupingKeyInfos_;
+  const std::vector<GroupingKeyInfo>& groupingKeyInfos() const {
+    return groupingKeyInfos_;
   }
 
   const std::vector<FieldAccessTypedExprPtr>& aggregationInputs() const {
@@ -617,7 +618,7 @@ class GroupIdNode : public PlanNode {
   const std::vector<PlanNodePtr> sources_;
   const RowTypePtr outputType_;
   const std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets_;
-  const std::vector<GroupingKeyInfo> outputGroupingKeyInfos_;
+  const std::vector<GroupingKeyInfo> groupingKeyInfos_;
   const std::vector<FieldAccessTypedExprPtr> aggregationInputs_;
   const std::string groupIdName_;
 };

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -571,8 +571,7 @@ class GroupIdNode : public PlanNode {
   GroupIdNode(
       PlanNodeId id,
       std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets,
-      std::map<int, std::shared_ptr<OutputGroupingKeyInfo>>
-          outputGroupingKeyInfos,
+      std::vector<OutputGroupingKeyInfo> outputGroupingKeyInfos,
       std::vector<FieldAccessTypedExprPtr> aggregationInputs,
       std::string groupIdName,
       PlanNodePtr source);
@@ -590,8 +589,7 @@ class GroupIdNode : public PlanNode {
     return groupingSets_;
   }
 
-  const std::map<int, std::shared_ptr<OutputGroupingKeyInfo>>&
-  outputGroupingKeyInfos() const {
+  const std::vector<OutputGroupingKeyInfo>& outputGroupingKeyInfos() const {
     return outputGroupingKeyInfos_;
   }
 
@@ -617,8 +615,7 @@ class GroupIdNode : public PlanNode {
   const std::vector<PlanNodePtr> sources_;
   const RowTypePtr outputType_;
   const std::vector<std::vector<FieldAccessTypedExprPtr>> groupingSets_;
-  const std::map<int, std::shared_ptr<OutputGroupingKeyInfo>>
-      outputGroupingKeyInfos_;
+  const std::vector<OutputGroupingKeyInfo> outputGroupingKeyInfos_;
   const std::vector<FieldAccessTypedExprPtr> aggregationInputs_;
   const std::string groupIdName_;
 };

--- a/velox/exec/GroupId.cpp
+++ b/velox/exec/GroupId.cpp
@@ -31,7 +31,7 @@ GroupId::GroupId(
 
   std::unordered_map<std::string, column_index_t>
       inputToOutputGroupingKeyMapping;
-  for (const auto& groupingKeyInfo : groupIdNode->outputGroupingKeyInfos()) {
+  for (const auto& groupingKeyInfo : groupIdNode->groupingKeyInfos()) {
     inputToOutputGroupingKeyMapping[groupingKeyInfo.input->name()] =
         outputType_->getChildIdx(groupingKeyInfo.output);
   }

--- a/velox/exec/GroupId.cpp
+++ b/velox/exec/GroupId.cpp
@@ -31,9 +31,9 @@ GroupId::GroupId(
 
   std::unordered_map<std::string, column_index_t>
       inputToOutputGroupingKeyMapping;
-  for (const auto& [output, input] : groupIdNode->outputGroupingKeyInfos()) {
-    inputToOutputGroupingKeyMapping[input->field->name()] =
-        outputType_->getChildIdx(input->name);
+  for (const auto& input : groupIdNode->outputGroupingKeyInfos()) {
+    inputToOutputGroupingKeyMapping[input.field->name()] =
+        outputType_->getChildIdx(input.name);
   }
 
   auto numGroupingSets = groupIdNode->groupingSets().size();

--- a/velox/exec/GroupId.cpp
+++ b/velox/exec/GroupId.cpp
@@ -31,9 +31,9 @@ GroupId::GroupId(
 
   std::unordered_map<std::string, column_index_t>
       inputToOutputGroupingKeyMapping;
-  for (const auto& [output, input] : groupIdNode->outputGroupingKeyNames()) {
-    inputToOutputGroupingKeyMapping[input->name()] =
-        outputType_->getChildIdx(output);
+  for (const auto& [output, input] : groupIdNode->outputGroupingKeyInfos()) {
+    inputToOutputGroupingKeyMapping[input->field->name()] =
+        outputType_->getChildIdx(input->name);
   }
 
   auto numGroupingSets = groupIdNode->groupingSets().size();

--- a/velox/exec/GroupId.cpp
+++ b/velox/exec/GroupId.cpp
@@ -31,9 +31,9 @@ GroupId::GroupId(
 
   std::unordered_map<std::string, column_index_t>
       inputToOutputGroupingKeyMapping;
-  for (const auto& input : groupIdNode->outputGroupingKeyInfos()) {
-    inputToOutputGroupingKeyMapping[input.field->name()] =
-        outputType_->getChildIdx(input.name);
+  for (const auto& groupingKeyInfo : groupIdNode->outputGroupingKeyInfos()) {
+    inputToOutputGroupingKeyMapping[groupingKeyInfo.input->name()] =
+        outputType_->getChildIdx(groupingKeyInfo.output);
   }
 
   auto numGroupingSets = groupIdNode->groupingSets().size();

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -624,8 +624,6 @@ PlanBuilder& PlanBuilder::streamingAggregation(
   return *this;
 }
 
-// groupId method creates GroupIdNode plan node with grouping keys appearing
-// in the output in the order they appear in 'groupingSets'.
 PlanBuilder& PlanBuilder::groupId(
     const std::vector<std::vector<std::string>>& groupingSets,
     const std::vector<std::string>& aggregationInputs,
@@ -636,7 +634,7 @@ PlanBuilder& PlanBuilder::groupId(
     groupingSetExprs.push_back(fields(groupingSet));
   }
 
-  std::vector<core::GroupIdNode::GroupingKeyInfo> outputGroupingKeyInfos;
+  std::vector<core::GroupIdNode::GroupingKeyInfo> groupingKeyInfos;
   std::set<std::string> names;
   auto index = 0;
   for (const auto& groupingSet : groupingSetExprs) {
@@ -645,7 +643,7 @@ PlanBuilder& PlanBuilder::groupId(
         core::GroupIdNode::GroupingKeyInfo keyInfos;
         keyInfos.output = groupingKey->name();
         keyInfos.input = groupingKey;
-        outputGroupingKeyInfos.push_back(keyInfos);
+        groupingKeyInfos.push_back(keyInfos);
       }
       names.insert(groupingKey->name());
     }
@@ -654,7 +652,7 @@ PlanBuilder& PlanBuilder::groupId(
   planNode_ = std::make_shared<core::GroupIdNode>(
       nextPlanNodeId(),
       groupingSetExprs,
-      std::move(outputGroupingKeyInfos),
+      std::move(groupingKeyInfos),
       fields(aggregationInputs),
       std::move(groupIdName),
       planNode_);

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -634,18 +634,16 @@ PlanBuilder& PlanBuilder::groupId(
     groupingSetExprs.push_back(fields(groupingSet));
   }
 
-  std::map<int, std::shared_ptr<core::GroupIdNode::OutputGroupingKeyInfo>>
-      outputGroupingKeyInfos;
+  std::vector<core::GroupIdNode::OutputGroupingKeyInfo> outputGroupingKeyInfos;
   std::set<std::string> names;
   auto index = 0;
   for (const auto& groupingSet : groupingSetExprs) {
     for (const auto& groupingKey : groupingSet) {
       if (names.find(groupingKey->name()) == names.end()) {
-        auto outputGroupingKeyInfo =
-            std::make_shared<core::GroupIdNode::OutputGroupingKeyInfo>();
-        outputGroupingKeyInfo->name = groupingKey->name();
-        outputGroupingKeyInfo->field = groupingKey;
-        outputGroupingKeyInfos[index++] = outputGroupingKeyInfo;
+        core::GroupIdNode::OutputGroupingKeyInfo keyInfos;
+        keyInfos.name = groupingKey->name();
+        keyInfos.field = groupingKey;
+        outputGroupingKeyInfos.push_back(keyInfos);
       }
       names.insert(groupingKey->name());
     }

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -624,6 +624,8 @@ PlanBuilder& PlanBuilder::streamingAggregation(
   return *this;
 }
 
+// groupId method creates GroupIdNode plan node with grouping keys appearing
+// in the output in the order they appear in 'groupingSets'.
 PlanBuilder& PlanBuilder::groupId(
     const std::vector<std::vector<std::string>>& groupingSets,
     const std::vector<std::string>& aggregationInputs,
@@ -634,15 +636,15 @@ PlanBuilder& PlanBuilder::groupId(
     groupingSetExprs.push_back(fields(groupingSet));
   }
 
-  std::vector<core::GroupIdNode::OutputGroupingKeyInfo> outputGroupingKeyInfos;
+  std::vector<core::GroupIdNode::GroupingKeyInfo> outputGroupingKeyInfos;
   std::set<std::string> names;
   auto index = 0;
   for (const auto& groupingSet : groupingSetExprs) {
     for (const auto& groupingKey : groupingSet) {
       if (names.find(groupingKey->name()) == names.end()) {
-        core::GroupIdNode::OutputGroupingKeyInfo keyInfos;
-        keyInfos.name = groupingKey->name();
-        keyInfos.field = groupingKey;
+        core::GroupIdNode::GroupingKeyInfo keyInfos;
+        keyInfos.output = groupingKey->name();
+        keyInfos.input = groupingKey;
         outputGroupingKeyInfos.push_back(keyInfos);
       }
       names.insert(groupingKey->name());

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -432,7 +432,8 @@ class PlanBuilder {
       const std::vector<TypePtr>& resultTypes = {});
 
   /// Add a GroupIdNode using the specified grouping sets, aggregation inputs
-  /// and a groupId column name.
+  /// and a groupId column name. And create GroupIdNode plan node with grouping
+  /// keys appearing in the output in the order they appear in 'groupingSets'.
   PlanBuilder& groupId(
       const std::vector<std::vector<std::string>>& groupingSets,
       const std::vector<std::string>& aggregationInputs,
@@ -660,6 +661,12 @@ class PlanBuilder {
   PlanBuilder& capturePlanNodeId(core::PlanNodeId& id) {
     VELOX_CHECK_NOT_NULL(planNode_);
     id = planNode_->id();
+    return *this;
+  }
+
+  PlanBuilder& capturePlanNode(core::PlanNodePtr& planNode) {
+    VELOX_CHECK_NOT_NULL(planNode_);
+    planNode = planNode_;
     return *this;
   }
 


### PR DESCRIPTION
The output type of GroupIdNode is constructed by the outputGroupingKeyNames,
which is stored in map and will be sorted by map key. So when the grouping sets
keys are out of order, the output type will be wrong. This PR use int as the
key to fix the above wrong output type issue.