### PR TITLE
Add more operator spilling stats.

### DIFF
--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -44,6 +44,11 @@ struct RuntimeMetric {
       RuntimeCounter::Unit _unit = RuntimeCounter::Unit::kNone)
       : unit(_unit) {}
 
+  explicit RuntimeMetric(
+      int64_t value,
+      RuntimeCounter::Unit _unit = RuntimeCounter::Unit::kNone)
+      : unit(_unit), sum{value}, count{1}, min{value}, max{value} {}
+
   void addValue(int64_t value);
 
   void printMetric(std::stringstream& stream) const;

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -178,12 +178,13 @@ void HashAggregation::addInput(RowVectorPtr input) {
   }
   groupingSet_->addInput(input, mayPushdown_);
   numInputRows_ += input->size();
-  auto spilledStats = groupingSet_->spilledStats();
   {
+    auto spillStats = groupingSet_->spilledStats();
     auto lockedStats = stats_.wlock();
-    lockedStats->spilledBytes = spilledStats.spilledBytes;
-    lockedStats->spilledRows = spilledStats.spilledRows;
-    lockedStats->spilledPartitions = spilledStats.spilledPartitions;
+    lockedStats->spilledBytes = spillStats.spilledBytes;
+    lockedStats->spilledRows = spillStats.spilledRows;
+    lockedStats->spilledPartitions = spillStats.spilledPartitions;
+    lockedStats->spilledFiles = spillStats.spilledFiles;
   }
 
   // NOTE: we should not trigger partial output flush in case of global

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -722,6 +722,7 @@ bool HashBuild::finishHashBuild() {
           lockedStats->spilledBytes += spillStats.spilledBytes;
           lockedStats->spilledRows += spillStats.spilledRows;
           lockedStats->spilledPartitions += spillStats.spilledPartitions;
+          lockedStats->spilledFiles += spillStats.spilledFiles;
         }
 
         spiller_->finishSpill(spillPartitions);

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -414,6 +414,7 @@ void OperatorStats::add(const OperatorStats& other) {
   spilledBytes += other.spilledBytes;
   spilledRows += other.spilledRows;
   spilledPartitions += other.spilledPartitions;
+  spilledFiles += other.spilledFiles;
 }
 
 void OperatorStats::clear() {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -137,6 +137,9 @@ struct OperatorStats {
   // Total spilled partitions.
   uint32_t spilledPartitions{0};
 
+  // Total current spilled files.
+  uint32_t spilledFiles{0};
+
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
 
   int numDrivers = 0;

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -113,11 +113,12 @@ void OrderBy::addInput(RowVectorPtr input) {
 
   numRows_ += allRows.size();
   if (spiller_ != nullptr) {
-    const auto spillerStats = spiller_->stats();
+    const auto spillStats = spiller_->stats();
     auto lockedStats = stats_.wlock();
-    lockedStats->spilledBytes = spillerStats.spilledBytes;
-    lockedStats->spilledRows = spillerStats.spilledRows;
-    lockedStats->spilledPartitions = spillerStats.spilledPartitions;
+    lockedStats->spilledBytes = spillStats.spilledBytes;
+    lockedStats->spilledRows = spillStats.spilledRows;
+    lockedStats->spilledPartitions = spillStats.spilledPartitions;
+    lockedStats->spilledFiles = spillStats.spilledFiles;
     VELOX_DCHECK_LE(lockedStats->spilledPartitions, 1);
   }
 }

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -74,6 +74,7 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   spilledBytes += stats.spilledBytes;
   spilledRows += stats.spilledRows;
   spilledPartitions += stats.spilledPartitions;
+  spilledFiles += stats.spilledFiles;
 }
 
 std::string PlanNodeStats::toString(bool includeInputStats) const {

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -108,6 +108,9 @@ struct PlanNodeStats {
   /// Total spilled partitions.
   uint32_t spilledPartitions{0};
 
+  /// Total spilled files.
+  uint32_t spilledFiles{0};
+
   /// Add stats for a single operator instance.
   void add(const OperatorStats& stats);
 

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -239,8 +239,8 @@ const SpillPartitionNumSet& SpillState::spilledPartitionSet() const {
   return spilledPartitionSet_;
 }
 
-int64_t SpillState::spilledFiles() const {
-  int64_t numFiles = 0;
+uint64_t SpillState::spilledFiles() const {
+  uint64_t numFiles = 0;
   for (const auto& list : files_) {
     if (list != nullptr) {
       numFiles += list->spilledFiles();

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -207,7 +207,7 @@ class SpillFileList {
 
   uint64_t spilledBytes() const;
 
-  int64_t spilledFiles() const {
+  uint64_t spilledFiles() const {
     return files_.size();
   }
 
@@ -638,7 +638,8 @@ class SpillState {
   /// Return the spilled partition number set.
   const SpillPartitionNumSet& spilledPartitionSet() const;
 
-  int64_t spilledFiles() const;
+  /// Returns the number of spilled files we have.
+  uint64_t spilledFiles() const;
 
   std::vector<std::string> testingSpilledFilePaths() const;
 

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -260,14 +260,17 @@ class Spiller {
     /// NOTE: when we sum up the stats from a group of spill operators, it is
     /// the total number of spilled partitions X number of operators.
     uint32_t spilledPartitions{0};
+    uint64_t spilledFiles{0};
 
     Stats(
         uint64_t _spilledBytes,
         uint64_t _spilledRows,
-        uint32_t _spilledPartitions)
+        uint32_t _spilledPartitions,
+        uint64_t _spilledFiles)
         : spilledBytes(_spilledBytes),
           spilledRows(_spilledRows),
-          spilledPartitions(_spilledPartitions) {}
+          spilledPartitions(_spilledPartitions),
+          spilledFiles(_spilledFiles) {}
 
     Stats() = default;
 
@@ -275,16 +278,21 @@ class Spiller {
       spilledBytes += other.spilledBytes;
       spilledRows += other.spilledRows;
       spilledPartitions += other.spilledPartitions;
+      spilledFiles += other.spilledFiles;
       return *this;
     }
   };
 
   Stats stats() const {
     return Stats{
-        state_.spilledBytes(), spilledRows_, state_.spilledPartitions()};
+        state_.spilledBytes(),
+        spilledRows_,
+        state_.spilledPartitions(),
+        spilledFiles()};
   }
 
-  int64_t spilledFiles() const {
+  /// Return the number of spilled files we have.
+  uint64_t spilledFiles() const {
     return state_.spilledFiles();
   }
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -150,6 +150,7 @@ Spiller::Stats taskSpilledStats(const exec::Task& task) {
       spilledStats.spilledBytes += op.spilledBytes;
       spilledStats.spilledRows += op.spilledRows;
       spilledStats.spilledPartitions += op.spilledPartitions;
+      spilledStats.spilledFiles += op.spilledFiles;
     }
   }
   return spilledStats;
@@ -613,6 +614,7 @@ class HashJoinBuilder {
         ASSERT_GT(spillStats.spilledRows, 0);
         ASSERT_GT(spillStats.spilledBytes, 0);
         ASSERT_GT(spillStats.spilledPartitions, 0);
+        ASSERT_GT(spillStats.spilledFiles, 0);
         if (maxSpillLevel != -1) {
           ASSERT_EQ(maxHashBuildSpillLevel(*task), maxSpillLevel);
         }
@@ -621,6 +623,7 @@ class HashJoinBuilder {
       ASSERT_EQ(spillStats.spilledRows, 0);
       ASSERT_EQ(spillStats.spilledBytes, 0);
       ASSERT_EQ(spillStats.spilledPartitions, 0);
+      ASSERT_EQ(spillStats.spilledFiles, 0);
     }
     // Customized test verification.
     if (testVerifier_ != nullptr) {
@@ -847,6 +850,7 @@ TEST_P(MultiThreadedHashJoinTest, emptyBuild) {
         ASSERT_EQ(spillStats.spilledRows, 0);
         ASSERT_EQ(spillStats.spilledBytes, 0);
         ASSERT_EQ(spillStats.spilledPartitions, 0);
+        ASSERT_EQ(spillStats.spilledFiles, 0);
       })
       .run();
 }
@@ -1156,6 +1160,7 @@ TEST_P(MultiThreadedHashJoinTest, innerJoinWithEmptyBuild) {
         ASSERT_EQ(spillStats.spilledRows, 0);
         ASSERT_EQ(spillStats.spilledBytes, 0);
         ASSERT_EQ(spillStats.spilledPartitions, 0);
+        ASSERT_EQ(spillStats.spilledFiles, 0);
         ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
       })
       .run();
@@ -1319,6 +1324,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyBuild) {
         ASSERT_EQ(spillStats.spilledRows, 0);
         ASSERT_EQ(spillStats.spilledBytes, 0);
         ASSERT_EQ(spillStats.spilledPartitions, 0);
+        ASSERT_EQ(spillStats.spilledFiles, 0);
         ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
       })
       .run();
@@ -1658,6 +1664,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilter) {
         ASSERT_EQ(spillStats.spilledRows, 0);
         ASSERT_EQ(spillStats.spilledBytes, 0);
         ASSERT_EQ(spillStats.spilledPartitions, 0);
+        ASSERT_EQ(spillStats.spilledFiles, 0);
         ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
       })
       .run();
@@ -1700,6 +1707,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterAndEmptyBuild) {
         ASSERT_EQ(spillStats.spilledRows, 0);
         ASSERT_EQ(spillStats.spilledBytes, 0);
         ASSERT_EQ(spillStats.spilledPartitions, 0);
+        ASSERT_EQ(spillStats.spilledFiles, 0);
         ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
       })
       .run();
@@ -1749,6 +1757,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterAndNullKey) {
           ASSERT_EQ(spillStats.spilledRows, 0);
           ASSERT_EQ(spillStats.spilledBytes, 0);
           ASSERT_EQ(spillStats.spilledPartitions, 0);
+          ASSERT_EQ(spillStats.spilledFiles, 0);
           ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
         })
         .run();
