### PR TITLE
Disable aggregation fuzzer test at every PR and update skip function list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,23 +277,6 @@ jobs:
       - store_artifacts:
           path: '/tmp/fuzzer_repro'
       - run:
-          name: "Run Aggregate Fuzzer Tests"
-          # Run aggregation fuzzer using the built executable.
-          command: |
-            mkdir -p /tmp/aggregate_fuzzer_repro/
-            rm -rfv /tmp/aggregate_fuzzer_repro/*
-            chmod -R 777 /tmp/aggregate_fuzzer_repro
-            _build/debug/velox/exec/tests/velox_aggregation_fuzzer_test \
-                --seed 123456 \
-                --duration_sec 60 \
-                --logtostderr=1 \
-                --minloglevel=0 \
-                --repro_persist_path=/tmp/aggregate_fuzzer_repro \
-            && echo -e "\n\nAggregation fuzzer run finished successfully."
-          no_output_timeout: 5m
-      - store_artifacts:
-          path: '/tmp/aggregate_fuzzer_repro'
-      - run:
          name: "Run Example Binaries"
          command: |
            find _build/debug/velox/examples/ -maxdepth 1 -type f -executable -exec "{}" \;

--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -51,6 +51,7 @@ int main(int argc, char** argv) {
   // be fixed before we can enable.
   std::unordered_set<std::string> skipFunctions = {
       "stddev_pop", // https://github.com/facebookincubator/velox/issues/3493
+      "approx_percentile", // https://github.com/facebookincubator/velox/issues/3556
   };
 
   // The results of the following functions depend on the order of input


### PR DESCRIPTION
Summary: The aggregation fuzzer test failed in nightly build due to approx_percentile, so disable this test at PR time until we make sure it succeed stably. Also add approx_percentile to the skip function list until it is fixed.

Differential Revision: D42173776

