### PR TITLE
fixing the empty map ingestion as flat map

### DIFF
--- a/velox/dwio/common/Range.h
+++ b/velox/dwio/common/Range.h
@@ -32,6 +32,9 @@ possible.
 class Ranges {
  public:
   void add(size_t begin, size_t end) {
+    if (begin == end) {
+      return;
+    }
     DWIO_ENSURE_LT(begin, end);
     size_ += (end - begin);
     if (ranges_.size()) {

--- a/velox/dwio/common/tests/RangeTests.cpp
+++ b/velox/dwio/common/tests/RangeTests.cpp
@@ -26,7 +26,7 @@ namespace facebook::velox::common {
 TEST(RangeTests, Add) {
   Ranges ranges;
   ASSERT_THROW(ranges.add(2, 1), exception::LoggedException);
-  ASSERT_THROW(ranges.add(2, 2), exception::LoggedException);
+  ranges.add(2, 2);
   ranges.add(1, 3);
   ASSERT_THAT(ranges.ranges_, ElementsAre(std::tuple<size_t, size_t>{1, 3}));
   ASSERT_EQ(ranges.size(), 2);


### PR DESCRIPTION
Summary: Fix the the issue while writting a flat map file with empty maps.

Reviewed By: HuamengJiang

Differential Revision: D41324957

