### PR TITLE
Support null filter in SelectiveRepeatedColumnReader

### DIFF
--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -16,7 +16,124 @@
 
 #include "velox/dwio/common/SelectiveRepeatedColumnReader.h"
 
+#include "velox/dwio/common/BufferUtil.h"
+#include "velox/dwio/common/SelectiveColumnReaderInternal.h"
+
 namespace facebook::velox::dwio::common {
+
+void SelectiveRepeatedColumnReader::makeNestedRowSet(RowSet rows) {
+  allLengths_.resize(rows.back() + 1);
+  assert(!allLengths_.empty()); // for lint only.
+  auto nulls = nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+  // Reads the lengths, leaves an uninitialized gap for a null
+  // map/list. Reading these checks the null nask.
+  readLengths(allLengths_.data(), rows.back() + 1, nulls);
+  dwio::common::ensureCapacity<vector_size_t>(
+      offsets_, rows.size(), &memoryPool_);
+  dwio::common::ensureCapacity<vector_size_t>(
+      sizes_, rows.size(), &memoryPool_);
+  auto rawOffsets = offsets_->asMutable<vector_size_t>();
+  auto rawSizes = sizes_->asMutable<vector_size_t>();
+  vector_size_t nestedLength = 0;
+  for (auto row : rows) {
+    if (!nulls || !bits::isBitNull(nulls, row)) {
+      nestedLength += allLengths_[row];
+    }
+  }
+  nestedRows_.resize(nestedLength);
+  vector_size_t currentRow = 0;
+  vector_size_t nestedRow = 0;
+  vector_size_t nestedOffset = 0;
+  for (auto rowIndex = 0; rowIndex < rows.size(); ++rowIndex) {
+    auto row = rows[rowIndex];
+    // Add up the lengths of non-null rows skipped since the last
+    // non-null.
+    for (auto i = currentRow; i < row; ++i) {
+      if (!nulls || !bits::isBitNull(nulls, i)) {
+        nestedOffset += allLengths_[i];
+      }
+    }
+    currentRow = row + 1;
+    // Check if parent is null after adding up the lengths leading
+    // up to this. If null, add a null to the result and keep
+    // looping. If the null is last, the lengths will all have been
+    // added up.
+    if (nulls && bits::isBitNull(nulls, row)) {
+      rawOffsets[rowIndex] = 0;
+      rawSizes[rowIndex] = 0;
+      bits::setNull(rawResultNulls_, rowIndex);
+      anyNulls_ = true;
+      continue;
+    }
+
+    auto lengthAtRow = allLengths_[row];
+    std::iota(
+        &nestedRows_[nestedRow],
+        &nestedRows_[nestedRow + lengthAtRow],
+        nestedOffset);
+    rawOffsets[rowIndex] = nestedRow;
+    rawSizes[rowIndex] = lengthAtRow;
+    nestedRow += lengthAtRow;
+    nestedOffset += lengthAtRow;
+  }
+  childTargetReadOffset_ += nestedOffset;
+}
+
+void SelectiveRepeatedColumnReader::compactOffsets(RowSet rows) {
+  auto rawOffsets = offsets_->asMutable<vector_size_t>();
+  auto rawSizes = sizes_->asMutable<vector_size_t>();
+  RowSet rowsToCompact;
+  if (valueRows_.empty()) {
+    valueRows_.resize(rows.size());
+    rowsToCompact = outputRows();
+  } else {
+    rowsToCompact = valueRows_;
+  }
+  if (rows.size() == rowsToCompact.size()) {
+    return;
+  }
+
+  int32_t current = 0;
+  bool moveNulls = shouldMoveNulls(rows);
+  for (int i = 0; i < rows.size(); ++i) {
+    auto row = rows[i];
+    while (rowsToCompact[current] < row) {
+      ++current;
+    }
+    VELOX_CHECK(rowsToCompact[current] == row);
+    valueRows_[i] = row;
+    rawOffsets[i] = rawOffsets[current];
+    rawSizes[i] = rawSizes[current];
+    if (moveNulls && i != current) {
+      bits::setBit(
+          rawResultNulls_, i, bits::isBitSet(rawResultNulls_, current));
+    }
+  }
+  numValues_ = rows.size();
+  valueRows_.resize(numValues_);
+  offsets_->setSize(numValues_ * sizeof(vector_size_t));
+  sizes_->setSize(numValues_ * sizeof(vector_size_t));
+}
+
+RowSet SelectiveRepeatedColumnReader::applyFilter(RowSet rows) {
+  if (!scanSpec_->filter()) {
+    return rows;
+  }
+  switch (scanSpec_->filter()->kind()) {
+    case velox::common::FilterKind::kIsNull:
+      filterNulls<int32_t>(rows, true, false);
+      break;
+    case velox::common::FilterKind::kIsNotNull:
+      filterNulls<int32_t>(rows, false, false);
+      break;
+    default:
+      VELOX_UNSUPPORTED(
+          "Unsupported filter for column {}, only IS NULL and IS NOT NULL are supported: {}",
+          scanSpec_->fieldName(),
+          scanSpec_->filter()->toString());
+  }
+  return outputRows_;
+}
 
 SelectiveListColumnReader::SelectiveListColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
@@ -57,11 +174,12 @@ void SelectiveListColumnReader::read(
   // Catch up if the child is behind the length stream.
   child_->seekTo(childTargetReadOffset_, false);
   prepareRead<char>(offset, rows, incomingNulls);
-  makeNestedRowSet(rows);
+  auto activeRows = applyFilter(rows);
+  makeNestedRowSet(activeRows);
   if (child_ && !nestedRows_.empty()) {
     child_->read(child_->readOffset(), nestedRows_, nullptr);
   }
-  numValues_ = rows.size();
+  numValues_ = activeRows.size();
   readOffset_ = offset + rows.back() + 1;
 }
 
@@ -135,12 +253,13 @@ void SelectiveMapColumnReader::read(
   }
 
   prepareRead<char>(offset, rows, incomingNulls);
-  makeNestedRowSet(rows);
+  auto activeRows = applyFilter(rows);
+  makeNestedRowSet(activeRows);
   if (keyReader_ && elementReader_ && !nestedRows_.empty()) {
     keyReader_->read(keyReader_->readOffset(), nestedRows_, nullptr);
     elementReader_->read(elementReader_->readOffset(), nestedRows_, nullptr);
   }
-  numValues_ = rows.size();
+  numValues_ = activeRows.size();
   readOffset_ = offset + rows.back() + 1;
 }
 


### PR DESCRIPTION
Summary: As discovered in https://github.com/prestodb/presto/pull/18826, when any filter is pushed down to a selective list or map column reader, the result becomes empty.  This change fixes the issue and leverages the `IS NULL` or `IS NOT NULL` filters in `ScanSpec`.

Differential Revision: D42194585

