### PR TITLE
Fix typo in Exceptions.h

### DIFF
--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -270,7 +270,7 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
       /* isRetriable */ false,                                   \
       ##__VA_ARGS__)
 
-#define VELOX_SCHMEA_MISMATCH_ERROR(...)                         \
+#define VELOX_SCHEMA_MISMATCH_ERROR(...)                         \
   _VELOX_THROW(                                                  \
       ::facebook::velox::VeloxUserError,                         \
       ::facebook::velox::error_source::kErrorSourceUser.c_str(), \

--- a/velox/dwio/common/TypeUtils.h
+++ b/velox/dwio/common/TypeUtils.h
@@ -122,7 +122,7 @@ class CompatChecker {
       bool recurse,
       const std::function<std::string()>& exceptionMessageCreator) const {
     if (!compat(from.kind(), to.kind())) {
-      VELOX_SCHMEA_MISMATCH_ERROR(fmt::format(
+      VELOX_SCHEMA_MISMATCH_ERROR(fmt::format(
           "{}, From Kind: {}, To Kind: {}",
           exceptionMessageCreator ? exceptionMessageCreator() : "",
           velox::mapTypeKindToName(from.kind()),


### PR DESCRIPTION
`SCHMEA` => `SCHEMA`

There are no functional changes in this patch.