### PR TITLE
Change VELOX_DEPENDENCY_SOURCE to use BUNDLED for benchmarks build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ jobs:
       CONBENCH_URL: "https://velox-conbench.voltrondata.run/"
       CONBENCH_HOST: "CircleCI-runner-dedicated"
       LINUX_DISTRO: "ubuntu"
-      VELOX_DEPENDENCY_SOURCE: SYSTEM
+      VELOX_DEPENDENCY_SOURCE: BUNDLED
     steps:
       - checkout
       - update-submodules


### PR DESCRIPTION
This happens because the proto installed in the image isnt the required version. 
Fixes issue : #3326 