### PR TITLE
Table writer 10: Support partition writes in TableWriter

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -101,9 +101,9 @@ class DataSink {
  public:
   virtual ~DataSink() = default;
 
-  /// Add the next data (vector) to be written. This call is blocking
-  // TODO maybe at some point we want to make it async
-  virtual void appendData(VectorPtr input) = 0;
+  /// Add the next data (vector) to be written. This call is blocking.
+  // TODO maybe at some point we want to make it async.
+  virtual void appendData(RowVectorPtr input) = 0;
 
   /// Called once after all data has been added via possibly multiple calls to
   /// appendData(). Could return data in the string form that would be included

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -47,4 +47,9 @@ HiveConfig::insertExistingPartitionsBehavior(const Config* config) {
       : InsertExistingPartitionsBehavior::kError;
 }
 
+// static
+uint32_t HiveConfig::maxPartitionsPerWriters(const Config* config) {
+  return config->get<uint32_t>(kMaxPartitionsPerWriters, 100);
+}
+
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -31,8 +31,14 @@ class HiveConfig {
   static constexpr const char* kInsertExistingPartitionsBehavior =
       "insert_existing_partitions_behavior";
 
+  /// Maximum number of partitions per a single table writer instance.
+  static constexpr const char* kMaxPartitionsPerWriters =
+      "max_partitions_per_writers";
+
   static InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const Config* config);
+
+  static uint32_t maxPartitionsPerWriters(const Config* config);
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -321,7 +321,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
     return;
   }
 
