### PR TITLE
Ensure slice() does not generate overlapping ranges

### DIFF
--- a/velox/functions/prestosql/Slice.cpp
+++ b/velox/functions/prestosql/Slice.cpp
@@ -69,6 +69,14 @@ class SliceFunction : public exec::VectorFunction {
         args[2]->typeKind(),
         "Function slice() requires start and length to be the same type");
 
+    // If the 2nd and 3rd parameters are not constants, we need to ensure that
+    // the 1st parameter is not a constant, so slice() doesn't generate
+    // overlapping ranges. To prevent this, we flatten the first parameter in
+    // these cases.
+    if (!args[1]->isConstantEncoding() || !args[2]->isConstantEncoding()) {
+      BaseVector::flattenVector(args[0], args[0]->size());
+    }
+
     VectorPtr localResult =
         applyArray<int64_t>(rows, args, context, outputType);
     context.moveOrCopyResult(localResult, rows, result);

--- a/velox/functions/prestosql/tests/SliceTest.cpp
+++ b/velox/functions/prestosql/tests/SliceTest.cpp
@@ -32,9 +32,9 @@ class SliceTest : public FunctionBaseTest {
       const ArrayVectorPtr& expectedArrayVector) {
     auto result = evaluate<ArrayVector>(expression, makeRowVector(parameters));
     assertEqualVectors(expectedArrayVector, result);
+    assertNoOverlappingRanges(result);
   }
 };
-} // namespace
 
 TEST_F(SliceTest, prestoTestCases) {
   {
@@ -249,6 +249,26 @@ TEST_F(SliceTest, variableInputArray) {
         {arrayVector, startsVector, lengthsVector},
         expectedArrayVector);
   }
+
+  // Tests constant arrays a non-constant starts and lengths.
+  {
+    auto startsVector = makeFlatVector<int64_t>(
+        kVectorSize, [](vector_size_t /*row*/) { return 2; });
+    auto lengthsVector = makeFlatVector<int64_t>(
+        kVectorSize, [](vector_size_t /*row*/) { return 2; });
+    auto arrayVector = makeConstantArray<int64_t>(kVectorSize, {99, 100, 101});
+
+    auto expectedSizeAt = [](vector_size_t row) { return 2; };
+    auto expectedValueAt = [](vector_size_t row, vector_size_t idx) {
+      return idx == 0 ? 100 : 101;
+    };
+    auto expectedArrayVector =
+        makeArrayVector<int64_t>(kVectorSize, expectedSizeAt, expectedValueAt);
+    testSlice(
+        "slice(C0, C1, C2)",
+        {arrayVector, startsVector, lengthsVector},
+        expectedArrayVector);
+  }
 }
 
 TEST_F(SliceTest, varcharVariableInput) {
@@ -385,3 +405,5 @@ TEST_F(SliceTest, negativeSliceLength) {
       },
       "The value of length argument of slice() function should not be negative");
 }
+
+} // namespace

--- a/velox/vector/tests/utils/VectorTestBase.cpp
+++ b/velox/vector/tests/utils/VectorTestBase.cpp
@@ -116,4 +116,24 @@ void assertCopyableVector(const VectorPtr& vector) {
   copy->copy(vector.get(), 0, 0, vector->size());
 }
 
+void assertNoOverlappingRanges(const ArrayVectorPtr& arrayVector) {
+  std::unordered_map<vector_size_t, vector_size_t> seenElements;
+  seenElements.reserve(arrayVector->elements()->size());
+
+  for (vector_size_t i = 0; i < arrayVector->size(); ++i) {
+    auto size = arrayVector->sizeAt(i);
+    auto offset = arrayVector->offsetAt(i);
+
+    for (vector_size_t j = 0; j < size; ++j) {
+      auto it = seenElements.find(offset + j);
+      ASSERT_EQ(it, seenElements.end())
+          << "found overlap at idx " << offset + j << ": element " << it->second
+          << " has offset " << arrayVector->offsetAt(it->second) << " and size "
+          << arrayVector->sizeAt(it->second) << ", and element " << i
+          << " has offset " << offset << " and size " << size << ".";
+      seenElements.emplace(offset + j, i);
+    }
+  }
+}
+
 } // namespace facebook::velox::test

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -34,6 +34,10 @@ void assertEqualVectors(const VectorPtr& expected, const VectorPtr& actual);
 /// Verify that 'vector' is copyable, by copying all rows.
 void assertCopyableVector(const VectorPtr& vector);
 
+/// Verify that an ArrayVector does not contain overlapping [offset, size]
+/// ranges.
+void assertNoOverlappingRanges(const ArrayVectorPtr& arrayVector);
+
 class VectorTestBase {
  protected:
   VectorTestBase() {


### PR DESCRIPTION
Summary:
In cases where the first parameter is a constant, but not the second
or third, slice() was generating overlapping (offset, size) ranges, which ends
up breaking other functions upstream that rely on the fact that array elements
do not overlap (like reverse). To prevent these cases, flatten the constant input.

Differential Revision: D41330251

