### PR TITLE
Add array_union Presto Functions

### DIFF
--- a/velox/docs/functions/array.rst
+++ b/velox/docs/functions/array.rst
@@ -34,6 +34,13 @@ Array Functions
 
         select array_has_duplicates(ARRAY [5, 2, 5, 1, 1, 5, null, null])); -- true
 
+.. function:: array_union(x, y) -> array
+
+    Returns an array of the elements in the union of array ``x`` and array ``y``, without duplicates. ::
+
+        SELECT array_union(ARRAY ['c', 'a', null, 'b'], ARRAY ['b', 'a']); -- [c, a, null, b]
+        SELECT array_union(ARRAY [1, 2, 3, null, 4], ARRAY [3, 1, 5]); -- [1, 2, 3, null, 4, 5]
+
 .. function:: array_intersect(array(E) x, array(E) y) -> array(E)
 
     Returns an array of the elements in the intersection of array ``x`` and array ``y``, without duplicates. ::

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -58,6 +58,15 @@ inline void registerArrayHasDuplicatesFunctions() {
       Array<T>>({"array_has_duplicates"});
 }
 
+template <typename T>
+inline void registerArrayUnionFunctions() {
+  registerFunction<
+      ParameterBinder<ArrayUnionFunction, T>,
+      Array<T>,
+      Array<T>,
+      Array<T>>({"array_union"});
+}
+
 void registerArrayFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_constructor, "array_constructor");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_distinct, "array_distinct");
@@ -114,5 +123,16 @@ void registerArrayFunctions() {
   registerArrayHasDuplicatesFunctions<int32_t>();
   registerArrayHasDuplicatesFunctions<int64_t>();
   registerArrayHasDuplicatesFunctions<Varchar>();
+
+  registerArrayUnionFunctions<int8_t>();
+  registerArrayUnionFunctions<int16_t>();
+  registerArrayUnionFunctions<int32_t>();
+  registerArrayUnionFunctions<int64_t>();
+  registerArrayUnionFunctions<float>();
+  registerArrayUnionFunctions<double>();
+  registerArrayUnionFunctions<bool>();
+  registerArrayUnionFunctions<Varchar>();
+  registerArrayUnionFunctions<Timestamp>();
+  registerArrayUnionFunctions<Date>();
 }
 }; // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/ArrayUnionTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayUnionTest.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace {
