### PR TITLE
Fuzzer: Add to results verification for order-dependent functions

### DIFF
--- a/velox/docs/develop/testing/fuzzer.rst
+++ b/velox/docs/develop/testing/fuzzer.rst
@@ -78,6 +78,15 @@ aggregate functions supported by the engine, and call
 
 .. _AggregationFuzzerTest.cpp: https://github.com/facebookincubator/velox/blob/main/velox/exec/tests/AggregationFuzzerTest.cpp
 
+Aggregation Fuzzer allows to indicate functions whose results depend on the
+order of inputs and optionally provide an expression to apply to the result to
+make it stable. For example, the results of array_agg can be stabilized by
+applying array_sort on top: array_sort(array_map(x)) and the results of map_agg
+can be stabilized using array_sort(map_keys(map_agg(k, v))). Order-dependent
+functions are tested to ensure no crashes or failures. The results of
+order-dependent functions with stabilizing expressions are further verified for
+correctness by ensuring that results of logically equivalent plans match.
+
 How to run
 ----------------------------
 
@@ -94,6 +103,10 @@ Fuzzers support a number of powerful command line arguments.
 * ``–-only``: A comma-separated list of functions to use in generated expressions.
 
 * ``–-batch_size``: The size of input vectors to generate. Default is 100.
+
+In addition, Aggregation Fuzzer supports:
+
+* ``--num_batches``: The number of input vectors of size `--batch_size` to generate. Default is 10.
 
 If running from CLion IDE, add ``--logtostderr=1`` to see the full output.
 

--- a/velox/exec/tests/AggregationFuzzer.cpp
+++ b/velox/exec/tests/AggregationFuzzer.cpp
@@ -38,6 +38,8 @@ DEFINE_int32(
     100,
     "The number of elements on each generated vector.");
 
+DEFINE_int32(num_batches, 10, "The number of generated vectors.");
+
 DEFINE_int32(
     max_num_varargs,
     5,
@@ -81,7 +83,8 @@ class AggregationFuzzer {
   AggregationFuzzer(
       AggregateFunctionSignatureMap signatureMap,
       size_t seed,
-      const std::unordered_set<std::string>& orderDependentFunctions);
+      const std::unordered_map<std::string, std::string>&
+          orderDependentFunctions);
 
   void go();
 
@@ -145,12 +148,14 @@ class AggregationFuzzer {
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& masks,
       const std::vector<RowVectorPtr>& input,
-      bool orderDependent);
+      bool orderDependent,
+      const std::vector<std::string>& projections);
 
   std::optional<MaterializedRowMultiset> computeDuckDbResult(
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& masks,
+      const std::vector<std::string>& projections,
       const std::vector<RowVectorPtr>& input,
       const core::PlanNodePtr& plan);
 
@@ -161,7 +166,7 @@ class AggregationFuzzer {
       bool verifyResults,
       const ResultOrError& expected);
 
-  const std::unordered_set<std::string> orderDependentFunctions_;
+  const std::unordered_map<std::string, std::string> orderDependentFunctions_;
   const bool persistAndRunOnce_;
   const std::string reproPersistPath_;
 
