### PR TITLE
Avoid calling addNulls in exprEval when there is no nulls to add.

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1267,7 +1267,7 @@ void Expr::evalAll(
 
   // Write non-selected rows in remainingRows as nulls in the result if some
   // rows have been skipped.
-  if (mutableRemainingRows != nullptr) {
+  if (mutableRemainingRows && !mutableRemainingRows->isAllSelected()) {
     addNulls(rows, mutableRemainingRows->asRange().bits(), context, result);
   }
   releaseInputValues(context);

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1422,6 +1422,12 @@ bool Expr::applyFunctionWithPeeling(
   VectorPtr wrappedResult =
       context.applyWrapToPeeledResult(this->type(), peeledResult, applyRows);
   context.moveOrCopyResult(wrappedResult, rows, result);
+
+  // Recycle peeledResult if it's not owned by the result vector. Examples of
+  // when this can happen is when the result is a primitive constant vector, or
+  // when moveOrCopyResult copies wrappedResult content.
+  context.releaseVector(peeledResult);
+
   return true;
 }
 


### PR DESCRIPTION
Summary:
before:
```
============================================================================
[...]lox/benchmarks/DenseProcBenchmark.cpp     relative  time/iter   iters/s
============================================================================
koskiExpandedOnVeloxIfFloor                               283.95ns     3.52M
koskiExpandedOnVeloxOneHot                                219.04ns     4.57M
koskiExpandedOnVeloxOneHot_OneHotHitting                  216.28ns     4.62M
```

after:
```
============================================================================
[...]lox/benchmarks/DenseProcBenchmark.cpp     relative  time/iter   iters/s
============================================================================
koskiExpandedOnVeloxIfFloor                               266.17ns     3.76M
koskiExpandedOnVeloxOneHot                                190.80ns     5.24M
koskiExpandedOnVeloxOneHot_OneHotHitting                  192.89ns     5.18M
```

Differential Revision: D41660725

