### PR TITLE
Increase runtime of DecodedVector benchmark and reduce vector size.

### DIFF
--- a/velox/benchmarks/basic/DecodedVector.cpp
+++ b/velox/benchmarks/basic/DecodedVector.cpp
@@ -16,7 +16,6 @@
 
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
-
 #include <gflags/gflags.h>
 
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
@@ -140,42 +139,50 @@ class DecodedVectorBenchmark : public functions::test::FunctionBenchmarkBase {
 
 std::unique_ptr<DecodedVectorBenchmark> benchmark;
 
-BENCHMARK_MULTI(scanFlat) {
-  return benchmark->runFlat();
+template <typename Func>
+void run(Func&& func, size_t iterations = 100) {
+  for (auto i = 0; i < iterations; i++) {
+    func();
+  }
 }
 
-BENCHMARK_MULTI(scanDecodedFlat) {
-  return benchmark->decodedRunFlat();
+BENCHMARK(scanFlat) {
+  run([&] { benchmark->runFlat(); });
 }
 
-BENCHMARK_MULTI(scanDecodedConstant) {
-  return benchmark->decodedRunConstant();
+BENCHMARK(scanDecodedFlat) {
+  run([&] { benchmark->decodedRunFlat(); });
 }
 
-BENCHMARK_MULTI(scanDecodedDict) {
-  return benchmark->decodedRunDict();
+BENCHMARK(scanDecodedConstant) {
+  run([&] { benchmark->decodedRunConstant(); });
 }
 
-BENCHMARK_MULTI(scanDecodedDict5Nested) {
-  return benchmark->decodedRunDict5Nested();
+BENCHMARK(scanDecodedDict) {
+  run([&] { benchmark->decodedRunDict(); });
+}
+
+BENCHMARK(scanDecodedDict5Nested) {
+  run([&] { benchmark->decodedRunDict5Nested(); });
 }
 
 BENCHMARK_DRAW_LINE();
 
+// For those we alwast report total runtime.
 BENCHMARK(decodeFlat) {
-  benchmark->decodeFlat();
+  run([&] { benchmark->decodeFlat(); });
 }
 
 BENCHMARK(decodeConstant) {
-  benchmark->decodeConstant();
+  run([&] { benchmark->decodeConstant(); });
 }
 
 BENCHMARK(decodeDictionary) {
-  benchmark->decodeDictionary();
+  run([&] { benchmark->decodeDictionary(); });
 }
 
 BENCHMARK(decodeDictionary5Nested) {
-  benchmark->decodeDictionary5Nested();
+  run([&] { benchmark->decodeDictionary5Nested(); });
 }
 
 } // namespace
@@ -184,7 +191,7 @@ int main(int argc, char* argv[]) {
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-  benchmark = std::make_unique<DecodedVectorBenchmark>(10'000'000);
+  benchmark = std::make_unique<DecodedVectorBenchmark>(100'000);
   folly::runBenchmarks();
   benchmark.reset();
   return 0;

--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -32,7 +32,6 @@ using namespace facebook::velox::exec;
 using namespace facebook::velox::test;
 
 namespace {
-
 // Variations of the simple multiply function regarding output values.
 template <typename T>
 struct MultiplyVoidOutputFunction {
@@ -134,16 +133,20 @@ class SimpleArithmeticBenchmark
         pool(), inputType_, nullptr, size, std::move(children));
   }
 
-  size_t runSmall(const std::string& expression, size_t times) {
-    return run(expression, times, smallRowVector_);
+  static constexpr auto kIterationsSmall = 10'000;
+  static constexpr auto kIterationsMeduim = 1000;
+  static constexpr auto kIterationsLarge = 100;
+
+  void runSmall(const std::string& expression) {
+    run(expression, kIterationsSmall, smallRowVector_);
   }
 
-  size_t runMedium(const std::string& expression, size_t times) {
-    return run(expression, times, mediumRowVector_);
+  void runMedium(const std::string& expression) {
+    run(expression, kIterationsMeduim, mediumRowVector_);
   }
 
-  size_t runLarge(const std::string& expression, size_t times) {
-    return run(expression, times, largeRowVector_);
+  void runLarge(const std::string& expression) {
+    run(expression, kIterationsLarge, largeRowVector_);
   }
 
   // Runs `expression` `times` thousand times.
@@ -154,7 +157,7 @@ class SimpleArithmeticBenchmark
     suspender.dismiss();
 
     size_t count = 0;
-    for (auto i = 0; i < times * 1'000; i++) {
+    for (auto i = 0; i < times; i++) {
       count += evaluate(exprSet, input)->size();
     }
     return count;
@@ -169,163 +172,160 @@ class SimpleArithmeticBenchmark
 
 std::unique_ptr<SimpleArithmeticBenchmark> benchmark;
 
-BENCHMARK_MULTI(multiplySmall, n) {
-  return benchmark->runSmall("multiply(a, b)", n);
+BENCHMARK(multiplySmall) {
+  benchmark->runSmall("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplySameColumnSmall, n) {
-  return benchmark->runSmall("multiply(a, a)", n);
+BENCHMARK(multiplySameColumnSmall) {
+  benchmark->runSmall("multiply(a, a)");
 }
 
-BENCHMARK_MULTI(multiplyHalfNullSmall, n) {
-  return benchmark->runSmall("multiply(a, half_null)", n);
+BENCHMARK(multiplyHalfNullSmall) {
+  benchmark->runSmall("multiply(a, half_null)");
 }
 
-BENCHMARK_MULTI(multiplyConstantSmall, n) {
-  return benchmark->runSmall("multiply(a, constant)", n);
+BENCHMARK(multiplyConstantSmall) {
+  benchmark->runSmall("multiply(a, constant)");
 }
 
-BENCHMARK_MULTI(multiplyNestedSmall, n) {
-  return benchmark->runSmall("multiply(multiply(a, b), b)", n);
+BENCHMARK(multiplyNestedSmall) {
+  benchmark->runSmall("multiply(multiply(a, b), b)");
 }
 
-BENCHMARK_MULTI(multiplyNestedDeepSmall, n) {
-  return benchmark->runSmall(
+BENCHMARK(multiplyNestedDeepSmall) {
+  benchmark->runSmall(
       "multiply(multiply(multiply(a, b), a), "
-      "multiply(a, multiply(a, b)))",
-      n);
+      "multiply(a, multiply(a, b)))");
 }
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(multiplyOutputVoidSmall, n) {
-  return benchmark->runSmall("multiply(a, b)", n);
+BENCHMARK(multiplyOutputVoidSmall) {
+  benchmark->runSmall("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputNullableSmall, n) {
-  return benchmark->runSmall("multiply_nullable_output(a, b)", n);
+BENCHMARK(multiplyOutputNullableSmall) {
+  benchmark->runSmall("multiply_nullable_output(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputAlwaysNullSmall, n) {
-  return benchmark->runSmall("multiply_null_output(a, b)", n);
-}
-
-BENCHMARK_DRAW_LINE();
-
-BENCHMARK_MULTI(plusUncheckedSmall, n) {
-  return benchmark->runSmall("plus(c, d)", n);
-}
-
-BENCHMARK_MULTI(plusCheckedSmall, n) {
-  return benchmark->runSmall("checked_plus(c, d)", n);
+BENCHMARK(multiplyOutputAlwaysNullSmall) {
+  benchmark->runSmall("multiply_null_output(a, b)");
 }
 
 BENCHMARK_DRAW_LINE();
+
+BENCHMARK(plusUncheckedSmall) {
+  benchmark->runSmall("plus(c, d)");
+}
+
+BENCHMARK(plusCheckedSmall) {
+  benchmark->runSmall("checked_plus(c, d)");
+}
+
+BENCHMARK_DRAW_LINE();
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(multiplyMedium, n) {
-  return benchmark->runMedium("multiply(a, b)", n);
+BENCHMARK(multiplyMedium) {
+  benchmark->runMedium("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplySameColumnMedium, n) {
-  return benchmark->runMedium("multiply(a, a)", n);
+BENCHMARK(multiplySameColumnMedium) {
+  benchmark->runMedium("multiply(a, a)");
 }
 
-BENCHMARK_MULTI(multiplyHalfNullMedium, n) {
-  return benchmark->runMedium("multiply(a, half_null)", n);
+BENCHMARK(multiplyHalfNullMedium) {
+  benchmark->runMedium("multiply(a, half_null)");
 }
 
-BENCHMARK_MULTI(multiplyConstantMedium, n) {
-  return benchmark->runMedium("multiply(a, constant)", n);
+BENCHMARK(multiplyConstantMedium) {
+  benchmark->runMedium("multiply(a, constant)");
 }
 
-BENCHMARK_MULTI(multiplyNestedMedium, n) {
-  return benchmark->runMedium("multiply(multiply(a, b), b)", n);
+BENCHMARK(multiplyNestedMedium) {
+  benchmark->runMedium("multiply(multiply(a, b), b)");
 }
 
-BENCHMARK_MULTI(multiplyNestedDeepMedium, n) {
-  return benchmark->runMedium(
+BENCHMARK(multiplyNestedDeepMedium) {
+  benchmark->runMedium(
       "multiply(multiply(multiply(a, b), a), "
-      "multiply(a, multiply(a, b)))",
-      n);
+      "multiply(a, multiply(a, b)))");
 }
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(multiplyOutputVoidMedium, n) {
-  return benchmark->runMedium("multiply(a, b)", n);
+BENCHMARK(multiplyOutputVoidMedium) {
+  benchmark->runMedium("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputNullableMedium, n) {
-  return benchmark->runMedium("multiply_nullable_output(a, b)", n);
+BENCHMARK(multiplyOutputNullableMedium) {
+  benchmark->runMedium("multiply_nullable_output(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputAlwaysNullMedium, n) {
-  return benchmark->runMedium("multiply_null_output(a, b)", n);
-}
-
-BENCHMARK_DRAW_LINE();
-
-BENCHMARK_MULTI(plusUncheckedMedium, n) {
-  return benchmark->runMedium("plus(c, d)", n);
-}
-
-BENCHMARK_MULTI(plusCheckedMedium, n) {
-  return benchmark->runMedium("checked_plus(c, d)", n);
+BENCHMARK(multiplyOutputAlwaysNullMedium) {
+  benchmark->runMedium("multiply_null_output(a, b)");
 }
 
 BENCHMARK_DRAW_LINE();
+
+BENCHMARK(plusUncheckedMedium) {
+  benchmark->runMedium("plus(c, d)");
+}
+
+BENCHMARK(plusCheckedMedium) {
+  benchmark->runMedium("checked_plus(c, d)");
+}
+
+BENCHMARK_DRAW_LINE();
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(multiplyLarge, n) {
-  return benchmark->runLarge("multiply(a, b)", n);
+BENCHMARK(multiplyLarge) {
+  benchmark->runLarge("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplySameColumnLarge, n) {
-  return benchmark->runLarge("multiply(a, a)", n);
+BENCHMARK(multiplySameColumnLarge) {
+  benchmark->runLarge("multiply(a, a)");
 }
 
-BENCHMARK_MULTI(multiplyHalfNullLarge, n) {
-  return benchmark->runLarge("multiply(a, half_null)", n);
+BENCHMARK(multiplyHalfNullLarge) {
+  benchmark->runLarge("multiply(a, half_null)");
 }
 
-BENCHMARK_MULTI(multiplyConstantLarge, n) {
-  return benchmark->runLarge("multiply(a, constant)", n);
+BENCHMARK(multiplyConstantLarge) {
+  benchmark->runLarge("multiply(a, constant)");
 }
 
-BENCHMARK_MULTI(multiplyNestedLarge, n) {
-  return benchmark->runLarge("multiply(multiply(a, b), b)", n);
+BENCHMARK(multiplyNestedLarge) {
+  benchmark->runLarge("multiply(multiply(a, b), b)");
 }
 
-BENCHMARK_MULTI(multiplyNestedDeepLarge, n) {
-  return benchmark->runLarge(
+BENCHMARK(multiplyNestedDeepLarge) {
+  benchmark->runLarge(
       "multiply(multiply(multiply(a, b), a), "
-      "multiply(a, multiply(a, b)))",
-      n);
+      "multiply(a, multiply(a, b)))");
 }
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(multiplyOutputVoidLarge, n) {
-  return benchmark->runLarge("multiply(a, b)", n);
+BENCHMARK(multiplyOutputVoidLarge) {
+  benchmark->runLarge("multiply(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputNullableLarge, n) {
-  return benchmark->runLarge("multiply_nullable_output(a, b)", n);
+BENCHMARK(multiplyOutputNullableLarge) {
+  benchmark->runLarge("multiply_nullable_output(a, b)");
 }
 
-BENCHMARK_MULTI(multiplyOutputAlwaysNullLarge, n) {
-  return benchmark->runLarge("multiply_null_output(a, b)", n);
+BENCHMARK(multiplyOutputAlwaysNullLarge) {
+  benchmark->runLarge("multiply_null_output(a, b)");
 }
 
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_MULTI(plusUncheckedLarge, n) {
-  return benchmark->runLarge("plus(c, d)", n);
+BENCHMARK(plusUncheckedLarge) {
+  benchmark->runLarge("plus(c, d)");
 }
 
-BENCHMARK_MULTI(plusCheckedLarge, n) {
-  return benchmark->runLarge("checked_plus(c, d)", n);
+BENCHMARK(plusCheckedLarge) {
+  benchmark->runLarge("checked_plus(c, d)");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Our Meta-internal benchmark validation tool operates on a granularity of 1ns, this
requires that benchmarks generates runtimes>>1ns.
Report total time instead of per row time to get longer runtime.

Also it changes the vector size to 10k.
```
============================================================================
[...]ox/benchmarks/basic/DecodedVector.cpp     relative  time/iter   iters/s
============================================================================
scanFlat                                                  121.56us     8.23K
scanDecodedFlat                                           123.37us     8.11K
scanDecodedConstant                                         4.11us   243.06K
scanDecodedDict                                           563.65us     1.77K
scanDecodedDict5Nested                                    574.59us     1.74K
----------------------------------------------------------------------------
decodeFlat                                                  2.12us   471.29K
decodeConstant                                              3.45us   290.09K
decodeDictionary                                            9.63us   103.79K
decodeDictionary5Nested                                     6.67ms    149.94
````

Differential Revision: D41190560

