### PR TITLE
Fix indicesOfSetBits skipping the first word if begin is multiple of 64

### DIFF
--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -186,7 +186,7 @@ int32_t indicesOfSetBits(
       row += 64;
       continue;
     }
-    if (wordIndex == firstWord && begin) {
+    if (wordIndex == firstWord && begin != firstWord * 64) {
       word &= bits::highMask(64 - (begin - firstWord * 64));
       if (!word) {
         row += 64;


### PR DESCRIPTION
Summary:
When `begin` is a multiple of 64, we should not handle the first word as a partial word.

Fix https://github.com/facebookincubator/velox/issues/3255

Differential Revision: D41341484

