### PR TITLE
Extract common superclasses for repeated readers

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(
   ScanSpec.cpp
   ColumnLoader.cpp
   SelectiveColumnReader.cpp
+  SelectiveRepeatedColumnReader.cpp
   SelectiveStructColumnReader.cpp
   SeekableInputStream.cpp
   TypeWithId.cpp)

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -59,6 +59,12 @@ std::vector<uint32_t> SelectiveColumnReader::filterRowGroups(
   return formatData_->filterRowGroups(*scanSpec_, rowGroupSize, context);
 }
 
+const std::vector<SelectiveColumnReader*> SelectiveColumnReader::children()
+    const {
+  static std::vector<SelectiveColumnReader*> empty;
+  return empty;
+}
+
 bool SelectiveColumnReader::rowGroupMatches(uint32_t rowGroupId) const {
   return formatData_->rowGroupMatches(rowGroupId, scanSpec_->filter());
 }

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -15,6 +15,7 @@
  */
 
 #pragma once
+#include "BufferedInput.h"
 #include "velox/common/base/RawVector.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/process/ProcessBase.h"
@@ -132,6 +133,9 @@ class SelectiveColumnReader {
     return *formatData_;
   }
 
+  /// Returns list of child readers, empty for leaf readers.
+  virtual const std::vector<SelectiveColumnReader*> children() const;
+
   /**
    * Read the next group of values into a RowVector.
    * @param numValues the number of values to read
@@ -193,6 +197,10 @@ class SelectiveColumnReader {
 
   const TypePtr& type() const {
     return type_;
+  }
+
+  const TypeWithId& nodeType() const {
+    return *nodeType_;
   }
 
   // The below functions are called from ColumnVisitor to fill the result set.
@@ -502,6 +510,7 @@ class SelectiveColumnReader {
 
   memory::MemoryPool& memoryPool_;
 
+  // Requested Velox type
   std::shared_ptr<const dwio::common::TypeWithId> nodeType_;
 
   // Format specific state and functions.
@@ -511,6 +520,8 @@ class SelectiveColumnReader {
   // spec is assigned at construction and the contents may change at
   // run time based on adaptation. Owned by caller.
   velox::common::ScanSpec* FOLLY_NONNULL scanSpec_;
+
+  // The file data type?
   TypePtr type_;
 
   // Row number after last read row, relative to stripe start.

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/SelectiveRepeatedColumnReader.h"
+
+namespace facebook::velox::dwio::common {
+
+SelectiveListColumnReader::SelectiveListColumnReader(
+    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
+    FormatParams& params,
+    velox::common::ScanSpec& scanSpec)
+    : SelectiveRepeatedColumnReader(dataType, params, scanSpec, dataType->type),
+      requestedType_{requestedType} {}
+
+uint64_t SelectiveListColumnReader::skip(uint64_t numValues) {
+  numValues = formatData_->skipNulls(numValues);
+  if (child_) {
+    std::array<int32_t, kBufferSize> buffer;
+    uint64_t childElements = 0;
+    uint64_t lengthsRead = 0;
+    while (lengthsRead < numValues) {
+      uint64_t chunk =
+          std::min(numValues - lengthsRead, static_cast<uint64_t>(kBufferSize));
+      readLengths(buffer.data(), chunk, nullptr);
+      for (size_t i = 0; i < chunk; ++i) {
+        childElements += static_cast<size_t>(buffer[i]);
+      }
+      lengthsRead += chunk;
+    }
+    child_->skip(childElements);
+    childTargetReadOffset_ += childElements;
+    child_->setReadOffset(child_->readOffset() + childElements);
+  } else {
+    VELOX_FAIL("Repeated reader with no children");
+  }
+  return numValues;
+}
+
+void SelectiveListColumnReader::read(
+    vector_size_t offset,
+    RowSet rows,
+    const uint64_t* incomingNulls) {
+  // Catch up if the child is behind the length stream.
+  child_->seekTo(childTargetReadOffset_, false);
+  prepareRead<char>(offset, rows, incomingNulls);
+  makeNestedRowSet(rows);
+  if (child_ && !nestedRows_.empty()) {
+    child_->read(child_->readOffset(), nestedRows_, nullptr);
+  }
+  numValues_ = rows.size();
+  readOffset_ = offset + rows.back() + 1;
+}
+
+void SelectiveListColumnReader::getValues(RowSet rows, VectorPtr* result) {
+  compactOffsets(rows);
+  VectorPtr elements;
+  if (child_ && !nestedRows_.empty()) {
+    prepareStructResult(type_->childAt(0), &elements);
+    child_->getValues(nestedRows_, &elements);
+  }
+  *result = std::make_shared<ArrayVector>(
+      &memoryPool_,
+      requestedType_->type,
+      anyNulls_ ? resultNulls_ : nullptr,
+      rows.size(),
+      offsets_,
+      sizes_,
+      elements);
+}
+
+SelectiveMapColumnReader::SelectiveMapColumnReader(
+    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
+    FormatParams& params,
+    velox::common::ScanSpec& scanSpec)
+    : SelectiveRepeatedColumnReader(dataType, params, scanSpec, dataType->type),
+      requestedType_{requestedType} {}
+
+uint64_t SelectiveMapColumnReader::skip(uint64_t numValues) {
+  numValues = formatData_->skipNulls(numValues);
+  if (keyReader_ || elementReader_) {
+    std::array<int32_t, kBufferSize> buffer;
+    uint64_t childElements = 0;
+    uint64_t lengthsRead = 0;
+    while (lengthsRead < numValues) {
+      uint64_t chunk =
+          std::min(numValues - lengthsRead, static_cast<uint64_t>(kBufferSize));
+      readLengths(buffer.data(), chunk, nullptr);
+      for (size_t i = 0; i < chunk; ++i) {
+        childElements += buffer[i];
+      }
+      lengthsRead += chunk;
+    }
+    if (keyReader_) {
+      keyReader_->skip(childElements);
+      keyReader_->setReadOffset(keyReader_->readOffset() + childElements);
+    }
+    if (elementReader_) {
+      elementReader_->skip(childElements);
+      elementReader_->setReadOffset(
+          elementReader_->readOffset() + childElements);
+    }
+    childTargetReadOffset_ += childElements;
+
+  } else {
+    VELOX_FAIL("repeated reader with no children");
+  }
+  return numValues;
+}
+
+void SelectiveMapColumnReader::read(
+    vector_size_t offset,
+    RowSet rows,
+    const uint64_t* incomingNulls) {
+  // Catch up if child readers are behind the length stream.
+  if (keyReader_) {
+    keyReader_->seekTo(childTargetReadOffset_, false);
+  }
+  if (elementReader_) {
+    elementReader_->seekTo(childTargetReadOffset_, false);
+  }
+
+  prepareRead<char>(offset, rows, incomingNulls);
+  makeNestedRowSet(rows);
+  if (keyReader_ && elementReader_ && !nestedRows_.empty()) {
+    keyReader_->read(keyReader_->readOffset(), nestedRows_, nullptr);
+    elementReader_->read(elementReader_->readOffset(), nestedRows_, nullptr);
+  }
+  numValues_ = rows.size();
+  readOffset_ = offset + rows.back() + 1;
+}
+
+void SelectiveMapColumnReader::getValues(RowSet rows, VectorPtr* result) {
+  compactOffsets(rows);
+  VectorPtr keys;
+  VectorPtr values;
+  VELOX_CHECK(
+      keyReader_ && elementReader_,
+      "keyReader_ and elementReaer_ must exist in "
+      "SelectiveMapColumnReader::getValues");
+  if (!nestedRows_.empty()) {
+    keyReader_->getValues(nestedRows_, &keys);
+    prepareStructResult(type_->childAt(1), &values);
+    elementReader_->getValues(nestedRows_, &values);
+  }
+  *result = std::make_shared<MapVector>(
+      &memoryPool_,
+      requestedType_->type,
+      anyNulls_ ? resultNulls_ : nullptr,
+      rows.size(),
+      offsets_,
+      sizes_,
+      keys,
+      values);
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/BufferUtil.h"
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
+
+namespace facebook::velox::dwio::common {
+
+// Abstract superclass for list and map readers. Encapsulates common
+// logic for dealing with mapping between enclosing and nested rows.
+class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
+ public:
+  bool useBulkPath() const override {
+    return false;
+  }
+
+ protected:
+  // Buffer size for reading lengths when skipping.
+  static constexpr int32_t kBufferSize = 1024;
+
+  SelectiveRepeatedColumnReader(
+      std::shared_ptr<const dwio::common::TypeWithId> nodeType,
+      FormatParams& params,
+      velox::common::ScanSpec& scanSpec,
+      const TypePtr& type)
+      : SelectiveColumnReader(std::move(nodeType), params, scanSpec, type) {}
+
+  /// Reads 'numLengths' next lengths into 'result'. If 'nulls' is
+  /// non-null, each kNull bit signifies a null with a length of 0 to
+  /// be inserted at the corresponding position in the result. 'nulls'
+  /// is expected to be null flags for 'numRows' next rows at the
+  /// level of this reader.
+  virtual void readLengths(
+      int32_t* FOLLY_NONNULL lengths,
+      int32_t numLengths,
+      const uint64_t* FOLLY_NULLABLE nulls) = 0;
+
+  void makeNestedRowSet(RowSet rows) {
+    allLengths_.resize(rows.back() + 1);
+    assert(!allLengths_.empty()); // for lint only.
+    auto nulls =
+        nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+    // Reads the lengths, leaves an uninitialized gap for a null
+    // map/list. Reading these checks the null nask.
+    readLengths(allLengths_.data(), rows.back() + 1, nulls);
+    dwio::common::ensureCapacity<vector_size_t>(
+        offsets_, rows.size(), &memoryPool_);
+    dwio::common::ensureCapacity<vector_size_t>(
+        sizes_, rows.size(), &memoryPool_);
+    auto rawOffsets = offsets_->asMutable<vector_size_t>();
+    auto rawSizes = sizes_->asMutable<vector_size_t>();
+    vector_size_t nestedLength = 0;
+    for (auto row : rows) {
+      if (!nulls || !bits::isBitNull(nulls, row)) {
+        nestedLength += allLengths_[row];
+      }
+    }
+    nestedRows_.resize(nestedLength);
+    vector_size_t currentRow = 0;
+    vector_size_t nestedRow = 0;
+    vector_size_t nestedOffset = 0;
+    for (auto rowIndex = 0; rowIndex < rows.size(); ++rowIndex) {
+      auto row = rows[rowIndex];
+      // Add up the lengths of non-null rows skipped since the last
+      // non-null.
+      for (auto i = currentRow; i < row; ++i) {
+        if (!nulls || !bits::isBitNull(nulls, i)) {
+          nestedOffset += allLengths_[i];
+        }
+      }
+      currentRow = row + 1;
+      // Check if parent is null after adding up the lengths leading
+      // up to this. If null, add a null to the result and keep
+      // looping. If the null is last, the lengths will all have been
+      // added up.
+      if (nulls && bits::isBitNull(nulls, row)) {
+        rawOffsets[rowIndex] = 0;
+        rawSizes[rowIndex] = 0;
+        bits::setNull(rawResultNulls_, rowIndex);
+        anyNulls_ = true;
+        continue;
+      }
+
+      auto lengthAtRow = allLengths_[row];
+      std::iota(
+          &nestedRows_[nestedRow],
+          &nestedRows_[nestedRow + lengthAtRow],
+          nestedOffset);
+      rawOffsets[rowIndex] = nestedRow;
+      rawSizes[rowIndex] = lengthAtRow;
+      nestedRow += lengthAtRow;
+      nestedOffset += lengthAtRow;
+    }
+    childTargetReadOffset_ += nestedOffset;
+  }
+
+  void compactOffsets(RowSet rows) {
+    auto rawOffsets = offsets_->asMutable<vector_size_t>();
+    auto rawSizes = sizes_->asMutable<vector_size_t>();
+    VELOX_CHECK(
+        outputRows_.empty(), "Repeated reader does not support filters");
+    RowSet rowsToCompact;
+    if (valueRows_.empty()) {
+      valueRows_.resize(rows.size());
+      rowsToCompact = inputRows_;
+    } else {
+      rowsToCompact = valueRows_;
+    }
+    if (rows.size() == rowsToCompact.size()) {
+      return;
+    }
+
+    int32_t current = 0;
+    bool moveNulls = shouldMoveNulls(rows);
+    for (int i = 0; i < rows.size(); ++i) {
+      auto row = rows[i];
+      while (rowsToCompact[current] < row) {
+        ++current;
+      }
+      VELOX_CHECK(rowsToCompact[current] == row);
+      valueRows_[i] = row;
+      rawOffsets[i] = rawOffsets[current];
+      rawSizes[i] = rawSizes[current];
+      if (moveNulls && i != current) {
+        bits::setBit(
+            rawResultNulls_, i, bits::isBitSet(rawResultNulls_, current));
+      }
+    }
+    numValues_ = rows.size();
+    valueRows_.resize(numValues_);
+    offsets_->setSize(numValues_ * sizeof(vector_size_t));
+    sizes_->setSize(numValues_ * sizeof(vector_size_t));
+  }
+
+  // Creates a struct if '*result' is empty and 'type' is a row.
+  void prepareStructResult(const TypePtr& type, VectorPtr* result) {
+    if (!*result && type->kind() == TypeKind::ROW) {
+      *result = BaseVector::create(type, 0, &memoryPool_);
+    }
+  }
+
+  std::vector<int32_t> allLengths_;
+  raw_vector<vector_size_t> nestedRows_;
+  BufferPtr offsets_;
+  BufferPtr sizes_;
+  // The position in the child readers that corresponds to the
+  // position in the length stream. The child readers can be behind if
+  // the last parents were null, so that the child stream was only
+  // read up to the last position corresponding to
+  // the last non-null parent.
+  vector_size_t childTargetReadOffset_ = 0;
+};
+
+class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
+ public:
+  SelectiveListColumnReader(
+      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
+      FormatParams& params,
+      velox::common::ScanSpec& scanSpec);
+
+  uint64_t skip(uint64_t numValues) override;
+
+  const std::vector<SelectiveColumnReader*> children() const override {
+    return std::vector<SelectiveColumnReader*>{child_.get()};
+  }
+
+  void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
+      override;
+
+  void getValues(RowSet rows, VectorPtr* result) override;
+
+ protected:
+  std::unique_ptr<SelectiveColumnReader> child_;
+  const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
+};
+
+class SelectiveMapColumnReader : public SelectiveRepeatedColumnReader {
+ public:
+  SelectiveMapColumnReader(
+      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
+      FormatParams& params,
+      velox::common::ScanSpec& scanSpec);
+
+  void resetFilterCaches() override {
+    keyReader_->resetFilterCaches();
+    elementReader_->resetFilterCaches();
+  }
+
+  uint64_t skip(uint64_t numValues) override;
+
+  const std::vector<SelectiveColumnReader*> children() const override {
+    return std::vector<SelectiveColumnReader*>{
+        keyReader_.get(), elementReader_.get()};
+  }
+
+  void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
+      override;
+
+  void getValues(RowSet rows, VectorPtr* result) override;
+
+  std::unique_ptr<SelectiveColumnReader> keyReader_;
+  std::unique_ptr<SelectiveColumnReader> elementReader_;
+  const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -18,14 +18,36 @@
 #include "velox/dwio/dwrf/reader/SelectiveDwrfReader.h"
 
 namespace facebook::velox::dwrf {
+namespace {
+std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> makeLengthDecoder(
+    const dwio::common::TypeWithId& nodeType,
+    DwrfParams& params,
+    memory::MemoryPool& pool) {
+  EncodingKey encodingKey{nodeType.id, params.flatMapContext().sequence};
+  auto& stripe = params.stripeStreams();
+  auto rleVersion = convertRleVersion(stripe.getEncoding(encodingKey).kind());
+  auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
+  bool lenVints = stripe.getUseVInts(lenId);
+  return createRleDecoder</*isSigned*/ false>(
+      stripe.getStream(lenId, true),
+      rleVersion,
+      pool,
+      lenVints,
+      dwio::common::INT_BYTE_SIZE);
+}
+} // namespace
 
 SelectiveListColumnReader::SelectiveListColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
     DwrfParams& params,
     common::ScanSpec& scanSpec)
