### PR TITLE
Consolidate peeling logic in CastExpr and Expr

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/TypeAliases.h"
+#include "velox/vector/tests/TestingDictionaryOverConstantFunction.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -919,5 +920,18 @@ TEST_F(CastExprTest, castAsCall) {
 
   auto result = evaluate(callExpr, input);
   auto expected = makeNullableFlatVector(outputValues);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(CastExprTest, dictionaryOverConst) {
+  exec::registerVectorFunction(
+      "dictionary_over_const",
+      TestingDictionaryOverConstFunction::signatures(),
+      std::make_unique<TestingDictionaryOverConstFunction>());
+
+  auto data = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto result = evaluate(
+      "cast(dictionary_over_const(c0) as smallint)", makeRowVector({data}));
+  auto expected = makeNullableFlatVector<int16_t>({1, 1, 1, 1, 1});
   assertEqualVectors(expected, result);
 }

--- a/velox/vector/tests/TestingDictionaryOverConstantFunction.h
+++ b/velox/vector/tests/TestingDictionaryOverConstantFunction.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/VectorFunction.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::test {
+
+/// Wraps input in a constant encoding that repeats the first element and then
+/// in dictionary that reverses the order of rows.
+class TestingDictionaryOverConstFunction : public exec::VectorFunction {
+ public:
+  TestingDictionaryOverConstFunction() {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /*outputType*/,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    const auto size = rows.size();
+    auto constant = BaseVector::wrapInConstant(size, 0, args[0]);
+
+    auto indices = makeIndicesInReverse(size, context.pool());
+    auto nulls = allocateNulls(size, context.pool());
+    result =
+        BaseVector::wrapInDictionary(nulls, indices, size, std::move(constant));
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    // T -> T
+    return {exec::FunctionSignatureBuilder()
+                .typeVariable("T")
+                .returnType("T")
+                .argumentType("T")
+                .build()};
+  }
+};
+
+} // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
Right now, CastExpr and Expr both have their own peeling logic. Expr first deselects null rows and error rows when evaluating inputs, and then peel off the common encodings across input values except constant encoding. On the other hand, CastExpr evaluates the input at all rows and then peel off all encodings of the input value. This divergence makes it hard to maintain both peeling logics and causes an incorrect result of cast expression: https://github.com/facebookincubator/velox/issues/3300.

This diff consolidates the peeling logic in Expr and CastExpr and makes sure the incorrect result is fixed.

Differential Revision: D42156225

