### PR TITLE
Add pr_number to Conbench GitHub info

### DIFF
--- a/scripts/veloxbench/veloxbench/_benchmark.py
+++ b/scripts/veloxbench/veloxbench/_benchmark.py
@@ -31,8 +31,12 @@ def _now_formatted() -> str:
 
 
 def github_info(velox_info: Dict[str, Any]) -> Dict[str, Any]:
+    pr_number_env = os.getenv("CIRCLE_PR_NUMBER", "")
+    pr_number = int(pr_number_env) if pr_number_env else None
+
     return {
         "repository": "https://github.com/facebookincubator/velox",
+        "pr_number": pr_number,
         "commit": velox_info["velox_git_revision"],
     }
 


### PR DESCRIPTION
This PR passes the Velox PR number to Conbench in the github info dict. This will enable better Conbench history tracking.