### PR TITLE
Introduce HashJoinNode::nullAware flag

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -377,8 +377,7 @@ AbstractJoinNode::AbstractJoinNode(
   // side.
   bool outputMayIncludeRightColumns =
       !(core::isLeftSemiFilterJoin(joinType) ||
-        core::isLeftSemiProjectJoin(joinType) || core::isAntiJoin(joinType) ||
-        core::isNullAwareAntiJoin(joinType));
+        core::isLeftSemiProjectJoin(joinType) || core::isAntiJoin(joinType));
 
   for (auto i = 0; i < numOutputColumms; ++i) {
     auto name = outputType_->nameOf(i);
@@ -412,6 +411,13 @@ void AbstractJoinNode::addDetails(std::stringstream& stream) const {
 
   if (filter_) {
     stream << ", filter: " << filter_->toString();
+  }
+}
+
+void HashJoinNode::addDetails(std::stringstream& stream) const {
+  AbstractJoinNode::addDetails(stream);
+  if (nullAware_) {
+    stream << ", null aware";
   }
 }
 

--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -166,7 +166,7 @@ std::optional<HashJoinBridge::SpillInput> HashJoinBridge::spillInputOrFuture(
 
 bool isNullAwareAntiJoinWithFilter(
     const std::shared_ptr<const core::HashJoinNode>& joinNode) {
-  return isNullAwareAntiJoin(joinNode->joinType()) &&
+  return isAntiJoin(joinNode->joinType()) && joinNode->isNullAware() &&
       (joinNode->filter() != nullptr);
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -262,6 +262,48 @@ TEST_F(PlanNodeToStringTest, hashJoin) {
   ASSERT_EQ(
       "-- HashJoin[LEFT t_c0=u_c0, filter: gt(ROW[\"t_c1\"],ROW[\"u_c1\"])] -> t_c0:SMALLINT, t_c1:INTEGER, u_c1:INTEGER\n",
       plan->toString(true, false));
+
+  plan = PlanBuilder()
+             .values({data_})
+             .project({"c0 as t_c0", "c1 as t_c1"})
+             .hashJoin(
+                 {"t_c0"},
+                 {"u_c0"},
+                 PlanBuilder()
+                     .values({data_})
+                     .project({"c0 as u_c0", "c1 as u_c1"})
+                     .planNode(),
+                 "",
+                 {"t_c0", "t_c1"},
+                 core::JoinType::kAnti,
+                 true /*nullAware*/)
+             .planNode();
+
+  ASSERT_EQ("-- HashJoin\n", plan->toString());
+  ASSERT_EQ(
+      "-- HashJoin[ANTI t_c0=u_c0, null aware] -> t_c0:SMALLINT, t_c1:INTEGER\n",
+      plan->toString(true, false));
+
+  plan = PlanBuilder()
+             .values({data_})
+             .project({"c0 as t_c0", "c1 as t_c1"})
+             .hashJoin(
+                 {"t_c0"},
+                 {"u_c0"},
+                 PlanBuilder()
+                     .values({data_})
+                     .project({"c0 as u_c0", "c1 as u_c1"})
+                     .planNode(),
+                 "",
+                 {"t_c0", "t_c1"},
+                 core::JoinType::kAnti,
+                 false /*nullAware*/)
+             .planNode();
+
+  ASSERT_EQ("-- HashJoin\n", plan->toString());
+  ASSERT_EQ(
+      "-- HashJoin[ANTI t_c0=u_c0] -> t_c0:SMALLINT, t_c1:INTEGER\n",
+      plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, mergeJoin) {

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -895,7 +895,8 @@ PlanBuilder& PlanBuilder::hashJoin(
     const core::PlanNodePtr& build,
     const std::string& filter,
     const std::vector<std::string>& outputLayout,
-    core::JoinType joinType) {
+    core::JoinType joinType,
+    bool nullAware) {
   VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
 
   auto leftType = planNode_->outputType();
@@ -929,6 +930,7 @@ PlanBuilder& PlanBuilder::hashJoin(
   planNode_ = std::make_shared<core::HashJoinNode>(
       nextPlanNodeId(),
       joinType,
+      nullAware,
       leftKeyFields,
       rightKeyFields,
       std::move(filterExpr),

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -581,13 +581,16 @@ class PlanBuilder {
   /// @param outputLayout Output layout consisting of columns from probe and
   /// build sides.
   /// @param joinType Type of the join: inner, left, right, full, semi, or anti.
+  /// @param nullAware Applies to semi and anti joins. Indicates whether the
+  /// join follows IN (null-aware) or EXISTS (regular) semantic.
   PlanBuilder& hashJoin(
       const std::vector<std::string>& leftKeys,
       const std::vector<std::string>& rightKeys,
       const core::PlanNodePtr& build,
       const std::string& filter,
       const std::vector<std::string>& outputLayout,
-      core::JoinType joinType = core::JoinType::kInner);
+      core::JoinType joinType = core::JoinType::kInner,
+      bool nullAware = false);
 
   /// Add a MergeJoinNode to join two inputs using one or more join keys and an
   /// optional filter. The caller is responsible to ensure that inputs are

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -1359,7 +1359,8 @@ TpchPlan TpchQueryBuilder::getQ16Plan() const {
               supplier,
               "",
               {"ps_suppkey", "p_brand", "p_type", "p_size"},
-              core::JoinType::kNullAwareAnti)
+              core::JoinType::kAnti,
+              true /*nullAware*/)
           // Empty aggregate is used here to get the distinct count of
           // ps_suppkey.
           // approx_distinct could be used instead for getting the count of
@@ -1729,7 +1730,8 @@ TpchPlan TpchQueryBuilder::getQ21Plan() const {
               lineitem3,
               "l_suppkey_3 <> l_suppkey_1",
               {"s_name"},
-              core::JoinType::kNullAwareAnti)
+              core::JoinType::kAnti,
+              true /*nullAware*/)
           .partialAggregation({"s_name"}, {"count(1) as numwait"})
           .localPartition({})
           .finalAggregation()
@@ -1810,7 +1812,8 @@ TpchPlan TpchQueryBuilder::getQ22Plan() const {
               orders,
               "",
               {"c_acctbal", "c_phone"},
-              core::JoinType::kNullAwareAnti)
+              core::JoinType::kAnti,
+              true /*nullAware*/)
           .project({"substr(c_phone, 1, 2) AS country_code", "c_acctbal"})
           .partialAggregation(
               {"country_code"},


### PR DESCRIPTION
It is necessary to distinguish between null aware (IN) and regular (EXISTS) semi joins.
To avoid adding 4 new values to the JoinType enum, we introduce nullAware flag
that applies to semi and anti joins and replace kNullAwareAntiJoin enum value
with a combination of kAntiJoin and nullAware = true.

See #3555 for more context.