### PR TITLE
Refactor to use ReadFile and BufferedInput to replace InputStream

### DIFF
--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -51,16 +51,14 @@ class ReadFile {
   pread(uint64_t offset, uint64_t length, void* FOLLY_NONNULL buf) const = 0;
 
   // Same as above, but returns owned data directly.
-  virtual std::string pread(uint64_t offset, uint64_t length) const = 0;
+  virtual std::string pread(uint64_t offset, uint64_t length) const;
 
   // Reads starting at 'offset' into the memory referenced by the
   // Ranges in 'buffers'. The buffers are filled left to right. A
   // buffer with nullptr data will cause its size worth of bytes to be skipped.
   virtual uint64_t preadv(
       uint64_t /*offset*/,
-      const std::vector<folly::Range<char*>>& /*buffers*/) const {
-    VELOX_NYI("preadv not supported");
-  }
+      const std::vector<folly::Range<char*>>& /*buffers*/) const;
 
   // Like preadv but may execute asynchronously and returns the read
   // size or exception via SemiFuture. Use hasPreadvAsync() to check
@@ -142,21 +140,19 @@ class WriteFile {
 // We don't provide registration functions for the in-memory files, as they
 // aren't intended for any robust use needing a filesystem.
 
-class InMemoryReadFile final : public ReadFile {
+class InMemoryReadFile : public ReadFile {
  public:
   explicit InMemoryReadFile(std::string_view file) : file_(file) {}
 
   explicit InMemoryReadFile(std::string file)
       : ownedFile_(std::move(file)), file_(ownedFile_) {}
 
-  std::string_view
-  pread(uint64_t offset, uint64_t length, void* FOLLY_NONNULL buf) const final;
-
-  std::string pread(uint64_t offset, uint64_t length) const final;
-
-  uint64_t preadv(
+  std::string_view pread(
       uint64_t offset,
-      const std::vector<folly::Range<char*>>& buffers) const final;
+      uint64_t length,
+      void* FOLLY_NONNULL buf) const override;
+
+  std::string pread(uint64_t offset, uint64_t length) const override;
 
   uint64_t size() const final {
     return file_.size();
@@ -215,8 +211,6 @@ class LocalReadFile final : public ReadFile {
 
   std::string_view
   pread(uint64_t offset, uint64_t length, void* FOLLY_NONNULL buf) const final;
-
-  std::string pread(uint64_t offset, uint64_t length) const final;
 
   uint64_t size() const final;
 

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -170,7 +170,6 @@ class HiveDataSource : public DataSource {
   FileHandleFactory* FOLLY_NONNULL fileHandleFactory_;
   velox::memory::MemoryPool* FOLLY_NONNULL pool_;
   std::shared_ptr<dwio::common::IoStatistics> ioStats_;
-  std::shared_ptr<dwio::common::BufferedInputFactory> bufferedInputFactory_;
   std::shared_ptr<common::ScanSpec> scanSpec_;
   std::shared_ptr<HiveConnectorSplit> split_;
   dwio::common::ReaderOptions readerOpts_;

--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -50,12 +50,12 @@ void BufferedInput::load(const LogType logType) {
         });
 
     // Now we have all buffers and regions, load it in parallel
-    input_.vread(buffers, regions, logType);
+    input_->vread(buffers, regions, logType);
   } else {
     loadWithAction(
         logType,
         [this](void* buf, uint64_t length, uint64_t offset, LogType type) {
-          input_.read(buf, length, offset, type);
+          input_->read(buf, length, offset, type);
         });
   }
 
@@ -116,8 +116,8 @@ bool BufferedInput::tryMerge(Region& first, const Region& second) {
     // the second region is inside first one if extension is negative
     if (extension > 0) {
       first.length += extension;
-      if ((input_.getStats() != nullptr) && gap > 0) {
-        input_.getStats()->incRawOverreadBytes(gap);
+      if ((input_->getStats() != nullptr) && gap > 0) {
+        input_->getStats()->incRawOverreadBytes(gap);
       }
     }
 
@@ -170,13 +170,6 @@ std::tuple<const char*, uint64_t> BufferedInput::readInternal(
   }
 
   return std::make_tuple(nullptr, MAX_UINT64);
-}
-
-//  static
-std::shared_ptr<BufferedInputFactory>
-BufferedInputFactory::baseFactoryShared() {
-  static auto instance = std::make_shared<BufferedInputFactory>();
-  return instance;
 }
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -31,7 +31,7 @@ CacheInputStream::CacheInputStream(
     CachedBufferedInput* bufferedInput,
     IoStatistics* ioStats,
     const Region& region,
-    InputStream& input,
+    std::shared_ptr<ReadFileInputStream> input,
     uint64_t fileNum,
     std::shared_ptr<ScanTracker> tracker,
     TrackingId trackingId,
@@ -40,7 +40,7 @@ CacheInputStream::CacheInputStream(
     : bufferedInput_(bufferedInput),
       cache_(bufferedInput_->cache()),
       ioStats_(ioStats),
-      input_(input),
+      input_(std::move(input)),
       region_(region),
       fileNum_(fileNum),
       tracker_(std::move(tracker)),
@@ -202,7 +202,7 @@ void CacheInputStream::loadSync(Region region) {
       uint64_t usec = 0;
       {
         MicrosecondTimer timer(&usec);
-        input_.read(ranges, region.offset, LogType::FILE);
+        input_->read(ranges, region.offset, LogType::FILE);
       }
       ioStats_->read().increment(region.length);
       ioStats_->queryThreadIoLatency().increment(usec);

--- a/velox/dwio/common/CacheInputStream.h
+++ b/velox/dwio/common/CacheInputStream.h
@@ -33,7 +33,7 @@ class CacheInputStream : public SeekableInputStream {
       CachedBufferedInput* cache,
       IoStatistics* ioStats,
       const Region& region,
-      InputStream& input,
+      std::shared_ptr<ReadFileInputStream> input,
       uint64_t fileNum,
       std::shared_ptr<cache::ScanTracker> tracker,
       cache::TrackingId trackingId,
@@ -110,7 +110,7 @@ class CacheInputStream : public SeekableInputStream {
   CachedBufferedInput* const bufferedInput_;
   cache::AsyncDataCache* const cache_;
   IoStatistics* ioStats_;
-  InputStream& input_;
+  std::shared_ptr<ReadFileInputStream> input_;
   // The region of 'input' 'this' ranges over.
   const Region region_;
   const uint64_t fileNum_;

--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -138,19 +138,11 @@ void FileInputStream::read(
 }
 
 ReadFileInputStream::ReadFileInputStream(
-    velox::ReadFile* readFile,
-    const MetricsLogPtr& metricsLog,
-    IoStatistics* stats)
-    : InputStream(readFile->getName(), metricsLog, stats),
-      readFile_(readFile) {}
-
-ReadFileInputStream::ReadFileInputStream(
     std::shared_ptr<velox::ReadFile> readFile,
     const MetricsLogPtr& metricsLog,
     IoStatistics* stats)
     : InputStream(readFile->getName(), metricsLog, stats),
-      readFile_(readFile.get()),
-      readFileOwned_(std::move(readFile)) {}
+      readFile_(std::move(readFile)) {}
 
 void ReadFileInputStream::read(
     void* buf,

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -185,12 +185,6 @@ class FileInputStream : public InputStream {
 // An input stream that reads from an already opened ReadFile.
 class ReadFileInputStream final : public InputStream {
  public:
-  // Does not take ownership of |readFile|.
-  explicit ReadFileInputStream(
-      velox::ReadFile* FOLLY_NONNULL readFile,
-      const MetricsLogPtr& metricsLog = MetricsLog::voidLog(),
-      IoStatistics* FOLLY_NULLABLE stats = nullptr);
-
   // Take shared ownership of |readFile|.
   explicit ReadFileInputStream(
       std::shared_ptr<velox::ReadFile>,
@@ -222,12 +216,11 @@ class ReadFileInputStream final : public InputStream {
   bool hasReadAsync() const override;
 
   const std::shared_ptr<velox::ReadFile>& getReadFile() const {
-    return readFileOwned_;
+    return readFile_;
   }
 
  private:
-  velox::ReadFile* FOLLY_NONNULL readFile_;
-  std::shared_ptr<velox::ReadFile> readFileOwned_;
+  std::shared_ptr<velox::ReadFile> readFile_;
 };
 
 class ReferenceableInputStream : public InputStream {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -19,17 +19,13 @@
 #include <limits>
 #include <unordered_set>
 
+#include <folly/Executor.h>
 #include "velox/common/memory/Memory.h"
-#include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/ErrorTolerance.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/encryption/Encryption.h"
-
-namespace facebook::velox::dwio::common {
-class ColumnReaderFactory;
-} // namespace facebook::velox::dwio::common
 
 namespace facebook {
 namespace velox {
@@ -323,9 +319,7 @@ class ReaderOptions {
   int32_t loadQuantum_{kDefaultLoadQuantum};
   int32_t maxCoalesceDistance_{kDefaultCoalesceDistance};
   SerDeOptions serDeOptions;
-  uint64_t fileNum;
   std::shared_ptr<encryption::DecrypterFactory> decrypterFactory_;
-  std::shared_ptr<BufferedInputFactory> bufferedInputFactory_;
 
  public:
   static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
@@ -355,9 +349,7 @@ class ReaderOptions {
     autoPreloadLength = other.autoPreloadLength;
     prefetchMode = other.prefetchMode;
     serDeOptions = other.serDeOptions;
-    fileNum = other.fileNum;
     decrypterFactory_ = other.decrypterFactory_;
-    bufferedInputFactory_ = other.bufferedInputFactory_;
     return *this;
   }
 
@@ -379,11 +371,6 @@ class ReaderOptions {
    */
   ReaderOptions& setFileFormat(FileFormat format) {
     fileFormat = format;
-    return *this;
-  }
-
-  ReaderOptions& setFileNum(uint64_t num) {
-    fileNum = num;
     return *this;
   }
 
@@ -456,12 +443,6 @@ class ReaderOptions {
     return *this;
   }
 
-  ReaderOptions& setBufferedInputFactory(
-      std::shared_ptr<BufferedInputFactory> factory) {
-    bufferedInputFactory_ = factory;
-    return *this;
-  }
-
   /**
    * Get the desired tail location.
    * @return if not set, return the maximum long.
@@ -475,10 +456,6 @@ class ReaderOptions {
    */
   velox::memory::MemoryPool& getMemoryPool() const {
     return *memoryPool;
-  }
-
-  uint64_t getFileNum() const {
-    return fileNum;
   }
 
   /**
@@ -522,10 +499,6 @@ class ReaderOptions {
   const std::shared_ptr<encryption::DecrypterFactory> getDecrypterFactory()
       const {
     return decrypterFactory_;
-  }
-
-  std::shared_ptr<BufferedInputFactory> getBufferedInputFactory() const {
-    return bufferedInputFactory_;
   }
 };
 

--- a/velox/dwio/common/ReaderFactory.h
+++ b/velox/dwio/common/ReaderFactory.h
@@ -18,7 +18,7 @@
 
 #include <memory>
 
-#include "velox/dwio/common/InputStream.h"
+#include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Reader.h"
 
@@ -57,7 +57,7 @@ class ReaderFactory {
    * @return reader object
    */
   virtual std::unique_ptr<Reader> createReader(
-      std::unique_ptr<InputStream> stream,
+      std::unique_ptr<BufferedInput>,
       const ReaderOptions& options) = 0;
 
  private:

--- a/velox/dwio/common/SeekableInputStream.cpp
+++ b/velox/dwio/common/SeekableInputStream.cpp
@@ -185,14 +185,14 @@ static uint64_t computeBlock(uint64_t request, uint64_t length) {
 }
 
 SeekableFileInputStream::SeekableFileInputStream(
-    InputStream& stream,
+    std::shared_ptr<ReadFileInputStream> input,
     uint64_t offset,
     uint64_t byteCount,
     memory::MemoryPool& _pool,
     LogType logType,
     uint64_t _blockSize)
     : pool(_pool),
-      input(stream),
+      input(std::move(input)),
       logType(logType),
       start(offset),
       length(byteCount),
@@ -211,7 +211,7 @@ bool SeekableFileInputStream::Next(const void** data, int32_t* size) {
     bytesRead = std::min(length - position, blockSize);
     buffer.resize(bytesRead);
     if (bytesRead > 0) {
-      input.read(buffer.data(), bytesRead, start + position, logType);
+      input->read(buffer.data(), bytesRead, start + position, logType);
       *data = static_cast<void*>(buffer.data());
     }
   }
@@ -252,7 +252,7 @@ void SeekableFileInputStream::seekToPosition(PositionProvider& location) {
 
 std::string SeekableFileInputStream::getName() const {
   return folly::to<std::string>(
-      input.getName(), " from ", start, " for ", length);
+      input->getName(), " from ", start, " for ", length);
 }
 
 size_t SeekableFileInputStream::positionSize() {

--- a/velox/dwio/common/SeekableInputStream.h
+++ b/velox/dwio/common/SeekableInputStream.h
@@ -109,7 +109,7 @@ class SeekableArrayInputStream : public SeekableInputStream {
 class SeekableFileInputStream : public SeekableInputStream {
  private:
   memory::MemoryPool& pool;
-  InputStream& input;
+  std::shared_ptr<ReadFileInputStream> input;
   LogType logType;
   const uint64_t start;
   const uint64_t length;
@@ -120,7 +120,7 @@ class SeekableFileInputStream : public SeekableInputStream {
 
  public:
   SeekableFileInputStream(
-      InputStream& input,
+      std::shared_ptr<ReadFileInputStream> input,
       uint64_t offset,
       uint64_t byteCount,
       memory::MemoryPool& pool,

--- a/velox/dwio/common/tests/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/E2EFilterTestBase.cpp
@@ -32,7 +32,8 @@ using namespace facebook::velox::dwio::common;
 using namespace facebook::velox;
 using namespace facebook::velox::common;
 
-using dwio::common::MemoryInputStream;
+using dwio::common::BufferedInput;
+using dwio::common::InMemoryReadFile;
 using dwio::common::MemorySink;
 using velox::common::Subfield;
 
@@ -83,11 +84,11 @@ void E2EFilterTestBase::readWithoutFilter(
     std::shared_ptr<ScanSpec> spec,
     const std::vector<RowVectorPtr>& batches,
     uint64_t& time) {
-  auto input = std::make_unique<MemoryInputStream>(
-      sinkPtr_->getData(), sinkPtr_->size());
-
   dwio::common::ReaderOptions readerOpts;
   dwio::common::RowReaderOptions rowReaderOpts;
+  std::string_view data(sinkPtr_->getData(), sinkPtr_->size());
+  auto input = std::make_unique<BufferedInput>(
+      std::make_shared<InMemoryReadFile>(data), readerOpts.getMemoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
 
   // The spec must stay live over the lifetime of the reader.
@@ -134,11 +135,11 @@ void E2EFilterTestBase::readWithFilter(
     uint64_t& time,
     bool useValueHook,
     bool skipCheck) {
-  auto input = std::make_unique<MemoryInputStream>(
-      sinkPtr_->getData(), sinkPtr_->size());
-
   dwio::common::ReaderOptions readerOpts;
   dwio::common::RowReaderOptions rowReaderOpts;
+  std::string_view data(sinkPtr_->getData(), sinkPtr_->size());
+  auto input = std::make_unique<BufferedInput>(
+      std::make_shared<InMemoryReadFile>(data), readerOpts.getMemoryPool());
   auto reader = makeReader(readerOpts, std::move(input));
   // The  spec must stay live over the lifetime of the reader.
   setUpRowReaderOptions(rowReaderOpts, spec);

--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -17,8 +17,8 @@
 #pragma once
 
 #include "velox/common/time/Timer.h"
+#include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/DataSink.h"
-#include "velox/dwio/common/MemoryInputStream.h"
 #include "velox/dwio/common/Reader.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/SelectiveColumnReader.h"
@@ -173,7 +173,7 @@ class E2EFilterTestBase : public testing::Test {
 
   virtual std::unique_ptr<dwio::common::Reader> makeReader(
       const dwio::common::ReaderOptions& opts,
-      std::unique_ptr<dwio::common::InputStream> input) = 0;
+      std::unique_ptr<dwio::common::BufferedInput> input) = 0;
 
   virtual void setUpRowReaderOptions(
       dwio::common::RowReaderOptions& opts,

--- a/velox/dwio/common/tests/ReadFileInputStreamTests.cpp
+++ b/velox/dwio/common/tests/ReadFileInputStreamTests.cpp
@@ -31,8 +31,8 @@ TEST(ReadFileInputStream, SimpleUsage) {
     writeFile.append("bbbbb");
     writeFile.append("ccccc");
   }
-  InMemoryReadFile readFile(fileData);
-  ReadFileInputStream inputStream(&readFile);
+  auto readFile = std::make_shared<InMemoryReadFile>(fileData);
+  ReadFileInputStream inputStream(readFile);
   ASSERT_EQ(inputStream.getLength(), 15);
   auto buf = std::make_unique<char[]>(15);
 

--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -16,14 +16,14 @@
 
 #include <gtest/gtest.h>
 #include "velox/dwio/common/BufferedInput.h"
-#include "velox/dwio/common/MemoryInputStream.h"
 
 using namespace facebook::velox::dwio::common;
 
 TEST(TestBufferedInput, ZeroLengthStream) {
-  MemoryInputStream stream{nullptr, 0};
+  auto readFile =
+      std::make_shared<facebook::velox::InMemoryReadFile>(std::string());
   auto pool = facebook::velox::memory::getDefaultMemoryPool();
-  BufferedInput input{stream, *pool};
+  BufferedInput input(readFile, *pool);
   auto ret = input.enqueue({0, 0});
   EXPECT_NE(ret, nullptr);
   const void* buf = nullptr;

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -73,10 +73,10 @@ DwrfRowReader::DwrfRowReader(
   std::function<std::string()> createExceptionContext = [&]() {
     std::string exceptionMessageContext = fmt::format(
         "The schema loaded in the reader does not match the schema in the file footer."
-        "Input Stream Name: {},\n"
+        "Input Name: {},\n"
         "File Footer Schema (without partition columns): {},\n"
         "Input Table Schema (with partition columns): {}\n",
-        getReader().getStream().getName(),
+        getReader().getBufferedInput().getName(),
         getReader().getSchema()->toString(),
         getType()->toString());
     return exceptionMessageContext;
@@ -472,15 +472,11 @@ std::optional<size_t> DwrfRowReader::estimatedRowSize() const {
 
 DwrfReader::DwrfReader(
     const ReaderOptions& options,
-    std::unique_ptr<InputStream> input)
+    std::unique_ptr<dwio::common::BufferedInput> input)
     : readerBase_(std::make_unique<ReaderBase>(
           options.getMemoryPool(),
           std::move(input),
           options.getDecrypterFactory(),
-          options.getBufferedInputFactory()
-              ? options.getBufferedInputFactory()
-              : dwio::common::BufferedInputFactory::baseFactoryShared(),
-          options.getFileNum(),
           options.getFileFormat() == FileFormat::ORC ? FileFormat::ORC
                                                      : FileFormat::DWRF)),
       options_(options) {}
@@ -653,11 +649,13 @@ uint64_t DwrfReader::getMemoryUse(
    * in the input stream and in the seekable input stream.
    * If no string column is read, estimate from the number of streams.
    */
-  uint64_t memory = hasStringColumn
-      ? 2 * maxDataLength
-      : std::min(
-            uint64_t(maxDataLength),
-            nSelectedStreams * readerBase.getStream().getNaturalReadSize());
+  uint64_t memory = hasStringColumn ? 2 * maxDataLength
+                                    : std::min(
+                                          uint64_t(maxDataLength),
+                                          nSelectedStreams *
+                                              readerBase.getBufferedInput()
+                                                  .getReadFile()
+                                                  ->getNaturalReadSize());
 
   // Do we need even more memory to read the footer or the metadata?
   auto footerLength = readerBase.getPostScript().footerLength();
@@ -698,9 +696,9 @@ std::unique_ptr<DwrfRowReader> DwrfReader::createDwrfRowReader(
 }
 
 std::unique_ptr<DwrfReader> DwrfReader::create(
-    std::unique_ptr<InputStream> stream,
+    std::unique_ptr<dwio::common::BufferedInput> input,
     const ReaderOptions& options) {
-  return std::make_unique<DwrfReader>(options, std::move(stream));
+  return std::make_unique<DwrfReader>(options, std::move(input));
 }
 
 void registerDwrfReaderFactory() {

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -166,7 +166,7 @@ class DwrfReader : public dwio::common::Reader {
    */
   DwrfReader(
       const dwio::common::ReaderOptions& options,
-      std::unique_ptr<dwio::common::InputStream> input);
+      std::unique_ptr<dwio::common::BufferedInput> input);
 
   ~DwrfReader() override = default;
 
@@ -274,7 +274,7 @@ class DwrfReader : public dwio::common::Reader {
    * @param options the options for reading the file
    */
   static std::unique_ptr<DwrfReader> create(
-      std::unique_ptr<dwio::common::InputStream> stream,
+      std::unique_ptr<dwio::common::BufferedInput> input,
       const dwio::common::ReaderOptions& options);
 
  private:
@@ -289,9 +289,9 @@ class DwrfReaderFactory : public dwio::common::ReaderFactory {
   DwrfReaderFactory() : ReaderFactory(dwio::common::FileFormat::DWRF) {}
 
   std::unique_ptr<dwio::common::Reader> createReader(
-      std::unique_ptr<dwio::common::InputStream> stream,
+      std::unique_ptr<dwio::common::BufferedInput> input,
       const dwio::common::ReaderOptions& options) override {
-    return DwrfReader::create(std::move(stream), options);
+    return DwrfReader::create(std::move(input), options);
   }
 };
 

--- a/velox/dwio/dwrf/reader/StripeReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.cpp
@@ -37,8 +37,7 @@ StripeInformationWrapper StripeReaderBase::loadStripe(
     // if file is preloaded, return stripe is preloaded
     preload = true;
   } else {
-    stripeInput_ = reader_->bufferedInputFactory().create(
-        reader_->getStream(), reader_->getMemoryPool(), reader_->getFileNum());
+    stripeInput_ = reader_->getBufferedInput().clone();
 
     if (preload) {
       // If metadata cache exists, adjust read position to avoid re-reading

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -18,7 +18,6 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/base/Nulls.h"
-#include "velox/dwio/common/MemoryInputStream.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
@@ -69,8 +68,9 @@ std::unique_ptr<RowReader> writeAndGetReader(
 
   writer.close();
 
-  auto input =
-      std::make_unique<MemoryInputStream>(sinkPtr->getData(), sinkPtr->size());
+  std::string_view data(sinkPtr->getData(), sinkPtr->size());
+  auto readFile = std::make_shared<facebook::velox::InMemoryReadFile>(data);
+  auto input = std::make_unique<BufferedInput>(readFile, pool);
 
   ReaderOptions readerOpts;
   RowReaderOptions rowReaderOpts;

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -93,7 +93,7 @@ class E2EFilterTest : public E2EFilterTestBase {
 
   std::unique_ptr<dwio::common::Reader> makeReader(
       const dwio::common::ReaderOptions& opts,
-      std::unique_ptr<dwio::common::InputStream> input) override {
+      std::unique_ptr<dwio::common::BufferedInput> input) override {
     return std::make_unique<DwrfReader>(opts, std::move(input));
   }
 

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -16,7 +16,6 @@
 
 #include <gtest/gtest.h>
 
-#include "velox/dwio/common/MemoryInputStream.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/dwrf/reader/StripeReaderBase.h"
 #include "velox/dwio/dwrf/utils/ProtoUtils.h"
@@ -68,7 +67,8 @@ class StripeLoadKeysTest : public Test {
 
     reader_ = std::make_unique<ReaderBase>(
         *pool_,
-        std::make_unique<MemoryInputStream>(nullptr, 0),
+        std::make_unique<BufferedInput>(
+            std::make_shared<InMemoryReadFile>(std::string()), *pool_),
         nullptr,
         footer,
         nullptr,

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -174,11 +174,15 @@ void checkBytes(const char* data, int32_t length, uint32_t startValue) {
   }
 }
 
+SeekableFileInputStream createSeekableFileInputStream() {
+  auto readFile = std::make_shared<LocalReadFile>(simpleFile);
+  auto file = std::make_shared<ReadFileInputStream>(std::move(readFile));
+  return SeekableFileInputStream(
+      std::move(file), 0, 200, *pool, LogType::TEST, 20);
+}
+
 TEST(TestDecompression, testFileBackup) {
-  SCOPED_TRACE("testFileBackup");
-  std::unique_ptr<InputStream> file =
-      std::make_unique<FileInputStream>(simpleFile);
-  SeekableFileInputStream stream(*file, 0, 200, *pool, LogType::TEST, 20);
+  auto stream = createSeekableFileInputStream();
   const void* ptr;
   int32_t len;
   ASSERT_THROW(stream.BackUp(10), exception::LoggedException);
@@ -207,10 +211,7 @@ TEST(TestDecompression, testFileBackup) {
 }
 
 TEST(TestDecompression, testFileSkip) {
-  SCOPED_TRACE("testFileSkip");
-  std::unique_ptr<InputStream> file =
-      std::make_unique<FileInputStream>(simpleFile);
-  SeekableFileInputStream stream(*file, 0, 200, *pool, LogType::TEST, 20);
+  auto stream = createSeekableFileInputStream();
   const void* ptr;
   int32_t len;
   ASSERT_EQ(true, stream.Next(&ptr, &len));
@@ -228,10 +229,7 @@ TEST(TestDecompression, testFileSkip) {
 }
 
 TEST(TestDecompression, testFileCombo) {
-  SCOPED_TRACE("testFileCombo");
-  std::unique_ptr<InputStream> file =
-      std::make_unique<FileInputStream>(simpleFile);
-  SeekableFileInputStream stream(*file, 0, 200, *pool, LogType::TEST, 20);
+  auto stream = createSeekableFileInputStream();
   const void* ptr;
   int32_t len;
   ASSERT_EQ(true, stream.Next(&ptr, &len));
@@ -249,10 +247,7 @@ TEST(TestDecompression, testFileCombo) {
 }
 
 TEST(TestDecompression, testFileSeek) {
-  SCOPED_TRACE("testFileSeek");
-  std::unique_ptr<InputStream> file =
-      std::make_unique<FileInputStream>(simpleFile);
-  SeekableFileInputStream stream(*file, 0, 200, *pool, LogType::TEST, 20);
+  auto stream = createSeekableFileInputStream();
   const void* ptr;
   int32_t len;
   EXPECT_EQ(0, stream.ByteCount());

--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -19,7 +19,6 @@
 
 #include "folly/Random.h"
 #include "velox/dwio/common/DataSink.h"
-#include "velox/dwio/common/MemoryInputStream.h"
 #include "velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/dwio/type/fbhive/HiveTypeParser.h"

--- a/velox/dwio/dwrf/test/WriterTests.cpp
+++ b/velox/dwio/dwrf/test/WriterTests.cpp
@@ -17,7 +17,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stdexcept>
-#include "velox/dwio/common/MemoryInputStream.h"
 #include "velox/dwio/dwrf/reader/ReaderBase.h"
 #include "velox/dwio/dwrf/writer/WriterBase.h"
 #include "velox/dwio/type/fbhive/HiveTypeParser.h"
@@ -44,6 +43,13 @@ class WriterTest : public Test {
     writer_ = std::make_unique<WriterBase>(std::move(sink));
     writer_->initContext(config, pool_->addChild("test_writer_pool"));
     return *writer_;
+  }
+
+  std::unique_ptr<ReaderBase> createReader() {
+    std::string_view data(sinkPtr_->getData(), sinkPtr_->size());
+    auto readFile = std::make_shared<InMemoryReadFile>(data);
+    auto input = std::make_unique<BufferedInput>(std::move(readFile), *pool_);
+    return std::make_unique<ReaderBase>(*pool_, std::move(input));
   }
 
   auto& getContext() {
@@ -109,9 +115,7 @@ TEST_F(WriterTest, WriteFooter) {
   writer.close();
 
   // deserialize and verify
-  auto input = std::make_unique<MemoryInputStream>(
-      sinkPtr_->getData(), sinkPtr_->size());
-  auto reader = std::make_unique<ReaderBase>(*pool_, std::move(input));
+  auto reader = createReader();
 
   auto& ps = reader->getPostScript();
   ASSERT_EQ(reader->getWriterVersion(), config->get(Config::WRITER_VERSION));
@@ -213,9 +217,7 @@ TEST_F(WriterTest, NoChecksum) {
   writer.close();
 
   // deserialize and verify
-  auto input = std::make_unique<MemoryInputStream>(
-      sinkPtr_->getData(), sinkPtr_->size());
-  auto reader = std::make_unique<ReaderBase>(*pool_, std::move(input));
+  auto reader = createReader();
   auto& footer = reader->getFooter();
   ASSERT_TRUE(footer.hasChecksumAlgorithm());
   ASSERT_EQ(footer.checksumAlgorithm(), proto::ChecksumAlgorithm::NULL_);
@@ -249,9 +251,7 @@ TEST_F(WriterTest, NoCache) {
   writer.close();
 
   // deserialize and verify
-  auto input = std::make_unique<MemoryInputStream>(
-      sinkPtr_->getData(), sinkPtr_->size());
-  auto reader = std::make_unique<ReaderBase>(*pool_, std::move(input));
+  auto reader = createReader();
   auto& footer = reader->getFooter();
   ASSERT_EQ(footer.stripeCacheOffsetsSize(), 0);
   auto& ps = reader->getPostScript();

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -17,7 +17,6 @@
 #include "velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h"
 
 #include <gtest/gtest.h>
-#include "velox/dwio/common/MemoryInputStream.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
@@ -90,8 +89,9 @@ namespace facebook::velox::dwrf {
       layoutPlannerFactory,
       writerMemoryCap);
   // read it back and compare
-  auto input =
-      std::make_unique<MemoryInputStream>(sinkPtr->getData(), sinkPtr->size());
+  auto readFile = std::make_shared<InMemoryReadFile>(
+      std::string_view(sinkPtr->getData(), sinkPtr->size()));
+  auto input = std::make_unique<BufferedInput>(readFile, pool);
 
   ReaderOptions readerOpts;
   RowReaderOptions rowReaderOpts;

--- a/velox/dwio/parquet/duckdb_reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/duckdb_reader/ParquetReader.cpp
@@ -309,7 +309,7 @@ std::optional<size_t> ParquetRowReader::estimatedRowSize() const {
 }
 
 ParquetReader::ParquetReader(
-    std::unique_ptr<dwio::common::InputStream> stream,
+    std::shared_ptr<dwio::common::InputStream> stream,
     const dwio::common::ReaderOptions& options)
     : fileSystem_(
           std::make_unique<duckdb::InputStreamFileSystem>(std::move(stream))),

--- a/velox/dwio/parquet/duckdb_reader/ParquetReader.h
+++ b/velox/dwio/parquet/duckdb_reader/ParquetReader.h
@@ -57,7 +57,7 @@ class ParquetRowReader : public dwio::common::RowReader {
 class ParquetReader : public dwio::common::Reader {
  public:
   ParquetReader(
-      std::unique_ptr<dwio::common::InputStream> stream,
+      std::shared_ptr<dwio::common::InputStream> stream,
       const dwio::common::ReaderOptions& options);
   ~ParquetReader() override = default;
 
@@ -88,9 +88,9 @@ class ParquetReaderFactory : public dwio::common::ReaderFactory {
   ParquetReaderFactory() : ReaderFactory(dwio::common::FileFormat::PARQUET) {}
 
   std::unique_ptr<dwio::common::Reader> createReader(
-      std::unique_ptr<dwio::common::InputStream> stream,
+      std::unique_ptr<dwio::common::BufferedInput> input,
       const dwio::common::ReaderOptions& options) override {
-    return std::make_unique<ParquetReader>(std::move(stream), options);
+    return std::make_unique<ParquetReader>(input->getInputStream(), options);
   }
 };
 

--- a/velox/dwio/parquet/duckdb_reader/duckdb/InputStreamFileSystem.h
+++ b/velox/dwio/parquet/duckdb_reader/duckdb/InputStreamFileSystem.h
@@ -33,7 +33,7 @@ namespace facebook::velox::duckdb {
 class InputStreamFileSystem : public ::duckdb::FileSystem {
  public:
   explicit InputStreamFileSystem(
-      std::unique_ptr<dwio::common::InputStream> stream)
+      std::shared_ptr<dwio::common::InputStream> stream)
       : stream_(std::move(stream)) {}
 
   ~InputStreamFileSystem() override = default;
@@ -152,7 +152,7 @@ class InputStreamFileSystem : public ::duckdb::FileSystem {
   }
 
  private:
-  std::unique_ptr<dwio::common::InputStream> stream_;
+  std::shared_ptr<dwio::common::InputStream> stream_;
 };
 
 } // namespace facebook::velox::duckdb

--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -36,7 +36,7 @@ class StructColumnReader;
 class ReaderBase {
  public:
   ReaderBase(
-      std::unique_ptr<dwio::common::InputStream> stream,
+      std::unique_ptr<dwio::common::BufferedInput>,
       const dwio::common::ReaderOptions& options);
 
   virtual ~ReaderBase() = default;
@@ -47,10 +47,6 @@ class ReaderBase {
 
   dwio::common::BufferedInput& bufferedInput() const {
     return *input_;
-  }
-
-  dwio::common::InputStream& stream() const {
-    return *stream_;
   }
 
   uint64_t fileLength() const {
@@ -108,9 +104,7 @@ class ReaderBase {
 
   memory::MemoryPool& pool_;
   const dwio::common::ReaderOptions& options_;
-  const std::unique_ptr<dwio::common::InputStream> stream_;
-  std::shared_ptr<dwio::common::BufferedInputFactory> bufferedInputFactory_;
-  std::shared_ptr<velox::dwio::common::BufferedInput> input_;
+  std::unique_ptr<velox::dwio::common::BufferedInput> input_;
   uint64_t fileLength_;
   std::unique_ptr<thrift::FileMetaData> fileMetaData_;
   RowTypePtr schema_;
@@ -179,7 +173,7 @@ class ParquetRowReader : public dwio::common::RowReader {
 class ParquetReader : public dwio::common::Reader {
  public:
   ParquetReader(
-      std::unique_ptr<dwio::common::InputStream> stream,
+      std::unique_ptr<dwio::common::BufferedInput>,
       const dwio::common::ReaderOptions& options);
 
   ~ParquetReader() override = default;
@@ -214,9 +208,9 @@ class ParquetReaderFactory : public dwio::common::ReaderFactory {
   ParquetReaderFactory() : ReaderFactory(dwio::common::FileFormat::PARQUET) {}
 
   std::unique_ptr<dwio::common::Reader> createReader(
-      std::unique_ptr<dwio::common::InputStream> stream,
+      std::unique_ptr<dwio::common::BufferedInput> input,
       const dwio::common::ReaderOptions& options) override {
-    return std::make_unique<ParquetReader>(std::move(stream), options);
+    return std::make_unique<ParquetReader>(std::move(input), options);
   }
 };
 

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetReaderTest.cpp
@@ -30,6 +30,15 @@ using namespace facebook::velox;
 using namespace facebook::velox::dwio::parquet;
 using namespace facebook::velox::parquet::duckdb_reader;
 
+std::unique_ptr<ParquetReader> createFileInput(
+    const std::string& path,
+    const ReaderOptions& opts) {
+  return std::make_unique<ParquetReader>(
+      std::make_shared<ReadFileInputStream>(
+          std::make_shared<LocalReadFile>(path)),
+      opts);
+}
+
 class ParquetReaderTest : public ParquetReaderTestBase {
  public:
   void assertReadWithFilters(
@@ -40,9 +49,7 @@ class ParquetReaderTest : public ParquetReaderTestBase {
     const auto filePath(getExampleFilePath(fileName));
 
     ReaderOptions readerOptions;
-    auto reader = std::make_unique<parquet::duckdb_reader::ParquetReader>(
-        std::make_unique<FileInputStream>(filePath), readerOptions);
-
+    auto reader = createFileInput(filePath, readerOptions);
     assertReadWithReaderAndFilters(
         std::move(reader), fileName, fileSchema, std::move(filters), expected);
   }
@@ -63,12 +70,11 @@ TEST_F(ParquetReaderTest, readSampleFull) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   ReaderOptions readerOptions;
-  ParquetReader reader(
-      std::make_unique<FileInputStream>(sample), readerOptions);
+  auto reader = createFileInput(sample, readerOptions);
 
-  EXPECT_EQ(reader.numberOfRows(), 20ULL);
+  EXPECT_EQ(reader->numberOfRows(), 20ULL);
 
-  auto type = reader.typeWithId();
+  auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 2ULL);
   auto col0 = type->childAt(0);
   EXPECT_EQ(col0->type->kind(), TypeKind::BIGINT);
@@ -80,7 +86,7 @@ TEST_F(ParquetReaderTest, readSampleFull) {
   auto rowReaderOpts = getReaderOpts(sampleSchema());
   auto scanSpec = makeScanSpec(sampleSchema());
   rowReaderOpts.setScanSpec(scanSpec);
-  auto rowReader = reader.createRowReader(rowReaderOpts);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
   auto expected = vectorMaker_->rowVector(
       {rangeVector<int64_t>(20, 1), rangeVector<double>(20, 1)});
   assertReadExpected(*rowReader, expected);
@@ -90,14 +96,13 @@ TEST_F(ParquetReaderTest, readSampleRange1) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   ReaderOptions readerOptions;
-  ParquetReader reader(
-      std::make_unique<FileInputStream>(sample), readerOptions);
+  auto reader = createFileInput(sample, readerOptions);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
   auto scanSpec = makeScanSpec(sampleSchema());
   rowReaderOpts.setScanSpec(scanSpec);
   rowReaderOpts.range(0, 200);
-  auto rowReader = reader.createRowReader(rowReaderOpts);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
   auto expected = vectorMaker_->rowVector(
       {rangeVector<int64_t>(10, 1), rangeVector<double>(10, 1)});
   assertReadExpected(*rowReader, expected);
@@ -107,14 +112,13 @@ TEST_F(ParquetReaderTest, readSampleRange2) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   ReaderOptions readerOptions;
-  ParquetReader reader(
-      std::make_unique<FileInputStream>(sample), readerOptions);
+  auto reader = createFileInput(sample, readerOptions);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
   auto scanSpec = makeScanSpec(sampleSchema());
   rowReaderOpts.setScanSpec(scanSpec);
   rowReaderOpts.range(200, 500);
-  auto rowReader = reader.createRowReader(rowReaderOpts);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
   auto expected = vectorMaker_->rowVector(
       {rangeVector<int64_t>(10, 11), rangeVector<double>(10, 11)});
   assertReadExpected(*rowReader, expected);
@@ -124,14 +128,13 @@ TEST_F(ParquetReaderTest, readSampleEmptyRange) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   ReaderOptions readerOptions;
-  ParquetReader reader(
-      std::make_unique<FileInputStream>(sample), readerOptions);
+  auto reader = createFileInput(sample, readerOptions);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
   auto scanSpec = makeScanSpec(sampleSchema());
   rowReaderOpts.setScanSpec(scanSpec);
   rowReaderOpts.range(300, 10);
-  auto rowReader = reader.createRowReader(rowReaderOpts);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   VectorPtr result;
   EXPECT_EQ(rowReader->next(1000, result), 0);
@@ -185,12 +188,11 @@ TEST_F(ParquetReaderTest, dateRead) {
   const std::string sample(getExampleFilePath("date.parquet"));
 
   ReaderOptions readerOptions;
-  ParquetReader reader(
-      std::make_unique<FileInputStream>(sample), readerOptions);
+  auto reader = createFileInput(sample, readerOptions);
 
-  EXPECT_EQ(reader.numberOfRows(), 25ULL);
+  EXPECT_EQ(reader->numberOfRows(), 25ULL);
 
-  auto type = reader.typeWithId();
+  auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 1ULL);
   auto col0 = type->childAt(0);
   EXPECT_EQ(col0->type->kind(), TypeKind::DATE);
@@ -198,7 +200,7 @@ TEST_F(ParquetReaderTest, dateRead) {
   auto rowReaderOpts = getReaderOpts(dateSchema());
   auto scanSpec = makeScanSpec(dateSchema());
   rowReaderOpts.setScanSpec(scanSpec);
-  auto rowReader = reader.createRowReader(rowReaderOpts);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   auto expected = vectorMaker_->rowVector({rangeVector<Date>(25, -5)});
   assertReadExpected(*rowReader, expected);
@@ -224,12 +226,11 @@ TEST_F(ParquetReaderTest, intRead) {
   const std::string sample(getExampleFilePath("int.parquet"));
 
   ReaderOptions readerOptions;
-  ParquetReader reader(
-      std::make_unique<FileInputStream>(sample), readerOptions);
+  auto reader = createFileInput(sample, readerOptions);
 
-  EXPECT_EQ(reader.numberOfRows(), 10ULL);
+  EXPECT_EQ(reader->numberOfRows(), 10ULL);
 
-  auto type = reader.typeWithId();
+  auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 2ULL);
   auto col0 = type->childAt(0);
   EXPECT_EQ(col0->type->kind(), TypeKind::INTEGER);
@@ -239,7 +240,7 @@ TEST_F(ParquetReaderTest, intRead) {
   auto rowReaderOpts = getReaderOpts(intSchema());
   auto scanSpec = makeScanSpec(intSchema());
   rowReaderOpts.setScanSpec(scanSpec);
-  auto rowReader = reader.createRowReader(rowReaderOpts);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
 
   auto expected = vectorMaker_->rowVector(
       {rangeVector<int32_t>(10, 100), rangeVector<int64_t>(10, 1000)});

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -25,7 +25,6 @@ using namespace facebook::velox::common;
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::parquet;
 
-using dwio::common::MemoryInputStream;
 using dwio::common::MemorySink;
 
 class E2EFilterTest : public E2EFilterTestBase {
@@ -71,7 +70,7 @@ class E2EFilterTest : public E2EFilterTestBase {
 
   std::unique_ptr<dwio::common::Reader> makeReader(
       const dwio::common::ReaderOptions& opts,
-      std::unique_ptr<dwio::common::InputStream> input) override {
+      std::unique_ptr<dwio::common::BufferedInput> input) override {
     return std::make_unique<ParquetReader>(std::move(input), opts);
   }
 

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "velox/dwio/common/DataSink.h"
-#include "velox/dwio/common/MemoryInputStream.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/common/tests/utils/DataSetBuilder.h"
@@ -121,7 +120,9 @@ class ParquetReaderBenchmark {
       std::shared_ptr<ScanSpec> scanSpec,
       const RowTypePtr& rowType) {
     dwio::common::ReaderOptions readerOpts;
-    auto input = std::make_unique<FileInputStream>("test.parquet");
+    auto input = std::make_unique<BufferedInput>(
+        std::make_shared<LocalReadFile>("test.parquet"),
+        readerOpts.getMemoryPool());
 
     std::unique_ptr<Reader> reader;
     switch (parquetReaderType) {
@@ -130,7 +131,7 @@ class ParquetReaderBenchmark {
         break;
       case ParquetReaderType::DUCKDB:
         reader = std::make_unique<duckdb_reader::ParquetReader>(
-            std::move(input), readerOpts);
+            input->getInputStream(), readerOpts);
         break;
       default:
         VELOX_UNSUPPORTED("Only native or DuckDB Parquet reader is supported");

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -25,6 +25,13 @@ using namespace facebook::velox::parquet;
 
 class ParquetReaderTest : public ParquetReaderTestBase {};
 
+ParquetReader createReader(const std::string& path, const ReaderOptions& opts) {
+  return ParquetReader(
+      std::make_unique<BufferedInput>(
+          std::make_shared<LocalReadFile>(path), opts.getMemoryPool()),
+      opts);
+}
+
 TEST_F(ParquetReaderTest, parseSample) {
   // sample.parquet holds two columns (a: BIGINT, b: DOUBLE) and
   // 20 rows (10 rows per group). Group offsets are 153 and 614.
@@ -34,8 +41,7 @@ TEST_F(ParquetReaderTest, parseSample) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   ReaderOptions readerOptions;
-  ParquetReader reader(
-      std::make_unique<FileInputStream>(sample), readerOptions);
+  ParquetReader reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader.numberOfRows(), 20ULL);
 
   auto type = reader.typeWithId();
@@ -56,8 +62,7 @@ TEST_F(ParquetReaderTest, parseDate) {
   const std::string sample(getExampleFilePath("date.parquet"));
 
   ReaderOptions readerOptions;
-  facebook::velox::parquet::ParquetReader reader(
-      std::make_unique<FileInputStream>(sample), readerOptions);
+  ParquetReader reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader.numberOfRows(), 25ULL);
 
@@ -74,8 +79,7 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
   const std::string sample(getExampleFilePath("row_map_array.parquet"));
 
   ReaderOptions readerOptions;
-  facebook::velox::parquet::ParquetReader reader(
-      std::make_unique<FileInputStream>(sample), readerOptions);
+  ParquetReader reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader.numberOfRows(), 1ULL);
 

--- a/velox/examples/ScanOrc.cpp
+++ b/velox/examples/ScanOrc.cpp
@@ -47,7 +47,10 @@ int main(int argc, char** argv) {
   // To make DwrfReader reads ORC file, setFileFormat to FileFormat::ORC
   readerOpts.setFileFormat(FileFormat::ORC);
   auto reader = DwrfReader::create(
-      std::make_unique<FileInputStream>(filePath), readerOpts);
+      std::make_unique<BufferedInput>(
+          std::make_shared<LocalReadFile>(filePath),
+          readerOpts.getMemoryPool()),
+      readerOpts);
 
   VectorPtr batch;
   RowReaderOptions rowReaderOptions;

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -82,12 +82,12 @@ void TpchQueryBuilder::initialize(const std::string& dataPath) {
       if (tableMetadata_[tableName].dataFiles.empty()) {
         dwio::common::ReaderOptions readerOptions;
         readerOptions.setFileFormat(format_);
+        auto input = std::make_unique<dwio::common::BufferedInput>(
+            std::make_shared<LocalReadFile>(dirEntry.path().string()),
+            readerOptions.getMemoryPool());
         std::unique_ptr<dwio::common::Reader> reader =
             dwio::common::getReaderFactory(readerOptions.getFileFormat())
-                ->createReader(
-                    std::make_unique<dwio::common::FileInputStream>(
-                        dirEntry.path()),
-                    readerOptions);
+                ->createReader(std::move(input), readerOptions);
         const auto fileType = reader->rowType();
         const auto fileColumnNames = fileType->names();
         // There can be extra columns in the file towards the end.


### PR DESCRIPTION
Summary:
Main changes in this diff:
1. `BufferedInput` takes `shared_ptr<ReadFile>`.
2. Readers takes `unique_ptr<BufferedInput>`.
3. `BufferedInput` can be duplicated to represent different pins on same file, the underlying `ReadFile` is shared.

Differential Revision: D41723926

