### PR TITLE
Prevent approx_most_frequent from crashing due to large buckets

### DIFF
--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -49,11 +49,7 @@ int main(int argc, char** argv) {
 
   // TODO: List of the functions that at some point crash or fail and need to
   // be fixed before we can enable.
-  std::unordered_set<std::string> skipFunctions = {
-      // approx_most_frequent crashes:
-      // https://github.com/facebookincubator/velox/issues/3101
-      "approx_most_frequent",
-  };
+  std::unordered_set<std::string> skipFunctions = {};
 
   // The results of the following functions depend on the order of input
   // rows. For some functions, the result can be transformed to a value that

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -105,22 +105,27 @@ struct ApproxMostFrequentAggregate : exec::Aggregate {
       }
       return;
     }
+    VELOX_USER_CHECK_LE(buckets_, std::numeric_limits<int>::max());
     auto mapVector = (*result)->as<MapVector>();
     auto [keys, values] = prepareFinalResult(groups, numGroups, mapVector);
     vector_size_t entryCount = 0;
-    std::vector<std::pair<T, int64_t>> tmp(buckets_);
     for (int i = 0; i < numGroups; ++i) {
       auto summary = value<StreamSummary>(groups[i]);
       int size = std::min<int>(buckets_, summary->size());
       if (size == 0) {
         mapVector->setNull(i, true);
       } else {
-        summary->topK(buckets_, tmp.data());
-        for (int j = 0; j < size; ++j) {
-          keys->set(entryCount, tmp[j].first);
-          values->set(entryCount, tmp[j].second);
-          ++entryCount;
+        summary->topK(
+            buckets_,
+            keys->mutableRawValues() + entryCount,
+            values->mutableRawValues() + entryCount);
+        if constexpr (std::is_same_v<T, StringView>) {
+          // Populate the string buffers.
+          for (int j = 0; j < size; ++j) {
+            keys->set(entryCount + j, keys->valueAtFast(entryCount + j));
+          }
         }
+        entryCount += size;
       }
       mapVector->setOffsetAndSize(i, entryCount - size, size);
     }
@@ -209,7 +214,7 @@ struct ApproxMostFrequentAggregate : exec::Aggregate {
       const char* name,
       int64_t& val,
       const DecodedVector& vec) {
-    VELOX_CHECK(
+    VELOX_USER_CHECK(
         vec.isConstantMapping(),
         "{} argument must be constant for all input rows",
         name);
@@ -218,6 +223,7 @@ struct ApproxMostFrequentAggregate : exec::Aggregate {
 
   StreamSummary* initSummary(char* group) {
     auto summary = value<StreamSummary>(group);
+    VELOX_USER_CHECK_LE(capacity_, std::numeric_limits<int>::max());
     summary->setCapacity(capacity_);
     return summary;
   }


### PR DESCRIPTION
Summary:
In old code we allocate a temporary vector with size equal to the
`buckets` parameter passed by user.  This value can be too large and crash the
process.  As a fix we remove the temporary vector and write directly to the
result buffers.  When allocating the buffers, the memory is capped and will
throw proper exception when this cap is exceeded.

Fix https://github.com/facebookincubator/velox/issues/3101

Differential Revision: D41311599

