### PR TITLE
Fix memory pool allocateZeroFilled and its usage issues

### DIFF
--- a/velox/dwio/common/DataBuffer.h
+++ b/velox/dwio/common/DataBuffer.h
@@ -35,7 +35,7 @@ class DataBuffer {
       : pool_(&pool),
         // Initial allocation uses calloc, to avoid memset.
         buf_(reinterpret_cast<T*>(
-            pool_->allocateZeroFilled(sizeInBytes(size), 1))),
+            pool_->allocateZeroFilled(1, sizeInBytes(size)))),
         size_(size),
         capacity_(size) {
     DWIO_ENSURE(buf_ != nullptr || size == 0);


### PR DESCRIPTION
1. Fix memory pool allocateZeroFilled usage in dwio DataBuffer
2. Correct the aligned size calculation to match the free path