### PR TITLE
[Velox] Table writer 4: Make HiveDataSink use WriteProtocol

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -386,26 +386,6 @@ class TableWriteNode : public PlanNode {
     }
   }
 
-  // TODO(gaoge): remove after presto_cpp is migrated to use the above
-  // constructor
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  TableWriteNode(
-      const PlanNodeId& id,
-      const RowTypePtr& columns,
-      const std::vector<std::string>& columnNames,
-      const std::shared_ptr<InsertTableHandle>& insertTableHandle,
-      const RowTypePtr& outputType,
-      const PlanNodePtr& source)
-      : TableWriteNode(
-            id,
-            columns,
-            columnNames,
-            insertTableHandle,
-            outputType,
-            connector::WriteProtocol::CommitStrategy::kNoCommit,
-            source) {}
-#endif
-
   const std::vector<PlanNodePtr>& sources() const override {
     return sources_;
   }

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -231,7 +231,7 @@ TEST_F(TableWriteTest, constantVectors) {
       "SELECT * FROM tmp");
 }
 
-TEST_F(TableWriteTest, TestASecondCommitStrategy) {
+TEST_F(TableWriteTest, TestCommitStrategy) {
   auto filePaths = makeFilePaths(10);
   auto vectors = makeVectors(rowType_, filePaths.size(), 1000);
   for (int i = 0; i < filePaths.size(); i++) {


### PR DESCRIPTION
Change HiveDataSink to get the required parameters for the underlying
writers from WriteProtocol, including the write & target directories
& file names.