### PR TITLE
Add support for k PRECEDING/FOLLOWING window frames in ROWS mode

### DIFF
--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -41,6 +41,18 @@ void initKeyInfo(
   }
 }
 
+VectorPtr const toConstantVector(
+    const std::shared_ptr<const core::ConstantTypedExpr>& constantExpr,
+    velox::memory::MemoryPool* pool) {
+  if (constantExpr->hasValueVector()) {
+    return BaseVector::wrapInConstant(1, 0, constantExpr->valueVector());
+  }
+  if (constantExpr->value().isNull()) {
+    return BaseVector::createNullConstant(constantExpr->type(), 1, pool);
+  }
+  return BaseVector::createConstant(constantExpr->value(), 1, pool);
+}
+
 }; // namespace
 
 Window::Window(
@@ -88,45 +100,56 @@ Window::Window(
   createWindowFunctions(windowNode, inputType);
 }
 
+Window::WindowFrame Window::createWindowFrame(
+    core::WindowNode::Frame frame,
+    const RowTypePtr& inputType) {
+  auto createFrameChannelArg =
+      [&](const core::TypedExprPtr& frame) -> std::optional<FrameChannelArg> {
+    // frame is nullptr for non (kPreceding or kFollowing) frames.
+    if (frame == nullptr) {
+      return std::nullopt;
+    }
+    auto frameChannel = exprToChannel(frame.get(), inputType);
+    if (frameChannel == kConstantChannel) {
+      auto constant =
+          std::dynamic_pointer_cast<const core::ConstantTypedExpr>(frame)
+              ->value();
+      VELOX_CHECK(!constant.isNull(), "k in frame bounds must not be null");
+      VELOX_USER_CHECK_GE(
+          constant.value<int64_t>(), 1, "k in frame bounds must be at least 1");
+      return std::make_optional(FrameChannelArg{
+          kConstantChannel, nullptr, constant.value<int64_t>()});
+    } else {
+      return std::make_optional(FrameChannelArg{
+          frameChannel, BaseVector::create(BIGINT(), 0, pool()), std::nullopt});
+    }
+  };
+
+  return WindowFrame(
+      {frame.type,
+       frame.startType,
+       frame.endType,
+       createFrameChannelArg(frame.startValue),
+       createFrameChannelArg(frame.endValue)});
+}
+
 void Window::createWindowFunctions(
     const std::shared_ptr<const core::WindowNode>& windowNode,
     const RowTypePtr& inputType) {
-  auto constantArg = [&](const core::TypedExprPtr arg) -> const VectorPtr {
-    if (auto typedExpr =
-            dynamic_cast<const core::ConstantTypedExpr*>(arg.get())) {
-      if (typedExpr->hasValueVector()) {
-        return BaseVector::wrapInConstant(1, 0, typedExpr->valueVector());
-      }
-      if (typedExpr->value().isNull()) {
-        return BaseVector::createNullConstant(typedExpr->type(), 1, pool());
-      }
-      return BaseVector::createConstant(typedExpr->value(), 1, pool());
-    }
-    return nullptr;
-  };
-
-  auto fieldArgToChannel =
-      [&](const core::TypedExprPtr arg) -> std::optional<column_index_t> {
-    if (arg) {
-      std::optional<column_index_t> argChannel =
-          exprToChannel(arg.get(), inputType);
-      VELOX_CHECK(
-          argChannel.value() != kConstantChannel,
-          "Window doesn't allow constant arguments or frame end-points");
-      return argChannel;
-    }
-    return std::nullopt;
-  };
-
   for (const auto& windowNodeFunction : windowNode->windowFunctions()) {
     std::vector<WindowFunctionArg> functionArgs;
     functionArgs.reserve(windowNodeFunction.functionCall->inputs().size());
     for (auto& arg : windowNodeFunction.functionCall->inputs()) {
-      if (auto constant = constantArg(arg)) {
-        functionArgs.push_back({arg->type(), constant, std::nullopt});
-      } else {
+      auto channel = exprToChannel(arg.get(), inputType);
+      if (channel == kConstantChannel) {
         functionArgs.push_back(
-            {arg->type(), nullptr, fieldArgToChannel(arg).value()});
+            {arg->type(),
+             toConstantVector(
+                 std::dynamic_pointer_cast<const core::ConstantTypedExpr>(arg),
+                 pool()),
+             std::nullopt});
+      } else {
+        functionArgs.push_back({arg->type(), nullptr, channel});
       }
     }
 
@@ -138,11 +161,7 @@ void Window::createWindowFunctions(
         &stringAllocator_));
 
     windowFrames_.push_back(
-        {windowNodeFunction.frame.type,
-         windowNodeFunction.frame.startType,
-         windowNodeFunction.frame.endType,
-         fieldArgToChannel(windowNodeFunction.frame.startValue),
-         fieldArgToChannel(windowNodeFunction.frame.endValue)});
+        createWindowFrame(windowNodeFunction.frame, inputType));
   }
 }
 
