### PR TITLE
Add method to access parent memory pool

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -144,6 +144,10 @@ const std::string& MemoryPool::name() const {
   return name_;
 }
 
+MemoryPool* MemoryPool::parent() const {
+  return parent_.get();
+}
+
 uint64_t MemoryPool::getChildCount() const {
   folly::SharedMutex::ReadHolder guard{childrenMutex_};
   return children_.size();


### PR DESCRIPTION
Add method to access parent memory pool to enable
trigger memory threshold based spilling for hash join
build operators.
Also improve the comment for memory pool a bit.