### PR TITLE
Centralize logic to convert CallExprs to SpecialForms

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
   ExprCompiler.cpp
   ExprToSubfieldFilter.cpp
   FieldReference.cpp
+  FunctionCallToSpecialForm.cpp
   LambdaExpr.cpp
   VectorFunction.cpp
   SimpleFunctionRegistry.cpp

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -703,4 +703,25 @@ std::string CastExpr::toSql(std::vector<VectorPtr>* complexConstants) const {
   out << ")";
   return out.str();
 }
+
+TypePtr CastCallToSpecialForm::resolveType(
+    const std::vector<TypePtr>& /* argTypes */) {
+  VELOX_FAIL("CAST expressions do not support type resolution.");
+}
+
+ExprPtr CastCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<ExprPtr>&& compiledChildren,
+    bool trackCpuUsage) {
+  VELOX_CHECK_EQ(
+      compiledChildren.size(),
+      1,
+      "CAST statements expect exactly 1 argument, received {}",
+      compiledChildren.size());
+  return std::make_shared<CastExpr>(
+      type,
+      std::move(compiledChildren[0]),
+      trackCpuUsage,
+      false /* nullOnFailure */);
+}
 } // namespace facebook::velox::exec

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/expression/FunctionCallToSpecialForm.h"
 #include "velox/expression/SpecialForm.h"
 
 namespace facebook::velox::exec {
@@ -201,6 +202,16 @@ class CastExpr : public SpecialForm {
   // Custom cast operator for the to-type. Nullptr if the type is native or
   // doesn't support cast-to.
   CastOperatorPtr castToOperator_;
+};
+
+class CastCallToSpecialForm : public FunctionCallToSpecialForm {
+ public:
+  TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
+
+  ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<ExprPtr>&& compiledChildren,
+      bool trackCpuUsage) override;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -27,12 +27,16 @@ CoalesceExpr::CoalesceExpr(
           kCoalesce,
           inputsSupportFlatNoNullsFastPath,
           false /* trackCpuUsage */) {
-  for (auto i = 1; i < inputs_.size(); i++) {
-    VELOX_USER_CHECK_EQ(
-        inputs_[0]->type()->kind(),
-        inputs_[i]->type()->kind(),
-        "Inputs to coalesce must have the same type");
-  }
+  std::vector<TypePtr> inputTypes;
+  inputTypes.reserve(inputs_.size());
+  std::transform(
+      inputs_.begin(),
+      inputs_.end(),
+      std::back_inserter(inputTypes),
+      [](const ExprPtr& expr) { return expr->type(); });
+
+  // Apply type checks.
+  resolveType(inputTypes);
 }
 
 void CoalesceExpr::evalSpecialForm(
@@ -69,5 +73,38 @@ void CoalesceExpr::evalSpecialForm(
       return;
     }
   }
+}
+
+// static
+TypePtr CoalesceExpr::resolveType(const std::vector<TypePtr>& argTypes) {
+  VELOX_CHECK_GT(
+      argTypes.size(),
+      0,
+      "COALESCE statements expect to receive at least 1 argument, but did not receive any.");
+  for (auto i = 1; i < argTypes.size(); i++) {
+    VELOX_USER_CHECK(
+        argTypes[0]->equivalent(*argTypes[i]),
+        "Inputs to coalesce must have the same type. ",
+        "Expected {}, but got {}.",
+        argTypes[0]->toString(),
+        argTypes[i]->toString());
+  }
+
+  return argTypes[0];
+}
+
+TypePtr CoalesceCallToSpecialForm::resolveType(
+    const std::vector<TypePtr>& argTypes) {
+  return CoalesceExpr::resolveType(argTypes);
+}
+
+ExprPtr CoalesceCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<ExprPtr>&& compiledChildren,
+    bool /* trackCpuUsage */) {
+  bool inputsSupportFlatNoNullsFastPath =
+      Expr::allSupportFlatNoNullsFastPath(compiledChildren);
+  return std::make_shared<CoalesceExpr>(
+      type, std::move(compiledChildren), inputsSupportFlatNoNullsFastPath);
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/CoalesceExpr.h
+++ b/velox/expression/CoalesceExpr.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/expression/FunctionCallToSpecialForm.h"
 #include "velox/expression/SpecialForm.h"
 
 namespace facebook::velox::exec {
@@ -36,5 +37,21 @@ class CoalesceExpr : public SpecialForm {
   bool propagatesNulls() const override {
     return false;
   }
+
+ private:
+  static TypePtr resolveType(const std::vector<TypePtr>& argTypes);
+
+  friend class CoalesceCallToSpecialForm;
 };
+
+class CoalesceCallToSpecialForm : public FunctionCallToSpecialForm {
+ public:
+  TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
+
+  ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<ExprPtr>&& compiledChildren,
+      bool trackCpuUsage) override;
+};
+
 } // namespace facebook::velox::exec