-    : SelectiveRepeatedColumnReader(dataType, params, scanSpec, dataType->type),
-      requestedType_{requestedType} {
+    : dwio::common::SelectiveListColumnReader(
+          requestedType,
+          dataType,
+          params,
+          scanSpec),
+      length_(makeLengthDecoder(*nodeType_, params, memoryPool_)) {
   DWIO_ENSURE_EQ(nodeType_->id, dataType->id, "working on the same node");
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
@@ -47,69 +69,17 @@ SelectiveListColumnReader::SelectiveListColumnReader(
       childType, nodeType_->childAt(0), childParams, *scanSpec_->children()[0]);
 }
 
-uint64_t SelectiveListColumnReader::skip(uint64_t numValues) {
-  numValues = formatData_->skipNulls(numValues);
-  if (child_) {
-    std::array<int64_t, kBufferSize> buffer;
-    uint64_t childElements = 0;
-    uint64_t lengthsRead = 0;
-    while (lengthsRead < numValues) {
-      uint64_t chunk =
-          std::min(numValues - lengthsRead, static_cast<uint64_t>(kBufferSize));
-      length_->next(buffer.data(), chunk, nullptr);
-      for (size_t i = 0; i < chunk; ++i) {
-        childElements += static_cast<size_t>(buffer[i]);
-      }
-      lengthsRead += chunk;
-    }
-    child_->skip(childElements);
-    childTargetReadOffset_ += childElements;
-    child_->setReadOffset(child_->readOffset() + childElements);
-  } else {
-    length_->skip(numValues);
-  }
-  return numValues;
-}
-
-void SelectiveListColumnReader::read(
-    vector_size_t offset,
-    RowSet rows,
-    const uint64_t* incomingNulls) {
-  // Catch up if the child is behind the length stream.
-  child_->seekTo(childTargetReadOffset_, false);
-  prepareRead<char>(offset, rows, incomingNulls);
-  makeNestedRowSet(rows);
-  if (child_ && !nestedRows_.empty()) {
-    child_->read(child_->readOffset(), nestedRows_, nullptr);
-  }
-  numValues_ = rows.size();
-  readOffset_ = offset + rows.back() + 1;
-}
-
-void SelectiveListColumnReader::getValues(RowSet rows, VectorPtr* result) {
-  compactOffsets(rows);
-  VectorPtr elements;
-  if (child_ && !nestedRows_.empty()) {
-    prepareStructResult(type_->childAt(0), &elements);
-    child_->getValues(nestedRows_, &elements);
-  }
-  *result = std::make_shared<ArrayVector>(
-      &memoryPool_,
-      requestedType_->type,
-      anyNulls_ ? resultNulls_ : nullptr,
-      rows.size(),
-      offsets_,
-      sizes_,
-      elements);
-}
-
 SelectiveMapColumnReader::SelectiveMapColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
     DwrfParams& params,
     common::ScanSpec& scanSpec)
