### PR TITLE
Remove ValueList::finalize method

### DIFF
--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -77,7 +77,7 @@ void setThreadLocalRunTimeStatWriter(
     BaseRuntimeStatWriter* FOLLY_NULLABLE writer);
 
 /// Retrives the current runtime stats writer.
-BaseRuntimeStatWriter* getThreadLocalRunTimeStatWriter();
+BaseRuntimeStatWriter* FOLLY_NULLABLE getThreadLocalRunTimeStatWriter();
 
 /// Writes runtime counter to the current Operator running on that thread.
 void addThreadLocalRuntimeStat(
@@ -87,7 +87,7 @@ void addThreadLocalRuntimeStat(
 /// Scope guard to conveniently set and revert back the current stat writer.
 class RuntimeStatWriterScopeGuard {
  public:
-  RuntimeStatWriterScopeGuard(BaseRuntimeStatWriter* writer)
+  RuntimeStatWriterScopeGuard(BaseRuntimeStatWriter* FOLLY_NULLABLE writer)
       : prevWriter_(getThreadLocalRunTimeStatWriter()) {
     setThreadLocalRunTimeStatWriter(writer);
   }

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -46,11 +46,7 @@ class ArrayAggAggregate : public exec::Aggregate {
     }
   }
 
-  void finalize(char** groups, int32_t numGroups) override {
-    for (auto i = 0; i < numGroups; i++) {
-      value<ArrayAccumulator>(groups[i])->elements.finalize(allocator_);
-    }
-  }
+  void finalize(char** groups, int32_t numGroups) override {}
 
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {

--- a/velox/functions/prestosql/aggregates/MapAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MapAggregateBase.h
@@ -47,12 +47,7 @@ class MapAggregateBase : public exec::Aggregate {
     setAllNulls(groups, indices);
   }
 
-  void finalize(char** groups, int32_t numGroups) override {
-    for (auto i = 0; i < numGroups; i++) {
-      value<MapAccumulator>(groups[i])->keys.finalize(allocator_);
-      value<MapAccumulator>(groups[i])->values.finalize(allocator_);
-    }
-  }
+  void finalize(char** groups, int32_t numGroups) override {}
 
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override;

--- a/velox/functions/prestosql/aggregates/ValueList.h
+++ b/velox/functions/prestosql/aggregates/ValueList.h
@@ -43,13 +43,6 @@ class ValueList {
     return size_;
   }
 
-  // Called after all data has been appended.
-  void finalize(HashStringAllocator* allocator) {
-    if (size_ != 0) {
-      writeLastNulls(allocator);
-    }
-  }
-
   // Called after 'finalize()' to get access to 'data' allocation.
   HashStringAllocator::Header* dataBegin() {
     return dataBegin_;
@@ -58,6 +51,10 @@ class ValueList {
   // Called after 'finalize()' to get access to 'nulls' allocation.
   HashStringAllocator::Header* nullsBegin() {
     return nullsBegin_;
+  }
+
+  uint64_t lastNulls() const {
+    return lastNulls_;
   }
 
   void free(HashStringAllocator* allocator) {
@@ -113,7 +110,9 @@ class ValueListReader {
   bool next(BaseVector& output, vector_size_t outputIndex);
 
  private:
-  ValueList& values_;
+  const vector_size_t size_;
+  const vector_size_t lastNullsStart_;
+  const uint64_t lastNulls_;
   ByteStream dataStream_;
   ByteStream nullsStream_;
   uint64_t nulls_;

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -49,7 +49,6 @@ class ValueListTest : public functions::test::FunctionBaseTest {
       for (auto i = 0; i < size; i++) {
         values.appendValue(decoded, i, allocator());
       }
-      values.finalize(allocator());
 
       ASSERT_EQ(size, values.size());
       auto result = read(values, data->type(), size);
@@ -61,7 +60,6 @@ class ValueListTest : public functions::test::FunctionBaseTest {
     {
       aggregate::ValueList values;
       values.appendRange(data, 0, size, allocator());
-      values.finalize(allocator());
 
       ASSERT_EQ(size, values.size());
       auto result = read(values, data->type(), size);
@@ -81,8 +79,6 @@ class ValueListTest : public functions::test::FunctionBaseTest {
 
 TEST_F(ValueListTest, empty) {
   aggregate::ValueList values;
-  values.finalize(allocator());
-
   ASSERT_EQ(0, values.size());
 }
 


### PR DESCRIPTION
ValueList is used in array_agg and map_agg to accumulate a list of values. The
values are written into 2 separate buffers: nulls and values. The null bits are
first accumulated into a uint64_t. These are written to the buffer every 64
entries. The 'finalize' method used to copy the current null bits into the
nulls buffer.

When array_agg and map_agg are used as window functions with
[unbounded preceding, current row] window frame, it is desired to use a single
accumulator to accumulate rows and extract 'running totals'. This requires
being able to read from a ValueList without calling 'finalize'. 

This change removes ValueList::finalize() method by incorporating the processing
the last null bits into ValueListReader.

See #3292 for additional context.