--- a/velox/expression/FunctionCallToSpecialForm.cpp
+++ b/velox/expression/FunctionCallToSpecialForm.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/FunctionCallToSpecialForm.h"
+
+#include "velox/expression/CastExpr.h"
+#include "velox/expression/CoalesceExpr.h"
+#include "velox/expression/ConjunctExpr.h"
+#include "velox/expression/SwitchExpr.h"
+#include "velox/expression/TryExpr.h"
+
+namespace facebook::velox::exec {
+namespace {
+using RegistryType =
+    std::unordered_map<std::string, std::unique_ptr<FunctionCallToSpecialForm>>;
+
+RegistryType makeRegistry() {
+  RegistryType registry;
+  registry.emplace(
+      "and", std::make_unique<ConjunctCallToSpecialForm>(true /* isAnd */));
+  registry.emplace("cast", std::make_unique<CastCallToSpecialForm>());
+  registry.emplace("coalesce", std::make_unique<CoalesceCallToSpecialForm>());
+  registry.emplace("if", std::make_unique<IfCallToSpecialForm>());
+  registry.emplace(
+      "or", std::make_unique<ConjunctCallToSpecialForm>(false /* isAnd */));
+  registry.emplace("switch", std::make_unique<SwitchCallToSpecialForm>());
+  registry.emplace("try", std::make_unique<TryCallToSpecialForm>());
+
+  return registry;
+}
+
+RegistryType& functionCallToSpecialFormRegistry() {
+  static RegistryType registry = makeRegistry();
+  return registry;
+}
+} // namespace
+
+TypePtr resolveTypeForSpecialForm(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes) {
+  auto& registry = functionCallToSpecialFormRegistry();
+
+  auto it = registry.find(functionName);
+  if (it == registry.end()) {
+    return nullptr;
+  }
+
+  return it->second->resolveType(argTypes);
+}
+
+ExprPtr constructSpecialForm(
+    const std::string& functionName,
+    const TypePtr& type,
+    std::vector<ExprPtr>&& compiledChildren,
+    bool trackCpuUsage) {
+  auto& registry = functionCallToSpecialFormRegistry();
+
+  auto it = registry.find(functionName);
+  if (it == registry.end()) {
+    return nullptr;
+  }
+
+  return it->second->constructSpecialForm(
+      type, std::move(compiledChildren), trackCpuUsage);
+}
+
+bool isFunctionCallToSpecialFormRegistered(const std::string& functionName) {
+  const auto& registry = functionCallToSpecialFormRegistry();
+
+  auto it = registry.find(functionName);
+  return it != registry.end();
+}
+} // namespace facebook::velox::exec

