### PR TITLE
Remove unnecessary hourly build for docker-compose ubuntu-cpp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ workflows:
       - linux-build-options
       - linux-adapters
       - macos-build
-      - docker-compose-ubuntu-cpp
 
 commands:
   update-submodules:


### PR DESCRIPTION
Nightly build should be enough. I've just realised I added it to hourly builds. I don't think this is necessary and we could save some CI resources.