### PR TITLE
Fix incorrect cast result for constant vector in dictionary encoding

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/TypeAliases.h"
+#include "velox/vector/tests/TestingDictionaryOverConstFunction.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -919,5 +920,18 @@ TEST_F(CastExprTest, castAsCall) {
 
   auto result = evaluate(callExpr, input);
   auto expected = makeNullableFlatVector(outputValues);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(CastExprTest, dictionaryOverConst) {
+  exec::registerVectorFunction(
+      "dictionary_over_const",
+      TestingDictionaryOverConstFunction::signatures(),
+      std::make_unique<TestingDictionaryOverConstFunction>());
+
+  auto data = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto result = evaluate(
+      "cast(dictionary_over_const(c0) as smallint)", makeRowVector({data}));
+  auto expected = makeNullableFlatVector<int16_t>({1, 1, 1, 1, 1});
   assertEqualVectors(expected, result);
 }

--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -442,8 +442,9 @@ void DecodedVector::setBaseDataForBias(
 
 namespace {
 bool isWrapper(VectorEncoding::Simple encoding) {
-  return encoding == VectorEncoding::Simple::SEQUENCE ||
-      encoding == VectorEncoding::Simple::DICTIONARY;
+  return encoding == VectorEncoding::Simple::CONSTANT ||
+      encoding == VectorEncoding::Simple::DICTIONARY ||
+      encoding == VectorEncoding::Simple::SEQUENCE;
 }
 
 /// Returns true if 'wrapper' is a dictionary vector wrapping non-dictionary

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -299,6 +299,17 @@ class DecodedVectorTest : public testing::Test, public VectorTestBase {
       DecodedVector decoded(*dictionaryVector, false);
       check(decoded);
     }
+
+    {
+      DecodedVector decoded(*dictionaryVector, false);
+      if (!decoded.isConstantMapping()) {
+        auto wrapping =
+            decoded.dictionaryWrapping(*dictionaryVector, dictionarySize);
+        auto rewrapped = BaseVector::wrapInDictionary(
+            wrapping.nulls, wrapping.indices, dictionarySize, base);
+        assertEqualVectors(dictionaryVector, rewrapped);
+      }
+    }
   }
 
   template <typename T>
@@ -340,6 +351,18 @@ class DecodedVectorTest : public testing::Test, public VectorTestBase {
     {
       DecodedVector decoded(*dictionaryVector, false);
       check(decoded);
+    }
+
+    {
+      DecodedVector decoded(*dictionaryVector, false);
+      if (!decoded.isConstantMapping()) {
+        auto wrapping =
+            decoded.dictionaryWrapping(*dictionaryVector, dictionarySize);
+        auto base = makeFlatVector<T>(std::vector<T>{value});
+        auto rewrapped = BaseVector::wrapInDictionary(
+            wrapping.nulls, wrapping.indices, dictionarySize, base);
+        assertEqualVectors(dictionaryVector, rewrapped);
+      }
     }
   }
 

--- a/velox/vector/tests/TestingDictionaryOverConstFunction.h
+++ b/velox/vector/tests/TestingDictionaryOverConstFunction.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/VectorFunction.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::test {
+
+/// Wraps input in a constant encoding that repeats the first element, then in a
+/// dictionary that reverses the order of rows.
+class TestingDictionaryOverConstFunction : public exec::VectorFunction {
+ public:
+  TestingDictionaryOverConstFunction() {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /*outputType*/,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    const auto size = rows.size();
+    auto constant = BaseVector::wrapInConstant(size, 0, args[0]);
+
+    auto indices = makeIndicesInReverse(size, context.pool());
+    auto nulls = allocateNulls(size, context.pool());
+    result =
+        BaseVector::wrapInDictionary(nulls, indices, size, std::move(constant));
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    // T -> T
+    return {exec::FunctionSignatureBuilder()
+                .typeVariable("T")
+                .returnType("T")
+                .argumentType("T")
+                .build()};
+  }
+};
+
+} // namespace facebook::velox::test


### PR DESCRIPTION
Summary: Expression fuzzer found a bug in `cast(c0 as SMALLINT)` when `c0` is a constant vector inside a dictionary encoding (https://github.com/facebookincubator/velox/issues/3300). In this situation, CastExpr tries to peel off the encoding before processing the data and wrap the encoding back to the result afterwards. But when we extract the encoding with DecodedVector::dictionaryWrapping(), dictionaryWrapping() only gets the top-level dictionary layer because `VectorEncoding::Simple::CONSTANT` is not considered a wrapper. So this constant layer is peeled off first, but not wrapped back to the result, hence causing the error. This diff fixes this bug by making DecodedVector consider `VectorEncoding::Simple::CONSTANT` as a wrapper.

Differential Revision: D41450072

