### PR TITLE
Make returnType optional in ArgumentTypeFuzzer

### DIFF
--- a/velox/expression/tests/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzer.cpp
@@ -71,11 +71,17 @@ bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {
   const auto& formalArgs = signature_.argumentTypes();
   auto formalArgsCnt = formalArgs.size();
 
-  exec::ReverseSignatureBinder binder{signature_, returnType_};
-  if (!binder.tryBind()) {
-    return false;
+  if (returnType_) {
+    exec::ReverseSignatureBinder binder{signature_, returnType_};
+    if (!binder.tryBind()) {
+      return false;
+    }
+    bindings_ = binder.bindings();
+  } else {
+    for (const auto& constraint : signature_.typeVariableConstraints()) {
+      bindings_.insert({constraint.name(), nullptr});
+    }
   }
-  bindings_ = binder.bindings();
 
   determineUnboundedTypeVariables();
   for (auto i = 0; i < formalArgsCnt; i++) {

--- a/velox/expression/tests/ArgumentTypeFuzzer.h
+++ b/velox/expression/tests/ArgumentTypeFuzzer.h
@@ -22,22 +22,29 @@
 
 namespace facebook::velox::test {
 
-/// For function signatures containing type variables, try generate a list of
-/// arguments types such that the function taking these arguments returns the
-/// given type. If there are type variables unbounded by the return type,
-/// generate a random type for them with rng_.
+/// For function signatures using type variables, generates a list of
+/// arguments types. Optionally, allows to specify a desired return type. If
+/// specified, the return type acts as a constraint on the possible set of
+/// argument types.
 class ArgumentTypeFuzzer {
  public:
   ArgumentTypeFuzzer(
       const exec::FunctionSignature& signature,
+      std::mt19937& rng)
+      : signature_{signature}, rng_{rng} {}
+
+  ArgumentTypeFuzzer(
+      const exec::FunctionSignature& signature,
       const TypePtr& returnType,
       std::mt19937& rng)
-      : signature_{signature}, returnType_{returnType}, rng_{rng} {}
+      : signature_{signature}, returnType_{returnType}, rng_{rng} {
+    VELOX_CHECK_NOT_NULL(returnType);
+  }
 
-  /// Generate random argument types if returnType_ can be bound to the return
-  /// type of signature_. Return true if the generation succeeds, false
-  /// otherwise. If signature_ has variable arity, repeat the last argument at
-  /// most maxVariadicArgs times.
+  /// Generate random argument types. If the desired returnType has been
+  /// specified, checks that it can be bound to the return type of signature_.
+  /// Return true if the generation succeeds, false otherwise. If signature_ has
+  /// variable arity, repeat the last argument at most maxVariadicArgs times.
   bool fuzzArgumentTypes(uint32_t maxVariadicArgs);
 
   /// Return the generated list of argument types. This function should be

--- a/velox/expression/tests/ArgumentTypeFuzzerTest.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzerTest.cpp
@@ -303,4 +303,27 @@ TEST_F(ArgumentTypeFuzzerTest, lambda) {
   }
 }
 
+TEST_F(ArgumentTypeFuzzerTest, unconstrainedSignatureTemplate) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .typeVariable("K")
+                       .typeVariable("V")
+                       .returnType("V")
+                       .argumentType("map(K,V)")
+                       .argumentType("K")
+                       .build();
+
+  std::mt19937 seed{0};
+  ArgumentTypeFuzzer fuzzer{*signature, MAP(BIGINT(), VARCHAR()), seed};
+  ASSERT_TRUE(fuzzer.fuzzArgumentTypes(kMaxVariadicArgs));
+
+  const auto& argumentTypes = fuzzer.argumentTypes();
+  ASSERT_EQ(2, argumentTypes.size());
+  ASSERT_TRUE(argumentTypes[0] != nullptr);
+  ASSERT_TRUE(argumentTypes[1] != nullptr);
+
+  ASSERT_EQ(argumentTypes[0]->kind(), TypeKind::MAP);
+
+  ASSERT_EQ(argumentTypes[0]->childAt(0), argumentTypes[1]);
+}
+
 } // namespace facebook::velox::test


### PR DESCRIPTION
Allow ArgumentTypeFuzzer to be used to generate concrete signature unconstrained
by the return type. This functionality will be used in the new Aggregation
Fuzzer.