### PR TITLE
Fix error: no return statement in function returning non-void

### DIFF
--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -200,11 +200,17 @@ const ::substrait::Expression_Literal& toSubstraitNotNullLiteral(
 
 template <TypeKind kind>
 const ::substrait::Expression_Literal& toSubstraitNotNullLiteral(
-    google::protobuf::Arena& /* arena */,
+    google::protobuf::Arena& arena,
     const typename TypeTraits<kind>::NativeType& /* value */) {
   VELOX_UNSUPPORTED(
       "toSubstraitNotNullLiteral function doesn't support {} type",
       TypeTraits<kind>::name);
+
+  // Make compiler happy.
+  ::substrait::Expression_Literal* literalExpr =
+      google::protobuf::Arena::CreateMessage<::substrait::Expression_Literal>(
+          &arena);
+  return *literalExpr;
 }
 
 template <>


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/facebookincubator/velox/17954/workflows/814c450e-6270-4aca-9af6-0f8c75150d53/jobs/113229

```
../../velox/substrait/VeloxToSubstraitExpr.cpp: In function 'const substrait::Expression_Literal& facebook::velox::substrait::{anonymous}::toSubstraitNotNullLiteral(google::protobuf::Arena&, const typename facebook::velox::TypeTraits<KIND>::NativeType&)':
../../velox/substrait/VeloxToSubstraitExpr.cpp:208:1: error: no return statement in function returning non-void [-Werror=return-type]
  208 | }
      | ^
```