### PR TITLE
Print out which path throws exceptions in fuzzer test

### DIFF
--- a/velox/expression/tests/FuzzerToolkit.cpp
+++ b/velox/expression/tests/FuzzerToolkit.cpp
@@ -128,7 +128,8 @@ void compareExceptions(
     std::exception_ptr simplifiedPtr) {
   // If we don't have two exceptions, fail.
   if (!commonPtr || !simplifiedPtr) {
-    LOG(ERROR) << "Only one path threw exception:";
+    LOG(ERROR) << "Only " << (commonPtr ? "common" : "simplified")
+               << " path threw exception:";
     if (commonPtr) {
       std::rethrow_exception(commonPtr);
     } else {


### PR DESCRIPTION
Summary: Let fuzzer test to print out which evaluation path throws the exception when only one path throws. This allows developers to get an insight about a fuzzer test failure before investigating it.

Reviewed By: Yuhta, kgpai

Differential Revision: D41969004

