### PR TITLE
Convert std::exception thrown in vector functions to VeloxException

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -313,7 +313,14 @@ void Expr::evalSimplifiedImpl(
   }
 
   // Apply the actual function.
-  vectorFunction_->apply(remainingRows, inputValues_, type(), context, result);
+  try {
+    vectorFunction_->apply(
+        remainingRows, inputValues_, type(), context, result);
+  } catch (const VeloxException& ve) {
+    throw;
+  } catch (const std::exception& e) {
+    VELOX_USER_FAIL(e.what());
+  }
 
   // Make sure the returned vector has its null bitmap properly set.
   addNulls(rows, remainingRows.asRange().bits(), context, result);
@@ -1438,7 +1445,13 @@ void Expr::applyFunction(
       ? computeIsAsciiForResult(vectorFunction_.get(), inputValues_, rows)
       : std::nullopt;
 
-  vectorFunction_->apply(rows, inputValues_, type(), context, result);
+  try {
+    vectorFunction_->apply(rows, inputValues_, type(), context, result);
+  } catch (const VeloxException& ve) {
+    throw;
+  } catch (const std::exception& e) {
+    VELOX_USER_FAIL(e.what());
+  }
 
   if (!result) {
     LocalSelectivityVector mutableRemainingRowsHolder(context);


### PR DESCRIPTION
Summary:
VeloxException provides more information than std::exception, while there are
some vector functions still throwing std::exception. This diff makes expression
evaluator catch std exceptions from UDFs and convert them into VeloxExceptions.

Reviewed By: xiaoxmeng

Differential Revision: D41758131

