### PR TITLE
Adding Task::spillDir_.

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -285,8 +285,9 @@ class QueryConfig {
   /// composed of Task id and serial numbers. The files are automatically
   /// deleted when no longer needed. Files may be left behind after crashes but
   /// are identifiable based on the Task id in the name.
+  /// TODO(spershin): This method and kSpillPath will be removed.
   std::optional<std::string> spillPath() const {
-    return get<std::string>(kSpillPath, "/tmp");
+    return get<std::string>(kSpillPath);
   }
 
   /// Returns 'is aggregation spilling enabled' flag. Must also check the

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -96,7 +96,7 @@ std::optional<Spiller::Config> OperatorCtx::makeSpillConfig(
   if (!queryConfig.spillEnabled()) {
     return std::nullopt;
   }
-  if (!queryConfig.spillPath().has_value()) {
+  if (driverCtx_->task->spillDirectory().empty()) {
     return std::nullopt;
   }
   switch (type) {
@@ -124,8 +124,8 @@ std::optional<Spiller::Config> OperatorCtx::makeSpillConfig(
 
   return Spiller::Config(
       makeOperatorSpillPath(
-          queryConfig.spillPath().value(),
-          taskId(),
+          driverCtx_->task->spillDirectory(),
+          driverCtx()->pipelineId,
           driverCtx()->driverId,
           operatorId_),
       queryConfig.maxSpillFileSize(),

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -336,12 +336,12 @@ void gatherCopy(
 }
 
 std::string makeOperatorSpillPath(
-    const std::string& spillPath,
-    const std::string& taskId,
+    const std::string& spillDir,
+    int pipelineId,
     int driverId,
     int32_t operatorId) {
-  VELOX_CHECK(!spillPath.empty());
-  return fmt::format("{}/{}_{}_{}", spillPath, taskId, driverId, operatorId);
+  VELOX_CHECK(!spillDir.empty());
+  return fmt::format("{}/{}_{}_{}", spillDir, pipelineId, driverId, operatorId);
 }
 
 void addOperatorRuntimeStats(

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -111,8 +111,8 @@ void gatherCopy(
 /// not. It is assumed that the disk spilling file hierarchy for an operator is
 /// flat.
 std::string makeOperatorSpillPath(
-    const std::string& spillPath,
-    const std::string& taskId,
+    const std::string& spillDir,
+    int pipelineId,
     int driverId,
     int32_t operatorId);
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -67,6 +67,12 @@ class Task : public std::enable_shared_from_this<Task> {
 
   ~Task();
 
+  /// Specify directory to which data will be spilled if spilling is enabled and
+  /// required.
+  void setSpillDirectory(const std::string& spillDirectory) {
+    spillDirectory_ = spillDirectory;
+  }
+
   std::string toString() const;
 
   /// Returns universally unique identifier of the task.
@@ -492,6 +498,10 @@ class Task : public std::enable_shared_from_this<Task> {
     return numDeletedTasks_;
   }
 
+  const std::string& spillDirectory() const {
+    return spillDirectory_;
+  }
+
   /// Invoked to wait for all the tasks created by the test to be deleted.
   ///
   /// NOTE: it is assumed that there is no more task to be created after or
@@ -842,6 +852,9 @@ class Task : public std::enable_shared_from_this<Task> {
   // terminate(). They are fulfilled when the last thread stops
   // running for 'this'.
   std::vector<ContinuePromise> threadFinishPromises_;
+
+  /// Base spill directory for this task.
+  std::string spillDirectory_;
 };
 
 /// Listener invoked on task completion.

--- a/velox/exec/tests/AggregationFuzzer.cpp
+++ b/velox/exec/tests/AggregationFuzzer.cpp
@@ -601,10 +601,10 @@ ResultOrError AggregationFuzzer::execute(
     AssertQueryBuilder builder(plan);
     if (injectSpill) {
       spillDirectory = exec::test::TempDirectoryPath::create();
-      builder.config(core::QueryConfig::kSpillEnabled, "true")
+      builder.spillDirectory(spillDirectory->path)
+          .config(core::QueryConfig::kSpillEnabled, "true")
           .config(core::QueryConfig::kAggregationSpillEnabled, "true")
-          .config(core::QueryConfig::kTestingSpillPct, "100")
-          .config(core::QueryConfig::kSpillPath, spillDirectory->path);
+          .config(core::QueryConfig::kTestingSpillPct, "100");
     }
     resultOrError.result = builder.maxDrivers(2).copyResults(pool_.get());
     LOG(INFO) << resultOrError.result->toString();

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -873,9 +873,9 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
                         .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
                         .planNode())
                     .queryCtx(queryCtx)
+                    .spillDirectory(tempDirectory->path)
                     .config(QueryConfig::kSpillEnabled, "true")
                     .config(QueryConfig::kAggregationSpillEnabled, "true")
-                    .config(QueryConfig::kSpillPath, tempDirectory->path)
                     .config(
                         QueryConfig::kAggregationSpillMemoryThreshold,
                         std::to_string(testData.aggregationMemLimit))
@@ -981,9 +981,9 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
                                .singleAggregation({"c0"}, {"array_agg(c1)"})
                                .planNode())
             .queryCtx(queryCtx)
+            .spillDirectory(tempDirectory->path)
             .config(QueryConfig::kSpillEnabled, "true")
             .config(QueryConfig::kAggregationSpillEnabled, "true")
-            .config(QueryConfig::kSpillPath, tempDirectory->path)
             .config(QueryConfig::kMinSpillRunSize, std::to_string(1000'000'000))
             .config(
                 QueryConfig::kSpillPartitionBits,
@@ -1092,9 +1092,9 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
                              .singleAggregation({"c0"}, {"array_agg(c1)"})
                              .planNode())
           .queryCtx(queryCtx)
+          .spillDirectory(tempDirectory->path)
           .config(QueryConfig::kSpillEnabled, "true")
           .config(QueryConfig::kAggregationSpillEnabled, "true")
-          .config(QueryConfig::kSpillPath, tempDirectory->path)
           .config(
               QueryConfig::kSpillPartitionBits, std::to_string(kPartitionsBits))
           // Set to increase the hash table a little bit to only trigger spill
@@ -1330,11 +1330,11 @@ TEST_F(AggregationTest, outputBatchSizeCheckWithSpill) {
                                .values(batches)
                                .singleAggregation({"c0", "c1"}, {"sum(c2)"})
                                .planNode())
+            .spillDirectory(tempDirectory->path)
             .config(QueryConfig::kSpillEnabled, "true")
             .config(QueryConfig::kAggregationSpillEnabled, "true")
             // Set one spill partition to avoid the test flakiness.
             .config(QueryConfig::kSpillPartitionBits, "0")
-            .config(QueryConfig::kSpillPath, tempDirectory->path)
             .config(
                 QueryConfig::kPreferredOutputBatchSize,
                 std::to_string(outputBufferSize))
@@ -1355,9 +1355,9 @@ TEST_F(AggregationTest, distinctWithSpilling) {
   auto spillDirectory = exec::test::TempDirectoryPath::create();
   core::PlanNodeId aggrNodeId;
   auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .spillDirectory(spillDirectory->path)
                   .config(QueryConfig::kSpillEnabled, "true")
                   .config(QueryConfig::kAggregationSpillEnabled, "true")
-                  .config(QueryConfig::kSpillPath, spillDirectory->path)
                   .config(QueryConfig::kTestingSpillPct, "100")
                   .plan(PlanBuilder()
                             .values(vectors)
@@ -1385,9 +1385,9 @@ TEST_F(AggregationTest, preGroupedAggregationWithSpilling) {
   core::PlanNodeId aggrNodeId;
   auto task =
       AssertQueryBuilder(duckDbQueryRunner_)
+          .spillDirectory(spillDirectory->path)
           .config(QueryConfig::kSpillEnabled, "true")
           .config(QueryConfig::kAggregationSpillEnabled, "true")
-          .config(QueryConfig::kSpillPath, spillDirectory->path)
           .config(QueryConfig::kTestingSpillPct, "100")
           .plan(PlanBuilder()
                     .values(vectors)

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -587,11 +587,11 @@ class HashJoinBuilder {
     std::shared_ptr<TempDirectoryPath> spillDirectory;
     if (injectSpill) {
       spillDirectory = exec::test::TempDirectoryPath::create();
+      builder.spillDirectory(spillDirectory->path);
       config(core::QueryConfig::kSpillEnabled, "true");
       config(core::QueryConfig::kMaxSpillLevel, std::to_string(maxSpillLevel));
       config(core::QueryConfig::kJoinSpillEnabled, "true");
       config(core::QueryConfig::kTestingSpillPct, "100");
-      config(core::QueryConfig::kSpillPath, spillDirectory->path);
     } else {
       config(core::QueryConfig::kSpillEnabled, "false");
     }

--- a/velox/exec/tests/JoinFuzzer.cpp
+++ b/velox/exec/tests/JoinFuzzer.cpp
@@ -265,7 +265,7 @@ RowVectorPtr JoinFuzzer::execute(
     builder.config(core::QueryConfig::kSpillEnabled, "true")
         .config(core::QueryConfig::kAggregationSpillEnabled, "true")
         .config(core::QueryConfig::kTestingSpillPct, "100")
-        .config(core::QueryConfig::kSpillPath, spillDirectory->path);
+        .spillDirectory(spillDirectory->path);
   }
 
   auto result = builder.maxDrivers(2).copyResults(pool_.get());

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -204,7 +204,7 @@ TEST_F(OperatorUtilsTest, gatherCopy) {
 }
 
 TEST_F(OperatorUtilsTest, makeOperatorSpillPath) {
-  EXPECT_EQ("spill/task_1_100", makeOperatorSpillPath("spill", "task", 1, 100));
+  EXPECT_EQ("spill/3_1_100", makeOperatorSpillPath("spill", 3, 1, 100));
 }
 
 TEST_F(OperatorUtilsTest, wrap) {

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -84,6 +84,14 @@ class AssertQueryBuilder {
     params_.queryCtx = ctx;
     return *this;
   }
+
+  /// Spilling directory, if not empty, then the task's spilling directory would
+  /// be built from it.
+  AssertQueryBuilder& spillDirectory(const std::string& dir) {
+    params_.spillDirectory = dir;
+    return *this;
+  }
+
   // Methods to run the query and verify the results.
 
   /// Run the query and verify results against DuckDB. Requires

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -45,6 +45,10 @@ struct CursorParameters {
   // Number of splits groups the task will be processing. Must be 1 for
   // ungrouped execution.
   int numSplitGroups{1};
+
+  /// Spilling directory, if not empty, then the task's spilling directory would
+  /// be built from it.
+  std::string spillDirectory;
 };
 
 class TaskQueue {

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -160,7 +160,7 @@ void AggregationTestBase::testAggregations(
     queryBuilder.config(core::QueryConfig::kTestingSpillPct, "100")
         .config(core::QueryConfig::kSpillEnabled, "true")
         .config(core::QueryConfig::kAggregationSpillEnabled, "true")
-        .config(core::QueryConfig::kSpillPath, spillDirectory->path)
+        .spillDirectory(spillDirectory->path)
         .maxDrivers(4);
 
     auto task = assertResults(queryBuilder);
@@ -206,7 +206,7 @@ void AggregationTestBase::testAggregations(
     queryBuilder.config(core::QueryConfig::kTestingSpillPct, "100")
         .config(core::QueryConfig::kSpillEnabled, "true")
         .config(core::QueryConfig::kAggregationSpillEnabled, "true")
-        .config(core::QueryConfig::kSpillPath, spillDirectory->path);
+        .spillDirectory(spillDirectory->path);
 
     auto task = assertResults(queryBuilder);
 


### PR DESCRIPTION
Summary:
Adding Task::spillDir_ which will hold the unique spilling
path for the task. This path would be given to the Task by the
application that uses Velox.
Using Task::spillDir_ to construct the complete spilling path for
the operator.
Currently in Presto Native the Task::spillDir_ would be empty until
the follow up change is landed which set it during the Task creation.

Differential Revision: D41895734

