### PR TITLE
Add hmac_sha256 Presto Functions

### DIFF
--- a/velox/docs/functions/binary.rst
+++ b/velox/docs/functions/binary.rst
@@ -22,6 +22,10 @@ Binary Functions
 
     Computes the SHA-512 hash of ``binary``.
 
+.. function:: hmac_sha256(binary, key) -> varbinary
+
+    Computes the HMAC with sha256 of ``binary`` with the given ``key``.
+
 .. function:: to_base64(binary) -> varchar
 
     Encodes ``binary`` into a base64 string representation.

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -288,6 +288,18 @@ FOLLY_ALWAYS_INLINE void sha512(TOutString& output, const TInString& input) {
       folly::ByteRange((const uint8_t*)input.data(), input.size()));
 }
 
+// Compute the HMAC-SHA256 Hash.
+template <typename TOutString, typename TInString>
+FOLLY_ALWAYS_INLINE bool
+HmacSha256(TOutString& output, const TInString& key, const TInString& data) {
+  output.resize(32);
+  folly::ssl::OpenSSLHash::hmac_sha256(
+      folly::MutableByteRange((uint8_t*)output.data(), output.size()),
+      folly::ByteRange((const uint8_t*)key.data(), key.size()),
+      folly::ByteRange((const uint8_t*)data.data(), data.size()));
+  return true;
+}
+
 template <typename TOutString, typename TInString>
 FOLLY_ALWAYS_INLINE bool toHex(TOutString& output, const TInString& input) {
   static const char* const kHexTable =

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -120,6 +120,18 @@ struct Sha512Function {
   }
 };
 
+/// sha1(varbinary) -> varbinary
+template <typename T>
+struct HmacSha256Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TOuput, typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TOuput& result, const TInput& data, const TInput& key) {
+    return stringImpl::HmacSha256(result, key, data);
+  }
+};
+
 template <typename T>
 struct ToHexFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -60,6 +60,8 @@ void registerSimpleFunctions() {
   registerFunction<Md5Function, Varbinary, Varbinary>({"md5"});
   registerFunction<Sha256Function, Varbinary, Varbinary>({"sha256"});
   registerFunction<Sha512Function, Varbinary, Varbinary>({"sha512"});
+  registerFunction<HmacSha256Function, Varbinary, Varbinary, Varbinary>(
+      {"hmac_sha256"});
 
   registerFunction<ToHexFunction, Varchar, Varbinary>({"to_hex"});
   registerFunction<FromHexFunction, Varbinary, Varchar>({"from_hex"});

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1201,6 +1201,37 @@ TEST_F(StringFunctionsTest, sha512) {
   EXPECT_EQ(std::nullopt, sha512(std::nullopt));
 }
 
+TEST_F(StringFunctionsTest, HmacSha256) {
+  const auto hmacSha256 = [&](std::optional<std::string> arg,
+                              std::optional<std::string> key) {
+    return evaluateOnce<std::string, std::string>(
+        "hmac_sha256(c0, c1)", {arg, key}, {VARBINARY(), VARBINARY()});
+  };
+  // Use python hmac lib results as the expected value.
+  // >>> import hmac
+  // >>> def sha256(data, key):
+  //         print(hmac.new(key, data, digestmod='sha256').hexdigest())
+  // >>> sha256(b"hashme", b"velox")
+  // 24bb7fa25fd592ef6a4c939d4fb91b7f7f04f8813260961101117ec30f865794
+  // >>> sha256(b"Infinity", b"velox")
+  // f45718c9586ae7d761194485d15cbf6284b5b606ade4f9d5820fbdd1eaf52b75
+  // >>> sha256(b"", b"velox")
+  // fd8658b6a6b6601155fecf9a39b6f95cf030863e550073423a8e250a35c6f5a4
+  EXPECT_EQ(
+      hexToDec(
+          "24bb7fa25fd592ef6a4c939d4fb91b7f7f04f8813260961101117ec30f865794"),
+      hmacSha256("hashme", "velox"));
+  EXPECT_EQ(
+      hexToDec(
+          "f45718c9586ae7d761194485d15cbf6284b5b606ade4f9d5820fbdd1eaf52b75"),
+      hmacSha256("Infinity", "velox"));
+  EXPECT_EQ(
+      hexToDec(
+          "fd8658b6a6b6601155fecf9a39b6f95cf030863e550073423a8e250a35c6f5a4"),
+      hmacSha256("", "velox"));
+  EXPECT_EQ(std::nullopt, hmacSha256(std::nullopt, "velox"));
+}
+
 void StringFunctionsTest::testReplaceInPlace(
     const std::vector<std::pair<std::string, std::string>>& tests,
     const std::string& search,


### PR DESCRIPTION
Add [hmac_sha256](https://prestodb.io/docs/current/functions/binary.html#:~:text=hmac_sha256(binary,%23)) Presto Functions
```
hmac_sha256(binary, key) → varbinary
     Computes HMAC with sha256 of binary with the given key.
```