### PR TITLE
Add granular stats for drivers in various states to TaskStats.

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -286,6 +286,10 @@ class Driver : public std::enable_shared_from_this<Driver> {
   // closing non-running Drivers.
   void closeByTask();
 
+  BlockingReason blockingReason() const {
+    return blockingReason_;
+  }
+
  private:
   void enqueueInternal();
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1419,10 +1419,13 @@ TaskStats Task::taskStats() const {
   // (their operators).
   TaskStats taskStats = taskStats_;
 
+  taskStats.numTotalDrivers = drivers_.size();
+
   // Add stats of the drivers (their operators) that are still running.
   for (const auto& driver : drivers_) {
     // Driver can be null.
     if (driver == nullptr) {
+      ++taskStats.numCompletedDrivers;
       continue;
     }
 
@@ -1431,6 +1434,13 @@ TaskStats Task::taskStats() const {
       taskStats.pipelineStats[statsCopy.pipelineId]
           .operatorStats[statsCopy.operatorId]
           .add(statsCopy);
+    }
+    if (driver->isOnThread()) {
+      ++taskStats.numRunningDrivers;
+    } else if (driver->isTerminated()) {
+      ++taskStats.numTerminatedDrivers;
+    } else {
+      ++taskStats.numBlockedDrivers[driver->blockingReason()];
     }
   }
 

--- a/velox/exec/TaskStats.h
+++ b/velox/exec/TaskStats.h
@@ -15,7 +15,12 @@
  */
 #pragma once
 
+#include <cstdint>
+#include <unordered_map>
 #include <unordered_set>
+#include <vector>
+
+#include "velox/exec/Driver.h"
 
 namespace facebook::velox::exec {
 
@@ -46,26 +51,40 @@ struct TaskStats {
   int32_t numQueuedSplits{0};
   std::unordered_set<int32_t> completedSplitGroups;
 
-  // The subscript is given by each Operator's
-  // DriverCtx::pipelineId. This is a sum total reflecting fully
-  // processed Splits for Drivers of this pipeline.
+  /// The subscript is given by each Operator's
+  /// DriverCtx::pipelineId. This is a sum total reflecting fully
+  /// processed Splits for Drivers of this pipeline.
   std::vector<PipelineStats> pipelineStats;
 
-  // Epoch time (ms) when task starts to run
+  /// Epoch time (ms) when task starts to run
   uint64_t executionStartTimeMs{0};
 
-  // Epoch time (ms) when last split is processed. For some tasks there might be
-  // some additional time to send buffered results before the task finishes.
+  /// Epoch time (ms) when last split is processed. For some tasks there might
+  /// be some additional time to send buffered results before the task finishes.
   uint64_t executionEndTimeMs{0};
 
-  // Epoch time (ms) when first split is fetched from the task by an operator.
+  /// Epoch time (ms) when first split is fetched from the task by an operator.
   uint64_t firstSplitStartTimeMs{0};
 
-  // Epoch time (ms) when last split is fetched from the task by an operator.
+  /// Epoch time (ms) when last split is fetched from the task by an operator.
   uint64_t lastSplitStartTimeMs{0};
 
-  // Epoch time (ms) when the task completed, e.g. all splits were processed and
-  // results have been consumed.
+  /// Epoch time (ms) when the task completed, e.g. all splits were processed
+  /// and results have been consumed.
   uint64_t endTimeMs{0};
+
+  /// Total number of drivers.
+  uint64_t numTotalDrivers{0};
+  /// The number of completed drivers (which slots are null in Task 'drivers_'
+  /// list).
+  uint64_t numCompletedDrivers{0};
+  /// The number of drivers that are terminating or terminated (isTerminated()
+  /// returns true).
+  uint64_t numTerminatedDrivers{0};
+  /// The number of drivers that are currently running on driver thread.
+  uint64_t numRunningDrivers{0};
+  /// Drivers blocked for various reasons. Based on enum BlockingReason.
+  std::unordered_map<BlockingReason, uint64_t> numBlockedDrivers;
 };
+
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -731,6 +731,7 @@ DEBUG_ONLY_TEST_F(TaskTest, liveStats) {
     result.push_back(cursor->current());
   }
   EXPECT_TRUE(waitForTaskCompletion(task)) << task->taskId();
+
   TaskStats finishStats = task->taskStats();
 
   for (auto i = 0; i < numBatches; ++i) {
@@ -740,7 +741,19 @@ DEBUG_ONLY_TEST_F(TaskTest, liveStats) {
     EXPECT_EQ(3 * i, operatorStats.outputPositions);
     EXPECT_EQ(i, operatorStats.outputVectors);
     EXPECT_EQ(0, operatorStats.finishTiming.count);
+
+    EXPECT_EQ(1, liveStats[i].numTotalDrivers);
+    EXPECT_EQ(0, liveStats[i].numCompletedDrivers);
+    EXPECT_EQ(0, liveStats[i].numTerminatedDrivers);
+    EXPECT_EQ(1, liveStats[i].numRunningDrivers);
+    EXPECT_EQ(0, liveStats[i].numBlockedDrivers.size());
   }
+
+  EXPECT_EQ(1, finishStats.numTotalDrivers);
+  EXPECT_EQ(1, finishStats.numCompletedDrivers);
+  EXPECT_EQ(0, finishStats.numTerminatedDrivers);
+  EXPECT_EQ(0, finishStats.numRunningDrivers);
+  EXPECT_EQ(0, finishStats.numBlockedDrivers.size());
 
   const auto& operatorStats = finishStats.pipelineStats[0].operatorStats[0];
   EXPECT_EQ(numBatches + 1, operatorStats.getOutputTiming.count);


### PR DESCRIPTION
Summary:
Add granular stats for drivers in various states (running,
blocked, completed, etc.) to TaskStats.

Differential Revision: D41445633

