### PR TITLE
Add flags to make veloxbench script more flexible

### DIFF
--- a/scripts/veloxbench/veloxbench/cpp_micro_benchmarks.py
+++ b/scripts/veloxbench/veloxbench/cpp_micro_benchmarks.py
@@ -18,14 +18,15 @@
 # (so users without conbench installed can run this file as a script).
 # The conbench integration is set up in implemented_benchmarks.py
 
+import argparse
 import copy
 import os
 import pathlib
+import re
 import subprocess
+import sys
 import tempfile
 
-
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
 
 RUN_OPTIONS = {
     "iterations": {
@@ -56,28 +57,45 @@ class LocalCppMicroBenchmarks:
     # see TODO about COMMON_OPTIONS above, set an empty dict for now
     options = copy.deepcopy(COMMON_OPTIONS)
     options.update(**RUN_OPTIONS)
-    description = "Run the Velox C++ micro benchmarks."
+    description = "Run Velox C++ micro-benchmarks."
     iterations = 1
     flags = {"language": "C++"}
 
-    def run(self, result_dir, **kwargs):
-        binaries = self._find_binaries(
-            REPO_ROOT.joinpath("_build", "release", "velox", "benchmarks", "basic")
-        )
+    def run(
+        self,
+        result_dir,
+        binary_path=None,
+        binary_filter=None,
+        bm_filter=None,
+        bm_max_secs=10,
+        bm_max_trials=1000000,
+        **kwargs,
+    ):
+        if binary_path:
+            binary_path = self._normalize_path(binary_path)
+        else:
+            binary_path = self._default_binary_path()
+
+        binaries = self._find_binaries(binary_path)
         result_dir_path = pathlib.Path(result_dir)
 
         for binary_path in binaries:
+            if binary_filter and not re.search(binary_filter, binary_path.name):
+                continue
+
             out_path = result_dir_path / f"{binary_path.name}.json"
             print(f"Executing and dumping results for '{binary_path}' to '{out_path}':")
             run_command = [
                 binary_path,
                 "--bm_max_secs",
-                "10",
+                str(bm_max_secs),
                 "--bm_max_trials",
-                "1000000",
+                str(bm_max_trials),
                 "--bm_json_verbose",
                 out_path,
             ]
+            if bm_filter:
+                run_command.extend(["--bm_regex", bm_filter])
 
             # TODO: extend cpp micro benchmarks to allow for iterations
             iterations = kwargs.get("iterations", None)
@@ -92,21 +110,35 @@ class LocalCppMicroBenchmarks:
                 raise e
 
     @staticmethod
-    def _find_binaries(binary_dir: pathlib.Path):
+    def _find_binaries(binary_path: pathlib.Path):
+        print(f"Looking for binaries at '{binary_path}'")
+
         # Must run `make benchmarks-basic-build` before this
         binaries = [
             path
-            for path in binary_dir.glob("*")
+            for path in binary_path.glob("*")
             if os.access(path, os.X_OK) and path.is_file()
         ]
         if not binaries:
-            raise ValueError(f"No binaries found at path {binary_dir.resolve()}")
+            raise ValueError(f"No binaries found at path '{binary_path.resolve()}'")
 
-        print(f"Found {len(binaries)} binaries to execute")
+        print(f"Found {len(binaries)} benchmark binaries")
         return binaries
 
     @staticmethod
-    def _parse_benchmark_name(full_name):
+    def _default_binary_path():
+        repo_root = pathlib.Path(__file__).parent.parent.parent.parent.absolute()
+        return repo_root.joinpath("_build", "release", "velox", "benchmarks", "basic")
+
+    @staticmethod
+    def _normalize_path(binary_path: str) -> pathlib.Path:
+        path = pathlib.Path(binary_path)
+        if not path.is_absolute():
+            path = pathlib.Path.cwd().joinpath(path).resolve()
+        return path
+
+    @staticmethod
+    def _parse_benchmark_name(full_name: str):
         # TODO: Do we need something more complicated?
         # https://github.com/ursacomputing/benchmarks/blob/033eee0951adbf41931a2de95caccbac887da6ff/benchmarks/cpp_micro_benchmarks.py#L86-L103
         if full_name[0] == "%":
@@ -131,6 +163,58 @@ class LocalCppMicroBenchmarks:
         return x
 
 
-if __name__ == "__main__":
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="VeloxBench Client Tool",
+        epilog="(c) Meta Platforms 2004-present",
+    )
+    parser.add_argument(
+        "--binary_path",
+        default=None,
+        help="Directory where benchmark binaries are stored. "
+        "Defaults to release build directory.",
+    )
+    parser.add_argument(
+        "--binary_filter",
+        default=None,
+        help="Filter applied to binary names. "
+        "By default execute all binaries found.",
+    )
+    parser.add_argument(
+        "--bm_filter",
+        default=None,
+        help="Filter applied to benchmark names within binaries. "
+        "By default execute all benchmarks.",
+    )
+    parser.add_argument(
+        "--bm_max_secs",
+        default=10,
+        type=int,
+        help="For how many second to run each benchmark in a binary.",
+    )
+    parser.add_argument(
+        "--bm_max_trials",
+        default=1000000,
+        type=int,
+        help="Maximum number of trials (iterations) executed for each benchmark.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+
     with tempfile.TemporaryDirectory() as result_dir:
-        LocalCppMicroBenchmarks().run(result_dir=result_dir)
+        LocalCppMicroBenchmarks().run(
+            result_dir=result_dir,
+            binary_path=args.binary_path,
+            binary_filter=args.binary_filter,
+            bm_max_secs=args.bm_max_secs,
+            bm_max_trials=args.bm_max_trials,
+            bm_filter=args.bm_filter,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adding three flags to make the cpp_micro_benchmarks.py script more flexible.

--binary_path: where to look for benchmark binaries
--binary_filter: regex filter to apply to binary names
--bm_filter: regex filter to apply to benchmark names