@@ -272,6 +291,7 @@ void Window::noMoreInput() {
 }
 
 void Window::callResetPartition(vector_size_t partitionNumber) {
+  partitionOffset_ = 0;
   auto partitionSize = partitionStartRows_[partitionNumber + 1] -
       partitionStartRows_[partitionNumber];
   auto partition = folly::Range(
@@ -281,6 +301,132 @@ void Window::callResetPartition(vector_size_t partitionNumber) {
     windowFunctions_[i]->resetPartition(windowPartition_.get());
   }
 }
+
+void Window::updateKRowsFrameBounds(
+    bool isKPreceding,
+    const FrameChannelArg& frameArg,
+    vector_size_t startRow,
+    vector_size_t numRows,
+    vector_size_t* rawFrameBounds) {
+  auto firstPartitionRow = partitionStartRows_[currentPartition_];
+
+  if (frameArg.index == kConstantChannel) {
+    auto offset = frameArg.constant.value();
+    if (isKPreceding) {
+      offset *= -1;
+    }
+    std::iota(
+        rawFrameBounds,
+        rawFrameBounds + numRows,
+        startRow + offset - firstPartitionRow);
+  } else {
+    windowPartition_->extractColumn(
+        frameArg.index, partitionOffset_, numRows, 0, frameArg.value);
+    auto offsets = frameArg.value->values()->asMutable<int64_t>();
+    for (auto i = 0; i < numRows; i++) {
+      VELOX_USER_CHECK(
+          !frameArg.value->isNullAt(i), "k in frame bounds cannot be null");
+      VELOX_USER_CHECK_GE(
+          offsets[i], 1, "k in frame bounds must be at least 1");
+    }
+
+    if (isKPreceding) {
+      for (auto i = 0; i < numRows; i++) {
+        offsets[i] *= -1;
+      }
+    }
+    for (auto i = 0; i < numRows; i++) {
+      rawFrameBounds[i] = (startRow + i) + offsets[i] - firstPartitionRow;
+    }
+  }
+}
+
+void Window::updateFrameBounds(
+    const WindowFrame& windowFrame,
+    const bool isStartBound,
+    const vector_size_t startRow,
+    const vector_size_t numRows,
+    const vector_size_t* rawPeerStarts,
+    const vector_size_t* rawPeerEnds,
+    vector_size_t* rawFrameBounds) {
+  auto firstPartitionRow = partitionStartRows_[currentPartition_];
+  auto lastPartitionRow = partitionStartRows_[currentPartition_ + 1] - 1;
+  auto windowType = windowFrame.type;
+  auto boundType = isStartBound ? windowFrame.startType : windowFrame.endType;
+  auto frameArg = isStartBound ? windowFrame.start : windowFrame.end;
+
+  switch (boundType) {
+    case core::WindowNode::BoundType::kUnboundedPreceding:
+      std::fill_n(rawFrameBounds, numRows, 0);
+      break;
+    case core::WindowNode::BoundType::kUnboundedFollowing:
+      std::fill_n(
+          rawFrameBounds, numRows, lastPartitionRow - firstPartitionRow);
+      break;
+    case core::WindowNode::BoundType::kCurrentRow: {
+      if (windowType == core::WindowNode::WindowType::kRange) {
+        const vector_size_t* rawPeerBuffer =
+            isStartBound ? rawPeerStarts : rawPeerEnds;
+        std::copy(rawPeerBuffer, rawPeerBuffer + numRows, rawFrameBounds);
+      } else {
+        // Fills the frameBound buffer with increasing value of row indices
+        // (corresponding to CURRENT ROW) from the startRow of the current
+        // output buffer. The startRow has to be adjusted relative to the
+        // partition start row.
+        std::iota(
+            rawFrameBounds,
+            rawFrameBounds + numRows,
+            startRow - firstPartitionRow);
+      }
+      break;
+    }
+    case core::WindowNode::BoundType::kPreceding: {
+      if (windowType == core::WindowNode::WindowType::kRows) {
+        updateKRowsFrameBounds(
+            true, frameArg.value(), startRow, numRows, rawFrameBounds);
+      } else {
+        VELOX_NYI("k preceding frame is only supported in ROWS mode");
+      }
+      break;
+    }
+    case core::WindowNode::BoundType::kFollowing: {
+      if (windowType == core::WindowNode::WindowType::kRows) {
+        updateKRowsFrameBounds(
+            false, frameArg.value(), startRow, numRows, rawFrameBounds);
+      } else {
+        VELOX_NYI("k following frame is only supported in ROWS mode");
+      }
+      break;
+    }
+    default:
+      VELOX_USER_FAIL("Invalid frame bound type");
+  }
+}
+
+namespace {
+void adjustKRowsFrameBounds(
+    vector_size_t lastRow,
+    vector_size_t numRows,
+    vector_size_t* rawFrameStarts,
+    vector_size_t* rawFrameEnds) {
+  auto frameStart = 0;
+  auto frameEnd = 0;
+
+  for (auto i = 0; i < numRows; i++) {
+    frameStart = rawFrameStarts[i];
+    frameEnd = rawFrameEnds[i];
+    // Clamp frameStart and frameEnd to the first and last row of the partition
+    // if required.
+    if (frameStart <= frameEnd) {
+      rawFrameStarts[i] = std::max(frameStart, 0);
+      rawFrameEnds[i] = std::min(frameEnd, lastRow);
+    } else {
+      VELOX_NYI("Empty frames are currently not supported");
+    }
+  }
+}
+
+}; // namespace
 
 void Window::callApplyForPartitionRows(
     vector_size_t startRow,
@@ -301,19 +447,18 @@ void Window::callApplyForPartitionRows(
   auto rawPeerStarts = peerStartBuffer_->asMutable<vector_size_t>();
   auto rawPeerEnds = peerEndBuffer_->asMutable<vector_size_t>();
 
-  std::vector<vector_size_t*> rawFrameStartBuffers;
-  std::vector<vector_size_t*> rawFrameEndBuffers;
-  rawFrameStartBuffers.reserve(numFuncs);
-  rawFrameEndBuffers.reserve(numFuncs);
+  std::vector<vector_size_t*> rawFrameStarts;
+  std::vector<vector_size_t*> rawFrameEnds;
+  rawFrameStarts.reserve(numFuncs);
+  rawFrameEnds.reserve(numFuncs);
   for (auto w = 0; w < numFuncs; w++) {
     frameStartBuffers_[w]->setSize(bufferSize);
     frameEndBuffers_[w]->setSize(bufferSize);
 
-    auto rawFrameStartBuffer =
-        frameStartBuffers_[w]->asMutable<vector_size_t>();
-    auto rawFrameEndBuffer = frameEndBuffers_[w]->asMutable<vector_size_t>();
-    rawFrameStartBuffers.push_back(rawFrameStartBuffer);
-    rawFrameEndBuffers.push_back(rawFrameEndBuffer);
+    auto rawFrameStart = frameStartBuffers_[w]->asMutable<vector_size_t>();
+    auto rawFrameEnd = frameEndBuffers_[w]->asMutable<vector_size_t>();
+    rawFrameStarts.push_back(rawFrameStart);
+    rawFrameEnds.push_back(rawFrameEnd);
   }
 
   auto peerCompare = [&](const char* lhs, const char* rhs) -> bool {
@@ -350,54 +495,35 @@ void Window::callApplyForPartitionRows(
     rawPeerEnds[j] = peerEndRow_ - 1 - firstPartitionRow;
   }
 
-  auto updateFrameBounds = [&](vector_size_t* rawFrameBounds,
-                               core::WindowNode::BoundType boundType,
-                               core::WindowNode::WindowType type,
-                               bool isStartBound) -> void {
-    switch (boundType) {
-      case core::WindowNode::BoundType::kUnboundedPreceding:
-        std::memset(rawFrameBounds, 0, numRows * sizeof(vector_size_t));
-        break;
-      case core::WindowNode::BoundType::kUnboundedFollowing:
-        std::fill_n(
-            rawFrameBounds, numRows, lastPartitionRow - firstPartitionRow);
-        break;
-      case core::WindowNode::BoundType::kCurrentRow: {
-        if (type == core::WindowNode::WindowType::kRange) {
-          vector_size_t* rawPeerBuffer =
-              isStartBound ? rawPeerStarts : rawPeerEnds;
-          std::copy(rawPeerBuffer, rawPeerBuffer + numRows, rawFrameBounds);
-        } else {
-          // Fills the frameBound buffer with increasing value of row indices
-          // (corresponding to CURRENT ROW) from the startRow of the current
-          // output buffer. The startRow has to be adjusted relative to the
-          // partition start row.
-          std::iota(
-              rawFrameBounds,
-              rawFrameBounds + numRows,
-              startRow - firstPartitionRow);
-        }
-        break;
-      }
-      case core::WindowNode::BoundType::kPreceding:
-      case core::WindowNode::BoundType::kFollowing:
-        VELOX_NYI("Not supported");
-      default:
-        VELOX_USER_FAIL("Invalid frame bound type");
-    }
-  };
-
   for (auto i = 0; i < numFuncs; i++) {
+    const auto& windowFrame = windowFrames_[i];
+
     updateFrameBounds(
-        rawFrameStartBuffers[i],
-        windowFrames_[i].startType,
-        windowFrames_[i].type,
-        true);
+        windowFrame,
+        true,
+        startRow,
+        numRows,
+        rawPeerStarts,
+        rawPeerEnds,
+        rawFrameStarts[i]);
     updateFrameBounds(
-        rawFrameEndBuffers[i],
-        windowFrames_[i].endType,
-        windowFrames_[i].type,
-        false);
+        windowFrame,
+        false,
+        startRow,
+        numRows,
+        rawPeerStarts,
+        rawPeerEnds,
+        rawFrameEnds[i]);
+    if (windowFrames_[i].start || windowFrames_[i].end) {
+      // k preceding and k following bounds in ROWS mode can go over the
+      // partition limits. Hence, they are bound to the first and last partition
+      // rows.
+      adjustKRowsFrameBounds(
+          lastPartitionRow - firstPartitionRow,
+          numRows,
+          rawFrameStarts[i],
+          rawFrameEnds[i]);
+    }
   }
 
   // Invoke the apply method for the WindowFunctions.
@@ -412,6 +538,7 @@ void Window::callApplyForPartitionRows(
   }
 
   numProcessedRows_ += numRows;
+  partitionOffset_ += numRows;
   if (endRow == partitionStartRows_[currentPartition_ + 1]) {
     currentPartition_++;
   }

--- a/velox/functions/prestosql/window/tests/NthValueTest.cpp
+++ b/velox/functions/prestosql/window/tests/NthValueTest.cpp
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/window/tests/WindowTestBase.h"
-
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 using namespace facebook::velox::exec::test;
@@ -25,26 +25,49 @@ namespace {
 
 class NthValueTest : public WindowTestBase {
  protected:
+  NthValueTest() : frameClause_("range unbounded preceding") {}
+
+  NthValueTest(const std::string& frameClause) : frameClause_(frameClause) {}
+
+  void testWindowFunction(
+      const std::vector<RowVectorPtr>& input,
+      const std::string& function,
+      const std::vector<std::string>& overClauses) {
+    WindowTestBase::testWindowFunction(
+        input, function, overClauses, frameClause_);
+  }
+
   void testPrimitiveType(const TypePtr& type) {
     vector_size_t size = 25;
     auto vectors = makeRowVector({
         makeFlatVector<int32_t>(size, [](auto row) { return row % 5; }),
         makeFlatVector<int32_t>(size, [](auto row) { return row; }),
         makeFlatVector<int64_t>(size, [](auto row) { return row % 3 + 1; }),
-        typeValues(type, size),
+        makeFlatFuzzVector(type, size),
     });
-    testWindowFunction({vectors}, "nth_value(c3, c2)", kBasicOverClauses);
+
+    // Add c3 column in sort order in overClauses to impose a deterministic
+    // output row order in the tests.
+    const auto column = ", c3";
+    const std::vector<std::string> basicOverClauses =
+        addSuffixToClauses(column, kBasicOverClauses);
+    const std::vector<std::string> sortOrderBasedOverClauses =
+        addSuffixToClauses(column, kSortOrderBasedOverClauses);
+
+    testWindowFunction({vectors}, "nth_value(c3, c2)", basicOverClauses);
     testWindowFunction(
-        {vectors}, "nth_value(c3, c2)", kSortOrderBasedOverClauses);
-    testWindowFunction({vectors}, "nth_value(c3, 1)", kBasicOverClauses);
+        {vectors}, "nth_value(c3, c2)", sortOrderBasedOverClauses);
+    testWindowFunction({vectors}, "nth_value(c3, 1)", basicOverClauses);
     testWindowFunction(
-        {vectors}, "nth_value(c3, 5)", kSortOrderBasedOverClauses);
+        {vectors}, "nth_value(c3, 5)", sortOrderBasedOverClauses);
   }
 
   RowVectorPtr makeBasicVectors(vector_size_t size) {
     return makeRowVector({
         makeFlatVector<int32_t>(size, [](auto row) { return row % 5; }),
-        makeFlatVector<int32_t>(size, [](auto row) { return row % 7; }),
+        // These columns are used for k PRECEDING/FOLLOWING frame bounds. So
+        // they should have values >= 1.
+        makeFlatVector<int64_t>(size, [](auto row) { return row % 7 + 1; }),
         makeFlatVector<int64_t>(size, [](auto row) { return row % 3 + 1; }),
     });
   }
@@ -52,23 +75,23 @@ class NthValueTest : public WindowTestBase {
   RowVectorPtr makeSinglePartitionVectors(vector_size_t size) {
     return makeRowVector({
         makeFlatVector<int32_t>(size, [](auto /* row */) { return 1; }),
-        makeFlatVector<int32_t>(size, [](auto row) { return row % 50; }),
+        // These columns are used for k PRECEDING/FOLLOWING frame bounds. So
+        // they should have values >= 1.
+        makeFlatVector<int64_t>(size, [](auto row) { return row % 50 + 1; }),
         makeFlatVector<int64_t>(size, [](auto row) { return row % 5 + 1; }),
     });
   }
 
- private:
-  VectorPtr typeValues(const TypePtr& type, vector_size_t size) {
-    VectorFuzzer::Options options;
-    options.vectorSize = size;
-    options.nullRatio = 0.2;
-    options.useMicrosecondPrecisionTimestamp = true;
-    VectorFuzzer fuzzer(options, pool_.get(), 0);
-    return fuzzer.fuzz(type);
-  }
+  const std::string frameClause_;
 };
 
-TEST_F(NthValueTest, basic) {
+class MultiNthValueTest : public NthValueTest,
+                          public testing::WithParamInterface<std::string> {
+ public:
+  MultiNthValueTest() : NthValueTest(GetParam()) {}
+};
+
+TEST_P(MultiNthValueTest, basic) {
   auto vectors = makeBasicVectors(50);
 
   testWindowFunction({vectors}, "nth_value(c0, c2)", kBasicOverClauses);
@@ -76,7 +99,7 @@ TEST_F(NthValueTest, basic) {
   testWindowFunction({vectors}, "nth_value(c0, 5)", kBasicOverClauses);
 }
 
-TEST_F(NthValueTest, basicWithSortOrder) {
+TEST_P(MultiNthValueTest, basicWithSortOrder) {
   auto vectors = makeBasicVectors(50);
 
   testWindowFunction(
@@ -85,7 +108,7 @@ TEST_F(NthValueTest, basicWithSortOrder) {
   testWindowFunction({vectors}, "nth_value(c0, 5)", kSortOrderBasedOverClauses);
 }
 
-TEST_F(NthValueTest, singlePartition) {
+TEST_P(MultiNthValueTest, singlePartition) {
   auto vectors = makeSinglePartitionVectors(500);
 
   testWindowFunction({vectors}, "nth_value(c0, c2)", kBasicOverClauses);
@@ -93,7 +116,7 @@ TEST_F(NthValueTest, singlePartition) {
   testWindowFunction({vectors}, "nth_value(c0, 25)", kBasicOverClauses);
 }
 
-TEST_F(NthValueTest, singlePartitionWithSortOrder) {
+TEST_P(MultiNthValueTest, singlePartitionWithSortOrder) {
   auto vectors = makeSinglePartitionVectors(500);
 
   testWindowFunction(
@@ -103,7 +126,7 @@ TEST_F(NthValueTest, singlePartitionWithSortOrder) {
       {vectors}, "nth_value(c0, 25)", kSortOrderBasedOverClauses);
 }
 
-TEST_F(NthValueTest, multiInput) {
+TEST_P(MultiNthValueTest, multiInput) {
   auto vectors = makeSinglePartitionVectors(250);
   auto doubleVectors = {vectors, vectors};
 
@@ -112,7 +135,7 @@ TEST_F(NthValueTest, multiInput) {
   testWindowFunction(doubleVectors, "nth_value(c0, 25)", kBasicOverClauses);
 }
 
-TEST_F(NthValueTest, multiInputWithSortOrder) {
+TEST_P(MultiNthValueTest, multiInputWithSortOrder) {
   auto vectors = makeSinglePartitionVectors(250);
   auto doubleVectors = {vectors, vectors};
 
@@ -124,43 +147,43 @@ TEST_F(NthValueTest, multiInputWithSortOrder) {
       doubleVectors, "nth_value(c0, 25)", kSortOrderBasedOverClauses);
 }
 
-TEST_F(NthValueTest, integerValues) {
+TEST_P(MultiNthValueTest, integerValues) {
   testPrimitiveType(INTEGER());
 }
 
-TEST_F(NthValueTest, tinyintValues) {
+TEST_P(MultiNthValueTest, tinyintValues) {
   testPrimitiveType(TINYINT());
 }
 
-TEST_F(NthValueTest, smallintValues) {
+TEST_P(MultiNthValueTest, smallintValues) {
   testPrimitiveType(SMALLINT());
 }
 
-TEST_F(NthValueTest, bigintValues) {
+TEST_P(MultiNthValueTest, bigintValues) {
   testPrimitiveType(BIGINT());
 }
 
-TEST_F(NthValueTest, realValues) {
+TEST_P(MultiNthValueTest, realValues) {
   testPrimitiveType(REAL());
 }
 
-TEST_F(NthValueTest, doubleValues) {
+TEST_P(MultiNthValueTest, doubleValues) {
   testPrimitiveType(DOUBLE());
 }
 
-TEST_F(NthValueTest, varcharValues) {
+TEST_P(MultiNthValueTest, varcharValues) {
   testPrimitiveType(VARCHAR());
 }
 
-TEST_F(NthValueTest, varbinaryValues) {
+TEST_P(MultiNthValueTest, varbinaryValues) {
   testPrimitiveType(VARBINARY());
 }
 
-TEST_F(NthValueTest, timestampValues) {
+TEST_P(MultiNthValueTest, timestampValues) {
   testPrimitiveType(TIMESTAMP());
 }
 
-TEST_F(NthValueTest, dateValues) {
+TEST_P(MultiNthValueTest, dateValues) {
   testPrimitiveType(DATE());
 }
 
@@ -180,8 +203,7 @@ TEST_F(NthValueTest, nullOffsets) {
       {vectors}, "nth_value(c0, c2)", kSortOrderBasedOverClauses);
 }
 
-TEST_F(NthValueTest, offsetValues) {
-  // Test values for offset < 1.
+TEST_F(NthValueTest, invalidOffsets) {
   vector_size_t size = 20;
 
   auto vectors = makeRowVector({
@@ -200,68 +222,34 @@ TEST_F(NthValueTest, offsetValues) {
       {vectors}, "nth_value(c0, c2)", overClause, offsetError);
 }
 
-TEST_F(NthValueTest, basicRangeFrames) {
-  auto vectors = makeBasicVectors(50);
+TEST_F(NthValueTest, invalidFrames) {
+  vector_size_t size = 20;
 
-  testWindowFunction(
-      {vectors}, "nth_value(c0, c2)", kFrameOverClauses, kRangeFrameClauses);
-  testWindowFunction(
-      {vectors}, "nth_value(c0, 1)", kFrameOverClauses, kRangeFrameClauses);
-  testWindowFunction(
-      {vectors}, "nth_value(c0, 5)", kFrameOverClauses, kRangeFrameClauses);
+  auto vectors = makeRowVector({
+      makeFlatVector<int32_t>(size, [](auto /* row */) { return 1; }),
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 50; }),
+      makeFlatVector<int64_t>(size, [](auto row) { return row % 5; }),
+  });
+
+  std::string overClause = "partition by c0 order by c1";
+  assertWindowFunctionError(
+      {vectors},
+      "nth_value(c0, 5)",
+      overClause,
+      "rows between 0 preceding and current row",
+      "k in frame bounds must be at least 1");
+  assertWindowFunctionError(
+      {vectors},
+      "nth_value(c0, 5)",
+      overClause,
+      "rows between c2 preceding and current row",
+      "k in frame bounds must be at least 1");
 }
 
-TEST_F(NthValueTest, singlePartitionRangeFrames) {
-  auto vectors = makeSinglePartitionVectors(400);
-
-  testWindowFunction(
-      {vectors}, "nth_value(c0, c2)", kFrameOverClauses, kRangeFrameClauses);
-  testWindowFunction(
-      {vectors}, "nth_value(c0, 5)", kFrameOverClauses, kRangeFrameClauses);
-}
-
-TEST_F(NthValueTest, multiInputRangeFrames) {
-  auto vectors = makeSinglePartitionVectors(200);
-  auto doubleVectors = {vectors, vectors};
-
-  testWindowFunction(
-      doubleVectors,
-      "nth_value(c0, c2)",
-      kFrameOverClauses,
-      kRangeFrameClauses);
-  testWindowFunction(
-      {vectors}, "nth_value(c0, 5)", kFrameOverClauses, kRangeFrameClauses);
-}
-
-TEST_F(NthValueTest, basicRowFrames) {
-  auto vectors = makeBasicVectors(50);
-
-  testWindowFunction(
-      {vectors}, "nth_value(c0, c2)", kFrameOverClauses, kRowsFrameClauses);
-  testWindowFunction(
-      {vectors}, "nth_value(c0, 1)", kFrameOverClauses, kRowsFrameClauses);
-  testWindowFunction(
-      {vectors}, "nth_value(c0, 5)", kFrameOverClauses, kRowsFrameClauses);
-}
-
-TEST_F(NthValueTest, singlePartitionRowFrames) {
-  auto vectors = makeSinglePartitionVectors(400);
-
-  testWindowFunction(
-      {vectors}, "nth_value(c0, c2)", kFrameOverClauses, kRowsFrameClauses);
-  testWindowFunction(
-      {vectors}, "nth_value(c0, 5)", kFrameOverClauses, kRowsFrameClauses);
-}
-
-TEST_F(NthValueTest, multiInputRowFrames) {
-  auto vectors = makeSinglePartitionVectors(200);
-  auto doubleVectors = {vectors, vectors};
-
-  testWindowFunction(
-      doubleVectors, "nth_value(c0, c2)", kFrameOverClauses, kRowsFrameClauses);
-  testWindowFunction(
-      {vectors}, "nth_value(c0, 5)", kFrameOverClauses, kRowsFrameClauses);
-}
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    NthValueTest,
+    MultiNthValueTest,
+    testing::ValuesIn(std::vector<std::string>(kFrameClauses)));
 
 }; // namespace
 }; // namespace facebook::velox::window::test

--- a/velox/functions/prestosql/window/tests/NtileTest.cpp
+++ b/velox/functions/prestosql/window/tests/NtileTest.cpp
@@ -42,6 +42,7 @@ class NtileTest : public WindowTestBase {
         makeFlatVector<int64_t>(size, [](auto row) { return row % 5 + 1; }),
         makeFlatVector<int64_t>(
             size, [](auto row) { return row % 7 + 1; }, nullEvery(15)),
+        makeFlatVector<int64_t>(size, [](auto row) { return row % 11; }),
     });
   }
 };


### PR DESCRIPTION
Add support for k PRECEDING and k FOLLOWING frame bounds in ROWS mode.
k can be an integer constant or a column containing integer values.
Empty frames will be handled in a subsequent PR.