### PR TITLE
Add array_has_duplicates Presto function

### DIFF
--- a/velox/docs/functions/array.rst
+++ b/velox/docs/functions/array.rst
@@ -15,7 +15,7 @@ Array Functions
     Returns a set of elements that occur more than once in array.
     E must be bigint or varchar.
 
-        select array_duplicates(ARRAY [5, 2, 5, 1, 1, 5, null, null])); -- [null, 1, 5]
+        select array_duplicates(ARRAY [5, 2, 5, 1, 1, 5, NULL, NULL])); -- [NULL, 1, 5]
 
 .. function:: array_except(array(E) x, array(E) y) -> array(E)
 
@@ -26,6 +26,17 @@ Array Functions
         SELECT array_except(ARRAY [1, 2, 2], ARRAY [1, 1, 2]); -- []
         SELECT array_except(ARRAY [1, 2, 2], ARRAY [1, 3, 4]); -- [2]
         SELECT array_except(ARRAY [1, NULL, NULL], ARRAY [1, 1, NULL]); -- []
+
+.. function:: array_has_duplicates(array(E)) -> boolean
+
+    Returns a boolean: whether array has any elements that occur more than once.
+    E must be bigint or varchar.
+
+        select array_has_duplicates(ARRAY [1, 2, 2])); -- true
+        select array_has_duplicates(ARRAY [1, 2, 2, NULL])); -- true
+        select array_has_duplicates(ARRAY [1, NULL, NULL])); -- true
+        select array_has_duplicates(ARRAY [1, 2, 3])); -- false
+        select array_has_duplicates(ARRAY [1, 2, NULL])); -- false
 
 .. function:: array_intersect(array(E) x, array(E) y) -> array(E)
 

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -50,6 +50,14 @@ inline void registerArrayCombinationsFunctions() {
       int64_t>({"combinations"});
 }
 
+template <typename T>
+inline void registerArrayHasDuplicatesFunctions() {
+  registerFunction<
+      ParameterBinder<ArrayHasDuplicatesFunction, T>,
+      bool,
+      Array<T>>({"array_has_duplicates"});
+}
+
 void registerArrayFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_constructor, "array_constructor");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_distinct, "array_distinct");
@@ -100,5 +108,8 @@ void registerArrayFunctions() {
   registerArrayCombinationsFunctions<Varchar>();
   registerArrayCombinationsFunctions<Timestamp>();
   registerArrayCombinationsFunctions<Date>();
+
+  registerArrayHasDuplicatesFunctions<int64_t>();
+  registerArrayHasDuplicatesFunctions<Varchar>();
 }
 }; // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/ArrayHasDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayHasDuplicatesTest.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace {
