### PR TITLE
Fix Coalesce error message

### DIFF
--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -84,8 +84,7 @@ TypePtr CoalesceExpr::resolveType(const std::vector<TypePtr>& argTypes) {
   for (auto i = 1; i < argTypes.size(); i++) {
     VELOX_USER_CHECK(
         argTypes[0]->equivalent(*argTypes[i]),
-        "Inputs to coalesce must have the same type. ",
-        "Expected {}, but got {}.",
+        "Inputs to coalesce must have the same type. Expected {}, but got {}.",
         argTypes[0]->toString(),
         argTypes[i]->toString());
   }

--- a/velox/expression/tests/CoalesceTest.cpp
+++ b/velox/expression/tests/CoalesceTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 
 using namespace facebook::velox;
@@ -86,4 +87,16 @@ TEST_F(CoalesceTest, strings) {
 
   auto result = evaluate<FlatVector<StringView>>("coalesce(c0, c1, c2)", input);
   assertEqualVectors(expectedResult, result);
+}
+
+TEST_F(CoalesceTest, incompatibleTypes) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<StringView>(
+          {"a", std::nullopt, std::nullopt, "d", std::nullopt}),
+      makeNullableFlatVector<int32_t>({1, 2, 3, 4, 5}),
+  });
+
+  VELOX_ASSERT_THROW(
+      evaluate<FlatVector<StringView>>("coalesce(c0, c1)", input),
+      "Inputs to coalesce must have the same type. Expected VARCHAR, but got INTEGER.");
 }


### PR DESCRIPTION
Summary: A stray comma is causing us to lose the type information.

Differential Revision: D42193996

