### PR TITLE
Fix hash table size

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -621,6 +621,9 @@ void HashTable<ignoreNullKeys>::checkSize(int32_t numNew) {
     // hashing.
     auto newSize = std::max(
         (uint64_t)2048, bits::nextPowerOfTwo(numNew * 2 + numDistinct_));
+    if (numNew + numDistinct_ > rehashSize(newSize)) {
+      newSize *= 2;
+    }
     allocateTables(newSize);
     if (numDistinct_) {
       rehash();

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -397,13 +397,17 @@ class HashTable : public BaseHashTable {
     return 0;
   }
 
+  uint64_t rehashSize() const {
+    return rehashSize(size_);
+  }
+
   std::string toString() override;
 
  private:
   // Returns the number of entries after which the table gets rehashed.
-  uint64_t rehashSize() const {
+  static uint64_t rehashSize(int64_t size) {
     // This implements the F14 load factor: Resize if less than 1/8 unoccupied.
-    return size_ - (size_ / 8);
+    return size - (size / 8);
   }
 
   template <RowContainer::ProbeType probeType>


### PR DESCRIPTION
Problem statement: https://github.com/facebookincubator/velox/issues/3173

The root cause is when we switch from kArray to regular hashing, we forgot to give extra space of the hash table. e.g.

If numDistinct_ > (256K*7/8), according to below logic, the hash table size should be 512k. But upstream logic will create a 256K hash table which leads to serious hash collision. It's the root cause of the performance regression. With the PRs' fix, we can make sure that in all cases rehashSize() >= numDistinct()
```
  if (!table_ || !size_) {
    // ...
    // If numNew is 0 and numDistinct_ is ~256K, newSize will also be 256K.
    auto newSize = std::max(
        (uint64_t)2048, bits::nextPowerOfTwo(numNew * 2 + numDistinct_));
    allocateTables(newSize);
    if (numDistinct_) {
      rehash();
    }

  //rehashSize()  = size_ - (size_ / 8)
  } else if (numNew + numDistinct_ > rehashSize()) {
    auto newSize = bits::nextPowerOfTwo(size_ + numNew);
    allocateTables(newSize);
    rehash();
  }
```