### PR TITLE
Fix tsan for AsyncDataCache/SsdCache

### DIFF
--- a/velox/common/base/Portability.h
+++ b/velox/common/base/Portability.h
@@ -16,8 +16,12 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <vector>
+
+namespace facebook::velox {
 
 inline size_t count_trailing_zeros(uint64_t x) {
   return x == 0 ? 64 : __builtin_ctzll(x);
@@ -32,3 +36,59 @@ inline size_t count_leading_zeros(uint64_t x) {
 #else
 #define INLINE_LAMBDA
 #endif
+
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define TSAN_BUILD 1
+#endif
+#endif
+
+/// Define tsan_atomic<T> to be std::atomic<T?> for tsan builds and
+/// T otherwise. This allows declaring variables like statistics
+/// counters that do not have to be exact nor have synchronized
+/// semantics. This deals with san errors while not incurring the
+/// bus lock overhead at run time in regular builds.
+#ifdef TSAN_BUILD
+template <typename T>
+using tsan_atomic = std::atomic<T>;
+
+template <typename T>
+inline T tsanAtomicValue(const std::atomic<T>& x) {
+  return x;
+}
+
+/// Lock guard in tsan build and no-op otherwise.
+template <typename T>
+using tsan_lock_guard = std::lock_guard<T>;
+
+#else
+
+template <typename T>
+using tsan_atomic = T;
+
+template <typename T>
+inline T tsanAtomicValue(T x) {
+  return x;
+}
+template <typename T>
+struct TsanEmptyLockGuard {
+  TsanEmptyLockGuard(T& /*ignore*/) {}
+};
+
+template <typename T>
+using tsan_lock_guard = TsanEmptyLockGuard<T>;
+
+#endif
+
+template <typename T>
+inline void resizeTsanAtomic(
+    std::vector<tsan_atomic<T>>& vector,
+    int32_t newSize) {
+  std::vector<tsan_atomic<T>> newVector(newSize);
+  auto numCopy = std::min<int32_t>(newSize, vector.size());
+  for (auto i = 0; i < numCopy; ++i) {
+    newVector[i] = tsanAtomicValue(vector[i]);
+  }
+  vector = std::move(newVector);
+}
+} // namespace facebook::velox

--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -17,7 +17,6 @@
 #include <folly/portability/SysUio.h>
 #include <numeric>
 #include "velox/common/caching/FileIds.h"
-
 #include "velox/common/caching/SsdCache.h"
 #include "velox/common/time/Timer.h"
 


### PR DESCRIPTION
Most counters in caching do not need atomicity. They count cumulative events and are not read with any meaningful synchronization. Some counters reflect access frequency and likewise do not have to be exact. tsan reports an error for all such uses. We introduce the type asan_atomic<T> to make these conditionally atomic when building for tsan.

Copies region scores before writing out.

Manipulates cache entry promises inside the shard's mutex even if entry is exclusively held so that asan does not complain.

Causes common/caching/tests to work with tsan.