### PR TITLE
Add large chunk memory allocations support for memory pool

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -141,6 +141,7 @@ class AsyncDataCacheEntry {
   static constexpr int32_t kTinyDataSize = 2048;
 
   explicit AsyncDataCacheEntry(CacheShard* FOLLY_NONNULL shard);
+  ~AsyncDataCacheEntry();
 
   // Sets the key and allocates the entry's memory.  Resets
   //  all other state. The entry must be held exclusively and must
@@ -503,8 +504,6 @@ struct CacheStats {
 // and other housekeeping.
 class CacheShard {
  public:
-  static constexpr int32_t kCacheOwner = -4;
-
   explicit CacheShard(AsyncDataCache* FOLLY_NONNULL cache) : cache_(cache) {}
 
   // See AsyncDataCache::findOrCreate.
@@ -564,6 +563,9 @@ class CacheShard {
   CachePin initEntry(
       RawFileCacheKey key,
       AsyncDataCacheEntry* FOLLY_NONNULL entry);
+
+  void freeAllocations(
+      std::vector<memory::MemoryAllocator::Allocation>& allocations);
 
   mutable std::mutex mutex_;
   folly::F14FastMap<RawFileCacheKey, AsyncDataCacheEntry * FOLLY_NONNULL>
@@ -629,9 +631,8 @@ class AsyncDataCache : public memory::MemoryAllocator {
 
   bool allocateNonContiguous(
       memory::MachinePageCount numPages,
-      int32_t owner,
       Allocation& out,
-      std::function<void(int64_t, bool)> beforeAllocCB = nullptr,
+      ReservationCallback reservationCB = nullptr,
       memory::MachinePageCount minSizeClass = 0) override;
 
   int64_t freeNonContiguous(Allocation& allocation) override {
@@ -642,7 +643,7 @@ class AsyncDataCache : public memory::MemoryAllocator {
       memory::MachinePageCount numPages,
       Allocation* FOLLY_NULLABLE collateral,
       ContiguousAllocation& allocation,
-      std::function<void(int64_t, bool)> beforeAllocCB = nullptr) override;
+      ReservationCallback reservationCB = nullptr) override;
 
   void freeContiguous(ContiguousAllocation& allocation) override {
     allocator_->freeContiguous(allocation);

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -425,7 +425,7 @@ void SsdFile::verifyWrite(AsyncDataCacheEntry& entry, SsdRun ssdRun) {
 
 void SsdFile::updateStats(SsdCacheStats& stats) const {
   // Lock only in tsan build. Incrementing the counters has no synchronized
-  // emantics.
+  // semantics.
   tsan_lock_guard<std::mutex> l(mutex_);
   stats.entriesWritten += stats_.entriesWritten;
   stats.bytesWritten += stats_.bytesWritten;

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -120,7 +120,7 @@ class SsdPin {
 
 // Metrics for SSD cache. Maintained by SsdFile and aggregated by SsdCache.
 struct SsdCacheStats {
-  SsdCacheStats() {}
+  SsdCacheStats() = default;
 
   SsdCacheStats(const SsdCacheStats& other) {
     *this = other;

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -43,6 +43,28 @@ struct Request {
 };
 
 class AsyncDataCacheTest : public testing::Test {
+ public:
+  // Deterministically fills 'allocation'  based on 'sequence'
+  static void initializeContents(
+      int64_t sequence,
+      MemoryAllocator::Allocation& alloc) {
+    bool first = true;
+    for (int32_t i = 0; i < alloc.numRuns(); ++i) {
+      MemoryAllocator::PageRun run = alloc.runAt(i);
+      int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
+      int32_t numWords =
+          run.numPages() * MemoryAllocator::kPageSize / sizeof(void*);
+      for (int32_t offset = 0; offset < numWords; offset++) {
+        if (first) {
+          ptr[offset] = sequence;
+          first = false;
+        } else {
+          ptr[offset] = offset + sequence;
+        }
+      }
+    }
+  }
+
  protected:
   static constexpr int32_t kNumFiles = 100;
 
@@ -133,28 +155,6 @@ class AsyncDataCacheTest : public testing::Test {
     }
   }
 
- public:
-  // Deterministically fills 'allocation'  based on 'sequence'
-  static void initializeContents(
-      int64_t sequence,
-      MemoryAllocator::Allocation& alloc) {
-    bool first = true;
-    for (int32_t i = 0; i < alloc.numRuns(); ++i) {
-      MemoryAllocator::PageRun run = alloc.runAt(i);
-      int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
-      int32_t numWords =
-          run.numPages() * MemoryAllocator::kPageSize / sizeof(void*);
-      for (int32_t offset = 0; offset < numWords; offset++) {
-        if (first) {
-          ptr[offset] = sequence;
-          first = false;
-        } else {
-          ptr[offset] = offset + sequence;
-        }
-      }
-    }
-  }
-
   // Checks that the contents are consistent with what is set in
   // initializeContents.
   static void checkContents(const AsyncDataCacheEntry& entry) {
@@ -201,7 +201,6 @@ class AsyncDataCacheTest : public testing::Test {
     };
   }
 
- protected:
   folly::IOThreadPoolExecutor* FOLLY_NONNULL executor() {
     static std::mutex mutex;
     std::lock_guard<std::mutex> l(mutex);
@@ -211,6 +210,13 @@ class AsyncDataCacheTest : public testing::Test {
       executor_ = std::make_unique<folly::IOThreadPoolExecutor>(20);
     }
     return executor_.get();
+  }
+
+  void clearAllocations(std::deque<MemoryAllocator::Allocation>& allocations) {
+    while (!allocations.empty()) {
+      cache_->freeNonContiguous(allocations.front());
+      allocations.pop_front();
+    }
   }
 
   std::shared_ptr<exec::test::TempDirectoryPath> tempDirectory_;
@@ -562,18 +568,17 @@ TEST_F(AsyncDataCacheTest, outOfCapacity) {
     }
     pins.pop_front();
   }
-  MemoryAllocator::Allocation allocation(cache_.get());
-  EXPECT_FALSE(cache_->allocateNonContiguous(kSizeInPages, 0, allocation));
+  MemoryAllocator::Allocation allocation;
+  ASSERT_FALSE(cache_->allocateNonContiguous(kSizeInPages, allocation));
   // One 4 page entry below the max size of 4K 4 page entries in 16MB of
   // capacity.
-  EXPECT_EQ(4092, cache_->incrementCachedPages(0));
-  EXPECT_EQ(4092, cache_->incrementPrefetchPages(0));
+  ASSERT_EQ(4092, cache_->incrementCachedPages(0));
+  ASSERT_EQ(4092, cache_->incrementPrefetchPages(0));
   pins.clear();
 
   // We allocate the full capacity and expect the cache entries to go.
   for (;;) {
-    MemoryAllocator::Allocation(cache_.get());
-    if (!cache_->allocateNonContiguous(kSizeInPages, 0, allocation)) {
+    if (!cache_->allocateNonContiguous(kSizeInPages, allocation)) {
       break;
     }
     allocations.push_back(std::move(allocation));
@@ -581,6 +586,7 @@ TEST_F(AsyncDataCacheTest, outOfCapacity) {
   EXPECT_EQ(0, cache_->incrementCachedPages(0));
   EXPECT_EQ(0, cache_->incrementPrefetchPages(0));
   EXPECT_EQ(4092, cache_->numAllocated());
+  clearAllocations(allocations);
 }
 
 namespace {

--- a/velox/common/hyperloglog/tests/DenseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/DenseHllTest.cpp
@@ -100,7 +100,8 @@ class DenseHllTest : public ::testing::TestWithParam<int8_t> {
         expected.cardinality());
   }
 
-  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  HashStringAllocator allocator_{pool_.get()};
 };
 
 TEST_P(DenseHllTest, basic) {

--- a/velox/common/hyperloglog/tests/SparseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/SparseHllTest.cpp
@@ -98,7 +98,8 @@ class SparseHllTest : public ::testing::Test {
     return serialized;
   }
 
-  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  HashStringAllocator allocator_{pool_.get()};
 };
 
 TEST_F(SparseHllTest, basic) {
@@ -173,7 +174,8 @@ class SparseHllToDenseTest : public ::testing::TestWithParam<int8_t> {
     return serialized;
   }
 
-  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  HashStringAllocator allocator_{pool_.get()};
 };
 
 TEST_P(SparseHllToDenseTest, toDense) {

--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -22,10 +22,10 @@
 namespace facebook::velox {
 
 void AllocationPool::clear() {
-  // Trigger Allocation's destructor to free allocated memory
-  auto copy = std::move(allocation_);
+  // Trigger Allocation's destructor to free allocated memory.
+  auto allocationToClear = std::move(allocation_);
   allocations_.clear();
-  auto copyLarge = std::move(largeAllocations_);
+  auto largeAllocationToClear = std::move(largeAllocations_);
   largeAllocations_.clear();
 }
 
@@ -36,11 +36,10 @@ char* AllocationPool::allocateFixed(uint64_t bytes) {
       memory::MemoryAllocator::kPageSize;
 
   // Use contiguous allocations from mapped memory if allocation size is large
-  if (numPages > allocator_->largestSizeClass()) {
+  if (numPages > pool_->largestSizeClass()) {
     auto largeAlloc =
         std::make_unique<memory::MemoryAllocator::ContiguousAllocation>();
-    largeAlloc->reset(allocator_, nullptr, 0);
-    if (!allocator_->allocateContiguous(numPages, nullptr, *largeAlloc)) {
+    if (!pool_->allocateContiguous(numPages, *largeAlloc)) {
       throw std::bad_alloc();
     }
     largeAllocations_.emplace_back(std::move(largeAlloc));
@@ -68,12 +67,8 @@ void AllocationPool::newRunImpl(memory::MachinePageCount numPages) {
           std::make_unique<memory::MemoryAllocator::Allocation>(
               std::move(allocation_)));
     }
-    if (!allocator_->allocateNonContiguous(
-            std::max<int32_t>(kMinPages, numPages),
-            owner_,
-            allocation_,
-            nullptr,
-            numPages)) {
+    if (!pool_->allocateNonContiguous(
+            std::max<int32_t>(kMinPages, numPages), allocation_, numPages)) {
       throw std::bad_alloc();
     }
     currentRun_ = 0;

--- a/velox/common/memory/AllocationPool.h
+++ b/velox/common/memory/AllocationPool.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "velox/common/memory/MemoryAllocator.h"
+#include "velox/common/memory/Memory.h"
 
 namespace facebook::velox {
 // A set of MappedMemory::Allocations holding the fixed width payload
@@ -27,13 +27,10 @@ namespace facebook::velox {
 // started.
 class AllocationPool {
  public:
-  static constexpr int32_t kHashTableOwner = -3;
   static constexpr int32_t kMinPages = 16;
 
-  explicit AllocationPool(
-      memory::MemoryAllocator* FOLLY_NONNULL allocator,
-      int32_t owner = kHashTableOwner)
-      : allocator_(allocator), allocation_(allocator), owner_(owner) {}
+  explicit AllocationPool(memory::MemoryPool* FOLLY_NONNULL pool)
+      : pool_(pool) {}
 
   ~AllocationPool() = default;
 
@@ -111,8 +108,8 @@ class AllocationPool {
     currentOffset_ = offset;
   }
 
-  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
-    return allocator_;
+  memory::MemoryPool* FOLLY_NONNULL pool() const {
+    return pool_;
   }
 
  private:
@@ -122,7 +119,7 @@ class AllocationPool {
 
   void newRunImpl(memory::MachinePageCount numPages);
 
-  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
+  memory::MemoryPool* FOLLY_NONNULL pool_;
   std::vector<std::unique_ptr<memory::MemoryAllocator::Allocation>>
       allocations_;
   std::vector<std::unique_ptr<memory::MemoryAllocator::ContiguousAllocation>>
@@ -130,7 +127,6 @@ class AllocationPool {
   memory::MemoryAllocator::Allocation allocation_;
   int32_t currentRun_ = 0;
   int32_t currentOffset_ = 0;
-  const int32_t owner_;
 };
 
 } // namespace facebook::velox

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -401,11 +401,11 @@ inline Date ByteStream::read<Date>() {
 class IOBufOutputStream : public OutputStream {
  public:
   explicit IOBufOutputStream(
-      memory::MemoryAllocator& allocator,
+      memory::MemoryPool& pool,
       OutputStreamListener* listener = nullptr,
       int32_t initialSize = memory::MemoryAllocator::kPageSize)
       : OutputStream(listener),
-        arena_(std::make_shared<StreamArena>(&allocator)),
+        arena_(std::make_shared<StreamArena>(&pool)),
         out_(std::make_unique<ByteStream>(arena_.get())) {
     out_->startWrite(initialSize);
   }

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -19,6 +19,7 @@
 #include "velox/common/memory/AllocationPool.h"
 #include "velox/common/memory/ByteStream.h"
 #include "velox/common/memory/CompactDoubleList.h"
+#include "velox/common/memory/Memory.h"
 #include "velox/common/memory/StreamArena.h"
 #include "velox/type/StringView.h"
 
@@ -130,10 +131,8 @@ class HashStringAllocator : public StreamArena {
     char* FOLLY_NULLABLE position;
   };
 
-  explicit HashStringAllocator(
-      memory::MemoryAllocator* FOLLY_NONNULL mappedMemory)
-      : StreamArena(mappedMemory),
-        pool_(mappedMemory, AllocationPool::kHashTableOwner) {}
+  explicit HashStringAllocator(memory::MemoryPool* FOLLY_NONNULL pool)
+      : StreamArena(pool), pool_(pool) {}
 
   // Copies a StringView at 'offset' in 'group' to storage owned by
   // the hash table. Updates the StringView.
@@ -271,8 +270,8 @@ class HashStringAllocator : public StreamArena {
     pool_.clear();
   }
 
-  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
-    return pool_.allocator();
+  memory::MemoryPool* FOLLY_NONNULL pool() const {
+    return pool_.pool();
   }
 
   uint64_t cumulativeBytes() const {

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -45,63 +45,43 @@ DECLARE_int32(memory_usage_aggregation_interval_millis);
 namespace facebook {
 namespace velox {
 namespace memory {
-#define VELOX_MEM_MANAGER_CAP_EXCEEDED(cap)                         \
-  _VELOX_THROW(                                                     \
-      ::facebook::velox::VeloxRuntimeError,                         \
-      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
-      ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
-      /* isRetriable */ true,                                       \
-      "Exceeded memory manager cap of {} MB",                       \
-      (cap) / 1024 / 1024);
 
-#define VELOX_MEM_MANUAL_CAP()                                      \
-  _VELOX_THROW(                                                     \
-      ::facebook::velox::VeloxRuntimeError,                         \
-      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
-      ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
-      /* isRetriable */ true,                                       \
-      "Memory allocation manually capped");
-
-/// This class provides the memory allocation interfaces for a query execution.
-/// Each query execution entity creates a dedicated memory pool object. The
-/// memory pool objects from a query are organized as a tree with four levels
-/// which reflects the query's physical execution plan:
+/// This class provides the memory allocation interfaces for query execution.
+/// Each query execution creates a dedicated memory pool object. The memory pool
+/// objects from a query are organized as a tree with four levels which mirrors
+/// the query's physical execution plan:
 ///
 /// The top level is a single root pool object (query pool) associated with the
 /// query. The query pool is created on the first executed query task and owned
-/// by QueryCtx. Note that the query pool is optional as not all the engines
+/// by QueryCtx. Note that the query pool is optional as not all engines
 /// using memory pool are creating multiple tasks for the same query in the same
 /// process.
 ///
 /// The second level is a number of intermediate pool objects (task pool) with
 /// one per each query task. The query pool is the parent of all the task pools
-/// from the same query. The task pool is created by the query task and owned by
+/// of the same query. The task pool is created by the query task and owned by
 /// Task.
 ///
 /// The third level is a number of intermediate pool objects (node pool) with
 /// one per each query plan node. The task pool is the parent of all the node
 /// pools from the task's physical query plan fragment. The node pool is created
-/// by the first instantiated operator. It is owned by Task in 'childPools_' to
-/// enable the memory sharing within a query task without copy.
+/// by the first operator instantiated for the corresponding plan node. It is
+/// owned by Task via 'childPools_'
 ///
-/// The bottom level is a number of leaf pool objects (operator pool) with one
-/// per with each instantiated query operator. Each node pool is the parent of
-/// all the operators instantiated from associated query plan node with one per
-/// each driver. For instance, if the pipeline of a query plan node N has M
-/// drivers in par, then N node pool has M child operator pools. The operator
-/// pool is created by the operator. It is also owned by Task in 'childPools_'
-/// to enable the memory sharing within a query task without copy.
+/// The bottom level consists of per-operator pools. These are children of the
+/// node pool that corresponds to the plan node from which the operator is
+/// created. Operator and node pools are owned by the Task via 'childPools_'.
 ///
 /// The query pool is created from IMemoryManager::getChild() as a child of a
 /// singleton root pool object (system pool). There is only one system pool for
-/// a velox runtime system. Hence each query pool objects forms a subtree rooted
-/// from the system pool.
+/// a velox process. Hence each query pool objects forms a subtree rooted from
+/// the system pool.
 ///
-/// Each child pool object holds a shared reference on its parent pool object.
+/// Each child pool object holds a shared reference to its parent pool object.
 /// The parent object tracks its child pool objects through the raw pool object
-/// pointer with lock protected. The child pool object destruction first removes
-/// its raw pointer from its parent through dropChild() and then drops the
-/// shared reference on the parent.
+/// pointer protected by a mutex. The child pool object destruction first
+/// removes its raw pointer from its parent through dropChild() and then drops
+/// the shared reference on the parent.
 ///
 /// NOTE: for the users that integrate at expression evaluation level, we don't
 /// need to build the memory pool hierarchy as described above. Users can either
@@ -111,18 +91,15 @@ namespace memory {
 /// enforcement.
 ///
 /// In addition to providing memory allocation functions, the memory pool object
-/// also provides the memory usage counting through MemoryUsageTracker which
-/// will be merged into memory pool object implementation later.
-///
-/// TODO: extend to provide contiguous and non-contiguous large chunk memory
-/// allocation and remove ScopedMappedMemory.
+/// also provides memory usage accounting through MemoryUsageTracker. This will
+/// be merged into memory pool object later.
 class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
  public:
   /// Constructs a named memory pool with specified 'parent'.
   MemoryPool(const std::string& name, std::shared_ptr<MemoryPool> parent);
 
-  /// Removes this memory pool's tracking from its parent through dropChild()
-  /// as well as drops the shared reference on its parent.
+  /// Removes this memory pool's tracking from its parent through dropChild().
+  /// Drops the shared reference to its parent.
   virtual ~MemoryPool();
 
   /// Tree methods used to access and manage the memory hierarchy.
@@ -151,23 +128,54 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
       const std::string& name,
       int64_t cap = kMaxMemory);
 
-  /// Invoked to allocate a buffer with specified 'size'.
+  /// Allocates a buffer with specified 'size'.
   virtual void* FOLLY_NULLABLE allocate(int64_t size) = 0;
 
-  /// Invoked to allocate a zero-filled buffer with capacity that can store
-  /// 'numEntries' entries with each size of 'sizeEach'.
+  /// Allocates a zero-filled buffer with capacity that can store 'numEntries'
+  /// entries with each size of 'sizeEach'.
   virtual void* FOLLY_NULLABLE
   allocateZeroFilled(int64_t numEntries, int64_t sizeEach) = 0;
 
-  /// Invoked to re-allocate from an existing buffer with 'newSize' and update
-  /// memory usage counting accordingly. If 'newSize' is larger than the current
-  /// buffer 'size', the function will allocate a new buffer and free the old
-  /// buffer.
+  /// Re-allocatea from an existing buffer with 'newSize' and update memory
+  /// usage counting accordingly. If 'newSize' is larger than the current buffer
+  /// 'size', the function will allocate a new buffer and free the old buffer.
   virtual void* FOLLY_NULLABLE
   reallocate(void* FOLLY_NULLABLE p, int64_t size, int64_t newSize) = 0;
 
-  /// Invoked to free an allocated buffer.
+  /// Frees an allocated buffer.
   virtual void free(void* FOLLY_NULLABLE p, int64_t size) = 0;
+
+  /// Allocates one or more runs that add up to at least 'numPages', with the
+  /// smallest run being at least 'minSizeClass' pages. 'minSizeClass' must be
+  /// <= the size of the largest size class. The new memory is returned in 'out'
+  /// and any memory formerly referenced by 'out' is freed. The function returns
+  /// true if the allocation succeeded. If returning false, 'out' references no
+  /// memory and any partially allocated memory is freed.
+  virtual bool allocateNonContiguous(
+      MachinePageCount numPages,
+      MemoryAllocator::Allocation& out,
+      MachinePageCount minSizeClass = 0) = 0;
+
+  /// Frees non-contiguous 'allocation'. 'allocation' is empty on return.
+  virtual void freeNonContiguous(MemoryAllocator::Allocation& allocation) = 0;
+
+  /// Returns the largest class size used by non-contiguous memory allocation.
+  virtual MachinePageCount largestSizeClass() const = 0;
+
+  /// Returns the list of supported size class sizes used by non-contiguous
+  /// memory allocation.
+  virtual const std::vector<MachinePageCount>& sizeClasses() const = 0;
+
+  /// Makes a large contiguous mmap of 'numPages'. The new mapped pages are
+  /// returned in 'out' on success. Any formly mapped pages referenced by
+  /// 'out' is unmapped in all the cases even if the allocation fails.
+  virtual bool allocateContiguous(
+      MachinePageCount numPages,
+      MemoryAllocator::ContiguousAllocation& out) = 0;
+
+  /// Frees contiguous 'allocation'. 'allocation' is empty on return.
+  virtual void freeContiguous(
+      MemoryAllocator::ContiguousAllocation& allocation) = 0;
 
   /// Rounds up to a power of 2 >= size, or to a size halfway between
   /// two consecutive powers of two, i.e 8, 12, 16, 24, 32, .... This
@@ -205,13 +213,13 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
 
   virtual int64_t updateSubtreeMemoryUsage(int64_t size) = 0;
 
-  /// Used to manage existing externally allocated memories without doing a new
+  /// Tracks the externally allocated memory usage without doing a new
   /// allocation.
   virtual void reserve(int64_t /* bytes */) {
     VELOX_NYI("reserve() needs to be implemented in derived memory pool.");
   }
 
-  /// Sometimes in memory governance we want to mock an update for quota
+  /// Sometimes in memory management we want to mock an update for quota
   /// accounting purposes and different implementations can
   /// choose to accommodate this differently.
   virtual void release(int64_t /* bytes */, bool /* mock */ = false) {
@@ -240,25 +248,17 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
       const std::string& name,
       int64_t cap) = 0;
 
-  /// Invoked only on object destructor to remove this memory pool from its
-  /// parent's child memory pool tracking.
+  /// Invoked only on destruction to remove this memory pool from its parent's
+  /// child memory pool tracking.
   virtual void dropChild(const MemoryPool* FOLLY_NONNULL child);
 
   const std::string name_;
   std::shared_ptr<MemoryPool> parent_;
 
-  /// Used protect the concurrent access to 'children_'.
+  /// Protects 'children_'.
   mutable folly::SharedMutex childrenMutex_;
   std::list<MemoryPool*> children_;
 };
-
-namespace detail {
-static inline MemoryPool& getCheckedReference(std::weak_ptr<MemoryPool> ptr) {
-  auto sptr = ptr.lock();
-  VELOX_USER_CHECK(sptr);
-  return *sptr;
-};
-} // namespace detail
 
 class MemoryManager;
 
@@ -302,28 +302,27 @@ class MemoryPoolImpl : public MemoryPool {
 
   void free(void* FOLLY_NULLABLE p, int64_t size) override;
 
-  //////////////////// Memory Management methods /////////////////////
-  // Library checks for low memory mode on a push model. The respective root,
-  // component level or global, would compute for memory pressure.
-  // This is the signaling mechanism the customer application can use to make
-  // all subcomponents start trimming memory usage.
-  // virtual bool shouldTrim() const {
-  //   return trimming_;
-  // }
-  // // Set by MemoryManager in periodic refresh threads. Stores the trim
-  // target
-  // // state potentially for a more granular/simplified global control.
-  // virtual void startTrimming(int64_t target) {
-  //   trimming_ = true;
-  //   trimTarget_ = target;
-  // }
-  // // Resets the trim flag and trim target.
-  // virtual void stopTrimming() {
-  //   trimming_ = false;
-  //   trimTarget_ = std::numeric_limits<int64_t>::max();
-  // }
+  bool allocateNonContiguous(
+      MachinePageCount numPages,
+      MemoryAllocator::Allocation& out,
+      MachinePageCount minSizeClass = 0) override;
 
-  // TODO: Consider putting these in base class also.
+  void freeNonContiguous(MemoryAllocator::Allocation& allocation) override;
+
+  MachinePageCount largestSizeClass() const override;
+
+  const std::vector<MachinePageCount>& sizeClasses() const override;
+
+  bool allocateContiguous(
+      MachinePageCount numPages,
+      MemoryAllocator::ContiguousAllocation& allocation) override;
+
+  void freeContiguous(
+      MemoryAllocator::ContiguousAllocation& allocation) override;
+
+  /// Memory Management methods.
+
+  /// TODO: Consider putting these in base class also.
   int64_t getCurrentBytes() const override;
 
   int64_t getMaxBytes() const override;
@@ -408,7 +407,7 @@ class IMemoryManager {
 
   /// Returns the total memory usage allowed under this memory manager.
   /// The memory manager maintains this quota as a hard cap, and any allocation
-  /// that would cause a quota breach results in exceptions.
+  /// that would exceed the quota throws.
   virtual int64_t getMemoryQuota() const = 0;
 
   /// Power users that want to explicitly modify the tree should get the root of
@@ -437,9 +436,6 @@ class IMemoryManager {
   virtual void release(int64_t size) = 0;
 };
 
-/// For now, users wanting multiple different allocators would need to
-/// instantiate different MemoryManager classes and manage them across static
-/// boundaries.
 class MemoryManager final : public IMemoryManager {
  public:
   /// Tries to get the singleton memory manager. If not previously initialized,

--- a/velox/common/memory/MmapArena.h
+++ b/velox/common/memory/MmapArena.h
@@ -28,12 +28,12 @@ namespace facebook::velox::memory {
 
 class MmapArena {
  public:
-  // Single MmapArena capacity is determined by mmap_arena_capacity_ratio ratio
-  // but the capacity should be at least kMinCapacityBytes if the calculated
-  // capacity from the ratio is too small to serve large allocations.
+  /// Single MmapArena capacity is determined by mmap_arena_capacity_ratio ratio
+  /// but the capacity should be at least kMinCapacityBytes if the calculated
+  /// capacity from the ratio is too small to serve large allocations.
   static constexpr int64_t kMinCapacityBytes = 128 * 1024 * 1024; // 128M
 
-  // MmapArena capacity should be multiple of kMinGrainSizeBytes.
+  /// MmapArena capacity should be multiple of kMinGrainSizeBytes.
   static constexpr uint64_t kMinGrainSizeBytes = 1024 * 1024; // 1M
 
   MmapArena(size_t capacityBytes);
@@ -64,16 +64,17 @@ class MmapArena {
   bool empty() {
     return freeBytes_ == byteSize_;
   }
-  // Checks internal consistency of this MmapArena. Returns true if OK. May
-  // return false if there are concurrent alocations and frees during the
-  // consistency check. This is a false positive but not dangerous. This is for
-  // test only
+
+  /// Checks internal consistency of this MmapArena. Returns true if OK. May
+  /// return false if there are concurrent alocations and frees during the
+  /// consistency check. This is a false positive but not dangerous. This is for
+  /// test only
   bool checkConsistency() const;
 
-  // translate lookup table to a string for debugging purpose only.
+  /// translate lookup table to a string for debugging purpose only.
   std::string freeLookupStr() {
     std::stringstream lookupStr;
-    for (auto itr = freeLookup_.begin(); itr != freeLookup_.end(); itr++) {
+    for (auto itr = freeLookup_.begin(); itr != freeLookup_.end(); ++itr) {
       lookupStr << "\n{" << itr->first << "->[";
       for (auto itrInner = itr->second.begin(); itrInner != itr->second.end();
            itrInner++) {
@@ -98,11 +99,11 @@ class MmapArena {
 
   void removeFreeBlock(std::map<uint64_t, uint64_t>::iterator& itr);
 
-  // Starting address of this arena
-  uint8_t* FOLLY_NONNULL address_;
-
   // Total capacity size of this arena
   const uint64_t byteSize_;
+
+  // Starting address of this arena
+  uint8_t* FOLLY_NONNULL address_;
 
   std::atomic<uint64_t> freeBytes_;
 

--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -18,8 +18,7 @@
 
 namespace facebook::velox {
 
-StreamArena::StreamArena(memory::MemoryAllocator* allocator)
-    : allocator_(allocator), allocation_(allocator_) {}
+StreamArena::StreamArena(memory::MemoryPool* pool) : pool_(pool) {}
 
 void StreamArena::newRange(int32_t bytes, ByteRange* range) {
   VELOX_CHECK_GT(bytes, 0);
@@ -33,10 +32,8 @@ void StreamArena::newRange(int32_t bytes, ByteRange* range) {
           std::make_unique<memory::MemoryAllocator::Allocation>(
               std::move(allocation_)));
     }
-    if (!allocator_->allocateNonContiguous(
-            std::max(allocationQuantum_, numPages),
-            kVectorStreamOwner,
-            allocation_)) {
+    if (!pool_->allocateNonContiguous(
+            std::max(allocationQuantum_, numPages), allocation_)) {
       throw std::bad_alloc();
     }
     currentRun_ = 0;

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #pragma once
-#include "velox/common/memory/MemoryAllocator.h"
+#include "velox/common/memory/Memory.h"
 
 namespace facebook::velox {
 
@@ -29,7 +29,7 @@ class StreamArena {
  public:
   static constexpr int32_t kVectorStreamOwner = 1;
 
-  explicit StreamArena(memory::MemoryAllocator* FOLLY_NONNULL allocator);
+  explicit StreamArena(memory::MemoryPool* FOLLY_NONNULL pool);
 
   virtual ~StreamArena() = default;
 
@@ -47,12 +47,12 @@ class StreamArena {
     return size_;
   }
 
-  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
-    return allocator_;
+  memory::MemoryPool* FOLLY_NONNULL pool() const {
+    return pool_;
   }
 
  private:
-  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
+  memory::MemoryPool* FOLLY_NONNULL pool_;
   // All allocations.
   std::vector<std::unique_ptr<memory::MemoryAllocator::Allocation>>
       allocations_;

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -31,6 +31,9 @@ class ByteStreamTest : public testing::TestWithParam<bool> {
     options.capacity = kMaxMappedMemory;
     mmapAllocator_ = std::make_shared<MmapAllocator>(options);
     MemoryAllocator::setDefaultInstance(mmapAllocator_.get());
+    memoryManager_ = std::make_unique<MemoryManager>(
+        kMaxMemory, MemoryAllocator::getInstance());
+    pool_ = memoryManager_->getChild();
   }
 
   void TearDown() override {
@@ -39,11 +42,12 @@ class ByteStreamTest : public testing::TestWithParam<bool> {
   }
 
   std::shared_ptr<MmapAllocator> mmapAllocator_;
+  std::unique_ptr<MemoryManager> memoryManager_;
+  std::shared_ptr<memory::MemoryPool> pool_;
 };
 
 TEST_F(ByteStreamTest, outputStream) {
-  auto out =
-      std::make_unique<IOBufOutputStream>(*mmapAllocator_, nullptr, 10000);
+  auto out = std::make_unique<IOBufOutputStream>(*pool_, nullptr, 10000);
   std::stringstream referenceSStream;
   auto reference = std::make_unique<OStreamOutputStream>(&referenceSStream);
   for (auto i = 0; i < 100; ++i) {

--- a/velox/common/memory/tests/FragmentationBenchmark.cpp
+++ b/velox/common/memory/tests/FragmentationBenchmark.cpp
@@ -34,12 +34,19 @@ using namespace facebook::velox;
 using namespace facebook::velox::memory;
 
 struct Block {
+  explicit Block(MemoryAllocator& _allocator) : allocator(_allocator) {}
+
   ~Block() {
-    if (data) {
+    if (data != nullptr) {
       free(data);
     }
+    if (allocation != nullptr) {
+      allocator.freeNonContiguous(*allocation);
+    }
+    allocator.freeContiguous(contiguous);
   }
 
+  MemoryAllocator& allocator;
   size_t size = 0;
   char* data = nullptr;
   std::shared_ptr<MemoryAllocator::Allocation> allocation;
@@ -84,14 +91,12 @@ class FragmentationTest {
   }
 
   void allocate(size_t size) {
-    auto block = std::make_unique<Block>();
+    auto block = std::make_unique<Block>(*memory_);
     block->size = size;
     if (memory_) {
       if (size <= 8 << 20) {
-        block->allocation =
-            std::make_shared<MemoryAllocator::Allocation>(memory_.get());
-        if (!memory_->allocateNonContiguous(
-                size / 4096, 0, *block->allocation)) {
+        block->allocation = std::make_shared<MemoryAllocator::Allocation>();
+        if (!memory_->allocateNonContiguous(size / 4096, *block->allocation)) {
           VELOX_FAIL("allocate() faild");
         }
         for (int i = 0; i < block->allocation->numRuns(); ++i) {

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -33,8 +33,8 @@ struct Multipart {
 class HashStringAllocatorTest : public testing::Test {
  protected:
   void SetUp() override {
-    instance_ = std::make_unique<HashStringAllocator>(
-        memory::MemoryAllocator::getInstance());
+    pool_ = memory::getDefaultMemoryPool();
+    instance_ = std::make_unique<HashStringAllocator>(pool_.get());
     rng_.seed(1);
   }
 
@@ -82,6 +82,7 @@ class HashStringAllocatorTest : public testing::Test {
     return result;
   }
 
+  std::shared_ptr<memory::MemoryPool> pool_;
   std::unique_ptr<HashStringAllocator> instance_;
   int32_t sequence_ = 0;
   folly::Random::DefaultGenerator rng_;

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -38,7 +38,114 @@ static constexpr uint64_t kMaxMemoryAllocator = 128UL * 1024 * 1024;
 static constexpr MachinePageCount kCapacity =
     (kMaxMemoryAllocator / MemoryAllocator::kPageSize);
 
-class MemoryAllocatorTest : public testing::TestWithParam<bool> {
+// The class leverage memory usage tracker to track the memory usage.
+class MockMemoryAllocator final : public MemoryAllocator {
+ public:
+  MockMemoryAllocator(
+      MemoryAllocator* FOLLY_NONNULL allocator,
+      std::shared_ptr<MemoryUsageTracker> tracker)
+      : allocator_(allocator), tracker_(std::move(tracker)) {}
+
+  bool allocateNonContiguous(
+      MachinePageCount numPages,
+      Allocation& out,
+      ReservationCallback /*unused*/ = nullptr,
+      MachinePageCount minSizeClass = 0) override {
+    freeNonContiguous(out);
+    return allocator_->allocateNonContiguous(
+        numPages,
+        out,
+        [this](int64_t allocBytes, bool preAllocate) {
+          if (tracker_ != nullptr) {
+            tracker_->update(preAllocate ? allocBytes : -allocBytes);
+          }
+        },
+        minSizeClass);
+  }
+
+  int64_t freeNonContiguous(Allocation& allocation) override {
+    const int64_t freed = allocator_->freeNonContiguous(allocation);
+    if (tracker_) {
+      tracker_->update(-freed);
+    }
+    return freed;
+  }
+
+  bool allocateContiguous(
+      MachinePageCount numPages,
+      Allocation* FOLLY_NULLABLE collateral,
+      ContiguousAllocation& allocation,
+      ReservationCallback /*unused*/ = nullptr) override {
+    return allocator_->allocateContiguous(
+        numPages,
+        collateral,
+        allocation,
+        [this](int64_t allocBytes, bool preAlloc) {
+          if (tracker_ != nullptr) {
+            tracker_->update(preAlloc ? allocBytes : -allocBytes);
+          }
+        });
+  }
+
+  void freeContiguous(ContiguousAllocation& allocation) override {
+    const int64_t size = allocation.size();
+    allocator_->freeContiguous(allocation);
+    if (tracker_ != nullptr) {
+      tracker_->update(-size);
+    }
+  }
+
+  bool checkConsistency() const override {
+    return allocator_->checkConsistency();
+  }
+
+  const std::vector<MachinePageCount>& sizeClasses() const override {
+    return allocator_->sizeClasses();
+  }
+
+  MachinePageCount numAllocated() const override {
+    return allocator_->numAllocated();
+  }
+
+  MachinePageCount numMapped() const override {
+    return allocator_->numMapped();
+  }
+
+  Stats stats() const override {
+    return allocator_->stats();
+  }
+
+ private:
+  MemoryAllocator* FOLLY_NONNULL allocator_;
+  std::shared_ptr<MemoryUsageTracker> tracker_;
+};
+
+struct TestParam {
+  bool useMmap;
+  // If true, use MockMemoryAllocator to tracker the memory usage through the
+  // memory usage tracker.
+  bool hasMemoryTracker;
+
+  TestParam(bool _useMmap, bool _hasMemoryTracker)
+      : useMmap(_useMmap), hasMemoryTracker(_hasMemoryTracker) {}
+
+  std::string toString() const {
+    return fmt::format(
+        "useMmap{} hasMemoryTracker{}", useMmap, hasMemoryTracker);
+  }
+};
+
+class MemoryAllocatorTest : public testing::TestWithParam<TestParam> {
+ public:
+  static const std::vector<TestParam> getTestParams() {
+    std::vector<TestParam> params;
+    params.push_back({true, true});
+    params.push_back({true, false});
+    params.push_back({false, true});
+    params.push_back({false, false});
+    return params;
+  }
+
  protected:
   static void SetUpTestCase() {
     TestValue::enable();
@@ -46,9 +153,7 @@ class MemoryAllocatorTest : public testing::TestWithParam<bool> {
 
   void SetUp() override {
     MemoryAllocator::testingDestroyInstance();
-    auto tracker = MemoryUsageTracker::create(
-        MemoryUsageConfigBuilder().maxTotalMemory(kMaxMemoryAllocator).build());
-    useMmap_ = GetParam();
+    useMmap_ = GetParam().useMmap;
     if (useMmap_) {
       MmapAllocatorOptions options;
       options.capacity = kMaxMemoryAllocator;
@@ -57,8 +162,19 @@ class MemoryAllocatorTest : public testing::TestWithParam<bool> {
     } else {
       MemoryAllocator::setDefaultInstance(nullptr);
     }
-    instancePtr_ = MemoryAllocator::getInstance()->addChild(tracker);
-    instance_ = instancePtr_.get();
+    hasMemoryTracker_ = GetParam().hasMemoryTracker;
+    if (hasMemoryTracker_) {
+      memoryUsageTracker_ =
+          MemoryUsageTracker::create(MemoryUsageConfigBuilder()
+                                         .maxTotalMemory(kMaxMemoryAllocator)
+                                         .build());
+      mockAllocator_ = std::make_shared<MockMemoryAllocator>(
+          MemoryAllocator::getInstance(), memoryUsageTracker_);
+      MemoryAllocator::setDefaultInstance(mockAllocator_.get());
+    }
+    instance_ = MemoryAllocator::getInstance();
+    memoryManager_ = std::make_unique<MemoryManager>(kMaxMemory, instance_);
+    pool_ = memoryManager_->getChild();
   }
 
   void TearDown() override {
@@ -67,12 +183,12 @@ class MemoryAllocatorTest : public testing::TestWithParam<bool> {
 
   bool allocate(int32_t numPages, MemoryAllocator::Allocation& result) {
     try {
-      if (!instance_->allocateNonContiguous(numPages, 0, result)) {
-        EXPECT_EQ(result.numRuns(), 0);
+      if (!instance_->allocateNonContiguous(numPages, result)) {
+        EXPECT_TRUE(result.empty());
         return false;
       }
     } catch (const VeloxException& e) {
-      EXPECT_EQ(result.numRuns(), 0);
+      EXPECT_TRUE(result.empty());
       return false;
     }
     EXPECT_GE(result.numPages(), numPages);
@@ -153,60 +269,113 @@ class MemoryAllocatorTest : public testing::TestWithParam<bool> {
     instance_->freeNonContiguous(alloc);
   }
 
+  void clearAllocations(
+      std::vector<std::unique_ptr<MemoryAllocator::Allocation>>& allocations) {
+    for (auto& allocation : allocations) {
+      instance_->freeNonContiguous(*allocation);
+    }
+    allocations.clear();
+  }
+
+  void clearAllocations(
+      std::vector<std::vector<std::unique_ptr<MemoryAllocator::Allocation>>>&
+          allocationsVector) {
+    for (auto& allocations : allocationsVector) {
+      for (auto& allocation : allocations) {
+        instance_->freeNonContiguous(*allocation);
+      }
+    }
+    allocationsVector.clear();
+  }
+
+  void shrinkAllocations(
+      std::vector<std::unique_ptr<MemoryAllocator::Allocation>>& allocations,
+      int32_t reducedSize) {
+    while (allocations.size() > reducedSize) {
+      instance_->freeNonContiguous(*allocations.back());
+      allocations.pop_back();
+    }
+    ASSERT_EQ(allocations.size(), reducedSize);
+  }
+
+  void clearContiguousAllocations(
+      std::vector<MemoryAllocator::ContiguousAllocation>& allocations) {
+    for (auto& allocation : allocations) {
+      instance_->freeContiguous(allocation);
+    }
+    allocations.clear();
+  }
+
   void allocateMultiple(
       MachinePageCount numPages,
       int32_t numAllocs,
       std::vector<std::unique_ptr<MemoryAllocator::Allocation>>& allocations) {
-    allocations.clear();
+    clearAllocations(allocations);
     allocations.reserve(numAllocs);
-    allocations.push_back(
-        std::make_unique<MemoryAllocator::Allocation>(instance_));
+    // allocations.push_back(std::make_unique<MemoryAllocator::Allocation>());
     bool largeTested = false;
     for (int32_t i = 0; i < numAllocs; ++i) {
-      if (allocate(numPages, *allocations.back().get())) {
-        allocations.push_back(
-            std::make_unique<MemoryAllocator::Allocation>(instance_));
-        int available = kCapacity - instance_->numAllocated();
+      auto allocation = std::make_unique<MemoryAllocator::Allocation>();
+      if (!allocate(numPages, *allocation)) {
+        continue;
+      }
+      allocations.push_back(std::move(allocation));
+      int available = kCapacity - instance_->numAllocated();
 
-        // Try large allocations after half the capacity is used.
-        if (available <= kCapacity / 2 && !largeTested) {
-          largeTested = true;
-          MemoryAllocator::ContiguousAllocation large;
-          if (!allocateContiguous(available / 2, nullptr, large)) {
-            FAIL() << "Could not allocate half the available";
-            return;
-          }
-          MemoryAllocator::Allocation small(instance_);
-          if (!instance_->allocateNonContiguous(available / 4, 0, small)) {
-            FAIL() << "Could not allocate 1/4 of available";
-            return;
-          }
-          // Try to allocate more than available;
-          EXPECT_THROW(
+      // Try large allocations after half the capacity is used.
+      if (available <= kCapacity / 2 && !largeTested) {
+        largeTested = true;
+        MemoryAllocator::ContiguousAllocation large;
+        if (!allocateContiguous(available / 2, nullptr, large)) {
+          FAIL() << "Could not allocate half the available";
+          return;
+        }
+        MemoryAllocator::Allocation small;
+        if (!instance_->allocateNonContiguous(available / 4, small)) {
+          FAIL() << "Could not allocate 1/4 of available";
+          return;
+        }
+        // Try to allocate more than available, and it should fail if we use
+        // MmapAllocator which enforces the capacity check.
+        if (hasMemoryTracker_) {
+          ASSERT_THROW(
               instance_->allocateContiguous(available + 1, &small, large),
               VeloxRuntimeError);
-
-          // Check The failed allocation freed the collateral.
-          EXPECT_EQ(small.numPages(), 0);
-          EXPECT_EQ(large.numPages(), 0);
-          if (!allocateContiguous(available, nullptr, large)) {
-            FAIL() << "Could not allocate rest of capacity";
-          }
-          EXPECT_GE(large.numPages(), available);
-          EXPECT_EQ(small.numPages(), 0);
-          EXPECT_EQ(kCapacity, instance_->numAllocated());
+        } else {
           if (useMmap_) {
-            // The allocator has everything allocated and half mapped, with the
-            // other half mapped by the contiguous allocation. numMapped()
-            // includes the contiguous allocation.
-            EXPECT_EQ(kCapacity, instance_->numMapped());
+            ASSERT_FALSE(
+                instance_->allocateContiguous(available + 1, &small, large));
+            ASSERT_TRUE(small.empty());
+            ASSERT_TRUE(large.empty());
+          } else {
+            ASSERT_TRUE(
+                instance_->allocateContiguous(available + 1, &small, large));
+            ASSERT_TRUE(small.empty());
+            ASSERT_FALSE(large.empty());
+            instance_->freeContiguous(large);
           }
-          if (!allocateContiguous(available / 2, nullptr, large)) {
-            FAIL()
-                << "Could not exchange all of available for half of available";
-          }
-          EXPECT_GE(large.numPages(), available / 2);
         }
+
+        // Check The failed allocation freed the collateral.
+        ASSERT_EQ(small.numPages(), 0);
+        ASSERT_EQ(large.numPages(), 0);
+        if (!allocateContiguous(available, nullptr, large)) {
+          FAIL() << "Could not allocate rest of capacity";
+        }
+        ASSERT_GE(large.numPages(), available);
+        ASSERT_EQ(small.numPages(), 0);
+        ASSERT_EQ(kCapacity, instance_->numAllocated());
+        if (useMmap_) {
+          // The allocator has everything allocated and half mapped, with the
+          // other half mapped by the contiguous allocation. numMapped()
+          // includes the contiguous allocation.
+          ASSERT_EQ(kCapacity, instance_->numMapped());
+        }
+        if (!allocateContiguous(available / 2, nullptr, large)) {
+          FAIL() << "Could not exchange all of available for half of available";
+        }
+        ASSERT_GE(large.numPages(), available / 2);
+        instance_->freeContiguous(large);
       }
     }
   }
@@ -274,22 +443,25 @@ class MemoryAllocatorTest : public testing::TestWithParam<bool> {
     std::vector<std::unique_ptr<MemoryAllocator::Allocation>> allocations;
     allocations.reserve(size);
     for (int32_t i = 0; i < size; i++) {
-      allocations.push_back(
-          std::make_unique<MemoryAllocator::Allocation>(instance_));
+      allocations.push_back(std::make_unique<MemoryAllocator::Allocation>());
     }
     return allocations;
   }
 
   bool useMmap_;
+  bool hasMemoryTracker_;
+  std::shared_ptr<MemoryUsageTracker> memoryUsageTracker_;
   std::shared_ptr<MmapAllocator> mmapAllocator_;
-  std::shared_ptr<MemoryAllocator> instancePtr_;
+  std::shared_ptr<MockMemoryAllocator> mockAllocator_;
   MemoryAllocator* instance_;
+  std::unique_ptr<MemoryManager> memoryManager_;
+  std::shared_ptr<MemoryPool> pool_;
   std::atomic<int32_t> sequence_ = {};
 };
 
 TEST_P(MemoryAllocatorTest, allocationPoolTest) {
   const size_t kNumLargeAllocPages = instance_->largestSizeClass() * 2;
-  AllocationPool pool(instance_);
+  AllocationPool pool(pool_.get());
 
   pool.allocateFixed(10);
   EXPECT_EQ(pool.numTotalAllocations(), 1);
@@ -326,8 +498,8 @@ TEST_P(MemoryAllocatorTest, allocationPoolTest) {
 
 TEST_P(MemoryAllocatorTest, allocationTest) {
   const int32_t kPageSize = MemoryAllocator::kPageSize;
-  MemoryAllocator::Allocation allocation(instance_);
-  uint8_t* pages = reinterpret_cast<uint8_t*>(malloc(kPageSize * 20));
+  MemoryAllocator::Allocation allocation;
+  uint8_t* pages = reinterpret_cast<uint8_t*>(::malloc(kPageSize * 20));
   // We append different pieces of 'pages' to 'allocation'.
   // 4 last pages.
   allocation.append(pages + 16 * kPageSize, 4);
@@ -335,8 +507,8 @@ TEST_P(MemoryAllocatorTest, allocationTest) {
   allocation.append(pages + 15 * kPageSize, 1);
   // 15 first pages.
   allocation.append(pages, 15);
-  EXPECT_EQ(allocation.numRuns(), 3);
-  EXPECT_EQ(allocation.numPages(), 20);
+  ASSERT_EQ(allocation.numRuns(), 3);
+  ASSERT_EQ(allocation.numPages(), 20);
   int32_t index;
   int32_t offsetInRun;
   // We look for the pointer of byte 2000 of the 16th page in
@@ -344,60 +516,77 @@ TEST_P(MemoryAllocatorTest, allocationTest) {
   const int32_t offset = 15 * kPageSize + 2000;
   allocation.findRun(offset, &index, &offsetInRun);
   // 3rd run.
-  EXPECT_EQ(index, 2);
-  EXPECT_EQ(offsetInRun, 10 * kPageSize + 2000);
-  EXPECT_EQ(allocation.runAt(1).data(), pages + 15 * kPageSize);
+  ASSERT_EQ(index, 2);
+  ASSERT_EQ(offsetInRun, 10 * kPageSize + 2000);
+  ASSERT_EQ(allocation.runAt(1).data(), pages + 15 * kPageSize);
 
   MemoryAllocator::Allocation moved(std::move(allocation));
-  EXPECT_EQ(allocation.numRuns(), 0);
-  EXPECT_EQ(allocation.numPages(), 0);
-  EXPECT_EQ(moved.numRuns(), 3);
-  EXPECT_EQ(moved.numPages(), 20);
+  ASSERT_TRUE(allocation.empty());
+  ASSERT_EQ(allocation.numRuns(), 0);
+  ASSERT_EQ(allocation.numPages(), 0);
+  ASSERT_EQ(moved.numRuns(), 3);
+  ASSERT_EQ(moved.numPages(), 20);
 
   moved.clear();
-  EXPECT_EQ(moved.numRuns(), 0);
-  EXPECT_EQ(moved.numPages(), 0);
+  ASSERT_TRUE(moved.empty());
+  ASSERT_EQ(moved.numRuns(), 0);
+  ASSERT_EQ(moved.numPages(), 0);
   ::free(pages);
 }
 
 TEST_P(MemoryAllocatorTest, singleAllocationTest) {
+  if (!useMmap_) {
+    return;
+  }
   const std::vector<MachinePageCount>& sizes = instance_->sizeClasses();
   MachinePageCount capacity = kCapacity;
   std::vector<std::unique_ptr<MemoryAllocator::Allocation>> allocations;
   for (auto i = 0; i < sizes.size(); ++i) {
     auto size = sizes[i];
     allocateMultiple(size, capacity / size + 10, allocations);
-    EXPECT_EQ(allocations.size() - 1, capacity / size);
-    EXPECT_TRUE(instance_->checkConsistency());
-    EXPECT_GT(instance_->numAllocated(), 0);
+    if (useMmap_) {
+      ASSERT_EQ(allocations.size(), capacity / size);
+    } else {
+      // NOTE: the non-mmap allocator doesn't enforce capacity for now.
+      ASSERT_EQ(allocations.size(), capacity / size + 10);
+    }
+    ASSERT_TRUE(instance_->checkConsistency());
+    ASSERT_GT(instance_->numAllocated(), 0);
 
-    allocations.clear();
+    clearAllocations(allocations);
     EXPECT_EQ(instance_->numAllocated(), 0);
 
     auto stats = instance_->stats();
     EXPECT_LT(0, stats.sizes[i].clocks());
-    EXPECT_GE(stats.sizes[i].totalBytes, capacity * MemoryAllocator::kPageSize);
-    EXPECT_GE(stats.sizes[i].numAllocations, capacity / size);
+    ASSERT_GE(stats.sizes[i].totalBytes, capacity * MemoryAllocator::kPageSize)
+        << i << " size: " << size;
+    ASSERT_GE(stats.sizes[i].numAllocations, capacity / size)
+        << i << " size: " << size;
 
     if (useMmap_) {
-      EXPECT_EQ(instance_->numMapped(), kCapacity);
+      ASSERT_EQ(instance_->numMapped(), kCapacity);
     }
-    EXPECT_TRUE(instance_->checkConsistency());
+    ASSERT_TRUE(instance_->checkConsistency());
   }
   for (int32_t i = sizes.size() - 2; i >= 0; --i) {
     auto size = sizes[i];
     allocateMultiple(size, capacity / size + 10, allocations);
-    EXPECT_EQ(allocations[0]->numPages(), size);
-    EXPECT_EQ(allocations.size() - 1, capacity / size);
-    EXPECT_TRUE(instance_->checkConsistency());
-    EXPECT_GT(instance_->numAllocated(), 0);
-
-    allocations.clear();
-    EXPECT_EQ(instance_->numAllocated(), 0);
+    ASSERT_EQ(allocations[0]->numPages(), size);
     if (useMmap_) {
-      EXPECT_EQ(instance_->numMapped(), kCapacity);
+      ASSERT_EQ(allocations.size(), capacity / size);
+    } else {
+      // NOTE: the non-mmap allocator doesn't enforce capacity for now.
+      ASSERT_EQ(allocations.size(), capacity / size + 10);
     }
-    EXPECT_TRUE(instance_->checkConsistency());
+    ASSERT_TRUE(instance_->checkConsistency());
+    ASSERT_GT(instance_->numAllocated(), 0);
+
+    clearAllocations(allocations);
+    ASSERT_EQ(instance_->numAllocated(), 0);
+    if (useMmap_) {
+      ASSERT_EQ(instance_->numMapped(), kCapacity);
+    }
+    ASSERT_TRUE(instance_->checkConsistency());
   }
 }
 
@@ -408,7 +597,7 @@ TEST_P(MemoryAllocatorTest, increasingSizeTest) {
   EXPECT_TRUE(instance_->checkConsistency());
   EXPECT_GT(instance_->numAllocated(), 0);
 
-  allocations.clear();
+  clearAllocations(allocations);
   EXPECT_TRUE(instance_->checkConsistency());
   EXPECT_EQ(instance_->numAllocated(), 0);
 }
@@ -434,78 +623,69 @@ TEST_P(MemoryAllocatorTest, increasingSizeWithThreadsTest) {
   EXPECT_TRUE(instance_->checkConsistency());
   EXPECT_GT(instance_->numAllocated(), 0);
 
-  allocations.clear();
+  clearAllocations(allocations);
   EXPECT_TRUE(instance_->checkConsistency());
   EXPECT_EQ(instance_->numAllocated(), 0);
 }
 
-TEST_P(MemoryAllocatorTest, scopedMemoryUsageTracking) {
+TEST_P(MemoryAllocatorTest, allocationWithMemoryUsageTracking) {
+  if (!hasMemoryTracker_) {
+    GTEST_SKIP();
+  }
   const int32_t numPages = 32;
   {
-    auto tracker = MemoryUsageTracker::create();
-    auto MemoryAllocator = instance_->addChild(tracker);
-
-    MemoryAllocator::Allocation result(MemoryAllocator.get());
-
-    MemoryAllocator->allocateNonContiguous(numPages, 0, result);
-    EXPECT_GE(result.numPages(), numPages);
-    EXPECT_EQ(
+    MemoryAllocator::Allocation result;
+    instance_->allocateNonContiguous(numPages, result);
+    ASSERT_GE(result.numPages(), numPages);
+    ASSERT_EQ(
         result.numPages() * MemoryAllocator::kPageSize,
-        tracker->getCurrentUserBytes());
-    MemoryAllocator->freeNonContiguous(result);
-    EXPECT_EQ(0, tracker->getCurrentUserBytes());
+        memoryUsageTracker_->getCurrentUserBytes());
+    instance_->freeNonContiguous(result);
+    ASSERT_EQ(memoryUsageTracker_->getCurrentUserBytes(), 0);
   }
 
-  auto tracker = MemoryUsageTracker::create();
-  auto MemoryAllocator = instance_->addChild(tracker);
   {
-    MemoryAllocator::Allocation result1(MemoryAllocator.get());
-    MemoryAllocator::Allocation result2(MemoryAllocator.get());
-    MemoryAllocator->allocateNonContiguous(numPages, 0, result1);
-    EXPECT_GE(result1.numPages(), numPages);
-    EXPECT_EQ(
+    MemoryAllocator::Allocation result1;
+    MemoryAllocator::Allocation result2;
+    instance_->allocateNonContiguous(numPages, result1);
+    ASSERT_GE(result1.numPages(), numPages);
+    ASSERT_EQ(
         result1.numPages() * MemoryAllocator::kPageSize,
-        tracker->getCurrentUserBytes());
+        memoryUsageTracker_->getCurrentUserBytes());
 
-    MemoryAllocator->allocateNonContiguous(numPages, 0, result2);
-    EXPECT_GE(result2.numPages(), numPages);
-    EXPECT_EQ(
+    instance_->allocateNonContiguous(numPages, result2);
+    ASSERT_GE(result2.numPages(), numPages);
+    ASSERT_EQ(
         (result1.numPages() + result2.numPages()) * MemoryAllocator::kPageSize,
-        tracker->getCurrentUserBytes());
+        memoryUsageTracker_->getCurrentUserBytes());
 
     // Since allocations are still valid, usage should not change.
-    EXPECT_EQ(
+    ASSERT_EQ(
         (result1.numPages() + result2.numPages()) * MemoryAllocator::kPageSize,
-        tracker->getCurrentUserBytes());
+        memoryUsageTracker_->getCurrentUserBytes());
+    instance_->freeNonContiguous(result1);
+    instance_->freeNonContiguous(result2);
   }
-  EXPECT_EQ(0, tracker->getCurrentUserBytes());
+  ASSERT_EQ(0, memoryUsageTracker_->getCurrentUserBytes());
 }
 
 TEST_P(MemoryAllocatorTest, minSizeClass) {
-  auto tracker = MemoryUsageTracker::create();
-  auto MemoryAllocator = instance_->addChild(tracker);
+  MemoryAllocator::Allocation result;
 
-  MemoryAllocator::Allocation result(MemoryAllocator.get());
-
-  int32_t sizeClass = MemoryAllocator->sizeClasses().back();
+  int32_t sizeClass = instance_->sizeClasses().back();
   int32_t numPages = sizeClass + 1;
-  MemoryAllocator->allocateNonContiguous(
-      numPages, 0, result, nullptr, sizeClass);
-  EXPECT_GE(result.numPages(), sizeClass * 2);
+  instance_->allocateNonContiguous(numPages, result, nullptr, sizeClass);
+  ASSERT_GE(result.numPages(), sizeClass * 2);
   // All runs have to be at least the minimum size.
   for (auto i = 0; i < result.numRuns(); ++i) {
-    EXPECT_LE(sizeClass, result.runAt(i).numPages());
+    ASSERT_LE(sizeClass, result.runAt(i).numPages());
   }
-  EXPECT_EQ(
-      result.numPages() * MemoryAllocator::kPageSize,
-      tracker->getCurrentUserBytes());
-  MemoryAllocator->freeNonContiguous(result);
-  EXPECT_EQ(0, tracker->getCurrentUserBytes());
+  instance_->freeNonContiguous(result);
 }
 
 TEST_P(MemoryAllocatorTest, externalAdvise) {
-  if (!useMmap_) {
-    return;
+  if (!useMmap_ || hasMemoryTracker_) {
+    GTEST_SKIP();
   }
   constexpr int32_t kSmallSize = 16;
   constexpr int32_t kLargeSize = 32 * kSmallSize + 1;
@@ -514,41 +694,42 @@ TEST_P(MemoryAllocatorTest, externalAdvise) {
   auto numAllocs = kCapacity / kSmallSize;
   allocations.reserve(numAllocs);
   for (int32_t i = 0; i < numAllocs; ++i) {
-    allocations.push_back(
-        std::make_unique<MemoryAllocator::Allocation>(instance));
-    EXPECT_TRUE(allocate(kSmallSize, *allocations.back().get()));
+    allocations.push_back(std::make_unique<MemoryAllocator::Allocation>());
+    ASSERT_TRUE(allocate(kSmallSize, *allocations.back().get()));
   }
   // We allocated and mapped the capacity. Now free half, leaving the memory
   // still mapped.
-  allocations.resize(numAllocs / 2);
-  EXPECT_TRUE(instance->checkConsistency());
-  EXPECT_EQ(instance->numMapped(), numAllocs * kSmallSize);
-  EXPECT_EQ(instance->numAllocated(), numAllocs / 2 * kSmallSize);
-  std::vector<MemoryAllocator::ContiguousAllocation> large(2);
-  EXPECT_TRUE(instance->allocateContiguous(kLargeSize, nullptr, large[0]));
+  shrinkAllocations(allocations, numAllocs / 2);
+  ASSERT_TRUE(instance->checkConsistency());
+  ASSERT_EQ(instance->numMapped(), numAllocs * kSmallSize);
+  ASSERT_EQ(instance->numAllocated(), numAllocs / 2 * kSmallSize);
+  std::vector<MemoryAllocator::ContiguousAllocation> larges(2);
+  ASSERT_TRUE(instance->allocateContiguous(kLargeSize, nullptr, larges[0]));
   // The same number are mapped but some got advised away to back the large
   // allocation. One kSmallSize got advised away but not fully used because
   // kLargeSize is not a multiple of kSmallSize.
-  EXPECT_EQ(instance->numMapped(), numAllocs * kSmallSize - kSmallSize + 1);
-  EXPECT_EQ(instance->numAllocated(), numAllocs / 2 * kSmallSize + kLargeSize);
-  EXPECT_TRUE(instance->allocateContiguous(kLargeSize, nullptr, large[1]));
-  large.clear();
-  EXPECT_EQ(instance->numAllocated(), allocations.size() * kSmallSize);
+  ASSERT_EQ(instance->numMapped(), numAllocs * kSmallSize - kSmallSize + 1);
+  ASSERT_EQ(instance->numAllocated(), numAllocs / 2 * kSmallSize + kLargeSize);
+  ASSERT_TRUE(instance->allocateContiguous(kLargeSize, nullptr, larges[1]));
+  clearContiguousAllocations(larges);
+  ASSERT_EQ(instance->numAllocated(), allocations.size() * kSmallSize);
   // After freeing 2xkLargeSize, We have unmapped 2*LargeSize at the free and
   // another (kSmallSize - 1 when allocating the first kLargeSize. Of the 15
   // that this unmapped, 1 was taken by the second large alloc. So, the mapped
   // pages is total - (2 * kLargeSize) - 14. The unused unmapped are 15 pages
   // after the first and 14 after the second allocContiguous().
-  EXPECT_EQ(
+  ASSERT_EQ(
       instance->numMapped(),
       kSmallSize * numAllocs - (2 * kLargeSize) -
           (kSmallSize - (2 * (kLargeSize % kSmallSize))));
-  EXPECT_TRUE(instance->checkConsistency());
+  ASSERT_TRUE(instance->checkConsistency());
+  clearAllocations(allocations);
+  ASSERT_TRUE(instance->checkConsistency());
 }
 
 TEST_P(MemoryAllocatorTest, allocContiguousFail) {
-  if (!useMmap_) {
-    return;
+  if (!useMmap_ || hasMemoryTracker_) {
+    GTEST_SKIP();
   }
   // Covers edge cases of
   constexpr int32_t kSmallSize = 16;
@@ -562,69 +743,72 @@ TEST_P(MemoryAllocatorTest, allocContiguousFail) {
   };
   allocations.reserve(numAllocs);
   for (int32_t i = 0; i < numAllocs; ++i) {
-    allocations.push_back(
-        std::make_unique<MemoryAllocator::Allocation>(instance));
-    EXPECT_TRUE(allocate(kSmallSize, *allocations.back().get()));
+    allocations.push_back(std::make_unique<MemoryAllocator::Allocation>());
+    ASSERT_TRUE(allocate(kSmallSize, *allocations.back().get()));
   }
   // We allocated and mapped the capacity. Now free half, leaving the memory
   // still mapped.
-  allocations.resize(numAllocs / 2);
-  EXPECT_TRUE(instance->checkConsistency());
-  EXPECT_EQ(instance->numMapped(), numAllocs * kSmallSize);
-  EXPECT_EQ(instance->numAllocated(), numAllocs / 2 * kSmallSize);
+  shrinkAllocations(allocations, numAllocs / 2);
+  ASSERT_TRUE(instance->checkConsistency());
+  ASSERT_EQ(instance->numMapped(), numAllocs * kSmallSize);
+  ASSERT_EQ(instance->numAllocated(), numAllocs / 2 * kSmallSize);
   MemoryAllocator::ContiguousAllocation large;
-  EXPECT_TRUE(instance->allocateContiguous(
+  ASSERT_TRUE(instance->allocateContiguous(
       kLargeSize / 2, nullptr, large, trackCallback));
-  EXPECT_TRUE(instance->checkConsistency());
+  ASSERT_TRUE(instance->checkConsistency());
 
   // The allocation should go through because there is 1/2 of
   // kLargeSize already in large[0], 1/2 of kLargeSize free and
   // kSmallSize given as collateral. This does not go through because
   // we inject a failure in advising away the collateral.
   instance->testingInjectFailure(MmapAllocator::Failure::kMadvise);
-  EXPECT_FALSE(instance->allocateContiguous(
+  ASSERT_FALSE(instance->allocateContiguous(
       kLargeSize + kSmallSize, allocations.back().get(), large, trackCallback));
-  EXPECT_TRUE(instance->checkConsistency());
+  ASSERT_TRUE(instance->checkConsistency());
   // large and allocations.back() were both freed and nothing was allocated.
-  EXPECT_EQ(kSmallSize * (allocations.size() - 1), instance->numAllocated());
+  ASSERT_EQ(kSmallSize * (allocations.size() - 1), instance->numAllocated());
   // An extra kSmallSize were freed.
-  EXPECT_EQ(-kSmallSize * MemoryAllocator::kPageSize, trackedBytes);
+  ASSERT_EQ(-kSmallSize * MemoryAllocator::kPageSize, trackedBytes);
   // Remove the cleared item from the end.
   allocations.pop_back();
 
   trackedBytes = 0;
-  EXPECT_TRUE(instance->allocateContiguous(
+  ASSERT_TRUE(instance->allocateContiguous(
       kLargeSize / 2, nullptr, large, trackCallback));
   instance->testingInjectFailure(MmapAllocator::Failure::kMmap);
   // Should go through because 1/2 of kLargeSize + kSmallSize free and 1/2 of
   // kLargeSize already in large. Fails because mmap after advise away fails.
-  EXPECT_FALSE(instance->allocateContiguous(
+  ASSERT_FALSE(instance->allocateContiguous(
       kLargeSize + 2 * kSmallSize,
       allocations.back().get(),
       large,
       trackCallback));
   // large and allocations.back() were both freed and nothing was allocated.
-  EXPECT_EQ(kSmallSize * (allocations.size() - 1), instance->numAllocated());
-  EXPECT_EQ(-kSmallSize * MemoryAllocator::kPageSize, trackedBytes);
+  ASSERT_EQ(kSmallSize * (allocations.size() - 1), instance->numAllocated());
+  ASSERT_EQ(-kSmallSize * MemoryAllocator::kPageSize, trackedBytes);
   allocations.pop_back();
-  EXPECT_TRUE(instance->checkConsistency());
+  ASSERT_TRUE(instance->checkConsistency());
 
   trackedBytes = 0;
-  EXPECT_TRUE(instance->allocateContiguous(
+  ASSERT_TRUE(instance->allocateContiguous(
       kLargeSize / 2, nullptr, large, trackCallback));
   // We succeed without injected failure.
-  EXPECT_TRUE(instance->allocateContiguous(
+  ASSERT_TRUE(instance->allocateContiguous(
       kLargeSize + 3 * kSmallSize,
       allocations.back().get(),
       large,
       trackCallback));
-  EXPECT_EQ(kCapacity, instance->numMapped());
-  EXPECT_EQ(kCapacity, instance->numAllocated());
+  ASSERT_EQ(kCapacity, instance->numMapped());
+  ASSERT_EQ(kCapacity, instance->numAllocated());
   // Size grew by kLargeSize + 2 * kSmallSize (one kSmallSize item was freed, so
   // no not 3 x kSmallSize).
-  EXPECT_EQ(
+  ASSERT_EQ(
       (kLargeSize + 2 * kSmallSize) * MemoryAllocator::kPageSize, trackedBytes);
-  EXPECT_TRUE(instance->checkConsistency());
+  ASSERT_TRUE(instance->checkConsistency());
+  instance_->freeContiguous(large);
+  ASSERT_TRUE(instance->checkConsistency());
+  clearAllocations(allocations);
+  ASSERT_TRUE(instance->checkConsistency());
 }
 
 TEST_P(MemoryAllocatorTest, allocateBytes) {
@@ -948,15 +1132,14 @@ TEST_P(MemoryAllocatorTest, StlMemoryAllocator) {
 DEBUG_ONLY_TEST_P(
     MemoryAllocatorTest,
     nonContiguousScopedMemoryAllocatorAllocationFailure) {
-  auto tracker = MemoryUsageTracker::create();
-  ASSERT_EQ(tracker->getCurrentUserBytes(), 0);
-  auto* MemoryAllocator = MemoryAllocator::getInstance();
-  auto scopedMemory = MemoryAllocator->addChild(tracker);
-  ASSERT_EQ(tracker->getCurrentUserBytes(), 0);
+  if (!memoryUsageTracker_) {
+    GTEST_SKIP();
+  }
+  ASSERT_EQ(memoryUsageTracker_->getCurrentUserBytes(), 0);
 
   const std::string testValueStr = useMmap_
-      ? "facebook::velox::memory::MmapAllocator::allocate"
-      : "facebook::velox::memory::MemoryAllocatorImpl::allocate";
+      ? "facebook::velox::memory::MmapAllocator::allocateNonContiguous"
+      : "facebook::velox::memory::MemoryAllocatorImpl::allocateNonContiguous";
   std::atomic<bool> testingInjectFailureOnce{true};
   SCOPED_TESTVALUE_SET(
       testValueStr, std::function<void(bool*)>([&](bool* testFlag) {
@@ -972,51 +1155,167 @@ DEBUG_ONLY_TEST_P(
 
   constexpr MachinePageCount kAllocSize = 8;
   std::unique_ptr<MemoryAllocator::Allocation> allocation(
-      new MemoryAllocator::Allocation(scopedMemory.get()));
-  ASSERT_FALSE(scopedMemory->allocateNonContiguous(kAllocSize, 0, *allocation));
-  ASSERT_EQ(tracker->getCurrentUserBytes(), 0);
-  ASSERT_TRUE(scopedMemory->allocateNonContiguous(kAllocSize, 0, *allocation));
-  ASSERT_GT(tracker->getCurrentUserBytes(), 0);
-  allocation.reset();
-  ASSERT_EQ(tracker->getCurrentUserBytes(), 0);
+      new MemoryAllocator::Allocation());
+  ASSERT_FALSE(instance_->allocateNonContiguous(kAllocSize, *allocation));
+  ASSERT_EQ(memoryUsageTracker_->getCurrentUserBytes(), 0);
+  ASSERT_TRUE(instance_->allocateNonContiguous(kAllocSize, *allocation));
+  ASSERT_GT(memoryUsageTracker_->getCurrentUserBytes(), 0);
+  instance_->freeNonContiguous(*allocation);
+  ASSERT_EQ(memoryUsageTracker_->getCurrentUserBytes(), 0);
 }
 
 TEST_P(MemoryAllocatorTest, contiguousScopedMemoryAllocatorAllocationFailure) {
-  if (!useMmap_) {
+  if (!useMmap_ || !hasMemoryTracker_) {
     // This test doesn't apply for MemoryAllocatorImpl which doesn't have memory
     // allocation failure rollback code path.
-    return;
+    GTEST_SKIP();
   }
-  auto* MemoryAllocator =
-      dynamic_cast<MmapAllocator*>(MemoryAllocator::getInstance());
   std::vector<MmapAllocator::Failure> failureTypes(
       {MmapAllocator::Failure::kMadvise, MmapAllocator::Failure::kMmap});
   for (const auto& failure : failureTypes) {
-    MemoryAllocator->testingInjectFailure(failure);
-    auto tracker = MemoryUsageTracker::create();
-    ASSERT_EQ(tracker->getCurrentUserBytes(), 0);
-    auto scopedMemory = MemoryAllocator->addChild(tracker);
-    ASSERT_EQ(tracker->getCurrentUserBytes(), 0);
+    mmapAllocator_->testingInjectFailure(failure);
+    ASSERT_EQ(memoryUsageTracker_->getCurrentUserBytes(), 0);
 
     constexpr MachinePageCount kAllocSize = 8;
     std::unique_ptr<MemoryAllocator::ContiguousAllocation> allocation(
         new MemoryAllocator::ContiguousAllocation());
     ASSERT_FALSE(
-        scopedMemory->allocateContiguous(kAllocSize, nullptr, *allocation));
-    ASSERT_EQ(tracker->getCurrentUserBytes(), 0);
-    MemoryAllocator->testingInjectFailure(MmapAllocator::Failure::kNone);
+        instance_->allocateContiguous(kAllocSize, nullptr, *allocation));
+    ASSERT_EQ(memoryUsageTracker_->getCurrentUserBytes(), 0);
+    mmapAllocator_->testingInjectFailure(MmapAllocator::Failure::kNone);
     ASSERT_TRUE(
-        scopedMemory->allocateContiguous(kAllocSize, nullptr, *allocation));
-    ASSERT_GT(tracker->getCurrentUserBytes(), 0);
-    allocation.reset();
-    ASSERT_EQ(tracker->getCurrentUserBytes(), 0);
+        instance_->allocateContiguous(kAllocSize, nullptr, *allocation));
+    ASSERT_GT(memoryUsageTracker_->getCurrentUserBytes(), 0);
+    instance_->freeContiguous(*allocation);
+    ASSERT_EQ(memoryUsageTracker_->getCurrentUserBytes(), 0);
   }
+}
+
+TEST_P(MemoryAllocatorTest, allocation) {
+  const MachinePageCount kNumPages = 133;
+  const MachinePageCount kMinClassSize = 20;
+  auto allocation = std::make_unique<MemoryAllocator::Allocation>();
+  ASSERT_TRUE(allocation->empty());
+  ASSERT_EQ(allocation->pool(), nullptr);
+  ASSERT_EQ(allocation->numPages(), 0);
+  ASSERT_EQ(allocation->numRuns(), 0);
+  ASSERT_THROW(
+      instance_->allocateNonContiguous(0, *allocation, nullptr, kMinClassSize),
+      VeloxRuntimeError);
+  ASSERT_TRUE(instance_->allocateNonContiguous(
+      kNumPages, *allocation, nullptr, kMinClassSize));
+  ASSERT_TRUE(!allocation->empty());
+  ASSERT_EQ(allocation->pool(), nullptr);
+  ASSERT_GT(allocation->numPages(), kNumPages);
+  ASSERT_GT(allocation->numRuns(), 0);
+  {
+    MemoryAllocator::Allocation movedAllocation = std::move(*allocation);
+    ASSERT_TRUE(allocation->empty());
+    ASSERT_TRUE(!movedAllocation.empty());
+    *allocation = std::move(movedAllocation);
+    ASSERT_TRUE(!allocation->empty());
+    ASSERT_TRUE(movedAllocation.empty());
+  }
+  ASSERT_DEATH(allocation.reset(), "");
+  instance_->freeNonContiguous(*allocation);
+  ASSERT_TRUE(allocation->empty());
+  ASSERT_EQ(allocation->pool(), nullptr);
+  ASSERT_EQ(allocation->numPages(), 0);
+  ASSERT_EQ(allocation->numRuns(), 0);
+  uint8_t* fakePtr = reinterpret_cast<uint8_t*>(allocation.get());
+  allocation->append(fakePtr, kNumPages);
+  ASSERT_EQ(allocation->numRuns(), 1);
+  ASSERT_EQ(allocation->numPages(), kNumPages);
+  ASSERT_EQ(allocation->pool(), nullptr);
+  ASSERT_TRUE(!allocation->empty());
+  allocation->setPool(pool_.get());
+  ASSERT_EQ(allocation->pool(), pool_.get());
+  {
+    MemoryAllocator::Allocation movedAllocation = std::move(*allocation);
+    ASSERT_TRUE(allocation->empty());
+    ASSERT_TRUE(!movedAllocation.empty());
+    ASSERT_EQ(movedAllocation.pool(), pool_.get());
+    *allocation = std::move(movedAllocation);
+    ASSERT_TRUE(!allocation->empty());
+    ASSERT_TRUE(movedAllocation.empty());
+    ASSERT_EQ(allocation->pool(), pool_.get());
+  }
+  ASSERT_THROW(allocation->setPool(pool_.get()), VeloxRuntimeError);
+  ASSERT_TRUE(!allocation->empty());
+  allocation->clear();
+  ASSERT_TRUE(allocation->empty());
+  ASSERT_EQ(allocation->numPages(), 0);
+  ASSERT_EQ(allocation->numRuns(), 0);
+  ASSERT_EQ(allocation->pool(), nullptr);
+  allocation->setPool(pool_.get());
+  ASSERT_THROW(allocation->setPool(pool_.get()), VeloxRuntimeError);
+  ASSERT_DEATH(allocation.reset(), "");
+  ASSERT_THROW(allocation->empty(), VeloxRuntimeError);
+  allocation->clear();
+}
+
+TEST_P(MemoryAllocatorTest, contiguousAllocation) {
+  const MachinePageCount kNumPages = instance_->largestSizeClass() + 1;
+  auto allocation = std::make_unique<MemoryAllocator::ContiguousAllocation>();
+  ASSERT_TRUE(allocation->empty());
+  ASSERT_EQ(allocation->pool(), nullptr);
+  ASSERT_EQ(allocation->numPages(), 0);
+  ASSERT_THROW(
+      instance_->allocateContiguous(0, nullptr, *allocation),
+      VeloxRuntimeError);
+  ASSERT_TRUE(instance_->allocateContiguous(kNumPages, nullptr, *allocation));
+  ASSERT_TRUE(!allocation->empty());
+  ASSERT_EQ(allocation->pool(), nullptr);
+  ASSERT_EQ(allocation->numPages(), kNumPages);
+  {
+    MemoryAllocator::ContiguousAllocation movedAllocation =
+        std::move(*allocation);
+    ASSERT_TRUE(allocation->empty());
+    ASSERT_TRUE(!movedAllocation.empty());
+    *allocation = std::move(movedAllocation);
+    ASSERT_TRUE(!allocation->empty());
+    ASSERT_TRUE(movedAllocation.empty());
+  }
+  ASSERT_DEATH(allocation.reset(), "");
+  instance_->freeContiguous(*allocation);
+  ASSERT_TRUE(allocation->empty());
+  ASSERT_EQ(allocation->pool(), nullptr);
+  ASSERT_EQ(allocation->numPages(), 0);
+  uint8_t* fakePtr = reinterpret_cast<uint8_t*>(allocation.get());
+  allocation->set(fakePtr, kNumPages * MemoryAllocator::kPageSize);
+  ASSERT_EQ(allocation->numPages(), kNumPages);
+  ASSERT_EQ(allocation->pool(), nullptr);
+  ASSERT_TRUE(!allocation->empty());
+  allocation->setPool(pool_.get());
+  ASSERT_EQ(allocation->pool(), pool_.get());
+  {
+    MemoryAllocator::ContiguousAllocation movedAllocation =
+        std::move(*allocation);
+    ASSERT_TRUE(allocation->empty());
+    ASSERT_TRUE(!movedAllocation.empty());
+    ASSERT_EQ(movedAllocation.pool(), pool_.get());
+    *allocation = std::move(movedAllocation);
+    ASSERT_TRUE(!allocation->empty());
+    ASSERT_TRUE(movedAllocation.empty());
+    ASSERT_EQ(allocation->pool(), pool_.get());
+  }
+  ASSERT_THROW(allocation->setPool(pool_.get()), VeloxRuntimeError);
+  ASSERT_TRUE(!allocation->empty());
+  allocation->clear();
+  ASSERT_TRUE(allocation->empty());
+  ASSERT_EQ(allocation->numPages(), 0);
+  ASSERT_EQ(allocation->pool(), nullptr);
+  allocation->setPool(pool_.get());
+  ASSERT_THROW(allocation->setPool(pool_.get()), VeloxRuntimeError);
+  ASSERT_DEATH(allocation.reset(), "");
+  ASSERT_THROW(allocation->empty(), VeloxRuntimeError);
+  allocation->clear();
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
     MemoryAllocatorTests,
     MemoryAllocatorTest,
-    testing::Values(true, false));
+    testing::ValuesIn(MemoryAllocatorTest::getTestParams()));
 
 class MmapArenaTest : public testing::Test {
  public:
@@ -1116,16 +1415,16 @@ TEST_F(MmapArenaTest, managedMmapArenas) {
     // Test natural growing of ManagedMmapArena
     std::unique_ptr<ManagedMmapArenas> managedArenas =
         std::make_unique<ManagedMmapArenas>(kArenaCapacityBytes);
-    EXPECT_EQ(managedArenas->arenas().size(), 1);
+    ASSERT_EQ(managedArenas->arenas().size(), 1);
     void* alloc1 = managedArenas->allocate(kArenaCapacityBytes);
-    EXPECT_EQ(managedArenas->arenas().size(), 1);
+    ASSERT_EQ(managedArenas->arenas().size(), 1);
     void* alloc2 = managedArenas->allocate(kArenaCapacityBytes);
-    EXPECT_EQ(managedArenas->arenas().size(), 2);
+    ASSERT_EQ(managedArenas->arenas().size(), 2);
 
     managedArenas->free(alloc2, kArenaCapacityBytes);
-    EXPECT_EQ(managedArenas->arenas().size(), 2);
+    ASSERT_EQ(managedArenas->arenas().size(), 2);
     managedArenas->free(alloc1, kArenaCapacityBytes);
-    EXPECT_EQ(managedArenas->arenas().size(), 1);
+    ASSERT_EQ(managedArenas->arenas().size(), 1);
   }
 
   {
@@ -1142,7 +1441,7 @@ TEST_F(MmapArenaTest, managedMmapArenas) {
             reinterpret_cast<uint64_t>(allocResult));
       }
     }
-    EXPECT_EQ(managedArenas->arenas().size(), 1);
+    ASSERT_EQ(managedArenas->arenas().size(), 1);
 
     // Free every other allocations so that the single MmapArena is fragmented
     // that it can no longer handle allocations of size larger than kAllocSize
@@ -1151,7 +1450,7 @@ TEST_F(MmapArenaTest, managedMmapArenas) {
     }
 
     managedArenas->allocate(kAllocSize * 2);
-    EXPECT_EQ(managedArenas->arenas().size(), 2);
+    ASSERT_EQ(managedArenas->arenas().size(), 2);
   }
 }
 } // namespace facebook::velox::memory

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "velox/common/memory/Memory.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/dwio/type/fbhive/HiveTypeParser.h"
 
@@ -82,6 +83,39 @@ class MockMemoryPool : public velox::memory::MemoryPool {
   void free(void* p, int64_t size) override {
     allocator_->freeBytes(p, size);
     updateLocalMemoryUsage(-size);
+  }
+
+  bool allocateNonContiguous(
+      velox::memory::MachinePageCount /*unused*/,
+      velox::memory::MemoryAllocator::Allocation& /*unused*/,
+      velox::memory::MachinePageCount /*unused*/) override {
+    VELOX_UNSUPPORTED("allocateNonContiguous unsupported");
+  }
+
+  void freeNonContiguous(
+      velox::memory::MemoryAllocator::Allocation& /*unused*/) override {
+    VELOX_UNSUPPORTED("freeNonContiguous unsupported");
+  }
+
+  velox::memory::MachinePageCount largestSizeClass() const override {
+    VELOX_UNSUPPORTED("largestSizeClass unsupported");
+  }
+
+  const std::vector<velox::memory::MachinePageCount>& sizeClasses()
+      const override {
+    VELOX_UNSUPPORTED("sizeClasses unsupported");
+  }
+
+  bool allocateContiguous(
+      velox::memory::MachinePageCount /*unused*/,
+      velox::memory::MemoryAllocator::ContiguousAllocation& /*unused*/)
+      override {
+    VELOX_UNSUPPORTED("allocateContiguous unsupported");
+  }
+
+  void freeContiguous(velox::memory::MemoryAllocator::ContiguousAllocation&
+                      /*unused*/) override {
+    VELOX_UNSUPPORTED("freeContiguous unsupported");
   }
 
   int64_t getCurrentBytes() const override {

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -61,13 +61,12 @@ GroupingSet::GroupingSet(
       constantLists_(std::move(constantLists)),
       intermediateTypes_(std::move(intermediateTypes)),
       ignoreNullKeys_(ignoreNullKeys),
-      allocator_(operatorCtx->allocator()),
       spillMemoryThreshold_(operatorCtx->driverCtx()
                                 ->queryConfig()
                                 .aggregationSpillMemoryThreshold()),
       spillConfig_(spillConfig),
-      stringAllocator_(allocator_),
-      rows_(allocator_),
+      stringAllocator_(operatorCtx->pool()),
+      rows_(operatorCtx->pool()),
       isAdaptive_(operatorCtx->task()
                       ->queryCtx()
                       ->queryConfig()
@@ -251,10 +250,10 @@ void GroupingSet::addRemainingInput() {
 void GroupingSet::createHashTable() {
   if (ignoreNullKeys_) {
     table_ = HashTable<true>::createForAggregation(
-        std::move(hashers_), aggregates_, allocator_);
+        std::move(hashers_), aggregates_, &pool_);
   } else {
     table_ = HashTable<false>::createForAggregation(
-        std::move(hashers_), aggregates_, allocator_);
+        std::move(hashers_), aggregates_, &pool_);
   }
   lookup_ = std::make_unique<HashLookup>(table_->hashers());
   if (!isAdaptive_ && table_->hashMode() != BaseHashTable::HashMode::kHash) {
@@ -506,7 +505,7 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
     return;
   }
 
-  auto tracker = allocator_->tracker();
+  auto tracker = pool_.getMemoryUsageTracker();
   const auto currentUsage = tracker->getCurrentUserBytes();
   if (spillMemoryThreshold_ != 0 && currentUsage > spillMemoryThreshold_) {
     const int64_t bytesToSpill =
@@ -563,7 +562,7 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
     for (auto i = 0; i < types.size(); ++i) {
       names.push_back(fmt::format("s{}", i));
     }
-    VELOX_DCHECK(allocator_->tracker() != nullptr);
+    VELOX_DCHECK(pool_.getMemoryUsageTracker() != nullptr);
     spiller_ = std::make_unique<Spiller>(
         Spiller::Type::kAggregate,
         rows,
@@ -601,7 +600,7 @@ bool GroupingSet::getOutputWithSpill(
         false,
         false,
         false,
-        allocator_,
+        &pool_,
         ContainerRowSerde::instance());
     // Take ownership of the rows and free the hash table. The table will not be
     // needed for producing spill output.

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -179,8 +179,6 @@ class GroupingSet {
 
   const bool ignoreNullKeys_;
 
-  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
-
   // The maximum memory usage that a final aggregation can hold before spilling.
   // If it is zero, then there is no such limit.
   const uint64_t spillMemoryThreshold_;
@@ -248,6 +246,7 @@ class GroupingSet {
 
   // Index of first in 'nonSpilledRows_' that has not been added to output.
   size_t nonSpilledIndex_ = 0;
+
   // Pool of the OperatorCtx. Used for spilling.
   memory::MemoryPool& pool_;
 

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -239,9 +239,6 @@ class HashBuild final : public Operator {
 
   const core::JoinType joinType_;
 
-  // Holds the areas in RowContainer of 'table_'
-  memory::MemoryAllocator* const FOLLY_NONNULL allocator_;
-
   const std::shared_ptr<HashJoinBridge> joinBridge_;
 
   const std::optional<Spiller::Config> spillConfig_;

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -38,7 +38,7 @@ HashTable<ignoreNullKeys>::HashTable(
     bool allowDuplicates,
     bool isJoinBuild,
     bool hasProbedFlag,
-    memory::MemoryAllocator* allocator)
+    memory::MemoryPool* pool)
     : BaseHashTable(std::move(hashers)), isJoinBuild_(isJoinBuild) {
   std::vector<TypePtr> keys;
   for (auto& hasher : hashers_) {
@@ -56,7 +56,7 @@ HashTable<ignoreNullKeys>::HashTable(
       isJoinBuild,
       hasProbedFlag,
       hashMode_ != HashMode::kHash,
-      allocator,
+      pool,
       ContainerRowSerde::instance());
   nextOffset_ = rows_->nextOffset();
 }
@@ -588,8 +588,7 @@ void HashTable<ignoreNullKeys>::allocateTables(uint64_t size) {
     // The total size is 9 bytes per slot, 8 in the pointers table and 1 in the
     // tags table.
     auto numPages = bits::roundUp(size * 9, kPageSize) / kPageSize;
-    if (!rows_->allocator()->allocateContiguous(
-            numPages, nullptr, tableAllocation_)) {
+    if (!rows_->pool()->allocateContiguous(numPages, tableAllocation_)) {
       VELOX_FAIL("Could not allocate join/group by hash table");
     }
     table_ = tableAllocation_.data<char*>();
@@ -1070,8 +1069,7 @@ void HashTable<ignoreNullKeys>::setHashMode(HashMode mode, int32_t numNew) {
     auto bytes = size_ * sizeof(char*);
     constexpr auto kPageSize = memory::MemoryAllocator::kPageSize;
     auto numPages = bits::roundUp(bytes, kPageSize) / kPageSize;
-    if (!rows_->allocator()->allocateContiguous(
-            numPages, nullptr, tableAllocation_)) {
+    if (!rows_->pool()->allocateContiguous(numPages, tableAllocation_)) {
       VELOX_FAIL(
           "Could not allocate array with {} bytes/{} pages for array mode hash table",
           bytes,

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -283,12 +283,12 @@ class HashTable : public BaseHashTable {
       bool allowDuplicates,
       bool isJoinBuild,
       bool hasProbedFlag,
-      memory::MemoryAllocator* FOLLY_NULLABLE memory);
+      memory::MemoryPool* FOLLY_NULLABLE pool);
 
   static std::unique_ptr<HashTable> createForAggregation(
       std::vector<std::unique_ptr<VectorHasher>>&& hashers,
       const std::vector<std::unique_ptr<Aggregate>>& aggregates,
-      memory::MemoryAllocator* FOLLY_NULLABLE memory) {
+      memory::MemoryPool* FOLLY_NULLABLE pool) {
     return std::make_unique<HashTable>(
         std::move(hashers),
         aggregates,
@@ -296,7 +296,7 @@ class HashTable : public BaseHashTable {
         false, // allowDuplicates
         false, // isJoinBuild
         false, // hasProbedFlag
-        memory);
+        pool);
   }
 
   static std::unique_ptr<HashTable> createForJoin(
@@ -304,7 +304,7 @@ class HashTable : public BaseHashTable {
       const std::vector<TypePtr>& dependentTypes,
       bool allowDuplicates,
       bool hasProbedFlag,
-      memory::MemoryAllocator* FOLLY_NULLABLE memory) {
+      memory::MemoryPool* FOLLY_NULLABLE pool) {
     static const std::vector<std::unique_ptr<Aggregate>> kNoAggregates;
     return std::make_unique<HashTable>(
         std::move(hashers),
@@ -313,7 +313,7 @@ class HashTable : public BaseHashTable {
         allowDuplicates,
         true, // isJoinBuild
         hasProbedFlag,
-        memory);
+        pool);
   }
 
   virtual ~HashTable() override = default;

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -232,14 +232,6 @@ std::optional<uint32_t> Operator::maxDrivers(
   return std::nullopt;
 }
 
-memory::MemoryAllocator* OperatorCtx::allocator() const {
-  if (allocator_ == nullptr) {
-    allocator_ =
-        driverCtx_->task->addOperatorMemory(pool_->getMemoryUsageTracker());
-  }
-  return allocator_;
-}
-
 const std::string& OperatorCtx::taskId() const {
   return driverCtx_->task->taskId();
 }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -197,8 +197,6 @@ class OperatorCtx {
     return operatorType_;
   }
 
-  memory::MemoryAllocator* FOLLY_NONNULL allocator() const;
-
   core::ExecCtx* FOLLY_NONNULL execCtx() const;
 
   /// Makes an extract of QueryCtx for use in a connector. 'planNodeId'
@@ -220,7 +218,6 @@ class OperatorCtx {
   velox::memory::MemoryPool* const FOLLY_NONNULL pool_;
 
   // These members are created on demand.
-  mutable memory::MemoryAllocator* FOLLY_NULLABLE allocator_{nullptr};
   mutable std::unique_ptr<core::ExecCtx> execCtx_;
   mutable std::unique_ptr<connector::ExpressionEvaluator> expressionEvaluator_;
 };

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -78,8 +78,6 @@ class OrderBy : public Operator {
   // in a paused state and off thread.
   void spill(int64_t targetRows, int64_t targetBytes);
 
-  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
-
   const int32_t numSortKeys_;
 
   // The maximum memory usage that an order by can hold before spilling.

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -63,7 +63,7 @@ void Destination::serialize(
     vector_size_t begin,
     vector_size_t end) {
   if (!current_) {
-    current_ = std::make_unique<VectorStreamGroup>(allocator_);
+    current_ = std::make_unique<VectorStreamGroup>(pool_);
     auto rowType = std::dynamic_pointer_cast<const RowType>(output->type());
     vector_size_t numRows = 0;
     for (vector_size_t i = begin; i < end; i++) {
@@ -84,7 +84,7 @@ BlockingReason Destination::flush(
   constexpr int32_t kMinMessageSize = 128;
   auto listener = bufferManager.newListener();
   IOBufOutputStream stream(
-      *current_->allocator(),
+      *current_->pool(),
       listener.get(),
       std::max<int64_t>(kMinMessageSize, current_->size()));
   current_->flush(&stream);
@@ -123,8 +123,7 @@ PartitionedOutput::PartitionedOutput(
       bufferManager_(PartitionedOutputBufferManager::getInstance()),
       maxBufferedBytes_(ctx->task->queryCtx()
                             ->queryConfig()
-                            .maxPartitionedOutputBufferSize()),
-      allocator_{operatorCtx_->allocator()} {
+                            .maxPartitionedOutputBufferSize()) {
   if (numDestinations_ == 1 || planNode->isBroadcast()) {
     VELOX_CHECK(keyChannels_.empty());
     VELOX_CHECK_NULL(partitionFunction_);
@@ -156,8 +155,7 @@ void PartitionedOutput::initializeDestinations() {
   if (destinations_.empty()) {
     auto taskId = operatorCtx_->taskId();
     for (int i = 0; i < numDestinations_; ++i) {
-      destinations_.push_back(
-          std::make_unique<Destination>(taskId, i, allocator_));
+      destinations_.push_back(std::make_unique<Destination>(taskId, i, pool()));
     }
   }
 }

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -27,8 +27,8 @@ class Destination {
   Destination(
       const std::string& taskId,
       int destination,
-      memory::MemoryAllocator* FOLLY_NONNULL allocator)
-      : taskId_(taskId), destination_(destination), allocator_(allocator) {
+      memory::MemoryPool* FOLLY_NONNULL pool)
+      : taskId_(taskId), destination_(destination), pool_(pool) {
     setTargetSizePct();
   }
 
@@ -89,7 +89,7 @@ class Destination {
 
   const std::string taskId_;
   const int destination_;
-  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
+  memory::MemoryPool* FOLLY_NONNULL const pool_;
   uint64_t bytesInCurrent_{0};
   std::vector<IndexRange> rows_;
 
@@ -190,7 +190,6 @@ class PartitionedOutput : public Operator {
   bool replicatedAny_{false};
   std::weak_ptr<exec::PartitionedOutputBufferManager> bufferManager_;
   const int64_t maxBufferedBytes_;
-  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
   RowVectorPtr output_;
 
   // Reusable memory.

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -54,15 +54,15 @@ RowContainer::RowContainer(
     bool isJoinBuild,
     bool hasProbedFlag,
     bool hasNormalizedKeys,
-    memory::MemoryAllocator* allocator,
+    memory::MemoryPool* pool,
     const RowSerde& serde)
     : keyTypes_(keyTypes),
       nullableKeys_(nullableKeys),
       aggregates_(aggregates),
       isJoinBuild_(isJoinBuild),
       hasNormalizedKeys_(hasNormalizedKeys),
-      rows_(allocator),
-      stringAllocator_(allocator),
+      rows_(pool),
+      stringAllocator_(pool),
       serde_(serde) {
   // Compute the layout of the payload row.  The row has keys, null
   // flags, accumulators, dependent fields. All fields are fixed
@@ -630,7 +630,7 @@ void RowContainer::skip(RowContainerIterator& iter, int32_t numRows) {
 
 RowPartitions& RowContainer::partitions() {
   if (!partitions_) {
-    partitions_ = std::make_unique<RowPartitions>(numRows_, *rows_.allocator());
+    partitions_ = std::make_unique<RowPartitions>(numRows_, *rows_.pool());
   }
   return *partitions_;
 }
@@ -705,13 +705,11 @@ int32_t RowContainer::listPartitionRows(
   return numResults;
 }
 
-RowPartitions::RowPartitions(
-    int32_t numRows,
-    memory::MemoryAllocator& allocator)
-    : capacity_(numRows), allocation_(&allocator) {
+RowPartitions::RowPartitions(int32_t numRows, memory::MemoryPool& pool)
+    : capacity_(numRows) {
   auto numPages = bits::roundUp(capacity_, memory::MemoryAllocator::kPageSize) /
       memory::MemoryAllocator::kPageSize;
-  if (!allocator.allocateNonContiguous(numPages, 0, allocation_)) {
+  if (!pool.allocateNonContiguous(numPages, allocation_)) {
     VELOX_FAIL(
         "Failed to allocate RowContainer partitions: {} pages", numPages);
   }

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -66,7 +66,7 @@ struct RowContainerIterator {
 class RowPartitions {
  public:
   /// Initializes this to hold up to 'numRows'.
-  RowPartitions(int32_t numRows, memory::MemoryAllocator& allocator);
+  RowPartitions(int32_t numRows, memory::MemoryPool& pool);
 
   /// Appends 'partitions' to the end of 'this'. Throws if adding more than the
   /// capacity given at construction.
@@ -136,13 +136,13 @@ class RowContainer {
   // allocation.
   RowContainer(
       const std::vector<TypePtr>& keyTypes,
-      memory::MemoryAllocator* FOLLY_NONNULL allocator)
-      : RowContainer(keyTypes, std::vector<TypePtr>{}, allocator) {}
+      memory::MemoryPool* FOLLY_NONNULL pool)
+      : RowContainer(keyTypes, std::vector<TypePtr>{}, pool) {}
 
   RowContainer(
       const std::vector<TypePtr>& keyTypes,
       const std::vector<TypePtr>& dependentTypes,
-      memory::MemoryAllocator* FOLLY_NONNULL allocator)
+      memory::MemoryPool* FOLLY_NONNULL pool)
       : RowContainer(
             keyTypes,
             true, // nullableKeys
@@ -152,7 +152,7 @@ class RowContainer {
             false, // isJoinBuild
             false, // hasProbedFlag
             false, // hasNormalizedKey
-            allocator,
+            pool,
             ContainerRowSerde::instance()) {}
 
   // 'keyTypes' gives the type of the key of each row. For a group by,
@@ -180,7 +180,7 @@ class RowContainer {
       bool isJoinBuild,
       bool hasProbedFlag,
       bool hasNormalizedKey,
-      memory::MemoryAllocator* FOLLY_NONNULL allocator,
+      memory::MemoryPool* FOLLY_NONNULL pool,
       const RowSerde& serde);
 
   // Allocates a new row and initializes possible aggregates to null.
@@ -570,8 +570,8 @@ class RowContainer {
     }
   }
 
-  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
-    return stringAllocator_.allocator();
+  memory::MemoryPool* FOLLY_NONNULL pool() const {
+    return stringAllocator_.pool();
   }
 
   // Returns the types of all non-aggregate columns of 'this', keys first.

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -102,7 +102,7 @@ WriteFile& SpillFileList::currentOutput() {
 void SpillFileList::flush() {
   if (batch_) {
     IOBufOutputStream out(
-        allocator_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
+        pool_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
     batch_->flush(&out);
     batch_.reset();
     auto iobuf = out.getIOBuf();
@@ -118,7 +118,7 @@ void SpillFileList::write(
     const RowVectorPtr& rows,
     const folly::Range<IndexRange*>& indices) {
   if (!batch_) {
-    batch_ = std::make_unique<VectorStreamGroup>(&allocator_);
+    batch_ = std::make_unique<VectorStreamGroup>(&pool_);
     batch_->createStreamTree(
         std::static_pointer_cast<const RowType>(rows->type()),
         1000,
@@ -182,8 +182,7 @@ void SpillState::appendToPartition(
         sortCompareFlags_,
         fmt::format("{}-spill-{}", path_, partition),
         targetFileSize_,
-        pool_,
-        allocator_);
+        pool_);
   }
 
   IndexRange range{0, rows->size()};

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -170,15 +170,13 @@ class SpillFileList {
       const std::vector<CompareFlags>& sortCompareFlags,
       const std::string& path,
       uint64_t targetFileSize,
-      memory::MemoryPool& pool,
-      memory::MemoryAllocator& allocator)
+      memory::MemoryPool& pool)
       : type_(type),
         numSortingKeys_(numSortingKeys),
         sortCompareFlags_(sortCompareFlags),
         path_(path),
         targetFileSize_(targetFileSize),
-        pool_(pool),
-        allocator_(allocator) {
+        pool_(pool) {
     // NOTE: if the associated spilling operator has specified the sort
     // comparison flags, then it must match the number of sorting keys.
     VELOX_CHECK(
@@ -230,7 +228,6 @@ class SpillFileList {
   const std::string path_;
   const uint64_t targetFileSize_;
   memory::MemoryPool& pool_;
-  memory::MemoryAllocator& allocator_;
   std::unique_ptr<VectorStreamGroup> batch_;
   SpillFiles files_;
 };
@@ -558,15 +555,13 @@ class SpillState {
       int32_t numSortingKeys,
       const std::vector<CompareFlags>& sortCompareFlags,
       uint64_t targetFileSize,
-      memory::MemoryPool& pool,
-      memory::MemoryAllocator& allocator)
+      memory::MemoryPool& pool)
       : path_(path),
         maxPartitions_(maxPartitions),
         numSortingKeys_(numSortingKeys),
         sortCompareFlags_(sortCompareFlags),
         targetFileSize_(targetFileSize),
         pool_(pool),
-        allocator_(allocator),
         files_(maxPartitions_) {}
 
   /// Indicates if a given 'partition' has been spilled or not.
@@ -652,7 +647,6 @@ class SpillState {
   const uint64_t targetFileSize_;
 
   memory::MemoryPool& pool_;
-  memory::MemoryAllocator& allocator_;
 
   // A set of spilled partition numbers.
   SpillPartitionNumSet spilledPartitionSet_;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -22,8 +22,9 @@
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
-
-constexpr int kLogEveryN = 32;
+namespace {
+constexpr int32_t kLogEveryN = 32;
+}
 
 Spiller::Spiller(
     Type type,
@@ -103,8 +104,7 @@ Spiller::Spiller(
           numSortingKeys,
           sortCompareFlags,
           targetFileSize,
-          pool,
-          spillMemoryAllocator()),
+          pool),
       pool_(pool),
       executor_(executor) {
   TestValue::adjust(

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -99,7 +99,7 @@ StreamingAggregation::StreamingAggregation(
       false,
       false,
       false,
-      operatorCtx_->allocator(),
+      pool(),
       ContainerRowSerde::instance());
 }
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -214,13 +214,6 @@ velox::memory::MemoryPool* FOLLY_NONNULL Task::addOperatorPool(
   return childPools_.back().get();
 }
 
-memory::MemoryAllocator* FOLLY_NONNULL Task::addOperatorMemory(
-    const std::shared_ptr<memory::MemoryUsageTracker>& tracker) {
-  auto allocator = queryCtx_->allocator()->addChild(tracker);
-  childAllocators_.emplace_back(allocator);
-  return allocator.get();
-}
-
 bool Task::supportsSingleThreadedExecution() const {
   std::vector<std::unique_ptr<DriverFactory>> driverFactories;
 
@@ -1495,7 +1488,7 @@ ContinueFuture Task::stateChangeFuture(uint64_t maxWaitMicros) {
   auto [promise, future] = makeVeloxContinuePromiseContract(
       fmt::format("Task::stateChangeFuture {}", taskId_));
   stateChangePromises_.emplace_back(std::move(promise));
-  if (maxWaitMicros) {
+  if (maxWaitMicros > 0) {
     return std::move(future).within(std::chrono::microseconds(maxWaitMicros));
   }
   return std::move(future);

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -272,12 +272,6 @@ class Task : public std::enable_shared_from_this<Task> {
       int pipelineId,
       const std::string& operatorType);
 
-  /// Creates new instance of MappedMemory, stores it in the task to ensure
-  /// lifetime and returns a raw pointer. Not thread safe, e.g. must be called
-  /// from the Operator's constructor.
-  memory::MemoryAllocator* FOLLY_NONNULL
-  addOperatorMemory(const std::shared_ptr<memory::MemoryUsageTracker>& tracker);
-
   // Removes driver from the set of drivers in 'self'. The task will be kept
   // alive by 'self'. 'self' going out of scope may cause the Task to
   // be freed. This happens if a cancelled task is decoupled from the
@@ -739,10 +733,6 @@ class Task : public std::enable_shared_from_this<Task> {
   //
   // NOTE: ''childPools_' holds the ownerships of node memory pools.
   std::unordered_map<core::PlanNodeId, memory::MemoryPool*> nodePools_;
-
-  // Keep operator MemoryAllocator instances alive for the duration of the task
-  // to allow for sharing data without copy.
-  std::vector<std::shared_ptr<memory::MemoryAllocator>> childAllocators_;
 
   // A set of IDs of leaf plan nodes that require splits. Used to check plan
   // node IDs specified in split management methods.

--- a/velox/exec/TopN.cpp
+++ b/velox/exec/TopN.cpp
@@ -29,9 +29,7 @@ TopN::TopN(
           topNNode->id(),
           "TopN"),
       count_(topNNode->count()),
-      data_(std::make_unique<RowContainer>(
-          outputType_->children(),
-          operatorCtx_->allocator())),
+      data_(std::make_unique<RowContainer>(outputType_->children(), pool())),
       comparator_(
           outputType_,
           topNNode->sortingKeys(),

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -58,9 +58,9 @@ Window::Window(
       numInputColumns_(windowNode->sources()[0]->outputType()->size()),
       data_(std::make_unique<RowContainer>(
           windowNode->sources()[0]->outputType()->children(),
-          operatorCtx_->allocator())),
+          pool())),
       decodedInputVectors_(numInputColumns_),
-      stringAllocator_(operatorCtx_->allocator()) {
+      stringAllocator_(pool()) {
   auto inputType = windowNode->sources()[0]->outputType();
   initKeyInfo(inputType, windowNode->partitionKeys(), {}, partitionKeyInfo_);
   initKeyInfo(

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -343,7 +343,7 @@ class AggregationTest : public OperatorTestBase {
         false,
         true,
         true,
-        allocator_,
+        pool_.get(),
         ContainerRowSerde::instance());
   }
 

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -75,7 +75,7 @@ class HashJoinBridgeTest : public testing::Test,
           std::make_unique<VectorHasher>(rowType_->childAt(channel), channel));
     }
     return HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, allocator_);
+        std::move(keyHashers), {}, true, false, pool_.get());
   }
 
   std::vector<ContinueFuture> createEmptyFutures(int32_t count) {

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -78,7 +78,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
             buildType->childAt(channel), channel));
       }
       auto table = HashTable<true>::createForJoin(
-          std::move(keyHashers), dependentTypes, true, false, allocator_);
+          std::move(keyHashers), dependentTypes, true, false, pool_.get());
 
       makeRows(size, 1, sequence, buildType, batches);
       copyVectorsToTable(batches, startOffset, table.get());
@@ -152,7 +152,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
     }
     static std::vector<std::unique_ptr<Aggregate>> empty;
     return HashTable<false>::createForAggregation(
-        std::move(keyHashers), empty, allocator_);
+        std::move(keyHashers), empty, pool_.get());
   }
 
   void insertGroups(
@@ -435,7 +435,6 @@ class HashTableTest : public testing::TestWithParam<bool> {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
-  memory::MemoryAllocator* allocator_{memory::MemoryAllocator::getInstance()};
   std::unique_ptr<test::VectorMaker> vectorMaker_{
       std::make_unique<test::VectorMaker>(pool_.get())};
   // Bitmap of positions in batches_ that end up in the table.
@@ -517,7 +516,7 @@ TEST_P(HashTableTest, clear) {
       std::vector<TypePtr>{BIGINT()},
       BIGINT()));
   auto table = HashTable<true>::createForAggregation(
-      std::move(keyHashers), aggregates, allocator_);
+      std::move(keyHashers), aggregates, pool_.get());
   table->clear();
 }
 
@@ -596,7 +595,7 @@ TEST_P(HashTableTest, regularHashingTableSize) {
           std::make_unique<VectorHasher>(type->childAt(channel), channel));
     }
     auto table = HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, allocator_);
+        std::move(keyHashers), {}, true, false, pool_.get());
     std::vector<RowVectorPtr> batches;
     makeRows(1 << 12, 1, 0, type, batches);
     copyVectorsToTable(batches, 0, table.get());

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -269,7 +269,7 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     std::vector<TypePtr> types{input->type()};
 
     // Store the vector in the rowContainer.
-    auto rowContainer = std::make_unique<RowContainer>(types, allocator_);
+    auto rowContainer = std::make_unique<RowContainer>(types, pool_.get());
     auto size = input->size();
     SelectivityVector allRows(size);
     std::vector<char*> rows(size);
@@ -806,7 +806,7 @@ TEST_F(RowContainerTest, probedFlag) {
       true, // isJoinBuild
       true, // hasProbedFlag
       false, // hasNormalizedKey
-      allocator_,
+      pool_.get(),
       ContainerRowSerde::instance());
 
   auto input = makeRowVector({

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -144,13 +144,7 @@ class SpillTest : public testing::Test,
     // the batch number of the vector in the partition. When read back, both
     // partitions produce an ascending sequence of integers without gaps.
     state_ = std::make_unique<SpillState>(
-        spillPath_,
-        numPartitions,
-        1,
-        compareFlags,
-        targetFileSize,
-        *pool(),
-        *allocator_);
+        spillPath_, numPartitions, 1, compareFlags, targetFileSize, *pool());
     EXPECT_EQ(targetFileSize, state_->targetFileSize());
     EXPECT_EQ(numPartitions, state_->maxPartitions());
     EXPECT_EQ(0, state_->spilledPartitions());
@@ -357,8 +351,7 @@ TEST_F(SpillTest, spillTimestamp) {
       Timestamp{1, 17'123'456},
       Timestamp{-1, 17'123'456}};
 
-  SpillState state(
-      spillPath, 1, 1, emptyCompareFlags, 1024, *pool(), *allocator_);
+  SpillState state(spillPath, 1, 1, emptyCompareFlags, 1024, *pool());
   int partitionIndex = 0;
   state.setPartitionSpilled(partitionIndex);
   EXPECT_TRUE(state.isPartitionSpilled(partitionIndex));

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -34,7 +34,6 @@ class RowContainerTestBase : public testing::Test,
  protected:
   void SetUp() override {
     pool_ = memory::getDefaultMemoryPool();
-    allocator_ = memory::MemoryAllocator::getInstance();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
@@ -68,11 +67,10 @@ class RowContainerTestBase : public testing::Test,
         isJoinBuild,
         true,
         true,
-        allocator_,
+        pool_.get(),
         ContainerRowSerde::instance());
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
-  memory::MemoryAllocator* allocator_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -314,7 +314,8 @@ TEST(KllSketchTest, mergeDeserialized) {
 // 2. Otherwise it's \f$ K \sum_i \(\frac{2}{3}\)^i \f$ and it converges to
 //    about O(3K).
 TEST(KllSketchTest, memoryUsage) {
-  HashStringAllocator alloc(memory::MemoryAllocator::getInstance());
+  auto pool = memory::getDefaultMemoryPool();
+  HashStringAllocator alloc(pool.get());
   KllSketch<int64_t, StlAllocator<int64_t>> kll(
       1024, StlAllocator<int64_t>(&alloc));
   EXPECT_LE(alloc.retainedSize() - alloc.freeSpace(), 64);

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -72,9 +72,9 @@ class ValueListTest : public functions::test::FunctionBaseTest {
     return allocator_.get();
   }
 
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   std::unique_ptr<HashStringAllocator> allocator_{
-      std::make_unique<HashStringAllocator>(
-          memory::MemoryAllocator::getInstance())};
+      std::make_unique<HashStringAllocator>(pool_.get())};
 };
 
 TEST_F(ValueListTest, empty) {

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -62,7 +62,8 @@ class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
     return signatureStrings;
   }
 
-  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  HashStringAllocator allocator_{pool_.get()};
 };
 
 TEST_F(HyperLogLogFunctionsTest, cardinalitySignatures) {

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -60,8 +60,7 @@ class PrestoSerializerTest : public ::testing::Test {
     sanityCheckEstimateSerializedSize(
         rowVector, folly::Range(rows.data(), numRows));
 
-    auto arena =
-        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
+    auto arena = std::make_unique<StreamArena>(pool_.get());
     auto rowType = asRowType(rowVector->type());
     auto serializer =
         serde_->createSerializer(rowType, numRows, arena.get(), serdeOptions);
@@ -78,8 +77,7 @@ class PrestoSerializerTest : public ::testing::Test {
       const VectorSerde::Options* serdeOptions) {
     facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
     OStreamOutputStream out(output, &listener);
-    auto arena =
-        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
+    auto arena = std::make_unique<StreamArena>(pool_.get());
     serde_->serializeConstants(rowVector, arena.get(), serdeOptions, &out);
   }
 

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -35,8 +35,7 @@ class UnsafeRowSerializerTest : public ::testing::Test {
       rows[i] = IndexRange{i, 1};
     }
 
-    auto arena =
-        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
+    auto arena = std::make_unique<StreamArena>(pool_.get());
     auto rowType = std::dynamic_pointer_cast<const RowType>(rowVector->type());
     auto serializer = serde_->createSerializer(rowType, numRows, arena.get());
 

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -40,7 +40,7 @@ class VectorSerializer {
       const folly::Range<const IndexRange*>& ranges) = 0;
 
   // Writes the contents to 'stream' in wire format
-  virtual void flush(OutputStream* stream) = 0;
+  virtual void flush(OutputStream* FOLLY_NONNULL stream) = 0;
 };
 
 class VectorSerde {
@@ -55,20 +55,20 @@ class VectorSerde {
   virtual void estimateSerializedSize(
       VectorPtr vector,
       const folly::Range<const IndexRange*>& ranges,
-      vector_size_t** sizes) = 0;
+      vector_size_t* FOLLY_NONNULL* FOLLY_NONNULL sizes) = 0;
 
   virtual std::unique_ptr<VectorSerializer> createSerializer(
       RowTypePtr type,
       int32_t numRows,
-      StreamArena* streamArena,
-      const Options* options = nullptr) = 0;
+      StreamArena* FOLLY_NONNULL streamArena,
+      const Options* FOLLY_NULLABLE options = nullptr) = 0;
 
   virtual void deserialize(
-      ByteStream* source,
-      velox::memory::MemoryPool* pool,
+      ByteStream* FOLLY_NONNULL source,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool,
       RowTypePtr type,
-      RowVectorPtr* result,
-      const Options* options = nullptr) = 0;
+      RowVectorPtr* FOLLY_NONNULL result,
+      const Options* FOLLY_NULLABLE options = nullptr) = 0;
 };
 
 bool registerVectorSerde(std::unique_ptr<VectorSerde> serde);
@@ -77,33 +77,33 @@ bool isRegisteredVectorSerde();
 
 class VectorStreamGroup : public StreamArena {
  public:
-  explicit VectorStreamGroup(memory::MemoryAllocator* allocator)
-      : StreamArena(allocator) {}
+  explicit VectorStreamGroup(memory::MemoryPool* FOLLY_NONNULL pool)
+      : StreamArena(pool) {}
 
   void createStreamTree(
       RowTypePtr type,
       int32_t numRows,
-      const VectorSerde::Options* options = nullptr);
+      const VectorSerde::Options* FOLLY_NULLABLE options = nullptr);
 
   static void estimateSerializedSize(
       VectorPtr vector,
       const folly::Range<const IndexRange*>& ranges,
-      vector_size_t** sizes);
+      vector_size_t* FOLLY_NONNULL* FOLLY_NONNULL sizes);
 
   void append(
       RowVectorPtr vector,
       const folly::Range<const IndexRange*>& ranges);
 
   // Writes the contents to 'stream' in wire format.
-  void flush(OutputStream* stream);
+  void flush(OutputStream* FOLLY_NONNULL stream);
 
   // Reads data in wire format. Returns the RowVector in 'result'.
   static void read(
-      ByteStream* source,
-      velox::memory::MemoryPool* pool,
+      ByteStream* FOLLY_NONNULL source,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool,
       RowTypePtr type,
-      RowVectorPtr* result,
-      const VectorSerde::Options* options = nullptr);
+      RowVectorPtr* FOLLY_NONNULL result,
+      const VectorSerde::Options* FOLLY_NULLABLE options = nullptr);
 
  private:
   std::unique_ptr<VectorSerializer> serializer_;

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -96,7 +96,6 @@ int NonPOD::alive = 0;
 class VectorTest : public testing::Test, public test::VectorTestBase {
  protected:
   void SetUp() override {
-    allocator_ = memory::MemoryAllocator::getInstance();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
@@ -757,10 +756,10 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     auto sourceRow = makeRowVector({"c"}, {source});
     auto sourceRowType = asRowType(sourceRow->type());
 
-    VectorStreamGroup even(allocator_);
+    VectorStreamGroup even(pool_.get());
     even.createStreamTree(sourceRowType, source->size() / 4);
 
-    VectorStreamGroup odd(allocator_);
+    VectorStreamGroup odd(pool_.get());
     odd.createStreamTree(sourceRowType, source->size() / 3);
 
     std::vector<IndexRange> evenIndices;
@@ -866,8 +865,6 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     slice->mutableSizes(slice->size());
     EXPECT_NE(slice->rawSizes(), sizes);
   }
-
-  memory::MemoryAllocator* allocator_;
 
   size_t vectorSize_{100};
   size_t numIterations_{3};


### PR DESCRIPTION
Add large chunk memory allocations for memory pool and deprecate
ScopedMemoryAllocator. Correspondingly, removed all the direct
memory allocator usages in Velox and all the large chunk memory
allocations now go through memory pool interface.
This PR also improve the management of Allocation and
ContiguousAllocation objects by removing the allocator from the
object constructor. The memory allocator doesn't own or are aware
of the ownerships of the two allocation object types. It is memory
pool object to set the pool or ownership on allocation success. For
direct allocation from memory allocator such as AsyncDataCache,
then user needs to free the allocations explicitly.
Add unit tests for the new memory pool interfaces and thorough
testing on the two allocation objects as well.