### PR TITLE
Fix hash table hang with large number of tombstone slots

### DIFF
--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -62,7 +62,12 @@ class BaseHashTable {
 
   // 2M entries, i.e. 16MB is the largest array based hash table.
   static constexpr uint64_t kArrayHashMaxSize = 2L << 20;
+
+  /// Specifies the hash mode of a table.
   enum class HashMode { kHash, kArray, kNormalizedKey };
+
+  /// Returns the string of the given 'mode'.
+  static std::string modeString(HashMode mode);
 
   // Keeps track of results returned from a join table. One batch of
   // keys can produce multiple batches of results. This is initialized
@@ -260,9 +265,17 @@ class BaseHashTable {
 
  protected:
   virtual void setHashMode(HashMode mode, int32_t numNew) = 0;
+
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
   std::unique_ptr<RowContainer> rows_;
 };
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& os,
+    const BaseHashTable::HashMode& mode) {
+  os << BaseHashTable::modeString(mode);
+  return os;
+}
 
 class ProbeState;
 
@@ -398,10 +411,19 @@ class HashTable : public BaseHashTable {
   }
 
   uint64_t rehashSize() const {
-    return rehashSize(size_);
+    return rehashSize(size_ - numTombstones_);
   }
 
   std::string toString() override;
+
+  /// Invoked to check the consistency of the internal state. The function scans
+  /// all the table slots to check if the relevant slot counting are correct
+  /// such as the number of used slots ('numDistinct_') and the number of
+  /// tombstone slots ('numTombstones_').
+  ///
+  /// NOTE: the check cost is non-trivial and is mostly intended for testing
+  /// purpose.
+  void checkConsistency() const;
 
  private:
   // Returns the number of entries after which the table gets rehashed.
@@ -608,6 +630,8 @@ class HashTable : public BaseHashTable {
   int64_t size_ = 0;
   int64_t sizeMask_ = 0;
   int64_t numDistinct_ = 0;
+  // Counts the number of tombstone table slots.
+  int64_t numTombstones_ = 0;
   HashMode hashMode_ = HashMode::kArray;
   // Owns the memory of multiple build side hash join tables that are
   // combined into a single probe hash table.


### PR DESCRIPTION
In spilling stress test with ~256KB memory limit when replaying meta production
queries in staging cluster, we run into hanging issue and it turns out the the 
hash aggregation operator is stuck in hash probe loop. RCA is that the spilling
execution path triggers hash table entry deletion which leaves a large number
of tombstone slots in the table and a tombstone slot can be used as free slot if
the associated table slot group has no empty slot. The reason is the hash table
is designed to leverage the tombstone slot to handle hash table collision. When
we lookup hash table, if a table group has no target table slot and no empty slot,
then we have to continue search the table as there might be potential match in
the rest of table slots. Given that, when we delete a table slot, we have to mark it
as tombstone slot instead of empty slot. A tombstone slot be used to store new
entry only after the lookup eventually hits a group which has empty slot. And the
first encountered tombstone slot during the lookup process will be used to store the
new entry. So if all the table slots which are either occupied or tombstoned, then
we can't have any free slot to store the new table entry. So we need to treat tombstone
as an occupied slot when we decide to trigger rehash or not. This will also help
improve lookup performance if there is a non-trivial amount of tombstone slots in the
table.

This PR fixes the issue by counting the tombstone slots on deletion/insertion and treat
tombstone slots as an occupied slot to trigger rehash in HashTable::checkSize(). A unit
test is added to reproduce the issue and verify the fix. Will verify on staging cluster with
spilling stress workloads.