### PR TITLE
Fix incorrect result of string concat() when used in IF expression

### DIFF
--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -233,7 +233,10 @@ class ConcatFunction : public exec::VectorFunction {
 
     // Allocate a string buffer.
     auto buffer = flatResult->getBufferWithSpace(totalResultBytes);
-    auto rawBuffer = buffer->asMutable<char>();
+    // getBufferWithSpace() may return a buffer that already has content, so we
+    // only use the space after that.
+    auto rawBuffer = buffer->asMutable<char>() + buffer->size();
+    buffer->setSize(buffer->size() + totalResultBytes);
 
     size_t offset = 0;
     rows.applyToSelected([&](int row) {

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -2081,3 +2081,16 @@ TEST_F(StringFunctionsTest, lpad) {
   EXPECT_EQ("x" + invalidString, lpad(invalidString, 8, "x"));
   EXPECT_EQ(invalidPadString + "abc", lpad("abc", 6, invalidPadString));
 }
+
+TEST_F(StringFunctionsTest, concatInSwitchExpr) {
+  auto data = makeRowVector(
+      {makeFlatVector<bool>({true, false}),
+       makeFlatVector<StringView>(
+           {"This is a long sentence"_sv, "This is some other sentence"_sv})});
+
+  auto result =
+      evaluate("if(c0, concat(c1, '-zzz'), concat('aaa-', c1))", data);
+  auto expected = makeFlatVector<StringView>(
+      {"This is a long sentence-zzz"_sv, "aaa-This is some other sentence"_sv});
+  test::assertEqualVectors(expected, result);
+}


### PR DESCRIPTION
Summary:
There is a bug in the string concat() function that leads to incorrect result when
evaluation `if(c0, concat(...), c1)` or `if(c0, f(c1), concat(...))`.
This bug is a misuse of `FlatVector<StringView>::getBufferWithSpace()`
and causes the else-branch to overwrite the results from the then-branch in the if
expression. Please see https://github.com/facebookincubator/velox/issues/3267 for more detailed explanation.

This diff fixes this bug and adds a unit test.

Reviewed By: mbasmanova

Differential Revision: D41330939

