### PR TITLE
Enhance fuzzer to re-use sub-expressions and columns

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -107,6 +107,10 @@ class ExpressionFuzzer {
   template <typename T>
   bool isDone(size_t i, T startTime) const;
 
+  /// Reset any stateful members. Should be called before every fuzzer
+  /// iteration.
+  void reset();
+
   FuzzerGenerator rng_;
   size_t currentSeed_{0};
 
@@ -148,6 +152,20 @@ class ExpressionFuzzer {
   /// particular iteration.
   std::vector<TypePtr> inputRowTypes_;
   std::vector<std::string> inputRowNames_;
+
+  /// Maps a 'Type' serialized as a string to the column names that have already
+  /// been generated. Used to easily look up columns that can be re-used when a
+  /// specific type is required as input to a callable.
+  std::unordered_map<std::string, std::vector<std::string>> typeToColumnNames_;
+
+  /// Maps a 'Type' serialized as a string to the expressions that have already
+  /// been generated and have the same return type. Used to easily look up
+  /// expressions that can be re-used when a specific return type is required.
+  /// Only expressions with no nested expressions are tracked here and can be
+  /// re-used.
+  /// TODO: add support for sharing multi-level expressions.
+  std::unordered_map<std::string, std::vector<core::TypedExprPtr>>
+      typeToExpressions_;
 };
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
After this change the expression fuzzer can generated sub-expressions
that re-use some already generated columns. Before picking an input
column to an expression it will check if there are existing columns
with the same type and randomly pick whether to re-use one of them
or create a new one.

Similar functionality is employed to re-use sub-expressions.
However, there is a current limitation to this that only expressions
with no subexpressions are shared.

Test Plan:
Ran fuzzer tests locally and verified manually that columns and
sub-expressions are being re-used.