### PR TITLE
let toSql output complex vector to separate files

### DIFF
--- a/velox/docs/develop/debugging/expression-fuzzer.rst
+++ b/velox/docs/develop/debugging/expression-fuzzer.rst
@@ -93,7 +93,7 @@ additions/removals of UDFs from the list, and etc. To have an accurate
 reproduction of a fuzzer failure regardless of environments you can record the
 input vector and expression to files and replay these later.
 
-1. Run Fuzzer using ``--seed`` and ``--repro_persist_path`` flags to save the input vector and expression to files in the specified directory.
+1. Run Fuzzer using ``--seed`` and ``--repro_persist_path`` flags to save the input vector and expression to files in the specified directory. Add "--persist_and_run_once" if the issue is not an exception failure but a crash failure.
 
 2. Run Expression Runner using generated files.
 
@@ -109,6 +109,8 @@ ExpressionRunner supports the following flags:
 * ``--input_path`` path to input vector that was created by the Fuzzer
 
 * ``--sql_path`` path to expression SQL that was created by the Fuzzer
+
+* ``--complex_constant_path`` optional path to complex constants that aren't accurately expressable in SQL (Array, Map, Structs, ...). This is used with SQL file to reproduce the exact expression, not needed when the expression doesn't contain complex constants.
 
 * ``--result_path`` optional path to result vector that was created by the Fuzzer. Result vector is used to reproduce cases where Fuzzer passes dirty vectors to expression evaluation as a result buffer. This ensures that functions are implemented correctly, taking into consideration dirty result buffer.
 

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -738,10 +738,10 @@ void toTypeSql(const TypePtr& type, std::ostream& out) {
 }
 } // namespace
 
