### PR TITLE
Add PlanFragment::canSpill().

### DIFF
--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 add_library(velox_config Context.cpp)
 target_link_libraries(velox_config ${FOLLY_WITH_DEPENDENCIES})
 
-add_library(velox_core PlanNode.cpp)
+add_library(velox_core PlanFragment.cpp PlanNode.cpp)
 
 target_link_libraries(
   velox_core

--- a/velox/core/PlanFragment.cpp
+++ b/velox/core/PlanFragment.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/core/PlanFragment.h"
+#include "velox/core/QueryConfig.h"
+
+namespace facebook::velox::core {
+
+bool PlanFragment::canSpill(const QueryConfig& queryConfig) const {
+  if (not queryConfig.spillEnabled()) {
+    return false;
+  }
+
+  const bool aggregationSpillEnabled = queryConfig.aggregationSpillEnabled();
+  const bool orderBySpillEnabled = queryConfig.orderBySpillEnabled();
+  const bool joinSpillEnabled = queryConfig.joinSpillEnabled();
+
+  const auto canNodeSpillFunc = [&](const core::PlanNode* node) {
+    if (aggregationSpillEnabled) {
+      if (const auto* aggregationNode =
+              dynamic_cast<const core::AggregationNode*>(node)) {
+        if (aggregationNode->isFinal() || aggregationNode->isSingle()) {
+          return true;
+        }
+      }
+    }
+    if (orderBySpillEnabled && dynamic_cast<const core::OrderByNode*>(node)) {
+      return true;
+    }
+    if (joinSpillEnabled && dynamic_cast<const core::HashJoinNode*>(node)) {
+      return true;
+    }
+    return false;
+  };
+
+  return PlanNode::findFirstNode(planNode.get(), canNodeSpillFunc) != nullptr;
+}
+
+} // namespace facebook::velox::core

--- a/velox/core/PlanFragment.h
+++ b/velox/core/PlanFragment.h
@@ -20,6 +20,8 @@
 
 namespace facebook::velox::core {
 
+class QueryConfig;
+
 /// Gives hints on how to execute the fragment of a plan.
 enum class ExecutionStrategy {
   /// Process splits as they come in any available driver.
@@ -56,6 +58,10 @@ struct PlanFragment {
       : planNode(std::move(topNode)),
         executionStrategy(strategy),
         numSplitGroups(numberOfSplitGroups) {}
+
+  /// Returns true if the spilling is enabled and there is at least one node in
+  /// the plan, whose operator can spill. Returns false otherwise.
+  bool canSpill(const QueryConfig& queryConfig) const;
 };
 
 } // namespace facebook::velox::core

--- a/velox/core/tests/CMakeLists.txt
+++ b/velox/core/tests/CMakeLists.txt
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_core_test TestPlanNode.cpp TestQueryConfig.cpp
-                               TestString.cpp TestTypeAnalysis.cpp)
+add_executable(
+  velox_core_test TestPlanFragment.cpp TestPlanNode.cpp TestQueryConfig.cpp
+                  TestString.cpp TestTypeAnalysis.cpp)
 
 add_test(velox_core_test velox_core_test)
 

--- a/velox/core/tests/TestPlanFragment.cpp
+++ b/velox/core/tests/TestPlanFragment.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "velox/core/Context.h"
+#include "velox/core/PlanFragment.h"
+#include "velox/core/QueryConfig.h"
+#include "velox/core/QueryCtx.h"
+
+using namespace ::facebook::velox;
+using namespace ::facebook::velox::core;
+
+namespace {
+std::shared_ptr<QueryCtx> getSpillQueryCtx(
+    bool spillEnabled,
+    bool aggrSpillEnabled,
+    bool joinSpillEnabled,
+    bool orderBySpillEnabled) {
+  std::unordered_map<std::string, std::string> configData({
+      {QueryConfig::kSpillEnabled, spillEnabled ? "true" : "false"},
+      {QueryConfig::kAggregationSpillEnabled,
+       aggrSpillEnabled ? "true" : "false"},
+      {QueryConfig::kJoinSpillEnabled, joinSpillEnabled ? "true" : "false"},
+      {QueryConfig::kOrderBySpillEnabled,
+       orderBySpillEnabled ? "true" : "false"},
+  });
+  return std::make_shared<QueryCtx>(
+      nullptr, std::make_shared<MemConfig>(configData));
+}
+}; // namespace
+
+TEST(TestPlanFragment, basic) {
+  // Create a small node tree: orderBy <- tableScan.
+  auto rowType = ROW({"name1"}, {BIGINT()});
+
+  std::shared_ptr<connector::ConnectorTableHandle> tableHandle;
+  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
+      assignments;
+  auto tableScan =
+      std::make_shared<TableScanNode>("2", rowType, tableHandle, assignments);
+
+  std::vector<FieldAccessTypedExprPtr> sortingKeys{nullptr};
+  std::vector<SortOrder> sortingOrders{{true, true}};
+
+  auto orderBy = std::make_shared<OrderByNode>(
+      "-1", sortingKeys, sortingOrders, false, tableScan);
+
+  PlanFragment fragmentNoSpill{tableScan};
+  PlanFragment fragmentOrderBySpill{orderBy};
+
+  // Create several query contexts with a variety of combination of spilling
+  // options.
+  auto queryCtxAllEnabled = getSpillQueryCtx(true, true, true, true);
+  auto queryCtxDisabled = getSpillQueryCtx(false, true, true, true);
+  auto queryCtxAllDisabled = getSpillQueryCtx(false, false, false, false);
+  auto queryCtxAggrEnabled = getSpillQueryCtx(true, true, false, false);
+  auto queryCtxOrderByEnabled = getSpillQueryCtx(true, false, false, true);
+
+  // No matter the spilling flags there is nothing to spill in this plan
+  // fragment.
+  EXPECT_FALSE(fragmentNoSpill.canSpill(queryCtxAllEnabled->queryConfig()));
+  EXPECT_FALSE(fragmentNoSpill.canSpill(queryCtxDisabled->queryConfig()));
+  EXPECT_FALSE(fragmentNoSpill.canSpill(queryCtxAllDisabled->queryConfig()));
+
+  // We can only spill from the 'order by' in this plan fragment, so we are
+  // looking for the specific flags enabled.
+  EXPECT_TRUE(fragmentOrderBySpill.canSpill(queryCtxAllEnabled->queryConfig()));
+  EXPECT_FALSE(fragmentOrderBySpill.canSpill(queryCtxDisabled->queryConfig()));
+  EXPECT_FALSE(
+      fragmentOrderBySpill.canSpill(queryCtxAllDisabled->queryConfig()));
+  EXPECT_FALSE(
+      fragmentOrderBySpill.canSpill(queryCtxAggrEnabled->queryConfig()));
+  EXPECT_TRUE(
+      fragmentOrderBySpill.canSpill(queryCtxOrderByEnabled->queryConfig()));
+}


### PR DESCRIPTION
Summary:
The new method has the logic copied from the maybeSetupTaskSpillDirectory()
in presto_cpp's TaskManager.cpp.
Later we will remove that logic from the TaskManager.cpp and will use
PlanFragment::canSpill().

Differential Revision: D42158794

