### PR TITLE
Optimize redundant shared pointer copying/moving during constant vector wrapping.

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1262,7 +1262,7 @@ void Expr::evalAll(
 
   // Write non-selected rows in remainingRows as nulls in the result if some
   // rows have been skipped.
-  if (mutableRemainingRows != nullptr) {
+  if (mutableRemainingRows && !mutableRemainingRows->isAllSelected()) {
     addNulls(rows, mutableRemainingRows->asRange().bits(), context, result);
   }
   releaseInputValues(context);

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1417,6 +1417,12 @@ bool Expr::applyFunctionWithPeeling(
   VectorPtr wrappedResult =
       context.applyWrapToPeeledResult(this->type(), peeledResult, applyRows);
   context.moveOrCopyResult(wrappedResult, rows, result);
+
+  // Recycle peeledResult if it's not owned by the result vector. Examples of
+  // when this can happen is when the result is a primitive constant vector, or
+  // when moveOrCopyResult copies wrappedResult content.
+  context.releaseVector(peeledResult);
+
   return true;
 }
 

--- a/velox/functions/prestosql/tests/ArrayConstructorTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayConstructorTest.cpp
@@ -124,29 +124,6 @@ TEST_F(ArrayConstructorTest, empty) {
     ASSERT_FALSE(cardinality->isNullAt(row)) << "at " << row;
     ASSERT_EQ(0, cardinality->valueAt(row)) << "at " << row;
   }
-
-  auto a = makeFlatVector<int64_t>(size, [](vector_size_t row) { return row; });
-  result = evaluate<ArrayVector>(
-      "if(C0 % 2 = 0, array_constructor(C0), array_constructor())",
-      makeRowVector({a}));
-  auto resultElements = result->elements()->asFlatVector<int64_t>();
-  ASSERT_EQ(size, result->size());
-  for (vector_size_t row = 0; row < size; row++) {
-    ASSERT_FALSE(result->isNullAt(row)) << "at " << row;
-    if (row % 2 == 0) {
-      ASSERT_EQ(0, result->sizeAt(1)) << "at " << row;
-      ASSERT_EQ(row, resultElements->valueAt(result->offsetAt(row)));
-    } else {
-      ASSERT_EQ(0, result->sizeAt(row)) << "at " << row;
-    }
-  }
-  // We produce the same result, this time a constant vector of
-  // unknown type array gets morphed into an array vector of int64.
-  auto sameResult = evaluate<ArrayVector>(
-      "if(C0 % 2 = 1, array_constructor(), array_constructor(C0))",
-      makeRowVector({a}));
-  auto other = asArray(sameResult);
-  EXPECT_TRUE(asArray(result)->equalValueAt(other.get(), 0, 0));
 }
 
 TEST_F(ArrayConstructorTest, reuseResultWithNulls) {

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -50,6 +50,9 @@ class FlatVector;
 
 class VectorPool;
 
+class BaseVector;
+using VectorPtr = std::shared_ptr<BaseVector>;
+
 /**
  * Base class for all columnar-based vectors of any type.
  */
@@ -59,9 +62,9 @@ class BaseVector {
 
   BaseVector(
       velox::memory::MemoryPool* pool,
-      TypePtr type,
+      const TypePtr& type,
       VectorEncoding::Simple encoding,
-      BufferPtr nulls,
+      const BufferPtr& nulls,
       size_t length,
       std::optional<vector_size_t> distinctValueCount = std::nullopt,
       std::optional<vector_size_t> nullCount = std::nullopt,
@@ -467,7 +470,7 @@ class BaseVector {
   static std::shared_ptr<BaseVector> wrapInConstant(
       vector_size_t length,
       vector_size_t index,
-      std::shared_ptr<BaseVector> vector);
+      const VectorPtr& vector);
 
   // Makes 'result' writable for 'rows'. A wrapper (e.g. dictionary, constant,
   // sequence) is flattened and a multiply referenced flat vector is copied.
@@ -534,7 +537,7 @@ class BaseVector {
   // If 'vector' is a wrapper, returns the underlying values vector. This is
   // virtual and defined here because we must be able to access this in type
   // agnostic code without a switch on all data types.
-  virtual std::shared_ptr<BaseVector> valueVector() const {
+  virtual const std::shared_ptr<BaseVector>& valueVector() const {
     VELOX_UNSUPPORTED("Vector is not a wrapper");
   }
 
@@ -839,8 +842,6 @@ template <>
 inline uint64_t BaseVector::byteSize<UnknownValue>(vector_size_t) {
   return 0;
 }
-
-using VectorPtr = std::shared_ptr<BaseVector>;
 
 // Returns true if vector is a Lazy vector, possibly wrapped, that hasn't
 // been loaded yet.

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -106,7 +106,7 @@ class DictionaryVector : public SimpleVector<T> {
     return indices_;
   }
 
-  VectorPtr valueVector() const override {
+  const VectorPtr& valueVector() const override {
     return dictionaryValues_;
   }
 

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -108,7 +108,7 @@ class SequenceVector : public SimpleVector<T> {
     return const_cast<SequenceVector<T>*>(this)->loadedVector();
   }
 
-  VectorPtr valueVector() const override {
+  const VectorPtr& valueVector() const override {
     return sequenceValues_;
   }
 

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -59,9 +59,9 @@ class SimpleVector : public BaseVector {
  public:
   SimpleVector(
       velox::memory::MemoryPool* pool,
-      std::shared_ptr<const Type> type,
+      const TypePtr& type,
       VectorEncoding::Simple encoding,
-      BufferPtr nulls,
+      const BufferPtr& nulls,
       size_t length,
       const SimpleVectorStats<T>& stats,
       std::optional<vector_size_t> distinctValueCount,
@@ -71,9 +71,9 @@ class SimpleVector : public BaseVector {
       std::optional<ByteCount> storageByteCount = std::nullopt)
       : BaseVector(
             pool,
-            std::move(type),
+            type,
             encoding,
-            std::move(nulls),
+            nulls,
             length,
             distinctValueCount,
             nullCount,


### PR DESCRIPTION
Summary:
before:
```
============================================================================
fbcode/velox/benchmarks/basic/Preproc.cpp     relative  time/iter   iters/s
============================================================================
ifFloor                                                     7.46ms    134.02
ifFloorWithSimpleEq                                         8.83ms    113.24
oneHot                                                      3.30ms    302.65
oneHotWithVectorArithmetic                                  3.27ms    306.23
allFused                                                    1.16ms    862.31
----------------------------------------------------------------------------
ifFloorWithNulls                                           24.25ms     41.23
ifFloorWithSimpleEqWithNulls                               20.01ms     49.97
oneHotWithNulls                                            14.40ms     69.42
oneHotWithVectorArithmeticWithNulls                        14.43ms     69.32
allFusedWithNulls                                           4.05ms    247.08

```

after:

```
============================================================================
fbcode/velox/benchmarks/basic/Preproc.cpp     relative  time/iter   iters/s
============================================================================
ifFloor                                                     6.93ms    144.37
ifFloorWithSimpleEq                                         8.27ms    120.90
oneHot                                                      3.28ms    305.13
oneHotWithVectorArithmetic                                  3.27ms    305.88
allFused                                                    1.20ms    835.53
----------------------------------------------------------------------------
ifFloorWithNulls                                           22.31ms     44.83
ifFloorWithSimpleEqWithNulls                               16.84ms     59.37
oneHotWithNulls                                            12.98ms     77.01
oneHotWithVectorArithmeticWithNulls                        12.58ms     79.52
allFusedWithNulls                                           3.71ms    269.58

```

Differential Revision: D41879701

