### PR TITLE
Fuzzer: Add support for order-dependent aggregate functions

### DIFF
--- a/velox/exec/tests/AggregationFuzzer.h
+++ b/velox/exec/tests/AggregationFuzzer.h
@@ -18,5 +18,8 @@
 #include "velox/exec/Aggregate.h"
 
 namespace facebook::velox::exec::test {
-void aggregateFuzzer(AggregateFunctionSignatureMap signatureMap, size_t seed);
+void aggregateFuzzer(
+    AggregateFunctionSignatureMap signatureMap,
+    size_t seed,
+    const std::unordered_set<std::string>& orderDependentFunctions);
 }

--- a/velox/exec/tests/AggregationFuzzerRunner.h
+++ b/velox/exec/tests/AggregationFuzzerRunner.h
@@ -65,7 +65,8 @@ class AggregationFuzzerRunner {
   static int run(
       const std::string& onlyFunctions,
       size_t seed,
-      const std::unordered_set<std::string>& skipFunctions) {
+      const std::unordered_set<std::string>& skipFunctions,
+      const std::unordered_set<std::string>& orderDependentFunctions) {
     auto signatures = facebook::velox::exec::getAggregateFunctionSignatures();
     if (signatures.empty()) {
       LOG(ERROR) << "No aggregate functions registered.";
@@ -80,7 +81,8 @@ class AggregationFuzzerRunner {
       exit(1);
     }
 
-    facebook::velox::exec::test::aggregateFuzzer(filteredSignatures, seed);
+    facebook::velox::exec::test::aggregateFuzzer(
+        filteredSignatures, seed, orderDependentFunctions);
     return RUN_ALL_TESTS();
   }
 

--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -48,19 +48,18 @@ int main(int argc, char** argv) {
   // TODO: List of the functions that at some point crash or fail and need to
   // be fixed before we can enable.
   std::unordered_set<std::string> skipFunctions = {
-      // approx_percentile crashes:
-      // https://github.com/facebookincubator/velox/issues/3099
-      "approx_percentile",
       // approx_most_frequent crashes:
       // https://github.com/facebookincubator/velox/issues/3101
       "approx_most_frequent",
       // avg crashes under UBSAN:
       // https://github.com/facebookincubator/velox/issues/3103
       "avg",
-      // The results of the following functions depend on the order of input
-      // rows.
-      // TODO Enhance the fuzzer allow partial testing for these, i.e. skip
-      // multi-threaded plans using local exchange.
+  };
+
+  // The results of the following functions depend on the order of input
+  // rows.
+  std::unordered_set<std::string> orderDependentFunctions = {
+      "approx_distinct",
       "approx_set",
       "arbitrary",
       "array_agg",
@@ -70,5 +69,6 @@ int main(int argc, char** argv) {
       "min_by",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
-  return AggregationFuzzerRunner::run(FLAGS_only, initialSeed, skipFunctions);
+  return AggregationFuzzerRunner::run(
+      FLAGS_only, initialSeed, skipFunctions, orderDependentFunctions);
 }

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -517,7 +517,7 @@ class ApproxPercentileAggregate : public exec::Aggregate {
     if (!hasAccuracy_) {
       return;
     }
-    VELOX_CHECK(
+    VELOX_USER_CHECK(
         decodedAccuracy_.isConstantMapping(),
         "Accuracy argument must be constant for all input rows");
     checkSetAccuracy(decodedAccuracy_.valueAt<double>(0));


### PR DESCRIPTION
Skip results verification when testing aggregate function whose results depend on the order of inputs.
