### PR TITLE
Fix ci error in hdfs write unit test

### DIFF
--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsWriteFile.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsWriteFile.cpp
@@ -49,6 +49,11 @@ void HdfsWriteFile::close() {
 }
 
 void HdfsWriteFile::flush() {
+  // Check Whether the file is opened for write.
+  VELOX_CHECK_EQ(
+      hdfsFileIsOpenForWrite(hdfsFile_),
+      1,
+      "Flush failure in HdfsWriteFile::flush as the file is not opened");
   int success = hdfsFlush(hdfsClient_, hdfsFile_);
   VELOX_CHECK_EQ(
       success, 0, "Hdfs flush error: {}", std::string(hdfsGetLastError()));
@@ -58,6 +63,11 @@ void HdfsWriteFile::append(std::string_view data) {
   if (data.size() == 0) {
     return;
   }
+  // Check Whether the file is opened for write.
+  VELOX_CHECK_EQ(
+      hdfsFileIsOpenForWrite(hdfsFile_),
+      1,
+      "Write failure in HdfsWriteFile::append as the file is not opened");
   int64_t totalWrittenBytes =
       hdfsWrite(hdfsClient_, hdfsFile_, std::string(data).c_str(), data.size());
   VELOX_CHECK_EQ(

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
@@ -383,14 +383,16 @@ TEST_F(HdfsFileSystemTest, missingFileForWrite) {
 }
 
 TEST_F(HdfsFileSystemTest, writeDataFailures) {
-  const std::string errorMsg = "Write failure in HDFSWriteFile::append";
+  const std::string errorMsg =
+      "Write failure in HdfsWriteFile::append as the file is not opened";
   auto writeFile = openFileForWrite("/a.txt");
   writeFile->close();
   VELOX_ASSERT_THROW(writeFile->append("abcde"), errorMsg);
 }
 
 TEST_F(HdfsFileSystemTest, writeFlushFailures) {
-  const std::string errorMsg = "Hdfs flush error";
+  const std::string errorMsg =
+      "Flush failure in HdfsWriteFile::flush as the file is not opened";
   auto writeFile = openFileForWrite("/a.txt");
   writeFile->close();
   VELOX_ASSERT_THROW(writeFile->flush(), errorMsg);


### PR DESCRIPTION
Fix ci error in hdfs write test descibed in issue#3237, check whether the hdfs file is open while before write/append and modify the  unit test