### PR TITLE
Use macos compatible syntax in info.sh

### DIFF
--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -29,14 +29,14 @@ ext() {
 }
 
 print_info() {
-echo "$info" | grep -P "$1" | ext
+echo "$info" | grep -e "$1" | ext
 }
 
 result="
 Velox System Info v${version}
 Commit: $(git rev-parse HEAD 2> /dev/null || echo "Not in a git repo.")
-CMake Version: $(cmake --version | grep -oP '\d+\.\d+\.\d+')
-System: $(print_info 'CMAKE_SYSTEM \"')
+CMake Version: $(cmake --version | grep -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+')
+System: $(print_info 'CMAKE_SYSTEM "')
 Arch: $(print_info 'CMAKE_SYSTEM_PROCESSOR')
 C++ Compiler: $(print_info 'CMAKE_CXX_COMPILER ==')
 C++ Compiler Version: $(print_info 'CMAKE_CXX_COMPILER_VERSION')

--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 set -e
 
-version='0.0.1'
+version='0.0.2'
 cb='```'
 
 if [ ! -x "$(command -v cmake)" ]; then
@@ -25,7 +25,7 @@ fi
 info=$(cmake --system-information)
 
 ext() {
-  grep -oP '\".+\"$' $1 | tr -d '\"'
+  grep -oE '".+"$' $1 | tr -d '"'
 }
 
 print_info() {


### PR DESCRIPTION
Closes #3409 

As I don't have a mac to test compatibility some local testing would be appreciated. 