### PR TITLE
Fix incorrect results when grouping set keys overlap with aggregate inputs

### DIFF
--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -87,7 +87,13 @@ HashAggregation::HashAggregation(
     std::vector<TypePtr> argTypes;
     for (auto& arg : aggregate->inputs()) {
       argTypes.push_back(arg->type());
-      channels.push_back(exprToChannel(arg.get(), inputType));
+      // In case of the present of GroupId, there could be duplicated column
+      // names if the grouping key also shows up in aggregate inputs.  The
+      // grouping key column could be set to NULL but the input column is
+      // unchanged.  As per implementation of GroupId, keys are always ordered
+      // before the inputs.  Here we need to get the channel of input, thus must
+      // search backward to get the last column with the name.
+      channels.push_back(exprToChannel(arg.get(), inputType, true));
       if (channels.back() == kConstantChannel) {
         auto constant = dynamic_cast<const core::ConstantTypedExpr*>(arg.get());
         if (constant->hasValueVector()) {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -475,7 +475,8 @@ std::vector<column_index_t> toChannels(
 
 column_index_t exprToChannel(
     const core::ITypedExpr* FOLLY_NONNULL expr,
-    const TypePtr& type);
+    const TypePtr& type,
+    bool lastChannel = false);
 
 /// Given a source output type and target input type we return the indices of
 /// the target input columns in the source output type.


### PR DESCRIPTION
Summary:
`GroupId` operator currently layouts all the grouping keys, then followed by all aggregate inputs, then the group ID column.  It then sets NULL to some of the key columns according to the currently active grouping set.  There is an edge case that if some columns show up in both keys and inputs, when the downstream aggregate operator receives the data and tries to retrieve the input, it will search by name and find the key column, which is potentially set to NULL.

To avoid this bug, we change the logic when looking up input column to search from backward.  This relies on the fact that `GroupId` always order the key columns before input columns.  This way we can avoid retrieving the column which is set to NULL by `GroupId`.

Fix https://github.com/facebookincubator/velox/issues/3357

Differential Revision: D41533704

