### PR TITLE
Support type variables onlyKnowntypes property

### DIFF
--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -1208,6 +1208,7 @@ The map_keys function takes any map and returns an array of map keys.
     // map(K,V) -> array(K)
     exec::FunctionSignatureBuilder()
       .typeVariable("K")
+      .knownTypeVariable("K)
       .typeVariable("V")
       .returnType("array(K)")
       .argumentType("map(K,V)")

--- a/velox/exec/tests/AggregationFuzzer.cpp
+++ b/velox/exec/tests/AggregationFuzzer.cpp
@@ -275,18 +275,18 @@ AggregationFuzzer::AggregationFuzzer(
         continue;
       }
 
-      if (!signature->typeVariableConstraints().empty()) {
+      if (!signature->variables().empty()) {
         bool skip = false;
         std::unordered_set<std::string> typeVariables;
-        for (auto& constraint : signature->typeVariableConstraints()) {
-          if (constraint.isIntegerParameter()) {
+        for (auto& [name, variable] : signature->variables()) {
+          if (variable.isIntegerParameter()) {
             LOG(WARNING) << "Skipping generic function signature: " << name
                          << signature->toString();
             skip = true;
             break;
           }
 
-          typeVariables.insert(constraint.name());
+          typeVariables.insert(name);
         }
         if (skip) {
           continue;
@@ -298,13 +298,13 @@ AggregationFuzzer::AggregationFuzzer(
         CallableSignature callable{
             .name = name,
             .args = {},
-            .returnType =
-                SignatureBinder::tryResolveType(signature->returnType(), {})};
+            .returnType = SignatureBinder::tryResolveType(
+                signature->returnType(), {}, {})};
         VELOX_CHECK_NOT_NULL(callable.returnType);
 
         // Process each argument and figure out its type.
         for (const auto& arg : signature->argumentTypes()) {
-          auto resolvedType = SignatureBinder::tryResolveType(arg, {});
+          auto resolvedType = SignatureBinder::tryResolveType(arg, {}, {});
           VELOX_CHECK_NOT_NULL(resolvedType);
 
           callable.args.emplace_back(resolvedType);

--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -44,7 +44,18 @@ TEST_F(FunctionSignatureBuilderTest, basicTypeTests) {
             .argumentType("array(T)")
             .build();
       },
-      "Type parameter declared twice");
+      "Variable T declared twice");
+
+  assertUserInvalidArgument(
+      [=]() {
+        FunctionSignatureBuilder()
+            .typeVariable("T")
+            .knownTypeVariable("T")
+            .returnType("integer")
+            .argumentType("array(T)")
+            .build();
+      },
+      "Variable T declared twice");
 
   // Unspecified type params.
   assertUserInvalidArgument(

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/FunctionSignature.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#include "FunctionSignature.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/type/Type.h"
 
@@ -132,7 +133,7 @@ bool isPositiveInteger(const std::string& str) {
 }
 
 void validateBaseTypeAndCollectTypeParams(
-    const std::unordered_set<std::string>& typeParams,
+    const std::unordered_map<std::string, TypeVariableConstraint>& typeParams,
     const TypeSignature& arg,
     std::unordered_set<std::string>& collectedTypeVariables) {
   if (!typeParams.count(arg.baseName())) {
@@ -168,32 +169,27 @@ void validateBaseTypeAndCollectTypeParams(
 }
 
 void validate(
-    const std::vector<TypeVariableConstraint>& typeVariableConstraints,
+    const std::unordered_map<std::string, TypeVariableConstraint>&
+        typeVariableConstraints,
     const TypeSignature& returnType,
     const std::vector<TypeSignature>& argumentTypes) {
   // Validate that the type params are unique.
-  std::unordered_set<std::string> typeNames(typeVariableConstraints.size());
-  for (const auto& variable : typeVariableConstraints) {
-    VELOX_USER_CHECK(
-        typeNames.insert(variable.name()).second,
-        "Type parameter declared twice {}",
-        variable.name());
-  }
-
   std::unordered_set<std::string> usedTypeVariables;
+
   // Validate the argument types.
   for (const auto& arg : argumentTypes) {
     // Is base type a type parameter or a built in type ?
-    validateBaseTypeAndCollectTypeParams(typeNames, arg, usedTypeVariables);
+    validateBaseTypeAndCollectTypeParams(
+        typeVariableConstraints, arg, usedTypeVariables);
   }
 
   // Similarly validate for return type.
   validateBaseTypeAndCollectTypeParams(
-      typeNames, returnType, usedTypeVariables);
+      typeVariableConstraints, returnType, usedTypeVariables);
 
   VELOX_USER_CHECK_EQ(
       usedTypeVariables.size(),
-      typeNames.size(),
+      typeVariableConstraints.size(),
       "Not all type parameters used");
 }
 
@@ -202,17 +198,24 @@ void validate(
 TypeVariableConstraint::TypeVariableConstraint(
     std::string name,
     std::optional<std::string> constraint,
-    ParameterType type)
+    ParameterType type,
+    bool knownTypesOnly)
     : name_{std::move(name)},
       constraint_(constraint.has_value() ? std::move(constraint.value()) : ""),
-      type_{type} {
+      type_{type},
+      knownTypesOnly_(knownTypesOnly) {
+  VELOX_CHECK(
+      !knownTypesOnly_ || isTypeParameter(),
+      "Non-Type variables cannot have the knownTypesOnly constraint");
+
   VELOX_CHECK(
       isIntegerParameter() || (isTypeParameter() && constraint_.empty()),
-      "Type parameters cannot have constraints");
+      "Type variables cannot have constraints");
 }
 
 FunctionSignature::FunctionSignature(
-    std::vector<TypeVariableConstraint> typeVariableConstraints,
+    std::unordered_map<std::string, TypeVariableConstraint>
+        typeVariableConstraints,
     TypeSignature returnType,
     std::vector<TypeSignature> argumentTypes,
     bool variableArity)

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -18,7 +18,10 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+#include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::exec {
 
@@ -41,7 +44,8 @@ class TypeVariableConstraint {
   explicit TypeVariableConstraint(
       std::string name,
       std::optional<std::string> constraint,
-      ParameterType type);
+      ParameterType type,
+      bool knownTypesOnly = false);
 
   const std::string& name() const {
     return name_;
@@ -49,6 +53,15 @@ class TypeVariableConstraint {
 
   const std::string& constraint() const {
     return constraint_;
+  }
+
+  bool knownTypesOnly() const {
+    VELOX_USER_CHECK(isTypeParameter());
+    return knownTypesOnly_;
+  }
+
+  void setKnownTypesOnly(bool value) {
+    knownTypesOnly_ = value;
   }
 
   bool isTypeParameter() const {
@@ -61,13 +74,17 @@ class TypeVariableConstraint {
 
   bool operator==(const TypeVariableConstraint& rhs) const {
     return type_ == rhs.type_ && name_ == rhs.name_ &&
-        constraint_ == rhs.constraint_;
+        constraint_ == rhs.constraint_ &&
+        knownTypesOnly_ == rhs.knownTypesOnly_;
   }
 
  private:
   const std::string name_;
   const std::string constraint_;
   const ParameterType type_;
+  // This property only applies to type variables and indicates if the type
+  // can bind to unknown or not.
+  bool knownTypesOnly_ = false;
 };
 
 // Base type (e.g. map) and optional parameters (e.g. K, V).
@@ -98,27 +115,25 @@ class TypeSignature {
 
 class FunctionSignature {
  public:
-  /// @param typeVariableConstraints Generic type names used in return type and
-  /// argument types (and constraints if necessary).
-  /// @param returnType Return type. May use generic type names, e.g. array(T).
+  /// @param typeVariableConstraints Generic type names used in return type
+  /// and argument types (and constraints if necessary).
+  /// @param returnType Return type. May use generic type names, e.g.
+  /// array(T).
   /// @param argumentTypes Argument types. May use generic type names, e.g.
-  /// map(K,V). The type of the last argument of a function with variable number
-  /// of arguments can be "any", which means that arguments of any type are
-  /// accepted.
+  /// map(K,V). The type of the last argument of a function with variable
+  /// number of arguments can be "any", which means that arguments of any type
+  /// are accepted.
   /// @param variableArity True if function accepts variable number of
   /// arguments, e.g. concat(varchar...). Variable arity arguments can appear
   /// only at the end of the argument list and their types must match the type
   /// specified in the last entry of 'argumentTypes'. Variable arity arguments
   /// can appear zero or more times.
   FunctionSignature(
-      std::vector<TypeVariableConstraint> typeVariableConstraints,
+      std::unordered_map<std::string, TypeVariableConstraint>
+          typeVariableConstraints,
       TypeSignature returnType,
       std::vector<TypeSignature> argumentTypes,
       bool variableArity);
-
-  const std::vector<TypeVariableConstraint>& typeVariableConstraints() const {
-    return typeVariableConstraints_;
-  }
 
   const TypeSignature& returnType() const {
     return returnType_;
@@ -134,6 +149,10 @@ class FunctionSignature {
 
   std::string toString() const;
 
+  const auto& variables() const {
+    return typeVariableConstraints_;
+  }
+
   // This tests syntactic equality not semantic equality
   // For example, even if only the names of the typeVariableConstraints are
   // different the signatures are considered not equal (array(K) != array(V))
@@ -145,7 +164,8 @@ class FunctionSignature {
   }
 
  private:
-  const std::vector<TypeVariableConstraint> typeVariableConstraints_;
+  const std::unordered_map<std::string, TypeVariableConstraint>
+      typeVariableConstraints_;
   const TypeSignature returnType_;
   const std::vector<TypeSignature> argumentTypes_;
   const bool variableArity_;
@@ -156,7 +176,8 @@ using FunctionSignaturePtr = std::shared_ptr<FunctionSignature>;
 class AggregateFunctionSignature : public FunctionSignature {
  public:
   AggregateFunctionSignature(
-      std::vector<TypeVariableConstraint> typeVariableConstraints,
+      std::unordered_map<std::string, TypeVariableConstraint>
+          typeVariableConstraints,
       TypeSignature returnType,
       TypeSignature intermediateType,
       std::vector<TypeSignature> argumentTypes,
@@ -175,6 +196,21 @@ class AggregateFunctionSignature : public FunctionSignature {
  private:
   const TypeSignature intermediateType_;
 };
+
+namespace {
+
+void addVariable(
+    std::unordered_map<std::string, TypeVariableConstraint>& variables,
+    const TypeVariableConstraint& variable) {
+  VELOX_USER_CHECK(
+      !variables.count(variable.name()),
+      "Variable {} declared twice",
+      variable.name());
+
+  variables.emplace(variable.name(), variable);
+}
+
+} // namespace
 
 /// Parses a string into TypeSignature. The format of the string is type name,
 /// optionally followed by type parameters enclosed in parenthesis.
@@ -207,17 +243,27 @@ TypeSignature parseTypeSignature(const std::string& signature);
 ///                .build()
 class FunctionSignatureBuilder {
  public:
-  FunctionSignatureBuilder& typeVariable(std::string name) {
-    typeVariableConstraints_.emplace_back(
-        name, "", ParameterType::kTypeParameter);
+  FunctionSignatureBuilder& typeVariable(const std::string& name) {
+    addVariable(
+        typeVariableConstraints_,
+        TypeVariableConstraint(name, "", ParameterType::kTypeParameter));
+    return *this;
+  }
+
+  FunctionSignatureBuilder& knownTypeVariable(const std::string& name) {
+    addVariable(
+        typeVariableConstraints_,
+        TypeVariableConstraint(name, "", ParameterType::kTypeParameter, true));
     return *this;
   }
 
   FunctionSignatureBuilder& integerVariable(
-      std::string name,
+      const std::string& name,
       std::optional<std::string> constraint = std::nullopt) {
-    typeVariableConstraints_.emplace_back(
-        name, constraint, ParameterType::kIntegerParameter);
+    addVariable(
+        typeVariableConstraints_,
+        TypeVariableConstraint(
+            name, constraint, ParameterType::kIntegerParameter));
     return *this;
   }
 
@@ -239,7 +285,8 @@ class FunctionSignatureBuilder {
   FunctionSignaturePtr build();
 
  private:
-  std::vector<TypeVariableConstraint> typeVariableConstraints_;
+  std::unordered_map<std::string, TypeVariableConstraint>
+      typeVariableConstraints_;
   std::optional<TypeSignature> returnType_;
   std::vector<TypeSignature> argumentTypes_;
   bool variableArity_{false};
@@ -248,7 +295,8 @@ class FunctionSignatureBuilder {
 /// Convenience class for creating AggregageFunctionSignature instances.
 /// Example of usage:
 ///
-///     - signature of covar_samp aggregate function: (double, double) -> double
+///     - signature of covar_samp aggregate function: (double, double) ->
+///     double
 ///
 ///     exec::AggregateFunctionSignatureBuilder()
 ///                .returnType("double")
@@ -258,17 +306,28 @@ class FunctionSignatureBuilder {
 ///                .build()
 class AggregateFunctionSignatureBuilder {
  public:
-  AggregateFunctionSignatureBuilder& typeVariable(std::string name) {
-    typeVariableConstraints_.emplace_back(
-        name, "", ParameterType::kTypeParameter);
+  AggregateFunctionSignatureBuilder& typeVariable(const std::string& name) {
+    addVariable(
+        typeVariableConstraints_,
+        TypeVariableConstraint(name, "", ParameterType::kTypeParameter));
+    return *this;
+  }
+
+  AggregateFunctionSignatureBuilder& knownTypeVariable(
+      const std::string& name) {
+    addVariable(
+        typeVariableConstraints_,
+        TypeVariableConstraint(name, "", ParameterType::kTypeParameter, true));
     return *this;
   }
 
   AggregateFunctionSignatureBuilder& integerVariable(
-      std::string name,
+      const std::string& name,
       std::optional<std::string> constraint = std::nullopt) {
-    typeVariableConstraints_.emplace_back(
-        name, constraint, ParameterType::kIntegerParameter);
+    addVariable(
+        typeVariableConstraints_,
+        TypeVariableConstraint(
+            name, constraint, ParameterType::kIntegerParameter));
     return *this;
   }
 
@@ -295,7 +354,8 @@ class AggregateFunctionSignatureBuilder {
   std::shared_ptr<AggregateFunctionSignature> build();
 
  private:
-  std::vector<TypeVariableConstraint> typeVariableConstraints_;
+  std::unordered_map<std::string, TypeVariableConstraint>
+      typeVariableConstraints_;
   std::optional<TypeSignature> returnType_;
   std::optional<TypeSignature> intermediateType_;
   std::vector<TypeSignature> argumentTypes_;
@@ -342,8 +402,9 @@ struct hash<facebook::velox::exec::FunctionSignature> {
         std::hash<facebook::velox::exec::TypeSignature>{};
 
     size_t val = 0;
-    for (const auto& constraint : key.typeVariableConstraints()) {
-      val = val * 31 + typeVariableConstraintHasher(constraint);
+    // No need to hash keys, since they are also a field in the value.
+    for (const auto& [_, variable] : key.variables()) {
+      val = val * 31 + typeVariableConstraintHasher(variable);
     }
 
     val = val * 31 + typeSignatureHasher(key.returnType());

--- a/velox/expression/ReverseSignatureBinder.cpp
+++ b/velox/expression/ReverseSignatureBinder.cpp
@@ -18,15 +18,17 @@
 
 namespace facebook::velox::exec {
 
-bool ReverseSignatureBinder::isConstrainedType(
+bool ReverseSignatureBinder::hasConstrainedIntegerVariable(
     const TypeSignature& type) const {
   if (type.parameters().empty()) {
-    return constraints_.find(type.baseName()) != constraints_.end();
+    auto it = variables().find(type.baseName());
+    return it != variables().end() && it->second.isIntegerParameter() &&
+        it->second.constraint() != "";
   }
 
   const auto& parameters = type.parameters();
   for (const auto& parameter : parameters) {
-    if (isConstrainedType(parameter)) {
+    if (hasConstrainedIntegerVariable(parameter)) {
       return true;
     }
   }
@@ -34,7 +36,7 @@ bool ReverseSignatureBinder::isConstrainedType(
 }
 
 bool ReverseSignatureBinder::tryBind() {
-  if (isConstrainedType(signature_.returnType())) {
+  if (hasConstrainedIntegerVariable(signature_.returnType())) {
     return false;
   }
   return SignatureBinderBase::tryBind(signature_.returnType(), returnType_);

--- a/velox/expression/ReverseSignatureBinder.h
+++ b/velox/expression/ReverseSignatureBinder.h
@@ -40,13 +40,13 @@ class ReverseSignatureBinder : private SignatureBinderBase {
   /// tryBind() and only if tryBind() returns true. If a type variable is not
   /// determined by tryBind(), it maps to a nullptr.
   const std::unordered_map<std::string, TypePtr>& bindings() const {
-    return typeParameters_;
+    return typeVariablesBindings_;
   }
 
  private:
-  /// Return whether there is a constraint on the type in the function
+  /// Return whether there is a constraint on an integer variable in type
   /// signature.
-  bool isConstrainedType(const TypeSignature& type) const;
+  bool hasConstrainedIntegerVariable(const TypeSignature& type) const;
 
   const TypePtr returnType_;
 };

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/expression/SignatureBinder.h"
 #include <boost/algorithm/string.hpp>
+#include <optional>
+
 #include "velox/expression/type_calculation/TypeCalculation.h"
 #include "velox/type/Type.h"
 
@@ -41,77 +43,56 @@ std::string buildCalculation(
 
 TypePtr inferDecimalType(
     const exec::TypeSignature& typeSignature,
-    const std::unordered_map<std::string, std::string>& constraints,
-    std::unordered_map<std::string, std::optional<int>>& integerParameters) {
+    const std::unordered_map<std::string, TypeVariableConstraint>& variables,
+    std::unordered_map<std::string, int>& integerVariablesBindings) {
   if (typeSignature.parameters().size() != 2) {
-    // Decimals must have two parameters.
     return nullptr;
   }
+
   const auto& precisionVar = typeSignature.parameters()[0].baseName();
   const auto& scaleVar = typeSignature.parameters()[1].baseName();
-  int precision = 0;
-  int scale = 0;
-  // Determine precision.
-  if (isPositiveInteger(precisionVar)) {
-    // Handle constant.
-    precision = atoi(precisionVar.c_str());
-  } else if (auto it = integerParameters.find(precisionVar);
-             it != integerParameters.end()) {
-    // Check if it is already computed.
-    if (it->second.has_value()) {
-      precision = it->second.value();
-    } else if (auto ct = constraints.find(precisionVar);
-               ct != constraints.end()) {
-      // Check constraints and evaluate.
-      auto precisionCalculation = buildCalculation(precisionVar, ct->second);
-      expression::calculation::evaluate(
-          precisionCalculation, integerParameters);
-      const auto result = integerParameters.at(precisionVar);
-      VELOX_CHECK(
-          result.has_value(), "Variable {} calculation failed.", precisionVar)
-      precision = result.value();
-    } else {
-      // Cannot evaluate further.
-      return nullptr;
+
+  auto inferPositiveInteger = [&](auto variable) -> std::optional<int> {
+    // Determine precision.
+    if (isPositiveInteger(variable)) {
+      // Handle constant.
+      return atoi(variable.c_str());
+    };
+
+    if (integerVariablesBindings.count(variable)) {
+      return integerVariablesBindings.at(variable);
     }
-  } else {
+
+    auto it = variables.find(variable);
+    if (it == variables.end()) {
+      return std::nullopt;
+    }
+
+    auto& constraints = it->second.constraint();
+
+    if (constraints == "") {
+      return std::nullopt;
+    }
+
+    // Try to assign value based on constraints.
+    // Check constraints and evaluate.
+    auto calculation = buildCalculation(variable, constraints);
+    expression::calculation::evaluate(calculation, integerVariablesBindings);
+    VELOX_CHECK(
+        integerVariablesBindings.count(variable),
+        "Variable {} calculation failed.",
+        variable)
+    return integerVariablesBindings.at(variable);
+  };
+
+  auto precision = inferPositiveInteger(precisionVar);
+  auto scale = inferPositiveInteger(scaleVar);
+  if (!precision.has_value() || !scale.has_value()) {
     return nullptr;
   }
-  // Determine scale.
-  if (isPositiveInteger(scaleVar)) {
-    // Handle constant.
-    scale = atoi(scaleVar.c_str());
-  } else if (auto it = integerParameters.find(scaleVar);
-             it != integerParameters.end()) {
-    // Check if it is already computed.
-    if (it->second.has_value()) {
-      scale = it->second.value();
-    } else if (auto ct = constraints.find(scaleVar); ct != constraints.end()) {
-      // Check constraints and evaluate.
-      auto scaleCalculation = buildCalculation(scaleVar, ct->second);
-      expression::calculation::evaluate(scaleCalculation, integerParameters);
-      const auto result = integerParameters.at(scaleVar);
-      VELOX_CHECK(
-          result.has_value(), "Variable {} calculation failed.", scaleVar)
-      scale = result.value();
-    } else {
-      // Cannot evaluate further.
-      return nullptr;
-    }
-  } else {
-    return nullptr;
-  }
-  return DECIMAL(precision, scale);
+  return DECIMAL(*precision, *scale);
 }
 
-bool isConcreteType(
-    const std::unordered_map<std::string, TypePtr>& typeParameters,
-    const std::unordered_map<std::string, std::optional<int>>&
-        integerParameters,
-    const std::string& name) {
-  return (typeParameters.count(name) == 0) &&
-      (integerParameters.count(name) == 0);
-}
 } // namespace
 
 bool SignatureBinder::tryBind() {
@@ -156,16 +137,19 @@ bool SignatureBinder::tryBind() {
 bool SignatureBinderBase::checkOrSetIntegerParameter(
     const std::string& parameterName,
     int value) {
-  auto it = integerParameters_.find(parameterName);
-  // Return false if the parameter is not found.
-  if (it == integerParameters_.end()) {
+  if (!variables().count(parameterName)) {
+    // Return false if the parameter is not found in the signature.
     return false;
   }
-  // Return false if the parameter is found with a different value.
-  if (it->second.has_value() && it->second.value() != value) {
-    return false;
+
+  if (integerVariablesBindings_.count(parameterName)) {
+    // Return false if the parameter is found with a different value.
+    if (integerVariablesBindings_[parameterName] != value) {
+      return false;
+    }
   }
-  it->second = value;
+  // Bind the variable.
+  integerVariablesBindings_[parameterName] = value;
   return true;
 }
 
@@ -173,12 +157,11 @@ bool SignatureBinderBase::tryBindIntegerParameters(
     const std::vector<exec::TypeSignature>& parameters,
     const TypePtr& actualType) {
   // Decimal types
-  if (actualType->isShortDecimal() || actualType->isLongDecimal()) {
-    VELOX_CHECK_EQ(parameters.size(), 2);
-    const auto& [precision, scale] = getDecimalPrecisionScale(*actualType);
-    return checkOrSetIntegerParameter(parameters[0].baseName(), precision) &&
-        checkOrSetIntegerParameter(parameters[1].baseName(), scale);
-  }
+  VELOX_CHECK_EQ(parameters.size(), 2);
+  const auto& [precision, scale] = getDecimalPrecisionScale(*actualType);
+  return checkOrSetIntegerParameter(parameters[0].baseName(), precision) &&
+      checkOrSetIntegerParameter(parameters[1].baseName(), scale);
+
   return false;
 }
 
@@ -190,115 +173,127 @@ bool SignatureBinderBase::tryBind(
   }
 
   const auto baseName = typeSignature.baseName();
-  if (isConcreteType(typeParameters_, integerParameters_, baseName)) {
-    auto typeName = boost::algorithm::to_upper_copy(baseName);
 
-    if (auto customType = getType(baseName, {})) {
-      VELOX_CHECK_EQ(
-          typeSignature.parameters().size(),
-          0,
-          "Custom types with parameters are not supported yet");
-      return customType->equivalent(*actualType);
+  if (variables().count(baseName)) {
+    // Variables cannot have further parameters.
+    VELOX_CHECK(
+        typeSignature.parameters().empty(),
+        "Variables with parameters are not supported");
+    auto& variable = variables().at(baseName);
+    VELOX_CHECK(variable.isTypeParameter(), "Not expecting integer variable");
+
+    if (typeVariablesBindings_.count(baseName)) {
+      // If the the variable type is already mapped to a concrete type, make
+      // sure the mapped type is equivalent to the actual type.
+      return typeVariablesBindings_[baseName]->equivalent(*actualType);
     }
 
-    if (typeName != actualType->kindName()) {
-      if (!(isCommonDecimalName(typeName) &&
-            (actualType->isLongDecimal() || actualType->isShortDecimal()))) {
-        return false;
-      }
-    }
-
-    const auto& params = typeSignature.parameters();
-    // Integer parameters have to be resolved here.
-    // We assume integer parameters start from the first parameter if present.
-    if (params.size() > 0 &&
-        integerParameters_.count(params[0].baseName()) != 0) {
-      return tryBindIntegerParameters(params, actualType);
-    }
-
-    // Type Parameters can recurse.
-    if (params.size() != actualType->size()) {
+    if (actualType->isUnKnown() && variable.knownTypesOnly()) {
       return false;
     }
-    for (auto i = 0; i < params.size(); i++) {
-      if (!tryBind(params[i], actualType->childAt(i))) {
-        return false;
-      }
-    }
+
+    typeVariablesBindings_[baseName] = actualType;
     return true;
   }
 
-  // Variables cannot have further parameters.
-  VELOX_CHECK_EQ(
-      typeSignature.parameters().size(),
-      0,
-      "Variables with parameters are not supported");
+  // Type is not a variable.
+  auto typeName = boost::algorithm::to_upper_copy(baseName);
 
-  // Resolve type parameters parameters.
-  if (auto it = typeParameters_.find(baseName); it != typeParameters_.end()) {
-    if (it->second == nullptr) {
-      it->second = actualType;
-      return true;
-    }
-    return it->second->equivalent(*actualType);
+  if (auto customType = getType(baseName, {})) {
+    VELOX_CHECK_EQ(
+        typeSignature.parameters().size(),
+        0,
+        "Custom types with parameters are not supported yet");
+    return customType->equivalent(*actualType);
   }
-  return false;
+
+  if (typeName != actualType->kindName()) {
+    // Should match except if it was "DECIMAL", then it can be LongDecimal or
+    // ShortDecimal.
+    if (!isCommonDecimalName(typeName)) {
+      return false;
+    }
+
+    // If typeName is "DECIMAL" actualType should be LongDecimal or
+    // ShortDecimal.
+    if (!actualType->isLongDecimal() && !actualType->isShortDecimal()) {
+      return false;
+    }
+  }
+  const auto& params = typeSignature.parameters();
+
+  // When actual type is LongDecimal or ShortDecimal() we should read two args.
+  if (actualType->isLongDecimal() || actualType->isShortDecimal()) {
+    return tryBindIntegerParameters(params, actualType);
+  }
+
+  // Type Parameters can recurse.
+  if (params.size() != actualType->size()) {
+    return false;
+  }
+
+  for (auto i = 0; i < params.size(); i++) {
+    if (!tryBind(params[i], actualType->childAt(i))) {
+      return false;
+    }
+  }
+  return true;
 }
 
-TypePtr SignatureBinder::tryResolveType(
-    const exec::TypeSignature& typeSignature) {
-  return tryResolveType(
-      typeSignature, typeParameters_, constraints_, integerParameters_);
-}
-
-// static
 TypePtr SignatureBinder::tryResolveType(
     const exec::TypeSignature& typeSignature,
-    const std::unordered_map<std::string, TypePtr>& typeParameters,
-    const std::unordered_map<std::string, std::string>& constraints,
-    std::unordered_map<std::string, std::optional<int>>& integerParameters) {
+    const std::unordered_map<std::string, TypeVariableConstraint>& variables,
+    const std::unordered_map<std::string, TypePtr>& typeVariablesBindings,
+    std::unordered_map<std::string, int>& integerVariablesBindings) {
   const auto baseName = typeSignature.baseName();
-  if (isConcreteType(typeParameters, integerParameters, baseName)) {
-    auto typeName = boost::algorithm::to_upper_copy(baseName);
-    if (isDecimalName(typeName) || isCommonDecimalName(typeName)) {
-      return inferDecimalType(typeSignature, constraints, integerParameters);
-    }
-    const auto& params = typeSignature.parameters();
-    std::vector<TypePtr> children;
-    children.reserve(params.size());
-    for (auto& param : params) {
-      auto type =
-          tryResolveType(param, typeParameters, constraints, integerParameters);
-      if (!type) {
-        return nullptr;
-      }
-      children.emplace_back(type);
-    }
 
-    if (auto type = getType(typeName, children)) {
-      return type;
-    }
-
-    auto typeKind = tryMapNameToTypeKind(typeName);
-    if (!typeKind.has_value()) {
+  if (variables.count(baseName)) {
+    auto it = typeVariablesBindings.find(baseName);
+    if (it == typeVariablesBindings.end()) {
       return nullptr;
     }
-
-    // createType(kind) function doesn't support ROW, UNKNOWN and OPAQUE type
-    // kinds.
-    switch (*typeKind) {
-      case TypeKind::ROW:
-        return ROW(std::move(children));
-      case TypeKind::UNKNOWN:
-        return UNKNOWN();
-      case TypeKind::OPAQUE:
-        return OpaqueType::create<void>();
-      default:
-        return createType(*typeKind, std::move(children));
-    }
-  } else if (typeParameters.count(baseName) != 0) {
-    return typeParameters.at(baseName);
+    return it->second;
   }
+
+  // Type is not a variable.
+  auto typeName = boost::algorithm::to_upper_copy(baseName);
+  if (isDecimalName(typeName) || isCommonDecimalName(typeName)) {
+    return inferDecimalType(typeSignature, variables, integerVariablesBindings);
+  }
+  const auto& params = typeSignature.parameters();
+  std::vector<TypePtr> children;
+  children.reserve(params.size());
+  for (auto& param : params) {
+    auto type = tryResolveType(
+        param, variables, typeVariablesBindings, integerVariablesBindings);
+    if (!type) {
+      return nullptr;
+    }
+    children.emplace_back(type);
+  }
+
+  if (auto type = getType(typeName, children)) {
+    return type;
+  }
+
+  auto typeKind = tryMapNameToTypeKind(typeName);
+  if (!typeKind.has_value()) {
+    return nullptr;
+  }
+
+  // createType(kind) function doesn't support ROW, UNKNOWN and OPAQUE type
+  // kinds.
+  switch (*typeKind) {
+    case TypeKind::ROW:
+      return ROW(std::move(children));
+    case TypeKind::UNKNOWN:
+      return UNKNOWN();
+    case TypeKind::OPAQUE:
+      return OpaqueType::create<void>();
+    default:
+      return createType(*typeKind, std::move(children));
+  }
+
   return nullptr;
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzer.cpp
@@ -60,10 +60,19 @@ std::optional<TypeKind> baseNameToTypeKind(const std::string& typeName) {
 }
 
 void ArgumentTypeFuzzer::determineUnboundedTypeVariables() {
-  for (auto& binding : bindings_) {
-    if (!binding.second) {
-      binding.second = randomType(rng_);
+  for (auto& [variableName, variableInfo] : variables()) {
+    if (!variableInfo.isTypeParameter()) {
+      continue;
     }
+
+    if (bindings_[variableName] != nullptr) {
+      continue;
+    }
+
+    // Random randomType() never generates unknown here.
+    // TODO: we should extend randomType types and exclude unknown based
+    // on variableInfo.
+    bindings_[variableName] = randomType(rng_);
   }
 }
 
@@ -78,8 +87,8 @@ bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {
     }
     bindings_ = binder.bindings();
   } else {
-    for (const auto& constraint : signature_.typeVariableConstraints()) {
-      bindings_.insert({constraint.name(), nullptr});
+    for (const auto& [name, _] : signature_.variables()) {
+      bindings_.insert({name, nullptr});
     }
   }
 
@@ -89,8 +98,8 @@ bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {
     if (formalArgs[i].baseName() == "any") {
       actualArg = randomType(rng_);
     } else {
-      actualArg =
-          exec::SignatureBinder::tryResolveType(formalArgs[i], bindings_);
+      actualArg = exec::SignatureBinder::tryResolveType(
+          formalArgs[i], variables(), bindings_);
       VELOX_CHECK(actualArg != nullptr);
     }
     argumentTypes_.push_back(actualArg);

--- a/velox/expression/tests/ArgumentTypeFuzzer.h
+++ b/velox/expression/tests/ArgumentTypeFuzzer.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <random>
+#include <unordered_map>
+
 #include "velox/expression/FunctionSignature.h"
 #include "velox/expression/SignatureBinder.h"
 #include "velox/type/Type.h"
@@ -31,15 +33,13 @@ class ArgumentTypeFuzzer {
   ArgumentTypeFuzzer(
       const exec::FunctionSignature& signature,
       std::mt19937& rng)
-      : signature_{signature}, rng_{rng} {}
+      : ArgumentTypeFuzzer(signature, nullptr, rng) {}
 
   ArgumentTypeFuzzer(
       const exec::FunctionSignature& signature,
       const TypePtr& returnType,
       std::mt19937& rng)
-      : signature_{signature}, returnType_{returnType}, rng_{rng} {
-    VELOX_CHECK_NOT_NULL(returnType);
-  }
+      : signature_{signature}, returnType_{returnType}, rng_{rng} {}
 
   /// Generate random argument types. If the desired returnType has been
   /// specified, checks that it can be bound to the return type of signature_.
@@ -54,6 +54,10 @@ class ArgumentTypeFuzzer {
   }
 
  private:
+  /// Return the variables in the signature.
+  auto& variables() const {
+    return signature_.variables();
+  }
   /// Bind each type variable that is not determined by the return type to a
   /// randomly generated type.
   void determineUnboundedTypeVariables();

--- a/velox/expression/tests/ArgumentTypeFuzzerTest.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzerTest.cpp
@@ -127,7 +127,7 @@ TEST_F(ArgumentTypeFuzzerTest, signatureTemplate) {
 
   {
     auto signature = exec::FunctionSignatureBuilder()
-                         .typeVariable("K")
+                         .knownTypeVariable("K")
                          .typeVariable("V")
                          .returnType("K")
                          .argumentType("array(K)")
@@ -153,7 +153,7 @@ TEST_F(ArgumentTypeFuzzerTest, signatureTemplate) {
 
   {
     auto signature = exec::FunctionSignatureBuilder()
-                         .typeVariable("K")
+                         .knownTypeVariable("K")
                          .typeVariable("V")
                          .returnType("bigint")
                          .argumentType("array(K)")
@@ -191,7 +191,7 @@ TEST_F(ArgumentTypeFuzzerTest, variableArity) {
 
   {
     auto signature = exec::FunctionSignatureBuilder()
-                         .typeVariable("K")
+                         .knownTypeVariable("K")
                          .returnType("bigint")
                          .argumentType("K")
                          .variableArity()
@@ -280,7 +280,7 @@ TEST_F(ArgumentTypeFuzzerTest, lambda) {
 
   // map(K, V1), function(K, V1, V2) -> map(K, V2)
   signature = exec::FunctionSignatureBuilder()
-                  .typeVariable("K")
+                  .knownTypeVariable("K")
                   .typeVariable("V1")
                   .typeVariable("V2")
                   .returnType("map(K,V2)")
@@ -305,7 +305,7 @@ TEST_F(ArgumentTypeFuzzerTest, lambda) {
 
 TEST_F(ArgumentTypeFuzzerTest, unconstrainedSignatureTemplate) {
   auto signature = exec::FunctionSignatureBuilder()
-                       .typeVariable("K")
+                       .knownTypeVariable("K")
                        .typeVariable("V")
                        .returnType("V")
                        .argumentType("map(K,V)")

--- a/velox/expression/tests/ReverseSignatureBinderTest.cpp
+++ b/velox/expression/tests/ReverseSignatureBinderTest.cpp
@@ -74,7 +74,7 @@ TEST_F(ReverseSignatureBinderTest, any) {
 
 TEST_F(ReverseSignatureBinderTest, signatureTemplateFullBinding) {
   auto signature = exec::FunctionSignatureBuilder()
-                       .typeVariable("K")
+                       .knownTypeVariable("K")
                        .typeVariable("V")
                        .returnType("map(K, V)")
                        .argumentType("K")
@@ -84,19 +84,19 @@ TEST_F(ReverseSignatureBinderTest, signatureTemplateFullBinding) {
   testBindingSuccess(
       signature, MAP(VARCHAR(), BIGINT()), {{"K", VARCHAR()}, {"V", BIGINT()}});
   testBindingFailure(signature, VARCHAR());
+  testBindingFailure(signature, MAP(UNKNOWN(), INTEGER()));
 }
 
 TEST_F(ReverseSignatureBinderTest, signatureTemplatePartialBinding) {
   auto signature = exec::FunctionSignatureBuilder()
-                       .typeVariable("K")
+                       .knownTypeVariable("K")
                        .typeVariable("V")
                        .returnType("array(K)")
                        .argumentType("K")
                        .argumentType("V")
                        .build();
 
-  testBindingSuccess(
-      signature, ARRAY(VARCHAR()), {{"K", VARCHAR()}, {"V", nullptr}});
+  testBindingSuccess(signature, ARRAY(VARCHAR()), {{"K", VARCHAR()}});
   testBindingFailure(signature, VARCHAR());
 }
 

--- a/velox/expression/type_calculation/Scanner.h
+++ b/velox/expression/type_calculation/Scanner.h
@@ -30,7 +30,7 @@ class Scanner : public yyFlexLexer {
   Scanner(
       std::istream& arg_yyin,
       std::ostream& arg_yyout,
-      std::unordered_map<std::string, std::optional<int>>& values)
+      std::unordered_map<std::string, int>& values)
       : yyFlexLexer(&arg_yyin, &arg_yyout), values_(values){};
   int lex(Parser::semantic_type* yylval);
 
@@ -39,13 +39,12 @@ class Scanner : public yyFlexLexer {
   }
 
   int getValue(const std::string& varName) const {
-    VELOX_CHECK(
-        values_.at(varName).has_value(), "Variable {} is not defined", varName);
-    return values_.at(varName).value();
+    VELOX_CHECK(values_.count(varName), "Variable {} is not defined", varName);
+    return values_.at(varName);
   }
 
  private:
-  std::unordered_map<std::string, std::optional<int>>& values_;
+  std::unordered_map<std::string, int>& values_;
 };
 
 } // namespace facebook::velox::expression::calculate

--- a/velox/expression/type_calculation/TypeCalculation.h
+++ b/velox/expression/type_calculation/TypeCalculation.h
@@ -22,5 +22,5 @@
 namespace facebook::velox::expression::calculation {
 void evaluate(
     const std::string& calculation,
-    std::unordered_map<std::string, std::optional<int>>& variables);
+    std::unordered_map<std::string, int>& variables);
 }

--- a/velox/expression/type_calculation/TypeCalculation.ll
+++ b/velox/expression/type_calculation/TypeCalculation.ll
@@ -35,7 +35,7 @@ int yyFlexLexer::yylex() {
 
 #include "velox/expression/type_calculation/TypeCalculation.h"
 
-void facebook::velox::expression::calculation::evaluate(const std::string& calculation, std::unordered_map<std::string, std::optional<int>>& variables) {
+void facebook::velox::expression::calculation::evaluate(const std::string& calculation, std::unordered_map<std::string, int>& variables) {
     std::istringstream is(calculation);
     facebook::velox::expression::calculate::Scanner scanner{ is, std::cerr, variables};
     facebook::velox::expression::calculate::Parser parser{ &scanner };

--- a/velox/functions/lib/MapConcat.cpp
+++ b/velox/functions/lib/MapConcat.cpp
@@ -161,7 +161,7 @@ class MapConcatFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V), map(K,V), ... -> map(K,V)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("map(K,V)")
                 .argumentType("map(K,V)")

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -82,7 +82,7 @@ class SubscriptImpl : public exec::VectorFunction {
             .build(),
         // map(K,V), K -> V
         exec::FunctionSignatureBuilder()
-            .typeVariable("K")
+            .knownTypeVariable("K")
             .typeVariable("V")
             .returnType("V")
             .argumentType("map(K,V)")

--- a/velox/functions/prestosql/FilterFunctions.cpp
+++ b/velox/functions/prestosql/FilterFunctions.cpp
@@ -239,7 +239,7 @@ class MapFilterFunction : public FilterFunctionBase {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V), function(K,V,boolean) -> map(K,V)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("map(K,V)")
                 .argumentType("map(K,V)")

--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -194,7 +194,7 @@ class MapFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // array(K), array(V) -> map(K,V)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("map(K,V)")
                 .argumentType("array(K)")

--- a/velox/functions/prestosql/MapEntries.cpp
+++ b/velox/functions/prestosql/MapEntries.cpp
@@ -55,7 +55,7 @@ class MapEntriesFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V) -> array(row(K,V))
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("array(row(K,V))")
                 .argumentType("map(K,V)")

--- a/velox/functions/prestosql/MapKeysAndValues.cpp
+++ b/velox/functions/prestosql/MapKeysAndValues.cpp
@@ -92,7 +92,7 @@ class MapKeysFunction : public MapKeyValueFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V) -> array(K)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("array(K)")
                 .argumentType("map(K,V)")
@@ -129,7 +129,7 @@ class MapValuesFunction : public MapKeyValueFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V) -> array(V)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("array(V)")
                 .argumentType("map(K,V)")

--- a/velox/functions/prestosql/MapZipWith.cpp
+++ b/velox/functions/prestosql/MapZipWith.cpp
@@ -210,7 +210,7 @@ class MapZipWithFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K, V1), map(K, V2), function(K, V1, V2, V3) -> map(K, V3)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V1")
                 .typeVariable("V2")
                 .typeVariable("V3")

--- a/velox/functions/prestosql/TransformValues.cpp
+++ b/velox/functions/prestosql/TransformValues.cpp
@@ -96,7 +96,7 @@ class TransformValuesFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K, V1), function(K, V1) -> V2 -> map(K, V2)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V1")
                 .typeVariable("V2")
                 .returnType("map(K,V2)")

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -45,7 +45,7 @@ class MapUnionAggregate : public aggregate::MapAggregateBase {
 bool registerMapUnionAggregate(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
-          .typeVariable("K")
+          .knownTypeVariable("K")
           .typeVariable("V")
           .returnType("map(K,V)")
           .intermediateType("map(K,V)")

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -164,7 +164,7 @@ class VectorFuncFour : public velox::exec::VectorFunction {
   signatures() {
     // map(K,V) -> array(K)
     return {velox::exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("array(K)")
                 .argumentType("map(K,V)")
@@ -372,7 +372,7 @@ TEST_F(FunctionRegistryTest, getFunctionSignatures) {
   ASSERT_EQ(
       functionSignatures["vector_func_four"].at(0)->toString(),
       exec::FunctionSignatureBuilder()
-          .typeVariable("K")
+          .knownTypeVariable("K")
           .typeVariable("V")
           .returnType("array(K)")
           .argumentType("map(K,V)")


### PR DESCRIPTION
Summary:
sWhen a type variable is used as an argument to a map type for the
key place holder, it should be restricted to known types only.

This diff adds such support:
```
{exec::FunctionSignatureBuilder()
                .typeVariable("K", /*onlyKnownTypes*/ true)
                .typeVariable("V")
                .returnType("array(V)")
                .argumentType("map(K,V)")
                .build()};
```

this fix the fuzzer issues:
https://github.com/facebookincubator/velox/issues/3046
https://github.com/facebookincubator/velox/issues/3121

Differential Revision: D41143050

