### PR TITLE
Add copyBitsBackward

### DIFF
--- a/velox/common/base/tests/BitUtilTest.cpp
+++ b/velox/common/base/tests/BitUtilTest.cpp
@@ -20,6 +20,7 @@
 #include <unordered_set>
 
 #include <boost/crc.hpp>
+#include <fmt/format.h>
 #include <folly/Random.h>
 #include <folly/hash/Checksum.h>
 #include <gflags/gflags.h>
@@ -613,6 +614,41 @@ TEST_F(BitUtilTest, copyBits) {
   // Write bits 61..638 in temp, check that there is no write past
   // 10th word in temp.
   testCopyBits(source, 3, 640 - 62);
+}
+
+TEST_F(BitUtilTest, copyBitsBackward) {
+  std::vector<uint64_t> origin(10);
+  for (auto i = 0; i < origin.size(); ++i) {
+    origin[i] = 0x1234567890abcdef >> i;
+  }
+  auto test = [&](int source, int target, int size) {
+    SCOPED_TRACE(
+        fmt::format("source={} target={} size={}", source, target, size));
+    auto data = origin;
+    copyBitsBackward(data.data(), source, target, size);
+    for (int i = 0; i < data.size() * 64; ++i) {
+      int j = i;
+      if (target <= i && i < target + size) {
+        j = i - target + source;
+      }
+      ASSERT_EQ(isBitSet(data.data(), i), isBitSet(origin.data(), j))
+          << "i=" << i << " j=" << j;
+    }
+  };
+  for (int source = 0; source <= 64; ++source) {
+    for (int target = source + 1; target <= 64; ++target) {
+      for (int size = 128; size <= 138; ++size) {
+        test(source, target, size);
+      }
+    }
+  }
+}
+
+TEST_F(BitUtilTest, toString) {
+  uint64_t bits = 0x1234567890abcdef;
+  EXPECT_EQ(
+      toString(&bits, 0, 64),
+      "1111011110110011110101010000100100011110011010100010110001001000");
 }
 
 TEST_F(BitUtilTest, scatterBits) {


### PR DESCRIPTION
Summary:
This function can be used to copy bits between ranges that have overlap.

Also fix a bug in `copyBits` that possibly corrupts the bits after the destination range.

Differential Revision: D41861728

