### PR TITLE
Specify template parameter for BaseVector::create

### DIFF
--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -120,8 +120,8 @@ int main(int argc, char** argv) {
   // Let's first create a single flat vector to represent the input
   // "my_col" bigint column, and manually fill some data in it:
   const size_t vectorSize = 10;
-  auto flatVector = std::dynamic_pointer_cast<FlatVector<int64_t>>(
-      BaseVector::create(BIGINT(), vectorSize, execCtx.pool()));
+  auto flatVector = BaseVector::create<FlatVector<int64_t>>(
+      BIGINT(), vectorSize, execCtx.pool());
   auto rawValues = flatVector->mutableRawValues();
   std::iota(rawValues, rawValues + vectorSize, 0); // 0, 1, 2, 3, ...
 

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -230,8 +230,8 @@ int main(int argc, char** argv) {
       variant::opaque(opaqueObj), vectorSize, execCtx.pool());
 
   // Create vector #3. The monotinically increasing flatVector<bigint>.
-  auto vector3 = std::dynamic_pointer_cast<FlatVector<int64_t>>(
-      BaseVector::create(BIGINT(), vectorSize, execCtx.pool()));
+  auto vector3 = BaseVector::create<FlatVector<int64_t>>(
+      BIGINT(), vectorSize, execCtx.pool());
   auto rawValues = vector3->mutableRawValues();
   std::iota(rawValues, rawValues + vectorSize, 0); // 0, 1, 2, 3, ...
 

--- a/velox/exec/EnforceSingleRow.cpp
+++ b/velox/exec/EnforceSingleRow.cpp
@@ -58,8 +58,7 @@ RowVectorPtr EnforceSingleRow::getOutput() {
 void EnforceSingleRow::noMoreInput() {
   if (!noMoreInput_ && input_ == nullptr) {
     // We have not seen any data. Return a single row of all nulls.
-    input_ = std::dynamic_pointer_cast<RowVector>(
-        BaseVector::create(outputType_, 1, pool()));
+    input_ = BaseVector::create<RowVector>(outputType_, 1, pool());
     for (auto& child : input_->children()) {
       child->resize(1);
       child->setNull(0, true);

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -638,8 +638,7 @@ void HashProbe::prepareOutput(vector_size_t size) {
     BaseVector::prepareForReuse(output, size);
     output_ = std::static_pointer_cast<RowVector>(output);
   } else {
-    output_ = std::static_pointer_cast<RowVector>(
-        BaseVector::create(outputType_, size, pool()));
+    output_ = BaseVector::create<RowVector>(outputType_, size, pool());
   }
 }
 
@@ -936,8 +935,7 @@ RowVectorPtr HashProbe::getOutput() {
 
 void HashProbe::fillFilterInput(vector_size_t size) {
   if (!filterInput_) {
-    filterInput_ = std::static_pointer_cast<RowVector>(
-        BaseVector::create(filterInputType_, 1, pool()));
+    filterInput_ = BaseVector::create<RowVector>(filterInputType_, 1, pool());
   }
   filterInput_->resize(size);
   for (auto projection : filterInputProjections_) {
@@ -959,8 +957,8 @@ void HashProbe::prepareFilterRowsForNullAwareAntiJoin(
     bool filterPropagateNulls) {
   VELOX_CHECK_LE(numRows, kBatchSize);
   if (filterTableInput_ == nullptr) {
-    filterTableInput_ = std::static_pointer_cast<RowVector>(
-        BaseVector::create(filterInputType_, kBatchSize, pool()));
+    filterTableInput_ =
+        BaseVector::create<RowVector>(filterInputType_, kBatchSize, pool());
   }
 
   if (filterPropagateNulls) {

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -124,8 +124,8 @@ RowVectorPtr Merge::getOutput() {
   }
 
   if (!output_) {
-    output_ = std::dynamic_pointer_cast<RowVector>(BaseVector::create(
-        outputType_, outputBatchSize_, operatorCtx_->pool()));
+    output_ = BaseVector::create<RowVector>(
+        outputType_, outputBatchSize_, operatorCtx_->pool());
     for (auto& child : output_->children()) {
       child->resize(outputBatchSize_);
     }

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -159,8 +159,7 @@ void StreamingAggregation::storeKeys(char* group, vector_size_t index) {
 }
 
 RowVectorPtr StreamingAggregation::createOutput(size_t numGroups) {
-  auto output = std::dynamic_pointer_cast<RowVector>(
-      BaseVector::create(outputType_, numGroups, pool()));
+  auto output = BaseVector::create<RowVector>(outputType_, numGroups, pool());
 
   for (auto i = 0; i < groupingKeys_.size(); ++i) {
     rows_->extractColumn(groups_.data(), numGroups, i, output->childAt(i));

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -460,8 +460,8 @@ RowVectorPtr Window::getOutput() {
 
   auto numRowsLeft = numRows_ - numProcessedRows_;
   auto numOutputRows = std::min(numRowsPerOutput_, numRowsLeft);
-  auto result = std::dynamic_pointer_cast<RowVector>(
-      BaseVector::create(outputType_, numOutputRows, operatorCtx_->pool()));
+  auto result = BaseVector::create<RowVector>(
+      outputType_, numOutputRows, operatorCtx_->pool());
 
   // Set all passthrough input columns.
   for (int i = 0; i < numInputColumns_; ++i) {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -251,8 +251,8 @@ class AggregationTest : public OperatorTestBase {
     RowVectorPtr rowVector;
     for (auto count = 0; count < numRows; ++count) {
       if (count % 1000 == 0) {
-        rowVector = std::static_pointer_cast<RowVector>(BaseVector::create(
-            rowType, std::min(1000, numRows - count), pool_.get()));
+        rowVector = BaseVector::create<RowVector>(
+            rowType, std::min(1000, numRows - count), pool_.get());
         batches.push_back(rowVector);
         for (auto& child : rowVector->children()) {
           child->resize(1000);
@@ -904,8 +904,8 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
     // The input batch has kNumDistinct distinct keys. The repeat count of a key
     // is given by min(1, (k % 100) - 90). The batch is repeated 3 times, each
     // time in a different order.
-    RowVectorPtr rowVector = std::static_pointer_cast<RowVector>(
-        BaseVector::create(rowType_, kNumDistinct, pool_.get()));
+    auto rowVector =
+        BaseVector::create<RowVector>(rowType_, kNumDistinct, pool_.get());
     SelectivityVector allRows(kNumDistinct);
     const TypePtr keyType = rowVector->type()->childAt(0);
     const TypePtr valueType = rowVector->type()->childAt(1);
@@ -1018,8 +1018,8 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
   // The input batch has kNumDistinct distinct keys. The repeat count of a key
   // is given by min(1, (k % 100) - 90). The batch is repeated 3 times, each
   // time in a different order.
-  RowVectorPtr rowVector = std::static_pointer_cast<RowVector>(
-      BaseVector::create(rowType_, kNumDistinct, pool_.get()));
+  auto rowVector =
+      BaseVector::create<RowVector>(rowType_, kNumDistinct, pool_.get());
   SelectivityVector allRows(kNumDistinct);
   const TypePtr keyType = rowVector->type()->childAt(0);
   const TypePtr valueType = rowVector->type()->childAt(1);

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -94,8 +94,8 @@ class TestDataSource : public connector::DataSource {
     }
 
     needSplit_ = true;
-    auto data = std::dynamic_pointer_cast<FlatVector<int64_t>>(
-        BaseVector::create({BIGINT()}, size, pool_));
+    auto data =
+        BaseVector::create<FlatVector<int64_t>>({BIGINT()}, size, pool_);
     for (auto i = 0; i < size; i++) {
       data->set(i, i);
     }

--- a/velox/exec/tests/FilterProjectTest.cpp
+++ b/velox/exec/tests/FilterProjectTest.cpp
@@ -260,8 +260,8 @@ TEST_F(FilterProjectTest, allFailedOrPassed) {
     // no row passes. c0 is flat vector. c1 is constant vector.
     int32_t value = i % 2 == 0 ? 0 : 1;
 
-    auto c0 = std::dynamic_pointer_cast<FlatVector<int32_t>>(
-        BaseVector::create(INTEGER(), 100, pool_.get()));
+    auto c0 =
+        BaseVector::create<FlatVector<int32_t>>(INTEGER(), 100, pool_.get());
     for (auto row = 0; row < c0->size(); ++row) {
       c0->set(row, value);
     }

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -309,8 +309,8 @@ class HashTableTest : public testing::TestWithParam<bool> {
             nullptr);
 
       case TypeKind::VARCHAR: {
-        auto strings = std::static_pointer_cast<FlatVector<StringView>>(
-            BaseVector::create(VARCHAR(), size, pool_.get()));
+        auto strings = BaseVector::create<FlatVector<StringView>>(
+            VARCHAR(), size, pool_.get());
         for (auto row = 0; row < size; ++row) {
           auto string = fmt::format("{}", keySpacing_ * (sequence + row));
           // Make strings that overflow the inline limit for 1/10 of

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -548,8 +548,8 @@ TEST_F(RowContainerTest, types) {
   }
   checkSizes(rows, *data);
   data->checkConsistency();
-  auto copy = std::static_pointer_cast<RowVector>(
-      BaseVector::create(batch->type(), batch->size(), pool_.get()));
+  auto copy =
+      BaseVector::create<RowVector>(batch->type(), batch->size(), pool_.get());
   for (auto column = 0; column < batch->childrenSize(); ++column) {
     testExtractColumn(*data, rows, column, batch->childAt(column));
 

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -169,8 +169,8 @@ RowVectorPtr AssertQueryBuilder::copyResults(memory::MemoryPool* pool) {
     totalCount += result->size();
   }
 
-  auto copy = std::dynamic_pointer_cast<RowVector>(
-      BaseVector::create(results[0]->type(), totalCount, pool));
+  auto copy =
+      BaseVector::create<RowVector>(results[0]->type(), totalCount, pool);
   auto copyCount = 0;
   for (const auto& result : results) {
     copy->copy(result.get(), copyCount, 0, result->size());

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -142,8 +142,8 @@ TaskCursor::TaskCursor(const CursorParameters& params)
         for (auto& child : vector->children()) {
           child->loadedVector();
         }
-        RowVectorPtr copy = std::dynamic_pointer_cast<RowVector>(
-            BaseVector::create(vector->type(), vector->size(), queue->pool()));
+        auto copy = BaseVector::create<RowVector>(
+            vector->type(), vector->size(), queue->pool());
         copy->copy(vector.get(), 0, 0, vector->size());
         return queue->enqueue(std::move(copy), future);
       });

--- a/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.h
+++ b/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.h
@@ -27,8 +27,8 @@ namespace facebook::velox::functions {
 template <typename T, typename Func>
 VectorPtr fastMinMax(const VectorPtr& in, const Func& func) {
   const auto numRows = in->size();
-  auto result = std::static_pointer_cast<FlatVector<T>>(
-      BaseVector::create(in->type()->childAt(0), numRows, in->pool()));
+  auto result = BaseVector::create<FlatVector<T>>(
+      in->type()->childAt(0), numRows, in->pool());
   auto rawResults = result->mutableRawValues();
 
   auto arrayVector = in->as<ArrayVector>();

--- a/velox/functions/prestosql/benchmarks/ArrayPositionBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayPositionBenchmark.cpp
@@ -36,9 +36,8 @@ VectorPtr fastPosition(const RowVectorPtr& inputs) {
   VectorPtr searches = inputs->childAt(1);
 
   const auto numRows = arrays->size();
-  auto result =
-      std::static_pointer_cast<FlatVector<int64_t>>(BaseVector::create(
-          CppToType<int64_t>::create(), numRows, arrays->pool()));
+  auto result = BaseVector::create<FlatVector<int64_t>>(
+      BIGINT(), numRows, arrays->pool());
 
   auto arrayVector = arrays->as<ArrayVector>();
   auto rawOffsets = arrayVector->rawOffsets();
@@ -80,9 +79,8 @@ VectorPtr fastPositionWithInstance(const RowVectorPtr& inputs) {
   VectorPtr instances = inputs->childAt(2);
 
   const auto numRows = arrays->size();
-  auto result =
-      std::static_pointer_cast<FlatVector<int64_t>>(BaseVector::create(
-          CppToType<int64_t>::create(), numRows, arrays->pool()));
+  auto result = BaseVector::create<FlatVector<int64_t>>(
+      BIGINT(), numRows, arrays->pool());
 
   auto arrayVector = arrays->as<ArrayVector>();
   auto rawOffsets = arrayVector->rawOffsets();

--- a/velox/functions/prestosql/benchmarks/MapZipWithBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapZipWithBenchmark.cpp
@@ -47,8 +47,8 @@ class MapZipWithBenchmark : public functions::test::FunctionBenchmarkBase {
         dictionaryKeysMap_->type(), options.vectorSize, pool());
     flatKeysMap_->copy(dictionaryKeysMap_.get(), 0, 0, options.vectorSize);
 
-    auto sortedKeysMap = std::dynamic_pointer_cast<MapVector>(
-        BaseVector::create(flatKeysMap_->type(), options.vectorSize, pool()));
+    auto sortedKeysMap = BaseVector::create<MapVector>(
+        flatKeysMap_->type(), options.vectorSize, pool());
     sortedKeysMap->copy(flatKeysMap_.get(), 0, 0, options.vectorSize);
     MapVector::canonicalize(sortedKeysMap);
     sortedKeysMap_ = std::move(sortedKeysMap);

--- a/velox/functions/prestosql/window/NthValue.cpp
+++ b/velox/functions/prestosql/window/NthValue.cpp
@@ -48,8 +48,7 @@ class NthValueFunction : public exec::WindowFunction {
       return;
     }
     offsetIndex_ = args[1].index.value();
-    offsets_ = std::dynamic_pointer_cast<FlatVector<int64_t>>(
-        BaseVector::create(BIGINT(), 0, pool));
+    offsets_ = BaseVector::create<FlatVector<int64_t>>(BIGINT(), 0, pool);
   }
 
   void resetPartition(const exec::WindowPartition* partition) override {

--- a/velox/serializers/UnsafeRowSerializer.cpp
+++ b/velox/serializers/UnsafeRowSerializer.cpp
@@ -112,8 +112,7 @@ void UnsafeRowVectorSerde::deserialize(
   }
 
   if (serializedRows.empty()) {
-    *result =
-        std::dynamic_pointer_cast<RowVector>(BaseVector::create(type, 0, pool));
+    *result = BaseVector::create<RowVector>(type, 0, pool);
     return;
   }
 

--- a/velox/substrait/VariantToVectorConverter.cpp
+++ b/velox/substrait/VariantToVectorConverter.cpp
@@ -26,8 +26,8 @@ VectorPtr setVectorFromVariantsByKind(
     memory::MemoryPool* pool) {
   using T = typename TypeTraits<KIND>::NativeType;
 
-  auto flatVector = std::dynamic_pointer_cast<FlatVector<T>>(
-      BaseVector::create(CppToType<T>::create(), values.size(), pool));
+  auto flatVector = BaseVector::create<FlatVector<T>>(
+      CppToType<T>::create(), values.size(), pool);
 
   for (vector_size_t i = 0; i < values.size(); i++) {
     if (values[i].isNull()) {
@@ -50,8 +50,8 @@ template <>
 VectorPtr setVectorFromVariantsByKind<TypeKind::VARCHAR>(
     const std::vector<velox::variant>& values,
     memory::MemoryPool* pool) {
-  auto flatVector = std::dynamic_pointer_cast<FlatVector<StringView>>(
-      BaseVector::create(VARCHAR(), values.size(), pool));
+  auto flatVector = BaseVector::create<FlatVector<StringView>>(
+      VARCHAR(), values.size(), pool);
 
   for (vector_size_t i = 0; i < values.size(); i++) {
     if (values[i].isNull()) {


### PR DESCRIPTION
Simplify the code by passing template parameter to BaseVector::create.

Before:

```
auto flatVector = std::dynamic_pointer_cast<FlatVector<int64_t>>(
      BaseVector::create(BIGINT(), vectorSize, execCtx.pool()));
```

After:
```
auto flatVector = BaseVector::create<FlatVector<int64_t>>(
      BIGINT(), vectorSize, execCtx.pool());
```