### PR TITLE
Fix template for If expression used in the fuzzer

### DIFF
--- a/velox/expression/tests/FuzzerRunner.h
+++ b/velox/expression/tests/FuzzerRunner.h
@@ -185,14 +185,12 @@ const std::unordered_map<
                     .typeVariable("T")
                     .argumentType("boolean")
                     .argumentType("T")
-                    .argumentType("T")
                     .returnType("T")
                     .build(),
-                // if (condition, then, else): boolean, T -> T
+                // if (condition, then, else): boolean, T, T -> T
                 facebook::velox::exec::FunctionSignatureBuilder()
                     .typeVariable("T")
                     .argumentType("boolean")
-                    .argumentType("T")
                     .argumentType("T")
                     .argumentType("T")
                     .returnType("T")


### PR DESCRIPTION
Summary:
Currently the template for If expression contains one extra input
parameter for each case, the first case (using 3 but expected 2)
works fine because it assumes the extra param is an else clause,
but for the second case (using 4 but expected 3), it expects a
boolean as return type for the third param but gets 'T' and throws
a USER error which both the common and simplified path throw.
Hence it gets ignored as a user error and the fuzzer never crashes.
This patch fixes this bug.

Differential Revision: D41600721

