### PR TITLE
Create register function for ArrayConstructor for custom aliasing (#3011)

### DIFF
--- a/velox/functions/prestosql/ArrayConstructor.cpp
+++ b/velox/functions/prestosql/ArrayConstructor.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/ArrayConstructor.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 
@@ -85,4 +86,9 @@ VELOX_DECLARE_VECTOR_FUNCTION(
     udf_array_constructor,
     ArrayConstructor::signatures(),
     std::make_unique<ArrayConstructor>());
+
+void registerArrayConstructor(const std::string& name) {
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_constructor, name);
+}
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/ArrayConstructor.h
+++ b/velox/functions/prestosql/ArrayConstructor.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <string>
+
+namespace facebook::velox::functions {
+
+void registerArrayConstructor(const std::string& name);
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/ArrayConstructor.h"
 #include "velox/functions/prestosql/ArrayFunctions.h"
 #include "velox/functions/prestosql/WidthBucketArray.h"
 
@@ -51,7 +52,7 @@ inline void registerArrayCombinationsFunctions() {
 }
 
 void registerArrayFunctions() {
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_constructor, "array_constructor");
+  registerArrayConstructor("array_constructor");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_distinct, "array_distinct");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_duplicates, "array_duplicates");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_intersect, "array_intersect");


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/velox/pull/3011

Created a method to register ArrayConstructor with custom aliases in its own header file to register this UDF with different aliases as per their need. This will let users reuse the same underlying implementation to perform Array construction instead of writing their own ones.

Reviewed By: kevinwilfong

Differential Revision: D40531013