+
+// Class to test the array_has_duplicates operator.
+class ArrayHasDuplicatesTest : public FunctionBaseTest {
+ protected:
+  // Evaluate an expression.
+  void testExpr(
+      const VectorPtr& expected,
+      const std::string& expression,
+      const std::vector<VectorPtr>& input) {
+    auto result = evaluate<FlatVector<bool>>(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+
+  // Execute test for bigint type.
+  void testBigint() {
+    auto array = makeNullableArrayVector<int64_t>({
+        // has no duplicates
+        {},
+        {std::nullopt},
+        {std::nullopt, 1},
+        {1},
+        {1, 2},
+        {1, 2, 3, 4, 5, -1, -2, -3},
+        {std::nullopt,
+         1,
+         std::numeric_limits<int64_t>::min(),
+         std::numeric_limits<int64_t>::max()},
+        // has duplicates
+        {1, 1},
+        {std::nullopt, std::nullopt},
+        {std::nullopt, -1, std::nullopt},
+        {1, std::nullopt, std::nullopt, std::nullopt, 1},
+        {1, -2, -2, 8, -2, 4, -1},
+        {1, -2, -2, 8, -2, 4, 1, 8},
+        {std::numeric_limits<int64_t>::max(),
+         std::numeric_limits<int64_t>::max(),
+         std::nullopt,
+         0},
+    });
+
+    auto expected = makeNullableFlatVector<bool>({
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+    });
+
+    testExpr(expected, "array_has_duplicates(C0)", {array});
+  }
+};
+
+} // namespace
+
+// Test integer arrays.
+TEST_F(ArrayHasDuplicatesTest, integerArrays) {
+  testBigint();
+}
+
+// Test inline (short) strings.
+TEST_F(ArrayHasDuplicatesTest, inlineStringArrays) {
+  using S = StringView;
+
+  auto array = makeNullableArrayVector<StringView>({
+      // has no duplicates
+      {},
+      {S("")},
+      {std::nullopt},
+      {S("a"), S("b")},
+      {S("a"), std::nullopt, S("b")},
+      // has duplicates
+      {S(""), S("")},
+      {S("a"), S("a")},
+      {S("b"), S("a"), S("b"), S("a"), S("a")},
+      {std::nullopt, std::nullopt},
+      {S(""), S(""), S("a")},
+      {std::nullopt, S("a"), std::nullopt},
+      {S("b"), std::nullopt, S("a"), S("a"), std::nullopt, S("b")},
+  });
+
+  auto expected = makeNullableFlatVector<bool>(
+      {false,
+       false,
+       false,
+       false,
+       false,
+       true,
+       true,
+       true,
+       true,
+       true,
+       true,
+       true});
+
+  testExpr(expected, "array_has_duplicates(C0)", {array});
+}
+
+// Test non-inline (> 12 character length) strings.
+TEST_F(ArrayHasDuplicatesTest, stringArrays) {
+  using S = StringView;
+
+  auto array = makeNullableArrayVector<StringView>(
+      {// has no duplicates
+       {S("red shiny car ahead"), S("blue clear sky above")},
+       {S("blue clear sky above"),
+        S("yellow rose flowers"),
+        std::nullopt,
+        S("orange beautiful sunset")},
+       // has duplicates
+       {S("red shiny car ahead"), S("red shiny car ahead")},
+       {S("red"), S("red shiny car ahead"), S{"red"}},
+       {S("red shiny car ahead"), S("red"), S("red shiny car ahead")},
+       {
+           S("red shiny car ahead"),
+           std::nullopt,
+           S("purple is an elegant color"),
+           S("red shiny car ahead"),
+           S("green plants make us happy"),
+           S("purple is an elegant color"),
+           std::nullopt,
+           S("purple is an elegant color"),
+       }});
+
+  auto expected =
+      makeNullableFlatVector<bool>({false, false, true, true, true, true});
+
+  testExpr(expected, "array_has_duplicates(C0)", {array});
+}
+
+TEST_F(ArrayHasDuplicatesTest, nonContiguousRows) {
+  auto c0 = makeFlatVector<int64_t>(4, [](auto row) { return row; });
+  auto c1 = makeArrayVector<int64_t>({
+      {1, 2, 3},
+      {1, 1, 2, 3, 4, 4},
+      {1, 1, 2, 3, 4, 5, 5},
+      {1, 1, 2, 3, 3, 4, 5, 6, 6},
+  });
+
+  auto c2 = makeArrayVector<int64_t>({
+      {0, 0, 1, 1, 2, 3, 3},
+      {0, 0, 1, 1, 2, 3, 4, 4},
+      {0, 0, 1, 1, 2, 3, 4, 5, 5},
+      {0, 1, 2, 3, 4, 5, 6},
+  });
+
+  auto expected = makeFlatVector<bool>({
+      false,
+      true,
+      true,
+      false,
+  });
+
+  auto result = evaluate<FlatVector<bool>>(
+      "if(c0 % 2 = 0, array_has_duplicates(c1), array_has_duplicates(c2))",
+      makeRowVector({c0, c1, c2}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayHasDuplicatesTest, constant) {
+  vector_size_t size = 1'000;
+  auto data = makeArrayVector<int64_t>({{1, 2, 3}, {4, 5, 4, 5}, {6, 6, 6, 6}});
+
+  auto evaluateConstant = [&](vector_size_t row, const VectorPtr& vector) {
+    return evaluate(
+        "array_has_duplicates(c0)",
+        makeRowVector({BaseVector::wrapInConstant(size, row, vector)}));
+  };
+
+  auto result = evaluateConstant(0, data);
+  auto expected = makeConstant<bool>(false, size);
+  assertEqualVectors(expected, result);
+
+  result = evaluateConstant(1, data);
+  expected = makeConstant<bool>(true, size);
+  assertEqualVectors(expected, result);
+
+  result = evaluateConstant(2, data);
+  expected = makeConstant<bool>(true, size);
+  assertEqualVectors(expected, result);
+}

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   ArrayDuplicatesTest.cpp
   ArrayExceptTest.cpp
   ArrayFilterTest.cpp
+  ArrayHasDuplicatesTest.cpp
   ArrayJoinTest.cpp
   ArrayIntersectTest.cpp
   ArrayMaxTest.cpp


### PR DESCRIPTION
## Summary
* Adding the array_has_duplicates Presto function to Velox

`array_has_duplicates(array(T))`

> Returns a boolean: whether array has any elements that occur more than once.
> T must be coercible to bigint or varchar.

For example:
```
select array_has_duplicates(ARRAY [1, 2, 2])); -- true
select array_has_duplicates(ARRAY [1, 2, 2, NULL])); -- true
select array_has_duplicates(ARRAY [1, NULL, NULL])); -- true
select array_has_duplicates(ARRAY [1, 2, 3])); -- false
select array_has_duplicates(ARRAY [1, 2, NULL])); -- false
select array_has_duplicates(ARRAY [true, true])); -- input type error
select array_has_duplicates(ARRAY [NULL, NULL])); -- input type error
select array_has_duplicates(NULL); -- null
```
