### PR TITLE
Some memory code cleanup

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -503,8 +503,6 @@ struct CacheStats {
 // and other housekeeping.
 class CacheShard {
  public:
-  static constexpr int32_t kCacheOwner = -4;
-
   explicit CacheShard(AsyncDataCache* FOLLY_NONNULL cache) : cache_(cache) {}
 
   // See AsyncDataCache::findOrCreate.
@@ -624,15 +622,14 @@ class AsyncDataCache : public memory::MappedMemory {
   // Returns true if there is an entry for 'key'. Updates access time.
   bool exists(RawFileCacheKey key) const;
 
-  bool allocate(
+  bool allocateNonContiguous(
       memory::MachinePageCount numPages,
-      int32_t owner,
       Allocation& out,
       std::function<void(int64_t, bool)> beforeAllocCB = nullptr,
       memory::MachinePageCount minSizeClass = 0) override;
 
-  int64_t free(Allocation& allocation) override {
-    return mappedMemory_->free(allocation);
+  int64_t freeNonContiguous(Allocation& allocation) override {
+    return mappedMemory_->freeNonContiguous(allocation);
   }
 
   bool allocateContiguous(

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -563,7 +563,7 @@ TEST_F(AsyncDataCacheTest, outOfCapacity) {
     pins.pop_front();
   }
   MappedMemory::Allocation allocation(cache_.get());
-  EXPECT_FALSE(cache_->allocate(kSizeInPages, 0, allocation));
+  EXPECT_FALSE(cache_->allocateNonContiguous(kSizeInPages, allocation));
   // One 4 page entry below the max size of 4K 4 page entries in 16MB of
   // capacity.
   EXPECT_EQ(4092, cache_->incrementCachedPages(0));
@@ -573,7 +573,7 @@ TEST_F(AsyncDataCacheTest, outOfCapacity) {
   // We allocate the full capacity and expect the cache entries to go.
   for (;;) {
     MappedMemory::Allocation(cache_.get());
-    if (!cache_->allocate(kSizeInPages, 0, allocation)) {
+    if (!cache_->allocateNonContiguous(kSizeInPages, allocation)) {
       break;
     }
     allocations.push_back(std::move(allocation));

--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -66,9 +66,8 @@ void AllocationPool::newRunImpl(memory::MachinePageCount numPages) {
       allocations_.push_back(std::make_unique<memory::MappedMemory::Allocation>(
           std::move(allocation_)));
     }
-    if (!mappedMemory_->allocate(
+    if (!mappedMemory_->allocateNonContiguous(
             std::max<int32_t>(kMinPages, numPages),
-            owner_,
             allocation_,
             nullptr,
             numPages)) {

--- a/velox/common/memory/AllocationPool.h
+++ b/velox/common/memory/AllocationPool.h
@@ -27,13 +27,10 @@ namespace facebook::velox {
 // started.
 class AllocationPool {
  public:
-  static constexpr int32_t kHashTableOwner = -3;
   static constexpr int32_t kMinPages = 16;
 
-  explicit AllocationPool(
-      memory::MappedMemory* mappedMemory,
-      int32_t owner = kHashTableOwner)
-      : mappedMemory_(mappedMemory), allocation_(mappedMemory), owner_(owner) {}
+  explicit AllocationPool(memory::MappedMemory* mappedMemory)
+      : mappedMemory_(mappedMemory), allocation_(mappedMemory) {}
 
   ~AllocationPool() = default;
 
@@ -128,7 +125,6 @@ class AllocationPool {
   memory::MappedMemory::Allocation allocation_;
   int32_t currentRun_ = 0;
   int32_t currentOffset_ = 0;
-  const int32_t owner_;
 };
 
 } // namespace facebook::velox

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -131,8 +131,7 @@ class HashStringAllocator : public StreamArena {
   };
 
   explicit HashStringAllocator(memory::MappedMemory* FOLLY_NONNULL mappedMemory)
-      : StreamArena(mappedMemory),
-        pool_(mappedMemory, AllocationPool::kHashTableOwner) {}
+      : StreamArena(mappedMemory), pool_(mappedMemory) {}
 
   // Copies a StringView at 'offset' in 'group' to storage owned by
   // the hash table. Updates the StringView.

--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<MemoryUsageTracker> MemoryUsageTracker::create(
   return std::make_shared<SharedMemoryUsageTracker>(parent, type, config);
 }
 
-void MemoryUsageTracker::update(int64_t size, bool /* mock */) {
+void MemoryUsageTracker::update(int64_t size) {
   if (size > 0) {
     int64_t increment = 0;
     ++usage(numAllocs_, UsageType::kTotalMem);

--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -163,10 +163,7 @@ class MemoryUsageTracker
   // allocation and negative for free. If there is no reservation or
   // the new allocated amount exceeds the reservation, propagates the
   // change upward.
-  // Sometimes the memory pool wants to mock an update for quota
-  // accounting purposes and different memory usage trackers can
-  // choose to accommodate this differently.
-  void update(int64_t size, bool /* mock */ = false);
+  void update(int64_t size);
 
   int64_t getCurrentUserBytes() const {
     return adjustByReservation(user(currentUsageInBytes_));

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -66,14 +66,13 @@ class MmapAllocator : public MappedMemory {
 
   explicit MmapAllocator(const MmapAllocatorOptions& options);
 
-  bool allocate(
+  bool allocateNonContiguous(
       MachinePageCount numPages,
-      int32_t owner,
       Allocation& out,
       std::function<void(int64_t, bool)> userAllocCB = nullptr,
       MachinePageCount minSizeClass = 0) override;
 
-  int64_t free(Allocation& allocation) override;
+  int64_t freeNonContiguous(Allocation& allocation) override;
 
   bool allocateContiguous(
       MachinePageCount numPages,
@@ -147,12 +146,11 @@ class MmapAllocator : public MappedMemory {
       return unitSize_;
     }
 
-    // Allocates 'numPages' from 'this' and appends these to
-    // *out. '*numUnmapped' is incremented by the number of pages that
-    // are not backed by memory.
+    // Allocates 'numPages' from 'this' and appends these to *out.
+    // '*numUnmapped' is incremented by the number of pages that are not backed
+    // by memory.
     bool allocate(
         ClassPageCount numPages,
-        int32_t owner,
         MachinePageCount& numUnmapped,
         MappedMemory::Allocation& out);
 
@@ -195,14 +193,12 @@ class MmapAllocator : public MappedMemory {
     // checks.
     static constexpr int32_t kSimdTail = 8;
 
-    // Same as allocate, except that this must be called inside
-    // 'mutex_'. If 'numUnmapped' is nullptr, the allocated pages must
-    // all be backed by memory. Otherwise numUnmapped is updated to be
-    // the count of machine pages needeing backing memory to back the
-    // allocation.
+    // Same as allocate, except that this must be called inside 'mutex_'. If
+    // 'numUnmapped' is nullptr, the allocated pages must all be backed by
+    // memory. Otherwise, numUnmapped is updated to be the count of machine
+    // pages needing backing memory to back the allocation.
     bool allocateLocked(
         ClassPageCount numPages,
-        int32_t owner,
         MachinePageCount* FOLLY_NULLABLE numUnmapped,
         MappedMemory::Allocation& out);
 

--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -33,10 +33,8 @@ void StreamArena::newRange(int32_t bytes, ByteRange* range) {
       allocations_.push_back(std::make_unique<memory::MappedMemory::Allocation>(
           std::move(allocation_)));
     }
-    if (!mappedMemory_->allocate(
-            std::max(allocationQuantum_, numPages),
-            kVectorStreamOwner,
-            allocation_)) {
+    if (!mappedMemory_->allocateNonContiguous(
+            std::max(allocationQuantum_, numPages), allocation_)) {
       throw std::bad_alloc();
     }
     currentRun_ = 0;

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -27,8 +27,6 @@ struct ByteRange;
 // complex types as serialized rows.
 class StreamArena {
  public:
-  static constexpr int32_t kVectorStreamOwner = 1;
-
   explicit StreamArena(memory::MappedMemory* mappedMemory);
 
   virtual ~StreamArena() = default;

--- a/velox/common/memory/tests/FragmentationBenchmark.cpp
+++ b/velox/common/memory/tests/FragmentationBenchmark.cpp
@@ -90,7 +90,7 @@ class FragmentationTest {
       if (size <= 8 << 20) {
         block->allocation =
             std::make_shared<MappedMemory::Allocation>(memory_.get());
-        if (!memory_->allocate(size / 4096, 0, *block->allocation)) {
+        if (!memory_->allocateNonContiguous(size / 4096, *block->allocation)) {
           VELOX_FAIL("allocate() faild");
         }
         for (int i = 0; i < block->allocation->numRuns(); ++i) {

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -712,7 +712,7 @@ RowPartitions::RowPartitions(
     : capacity_(numRows), allocation_(&mappedMemory) {
   auto numPages = bits::roundUp(capacity_, memory::MappedMemory::kPageSize) /
       memory::MappedMemory::kPageSize;
-  if (!mappedMemory.allocate(numPages, 0, allocation_)) {
+  if (!mappedMemory.allocateNonContiguous(numPages, allocation_)) {
     VELOX_FAIL(
         "Failed to allocate RowContainer partitions: {} pages", numPages);
   }


### PR DESCRIPTION
1. remove mock flag which is previously used by SimpleMemoryTracker
   SimpleMemoryTracker has been deprecated now.
2. rename allocate/free in MappedMemory to allocateNonContiguous/freeNonContiguous
3. remove owner support in allocateNonContiguous API which is actually
    not implemented at the backend. We could add it later if really needs.