### PR TITLE
Move toTypeSql to Type.h from CastExpr.cpp

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -210,18 +210,7 @@ std::string makeCreateTableSql(
       sql << ", ";
     }
     sql << rowType.nameOf(i) << " ";
-    auto child = rowType.childAt(i);
-    if (child->isArray()) {
-      sql << child->asArray().elementType()->kindName() << "[]";
-    } else if (child->isMap()) {
-      sql << "MAP(" << child->asMap().keyType()->kindName() << ", "
-          << child->asMap().valueType()->kindName() << ")";
-    } else if (child->isShortDecimal() || child->isLongDecimal()) {
-      const auto& [precision, scale] = getDecimalPrecisionScale(*child);
-      sql << "DECIMAL(" << precision << ", " << scale << ")";
-    } else {
-      sql << child->kindName();
-    }
+    toTypeSql(rowType.childAt(i), sql);
   }
   sql << ")";
   return sql.str();

--- a/velox/duckdb/conversion/tests/DuckConversionTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckConversionTest.cpp
@@ -127,3 +127,44 @@ TEST(DuckConversionTest, types) {
   testRoundTrip(ROW(
       {"a", "b", "c"}, {BIGINT(), ARRAY(DOUBLE()), MAP(BIGINT(), VARCHAR())}));
 }
+
+TEST(DuckConversionTest, createTable) {
+  ::duckdb::DuckDB db_;
+  ::duckdb::Connection con(db_);
+
+  auto testCreateTable = [&](const RowTypePtr& rowType) {
+    auto result = con.Query("DROP TABLE IF EXISTS t");
+    VELOX_CHECK(result->success, "{}", result->error);
+
+    result = con.Query(makeCreateTableSql("t", *rowType));
+    VELOX_CHECK(result->success, "{}", result->error);
+  };
+
+  testCreateTable(
+      ROW({"b", "i8", "i16", "i32", "i64", "r", "d"},
+          {BOOLEAN(),
+           TINYINT(),
+           INTEGER(),
+           SMALLINT(),
+           BIGINT(),
+           REAL(),
+           DOUBLE()}));
+
+  testCreateTable(
+      ROW({"a", "b", "c"}, {TIMESTAMP(), DATE(), INTERVAL_DAY_TIME()}));
+
+  testCreateTable(ROW({"a", "b"}, {DECIMAL(7, 5), DECIMAL(30, 10)}));
+
+  testCreateTable(ROW({"a", "b"}, {ARRAY(BIGINT()), ARRAY(ARRAY(DOUBLE()))}));
+
+  testCreateTable(ROW(
+      {"a", "b"}, {MAP(BIGINT(), DOUBLE()), MAP(VARCHAR(), ARRAY(BIGINT()))}));
+
+  testCreateTable(
+      ROW({"a", "b"},
+          {
+              ROW({"x", "y"}, {BIGINT(), ARRAY(DOUBLE())}),
+              ROW({"x", "y", "z"},
+                  {ARRAY(INTEGER()), MAP(INTEGER(), VARCHAR()), TIMESTAMP()}),
+          }));
+}

