### PR TITLE
Add support for S3 FileSystem compatible schemes 's3n'

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -35,6 +35,8 @@ constexpr std::string_view kS3Scheme{"s3://"};
 // This should not be mixed with s3 nor the s3a.
 // S3A Hadoop 3.x (previous connectors "s3" and "s3n" are deprecated).
 constexpr std::string_view kS3aScheme{"s3a://"};
+// DEPRECATED: s3n are deprecated in Hadoop 3.x but we are supporting s3n for data that hasn't been migrated yet.
+constexpr std::string_view kS3nScheme{"s3n://"};
 // OSS Alibaba support S3 format, usage only with SSL.
 constexpr std::string_view kOssScheme{"oss://"};
 // From AWS documentation
@@ -49,13 +51,17 @@ inline bool isS3aFile(const std::string_view filename) {
   return filename.substr(0, kS3aScheme.size()) == kS3aScheme;
 }
 
+inline bool isS3nFile(const std::string_view filename) {
+  return filename.substr(0, kS3nScheme.size()) == kS3nScheme;
+}
+
 inline bool isOssFile(const std::string_view filename) {
   return filename.substr(0, kOssScheme.size()) == kOssScheme;
 }
 
 inline bool isS3File(const std::string_view filename) {
   // TODO: Each prefix should be implemented as its own filesystem.
-  return isS3AwsFile(filename) || isS3aFile(filename) || isOssFile(filename);
+  return isS3AwsFile(filename) || isS3aFile(filename) || isS3nFile(filename) || isOssFile(filename);
 }
 
 inline void bucketAndKeyFromS3Path(
@@ -90,6 +96,8 @@ inline std::string s3Path(const std::string_view& path) {
     return std::string(path.substr(kS3Scheme.length()));
   } else if (isS3aFile(path)) {
     return std::string(path.substr(kS3aScheme.length()));
+  } else if (isS3nFile(path)) {
+    return std::string(path.substr(kS3nScheme.length()));
   } else if (isOssFile(path)) {
     return std::string(path.substr(kOssScheme.length()));
   }

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -35,7 +35,8 @@ constexpr std::string_view kS3Scheme{"s3://"};
 // This should not be mixed with s3 nor the s3a.
 // S3A Hadoop 3.x (previous connectors "s3" and "s3n" are deprecated).
 constexpr std::string_view kS3aScheme{"s3a://"};
-// DEPRECATED: s3n are deprecated in Hadoop 3.x but we are supporting s3n for data that hasn't been migrated yet.
+// DEPRECATED: s3n are deprecated in Hadoop 3.x but we are supporting s3n for
+// data that hasn't been migrated yet.
 constexpr std::string_view kS3nScheme{"s3n://"};
 // OSS Alibaba support S3 format, usage only with SSL.
 constexpr std::string_view kOssScheme{"oss://"};
@@ -61,7 +62,8 @@ inline bool isOssFile(const std::string_view filename) {
 
 inline bool isS3File(const std::string_view filename) {
   // TODO: Each prefix should be implemented as its own filesystem.
-  return isS3AwsFile(filename) || isS3aFile(filename) || isS3nFile(filename) || isOssFile(filename);
+  return isS3AwsFile(filename) || isS3aFile(filename) || isS3nFile(filename) ||
+      isOssFile(filename);
 }
 
 inline void bucketAndKeyFromS3Path(

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -50,11 +50,11 @@ TEST(S3UtilTest, isS3aFile) {
 }
 
 TEST(S3UtilTest, isS3nFile) {
-  EXPECT_FALSE(isS3aFile("s3n:"));
-  EXPECT_FALSE(isS3aFile("s3n::/bucket"));
-  EXPECT_FALSE(isS3aFile("s3n:/bucket"));
-  EXPECT_FALSE(isS3aFile("S3N://bucket-name/file.txt"));
-  EXPECT_TRUE(isS3aFile("s3n://bucket/file.txt"));
+  EXPECT_FALSE(isS3nFile("s3n:"));
+  EXPECT_FALSE(isS3nFile("s3n::/bucket"));
+  EXPECT_FALSE(isS3nFile("s3n:/bucket"));
+  EXPECT_FALSE(isS3nFile("S3N://bucket-name/file.txt"));
+  EXPECT_TRUE(isS3nFile("s3n://bucket/file.txt"));
 }
 
 TEST(S3UtilTest, isOssFile) {

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -31,6 +31,7 @@ TEST(S3UtilTest, isS3File) {
   EXPECT_FALSE(isS3File("s3:/bucket"));
   EXPECT_FALSE(isS3File("file://bucket"));
   EXPECT_TRUE(isS3File("s3://bucket/file.txt"));
+  EXPECT_TRUE(isS3File("s3n://bucket/file.txt"));
 }
 
 TEST(S3UtilTest, isS3AwsFile) {
@@ -48,6 +49,14 @@ TEST(S3UtilTest, isS3aFile) {
   EXPECT_TRUE(isS3aFile("s3a://bucket/file.txt"));
 }
 
+TEST(S3UtilTest, isS3nFile) {
+  EXPECT_FALSE(isS3aFile("s3n:"));
+  EXPECT_FALSE(isS3aFile("s3n::/bucket"));
+  EXPECT_FALSE(isS3aFile("s3n:/bucket"));
+  EXPECT_FALSE(isS3aFile("S3N://bucket-name/file.txt"));
+  EXPECT_TRUE(isS3aFile("s3n://bucket/file.txt"));
+}
+
 TEST(S3UtilTest, isOssFile) {
   EXPECT_FALSE(isOssFile("oss:"));
   EXPECT_FALSE(isOssFile("oss::/bucket"));
@@ -61,9 +70,11 @@ TEST(S3UtilTest, s3Path) {
   auto path_0 = s3Path("s3://bucket/file.txt");
   auto path_1 = s3Path("oss://bucket-name/file.txt");
   auto path_2 = s3Path("S3A://bucket-NAME/sub-PATH/my-file.txt");
+  auto path_3 = s3Path("s3n://bucket-NAME/sub-PATH/my-file.txt");
   EXPECT_EQ(path_0, "bucket/file.txt");
   EXPECT_EQ(path_1, "bucket-name/file.txt");
   EXPECT_NE(path_2, "bucket-NAME/sub-PATH/my-file.txt");
+  EXPECT_NE(path_3, "bucket-NAME/sub-PATH/my-file.txt");
 }
 
 TEST(S3UtilTest, bucketAndKeyFromS3Path) {

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -70,7 +70,7 @@ TEST(S3UtilTest, s3Path) {
   auto path_0 = s3Path("s3://bucket/file.txt");
   auto path_1 = s3Path("oss://bucket-name/file.txt");
   auto path_2 = s3Path("S3A://bucket-NAME/sub-PATH/my-file.txt");
-  auto path_3 = s3Path("s3n://bucket-NAME/sub-PATH/my-file.txt");
+  auto path_3 = s3Path("s3N://bucket-NAME/sub-PATH/my-file.txt");
   EXPECT_EQ(path_0, "bucket/file.txt");
   EXPECT_EQ(path_1, "bucket-name/file.txt");
   EXPECT_NE(path_2, "bucket-NAME/sub-PATH/my-file.txt");


### PR DESCRIPTION
S3 compatible scheme "s3a" and "oss" was added by https://github.com/facebookincubator/velox/pull/2410. However, there are currently datasets still using the old scheme "s3n". This PR adds support for that.

As "s3n" is deprecated in latest Hadoop. Thus we are adding comment indicating this is just a change for backward compatibility purpose.