### PR TITLE
ConstantExpr always allocates a new Vector

### DIFF
--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -188,6 +188,10 @@ BENCHMARK(multiplyConstantSmall) {
   benchmark->runSmall("multiply(a, constant)");
 }
 
+BENCHMARK(multiplyLiteralSmall) {
+  benchmark->runSmall("multiply(a, cast(2 as double))");
+}
+
 BENCHMARK(multiplyNestedSmall) {
   benchmark->runSmall("multiply(multiply(a, b), b)");
 }
@@ -241,6 +245,10 @@ BENCHMARK(multiplyConstantMedium) {
   benchmark->runMedium("multiply(a, constant)");
 }
 
+BENCHMARK(multiplyLiteralMedium) {
+  benchmark->runMedium("multiply(a, cast(2 as double))");
+}
+
 BENCHMARK(multiplyNestedMedium) {
   benchmark->runMedium("multiply(multiply(a, b), b)");
 }
@@ -292,6 +300,10 @@ BENCHMARK(multiplyHalfNullLarge) {
 
 BENCHMARK(multiplyConstantLarge) {
   benchmark->runLarge("multiply(a, constant)");
+}
+
+BENCHMARK(multiplyLiteralLarge) {
+  benchmark->runLarge("multiply(a, cast(2 as double))");
 }
 
 BENCHMARK(multiplyNestedLarge) {

--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -37,13 +37,14 @@ void ConstantExpr::evalSpecialForm(
 
   if (sharedSubexprValues_.unique()) {
     sharedSubexprValues_->resize(rows.end());
-    context.moveOrCopyResult(sharedSubexprValues_, rows, result);
   } else {
-    context.moveOrCopyResult(
-        BaseVector::wrapInConstant(rows.end(), 0, sharedSubexprValues_),
-        rows,
-        result);
+    // By reassigning sharedSubexprValues_ we increase the chances that it will
+    // be unique the next time this expression is evaluated.
+    sharedSubexprValues_ =
+        BaseVector::wrapInConstant(rows.end(), 0, sharedSubexprValues_);
   }
+
+  context.moveOrCopyResult(sharedSubexprValues_, rows, result);
 }
 
 void ConstantExpr::evalSpecialFormSimplified(


### PR DESCRIPTION
Summary:
ConstantExpr will reuse sharedSubexprValues_ and just resize it in evalSpecialForm if it's unique.

Expr will always grab a copy of the shared_ptr through the class's value() function, so this optimization can never be applied
https://github.com/facebookincubator/velox/blob/ad12f0154504b0feb9609aaba767fec670248b10/velox/expression/Expr.cpp#L134

This means ConstantExpr allocates a new Vector every time it's invoked.

To fix this, since evalSpecialForm is allocating a new Vector anyway, I just assign that to sharedSubexprValues_ so that after the first call, assuming nothing downstream is holding onto the pointer, the Vector can be reused.

(I also considered making a copy to return in value() instead, but that meant making a copy everywhere sharedSubexprValues_ could be exposed, and this felt easier to maintain.)

I added a benchmark to demonstrate the difference

The best times over a course of a few runs before:
```
============================================================================
[...]benchmarks/basic/SimpleArithmetic.cpp     relative  time/iter   iters/s
============================================================================
multiplyLiteralSmall                                        5.41ms    185.00
multiplyLiteralMedium                                     665.42us     1.50K
multiplyLiteralLarge                                      286.71us     3.49K
```

The best times over a course of a few runs after:
```
============================================================================
[...]benchmarks/basic/SimpleArithmetic.cpp     relative  time/iter   iters/s
============================================================================
multiplyLiteralSmall                                        4.43ms    225.95
multiplyLiteralMedium                                     522.80us     1.91K
multiplyLiteralLarge                                      269.41us     3.71K
```

The difference is significant for small and medium batches.

Differential Revision: D42112520

