### PR TITLE
Fix toSql() for expressions that are functions without inputs

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1558,6 +1558,9 @@ void Expr::appendInputsSql(
       stream << inputs_[i]->toSql(complexConstants);
     }
     stream << ")";
+  } else if (vectorFunction_ != nullptr) {
+    // Function with no inputs.
+    stream << "()";
   }
 }
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2474,6 +2474,9 @@ TEST_F(ExprTest, toSql) {
   testToSql("transform(e, x -> x + b)", rowType);
   testToSql("map_filter(f, (k, v) -> (v > 10::double))", rowType);
   testToSql("reduce(e, b, (s, x) -> s + x, s -> s * 10)", rowType);
+
+  // Function without inputs.
+  testToSql("pi()", rowType);
 }
 
 namespace {


### PR DESCRIPTION
Summary:
Currently, toSql() only writes out the function name without the
parenthesis for functions which do not have inputs like pi().
The sql generated would then parse that function as a column
instead and throw an error. This patch fixes this case.

Differential Revision: D41600396

