### PR TITLE
Add fuzzer support for Switch expression

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -406,6 +406,7 @@ ExpressionFuzzer::ExpressionFuzzer(
       &ExpressionFuzzer::generateEmptyApproxSetArgs, "empty_approx_set");
   registerFuncOverride(
       &ExpressionFuzzer::generateRegexpReplaceArgs, "regexp_replace");
+  registerFuncOverride(&ExpressionFuzzer::generateSwitchArgs, "switch");
 }
 
 template <typename TFunc>
@@ -534,6 +535,29 @@ std::vector<core::TypedExprPtr> ExpressionFuzzer::generateRegexpReplaceArgs(
       generateArg(input.args[0]), generateArgConstant(input.args[1])};
   if (input.args.size() == 3) {
     inputExpressions.emplace_back(generateArgConstant(input.args[2]));
+  }
+  return inputExpressions;
+}
+
+std::vector<core::TypedExprPtr> ExpressionFuzzer::generateSwitchArgs(
+    const CallableSignature& input) {
+  VELOX_CHECK_EQ(
+      input.args.size(),
+      2,
+      "Only two inputs are expected from the template signature.");
+  size_t cases = boost::random::uniform_int_distribution<uint32_t>(1, 5)(rng_);
+  bool useFinalElse =
+      boost::random::uniform_int_distribution<uint32_t>(0, 1)(rng_) > 0;
+
+  auto conditionClauseType = input.args[0];
+  auto thenClauseType = input.args[1];
+  std::vector<core::TypedExprPtr> inputExpressions;
+  for (int case_idx = 0; case_idx < cases; case_idx++) {
+    inputExpressions.push_back(generateArg(conditionClauseType));
+    inputExpressions.push_back(generateArg(thenClauseType));
+  }
+  if (useFinalElse) {
+    inputExpressions.push_back(generateArg(thenClauseType));
   }
   return inputExpressions;
 }

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -87,6 +87,15 @@ class ExpressionFuzzer {
   std::vector<core::TypedExprPtr> getArgsForCallable(
       const CallableSignature& callable);
 
+  /// Specialization for the "switch" function. Takes in a signature that is of
+  /// the form Switch (condition, then): boolean, T -> T where the type variable
+  /// is bounded to a randomly selected type. It randomly decides the number
+  /// of cases (upto a max of 5) to generate and whether to include the else
+  /// clause. Finally, uses the type specified in the signature to generate
+  /// inputs with that return type.
+  std::vector<core::TypedExprPtr> generateSwitchArgs(
+      const CallableSignature& input);
+
   core::TypedExprPtr getCallExprFromCallable(const CallableSignature& callable);
 
   /// Generate an expression with a random concrete function signature that

--- a/velox/expression/tests/FuzzerRunner.h
+++ b/velox/expression/tests/FuzzerRunner.h
@@ -151,7 +151,8 @@ const std::unordered_map<
     FuzzerRunner::kSpecialForms = {
         {"and",
          std::vector<facebook::velox::exec::FunctionSignaturePtr>{
-             // and: boolean, boolean,.. -> boolean
+             // Signature: and (condition,...) -> output:
+             // boolean, boolean,.. -> boolean
              facebook::velox::exec::FunctionSignatureBuilder()
                  .argumentType("boolean")
                  .argumentType("boolean")
@@ -160,7 +161,8 @@ const std::unordered_map<
                  .build()}},
         {"or",
          std::vector<facebook::velox::exec::FunctionSignaturePtr>{
-             // or: boolean, boolean,.. -> boolean
+             // Signature: or (condition,...) -> output:
+             // boolean, boolean,.. -> boolean
              facebook::velox::exec::FunctionSignatureBuilder()
                  .argumentType("boolean")
                  .argumentType("boolean")
@@ -169,7 +171,8 @@ const std::unordered_map<
                  .build()}},
         {"coalesce",
          std::vector<facebook::velox::exec::FunctionSignaturePtr>{
-             // coalesce: T, T,.. -> T
+             // Signature: coalesce (input,...) -> output:
+             // T, T,.. -> T
              facebook::velox::exec::FunctionSignatureBuilder()
                  .typeVariable("T")
                  .argumentType("T")
@@ -180,18 +183,36 @@ const std::unordered_map<
         {
             "if",
             std::vector<facebook::velox::exec::FunctionSignaturePtr>{
-                // if (condition, then): boolean, T -> T
+                // Signature: if (condition, then) -> output:
+                // boolean, T -> T
                 facebook::velox::exec::FunctionSignatureBuilder()
                     .typeVariable("T")
                     .argumentType("boolean")
                     .argumentType("T")
                     .returnType("T")
                     .build(),
-                // if (condition, then, else): boolean, T, T -> T
+                // Signature: if (condition, then, else) -> output:
+                // boolean, T, T -> T
                 facebook::velox::exec::FunctionSignatureBuilder()
                     .typeVariable("T")
                     .argumentType("boolean")
                     .argumentType("T")
+                    .argumentType("T")
+                    .returnType("T")
+                    .build()},
+        },
+        {
+            "switch",
+            std::vector<facebook::velox::exec::FunctionSignaturePtr>{
+                // Signature: Switch (condition, then) -> output:
+                // boolean, T -> T
+                // This is only used to bind to a randomly selected type for the
+                // output, then while generating arguments, an override is used
+                // to generate inputs that can create variation of multiple
+                // cases and may or may not include a final else clause.
+                facebook::velox::exec::FunctionSignatureBuilder()
+                    .typeVariable("T")
+                    .argumentType("boolean")
                     .argumentType("T")
                     .returnType("T")
                     .build()},


### PR DESCRIPTION
Needs to be enabled by adding "switch" to the --special_forms flag.
Currently, it randomly picks between 1 to 5 cases (condition, then
pairs) and also randomly chooses whether to include the final else
clause or not. It also reduces the nesting level when being used to
avoid blowing up the expression tree as it can add up to 11 more
branches to it. This PR addresses https://github.com/facebookincubator/velox/issues/3387.

Test Plan:
Manually tested and verified.