### PR TITLE
Remove memory usage type from MemoryUsageTracker

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -341,14 +341,16 @@ class MemoryPoolImpl : public MemoryPool {
 
   ~MemoryPoolImpl() {
     if (const auto& tracker = getMemoryUsageTracker()) {
-      auto remainingBytes = tracker->getCurrentUserBytes();
+      // TODO: change to check reserved bytes which including the unused
+      // reservation.
+      auto remainingBytes = tracker->currentBytes();
       VELOX_CHECK_EQ(
           0,
           remainingBytes,
           "Memory pool should be destroyed only after all allocated memory has been freed. Remaining bytes allocated: {}, cumulative bytes allocated: {}, number of allocations: {}",
           remainingBytes,
-          tracker->getCumulativeBytes(),
-          tracker->getNumAllocs());
+          tracker->cumulativeBytes(),
+          tracker->numAllocs());
     }
   }
 

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -620,8 +620,8 @@ TEST(MemoryPoolTest, childUsageTest) {
       EXPECT_EQ(tree[i]->getMaxBytes(), maxBytes[i]);
       auto tracker = tree[i]->getMemoryUsageTracker();
       ASSERT_TRUE(tracker);
-      EXPECT_GE(tracker->getCurrentUserBytes(), trackerCurrentBytes[i]);
-      EXPECT_GE(tracker->getPeakTotalBytes(), trackerMaxBytes[i]);
+      EXPECT_GE(tracker->currentBytes(), trackerCurrentBytes[i]);
+      EXPECT_GE(tracker->peakBytes(), trackerMaxBytes[i]);
     }
   };
 
@@ -702,8 +702,8 @@ TEST(MemoryPoolTest, childUsageTest) {
 
   // Verify the stats still holds the correct stats.
   for (unsigned i = 0, e = trackers.size(); i != e; ++i) {
-    ASSERT_GE(trackers[i]->getCurrentUserBytes(), expectedCurrentBytes[i]);
-    ASSERT_GE(trackers[i]->getPeakTotalBytes(), expectedMaxBytes[i]);
+    ASSERT_GE(trackers[i]->currentBytes(), expectedCurrentBytes[i]);
+    ASSERT_GE(trackers[i]->peakBytes(), expectedMaxBytes[i]);
   }
 }
 

--- a/velox/common/memory/tests/MemoryUsageTrackerTest.cpp
+++ b/velox/common/memory/tests/MemoryUsageTrackerTest.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "folly/Random.h"
 #include "velox/common/memory/MemoryUsageTracker.h"
 
 using namespace ::testing;
