### PR TITLE
Fix signed integer overflow in Timestamp::toMillis(), toMicros(), and toNanos()

### DIFF
--- a/velox/common/base/CheckedArithmetic.h
+++ b/velox/common/base/CheckedArithmetic.h
@@ -20,8 +20,6 @@
 #include <string>
 #include "folly/Likely.h"
 #include "velox/common/base/Exceptions.h"
-#include "velox/type/UnscaledLongDecimal.h"
-#include "velox/type/UnscaledShortDecimal.h"
 
 namespace facebook::velox {
 
@@ -35,34 +33,6 @@ T checkedPlus(const T& a, const T& b) {
   return result;
 }
 
-template <>
-inline UnscaledShortDecimal checkedPlus(
-    const UnscaledShortDecimal& a,
-    const UnscaledShortDecimal& b) {
-  int64_t result;
-  bool overflow =
-      __builtin_add_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow || !UnscaledShortDecimal::valueInRange(result))) {
-    VELOX_ARITHMETIC_ERROR(
-        "Decimal overflow: {} + {}", a.unscaledValue(), b.unscaledValue());
-  }
-  return UnscaledShortDecimal(result);
-}
-
-template <>
-inline UnscaledLongDecimal checkedPlus(
-    const UnscaledLongDecimal& a,
-    const UnscaledLongDecimal& b) {
-  int128_t result;
-  bool overflow =
-      __builtin_add_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
-    VELOX_ARITHMETIC_ERROR(
-        "Decimal overflow: {} + {}", a.unscaledValue(), b.unscaledValue());
-  }
-  return UnscaledLongDecimal(result);
-}
-
 template <typename T>
 T checkedMinus(const T& a, const T& b) {
   T result;
@@ -73,35 +43,6 @@ T checkedMinus(const T& a, const T& b) {
   return result;
 }
 
-template <>
-inline UnscaledShortDecimal checkedMinus(
-    const UnscaledShortDecimal& a,
-    const UnscaledShortDecimal& b) {
-  int64_t result;
-  bool overflow =
-      __builtin_sub_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow || !UnscaledShortDecimal::valueInRange(result))) {
-    VELOX_ARITHMETIC_ERROR(
-        "Decimal overflow: {} - {}", a.unscaledValue(), b.unscaledValue());
-  }
-  return UnscaledShortDecimal(result);
-}
-
-template <>
-inline UnscaledLongDecimal checkedMinus(
-    const UnscaledLongDecimal& a,
-    const UnscaledLongDecimal& b) {
-  int128_t result;
-  bool overflow =
-      __builtin_sub_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
-    VELOX_ARITHMETIC_ERROR(
-        "Decimal overflow: {} - {}", a.unscaledValue(), b.unscaledValue());
-  }
-
-  return UnscaledLongDecimal(result);
-}
-
 template <typename T>
 T checkedMultiply(const T& a, const T& b) {
   T result;
@@ -110,34 +51,6 @@ T checkedMultiply(const T& a, const T& b) {
     VELOX_ARITHMETIC_ERROR("integer overflow: {} * {}", a, b);
   }
   return result;
-}
-
-template <>
-inline UnscaledShortDecimal checkedMultiply(
-    const UnscaledShortDecimal& a,
-    const UnscaledShortDecimal& b) {
-  int64_t result;
-  bool overflow =
-      __builtin_mul_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow || !UnscaledShortDecimal::valueInRange(result))) {
-    VELOX_ARITHMETIC_ERROR(
-        "Decimal overflow: {} * {}", a.unscaledValue(), b.unscaledValue());
-  }
-  return UnscaledShortDecimal(result);
-}
-
-template <>
-inline UnscaledLongDecimal checkedMultiply(
-    const UnscaledLongDecimal& a,
-    const UnscaledLongDecimal& b) {
-  int128_t result;
-  bool overflow =
-      __builtin_mul_overflow(a.unscaledValue(), b.unscaledValue(), &result);
-  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
-    VELOX_ARITHMETIC_ERROR(
-        "Decimal overflow: {} * {}", a.unscaledValue(), b.unscaledValue());
-  }
-  return UnscaledLongDecimal(result);
 }
 
 template <typename T>

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -15,13 +15,14 @@
  */
 #pragma once
 
-#include "velox/type/StringView.h"
-
 #include <iomanip>
 #include <sstream>
 #include <string>
 
 #include <folly/dynamic.h>
