### PR TITLE
Add repeat Presto function

### DIFF
--- a/velox/docs/functions/array.rst
+++ b/velox/docs/functions/array.rst
@@ -148,6 +148,10 @@ Array Functions
                       (s, x) -> CAST(ROW(x + s.sum, s.count + 1) AS ROW(sum DOUBLE, count INTEGER)),
                       s -> IF(s.count = 0, NULL, s.sum / s.count));
 
+.. function:: repeat(element, count) -> array(E)
+
+    Repeat ``element`` for ``count`` times. ``count`` cannot be negative and must be less than or equal to 10000.
+
 .. function:: reverse(array(E)) -> array(E)
 
     Returns an array which has the reversed order of the input array.
@@ -191,4 +195,3 @@ Array Functions
         SELECT zip_with(ARRAY[1, 2], ARRAY[3, 4], (x, y) -> x + y); -- [4, 6]
         SELECT zip_with(ARRAY['a', 'b', 'c'], ARRAY['d', 'e', 'f'], (x, y) -> concat(x, y)); -- ['ad', 'be', 'cf']
         SELECT zip_with(ARRAY['a'], ARRAY['d', null, 'f'], (x, y) -> coalesce(x, y)); -- ['a', null, 'f']
-

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(
   MapZipWith.cpp
   Not.cpp
   Reduce.cpp
+  Repeat.cpp
   Reverse.cpp
   RowFunction.cpp
   Slice.cpp

--- a/velox/functions/prestosql/Repeat.cpp
+++ b/velox/functions/prestosql/Repeat.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/DecodedArgs.h"
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+// See documentation at https://prestodb.io/docs/current/functions/array.html
+class RepeatFunction : public exec::VectorFunction {
+ public:
+  static constexpr int32_t kMaxResultEntries = 10'000;
+
+  bool isDefaultNullBehavior() const override {
+    // repeat(null, n) returns an array of n nulls.
+    return false;
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VectorPtr localResult;
+    if (args[1]->isConstantEncoding()) {
+      try {
+        localResult = applyConstant(rows, args, outputType, context);
+      } catch (const std::exception& e) {
+        context.setErrors(rows, std::current_exception());
+        return;
+      }
+    } else {
+      localResult = applyFlat(rows, args, outputType, context);
+    }
+    context.moveOrCopyResult(localResult, rows, result);
+  }
+
+ private:
+  static void checkCount(const int32_t count) {
+    VELOX_USER_CHECK_GE(
+        count,
+        0,
+        "Count argument of repeat function must be greater than or equal to 0");
+    VELOX_USER_CHECK_LE(
+        count,
+        kMaxResultEntries,
+        "Count argument of repeat function must be less than or equal to 10000");
+  }
+
+  VectorPtr applyConstant(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context) const {
+    const auto numRows = rows.size();
+    auto pool = context.pool();
+
+    if (args[1]->as<ConstantVector<int32_t>>()->isNullAt(0)) {
+      // If count is a null constant, the result should be all nulls.
+      return BaseVector::createNullConstant(outputType, numRows, pool);
+    }
+
+    const auto count = args[1]->as<ConstantVector<int32_t>>()->valueAt(0);
+    // Exception will be processed on the upper level.
+    checkCount(count);
+    const auto totalCount = count * numRows;
+
+    // Allocate new vectors for indices, lengths and offsets.
+    BufferPtr indices = allocateIndices(totalCount, pool);
+    BufferPtr sizes = allocateSizes(numRows, pool);
+    BufferPtr offsets = allocateOffsets(numRows, pool);
+    auto rawIndices = indices->asMutable<vector_size_t>();
+    auto rawSizes = sizes->asMutable<vector_size_t>();
+    auto rawOffsets = offsets->asMutable<vector_size_t>();
+
+    vector_size_t offset = 0;
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      rawSizes[row] = count;
+      rawOffsets[row] = offset;
+      std::fill(rawIndices + offset, rawIndices + offset + count, row);
+      offset += count;
+    });
+
+    return std::make_shared<ArrayVector>(
+        pool,
+        outputType,
+        nullptr,
+        numRows,
+        offsets,
+        sizes,
+        BaseVector::wrapInDictionary(nullptr, indices, totalCount, args[0]));
+  }
+
+  VectorPtr applyFlat(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context) const {
+    exec::DecodedArgs decodedArgs(rows, args, context);
+    auto countDecoded = decodedArgs.at(1);
+    int32_t totalCount = 0;
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      auto count =
+          countDecoded->isNullAt(row) ? 0 : countDecoded->valueAt<int32_t>(row);
+      checkCount(count);
+      totalCount += count;
+    });
+
+    const auto numRows = rows.size();
+    auto pool = context.pool();
+
+    // Allocate new vector for nulls if necessary.
+    BufferPtr nulls;
+    uint64_t* rawNulls = nullptr;
+    if (countDecoded->mayHaveNulls()) {
+      nulls = allocateNulls(numRows, pool);
+      rawNulls = nulls->asMutable<uint64_t>();
+    }
+
+    // Allocate new vectors for indices, lengths and offsets.
+    BufferPtr indices = allocateIndices(totalCount, pool);
+    BufferPtr sizes = allocateSizes(numRows, pool);
+    BufferPtr offsets = allocateOffsets(numRows, pool);
+    auto rawIndices = indices->asMutable<vector_size_t>();
+    auto rawSizes = sizes->asMutable<vector_size_t>();
+    auto rawOffsets = offsets->asMutable<vector_size_t>();
+
+    // When context.throwOnError is false, rows with invalid count argument
+    // should be deselected and not be processed further.
+    SelectivityVector remainingRows = rows;
+    context.deselectErrors(remainingRows);
+    vector_size_t offset = 0;
+    context.applyToSelectedNoThrow(remainingRows, [&](auto row) {
+      if (rawNulls && countDecoded->isNullAt(row)) {
+        // Returns null if count argument is null.
+        // e.g. repeat('a', null) -> null
+        bits::setNull(rawNulls, row);
+        return;
+      }
+      auto count = countDecoded->valueAt<int32_t>(row);
+      rawSizes[row] = count;
+      rawOffsets[row] = offset;
+      std::fill(rawIndices + offset, rawIndices + offset + count, row);
+      offset += count;
+    });
+
+    return std::make_shared<ArrayVector>(
+        pool,
+        outputType,
+        nulls,
+        numRows,
+        offsets,
+        sizes,
+        BaseVector::wrapInDictionary(nullptr, indices, totalCount, args[0]));
+  }
+};
+
+static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+  // T, integer -> array(T)
+  return {exec::FunctionSignatureBuilder()
+              .typeVariable("T")
+              .returnType("array(T)")
+              .argumentType("T")
+              .argumentType("integer")
+              .build()};
+}
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_repeat,
+    signatures(),
+    std::make_unique<RepeatFunction>());
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -73,6 +73,7 @@ void registerArrayFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_position, "array_position");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sort, "array_sort");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sum, "array_sum");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_repeat, "repeat");
 
   exec::registerStatefulVectorFunction(
       "width_bucket", widthBucketArraySignature(), makeWidthBucketArray);

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(
   NotTest.cpp
   ReduceTest.cpp
   RegexpReplaceTest.cpp
+  RepeatTest.cpp
   ReverseTest.cpp
   RoundTest.cpp
   SliceTest.cpp

--- a/velox/functions/prestosql/tests/RepeatTest.cpp
+++ b/velox/functions/prestosql/tests/RepeatTest.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace {
+
+class RepeatTest : public FunctionBaseTest {
+ protected:
+  void testExpression(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected) {
+    auto result = evaluate(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+
+  void testExpressionWithError(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const std::string& expectedError) {
+    VELOX_ASSERT_THROW(
+        evaluate(expression, makeRowVector(input)), expectedError);
+  }
+};
+} // namespace
+
+TEST_F(RepeatTest, repeat) {
+  const auto elementVector = makeNullableFlatVector<float>(
+      {0.0, -2.0, 3.333333, 4.0004, std::nullopt, 5.12345});
+  const auto countVector =
+      makeNullableFlatVector<int32_t>({1, 2, 3, 0, 4, std::nullopt});
+  VectorPtr expected;
+
+  expected = makeNullableArrayVector<float>({
+      {{0.0}},
+      {{-2.0, -2.0}},
+      {{3.333333, 3.333333, 3.333333}},
+      {{}},
+      {{std::nullopt, std::nullopt, std::nullopt, std::nullopt}},
+      std::nullopt,
+  });
+  testExpression("repeat(C0, C1)", {elementVector, countVector}, expected);
+  testExpression("try(repeat(C0, C1))", {elementVector, countVector}, expected);
+
+  // Test using a null constant as the count argument.
+  expected = BaseVector::createNullConstant(ARRAY(REAL()), 6, pool());
+  testExpression("repeat(C0, null::INTEGER)", {elementVector}, expected);
+  testExpression("try(repeat(C0, null::INTEGER))", {elementVector}, expected);
+
+  // Test using a non-null constant as the count argument.
+  expected = makeNullableArrayVector<float>({
+      {0.0, 0.0, 0.0},
+      {-2.0, -2.0, -2.0},
+      {3.333333, 3.333333, 3.333333},
+      {4.0004, 4.0004, 4.0004},
+      {std::nullopt, std::nullopt, std::nullopt},
+      {5.12345, 5.12345, 5.12345},
+  });
+  testExpression("repeat(C0, '3'::INTEGER)", {elementVector}, expected);
+  testExpression("try(repeat(C0, '3'::INTEGER))", {elementVector}, expected);
+
+  expected = makeArrayVector<float>({{}, {}, {}, {}, {}, {}});
+  testExpression("repeat(C0, '0'::INTEGER)", {elementVector}, expected);
+  testExpression("try(repeat(C0, '0'::INTEGER))", {elementVector}, expected);
+}
+
+TEST_F(RepeatTest, repeatWithInvalidCount) {
+  const auto elementVector =
+      makeNullableFlatVector<float>({0.0, 2.0, 3.333333});
+
+  VectorPtr countVector;
+  VectorPtr expected;
+
+  expected = makeNullableArrayVector<float>({
+      {{0.0}},
+      std::nullopt,
+      {{3.333333, 3.333333, 3.333333}},
+  });
+  countVector = makeNullableFlatVector<int32_t>({1, -2, 3});
+  testExpression("try(repeat(C0, C1))", {elementVector, countVector}, expected);
+  testExpressionWithError(
+      "repeat(C0, C1)",
+      {elementVector, countVector},
+      "(-2 vs. 0) Count argument of repeat function must be greater than or equal to 0");
+
+  countVector = makeNullableFlatVector<int32_t>({1, 123456, 3});
+  testExpression("try(repeat(C0, C1))", {elementVector, countVector}, expected);
+  testExpressionWithError(
+      "repeat(C0, C1)",
+      {elementVector, countVector},
+      "(123456 vs. 10000) Count argument of repeat function must be less than or equal to 10000");
+
+  // Test using a constant as the count argument.
+  expected = BaseVector::createNullConstant(ARRAY(REAL()), 3, pool());
+  testExpression("try(repeat(C0, '-5'::INTEGER))", {elementVector}, expected);
+  testExpressionWithError(
+      "repeat(C0, '-5'::INTEGER)",
+      {elementVector},
+      "(-5 vs. 0) Count argument of repeat function must be greater than or equal to 0");
+
+  testExpression(
+      "try(repeat(C0, '10001'::INTEGER))", {elementVector}, expected);
+  testExpressionWithError(
+      "repeat(C0, '10001'::INTEGER)",
+      {elementVector},
+      "(10001 vs. 10000) Count argument of repeat function must be less than or equal to 10000");
+}


### PR DESCRIPTION
`repeat(element, count) → array`:
&nbsp;&nbsp;&nbsp;&nbsp; - Repeat _element_ for _count_ times.

Examples:
```SQL
SELECT repeat(1, 3); -- [1, 1, 1]
SELECT repeat(1, 0); -- []
SELECT repeat("foo", 2); -- ["foo", "foo"]
SELECT repeat(true, 3); -- [true, true, true]
SELECT repeat(null, 2); -- [null, null]
SELECT repeat(3, null); -- null

# illegal count argument
SELECT repeat(10, -2);
SELECT repeat(10, 1.23);
SELECT repeat(10, "foo");
SELECT repeat(10, true);
```