-std::string CastExpr::toSql() const {
+std::string CastExpr::toSql(std::vector<VectorPtr>* complexConstants) const {
   std::stringstream out;
   out << "cast(";
-  appendInputsSql(out);
+  appendInputsSql(out, complexConstants);
   out << " as ";
   toTypeSql(type_, out);
   out << ")";

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -102,7 +102,7 @@ class CastExpr : public SpecialForm {
 
   std::string toString(bool recursive = true) const override;
 
-  std::string toSql() const override;
+  std::string toSql(std::vector<VectorPtr>*) const override;
 
  private:
   /// @tparam To The cast target type

--- a/velox/expression/ConjunctExpr.cpp
+++ b/velox/expression/ConjunctExpr.cpp
@@ -266,12 +266,13 @@ void ConjunctExpr::updateResult(
   }
 }
 
-std::string ConjunctExpr::toSql() const {
+std::string ConjunctExpr::toSql(
+    std::vector<VectorPtr>* complexConstants) const {
   std::stringstream out;
-  out << "(" << inputs_[0]->toSql() << ")";
+  out << "(" << inputs_[0]->toSql(complexConstants) << ")";
   for (auto i = 1; i < inputs_.size(); ++i) {
     out << " " << name_ << " "
-        << "(" << inputs_[i]->toSql() << ")";
+        << "(" << inputs_[i]->toSql(complexConstants) << ")";
   }
   return out.str();
 }

--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -56,7 +56,8 @@ class ConjunctExpr : public SpecialForm {
     return selectivity_[inputOrder_[index]];
   }
 
-  std::string toSql() const override;
+  std::string toSql(
+      std::vector<VectorPtr>* complexConstants = nullptr) const override;
 
  private:
   void maybeReorderInputs();

--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -218,10 +218,17 @@ void appendSqlLiteral(
 }
 } // namespace
 
-std::string ConstantExpr::toSql() const {
+std::string ConstantExpr::toSql(
+    std::vector<VectorPtr>* complexConstants) const {
   VELOX_CHECK_NOT_NULL(sharedSubexprValues_);
   std::ostringstream out;
-  appendSqlLiteral(*sharedSubexprValues_, 0, out);
+  if (complexConstants && !sharedSubexprValues_->type()->isPrimitiveType()) {
+    int idx = complexConstants->size();
+    out << "__complex_constant(c" << idx << ")";
+    complexConstants->push_back(sharedSubexprValues_);
+  } else {
+    appendSqlLiteral(*sharedSubexprValues_, 0, out);
+  }
   return out.str();
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/ConstantExpr.h
+++ b/velox/expression/ConstantExpr.h
@@ -61,7 +61,8 @@ class ConstantExpr : public SpecialForm {
 
   std::string toString(bool recursive = true) const override;
 
-  std::string toSql() const override;
+  std::string toSql(
+      std::vector<VectorPtr>* complexConstants = nullptr) const override;
 
  private:
   const variant value_;

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1525,10 +1525,10 @@ std::string Expr::toString(bool recursive) const {
   return name_;
 }
 
-std::string Expr::toSql() const {
+std::string Expr::toSql(std::vector<VectorPtr>* complexConstants) const {
   std::stringstream out;
   out << "\"" << name_ << "\"";
-  appendInputsSql(out);
+  appendInputsSql(out, complexConstants);
   return out.str();
 }
 
@@ -1545,14 +1545,16 @@ void Expr::appendInputs(std::stringstream& stream) const {
   }
 }
 
-void Expr::appendInputsSql(std::stringstream& stream) const {
+void Expr::appendInputsSql(
+    std::stringstream& stream,
+    std::vector<VectorPtr>* complexConstants) const {
   if (!inputs_.empty()) {
     stream << "(";
     for (auto i = 0; i < inputs_.size(); ++i) {
       if (i > 0) {
         stream << ", ";
       }
-      stream << inputs_[i]->toSql();
+      stream << inputs_[i]->toSql(complexConstants);
     }
     stream << ")";
   }

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -236,7 +236,12 @@ class Expr {
   virtual std::string toString(bool recursive = true) const;
 
   /// Return the expression as SQL string.
-  virtual std::string toSql() const;
+  /// @param complexConstants An optional std::vector of VectorPtr to record
+  /// complex constants (Array, Maps, Structs, ...) that aren't accurately
+  /// expressable as sql. If not given, they will be converted to
+  /// SQL-expressable simple constants.
+  virtual std::string toSql(
+      std::vector<VectorPtr>* complexConstants = nullptr) const;
 
   const ExprStats& stats() const {
     return stats_;
@@ -362,7 +367,9 @@ class Expr {
  protected:
   void appendInputs(std::stringstream& stream) const;
 
-  void appendInputsSql(std::stringstream& stream) const;
+  void appendInputsSql(
+      std::stringstream& stream,
+      std::vector<VectorPtr>* complexConstants) const;
 
   /// Release 'inputValues_' back to vector pool in 'evalCtx' so they can be
   /// reused.

--- a/velox/expression/LambdaExpr.cpp
+++ b/velox/expression/LambdaExpr.cpp
@@ -115,7 +115,7 @@ std::string LambdaExpr::toString(bool recursive) const {
   return fmt::format("({}) -> {}", inputs, body_->toString());
 }
 
-std::string LambdaExpr::toSql() const {
+std::string LambdaExpr::toSql(std::vector<VectorPtr>* complexConstants) const {
   std::ostringstream out;
   out << "(";
   // Inputs.
@@ -125,7 +125,7 @@ std::string LambdaExpr::toSql() const {
     }
     out << signature_->nameOf(i);
   }
-  out << ") -> " << body_->toSql();
+  out << ") -> " << body_->toSql(complexConstants);
 
   return out.str();
 }

--- a/velox/expression/LambdaExpr.h
+++ b/velox/expression/LambdaExpr.h
@@ -50,7 +50,8 @@ class LambdaExpr : public SpecialForm {
 
   std::string toString(bool recursive = true) const override;
 
-  std::string toSql() const override;
+  std::string toSql(
+      std::vector<VectorPtr>* complexConstants = nullptr) const override;
 
   bool propagatesNulls() const override {
     // A null capture does not result in a null function.

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -123,12 +123,14 @@ add_executable(velox_expression_runner_unit_test ExpressionRunnerUnitTest.cpp)
 target_link_libraries(
   velox_expression_runner_unit_test
   velox_dwio_common_test_utils
+  velox_expression
   velox_expression_runner
   velox_expression_fuzzer
   velox_expression_verifier
   velox_function_registry
   velox_temp_path
   velox_exec_test_lib
+  velox_vector_test_lib
   gtest
   gtest_main)
 

--- a/velox/expression/tests/ExpressionRunner.h
+++ b/velox/expression/tests/ExpressionRunner.h
@@ -15,6 +15,7 @@
  */
 
 #include <string>
+#include "velox/parse/Expressions.h"
 #include "velox/vector/TypeAliases.h"
 
 namespace facebook::velox::test {
@@ -32,6 +33,9 @@ class ExpressionRunner {
   /// @param inputPath The path to the on-disk vector that will be used as input
   ///        to feed to the expression.
   /// @param sql Comma-separated SQL expressions.
+  /// @param complexConstantsPath The path to on-disk vector that stores complex
+  ///        subexpressions that aren't expressable in SQL (if any), used with
+  ///        sql to construct the complete plan
   /// @param resultPath The path to the on-disk vector
   ///        that will be used as the result buffer to which the expression
   ///        evaluation results will be written.
@@ -45,10 +49,19 @@ class ExpressionRunner {
   static void run(
       const std::string& inputPath,
       const std::string& sql,
+      const std::string& complexConstantsPath,
       const std::string& resultPath,
       const std::string& mode,
       vector_size_t numRows,
       const std::string& storeResultPath);
+
+  /// Parse comma-separated SQL expressions. This should be treated as private
+  /// except for tests.
+  static std::vector<core::TypedExprPtr> parseSql(
+      const std::string& sql,
+      const TypePtr& inputType,
+      memory::MemoryPool* pool,
+      const VectorPtr& complexConstants);
 };
 
 } // namespace facebook::velox::test

--- a/velox/expression/tests/ExpressionRunnerTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerTest.cpp
@@ -37,6 +37,11 @@ DEFINE_string(
     "This has to be set with input_path and optionally result_path.");
 
 DEFINE_string(
+    complex_constant_path,
+    "",
+    "Path for complex constants that aren't expressable in SQL.");
+
+DEFINE_string(
     sql,
     "",
     "Comma separated SQL expressions to evaluate. This flag and --sql_path "
@@ -113,6 +118,7 @@ int main(int argc, char** argv) {
   facebook::velox::test::ExpressionRunner::run(
       FLAGS_input_path,
       sql,
+      FLAGS_complex_constant_path,
       FLAGS_result_path,
       FLAGS_mode,
       FLAGS_num_rows,

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -61,7 +61,8 @@ class ExpressionVerifier {
       const VectorPtr& inputVector,
       std::vector<column_index_t> columnsToWarpInLazy,
       const VectorPtr& resultVector,
-      const std::string& sql);
+      const std::string& sql,
+      const std::vector<VectorPtr>& complexConstants);
 
  private:
   core::ExecCtx* FOLLY_NONNULL execCtx_;

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -186,8 +186,9 @@ bool hasLambdaArgument(const exec::FunctionSignature& signature) {
 TypedExprPtr Expressions::inferTypes(
     const std::shared_ptr<const core::IExpr>& expr,
     const TypePtr& inputRow,
-    memory::MemoryPool* pool) {
-  return inferTypes(expr, inputRow, {}, pool);
+    memory::MemoryPool* pool,
+    const VectorPtr& complexConstants) {
+  return inferTypes(expr, inputRow, {}, pool, complexConstants);
 }
 
 // static
@@ -195,7 +196,8 @@ TypedExprPtr Expressions::inferTypes(
     const std::shared_ptr<const core::IExpr>& expr,
     const TypePtr& inputRow,
     const std::vector<TypePtr>& lambdaInputTypes,
-    memory::MemoryPool* pool) {
+    memory::MemoryPool* pool,
+    const VectorPtr& complexConstants) {
   VELOX_CHECK_NOT_NULL(expr);
 
   if (auto lambdaExpr = std::dynamic_pointer_cast<const LambdaExpr>(expr)) {
@@ -210,9 +212,24 @@ TypedExprPtr Expressions::inferTypes(
     }
   }
 
+  // try rebuilding complex constant type from vector
+  if (auto fun = std::dynamic_pointer_cast<const CallExpr>(expr)) {
+    if (fun->getFunctionName() == "__complex_constant") {
+      VELOX_CHECK(complexConstants);
+      auto ccInputRow = complexConstants->as<RowVector>();
+      auto name =
+          std::dynamic_pointer_cast<const FieldAccessExpr>(fun->getInputs()[0])
+              ->getFieldName();
+      auto rowType = asRowType(ccInputRow->type());
+      return std::make_shared<const ConstantTypedExpr>(
+          ccInputRow->childAt(rowType->getChildIdx(name)));
+    }
+  }
+
   std::vector<TypedExprPtr> children;
   for (auto& child : expr->getInputs()) {
-    children.push_back(inferTypes(child, inputRow, lambdaInputTypes, pool));
+    children.push_back(
+        inferTypes(child, inputRow, lambdaInputTypes, pool, complexConstants));
   }
 
   if (auto fae = std::dynamic_pointer_cast<const FieldAccessExpr>(expr)) {

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -40,7 +40,8 @@ class Expressions {
   static TypedExprPtr inferTypes(
       const std::shared_ptr<const IExpr>& expr,
       const TypePtr& input,
-      memory::MemoryPool* pool);
+      memory::MemoryPool* pool,
+      const VectorPtr& complexConstants = nullptr);
 
   static TypePtr getInputRowType(const TypedExprPtr& expr);
 
@@ -57,7 +58,8 @@ class Expressions {
       const std::shared_ptr<const IExpr>& expr,
       const TypePtr& input,
       const std::vector<TypePtr>& lambdaInputTypes,
-      memory::MemoryPool* pool);
+      memory::MemoryPool* pool,
+      const VectorPtr& complexConstants = nullptr);
 
   static TypedExprPtr resolveLambdaExpr(
       const std::shared_ptr<const core::LambdaExpr>& lambdaExpr,


### PR DESCRIPTION
Summary:
Addressing https://github.com/facebookincubator/velox/issues/2972

Steps for an accurate repro:
1. When emitting `ConstantExpr` to sql, check it's scalar type (`typeKind() < ARRAY`), if not then omit `__complex_constant(c{i})`, where `i` = the i-th (0 idxed) complex constant in this sql, and add the constant vector to a list
2. Combine all constant vector in the list to a `RowVector` and write the vector to a file
3. When reproducing, `__complex_constant` will automatically be treated as a `CallExpr` by the parser.
4. Modify `inferTypes()` so that when seeing a `CallExpr`, check if the name is `__complex_constant`, if so, return a `ConstantExpr` built from the corresponding vector.
5. Added test on a small example.

Downside: sql-expressable complex constant will also become `__complex_constant`, for example `map(Array[0,1,2,3,4], Array[1,2,3,4,5])`, which makes the sql contain less readable information.

Differential Revision: D41106933