@@ -1795,6 +1804,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterOnNullableColumn) {
           ASSERT_EQ(spillStats.spilledRows, 0);
           ASSERT_EQ(spillStats.spilledBytes, 0);
           ASSERT_EQ(spillStats.spilledPartitions, 0);
+          ASSERT_EQ(spillStats.spilledFiles, 0);
           ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
         })
         .run();
@@ -1838,6 +1848,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterOnNullableColumn) {
           ASSERT_EQ(spillStats.spilledRows, 0);
           ASSERT_EQ(spillStats.spilledBytes, 0);
           ASSERT_EQ(spillStats.spilledPartitions, 0);
+          ASSERT_EQ(spillStats.spilledFiles, 0);
           ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
         })
         .run();
@@ -1926,6 +1937,7 @@ TEST_P(MultiThreadedHashJoinTest, antiJoinWithFilterAndEmptyBuild) {
         ASSERT_EQ(spillStats.spilledRows, 0);
         ASSERT_EQ(spillStats.spilledBytes, 0);
         ASSERT_EQ(spillStats.spilledPartitions, 0);
+        ASSERT_EQ(spillStats.spilledFiles, 0);
         ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
       })
       .run();

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -39,6 +39,7 @@ Spiller::Stats spilledStats(const exec::Task& task) {
       spilledStats.spilledBytes += op.spilledBytes;
       spilledStats.spilledRows += op.spilledRows;
       spilledStats.spilledPartitions += op.spilledPartitions;
+      spilledStats.spilledFiles += op.spilledFiles;
     }
   }
   return spilledStats;
@@ -179,6 +180,7 @@ class OrderByTest : public OperatorTestBase {
       if (inputRows > 0) {
         EXPECT_LT(0, spilledStats(*task).spilledBytes);
         EXPECT_EQ(1, spilledStats(*task).spilledPartitions);
+        EXPECT_LT(0, spilledStats(*task).spilledFiles);
         // NOTE: the last input batch won't go spilling.
         EXPECT_GT(inputRows, spilledStats(*task).spilledRows);
       } else {
@@ -445,6 +447,7 @@ TEST_F(OrderByTest, spill) {
   EXPECT_GT(kNumBatches * kNumRows, stats[0].operatorStats[1].spilledRows);
   EXPECT_LT(0, stats[0].operatorStats[1].spilledBytes);
   EXPECT_EQ(1, stats[0].operatorStats[1].spilledPartitions);
+  EXPECT_EQ(2, stats[0].operatorStats[1].spilledFiles);
 }
 
 TEST_F(OrderByTest, spillWithMemoryLimit) {


### PR DESCRIPTION
Summary:
Add 'spilledFiles' to operator spilling stats.
In Presto Native we will add them to the Operator and Task runtime stats.

Differential Revision: D41419005

