### PR TITLE
Support resolving SpecialForms

### DIFF
--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -36,6 +36,25 @@ std::shared_ptr<const Type> resolveFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
+/// Given a function name and argument types, returns the return type if the
+/// function exists or is a special form that supports type resolution (see
+/// resolveCallableSpecialForm), otherwise returns nullptr.
+std::shared_ptr<const Type> resolveFunctionOrCallableSpecialForm(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes);
+
+/// Given the name of a special form and argument types, returns
+/// the return type if the special form exists and is supported, otherwise
+/// returns nullptr.
+/// Special forms are not supported by this function if:
+/// 1) they cannot be invoked as a CallExpr, e.g. FieldReference.
+/// or
+/// 2) their return types cannot be inferred from their argument types, e.g.
+///    Cast.
+std::shared_ptr<const Type> resolveCallableSpecialForm(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes);
+
 /// Given name of simple function and argument types, returns
 /// the return type if function exists otherwise returns nullptr
 std::shared_ptr<const Type> resolveSimpleFunction(

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -519,4 +519,47 @@ TEST_F(FunctionRegistryTest, resolveFunctionsBasedOnPriority) {
   ASSERT_EQ(*result5, *REAL());
 }
 
+TEST_F(FunctionRegistryTest, resolveSpecialForms) {
+  auto andResult =
+      resolveFunctionOrCallableSpecialForm("and", {BOOLEAN(), BOOLEAN()});
+  ASSERT_EQ(*andResult, *BOOLEAN());
+
+  auto coalesceResult =
+      resolveFunctionOrCallableSpecialForm("coalesce", {VARCHAR(), VARCHAR()});
+  ASSERT_EQ(*coalesceResult, *VARCHAR());
+
+  auto ifResult = resolveFunctionOrCallableSpecialForm(
+      "if", {BOOLEAN(), INTEGER(), INTEGER()});
+  ASSERT_EQ(*ifResult, *INTEGER());
+
+  auto orResult =
+      resolveFunctionOrCallableSpecialForm("or", {BOOLEAN(), BOOLEAN()});
+  ASSERT_EQ(*orResult, *BOOLEAN());
+
+  auto switchResult = resolveFunctionOrCallableSpecialForm(
+      "switch", {BOOLEAN(), DOUBLE(), BOOLEAN(), DOUBLE(), DOUBLE()});
+  ASSERT_EQ(*switchResult, *DOUBLE());
+
+  auto tryResult = resolveFunctionOrCallableSpecialForm("try", {REAL()});
+  ASSERT_EQ(*tryResult, *REAL());
+}
+
+TEST_F(FunctionRegistryTest, resolveRowConstructor) {
+  auto result = resolveFunctionOrCallableSpecialForm(
+      "row_constructor", {INTEGER(), BOOLEAN(), DOUBLE()});
+  ASSERT_EQ(
+      *result, *ROW({"c1", "c2", "c3"}, {INTEGER(), BOOLEAN(), DOUBLE()}));
+}
+
+TEST_F(FunctionRegistryTest, resolveFunctionNotSpecialForm) {
+  auto result = resolveFunctionOrCallableSpecialForm("func_one", {VARCHAR()});
+  ASSERT_EQ(*result, *VARCHAR());
+}
+
+TEST_F(FunctionRegistryTest, resolveCast) {
+  ASSERT_THROW(
+      resolveFunctionOrCallableSpecialForm("cast", {VARCHAR()}),
+      velox::VeloxRuntimeError);
+}
+
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
Velox supports expressing some SpecialForms as normal
function calls (CallExprs).

However, Velox does not support resolving the "function
names" like normal functions, users have to add special
handling for these, which takes away some of the magic and
puts a burden on users.

To help with this, I've added a new function
resolveFunctionOrCallableSpecialForm
that can resolve functions are SpecialForms that can be
written like function calls.  Here we're using a new function
to preserve backwards compatibility of resolveFunction.

This allows users the freedom to not distinguish between
function calls that are really functions and function calls that
are special forms.

The one exception is CAST.  The return type for a CAST
cannot be determined from its input arguments.  The type
being casted to is a special argument that is not part of the
function call.  For this reason users still need to have special
handling for this case.  With this change they will get an
explicit error message that CAST does not support type
resolution, instead of a nullptr as they would with
resolveFunction.

Differential Revision: D41283895

