### PR TITLE
Fuzzer: test aggregations on flat input

### DIFF
--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -53,7 +53,10 @@ int main(int argc, char** argv) {
       "approx_most_frequent",
       // avg crashes under UBSAN:
       // https://github.com/facebookincubator/velox/issues/3103
+      // Incorrect results:
+      // https://github.com/facebookincubator/velox/issues/3207
       "avg",
+      "max_data_size_for_stats",
   };
 
   // The results of the following functions depend on the order of input

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -241,7 +241,7 @@ class Expr {
   /// expressable as sql. If not given, they will be converted to
   /// SQL-expressable simple constants.
   virtual std::string toSql(
-      std::vector<VectorPtr>* complexConstants = nullptr) const;
+      std::vector<VectorPtr>* FOLLY_NULLABLE complexConstants = nullptr) const;
 
   const ExprStats& stats() const {
     return stats_;
@@ -369,7 +369,7 @@ class Expr {
 
   void appendInputsSql(
       std::stringstream& stream,
-      std::vector<VectorPtr>* complexConstants) const;
+      std::vector<VectorPtr>* FOLLY_NULLABLE complexConstants) const;
 
   /// Release 'inputValues_' back to vector pool in 'evalCtx' so they can be
   /// reused.


### PR DESCRIPTION
Add logic to execute query plans on flattened inputs and compare results with
query plans executed on original (potentially encoded) inputs.

Enhance testing of aggregations whose results depend on the order of inputs by
checking the number of rows in results.

Enhance testing of plans with local exchanges to use multiple batches of inputs
for each source.

The extra testing caught a bug in max_data_size_for_stats: #3207