### PR TITLE
Any not allowed in return type.

### DIFF
--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -1207,7 +1207,7 @@ The map_keys function takes any map and returns an array of map keys.
 
     // map(K,V) -> array(K)
     exec::FunctionSignatureBuilder()
-      .typeVariable("K")
+      .knownTypeVariable("K)
       .typeVariable("V")
       .returnType("array(K)")
       .argumentType("map(K,V)")

--- a/velox/exec/tests/AggregationFuzzer.cpp
+++ b/velox/exec/tests/AggregationFuzzer.cpp
@@ -275,18 +275,18 @@ AggregationFuzzer::AggregationFuzzer(
         continue;
       }
 
-      if (!signature->typeVariableConstraints().empty()) {
+      if (!signature->variables().empty()) {
         bool skip = false;
         std::unordered_set<std::string> typeVariables;
-        for (auto& constraint : signature->typeVariableConstraints()) {
-          if (constraint.isIntegerParameter()) {
+        for (auto& [name, variable] : signature->variables()) {
+          if (variable.isIntegerParameter()) {
             LOG(WARNING) << "Skipping generic function signature: " << name
                          << signature->toString();
             skip = true;
             break;
           }
 
-          typeVariables.insert(constraint.name());
+          typeVariables.insert(name);
         }
         if (skip) {
           continue;
@@ -298,13 +298,13 @@ AggregationFuzzer::AggregationFuzzer(
         CallableSignature callable{
             .name = name,
             .args = {},
-            .returnType =
-                SignatureBinder::tryResolveType(signature->returnType(), {})};
+            .returnType = SignatureBinder::tryResolveType(
+                signature->returnType(), {}, {})};
         VELOX_CHECK_NOT_NULL(callable.returnType);
 
         // Process each argument and figure out its type.
         for (const auto& arg : signature->argumentTypes()) {
-          auto resolvedType = SignatureBinder::tryResolveType(arg, {});
+          auto resolvedType = SignatureBinder::tryResolveType(arg, {}, {});
           VELOX_CHECK_NOT_NULL(resolvedType);
 
           callable.args.emplace_back(resolvedType);

--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -44,7 +44,18 @@ TEST_F(FunctionSignatureBuilderTest, basicTypeTests) {
             .argumentType("array(T)")
             .build();
       },
-      "Type parameter declared twice");
+      "Variable T declared twice");
+
+  assertUserInvalidArgument(
+      [=]() {
+        FunctionSignatureBuilder()
+            .typeVariable("T")
+            .knownTypeVariable("T")
+            .returnType("integer")
+            .argumentType("array(T)")
+            .build();
+      },
+      "Variable T declared twice");
 
   // Unspecified type params.
   assertUserInvalidArgument(

--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -125,3 +125,25 @@ TEST_F(FunctionSignatureBuilderTest, typeParamTests) {
       },
       "Named type cannot have parameters : T(M)");
 }
+
+TEST_F(FunctionSignatureBuilderTest, anyInReturn) {
+  assertUserInvalidArgument(
+      [=]() {
+        FunctionSignatureBuilder()
+            .typeVariable("T")
+            .returnType("Any")
+            .argumentType("T")
+            .build();
+      },
+      "Type 'Any' cannot appear in return type");
+
+  assertUserInvalidArgument(
+      [=]() {
+        FunctionSignatureBuilder()
+            .typeVariable("T")
+            .returnType("row(any, T)")
+            .argumentType("T")
+            .build();
+      },
+      "Type 'Any' cannot appear in return type");
+}

--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
+
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 

--- a/velox/expression/ReverseSignatureBinder.cpp
+++ b/velox/expression/ReverseSignatureBinder.cpp
@@ -18,15 +18,17 @@
 
 namespace facebook::velox::exec {
 
-bool ReverseSignatureBinder::isConstrainedType(
+bool ReverseSignatureBinder::hasConstrainedIntegerVariable(
     const TypeSignature& type) const {
   if (type.parameters().empty()) {
-    return constraints_.find(type.baseName()) != constraints_.end();
+    auto it = variables().find(type.baseName());
+    return it != variables().end() && it->second.isIntegerParameter() &&
+        it->second.constraint() != "";
   }
 
   const auto& parameters = type.parameters();
   for (const auto& parameter : parameters) {
-    if (isConstrainedType(parameter)) {
+    if (hasConstrainedIntegerVariable(parameter)) {
       return true;
     }
   }
@@ -34,7 +36,7 @@ bool ReverseSignatureBinder::isConstrainedType(
 }
 
 bool ReverseSignatureBinder::tryBind() {
-  if (isConstrainedType(signature_.returnType())) {
+  if (hasConstrainedIntegerVariable(signature_.returnType())) {
     return false;
   }
   return SignatureBinderBase::tryBind(signature_.returnType(), returnType_);

--- a/velox/expression/ReverseSignatureBinder.h
+++ b/velox/expression/ReverseSignatureBinder.h
@@ -40,13 +40,13 @@ class ReverseSignatureBinder : private SignatureBinderBase {
   /// tryBind() and only if tryBind() returns true. If a type variable is not
   /// determined by tryBind(), it maps to a nullptr.
   const std::unordered_map<std::string, TypePtr>& bindings() const {
-    return typeParameters_;
+    return typeVariablesBindings_;
   }
 
  private:
-  /// Return whether there is a constraint on the type in the function
+  /// Return whether there is a constraint on an integer variable in type
   /// signature.
-  bool isConstrainedType(const TypeSignature& type) const;
+  bool hasConstrainedIntegerVariable(const TypeSignature& type) const;
 
   const TypePtr returnType_;
 };

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -43,7 +43,7 @@ std::string buildCalculation(
 
 TypePtr inferDecimalType(
     const exec::TypeSignature& typeSignature,
-    const std::unordered_map<std::string, TypeVariableConstraint>& variables,
+    const std::unordered_map<std::string, SignatureVariable>& variables,
     std::unordered_map<std::string, int>& integerVariablesBindings) {
   if (typeSignature.parameters().size() != 2) {
     return nullptr;
@@ -242,7 +242,7 @@ bool SignatureBinderBase::tryBind(
 
 TypePtr SignatureBinder::tryResolveType(
     const exec::TypeSignature& typeSignature,
-    const std::unordered_map<std::string, TypeVariableConstraint>& variables,
+    const std::unordered_map<std::string, SignatureVariable>& variables,
     const std::unordered_map<std::string, TypePtr>& typeVariablesBindings,
     std::unordered_map<std::string, int>& integerVariablesBindings) {
   const auto baseName = typeSignature.baseName();

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -93,7 +93,7 @@ class SignatureBinder : private SignatureBinderBase {
   // possible.
   static TypePtr tryResolveType(
       const exec::TypeSignature& typeSignature,
-      const std::unordered_map<std::string, TypeVariableConstraint>& variables,
+      const std::unordered_map<std::string, SignatureVariable>& variables,
       const std::unordered_map<std::string, TypePtr>& resolvedTypeVariables) {
     std::unordered_map<std::string, int> dummyEmpty = {};
     return tryResolveType(
@@ -105,7 +105,7 @@ class SignatureBinder : private SignatureBinderBase {
   // updated with the bound value.
   static TypePtr tryResolveType(
       const exec::TypeSignature& typeSignature,
-      const std::unordered_map<std::string, TypeVariableConstraint>& variables,
+      const std::unordered_map<std::string, SignatureVariable>& variables,
       const std::unordered_map<std::string, TypePtr>& typeVariablesBindings,
       std::unordered_map<std::string, int>& integerVariablesBindings);
 

--- a/velox/expression/tests/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzer.cpp
@@ -60,10 +60,19 @@ std::optional<TypeKind> baseNameToTypeKind(const std::string& typeName) {
 }
 
 void ArgumentTypeFuzzer::determineUnboundedTypeVariables() {
-  for (auto& binding : bindings_) {
-    if (!binding.second) {
-      binding.second = randomType(rng_);
+  for (auto& [variableName, variableInfo] : variables()) {
+    if (!variableInfo.isTypeParameter()) {
+      continue;
     }
+
+    if (bindings_[variableName] != nullptr) {
+      continue;
+    }
+
+    // Random randomType() never generates unknown here.
+    // TODO: we should extend randomType types and exclude unknown based
+    // on variableInfo.
+    bindings_[variableName] = randomType(rng_);
   }
 }
 
@@ -78,8 +87,8 @@ bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {
     }
     bindings_ = binder.bindings();
   } else {
-    for (const auto& constraint : signature_.typeVariableConstraints()) {
-      bindings_.insert({constraint.name(), nullptr});
+    for (const auto& [name, _] : signature_.variables()) {
+      bindings_.insert({name, nullptr});
     }
   }
 
@@ -89,8 +98,8 @@ bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {
     if (formalArgs[i].baseName() == "any") {
       actualArg = randomType(rng_);
     } else {
-      actualArg =
-          exec::SignatureBinder::tryResolveType(formalArgs[i], bindings_);
+      actualArg = exec::SignatureBinder::tryResolveType(
+          formalArgs[i], variables(), bindings_);
       VELOX_CHECK(actualArg != nullptr);
     }
     argumentTypes_.push_back(actualArg);

--- a/velox/expression/tests/ArgumentTypeFuzzer.h
+++ b/velox/expression/tests/ArgumentTypeFuzzer.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <random>
+#include <unordered_map>
+
 #include "velox/expression/FunctionSignature.h"
 #include "velox/expression/SignatureBinder.h"
 #include "velox/type/Type.h"
@@ -31,15 +33,13 @@ class ArgumentTypeFuzzer {
   ArgumentTypeFuzzer(
       const exec::FunctionSignature& signature,
       std::mt19937& rng)
-      : signature_{signature}, rng_{rng} {}
+      : ArgumentTypeFuzzer(signature, nullptr, rng) {}
 
   ArgumentTypeFuzzer(
       const exec::FunctionSignature& signature,
       const TypePtr& returnType,
       std::mt19937& rng)
-      : signature_{signature}, returnType_{returnType}, rng_{rng} {
-    VELOX_CHECK_NOT_NULL(returnType);
-  }
+      : signature_{signature}, returnType_{returnType}, rng_{rng} {}
 
   /// Generate random argument types. If the desired returnType has been
   /// specified, checks that it can be bound to the return type of signature_.
@@ -54,6 +54,10 @@ class ArgumentTypeFuzzer {
   }
 
  private:
+  /// Return the variables in the signature.
+  auto& variables() const {
+    return signature_.variables();
+  }
   /// Bind each type variable that is not determined by the return type to a
   /// randomly generated type.
   void determineUnboundedTypeVariables();

--- a/velox/expression/tests/ArgumentTypeFuzzerTest.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzerTest.cpp
@@ -127,7 +127,7 @@ TEST_F(ArgumentTypeFuzzerTest, signatureTemplate) {
 
   {
     auto signature = exec::FunctionSignatureBuilder()
-                         .typeVariable("K")
+                         .knownTypeVariable("K")
                          .typeVariable("V")
                          .returnType("K")
                          .argumentType("array(K)")
@@ -153,7 +153,7 @@ TEST_F(ArgumentTypeFuzzerTest, signatureTemplate) {
 
   {
     auto signature = exec::FunctionSignatureBuilder()
-                         .typeVariable("K")
+                         .knownTypeVariable("K")
                          .typeVariable("V")
                          .returnType("bigint")
                          .argumentType("array(K)")
@@ -191,7 +191,7 @@ TEST_F(ArgumentTypeFuzzerTest, variableArity) {
 
   {
     auto signature = exec::FunctionSignatureBuilder()
-                         .typeVariable("K")
+                         .knownTypeVariable("K")
                          .returnType("bigint")
                          .argumentType("K")
                          .variableArity()
@@ -280,7 +280,7 @@ TEST_F(ArgumentTypeFuzzerTest, lambda) {
 
   // map(K, V1), function(K, V1, V2) -> map(K, V2)
   signature = exec::FunctionSignatureBuilder()
-                  .typeVariable("K")
+                  .knownTypeVariable("K")
                   .typeVariable("V1")
                   .typeVariable("V2")
                   .returnType("map(K,V2)")
@@ -305,7 +305,7 @@ TEST_F(ArgumentTypeFuzzerTest, lambda) {
 
 TEST_F(ArgumentTypeFuzzerTest, unconstrainedSignatureTemplate) {
   auto signature = exec::FunctionSignatureBuilder()
-                       .typeVariable("K")
+                       .knownTypeVariable("K")
                        .typeVariable("V")
                        .returnType("V")
                        .argumentType("map(K,V)")

--- a/velox/expression/tests/ReverseSignatureBinderTest.cpp
+++ b/velox/expression/tests/ReverseSignatureBinderTest.cpp
@@ -74,7 +74,7 @@ TEST_F(ReverseSignatureBinderTest, any) {
 
 TEST_F(ReverseSignatureBinderTest, signatureTemplateFullBinding) {
   auto signature = exec::FunctionSignatureBuilder()
-                       .typeVariable("K")
+                       .knownTypeVariable("K")
                        .typeVariable("V")
                        .returnType("map(K, V)")
                        .argumentType("K")
@@ -84,19 +84,19 @@ TEST_F(ReverseSignatureBinderTest, signatureTemplateFullBinding) {
   testBindingSuccess(
       signature, MAP(VARCHAR(), BIGINT()), {{"K", VARCHAR()}, {"V", BIGINT()}});
   testBindingFailure(signature, VARCHAR());
+  testBindingFailure(signature, MAP(UNKNOWN(), INTEGER()));
 }
 
 TEST_F(ReverseSignatureBinderTest, signatureTemplatePartialBinding) {
   auto signature = exec::FunctionSignatureBuilder()
-                       .typeVariable("K")
+                       .knownTypeVariable("K")
                        .typeVariable("V")
                        .returnType("array(K)")
                        .argumentType("K")
                        .argumentType("V")
                        .build();
 
-  testBindingSuccess(
-      signature, ARRAY(VARCHAR()), {{"K", VARCHAR()}, {"V", nullptr}});
+  testBindingSuccess(signature, ARRAY(VARCHAR()), {{"K", VARCHAR()}});
   testBindingFailure(signature, VARCHAR());
 }
 

--- a/velox/expression/tests/ReverseSignatureBinderTest.cpp
+++ b/velox/expression/tests/ReverseSignatureBinderTest.cpp
@@ -61,17 +61,6 @@ TEST_F(ReverseSignatureBinderTest, concreteSignature) {
   testBindingFailure(signature, VARCHAR());
 }
 
-TEST_F(ReverseSignatureBinderTest, any) {
-  auto signature = exec::FunctionSignatureBuilder()
-                       .returnType("array(any)")
-                       .argumentType("varchar")
-                       .argumentType("bigint")
-                       .build();
-
-  testBindingSuccess(signature, ARRAY(VARCHAR()), {});
-  testBindingFailure(signature, VARCHAR());
-}
-
 TEST_F(ReverseSignatureBinderTest, signatureTemplateFullBinding) {
   auto signature = exec::FunctionSignatureBuilder()
                        .knownTypeVariable("K")

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -263,7 +263,7 @@ TEST(SignatureBinderTest, decimals) {
     // Type parameter + constraint = error.
     {
       VELOX_ASSERT_THROW(
-          exec::TypeVariableConstraint(
+          exec::SignatureVariable(
               "TypeName", "a = b", exec::ParameterType::kTypeParameter),
           "Type variables cannot have constraints");
     }

--- a/velox/expression/type_calculation/Scanner.h
+++ b/velox/expression/type_calculation/Scanner.h
@@ -30,7 +30,7 @@ class Scanner : public yyFlexLexer {
   Scanner(
       std::istream& arg_yyin,
       std::ostream& arg_yyout,
-      std::unordered_map<std::string, std::optional<int>>& values)
+      std::unordered_map<std::string, int>& values)
       : yyFlexLexer(&arg_yyin, &arg_yyout), values_(values){};
   int lex(Parser::semantic_type* yylval);
 
@@ -39,13 +39,12 @@ class Scanner : public yyFlexLexer {
   }
 
   int getValue(const std::string& varName) const {
-    VELOX_CHECK(
-        values_.at(varName).has_value(), "Variable {} is not defined", varName);
-    return values_.at(varName).value();
+    VELOX_CHECK(values_.count(varName), "Variable {} is not defined", varName);
+    return values_.at(varName);
   }
 
  private:
-  std::unordered_map<std::string, std::optional<int>>& values_;
+  std::unordered_map<std::string, int>& values_;
 };
 
 } // namespace facebook::velox::expression::calculate

--- a/velox/expression/type_calculation/TypeCalculation.h
+++ b/velox/expression/type_calculation/TypeCalculation.h
@@ -22,5 +22,5 @@
 namespace facebook::velox::expression::calculation {
 void evaluate(
     const std::string& calculation,
-    std::unordered_map<std::string, std::optional<int>>& variables);
+    std::unordered_map<std::string, int>& variables);
 }

--- a/velox/expression/type_calculation/TypeCalculation.ll
+++ b/velox/expression/type_calculation/TypeCalculation.ll
@@ -35,7 +35,7 @@ int yyFlexLexer::yylex() {
 
 #include "velox/expression/type_calculation/TypeCalculation.h"
 
-void facebook::velox::expression::calculation::evaluate(const std::string& calculation, std::unordered_map<std::string, std::optional<int>>& variables) {
+void facebook::velox::expression::calculation::evaluate(const std::string& calculation, std::unordered_map<std::string, int>& variables) {
     std::istringstream is(calculation);
     facebook::velox::expression::calculate::Scanner scanner{ is, std::cerr, variables};
     facebook::velox::expression::calculate::Parser parser{ &scanner };

--- a/velox/functions/lib/MapConcat.cpp
+++ b/velox/functions/lib/MapConcat.cpp
@@ -161,7 +161,7 @@ class MapConcatFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V), map(K,V), ... -> map(K,V)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("map(K,V)")
                 .argumentType("map(K,V)")

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -82,7 +82,7 @@ class SubscriptImpl : public exec::VectorFunction {
             .build(),
         // map(K,V), K -> V
         exec::FunctionSignatureBuilder()
-            .typeVariable("K")
+            .knownTypeVariable("K")
             .typeVariable("V")
             .returnType("V")
             .argumentType("map(K,V)")

--- a/velox/functions/prestosql/FilterFunctions.cpp
+++ b/velox/functions/prestosql/FilterFunctions.cpp
@@ -239,7 +239,7 @@ class MapFilterFunction : public FilterFunctionBase {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V), function(K,V,boolean) -> map(K,V)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("map(K,V)")
                 .argumentType("map(K,V)")

--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -194,7 +194,7 @@ class MapFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // array(K), array(V) -> map(K,V)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("map(K,V)")
                 .argumentType("array(K)")

--- a/velox/functions/prestosql/MapEntries.cpp
+++ b/velox/functions/prestosql/MapEntries.cpp
@@ -55,7 +55,7 @@ class MapEntriesFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V) -> array(row(K,V))
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("array(row(K,V))")
                 .argumentType("map(K,V)")

--- a/velox/functions/prestosql/MapKeysAndValues.cpp
+++ b/velox/functions/prestosql/MapKeysAndValues.cpp
@@ -92,7 +92,7 @@ class MapKeysFunction : public MapKeyValueFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V) -> array(K)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("array(K)")
                 .argumentType("map(K,V)")
@@ -129,7 +129,7 @@ class MapValuesFunction : public MapKeyValueFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V) -> array(V)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("array(V)")
                 .argumentType("map(K,V)")

--- a/velox/functions/prestosql/MapZipWith.cpp
+++ b/velox/functions/prestosql/MapZipWith.cpp
@@ -210,7 +210,7 @@ class MapZipWithFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K, V1), map(K, V2), function(K, V1, V2, V3) -> map(K, V3)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V1")
                 .typeVariable("V2")
                 .typeVariable("V3")

--- a/velox/functions/prestosql/TransformValues.cpp
+++ b/velox/functions/prestosql/TransformValues.cpp
@@ -96,7 +96,7 @@ class TransformValuesFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K, V1), function(K, V1) -> V2 -> map(K, V2)
     return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V1")
                 .typeVariable("V2")
                 .returnType("map(K,V2)")

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -71,7 +71,7 @@ class MapAggAggregate : public aggregate::MapAggregateBase {
 bool registerMapAggAggregate(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
-          .typeVariable("K")
+          .knownTypeVariable("K")
           .typeVariable("V")
           .returnType("map(K,V)")
           .intermediateType("map(K,V)")

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -45,7 +45,7 @@ class MapUnionAggregate : public aggregate::MapAggregateBase {
 bool registerMapUnionAggregate(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
-          .typeVariable("K")
+          .knownTypeVariable("K")
           .typeVariable("V")
           .returnType("map(K,V)")
           .intermediateType("map(K,V)")

--- a/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
@@ -274,7 +274,7 @@ class MapInputBenchmark : public functions::test::FunctionBenchmarkBase {
     facebook::velox::exec::registerVectorFunction(
         "nested_map_sum_vector",
         {exec::FunctionSignatureBuilder()
-             .typeVariable("K")
+             .knownTypeVariable("K")
              .typeVariable("V")
              .returnType("bigint")
              .argumentType("map(K,V)")
@@ -284,7 +284,7 @@ class MapInputBenchmark : public functions::test::FunctionBenchmarkBase {
     facebook::velox::exec::registerVectorFunction(
         "nested_map_sum_vector_mapview",
         {exec::FunctionSignatureBuilder()
-             .typeVariable("K")
+             .knownTypeVariable("K")
              .typeVariable("V")
              .returnType("bigint")
              .argumentType("map(K,V)")

--- a/velox/functions/sparksql/Map.cpp
+++ b/velox/functions/sparksql/Map.cpp
@@ -161,7 +161,7 @@ class MapFunction : public exec::VectorFunction {
     signatures.reserve(kNumberOfSignatures);
     for (int i = 1; i <= kNumberOfSignatures; i++) {
       auto builder = exec::FunctionSignatureBuilder()
-                         .typeVariable("K")
+                         .knownTypeVariable("K")
                          .typeVariable("V")
                          .returnType("map(K,V)");
       for (int arg = 0; arg < i; arg++) {

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -164,7 +164,7 @@ class VectorFuncFour : public velox::exec::VectorFunction {
   signatures() {
     // map(K,V) -> array(K)
     return {velox::exec::FunctionSignatureBuilder()
-                .typeVariable("K")
+                .knownTypeVariable("K")
                 .typeVariable("V")
                 .returnType("array(K)")
                 .argumentType("map(K,V)")
@@ -372,7 +372,7 @@ TEST_F(FunctionRegistryTest, getFunctionSignatures) {
   ASSERT_EQ(
       functionSignatures["vector_func_four"].at(0)->toString(),
       exec::FunctionSignatureBuilder()
-          .typeVariable("K")
+          .knownTypeVariable("K")
           .typeVariable("V")
           .returnType("array(K)")
           .argumentType("map(K,V)")


### PR DESCRIPTION
Summary:
Velox expressions are type checked, if a function return type has "any" in it.
Then It Is impossible to infer its output type. This diff make sure such signature can't be created.

Reviewed By: mbasmanova

Differential Revision: D41167570