--- a/velox/expression/FunctionCallToSpecialForm.h
+++ b/velox/expression/FunctionCallToSpecialForm.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/Expr.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::exec {
+class FunctionCallToSpecialForm {
+ public:
+  virtual ~FunctionCallToSpecialForm() {}
+
+  /// Returns the output Type of the SpecialForm given the input argument Types.
+  /// Throws if the input Types do not match what's expected for the SpecialForm
+  /// or if the SpecialForm cannot infer the return Type based on the input
+  /// arguments, e.g. Try.
+  virtual TypePtr resolveType(const std::vector<TypePtr>& argTypes) = 0;
+
+  /// Given the output Type, the child expresssions, and whether or not to track
+  /// CPU usage, returns the SpecialForm.
+  virtual ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<ExprPtr>&& compiledChildren,
+      bool trackCpuUsage) = 0;
+};
+
+/// Returns the output Type of the SpecialForm associated with the functionName
+/// given the input argument Types. If functionName is not the name of a known
+/// SpecialForm, returns nullptr. Note that some SpecialForms may throw on
+/// invalid arguments or if they don't support type resolution, e.g. Try.
+TypePtr resolveTypeForSpecialForm(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes);
+
+/// Returns the SpeicalForm associated with the functionName.  If functionName
+/// is not the name of a known SpecialForm, returns nulltpr.
+ExprPtr constructSpecialForm(
+    const std::string& functionName,
+    const TypePtr& type,
+    std::vector<ExprPtr>&& compiledChildren,
+    bool trackCpuUsage);
+
+/// Returns true iff a FunctionCallToSpeicalForm object has been registered for
+/// the given functionName.
+bool isFunctionCallToSpecialFormRegistered(const std::string& functionName);
+} // namespace facebook::velox::exec

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -38,45 +38,16 @@ SwitchExpr::SwitchExpr(
           false /* trackCpuUsage */),
       numCases_{inputs_.size() / 2},
       hasElseClause_{hasElseClause(inputs_)} {
-  VELOX_CHECK_GT(numCases_, 0);
+  std::vector<TypePtr> inputTypes;
+  inputTypes.reserve(inputs_.size());
+  std::transform(
+      inputs_.begin(),
+      inputs_.end(),
+      std::back_inserter(inputTypes),
+      [](const ExprPtr& expr) { return expr->type(); });
 
-  // Make sure all 'condition' expressions hae type BOOLEAN and all 'then' and
-  // an optional 'else' clause have the same type.
-
-  // Find first 'then' type that's not an UNKNOWN type.
-  TypePtr thenType;
-
-  for (auto i = 0; i < numCases_; i++) {
-    auto& condition = inputs_[i * 2];
-    VELOX_CHECK_EQ(condition->type()->kind(), TypeKind::BOOLEAN);
-    auto& thenClause = inputs_[i * 2 + 1];
-    if (thenClause->type()->containsUnknown()) {
-      // Allow null expressions.
-    } else if (!thenType) {
-      thenType = thenClause->type();
-    } else {
-      VELOX_CHECK(
-          thenType->equivalent(*thenClause->type()),
-          "All then clauses of a SWITCH statement must have the same type. "
-          "Expected {}, but got {}.",
-          thenType->toString(),
-          thenClause->type()->toString());
-    }
-  }
-
-  if (hasElseClause_ && thenType) {
-    auto& elseClause = inputs_.back();
-    if (elseClause->type()->containsUnknown()) {
-      // Allow null expressions.
-    } else {
-      VELOX_CHECK(
-          thenType->equivalent(*elseClause->type()),
-          "Else clause of a SWITCH statement must have the same type as 'then' clauses. "
-          "Expected {}, but got {}.",
-          thenType->toString(),
-          elseClause->type()->toString());
-    }
-  }
+  // Apply type checking.
+  resolveType(inputTypes);
 }
 
 void SwitchExpr::evalSpecialForm(
@@ -185,5 +156,84 @@ bool SwitchExpr::propagatesNulls() const {
   }
 
   return true;
+}
+
+// static
+TypePtr SwitchExpr::resolveType(const std::vector<TypePtr>& argTypes) {
+  VELOX_CHECK_GT(
+      argTypes.size(),
+      1,
+      "Switch statements expect at least 2 arguments, received {}",
+      argTypes.size());
+
+  // Make sure all 'condition' expressions hae type BOOLEAN and all 'then' and
+  // an optional 'else' clause have the same type.
+
+  // Find first 'then' type that's not an UNKNOWN type.
+  TypePtr thenType;
+
+  for (auto i = 0; i < argTypes.size() / 2; i++) {
+    auto& conditionType = argTypes[i * 2];
+    VELOX_CHECK_EQ(conditionType->kind(), TypeKind::BOOLEAN);
+    auto& thenClauseType = argTypes[i * 2 + 1];
+    if (thenClauseType->containsUnknown()) {
+      // Allow null expressions.
+    } else if (!thenType) {
+      thenType = thenClauseType;
+    } else {
+      VELOX_CHECK(
+          thenType->equivalent(*thenClauseType),
+          "All then clauses of a SWITCH statement must have the same type. "
+          "Expected {}, but got {}.",
+          thenType->toString(),
+          thenClauseType->toString());
+    }
+  }
+
+  if (argTypes.size() % 2 == 1) {
+    auto& elseClauseType = argTypes.back();
+    if (thenType) {
+      if (elseClauseType->containsUnknown()) {
+        // Allow null expressions.
+      } else {
+        VELOX_CHECK(
+            thenType->equivalent(*elseClauseType),
+            "Else clause of a SWITCH statement must have the same type as 'then' clauses. "
+            "Expected {}, but got {}.",
+            thenType->toString(),
+            elseClauseType->toString());
+      }
+    } else {
+      // If every then clause had an UNKNOWN, default to the type of the else
+      // clause.
+      thenType = elseClauseType;
+    }
+  }
+
+  return thenType;
+}
+
+TypePtr SwitchCallToSpecialForm::resolveType(
+    const std::vector<TypePtr>& argTypes) {
+  return SwitchExpr::resolveType(argTypes);
+}
+
+ExprPtr SwitchCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<ExprPtr>&& compiledChildren,
+    bool /* trackCpuUsage */) {
+  bool inputsSupportFlatNoNullsFastPath =
+      Expr::allSupportFlatNoNullsFastPath(compiledChildren);
+  return std::make_shared<SwitchExpr>(
+      type, std::move(compiledChildren), inputsSupportFlatNoNullsFastPath);
+}
+
+TypePtr IfCallToSpecialForm::resolveType(const std::vector<TypePtr>& argTypes) {
+  VELOX_CHECK(
+      argTypes.size() == 3,
+      "An IF statement must have 3 clauses, the if clause, the then clause, and the else clause. Expected 3, but got {}.",
+      argTypes.size());
+
+  return SwitchCallToSpecialForm::resolveType(argTypes);
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/SwitchExpr.h
+++ b/velox/expression/SwitchExpr.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/expression/FunctionCallToSpecialForm.h"
 #include "velox/expression/SpecialForm.h"
 
 namespace facebook::velox::exec {
@@ -54,8 +55,27 @@ class SwitchExpr : public SpecialForm {
   }
 
  private:
+  static TypePtr resolveType(const std::vector<TypePtr>& argTypes);
+
   const size_t numCases_;
   const bool hasElseClause_;
   BufferPtr tempValues_;
+
+  friend class SwitchCallToSpecialForm;
+};
+
+class SwitchCallToSpecialForm : public FunctionCallToSpecialForm {
+ public:
+  TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
+
+  ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<ExprPtr>&& compiledChildren,
+      bool trackCpuUsage) override;
+};
+
+class IfCallToSpecialForm : public SwitchCallToSpecialForm {
+ public:
+  TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/TryExpr.cpp
+++ b/velox/expression/TryExpr.cpp
@@ -126,4 +126,26 @@ void TryExpr::nullOutErrors(
     }
   }
 }
