### PR TITLE
Do not throw from PartitionedOutputBufferManager::getData

### DIFF
--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -544,7 +544,14 @@ void PartitionedOutputBufferManager::getData(
     uint64_t maxBytes,
     int64_t sequence,
     DataAvailableCallback notify) {
-  getBuffer(taskId)->getData(destination, maxBytes, sequence, notify);
+  std::shared_ptr<PartitionedOutputBuffer> buffer;
+  try {
+    buffer = getBuffer(taskId);
+  } catch (const VeloxException& e) {
+    notify({}, sequence);
+    return;
+  }
+  buffer->getData(destination, maxBytes, sequence, notify);
 }
 
 void PartitionedOutputBufferManager::initializeTask(

--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -533,8 +533,7 @@ void PartitionedOutputBufferManager::acknowledge(
 void PartitionedOutputBufferManager::deleteResults(
     const std::string& taskId,
     int destination) {
-  auto buffer = getBufferIfExists(taskId);
-  if (buffer) {
+  if (auto buffer = getBufferIfExists(taskId)) {
     buffer->deleteResults(destination);
   }
 }
@@ -545,8 +544,7 @@ bool PartitionedOutputBufferManager::getData(
     uint64_t maxBytes,
     int64_t sequence,
     DataAvailableCallback notify) {
-  auto buffer = getBufferIfExists(taskId);
-  if (buffer) {
+  if (auto buffer = getBufferIfExists(taskId)) {
     buffer->getData(destination, maxBytes, sequence, notify);
     return true;
   }

--- a/velox/exec/PartitionedOutputBufferManager.h
+++ b/velox/exec/PartitionedOutputBufferManager.h
@@ -266,10 +266,11 @@ class PartitionedOutputBufferManager {
 
  private:
   // Retrieves the set of buffers for a query.
+  // Throws an exception if buffer doesn't exist.
   std::shared_ptr<PartitionedOutputBuffer> getBuffer(const std::string& taskId);
 
-  // Retrieves the set of buffers for a query if exists. If taskId is not found,
-  // returns NULL.
+  // Retrieves the set of buffers for a query if exists.
+  // Returns NULL if task not found.
   std::shared_ptr<PartitionedOutputBuffer> getBufferIfExists(
       const std::string& taskId);
 


### PR DESCRIPTION
A task being executed by multiple drivers, and if one of the drivers catches an
exception, can terminate the task. This termination will remove any
PartitionedOutputBuffer assigned to that taskId. In a parallel thread, the task
manager may try to access this buffer leading to "Output buffers not found"
exception. This exception is valid, but instead of the exception encountered by
the Driver trickling up to the user, the "Output buffers not found" exception
may sometimes get thrown to the user. 

Instead of throwing exception, the getData() will return
a bool indicating whether a matching buffer for a given task id was found or not.


See #3009 for more context.