### PR TITLE
All type variables should apear in the inputs

### DIFF
--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -25,6 +25,7 @@ class FunctionSignatureBuilderTest : public functions::test::FunctionBaseTest {
 };
 
 TEST_F(FunctionSignatureBuilderTest, basicTypeTests) {
+  // All type variables should be used in the inputs arguments.
   assertUserInvalidArgument(
       [=]() {
         FunctionSignatureBuilder()
@@ -33,7 +34,35 @@ TEST_F(FunctionSignatureBuilderTest, basicTypeTests) {
             .argumentType("integer")
             .build();
       },
-      "Not all type parameters used");
+      "Some type variables are not used in the inputs");
+
+  assertUserInvalidArgument(
+      [=]() {
+        FunctionSignatureBuilder()
+            .typeVariable("T")
+            .returnType("T")
+            .argumentType("integer")
+            .build();
+      },
+      "Some type variables are not used in the inputs");
+
+  // Integer variables do not have to be used in the inputs, but in that case
+  // must appear in the return.
+  ASSERT_NO_THROW(FunctionSignatureBuilder()
+                      .integerVariable("a")
+                      .returnType("DECIMAL(a, a)")
+                      .argumentType("integer")
+                      .build(););
+
+  assertUserInvalidArgument(
+      [=]() {
+        FunctionSignatureBuilder()
+            .integerVariable("a")
+            .returnType("integer")
+            .argumentType("integer")
+            .build();
+      },
+      "Some integer variables are not used");
 
   // Duplicate type params.
   assertUserInvalidArgument(
@@ -64,6 +93,7 @@ TEST_F(FunctionSignatureBuilderTest, basicTypeTests) {
         FunctionSignatureBuilder()
             .typeVariable("T")
             .returnType("integer")
+            .argumentType("T")
             .argumentType("array(M)")
             .build();
       },
@@ -86,7 +116,7 @@ TEST_F(FunctionSignatureBuilderTest, basicTypeTests) {
           .typeVariable("T")
           .typeVariable("M")
           .returnType("Array(M)")
-          .argumentType("Map(Map(Array(T)), Any)")
+          .argumentType("Map(Map(Array(T), M), Any)")
           .build() != nullptr);
 }
 

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -176,23 +176,29 @@ void validate(
     const std::unordered_map<std::string, SignatureVariable>& variables,
     const TypeSignature& returnType,
     const std::vector<TypeSignature>& argumentTypes) {
-  // Validate that the type params are unique.
-  std::unordered_set<std::string> usedTypeVariables;
-
+  std::unordered_set<std::string> usedVariables;
   // Validate the argument types.
   for (const auto& arg : argumentTypes) {
     // Is base type a type parameter or a built in type ?
-    validateBaseTypeAndCollectTypeParams(
-        variables, arg, usedTypeVariables, false);
+    validateBaseTypeAndCollectTypeParams(variables, arg, usedVariables, false);
+  }
+
+  // All type variables should apear in the inputs arguments.
+  for (auto& [name, variable] : variables) {
+    if (variable.isTypeParameter()) {
+      VELOX_USER_CHECK(
+          usedVariables.count(name),
+          "Some type variables are not used in the inputs");
+    }
   }
 
   validateBaseTypeAndCollectTypeParams(
-      variables, returnType, usedTypeVariables, true);
+      variables, returnType, usedVariables, true);
 
   VELOX_USER_CHECK_EQ(
-      usedTypeVariables.size(),
+      usedVariables.size(),
       variables.size(),
-      "Not all type parameters used");
+      "Some integer variables are not used");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
1. All type variables should appear in the inputs, for the signature to be typed.
2. Integer variables do not have to appear in the inputs. and could appear in the output. (we do not have a check yet that they have sufficient relational constraints).

Reviewed By: mbasmanova

Differential Revision: D41174121