@@ -30,186 +31,175 @@ TEST(MemoryUsageTrackerTest, constructor) {
   trackers.push_back(tracker->addChild(true));
 
   for (unsigned i = 0; i < trackers.size(); ++i) {
-    EXPECT_EQ(0, trackers[i]->getCurrentUserBytes());
-    EXPECT_EQ(0, trackers[i]->getCurrentSystemBytes());
-    EXPECT_EQ(0, trackers[i]->getCurrentTotalBytes());
-    EXPECT_EQ(0, trackers[i]->getPeakUserBytes());
-    EXPECT_EQ(0, trackers[i]->getPeakSystemBytes());
-    EXPECT_EQ(0, trackers[i]->getPeakTotalBytes());
+    EXPECT_EQ(0, trackers[i]->currentBytes());
+    EXPECT_EQ(0, trackers[i]->peakBytes());
   }
 }
 
 TEST(MemoryUsageTrackerTest, update) {
   constexpr int64_t kMaxSize = 1 << 30; // 1GB
   constexpr int64_t kMB = 1 << 20;
-  auto config = MemoryUsageConfigBuilder().maxUserMemory(kMaxSize).build();
-  auto parent = MemoryUsageTracker::create(config);
+  auto parent = MemoryUsageTracker::create(kMaxSize);
 
   auto child1 = parent->addChild();
   auto child2 = parent->addChild();
 
   ASSERT_THROW(child1->reserve(2 * kMaxSize), VeloxRuntimeError);
 
-  ASSERT_EQ(0, parent->getCurrentTotalBytes());
-  ASSERT_EQ(0, parent->getCumulativeBytes());
+  ASSERT_EQ(0, parent->currentBytes());
+  ASSERT_EQ(0, parent->cumulativeBytes());
   child1->update(1000);
-  ASSERT_EQ(kMB, parent->getCurrentTotalBytes());
-  ASSERT_EQ(kMB, parent->getCumulativeBytes());
-  ASSERT_EQ(kMB - 1000, child1->getAvailableReservation());
+  ASSERT_EQ(kMB, parent->currentBytes());
+  ASSERT_EQ(kMB, parent->cumulativeBytes());
+  ASSERT_EQ(kMB - 1000, child1->availableReservation());
   child1->update(1000);
-  ASSERT_EQ(kMB, parent->getCurrentTotalBytes());
-  ASSERT_EQ(kMB, parent->getCumulativeBytes());
+  ASSERT_EQ(kMB, parent->currentBytes());
+  ASSERT_EQ(kMB, parent->cumulativeBytes());
   child1->update(kMB);
-  ASSERT_EQ(2 * kMB, parent->getCurrentTotalBytes());
-  ASSERT_EQ(2 * kMB, parent->getCumulativeBytes());
+  ASSERT_EQ(2 * kMB, parent->currentBytes());
+  ASSERT_EQ(2 * kMB, parent->cumulativeBytes());
 
   child1->update(100 * kMB);
   // Larger sizes round up to next 8MB.
-  ASSERT_EQ(104 * kMB, parent->getCurrentTotalBytes());
-  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
+  ASSERT_EQ(104 * kMB, parent->currentBytes());
+  ASSERT_EQ(104 * kMB, parent->cumulativeBytes());
   child1->update(-kMB);
   // 1MB less does not decrease the reservation.
-  ASSERT_EQ(104 * kMB, parent->getCurrentTotalBytes());
-  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
+  ASSERT_EQ(104 * kMB, parent->currentBytes());
+  ASSERT_EQ(104 * kMB, parent->cumulativeBytes());
 
   child1->update(-7 * kMB);
-  ASSERT_EQ(96 * kMB, parent->getCurrentTotalBytes());
-  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
+  ASSERT_EQ(96 * kMB, parent->currentBytes());
+  ASSERT_EQ(104 * kMB, parent->cumulativeBytes());
   child1->update(-92 * kMB);
-  ASSERT_EQ(2 * kMB, parent->getCurrentTotalBytes());
-  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
+  ASSERT_EQ(2 * kMB, parent->currentBytes());
+  ASSERT_EQ(104 * kMB, parent->cumulativeBytes());
   child1->update(-kMB);
-  ASSERT_EQ(kMB, parent->getCurrentTotalBytes());
-  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
+  ASSERT_EQ(kMB, parent->currentBytes());
+  ASSERT_EQ(104 * kMB, parent->cumulativeBytes());
 
   child1->update(-2000);
-  ASSERT_EQ(0, parent->getCurrentTotalBytes());
-  ASSERT_EQ(104 * kMB, parent->getCumulativeBytes());
+  ASSERT_EQ(0, parent->currentBytes());
+  ASSERT_EQ(104 * kMB, parent->cumulativeBytes());
 }
 
 TEST(MemoryUsageTrackerTest, reserve) {
   constexpr int64_t kMaxSize = 1 << 30;
   constexpr int64_t kMB = 1 << 20;
-  auto config = MemoryUsageConfigBuilder().maxUserMemory(kMaxSize).build();
-  auto parent = MemoryUsageTracker::create(config);
+  auto parent = MemoryUsageTracker::create(kMaxSize);
 
   auto child = parent->addChild();
 
   EXPECT_THROW(child->reserve(2 * kMaxSize), VeloxRuntimeError);
 
   child->reserve(100 * kMB);
-  EXPECT_EQ(0, child->getCurrentTotalBytes());
+  EXPECT_EQ(0, child->currentBytes());
   // The reservationon child shows up as a reservation on the child
   // and as an allocation on the parent.
-  EXPECT_EQ(104 * kMB, child->getAvailableReservation());
-  EXPECT_EQ(0, child->getCurrentTotalBytes());
-  EXPECT_EQ(104 * kMB, parent->getCurrentTotalBytes());
+  EXPECT_EQ(104 * kMB, child->availableReservation());
+  EXPECT_EQ(0, child->currentBytes());
+  EXPECT_EQ(104 * kMB, parent->currentBytes());
   child->update(60 * kMB);
-  EXPECT_EQ(60 * kMB, child->getCurrentTotalBytes());
-  EXPECT_EQ(104 * kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ((104 - 60) * kMB, child->getAvailableReservation());
+  EXPECT_EQ(60 * kMB, child->currentBytes());
+  EXPECT_EQ(104 * kMB, parent->currentBytes());
+  EXPECT_EQ((104 - 60) * kMB, child->availableReservation());
   child->update(70 * kMB);
   // Extended and rounded up the reservation to then next 8MB.
-  EXPECT_EQ(136 * kMB, parent->getCurrentTotalBytes());
+  EXPECT_EQ(136 * kMB, parent->currentBytes());
   child->update(-130 * kMB);
   // The reservation goes down to the explicitly made reservation.
-  EXPECT_EQ(104 * kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(104 * kMB, child->getAvailableReservation());
+  EXPECT_EQ(104 * kMB, parent->currentBytes());
+  EXPECT_EQ(104 * kMB, child->availableReservation());
   child->release();
-  EXPECT_EQ(0, parent->getCurrentTotalBytes());
+  EXPECT_EQ(0, parent->currentBytes());
 }
 
 TEST(MemoryUsageTrackerTest, reserveAndUpdate) {
   constexpr int64_t kMaxSize = 1 << 30; // 1GB
   constexpr int64_t kMB = 1 << 20;
-  auto config = MemoryUsageConfigBuilder().maxUserMemory(kMaxSize).build();
-  auto parent = MemoryUsageTracker::create(config);
+  auto parent = MemoryUsageTracker::create(kMaxSize);
 
   auto child1 = parent->addChild();
 
   child1->update(1000);
-  EXPECT_EQ(kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(kMB - 1000, child1->getAvailableReservation());
+  EXPECT_EQ(kMB, parent->currentBytes());
+  EXPECT_EQ(kMB - 1000, child1->availableReservation());
   child1->update(1000);
-  EXPECT_EQ(kMB, parent->getCurrentTotalBytes());
+  EXPECT_EQ(kMB, parent->currentBytes());
 
   child1->reserve(kMB);
-  EXPECT_EQ(2 * kMB, parent->getCurrentTotalBytes());
+  EXPECT_EQ(2 * kMB, parent->currentBytes());
   child1->update(kMB);
 
   // release has no effect  since usage within quantum of reservation.
   child1->release();
-  EXPECT_EQ(2 * kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(2000 + kMB, child1->getCurrentTotalBytes());
-  EXPECT_EQ(kMB - 2000, child1->getAvailableReservation());
+  EXPECT_EQ(2 * kMB, parent->currentBytes());
+  EXPECT_EQ(2000 + kMB, child1->currentBytes());
+  EXPECT_EQ(kMB - 2000, child1->availableReservation());
 
   // We reserve 20MB, consume 9MB and release the unconsumed.
   child1->reserve(20 * kMB);
   // 22 rounded up to 24.
-  EXPECT_EQ(24 * kMB, parent->getCurrentTotalBytes());
+  EXPECT_EQ(24 * kMB, parent->currentBytes());
   child1->update(7 * kMB);
-  EXPECT_EQ(16 * kMB - 2000, child1->getAvailableReservation());
+  EXPECT_EQ(16 * kMB - 2000, child1->availableReservation());
   child1->release();
-  EXPECT_EQ(kMB - 2000, child1->getAvailableReservation());
-  EXPECT_EQ(9 * kMB, parent->getCurrentTotalBytes());
+  EXPECT_EQ(kMB - 2000, child1->availableReservation());
+  EXPECT_EQ(9 * kMB, parent->currentBytes());
 
   // We reserve another 20 MB, consume 25 and release nothing because
   // reservation is already taken.
   child1->reserve(20 * kMB);
   child1->update(25 * kMB);
-  EXPECT_EQ(36 * kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(3 * kMB - 2000, child1->getAvailableReservation());
+  EXPECT_EQ(36 * kMB, parent->currentBytes());
+  EXPECT_EQ(3 * kMB - 2000, child1->availableReservation());
   child1->release();
 
   // Nothing changed by release since already over the explicit reservation.
-  EXPECT_EQ(36 * kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(3 * kMB - 2000, child1->getAvailableReservation());
+  EXPECT_EQ(36 * kMB, parent->currentBytes());
+  EXPECT_EQ(3 * kMB - 2000, child1->availableReservation());
 
   // We reserve 20MB and free 5MB and release. Expect 25MB drop.
   child1->reserve(20 * kMB);
   child1->update(-5 * kMB);
-  EXPECT_EQ(28 * kMB - 2000, child1->getAvailableReservation());
-  EXPECT_EQ(56 * kMB, parent->getCurrentTotalBytes());
+  EXPECT_EQ(28 * kMB - 2000, child1->availableReservation());
+  EXPECT_EQ(56 * kMB, parent->currentBytes());
 
   // Reservation drops by 25, rounded to  quantized size of 32.
   child1->release();
 
-  EXPECT_EQ(32 * kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(4 * kMB - 2000, child1->getAvailableReservation());
+  EXPECT_EQ(32 * kMB, parent->currentBytes());
+  EXPECT_EQ(4 * kMB - 2000, child1->availableReservation());
 
   // We reserve 20MB, allocate 25 and free 15
   child1->reserve(20 * kMB);
   child1->update(25 * kMB);
-  EXPECT_EQ(56 * kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(3 * kMB - 2000, child1->getAvailableReservation());
+  EXPECT_EQ(56 * kMB, parent->currentBytes());
+  EXPECT_EQ(3 * kMB - 2000, child1->availableReservation());
   child1->update(-15 * kMB);
 
   // There is 14MB - 2000  of available reservation because the reservation does
   // not drop below the bar set in reserve(). The used size reflected in the
   // parent drops a little to match the level given in reserver().
-  EXPECT_EQ(52 * kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(14 * kMB - 2000, child1->getAvailableReservation());
+  EXPECT_EQ(52 * kMB, parent->currentBytes());
+  EXPECT_EQ(14 * kMB - 2000, child1->availableReservation());
 
   // The unused reservation is freed.
   child1->release();
-  EXPECT_EQ(40 * kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(2 * kMB - 2000, child1->getAvailableReservation());
+  EXPECT_EQ(40 * kMB, parent->currentBytes());
+  EXPECT_EQ(2 * kMB - 2000, child1->availableReservation());
 }
 
 namespace {
 // Model implementation of a GrowCallback.
-bool grow(
-    MemoryUsageTracker::UsageType /*type*/,
-    int64_t /*size*/,
-    int64_t hardLimit,
-    MemoryUsageTracker& tracker) {
+bool grow(int64_t /*size*/, int64_t hardLimit, MemoryUsageTracker& tracker) {
   static std::mutex mutex;
   // The calls from different threads on the same tracker must be serialized.
   std::lock_guard<std::mutex> l(mutex);
   // The total includes the allocation that exceeded the limit. This function's
   // job is to raise the limit to >= current.
-  auto current = tracker.totalReservedBytes();
-  auto limit = tracker.maxTotalBytes();
+  auto current = tracker.reservedBytes();
+  auto limit = tracker.maxMemory();
   if (current <= limit) {
     // No need to increase. It could be another thread already
     // increased the cap far enough while this thread was waiting to
@@ -222,41 +212,34 @@ bool grow(
     return false;
   }
   // We set the new limit to be the requested size.
-  auto config = MemoryUsageConfigBuilder().maxTotalMemory(current).build();
-  tracker.updateConfig(config);
+  tracker.testingUpdateMaxMemory(current);
   return true;
 }
 } // namespace
 
 TEST(MemoryUsageTrackerTest, grow) {
   constexpr int64_t kMB = 1 << 20;
-  auto config = MemoryUsageConfigBuilder().maxTotalMemory(10 * kMB).build();
-  auto parent = MemoryUsageTracker::create(config);
+  auto parent = MemoryUsageTracker::create(10 * kMB);
 
   auto child = parent->addChild();
-  auto childConfig = MemoryUsageConfigBuilder().maxTotalMemory(5 * kMB).build();
-  child->updateConfig(childConfig);
+  child->testingUpdateMaxMemory(5 * kMB);
   int64_t parentLimit = 100 * kMB;
   int64_t childLimit = 150 * kMB;
-  parent->setGrowCallback([&](MemoryUsageTracker::UsageType type,
-                              int64_t size,
-                              MemoryUsageTracker& tracker) {
-    return grow(type, size, parentLimit, tracker);
+  parent->setGrowCallback([&](int64_t size, MemoryUsageTracker& tracker) {
+    return grow(size, parentLimit, tracker);
   });
-  child->setGrowCallback([&](MemoryUsageTracker::UsageType type,
-                             int64_t size,
-                             MemoryUsageTracker& tracker) {
-    return grow(type, size, childLimit, tracker);
+  child->setGrowCallback([&](int64_t size, MemoryUsageTracker& tracker) {
+    return grow(size, childLimit, tracker);
   });
 
   child->update(10 * kMB);
-  EXPECT_EQ(10 * kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(10 * kMB, child->maxTotalBytes());
+  EXPECT_EQ(10 * kMB, parent->currentBytes());
+  EXPECT_EQ(10 * kMB, child->maxMemory());
   EXPECT_THROW(child->update(100 * kMB), VeloxRuntimeError);
-  EXPECT_EQ(10 * kMB, child->getCurrentTotalBytes());
+  EXPECT_EQ(10 * kMB, child->currentBytes());
   // The parent failed to increase limit, the child'd limit should be unchanged.
-  EXPECT_EQ(10 * kMB, child->maxTotalBytes());
-  EXPECT_EQ(10 * kMB, parent->maxTotalBytes());
+  EXPECT_EQ(10 * kMB, child->maxMemory());
+  EXPECT_EQ(10 * kMB, parent->maxMemory());
 
   // We pass the parent limit but fail te child limit. leaves a raised
   // limit on the parent. Rolling back the increment of parent limit
@@ -266,52 +249,170 @@ TEST(MemoryUsageTrackerTest, grow) {
   // trackers with a limit but we cover this for documentation.
   parentLimit = 200 * kMB;
   EXPECT_THROW(child->update(160 * kMB);, VeloxException);
-  EXPECT_EQ(10 * kMB, parent->getCurrentTotalBytes());
-  EXPECT_EQ(10 * kMB, child->getCurrentTotalBytes());
+  EXPECT_EQ(10 * kMB, parent->currentBytes());
+  EXPECT_EQ(10 * kMB, child->currentBytes());
   // The child limit could not be raised.
-  EXPECT_EQ(10 * kMB, child->maxTotalBytes());
+  EXPECT_EQ(10 * kMB, child->maxMemory());
   // The parent limit got set to 170, rounded up to 176
-  EXPECT_EQ(176 * kMB, parent->maxTotalBytes());
+  EXPECT_EQ(176 * kMB, parent->maxMemory());
 }
 
 TEST(MemoryUsageTrackerTest, maybeReserve) {
   constexpr int64_t kMB = 1 << 20;
-  auto config =
-      memory::MemoryUsageConfigBuilder().maxTotalMemory(10 * kMB).build();
-  auto parent = memory::MemoryUsageTracker::create(config);
+  auto parent = memory::MemoryUsageTracker::create(10 * kMB);
   auto child = parent->addChild();
-  auto childConfig = memory::MemoryUsageConfigBuilder().build();
-  child->updateConfig(childConfig);
+  child->testingUpdateMaxMemory(kMaxMemory);
   // 1MB can be reserved, rounds up to 8 and leaves 2 unreserved in parent.
   EXPECT_TRUE(child->maybeReserve(kMB));
-  EXPECT_EQ(0, child->getCurrentUserBytes());
-  EXPECT_EQ(8 * kMB, child->getAvailableReservation());
-  EXPECT_EQ(8 * kMB, parent->getCurrentUserBytes());
+  EXPECT_EQ(0, child->currentBytes());
+  EXPECT_EQ(8 * kMB, child->availableReservation());
+  EXPECT_EQ(8 * kMB, parent->currentBytes());
   // Fails to reserve 100MB, existing reservations are unchanged.
   EXPECT_FALSE(child->maybeReserve(100 * kMB));
-  EXPECT_EQ(0, child->getCurrentTotalBytes());
+  EXPECT_EQ(0, child->currentBytes());
   // Use some memory from child and expect there is no memory usage change in
   // parent.
   constexpr int64_t kB = 1 << 10;
   constexpr int64_t childMemUsageBytes = 10 * kB;
   child->update(childMemUsageBytes);
-  EXPECT_EQ(8 * kMB - childMemUsageBytes, child->getAvailableReservation());
-  EXPECT_EQ(8 * kMB, parent->getCurrentUserBytes());
+  EXPECT_EQ(8 * kMB - childMemUsageBytes, child->availableReservation());
+  EXPECT_EQ(8 * kMB, parent->currentBytes());
   // Free up the memory usage and expect the reserved memory is still available,
   // and there is no memory usage change in parent.
   child->update(-childMemUsageBytes);
-  EXPECT_EQ(8 * kMB, child->getAvailableReservation());
-  EXPECT_EQ(8 * kMB, parent->getCurrentUserBytes());
+  EXPECT_EQ(8 * kMB, child->availableReservation());
+  EXPECT_EQ(8 * kMB, parent->currentBytes());
   // Release the child reserved memory.
   child->release();
-  EXPECT_EQ(0, parent->getCurrentUserBytes());
+  EXPECT_EQ(0, parent->currentBytes());
 
   child = parent->addChild();
   EXPECT_TRUE(child->maybeReserve(kMB));
-  EXPECT_EQ(0, child->getCurrentUserBytes());
-  EXPECT_EQ(8 * kMB, child->getAvailableReservation());
-  EXPECT_EQ(8 * kMB, parent->getCurrentUserBytes());
+  EXPECT_EQ(0, child->currentBytes());
+  EXPECT_EQ(8 * kMB, child->availableReservation());
+  EXPECT_EQ(8 * kMB, parent->currentBytes());
   child.reset();
   // The child destruction won't release the reserved memory back to the parent.
-  EXPECT_EQ(8 * kMB, parent->getCurrentUserBytes());
+  EXPECT_EQ(8 * kMB, parent->currentBytes());
+}
+
+// Class used to test operations on MemoryUsageTracker.
+class MemoryUsageTrackTester {
+ public:
+  MemoryUsageTrackTester(
+      int32_t id,
+      int64_t maxMemory,
+      memory::MemoryUsageTracker& tracker)
+      : id_(id), maxMemory_(maxMemory), tracker_(tracker) {}
+
+  ~MemoryUsageTrackTester() {
+    VELOX_CHECK_GE(usedBytes_, 0);
+    if (usedBytes_ != 0) {
+      tracker_.update(-usedBytes_);
+    }
+  }
+
+  void run() {
+    const int32_t op = folly::Random().rand32() % 5;
+    switch (op) {
+      case 0: {
+        // update increase.
+        const int64_t updateBytes = folly::Random().rand32() % maxMemory_;
+        try {
+          tracker_.update(updateBytes);
+        } catch (VeloxException& e) {
+          // Ignore memory limit exception.
+          ASSERT_TRUE(e.message().find("Negative") == std::string::npos);
+          return;
+        }
+        usedBytes_ += updateBytes;
+        break;
+      }
+      case 1: {
+        // update decrease.
+        if (usedBytes_ > 0) {
+          const int64_t updateBytes = folly::Random().rand32() % usedBytes_;
+          tracker_.update(-updateBytes);
+          usedBytes_ -= updateBytes;
+          ASSERT_GE(usedBytes_, 0);
+        }
+        break;
+      }
+      case 2: {
+        // reserve.
+        const int64_t reservedBytes = folly::Random().rand32() % maxMemory_;
+        try {
+          tracker_.reserve(reservedBytes);
+        } catch (VeloxException& e) {
+          // Ignore memory limit exception.
+          ASSERT_TRUE(e.message().find("Negative") == std::string::npos);
+          return;
+        }
+        break;
+      }
+      case 3: {
+        // maybe reserve.
+        const int64_t reservedBytes = folly::Random().rand32() % maxMemory_;
+        tracker_.maybeReserve(reservedBytes);
+        break;
+      }
+      case 4:
+        // release.
+        tracker_.release();
+        ASSERT_LE(usedBytes_, tracker_.currentBytes());
+        break;
+    }
+  }
+
+ private:
+  const int32_t id_;
+  const int64_t maxMemory_;
+  memory::MemoryUsageTracker& tracker_;
+  int64_t usedBytes_{0};
+};
+
+TEST(MemoryUsageTrackerTest, concurrentUpdate) {
+  constexpr int64_t kMB = 1 << 20;
+  constexpr int64_t kMaxMemory = 10 * kMB;
+  auto parent = memory::MemoryUsageTracker::create(kMaxMemory);
+  const int32_t kNumThreads = 10;
+  // Create one memory tracker per each thread.
+  std::vector<std::shared_ptr<MemoryUsageTracker>> childTrackers;
+  for (int32_t i = 0; i < kNumThreads; ++i) {
+    childTrackers.push_back(parent->addChild());
+  }
+
+  folly::Random::DefaultGenerator rng;
+  rng.seed(1234);
+
+  const int32_t kNumOpsPerThread = 50'000;
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  for (size_t i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([&, i]() {
+      // Set 2x of actual limit to trigger memory limit exception more
+      // frequently.
+      MemoryUsageTrackTester tester(i, kMaxMemory, *childTrackers[i]);
+      for (int32_t iter = 0; iter < kNumOpsPerThread; ++iter) {
+        tester.run();
+      }
+    });
+  }
+
+  for (auto& th : threads) {
+    th.join();
+  }
+  ASSERT_EQ(parent->availableReservation(), 0);
+  for (int32_t i = 0; i < kNumThreads; ++i) {
+    auto& child = childTrackers[i];
+    ASSERT_EQ(child->currentBytes(), 0);
+    child->release();
+    ASSERT_EQ(child->reservedBytes(), 0);
+    ASSERT_EQ(child->availableReservation(), 0);
+    ASSERT_EQ(child->currentBytes(), 0);
+    ASSERT_LE(child->peakBytes(), child->cumulativeBytes());
+  }
+  ASSERT_LE(parent->peakBytes(), parent->cumulativeBytes());
+  childTrackers.clear();
+  ASSERT_LE(parent->peakBytes(), parent->cumulativeBytes());
 }

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -145,9 +145,7 @@ class QueryCtx : public Context {
   void initPool(const std::string& queryId) {
     pool_ = memory::getProcessDefaultMemoryManager().getRoot().addChild(
         QueryCtx::generatePoolName(queryId));
-    static const auto kUnlimited = std::numeric_limits<int64_t>::max();
-    pool_->setMemoryUsageTracker(
-        memory::MemoryUsageTracker::create(kUnlimited, kUnlimited, kUnlimited));
+    pool_->setMemoryUsageTracker(memory::MemoryUsageTracker::create());
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -505,7 +505,7 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   }
 
   auto tracker = mappedMemory_->tracker();
-  const auto currentUsage = tracker->getCurrentUserBytes();
+  const auto currentUsage = tracker->currentBytes();
   if (spillMemoryThreshold_ != 0 && currentUsage > spillMemoryThreshold_) {
     const int64_t bytesToSpill =
         currentUsage * spillConfig_->spillableReservationGrowthPct / 100;
@@ -531,7 +531,7 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
       rows->sizeIncrement(input->size(), outOfLineBytes ? flatBytes : 0) +
       tableIncrement;
   // There must be at least 2x the increment in reservation.
-  if (tracker->getAvailableReservation() > 2 * increment) {
+  if (tracker->availableReservation() > 2 * increment) {
     return;
   }
   // Check if can increase reservation. The increment is the larger of

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -429,7 +429,7 @@ bool HashBuild::reserveMemory(const RowVectorPtr& input) {
 
   auto tracker = CHECK_NOTNULL(mappedMemory_->tracker());
   // There must be at least 2x the increments in reservation.
-  if (tracker->getAvailableReservation() > 2 * increment) {
+  if (tracker->availableReservation() > 2 * increment) {
     return true;
   }
 
@@ -438,8 +438,8 @@ bool HashBuild::reserveMemory(const RowVectorPtr& input) {
   // 'spillableReservationGrowthPct_' of the current reservation.
   auto targetIncrement = std::max<int64_t>(
       increment * 2,
-      tracker->getCurrentUserBytes() *
-          spillConfig()->spillableReservationGrowthPct / 100);
+      tracker->currentBytes() * spillConfig()->spillableReservationGrowthPct /
+          100);
   if (tracker->maybeReserve(targetIncrement)) {
     return true;
   }

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -165,7 +165,7 @@ Operator::Operator(
           std::stringstream out;
           out << "\nFailed Operator: " << this->operatorType() << "."
               << this->operatorId() << ": "
-              << succinctBytes(tracker.getCurrentTotalBytes());
+              << succinctBytes(tracker.currentBytes());
           return out.str();
         });
   }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -47,15 +47,15 @@ struct MemoryStats {
   uint64_t numMemoryAllocations{0};
 
   void update(const std::shared_ptr<memory::MemoryUsageTracker>& tracker) {
-    if (!tracker) {
+    if (tracker == nullptr) {
       return;
     }
-    userMemoryReservation = tracker->getCurrentUserBytes();
-    systemMemoryReservation = tracker->getCurrentSystemBytes();
-    peakUserMemoryReservation = tracker->getPeakUserBytes();
-    peakSystemMemoryReservation = tracker->getPeakSystemBytes();
-    peakTotalMemoryReservation = tracker->getPeakTotalBytes();
-    numMemoryAllocations = tracker->getNumAllocs();
+    userMemoryReservation = tracker->currentBytes();
+    systemMemoryReservation = 0;
+    peakUserMemoryReservation = tracker->peakBytes();
+    peakSystemMemoryReservation = 0;
+    peakTotalMemoryReservation = tracker->peakBytes();
+    numMemoryAllocations = tracker->numAllocs();
   }
 
   void add(const MemoryStats& other) {

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -157,7 +157,7 @@ void OrderBy::ensureInputFits(const RowVectorPtr& input) {
 
   auto tracker = mappedMemory_->tracker();
   VELOX_CHECK_NOT_NULL(tracker);
-  const auto currentUsage = tracker->getCurrentUserBytes();
+  const auto currentUsage = tracker->currentBytes();
   if (spillMemoryThreshold_ != 0 && currentUsage > spillMemoryThreshold_) {
     const int64_t bytesToSpill =
         currentUsage * spillConfig.spillableReservationGrowthPct / 100;
@@ -184,7 +184,7 @@ void OrderBy::ensureInputFits(const RowVectorPtr& input) {
       data_->sizeIncrement(input->size(), outOfLineBytes ? flatInputBytes : 0);
 
   // There must be at least 2x the increment in reservation.
-  if (tracker->getAvailableReservation() > 2 * incrementBytes) {
+  if (tracker->availableReservation() > 2 * incrementBytes) {
     return;
   }
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1894,8 +1894,7 @@ struct TaskMemoryUsage {
 void collectOperatorMemoryUsage(
     NodeMemoryUsage& nodeMemoryUsage,
     memory::MemoryPool* operatorPool) {
-  const auto numBytes =
-      operatorPool->getMemoryUsageTracker()->getCurrentTotalBytes();
+  const auto numBytes = operatorPool->getMemoryUsageTracker()->currentBytes();
   nodeMemoryUsage.total.update(numBytes);
   auto& operatorMemoryUsage = nodeMemoryUsage.operators[operatorPool->name()];
   operatorMemoryUsage.update(numBytes);
@@ -1906,7 +1905,7 @@ void collectNodeMemoryUsage(
     memory::MemoryPool* nodePool) {
   // Update task's stats from each node.
   taskMemoryUsage.total.update(
-      nodePool->getMemoryUsageTracker()->getCurrentTotalBytes());
+      nodePool->getMemoryUsageTracker()->currentBytes());
 
   // NOTE: we use a plan node id as the node memory pool's name.
   const auto& poolName = nodePool->name();
@@ -1949,8 +1948,7 @@ std::string getQueryMemoryUsageString(memory::MemoryPool* queryPool) {
   out << "\n";
   out << queryPool->name();
   out << ": total: ";
-  out << succinctBytes(
-      queryPool->getMemoryUsageTracker()->getCurrentTotalBytes());
+  out << succinctBytes(queryPool->getMemoryUsageTracker()->currentBytes());
   for (const auto& taskMemoryUsage : taskMemoryUsages) {
     taskMemoryUsage.toString(out);
     // Collect each operator's memory usage into the vector.

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -3150,8 +3150,8 @@ TEST_F(HashJoinTest, memory) {
   params.queryCtx->pool()->setMemoryUsageTracker(tracker);
 
   auto [taskCursor, rows] = readCursor(params, [](Task*) {});
-  EXPECT_GT(3'500, tracker->getNumAllocs());
-  EXPECT_GT(7'500'000, tracker->getCumulativeBytes());
+  EXPECT_GT(3'500, tracker->numAllocs());
+  EXPECT_GT(7'500'000, tracker->cumulativeBytes());
 }
 
 TEST_F(HashJoinTest, lazyVectors) {
@@ -3855,7 +3855,7 @@ TEST_F(HashJoinTest, memoryUsage) {
         // Verify number of memory allocations. Should not be too high if
         // hash join is able to re-use output vectors that contain
         // build-side data.
-        ASSERT_GT(40, task->pool()->getMemoryUsageTracker()->getNumAllocs());
+        ASSERT_GT(40, task->pool()->getMemoryUsageTracker()->numAllocs());
       })
       .run();
 }

--- a/velox/exec/tests/MemoryCapExceededTest.cpp
+++ b/velox/exec/tests/MemoryCapExceededTest.cpp
@@ -69,8 +69,7 @@ TEST_F(MemoryCapExceededTest, singleDriver) {
                   .planNode();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->pool()->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(
-          kMaxBytes, kMaxBytes, kMaxBytes));
+      velox::memory::MemoryUsageTracker::create(kMaxBytes));
   CursorParameters params;
   params.planNode = plan;
   params.queryCtx = queryCtx;
@@ -114,8 +113,7 @@ TEST_F(MemoryCapExceededTest, multipleDrivers) {
                   .planNode();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->pool()->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(
-          kMaxBytes, kMaxBytes, kMaxBytes));
+      velox::memory::MemoryUsageTracker::create(kMaxBytes));
 
   const int32_t numDrivers = 10;
   CursorParameters params;

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -428,7 +428,7 @@ TEST_F(OrderByTest, spill) {
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   constexpr int64_t kMaxBytes = 20LL << 20; // 20 MB
   queryCtx->pool()->setMemoryUsageTracker(
-      memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
+      memory::MemoryUsageTracker::create(kMaxBytes));
   // Set 'kSpillableReservationGrowthPct' to an extreme large value to trigger
   // disk spilling by failed memory growth reservation.
   queryCtx->setConfigOverridesUnsafe({
@@ -480,7 +480,7 @@ TEST_F(OrderByTest, spillWithMemoryLimit) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->pool()->setMemoryUsageTracker(
-        memory::MemoryUsageTracker::create(kMaxBytes, 0, kMaxBytes));
+        memory::MemoryUsageTracker::create(kMaxBytes));
     auto results =
         AssertQueryBuilder(
             PlanBuilder()

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -903,10 +903,10 @@ TEST_F(SimpleFunctionTest, reuseArgVector) {
 
   pool_->setMemoryUsageTracker(memory::MemoryUsageTracker::create());
 
-  auto prevAllocations = pool_->getMemoryUsageTracker()->getNumAllocs();
+  auto prevAllocations = pool_->getMemoryUsageTracker()->numAllocs();
 
   evaluate(*exprSet, data);
-  auto currAllocations = pool_->getMemoryUsageTracker()->getNumAllocs();
+  auto currAllocations = pool_->getMemoryUsageTracker()->numAllocs();
 
   // Expect a single allocation for the result. Intermediate results should
   // reuse memory.

--- a/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
@@ -135,8 +135,7 @@ TYPED_TEST(ApproxMostFrequentTest, emptyGroup) {
 using ApproxMostFrequentTestInt = ApproxMostFrequentTest<int>;
 
 TEST_F(ApproxMostFrequentTestInt, invalidBuckets) {
-  pool()->getMemoryUsageTracker()->updateConfig(
-      memory::MemoryUsageConfigBuilder().maxTotalMemory(1 << 21).build());
+  pool()->getMemoryUsageTracker()->testingUpdateMaxMemory(1 << 21);
   auto run = [&](int64_t buckets) {
     auto rows = makeRowVector({
         makeConstant<int64_t>(buckets, buckets),

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -221,12 +221,12 @@ class StringFunctionsTest : public FunctionBaseTest {
     // We expect 2 allocations: one for the values buffer and another for the
     // strings buffer. I.e. FlatVector<StringView>::values and
     // FlatVector<StringView>::stringBuffers.
-    auto numAllocsBefore = pool()->getMemoryUsageTracker()->getNumAllocs();
+    auto numAllocsBefore = pool()->getMemoryUsageTracker()->numAllocs();
 
     auto result = evaluate<FlatVector<StringView>>(
         buildConcatQuery(), makeRowVector(inputVectors));
 
-    auto numAllocsAfter = pool()->getMemoryUsageTracker()->getNumAllocs();
+    auto numAllocsAfter = pool()->getMemoryUsageTracker()->numAllocs();
     ASSERT_EQ(numAllocsAfter - numAllocsBefore, 2);
 
     auto concatStd = [](const std::vector<std::string>& inputs) {

--- a/velox/vector/tests/VectorPrepareForReuseTest.cpp
+++ b/velox/vector/tests/VectorPrepareForReuseTest.cpp
@@ -30,22 +30,22 @@ class MemoryAllocationChecker {
  public:
   explicit MemoryAllocationChecker(memory::MemoryPool* pool)
       : tracker_{pool->getMemoryUsageTracker().get()},
-        numAllocations_{tracker_->getNumAllocs()} {}
+        numAllocations_{tracker_->numAllocs()} {}
 
   bool assertOne() {
-    bool ok = numAllocations_ + 1 == tracker_->getNumAllocs();
-    numAllocations_ = tracker_->getNumAllocs();
+    bool ok = numAllocations_ + 1 == tracker_->numAllocs();
+    numAllocations_ = tracker_->numAllocs();
     return ok;
   }
 
   bool assertAtLeastOne() {
-    bool ok = numAllocations_ < tracker_->getNumAllocs();
-    numAllocations_ = tracker_->getNumAllocs();
+    bool ok = numAllocations_ < tracker_->numAllocs();
+    numAllocations_ = tracker_->numAllocs();
     return ok;
   }
 
   ~MemoryAllocationChecker() {
-    EXPECT_EQ(numAllocations_, tracker_->getNumAllocs());
+    EXPECT_EQ(numAllocations_, tracker_->numAllocs());
   }
 
  private:


### PR DESCRIPTION
Remove memory usage type from MemoryUsageTracker and
add a multi-threading test for memory tracker.

Followups: make leaf tracker update thread-safe.