### PR TITLE
Disable spilling for distinct aggregation and pre-grouped aggregation

### DIFF
--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -216,8 +216,8 @@ class GroupingSet {
   /// First row in remainingInput_ that needs to be processed.
   vector_size_t firstRemainingRow_;
 
-  /// The value of mayPushdown flag specified in addInput() for the
-  /// 'remainingInput_'.
+  // The value of mayPushdown flag specified in addInput() for the
+  // 'remainingInput_'.
   bool remainingMayPushdown_;
 
   std::unique_ptr<Spiller> spiller_;

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -52,19 +52,27 @@ class HashAggregation : public Operator {
   }
 
  private:
+  // Checks if the spilling is allowed for this hash aggregation. As for now, we
+  // don't allow spilling for distinct aggregation
+  // (https://github.com/facebookincubator/velox/issues/3263) and pre-grouped
+  // aggregation (https://github.com/facebookincubator/velox/issues/3264). We
+  // will add support later to re-enable.
+  bool isSpillAllowed(
+      const std::shared_ptr<const core::AggregationNode>& node) const;
+
   void prepareOutput(vector_size_t size);
 
-  /// Invoked to reset partial aggregation state if it was full and has been
-  /// flushed.
+  // Invoked to reset partial aggregation state if it was full and has been
+  // flushed.
   void resetPartialOutputIfNeed();
 
-  /// Invoked on partial output flush to try to bump up the partial aggregation
-  /// memory usage if it needs. 'aggregationPct' is the ratio between the number
-  /// of output rows and the number of input rows as a percentage. It is a
-  /// measure of the effectiveness of the partial aggregation.
+  // Invoked on partial output flush to try to bump up the partial aggregation
+  // memory usage if it needs. 'aggregationPct' is the ratio between the number
+  // of output rows and the number of input rows as a percentage. It is a
+  // measure of the effectiveness of the partial aggregation.
   void maybeIncreasePartialAggregationMemoryUsage(double aggregationPct);
 
-  /// Maximum number of rows in the output batch.
+  // Maximum number of rows in the output batch.
   const uint32_t outputBatchSize_;
 
   const bool isPartialOutput_;

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -476,7 +476,7 @@ void HashTable<ignoreNullKeys>::arrayGroupProbe(HashLookup& lookup) {
   for (; i < numProbes; ++i) {
     auto row = rows[i];
     uint64_t index = hashes[row];
-    VELOX_DCHECK(index < size_);
+    VELOX_DCHECK_LT(index, size_);
     char* group = table_[index];
     if (UNLIKELY(!group)) {
       group = insertEntry(lookup, index, row);

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -70,6 +70,10 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   }
 
   numSplits += stats.numSplits;
+
+  spilledBytes += stats.spilledBytes;
+  spilledRows += stats.spilledRows;
+  spilledPartitions += stats.spilledPartitions;
 }
 
 std::string PlanNodeStats::toString(bool includeInputStats) const {

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -99,6 +99,15 @@ struct PlanNodeStats {
   /// Number of total splits.
   int numSplits{0};
 
+  /// Total bytes written for spilling.
+  uint64_t spilledBytes{0};
+
+  /// Total rows written for spilling.
+  uint64_t spilledRows{0};
+
+  /// Total spilled partitions.
+  uint32_t spilledPartitions{0};
+
   /// Add stats for a single operator instance.
   void add(const OperatorStats& stats);
 


### PR DESCRIPTION
Spilling for distinct aggregation has following problem:
The current implementation for distinct aggregation has assumption
that all the groups are kept in the hash table for the entire processing
so we can start yielding result immediately and output the new distinct
groups as new groups inserted in hash table. This assumption is no longer
true with spilling enabled. As we might turn on spilling in the middle of
input processing, there is no way to tell if a new inserted group is new 
distinct group or not as the hash table only holds a subset of groups. 
The proposed solution is described in [3263](https://github.com/facebookincubator/velox/issues/3263)

Spilling for pre-grouped keys has following problem:
The current pre-grouped key hash aggregation implementation starts to
yield aggregation result once after it processed all the input rows with
the same pre-grouped keys. It works like streaming aggregation and won't
hold much in-memory state. But in rare case that some particular
pre-grouped keys has very large number of rows, it can still trigger spilling.
Once it happens, we can not simply yield the result after process all the rows
with the same pre-grouped keys as the spilling is triggered in the middle of
row stream.
The proposed solution is described in [3264](https://github.com/facebookincubator/velox/issues/3264)

This PR disable the spilling for the above two hash aggregation use cases
and add unit tests to cover.