+
+#include "velox/common/base/CheckedArithmetic.h"
+#include "velox/type/StringView.h"
 
 namespace date {
 class time_zone;
@@ -45,15 +46,21 @@ struct Timestamp {
 
   int64_t toNanos() const {
     // int64 can store around 292 years in nanos ~ till 2262-04-12
-    return seconds_ * 1'000'000'000 + nanos_;
+    // The addition cannot overflow because the product will be promoted to
+    // uint64_t first and its value is at most UINT64_MAX / 2.
+    return checkedMultiply(seconds_, (int64_t)1'000'000'000) + nanos_;
   }
 
   int64_t toMillis() const {
-    return seconds_ * 1'000 + nanos_ / 1'000'000;
+    // The addition cannot overflow because the product will be promoted to
+    // uint64_t first and its value is at most UINT64_MAX / 2.
+    return checkedMultiply(seconds_, (int64_t)1'000) + nanos_ / 1'000'000;
   }
 
   int64_t toMicros() const {
-    return seconds_ * 1'000'000 + nanos_ / 1'000;
+    // The addition cannot overflow because the product will be promoted to
+    // uint64_t first and its value is at most UINT64_MAX / 2.
+    return checkedMultiply(seconds_, (int64_t)1'000'000) + nanos_ / 1'000;
   }
 
   static Timestamp fromMillis(int64_t millis) {

--- a/velox/type/UnscaledLongDecimal.cpp
+++ b/velox/type/UnscaledLongDecimal.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "velox/type/UnscaledLongDecimal.h"
-#include "velox/common/base/CheckedArithmetic.h"
 
 namespace std {
 

--- a/velox/type/UnscaledLongDecimal.h
+++ b/velox/type/UnscaledLongDecimal.h
@@ -185,6 +185,50 @@ static inline UnscaledLongDecimal operator*(
     int b) {
   return UnscaledLongDecimal(mul(a.unscaledValue(), b));
 }
+
+template <>
+inline UnscaledLongDecimal checkedPlus(
+    const UnscaledLongDecimal& a,
+    const UnscaledLongDecimal& b) {
+  int128_t result;
+  bool overflow =
+      __builtin_add_overflow(a.unscaledValue(), b.unscaledValue(), &result);
+  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
+    VELOX_ARITHMETIC_ERROR(
+        "Decimal overflow: {} + {}", a.unscaledValue(), b.unscaledValue());
+  }
+  return UnscaledLongDecimal(result);
+}
+
+template <>
+inline UnscaledLongDecimal checkedMinus(
+    const UnscaledLongDecimal& a,
+    const UnscaledLongDecimal& b) {
+  int128_t result;
+  bool overflow =
+      __builtin_sub_overflow(a.unscaledValue(), b.unscaledValue(), &result);
+  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
+    VELOX_ARITHMETIC_ERROR(
+        "Decimal overflow: {} - {}", a.unscaledValue(), b.unscaledValue());
+  }
+
+  return UnscaledLongDecimal(result);
+}
+
+template <>
+inline UnscaledLongDecimal checkedMultiply(
+    const UnscaledLongDecimal& a,
+    const UnscaledLongDecimal& b) {
+  int128_t result;
+  bool overflow =
+      __builtin_mul_overflow(a.unscaledValue(), b.unscaledValue(), &result);
+  if (UNLIKELY(overflow || !UnscaledLongDecimal::valueInRange(result))) {
+    VELOX_ARITHMETIC_ERROR(
+        "Decimal overflow: {} * {}", a.unscaledValue(), b.unscaledValue());
+  }
+  return UnscaledLongDecimal(result);
+}
+
 } // namespace facebook::velox
 
 namespace folly {

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/type/Timestamp.h"
 
 namespace facebook::velox {
@@ -67,6 +68,27 @@ TEST(TimestampTest, fromNanos) {
   Timestamp ts3(negativeSecond, 0);
   EXPECT_EQ(ts3, Timestamp::fromNanos(negativeSecond * 1'000'000'000));
   EXPECT_EQ(ts3, Timestamp::fromNanos(ts3.toNanos()));
+}
+
+TEST(TimestampTest, arithmeticOverflow) {
+  int64_t positiveSecond = 9223372036854776;
+  uint64_t nano = 123 * 1'000'000;
+
+  Timestamp ts1(positiveSecond, nano);
+  VELOX_ASSERT_THROW(
+      ts1.toMillis(), "integer overflow: 9223372036854776 * 1000");
+  VELOX_ASSERT_THROW(
+      ts1.toMicros(), "integer overflow: 9223372036854776 * 1000000");
+  VELOX_ASSERT_THROW(
+      ts1.toNanos(), "integer overflow: 9223372036854776 * 1000000000");
+
+  Timestamp ts2(-positiveSecond, nano);
+  VELOX_ASSERT_THROW(
+      ts2.toMillis(), "integer overflow: -9223372036854776 * 1000");
+  VELOX_ASSERT_THROW(
+      ts2.toMicros(), "integer overflow: -9223372036854776 * 1000000");
+  VELOX_ASSERT_THROW(
+      ts2.toNanos(), "integer overflow: -9223372036854776 * 1000000000");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Fuzzer found a bug in Timestamp::toMillis() when Timestamp::seconds_ * 1000
exceeds the maximum of int64_t (https://github.com/facebookincubator/velox/issues/3038).
This diff fix this bug as well as the similar ones in Timestamp::toMicros() and
Timestamp::toNanos().

Reviewed By: mbasmanova

Differential Revision: D41145735

