### PR TITLE
Fix some typos in the blog Simple Functions: Introduction and Basic Optimizations

### DIFF
--- a/website/blog/2022-10-31-simple-1.mdx
+++ b/website/blog/2022-10-31-simple-1.mdx
@@ -106,4 +106,4 @@ Users can pre-process constant inputs of functions to avoid repeated computation
 
 
 
-For more information about how to writer simple functions check the documentation<a href="https://facebookincubator.github.io/velox/develop/scalar-functions.html">documentation</a> and the <a href="https://github.com/facebookincubator/velox/blob/main/velox/examples/SimpleFunctions.cpp">examples</a>.
+For more information about how to write simple functions check the <a href="https://facebookincubator.github.io/velox/develop/scalar-functions.html">documentation</a> and the <a href="https://github.com/facebookincubator/velox/blob/main/velox/examples/SimpleFunctions.cpp">examples</a>.


### PR DESCRIPTION
Fix the typo **writer** and remove the redundant word **documentation** in the last line of the blog [Simple Functions: Introduction and Basic Optimizations](https://velox-lib.io/blog/simple-functions-1/#:~:text=documentationdocumentation)

For more information about how to **writer** simple functions check the documentation[documentation](https://facebookincubator.github.io/velox/develop/scalar-functions.html)   
--> 
For more information about how to **write** simple functions check the [documentation](https://facebookincubator.github.io/velox/develop/scalar-functions.html) 