### PR TITLE
Consolidate memory allocators

### DIFF
--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -44,8 +44,7 @@ class BufferTest : public testing::Test {
     pool_ = memoryManager_.getChild();
   }
 
-  memory::MemoryManager<memory::MemoryAllocator, AlignedBuffer::kAlignment>
-      memoryManager_;
+  memory::MemoryManager<AlignedBuffer::kAlignment> memoryManager_;
   std::shared_ptr<memory::MemoryPool> pool_;
 };
 

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -25,7 +25,7 @@
 namespace facebook::velox::cache {
 
 using memory::MachinePageCount;
-using memory::MappedMemory;
+using memory::MemoryAllocator;
 
 AsyncDataCacheEntry::AsyncDataCacheEntry(CacheShard* shard)
     : shard_(shard), data_(shard->cache()) {
@@ -88,8 +88,8 @@ void AsyncDataCacheEntry::addReference() {
 
 memory::MachinePageCount AsyncDataCacheEntry::setPrefetch(bool flag) {
   isPrefetch_ = flag;
-  auto numPages = bits::roundUp(size_, memory::MappedMemory::kPageSize) /
-      memory::MappedMemory::kPageSize;
+  auto numPages = bits::roundUp(size_, memory::MemoryAllocator::kPageSize) /
+      memory::MemoryAllocator::kPageSize;
   return shard_->cache()->incrementPrefetchPages(flag ? numPages : -numPages);
 }
 
@@ -103,9 +103,10 @@ void AsyncDataCacheEntry::initialize(FileCacheKey key) {
     tinyData_.resize(size_);
   } else {
     tinyData_.clear();
-    auto sizePages =
-        bits::roundUp(size_, MappedMemory::kPageSize) / MappedMemory::kPageSize;
-    if (cache->allocate(sizePages, CacheShard::kCacheOwner, data_)) {
+    auto sizePages = bits::roundUp(size_, MemoryAllocator::kPageSize) /
+        MemoryAllocator::kPageSize;
+    if (cache->allocateNonContiguous(
+            sizePages, CacheShard::kCacheOwner, data_)) {
       cache->incrementCachedPages(data().numPages());
     } else {
       // No memory to cover 'this'.
@@ -315,7 +316,7 @@ void CacheShard::removeEntryLocked(AsyncDataCacheEntry* entry) {
     auto numPages = entry->data().numPages();
     if (numPages) {
       cache_->incrementCachedPages(-numPages);
-      cache_->free(entry->data());
+      cache_->freeNonContiguous(entry->data());
     }
   }
 }
@@ -327,7 +328,7 @@ void CacheShard::evict(uint64_t bytesToFree, bool evictAllUnpinned) {
   auto ssdCache = cache_->ssdCache();
   bool skipSsdSaveable = ssdCache && ssdCache->writeInProgress();
   auto now = accessTime();
-  std::vector<MappedMemory::Allocation> toFree;
+  std::vector<MemoryAllocator::Allocation> toFree;
   {
     std::lock_guard<std::mutex> l(mutex_);
     int size = entries_.size();
@@ -389,7 +390,7 @@ void CacheShard::evict(uint64_t bytesToFree, bool evictAllUnpinned) {
   ClockTimer t(allocClocks_);
   toFree.clear();
   cache_->incrementCachedPages(
-      -largeFreed / static_cast<int32_t>(MappedMemory::kPageSize));
+      -largeFreed / static_cast<int32_t>(MemoryAllocator::kPageSize));
   if (evictSaveableSkipped && ssdCache && ssdCache->startWrite()) {
     // Rare. May occur if SSD is unusually slow. Useful for  diagnostics.
     LOG(INFO) << "SSDCA: Start save for old saveable, skipped "
@@ -478,10 +479,10 @@ void CacheShard::appendSsdSaveable(std::vector<CachePin>& pins) {
 }
 
 AsyncDataCache::AsyncDataCache(
-    const std::shared_ptr<MappedMemory>& mappedMemory,
+    const std::shared_ptr<MemoryAllocator>& allocator,
     uint64_t maxBytes,
     std::unique_ptr<SsdCache> ssdCache)
-    : mappedMemory_(mappedMemory),
+    : allocator_(allocator),
       ssdCache_(std::move(ssdCache)),
       cachedPages_(0),
       maxBytes_(maxBytes) {
@@ -537,8 +538,8 @@ bool AsyncDataCache::makeSpace(
     isCounted = true;
   }
   for (auto nthAttempt = 0; nthAttempt < kMaxAttempts; ++nthAttempt) {
-    if (mappedMemory_->numAllocated() + numPages <
-        maxBytes_ / MappedMemory::kPageSize) {
+    if (allocator_->numAllocated() + numPages <
+        maxBytes_ / MemoryAllocator::kPageSize) {
       try {
         if (allocate()) {
           if (isCounted) {
@@ -572,7 +573,7 @@ bool AsyncDataCache::makeSpace(
     // and still have not made the allocation, we go to desperate mode
     // with 'evictAllUnpinned' set to true.
     shards_[shardCounter_ & (kShardMask)]->evict(
-        numPages * sizeMultiplier * MappedMemory::kPageSize,
+        numPages * sizeMultiplier * MemoryAllocator::kPageSize,
         nthAttempt >= kNumShards);
     if (numPages < kSmallSizePages && sizeMultiplier < 4) {
       sizeMultiplier *= 2;
@@ -591,15 +592,15 @@ void AsyncDataCache::backoff(int32_t counter) {
   std::this_thread::sleep_for(std::chrono::microseconds(usec)); // NOLINT
 }
 
-bool AsyncDataCache::allocate(
+bool AsyncDataCache::allocateNonContiguous(
     MachinePageCount numPages,
     int32_t owner,
     Allocation& out,
     std::function<void(int64_t, bool)> beforeAllocCB,
     MachinePageCount minSizeClass) {
-  free(out);
+  freeNonContiguous(out);
   return makeSpace(numPages, [&]() {
-    return mappedMemory_->allocate(
+    return allocator_->allocateNonContiguous(
         numPages, owner, out, beforeAllocCB, minSizeClass);
   });
 }
@@ -610,16 +611,18 @@ bool AsyncDataCache::allocateContiguous(
     ContiguousAllocation& allocation,
     std::function<void(int64_t, bool)> beforeAllocCB) {
   return makeSpace(numPages, [&]() {
-    return mappedMemory_->allocateContiguous(
+    return allocator_->allocateContiguous(
         numPages, collateral, allocation, beforeAllocCB);
   });
 }
 
-void* FOLLY_NULLABLE
-AsyncDataCache::allocateBytes(uint64_t bytes, uint64_t maxMallocSize) {
+void* FOLLY_NULLABLE AsyncDataCache::allocateBytes(
+    uint64_t bytes,
+    uint16_t alignment,
+    uint64_t maxMallocSize) {
   void* result = nullptr;
   makeSpace(bits::roundUp(bytes, kPageSize) / kPageSize, [&]() {
-    result = mappedMemory_->allocateBytes(bytes, maxMallocSize);
+    result = allocator_->allocateBytes(bytes, alignment, maxMallocSize);
     return result != nullptr;
   });
   return result;
@@ -633,7 +636,7 @@ void AsyncDataCache::incrementNew(uint64_t size) {
   if (newBytes_ > nextSsdScoreSize_) {
     // Check next time after replacing half the cache.
     nextSsdScoreSize_ = newBytes_ +
-        std::max<int64_t>(cachedPages_ * MappedMemory::kPageSize, 1UL << 28);
+        std::max<int64_t>(cachedPages_ * MemoryAllocator::kPageSize, 1UL << 28);
     ssdCache_->groupStats().updateSsdFilter(ssdCache_->maxBytes() * 0.9);
   }
 }
@@ -645,7 +648,7 @@ void AsyncDataCache::possibleSsdSave(uint64_t bytes) {
   }
 
   ssdSaveable_ += bytes;
-  if (ssdSaveable_ / MappedMemory::kPageSize >
+  if (ssdSaveable_ / MemoryAllocator::kPageSize >
       std::max<int32_t>(kMinSavePages, cachedPages_ / 8)) {
     // Do not start a new save if another one is in progress.
     if (!ssdCache_->startWrite()) {
@@ -693,7 +696,7 @@ std::string AsyncDataCache::toString() const {
       << " Alloc Megaclocks " << (stats.allocClocks >> 20)
       << " allocated pages " << numAllocated() << " cached pages "
       << cachedPages_;
-  out << "\nBacking: " << mappedMemory_->toString();
+  out << "\nBacking: " << allocator_->toString();
   if (ssdCache_) {
     out << "\nSSD: " << ssdCache_->toString();
   }

--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -25,7 +25,7 @@
 using namespace facebook::velox;
 using namespace facebook::velox::cache;
 
-using facebook::velox::memory::MappedMemory;
+using facebook::velox::memory::MemoryAllocator;
 
 // Represents an entry written to SSD.
 struct TestEntry {
@@ -51,7 +51,7 @@ class SsdFileTest : public testing::Test {
     // tmpfs does not support O_DIRECT, so turn this off for testing.
     FLAGS_ssd_odirect = false;
     cache_ = std::make_shared<AsyncDataCache>(
-        MappedMemory::createDefaultInstance(), maxBytes);
+        MemoryAllocator::createDefaultInstance(), maxBytes);
 
     fileName_ = StringIdLease(fileIds(), "fileInStorage");
 
@@ -64,13 +64,13 @@ class SsdFileTest : public testing::Test {
 
   static void initializeContents(
       int64_t sequence,
-      MappedMemory::Allocation& alloc) {
+      MemoryAllocator::Allocation& alloc) {
     bool first = true;
     for (int32_t i = 0; i < alloc.numRuns(); ++i) {
-      MappedMemory::PageRun run = alloc.runAt(i);
+      MemoryAllocator::PageRun run = alloc.runAt(i);
       int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
       int32_t numWords =
-          run.numPages() * MappedMemory::kPageSize / sizeof(void*);
+          run.numPages() * MemoryAllocator::kPageSize / sizeof(void*);
       for (int32_t offset = 0; offset < numWords; offset++) {
         if (first) {
           ptr[offset] = sequence;
@@ -85,16 +85,16 @@ class SsdFileTest : public testing::Test {
   // Checks that the contents are consistent with what is set in
   // initializeContents.
   static void checkContents(
-      const MappedMemory::Allocation& alloc,
+      const MemoryAllocator::Allocation& alloc,
       int32_t numBytes) {
     bool first = true;
     int64_t sequence;
     int32_t bytesChecked = sizeof(int64_t);
     for (int32_t i = 0; i < alloc.numRuns(); ++i) {
-      MappedMemory::PageRun run = alloc.runAt(i);
+      MemoryAllocator::PageRun run = alloc.runAt(i);
       int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
       int32_t numWords =
-          run.numPages() * MappedMemory::kPageSize / sizeof(void*);
+          run.numPages() * MemoryAllocator::kPageSize / sizeof(void*);
       for (int32_t offset = 0; offset < numWords; offset++) {
         if (first) {
           sequence = ptr[offset];

--- a/velox/common/hyperloglog/tests/DenseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/DenseHllTest.cpp
@@ -100,7 +100,7 @@ class DenseHllTest : public ::testing::TestWithParam<int8_t> {
         expected.cardinality());
   }
 
-  HashStringAllocator allocator_{memory::MappedMemory::getInstance()};
+  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
 };
 
 TEST_P(DenseHllTest, basic) {

--- a/velox/common/hyperloglog/tests/SparseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/SparseHllTest.cpp
@@ -98,7 +98,7 @@ class SparseHllTest : public ::testing::Test {
     return serialized;
   }
 
-  HashStringAllocator allocator_{memory::MappedMemory::getInstance()};
+  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
 };
 
 TEST_F(SparseHllTest, basic) {
@@ -173,7 +173,7 @@ class SparseHllToDenseTest : public ::testing::TestWithParam<int8_t> {
     return serialized;
   }
 
-  HashStringAllocator allocator_{memory::MappedMemory::getInstance()};
+  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
 };
 
 TEST_P(SparseHllToDenseTest, toDense) {

--- a/velox/common/memory/AllocationPool.h
+++ b/velox/common/memory/AllocationPool.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 
 namespace facebook::velox {
 // A set of MappedMemory::Allocations holding the fixed width payload
@@ -31,15 +31,15 @@ class AllocationPool {
   static constexpr int32_t kMinPages = 16;
 
   explicit AllocationPool(
-      memory::MappedMemory* mappedMemory,
+      memory::MemoryAllocator* FOLLY_NONNULL allocator,
       int32_t owner = kHashTableOwner)
-      : mappedMemory_(mappedMemory), allocation_(mappedMemory), owner_(owner) {}
+      : allocator_(allocator), allocation_(allocator), owner_(owner) {}
 
   ~AllocationPool() = default;
 
   void clear();
 
-  char* allocateFixed(uint64_t bytes);
+  char* FOLLY_NONNULL allocateFixed(uint64_t bytes);
 
   // Starts a new run for variable length allocation. The actual size
   // is at least one machine page. Throws std::bad_alloc if no space.
@@ -57,13 +57,14 @@ class AllocationPool {
     return largeAllocations_.size();
   }
 
-  const memory::MappedMemory::Allocation* allocationAt(int32_t index) const {
+  const memory::MemoryAllocator::Allocation* FOLLY_NONNULL
+  allocationAt(int32_t index) const {
     return index == allocations_.size() ? &allocation_
                                         : allocations_[index].get();
   }
 
-  const memory::MappedMemory::ContiguousAllocation* largeAllocationAt(
-      int32_t index) const {
+  const memory::MemoryAllocator::ContiguousAllocation* FOLLY_NONNULL
+  largeAllocationAt(int32_t index) const {
     return largeAllocations_[index].get();
   }
 
@@ -83,7 +84,7 @@ class AllocationPool {
     for (auto& largeAllocation : largeAllocations_) {
       totalPages += largeAllocation->numPages();
     }
-    return totalPages * memory::MappedMemory::kPageSize;
+    return totalPages * memory::MemoryAllocator::kPageSize;
   }
 
   // Returns number of bytes left at the end of the current run.
@@ -95,13 +96,13 @@ class AllocationPool {
   }
 
   // Returns pointer to first unallocated byte in the current run.
-  char* firstFreeInRun() {
+  char* FOLLY_NONNULL firstFreeInRun() {
     VELOX_DCHECK(availableInRun() > 0);
     return currentRun().data<char>() + currentOffset_;
   }
 
   // Sets the first free position in the current run.
-  void setFirstFreeInRun(const char* firstFree) {
+  void setFirstFreeInRun(const char* FOLLY_NONNULL firstFree) {
     auto run = currentRun();
     auto offset = firstFree - run.data<char>();
     VELOX_CHECK(
@@ -110,22 +111,23 @@ class AllocationPool {
     currentOffset_ = offset;
   }
 
-  memory::MappedMemory* mappedMemory() const {
-    return mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
+    return allocator_;
   }
 
  private:
-  memory::MappedMemory::PageRun currentRun() const {
+  memory::MemoryAllocator::PageRun currentRun() const {
     return allocation_.runAt(currentRun_);
   }
 
   void newRunImpl(memory::MachinePageCount numPages);
 
-  memory::MappedMemory* mappedMemory_;
-  std::vector<std::unique_ptr<memory::MappedMemory::Allocation>> allocations_;
-  std::vector<std::unique_ptr<memory::MappedMemory::ContiguousAllocation>>
+  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
+  std::vector<std::unique_ptr<memory::MemoryAllocator::Allocation>>
+      allocations_;
+  std::vector<std::unique_ptr<memory::MemoryAllocator::ContiguousAllocation>>
       largeAllocations_;
-  memory::MappedMemory::Allocation allocation_;
+  memory::MemoryAllocator::Allocation allocation_;
   int32_t currentRun_ = 0;
   int32_t currentOffset_ = 0;
   const int32_t owner_;

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -328,7 +328,7 @@ class ByteStream {
       if (offset == bytes) {
         return;
       }
-      extend(bits::roundUp(bytes - offset, memory::MappedMemory::kPageSize));
+      extend(bits::roundUp(bytes - offset, memory::MemoryAllocator::kPageSize));
     }
   }
 
@@ -350,7 +350,7 @@ class ByteStream {
   }
 
  private:
-  void extend(int32_t bytes = memory::MappedMemory::kPageSize);
+  void extend(int32_t bytes = memory::MemoryAllocator::kPageSize);
 
   void updateEnd() {
     if (!ranges_.empty() && current_ == &ranges_.back() &&
@@ -401,11 +401,11 @@ inline Date ByteStream::read<Date>() {
 class IOBufOutputStream : public OutputStream {
  public:
   explicit IOBufOutputStream(
-      memory::MappedMemory& mappedMemory,
+      memory::MemoryAllocator& allocator,
       OutputStreamListener* listener = nullptr,
-      int32_t initialSize = memory::MappedMemory::kPageSize)
+      int32_t initialSize = memory::MemoryAllocator::kPageSize)
       : OutputStream(listener),
-        arena_(std::make_shared<StreamArena>(&mappedMemory)),
+        arena_(std::make_shared<StreamArena>(&allocator)),
         out_(std::make_unique<ByteStream>(arena_.get())) {
     out_->startWrite(initialSize);
   }

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library(
   HashStringAllocator.cpp
   Memory.cpp
   MemoryUsage.cpp
-  MappedMemory.cpp
+  MemoryAllocator.cpp
   MmapAllocator.cpp
   MmapArena.cpp
   MemoryUsageTracker.cpp

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -148,7 +148,8 @@ HashStringAllocator::Position HashStringAllocator::finishWrite(
 
 void HashStringAllocator::newSlab(int32_t size) {
   int32_t needed = std::max<int32_t>(
-      bits::roundUp(size + 2 * sizeof(Header), memory::MappedMemory::kPageSize),
+      bits::roundUp(
+          size + 2 * sizeof(Header), memory::MemoryAllocator::kPageSize),
       kUnitSize);
   pool_.newRun(needed);
   auto run = pool_.firstFreeInRun();

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -130,7 +130,8 @@ class HashStringAllocator : public StreamArena {
     char* FOLLY_NULLABLE position;
   };
 
-  explicit HashStringAllocator(memory::MappedMemory* FOLLY_NONNULL mappedMemory)
+  explicit HashStringAllocator(
+      memory::MemoryAllocator* FOLLY_NONNULL mappedMemory)
       : StreamArena(mappedMemory),
         pool_(mappedMemory, AllocationPool::kHashTableOwner) {}
 
@@ -270,8 +271,8 @@ class HashStringAllocator : public StreamArena {
     pool_.clear();
   }
 
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory() const {
-    return pool_.mappedMemory();
+  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
+    return pool_.allocator();
   }
 
   uint64_t cumulativeBytes() const {
@@ -283,7 +284,7 @@ class HashStringAllocator : public StreamArena {
   void checkConsistency() const;
 
  private:
-  static constexpr int32_t kUnitSize = 16 * memory::MappedMemory::kPageSize;
+  static constexpr int32_t kUnitSize = 16 * memory::MemoryAllocator::kPageSize;
   static constexpr int32_t kMinContiguous = 48;
 
   // Adds 'bytes' worth of contiguous space to the free list. This

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -140,35 +140,54 @@ struct Stats {
   int64_t numAdvise{0};
 };
 
-class ScopedMappedMemory;
+class ScopedMemoryAllocator;
 
-// Denotes a number of machine pages as in mmap and related functions.
+/// Denotes a number of machine pages as in mmap and related functions.
 using MachinePageCount = uint64_t;
 
-// Base class for allocating runs of machine pages from predefined
-// size classes. An allocation that does not match a size class is
-// composed of multiple runs from different size classes. To get 11
-// pages, one could have a run of 8, one of 2 and one of 1
-// page. This is intended for all high volume allocations, like
-// caches, IO buffers and hash tables for join/group
-// by. Implementations may use malloc or mmap/madvise. Caches
-// subclass this to provide allocation that is fungible with cached
-// capacity, i.e. a cache can evict data to make space for non-cache
-// memory users. The point is to have all large allocation come from
-// a single source to have dynamic balancing between different
-// users. Proxy subclasses may provide context specific tracking
-// while delegating the allocation to a root allocator.
-class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
+/// This class provides interface for the actual memory allocations from memory
+/// pool. It allocates runs of machine pages from predefined size classes, and
+/// supports both contiguous and non-contiguous memory allocations. An
+/// non-contiguous allocation that does not match a size class is composed of
+/// multiple runs from different size classes. To get 11 pages, one could have a
+/// run of 8, one of 2 and one of 1 page. This is intended for all high volume
+/// allocations, like caches, IO buffers and hash tables for join/group by.
+/// Implementations may use malloc or mmap/madvise. Caches subclass this to
+/// provide allocation that is fungible with cached capacity, i.e. a cache can
+/// evict data to make space for non-cache memory users. The point is to have
+/// all large allocation come from a single source to have dynamic balancing
+/// between different users. Proxy subclasses may provide context specific
+/// tracking while delegating the allocation to a root allocator.
+class MemoryAllocator : std::enable_shared_from_this<MemoryAllocator> {
  public:
+  /// Returns the process-wide default instance or an application-supplied
+  /// custom instance set via setDefaultInstance().
+  static MemoryAllocator* FOLLY_NONNULL getInstance();
+
+  /// Overrides the process-wide default instance. The caller keeps ownership
+  /// and must not destroy the instance until it is empty. Calling this with
+  /// nullptr restores the initial process-wide default instance.
+  static void setDefaultInstance(MemoryAllocator* FOLLY_NULLABLE instance);
+
+  /// Creates a default MemoryAllocator instance but does not set this to
+  /// process default.
+  static std::shared_ptr<MemoryAllocator> createDefaultInstance();
+
+  static void testingDestroyInstance();
+
+  MemoryAllocator() = default;
+  virtual ~MemoryAllocator() = default;
+
   static constexpr uint64_t kPageSize = 4096;
   static constexpr int32_t kMaxSizeClasses = 12;
   static constexpr int32_t kNoOwner = -1;
-  // Marks allocation via allocateBytes, e.g. StlMappedMemoryAllocator.
+  /// Marks allocation via allocateBytes, e.g. StlMemoryAllocator.
   static constexpr int32_t kMallocOwner = -14;
-  // Allocations smaller than 3K should  go to malloc.
+  /// Allocations smaller than 3K should go to malloc.
   static constexpr int32_t kMaxMallocBytes = 3072;
+  static constexpr uint16_t kMaxAlignment = 64;
 
-  // Represents a number of consecutive pages of kPageSize bytes.
+  /// Represents a number of consecutive pages of kPageSize bytes.
   class PageRun {
    public:
     static constexpr uint8_t kPointerSignificantBits = 48;
@@ -179,14 +198,14 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
     PageRun(void* FOLLY_NONNULL address, MachinePageCount numPages) {
       auto word = reinterpret_cast<uint64_t>(address); // NOLINT
       if (!FLAGS_velox_use_malloc) {
-        VELOX_CHECK(
-            (word & (kPageSize - 1)) == 0,
+        VELOX_CHECK_EQ(
+            word & (kPageSize - 1),
+            0,
             "Address is not page-aligned for PageRun");
       }
-      VELOX_CHECK(numPages <= kMaxPagesInRun);
-      VELOX_CHECK(
-          (word & ~kPointerMask) == 0,
-          "A pointer must have its 16 high bits 0");
+      VELOX_CHECK_LE(numPages, kMaxPagesInRun);
+      VELOX_CHECK_EQ(
+          word & ~kPointerMask, 0, "A pointer must have its 16 high bits 0");
       data_ =
           word | (static_cast<uint64_t>(numPages) << kPointerSignificantBits);
     }
@@ -208,22 +227,22 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
     uint64_t data_;
   };
 
-  // Represents a set of PageRuns that are allocated together.
+  /// Represents a set of PageRuns that are allocated together.
   class Allocation {
    public:
-    explicit Allocation(MappedMemory* FOLLY_NONNULL mappedMemory)
-        : mappedMemory_(mappedMemory) {
-      VELOX_CHECK(mappedMemory);
+    explicit Allocation(MemoryAllocator* FOLLY_NONNULL allocator)
+        : allocator_(allocator) {
+      VELOX_CHECK_NOT_NULL(allocator_);
     }
 
     ~Allocation() {
-      mappedMemory_->free(*this);
+      allocator_->freeNonContiguous(*this);
     }
 
     Allocation(const Allocation& other) = delete;
 
     Allocation(Allocation&& other) noexcept {
-      mappedMemory_ = other.mappedMemory_;
+      allocator_ = other.allocator_;
       runs_ = std::move(other.runs_);
       numPages_ = other.numPages_;
       other.numPages_ = 0;
@@ -232,7 +251,7 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
     void operator=(const Allocation& other) = delete;
 
     void operator=(Allocation&& other) {
-      mappedMemory_ = other.mappedMemory_;
+      allocator_ = other.allocator_;
       runs_ = std::move(other.runs_);
       numPages_ = other.numPages_;
       other.numPages_ = 0;
@@ -261,42 +280,36 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
       numPages_ = 0;
     }
 
-    // Returns the run number and the position within the run
-    // corresponding to 'offset' from the start of 'this'.
+    /// Returns the run number in 'runs_' and the position within the run
+    /// corresponding to 'offset' from the start of 'this'.
     void findRun(
         uint64_t offset,
         int32_t* FOLLY_NONNULL index,
         int32_t* FOLLY_NONNULL offsetInRun) const;
 
    private:
-    MappedMemory* FOLLY_NONNULL mappedMemory_;
+    MemoryAllocator* FOLLY_NONNULL allocator_;
     std::vector<PageRun> runs_;
     int32_t numPages_ = 0;
   };
 
-  // Represents a mmap'd run of contiguous pages that do not belong to
-  // any size class but are still accounted by the owning
-  // MappedMemory.
+  /// Represents a run of contiguous pages that do not belong to any size class.
   class ContiguousAllocation {
    public:
     ContiguousAllocation() = default;
     ~ContiguousAllocation() {
-      if (data_ && mappedMemory_) {
-        mappedMemory_->freeContiguous(*this);
+      if (data_ && allocator_) {
+        allocator_->freeContiguous(*this);
       }
       data_ = nullptr;
     }
 
     ContiguousAllocation(ContiguousAllocation&& other) noexcept {
-      mappedMemory_ = other.mappedMemory_;
+      allocator_ = other.allocator_;
       data_ = other.data_;
       size_ = other.size_;
       other.data_ = nullptr;
       other.size_ = 0;
-    }
-
-    MappedMemory* FOLLY_NULLABLE mappedMemory() const {
-      return mappedMemory_;
     }
 
     MachinePageCount numPages() const;
@@ -306,33 +319,33 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
       return reinterpret_cast<T*>(data_);
     }
 
-    // size in bytes.
+    /// size in bytes.
     uint64_t size() const {
       return size_;
     }
 
     void reset(
-        MappedMemory* FOLLY_NULLABLE mappedMemory,
+        MemoryAllocator* FOLLY_NULLABLE allocator,
         void* FOLLY_NULLABLE data,
         uint64_t size) {
-      mappedMemory_ = mappedMemory;
+      allocator_ = allocator;
       data_ = data;
       size_ = size;
     }
 
    private:
-    MappedMemory* FOLLY_NULLABLE mappedMemory_{nullptr};
+    MemoryAllocator* FOLLY_NULLABLE allocator_{nullptr};
     void* FOLLY_NULLABLE data_{nullptr};
     uint64_t size_{0};
   };
 
-  // Stats on memory allocated by allocateBytes().
+  /// Stats on memory allocated by allocateBytes().
   struct AllocateBytesStats {
-    // Total size of small allocations.
+    /// Total size of small allocations.
     uint64_t totalSmall;
-    // Total size of allocations from some size class.
+    /// Total size of allocations from some size class.
     uint64_t totalInSizeClasses;
-    // Total in standalone large allocations via allocateContiguous().
+    /// Total in standalone large allocations via allocateContiguous().
     uint64_t totalLarge;
 
     AllocateBytesStats operator-(const AllocateBytesStats& other) const {
@@ -344,23 +357,40 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
     }
   };
 
-  MappedMemory() {}
+  /// Allocates 'bytes' contiguous bytes and returns the pointer to the first
+  /// byte. If 'bytes' is less than 'maxMallocSize', delegates the allocation to
+  /// malloc. If the size is above that and below the largest size classes'
+  /// size, allocates one element of the next size classes' size. If 'size' is
+  /// greater than the largest size classes' size, calls allocateContiguous().
+  /// Returns nullptr if there is no space. The amount to allocate is subject to
+  /// the size limit of 'this'. This function is not virtual but calls the
+  /// virtual functions allocateNonContiguous and allocateContiguous, which can
+  /// track sizes and enforce caps etc.
+  virtual void* FOLLY_NULLABLE allocateBytes(
+      uint64_t bytes,
+      uint16_t alignment = 0,
+      uint64_t maxMallocSize = kMaxMallocBytes);
 
-  virtual ~MappedMemory() {}
+  /// Allocates a zero-filled contiguous bytes with capacity that can store
+  /// 'numMembers' entries with each size of 'sizeEach'.
+  virtual void* FOLLY_NULLABLE
+  allocateZeroFilled(int64_t numMembers, int64_t sizeEach);
 
-  // Returns the process-wide default instance or an application-supplied custom
-  // instance set via setDefaultInstance().
-  static MappedMemory* FOLLY_NONNULL getInstance();
+  /// Allocates 'newSize' contiguous bytes. If 'p' is not null, this function
+  /// copies std::min(size, newSize) bytes from 'p' to the newly allocated
+  /// buffer and free 'p' after that.
+  virtual void* FOLLY_NULLABLE reallocateBytes(
+      void* FOLLY_NULLABLE p,
+      int64_t size,
+      int64_t newSize,
+      uint16_t alignment = 0);
 
-  // Creates a default MappedMemory instance but does not set this to process
-  // default.
-  static std::shared_ptr<MappedMemory> createDefaultInstance();
-
-  // Overrides the process-wide default instance. The caller keeps
-  // ownership and must not destroy the instance until it is
-  // empty. Calling this with nullptr restores the initial
-  // process-wide default instance.
-  static void setDefaultInstance(MappedMemory* FOLLY_NULLABLE instance);
+  /// Frees contiguous memory allocated by allocateBytes, allocateZeroFilled,
+  /// reallocateBytes.
+  virtual void freeBytes(
+      void* FOLLY_NONNULL p,
+      uint64_t size,
+      uint64_t maxMallocSize = kMaxMallocBytes) noexcept;
 
   /// Allocates one or more runs that add up to at least 'numPages', with the
   /// smallest run being at least 'minSizeClass' pages. 'minSizeClass' must be
@@ -370,20 +400,20 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
   /// called for pre-allocation or post-allocation failure. The flag is true for
   /// pre-allocation call and false for post-allocation failure call. The latter
   /// is to let user have a chance to rollback if needed. For instance,
-  /// 'ScopedMappedMemory' object will make memory counting reservation in
+  /// 'ScopedMemoryAllocator' object will make memory counting reservation in
   /// 'userAllocCB' before the actual memory allocation so it needs to release
   /// the reservation if the actual allocation fails. The function returns true
   /// if the allocation succeeded. If returning false, 'out' references no
   /// memory and any partially allocated memory is freed.
-  virtual bool allocate(
+  virtual bool allocateNonContiguous(
       MachinePageCount numPages,
       int32_t owner,
       Allocation& out,
       std::function<void(int64_t, bool)> userAllocCB = nullptr,
       MachinePageCount minSizeClass = 0) = 0;
 
-  // Returns the number of freed bytes.
-  virtual int64_t free(Allocation& allocation) = 0;
+  /// Returns non-contiguous 'allocation'.
+  virtual int64_t freeNonContiguous(Allocation& allocation) = 0;
 
   /// Makes a contiguous mmap of 'numPages'. Advises away the required number of
   /// free pages so as not to have resident size exceed the capacity if capacity
@@ -402,32 +432,14 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
       ContiguousAllocation& allocation,
       std::function<void(int64_t, bool)> userAllocCB = nullptr) = 0;
 
+  /// Returns contiguous 'allocation'.
   virtual void freeContiguous(ContiguousAllocation& allocation) = 0;
 
-  // Allocates 'bytes' contiguous bytes and returns the pointer to the first
-  // byte. If 'bytes' is less than 'maxMallocSize', delegates the allocation to
-  // malloc. If the size is above that and below the largest size classes' size,
-  // allocates one element of the next size classes' size. If 'size' is greater
-  // than the largest size classes' size, calls allocateContiguous(). Returns
-  // nullptr if there is no space. The amount to allocate is subject to the size
-  // limit of 'this'. This function is not virtual but calls the virtual
-  // functions allocate and allocateContiguous, which can track sizes and
-  // enforce caps etc.
-  virtual void* FOLLY_NULLABLE
-  allocateBytes(uint64_t bytes, uint64_t maxMallocSize = kMaxMallocBytes);
-
-  // Frees memory allocated with allocateBytes().
-  virtual void freeBytes(
-      void* FOLLY_NONNULL p,
-      uint64_t size,
-      uint64_t maxMallocSize = kMaxMallocBytes) noexcept;
-
-  // Checks internal consistency of allocation data
-  // structures. Returns true if OK.
+  /// Checks internal consistency of allocation data structures. Returns true if
+  /// OK.
   virtual bool checkConsistency() const = 0;
 
-  static void destroyTestOnly();
-
+  /// Returns the largest class size.
   virtual MachinePageCount largestSizeClass() const {
     return sizeClassSizes_.back();
   }
@@ -440,15 +452,7 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
 
   virtual MachinePageCount numMapped() const = 0;
 
-  virtual std::shared_ptr<MappedMemory> addChild(
-      std::shared_ptr<MemoryUsageTracker> tracker);
-
-  virtual MemoryUsageTracker* FOLLY_NULLABLE tracker() const {
-    return nullptr;
-  }
-
-  // Returns static counters for allocateBytes usage.
-
+  /// Returns static counters for allocateBytes usage.
   static AllocateBytesStats allocateBytesStats() {
     return {
         totalSmallAllocateBytes_,
@@ -456,7 +460,7 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
         totalLargeAllocateBytes_};
   }
 
-  // clears counters to revert effect of previous tests.
+  /// Clears counters to revert effect of previous tests.
   static void testingClearAllocateBytesStats() {
     totalSmallAllocateBytes_ = 0;
     totalSizeClassAllocateBytes_ = 0;
@@ -465,6 +469,16 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
 
   virtual Stats stats() const {
     return Stats();
+  }
+
+  /// TODO: deprecate the following ScopedMemoryAllocator related APIs after
+  /// provides both contiguous and non-contiguous memory allocations through
+  /// memory pool interface.
+  virtual std::shared_ptr<MemoryAllocator> addChild(
+      std::shared_ptr<MemoryUsageTracker> tracker);
+
+  virtual MemoryUsageTracker* FOLLY_NULLABLE tracker() const {
+    return nullptr;
   }
 
   virtual std::string toString() const;
@@ -484,9 +498,9 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
     int32_t totalPages{0};
   };
 
-  // Returns a mix of standard sizes and allocation counts for
-  // covering 'numPages' worth of memory. 'minSizeClass' is the size
-  // of the smallest usable size class.
+  /// Returns a mix of standard sizes and allocation counts for covering
+  /// 'numPages' worth of memory. 'minSizeClass' is the size of the smallest
+  /// usable size class.
   SizeMix allocationSize(
       MachinePageCount numPages,
       MachinePageCount minSizeClass) const;
@@ -497,52 +511,55 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
       sizeClassSizes_{1, 2, 4, 8, 16, 32, 64, 128, 256};
 
  private:
+  inline static std::mutex initMutex_;
   // Singleton instance.
-  static std::shared_ptr<MappedMemory> instance_;
-  // Application-supplied custom implementation of MappedMemory to be returned
-  // by getInstance().
-  static MappedMemory* FOLLY_NULLABLE customInstance_;
-  static std::mutex initMutex_;
+  inline static std::shared_ptr<MemoryAllocator> instance_;
+  // Application-supplied custom implementation of MemoryAllocator to be
+  // returned by getInstance().
+  inline static MemoryAllocator* FOLLY_NULLABLE customInstance_;
 
   // Static counters for STL and memoryPool users of
-  // MappedMemory. Updated by allocateBytes() and freeBytes(). These
+  // MemoryAllocator. Updated by allocateBytes() and freeBytes(). These
   // are intended to be exported via StatsReporter. These are
   // respectively backed by malloc, allocate from a single size class
   // and standalone mmap.
-  static std::atomic<uint64_t> totalSmallAllocateBytes_;
-  static std::atomic<uint64_t> totalSizeClassAllocateBytes_;
-  static std::atomic<uint64_t> totalLargeAllocateBytes_;
+  inline static std::atomic<uint64_t> totalSmallAllocateBytes_;
+  inline static std::atomic<uint64_t> totalSizeClassAllocateBytes_;
+  inline static std::atomic<uint64_t> totalLargeAllocateBytes_;
 };
 
-// Wrapper around MappedMemory for scoped tracking of activity. We
-// expect a single level of wrappers around the process root
-// MappedMemory. Each will have its own MemoryUsageTracker that will
-// be a child of the Driver/Task level tracker. in this way
-// MappedMemory activity can be attributed to individual operators and
-// these operators can be requested to spill or limit their memory utilization.
-class ScopedMappedMemory final : public MappedMemory {
+/// Wrapper around MemoryAllocator for scoped tracking of activity. We
+/// expect a single level of wrappers around the process root
+/// MemoryAllocator. Each will have its own MemoryUsageTracker that will
+/// be a child of the Driver/Task level tracker. in this way
+/// MemoryAllocator activity can be attributed to individual operators and
+/// these operators can be requested to spill or limit their memory utilization.
+///
+/// TODO: deprecate this class after we provide both contiguous and
+/// non-contiguous memory allocations through memory pool interface.
+class ScopedMemoryAllocator final : public MemoryAllocator {
  public:
-  ScopedMappedMemory(
-      MappedMemory* FOLLY_NONNULL parent,
+  ScopedMemoryAllocator(
+      MemoryAllocator* FOLLY_NONNULL parent,
       std::shared_ptr<MemoryUsageTracker> tracker)
       : parent_(parent), tracker_(std::move(tracker)) {}
 
-  ScopedMappedMemory(
-      std::shared_ptr<ScopedMappedMemory> parent,
+  ScopedMemoryAllocator(
+      std::shared_ptr<ScopedMemoryAllocator> parent,
       std::shared_ptr<MemoryUsageTracker> tracker)
       : parentPtr_(std::move(parent)),
         parent_(parentPtr_.get()),
         tracker_(std::move(tracker)) {}
 
-  bool allocate(
+  bool allocateNonContiguous(
       MachinePageCount numPages,
       int32_t owner,
       Allocation& out,
       std::function<void(int64_t, bool)> userAllocCB,
       MachinePageCount minSizeClass) override;
 
-  int64_t free(Allocation& allocation) override {
-    int64_t freed = parent_->free(allocation);
+  int64_t freeNonContiguous(Allocation& allocation) override {
+    int64_t freed = parent_->freeNonContiguous(allocation);
     if (tracker_) {
       tracker_->update(-freed);
     }
@@ -579,9 +596,9 @@ class ScopedMappedMemory final : public MappedMemory {
     return parent_->numMapped();
   }
 
-  std::shared_ptr<MappedMemory> addChild(
+  std::shared_ptr<MemoryAllocator> addChild(
       std::shared_ptr<MemoryUsageTracker> tracker) override {
-    return std::make_shared<ScopedMappedMemory>(this, tracker);
+    return std::make_shared<ScopedMemoryAllocator>(this, tracker);
   }
 
   MemoryUsageTracker* FOLLY_NULLABLE tracker() const override {
@@ -593,26 +610,25 @@ class ScopedMappedMemory final : public MappedMemory {
   }
 
  private:
-  std::shared_ptr<MappedMemory> parentPtr_;
-  MappedMemory* FOLLY_NONNULL parent_;
+  std::shared_ptr<MemoryAllocator> parentPtr_;
+  MemoryAllocator* FOLLY_NONNULL parent_;
   std::shared_ptr<MemoryUsageTracker> tracker_;
 };
 
-// An Allocator backed by MappedMemory for for STL containers.
+/// An Allocator backed by MemoryAllocator for STL containers.
 template <class T>
-struct StlMappedMemoryAllocator {
+struct StlMemoryAllocator {
   using value_type = T;
 
-  explicit StlMappedMemoryAllocator(MappedMemory* FOLLY_NONNULL allocator)
+  explicit StlMemoryAllocator(MemoryAllocator* FOLLY_NONNULL allocator)
       : allocator_{allocator} {
-    VELOX_CHECK(allocator);
+    VELOX_CHECK_NOT_NULL(allocator_);
   }
 
   template <class U>
-  explicit StlMappedMemoryAllocator(
-      const StlMappedMemoryAllocator<U>& allocator)
+  explicit StlMemoryAllocator(const StlMemoryAllocator<U>& allocator)
       : allocator_{allocator.allocator()} {
-    VELOX_CHECK(allocator_);
+    VELOX_CHECK_NOT_NULL(allocator_);
   }
 
   T* FOLLY_NONNULL allocate(std::size_t n) {
@@ -624,23 +640,23 @@ struct StlMappedMemoryAllocator {
     allocator_->freeBytes(p, checkedMultiply(n, sizeof(T)));
   }
 
-  MappedMemory* FOLLY_NONNULL allocator() const {
+  MemoryAllocator* FOLLY_NONNULL allocator() const {
     return allocator_;
   }
 
   friend bool operator==(
-      const StlMappedMemoryAllocator& lhs,
-      const StlMappedMemoryAllocator& rhs) {
+      const StlMemoryAllocator& lhs,
+      const StlMemoryAllocator& rhs) {
     return lhs.allocator_ == rhs.allocator_;
   }
   friend bool operator!=(
-      const StlMappedMemoryAllocator& lhs,
-      const StlMappedMemoryAllocator& rhs) {
+      const StlMemoryAllocator& lhs,
+      const StlMemoryAllocator& rhs) {
     return !(lhs == rhs);
   }
 
  private:
-  MappedMemory* FOLLY_NONNULL allocator_;
+  MemoryAllocator* FOLLY_NONNULL const allocator_;
 };
 
 } // namespace facebook::velox::memory

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -25,55 +25,55 @@
 #include <unordered_set>
 
 #include "velox/common/base/SimdUtil.h"
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/memory/MmapArena.h"
 
 namespace facebook::velox::memory {
 
-// Denotes a number of pages of one size class, i.e. one page consists
-// of a size class dependent number of consecutive machine pages.
+/// Denotes a number of pages of one size class, i.e. one page consists
+/// of a size class dependent number of consecutive machine pages.
 using ClassPageCount = int32_t;
 
 struct MmapAllocatorOptions {
-  //  Capacity in bytes, default 512MB
+  ///  Capacity in bytes, default 512MB
   uint64_t capacity = 1L << 29;
 
-  // If set true, allocations larger than largest size class size will be
-  // delegated to ManagedMmapArena. Otherwise a system mmap call will be
-  // issued for each such allocation.
+  /// If set true, allocations larger than largest size class size will be
+  /// delegated to ManagedMmapArena. Otherwise a system mmap call will be
+  /// issued for each such allocation.
   bool useMmapArena = false;
 
-  // Used to determine MmapArena capacity. The ratio represents system memory
-  // capacity to single MmapArena capacity ratio.
+  /// Used to determine MmapArena capacity. The ratio represents system memory
+  /// capacity to single MmapArena capacity ratio.
   int32_t mmapArenaCapacityRatio = 10;
 };
 
-// Implementation of MappedMemory with mmap and madvise. Each size
-// class is mmapped for the whole capacity. Each size class has a
-// bitmap of allocated entries and entries that are backed by
-// memory. If a size class does not have an entry that is free and
-// backed by memory, we allocate an entry that is free and we advise
-// away pages from other size classes where the corresponding entry
-// is free. In this way, any combination of sizes that adds up to
-// the capacity can be allocated without fragmentation. If a size
-// needs to be allocated that does not correspond to size classes,
-// we advise away enough pages from other size classes to cover for
-// it and then make a new mmap of the requested size
-// (ContiguousAllocation).
-class MmapAllocator : public MappedMemory {
+/// Implementation of MemoryAllocator with mmap and madvise. Each size class is
+/// mmapped for the whole capacity. Each size class has a bitmap of allocated
+/// entries and entries that are backed by memory. If a size class does not have
+/// an entry that is free and backed by memory, we allocate an entry that is
+/// free and we advise away pages from other size classes where the
+/// corresponding entry is free. In this way, any combination of sizes that adds
+/// up to the capacity can be allocated without fragmentation. If a size needs
+/// to be allocated that does not correspond to size classes, we advise away
+/// enough pages from other size classes to cover for it and then make a new
+/// mmap of the requested size (ContiguousAllocation). Small contiguous memory
+/// allocations less than 3/4 of smallest size class are still delegated to
+/// malloc.
+class MmapAllocator : public MemoryAllocator {
  public:
   enum class Failure { kNone, kMadvise, kMmap };
 
   explicit MmapAllocator(const MmapAllocatorOptions& options);
 
-  bool allocate(
+  bool allocateNonContiguous(
       MachinePageCount numPages,
       int32_t owner,
       Allocation& out,
       std::function<void(int64_t, bool)> userAllocCB = nullptr,
       MachinePageCount minSizeClass = 0) override;
 
-  int64_t free(Allocation& allocation) override;
+  int64_t freeNonContiguous(Allocation& allocation) override;
 
   bool allocateContiguous(
       MachinePageCount numPages,
@@ -93,13 +93,12 @@ class MmapAllocator : public MappedMemory {
         allocation.size(), [&]() { freeContiguousImpl(allocation); });
   }
 
-  // Checks internal consistency of allocation data
-  // structures. Returns true if OK. May return false if there are
-  // concurrent alocations and frees during the consistency check. This
-  // is a false positive but not dangerous.
-  //
-  // Checks that the totals of mapped free and mapped and allocated
-  // pages match the data in the bitmaps in the size classes.
+  /// Checks internal consistency of allocation data structures. Returns true if
+  /// OK. May return false if there are concurrent allocations and frees during
+  /// the consistency check. This is a false positive but not dangerous.
+  ///
+  /// Checks that the totals of mapped free and mapped and allocated pages match
+  /// the data in the bitmaps in the size classes.
   bool checkConsistency() const override;
 
   MachinePageCount capacity() const {
@@ -114,9 +113,9 @@ class MmapAllocator : public MappedMemory {
     return numMapped_;
   }
 
-  // Causes 'failure' to occur in next call. This is a test-only
-  // function for validating otherwise unreachable error paths.
-  void injectFailure(Failure failure) {
+  /// Causes 'failure' to occur in next call. This is a test-only function for
+  /// validating otherwise unreachable error paths.
+  void testingInjectFailure(Failure failure) {
     injectedFailure_ = failure;
   }
 
@@ -124,13 +123,13 @@ class MmapAllocator : public MappedMemory {
     return numExternalMapped_;
   }
 
-  std::string toString() const override;
-
   Stats stats() const override {
     auto stats = stats_;
     stats.numAdvise = numAdvisedPages_;
     return stats;
   }
+
+  std::string toString() const override;
 
  private:
   static constexpr uint64_t kAllSet = 0xffffffffffffffff;
@@ -154,7 +153,7 @@ class MmapAllocator : public MappedMemory {
         ClassPageCount numPages,
         int32_t owner,
         MachinePageCount& numUnmapped,
-        MappedMemory::Allocation& out);
+        MemoryAllocator::Allocation& out);
 
     // Frees all pages of 'allocation' that fall in this size
     // class. Erases the corresponding runs from 'allocation'.
@@ -177,7 +176,7 @@ class MmapAllocator : public MappedMemory {
     void setAllMapped(const Allocation& allocation, bool value);
 
     // Sets the mapped flag for the class pages in 'run' to 'value'
-    void setMappedBits(const MappedMemory::PageRun run, bool value);
+    void setMappedBits(const MemoryAllocator::PageRun run, bool value);
 
     // True if 'ptr' is in the address range of 'this'. Checks that ptr is at a
     // size class page boundary.
@@ -204,7 +203,7 @@ class MmapAllocator : public MappedMemory {
         ClassPageCount numPages,
         int32_t owner,
         MachinePageCount* FOLLY_NULLABLE numUnmapped,
-        MappedMemory::Allocation& out);
+        MemoryAllocator::Allocation& out);
 
     // Returns the bit offset of the first bit of a 512 bit group in
     // 'pageAllocated_'/'pageMapped_'  that contains at least one mapped free

--- a/velox/common/memory/MmapArena.h
+++ b/velox/common/memory/MmapArena.h
@@ -21,7 +21,8 @@
 #include <map>
 #include <memory>
 #include <unordered_set>
-#include "velox/common/memory/MappedMemory.h"
+
+#include "velox/common/memory/MemoryAllocator.h"
 
 namespace facebook::velox::memory {
 

--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -18,22 +18,22 @@
 
 namespace facebook::velox {
 
-StreamArena::StreamArena(memory::MappedMemory* mappedMemory)
-    : mappedMemory_(mappedMemory->shared_from_this()),
-      allocation_(mappedMemory) {}
+StreamArena::StreamArena(memory::MemoryAllocator* allocator)
+    : allocator_(allocator), allocation_(allocator_) {}
 
 void StreamArena::newRange(int32_t bytes, ByteRange* range) {
-  VELOX_CHECK(bytes > 0);
+  VELOX_CHECK_GT(bytes, 0);
   memory::MachinePageCount numPages =
-      bits::roundUp(bytes, memory::MappedMemory::kPageSize) /
-      memory::MappedMemory::kPageSize;
+      bits::roundUp(bytes, memory::MemoryAllocator::kPageSize) /
+      memory::MemoryAllocator::kPageSize;
   int32_t numRuns = allocation_.numRuns();
   if (currentRun_ >= numRuns) {
     if (numRuns) {
-      allocations_.push_back(std::make_unique<memory::MappedMemory::Allocation>(
-          std::move(allocation_)));
+      allocations_.push_back(
+          std::make_unique<memory::MemoryAllocator::Allocation>(
+              std::move(allocation_)));
     }
-    if (!mappedMemory_->allocate(
+    if (!allocator_->allocateNonContiguous(
             std::max(allocationQuantum_, numPages),
             kVectorStreamOwner,
             allocation_)) {
@@ -45,9 +45,10 @@ void StreamArena::newRange(int32_t bytes, ByteRange* range) {
   }
   auto run = allocation_.runAt(currentRun_);
   int32_t available = run.numPages() - currentPage_;
-  range->buffer = run.data() + memory::MappedMemory::kPageSize * currentPage_;
-  range->size =
-      std::min<int32_t>(numPages, available) * memory::MappedMemory::kPageSize;
+  range->buffer =
+      run.data() + memory::MemoryAllocator::kPageSize * currentPage_;
+  range->size = std::min<int32_t>(numPages, available) *
+      memory::MemoryAllocator::kPageSize;
   range->position = 0;
   currentPage_ += std::min<int32_t>(available, numPages);
   if (currentPage_ == run.numPages()) {

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #pragma once
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 
 namespace facebook::velox {
 
@@ -29,35 +29,36 @@ class StreamArena {
  public:
   static constexpr int32_t kVectorStreamOwner = 1;
 
-  explicit StreamArena(memory::MappedMemory* mappedMemory);
+  explicit StreamArena(memory::MemoryAllocator* FOLLY_NONNULL allocator);
 
   virtual ~StreamArena() = default;
 
   // Sets range to refer  to at least one page of writable memory owned by
   // 'this'. Up to 'numPages' may be  allocated.
-  virtual void newRange(int32_t bytes, ByteRange* range);
+  virtual void newRange(int32_t bytes, ByteRange* FOLLY_NONNULL range);
 
   // sets 'range' to point to a small piece of memory owned by this. These alwys
   // come from the heap. The use case is for headers that may change length
   // based on data properties, not for bulk data.
-  virtual void newTinyRange(int32_t bytes, ByteRange* range);
+  virtual void newTinyRange(int32_t bytes, ByteRange* FOLLY_NONNULL range);
 
   // Returns the Total size in bytes held by all Allocations.
   virtual size_t size() const {
     return size_;
   }
 
-  memory::MappedMemory* mappedMemory() {
-    return mappedMemory_.get();
+  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
+    return allocator_;
   }
 
  private:
-  std::shared_ptr<memory::MappedMemory> mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
   // All allocations.
-  std::vector<std::unique_ptr<memory::MappedMemory::Allocation>> allocations_;
+  std::vector<std::unique_ptr<memory::MemoryAllocator::Allocation>>
+      allocations_;
   // The allocation from which pages are given out. Moved to 'allocations_' when
   // used up.
-  memory::MappedMemory::Allocation allocation_;
+  memory::MemoryAllocator::Allocation allocation_;
   int32_t currentRun_ = 0;
   int32_t currentPage_ = 0;
   memory::MachinePageCount allocationQuantum_ = 2;

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/memory/ByteStream.h"
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/memory/MmapAllocator.h"
 
 #include <gflags/gflags.h>
@@ -30,12 +30,12 @@ class ByteStreamTest : public testing::TestWithParam<bool> {
     MmapAllocatorOptions options;
     options.capacity = kMaxMappedMemory;
     mmapAllocator_ = std::make_shared<MmapAllocator>(options);
-    MappedMemory::setDefaultInstance(mmapAllocator_.get());
+    MemoryAllocator::setDefaultInstance(mmapAllocator_.get());
   }
 
   void TearDown() override {
-    MappedMemory::destroyTestOnly();
-    MappedMemory::setDefaultInstance(nullptr);
+    MmapAllocator::testingDestroyInstance();
+    MemoryAllocator::setDefaultInstance(nullptr);
   }
 
   std::shared_ptr<MmapAllocator> mmapAllocator_;

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -17,12 +17,12 @@ add_executable(
   ByteStreamTest.cpp
   CompactDoubleListTest.cpp
   HashStringAllocatorTest.cpp
+  MemoryAllocatorTest.cpp
   MemoryHeaderTest.cpp
   MemoryManagerTest.cpp
   MemoryPoolTest.cpp
   MemoryUsageTest.cpp
-  MemoryUsageTrackerTest.cpp
-  MappedMemoryTest.cpp)
+  MemoryUsageTrackerTest.cpp)
 
 target_link_libraries(
   velox_memory_test

--- a/velox/common/memory/tests/FragmentationBenchmark.cpp
+++ b/velox/common/memory/tests/FragmentationBenchmark.cpp
@@ -42,7 +42,7 @@ struct Block {
 
   size_t size = 0;
   char* data = nullptr;
-  std::shared_ptr<MappedMemory::Allocation> allocation;
+  std::shared_ptr<MemoryAllocator::Allocation> allocation;
   MmapAllocator::ContiguousAllocation contiguous;
 };
 
@@ -89,8 +89,9 @@ class FragmentationTest {
     if (memory_) {
       if (size <= 8 << 20) {
         block->allocation =
-            std::make_shared<MappedMemory::Allocation>(memory_.get());
-        if (!memory_->allocate(size / 4096, 0, *block->allocation)) {
+            std::make_shared<MemoryAllocator::Allocation>(memory_.get());
+        if (!memory_->allocateNonContiguous(
+                size / 4096, 0, *block->allocation)) {
           VELOX_FAIL("allocate() faild");
         }
         for (int i = 0; i < block->allocation->numRuns(); ++i) {

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -34,7 +34,7 @@ class HashStringAllocatorTest : public testing::Test {
  protected:
   void SetUp() override {
     instance_ = std::make_unique<HashStringAllocator>(
-        memory::MappedMemory::getInstance());
+        memory::MemoryAllocator::getInstance());
     rng_.seed(1);
   }
 

--- a/velox/common/memory/tests/MemoryPoolBenchmark.cpp
+++ b/velox/common/memory/tests/MemoryPoolBenchmark.cpp
@@ -30,7 +30,7 @@ namespace facebook::velox::memory {
 
 class BenchmarkHelper {
  public:
-  BenchmarkHelper(MemoryManager<MemoryAllocator, kNoAlignment>& manager)
+  BenchmarkHelper(MemoryManager<kNoAlignment>& manager)
       : manager_{manager}, leaves_{findLeaves()} {}
 
   std::vector<MemoryPool*> findLeaves() {
@@ -62,14 +62,14 @@ class BenchmarkHelper {
 
  private:
   // TODO: move semantic is better
-  MemoryManager<MemoryAllocator, kNoAlignment>& manager_;
+  MemoryManager<kNoAlignment>& manager_;
   std::vector<MemoryPool*> leaves_;
 };
 } // namespace facebook::velox::memory
 
 BENCHMARK(SingleNodeAlloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
@@ -83,7 +83,7 @@ BENCHMARK(SingleNodeAlloc, iters) {
 // Should be the same.
 BENCHMARK(SingleNodeAllocWithCap, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   auto pool = manager.getRoot().addChild(
       "pride_of_higara", iters * kMemoryFootprintIncrement);
 
@@ -98,7 +98,7 @@ BENCHMARK(SingleNodeAllocWithCap, iters) {
 
 BENCHMARK(SingleNodeFree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
@@ -112,7 +112,7 @@ BENCHMARK(SingleNodeFree, iters) {
 
 BENCHMARK(SingleNodeRealloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   void* p = pool->allocate(kMemoryFootprintIncrement);
@@ -129,7 +129,7 @@ BENCHMARK(SingleNodeRealloc, iters) {
 
 BENCHMARK(SingleNodeAlignedAlloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kDefaultAlignment> manager{};
+  MemoryManager<kDefaultAlignment> manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
@@ -143,7 +143,7 @@ BENCHMARK(SingleNodeAlignedAlloc, iters) {
 
 BENCHMARK(SingleNodeAlignedAllocWithCap, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kDefaultAlignment> manager{};
+  MemoryManager<kDefaultAlignment> manager{};
   auto unalignedTotal = iters * kMemoryFootprintIncrement;
   auto alignedCap = unalignedTotal % kDefaultAlignment == 0
       ? unalignedTotal
@@ -161,7 +161,7 @@ BENCHMARK(SingleNodeAlignedAllocWithCap, iters) {
 
 BENCHMARK(SingleNodeAlignedRealloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kDefaultAlignment> manager{};
+  MemoryManager<kDefaultAlignment> manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   void* p = pool->allocate(kMemoryFootprintIncrement);
@@ -191,7 +191,7 @@ void addNLeaves(
 // with single leaf runs.
 BENCHMARK(FlatTree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   addNLeaves(manager.getRoot(), 10 * 20);
   BenchmarkHelper helper{manager};
   suspender.dismiss();
@@ -211,7 +211,7 @@ BENCHMARK(FlatTree, iters) {
 // with single leaf runs.
 BENCHMARK(DeeperTree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   for (size_t i = 0; i < 10; ++i) {
     auto child = manager.getRoot().addChild(
         "query_fragment_" + folly::to<std::string>(i));
@@ -233,7 +233,7 @@ BENCHMARK(DeeperTree, iters) {
 
 BENCHMARK(FlatSubtree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   auto child = manager.getRoot().addChild("query_fragment_1");
   addNLeaves(*child, 10 * 20);
   BenchmarkHelper helper{manager};
@@ -252,7 +252,7 @@ BENCHMARK(FlatSubtree, iters) {
 
 BENCHMARK(FlatSticks, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   for (size_t i = 0; i < 10 * 20; ++i) {
     auto child = manager.getRoot().addChild(
         "query_fragment_" + folly::to<std::string>(i));

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -179,14 +179,14 @@ class ConnectorQueryCtx {
       memory::MemoryPool* FOLLY_NONNULL pool,
       const Config* FOLLY_NONNULL connectorConfig,
       ExpressionEvaluator* FOLLY_NULLABLE expressionEvaluator,
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory,
+      memory::MemoryAllocator* FOLLY_NONNULL allocator,
       const std::string& taskId,
       const std::string& planNodeId,
       int driverId)
       : pool_(pool),
         config_(connectorConfig),
         expressionEvaluator_(expressionEvaluator),
-        mappedMemory_(mappedMemory),
+        allocator_(allocator),
         scanId_(fmt::format("{}.{}", taskId, planNodeId)),
         taskId_(taskId),
         driverId_(driverId) {}
@@ -203,10 +203,10 @@ class ConnectorQueryCtx {
     return expressionEvaluator_;
   }
 
-  // MappedMemory for large allocations. Used for caching with
-  // CachedBufferedImput if this implements cache::AsyncDataCache.
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory() const {
-    return mappedMemory_;
+  /// MemoryAllocator used for large allocations. Used for caching with
+  /// CachedBufferedInput if this implements cache::AsyncDataCache.
+  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
+    return allocator_;
   }
 
   // This is a combination of task id and the scan's PlanNodeId. This is an id
@@ -226,10 +226,10 @@ class ConnectorQueryCtx {
   }
 
  private:
-  memory::MemoryPool* FOLLY_NONNULL pool_;
-  const Config* FOLLY_NONNULL config_;
-  ExpressionEvaluator* FOLLY_NULLABLE expressionEvaluator_;
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory_;
+  memory::MemoryPool* FOLLY_NONNULL const pool_;
+  const Config* FOLLY_NONNULL const config_;
+  ExpressionEvaluator* FOLLY_NULLABLE const expressionEvaluator_;
+  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
   const std::string scanId_;
   const std::string taskId_;
   const int driverId_;

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -172,7 +172,7 @@ HiveDataSource::HiveDataSource(
     FileHandleFactory* fileHandleFactory,
     velox::memory::MemoryPool* pool,
     ExpressionEvaluator* expressionEvaluator,
-    memory::MappedMemory* mappedMemory,
+    memory::MemoryAllocator* allocator,
     const std::string& scanId,
     folly::Executor* executor)
     : outputType_(outputType),
@@ -180,7 +180,7 @@ HiveDataSource::HiveDataSource(
       pool_(pool),
       readerOpts_(pool),
       expressionEvaluator_(expressionEvaluator),
-      mappedMemory_(mappedMemory),
+      allocator_(allocator),
       scanId_(scanId),
       executor_(executor) {
   // Column handled keyed on the column alias, the name used in the query.
@@ -362,7 +362,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
   fileHandle_ = fileHandleFactory_->generate(split_->filePath);
   // For DataCache and no cache, the stream keeps track of IO.
-  auto asyncCache = dynamic_cast<cache::AsyncDataCache*>(mappedMemory_);
+  auto asyncCache = dynamic_cast<cache::AsyncDataCache*>(allocator_);
   // Decide between AsyncDataCache, legacy DataCache and no cache. All
   // three are supported to enable comparison.
   if (asyncCache) {

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -114,7 +114,7 @@ class HiveDataSource : public DataSource {
       FileHandleFactory* FOLLY_NONNULL fileHandleFactory,
       velox::memory::MemoryPool* FOLLY_NONNULL pool,
       ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator,
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory,
+      memory::MemoryAllocator* FOLLY_NONNULL allocator,
       const std::string& scanId,
       folly::Executor* FOLLY_NULLABLE executor);
 
@@ -193,7 +193,7 @@ class HiveDataSource : public DataSource {
   SelectivityVector filterRows_;
   exec::FilterEvalCtx filterEvalCtx_;
 
-  memory::MappedMemory* const FOLLY_NONNULL mappedMemory_;
+  memory::MemoryAllocator* const FOLLY_NONNULL allocator_;
   const std::string& scanId_;
   folly::Executor* FOLLY_NULLABLE executor_;
 };
@@ -236,7 +236,7 @@ class HiveConnector final : public Connector {
         &fileHandleFactory_,
         connectorQueryCtx->memoryPool(),
         connectorQueryCtx->expressionEvaluator(),
-        connectorQueryCtx->mappedMemory(),
+        connectorQueryCtx->allocator(),
         connectorQueryCtx->scanId(),
         executor_);
   }

--- a/velox/connectors/hive/tests/HiveWriteProtocolTest.cpp
+++ b/velox/connectors/hive/tests/HiveWriteProtocolTest.cpp
@@ -34,7 +34,7 @@ TEST(HiveWriteProtocolTest, writerParameters) {
       queryCtx->pool(),
       queryCtx->getConnectorConfig(HiveConnectorFactory::kHiveConnectorName),
       nullptr,
-      queryCtx->mappedMemory(),
+      queryCtx->allocator(),
       "test_task_id",
       "test_plan_node_id",
       0);

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -17,8 +17,8 @@
 
 #include <folly/Executor.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
-#include "velox/common/memory/MappedMemory.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/core/Context.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/vector/DecodedVector.h"
@@ -40,14 +40,14 @@ class QueryCtx : public Context {
       std::shared_ptr<Config> config = std::make_shared<MemConfig>(),
       std::unordered_map<std::string, std::shared_ptr<Config>>
           connectorConfigs = {},
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory =
-          memory::MappedMemory::getInstance(),
+      memory::MemoryAllocator* FOLLY_NONNULL allocator =
+          memory::MemoryAllocator::getInstance(),
       std::shared_ptr<memory::MemoryPool> pool = nullptr,
       std::shared_ptr<folly::Executor> spillExecutor = nullptr,
       const std::string& queryId = "")
       : Context{ContextScope::QUERY},
         pool_(std::move(pool)),
-        mappedMemory_(mappedMemory),
+        allocator_(allocator),
         connectorConfigs_(connectorConfigs),
         executor_(executor),
         config_{this},
@@ -68,13 +68,13 @@ class QueryCtx : public Context {
       std::shared_ptr<Config> config = std::make_shared<MemConfig>(),
       std::unordered_map<std::string, std::shared_ptr<Config>>
           connectorConfigs = {},
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory =
-          memory::MappedMemory::getInstance(),
+      memory::MemoryAllocator* FOLLY_NONNULL allocator =
+          memory::MemoryAllocator::getInstance(),
       std::shared_ptr<memory::MemoryPool> pool = nullptr,
       const std::string& queryId = "")
       : Context{ContextScope::QUERY},
         pool_(std::move(pool)),
-        mappedMemory_(mappedMemory),
+        allocator_(allocator),
         connectorConfigs_(connectorConfigs),
         executorKeepalive_(std::move(executorKeepalive)),
         config_{this},
@@ -93,8 +93,8 @@ class QueryCtx : public Context {
     return pool_.get();
   }
 
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory() const {
-    return mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
+    return allocator_;
   }
 
   folly::Executor* FOLLY_NONNULL executor() const {
@@ -151,7 +151,7 @@ class QueryCtx : public Context {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
   std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs_;
   folly::Executor* FOLLY_NULLABLE executor_;
   folly::Executor::KeepAlive<> executorKeepalive_;

--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -25,7 +25,7 @@ namespace facebook::velox::dwio::common {
 
 using velox::cache::ScanTracker;
 using velox::cache::TrackingId;
-using velox::memory::MappedMemory;
+using velox::memory::MemoryAllocator;
 
 CacheInputStream::CacheInputStream(
     CachedBufferedInput* bufferedInput,
@@ -133,7 +133,7 @@ std::vector<folly::Range<char*>> makeRanges(
     uint64_t offsetInRuns = 0;
     for (int i = 0; i < allocation.numRuns(); ++i) {
       auto run = allocation.runAt(i);
-      uint64_t bytes = run.numPages() * MappedMemory::kPageSize;
+      uint64_t bytes = run.numPages() * MemoryAllocator::kPageSize;
       uint64_t readSize = std::min(bytes, length - offsetInRuns);
       buffers.push_back(folly::Range<char*>(run.data<char>(), readSize));
       offsetInRuns += readSize;
@@ -300,7 +300,7 @@ void CacheInputStream::loadPosition() {
       offsetOfRun_ = offsetInEntry - offsetInRun_;
       auto run = entry->data().runAt(runIndex_);
       run_ = run.data();
-      runSize_ = run.numPages() * MappedMemory::kPageSize;
+      runSize_ = run.numPages() * MemoryAllocator::kPageSize;
       if (offsetOfRun_ + runSize_ > entry->size()) {
         runSize_ = entry->size() - offsetOfRun_;
       }

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -32,7 +32,7 @@ using cache::ScanTracker;
 using cache::SsdFile;
 using cache::SsdPin;
 using cache::TrackingId;
-using memory::MappedMemory;
+using memory::MemoryAllocator;
 
 std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
     Region region,
@@ -79,11 +79,11 @@ bool CachedBufferedInput::shouldPreload() {
   for (auto& request : requests_) {
     numPages += bits::roundUp(
                     std::min<int32_t>(request.size, loadQuantum_),
-                    MappedMemory::kPageSize) /
-        MappedMemory::kPageSize;
+                    MemoryAllocator::kPageSize) /
+        MemoryAllocator::kPageSize;
   }
   auto cachePages = cache_->incrementCachedPages(0);
-  auto maxPages = cache_->maxBytes() / MappedMemory::kPageSize;
+  auto maxPages = cache_->maxBytes() / MemoryAllocator::kPageSize;
   auto allocatedPages = cache_->numAllocated();
   if (numPages < maxPages - allocatedPages) {
     // There is free space for the read-ahead.

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -30,7 +30,7 @@ using namespace facebook::velox::dwio;
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::cache;
 
-using memory::MappedMemory;
+using memory::MemoryAllocator;
 using IoStatisticsPtr = std::shared_ptr<IoStatistics>;
 
 // Testing stream producing deterministic data. The byte at offset is
@@ -482,7 +482,8 @@ TEST_F(CacheTest, window) {
   auto stream = input->read(begin, end - begin, LogType::TEST);
   auto cacheInput = dynamic_cast<CacheInputStream*>(stream.get());
   EXPECT_TRUE(cacheInput != nullptr);
-  auto maxSize = cache_->sizeClasses().back() * memory::MappedMemory::kPageSize;
+  auto maxSize =
+      cache_->sizeClasses().back() * memory::MemoryAllocator::kPageSize;
   const void* buffer;
   int32_t size;
   int32_t numRead = 0;

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -60,11 +60,11 @@ class MockMemoryPool : public velox::memory::MemoryPool {
 
   void* allocate(int64_t size) override {
     updateLocalMemoryUsage(size);
-    return allocator_.alloc(size);
+    return allocator_->allocateBytes(size);
   }
   void* allocateZeroFilled(int64_t numMembers, int64_t sizeEach) override {
     updateLocalMemoryUsage(numMembers * sizeEach);
-    return allocator_.allocZeroFilled(numMembers, sizeEach);
+    return allocator_->allocateZeroFilled(numMembers, sizeEach);
   }
 
   // No-op for attempts to shrink buffer.
@@ -76,10 +76,10 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     if (UNLIKELY(difference <= 0)) {
       return p;
     }
-    return allocator_.realloc(p, size, newSize);
+    return allocator_->reallocateBytes(p, size, newSize);
   }
   void free(void* p, int64_t size) override {
-    allocator_.free(p, size);
+    allocator_->freeBytes(p, size);
     updateLocalMemoryUsage(-size);
   }
 
@@ -126,7 +126,8 @@ class MockMemoryPool : public velox::memory::MemoryPool {
   MOCK_CONST_METHOD0(getAlignment, uint16_t());
 
  private:
-  velox::memory::MemoryAllocator allocator_{};
+  velox::memory::MemoryAllocator* const FOLLY_NONNULL allocator_{
+      velox::memory::MemoryAllocator::getInstance()};
   int64_t localMemoryUsage_{0};
   int64_t subtreeMemoryUsage_{0};
   int64_t cap_;

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -15,10 +15,10 @@
  */
 #pragma once
 
-#include <velox/common/memory/MappedMemory.h>
-#include <velox/common/memory/Memory.h>
 #include <memory>
+
 #include "velox/common/memory/ByteStream.h"
+#include "velox/common/memory/Memory.h"
 #include "velox/exec/Operator.h"
 
 namespace facebook::velox::exec {

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -61,13 +61,13 @@ GroupingSet::GroupingSet(
       constantLists_(std::move(constantLists)),
       intermediateTypes_(std::move(intermediateTypes)),
       ignoreNullKeys_(ignoreNullKeys),
-      mappedMemory_(operatorCtx->mappedMemory()),
+      allocator_(operatorCtx->allocator()),
       spillMemoryThreshold_(operatorCtx->driverCtx()
                                 ->queryConfig()
                                 .aggregationSpillMemoryThreshold()),
       spillConfig_(spillConfig),
-      stringAllocator_(mappedMemory_),
-      rows_(mappedMemory_),
+      stringAllocator_(allocator_),
+      rows_(allocator_),
       isAdaptive_(
           operatorCtx->task()->queryCtx()->config().hashAdaptivityEnabled()),
       pool_(*operatorCtx->pool()) {
@@ -249,10 +249,10 @@ void GroupingSet::addRemainingInput() {
 void GroupingSet::createHashTable() {
   if (ignoreNullKeys_) {
     table_ = HashTable<true>::createForAggregation(
-        std::move(hashers_), aggregates_, mappedMemory_);
+        std::move(hashers_), aggregates_, allocator_);
   } else {
     table_ = HashTable<false>::createForAggregation(
-        std::move(hashers_), aggregates_, mappedMemory_);
+        std::move(hashers_), aggregates_, allocator_);
   }
   lookup_ = std::make_unique<HashLookup>(table_->hashers());
   if (!isAdaptive_ && table_->hashMode() != BaseHashTable::HashMode::kHash) {
@@ -504,7 +504,7 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
     return;
   }
 
-  auto tracker = mappedMemory_->tracker();
+  auto tracker = allocator_->tracker();
   const auto currentUsage = tracker->getCurrentUserBytes();
   if (spillMemoryThreshold_ != 0 && currentUsage > spillMemoryThreshold_) {
     const int64_t bytesToSpill =
@@ -561,7 +561,7 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
     for (auto i = 0; i < types.size(); ++i) {
       names.push_back(fmt::format("s{}", i));
     }
-    VELOX_DCHECK(mappedMemory_->tracker() != nullptr);
+    VELOX_DCHECK(allocator_->tracker() != nullptr);
     spiller_ = std::make_unique<Spiller>(
         Spiller::Type::kAggregate,
         rows,
@@ -599,7 +599,7 @@ bool GroupingSet::getOutputWithSpill(
         false,
         false,
         false,
-        mappedMemory_,
+        allocator_,
         ContainerRowSerde::instance());
     // Take ownership of the rows and free the hash table. The table will not be
     // needed for producing spill output.

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -179,7 +179,7 @@ class GroupingSet {
 
   const bool ignoreNullKeys_;
 
-  memory::MappedMemory* FOLLY_NONNULL const mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
 
   // The maximum memory usage that a final aggregation can hold before spilling.
   // If it is zero, then there is no such limit.

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -50,7 +50,7 @@ HashBuild::HashBuild(
     : Operator(driverCtx, nullptr, operatorId, joinNode->id(), "HashBuild"),
       joinNode_(std::move(joinNode)),
       joinType_{joinNode_->joinType()},
-      mappedMemory_(operatorCtx_->mappedMemory()),
+      allocator_(operatorCtx_->allocator()),
       joinBridge_(operatorCtx_->task()->getHashJoinBridgeLocked(
           operatorCtx_->driverCtx()->splitGroupId,
           planNodeId())),
@@ -132,7 +132,7 @@ void HashBuild::setupTable() {
         dependentTypes,
         true, // allowDuplicates
         true, // hasProbedFlag
-        mappedMemory_);
+        allocator_);
   } else {
     // (Left) semi and anti join with no extra filter only needs to know whether
     // there is a match. Hence, no need to store entries with duplicate keys.
@@ -149,7 +149,7 @@ void HashBuild::setupTable() {
           dependentTypes,
           !dropDuplicates, // allowDuplicates
           needProbedFlag, // hasProbedFlag
-          mappedMemory_);
+          allocator_);
     } else {
       // Ignore null keys
       table_ = HashTable<true>::createForJoin(
@@ -157,7 +157,7 @@ void HashBuild::setupTable() {
           dependentTypes,
           !dropDuplicates, // allowDuplicates
           needProbedFlag, // hasProbedFlag
-          mappedMemory_);
+          allocator_);
     }
   }
   analyzeKeys_ = table_->hashMode() != BaseHashTable::HashMode::kHash;
@@ -427,7 +427,7 @@ bool HashBuild::reserveMemory(const RowVectorPtr& input) {
   const auto increment =
       rows->sizeIncrement(input->size(), outOfLineBytes ? flatBytes : 0);
 
-  auto tracker = CHECK_NOTNULL(mappedMemory_->tracker());
+  auto tracker = CHECK_NOTNULL(allocator_->tracker());
   // There must be at least 2x the increments in reservation.
   if (tracker->getAvailableReservation() > 2 * increment) {
     return true;
@@ -763,7 +763,7 @@ void HashBuild::postHashBuildProcess() {
 
   // Release the unused memory reservation since we have finished the table
   // build.
-  operatorCtx_->mappedMemory()->tracker()->release();
+  operatorCtx_->allocator()->tracker()->release();
 
   if (!spillEnabled()) {
     setState(State::kFinish);

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -240,7 +240,7 @@ class HashBuild final : public Operator {
   const core::JoinType joinType_;
 
   // Holds the areas in RowContainer of 'table_'
-  memory::MappedMemory* const FOLLY_NONNULL mappedMemory_;
+  memory::MemoryAllocator* const FOLLY_NONNULL allocator_;
 
   const std::shared_ptr<HashJoinBridge> joinBridge_;
 

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -38,7 +38,7 @@ HashTable<ignoreNullKeys>::HashTable(
     bool allowDuplicates,
     bool isJoinBuild,
     bool hasProbedFlag,
-    memory::MappedMemory* mappedMemory)
+    memory::MemoryAllocator* allocator)
     : BaseHashTable(std::move(hashers)), isJoinBuild_(isJoinBuild) {
   std::vector<TypePtr> keys;
   for (auto& hasher : hashers_) {
@@ -56,7 +56,7 @@ HashTable<ignoreNullKeys>::HashTable(
       isJoinBuild,
       hasProbedFlag,
       hashMode_ != HashMode::kHash,
-      mappedMemory,
+      allocator,
       ContainerRowSerde::instance());
   nextOffset_ = rows_->nextOffset();
 }
@@ -584,11 +584,11 @@ void HashTable<ignoreNullKeys>::allocateTables(uint64_t size) {
     size_ = size;
     sizeMask_ = size_ - 1;
     sizeBits_ = __builtin_popcountll(sizeMask_);
-    constexpr auto kPageSize = memory::MappedMemory::kPageSize;
+    constexpr auto kPageSize = memory::MemoryAllocator::kPageSize;
     // The total size is 9 bytes per slot, 8 in the pointers table and 1 in the
     // tags table.
     auto numPages = bits::roundUp(size * 9, kPageSize) / kPageSize;
-    if (!rows_->mappedMemory()->allocateContiguous(
+    if (!rows_->allocator()->allocateContiguous(
             numPages, nullptr, tableAllocation_)) {
       VELOX_FAIL("Could not allocate join/group by hash table");
     }
@@ -1068,9 +1068,9 @@ void HashTable<ignoreNullKeys>::setHashMode(HashMode mode, int32_t numNew) {
   VELOX_CHECK_NE(hashMode_, HashMode::kHash);
   if (mode == HashMode::kArray) {
     auto bytes = size_ * sizeof(char*);
-    constexpr auto kPageSize = memory::MappedMemory::kPageSize;
+    constexpr auto kPageSize = memory::MemoryAllocator::kPageSize;
     auto numPages = bits::roundUp(bytes, kPageSize) / kPageSize;
-    if (!rows_->mappedMemory()->allocateContiguous(
+    if (!rows_->allocator()->allocateContiguous(
             numPages, nullptr, tableAllocation_)) {
       VELOX_FAIL(
           "Could not allocate array with {} bytes/{} pages for array mode hash table",

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/RowContainer.h"
@@ -283,12 +283,12 @@ class HashTable : public BaseHashTable {
       bool allowDuplicates,
       bool isJoinBuild,
       bool hasProbedFlag,
-      memory::MappedMemory* FOLLY_NULLABLE memory);
+      memory::MemoryAllocator* FOLLY_NULLABLE memory);
 
   static std::unique_ptr<HashTable> createForAggregation(
       std::vector<std::unique_ptr<VectorHasher>>&& hashers,
       const std::vector<std::unique_ptr<Aggregate>>& aggregates,
-      memory::MappedMemory* FOLLY_NULLABLE memory) {
+      memory::MemoryAllocator* FOLLY_NULLABLE memory) {
     return std::make_unique<HashTable>(
         std::move(hashers),
         aggregates,
@@ -304,7 +304,7 @@ class HashTable : public BaseHashTable {
       const std::vector<TypePtr>& dependentTypes,
       bool allowDuplicates,
       bool hasProbedFlag,
-      memory::MappedMemory* FOLLY_NULLABLE memory) {
+      memory::MemoryAllocator* FOLLY_NULLABLE memory) {
     static const std::vector<std::unique_ptr<Aggregate>> kNoAggregates;
     return std::make_unique<HashTable>(
         std::move(hashers),
@@ -604,7 +604,7 @@ class HashTable : public BaseHashTable {
   int32_t nextOffset_;
   uint8_t* FOLLY_NULLABLE tags_ = nullptr;
   char* FOLLY_NULLABLE* FOLLY_NULLABLE table_ = nullptr;
-  memory::MappedMemory::ContiguousAllocation tableAllocation_;
+  memory::MemoryAllocator::ContiguousAllocation tableAllocation_;
   int64_t size_ = 0;
   int64_t sizeMask_ = 0;
   int64_t numDistinct_ = 0;

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -50,10 +50,6 @@ class Merge : public SourceOperator {
     return outputType_;
   }
 
-  memory::MappedMemory* mappedMemory() const {
-    return operatorCtx_->mappedMemory();
-  }
-
  protected:
   virtual BlockingReason addMergeSources(ContinueFuture* future) = 0;
 

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -84,7 +84,7 @@ OperatorCtx::createConnectorQueryCtx(
       pool_,
       driverCtx_->task->queryCtx()->getConnectorConfig(connectorId),
       expressionEvaluator_.get(),
-      driverCtx_->task->queryCtx()->mappedMemory(),
+      driverCtx_->task->queryCtx()->allocator(),
       taskId(),
       planNodeId,
       driverCtx_->driverId);
@@ -232,12 +232,12 @@ std::optional<uint32_t> Operator::maxDrivers(
   return std::nullopt;
 }
 
-memory::MappedMemory* OperatorCtx::mappedMemory() const {
-  if (!mappedMemory_) {
-    mappedMemory_ =
+memory::MemoryAllocator* OperatorCtx::allocator() const {
+  if (allocator_ == nullptr) {
+    allocator_ =
         driverCtx_->task->addOperatorMemory(pool_->getMemoryUsageTracker());
   }
-  return mappedMemory_;
+  return allocator_;
 }
 
 const std::string& OperatorCtx::taskId() const {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -197,7 +197,7 @@ class OperatorCtx {
     return operatorType_;
   }
 
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory() const;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator() const;
 
   core::ExecCtx* FOLLY_NONNULL execCtx() const;
 
@@ -220,7 +220,7 @@ class OperatorCtx {
   velox::memory::MemoryPool* const FOLLY_NONNULL pool_;
 
   // These members are created on demand.
-  mutable memory::MappedMemory* FOLLY_NULLABLE mappedMemory_{nullptr};
+  mutable memory::MemoryAllocator* FOLLY_NULLABLE allocator_{nullptr};
   mutable std::unique_ptr<core::ExecCtx> execCtx_;
   mutable std::unique_ptr<connector::ExpressionEvaluator> expressionEvaluator_;
 };

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -78,7 +78,7 @@ class OrderBy : public Operator {
   // in a paused state and off thread.
   void spill(int64_t targetRows, int64_t targetBytes);
 
-  memory::MappedMemory* FOLLY_NONNULL const mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
 
   const int32_t numSortKeys_;
 

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -63,7 +63,7 @@ void Destination::serialize(
     vector_size_t begin,
     vector_size_t end) {
   if (!current_) {
-    current_ = std::make_unique<VectorStreamGroup>(memory_);
+    current_ = std::make_unique<VectorStreamGroup>(allocator_);
     auto rowType = std::dynamic_pointer_cast<const RowType>(output->type());
     vector_size_t numRows = 0;
     for (vector_size_t i = begin; i < end; i++) {
@@ -84,7 +84,7 @@ BlockingReason Destination::flush(
   constexpr int32_t kMinMessageSize = 128;
   auto listener = bufferManager.newListener();
   IOBufOutputStream stream(
-      *current_->mappedMemory(),
+      *current_->allocator(),
       listener.get(),
       std::max<int64_t>(kMinMessageSize, current_->size()));
   current_->flush(&stream);
@@ -125,7 +125,7 @@ void PartitionedOutput::initializeDestinations() {
     auto taskId = operatorCtx_->taskId();
     for (int i = 0; i < numDestinations_; ++i) {
       destinations_.push_back(
-          std::make_unique<Destination>(taskId, i, mappedMemory_));
+          std::make_unique<Destination>(taskId, i, allocator_));
     }
   }
 }

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -27,8 +27,8 @@ class Destination {
   Destination(
       const std::string& taskId,
       int destination,
-      memory::MappedMemory* FOLLY_NONNULL memory)
-      : taskId_(taskId), destination_(destination), memory_(memory) {
+      memory::MemoryAllocator* FOLLY_NONNULL allocator)
+      : taskId_(taskId), destination_(destination), allocator_(allocator) {
     setTargetSizePct();
   }
 
@@ -89,7 +89,7 @@ class Destination {
 
   const std::string taskId_;
   const int destination_;
-  memory::MappedMemory* FOLLY_NONNULL const memory_;
+  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
   uint64_t bytesInCurrent_{0};
   std::vector<IndexRange> rows_;
 
@@ -150,7 +150,7 @@ class PartitionedOutput : public Operator {
         bufferManager_(PartitionedOutputBufferManager::getInstance()),
         maxBufferedBytes_(
             ctx->task->queryCtx()->config().maxPartitionedOutputBufferSize()),
-        mappedMemory_{operatorCtx_->mappedMemory()} {
+        allocator_{operatorCtx_->allocator()} {
     if (numDestinations_ == 1 || planNode->isBroadcast()) {
       VELOX_CHECK(keyChannels_.empty());
       VELOX_CHECK_NULL(partitionFunction_);
@@ -216,7 +216,7 @@ class PartitionedOutput : public Operator {
   bool replicatedAny_{false};
   std::weak_ptr<exec::PartitionedOutputBufferManager> bufferManager_;
   const int64_t maxBufferedBytes_;
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
   RowVectorPtr output_;
 
   // Reusable memory.

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -54,15 +54,15 @@ RowContainer::RowContainer(
     bool isJoinBuild,
     bool hasProbedFlag,
     bool hasNormalizedKeys,
-    memory::MappedMemory* mappedMemory,
+    memory::MemoryAllocator* allocator,
     const RowSerde& serde)
     : keyTypes_(keyTypes),
       nullableKeys_(nullableKeys),
       aggregates_(aggregates),
       isJoinBuild_(isJoinBuild),
       hasNormalizedKeys_(hasNormalizedKeys),
-      rows_(mappedMemory),
-      stringAllocator_(mappedMemory),
+      rows_(allocator),
+      stringAllocator_(allocator),
       serde_(serde) {
   // Compute the layout of the payload row.  The row has keys, null
   // flags, accumulators, dependent fields. All fields are fixed
@@ -565,7 +565,7 @@ int64_t RowContainer::sizeIncrement(
     vector_size_t numRows,
     int64_t variableLengthBytes) const {
   constexpr int32_t kAllocUnit =
-      AllocationPool::kMinPages * memory::MappedMemory::kPageSize;
+      AllocationPool::kMinPages * memory::MemoryAllocator::kPageSize;
   int32_t needRows = std::max<int64_t>(0, numRows - numFreeRows_);
   int64_t needBytes =
       std::min<int64_t>(0, variableLengthBytes - stringAllocator_.freeSpace());
@@ -630,8 +630,7 @@ void RowContainer::skip(RowContainerIterator& iter, int32_t numRows) {
 
 RowPartitions& RowContainer::partitions() {
   if (!partitions_) {
-    partitions_ =
-        std::make_unique<RowPartitions>(numRows_, *rows_.mappedMemory());
+    partitions_ = std::make_unique<RowPartitions>(numRows_, *rows_.allocator());
   }
   return *partitions_;
 }
@@ -708,11 +707,11 @@ int32_t RowContainer::listPartitionRows(
 
 RowPartitions::RowPartitions(
     int32_t numRows,
-    memory::MappedMemory& mappedMemory)
-    : capacity_(numRows), allocation_(&mappedMemory) {
-  auto numPages = bits::roundUp(capacity_, memory::MappedMemory::kPageSize) /
-      memory::MappedMemory::kPageSize;
-  if (!mappedMemory.allocate(numPages, 0, allocation_)) {
+    memory::MemoryAllocator& allocator)
+    : capacity_(numRows), allocation_(&allocator) {
+  auto numPages = bits::roundUp(capacity_, memory::MemoryAllocator::kPageSize) /
+      memory::MemoryAllocator::kPageSize;
+  if (!allocator.allocateNonContiguous(numPages, 0, allocation_)) {
     VELOX_FAIL(
         "Failed to allocate RowContainer partitions: {} pages", numPages);
   }

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -16,12 +16,13 @@
 #pragma once
 
 #include "velox/common/memory/HashStringAllocator.h"
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/exec/Spill.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
+
 namespace facebook::velox::exec {
 
 using normalized_key_t = uint64_t;
@@ -65,7 +66,7 @@ struct RowContainerIterator {
 class RowPartitions {
  public:
   /// Initializes this to hold up to 'numRows'.
-  RowPartitions(int32_t numRows, memory::MappedMemory& mappedMemory);
+  RowPartitions(int32_t numRows, memory::MemoryAllocator& allocator);
 
   /// Appends 'partitions' to the end of 'this'. Throws if adding more than the
   /// capacity given at construction.
@@ -86,7 +87,7 @@ class RowPartitions {
   int32_t size_{0};
 
   // Partition numbers. 1 byte each.
-  memory::MappedMemory::Allocation allocation_;
+  memory::MemoryAllocator::Allocation allocation_;
 };
 
 // Packed representation of offset, null byte offset and null mask for
@@ -131,17 +132,17 @@ class RowContainer {
   static constexpr uint64_t kUnlimited = std::numeric_limits<uint64_t>::max();
   using Eraser = std::function<void(folly::Range<char**> rows)>;
 
-  // 'keyTypes' gives the type of row and use 'mappedMemory' for bulk
+  // 'keyTypes' gives the type of row and use 'allocator' for bulk
   // allocation.
   RowContainer(
       const std::vector<TypePtr>& keyTypes,
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory)
-      : RowContainer(keyTypes, std::vector<TypePtr>{}, mappedMemory) {}
+      memory::MemoryAllocator* FOLLY_NONNULL allocator)
+      : RowContainer(keyTypes, std::vector<TypePtr>{}, allocator) {}
 
   RowContainer(
       const std::vector<TypePtr>& keyTypes,
       const std::vector<TypePtr>& dependentTypes,
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory)
+      memory::MemoryAllocator* FOLLY_NONNULL allocator)
       : RowContainer(
             keyTypes,
             true, // nullableKeys
@@ -151,7 +152,7 @@ class RowContainer {
             false, // isJoinBuild
             false, // hasProbedFlag
             false, // hasNormalizedKey
-            mappedMemory,
+            allocator,
             ContainerRowSerde::instance()) {}
 
   // 'keyTypes' gives the type of the key of each row. For a group by,
@@ -168,7 +169,7 @@ class RowContainer {
   // join. 'hasNormalizedKey' specifies that an extra word is left
   // below each row for a normalized key that collapses all parts
   // into one word for faster comparison. The bulk allocation is done
-  // from 'mappedMemory'.  'serde_' is used for serializing complex
+  // from 'allocator'.  'serde_' is used for serializing complex
   // type values into the container.
   RowContainer(
       const std::vector<TypePtr>& keyTypes,
@@ -179,7 +180,7 @@ class RowContainer {
       bool isJoinBuild,
       bool hasProbedFlag,
       bool hasNormalizedKey,
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory,
+      memory::MemoryAllocator* FOLLY_NONNULL allocator,
       const RowSerde& serde);
 
   // Allocates a new row and initializes possible aggregates to null.
@@ -354,13 +355,13 @@ class RowContainer {
       auto allocation = rows_.allocationAt(i);
       auto numRuns = allocation->numRuns();
       for (auto runIndex = iter->runIndex; runIndex < numRuns; ++runIndex) {
-        memory::MappedMemory::PageRun run = allocation->runAt(runIndex);
+        memory::MemoryAllocator::PageRun run = allocation->runAt(runIndex);
         auto data = run.data<char>();
         int64_t limit;
         if (i == numAllocations - 1 && runIndex == rows_.currentRunIndex()) {
           limit = rows_.currentOffset();
         } else {
-          limit = run.numPages() * memory::MappedMemory::kPageSize;
+          limit = run.numPages() * memory::MemoryAllocator::kPageSize;
         }
         auto row = iter->rowOffset;
         while (row + rowSize <= limit) {
@@ -569,8 +570,8 @@ class RowContainer {
     }
   }
 
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory() const {
-    return stringAllocator_.mappedMemory();
+  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
+    return stringAllocator_.allocator();
   }
 
   // Returns the types of all non-aggregate columns of 'this', keys first.

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -102,7 +102,7 @@ WriteFile& SpillFileList::currentOutput() {
 void SpillFileList::flush() {
   if (batch_) {
     IOBufOutputStream out(
-        mappedMemory_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
+        allocator_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
     batch_->flush(&out);
     batch_.reset();
     auto iobuf = out.getIOBuf();
@@ -118,7 +118,7 @@ void SpillFileList::write(
     const RowVectorPtr& rows,
     const folly::Range<IndexRange*>& indices) {
   if (!batch_) {
-    batch_ = std::make_unique<VectorStreamGroup>(&mappedMemory_);
+    batch_ = std::make_unique<VectorStreamGroup>(&allocator_);
     batch_->createStreamTree(
         std::static_pointer_cast<const RowType>(rows->type()),
         1000,
@@ -183,7 +183,7 @@ void SpillState::appendToPartition(
         fmt::format("{}-spill-{}", path_, partition),
         targetFileSize_,
         pool_,
-        mappedMemory_);
+        allocator_);
   }
 
   IndexRange range{0, rows->size()};

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -171,14 +171,14 @@ class SpillFileList {
       const std::string& path,
       uint64_t targetFileSize,
       memory::MemoryPool& pool,
-      memory::MappedMemory& mappedMemory)
+      memory::MemoryAllocator& allocator)
       : type_(type),
         numSortingKeys_(numSortingKeys),
         sortCompareFlags_(sortCompareFlags),
         path_(path),
         targetFileSize_(targetFileSize),
         pool_(pool),
-        mappedMemory_(mappedMemory) {
+        allocator_(allocator) {
     // NOTE: if the associated spilling operator has specified the sort
     // comparison flags, then it must match the number of sorting keys.
     VELOX_CHECK(
@@ -230,7 +230,7 @@ class SpillFileList {
   const std::string path_;
   const uint64_t targetFileSize_;
   memory::MemoryPool& pool_;
-  memory::MappedMemory& mappedMemory_;
+  memory::MemoryAllocator& allocator_;
   std::unique_ptr<VectorStreamGroup> batch_;
   SpillFiles files_;
 };
@@ -559,14 +559,14 @@ class SpillState {
       const std::vector<CompareFlags>& sortCompareFlags,
       uint64_t targetFileSize,
       memory::MemoryPool& pool,
-      memory::MappedMemory& mappedMemory)
+      memory::MemoryAllocator& allocator)
       : path_(path),
         maxPartitions_(maxPartitions),
         numSortingKeys_(numSortingKeys),
         sortCompareFlags_(sortCompareFlags),
         targetFileSize_(targetFileSize),
         pool_(pool),
-        mappedMemory_(mappedMemory),
+        allocator_(allocator),
         files_(maxPartitions_) {}
 
   /// Indicates if a given 'partition' has been spilled or not.
@@ -652,7 +652,7 @@ class SpillState {
   const uint64_t targetFileSize_;
 
   memory::MemoryPool& pool_;
-  memory::MappedMemory& mappedMemory_;
+  memory::MemoryAllocator& allocator_;
 
   // A set of spilled partition numbers.
   SpillPartitionNumSet spilledPartitionSet_;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -104,7 +104,7 @@ Spiller::Spiller(
           sortCompareFlags,
           targetFileSize,
           pool,
-          spillMappedMemory()),
+          spillMemoryAllocator()),
       pool_(pool),
       executor_(executor) {
   TestValue::adjust(
@@ -115,7 +115,7 @@ Spiller::Spiller(
   VELOX_CHECK((type_ != Type::kOrderBy) || (state_.maxPartitions() == 1));
   spillRuns_.reserve(state_.maxPartitions());
   for (int i = 0; i < state_.maxPartitions(); ++i) {
-    spillRuns_.emplace_back(spillMappedMemory());
+    spillRuns_.emplace_back(spillMemoryAllocator());
   }
 }
 
@@ -498,7 +498,7 @@ Spiller::SpillRows Spiller::finishSpill() {
   spillFinalized_ = true;
 
   SpillRows rowsFromNonSpillingPartitions(
-      0, memory::StlMappedMemoryAllocator<char*>(&spillMappedMemory()));
+      0, memory::StlMemoryAllocator<char*>(&spillMemoryAllocator()));
   if (type_ != Spiller::Type::kHashJoinProbe) {
     fillSpillRuns(&rowsFromNonSpillingPartitions);
   }
@@ -651,12 +651,12 @@ void Spiller::fillSpillRuns(std::vector<SpillableStats>& statsList) {
 }
 
 // static
-memory::MappedMemory& Spiller::spillMappedMemory() {
+memory::MemoryAllocator& Spiller::spillMemoryAllocator() {
   // Return the top level instance. Since this too may be full,
   // another possibility is to return an emergency instance that
   // delegates to the process wide one and makes a file-backed mmap
   // if the allocation fails.
-  return *memory::MappedMemory::getInstance();
+  return *memory::MemoryAllocator::getInstance();
 }
 
 // static

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -106,7 +106,7 @@ class Spiller {
     int32_t testSpillPct;
   };
 
-  using SpillRows = std::vector<char*, memory::StlMappedMemoryAllocator<char*>>;
+  using SpillRows = std::vector<char*, memory::StlMemoryAllocator<char*>>;
 
   // The constructor without specifying hash bits which will only use one
   // partition by default. It is only used by kOrderBy spiller type as for now.
@@ -296,10 +296,10 @@ class Spiller {
     return state_.spilledFiles();
   }
 
-  // Returns the MappedMemory to use for intermediate storage for
+  // Returns the MemoryAllocator to use for intermediate storage for
   // spilling. This is not directly the RowContainer's memory because
   // this is usually at limit when starting spilling.
-  static memory::MappedMemory& spillMappedMemory();
+  static memory::MemoryAllocator& spillMemoryAllocator();
 
   // Global memory pool for spill intermediates. ~1MB per spill executor thread
   // is the expected peak utilization.
@@ -326,8 +326,8 @@ class Spiller {
   // goes empty this is refilled from the RowContainer for the next
   // spill run from the same partition.
   struct SpillRun {
-    explicit SpillRun(memory::MappedMemory& mappedMemory)
-        : rows(0, memory::StlMappedMemoryAllocator<char*>(&mappedMemory)) {}
+    explicit SpillRun(memory::MemoryAllocator& allocator)
+        : rows(0, memory::StlMemoryAllocator<char*>(&allocator)) {}
     // Spillable rows from the RowContainer.
     SpillRows rows;
     // The total byte size of rows referenced from 'rows'.

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -99,7 +99,7 @@ StreamingAggregation::StreamingAggregation(
       false,
       false,
       false,
-      operatorCtx_->mappedMemory(),
+      operatorCtx_->allocator(),
       ContainerRowSerde::instance());
 }
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -214,11 +214,11 @@ velox::memory::MemoryPool* FOLLY_NONNULL Task::addOperatorPool(
   return childPools_.back().get();
 }
 
-memory::MappedMemory* FOLLY_NONNULL Task::addOperatorMemory(
+memory::MemoryAllocator* FOLLY_NONNULL Task::addOperatorMemory(
     const std::shared_ptr<memory::MemoryUsageTracker>& tracker) {
-  auto mappedMemory = queryCtx_->mappedMemory()->addChild(tracker);
-  childMappedMemories_.emplace_back(mappedMemory);
-  return mappedMemory.get();
+  auto allocator = queryCtx_->allocator()->addChild(tracker);
+  childAllocators_.emplace_back(allocator);
+  return allocator.get();
 }
 
 bool Task::supportsSingleThreadedExecution() const {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -275,7 +275,7 @@ class Task : public std::enable_shared_from_this<Task> {
   /// Creates new instance of MappedMemory, stores it in the task to ensure
   /// lifetime and returns a raw pointer. Not thread safe, e.g. must be called
   /// from the Operator's constructor.
-  memory::MappedMemory* FOLLY_NONNULL
+  memory::MemoryAllocator* FOLLY_NONNULL
   addOperatorMemory(const std::shared_ptr<memory::MemoryUsageTracker>& tracker);
 
   // Removes driver from the set of drivers in 'self'. The task will be kept
@@ -740,9 +740,9 @@ class Task : public std::enable_shared_from_this<Task> {
   // NOTE: ''childPools_' holds the ownerships of node memory pools.
   std::unordered_map<core::PlanNodeId, memory::MemoryPool*> nodePools_;
 
-  // Keep operator MappedMemory instances alive for the duration of the task to
-  // allow for sharing data without copy.
-  std::vector<std::shared_ptr<memory::MappedMemory>> childMappedMemories_;
+  // Keep operator MemoryAllocator instances alive for the duration of the task
+  // to allow for sharing data without copy.
+  std::vector<std::shared_ptr<memory::MemoryAllocator>> childAllocators_;
 
   // A set of IDs of leaf plan nodes that require splits. Used to check plan
   // node IDs specified in split management methods.

--- a/velox/exec/TopN.cpp
+++ b/velox/exec/TopN.cpp
@@ -31,7 +31,7 @@ TopN::TopN(
       count_(topNNode->count()),
       data_(std::make_unique<RowContainer>(
           outputType_->children(),
-          operatorCtx_->mappedMemory())),
+          operatorCtx_->allocator())),
       comparator_(
           outputType_,
           topNNode->sortingKeys(),

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -58,9 +58,9 @@ Window::Window(
       numInputColumns_(windowNode->sources()[0]->outputType()->size()),
       data_(std::make_unique<RowContainer>(
           windowNode->sources()[0]->outputType()->children(),
-          operatorCtx_->mappedMemory())),
+          operatorCtx_->allocator())),
       decodedInputVectors_(numInputColumns_),
-      stringAllocator_(operatorCtx_->mappedMemory()) {
+      stringAllocator_(operatorCtx_->allocator()) {
   auto inputType = windowNode->sources()[0]->outputType();
   initKeyInfo(inputType, windowNode->partitionKeys(), {}, partitionKeyInfo_);
   initKeyInfo(

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -113,7 +113,7 @@ class AggregationTest : public OperatorTestBase {
   void SetUp() override {
     OperatorTestBase::SetUp();
     filesystems::registerLocalFileSystem();
-    mappedMemory_ = memory::MappedMemory::getInstance();
+    allocator_ = memory::MemoryAllocator::getInstance();
     registerSumNonPODAggregate("sumnonpod");
   }
 
@@ -343,7 +343,7 @@ class AggregationTest : public OperatorTestBase {
         false,
         true,
         true,
-        mappedMemory_,
+        allocator_,
         ContainerRowSerde::instance());
   }
 
@@ -357,7 +357,7 @@ class AggregationTest : public OperatorTestBase {
            DOUBLE(),
            VARCHAR()})};
   folly::Random::DefaultGenerator rng_;
-  memory::MappedMemory* mappedMemory_;
+  memory::MemoryAllocator* allocator_;
 };
 
 template <>

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -75,7 +75,7 @@ class HashJoinBridgeTest : public testing::Test,
           std::make_unique<VectorHasher>(rowType_->childAt(channel), channel));
     }
     return HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, mappedMemory_);
+        std::move(keyHashers), {}, true, false, allocator_);
   }
 
   std::vector<ContinueFuture> createEmptyFutures(int32_t count) {
@@ -137,7 +137,7 @@ class HashJoinBridgeTest : public testing::Test,
   const uint32_t numSpillFilesPerPartition_{20};
 
   std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
-  memory::MappedMemory* mappedMemory_{memory::MappedMemory::getInstance()};
+  memory::MemoryAllocator* allocator_{memory::MemoryAllocator::getInstance()};
   std::shared_ptr<TempDirectoryPath> tempDir_;
 
   std::mutex mutex_;

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -78,7 +78,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
             buildType->childAt(channel), channel));
       }
       auto table = HashTable<true>::createForJoin(
-          std::move(keyHashers), dependentTypes, true, false, mappedMemory_);
+          std::move(keyHashers), dependentTypes, true, false, allocator_);
 
       makeRows(size, 1, sequence, buildType, batches);
       copyVectorsToTable(batches, startOffset, table.get());
@@ -152,7 +152,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
     }
     static std::vector<std::unique_ptr<Aggregate>> empty;
     return HashTable<false>::createForAggregation(
-        std::move(keyHashers), empty, mappedMemory_);
+        std::move(keyHashers), empty, allocator_);
   }
 
   void insertGroups(
@@ -435,7 +435,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
-  memory::MappedMemory* mappedMemory_{memory::MappedMemory::getInstance()};
+  memory::MemoryAllocator* allocator_{memory::MemoryAllocator::getInstance()};
   std::unique_ptr<test::VectorMaker> vectorMaker_{
       std::make_unique<test::VectorMaker>(pool_.get())};
   // Bitmap of positions in batches_ that end up in the table.
@@ -517,7 +517,7 @@ TEST_P(HashTableTest, clear) {
       std::vector<TypePtr>{BIGINT()},
       BIGINT()));
   auto table = HashTable<true>::createForAggregation(
-      std::move(keyHashers), aggregates, mappedMemory_);
+      std::move(keyHashers), aggregates, allocator_);
   table->clear();
 }
 
@@ -596,7 +596,7 @@ TEST_P(HashTableTest, regularHashingTableSize) {
           std::make_unique<VectorHasher>(type->childAt(channel), channel));
     }
     auto table = HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, mappedMemory_);
+        std::move(keyHashers), {}, true, false, allocator_);
     std::vector<RowVectorPtr> batches;
     makeRows(1 << 12, 1, 0, type, batches);
     copyVectorsToTable(batches, 0, table.get());

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -269,7 +269,7 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     std::vector<TypePtr> types{input->type()};
 
     // Store the vector in the rowContainer.
-    auto rowContainer = std::make_unique<RowContainer>(types, mappedMemory_);
+    auto rowContainer = std::make_unique<RowContainer>(types, allocator_);
     auto size = input->size();
     SelectivityVector allRows(size);
     std::vector<char*> rows(size);
@@ -806,7 +806,7 @@ TEST_F(RowContainerTest, probedFlag) {
       true, // isJoinBuild
       true, // hasProbedFlag
       false, // hasNormalizedKey
-      mappedMemory_,
+      allocator_,
       ContainerRowSerde::instance());
 
   auto input = makeRowVector({

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -63,7 +63,7 @@ class SpillTest : public testing::Test,
 
  protected:
   void SetUp() override {
-    mappedMemory_ = memory::MappedMemory::getInstance();
+    allocator_ = memory::MemoryAllocator::getInstance();
     tempDir_ = exec::test::TempDirectoryPath::create();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
@@ -150,7 +150,7 @@ class SpillTest : public testing::Test,
         compareFlags,
         targetFileSize,
         *pool(),
-        *mappedMemory_);
+        *allocator_);
     EXPECT_EQ(targetFileSize, state_->targetFileSize());
     EXPECT_EQ(numPartitions, state_->maxPartitions());
     EXPECT_EQ(0, state_->spilledPartitions());
@@ -316,7 +316,7 @@ class SpillTest : public testing::Test,
 
   folly::Random::DefaultGenerator rng_;
   std::shared_ptr<TempDirectoryPath> tempDir_;
-  memory::MappedMemory* mappedMemory_;
+  memory::MemoryAllocator* allocator_;
   std::vector<std::optional<int64_t>> values_;
   std::vector<std::vector<RowVectorPtr>> batchesByPartition_;
   std::string spillPath_;
@@ -358,7 +358,7 @@ TEST_F(SpillTest, spillTimestamp) {
       Timestamp{-1, 17'123'456}};
 
   SpillState state(
-      spillPath, 1, 1, emptyCompareFlags, 1024, *pool(), *mappedMemory_);
+      spillPath, 1, 1, emptyCompareFlags, 1024, *pool(), *allocator_);
   int partitionIndex = 0;
   state.setPartitionSpilled(partitionIndex);
   EXPECT_TRUE(state.isPartitionSpilled(partitionIndex));

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2100,8 +2100,8 @@ TEST_F(TableScanTest, addSplitsToFailedTask) {
 }
 
 TEST_F(TableScanTest, errorInLoadLazy) {
-  auto cache =
-      dynamic_cast<cache::AsyncDataCache*>(memory::MappedMemory::getInstance());
+  auto cache = dynamic_cast<cache::AsyncDataCache*>(
+      memory::MemoryAllocator::getInstance());
   VELOX_CHECK_NOT_NULL(cache);
 
   auto vectors = makeVectors(10, 1'000);

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -139,8 +139,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
     return assignments;
   }
 
-  memory::MappedMemory* mappedMemory() {
-    return memory::MappedMemory::getInstance();
+  memory::MemoryAllocator* allocator() {
+    return memory::MemoryAllocator::getInstance();
   }
 };
 

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -36,7 +36,7 @@ namespace facebook::velox::exec::test {
 std::shared_ptr<cache::AsyncDataCache> OperatorTestBase::asyncDataCache_;
 
 OperatorTestBase::OperatorTestBase() {
-  using memory::MappedMemory;
+  using memory::MemoryAllocator;
   facebook::velox::exec::ExchangeSource::registerFactory();
   parse::registerTypeResolver();
 }
@@ -47,7 +47,7 @@ void OperatorTestBase::registerVectorSerde() {
 
 OperatorTestBase::~OperatorTestBase() {
   // Revert to default process-wide MappedMemory.
-  memory::MappedMemory::setDefaultInstance(nullptr);
+  memory::MemoryAllocator::setDefaultInstance(nullptr);
 }
 
 void OperatorTestBase::TearDownTestCase() {
@@ -59,9 +59,9 @@ void OperatorTestBase::SetUp() {
   // to 4GB backed by a default MappedMemory
   if (!asyncDataCache_) {
     asyncDataCache_ = std::make_shared<cache::AsyncDataCache>(
-        memory::MappedMemory::createDefaultInstance(), 4UL << 30);
+        memory::MemoryAllocator::createDefaultInstance(), 4UL << 30);
   }
-  memory::MappedMemory::setDefaultInstance(asyncDataCache_.get());
+  memory::MemoryAllocator::setDefaultInstance(asyncDataCache_.get());
   if (!isRegisteredVectorSerde()) {
     this->registerVectorSerde();
   }

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -34,7 +34,7 @@ class RowContainerTestBase : public testing::Test,
  protected:
   void SetUp() override {
     pool_ = memory::getDefaultMemoryPool();
-    mappedMemory_ = memory::MappedMemory::getInstance();
+    allocator_ = memory::MemoryAllocator::getInstance();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
@@ -68,11 +68,11 @@ class RowContainerTestBase : public testing::Test,
         isJoinBuild,
         true,
         true,
-        mappedMemory_,
+        allocator_,
         ContainerRowSerde::instance());
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
-  memory::MappedMemory* mappedMemory_;
+  memory::MemoryAllocator* allocator_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -314,7 +314,7 @@ TEST(KllSketchTest, mergeDeserialized) {
 // 2. Otherwise it's \f$ K \sum_i \(\frac{2}{3}\)^i \f$ and it converges to
 //    about O(3K).
 TEST(KllSketchTest, memoryUsage) {
-  HashStringAllocator alloc(memory::MappedMemory::getInstance());
+  HashStringAllocator alloc(memory::MemoryAllocator::getInstance());
   KllSketch<int64_t, StlAllocator<int64_t>> kll(
       1024, StlAllocator<int64_t>(&alloc));
   EXPECT_LE(alloc.retainedSize() - alloc.freeSpace(), 64);

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -74,7 +74,7 @@ class ValueListTest : public functions::test::FunctionBaseTest {
 
   std::unique_ptr<HashStringAllocator> allocator_{
       std::make_unique<HashStringAllocator>(
-          memory::MappedMemory::getInstance())};
+          memory::MemoryAllocator::getInstance())};
 };
 
 TEST_F(ValueListTest, empty) {

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -62,7 +62,7 @@ class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
     return signatureStrings;
   }
 
-  HashStringAllocator allocator_{memory::MappedMemory::getInstance()};
+  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
 };
 
 TEST_F(HyperLogLogFunctionsTest, cardinalitySignatures) {

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -61,7 +61,7 @@ class PrestoSerializerTest : public ::testing::Test {
         rowVector, folly::Range(rows.data(), numRows));
 
     auto arena =
-        std::make_unique<StreamArena>(memory::MappedMemory::getInstance());
+        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
     auto rowType = asRowType(rowVector->type());
     auto serializer =
         serde_->createSerializer(rowType, numRows, arena.get(), serdeOptions);
@@ -79,7 +79,7 @@ class PrestoSerializerTest : public ::testing::Test {
     facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
     OStreamOutputStream out(output, &listener);
     auto arena =
-        std::make_unique<StreamArena>(memory::MappedMemory::getInstance());
+        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
     serde_->serializeConstants(rowVector, arena.get(), serdeOptions, &out);
   }
 

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -36,7 +36,7 @@ class UnsafeRowSerializerTest : public ::testing::Test {
     }
 
     auto arena =
-        std::make_unique<StreamArena>(memory::MappedMemory::getInstance());
+        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
     auto rowType = std::dynamic_pointer_cast<const RowType>(rowVector->type());
     auto serializer = serde_->createSerializer(rowType, numRows, arena.get());
 

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -17,8 +17,8 @@
 
 #include "velox/buffer/Buffer.h"
 #include "velox/common/memory/ByteStream.h"
-#include "velox/common/memory/MappedMemory.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/memory/StreamArena.h"
 #include "velox/vector/ComplexVector.h"
 
@@ -77,8 +77,8 @@ bool isRegisteredVectorSerde();
 
 class VectorStreamGroup : public StreamArena {
  public:
-  explicit VectorStreamGroup(memory::MappedMemory* mappedMemory)
-      : StreamArena(mappedMemory) {}
+  explicit VectorStreamGroup(memory::MemoryAllocator* allocator)
+      : StreamArena(allocator) {}
 
   void createStreamTree(
       RowTypePtr type,

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -96,7 +96,7 @@ int NonPOD::alive = 0;
 class VectorTest : public testing::Test, public test::VectorTestBase {
  protected:
   void SetUp() override {
-    mappedMemory_ = memory::MappedMemory::getInstance();
+    allocator_ = memory::MemoryAllocator::getInstance();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
@@ -757,10 +757,10 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     auto sourceRow = makeRowVector({"c"}, {source});
     auto sourceRowType = asRowType(sourceRow->type());
 
-    VectorStreamGroup even(mappedMemory_);
+    VectorStreamGroup even(allocator_);
     even.createStreamTree(sourceRowType, source->size() / 4);
 
-    VectorStreamGroup odd(mappedMemory_);
+    VectorStreamGroup odd(allocator_);
     odd.createStreamTree(sourceRowType, source->size() / 3);
 
     std::vector<IndexRange> evenIndices;
@@ -867,7 +867,7 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     EXPECT_NE(slice->rawSizes(), sizes);
   }
 
-  memory::MappedMemory* mappedMemory_;
+  memory::MemoryAllocator* allocator_;
 
   size_t vectorSize_{100};
   size_t numIterations_{3};

--- a/velox/vector/tests/VectorUtilTest.cpp
+++ b/velox/vector/tests/VectorUtilTest.cpp
@@ -61,8 +61,7 @@ class VectorUtilTest : public testing::Test {
     pool_ = memoryManager_.getChild();
   }
 
-  memory::MemoryManager<memory::MemoryAllocator, AlignedBuffer::kAlignment>
-      memoryManager_;
+  memory::MemoryManager<AlignedBuffer::kAlignment> memoryManager_;
   std::shared_ptr<memory::MemoryPool> pool_;
 };
 


### PR DESCRIPTION
Simplifies the memory management by (1) remove the existing memory 
allocator objects: MemoryAllocator and MmapMemoryAllocator. Both
are interfacing wrappers for memory allocations from MemoryPool.
MemoryAllocator delegates all the memory allocations to std::malloc
directly. MmapMemoryAllocator delegates the memory allocations to
MappedMemory which has three implementations: MappedMemoryImpl,
MmapAllocator and AsyncDataCache. The AsyncDataCache is a simple
wrapper on top of either MappedMemoryImpl or MmapAllocator to integrate
with file cache. MappedMemoryImpl delegates most memory allocation to
std::malloc except large contiguous memory allocation which use mmap.
MmapAllocator manages the memory through madvice only small memory
allocation goes to std::malloc. There is ScopedMappedMemory which is
a simple wrapper on either one of the above three to provide memory tracking
capabilities; (2) After remove MemoryAllocator and MmapMemoryAllocator,
memory object allocates memory directly from MappedMemory objects, and 
refactor the code base by defining a new MemoryAllocator interface which has
MemoryAllocatorImpl, MmapAllocator, AsyncDataCache and ScopedMemoryAllocator
implementations; (3) extend MemoryAllocator to support alignment allocation
as well as reallocate which is required by memory pool. And previously, this is provided
by the removed MemoryAllocator and MmapMemoryAllocator objects; (4) add
unit tests for the new APIs and add alignment enforcement check; (5) simplify 
the memory manager by removing the allocator template. The memory manager
constructor either take default singleton MemoryAllocator instance or passed it
by the caller.

Next steps is to extend memory pool to support large chunk memory allocations
(both contiguous and non-contiguous) and then deprecate ScopedMemoryAllocator
and all the memory allocations go through memory pool but not through
MemoryAllocator interface directly.