### PR TITLE
non-mapped memory allocator use malloc for allocateBytes

### DIFF
--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -66,6 +66,16 @@ class MmapAllocator : public MemoryAllocator {
 
   explicit MmapAllocator(const MmapAllocatorOptions& options);
 
+  void* FOLLY_NULLABLE allocateBytes(
+      uint64_t bytes,
+      uint16_t alignment,
+      uint64_t maxMallocSize) override;
+
+  void freeBytes(
+      void* FOLLY_NONNULL p,
+      uint64_t size,
+      uint64_t maxMallocSize = kMaxMallocBytes) noexcept override;
+
   bool allocateNonContiguous(
       MachinePageCount numPages,
       Allocation& out,


### PR DESCRIPTION
Meta internal use see perf regression when use sizeClass allocation for
allocateBytes API (when allocation size goes beyond 3KB as default
small allocation size threshold). There is no benefit doing so as sizeClass
in non-mapped memory allocator also use ::malloc. This regression is
due to the recent refactoring that remove the previous MemoryAllocator
object which is backed by malloc. This PR fixes this by allocating memory
from malloc for allocateBytes API no matter the size for non-mapped
memory allocator. Only the mapped memory allocator goes to sizeClass
memory allocator.