### PR TITLE
Remove neq from Fuzzer's skip list

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
       // cardinality passing a VARBINARY (since HLL's implementation uses an
       // alias to VARBINARY).
       "cardinality",
-      "neq"};
+  };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(
       FLAGS_only, initialSeed, skipFunctions, FLAGS_special_forms);


### PR DESCRIPTION
There is no GitHub issue attached to neq function in the skip list, hence, it is
not clear why it was added in the first place. Removing the function from the
skip list and running the fuzzer doesn't result in an error.  