+
+TypePtr TryCallToSpecialForm::resolveType(
+    const std::vector<TypePtr>& argTypes) {
+  VELOX_CHECK_EQ(
+      argTypes.size(),
+      1,
+      "TRY expressions expect exactly 1 argument, received: {}",
+      argTypes.size());
+  return argTypes[0];
+}
+
+ExprPtr TryCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<ExprPtr>&& compiledChildren,
+    bool /* trackCpuUsage */) {
+  VELOX_CHECK_EQ(
+      compiledChildren.size(),
+      1,
+      "TRY expressions expect exactly 1 argument, received: {}",
+      compiledChildren.size());
+  return std::make_shared<TryExpr>(type, std::move(compiledChildren[0]));
+}
 } // namespace facebook::velox::exec

--- a/velox/expression/TryExpr.h
+++ b/velox/expression/TryExpr.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/expression/FunctionCallToSpecialForm.h"
 #include "velox/expression/SpecialForm.h"
 
 namespace facebook::velox::exec {
@@ -49,4 +50,15 @@ class TryExpr : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result);
 };
+
+class TryCallToSpecialForm : public FunctionCallToSpecialForm {
+ public:
+  TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
+
+  ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<ExprPtr>&& compiledChildren,
+      bool trackCpuUsage) override;
+};
+
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(
   ReverseSignatureBinderTest.cpp
   RowWriterTest.cpp
   EvalSimplifiedTest.cpp
+  FunctionCallToSpecialFormTest.cpp
   SignatureBinderTest.cpp
   SimpleFunctionTest.cpp
   SimpleFunctionInitTest.cpp

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -849,3 +849,20 @@ TEST_F(CastExprTest, primitiveWithDictionaryIntroducedNulls) {
     assertEqualVectors(expected, result);
   }
 }
