### PR TITLE
[Velox2Substrait] Add support for OrderBy/TopN/Limit plan nodes

### DIFF
--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -61,7 +61,8 @@ class SubstraitVeloxPlanConverter {
       const ::substrait::ReadRel& readRel,
       std::shared_ptr<SplitInfo>& splitInfo);
 
-  /// Convert Substrait FetchRel into Velox LimitNode.
+  /// Convert Substrait FetchRel into Velox LimitNode or TopNNode according the
+  /// different input of fetchRel.
   core::PlanNodePtr toVeloxPlan(const ::substrait::FetchRel& fetchRel);
 
   /// Convert Substrait ReadRel into Velox Values Node.
@@ -75,7 +76,7 @@ class SubstraitVeloxPlanConverter {
   /// Convert Substrait RelRoot into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::RelRoot& root);
 
-  /// Convert Substrait SortRel into Velox PlanNode.
+  /// Convert Substrait SortRel into Velox OrderByNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::SortRel& sortRel);
 
   /// Convert Substrait Plan into Velox PlanNode.
@@ -131,7 +132,8 @@ class SubstraitVeloxPlanConverter {
   std::shared_ptr<SubstraitParser> substraitParser_{
       std::make_shared<SubstraitParser>()};
 
-  /// Helper Function to convert Substrait SortField.
+  /// Helper Function to convert Substrait sortField to Velox sortingKeys and
+  /// sortingOrders.
   std::pair<
       std::vector<core::FieldAccessTypedExprPtr>,
       std::vector<core::SortOrder>>
@@ -157,6 +159,13 @@ class SubstraitVeloxPlanConverter {
 
   /// Memory pool.
   memory::MemoryPool* pool_;
+
+  /// Helper function to convert the input of Substrait Rel to Velox Node.
+  template <typename T>
+  core::PlanNodePtr convertSingleInput(T rel) {
+    VELOX_CHECK(rel.has_input(), "Child Rel is expected here.");
+    return toVeloxPlan(rel.input());
+  }
 };
 
 } // namespace facebook::velox::substrait

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -75,6 +75,9 @@ class SubstraitVeloxPlanConverter {
   /// Convert Substrait RelRoot into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::RelRoot& root);
 
+  /// Used to convert Substrait SortRel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::SortRel& sSort);
+
   /// Convert Substrait Plan into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::Plan& substraitPlan);
 

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -76,7 +76,10 @@ class SubstraitVeloxPlanConverter {
   core::PlanNodePtr toVeloxPlan(const ::substrait::RelRoot& root);
 
   /// Used to convert Substrait SortRel into Velox PlanNode.
-  core::PlanNodePtr toVeloxPlan(const ::substrait::SortRel& sSort);
+  core::PlanNodePtr toVeloxPlan(const ::substrait::SortRel& sortRel);
+
+  /// Used to convert Substrait TopNRel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::TopNRel& topNRel);
 
   /// Convert Substrait Plan into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::Plan& substraitPlan);
@@ -130,6 +133,15 @@ class SubstraitVeloxPlanConverter {
   /// recognizable representations.
   std::shared_ptr<SubstraitParser> substraitParser_{
       std::make_shared<SubstraitParser>()};
+
+  /// Helper Function to convert Substrait SortField.
+  std::pair<
+      std::vector<core::FieldAccessTypedExprPtr>,
+      std::vector<core::SortOrder>>
+  processSortField(
+      const ::google::protobuf::RepeatedPtrField<::substrait::SortField>&
+          sortField,
+      const RowTypePtr& inputType);
 
   /// The Expression converter used to convert Substrait representations into
   /// Velox expressions.

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -75,11 +75,8 @@ class SubstraitVeloxPlanConverter {
   /// Convert Substrait RelRoot into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::RelRoot& root);
 
-  /// Used to convert Substrait SortRel into Velox PlanNode.
+  /// Convert Substrait SortRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::SortRel& sortRel);
-
-  /// Used to convert Substrait TopNRel into Velox PlanNode.
-  core::PlanNodePtr toVeloxPlan(const ::substrait::TopNRel& topNRel);
 
   /// Convert Substrait Plan into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::Plan& substraitPlan);

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -61,6 +61,9 @@ class SubstraitVeloxPlanConverter {
       const ::substrait::ReadRel& readRel,
       std::shared_ptr<SplitInfo>& splitInfo);
 
+  /// Convert Substrait FetchRel into Velox LimitNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::FetchRel& fetchRel);
+
   /// Convert Substrait ReadRel into Velox Values Node.
   core::PlanNodePtr toVeloxPlan(
       const ::substrait::ReadRel& readRel,

--- a/velox/substrait/VeloxToSubstraitExpr.h
+++ b/velox/substrait/VeloxToSubstraitExpr.h
@@ -64,17 +64,17 @@ class VeloxToSubstraitExprConvertor {
       google::protobuf::Arena& arena,
       const velox::variant& variantValue);
 
+  /// Convert Velox FieldAccessTypedExpr to Substrait FieldReference Expression.
+  const ::substrait::Expression_FieldReference& toSubstraitExpr(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::FieldAccessTypedExpr>& fieldExpr,
+      const RowTypePtr& inputType);
+
  private:
   /// Convert Velox Cast Expression to Substrait Cast Expression.
   const ::substrait::Expression_Cast& toSubstraitExpr(
       google::protobuf::Arena& arena,
       const std::shared_ptr<const core::CastTypedExpr>& castExpr,
-      const RowTypePtr& inputType);
-
-  /// Convert Velox FieldAccessTypedExpr to Substrait FieldReference Expression.
-  const ::substrait::Expression_FieldReference& toSubstraitExpr(
-      google::protobuf::Arena& arena,
-      const std::shared_ptr<const core::FieldAccessTypedExpr>& fieldExpr,
       const RowTypePtr& inputType);
 
   /// Convert Velox CallTypedExpr Expression to Substrait Expression.

--- a/velox/substrait/VeloxToSubstraitPlan.cpp
+++ b/velox/substrait/VeloxToSubstraitPlan.cpp
@@ -410,7 +410,6 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
     sortField->set_direction(toSortDirection(sortingOrders[i]));
   }
 
-  topNRel->set_offset(0);
   topNRel->set_is_partial(topNNode->isPartial());
   topNRel->set_count(topNNode->count());
   topNRel->mutable_common()->mutable_direct();

--- a/velox/substrait/VeloxToSubstraitPlan.cpp
+++ b/velox/substrait/VeloxToSubstraitPlan.cpp
@@ -365,8 +365,10 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
 
   for (int64_t i = 0; i < sortingKeys.size(); i++) {
     ::substrait::SortField* sortField = sortRel->add_sorts();
-    sortField->mutable_expr()->MergeFrom(
-        exprConvertor_->toSubstraitExpr(arena, sortingKeys[i], inputType));
+    sortField->mutable_expr()->MergeFrom(exprConvertor_->toSubstraitExpr(
+        arena,
+        std::dynamic_pointer_cast<const core::ITypedExpr>(sortingKeys[i]),
+        inputType));
 
     sortField->set_direction(toSortDirection(sortingOrders[i]));
   }
@@ -400,8 +402,10 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
 
   for (int64_t i = 0; i < sortingKeys.size(); i++) {
     ::substrait::SortField* sortField = topNRel->add_sorts();
-    sortField->mutable_expr()->MergeFrom(
-        exprConvertor_->toSubstraitExpr(arena, sortingKeys[i], inputType));
+    sortField->mutable_expr()->MergeFrom(exprConvertor_->toSubstraitExpr(
+        arena,
+        std::dynamic_pointer_cast<const core::ITypedExpr>(sortingKeys[i]),
+        inputType));
 
     sortField->set_direction(toSortDirection(sortingOrders[i]));
   }

--- a/velox/substrait/VeloxToSubstraitPlan.cpp
+++ b/velox/substrait/VeloxToSubstraitPlan.cpp
@@ -151,9 +151,7 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
     ::substrait::FilterRel* filterRel) {
   const auto& source = getSingleSource(filterNode);
 
-  ::substrait::Rel* filterInput = filterRel->mutable_input();
-
-  toSubstrait(arena, source, filterInput);
+  toSubstrait(arena, source, filterRel->mutable_input());
 
   // Construct substrait expr(Filter condition).
   auto filterCondition = filterNode->filter();
@@ -212,8 +210,7 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
   const auto& source = getSingleSource(projectNode);
 
   // Process the source Node.
-  ::substrait::Rel* projectRelInput = projectRel->mutable_input();
-  toSubstrait(arena, source, projectRelInput);
+  toSubstrait(arena, source, projectRel->mutable_input());
 
   // Remap the output.
   ::substrait::RelCommon_Emit* projRelEmit =

--- a/velox/substrait/VeloxToSubstraitPlan.cpp
+++ b/velox/substrait/VeloxToSubstraitPlan.cpp
@@ -372,7 +372,6 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
   }
 
   sortRel->set_is_partial(orderByNode->isPartial());
-  // TODO: output.
   sortRel->mutable_common()->mutable_direct();
 }
 
@@ -410,7 +409,7 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
   topNRel->set_offset(0);
   topNRel->set_is_partial(topNNode->isPartial());
   topNRel->set_count(topNNode->count());
-  // TODO: output.
+  topNRel->mutable_common()->mutable_direct();
 }
 
 void VeloxToSubstraitPlanConvertor::toSubstrait(
@@ -429,6 +428,7 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
   fetchRel->set_offset(limitNode->offset());
   fetchRel->set_count(limitNode->count());
   fetchRel->set_is_partial(limitNode->isPartial());
+  fetchRel->mutable_common()->mutable_direct();
 }
 
 } // namespace facebook::velox::substrait

--- a/velox/substrait/VeloxToSubstraitPlan.cpp
+++ b/velox/substrait/VeloxToSubstraitPlan.cpp
@@ -35,7 +35,7 @@ namespace {
       return ::substrait::AGGREGATION_PHASE_INTERMEDIATE_TO_RESULT;
     }
     default:
-      VELOX_NYI(
+      VELOX_UNSUPPORTED(
           "Unsupported Aggregate Step '{}' in Substrait ",
           mapAggregationStepToName(step));
   }
@@ -52,7 +52,8 @@ namespace {
   } else if (!sortOrder.isNullsFirst() && !sortOrder.isAscending()) {
     return ::substrait::SortField_SortDirection_SORT_DIRECTION_DESC_NULLS_LAST;
   } else {
-    VELOX_NYI("SortOrder '{}' is not supported yet.", sortOrder.toString());
+    VELOX_UNSUPPORTED(
+        "SortOrder '{}' is not supported yet.", sortOrder.toString());
   }
 }
 
