### PR TITLE
Back out "Fix MemoryAllocator singleton access race"

### DIFF
--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -473,16 +473,13 @@ bool MemoryAllocatorImpl::checkConsistency() const {
 
 // static
 MemoryAllocator* MemoryAllocator::getInstance() {
-  {
-    folly::SharedMutex::ReadHolder readGuard(instanceMutex_);
-    if (customInstance_) {
-      return customInstance_;
-    }
-    if (instance_) {
-      return instance_.get();
-    }
+  if (customInstance_) {
+    return customInstance_;
   }
-  folly::SharedMutex::WriteHolder writeGuard(instanceMutex_);
+  if (instance_) {
+    return instance_.get();
+  }
+  std::lock_guard<std::mutex> l(initMutex_);
   if (instance_) {
     return instance_.get();
   }
@@ -497,13 +494,11 @@ std::shared_ptr<MemoryAllocator> MemoryAllocator::createDefaultInstance() {
 
 // static
 void MemoryAllocator::setDefaultInstance(MemoryAllocator* instance) {
-  folly::SharedMutex::WriteHolder writeGuard(instanceMutex_);
   customInstance_ = instance;
 }
 
 // static
 void MemoryAllocator::testingDestroyInstance() {
-  folly::SharedMutex::WriteHolder writeGuard(instanceMutex_);
   instance_ = nullptr;
 }
 

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <gflags/gflags.h>
 #include <array>
 #include <atomic>
 #include <cstdint>
@@ -24,7 +23,7 @@
 #include <mutex>
 #include <unordered_set>
 
-#include "folly/SharedMutex.h"
+#include <gflags/gflags.h>
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/memory/MemoryUsageTracker.h"
@@ -583,7 +582,7 @@ class MemoryAllocator : std::enable_shared_from_this<MemoryAllocator> {
   inline static std::atomic<uint64_t> totalLargeAllocateBytes_;
 
  private:
-  inline static folly::SharedMutex instanceMutex_;
+  inline static std::mutex initMutex_;
   // Singleton instance.
   inline static std::shared_ptr<MemoryAllocator> instance_;
   // Application-supplied custom implementation of MemoryAllocator to be


### PR DESCRIPTION
Summary:
Original commit changeset: 806823359736

Original Phabricator Diff: D41914224 (https://github.com/facebookincubator/velox/commit/e84e6797fd8ab12b2db717ba5720008f4677f049)

A bisect points to this diff causing test flakiness. I don't believe it, but I don't have time to investigate for the week. Unland for now and landing later when I can specifically try to repro the flakiness.

Reviewed By: xiaoxmeng

Differential Revision: D41968097

