### PR TITLE
Add memory alignment support through options

### DIFF
--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -28,6 +28,16 @@
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::memory {
+/*static*/
+void MemoryAllocator::validateAlignment(uint16_t alignment) {
+  if (alignment == 0) {
+    return;
+  }
+  VELOX_CHECK_LE(MemoryAllocator::kMinAlignment, alignment);
+  VELOX_CHECK_GE(MemoryAllocator::kMaxAlignment, alignment);
+  VELOX_CHECK_EQ(alignment & (alignment - 1), 0);
+}
+
 MemoryAllocator::Allocation::~Allocation() {
   if (pool_ != nullptr) {
     pool_->freeNonContiguous(*this);

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -185,6 +185,8 @@ class MemoryAllocator : std::enable_shared_from_this<MemoryAllocator> {
   static constexpr uint16_t kMinAlignment = 8;
   static constexpr uint16_t kMaxAlignment = 64;
 
+  static void validateAlignment(uint16_t alignment);
+
   /// Represents a number of consecutive pages of kPageSize bytes.
   class PageRun {
    public:

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -27,12 +27,13 @@ class ByteStreamTest : public testing::TestWithParam<bool> {
  protected:
   void SetUp() override {
     constexpr uint64_t kMaxMappedMemory = 64 << 20;
-    MmapAllocatorOptions options;
-    options.capacity = kMaxMappedMemory;
-    mmapAllocator_ = std::make_shared<MmapAllocator>(options);
+    MmapAllocatorOptions allocatorOptions;
+    allocatorOptions.capacity = kMaxMappedMemory;
+    mmapAllocator_ = std::make_shared<MmapAllocator>(allocatorOptions);
     MemoryAllocator::setDefaultInstance(mmapAllocator_.get());
-    memoryManager_ = std::make_unique<MemoryManager>(
-        kMaxMemory, MemoryAllocator::getInstance());
+    IMemoryManager::Options mgrOptions;
+    mgrOptions.capacity = kMaxMemory;
+    memoryManager_ = std::make_unique<MemoryManager>(mgrOptions);
     pool_ = memoryManager_->getChild();
   }
 

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -187,7 +187,10 @@ class MemoryAllocatorTest : public testing::TestWithParam<TestParam> {
       MemoryAllocator::setDefaultInstance(mockAllocator_.get());
     }
     instance_ = MemoryAllocator::getInstance();
-    memoryManager_ = std::make_unique<MemoryManager>(kMaxMemory, instance_);
+    IMemoryManager::Options options;
+    options.capacity = kMaxMemory;
+    options.allocator = instance_;
+    memoryManager_ = std::make_unique<MemoryManager>(options);
     pool_ = memoryManager_->getChild();
   }
 

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -33,20 +33,22 @@ TEST(MemoryManagerTest, Ctor) {
     ASSERT_EQ(std::numeric_limits<int64_t>::max(), root.cap());
     ASSERT_EQ(0, root.getChildCount());
     ASSERT_EQ(0, root.getCurrentBytes());
-    ASSERT_EQ(std::numeric_limits<int64_t>::max(), manager.getMemoryQuota());
+    ASSERT_EQ(std::numeric_limits<int64_t>::max(), manager.capacity());
     ASSERT_EQ(0, manager.getTotalBytes());
   }
   {
-    MemoryManager manager{8L * 1024 * 1024};
+    IMemoryManager::Options options;
+    options.capacity = 8UL * 1024 * 1024;
+    MemoryManager manager{options};
     const auto& root = manager.getRoot();
 
     ASSERT_EQ(8L * 1024 * 1024, root.cap());
     ASSERT_EQ(0, root.getChildCount());
     ASSERT_EQ(0, root.getCurrentBytes());
-    ASSERT_EQ(8L * 1024 * 1024, manager.getMemoryQuota());
+    ASSERT_EQ(8L * 1024 * 1024, manager.capacity());
     ASSERT_EQ(0, manager.getTotalBytes());
+    { ASSERT_ANY_THROW(MemoryManager manager{{.capacity = -1}}); }
   }
-  { ASSERT_ANY_THROW(MemoryManager manager{-1}); }
 }
 
 // TODO: when run sequentially, e.g. `buck run dwio/memory/...`, this has side
@@ -86,7 +88,9 @@ TEST(MemoryManagerTest, Reserve) {
     ASSERT_EQ(0, manager.getTotalBytes());
   }
   {
-    MemoryManager manager{42};
+    IMemoryManager::Options options;
+    options.capacity = 42;
+    MemoryManager manager{options};
     ASSERT_TRUE(manager.reserve(1));
     ASSERT_TRUE(manager.reserve(1));
     ASSERT_TRUE(manager.reserve(2));
@@ -108,10 +112,53 @@ TEST(MemoryManagerTest, Reserve) {
 
 TEST(MemoryManagerTest, GlobalMemoryManagerQuota) {
   auto& manager = MemoryManager::getInstance();
-  ASSERT_THROW(MemoryManager::getInstance(42, true), velox::VeloxUserError);
+  IMemoryManager::Options options;
+  options.capacity = 42;
+  ASSERT_THROW(
+      MemoryManager::getInstance(options, true), velox::VeloxUserError);
 
-  auto& coercedManager = MemoryManager::getInstance(42);
-  ASSERT_EQ(manager.getMemoryQuota(), coercedManager.getMemoryQuota());
+  auto& coercedManager = MemoryManager::getInstance(options);
+  ASSERT_EQ(manager.capacity(), coercedManager.capacity());
+}
+
+TEST(MemoryManagerTest, memoryAlignmentOptionCheck) {
+  struct {
+    uint16_t alignment;
+    bool expectedSuccess;
+
+    std::string debugString() const {
+      return fmt::format(
+          "alignment:{}, expectedSuccess:{}", alignment, expectedSuccess);
+    }
+  } testSettings[] = {
+      {0, true},
+      {MemoryAllocator::kMinAlignment - 1, false},
+      {MemoryAllocator::kMinAlignment, true},
+      {MemoryAllocator::kMinAlignment * 2, true},
+      {MemoryAllocator::kMinAlignment + 1, false},
+      {MemoryAllocator::kMaxAlignment - 1, false},
+      {MemoryAllocator::kMaxAlignment, true},
+      {MemoryAllocator::kMaxAlignment + 1, false},
+      {MemoryAllocator::kMaxAlignment * 2, false}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    IMemoryManager::Options options;
+    options.alignment = testData.alignment;
+    if (!testData.expectedSuccess) {
+      ASSERT_THROW(MemoryManager{options}, VeloxRuntimeError);
+      continue;
+    }
+    MemoryManager manager{options};
+    ASSERT_EQ(manager.alignment(), testData.alignment);
+    ASSERT_EQ(
+        manager.getRoot().alignment(),
+        testData.alignment == 0 ? MemoryAllocator::kMinAlignment
+                                : testData.alignment);
+    ASSERT_EQ(
+        manager.getChild()->alignment(),
+        testData.alignment == 0 ? MemoryAllocator::kMinAlignment
+                                : testData.alignment);
+  }
 }
 } // namespace memory
 } // namespace velox

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -38,7 +38,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
       const std::string& name,
       std::shared_ptr<MemoryPool> parent,
       int64_t cap = std::numeric_limits<int64_t>::max())
-      : MemoryPool{name, parent}, cap_{cap} {}
+      : MemoryPool{name, parent, 0}, cap_{cap} {}
 
   // Methods not usually exposed by MemoryPool interface to
   // allow for manipulation.
@@ -108,8 +108,8 @@ class MockMemoryPool : public velox::memory::MemoryPool {
 
   bool allocateContiguous(
       velox::memory::MachinePageCount /*unused*/,
-      velox::memory::MemoryAllocator::ContiguousAllocation& /*unused*/)
-      override {
+      velox::memory::MemoryAllocator::ContiguousAllocation&
+      /*unused*/) override {
     VELOX_UNSUPPORTED("allocateContiguous unsupported");
   }
 
@@ -158,7 +158,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
       setMemoryUsageTracker,
       void(const std::shared_ptr<velox::memory::MemoryUsageTracker>&));
 
-  MOCK_CONST_METHOD0(getAlignment, uint16_t());
+  MOCK_CONST_METHOD0(alignment, uint16_t());
 
  private:
   velox::memory::MemoryAllocator* const FOLLY_NONNULL allocator_{


### PR DESCRIPTION
Add options to IMemoryManager and MemoryPool to allow
user to specify the alignment and parameters might be used
by the memory arbitrator next.