### PR TITLE
Back out "Add json_format Presto function" (#3508)

### DIFF
--- a/velox/docs/functions/json.rst
+++ b/velox/docs/functions/json.rst
@@ -133,13 +133,6 @@ JSON Functions
         SELECT json_size('{"x": [1, 2, 3]}', '$.x'); -- 3
         SELECT json_size('{"x": {"a": 1, "b": 2}}', '$.x.a'); -- 0
 
-.. function:: json_format(json) -> varchar
-
-    Serializes the input JSON value to JSON text conforming to RFC 7159.
-    The JSON value can be a JSON object, a JSON array, a JSON string, a JSON number, true, false or null
-
-        SELECT json_format(JSON '{"a": 1, "b": 2}')
-
 ============
 JSON Vectors
 ============

--- a/velox/functions/prestosql/JsonFunctions.h
+++ b/velox/functions/prestosql/JsonFunctions.h
@@ -21,18 +21,6 @@
 namespace facebook::velox::functions {
 
 template <typename T>
-struct JsonFormatFunction {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-
-  FOLLY_ALWAYS_INLINE void call(
-      out_type<Varchar>& jsonString,
-      const arg_type<Json>& json) {
-    folly::parseJson(json.getString());
-    jsonString.setNoCopy(json);
-  }
-};
-
-template <typename T>
 struct IsJsonScalarFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -35,7 +35,6 @@ void registerJsonFunctions() {
   registerFunction<JsonArrayContainsFunction, bool, Json, Varchar>(
       {"json_array_contains"});
   registerFunction<JsonSizeFunction, int64_t, Json, Varchar>({"json_size"});
-  registerFunction<JsonFormatFunction, Varchar, Json>({"json_format"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -58,37 +58,6 @@ class JsonFunctionsTest : public functions::test::FunctionBaseTest {
   }
 };
 
-TEST_F(JsonFunctionsTest, JsonFormat) {
-  const auto json_format = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string, std::string>(
-        "json_format(c0)", {value}, {JSON()});
-  };
-
-  EXPECT_EQ(json_format(R"(true)"), "true");
-  EXPECT_EQ(json_format(R"(null)"), "null");
-  EXPECT_EQ(json_format(R"(42)"), "42");
-  EXPECT_EQ(json_format(R"("abc")"), "\"abc\"");
-  EXPECT_EQ(json_format(R"([1, 2, 3])"), "[1, 2, 3]");
-  EXPECT_EQ(json_format(R"({"k1":"v1"})"), "{\"k1\":\"v1\"}");
-
-  // check keys and values are there
-  const std::string jsonStr = json_format(R"({"k1":"v1","k2":"v2"})").value();
-  folly::dynamic object = folly::parseJson(jsonStr);
-
-  std::set<std::string> keys{"k1", "k2"};
-
-  for (const auto& key : object.keys()) {
-    EXPECT_TRUE(keys.find(key.getString()) != keys.end());
-  }
-
-  std::unordered_map<std::string, std::string> jsonMap{
-      {"k1", "v1"}, {"k2", "v2"}};
-
-  for (const auto& key : jsonMap) {
-    EXPECT_EQ(object.at(key.first), jsonMap.at(key.first));
-  }
-}
-
 TEST_F(JsonFunctionsTest, isJsonScalarSignatures) {
   auto signatures = getSignatureStrings("is_json_scalar");
   ASSERT_EQ(1, signatures.size());


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/velox/pull/3508

The implementation of json_format() uses the setNoCopy() API to avoid copying strings 
from the input to the output vector. But it forgets to copy the string buffer to the output 
vector as well. This causes some memory bugs that fails Velox fuzzer test in CircleCI. We 
back out this change now and will add it back after we fix it.

Original commit changeset: f2cc011a4b03

Original Phabricator Diff: D41643635 (https://github.com/facebookincubator/velox/commit/e2802d7dd78019c8578f1fd8ab814f98864a3834)

Differential Revision: D42020592

