### PR TITLE
Add AlphaReaderFactory to velox

### DIFF
--- a/velox/connectors/hive/FileHandle.h
+++ b/velox/connectors/hive/FileHandle.h
@@ -39,7 +39,7 @@ namespace facebook::velox {
 
 // See the file comment.
 struct FileHandle {
-  std::unique_ptr<ReadFile> file;
+  std::shared_ptr<ReadFile> file;
 
   // Each time we make a new FileHandle we assign it a uuid and use that id as
   // the identifier in downstream data caching structures. This saves a lot of

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -300,7 +300,7 @@ class InputStreamHolder : public dwio::common::AbstractInputStreamHolder {
       std::shared_ptr<dwio::common::IoStatistics> stats)
       : fileHandle_(std::move(fileHandle)), stats_(std::move(stats)) {
     input_ = std::make_unique<dwio::common::ReadFileInputStream>(
-        fileHandle_->file.get(), dwio::common::MetricsLog::voidLog(), nullptr);
+        fileHandle_->file, dwio::common::MetricsLog::voidLog(), nullptr);
   }
 
   dwio::common::InputStream& get() override {
@@ -396,7 +396,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   reader_ = dwio::common::getReaderFactory(readerOpts_.getFileFormat())
                 ->createReader(
                     std::make_unique<dwio::common::ReadFileInputStream>(
-                        fileHandle_->file.get(),
+                        fileHandle_->file,
                         dwio::common::MetricsLog::voidLog(),
                         asyncCache ? nullptr : ioStats_.get()),
                     readerOpts_);

--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -145,6 +145,14 @@ ReadFileInputStream::ReadFileInputStream(
     IoStatistics* stats)
     : InputStream(kReadFilePath, metricsLog, stats), readFile_(readFile) {}
 
+ReadFileInputStream::ReadFileInputStream(
+    std::shared_ptr<velox::ReadFile> readFile,
+    const MetricsLogPtr& metricsLog,
+    IoStatistics* stats)
+    : InputStream(kReadFilePath, metricsLog, stats),
+      readFile_(readFile.get()),
+      readFileOwned_(std::move(readFile)) {}
+
 void ReadFileInputStream::read(
     void* buf,
     uint64_t length,

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -191,6 +191,12 @@ class ReadFileInputStream final : public InputStream {
       const MetricsLogPtr& metricsLog = MetricsLog::voidLog(),
       IoStatistics* FOLLY_NULLABLE stats = nullptr);
 
+  // Take shared ownership of |readFile|.
+  explicit ReadFileInputStream(
+      std::shared_ptr<velox::ReadFile>,
+      const MetricsLogPtr& metricsLog = MetricsLog::voidLog(),
+      IoStatistics* FOLLY_NULLABLE stats = nullptr);
+
   virtual ~ReadFileInputStream() {}
 
   uint64_t getLength() const final {
@@ -216,8 +222,13 @@ class ReadFileInputStream final : public InputStream {
 
   bool hasReadAsync() const override;
 
+  const std::shared_ptr<velox::ReadFile>& getReadFile() const {
+    return readFileOwned_;
+  }
+
  private:
   velox::ReadFile* FOLLY_NONNULL readFile_;
+  std::shared_ptr<velox::ReadFile> readFileOwned_;
 };
 
 class ReferenceableInputStream : public InputStream {


### PR DESCRIPTION
Summary: This change will allow user to register Alpha file format and read them in Velox connectors.  Only non-selective reader is supported for now, and cached input is not supported yet.  The `InputStream` passed to the factory must be a `ReadFileInputStream` with a shared ownership of `ReadFile`.  Later we will refactor the factory to take `ReadFile` directly.

Differential Revision: D41473280

