### PR TITLE
Adds Parquet list reader for scalars

### DIFF
--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -16,9 +16,11 @@ add_library(
   velox_dwio_native_parquet_reader
   NestedStructureDecoder.cpp
   ParquetReader.cpp
+  ParquetTypeWithId.cpp
   PageReader.cpp
-  ParquetData.cpp
   ParquetColumnReader.cpp
+  ParquetData.cpp
+  RepeatedColumnReader.cpp
   RleBpDecoder.cpp
   Statistics.cpp
   StructColumnReader.cpp
@@ -30,5 +32,6 @@ target_link_libraries(
   velox_type
   velox_dwio_common
   arrow
+  parquet
   thrift
   ${FMT})

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -17,10 +17,10 @@
 #include "velox/dwio/parquet/reader/PageReader.h"
 #include "velox/dwio/common/BufferUtil.h"
 #include "velox/dwio/common/ColumnVisitors.h"
+#include "velox/dwio/parquet/reader/NestedStructureDecoder.h"
 #include "velox/dwio/parquet/thrift/ThriftTransport.h"
 #include "velox/vector/FlatVector.h"
 
-#include <arrow/util/rle_encoding.h>
 #include <snappy.h>
 #include <thrift/protocol/TCompactProtocol.h> //@manual
 #include <zlib.h>
@@ -31,12 +31,13 @@ namespace facebook::velox::parquet {
 using thrift::Encoding;
 using thrift::PageHeader;
 
-void PageReader::readNextPage(int64_t row) {
+void PageReader::seekToPage(int64_t row) {
   defineDecoder_.reset();
   repeatDecoder_.reset();
   // 'rowOfPage_' is the row number of the first row of the next page.
   rowOfPage_ += numRowsInPage_;
   for (;;) {
+    auto dataStart = pageStart_;
     PageHeader pageHeader = readPageHeader(chunkSize_ - pageStart_);
     pageStart_ = pageDataStart_ + pageHeader.compressed_page_size;
 
@@ -48,15 +49,23 @@ void PageReader::readNextPage(int64_t row) {
         prepareDataPageV2(pageHeader, row);
         break;
       case thrift::PageType::DICTIONARY_PAGE:
+        if (row == kRepDefOnly) {
+          skipBytes(
+              pageHeader.uncompressed_page_size,
+              inputStream_.get(),
+              bufferStart_,
+              bufferEnd_);
+          continue;
+        }
         prepareDictionary(pageHeader);
         continue;
       default:
         break; // ignore INDEX page type and any other custom extensions
     }
-    if (row < rowOfPage_ + numRowsInPage_) {
+    if (row == kRepDefOnly || row < rowOfPage_ + numRowsInPage_) {
       break;
     }
-    rowOfPage_ += numRowsInPage_;
+    updateRowInfoAfterPageSkipped();
     dwio::common::skipBytes(
         pageHeader.compressed_page_size,
         inputStream_.get(),
@@ -212,12 +221,34 @@ const char* FOLLY_NONNULL PageReader::uncompressData(
   }
 }
 
+void PageReader::setPageRowInfo(bool forRepDef) {
+  if (isTopLevel_ || forRepDef) {
+    numRowsInPage_ = numRepDefsInPage_;
+  } else {
+    ++pageIndex_;
+    VELOX_CHECK_LT(
+        pageIndex_,
+        numLeavesInPage_.size(),
+        "Seeking past known repdefs for non top level column page {}",
+        pageIndex_);
+    numRowsInPage_ = numLeavesInPage_[pageIndex_];
+  }
+}
+
+void PageReader::updateRowInfoAfterPageSkipped() {
+  rowOfPage_ += numRowsInPage_;
+  if (!isTopLevel_) {
+    numLeafNullsConsumed_ = rowOfPage_;
+  }
+}
+
 void PageReader::prepareDataPageV1(const PageHeader& pageHeader, int64_t row) {
   VELOX_CHECK(
       pageHeader.type == thrift::PageType::DATA_PAGE &&
       pageHeader.__isset.data_page_header);
-  numRowsInPage_ = pageHeader.data_page_header.num_values;
-  if (numRowsInPage_ + rowOfPage_ <= row) {
+  numRepDefsInPage_ = pageHeader.data_page_header.num_values;
+  setPageRowInfo(row == kRepDefOnly);
+  if (row != kRepDefOnly && numRowsInPage_ + rowOfPage_ <= row) {
     return;
   }
   pageData_ = readBytes(pageHeader.compressed_page_size, pageBuffer_);
@@ -228,32 +259,47 @@ void PageReader::prepareDataPageV1(const PageHeader& pageHeader, int64_t row) {
   auto pageEnd = pageData_ + pageHeader.uncompressed_page_size;
   if (maxRepeat_ > 0) {
     uint32_t repeatLength = readField<int32_t>(pageData_);
-    pageData_ += repeatLength;
-    repeatDecoder_ = std::make_unique<RleBpDecoder>(
-        pageData_,
-        pageData_ + repeatLength,
+    repeatDecoder_ = std::make_unique<arrow::util::RleDecoder>(
+        reinterpret_cast<const uint8_t*>(pageData_),
+        repeatLength,
         arrow::bit_util::NumRequiredBits(maxRepeat_));
+
     pageData_ += repeatLength;
   }
 
   if (maxDefine_ > 0) {
     auto defineLength = readField<uint32_t>(pageData_);
-    defineDecoder_ = std::make_unique<RleBpDecoder>(
-        pageData_,
-        pageData_ + defineLength,
-        arrow::bit_util::NumRequiredBits(maxDefine_));
+    if (maxDefine_ == 1) {
+      defineDecoder_ = std::make_unique<RleBpDecoder>(
+          pageData_,
+          pageData_ + defineLength,
+          arrow::bit_util::NumRequiredBits(maxDefine_));
+    } else {
+      wideDefineDecoder_ = std::make_unique<arrow::util::RleDecoder>(
+          reinterpret_cast<const uint8_t*>(pageData_),
+          defineLength,
+          arrow::bit_util::NumRequiredBits(maxDefine_));
+    }
     pageData_ += defineLength;
   }
   encodedDataSize_ = pageEnd - pageData_;
 
   encoding_ = pageHeader.data_page_header.encoding;
-  makeDecoder();
+  if (row != kRepDefOnly) {
+    makeDecoder();
+  }
 }
 
 void PageReader::prepareDataPageV2(const PageHeader& pageHeader, int64_t row) {
   VELOX_CHECK(pageHeader.__isset.data_page_header_v2);
-  numRowsInPage_ = pageHeader.data_page_header_v2.num_values;
-  if (numRowsInPage_ + rowOfPage_ <= row) {
+  numRepDefsInPage_ = pageHeader.data_page_header_v2.num_values;
+  setPageRowInfo(row == kRepDefOnly);
+  if (row != kRepDefOnly && numRowsInPage_ + rowOfPage_ <= row) {
+    skipBytes(
+        pageHeader.compressed_page_size,
+        inputStream_.get(),
+        bufferStart_,
+        bufferEnd_);
     return;
   }
 
@@ -267,9 +313,9 @@ void PageReader::prepareDataPageV2(const PageHeader& pageHeader, int64_t row) {
   pageData_ = readBytes(bytes, pageBuffer_);
 
   if (repeatLength) {
-    repeatDecoder_ = std::make_unique<RleBpDecoder>(
-        pageData_,
-        pageData_ + repeatLength,
+    repeatDecoder_ = std::make_unique<arrow::util::RleDecoder>(
+        reinterpret_cast<const uint8_t*>(pageData_),
+        repeatLength,
         arrow::bit_util::NumRequiredBits(maxRepeat_));
   }
 
@@ -288,6 +334,11 @@ void PageReader::prepareDataPageV2(const PageHeader& pageHeader, int64_t row) {
         pageHeader.compressed_page_size - levelsSize,
         pageHeader.uncompressed_page_size - levelsSize);
   }
+  if (row == kRepDefOnly) {
+    skipBytes(bytes, inputStream_.get(), bufferStart_, bufferEnd_);
+    return;
+  }
+
   encodedDataSize_ = pageHeader.uncompressed_page_size - levelsSize;
   encoding_ = pageHeader.data_page_header_v2.encoding;
   makeDecoder();
@@ -459,6 +510,108 @@ int32_t parquetTypeBytes(thrift::Type::type type) {
 }
 } // namespace
 
+void PageReader::preloadRepDefs() {
+  while (pageStart_ < chunkSize_) {
+    seekToPage(kRepDefOnly);
+    auto begin = repetitionLevels_.size();
+    auto numLevels = repetitionLevels_.size() + numRepDefsInPage_;
+    definitionLevels_.resize(numLevels);
+    repetitionLevels_.resize(numLevels);
+    wideDefineDecoder_->GetBatch(
+        definitionLevels_.data() + begin, numRepDefsInPage_);
+    repeatDecoder_->GetBatch(
+        repetitionLevels_.data() + begin, numRepDefsInPage_);
+    leafNulls_.resize(bits::nwords(leafNullsSize_ + numRepDefsInPage_));
+    auto numLeaves = getLengthsAndNulls(
+        LevelMode::kNulls,
+        leafInfo_,
+        begin,
+        begin + numRepDefsInPage_,
+        numRepDefsInPage_,
+        nullptr,
+        leafNulls_.data(),
+        leafNullsSize_);
+    leafNullsSize_ += numLeaves;
+    numLeavesInPage_.push_back(numLeaves);
+  }
+
+  // Reset the input to start of column chunk.
+  std::vector<uint64_t> rewind = {0};
+  pageStart_ = 0;
+  dwio::common::PositionProvider position(rewind);
+  inputStream_->seekToPosition(position);
+  bufferStart_ = bufferEnd_ = nullptr;
+  rowOfPage_ = 0;
+  numRowsInPage_ = 0;
+  pageData_ = nullptr;
+}
+
+void PageReader::decodeRepDefs(int32_t numTopLevelRows) {
+  if (repetitionLevels_.empty()) {
+    preloadRepDefs();
+  }
+  repDefBegin_ = repDefEnd_;
+  int32_t numLevels = definitionLevels_.size();
+  int32_t topFound = 0;
+  int32_t i = repDefBegin_;
+  for (; i < numLevels; ++i) {
+    if (repetitionLevels_[i] == 0)
+      ++topFound;
+    if (topFound == numTopLevelRows + 1) {
+      break;
+    }
+  }
+  repDefEnd_ = i;
+}
+
+int32_t PageReader::getLengthsAndNulls(
+    LevelMode mode,
+    const ::parquet::internal::LevelInfo& info,
+    int32_t begin,
+    int32_t end,
+    int32_t maxItems,
+    int32_t* lengths,
+    uint64_t* nulls,
+    int32_t nullsStartIndex) const {
+  ::parquet::internal::ValidityBitmapInputOutput bits;
+  bits.values_read_upper_bound = maxItems;
+  bits.values_read = 0;
+  bits.null_count = 0;
+  bits.valid_bits = reinterpret_cast<uint8_t*>(nulls);
+  bits.valid_bits_offset = nullsStartIndex;
+
+  switch (mode) {
+    case LevelMode::kNulls:
+      DefLevelsToBitmap(
+          definitionLevels_.data() + begin, end - begin, info, &bits);
+      break;
+    case LevelMode::kList: {
+      ::parquet::internal::DefRepLevelsToList(
+          definitionLevels_.data() + begin,
+          repetitionLevels_.data() + begin,
+          end - begin,
+          info,
+          &bits,
+          lengths);
+      // Convert offsets to lengths.
+      for (auto i = 0; i < bits.values_read; ++i) {
+        lengths[i] = lengths[i + 1] - lengths[i];
+      }
+      break;
+    }
+    case LevelMode::kStructOverLists: {
+      DefRepLevelsToBitmap(
+          definitionLevels_.data() + begin,
+          repetitionLevels_.data() + begin,
+          end - begin,
+          info,
+          &bits);
+      break;
+    }
+  }
+  return bits.values_read;
+}
+
 void PageReader::makeDecoder() {
   auto parquetType = type_->parquetType_.value();
   switch (encoding_) {
@@ -503,7 +656,10 @@ void PageReader::skip(int64_t numRows) {
   }
   auto toSkip = numRows;
   if (firstUnvisited_ + numRows >= rowOfPage_ + numRowsInPage_) {
-    readNextPage(firstUnvisited_ + numRows);
+    seekToPage(firstUnvisited_ + numRows);
+    if (!leafNulls_.empty()) {
+      numLeafNullsConsumed_ = rowOfPage_;
+    }
     toSkip -= rowOfPage_ - firstUnvisited_;
   }
   firstUnvisited_ += numRows;
@@ -524,17 +680,21 @@ void PageReader::skip(int64_t numRows) {
 }
 
 int32_t PageReader::skipNulls(int32_t numValues) {
-  if (!defineDecoder_) {
+  if (!defineDecoder_ && isTopLevel_) {
     return numValues;
   }
-  VELOX_CHECK_EQ(1, maxDefine_);
+  VELOX_CHECK(1 == maxDefine_ || !leafNulls_.empty());
   dwio::common::ensureCapacity<bool>(tempNulls_, numValues, &pool_);
   tempNulls_->setSize(0);
-  bool allOnes;
-  defineDecoder_->readBits(
-      numValues, tempNulls_->asMutable<uint64_t>(), &allOnes);
-  if (allOnes) {
-    return numValues;
+  if (isTopLevel_) {
+    bool allOnes;
+    defineDecoder_->readBits(
+        numValues, tempNulls_->asMutable<uint64_t>(), &allOnes);
+    if (allOnes) {
+      return numValues;
+    }
+  } else {
+    readNulls(numValues, tempNulls_);
   }
   auto words = tempNulls_->as<uint64_t>();
   return bits::countBits(words, 0, numValues);
@@ -547,7 +707,7 @@ void PageReader::skipNullsOnly(int64_t numRows) {
   }
   auto toSkip = numRows;
   if (firstUnvisited_ + numRows >= rowOfPage_ + numRowsInPage_) {
-    readNextPage(firstUnvisited_ + numRows);
+    seekToPage(firstUnvisited_ + numRows);
     firstUnvisited_ += numRows;
     toSkip = firstUnvisited_ - rowOfPage_;
   }
@@ -558,6 +718,7 @@ void PageReader::skipNullsOnly(int64_t numRows) {
 }
 
 void PageReader::readNullsOnly(int64_t numValues, BufferPtr& buffer) {
+  VELOX_CHECK(isTopLevel_);
   auto toRead = numValues;
   if (buffer) {
     dwio::common::ensureCapacity<bool>(buffer, numValues, &pool_);
@@ -566,7 +727,7 @@ void PageReader::readNullsOnly(int64_t numValues, BufferPtr& buffer) {
   while (toRead) {
     auto availableOnPage = rowOfPage_ + numRowsInPage_ - firstUnvisited_;
     if (!availableOnPage) {
-      readNextPage(firstUnvisited_);
+      seekToPage(firstUnvisited_);
       availableOnPage = numRowsInPage_;
     }
     auto numRead = std::min(availableOnPage, toRead);
@@ -580,15 +741,26 @@ void PageReader::readNullsOnly(int64_t numValues, BufferPtr& buffer) {
 
 const uint64_t* FOLLY_NULLABLE
 PageReader::readNulls(int32_t numValues, BufferPtr& buffer) {
-  if (!defineDecoder_) {
+  if (maxDefine_ == 0) {
     buffer = nullptr;
     return nullptr;
   }
-  VELOX_CHECK_EQ(1, maxDefine_);
   dwio::common::ensureCapacity<bool>(buffer, numValues, &pool_);
-  bool allOnes;
-  defineDecoder_->readBits(numValues, buffer->asMutable<uint64_t>(), &allOnes);
-  return allOnes ? nullptr : buffer->as<uint64_t>();
+  if (isTopLevel_) {
+    VELOX_CHECK_EQ(1, maxDefine_);
+    bool allOnes;
+    defineDecoder_->readBits(
+        numValues, buffer->asMutable<uint64_t>(), &allOnes);
+    return allOnes ? nullptr : buffer->as<uint64_t>();
+  }
+  bits::copyBits(
+      leafNulls_.data(),
+      numLeafNullsConsumed_,
+      buffer->asMutable<uint64_t>(),
+      0,
+      numValues);
+  numLeafNullsConsumed_ += numValues;
+  return buffer->as<uint64_t>();
 }
 
 void PageReader::startVisit(folly::Range<const vector_size_t*> rows) {
@@ -613,7 +785,10 @@ bool PageReader::rowsForPage(
   // page that contains the row.
   auto rowZero = visitBase_ + visitorRows_[currentVisitorRow_];
   if (rowZero >= rowOfPage_ + numRowsInPage_) {
-    readNextPage(rowZero);
+    seekToPage(rowZero);
+    if (!leafNulls_.empty()) {
+      numLeafNullsConsumed_ = rowOfPage_;
+    }
   }
   auto& scanState = reader.scanState();
   if (isDictionary()) {

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -22,6 +22,7 @@
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 #include "velox/dwio/parquet/reader/FloatingPointColumnReader.h"
 #include "velox/dwio/parquet/reader/IntegerColumnReader.h"
+#include "velox/dwio/parquet/reader/RepeatedColumnReader.h"
 #include "velox/dwio/parquet/reader/StringColumnReader.h"
 #include "velox/dwio/parquet/reader/StructColumnReader.h"
 
@@ -62,8 +63,10 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
     case TypeKind::VARCHAR:
       return std::make_unique<StringColumnReader>(dataType, params, scanSpec);
 
-    case TypeKind::BOOLEAN:
     case TypeKind::ARRAY:
+      return std::make_unique<ListColumnReader>(dataType, params, scanSpec);
+
+    case TypeKind::BOOLEAN:
     case TypeKind::MAP:
 
       VELOX_UNSUPPORTED("Type is not supported: ", dataType->type->kind());

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -70,6 +70,10 @@ class ParquetData : public dwio::common::FormatData {
       uint64_t rowsPerRowGroup,
       const dwio::common::StatsContext& writerContext) override;
 
+  PageReader* FOLLY_NONNULL reader() const {
+    return reader_.get();
+  }
+
   // Reads null flags for 'numValues' next top level rows. The first 'numValues'
   // bits of 'nulls' are set and the reader is advanced by numValues'.
   void readNullsOnly(int32_t numValues, BufferPtr& nulls) {
@@ -80,12 +84,37 @@ class ParquetData : public dwio::common::FormatData {
     return maxDefine_ > 0;
   }
 
+  /// Sets nulls to be returned by readNulls(). Nulls for non-leaf readers come
+  /// from leaf repdefs which are gathered before descending the reader tree.
+  void setNulls(BufferPtr& nulls, int32_t numValues) {
+    presetNulls_ = nulls;
+    presetNullsSize_ = numValues;
+    presetNullsSkipped_ = 0;
+  }
+
   void readNulls(
       vector_size_t numValues,
       const uint64_t* FOLLY_NULLABLE incomingNulls,
       BufferPtr& nulls,
       bool nullsOnly = false) override {
     // If the query accesses only nulls, read the nulls from the pages in range.
+    // If nulls are preread, return those minus any skipped.
+    if (presetNulls_) {
+      VELOX_CHECK_EQ(numValues, presetNullsSize_ - presetNullsSkipped_);
+      nulls = std::move(presetNulls_);
+      if (presetNullsSkipped_) {
+        auto bits = nulls->asMutable<uint64_t>();
+        bits::copyBits(
+            bits,
+            presetNullsSkipped_,
+            bits,
+            0,
+            presetNullsSize_ - presetNullsSkipped_);
+      }
+      presetNullsSkipped_ = 0;
+      presetNullsSize_ = 0;
+      return;
+    }
     if (nullsOnly) {
       readNullsOnly(numValues, nulls);
       return;
@@ -102,6 +131,9 @@ class ParquetData : public dwio::common::FormatData {
     // pages it takes to skip 'numValues' top level rows.
     if (nullsOnly) {
       reader_->skipNullsOnly(numValues);
+    }
+    if (presetNulls_) {
+      presetNullsSkipped_ += numValues;
     }
     return numValues;
   }
@@ -142,6 +174,15 @@ class ParquetData : public dwio::common::FormatData {
   const uint32_t maxRepeat_;
   int64_t rowsInRowGroup_;
   std::unique_ptr<PageReader> reader_;
+
+  // Nulls derived from leaf repdefs for non-leaf readers.
+  BufferPtr presetNulls_;
+
+  // Number of valid bits in 'presetNulls_'.
+  int32_t presetNullsSize_{0};
+
+  // Count of leading skipped positions in 'presetNulls_'
+  int32_t presetNullsSkipped_{0};
 };
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -170,7 +170,7 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
               ParquetTypeWithId::kNonLeaf, // columnIdx,
               schemaElement.name,
               std::nullopt,
-              maxRepeat,
+              maxRepeat + 1,
               maxDefine);
         }
         case thrift::ConvertedType::MAP_KEY_VALUE: {
@@ -337,7 +337,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT64,
             "UINT_64 converted type can only be set for value of thrift::Type::INT64");
-        return TINYINT();
+        return BIGINT();
 
       case thrift::ConvertedType::DATE:
         VELOX_CHECK_EQ(

--- a/velox/dwio/parquet/reader/ParquetTypeWithId.cpp
+++ b/velox/dwio/parquet/reader/ParquetTypeWithId.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/parquet/reader/ParquetTypeWithId.h"
+
+namespace facebook::velox::parquet {
+namespace {
+bool containsList(const ParquetTypeWithId& type) {
+  if (type.type->kind() == TypeKind::ARRAY) {
+    return true;
+  }
+  if (type.type->kind() == TypeKind::ROW) {
+    for (auto i = 0; i < type.getChildren().size(); ++i) {
+      if (containsList(type.parquetChildAt(i))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+} // namespace
+using ::parquet::internal::LevelInfo;
+
+LevelMode ParquetTypeWithId::makeLevelInfo(LevelInfo& info) const {
+  int16_t repeatedAncestor = 0;
+  for (auto parent = parquetParent(); parent;
+       parent = parent->parquetParent()) {
+    if (parent->type->kind() == TypeKind::ARRAY) {
+      repeatedAncestor = parent->maxDefine_;
+      break;
+    }
+  }
+  bool isList = type->kind() == TypeKind::ARRAY;
+  bool isStruct = type->kind() == TypeKind::ROW;
+  bool hasList = false;
+  if (isStruct) {
+    bool isAllLists = true;
+    for (auto i = 0; i < getChildren().size(); ++i) {
+      auto child = parquetChildAt(i);
+      if (child.type->kind() != TypeKind ::ARRAY) {
+        isAllLists = false;
+      }
+      hasList |= hasList || containsList(child);
+    }
+  }
+  if (isList) {
+    // the definition level is the level of a present element.
+    new (&info) LevelInfo(1, maxDefine_ + 1, maxRepeat_, repeatedAncestor);
+    return LevelMode::kList;
+  }
+  if (isStruct) {
+    new (&info) LevelInfo(1, maxDefine_, maxRepeat_, repeatedAncestor);
+    return hasList ? LevelMode::kStructOverLists : LevelMode::kNulls;
+  }
+  new (&info) LevelInfo(1, maxDefine_, maxRepeat_, repeatedAncestor);
+  return LevelMode::kNulls;
+}
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/ParquetTypeWithId.h
+++ b/velox/dwio/parquet/reader/ParquetTypeWithId.h
@@ -16,10 +16,17 @@
 
 #pragma once
 
+#include <parquet/level_conversion.h>
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
 
 namespace facebook::velox::parquet {
+
+/// Describes what to extract from leaf repetition / definition
+/// levels for a particular level. Selects between using
+/// DefLevelsToBitmap, DefRepLevelsToList or DefRepLevelsToBitmap
+/// respectively.
+enum class LevelMode { kList, kNulls, kStructOverLists };
 
 // Describes a Parquet column.
 class ParquetTypeWithId : public dwio::common::TypeWithId {
@@ -57,6 +64,13 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
   const ParquetTypeWithId& parquetChildAt(uint32_t index) const {
     return *reinterpret_cast<const ParquetTypeWithId*>(childAt(index).get());
   }
+
+  const ParquetTypeWithId* FOLLY_NULLABLE parquetParent() const {
+    return reinterpret_cast<const ParquetTypeWithId*>(parent);
+  }
+
+  /// Fills 'info' and returns the mode for interpreting levels.
+  LevelMode makeLevelInfo(::parquet::internal::LevelInfo& info) const;
 
   const std::string name_;
   const std::optional<thrift::Type::type> parquetType_;

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/parquet/reader/RepeatedColumnReader.h"
+#include "velox/dwio/parquet/reader/ParquetColumnReader.h"
+#include "velox/dwio/parquet/reader/StructColumnReader.h"
+
+namespace facebook::velox::parquet {
+
+PageReader* readLeafRepDefs(
+    dwio::common::SelectiveColumnReader* FOLLY_NONNULL reader,
+    int32_t numTop) {
+  auto children = reader->children();
+  if (children.empty()) {
+    auto pageReader = reader->formatData().as<ParquetData>().reader();
+    pageReader->decodeRepDefs(numTop);
+    return pageReader;
+  }
+  PageReader* pageReader;
+  for (auto i = 0; i < children.size(); ++i) {
+    auto child = children[i];
+    if (i == 0) {
+      pageReader = readLeafRepDefs(child, numTop);
+
+      auto& type =
+          *reinterpret_cast<const ParquetTypeWithId*>(&reader->nodeType());
+      if (auto structChild = dynamic_cast<StructColumnReader*>(reader)) {
+        VELOX_NYI();
+      }
+      auto list = dynamic_cast<ListColumnReader*>(reader);
+      VELOX_CHECK(list);
+      list->setLengthsFromRepDefs(*pageReader);
+    } else {
+      readLeafRepDefs(child, numTop);
+    }
+  }
+  return pageReader;
+}
+
+void enqueueChildren(
+    dwio::common::SelectiveColumnReader* reader,
+    uint32_t index,
+    dwio::common::BufferedInput& input) {
+  auto children = reader->children();
+  if (children.empty()) {
+    reader->formatData().as<ParquetData>().enqueueRowGroup(index, input);
+    return;
+  }
+  for (auto* child : children) {
+    enqueueChildren(child, index, input);
+  }
+}
+
+void ensureRepDefs(
+    dwio::common::SelectiveColumnReader& reader,
+    int32_t numTop) {
+  auto& nodeType =
+      *reinterpret_cast<const ParquetTypeWithId*>(&reader.nodeType());
+  if (nodeType.maxDefine_ <= 1)
+    readLeafRepDefs(&reader, numTop);
+}
+
+ListColumnReader::ListColumnReader(
+    std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+    ParquetParams& params,
+    common::ScanSpec& scanSpec)
+    : dwio::common::SelectiveListColumnReader(
+          requestedType,
+          requestedType,
+          params,
+          scanSpec) {
+  auto& childType = requestedType->childAt(0);
+  child_ =
+      ParquetColumnReader::build(childType, params, *scanSpec.children()[0]);
+  reinterpret_cast<const ParquetTypeWithId*>(requestedType.get())
+      ->makeLevelInfo(levelInfo_);
+}
+
+void ListColumnReader::enqueueRowGroup(
+    uint32_t index,
+    dwio::common::BufferedInput& input) {
+  enqueueChildren(this, index, input);
+}
+
+void ListColumnReader::seekToRowGroup(uint32_t index) {
+  SelectiveColumnReader::seekToRowGroup(index);
+  readOffset_ = 0;
+  childTargetReadOffset_ = 0;
+  child_->seekToRowGroup(index);
+}
+
+void ListColumnReader::setLengthsFromRepDefs(PageReader& pageReader) {
+  auto repDefRange = pageReader.repDefRange();
+  int32_t numRepDefs = repDefRange.second - repDefRange.first;
+  BufferPtr lengths = std::move(lengths_.lengths());
+  dwio::common::ensureCapacity<int32_t>(lengths, numRepDefs, &memoryPool_);
+  memset(lengths->asMutable<uint64_t>(), 0, lengths->size());
+  dwio::common::ensureCapacity<uint64_t>(
+      nullsInReadRange_, bits::nwords(numRepDefs), &memoryPool_);
+  auto numLists = pageReader.getLengthsAndNulls(
+      LevelMode::kList,
+      levelInfo_,
+      repDefRange.first,
+      repDefRange.second,
+      numRepDefs,
+      lengths->asMutable<int32_t>(),
+      nullsInReadRange()->asMutable<uint64_t>(),
+      0);
+  lengths->setSize(numLists * sizeof(int32_t));
+  formatData_->as<ParquetData>().setNulls(nullsInReadRange(), numLists);
+  setLengths(std::move(lengths));
+}
+void ListColumnReader::read(
+    vector_size_t offset,
+    RowSet rows,
+    const uint64_t* incomingNulls) {
+  // The topmost list reader reads the repdefs for the left subtree.
+  ensureRepDefs(*this, offset + rows.back() + 1 - readOffset_);
+  SelectiveListColumnReader::read(offset, rows, incomingNulls);
+}
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.h
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/common/SelectiveRepeatedColumnReader.h"
+#include "velox/dwio/parquet/reader/ParquetData.h"
+
+namespace facebook::velox::parquet {
+
+/// Comtainer for the lengths of a repeated reader where the lengths are
+/// pre-filled from repdefs.
+class RepeatedLengths {
+ public:
+  void setLengths(BufferPtr lengths) {
+    lengths_ = std::move(lengths);
+    nextLengthIndex_ = 0;
+  }
+
+  BufferPtr& lengths() {
+    return lengths_;
+  }
+
+  void readLengths(int32_t* FOLLY_NONNULL lengths, int32_t numLengths) {
+    VELOX_CHECK_LE(
+        nextLengthIndex_ + numLengths, lengths_->size() / sizeof(int32_t));
+    memcpy(
+        lengths,
+        lengths_->as<int32_t>() + nextLengthIndex_,
+        numLengths * sizeof(int32_t));
+    nextLengthIndex_ += numLengths;
+  }
+
+ private:
+  BufferPtr lengths_;
+  int32_t nextLengthIndex_{0};
+};
+
+class ListColumnReader : public dwio::common::SelectiveListColumnReader {
+ public:
+  ListColumnReader(
+      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+      ParquetParams& params,
+      common::ScanSpec& scanSpec);
+
+  void prepareRead(
+      vector_size_t offset,
+      RowSet rows,
+      const uint64_t* FOLLY_NULLABLE incomingNulls) {
+    // The prepare is done by the topmost list/struct.
+  }
+
+  void seekToRowGroup(uint32_t index) override;
+
+  void enqueueRowGroup(uint32_t index, dwio::common::BufferedInput& input);
+
+  void read(
+      vector_size_t offset,
+      RowSet rows,
+      const uint64_t* FOLLY_NULLABLE /*incomingNulls*/) override;
+
+  void setLengths(BufferPtr lengths) {
+    lengths_.setLengths(lengths);
+  }
+  void readLengths(
+      int32_t* FOLLY_NONNULL lengths,
+      int32_t numLengths,
+      const uint64_t* FOLLY_NULLABLE /*nulls*/) override {
+    lengths_.readLengths(lengths, numLengths);
+  }
+
+  void setLengthsFromRepDefs(PageReader& leaf);
+
+ private:
+  RepeatedLengths lengths_;
+  ::parquet::internal::LevelInfo levelInfo_;
+};
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/parquet/reader/StructColumnReader.h"
+#include "velox/dwio/parquet/reader/RepeatedColumnReader.h"
 
 namespace facebook::velox::parquet {
 
@@ -41,6 +42,8 @@ void StructColumnReader::enqueueRowGroup(
   for (auto& child : children_) {
     if (auto structChild = dynamic_cast<StructColumnReader*>(child)) {
       structChild->enqueueRowGroup(index, input);
+    } else if (auto listChild = dynamic_cast<ListColumnReader*>(child)) {
+      listChild->enqueueRowGroup(index, input);
     } else {
       child->formatData().as<ParquetData>().enqueueRowGroup(index, input);
     }

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -45,7 +45,9 @@ class E2EFilterTest : public E2EFilterTestBase {
 
     // Always test no null case.
     auto newCustomize = [&]() {
-      customize();
+      if (customize) {
+        customize();
+      }
       makeNotNull(0);
     };
     testSenario(
@@ -397,6 +399,18 @@ TEST_F(E2EFilterTest, dedictionarize) {
       false,
       {"long_val", "string_val", "string_val_2"},
       20);
+}
+
+TEST_F(E2EFilterTest, scalarList) {
+  // Break up the leaf data in small pages to cover coalescing repdefs.
+  writerProperties_ =
+      ::parquet::WriterProperties::Builder().data_pagesize(4 * 1024)->build();
+  testWithTypes(
+      "long_val:bigint, array_val:array<int>",
+      nullptr,
+      false,
+      {"long_val"},
+      10);
 }
 
 // Define main so that gflags get processed.

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -56,7 +56,7 @@ TEST_F(ParquetReaderTest, parseDate) {
   const std::string sample(getExampleFilePath("date.parquet"));
 
   ReaderOptions readerOptions;
-  parquet::ParquetReader reader(
+  facebook::velox::parquet::ParquetReader reader(
       std::make_unique<FileInputStream>(sample), readerOptions);
 
   EXPECT_EQ(reader.numberOfRows(), 25ULL);
@@ -74,7 +74,7 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
   const std::string sample(getExampleFilePath("row_map_array.parquet"));
 
   ReaderOptions readerOptions;
-  parquet::ParquetReader reader(
+  facebook::velox::parquet::ParquetReader reader(
       std::make_unique<FileInputStream>(sample), readerOptions);
 
   EXPECT_EQ(reader.numberOfRows(), 1ULL);


### PR DESCRIPTION
Adds interpretation of repetition and definition levels for nested data to PageReader. Levels are read for the leafmost column of a list and stored in the PageReader for the column chunk on first use.

the repeated reader is inherited from dwio/common, formerley SelectiveRepeatedColumnReader in dwio/dwrf/reader/. The Parquet nested types read like the ORC ones once the repdefs are read for the column and converted to lengths and nulls at the different levels. This is done on first use of a non-scalar reader under the top struct reader.