### PR TITLE
mutableNulls can be used to allocate nulls_ with fewer bits than length_

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -64,8 +64,12 @@ BaseVector::BaseVector(
   }
 }
 
-void BaseVector::ensureNullsCapacity(vector_size_t size, bool setNotNull) {
+void BaseVector::ensureNullsCapacity(
+    vector_size_t minimumSize,
+    bool setNotNull) {
   auto fill = setNotNull ? bits::kNotNull : bits::kNull;
+  // Ensure the size of nulls_ is always at least as large as length_.
+  auto size = std::max(minimumSize, length_);
   if (nulls_ && nulls_->isMutable()) {
     if (nulls_->capacity() < bits::nbytes(size)) {
       AlignedBuffer::reallocate<bool>(&nulls_, size, fill);

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -746,10 +746,10 @@ class BaseVector {
   virtual std::string toSummaryString() const;
 
   /*
-   * Allocates or reallocates nulls_ with the given size if nulls_ hasn't
-   * been allocated yet or has been allocated with a smaller capacity.
+   * Allocates or reallocates nulls_ with at least the given size if nulls_
+   * hasn't been allocated yet or has been allocated with a smaller capacity.
    */
-  void ensureNullsCapacity(vector_size_t size, bool setNotNull = false);
+  void ensureNullsCapacity(vector_size_t minimumSize, bool setNotNull = false);
 
   FOLLY_ALWAYS_INLINE static std::optional<int32_t>
   compareNulls(bool thisNull, bool otherNull, CompareFlags flags) {

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2168,3 +2168,11 @@ TEST_F(VectorTest, lifetime) {
       },
       "Memory pool should be destroyed only after all allocated memory has been freed.");
 }
+
+TEST_F(VectorTest, ensureNullsCapacity) {
+  // Has to be more than 1 byte's worth of bits.
+  size_t size = 100;
+  auto vec = makeFlatVector<int64_t>(size, [](vector_size_t i) { return i; });
+  auto nulls = vec->mutableNulls(2);
+  ASSERT_GE(nulls->size(), bits::nbytes(size));
+}


### PR DESCRIPTION
Summary:
mutableNulls calls ensureNullsCapacity which doesn't check that nulls_ has enough capacity to hold length_ bits.  This is an invariant ensured throughout BaseVector except here.

Ensured that we allocate length_ or size bits whichever is larger.

Differential Revision: D41749655

