### PR TITLE
Use ReadFile in InputStreamFactory::create

### DIFF
--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(
   RawVector.cpp
   RuntimeMetrics.cpp
   SimdUtil.cpp
+  StatsReporter.cpp
   SuccinctPrinter.cpp)
 
 target_link_libraries(velox_common_base velox_exception velox_process xsimd)

--- a/velox/common/base/StatsReporter.cpp
+++ b/velox/common/base/StatsReporter.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/StatsReporter.h"
+
+namespace facebook::velox {
+
+bool BaseStatsReporter::registered = false;
+
+}

--- a/velox/common/base/StatsReporter.h
+++ b/velox/common/base/StatsReporter.h
@@ -70,6 +70,8 @@ class BaseStatsReporter {
   virtual void addStatValue(const char* key, size_t value = 1) const = 0;
 
   virtual void addStatValue(folly::StringPiece key, size_t value = 1) const = 0;
+
+  static bool registered;
 };
 
 // This is a dummy reporter that does nothing
@@ -90,22 +92,26 @@ class DummyStatsReporter : public BaseStatsReporter {
       const override {}
 };
 
-#define REPORT_ADD_STAT_VALUE(k, ...)                                         \
-  {                                                                           \
-    auto reporter =                                                           \
-        folly::Singleton<facebook::velox::BaseStatsReporter>::try_get_fast(); \
-    if (LIKELY(reporter != nullptr)) {                                        \
-      reporter->addStatValue((k), ##__VA_ARGS__);                             \
-    }                                                                         \
+#define REPORT_ADD_STAT_VALUE(k, ...)                          \
+  {                                                            \
+    if (::facebook::velox::BaseStatsReporter::registered) {    \
+      auto reporter = folly::Singleton<                        \
+          facebook::velox::BaseStatsReporter>::try_get_fast(); \
+      if (LIKELY(reporter != nullptr)) {                       \
+        reporter->addStatValue((k), ##__VA_ARGS__);            \
+      }                                                        \
+    }                                                          \
   }
 
-#define REPORT_ADD_STAT_EXPORT_TYPE(k, t)                                     \
-  {                                                                           \
-    auto reporter =                                                           \
-        folly::Singleton<facebook::velox::BaseStatsReporter>::try_get_fast(); \
-    if (LIKELY(reporter != nullptr)) {                                        \
-      reporter->addStatExportType((k), (t));                                  \
-    }                                                                         \
+#define REPORT_ADD_STAT_EXPORT_TYPE(k, t)                      \
+  {                                                            \
+    if (::facebook::velox::BaseStatsReporter::registered) {    \
+      auto reporter = folly::Singleton<                        \
+          facebook::velox::BaseStatsReporter>::try_get_fast(); \
+      if (LIKELY(reporter != nullptr)) {                       \
+        reporter->addStatExportType((k), (t));                 \
+      }                                                        \
+    }                                                          \
   }
 
 } // namespace facebook::velox

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -92,5 +92,6 @@ folly::Singleton<BaseStatsReporter> reporter([]() {
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   folly::init(&argc, &argv, false);
+  facebook::velox::BaseStatsReporter::registered = true;
   return RUN_ALL_TESTS();
 }

--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -64,11 +64,8 @@ uint64_t InMemoryWriteFile::size() const {
   return file_->size();
 }
 
-LocalReadFile::LocalReadFile(std::string_view path) {
-  std::unique_ptr<char[]> buf(new char[path.size() + 1]);
-  buf[path.size()] = 0;
-  memcpy(buf.get(), path.data(), path.size());
-  fd_ = open(buf.get(), O_RDONLY);
+LocalReadFile::LocalReadFile(std::string_view path) : path_(path) {
+  fd_ = open(path_.c_str(), O_RDONLY);
   VELOX_CHECK_GE(
       fd_,
       0,

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -102,6 +102,14 @@ class ReadFile {
     bytesRead_ = 0;
   }
 
+  virtual std::string getName() const = 0;
+
+  //
+  // Get the natural size for reads.
+  // @return the number of bytes that should be read at once
+  //
+  virtual uint64_t getNaturalReadSize() const = 0;
+
  protected:
   mutable std::atomic<uint64_t> bytesRead_ = 0;
 };
@@ -166,6 +174,14 @@ class InMemoryReadFile final : public ReadFile {
     return shouldCoalesce_;
   }
 
+  std::string getName() const override {
+    return "<InMemoryReadFile>";
+  }
+
+  uint64_t getNaturalReadSize() const override {
+    return 1024;
+  }
+
  private:
   const std::string ownedFile_;
   const std::string_view file_;
@@ -214,10 +230,22 @@ class LocalReadFile final : public ReadFile {
     return false;
   }
 
+  std::string getName() const override {
+    if (path_.empty()) {
+      return "<LocalReadFile>";
+    }
+    return path_;
+  }
+
+  uint64_t getNaturalReadSize() const override {
+    return 10 << 20;
+  }
+
  private:
   void preadInternal(uint64_t offset, uint64_t length, char* FOLLY_NONNULL pos)
       const;
 
+  std::string path_;
   int32_t fd_;
   long size_;
 };

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
@@ -34,6 +34,14 @@ class HdfsReadFile final : public ReadFile {
 
   bool shouldCoalesce() const final;
 
+  std::string getName() const final {
+    return filePath_;
+  }
+
+  uint64_t getNaturalReadSize() const final {
+    return 72 << 20;
+  }
+
  private:
   void preadInternal(uint64_t offset, uint64_t length, char* pos) const;
   void seekToPosition(hdfsFile file, uint64_t offset) const;

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -138,6 +138,14 @@ class S3ReadFile final : public ReadFile {
     return false;
   }
 
+  std::string getName() const final {
+    return fmt::format("s3://{}/{}", bucket_, key_);
+  }
+
+  uint64_t getNaturalReadSize() const final {
+    return 72 << 20;
+  }
+
  private:
   // The assumption here is that "position" has space for at least "length"
   // bytes.

--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -137,19 +137,18 @@ void FileInputStream::read(
   }
 }
 
-static constexpr char kReadFilePath[] = "ReadFileFakePath";
-
 ReadFileInputStream::ReadFileInputStream(
     velox::ReadFile* readFile,
     const MetricsLogPtr& metricsLog,
     IoStatistics* stats)
-    : InputStream(kReadFilePath, metricsLog, stats), readFile_(readFile) {}
+    : InputStream(readFile->getName(), metricsLog, stats),
+      readFile_(readFile) {}
 
 ReadFileInputStream::ReadFileInputStream(
     std::shared_ptr<velox::ReadFile> readFile,
     const MetricsLogPtr& metricsLog,
     IoStatistics* stats)
-    : InputStream(kReadFilePath, metricsLog, stats),
+    : InputStream(readFile->getName(), metricsLog, stats),
       readFile_(readFile.get()),
       readFileOwned_(std::move(readFile)) {}
 

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -204,8 +204,7 @@ class ReadFileInputStream final : public InputStream {
   }
 
   uint64_t getNaturalReadSize() const final {
-    // TODO: configure this accurately if it actually has impact.
-    return 10ULL << 20;
+    return readFile_->getNaturalReadSize();
   }
 
   void read(void* FOLLY_NONNULL, uint64_t, uint64_t, LogType) override;


### PR DESCRIPTION
Summary:
In subsequent changes, `BufferedInput` will only takes `ReadFile` or `ReadFileInputStream`.

As we now use `WSReadFile` in `InputStreamFactory`, all downstream libraries will crash if they do not register an implementation of `BaseStatsReporter`.  The implementation is registered as a `folly::Singleton` and there is currently no way to provide a fallback implementation.  To workaround this, we add a flag `BaseStatsReporter::registered`, and only report the stats from `WSReadFile` when this flag is set to true.  A grep in the codebase suggest only `presto_cpp` will need to set this flag.

Differential Revision: D41749995

