### PR TITLE
Fix saving and restoring EvalCtx::constantWrapIndex_

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -111,6 +111,7 @@ void EvalCtx::saveAndReset(
   saver.peeled = std::move(peeledFields_);
   saver.wrap = std::move(wrap_);
   saver.wrapNulls = std::move(wrapNulls_);
+  saver.constantWrapIndex = constantWrapIndex_;
   saver.wrapEncoding = wrapEncoding_;
   wrapEncoding_ = VectorEncoding::Simple::FLAT;
   saver.nullsPruned = nullsPruned_;
@@ -205,6 +206,7 @@ void EvalCtx::restore(ScopedContextSaver& saver) {
   errors_ = std::move(saver.errors);
   wrap_ = std::move(saver.wrap);
   wrapNulls_ = std::move(saver.wrapNulls);
+  constantWrapIndex_ = saver.constantWrapIndex;
   wrapEncoding_ = saver.wrapEncoding;
   finalSelection_ = saver.finalSelection;
 }

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -299,6 +299,7 @@ struct ScopedContextSaver {
   std::vector<VectorPtr> peeled;
   BufferPtr wrap;
   BufferPtr wrapNulls;
+  vector_size_t constantWrapIndex;
   VectorEncoding::Simple wrapEncoding;
   bool nullsPruned = false;
   // The selection of the context being saved.

--- a/velox/expression/tests/EvalCtxTest.cpp
+++ b/velox/expression/tests/EvalCtxTest.cpp
@@ -190,3 +190,35 @@ TEST_F(EvalCtxTest, addErrorsPreserveOldErrors) {
   ASSERT_TRUE(context.errors()->isNullAt(1));
   ASSERT_TRUE(context.errors()->isNullAt(2));
 }
+
+/// Verify that constant wrapping is saved and restored correctly.
+TEST_F(EvalCtxTest, constantWrapSaver) {
+  EvalCtx context(&execCtx_);
+  SelectivityVector rows(10);
+
+  ASSERT_EQ(context.wrapEncoding(), VectorEncoding::Simple::FLAT);
+  {
+    ScopedContextSaver saver;
+    context.saveAndReset(saver, rows);
+
+    context.setConstantWrap(2);
+    ASSERT_EQ(context.wrapEncoding(), VectorEncoding::Simple::CONSTANT);
+
+    auto vector = makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5});
+    auto wrapped = context.applyWrapToPeeledResult(BIGINT(), vector, rows);
+    ASSERT_TRUE(wrapped->isConstantEncoding());
+    ASSERT_EQ(wrapped->as<ConstantVector<int64_t>>()->valueAt(0), 2);
+
+    {
+      ScopedContextSaver innerSaver;
+      context.saveAndReset(innerSaver, rows);
+      context.setConstantWrap(10);
+    }
+    ASSERT_EQ(context.wrapEncoding(), VectorEncoding::Simple::CONSTANT);
+
+    wrapped = context.applyWrapToPeeledResult(BIGINT(), vector, rows);
+    ASSERT_TRUE(wrapped->isConstantEncoding());
+    ASSERT_EQ(wrapped->as<ConstantVector<int64_t>>()->valueAt(0), 2);
+  }
+  ASSERT_EQ(context.wrapEncoding(), VectorEncoding::Simple::FLAT);
+}

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3086,3 +3086,16 @@ TEST_F(ExprTest, mapKeysAndValues) {
   std::vector<VectorPtr> result(2);
   ASSERT_NO_THROW(exprSet->eval(rows, context, result));
 }
+
+/// Test recursive constant peeling: in general expression evaluation first,
+/// then in cast.
+TEST_F(ExprTest, constantWrap) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({std::nullopt, 1, 25, 3}),
+      makeConstant("5", 4),
+  });
+
+  auto result = evaluate("c0 < (cast(c1 as bigint) + 10)", {data});
+  assertEqualVectors(
+      makeNullableFlatVector<bool>({std::nullopt, true, false, true}), result);
+}


### PR DESCRIPTION
EvalCtx::saveAndReset didn't save constantWrapIndex_ leading to incorrect results.