### PR TITLE
Nightly workflow to build presto native 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ workflows:
       - linux-aggregate-fuzzer-run
       - docker-compose-ubuntu-cpp
       - docker-compose-centos-cpp
+      - docker-compose-presto-native
 
   # Hourly build on weekdays
   weekday:
@@ -631,3 +632,28 @@ jobs:
       - run:
           name: "Run centos-cpp image"
           command: docker-compose run -e NUM_THREADS=16 --rm centos-cpp
+
+  docker-compose-presto-native:
+    machine: # Use machine executor type to use docker-compose
+      image: ubuntu-2204:2022.10.1
+    resource_class: 2xlarge
+    environment:
+      PRESTODB_REPOSITORY: https://github.com/prestodb/presto
+    steps:
+      - run:
+          name: "Checkout prestodb"
+          command: git clone git@github.com:prestodb/presto.git
+      - run:
+          name: "Update presto-native to latest Velox"
+          command: |
+            cd presto
+            git submodule update --init --recursive
+            cd presto-native-execution
+            git submodule update --remote --merge
+      - run:
+          name: "Build presto-native container"
+          command: |
+            git config --global user.email "velox@users.noreply.github.com"
+            git config --global user.name "velox"
+            cd presto/presto-native-execution
+            make runtime-container


### PR DESCRIPTION
This sets up a nightly job to build presto-native against mainline velox . We do this with the the help of the presto native docker job  (thanks to @Mionsz : https://github.com/prestodb/presto/pull/18572/files) so that it exercises velox build & setup processes. This allows us to validate that changes to velox build scripts/dependencies do not break presto-native. 

cc: @spershin @majetideepak 

Heres a succesful run : https://app.circleci.com/pipelines/github/facebookincubator/velox/17536/workflows/f96739f4-7c09-4bb5-bd92-0ad7950e17d2/jobs/110078. 