### PR TITLE
Suppress errors for unused arguments of null-propagating functions

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -151,6 +151,26 @@ class EvalCtx {
     std::swap(errors_, other);
   }
 
+  /// Adds errors in 'this' to 'other'. Clears errors from 'this'.
+  void moveAppendErrors(ErrorVectorPtr& other) {
+    if (!errors_) {
+      return;
+    }
+
+    if (!other) {
+      std::swap(errors_, other);
+      return;
+    }
+
+    ensureErrorsVectorSize(other, errors_->size());
+    bits::forEachBit(
+        errors_->rawNulls(), 0, errors_->size(), bits::kNotNull, [&](auto row) {
+          other->set(row, errors_->valueAt(row));
+        });
+
+    errors_.reset();
+  }
+
   bool throwOnError() const {
     return throwOnError_;
   }

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -28,6 +28,8 @@
 #include "velox/expression/ConstantExpr.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
@@ -3155,6 +3157,82 @@ TEST_F(ExprTest, mapKeysAndValues) {
   rows.updateBounds();
   std::vector<VectorPtr> result(2);
   ASSERT_NO_THROW(exprSet->eval(rows, context, result));
+}
+
+TEST_F(ExprTest, maskErrorByNull) {
+  // Checks that errors in arguments of null-propagating functions are ignored
+  // for rows with at least one null.
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6}),
+       makeFlatVector<int32_t>({1, 0, 3, 0, 5, 6}),
+       makeNullableFlatVector<int32_t>(
+           {std::nullopt, 10, std::nullopt, 10, std::nullopt, 10})});
+
+  auto resultAB =
+      evaluate("if (c2 is null, 10, CAST(null as BIGINT))  + (c0 / c1)", data);
+  auto resultBA =
+      evaluate("(c0 / c1) + if (c2 is null, 10, CAST(null as BIGINT))", data);
+
+  assertEqualVectors(resultAB, resultBA);
+  VELOX_ASSERT_THROW(evaluate("(c0 / c1) + 10", data), "division by zero");
+  VELOX_ASSERT_THROW(
+      evaluate("(c0 / c1) + (c0 + if(c1 = 0, 10, CAST(null as BIGINT)))", data),
+      "division by zero");
+
+  // Make non null flat input to invoke flat no null path for a subtree.
+  data = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6}),
+       makeFlatVector<int32_t>({1, 0, 3, 0, 5, 6})});
+  // Register a function that does not support flat no nulls fast path.
+  exec::registerVectorFunction(
+      "plus5",
+      PlusConstantFunction::signatures(),
+      std::make_unique<PlusConstantFunction>(5));
+
+  auto result = evaluate("plus5(c0 + c1)", data);
+  assertEqualVectors(
+      result, makeNullableFlatVector<int32_t>({7, 7, 11, 9, 15, 17}));
+
+  // try permutations of nulls and errors. c1 is 0 every 3rd. c1 is null every
+  // 5th. c2 is 0 every 7th.
+  data = makeRowVector(
+      {makeFlatVector<int32_t>(100, [](auto row) { return row % 3; }),
+       makeFlatVector<int32_t>(
+           100,
+           [](auto row) { return 1 + (row % 5); },
+           [](auto row) { return row % 5 == 0; }),
+       makeFlatVector<int32_t>(100, [](auto row) { return row % 7; })});
+  // All 6 permutations of 0, 1, 2.
+  std::vector<std::vector<int32_t>> permutations = {
+      {0, 1, 2}, {0, 2, 1}, {1, 0, 2}, {1, 2, 0}, {2, 0, 1}, {2, 1, 0}};
+  VectorPtr firstResult;
+  VectorPtr firstCoalesceResult;
+  for (auto& permutation : permutations) {
+    result = evaluate(
+        fmt::format(
+            "try((100 / c{}) + (100 / c{}) + (100 / c{}))",
+            permutation[0],
+            permutation[1],
+            permutation[2]),
+        data);
+    if (!firstResult) {
+      firstResult = result;
+    } else {
+      assertEqualVectors(firstResult, result);
+    }
+    auto coalesceResult = evaluate(
+        fmt::format(
+            "try(coalesce((100 / c{}) + (100 / c{}) + (100 / c{}), 9999))",
+            permutation[0],
+            permutation[1],
+            permutation[2]),
+        data);
+    if (!firstCoalesceResult) {
+      firstCoalesceResult = coalesceResult;
+    } else {
+      assertEqualVectors(firstCoalesceResult, coalesceResult);
+    }
+  }
 }
 
 /// Test recursive constant peeling: in general expression evaluation first,


### PR DESCRIPTION
Suppress errors for unused arguments of null-propagating functions

Null propagating functions will not be called if at least one argument
is null. Also, other arguments for rows where one argument was null
will not be evaluated for the null rows. This may cause errors to be
masked in a way depending on argument order. This makes a commutative
function like + not be commutative in the presence of masked errors.

We defer signalling of errors for arguments of null propagating
functions. An error will be signalled only if there is no null on its
row.

The errors for each Expr subtree are treated separately. Errors from
subtrees to the left must not null out rows for a subtree to the
right. Only arguments of the same function may interact in this way,
hence extra logic for scoping errors in Expr::evalAll.

We divide argument evaluation into distinct functions for default null
behavior and non-null propagating cases.

Expr::evalAll works as before for functions with non-default null
behavior.  default null behavior, evalArgsDefaultNulls first captures
the errors in effect at entry. It then calls eval on each argument
with an empty error state in EvalCtx. It reads the errors from EvalCtx
after each argument and collects these in 'argumentErrors'. If an
argument eval returned null and no error for a row, subsequent
arguments will not be evaluated for this row. After
  all arguments are evaluated, errors are kept only for those rows
 where there is no null with no error.  If errors are left
at this time, they are added to the errors in effect at entry. If we
are in a mode where errors are signalled as they happen
(EvalCtx::throwOnError), we throw.

This change may cause previously reported errors to no longer be
reported or a different error to be reported if there are multiple
errors on a row.