--- a/velox/dwio/type/fbhive/tests/HiveTypeParserTests.cpp
+++ b/velox/dwio/type/fbhive/tests/HiveTypeParserTests.cpp
@@ -64,7 +64,7 @@ TEST(FbHive, shortDecimal) {
   auto type = t->asShortDecimal();
   ASSERT_EQ(type.precision(), 10);
   ASSERT_EQ(type.scale(), 5);
-  ASSERT_EQ(t->toString(), "SHORT_DECIMAL(10,5)");
+  ASSERT_EQ(t->toString(), "DECIMAL(10,5)");
 }
 
 TEST(FbHive, longDecimal) {
@@ -74,7 +74,7 @@ TEST(FbHive, longDecimal) {
   auto type = t->asLongDecimal();
   ASSERT_EQ(type.precision(), 20);
   ASSERT_EQ(type.scale(), 5);
-  ASSERT_EQ(t->toString(), "LONG_DECIMAL(20,5)");
+  ASSERT_EQ(t->toString(), "DECIMAL(20,5)");
 }
 
 TEST(FbHive, list) {

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -546,7 +546,7 @@ TEST_F(PlanNodeToStringTest, decimalConstant) {
                   .planNode();
 
   ASSERT_EQ(
-      "-- Project[expressions: (a:VARCHAR, ROW[\"a\"]), (p1:SHORT_DECIMAL(4,3), 1.234)] -> a:VARCHAR, p1:SHORT_DECIMAL(4,3)\n",
+      "-- Project[expressions: (a:VARCHAR, ROW[\"a\"]), (p1:DECIMAL(4,3), 1.234)] -> a:VARCHAR, p1:DECIMAL(4,3)\n",
       plan->toString(true));
 }
 

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -694,50 +694,6 @@ std::string CastExpr::toString(bool recursive) const {
   return out.str();
 }
 
-namespace {
-
-/// Appends type's SQL string to 'out'. Uses DuckDB SQL.
-void toTypeSql(const TypePtr& type, std::ostream& out) {
-  if (type->isPrimitiveType()) {
-    out << type->toString();
-    return;
-  }
-
-  switch (type->kind()) {
-    case TypeKind::ARRAY:
-      // Append <type>[], e.g. bigint[].
-      toTypeSql(type->childAt(0), out);
-      out << "[]";
-      break;
-    case TypeKind::MAP:
-      // Append map(<key>, <value>), e.g. map(varchar, bigint).
-      out << "map(";
-      toTypeSql(type->childAt(0), out);
-      out << ", ";
-      toTypeSql(type->childAt(1), out);
-      out << ")";
-      break;
-    case TypeKind::ROW: {
-      // Append struct(name1 type1, name2 type2,..), e.g.
-      // struct(a bigint, b real);
-      const auto& rowType = type->asRow();
-      out << "struct(";
-      for (auto i = 0; i < type->size(); ++i) {
-        if (i > 0) {
-          out << ", ";
-        }
-        out << rowType.nameOf(i) << " ";
-        toTypeSql(type->childAt(i), out);
-      }
-      out << ")";
-      break;
-    }
-    default:
-      VELOX_UNSUPPORTED("Type is not supported: {}", type->toString());
-  }
-}
-} // namespace
-
 std::string CastExpr::toSql(std::vector<VectorPtr>* complexConstants) const {
   std::stringstream out;
   out << "cast(";

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -123,7 +123,8 @@ TEST_F(ComparisonsTest, betweenDecimal) {
   // Comparing LONG_DECIMAL and SHORT_DECIMAL must throw error.
   VELOX_ASSERT_THROW(
       runAndCompare("c0 between 2.00 and 3.00", longFlat, expectedResult),
-      "Scalar function signature is not supported: between(LONG_DECIMAL(20,2), SHORT_DECIMAL(3,2), SHORT_DECIMAL(3,2)).");
+      "Scalar function signature is not supported: "
+      "between(DECIMAL(20,2), DECIMAL(3,2), DECIMAL(3,2)).");
 }
 
 TEST_F(ComparisonsTest, eqDecimal) {
@@ -149,8 +150,8 @@ TEST_F(ComparisonsTest, eqDecimal) {
       makeShortDecimalFlatVector({1}, DECIMAL(10, 4))};
   VELOX_ASSERT_THROW(
       runAndCompare(inputs, expected),
-      "Scalar function signature is not supported: eq(SHORT_DECIMAL(10,5),"
-      " SHORT_DECIMAL(10,4))");
+      "Scalar function signature is not supported: "
+      "eq(DECIMAL(10,5), DECIMAL(10,4))");
 }
 
 TEST_F(ComparisonsTest, gtLtDecimal) {

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -834,4 +834,44 @@ TypePtr fromKindToScalerType(TypeKind kind) {
   }
 }
 
+void toTypeSql(const TypePtr& type, std::ostream& out) {
+  if (type->isPrimitiveType()) {
+    out << type->toString();
+    return;
+  }
+
+  switch (type->kind()) {
+    case TypeKind::ARRAY:
+      // Append <type>[], e.g. bigint[].
+      toTypeSql(type->childAt(0), out);
+      out << "[]";
+      break;
+    case TypeKind::MAP:
+      // Append map(<key>, <value>), e.g. map(varchar, bigint).
+      out << "map(";
+      toTypeSql(type->childAt(0), out);
+      out << ", ";
+      toTypeSql(type->childAt(1), out);
+      out << ")";
+      break;
+    case TypeKind::ROW: {
+      // Append struct(name1 type1, name2 type2,..), e.g.
+      // struct(a bigint, b real);
+      const auto& rowType = type->asRow();
+      out << "struct(";
+      for (auto i = 0; i < type->size(); ++i) {
+        if (i > 0) {
+          out << ", ";
+        }
+        out << rowType.nameOf(i) << " ";
+        toTypeSql(type->childAt(i), out);
+      }
+      out << ")";
+      break;
+    }
+    default:
+      VELOX_UNSUPPORTED("Type is not supported: {}", type->toString());
+  }
+}
+
 } // namespace facebook::velox

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -650,7 +650,7 @@ class DecimalType : public ScalarType<KIND> {
   }
 
   std::string toString() const override {
-    return fmt::format("{}({},{})", TypeTraits<KIND>::name, precision_, scale_);
+    return fmt::format("DECIMAL({},{})", precision_, scale_);
   }
 
   folly::dynamic serialize() const override {
@@ -1980,6 +1980,9 @@ struct CastTypeChecker<Row<T...>> {
 
 /// Return the scalar type for a given 'kind'.
 TypePtr fromKindToScalerType(TypeKind kind);
+
+/// Appends type's SQL string to 'out'. Uses DuckDB SQL.
+void toTypeSql(const TypePtr& type, std::ostream& out);
 
 } // namespace facebook::velox
 

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -134,7 +134,7 @@ TEST(TypeTest, intervalDayTime) {
 
 TEST(TypeTest, shortDecimal) {
   auto shortDecimal = SHORT_DECIMAL(10, 5);
-  EXPECT_EQ(shortDecimal->toString(), "SHORT_DECIMAL(10,5)");
+  EXPECT_EQ(shortDecimal->toString(), "DECIMAL(10,5)");
   EXPECT_EQ(shortDecimal->size(), 0);
   EXPECT_THROW(shortDecimal->childAt(0), std::invalid_argument);
   EXPECT_EQ(shortDecimal->kind(), TypeKind::SHORT_DECIMAL);
@@ -153,7 +153,7 @@ TEST(TypeTest, shortDecimal) {
 
 TEST(TypeTest, longDecimal) {
   auto longDecimal = LONG_DECIMAL(30, 5);
-  EXPECT_EQ(longDecimal->toString(), "LONG_DECIMAL(30,5)");
+  EXPECT_EQ(longDecimal->toString(), "DECIMAL(30,5)");
   EXPECT_EQ(longDecimal->size(), 0);
   EXPECT_THROW(longDecimal->childAt(0), std::invalid_argument);
   EXPECT_EQ(longDecimal->kind(), TypeKind::LONG_DECIMAL);

--- a/velox/vector/tests/VectorToStringTest.cpp
+++ b/velox/vector/tests/VectorToStringTest.cpp
@@ -107,7 +107,7 @@ TEST_F(VectorToStringTest, decimals) {
       {1000265, 35610, -314159, 7, 0}, DECIMAL(10, 3));
   ASSERT_EQ(
       shortDecimalFlatVector->toString(),
-      "[FLAT SHORT_DECIMAL(10,3): 5 elements, no nulls]");
+      "[FLAT DECIMAL(10,3): 5 elements, no nulls]");
   ASSERT_EQ(
       shortDecimalFlatVector->toString(0, 5),
       "0: 1000.265\n"
@@ -120,7 +120,7 @@ TEST_F(VectorToStringTest, decimals) {
       {1000265, 35610, -314159, 7, 0}, DECIMAL(20, 4));
   ASSERT_EQ(
       longDecimalFlatVector->toString(),
-      "[FLAT LONG_DECIMAL(20,4): 5 elements, no nulls]");
+      "[FLAT DECIMAL(20,4): 5 elements, no nulls]");
   ASSERT_EQ(
       longDecimalFlatVector->toString(0, 5),
       "0: 100.0265\n"
@@ -135,7 +135,7 @@ TEST_F(VectorToStringTest, nullableDecimals) {
       {1000265, 35610, -314159, 7, std::nullopt}, DECIMAL(10, 3));
   ASSERT_EQ(
       shortDecimalFlatVector->toString(),
-      "[FLAT SHORT_DECIMAL(10,3): 5 elements, 1 nulls]");
+      "[FLAT DECIMAL(10,3): 5 elements, 1 nulls]");
   ASSERT_EQ(
       shortDecimalFlatVector->toString(0, 5),
       "0: 1000.265\n"
@@ -148,7 +148,7 @@ TEST_F(VectorToStringTest, nullableDecimals) {
       {1000265, 35610, -314159, 7, std::nullopt}, DECIMAL(20, 4));
   ASSERT_EQ(
       longDecimalFlatVector->toString(),
-      "[FLAT LONG_DECIMAL(20,4): 5 elements, 1 nulls]");
+      "[FLAT DECIMAL(20,4): 5 elements, 1 nulls]");
   ASSERT_EQ(
       longDecimalFlatVector->toString(0, 5),
       "0: 100.0265\n"


### PR DESCRIPTION
Also,
- Use toTypeSql(type) helper function in makeCreateTableSql to allow
 creating DuckDB tables with nested complex types.
- Fix toTypeSql() for decimal types.