### PR TITLE
Fix outputDriverFinishEarly test deadlock issue

### DIFF
--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -77,7 +77,7 @@ void setThreadLocalRunTimeStatWriter(
     BaseRuntimeStatWriter* FOLLY_NULLABLE writer);
 
 /// Retrives the current runtime stats writer.
-BaseRuntimeStatWriter* getThreadLocalRunTimeStatWriter();
+BaseRuntimeStatWriter* FOLLY_NULLABLE getThreadLocalRunTimeStatWriter();
 
 /// Writes runtime counter to the current Operator running on that thread.
 void addThreadLocalRuntimeStat(
@@ -87,7 +87,7 @@ void addThreadLocalRuntimeStat(
 /// Scope guard to conveniently set and revert back the current stat writer.
 class RuntimeStatWriterScopeGuard {
  public:
-  RuntimeStatWriterScopeGuard(BaseRuntimeStatWriter* writer)
+  RuntimeStatWriterScopeGuard(BaseRuntimeStatWriter* FOLLY_NULLABLE writer)
       : prevWriter_(getThreadLocalRunTimeStatWriter()) {
     setThreadLocalRunTimeStatWriter(writer);
   }

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -808,7 +808,7 @@ class MultiThreadedHashJoinTest
 };
 
 TEST_P(MultiThreadedHashJoinTest, bigintArray) {
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .keyTypes({BIGINT()})
       .probeVectors(1600, 5)
@@ -819,7 +819,7 @@ TEST_P(MultiThreadedHashJoinTest, bigintArray) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, outOfJoinKeyColumnOrder) {
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeType(probeType_)
       .probeKeys({"t_k2"})
@@ -834,7 +834,7 @@ TEST_P(MultiThreadedHashJoinTest, outOfJoinKeyColumnOrder) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, emptyBuild) {
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .keyTypes({BIGINT()})
       .probeVectors(1600, 5)
@@ -852,7 +852,7 @@ TEST_P(MultiThreadedHashJoinTest, emptyBuild) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, emptyProbe) {
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .keyTypes({BIGINT()})
       .probeVectors(0, 5)
@@ -863,7 +863,7 @@ TEST_P(MultiThreadedHashJoinTest, emptyProbe) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, normalizedKey) {
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .keyTypes({BIGINT(), VARCHAR()})
       .probeVectors(1600, 5)
@@ -874,7 +874,7 @@ TEST_P(MultiThreadedHashJoinTest, normalizedKey) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, normalizedKeyOverflow) {
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .keyTypes({BIGINT(), VARCHAR(), BIGINT(), BIGINT(), BIGINT(), BIGINT()})
       .probeVectors(1600, 5)
       .buildVectors(1500, 5)
@@ -888,7 +888,7 @@ DEBUG_ONLY_TEST_P(MultiThreadedHashJoinTest, parallelJoinBuildCheck) {
   SCOPED_TESTVALUE_SET(
       "facebook::velox::exec::HashTable::parallelJoinBuild",
       std::function<void(void*)>([&](void*) { isParallelBuild = true; }));
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .keyTypes({BIGINT(), VARCHAR()})
       .probeVectors(1600, 5)
@@ -901,7 +901,7 @@ DEBUG_ONLY_TEST_P(MultiThreadedHashJoinTest, parallelJoinBuildCheck) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, allTypes) {
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .keyTypes(
           {BIGINT(),
            VARCHAR(),
@@ -918,7 +918,7 @@ TEST_P(MultiThreadedHashJoinTest, allTypes) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, filter) {
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .keyTypes({BIGINT()})
       .probeVectors(1600, 5)
@@ -954,7 +954,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithNull) {
         makeBatches(5, 6, buildType_, pool_.get(), 0.0),
         makeBatches(5, 6, buildType_, pool_.get(), testData.buildNullRatio));
 
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeType(probeType_)
         .probeKeys({"t_k2"})
@@ -991,7 +991,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithLargeOutput) {
              makeFlatVector<int32_t>(2048, [](auto row) { return row; })});
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"t0"})
       .probeVectors(std::move(probeVectors))
@@ -1042,7 +1042,7 @@ TEST_P(MultiThreadedHashJoinTest, arrayBasedLookup) {
       makeRowVector(
           {makeFlatVector<int32_t>(100, [](auto row) { return row; })})};
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -1108,7 +1108,7 @@ TEST_P(MultiThreadedHashJoinTest, joinSidesDifferentSchema) {
       //"  u.c2 > 10 AND ltrim(t.c1) = 'aaa'";
       "  u.c2 > 10";
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"t_c0"})
       .probeVectors(std::move(probeVectors))
