### PR TITLE
Recylce peeled results in applyFunctionWithPeeling for constant primitive results

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1429,6 +1429,12 @@ bool Expr::applyFunctionWithPeeling(
   VectorPtr wrappedResult =
       context.applyWrapToPeeledResult(this->type(), peeledResult, applyRows);
   context.moveOrCopyResult(wrappedResult, rows, result);
+
+  // Recycle peeledResult if it's not owned by the result vector. Examples of
+  // when this can happen is when the result is a primitive constant vector, or
+  // when moveOrCopyResult copies wrappedResult content.
+  context.releaseVector(peeledResult);
+
   return true;
 }
 


### PR DESCRIPTION
Summary:
when the peeling happen because all inputs are constant, then peeled results is re-allocated for each batch
this diff recycles it. note that it can be recycled at that point because constant vectors do not need holds
the values vector when the constant is a primitive.

Differential Revision: D41638700