### PR TITLE
Add Parquet struct reader

### DIFF
--- a/velox/dwio/common/FormatData.h
+++ b/velox/dwio/common/FormatData.h
@@ -116,6 +116,16 @@ class FormatData {
   virtual bool rowGroupMatches(
       uint32_t rowGroupId,
       velox::common::Filter* FOLLY_NULLABLE filter) = 0;
+
+  /// True if leaf columns contain nullness information for struct
+  /// parents. This is true in Parquet and false in ORC. and Alpha. If
+  /// false, struct parent must maintain the count of skipped nulls at
+  /// the struct level so that the children will not skip positions
+  /// where the parent was null and there is no value to skip in the
+  /// child.
+  virtual bool parentNullsInLeaves() const {
+    return false;
+  }
 };
 
 /// Base class for format-specific reader initialization arguments.

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -59,7 +59,7 @@ std::vector<uint32_t> SelectiveColumnReader::filterRowGroups(
   return formatData_->filterRowGroups(*scanSpec_, rowGroupSize, context);
 }
 
-const std::vector<SelectiveColumnReader*> SelectiveColumnReader::children()
+const std::vector<SelectiveColumnReader*>& SelectiveColumnReader::children()
     const {
   static std::vector<SelectiveColumnReader*> empty;
   return empty;

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -133,7 +133,7 @@ class SelectiveColumnReader {
   }
 
   /// Returns list of child readers, empty for leaf readers.
-  virtual const std::vector<SelectiveColumnReader*> children() const;
+  virtual const std::vector<SelectiveColumnReader*>& children() const;
 
   /**
    * Read the next group of values into a RowVector.

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -29,6 +29,10 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
     return false;
   }
 
+  const std::vector<SelectiveColumnReader*>& children() const override {
+    return children_;
+  }
+
  protected:
   // Buffer size for reading lengths when skipping.
   static constexpr int32_t kBufferSize = 1024;
@@ -166,6 +170,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
   // read up to the last position corresponding to
   // the last non-null parent.
   vector_size_t childTargetReadOffset_ = 0;
+  std::vector<SelectiveColumnReader*> children_;
 };
 
 class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
@@ -177,10 +182,6 @@ class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
       velox::common::ScanSpec& scanSpec);
 
   uint64_t skip(uint64_t numValues) override;
-
-  const std::vector<SelectiveColumnReader*> children() const override {
-    return std::vector<SelectiveColumnReader*>{child_.get()};
-  }
 
   void read(
       vector_size_t offset,
@@ -208,11 +209,6 @@ class SelectiveMapColumnReader : public SelectiveRepeatedColumnReader {
   }
 
   uint64_t skip(uint64_t numValues) override;
-
-  const std::vector<SelectiveColumnReader*> children() const override {
-    return std::vector<SelectiveColumnReader*>{
-        keyReader_.get(), elementReader_.get()};
-  }
 
   void read(
       vector_size_t offset,

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -183,6 +183,9 @@ void SelectiveStructColumnReaderBase::read(
 void SelectiveStructColumnReaderBase::recordParentNullsInChildren(
     vector_size_t offset,
     RowSet rows) {
+  if (formatData_->parentNullsInLeaves()) {
+    return;
+  }
   auto& childSpecs = scanSpec_->children();
   for (auto i = 0; i < childSpecs.size(); ++i) {
     auto& childSpec = childSpecs[i];

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -81,6 +81,10 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
     }
   }
 
+  const std::vector<SelectiveColumnReader*>& children() const override {
+    return children_;
+  }
+
   // Sets 'rows' as the set of rows for which 'this' or its children
   // may be loaded as LazyVectors. When a struct is loaded as lazy,
   // its children will be lazy if the struct does not add nulls. The

--- a/velox/dwio/common/tests/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/E2EFilterTestBase.cpp
@@ -44,7 +44,7 @@ std::vector<RowVectorPtr> E2EFilterTestBase::makeDataset(
     dataSetBuilder_ = std::make_unique<DataSetBuilder>(*pool_, 0);
   }
 
-  dataSetBuilder_->makeDataset(rowType_, kBatchCount, kBatchSize);
+  dataSetBuilder_->makeDataset(rowType_, batchCount_, batchSize_);
 
   if (forRowGroupSkip) {
     dataSetBuilder_->withRowGroupSpecificData(kRowsInGroup);

--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -286,6 +286,8 @@ class E2EFilterTestBase : public testing::Test {
   int32_t flushEveryNBatches_{10};
   int32_t nextReadSizeIndex_{0};
   std::vector<int32_t> readSizes_;
+  int32_t batchCount_ = kBatchCount;
+  int32_t batchSize_ = kBatchSize;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -67,6 +67,7 @@ SelectiveListColumnReader::SelectiveListColumnReader(
       DwrfParams(stripe, FlatMapContext{encodingKey.sequence, nullptr});
   child_ = SelectiveDwrfReader::build(
       childType, nodeType_->childAt(0), childParams, *scanSpec_->children()[0]);
+  children_ = {child_.get()};
 }
 
 SelectiveMapColumnReader::SelectiveMapColumnReader(
@@ -116,6 +117,7 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
       nodeType_->childAt(1),
       elementParams,
       *scanSpec_->children()[1]);
+  children_ = {keyReader_.get(), elementReader_.get()};
 
   VLOG(1) << "[Map] Initialized map column reader for node " << nodeType_->id;
 }

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -18,6 +18,7 @@
 
 #include <thrift/protocol/TCompactProtocol.h> //@manual
 #include "velox/common/base/RawVector.h"
+#include "velox/dwio/common/BufferUtil.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/parquet/reader/PageReader.h"
@@ -87,9 +88,16 @@ class ParquetData : public dwio::common::FormatData {
   /// Sets nulls to be returned by readNulls(). Nulls for non-leaf readers come
   /// from leaf repdefs which are gathered before descending the reader tree.
   void setNulls(BufferPtr& nulls, int32_t numValues) {
+    if (nulls || numValues) {
+      VELOX_CHECK_EQ(presetNullsConsumed_, presetNullsSize_);
+    }
     presetNulls_ = nulls;
     presetNullsSize_ = numValues;
-    presetNullsSkipped_ = 0;
+    presetNullsConsumed_ = 0;
+  }
+
+  int32_t presetNullsLeft() const {
+    return presetNullsSize_ - presetNullsConsumed_;
   }
 
   void readNulls(
@@ -100,19 +108,21 @@ class ParquetData : public dwio::common::FormatData {
     // If the query accesses only nulls, read the nulls from the pages in range.
     // If nulls are preread, return those minus any skipped.
     if (presetNulls_) {
-      VELOX_CHECK_EQ(numValues, presetNullsSize_ - presetNullsSkipped_);
-      nulls = std::move(presetNulls_);
-      if (presetNullsSkipped_) {
+      VELOX_CHECK_LE(numValues, presetNullsSize_ - presetNullsConsumed_);
+      if (!presetNullsConsumed_ && numValues == presetNullsSize_) {
+        nulls = std::move(presetNulls_);
+        presetNullsConsumed_ = numValues;
+      } else {
+        dwio::common::ensureCapacity<bool>(nulls, numValues, &pool_);
         auto bits = nulls->asMutable<uint64_t>();
         bits::copyBits(
-            bits,
-            presetNullsSkipped_,
+            presetNulls_->as<uint64_t>(),
+            presetNullsConsumed_,
             bits,
             0,
-            presetNullsSize_ - presetNullsSkipped_);
+            numValues);
+        presetNullsConsumed_ += numValues;
       }
-      presetNullsSkipped_ = 0;
-      presetNullsSize_ = 0;
       return;
     }
     if (nullsOnly) {
@@ -133,7 +143,7 @@ class ParquetData : public dwio::common::FormatData {
       reader_->skipNullsOnly(numValues);
     }
     if (presetNulls_) {
-      presetNullsSkipped_ += numValues;
+      presetNullsConsumed_ += numValues;
     }
     return numValues;
   }
@@ -162,6 +172,10 @@ class ParquetData : public dwio::common::FormatData {
     return reader_->isDictionary();
   }
 
+  bool parentNullsInLeaves() const override {
+    return true;
+  }
+
  protected:
   memory::MemoryPool& pool_;
   std::shared_ptr<const ParquetTypeWithId> type_;
@@ -182,7 +196,7 @@ class ParquetData : public dwio::common::FormatData {
   int32_t presetNullsSize_{0};
 
   // Count of leading skipped positions in 'presetNulls_'
-  int32_t presetNullsSkipped_{0};
+  int32_t presetNullsConsumed_{0};
 };
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/ParquetTypeWithId.cpp
+++ b/velox/dwio/parquet/reader/ParquetTypeWithId.cpp
@@ -34,6 +34,22 @@ bool containsList(const ParquetTypeWithId& type) {
 } // namespace
 using ::parquet::internal::LevelInfo;
 
+bool ParquetTypeWithId::hasNonRepeatedLeaf() const {
+  if (type->kind() == TypeKind::ARRAY) {
+    return false;
+  }
+  if (type->kind() == TypeKind::ROW) {
+    for (auto i = 0; i < type->size(); ++i) {
+      if (parquetChildAt(i).hasNonRepeatedLeaf()) {
+        return true;
+      }
+    }
+    return false;
+  } else {
+    return true;
+  }
+}
+
 LevelMode ParquetTypeWithId::makeLevelInfo(LevelInfo& info) const {
   int16_t repeatedAncestor = 0;
   for (auto parent = parquetParent(); parent;

--- a/velox/dwio/parquet/reader/ParquetTypeWithId.h
+++ b/velox/dwio/parquet/reader/ParquetTypeWithId.h
@@ -79,6 +79,9 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
   const int32_t precision_;
   const int32_t scale_;
   const int32_t typeLength_;
+
+  // True if this is or has a non-repeated leaf.
+  bool hasNonRepeatedLeaf() const;
 };
 
 using ParquetTypeWithIdPtr = std::shared_ptr<const ParquetTypeWithId>;

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -34,6 +34,61 @@ StructColumnReader::StructColumnReader(
     addChild(ParquetColumnReader::build(childDataType, params, *childSpecs[i]));
     childSpecs[i]->setSubscript(children_.size() - 1);
   }
+  auto type = reinterpret_cast<const ParquetTypeWithId*>(nodeType_.get());
+  if (type->parent) {
+    levelMode_ = reinterpret_cast<const ParquetTypeWithId*>(nodeType_.get())
+                     ->makeLevelInfo(levelInfo_);
+    childForRepDefs_ = findBestLeaf();
+    // Set mode to struct over lists if the child for repdefs has a list between
+    // this and the child.
+    auto child = childForRepDefs_;
+    for (;;) {
+      assert(child);
+      if (child->type()->kind() == TypeKind::ARRAY) {
+        levelMode_ = LevelMode::kStructOverLists;
+        break;
+      }
+      if (child->type()->kind() == TypeKind::ROW) {
+        child = reinterpret_cast<StructColumnReader*>(child)->childForRepDefs();
+        continue;
+      }
+      levelMode_ = LevelMode::kNulls;
+      break;
+    }
+  }
+}
+
+dwio::common::SelectiveColumnReader* FOLLY_NONNULL
+StructColumnReader::findBestLeaf() {
+  SelectiveColumnReader* best = nullptr;
+  for (auto i = 0; i < children_.size(); ++i) {
+    auto child = children_[i];
+    auto kind = child->type()->kind();
+    // Complex type child repdefs must be read in any case.
+    if (kind == TypeKind::ROW || kind == TypeKind::ARRAY) {
+      return child;
+    }
+    if (!best) {
+      best = child;
+    } else if (best->scanSpec()->filter() && !child->scanSpec()->filter()) {
+      continue;
+    } else if (!best->scanSpec()->filter() && child->scanSpec()->filter()) {
+      best = child;
+      continue;
+    } else if (kind < best->type()->kind()) {
+      best = child;
+    }
+  }
+  assert(best);
+  return best;
+}
+
+void StructColumnReader::read(
+    vector_size_t offset,
+    RowSet rows,
+    const uint64_t* /*incomingNulls*/) {
+  ensureRepDefs(*this, offset + rows.back() + 1 - readOffset_);
+  SelectiveStructColumnReader::read(offset, rows, nullptr);
 }
 
 void StructColumnReader::enqueueRowGroup(
@@ -52,6 +107,8 @@ void StructColumnReader::enqueueRowGroup(
 
 void StructColumnReader::seekToRowGroup(uint32_t index) {
   SelectiveColumnReader::seekToRowGroup(index);
+  BufferPtr noBuffer;
+  formatData_->as<ParquetData>().setNulls(noBuffer, 0);
   readOffset_ = 0;
   for (auto& child : children_) {
     child->seekToRowGroup(index);
@@ -60,6 +117,44 @@ void StructColumnReader::seekToRowGroup(uint32_t index) {
 
 bool StructColumnReader::filterMatches(const thrift::RowGroup& /*rowGroup*/) {
   return true;
+}
+
+void StructColumnReader::seekToEndOfPresetNulls() {
+  auto numUnread = formatData_->as<ParquetData>().presetNullsLeft();
+  for (auto i = 0; i < children_.size(); ++i) {
+    auto child = children_[i];
+    if (!child) {
+      continue;
+    }
+
+    if (child->type()->kind() != TypeKind::ROW) {
+      child->seekTo(readOffset_ + numUnread, false);
+    } else if (child->type()->kind() == TypeKind::ROW) {
+      reinterpret_cast<StructColumnReader*>(child)->seekToEndOfPresetNulls();
+    }
+  }
+  readOffset_ += numUnread;
+  formatData_->as<ParquetData>().skipNulls(numUnread, false);
+}
+
+void StructColumnReader::setNullsFromRepDefs(PageReader& pageReader) {
+  if (levelInfo_.def_level == 0) {
+    return;
+  }
+  auto repDefRange = pageReader.repDefRange();
+  int32_t numRepDefs = repDefRange.second - repDefRange.first;
+  dwio::common::ensureCapacity<uint64_t>(
+      nullsInReadRange_, bits::nwords(numRepDefs), &memoryPool_);
+  auto numStructs = pageReader.getLengthsAndNulls(
+      levelMode_,
+      levelInfo_,
+      repDefRange.first,
+      repDefRange.second,
+      numRepDefs,
+      nullptr,
+      nullsInReadRange()->asMutable<uint64_t>(),
+      0);
+  formatData_->as<ParquetData>().setNulls(nullsInReadRange(), numStructs);
 }
 
 } // namespace facebook::velox::parquet

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2103,7 +2103,6 @@ TEST_F(TableScanTest, errorInLoadLazy) {
   auto cache = dynamic_cast<cache::AsyncDataCache*>(
       memory::MemoryAllocator::getInstance());
   VELOX_CHECK_NOT_NULL(cache);
-
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, vectors);


### PR DESCRIPTION
Each struct or list must have one leaf descendent that reads all the repdefs of its column chunk. Nested structs/lists may share te same leaf. The single leaf for which the whole column chunk of repdefs will be read is selected to be or the narrowest type. Filtered leaves  are preferred over non-filtered.

The mentioned leaves are read for the column chunk on first use when first reading the containing top level list/struct. Other leaf columns are read as needed.

Non-top level leaves for which the repdefs are not read for the column chunk have the definition levels translated into null flags and leaf value counts at the time of reading the page header.

The lengths and nulls for all non-leaf readers are set by ensureRepDefs() when calling read() for the topmost struct/list.  Each reader will access these when its read() is called.

Nested structs with filters in inner structs may end a read() with different substructs at different rows. Before initiating a new top level read, the nested structs and their children are all brought to the end of the rows covered by the repdefs of the previous read(). In this way, the new repdefs all pick up at the same top level row.