### PR TITLE
add support for casting bigint to decimal

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -119,7 +119,7 @@ void applyDecimalCastKernel(
 }
 
 template <typename TOutput>
-void applyCastBigintToDecimalKernel(
+void applyBigintToDecimalCastKernel(
     const SelectivityVector& rows,
     const BaseVector& input,
     exec::EvalCtx& context,
@@ -550,10 +550,10 @@ VectorPtr CastExpr::applyDecimal(
     }
     case TypeKind::BIGINT: {
       if (toType->kind() == TypeKind::SHORT_DECIMAL) {
-        applyCastBigintToDecimalKernel<UnscaledShortDecimal>(
+        applyBigintToDecimalCastKernel<UnscaledShortDecimal>(
             rows, input, context, toType, castResult, nullOnFailure_);
       } else {
-        applyCastBigintToDecimalKernel<UnscaledLongDecimal>(
+        applyBigintToDecimalCastKernel<UnscaledLongDecimal>(
             rows, input, context, toType, castResult, nullOnFailure_);
       }
       break;

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -123,7 +123,6 @@ void applyCastBigintToDecimalKernel(
     const SelectivityVector& rows,
     const BaseVector& input,
     exec::EvalCtx& context,
-    const TypePtr& fromType,
     const TypePtr& toType,
     VectorPtr castResult,
     const bool nullOnFailure) {
@@ -553,11 +552,11 @@ VectorPtr CastExpr::applyDecimal(
       if (toType->kind() == TypeKind::SHORT_DECIMAL) {
         auto* inputVector = input.asUnchecked<SimpleVector<int64_t>>();
         applyCastBigintToDecimalKernel<UnscaledShortDecimal>(
-            rows, input, context, fromType, toType, castResult, nullOnFailure_);
+            rows, input, context, toType, castResult, nullOnFailure_);
       } else {
         auto* inputVector = input.asUnchecked<SimpleVector<int64_t>>();
         applyCastBigintToDecimalKernel<UnscaledLongDecimal>(
-            rows, input, context, fromType, toType, castResult, nullOnFailure_);
+            rows, input, context, toType, castResult, nullOnFailure_);
       }
       break;
     }

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -550,11 +550,9 @@ VectorPtr CastExpr::applyDecimal(
     }
     case TypeKind::BIGINT: {
       if (toType->kind() == TypeKind::SHORT_DECIMAL) {
-        auto* inputVector = input.asUnchecked<SimpleVector<int64_t>>();
         applyCastBigintToDecimalKernel<UnscaledShortDecimal>(
             rows, input, context, toType, castResult, nullOnFailure_);
       } else {
-        auto* inputVector = input.asUnchecked<SimpleVector<int64_t>>();
         applyCastBigintToDecimalKernel<UnscaledLongDecimal>(
             rows, input, context, toType, castResult, nullOnFailure_);
       }

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -90,6 +90,9 @@ class DecimalUtil {
       const int toPrecision,
       const int toScale,
       const bool nullOnFailure) {
+    static_assert(
+        std::is_same_v<TOutput, UnscaledShortDecimal> ||
+        std::is_same_v<TOutput, UnscaledLongDecimal>);
     int128_t rescaledValue = inputValue;
     bool isOverflow = __builtin_mul_overflow(
         rescaledValue, DecimalUtil::kPowersOfTen[toScale], &rescaledValue);
@@ -104,12 +107,11 @@ class DecimalUtil {
           inputValue,
           toPrecision,
           toScale);
+    }
+    if constexpr (std::is_same_v<TOutput, UnscaledShortDecimal>) {
+      return UnscaledShortDecimal(static_cast<int64_t>(rescaledValue));
     } else {
-      if constexpr (std::is_same_v<TOutput, UnscaledShortDecimal>) {
-        return UnscaledShortDecimal(static_cast<int64_t>(rescaledValue));
-      } else {
-        return UnscaledLongDecimal(static_cast<int64_t>(rescaledValue));
-      }
+      return UnscaledLongDecimal(rescaledValue);
     }
   }
 

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -93,7 +93,7 @@ class DecimalUtil {
     static_assert(
         std::is_same_v<TOutput, UnscaledShortDecimal> ||
         std::is_same_v<TOutput, UnscaledLongDecimal>);
-    int128_t rescaledValue = inputValue;
+    int128_t rescaledValue = static_cast<int128_t>(inputValue);
     bool isOverflow = __builtin_mul_overflow(
         rescaledValue, DecimalUtil::kPowersOfTen[toScale], &rescaledValue);
     // Check overflow.

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -84,6 +84,35 @@ class DecimalUtil {
     }
   }
 
+  template <typename TOutput>
+  inline static std::optional<TOutput> rescaleBigint(
+      const int128_t inputValue,
+      const int toPrecision,
+      const int toScale,
+      const bool nullOnFailure) {
+    int128_t rescaledValue = inputValue;
+    bool isOverflow = __builtin_mul_overflow(
+        rescaledValue, DecimalUtil::kPowersOfTen[toScale], &rescaledValue);
+    // Check overflow.
+    if (rescaledValue < -DecimalUtil::kPowersOfTen[toPrecision] ||
+        rescaledValue > DecimalUtil::kPowersOfTen[toPrecision] || isOverflow) {
+      if (nullOnFailure) {
+        return std::nullopt;
+      }
+      VELOX_USER_FAIL(
+          "Cannot cast BIGINT '{}' to DECIMAL({},{})",
+          inputValue,
+          toPrecision,
+          toScale);
+    } else {
+      if constexpr (std::is_same_v<TOutput, UnscaledShortDecimal>) {
+        return UnscaledShortDecimal(static_cast<int64_t>(rescaledValue));
+      } else {
+        return UnscaledLongDecimal(static_cast<int64_t>(rescaledValue));
+      }
+    }
+  }
+
   template <typename R, typename A, typename B>
   inline static R divideWithRoundUp(
       R& r,


### PR DESCRIPTION
Currently, Velox only support casting between Decimal types of different precisions and scales. But not from other primitive types to Decimal types or vice versa. This PR is intended to support casting bigint to decimal.