@@ -129,7 +130,8 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
   }
   if (auto topNNode =
           std::dynamic_pointer_cast<const core::TopNNode>(planNode)) {
-    toSubstrait(arena, topNNode, rel->mutable_top_n());
+    // Convert it to fetchRel->sortRel.
+    toSubstrait(arena, topNNode, rel->mutable_fetch());
     return;
   }
   if (auto limitNode =
@@ -137,6 +139,7 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
     toSubstrait(arena, limitNode, rel->mutable_fetch());
     return;
   }
+  VELOX_UNSUPPORTED("Unsupported Node '{}' .", planNode->name());
 }
 
 void VeloxToSubstraitPlanConvertor::toSubstrait(
@@ -349,19 +352,64 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
       1, sources.size(), "OrderBy plan node must have exactly one source.");
 
   const auto& source = sources[0];
-  auto inputType = source->outputType();
 
   // Build source.
   toSubstrait(arena, source, sortRel->mutable_input());
 
   // Process sortingKeys and sortingOrders.
-  std::vector<core::FieldAccessTypedExprPtr> sortingKeys =
-      orderByNode->sortingKeys();
-  std::vector<core::SortOrder> sortingOrders = orderByNode->sortingOrders();
+  sortRel->MergeFrom(processSortFields(
+      arena,
+      orderByNode->sortingKeys(),
+      orderByNode->sortingOrders(),
+      source->outputType()));
+
+  sortRel->set_is_partial(orderByNode->isPartial());
+  sortRel->mutable_common()->mutable_direct();
+}
+
+void VeloxToSubstraitPlanConvertor::toSubstrait(
+    google::protobuf::Arena& arena,
+    const std::shared_ptr<const core::TopNNode>& topNNode,
+    ::substrait::FetchRel* fetchRel) {
+  std::vector<core::PlanNodePtr> sources = topNNode->sources();
+  // Convert it to be fetchRel->SortRel.
+  // Check there only have one input.
+  VELOX_USER_CHECK_EQ(
+      1, sources.size(), "Top-N plan node must have exactly one source.");
+  const auto& source = sources[0];
+
+  // Construct the sortRel as the FetchRel input.
+  ::substrait::SortRel* sortRel = fetchRel->mutable_input()->mutable_sort();
+
+  // Build source.
+  toSubstrait(arena, source, sortRel->mutable_input());
+
+  sortRel->MergeFrom(processSortFields(
+      arena,
+      topNNode->sortingKeys(),
+      topNNode->sortingOrders(),
+      source->outputType()));
+
+  sortRel->set_is_partial(topNNode->isPartial());
+  sortRel->mutable_common()->mutable_direct();
+
+  fetchRel->set_is_partial(topNNode->isPartial());
+  fetchRel->set_count(topNNode->count());
+  fetchRel->mutable_common()->mutable_direct();
+}
+
+const ::substrait::SortRel& VeloxToSubstraitPlanConvertor::processSortFields(
+    google::protobuf::Arena& arena,
+    const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys,
+    const std::vector<core::SortOrder>& sortingOrders,
+    const facebook::velox::RowTypePtr& inputType) {
+  ::substrait::SortRel* sortRel =
+      google::protobuf::Arena::CreateMessage<::substrait::SortRel>(&arena);
+
   VELOX_CHECK_EQ(
       sortingKeys.size(),
       sortingOrders.size(),
-      "Number of sorting keys and sorting orders in OrderBy must be the same");
+      "Number of sorting keys and sorting orders must be the same");
 
   for (int64_t i = 0; i < sortingKeys.size(); i++) {
     ::substrait::SortField* sortField = sortRel->add_sorts();
@@ -372,47 +420,7 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
 
     sortField->set_direction(toSortDirection(sortingOrders[i]));
   }
