### PR TITLE
Fix semi project join in the presence of null keys

### DIFF
--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -279,9 +279,9 @@ class HashBuild final : public Operator {
   // Set of active rows during addInput().
   SelectivityVector activeRows_;
 
-  // True if this is a build side of an anti join and has at least one entry
-  // with null join keys.
-  bool antiJoinHasNullKeys_{false};
+  // True if this is a build side of an anti or left semi project join and has
+  // at least one entry with null join keys.
+  bool joinHasNullKeys_{false};
 
   // Counts input batches and triggers spilling if folly hash of this % 100 <=
   // 'testSpillPct_';.

--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -32,7 +32,8 @@ void HashJoinBridge::addBuilder() {
 
 bool HashJoinBridge::setHashTable(
     std::unique_ptr<BaseHashTable> table,
-    SpillPartitionSet spillPartitionSet) {
+    SpillPartitionSet spillPartitionSet,
+    bool hasNullKeys) {
   VELOX_CHECK_NOT_NULL(table, "setHashTable called with null table");
 
   auto spillPartitionIdSet = toSpillPartitionIdSet(spillPartitionSet);
@@ -61,7 +62,8 @@ bool HashJoinBridge::setHashTable(
     buildResult_ = HashBuildResult(
         std::move(table),
         std::move(restoringSpillPartitionId_),
-        std::move(spillPartitionIdSet));
+        std::move(spillPartitionIdSet),
+        hasNullKeys);
     restoringSpillPartitionId_.reset();
 
     hasSpillData = !spillPartitionSets_.empty();

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -40,7 +40,8 @@ class HashJoinBridge : public JoinBridge {
   /// applies if the disk spilling is enabled.
   bool setHashTable(
       std::unique_ptr<BaseHashTable> table,
-      SpillPartitionSet spillPartitionSet);
+      SpillPartitionSet spillPartitionSet,
+      bool hasNullKeys);
 
   void setAntiJoinHasNullKeys();
 
@@ -54,15 +55,16 @@ class HashJoinBridge : public JoinBridge {
     HashBuildResult(
         std::shared_ptr<BaseHashTable> _table,
         std::optional<SpillPartitionId> _restoredPartitionId,
-        SpillPartitionIdSet _spillPartitionIds)
-        : antiJoinHasNullKeys(false),
+        SpillPartitionIdSet _spillPartitionIds,
+        bool _hasNullKeys)
+        : hasNullKeys(_hasNullKeys),
           table(std::move(_table)),
           restoredPartitionId(std::move(_restoredPartitionId)),
           spillPartitionIds(std::move(_spillPartitionIds)) {}
 
-    HashBuildResult() : antiJoinHasNullKeys(true) {}
+    HashBuildResult() : hasNullKeys(true) {}
 
-    bool antiJoinHasNullKeys{false};
+    bool hasNullKeys;
     std::shared_ptr<BaseHashTable> table;
     std::optional<SpillPartitionId> restoredPartitionId;
     SpillPartitionIdSet spillPartitionIds;

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -286,14 +286,21 @@ void HashProbe::asyncWaitForHashTable() {
     return;
   }
 
-  if (hashBuildResult->antiJoinHasNullKeys) {
-    // Null-aware anti join with null keys on the build side without a filter
-    // always returns nothing.
-    VELOX_CHECK(isNullAwareAntiJoin(joinType_));
-    // 'antiJoinHasNullKeys' flag shall only be set on the first built 'table_'
-    VELOX_CHECK(spillPartitionSet_.empty());
-    noMoreInput();
-    return;
+  if (hashBuildResult->hasNullKeys) {
+    if (isNullAwareAntiJoin(joinType_)) {
+      // Null-aware anti join with null keys on the build side without a filter
+      // always returns nothing.
+      // The flag must be set on the first (and only) built 'table_'.
+      VELOX_CHECK(spillPartitionSet_.empty());
+      noMoreInput();
+      return;
+    }
+
+    if (isLeftSemiProjectJoin(joinType_)) {
+      buildSideHasNullKeys_ = true;
+    } else {
+      VELOX_UNREACHABLE();
+    }
   }
 
   table_ = std::move(hashBuildResult->table);
@@ -497,6 +504,22 @@ void HashProbe::clearDynamicFilters() {
   Operator::clearDynamicFilters();
 }
 
+void HashProbe::decodeAndDetectNonNullKeys() {
+  nonNullInputRows_.resize(input_->size());
+  nonNullInputRows_.setAll();
+
+  for (auto i = 0; i < hashers_.size(); ++i) {
+    auto key = input_->childAt(hashers_[i]->channel())->loadedVector();
+    hashers_[i]->decode(*key, nonNullInputRows_);
+  }
+
+  deselectRowsWithNulls(hashers_, nonNullInputRows_);
+  if (isRightSemiProjectJoin(joinType_) &&
+      nonNullInputRows_.countSelected() < input_->size()) {
+    probeSideHasNullKeys_ = true;
+  }
+}
+
 void HashProbe::addInput(RowVectorPtr input) {
   input_ = std::move(input);
 
@@ -505,7 +528,14 @@ void HashProbe::addInput(RowVectorPtr input) {
     return;
   }
 
+  bool hasDecoded = false;
+
   if (needSpillInput()) {
+    if (isRightSemiProjectJoin(joinType_) && !probeSideHasNullKeys_) {
+      decodeAndDetectNonNullKeys();
+      hasDecoded = true;
+    }
+
     spillInput(input_);
     // Check if all the probe input rows have been spilled.
     if (input_ == nullptr) {
@@ -524,28 +554,19 @@ void HashProbe::addInput(RowVectorPtr input) {
     VELOX_CHECK(
         isAntiJoins(joinType_) || isLeftJoin(joinType_) ||
         isFullJoin(joinType_) || isLeftSemiProjectJoin(joinType_));
-    if (!isAntiJoins(joinType_) || (filter_ == nullptr)) {
-      return;
+    if (isLeftSemiProjectJoin(joinType_) ||
+        (isAntiJoins(joinType_) && filter_)) {
+      // For anti join with filter and semi project join we need to decode the
+      // join keys columns to initialize 'nonNullInputRows_'. The anti join
+      // filter evaluation and semi project join output generation will access
+      // 'nonNullInputRows_' later.
+      decodeAndDetectNonNullKeys();
     }
-    // For anti join types we need to decode the join keys columns to initialize
-    // 'nonNullInputRows_' if the filter is also present. The filter evaluation
-    // will access 'nonNullInputRows_' later.
-  }
-
-  nonNullInputRows_.resize(input_->size());
-  nonNullInputRows_.setAll();
-
-  for (auto i = 0; i < hashers_.size(); ++i) {
-    auto key = input_->childAt(hashers_[i]->channel())->loadedVector();
-    hashers_[i]->decode(*key, nonNullInputRows_);
-  }
-
-  deselectRowsWithNulls(hashers_, nonNullInputRows_);
-
-  if (table_->numDistinct() == 0) {
-    VELOX_CHECK(isAntiJoins(joinType_));
-    VELOX_CHECK_NOT_NULL(filter_);
     return;
+  }
+
+  if (!hasDecoded) {
+    decodeAndDetectNonNullKeys();
   }
 
   activeRows_ = nonNullInputRows_;
@@ -639,7 +660,16 @@ void HashProbe::fillOutput(vector_size_t size) {
     auto flatMatch = match->as<FlatVector<bool>>();
     auto rawValues = flatMatch->mutableRawValues<uint64_t>();
     for (auto i = 0; i < size; ++i) {
-      bits::setBit(rawValues, i, outputTableRows_[i] != nullptr);
+      if (!nonNullInputRows_.isValid(i)) {
+        flatMatch->setNull(i, true);
+      } else {
+        bool hasMatch = outputTableRows_[i] != nullptr;
+        if (!hasMatch && buildSideHasNullKeys_) {
+          flatMatch->setNull(i, true);
+        } else {
+          bits::setBit(rawValues, i, hasMatch);
+        }
+      }
     }
   } else {
     extractColumns(
@@ -696,7 +726,8 @@ RowVectorPtr HashProbe::getBuildSideOutput() {
   if (isRightSemiProjectJoin(joinType_)) {
     // Populate 'match' column.
     auto match = output_->childAt(outputType_->size() - 1);
-    table_->rows()->extractProbedFlags(outputTableRows_.data(), numOut, match);
+    table_->rows()->extractProbedFlags(
+        outputTableRows_.data(), numOut, probeSideHasNullKeys_, match);
   }
 
   return output_;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -227,6 +227,9 @@ class HashProbe : public Operator {
       vector_size_t numInput,
       const folly::F14FastSet<uint32_t>& spillPartitions);
 
+  /// Decode join key inputs and populate 'nonNullInputRows_'.
+  void decodeAndDetectNonNullKeys();
+
   // Invoked when there is no more input from either upstream task or spill
   // input. If there is remaining spilled data, then the last finished probe
   // operator is responsible for notifying the hash build operators to build the
@@ -289,6 +292,14 @@ class HashProbe : public Operator {
   // Table shared between other HashProbes in other Drivers of the
   // same pipeline.
   std::shared_ptr<BaseHashTable> table_;
+
+  // Indicates whether there are rows with null join keys on the build
+  // side. Used by left semi project join.
+  bool buildSideHasNullKeys_{false};
+
+  // Indicates whether there are rows with null join keys on the probe
+  // side. Used by right semi project join.
+  bool probeSideHasNullKeys_{false};
 
   VectorHasher::ScratchMemory scratchMemory_;
 

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -306,9 +306,14 @@ class RowContainer {
 
   /// Copies the 'probed' flags for the specified rows into 'result'.
   /// The 'result' is expected to be flat vector of type boolean.
+  /// Sets null in 'result' for rows with null keys.
+  /// If 'replaceFalseWithNull' is true, replaces the false probed
+  /// flag with null in 'result' for rows with no null keys. This is used for
+  /// right semi project join type when probe side has nulls in the join keys.
   void extractProbedFlags(
       const char* FOLLY_NONNULL const* FOLLY_NONNULL rows,
       int32_t numRows,
+      bool replaceFalseWithNull,
       const VectorPtr& result);
 
   static inline int32_t nullByte(int32_t nullOffset) {

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -16,14 +16,12 @@
 #include "velox/exec/RowContainer.h"
 #include <gtest/gtest.h>
 #include <algorithm>
-#include <array>
 #include <random>
 #include "velox/common/file/FileSystems.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/exec/VectorHasher.h"
 #include "velox/exec/tests/utils/RowContainerTestBase.h"
-#include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 using namespace facebook::velox;
@@ -798,12 +796,21 @@ TEST_F(RowContainerTest, partition) {
 }
 
 TEST_F(RowContainerTest, probedFlag) {
-  auto rowContainer =
-      makeRowContainer({BIGINT()}, {BIGINT()}, true /*isJoinBuild*/);
+  auto rowContainer = std::make_unique<RowContainer>(
+      std::vector<TypePtr>{BIGINT()}, // keyTypes
+      true, // nullableKeys
+      std::vector<std::unique_ptr<Aggregate>>{},
+      std::vector<TypePtr>{BIGINT()}, // dependentTypes
+      true, // hasNext
+      true, // isJoinBuild
+      true, // hasProbedFlag
+      false, // hasNormalizedKey
+      mappedMemory_,
+      ContainerRowSerde::instance());
 
   auto input = makeRowVector({
-      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
-      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      makeNullableFlatVector<int64_t>({1, 2, 3, 4, std::nullopt, 5}),
+      makeFlatVector<int64_t>({10, 20, 30, 40, -1, 50}),
   });
 
   auto size = input->size();
@@ -816,14 +823,26 @@ TEST_F(RowContainerTest, probedFlag) {
     rowContainer->store(decodedValue, i, rows[i], 1);
   }
 
-  // No 'probed' flags set. Verify all false.
+  // No 'probed' flags set. Verify all false, except for null key row.
   auto result = BaseVector::create<FlatVector<bool>>(BOOLEAN(), 1, pool());
-  rowContainer->extractProbedFlags(rows.data(), size, result);
+  rowContainer->extractProbedFlags(
+      rows.data(), size, false /*replaceFalseWithNull*/, result);
 
   ASSERT_EQ(size, result->size());
   for (auto i = 0; i < size; ++i) {
-    ASSERT_FALSE(result->isNullAt(i));
-    ASSERT_FALSE(result->valueAt(i));
+    if (i == 4) {
+      ASSERT_TRUE(result->isNullAt(i));
+    } else {
+      ASSERT_FALSE(result->isNullAt(i));
+      ASSERT_FALSE(result->valueAt(i));
+    }
+  }
+
+  rowContainer->extractProbedFlags(
+      rows.data(), size, true /*replaceFalseWithNull*/, result);
+  ASSERT_EQ(size, result->size());
+  for (auto i = 0; i < size; ++i) {
+    ASSERT_TRUE(result->isNullAt(i));
   }
 
   // Set 'probed' flags for every other row.
@@ -831,20 +850,54 @@ TEST_F(RowContainerTest, probedFlag) {
     rowContainer->setProbedFlag(rows.data() + i, 1);
   }
 
-  rowContainer->extractProbedFlags(rows.data(), size, result);
+  rowContainer->extractProbedFlags(
+      rows.data(), size, false /*replaceFalseWithNull*/, result);
   ASSERT_EQ(size, result->size());
   for (auto i = 0; i < size; ++i) {
-    ASSERT_FALSE(result->isNullAt(i));
-    ASSERT_EQ(result->valueAt(i), i % 2 == 0);
+    if (i == 4) {
+      ASSERT_TRUE(result->isNullAt(i));
+    } else {
+      ASSERT_FALSE(result->isNullAt(i));
+      ASSERT_EQ(result->valueAt(i), i % 2 == 0);
+    }
+  }
+
+  rowContainer->extractProbedFlags(
+      rows.data(), size, true /*replaceFalseWithNull*/, result);
+  ASSERT_EQ(size, result->size());
+  for (auto i = 0; i < size; ++i) {
+    if (i == 4 || i % 2 != 0) {
+      ASSERT_TRUE(result->isNullAt(i));
+    } else {
+      ASSERT_FALSE(result->isNullAt(i));
+      ASSERT_TRUE(result->valueAt(i));
+    }
   }
 
   // Set 'probed' flags for all rows.
   rowContainer->setProbedFlag(rows.data(), size);
 
-  rowContainer->extractProbedFlags(rows.data(), size, result);
+  rowContainer->extractProbedFlags(
+      rows.data(), size, false /*replaceFalseWithNull*/, result);
   ASSERT_EQ(size, result->size());
   for (auto i = 0; i < size; ++i) {
-    ASSERT_FALSE(result->isNullAt(i));
-    ASSERT_TRUE(result->valueAt(i));
+    if (i == 4) {
+      ASSERT_TRUE(result->isNullAt(i));
+    } else {
+      ASSERT_FALSE(result->isNullAt(i));
+      ASSERT_TRUE(result->valueAt(i));
+    }
+  }
+
+  rowContainer->extractProbedFlags(
+      rows.data(), size, true /*replaceFalseWithNull*/, result);
+  ASSERT_EQ(size, result->size());
+  for (auto i = 0; i < size; ++i) {
+    if (i == 4) {
+      ASSERT_TRUE(result->isNullAt(i));
+    } else {
+      ASSERT_FALSE(result->isNullAt(i));
+      ASSERT_TRUE(result->valueAt(i));
+    }
   }
 }

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -317,8 +317,8 @@ velox::variant arrayVariantAt(
 std::vector<MaterializedRow> materialize(
     ::duckdb::DataChunk* dataChunk,
     const std::shared_ptr<const RowType>& rowType) {
-  EXPECT_EQ(rowType->size(), dataChunk->GetTypes().size())
-      << "Wrong number of columns";
+  VELOX_CHECK_EQ(
+      rowType->size(), dataChunk->GetTypes().size(), "Wrong number of columns");
 
   auto size = dataChunk->size();
   std::vector<MaterializedRow> rows;


### PR DESCRIPTION
When nulls are present in the join keys the behavior of the left semi join should be:

- Left-side rows with nulls in the join key should report NULL regardless of whether build side has nulls or not.
- Left-side rows with non-null keys and no match in the build side should report FALSE if build side has no nulls and NULL if build side has nulls.

Fixes #3169