@@ -184,7 +189,8 @@ class AggregationFuzzer {
 void aggregateFuzzer(
     AggregateFunctionSignatureMap signatureMap,
     size_t seed,
-    const std::unordered_set<std::string>& orderDependentFunctions) {
+    const std::unordered_map<std::string, std::string>&
+        orderDependentFunctions) {
   AggregationFuzzer(std::move(signatureMap), seed, orderDependentFunctions)
       .go();
 }
@@ -236,7 +242,7 @@ std::unordered_set<std::string> getDuckDbFunctions() {
 AggregationFuzzer::AggregationFuzzer(
     AggregateFunctionSignatureMap signatureMap,
     size_t initialSeed,
-    const std::unordered_set<std::string>& orderDependentFunctions)
+    const std::unordered_map<std::string, std::string>& orderDependentFunctions)
     : orderDependentFunctions_{orderDependentFunctions},
       persistAndRunOnce_{FLAGS_persist_and_run_once},
       reproPersistPath_{FLAGS_repro_persist_path},
@@ -443,7 +449,7 @@ std::vector<RowVectorPtr> AggregationFuzzer::generateInputData(
     std::vector<TypePtr> types) {
   auto inputType = ROW(std::move(names), std::move(types));
   std::vector<RowVectorPtr> input;
-  for (auto i = 0; i < 10; ++i) {
+  for (auto i = 0; i < FLAGS_num_batches; ++i) {
     input.push_back(vectorFuzzer_.fuzzInputRow(inputType));
   }
   return input;
@@ -471,7 +477,7 @@ void AggregationFuzzer::go() {
       auto groupingKeys = generateGroupingKeys(names, types);
       auto input = generateInputData(names, types);
 
-      verify(groupingKeys, {}, {}, input, false);
+      verify(groupingKeys, {}, {}, input, false, {});
     } else {
       // Pick a random signature.
       CallableSignature signature = pickSignature();
@@ -503,9 +509,20 @@ void AggregationFuzzer::go() {
         groupingKeys = generateGroupingKeys(argNames, argTypes);
       }
 
+      std::vector<std::string> projections;
+      if (orderDependent) {
+        // Add optional projection on the original result to make it order
+        // independent for comparison.
+        auto mitigation = orderDependentFunctions_.at(signature.name);
+        if (!mitigation.empty()) {
+          projections = groupingKeys;
+          projections.push_back(fmt::format(fmt::runtime(mitigation), "a0"));
+        }
+      }
+
       auto input = generateInputData(argNames, argTypes);
 
-      verify(groupingKeys, {call}, masks, input, orderDependent);
+      verify(groupingKeys, {call}, masks, input, orderDependent, projections);
     }
     LOG(INFO) << "==============================> Done with iteration "
               << iteration;
@@ -546,7 +563,8 @@ ResultOrError AggregationFuzzer::execute(const core::PlanNodePtr& plan) {
 std::string makeDuckDbSql(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates,
-    const std::vector<std::string>& masks) {
+    const std::vector<std::string>& masks,
+    const std::vector<std::string>& projections) {
   std::stringstream sql;
   sql << "SELECT " << folly::join(", ", groupingKeys);
 
@@ -570,6 +588,11 @@ std::string makeDuckDbSql(
     sql << " GROUP BY " << folly::join(", ", groupingKeys);
   }
 
+  if (!projections.empty()) {
+    return fmt::format(
+        "SELECT {} FROM ({})", folly::join(", ", projections), sql.str());
+  }
+
   return sql.str();
 }
 
@@ -577,11 +600,14 @@ std::optional<MaterializedRowMultiset> AggregationFuzzer::computeDuckDbResult(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates,
     const std::vector<std::string>& masks,
+    const std::vector<std::string>& projections,
     const std::vector<RowVectorPtr>& input,
     const core::PlanNodePtr& plan) {
   // Check if DuckDB supports specified aggregate functions.
-  for (const auto& agg :
-       dynamic_cast<const core::AggregationNode*>(plan.get())->aggregates()) {
+  auto aggregationNode = dynamic_cast<const core::AggregationNode*>(
+      projections.empty() ? plan.get() : plan->sources()[0].get());
+  VELOX_CHECK_NOT_NULL(aggregationNode);
+  for (const auto& agg : aggregationNode->aggregates()) {
     if (duckDbFunctionNames_.count(agg->name()) == 0) {
       return std::nullopt;
     }
@@ -606,13 +632,14 @@ std::optional<MaterializedRowMultiset> AggregationFuzzer::computeDuckDbResult(
   DuckDbQueryRunner queryRunner;
   queryRunner.createTable("tmp", {input});
   return queryRunner.execute(
-      makeDuckDbSql(groupingKeys, aggregates, masks), outputType);
+      makeDuckDbSql(groupingKeys, aggregates, masks, projections), outputType);
 }
 
 std::vector<core::PlanNodePtr> makeAlternativePlans(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates,
     const std::vector<std::string>& masks,
+    const std::vector<std::string>& projections,
     const std::vector<RowVectorPtr>& inputVectors) {
   std::vector<core::PlanNodePtr> plans;
 
@@ -621,6 +648,7 @@ std::vector<core::PlanNodePtr> makeAlternativePlans(
                       .values(inputVectors)
                       .partialAggregation(groupingKeys, aggregates, masks)
                       .finalAggregation()
+                      .optionalProject(projections)
                       .planNode());
 
   // Partial -> intermediate -> final aggregation plan.
@@ -629,12 +657,14 @@ std::vector<core::PlanNodePtr> makeAlternativePlans(
                       .partialAggregation(groupingKeys, aggregates, masks)
                       .intermediateAggregation()
                       .finalAggregation()
+                      .optionalProject(projections)
                       .planNode());
 
   // Partial -> local exchange -> final aggregation plan.
-  std::vector<std::vector<RowVectorPtr>> sourceInputs(4);
+  auto numSources = std::min<size_t>(4, inputVectors.size());
+  std::vector<std::vector<RowVectorPtr>> sourceInputs(numSources);
   for (auto i = 0; i < inputVectors.size(); ++i) {
-    sourceInputs[i % 4].push_back(inputVectors[i]);
+    sourceInputs[i % numSources].push_back(inputVectors[i]);
   }
 
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -648,6 +678,7 @@ std::vector<core::PlanNodePtr> makeAlternativePlans(
   plans.push_back(PlanBuilder(planNodeIdGenerator)
                       .localPartition(groupingKeys, sources)
                       .finalAggregation()
+                      .optionalProject(projections)
                       .planNode());
 
   return plans;
@@ -683,10 +714,12 @@ void AggregationFuzzer::verify(
     const std::vector<std::string>& aggregates,
     const std::vector<std::string>& masks,
     const std::vector<RowVectorPtr>& input,
-    bool orderDependent) {
+    bool orderDependent,
+    const std::vector<std::string>& projections) {
   auto plan = PlanBuilder()
                   .values(input)
                   .singleAggregation(groupingKeys, aggregates, masks)
+                  .optionalProject(projections)
                   .planNode();
 
   if (persistAndRunOnce_) {
@@ -699,11 +732,13 @@ void AggregationFuzzer::verify(
       ++stats_.numFailed;
     }
 
+    const bool verifyResults = !orderDependent || !projections.empty();
+
     std::optional<MaterializedRowMultiset> expectedResult;
     try {
-      if (!orderDependent) {
-        expectedResult =
-            computeDuckDbResult(groupingKeys, aggregates, masks, input, plan);
+      if (verifyResults) {
+        expectedResult = computeDuckDbResult(
+            groupingKeys, aggregates, masks, projections, input, plan);
         ++stats_.numDuckDbVerified;
       }
     } catch (std::exception& e) {
@@ -716,9 +751,9 @@ void AggregationFuzzer::verify(
           "Velox and DuckDB results don't match");
     }
 
-    auto altPlans =
-        makeAlternativePlans(groupingKeys, aggregates, masks, input);
-    testPlans(altPlans, !orderDependent, resultOrError);
+    auto altPlans = makeAlternativePlans(
+        groupingKeys, aggregates, masks, projections, input);
+    testPlans(altPlans, verifyResults, resultOrError);
 
     // Evaluate same plans on flat inputs.
     std::vector<RowVectorPtr> flatInput;
@@ -729,8 +764,9 @@ void AggregationFuzzer::verify(
       flatInput.push_back(flat);
     }
 
-    altPlans = makeAlternativePlans(groupingKeys, aggregates, masks, flatInput);
-    testPlans(altPlans, !orderDependent, resultOrError);
+    altPlans = makeAlternativePlans(
+        groupingKeys, aggregates, masks, projections, flatInput);
+    testPlans(altPlans, verifyResults, resultOrError);
 
   } catch (...) {
     if (!reproPersistPath_.empty()) {

--- a/velox/exec/tests/AggregationFuzzer.h
+++ b/velox/exec/tests/AggregationFuzzer.h
@@ -21,5 +21,6 @@ namespace facebook::velox::exec::test {
 void aggregateFuzzer(
     AggregateFunctionSignatureMap signatureMap,
     size_t seed,
-    const std::unordered_set<std::string>& orderDependentFunctions);
+    const std::unordered_map<std::string, std::string>&
+        orderDependentFunctions);
 }

--- a/velox/exec/tests/AggregationFuzzerRunner.h
+++ b/velox/exec/tests/AggregationFuzzerRunner.h
@@ -24,6 +24,7 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/tests/AggregationFuzzer.h"
+#include "velox/parse/TypeResolver.h"
 
 /// AggregationFuzzerRunner leverages AggregationFuzzer and VectorFuzzer to
 /// automatically generate and execute aggregation tests. It works by:
@@ -66,7 +67,8 @@ class AggregationFuzzerRunner {
       const std::string& onlyFunctions,
       size_t seed,
       const std::unordered_set<std::string>& skipFunctions,
-      const std::unordered_set<std::string>& orderDependentFunctions) {
+      const std::unordered_map<std::string, std::string>&
+          orderDependentFunctions) {
     auto signatures = facebook::velox::exec::getAggregateFunctionSignatures();
     if (signatures.empty()) {
       LOG(ERROR) << "No aggregate functions registered.";
@@ -80,6 +82,8 @@ class AggregationFuzzerRunner {
           << "No aggregate functions left after filtering using 'only' and 'skip' lists.";
       exit(1);
     }
+
+    facebook::velox::parse::registerTypeResolver();
 
     facebook::velox::exec::test::aggregateFuzzer(
         filteredSignatures, seed, orderDependentFunctions);

--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -53,7 +53,10 @@ int main(int argc, char** argv) {
       "approx_most_frequent",
       // avg crashes under UBSAN:
       // https://github.com/facebookincubator/velox/issues/3103
+      // Incorrect results:
+      // https://github.com/facebookincubator/velox/issues/3207
       "avg",
+      "max_data_size_for_stats",
   };
 
   // The results of the following functions depend on the order of input

--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -21,6 +21,7 @@
 
 #include "velox/exec/tests/AggregationFuzzerRunner.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 
 DEFINE_int64(
     seed,
@@ -37,6 +38,7 @@ DEFINE_string(
 
 int main(int argc, char** argv) {
   facebook::velox::aggregate::prestosql::registerAllAggregateFunctions();
+  facebook::velox::functions::prestosql::registerAllScalarFunctions();
 
   ::testing::InitGoogleTest(&argc, argv);
 
@@ -53,23 +55,26 @@ int main(int argc, char** argv) {
       "approx_most_frequent",
       // avg crashes under UBSAN:
       // https://github.com/facebookincubator/velox/issues/3103
+      "avg",
       // Incorrect results:
       // https://github.com/facebookincubator/velox/issues/3207
-      "avg",
       "max_data_size_for_stats",
   };
 
   // The results of the following functions depend on the order of input
-  // rows.
-  std::unordered_set<std::string> orderDependentFunctions = {
-      "approx_distinct",
-      "approx_set",
-      "arbitrary",
-      "array_agg",
-      "map_agg",
-      "map_union",
-      "max_by",
-      "min_by",
+  // rows. For some functions, the result can be transformed to a value that
+  // doesn't dopend on the order of inputs. If such transformation exists, it
+  // can be specified to be used for results verification. If no transformation
+  // is specified, results are not verified.
+  std::unordered_map<std::string, std::string> orderDependentFunctions = {
+      {"approx_distinct", ""},
+      {"approx_set", ""},
+      {"arbitrary", ""},
+      {"array_agg", "array_sort({})"},
+      {"map_agg", "array_sort(map_keys({}))"},
+      {"map_union", "array_sort(map_keys({}))"},
+      {"max_by", ""},
+      {"min_by", ""},
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return AggregationFuzzerRunner::run(

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -36,6 +36,7 @@ class MapAggAggregate : public aggregate::MapAggregateBase {
       // Skip null keys
       if (!decodedKeys_.isNullAt(row)) {
         auto group = groups[row];
+        clearNull(group);
         auto accumulator = value<MapAccumulator>(group);
         auto tracker = trackRowSize(group);
         accumulator->keys.appendValue(decodedKeys_, row, allocator_);
@@ -59,6 +60,7 @@ class MapAggAggregate : public aggregate::MapAggregateBase {
     rows.applyToSelected([&](vector_size_t row) {
       // Skip null keys
       if (!decodedKeys_.isNullAt(row)) {
+        clearNull(group);
         keys.appendValue(decodedKeys_, row, allocator_);
         values.appendValue(decodedValues_, row, allocator_);
       }

--- a/velox/functions/prestosql/aggregates/MapAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MapAggregateBase.h
@@ -44,6 +44,7 @@ class MapAggregateBase : public exec::Aggregate {
     for (auto index : indices) {
       new (groups[index] + offset_) MapAccumulator();
     }
+    setAllNulls(groups, indices);
   }
 
   void finalize(char** groups, int32_t numGroups) override {


### PR DESCRIPTION
For some functions, the result can be transformed to a value that doesn't depend
on the order of inputs. If such transformation exists, it can be specified to
be used for results verification.  For example,

- array_agg(x) -> array_sort(array_agg(x))
- map_agg(x) -> array_sort(map_keys(map_agg(x)))
- map_union(x) -> array_sort(map_keys(map_union(x)))

This additional verification caught a bug in map_union: #3206

Also, add --num_batches command line argument to control the number of input vectors used for testing.