### PR TITLE
Fix semi join project with null join keys and empty build side

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -522,6 +522,10 @@ void HashProbe::decodeAndDetectNonNullKeys() {
 void HashProbe::addInput(RowVectorPtr input) {
   input_ = std::move(input);
 
+  if (input_->size() > 0) {
+    noInput_ = false;
+  }
+
   if (canReplaceWithDynamicFilter_) {
     replacedWithDynamicFilter_ = true;
     return;
@@ -654,19 +658,24 @@ void HashProbe::fillOutput(vector_size_t size) {
 
   if (isLeftSemiProjectJoin(joinType_)) {
     // Populate 'match' column.
-    auto match = output_->childAt(outputType_->size() - 1);
-    match->resize(size);
-    auto flatMatch = match->as<FlatVector<bool>>();
-    auto rawValues = flatMatch->mutableRawValues<uint64_t>();
-    for (auto i = 0; i < size; ++i) {
-      if (!nonNullInputRows_.isValid(i)) {
-        flatMatch->setNull(i, true);
-      } else {
-        bool hasMatch = outputTableRows_[i] != nullptr;
-        if (!hasMatch && buildSideHasNullKeys_) {
+    if (emptyBuildSide()) {
+      // Build side is empty. All rows should return 'match = false', even ones
+      // with a null join key.
+      matchColumn() = BaseVector::createConstant(false, size, pool());
+    } else {
+      auto flatMatch = matchColumn()->as<FlatVector<bool>>();
+      flatMatch->resize(size);
+      auto rawValues = flatMatch->mutableRawValues<uint64_t>();
+      for (auto i = 0; i < size; ++i) {
+        if (!nonNullInputRows_.isValid(i)) {
           flatMatch->setNull(i, true);
         } else {
-          bits::setBit(rawValues, i, hasMatch);
+          bool hasMatch = outputTableRows_[i] != nullptr;
+          if (!hasMatch && buildSideHasNullKeys_) {
+            flatMatch->setNull(i, true);
+          } else {
+            bits::setBit(rawValues, i, hasMatch);
+          }
         }
       }
     }
@@ -724,9 +733,17 @@ RowVectorPtr HashProbe::getBuildSideOutput() {
 
   if (isRightSemiProjectJoin(joinType_)) {
     // Populate 'match' column.
-    auto match = output_->childAt(outputType_->size() - 1);
-    table_->rows()->extractProbedFlags(
-        outputTableRows_.data(), numOut, probeSideHasNullKeys_, match);
+    if (noInput_) {
+      // Probe side is empty. All rows should return 'match = false', even ones
+      // with a null join key.
+      matchColumn() = BaseVector::createConstant(false, numOut, pool());
+    } else {
+      table_->rows()->extractProbedFlags(
+          outputTableRows_.data(),
+          numOut,
+          probeSideHasNullKeys_,
+          matchColumn());
+    }
   }
 
   return output_;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -236,6 +236,24 @@ class HashProbe : public Operator {
   // next hash table from the spilled data.
   void noMoreInputInternal();
 
+  // Returns the index of the 'match' column in the output for semi project
+  // joins.
+  VectorPtr& matchColumn() const {
+    VELOX_DCHECK(
+        isRightSemiProjectJoin(joinType_) || isLeftSemiProjectJoin(joinType_));
+    return output_->children().back();
+  }
+
+  // Returns true if build side has no data.
+  // NOTE: if build side has triggered spilling, then the first hash table
+  // might be empty, but we still have spilled partition data remaining to
+  // restore. Also note that the spilled partition at build side must not be
+  // empty.
+  bool emptyBuildSide() const {
+    return table_->numDistinct() == 0 && spillPartitionSet_.empty() &&
+        spillInputPartitionIds_.empty();
+  }
+
   // TODO: Define batch size as bytes based on RowContainer row sizes.
   const uint32_t outputBatchSize_;
 
@@ -292,6 +310,9 @@ class HashProbe : public Operator {
   // Table shared between other HashProbes in other Drivers of the
   // same pipeline.
   std::shared_ptr<BaseHashTable> table_;
+
+  // Indicates whether there was no input. Used for right semi join project.
+  bool noInput_{true};
 
   // Indicates whether there are rows with null join keys on the build
   // side. Used by left semi project join.

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -2974,6 +2974,23 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
       .referenceQuery(
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NOT NULL) FROM t")
       .run();
+
+  // Empty build side.
+  plan = makePlan("", "u0 < 0");
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(plan)
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 < 0) FROM t")
+      .run();
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      .planNode(flipJoinSides(plan))
+      .checkSpillStats(false)
+      .referenceQuery(
+          "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 < 0) FROM t")
+      .run();
 }
 
 TEST_F(HashJoinTest, semiProjectOverLazyVectors) {


### PR DESCRIPTION
Left semi project join used to return 'match = NULL' for all rows with null join
keys. It should return 'match = false' if build side is empty. Same for right
semi project.

Fixes #3271