### PR TITLE
Improve error message in XxxVector::toString(index)

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -502,6 +502,7 @@ std::string BaseVector::toString(bool recursive) const {
 }
 
 std::string BaseVector::toString(vector_size_t index) const {
+  VELOX_CHECK_LT(index, length_, "Vector index should be less than length.");
   std::stringstream out;
   if (!nulls_) {
     out << "no nulls";

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -323,6 +323,7 @@ std::unique_ptr<SimpleVector<uint64_t>> RowVector::hashAll() const {
 }
 
 std::string RowVector::toString(vector_size_t index) const {
+  VELOX_CHECK_LT(index, length_, "Vector index should be less than length.");
   if (isNullAt(index)) {
     return "null";
   }
@@ -682,6 +683,7 @@ std::unique_ptr<SimpleVector<uint64_t>> ArrayVector::hashAll() const {
 }
 
 std::string ArrayVector::toString(vector_size_t index) const {
+  VELOX_CHECK_LT(index, length_, "Vector index should be less than length.");
   if (isNullAt(index)) {
     return "null";
   }
@@ -944,6 +946,7 @@ BufferPtr MapVector::elementIndices() const {
 }
 
 std::string MapVector::toString(vector_size_t index) const {
+  VELOX_CHECK_LT(index, length_, "Vector index should be less than length.");
   if (isNullAt(index)) {
     return "null";
   }

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -172,6 +172,7 @@ class SimpleVector : public BaseVector {
   using BaseVector::toString;
 
   std::string toString(vector_size_t index) const override {
+    VELOX_CHECK_LT(index, length_, "Vector index should be less than length.");
     std::stringstream out;
     if (isNullAt(index)) {
       out << "null";

--- a/velox/vector/tests/VectorToStringTest.cpp
+++ b/velox/vector/tests/VectorToStringTest.cpp
@@ -302,4 +302,10 @@ TEST_F(VectorToStringTest, printIndices) {
   EXPECT_EQ(
       printIndices(indices), "5 unique indices out of 6: 34, 79, 11, 0, 0, 33");
 }
+
+TEST_F(VectorToStringTest, indexOverflow) {
+  // No nulls.
+  auto flat = makeFlatVector<int32_t>({1, 2, 3});
+  ASSERT_THROW(flat->toString(4), VeloxException);
+}
 } // namespace facebook::velox::test


### PR DESCRIPTION
Before the change, calling XxxVector::toString(index) with index value out of
range would throw an error that didn't specify the index and the valid range:

```
E1216 16:42:16.781491 637970 Exceptions.h:68] Line: /mnt/DP_disk1/code/velox/./velox/vector/BaseVector.h:139, Function:isNullAt, Expression: isIndexInRange(idx) , Source: RUNTIME, ErrorCode: INVALID_STATE
unknown file: Failure
C++ exception with description "Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Retriable: False
Expression: isIndexInRange(idx)
Function: isNullAt
File: /mnt/DP_disk1/code/velox/./velox/vector/BaseVector.h
Line: 139
```

After this change, the error includes both index and valid range. 
The new exception is
```
E1226 09:29:35.171662 3978005 Exceptions.h:68] Line: /mnt/DP_disk1/code/velox/./velox/vector/SimpleVector.h:175, Function:toString, Expression: index < length_ (4 vs. 3) Vector index should be less than length., Source: RUNTIME, ErrorCode: INVALID_STATE
unknown file: Failure
C++ exception with description "Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: (4 vs. 3) Vector index should be less than length.
Retriable: False
Expression: index < length_
Function: toString
File: /mnt/DP_disk1/code/velox/./velox/vector/SimpleVector.h
Line: 175

```
Also, the existing check applied only to debug builds,. This change adds the
check to release builds.