### PR TITLE
Table writer 6: create directory if not exists

### DIFF
--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -269,12 +269,12 @@ class HiveConnectorFactory : public ConnectorFactory {
       "hive-hadoop2";
 
   HiveConnectorFactory() : ConnectorFactory(kHiveConnectorName) {
-    dwio::common::FileSink::registerFactory();
+    dwio::common::LocalFileSink::registerFactory();
   }
 
   HiveConnectorFactory(const char* FOLLY_NONNULL connectorName)
       : ConnectorFactory(connectorName) {
-    dwio::common::FileSink::registerFactory();
+    dwio::common::LocalFileSink::registerFactory();
   }
 
   std::shared_ptr<Connector> newConnector(

--- a/velox/dwio/common/DataSink.h
+++ b/velox/dwio/common/DataSink.h
@@ -133,14 +133,14 @@ class DataSink : public Closeable {
   }
 };
 
-class FileSink : public DataSink {
+class LocalFileSink : public DataSink {
  public:
-  explicit FileSink(
+  explicit LocalFileSink(
       const std::string& name,
       const MetricsLogPtr& metricLogger = MetricsLog::voidLog(),
       IoStatistics* stats = nullptr);
 
-  ~FileSink() override {
+  ~LocalFileSink() override {
     destroy();
   }
 
@@ -158,6 +158,10 @@ class FileSink : public DataSink {
  private:
   int file_;
 };
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+using FileSink = LocalFileSink;
+#endif
 
 class MemorySink : public DataSink {
  public:

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
   ChainedBufferTests.cpp
   DataBufferTests.cpp
   DecoderUtilTest.cpp
+  LocalFileSinkTest.cpp
   LoggedExceptionTest.cpp
   RangeTests.cpp
   RetryTests.cpp

--- a/velox/dwio/common/tests/LocalFileSinkTest.cpp
+++ b/velox/dwio/common/tests/LocalFileSinkTest.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/Fs.h"
+#include "velox/dwio/common/DataSink.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::dwio::common {
+
+TEST(LocalFileSinkTest, create) {
+  LocalFileSink::registerFactory();
+
+  auto root = TempDirectoryPath::create();
+  auto filePath = fs::path(root->path) / "xxx/yyy/zzz/test_file.ext";
+
+  ASSERT_FALSE(fs::exists(filePath.string()));
+
+  auto localFileSink =
+      DataSink::create(fmt::format("file:{}", filePath.string()));
+  localFileSink->close();
+
+  EXPECT_TRUE(fs::exists(filePath.string()));
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/test/E2EWriterTests.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTests.cpp
@@ -82,7 +82,7 @@ TEST(E2EWriterTests, DISABLED_TestFileCreation) {
     batches.push_back(BatchMaker::createBatch(type, size, *pool, nullptr, i));
   }
 
-  auto sink = std::make_unique<FileSink>("/tmp/e2e_generated_file.orc");
+  auto sink = std::make_unique<LocalFileSink>("/tmp/e2e_generated_file.orc");
   E2EWriterTestUtil::writeData(
       std::move(sink),
       type,

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -44,7 +44,7 @@ class ParquetReaderBenchmark {
     pool_ = memory::getDefaultMemoryPool();
     dataSetBuilder_ = std::make_unique<DataSetBuilder>(*pool_.get(), 0);
 
-    auto sink = std::make_unique<FileSink>("test.parquet");
+    auto sink = std::make_unique<LocalFileSink>("test.parquet");
     std::shared_ptr<::parquet::WriterProperties> writerProperties;
     if (disableDictionary_) {
       // The parquet file is in plain encoding format.

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -64,7 +64,7 @@ void HiveConnectorTestBase::writeToFile(
   options.config = config;
   options.schema = vectors[0]->type();
   auto sink =
-      std::make_unique<facebook::velox::dwio::common::FileSink>(filePath);
+      std::make_unique<facebook::velox::dwio::common::LocalFileSink>(filePath);
   auto childPool =
       pool_->addChild(kWriter, std::numeric_limits<int64_t>::max());
   facebook::velox::dwrf::Writer writer{options, std::move(sink), *childPool};


### PR DESCRIPTION
If the parent directory of the file that a LocalFileSink writes to
does not exist, create the directory first when creating
the LocalFileSink.

Rename FileSink to LocalFileSink, to be more clear.
LocalFileSink is one subclass of the interface
dwio::common::DataSink that implements a local file
system based data sink for a dwio writer.

This is needed by a partitioned table writer, which calls on
the LocalFileSink to write to files under partition subdirectories
that are created during query execution.