### PR TITLE
Add map_from_entries Presto function

### DIFF
--- a/velox/docs/functions/map.rst
+++ b/velox/docs/functions/map.rst
@@ -26,6 +26,12 @@ Map Functions
 
     See also :func:`map_agg` for creating a map as an aggregation.
 
+.. function:: map_from_entries(array(row(K, V))) -> map(K, V)
+
+    Returns a map created from the given array of entries. ::
+
+        SELECT map_from_entries(ARRAY[(1, 'x'), (2, 'y')]); -- {1 -> 'x', 2 -> 'y'}
+
 .. function:: map_entries(map(K,V)) -> array(row(K,V))
 
     Returns an array of all entries in the given map. ::

--- a/velox/functions/prestosql/MapFunctions.h
+++ b/velox/functions/prestosql/MapFunctions.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <fmt/format.h>
+#include "folly/container/F14Set.h"
+
+#include "velox/functions/Udf.h"
+
+namespace facebook::velox::functions {
+
+template <typename V>
+bool constexpr provide_std_interface =
+    CppToType<V>::isPrimitiveType && !std::is_same_v<Varchar, V> &&
+    !std::is_same_v<Varbinary, V> && !std::is_same_v<Any, V>;
+
+/// Function Signature: map_from_entries(array(row(K, V))) -> map(K, V)
+/// Returns a map created from the given array of entries.
+template <typename TExecCtx, typename K, typename V>
+struct MapFromEntriesFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExecCtx);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Map<K, V>>& out,
+      const arg_type<Array<Row<K, V>>>& inputArray) {
+    // Do not accept any nulls from the input array
+    VELOX_USER_CHECK(!inputArray.mayHaveNulls(), "map entry cannot be null");
+
+    folly::F14FastSet<arg_type<K>> uniqueSet;
+    for (const auto& tuple : inputArray) {
+      const auto& key = tuple.value().template at<0>();
+      // 1. Do not accept null for any map key, but accept a null map value
+      VELOX_USER_CHECK(key.has_value(), "map key cannot be null");
+      // 2. Do not accept duplicate keys
+      VELOX_USER_CHECK(
+          uniqueSet.insert(*key).second,
+          fmt::format(
+              "Duplicate keys ({}) are not allowed", toString(key.value())));
+
+      const auto& value = tuple.value().template at<1>();
+      emplace(out, key, value);
+    }
+    return;
+  }
+
+  // TODO: turn this function as a member function of `MapWriter` class
+  void emplace(
+      out_type<Map<K, V>>& out,
+      const exec::OptionalAccessor<K>& key,
+      const exec::OptionalAccessor<V>& value) {
+    if (value.has_value()) {
+      auto [keyWriter, valueWriter] = out.add_item();
+      // set key
+      if constexpr (provide_std_interface<K>) {
+        keyWriter = *key;
+      } else {
+        keyWriter.setNoCopy(*key);
+      }
+      // set value
+      if constexpr (provide_std_interface<V>) {
+        valueWriter = *value;
+      } else {
+        valueWriter.setNoCopy(*value);
+      }
+    } else {
+      // Value is null
+      auto& keyWriter = out.add_null();
+      // copy key
+      if constexpr (provide_std_interface<K>) {
+        keyWriter = *key;
+      } else {
+        keyWriter.setNoCopy(*key);
+      }
+    }
+  }
+
+  template <typename T>
+  std::string toString(const T& val) {
+    static_assert(
+        CppToType<T>::isPrimitiveType, "Only support primitive types");
+    if constexpr (std::is_same_v<T, StringView>) {
+      return val.str();
+    } else {
+      return std::to_string(val);
+    }
+  }
+};
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -17,8 +17,45 @@
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/MapConcat.h"
+#include "velox/functions/prestosql/MapFunctions.h"
 
 namespace facebook::velox::functions {
+
+template <typename K, typename V>
+inline void registerMapFromEntriesFunctions() {
+  registerFunction<
+      ParameterBinder<MapFromEntriesFunction, K, V>,
+      Map<K, V>,
+      Array<Row<K, V>>>({"map_from_entries"});
+}
+
+template <typename V>
+void registerMapFromEntriesWithFixedKeyType() {
+  registerMapFromEntriesFunctions<int8_t, V>();
+  registerMapFromEntriesFunctions<int16_t, V>();
+  registerMapFromEntriesFunctions<int32_t, V>();
+  registerMapFromEntriesFunctions<int64_t, V>();
+  registerMapFromEntriesFunctions<float, V>();
+  registerMapFromEntriesFunctions<double, V>();
+  registerMapFromEntriesFunctions<bool, V>();
+  registerMapFromEntriesFunctions<Varchar, V>();
+  registerMapFromEntriesFunctions<Timestamp, V>();
+  registerMapFromEntriesFunctions<Date, V>();
+}
+
+void registerMapFromEntries() {
+  registerMapFromEntriesWithFixedKeyType<int8_t>();
+  registerMapFromEntriesWithFixedKeyType<int16_t>();
+  registerMapFromEntriesWithFixedKeyType<int32_t>();
+  registerMapFromEntriesWithFixedKeyType<int64_t>();
+  registerMapFromEntriesWithFixedKeyType<float>();
+  registerMapFromEntriesWithFixedKeyType<double>();
+  registerMapFromEntriesWithFixedKeyType<bool>();
+  registerMapFromEntriesWithFixedKeyType<Varchar>();
+  registerMapFromEntriesWithFixedKeyType<Timestamp>();
+  registerMapFromEntriesWithFixedKeyType<Date>();
+}
+
 void registerMapFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_filter, "map_filter");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_transform_keys, "transform_keys");
@@ -30,6 +67,7 @@ void registerMapFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_zip_with, "map_zip_with");
 
   registerMapConcatFunction("map_concat");