@@ -1141,7 +1141,7 @@ TEST_P(MultiThreadedHashJoinTest, innerJoinWithEmptyBuild) {
         nullEvery(7))});
   });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -1162,7 +1162,7 @@ TEST_P(MultiThreadedHashJoinTest, innerJoinWithEmptyBuild) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, leftSemiJoinFilter) {
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeType(probeType_)
       .probeVectors(174, 5)
@@ -1193,7 +1193,7 @@ TEST_P(MultiThreadedHashJoinTest, leftSemiJoinFilterWithEmptyBuild) {
         });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -1233,7 +1233,7 @@ TEST_P(MultiThreadedHashJoinTest, leftSemiJoinFilterWithExtraFilter) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
@@ -1249,7 +1249,7 @@ TEST_P(MultiThreadedHashJoinTest, leftSemiJoinFilterWithExtraFilter) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
@@ -1265,7 +1265,7 @@ TEST_P(MultiThreadedHashJoinTest, leftSemiJoinFilterWithExtraFilter) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilter) {
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeType(probeType_)
       .probeVectors(133, 3)
@@ -1301,7 +1301,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyBuild) {
             });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"t0"})
       .probeVectors(std::move(probeVectors))
@@ -1346,7 +1346,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithAllMatches) {
              makeFlatVector<int32_t>(314, [](auto row) { return row; })});
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"t0"})
       .probeVectors(std::move(probeVectors))
@@ -1381,7 +1381,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithExtraFilter) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
@@ -1403,7 +1403,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithExtraFilter) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
@@ -1424,7 +1424,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithExtraFilter) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
@@ -1496,14 +1496,14 @@ TEST_P(MultiThreadedHashJoinTest, semiFilterOverLazyVectors) {
       {buildScanId, {exec::Split(makeHiveConnectorSplit(buildFile->path))}},
   };
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
       .inputSplits(splitInput)
       .checkSpillStats(false)
       .referenceQuery("SELECT t0, t1 FROM t WHERE t0 IN (SELECT u0 FROM u)")
       .run();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
       .inputSplits(splitInput)
       .checkSpillStats(false)
@@ -1527,7 +1527,7 @@ TEST_P(MultiThreadedHashJoinTest, semiFilterOverLazyVectors) {
                  core::JoinType::kLeftSemiFilter)
              .planNode();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
       .inputSplits(splitInput)
       .checkSpillStats(false)
@@ -1535,7 +1535,7 @@ TEST_P(MultiThreadedHashJoinTest, semiFilterOverLazyVectors) {
           "SELECT t0, t1 FROM t WHERE t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0)")
       .run();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
       .inputSplits(splitInput)
       .checkSpillStats(false)
@@ -1565,7 +1565,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoin) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
@@ -1584,7 +1584,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoin) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
@@ -1603,7 +1603,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoin) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
@@ -1639,7 +1639,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilter) {
             });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"t0"})
       .probeVectors(std::move(probeVectors))
@@ -1680,7 +1680,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterAndEmptyBuild) {
             makeFlatVector<int32_t>({0, 2, 3}),
         });
   });
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"t0"})
       .probeVectors(std::vector<RowVectorPtr>(probeVectors))
@@ -1731,7 +1731,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterAndNullKey) {
 
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
@@ -1777,7 +1777,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterOnNullableColumn) {
               makeFlatVector<int32_t>(234, folly::identity, nullEvery(91)),
           });
     });
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"t0"})
         .probeVectors(std::move(probeVectors))
