### PR TITLE
FIX: allow unknown in if then part.

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -218,7 +218,10 @@ class EvalCtx {
       const SelectivityVector& rows,
       VectorPtr& result) const {
     if (result && !isFinalSelection() && *finalSelection() != rows) {
-      BaseVector::ensureWritable(rows, result->type(), result->pool(), result);
+      auto type =
+          Type::resolveUnknownTypes(result->type(), localResult->type());
+      VELOX_CHECK(type, "moveOrCopyResult encountered incompatible types");
+      BaseVector::ensureWritable(rows, type, result->pool(), result);
       result->copy(localResult.get(), rows, nullptr);
     } else {
       result = localResult;

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1422,6 +1422,13 @@ bool Expr::applyFunctionWithPeeling(
   VectorPtr wrappedResult =
       context.applyWrapToPeeledResult(this->type(), peeledResult, applyRows);
   context.moveOrCopyResult(wrappedResult, rows, result);
+
+  if (context.wrapEncoding() == VectorEncoding::Simple::CONSTANT &&
+      type()->isPrimitiveType()) {
+    // The if condition is optional, but it makes it clear when this will be
+    // useful.
+    context.releaseVector(peeledResult);
+  }
   return true;
 }
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1268,7 +1268,11 @@ void Expr::evalAll(
   // Write non-selected rows in remainingRows as nulls in the result if some
   // rows have been skipped.
   if (mutableRemainingRows != nullptr) {
-    addNulls(rows, mutableRemainingRows->asRange().bits(), context, result);
+    bool KnownToBeAllSelected = mutableRemainingRows->isAllSelectedSet() &&
+        mutableRemainingRows->isAllSelected();
+    if (!KnownToBeAllSelected) {
+      addNulls(rows, mutableRemainingRows->asRange().bits(), context, result);
+    }
   }
   releaseInputValues(context);
 }

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -435,6 +435,9 @@ struct TypeFactory;
     return this->kind() == TypeKind::KIND;                                \
   }
 
+class Type;
+using TypePtr = std::shared_ptr<const Type>;
+
 /// Abstract class hierarchy. Instances of these classes carry full
 /// information about types, including for example field names.
 /// Can be instantiated by factory methods, like INTEGER()
@@ -505,6 +508,11 @@ class Type : public Tree<const std::shared_ptr<const Type>>,
 
   static std::shared_ptr<const Type> create(const folly::dynamic& obj);
 
+  // Combine two compatible types by resolving unknowns. If the types are not
+  // compatible, return nullptr. row(unknow, int), row(int, unknown) -> row(int,
+  // int). row(int), row(float) -> nullptr.
+  static TypePtr resolveUnknownTypes(const TypePtr& a, const TypePtr& b);
+
   /// Recursive kind hashing (uses only TypeKind).
   size_t hashKind() const;
 
@@ -546,8 +554,6 @@ class Type : public Tree<const std::shared_ptr<const Type>>,
 };
 
 #undef VELOX_FLUENT_CAST
-
-using TypePtr = std::shared_ptr<const Type>;
 
 template <TypeKind KIND>
 class TypeBase : public Type {

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -290,6 +290,10 @@ class SelectivityVector {
     allSelected_.reset();
   }
 
+  bool isAllSelectedSet() const {
+    return allSelected_.has_value();
+  }
+
   bool isAllSelected() const {
     if (allSelected_.has_value()) {
       return allSelected_.value();


### PR DESCRIPTION
Summary:
before this diff the following would fail:

if(c0 is not Null, if(c0=2 , 2, 3), null)
if(c0 is Null, row_constructor(null, c0), row_constructor(c0,null)

note that this did not fail before:
if(c0 is not Null, if(c0=2 , 2, 3), null)

this diff update moveOrCopyResult so that `ensureWritable` uses the
a type with resolved unknown.

Differential Revision: D41743247

