### PR TITLE
Remove max malloc threshold from MappedMemory interface

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -619,11 +619,10 @@ bool AsyncDataCache::allocateContiguous(
   });
 }
 
-void* FOLLY_NULLABLE
-AsyncDataCache::allocateBytes(uint64_t bytes, uint64_t maxMallocSize) {
+void* FOLLY_NULLABLE AsyncDataCache::allocateBytes(uint64_t bytes) {
   void* result = nullptr;
   makeSpace(bits::roundUp(bytes, kPageSize) / kPageSize, [&]() {
-    result = mappedMemory_->allocateBytes(bytes, maxMallocSize);
+    result = mappedMemory_->allocateBytes(bytes);
     return result != nullptr;
   });
   return result;

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -642,14 +642,10 @@ class AsyncDataCache : public memory::MappedMemory {
     mappedMemory_->freeContiguous(allocation);
   }
 
-  void* allocateBytes(uint64_t bytes, uint64_t maxMallocSize = kMaxMallocBytes)
-      override;
+  void* allocateBytes(uint64_t bytes) override;
 
-  void freeBytes(
-      void* p,
-      uint64_t size,
-      uint64_t maxMallocSize = kMaxMallocBytes) noexcept override {
-    mappedMemory_->freeBytes(p, size, maxMallocSize);
+  void freeBytes(void* p, uint64_t size) noexcept override {
+    mappedMemory_->freeBytes(p, size);
   }
 
   bool checkConsistency() const override {

--- a/velox/common/memory/MappedMemory.cpp
+++ b/velox/common/memory/MappedMemory.cpp
@@ -409,9 +409,8 @@ MachinePageCount roundUpToSizeClassSize(
 }
 } // namespace
 
-void* FOLLY_NULLABLE
-MappedMemory::allocateBytes(uint64_t bytes, uint64_t maxMallocSize) {
-  if (bytes <= maxMallocSize) {
+void* FOLLY_NULLABLE MappedMemory::allocateBytes(uint64_t bytes) {
+  if (bytes <= kMaxMallocBytes) {
     auto result = ::malloc(bytes);
     if (result) {
       totalSmallAllocateBytes_ += bytes;
@@ -444,11 +443,8 @@ MappedMemory::allocateBytes(uint64_t bytes, uint64_t maxMallocSize) {
   return nullptr;
 }
 
-void MappedMemory::freeBytes(
-    void* FOLLY_NONNULL p,
-    uint64_t bytes,
-    uint64_t maxMallocSize) noexcept {
-  if (bytes <= maxMallocSize) {
+void MappedMemory::freeBytes(void* FOLLY_NONNULL p, uint64_t bytes) noexcept {
+  if (bytes <= kMaxMallocBytes) {
     ::free(p); // NOLINT
     totalSmallAllocateBytes_ -= bytes;
   } else if (bytes <= sizeClassSizes_.back() * kPageSize) {

--- a/velox/common/memory/MappedMemory.h
+++ b/velox/common/memory/MappedMemory.h
@@ -401,22 +401,18 @@ class MappedMemory : public std::enable_shared_from_this<MappedMemory> {
   virtual void freeContiguous(ContiguousAllocation& allocation) = 0;
 
   // Allocates 'bytes' contiguous bytes and returns the pointer to the first
-  // byte. If 'bytes' is less than 'maxMallocSize', delegates the allocation to
-  // malloc. If the size is above that and below the largest size classes' size,
-  // allocates one element of the next size classes' size. If 'size' is greater
-  // than the largest size classes' size, calls allocateContiguous(). Returns
-  // nullptr if there is no space. The amount to allocate is subject to the size
-  // limit of 'this'. This function is not virtual but calls the virtual
-  // functions allocate and allocateContiguous, which can track sizes and
-  // enforce caps etc.
-  virtual void* FOLLY_NULLABLE
-  allocateBytes(uint64_t bytes, uint64_t maxMallocSize = kMaxMallocBytes);
+  // byte. If 'bytes' is less than 'kMaxMallocBytes', delegates the allocation
+  // to malloc. If the size is above that and below the largest size classes'
+  // size, allocates one element of the next size classes' size. If 'size' is
+  // greater than the largest size classes' size, calls allocateContiguous().
+  // Returns nullptr if there is no space. The amount to allocate is subject to
+  // the size limit of 'this'. This function is not virtual but calls the
+  // virtual functions allocate and allocateContiguous, which can track sizes
+  // and enforce caps etc.
+  virtual void* FOLLY_NULLABLE allocateBytes(uint64_t bytes);
 
   // Frees memory allocated with allocateBytes().
-  virtual void freeBytes(
-      void* FOLLY_NONNULL p,
-      uint64_t size,
-      uint64_t maxMallocSize = kMaxMallocBytes) noexcept;
+  virtual void freeBytes(void* FOLLY_NONNULL p, uint64_t size) noexcept;
 
   // Checks internal consistency of allocation data
   // structures. Returns true if OK.


### PR DESCRIPTION
Remove max malloc threshold from MappedMemory
allocateBytes/freeBytes interface which is error prone if user
passes a wrong threshold on free. Also some MappedMemory
allocation might not respect that parameter. Will move this 
threshold from MappedMemory to MmapMemory