### PR TITLE
Add crc32 Presto Functions

### DIFF
--- a/velox/docs/functions/binary.rst
+++ b/velox/docs/functions/binary.rst
@@ -2,6 +2,10 @@
 Binary Functions
 ================
 
+.. function:: crc32(binary) -> bigint
+
+    Computes the crc32 checksum of ``binary``.
+
 .. function:: xxhash64(binary) -> varbinary
 
     Computes the xxhash64 hash of ``binary``.

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -64,7 +64,7 @@ target_link_libraries(
   velox_type_tz
   velox_presto_types
   velox_functions_util
-  ${ZLIB_LIBRARIES})
+  ${FOLLY})
 
 set_property(TARGET velox_functions_prestosql_impl PROPERTY JOB_POOL_COMPILE
                                                             high_memory_pool)

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -63,7 +63,8 @@ target_link_libraries(
   md5
   velox_type_tz
   velox_presto_types
-  velox_functions_util)
+  velox_functions_util
+  ${ZLIB_LIBRARIES})
 
 set_property(TARGET velox_functions_prestosql_impl PROPERTY JOB_POOL_COMPILE
                                                             high_memory_pool)

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #define XXH_INLINE_ALL
 #include <xxhash.h>
+#include <zlib.h>
 
 #include "velox/functions/Udf.h"
 #include "velox/functions/lib/string/StringCore.h"
@@ -49,6 +50,20 @@ struct CodePointFunction {
       int32_t& result,
       const arg_type<Varchar>& inputChar) {
     result = stringImpl::charToCodePoint(inputChar);
+    return true;
+  }
+};
+
+/// crc32(varbinary) → bigint
+/// Return an int64_t checksum calculated using the crc32 method in zlib.
+template <typename T>
+struct CRC32Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  bool call(out_type<int64_t>& result, const arg_type<Varchar>& input) {
+    result = static_cast<int64_t>(crc32_z(
+        0, reinterpret_cast<unsigned const char*>(input.data()), input.size()));
     return true;
   }
 };

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -15,10 +15,10 @@
  */
 #pragma once
 
+#include <folly/hash/Checksum.h>
 #include <cstdint>
 #define XXH_INLINE_ALL
 #include <xxhash.h>
-#include <zlib.h>
 
 #include "velox/functions/Udf.h"
 #include "velox/functions/lib/string/StringCore.h"
@@ -62,8 +62,8 @@ struct CRC32Function {
 
   FOLLY_ALWAYS_INLINE
   bool call(out_type<int64_t>& result, const arg_type<Varchar>& input) {
-    result = static_cast<int64_t>(crc32_z(
-        0, reinterpret_cast<unsigned const char*>(input.data()), input.size()));
+    result = static_cast<int64_t>(folly::crc32_type(
+        reinterpret_cast<const unsigned char*>(input.data()), input.size()));
     return true;
   }
 };

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -55,6 +55,7 @@ void registerSimpleFunctions() {
   registerFunction<RPadFunction, Varchar, Varchar, int64_t, Varchar>({"rpad"});
 
   // Register hash functions.
+  registerFunction<CRC32Function, int64_t, Varbinary>({"crc32"});
   registerFunction<XxHash64Function, Varbinary, Varbinary>({"xxhash64"});
   registerFunction<Md5Function, Varbinary, Varbinary>({"md5"});
   registerFunction<Sha256Function, Varbinary, Varbinary>({"sha256"});

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1384,6 +1384,26 @@ TEST_F(StringFunctionsTest, controlExprEncodingPropagation) {
   test("if(1!=1, lower(C1), lower(C2))", false);
 }
 
+TEST_F(StringFunctionsTest, crc32) {
+  const auto crc32 = [&](std::optional<std::string> value) {
+    return evaluateOnce<int64_t, std::string>(
+        "crc32(c0)", {value}, {VARBINARY()});
+  };
+  // use python3 zlib result as the expected values,
+  // >>> import zlib
+  // >>> print(zlib.crc32(b"DEAD_BEEF"))
+  // 2634114297
+  // >>> print(zlib.crc32(b"CRC32"))
+  // 4128576900
+  // >>> print(zlib.crc32(b"velox is an open source unified execution engine."))
+  // 2173230066
+  EXPECT_EQ(std::nullopt, crc32(std::nullopt));
+  EXPECT_EQ(2634114297L, crc32("DEAD_BEEF"));
+  EXPECT_EQ(4128576900L, crc32("CRC32"));
+  EXPECT_EQ(
+      2173230066L, crc32("velox is an open source unified execution engine."));
+}
+
 TEST_F(StringFunctionsTest, xxhash64) {
   const auto xxhash64 = [&](std::optional<std::string> value) {
     return evaluateOnce<std::string, std::string>(


### PR DESCRIPTION
[Add crc32 Presto Functions](https://prestodb.io/docs/current/functions/binary.html#crc32)

crc32(binary) → bigint

Computes the CRC-32 of binary. For general purpose hashing, use [xxhash64()](https://prestodb.io/docs/current/functions/binary.html#xxhash64), as it is much faster and produces a better quality hash.