+  registerMapFromEntries();
 }
 
 void registerMapAllowingDuplicates(const std::string& name) {

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(
   JsonFunctionsTest.cpp
   MapEntriesTest.cpp
   MapFilterTest.cpp
+  MapFromEntriesTest.cpp
   MapKeysAndValuesTest.cpp
   MapTest.cpp
   MapZipWithTest.cpp

--- a/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
+++ b/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace {
+class MapFromEntriesTest : public FunctionBaseTest {
+ protected:
+  // Evaluate an expression.
+  void testExpr(
+      const VectorPtr& expected,
+      const std::string& expression,
+      const std::vector<VectorPtr>& input) {
+    auto result = evaluate<MapVector>(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+
+  // Evaluate an expression only, usually expect error thrown.
+  void evaluateExprOnly(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input) {
+    evaluate(expression, makeRowVector(input));
+  }
+};
+} // namespace
+
+TEST_F(MapFromEntriesTest, primitiveKeyAndPrimitiveValue) {
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({1, 11}), variant::row({2, 22}), variant::row({3, 33})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  auto expected =
+      makeMapVector<int32_t, int32_t>({{{1, 11}, {2, 22}, {3, 33}}});
+  testExpr(expected, "map_from_entries(C0)", {input});
+}
+
+TEST_F(MapFromEntriesTest, primitiveKeyAndVarcharValue) {
+  auto rowType = ROW({INTEGER(), VARCHAR()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({1, "red"}),
+       variant::row({2, "blue"}),
+       variant::row({3, "green"})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  auto expected = makeMapVector<int32_t, StringView>(
+      {{{1, "red"_sv}, {2, "blue"_sv}, {3, "green"_sv}}});
+  testExpr(expected, "map_from_entries(C0)", {input});
+}
+
+TEST_F(MapFromEntriesTest, varcharKeyAndPrimitiveValue) {
+  auto rowType = ROW({VARCHAR(), INTEGER()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({"red shiny car ahead", 1}),
+       variant::row({"blue clear sky above", 2}),
+       variant::row({"yellow rose flowers", 3})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  auto expected = makeMapVector<StringView, int32_t>(
+      {{{"red shiny car ahead"_sv, 1},
+        {"blue clear sky above"_sv, 2},
+        {"yellow rose flowers"_sv, 3}}});
+  testExpr(expected, "map_from_entries(C0)", {input});
+}
+
+TEST_F(MapFromEntriesTest, varcharKeyAndVarcharValue) {
+  auto rowType = ROW({VARCHAR(), VARCHAR()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({"red", "red shiny car ahead"}),
+       variant::row({"blue", "blue clear sky above"}),
+       variant::row({"yellow", "yellow rose flowers"})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  auto expected = makeMapVector<StringView, StringView>(
+      {{{"red"_sv, "red shiny car ahead"_sv},
+        {"blue"_sv, "blue clear sky above"_sv},
+        {"yellow"_sv, "yellow rose flowers"_sv}}});
+  testExpr(expected, "map_from_entries(C0)", {input});
+}
+
+TEST_F(MapFromEntriesTest, valueIsNull) {
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({1, variant::null(TypeKind::INTEGER)}),
+       variant::row({2, 22}),
+       variant::row({3, 33})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  auto expected =
+      makeMapVector<int32_t, int32_t>({{{1, std::nullopt}, {2, 22}, {3, 33}}});
+  testExpr(expected, "map_from_entries(C0)", {input});
+}
+
+TEST_F(MapFromEntriesTest, mapEntryIsNull) {
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  std::vector<std::vector<variant>> data = {
+      {variant(TypeKind::ROW), variant::row({1, 11})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  EXPECT_THROW(
+      evaluateExprOnly("map_from_entries(C0)", {input}), VeloxUserError);
+}
+
+TEST_F(MapFromEntriesTest, keyIsNull) {
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({variant::null(TypeKind::INTEGER), 0}),
+       variant::row({1, 11})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  EXPECT_THROW(
+      evaluateExprOnly("map_from_entries(C0)", {input}), VeloxUserError);
+}
+
+TEST_F(MapFromEntriesTest, duplicateKey) {
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({1, 10}), variant::row({1, 11}), variant::row({2, 22})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  EXPECT_THROW(
+      evaluateExprOnly("map_from_entries(C0)", {input}), VeloxUserError);
+}

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -232,7 +232,9 @@ class VectorTestBase {
 
   // Create an ArrayVector<ROW> from nested std::vectors of variants.
   // Example:
-  //   auto arrayVector = makeArrayOfRowVector({
+  //   auto arrayVector = makeArrayOfRowVector(
+  //     ROW({INTEGER(), VARCHAR()}),
+  //     {
   //       {variant::row({1, "red"}), variant::row({1, "blue"})},
   //       {},
   //       {variant::row({3, "green"})},


### PR DESCRIPTION
## Summary
* Adding the `map_from_entries` Presto function to Velox

`map_from_entries(array(row(K, V))) -> map(K, V)`

> Returns a map created from the given array of entries.

For example:
```
SELECT map_from_entries(ARRAY[(1, 'x'), (2, 'y')]); -- {1 -> 'x', 2 -> 'y'}
SELECT map_from_entries(ARRAY[(1, 'x'), (2, null)]); -- {1 -> 'x', 2 -> null}
SELECT map_from_entries(ARRAY[(1, 'x'), (1, 'y')]); -- duplicate key error
SELECT map_from_entries(ARRAY[(null, 'x'), (1, 'y')]); -- map key cannot be null error
SELECT map_from_entries(ARRAY[cast(null as ROW(int, varchar)), (1, 'y')]); -- map entry cannot be null error
```
