### PR TITLE
Add allocateZeroFilled and reallocateBytes APIs for MappedMemory

### DIFF
--- a/velox/benchmarks/basic/MemoryAllocationBenchmark.cpp
+++ b/velox/benchmarks/basic/MemoryAllocationBenchmark.cpp
@@ -191,17 +191,16 @@ size_t MemoryPoolAllocationBenchMark<ALIGNMENT>::runReallocate() {
   return FLAGS_memory_allocation_count;
 }
 
-// TODO: turn on the following tests after adding aligned APIs supports for
-// MappedMemory.
-#if 0
 // allocateBytes API.
-BENCHMARK_MULTI(StdAllocateSmall8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 128, 3072);
+BENCHMARK_MULTI(StdAllocateSmallNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 128, 3072);
   return benchmark.runAllocate();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapAllocateSmall8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 128, 3072);
+BENCHMARK_RELATIVE_MULTI(MmapAllocateSmallNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 128, 3072);
   return benchmark.runAllocate();
 }
 
@@ -215,13 +214,15 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateSmall64) {
   return benchmark.runAllocate();
 }
 
-BENCHMARK_MULTI(StdAllocateMid8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 4 << 10, 1 << 20);
+BENCHMARK_MULTI(StdAllocateMidNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 4 << 10, 1 << 20);
   return benchmark.runAllocate();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapAllocateMid8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 4 << 10, 1 << 20);
+BENCHMARK_RELATIVE_MULTI(MmapAllocateMidNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 4 << 10, 1 << 20);
   return benchmark.runAllocate();
 }
 
@@ -235,13 +236,15 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateMid64) {
   return benchmark.runAllocate();
 }
 
-BENCHMARK_MULTI(StdAllocateLarge8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 1 << 20, 32 << 20);
+BENCHMARK_MULTI(StdAllocateLargeNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 1 << 20, 32 << 20);
   return benchmark.runAllocate();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapAllocateLarge8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 1 << 20, 32 << 20);
+BENCHMARK_RELATIVE_MULTI(MmapAllocateLargeNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 1 << 20, 32 << 20);
   return benchmark.runAllocate();
 }
 
@@ -255,13 +258,15 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateLarge64) {
   return benchmark.runAllocate();
 }
 
-BENCHMARK_MULTI(StdAllocateMix8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 128, 32 << 20);
+BENCHMARK_MULTI(StdAllocateMixNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 128, 32 << 20);
   return benchmark.runAllocate();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapAllocateMix8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 128, 32 << 20);
+BENCHMARK_RELATIVE_MULTI(MmapAllocateMixNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 128, 32 << 20);
   return benchmark.runAllocate();
 }
 
@@ -276,13 +281,15 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateMix64) {
 }
 
 // allocateZeroFilled API.
-BENCHMARK_MULTI(StdAllocateZeroFilledSmall8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 128, 3072);
+BENCHMARK_MULTI(StdAllocateZeroFilledSmallNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 128, 3072);
   return benchmark.runAllocateZeroFilled();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledSmall8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 128, 3072);
+BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledSmallNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 128, 3072);
   return benchmark.runAllocateZeroFilled();
 }
 
@@ -296,13 +303,15 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledSmall64) {
   return benchmark.runAllocateZeroFilled();
 }
 
-BENCHMARK_MULTI(StdAllocateZeroFilledMid8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 4 << 10, 1 << 20);
+BENCHMARK_MULTI(StdAllocateZeroFilledMidNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 4 << 10, 1 << 20);
   return benchmark.runAllocateZeroFilled();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledMid8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 4 << 10, 1 << 20);
+BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledMidNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 4 << 10, 1 << 20);
   return benchmark.runAllocateZeroFilled();
 }
 
@@ -316,13 +325,15 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledMid64) {
   return benchmark.runAllocateZeroFilled();
 }
 
-BENCHMARK_MULTI(StdAllocateZeroFilledLarge8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 1 << 20, 32 << 20);
+BENCHMARK_MULTI(StdAllocateZeroFilledLargeNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 1 << 20, 32 << 20);
   return benchmark.runAllocateZeroFilled();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledLarge8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 1 << 20, 32 << 20);
+BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledLargeNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 1 << 20, 32 << 20);
   return benchmark.runAllocateZeroFilled();
 }
 
@@ -336,33 +347,39 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledLarge64) {
   return benchmark.runAllocateZeroFilled();
 }
 