@@ -1820,7 +1820,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterOnNullableColumn) {
               makeFlatVector<int32_t>(234, folly::identity, nullEvery(37)),
           });
     });
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"t0"})
         .probeVectors(std::move(probeVectors))
@@ -1861,7 +1861,7 @@ TEST_P(MultiThreadedHashJoinTest, antiJoin) {
             makeFlatVector<int32_t>({0, 2, 3}),
         });
   });
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"t0"})
       .probeVectors(std::vector<RowVectorPtr>(probeVectors))
@@ -1875,7 +1875,7 @@ TEST_P(MultiThreadedHashJoinTest, antiJoin) {
 
   std::vector<std::string> filters({"u1 > t1", "u1 * t1 > 0"});
   for (const std::string& filter : filters) {
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"t0"})
         .probeVectors(std::vector<RowVectorPtr>(probeVectors))
@@ -1908,7 +1908,7 @@ TEST_P(MultiThreadedHashJoinTest, antiJoinWithFilterAndEmptyBuild) {
             makeFlatVector<int32_t>({0, 2, 3}),
         });
   });
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"t0"})
       .probeVectors(std::vector<RowVectorPtr>(probeVectors))
@@ -1974,7 +1974,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoin) {
         });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -2032,7 +2032,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithEmptyBuild) {
         });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -2091,7 +2091,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithNoJoin) {
         });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -2148,7 +2148,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithAllMatch) {
         });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -2210,7 +2210,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithFilter) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
@@ -2229,7 +2229,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithFilter) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
@@ -2275,7 +2275,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithNullableFilter) {
         return makeRowVector({makeFlatVector<int32_t>({1, 2, 10, 30, 40})});
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -2326,7 +2326,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoin) {
         });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -2376,7 +2376,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithEmptyBuild) {
         });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -2427,7 +2427,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithAllMatch) {
         });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -2482,7 +2482,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithFilter) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
