### PR TITLE
Remove ALIGNMENT template parameters from memory manager and pool

### DIFF
--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -44,7 +44,7 @@ class BufferTest : public testing::Test {
     pool_ = memoryManager_.getChild();
   }
 
-  memory::MemoryManager<AlignedBuffer::kAlignment> memoryManager_;
+  memory::MemoryManager memoryManager_;
   std::shared_ptr<memory::MemoryPool> pool_;
 };
 

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -106,14 +106,286 @@ size_t MemoryPool::getPreferredSize(size_t size) {
   return lower * 2;
 }
 
+MemoryPoolImpl::MemoryPoolImpl(
+    MemoryManager& memoryManager,
+    const std::string& name,
+    std::shared_ptr<MemoryPool> parent,
+    int64_t cap)
+    : MemoryPool{name, parent},
+      memoryManager_{memoryManager},
+      localMemoryUsage_{},
+      cap_{cap},
+      allocator_{memoryManager_.getAllocator()} {
+  VELOX_USER_CHECK_GT(cap, 0);
+}
+
+/* static */
+int64_t MemoryPoolImpl::sizeAlign(int64_t size) {
+  const auto remainder = size % alignment_;
+  return (remainder == 0) ? size : (size + alignment_ - remainder);
+}
+
+void* MemoryPoolImpl::allocate(int64_t size) {
+  if (this->isMemoryCapped()) {
+    VELOX_MEM_MANUAL_CAP();
+  }
+  auto alignedSize = sizeAlign(size);
+  reserve(alignedSize);
+  return allocator_.allocateBytes(alignedSize, alignment_);
+}
+
+void* MemoryPoolImpl::allocateZeroFilled(int64_t numEntries, int64_t sizeEach) {
+  if (this->isMemoryCapped()) {
+    VELOX_MEM_MANUAL_CAP();
+  }
+  const auto alignedSize = sizeAlign(sizeEach * numEntries);
+  reserve(alignedSize);
+  return allocator_.allocateZeroFilled(alignedSize, alignment_);
+}
+
+void* MemoryPoolImpl::reallocate(
+    void* FOLLY_NULLABLE p,
+    int64_t size,
+    int64_t newSize) {
+  auto alignedSize = sizeAlign(size);
+  auto alignedNewSize = sizeAlign(newSize);
+  const int64_t difference = alignedNewSize - alignedSize;
+  if (FOLLY_UNLIKELY(difference <= 0)) {
+    // Track and pretend the shrink took place for accounting purposes.
+    release(-difference, true);
+    return p;
+  }
+
+  reserve(difference);
+  void* newP =
+      allocator_.reallocateBytes(p, alignedSize, alignedNewSize, alignment_);
+  if (FOLLY_UNLIKELY(newP == nullptr)) {
+    free(p, alignedSize);
+    auto errorMessage = fmt::format(
+        MEM_CAP_EXCEEDED_ERROR_FORMAT,
+        succinctBytes(cap_),
+        succinctBytes(difference));
+    VELOX_MEM_CAP_EXCEEDED(errorMessage);
+  }
+  return newP;
+}
+
+void MemoryPoolImpl::free(void* p, int64_t size) {
+  const auto alignedSize = sizeAlign(size);
+  allocator_.freeBytes(p, alignedSize);
+  release(alignedSize);
+}
+
+int64_t MemoryPoolImpl::getCurrentBytes() const {
+  return getAggregateBytes();
+}
+
+int64_t MemoryPoolImpl::getMaxBytes() const {
+  return std::max(getSubtreeMaxBytes(), localMemoryUsage_.getMaxBytes());
+}
+
+void MemoryPoolImpl::setMemoryUsageTracker(
+    const std::shared_ptr<MemoryUsageTracker>& tracker) {
+  const auto currentBytes = getCurrentBytes();
+  if (memoryUsageTracker_) {
+    memoryUsageTracker_->update(-currentBytes);
+  }
+  memoryUsageTracker_ = tracker;
+  memoryUsageTracker_->update(currentBytes);
+}
+
+const std::shared_ptr<MemoryUsageTracker>&
+MemoryPoolImpl::getMemoryUsageTracker() const {
+  return memoryUsageTracker_;
+}
+
+void MemoryPoolImpl::setSubtreeMemoryUsage(int64_t size) {
+  updateSubtreeMemoryUsage([size](MemoryUsage& subtreeUsage) {
+    subtreeUsage.setCurrentBytes(size);
+  });
+}
+
+int64_t MemoryPoolImpl::updateSubtreeMemoryUsage(int64_t size) {
+  int64_t aggregateBytes;
+  updateSubtreeMemoryUsage([&aggregateBytes, size](MemoryUsage& subtreeUsage) {
+    aggregateBytes = subtreeUsage.getCurrentBytes() + size;
+    subtreeUsage.setCurrentBytes(aggregateBytes);
+  });
+  return aggregateBytes;
+}
+
+int64_t MemoryPoolImpl::cap() const {
+  return cap_;
+}
+
+uint16_t MemoryPoolImpl::getAlignment() const {
+  return alignment_;
+}
+
+void MemoryPoolImpl::capMemoryAllocation() {
+  capped_.store(true);
+  for (const auto& child : children_) {
+    child->capMemoryAllocation();
+  }
+}
+
+void MemoryPoolImpl::uncapMemoryAllocation() {
+  // This means if we try to post-order traverse the tree like we do
+  // in MemoryManager, only parent has the right to lift the cap.
+  // This suffices because parent will then recursively lift the cap on the
+  // entire tree.
+  if (getAggregateBytes() > cap()) {
+    return;
+  }
+  if (parent_ != nullptr && parent_->isMemoryCapped()) {
+    return;
+  }
+  capped_.store(false);
+  visitChildren([](MemoryPool* child) { child->uncapMemoryAllocation(); });
+}
+
+bool MemoryPoolImpl::isMemoryCapped() const {
+  return capped_.load();
+}
+
+std::shared_ptr<MemoryPool> MemoryPoolImpl::genChild(
+    std::shared_ptr<MemoryPool> parent,
+    const std::string& name,
+    int64_t cap) {
+  return std::make_shared<MemoryPoolImpl>(memoryManager_, name, parent, cap);
+}
+
+const MemoryUsage& MemoryPoolImpl::getLocalMemoryUsage() const {
+  return localMemoryUsage_;
+}
+
+int64_t MemoryPoolImpl::getAggregateBytes() const {
+  int64_t aggregateBytes = localMemoryUsage_.getCurrentBytes();
+  accessSubtreeMemoryUsage([&aggregateBytes](const MemoryUsage& subtreeUsage) {
+    aggregateBytes += subtreeUsage.getCurrentBytes();
+  });
+  return aggregateBytes;
+}
+
+int64_t MemoryPoolImpl::getSubtreeMaxBytes() const {
+  int64_t maxBytes;
+  accessSubtreeMemoryUsage([&maxBytes](const MemoryUsage& subtreeUsage) {
+    maxBytes = subtreeUsage.getMaxBytes();
+  });
+  return maxBytes;
+}
+
+void MemoryPoolImpl::accessSubtreeMemoryUsage(
+    std::function<void(const MemoryUsage&)> visitor) const {
+  folly::SharedMutex::ReadHolder readLock{subtreeUsageMutex_};
+  visitor(subtreeMemoryUsage_);
+}
+
+void MemoryPoolImpl::updateSubtreeMemoryUsage(
+    std::function<void(MemoryUsage&)> visitor) {
+  folly::SharedMutex::WriteHolder writeLock{subtreeUsageMutex_};
+  visitor(subtreeMemoryUsage_);
+}
+
+void MemoryPoolImpl::reserve(int64_t size) {
+  if (memoryUsageTracker_) {
+    memoryUsageTracker_->update(size);
+  }
+  localMemoryUsage_.incrementCurrentBytes(size);
+
+  bool success = memoryManager_.reserve(size);
+  bool manualCap = isMemoryCapped();
+  int64_t aggregateBytes = getAggregateBytes();
+  if (UNLIKELY(!success || manualCap || aggregateBytes > cap_)) {
+    // NOTE: If we can make the reserve and release a single transaction we
+    // would have more accurate aggregates in intermediate states. However, this
+    // is low-pri because we can only have inflated aggregates, and be on the
+    // more conservative side.
+    release(size);
+    if (!success) {
+      VELOX_MEM_MANAGER_CAP_EXCEEDED(memoryManager_.getMemoryQuota());
+    }
+    if (manualCap) {
+      VELOX_MEM_MANUAL_CAP();
+    }
+    auto errorMessage = fmt::format(
+        MEM_CAP_EXCEEDED_ERROR_FORMAT,
+        succinctBytes(cap_),
+        succinctBytes(size));
+    VELOX_MEM_CAP_EXCEEDED(errorMessage);
+  }
+}
+
+void MemoryPoolImpl::release(int64_t size, bool mock) {
+  memoryManager_.release(size);
+  localMemoryUsage_.incrementCurrentBytes(-size);
+  if (memoryUsageTracker_) {
+    memoryUsageTracker_->update(-size, mock);
+  }
+}
+
+MemoryManager::MemoryManager(
+    int64_t memoryQuota,
+    MemoryAllocator* FOLLY_NONNULL allocator)
+    : allocator_{std::move(allocator)},
+      memoryQuota_{memoryQuota},
+      root_{std::make_shared<MemoryPoolImpl>(
+          *this,
+          kRootNodeName.str(),
+          nullptr,
+          memoryQuota)} {
+  VELOX_USER_CHECK_GE(memoryQuota_, 0);
+}
+
+MemoryManager::~MemoryManager() {
+  auto currentBytes = getTotalBytes();
+  if (currentBytes > 0) {
+    LOG(WARNING) << "Leaked total memory of " << currentBytes << " bytes.";
+  }
+}
+
+int64_t MemoryManager::getMemoryQuota() const {
+  return memoryQuota_;
+}
+
+MemoryPool& MemoryManager::getRoot() const {
+  return *root_;
+}
+
+std::shared_ptr<MemoryPool> MemoryManager::getChild(int64_t cap) {
+  return root_->addChild(
+      fmt::format(
+          "default_usage_node_{}",
+          folly::to<std::string>(folly::Random::rand64())),
+      cap);
+}
+
+int64_t MemoryManager::getTotalBytes() const {
+  return totalBytes_.load(std::memory_order_relaxed);
+}
+
+bool MemoryManager::reserve(int64_t size) {
+  return totalBytes_.fetch_add(size, std::memory_order_relaxed) + size <=
+      memoryQuota_;
+}
+
+void MemoryManager::release(int64_t size) {
+  totalBytes_.fetch_sub(size, std::memory_order_relaxed);
+}
+
+MemoryAllocator& MemoryManager::getAllocator() {
+  return *allocator_;
+}
+
 IMemoryManager& getProcessDefaultMemoryManager() {
-  return MemoryManager<>::getInstance();
+  return MemoryManager::getInstance();
 }
 
 std::shared_ptr<MemoryPool> getDefaultMemoryPool(int64_t cap) {
   auto& memoryManager = getProcessDefaultMemoryManager();
   return memoryManager.getChild(cap);
 }