+
+class ArrayUnionTest : public FunctionBaseTest {
+ protected:
+  // Evaluate an expression.
+  void testExpr(
+      const VectorPtr& expected,
+      const VectorPtr& array1,
+      const VectorPtr& array2) {
+    auto result = evaluate<ArrayVector>(
+        "array_union(c0, c1)", makeRowVector({array1, array2}));
+    assertEqualVectors(expected, result);
+  }
+
+  template <typename T>
+  void testNumerics() {
+    auto array1 = makeNullableArrayVector<T>(
+        {{1, std::nullopt, 2, 2, 4}, {5, std::nullopt, 6, 6}});
+    auto array2 =
+        makeNullableArrayVector<T>({{3, 1, std::nullopt, 2}, {9, 5, 6}});
+    auto expected = makeNullableArrayVector<T>(
+        {{1, std::nullopt, 2, 4, 3}, {5, std::nullopt, 6, 9}});
+    testExpr(expected, array1, array2);
+  }
+
+  template <typename T>
+  void testNullFreeNumerics() {
+    auto array1 = makeArrayVector<T>({{1, 2, 2, 4}, {5, 6, 6}});
+    auto array2 = makeArrayVector<T>({{3, 1, 2}, {9, 5, 6}});
+    auto expected = makeArrayVector<T>({{1, 2, 4, 3}, {5, 6, 9}});
+    testExpr(expected, array1, array2);
+  }
+};
+
+} // namespace
+
+TEST_F(ArrayUnionTest, numerics) {
+  testNumerics<int8_t>();
+  testNumerics<int16_t>();
+  testNumerics<int32_t>();
+  testNumerics<int64_t>();
+  testNumerics<float>();
+  testNumerics<double>();
+}
+
+TEST_F(ArrayUnionTest, strings) {
+  auto array1 = makeNullableArrayVector<StringView>(
+      {{"A", "B", "C", std::nullopt},
+       {"Sadly I stand on the toes of their predecessors, not on their shoulders.",
+        "E"}});
+  auto array2 = makeNullableArrayVector<StringView>(
+      {{std::nullopt, "C", "A", "E"},
+       {"E", "D", "Velox is a novel C++ database acceleration library"}});
+  auto expected = makeNullableArrayVector<StringView>(
+      {{"A", "B", "C", std::nullopt, "E"},
+       {"Sadly I stand on the toes of their predecessors, not on their shoulders.",
+        "E",
+        "D",
+        "Velox is a novel C++ database acceleration library"}});
+  testExpr(expected, array1, array2);
+}
+
+TEST_F(ArrayUnionTest, booleans) {
+  auto array1 = makeNullableArrayVector<bool>({{true, std::nullopt}, {false}});
+  auto array2 =
+      makeNullableArrayVector<bool>({{std::nullopt, false}, {std::nullopt}});
+  auto expected = makeNullableArrayVector<bool>(
+      {{true, std::nullopt, false}, {false, std::nullopt}});
+  testExpr(expected, array1, array2);
+}
+
+TEST_F(ArrayUnionTest, dates) {
+  using D = Date;
+  auto array1 = makeNullableArrayVector<Date>(
+      {{D{1}, std::nullopt, D{1024}}, {D{2}, D{2048}}});
+  auto array2 = makeNullableArrayVector<Date>(
+      {{
+           D{3},
+           std::nullopt,
+       },
+       {D{128}}});
+  auto expected = makeNullableArrayVector<Date>(
+      {{D{1}, std::nullopt, D{1024}, D{3}}, {D{2}, D{2048}, D{128}}});
+  testExpr(expected, array1, array2);
+}
+
+TEST_F(ArrayUnionTest, timestamps) {
+  using T = Timestamp;
+  auto array1 = makeNullableArrayVector<Timestamp>(
+      {{T{0, 1}, T{0, 1024}}, {T{1, 2}, std::nullopt, T{1, 2048}}});
+  auto array2 = makeNullableArrayVector<Timestamp>({{T{0, 3}}, {T{1, 128}}});
+  auto expected = makeNullableArrayVector<Timestamp>(
+      {{T{0, 1}, T{0, 1024}, T{0, 3}},
+       {T{1, 2}, std::nullopt, T{1, 2048}, T{1, 128}}});
+  testExpr(expected, array1, array2);
+}
+
+TEST_F(ArrayUnionTest, nullFreeNumerics) {
+  testNullFreeNumerics<int8_t>();
+  testNullFreeNumerics<int16_t>();
+  testNullFreeNumerics<int32_t>();
+  testNullFreeNumerics<int64_t>();
+  testNullFreeNumerics<float>();
+  testNullFreeNumerics<double>();
+}
+
+TEST_F(ArrayUnionTest, nullFreeBooleans) {
+  auto array1 = makeArrayVector<bool>({{true, true}, {false, true}});
+  auto array2 = makeArrayVector<bool>({{true}, {true, true}});
+  auto expected = makeArrayVector<bool>({{true}, {false, true}});
+  testExpr(expected, array1, array2);
+}
+
+TEST_F(ArrayUnionTest, nullFreeDates) {
+  using D = Date;
+  auto array1 = makeArrayVector<Date>({{D{1}, D{1024}}, {D{2}, D{2048}}});
+  auto array2 = makeArrayVector<Date>({{D{3}}, {D{128}}});
+  auto expected =
+      makeArrayVector<Date>({{D{1}, D{1024}, D{3}}, {D{2}, D{2048}, D{128}}});
+  testExpr(expected, array1, array2);
+}
+
+TEST_F(ArrayUnionTest, nullFreeTimestamps) {
+  using T = Timestamp;
+  auto array1 = makeArrayVector<Timestamp>(
+      {{T{0, 1}, T{0, 1024}}, {T{1, 2}, T{1, 2048}}});
+  auto array2 = makeArrayVector<Timestamp>({{T{0, 3}}, {T{1, 128}}});
+  auto expected = makeArrayVector<Timestamp>(
+      {{T{0, 1}, T{0, 1024}, T{0, 3}}, {T{1, 2}, T{1, 2048}, T{1, 128}}});
+  testExpr(expected, array1, array2);
+}
+
+TEST_F(ArrayUnionTest, nullFreeStrings) {
+  auto array1 = makeArrayVector<StringView>(
+      {{"A", "B", "C"},
+       {"Sadly I stand on the toes of their predecessors, not on their shoulders.",
+        "E"}});
+  auto array2 = makeArrayVector<StringView>(
+      {{"C", "A", "E"},
+       {"E", "D", "Velox is a novel C++ database acceleration library"}});
+  auto expected = makeArrayVector<StringView>(
+      {{"A", "B", "C", "E"},
+       {"Sadly I stand on the toes of their predecessors, not on their shoulders.",
+        "E",
+        "D",
+        "Velox is a novel C++ database acceleration library"}});
+  testExpr(expected, array1, array2);
+}

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(
   ArraySortTest.cpp
   ArraysOverlapTest.cpp
   ArraySumTest.cpp
+  ArrayUnionTest.cpp
   BitwiseTest.cpp
   CardinalityTest.cpp
   CeilFloorTest.cpp


### PR DESCRIPTION
array_union(x, y) → array[#](https://prestodb.io/docs/current/functions/array.html#array_union)
Returns an array of the elements in the union of x and y, without duplicates.

```SQL
SELECT array_union(ARRAY ['c', 'a', null, 'b'], ARRAY ['b', 'a']); -- [c, a, null, b]
SELECT array_union(ARRAY [1, 2, 3, null, 4], ARRAY [3, 1, 5]); -- [1, 2, 3, null, 4, 5]
```