### PR TITLE
Fix reverseUnicode

### DIFF
--- a/velox/functions/lib/string/StringCore.h
+++ b/velox/functions/lib/string/StringCore.h
@@ -71,7 +71,7 @@ reverseUnicode(char* output, const char* input, size_t length) {
   auto inputIdx = 0;
   auto outputIdx = length;
   while (inputIdx < length) {
-    int size;
+    int size = 1;
     utf8proc_codepoint(&input[inputIdx], size);
     // invalid utf8 gets byte sequence with nextCodePoint==-1 and size==1,
     // continue reverse invalid sequence byte by byte.


### PR DESCRIPTION
Summary:
`size` is left uninitialized if the code point is invalid.  Assign to 1
to achieve byte by byte reversion.

Differential Revision: D41319511

