### PR TITLE
Properly rename config members.

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -19,9 +19,12 @@
 
 namespace facebook::velox::core {
 
+/// A simple wrapper around BaseConfigManager. Defines constants for query
+/// config properties and accessor methods.
 class QueryConfig {
  public:
-  explicit QueryConfig(BaseConfigManager* config) : config_{config} {}
+  explicit QueryConfig(BaseConfigManager* configManager)
+      : configManager_{configManager} {}
 
   static constexpr const char* kCodegenEnabled = "driver.codegen.enabled";
 
@@ -360,14 +363,14 @@ class QueryConfig {
 
   template <typename T>
   T get(const std::string& key, const T& defaultValue) const {
-    return config_->get<T>(key, defaultValue);
+    return configManager_->get<T>(key, defaultValue);
   }
   template <typename T>
   std::optional<T> get(const std::string& key) const {
-    return std::optional<T>(config_->get<T>(key));
+    return std::optional<T>(configManager_->get<T>(key));
   }
 
  private:
-  BaseConfigManager* config_;
+  BaseConfigManager* FOLLY_NONNULL configManager_;
 };
 } // namespace facebook::velox::core

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -50,7 +50,7 @@ class QueryCtx : public Context {
         allocator_(allocator),
         connectorConfigs_(connectorConfigs),
         executor_(executor),
-        config_{this},
+        queryConfig_{this},
         queryId_(queryId),
         spillExecutor_(std::move(spillExecutor)) {
     setConfigOverrides(config);
@@ -63,7 +63,7 @@ class QueryCtx : public Context {
   // object is alive.
   //
   // This constructor does not keep the ownership of executor.
-  QueryCtx(
+  explicit QueryCtx(
       folly::Executor::KeepAlive<> executorKeepalive,
       std::shared_ptr<Config> config = std::make_shared<MemConfig>(),
       std::unordered_map<std::string, std::shared_ptr<Config>>
@@ -77,7 +77,7 @@ class QueryCtx : public Context {
         allocator_(allocator),
         connectorConfigs_(connectorConfigs),
         executorKeepalive_(std::move(executorKeepalive)),
-        config_{this},
+        queryConfig_{this},
         queryId_(queryId) {
     setConfigOverrides(config);
     if (!pool_) {
@@ -106,8 +106,8 @@ class QueryCtx : public Context {
     return executor;
   }
 
-  const QueryConfig& config() const {
-    return config_;
+  const QueryConfig& queryConfig() const {
+    return queryConfig_;
   }
 
   Config* FOLLY_NONNULL
@@ -155,7 +155,7 @@ class QueryCtx : public Context {
   std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs_;
   folly::Executor* FOLLY_NULLABLE executor_;
   folly::Executor::KeepAlive<> executorKeepalive_;
-  QueryConfig config_;
+  QueryConfig queryConfig_;
   const std::string queryId_;
   std::shared_ptr<folly::Executor> spillExecutor_;
 };

--- a/velox/core/tests/TestQueryConfig.cpp
+++ b/velox/core/tests/TestQueryConfig.cpp
@@ -27,7 +27,7 @@ TEST(TestQueryConfig, emptyConfig) {
   std::unordered_map<std::string, std::string> configData;
   auto queryCtxConfig = std::make_shared<MemConfig>(configData);
   auto queryCtx = std::make_shared<QueryCtx>(nullptr, queryCtxConfig);
-  const QueryConfig& config = queryCtx->config();
+  const QueryConfig& config = queryCtx->queryConfig();
 
   ASSERT_FALSE(config.codegenEnabled());
   ASSERT_EQ(config.codegenConfigurationFilePath(), "");
@@ -41,7 +41,7 @@ TEST(TestQueryConfig, setConfig) {
        {QueryConfig::kCodegenConfigurationFilePath, path}});
   auto queryCtxConfig = std::make_shared<MemConfig>(configData);
   auto queryCtx = std::make_shared<QueryCtx>(nullptr, queryCtxConfig);
-  const QueryConfig& config = queryCtx->config();
+  const QueryConfig& config = queryCtx->queryConfig();
 
   ASSERT_TRUE(config.codegenEnabled());
   ASSERT_EQ(config.codegenConfigurationFilePath(), path);

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -38,7 +38,7 @@ DriverCtx::DriverCtx(
       task(_task) {}
 
 const core::QueryConfig& DriverCtx::queryConfig() const {
-  return task->queryCtx()->config();
+  return task->queryCtx()->queryConfig();
 }
 
 velox::memory::MemoryPool* FOLLY_NONNULL DriverCtx::addOperatorPool(

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -68,8 +68,10 @@ GroupingSet::GroupingSet(
       spillConfig_(spillConfig),
       stringAllocator_(allocator_),
       rows_(allocator_),
-      isAdaptive_(
-          operatorCtx->task()->queryCtx()->config().hashAdaptivityEnabled()),
+      isAdaptive_(operatorCtx->task()
+                      ->queryCtx()
+                      ->queryConfig()
+                      .hashAdaptivityEnabled()),
       pool_(*operatorCtx->pool()) {
   for (auto& hasher : hashers_) {
     keyChannels_.push_back(hasher->channel());

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -92,7 +92,7 @@ OperatorCtx::createConnectorQueryCtx(
 
 std::optional<Spiller::Config> OperatorCtx::makeSpillConfig(
     Spiller::Type type) const {
-  const auto& queryConfig = driverCtx_->task->queryCtx()->config();
+  const auto& queryConfig = driverCtx_->task->queryCtx()->queryConfig();
   if (!queryConfig.spillEnabled()) {
     return std::nullopt;
   }

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -90,7 +90,10 @@ OrderBy::OrderBy(
 #endif
 
   outputBatchSize_ = std::max<uint32_t>(
-      operatorCtx_->execCtx()->queryCtx()->config().preferredOutputBatchSize(),
+      operatorCtx_->execCtx()
+          ->queryCtx()
+          ->queryConfig()
+          .preferredOutputBatchSize(),
       data_->estimatedNumRowsPerBatch(kBatchSizeInBytes));
 }
 

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -129,33 +129,7 @@ class PartitionedOutput : public Operator {
   PartitionedOutput(
       int32_t operatorId,
       DriverCtx* FOLLY_NONNULL ctx,
-      const std::shared_ptr<const core::PartitionedOutputNode>& planNode)
-      : Operator(
-            ctx,
-            planNode->outputType(),
-            operatorId,
-            planNode->id(),
-            "PartitionedOutput"),
-        keyChannels_(toChannels(planNode->inputType(), planNode->keys())),
-        numDestinations_(planNode->numPartitions()),
-        replicateNullsAndAny_(planNode->isReplicateNullsAndAny()),
-        partitionFunction_(
-            numDestinations_ == 1
-                ? nullptr
-                : planNode->partitionFunctionFactory()(numDestinations_)),
-        outputChannels_(calculateOutputChannels(
-            planNode->inputType(),
-            planNode->outputType(),
-            planNode->outputType())),
-        bufferManager_(PartitionedOutputBufferManager::getInstance()),
-        maxBufferedBytes_(
-            ctx->task->queryCtx()->config().maxPartitionedOutputBufferSize()),
-        allocator_{operatorCtx_->allocator()} {
-    if (numDestinations_ == 1 || planNode->isBroadcast()) {
-      VELOX_CHECK(keyChannels_.empty());
-      VELOX_CHECK_NULL(partitionFunction_);
-    }
-  }
+      const std::shared_ptr<const core::PartitionedOutputNode>& planNode);
 
   void addInput(RowVectorPtr input) override;
 

--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -154,7 +154,8 @@ PartitionedOutputBuffer::PartitionedOutputBuffer(
     : task_(std::move(task)),
       broadcast_(broadcast),
       numDrivers_(numDrivers),
-      maxSize_(task_->queryCtx()->config().maxPartitionedOutputBufferSize()),
+      maxSize_(
+          task_->queryCtx()->queryConfig().maxPartitionedOutputBufferSize()),
       continueSize_((maxSize_ * kContinuePct) / 100) {
   buffers_.reserve(numDestinations);
   for (int i = 0; i < numDestinations; i++) {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -351,7 +351,7 @@ void Task::start(
   }
 
 #if CODEGEN_ENABLED == 1
-  const auto& config = self->queryCtx()->config();
+  const auto& config = self->queryCtx()->queryConfig();
   if (config.codegenEnabled() &&
       config.codegenConfigurationFilePath().length() != 0) {
     auto codegenLogger =
@@ -427,7 +427,7 @@ void Task::start(
       // buffer size of the producers.
       self->exchangeClients_[pipeline] = std::make_shared<ExchangeClient>(
           self->destination_,
-          self->queryCtx()->config().maxPartitionedOutputBufferSize() / 2);
+          self->queryCtx()->queryConfig().maxPartitionedOutputBufferSize() / 2);
 
       self->exchangeClientByPlanNode_.emplace(
           exchangeNodeId.value(), self->exchangeClients_[pipeline]);
@@ -1582,7 +1582,7 @@ void Task::createLocalExchangeQueuesLocked(
   //  in all split groups?
   LocalExchangeState exchange;
   exchange.memoryManager = std::make_shared<LocalExchangeMemoryManager>(
-      queryCtx_->config().maxLocalExchangeBufferSize());
+      queryCtx_->queryConfig().maxLocalExchangeBufferSize());
 
   exchange.queues.reserve(numPartitions);
   for (auto i = 0; i < numPartitions; ++i) {

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -151,7 +151,7 @@ void CastExpr::applyCastWithTry(
     exec::EvalCtx& context,
     const BaseVector& input,
     FlatVector<To>* resultFlatVector) {
-  const auto& queryConfig = context.execCtx()->queryCtx()->config();
+  const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
   auto isCastIntByTruncate = queryConfig.isCastIntByTruncate();
 
   if (!nullOnFailure_) {
@@ -441,7 +441,7 @@ VectorPtr CastExpr::applyRow(
   // Extract the flag indicating matching of children must be done by name or
   // position
   auto matchByName =
-      context.execCtx()->queryCtx()->config().isMatchStructByName();
+      context.execCtx()->queryCtx()->queryConfig().isMatchStructByName();
 
   // Cast each row child to its corresponding output child
   std::vector<VectorPtr> newChildren;

--- a/velox/expression/ConjunctExpr.cpp
+++ b/velox/expression/ConjunctExpr.cpp
@@ -161,7 +161,7 @@ void ConjunctExpr::evalSpecialForm(
   if (!reorderEnabledChecked_) {
     reorderEnabled_ = context.execCtx()
                           ->queryCtx()
-                          ->config()
+                          ->queryConfig()
                           .adaptiveFilterReorderingEnabled();
     reorderEnabledChecked_ = true;
   }

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1703,7 +1703,7 @@ void ExprSetSimplified::eval(
 std::unique_ptr<ExprSet> makeExprSetFromFlag(
     std::vector<core::TypedExprPtr>&& source,
     core::ExecCtx* execCtx) {
-  if (execCtx->queryCtx()->config().exprEvalSimplified() ||
+  if (execCtx->queryCtx()->queryConfig().exprEvalSimplified() ||
       FLAGS_force_eval_simplified) {
     return std::make_unique<ExprSetSimplified>(std::move(source), execCtx);
   }

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -529,7 +529,7 @@ std::vector<std::shared_ptr<Expr>> compileExpressions(
     exprs.push_back(compileExpression(
         source,
         &scope,
-        execCtx->queryCtx()->config(),
+        execCtx->queryCtx()->queryConfig(),
         execCtx->pool(),
         flatteningCandidates,
         enableConstantFolding));

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -935,10 +935,11 @@ VectorPtr testVariadicArgReuse(
   // This is a bit of a round about way of creating the SimpleFunctionAdapter,
   // especially since it requires the caller to register the function as well,
   // but it should be easier to maintain.
-  auto function = exec::SimpleFunctions()
-                      .resolveFunction(functionName, {})
-                      ->createFunction()
-                      ->createVectorFunction(execCtx->queryCtx()->config(), {});
+  auto function =
+      exec::SimpleFunctions()
+          .resolveFunction(functionName, {})
+          ->createFunction()
+          ->createVectorFunction(execCtx->queryCtx()->queryConfig(), {});
 
   // Create a dummy EvalCtx.
   SelectivityVector rows(inputs[0]->size());

--- a/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
@@ -57,7 +57,7 @@ class HourFunction : public exec::VectorFunction {
     // Check if we need to adjust the current UTC timestamps to
     // the user provided session timezone.
     const auto* timeZone =
-        getTimeZoneIfNeeded(context.execCtx()->queryCtx()->config());
+        getTimeZoneIfNeeded(context.execCtx()->queryCtx()->queryConfig());
     if (timeZone != nullptr) {
       rows.applyToSelected([&](int row) {
         auto timestamp = timestamps[row];


### PR DESCRIPTION
Summary:
The config members are quite confusing, renaming them makes
it easier to understand.

Differential Revision: D41708793

