### PR TITLE
Handle exception thrown in ExprSet's destructor

### DIFF
--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -213,6 +213,8 @@ void appendSqlLiteral(
       break;
     }
     default:
+      // TODO: update ExprStatsTest.exceptionPreparingStatsForListener once
+      // support for VARBINARY is added.
       VELOX_UNSUPPORTED(
           "Type not supported yet: {}", vector.type()->toString());
   }

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1613,7 +1613,12 @@ ExprSet::~ExprSet() {
       std::unordered_set<const exec::Expr*> uniqueExprs;
       std::vector<std::string> sqls;
       for (const auto& expr : exprs()) {
-        sqls.emplace_back(expr->toSql());
+        try {
+          sqls.emplace_back(expr->toSql());
+        } catch (const std::exception& e) {
+          LOG_EVERY_N(WARNING, 100) << "Failed to generate SQL: " << e.what();
+          sqls.emplace_back("<failed to generate>");
+        }
         addStats(*expr, stats, uniqueExprs);
       }
 

--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -430,3 +430,24 @@ TEST_F(ExprStatsTest, errorLog) {
 
   ASSERT_TRUE(exec::unregisterExprSetListener(listener));
 }
+
+TEST_F(ExprStatsTest, exceptionPreparingStatsForListener) {
+  // Currently a ConstantExpr of VARBINARY type does not support generating
+  // its sql form. Therefore, it throws an exception when ExprSet tries to
+  // generate its sql while preparing data for listeners in its destructor.
+  // This test replicates this scenario and ensures that the exception is
+  // handled and the process is not terminated.
+  std::vector<Event> events;
+  std::vector<std::string> exceptions;
+  auto listener = std::make_shared<TestListener>(events, exceptions);
+  ASSERT_TRUE(exec::registerExprSetListener(listener));
+  auto varbinaryData = vectorMaker_.flatVector<StringView>(
+      {"12"_sv}, CppToType<Varbinary>::create());
+  std::vector<core::TypedExprPtr> expressions = {
+      std::make_shared<const core::ConstantTypedExpr>(
+          BaseVector::wrapInConstant(1, 0, varbinaryData))};
+  auto exprSet =
+      std::make_unique<exec::ExprSet>(std::move(expressions), &execCtx_);
+  evaluate(*exprSet, makeRowVector({varbinaryData}));
+  ASSERT_TRUE(exec::unregisterExprSetListener(listener));
+}


### PR DESCRIPTION
This adds handling  of the aforementioned exception that prevented stats
from successfully propagating  when an ExprSet object is destroyed.

Test Plan:
Added unit test.

Fixes #3578