### PR TITLE
Fuzzer: fuzz window expressions

### DIFF
--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -94,8 +94,10 @@ class AggregateWindowFunction : public exec::WindowFunction {
   ~AggregateWindowFunction() {
     // Needed to delete any out-of-line storage for the accumulator in the
     // group row.
-    std::vector<char*> singleGroupRowVector = {rawSingleGroupRow_};
-    aggregate_->destroy(folly::Range(singleGroupRowVector.data(), 1));
+    if (aggregateInitialized_) {
+      std::vector<char*> singleGroupRowVector = {rawSingleGroupRow_};
+      aggregate_->destroy(folly::Range(singleGroupRowVector.data(), 1));
+    }
   }
 
   void resetPartition(const exec::WindowPartition* partition) override {
@@ -134,6 +136,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
         auto singleGroup = std::vector<vector_size_t>{0};
         aggregate_->clear();
         aggregate_->initializeNewGroups(&rawSingleGroupRow_, singleGroup);
+        aggregateInitialized_ = true;
       }
 
       fillArgVectors(startRow, frameMetadata.lastRow);
@@ -234,8 +237,11 @@ class AggregateWindowFunction : public exec::WindowFunction {
     rows.setValidRange(startFrame, endFrame, true);
     rows.updateBounds();
 
+    BaseVector::prepareForReuse(aggregateResultVector_, 1);
+
     aggregate_->addSingleGroupRawInput(
         rawSingleGroupRow_, rows, argVectors_, false);
+    aggregate_->finalize(&rawSingleGroupRow_, 1);
     aggregate_->extractValues(&rawSingleGroupRow_, 1, &aggregateResultVector_);
   }
 
@@ -285,6 +291,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
       // require adding new APIs to the Aggregate framework.
       aggregate_->clear();
       aggregate_->initializeNewGroups(&rawSingleGroupRow_, kSingleGroup);
+      aggregateInitialized_ = true;
 
       auto frameStartIndex = frameStartsVector[i] - minFrame;
       auto frameEndIndex = frameEndsVector[i] - minFrame + 1;
@@ -295,6 +302,8 @@ class AggregateWindowFunction : public exec::WindowFunction {
 
   // Aggregate function object required for this window function evaluation.
   std::unique_ptr<exec::Aggregate> aggregate_;
+
+  bool aggregateInitialized_{false};
 
   // Current WindowPartition used for accessing rows in the apply method.
   const exec::WindowPartition* partition_;

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -129,7 +129,7 @@ target_link_libraries(velox_aggregation_fuzzer velox_type velox_vector_fuzzer
 add_executable(velox_aggregation_fuzzer_test AggregationFuzzerTest.cpp)
 
 target_link_libraries(velox_aggregation_fuzzer_test velox_aggregation_fuzzer
-                      velox_aggregates gtest gtest_main)
+                      velox_aggregates velox_window gtest gtest_main)
 
 # Join Fuzzer.
 

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -591,7 +591,7 @@ std::string generateUserFriendlyDiff(
 
 void verifyDuckDBResult(const DuckDBQueryResult& result, std::string_view sql) {
   VELOX_CHECK(
-      result->success, "DuckDB query failed: {} \n {}", result->error, sql);
+      result->success, "DuckDB query failed: {}\n{}", result->error, sql);
 }
 
 } // namespace

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -98,6 +98,7 @@ class HistogramAggregate : public exec::Aggregate {
       if (mapSize == 0) {
         bits::setNull(rawNulls, i, true);
       } else {
+        clearNull(rawNulls, i);
         for (auto it = groupMap->begin(); it != groupMap->end(); ++it) {
           mapKeys->set(index, it->first);
           mapValues->set(index, it->second);

--- a/velox/functions/prestosql/aggregates/MapAggregateBase.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggregateBase.cpp
@@ -39,6 +39,7 @@ void MapAggregateBase::extractValues(
 
     if (isNull(group)) {
       mapVector->setNull(i, true);
+      mapVector->setOffsetAndSize(i, 0, 0);
       continue;
     }
 
@@ -86,6 +87,9 @@ VectorPtr MapAggregateBase::removeDuplicates(MapVectorPtr& mapVector) const {
 
   // Check for duplicate keys.
   for (vector_size_t row = 0; row < numRows; row++) {
+    if (mapVector->isNullAt(row)) {
+      continue;
+    }
     auto offset = offsets[row];
     auto size = sizes[row];
     auto duplicateCnt = 0;

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -1023,6 +1023,8 @@ uint64_t MapVector::estimateFlatSize() const {
 void MapVector::prepareForReuse() {
   BaseVector::prepareForReuse();
 
+  sortedKeys_ = false;
+
   if (!(offsets_->unique() && offsets_->isMutable())) {
     offsets_ = nullptr;
   } else {


### PR DESCRIPTION
Add some basic window queries with minimal verification (no error, no crash, 
results match DuckDB) to Aggregation Fuzzer.

The new functionality is disabled by default. Use --enable_window to enable.

Found a few bugs:

- MapAggregateBase::removeDuplicates doesn't check for nulls.
- histogram aggregate function doesn't clear null flags.
- map_agg and array_agg do not support addInput/finalize/extractValues called in a loop.
- WindowAggregate doesn't call Aggregate::finalize and BaseVector::prepareForReuse:
  -  #3292
  -  #3304
- WindowAggregate's destructor may call Aggregate::destroy without first calling initialize 
  causing a crash.

CC: @aditi-pandit @pedroerp @xiaoxmeng @kagamiori 