### PR TITLE
Fix error handling in transform_keys Presto function

### DIFF
--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(velox_functions_util velox_vector velox_common_base)
 
 add_library(
   velox_functions_lib
+  CheckDuplicateKeys.cpp
   DateTimeFormatter.cpp
   DateTimeFormatterBuilder.cpp
   KllSketch.cpp

--- a/velox/functions/lib/CheckDuplicateKeys.cpp
+++ b/velox/functions/lib/CheckDuplicateKeys.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/lib/CheckDuplicateKeys.h"
+
+namespace facebook::velox::functions {
+
+void checkDuplicateKeys(
+    const MapVectorPtr& mapVector,
+    const SelectivityVector& rows,
+    exec::EvalCtx& context) {
+  static const char* kDuplicateKey = "Duplicate map keys ({}) are not allowed";
+
+  MapVector::canonicalize(mapVector);
+
+  auto offsets = mapVector->rawOffsets();
+  auto sizes = mapVector->rawSizes();
+  auto mapKeys = mapVector->mapKeys();
+  context.applyToSelectedNoThrow(rows, [&](auto row) {
+    auto offset = offsets[row];
+    auto size = sizes[row];
+    for (auto i = 1; i < size; i++) {
+      if (mapKeys->equalValueAt(mapKeys.get(), offset + i, offset + i - 1)) {
+        auto duplicateKey = mapKeys->wrappedVector()->toString(
+            mapKeys->wrappedIndex(offset + i));
+        VELOX_USER_FAIL(kDuplicateKey, duplicateKey);
+      }
+    }
+  });
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/CheckDuplicateKeys.h
+++ b/velox/functions/lib/CheckDuplicateKeys.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/EvalCtx.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::functions {
+
+/// Check map keys for duplicates. Mark rows with duplicate keys as 'failed' in
+/// the 'context'.
+void checkDuplicateKeys(
+    const MapVectorPtr& mapVector,
+    const SelectivityVector& rows,
+    exec::EvalCtx& context);
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/TransformKeysTest.cpp
+++ b/velox/functions/prestosql/tests/TransformKeysTest.cpp
@@ -68,6 +68,9 @@ TEST_F(TransformKeysTest, duplicateKeys) {
   VELOX_ASSERT_THROW(
       evaluate<MapVector>("transform_keys(c0, (k, v) -> 10 + k % 2)", input),
       "Duplicate map keys (11) are not allowed");
+
+  ASSERT_NO_THROW(evaluate<MapVector>(
+      "try(transform_keys(c0, (k, v) -> 10 + k % 2))", input));
 }
 
 TEST_F(TransformKeysTest, differentResultType) {


### PR DESCRIPTION
The function didn't use context.applyToSelectedNoThrow when checking for 
duplicate map keys. 

Fixes #3518.