### PR TITLE
Add hmac_sha1 Presto Functions

### DIFF
--- a/velox/docs/functions/binary.rst
+++ b/velox/docs/functions/binary.rst
@@ -22,6 +22,10 @@ Binary Functions
 
     Computes the SHA-512 hash of ``binary``.
 
+.. function:: hmac_sha1(binary, key) -> varbinary
+
+    Computes the HMAC with sha1 of ``binary`` with the given ``key``.
+
 .. function:: hmac_sha256(binary, key) -> varbinary
 
     Computes the HMAC with sha256 of ``binary`` with the given ``key``.

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -288,6 +288,17 @@ FOLLY_ALWAYS_INLINE void sha512(TOutString& output, const TInString& input) {
       folly::ByteRange((const uint8_t*)input.data(), input.size()));
 }
 
+// Compute the HMAC-SHA1 Hash.
+template <typename TOutString, typename TInString>
+FOLLY_ALWAYS_INLINE void
+HmacSha1(TOutString& output, const TInString& key, const TInString& data) {
+  output.resize(20);
+  folly::ssl::OpenSSLHash::hmac_sha1(
+      folly::MutableByteRange((uint8_t*)output.data(), output.size()),
+      folly::ByteRange((const uint8_t*)key.data(), key.size()),
+      folly::ByteRange((const uint8_t*)data.data(), data.size()));
+}
+
 // Compute the HMAC-SHA256 Hash.
 template <typename TOutString, typename TInString>
 FOLLY_ALWAYS_INLINE bool

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -120,6 +120,18 @@ struct Sha512Function {
   }
 };
 
+/// hmac_sha1(varbinary) -> varbinary
+template <typename T>
+struct HmacSha1Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  template <typename TOuput, typename TInput>
+  FOLLY_ALWAYS_INLINE void
+  call(TOuput& result, const TInput& data, const TInput& key) {
+    return stringImpl::HmacSha1(result, key, data);
+  }
+};
+
 /// sha1(varbinary) -> varbinary
 template <typename T>
 struct HmacSha256Function {

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -60,6 +60,8 @@ void registerSimpleFunctions() {
   registerFunction<Md5Function, Varbinary, Varbinary>({"md5"});
   registerFunction<Sha256Function, Varbinary, Varbinary>({"sha256"});
   registerFunction<Sha512Function, Varbinary, Varbinary>({"sha512"});
+  registerFunction<HmacSha1Function, Varbinary, Varbinary, Varbinary>(
+      {"hmac_sha1"});
   registerFunction<HmacSha256Function, Varbinary, Varbinary, Varbinary>(
       {"hmac_sha256"});
 

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1201,6 +1201,34 @@ TEST_F(StringFunctionsTest, sha512) {
   EXPECT_EQ(std::nullopt, sha512(std::nullopt));
 }
 
+TEST_F(StringFunctionsTest, HmacSha1) {
+  const auto hmacSha1 = [&](std::optional<std::string> arg,
+                            std::optional<std::string> key) {
+    return evaluateOnce<std::string, std::string>(
+        "hmac_sha1(c0, c1)", {arg, key}, {VARBINARY(), VARBINARY()});
+  };
+  // Use python hmac lib results as the expected value.
+  // >>> import hmac
+  // >>> def sha1(data, key):
+  //         print(hmac.new(key, data, digestmod='sha1').hexdigest())
+  // >>> sha1(b"hashme", b"velox")
+  // d49c944625bdde6c47ad93ea63952bfcf16a630a
+  // >>> sha1(b"Infinity", b"velox")
+  // c19b6b753fe4ac28579c7e84d18feb29760a0d1c
+  // >>> sha1(b"", b"velox")
+  // d0569c4a4f3df995b04ec497b12872c4a2f97517
+  EXPECT_EQ(
+      hexToDec("d49c944625bdde6c47ad93ea63952bfcf16a630a"),
+      hmacSha1("hashme", "velox"));
+  EXPECT_EQ(
+      hexToDec("c19b6b753fe4ac28579c7e84d18feb29760a0d1c"),
+      hmacSha1("Infinity", "velox"));
+  EXPECT_EQ(
+      hexToDec("d0569c4a4f3df995b04ec497b12872c4a2f97517"),
+      hmacSha1("", "velox"));
+  EXPECT_EQ(std::nullopt, hmacSha1(std::nullopt, "velox"));
+}
+
 TEST_F(StringFunctionsTest, HmacSha256) {
   const auto hmacSha256 = [&](std::optional<std::string> arg,
                               std::optional<std::string> key) {


### PR DESCRIPTION
Add [hmac_sha1](https://prestodb.io/docs/current/functions/binary.html#:~:text=given%20key.-,hmac_sha1,-(binary%2C)) Presto Functions

```
hmac_sha1(binary, key) → varbinary
     Computes HMAC with sha1 of binary with the given key.
```