-  // Check filters and see if the whole split can be skipped
+  // Check filters and see if the whole split can be skipped.
   if (!testFilters(scanSpec_.get(), reader_.get(), split_->filePath)) {
     emptySplit_ = true;
     ++runtimeStats_.skippedSplits;
@@ -417,7 +417,7 @@ std::optional<RowVectorPtr> HiveDataSource::next(
         !output_->mayHaveNulls(), "Top-level row vector cannot have nulls");
     auto rowsRemaining = output_->size();
     if (rowsRemaining == 0) {
-      // no rows passed the pushed down filters
+      // no rows passed the pushed down filters.
       return RowVector::createEmpty(outputType_, pool_);
     }
 

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -184,7 +184,7 @@ class HiveDataSource : public DataSource {
   ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator_;
   uint64_t completedRows_ = 0;
 
-  // Reusable memory for remaining filter evaluation
+  // Reusable memory for remaining filter evaluation.
   VectorPtr filterResult_;
   SelectivityVector filterRows_;
   exec::FilterEvalCtx filterEvalCtx_;

--- a/velox/connectors/hive/HivePartitionUtil.cpp
+++ b/velox/connectors/hive/HivePartitionUtil.cpp
@@ -72,20 +72,19 @@ std::string makePartitionKeyValueString(
 } // namespace
 
 std::string makePartitionName(
-    const RowVectorPtr& input,
-    const std::vector<column_index_t>& partitionChannels,
+    const RowVectorPtr& partitionsVector,
     vector_size_t row) {
   std::stringstream ss;
-  for (auto i = 0; i < partitionChannels.size(); i++) {
+  for (auto i = 0; i < partitionsVector->childrenSize(); i++) {
     if (i > 0) {
       ss << '/';
     }
     ss << PARTITION_TYPE_DISPATCH(
         makePartitionKeyValueString,
-        input->childAt(partitionChannels[i])->typeKind(),
-        input->childAt(partitionChannels[i])->loadedVector(),
+        partitionsVector->childAt(i)->typeKind(),
+        partitionsVector->childAt(i)->loadedVector(),
         row,
-        asRowType(input->type())->nameOf(partitionChannels[i]));
+        asRowType(partitionsVector->type())->nameOf(i));
   }
   return ss.str();
 }

--- a/velox/connectors/hive/HivePartitionUtil.h
+++ b/velox/connectors/hive/HivePartitionUtil.h
@@ -19,12 +19,10 @@
 
 namespace facebook::velox::connector::hive {
 
-/// Make partition name in the typical Hive style, which
-/// is key1=value1/key2=value2/... It would be the leaf directory
-/// of the partition path.
+/// Make the partition name in the Hive style, with the partition values at row.
+/// Partition name is in the format of key1=value1/key2=value2/...
 std::string makePartitionName(
-    const RowVectorPtr& input,
-    const std::vector<column_index_t>& partitionChannels,
+    const RowVectorPtr& partitionsVector,
     vector_size_t row);
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/PartitionIdGenerator.h
+++ b/velox/connectors/hive/PartitionIdGenerator.h
@@ -41,10 +41,16 @@ class PartitionIdGenerator {
   /// @param result Generated integer IDs indexed by input row number.
   void run(const RowVectorPtr& input, raw_vector<uint64_t>& result);
 
-  /// Return the maximum partition ID generated for the most recent input.
-  uint64_t recentMaxPartitionId() const {
-    return recentMaxId_;
+  /// Return the total number of distinct partitions processed so far.
+  uint64_t numPartitions() const {
+    return partitionIds_.size();
   }
+
+  /// Return partition name for the given partition id in the typical Hive
+  /// style. It is derived from the partitionValues_ at index partitionId.
+  /// Partition keys appear in the order of partition columns in the table
+  /// schema.
+  std::string partitionName(uint64_t partitionId) const;
 
  private:
   static constexpr const int32_t kHasherReservePct = 20;
@@ -79,9 +85,6 @@ class PartitionIdGenerator {
   // A vector holding unique partition key values. One row per partition. Row
   // numbers match partition IDs.
   RowVectorPtr partitionValues_;
-
-  // Maximum partition ID generated for the most recent input.
-  uint64_t recentMaxId_ = 0;
 
   // All rows are set valid to compute partition IDs for all input rows.
   SelectivityVector allRows_;

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -123,6 +123,15 @@ class QueryCtx : public Context {
         std::make_shared<const MemConfig>(std::move(configOverrides)));
   }
 
+  // Overrides the previous connector-specific configuration. Note that this
+  // function is NOT thread-safe and should probably only be used in tests.
+  void setConnectorConfigOverridesUnsafe(
+      const std::string& connectorId,
+      std::unordered_map<std::string, std::string>&& configOverrides) {
+    connectorConfigs_[connectorId] =
+        std::make_shared<MemConfig>(std::move(configOverrides));
+  }
+
   folly::Executor* FOLLY_NULLABLE spillExecutor() const {
     return spillExecutor_.get();
   }
@@ -245,7 +254,7 @@ class ExecCtx : public Context {
   }
 
  private:
-  // Pool for all Buffers for this thread
+  // Pool for all Buffers for this thread.
   memory::MemoryPool* FOLLY_NONNULL pool_;
   QueryCtx* FOLLY_NULLABLE queryCtx_;
   // A pool of preallocated DecodedVectors for use by expressions and operators.

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -176,7 +176,7 @@ Hive Connector
     * **Type:** ``integer``
     * **Default value:** ``100``
 
-Maximum number of partitions per writer.
+Maximum number of partitions per a single table writer instance.
 
 ``insert_existing_partitions_behavior``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -88,7 +88,7 @@ void TableWriter::addInput(RowVectorPtr input) {
 }
 
 RowVectorPtr TableWriter::getOutput() {
-  // Making sure the output is read only once after the write is fully done
+  // Making sure the output is read only once after the write is fully done.
   if (!noMoreInput_ || finished_) {
     return nullptr;
   }

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -15,12 +15,18 @@
  */
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/HivePartitionUtil.h"
 #include "velox/dwio/common/DataSink.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
+#include <regex>
+
 using namespace facebook::velox;
+using namespace facebook::velox::core;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::connector;
@@ -39,11 +45,107 @@ class TableWriteTest : public HiveConnectorTestBase {
   std::vector<std::shared_ptr<connector::ConnectorSplit>>
   makeHiveConnectorSplits(
       const std::shared_ptr<TempDirectoryPath>& directoryPath) {
+    return makeHiveConnectorSplits(directoryPath->path);
+  }
+
+  std::vector<std::shared_ptr<connector::ConnectorSplit>>
+  makeHiveConnectorSplits(const std::string& directoryPath) {
     std::vector<std::shared_ptr<connector::ConnectorSplit>> splits;
-    for (auto& filePath : fs::directory_iterator(directoryPath->path)) {
-      splits.push_back(makeHiveConnectorSplit(filePath.path().string()));
+
+    for (auto& path : fs::recursive_directory_iterator(directoryPath)) {
+      if (path.is_regular_file()) {
+        splits.push_back(makeHiveConnectorSplit(path.path().string()));
+      }
     }
+
     return splits;
+  }
+
+  std::vector<RowVectorPtr> makeBatches(
+      vector_size_t numBatches,
+      std::function<RowVectorPtr(int32_t)> makeVector) {
+    std::vector<RowVectorPtr> batches;
+    batches.reserve(numBatches);
+    for (int32_t i = 0; i < numBatches; ++i) {
+      batches.push_back(makeVector(i));
+    }
+    return batches;
+  }
+
+  std::set<std::string> getLeafSubdirectories(
+      const std::string& directoryPath) {
+    std::set<std::string> subdirectories;
+    for (auto& path : fs::recursive_directory_iterator(directoryPath)) {
+      if (path.is_regular_file()) {
+        subdirectories.emplace(path.path().parent_path().string());
+      }
+    }
+    return subdirectories;
+  }
+
+  std::vector<std::string> getRecursiveFiles(const std::string& directoryPath) {
+    std::vector<std::string> files;
+    for (auto& path : fs::recursive_directory_iterator(directoryPath)) {
+      if (path.is_regular_file()) {
+        files.push_back(path.path().string());
+      }
+    }
+    return files;
+  }
+
+  uint32_t countRecursiveFiles(const std::string& directoryPath) {
+    return getRecursiveFiles(directoryPath).size();
+  }
+
+  RowVectorPtr makePartitionsVector(
+      RowVectorPtr input,
+      const std::vector<column_index_t>& partitionChannels) {
+    std::vector<VectorPtr> partitions;
+    std::vector<std::string> partitonKeyNames;
+    std::vector<TypePtr> partitionKeyTypes;
+
+    RowTypePtr inputType = asRowType(input->type());
+    for (column_index_t channel : partitionChannels) {
+      partitions.push_back(input->childAt(channel));
+      partitonKeyNames.push_back(inputType->nameOf(channel));
+      partitionKeyTypes.push_back(inputType->childAt(channel));
+    }
+
+    return std::make_shared<RowVector>(
+        pool(),
+        ROW(std::move(partitonKeyNames), std::move(partitionKeyTypes)),
+        nullptr,
+        input->size(),
+        partitions);
+  }
+
+  // Parameter partitionName is string formatted in the Hive style
+  // key1=value1/key2=value2/... Parameter partitionTypes are types of partition
+  // keys in the same order as in partitionName.The return value is a SQL
+  // predicate with values single quoted for string and date and not quoted for
+  // other supported types, ex., key1='value1' AND key2=value2 AND ...
+  std::string partitionNameToPredicate(
+      const std::string& partitionName,
+      const std::vector<TypePtr>& partitionTypes) {
+    std::vector<std::string> conjuncts;
+
+    std::vector<std::string> partitionKeyValues;
+    folly::split("/", partitionName, partitionKeyValues);
+    VELOX_CHECK_EQ(partitionKeyValues.size(), partitionTypes.size());
+
+    for (auto i = 0; i < partitionKeyValues.size(); i++) {
+      if (partitionTypes[i]->isVarchar() || partitionTypes[i]->isVarbinary() ||
+          partitionTypes[i]->isDate()) {
+        conjuncts.push_back(
+            partitionKeyValues[i]
+                .replace(partitionKeyValues[i].find("="), 1, "='")
+                .append("'"));
+      } else {
+        conjuncts.push_back(partitionKeyValues[i]);
+      }
+    }
+
+    return folly::join(" AND ", conjuncts);
   }
 
   RowTypePtr rowType_{
@@ -51,7 +153,7 @@ class TableWriteTest : public HiveConnectorTestBase {
           {BIGINT(), INTEGER(), SMALLINT(), REAL(), DOUBLE(), VARCHAR()})};
 };
 
-// Runs a pipeline with read + filter + project (with substr) + write
+// Runs a pipeline with read + filter + project (with substr) + write.
 TEST_F(TableWriteTest, scanFilterProjectWrite) {
   auto filePaths = makeFilePaths(10);
   auto vectors = makeVectors(rowType_, filePaths.size(), 1000);
@@ -68,16 +170,17 @@ TEST_F(TableWriteTest, scanFilterProjectWrite) {
                      .project({"c0", "c1", "c1 + c2", "substr(c5, 1, 1)"})
                      .planNode();
 
-  std::vector<std::string> columnNames = {
+  auto types = project->outputType()->children();
+  std::vector<std::string> tableColumnNames = {
       "c0", "c1", "c1_plus_c2", "substr_c5"};
   auto plan = planBuilder
                   .tableWrite(
-                      columnNames,
+                      tableColumnNames,
                       std::make_shared<core::InsertTableHandle>(
                           kHiveConnectorId,
                           makeHiveInsertTableHandle(
-                              columnNames,
-                              rowType_->children(),
+                              tableColumnNames,
+                              types,
                               {},
                               makeLocationHandle(outputDirectory->path))),
                       CommitStrategy::kNoCommit,
@@ -89,12 +192,12 @@ TEST_F(TableWriteTest, scanFilterProjectWrite) {
 
   // To test the correctness of the generated output,
   // We create a new plan that only read that file and then
-  // compare that against a duckDB query that runs the whole query
+  // compare that against a duckDB query that runs the whole query.
 
-  auto types = project->outputType()->children();
-  auto rowType = ROW(std::move(columnNames), std::move(types));
   assertQuery(
-      PlanBuilder().tableScan(rowType).planNode(),
+      PlanBuilder()
+          .tableScan(ROW(std::move(tableColumnNames), std::move(types)))
+          .planNode(),
       makeHiveConnectorSplits(outputDirectory),
       "SELECT c0, c1, c1 + c2, substr(c5, 1, 1) FROM tmp WHERE c0 <> 0");
 }
@@ -111,17 +214,18 @@ TEST_F(TableWriteTest, renameAndReorderColumns) {
   createDuckDbTable(vectors);
 
   auto outputDirectory = TempDirectoryPath::create();
-  auto tableRowType = ROW({"d", "c", "b"}, {VARCHAR(), DOUBLE(), INTEGER()});
+  auto inputRowType = ROW({"d", "c", "b"}, {VARCHAR(), DOUBLE(), INTEGER()});
+  std::vector<std::string> tableColumnNames = {"x", "y", "z"};
   auto plan = PlanBuilder()
                   .tableScan(rowType)
                   .tableWrite(
-                      tableRowType,
-                      {"x", "y", "z"},
+                      inputRowType,
+                      tableColumnNames,
                       std::make_shared<core::InsertTableHandle>(
                           kHiveConnectorId,
                           makeHiveInsertTableHandle(
-                              {"x", "y", "z"},
-                              tableRowType->children(),
+                              tableColumnNames,
+                              inputRowType->children(),
                               {},
                               makeLocationHandle(outputDirectory->path))),
                       CommitStrategy::kNoCommit,
@@ -133,13 +237,14 @@ TEST_F(TableWriteTest, renameAndReorderColumns) {
 
   assertQuery(
       PlanBuilder()
-          .tableScan(ROW({"x", "y", "z"}, {VARCHAR(), DOUBLE(), INTEGER()}))
+          .tableScan(ROW(
+              std::move(tableColumnNames), {{VARCHAR(), DOUBLE(), INTEGER()}}))
           .planNode(),
       makeHiveConnectorSplits(outputDirectory),
       "SELECT d, c, b FROM tmp");
 }
 
-// Runs a pipeline with read + write
+// Runs a pipeline with read + write.
 TEST_F(TableWriteTest, directReadWrite) {
   auto filePaths = makeFilePaths(10);
   auto vectors = makeVectors(rowType_, filePaths.size(), 1000);
@@ -170,7 +275,7 @@ TEST_F(TableWriteTest, directReadWrite) {
 
   // To test the correctness of the generated output,
   // We create a new plan that only read that file and then
-  // compare that against a duckDB query that runs the whole query
+  // compare that against a duckDB query that runs the whole query.
 
   assertQuery(
       PlanBuilder().tableScan(rowType_).planNode(),
@@ -178,7 +283,7 @@ TEST_F(TableWriteTest, directReadWrite) {
       "SELECT * FROM tmp");
 }
 
-// Tests writing constant vectors
+// Tests writing constant vectors.
 TEST_F(TableWriteTest, constantVectors) {
   vector_size_t size = 1'000;
 
@@ -211,8 +316,8 @@ TEST_F(TableWriteTest, constantVectors) {
                     std::make_shared<core::InsertTableHandle>(
                         kHiveConnectorId,
                         makeHiveInsertTableHandle(
-                            rowType_->names(),
-                            rowType_->children(),
+                            rowType->names(),
+                            rowType->children(),
                             {},
                             makeLocationHandle(outputDirectory->path))),
                     CommitStrategy::kNoCommit,
@@ -228,40 +333,251 @@ TEST_F(TableWriteTest, constantVectors) {
       "SELECT * FROM tmp");
 }
 
-TEST_F(TableWriteTest, TestASecondCommitStrategy) {
+TEST_F(TableWriteTest, commitStrategies) {
   auto filePaths = makeFilePaths(10);
   auto vectors = makeVectors(rowType_, filePaths.size(), 1000);
-  for (int i = 0; i < filePaths.size(); i++) {
-    writeToFile(filePaths[i]->path, vectors[i]);
-  }
 
   createDuckDbTable(vectors);
 
+  // Test the kTaskCommit commit strategy writing to one dot-prefixed temporary
+  // file.
+  {
+    auto outputDirectory = TempDirectoryPath::create();
+    auto plan = PlanBuilder()
+                    .values(vectors)
+                    .tableWrite(
+                        rowType_->names(),
+                        std::make_shared<core::InsertTableHandle>(
+                            kHiveConnectorId,
+                            makeHiveInsertTableHandle(
+                                rowType_->names(),
+                                rowType_->children(),
+                                {},
+                                makeLocationHandle(outputDirectory->path))),
+                        CommitStrategy::kTaskCommit,
+                        "rows")
+                    .project({"rows"})
+                    .planNode();
+
+    assertQuery(plan, "SELECT count(*) FROM tmp");
+
+    auto outputFiles = getRecursiveFiles(outputDirectory->path);
+    EXPECT_EQ(outputFiles.size(), 1);
+    EXPECT_EQ(fs::path(outputFiles[0]).filename().string()[0], '.');
+    assertQuery(
+        PlanBuilder().tableScan(rowType_).planNode(),
+        makeHiveConnectorSplits(outputDirectory),
+        "SELECT * FROM tmp");
+  }
+  // Test kNoCommit commit strategy writing to non-temporary files.
+  {
+    auto outputDirectory = TempDirectoryPath::create();
+    auto plan = PlanBuilder()
+                    .values(vectors)
+                    .tableWrite(
+                        rowType_->names(),
+                        std::make_shared<core::InsertTableHandle>(
+                            kHiveConnectorId,
+                            makeHiveInsertTableHandle(
+                                rowType_->names(),
+                                rowType_->children(),
+                                {},
+                                makeLocationHandle(outputDirectory->path))),
+                        CommitStrategy::kNoCommit,
+                        "rows")
+                    .project({"rows"})
+                    .planNode();
+
+    assertQuery(plan, "SELECT count(*) FROM tmp");
+
+    auto outputFiles = getRecursiveFiles(outputDirectory->path);
+    EXPECT_EQ(outputFiles.size(), 1);
+    EXPECT_NE(fs::path(outputFiles[0]).filename().string()[0], '.');
+    assertQuery(
+        PlanBuilder().tableScan(rowType_).planNode(),
+        makeHiveConnectorSplits(outputDirectory),
+        "SELECT * FROM tmp");
+  }
+}
+
+TEST_F(TableWriteTest, multiplePartitions) {
+  int32_t numPartitions = 50;
+  int32_t numBatches = 2;
+
+  auto rowType = ROW(
+      {"c0", "p0", "p1", "c1"}, {INTEGER(), INTEGER(), VARCHAR(), BIGINT()});
+  std::vector<column_index_t> partitionChannels = {1, 2};
+  std::vector<std::string> partitionKeys = {"p0", "p1"};
+  std::vector<TypePtr> partitionTypes = {INTEGER(), VARCHAR()};
+
+  std::vector<RowVectorPtr> vectors = makeBatches(numBatches, [&](auto) {
+    return makeRowVector(
+        rowType->names(),
+        {makeFlatVector<int32_t>(
+             numPartitions, [&](auto row) { return row + 100; }),
+         makeFlatVector<int32_t>(numPartitions, [&](auto row) { return row; }),
+         makeFlatVector<StringView>(
+             numPartitions,
+             [&](auto row) { return StringView(fmt::format("str_{}", row)); }),
+         makeFlatVector<int64_t>(
+             numPartitions, [&](auto row) { return row + 1000; })});
+  });
+  createDuckDbTable(vectors);
+
+  auto inputFilePaths = makeFilePaths(numBatches);
+  for (int i = 0; i < numBatches; i++) {
+    writeToFile(inputFilePaths[i]->path, vectors[i]);
+  }
+
   auto outputDirectory = TempDirectoryPath::create();
   auto plan = PlanBuilder()
-                  .tableScan(rowType_)
+                  .tableScan(rowType)
                   .tableWrite(
-                      rowType_->names(),
+                      rowType->names(),
                       std::make_shared<core::InsertTableHandle>(
                           kHiveConnectorId,
                           makeHiveInsertTableHandle(
-                              rowType_->names(),
-                              rowType_->children(),
-                              {},
+                              rowType->names(),
+                              rowType->children(),
+                              partitionKeys,
                               makeLocationHandle(outputDirectory->path))),
-                      CommitStrategy::kTaskCommit,
+                      CommitStrategy::kNoCommit,
                       "rows")
                   .project({"rows"})
                   .planNode();
 
-  assertQuery(plan, filePaths, "SELECT count(*) FROM tmp");
+  auto task = assertQuery(plan, inputFilePaths, "SELECT count(*) FROM tmp");
 
-  // HiveTaskCommitWriteProtocol writes to dot-prefixed file in the
-  // outputDirectory which is still picked up by table scan.
+  // Verify that there is one partition directory for each partition.
+  std::set<std::string> actualPartitionDirectories =
+      getLeafSubdirectories(outputDirectory->path);
+
+  std::set<std::string> expectedPartitionDirectories;
+  std::set<std::string> partitionNames;
+  for (auto i = 0; i < numPartitions; i++) {
+    auto partitionName = fmt::format("p0={}/p1=str_{}", i, i);
+    partitionNames.emplace(partitionName);
+    expectedPartitionDirectories.emplace(
+        fs::path(outputDirectory->path) / partitionName);
+  }
+  EXPECT_EQ(actualPartitionDirectories, expectedPartitionDirectories);
+
+  // Verify distribution of records in partition directories.
+  auto iterPartitionDirectory = actualPartitionDirectories.begin();
+  auto iterPartitionName = partitionNames.begin();
+  while (iterPartitionDirectory != actualPartitionDirectories.end()) {
+    assertQuery(
+        PlanBuilder().tableScan(rowType).planNode(),
+        makeHiveConnectorSplits(*iterPartitionDirectory),
+        fmt::format(
+            "SELECT * FROM tmp WHERE {}",
+            partitionNameToPredicate(*iterPartitionName, partitionTypes)));
+    // One single file is written to each partition directory for Hive
+    // connector.
+    EXPECT_EQ(countRecursiveFiles(*iterPartitionDirectory), 1);
+
+    ++iterPartitionDirectory;
+    ++iterPartitionName;
+  }
+}
+
+TEST_F(TableWriteTest, singlePartition) {
+  int32_t numBatches = 2;
+
+  auto rowType = ROW({"c0", "p0"}, {VARCHAR(), BIGINT()});
+  std::vector<std::string> partitionKeys = {"p0"};
+
+  // Partition vector is constant vector.
+  std::vector<RowVectorPtr> vectors = makeBatches(numBatches, [&](auto) {
+    return makeRowVector(
+        rowType->names(),
+        {makeFlatVector<StringView>(
+             1'000,
+             [&](auto row) { return StringView(fmt::format("str_{}", row)); }),
+         createConstant((int64_t)365, 1'000)});
+  });
+  createDuckDbTable(vectors);
+
+  auto inputFilePaths = makeFilePaths(numBatches);
+  for (int i = 0; i < numBatches; i++) {
+    writeToFile(inputFilePaths[i]->path, vectors[i]);
+  }
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .tableScan(rowType)
+                  .tableWrite(
+                      rowType->names(),
+                      std::make_shared<core::InsertTableHandle>(
+                          kHiveConnectorId,
+                          makeHiveInsertTableHandle(
+                              rowType->names(),
+                              rowType->children(),
+                              partitionKeys,
+                              makeLocationHandle(outputDirectory->path))),
+                      CommitStrategy::kNoCommit,
+                      "rows")
+                  .project({"rows"})
+                  .planNode();
+
+  auto task = assertQuery(plan, inputFilePaths, "SELECT count(*) FROM tmp");
+
+  std::set<std::string> partitionDirectories =
+      getLeafSubdirectories(outputDirectory->path);
+
+  // Verify only a single partition directory is created.
+  EXPECT_EQ(partitionDirectories.size(), 1);
+  EXPECT_EQ(
+      *partitionDirectories.begin(),
+      fs::path(outputDirectory->path) / "p0=365");
+
+  // Verify all data is written to the single partition directory.
   assertQuery(
-      PlanBuilder().tableScan(rowType_).planNode(),
+      PlanBuilder().tableScan(rowType).planNode(),
       makeHiveConnectorSplits(outputDirectory),
       "SELECT * FROM tmp");
+
+  // Verify that one single file is written to the single partition directory
+  // for Hive connector.
+  EXPECT_EQ(countRecursiveFiles(*partitionDirectories.begin()), 1);
+}
+
+TEST_F(TableWriteTest, maxPartitions) {
+  int32_t maxPartitions = 1'000;
+  int32_t numPartitions = maxPartitions + 1;
+
+  auto rowType = ROW({"p0"}, {BIGINT()});
+  std::vector<std::string> partitionKeys = {"p0"};
+
+  auto vector = makeRowVector(
+      rowType->names(),
+      {makeFlatVector<int64_t>(numPartitions, [&](auto row) { return row; })});
+
+  auto outputDirectory = TempDirectoryPath::create();
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .tableWrite(
+                      rowType->names(),
+                      std::make_shared<core::InsertTableHandle>(
+                          kHiveConnectorId,
+                          makeHiveInsertTableHandle(
+                              rowType->names(),
+                              rowType->children(),
+                              partitionKeys,
+                              makeLocationHandle(outputDirectory->path))),
+                      CommitStrategy::kNoCommit,
+                      "rows")
+                  .project({"rows"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan)
+          .connectorConfig(
+              kHiveConnectorId,
+              HiveConfig::kMaxPartitionsPerWriters,
+              folly::to<std::string>(maxPartitions))
+          .copyResults(pool()),
+      fmt::format("Exceeded limit of {} distinct partitions.", maxPartitions));
 }
 
 // Test TableWriter does not create a file if input is empty.

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -39,6 +39,13 @@ class AssertQueryBuilder {
   /// properties.
   AssertQueryBuilder& config(const std::string& key, const std::string& value);
 
+  /// Set connector-specific configuration property. May be called multiple
+  /// times to set multiple properties for one or multiple connectors.
+  AssertQueryBuilder& connectorConfig(
+      const std::string& connectorId,
+      const std::string& key,
+      const std::string& value);
+
   // Methods to add splits.
 
   /// Add a single split for the specified plan node.
@@ -121,6 +128,8 @@ class AssertQueryBuilder {
   DuckDbQueryRunner* FOLLY_NULLABLE const duckDbQueryRunner_;
   CursorParameters params_;
   std::unordered_map<std::string, std::string> configs_;
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      connectorConfigs_;
   std::unordered_map<core::PlanNodeId, std::vector<Split>> splits_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -266,13 +266,13 @@ PlanBuilder& PlanBuilder::filter(const std::string& filter) {
 }
 
 PlanBuilder& PlanBuilder::tableWrite(
-    const std::vector<std::string>& columnNames,
+    const std::vector<std::string>& tableColumnNames,
     const std::shared_ptr<core::InsertTableHandle>& insertHandle,
     CommitStrategy commitStrategy,
     const std::string& rowCountColumnName) {
   return tableWrite(
       planNode_->outputType(),
-      columnNames,
+      tableColumnNames,
       insertHandle,
       commitStrategy,
       rowCountColumnName);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -238,15 +238,15 @@ class PlanBuilder {
           connector::CommitStrategy::kNoCommit,
       const std::string& rowCountColumnName = "rowCount");
 
-  /// Add a TableWriteNode assuming that input columns names match column names
-  /// in the target table.
+  /// Add a TableWriteNode assuming that input columns match the source node
+  /// columns in order.
   ///
-  /// @param columnNames A subset of input columns to write.
+  /// @param tableColumnNames Column names in the target table.
   /// @param insertHandle Connector-specific table handle.
   /// @param rowCountColumnName The name of the output column containing the
   /// number of rows written.
   PlanBuilder& tableWrite(
-      const std::vector<std::string>& columnNames,
+      const std::vector<std::string>& tableColumnNames,
       const std::shared_ptr<core::InsertTableHandle>& insertHandle,
       connector::CommitStrategy commitStrategy =
           connector::CommitStrategy::kNoCommit,


### PR DESCRIPTION
When the table is partitioned, create multiple dwrf writers
by HiveDataSink, one for each distinct partition value.
Call PartitionIdGenerator to generate consecutive IDs
for distinct partition values, which are used for the index
of the dwrf writer vector. Each input could see new partition
values, so dwrf writers are created incrementally.

To assemble the input for different dwrf writers, we compute
the index into the original input for every partition value
and wrap the original input into a DictionaryVector.
The DictionaryVector is sent to the corresponding dwrf writer
as writer input. In the frequent case of the input belonging
to the same partition, no input wrap happens and we directly
send the input vector to the dwrf writer.