### PR TITLE
Some code cleanup in MappedMemory

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -106,7 +106,7 @@ class TpchBenchmark {
   void initialize() {
     if (FLAGS_cache_gb) {
       int64_t memoryBytes = FLAGS_cache_gb * (1LL << 30);
-      memory::MmapAllocatorOptions options;
+      memory::MmapAllocator::Options options;
       options.capacity = memoryBytes;
       options.useMmapArena = true;
       options.mmapArenaCapacityRatio = 1;

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -74,7 +74,7 @@ class AsyncDataCacheTest : public testing::Test {
           executor(),
           ssdBytes / 20);
     }
-    memory::MmapAllocatorOptions options;
+    memory::MmapAllocator::Options options;
     options.capacity = maxBytes;
     cache_ = std::make_shared<AsyncDataCache>(
         std::make_shared<memory::MmapAllocator>(options),

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -24,7 +24,7 @@ using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::memory {
 
-MmapAllocator::MmapAllocator(const MmapAllocatorOptions& options)
+MmapAllocator::MmapAllocator(const Options& options)
     : MappedMemory(),
       numAllocated_(0),
       numMapped_(0),

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -27,14 +27,14 @@ class ByteStreamTest : public testing::TestWithParam<bool> {
  protected:
   void SetUp() override {
     constexpr uint64_t kMaxMappedMemory = 64 << 20;
-    MmapAllocatorOptions options;
+    MmapAllocator::Options options;
     options.capacity = kMaxMappedMemory;
     mmapAllocator_ = std::make_shared<MmapAllocator>(options);
     MappedMemory::setDefaultInstance(mmapAllocator_.get());
   }
 
   void TearDown() override {
-    MappedMemory::destroyTestOnly();
+    MappedMemory::testingDestroyInstance();
     MappedMemory::setDefaultInstance(nullptr);
   }
 

--- a/velox/common/memory/tests/FragmentationBenchmark.cpp
+++ b/velox/common/memory/tests/FragmentationBenchmark.cpp
@@ -142,7 +142,7 @@ class FragmentationTest {
   }
 
   void initMemory(size_t sizeCap) {
-    MmapAllocatorOptions options;
+    MmapAllocator::Options options;
     options.capacity = sizeCap + (64 << 20);
     memory_ = std::make_shared<MmapAllocator>(options);
   }

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -39,7 +39,7 @@ class MemoryPoolTest : public testing::TestWithParam<bool> {
     // For duration of the test, make a local MmapAllocator that will not be
     // seen by any other test.
     if (useMmap_) {
-      MmapAllocatorOptions opts{8UL << 30};
+      MmapAllocator::Options opts{8UL << 30};
       mmapAllocator_ = std::make_unique<MmapAllocator>(opts);
       MappedMemory::setDefaultInstance(mmapAllocator_.get());
     } else {
@@ -346,7 +346,7 @@ void testMmapMemoryAllocation(
 }
 
 TEST(MemoryPoolTest, SmallMmapMemoryAllocation) {
-  MmapAllocatorOptions options;
+  MmapAllocator::Options options;
   options.capacity = 8 * GB;
   auto mmapAllocator = std::make_unique<memory::MmapAllocator>(options);
   MappedMemory::setDefaultInstance(mmapAllocator.get());
@@ -354,7 +354,7 @@ TEST(MemoryPoolTest, SmallMmapMemoryAllocation) {
 }
 
 TEST(MemoryPoolTest, BigMmapMemoryAllocation) {
-  MmapAllocatorOptions options;
+  MmapAllocator::Options options;
   options.capacity = 8 * GB;
   auto mmapAllocator = std::make_unique<memory::MmapAllocator>(options);
   MappedMemory::setDefaultInstance(mmapAllocator.get());

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -125,7 +125,7 @@ class CacheTest : public testing::Test {
           executor_.get());
       groupStats_ = &ssd->groupStats();
     }
-    memory::MmapAllocatorOptions options;
+    memory::MmapAllocator::Options options;
     options.capacity = maxBytes;
     cache_ = std::make_shared<AsyncDataCache>(
         std::make_shared<memory::MmapAllocator>(options),


### PR DESCRIPTION
1. Remove FLAGS_velox_use_malloc from code
2. Move MmapAllocatorOptions to MmapAllocator as Options
Will add a system config properties in presto cpp to configure
memory allocator In followup. Presto cpp is now hard coded to
use mmap allocator.