### PR TITLE
Refactor ParquetDataReader

### DIFF
--- a/velox/dwio/common/FormatDataReader.h
+++ b/velox/dwio/common/FormatDataReader.h
@@ -28,9 +28,9 @@ namespace facebook::velox::dwio::common {
 
 /// Interface base class for format-specific state in common between different
 /// file format readers.
-class FormatData {
+class FormatDataReader {
  public:
-  virtual ~FormatData() = default;
+  virtual ~FormatDataReader() = default;
 
   template <typename T>
   T& as() {
@@ -84,7 +84,7 @@ class FormatData {
   /// Seeks the position to the 'index'th row group for the streams
   /// managed by 'this'. Returns a PositionProvider for streams not
   /// managed by 'this'. In a format like Parquet where all the reading
-  /// is in FormatData the provider is at end. For ORC/DWRF the type
+  /// is in FormatDataReader the provider is at end. For ORC/DWRF the type
   /// dependent stream positions are accessed via the provider. The
   /// provider is valid until next call of this.
   virtual dwio::common::PositionProvider seekToRowGroup(uint32_t index) = 0;
@@ -127,7 +127,7 @@ class FormatParams {
 
   /// Makes format-specific structures for the column given by  'type'.
   /// 'scanSpec' is given as extra context.
-  virtual std::unique_ptr<FormatData> toFormatData(
+  virtual std::unique_ptr<FormatDataReader> toFormatDataReader(
       const std::shared_ptr<const dwio::common::TypeWithId>& type,
       const velox::common::ScanSpec& scanSpec) = 0;
 

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -49,7 +49,7 @@ SelectiveColumnReader::SelectiveColumnReader(
     const TypePtr& type)
     : memoryPool_(params.pool()),
       nodeType_(requestedType),
-      formatData_(params.toFormatData(requestedType, scanSpec)),
+      formatData_(params.toFormatDataReader(requestedType, scanSpec)),
       scanSpec_(&scanSpec),
       type_{type} {}
 

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -19,7 +19,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/common/process/ProcessBase.h"
 #include "velox/dwio/common/ColumnSelector.h"
-#include "velox/dwio/common/FormatData.h"
+#include "velox/dwio/common/FormatDataReader.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/type/Filter.h"
 
@@ -128,7 +128,7 @@ class SelectiveColumnReader {
 
   virtual ~SelectiveColumnReader() = default;
 
-  dwio::common::FormatData& formatData() const {
+  dwio::common::FormatDataReader& formatData() const {
     return *formatData_;
   }
 
@@ -505,7 +505,7 @@ class SelectiveColumnReader {
   std::shared_ptr<const dwio::common::TypeWithId> nodeType_;
 
   // Format specific state and functions.
-  std::unique_ptr<dwio::common::FormatData> formatData_;
+  std::unique_ptr<dwio::common::FormatDataReader> formatData_;
 
   // Specification of filters, value extraction, pruning etc. The
   // spec is assigned at construction and the contents may change at

--- a/velox/dwio/dwrf/reader/CMakeLists.txt
+++ b/velox/dwio/dwrf/reader/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(
   velox_dwio_dwrf_reader
   BinaryStreamReader.cpp
   ColumnReader.cpp
-  DwrfData.cpp
+  DwrfDataReader.cpp
   DwrfReader.cpp
   FlatMapColumnReader.cpp
   ReaderBase.cpp

--- a/velox/dwio/dwrf/reader/DwrfDataReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfDataReader.cpp
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/dwrf/reader/DwrfData.h"
+#include "velox/dwio/dwrf/reader/DwrfDataReader.h"
 
 #include "velox/dwio/common/BufferUtil.h"
 
 namespace facebook::velox::dwrf {
 
-DwrfData::DwrfData(
+DwrfDataReader::DwrfDataReader(
     std::shared_ptr<const dwio::common::TypeWithId> nodeType,
     StripeStreams& stripe,
     FlatMapContext flatMapContext)
@@ -44,7 +44,7 @@ DwrfData::DwrfData(
       encodingKey.forKind(proto::Stream_Kind_ROW_INDEX), false);
 }
 
-uint64_t DwrfData::skipNulls(uint64_t numValues, bool /*nullsOnly*/) {
+uint64_t DwrfDataReader::skipNulls(uint64_t numValues, bool /*nullsOnly*/) {
   if (!notNullDecoder_ && !flatMapContext_.inMapDecoder) {
     return numValues;
   }
@@ -77,14 +77,14 @@ uint64_t DwrfData::skipNulls(uint64_t numValues, bool /*nullsOnly*/) {
   return numValues;
 }
 
-void DwrfData::ensureRowGroupIndex() {
+void DwrfDataReader::ensureRowGroupIndex() {
   VELOX_CHECK(index_ || indexStream_, "Reader needs to have an index stream");
   if (indexStream_) {
     index_ = ProtoUtils::readProto<proto::RowIndex>(std::move(indexStream_));
   }
 }
 
-dwio::common::PositionProvider DwrfData::seekToRowGroup(uint32_t index) {
+dwio::common::PositionProvider DwrfDataReader::seekToRowGroup(uint32_t index) {
   ensureRowGroupIndex();
   tempPositions_ = toPositionsInner(index_->entry(index));
   dwio::common::PositionProvider positionProvider(tempPositions_);
@@ -99,7 +99,7 @@ dwio::common::PositionProvider DwrfData::seekToRowGroup(uint32_t index) {
   return positionProvider;
 }
 
-void DwrfData::readNulls(
+void DwrfDataReader::readNulls(
     vector_size_t numValues,
     const uint64_t* FOLLY_NULLABLE incomingNulls,
     BufferPtr& nulls,
@@ -131,7 +131,7 @@ void DwrfData::readNulls(
   }
 }
 
-std::vector<uint32_t> DwrfData::filterRowGroups(
+std::vector<uint32_t> DwrfDataReader::filterRowGroups(
     const common::ScanSpec& scanSpec,
     uint64_t rowGroupSize,
     const dwio::common::StatsContext& writerContext) {

--- a/velox/dwio/dwrf/reader/DwrfDataReader.h
+++ b/velox/dwio/dwrf/reader/DwrfDataReader.h
@@ -18,7 +18,7 @@
 
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnSelector.h"
-#include "velox/dwio/common/FormatData.h"
+#include "velox/dwio/common/FormatDataReader.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/dwrf/common/ByteRLE.h"
 #include "velox/dwio/dwrf/common/Compression.h"
@@ -31,9 +31,9 @@
 namespace facebook::velox::dwrf {
 
 // DWRF specific functions shared between all readers.
-class DwrfData : public dwio::common::FormatData {
+class DwrfDataReader : public dwio::common::FormatDataReader {
  public:
-  DwrfData(
+  DwrfDataReader(
       std::shared_ptr<const dwio::common::TypeWithId> nodeType,
       StripeStreams& stripe,
       FlatMapContext flatMapContext);
@@ -128,10 +128,11 @@ class DwrfParams : public dwio::common::FormatParams {
         stripeStreams_(stripeStreams),
         flatMapContext_(context) {}
 
-  std::unique_ptr<dwio::common::FormatData> toFormatData(
+  std::unique_ptr<dwio::common::FormatDataReader> toFormatDataReader(
       const std::shared_ptr<const dwio::common::TypeWithId>& type,
       const common::ScanSpec& /*scanSpec*/) override {
-    return std::make_unique<DwrfData>(type, stripeStreams_, flatMapContext_);
+    return std::make_unique<DwrfDataReader>(
+        type, stripeStreams_, flatMapContext_);
   }
 
   StripeStreams& stripeStreams() {

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
-#include "velox/dwio/dwrf/reader/DwrfData.h"
+#include "velox/dwio/dwrf/reader/DwrfDataReader.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
@@ -18,7 +18,7 @@
 
 #include "velox/dwio/common/SelectiveColumnReader.h"
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
-#include "velox/dwio/dwrf/reader/DwrfData.h"
+#include "velox/dwio/dwrf/reader/DwrfDataReader.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -275,7 +275,8 @@ class SelectiveFlatMapReader : public SelectiveStructColumnReaderBase {
       }
       int currentRowSize = 0;
       for (int k = 0; k < children_.size(); ++k) {
-        auto& data = static_cast<const DwrfData&>(children_[k]->formatData());
+        auto& data =
+            static_cast<const DwrfDataReader&>(children_[k]->formatData());
         auto* inMap = data.inMap();
         if (inMap && bits::isBitNull(inMap, rows[i])) {
           continue;

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveColumnReader.h"
-#include "velox/dwio/dwrf/reader/DwrfData.h"
+#include "velox/dwio/dwrf/reader/DwrfDataReader.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveIntegerColumnReader.h"
-#include "velox/dwio/dwrf/reader/DwrfData.h"
+#include "velox/dwio/dwrf/reader/DwrfDataReader.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -18,7 +18,7 @@
 
 #include "velox/dwio/common/SelectiveIntegerColumnReader.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
-#include "velox/dwio/dwrf/reader/DwrfData.h"
+#include "velox/dwio/dwrf/reader/DwrfDataReader.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -19,7 +19,7 @@
 #include "velox/dwio/common/BufferUtil.h"
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
-#include "velox/dwio/dwrf/reader/DwrfData.h"
+#include "velox/dwio/dwrf/reader/DwrfDataReader.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -61,7 +61,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
   std::unique_ptr<SeekableInputStream> inDictStream = stripe.getStream(
       encodingKey.forKind(proto::Stream_Kind_IN_DICTIONARY), false);
   if (inDictStream) {
-    formatData_->as<DwrfData>().ensureRowGroupIndex();
+    formatData_->as<DwrfDataReader>().ensureRowGroupIndex();
 
     inDictionaryReader_ =
         createBooleanRleDecoder(std::move(inDictStream), encodingKey);
@@ -132,7 +132,7 @@ void SelectiveStringDictionaryColumnReader::loadStrideDictionary() {
 
   // get stride dictionary size and load it if needed
   auto& positions =
-      formatData_->as<DwrfData>().index().entry(nextStride).positions();
+      formatData_->as<DwrfDataReader>().index().entry(nextStride).positions();
   scanState_.dictionary2.numValues = positions.Get(strideDictSizeOffset_);
   if (scanState_.dictionary2.numValues > 0) {
     // seek stride dictionary related streams
@@ -295,7 +295,7 @@ void SelectiveStringDictionaryColumnReader::ensureInitialized() {
 
   // handle in dictionary stream
   if (inDictionaryReader_) {
-    auto& dwrfData = formatData_->as<DwrfData>();
+    auto& dwrfData = formatData_->as<DwrfDataReader>();
     dwrfData.ensureRowGroupIndex();
     // load stride dictionary offsets
     auto indexStartOffset = dwrfData.flatMapContext().inMapDecoder

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
-#include "velox/dwio/dwrf/reader/DwrfData.h"
+#include "velox/dwio/dwrf/reader/DwrfDataReader.h"
 
 namespace facebook::velox::dwrf {
 
@@ -33,7 +33,8 @@ class SelectiveStringDictionaryColumnReader
 
   void seekToRowGroup(uint32_t index) override {
     SelectiveColumnReader::seekToRowGroup(index);
-    auto positionsProvider = formatData_->as<DwrfData>().seekToRowGroup(index);
+    auto positionsProvider =
+        formatData_->as<DwrfDataReader>().seekToRowGroup(index);
     if (strideDictStream_) {
       strideDictStream_->seekToPosition(positionsProvider);
       strideDictLengthDecoder_->seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
-#include "velox/dwio/dwrf/reader/DwrfData.h"
+#include "velox/dwio/dwrf/reader/DwrfDataReader.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
-#include "velox/dwio/dwrf/reader/DwrfData.h"
+#include "velox/dwio/dwrf/reader/DwrfDataReader.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
-#include "velox/dwio/dwrf/reader/DwrfData.h"
+#include "velox/dwio/dwrf/reader/DwrfDataReader.h"
 
 namespace facebook::velox::dwrf {
 class SelectiveTimestampColumnReader

--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(
   NestedStructureDecoder.cpp
   ParquetReader.cpp
   PageReader.cpp
-  ParquetData.cpp
+  ParquetDataReader.cpp
   ParquetColumnReader.cpp
   RleBpDecoder.cpp
   Statistics.cpp

--- a/velox/dwio/parquet/reader/FloatingPointColumnReader.h
+++ b/velox/dwio/parquet/reader/FloatingPointColumnReader.h
@@ -40,7 +40,7 @@ class FloatingPointColumnReader
     root::seekToRowGroup(index);
     root::scanState().clear();
     root::readOffset_ = 0;
-    root::formatData_->as<ParquetData>().seekToRowGroup(index);
+    root::formatData_->as<ParquetDataReader>().seekToRowGroup(index);
   }
 
   uint64_t skip(uint64_t numValues) override;
@@ -76,7 +76,7 @@ template <typename TVisitor>
 void FloatingPointColumnReader<TData, TRequested>::readWithVisitor(
     RowSet rows,
     TVisitor visitor) {
-  root::formatData_->as<ParquetData>().readWithVisitor(visitor);
+  root::formatData_->as<ParquetDataReader>().readWithVisitor(visitor);
   root::readOffset_ += rows.back() + 1;
 }
 

--- a/velox/dwio/parquet/reader/FloatingPointColumnReader.h
+++ b/velox/dwio/parquet/reader/FloatingPointColumnReader.h
@@ -40,7 +40,7 @@ class FloatingPointColumnReader
     root::seekToRowGroup(index);
     root::scanState().clear();
     root::readOffset_ = 0;
-    root::formatData_->as<ParquetDataReader>().seekToRowGroup(index);
+    root::formatData_->as<ParquetPrimitiveDataReader>().seekToRowGroup(index);
   }
 
   uint64_t skip(uint64_t numValues) override;
@@ -76,7 +76,7 @@ template <typename TVisitor>
 void FloatingPointColumnReader<TData, TRequested>::readWithVisitor(
     RowSet rows,
     TVisitor visitor) {
-  root::formatData_->as<ParquetDataReader>().readWithVisitor(visitor);
+  root::formatData_->as<ParquetPrimitiveDataReader>().readWithVisitor(visitor);
   root::readOffset_ += rows.back() + 1;
 }
 

--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -37,7 +37,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
   bool hasBulkPath() const override {
     return !this->type()->isLongDecimal() &&
         ((this->type()->isShortDecimal())
-             ? formatData_->as<ParquetData>().hasDictionary()
+             ? formatData_->as<ParquetDataReader>().hasDictionary()
              : true);
   }
 
@@ -45,11 +45,11 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
     SelectiveColumnReader::seekToRowGroup(index);
     scanState().clear();
     readOffset_ = 0;
-    formatData_->as<ParquetData>().seekToRowGroup(index);
+    formatData_->as<ParquetDataReader>().seekToRowGroup(index);
   }
 
   uint64_t skip(uint64_t numValues) override {
-    formatData_->as<ParquetData>().skip(numValues);
+    formatData_->as<ParquetDataReader>().skip(numValues);
     return numValues;
   }
 
@@ -57,7 +57,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
       vector_size_t offset,
       RowSet rows,
       const uint64_t* /*incomingNulls*/) override {
-    auto& data = formatData_->as<ParquetData>();
+    auto& data = formatData_->as<ParquetDataReader>();
     VELOX_WIDTH_DISPATCH(
         parquetSizeOfIntKind(type_->kind()),
         prepareRead,
@@ -69,7 +69,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
 
   template <typename ColumnVisitor>
   void readWithVisitor(RowSet rows, ColumnVisitor visitor) {
-    formatData_->as<ParquetData>().readWithVisitor(visitor);
+    formatData_->as<ParquetDataReader>().readWithVisitor(visitor);
     readOffset_ += rows.back() + 1;
   }
 };

--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -37,7 +37,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
   bool hasBulkPath() const override {
     return !this->type()->isLongDecimal() &&
         ((this->type()->isShortDecimal())
-             ? formatData_->as<ParquetDataReader>().hasDictionary()
+             ? formatData_->as<ParquetPrimitiveDataReader>().hasDictionary()
              : true);
   }
 
@@ -45,11 +45,11 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
     SelectiveColumnReader::seekToRowGroup(index);
     scanState().clear();
     readOffset_ = 0;
-    formatData_->as<ParquetDataReader>().seekToRowGroup(index);
+    formatData_->as<ParquetPrimitiveDataReader>().seekToRowGroup(index);
   }
 
   uint64_t skip(uint64_t numValues) override {
-    formatData_->as<ParquetDataReader>().skip(numValues);
+    formatData_->as<ParquetPrimitiveDataReader>().skip(numValues);
     return numValues;
   }
 
@@ -57,7 +57,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
       vector_size_t offset,
       RowSet rows,
       const uint64_t* /*incomingNulls*/) override {
-    auto& data = formatData_->as<ParquetDataReader>();
+    auto& data = formatData_->as<ParquetPrimitiveDataReader>();
     VELOX_WIDTH_DISPATCH(
         parquetSizeOfIntKind(type_->kind()),
         prepareRead,
@@ -69,7 +69,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
 
   template <typename ColumnVisitor>
   void readWithVisitor(RowSet rows, ColumnVisitor visitor) {
-    formatData_->as<ParquetDataReader>().readWithVisitor(visitor);
+    formatData_->as<ParquetPrimitiveDataReader>().readWithVisitor(visitor);
     readOffset_ += rows.back() + 1;
   }
 };

--- a/velox/dwio/parquet/reader/ParquetColumnReader.h
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "velox/dwio/parquet/reader/ParquetData.h"
+#include "velox/dwio/parquet/reader/ParquetDataReader.h"
 
 namespace facebook::velox::parquet {
 

--- a/velox/dwio/parquet/reader/ParquetDataReader.h
+++ b/velox/dwio/parquet/reader/ParquetDataReader.h
@@ -29,7 +29,8 @@ class ParquetParams : public dwio::common::FormatParams {
  public:
   ParquetParams(memory::MemoryPool& pool, const thrift::FileMetaData& metaData)
       : FormatParams(pool), metaData_(metaData) {}
-  std::unique_ptr<dwio::common::FormatData> toFormatData(
+
+  std::unique_ptr<dwio::common::FormatDataReader> toFormatDataReader(
       const std::shared_ptr<const dwio::common::TypeWithId>& type,
       const common::ScanSpec& scanSpec) override;
 
@@ -38,9 +39,9 @@ class ParquetParams : public dwio::common::FormatParams {
 };
 
 /// Format-specific data created for each leaf column of a Parquet rowgroup.
-class ParquetData : public dwio::common::FormatData {
+class ParquetDataReader : public dwio::common::FormatDataReader {
  public:
-  ParquetData(
+  ParquetDataReader(
       const std::shared_ptr<const dwio::common::TypeWithId>& type,
       const std::vector<thrift::RowGroup>& rowGroups,
       memory::MemoryPool& pool)

--- a/velox/dwio/parquet/reader/StringColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StringColumnReader.cpp
@@ -35,7 +35,7 @@ void StringColumnReader::readHelper(
     common::Filter* filter,
     RowSet rows,
     ExtractValues extractValues) {
-  formatData_->as<ParquetDataReader>().readWithVisitor(
+  formatData_->as<ParquetPrimitiveDataReader>().readWithVisitor(
       dwio::common::
           ColumnVisitor<folly::StringPiece, TFilter, ExtractValues, isDense>(
               *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
@@ -128,7 +128,7 @@ void StringColumnReader::read(
 void StringColumnReader::getValues(RowSet rows, VectorPtr* result) {
   if (scanState_.dictionary.values) {
     auto dictionaryValues =
-        formatData_->as<ParquetDataReader>().dictionaryValues();
+        formatData_->as<ParquetPrimitiveDataReader>().dictionaryValues();
     compactScalarValues<int32_t, int32_t>(rows, false);
 
     *result = std::make_shared<DictionaryVector<StringView>>(
@@ -149,7 +149,7 @@ void StringColumnReader::getValues(RowSet rows, VectorPtr* result) {
 
 void StringColumnReader::dedictionarize() {
   if (scanSpec_->keepValues()) {
-    auto dict = formatData_->as<ParquetDataReader>()
+    auto dict = formatData_->as<ParquetPrimitiveDataReader>()
                     .dictionaryValues()
                     ->as<FlatVector<StringView>>();
     auto valuesCapacity = values_->capacity();
@@ -176,6 +176,6 @@ void StringColumnReader::dedictionarize() {
     numValues_ = numValues;
   }
   scanState_.clear();
-  formatData_->as<ParquetDataReader>().clearDictionary();
+  formatData_->as<ParquetPrimitiveDataReader>().clearDictionary();
 }
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/StringColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StringColumnReader.cpp
@@ -35,7 +35,7 @@ void StringColumnReader::readHelper(
     common::Filter* filter,
     RowSet rows,
     ExtractValues extractValues) {
-  formatData_->as<ParquetData>().readWithVisitor(
+  formatData_->as<ParquetDataReader>().readWithVisitor(
       dwio::common::
           ColumnVisitor<folly::StringPiece, TFilter, ExtractValues, isDense>(
               *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
@@ -127,7 +127,8 @@ void StringColumnReader::read(
 
 void StringColumnReader::getValues(RowSet rows, VectorPtr* result) {
   if (scanState_.dictionary.values) {
-    auto dictionaryValues = formatData_->as<ParquetData>().dictionaryValues();
+    auto dictionaryValues =
+        formatData_->as<ParquetDataReader>().dictionaryValues();
     compactScalarValues<int32_t, int32_t>(rows, false);
 
     *result = std::make_shared<DictionaryVector<StringView>>(
@@ -148,7 +149,7 @@ void StringColumnReader::getValues(RowSet rows, VectorPtr* result) {
 
 void StringColumnReader::dedictionarize() {
   if (scanSpec_->keepValues()) {
-    auto dict = formatData_->as<ParquetData>()
+    auto dict = formatData_->as<ParquetDataReader>()
                     .dictionaryValues()
                     ->as<FlatVector<StringView>>();
     auto valuesCapacity = values_->capacity();
@@ -175,6 +176,6 @@ void StringColumnReader::dedictionarize() {
     numValues_ = numValues;
   }
   scanState_.clear();
-  formatData_->as<ParquetData>().clearDictionary();
+  formatData_->as<ParquetDataReader>().clearDictionary();
 }
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/StringColumnReader.h
+++ b/velox/dwio/parquet/reader/StringColumnReader.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
-#include "velox/dwio/parquet/reader/ParquetData.h"
+#include "velox/dwio/parquet/reader/ParquetDataReader.h"
 
 namespace facebook::velox::parquet {
 
@@ -38,7 +38,7 @@ class StringColumnReader : public dwio::common::SelectiveColumnReader {
     SelectiveColumnReader::seekToRowGroup(index);
     scanState().clear();
     readOffset_ = 0;
-    formatData_->as<ParquetData>().seekToRowGroup(index);
+    formatData_->as<ParquetDataReader>().seekToRowGroup(index);
   }
 
   uint64_t skip(uint64_t numValues) override;

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -42,7 +42,7 @@ void StructColumnReader::enqueueRowGroup(
     if (auto structChild = dynamic_cast<StructColumnReader*>(child)) {
       structChild->enqueueRowGroup(index, input);
     } else {
-      child->formatData().as<ParquetData>().enqueueRowGroup(index, input);
+      child->formatData().as<ParquetDataReader>().enqueueRowGroup(index, input);
     }
   }
 }


### PR DESCRIPTION
To prepare for the Parquet complex type readers, this commit extracts a
common `ParquetDataReader` which handles RowGroup related operations. The
previous `ParquetDataReader` was renamed as `ParquetPrimitiveDataReader`.
Its member `reader_` was renamed as `pageReader_`.

This is the second PR of https://github.com/facebookincubator/velox/pull/3090. Depending on https://github.com/facebookincubator/velox/pull/3162