### PR TITLE
Add check to enforce invariant related to lazy vectors

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -725,6 +725,17 @@ class BaseVector {
     return isCodegenOutput_;
   }
 
+  /// Marks the vector as containing or being a lazy vector and being wrapped.
+  /// Should only be used if 'this' is lazy or has a nested lazy vector.
+  /// Returns true if this is the first time it was wrapped, else returns false.
+  bool markAsContainingLazyAndWrapped() {
+    if (containsLazyAndIsWrapped_) {
+      return false;
+    }
+    containsLazyAndIsWrapped_ = true;
+    return true;
+  }
+
  protected:
   /// Returns a brief summary of the vector. The default implementation includes
   /// encoding, type, number of rows and number of nulls.
@@ -812,6 +823,13 @@ class BaseVector {
   bool isCodegenOutput_ = false;
 
   friend class LazyVector;
+
+  /// Is true if this vector is a lazy vector or contains one and is being
+  /// wrapped. Keeping track of this helps to enforce the invariant that an
+  /// unloaded lazy vector should not be wrapped by two separate top level
+  /// vectors. This would ensure we avoid it being loaded for two separate set
+  /// of rows.
+  bool containsLazyAndIsWrapped_{false};
 };
 
 template <>

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -336,6 +336,10 @@ class ConstantVector final : public SimpleVector<T> {
  private:
   void setInternalState() {
     if (isLazyNotLoaded(*valueVector_)) {
+      VELOX_CHECK(
+          valueVector_->markAsContainingLazyAndWrapped(),
+          "An unloaded lazy vector cannot be wrapped by two different "
+          "top level vectors.");
       // Do not load Lazy vector
       return;
     }

--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -52,6 +52,10 @@ void DictionaryVector<T>::setInternalState() {
 #endif
 
   if (isLazyNotLoaded(*dictionaryValues_)) {
+    VELOX_CHECK(
+        dictionaryValues_->markAsContainingLazyAndWrapped(),
+        "An unloaded lazy vector cannot be wrapped by two different"
+        " top level vectors.");
     // Do not load Lazy vector
     return;
   }

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -16,6 +16,7 @@
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/ByteStream.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/vector/BaseVector.h"
@@ -1912,6 +1913,42 @@ TEST_F(VectorTest, selectiveLoadingOfLazyDictionaryNested) {
 
   dict->loadedVector();
   ASSERT_EQ(loaderPtr->rowCount(), 1 + size / 4);
+}
+
+TEST_F(VectorTest, nestedLazy) {
+  // Verify that explicit checks are triggered that ensure lazy vectors cannot
+  // be nested within two different top level vectors.
+  vector_size_t size = 10;
+  auto indexAt = [](vector_size_t) { return 0; };
+  auto makeLazy = [&]() {
+    return std::make_shared<LazyVector>(
+        pool_.get(),
+        INTEGER(),
+        size,
+        std::make_unique<TestingLoader>(
+            makeFlatVector<int64_t>(size, [](auto row) { return row; })));
+  };
+  auto lazy = makeLazy();
+  auto dict = BaseVector::wrapInDictionary(
+      nullptr, makeIndices(size, indexAt), size, lazy);
+
+  VELOX_ASSERT_THROW(
+      BaseVector::wrapInDictionary(
+          nullptr, makeIndices(size, indexAt), size, lazy),
+      "An unloaded lazy vector cannot be wrapped by two different top level"
+      " vectors.");
+
+  // Verify that the unloaded dictionary can be nested as long as it has one top
+  // level vector.
+  EXPECT_NO_THROW(BaseVector::wrapInDictionary(
+      nullptr, makeIndices(size, indexAt), size, dict));
+
+  // Limitation: Current checks cannot prevent existing references of the lazy
+  // vector to load rows. For example, the following would succeed even though
+  // it was wrapped under 2 layer of dictionary above:
+  EXPECT_FALSE(lazy->isLoaded());
+  EXPECT_NO_THROW(lazy->loadedVector());
+  EXPECT_TRUE(lazy->isLoaded());
 }
 
 TEST_F(VectorTest, dictionaryResize) {


### PR DESCRIPTION
This adds an explicit check to ensure an unloaded lazy vectors cannot
be wrapped by two different top level vectors, that is
Dictionary1(lazy1) and Dictionary2(lazy1) is not possible but
Dictionary3(Dictionary1(lazy1)) is possible. This is an attempt
to reduce the possibility of a lazy being loaded with potentially
different set of rows.

Limitation:
This does not prevent the case where another reference to the lazy can
potentially call load on it.

Test Plan:
Added a unit test.