### PR TITLE
Add support for fmt 8.1.x

### DIFF
--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -100,3 +100,10 @@ class RuntimeStatWriterScopeGuard {
 };
 
 } // namespace facebook::velox
+
+template <>
+struct fmt::formatter<facebook::velox::RuntimeCounter::Unit> : formatter<int> {
+  auto format(facebook::velox::RuntimeCounter::Unit s, format_context& ctx) {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};

--- a/velox/core/PlanFragment.h
+++ b/velox/core/PlanFragment.h
@@ -59,3 +59,10 @@ struct PlanFragment {
 };
 
 } // namespace facebook::velox::core
+
+template <>
+struct fmt::formatter<facebook::velox::core::ExecutionStrategy> : formatter<int> {
+  auto format(facebook::velox::core::ExecutionStrategy s, format_context& ctx) {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1680,3 +1680,23 @@ class WindowNode : public PlanNode {
 };
 
 } // namespace facebook::velox::core
+
+template <>
+struct fmt::formatter<facebook::velox::core::WindowNode::WindowType>
+    : formatter<int> {
+  auto format(
+      facebook::velox::core::WindowNode::WindowType s,
+      format_context& ctx) {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};
+
+template <>
+struct fmt::formatter<facebook::velox::core::WindowNode::BoundType>
+    : formatter<int> {
+  auto format(
+      facebook::velox::core::WindowNode::BoundType s,
+      format_context& ctx) {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};

--- a/velox/dwio/dwrf/common/FileMetadata.h
+++ b/velox/dwio/dwrf/common/FileMetadata.h
@@ -494,3 +494,10 @@ class FooterWrapper : public ProtoWrapperBase {
 };
 
 } // namespace facebook::velox::dwrf
+
+template <>
+struct fmt::formatter<facebook::velox::dwrf::DwrfFormat> : formatter<int> {
+  auto format(facebook::velox::dwrf::DwrfFormat s, format_context& ctx) {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -629,3 +629,13 @@ class HashTable : public BaseHashTable {
 };
 
 } // namespace facebook::velox::exec
+
+template <>
+struct fmt::formatter<facebook::velox::exec::BaseHashTable::HashMode>
+    : formatter<int> {
+  auto format(
+      facebook::velox::exec::BaseHashTable::HashMode s,
+      format_context& ctx) {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -427,3 +427,10 @@ class Spiller {
 };
 
 } // namespace facebook::velox::exec
+
+template <>
+struct fmt::formatter<facebook::velox::exec::Spiller::Type> : formatter<int> {
+  auto format(facebook::velox::exec::Spiller::Type s, format_context& ctx) {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -193,3 +193,23 @@ std::shared_ptr<DateTimeFormatter> buildJodaDateTimeFormatter(
     const std::string_view& format);
 
 } // namespace facebook::velox::functions
+
+template <>
+struct fmt::formatter<facebook::velox::functions::DateTimeFormatterType>
+    : formatter<int> {
+  auto format(
+      facebook::velox::functions::DateTimeFormatterType s,
+      format_context& ctx) {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};
+
+template <>
+struct fmt::formatter<facebook::velox::functions::DateTimeFormatSpecifier>
+    : formatter<int> {
+  auto format(
+      facebook::velox::functions::DateTimeFormatSpecifier s,
+      format_context& ctx) {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -494,3 +494,10 @@ struct TruncateFunction {
 
 } // namespace
 } // namespace facebook::velox::functions
+
+template <>
+struct fmt::formatter<std::errc> : formatter<int> {
+  auto format(std::errc s, format_context& ctx) {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};

--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -791,3 +791,10 @@ template void saveVectorTofile<column_index_t>(
     const std::vector<column_index_t>& list,
     const char* filePath);
 } // namespace facebook::velox
+
+template <>
+struct fmt::formatter<facebook::velox::Encoding> : formatter<int> {
+  auto format(facebook::velox::Encoding s, format_context& ctx) {
+    return formatter<int>::format(static_cast<int>(s), ctx);
+  }
+};


### PR DESCRIPTION
fmt 8.1.0 removes the implicit conversion of enum classes to ints, which means we must manually supply fmt::formatters in order to build with this version or newer.

fmt 9.0.0+ has a slightly nicer API with `format_as`, but unfortunately fmt 8.1.x does not have that. Additionally fmt 9 requires a few more changes due to the use of `std::quoted` https://github.com/fmtlib/fmt/issues/3131 , but those are not yet addressed in this PR.