### PR TITLE
Fix LocalFileSystem::mkdir()

### DIFF
--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -142,8 +142,10 @@ class LocalFileSystem : public FileSystem {
 
   void mkdir(std::string_view path) override {
     std::error_code ec;
-    VELOX_CHECK(
-        std::filesystem::create_directories(path, ec),
+    std::filesystem::create_directories(path, ec);
+    VELOX_CHECK_EQ(
+        0,
+        ec.value(),
         "Mkdir {} failed: {}, message: {}",
         path,
         ec,

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -228,6 +228,9 @@ TEST(LocalFile, mkdir) {
   EXPECT_NO_THROW(localFs->mkdir(path));
   EXPECT_TRUE(localFs->exists(path));
 
+  // Create a completely existing directory - we should not throw.
+  EXPECT_NO_THROW(localFs->mkdir(path));
+
   // Write a file to our directory to double check it exist.
   path += "/a.txt";
   const std::string data("aaaaa");


### PR DESCRIPTION
Summary:
LocalFileSystem::mkdir() can return false when creating an
already existing directory.
We should not check the returned bool, but rather the error code.

Differential Revision: D42077993

