### PR TITLE
Avoid to install x86 dependencies with brew for Mac M1

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -60,7 +60,18 @@ function update_brew {
   /usr/local/bin/brew update --force --quiet
 }
 
+function check_brew_arch_consistency {
+  if [[ ${CPU_TARGET} == "arm64" ]] && [[ $(arch) == "i386" ]];
+  then
+    echo "Avoid to install x86 dependencies with brew for Mac M1"
+    exit 1
+  fi
+}
+
 function install_build_prerequisites {
+
+  run_and_time check_brew_arch_consistency
+
   for pkg in ${MACOS_DEPS}
   do
     if [[ "${pkg}" =~ ^([0-9a-z-]*):([0-9](\.[0-9\])*)$ ]];


### PR DESCRIPTION
When use iTerm with Rosetta2, you installed homebrew may be x86-version.
Under this case, the setup-macos.sh may install x86 dependencies, even you set CPU_TARGET="arm64"
The terrible thing is that you have to reinstall you homebrew to arm64 and all dependencies installed by the previous homebrew.

This will cause this issue. 
https://github.com/facebookincubator/velox/issues/2764 

