### PR TITLE
Fix map_agg and map_union for empty input

### DIFF
--- a/velox/functions/prestosql/aggregates/MapAggregateBase.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggregateBase.cpp
@@ -36,11 +36,11 @@ void MapAggregateBase::extractValues(
 
   for (int32_t i = 0; i < numGroups; ++i) {
     char* group = groups[i];
-    clearNull(rawNulls, i);
 
     auto accumulator = value<MapAccumulator>(group);
     auto mapSize = accumulator->keys.size();
     if (mapSize) {
+      clearNull(rawNulls, i);
       ValueListReader keysReader(accumulator->keys);
       ValueListReader valuesReader(accumulator->values);
       for (auto index = 0; index < mapSize; ++index) {
@@ -50,7 +50,7 @@ void MapAggregateBase::extractValues(
       mapVector->setOffsetAndSize(i, offset, mapSize);
       offset += mapSize;
     } else {
-      mapVector->setOffsetAndSize(i, offset, 0);
+      mapVector->setNull(i, true);
     }
   }
 

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -139,13 +139,8 @@ TEST_F(MapAggTest, globalWithNulls) {
 TEST_F(MapAggTest, globalNoData) {
   auto vectors = {makeRowVector(
       {makeFlatVector<int32_t>({}), makeFlatVector<int32_t>({})})};
-  auto expectedResult = {makeRowVector({makeMapVector<int32_t, double>(
-      1,
-      [&](vector_size_t /*row*/) { return 0; },
-      [&](vector_size_t /*row*/) { return 0; },
-      [&](vector_size_t /*row*/) { return 0; })})};
 
-  testAggregations(vectors, {}, {"map_agg(c0, c1)"}, expectedResult);
+  testAggregations(vectors, {}, {"map_agg(c0, c1)"}, "SELECT null");
 }
 
 TEST_F(MapAggTest, globalDuplicateKeys) {

--- a/velox/functions/prestosql/aggregates/tests/MapUnionAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapUnionAggregationTest.cpp
@@ -175,14 +175,9 @@ TEST_F(MapUnionTest, globalWithDuplicates) {
  * the input is empty.
  */
 TEST_F(MapUnionTest, globalNoData) {
-  auto inputVectors = {makeRowVector({makeMapVector<int32_t, double>(
-      1,
-      [&](vector_size_t /*row*/) { return 0; },
-      [&](vector_size_t /*row*/) { return 0; },
-      [&](vector_size_t /*row*/) { return 0; })})};
-  auto expectedResult = inputVectors;
+  auto data = makeRowVector(ROW({"c0"}, {MAP(BIGINT(), VARCHAR())}), 0);
 
-  testAggregations(inputVectors, {}, {"map_union(c0)"}, expectedResult);
+  testAggregations({data}, {}, {"map_union(c0)"}, "SELECT null");
 }
 } // namespace
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Map_agg and map_union should return NULL if input is empty, not empty map.

Fixes #3145