### PR TITLE
Always return NULL from subscript operator on empty arrays

### DIFF
--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -247,6 +247,11 @@ class SubscriptImpl : public exec::VectorFunction {
       const vector_size_t* indices) const {
     auto arraySize = rawSizes[indices[row]];
 
+    // Subscript into empty arrays always returns NULLs.
+    if (arraySize == 0) {
+      return -1;
+    }
+
     if (index < 0) {
       // Check if we allow negative indices. If so, adjust.
       if constexpr (allowNegativeIndices) {

--- a/velox/functions/prestosql/tests/ElementAtTest.cpp
+++ b/velox/functions/prestosql/tests/ElementAtTest.cpp
@@ -593,3 +593,58 @@ TEST_F(ElementAtTest, emptyElementVector) {
     test::assertEqualVectors(expected, result);
   }
 }
+
+TEST_F(ElementAtTest, emptyContainer) {
+  // Accessing an element in an empty container should always return NULL,
+  // regardless of the index value.
+  auto keys = makeFlatVector<int64_t>(std::vector<int64_t>{1});
+  auto values = makeFlatVector<int64_t>(std::vector<int64_t>{2});
+
+  auto offsets = allocateOffsets(2, pool());
+  auto rawOffsets = offsets->asMutable<vector_size_t>();
+  rawOffsets[0] = 0;
+  rawOffsets[1] = 0;
+
+  auto sizes = allocateSizes(2, pool());
+  auto rawSizes = sizes->asMutable<vector_size_t>();
+  rawSizes[0] = 0;
+  rawSizes[1] = 1;
+
+  // Our Vectors have 2 elements but we only evaluate on the first, this way the
+  // elements aren't empty though the collection we're evaluating on is.
+  SelectivityVector rows(1);
+
+  VectorPtr result;
+
+  // Test map vector.
+  {
+    auto map = std::make_shared<MapVector>(
+        pool(),
+        MAP(BIGINT(), BIGINT()),
+        nullptr,
+        2,
+        offsets,
+        sizes,
+        keys,
+        values);
+    auto expected = makeNullConstant(TypeKind::BIGINT, 1);
+
+    evaluate<SimpleVector<int64_t>>(
+        "element_at(c0, -1)", makeRowVector({map}), rows, result);
+    test::assertEqualVectors(expected, result);
+    evaluate<SimpleVector<int64_t>>(
+        "c0[-1]", makeRowVector({map}), rows, result);
+    test::assertEqualVectors(expected, result);
+  }
+
+  // Test array vector.
+  {
+    auto array = std::make_shared<ArrayVector>(
+        pool(), ARRAY(BIGINT()), nullptr, 2, offsets, sizes, values);
+    auto expected = makeNullConstant(TypeKind::BIGINT, 1);
+
+    evaluate<SimpleVector<int64_t>>(
+        "element_at(c0, -1)", makeRowVector({array}), rows, result);
+    test::assertEqualVectors(expected, result);
+  }
+}


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/velox/pull/3284 changed the behavior of subscript operators so if an array is empty any subscript access (regardless of value) returns NULL.

The way it was written, this only applies if all the arrays in a batch are empty.  This change makes it so it applies consistently if only a subset of arrays are empty.

This inconsistency in behavior was identified in https://github.com/facebookincubator/velox/issues/3490

Differential Revision: D42021583

