### PR TITLE
Allow function signature templates to be used at top-level expression in fuzzer

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -39,7 +39,7 @@ AggregateFunctionMap& aggregateFunctions() {
 namespace {
 std::optional<const AggregateFunctionEntry*> getAggregateFunctionEntry(
     const std::string& name) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
 
   auto& functionsMap = aggregateFunctions();
   auto it = functionsMap.find(sanitizedName);
@@ -55,7 +55,7 @@ bool registerAggregateFunction(
     const std::string& name,
     std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures,
     AggregateFunctionFactory factory) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
 
   aggregateFunctions()[sanitizedName] = {
       std::move(signatures), std::move(factory)};

--- a/velox/exec/WindowFunction.cpp
+++ b/velox/exec/WindowFunction.cpp
@@ -41,7 +41,7 @@ bool registerWindowFunction(
     const std::string& name,
     std::vector<FunctionSignaturePtr> signatures,
     WindowFunctionFactory factory) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
   windowFunctions()[sanitizedName] = {
       std::move(signatures), std::move(factory)};
   return true;
@@ -49,7 +49,7 @@ bool registerWindowFunction(
 
 std::optional<std::vector<FunctionSignaturePtr>> getWindowFunctionSignatures(
     const std::string& name) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
   if (auto func = getWindowFunctionEntry(sanitizedName)) {
     return func.value()->signatures;
   }

--- a/velox/expression/FunctionRegistry.h
+++ b/velox/expression/FunctionRegistry.h
@@ -133,7 +133,7 @@ class FunctionRegistry {
       const std::shared_ptr<const Metadata>& metadata,
       const typename FunctionEntry<Function, Metadata>::FunctionFactory&
           factory) {
-    const auto sanitizedName = sanitizeFunctionName(name);
+    const auto sanitizedName = sanitizeName(name);
     SignatureMap& signatureMap = registeredFunctions_[sanitizedName];
     signatureMap[*metadata->signature()] =
         std::make_unique<const FunctionEntry<Function, Metadata>>(
@@ -141,7 +141,7 @@ class FunctionRegistry {
   }
 
   const SignatureMap* getSignatureMap(const std::string& name) const {
-    const auto sanitizedName = sanitizeFunctionName(name);
+    const auto sanitizedName = sanitizeName(name);
     const auto it = registeredFunctions_.find(sanitizedName);
     return it != registeredFunctions_.end() ? &it->second : nullptr;
   }

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -22,7 +22,7 @@
 
 namespace facebook::velox::exec {
 
-std::string sanitizeFunctionName(const std::string& name) {
+std::string sanitizeName(const std::string& name) {
   std::string sanitizedName;
   sanitizedName.resize(name.size());
   std::transform(

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -25,7 +25,7 @@
 
 namespace facebook::velox::exec {
 
-std::string sanitizeFunctionName(const std::string& name);
+std::string sanitizeName(const std::string& name);
 
 inline bool isCommonDecimalName(const std::string& typeName) {
   return (typeName == "DECIMAL");

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -28,7 +28,7 @@ VectorFunctionMap& vectorFunctionFactories() {
 
 std::optional<std::vector<FunctionSignaturePtr>> getVectorFunctionSignatures(
     const std::string& name) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
 
   return vectorFunctionFactories()
       .withRLock([&sanitizedName](auto& functions) -> auto {
@@ -58,7 +58,7 @@ std::shared_ptr<VectorFunction> getVectorFunction(
     const std::string& name,
     const std::vector<TypePtr>& inputTypes,
     const std::vector<VectorPtr>& constantInputs) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
 
   if (!constantInputs.empty()) {
     VELOX_CHECK_EQ(inputTypes.size(), constantInputs.size());
@@ -96,7 +96,7 @@ bool registerStatefulVectorFunction(
     VectorFunctionFactory factory,
     VectorFunctionMetadata metadata,
     bool overwrite) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
 
   if (overwrite) {
     vectorFunctionFactories().withWLock([&](auto& functionMap) {

--- a/velox/expression/tests/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzer.cpp
@@ -119,4 +119,21 @@ bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {
   return true;
 }
 
+TypePtr ArgumentTypeFuzzer::fuzzReturnType() {
+  VELOX_CHECK_EQ(
+      returnType_,
+      nullptr,
+      "Only fuzzing uninitialized return type is allowed.");
+
+  determineUnboundedTypeVariables();
+  if (signature_.returnType().baseName() == "any") {
+    return randomType(rng_);
+  } else {
+    auto actualType = exec::SignatureBinder::tryResolveType(
+        signature_.returnType(), variables(), bindings_);
+    VELOX_CHECK_NE(actualType, nullptr);
+    return actualType;
+  }
+}
+
 } // namespace facebook::velox::test

--- a/velox/expression/tests/ArgumentTypeFuzzer.h
+++ b/velox/expression/tests/ArgumentTypeFuzzer.h
@@ -27,7 +27,8 @@ namespace facebook::velox::test {
 /// For function signatures using type variables, generates a list of
 /// arguments types. Optionally, allows to specify a desired return type. If
 /// specified, the return type acts as a constraint on the possible set of
-/// argument types.
+/// argument types. If no return type is specified, it also allows generate a
+/// random type that can bind to the function's return type.
 class ArgumentTypeFuzzer {
  public:
   ArgumentTypeFuzzer(
@@ -52,6 +53,10 @@ class ArgumentTypeFuzzer {
   const std::vector<TypePtr>& argumentTypes() const {
     return argumentTypes_;
   }
+
+  /// Return a random type that can bind to the function signature's return
+  /// type. This is only allowed when returnType_ is not initialized.
+  TypePtr fuzzReturnType();
 
  private:
   /// Return the variables in the signature.


### PR DESCRIPTION
Summary:
The signatures of some functions contain type variables such as "T". When generating
a random expression, fuzzer currently choose the top-level function only from function
signatures that do not contain type variable. This is a limitation because sometimes we
would like to test only a function that have type variables in its signature.

This diff allows choosing function signatures that contain type variables as the top-level
function. It also add an API  ArgumentTypeFuzzer::fuzzReturnType() to return a concrete
type that can bind to the formal return type of a function signature.

This diff fixes the issue https://github.com/facebookincubator/velox/issues/3533.

Differential Revision: D42116543

