### PR TITLE
Remove mutex for accessing default memory allocator

### DIFF
--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -28,6 +28,15 @@
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::memory {
+
+namespace {
+std::shared_ptr<MemoryAllocator>& getDefaultInstance() {
+  static std::shared_ptr<MemoryAllocator> instance_ =
+      MemoryAllocator::createDefaultInstance();
+  return instance_;
+}
+} // namespace
+
 /*static*/
 void MemoryAllocator::validateAlignment(uint16_t alignment) {
   if (alignment == 0) {
@@ -476,15 +485,7 @@ MemoryAllocator* MemoryAllocator::getInstance() {
   if (customInstance_) {
     return customInstance_;
   }
-  if (instance_) {
-    return instance_.get();
-  }
-  std::lock_guard<std::mutex> l(initMutex_);
-  if (instance_) {
-    return instance_.get();
-  }
-  instance_ = createDefaultInstance();
-  return instance_.get();
+  return getDefaultInstance().get();
 }
 
 // static
@@ -498,8 +499,8 @@ void MemoryAllocator::setDefaultInstance(MemoryAllocator* instance) {
 }
 
 // static
-void MemoryAllocator::testingDestroyInstance() {
-  instance_ = nullptr;
+void MemoryAllocator::testingResetDefaultInstance() {
+  getDefaultInstance() = MemoryAllocator::createDefaultInstance();
 }
 
 // static

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -173,7 +173,9 @@ class MemoryAllocator : std::enable_shared_from_this<MemoryAllocator> {
   /// process default.
   static std::shared_ptr<MemoryAllocator> createDefaultInstance();
 
-  static void testingDestroyInstance();
+  /// Recreate default memory allocator instance for testing purpose.
+  /// This is NOT threadsafe.
+  static void testingResetDefaultInstance();
 
   MemoryAllocator() = default;
   virtual ~MemoryAllocator() = default;
@@ -582,9 +584,6 @@ class MemoryAllocator : std::enable_shared_from_this<MemoryAllocator> {
   inline static std::atomic<uint64_t> totalLargeAllocateBytes_;
 
  private:
-  inline static std::mutex initMutex_;
-  // Singleton instance.
-  inline static std::shared_ptr<MemoryAllocator> instance_;
   // Application-supplied custom implementation of MemoryAllocator to be
   // returned by getInstance().
   inline static MemoryAllocator* FOLLY_NULLABLE customInstance_;

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -38,7 +38,7 @@ class ByteStreamTest : public testing::TestWithParam<bool> {
   }
 
   void TearDown() override {
-    MmapAllocator::testingDestroyInstance();
+    MmapAllocator::testingResetDefaultInstance();
     MemoryAllocator::setDefaultInstance(nullptr);
   }
 

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -166,7 +166,7 @@ class MemoryAllocatorTest : public testing::TestWithParam<TestParam> {
   }
 
   void SetUp() override {
-    MemoryAllocator::testingDestroyInstance();
+    MemoryAllocator::testingResetDefaultInstance();
     useMmap_ = GetParam().useMmap;
     if (useMmap_) {
       MmapAllocatorOptions options;
@@ -195,7 +195,7 @@ class MemoryAllocatorTest : public testing::TestWithParam<TestParam> {
   }
 
   void TearDown() override {
-    MemoryAllocator::testingDestroyInstance();
+    MemoryAllocator::testingResetDefaultInstance();
   }
 
   bool allocate(int32_t numPages, MemoryAllocator::Allocation& result) {


### PR DESCRIPTION
Summary:
# Problem

We have race conditions in accessing default memory allocator. I'm seeing some problems

- We have unprotected access to the shared pointer, which COULD have race condition in updating it.
- We have read lock read pattern here, but `shared_ptr` operation is NOT atomic.
- Other update function (`testingDestroyInstance()`) ignores the mutex.
- We always compare if the instance exists, which we can avoid

# Solution
In this diff, __I'm suggesting remove the mutex, and rely on static memory initialization.__

This diff solves the problem this way:
- When we need it, we use static memory initialization to have a single instance.
- We do not worry about the instance, and use it without checking, which means faster.
- Only when we need to update (testing), we can push a new instance, instead of making it null.

I believe this would solve all race conditions that we observed in our testing.

Does it make sense?

Differential Revision: D42046654