@@ -2501,7 +2501,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithFilter) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
@@ -2554,7 +2554,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoin) {
         });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -2604,7 +2604,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithEmptyBuild) {
         });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -2656,7 +2656,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithNoMatch) {
         });
       });
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
@@ -2711,7 +2711,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithFilters) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
@@ -2730,7 +2730,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithFilters) {
   {
     auto testProbeVectors = probeVectors;
     auto testBuildVectors = buildVectors;
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
@@ -2747,7 +2747,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithFilters) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, noSpillLevelLimit) {
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
       .keyTypes({INTEGER()})
       .probeVectors(1600, 5)
@@ -2805,13 +2805,13 @@ TEST_F(HashJoinTest, semiProject) {
                       core::JoinType::kLeftSemiProject)
                   .planNode();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
       .referenceQuery(
           "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0) FROM t")
       .run();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
       .referenceQuery(
           "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0) FROM t")
@@ -2834,13 +2834,13 @@ TEST_F(HashJoinTest, semiProject) {
                  core::JoinType::kLeftSemiProject)
              .planNode();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
       .referenceQuery(
           "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND t.c1 * 10 <> u.c1) FROM t")
       .run();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
       .referenceQuery(
           "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND t.c1 * 10 <> u.c1) FROM t")
@@ -2864,7 +2864,7 @@ TEST_F(HashJoinTest, semiProject) {
                  core::JoinType::kLeftSemiProject)
              .planNode();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
       .referenceQuery(
           "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE u.c0 < 0 AND t.c0 = u.c0) FROM t")
@@ -2873,7 +2873,7 @@ TEST_F(HashJoinTest, semiProject) {
       .checkSpillStats(false)
       .run();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
       .referenceQuery(
           "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE u.c0 < 0 AND t.c0 = u.c0) FROM t")
@@ -2935,12 +2935,12 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
   // Null join keys on both sides.
   auto plan = makePlan();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
       .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
       .run();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
       .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
       .run();
@@ -2948,13 +2948,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
   // Null join keys on build side-only.
   plan = makePlan("t0 IS NOT NULL");
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
       .referenceQuery(
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t WHERE t0 IS NOT NULL")
       .run();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
       .referenceQuery(
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t WHERE t0 IS NOT NULL")
@@ -2963,13 +2963,13 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
   // Null join keys on probe side-only.
   plan = makePlan("", "u0 IS NOT NULL");
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
       .referenceQuery(
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NOT NULL) FROM t")
       .run();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
       .referenceQuery(
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE u0 IS NOT NULL) FROM t")
@@ -3029,14 +3029,14 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
       {buildScanId, {exec::Split(makeHiveConnectorSplit(buildFile->path))}},
   };
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
       .inputSplits(splitInput)
       .checkSpillStats(false)
       .referenceQuery("SELECT t0, t1, t0 IN (SELECT u0 FROM u) FROM t")
       .run();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
       .inputSplits(splitInput)
       .checkSpillStats(false)
@@ -3060,7 +3060,7 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
                  core::JoinType::kLeftSemiProject)
              .planNode();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(plan)
       .inputSplits(splitInput)
       .checkSpillStats(false)
@@ -3068,7 +3068,7 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
           "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t")
       .run();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(flipJoinSides(plan))
       .inputSplits(splitInput)
       .checkSpillStats(false)
@@ -3116,7 +3116,7 @@ TEST_F(HashJoinTest, memory) {
                         .project({"t_k1 % 1000 AS k1", "u_k1 % 1000 AS k2"})
                         .singleAggregation({}, {"sum(k1)", "sum(k2)"})
                         .planNode();
-  params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
   auto tracker = memory::MemoryUsageTracker::create();
   params.queryCtx->pool()->setMemoryUsageTracker(tracker);
 
@@ -3189,7 +3189,7 @@ TEST_F(HashJoinTest, lazyVectors) {
     SplitInput splits;
     splits.emplace(probeScanId, probeSplits);
     splits.emplace(buildScanId, buildSplits);
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .planNode(std::move(op))
         .inputSplits(splits)
         .referenceQuery("SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0")
@@ -3223,7 +3223,7 @@ TEST_F(HashJoinTest, lazyVectors) {
     splits.emplace(probeScanId, probeSplits);
     splits.emplace(buildScanId, buildSplits);
 
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .planNode(std::move(op))
         .inputSplits(splits)
         .referenceQuery(
@@ -3309,7 +3309,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
       SplitInput splits;
       splits.emplace(probeScanId, probeSplits);
 
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .planNode(std::move(op))
           .inputSplits(splits)
           .referenceQuery(
@@ -3349,7 +3349,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
       SplitInput splits;
       splits.emplace(probeScanId, probeSplits);
 
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .planNode(std::move(op))
           .inputSplits(splits)
           .referenceQuery(
@@ -3390,7 +3390,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
       SplitInput splits;
       splits.emplace(probeScanId, probeSplits);
 
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .planNode(std::move(op))
           .inputSplits(splits)
           .referenceQuery(
@@ -3437,7 +3437,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     SplitInput splits;
     splits.emplace(probeScanId, probeSplits);
 
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .planNode(std::move(op))
         .inputSplits(splits)
         .referenceQuery(
@@ -3473,7 +3473,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     SplitInput splits;
     splits.emplace(probeScanId, probeSplits);
 
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .planNode(std::move(op))
         .inputSplits(splits)
         .referenceQuery(
@@ -3510,7 +3510,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     SplitInput splits;
     splits.emplace(probeScanId, probeSplits);
 
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .planNode(std::move(op))
         .inputSplits(splits)
         .referenceQuery("SELECT t.c0, t.c1 + 1 FROM t, u WHERE t.c0 = u.c0")
@@ -3547,7 +3547,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     SplitInput splits;
     splits.emplace(probeScanId, probeSplits);
 
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .planNode(std::move(op))
         .inputSplits(splits)
         .referenceQuery("SELECT t.c0 FROM t JOIN u ON (t.c0 = u.c0)")
@@ -3584,7 +3584,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     SplitInput splits;
     splits.emplace(probeScanId, probeSplits);
 
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .planNode(std::move(op))
         .inputSplits(splits)
         .referenceQuery(
@@ -3624,7 +3624,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
       SplitInput splits;
       splits.emplace(probeScanId, probeSplits);
 
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .planNode(std::move(op))
           .inputSplits(splits)
           .referenceQuery(
@@ -3665,7 +3665,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
       SplitInput splits;
       splits.emplace(probeScanId, probeSplits);
 
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .planNode(std::move(op))
           .inputSplits(splits)
           .referenceQuery(
@@ -3706,7 +3706,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
       SplitInput splits;
       splits.emplace(probeScanId, probeSplits);
 
-      HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .planNode(std::move(op))
           .inputSplits(splits)
           .referenceQuery(
@@ -3738,7 +3738,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
                   .project({"c1 + 1"})
                   .planNode();
 
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .planNode(std::move(op))
         .referenceQuery("SELECT t.c1 + 1 FROM t, u WHERE t.c0 = u.c0")
         .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
@@ -3764,7 +3764,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     SplitInput splits;
     splits.emplace(probeScanId, probeSplits);
 
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .planNode(std::move(op))
         .inputSplits(splits)
         .referenceQuery("SELECT t.c1 + 1 FROM t, u WHERE (t.c0 + 1) = u.c0")
@@ -3813,7 +3813,7 @@ TEST_F(HashJoinTest, memoryUsage) {
                   .singleAggregation({}, {"count(1)"})
                   .planNode();
 
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(std::move(plan))
       .referenceQuery("SELECT 30000")
       .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
@@ -3872,7 +3872,7 @@ TEST_F(HashJoinTest, smallOutputBatchSize) {
 
   // Use small output batch size to trigger logic for calculating set of
   // probe-side rows to load lazy vectors for.
-  HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(std::move(plan))
       .config(core::QueryConfig::kPreferredOutputBatchSize, std::to_string(10))
       .referenceQuery("SELECT c0, u_c1 FROM t, u WHERE c0 = u_c0 AND c1 < u_c1")
@@ -3884,7 +3884,7 @@ TEST_F(HashJoinTest, spillFileSize) {
   const std::vector<uint64_t> maxSpillFileSizes({0, 1, 1'000'000'000});
   for (const auto spillFileSize : maxSpillFileSizes) {
     SCOPED_TRACE(fmt::format("spillFileSize: {}", spillFileSize));
-    HashJoinBuilder(*pool_, duckDbQueryRunner_, executor_.get())
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
         .keyTypes({BIGINT()})
         .probeVectors(100, 3)

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -90,7 +90,7 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
       "task-1",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(executor_.get()));
+      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
 
   // Add split for the source node.
   task.addSplit("0", exec::Split(folly::copy(connectorSplit)));
@@ -142,7 +142,7 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
       "task-2",
       std::move(plan),
       0,
-      std::make_shared<core::QueryCtx>(executor_.get()));
+      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
   errorMessage =
       "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 0 doesn't refer to such plan node.";
   VELOX_ASSERT_THROW(
@@ -168,7 +168,7 @@ TEST_F(TaskTest, duplicatePlanNodeIds) {
           "task-1",
           std::move(plan),
           0,
-          std::make_shared<core::QueryCtx>(executor_.get())),
+          std::make_shared<core::QueryCtx>(driverExecutor_.get())),
       "Plan node IDs must be unique. Found duplicate ID: 0.")
 }
 
@@ -646,7 +646,7 @@ DEBUG_ONLY_TEST_F(TaskTest, outputDriverFinishEarly) {
           .limit(0, 1, false)
           .planNode();
 
-  // Setup the test value to generate the race condition that the output
+  // Set up the test value to generate the race condition that the output
   // pipeline finishes early and terminate the task while the input pipeline
   // driver is running on thread.
   ContinuePromise mergePromise("mergePromise");
@@ -687,11 +687,11 @@ DEBUG_ONLY_TEST_F(TaskTest, outputDriverFinishEarly) {
 
   CursorParameters params;
   params.planNode = plan;
-  params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
   params.queryCtx->setConfigOverridesUnsafe(
       {{core::QueryConfig::kPreferredOutputBatchSize, "1"}});
   auto task = assertQueryOrdered(params, "VALUES (0)", {0});
-  waitForTaskCompletion(task.get(), 1'000'000);
+  ASSERT_TRUE(waitForTaskCompletion(task.get(), 1'000'000));
   task.reset();
   valuePromise.setValue();
   // Wait for Values driver to complete.

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -31,19 +31,15 @@ HiveConnectorTestBase::HiveConnectorTestBase() {
 
 void HiveConnectorTestBase::SetUp() {
   OperatorTestBase::SetUp();
-  executor_ = std::make_unique<folly::IOThreadPoolExecutor>(3);
   auto hiveConnector =
       connector::getConnectorFactory(
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector(kHiveConnectorId, nullptr, executor_.get());
+          ->newConnector(kHiveConnectorId, nullptr, ioExecutor_.get());
   connector::registerConnector(hiveConnector);
   dwrf::registerDwrfReaderFactory();
 }
 
 void HiveConnectorTestBase::TearDown() {
-  if (executor_) {
-    executor_->join();
-  }
   dwrf::unregisterDwrfReaderFactory();
   connector::unregisterConnector(kHiveConnectorId);
   OperatorTestBase::TearDown();

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -20,8 +20,6 @@
 #include "velox/exec/tests/utils/TempFilePath.h"
 #include "velox/type/tests/SubfieldFiltersBuilder.h"
 
-#include <folly/executors/IOThreadPoolExecutor.h>
-
 namespace facebook::velox::exec::test {
 
 static const std::string kHiveConnectorId = "test-hive";
@@ -144,8 +142,6 @@ class HiveConnectorTestBase : public OperatorTestBase {
   memory::MappedMemory* mappedMemory() {
     return memory::MappedMemory::getInstance();
   }
-
-  std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
 };
 
 class HiveConnectorSplitBuilder {

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -65,6 +65,8 @@ void OperatorTestBase::SetUp() {
   if (!isRegisteredVectorSerde()) {
     this->registerVectorSerde();
   }
+  driverExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(3);
+  ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(3);
 }
 
 void OperatorTestBase::SetUpTestCase() {

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -15,7 +15,9 @@
  */
 #pragma once
 
+#include <folly/executors/IOThreadPoolExecutor.h>
 #include <gtest/gtest.h>
+
 #include "velox/common/caching/SsdCache.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/PlanNode.h"
@@ -135,5 +137,11 @@ class OperatorTestBase : public testing::Test,
 
   // Used as default MappedMemory. Created on first use.
   static std::shared_ptr<cache::AsyncDataCache> asyncDataCache_;
+
+  // Used for driver thread execution.
+  std::unique_ptr<folly::CPUThreadPoolExecutor> driverExecutor_;
+
+  // Used for IO prefetch and spilling.
+  std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
 };
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
outputDriverFinishEarly test is designed as one driver thread A will
(1) resume a driver execution; (2) wait for a future signaled by the
test main thread. The test main thread will wait for the resumed
driver execution to finish before signal the future wait by the driver
thread A. TaskTest use folly IO executor as the driver executor which
has one queue per thread ([ref]((https://github.com/facebook/folly/blob/main/folly/executors/IOThreadPoolExecutor.h#L45))) so that the resumed driver execution or
its scheduled callback will be queued in the same queue of driver
thread A which will never be executed which form a deadlock.

This PR fixed the test issue by using folly cpu executor which is the
right type of executor as used in prod as well. Move the executor_
from HiveConnectorTestBase class to OperatorTeseBase as ioExecutor_
for prefetch io and spilling uses. And add driverExecutor_ in OperatorTeseBase
for driver thread execution.

In followup, we will move the ownership of spilling executor out of QueryCtx
similar to what we do for driver executor. For test, we could use ioExecutor_
for spilling thread execution.

