### PR TITLE
Fix flaky test AssertQueryBuilderTest.hiveSplits

### DIFF
--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -40,6 +40,9 @@ void HiveConnectorTestBase::SetUp() {
 }
 
 void HiveConnectorTestBase::TearDown() {
+  // Make sure all pending loads are finished or cancelled before unregister
+  // connector.
+  ioExecutor_.reset();
   dwrf::unregisterDwrfReaderFactory();
   connector::unregisterConnector(kHiveConnectorId);
   OperatorTestBase::TearDown();


### PR DESCRIPTION
Summary: Make sure all pending loads are finished or cancelled before unregister connector in HiveConnectorTestBase.

Differential Revision: D41619090

