### PR TITLE
Update the group id based on whether the col in the grouping set

### DIFF
--- a/velox/exec/GroupId.cpp
+++ b/velox/exec/GroupId.cpp
@@ -88,11 +88,13 @@ RowVectorPtr GroupId::getOutput() {
   auto numGroupingKeys = mapping.size();
 
   // Fill in grouping keys.
+  auto gid = 0;
   for (auto i = 0; i < numGroupingKeys; ++i) {
     if (mapping[i] == kMissingGroupingKey) {
       // Add null column.
       outputColumns[i] = BaseVector::createNullConstant(
           outputType_->childAt(i), numInput, pool());
+      gid = 1 << (numGroupingKeys - i - 1) | gid;
     } else {
       outputColumns[i] = input_->childAt(mapping[i]);
     }
@@ -105,7 +107,7 @@ RowVectorPtr GroupId::getOutput() {
 
   // Add groupId column.
   outputColumns[outputType_->size() - 1] =
-      BaseVector::createConstant((int64_t)groupingSetIndex_, numInput, pool());
+      BaseVector::createConstant((int64_t)gid, numInput, pool());
 
   ++groupingSetIndex_;
   if (groupingSetIndex_ == groupingKeyMappings_.size()) {


### PR DESCRIPTION
Currently the group_id column value is from 0 to number of grouping sets keys, which cannot  specify whether the column in the grouping set.  
In this PR If the column is in the grouping sets, we set the bit value to 0, otherwise 1. Then we convert the bit vector to a int value as the group_id.
