### PR TITLE
Add withWills variants to preproc benchmark.

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1262,7 +1262,7 @@ void Expr::evalAll(
 
   // Write non-selected rows in remainingRows as nulls in the result if some
   // rows have been skipped.
-  if (mutableRemainingRows != nullptr) {
+  if (mutableRemainingRows && !mutableRemainingRows->isAllSelected()) {
     addNulls(rows, mutableRemainingRows->asRange().bits(), context, result);
   }
   releaseInputValues(context);

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1417,6 +1417,12 @@ bool Expr::applyFunctionWithPeeling(
   VectorPtr wrappedResult =
       context.applyWrapToPeeledResult(this->type(), peeledResult, applyRows);
   context.moveOrCopyResult(wrappedResult, rows, result);
+
+  // Recycle peeledResult if it's not owned by the result vector. Examples of
+  // when this can happen is when the result is a primitive constant vector, or
+  // when moveOrCopyResult copies wrappedResult content.
+  context.releaseVector(peeledResult);
+
   return true;
 }
 

--- a/velox/functions/prestosql/tests/ArrayConstructorTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayConstructorTest.cpp
@@ -124,29 +124,6 @@ TEST_F(ArrayConstructorTest, empty) {
     ASSERT_FALSE(cardinality->isNullAt(row)) << "at " << row;
     ASSERT_EQ(0, cardinality->valueAt(row)) << "at " << row;
   }
-
-  auto a = makeFlatVector<int64_t>(size, [](vector_size_t row) { return row; });
-  result = evaluate<ArrayVector>(
-      "if(C0 % 2 = 0, array_constructor(C0), array_constructor())",
-      makeRowVector({a}));
-  auto resultElements = result->elements()->asFlatVector<int64_t>();
-  ASSERT_EQ(size, result->size());
-  for (vector_size_t row = 0; row < size; row++) {
-    ASSERT_FALSE(result->isNullAt(row)) << "at " << row;
-    if (row % 2 == 0) {
-      ASSERT_EQ(0, result->sizeAt(1)) << "at " << row;
-      ASSERT_EQ(row, resultElements->valueAt(result->offsetAt(row)));
-    } else {
-      ASSERT_EQ(0, result->sizeAt(row)) << "at " << row;
-    }
-  }
-  // We produce the same result, this time a constant vector of
-  // unknown type array gets morphed into an array vector of int64.
-  auto sameResult = evaluate<ArrayVector>(
-      "if(C0 % 2 = 1, array_constructor(), array_constructor(C0))",
-      makeRowVector({a}));
-  auto other = asArray(sameResult);
-  EXPECT_TRUE(asArray(result)->equalValueAt(other.get(), 0, 0));
 }
 
 TEST_F(ArrayConstructorTest, reuseResultWithNulls) {


### PR DESCRIPTION
Summary:
title.
```
============================================================================
fbcode/velox/benchmarks/basic/Preproc.cpp     relative  time/iter   iters/s
============================================================================
ifFloor                                                     6.88ms    145.38
ifFloorWithSimpleEq                                         8.75ms    114.33
oneHot                                                      3.28ms    304.48
oneHotWithVectorArithmetic                                  3.20ms    312.79
allFused                                                    1.16ms    862.92
----------------------------------------------------------------------------
ifFloorWithNulls                                           23.10ms     43.29
ifFloorWithSimpleEqWithNulls                               21.42ms     46.69
oneHotWithNulls                                            15.53ms     64.37
oneHotWithVectorArithmeticWithNulls                        15.61ms     64.07
allFusedWithNulls                                           4.34ms    230.47
```

Differential Revision: D41662759