-BENCHMARK_MULTI(StdAllocateZeroFilledMix8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 128, 32 << 20);
+BENCHMARK_MULTI(StdAllocateZeroFilledMixNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 128, 32 << 20);
   return benchmark.runAllocate();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledMix8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 128, 32 << 20);
+BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledMixNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 128, 32 << 20);
   return benchmark.runAllocate();
 }
 
 BENCHMARK_MULTI(StdAllocateZeroFilledMix64) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 128, 32 << 20);
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 128, 32 << 20);
   return benchmark.runAllocate();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledMix64) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 128, 32 << 20);
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 128, 32 << 20);
   return benchmark.runAllocate();
 }
 
-BENCHMARK_MULTI(StdReallocateSmall8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 128, 3072);
+BENCHMARK_MULTI(StdReallocateSmallNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 128, 3072);
   return benchmark.runReallocate();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapReallocateSmall8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 128, 3072);
+BENCHMARK_RELATIVE_MULTI(MmapReallocateSmallNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 128, 3072);
   return benchmark.runReallocate();
 }
 
@@ -376,13 +393,15 @@ BENCHMARK_RELATIVE_MULTI(MmapReallocateSmall64) {
   return benchmark.runReallocate();
 }
 
-BENCHMARK_MULTI(StdReallocateMid8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 4 << 10, 1 << 20);
+BENCHMARK_MULTI(StdReallocateMidNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 4 << 10, 1 << 20);
   return benchmark.runReallocate();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapReallocateMid8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 4 << 10, 1 << 20);
+BENCHMARK_RELATIVE_MULTI(MmapReallocateMidNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 4 << 10, 1 << 20);
   return benchmark.runReallocate();
 }
 
@@ -396,13 +415,15 @@ BENCHMARK_RELATIVE_MULTI(MmapReallocateMid64) {
   return benchmark.runReallocate();
 }
 
-BENCHMARK_MULTI(StdReallocateLarge8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 1 << 20, 32 << 20);
+BENCHMARK_MULTI(StdReallocateLargeNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 1 << 20, 32 << 20);
   return benchmark.runReallocate();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapReallocateLarge8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 1 << 20, 32 << 20);
+BENCHMARK_RELATIVE_MULTI(MmapReallocateLargeNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 1 << 20, 32 << 20);
   return benchmark.runReallocate();
 }
 
@@ -416,13 +437,15 @@ BENCHMARK_RELATIVE_MULTI(MmapReallocateLarge64) {
   return benchmark.runReallocate();
 }
 
-BENCHMARK_MULTI(StdReallocateMix8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kStd, 128, 32 << 20);
+BENCHMARK_MULTI(StdReallocateMixNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kStd, 128, 32 << 20);
   return benchmark.runReallocate();
 }
 
-BENCHMARK_RELATIVE_MULTI(MmapReallocateMix8) {
-  MemoryPoolAllocationBenchMark<8> benchmark(Type::kMmap, 128, 32 << 20);
+BENCHMARK_RELATIVE_MULTI(MmapReallocateMixNoAlignment) {
+  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+      Type::kMmap, 128, 32 << 20);
   return benchmark.runReallocate();
 }
 
@@ -435,7 +458,6 @@ BENCHMARK_RELATIVE_MULTI(MmapReallocateMix64) {
   MemoryPoolAllocationBenchMark<64> benchmark(Type::kMmap, 128, 32 << 20);
   return benchmark.runReallocate();
 }
-#endif
 } // namespace
 
 int main(int argc, char* argv[]) {

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -619,10 +619,10 @@ bool AsyncDataCache::allocateContiguous(
   });
 }
 
