### PR TITLE
Add file read ahead through AsyncDataCache

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -122,6 +122,11 @@ void AsyncDataCacheEntry::initialize(FileCacheKey key) {
   }
 }
 
+void AsyncDataCacheEntry::makeEvictable() {
+  accessStats_.lastUse = 0;
+  accessStats_.numUses = 0;
+}
+
 std::string AsyncDataCacheEntry::toString() const {
   return fmt::format(
       "<entry key:{}:{} size {} pins {}>",

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -71,8 +71,9 @@ class BufferedInput {
 
   // True if there is free memory for prefetching the stripe. This is
   // called to check if a stripe that is not next for read should be
-  // prefetched.
-  virtual bool shouldPreload() {
+  // prefetched. 'numPages' is added to the already enqueued pages, so
+  // that this can be called also before enqueueing regions.
+  virtual bool shouldPreload(int32_t /*numPages*/ = 0) {
     return false;
   }
 

--- a/velox/dwio/common/CachedBufferedInput.h
+++ b/velox/dwio/common/CachedBufferedInput.h
@@ -118,7 +118,11 @@ class CachedBufferedInput : public BufferedInput {
   std::unique_ptr<SeekableInputStream>
   read(uint64_t offset, uint64_t length, LogType logType) const override;
 
-  bool shouldPreload() override;
+  /// Schedules load of 'region' on 'executor_'. Fails silently if no memory or
+  /// if shouldPreload() is false.
+  bool prefetch(Region region);
+
+  bool shouldPreload(int32_t numPages = 0) override;
 
   bool shouldPrefetchStripes() const override {
     return true;

--- a/velox/dwio/common/StreamIdentifier.h
+++ b/velox/dwio/common/StreamIdentifier.h
@@ -49,6 +49,13 @@ class StreamIdentifier {
     return fmt::format("[id={}]", id_);
   }
 
+  /// Returns a special value indicating a stream to be read load quantum by
+  /// load quantum
+  static StreamIdentifier sequentialFile() {
+    constexpr int32_t kSequentialFile = std::numeric_limits<int32_t>::max() - 1;
+    return StreamIdentifier(kSequentialFile);
+  }
+
   int32_t id_;
 };
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2108,7 +2108,7 @@ TEST_F(TableScanTest, errorInLoadLazy) {
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, vectors);
 
-  int32_t counter = 0;
+  std::atomic<int32_t> counter = 0;
   cache->setVerifyHook([&](const cache::AsyncDataCacheEntry&) {
     if (++counter >= 7) {
       VELOX_FAIL("Testing error");


### PR DESCRIPTION
adds a code sample and supporting functions for using CachedBufferedInput for smart prefetching of sequential files.  A SeekableInputStream is registered for each file of interest. Each time the read proceeds past a given fraction of the current load quantum, the load of the next quantum is scheduled. The load prefetches into AsyncDataCache and will be found there when moving past the end of thecurrent quantum. Prefetch will fail silently if there is no memory or if over half the cache is taken by not yet accessed prefetched data.

Adds a special StreamIdentifier to denote expected sequential access. The default for no StreamIdentifier in enqueue is preloading the whole enqueued range.

Adds a mode where each visited cache entry is made evictable immediately after unpinning. This allows not polluting the cache with one time large sequential accesses.

Adds a test that simulates a multifile merge. Each thread has 100 files and consumes a chunk of each in turn.