-    : SelectiveRepeatedColumnReader(dataType, params, scanSpec, dataType->type),
-      requestedType_{requestedType} {
+    : dwio::common::SelectiveMapColumnReader(
+          requestedType,
+          dataType,
+          params,
+          scanSpec),
+      length_(makeLengthDecoder(*nodeType_, params, memoryPool_)) {
   DWIO_ENSURE_EQ(nodeType_->id, dataType->id, "working on the same node");
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
@@ -148,84 +118,6 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
       *scanSpec_->children()[1]);
 
   VLOG(1) << "[Map] Initialized map column reader for node " << nodeType_->id;
-}
-
-uint64_t SelectiveMapColumnReader::skip(uint64_t numValues) {
-  numValues = formatData_->skipNulls(numValues);
-  if (keyReader_ || elementReader_) {
-    std::array<int64_t, kBufferSize> buffer;
-    uint64_t childElements = 0;
-    uint64_t lengthsRead = 0;
-    while (lengthsRead < numValues) {
-      uint64_t chunk =
-          std::min(numValues - lengthsRead, static_cast<uint64_t>(kBufferSize));
-      length_->next(buffer.data(), chunk, nullptr);
-      for (size_t i = 0; i < chunk; ++i) {
-        childElements += buffer[i];
-      }
-      lengthsRead += chunk;
-    }
-    if (keyReader_) {
-      keyReader_->skip(childElements);
-      keyReader_->setReadOffset(keyReader_->readOffset() + childElements);
-    }
-    if (elementReader_) {
-      elementReader_->skip(childElements);
-      elementReader_->setReadOffset(
-          elementReader_->readOffset() + childElements);
-    }
-    childTargetReadOffset_ += childElements;
-
-  } else {
-    length_->skip(numValues);
-  }
-  return numValues;
-}
-
-void SelectiveMapColumnReader::read(
-    vector_size_t offset,
-    RowSet rows,
-    const uint64_t* incomingNulls) {
-  // Catch up if child readers are behind the length stream.
-  if (keyReader_) {
-    keyReader_->seekTo(childTargetReadOffset_, false);
-  }
-  if (elementReader_) {
-    elementReader_->seekTo(childTargetReadOffset_, false);
-  }
-
-  prepareRead<char>(offset, rows, incomingNulls);
-  makeNestedRowSet(rows);
-  if (keyReader_ && elementReader_ && !nestedRows_.empty()) {
-    keyReader_->read(keyReader_->readOffset(), nestedRows_, nullptr);
-    elementReader_->read(elementReader_->readOffset(), nestedRows_, nullptr);
-  }
-  numValues_ = rows.size();
-  readOffset_ = offset + rows.back() + 1;
-}
-
-void SelectiveMapColumnReader::getValues(RowSet rows, VectorPtr* result) {
-  compactOffsets(rows);
-  VectorPtr keys;
-  VectorPtr values;
-  VELOX_CHECK(
-      keyReader_ && elementReader_,
-      "keyReader_ and elementReaer_ must exist in "
-      "SelectiveMapColumnReader::getValues");
-  if (!nestedRows_.empty()) {
-    keyReader_->getValues(nestedRows_, &keys);
-    prepareStructResult(type_->childAt(1), &values);
-    elementReader_->getValues(nestedRows_, &values);
-  }
-  *result = std::make_shared<MapVector>(
-      &memoryPool_,
-      requestedType_->type,
-      anyNulls_ ? resultNulls_ : nullptr,
-      rows.size(),
-      offsets_,
-      sizes_,
-      keys,
-      values);
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -18,161 +18,14 @@
 
 #include "velox/dwio/common/BufferUtil.h"
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
+#include "velox/dwio/common/SelectiveRepeatedColumnReader.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
 
 namespace facebook::velox::dwrf {
 
-// Abstract superclass for list and map readers. Encapsulates common
-// logic for dealing with mapping between enclosing and nested rows.
-class SelectiveRepeatedColumnReader
-    : public dwio::common::SelectiveColumnReader {
- public:
-  bool useBulkPath() const override {
-    return false;
-  }
-
- protected:
-  // Buffer size for reading length stream
-  static constexpr size_t kBufferSize = 1024;
-
-  SelectiveRepeatedColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> nodeType,
-      DwrfParams& params,
-      common::ScanSpec& scanSpec,
-      const TypePtr& type)
-      : SelectiveColumnReader(std::move(nodeType), params, scanSpec, type) {
-    EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
-    auto& stripe = params.stripeStreams();
-    auto rleVersion = convertRleVersion(stripe.getEncoding(encodingKey).kind());
-    auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
-    bool lenVints = stripe.getUseVInts(lenId);
-    length_ = createRleDecoder</*isSigned*/ false>(
-        stripe.getStream(lenId, true),
-        rleVersion,
-        memoryPool_,
-        lenVints,
-        dwio::common::INT_BYTE_SIZE);
-  }
-
-  void makeNestedRowSet(RowSet rows) {
-    allLengths_.resize(rows.back() + 1);
-    assert(!allLengths_.empty()); // for lint only.
-    auto nulls =
-        nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
-    // Reads the lengths, leaves an uninitialized gap for a null
-    // map/list. Reading these checks the null nask.
-    length_->next(allLengths_.data(), rows.back() + 1, nulls);
-    dwio::common::ensureCapacity<vector_size_t>(
-        offsets_, rows.size(), &memoryPool_);
-    dwio::common::ensureCapacity<vector_size_t>(
-        sizes_, rows.size(), &memoryPool_);
-    auto rawOffsets = offsets_->asMutable<vector_size_t>();
-    auto rawSizes = sizes_->asMutable<vector_size_t>();
-    vector_size_t nestedLength = 0;
-    for (auto row : rows) {
-      if (!nulls || !bits::isBitNull(nulls, row)) {
-        nestedLength += allLengths_[row];
-      }
-    }
-    nestedRows_.resize(nestedLength);
-    vector_size_t currentRow = 0;
-    vector_size_t nestedRow = 0;
-    vector_size_t nestedOffset = 0;
-    for (auto rowIndex = 0; rowIndex < rows.size(); ++rowIndex) {
-      auto row = rows[rowIndex];
-      // Add up the lengths of non-null rows skipped since the last
-      // non-null.
-      for (auto i = currentRow; i < row; ++i) {
-        if (!nulls || !bits::isBitNull(nulls, i)) {
-          nestedOffset += allLengths_[i];
-        }
-      }
-      currentRow = row + 1;
-      // Check if parent is null after adding up the lengths leading
-      // up to this. If null, add a null to the result and keep
-      // looping. If the null is last, the lengths will all have been
-      // added up.
-      if (nulls && bits::isBitNull(nulls, row)) {
-        rawOffsets[rowIndex] = 0;
-        rawSizes[rowIndex] = 0;
-        bits::setNull(rawResultNulls_, rowIndex);
-        anyNulls_ = true;
-        continue;
-      }
-
-      auto lengthAtRow = allLengths_[row];
-      std::iota(
-          &nestedRows_[nestedRow],
-          &nestedRows_[nestedRow + lengthAtRow],
-          nestedOffset);
-      rawOffsets[rowIndex] = nestedRow;
-      rawSizes[rowIndex] = lengthAtRow;
-      nestedRow += lengthAtRow;
-      nestedOffset += lengthAtRow;
-    }
-    childTargetReadOffset_ += nestedOffset;
-  }
-
-  void compactOffsets(RowSet rows) {
-    auto rawOffsets = offsets_->asMutable<vector_size_t>();
-    auto rawSizes = sizes_->asMutable<vector_size_t>();
-    VELOX_CHECK(
-        outputRows_.empty(), "Repeated reader does not support filters");
-    RowSet rowsToCompact;
-    if (valueRows_.empty()) {
-      valueRows_.resize(rows.size());
-      rowsToCompact = inputRows_;
-    } else {
-      rowsToCompact = valueRows_;
-    }
-    if (rows.size() == rowsToCompact.size()) {
-      return;
-    }
-
-    int32_t current = 0;
-    bool moveNulls = shouldMoveNulls(rows);
-    for (int i = 0; i < rows.size(); ++i) {
-      auto row = rows[i];
-      while (rowsToCompact[current] < row) {
-        ++current;
-      }
-      VELOX_CHECK(rowsToCompact[current] == row);
-      valueRows_[i] = row;
-      rawOffsets[i] = rawOffsets[current];
-      rawSizes[i] = rawSizes[current];
-      if (moveNulls && i != current) {
-        bits::setBit(
-            rawResultNulls_, i, bits::isBitSet(rawResultNulls_, current));
-      }
-    }
-    numValues_ = rows.size();
-    valueRows_.resize(numValues_);
-    offsets_->setSize(numValues_ * sizeof(vector_size_t));
-    sizes_->setSize(numValues_ * sizeof(vector_size_t));
-  }
-
-  // Creates a struct if '*result' is empty and 'type' is a row.
-  void prepareStructResult(const TypePtr& type, VectorPtr* result) {
-    if (!*result && type->kind() == TypeKind::ROW) {
-      *result = BaseVector::create(type, 0, &memoryPool_);
-    }
-  }
-
-  std::vector<int64_t> allLengths_;
-  raw_vector<vector_size_t> nestedRows_;
-  BufferPtr offsets_;
-  BufferPtr sizes_;
-  // The position in the child readers that corresponds to the
-  // position in the length stream. The child readers can be behind if
-  // the last parents were null, so that the child stream was only
-  // read up to the last position corresponding to
-  // the last non-null parent.
-  vector_size_t childTargetReadOffset_ = 0;
-  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> length_;
-};
-
-class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
+class SelectiveListColumnReader
+    : public dwio::common::SelectiveListColumnReader {
  public:
   SelectiveListColumnReader(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
@@ -196,19 +49,18 @@ class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
     childTargetReadOffset_ = 0;
   }
 
-  uint64_t skip(uint64_t numValues) override;
-
-  void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
-      override;
-
-  void getValues(RowSet rows, VectorPtr* result) override;
+  void readLengths(
+      int32_t* FOLLY_NONNULL lengths,
+      int32_t numLengths,
+      const uint64_t* FOLLY_NULLABLE nulls) override {
+    length_->next(lengths, numLengths, nulls);
+  }
 
  private:
-  std::unique_ptr<SelectiveColumnReader> child_;
-  const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> length_;
 };
 
-class SelectiveMapColumnReader : public SelectiveRepeatedColumnReader {
+class SelectiveMapColumnReader : public dwio::common::SelectiveMapColumnReader {
  public:
   SelectiveMapColumnReader(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
@@ -236,17 +88,15 @@ class SelectiveMapColumnReader : public SelectiveRepeatedColumnReader {
     childTargetReadOffset_ = 0;
   }
 
-  uint64_t skip(uint64_t numValues) override;
-
-  void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
-      override;
-
-  void getValues(RowSet rows, VectorPtr* result) override;
+  void readLengths(
+      int32_t* FOLLY_NONNULL lengths,
+      int32_t numLengths,
+      const uint64_t* FOLLY_NULLABLE nulls) override {
+    length_->next(lengths, numLengths, nulls);
+  }
 
  private:
-  std::unique_ptr<SelectiveColumnReader> keyReader_;
-  std::unique_ptr<SelectiveColumnReader> elementReader_;
-  const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> length_;
 };
 
 } // namespace facebook::velox::dwrf


### PR DESCRIPTION
Creats a cross format superclass for repeated types. Does not change the operation of the concerned DWRF readers.