### PR TITLE
Zip UDF fast path breaks with non-dense in order elements

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -39,7 +39,7 @@ AggregateFunctionMap& aggregateFunctions() {
 namespace {
 std::optional<const AggregateFunctionEntry*> getAggregateFunctionEntry(
     const std::string& name) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
 
   auto& functionsMap = aggregateFunctions();
   auto it = functionsMap.find(sanitizedName);
@@ -55,7 +55,7 @@ bool registerAggregateFunction(
     const std::string& name,
     std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures,
     AggregateFunctionFactory factory) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
 
   aggregateFunctions()[sanitizedName] = {
       std::move(signatures), std::move(factory)};

--- a/velox/exec/WindowFunction.cpp
+++ b/velox/exec/WindowFunction.cpp
@@ -41,7 +41,7 @@ bool registerWindowFunction(
     const std::string& name,
     std::vector<FunctionSignaturePtr> signatures,
     WindowFunctionFactory factory) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
   windowFunctions()[sanitizedName] = {
       std::move(signatures), std::move(factory)};
   return true;
@@ -49,7 +49,7 @@ bool registerWindowFunction(
 
 std::optional<std::vector<FunctionSignaturePtr>> getWindowFunctionSignatures(
     const std::string& name) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
   if (auto func = getWindowFunctionEntry(sanitizedName)) {
     return func.value()->signatures;
   }

--- a/velox/expression/FunctionRegistry.h
+++ b/velox/expression/FunctionRegistry.h
@@ -133,7 +133,7 @@ class FunctionRegistry {
       const std::shared_ptr<const Metadata>& metadata,
       const typename FunctionEntry<Function, Metadata>::FunctionFactory&
           factory) {
-    const auto sanitizedName = sanitizeFunctionName(name);
+    const auto sanitizedName = sanitizeName(name);
     SignatureMap& signatureMap = registeredFunctions_[sanitizedName];
     signatureMap[*metadata->signature()] =
         std::make_unique<const FunctionEntry<Function, Metadata>>(
@@ -141,7 +141,7 @@ class FunctionRegistry {
   }
 
   const SignatureMap* getSignatureMap(const std::string& name) const {
-    const auto sanitizedName = sanitizeFunctionName(name);
+    const auto sanitizedName = sanitizeName(name);
     const auto it = registeredFunctions_.find(sanitizedName);
     return it != registeredFunctions_.end() ? &it->second : nullptr;
   }

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -22,7 +22,7 @@
 
 namespace facebook::velox::exec {
 
-std::string sanitizeFunctionName(const std::string& name) {
+std::string sanitizeName(const std::string& name) {
   std::string sanitizedName;
   sanitizedName.resize(name.size());
   std::transform(

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -25,7 +25,7 @@
 
 namespace facebook::velox::exec {
 
-std::string sanitizeFunctionName(const std::string& name);
+std::string sanitizeName(const std::string& name);
 
 inline bool isCommonDecimalName(const std::string& typeName) {
   return (typeName == "DECIMAL");

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -28,7 +28,7 @@ VectorFunctionMap& vectorFunctionFactories() {
 
 std::optional<std::vector<FunctionSignaturePtr>> getVectorFunctionSignatures(
     const std::string& name) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
 
   return vectorFunctionFactories()
       .withRLock([&sanitizedName](auto& functions) -> auto {
@@ -58,7 +58,7 @@ std::shared_ptr<VectorFunction> getVectorFunction(
     const std::string& name,
     const std::vector<TypePtr>& inputTypes,
     const std::vector<VectorPtr>& constantInputs) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
 
   if (!constantInputs.empty()) {
     VELOX_CHECK_EQ(inputTypes.size(), constantInputs.size());
@@ -96,7 +96,7 @@ bool registerStatefulVectorFunction(
     VectorFunctionFactory factory,
     VectorFunctionMetadata metadata,
     bool overwrite) {
-  auto sanitizedName = sanitizeFunctionName(name);
+  auto sanitizedName = sanitizeName(name);
 
   if (overwrite) {
     vectorFunctionFactories().withWLock([&](auto& functionMap) {

--- a/velox/expression/tests/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzer.cpp
@@ -119,4 +119,21 @@ bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {
   return true;
 }
 
+TypePtr ArgumentTypeFuzzer::fuzzReturnType() {
+  VELOX_CHECK_EQ(
+      returnType_,
+      nullptr,
+      "Only fuzzing uninitialized return type is allowed.");
+
+  determineUnboundedTypeVariables();
+  if (signature_.returnType().baseName() == "any") {
+    return randomType(rng_);
+  } else {
+    auto actualType = exec::SignatureBinder::tryResolveType(
+        signature_.returnType(), variables(), bindings_);
+    VELOX_CHECK_NE(actualType, nullptr);
+    return actualType;
+  }
+}
+
 } // namespace facebook::velox::test

--- a/velox/expression/tests/ArgumentTypeFuzzer.h
+++ b/velox/expression/tests/ArgumentTypeFuzzer.h
@@ -27,7 +27,8 @@ namespace facebook::velox::test {
 /// For function signatures using type variables, generates a list of
 /// arguments types. Optionally, allows to specify a desired return type. If
 /// specified, the return type acts as a constraint on the possible set of
-/// argument types.
+/// argument types. If no return type is specified, it also allows generate a
+/// random type that can bind to the function's return type.
 class ArgumentTypeFuzzer {
  public:
   ArgumentTypeFuzzer(
@@ -52,6 +53,10 @@ class ArgumentTypeFuzzer {
   const std::vector<TypePtr>& argumentTypes() const {
     return argumentTypes_;
   }
+
+  /// Return a random type that can bind to the function signature's return
+  /// type. This is only allowed when returnType_ is not initialized.
+  TypePtr fuzzReturnType();
 
  private:
   /// Return the variables in the signature.

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -231,11 +231,13 @@ std::optional<CallableSignature> processSignature(
   return std::nullopt;
 }
 
-// Determine whether type is or contains typeName.
+// Determine whether type is or contains typeName. typeName should be in lower
+// case.
 bool containTypeName(
     const exec::TypeSignature& type,
     const std::string& typeName) {
-  if (type.baseName() == typeName) {
+  auto sanitizedTypeName = exec::sanitizeName(type.baseName());
+  if (sanitizedTypeName == typeName) {
     return true;
   }
   for (const auto& parameter : type.parameters()) {
@@ -247,7 +249,7 @@ bool containTypeName(
 }
 
 // Determine whether the signature has an argument or return type that contains
-// typeName.
+// typeName. typeName should be in lower case.
 bool useTypeName(
     const exec::FunctionSignature& signature,
     const std::string& typeName) {
@@ -260,6 +262,20 @@ bool useTypeName(
     }
   }
   return false;
+}
+
+bool isSupportedSignature(const exec::FunctionSignature& signature) {
+  // Not supporting lambda functions, or functions using decimal and
+  // timestamp with time zone types.
+  return !(
+      useTypeName(signature, "function") ||
+      useTypeName(signature, "long_decimal") ||
+      useTypeName(signature, "short_decimal") ||
+      useTypeName(signature, "decimal") ||
+      useTypeName(signature, "timestamp with time zone") ||
+      useTypeName(signature, "interval day to second") ||
+      (FLAGS_velox_fuzzer_enable_complex_types &&
+       useTypeName(signature, "unknown")));
 }
 
 // Randomly pick columns from the input row vector to wrap in lazy.
@@ -304,16 +320,7 @@ ExpressionFuzzer::ExpressionFuzzer(
     for (const auto& signature : function.second) {
       ++totalFunctionSignatures;
 
-      // Not supporting lambda functions, or functions using decimal and
-      // timestamp with time zone types.
-      if (useTypeName(*signature, "function") ||
-          useTypeName(*signature, "long_decimal") ||
-          useTypeName(*signature, "short_decimal") ||
-          useTypeName(*signature, "decimal") ||
-          useTypeName(*signature, "timestamp with time zone") ||
-          useTypeName(*signature, "interval day to second") ||
-          (FLAGS_velox_fuzzer_enable_complex_types &&
-           useTypeName(*signature, "unknown"))) {
+      if (!isSupportedSignature(*signature)) {
         continue;
       }
 
@@ -775,7 +782,6 @@ void ExpressionFuzzer::reset() {
 }
 
 void ExpressionFuzzer::go() {
-  VELOX_CHECK(!signatures_.empty(), "No function signatures available.");
   VELOX_CHECK(
       FLAGS_steps > 0 || FLAGS_duration_sec > 0,
       "Either --steps or --duration_sec needs to be greater than zero.")
@@ -788,10 +794,28 @@ void ExpressionFuzzer::go() {
               << " (seed: " << currentSeed_ << ")";
     reset();
 
-    // Pick a random signature to choose the root return type.
-    size_t idx = boost::random::uniform_int_distribution<uint32_t>(
-        0, signatures_.size() - 1)(rng_);
-    const auto& rootType = signatures_[idx].returnType;
+    auto chooseFromConcreteSignatures =
+        boost::random::uniform_int_distribution<uint32_t>(0, 1)(rng_);
+    chooseFromConcreteSignatures =
+        (chooseFromConcreteSignatures && !signatures_.empty()) ||
+        (!chooseFromConcreteSignatures && signatureTemplates_.empty());
+    TypePtr rootType;
+    if (chooseFromConcreteSignatures) {
+      // Pick a random signature to choose the root return type.
+      VELOX_CHECK(!signatures_.empty(), "No function signature available.");
+      size_t idx = boost::random::uniform_int_distribution<uint32_t>(
+          0, signatures_.size() - 1)(rng_);
+      rootType = signatures_[idx].returnType;
+    } else {
+      // Pick a random concrete return type that can bind to the return type of
+      // a chosen signature.
+      VELOX_CHECK(
+          !signatureTemplates_.empty(), "No function signature available.");
+      size_t idx = boost::random::uniform_int_distribution<uint32_t>(
+          0, signatureTemplates_.size() - 1)(rng_);
+      ArgumentTypeFuzzer typeFuzzer{*signatureTemplates_[idx].signature, rng_};
+      rootType = typeFuzzer.fuzzReturnType();
+    }
 
     // Generate expression tree and input data vectors.
     auto plan = generateExpression(rootType);

--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -62,6 +62,7 @@ int main(int argc, char** argv) {
       "element_at",
       "width_bucket",
       "array_intersect",
+      "zip", // https://github.com/facebookincubator/velox/issues/3542
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(

--- a/velox/functions/prestosql/tests/ZipTest.cpp
+++ b/velox/functions/prestosql/tests/ZipTest.cpp
@@ -251,4 +251,169 @@ TEST_F(ZipTest, dictionaryArrays) {
 
   assertEqualVectors(expected, result);
 }
+
+/// Test if we can zip two flat vectors of arrays with rows starting at
+/// different offsets
+TEST_F(ZipTest, flatArraysWithDifferentOffsets) {
+  auto firstElements = makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8});
+  auto firstVector = makeArrayVector({0, 3, 6}, firstElements);
+
+  // Use different offsets.
+  auto secondElements =
+      makeFlatVector<int32_t>({10, 11, 12, 13, 14, 15, 16, 17, 18});
+  const auto size = 3;
+  BufferPtr offsetsBuffer = allocateOffsets(size, pool_.get());
+  BufferPtr sizesBuffer = allocateSizes(size, pool_.get());
+  auto rawOffsets = offsetsBuffer->asMutable<vector_size_t>();
+  auto rawSizes = sizesBuffer->asMutable<vector_size_t>();
+
+  rawOffsets[0] = 6;
+  rawOffsets[1] = 3;
+  rawOffsets[2] = 0;
+
+  for (int i = 0; i < size; i++) {
+    rawSizes[i] = 3;
+  }
+
+  auto secondVector = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(INTEGER()),
+      nullptr,
+      size,
+      offsetsBuffer,
+      sizesBuffer,
+      secondElements);
+
+  auto result = evaluate<ArrayVector>(
+      "zip(c0, c1)",
+      makeRowVector({
+          firstVector,
+          secondVector,
+      }));
+
+  auto firstResult = makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8});
+  auto secondResult =
+      makeFlatVector<int32_t>({16, 17, 18, 13, 14, 15, 10, 11, 12});
+
+  auto rowVector = makeRowVector({firstResult, secondResult});
+
+  // create the expected ArrayVector
+  auto expected = makeArrayVector({0, 3, 6}, rowVector);
+
+  assertEqualVectors(expected, result);
+}
+
+/// Test if we can zip two flat vectors of arrays with overlapping ranges of
+/// elements.
+TEST_F(ZipTest, flatArraysWithOverlappingRanges) {
+  const auto size = 3;
+  BufferPtr offsetsBuffer = allocateOffsets(size, pool_.get());
+  BufferPtr sizesBuffer = allocateSizes(size, pool_.get());
+  auto rawOffsets = offsetsBuffer->asMutable<vector_size_t>();
+  auto rawSizes = sizesBuffer->asMutable<vector_size_t>();
+
+  rawOffsets[0] = 0;
+  rawOffsets[1] = 1;
+  rawOffsets[2] = 2;
+
+  for (int i = 0; i < size; i++) {
+    rawSizes[i] = 3;
+  }
+
+  auto firstElements = makeFlatVector<int32_t>({0, 1, 2, 3, 4});
+  auto firstVector = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(INTEGER()),
+      nullptr,
+      size,
+      offsetsBuffer,
+      sizesBuffer,
+      firstElements);
+
+  auto secondElements = makeFlatVector<int32_t>({10, 11, 12, 13, 14});
+  auto secondVector = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(INTEGER()),
+      nullptr,
+      size,
+      offsetsBuffer,
+      sizesBuffer,
+      secondElements);
+
+  auto result = evaluate<ArrayVector>(
+      "zip(c0, c1)",
+      makeRowVector({
+          firstVector,
+          secondVector,
+      }));
+
+  auto firstResult = makeFlatVector<int32_t>({0, 1, 2, 1, 2, 3, 2, 3, 4});
+  auto secondResult =
+      makeFlatVector<int32_t>({10, 11, 12, 11, 12, 13, 12, 13, 14});
+
+  auto rowVector = makeRowVector({firstResult, secondResult});
+
+  // create the expected ArrayVector
+  auto expected = makeArrayVector({0, 3, 6}, rowVector);
+
+  assertEqualVectors(expected, result);
+}
+
+/// Test if we can zip two flat vectors of arrays with a gap in the range of
+/// elements.
+TEST_F(ZipTest, flatArraysWithGapInElements) {
+  const auto size = 3;
+  BufferPtr offsetsBuffer = allocateOffsets(size, pool_.get());
+  BufferPtr sizesBuffer = allocateSizes(size, pool_.get());
+  auto rawOffsets = offsetsBuffer->asMutable<vector_size_t>();
+  auto rawSizes = sizesBuffer->asMutable<vector_size_t>();
+
+  rawOffsets[0] = 0;
+  rawOffsets[1] = 6;
+  rawOffsets[2] = 9;
+
+  for (int i = 0; i < size; i++) {
+    rawSizes[i] = 3;
+  }
+
+  auto firstElements =
+      makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+  auto firstVector = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(INTEGER()),
+      nullptr,
+      size,
+      offsetsBuffer,
+      sizesBuffer,
+      firstElements);
+
+  auto secondElements =
+      makeFlatVector<int32_t>({10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21});
+  auto secondVector = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(INTEGER()),
+      nullptr,
+      size,
+      offsetsBuffer,
+      sizesBuffer,
+      secondElements);
+
+  auto result = evaluate<ArrayVector>(
+      "zip(c0, c1)",
+      makeRowVector({
+          firstVector,
+          secondVector,
+      }));
+
+  auto firstResult = makeFlatVector<int32_t>({0, 1, 2, 6, 7, 8, 9, 10, 11});
+  auto secondResult =
+      makeFlatVector<int32_t>({10, 11, 12, 16, 17, 18, 19, 20, 21});
+
+  auto rowVector = makeRowVector({firstResult, secondResult});
+
+  // create the expected ArrayVector
+  auto expected = makeArrayVector({0, 3, 6}, rowVector);
+
+  assertEqualVectors(expected, result);
+}
 } // namespace


### PR DESCRIPTION
Summary:
The fuzzer discovered an issue with the Zip UDF
https://github.com/facebookincubator/velox/issues/3542

I hadn't accounted for the fact that just because all of the arrays are flat and the same size, doesn't mean they all have the same offsets into their elements Vectors.

E.g. with 3 arrays of size 3, the offsets could be 0, 3, 6 or 6, 3, 0 or 0, 4, 7 (if there are unused elements)

When this is the case the fast path added to the Zip UDF produces incorrect results.

The fix is just to validate the offsets are the same in addition to the sizes.

Differential Revision: D42183237

