### PR TITLE
Fix array-agg for empty input

### DIFF
--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -64,11 +64,11 @@ class ArrayAggAggregate : public exec::Aggregate {
     uint64_t* rawNulls = getRawNulls(vector);
     vector_size_t offset = 0;
     for (int32_t i = 0; i < numGroups; ++i) {
-      clearNull(rawNulls, i);
-
       auto& values = value<ArrayAccumulator>(groups[i])->elements;
       auto arraySize = values.size();
       if (arraySize) {
+        clearNull(rawNulls, i);
+
         ValueListReader reader(values);
         for (auto index = 0; index < arraySize; ++index) {
           reader.next(*elements, offset + index);
@@ -76,7 +76,7 @@ class ArrayAggAggregate : public exec::Aggregate {
         vector->setOffsetAndSize(i, offset, arraySize);
         offset += arraySize;
       } else {
-        vector->setOffsetAndSize(i, offset, 0);
+        vector->setNull(i, true);
       }
     }
   }


### PR DESCRIPTION
Array_agg should return NULL for empty input, not empty array.

This issue was found by the new Aggregation Fuzzer.

```
presto> select array_agg(a) from (select 1 as a limit 0);
 _col0
-------
 NULL
(1 row)

presto> select array_agg(a) filter (where b) from unnest(array[1, 2, 3], array[false, false, false]) as _t(a,b);
 _col0
-------
 NULL
(1 row)
```

Fixes #3144