### PR TITLE
Memory pool refactoring by removing MemoryPoolBase and ScopedMemoryPool

### DIFF
--- a/velox/benchmarks/basic/VectorFuzzer.cpp
+++ b/velox/benchmarks/basic/VectorFuzzer.cpp
@@ -28,7 +28,7 @@ namespace {
 
 using namespace facebook::velox;
 
-std::unique_ptr<memory::MemoryPool> pool{memory::getDefaultScopedMemoryPool()};
+std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
 
 VectorFuzzer::Options getOpts(size_t n, double nullRatio = 0) {
   VectorFuzzer::Options opts;

--- a/velox/benchmarks/basic/VectorSlice.cpp
+++ b/velox/benchmarks/basic/VectorSlice.cpp
@@ -30,7 +30,7 @@ namespace {
 constexpr int kVectorSize = 16 << 10;
 
 struct BenchmarkData {
-  BenchmarkData() : pool_(memory::getDefaultScopedMemoryPool()) {
+  BenchmarkData() : pool_(memory::getDefaultMemoryPool()) {
     VectorFuzzer::Options opts;
     opts.nullRatio = 0.01;
     opts.vectorSize = kVectorSize;
@@ -42,7 +42,7 @@ struct BenchmarkData {
   }
 
  private:
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
 
  public:
   VectorPtr flatVector;

--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -41,12 +41,12 @@ static_assert(!Buffer::is_pod_like_v<std::shared_ptr<int>>, "");
 class BufferTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memoryManager_.getScopedPool();
+    pool_ = memoryManager_.getChild();
   }
 
   memory::MemoryManager<memory::MemoryAllocator, AlignedBuffer::kAlignment>
       memoryManager_;
-  std::unique_ptr<memory::ScopedMemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
 };
 
 TEST_F(BufferTest, testAlignedBuffer) {

--- a/velox/common/memory/tests/MemoryHeaderTest.cpp
+++ b/velox/common/memory/tests/MemoryHeaderTest.cpp
@@ -22,33 +22,33 @@ using namespace ::testing;
 using namespace facebook::velox::memory;
 
 TEST(MemoryHeaderTest, GetProcessDefaultMemoryManager) {
-  auto& manager_a = getProcessDefaultMemoryManager();
-  auto& manager_b = getProcessDefaultMemoryManager();
-  ASSERT_EQ(0, manager_a.getRoot().getChildCount());
-  ASSERT_EQ(0, manager_b.getRoot().getChildCount());
+  auto& managerA = getProcessDefaultMemoryManager();
+  auto& managerB = getProcessDefaultMemoryManager();
+  ASSERT_EQ(0, managerA.getRoot().getChildCount());
+  ASSERT_EQ(0, managerB.getRoot().getChildCount());
 
-  auto& child1 = manager_a.getRoot().addChild("child_1");
-  auto& child2 = manager_b.getRoot().addChild("child_2");
-  EXPECT_EQ(2, manager_a.getRoot().getChildCount());
-  EXPECT_EQ(2, manager_b.getRoot().getChildCount());
-  child1.removeSelf();
-  child2.removeSelf();
-  EXPECT_EQ(0, manager_b.getRoot().getChildCount());
+  auto child1 = managerA.getRoot().addChild("child_1");
+  auto child2 = managerB.getRoot().addChild("child_2");
+  EXPECT_EQ(2, managerA.getRoot().getChildCount());
+  EXPECT_EQ(2, managerB.getRoot().getChildCount());
+  child1.reset();
+  child2.reset();
+  EXPECT_EQ(0, managerB.getRoot().getChildCount());
 }
 
-TEST(MemoryHeaderTest, getDefaultScopedMemoryPool) {
+TEST(MemoryHeaderTest, getDefaultMemoryPool) {
   auto& manager = getProcessDefaultMemoryManager();
   ASSERT_EQ(0, manager.getRoot().getChildCount());
   {
-    auto pool_a = getDefaultScopedMemoryPool();
-    auto pool_b = getDefaultScopedMemoryPool(42);
+    auto poolA = getDefaultMemoryPool();
+    auto poolB = getDefaultMemoryPool(42);
     EXPECT_EQ(2, manager.getRoot().getChildCount());
-    EXPECT_EQ(42, pool_b->getPool().getCap());
+    EXPECT_EQ(42, poolB->cap());
     {
-      auto pool_c = getDefaultScopedMemoryPool();
+      auto poolC = getDefaultMemoryPool();
       EXPECT_EQ(3, manager.getRoot().getChildCount());
       {
-        auto pool_d = getDefaultScopedMemoryPool();
+        auto poolD = getDefaultMemoryPool();
         EXPECT_EQ(4, manager.getRoot().getChildCount());
       }
       EXPECT_EQ(3, manager.getRoot().getChildCount());

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -30,23 +30,23 @@ TEST(MemoryManagerTest, Ctor) {
     MemoryManager<MemoryAllocator> manager{};
     const auto& root = manager.getRoot();
 
-    EXPECT_EQ(std::numeric_limits<int64_t>::max(), root.getCap());
-    EXPECT_EQ(0, root.getChildCount());
-    EXPECT_EQ(0, root.getCurrentBytes());
-    EXPECT_EQ(std::numeric_limits<int64_t>::max(), manager.getMemoryQuota());
-    EXPECT_EQ(0, manager.getTotalBytes());
+    ASSERT_EQ(std::numeric_limits<int64_t>::max(), root.cap());
+    ASSERT_EQ(0, root.getChildCount());
+    ASSERT_EQ(0, root.getCurrentBytes());
+    ASSERT_EQ(std::numeric_limits<int64_t>::max(), manager.getMemoryQuota());
+    ASSERT_EQ(0, manager.getTotalBytes());
   }
   {
     MemoryManager<MemoryAllocator> manager{8L * 1024 * 1024};
     const auto& root = manager.getRoot();
 
-    EXPECT_EQ(8L * 1024 * 1024, root.getCap());
-    EXPECT_EQ(0, root.getChildCount());
-    EXPECT_EQ(0, root.getCurrentBytes());
-    EXPECT_EQ(8L * 1024 * 1024, manager.getMemoryQuota());
-    EXPECT_EQ(0, manager.getTotalBytes());
+    ASSERT_EQ(8L * 1024 * 1024, root.cap());
+    ASSERT_EQ(0, root.getChildCount());
+    ASSERT_EQ(0, root.getCurrentBytes());
+    ASSERT_EQ(8L * 1024 * 1024, manager.getMemoryQuota());
+    ASSERT_EQ(0, manager.getTotalBytes());
   }
-  { EXPECT_ANY_THROW(MemoryManager<MemoryAllocator> manager{-1}); }
+  { ASSERT_ANY_THROW(MemoryManager<MemoryAllocator> manager{-1}); }
 }
 
 // TODO: when run sequentially, e.g. `buck run dwio/memory/...`, this has side
@@ -57,59 +57,63 @@ TEST(MemoryManagerTest, GlobalMemoryManager) {
   auto& managerII = MemoryManager<>::getProcessDefaultManager();
 
   auto& root = manager.getRoot();
-  root.addChild("some_child", 42);
+  auto child = root.addChild("some_child", 42);
   ASSERT_EQ(1, root.getChildCount());
 
   auto& rootII = managerII.getRoot();
-  EXPECT_EQ(1, rootII.getChildCount());
+  ASSERT_EQ(1, rootII.getChildCount());
   std::vector<MemoryPool*> pools{};
   rootII.visitChildren(
       [&pools](MemoryPool* child) { pools.emplace_back(child); });
   ASSERT_EQ(1, pools.size());
   auto& pool = *pools.back();
-  EXPECT_EQ("some_child", pool.getName());
-  EXPECT_EQ(42, pool.getCap());
+  ASSERT_EQ("some_child", pool.name());
+  ASSERT_EQ(42, pool.cap());
 }
 
 TEST(MemoryManagerTest, Reserve) {
   {
     MemoryManager<MemoryAllocator> manager{};
-    EXPECT_TRUE(manager.reserve(0));
-    EXPECT_EQ(0, manager.getTotalBytes());
+    ASSERT_TRUE(manager.reserve(0));
+    ASSERT_EQ(0, manager.getTotalBytes());
     manager.release(0);
-    EXPECT_TRUE(manager.reserve(42));
-    EXPECT_EQ(42, manager.getTotalBytes());
+    ASSERT_TRUE(manager.reserve(42));
+    ASSERT_EQ(42, manager.getTotalBytes());
     manager.release(42);
-    EXPECT_TRUE(manager.reserve(std::numeric_limits<int64_t>::max()));
-    EXPECT_EQ(std::numeric_limits<int64_t>::max(), manager.getTotalBytes());
+    ASSERT_TRUE(manager.reserve(std::numeric_limits<int64_t>::max()));
+    ASSERT_EQ(std::numeric_limits<int64_t>::max(), manager.getTotalBytes());
+    manager.release(std::numeric_limits<int64_t>::max());
+    ASSERT_EQ(0, manager.getTotalBytes());
   }
   {
     MemoryManager<MemoryAllocator> manager{42};
-    EXPECT_TRUE(manager.reserve(1));
-    EXPECT_TRUE(manager.reserve(1));
-    EXPECT_TRUE(manager.reserve(2));
-    EXPECT_TRUE(manager.reserve(3));
-    EXPECT_TRUE(manager.reserve(5));
-    EXPECT_TRUE(manager.reserve(8));
-    EXPECT_TRUE(manager.reserve(13));
-    EXPECT_FALSE(manager.reserve(21));
-    EXPECT_FALSE(manager.reserve(1));
-    EXPECT_FALSE(manager.reserve(2));
-    EXPECT_FALSE(manager.reserve(3));
+    ASSERT_TRUE(manager.reserve(1));
+    ASSERT_TRUE(manager.reserve(1));
+    ASSERT_TRUE(manager.reserve(2));
+    ASSERT_TRUE(manager.reserve(3));
+    ASSERT_TRUE(manager.reserve(5));
+    ASSERT_TRUE(manager.reserve(8));
+    ASSERT_TRUE(manager.reserve(13));
+    ASSERT_FALSE(manager.reserve(21));
+    ASSERT_FALSE(manager.reserve(1));
+    ASSERT_FALSE(manager.reserve(2));
+    ASSERT_FALSE(manager.reserve(3));
     manager.release(20);
-    EXPECT_TRUE(manager.reserve(1));
-    EXPECT_FALSE(manager.reserve(2));
+    ASSERT_TRUE(manager.reserve(1));
+    ASSERT_FALSE(manager.reserve(2));
+    manager.release(manager.getTotalBytes());
+    ASSERT_EQ(manager.getTotalBytes(), 0);
   }
 }
 
 TEST(MemoryManagerTest, GlobalMemoryManagerQuota) {
   auto& manager = MemoryManager<>::getProcessDefaultManager();
-  EXPECT_THROW(
+  ASSERT_THROW(
       MemoryManager<>::getProcessDefaultManager(42, true),
       velox::VeloxUserError);
 
   auto& coercedManager = MemoryManager<>::getProcessDefaultManager(42);
-  EXPECT_EQ(manager.getMemoryQuota(), coercedManager.getMemoryQuota());
+  ASSERT_EQ(manager.getMemoryQuota(), coercedManager.getMemoryQuota());
 }
 } // namespace memory
 } // namespace velox

--- a/velox/common/memory/tests/MemoryPoolBenchmark.cpp
+++ b/velox/common/memory/tests/MemoryPoolBenchmark.cpp
@@ -70,42 +70,42 @@ class BenchmarkHelper {
 BENCHMARK(SingleNodeAlloc, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager<MemoryAllocator, kNoAlignment> manager{};
-  auto& pool = manager.getRoot().addChild("pride_of_higara");
+  auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
     auto dataSize = (i + 1) * kMemoryFootprintIncrement;
     suspender.dismiss();
-    auto p = pool.allocate(dataSize);
+    auto p = pool->allocate(dataSize);
     suspender.rehire();
-    pool.free(p, dataSize);
+    pool->free(p, dataSize);
   }
 }
 // Should be the same.
 BENCHMARK(SingleNodeAllocWithCap, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager<MemoryAllocator, kNoAlignment> manager{};
-  auto& pool = manager.getRoot().addChild(
+  auto pool = manager.getRoot().addChild(
       "pride_of_higara", iters * kMemoryFootprintIncrement);
 
   for (size_t i = 0; i < iters; ++i) {
     auto dataSize = (i + 1) * kMemoryFootprintIncrement;
     suspender.dismiss();
-    auto p = pool.allocate(dataSize);
+    auto p = pool->allocate(dataSize);
     suspender.rehire();
-    pool.free(p, dataSize);
+    pool->free(p, dataSize);
   }
 }
 
 BENCHMARK(SingleNodeFree, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager<MemoryAllocator, kNoAlignment> manager{};
-  auto& pool = manager.getRoot().addChild("pride_of_higara");
+  auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
     auto dataSize = (i + 1) * kMemoryFootprintIncrement;
-    auto p = pool.allocate(dataSize);
+    auto p = pool->allocate(dataSize);
     suspender.dismiss();
-    pool.free(p, dataSize);
+    pool->free(p, dataSize);
     suspender.rehire();
   }
 }
@@ -113,31 +113,31 @@ BENCHMARK(SingleNodeFree, iters) {
 BENCHMARK(SingleNodeRealloc, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager<MemoryAllocator, kNoAlignment> manager{};
-  auto& pool = manager.getRoot().addChild("pride_of_higara");
+  auto pool = manager.getRoot().addChild("pride_of_higara");
 
-  void* p = pool.allocate(kMemoryFootprintIncrement);
+  void* p = pool->allocate(kMemoryFootprintIncrement);
   for (size_t i = 0; i < iters; ++i) {
     suspender.dismiss();
-    p = pool.reallocate(
+    p = pool->reallocate(
         p,
         (i + 1) * kMemoryFootprintIncrement,
         (i + 2) * kMemoryFootprintIncrement);
     suspender.rehire();
   }
-  pool.free(p, (iters + 1) * kMemoryFootprintIncrement);
+  pool->free(p, (iters + 1) * kMemoryFootprintIncrement);
 }
 
 BENCHMARK(SingleNodeAlignedAlloc, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager<MemoryAllocator, kDefaultAlignment> manager{};
-  auto& pool = manager.getRoot().addChild("pride_of_higara");
+  auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
     auto dataSize = (i + 1) * kMemoryFootprintIncrement;
     suspender.dismiss();
-    auto p = pool.allocate(dataSize);
+    auto p = pool->allocate(dataSize);
     suspender.rehire();
-    pool.free(p, dataSize);
+    pool->free(p, dataSize);
   }
 }
 
@@ -148,32 +148,32 @@ BENCHMARK(SingleNodeAlignedAllocWithCap, iters) {
   auto alignedCap = unalignedTotal % kDefaultAlignment == 0
       ? unalignedTotal
       : (unalignedTotal / kDefaultAlignment + 1) * kDefaultAlignment;
-  auto& pool = manager.getRoot().addChild("pride_of_higara", alignedCap);
+  auto pool = manager.getRoot().addChild("pride_of_higara", alignedCap);
 
   for (size_t i = 0; i < iters; ++i) {
     auto dataSize = (i + 1) * kMemoryFootprintIncrement;
     suspender.dismiss();
-    auto p = pool.allocate(dataSize);
+    auto p = pool->allocate(dataSize);
     suspender.rehire();
-    pool.free(p, dataSize);
+    pool->free(p, dataSize);
   }
 }
 
 BENCHMARK(SingleNodeAlignedRealloc, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager<MemoryAllocator, kDefaultAlignment> manager{};
-  auto& pool = manager.getRoot().addChild("pride_of_higara");
+  auto pool = manager.getRoot().addChild("pride_of_higara");
 
-  void* p = pool.allocate(kMemoryFootprintIncrement);
+  void* p = pool->allocate(kMemoryFootprintIncrement);
   for (size_t i = 0; i < iters; ++i) {
     suspender.dismiss();
-    p = pool.reallocate(
+    p = pool->reallocate(
         p,
         (i + 1) * kMemoryFootprintIncrement,
         (i + 2) * kMemoryFootprintIncrement);
     suspender.rehire();
   }
-  pool.free(p, (iters + 1) * kMemoryFootprintIncrement);
+  pool->free(p, (iters + 1) * kMemoryFootprintIncrement);
 }
 
 namespace {
@@ -182,7 +182,7 @@ void addNLeaves(
     size_t n,
     int64_t cap = std::numeric_limits<int64_t>::max()) {
   for (size_t i = 0; i < n; ++i) {
-    pool.addChild(pool.getName() + ".leaf_" + folly::to<std::string>(i), cap);
+    pool.addChild(pool.name() + ".leaf_" + folly::to<std::string>(i), cap);
   }
 }
 } // namespace
@@ -213,9 +213,9 @@ BENCHMARK(DeeperTree, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager<MemoryAllocator, kNoAlignment> manager{};
   for (size_t i = 0; i < 10; ++i) {
-    auto& child = manager.getRoot().addChild(
+    auto child = manager.getRoot().addChild(
         "query_fragment_" + folly::to<std::string>(i));
-    addNLeaves(child, 20);
+    addNLeaves(*child, 20);
   }
   BenchmarkHelper helper{manager};
   suspender.dismiss();
@@ -234,8 +234,8 @@ BENCHMARK(DeeperTree, iters) {
 BENCHMARK(FlatSubtree, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager<MemoryAllocator, kNoAlignment> manager{};
-  auto& child = manager.getRoot().addChild("query_fragment_1");
-  addNLeaves(child, 10 * 20);
+  auto child = manager.getRoot().addChild("query_fragment_1");
+  addNLeaves(*child, 10 * 20);
   BenchmarkHelper helper{manager};
   suspender.dismiss();
   helper.runForEachPool([iters](MemoryPool& pool) {
@@ -254,9 +254,9 @@ BENCHMARK(FlatSticks, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager<MemoryAllocator, kNoAlignment> manager{};
   for (size_t i = 0; i < 10 * 20; ++i) {
-    auto& child = manager.getRoot().addChild(
+    auto child = manager.getRoot().addChild(
         "query_fragment_" + folly::to<std::string>(i));
-    addNLeaves(child, 1);
+    addNLeaves(*child, 1);
   }
   BenchmarkHelper helper{manager};
   suspender.dismiss();

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -42,7 +42,7 @@ class QueryCtx : public Context {
           connectorConfigs = {},
       memory::MappedMemory* FOLLY_NONNULL mappedMemory =
           memory::MappedMemory::getInstance(),
-      std::unique_ptr<memory::MemoryPool> pool = nullptr,
+      std::shared_ptr<memory::MemoryPool> pool = nullptr,
       std::shared_ptr<folly::Executor> spillExecutor = nullptr,
       const std::string& queryId = "")
       : Context{ContextScope::QUERY},
@@ -70,7 +70,7 @@ class QueryCtx : public Context {
           connectorConfigs = {},
       memory::MappedMemory* FOLLY_NONNULL mappedMemory =
           memory::MappedMemory::getInstance(),
-      std::unique_ptr<memory::MemoryPool> pool = nullptr,
+      std::shared_ptr<memory::MemoryPool> pool = nullptr,
       const std::string& queryId = "")
       : Context{ContextScope::QUERY},
         pool_(std::move(pool)),
@@ -143,14 +143,14 @@ class QueryCtx : public Context {
   }
 
   void initPool(const std::string& queryId) {
-    pool_ = memory::getProcessDefaultMemoryManager().getRoot().addScopedChild(
+    pool_ = memory::getProcessDefaultMemoryManager().getRoot().addChild(
         QueryCtx::generatePoolName(queryId));
     static const auto kUnlimited = std::numeric_limits<int64_t>::max();
     pool_->setMemoryUsageTracker(
         memory::MemoryUsageTracker::create(kUnlimited, kUnlimited, kUnlimited));
   }
 
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   memory::MappedMemory* FOLLY_NONNULL mappedMemory_;
   std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs_;
   folly::Executor* FOLLY_NULLABLE executor_;

--- a/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
@@ -91,8 +91,7 @@ class BaseDuckWrapperTest : public testing::Test {
   }
 
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
   std::unique_ptr<DuckDBWrapper> db_{

--- a/velox/dwio/common/tests/BitConcatenationTest.cpp
+++ b/velox/dwio/common/tests/BitConcatenationTest.cpp
@@ -22,7 +22,7 @@ using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;
 
 TEST(BitConcatenationTests, basic) {
-  auto pool = facebook::velox::memory::getDefaultScopedMemoryPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
   BitConcatenation bits(*pool);
   BufferPtr result;
 

--- a/velox/dwio/common/tests/DataBufferBenchmark.cpp
+++ b/velox/dwio/common/tests/DataBufferBenchmark.cpp
@@ -24,11 +24,10 @@ using namespace facebook::velox::dwio;
 using namespace facebook::velox::dwio::common;
 
 BENCHMARK(DataBufferOps, iters) {
-  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
   constexpr size_t size = 1024 * 1024 * 16;
   for (size_t i = 0; i < iters; ++i) {
-    DataBuffer<int32_t> buf{pool};
+    DataBuffer<int32_t> buf{*pool};
     buf.reserve(size);
     for (size_t j = 0; j < size; ++j) {
       buf.unsafeAppend(j);
@@ -40,11 +39,10 @@ BENCHMARK(DataBufferOps, iters) {
 }
 
 BENCHMARK(ChainedBufferOps, iters) {
-  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
   constexpr size_t size = 1024 * 1024 * 16;
   for (size_t i = 0; i < iters; ++i) {
-    ChainedBuffer<int32_t> buf{pool, size, size * 4};
+    ChainedBuffer<int32_t> buf{*pool, size, size * 4};
     for (size_t j = 0; j < size; ++j) {
       buf.unsafeAppend(j);
     }

--- a/velox/dwio/common/tests/DataBufferTests.cpp
+++ b/velox/dwio/common/tests/DataBufferTests.cpp
@@ -30,7 +30,7 @@ using MemoryPool = facebook::velox::memory::MemoryPool;
 
 TEST(DataBuffer, ZeroOut) {
   const uint8_t VALUE = 13;
-  auto pool = facebook::velox::memory::getDefaultScopedMemoryPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
   DataBuffer<uint8_t> buffer(*pool, 16);
   for (auto i = 0; i < buffer.size(); i++) {
     auto data = buffer.data();
@@ -58,7 +58,7 @@ TEST(DataBuffer, ZeroOut) {
 }
 
 TEST(DataBuffer, At) {
-  auto pool = facebook::velox::memory::getDefaultScopedMemoryPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
 
   DataBuffer<uint8_t> buffer{*pool};
   for (auto i = 0; i != 15; ++i) {
@@ -80,7 +80,7 @@ TEST(DataBuffer, At) {
 }
 
 TEST(DataBuffer, Reset) {
-  auto pool = facebook::velox::memory::getDefaultScopedMemoryPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
 
   DataBuffer<uint8_t> buffer{*pool};
   buffer.reserve(16);
@@ -136,7 +136,7 @@ TEST(DataBuffer, Reset) {
 }
 
 TEST(DataBuffer, Wrap) {
-  auto pool = facebook::velox::memory::getDefaultScopedMemoryPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
   auto size = 26;
   auto buffer = velox::AlignedBuffer::allocate<char>(size, pool.get());
   auto raw = buffer->asMutable<char>();
@@ -153,7 +153,7 @@ TEST(DataBuffer, Wrap) {
 }
 
 TEST(DataBuffer, Move) {
-  auto pool = facebook::velox::memory::getDefaultScopedMemoryPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
   {
     DataBuffer<uint8_t> buffer{*pool};
     buffer.reserve(16);

--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -79,7 +79,7 @@ class E2EFilterTestBase : public testing::Test {
   static constexpr int32_t kRowsInGroup = 10'000;
 
   void SetUp() override {
-    pool_ = memory::getDefaultScopedMemoryPool();
+    pool_ = memory::getDefaultMemoryPool();
   }
 
   static bool typeKindSupportsValueHook(TypeKind kind) {
@@ -277,7 +277,7 @@ class E2EFilterTestBase : public testing::Test {
 
   std::unique_ptr<test::DataSetBuilder> dataSetBuilder_;
   std::unique_ptr<common::FilterGenerator> filterGenerator_;
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   std::shared_ptr<const RowType> rowType_;
   dwio::common::MemorySink* sinkPtr_;
   bool useVInts_ = true;

--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -22,9 +22,8 @@ using namespace facebook::velox::dwio::common;
 
 TEST(TestBufferedInput, ZeroLengthStream) {
   MemoryInputStream stream{nullptr, 0};
-  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  BufferedInput input{stream, pool};
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  BufferedInput input{stream, *pool};
   auto ret = input.enqueue({0, 0});
   EXPECT_NE(ret, nullptr);
   const void* buf = nullptr;

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -399,7 +399,7 @@ target_link_libraries(
   ${ZLIB_LIBRARIES}
   ${TEST_LINK_LIBS})
 
-add_executable(velox_dwrf_writer_flush_test TestWriterFlush.cpp)
+add_executable(velox_dwrf_writer_flush_test WriterFlushTest.cpp)
 add_test(velox_dwrf_writer_flush_test velox_dwrf_writer_flush_test)
 
 target_link_libraries(

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -435,8 +435,7 @@ class CacheTest : public testing::Test {
   std::shared_ptr<AsyncDataCache> cache_;
   std::shared_ptr<IoStatistics> ioStats_;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
 
   // Id of simulated streams. Corresponds 1:1 to 'streamStarts_'.
   std::vector<std::unique_ptr<dwrf::DwrfStreamIdentifier>> streamIds_;

--- a/velox/dwio/dwrf/test/ColumnWriterIndexTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterIndexTests.cpp
@@ -268,7 +268,7 @@ class WriterEncodingIndexTest2 {
  public:
   WriterEncodingIndexTest2()
       : config_{std::make_shared<Config>()},
-        scopedPool_{facebook::velox::memory::getDefaultScopedMemoryPool()} {}
+        pool_{facebook::velox::memory::getDefaultMemoryPool()} {}
 
   virtual ~WriterEncodingIndexTest2() = default;
 
@@ -295,7 +295,7 @@ class WriterEncodingIndexTest2 {
       size_t flatMapOffset = 0) {
     auto isFlatMap = isRoot && flatMapOffset > 0;
     ASSERT_EQ(recordPositionCount.size(), backfillPositionCount.size());
-    WriterContext context{config_, velox::memory::getDefaultScopedMemoryPool()};
+    WriterContext context{config_, velox::memory::getDefaultMemoryPool()};
     std::vector<StrictMock<MockIndexBuilder>*> mocks;
     for (auto i = 0; i < recordPositionCount.size(); ++i) {
       mocks.push_back(new StrictMock<MockIndexBuilder>());
@@ -318,7 +318,7 @@ class WriterEncodingIndexTest2 {
     };
     auto type = CppToType<Type>::create();
     auto typeWithId = TypeWithId::create(type, isRoot ? 0 : 1);
-    auto batch = prepBatch(1000, &scopedPool_->getPool(), isRoot);
+    auto batch = prepBatch(1000, pool_.get(), isRoot);
 
     // Creating a stream calls recordPosition.
     for (auto n = 0; n < mocks.size(); ++n) {
@@ -398,7 +398,7 @@ class WriterEncodingIndexTest2 {
   }
 
   std::shared_ptr<Config> config_;
-  std::unique_ptr<facebook::velox::memory::ScopedMemoryPool> scopedPool_;
+  std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
 };
 
 class TimestampWriterIndexTest : public testing::Test,
@@ -410,7 +410,7 @@ class TimestampWriterIndexTest : public testing::Test,
   VectorPtr prepBatch(size_t size, MemoryPool* pool) override {
     return prepBatchImpl<Timestamp>(
         size,
-        &scopedPool_->getPool(),
+        pool_.get(),
         [](size_t i, size_t /*unused*/) -> Timestamp {
           return Timestamp(i, i);
         },
@@ -655,7 +655,7 @@ TYPED_TEST(FloatColumnWriterEncodingIndexTest, TestIndex) {
 class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
  public:
   explicit IntegerColumnWriterDirectEncodingIndexTest(bool abandonDict = false)
-      : pool_{memory::getDefaultScopedMemoryPool()},
+      : pool_{memory::getDefaultMemoryPool()},
         config_{std::make_shared<Config>()},
         abandonDict_{abandonDict} {
     config_->set(
@@ -694,7 +694,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
       size_t positionCount,
       size_t stripeCount,
       std::function<bool(size_t, size_t)> callAbandonDict) {
-    WriterContext context{config_, velox::memory::getDefaultScopedMemoryPool()};
+    WriterContext context{config_, velox::memory::getDefaultMemoryPool()};
     auto mockIndexBuilder = std::make_unique<StrictMock<MockIndexBuilder>>();
     auto mockIndexBuilderPtr = mockIndexBuilder.get();
     context.indexBuilderFactory_ = [&](auto /* unused */) {
@@ -819,7 +819,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
     }
   }
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   std::shared_ptr<Config> config_;
   bool abandonDict_;
 };
@@ -858,7 +858,7 @@ TEST_F(IntegerColumnWriterAbandonDictionaryIndexTest, AbandonDictionary) {
 class StringColumnWriterDictionaryEncodingIndexTest : public testing::Test {
  public:
   explicit StringColumnWriterDictionaryEncodingIndexTest()
-      : pool_{memory::getDefaultScopedMemoryPool()},
+      : pool_{memory::getDefaultMemoryPool()},
         config_{std::make_shared<Config>()} {
     config_->set(
         Config::STRING_STATS_LIMIT, std::numeric_limits<uint32_t>::max());
@@ -881,7 +881,7 @@ class StringColumnWriterDictionaryEncodingIndexTest : public testing::Test {
   }
 
   void runTest(size_t pageCount, size_t positionCount, size_t stripeCount) {
-    WriterContext context{config_, velox::memory::getDefaultScopedMemoryPool()};
+    WriterContext context{config_, velox::memory::getDefaultMemoryPool()};
     auto mockIndexBuilder = std::make_unique<StrictMock<MockIndexBuilder>>();
     auto mockIndexBuilderPtr = mockIndexBuilder.get();
     context.indexBuilderFactory_ = [&](auto /* unused */) {
@@ -934,7 +934,7 @@ class StringColumnWriterDictionaryEncodingIndexTest : public testing::Test {
     }
   }
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   std::shared_ptr<Config> config_;
 };
 
@@ -957,7 +957,7 @@ TEST_F(StringColumnWriterDictionaryEncodingIndexTest, OmitInDictStream) {
 class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
  public:
   explicit StringColumnWriterDirectEncodingIndexTest(bool abandonDict = false)
-      : pool_{memory::getDefaultScopedMemoryPool()},
+      : pool_{memory::getDefaultMemoryPool()},
         config_{std::make_shared<Config>()},
         abandonDict_{abandonDict} {
     config_->set(
@@ -984,7 +984,7 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
       size_t positionCount,
       size_t stripeCount,
       std::function<bool(size_t, size_t)> callAbandonDict = neverAbandonDict) {
-    WriterContext context{config_, velox::memory::getDefaultScopedMemoryPool()};
+    WriterContext context{config_, velox::memory::getDefaultMemoryPool()};
     auto mockIndexBuilder = std::make_unique<StrictMock<MockIndexBuilder>>();
     auto mockIndexBuilderPtr = mockIndexBuilder.get();
     context.indexBuilderFactory_ = [&](auto /* unused */) {
@@ -1108,7 +1108,7 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
     }
   }
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   std::shared_ptr<Config> config_;
   bool abandonDict_;
 };

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -307,16 +307,15 @@ void testDataTypeWriter(
   std::shuffle(data.begin(), data.end(), std::default_random_engine(seed));
 
   auto config = std::make_shared<Config>();
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  WriterContext context{config, getDefaultScopedMemoryPool()};
+  auto pool = getDefaultMemoryPool();
+  WriterContext context{config, getDefaultMemoryPool()};
   auto rowType = ROW({type});
   auto dataTypeWithId = TypeWithId::create(type, 1);
 
   // write
   auto writer = BaseColumnWriter::create(context, *dataTypeWithId, sequence);
   auto size = data.size();
-  auto batch = populateBatch(data, &pool);
+  auto batch = populateBatch(data, pool.get());
   const size_t stripeCount = 2;
   const size_t strideCount = 3;
 
@@ -355,7 +354,7 @@ TEST(ColumnWriterTests, LowMemoryModeConfig) {
   auto dataTypeWithId = TypeWithId::create(std::make_shared<VarcharType>(), 1);
   auto config = std::make_shared<Config>();
   WriterContext context{
-      config, facebook::velox::memory::getDefaultScopedMemoryPool()};
+      config, facebook::velox::memory::getDefaultMemoryPool()};
   auto writer = BaseColumnWriter::create(context, *dataTypeWithId);
   EXPECT_TRUE(writer->useDictionaryEncoding());
 }
@@ -881,7 +880,7 @@ void testMapWriter(
     // expect that if we pass useStruct true with useFlatMap false, it will fail
   }
 
-  WriterContext context{config, getDefaultScopedMemoryPool()};
+  WriterContext context{config, getDefaultMemoryPool()};
   const auto writer = BaseColumnWriter::create(context, *writerDataTypeWithId);
   // For writing flat map with encoded input, we'd like to test all 4
   // combinations.
@@ -1027,7 +1026,7 @@ void testMapWriterRow(
   config->set(
       Config::MAP_FLAT_DISABLE_DICT_ENCODING, disableDictionaryEncoding);
 
-  WriterContext context{config, getDefaultScopedMemoryPool()};
+  WriterContext context{config, getDefaultMemoryPool()};
   const auto writer = BaseColumnWriter::create(context, *writerDataTypeWithId);
 
   // Each batch represents an input for a separate stripe
@@ -1114,14 +1113,13 @@ template <typename TVALUE>
 void testMapWriterRowImpl() {
   auto type = CppToType<Row<TVALUE, TVALUE>>::create();
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  auto batch = BatchMaker::createVector<TypeKind::ROW>(type, 10, pool);
+  auto pool = getDefaultMemoryPool();
+  auto batch = BatchMaker::createVector<TypeKind::ROW>(type, 10, *pool);
 
   std::vector<VectorPtr> batches{batch, batch};
 
-  testMapWriterRow<TVALUE>(pool, batches, true, false);
-  testMapWriterRow<TVALUE>(pool, batches, true, true);
+  testMapWriterRow<TVALUE>(*pool, batches, true, false);
+  testMapWriterRow<TVALUE>(*pool, batches, true, true);
 }
 
 TEST(ColumnWriterTests, TestMapWriterNestedRow) {
@@ -1160,10 +1158,9 @@ template <typename T>
 void testMapWriterNumericKey(bool useFlatMap, bool useStruct = false) {
   using b = MapBuilder<T, T>;
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
   auto batch = b::create(
-      pool,
+      *pool,
       {typename b::row{
            typename b::pair{std::numeric_limits<T>::max(), 3},
            typename b::pair{2, std::numeric_limits<T>::max()}},
@@ -1172,7 +1169,7 @@ void testMapWriterNumericKey(bool useFlatMap, bool useStruct = false) {
            typename b::pair{
                std::numeric_limits<T>::min(), std::numeric_limits<T>::min()}}});
 
-  testMapWriter<T, T>(pool, batch, useFlatMap, true, useStruct);
+  testMapWriter<T, T>(*pool, batch, useFlatMap, true, useStruct);
 }
 
 TEST(ColumnWriterTests, TestMapWriterFloatKey) {
@@ -1219,17 +1216,16 @@ TEST(ColumnWriterTests, TestMapWriterStringKey) {
   using valueType = StringView;
   using b = MapBuilder<keyType, valueType>;
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
   auto batch = b::create(
-      pool,
+      *pool,
       {b::row{b::pair{"1", "3"}, b::pair{"2", "2"}},
        b::row{b::pair{"2", "5"}, b::pair{"3", "8"}}});
 
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ false);
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ true);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ false);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ true);
   testMapWriter<keyType, valueType>(
-      pool, batch, /* useFlatMap */ true, true, /* useStruct */ true);
+      *pool, batch, /* useFlatMap */ true, true, /* useStruct */ true);
 }
 
 TEST(ColumnWriterTests, TestMapWriterDifferentNumericKeyValue) {
@@ -1237,14 +1233,13 @@ TEST(ColumnWriterTests, TestMapWriterDifferentNumericKeyValue) {
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
   auto batch = b::create(
-      pool,
+      *pool,
       {b::row{b::pair{1, 3}, b::pair{2, 2}},
        b::row{b::pair{2, 5}, b::pair{3, 8}}});
 
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ false);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ false);
 }
 
 TEST(ColumnWriterTests, TestMapWriterDifferentKeyValue) {
@@ -1252,14 +1247,13 @@ TEST(ColumnWriterTests, TestMapWriterDifferentKeyValue) {
   using valueType = StringView;
   using b = MapBuilder<keyType, valueType>;
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
   auto batch = b::create(
-      pool,
+      *pool,
       {b::row{b::pair{1, "3"}, b::pair{2, "2"}},
        b::row{b::pair{2, "5"}, b::pair{3, "8"}}});
 
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ false);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ false);
 }
 
 TEST(ColumnWriterTests, TestMapWriterMixedBatchTypeHandling) {
@@ -1270,15 +1264,14 @@ TEST(ColumnWriterTests, TestMapWriterMixedBatchTypeHandling) {
   using valueType2 = StringView;
   using b2 = MapBuilder<keyType, valueType2>;
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
   auto batch1 = b::create(
-      pool,
+      *pool,
       {b::row{b::pair{1, 3}, b::pair{2, 2}},
        b::row{b::pair{5, 5}, b::pair{3, 4}, b::pair{2, 5}}});
 
   auto batch2 = b2::create(
-      pool,
+      *pool,
       {b2::row{b2::pair{8, "3"}, b2::pair{6, "2"}},
        b2::row{b2::pair{20, "5"}, b2::pair{2, "4"}, b2::pair{63, "5"}}});
 
@@ -1288,7 +1281,7 @@ TEST(ColumnWriterTests, TestMapWriterMixedBatchTypeHandling) {
   // when dictionary encoding is enabled.
   EXPECT_THROW(
       (testMapWriter<keyType, valueType>(
-          pool,
+          *pool,
           batches,
           /* useFlatMap */ true,
           true,
@@ -1301,31 +1294,27 @@ TEST(ColumnWriterTests, TestMapWriterBinaryKey) {
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
   auto batch = b::create(
-      pool,
+      *pool,
       {b::row{b::pair{"1", 3}, b::pair{"2", 2}},
        b::row{b::pair{"2", 5}, b::pair{"3", 8}}});
 
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ false);
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ true);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ false);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ true);
   testMapWriter<keyType, valueType>(
-      pool, batch, /* useFlatMap */ true, true, /* useStruct */ true);
+      *pool, batch, /* useFlatMap */ true, true, /* useStruct */ true);
 }
 
 template <typename keyType, typename valueType>
 void testMapWriterImpl() {
   auto type = CppToType<Map<keyType, valueType>>::create();
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  auto batch = BatchMaker::createVector<TypeKind::MAP>(type, 100, pool);
+  auto pool = getDefaultMemoryPool();
+  auto batch = BatchMaker::createVector<TypeKind::MAP>(type, 100, *pool);
 
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ false);
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ true);
-  // testMapWriter<keyType, valueType>(
-  //     pool, batch, /* useFlatMap */ true, true, /* useStruct */ true);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ false);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ true);
 }
 
 TEST(ColumnWriterTests, TestMapWriterNestedMap) {
@@ -1347,28 +1336,27 @@ TEST(ColumnWriterTests, TestMapWriterDifferentStripeBatches) {
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
   auto batch1 = b::create(
-      pool,
+      *pool,
       {b::row{b::pair{1, 3}, b::pair{2, 2}},
        b::row{b::pair{5, 5}, b::pair{3, 4}, b::pair{2, 5}}});
 
   auto batch2 = b::create(
-      pool,
+      *pool,
       {b::row{b::pair{8, 3}, b::pair{6, 2}},
        b::row{b::pair{20, 5}, b::pair{2, 4}, b::pair{63, 5}}});
 
   std::vector<VectorPtr> batches{batch1, batch2};
 
   testMapWriter<keyType, valueType>(
-      pool,
+      *pool,
       batches,
       /* useFlatMap */ false,
       false,
       false);
   testMapWriter<keyType, valueType>(
-      pool,
+      *pool,
       batches,
       /* useFlatMap */ true,
       false,
@@ -1380,15 +1368,14 @@ TEST(ColumnWriterTests, TestMapWriterNullValues) {
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
   auto batch = b::create(
-      pool,
+      *pool,
       {b::row{b::pair{1, std::nullopt}, b::pair{2, 2}},
        b::row{b::pair{5, 5}, b::pair{3, std::nullopt}, b::pair{2, 5}}});
 
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ false);
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ true);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ false);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ true);
 }
 
 TEST(ColumnWriterTests, TestMapWriterNullRows) {
@@ -1396,18 +1383,17 @@ TEST(ColumnWriterTests, TestMapWriterNullRows) {
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
   auto batch = b::create(
-      pool,
+      *pool,
       {std::nullopt,
        b::row{b::pair{1, 3}, b::pair{2, 2}},
        std::nullopt,
        b::row{b::pair{2, 5}},
        std::nullopt});
 
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ false);
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ true);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ false);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ true);
 }
 
 TEST(ColumnWriterTests, TestMapWriterDuplicateKeys) {
@@ -1415,19 +1401,18 @@ TEST(ColumnWriterTests, TestMapWriterDuplicateKeys) {
   using valueType = int32_t;
   using b = MapBuilder<keyType, valueType>;
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
   auto batch = b::create(
-      pool,
+      *pool,
       {
           b::row{b::pair{1, 3}, b::pair{1, 2}},
       });
 
   // Default map writer doesn't throw on duplicate keys
   // TODO: Is there a way to easily detect duplicate keys in MapColumnWriter?
-  testMapWriter<keyType, valueType>(pool, batch, /* useFlatMap */ false);
+  testMapWriter<keyType, valueType>(*pool, batch, /* useFlatMap */ false);
   EXPECT_THROW(
-      (testMapWriter<keyType, valueType>(pool, batch, true)),
+      (testMapWriter<keyType, valueType>(*pool, batch, true)),
       exception::LoggedException);
 }
 
@@ -1440,8 +1425,7 @@ TEST(ColumnWriterTests, TestMapWriterBigBatch) {
   const auto maxDictionarySize = 50;
   const auto nullEvery = 10;
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
   b::rows rows;
   for (int32_t i = 0; i < size; ++i) {
     if ((i % nullEvery) == 0) {
@@ -1457,13 +1441,13 @@ TEST(ColumnWriterTests, TestMapWriterBigBatch) {
     rows.push_back(row);
   }
 
-  auto batch = b::create(pool, rows);
+  auto batch = b::create(*pool, rows);
   testMapWriter<keyType, valueType>(
-      pool,
+      *pool,
       batch,
       /* useFlatMap */ false);
   testMapWriter<keyType, valueType>(
-      pool,
+      *pool,
       batch,
       /* useFlatMap */ true);
 }
@@ -1525,11 +1509,10 @@ void removeSizeFromStats(std::string& input) {
 }
 
 void testMapWriterStats(const std::shared_ptr<const RowType> type) {
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  auto batch = BatchMaker::createBatch(type, 10, pool);
-  auto mapReader = getDwrfReader(pool, type, batch, false);
-  auto flatMapReader = getDwrfReader(pool, type, batch, true);
+  auto pool = getDefaultMemoryPool();
+  auto batch = BatchMaker::createBatch(type, 10, *pool);
+  auto mapReader = getDwrfReader(*pool, type, batch, false);
+  auto flatMapReader = getDwrfReader(*pool, type, batch, true);
   ASSERT_EQ(
       mapReader->getFooter().statisticsSize(),
       flatMapReader->getFooter().statisticsSize());
@@ -1940,15 +1923,15 @@ struct IntegerColumnWriterTypedTestCase {
   void runTest() const {
     auto type = CppToType<Integer>::create();
     auto typeWithId = TypeWithId::create(type, 1);
-    std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = *scopedPool;
+    auto pool = getDefaultMemoryPool();
 
     // Prepare input
-    BufferPtr nulls = AlignedBuffer::allocate<char>(bits::nbytes(size), &pool);
+    BufferPtr nulls =
+        AlignedBuffer::allocate<char>(bits::nbytes(size), pool.get());
     auto* nullsPtr = nulls->asMutable<uint64_t>();
     size_t nullCount = 0;
 
-    BufferPtr values = AlignedBuffer::allocate<Integer>(size, &pool);
+    BufferPtr values = AlignedBuffer::allocate<Integer>(size, pool.get());
     auto* valuesPtr = values->asMutable<Integer>();
 
     for (size_t i = 0; i != size; ++i) {
@@ -1980,7 +1963,7 @@ struct IntegerColumnWriterTypedTestCase {
     }
 
     auto batch = std::make_shared<FlatVector<Integer>>(
-        &pool, nulls, size, values, std::vector<BufferPtr>());
+        pool.get(), nulls, size, values, std::vector<BufferPtr>());
     batch->setNullCount(nullCount);
 
     // Set up writer.
@@ -1988,7 +1971,7 @@ struct IntegerColumnWriterTypedTestCase {
     config->set(
         Config::DICTIONARY_NUMERIC_KEY_SIZE_THRESHOLD,
         dictionaryWriteThreshold);
-    WriterContext context{config, getDefaultScopedMemoryPool()};
+    WriterContext context{config, getDefaultMemoryPool()};
     // Register root node.
     auto columnWriter = BaseColumnWriter::create(context, *typeWithId);
 
@@ -3079,21 +3062,20 @@ template <typename Integer>
 void testIntegerDictionaryEncodableWriterConstructor() {
   auto type = CppToType<Integer>::create();
   auto typeWithId = TypeWithId::create(type, 1);
-  std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = getDefaultMemoryPool();
 
   // Write input
   auto config = std::make_shared<Config>();
   float slightlyOver = 1.0f + std::numeric_limits<float>::epsilon() * 2;
   {
     config->set(Config::DICTIONARY_NUMERIC_KEY_SIZE_THRESHOLD, slightlyOver);
-    WriterContext context{config, getDefaultScopedMemoryPool()};
+    WriterContext context{config, getDefaultMemoryPool()};
     EXPECT_ANY_THROW(BaseColumnWriter::create(context, *typeWithId));
   }
   float slightlyUnder = -std::numeric_limits<float>::epsilon();
   {
     config->set(Config::DICTIONARY_NUMERIC_KEY_SIZE_THRESHOLD, slightlyUnder);
-    WriterContext context{config, getDefaultScopedMemoryPool()};
+    WriterContext context{config, getDefaultMemoryPool()};
     EXPECT_ANY_THROW(BaseColumnWriter::create(context, *typeWithId));
   }
 }
@@ -3199,8 +3181,7 @@ struct StringColumnWriterTestCase {
   }
 
   void runTest() const {
-    std::unique_ptr<ScopedMemoryPool> scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = *scopedPool;
+    auto pool = getDefaultMemoryPool();
 
     // Set up writer.
     auto config = std::make_shared<Config>();
@@ -3210,7 +3191,7 @@ struct StringColumnWriterTestCase {
     config->set(
         Config::DICTIONARY_STRING_KEY_SIZE_THRESHOLD,
         dictionaryKeyEfficiencyThreshold);
-    WriterContext context{config, getDefaultScopedMemoryPool()};
+    WriterContext context{config, getDefaultMemoryPool()};
     // Register root node.
     auto typeWithId = TypeWithId::create(type, 1);
     auto columnWriter = BaseColumnWriter::create(context, *typeWithId);
@@ -3219,7 +3200,7 @@ struct StringColumnWriterTestCase {
     std::vector<VectorPtr> batches;
 
     for (size_t j = 0; j != repetitionCount; j++) {
-      batches.emplace_back(generateStringSlice(j, &pool));
+      batches.emplace_back(generateStringSlice(j, pool.get()));
     }
 
     for (size_t i = 0; i != flushCount; ++i) {
@@ -4042,9 +4023,8 @@ TEST(ColumnWriterTests, StringColumnWriterAbandonLowValueDictionaries) {
 
 TEST(ColumnWriterTests, IntDictWriterDirectValueOverflow) {
   auto config = std::make_shared<Config>();
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  WriterContext context{config, getDefaultScopedMemoryPool()};
+  auto pool = getDefaultMemoryPool();
+  WriterContext context{config, getDefaultMemoryPool()};
   auto type = std::make_shared<const IntegerType>();
   auto typeWithId = TypeWithId::create(type, 1);
 
@@ -4054,7 +4034,7 @@ TEST(ColumnWriterTests, IntDictWriterDirectValueOverflow) {
   for (auto i = 0; i < size; ++i) {
     data.push_back((i == 0 ? -1 : 1));
   }
-  auto vector = populateBatch<int32_t>(data, &pool);
+  auto vector = populateBatch<int32_t>(data, pool.get());
 
   auto writer = BaseColumnWriter::create(context, *typeWithId, 0);
   writer->write(vector, common::Ranges::of(0, size));
@@ -4073,7 +4053,7 @@ TEST(ColumnWriterTests, IntDictWriterDirectValueOverflow) {
 
   // read it as long
   auto decoder = createRleDecoder<false>(
-      std::move(stream), RleVersion_1, pool, streams.getUseVInts(si), 8);
+      std::move(stream), RleVersion_1, *pool, streams.getUseVInts(si), 8);
   std::array<int64_t, size> actual;
   decoder->next(actual.data(), size, nullptr);
   for (auto i = 0; i < size; ++i) {
@@ -4083,9 +4063,8 @@ TEST(ColumnWriterTests, IntDictWriterDirectValueOverflow) {
 
 TEST(ColumnWriterTests, ShortDictWriterDictValueOverflow) {
   auto config = std::make_shared<Config>();
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  WriterContext context{config, getDefaultScopedMemoryPool()};
+  auto pool = getDefaultMemoryPool();
+  WriterContext context{config, getDefaultMemoryPool()};
   auto type = std::make_shared<const SmallintType>();
   auto typeWithId = TypeWithId::create(type, 1);
 
@@ -4100,7 +4079,7 @@ TEST(ColumnWriterTests, ShortDictWriterDictValueOverflow) {
       data.push_back(val++);
     }
   }
-  auto vector = populateBatch<int16_t>(data, &pool);
+  auto vector = populateBatch<int16_t>(data, pool.get());
 
   auto writer = BaseColumnWriter::create(context, *typeWithId, 0);
   writer->write(vector, common::Ranges::of(0, size));
@@ -4119,7 +4098,7 @@ TEST(ColumnWriterTests, ShortDictWriterDictValueOverflow) {
 
   // read it as long
   auto decoder = createRleDecoder<false>(
-      std::move(stream), RleVersion_1, pool, streams.getUseVInts(si), 8);
+      std::move(stream), RleVersion_1, *pool, streams.getUseVInts(si), 8);
   std::array<int64_t, size> actual;
   decoder->next(actual.data(), size, nullptr);
   for (auto i = 0; i < size; ++i) {
@@ -4129,16 +4108,15 @@ TEST(ColumnWriterTests, ShortDictWriterDictValueOverflow) {
 
 TEST(ColumnWriterTests, RemovePresentStream) {
   auto config = std::make_shared<Config>();
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = getDefaultMemoryPool();
 
   std::vector<std::optional<int32_t>> data;
   auto size = 100;
   for (auto i = 0; i < size; ++i) {
     data.push_back(i);
   }
-  auto vector = populateBatch<int32_t>(data, &pool);
-  WriterContext context{config, getDefaultScopedMemoryPool()};
+  auto vector = populateBatch<int32_t>(data, pool.get());
+  WriterContext context{config, getDefaultMemoryPool()};
   auto type = std::make_shared<const IntegerType>();
   auto typeWithId = TypeWithId::create(type, 1);
 
@@ -4160,16 +4138,15 @@ TEST(ColumnWriterTests, RemovePresentStream) {
 
 TEST(ColumnWriterTests, ColumnIdInStream) {
   auto config = std::make_shared<Config>();
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = getDefaultMemoryPool();
 
   std::vector<std::optional<int32_t>> data;
   auto size = 100;
   for (auto i = 0; i < size; ++i) {
     data.push_back(i);
   }
-  auto vector = populateBatch<int32_t>(data, &pool);
-  WriterContext context{config, getDefaultScopedMemoryPool()};
+  auto vector = populateBatch<int32_t>(data, pool.get());
+  WriterContext context{config, getDefaultMemoryPool()};
   auto type = std::make_shared<const IntegerType>();
   const uint32_t kNodeId = 4;
   const uint32_t kColumnId = 2;
@@ -4206,7 +4183,8 @@ struct DictColumnWriterTestCase {
   TypePtr type_;
 
   BufferPtr randomIndices(vector_size_t size) {
-    BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, &pool_);
+    BufferPtr indices =
+        AlignedBuffer::allocate<vector_size_t>(size, pool_.get());
     auto rawIndices = indices->asMutable<vector_size_t>();
     for (int32_t i = 0; i < size; i++) {
       rawIndices[i] = folly::Random::rand32(size);
@@ -4226,7 +4204,7 @@ struct DictColumnWriterTestCase {
       std::function<T(vector_size_t /*index*/)> valueAt,
       std::function<bool(vector_size_t /*index*/)> isNullAt = nullptr) {
     auto vector = std::dynamic_pointer_cast<FlatVector<T>>(
-        BaseVector::create(type_, size, &pool_));
+        BaseVector::create(type_, size, pool_.get()));
     for (int32_t i = 0; i < size; ++i) {
       if (isNullAt && isNullAt(i)) {
         vector->setNull(i, true);
@@ -4251,7 +4229,7 @@ struct DictColumnWriterTestCase {
       int32_t count,
       std::function<bool(vector_size_t /*index*/)> isNullAt) {
     auto vector = std::dynamic_pointer_cast<RowVector>(
-        BatchMaker::createBatch(rowType, count, pool_, isNullAt));
+        BatchMaker::createBatch(rowType, count, *pool_, isNullAt));
     // Batch is returned as a RowVector and so we grab its first column
     return vector->childAt(0);
   }
@@ -4293,7 +4271,7 @@ struct DictColumnWriterTestCase {
     auto typeWithId = TypeWithId::create(type_, 1);
     auto rowType = ROW({type_});
 
-    WriterContext context{config, getDefaultScopedMemoryPool()};
+    WriterContext context{config, getDefaultMemoryPool()};
 
     // complexVectorType will be nullptr if the vector is not complex.
     bool isComplexType = std::dynamic_pointer_cast<const RowType>(type_) ||
@@ -4341,8 +4319,7 @@ struct DictColumnWriterTestCase {
     }
   }
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool_ = getDefaultScopedMemoryPool();
-  MemoryPool& pool_ = *scopedPool_;
+  std::shared_ptr<MemoryPool> pool_ = getDefaultMemoryPool();
 };
 
 std::function<bool(vector_size_t /*index*/)> randomNulls(int32_t n) {

--- a/velox/dwio/dwrf/test/FlushPolicyTest.cpp
+++ b/velox/dwio/dwrf/test/FlushPolicyTest.cpp
@@ -232,7 +232,7 @@ TEST(RowsPerStripeFlushPolicyTest, InvalidCases) {
 // RowsPerStripeFlushPolicy has no dictionary flush criteria.
 TEST(RowsPerSTripeFlushPolicyTest, DictionaryCriteriaTest) {
   auto config = std::make_shared<Config>();
-  WriterContext context{config, getDefaultScopedMemoryPool()};
+  WriterContext context{config, getDefaultMemoryPool()};
 
   RowsPerStripeFlushPolicy policy({42});
   EXPECT_EQ(

--- a/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
+++ b/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
@@ -30,8 +30,8 @@ using namespace facebook::velox::memory;
 
 static size_t generateAutoId(int64_t startId, int64_t count) {
   size_t capacity = count * folly::kMaxVarintLength64;
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  DataBufferHolder holder{*scopedPool, capacity};
+  auto pool = memory::getDefaultMemoryPool();
+  DataBufferHolder holder{*pool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
       createDirectEncoder<true>(std::move(output), true, sizeof(int64_t));
@@ -44,8 +44,8 @@ static size_t generateAutoId(int64_t startId, int64_t count) {
 
 static size_t generateAutoId2(int64_t startId, int64_t count) {
   size_t capacity = count * folly::kMaxVarintLength64;
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  DataBufferHolder holder{*scopedPool, capacity};
+  auto pool = memory::getDefaultMemoryPool();
+  DataBufferHolder holder{*pool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
       createDirectEncoder<true>(std::move(output), true, sizeof(int64_t));

--- a/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
+++ b/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
@@ -24,7 +24,7 @@ TEST(LayoutPlannerTests, Basic) {
   config->set(
       Config::COMPRESSION, dwio::common::CompressionKind::CompressionKind_NONE);
   WriterContext context{
-      config, facebook::velox::memory::getDefaultScopedMemoryPool()};
+      config, facebook::velox::memory::getDefaultMemoryPool()};
   // fake streams
   std::vector<DwrfStreamIdentifier> streams;
   streams.reserve(10);

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -64,10 +64,10 @@ class StripeLoadKeysTest : public Test {
 
     TestDecrypterFactory factory;
     auto handler = DecryptionHandler::create(FooterWrapper(footer), &factory);
-    scopedPool_ = getDefaultScopedMemoryPool();
+    pool_ = getDefaultMemoryPool();
 
     reader_ = std::make_unique<ReaderBase>(
-        scopedPool_->getPool(),
+        *pool_,
         std::make_unique<MemoryInputStream>(nullptr, 0),
         nullptr,
         footer,
@@ -90,7 +90,7 @@ class StripeLoadKeysTest : public Test {
   std::shared_ptr<ReaderBase> reader_;
   std::unique_ptr<StripeReaderBase> stripeReader_;
   TestEncryption* enc_;
-  std::unique_ptr<ScopedMemoryPool> scopedPool_;
+  std::shared_ptr<MemoryPool> pool_;
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/TestBufferedOutputStream.cpp
+++ b/velox/dwio/dwrf/test/TestBufferedOutputStream.cpp
@@ -25,12 +25,11 @@ using namespace facebook::velox::memory;
 using namespace facebook::velox::dwrf;
 
 TEST(BufferedOutputStream, blockAligned) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  MemorySink memSink(pool, 1024);
+  auto pool = getDefaultMemoryPool();
+  MemorySink memSink(*pool, 1024);
 
   uint64_t block = 10;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
   BufferedOutputStream bufStream(holder);
   for (int32_t i = 0; i < 100; ++i) {
     char* buf;
@@ -50,12 +49,11 @@ TEST(BufferedOutputStream, blockAligned) {
 }
 
 TEST(BufferedOutputStream, blockNotAligned) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  MemorySink memSink(pool, 1024);
+  auto pool = getDefaultMemoryPool();
+  MemorySink memSink(*pool, 1024);
 
   uint64_t block = 10;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
   BufferedOutputStream bufStream(holder);
 
   char* buf;
@@ -96,12 +94,11 @@ TEST(BufferedOutputStream, blockNotAligned) {
 }
 
 TEST(BufferedOutputStream, protoBufSerialization) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  MemorySink memSink(pool, 1024);
+  auto pool = getDefaultMemoryPool();
+  MemorySink memSink(*pool, 1024);
 
   uint64_t block = 10;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
   BufferedOutputStream bufStream(holder);
 
   proto::PostScript ps;
@@ -122,13 +119,12 @@ TEST(BufferedOutputStream, protoBufSerialization) {
 }
 
 TEST(BufferedOutputStream, increaseSize) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  MemorySink memSink(pool, 1024);
+  auto pool = getDefaultMemoryPool();
+  MemorySink memSink(*pool, 1024);
 
   uint64_t max = 512;
   uint64_t min = 16;
-  DataBufferHolder holder{pool, max, min, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, max, min, DEFAULT_PAGE_GROW_RATIO, &memSink};
   BufferedOutputStream bufStream(holder);
 
   char* buf;
@@ -178,13 +174,12 @@ TEST(BufferedOutputStream, increaseSize) {
 }
 
 TEST(BufferedOutputStream, recordPosition) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  MemorySink memSink(pool, 1024);
+  auto pool = getDefaultMemoryPool();
+  MemorySink memSink(*pool, 1024);
   uint64_t block = 256;
   uint64_t initial = 128;
   DataBufferHolder holder{
-      pool, block, initial, DEFAULT_PAGE_GROW_RATIO, &memSink};
+      *pool, block, initial, DEFAULT_PAGE_GROW_RATIO, &memSink};
   BufferedOutputStream bufStream(holder);
 
   TestPositionRecorder recorder;
@@ -239,11 +234,10 @@ TEST(BufferedOutputStream, recordPosition) {
 }
 
 TEST(AppendOnlyBufferedStream, Basic) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  MemorySink memSink(pool, 1024);
+  auto pool = getDefaultMemoryPool();
+  MemorySink memSink(*pool, 1024);
   uint64_t block = 10;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
   auto bufStream = std::make_unique<BufferedOutputStream>(holder);
   AppendOnlyBufferedStream appendable(std::move(bufStream));
 

--- a/velox/dwio/dwrf/test/TestByteRLEEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestByteRLEEncoder.cpp
@@ -111,12 +111,11 @@ void decodeAndVerifyBoolean(
 }
 
 TEST(ByteRleEncoder, random_chars) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
   auto outStream = std::make_unique<BufferedOutputStream>(holder);
 
   std::unique_ptr<ByteRleEncoder> encoder =
@@ -132,12 +131,11 @@ TEST(ByteRleEncoder, random_chars) {
 }
 
 TEST(ByteRleEncoder, random_chars_with_null) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
   auto outStream = std::make_unique<BufferedOutputStream>(holder);
 
   std::unique_ptr<ByteRleEncoder> encoder =
@@ -155,12 +153,11 @@ TEST(ByteRleEncoder, random_chars_with_null) {
 }
 
 TEST(BooleanRleEncoder, random_bits_not_aligned) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
   auto outStream = std::make_unique<BufferedOutputStream>(holder);
 
   std::unique_ptr<ByteRleEncoder> encoder =
@@ -176,12 +173,11 @@ TEST(BooleanRleEncoder, random_bits_not_aligned) {
 }
 
 TEST(BooleanRleEncoder, random_bits_aligned) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
   auto outStream = std::make_unique<BufferedOutputStream>(holder);
 
   std::unique_ptr<ByteRleEncoder> encoder =
@@ -197,12 +193,11 @@ TEST(BooleanRleEncoder, random_bits_aligned) {
 }
 
 TEST(BooleanRleEncoder, random_bits_aligned_with_null) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
   auto outStream = std::make_unique<BufferedOutputStream>(holder);
 
   std::unique_ptr<ByteRleEncoder> encoder =

--- a/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
+++ b/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
@@ -91,22 +91,21 @@ TEST(TestDictionaryEncodingUtils, StringGetSortedIndexLookupTable) {
           {0, 1, 2, 3}}};
 
   for (const auto& testCase : testCases) {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    StringDictionaryEncoder stringDictEncoder{pool, pool};
+    auto pool = getDefaultMemoryPool();
+    StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
     }
 
-    dwio::common::DataBuffer<bool> inDict{pool};
-    dwio::common::DataBuffer<uint32_t> lookupTable{pool};
-    dwio::common::DataBuffer<uint32_t> strideDictCounts{pool};
+    dwio::common::DataBuffer<bool> inDict{*pool};
+    dwio::common::DataBuffer<uint32_t> lookupTable{*pool};
+    dwio::common::DataBuffer<uint32_t> strideDictCounts{*pool};
     size_t pos = 0;
     EXPECT_EQ(
         stringDictEncoder.size(),
         DictionaryEncodingUtils::getSortedIndexLookupTable(
             stringDictEncoder,
-            pool,
+            *pool,
             testCase.sort,
             testCase.ordering,
             false,
@@ -297,18 +296,17 @@ TEST(TestDictionaryEncodingUtils, StringStrideDictOptimization) {
   };
 
   for (const auto& testCase : testCases) {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    StringDictionaryEncoder stringDictEncoder{pool, pool};
+    auto pool = getDefaultMemoryPool();
+    StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     size_t rowCount = 0;
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, rowCount++ / kStrideSize);
     }
 
-    dwio::common::DataBuffer<bool> inDict{pool};
-    dwio::common::DataBuffer<uint32_t> lookupTable{pool};
+    dwio::common::DataBuffer<bool> inDict{*pool};
+    dwio::common::DataBuffer<uint32_t> lookupTable{*pool};
     dwio::common::DataBuffer<uint32_t> strideDictSizes{
-        pool, rowCount / kStrideSize + 1};
+        *pool, rowCount / kStrideSize + 1};
 
     std::vector<folly::StringPiece> expected{testCase.finalDictSize};
     std::vector<uint32_t> expectedSize(testCase.finalDictSize);
@@ -326,7 +324,7 @@ TEST(TestDictionaryEncodingUtils, StringStrideDictOptimization) {
         testCase.finalDictSize,
         DictionaryEncodingUtils::getSortedIndexLookupTable(
             stringDictEncoder,
-            pool,
+            *pool,
             testCase.sort,
             testCase.ordering,
             true,

--- a/velox/dwio/dwrf/test/TestEncodingSelector.cpp
+++ b/velox/dwio/dwrf/test/TestEncodingSelector.cpp
@@ -23,22 +23,21 @@ using namespace facebook::velox::memory;
 namespace facebook::velox::dwrf {
 
 TEST(TestEntropyEncodingSelector, Ctor) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = getDefaultMemoryPool();
   float slightlyOver = 1.0f + std::numeric_limits<float>::epsilon() * 2;
   float slightlyUnder = -std::numeric_limits<float>::epsilon();
   EXPECT_ANY_THROW(
-      EntropyEncodingSelector(pool, slightlyOver, 0.5f, 0, 0.01, 0));
+      EntropyEncodingSelector(*pool, slightlyOver, 0.5f, 0, 0.01, 0));
   EXPECT_ANY_THROW(
-      EntropyEncodingSelector(pool, slightlyUnder, 0.5f, 0, 0.01, 0));
+      EntropyEncodingSelector(*pool, slightlyUnder, 0.5f, 0, 0.01, 0));
   EXPECT_ANY_THROW(
-      EntropyEncodingSelector(pool, 0.5f, slightlyOver, 0, 0.01, 0));
+      EntropyEncodingSelector(*pool, 0.5f, slightlyOver, 0, 0.01, 0));
   EXPECT_ANY_THROW(
-      EntropyEncodingSelector(pool, 0.5f, slightlyUnder, 0, 0.01, 0));
+      EntropyEncodingSelector(*pool, 0.5f, slightlyUnder, 0, 0.01, 0));
   EXPECT_ANY_THROW(
-      EntropyEncodingSelector(pool, 0.5f, 0.5f, 0, slightlyOver, 0));
+      EntropyEncodingSelector(*pool, 0.5f, 0.5f, 0, slightlyOver, 0));
   EXPECT_ANY_THROW(
-      EntropyEncodingSelector(pool, 0.5f, 0.5f, 0, slightlyUnder, 0));
+      EntropyEncodingSelector(*pool, 0.5f, 0.5f, 0, slightlyUnder, 0));
 }
 
 class EntropyEncodingSelectorTest {
@@ -71,16 +70,15 @@ class EntropyEncodingSelectorTest {
         decision_{decision} {}
 
   void runTest() const {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    StringDictionaryEncoder stringDictEncoder{pool, pool};
-    dwio::common::DataBuffer<uint32_t> rows{pool};
+    auto pool = getDefaultMemoryPool();
+    StringDictionaryEncoder stringDictEncoder{*pool, *pool};
+    dwio::common::DataBuffer<uint32_t> rows{*pool};
     rows.reserve(size_);
     for (size_t i = 0; i != size_; ++i) {
       rows.append(stringDictEncoder.addKey(genData_(i, size_), 0));
     }
     EntropyEncodingSelector selector{
-        pool,
+        *pool,
         dictionaryKeySizeThreshold_,
         entropyKeySizeThreshold_,
         entropyMinSamples_,

--- a/velox/dwio/dwrf/test/TestIntDirect.cpp
+++ b/velox/dwio/dwrf/test/TestIntDirect.cpp
@@ -30,10 +30,9 @@ using namespace facebook::velox::dwrf;
 
 template <typename T, bool isSigned, bool vInt>
 void testInts(std::function<T()> generator) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = memory::getDefaultMemoryPool();
   constexpr size_t count = 10240;
-  DataBuffer<T> buffer{pool, count};
+  DataBuffer<T> buffer{*pool, count};
   std::array<uint64_t, count / 64> nulls;
   for (size_t i = 0; i < count; ++i) {
     buffer[i] = generator();
@@ -42,8 +41,8 @@ void testInts(std::function<T()> generator) {
 
   constexpr size_t capacity =
       count * (vInt ? folly::kMaxVarintLength64 : sizeof(T));
-  MemorySink sink{pool, capacity};
-  DataBufferHolder holder{pool, capacity, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
+  MemorySink sink{*pool, capacity};
+  DataBufferHolder holder{*pool, capacity, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
       createDirectEncoder<isSigned>(std::move(output), vInt, sizeof(T));

--- a/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
@@ -41,9 +41,8 @@ TEST(TestIntegerDictionaryEncoder, AddKey) {
       TestCase{{-2, 2, 2, -2, 2}, {0, 1, 1, 0, 1}}};
 
   for (const auto& testCase : testCases) {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    IntegerDictionaryEncoder<int64_t> intDictEncoder{pool, pool};
+    auto pool = getDefaultMemoryPool();
+    IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     std::vector<size_t> actualEncodedSequence{};
     for (const auto& key : testCase.addKeySequence) {
       actualEncodedSequence.push_back(intDictEncoder.addKey(key));
@@ -75,9 +74,8 @@ TEST(TestIntegerDictionaryEncoder, GetCount) {
           {3, 2, 3, 3, 2}}};
 
   for (const auto& testCase : testCases) {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    IntegerDictionaryEncoder<int64_t> intDictEncoder{pool, pool};
+    auto pool = getDefaultMemoryPool();
+    IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
     }
@@ -108,9 +106,8 @@ TEST(TestIntegerDictionaryEncoder, GetTotalCount) {
       TestCase{{-2, 1, 2, 0, -1, 1, 0, 2, 0, -2, -1, -2, 1}, 13}};
 
   for (const auto& testCase : testCases) {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    IntegerDictionaryEncoder<int64_t> intDictEncoder{pool, pool};
+    auto pool = getDefaultMemoryPool();
+    IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
     }
@@ -120,10 +117,9 @@ TEST(TestIntegerDictionaryEncoder, GetTotalCount) {
 }
 
 TEST(TestIntegerDictionaryEncoder, Clear) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = getDefaultMemoryPool();
   {
-    IntegerDictionaryEncoder<int64_t> intDictEncoder{pool, pool};
+    IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     EXPECT_EQ(1, intDictEncoder.refCount_);
     EXPECT_EQ(0, intDictEncoder.clearCount_);
     for (size_t i = 0; i != 2500; ++i) {
@@ -155,7 +151,7 @@ TEST(TestIntegerDictionaryEncoder, Clear) {
     // EXPECT_LT(pool.getCurrentBytes(), peakMemory);
   }
   {
-    IntegerDictionaryEncoder<int64_t> intDictEncoder{pool, pool};
+    IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     intDictEncoder.bumpRefCount();
     intDictEncoder.bumpRefCount();
     intDictEncoder.bumpRefCount();
@@ -204,9 +200,8 @@ TEST(TestIntegerDictionaryEncoder, Clear) {
 }
 
 TEST(TestIntegerDictionaryEncoder, RepeatedFlush) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  IntegerDictionaryEncoder<int64_t> intDictEncoder{pool, pool};
+  auto pool = getDefaultMemoryPool();
+  IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
   std::vector<int> keys{0, 1, 4, 9, 16, 25, 9, 1};
   for (const auto& key : keys) {
     intDictEncoder.addKey(key);
@@ -231,9 +226,8 @@ TEST(TestIntegerDictionaryEncoder, RepeatedFlush) {
 }
 
 TEST(TestIntegerDictionaryEncoder, Limit) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  IntegerDictionaryEncoder<int16_t> intDictEncoder{pool, pool};
+  auto pool = getDefaultMemoryPool();
+  IntegerDictionaryEncoder<int16_t> intDictEncoder{*pool, *pool};
   for (size_t iter = 0; iter < 2; ++iter) {
     int16_t val = std::numeric_limits<int16_t>::min();
     uint16_t offset = 0;
@@ -269,21 +263,20 @@ void testGetSortedIndexLookupTable() {
       TestCase{{-1, 0, -2, 2, 1}, false, {0, 1, 2, 3, 4}}};
 
   for (const auto& testCase : testCases) {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    IntegerDictionaryEncoder<T> intDictEncoder{pool, pool};
+    auto pool = getDefaultMemoryPool();
+    IntegerDictionaryEncoder<T> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
     }
 
-    dwio::common::DataBuffer<bool> inDict{pool};
-    dwio::common::DataBuffer<T> lookupTable{pool};
-    dwio::common::DataBuffer<char> writeBuffer{pool, 1024};
+    dwio::common::DataBuffer<bool> inDict{*pool};
+    dwio::common::DataBuffer<T> lookupTable{*pool};
+    dwio::common::DataBuffer<char> writeBuffer{*pool, 1024};
     EXPECT_EQ(
         intDictEncoder.size(),
         IntegerDictionaryEncoder<T>::template getSortedIndexLookupTable<T>(
             intDictEncoder,
-            pool,
+            *pool,
             false,
             testCase.sort,
             lookupTable,
@@ -337,12 +330,11 @@ TEST(TestIntegerDictionaryEncoder, ShortIntegerDictionary) {
     values.emplace_back(static_cast<int16_t>(i));
   }
 
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  IntegerDictionaryEncoder<int16_t> intDictEncoder{pool, pool};
-  dwio::common::DataBuffer<bool> inDict{pool};
-  dwio::common::DataBuffer<int16_t> lookupTable{pool};
-  dwio::common::DataBuffer<char> writeBuffer{pool, 1024};
+  auto pool = getDefaultMemoryPool();
+  IntegerDictionaryEncoder<int16_t> intDictEncoder{*pool, *pool};
+  dwio::common::DataBuffer<bool> inDict{*pool};
+  dwio::common::DataBuffer<int16_t> lookupTable{*pool};
+  dwio::common::DataBuffer<char> writeBuffer{*pool, 1024};
   for (const auto& key : values) {
     intDictEncoder.addKey(key);
   }
@@ -354,7 +346,7 @@ TEST(TestIntegerDictionaryEncoder, ShortIntegerDictionary) {
       IntegerDictionaryEncoder<int16_t>::template getSortedIndexLookupTable<
           int16_t>(
           intDictEncoder,
-          pool,
+          *pool,
           /* dropInFrequentKeys */ true,
           /* sort */ true,
           lookupTable,
@@ -451,21 +443,20 @@ void testInfrequentKeyOptimization() {
           24}};
 
   for (const auto& testCase : testCases) {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    IntegerDictionaryEncoder<T> intDictEncoder{pool, pool};
+    auto pool = getDefaultMemoryPool();
+    IntegerDictionaryEncoder<T> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
     }
 
-    dwio::common::DataBuffer<bool> inDict{pool};
-    dwio::common::DataBuffer<T> lookupTable{pool};
-    dwio::common::DataBuffer<char> writeBuffer{pool, 1024};
+    dwio::common::DataBuffer<bool> inDict{*pool};
+    dwio::common::DataBuffer<T> lookupTable{*pool};
+    dwio::common::DataBuffer<char> writeBuffer{*pool, 1024};
     EXPECT_EQ(
         testCase.finalDictSize,
         IntegerDictionaryEncoder<T>::template getSortedIndexLookupTable<T>(
             intDictEncoder,
-            pool,
+            *pool,
             true,
             testCase.sort,
             lookupTable,

--- a/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
+++ b/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
@@ -89,12 +89,11 @@ void decodeAndVerify(
 class RleEncoderV1Test : public testing::Test {};
 
 TEST(RleEncoderV1Test, encodeMinAndMax) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<false> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -111,12 +110,11 @@ TEST(RleEncoderV1Test, encodeMinAndMax) {
 }
 
 TEST(RleEncoderV1Test, encodeMinAndMaxint32) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -134,12 +132,11 @@ TEST(RleEncoderV1Test, encodeMinAndMaxint32) {
 }
 
 TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsigned) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<false> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -154,12 +151,11 @@ TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsigned) {
 }
 
 TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsignedNull) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<false> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -176,12 +172,11 @@ TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsignedNull) {
 }
 
 TEST(RleEncoderV1Test, deltaDecreasingSequanceUnsigned) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<false> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -196,12 +191,11 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceUnsigned) {
 }
 
 TEST(RleEncoderV1Test, deltaDecreasingSequanceSigned) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -216,12 +210,11 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceSigned) {
 }
 
 TEST(RleEncoderV1Test, deltaDecreasingSequanceSignedNull) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -238,12 +231,11 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceSignedNull) {
 }
 
 TEST(RleEncoderV1Test, randomSequanceSigned) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -258,12 +250,11 @@ TEST(RleEncoderV1Test, randomSequanceSigned) {
 }
 
 TEST(RleEncoderV1Test, allNull) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -280,12 +271,11 @@ TEST(RleEncoderV1Test, allNull) {
 }
 
 TEST(RleEncoderV1Test, recordPosition) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -303,12 +293,11 @@ TEST(RleEncoderV1Test, recordPosition) {
 }
 
 TEST(RleEncoderV1Test, backfillPosition) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
-  MemorySink memSink(pool, DEFAULT_MEM_STREAM_SIZE);
+  auto pool = memory::getDefaultMemoryPool();
+  MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
-  DataBufferHolder holder{pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);

--- a/velox/dwio/dwrf/test/TestRle.cpp
+++ b/velox/dwio/dwrf/test/TestRle.cpp
@@ -31,11 +31,11 @@ std::vector<int64_t> decodeRLEv2(
     size_t n,
     size_t count,
     const uint64_t* nulls = nullptr) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::make_unique<dwio::common::SeekableArrayInputStream>(bytes, l),
       RleVersion_2,
-      *scopedPool,
+      *pool,
       true /* doesn't matter */,
       dwio::common::INT_BYTE_SIZE /* doesn't matter */);
   std::vector<int64_t> results;
@@ -174,7 +174,7 @@ TEST(RLEv2, basicDelta4) {
 };
 
 TEST(RLEv2, delta0Width) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   const unsigned char buffer[] = {
       0x4e, 0x2, 0x0, 0x1, 0x2, 0xc0, 0x2, 0x42, 0x0};
   std::unique_ptr<dwio::common::IntDecoder<false>> decoder =
@@ -183,7 +183,7 @@ TEST(RLEv2, delta0Width) {
               new dwio::common::SeekableArrayInputStream(
                   buffer, VELOX_ARRAY_SIZE(buffer))),
           RleVersion_2,
-          *scopedPool,
+          *pool,
           true /* doesn't matter */,
           dwio::common::INT_BYTE_SIZE /* doesn't matter */);
   int64_t values[6];
@@ -268,14 +268,14 @@ TEST(RLEv2, multiByteShortRepeats) {
 };
 
 TEST(RLEv2, 0to2Repeat1Direct) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   const unsigned char buffer[] = {0x46, 0x02, 0x02, 0x40};
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(
           new dwio::common::SeekableArrayInputStream(
               buffer, VELOX_ARRAY_SIZE(buffer))),
       RleVersion_2,
-      *scopedPool,
+      *pool,
       true /* doesn't matter */,
       dwio::common::INT_BYTE_SIZE /* doesn't matter */);
   std::vector<int64_t> data(3);
@@ -366,7 +366,7 @@ TEST(RLEv2, multipleRunsDirect) {
 };
 
 TEST(RLEv2, largeNegativesDirect) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   const unsigned char buffer[] = {
       0x7e, 0x04, 0xcf, 0xca, 0xcc, 0x91, 0xba, 0x38, 0x93, 0xab, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -377,7 +377,7 @@ TEST(RLEv2, largeNegativesDirect) {
           new dwio::common::SeekableArrayInputStream(
               buffer, VELOX_ARRAY_SIZE(buffer))),
       RleVersion_2,
-      *scopedPool,
+      *pool,
       true /* doesn't matter */,
       dwio::common::INT_BYTE_SIZE /* doesn't matter */);
   std::vector<int64_t> data(5);
@@ -549,7 +549,7 @@ TEST(RLEv2, mixedPatchedAndShortRepeats) {
 };
 
 TEST(RLEv2, basicDirectSeek) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   // 0,1 repeated 10 times (signed ints) followed by
   // 0,2 repeated 10 times (signed ints)
   const unsigned char bytes[] = {
@@ -578,7 +578,7 @@ TEST(RLEv2, basicDirectSeek) {
       std::unique_ptr<dwio::common::SeekableInputStream>(
           new dwio::common::SeekableArrayInputStream(bytes, l)),
       RleVersion_2,
-      *scopedPool,
+      *pool,
       true /* doesn't matter */,
       dwio::common::INT_BYTE_SIZE /* doesn't matter */);
   std::vector<uint64_t> position;
@@ -601,7 +601,7 @@ TEST(RLEv2, basicDirectSeek) {
 };
 
 TEST(RLEv2, bitsLeftByPreviousStream) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   // test for #109
   // 118 DIRECT values, followed by PATHCED values
   const unsigned char bytes[] = {
@@ -654,7 +654,7 @@ TEST(RLEv2, bitsLeftByPreviousStream) {
       std::unique_ptr<dwio::common::SeekableInputStream>(
           new dwio::common::SeekableArrayInputStream(bytes, l)),
       RleVersion_2,
-      *scopedPool,
+      *pool,
       true /* doesn't matter */,
       dwio::common::INT_BYTE_SIZE /* doesn't matter */);
 
@@ -667,7 +667,7 @@ TEST(RLEv2, bitsLeftByPreviousStream) {
 };
 
 TEST(RLEv1, simpleTest) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   const unsigned char buffer[] = {
       0x61, 0xff, 0x64, 0xfb, 0x02, 0x03, 0x5, 0x7, 0xb};
   std::unique_ptr<dwio::common::IntDecoder<false>> rle =
@@ -676,7 +676,7 @@ TEST(RLEv1, simpleTest) {
               new dwio::common::SeekableArrayInputStream(
                   buffer, VELOX_ARRAY_SIZE(buffer))),
           RleVersion_1,
-          *scopedPool,
+          *pool,
           true,
           dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(105);
@@ -693,14 +693,14 @@ TEST(RLEv1, simpleTest) {
 };
 
 TEST(RLEv1, signedNullLiteralTest) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   const unsigned char buffer[] = {0xf8, 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7};
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(
           new dwio::common::SeekableArrayInputStream(
               buffer, VELOX_ARRAY_SIZE(buffer))),
       RleVersion_1,
-      *scopedPool,
+      *pool,
       true,
       dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(8);
@@ -713,7 +713,7 @@ TEST(RLEv1, signedNullLiteralTest) {
 }
 
 TEST(RLEv1, splitHeader) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   const unsigned char buffer[] = {0x0, 0x00, 0xdc, 0xba, 0x98, 0x76};
   std::unique_ptr<dwio::common::IntDecoder<false>> rle =
       createRleDecoder<false>(
@@ -721,7 +721,7 @@ TEST(RLEv1, splitHeader) {
               new dwio::common::SeekableArrayInputStream(
                   buffer, VELOX_ARRAY_SIZE(buffer), 4)),
           RleVersion_1,
-          *scopedPool,
+          *pool,
           true,
           dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(200);
@@ -733,7 +733,7 @@ TEST(RLEv1, splitHeader) {
 }
 
 TEST(RLEv1, splitRuns) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   const unsigned char buffer[] = {
       0x7d, 0x01, 0xff, 0x01, 0xfb, 0x01, 0x02, 0x03, 0x04, 0x05};
   dwio::common::SeekableInputStream* const stream =
@@ -743,7 +743,7 @@ TEST(RLEv1, splitRuns) {
       createRleDecoder<false>(
           std::unique_ptr<dwio::common::SeekableInputStream>(stream),
           RleVersion_1,
-          *scopedPool,
+          *pool,
           true,
           dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(200);
@@ -767,7 +767,7 @@ TEST(RLEv1, splitRuns) {
 }
 
 TEST(RLEv1, testSigned) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   const unsigned char buffer[] = {0x7f, 0xff, 0x20};
   dwio::common::SeekableInputStream* const stream =
       new dwio::common::SeekableArrayInputStream(
@@ -775,7 +775,7 @@ TEST(RLEv1, testSigned) {
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(stream),
       RleVersion_1,
-      *scopedPool,
+      *pool,
       true,
       dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(100);
@@ -791,7 +791,7 @@ TEST(RLEv1, testSigned) {
 }
 
 TEST(RLEv1, testNull) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   const unsigned char buffer[] = {0x75, 0x02, 0x00};
   dwio::common::SeekableInputStream* const stream =
       new dwio::common::SeekableArrayInputStream(
@@ -799,7 +799,7 @@ TEST(RLEv1, testNull) {
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(stream),
       RleVersion_1,
-      *scopedPool,
+      *pool,
       true,
       dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(24);
@@ -823,7 +823,7 @@ TEST(RLEv1, testNull) {
 }
 
 TEST(RLEv1, testAllNulls) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   const unsigned char buffer[] = {0xf0, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
                                   0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
                                   0x0d, 0x0e, 0x0f, 0x3d, 0x00, 0x12};
@@ -834,7 +834,7 @@ TEST(RLEv1, testAllNulls) {
       createRleDecoder<false>(
           std::unique_ptr<dwio::common::SeekableInputStream>(stream),
           RleVersion_1,
-          *scopedPool,
+          *pool,
           true,
           dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(16, -1);
@@ -863,7 +863,7 @@ TEST(RLEv1, testAllNulls) {
 }
 
 TEST(RLEv1, skipTest) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   // Create the RLE stream from Java's TestRunLengthIntegerEncoding.testSkips
   // for (size_t i = 0; i < 1024; ++i)
   //   out.write(i);
@@ -1086,7 +1086,7 @@ TEST(RLEv1, skipTest) {
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(stream),
       RleVersion_1,
-      *scopedPool,
+      *pool,
       true,
       dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(1);
@@ -1105,7 +1105,7 @@ TEST(RLEv1, skipTest) {
 }
 
 TEST(RLEv1, seekTest) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   // Create the RLE stream from Java's
   // TestRunLengthIntegerEncoding.testUncompressedSeek
   // for (size_t i = 0; i < 1024; ++i)
@@ -2966,7 +2966,7 @@ TEST(RLEv1, seekTest) {
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(stream),
       RleVersion_1,
-      *scopedPool,
+      *pool,
       true,
       dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(2048);
@@ -3015,7 +3015,7 @@ TEST(RLEv1, seekTest) {
 }
 
 TEST(RLEv1, testLeadingNulls) {
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   const unsigned char buffer[] = {0xfb, 0x01, 0x02, 0x03, 0x04, 0x05};
   std::unique_ptr<dwio::common::IntDecoder<false>> rle =
       createRleDecoder<false>(
@@ -3023,7 +3023,7 @@ TEST(RLEv1, testLeadingNulls) {
               new dwio::common::SeekableArrayInputStream(
                   buffer, VELOX_ARRAY_SIZE(buffer))),
           RleVersion_1,
-          *scopedPool,
+          *pool,
           true,
           dwio::common::INT_BYTE_SIZE);
   std::vector<int64_t> data(10);

--- a/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
+++ b/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
@@ -60,17 +60,16 @@ TEST(TestStatisticsBuilderUtils, addIntegerValues) {
   IntegerStatisticsBuilder builder{options};
 
   // add values non null
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = memory::getDefaultMemoryPool();
   size_t size = 10;
 
-  auto values = AlignedBuffer::allocate<int32_t>(size, &pool);
+  auto values = AlignedBuffer::allocate<int32_t>(size, pool.get());
   auto* valuesPtr = values->asMutable<int32_t>();
   for (size_t i = 0; i < size; ++i) {
     valuesPtr[i] = i + 1;
   }
 
-  auto vec = makeFlatVectorNoNulls<int32_t>(&pool, size, values);
+  auto vec = makeFlatVectorNoNulls<int32_t>(pool.get(), size, values);
   {
     StatisticsBuilderUtils::addValues<int32_t>(
         builder, vec, common::Ranges::of(0, size));
@@ -84,10 +83,10 @@ TEST(TestStatisticsBuilderUtils, addIntegerValues) {
   }
 
   // add values with null
-  auto nulls = allocateNulls(size, &pool);
+  auto nulls = allocateNulls(size, pool.get());
   bits::setNull(nulls->asMutable<uint64_t>(), 3);
 
-  vec = makeFlatVector<int32_t>(&pool, nulls, 1, size, values);
+  vec = makeFlatVector<int32_t>(pool.get(), nulls, 1, size, values);
 
   {
     StatisticsBuilderUtils::addValues<int32_t>(
@@ -106,18 +105,17 @@ TEST(TestStatisticsBuilderUtils, addDoubleValues) {
   DoubleStatisticsBuilder builder{options};
 
   // add values non null
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = memory::getDefaultMemoryPool();
   size_t size = 10;
 
-  auto values = AlignedBuffer::allocate<float>(size, &pool);
+  auto values = AlignedBuffer::allocate<float>(size, pool.get());
   auto* valuesPtr = values->asMutable<float>();
   for (size_t i = 0; i < size; ++i) {
     valuesPtr[i] = i + 1;
   }
 
   {
-    auto vec = makeFlatVectorNoNulls<float>(&pool, size, values);
+    auto vec = makeFlatVectorNoNulls<float>(pool.get(), size, values);
     StatisticsBuilderUtils::addValues<float>(
         builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
@@ -130,11 +128,11 @@ TEST(TestStatisticsBuilderUtils, addDoubleValues) {
   }
 
   // add values with null
-  auto nulls = allocateNulls(size, &pool);
+  auto nulls = allocateNulls(size, pool.get());
   bits::setNull(nulls->asMutable<uint64_t>(), 3);
 
   {
-    auto vec = makeFlatVector<float>(&pool, nulls, 1, size, values);
+    auto vec = makeFlatVector<float>(pool.get(), nulls, 1, size, values);
 
     StatisticsBuilderUtils::addValues<float>(
         builder, vec, common::Ranges::of(0, size));
@@ -152,18 +150,17 @@ TEST(TestStatisticsBuilderUtils, addStringValues) {
   StringStatisticsBuilder builder{options};
 
   // add values non null
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = memory::getDefaultMemoryPool();
   size_t size = 10;
 
-  auto values = AlignedBuffer::allocate<StringView>(10, &pool);
+  auto values = AlignedBuffer::allocate<StringView>(10, pool.get());
   auto* valuesPtr = values->asMutable<StringView>();
   for (size_t i = 0; i < size; ++i) {
     valuesPtr[i] = StringView(std::string(1, 'a' + i));
   }
 
   {
-    auto vec = makeFlatVectorNoNulls<StringView>(&pool, size, values);
+    auto vec = makeFlatVectorNoNulls<StringView>(pool.get(), size, values);
     StatisticsBuilderUtils::addValues(
         builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
@@ -176,11 +173,11 @@ TEST(TestStatisticsBuilderUtils, addStringValues) {
   }
 
   // add values with null
-  auto nulls = allocateNulls(size, &pool);
+  auto nulls = allocateNulls(size, pool.get());
   bits::setNull(nulls->asMutable<uint64_t>(), 3);
 
   {
-    auto vec = makeFlatVector<StringView>(&pool, nulls, 1, size, values);
+    auto vec = makeFlatVector<StringView>(pool.get(), nulls, 1, size, values);
     StatisticsBuilderUtils::addValues(
         builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
@@ -197,11 +194,10 @@ TEST(TestStatisticsBuilderUtils, addBooleanValues) {
   BooleanStatisticsBuilder builder{options};
 
   // add values non null
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = memory::getDefaultMemoryPool();
   size_t size = 10;
 
-  auto values = AlignedBuffer::allocate<bool>(size, &pool);
+  auto values = AlignedBuffer::allocate<bool>(size, pool.get());
   auto valuesPtr = values->asMutableRange<bool>();
   for (int32_t i = 0; i < size; ++i) {
     valuesPtr[i] = true;
@@ -209,7 +205,7 @@ TEST(TestStatisticsBuilderUtils, addBooleanValues) {
   valuesPtr[6] = false;
 
   {
-    auto vec = makeFlatVectorNoNulls<bool>(&pool, size, values);
+    auto vec = makeFlatVectorNoNulls<bool>(pool.get(), size, values);
 
     StatisticsBuilderUtils::addValues(
         builder, vec, common::Ranges::of(0, size));
@@ -221,11 +217,11 @@ TEST(TestStatisticsBuilderUtils, addBooleanValues) {
   }
 
   // add values with null
-  auto nulls = allocateNulls(size, &pool);
+  auto nulls = allocateNulls(size, pool.get());
   bits::setNull(nulls->asMutable<uint64_t>(), 3);
 
   {
-    auto vec = makeFlatVector<bool>(&pool, nulls, 1, size, values);
+    auto vec = makeFlatVector<bool>(pool.get(), nulls, 1, size, values);
 
     StatisticsBuilderUtils::addValues(
         builder, vec, common::Ranges::of(0, size));
@@ -241,14 +237,13 @@ TEST(TestStatisticsBuilderUtils, addValues) {
   StatisticsBuilder builder{options};
 
   // add values non null
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = memory::getDefaultMemoryPool();
   size_t size = 10;
 
-  auto values = AlignedBuffer::allocate<bool>(size, &pool);
+  auto values = AlignedBuffer::allocate<bool>(size, pool.get());
 
   {
-    auto vec = makeFlatVectorNoNulls<bool>(&pool, size, values);
+    auto vec = makeFlatVectorNoNulls<bool>(pool.get(), size, values);
 
     StatisticsBuilderUtils::addValues(
         builder, vec, common::Ranges::of(0, size));
@@ -258,11 +253,11 @@ TEST(TestStatisticsBuilderUtils, addValues) {
   }
 
   // add values with null
-  auto nulls = allocateNulls(size, &pool);
+  auto nulls = allocateNulls(size, pool.get());
   bits::setNull(nulls->asMutable<uint64_t>(), 3);
 
   {
-    auto vec = makeFlatVector<bool>(&pool, nulls, 1, size, values);
+    auto vec = makeFlatVector<bool>(pool.get(), nulls, 1, size, values);
 
     StatisticsBuilderUtils::addValues(
         builder, vec, common::Ranges::of(0, size));
@@ -276,11 +271,10 @@ TEST(TestStatisticsBuilderUtils, addBinaryValues) {
   BinaryStatisticsBuilder builder{options};
 
   // add values non null
-  auto scopedPool = memory::getDefaultScopedMemoryPool();
-  auto& pool = *scopedPool;
+  auto pool = memory::getDefaultMemoryPool();
   size_t size = 10;
 
-  auto values = AlignedBuffer::allocate<StringView>(size, &pool);
+  auto values = AlignedBuffer::allocate<StringView>(size, pool.get());
   auto* valuesPtr = values->asMutable<StringView>();
 
   std::array<char, 10> data;
@@ -292,7 +286,7 @@ TEST(TestStatisticsBuilderUtils, addBinaryValues) {
   }
 
   {
-    auto vec = makeFlatVectorNoNulls<StringView>(&pool, size, values);
+    auto vec = makeFlatVectorNoNulls<StringView>(pool.get(), size, values);
 
     StatisticsBuilderUtils::addValues(
         builder, vec, common::Ranges::of(0, size));
@@ -304,11 +298,11 @@ TEST(TestStatisticsBuilderUtils, addBinaryValues) {
   }
 
   // add values with null
-  auto nulls = allocateNulls(size, &pool);
+  auto nulls = allocateNulls(size, pool.get());
   bits::setNull(nulls->asMutable<uint64_t>(), 3);
 
   {
-    auto vec = makeFlatVector<StringView>(&pool, nulls, 1, size, values);
+    auto vec = makeFlatVector<StringView>(pool.get(), nulls, 1, size, values);
 
     StatisticsBuilderUtils::addValues(
         builder, vec, common::Ranges::of(0, size));

--- a/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
@@ -40,9 +40,8 @@ TEST(TestStringDictionaryEncoder, AddKey) {
       TestCase{{"doe", "sow", "sow", "doe", "sow"}, {0, 1, 1, 0, 1}}};
 
   for (const auto& testCase : testCases) {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    StringDictionaryEncoder stringDictEncoder{pool, pool};
+    auto pool = getDefaultMemoryPool();
+    StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     std::vector<size_t> actualEncodedSequence{};
     for (const auto& key : testCase.addKeySequence) {
       actualEncodedSequence.push_back(stringDictEncoder.addKey(key, 0));
@@ -85,9 +84,8 @@ TEST(TestStringDictionaryEncoder, GetIndex) {
           {0, 3, 4, 2, 1, 3, 2, 4, 2, 0, 1, 0, 3}}};
 
   for (const auto& testCase : testCases) {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    StringDictionaryEncoder stringDictEncoder{pool, pool};
+    auto pool = getDefaultMemoryPool();
+    StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
     }
@@ -135,9 +133,8 @@ TEST(TestStringDictionaryEncoder, GetCount) {
           {3, 2, 3, 3, 2}}};
 
   for (const auto& testCase : testCases) {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    StringDictionaryEncoder stringDictEncoder{pool, pool};
+    auto pool = getDefaultMemoryPool();
+    StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
     }
@@ -190,9 +187,8 @@ TEST(TestStringDictionaryEncoder, GetStride) {
           {1, 1, 6, 3, 4}}};
 
   for (const auto& testCase : testCases) {
-    auto scopedPool = getDefaultScopedMemoryPool();
-    auto& pool = scopedPool->getPool();
-    StringDictionaryEncoder stringDictEncoder{pool, pool};
+    auto pool = getDefaultMemoryPool();
+    StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& kv : testCase.addKeySequence) {
       stringDictEncoder.addKey(kv.first, kv.second);
     }
@@ -214,14 +210,13 @@ std::string genPaddedIntegerString(size_t integer, size_t length) {
 }
 
 TEST(TestStringDictionaryEncoder, Clear) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  StringDictionaryEncoder stringDictEncoder{pool, pool};
+  auto pool = getDefaultMemoryPool();
+  StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
   for (size_t i = 0; i != 2500; ++i) {
     stringDictEncoder.addKey(baseString + genPaddedIntegerString(i, 4), 0);
   }
-  auto peakMemory = pool.getCurrentBytes();
+  auto peakMemory = pool->getCurrentBytes();
   stringDictEncoder.clear();
   EXPECT_EQ(0, stringDictEncoder.size());
   EXPECT_EQ(0, stringDictEncoder.keyIndex_.size());
@@ -233,27 +228,25 @@ TEST(TestStringDictionaryEncoder, Clear) {
   EXPECT_EQ(0, stringDictEncoder.counts_.capacity());
   EXPECT_EQ(0, stringDictEncoder.firstSeenStrideIndex_.size());
   EXPECT_EQ(0, stringDictEncoder.firstSeenStrideIndex_.capacity());
-  EXPECT_LT(pool.getCurrentBytes(), peakMemory);
+  EXPECT_LT(pool->getCurrentBytes(), peakMemory);
 }
 
 TEST(TestStringDictionaryEncoder, MemBenchmark) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  StringDictionaryEncoder stringDictEncoder{pool, pool};
+  auto pool = getDefaultMemoryPool();
+  StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
   for (size_t i = 0; i != 10000; ++i) {
     stringDictEncoder.addKey(baseString + genPaddedIntegerString(i, 4), 0);
   }
 
-  LOG(INFO) << "Total memory bytes: " << pool.getCurrentBytes();
+  LOG(INFO) << "Total memory bytes: " << pool->getCurrentBytes();
 }
 
 TEST(TestStringDictionaryEncoder, Limit) {
-  auto scopedPool = getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
-  StringDictionaryEncoder encoder{pool, pool};
+  auto pool = getDefaultMemoryPool();
+  StringDictionaryEncoder encoder{*pool, *pool};
   encoder.addKey(folly::StringPiece{"abc"}, 0);
-  dwio::common::DataBuffer<char> buf{pool};
+  dwio::common::DataBuffer<char> buf{*pool};
   buf.resize(std::numeric_limits<uint32_t>::max());
 
   ASSERT_THROW(

--- a/velox/dwio/dwrf/test/TestWriterContext.cpp
+++ b/velox/dwio/dwrf/test/TestWriterContext.cpp
@@ -23,57 +23,57 @@ using namespace ::testing;
 namespace facebook::velox::dwrf {
 TEST(TestWriterContext, GetIntDictionaryEncoder) {
   auto config = std::make_shared<Config>();
-  WriterContext context{config, memory::getDefaultScopedMemoryPool()};
+  WriterContext context{config, memory::getDefaultMemoryPool()};
 
   EXPECT_EQ(0, context.dictEncoders_.size());
   auto& intEncoder_1_0 = context.getIntDictionaryEncoder<int32_t>(
-      {1, 0}, context.dictionaryPool_, context.generalPool_);
+      {1, 0}, *context.dictionaryPool_, *context.generalPool_);
   EXPECT_EQ(1, context.dictEncoders_.size());
   ASSERT_EQ(1, intEncoder_1_0.refCount_);
 
   auto& duplicateCallResult_1_0 = context.getIntDictionaryEncoder<int32_t>(
-      {1, 0}, context.dictionaryPool_, context.generalPool_);
+      {1, 0}, *context.dictionaryPool_, *context.generalPool_);
   EXPECT_EQ(1, context.dictEncoders_.size());
   EXPECT_EQ(&intEncoder_1_0, &duplicateCallResult_1_0);
   EXPECT_EQ(2, intEncoder_1_0.refCount_);
 
   for (size_t i = 0; i < 40; ++i) {
     context.getIntDictionaryEncoder<int32_t>(
-        {1, 0}, context.dictionaryPool_, context.generalPool_);
+        {1, 0}, *context.dictionaryPool_, *context.generalPool_);
   }
   EXPECT_EQ(42, intEncoder_1_0.refCount_);
 
   // Ignore the mismatched type request.
   context.getIntDictionaryEncoder<int64_t>(
-      {1, 0}, context.dictionaryPool_, context.generalPool_);
+      {1, 0}, *context.dictionaryPool_, *context.generalPool_);
   EXPECT_EQ(1, context.dictEncoders_.size());
 
   context.getIntDictionaryEncoder<int32_t>(
-      {2, 0}, context.dictionaryPool_, context.generalPool_);
+      {2, 0}, *context.dictionaryPool_, *context.generalPool_);
   EXPECT_EQ(2, context.dictEncoders_.size());
 }
 
 TEST(TestWriterContext, RemoveIntDictionaryEncoderForNode) {
   auto config = std::make_shared<Config>();
   config->set(Config::MAP_FLAT_DICT_SHARE, false);
-  WriterContext context{config, memory::getDefaultScopedMemoryPool()};
+  WriterContext context{config, memory::getDefaultMemoryPool()};
 
   context.getIntDictionaryEncoder<int32_t>(
-      {1, 1}, context.dictionaryPool_, context.generalPool_);
+      {1, 1}, *context.dictionaryPool_, *context.generalPool_);
   context.getIntDictionaryEncoder<int32_t>(
-      {1, 2}, context.dictionaryPool_, context.generalPool_);
+      {1, 2}, *context.dictionaryPool_, *context.generalPool_);
   context.getIntDictionaryEncoder<int32_t>(
-      {1, 4}, context.dictionaryPool_, context.generalPool_);
+      {1, 4}, *context.dictionaryPool_, *context.generalPool_);
   context.getIntDictionaryEncoder<int32_t>(
-      {1, 5}, context.dictionaryPool_, context.generalPool_);
+      {1, 5}, *context.dictionaryPool_, *context.generalPool_);
   EXPECT_EQ(4, context.dictEncoders_.size());
 
   context.getIntDictionaryEncoder<int32_t>(
-      {2, 0}, context.dictionaryPool_, context.generalPool_);
+      {2, 0}, *context.dictionaryPool_, *context.generalPool_);
   context.getIntDictionaryEncoder<int32_t>(
-      {3, 1}, context.dictionaryPool_, context.generalPool_);
+      {3, 1}, *context.dictionaryPool_, *context.generalPool_);
   context.getIntDictionaryEncoder<int32_t>(
-      {3, 3}, context.dictionaryPool_, context.generalPool_);
+      {3, 3}, *context.dictionaryPool_, *context.generalPool_);
   EXPECT_EQ(7, context.dictEncoders_.size());
 
   context.removeAllIntDictionaryEncodersOnNode(

--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -61,6 +61,17 @@ struct FlushPolicyTestCase {
   const uint32_t numStripesUpper;
   const uint32_t seed;
   const int64_t memoryBudget;
+
+  std::string debugString() const {
+    return fmt::format(
+        "inputStripeSize {}, dictSize {}, inputNumStripesLower {}, inputNumStripesUpper {}, seed {}, memoryBudget {}",
+        stripeSize,
+        dictSize,
+        numStripesLower,
+        numStripesUpper,
+        seed,
+        memoryBudget);
+  }
 };
 
 struct FlatMapFlushPolicyTestCase : public FlushPolicyTestCase {
@@ -133,8 +144,7 @@ void testWriterStaticBudgetFlushPolicy(
 TEST(E2EWriterTests, FlushPolicySimpleEncoding) {
   const size_t batchCount = 200;
   const size_t size = 1000;
-  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -171,9 +181,9 @@ TEST(E2EWriterTests, FlushPolicySimpleEncoding) {
     config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
     config->set(Config::STRIPE_SIZE, testCase.stripeSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, pool);
+        type, batchCount, size, testCase.seed, *pool);
     testWriterDefaultFlushPolicy(
-        pool,
+        *pool,
         type,
         batches,
         testCase.numStripesLower,
@@ -188,8 +198,7 @@ TEST(E2EWriterTests, FlushPolicySimpleEncoding) {
 TEST(E2EWriterTests, FlushPolicyDictionaryEncoding) {
   const size_t batchCount = 500;
   const size_t size = 1000;
-  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -234,9 +243,9 @@ TEST(E2EWriterTests, FlushPolicyDictionaryEncoding) {
     config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
     config->set(Config::STRIPE_SIZE, testCase.stripeSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, pool);
+        type, batchCount, size, testCase.seed, *pool);
     testWriterDefaultFlushPolicy(
-        pool,
+        *pool,
         type,
         batches,
         testCase.numStripesLower,
@@ -281,9 +290,9 @@ TEST(E2EWriterTests, FlushPolicyDictionaryEncoding) {
     config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
     config->set(Config::STRIPE_SIZE, testCase.stripeSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, pool);
+        type, batchCount, size, testCase.seed, *pool);
     testWriterDefaultFlushPolicy(
-        pool,
+        *pool,
         type,
         batches,
         testCase.numStripesLower,
@@ -315,9 +324,9 @@ TEST(E2EWriterTests, FlushPolicyDictionaryEncoding) {
 
     config->set(Config::MAX_DICTIONARY_SIZE, testCase.dictSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, pool);
+        type, batchCount, size, testCase.seed, *pool);
     testWriterDefaultFlushPolicy(
-        pool,
+        *pool,
         type,
         batches,
         testCase.numStripesLower,
@@ -331,8 +340,7 @@ TEST(E2EWriterTests, FlushPolicyDictionaryEncoding) {
 TEST(E2EWriterTests, FlushPolicyNestedTypes) {
   const size_t batchCount = 10;
   const size_t size = 1000;
-  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -377,9 +385,9 @@ TEST(E2EWriterTests, FlushPolicyNestedTypes) {
     config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
     config->set(Config::STRIPE_SIZE, testCase.stripeSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, pool);
+        type, batchCount, size, testCase.seed, *pool);
     testWriterDefaultFlushPolicy(
-        pool,
+        *pool,
         type,
         batches,
         testCase.numStripesLower,
@@ -393,8 +401,7 @@ TEST(E2EWriterTests, FlushPolicyNestedTypes) {
 TEST(E2EWriterTests, FlushPolicyWithStaticMemoryBudget) {
   const size_t batchCount = 2000;
   const size_t size = 1000;
-  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
 
   HiveTypeParser parser;
   // Dictionary encodable types have the richest feature to test.
@@ -469,9 +476,9 @@ TEST(E2EWriterTests, FlushPolicyWithStaticMemoryBudget) {
     config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
     config->set(Config::STRIPE_SIZE, testCase.stripeSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, pool);
+        type, batchCount, size, testCase.seed, *pool);
     testWriterStaticBudgetFlushPolicy(
-        pool,
+        *pool,
         type,
         batches,
         testCase.numStripesLower,
@@ -484,8 +491,7 @@ TEST(E2EWriterTests, FlushPolicyWithStaticMemoryBudget) {
 TEST(E2EWriterTests, FlushPolicyDictionaryEncodingWithStaticMemoryBudget) {
   const size_t batchCount = 500;
   const size_t size = 1000;
-  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
 
   HiveTypeParser parser;
   // Dictionary encodable types have the richest feature to test.
@@ -534,9 +540,9 @@ TEST(E2EWriterTests, FlushPolicyDictionaryEncodingWithStaticMemoryBudget) {
     config->set(Config::DISABLE_LOW_MEMORY_MODE, true);
     config->set(Config::STRIPE_SIZE, testCase.stripeSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, pool);
+        type, batchCount, size, testCase.seed, *pool);
     testWriterStaticBudgetFlushPolicy(
-        pool,
+        *pool,
         type,
         batches,
         testCase.numStripesLower,
@@ -550,8 +556,7 @@ TEST(E2EWriterTests, FlushPolicyDictionaryEncodingWithStaticMemoryBudget) {
 TEST(E2EWriterTests, StaticMemoryBudgetTrim) {
   const size_t batchCount = 2000;
   const size_t size = 1000;
-  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
 
   HiveTypeParser parser;
   // Dictionary encodable types have the richest feature to test.
@@ -575,8 +580,8 @@ TEST(E2EWriterTests, StaticMemoryBudgetTrim) {
       FlushPolicyTestCase{
           /*stripeSize*/ 512 * kSizeKB,
           /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 86,
-          /*numStripesUpper*/ 86,
+          /*numStripesLower*/ 87,
+          /*numStripesUpper*/ 87,
           /*seed*/ 630992088,
           6 * kSizeMB},
       FlushPolicyTestCase{
@@ -607,8 +612,8 @@ TEST(E2EWriterTests, StaticMemoryBudgetTrim) {
           /*numStripesUpper*/ 3,
           /*seed*/ 630992088,
           40 * kSizeMB});
-
   for (const auto& testCase : dictionaryEncodingTestCases) {
+    SCOPED_TRACE(testCase.debugString());
     auto config = std::make_shared<Config>();
     config->set(Config::DICTIONARY_NUMERIC_KEY_SIZE_THRESHOLD, 1.0f);
     config->set(Config::DICTIONARY_STRING_KEY_SIZE_THRESHOLD, 1.0f);
@@ -616,9 +621,9 @@ TEST(E2EWriterTests, StaticMemoryBudgetTrim) {
     // This is the one flush policy test that doesn't disable low memory mode.
     config->set(Config::STRIPE_SIZE, testCase.stripeSize);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, pool);
+        type, batchCount, size, testCase.seed, *pool);
     testWriterStaticBudgetFlushPolicy(
-        pool,
+        *pool,
         type,
         batches,
         testCase.numStripesLower,
@@ -632,8 +637,7 @@ TEST(E2EWriterTests, StaticMemoryBudgetTrim) {
 TEST(E2EWriterTests, FlushPolicyFlatMap) {
   const size_t batchCount = 10;
   const size_t size = 1000;
-  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
 
   HiveTypeParser parser;
   // A mixture of columns where dictionary sharing is not necessarily
@@ -713,10 +717,10 @@ TEST(E2EWriterTests, FlushPolicyFlatMap) {
     }
     config->set(Config::MAP_FLAT_DICT_SHARE, testCase.enableDictionarySharing);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, pool);
+        type, batchCount, size, testCase.seed, *pool);
 
     testWriterDefaultFlushPolicy(
-        pool,
+        *pool,
         type,
         batches,
         testCase.numStripesLower,
@@ -729,8 +733,7 @@ TEST(E2EWriterTests, FlushPolicyFlatMap) {
 TEST(E2EWriterTests, FlushPolicyFlatMapWithStaticMemoryBudget) {
   const size_t batchCount = 10;
   const size_t size = 1000;
-  auto scopedPool = facebook::velox::memory::getDefaultScopedMemoryPool();
-  auto& pool = scopedPool->getPool();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
 
   HiveTypeParser parser;
   // A mixture of columns where dictionary sharing is not necessarily
@@ -796,10 +799,10 @@ TEST(E2EWriterTests, FlushPolicyFlatMapWithStaticMemoryBudget) {
     }
     config->set(Config::MAP_FLAT_DICT_SHARE, testCase.enableDictionarySharing);
     auto batches = E2EWriterTestUtil::generateBatches(
-        type, batchCount, size, testCase.seed, pool);
+        type, batchCount, size, testCase.seed, *pool);
 
     testWriterStaticBudgetFlushPolicy(
-        pool,
+        *pool,
         type,
         batches,
         testCase.numStripesLower,

--- a/velox/dwio/dwrf/test/WriterTests.cpp
+++ b/velox/dwio/dwrf/test/WriterTests.cpp
@@ -31,47 +31,45 @@ namespace facebook::velox::dwrf {
 
 class WriterTest : public Test {
  public:
-  WriterTest()
-      : scopedPool{getDefaultScopedMemoryPool()}, pool{scopedPool->getPool()} {}
+  WriterTest() : pool_(getDefaultMemoryPool()) {}
 
   WriterBase& createWriter(
       const std::shared_ptr<Config>& config,
       std::unique_ptr<DataSink> sink = nullptr) {
     if (!sink) {
-      auto memSink = std::make_unique<MemorySink>(pool, 1024);
-      sinkPtr = memSink.get();
+      auto memSink = std::make_unique<MemorySink>(*pool_, 1024);
+      sinkPtr_ = memSink.get();
       sink = std::move(memSink);
     }
-    writer = std::make_unique<WriterBase>(std::move(sink));
-    writer->initContext(config, pool.addScopedChild("test_writer_pool"));
-    return *writer;
+    writer_ = std::make_unique<WriterBase>(std::move(sink));
+    writer_->initContext(config, pool_->addChild("test_writer_pool"));
+    return *writer_;
   }
 
   auto& getContext() {
-    return writer->getContext();
+    return writer_->getContext();
   }
 
   auto& getFooter() {
-    return writer->getFooter();
+    return writer_->getFooter();
   }
 
   auto& addStripeInfo() {
-    return writer->addStripeInfo();
+    return writer_->addStripeInfo();
   }
 
   void writeFooter(const Type& type) {
-    writer->writeFooter(type);
+    writer_->writeFooter(type);
   }
 
   void validateStreamSize(uint64_t streamSize) {
     DwrfStreamIdentifier si{1, 0, 0, proto::Stream_Kind_DATA};
-    writer->validateStreamSize(si, streamSize);
+    writer_->validateStreamSize(si, streamSize);
   }
 
-  std::unique_ptr<ScopedMemoryPool> scopedPool;
-  MemoryPool& pool;
-  MemorySink* sinkPtr;
-  std::unique_ptr<WriterBase> writer;
+  std::shared_ptr<MemoryPool> pool_;
+  MemorySink* sinkPtr_;
+  std::unique_ptr<WriterBase> writer_;
 };
 
 TEST_F(WriterTest, WriteFooter) {
@@ -84,11 +82,11 @@ TEST_F(WriterTest, WriteFooter) {
 
   for (size_t i = 0; i < 3; ++i) {
     writerSink.setMode(WriterSink::Mode::Index);
-    writerSink.addBuffer(pool, data.data(), data.size());
+    writerSink.addBuffer(*pool_, data.data(), data.size());
     writerSink.setMode(WriterSink::Mode::Data);
-    writerSink.addBuffer(pool, data.data(), data.size());
+    writerSink.addBuffer(*pool_, data.data(), data.size());
     writerSink.setMode(WriterSink::Mode::Footer);
-    writerSink.addBuffer(pool, data.data(), data.size());
+    writerSink.addBuffer(*pool_, data.data(), data.size());
     writerSink.setMode(WriterSink::Mode::None);
     context.stripeRowCount = 123;
     context.stripeRawSize = 345;
@@ -111,9 +109,9 @@ TEST_F(WriterTest, WriteFooter) {
   writer.close();
 
   // deserialize and verify
-  auto input =
-      std::make_unique<MemoryInputStream>(sinkPtr->getData(), sinkPtr->size());
-  auto reader = std::make_unique<ReaderBase>(pool, std::move(input));
+  auto input = std::make_unique<MemoryInputStream>(
+      sinkPtr_->getData(), sinkPtr_->size());
+  auto reader = std::make_unique<ReaderBase>(*pool_, std::move(input));
 
   auto& ps = reader->getPostScript();
   ASSERT_EQ(reader->getWriterVersion(), config->get(Config::WRITER_VERSION));
@@ -180,7 +178,7 @@ TEST_F(WriterTest, AddStripeInfo) {
   std::memset(data.data(), 'a', data.size());
   auto& writerSink = writer.getSink();
   writerSink.setMode(WriterSink::Mode::Data);
-  writerSink.addBuffer(pool, data.data(), data.size());
+  writerSink.addBuffer(*pool_, data.data(), data.size());
   writerSink.setMode(WriterSink::Mode::None);
 
   auto& ret = addStripeInfo();
@@ -199,7 +197,7 @@ TEST_F(WriterTest, NoChecksum) {
   std::memset(data.data(), 'a', data.size());
   auto& writerSink = writer.getSink();
   writerSink.setMode(WriterSink::Mode::Data);
-  writerSink.addBuffer(pool, data.data(), data.size());
+  writerSink.addBuffer(*pool_, data.data(), data.size());
   writerSink.setMode(WriterSink::Mode::None);
 
   auto& ret = addStripeInfo();
@@ -215,9 +213,9 @@ TEST_F(WriterTest, NoChecksum) {
   writer.close();
 
   // deserialize and verify
-  auto input =
-      std::make_unique<MemoryInputStream>(sinkPtr->getData(), sinkPtr->size());
-  auto reader = std::make_unique<ReaderBase>(pool, std::move(input));
+  auto input = std::make_unique<MemoryInputStream>(
+      sinkPtr_->getData(), sinkPtr_->size());
+  auto reader = std::make_unique<ReaderBase>(*pool_, std::move(input));
   auto& footer = reader->getFooter();
   ASSERT_TRUE(footer.hasChecksumAlgorithm());
   ASSERT_EQ(footer.checksumAlgorithm(), proto::ChecksumAlgorithm::NULL_);
@@ -232,11 +230,11 @@ TEST_F(WriterTest, NoCache) {
   std::memset(data.data(), 'a', data.size());
   auto& writerSink = writer.getSink();
   writerSink.setMode(WriterSink::Mode::Index);
-  writerSink.addBuffer(pool, data.data(), 10);
+  writerSink.addBuffer(*pool_, data.data(), 10);
   writerSink.setMode(WriterSink::Mode::Data);
-  writerSink.addBuffer(pool, data.data(), 10);
+  writerSink.addBuffer(*pool_, data.data(), 10);
   writerSink.setMode(WriterSink::Mode::Footer);
-  writerSink.addBuffer(pool, data.data(), 10);
+  writerSink.addBuffer(*pool_, data.data(), 10);
   writerSink.setMode(WriterSink::Mode::None);
 
   addStripeInfo();
@@ -251,9 +249,9 @@ TEST_F(WriterTest, NoCache) {
   writer.close();
 
   // deserialize and verify
-  auto input =
-      std::make_unique<MemoryInputStream>(sinkPtr->getData(), sinkPtr->size());
-  auto reader = std::make_unique<ReaderBase>(pool, std::move(input));
+  auto input = std::make_unique<MemoryInputStream>(
+      sinkPtr_->getData(), sinkPtr_->size());
+  auto reader = std::make_unique<ReaderBase>(*pool_, std::move(input));
   auto& footer = reader->getFooter();
   ASSERT_EQ(footer.stripeCacheOffsetsSize(), 0);
   auto& ps = reader->getPostScript();
@@ -328,14 +326,14 @@ class MockDataSink : public dwio::common::DataSink {
 
 TEST(WriterBaseTest, FlushWriterSinkUponClose) {
   auto config = std::make_shared<Config>();
-  auto pool = getDefaultScopedMemoryPool();
+  auto pool = getDefaultMemoryPool();
   auto sink = std::make_unique<MockDataSink>();
   MockDataSink* sinkPtr = sink.get();
   EXPECT_CALL(*sinkPtr, write(_)).Times(1);
   EXPECT_CALL(*sinkPtr, isBuffered()).WillOnce(Return(false));
   {
     auto writer = std::make_unique<WriterBase>(std::move(sink));
-    writer->initContext(config, pool->addScopedChild("test_writer_pool"));
+    writer->initContext(config, pool->addChild("test_writer_pool"));
     writer->close();
   }
 }

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -143,11 +143,11 @@ class Writer : public WriterBase {
                                 : nullptr);
     initContext(
         options.config,
-        parentPool.addScopedChild(
+        parentPool.addChild(
             fmt::format(
                 "writer_node_{}",
                 folly::to<std::string>(folly::Random::rand64())),
-            std::min(options.memoryBudget, parentPool.getCap())),
+            std::min(options.memoryBudget, parentPool.cap())),
         std::move(handler));
     if (!options.flushPolicyFactory) {
       auto& context = getContext();
@@ -200,7 +200,7 @@ class Writer : public WriterBase {
         .setMemoryUsageTracker(tracker->addChild());
   }
 
- protected:
+  // protected:
   bool overMemoryBudget(const WriterContext& context, size_t writeLength) const;
 
   bool shouldFlush(const WriterContext& context, size_t nextWriteLength);

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -66,12 +66,12 @@ class WriterBase {
     userMetadata_[key] = value;
   }
 
- protected:
+  // protected:
   void writeFooter(const Type& type);
 
   void initContext(
       const std::shared_ptr<const Config>& config,
-      std::unique_ptr<velox::memory::ScopedMemoryPool> pool,
+      std::shared_ptr<velox::memory::MemoryPool> pool,
       std::unique_ptr<encryption::EncryptionHandler> handler = nullptr) {
     context_ = std::make_unique<WriterContext>(
         config, std::move(pool), sink_->getMetricsLog(), std::move(handler));

--- a/velox/dwio/parquet/tests/ParquetReaderTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetReaderTestBase.h
@@ -152,8 +152,7 @@ class ParquetReaderTestBase : public testing::Test {
         "velox/dwio/parquet/tests/reader", "../examples/" + fileName);
   }
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   std::unique_ptr<test::VectorMaker> vectorMaker_{
       std::make_unique<test::VectorMaker>(pool_.get())};
 };

--- a/velox/dwio/parquet/tests/reader/NestedStructureDecoderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/NestedStructureDecoderBenchmark.cpp
@@ -30,7 +30,7 @@ class NestedStructureDecoderBenchmark {
       : numValues_(numValues),
         definitionLevels_(new unsigned char[numValues]()),
         repetitionLevels_(new unsigned char[numValues]()),
-        pool_(memory::getDefaultScopedMemoryPool()) {}
+        pool_(memory::getDefaultMemoryPool()) {}
 
   void setUp(uint16_t maxDefinition, uint16_t maxRepetition) {
     dwio::common::ensureCapacity<uint64_t>(
@@ -47,7 +47,7 @@ class NestedStructureDecoderBenchmark {
 
   std::unique_ptr<uint8_t> definitionLevels_;
   std::unique_ptr<uint8_t> repetitionLevels_;
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
 
   BufferPtr offsetsBuffer_;
   BufferPtr lengthsBuffer_;

--- a/velox/dwio/parquet/tests/reader/NestedStructureDecoderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/NestedStructureDecoderTest.cpp
@@ -30,7 +30,7 @@ class NestedStructureDecoderTest : public testing::Test {
 
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultScopedMemoryPool();
+    pool_ = memory::getDefaultMemoryPool();
 
     dwio::common::ensureCapacity<bool>(
         nullsBuffer_, kMaxNumValues, pool_.get());
@@ -99,7 +99,7 @@ class NestedStructureDecoderTest : public testing::Test {
     }
   }
 
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   BufferPtr offsetsBuffer_;
   BufferPtr lengthsBuffer_;
   BufferPtr nullsBuffer_;

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -42,7 +42,7 @@ const uint32_t kNumRowsPerRowGroup = 10000;
 class ParquetReaderBenchmark {
  public:
   ParquetReaderBenchmark() {
-    pool_ = memory::getDefaultScopedMemoryPool();
+    pool_ = memory::getDefaultMemoryPool();
     dataSetBuilder_ = std::make_unique<DataSetBuilder>(*pool_.get(), 0);
 
     auto sink = std::make_unique<FileSink>("test.parquet");
@@ -161,7 +161,7 @@ class ParquetReaderBenchmark {
 
  private:
   std::unique_ptr<test::DataSetBuilder> dataSetBuilder_;
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   dwio::common::DataSink* sinkPtr_;
   std::unique_ptr<facebook::velox::parquet::Writer> writer_;
   RuntimeStatistics runtimeStats_;

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -64,8 +64,8 @@ int main(int argc, char** argv) {
   // pointer to this pool can be obtained using execCtx.pool().
   //
   // Optionally, one can control the per-thread memory cap by passing it as an
-  // argument to getDefaultScopedMemoryPool() - no limit by default.
-  auto pool = memory::getDefaultScopedMemoryPool();
+  // argument to getDefaultMemoryPool() - no limit by default.
+  auto pool = memory::getDefaultMemoryPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   // Next, let's create an expression tree to be executed in this example. On a

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -189,7 +189,7 @@ int main(int argc, char** argv) {
 
   // Create memory pool and other query-related structures.
   auto queryCtx = std::make_shared<core::QueryCtx>();
-  auto pool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   // Next, we need to generate an input batch of data (rowVector). We create a

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
   folly::init(&argc, &argv);
 
   // Default memory allocator used throughout this example.
-  auto pool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
 
   // For this example, the input dataset will be comprised of a single BIGINT
   // column ("my_col"), containing 10 rows.

--- a/velox/examples/VectorReaderWriter.cpp
+++ b/velox/examples/VectorReaderWriter.cpp
@@ -46,7 +46,7 @@ int main() {
   // Array<Map<int,int>>
   auto type = TypeFactory<TypeKind::ARRAY>::create(
       TypeFactory<TypeKind::MAP>::create(BIGINT(), BIGINT()));
-  auto pool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
 
   // result vector
   VectorPtr result;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -670,7 +670,7 @@ memory::MappedMemory& Spiller::spillMappedMemory() {
 
 // static
 memory::MemoryPool& Spiller::spillPool() {
-  static auto pool = memory::getDefaultScopedMemoryPool();
+  static auto pool = memory::getDefaultMemoryPool();
   return *pool;
 }
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -162,8 +162,8 @@ Task::Task(
       planFragment_(std::move(planFragment)),
       destination_(destination),
       queryCtx_(std::move(queryCtx)),
-      pool_(queryCtx_->pool()->addScopedChild(
-          fmt::format("task.{}", taskId_.c_str()))),
+      pool_(
+          queryCtx_->pool()->addChild(fmt::format("task.{}", taskId_.c_str()))),
       splitPlanNodeIds_(collectSplitPlanNodeIds(planFragment_.planNode)),
       consumerSupplier_(std::move(consumerSupplier)),
       onError_(onError),
@@ -195,8 +195,7 @@ Task::getOrAddNodePool(const core::PlanNodeId& planNodeId) {
   if (nodePools_.count(planNodeId) == 1) {
     return nodePools_[planNodeId];
   }
-  childPools_.push_back(
-      pool_->addScopedChild(fmt::format("node.{}", planNodeId)));
+  childPools_.push_back(pool_->addChild(fmt::format("node.{}", planNodeId)));
   auto* nodePool = childPools_.back().get();
   auto parentTracker = pool_->getMemoryUsageTracker();
   if (parentTracker != nullptr) {
@@ -210,7 +209,7 @@ velox::memory::MemoryPool* FOLLY_NONNULL Task::addOperatorPool(
     int pipelineId,
     const std::string& operatorType) {
   auto* nodePool = getOrAddNodePool(planNodeId);
-  childPools_.push_back(nodePool->addScopedChild(
+  childPools_.push_back(nodePool->addChild(
       fmt::format("op.{}.{}.{}", planNodeId, pipelineId, operatorType)));
   return childPools_.back().get();
 }
@@ -1864,8 +1863,7 @@ void collectOperatorMemoryUsage(
   const auto numBytes =
       operatorPool->getMemoryUsageTracker()->getCurrentTotalBytes();
   nodeMemoryUsage.total.update(numBytes);
-  auto& operatorMemoryUsage =
-      nodeMemoryUsage.operators[operatorPool->getName()];
+  auto& operatorMemoryUsage = nodeMemoryUsage.operators[operatorPool->name()];
   operatorMemoryUsage.update(numBytes);
 }
 
@@ -1877,7 +1875,7 @@ void collectNodeMemoryUsage(
       nodePool->getMemoryUsageTracker()->getCurrentTotalBytes());
 
   // NOTE: we use a plan node id as the node memory pool's name.
-  const auto& poolName = nodePool->getName();
+  const auto& poolName = nodePool->name();
   auto& nodeMemoryUsage = taskMemoryUsage.nodes[poolName];
 
   // Run through the node's child operator pools and update the memory usage.
@@ -1889,7 +1887,7 @@ void collectNodeMemoryUsage(
 void collectTaskMemoryUsage(
     TaskMemoryUsage& taskMemoryUsage,
     memory::MemoryPool* taskPool) {
-  taskMemoryUsage.taskId = taskPool->getName();
+  taskMemoryUsage.taskId = taskPool->name();
   taskPool->visitChildren([&taskMemoryUsage](memory::MemoryPool* nodePool) {
     collectNodeMemoryUsage(taskMemoryUsage, nodePool);
   });
@@ -1915,7 +1913,7 @@ std::string getQueryMemoryUsageString(memory::MemoryPool* queryPool) {
   // Build the query memory use tree (task->node->operator).
   std::stringstream out;
   out << "\n";
-  out << queryPool->getName();
+  out << queryPool->name();
   out << ": total: ";
   out << succinctBytes(
       queryPool->getMemoryUsageTracker()->getCurrentTotalBytes());

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -730,11 +730,11 @@ class Task : public std::enable_shared_from_this<Task> {
   // Root MemoryPool for this Task. All member variables that hold references
   // to pool_ must be defined after pool_, childPools_, and
   // childMappedMemories_
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
 
   // Keep driver and operator memory pools alive for the duration of the task
   // to allow for sharing vectors across drivers without copy.
-  std::vector<std::unique_ptr<memory::MemoryPool>> childPools_;
+  std::vector<std::shared_ptr<memory::MemoryPool>> childPools_;
 
   // The map from plan node it to the corresponding memory pool object's raw
   // pointer.

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -52,8 +52,7 @@ class BenchmarkBase {
   }
 
  private:
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   VectorMaker vectorMaker_{pool_.get()};
 };
 

--- a/velox/exec/tests/AggregationFuzzer.cpp
+++ b/velox/exec/tests/AggregationFuzzer.cpp
@@ -178,8 +178,7 @@ class AggregationFuzzer {
   FuzzerGenerator rng_;
   size_t currentSeed_{0};
 
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   VectorFuzzer vectorFuzzer_;
 
   Stats stats_;

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -136,8 +136,7 @@ class HashJoinBridgeTest : public testing::Test,
   const uint32_t maxNumPartitions_{8};
   const uint32_t numSpillFilesPerPartition_{20};
 
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   memory::MappedMemory* mappedMemory_{memory::MappedMemory::getInstance()};
   std::shared_ptr<TempDirectoryPath> tempDir_;
 

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -434,8 +434,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
     topTable_->erase(folly::Range<char**>(toErase.data(), toErase.size()));
   }
 
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   memory::MappedMemory* mappedMemory_{memory::MappedMemory::getInstance()};
   std::unique_ptr<test::VectorMaker> vectorMaker_{
       std::make_unique<test::VectorMaker>(pool_.get())};

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -106,8 +106,7 @@ class OperatorUtilsTest
     }
   }
 
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
 };
 
 TEST_F(OperatorUtilsTest, wrapChildConstant) {

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -29,7 +29,7 @@ using facebook::velox::test::BatchMaker;
 class PartitionedOutputBufferManagerTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = facebook::velox::memory::getDefaultScopedMemoryPool();
+    pool_ = facebook::velox::memory::getDefaultMemoryPool();
     mappedMemory_ = memory::MappedMemory::getInstance();
     bufferManager_ = PartitionedOutputBufferManager::getInstance().lock();
     if (!isRegisteredVectorSerde()) {
@@ -230,7 +230,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};
-  std::unique_ptr<facebook::velox::memory::ScopedMemoryPool> pool_;
+  std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
   memory::MappedMemory* mappedMemory_;
   std::shared_ptr<PartitionedOutputBufferManager> bufferManager_;
 };

--- a/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
+++ b/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
@@ -22,7 +22,7 @@ using namespace facebook::velox;
 TEST(RoundRobinPartitionFunctionTest, basic) {
   exec::RoundRobinPartitionFunction partitionFunction(10);
 
-  auto pool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   test::VectorMaker vm(pool.get());
 
   auto data = vm.rowVector(ROW({}, {}), 31);

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -24,7 +24,7 @@ using namespace facebook::velox::exec;
 class VectorHasherTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = facebook::velox::memory::getDefaultScopedMemoryPool();
+    pool_ = facebook::velox::memory::getDefaultMemoryPool();
     allRows_ = SelectivityVector(100);
 
     oddRows_ = VectorHasherTest::makeOddRows(100);
@@ -152,7 +152,7 @@ class VectorHasherTest : public testing::Test {
         base);
   }
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   SelectivityVector allRows_;
   SelectivityVector oddRows_;
   std::unique_ptr<test::VectorMaker> vectorMaker_;

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -55,7 +55,7 @@ class TaskQueue {
   };
 
   explicit TaskQueue(uint64_t maxBytes)
-      : pool_(memory::getDefaultScopedMemoryPool()), maxBytes_(maxBytes) {}
+      : pool_(memory::getDefaultMemoryPool()), maxBytes_(maxBytes) {}
 
   void setNumProducers(int32_t n) {
     numProducers_ = n;
@@ -82,7 +82,7 @@ class TaskQueue {
 
  private:
   // Owns the vectors in 'queue_', hence must be declared first.
-  std::unique_ptr<velox::memory::MemoryPool> pool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::deque<TaskQueueEntry> queue_;
   std::optional<int32_t> numProducers_;
   int32_t producersFinished_ = 0;

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -66,11 +66,9 @@ void HiveConnectorTestBase::writeToFile(
   options.schema = vectors[0]->type();
   auto sink =
       std::make_unique<facebook::velox::dwio::common::FileSink>(filePath);
-  facebook::velox::dwrf::Writer writer{
-      options,
-      std::move(sink),
-      pool_->addChild(kWriter, std::numeric_limits<int64_t>::max())};
-
+  auto childPool =
+      pool_->addChild(kWriter, std::numeric_limits<int64_t>::max());
+  facebook::velox::dwrf::Writer writer{options, std::move(sink), *childPool};
   for (size_t i = 0; i < vectors.size(); ++i) {
     writer.write(vectors[i]);
   }

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -33,7 +33,7 @@ class RowContainerTestBase : public testing::Test,
                              public velox::test::VectorTestBase {
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultScopedMemoryPool();
+    pool_ = memory::getDefaultMemoryPool();
     mappedMemory_ = memory::MappedMemory::getInstance();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
@@ -72,7 +72,7 @@ class RowContainerTestBase : public testing::Test,
         ContainerRowSerde::instance());
   }
 
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   memory::MappedMemory* mappedMemory_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -125,8 +125,7 @@ class TpchQueryBuilder {
   static constexpr const char* kPart = "part";
   static constexpr const char* kSupplier = "supplier";
   static constexpr const char* kPartsupp = "partsupp";
-  std::unique_ptr<memory::ScopedMemoryPool> pool_ =
-      memory::getDefaultScopedMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
 };
 
 } // namespace facebook::velox::exec::test

--- a/velox/experimental/codegen/benchmark/CodegenBenchmark.h
+++ b/velox/experimental/codegen/benchmark/CodegenBenchmark.h
@@ -126,13 +126,13 @@ class CodegenBenchmark : public CodegenTestCore {
   CodegenBenchmark() {
     CodegenTestCore::init();
     queryCtx = std::make_shared<core::QueryCtx>();
-    pool = memory::getDefaultScopedMemoryPool();
+    pool = memory::getDefaultMemoryPool();
     execCtx = std::make_unique<core::ExecCtx>(pool.get(), queryCtx_.get());
   }
 
   std::vector<BenchmarkInfo> templateBenchmarkInfo;
   std::shared_ptr<core::QueryCtx> queryCtx;
-  std::unique_ptr<memory::MemoryPool> pool;
+  std::shared_ptr<memory::MemoryPool> pool;
   std::unique_ptr<core::ExecCtx> execCtx;
   std::vector<BenchmarkInfo> benchmarkInfos;
   bool reusePlanNode = true;
@@ -605,4 +605,4 @@ class BenchmarkGTest : public CodegenTestBase {
     benchmark.compareResults();
   }
 };
-}
+} // namespace facebook::velox::codegen

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -581,8 +581,7 @@ class ExpressionCodegenTestBase : public testing::Test {
   }
 
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<facebook::velox::core::ExecCtx>(
           pool_.get(),

--- a/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
+++ b/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
@@ -57,7 +57,7 @@ class GenerateAstTest : public CodegenTestBase {
     registerVeloxArithmeticUDFs(udfManager_);
     useBuiltInForArithmetic_ = false;
 
-    pool_ = memory::getDefaultScopedMemoryPool();
+    pool_ = memory::getDefaultMemoryPool();
 
     rowType_ = ROW({"c0", "c1", "c2"}, {DOUBLE(), DOUBLE(), DOUBLE()});
 
@@ -78,7 +78,7 @@ class GenerateAstTest : public CodegenTestBase {
         valueNode);
   };
 
-  std::unique_ptr<facebook::velox::memory::MemoryPool> pool_;
+  std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
 
   std::shared_ptr<ProjectNode> project_;
   std::shared_ptr<const RowType> rowType_;

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -104,7 +104,7 @@ class CodegenTestCore {
             udfManager_,
             useSymbolForArithmetic_,
             eventSequence_);
-    pool_ = memory::getDefaultScopedMemoryPool();
+    pool_ = memory::getDefaultMemoryPool();
     queryCtx_ = std::make_shared<core::QueryCtx>(executor_.get());
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
 
@@ -285,7 +285,7 @@ class CodegenTestCore {
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};
   std::unique_ptr<CodegenCompiledExpressionTransform> codegenTransformation_;
-  std::unique_ptr<facebook::velox::memory::MemoryPool> pool_;
+  std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
   std::unique_ptr<core::ExecCtx> execCtx_;
   std::shared_ptr<core::QueryCtx> queryCtx_;
   UDFManager udfManager_;

--- a/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
@@ -89,10 +89,9 @@ TEST(TestConcat, EvalConcatFunction) {
   auto outRowType =
       ROW({"pl", "mi"},
           {std::make_shared<DoubleType>(), std::make_shared<DoubleType>()});
-  auto pool_ = memory::getDefaultScopedMemoryPool();
-  auto pool = pool_.get();
-  auto inRowVector = BaseVector::create(inRowType, rowLength, pool);
-  auto outRowVector = BaseVector::create(outRowType, rowLength, pool);
+  auto pool = memory::getDefaultMemoryPool();
+  auto inRowVector = BaseVector::create(inRowType, rowLength, pool.get());
+  auto outRowVector = BaseVector::create(outRowType, rowLength, pool.get());
 
   VectorPtr& in1 = inRowVector->as<RowVector>()->childAt(0);
   VectorPtr& in2 = inRowVector->as<RowVector>()->childAt(1);
@@ -104,7 +103,7 @@ TEST(TestConcat, EvalConcatFunction) {
 
   std::vector<VectorPtr> in{in1, in2};
   auto queryCtx = std::make_shared<core::QueryCtx>();
-  auto execCtx = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx.get());
+  auto execCtx = std::make_unique<core::ExecCtx>(pool.get(), queryCtx.get());
   exec::EvalCtx context(execCtx.get(), nullptr, inRowVector->as<RowVector>());
   GeneratedVectorFunction<GeneratedVectorFunctionConfigDouble> vectorFunction;
 
@@ -192,11 +191,10 @@ struct GeneratedVectorFunctionConfigBool {
 
 TEST(TestBooEvalVectorFunction, EvalBoolExpression) {
   // TODO: Move those to test class
-  auto pool_ = memory::getDefaultScopedMemoryPool();
-  auto pool = pool_.get();
+  auto pool = memory::getDefaultMemoryPool();
   const size_t vectorSize = 1000;
   auto queryCtx = std::make_shared<core::QueryCtx>();
-  auto execCtx = std::make_unique<core::ExecCtx>(pool, queryCtx.get());
+  auto execCtx = std::make_unique<core::ExecCtx>(pool.get(), queryCtx.get());
 
   auto inRowType =
       ROW({"a", "b"},
@@ -206,8 +204,8 @@ TEST(TestBooEvalVectorFunction, EvalBoolExpression) {
           {std::make_shared<BooleanType>(), std::make_shared<BooleanType>()});
 
   // Initializing input vectors
-  auto inRowVector = BaseVector::create(inRowType, vectorSize, pool);
-  auto outRowVector = BaseVector::create(outRowType, vectorSize, pool);
+  auto inRowVector = BaseVector::create(inRowType, vectorSize, pool.get());
+  auto outRowVector = BaseVector::create(outRowType, vectorSize, pool.get());
 
   VectorPtr& inputVector1 = inRowVector->as<RowVector>()->childAt(0);
   VectorPtr& inputVector2 = inRowVector->as<RowVector>()->childAt(1);

--- a/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
@@ -26,10 +26,9 @@ TEST(VectorReader, ReadDoublesVectors) {
   auto inRowType = ROW({"columnA", "columnB"}, {DOUBLE(), DOUBLE()});
   auto outRowType = ROW({"expr1", "expr2"}, {DOUBLE(), DOUBLE()});
 
-  auto pool_ = memory::getDefaultScopedMemoryPool();
-  auto pool = pool_.get();
-  auto inRowVector = BaseVector::create(inRowType, vectorSize, pool);
-  auto outRowVector = BaseVector::create(outRowType, vectorSize, pool);
+  auto pool = memory::getDefaultMemoryPool();
+  auto inRowVector = BaseVector::create(inRowType, vectorSize, pool.get());
+  auto outRowVector = BaseVector::create(outRowType, vectorSize, pool.get());
 
   VectorPtr& in1 = inRowVector->as<RowVector>()->childAt(0);
 
@@ -55,15 +54,14 @@ TEST(VectorReader, ReadDoublesVectors) {
 
 TEST(VectorReader, ReadBoolVectors) {
   // TODO: Move those to test class
-  auto pool_ = memory::getDefaultScopedMemoryPool();
-  auto pool = pool_.get();
+  auto pool = memory::getDefaultMemoryPool();
   const size_t vectorSize = 1000;
 
   auto inRowType = ROW({"columnA", "columnB"}, {BOOLEAN(), BOOLEAN()});
   auto outRowType = ROW({"expr1", "expr2"}, {BOOLEAN(), BOOLEAN()});
 
-  auto inRowVector = BaseVector::create(inRowType, vectorSize, pool);
-  auto outRowVector = BaseVector::create(outRowType, vectorSize, pool);
+  auto inRowVector = BaseVector::create(inRowType, vectorSize, pool.get());
+  auto outRowVector = BaseVector::create(outRowType, vectorSize, pool.get());
 
   VectorPtr& inputVector = inRowVector->as<RowVector>()->childAt(0);
   inputVector->resize(vectorSize);

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -137,8 +137,7 @@ class ExpressionFuzzer {
   std::unordered_map<std::string, ArgsOverrideFunc> funcArgOverrides_;
 
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   test::ExpressionVerifier verifier_;
 

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -116,8 +116,7 @@ void ExpressionRunner::run(
   VELOX_CHECK(!sql.empty());
 
   std::shared_ptr<core::QueryCtx> queryCtx{std::make_shared<core::QueryCtx>()};
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   RowVectorPtr inputVector;

--- a/velox/expression/tests/ExpressionRunnerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerUnitTest.cpp
@@ -35,8 +35,7 @@ class ExpressionRunnerUnitTest : public testing::Test, public VectorTestBase {
   }
 
  protected:
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   core::QueryCtx queryCtx_{};
   core::ExecCtx execCtx_{pool_.get(), &queryCtx_};
 };

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -61,8 +61,7 @@ class FunctionBenchmarkBase {
 
  protected:
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
   parse::ParseOptions options_;

--- a/velox/functions/lib/tests/ArrayBuilderTest.cpp
+++ b/velox/functions/lib/tests/ArrayBuilderTest.cpp
@@ -26,7 +26,7 @@ namespace facebook::velox::functions::test {
 namespace {
 
 TEST(ArrayBuilder, zeroState) {
-  auto pool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   for (int arraySize : {0, 10, 100, 1000, 10000}) {
     auto arrays =
         ArrayBuilder<int32_t>(arraySize, 0, pool.get()).finish(pool.get());
@@ -43,7 +43,7 @@ TEST(ArrayBuilder, int32) {
   constexpr int kNumArrays = 100;
   for (int estimatedElementCount : {0, 10, 100, 1000}) {
     LOG(INFO) << "estimatedElementCount=" << estimatedElementCount;
-    auto pool = memory::getDefaultScopedMemoryPool();
+    auto pool = memory::getDefaultMemoryPool();
     ArrayBuilder<int32_t> builder(
         kNumArrays, estimatedElementCount, pool.get());
     int numElements = 0;
@@ -74,7 +74,7 @@ TEST(ArrayBuilder, bool) {
   constexpr int kNumArrays = 100;
   for (int estimatedElementCount : {0, 10, 100, 1000}) {
     LOG(INFO) << "estimatedElementCount=" << estimatedElementCount;
-    auto pool = memory::getDefaultScopedMemoryPool();
+    auto pool = memory::getDefaultMemoryPool();
     ArrayBuilder<bool> builder(kNumArrays, estimatedElementCount, pool.get());
     int numElements = 0;
     for (int i = 0; i < kNumArrays; ++i) {
@@ -104,7 +104,7 @@ TEST(ArrayBuilder, bool) {
 TEST(ArrayBuilder, Varchar) {
   constexpr int kNumArrays = 100;
   for (int estimatedElementCount : {0, 10, 100, 1000}) {
-    auto pool = memory::getDefaultScopedMemoryPool();
+    auto pool = memory::getDefaultMemoryPool();
     std::optional<StringViewBufferHolder> arena(pool.get());
     ArrayBuilder<Varchar> builder(
         kNumArrays, estimatedElementCount, pool.get());

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -23,8 +23,7 @@ class InPredicateTest : public FunctionBaseTest {
  protected:
   template <typename T>
   void testIntegers() {
-    std::unique_ptr<memory::MemoryPool> pool{
-        memory::getDefaultScopedMemoryPool()};
+    std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
 
     const vector_size_t size = 1'000;
     auto vector = makeFlatVector<T>(size, [](auto row) { return row % 17; });

--- a/velox/parse/tests/QueryPlannerTest.cpp
+++ b/velox/parse/tests/QueryPlannerTest.cpp
@@ -54,8 +54,7 @@ class QueryPlannerTest : public testing::Test {
         std::vector<VectorPtr>{});
   }
 
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
 };
 
 TEST_F(QueryPlannerTest, values) {

--- a/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
+++ b/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
@@ -51,9 +51,7 @@ class UnsaferowDeserializer : public Deserializer {
   }
 
  private:
-  std::unique_ptr<memory::ScopedMemoryPool> pool_ =
-      memory::getDefaultScopedMemoryPool();
-  ;
+  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
 };
 
 class UnsaferowBatchDeserializer : public Deserializer {
@@ -68,8 +66,7 @@ class UnsaferowBatchDeserializer : public Deserializer {
   }
 
  private:
-  std::unique_ptr<memory::ScopedMemoryPool> pool_ =
-      memory::getDefaultScopedMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
 };
 
 class BenchmarkHelper {
@@ -133,8 +130,7 @@ class BenchmarkHelper {
       MAP(VARCHAR(), ARRAY(INTEGER())),
       ROW({INTEGER()})};
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_ =
-      memory::getDefaultScopedMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
 };
 
 int deserialize(

--- a/velox/row/tests/UnsafeRowBatchDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowBatchDeserializerTest.cpp
@@ -33,7 +33,7 @@ using namespace facebook::velox::test;
 class UnsafeRowBatchDeserializerTest : public ::testing::Test {
  public:
   UnsafeRowBatchDeserializerTest()
-      : pool_(memory::getDefaultScopedMemoryPool()),
+      : pool_(memory::getDefaultMemoryPool()),
         bufferPtr(AlignedBuffer::allocate<char>(1024, pool_.get(), true)),
         buffer(bufferPtr->asMutable<char>()) {}
 
@@ -83,7 +83,7 @@ class UnsafeRowBatchDeserializerTest : public ::testing::Test {
     return testing::AssertionSuccess();
   }
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
 
   BufferPtr bufferPtr;
 
@@ -666,8 +666,7 @@ class UnsafeRowComplexBatchDeserializerTests
         {intVector, stringVector, intArrayVector, stringArrayVector});
   }
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_ =
-      memory::getDefaultScopedMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
   std::array<char[1024], kMaxBuffers> buffers_{};
 };
 

--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -70,7 +70,7 @@ template <typename T>
 class UnsafeRowVectorDeserializerTest : public ::testing::Test {
  public:
   UnsafeRowVectorDeserializerTest()
-      : pool_(memory::getDefaultScopedMemoryPool()),
+      : pool_(memory::getDefaultMemoryPool()),
         bufferPtr(AlignedBuffer::allocate<char>(1024, pool_.get(), true)),
         buffer(bufferPtr->asMutable<char>()) {}
 
@@ -120,7 +120,7 @@ class UnsafeRowVectorDeserializerTest : public ::testing::Test {
     return testing::AssertionSuccess();
   }
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
 
   BufferPtr bufferPtr;
 
@@ -925,8 +925,7 @@ class UnsafeRowComplexDeserializerTests : public exec::test::OperatorTestBase {
         {intVector, stringVector, intArrayVector, stringArrayVector});
   }
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_ =
-      memory::getDefaultScopedMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
   std::array<char[1024], kMaxBuffers> buffers_{};
 };
 

--- a/velox/row/tests/UnsafeRowFuzzTests.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTests.cpp
@@ -42,8 +42,7 @@ class UnsafeRowFuzzTests : public ::testing::Test {
     std::memset(buffer_, 0, BUFFER_SIZE);
   }
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_ =
-      memory::getDefaultScopedMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
   BufferPtr bufferPtr_ =
       AlignedBuffer::allocate<char>(BUFFER_SIZE, pool_.get(), true);
   char* buffer_ = bufferPtr_->asMutable<char>();

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -29,7 +29,7 @@ using namespace facebook::velox::test;
 class PrestoSerializerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultScopedMemoryPool();
+    pool_ = memory::getDefaultMemoryPool();
     serde_ = std::make_unique<serializer::presto::PrestoVectorSerde>();
     vectorMaker_ = std::make_unique<test::VectorMaker>(pool_.get());
   }
@@ -139,7 +139,7 @@ class PrestoSerializerTest : public ::testing::Test {
     assertEqualVectors(rowVector, deserialized);
   }
 
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   std::unique_ptr<serializer::presto::PrestoVectorSerde> serde_;
   std::unique_ptr<test::VectorMaker> vectorMaker_;
 };

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -23,7 +23,7 @@ using namespace facebook::velox;
 class UnsafeRowSerializerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultScopedMemoryPool();
+    pool_ = memory::getDefaultMemoryPool();
     serde_ = std::make_unique<serializer::spark::UnsafeRowVectorSerde>();
   }
 
@@ -74,7 +74,7 @@ class UnsafeRowSerializerTest : public ::testing::Test {
     test::assertEqualVectors(deserialized, rowVector);
   }
 
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   std::unique_ptr<VectorSerde> serde_;
 };
 

--- a/velox/substrait/tests/FunctionTest.cpp
+++ b/velox/substrait/tests/FunctionTest.cpp
@@ -35,8 +35,7 @@ class FunctionTest : public ::testing::Test {
   std::shared_ptr<core::QueryCtx> queryCtx_ =
       std::make_shared<core::QueryCtx>();
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_ =
-      memory::getDefaultScopedMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
 
   std::shared_ptr<vestrait::SubstraitParser> substraitParser_ =
       std::make_shared<vestrait::SubstraitParser>();

--- a/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
+++ b/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
@@ -117,8 +117,7 @@ TEST_F(Substrait2VeloxPlanConversionTest, q6) {
            VARCHAR(),
            VARCHAR(),
            VARCHAR()});
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   std::vector<VectorPtr> vectors;
   // TPC-H lineitem table has 16 columns.
   int colNum = 16;

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -187,8 +187,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
 
   // Boiler plate structures required by vectorMaker.
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
 };
@@ -1125,8 +1124,7 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
     EXPECT_NO_THROW(importFromArrow(arrowSchema, arrowArray, pool_.get()));
   }
 
-  std::unique_ptr<memory::ScopedMemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
 };
 
 class ArrowBridgeArrayImportAsViewerTest : public ArrowBridgeArrayImportTest {

--- a/velox/vector/benchmarks/CopyBenchmark.cpp
+++ b/velox/vector/benchmarks/CopyBenchmark.cpp
@@ -68,8 +68,7 @@ size_t runBenchmark(
 
 BENCHMARK_MULTI(copyArray) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -85,8 +84,7 @@ BENCHMARK_MULTI(copyArray) {
 
 BENCHMARK_MULTI(copyArrayWithNulls) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -103,8 +101,7 @@ BENCHMARK_MULTI(copyArrayWithNulls) {
 
 BENCHMARK_MULTI(copyArrayDictionaryEncoded) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -134,8 +131,7 @@ BENCHMARK_MULTI(copyArrayDictionaryEncoded) {
 
 BENCHMARK_MULTI(copyArrayOneAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -151,8 +147,7 @@ BENCHMARK_MULTI(copyArrayOneAtATime) {
 
 BENCHMARK_MULTI(copyArrayTwoAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -168,8 +163,7 @@ BENCHMARK_MULTI(copyArrayTwoAtATime) {
 
 BENCHMARK_MULTI(copyArrayOfVarchar) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 50'000;
@@ -198,8 +192,7 @@ BENCHMARK_MULTI(copyArrayOfVarchar) {
 
 BENCHMARK_MULTI(copyArrayOfArray) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -227,8 +220,7 @@ BENCHMARK_MULTI(copyArrayOfArray) {
 
 BENCHMARK_MULTI(copyMap) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -246,8 +238,7 @@ BENCHMARK_MULTI(copyMap) {
 
 BENCHMARK_MULTI(copyMapWithNulls) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -266,8 +257,7 @@ BENCHMARK_MULTI(copyMapWithNulls) {
 
 BENCHMARK_MULTI(copyMapDictionaryEncoded) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -300,8 +290,7 @@ BENCHMARK_MULTI(copyMapDictionaryEncoded) {
 
 BENCHMARK_MULTI(copyMapOneAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -319,8 +308,7 @@ BENCHMARK_MULTI(copyMapOneAtATime) {
 
 BENCHMARK_MULTI(copyMapTwoAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -338,8 +326,7 @@ BENCHMARK_MULTI(copyMapTwoAtATime) {
 
 BENCHMARK_MULTI(copyStructNonContiguous) {
   folly::BenchmarkSuspender suspender;
-  std::unique_ptr<memory::MemoryPool> pool{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
   constexpr vector_size_t kSize = 2'000;
   std::vector<VectorPtr> children = {

--- a/velox/vector/benchmarks/SimpleVectorHashAllBenchmark.cpp
+++ b/velox/vector/benchmarks/SimpleVectorHashAllBenchmark.cpp
@@ -89,7 +89,7 @@ void vectorBenchmark(
     bool sequences,
     VectorEncoding::Simple encoding) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   VectorMaker vectorMaker(pool.get());
 
   for (size_t k = 0; k < iterations; ++k) {

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -75,8 +75,7 @@ class VectorFuzzerTest : public testing::Test {
   }
 
  private:
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
 };
 
 // TODO: add coverage for other VectorFuzzer methods.

--- a/velox/vector/tests/BiasVectorTest.cpp
+++ b/velox/vector/tests/BiasVectorTest.cpp
@@ -24,8 +24,8 @@ namespace facebook::velox::test {
 
 class BiasVectorTestBase : public testing::Test {
  protected:
-  std::unique_ptr<velox::memory::ScopedMemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<velox::memory::MemoryPool> pool_{
+      memory::getDefaultMemoryPool()};
   VectorMaker vectorMaker_{pool_.get()};
 };
 

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -22,11 +22,11 @@ using namespace facebook::velox;
 class EnsureWritableVectorTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultScopedMemoryPool();
+    pool_ = memory::getDefaultMemoryPool();
     vectorMaker_ = std::make_unique<test::VectorMaker>(pool_.get());
   }
 
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   std::unique_ptr<test::VectorMaker> vectorMaker_;
 };
 

--- a/velox/vector/tests/IsWritableVectorTest.cpp
+++ b/velox/vector/tests/IsWritableVectorTest.cpp
@@ -25,7 +25,7 @@ using namespace facebook::velox::test;
 class IsWritableVectorTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultScopedMemoryPool();
+    pool_ = memory::getDefaultMemoryPool();
     vectorMaker_ = std::make_unique<VectorMaker>(pool_.get());
   }
 
@@ -101,7 +101,7 @@ class IsWritableVectorTest : public testing::Test {
     }
   }
 
-  std::unique_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
   std::unique_ptr<VectorMaker> vectorMaker_;
 };
 

--- a/velox/vector/tests/MayHaveNullsRecursiveTest.cpp
+++ b/velox/vector/tests/MayHaveNullsRecursiveTest.cpp
@@ -22,8 +22,8 @@ namespace facebook::velox::test {
 
 class MayHaveNullsRecursiveTest : public testing::Test {
  protected:
-  std::unique_ptr<velox::memory::ScopedMemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<velox::memory::MemoryPool> pool_{
+      memory::getDefaultMemoryPool()};
   VectorMaker vectorMaker_{pool_.get()};
 
   enum class TestOptions {

--- a/velox/vector/tests/SimpleVectorTestHelper.h
+++ b/velox/vector/tests/SimpleVectorTestHelper.h
@@ -102,8 +102,7 @@ class SimpleVectorTest : public ::testing::Test {
   }
 
  protected:
-  std::unique_ptr<memory::ScopedMemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   VectorMaker maker_{pool_.get()};
 };
 

--- a/velox/vector/tests/VariantToVectorTest.cpp
+++ b/velox/vector/tests/VariantToVectorTest.cpp
@@ -26,8 +26,7 @@ using namespace facebook::velox;
 using facebook::velox::core::variantArrayToVector;
 
 class VariantToVectorTest : public testing::Test {
-  std::unique_ptr<memory::ScopedMemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
 
  public:
   template <TypeKind KIND>

--- a/velox/vector/tests/VectorMakerTest.cpp
+++ b/velox/vector/tests/VectorMakerTest.cpp
@@ -25,8 +25,7 @@ using facebook::velox::test::VectorMaker;
 
 class VectorMakerTest : public ::testing::Test {
  protected:
-  std::unique_ptr<memory::ScopedMemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   VectorMaker maker_{pool_.get()};
 };
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2121,7 +2121,7 @@ TEST_F(VectorTest, mapSliceMutability) {
 TEST_F(VectorTest, lifetime) {
   ASSERT_DEATH(
       {
-        auto childPool = pool_->addScopedChild("test");
+        auto childPool = pool_->addChild("test");
         auto v = BaseVector::create(INTEGER(), 10, childPool.get());
 
         // BUG: Memory pool needs to stay alive until all memory allocated from

--- a/velox/vector/tests/VectorTestUtils.h
+++ b/velox/vector/tests/VectorTestUtils.h
@@ -80,8 +80,8 @@ class VectorGeneratedData {
   ExpectedData<T> data_;
 
   // In case T is StringView, the buffer below holds their actual data.
-  std::unique_ptr<memory::ScopedMemoryPool> scopedPool =
-      memory::getDefaultScopedMemoryPool();
+  std::shared_ptr<memory::MemoryPool> scopedPool =
+      memory::getDefaultMemoryPool();
   StringViewBufferHolder stringViewBufferHolder_ =
       StringViewBufferHolder(scopedPool.get());
 };
@@ -266,7 +266,7 @@ template <typename T>
 SimpleVectorPtr<T> createAndAssert(
     const ExpectedData<T>& expected,
     VectorEncoding::Simple encoding) {
-  auto pool = memory::getDefaultScopedMemoryPool();
+  auto pool = memory::getDefaultMemoryPool();
   VectorMaker maker(pool.get());
 
   auto vector = maker.encodedVector(encoding, expected);

--- a/velox/vector/tests/VectorUtilTest.cpp
+++ b/velox/vector/tests/VectorUtilTest.cpp
@@ -58,12 +58,12 @@ class VectorUtilTest : public testing::Test {
 
  protected:
   void SetUp() override {
-    pool_ = memoryManager_.getScopedPool();
+    pool_ = memoryManager_.getChild();
   }
 
   memory::MemoryManager<memory::MemoryAllocator, AlignedBuffer::kAlignment>
       memoryManager_;
-  std::unique_ptr<memory::ScopedMemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
 };
 
 using ScalarTypes =

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -704,8 +704,7 @@ class VectorTestBase {
     return pool_.get();
   }
 
-  std::unique_ptr<memory::MemoryPool> pool_{
-      memory::getDefaultScopedMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(


### PR DESCRIPTION
Remove MemoryPoolBase and ScopedMemoryPool, and consolidate into
one memory pool interface MemoryPool and one production implementation
MemoryPoolImp. For the details about the memory pool hierarchy and
ownership see the class comment for MemoryPool.

A query gets the root memory pool object from memory manager by calling
IMemoryManager::getChild(). IMemoryManager is the interface of memory
manger. During the query execution, we calls a parent memory pool's getChild()
to create a child memory pool object.

This PR also changes the references between parent and child memory pool
objects:
1. parent pool object tracks the child pool object through a raw pointer;
2. child pool object holds a shared reference to parent pool object so a parent
    pool object can only destroy after all its child pool objects have been destroyed;
4. child pool object destruction removes its raw pointer tracked in the parent pool
    and release the shared reference on its parent.