### PR TITLE
Add null check for hdfs write handle in HdfsWriteFile

### DIFF
--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsWriteFile.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsWriteFile.cpp
@@ -50,11 +50,9 @@ void HdfsWriteFile::close() {
 }
 
 void HdfsWriteFile::flush() {
-  // Check whether the file is opened for write.
-  VELOX_CHECK_EQ(
-      hdfsFileIsOpenForWrite(hdfsFile_),
-      1,
-      "Cannot flush HDFS file because file is not opened for write: {}",
+  VELOX_CHECK_NOT_NULL(
+      hdfsFile_,
+      "Cannot flush HDFS file because file handle is null, file path: {}",
       filePath_);
   int success = hdfsFlush(hdfsClient_, hdfsFile_);
   VELOX_CHECK_EQ(
@@ -65,11 +63,9 @@ void HdfsWriteFile::append(std::string_view data) {
   if (data.size() == 0) {
     return;
   }
-  // Check whether the file is opened for write.
-  VELOX_CHECK_EQ(
-      hdfsFileIsOpenForWrite(hdfsFile_),
-      1,
-      "Cannot append to HDFS file because file is not opened for write: {}",
+  VELOX_CHECK_NOT_NULL(
+      hdfsFile_,
+      "Cannot append to HDFS file because file handle is null, file path: {}",
       filePath_);
   int64_t totalWrittenBytes =
       hdfsWrite(hdfsClient_, hdfsFile_, std::string(data).c_str(), data.size());

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
@@ -387,7 +387,7 @@ TEST_F(HdfsFileSystemTest, writeDataFailures) {
   writeFile->close();
   VELOX_ASSERT_THROW(
       writeFile->append("abcde"),
-      "Cannot append to HDFS file because file is not opened for write: /a.txt");
+      "Cannot append to HDFS file because file handle is null, file path: /a.txt");
 }
 
 TEST_F(HdfsFileSystemTest, writeFlushFailures) {
@@ -395,7 +395,7 @@ TEST_F(HdfsFileSystemTest, writeFlushFailures) {
   writeFile->close();
   VELOX_ASSERT_THROW(
       writeFile->flush(),
-      "Cannot flush HDFS file because file is not opened for write: /a.txt");
+      "Cannot flush HDFS file because file handle is null, file path: /a.txt");
 }
 
 TEST_F(HdfsFileSystemTest, readFailures) {


### PR DESCRIPTION
This change is to address a comment from https://github.com/facebookincubator/velox/pull/3252