### PR TITLE
fuzzMap calls in VectorFuzzer yield inconsistent results across platforms

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -287,6 +287,9 @@ class VectorFuzzer {
 
   memory::MemoryPool* pool_;
 
+  // Be careful not to call any functions that use rng_ inline as arguments to a
+  // function.  C++ does not guarantee the order in which arguments are
+  // evaluated, which can lead to inconsistent results across platforms.
   FuzzerGenerator rng_;
 };
 


### PR DESCRIPTION
Summary:
The order arguments are evaluated in a function call in C++ is not specified.

This leads to issues when we call functions that invoke our RNG in the VectorFuzzer in two arguments, like these fuzzMap calls where we call one such function for the keys and one for the values.

This came up when trying to repro
https://github.com/facebookincubator/velox/issues/3419

In the CircleCI environment the values were generated before the keys when calling fuzzMap, while in my local environment the keys were generated before the values.  I was getting different results and unable to reproduce the issue.

Constructing the arguments outside the function call allows us to control the order in which their invoked.

Differential Revision: D42178884