+
 } // namespace memory
 } // namespace velox
 } // namespace facebook

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -185,6 +185,7 @@ class MemoryAllocator : std::enable_shared_from_this<MemoryAllocator> {
   static constexpr int32_t kMallocOwner = -14;
   /// Allocations smaller than 3K should go to malloc.
   static constexpr int32_t kMaxMallocBytes = 3072;
+  static constexpr uint16_t kMinAlignment = 8;
   static constexpr uint16_t kMaxAlignment = 64;
 
   /// Represents a number of consecutive pages of kPageSize bytes.
@@ -366,19 +367,27 @@ class MemoryAllocator : std::enable_shared_from_this<MemoryAllocator> {
   /// the size limit of 'this'. This function is not virtual but calls the
   /// virtual functions allocateNonContiguous and allocateContiguous, which can
   /// track sizes and enforce caps etc.
+  ///
+  /// NOTE: if not zero, 'alignment' must be power of two and in range of
+  /// [kMinAlignment, kMaxAlignment].
   virtual void* FOLLY_NULLABLE allocateBytes(
       uint64_t bytes,
       uint16_t alignment = 0,
       uint64_t maxMallocSize = kMaxMallocBytes);
 
-  /// Allocates a zero-filled contiguous bytes with capacity that can store
-  /// 'numMembers' entries with each size of 'sizeEach'.
+  /// Allocates a zero-filled contiguous bytes.
+  ///
+  /// NOTE: if not zero, 'alignment' must be power of two and in range of
+  /// [kMinAlignment, kMaxAlignment].
   virtual void* FOLLY_NULLABLE
-  allocateZeroFilled(int64_t numMembers, int64_t sizeEach);
+  allocateZeroFilled(uint64_t bytes, uint64_t alignment = 0);
 
   /// Allocates 'newSize' contiguous bytes. If 'p' is not null, this function
   /// copies std::min(size, newSize) bytes from 'p' to the newly allocated
   /// buffer and free 'p' after that.
+  ///
+  /// NOTE: if not zero, 'alignment' must be power of two and in range of
+  /// [kMinAlignment, kMaxAlignment].g
   virtual void* FOLLY_NULLABLE reallocateBytes(
       void* FOLLY_NULLABLE p,
       int64_t size,

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -27,7 +27,7 @@ namespace memory {
 
 TEST(MemoryManagerTest, Ctor) {
   {
-    MemoryManager<> manager{};
+    MemoryManager manager{};
     const auto& root = manager.getRoot();
 
     ASSERT_EQ(std::numeric_limits<int64_t>::max(), root.cap());
@@ -37,7 +37,7 @@ TEST(MemoryManagerTest, Ctor) {
     ASSERT_EQ(0, manager.getTotalBytes());
   }
   {
-    MemoryManager<> manager{8L * 1024 * 1024};
+    MemoryManager manager{8L * 1024 * 1024};
     const auto& root = manager.getRoot();
 
     ASSERT_EQ(8L * 1024 * 1024, root.cap());
@@ -46,15 +46,15 @@ TEST(MemoryManagerTest, Ctor) {
     ASSERT_EQ(8L * 1024 * 1024, manager.getMemoryQuota());
     ASSERT_EQ(0, manager.getTotalBytes());
   }
-  { ASSERT_ANY_THROW(MemoryManager<> manager{-1}); }
+  { ASSERT_ANY_THROW(MemoryManager manager{-1}); }
 }
 
 // TODO: when run sequentially, e.g. `buck run dwio/memory/...`, this has side
 // effects for other tests using process singleton memory manager. Might need to
 // use folly::Singleton for isolation by tag.
 TEST(MemoryManagerTest, GlobalMemoryManager) {
-  auto& manager = MemoryManager<>::getInstance();
-  auto& managerII = MemoryManager<>::getInstance();
+  auto& manager = MemoryManager::getInstance();
+  auto& managerII = MemoryManager::getInstance();
 
   auto& root = manager.getRoot();
   auto child = root.addChild("some_child", 42);
@@ -73,7 +73,7 @@ TEST(MemoryManagerTest, GlobalMemoryManager) {
 
 TEST(MemoryManagerTest, Reserve) {
   {
-    MemoryManager<> manager{};
+    MemoryManager manager{};
     ASSERT_TRUE(manager.reserve(0));
     ASSERT_EQ(0, manager.getTotalBytes());
     manager.release(0);
@@ -86,7 +86,7 @@ TEST(MemoryManagerTest, Reserve) {
     ASSERT_EQ(0, manager.getTotalBytes());
   }
   {
-    MemoryManager<> manager{42};
+    MemoryManager manager{42};
     ASSERT_TRUE(manager.reserve(1));
     ASSERT_TRUE(manager.reserve(1));
     ASSERT_TRUE(manager.reserve(2));
@@ -107,10 +107,10 @@ TEST(MemoryManagerTest, Reserve) {
 }
 
 TEST(MemoryManagerTest, GlobalMemoryManagerQuota) {
-  auto& manager = MemoryManager<>::getInstance();
-  ASSERT_THROW(MemoryManager<>::getInstance(42, true), velox::VeloxUserError);
+  auto& manager = MemoryManager::getInstance();
+  ASSERT_THROW(MemoryManager::getInstance(42, true), velox::VeloxUserError);
 
-  auto& coercedManager = MemoryManager<>::getInstance(42);
+  auto& coercedManager = MemoryManager::getInstance(42);
   ASSERT_EQ(manager.getMemoryQuota(), coercedManager.getMemoryQuota());
 }
 } // namespace memory

--- a/velox/common/memory/tests/MemoryPoolBenchmark.cpp
+++ b/velox/common/memory/tests/MemoryPoolBenchmark.cpp
@@ -24,13 +24,13 @@
 
 using namespace facebook::velox::memory;
 
-constexpr int64_t kMemoryFootprintIncrement = kDefaultAlignment;
+constexpr int64_t kMemoryFootprintIncrement = MemoryAllocator::kMaxAlignment;
 
 namespace facebook::velox::memory {
 
 class BenchmarkHelper {
  public:
-  BenchmarkHelper(MemoryManager<kNoAlignment>& manager)
+  BenchmarkHelper(MemoryManager& manager)
       : manager_{manager}, leaves_{findLeaves()} {}
 
   std::vector<MemoryPool*> findLeaves() {
@@ -62,14 +62,14 @@ class BenchmarkHelper {
 
  private:
   // TODO: move semantic is better
-  MemoryManager<kNoAlignment>& manager_;
+  MemoryManager& manager_;
   std::vector<MemoryPool*> leaves_;
 };
 } // namespace facebook::velox::memory
 
 BENCHMARK(SingleNodeAlloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<kNoAlignment> manager{};
+  MemoryManager manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
@@ -83,7 +83,7 @@ BENCHMARK(SingleNodeAlloc, iters) {
 // Should be the same.
 BENCHMARK(SingleNodeAllocWithCap, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<kNoAlignment> manager{};
+  MemoryManager manager{};
   auto pool = manager.getRoot().addChild(
       "pride_of_higara", iters * kMemoryFootprintIncrement);
 
@@ -98,7 +98,7 @@ BENCHMARK(SingleNodeAllocWithCap, iters) {
 
 BENCHMARK(SingleNodeFree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<kNoAlignment> manager{};
+  MemoryManager manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
@@ -112,7 +112,7 @@ BENCHMARK(SingleNodeFree, iters) {
 
 BENCHMARK(SingleNodeRealloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<kNoAlignment> manager{};
+  MemoryManager manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   void* p = pool->allocate(kMemoryFootprintIncrement);
@@ -129,7 +129,7 @@ BENCHMARK(SingleNodeRealloc, iters) {
 
 BENCHMARK(SingleNodeAlignedAlloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<kDefaultAlignment> manager{};
+  MemoryManager manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
@@ -143,11 +143,12 @@ BENCHMARK(SingleNodeAlignedAlloc, iters) {
 
 BENCHMARK(SingleNodeAlignedAllocWithCap, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<kDefaultAlignment> manager{};
+  MemoryManager manager{};
   auto unalignedTotal = iters * kMemoryFootprintIncrement;
-  auto alignedCap = unalignedTotal % kDefaultAlignment == 0
+  auto alignedCap = unalignedTotal % MemoryAllocator::kMaxAlignment == 0
       ? unalignedTotal
-      : (unalignedTotal / kDefaultAlignment + 1) * kDefaultAlignment;
+      : (unalignedTotal / MemoryAllocator::kMaxAlignment + 1) *
+          MemoryAllocator::kMaxAlignment;
   auto pool = manager.getRoot().addChild("pride_of_higara", alignedCap);
 
   for (size_t i = 0; i < iters; ++i) {
@@ -161,7 +162,7 @@ BENCHMARK(SingleNodeAlignedAllocWithCap, iters) {
 
 BENCHMARK(SingleNodeAlignedRealloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<kDefaultAlignment> manager{};
+  MemoryManager manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   void* p = pool->allocate(kMemoryFootprintIncrement);
@@ -191,7 +192,7 @@ void addNLeaves(
 // with single leaf runs.
 BENCHMARK(FlatTree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<kNoAlignment> manager{};
+  MemoryManager manager{};
   addNLeaves(manager.getRoot(), 10 * 20);
   BenchmarkHelper helper{manager};
   suspender.dismiss();
@@ -211,7 +212,7 @@ BENCHMARK(FlatTree, iters) {
 // with single leaf runs.
 BENCHMARK(DeeperTree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<kNoAlignment> manager{};
+  MemoryManager manager{};
   for (size_t i = 0; i < 10; ++i) {
     auto child = manager.getRoot().addChild(
         "query_fragment_" + folly::to<std::string>(i));
@@ -233,7 +234,7 @@ BENCHMARK(DeeperTree, iters) {
 
 BENCHMARK(FlatSubtree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<kNoAlignment> manager{};
+  MemoryManager manager{};
   auto child = manager.getRoot().addChild("query_fragment_1");
   addNLeaves(*child, 10 * 20);
   BenchmarkHelper helper{manager};
@@ -252,7 +253,7 @@ BENCHMARK(FlatSubtree, iters) {
 
 BENCHMARK(FlatSticks, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<kNoAlignment> manager{};
+  MemoryManager manager{};
   for (size_t i = 0; i < 10 * 20; ++i) {
     auto child = manager.getRoot().addChild(
         "query_fragment_" + folly::to<std::string>(i));

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -53,7 +53,7 @@ class MemoryPoolTest : public testing::TestWithParam<bool> {
   }
 
   std::shared_ptr<IMemoryManager> getMemoryManager(int64_t quota) {
-    return std::make_shared<MemoryManager<>>(quota);
+    return std::make_shared<MemoryManager>(quota);
   }
 
   const bool useMmap_;
@@ -61,18 +61,17 @@ class MemoryPoolTest : public testing::TestWithParam<bool> {
 };
 
 TEST(MemoryPoolTest, Ctor) {
-  constexpr uint16_t kAlignment = 64;
-  MemoryManager<kAlignment> manager{8 * GB};
+  MemoryManager manager{8 * GB};
   // While not recommended, the root allocator should be valid.
-  auto& root = dynamic_cast<MemoryPoolImpl<64>&>(manager.getRoot());
+  auto& root = dynamic_cast<MemoryPoolImpl&>(manager.getRoot());
 
   ASSERT_EQ(8 * GB, root.cap_);
   ASSERT_EQ(0, root.getCurrentBytes());
   ASSERT_EQ(root.parent(), nullptr);
 
   {
-    auto fakeRoot = std::make_shared<MemoryPoolImpl<kAlignment>>(
-        manager, "fake_root", nullptr, 4 * GB);
+    auto fakeRoot =
+        std::make_shared<MemoryPoolImpl>(manager, "fake_root", nullptr, 4 * GB);
     ASSERT_EQ("fake_root", fakeRoot->name());
     ASSERT_EQ(4 * GB, fakeRoot->cap_);
     ASSERT_EQ(&root.allocator_, &fakeRoot->allocator_);
@@ -82,7 +81,7 @@ TEST(MemoryPoolTest, Ctor) {
   {
     auto child = root.addChild("favorite_child");
     ASSERT_EQ(child->parent(), &root);
-    auto& favoriteChild = dynamic_cast<MemoryPoolImpl<64>&>(*child);
+    auto& favoriteChild = dynamic_cast<MemoryPoolImpl&>(*child);
     ASSERT_EQ("favorite_child", favoriteChild.name());
     ASSERT_EQ(std::numeric_limits<int64_t>::max(), favoriteChild.cap_);
     ASSERT_EQ(&root.allocator_, &favoriteChild.allocator_);
@@ -91,7 +90,7 @@ TEST(MemoryPoolTest, Ctor) {
   {
     auto child = root.addChild("naughty_child", 3 * GB);
     ASSERT_EQ(child->parent(), &root);
-    auto& naughtyChild = dynamic_cast<MemoryPoolImpl<kAlignment>&>(*child);
+    auto& naughtyChild = dynamic_cast<MemoryPoolImpl&>(*child);
     ASSERT_EQ("naughty_child", naughtyChild.name());
     ASSERT_EQ(3 * GB, naughtyChild.cap_);
     ASSERT_EQ(&root.allocator_, &naughtyChild.allocator_);
@@ -100,7 +99,7 @@ TEST(MemoryPoolTest, Ctor) {
 }
 
 TEST(MemoryPoolTest, AddChild) {
-  MemoryManager<> manager{};
+  MemoryManager manager{};
   auto& root = manager.getRoot();
 
   ASSERT_EQ(0, root.getChildCount());
@@ -125,7 +124,7 @@ TEST(MemoryPoolTest, AddChild) {
 }
 
 TEST_P(MemoryPoolTest, dropChild) {
-  MemoryManager<> manager{};
+  MemoryManager manager{};
   auto& root = manager.getRoot();
   ASSERT_EQ(root.parent(), nullptr);
 
@@ -166,7 +165,7 @@ TEST_P(MemoryPoolTest, dropChild) {
 }
 
 TEST(MemoryPoolTest, CapSubtree) {
-  MemoryManager<> manager{};
+  MemoryManager manager{};
   auto& root = manager.getRoot();
 
   // left subtree.
@@ -208,7 +207,7 @@ TEST(MemoryPoolTest, CapSubtree) {
 }
 
 TEST(MemoryPoolTest, UncapMemory) {
-  MemoryManager<> manager{};
+  MemoryManager manager{};
   auto& root = manager.getRoot();
 
   auto node_a = root.addChild("node_a");
@@ -259,7 +258,7 @@ TEST(MemoryPoolTest, UncapMemory) {
 
 // Mainly tests how it tracks externally allocated memory.
 TEST(MemoryPoolTest, ReserveTest) {
-  MemoryManager<> manager{8 * GB};
+  MemoryManager manager{8 * GB};
   auto& root = manager.getRoot();
 
   auto child = root.addChild("elastic_quota");
@@ -298,7 +297,7 @@ void testMmapMemoryAllocation(
     const MmapAllocator* mmapAllocator,
     MachinePageCount allocPages,
     size_t allocCount) {
-  MemoryManager<> manager(8 * GB);
+  MemoryManager manager(8 * GB);
   const auto kPageSize = 4 * KB;
 
   auto& root = manager.getRoot();
@@ -370,6 +369,7 @@ TEST_P(MemoryPoolTest, AllocTest) {
   const int64_t kChunkSize{32L * MB};
 
   void* oneChunk = child->allocate(kChunkSize);
+  ASSERT_EQ(reinterpret_cast<uint64_t>(oneChunk) % child->getAlignment(), 0);
   ASSERT_EQ(kChunkSize, child->getCurrentBytes());
   ASSERT_EQ(kChunkSize, child->getMaxBytes());
 
@@ -482,8 +482,34 @@ TEST_P(MemoryPoolTest, CapAllocation) {
   }
 }
 
-TEST(MemoryPoolTest, MemoryCapExceptions) {
-  MemoryManager<> manager{127L * MB};
+TEST_P(MemoryPoolTest, allocateZeroFilled) {
+  auto manager = getMemoryManager(8 * GB);
+  auto& root = manager->getRoot();
+
+  auto pool = root.addChild("elastic_quota");
+
+  const std::vector<int64_t> numEntriesVector({1, 2, 10});
+  const std::vector<int64_t> sizeEachVector({1, 117, 2467});
+  std::vector<void*> allocationPtrs;
+  std::vector<int64_t> allocationSizes;
+  for (const auto& numEntries : numEntriesVector) {
+    for (const auto& sizeEach : sizeEachVector) {
+      SCOPED_TRACE(
+          fmt::format("numEntries{}, sizeEach{}", numEntries, sizeEach));
+      void* ptr = pool->allocateZeroFilled(numEntries, sizeEach);
+      ASSERT_EQ(reinterpret_cast<uint64_t>(ptr) % pool->getAlignment(), 0);
+      allocationPtrs.push_back(ptr);
+      allocationSizes.push_back(numEntries * sizeEach);
+    }
+  }
+  for (int32_t i = 0; i < allocationPtrs.size(); ++i) {
+    pool->free(allocationPtrs[i], allocationSizes[i]);
+  }
+  ASSERT_EQ(0, pool->getCurrentBytes());
+}
+
+TEST_P(MemoryPoolTest, MemoryCapExceptions) {
+  MemoryManager manager{127L * MB};
   auto& root = manager.getRoot();
 
   auto pool = root.addChild("static_quota", 63L * MB);
@@ -534,18 +560,13 @@ TEST(MemoryPoolTest, MemoryCapExceptions) {
   }
 }
 
-TEST(MemoryPoolTest, GetAlignment) {
-  {
-    EXPECT_EQ(kNoAlignment, MemoryManager<>{32 * MB}.getRoot().getAlignment());
-  }
-  {
-    MemoryManager<64> manager{32 * MB};
-    EXPECT_EQ(64, manager.getRoot().getAlignment());
-  }
+TEST_P(MemoryPoolTest, GetAlignment) {
+  MemoryManager manager{32 * MB};
+  EXPECT_EQ(MemoryAllocator::kMaxAlignment, manager.getRoot().getAlignment());
 }
 
-TEST(MemoryPoolTest, MemoryManagerGlobalCap) {
-  MemoryManager<> manager{32 * MB};
+TEST_P(MemoryPoolTest, MemoryManagerGlobalCap) {
+  MemoryManager manager{32 * MB};
 
   auto& root = manager.getRoot();
   auto pool = root.addChild("unbounded");
@@ -567,8 +588,8 @@ TEST(MemoryPoolTest, MemoryManagerGlobalCap) {
 // Tests how child updates itself and its parent's memory usage
 // and what it returns for getCurrentBytes()/getMaxBytes and
 // with memoryUsageTracker.
-TEST(MemoryPoolTest, childUsageTest) {
-  MemoryManager<> manager{8 * GB};
+TEST_P(MemoryPoolTest, childUsageTest) {
+  MemoryManager manager{8 * GB};
   auto& root = manager.getRoot();
 
   auto pool = root.addChild("main_pool");
@@ -626,35 +647,34 @@ TEST(MemoryPoolTest, childUsageTest) {
   void* p3Chunk0 = tree[3]->allocate(16);
   verifyUsage(
       tree,
-      {0, 0, 0, 16, 0, 0, 0},
-      {0, 0, 0, 16, 0, 0, 0},
-      {16, 16, 0, 16, 0, 0, 0},
-      {16, 16, 0, 16, 0, 0, 0});
+      {0, 0, 0, 64, 0, 0, 0},
+      {0, 0, 0, 64, 0, 0, 0},
+      {64, 64, 0, 64, 0, 0, 0},
+      {64, 64, 0, 64, 0, 0, 0});
 
   void* p5Chunk0 = tree[5]->allocate(64);
   verifyUsage(
       tree,
-      {0, 0, 0, 16, 0, 64, 0},
-      {0, 0, 0, 16, 0, 64, 0},
-      {80, 16, 64, 16, 0, 64, 0},
-      {80, 16, 64, 16, 0, 64, 0});
+      {0, 0, 0, 64, 0, 64, 0},
+      {0, 0, 0, 64, 0, 64, 0},
+      {128, 64, 64, 64, 0, 64, 0},
+      {128, 64, 64, 64, 0, 64, 0});
 
   tree[3]->free(p3Chunk0, 16);
-
   verifyUsage(
       tree,
       {0, 0, 0, 0, 0, 64, 0},
-      {0, 0, 0, 16, 0, 64, 0},
+      {0, 0, 0, 64, 0, 64, 0},
       {64, 0, 64, 0, 0, 64, 0},
-      {80, 16, 64, 16, 0, 64, 0});
+      {128, 64, 64, 64, 0, 64, 0});
 
   tree[5]->free(p5Chunk0, 64);
   verifyUsage(
       tree,
       {0, 0, 0, 0, 0, 0, 0},
-      {0, 0, 0, 16, 0, 64, 0},
+      {0, 0, 0, 64, 0, 64, 0},
       {0, 0, 0, 0, 0, 0, 0},
-      {80, 16, 64, 16, 0, 64, 0});
+      {128, 64, 64, 64, 0, 64, 0});
 
   std::vector<std::shared_ptr<MemoryUsageTracker>> trackers;
   for (unsigned i = 0, e = tree.size(); i != e; ++i) {
@@ -665,7 +685,7 @@ TEST(MemoryPoolTest, childUsageTest) {
   tree.clear();
 
   std::vector<int64_t> expectedCurrentBytes({0, 0, 0, 0, 0, 0, 0});
-  std::vector<int64_t> expectedMaxBytes({80, 16, 64, 16, 0, 64, 0});
+  std::vector<int64_t> expectedMaxBytes({128, 64, 64, 64, 0, 64, 0});
 
   // Verify the stats still holds the correct stats.
   for (unsigned i = 0, e = trackers.size(); i != e; ++i) {
@@ -674,8 +694,8 @@ TEST(MemoryPoolTest, childUsageTest) {
   }
 }
 
-TEST(MemoryPoolTest, setMemoryUsageTrackerTest) {
-  MemoryManager<> manager{};
+TEST_P(MemoryPoolTest, setMemoryUsageTrackerTest) {
+  MemoryManager manager{};
   auto& root = manager.getRoot();
   const int64_t kChunkSize{32L * MB};
   {
@@ -737,8 +757,8 @@ TEST(MemoryPoolTest, setMemoryUsageTrackerTest) {
   }
 }
 
-TEST(MemoryPoolTest, mockUpdatesTest) {
-  MemoryManager<> manager{};
+TEST_P(MemoryPoolTest, mockUpdatesTest) {
+  MemoryManager manager{};
   auto& root = manager.getRoot();
   const int64_t kChunkSize{32L * MB};
   {
@@ -769,9 +789,9 @@ TEST(MemoryPoolTest, mockUpdatesTest) {
   }
 }
 
-TEST(MemoryPoolTest, getPreferredSize) {
-  MemoryManager<64> manager{};
-  auto& pool = dynamic_cast<MemoryPoolImpl<64>&>(manager.getRoot());
+TEST_P(MemoryPoolTest, getPreferredSize) {
+  MemoryManager manager{};
+  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.getRoot());
 
   // size < 8
   EXPECT_EQ(8, pool.getPreferredSize(1));
@@ -786,17 +806,17 @@ TEST(MemoryPoolTest, getPreferredSize) {
   EXPECT_EQ(1024 * 1024 * 2, pool.getPreferredSize(1024 * 1536 + 1));
 }
 
-TEST(MemoryPoolTest, getPreferredSizeOverflow) {
-  MemoryManager<64> manager{};
-  auto& pool = dynamic_cast<MemoryPoolImpl<64>&>(manager.getRoot());
+TEST_P(MemoryPoolTest, getPreferredSizeOverflow) {
+  MemoryManager manager{};
+  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.getRoot());
 
   EXPECT_EQ(1ULL << 32, pool.getPreferredSize((1ULL << 32) - 1));
   EXPECT_EQ(1ULL << 63, pool.getPreferredSize((1ULL << 62) - 1 + (1ULL << 62)));
 }
 
-TEST(MemoryPoolTest, allocatorOverflow) {
-  MemoryManager<64> manager{};
-  auto& pool = dynamic_cast<MemoryPoolImpl<64>&>(manager.getRoot());
+TEST_P(MemoryPoolTest, allocatorOverflow) {
+  MemoryManager manager{};
+  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.getRoot());
   Allocator<int64_t> alloc(pool);
   EXPECT_THROW(alloc.allocate(1ULL << 62), VeloxException);
   EXPECT_THROW(alloc.deallocate(nullptr, 1ULL << 62), VeloxException);

--- a/velox/dwio/common/DataBuffer.h
+++ b/velox/dwio/common/DataBuffer.h
@@ -35,7 +35,7 @@ class DataBuffer {
       : pool_(&pool),
         // Initial allocation uses calloc, to avoid memset.
         buf_(reinterpret_cast<T*>(
-            pool_->allocateZeroFilled(sizeInBytes(size), 1))),
+            pool_->allocateZeroFilled(1, sizeInBytes(size)))),
         size_(size),
         capacity_(size) {
     DWIO_ENSURE(buf_ != nullptr || size == 0);

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -62,9 +62,10 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     updateLocalMemoryUsage(size);
     return allocator_->allocateBytes(size);
   }
-  void* allocateZeroFilled(int64_t numMembers, int64_t sizeEach) override {
-    updateLocalMemoryUsage(numMembers * sizeEach);
-    return allocator_->allocateZeroFilled(numMembers, sizeEach);
+
+  void* allocateZeroFilled(int64_t numEntries, int64_t sizeEach) override {
+    updateLocalMemoryUsage(numEntries * sizeEach);
+    return allocator_->allocateZeroFilled(numEntries * sizeEach);
   }
 
   // No-op for attempts to shrink buffer.

--- a/velox/vector/tests/VectorUtilTest.cpp
+++ b/velox/vector/tests/VectorUtilTest.cpp
@@ -61,7 +61,7 @@ class VectorUtilTest : public testing::Test {
     pool_ = memoryManager_.getChild();
   }
 
-  memory::MemoryManager<AlignedBuffer::kAlignment> memoryManager_;
+  memory::MemoryManager memoryManager_;
   std::shared_ptr<memory::MemoryPool> pool_;
 };
 


### PR DESCRIPTION
Remove ALIGNMENT template parameters from memory manager and pool
and always align with 64 bytes for small memory allocations from memory pool.