### PR TITLE
Add option to report runtime/row or total runtime to simple arithmetic benchmarks

### DIFF
--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -32,7 +32,6 @@ using namespace facebook::velox::exec;
 using namespace facebook::velox::test;
 
 namespace {
-
 // Variations of the simple multiply function regarding output values.
 template <typename T>
 struct MultiplyVoidOutputFunction {
@@ -134,16 +133,20 @@ class SimpleArithmeticBenchmark
         pool(), inputType_, nullptr, size, std::move(children));
   }
 
-  size_t runSmall(const std::string& expression, size_t times) {
-    return run(expression, times, smallRowVector_);
+  static constexpr auto kIterationsSmall = 10'000;
+  static constexpr auto kIterationsMeduim = 1000;
+  static constexpr auto kIterationsLarge = 100;
+
+  void runSmall(const std::string& expression) {
+    run(expression, kIterationsSmall, smallRowVector_);
   }
 
-  size_t runMedium(const std::string& expression, size_t times) {
-    return run(expression, times, mediumRowVector_);
+  void runMedium(const std::string& expression) {
+    run(expression, kIterationsMeduim, mediumRowVector_);
   }
 
-  size_t runLarge(const std::string& expression, size_t times) {
-    return run(expression, times, largeRowVector_);
+  void runLarge(const std::string& expression) {
+    run(expression, kIterationsLarge, largeRowVector_);
   }
 
   // Runs `expression` `times` thousand times.
@@ -154,7 +157,7 @@ class SimpleArithmeticBenchmark
     suspender.dismiss();
 
     size_t count = 0;
-    for (auto i = 0; i < times * 1'000; i++) {
+    for (auto i = 0; i < times; i++) {
       count += evaluate(exprSet, input)->size();
     }
     return count;
@@ -169,163 +172,160 @@ class SimpleArithmeticBenchmark
 
 std::unique_ptr<SimpleArithmeticBenchmark> benchmark;
 
-BENCHMARK_MULTI(multiplySmall, n) {
-  return benchmark->runSmall("multiply(a, b)", n);
+BENCHMARK(multiplySmall) {
+  benchmark->runSmall("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplySameColumnSmall, n) {
-  return benchmark->runSmall("multiply(a, a)", n);
+BENCHMARK(multiplySameColumnSmall) {
+  benchmark->runSmall("multiply(a, a)");
 }
 
-BENCHMARK_MULTI(multiplyHalfNullSmall, n) {
-  return benchmark->runSmall("multiply(a, half_null)", n);
+BENCHMARK(multiplyHalfNullSmall) {
+  benchmark->runSmall("multiply(a, half_null)");
 }
 
-BENCHMARK_MULTI(multiplyConstantSmall, n) {
-  return benchmark->runSmall("multiply(a, constant)", n);
+BENCHMARK(multiplyConstantSmall) {
+  benchmark->runSmall("multiply(a, constant)");
 }
 
-BENCHMARK_MULTI(multiplyNestedSmall, n) {
-  return benchmark->runSmall("multiply(multiply(a, b), b)", n);
+BENCHMARK(multiplyNestedSmall) {
+  benchmark->runSmall("multiply(multiply(a, b), b)");
 }
 
-BENCHMARK_MULTI(multiplyNestedDeepSmall, n) {
-  return benchmark->runSmall(
+BENCHMARK(multiplyNestedDeepSmall) {
+  benchmark->runSmall(
       "multiply(multiply(multiply(a, b), a), "
-      "multiply(a, multiply(a, b)))",
-      n);
+      "multiply(a, multiply(a, b)))");
 }
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(multiplyOutputVoidSmall, n) {
-  return benchmark->runSmall("multiply(a, b)", n);
+BENCHMARK(multiplyOutputVoidSmall) {
+  benchmark->runSmall("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputNullableSmall, n) {
-  return benchmark->runSmall("multiply_nullable_output(a, b)", n);
+BENCHMARK(multiplyOutputNullableSmall) {
+  benchmark->runSmall("multiply_nullable_output(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputAlwaysNullSmall, n) {
-  return benchmark->runSmall("multiply_null_output(a, b)", n);
-}
-
-BENCHMARK_DRAW_LINE();
-
-BENCHMARK_MULTI(plusUncheckedSmall, n) {
-  return benchmark->runSmall("plus(c, d)", n);
-}
-
-BENCHMARK_MULTI(plusCheckedSmall, n) {
-  return benchmark->runSmall("checked_plus(c, d)", n);
+BENCHMARK(multiplyOutputAlwaysNullSmall) {
+  benchmark->runSmall("multiply_null_output(a, b)");
 }
 
 BENCHMARK_DRAW_LINE();
+
+BENCHMARK(plusUncheckedSmall) {
+  benchmark->runSmall("plus(c, d)");
+}
+
+BENCHMARK(plusCheckedSmall) {
+  benchmark->runSmall("checked_plus(c, d)");
+}
+
+BENCHMARK_DRAW_LINE();
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(multiplyMedium, n) {
-  return benchmark->runMedium("multiply(a, b)", n);
+BENCHMARK(multiplyMedium) {
+  benchmark->runMedium("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplySameColumnMedium, n) {
-  return benchmark->runMedium("multiply(a, a)", n);
+BENCHMARK(multiplySameColumnMedium) {
+  benchmark->runMedium("multiply(a, a)");
 }
 
-BENCHMARK_MULTI(multiplyHalfNullMedium, n) {
-  return benchmark->runMedium("multiply(a, half_null)", n);
+BENCHMARK(multiplyHalfNullMedium) {
+  benchmark->runMedium("multiply(a, half_null)");
 }
 
-BENCHMARK_MULTI(multiplyConstantMedium, n) {
-  return benchmark->runMedium("multiply(a, constant)", n);
+BENCHMARK(multiplyConstantMedium) {
+  benchmark->runMedium("multiply(a, constant)");
 }
 
-BENCHMARK_MULTI(multiplyNestedMedium, n) {
-  return benchmark->runMedium("multiply(multiply(a, b), b)", n);
+BENCHMARK(multiplyNestedMedium) {
+  benchmark->runMedium("multiply(multiply(a, b), b)");
 }
 
-BENCHMARK_MULTI(multiplyNestedDeepMedium, n) {
-  return benchmark->runMedium(
+BENCHMARK(multiplyNestedDeepMedium) {
+  benchmark->runMedium(
       "multiply(multiply(multiply(a, b), a), "
-      "multiply(a, multiply(a, b)))",
-      n);
+      "multiply(a, multiply(a, b)))");
 }
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(multiplyOutputVoidMedium, n) {
-  return benchmark->runMedium("multiply(a, b)", n);
+BENCHMARK(multiplyOutputVoidMedium) {
+  benchmark->runMedium("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputNullableMedium, n) {
-  return benchmark->runMedium("multiply_nullable_output(a, b)", n);
+BENCHMARK(multiplyOutputNullableMedium) {
+  benchmark->runMedium("multiply_nullable_output(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputAlwaysNullMedium, n) {
-  return benchmark->runMedium("multiply_null_output(a, b)", n);
-}
-
-BENCHMARK_DRAW_LINE();
-
-BENCHMARK_MULTI(plusUncheckedMedium, n) {
-  return benchmark->runMedium("plus(c, d)", n);
-}
-
-BENCHMARK_MULTI(plusCheckedMedium, n) {
-  return benchmark->runMedium("checked_plus(c, d)", n);
+BENCHMARK(multiplyOutputAlwaysNullMedium) {
+  benchmark->runMedium("multiply_null_output(a, b)");
 }
 
 BENCHMARK_DRAW_LINE();
+
+BENCHMARK(plusUncheckedMedium) {
+  benchmark->runMedium("plus(c, d)");
+}
+
+BENCHMARK(plusCheckedMedium) {
+  benchmark->runMedium("checked_plus(c, d)");
+}
+
+BENCHMARK_DRAW_LINE();
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(multiplyLarge, n) {
-  return benchmark->runLarge("multiply(a, b)", n);
+BENCHMARK(multiplyLarge) {
+  benchmark->runLarge("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplySameColumnLarge, n) {
-  return benchmark->runLarge("multiply(a, a)", n);
+BENCHMARK(multiplySameColumnLarge) {
+  benchmark->runLarge("multiply(a, a)");
 }
 
-BENCHMARK_MULTI(multiplyHalfNullLarge, n) {
-  return benchmark->runLarge("multiply(a, half_null)", n);
+BENCHMARK(multiplyHalfNullLarge) {
+  benchmark->runLarge("multiply(a, half_null)");
 }
 
-BENCHMARK_MULTI(multiplyConstantLarge, n) {
-  return benchmark->runLarge("multiply(a, constant)", n);
+BENCHMARK(multiplyConstantLarge) {
+  benchmark->runLarge("multiply(a, constant)");
 }
 
-BENCHMARK_MULTI(multiplyNestedLarge, n) {
-  return benchmark->runLarge("multiply(multiply(a, b), b)", n);
+BENCHMARK(multiplyNestedLarge) {
+  benchmark->runLarge("multiply(multiply(a, b), b)");
 }
 
-BENCHMARK_MULTI(multiplyNestedDeepLarge, n) {
-  return benchmark->runLarge(
+BENCHMARK(multiplyNestedDeepLarge) {
+  benchmark->runLarge(
       "multiply(multiply(multiply(a, b), a), "
-      "multiply(a, multiply(a, b)))",
-      n);
+      "multiply(a, multiply(a, b)))");
 }
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(multiplyOutputVoidLarge, n) {
-  return benchmark->runLarge("multiply(a, b)", n);
+BENCHMARK(multiplyOutputVoidLarge) {
+  benchmark->runLarge("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputNullableLarge, n) {
-  return benchmark->runLarge("multiply_nullable_output(a, b)", n);
+BENCHMARK(multiplyOutputNullableLarge) {
+  benchmark->runLarge("multiply_nullable_output(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputAlwaysNullLarge, n) {
-  return benchmark->runLarge("multiply_null_output(a, b)", n);
+BENCHMARK(multiplyOutputAlwaysNullLarge) {
+  benchmark->runLarge("multiply_null_output(a, b)");
 }
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(plusUncheckedLarge, n) {
-  return benchmark->runLarge("plus(c, d)", n);
+BENCHMARK(plusUncheckedLarge) {
+  benchmark->runLarge("plus(c, d)");
 }
 
-BENCHMARK_MULTI(plusCheckedLarge, n) {
-  return benchmark->runLarge("checked_plus(c, d)", n);
+BENCHMARK(plusCheckedLarge) {
+  benchmark->runLarge("checked_plus(c, d)");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Add a compile time options that determine what is the reported time when running the benchmark.
meta internal tools requires that runtime>>ns, hence will use a binary that
reports total runtime.

// runtime normalized:
```
============================================================================
[...]benchmarks/basic/SimpleArithmetic.cpp     relative  time/iter   iters/s
============================================================================
multiplySmall                                               6.95ns   143.98M
multiplySameColumnSmall                                     6.62ns   151.10M
multiplyHalfNullSmall                                      12.82ns    77.99M
multiplyConstantSmall                                       8.39ns   119.15M
multiplyNestedSmall                                        10.16ns    98.41M
multiplyNestedDeepSmall                                    18.90ns    52.91M
----------------------------------------------------------------------------
multiplyOutputVoidSmall                                     6.92ns   144.52M
multiplyOutputNullableSmall                                 6.86ns   145.67M
multiplyOutputAlwaysNullSmall                              10.01ns    99.92M
----------------------------------------------------------------------------
plusUncheckedSmall                                         26.80ns    37.32M
plusCheckedSmall                                           28.77ns    34.76M
----------------------------------------------------------------------------
----------------------------------------------------------------------------
multiplyMedium                                            538.80ps     1.86G
multiplySameColumnMedium                                  380.42ps     2.63G
multiplyHalfNullMedium                                      1.50ns   664.87M
multiplyConstantMedium                                    427.08ps     2.34G
multiplyNestedMedium                                        1.51ns   661.63M
multiplyNestedDeepMedium                                    2.84ns   351.89M
----------------------------------------------------------------------------
multiplyOutputVoidMedium                                  589.71ps     1.70G
multiplyOutputNullableMedium                              515.32ps     1.94G
multiplyOutputAlwaysNullMedium                              2.28ns   437.77M
----------------------------------------------------------------------------
plusUncheckedMedium                                        12.44ns    80.40M
plusCheckedMedium                                          14.01ns    71.40M
----------------------------------------------------------------------------
----------------------------------------------------------------------------
multiplyLarge                                              44.00ps    22.73G
multiplySameColumnLarge                                     0.00fs  Infinity
multiplyHalfNullLarge                                     572.23ps     1.75G
multiplyConstantLarge                                       0.00fs  Infinity
multiplyNestedLarge                                       799.00ps     1.25G
multiplyNestedDeepLarge                                     1.62ns   616.44M
----------------------------------------------------------------------------
multiplyOutputVoidLarge                                    27.71ps    36.09G
multiplyOutputNullableLarge                                23.19ps    43.12G
multiplyOutputAlwaysNullLarge                               1.58ns   632.95M
----------------------------------------------------------------------------
plusUncheckedLarge                                         11.65ns    85.83M
plusCheckedLarge                                           13.26ns    75.41M
```

// total runtime
```
============================================================================
[...]benchmarks/basic/SimpleArithmetic.cpp     relative  time/iter   iters/s
============================================================================
multiplySmall                                               7.45ms    134.17
multiplySameColumnSmall                                     7.23ms    138.27
multiplyHalfNullSmall                                      12.57ms     79.52
multiplyConstantSmall                                       8.73ms    114.53
multiplyNestedSmall                                        10.93ms     91.47
multiplyNestedDeepSmall                                    20.39ms     49.03
----------------------------------------------------------------------------
multiplyOutputVoidSmall                                     7.62ms    131.25
multiplyOutputNullableSmall                                 7.46ms    134.12
multiplyOutputAlwaysNullSmall                              10.55ms     94.74
----------------------------------------------------------------------------
plusUncheckedSmall                                         27.32ms     36.61
plusCheckedSmall                                           29.54ms     33.86
----------------------------------------------------------------------------
----------------------------------------------------------------------------
multiplyMedium                                              1.08ms    925.86
multiplySameColumnMedium                                  855.87us     1.17K
multiplyHalfNullMedium                                      2.10ms    475.39
multiplyConstantMedium                                    947.26us     1.06K
multiplyNestedMedium                                        1.89ms    529.53
multiplyNestedDeepMedium                                    3.53ms    283.54
----------------------------------------------------------------------------
multiplyOutputVoidMedium                                    1.04ms    965.16
multiplyOutputNullableMedium                              983.85us     1.02K
multiplyOutputAlwaysNullMedium                              2.80ms    356.71
----------------------------------------------------------------------------
plusUncheckedMedium                                        12.76ms     78.35
plusCheckedMedium                                          14.67ms     68.17
----------------------------------------------------------------------------
----------------------------------------------------------------------------
multiplyLarge                                             459.70us     2.18K
multiplySameColumnLarge                                   386.83us     2.59K
multiplyHalfNullLarge                                       1.09ms    918.51
multiplyConstantLarge                                     397.43us     2.52K
multiplyNestedLarge                                         1.34ms    748.28
multiplyNestedDeepLarge                                     2.15ms    464.98
----------------------------------------------------------------------------
multiplyOutputVoidLarge                                   461.35us     2.17K
multiplyOutputNullableLarge                               456.30us     2.19K
multiplyOutputAlwaysNullLarge                               2.11ms    474.93
----------------------------------------------------------------------------
plusUncheckedLarge                                         11.35ms     88.13
plusCheckedLarge                                           13.08ms     76.47
```

Differential Revision: D41229555