+
+TEST_F(CastExprTest, castAsCall) {
+  // Invoking cast through a CallExpr instead of a CastExpr
+  const std::vector<std::optional<int32_t>> inputValues = {1, 2, 3, 100, -100};
+  const std::vector<std::optional<double>> outputValues = {
+      1.0, 2.0, 3.0, 100.0, -100.0};
+
+  auto input = makeRowVector({makeNullableFlatVector(inputValues)});
+  core::TypedExprPtr inputField =
+      std::make_shared<const core::FieldAccessTypedExpr>(INTEGER(), "c0");
+  core::TypedExprPtr callExpr = std::make_shared<const core::CallTypedExpr>(
+      DOUBLE(), std::vector<core::TypedExprPtr>{inputField}, "cast");
+
+  auto result = evaluate(callExpr, input);
+  auto expected = makeNullableFlatVector(outputValues);
+  assertEqualVectors(expected, result);
+}

--- a/velox/expression/tests/FunctionCallToSpecialFormTest.cpp
+++ b/velox/expression/tests/FunctionCallToSpecialFormTest.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "velox/expression/CastExpr.h"
+#include "velox/expression/CoalesceExpr.h"
+#include "velox/expression/ConjunctExpr.h"
+#include "velox/expression/ConstantExpr.h"
+#include "velox/expression/FunctionCallToSpecialForm.h"
+#include "velox/expression/SwitchExpr.h"
+#include "velox/expression/TryExpr.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::core;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+class FunctionCallToSpecialFormTest : public testing::Test,
+                                      public VectorTestBase {};
+
+TEST_F(FunctionCallToSpecialFormTest, andCall) {
+  ASSERT_TRUE(isFunctionCallToSpecialFormRegistered("and"));
+
+  auto type = resolveTypeForSpecialForm("and", {BOOLEAN(), BOOLEAN()});
+  ASSERT_EQ(type, BOOLEAN());
+
+  auto specialForm = constructSpecialForm(
+      "and",
+      BOOLEAN(),
+      {std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<bool>({true})),
+       std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<bool>({false}))},
+      false);
+  ASSERT_EQ(typeid(*specialForm), typeid(const ConjunctExpr&));
+}
+
+TEST_F(FunctionCallToSpecialFormTest, castCall) {
+  ASSERT_TRUE(isFunctionCallToSpecialFormRegistered("cast"));
+
+  ASSERT_THROW(resolveTypeForSpecialForm("cast", {}), VeloxRuntimeError);
+
+  auto specialForm = constructSpecialForm(
+      "cast",
+      DOUBLE(),
+      {std::make_shared<ConstantExpr>(
+          vectorMaker_.constantVector<int32_t>({0}))},
+      false);
+  ASSERT_EQ(typeid(*specialForm), typeid(const CastExpr&));
+}
+
+TEST_F(FunctionCallToSpecialFormTest, coalesceCall) {
+  ASSERT_TRUE(isFunctionCallToSpecialFormRegistered("coalesce"));
+
+  auto type = resolveTypeForSpecialForm("coalesce", {BOOLEAN()});
+  ASSERT_EQ(type, BOOLEAN());
+
+  auto specialForm = constructSpecialForm(
+      "coalesce",
+      INTEGER(),
+      {std::make_shared<ConstantExpr>(
+          vectorMaker_.constantVector<int32_t>({0}))},
+      false);
+  ASSERT_EQ(typeid(*specialForm), typeid(const CoalesceExpr&));
+}
+
+TEST_F(FunctionCallToSpecialFormTest, ifCall) {
+  ASSERT_TRUE(isFunctionCallToSpecialFormRegistered("if"));
+
+  auto type =
+      resolveTypeForSpecialForm("if", {BOOLEAN(), INTEGER(), INTEGER()});
+  ASSERT_EQ(type, INTEGER());
+
+  auto specialForm = constructSpecialForm(
+      "if",
+      INTEGER(),
+      {std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<bool>({true})),
+       std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<int32_t>({0})),
+       std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<int32_t>({1}))},
+      false);
+  ASSERT_EQ(typeid(*specialForm), typeid(const SwitchExpr&));
+}
+
+TEST_F(FunctionCallToSpecialFormTest, orCall) {
+  ASSERT_TRUE(isFunctionCallToSpecialFormRegistered("or"));
+
+  auto type = resolveTypeForSpecialForm("or", {BOOLEAN(), BOOLEAN()});
+  ASSERT_EQ(type, BOOLEAN());
+
+  auto specialForm = constructSpecialForm(
+      "or",
+      BOOLEAN(),
+      {std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<bool>({true})),
+       std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<bool>({false}))},
+      false);
+  ASSERT_EQ(typeid(*specialForm), typeid(const ConjunctExpr&));
+}
+
+TEST_F(FunctionCallToSpecialFormTest, switchCall) {
+  ASSERT_TRUE(isFunctionCallToSpecialFormRegistered("switch"));
+
+  auto type = resolveTypeForSpecialForm(
+      "switch", {BOOLEAN(), INTEGER(), BOOLEAN(), INTEGER(), INTEGER()});
+  ASSERT_EQ(type, INTEGER());
+
+  auto specialForm = constructSpecialForm(
+      "switch",
+      INTEGER(),
+      {std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<bool>({true})),
+       std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<int32_t>({0})),
+       std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<bool>({false})),
+       std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<int32_t>({1})),
+       std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<int32_t>({2}))},
+      false);
+  ASSERT_EQ(typeid(*specialForm), typeid(const SwitchExpr&));
+}
+
+TEST_F(FunctionCallToSpecialFormTest, tryCall) {
+  ASSERT_TRUE(isFunctionCallToSpecialFormRegistered("try"));
+
+  auto type = resolveTypeForSpecialForm("try", {BOOLEAN()});
+  ASSERT_EQ(type, BOOLEAN());
+
+  auto specialForm = constructSpecialForm(
+      "try",
+      INTEGER(),
+      {std::make_shared<ConstantExpr>(
+          vectorMaker_.constantVector<int32_t>({0}))},
+      false);
+  ASSERT_EQ(typeid(*specialForm), typeid(const TryExpr&));
+}
+
+TEST_F(FunctionCallToSpecialFormTest, notASpecialForm) {
+  ASSERT_FALSE(isFunctionCallToSpecialFormRegistered("not_a_special_form"));
+
+  auto type = resolveTypeForSpecialForm("not_a_special_form", {BOOLEAN()});
+  ASSERT_EQ(type, nullptr);
+
+  auto specialForm = constructSpecialForm(
+      "not_a_special_form",
+      INTEGER(),
+      {std::make_shared<ConstantExpr>(
+          vectorMaker_.constantVector<int32_t>({0}))},
+      false);
+  ASSERT_EQ(specialForm, nullptr);
+}


### PR DESCRIPTION
Summary:
Currently logic related to allowing SpecialForms to be
expressed as CallExprs is spread across two files.

1) TypeResolver has special logic for each special form to
simulate type resolution of them as function calls.
2) ExprCompiler has special logic for each special form to do
the conversion from CallExprs.

(Side note, I'm planning to add a third for function resolution)

Rather than writing logic specific to certain special forms in
files not directly related to those special forms, and
duplicating the knowledge of what special forms exist across
those files, I propose:
1) Creating a single file FunctionCallToSpecialForm that
knows what SpecialForms can be expressed as CallExprs,
and exposes a single interface to do that special handling
for all SpecialForms.
2) Moving the type resolution and the logic to convert to
SpecialForms to the files specifying those SpecialForms.

This makes it easy to share type checking logic between the
SpecialForm constructor, the type resolution and the logic to
convert from a CallExpr.

This means the names and list of SpecialForms only need to
be hard coded in one place.

This consolidates logic for SpecialForms in a few places
directly related to those SpecialForms.

Differential Revision: D41282078