-
-  sortRel->set_is_partial(orderByNode->isPartial());
-  sortRel->mutable_common()->mutable_direct();
-}
-
-void VeloxToSubstraitPlanConvertor::toSubstrait(
-    google::protobuf::Arena& arena,
-    const std::shared_ptr<const core::TopNNode>& topNNode,
-    ::substrait::TopNRel* topNRel) {
-  std::vector<core::PlanNodePtr> sources = topNNode->sources();
-
-  // Check there only have one input.
-  VELOX_USER_CHECK_EQ(
-      1, sources.size(), "Top-N plan node must have exactly one source.");
-  const auto& source = sources[0];
-  auto inputType = source->outputType();
-
-  // Build source.
-  toSubstrait(arena, source, topNRel->mutable_input());
-
-  std::vector<core::FieldAccessTypedExprPtr> sortingKeys =
-      topNNode->sortingKeys();
-  std::vector<core::SortOrder> sortingOrders = topNNode->sortingOrders();
-  VELOX_CHECK_EQ(
-      sortingKeys.size(),
-      sortingOrders.size(),
-      "Number of sorting keys and sorting orders in TopN must be the same");
-
-  for (int64_t i = 0; i < sortingKeys.size(); i++) {
-    ::substrait::SortField* sortField = topNRel->add_sorts();
-    sortField->mutable_expr()->MergeFrom(exprConvertor_->toSubstraitExpr(
-        arena,
-        std::dynamic_pointer_cast<const core::ITypedExpr>(sortingKeys[i]),
-        inputType));
-
-    sortField->set_direction(toSortDirection(sortingOrders[i]));
-  }
-
-  topNRel->set_is_partial(topNNode->isPartial());
-  topNRel->set_count(topNNode->count());
-  topNRel->mutable_common()->mutable_direct();
+  return *sortRel;
 }
 
 void VeloxToSubstraitPlanConvertor::toSubstrait(

--- a/velox/substrait/VeloxToSubstraitPlan.h
+++ b/velox/substrait/VeloxToSubstraitPlan.h
@@ -79,11 +79,18 @@ class VeloxToSubstraitPlanConvertor {
       const std::shared_ptr<const core::OrderByNode>& orderByNode,
       ::substrait::SortRel* sortRel);
 
-  /// Convert Velox TopN Node into Substrait TopNRel.
+  /// Convert Velox TopN Node into Substrait SortRel->FetchRel.
   void toSubstrait(
       google::protobuf::Arena& arena,
       const std::shared_ptr<const core::TopNNode>& topNNode,
-      ::substrait::TopNRel* topNRel);
+      ::substrait::FetchRel* fetchRel);
+
+  /// Helper function to process sortingKeys and sortingOrders.
+  const ::substrait::SortRel& processSortFields(
+      google::protobuf::Arena& arena,
+      const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys,
+      const std::vector<core::SortOrder>& sortingOrders,
+      const RowTypePtr& inputType);
 
   /// Convert Velox Limit Node into Substrait FetchRel.
   void toSubstrait(

--- a/velox/substrait/VeloxToSubstraitPlan.h
+++ b/velox/substrait/VeloxToSubstraitPlan.h
@@ -73,6 +73,24 @@ class VeloxToSubstraitPlanConvertor {
       const std::shared_ptr<const core::AggregationNode>& aggregateNode,
       ::substrait::AggregateRel* aggregateRel);
 
+  /// Convert Velox OrderBy Node into Substrait SortRel.
+  void toSubstrait(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::OrderByNode>& orderByNode,
+      ::substrait::SortRel* sortRel);
+
+  /// Convert Velox TopN Node into Substrait TopNRel.
+  void toSubstrait(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::TopNNode>& topNNode,
+      ::substrait::TopNRel* topNRel);
+
+  /// Convert Velox Limit Node into Substrait FetchRel.
+  void toSubstrait(
+      google::protobuf::Arena& arena,
+      const std::shared_ptr<const core::LimitNode>& limitNode,
+      ::substrait::FetchRel* fetchRel);
+
   /// The Expression converter used to convert Velox representations into
   /// Substrait expressions.
   VeloxToSubstraitExprConvertorPtr exprConvertor_;

--- a/velox/substrait/VeloxToSubstraitPlan.h
+++ b/velox/substrait/VeloxToSubstraitPlan.h
@@ -85,7 +85,8 @@ class VeloxToSubstraitPlanConvertor {
       const std::shared_ptr<const core::TopNNode>& topNNode,
       ::substrait::FetchRel* fetchRel);
 
-  /// Helper function to process sortingKeys and sortingOrders.
+  /// Helper function to process sortingKeys and sortingOrders in Velox to
+  /// convert them to the sortField of SortRel in Substrait.
   const ::substrait::SortRel& processSortFields(
       google::protobuf::Arena& arena,
       const std::vector<core::FieldAccessTypedExprPtr>& sortingKeys,
@@ -97,6 +98,9 @@ class VeloxToSubstraitPlanConvertor {
       google::protobuf::Arena& arena,
       const std::shared_ptr<const core::LimitNode>& limitNode,
       ::substrait::FetchRel* fetchRel);
+
+  /// Check there only have one source for the velox node and return it.
+  const core::PlanNodePtr& getSingleSource(const core::PlanNodePtr& node);
 
   /// The Expression converter used to convert Velox representations into
   /// Substrait expressions.

--- a/velox/substrait/proto/substrait/algebra.proto
+++ b/velox/substrait/proto/substrait/algebra.proto
@@ -243,20 +243,6 @@ message SortRel {
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
-// The Top-N relational operator.
-message TopNRel {
-  RelCommon common = 1;
-  Rel input = 2;
-  repeated SortField sorts = 3;
-  // The offset expressed in number of records. Optional, defaults to 0.
-  int64 offset = 4;
-  // The amount of records to return.
-  int64 count = 5;
-  bool is_partial = 6;
-
-  substrait.extensions.AdvancedExtension advanced_extension = 10;
-}
-
 // The relational operator capturing simple FILTERs (as in the WHERE clause of SQL)
 message FilterRel {
   RelCommon common = 1;
@@ -384,7 +370,6 @@ message Rel {
     ExtensionMultiRel extension_multi = 10;
     ExtensionLeafRel extension_leaf = 11;
     CrossRel cross = 12;
-    TopNRel top_n = 13;
   }
 }
 

--- a/velox/substrait/proto/substrait/algebra.proto
+++ b/velox/substrait/proto/substrait/algebra.proto
@@ -194,6 +194,10 @@ message FetchRel {
   int64 offset = 3;
   // the amount of records to return
   int64 count = 4;
+  // A Boolean indicating whether the node generates partial
+  // results on local workers or finalizes the partial results.
+  bool is_partial = 5;
+
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
@@ -232,6 +236,24 @@ message SortRel {
   RelCommon common = 1;
   Rel input = 2;
   repeated SortField sorts = 3;
+
+  // True if this node only sorts a portion of the final result. If it is true,
+  // a local merge or merge exchange is required to merge the sorted runs.
+  bool is_partial = 4;
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+}
+
+// The Top-N relational operator.
+message TopNRel {
+  RelCommon common = 1;
+  Rel input = 2;
+  repeated SortField sorts = 3;
+  // The offset expressed in number of records. Optional, defaults to 0.
+  int64 offset = 4;
+  // The amount of records to return.
+  int64 count = 5;
+  bool is_partial = 6;
+
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
@@ -362,6 +384,7 @@ message Rel {
     ExtensionMultiRel extension_multi = 10;
     ExtensionLeafRel extension_leaf = 11;
     CrossRel cross = 12;
+    TopNRel top_n = 13;
   }
 }
 

--- a/velox/substrait/proto/substrait/algebra.proto
+++ b/velox/substrait/proto/substrait/algebra.proto
@@ -194,10 +194,6 @@ message FetchRel {
   int64 offset = 3;
   // the amount of records to return
   int64 count = 4;
-  // A Boolean indicating whether the node generates partial
-  // results on local workers or finalizes the partial results.
-  bool is_partial = 5;
-
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
@@ -236,10 +232,6 @@ message SortRel {
   RelCommon common = 1;
   Rel input = 2;
   repeated SortField sorts = 3;
-
-  // True if this node only sorts a portion of the final result. If it is true,
-  // a local merge or merge exchange is required to merge the sorted runs.
-  bool is_partial = 4;
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 

--- a/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
@@ -286,6 +286,59 @@ TEST_F(VeloxSubstraitRoundTripTest, ifThen) {
   assertPlanConversion(plan, "SELECT if (c0=1, c0 + 1, c1 + 2) as x FROM tmp");
 }
 
+TEST_F(VeloxSubstraitRoundTripTest, orderBySingleKey) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .orderBy({"c0 DESC NULLS LAST"}, false)
+                  .planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp ORDER BY c0 DESC NULLS LAST");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, orderBy) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .orderBy({"c0 ASC NULLS FIRST", "c1 ASC NULLS LAST"}, false)
+                  .planNode();
+  assertPlanConversion(
+      plan, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST, c1 NULLS LAST");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, orderByPartial) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .orderBy({"c0 ASC NULLS FIRST", "c1 ASC NULLS LAST"}, true)
+                  .planNode();
+  assertPlanConversion(
+      plan, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST, c1 NULLS LAST");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, Limit) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).limit(0, 10, false).planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp LIMIT 10");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, LimitPartial) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).limit(0, 10, true).planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp LIMIT 10");
+}
+
+TEST_F(VeloxSubstraitRoundTripTest, LimitOffest) {
+  auto vectors = makeVectors(3, 4, 2);
+  createDuckDbTable(vectors);
+  auto plan = PlanBuilder().values(vectors).limit(5, 10, false).planNode();
+  assertPlanConversion(plan, "SELECT * FROM tmp OFFSET 5 LIMIT 10");
+}
+
 TEST_F(VeloxSubstraitRoundTripTest, notNullLiteral) {
   auto vectors = makeRowVector(ROW({}, {}), 1);
   auto plan = PlanBuilder(pool_.get())

--- a/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
@@ -361,7 +361,6 @@ TEST_F(VeloxSubstraitRoundTripTest, topNPartial) {
       plan, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST LIMIT 10");
 }
 
-
 TEST_F(VeloxSubstraitRoundTripTest, topNFilter) {
   auto vectors = makeVectors(3, 4, 2);
   createDuckDbTable(vectors);
@@ -383,7 +382,8 @@ TEST_F(VeloxSubstraitRoundTripTest, topNTwoKeys) {
                   .topN({"c0 NULLS FIRST", "c1 DESC NULLS LAST"}, 10, true)
                   .planNode();
   assertPlanConversion(
-      plan, "SELECT * FROM tmp WHERE c0 > 15 ORDER BY c0 NULLS FIRST, c1 DESC NULLS LAST LIMIT 10");
+      plan,
+      "SELECT * FROM tmp WHERE c0 > 15 ORDER BY c0 NULLS FIRST, c1 DESC NULLS LAST LIMIT 10");
 }
 
 TEST_F(VeloxSubstraitRoundTripTest, notNullLiteral) {

--- a/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
@@ -287,7 +287,7 @@ TEST_F(VeloxSubstraitRoundTripTest, ifThen) {
 }
 
 TEST_F(VeloxSubstraitRoundTripTest, orderBySingleKey) {
-  auto vectors = makeVectors(3, 4, 2);
+  auto vectors = makeVectors(10, 4, 2);
   createDuckDbTable(vectors);
   auto plan = PlanBuilder()
                   .values(vectors)
@@ -297,7 +297,7 @@ TEST_F(VeloxSubstraitRoundTripTest, orderBySingleKey) {
 }
 
 TEST_F(VeloxSubstraitRoundTripTest, orderBy) {
-  auto vectors = makeVectors(3, 4, 2);
+  auto vectors = makeVectors(10, 4, 2);
   createDuckDbTable(vectors);
   auto plan = PlanBuilder()
                   .values(vectors)
@@ -308,39 +308,39 @@ TEST_F(VeloxSubstraitRoundTripTest, orderBy) {
 }
 
 TEST_F(VeloxSubstraitRoundTripTest, orderByPartial) {
-  auto vectors = makeVectors(3, 4, 2);
+  auto vectors = makeVectors(10, 4, 2);
   createDuckDbTable(vectors);
   auto plan = PlanBuilder()
                   .values(vectors)
-                  .orderBy({"c0 ASC NULLS FIRST", "c1 ASC NULLS LAST"}, true)
+                  .orderBy({"c0 DESC NULLS FIRST", "c1 ASC NULLS LAST"}, true)
                   .planNode();
   assertPlanConversion(
-      plan, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST, c1 NULLS LAST");
+      plan, "SELECT * FROM tmp ORDER BY c0 DESC NULLS FIRST, c1 NULLS LAST");
 }
 
-TEST_F(VeloxSubstraitRoundTripTest, Limit) {
-  auto vectors = makeVectors(3, 4, 2);
+TEST_F(VeloxSubstraitRoundTripTest, limit) {
+  auto vectors = makeVectors(10, 4, 2);
   createDuckDbTable(vectors);
   auto plan = PlanBuilder().values(vectors).limit(0, 10, false).planNode();
   assertPlanConversion(plan, "SELECT * FROM tmp LIMIT 10");
 }
 
-TEST_F(VeloxSubstraitRoundTripTest, LimitPartial) {
-  auto vectors = makeVectors(3, 4, 2);
+TEST_F(VeloxSubstraitRoundTripTest, limitPartial) {
+  auto vectors = makeVectors(10, 4, 2);
   createDuckDbTable(vectors);
   auto plan = PlanBuilder().values(vectors).limit(0, 10, true).planNode();
   assertPlanConversion(plan, "SELECT * FROM tmp LIMIT 10");
 }
 
-TEST_F(VeloxSubstraitRoundTripTest, LimitOffest) {
-  auto vectors = makeVectors(3, 4, 2);
+TEST_F(VeloxSubstraitRoundTripTest, limitOffest) {
+  auto vectors = makeVectors(10, 4, 2);
   createDuckDbTable(vectors);
   auto plan = PlanBuilder().values(vectors).limit(5, 10, false).planNode();
   assertPlanConversion(plan, "SELECT * FROM tmp OFFSET 5 LIMIT 10");
 }
 
 TEST_F(VeloxSubstraitRoundTripTest, topN) {
-  auto vectors = makeVectors(3, 4, 2);
+  auto vectors = makeVectors(10, 4, 2);
   createDuckDbTable(vectors);
   auto plan = PlanBuilder()
                   .values(vectors)
@@ -351,30 +351,31 @@ TEST_F(VeloxSubstraitRoundTripTest, topN) {
 }
 
 TEST_F(VeloxSubstraitRoundTripTest, topNPartial) {
-  auto vectors = makeVectors(3, 4, 2);
+  auto vectors = makeVectors(10, 4, 2);
   createDuckDbTable(vectors);
   auto plan = PlanBuilder()
                   .values(vectors)
-                  .topN({"c0 NULLS FIRST"}, 10, true)
+                  .topN({"c0 NULLS LAST"}, 10, true)
                   .planNode();
   assertPlanConversion(
-      plan, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST LIMIT 10");
+      plan, "SELECT * FROM tmp ORDER BY c0 NULLS LAST LIMIT 10");
 }
 
 TEST_F(VeloxSubstraitRoundTripTest, topNFilter) {
-  auto vectors = makeVectors(3, 4, 2);
+  auto vectors = makeVectors(10, 4, 2);
   createDuckDbTable(vectors);
   auto plan = PlanBuilder()
                   .values(vectors)
                   .filter("c0 > 15")
-                  .topN({"c0 NULLS FIRST"}, 10, true)
+                  .topN({"c0 DESC NULLS FIRST"}, 10, true)
                   .planNode();
   assertPlanConversion(
-      plan, "SELECT * FROM tmp WHERE c0 > 15 ORDER BY c0 NULLS FIRST LIMIT 10");
+      plan,
+      "SELECT * FROM tmp WHERE c0 > 15 ORDER BY c0 DESC NULLS FIRST LIMIT 10");
 }
 
 TEST_F(VeloxSubstraitRoundTripTest, topNTwoKeys) {
-  auto vectors = makeVectors(3, 4, 2);
+  auto vectors = makeVectors(10, 4, 2);
   createDuckDbTable(vectors);
   auto plan = PlanBuilder()
                   .values(vectors)


### PR DESCRIPTION
Add support for the following conversions:

- OrderByNode -> Substrait SortRel.
- LimitNode -> Substrait FetchRel.
- TopNNode-> Substrait FetchRel + SortRel.

Limitations: Substrait currently doesn't support 'partial' flag for these nodes, hence, not converting these.