-void* FOLLY_NULLABLE AsyncDataCache::allocateBytes(uint64_t bytes) {
+void* AsyncDataCache::allocateBytes(uint64_t bytes, uint16_t alignment) {
   void* result = nullptr;
   makeSpace(bits::roundUp(bytes, kPageSize) / kPageSize, [&]() {
-    result = mappedMemory_->allocateBytes(bytes);
+    result = mappedMemory_->allocateBytes(bytes, alignment);
     return result != nullptr;
   });
   return result;

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -642,7 +642,7 @@ class AsyncDataCache : public memory::MappedMemory {
     mappedMemory_->freeContiguous(allocation);
   }
 
-  void* allocateBytes(uint64_t bytes) override;
+  void* allocateBytes(uint64_t bytes, uint16_t alignment) override;
 
   void freeBytes(void* p, uint64_t size) noexcept override {
     mappedMemory_->freeBytes(p, size);

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -512,6 +512,9 @@ class IMemoryManager {
   virtual bool reserve(int64_t size) = 0;
   // Subtracts from current total and regain memory quota.
   virtual void release(int64_t size) = 0;
+
+  // Returns the debug string of this memory manager.
+  virtual std::string toString() = 0;
 };
 
 // For now, users wanting multiple different allocators would need to
@@ -557,6 +560,11 @@ class MemoryManager final : public IMemoryManager {
   void release(int64_t size) final;
 
   Allocator& getAllocator();
+
+  std::string toString() final {
+    return fmt::format(
+        "memoryQuota: {}bytes, alignment: {}bytes", memoryQuota_, ALIGNMENT);
+  }
 
  private:
   VELOX_FRIEND_TEST(MemoryPoolImplTest, CapSubtree);

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -15,10 +15,11 @@
  */
 
 #include "velox/common/memory/MmapAllocator.h"
-#include "velox/common/base/Portability.h"
-#include "velox/common/testutil/TestValue.h"
 
 #include <sys/mman.h>
+
+#include "velox/common/base/Portability.h"
+#include "velox/common/testutil/TestValue.h"
 
 using facebook::velox::common::testutil::TestValue;
 
@@ -319,6 +320,71 @@ void MmapAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
     numAllocated_ -= allocation.numPages();
     allocation.reset(nullptr, nullptr, 0);
   }
+}
+
+void* MmapAllocator::allocateBytes(uint64_t bytes, uint16_t alignment) {
+  alignmentCheck(bytes, alignment);
+
+  if (bytes <= kMaxMallocBytes) {
+    auto* result = alignment > kMinAlignment ? ::aligned_alloc(alignment, bytes)
+                                             : ::malloc(bytes);
+    if (result != nullptr) {
+      totalSmallAllocateBytes_ += bytes;
+    } else {
+      LOG(ERROR) << "Failed to allocateBytes " << bytes << " bytes with "
+                 << alignment << " alignment";
+    }
+    return result;
+  }
+
+  if (bytes <= sizeClassSizes_.back() * kPageSize) {
+    Allocation allocation(this);
+    auto numPages = roundUpToSizeClassSize(bytes, sizeClassSizes_);
+    if (!allocateNonContiguous(numPages, allocation, nullptr, numPages)) {
+      return nullptr;
+    }
+    auto run = allocation.runAt(0);
+    VELOX_CHECK_EQ(
+        1,
+        allocation.numRuns(),
+        "A size class allocateBytes must produce one run");
+    allocation.clear();
+    totalSizeClassAllocateBytes_ += numPages * kPageSize;
+    return run.data<char>();
+  }
+
+  ContiguousAllocation allocation;
+  auto numPages = bits::roundUp(bytes, kPageSize) / kPageSize;
+  if (!allocateContiguous(numPages, nullptr, allocation)) {
+    return nullptr;
+  }
+
+  char* data = allocation.data<char>();
+  allocation.reset(nullptr, nullptr, 0);
+  totalLargeAllocateBytes_ += numPages * kPageSize;
+  return data;
+}
+
+void MmapAllocator::freeBytes(void* p, uint64_t bytes) noexcept {
+  if (bytes <= kMaxMallocBytes) {
+    ::free(p); // NOLINT
+    totalSmallAllocateBytes_ -= bytes;
+    return;
+  }
+
+  if (bytes <= sizeClassSizes_.back() * kPageSize) {
+    Allocation allocation(this);
+    auto numPages = roundUpToSizeClassSize(bytes, sizeClassSizes_);
+    allocation.append(reinterpret_cast<uint8_t*>(p), numPages);
+    freeNonContiguous(allocation);
+    totalSizeClassAllocateBytes_ -= numPages * kPageSize;
+    return;
+  }
+
+  ContiguousAllocation allocation;
+  allocation.reset(this, p, bytes);
+  freeContiguous(allocation);
+  totalLargeAllocateBytes_ -= bits::roundUp(bytes, kPageSize);
 }
 
 void MmapAllocator::markAllMapped(const Allocation& allocation) {

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -90,12 +90,17 @@ class MmapAllocator : public MappedMemory {
         allocation.size(), [&]() { freeContiguousImpl(allocation); });
   }
 
-  /// Checks internal consistency of allocation data structures. Returns true if
-  /// OK. May return false if there are concurrent allocations and frees during
-  /// the consistency check. This is a false positive but not dangerous.
-  ///
-  /// Checks that the totals of mapped free and mapped and allocated pages match
-  /// the data in the bitmaps in the size classes.
+  void* FOLLY_NULLABLE
+  allocateBytes(uint64_t bytes, uint16_t alignment) override;
+
+  void freeBytes(void* p, uint64_t bytes) noexcept override;
+
+  // Checks internal consistency of allocation data structures. Returns true if
+  // OK. May return false if there are concurrent allocations and frees during
+  // the consistency check. This is a false positive but not dangerous.
+  //
+  // Checks that the totals of mapped free and mapped and allocated pages match
+  // the data in the bitmaps in the size classes.
   bool checkConsistency() const override;
 
   MachinePageCount capacity() const {


### PR DESCRIPTION
1. Add reallocateBytes APIs for MappedMemory to support aligned
memory pool reallocateBytes API.
2. Add allocateZeroFilled to optimize memory pool allocZeroFilled
implementation
3. Optimize allocateBytes implementation for non-mmap MappedMemory
implementation.
Results verified by memory allocation microbenchmark (attached)

```
============================================================================
[...]s/basic/MemoryAllocationBenchmark.cpp     relative  time/iter   iters/s
============================================================================
StdAllocateSmallNoAlignment                               253.94ns     3.94M
MmapAllocateSmallNoAlignment                    95.191%   266.77ns     3.75M
StdAllocateSmall64                                        253.62ns     3.94M
MmapAllocateSmall64                             88.168%   287.66ns     3.48M
StdAllocateMidNoAlignment                                   1.07us   932.12K
MmapAllocateMidNoAlignment                      104.24%     1.03us   971.65K
StdAllocateMid64                                            1.03us   975.48K
MmapAllocateMid64                                 98.4%     1.04us   959.88K
StdAllocateLargeNoAlignment                                 1.75us   572.66K
MmapAllocateLargeNoAlignment                    95.608%     1.83us   547.51K
StdAllocateLarge64                                          1.80us   555.77K
MmapAllocateLarge64                             98.965%     1.82us   550.01K
StdAllocateMixNoAlignment                                   1.78us   562.53K
MmapAllocateMixNoAlignment                      98.581%     1.80us   554.55K
StdAllocateMix64                                            1.79us   557.18K
MmapAllocateMix64                               100.24%     1.79us   558.52K
StdAllocateZeroFilledSmallNoAlignment                     326.01ns     3.07M
MmapAllocateZeroFilledSmallNoAlignment          92.734%   351.56ns     2.84M
StdAllocateZeroFilledSmall64                              322.48ns     3.10M
MmapAllocateZeroFilledSmall64                   91.248%   353.41ns     2.83M
StdAllocateZeroFilledMidNoAlignment                         1.99us   502.09K
MmapAllocateZeroFilledMidNoAlignment             98.17%     2.03us   492.90K
StdAllocateZeroFilledMid64                                  2.10us   476.25K
MmapAllocateZeroFilledMid64                     104.18%     2.02us   496.17K
StdAllocateZeroFilledLargeNoAlignment                       2.26us   441.64K
MmapAllocateZeroFilledLargeNoAlignment          97.929%     2.31us   432.50K
StdAllocateZeroFilledLarge64                                2.27us   440.48K
MmapAllocateZeroFilledLarge64                   102.32%     2.22us   450.68K
StdAllocateZeroFilledMixNoAlignment                         1.76us   566.98K
MmapAllocateZeroFilledMixNoAlignment            100.45%     1.76us   569.53K
StdAllocateZeroFilledMix64                                  1.75us   571.80K
MmapAllocateZeroFilledMix64                     103.18%     1.69us   590.01K
StdReallocateSmallNoAlignment                             378.11ns     2.64M
MmapReallocateSmallNoAlignment                  87.578%   431.74ns     2.32M
StdReallocateSmall64                                      422.77ns     2.37M
MmapReallocateSmall64                           91.412%   462.48ns     2.16M
StdReallocateMidNoAlignment                                44.30us    22.57K
MmapReallocateMidNoAlignment                    98.558%    44.95us    22.25K
StdReallocateMid64                                         94.71us    10.56K
MmapReallocateMid64                             111.06%    85.28us    11.73K
StdReallocateLargeNoAlignment                               3.37ms    296.98
MmapReallocateLargeNoAlignment                  96.522%     3.49ms    286.65
StdReallocateLarge64                                        7.00ms    142.81
MmapReallocateLarge64                           99.318%     7.05ms    141.84
StdReallocateMixNoAlignment                                 3.53ms    283.45
MmapReallocateMixNoAlignment                    101.38%     3.48ms    287.35
StdReallocateMix64                                          6.63ms    150.90
MmapReallocateMix64                             99.634%     6.65ms    150.35
```